### PR TITLE
fix: make crear_pedido_completo SECURITY DEFINER for preventista access

### DIFF
--- a/migrations/031_fix_crear_pedido_security_definer.sql
+++ b/migrations/031_fix_crear_pedido_security_definer.sql
@@ -1,0 +1,91 @@
+-- Fix: Make crear_pedido_completo SECURITY DEFINER so preventistas can create orders.
+-- Problem: The FOR UPDATE lock on productos requires UPDATE RLS policy,
+-- which preventistas don't have. This caused "Producto ID X no encontrado" errors.
+-- Solution: SECURITY DEFINER runs the function as the owner (postgres), bypassing RLS.
+-- Added explicit authorization check inside the function for safety.
+
+CREATE OR REPLACE FUNCTION public.crear_pedido_completo(
+  p_cliente_id integer,
+  p_total numeric,
+  p_usuario_id uuid,
+  p_items jsonb,
+  p_notas text DEFAULT NULL::text,
+  p_forma_pago text DEFAULT 'efectivo'::text,
+  p_estado_pago text DEFAULT 'pendiente'::text
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $function$
+DECLARE
+  v_pedido_id INT;
+  item JSONB;
+  v_producto_id INT;
+  v_cantidad INT;
+  v_precio_unitario DECIMAL;
+  v_stock_actual INT;
+  v_producto_nombre TEXT;
+  errores TEXT[] := '{}';
+  v_user_role TEXT;
+BEGIN
+  -- Authorization check: only admin and preventista can create orders
+  SELECT rol INTO v_user_role FROM perfiles WHERE id = p_usuario_id;
+  IF v_user_role IS NULL OR v_user_role NOT IN ('admin', 'preventista') THEN
+    RETURN jsonb_build_object('success', false, 'errores', jsonb_build_array('No tiene permisos para crear pedidos'));
+  END IF;
+
+  -- 1. Verificar stock de todos los productos (con bloqueo)
+  FOR item IN SELECT * FROM jsonb_array_elements(p_items)
+  LOOP
+    v_producto_id := (item->>'producto_id')::INT;
+    v_cantidad := (item->>'cantidad')::INT;
+
+    -- SECURITY FIX: Validar que la cantidad sea positiva
+    IF v_cantidad IS NULL OR v_cantidad <= 0 THEN
+      errores := array_append(errores, 'Cantidad inválida para producto ID ' || v_producto_id || ': debe ser mayor a 0');
+      CONTINUE;
+    END IF;
+
+    SELECT stock, nombre INTO v_stock_actual, v_producto_nombre
+    FROM productos
+    WHERE id = v_producto_id
+    FOR UPDATE;
+
+    IF v_stock_actual IS NULL THEN
+      errores := array_append(errores, 'Producto ID ' || v_producto_id || ' no encontrado');
+    ELSIF v_stock_actual < v_cantidad THEN
+      errores := array_append(errores, v_producto_nombre || ': stock insuficiente (disponible: ' || v_stock_actual || ', solicitado: ' || v_cantidad || ')');
+    END IF;
+  END LOOP;
+
+  -- Si hay errores de stock, abortar
+  IF array_length(errores, 1) > 0 THEN
+    RETURN jsonb_build_object('success', false, 'errores', to_jsonb(errores));
+  END IF;
+
+  -- 2. Crear el pedido
+  INSERT INTO pedidos (cliente_id, total, estado, usuario_id, stock_descontado, notas, forma_pago, estado_pago)
+  VALUES (p_cliente_id, p_total, 'pendiente', p_usuario_id, true, p_notas, p_forma_pago, p_estado_pago)
+  RETURNING id INTO v_pedido_id;
+
+  -- 3. Crear los items y descontar stock
+  FOR item IN SELECT * FROM jsonb_array_elements(p_items)
+  LOOP
+    v_producto_id := (item->>'producto_id')::INT;
+    v_cantidad := (item->>'cantidad')::INT;
+    v_precio_unitario := (item->>'precio_unitario')::DECIMAL;
+
+    -- Insertar item
+    INSERT INTO pedido_items (pedido_id, producto_id, cantidad, precio_unitario, subtotal)
+    VALUES (v_pedido_id, v_producto_id, v_cantidad, v_precio_unitario, v_cantidad * v_precio_unitario);
+
+    -- Descontar stock
+    UPDATE productos
+    SET stock = stock - v_cantidad
+    WHERE id = v_producto_id;
+  END LOOP;
+
+  RETURN jsonb_build_object('success', true, 'pedido_id', v_pedido_id);
+END;
+$function$;


### PR DESCRIPTION
The FOR UPDATE lock on productos requires UPDATE RLS policy, which preventistas don't have. This caused "Producto ID X no encontrado" errors when preventistas tried to create orders. Added explicit authorization check inside the function for safety.