### PR TITLE
feat: add fecha_pedido selector + fix RPC security for preventistas

### DIFF
--- a/migrations/032_fix_rpc_security_and_add_fecha_pedido.sql
+++ b/migrations/032_fix_rpc_security_and_add_fecha_pedido.sql
@@ -1,0 +1,199 @@
+-- Fix: Multiple RPC security issues + add fecha parameter to crear_pedido_completo
+--
+-- Problems fixed:
+-- 1. Legacy eliminar_pedido_completo(integer, boolean) overload was NOT SECURITY DEFINER
+-- 2. obtener_resumen_cuenta_cliente was NOT SECURITY DEFINER (incorrect data for preventistas)
+-- 3. descontar_stock_atomico was NOT SECURITY DEFINER (failed for preventistas)
+-- 4. restaurar_stock_atomico was NOT SECURITY DEFINER (failed for preventistas)
+-- 5. crear_pedido_completo old overload (7 params without p_fecha) needed cleanup
+-- 6. Added p_fecha parameter to crear_pedido_completo for user-selectable order date
+
+-- Drop legacy eliminar_pedido_completo overload (non-SECURITY DEFINER)
+DROP FUNCTION IF EXISTS public.eliminar_pedido_completo(integer, boolean);
+
+-- Drop old crear_pedido_completo overload (7 params, without p_fecha)
+DROP FUNCTION IF EXISTS public.crear_pedido_completo(integer, numeric, uuid, jsonb, text, text, text);
+
+-- Make obtener_resumen_cuenta_cliente SECURITY DEFINER
+CREATE OR REPLACE FUNCTION public.obtener_resumen_cuenta_cliente(p_cliente_id integer)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $function$
+DECLARE
+  v_total_pedidos NUMERIC;
+  v_total_pagado NUMERIC;
+  v_saldo NUMERIC;
+  v_user_role TEXT;
+BEGIN
+  -- Auth check
+  SELECT rol INTO v_user_role FROM perfiles WHERE id = auth.uid();
+  IF v_user_role IS NULL OR v_user_role NOT IN ('admin', 'preventista') THEN
+    RETURN jsonb_build_object('error', 'No autorizado');
+  END IF;
+
+  SELECT COALESCE(SUM(total), 0) INTO v_total_pedidos
+  FROM pedidos WHERE cliente_id = p_cliente_id AND estado != 'cancelado';
+
+  SELECT COALESCE(SUM(monto), 0) INTO v_total_pagado
+  FROM pagos WHERE cliente_id = p_cliente_id;
+
+  v_saldo := v_total_pedidos - v_total_pagado;
+
+  RETURN jsonb_build_object(
+    'total_pedidos', v_total_pedidos,
+    'total_pagado', v_total_pagado,
+    'saldo', v_saldo
+  );
+END;
+$function$;
+
+-- Make descontar_stock_atomico SECURITY DEFINER
+CREATE OR REPLACE FUNCTION public.descontar_stock_atomico(p_producto_id integer, p_cantidad integer)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $function$
+DECLARE
+  v_stock_actual INT;
+  v_producto_nombre TEXT;
+  v_user_role TEXT;
+BEGIN
+  -- Auth check
+  SELECT rol INTO v_user_role FROM perfiles WHERE id = auth.uid();
+  IF v_user_role IS NULL OR v_user_role NOT IN ('admin', 'preventista', 'deposito') THEN
+    RETURN jsonb_build_object('success', false, 'error', 'No autorizado');
+  END IF;
+
+  SELECT stock, nombre INTO v_stock_actual, v_producto_nombre
+  FROM productos WHERE id = p_producto_id FOR UPDATE;
+
+  IF v_stock_actual IS NULL THEN
+    RETURN jsonb_build_object('success', false, 'error', 'Producto no encontrado');
+  END IF;
+
+  IF v_stock_actual < p_cantidad THEN
+    RETURN jsonb_build_object('success', false, 'error',
+      v_producto_nombre || ': stock insuficiente (disponible: ' || v_stock_actual || ', solicitado: ' || p_cantidad || ')');
+  END IF;
+
+  UPDATE productos SET stock = stock - p_cantidad WHERE id = p_producto_id;
+
+  RETURN jsonb_build_object('success', true, 'stock_anterior', v_stock_actual, 'stock_nuevo', v_stock_actual - p_cantidad);
+END;
+$function$;
+
+-- Make restaurar_stock_atomico SECURITY DEFINER
+CREATE OR REPLACE FUNCTION public.restaurar_stock_atomico(p_producto_id integer, p_cantidad integer)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $function$
+DECLARE
+  v_stock_actual INT;
+  v_user_role TEXT;
+BEGIN
+  -- Auth check
+  SELECT rol INTO v_user_role FROM perfiles WHERE id = auth.uid();
+  IF v_user_role IS NULL OR v_user_role NOT IN ('admin', 'preventista', 'deposito') THEN
+    RETURN jsonb_build_object('success', false, 'error', 'No autorizado');
+  END IF;
+
+  SELECT stock INTO v_stock_actual FROM productos WHERE id = p_producto_id FOR UPDATE;
+
+  IF v_stock_actual IS NULL THEN
+    RETURN jsonb_build_object('success', false, 'error', 'Producto no encontrado');
+  END IF;
+
+  UPDATE productos SET stock = stock + p_cantidad WHERE id = p_producto_id;
+
+  RETURN jsonb_build_object('success', true, 'stock_anterior', v_stock_actual, 'stock_nuevo', v_stock_actual + p_cantidad);
+END;
+$function$;
+
+-- Updated crear_pedido_completo with p_fecha parameter
+CREATE OR REPLACE FUNCTION public.crear_pedido_completo(
+  p_cliente_id integer,
+  p_total numeric,
+  p_usuario_id uuid,
+  p_items jsonb,
+  p_notas text DEFAULT NULL::text,
+  p_forma_pago text DEFAULT 'efectivo'::text,
+  p_estado_pago text DEFAULT 'pendiente'::text,
+  p_fecha date DEFAULT CURRENT_DATE
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $function$
+DECLARE
+  v_pedido_id INT;
+  item JSONB;
+  v_producto_id INT;
+  v_cantidad INT;
+  v_precio_unitario DECIMAL;
+  v_stock_actual INT;
+  v_producto_nombre TEXT;
+  errores TEXT[] := '{}';
+  v_user_role TEXT;
+BEGIN
+  -- Authorization check: only admin and preventista can create orders
+  SELECT rol INTO v_user_role FROM perfiles WHERE id = p_usuario_id;
+  IF v_user_role IS NULL OR v_user_role NOT IN ('admin', 'preventista') THEN
+    RETURN jsonb_build_object('success', false, 'errores', jsonb_build_array('No tiene permisos para crear pedidos'));
+  END IF;
+
+  -- 1. Verificar stock de todos los productos (con bloqueo)
+  FOR item IN SELECT * FROM jsonb_array_elements(p_items)
+  LOOP
+    v_producto_id := (item->>'producto_id')::INT;
+    v_cantidad := (item->>'cantidad')::INT;
+
+    IF v_cantidad IS NULL OR v_cantidad <= 0 THEN
+      errores := array_append(errores, 'Cantidad inválida para producto ID ' || v_producto_id || ': debe ser mayor a 0');
+      CONTINUE;
+    END IF;
+
+    SELECT stock, nombre INTO v_stock_actual, v_producto_nombre
+    FROM productos
+    WHERE id = v_producto_id
+    FOR UPDATE;
+
+    IF v_stock_actual IS NULL THEN
+      errores := array_append(errores, 'Producto ID ' || v_producto_id || ' no encontrado');
+    ELSIF v_stock_actual < v_cantidad THEN
+      errores := array_append(errores, v_producto_nombre || ': stock insuficiente (disponible: ' || v_stock_actual || ', solicitado: ' || v_cantidad || ')');
+    END IF;
+  END LOOP;
+
+  IF array_length(errores, 1) > 0 THEN
+    RETURN jsonb_build_object('success', false, 'errores', to_jsonb(errores));
+  END IF;
+
+  -- 2. Crear el pedido with user-selected fecha
+  INSERT INTO pedidos (cliente_id, fecha, total, estado, usuario_id, stock_descontado, notas, forma_pago, estado_pago)
+  VALUES (p_cliente_id, p_fecha, p_total, 'pendiente', p_usuario_id, true, p_notas, p_forma_pago, p_estado_pago)
+  RETURNING id INTO v_pedido_id;
+
+  -- 3. Crear los items y descontar stock
+  FOR item IN SELECT * FROM jsonb_array_elements(p_items)
+  LOOP
+    v_producto_id := (item->>'producto_id')::INT;
+    v_cantidad := (item->>'cantidad')::INT;
+    v_precio_unitario := (item->>'precio_unitario')::DECIMAL;
+
+    INSERT INTO pedido_items (pedido_id, producto_id, cantidad, precio_unitario, subtotal)
+    VALUES (v_pedido_id, v_producto_id, v_cantidad, v_precio_unitario, v_cantidad * v_precio_unitario);
+
+    UPDATE productos
+    SET stock = stock - v_cantidad
+    WHERE id = v_producto_id;
+  END LOOP;
+
+  RETURN jsonb_build_object('success', true, 'pedido_id', v_pedido_id);
+END;
+$function$;

--- a/migrations/033_fix_security_audit_search_path_and_rls.sql
+++ b/migrations/033_fix_security_audit_search_path_and_rls.sql
@@ -1,0 +1,144 @@
+-- Fix: Security audit - function search_path mutable + overly permissive RLS policies
+--
+-- Problems fixed:
+-- 1. 46 functions missing SET search_path = public (search_path mutable vulnerability)
+-- 2. 9 RLS policies using USING(true) or WITH CHECK(true) for INSERT/UPDATE/DELETE
+--
+-- Note: "Leaked Password Protection" must be enabled manually in Supabase Dashboard:
+--   Auth > Providers > Email > "Prevent use of leaked passwords"
+--   (Requires Pro Plan)
+
+----------------------------------------------------------------------
+-- PART 1: Fix search_path for all functions missing it
+----------------------------------------------------------------------
+
+-- Trigger functions (no args)
+ALTER FUNCTION public.actualizar_estado_pago_pedido() SET search_path = public;
+ALTER FUNCTION public.actualizar_recorrido_entrega() SET search_path = public;
+ALTER FUNCTION public.actualizar_saldo_cliente() SET search_path = public;
+ALTER FUNCTION public.actualizar_saldo_pedido() SET search_path = public;
+ALTER FUNCTION public.audit_log_changes() SET search_path = public;
+ALTER FUNCTION public.registrar_cambio_pedido() SET search_path = public;
+ALTER FUNCTION public.registrar_cambio_stock() SET search_path = public;
+ALTER FUNCTION public.registrar_creacion_pedido() SET search_path = public;
+ALTER FUNCTION public.update_compras_updated_at() SET search_path = public;
+ALTER FUNCTION public.update_grupos_precio_updated_at() SET search_path = public;
+ALTER FUNCTION public.update_productos_updated_at() SET search_path = public;
+ALTER FUNCTION public.update_rendiciones_updated_at() SET search_path = public;
+ALTER FUNCTION public.update_salvedades_updated_at() SET search_path = public;
+ALTER FUNCTION public.handle_new_user() SET search_path = public;
+
+-- Role-checking helper functions (no args)
+ALTER FUNCTION public.es_admin() SET search_path = public;
+ALTER FUNCTION public.es_admin_rendiciones() SET search_path = public;
+ALTER FUNCTION public.es_admin_salvedades() SET search_path = public;
+ALTER FUNCTION public.es_preventista() SET search_path = public;
+ALTER FUNCTION public.es_transportista() SET search_path = public;
+ALTER FUNCTION public.es_transportista_rendiciones() SET search_path = public;
+ALTER FUNCTION public.get_mi_rol() SET search_path = public;
+ALTER FUNCTION public.get_user_role() SET search_path = public;
+ALTER FUNCTION public.is_admin() SET search_path = public;
+ALTER FUNCTION public.is_preventista() SET search_path = public;
+ALTER FUNCTION public.is_transportista() SET search_path = public;
+
+-- Business logic functions (with args)
+ALTER FUNCTION public.actualizar_orden_entrega_batch(ordenes jsonb) SET search_path = public;
+ALTER FUNCTION public.actualizar_orden_entrega_batch(ordenes orden_entrega_item[]) SET search_path = public;
+ALTER FUNCTION public.actualizar_pedido_items(p_pedido_id bigint, p_items_nuevos jsonb, p_usuario_id uuid) SET search_path = public;
+ALTER FUNCTION public.actualizar_precios_masivo(p_productos jsonb) SET search_path = public;
+ALTER FUNCTION public.anular_salvedad(p_salvedad_id bigint, p_notas text) SET search_path = public;
+ALTER FUNCTION public.crear_recorrido(p_transportista_id uuid, p_pedidos jsonb, p_distancia numeric, p_duracion integer) SET search_path = public;
+ALTER FUNCTION public.crear_rendicion_recorrido(p_recorrido_id bigint, p_transportista_id uuid) SET search_path = public;
+ALTER FUNCTION public.eliminar_pedido_completo(p_pedido_id bigint, p_restaurar_stock boolean, p_usuario_id uuid, p_motivo text) SET search_path = public;
+ALTER FUNCTION public.eliminar_proveedor(p_proveedor_id bigint) SET search_path = public;
+ALTER FUNCTION public.get_audit_history(p_tabla text, p_registro_id text, p_limit integer) SET search_path = public;
+ALTER FUNCTION public.get_suspicious_activity(p_days integer) SET search_path = public;
+ALTER FUNCTION public.limpiar_orden_entrega(p_transportista_id uuid) SET search_path = public;
+ALTER FUNCTION public.obtener_estadisticas_pedidos(p_fecha_desde timestamptz, p_fecha_hasta timestamptz, p_usuario_id uuid) SET search_path = public;
+ALTER FUNCTION public.obtener_estadisticas_rendiciones(p_fecha_desde date, p_fecha_hasta date, p_transportista_id uuid) SET search_path = public;
+ALTER FUNCTION public.obtener_resumen_compras(p_fecha_desde date, p_fecha_hasta date) SET search_path = public;
+ALTER FUNCTION public.presentar_rendicion(p_rendicion_id bigint, p_monto_rendido numeric, p_justificacion text) SET search_path = public;
+ALTER FUNCTION public.registrar_compra_completa(p_proveedor_id bigint, p_proveedor_nombre varchar, p_numero_factura varchar, p_fecha_compra date, p_subtotal numeric, p_iva numeric, p_otros_impuestos numeric, p_total numeric, p_forma_pago varchar, p_notas text, p_usuario_id uuid, p_items jsonb) SET search_path = public;
+ALTER FUNCTION public.registrar_salvedad(p_pedido_id bigint, p_pedido_item_id bigint, p_cantidad_afectada integer, p_motivo varchar, p_descripcion text, p_foto_url text, p_devolver_stock boolean) SET search_path = public;
+ALTER FUNCTION public.resolver_salvedad(p_salvedad_id bigint, p_estado_resolucion varchar, p_notas text, p_pedido_reprogramado_id bigint) SET search_path = public;
+ALTER FUNCTION public.revisar_rendicion(p_rendicion_id bigint, p_accion varchar, p_observaciones text) SET search_path = public;
+ALTER FUNCTION public.run_sql(query text) SET search_path = public;
+
+----------------------------------------------------------------------
+-- PART 2: Fix overly permissive RLS policies
+----------------------------------------------------------------------
+
+-- audit_logs: INSERT restricted to admin (trigger functions are SECURITY DEFINER, bypass RLS)
+DROP POLICY IF EXISTS "audit_logs_insert" ON public.audit_logs;
+CREATE POLICY "audit_logs_insert" ON public.audit_logs
+  FOR INSERT
+  WITH CHECK (
+    EXISTS (SELECT 1 FROM perfiles WHERE perfiles.id = auth.uid() AND perfiles.rol = 'admin')
+  );
+
+-- historial_cambios: INSERT restricted to admin (trigger functions bypass RLS)
+DROP POLICY IF EXISTS "Sistema puede insertar historial" ON public.historial_cambios;
+CREATE POLICY "Sistema puede insertar historial" ON public.historial_cambios
+  FOR INSERT
+  WITH CHECK (
+    EXISTS (SELECT 1 FROM perfiles WHERE perfiles.id = auth.uid() AND perfiles.rol = 'admin')
+  );
+
+-- salvedad_historial: INSERT restricted to admin/transportista
+DROP POLICY IF EXISTS "Insertar historial" ON public.salvedad_historial;
+CREATE POLICY "Insertar historial" ON public.salvedad_historial
+  FOR INSERT
+  WITH CHECK (
+    EXISTS (SELECT 1 FROM perfiles WHERE perfiles.id = auth.uid() AND perfiles.rol IN ('admin', 'transportista'))
+  );
+
+-- stock_historico: INSERT restricted to admin/deposito (trigger functions bypass RLS)
+DROP POLICY IF EXISTS "stock_historico_insert" ON public.stock_historico;
+CREATE POLICY "stock_historico_insert" ON public.stock_historico
+  FOR INSERT TO authenticated
+  WITH CHECK (
+    EXISTS (SELECT 1 FROM perfiles WHERE perfiles.id = auth.uid() AND perfiles.rol IN ('admin', 'deposito'))
+  );
+
+-- preventista_zonas: INSERT/UPDATE/DELETE restricted to admin only
+DROP POLICY IF EXISTS "prev_zonas_insert_authenticated" ON public.preventista_zonas;
+CREATE POLICY "prev_zonas_insert_authenticated" ON public.preventista_zonas
+  FOR INSERT TO authenticated
+  WITH CHECK (
+    EXISTS (SELECT 1 FROM perfiles WHERE perfiles.id = auth.uid() AND perfiles.rol = 'admin')
+  );
+
+DROP POLICY IF EXISTS "prev_zonas_update_authenticated" ON public.preventista_zonas;
+CREATE POLICY "prev_zonas_update_authenticated" ON public.preventista_zonas
+  FOR UPDATE TO authenticated
+  USING (
+    EXISTS (SELECT 1 FROM perfiles WHERE perfiles.id = auth.uid() AND perfiles.rol = 'admin')
+  )
+  WITH CHECK (
+    EXISTS (SELECT 1 FROM perfiles WHERE perfiles.id = auth.uid() AND perfiles.rol = 'admin')
+  );
+
+DROP POLICY IF EXISTS "prev_zonas_delete_authenticated" ON public.preventista_zonas;
+CREATE POLICY "prev_zonas_delete_authenticated" ON public.preventista_zonas
+  FOR DELETE TO authenticated
+  USING (
+    EXISTS (SELECT 1 FROM perfiles WHERE perfiles.id = auth.uid() AND perfiles.rol = 'admin')
+  );
+
+-- zonas: INSERT/UPDATE restricted to admin only
+DROP POLICY IF EXISTS "zonas_insert_authenticated" ON public.zonas;
+CREATE POLICY "zonas_insert_authenticated" ON public.zonas
+  FOR INSERT TO authenticated
+  WITH CHECK (
+    EXISTS (SELECT 1 FROM perfiles WHERE perfiles.id = auth.uid() AND perfiles.rol = 'admin')
+  );
+
+DROP POLICY IF EXISTS "zonas_update_authenticated" ON public.zonas;
+CREATE POLICY "zonas_update_authenticated" ON public.zonas
+  FOR UPDATE TO authenticated
+  USING (
+    EXISTS (SELECT 1 FROM perfiles WHERE perfiles.id = auth.uid() AND perfiles.rol = 'admin')
+  )
+  WITH CHECK (
+    EXISTS (SELECT 1 FROM perfiles WHERE perfiles.id = auth.uid() AND perfiles.rol = 'admin')
+  );

--- a/src/components/containers/PedidosContainer.tsx
+++ b/src/components/containers/PedidosContainer.tsx
@@ -131,12 +131,14 @@ export default function PedidosContainer(): React.ReactElement {
     formaPago: 'efectivo',
     estadoPago: 'pendiente',
     montoPagado: 0,
+    fecha: new Date().toISOString().split('T')[0],
   })
 
   const resetNuevoPedido = useCallback(() => {
     setNuevoPedido({
       clienteId: '', items: [], notas: '',
       formaPago: 'efectivo', estadoPago: 'pendiente', montoPagado: 0,
+      fecha: new Date().toISOString().split('T')[0],
     })
   }, [])
 
@@ -276,7 +278,8 @@ export default function PedidosContainer(): React.ReactElement {
       const rows = pedidos.map(p => [
         p.id,
         (p.cliente as { nombre_fantasia?: string })?.nombre_fantasia || '',
-        p.estado, p.total, p.forma_pago, p.estado_pago, p.created_at,
+        p.estado, p.total, p.forma_pago, p.estado_pago,
+        (p as unknown as { fecha?: string }).fecha || p.created_at,
       ].join(','))
       const csv = ['ID,Cliente,Estado,Total,FormaPago,EstadoPago,Fecha', ...rows].join('\n')
       const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' })
@@ -354,6 +357,7 @@ export default function PedidosContainer(): React.ReactElement {
         formaPago: nuevoPedido.formaPago,
         estadoPago: nuevoPedido.estadoPago,
         montoPagado: nuevoPedido.montoPagado,
+        fecha: nuevoPedido.fecha,
       })
       resetNuevoPedido()
       setModalPedidoOpen(false)
@@ -543,6 +547,7 @@ export default function PedidosContainer(): React.ReactElement {
             onFormaPagoChange={(fp: string) => setNuevoPedido(prev => ({ ...prev, formaPago: fp }))}
             onEstadoPagoChange={(ep: string) => setNuevoPedido(prev => ({ ...prev, estadoPago: ep }))}
             onMontoPagadoChange={(m: number) => setNuevoPedido(prev => ({ ...prev, montoPagado: m }))}
+            onFechaChange={(fecha: string) => setNuevoPedido(prev => ({ ...prev, fecha }))}
             isOffline={!isOnline}
           />
         </Suspense>

--- a/src/components/modals/ModalPedido.tsx
+++ b/src/components/modals/ModalPedido.tsx
@@ -1,5 +1,5 @@
 import { useState, useMemo, memo } from 'react';
-import { X, Loader2, Search, MapPin, Tag } from 'lucide-react';
+import { X, Loader2, Search, MapPin, Tag, Calendar } from 'lucide-react';
 import { formatPrecio } from '../../utils/formatters';
 import { AddressAutocomplete } from '../AddressAutocomplete';
 import { usePrecioMayorista } from '../../hooks/usePrecioMayorista';
@@ -20,6 +20,7 @@ export interface NuevoPedidoState {
   formaPago?: string;
   estadoPago?: string;
   montoPagado?: number;
+  fecha?: string;
 }
 
 /** Datos del cliente a crear */
@@ -80,6 +81,8 @@ export interface ModalPedidoProps {
   onEstadoPagoChange?: (estadoPago: string) => void;
   /** Callback al cambiar monto pagado */
   onMontoPagadoChange?: (monto: number) => void;
+  /** Callback al cambiar fecha del pedido */
+  onFechaChange?: (fecha: string) => void;
   /** Si está offline */
   isOffline?: boolean;
 }
@@ -102,7 +105,8 @@ const ModalPedido = memo(function ModalPedido({
   onNotasChange,
   onFormaPagoChange,
   onEstadoPagoChange,
-  onMontoPagadoChange
+  onMontoPagadoChange,
+  onFechaChange
 }: ModalPedidoProps) {
   const [busquedaProducto, setBusquedaProducto] = useState<string>('');
   const [busquedaCliente, setBusquedaCliente] = useState<string>('');
@@ -241,6 +245,24 @@ const ModalPedido = memo(function ModalPedido({
                   </div>
                 )}
               </div>
+            )}
+          </div>
+
+          {/* Fecha del pedido */}
+          <div>
+            <label className="block text-sm font-medium mb-1 dark:text-gray-200">
+              <Calendar className="w-4 h-4 inline mr-1" />
+              Fecha del pedido
+            </label>
+            <input
+              type="date"
+              value={nuevoPedido.fecha || new Date().toISOString().split('T')[0]}
+              onChange={e => onFechaChange && onFechaChange(e.target.value)}
+              max={new Date().toISOString().split('T')[0]}
+              className="w-full px-3 py-2 border rounded-lg bg-white dark:bg-gray-700 dark:border-gray-600 dark:text-white"
+            />
+            {nuevoPedido.fecha && nuevoPedido.fecha !== new Date().toISOString().split('T')[0] && (
+              <p className="text-xs text-amber-600 mt-1">Se registrará con fecha distinta a hoy</p>
             )}
           </div>
 

--- a/src/components/pedidos/PedidoCard.tsx
+++ b/src/components/pedidos/PedidoCard.tsx
@@ -174,8 +174,8 @@ function PedidoCard({
               </h3>
               <p className="text-sm text-gray-500 dark:text-gray-400">{pedido.cliente?.direccion}</p>
               <p className="text-sm text-gray-400 dark:text-gray-500 mt-1 flex items-center gap-2">
-                <span>#{pedido.id} - {formatFecha(pedido.created_at)}</span>
-                <BadgeAntiguedad dias={calcularDiasAntiguedad(pedido.created_at)} estado={pedido.estado} />
+                <span>#{pedido.id} - {formatFecha(pedido.fecha || pedido.created_at)}</span>
+                <BadgeAntiguedad dias={calcularDiasAntiguedad(pedido.fecha || pedido.created_at)} estado={pedido.estado} />
               </p>
             </div>
           </div>

--- a/src/hooks/queries/useMetricasQuery.ts
+++ b/src/hooks/queries/useMetricasQuery.ts
@@ -32,6 +32,7 @@ interface PedidoWithRelations {
   estado_pago?: string
   total: number
   monto_pagado?: number
+  fecha?: string
   created_at?: string
   items?: Array<{
     producto_id: string
@@ -112,10 +113,10 @@ async function calcularMetricas(params: MetricasParams): Promise<DashboardMetric
 
   let pedidosFiltrados = pedidosTyped
   if (fechaInicioStr) {
-    pedidosFiltrados = pedidosTyped.filter(p => (p.created_at?.split('T')[0] ?? '') >= fechaInicioStr!)
+    pedidosFiltrados = pedidosTyped.filter(p => (p.fecha ?? p.created_at?.split('T')[0] ?? '') >= fechaInicioStr!)
   }
   if (periodo === 'personalizado' && fechaHasta) {
-    pedidosFiltrados = pedidosFiltrados.filter(p => (p.created_at?.split('T')[0] ?? '') <= fechaHasta)
+    pedidosFiltrados = pedidosFiltrados.filter(p => (p.fecha ?? p.created_at?.split('T')[0] ?? '') <= fechaHasta)
   }
 
   // Productos más vendidos
@@ -152,7 +153,7 @@ async function calcularMetricas(params: MetricasParams): Promise<DashboardMetric
     const fecha = new Date()
     fecha.setDate(fecha.getDate() - i)
     const fechaStr = fecha.toISOString().split('T')[0]
-    const pedidosDia = pedidosTyped.filter(p => p.created_at?.split('T')[0] === fechaStr)
+    const pedidosDia = pedidosTyped.filter(p => (p.fecha ?? p.created_at?.split('T')[0]) === fechaStr)
     ventasPorDia.push({
       dia: fecha.toLocaleDateString('es-AR', { weekday: 'short' }),
       ventas: pedidosDia.reduce((s, p) => s + (p.total || 0), 0),
@@ -185,10 +186,10 @@ async function calcularReportePreventistas(
   let query = supabase.from('pedidos').select(`*, items:pedido_items(*)`)
 
   if (fechaDesde) {
-    query = query.gte('created_at', `${fechaDesde}T00:00:00`)
+    query = query.gte('fecha', fechaDesde)
   }
   if (fechaHasta) {
-    query = query.lte('created_at', `${fechaHasta}T23:59:59`)
+    query = query.lte('fecha', fechaHasta)
   }
 
   const { data: pedidos, error } = await query

--- a/src/hooks/queries/usePedidosQuery.ts
+++ b/src/hooks/queries/usePedidosQuery.ts
@@ -40,6 +40,7 @@ interface CrearPedidoInput {
   formaPago?: string
   estadoPago?: string
   montoPagado?: number
+  fecha?: string
 }
 
 interface ActualizarEstadoInput {
@@ -160,10 +161,10 @@ async function fetchPedidosPaginated(
     query = query.eq('transportista_id', filters.transportistaId)
   }
   if (filters?.fechaDesde) {
-    query = query.gte('created_at', filters.fechaDesde + 'T00:00:00')
+    query = query.gte('fecha', filters.fechaDesde)
   }
   if (filters?.fechaHasta) {
-    query = query.lte('created_at', filters.fechaHasta + 'T23:59:59')
+    query = query.lte('fecha', filters.fechaHasta)
   }
 
   // Search by client name (using the foreign key relationship)
@@ -222,7 +223,8 @@ async function crearPedido(input: CrearPedidoInput): Promise<{ id: string }> {
     p_items: itemsParaRPC,
     p_notas: input.notas || null,
     p_forma_pago: input.formaPago || 'efectivo',
-    p_estado_pago: input.estadoPago || 'pendiente'
+    p_estado_pago: input.estadoPago || 'pendiente',
+    ...(input.fecha ? { p_fecha: input.fecha } : {})
   })
 
   if (error) throw error

--- a/src/types/hooks.ts
+++ b/src/types/hooks.ts
@@ -97,6 +97,7 @@ export interface PedidoDB {
   items?: PedidoItemDB[];
   salvedades?: PedidoSalvedadResumen[];
   stock_descontado?: boolean;
+  fecha?: string;
   fecha_entrega?: string | null;
   created_at?: string;
   updated_at?: string;


### PR DESCRIPTION
- Add date picker to ModalPedido for user-selectable order date (defaults to today)
- Pass p_fecha parameter to crear_pedido_completo RPC
- Update metrics, filters, and PedidoCard to use fecha instead of created_at
- Make obtener_resumen_cuenta_cliente, descontar_stock_atomico, restaurar_stock_atomico SECURITY DEFINER
- Drop legacy eliminar_pedido_completo(int, bool) non-SECURITY DEFINER overload
- Add fecha field to PedidoDB type