### PR TITLE
feat: add bulk delivery and cancel order with reason

### DIFF
--- a/src/components/containers/PedidosContainer.tsx
+++ b/src/components/containers/PedidosContainer.tsx
@@ -14,6 +14,8 @@ import {
   useCambiarEstadoMutation,
   useAsignarTransportistaMutation,
   useEliminarPedidoMutation,
+  useEntregasMasivasMutation,
+  useCancelarPedidoMutation,
   useClientesQuery,
   useProductosQuery,
   useTransportistasQuery,
@@ -40,6 +42,8 @@ const ModalExportarPDF = lazy(() => import('../modals/ModalExportarPDF'))
 const ModalGestionRutas = lazy(() => import('../modals/ModalGestionRutas'))
 const ModalPedidosEliminados = lazy(() => import('../modals/ModalPedidosEliminados'))
 const ModalEntregaConSalvedad = lazy(() => import('../modals/ModalEntregaConSalvedad'))
+const ModalEntregasMasivas = lazy(() => import('../modals/ModalEntregasMasivas'))
+const ModalCancelarPedido = lazy(() => import('../modals/ModalCancelarPedido'))
 
 const ITEMS_PER_PAGE = 15
 
@@ -94,6 +98,8 @@ export default function PedidosContainer(): React.ReactElement {
   const cambiarEstado = useCambiarEstadoMutation()
   const asignarTransportistaMut = useAsignarTransportistaMutation()
   const eliminarPedido = useEliminarPedidoMutation()
+  const entregasMasivas = useEntregasMasivasMutation()
+  const cancelarPedidoMut = useCancelarPedidoMutation()
   const crearClienteMut = useCrearClienteMutation()
 
   // Route optimization
@@ -117,6 +123,8 @@ export default function PedidosContainer(): React.ReactElement {
   const [modalOptimizarRutaOpen, setModalOptimizarRutaOpen] = useState(false)
   const [modalPedidosEliminadosOpen, setModalPedidosEliminadosOpen] = useState(false)
   const [modalEntregaSalvedadOpen, setModalEntregaSalvedadOpen] = useState(false)
+  const [modalEntregasMasivasOpen, setModalEntregasMasivasOpen] = useState(false)
+  const [modalCancelarOpen, setModalCancelarOpen] = useState(false)
   const [confirmConfig, setConfirmConfig] = useState<ConfirmConfig>({ visible: false })
 
   // Pedido-specific state for modals
@@ -126,6 +134,7 @@ export default function PedidosContainer(): React.ReactElement {
   const [cargandoHistorial, setCargandoHistorial] = useState(false)
   const [pedidoEditando, setPedidoEditando] = useState<PedidoDB | null>(null)
   const [pedidoParaSalvedad, setPedidoParaSalvedad] = useState<PedidoDB | null>(null)
+  const [pedidoCancelando, setPedidoCancelando] = useState<PedidoDB | null>(null)
   const [guardando, setGuardando] = useState(false)
 
   // Nuevo pedido form state
@@ -275,6 +284,33 @@ export default function PedidosContainer(): React.ReactElement {
     setPedidoParaSalvedad(pedido)
     setModalEntregaSalvedadOpen(true)
   }, [])
+
+  const handleCancelarPedido = useCallback((pedido: PedidoDB) => {
+    setPedidoCancelando(pedido)
+    setModalCancelarOpen(true)
+  }, [])
+
+  const handleConfirmarCancelacion = useCallback(async (motivo: string) => {
+    if (!pedidoCancelando) return
+    setGuardando(true)
+    try {
+      await cancelarPedidoMut.mutateAsync({ pedidoId: pedidoCancelando.id, motivo })
+      setModalCancelarOpen(false)
+      setPedidoCancelando(null)
+      notify.success('Pedido cancelado')
+    } catch (e) { notify.error((e as Error).message) }
+    setGuardando(false)
+  }, [pedidoCancelando, cancelarPedidoMut, notify])
+
+  const handleEntregasMasivas = useCallback(async (transportistaId: string, pedidoIds: string[]) => {
+    setGuardando(true)
+    try {
+      await entregasMasivas.mutateAsync({ pedidoIds, transportistaId })
+      setModalEntregasMasivasOpen(false)
+      notify.success(`${pedidoIds.length} pedido${pedidoIds.length !== 1 ? 's' : ''} marcado${pedidoIds.length !== 1 ? 's' : ''} como entregado${pedidoIds.length !== 1 ? 's' : ''}`)
+    } catch (e) { notify.error('Error en entregas masivas: ' + (e as Error).message) }
+    setGuardando(false)
+  }, [entregasMasivas, notify])
 
   // Excel export (multi-sheet con ExcelJS)
   const handleExportarExcel = useCallback(async () => {
@@ -568,7 +604,9 @@ export default function PedidosContainer(): React.ReactElement {
           onMarcarEntregado={handleMarcarEntregado}
           onMarcarEntregadoConSalvedad={handleMarcarEntregadoConSalvedad}
           onDesmarcarEntregado={handleDesmarcarEntregado}
+          onCancelarPedido={handleCancelarPedido}
           onEliminarPedido={handleEliminarPedido}
+          onEntregasMasivas={() => setModalEntregasMasivasOpen(true)}
           onVerPedidosEliminados={() => setModalPedidosEliminadosOpen(true)}
         />
       </Suspense>
@@ -743,6 +781,30 @@ export default function PedidosContainer(): React.ReactElement {
             onSave={handleSaveSalvedades as Parameters<typeof ModalEntregaConSalvedad>[0]['onSave']}
             onMarcarEntregado={handleMarcarEntregadoConSalvedadConfirm}
             onClose={() => { setModalEntregaSalvedadOpen(false); setPedidoParaSalvedad(null) }}
+          />
+        </Suspense>
+      )}
+
+      {/* Modal Entregas Masivas */}
+      {modalEntregasMasivasOpen && (
+        <Suspense fallback={null}>
+          <ModalEntregasMasivas
+            transportistas={transportistas}
+            onConfirm={handleEntregasMasivas}
+            onClose={() => setModalEntregasMasivasOpen(false)}
+            guardando={guardando}
+          />
+        </Suspense>
+      )}
+
+      {/* Modal Cancelar Pedido */}
+      {modalCancelarOpen && pedidoCancelando && (
+        <Suspense fallback={null}>
+          <ModalCancelarPedido
+            pedido={pedidoCancelando}
+            onConfirm={handleConfirmarCancelacion}
+            onClose={() => { setModalCancelarOpen(false); setPedidoCancelando(null) }}
+            guardando={guardando}
           />
         </Suspense>
       )}

--- a/src/components/modals/ModalCancelarPedido.tsx
+++ b/src/components/modals/ModalCancelarPedido.tsx
@@ -1,0 +1,88 @@
+import { useState, memo } from 'react'
+import { Loader2, AlertTriangle } from 'lucide-react'
+import ModalBase from './ModalBase'
+import { formatPrecio } from '../../utils/formatters'
+import type { PedidoDB } from '../../types'
+
+export interface ModalCancelarPedidoProps {
+  pedido: PedidoDB
+  onConfirm: (motivo: string) => Promise<void>
+  onClose: () => void
+  guardando: boolean
+}
+
+const ModalCancelarPedido = memo(function ModalCancelarPedido({
+  pedido,
+  onConfirm,
+  onClose,
+  guardando,
+}: ModalCancelarPedidoProps) {
+  const [motivo, setMotivo] = useState('')
+
+  const canConfirm = motivo.trim().length >= 3 && !guardando
+
+  return (
+    <ModalBase title="Cancelar Pedido" onClose={onClose}>
+      <div className="p-4 space-y-4">
+        {/* Warning */}
+        <div className="flex items-start gap-3 p-3 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg">
+          <AlertTriangle className="w-5 h-5 text-red-600 dark:text-red-400 flex-shrink-0 mt-0.5" />
+          <div>
+            <p className="text-sm font-medium text-red-800 dark:text-red-300">
+              Esta accion cancelara el pedido. El pedido permanecera visible con estado "Cancelado".
+            </p>
+            <p className="text-xs text-red-600 dark:text-red-400 mt-1">
+              Si necesitas restaurar el stock, usa "Eliminar" en su lugar.
+            </p>
+          </div>
+        </div>
+
+        {/* Pedido info */}
+        <div className="bg-gray-50 dark:bg-gray-700/50 rounded-lg p-3">
+          <p className="text-sm text-gray-600 dark:text-gray-400">Pedido #{pedido.id}</p>
+          <p className="font-medium text-gray-800 dark:text-white">
+            {pedido.cliente?.nombre_fantasia || 'Sin cliente'}
+          </p>
+          <p className="text-lg font-bold text-blue-600 mt-1">{formatPrecio(pedido.total)}</p>
+        </div>
+
+        {/* Motivo */}
+        <div>
+          <label className="block text-sm font-medium mb-1 text-gray-700 dark:text-gray-300">
+            Motivo de cancelacion <span className="text-red-500">*</span>
+          </label>
+          <textarea
+            value={motivo}
+            onChange={e => setMotivo(e.target.value)}
+            placeholder="Ingresa el motivo de la cancelacion..."
+            rows={3}
+            className="w-full px-3 py-2 border rounded-lg resize-none dark:bg-gray-700 dark:border-gray-600 dark:text-white"
+          />
+          {motivo.length > 0 && motivo.trim().length < 3 && (
+            <p className="text-xs text-red-500 mt-1">El motivo debe tener al menos 3 caracteres</p>
+          )}
+        </div>
+      </div>
+
+      {/* Footer */}
+      <div className="flex justify-end space-x-3 p-4 border-t bg-gray-50 dark:bg-gray-800 dark:border-gray-700">
+        <button
+          onClick={onClose}
+          className="px-4 py-2 text-gray-700 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-600 rounded-lg"
+        >
+          Volver
+        </button>
+        <button
+          onClick={() => canConfirm && onConfirm(motivo.trim())}
+          disabled={!canConfirm}
+          className="px-4 py-2 bg-red-600 text-white rounded-lg hover:bg-red-700 disabled:opacity-50 disabled:cursor-not-allowed flex items-center"
+        >
+          {guardando && <Loader2 className="w-4 h-4 mr-2 animate-spin" />}
+          Cancelar Pedido
+        </button>
+      </div>
+    </ModalBase>
+  )
+})
+
+export default ModalCancelarPedido

--- a/src/components/modals/ModalEntregasMasivas.tsx
+++ b/src/components/modals/ModalEntregasMasivas.tsx
@@ -1,0 +1,181 @@
+import { useState, useMemo, memo } from 'react'
+import { Loader2, Search } from 'lucide-react'
+import ModalBase from './ModalBase'
+import { usePedidosNoEntregadosQuery } from '../../hooks/queries'
+import { getEstadoColor, getEstadoLabel, formatPrecio } from '../../utils/formatters'
+import type { PerfilDB } from '../../types'
+
+export interface ModalEntregasMasivasProps {
+  transportistas: PerfilDB[]
+  onConfirm: (transportistaId: string, pedidoIds: string[]) => Promise<void>
+  onClose: () => void
+  guardando: boolean
+}
+
+const ModalEntregasMasivas = memo(function ModalEntregasMasivas({
+  transportistas,
+  onConfirm,
+  onClose,
+  guardando,
+}: ModalEntregasMasivasProps) {
+  const [selectedTransportista, setSelectedTransportista] = useState('')
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set())
+  const [busqueda, setBusqueda] = useState('')
+
+  const { data: pedidos = [], isLoading } = usePedidosNoEntregadosQuery(true)
+
+  const pedidosFiltrados = useMemo(() => {
+    if (!busqueda.trim()) return pedidos
+    const term = busqueda.toLowerCase()
+    return pedidos.filter(p =>
+      p.cliente?.nombre_fantasia?.toLowerCase().includes(term) ||
+      p.cliente?.direccion?.toLowerCase().includes(term) ||
+      String(p.id).includes(term)
+    )
+  }, [pedidos, busqueda])
+
+  const toggleSelect = (id: string) => {
+    setSelectedIds(prev => {
+      const next = new Set(prev)
+      if (next.has(id)) next.delete(id)
+      else next.add(id)
+      return next
+    })
+  }
+
+  const toggleAll = () => {
+    if (selectedIds.size === pedidosFiltrados.length) {
+      setSelectedIds(new Set())
+    } else {
+      setSelectedIds(new Set(pedidosFiltrados.map(p => p.id)))
+    }
+  }
+
+  const allSelected = pedidosFiltrados.length > 0 && selectedIds.size === pedidosFiltrados.length
+  const canConfirm = selectedTransportista && selectedIds.size > 0 && !guardando
+
+  return (
+    <ModalBase title="Entregas Masivas" onClose={onClose} maxWidth="max-w-3xl">
+      <div className="p-4 space-y-4">
+        {/* Selector de transportista */}
+        <div>
+          <label className="block text-sm font-medium mb-1 text-gray-700 dark:text-gray-300">
+            Transportista
+          </label>
+          <select
+            value={selectedTransportista}
+            onChange={e => setSelectedTransportista(e.target.value)}
+            className="w-full px-3 py-2 border rounded-lg dark:bg-gray-700 dark:border-gray-600 dark:text-white"
+          >
+            <option value="">Seleccionar transportista...</option>
+            {transportistas.map(t => (
+              <option key={t.id} value={t.id}>{t.nombre}</option>
+            ))}
+          </select>
+        </div>
+
+        {/* Busqueda */}
+        <div className="relative">
+          <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400" />
+          <input
+            type="text"
+            placeholder="Buscar por cliente, direccion o #pedido..."
+            value={busqueda}
+            onChange={e => setBusqueda(e.target.value)}
+            className="w-full pl-9 pr-3 py-2 border rounded-lg dark:bg-gray-700 dark:border-gray-600 dark:text-white"
+          />
+        </div>
+
+        {/* Seleccionar todos */}
+        {pedidosFiltrados.length > 0 && (
+          <label className="flex items-center space-x-2 cursor-pointer">
+            <input
+              type="checkbox"
+              checked={allSelected}
+              onChange={toggleAll}
+              className="w-4 h-4 rounded border-gray-300"
+            />
+            <span className="text-sm font-medium text-gray-700 dark:text-gray-300">
+              Seleccionar todos ({pedidosFiltrados.length})
+            </span>
+          </label>
+        )}
+
+        {/* Lista de pedidos */}
+        <div className="max-h-96 overflow-y-auto border rounded-lg dark:border-gray-600">
+          {isLoading ? (
+            <div className="flex items-center justify-center py-8">
+              <Loader2 className="w-6 h-6 animate-spin text-blue-600" />
+              <span className="ml-2 text-gray-500">Cargando pedidos...</span>
+            </div>
+          ) : pedidosFiltrados.length === 0 ? (
+            <div className="text-center py-8 text-gray-500">
+              No hay pedidos disponibles para entregar
+            </div>
+          ) : (
+            pedidosFiltrados.map(pedido => (
+              <label
+                key={pedido.id}
+                className={`flex items-center p-3 border-b last:border-b-0 dark:border-gray-600 cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-700/50 transition-colors ${
+                  selectedIds.has(pedido.id) ? 'bg-teal-50 dark:bg-teal-900/20' : ''
+                }`}
+              >
+                <input
+                  type="checkbox"
+                  checked={selectedIds.has(pedido.id)}
+                  onChange={() => toggleSelect(pedido.id)}
+                  className="w-4 h-4 rounded border-gray-300 mr-3 flex-shrink-0"
+                />
+                <div className="flex-1 min-w-0">
+                  <div className="flex items-center gap-2">
+                    <span className="text-xs text-gray-400">#{pedido.id}</span>
+                    <span className={`px-2 py-0.5 rounded-full text-xs font-medium ${getEstadoColor(pedido.estado)}`}>
+                      {getEstadoLabel(pedido.estado)}
+                    </span>
+                  </div>
+                  <p className="font-medium text-gray-800 dark:text-white truncate">
+                    {pedido.cliente?.nombre_fantasia || 'Sin cliente'}
+                  </p>
+                  <p className="text-xs text-gray-500 truncate">
+                    {pedido.cliente?.direccion}
+                  </p>
+                </div>
+                <div className="text-right ml-3 flex-shrink-0">
+                  <p className="font-bold text-blue-600">{formatPrecio(pedido.total)}</p>
+                  {pedido.transportista && (
+                    <p className="text-xs text-orange-600">{pedido.transportista.nombre}</p>
+                  )}
+                </div>
+              </label>
+            ))
+          )}
+        </div>
+      </div>
+
+      {/* Footer */}
+      <div className="flex items-center justify-between p-4 border-t bg-gray-50 dark:bg-gray-800 dark:border-gray-700">
+        <span className="text-sm text-gray-600 dark:text-gray-400">
+          {selectedIds.size} pedido{selectedIds.size !== 1 ? 's' : ''} seleccionado{selectedIds.size !== 1 ? 's' : ''}
+        </span>
+        <div className="flex space-x-3">
+          <button
+            onClick={onClose}
+            className="px-4 py-2 text-gray-700 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-600 rounded-lg"
+          >
+            Cancelar
+          </button>
+          <button
+            onClick={() => canConfirm && onConfirm(selectedTransportista, Array.from(selectedIds))}
+            disabled={!canConfirm}
+            className="px-4 py-2 bg-teal-600 text-white rounded-lg hover:bg-teal-700 disabled:opacity-50 disabled:cursor-not-allowed flex items-center"
+          >
+            {guardando && <Loader2 className="w-4 h-4 mr-2 animate-spin" />}
+            Marcar como Entregados
+          </button>
+        </div>
+      </div>
+    </ModalBase>
+  )
+})
+
+export default ModalEntregasMasivas

--- a/src/components/pedidos/PedidoActions.tsx
+++ b/src/components/pedidos/PedidoActions.tsx
@@ -9,7 +9,7 @@
  * - Focus visible en items
  */
 import React, { memo, useMemo } from 'react';
-import { MoreVertical, History, Edit2, Package, User, Check, AlertTriangle, Trash2, RotateCcw, AlertCircle, LucideIcon } from 'lucide-react';
+import { MoreVertical, History, Edit2, Package, User, Check, AlertTriangle, Trash2, RotateCcw, AlertCircle, XCircle, LucideIcon } from 'lucide-react';
 import {
   DropdownMenu,
   DropdownMenuTrigger,
@@ -36,6 +36,7 @@ export interface AccionesDropdownProps {
   onEntregado?: (pedido: PedidoDB) => void;
   onEntregadoConSalvedad?: (pedido: PedidoDB) => void;
   onRevertir?: (pedido: PedidoDB) => void;
+  onCancelarPedido?: (pedido: PedidoDB) => void;
   onEliminar?: (pedidoId: string) => void;
 }
 
@@ -64,6 +65,7 @@ function AccionesDropdown({
   onEntregado,
   onEntregadoConSalvedad,
   onRevertir,
+  onCancelarPedido,
   onEliminar
 }: AccionesDropdownProps): React.ReactElement {
   // Memoizar acciones para evitar recalculos innecesarios
@@ -150,6 +152,17 @@ function AccionesDropdown({
       });
     }
 
+    // Admin puede cancelar si no esta entregado ni cancelado
+    if (isAdmin && pedido.estado !== 'entregado' && pedido.estado !== 'cancelado' && onCancelarPedido) {
+      items.push({
+        label: 'Cancelar Pedido',
+        icon: XCircle,
+        onClick: () => onCancelarPedido(pedido),
+        className: 'text-red-600 dark:text-red-400',
+        divider: true
+      });
+    }
+
     // Admin puede eliminar (con separador)
     if (isAdmin && onEliminar) {
       items.push({
@@ -162,7 +175,7 @@ function AccionesDropdown({
     }
 
     return items;
-  }, [pedido, isAdmin, isPreventista, isTransportista, onHistorial, onEditar, onPreparar, onVolverAPendiente, onAsignar, onEntregado, onEntregadoConSalvedad, onRevertir, onEliminar]);
+  }, [pedido, isAdmin, isPreventista, isTransportista, onHistorial, onEditar, onPreparar, onVolverAPendiente, onAsignar, onEntregado, onEntregadoConSalvedad, onRevertir, onCancelarPedido, onEliminar]);
 
   return (
     <DropdownMenu>

--- a/src/components/pedidos/PedidoCard.tsx
+++ b/src/components/pedidos/PedidoCard.tsx
@@ -46,6 +46,7 @@ export interface PedidoCardProps {
   onMarcarEntregado?: (pedido: PedidoDB) => void;
   onMarcarEntregadoConSalvedad?: (pedido: PedidoDB) => void;
   onDesmarcarEntregado?: (pedido: PedidoDB) => void;
+  onCancelarPedido?: (pedido: PedidoDB) => void;
   onEliminarPedido?: (pedidoId: string) => void;
 }
 
@@ -149,6 +150,7 @@ function PedidoCard({
   onMarcarEntregado,
   onMarcarEntregadoConSalvedad,
   onDesmarcarEntregado,
+  onCancelarPedido,
   onEliminarPedido
 }: PedidoCardProps): React.ReactElement {
   const [expandido, setExpandido] = useState<boolean>(false);
@@ -189,6 +191,12 @@ function PedidoCard({
               {pedido.transportista.nombre}
             </div>
           )}
+          {pedido.estado === 'cancelado' && pedido.motivo_cancelacion && (
+            <div className="mt-2 inline-flex items-center px-2 py-1 bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400 rounded-full text-sm">
+              <AlertTriangle className="w-3 h-3 mr-1" />
+              <span className="truncate max-w-xs">{pedido.motivo_cancelacion}</span>
+            </div>
+          )}
         </div>
 
         {/* Acciones */}
@@ -214,6 +222,7 @@ function PedidoCard({
             onEntregado={handleMarcarEntregado}
             onEntregadoConSalvedad={onMarcarEntregadoConSalvedad}
             onRevertir={handleDesmarcarEntregado}
+            onCancelarPedido={onCancelarPedido}
             onEliminar={handleEliminarPedido}
           />
         </div>
@@ -373,6 +382,17 @@ function PedidoCard({
                   </p>
                 </div>
               </div>
+            </div>
+          )}
+
+          {/* Motivo de cancelacion */}
+          {pedido.estado === 'cancelado' && pedido.motivo_cancelacion && (
+            <div className="p-3 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg">
+              <h4 className="text-sm font-semibold text-red-700 dark:text-red-300 mb-1 flex items-center gap-2">
+                <AlertTriangle className="w-4 h-4" />
+                Motivo de cancelacion
+              </h4>
+              <p className="text-sm text-red-800 dark:text-red-200 whitespace-pre-wrap">{pedido.motivo_cancelacion}</p>
             </div>
           )}
 

--- a/src/components/vistas/VistaPedidos.tsx
+++ b/src/components/vistas/VistaPedidos.tsx
@@ -4,7 +4,7 @@
  * Recibe datos ya paginados server-side desde PedidosContainer.
  * Renderiza lista + controles de paginación.
  */
-import { ShoppingCart, Plus, Route, FileDown, Trash2 } from 'lucide-react';
+import { ShoppingCart, Plus, Route, FileDown, Trash2, PackageCheck } from 'lucide-react';
 import LoadingSpinner from '../layout/LoadingSpinner';
 import Paginacion from '../layout/Paginacion';
 import { PedidoCard, PedidoFilters, PedidoStats, VistaRutaTransportista } from '../pedidos';
@@ -54,7 +54,9 @@ export interface VistaPedidosProps {
   onMarcarEntregado: (pedido: PedidoDB) => void;
   onMarcarEntregadoConSalvedad?: (pedido: PedidoDB) => void;
   onDesmarcarEntregado: (pedido: PedidoDB) => void;
+  onCancelarPedido?: (pedido: PedidoDB) => void;
   onEliminarPedido: (pedido: PedidoDB) => void;
+  onEntregasMasivas?: () => void;
   onVerPedidosEliminados?: () => void;
 }
 
@@ -90,7 +92,9 @@ export default function VistaPedidos({
   onMarcarEntregado,
   onMarcarEntregadoConSalvedad,
   onDesmarcarEntregado,
+  onCancelarPedido,
   onEliminarPedido,
+  onEntregasMasivas,
   onVerPedidosEliminados
 }: VistaPedidosProps) {
   // Si es transportista, mostrar vista especial de ruta
@@ -138,6 +142,15 @@ export default function VistaPedidos({
             >
               <FileDown className="w-5 h-5" />
               <span>Excel</span>
+            </button>
+          )}
+          {isAdmin && onEntregasMasivas && (
+            <button
+              onClick={onEntregasMasivas}
+              className="flex items-center space-x-2 px-4 py-2 bg-teal-600 text-white rounded-lg hover:bg-teal-700 transition-colors"
+            >
+              <PackageCheck className="w-5 h-5" />
+              <span className="hidden sm:inline">Entregas Masivas</span>
             </button>
           )}
           {isAdmin && onVerPedidosEliminados && (
@@ -202,6 +215,7 @@ export default function VistaPedidos({
                 onMarcarEntregado={onMarcarEntregado}
                 onMarcarEntregadoConSalvedad={onMarcarEntregadoConSalvedad}
                 onDesmarcarEntregado={onDesmarcarEntregado}
+                onCancelarPedido={onCancelarPedido}
                 onEliminarPedido={(pedidoId: string) => {
                   const p = pedidos.find(x => x.id === pedidoId);
                   if (p) onEliminarPedido(p);

--- a/src/hooks/queries/index.ts
+++ b/src/hooks/queries/index.ts
@@ -43,6 +43,9 @@ export {
   useActualizarPagoMutation,
   useAsignarTransportistaMutation,
   useEliminarPedidoMutation,
+  usePedidosNoEntregadosQuery,
+  useEntregasMasivasMutation,
+  useCancelarPedidoMutation,
 } from './usePedidosQuery'
 export type { PaginatedResult } from './usePedidosQuery'
 

--- a/src/hooks/queries/usePedidosQuery.ts
+++ b/src/hooks/queries/usePedidosQuery.ts
@@ -507,3 +507,129 @@ export function useEliminarPedidoMutation() {
     },
   })
 }
+
+// =========================================================================
+// Entregas Masivas
+// =========================================================================
+
+async function fetchPedidosNoEntregados(): Promise<PedidoDB[]> {
+  const { data, error } = await supabase
+    .from('pedidos')
+    .select('*, cliente:clientes(id, nombre_fantasia, direccion)')
+    .not('estado', 'in', '("entregado","cancelado")')
+    .order('created_at', { ascending: false })
+
+  if (error) throw error
+
+  // Enrich with transportista names
+  const transportistaIds = new Set<string>()
+  for (const pedido of (data || [])) {
+    if (pedido.transportista_id) transportistaIds.add(pedido.transportista_id as string)
+  }
+
+  let perfilesMap: Record<string, PerfilDB> = {}
+  if (transportistaIds.size > 0) {
+    const { data: perfiles } = await supabase
+      .from('perfiles')
+      .select('id, nombre, email')
+      .in('id', Array.from(transportistaIds))
+
+    if (perfiles) {
+      perfilesMap = Object.fromEntries(
+        (perfiles as PerfilDB[]).map(p => [p.id, p])
+      )
+    }
+  }
+
+  return (data || []).map(pedido => ({
+    ...pedido,
+    transportista: pedido.transportista_id ? perfilesMap[pedido.transportista_id] : null,
+  })) as PedidoDB[]
+}
+
+/**
+ * Hook para obtener todos los pedidos no entregados/cancelados (sin paginacion)
+ * Se habilita solo cuando enabled=true (modal abierto)
+ */
+export function usePedidosNoEntregadosQuery(enabled = false) {
+  return useQuery({
+    queryKey: [...pedidosKeys.all, 'no-entregados'] as const,
+    queryFn: fetchPedidosNoEntregados,
+    enabled,
+    staleTime: 30 * 1000, // 30 segundos
+  })
+}
+
+async function entregarPedidosMasivo(pedidoIds: string[], transportistaId: string): Promise<void> {
+  const ahora = new Date().toISOString()
+
+  const { error } = await supabase
+    .from('pedidos')
+    .update({
+      transportista_id: transportistaId,
+      estado: 'entregado',
+      fecha_entrega: ahora,
+    })
+    .in('id', pedidoIds)
+
+  if (error) throw error
+
+  // Registrar historial best-effort
+  const historialEntries = pedidoIds.map(pedidoId => ({
+    pedido_id: pedidoId,
+    accion: 'entregado',
+    descripcion: `Entrega masiva - Transportista: ${transportistaId}`,
+    fecha: ahora,
+  }))
+
+  await supabase.from('pedido_historial').insert(historialEntries).then(() => {})
+}
+
+/**
+ * Hook para marcar multiples pedidos como entregados
+ */
+export function useEntregasMasivasMutation() {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: ({ pedidoIds, transportistaId }: { pedidoIds: string[]; transportistaId: string }) =>
+      entregarPedidosMasivo(pedidoIds, transportistaId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: pedidosKeys.all })
+    },
+  })
+}
+
+// =========================================================================
+// Cancelar Pedido
+// =========================================================================
+
+async function cancelarPedido(pedidoId: string, motivo: string): Promise<PedidoDB> {
+  const { data, error } = await supabase
+    .from('pedidos')
+    .update({
+      estado: 'cancelado',
+      motivo_cancelacion: motivo,
+    })
+    .eq('id', pedidoId)
+    .select()
+    .single()
+
+  if (error) throw error
+  return data as PedidoDB
+}
+
+/**
+ * Hook para cancelar un pedido con motivo
+ */
+export function useCancelarPedidoMutation() {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: ({ pedidoId, motivo }: { pedidoId: string; motivo: string }) =>
+      cancelarPedido(pedidoId, motivo),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: pedidosKeys.all })
+    },
+  })
+}

--- a/src/types/hooks.ts
+++ b/src/types/hooks.ts
@@ -93,6 +93,7 @@ export interface PedidoDB {
   total: number;
   monto_pagado?: number;
   notas?: string | null;
+  motivo_cancelacion?: string | null;
   orden_entrega?: number | null;
   items?: PedidoItemDB[];
   salvedades?: PedidoSalvedadResumen[];

--- a/supabase/migrations/20260323_add_motivo_cancelacion.sql
+++ b/supabase/migrations/20260323_add_motivo_cancelacion.sql
@@ -1,0 +1,3 @@
+-- Add motivo_cancelacion column to pedidos table
+-- Stores the reason when an order is cancelled (estado = 'cancelado')
+ALTER TABLE pedidos ADD COLUMN IF NOT EXISTS motivo_cancelacion TEXT;


### PR DESCRIPTION
Add "Entregas Masivas" button (admin only) to mark multiple orders as delivered at once with a selected driver, loading all undelivered orders regardless of pagination. Add "Cancelar Pedido" action with mandatory reason field, keeping cancelled orders visible with motivo displayed.