### PR TITLE
Display delivery exceptions (salvedades) in order cards

### DIFF
--- a/src/components/modals/ModalEntregaConSalvedad.tsx
+++ b/src/components/modals/ModalEntregaConSalvedad.tsx
@@ -20,7 +20,7 @@ const MOTIVOS_SALVEDAD: MotivoOption[] = [
   { value: 'error_pedido', label: MOTIVOS_SALVEDAD_LABELS.error_pedido, devuelveStock: true },
   { value: 'producto_vencido', label: MOTIVOS_SALVEDAD_LABELS.producto_vencido, devuelveStock: false },
   { value: 'diferencia_precio', label: MOTIVOS_SALVEDAD_LABELS.diferencia_precio, devuelveStock: true },
-  { value: 'otro', label: MOTIVOS_SALVEDAD_LABELS.otro, devuelveStock: true }
+  { value: 'otro', label: MOTIVOS_SALVEDAD_LABELS.otro, devuelveStock: false }
 ]
 
 interface ItemSalvedad {

--- a/src/hooks/supabase/usePedidos.ts
+++ b/src/hooks/supabase/usePedidos.ts
@@ -134,7 +134,7 @@ export function usePedidos(): UsePedidosHookReturn {
     try {
       const { data, error } = await supabase
         .from('pedidos')
-        .select(`*, cliente:clientes(*), items:pedido_items(*, producto:productos(*))`)
+        .select(`*, cliente:clientes(*), items:pedido_items(*, producto:productos(*)), salvedades:salvedades_items(id, motivo, cantidad_afectada, monto_afectado, estado_resolucion, producto_id)`)
         .order('created_at', { ascending: false })
 
       if (error) {

--- a/src/hooks/supabase/useSalvedades.ts
+++ b/src/hooks/supabase/useSalvedades.ts
@@ -134,7 +134,7 @@ export function useSalvedades(): UseSalvedadesReturn {
   // Registrar salvedad
   const registrarSalvedad = async (input: RegistrarSalvedadInput): Promise<RegistrarSalvedadResult> => {
     try {
-      const { data, error } = await supabase.rpc('registrar_salvedad_debug', {
+      const { data, error } = await supabase.rpc('registrar_salvedad', {
         p_pedido_id: parseInt(input.pedidoId, 10),
         p_pedido_item_id: parseInt(input.pedidoItemId, 10),
         p_cantidad_afectada: input.cantidadAfectada,

--- a/src/types/hooks.ts
+++ b/src/types/hooks.ts
@@ -68,6 +68,15 @@ export interface PerfilDB {
   activo?: boolean;
 }
 
+export interface PedidoSalvedadResumen {
+  id: string;
+  motivo: string;
+  cantidad_afectada: number;
+  monto_afectado: number;
+  estado_resolucion: string;
+  producto_id: string;
+}
+
 export interface PedidoDB {
   id: string;
   cliente_id: string;
@@ -84,6 +93,7 @@ export interface PedidoDB {
   notas?: string | null;
   orden_entrega?: number | null;
   items?: PedidoItemDB[];
+  salvedades?: PedidoSalvedadResumen[];
   stock_descontado?: boolean;
   fecha_entrega?: string | null;
   created_at?: string;


### PR DESCRIPTION
## Summary
This PR adds comprehensive support for displaying delivery exceptions (salvedades) directly in the order card UI, improving visibility of issues that occurred during delivery.

## Key Changes

- **Modal Configuration**: Changed the 'otro' (other) salvedad reason to not return stock (`devuelveStock: false`)

- **Order Card UI Enhancements**:
  - Added `AlertTriangle` icon import for visual indication of exceptions
  - Modified `EstadoStepper` component to display "Con Salvedad" (With Exception) status with warning icon when exceptions exist
  - Applied amber/warning color scheme to the final step when exceptions are present
  - Added new "Salvedades" section in expanded order details showing:
    - List of affected products with exception reasons
    - Quantity and amount affected per item
    - Resolution status (pending/resolved) with color-coded badges
    - Total amount affected across all exceptions

- **Data Fetching**: Updated `usePedidos` hook to include salvedades data in the order query with relevant fields (id, motivo, cantidad_afectada, monto_afectado, estado_resolucion, producto_id)

- **Type Definitions**: Added `PedidoSalvedadResumen` interface to properly type exception data and extended `PedidoDB` to include optional salvedades array

- **API Call Fix**: Changed `registrar_salvedad_debug` RPC call to `registrar_salvedad` in `useSalvedades` hook (removed debug suffix)

## Implementation Details

- Salvedades section only displays when exceptions exist (`tieneSalvedad` flag)
- Uses MOTIVOS_SALVEDAD_LABELS for consistent exception reason labeling
- Displays formatted currency amounts for affected values
- Maintains dark mode compatibility with appropriate color schemes
- Integrates seamlessly with existing order card layout and styling

https://claude.ai/code/session_01FzXQZJz1PSQ2y3zmgFdeuz