### PR TITLE
feat: Add proveedor dropdown to product form

### DIFF
--- a/src/components/containers/ProductosContainer.tsx
+++ b/src/components/containers/ProductosContainer.tsx
@@ -13,6 +13,7 @@ import {
   useEliminarProductoMutation
 } from '../../hooks/queries'
 import { useMermasQuery, useRegistrarMermaMutation } from '../../hooks/queries'
+import { useProveedoresActivosQuery } from '../../hooks/queries'
 import { useAuthData } from '../../contexts/AuthDataContext'
 import { useNotification } from '../../contexts/NotificationContext'
 import type { ProductoDB, ProductoFormInput, MermaFormInputExtended } from '../../types'
@@ -39,6 +40,7 @@ export default function ProductosContainer(): React.ReactElement {
   // Queries
   const { data: productos = [], isLoading } = useProductosQuery()
   const { data: mermas = [] } = useMermasQuery()
+  const { data: proveedores = [] } = useProveedoresActivosQuery()
 
   // Mutations
   const crearProducto = useCrearProductoMutation()
@@ -151,6 +153,7 @@ export default function ProductosContainer(): React.ReactElement {
       <Suspense fallback={<LoadingState />}>
         <VistaProductos
           productos={productos}
+          proveedores={proveedores}
           loading={isLoading}
           isAdmin={isAdmin}
           onNuevoProducto={handleNuevoProducto}
@@ -168,6 +171,7 @@ export default function ProductosContainer(): React.ReactElement {
           <ModalProducto
             producto={productoEditando}
             categorias={categorias}
+            proveedores={proveedores}
             onSave={handleGuardarProducto as Parameters<typeof ModalProducto>[0]['onSave']}
             onClose={() => {
               setModalProductoOpen(false)

--- a/src/components/modals/ModalProducto.tsx
+++ b/src/components/modals/ModalProducto.tsx
@@ -5,7 +5,7 @@ import ModalBase from './ModalBase';
 import { useZodValidation } from '../../hooks/useZodValidation';
 import { modalProductoSchema } from '../../lib/schemas';
 import { calcularTotalConIva } from '../../utils/calculations';
-import type { ProductoDB } from '../../types';
+import type { ProductoDB, ProveedorDBExtended } from '../../types';
 
 // =============================================================================
 // TYPES
@@ -17,6 +17,7 @@ export interface ProductoFormData {
   nombre: string;
   codigo: string;
   categoria: string;
+  proveedor_id: string;
   stock: number | string;
   stock_minimo: number;
   porcentaje_iva: number;
@@ -48,6 +49,8 @@ export interface ModalProductoProps {
   producto: ProductoDB | null;
   /** Categorías disponibles (can be strings or objects) */
   categorias: string[] | CategoriaOption[];
+  /** Proveedores disponibles para el desplegable */
+  proveedores?: ProveedorDBExtended[];
   /** Callback al guardar */
   onSave: (data: ProductoFormData) => void | Promise<void>;
   /** Callback al cerrar */
@@ -73,7 +76,7 @@ const getCategoryKey = (cat: string | CategoriaOption): string => {
   return typeof cat === 'string' ? cat : (cat.id || cat.nombre);
 };
 
-const ModalProducto = memo(function ModalProducto({ producto, categorias, onSave, onClose, guardando }: ModalProductoProps) {
+const ModalProducto = memo(function ModalProducto({ producto, categorias, proveedores = [], onSave, onClose, guardando }: ModalProductoProps) {
   // Zod validation hook
   const { errors, validate, clearFieldError, hasAttemptedSubmit: intentoGuardar } = useZodValidation(modalProductoSchema);
   const errores = errors as ValidationErrors;
@@ -83,6 +86,7 @@ const ModalProducto = memo(function ModalProducto({ producto, categorias, onSave
     nombre: producto.nombre || '',
     codigo: producto.codigo || '',
     categoria: producto.categoria || '',
+    proveedor_id: producto.proveedor_id || '',
     stock: producto.stock ?? '',
     stock_minimo: producto.stock_minimo ?? 10,
     porcentaje_iva: 21,
@@ -95,6 +99,7 @@ const ModalProducto = memo(function ModalProducto({ producto, categorias, onSave
     nombre: '',
     codigo: '',
     categoria: '',
+    proveedor_id: '',
     stock: '',
     stock_minimo: 10,
     porcentaje_iva: 21,
@@ -254,6 +259,23 @@ const ModalProducto = memo(function ModalProducto({ producto, categorias, onSave
             </select>
           )}
         </div>
+
+        {/* Proveedor */}
+        {proveedores.length > 0 && (
+          <div>
+            <label className="block text-sm font-medium mb-1">Proveedor</label>
+            <select
+              value={form.proveedor_id || ''}
+              onChange={(e: ChangeEvent<HTMLSelectElement>) => setForm({ ...form, proveedor_id: e.target.value })}
+              className="w-full px-3 py-2 border rounded-lg"
+            >
+              <option value="">Sin proveedor</option>
+              {proveedores.map(prov => (
+                <option key={prov.id} value={prov.id}>{prov.nombre}</option>
+              ))}
+            </select>
+          </div>
+        )}
 
         {/* Seccion de IVA */}
         <div className="border-t pt-4">

--- a/src/components/vistas/VistaProductos.tsx
+++ b/src/components/vistas/VistaProductos.tsx
@@ -3,7 +3,7 @@ import type { ChangeEvent } from 'react';
 import { Package, Plus, Edit2, Trash2, Search, AlertTriangle, Minus, TrendingDown, FileSpreadsheet } from 'lucide-react';
 import { formatPrecio } from '../../utils/formatters';
 import LoadingSpinner from '../layout/LoadingSpinner';
-import type { ProductoDB } from '../../types';
+import type { ProductoDB, ProveedorDBExtended } from '../../types';
 
 // =============================================================================
 // INTERFACES DE PROPS
@@ -11,6 +11,7 @@ import type { ProductoDB } from '../../types';
 
 export interface VistaProductosProps {
   productos: ProductoDB[];
+  proveedores?: ProveedorDBExtended[];
   loading: boolean;
   isAdmin: boolean;
   onNuevoProducto: () => void;
@@ -23,6 +24,7 @@ export interface VistaProductosProps {
 
 export default function VistaProductos({
   productos,
+  proveedores = [],
   loading,
   isAdmin,
   onNuevoProducto,
@@ -61,6 +63,11 @@ export default function VistaProductos({
       return matchBusqueda && matchCategoria && matchStockBajo;
     });
   }, [productos, busqueda, filtroCategoria, mostrarSoloStockBajo]);
+
+  // Mapa de proveedores para lookup rápido
+  const proveedoresMap = useMemo(() => {
+    return new Map(proveedores.map(p => [p.id, p.nombre]))
+  }, [proveedores])
 
   const getStockColor = (producto: ProductoDB): string => {
     const stockMinimo = producto.stock_minimo || 10;
@@ -195,6 +202,7 @@ export default function VistaProductos({
                 <th scope="col" className="px-4 py-3 text-left text-sm font-medium text-gray-700 dark:text-gray-300">Código</th>
                 <th scope="col" className="px-4 py-3 text-left text-sm font-medium text-gray-700 dark:text-gray-300">Producto</th>
                 <th scope="col" className="px-4 py-3 text-left text-sm font-medium text-gray-700 dark:text-gray-300">Categoría</th>
+                <th scope="col" className="px-4 py-3 text-left text-sm font-medium text-gray-700 dark:text-gray-300">Proveedor</th>
                 <th scope="col" className="px-4 py-3 text-right text-sm font-medium text-gray-700 dark:text-gray-300">Precio</th>
                 <th scope="col" className="px-4 py-3 text-right text-sm font-medium text-gray-700 dark:text-gray-300">Stock</th>
                 {isAdmin && <th scope="col" className="px-4 py-3 text-right text-sm font-medium text-gray-700 dark:text-gray-300">Acciones</th>}
@@ -213,6 +221,9 @@ export default function VistaProductos({
                     <span className={producto.categoria ? 'px-2 py-1 bg-gray-100 dark:bg-gray-700 rounded-full text-sm text-gray-700 dark:text-gray-300' : 'text-gray-400 dark:text-gray-500'}>
                       {producto.categoria || 'Sin categoría'}
                     </span>
+                  </td>
+                  <td className="px-4 py-3 text-sm text-gray-600 dark:text-gray-400">
+                    {producto.proveedor_id ? (proveedoresMap.get(producto.proveedor_id) || '-') : '-'}
                   </td>
                   <td className="px-4 py-3 text-right font-semibold text-blue-600 dark:text-blue-400">
                     {formatPrecio(producto.precio)}

--- a/src/hooks/queries/useProductosQuery.ts
+++ b/src/hooks/queries/useProductosQuery.ts
@@ -60,6 +60,7 @@ async function createProducto(producto: ProductoFormInput): Promise<ProductoDB> 
       stock: producto.stock,
       stock_minimo: producto.stock_minimo ?? 10,
       categoria: producto.categoria || null,
+      proveedor_id: producto.proveedor_id || null,
       costo_sin_iva: producto.costo_sin_iva ? parseFloat(String(producto.costo_sin_iva)) : null,
       costo_con_iva: producto.costo_con_iva ? parseFloat(String(producto.costo_con_iva)) : null,
       impuestos_internos: producto.impuestos_internos ? parseFloat(String(producto.impuestos_internos)) : null,
@@ -80,6 +81,7 @@ async function updateProducto({ id, data: producto }: { id: string; data: Partia
   if (producto.stock !== undefined) updateData.stock = producto.stock
   if (producto.stock_minimo !== undefined) updateData.stock_minimo = producto.stock_minimo
   if (producto.categoria !== undefined) updateData.categoria = producto.categoria || null
+  if (producto.proveedor_id !== undefined) updateData.proveedor_id = producto.proveedor_id || null
   if (producto.costo_sin_iva !== undefined) updateData.costo_sin_iva = producto.costo_sin_iva ? parseFloat(String(producto.costo_sin_iva)) : null
   if (producto.costo_con_iva !== undefined) updateData.costo_con_iva = producto.costo_con_iva ? parseFloat(String(producto.costo_con_iva)) : null
   if (producto.impuestos_internos !== undefined) updateData.impuestos_internos = producto.impuestos_internos ? parseFloat(String(producto.impuestos_internos)) : null

--- a/src/types/hooks.ts
+++ b/src/types/hooks.ts
@@ -39,6 +39,7 @@ export interface ProductoDB {
   stock: number;
   stock_minimo?: number;
   categoria?: string | null;
+  proveedor_id?: string | null;
   costo_sin_iva?: number | null;
   costo_con_iva?: number | null;
   impuestos_internos?: number | null;
@@ -194,6 +195,7 @@ export interface ProductoFormInput {
   stock: number;
   stock_minimo?: number;
   categoria?: string;
+  proveedor_id?: string | null;
   costo_sin_iva?: number | string;
   costo_con_iva?: number | string;
   impuestos_internos?: number | string;


### PR DESCRIPTION
- Add proveedor_id field to ProductoDB and ProductoFormInput types
- Add proveedor select dropdown in ModalProducto (after category field)
- Fetch active proveedores in ProductosContainer via useProveedoresActivosQuery
- Show proveedor column in VistaProductos product table
- Handle proveedor_id in create/update mutations

Note: Requires adding proveedor_id column (uuid, nullable, FK to proveedores.id) to the productos table in Supabase.

https://claude.ai/code/session_012Hjjy3aQSfyV39CY3bsd2o