### PR TITLE
fix: Revertir join de salvedades que rompía carga de pedidos

### DIFF
--- a/src/hooks/supabase/usePedidos.ts
+++ b/src/hooks/supabase/usePedidos.ts
@@ -134,7 +134,7 @@ export function usePedidos(): UsePedidosHookReturn {
     try {
       const { data, error } = await supabase
         .from('pedidos')
-        .select(`*, cliente:clientes(*), items:pedido_items(*, producto:productos(*)), salvedades:salvedades_items(id, motivo, cantidad_afectada, monto_afectado, estado_resolucion, producto_id)`)
+        .select(`*, cliente:clientes(*), items:pedido_items(*, producto:productos(*))`)
         .order('created_at', { ascending: false })
 
       if (error) {


### PR DESCRIPTION
El join con salvedades_items fallaba porque la relación FK no está configurada correctamente en Supabase.

https://claude.ai/code/session_01FzXQZJz1PSQ2y3zmgFdeuz