### PR TITLE
fix: don't block error propagation on login failure signOut

### DIFF
--- a/e2e/login.spec.js
+++ b/e2e/login.spec.js
@@ -32,7 +32,7 @@ test.describe('Login', () => {
     await page.getByRole('button', { name: /ingresar/i }).click()
 
     // Verificar mensaje de error (auth timeout is 15s, plus render time)
-    await expect(page.getByText(/incorrectos|inválido|error|timed out/i)).toBeVisible({ timeout: 25000 })
+    await expect(page.getByText(/incorrectos|inválido|error|timed out/i)).toBeVisible({ timeout: 20000 })
   })
 
   test('debe validar campo de email vacío', async ({ page }) => {

--- a/src/hooks/supabase/useAuth.tsx
+++ b/src/hooks/supabase/useAuth.tsx
@@ -400,7 +400,9 @@ export function AuthProvider({ children }: AuthProviderProps) {
 
       return data
     } catch (err) {
-      await signOutLocal('login:error')
+      // Fire-and-forget: don't block error propagation if signOut hangs
+      // (e.g. Supabase unreachable in CI)
+      signOutLocal('login:error').catch(() => {})
       throw err
     } finally {
       if (mountedRef.current) {


### PR DESCRIPTION
signOutLocal in the login catch was awaited, which blocks error propagation to LoginScreen if supabase.auth.signOut() hangs (e.g. Supabase unreachable in CI). Changed to fire-and-forget so the error message is shown immediately.