### PR TITLE
fix: resolve CORS for n8n webhooks via nginx proxy and send google_ap…

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,11 +14,13 @@ VITE_SUPABASE_ANON_KEY=tu-anon-key-aqui
 # NOTA: Preferiblemente esta key debe estar en el backend (n8n), no en el cliente
 VITE_GOOGLE_API_KEY=tu-google-api-key-aqui
 
-# URL del webhook de n8n para optimizacion de rutas
-VITE_N8N_WEBHOOK_URL=https://tu-servidor.com/webhook/optimizar-ruta
-
-# URL del webhook de n8n para escaneo de facturas con IA (Vision API)
-VITE_N8N_FACTURA_WEBHOOK_URL=https://tu-servidor.com/webhook/escanear-factura
+# URLs de webhooks n8n (usan proxy nginx para evitar CORS)
+# En produccion con Docker, usar rutas relativas al proxy:
+VITE_N8N_WEBHOOK_URL=/api/n8n/webhook/optimizar-ruta
+VITE_N8N_FACTURA_WEBHOOK_URL=/api/n8n/webhook/escanear-factura
+# En desarrollo local sin proxy, usar la URL completa:
+# VITE_N8N_WEBHOOK_URL=https://n8n.shycia.com.ar/webhook/optimizar-ruta
+# VITE_N8N_FACTURA_WEBHOOK_URL=https://n8n.shycia.com.ar/webhook/escanear-factura
 
 # ===========================================
 # MONITOREO Y ERRORES

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -100,6 +100,7 @@ jobs:
           VITE_SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
           VITE_GOOGLE_API_KEY: ${{ secrets.VITE_GOOGLE_API_KEY }}
           VITE_N8N_WEBHOOK_URL: ${{ secrets.VITE_N8N_WEBHOOK_URL }}
+          VITE_N8N_FACTURA_WEBHOOK_URL: ${{ secrets.VITE_N8N_FACTURA_WEBHOOK_URL }}
           VITE_APP_VERSION: ${{ github.sha }}
 
       - name: Deploy to Vercel (Preview)

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,7 @@ ARG VITE_GOOGLE_API_KEY
 ARG VITE_SENTRY_DSN
 ARG VITE_APP_VERSION
 ARG VITE_N8N_WEBHOOK_URL
+ARG VITE_N8N_FACTURA_WEBHOOK_URL
 
 RUN npm run build
 
@@ -30,8 +31,8 @@ FROM nginx:1.27-alpine
 # Remove default config
 RUN rm /etc/nginx/conf.d/default.conf
 
-# Copy custom nginx config
-COPY nginx.conf /etc/nginx/conf.d/default.conf
+# Copy nginx config as template (envsubst replaces ${N8N_UPSTREAM} at startup)
+COPY nginx.conf /etc/nginx/conf.d/default.conf.template
 
 # Copy built assets
 COPY --from=builder /app/dist /usr/share/nginx/html
@@ -40,6 +41,10 @@ COPY --from=builder /app/dist /usr/share/nginx/html
 HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
   CMD wget -qO- http://localhost/ || exit 1
 
+# N8N upstream URL for reverse proxy (set at runtime, e.g. https://n8n.shycia.com.ar)
+ENV N8N_UPSTREAM=""
+
 EXPOSE 80
 
-CMD ["nginx", "-g", "daemon off;"]
+# At startup: substitute N8N_UPSTREAM in nginx template, then start nginx
+CMD ["/bin/sh", "-c", "envsubst '${N8N_UPSTREAM}' < /etc/nginx/conf.d/default.conf.template > /etc/nginx/conf.d/default.conf && nginx -g 'daemon off;'"]

--- a/nginx.conf
+++ b/nginx.conf
@@ -80,6 +80,22 @@ server {
     }
 
     # =========================================================================
+    # N8N Webhook Reverse Proxy (eliminates CORS issues)
+    # N8N_UPSTREAM is replaced at container startup via envsubst
+    # =========================================================================
+    location /api/n8n/ {
+        proxy_pass ${N8N_UPSTREAM}/;
+        proxy_ssl_server_name on;
+        proxy_set_header Host $proxy_host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_connect_timeout 30s;
+        proxy_read_timeout 120s;
+        proxy_send_timeout 30s;
+    }
+
+    # =========================================================================
     # Block dotfiles (except .well-known)
     # =========================================================================
     location ~ /\.(?!well-known) {

--- a/src/hooks/useOptimizarRuta.ts
+++ b/src/hooks/useOptimizarRuta.ts
@@ -44,6 +44,7 @@ export interface OptimizarRutaRequestBody {
   deposito_lat: number;
   deposito_lng: number;
   pedidos: PedidoParaOptimizar[];
+  google_api_key?: string;
 }
 
 export interface UseOptimizarRutaReturn {
@@ -61,8 +62,8 @@ export interface UseOptimizarRutaReturn {
 // URL del webhook de n8n para optimizar rutas (desde variables de entorno)
 const N8N_WEBHOOK_URL: string = import.meta.env.VITE_N8N_WEBHOOK_URL || '';
 
-// NOTA: La Google API Key ahora debe estar configurada en el servidor n8n
-// No se envia desde el cliente por razones de seguridad
+// Google API Key para el workflow de n8n (Routes API)
+const GOOGLE_API_KEY: string = import.meta.env.VITE_GOOGLE_API_KEY || '';
 
 // Coordenadas del depósito por defecto (se pueden configurar)
 const DEPOSITO_DEFAULT: DepositoCoords = {
@@ -176,7 +177,8 @@ export function useOptimizarRuta(): UseOptimizarRutaReturn {
       transportista_id: transportistaId,
       deposito_lat: deposito.lat,
       deposito_lng: deposito.lng,
-      pedidos: pedidosConCoordenadas
+      pedidos: pedidosConCoordenadas,
+      google_api_key: GOOGLE_API_KEY
     };
 
     try {

--- a/src/hooks/useOptimizarRutaPreventista.ts
+++ b/src/hooks/useOptimizarRutaPreventista.ts
@@ -50,6 +50,7 @@ export interface UseOptimizarRutaPreventistaReturn {
 // ============================================================================
 
 const N8N_WEBHOOK_URL: string = import.meta.env.VITE_N8N_WEBHOOK_URL || '';
+const GOOGLE_API_KEY: string = import.meta.env.VITE_GOOGLE_API_KEY || '';
 
 // ============================================================================
 // HOOK
@@ -111,7 +112,8 @@ export function useOptimizarRutaPreventista(): UseOptimizarRutaPreventistaReturn
           transportista_id: preventistaId,  // reuse field for n8n
           deposito_lat: deposito.lat,
           deposito_lng: deposito.lng,
-          pedidos: clientesConCoords          // reuse field for n8n
+          pedidos: clientesConCoords,         // reuse field for n8n
+          google_api_key: GOOGLE_API_KEY
         })
       });
 

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -5,6 +5,7 @@ interface ImportMetaEnv {
   readonly VITE_APP_VERSION: string | undefined
   readonly VITE_GOOGLE_API_KEY: string | undefined
   readonly VITE_N8N_WEBHOOK_URL: string | undefined
+  readonly VITE_N8N_FACTURA_WEBHOOK_URL: string | undefined
   readonly PROD: boolean
   readonly DEV: boolean
   readonly MODE: string


### PR DESCRIPTION
…i_key

- Add nginx reverse proxy at /api/n8n/ that forwards to N8N_UPSTREAM, eliminating cross-origin requests from the browser to n8n
- Use envsubst in Dockerfile CMD to inject N8N_UPSTREAM at container startup (e.g. N8N_UPSTREAM=https://n8n.shycia.com.ar)
- Send google_api_key in POST body for optimizar-ruta workflows (both useOptimizarRuta and useOptimizarRutaPreventista)
- Add VITE_N8N_FACTURA_WEBHOOK_URL build arg to Dockerfile and deploy.yml
- Update .env.example with proxy-relative paths for production

https://claude.ai/code/session_01VFSCLb5rWp1mYq9JjSfZxn