### PR TITLE
feat: Agregar módulo profesional de compras a proveedores

### DIFF
--- a/migrations/013_add_compras.sql
+++ b/migrations/013_add_compras.sql
@@ -1,0 +1,241 @@
+-- Migración para agregar módulo de compras
+-- Permite registrar compras a proveedores y actualizar stock automáticamente
+
+-- Crear tabla de proveedores (opcional, para futuras mejoras)
+CREATE TABLE IF NOT EXISTS proveedores (
+  id BIGSERIAL PRIMARY KEY,
+  nombre VARCHAR(200) NOT NULL,
+  cuit VARCHAR(20),
+  direccion TEXT,
+  telefono VARCHAR(50),
+  email VARCHAR(100),
+  contacto VARCHAR(100),
+  notas TEXT,
+  activo BOOLEAN DEFAULT true,
+  created_at TIMESTAMPTZ DEFAULT NOW(),
+  updated_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+-- Crear tabla principal de compras
+CREATE TABLE IF NOT EXISTS compras (
+  id BIGSERIAL PRIMARY KEY,
+  proveedor_id BIGINT REFERENCES proveedores(id) ON DELETE SET NULL,
+  proveedor_nombre VARCHAR(200), -- Para cuando no se usa proveedor registrado
+  numero_factura VARCHAR(100),
+  fecha_compra DATE NOT NULL DEFAULT CURRENT_DATE,
+  fecha_recepcion DATE,
+  subtotal DECIMAL(12, 2) NOT NULL DEFAULT 0,
+  iva DECIMAL(12, 2) NOT NULL DEFAULT 0,
+  otros_impuestos DECIMAL(12, 2) NOT NULL DEFAULT 0,
+  total DECIMAL(12, 2) NOT NULL DEFAULT 0,
+  forma_pago VARCHAR(50) DEFAULT 'efectivo' CHECK (forma_pago IN ('efectivo', 'transferencia', 'cheque', 'cuenta_corriente', 'tarjeta')),
+  estado VARCHAR(50) DEFAULT 'pendiente' CHECK (estado IN ('pendiente', 'recibida', 'parcial', 'cancelada')),
+  notas TEXT,
+  usuario_id UUID REFERENCES perfiles(id) ON DELETE SET NULL,
+  created_at TIMESTAMPTZ DEFAULT NOW(),
+  updated_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+-- Crear tabla de items de compra
+CREATE TABLE IF NOT EXISTS compra_items (
+  id BIGSERIAL PRIMARY KEY,
+  compra_id BIGINT NOT NULL REFERENCES compras(id) ON DELETE CASCADE,
+  producto_id BIGINT NOT NULL REFERENCES productos(id) ON DELETE CASCADE,
+  cantidad INTEGER NOT NULL CHECK (cantidad > 0),
+  costo_unitario DECIMAL(12, 2) NOT NULL DEFAULT 0,
+  subtotal DECIMAL(12, 2) NOT NULL DEFAULT 0,
+  stock_anterior INTEGER NOT NULL DEFAULT 0,
+  stock_nuevo INTEGER NOT NULL DEFAULT 0,
+  created_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+-- Índices para búsquedas frecuentes
+CREATE INDEX IF NOT EXISTS idx_compras_fecha ON compras(fecha_compra DESC);
+CREATE INDEX IF NOT EXISTS idx_compras_proveedor ON compras(proveedor_id);
+CREATE INDEX IF NOT EXISTS idx_compras_estado ON compras(estado);
+CREATE INDEX IF NOT EXISTS idx_compras_created ON compras(created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_compra_items_compra ON compra_items(compra_id);
+CREATE INDEX IF NOT EXISTS idx_compra_items_producto ON compra_items(producto_id);
+CREATE INDEX IF NOT EXISTS idx_proveedores_nombre ON proveedores(nombre);
+
+-- Habilitar RLS
+ALTER TABLE compras ENABLE ROW LEVEL SECURITY;
+ALTER TABLE compra_items ENABLE ROW LEVEL SECURITY;
+ALTER TABLE proveedores ENABLE ROW LEVEL SECURITY;
+
+-- Políticas de seguridad para compras
+CREATE POLICY "Admin full access compras" ON compras
+  FOR ALL USING (
+    EXISTS (SELECT 1 FROM perfiles WHERE id = auth.uid() AND rol = 'admin')
+  );
+
+CREATE POLICY "Users can view compras" ON compras
+  FOR SELECT USING (
+    EXISTS (SELECT 1 FROM perfiles WHERE id = auth.uid() AND activo = true)
+  );
+
+-- Políticas de seguridad para compra_items
+CREATE POLICY "Admin full access compra_items" ON compra_items
+  FOR ALL USING (
+    EXISTS (SELECT 1 FROM perfiles WHERE id = auth.uid() AND rol = 'admin')
+  );
+
+CREATE POLICY "Users can view compra_items" ON compra_items
+  FOR SELECT USING (
+    EXISTS (SELECT 1 FROM perfiles WHERE id = auth.uid() AND activo = true)
+  );
+
+-- Políticas de seguridad para proveedores
+CREATE POLICY "Admin full access proveedores" ON proveedores
+  FOR ALL USING (
+    EXISTS (SELECT 1 FROM perfiles WHERE id = auth.uid() AND rol = 'admin')
+  );
+
+CREATE POLICY "Users can view proveedores" ON proveedores
+  FOR SELECT USING (
+    EXISTS (SELECT 1 FROM perfiles WHERE id = auth.uid() AND activo = true)
+  );
+
+-- Función para registrar compra completa con actualización de stock
+CREATE OR REPLACE FUNCTION registrar_compra_completa(
+  p_proveedor_id BIGINT DEFAULT NULL,
+  p_proveedor_nombre VARCHAR DEFAULT NULL,
+  p_numero_factura VARCHAR DEFAULT NULL,
+  p_fecha_compra DATE DEFAULT CURRENT_DATE,
+  p_subtotal DECIMAL DEFAULT 0,
+  p_iva DECIMAL DEFAULT 0,
+  p_otros_impuestos DECIMAL DEFAULT 0,
+  p_total DECIMAL DEFAULT 0,
+  p_forma_pago VARCHAR DEFAULT 'efectivo',
+  p_notas TEXT DEFAULT NULL,
+  p_usuario_id UUID DEFAULT NULL,
+  p_items JSONB DEFAULT '[]'
+)
+RETURNS JSONB AS $$
+DECLARE
+  v_compra_id BIGINT;
+  v_item JSONB;
+  v_producto RECORD;
+  v_stock_anterior INTEGER;
+  v_stock_nuevo INTEGER;
+  v_items_procesados JSONB := '[]'::JSONB;
+BEGIN
+  -- Crear la compra
+  INSERT INTO compras (
+    proveedor_id, proveedor_nombre, numero_factura, fecha_compra,
+    subtotal, iva, otros_impuestos, total, forma_pago, notas, usuario_id, estado
+  ) VALUES (
+    p_proveedor_id, p_proveedor_nombre, p_numero_factura, p_fecha_compra,
+    p_subtotal, p_iva, p_otros_impuestos, p_total, p_forma_pago, p_notas, p_usuario_id, 'recibida'
+  ) RETURNING id INTO v_compra_id;
+
+  -- Procesar cada item
+  FOR v_item IN SELECT * FROM jsonb_array_elements(p_items)
+  LOOP
+    -- Obtener stock actual del producto
+    SELECT id, stock INTO v_producto
+    FROM productos
+    WHERE id = (v_item->>'producto_id')::BIGINT;
+
+    IF NOT FOUND THEN
+      RAISE EXCEPTION 'Producto no encontrado: %', v_item->>'producto_id';
+    END IF;
+
+    v_stock_anterior := COALESCE(v_producto.stock, 0);
+    v_stock_nuevo := v_stock_anterior + (v_item->>'cantidad')::INTEGER;
+
+    -- Insertar item de compra
+    INSERT INTO compra_items (
+      compra_id, producto_id, cantidad, costo_unitario, subtotal,
+      stock_anterior, stock_nuevo
+    ) VALUES (
+      v_compra_id,
+      (v_item->>'producto_id')::BIGINT,
+      (v_item->>'cantidad')::INTEGER,
+      COALESCE((v_item->>'costo_unitario')::DECIMAL, 0),
+      COALESCE((v_item->>'subtotal')::DECIMAL, 0),
+      v_stock_anterior,
+      v_stock_nuevo
+    );
+
+    -- Actualizar stock del producto
+    UPDATE productos
+    SET stock = v_stock_nuevo,
+        updated_at = NOW()
+    WHERE id = (v_item->>'producto_id')::BIGINT;
+
+    -- Agregar a items procesados
+    v_items_procesados := v_items_procesados || jsonb_build_object(
+      'producto_id', (v_item->>'producto_id')::BIGINT,
+      'cantidad', (v_item->>'cantidad')::INTEGER,
+      'stock_anterior', v_stock_anterior,
+      'stock_nuevo', v_stock_nuevo
+    );
+  END LOOP;
+
+  RETURN jsonb_build_object(
+    'success', true,
+    'compra_id', v_compra_id,
+    'items_procesados', v_items_procesados
+  );
+EXCEPTION
+  WHEN OTHERS THEN
+    RETURN jsonb_build_object(
+      'success', false,
+      'error', SQLERRM
+    );
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+-- Función para obtener resumen de compras por período
+CREATE OR REPLACE FUNCTION obtener_resumen_compras(
+  p_fecha_desde DATE DEFAULT NULL,
+  p_fecha_hasta DATE DEFAULT NULL
+)
+RETURNS TABLE (
+  total_compras BIGINT,
+  monto_total DECIMAL,
+  promedio_compra DECIMAL,
+  productos_comprados BIGINT
+) AS $$
+BEGIN
+  RETURN QUERY
+  SELECT
+    COUNT(DISTINCT c.id)::BIGINT as total_compras,
+    COALESCE(SUM(c.total), 0)::DECIMAL as monto_total,
+    COALESCE(AVG(c.total), 0)::DECIMAL as promedio_compra,
+    COALESCE(SUM(ci.cantidad), 0)::BIGINT as productos_comprados
+  FROM compras c
+  LEFT JOIN compra_items ci ON c.id = ci.compra_id
+  WHERE c.estado != 'cancelada'
+    AND (p_fecha_desde IS NULL OR c.fecha_compra >= p_fecha_desde)
+    AND (p_fecha_hasta IS NULL OR c.fecha_compra <= p_fecha_hasta);
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+-- Trigger para actualizar updated_at en compras
+CREATE OR REPLACE FUNCTION update_compras_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = NOW();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER trigger_update_compras_timestamp
+  BEFORE UPDATE ON compras
+  FOR EACH ROW
+  EXECUTE FUNCTION update_compras_updated_at();
+
+CREATE TRIGGER trigger_update_proveedores_timestamp
+  BEFORE UPDATE ON proveedores
+  FOR EACH ROW
+  EXECUTE FUNCTION update_compras_updated_at();
+
+-- Comentarios para documentación
+COMMENT ON TABLE compras IS 'Registro de compras a proveedores con actualización automática de stock';
+COMMENT ON TABLE compra_items IS 'Items individuales de cada compra';
+COMMENT ON TABLE proveedores IS 'Catálogo de proveedores';
+COMMENT ON COLUMN compras.estado IS 'Estado de la compra: pendiente, recibida, parcial, cancelada';
+COMMENT ON COLUMN compra_items.stock_anterior IS 'Stock del producto antes de la compra';
+COMMENT ON COLUMN compra_items.stock_nuevo IS 'Stock del producto después de la compra';

--- a/src/components/layout/TopNavigation.jsx
+++ b/src/components/layout/TopNavigation.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useRef, useEffect } from 'react';
-import { Truck, Menu, X, LogOut, Moon, Sun, BarChart3, ShoppingCart, Users, Package, TrendingUp, UserCog, ChevronDown, Route } from 'lucide-react';
+import { Truck, Menu, X, LogOut, Moon, Sun, BarChart3, ShoppingCart, Users, Package, TrendingUp, UserCog, ChevronDown, Route, ShoppingBag } from 'lucide-react';
 import { getRolColor, getRolLabel } from '../../utils/formatters';
 import { useTheme } from '../../contexts/ThemeContext';
 import { NotificationCenter } from '../../contexts/NotificationContext';
@@ -9,6 +9,7 @@ const menuConfig = [
   { id: 'pedidos', icon: ShoppingCart, label: 'Pedidos', roles: ['admin', 'preventista', 'transportista'] },
   { id: 'clientes', icon: Users, label: 'Clientes', roles: ['admin', 'preventista'] },
   { id: 'productos', icon: Package, label: 'Productos', roles: ['admin', 'preventista'] },
+  { id: 'compras', icon: ShoppingBag, label: 'Compras', roles: ['admin'] },
   { id: 'recorridos', icon: Route, label: 'Recorridos', roles: ['admin'] },
   { id: 'reportes', icon: TrendingUp, label: 'Reportes', roles: ['admin'] },
   { id: 'usuarios', icon: UserCog, label: 'Usuarios', roles: ['admin'] },

--- a/src/components/modals/ModalCompra.jsx
+++ b/src/components/modals/ModalCompra.jsx
@@ -1,0 +1,461 @@
+import React, { useState, useMemo } from 'react'
+import { X, ShoppingCart, Plus, Trash2, Package, Building2, FileText, Calculator, Search } from 'lucide-react'
+import { formatPrecio } from '../../utils/formatters'
+
+const FORMAS_PAGO = [
+  { value: 'efectivo', label: 'Efectivo' },
+  { value: 'transferencia', label: 'Transferencia' },
+  { value: 'cheque', label: 'Cheque' },
+  { value: 'cuenta_corriente', label: 'Cuenta Corriente' },
+  { value: 'tarjeta', label: 'Tarjeta' }
+]
+
+export default function ModalCompra({ productos, proveedores, onSave, onClose, onAgregarProveedor }) {
+  const [proveedorId, setProveedorId] = useState('')
+  const [proveedorNombre, setProveedorNombre] = useState('')
+  const [usarProveedorNuevo, setUsarProveedorNuevo] = useState(false)
+  const [numeroFactura, setNumeroFactura] = useState('')
+  const [fechaCompra, setFechaCompra] = useState(new Date().toISOString().split('T')[0])
+  const [formaPago, setFormaPago] = useState('efectivo')
+  const [notas, setNotas] = useState('')
+  const [items, setItems] = useState([])
+  const [guardando, setGuardando] = useState(false)
+  const [error, setError] = useState('')
+
+  // Buscador de productos
+  const [busquedaProducto, setBusquedaProducto] = useState('')
+  const [mostrarBuscador, setMostrarBuscador] = useState(false)
+
+  // IVA configurable
+  const [aplicarIva, setAplicarIva] = useState(true)
+  const tasaIva = 21
+
+  // Productos filtrados
+  const productosFiltrados = useMemo(() => {
+    if (!busquedaProducto.trim()) return productos.slice(0, 10)
+    const termino = busquedaProducto.toLowerCase()
+    return productos.filter(p =>
+      p.nombre?.toLowerCase().includes(termino) ||
+      p.codigo?.toLowerCase().includes(termino)
+    ).slice(0, 10)
+  }, [productos, busquedaProducto])
+
+  // Cálculos
+  const subtotal = useMemo(() => {
+    return items.reduce((sum, item) => sum + (item.cantidad * item.costoUnitario), 0)
+  }, [items])
+
+  const iva = useMemo(() => {
+    return aplicarIva ? subtotal * (tasaIva / 100) : 0
+  }, [subtotal, aplicarIva])
+
+  const total = useMemo(() => subtotal + iva, [subtotal, iva])
+
+  const agregarItem = (producto) => {
+    // Verificar si ya existe
+    const existente = items.find(i => i.productoId === producto.id)
+    if (existente) {
+      setItems(items.map(i =>
+        i.productoId === producto.id
+          ? { ...i, cantidad: i.cantidad + 1 }
+          : i
+      ))
+    } else {
+      setItems([...items, {
+        productoId: producto.id,
+        productoNombre: producto.nombre,
+        productoCodigo: producto.codigo,
+        cantidad: 1,
+        costoUnitario: producto.costo_sin_iva || producto.costo_con_iva || 0,
+        stockActual: producto.stock
+      }])
+    }
+    setBusquedaProducto('')
+    setMostrarBuscador(false)
+  }
+
+  const actualizarItem = (index, campo, valor) => {
+    setItems(items.map((item, i) =>
+      i === index ? { ...item, [campo]: valor } : item
+    ))
+  }
+
+  const eliminarItem = (index) => {
+    setItems(items.filter((_, i) => i !== index))
+  }
+
+  const handleSubmit = async (e) => {
+    e.preventDefault()
+    setError('')
+
+    if (items.length === 0) {
+      setError('Debe agregar al menos un producto')
+      return
+    }
+
+    if (!usarProveedorNuevo && !proveedorId && !proveedorNombre.trim()) {
+      setError('Debe seleccionar o ingresar un proveedor')
+      return
+    }
+
+    // Validar items
+    for (const item of items) {
+      if (item.cantidad <= 0) {
+        setError(`La cantidad de "${item.productoNombre}" debe ser mayor a 0`)
+        return
+      }
+    }
+
+    setGuardando(true)
+    try {
+      await onSave({
+        proveedorId: usarProveedorNuevo ? null : (proveedorId || null),
+        proveedorNombre: usarProveedorNuevo || !proveedorId ? proveedorNombre : null,
+        numeroFactura,
+        fechaCompra,
+        subtotal,
+        iva,
+        otrosImpuestos: 0,
+        total,
+        formaPago,
+        notas,
+        items: items.map(item => ({
+          productoId: item.productoId,
+          cantidad: parseInt(item.cantidad),
+          costoUnitario: parseFloat(item.costoUnitario) || 0,
+          subtotal: item.cantidad * item.costoUnitario
+        }))
+      })
+      onClose()
+    } catch (err) {
+      setError(err.message || 'Error al registrar la compra')
+    } finally {
+      setGuardando(false)
+    }
+  }
+
+  return (
+    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
+      <div className="bg-white dark:bg-gray-800 rounded-xl shadow-xl w-full max-w-4xl max-h-[90vh] overflow-hidden flex flex-col">
+        {/* Header */}
+        <div className="flex items-center justify-between p-4 border-b dark:border-gray-700 shrink-0">
+          <div className="flex items-center gap-2">
+            <div className="p-2 bg-green-100 dark:bg-green-900/30 rounded-lg">
+              <ShoppingCart className="w-5 h-5 text-green-600" />
+            </div>
+            <div>
+              <h2 className="text-lg font-semibold text-gray-800 dark:text-white">Nueva Compra</h2>
+              <p className="text-sm text-gray-500">Registrar compra a proveedor</p>
+            </div>
+          </div>
+          <button onClick={onClose} className="p-2 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-lg">
+            <X className="w-5 h-5" />
+          </button>
+        </div>
+
+        {/* Contenido scrolleable */}
+        <form onSubmit={handleSubmit} className="flex-1 overflow-y-auto p-4 space-y-4">
+          {/* Sección Proveedor */}
+          <div className="bg-gray-50 dark:bg-gray-900 rounded-lg p-4 space-y-3">
+            <div className="flex items-center gap-2 mb-2">
+              <Building2 className="w-5 h-5 text-gray-500" />
+              <h3 className="font-medium text-gray-800 dark:text-white">Proveedor</h3>
+            </div>
+
+            <div className="flex items-center gap-4 mb-2">
+              <label className="flex items-center gap-2 cursor-pointer">
+                <input
+                  type="radio"
+                  checked={!usarProveedorNuevo}
+                  onChange={() => setUsarProveedorNuevo(false)}
+                  className="text-green-600"
+                />
+                <span className="text-sm">Seleccionar existente</span>
+              </label>
+              <label className="flex items-center gap-2 cursor-pointer">
+                <input
+                  type="radio"
+                  checked={usarProveedorNuevo}
+                  onChange={() => setUsarProveedorNuevo(true)}
+                  className="text-green-600"
+                />
+                <span className="text-sm">Ingresar nombre</span>
+              </label>
+            </div>
+
+            {!usarProveedorNuevo ? (
+              <select
+                value={proveedorId}
+                onChange={e => setProveedorId(e.target.value)}
+                className="w-full px-4 py-2 border dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-green-500 dark:bg-gray-700 dark:text-white"
+              >
+                <option value="">Seleccionar proveedor...</option>
+                {proveedores.map(p => (
+                  <option key={p.id} value={p.id}>{p.nombre} {p.cuit ? `(${p.cuit})` : ''}</option>
+                ))}
+              </select>
+            ) : (
+              <input
+                type="text"
+                value={proveedorNombre}
+                onChange={e => setProveedorNombre(e.target.value)}
+                placeholder="Nombre del proveedor"
+                className="w-full px-4 py-2 border dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-green-500 dark:bg-gray-700 dark:text-white"
+              />
+            )}
+          </div>
+
+          {/* Datos de la compra */}
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+            <div>
+              <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                N° Factura / Remito
+              </label>
+              <input
+                type="text"
+                value={numeroFactura}
+                onChange={e => setNumeroFactura(e.target.value)}
+                placeholder="Ej: 0001-00012345"
+                className="w-full px-4 py-2 border dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-green-500 dark:bg-gray-700 dark:text-white"
+              />
+            </div>
+            <div>
+              <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                Fecha de Compra *
+              </label>
+              <input
+                type="date"
+                value={fechaCompra}
+                onChange={e => setFechaCompra(e.target.value)}
+                className="w-full px-4 py-2 border dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-green-500 dark:bg-gray-700 dark:text-white"
+                required
+              />
+            </div>
+            <div>
+              <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                Forma de Pago
+              </label>
+              <select
+                value={formaPago}
+                onChange={e => setFormaPago(e.target.value)}
+                className="w-full px-4 py-2 border dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-green-500 dark:bg-gray-700 dark:text-white"
+              >
+                {FORMAS_PAGO.map(fp => (
+                  <option key={fp.value} value={fp.value}>{fp.label}</option>
+                ))}
+              </select>
+            </div>
+          </div>
+
+          {/* Productos */}
+          <div className="bg-gray-50 dark:bg-gray-900 rounded-lg p-4 space-y-3">
+            <div className="flex items-center justify-between">
+              <div className="flex items-center gap-2">
+                <Package className="w-5 h-5 text-gray-500" />
+                <h3 className="font-medium text-gray-800 dark:text-white">Productos</h3>
+              </div>
+            </div>
+
+            {/* Buscador de productos */}
+            <div className="relative">
+              <div className="flex items-center gap-2">
+                <div className="relative flex-1">
+                  <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400" />
+                  <input
+                    type="text"
+                    value={busquedaProducto}
+                    onChange={e => {
+                      setBusquedaProducto(e.target.value)
+                      setMostrarBuscador(true)
+                    }}
+                    onFocus={() => setMostrarBuscador(true)}
+                    placeholder="Buscar producto por nombre o código..."
+                    className="w-full pl-10 pr-4 py-2 border dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-green-500 dark:bg-gray-700 dark:text-white"
+                  />
+                </div>
+              </div>
+
+              {/* Dropdown de resultados */}
+              {mostrarBuscador && (
+                <div className="absolute z-10 w-full mt-1 bg-white dark:bg-gray-800 border dark:border-gray-600 rounded-lg shadow-lg max-h-48 overflow-y-auto">
+                  {productosFiltrados.length > 0 ? (
+                    productosFiltrados.map(p => (
+                      <button
+                        key={p.id}
+                        type="button"
+                        onClick={() => agregarItem(p)}
+                        className="w-full px-4 py-2 text-left hover:bg-gray-100 dark:hover:bg-gray-700 flex items-center justify-between"
+                      >
+                        <div>
+                          <p className="font-medium text-gray-800 dark:text-white">{p.nombre}</p>
+                          <p className="text-xs text-gray-500">
+                            {p.codigo && `Código: ${p.codigo} • `}
+                            Stock: {p.stock}
+                          </p>
+                        </div>
+                        <Plus className="w-4 h-4 text-green-600" />
+                      </button>
+                    ))
+                  ) : (
+                    <p className="px-4 py-2 text-sm text-gray-500">No se encontraron productos</p>
+                  )}
+                  <button
+                    type="button"
+                    onClick={() => setMostrarBuscador(false)}
+                    className="w-full px-4 py-2 text-sm text-gray-500 hover:bg-gray-100 dark:hover:bg-gray-700 border-t dark:border-gray-600"
+                  >
+                    Cerrar
+                  </button>
+                </div>
+              )}
+            </div>
+
+            {/* Lista de items */}
+            {items.length > 0 ? (
+              <div className="space-y-2">
+                <div className="grid grid-cols-12 gap-2 text-xs font-medium text-gray-500 uppercase px-2">
+                  <div className="col-span-5">Producto</div>
+                  <div className="col-span-2 text-center">Cantidad</div>
+                  <div className="col-span-2 text-center">Costo Unit.</div>
+                  <div className="col-span-2 text-right">Subtotal</div>
+                  <div className="col-span-1"></div>
+                </div>
+                {items.map((item, index) => (
+                  <div key={index} className="grid grid-cols-12 gap-2 items-center bg-white dark:bg-gray-800 p-2 rounded-lg border dark:border-gray-600">
+                    <div className="col-span-5">
+                      <p className="font-medium text-gray-800 dark:text-white text-sm">{item.productoNombre}</p>
+                      <p className="text-xs text-gray-500">Stock actual: {item.stockActual}</p>
+                    </div>
+                    <div className="col-span-2">
+                      <input
+                        type="number"
+                        min="1"
+                        value={item.cantidad}
+                        onChange={e => actualizarItem(index, 'cantidad', parseInt(e.target.value) || 0)}
+                        className="w-full px-2 py-1 text-center border dark:border-gray-600 rounded focus:ring-2 focus:ring-green-500 dark:bg-gray-700 dark:text-white text-sm"
+                      />
+                    </div>
+                    <div className="col-span-2">
+                      <input
+                        type="number"
+                        min="0"
+                        step="0.01"
+                        value={item.costoUnitario}
+                        onChange={e => actualizarItem(index, 'costoUnitario', parseFloat(e.target.value) || 0)}
+                        className="w-full px-2 py-1 text-center border dark:border-gray-600 rounded focus:ring-2 focus:ring-green-500 dark:bg-gray-700 dark:text-white text-sm"
+                      />
+                    </div>
+                    <div className="col-span-2 text-right font-medium text-gray-800 dark:text-white text-sm">
+                      {formatPrecio(item.cantidad * item.costoUnitario)}
+                    </div>
+                    <div className="col-span-1 text-right">
+                      <button
+                        type="button"
+                        onClick={() => eliminarItem(index)}
+                        className="p-1 text-red-500 hover:bg-red-50 dark:hover:bg-red-900/20 rounded"
+                      >
+                        <Trash2 className="w-4 h-4" />
+                      </button>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            ) : (
+              <div className="text-center py-8 text-gray-500">
+                <Package className="w-12 h-12 mx-auto mb-2 opacity-50" />
+                <p>No hay productos agregados</p>
+                <p className="text-sm">Use el buscador para agregar productos</p>
+              </div>
+            )}
+          </div>
+
+          {/* Totales */}
+          {items.length > 0 && (
+            <div className="bg-green-50 dark:bg-green-900/20 rounded-lg p-4">
+              <div className="flex items-center gap-2 mb-3">
+                <Calculator className="w-5 h-5 text-green-600" />
+                <h3 className="font-medium text-gray-800 dark:text-white">Resumen</h3>
+              </div>
+
+              <div className="space-y-2">
+                <div className="flex justify-between text-sm">
+                  <span className="text-gray-600 dark:text-gray-400">Subtotal:</span>
+                  <span className="font-medium text-gray-800 dark:text-white">{formatPrecio(subtotal)}</span>
+                </div>
+                <div className="flex justify-between items-center text-sm">
+                  <div className="flex items-center gap-2">
+                    <span className="text-gray-600 dark:text-gray-400">IVA ({tasaIva}%):</span>
+                    <label className="flex items-center gap-1 cursor-pointer">
+                      <input
+                        type="checkbox"
+                        checked={aplicarIva}
+                        onChange={e => setAplicarIva(e.target.checked)}
+                        className="rounded text-green-600"
+                      />
+                      <span className="text-xs text-gray-500">Aplicar</span>
+                    </label>
+                  </div>
+                  <span className="font-medium text-gray-800 dark:text-white">{formatPrecio(iva)}</span>
+                </div>
+                <div className="flex justify-between text-lg font-bold pt-2 border-t dark:border-gray-600">
+                  <span className="text-gray-800 dark:text-white">Total:</span>
+                  <span className="text-green-600">{formatPrecio(total)}</span>
+                </div>
+              </div>
+            </div>
+          )}
+
+          {/* Notas */}
+          <div>
+            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+              <FileText className="w-4 h-4 inline mr-1" />
+              Notas (opcional)
+            </label>
+            <textarea
+              value={notas}
+              onChange={e => setNotas(e.target.value)}
+              placeholder="Observaciones adicionales..."
+              rows={2}
+              className="w-full px-4 py-2 border dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-green-500 dark:bg-gray-700 dark:text-white"
+            />
+          </div>
+
+          {/* Error */}
+          {error && (
+            <div className="p-3 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg">
+              <p className="text-sm text-red-600 dark:text-red-400">{error}</p>
+            </div>
+          )}
+        </form>
+
+        {/* Footer con botones */}
+        <div className="flex gap-3 p-4 border-t dark:border-gray-700 shrink-0">
+          <button
+            type="button"
+            onClick={onClose}
+            className="flex-1 px-4 py-2 border dark:border-gray-600 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors"
+          >
+            Cancelar
+          </button>
+          <button
+            onClick={handleSubmit}
+            disabled={guardando || items.length === 0}
+            className="flex-1 px-4 py-2 bg-green-600 hover:bg-green-700 disabled:bg-green-400 text-white rounded-lg transition-colors flex items-center justify-center gap-2"
+          >
+            {guardando ? (
+              <>
+                <span className="animate-spin">...</span>
+                Registrando...
+              </>
+            ) : (
+              <>
+                <ShoppingCart className="w-4 h-4" />
+                Registrar Compra
+              </>
+            )}
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/components/modals/ModalDetalleCompra.jsx
+++ b/src/components/modals/ModalDetalleCompra.jsx
@@ -1,0 +1,221 @@
+import React from 'react'
+import { X, ShoppingCart, Package, Building2, Calendar, CreditCard, FileText, TrendingUp, Hash } from 'lucide-react'
+import { formatPrecio } from '../../utils/formatters'
+
+const ESTADOS_COMPRA = {
+  pendiente: { label: 'Pendiente', color: 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-400' },
+  recibida: { label: 'Recibida', color: 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400' },
+  parcial: { label: 'Parcial', color: 'bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-400' },
+  cancelada: { label: 'Cancelada', color: 'bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-400' }
+}
+
+const FORMAS_PAGO = {
+  efectivo: 'Efectivo',
+  transferencia: 'Transferencia',
+  cheque: 'Cheque',
+  cuenta_corriente: 'Cuenta Corriente',
+  tarjeta: 'Tarjeta'
+}
+
+export default function ModalDetalleCompra({ compra, onClose, onAnular }) {
+  if (!compra) return null
+
+  const estado = ESTADOS_COMPRA[compra.estado] || ESTADOS_COMPRA.pendiente
+  const totalUnidades = (compra.items || []).reduce((sum, i) => sum + i.cantidad, 0)
+
+  return (
+    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
+      <div className="bg-white dark:bg-gray-800 rounded-xl shadow-xl w-full max-w-2xl max-h-[90vh] flex flex-col">
+        {/* Header */}
+        <div className="flex items-center justify-between p-4 border-b dark:border-gray-700">
+          <div className="flex items-center gap-2">
+            <div className="p-2 bg-green-100 dark:bg-green-900/30 rounded-lg">
+              <ShoppingCart className="w-5 h-5 text-green-600" />
+            </div>
+            <div>
+              <h2 className="text-lg font-semibold text-gray-800 dark:text-white">
+                Detalle de Compra #{compra.id}
+              </h2>
+              <p className="text-sm text-gray-500">
+                {new Date(compra.created_at).toLocaleDateString('es-AR', {
+                  year: 'numeric',
+                  month: 'long',
+                  day: 'numeric',
+                  hour: '2-digit',
+                  minute: '2-digit'
+                })}
+              </p>
+            </div>
+          </div>
+          <div className="flex items-center gap-2">
+            <span className={`px-3 py-1 rounded-full text-xs font-medium ${estado.color}`}>
+              {estado.label}
+            </span>
+            <button onClick={onClose} className="p-2 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-lg">
+              <X className="w-5 h-5" />
+            </button>
+          </div>
+        </div>
+
+        {/* Contenido scrolleable */}
+        <div className="flex-1 overflow-y-auto p-4 space-y-4">
+          {/* Info del proveedor */}
+          <div className="bg-gray-50 dark:bg-gray-900 rounded-lg p-4">
+            <div className="flex items-center gap-2 mb-3">
+              <Building2 className="w-5 h-5 text-gray-500" />
+              <h3 className="font-medium text-gray-800 dark:text-white">Proveedor</h3>
+            </div>
+            <p className="text-lg font-medium text-gray-800 dark:text-white">
+              {compra.proveedor?.nombre || compra.proveedor_nombre || 'Sin proveedor especificado'}
+            </p>
+            {compra.proveedor?.cuit && (
+              <p className="text-sm text-gray-500">CUIT: {compra.proveedor.cuit}</p>
+            )}
+          </div>
+
+          {/* Datos de la compra */}
+          <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+            <div className="bg-gray-50 dark:bg-gray-900 rounded-lg p-3">
+              <div className="flex items-center gap-2 text-gray-500 mb-1">
+                <Calendar className="w-4 h-4" />
+                <span className="text-xs">Fecha compra</span>
+              </div>
+              <p className="font-medium text-gray-800 dark:text-white">
+                {new Date(compra.fecha_compra).toLocaleDateString('es-AR')}
+              </p>
+            </div>
+            <div className="bg-gray-50 dark:bg-gray-900 rounded-lg p-3">
+              <div className="flex items-center gap-2 text-gray-500 mb-1">
+                <Hash className="w-4 h-4" />
+                <span className="text-xs">N° Factura</span>
+              </div>
+              <p className="font-medium text-gray-800 dark:text-white">
+                {compra.numero_factura || 'Sin especificar'}
+              </p>
+            </div>
+            <div className="bg-gray-50 dark:bg-gray-900 rounded-lg p-3">
+              <div className="flex items-center gap-2 text-gray-500 mb-1">
+                <CreditCard className="w-4 h-4" />
+                <span className="text-xs">Forma de pago</span>
+              </div>
+              <p className="font-medium text-gray-800 dark:text-white">
+                {FORMAS_PAGO[compra.forma_pago] || compra.forma_pago}
+              </p>
+            </div>
+            <div className="bg-gray-50 dark:bg-gray-900 rounded-lg p-3">
+              <div className="flex items-center gap-2 text-gray-500 mb-1">
+                <Package className="w-4 h-4" />
+                <span className="text-xs">Total unidades</span>
+              </div>
+              <p className="font-medium text-gray-800 dark:text-white">{totalUnidades}</p>
+            </div>
+          </div>
+
+          {/* Items de la compra */}
+          <div>
+            <div className="flex items-center gap-2 mb-3">
+              <Package className="w-5 h-5 text-gray-500" />
+              <h3 className="font-medium text-gray-800 dark:text-white">Productos ({compra.items?.length || 0})</h3>
+            </div>
+            <div className="bg-gray-50 dark:bg-gray-900 rounded-lg overflow-hidden">
+              <table className="w-full text-sm">
+                <thead className="bg-gray-100 dark:bg-gray-800">
+                  <tr>
+                    <th className="text-left px-4 py-2 text-gray-600 dark:text-gray-400">Producto</th>
+                    <th className="text-center px-4 py-2 text-gray-600 dark:text-gray-400">Cantidad</th>
+                    <th className="text-right px-4 py-2 text-gray-600 dark:text-gray-400">Costo Unit.</th>
+                    <th className="text-right px-4 py-2 text-gray-600 dark:text-gray-400">Subtotal</th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y dark:divide-gray-700">
+                  {(compra.items || []).map((item, index) => (
+                    <tr key={index}>
+                      <td className="px-4 py-3">
+                        <p className="font-medium text-gray-800 dark:text-white">
+                          {item.producto?.nombre || 'Producto'}
+                        </p>
+                        <p className="text-xs text-gray-500">
+                          Stock: {item.stock_anterior} → {item.stock_nuevo}
+                          <TrendingUp className="inline w-3 h-3 ml-1 text-green-500" />
+                        </p>
+                      </td>
+                      <td className="px-4 py-3 text-center text-gray-800 dark:text-white">
+                        {item.cantidad}
+                      </td>
+                      <td className="px-4 py-3 text-right text-gray-800 dark:text-white">
+                        {formatPrecio(item.costo_unitario)}
+                      </td>
+                      <td className="px-4 py-3 text-right font-medium text-gray-800 dark:text-white">
+                        {formatPrecio(item.subtotal || item.cantidad * item.costo_unitario)}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </div>
+
+          {/* Totales */}
+          <div className="bg-green-50 dark:bg-green-900/20 rounded-lg p-4">
+            <div className="space-y-2">
+              <div className="flex justify-between text-sm">
+                <span className="text-gray-600 dark:text-gray-400">Subtotal:</span>
+                <span className="font-medium text-gray-800 dark:text-white">{formatPrecio(compra.subtotal)}</span>
+              </div>
+              <div className="flex justify-between text-sm">
+                <span className="text-gray-600 dark:text-gray-400">IVA:</span>
+                <span className="font-medium text-gray-800 dark:text-white">{formatPrecio(compra.iva)}</span>
+              </div>
+              {compra.otros_impuestos > 0 && (
+                <div className="flex justify-between text-sm">
+                  <span className="text-gray-600 dark:text-gray-400">Otros impuestos:</span>
+                  <span className="font-medium text-gray-800 dark:text-white">{formatPrecio(compra.otros_impuestos)}</span>
+                </div>
+              )}
+              <div className="flex justify-between text-lg font-bold pt-2 border-t border-green-200 dark:border-green-800">
+                <span className="text-gray-800 dark:text-white">Total:</span>
+                <span className="text-green-600">{formatPrecio(compra.total)}</span>
+              </div>
+            </div>
+          </div>
+
+          {/* Notas */}
+          {compra.notas && (
+            <div className="bg-gray-50 dark:bg-gray-900 rounded-lg p-4">
+              <div className="flex items-center gap-2 mb-2">
+                <FileText className="w-4 h-4 text-gray-500" />
+                <span className="text-sm font-medium text-gray-600 dark:text-gray-400">Notas</span>
+              </div>
+              <p className="text-gray-800 dark:text-white">{compra.notas}</p>
+            </div>
+          )}
+
+          {/* Usuario que registró */}
+          {compra.usuario && (
+            <div className="text-sm text-gray-500 text-center">
+              Registrado por: {compra.usuario.nombre}
+            </div>
+          )}
+        </div>
+
+        {/* Footer */}
+        <div className="flex gap-3 p-4 border-t dark:border-gray-700">
+          {compra.estado !== 'cancelada' && onAnular && (
+            <button
+              onClick={() => onAnular(compra.id)}
+              className="px-4 py-2 text-red-600 border border-red-200 dark:border-red-800 hover:bg-red-50 dark:hover:bg-red-900/20 rounded-lg transition-colors"
+            >
+              Anular Compra
+            </button>
+          )}
+          <button
+            onClick={onClose}
+            className="flex-1 px-4 py-2 bg-gray-100 dark:bg-gray-700 hover:bg-gray-200 dark:hover:bg-gray-600 rounded-lg transition-colors"
+          >
+            Cerrar
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/hooks/useSupabase.jsx
+++ b/src/hooks/useSupabase.jsx
@@ -1505,6 +1505,314 @@ export function useMermas() {
   }
 }
 
+// Hook para gestión de compras a proveedores
+export function useCompras() {
+  const [compras, setCompras] = useState([])
+  const [proveedores, setProveedores] = useState([])
+  const [loading, setLoading] = useState(false)
+
+  const fetchCompras = async () => {
+    setLoading(true)
+    try {
+      const { data, error } = await supabase
+        .from('compras')
+        .select(`
+          *,
+          proveedor:proveedores(*),
+          items:compra_items(*, producto:productos(*)),
+          usuario:perfiles(id, nombre)
+        `)
+        .order('created_at', { ascending: false })
+
+      if (error) {
+        if (error.message.includes('does not exist')) {
+          console.warn('Tabla compras no existe. Ejecute la migración 013_add_compras.sql')
+          setCompras([])
+          return
+        }
+        throw error
+      }
+      setCompras(data || [])
+    } catch (error) {
+      console.error('Error fetching compras:', error)
+      notifyError('Error al cargar compras: ' + error.message)
+      setCompras([])
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  const fetchProveedores = async () => {
+    try {
+      const { data, error } = await supabase
+        .from('proveedores')
+        .select('*')
+        .eq('activo', true)
+        .order('nombre')
+
+      if (error) {
+        if (error.message.includes('does not exist')) {
+          console.warn('Tabla proveedores no existe.')
+          setProveedores([])
+          return
+        }
+        throw error
+      }
+      setProveedores(data || [])
+    } catch (error) {
+      console.error('Error fetching proveedores:', error)
+      setProveedores([])
+    }
+  }
+
+  useEffect(() => {
+    fetchCompras()
+    fetchProveedores()
+  }, [])
+
+  const registrarCompra = async (compraData) => {
+    try {
+      // Preparar items para RPC
+      const itemsParaRPC = compraData.items.map(item => ({
+        producto_id: item.productoId,
+        cantidad: item.cantidad,
+        costo_unitario: item.costoUnitario || 0,
+        subtotal: item.subtotal || (item.cantidad * (item.costoUnitario || 0))
+      }))
+
+      // Intentar usar función RPC
+      const { data, error } = await supabase.rpc('registrar_compra_completa', {
+        p_proveedor_id: compraData.proveedorId || null,
+        p_proveedor_nombre: compraData.proveedorNombre || null,
+        p_numero_factura: compraData.numeroFactura || null,
+        p_fecha_compra: compraData.fechaCompra || new Date().toISOString().split('T')[0],
+        p_subtotal: compraData.subtotal || 0,
+        p_iva: compraData.iva || 0,
+        p_otros_impuestos: compraData.otrosImpuestos || 0,
+        p_total: compraData.total || 0,
+        p_forma_pago: compraData.formaPago || 'efectivo',
+        p_notas: compraData.notas || null,
+        p_usuario_id: compraData.usuarioId || null,
+        p_items: itemsParaRPC
+      })
+
+      if (error) {
+        // Fallback si la función RPC no existe
+        if (error.message.includes('does not exist')) {
+          console.warn('RPC registrar_compra_completa no disponible, usando método manual')
+          return await registrarCompraManual(compraData)
+        }
+        throw error
+      }
+
+      if (!data.success) {
+        throw new Error(data.error || 'Error al registrar compra')
+      }
+
+      await fetchCompras()
+      return { success: true, compraId: data.compra_id }
+    } catch (error) {
+      console.error('Error registrando compra:', error)
+      throw error
+    }
+  }
+
+  // Método manual de fallback
+  const registrarCompraManual = async (compraData) => {
+    // Crear la compra
+    const { data: compra, error: compraError } = await supabase
+      .from('compras')
+      .insert([{
+        proveedor_id: compraData.proveedorId || null,
+        proveedor_nombre: compraData.proveedorNombre || null,
+        numero_factura: compraData.numeroFactura || null,
+        fecha_compra: compraData.fechaCompra || new Date().toISOString().split('T')[0],
+        subtotal: compraData.subtotal || 0,
+        iva: compraData.iva || 0,
+        otros_impuestos: compraData.otrosImpuestos || 0,
+        total: compraData.total || 0,
+        forma_pago: compraData.formaPago || 'efectivo',
+        notas: compraData.notas || null,
+        usuario_id: compraData.usuarioId || null,
+        estado: 'recibida'
+      }])
+      .select()
+      .single()
+
+    if (compraError) throw compraError
+
+    // Procesar cada item
+    for (const item of compraData.items) {
+      // Obtener stock actual
+      const { data: producto } = await supabase
+        .from('productos')
+        .select('stock')
+        .eq('id', item.productoId)
+        .single()
+
+      const stockAnterior = producto?.stock || 0
+      const stockNuevo = stockAnterior + item.cantidad
+
+      // Insertar item
+      await supabase.from('compra_items').insert([{
+        compra_id: compra.id,
+        producto_id: item.productoId,
+        cantidad: item.cantidad,
+        costo_unitario: item.costoUnitario || 0,
+        subtotal: item.subtotal || (item.cantidad * (item.costoUnitario || 0)),
+        stock_anterior: stockAnterior,
+        stock_nuevo: stockNuevo
+      }])
+
+      // Actualizar stock del producto
+      await supabase
+        .from('productos')
+        .update({ stock: stockNuevo })
+        .eq('id', item.productoId)
+    }
+
+    await fetchCompras()
+    return { success: true, compraId: compra.id }
+  }
+
+  const agregarProveedor = async (proveedor) => {
+    try {
+      const { data, error } = await supabase
+        .from('proveedores')
+        .insert([{
+          nombre: proveedor.nombre,
+          cuit: proveedor.cuit || null,
+          direccion: proveedor.direccion || null,
+          telefono: proveedor.telefono || null,
+          email: proveedor.email || null,
+          contacto: proveedor.contacto || null,
+          notas: proveedor.notas || null
+        }])
+        .select()
+        .single()
+
+      if (error) throw error
+      setProveedores(prev => [...prev, data].sort((a, b) => a.nombre.localeCompare(b.nombre)))
+      return data
+    } catch (error) {
+      console.error('Error agregando proveedor:', error)
+      throw error
+    }
+  }
+
+  const actualizarProveedor = async (id, proveedor) => {
+    try {
+      const { data, error } = await supabase
+        .from('proveedores')
+        .update({
+          nombre: proveedor.nombre,
+          cuit: proveedor.cuit || null,
+          direccion: proveedor.direccion || null,
+          telefono: proveedor.telefono || null,
+          email: proveedor.email || null,
+          contacto: proveedor.contacto || null,
+          notas: proveedor.notas || null,
+          activo: proveedor.activo !== undefined ? proveedor.activo : true
+        })
+        .eq('id', id)
+        .select()
+        .single()
+
+      if (error) throw error
+      setProveedores(prev => prev.map(p => p.id === id ? data : p))
+      return data
+    } catch (error) {
+      console.error('Error actualizando proveedor:', error)
+      throw error
+    }
+  }
+
+  const getComprasPorProducto = (productoId) => {
+    const comprasConProducto = []
+    compras.forEach(compra => {
+      const itemsDelProducto = compra.items?.filter(i => i.producto_id === productoId) || []
+      if (itemsDelProducto.length > 0) {
+        comprasConProducto.push({
+          ...compra,
+          items: itemsDelProducto
+        })
+      }
+    })
+    return comprasConProducto
+  }
+
+  const getResumenCompras = (fechaDesde = null, fechaHasta = null) => {
+    let comprasFiltradas = [...compras]
+
+    if (fechaDesde) {
+      comprasFiltradas = comprasFiltradas.filter(c => c.fecha_compra >= fechaDesde)
+    }
+    if (fechaHasta) {
+      comprasFiltradas = comprasFiltradas.filter(c => c.fecha_compra <= fechaHasta)
+    }
+
+    const porProveedor = {}
+    comprasFiltradas.forEach(c => {
+      const proveedorNombre = c.proveedor?.nombre || c.proveedor_nombre || 'Sin proveedor'
+      if (!porProveedor[proveedorNombre]) {
+        porProveedor[proveedorNombre] = { total: 0, compras: 0, unidades: 0 }
+      }
+      porProveedor[proveedorNombre].total += c.total || 0
+      porProveedor[proveedorNombre].compras += 1
+      porProveedor[proveedorNombre].unidades += (c.items || []).reduce((s, i) => s + i.cantidad, 0)
+    })
+
+    return {
+      totalMonto: comprasFiltradas.reduce((sum, c) => sum + (c.total || 0), 0),
+      totalCompras: comprasFiltradas.length,
+      totalUnidades: comprasFiltradas.reduce((sum, c) => sum + (c.items || []).reduce((s, i) => s + i.cantidad, 0), 0),
+      porProveedor
+    }
+  }
+
+  const anularCompra = async (compraId) => {
+    try {
+      const compra = compras.find(c => c.id === compraId)
+      if (!compra) throw new Error('Compra no encontrada')
+
+      // Revertir stock de cada item
+      for (const item of (compra.items || [])) {
+        const nuevoStock = (item.stock_nuevo || 0) - item.cantidad
+        await supabase
+          .from('productos')
+          .update({ stock: Math.max(0, nuevoStock) })
+          .eq('id', item.producto_id)
+      }
+
+      // Marcar compra como cancelada
+      const { error } = await supabase
+        .from('compras')
+        .update({ estado: 'cancelada' })
+        .eq('id', compraId)
+
+      if (error) throw error
+      await fetchCompras()
+    } catch (error) {
+      console.error('Error anulando compra:', error)
+      throw error
+    }
+  }
+
+  return {
+    compras,
+    proveedores,
+    loading,
+    registrarCompra,
+    agregarProveedor,
+    actualizarProveedor,
+    getComprasPorProducto,
+    getResumenCompras,
+    anularCompra,
+    refetch: fetchCompras,
+    refetchProveedores: fetchProveedores
+  }
+}
+
 // Hook para gestión de recorridos de transportistas
 export function useRecorridos() {
   const [recorridos, setRecorridos] = useState([])


### PR DESCRIPTION
- Crear migración SQL para tablas compras, compra_items y proveedores
- Agregar función RPC registrar_compra_completa para operación atómica
- Crear hook useCompras() con CRUD completo y gestión de proveedores
- Implementar ModalCompra.jsx con buscador de productos y cálculo de IVA
- Crear ModalDetalleCompra.jsx para visualizar detalles de compra
- Agregar VistaCompras.jsx con filtros, estadísticas y listado
- Integrar módulo completo en App.jsx con handlers y modales
- Agregar navegación al menú principal (solo admin)

El módulo permite:
- Registrar compras a proveedores con múltiples productos
- Actualizar stock automáticamente al registrar una compra
- Anular compras con reversión de stock
- Filtrar por proveedor, estado, fecha y búsqueda
- Ver resumen con estadísticas de compras