### PR TITLE
feat: add minimum order quantity and rename to Condiciones Mayoristas

### DIFF
--- a/migrations/036_cantidad_minima_pedido.sql
+++ b/migrations/036_cantidad_minima_pedido.sql
@@ -1,0 +1,13 @@
+-- Migración 036: Cantidad mínima de pedido por producto en grupos mayoristas
+-- Permite configurar un MOQ (minimum order quantity) por producto dentro de cada grupo.
+-- NULL = sin mínimo (backward compatible).
+
+ALTER TABLE grupo_precio_productos
+  ADD COLUMN cantidad_minima_pedido INTEGER DEFAULT NULL;
+
+ALTER TABLE grupo_precio_productos
+  ADD CONSTRAINT chk_cantidad_minima_pedido_positiva
+  CHECK (cantidad_minima_pedido IS NULL OR cantidad_minima_pedido > 0);
+
+COMMENT ON COLUMN grupo_precio_productos.cantidad_minima_pedido
+  IS 'Cantidad mínima de pedido por producto dentro de este grupo. NULL = sin mínimo.';

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -221,7 +221,7 @@ function MainApp(): ReactElement {
                 />
 
                 <Route
-                  path="/precios-mayoristas"
+                  path="/condiciones-mayoristas"
                   element={isAdmin ? <GruposPrecioContainer /> : <Navigate to="/pedidos" replace />}
                 />
 

--- a/src/components/layout/TopNavigation.tsx
+++ b/src/components/layout/TopNavigation.tsx
@@ -69,7 +69,7 @@ const menuGroups: MenuGroup[] = [
       { id: 'productos', icon: Package, label: 'Productos', roles: ['admin', 'preventista', 'deposito'] },
       { id: 'compras', icon: ShoppingBag, label: 'Compras', roles: ['admin'] },
       { id: 'proveedores', icon: Building2, label: 'Proveedores', roles: ['admin'] },
-      { id: 'precios-mayoristas', icon: Tag, label: 'Precios Mayoristas', roles: ['admin'] },
+      { id: 'condiciones-mayoristas', icon: Tag, label: 'Condiciones Mayoristas', roles: ['admin'] },
     ]
   },
   {

--- a/src/components/modals/ModalEditarPedido.tsx
+++ b/src/components/modals/ModalEditarPedido.tsx
@@ -100,7 +100,7 @@ const ModalEditarPedido = memo(function ModalEditarPedido({
     });
   }, [items, productos]);
 
-  const { itemsConPrecioMayorista, totalMayorista: totalCalculado } = usePrecioMayorista(itemsConPrecioBase);
+  const { itemsConPrecioMayorista, totalMayorista: totalCalculado, moqMap } = usePrecioMayorista(itemsConPrecioBase);
 
   // Mapa de precios resueltos para mostrar en cada item
   const preciosResueltosMap = useMemo(() => {
@@ -172,7 +172,9 @@ const ModalEditarPedido = memo(function ModalEditarPedido({
     setErrorStock(null);
     setItems(prev => prev.map(item => {
       if (item.productoId === productoId) {
-        const nuevaCantidad = Math.max(1, item.cantidad + delta);
+        const moq = moqMap.get(String(productoId));
+        const minCantidad = moq && moq > 1 ? moq : 1;
+        const nuevaCantidad = Math.max(minCantidad, item.cantidad + delta);
         // Verificar stock disponible
         const producto = productos.find(p => p.id === productoId);
         const cantidadOriginal = itemsOriginales.find(o => o.productoId === productoId)?.cantidad || 0;
@@ -193,10 +195,12 @@ const ModalEditarPedido = memo(function ModalEditarPedido({
   };
 
   const handleAgregarProducto = (producto: ProductoDB): void => {
+    const moq = moqMap.get(String(producto.id));
+    const cantidadInicial = moq && moq > 1 ? moq : 1;
     setItems(prev => [...prev, {
       productoId: producto.id,
       nombre: producto.nombre,
-      cantidad: 1,
+      cantidad: cantidadInicial,
       precioUnitario: producto.precio,
       cantidadOriginal: 0,
       esNuevo: true
@@ -399,7 +403,7 @@ const ModalEditarPedido = memo(function ModalEditarPedido({
                         <div className="flex items-center border dark:border-gray-600 rounded-lg">
                           <button
                             onClick={() => handleCantidadChange(item.productoId, -1)}
-                            disabled={item.cantidad <= 1}
+                            disabled={item.cantidad <= (moqMap.get(String(item.productoId)) || 1)}
                             className="p-1.5 hover:bg-gray-100 dark:hover:bg-gray-700 disabled:opacity-50 rounded-l-lg"
                           >
                             <Minus className="w-4 h-4" />

--- a/src/components/modals/ModalGrupoPrecio.tsx
+++ b/src/components/modals/ModalGrupoPrecio.tsx
@@ -1,11 +1,11 @@
 /**
  * ModalGrupoPrecio
  *
- * Modal para crear/editar un grupo de precio mayorista.
- * Incluye: nombre, descripción, selector de productos, editor de escalas.
+ * Modal para crear/editar una condición mayorista.
+ * Incluye: nombre, descripción, selector de productos con cantidad mínima, editor de escalas.
  */
 import { useState, useMemo } from 'react'
-import { X, Plus, Trash2, Search } from 'lucide-react'
+import { X, Plus, Trash2, Search, Copy } from 'lucide-react'
 import { formatPrecio } from '../../utils/formatters'
 import type { GrupoPrecioConDetalles, GrupoPrecioFormInput, ProductoDB } from '../../types'
 
@@ -42,6 +42,18 @@ export default function ModalGrupoPrecio({
       etiqueta: e.etiqueta || '',
     })) || [{ cantidadMinima: '', precioUnitario: '', etiqueta: '' }]
   )
+  const [moqPorProducto, setMoqPorProducto] = useState<Map<string, string>>(() => {
+    const map = new Map<string, string>()
+    if (grupo?.productos) {
+      for (const p of grupo.productos) {
+        if (p.cantidad_minima_pedido && p.cantidad_minima_pedido > 0) {
+          map.set(String(p.producto_id), String(p.cantidad_minima_pedido))
+        }
+      }
+    }
+    return map
+  })
+  const [moqGlobal, setMoqGlobal] = useState('')
   const [busquedaProducto, setBusquedaProducto] = useState('')
   const [error, setError] = useState('')
   const [guardando, setGuardando] = useState(false)
@@ -63,8 +75,32 @@ export default function ModalGrupoPrecio({
       const next = new Set(prev)
       if (next.has(id)) {
         next.delete(id)
+        setMoqPorProducto(prev => { const m = new Map(prev); m.delete(id); return m })
       } else {
         next.add(id)
+      }
+      return next
+    })
+  }
+
+  const actualizarMoqProducto = (productoId: string, value: string) => {
+    setMoqPorProducto(prev => {
+      const next = new Map(prev)
+      if (!value || value === '0') {
+        next.delete(productoId)
+      } else {
+        next.set(productoId, value)
+      }
+      return next
+    })
+  }
+
+  const aplicarMoqATodos = () => {
+    if (!moqGlobal || parseInt(moqGlobal) <= 0) return
+    setMoqPorProducto(() => {
+      const next = new Map<string, string>()
+      for (const pid of productoIds) {
+        next.set(pid, moqGlobal)
       }
       return next
     })
@@ -122,10 +158,17 @@ export default function ModalGrupoPrecio({
 
     setGuardando(true)
     try {
+      const cantidadesMinimas: Record<string, number | null> = {}
+      for (const [pid, val] of moqPorProducto) {
+        const parsed = parseInt(val)
+        cantidadesMinimas[pid] = !isNaN(parsed) && parsed > 0 ? parsed : null
+      }
+
       const result = await onSave({
         nombre: nombre.trim(),
         descripcion: descripcion.trim() || null,
         productoIds: Array.from(productoIds),
+        cantidadesMinimas,
         escalas: escalasValidas.map(e => ({
           cantidadMinima: parseInt(e.cantidadMinima),
           precioUnitario: parseFloat(e.precioUnitario),
@@ -148,7 +191,7 @@ export default function ModalGrupoPrecio({
         {/* Header */}
         <div className="flex justify-between items-center p-4 border-b dark:border-gray-700">
           <h2 className="text-xl font-semibold dark:text-white">
-            {isEditing ? 'Editar Grupo de Precio' : 'Nuevo Grupo de Precio'}
+            {isEditing ? 'Editar Condicion Mayorista' : 'Nueva Condicion Mayorista'}
           </h2>
           <button onClick={onClose}>
             <X className="w-6 h-6 text-gray-500 dark:text-gray-400" />
@@ -205,15 +248,14 @@ export default function ModalGrupoPrecio({
                   return (
                     <div
                       key={p.id}
-                      onClick={() => toggleProducto(String(p.id))}
-                      className={`flex items-center justify-between p-2.5 border-b dark:border-gray-700 cursor-pointer transition-colors ${
+                      className={`flex items-center justify-between p-2.5 border-b dark:border-gray-700 transition-colors ${
                         isSelected
                           ? 'bg-blue-50 dark:bg-blue-900/20'
                           : 'hover:bg-gray-50 dark:hover:bg-gray-700'
                       }`}
                     >
-                      <div className="flex items-center gap-2">
-                        <div className={`w-4 h-4 rounded border-2 flex items-center justify-center ${
+                      <div className="flex items-center gap-2 cursor-pointer flex-1" onClick={() => toggleProducto(String(p.id))}>
+                        <div className={`w-4 h-4 rounded border-2 flex items-center justify-center flex-shrink-0 ${
                           isSelected
                             ? 'bg-blue-600 border-blue-600'
                             : 'border-gray-300 dark:border-gray-500'
@@ -227,12 +269,48 @@ export default function ModalGrupoPrecio({
                           )}
                         </div>
                       </div>
-                      <span className="text-sm text-gray-500">{formatPrecio(p.precio)}</span>
+                      <div className="flex items-center gap-2">
+                        {isSelected && (
+                          <input
+                            type="number"
+                            min="1"
+                            value={moqPorProducto.get(String(p.id)) || ''}
+                            onChange={e => actualizarMoqProducto(String(p.id), e.target.value)}
+                            onClick={e => e.stopPropagation()}
+                            className="w-16 px-2 py-1 border rounded text-xs text-center dark:bg-gray-700 dark:border-gray-600 dark:text-white"
+                            placeholder="Min"
+                            title="Cantidad minima de pedido"
+                          />
+                        )}
+                        <span className="text-sm text-gray-500 w-20 text-right">{formatPrecio(p.precio)}</span>
+                      </div>
                     </div>
                   )
                 })
               )}
             </div>
+
+            {/* Aplicar cantidad mínima a todos */}
+            {productoIds.size > 0 && (
+              <div className="flex items-center gap-2 mt-2">
+                <input
+                  type="number"
+                  min="1"
+                  value={moqGlobal}
+                  onChange={e => setMoqGlobal(e.target.value)}
+                  className="w-24 px-2 py-1.5 border rounded-lg text-sm dark:bg-gray-700 dark:border-gray-600 dark:text-white"
+                  placeholder="Cant. min"
+                />
+                <button
+                  onClick={aplicarMoqATodos}
+                  disabled={!moqGlobal || parseInt(moqGlobal) <= 0}
+                  className="flex items-center gap-1 text-sm text-blue-600 hover:text-blue-700 disabled:text-gray-400"
+                >
+                  <Copy className="w-3 h-3" /> Aplicar a todos
+                </button>
+                <span className="text-xs text-gray-400">Cantidad minima de pedido</span>
+              </div>
+            )}
           </div>
 
           {/* Editor de escalas */}
@@ -335,7 +413,7 @@ export default function ModalGrupoPrecio({
               {guardando && (
                 <div className="w-4 h-4 border-2 border-white border-t-transparent rounded-full animate-spin" />
               )}
-              {isEditing ? 'Guardar cambios' : 'Crear grupo'}
+              {isEditing ? 'Guardar cambios' : 'Crear condicion'}
             </button>
           </div>
         </div>

--- a/src/components/modals/ModalPedido.tsx
+++ b/src/components/modals/ModalPedido.tsx
@@ -192,8 +192,8 @@ const ModalPedido = memo(function ModalPedido({
 
   const calcularTotal = (): number => nuevoPedido.items.reduce((t, i) => t + (i.precioUnitario * i.cantidad), 0);
 
-  // Precios mayoristas
-  const { preciosResueltos, faltantes, totalMayorista, totalOriginal, ahorro, hayMayorista } = usePrecioMayorista(nuevoPedido.items);
+  // Precios mayoristas y cantidades mínimas
+  const { preciosResueltos, faltantes, totalMayorista, totalOriginal, ahorro, hayMayorista, moqMap, violacionesMOQ } = usePrecioMayorista(nuevoPedido.items);
 
   return (
     <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center p-4 z-50">
@@ -400,21 +400,25 @@ const ModalPedido = memo(function ModalPedido({
             {productosFiltrados.length === 0 ? (
               <p className="p-4 text-center text-gray-500">No se encontraron productos</p>
             ) : (
-              productosFiltrados.map(p => (
-                <div key={p.id} className="flex justify-between items-center p-3 hover:bg-gray-50 border-b cursor-pointer" onClick={() => onAgregarItem(p.id)}>
-                  <div>
-                    <p className="font-medium">{p.nombre}</p>
-                    <p className="text-sm text-gray-500">
-                      Stock: {p.stock}
-                      {p.categoria && <span className="ml-2 px-2 py-0.5 bg-gray-100 rounded text-xs">{p.categoria}</span>}
-                    </p>
+              productosFiltrados.map(p => {
+                const moq = moqMap.get(String(p.id))
+                return (
+                  <div key={p.id} className="flex justify-between items-center p-3 hover:bg-gray-50 border-b cursor-pointer" onClick={() => onAgregarItem(p.id, moq || 1)}>
+                    <div>
+                      <p className="font-medium">{p.nombre}</p>
+                      <p className="text-sm text-gray-500">
+                        Stock: {p.stock}
+                        {p.categoria && <span className="ml-2 px-2 py-0.5 bg-gray-100 rounded text-xs">{p.categoria}</span>}
+                        {moq && moq > 1 && <span className="ml-2 px-2 py-0.5 bg-amber-100 text-amber-700 rounded text-xs font-medium">Min: {moq}</span>}
+                      </p>
+                    </div>
+                    <div className="text-right">
+                      <p className="font-semibold text-blue-600">{formatPrecio(p.precio)}</p>
+                      <span className="text-sm text-blue-500">+ Agregar</span>
+                    </div>
                   </div>
-                  <div className="text-right">
-                    <p className="font-semibold text-blue-600">{formatPrecio(p.precio)}</p>
-                    <span className="text-sm text-blue-500">+ Agregar</span>
-                  </div>
-                </div>
-              ))
+                )
+              })
             )}
           </div>
 
@@ -430,6 +434,8 @@ const ModalPedido = memo(function ModalPedido({
                   const esMayorista = precioInfo?.esMayorista || false;
                   const precioMostrar = esMayorista ? precioInfo!.precioResuelto : item.precioUnitario;
                   const subtotal = precioMostrar * item.cantidad;
+                  const itemMoq = moqMap.get(String(item.productoId));
+                  const minCantidad = itemMoq && itemMoq > 1 ? itemMoq : 1;
                   return (
                     <div key={item.productoId} className="p-3">
                       <div className="flex justify-between items-center">
@@ -451,9 +457,12 @@ const ModalPedido = memo(function ModalPedido({
                           ) : (
                             <p className="text-sm text-gray-500">{formatPrecio(item.precioUnitario)} c/u</p>
                           )}
+                          {itemMoq && itemMoq > 1 && (
+                            <p className="text-xs text-amber-600 mt-0.5">Pedido minimo: {itemMoq} unidades</p>
+                          )}
                         </div>
                         <div className="flex items-center space-x-3">
-                          <button onClick={(e) => { e.stopPropagation(); onActualizarCantidad(item.productoId, item.cantidad - 1); }} className="w-8 h-8 rounded-full bg-gray-200 hover:bg-gray-300">-</button>
+                          <button onClick={(e) => { e.stopPropagation(); onActualizarCantidad(item.productoId, Math.max(item.cantidad - 1, minCantidad)); }} className={`w-8 h-8 rounded-full ${item.cantidad <= minCantidad ? 'bg-gray-100 text-gray-400' : 'bg-gray-200 hover:bg-gray-300'}`} disabled={item.cantidad <= minCantidad}>-</button>
                           <span className="w-8 text-center font-medium">{item.cantidad}</span>
                           <button onClick={(e) => { e.stopPropagation(); onActualizarCantidad(item.productoId, item.cantidad + 1); }} className="w-8 h-8 rounded-full bg-gray-200 hover:bg-gray-300">+</button>
                           <p className="w-24 text-right font-semibold">{formatPrecio(subtotal)}</p>
@@ -496,7 +505,7 @@ const ModalPedido = memo(function ModalPedido({
           </div>
           <div className="flex justify-end space-x-3">
             <button onClick={onClose} className="px-4 py-2 text-gray-700 hover:bg-gray-200 rounded-lg">Cancelar</button>
-            <button onClick={onGuardar} disabled={guardando} className="px-6 py-2 bg-green-600 text-white rounded-lg hover:bg-green-700 flex items-center">
+            <button onClick={onGuardar} disabled={guardando || violacionesMOQ.length > 0} className="px-6 py-2 bg-green-600 text-white rounded-lg hover:bg-green-700 disabled:bg-gray-400 flex items-center">
               {guardando && <Loader2 className="w-4 h-4 mr-2 animate-spin" />}Confirmar
             </button>
           </div>

--- a/src/components/vistas/VistaGruposPrecio.tsx
+++ b/src/components/vistas/VistaGruposPrecio.tsx
@@ -46,9 +46,9 @@ export default function VistaGruposPrecio({
       {/* Header */}
       <div className="flex justify-between items-center">
         <div>
-          <h1 className="text-2xl font-bold dark:text-white">Precios Mayoristas</h1>
+          <h1 className="text-2xl font-bold dark:text-white">Condiciones Mayoristas</h1>
           <p className="text-sm text-gray-500 dark:text-gray-400 mt-1">
-            Configura grupos de productos con precios por volumen
+            Configura precios por volumen y cantidades minimas de pedido
           </p>
         </div>
         <button
@@ -64,9 +64,9 @@ export default function VistaGruposPrecio({
       {grupos.length === 0 ? (
         <div className="text-center py-16 bg-white dark:bg-gray-800 rounded-xl border dark:border-gray-700">
           <Tag className="w-12 h-12 text-gray-300 mx-auto mb-4" />
-          <h3 className="text-lg font-medium text-gray-500 dark:text-gray-400">Sin grupos de precio</h3>
+          <h3 className="text-lg font-medium text-gray-500 dark:text-gray-400">Sin condiciones mayoristas</h3>
           <p className="text-sm text-gray-400 dark:text-gray-500 mt-1">
-            Crea un grupo para definir precios mayoristas por volumen
+            Crea una condicion para definir precios y cantidades minimas
           </p>
           <button
             onClick={onNuevoGrupo}
@@ -141,6 +141,11 @@ export default function VistaGruposPrecio({
                       className="text-xs px-2.5 py-1 bg-blue-50 dark:bg-blue-900/20 text-blue-700 dark:text-blue-300 rounded-full"
                     >
                       {getProductoNombre(gpp.producto_id)}
+                      {gpp.cantidad_minima_pedido && gpp.cantidad_minima_pedido > 0 && (
+                        <span className="ml-1 text-amber-600 dark:text-amber-400 font-medium">
+                          (min {gpp.cantidad_minima_pedido})
+                        </span>
+                      )}
                     </span>
                   ))}
                   {grupo.productos.length === 0 && (

--- a/src/hooks/handlers/usePedidoHandlers.ts
+++ b/src/hooks/handlers/usePedidoHandlers.ts
@@ -7,7 +7,7 @@ import { useCallback, type Dispatch, type SetStateAction } from 'react'
 import { useLatestRef } from '../useLatestRef'
 import { calcularTotalPedido } from '../useAppState'
 import { usePricingMapQuery } from '../queries/useGruposPrecioQuery'
-import { resolverPreciosMayorista, aplicarPreciosMayorista } from '../../utils/precioMayorista'
+import { resolverPreciosMayorista, aplicarPreciosMayorista, validarMOQPedido } from '../../utils/precioMayorista'
 import type { User } from '@supabase/supabase-js'
 import type {
   ProductoDB,
@@ -355,8 +355,18 @@ export function usePedidoHandlers({
       return
     }
 
-    // Aplicar precios mayoristas si hay pricing map disponible
+    // Validar cantidades mínimas de pedido
     const currentPricingMap = pricingMapRef.current
+    if (currentPricingMap && currentPricingMap.size > 0) {
+      const violaciones = validarMOQPedido(nuevoPedido.items, currentPricingMap)
+      if (violaciones.length > 0) {
+        const mensajes = violaciones.map(v => `${productosRef.current.find(p => p.id === v.productoId)?.nombre || 'Producto'}: mínimo ${v.cantidadMinima} unidades`)
+        notify.error(`Cantidad mínima no alcanzada:\n${mensajes.join('\n')}`, 5000)
+        return
+      }
+    }
+
+    // Aplicar precios mayoristas si hay pricing map disponible
     let itemsFinales = nuevoPedido.items
     if (currentPricingMap && currentPricingMap.size > 0) {
       const preciosResueltos = resolverPreciosMayorista(nuevoPedido.items, currentPricingMap)
@@ -420,7 +430,7 @@ export function usePedidoHandlers({
       notify.error('Error al crear pedido: ' + error.message)
     }
     setGuardando(false)
-  }, [nuevoPedidoRef, userRef, isOnlineRef, pricingMapRef, validarStock, guardarPedidoOffline, resetNuevoPedido, modales.pedido, crearPedido, descontarStock, registrarPago, refetchProductos, refetchMetricas, notify, setGuardando])
+  }, [nuevoPedidoRef, userRef, isOnlineRef, pricingMapRef, productosRef, validarStock, guardarPedidoOffline, resetNuevoPedido, modales.pedido, crearPedido, descontarStock, registrarPago, refetchProductos, refetchMetricas, notify, setGuardando])
 
   // State change handlers
   const handleMarcarEntregado = useCallback((pedido: PedidoDB): void => {

--- a/src/hooks/queries/useGruposPrecioQuery.ts
+++ b/src/hooks/queries/useGruposPrecioQuery.ts
@@ -92,11 +92,19 @@ async function fetchPricingMap(): Promise<PricingMap> {
 
     const productoIds = grupo.productos.map(p => String(p.producto_id))
 
+    const moqPorProducto = new Map<string, number>()
+    for (const p of grupo.productos) {
+      if (p.cantidad_minima_pedido && p.cantidad_minima_pedido > 0) {
+        moqPorProducto.set(String(p.producto_id), p.cantidad_minima_pedido)
+      }
+    }
+
     const grupoInfo: GrupoPrecioInfo = {
       grupoId: String(grupo.id),
       grupoNombre: grupo.nombre,
       escalas: escalasActivas,
       productoIds,
+      moqPorProducto,
     }
 
     // Agregar el grupo a cada producto del grupo
@@ -133,6 +141,7 @@ async function createGrupoPrecio(input: GrupoPrecioFormInput): Promise<GrupoPrec
       .insert(input.productoIds.map(pid => ({
         grupo_precio_id: parseInt(grupoId),
         producto_id: parseInt(pid),
+        cantidad_minima_pedido: input.cantidadesMinimas?.[pid] || null,
       })))
 
     if (errorProductos) throw errorProductos
@@ -196,6 +205,7 @@ async function updateGrupoPrecio(
       .insert(input.productoIds.map(pid => ({
         grupo_precio_id: parseInt(id),
         producto_id: parseInt(pid),
+        cantidad_minima_pedido: input.cantidadesMinimas?.[pid] || null,
       })))
 
     if (errorProductos) throw errorProductos

--- a/src/hooks/usePrecioMayorista.ts
+++ b/src/hooks/usePrecioMayorista.ts
@@ -10,9 +10,12 @@ import {
   resolverPreciosMayorista,
   calcularFaltanteParaTier,
   aplicarPreciosMayorista,
+  construirMOQMap,
+  validarMOQPedido,
   type ItemPedido,
   type PrecioResuelto,
   type FaltanteParaTier,
+  type ViolacionMOQ,
   type PricingMap
 } from '../utils/precioMayorista'
 
@@ -33,6 +36,10 @@ interface UsePrecioMayoristaReturn {
   hayMayorista: boolean
   /** Si el pricing map está cargando */
   isLoading: boolean
+  /** Mapa de productoId → cantidad mínima de pedido (solo productos con MOQ > 1) */
+  moqMap: Map<string, number>
+  /** Items que no cumplen la cantidad mínima de pedido */
+  violacionesMOQ: ViolacionMOQ[]
 }
 
 /**
@@ -85,6 +92,16 @@ export function usePrecioMayorista(items: ItemPedido[]): UsePrecioMayoristaRetur
     return false
   }, [preciosResueltos])
 
+  const moqMap = useMemo(() => {
+    if (!pricingMap || pricingMap.size === 0) return new Map<string, number>()
+    return construirMOQMap(items, pricingMap)
+  }, [items, pricingMap])
+
+  const violacionesMOQ = useMemo(() => {
+    if (!pricingMap || pricingMap.size === 0 || items.length === 0) return []
+    return validarMOQPedido(items, pricingMap)
+  }, [items, pricingMap])
+
   return {
     preciosResueltos,
     faltantes,
@@ -94,5 +111,7 @@ export function usePrecioMayorista(items: ItemPedido[]): UsePrecioMayoristaRetur
     ahorro: totalOriginal - totalMayorista,
     hayMayorista,
     isLoading,
+    moqMap,
+    violacionesMOQ,
   }
 }

--- a/src/types/hooks.ts
+++ b/src/types/hooks.ts
@@ -1257,6 +1257,7 @@ export interface GrupoPrecioProductoDB {
   id: string;
   grupo_precio_id: string;
   producto_id: string;
+  cantidad_minima_pedido?: number | null;
   created_at?: string;
 }
 
@@ -1279,6 +1280,7 @@ export interface GrupoPrecioFormInput {
   nombre: string;
   descripcion?: string | null;
   productoIds: string[];
+  cantidadesMinimas?: Record<string, number | null>;
   escalas: Array<{
     cantidadMinima: number;
     precioUnitario: number;

--- a/src/utils/precioMayorista.ts
+++ b/src/utils/precioMayorista.ts
@@ -24,6 +24,7 @@ export interface GrupoPrecioInfo {
   grupoNombre: string
   escalas: EscalaPrecio[]
   productoIds: string[]
+  moqPorProducto: Map<string, number>
 }
 
 /** Mapa de productoId → grupos a los que pertenece */
@@ -230,4 +231,70 @@ export function aplicarPreciosMayorista(
     }
     return item
   })
+}
+
+// =============================================================================
+// CANTIDAD MÍNIMA DE PEDIDO (MOQ)
+// =============================================================================
+
+export interface ViolacionMOQ {
+  productoId: string
+  cantidadActual: number
+  cantidadMinima: number
+  grupoNombre: string
+}
+
+/**
+ * Obtiene el MOQ efectivo de un producto.
+ * Si pertenece a varios grupos, toma el más restrictivo (máximo).
+ * Retorna 1 si no tiene MOQ configurado.
+ */
+export function obtenerMOQ(productoId: string, pricingMap: PricingMap): number {
+  const grupos = pricingMap.get(String(productoId))
+  if (!grupos) return 1
+  let maxMoq = 1
+  for (const grupo of grupos) {
+    const moq = grupo.moqPorProducto.get(String(productoId))
+    if (moq && moq > maxMoq) maxMoq = moq
+  }
+  return maxMoq
+}
+
+/**
+ * Construye un mapa de productoId → MOQ efectivo para una lista de items.
+ */
+export function construirMOQMap(items: ItemPedido[], pricingMap: PricingMap): Map<string, number> {
+  const map = new Map<string, number>()
+  for (const item of items) {
+    const moq = obtenerMOQ(item.productoId, pricingMap)
+    if (moq > 1) {
+      map.set(String(item.productoId), moq)
+    }
+  }
+  return map
+}
+
+/**
+ * Valida que todos los items cumplan con su cantidad mínima de pedido.
+ * Retorna las violaciones encontradas.
+ */
+export function validarMOQPedido(items: ItemPedido[], pricingMap: PricingMap): ViolacionMOQ[] {
+  const violaciones: ViolacionMOQ[] = []
+  for (const item of items) {
+    const grupos = pricingMap.get(String(item.productoId))
+    if (!grupos) continue
+    for (const grupo of grupos) {
+      const moq = grupo.moqPorProducto.get(String(item.productoId))
+      if (moq && item.cantidad < moq) {
+        violaciones.push({
+          productoId: String(item.productoId),
+          cantidadActual: item.cantidad,
+          cantidadMinima: moq,
+          grupoNombre: grupo.grupoNombre,
+        })
+        break // Una violación por producto es suficiente
+      }
+    }
+  }
+  return violaciones
 }


### PR DESCRIPTION
Add per-product minimum order quantity (MOQ) configurable from the wholesale conditions panel. Rename "Precios Mayoristas" to "Condiciones Mayoristas" to reflect the broader scope of wholesale business rules.

- New DB column cantidad_minima_pedido on grupo_precio_productos
- Admin UI: per-product MOQ input + "apply to all" shortcut
- Order flow: enforce MOQ with visual badges, clamp quantities, block submit
- Route renamed to /condiciones-mayoristas