### PR TITLE
fix: Remove non-existent 'activo' column from clientes insert/delete

### DIFF
--- a/src/components/containers/ClientesContainer.tsx
+++ b/src/components/containers/ClientesContainer.tsx
@@ -99,7 +99,7 @@ export default function ClientesContainer(): React.ReactElement {
       horarios_atencion: data.horarios_atencion || undefined,
       rubro: data.rubro || undefined,
       notas: data.notas || undefined,
-      preventista_id: data.preventista_id || null
+      ...(data.preventista_id ? { preventista_id: data.preventista_id } : {})
     }
 
     try {

--- a/src/hooks/queries/useClientesQuery.ts
+++ b/src/hooks/queries/useClientesQuery.ts
@@ -100,8 +100,7 @@ async function createCliente(cliente: ClienteCreateInput): Promise<ClienteDB> {
       horarios_atencion: cliente.horarios_atencion || null,
       rubro: cliente.rubro || null,
       notas: cliente.notas || null,
-      preventista_id: cliente.preventista_id || null,
-      activo: true
+      ...(cliente.preventista_id ? { preventista_id: cliente.preventista_id } : {})
     }])
     .select()
     .single()
@@ -123,10 +122,9 @@ async function updateCliente({ id, data: cliente }: { id: string; data: Partial<
 }
 
 async function deleteCliente(id: string): Promise<void> {
-  // Soft delete - marcar como inactivo
   const { error } = await supabase
     .from('clientes')
-    .update({ activo: false })
+    .delete()
     .eq('id', id)
 
   if (error) throw error


### PR DESCRIPTION
- Remove `activo: true` from createCliente — column doesn't exist on clientes table
- Change deleteCliente from soft-delete (activo: false) to actual delete
- Make preventista_id conditional in insert — only include when set, so the app works before the migration is applied

https://claude.ai/code/session_012Hjjy3aQSfyV39CY3bsd2o