### PR TITLE
fix: Calcular estadísticas localmente sin usar RPCs

### DIFF
--- a/src/components/vistas/VistaRendiciones.tsx
+++ b/src/components/vistas/VistaRendiciones.tsx
@@ -241,9 +241,16 @@ export default function VistaRendiciones(): React.ReactElement {
 
   const cargarDatos = useCallback(async () => {
     await fetchRendicionesPorFecha(fechaFiltro)
-    const stats = await getEstadisticas(fechaFiltro, fechaFiltro)
-    setEstadisticas(stats)
-  }, [fechaFiltro, fetchRendicionesPorFecha, getEstadisticas])
+  }, [fechaFiltro, fetchRendicionesPorFecha])
+
+  // Calcular estadísticas cuando cambian los datos
+  useEffect(() => {
+    const calcular = async () => {
+      const stats = await getEstadisticas()
+      setEstadisticas(stats)
+    }
+    calcular()
+  }, [rendiciones, getEstadisticas])
 
   useEffect(() => {
     cargarDatos()

--- a/src/components/vistas/VistaSalvedades.tsx
+++ b/src/components/vistas/VistaSalvedades.tsx
@@ -221,9 +221,16 @@ export default function VistaSalvedades(): React.ReactElement {
     } else {
       await fetchSalvedadesPorFecha(fechaDesde, fechaHasta)
     }
-    const stats = await getEstadisticas(fechaDesde, fechaHasta)
-    setEstadisticas(stats)
-  }, [filtroEstado, fechaDesde, fechaHasta, fetchSalvedadesPendientes, fetchSalvedadesPorFecha, getEstadisticas])
+  }, [filtroEstado, fechaDesde, fechaHasta, fetchSalvedadesPendientes, fetchSalvedadesPorFecha])
+
+  // Calcular estadísticas cuando cambian los datos
+  useEffect(() => {
+    const calcular = async () => {
+      const stats = await getEstadisticas()
+      setEstadisticas(stats)
+    }
+    calcular()
+  }, [salvedades, getEstadisticas])
 
   useEffect(() => {
     cargarDatos()


### PR DESCRIPTION
Los RPCs de estadísticas no existen en Supabase, causando errores repetidos en consola. Ahora las estadísticas se calculan directamente desde los datos ya cargados en memoria.

- useSalvedades: getEstadisticas usa datos locales
- useRendiciones: getEstadisticas usa datos locales
- VistaSalvedades: Usa useEffect separado para estadísticas
- VistaRendiciones: Usa useEffect separado para estadísticas