### PR TITLE
fix: Fix Canasta de Productos showing 'Desconocido' for all products

### DIFF
--- a/src/services/__tests__/analyticsExport.test.ts
+++ b/src/services/__tests__/analyticsExport.test.ts
@@ -564,8 +564,10 @@ describe('analyticsExport', () => {
 
       expect(result).toHaveLength(2)
       expect(result[0]).toMatchObject({
+        producto_a_id: 'prod1',
         producto_a_nombre: 'Producto A',
         producto_a_codigo: 'PA001',
+        producto_b_id: 'prod2',
         producto_b_nombre: 'Producto B',
         producto_b_codigo: 'PB002',
         veces_comprados_juntos: 5,


### PR DESCRIPTION
- Fetch all productos in parallel with pedidos instead of using .in() filter after market basket calculation (avoids silent query failures)
- Add producto_a_id and producto_b_id columns for traceability
- Fallback shows raw UUID instead of 'Desconocido' for debugging

https://claude.ai/code/session_012Hjjy3aQSfyV39CY3bsd2o