### PR TITLE
fix: add error handling to legacy quick client creation handler

### DIFF
--- a/src/components/modals/ModalPedido.tsx
+++ b/src/components/modals/ModalPedido.tsx
@@ -153,8 +153,8 @@ const ModalPedido = memo(function ModalPedido({
       onClienteChange(cliente.id.toString());
       setMostrarNuevoCliente(false);
       setNuevoCliente({ nombre: '', nombreFantasia: '', direccion: '', telefono: '', zona: '', latitud: null, longitud: null });
-    } catch {
-      // Error handled by parent
+    } catch (err) {
+      console.error('Error al crear cliente rápido:', err)
     }
     setGuardandoCliente(false);
   };

--- a/src/hooks/handlers/usePedidoHandlers.ts
+++ b/src/hooks/handlers/usePedidoHandlers.ts
@@ -329,9 +329,14 @@ export function usePedidoHandlers({
   }, [setNuevoPedido])
 
   const handleCrearClienteEnPedido = useCallback(async (nuevoCliente: ClienteFormInput): Promise<ClienteDB> => {
-    const cliente = await agregarCliente(nuevoCliente)
-    notify.success('Cliente creado correctamente')
-    return cliente
+    try {
+      const cliente = await agregarCliente(nuevoCliente)
+      notify.success(`Cliente "${cliente.nombre_fantasia}" creado`)
+      return cliente
+    } catch (e) {
+      notify.error((e as Error).message || 'Error al crear cliente')
+      throw e
+    }
   }, [agregarCliente, notify])
 
   // Main order creation - optimizado con refs para reducir deps de 15 a 9


### PR DESCRIPTION
- usePedidoHandlers: wrap handleCrearClienteEnPedido in try/catch with notify.error so errors are visible instead of silently swallowed
- ModalPedido: log errors in handleCrearClienteRapido catch block