### PR TITLE
fix: don't unmount LoginScreen during auth failure

### DIFF
--- a/src/hooks/supabase/useAuth.tsx
+++ b/src/hooks/supabase/useAuth.tsx
@@ -376,9 +376,10 @@ export function AuthProvider({ children }: AuthProviderProps) {
 
   const login = async (email: string, password: string) => {
     beginAuthTrace('login')
-    if (mountedRef.current) {
-      setAuthTransitionLoading(true)
-    }
+    // NOTE: Don't set authTransitionLoading here. It causes AppContent to
+    // show the global spinner which unmounts LoginScreen. If signIn fails,
+    // the remounted LoginScreen loses the error state. Instead, we only
+    // set it after signIn succeeds (before profile fetch).
 
     try {
       const { data, error } = await withTimeout(
@@ -388,6 +389,11 @@ export function AuthProvider({ children }: AuthProviderProps) {
       )
       if (error) {
         throw error
+      }
+
+      // Only show global loading transition after successful auth
+      if (mountedRef.current) {
+        setAuthTransitionLoading(true)
       }
 
       if (data.user) {


### PR DESCRIPTION
authTransitionLoading was set to true immediately in login(), causing AppContent to show the global spinner and unmount LoginScreen. If signInWithPassword failed/timed out, the error was caught by the now- unmounted LoginScreen instance, and the newly mounted one had no error state. Fix: only set authTransitionLoading after signIn succeeds.