### PR TITLE
fix: Update tests for IndexedDB-based useOfflineSync and fix race con…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -52,6 +52,7 @@
         "eslint": "^9.39.1",
         "eslint-plugin-react-hooks": "^7.0.1",
         "eslint-plugin-react-refresh": "^0.4.24",
+        "fake-indexeddb": "^6.2.5",
         "globals": "^16.5.0",
         "husky": "^9.1.7",
         "jsdom": "^27.4.0",
@@ -6528,6 +6529,16 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fake-indexeddb": {
+      "version": "6.2.5",
+      "resolved": "https://registry.npmjs.org/fake-indexeddb/-/fake-indexeddb-6.2.5.tgz",
+      "integrity": "sha512-CGnyrvbhPlWYMngksqrSSUT1BAVP49dZocrHuK0SvtR0D5TMs5wP0o3j7jexDJW01KSadjBp1M/71o/KR3nD1w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/fast-csv": {

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "eslint": "^9.39.1",
     "eslint-plugin-react-hooks": "^7.0.1",
     "eslint-plugin-react-refresh": "^0.4.24",
+    "fake-indexeddb": "^6.2.5",
     "globals": "^16.5.0",
     "husky": "^9.1.7",
     "jsdom": "^27.4.0",

--- a/src/hooks/useOfflineSync.ts
+++ b/src/hooks/useOfflineSync.ts
@@ -402,21 +402,23 @@ export function useOfflineSync(): UseOfflineSyncReturn {
       return { success: false, sincronizados: 0, errores: [{ error: 'Sin conexión' }] }
     }
 
-    // Obtener operaciones pendientes desde IndexedDB
-    const operations = await getPendingOperations(100)
-    const pedidoOps = operations.filter(op => op.type === 'CREATE_PEDIDO')
-
-    if (pedidoOps.length === 0) {
-      return { success: true, sincronizados: 0, errores: [] }
-    }
-
-    // RACE CONDITION FIX: Verificar si ya está sincronizando usando ref
+    // RACE CONDITION FIX: Verificar si ya está sincronizando usando ref BEFORE any async operations
     if (sincronizandoRef.current) {
       return { success: false, sincronizados: 0, errores: [{ error: 'Sincronización ya en progreso' }] }
     }
 
     sincronizandoRef.current = true
     setSincronizando(true)
+
+    // Obtener operaciones pendientes desde IndexedDB
+    const operations = await getPendingOperations(100)
+    const pedidoOps = operations.filter(op => op.type === 'CREATE_PEDIDO')
+
+    if (pedidoOps.length === 0) {
+      sincronizandoRef.current = false
+      setSincronizando(false)
+      return { success: true, sincronizados: 0, errores: [] }
+    }
     const errores: SyncResult['errores'] = []
     let sincronizados = 0
 
@@ -464,21 +466,23 @@ export function useOfflineSync(): UseOfflineSyncReturn {
       return { success: false, sincronizados: 0, errores: [{ error: 'Sin conexión' }] }
     }
 
-    // Obtener operaciones pendientes desde IndexedDB
-    const operations = await getPendingOperations(100)
-    const mermaOps = operations.filter(op => op.type === 'CREATE_MERMA')
-
-    if (mermaOps.length === 0) {
-      return { success: true, sincronizados: 0, errores: [] }
-    }
-
-    // RACE CONDITION FIX: Verificar si ya está sincronizando usando ref
+    // RACE CONDITION FIX: Verificar si ya está sincronizando usando ref BEFORE any async operations
     if (sincronizandoRef.current) {
       return { success: false, sincronizados: 0, errores: [{ error: 'Sincronización ya en progreso' }] }
     }
 
     sincronizandoRef.current = true
     setSincronizando(true)
+
+    // Obtener operaciones pendientes desde IndexedDB
+    const operations = await getPendingOperations(100)
+    const mermaOps = operations.filter(op => op.type === 'CREATE_MERMA')
+
+    if (mermaOps.length === 0) {
+      sincronizandoRef.current = false
+      setSincronizando(false)
+      return { success: true, sincronizados: 0, errores: [] }
+    }
     const errores: SyncResult['errores'] = []
     let sincronizados = 0
 


### PR DESCRIPTION
…dition

- Add crypto.subtle.digest mock for Dexie.js compatibility in tests
- Add fake-indexeddb for IndexedDB mocking in test environment
- Update useOfflineSync.integration.test.ts to mock offlineDb instead of secureStorage
- Fix race condition in sincronizarPedidos/sincronizarMermas by checking ref before async calls
- Update test mocks to properly sequence getPendingOperations calls

https://claude.ai/code/session_019Bo1jakGEt3UJdHEMmtBRv