### PR TITLE
fix: repair pedidos search (400 errors) + add debounce

### DIFF
--- a/src/components/containers/PedidosContainer.tsx
+++ b/src/components/containers/PedidosContainer.tsx
@@ -22,6 +22,7 @@ import { useAuthData } from '../../contexts/AuthDataContext'
 import { useNotification } from '../../contexts/NotificationContext'
 import { useOptimizarRuta } from '../../hooks/useOptimizarRuta'
 import { usePrecioMayorista } from '../../hooks/usePrecioMayorista'
+import { useDebounce } from '../../hooks/useAsync'
 import { supabase } from '../../hooks/supabase/base'
 import type { PedidoDB, FiltrosPedidosState, PerfilDB, RegistrarSalvedadInput, RegistrarSalvedadResult } from '../../types'
 
@@ -74,11 +75,12 @@ export default function PedidosContainer(): React.ReactElement {
   // Pagination state
   const [paginaActual, setPaginaActual] = useState(1)
   const [busqueda, setBusqueda] = useState('')
+  const debouncedBusqueda = useDebounce(busqueda, 350)
   const [filtros, setFiltros] = useState<FiltrosPedidosState>(DEFAULT_FILTROS)
 
-  // Queries
+  // Queries - use debounced search to avoid firing on every keystroke
   const { data: paginatedResult, isLoading: loadingPedidos } = usePedidosPaginatedQuery(
-    paginaActual, ITEMS_PER_PAGE, filtros, busqueda
+    paginaActual, ITEMS_PER_PAGE, filtros, debouncedBusqueda
   )
   const { data: clientes = [] } = useClientesQuery()
   const { data: productos = [] } = useProductosQuery()

--- a/src/hooks/queries/usePedidosQuery.ts
+++ b/src/hooks/queries/usePedidosQuery.ts
@@ -145,9 +145,16 @@ async function fetchPedidosPaginated(
   const from = (page - 1) * pageSize
   const to = from + pageSize - 1
 
+  const hasSearch = search && search.trim().length > 0
+
+  // Use !inner join when searching so PostgREST filters parent rows by client fields
+  const selectStr = hasSearch
+    ? '*, cliente:clientes!inner(*), items:pedido_items(*, producto:productos(*))'
+    : '*, cliente:clientes(*), items:pedido_items(*, producto:productos(*))'
+
   let query = supabase
     .from('pedidos')
-    .select('*, cliente:clientes(*), items:pedido_items(*, producto:productos(*))', { count: 'exact' })
+    .select(selectStr, { count: 'exact' })
     .order('created_at', { ascending: false })
 
   // Apply server-side filters
@@ -167,9 +174,13 @@ async function fetchPedidosPaginated(
     query = query.lte('fecha', filters.fechaHasta)
   }
 
-  // Search by client name (using the foreign key relationship)
-  if (search && search.trim().length > 0) {
-    query = query.or(`cliente.nombre_fantasia.ilike.%${search.trim()}%,cliente.cuit.ilike.%${search.trim()}%`)
+  // Search by client fields using referencedTable for related table filtering
+  if (hasSearch) {
+    const trimmed = search!.trim()
+    query = query.or(
+      `nombre_fantasia.ilike.%${trimmed}%,razon_social.ilike.%${trimmed}%,cuit.ilike.%${trimmed}%,direccion.ilike.%${trimmed}%`,
+      { referencedTable: 'clientes' }
+    )
   }
 
   query = query.range(from, to)


### PR DESCRIPTION
- Fix PostgREST query: use referencedTable + !inner join instead of invalid dot-notation in .or() for related table filtering
- Add 350ms debounce to search input to prevent excessive API calls
- Expand search to include razon_social and direccion fields