### PR TITLE
fix: extend session duration from 15min to 8h inactivity timeout

### DIFF
--- a/src/hooks/supabase/useAuth.tsx
+++ b/src/hooks/supabase/useAuth.tsx
@@ -5,17 +5,20 @@ import { supabase } from './base'
 import { logger } from '../../utils/logger'
 import type { RolUsuario } from '../../types'
 
-// Tiempo de inactividad antes de cerrar sesión automáticamente (15 minutos)
-const INACTIVITY_TIMEOUT_MS = 15 * 60 * 1000
+// Tiempo de inactividad antes de cerrar sesión automáticamente (8 horas)
+const INACTIVITY_TIMEOUT_MS = 8 * 60 * 60 * 1000
 
 // Eventos que reinician el timer de inactividad
-type ActivityEventName = 'mousedown' | 'keydown' | 'touchstart' | 'scroll' | 'mousemove'
+type ActivityEventName = 'mousedown' | 'keydown' | 'touchstart' | 'scroll' | 'mousemove' | 'click' | 'input' | 'touchmove'
 const ACTIVITY_EVENTS: ActivityEventName[] = [
   'mousedown',
   'keydown',
   'touchstart',
+  'touchmove',
   'scroll',
-  'mousemove'
+  'mousemove',
+  'click',
+  'input'
 ]
 
 // Tipo para el perfil de usuario

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -7,6 +7,7 @@ export const supabase = createClient(supabaseUrl, supabaseAnonKey, {
   auth: {
     storageKey: 'distribuidora_v2',
     persistSession: true,
+    autoRefreshToken: true,
     detectSessionInUrl: true,
   }
 })


### PR DESCRIPTION
Users reported being logged out while actively working. The custom inactivity timeout was set to 15 minutes which is too short for a distribution app. Extended to 8 hours and added more activity events (click, input, touchmove) to better detect mobile/tablet usage. Also explicitly enabled autoRefreshToken in Supabase client config.