### PR TITLE
fix: preserve street number in address autocomplete selection

### DIFF
--- a/src/components/AddressAutocomplete.tsx
+++ b/src/components/AddressAutocomplete.tsx
@@ -164,6 +164,9 @@ export const AddressAutocomplete = ({
   const handleSelectPrediction = useCallback((prediction: PlacePrediction): void => {
     if (!placesServiceRef.current) return;
 
+    // Guardar el input original del usuario para intentar preservar el número de calle
+    const originalInput = inputRef.current?.value || '';
+
     setLoading(true);
     setShowDropdown(false);
     onChange(prediction.description);
@@ -178,12 +181,31 @@ export const AddressAutocomplete = ({
         setLoading(false);
 
         if (status === window.google.maps.places.PlacesServiceStatus.OK && place) {
+          const components = (place.address_components as AddressComponent[]) || [];
+          let direccion = place.formatted_address || prediction.description;
+
+          // Si Google no devolvió número de calle, intentar extraerlo del input original
+          const tieneStreetNumber = components.some(c => c.types.includes('street_number'));
+          if (!tieneStreetNumber) {
+            const route = components.find(c => c.types.includes('route'))?.long_name;
+            // Extraer número del input original del usuario (ej: "eudoro araos 2135" → "2135")
+            const numberMatch = originalInput.match(/\b(\d{1,5})\b/);
+            if (route && numberMatch) {
+              const streetNumber = numberMatch[1];
+              // Insertar el número después del nombre de la calle
+              direccion = direccion.replace(route, `${route} ${streetNumber}`);
+            }
+          }
+
           const result: AddressSelectResult = {
-            direccion: place.formatted_address || prediction.description,
+            direccion,
             latitud: place.geometry?.location?.lat() || null,
             longitud: place.geometry?.location?.lng() || null,
-            componentes: (place.address_components as AddressComponent[]) || []
+            componentes: components
           };
+
+          // Actualizar el input con la dirección final (incluyendo número si se recuperó)
+          onChange(direccion);
           onSelect(result);
 
           // Crear nuevo session token para la próxima búsqueda

--- a/src/components/modals/ModalPedido.tsx
+++ b/src/components/modals/ModalPedido.tsx
@@ -217,13 +217,13 @@ const ModalPedido = memo(function ModalPedido({
 
             {mostrarNuevoCliente ? (
               <div className="border rounded-lg p-3 space-y-3 bg-blue-50 dark:bg-gray-700 dark:border-gray-600">
-                <input type="text" value={nuevoCliente.nombreFantasia} onChange={e => setNuevoCliente({ ...nuevoCliente, nombreFantasia: e.target.value })} className="w-full px-3 py-2 border rounded-lg bg-white dark:bg-gray-800 dark:border-gray-600 dark:text-white" placeholder="Nombre fantasia *" />
-                <input type="text" value={nuevoCliente.nombre} onChange={e => setNuevoCliente({ ...nuevoCliente, nombre: e.target.value })} className="w-full px-3 py-2 border rounded-lg bg-white dark:bg-gray-800 dark:border-gray-600 dark:text-white" placeholder="Nombre completo *" />
+                <input type="text" value={nuevoCliente.nombreFantasia} onChange={e => setNuevoCliente(prev => ({ ...prev, nombreFantasia: e.target.value }))} className="w-full px-3 py-2 border rounded-lg bg-white dark:bg-gray-800 dark:border-gray-600 dark:text-white" placeholder="Nombre fantasia *" />
+                <input type="text" value={nuevoCliente.nombre} onChange={e => setNuevoCliente(prev => ({ ...prev, nombre: e.target.value }))} className="w-full px-3 py-2 border rounded-lg bg-white dark:bg-gray-800 dark:border-gray-600 dark:text-white" placeholder="Nombre completo *" />
                 <AddressAutocomplete
                   value={nuevoCliente.direccion}
-                  onChange={(val: string) => setNuevoCliente({ ...nuevoCliente, direccion: val })}
+                  onChange={(val: string) => setNuevoCliente(prev => ({ ...prev, direccion: val }))}
                   onSelect={(result) => {
-                    setNuevoCliente({ ...nuevoCliente, direccion: result.direccion, latitud: result.latitud, longitud: result.longitud });
+                    setNuevoCliente(prev => ({ ...prev, direccion: result.direccion, latitud: result.latitud, longitud: result.longitud }));
                   }}
                   placeholder="Buscar dirección..."
                 />


### PR DESCRIPTION
When Google Places returns a prediction without street_number in address_components (e.g., "Eudoro Aráoz" without "2135"), extract the number from the user's original input and insert it into the address.

Also fix stale closure in ModalPedido quick-create client form by using functional state updates (prev => ...) instead of spreading the captured closure variable.