### PR TITLE
refactor: Replace console.log/warn/error with logger utility

### DIFF
--- a/src/components/PWAPrompt.tsx
+++ b/src/components/PWAPrompt.tsx
@@ -10,6 +10,7 @@ import { useState, useEffect, MouseEvent, ReactElement } from 'react'
 import { Download, RefreshCw, X, Smartphone } from 'lucide-react'
 // @ts-expect-error - virtual:pwa-register/react is provided by vite-plugin-pwa
 import { useRegisterSW } from 'virtual:pwa-register/react'
+import { logger } from '../utils/logger'
 
 // =============================================================================
 // TYPES
@@ -61,7 +62,7 @@ export function PWAPrompt(_props: PWAPromptProps): ReactElement | null {
       }
     },
     onRegisterError(error: Error) {
-      console.error('SW registration error:', error)
+      logger.error('SW registration error:', error)
     }
   })
 

--- a/src/components/modals/ModalFichaCliente.tsx
+++ b/src/components/modals/ModalFichaCliente.tsx
@@ -3,6 +3,7 @@ import type { LucideIcon } from 'lucide-react'
 import { X, User, MapPin, Phone, CreditCard, ShoppingBag, TrendingUp, Calendar, DollarSign, Clock, Package, ChevronDown, ChevronUp, FileText, Plus, AlertTriangle, CheckCircle, Tag, UserCheck, Building2 } from 'lucide-react'
 import { useFichaCliente, usePagos } from '../../hooks/supabase'
 import { formatPrecio as formatCurrency, formatFecha as formatDate, getEstadoColor, getEstadoPagoColor } from '../../utils/formatters'
+import { logger } from '../../utils/logger'
 import type { ClienteDB, PedidoDB, PagoDBWithUsuario, ResumenCuenta, EstadisticasCliente, PedidoClienteWithItems } from '../../types'
 
 // =============================================================================
@@ -52,7 +53,7 @@ export default function ModalFichaCliente({ cliente, onClose, onRegistrarPago, o
       obtenerResumenCuenta(cliente.id)
         .then((res: ResumenCuenta | null) => setResumenCuenta(res))
         .catch((err: Error) => {
-          console.error('Error al obtener resumen de cuenta:', err.message)
+          logger.error('Error al obtener resumen de cuenta:', err.message)
           setResumenCuenta(null)
         })
     }

--- a/src/components/modals/ModalImportarPrecios.tsx
+++ b/src/components/modals/ModalImportarPrecios.tsx
@@ -3,6 +3,7 @@ import type { ChangeEvent, DragEvent } from 'react';
 import { X, Upload, FileSpreadsheet, AlertCircle, CheckCircle, Download, RefreshCw } from 'lucide-react';
 import { readExcelFile, createTemplate } from '../../utils/excel';
 import { validateExcelFile, validateAndSanitizeExcelData, FILE_LIMITS } from '../../utils/fileValidation';
+import { logger } from '../../utils/logger';
 import type { ProductoDB } from '../../types';
 
 // =============================================================================
@@ -223,7 +224,7 @@ export default function ModalImportarPrecios({ productos, onActualizarPrecios, o
       // Capturar mejor el error
       const error = err as Error;
       const errorMsg = error?.message || error?.toString?.() || 'Error desconocido al actualizar precios';
-      console.error('Error en importacion de precios:', err);
+      logger.error('Error en importacion de precios:', err);
       setResultado({ success: false, error: errorMsg });
     } finally {
       setProcesando(false);

--- a/src/hooks/supabase/usePedidos.ts
+++ b/src/hooks/supabase/usePedidos.ts
@@ -14,6 +14,7 @@
 
 import { useState, useEffect, type Dispatch, type SetStateAction } from 'react'
 import { supabase, notifyError } from './base'
+import { logger } from '../../utils/logger'
 import type {
   PedidoDB,
   PedidoItemDB,
@@ -371,7 +372,7 @@ export function usePedidos(): UsePedidosHookReturn {
     })
 
     if (error) {
-      console.error('[RPC Error] eliminar_pedido_completo:', {
+      logger.error('[RPC Error] eliminar_pedido_completo:', {
         code: error.code,
         message: error.message,
         details: error.details,

--- a/src/hooks/supabase/useProductos.ts
+++ b/src/hooks/supabase/useProductos.ts
@@ -14,6 +14,7 @@
 
 import { useState, useEffect } from 'react'
 import { supabase, notifyError } from './base'
+import { logger } from '../../utils/logger'
 import type { ProductoDB, ProductoFormInput, UseProductosReturn } from '../../types'
 
 interface StockItem {
@@ -203,7 +204,7 @@ export function useProductos(): UseProductosReturn {
 
     // Si la funcion RPC no existe o falla, usar fallback con updates individuales
     if (error) {
-      console.warn('RPC actualizar_precios_masivo fallo, usando fallback:', error.message)
+      logger.warn('RPC actualizar_precios_masivo fallo, usando fallback:', error.message)
 
       let actualizados = 0
       const errores: string[] = []

--- a/src/hooks/useAsync.ts
+++ b/src/hooks/useAsync.ts
@@ -3,6 +3,7 @@
  * @module hooks/useAsync
  */
 import { useState, useCallback, useRef, useEffect, type RefObject, type Dispatch, type SetStateAction } from 'react'
+import { logger } from '../utils/logger'
 
 /**
  * Estado de una operación async
@@ -266,7 +267,7 @@ export function useLocalStorage<T>(key: string, initialValue: T): UseLocalStorag
       const item = window.localStorage.getItem(key)
       return item ? (JSON.parse(item) as T) : initialValue
     } catch (error) {
-      console.warn(`Error reading localStorage key "${key}":`, error)
+      logger.warn(`Error reading localStorage key "${key}":`, error)
       return initialValue
     }
   })
@@ -277,7 +278,7 @@ export function useLocalStorage<T>(key: string, initialValue: T): UseLocalStorag
       setStoredValue(valueToStore)
       window.localStorage.setItem(key, JSON.stringify(valueToStore))
     } catch (error) {
-      console.warn(`Error setting localStorage key "${key}":`, error)
+      logger.warn(`Error setting localStorage key "${key}":`, error)
     }
   }, [key, storedValue])
 

--- a/src/hooks/useGenericHandlers.ts
+++ b/src/hooks/useGenericHandlers.ts
@@ -7,6 +7,7 @@
  */
 import { useCallback } from 'react';
 import { withLoadingState, showDeleteConfirmation } from '../utils/errorHandling';
+import { logger } from '../utils/logger';
 import type { NotifyService, ModalControl, ConfirmModal } from './handlers/types';
 
 // ============================================
@@ -131,7 +132,7 @@ export function useGenericHandlers<T extends { id?: string }, TInput = Partial<T
    */
   const handleDelete = useCallback((id: string, itemName?: string): void => {
     if (!confirmModal) {
-      console.warn('No se proporcionó modal de confirmación');
+      logger.warn('No se proporcionó modal de confirmación');
       return;
     }
 

--- a/src/hooks/useGoogleMaps.ts
+++ b/src/hooks/useGoogleMaps.ts
@@ -8,6 +8,7 @@
  */
 
 import { useState, useCallback, useEffect } from 'react'
+import { logger } from '../utils/logger'
 
 /**
  * ID del script de Google Maps en el DOM
@@ -66,7 +67,7 @@ export function loadGoogleMapsAPI(): Promise<void> {
     const apiKey = import.meta.env.VITE_GOOGLE_API_KEY
 
     if (!apiKey) {
-      console.warn('[Google Maps] VITE_GOOGLE_API_KEY no configurada. El autocompletado de direcciones no estará disponible.')
+      logger.warn('[Google Maps] VITE_GOOGLE_API_KEY no configurada. El autocompletado de direcciones no estará disponible.')
       reject(new Error('Google Maps API key not configured'))
       return
     }

--- a/src/hooks/useOfflineSync.ts
+++ b/src/hooks/useOfflineSync.ts
@@ -5,6 +5,7 @@ import {
   removeSecureItem,
   migrateToSecure
 } from '../utils/secureStorage'
+import { logger } from '../utils/logger'
 import type { MermaFormInput, ProductoDB } from '../types'
 
 // ============================================================================
@@ -246,7 +247,7 @@ export function useOfflineSync(): UseOfflineSyncReturn {
       const updated = [...prev, nuevoPedido]
       // Guardar async sin bloquear - con manejo de errores
       setSecureItem(OFFLINE_PEDIDOS_KEY, updated).catch((err) => {
-        console.error('Error crítico: No se pudo guardar pedido offline:', err)
+        logger.error('Error crítico: No se pudo guardar pedido offline:', err)
         // Intentar notificar al usuario via evento custom
         window.dispatchEvent(new CustomEvent('offline-storage-error', {
           detail: { type: 'pedido', error: err.message }
@@ -275,7 +276,7 @@ export function useOfflineSync(): UseOfflineSyncReturn {
       const updated = [...prev, nuevaMerma]
       // Guardar async sin bloquear - con manejo de errores
       setSecureItem(OFFLINE_MERMAS_KEY, updated).catch((err) => {
-        console.error('Error crítico: No se pudo guardar merma offline:', err)
+        logger.error('Error crítico: No se pudo guardar merma offline:', err)
         window.dispatchEvent(new CustomEvent('offline-storage-error', {
           detail: { type: 'merma', error: err.message }
         }))
@@ -295,7 +296,7 @@ export function useOfflineSync(): UseOfflineSyncReturn {
       const updated = prev.filter(p => p.offlineId !== offlineId)
       // Guardar async sin bloquear - con manejo de errores
       setSecureItem(OFFLINE_PEDIDOS_KEY, updated).catch((err) => {
-        console.error('Error al actualizar pedidos offline:', err)
+        logger.error('Error al actualizar pedidos offline:', err)
       })
       return updated
     })
@@ -310,7 +311,7 @@ export function useOfflineSync(): UseOfflineSyncReturn {
       const updated = prev.filter(m => m.offlineId !== offlineId)
       // Guardar async sin bloquear - con manejo de errores
       setSecureItem(OFFLINE_MERMAS_KEY, updated).catch((err) => {
-        console.error('Error al actualizar mermas offline:', err)
+        logger.error('Error al actualizar mermas offline:', err)
       })
       return updated
     })

--- a/src/services/api/baseService.ts
+++ b/src/services/api/baseService.ts
@@ -10,6 +10,7 @@
  */
 
 import { supabase, notifyError } from '../../hooks/supabase/base'
+import { logger } from '../../utils/logger'
 import type { SupabaseClient } from '@supabase/supabase-js'
 
 // Type for filter builder - using generic type to avoid importing non-exported types
@@ -532,8 +533,8 @@ export class BaseService<T = Record<string, unknown>> {
       const { data, error } = await this.db.rpc(functionName, params)
 
       if (error) {
-        // Log detallado para debugging
-        console.error(`[RPC Error] ${functionName}:`, {
+        // Log detallado para debugging (solo en desarrollo)
+        logger.error(`[RPC Error] ${functionName}:`, {
           code: error.code,
           message: error.message,
           details: error.details,
@@ -603,7 +604,7 @@ export class BaseService<T = Record<string, unknown>> {
    */
   protected handleError(operation: string, error: Error): void {
     const message = `Error al ${operation} en ${this.table}: ${error.message}`
-    console.error(message, error)
+    logger.error(message, error)
     notifyError(message)
   }
 }

--- a/src/services/api/pedidoService.ts
+++ b/src/services/api/pedidoService.ts
@@ -9,6 +9,7 @@
  */
 
 import { BaseService } from './baseService'
+import { logger } from '../../utils/logger'
 import type { Pedido, PedidoItem, EstadoPedido } from '../../types'
 
 export interface PedidoFiltros {
@@ -263,7 +264,7 @@ class PedidoService extends BaseService<Pedido> {
       })
     } catch (error) {
       // No fallar si el historial falla
-      console.warn('Error registrando historial:', error)
+      logger.warn('Error registrando historial:', error)
     }
   }
 

--- a/src/services/business/stockManager.ts
+++ b/src/services/business/stockManager.ts
@@ -10,6 +10,7 @@
 
 import { productoService } from '../api/productoService'
 import { supabase } from '../../hooks/supabase/base'
+import { logger } from '../../utils/logger'
 import type { Producto } from '../../types'
 
 export interface StockItem {
@@ -278,7 +279,7 @@ class StockManager {
 
       return data as Merma
     } catch (error) {
-      console.error('Error registrando merma:', error)
+      logger.error('Error registrando merma:', error)
       throw error
     }
   }
@@ -310,7 +311,7 @@ class StockManager {
     const { data, error } = await query
 
     if (error) {
-      console.error('Error obteniendo mermas:', error)
+      logger.error('Error obteniendo mermas:', error)
       return []
     }
 

--- a/src/utils/backgroundSync.ts
+++ b/src/utils/backgroundSync.ts
@@ -5,6 +5,8 @@
  * con fallback a sincronización manual cuando vuelve la conexión.
  */
 
+import { logger } from './logger'
+
 const SYNC_TAG_PEDIDOS = 'sync-pedidos'
 const SYNC_TAG_MERMAS = 'sync-mermas'
 
@@ -33,17 +35,17 @@ export function isBackgroundSyncSupported(): boolean {
  */
 export async function registerPedidosSync(): Promise<boolean> {
   if (!isBackgroundSyncSupported()) {
-    console.log('Background Sync no soportado, usando fallback')
+    logger.info('Background Sync no soportado, usando fallback')
     return false
   }
 
   try {
     const registration = await navigator.serviceWorker.ready as ServiceWorkerRegistrationWithSync
     await registration.sync.register(SYNC_TAG_PEDIDOS)
-    console.log('Background sync registrado para pedidos')
+    logger.info('Background sync registrado para pedidos')
     return true
   } catch (error) {
-    console.error('Error registrando background sync:', error)
+    logger.error('Error registrando background sync:', error)
     return false
   }
 }
@@ -59,10 +61,10 @@ export async function registerMermasSync(): Promise<boolean> {
   try {
     const registration = await navigator.serviceWorker.ready as ServiceWorkerRegistrationWithSync
     await registration.sync.register(SYNC_TAG_MERMAS)
-    console.log('Background sync registrado para mermas')
+    logger.info('Background sync registrado para mermas')
     return true
   } catch (error) {
-    console.error('Error registrando background sync:', error)
+    logger.error('Error registrando background sync:', error)
     return false
   }
 }
@@ -85,11 +87,11 @@ export async function registerPeriodicSync(tag = 'periodic-sync', minInterval = 
       await registration.periodicSync.register(tag, {
         minInterval
       })
-      console.log('Periodic sync registrado:', tag)
+      logger.info('Periodic sync registrado:', tag)
       return true
     }
   } catch (error) {
-    console.error('Error registrando periodic sync:', error)
+    logger.error('Error registrando periodic sync:', error)
   }
   return false
 }

--- a/src/utils/errorHandling.ts
+++ b/src/utils/errorHandling.ts
@@ -8,6 +8,7 @@
  */
 
 import type { NotifyService } from '../hooks/handlers/types';
+import { logger } from './logger';
 
 // ============================================
 // TIPOS
@@ -89,7 +90,7 @@ export function handleError(
     : normalizedError.message;
 
   if (log) {
-    console.error('[Error]', message, normalizedError);
+    logger.error('[Error]', message, normalizedError);
   }
 
   if (notify && notifyService) {

--- a/src/utils/fileValidation.ts
+++ b/src/utils/fileValidation.ts
@@ -7,6 +7,8 @@
  * - Validación de estructura básica
  */
 
+import { logger } from './logger'
+
 // Configuración de límites
 export const FILE_LIMITS = {
   maxSizeBytes: 10 * 1024 * 1024, // 10MB máximo
@@ -73,7 +75,7 @@ export function validateExcelFile(file: File | null | undefined): ValidationResu
 
   // Validar tipo MIME (algunos navegadores pueden no reportarlo correctamente)
   if (file.type && !(EXCEL_CONFIG.allowedMimeTypes as readonly string[]).includes(file.type)) {
-    console.warn(`[FileValidation] MIME type inesperado: ${file.type}, pero extensión válida`)
+    logger.warn(`[FileValidation] MIME type inesperado: ${file.type}, pero extensión válida`)
     // No rechazar por MIME ya que algunos navegadores reportan incorrectamente
   }
 

--- a/src/utils/imageOptimization.ts
+++ b/src/utils/imageOptimization.ts
@@ -6,6 +6,7 @@
  */
 
 import type React from 'react'
+import { logger } from './logger'
 
 /**
  * Cache del resultado de soporte WebP
@@ -237,7 +238,7 @@ export function getOptimizedBackgroundStyle(src: string, options: BackgroundStyl
  */
 export async function initImageOptimization(): Promise<void> {
   await supportsWebP()
-  console.log(`[ImageOptimization] WebP support: ${webpSupportCache}`)
+  logger.info(`[ImageOptimization] WebP support: ${webpSupportCache}`)
 }
 
 export default {

--- a/src/utils/secureStorage.ts
+++ b/src/utils/secureStorage.ts
@@ -5,6 +5,8 @@
  * Mantiene compatibilidad con datos legacy (XOR) para migración automática.
  */
 
+import { logger } from './logger'
+
 const STORAGE_PREFIX = 'distribuidora_secure_'
 const KEY_STORAGE_NAME = 'distribuidora_crypto_key'
 
@@ -51,7 +53,7 @@ async function getCryptoKey(): Promise<CryptoKey | null> {
 
     return key
   } catch (e) {
-    console.warn('Error inicializando crypto key:', e)
+    logger.warn('Error inicializando crypto key:', e)
     return null
   }
 }
@@ -88,7 +90,7 @@ async function encryptAES(plaintext: string): Promise<string | null> {
 
     return btoa(String.fromCharCode(...combined))
   } catch (e) {
-    console.warn('Error cifrando:', e)
+    logger.warn('Error cifrando:', e)
     return null
   }
 }


### PR DESCRIPTION
Replace direct console usage with the centralized logger utility across 17 files to ensure proper logging in production (silent) vs development (verbose) environments.

Files updated:
- Components: PWAPrompt, ModalFichaCliente, ModalImportarPrecios
- Hooks: usePedidos, useProductos, useAsync, useGenericHandlers, useGoogleMaps, useOfflineSync
- Services: baseService, pedidoService, stockManager
- Utils: backgroundSync, errorHandling, fileValidation, imageOptimization, secureStorage

The logger utility already integrates with Sentry for error tracking in production and only outputs to console in development.

https://claude.ai/code/session_019Bo1jakGEt3UJdHEMmtBRv