### PR TITLE
fix: align crear_pedido_completo RPC params with database function

### DIFF
--- a/src/hooks/queries/usePedidosQuery.ts
+++ b/src/hooks/queries/usePedidosQuery.ts
@@ -136,13 +136,12 @@ async function crearPedido(input: CrearPedidoInput): Promise<{ id: string }> {
 
   const { data, error } = await supabase.rpc('crear_pedido_completo', {
     p_cliente_id: input.clienteId,
-    p_items: itemsParaRPC,
     p_total: input.total,
     p_usuario_id: input.usuarioId,
+    p_items: itemsParaRPC,
     p_notas: input.notas || null,
     p_forma_pago: input.formaPago || 'efectivo',
-    p_estado_pago: input.estadoPago || 'pendiente',
-    p_monto_pagado: input.montoPagado || 0
+    p_estado_pago: input.estadoPago || 'pendiente'
   })
 
   if (error) throw error

--- a/src/services/__tests__/pedidoService.test.ts
+++ b/src/services/__tests__/pedidoService.test.ts
@@ -191,10 +191,12 @@ describe('PedidoService', () => {
   describe('crearPedidoCompleto', () => {
     const pedidoData = {
       cliente_id: 'client-1',
+      total: 1000,
+      usuario_id: 'user-1',
       preventista_id: 'prev-1',
       notas: 'Entregar por la tarde',
-      metodo_pago: 'efectivo',
-      descuento: 10
+      forma_pago: 'efectivo',
+      estado_pago: 'pendiente' as const
     }
 
     const items = [
@@ -210,11 +212,12 @@ describe('PedidoService', () => {
 
       expect(supabase.rpc).toHaveBeenCalledWith('crear_pedido_completo', {
         p_cliente_id: 'client-1',
-        p_preventista_id: 'prev-1',
+        p_total: 1000,
+        p_usuario_id: 'user-1',
         p_items: JSON.stringify(items),
         p_notas: 'Entregar por la tarde',
-        p_metodo_pago: 'efectivo',
-        p_descuento: 10
+        p_forma_pago: 'efectivo',
+        p_estado_pago: 'pendiente'
       })
       expect(result).toEqual(createdPedido)
     })
@@ -230,14 +233,14 @@ describe('PedidoService', () => {
     it('should use default values for optional pedidoData fields', async () => {
       mockRpcSuccess({ id: 'ped-2' })
 
-      await pedidoService.crearPedidoCompleto({ cliente_id: 'c-1' }, items)
+      await pedidoService.crearPedidoCompleto({ cliente_id: 'c-1', total: 0, usuario_id: 'u-1' }, items)
 
       expect(supabase.rpc).toHaveBeenCalledWith(
         'crear_pedido_completo',
         expect.objectContaining({
           p_notas: '',
-          p_metodo_pago: 'efectivo',
-          p_descuento: 0
+          p_forma_pago: 'efectivo',
+          p_estado_pago: 'pendiente'
         })
       )
     })

--- a/src/services/api/pedidoService.ts
+++ b/src/services/api/pedidoService.ts
@@ -25,11 +25,13 @@ export interface PedidoFiltros {
 
 export interface PedidoData {
   cliente_id: string;
+  total: number;
+  usuario_id: string;
   preventista_id?: string;
   transportista_id?: string | null;
-  metodo_pago?: string;
+  forma_pago?: string;
+  estado_pago?: string;
   notas?: string;
-  descuento?: number;
 }
 
 export interface PedidoItemInput {
@@ -147,11 +149,12 @@ class PedidoService extends BaseService<Pedido> {
   async crearPedidoCompleto(pedidoData: PedidoData, items: PedidoItemInput[], _descontarStock = true): Promise<Pedido> {
     return this.rpc<Pedido>('crear_pedido_completo', {
       p_cliente_id: pedidoData.cliente_id,
-      p_preventista_id: pedidoData.preventista_id,
+      p_total: pedidoData.total,
+      p_usuario_id: pedidoData.usuario_id,
       p_items: JSON.stringify(items),
       p_notas: pedidoData.notas || '',
-      p_metodo_pago: pedidoData.metodo_pago || 'efectivo',
-      p_descuento: pedidoData.descuento || 0
+      p_forma_pago: pedidoData.forma_pago || 'efectivo',
+      p_estado_pago: pedidoData.estado_pago || 'pendiente'
     })
   }
 


### PR DESCRIPTION
Remove p_monto_pagado from usePedidosQuery.ts RPC call — this parameter does not exist in the database function, causing "Could not find function in schema cache" error when creating pedidos.

Also fix pedidoService.ts which passed wrong parameter names (p_preventista_id, p_metodo_pago, p_descuento) instead of the correct ones (p_total, p_usuario_id, p_forma_pago, p_estado_pago).

https://claude.ai/code/session_013KARAhbS1fXWrUUZp4B35H