### PR TITLE
fix: login sets user+perfil directly, use authReady to gate UI

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -409,16 +409,16 @@ function MainApp(): ReactElement {
 // =============================================================================
 
 function AppContent(): ReactElement {
-  const { user, perfil, loading } = useAuth();
-  if (loading) {
+  const { user, perfil, authReady } = useAuth();
+  // Show spinner while auth is initializing OR while perfil is being fetched for an authenticated user
+  if (!authReady) {
     return (
       <div className="min-h-screen bg-gray-100 dark:bg-gray-900 flex items-center justify-center transition-colors">
         <Loader2 className="w-8 h-8 animate-spin text-blue-600" aria-label="Cargando" />
       </div>
     );
   }
-  // Only render MainApp when BOTH user and perfil are loaded.
-  // This prevents the "Usuario" stuck state where user exists but perfil is null.
+  // authReady guarantees: either no user, or user WITH perfil loaded
   return (user && perfil) ? <MainApp /> : <LoginScreen />;
 }
 

--- a/src/components/auth/LoginScreen.tsx
+++ b/src/components/auth/LoginScreen.tsx
@@ -15,8 +15,11 @@ export default function LoginScreen() {
     setLoading(true);
     try {
       await login(email, password);
-    } catch {
-      setError('Email o contraseña incorrectos');
+    } catch (err) {
+      const message = err instanceof Error ? err.message : '';
+      setError(message.includes('perfil')
+        ? message
+        : 'Email o contraseña incorrectos');
     }
     setLoading(false);
   };

--- a/src/hooks/supabase/useAuth.tsx
+++ b/src/hooks/supabase/useAuth.tsx
@@ -161,6 +161,19 @@ export function AuthProvider({ children }: AuthProviderProps) {
   const login = async (email: string, password: string) => {
     const { data, error } = await supabase.auth.signInWithPassword({ email, password })
     if (error) throw error
+    // Set user and fetch perfil HERE, don't rely solely on onAuthStateChange.
+    // This guarantees both user + perfil are set before login() returns,
+    // so AppContent renders MainApp immediately instead of flashing LoginScreen.
+    if (data.user) {
+      setUser(data.user)
+      const perfilLoaded = await fetchPerfil(data.user.id)
+      if (!perfilLoaded) {
+        // Auth succeeded but perfil load failed — clean up and surface error
+        await supabase.auth.signOut({ scope: 'local' })
+        setUser(null)
+        throw new Error('No se pudo cargar el perfil del usuario. Intentá de nuevo.')
+      }
+    }
     return data
   }
 


### PR DESCRIPTION
Root cause of "can't log in": login() relied on onAuthStateChange to set user/perfil, but React re-rendered between setUser and setPerfil, showing LoginScreen for an authenticated user (since AppContent checked user && perfil).

Changes:
- login() now sets user and awaits fetchPerfil before returning, guaranteeing both are set when LoginScreen's handleSubmit ends
- If fetchPerfil fails after successful auth, sign out and throw a descriptive error instead of silently leaving user stuck
- AppContent uses authReady (not loading) to gate rendering: spinner while user exists but perfil is still loading
- LoginScreen shows actual error message when perfil load fails