### PR TITLE
Fix: Migrar a AutocompleteService para evitar bloqueo de Google

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>distribuidora-app</title>
-    <script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyDm-whIYAYmcOPHac0q2WYpilB9oGfO_KQ&libraries=places" async defer></script>
+    <script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyDm-whIYAYmcOPHac0q2WYpilB9oGfO_KQ&libraries=places&loading=async" async defer></script>
   </head>
   <body>
     <div id="root"></div>


### PR DESCRIPTION
- Reemplazar google.maps.places.Autocomplete (deprecado desde marzo 2025) por AutocompleteService + PlacesService
- Implementar dropdown personalizado con predicciones de direcciones
- Agregar session tokens para optimizar costos de API
- Agregar loading=async al script de Google Maps
- Mantener fallback para entrada manual si la API falla