### PR TITLE
fix: Use costo_unitario instead of precio_unitario for compra_items

### DIFF
--- a/src/services/__tests__/analyticsExport.test.ts
+++ b/src/services/__tests__/analyticsExport.test.ts
@@ -428,13 +428,13 @@ describe('analyticsExport', () => {
           items: [
             {
               cantidad: 10,
-              precio_unitario: 200,
+              costo_unitario: 200,
               subtotal: 2000,
               producto: { nombre: 'Producto X', codigo: 'PX001', categoria: 'Cat1' },
             },
             {
               cantidad: 5,
-              precio_unitario: 300,
+              costo_unitario: 300,
               subtotal: 1500,
               producto: { nombre: 'Producto Y', codigo: 'PY002', categoria: 'Cat2' },
             },

--- a/src/services/analyticsExport.ts
+++ b/src/services/analyticsExport.ts
@@ -287,7 +287,7 @@ export async function fetchComprasFact(
       proveedor:proveedores(nombre, cuit),
       items:compra_items(
         cantidad,
-        precio_unitario,
+        costo_unitario,
         subtotal,
         producto:productos(nombre, codigo, categoria)
       )
@@ -315,7 +315,7 @@ export async function fetchComprasFact(
         producto_codigo: safe(producto?.codigo),
         producto_categoria: safe(producto?.categoria),
         cantidad: item.cantidad,
-        costo_unitario: item.precio_unitario,
+        costo_unitario: item.costo_unitario,
         subtotal: item.subtotal,
         estado: safe(compra.estado),
       })


### PR DESCRIPTION
The compra_items table uses 'costo_unitario', not 'precio_unitario'. This caused "column compra_items_1.precio_unitario does not exist" error when exporting BI data.

https://claude.ai/code/session_012Hjjy3aQSfyV39CY3bsd2o