### PR TITLE
fix: page refresh stuck on spinner when token expired

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -409,9 +409,11 @@ function MainApp(): ReactElement {
 // =============================================================================
 
 function AppContent(): ReactElement {
-  const { user, perfil, authReady } = useAuth();
-  // Show spinner while auth is initializing OR while perfil is being fetched for an authenticated user
-  if (!authReady) {
+  const { user, perfil, loading } = useAuth();
+  // Show spinner only while auth is initializing (loading=true).
+  // login() guarantees user+perfil are both set before returning.
+  // initAuth clears user if perfil fetch fails, so loading=false always leads to a valid state.
+  if (loading) {
     return (
       <div className="min-h-screen bg-gray-100 dark:bg-gray-900 flex items-center justify-center transition-colors">
         <Loader2 className="w-8 h-8 animate-spin text-blue-600" aria-label="Cargando" />

--- a/src/hooks/supabase/useAuth.tsx
+++ b/src/hooks/supabase/useAuth.tsx
@@ -102,7 +102,31 @@ export function AuthProvider({ children }: AuthProviderProps) {
         if (data?.session?.user) {
           setUser(data.session.user)
           // AWAIT perfil before setting loading=false
-          await fetchPerfil(data.session.user.id)
+          const perfilLoaded = await fetchPerfil(data.session.user.id)
+
+          if (!perfilLoaded && mounted) {
+            // Perfil fetch failed (likely expired token) — try refreshing session
+            logger.warn('[useAuth] Perfil fetch failed, attempting session refresh...')
+            const { data: refreshData, error: refreshError } = await supabase.auth.refreshSession()
+
+            if (refreshError || !refreshData.session) {
+              // Session is dead — clear state so user sees LoginScreen
+              logger.warn('[useAuth] Session refresh failed, clearing auth state')
+              setUser(null)
+              setPerfil(null)
+              await supabase.auth.signOut({ scope: 'local' })
+            } else {
+              // Token refreshed — retry perfil fetch
+              setUser(refreshData.session.user)
+              const retryOk = await fetchPerfil(refreshData.session.user.id)
+              if (!retryOk && mounted) {
+                logger.error('[useAuth] Perfil fetch failed even after session refresh')
+                setUser(null)
+                setPerfil(null)
+                await supabase.auth.signOut({ scope: 'local' })
+              }
+            }
+          }
         }
       } catch (err) {
         logger.error('[useAuth] Error initializing auth:', err)


### PR DESCRIPTION
Root cause: authReady was false forever when fetchPerfil failed (user set but perfil null). AppContent used authReady → spinner.

Changes:
- initAuth: if fetchPerfil fails, attempt session refresh and retry. If still fails, clear user state and sign out so LoginScreen appears instead of infinite spinner.
- AppContent: use loading (not authReady) since login() now guarantees user+perfil are set, and initAuth cleans up on failure. loading=false always leads to a valid render state.