### PR TITLE
fix: Corregir errores de DB y agregar opción Volver a Pendiente

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -212,6 +212,7 @@ function MainApp(): ReactElement {
                 onVerHistorial={handlers.handleVerHistorial}
                 onEditarPedido={handlers.handleEditarPedido}
                 onMarcarEnPreparacion={handlers.handleMarcarEnPreparacion}
+                onVolverAPendiente={handlers.handleVolverAPendiente}
                 onAsignarTransportista={(pedido) => { appState.setPedidoAsignando(pedido); modales.asignar.setOpen(true); }}
                 onMarcarEntregado={handlers.handleMarcarEntregado}
                 onDesmarcarEntregado={handlers.handleDesmarcarEntregado}

--- a/src/components/pedidos/PedidoActions.tsx
+++ b/src/components/pedidos/PedidoActions.tsx
@@ -9,7 +9,7 @@
  * - Focus visible en items
  */
 import React, { memo, useMemo } from 'react';
-import { MoreVertical, History, Edit2, Package, User, Check, AlertTriangle, Trash2, LucideIcon } from 'lucide-react';
+import { MoreVertical, History, Edit2, Package, User, Check, AlertTriangle, Trash2, RotateCcw, LucideIcon } from 'lucide-react';
 import {
   DropdownMenu,
   DropdownMenuTrigger,
@@ -31,6 +31,7 @@ export interface AccionesDropdownProps {
   onHistorial?: (pedido: PedidoDB) => void;
   onEditar?: (pedido: PedidoDB) => void;
   onPreparar?: (pedido: PedidoDB) => void;
+  onVolverAPendiente?: (pedido: PedidoDB) => void;
   onAsignar?: (pedido: PedidoDB) => void;
   onEntregado?: (pedido: PedidoDB) => void;
   onRevertir?: (pedido: PedidoDB) => void;
@@ -57,6 +58,7 @@ function AccionesDropdown({
   onHistorial,
   onEditar,
   onPreparar,
+  onVolverAPendiente,
   onAsignar,
   onEntregado,
   onRevertir,
@@ -93,6 +95,16 @@ function AccionesDropdown({
         icon: Package,
         onClick: () => onPreparar(pedido),
         className: 'text-orange-700 dark:text-orange-400'
+      });
+    }
+
+    // Admin puede volver a pendiente si esta en preparacion o asignado
+    if (isAdmin && (pedido.estado === 'en_preparacion' || pedido.estado === 'asignado') && onVolverAPendiente) {
+      items.push({
+        label: 'Volver a Pendiente',
+        icon: RotateCcw,
+        onClick: () => onVolverAPendiente(pedido),
+        className: 'text-gray-700 dark:text-gray-400'
       });
     }
 
@@ -138,7 +150,7 @@ function AccionesDropdown({
     }
 
     return items;
-  }, [pedido, isAdmin, isPreventista, isTransportista, onHistorial, onEditar, onPreparar, onAsignar, onEntregado, onRevertir, onEliminar]);
+  }, [pedido, isAdmin, isPreventista, isTransportista, onHistorial, onEditar, onPreparar, onVolverAPendiente, onAsignar, onEntregado, onRevertir, onEliminar]);
 
   return (
     <DropdownMenu>

--- a/src/components/pedidos/PedidoCard.tsx
+++ b/src/components/pedidos/PedidoCard.tsx
@@ -29,6 +29,7 @@ export interface PedidoCardProps {
   onVerHistorial?: (pedido: PedidoDB) => void;
   onEditarPedido?: (pedido: PedidoDB) => void;
   onMarcarEnPreparacion?: (pedido: PedidoDB) => void;
+  onVolverAPendiente?: (pedido: PedidoDB) => void;
   onAsignarTransportista?: (pedido: PedidoDB) => void;
   onMarcarEntregado?: (pedido: PedidoDB) => void;
   onDesmarcarEntregado?: (pedido: PedidoDB) => void;
@@ -124,6 +125,7 @@ function PedidoCard({
   onVerHistorial,
   onEditarPedido,
   onMarcarEnPreparacion,
+  onVolverAPendiente,
   onAsignarTransportista,
   onMarcarEntregado,
   onDesmarcarEntregado,
@@ -174,6 +176,7 @@ function PedidoCard({
             onHistorial={onVerHistorial}
             onEditar={onEditarPedido}
             onPreparar={onMarcarEnPreparacion}
+            onVolverAPendiente={onVolverAPendiente}
             onAsignar={onAsignarTransportista}
             onEntregado={onMarcarEntregado}
             onRevertir={onDesmarcarEntregado}

--- a/src/components/pedidos/VirtualizedPedidoList.tsx
+++ b/src/components/pedidos/VirtualizedPedidoList.tsx
@@ -35,6 +35,7 @@ export interface VirtualizedPedidoListProps {
   onVerHistorial?: (pedido: PedidoDB) => void;
   onEditarPedido?: (pedido: PedidoDB) => void;
   onMarcarEnPreparacion?: (pedido: PedidoDB) => void;
+  onVolverAPendiente?: (pedido: PedidoDB) => void;
   onAsignarTransportista?: (pedido: PedidoDB) => void;
   onMarcarEntregado?: (pedido: PedidoDB) => void;
   onDesmarcarEntregado?: (pedido: PedidoDB) => void;
@@ -54,6 +55,7 @@ interface VirtualizedPedidoListData {
     onVerHistorial?: (pedido: PedidoDB) => void;
     onEditarPedido?: (pedido: PedidoDB) => void;
     onMarcarEnPreparacion?: (pedido: PedidoDB) => void;
+    onVolverAPendiente?: (pedido: PedidoDB) => void;
     onAsignarTransportista?: (pedido: PedidoDB) => void;
     onMarcarEntregado?: (pedido: PedidoDB) => void;
     onDesmarcarEntregado?: (pedido: PedidoDB) => void;
@@ -103,6 +105,7 @@ const PedidoRow = memo(function PedidoRow({ index, style, ariaAttributes }: Pedi
           onVerHistorial={handlers?.onVerHistorial}
           onEditarPedido={handlers?.onEditarPedido}
           onMarcarEnPreparacion={handlers?.onMarcarEnPreparacion}
+          onVolverAPendiente={handlers?.onVolverAPendiente}
           onAsignarTransportista={handlers?.onAsignarTransportista}
           onMarcarEntregado={handlers?.onMarcarEntregado}
           onDesmarcarEntregado={handlers?.onDesmarcarEntregado}
@@ -124,6 +127,7 @@ function VirtualizedPedidoList({
   onVerHistorial,
   onEditarPedido,
   onMarcarEnPreparacion,
+  onVolverAPendiente,
   onAsignarTransportista,
   onMarcarEntregado,
   onDesmarcarEntregado,
@@ -149,6 +153,7 @@ function VirtualizedPedidoList({
         onVerHistorial,
         onEditarPedido,
         onMarcarEnPreparacion,
+        onVolverAPendiente,
         onAsignarTransportista,
         onMarcarEntregado,
         onDesmarcarEntregado,
@@ -172,6 +177,7 @@ function VirtualizedPedidoList({
     onVerHistorial,
     onEditarPedido,
     onMarcarEnPreparacion,
+    onVolverAPendiente,
     onAsignarTransportista,
     onMarcarEntregado,
     onDesmarcarEntregado,

--- a/src/components/vistas/VistaPedidos.tsx
+++ b/src/components/vistas/VistaPedidos.tsx
@@ -51,6 +51,7 @@ export interface VistaPedidosProps {
   onVerHistorial: (pedido: PedidoDB) => void;
   onEditarPedido: (pedido: PedidoDB) => void;
   onMarcarEnPreparacion: (pedido: PedidoDB) => void;
+  onVolverAPendiente: (pedido: PedidoDB) => void;
   onAsignarTransportista: (pedido: PedidoDB) => void;
   onMarcarEntregado: (pedido: PedidoDB) => void;
   onDesmarcarEntregado: (pedido: PedidoDB) => void;
@@ -90,6 +91,7 @@ export default function VistaPedidos({
   onVerHistorial,
   onEditarPedido,
   onMarcarEnPreparacion,
+  onVolverAPendiente,
   onAsignarTransportista,
   onMarcarEntregado,
   onDesmarcarEntregado,
@@ -205,6 +207,7 @@ export default function VistaPedidos({
             onVerHistorial={onVerHistorial}
             onEditarPedido={onEditarPedido}
             onMarcarEnPreparacion={onMarcarEnPreparacion}
+            onVolverAPendiente={onVolverAPendiente}
             onAsignarTransportista={onAsignarTransportista}
             onMarcarEntregado={onMarcarEntregado}
             onDesmarcarEntregado={onDesmarcarEntregado}
@@ -228,6 +231,7 @@ export default function VistaPedidos({
                 onVerHistorial={onVerHistorial}
                 onEditarPedido={onEditarPedido}
                 onMarcarEnPreparacion={onMarcarEnPreparacion}
+                onVolverAPendiente={onVolverAPendiente}
                 onAsignarTransportista={onAsignarTransportista}
                 onMarcarEntregado={onMarcarEntregado}
                 onDesmarcarEntregado={onDesmarcarEntregado}

--- a/src/hooks/supabase/useSalvedades.ts
+++ b/src/hooks/supabase/useSalvedades.ts
@@ -20,6 +20,7 @@ export function useSalvedades(): UseSalvedadesReturn {
   const [loading, setLoading] = useState<boolean>(false)
 
   // Query base para salvedades con joins
+  // Nota: evitamos el join anidado pedidos->perfiles porque genera errores de FK en Supabase
   const buildSalvedadesQuery = () => {
     return supabase
       .from('salvedades_items')
@@ -30,8 +31,8 @@ export function useSalvedades(): UseSalvedadesReturn {
           id,
           total,
           estado,
-          cliente:clientes!cliente_id(id, nombre_fantasia),
-          transportista:perfiles!transportista_id(id, nombre)
+          transportista_id,
+          cliente:clientes!cliente_id(id, nombre_fantasia)
         ),
         reportado:perfiles!reportado_por(id, nombre),
         resuelto:perfiles!resuelto_por(id, nombre)
@@ -39,13 +40,12 @@ export function useSalvedades(): UseSalvedadesReturn {
   }
 
   // Transformar datos para compatibilidad con tipos extendidos
-   
   const transformarSalvedad = (s: any): SalvedadItemDBExtended => ({
     ...s,
     producto_nombre: s.producto?.nombre,
     producto_codigo: s.producto?.codigo,
     cliente_nombre: s.pedido?.cliente?.nombre_fantasia,
-    transportista_nombre: s.pedido?.transportista?.nombre,
+    transportista_id: s.pedido?.transportista_id,
     pedido_estado: s.pedido?.estado,
     pedido_total: s.pedido?.total,
     reportado_por_nombre: s.reportado?.nombre,

--- a/src/hooks/useAppHandlers.ts
+++ b/src/hooks/useAppHandlers.ts
@@ -276,6 +276,7 @@ export interface UseAppHandlersReturn {
   handleMarcarEntregado: (pedido: PedidoDB) => void;
   handleDesmarcarEntregado: (pedido: PedidoDB) => void;
   handleMarcarEnPreparacion: (pedido: PedidoDB) => void;
+  handleVolverAPendiente: (pedido: PedidoDB) => void;
   handleAsignarTransportista: (transportistaId: string | null, marcarListo?: boolean) => Promise<void>;
   handleEliminarPedido: (id: string) => void;
   handleVerHistorial: (pedido: PedidoDB) => Promise<void>;


### PR DESCRIPTION
Cambios en hooks de Supabase:
- useSalvedades: Quitar join anidado con perfiles que causaba error 400
- useRendiciones: Separar queries de perfiles para evitar errores de FK

Nueva funcionalidad:
- Agregar handler handleVolverAPendiente para que admin pueda revertir pedidos en preparación o asignados a estado pendiente
- Actualizar componentes PedidoCard, PedidoActions, VirtualizedPedidoList y VistaPedidos para incluir la nueva opción