### PR TITLE
Fix: Corregir sintaxis de foreign keys en queries de Supabase

### DIFF
--- a/src/hooks/useSupabase.jsx
+++ b/src/hooks/useSupabase.jsx
@@ -155,8 +155,8 @@ export function usePedidos() {
           *,
           cliente:clientes(*),
           items:pedido_items(*, producto:productos(*)),
-          usuario:usuario_id(id, nombre, email),
-          transportista:transportista_id(id, nombre, email)
+          usuario:perfiles!usuario_id(id, nombre, email),
+          transportista:perfiles!transportista_id(id, nombre, email)
         `)
         .order('created_at', { ascending: false })
 
@@ -355,7 +355,7 @@ export function useDashboard() {
     try {
       let query = supabase
         .from('pedidos')
-        .select(`*, usuario:usuario_id(id, nombre, email), items:pedido_items(*)`)
+        .select(`*, usuario:perfiles!usuario_id(id, nombre, email), items:pedido_items(*)`)
 
       if (fechaDesde) query = query.gte('created_at', new Date(fechaDesde).toISOString())
       if (fechaHasta) {


### PR DESCRIPTION
- Cambiar usuario:usuario_id -> usuario:perfiles!usuario_id
- Cambiar transportista:transportista_id -> transportista:perfiles!transportista_id

La sintaxis correcta de Supabase para relaciones FK especifica la tabla destino (perfiles) con el hint de la columna FK (!usuario_id).