### PR TITLE
feat: Agregar escaneo de facturas por foto en ModalCompra via n8n

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,6 +17,9 @@ VITE_GOOGLE_API_KEY=tu-google-api-key-aqui
 # URL del webhook de n8n para optimizacion de rutas
 VITE_N8N_WEBHOOK_URL=https://tu-servidor.com/webhook/optimizar-ruta
 
+# URL del webhook de n8n para escaneo de facturas con IA (Vision API)
+VITE_N8N_FACTURA_WEBHOOK_URL=https://tu-servidor.com/webhook/escanear-factura
+
 # ===========================================
 # MONITOREO Y ERRORES
 # ===========================================


### PR DESCRIPTION
Permite sacar foto a una factura y pre-cargar automáticamente todos los campos: proveedor, número factura, fecha, items con cantidades y precios, forma de pago. Usa n8n como middleware hacia una API de visión (Gemini/GPT/Claude configurable en el workflow).

- Botón "Escanear Factura" con acceso a cámara en mobile
- Upload de imagen a Supabase Storage (bucket "facturas")
- POST a webhook n8n con URL de imagen
- Preview de resultado con % de confianza antes de aplicar
- Matching automático de proveedor por CUIT y productos por código
- Estados de escaneo en el reducer (escaneando, resultado, error)
- Variable VITE_N8N_FACTURA_WEBHOOK_URL en .env.example

Requiere: crear bucket "facturas" en Supabase y workflow en n8n.

https://claude.ai/code/session_01VDLp9ZB5FRtPESDm2mNSMC