### PR TITLE
ux: reorganize order modal to prioritize product selection

### DIFF
--- a/src/components/modals/ModalPedido.tsx
+++ b/src/components/modals/ModalPedido.tsx
@@ -268,104 +268,37 @@ const ModalPedido = memo(function ModalPedido({
             )}
           </div>
 
-          {/* Fecha del pedido */}
-          <div>
-            <label className="block text-sm font-medium mb-1 dark:text-gray-200">
-              <Calendar className="w-4 h-4 inline mr-1" />
-              Fecha del pedido
+          {/* Fecha del pedido - compact inline */}
+          <div className="flex items-center gap-3">
+            <label className="text-sm font-medium dark:text-gray-200 whitespace-nowrap flex items-center gap-1">
+              <Calendar className="w-4 h-4" />
+              Fecha
             </label>
             <input
               type="date"
               value={nuevoPedido.fecha || new Date().toISOString().split('T')[0]}
               onChange={e => onFechaChange && onFechaChange(e.target.value)}
               max={new Date().toISOString().split('T')[0]}
-              className="w-full px-3 py-2 border rounded-lg bg-white dark:bg-gray-700 dark:border-gray-600 dark:text-white"
+              className="flex-1 px-3 py-1.5 border rounded-lg bg-white dark:bg-gray-700 dark:border-gray-600 dark:text-white text-sm"
             />
             {nuevoPedido.fecha && nuevoPedido.fecha !== new Date().toISOString().split('T')[0] && (
-              <p className="text-xs text-amber-600 mt-1">Se registrará con fecha distinta a hoy</p>
+              <p className="text-xs text-amber-600 whitespace-nowrap">Fecha distinta a hoy</p>
             )}
           </div>
 
-          {/* Seccion Notas */}
-          <div>
-            <label className="block text-sm font-medium mb-1 dark:text-gray-200">Notas / Observaciones</label>
-            <textarea
-              value={nuevoPedido.notas || ''}
-              onChange={e => onNotasChange && onNotasChange(e.target.value)}
-              className="w-full px-3 py-2 border rounded-lg bg-white dark:bg-gray-700 dark:border-gray-600 dark:text-white"
-              placeholder="Observaciones importantes para la preparacion del pedido..."
-              rows={2}
-            />
-          </div>
-
-          {/* Seccion Forma de Pago y Estado de Pago */}
-          <div className="grid grid-cols-2 gap-4">
-            <div>
-              <label className="block text-sm font-medium mb-1 dark:text-gray-200">Forma de Pago</label>
-              <select
-                value={nuevoPedido.formaPago || 'efectivo'}
-                onChange={e => onFormaPagoChange && onFormaPagoChange(e.target.value)}
-                className="w-full px-3 py-2 border rounded-lg bg-white dark:bg-gray-700 dark:border-gray-600 dark:text-white"
-              >
-                <option value="efectivo">Efectivo</option>
-                <option value="transferencia">Transferencia</option>
-                <option value="cheque">Cheque</option>
-                <option value="cuenta_corriente">Cuenta Corriente</option>
-                <option value="tarjeta">Tarjeta</option>
-              </select>
-            </div>
-            <div>
-              <label className="block text-sm font-medium mb-1 dark:text-gray-200">Estado de Pago</label>
-              <select
-                value={nuevoPedido.estadoPago || 'pendiente'}
-                onChange={e => onEstadoPagoChange && onEstadoPagoChange(e.target.value)}
-                className="w-full px-3 py-2 border rounded-lg bg-white dark:bg-gray-700 dark:border-gray-600 dark:text-white"
-              >
-                <option value="pendiente">Pendiente</option>
-                <option value="pagado">Pagado</option>
-                <option value="parcial">Parcial</option>
-              </select>
-            </div>
-          </div>
-
-          {/* Monto pagado si es pago parcial */}
-          {nuevoPedido.estadoPago === 'parcial' && (
-            <div className="p-3 bg-yellow-50 border border-yellow-200 rounded-lg">
-              <label className="block text-sm font-medium mb-1 text-yellow-800">Monto del pago parcial *</label>
-              <div className="flex items-center gap-2">
-                <span className="text-lg font-semibold text-yellow-700">$</span>
-                <input
-                  type="number"
-                  min="0"
-                  step="0.01"
-                  max={calcularTotal()}
-                  value={nuevoPedido.montoPagado || ''}
-                  onChange={e => onMontoPagadoChange && onMontoPagadoChange(parseFloat(e.target.value) || 0)}
-                  className="flex-1 px-3 py-2 border border-yellow-300 rounded-lg focus:ring-2 focus:ring-yellow-500 bg-white"
-                  placeholder="Ingrese el monto pagado"
-                />
-              </div>
-              {(nuevoPedido.montoPagado ?? 0) > 0 && (
-                <p className="text-sm text-yellow-700 mt-2">
-                  Resta por pagar: {formatPrecio(calcularTotal() - (nuevoPedido.montoPagado ?? 0))}
-                </p>
-              )}
-            </div>
-          )}
-
           {/* Seccion Productos con filtro por categoria */}
           <div>
-            <label className="block text-sm font-medium mb-1">Agregar Productos</label>
+            <label className="block text-sm font-medium mb-1 dark:text-gray-200">Agregar Productos</label>
 
             {/* Filtros de categoria */}
             {categorias.length > 0 && (
-              <div className="flex flex-wrap gap-2 mb-2">
+              <div className="flex flex-wrap gap-1.5 mb-2">
                 <button
                   onClick={() => setCategoriaSeleccionada('')}
-                  className={`px-3 py-1 rounded-full text-sm font-medium transition-colors ${
+                  className={`px-2.5 py-1 rounded-full text-xs font-medium transition-colors ${
                     categoriaSeleccionada === ''
                       ? 'bg-blue-600 text-white'
-                      : 'bg-gray-100 text-gray-700 hover:bg-gray-200'
+                      : 'bg-gray-100 text-gray-700 hover:bg-gray-200 dark:bg-gray-700 dark:text-gray-300'
                   }`}
                 >
                   Todos
@@ -377,10 +310,10 @@ const ModalPedido = memo(function ModalPedido({
                     <button
                       key={catKey}
                       onClick={() => setCategoriaSeleccionada(catValue)}
-                      className={`px-3 py-1 rounded-full text-sm font-medium transition-colors ${
+                      className={`px-2.5 py-1 rounded-full text-xs font-medium transition-colors ${
                         categoriaSeleccionada === catValue
                           ? 'bg-blue-600 text-white'
-                          : 'bg-gray-100 text-gray-700 hover:bg-gray-200'
+                          : 'bg-gray-100 text-gray-700 hover:bg-gray-200 dark:bg-gray-700 dark:text-gray-300'
                       }`}
                     >
                       {catValue}
@@ -391,30 +324,40 @@ const ModalPedido = memo(function ModalPedido({
             )}
 
             <div className="relative">
-              <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 text-gray-400 w-5 h-5" />
-              <input type="text" value={busquedaProducto} onChange={e => setBusquedaProducto(e.target.value)} className="w-full pl-10 pr-3 py-2 border rounded-lg" placeholder="Buscar producto..." />
+              <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 text-gray-400 w-4 h-4" />
+              <input type="text" value={busquedaProducto} onChange={e => setBusquedaProducto(e.target.value)} className="w-full pl-9 pr-3 py-2 border rounded-lg dark:bg-gray-700 dark:border-gray-600 dark:text-white" placeholder="Buscar producto..." />
             </div>
           </div>
 
-          <div className="border rounded-lg max-h-48 overflow-y-auto">
+          {/* Lista de productos disponibles - altura adaptativa */}
+          <div className="border dark:border-gray-600 rounded-lg max-h-[40vh] sm:max-h-64 overflow-y-auto">
             {productosFiltrados.length === 0 ? (
-              <p className="p-4 text-center text-gray-500">No se encontraron productos</p>
+              <p className="p-4 text-center text-gray-500 dark:text-gray-400">No se encontraron productos</p>
             ) : (
               productosFiltrados.map(p => {
                 const moq = moqMap.get(String(p.id))
+                const yaAgregado = nuevoPedido.items.some(i => i.productoId === p.id);
                 return (
-                  <div key={p.id} className="flex justify-between items-center p-3 hover:bg-gray-50 border-b cursor-pointer" onClick={() => onAgregarItem(p.id, moq || 1)}>
-                    <div>
-                      <p className="font-medium">{p.nombre}</p>
-                      <p className="text-sm text-gray-500">
+                  <div
+                    key={p.id}
+                    className={`flex justify-between items-center px-3 py-2.5 border-b dark:border-gray-600 cursor-pointer transition-colors ${
+                      yaAgregado
+                        ? 'bg-blue-50 dark:bg-blue-900/20'
+                        : 'hover:bg-gray-50 dark:hover:bg-gray-700'
+                    }`}
+                    onClick={() => onAgregarItem(p.id, moq || 1)}
+                  >
+                    <div className="min-w-0 flex-1">
+                      <p className="font-medium text-sm dark:text-white truncate">{p.nombre}</p>
+                      <p className="text-xs text-gray-500 dark:text-gray-400">
                         Stock: {p.stock}
-                        {p.categoria && <span className="ml-2 px-2 py-0.5 bg-gray-100 rounded text-xs">{p.categoria}</span>}
-                        {moq && moq > 1 && <span className="ml-2 px-2 py-0.5 bg-amber-100 text-amber-700 rounded text-xs font-medium">Min: {moq}</span>}
+                        {p.categoria && <span className="ml-1.5 px-1.5 py-0.5 bg-gray-100 dark:bg-gray-600 rounded text-xs">{p.categoria}</span>}
+                        {moq && moq > 1 && <span className="ml-1.5 px-1.5 py-0.5 bg-amber-100 text-amber-700 rounded text-xs font-medium">Min: {moq}</span>}
                       </p>
                     </div>
-                    <div className="text-right">
-                      <p className="font-semibold text-blue-600">{formatPrecio(p.precio)}</p>
-                      <span className="text-sm text-blue-500">+ Agregar</span>
+                    <div className="text-right ml-3 shrink-0">
+                      <p className="font-semibold text-sm text-blue-600 dark:text-blue-400">{formatPrecio(p.precio)}</p>
+                      <span className="text-xs text-blue-500">{yaAgregado ? '+ Mas' : '+ Agregar'}</span>
                     </div>
                   </div>
                 )
@@ -425,8 +368,8 @@ const ModalPedido = memo(function ModalPedido({
           {/* Items del pedido */}
           {nuevoPedido.items.length > 0 && (
             <div>
-              <h3 className="font-medium mb-2">Productos en el pedido</h3>
-              <div className="border rounded-lg divide-y">
+              <h3 className="font-medium mb-2 dark:text-white text-sm">Productos en el pedido ({nuevoPedido.items.length})</h3>
+              <div className="border dark:border-gray-600 rounded-lg divide-y dark:divide-gray-600">
                 {nuevoPedido.items.map(item => {
                   const prod = productos.find(p => p.id === item.productoId);
                   const warning = getStockWarning(item.productoId, item.cantidad);
@@ -437,39 +380,39 @@ const ModalPedido = memo(function ModalPedido({
                   const itemMoq = moqMap.get(String(item.productoId));
                   const minCantidad = itemMoq && itemMoq > 1 ? itemMoq : 1;
                   return (
-                    <div key={item.productoId} className="p-3">
-                      <div className="flex justify-between items-center">
-                        <div>
-                          <div className="flex items-center gap-2">
-                            <p className="font-medium">{prod?.nombre}</p>
+                    <div key={item.productoId} className="px-3 py-2.5">
+                      <div className="flex justify-between items-center gap-2">
+                        <div className="min-w-0 flex-1">
+                          <div className="flex items-center gap-1.5">
+                            <p className="font-medium text-sm dark:text-white truncate">{prod?.nombre}</p>
                             {esMayorista && (
-                              <span className="inline-flex items-center gap-0.5 text-xs px-1.5 py-0.5 bg-green-100 text-green-700 rounded-full font-medium">
+                              <span className="inline-flex items-center gap-0.5 text-xs px-1.5 py-0.5 bg-green-100 text-green-700 rounded-full font-medium shrink-0">
                                 <Tag className="w-3 h-3" />
                                 {precioInfo?.etiqueta || 'Mayorista'}
                               </span>
                             )}
                           </div>
                           {esMayorista ? (
-                            <p className="text-sm">
+                            <p className="text-xs">
                               <span className="text-gray-400 line-through">{formatPrecio(item.precioUnitario)}</span>
-                              <span className="ml-1.5 text-green-600 font-medium">{formatPrecio(precioInfo!.precioResuelto)} c/u</span>
+                              <span className="ml-1 text-green-600 font-medium">{formatPrecio(precioInfo!.precioResuelto)} c/u</span>
                             </p>
                           ) : (
-                            <p className="text-sm text-gray-500">{formatPrecio(item.precioUnitario)} c/u</p>
+                            <p className="text-xs text-gray-500 dark:text-gray-400">{formatPrecio(item.precioUnitario)} c/u</p>
                           )}
                           {itemMoq && itemMoq > 1 && (
-                            <p className="text-xs text-amber-600 mt-0.5">Pedido minimo: {itemMoq} unidades</p>
+                            <p className="text-xs text-amber-600 mt-0.5">Min: {itemMoq} uds</p>
                           )}
                         </div>
-                        <div className="flex items-center space-x-3">
-                          <button onClick={(e) => { e.stopPropagation(); onActualizarCantidad(item.productoId, 0); }} className="p-1.5 text-red-500 hover:bg-red-50 rounded" title="Eliminar producto"><Trash2 className="w-4 h-4" /></button>
-                          <button onClick={(e) => { e.stopPropagation(); onActualizarCantidad(item.productoId, Math.max(item.cantidad - 1, minCantidad)); }} className={`w-8 h-8 rounded-full ${item.cantidad <= minCantidad ? 'bg-gray-100 text-gray-400' : 'bg-gray-200 hover:bg-gray-300'}`} disabled={item.cantidad <= minCantidad}>-</button>
-                          <span className="w-8 text-center font-medium">{item.cantidad}</span>
-                          <button onClick={(e) => { e.stopPropagation(); onActualizarCantidad(item.productoId, item.cantidad + 1); }} className="w-8 h-8 rounded-full bg-gray-200 hover:bg-gray-300">+</button>
-                          <p className="w-24 text-right font-semibold">{formatPrecio(subtotal)}</p>
+                        <div className="flex items-center gap-2 shrink-0">
+                          <button onClick={(e) => { e.stopPropagation(); onActualizarCantidad(item.productoId, 0); }} className="p-1 text-red-500 hover:bg-red-50 dark:hover:bg-red-900/20 rounded" title="Eliminar producto"><Trash2 className="w-4 h-4" /></button>
+                          <button onClick={(e) => { e.stopPropagation(); onActualizarCantidad(item.productoId, Math.max(item.cantidad - 1, minCantidad)); }} className={`w-7 h-7 rounded-full text-sm ${item.cantidad <= minCantidad ? 'bg-gray-100 text-gray-400 dark:bg-gray-700' : 'bg-gray-200 hover:bg-gray-300 dark:bg-gray-600 dark:hover:bg-gray-500'}`} disabled={item.cantidad <= minCantidad}>-</button>
+                          <span className="w-6 text-center font-medium text-sm dark:text-white">{item.cantidad}</span>
+                          <button onClick={(e) => { e.stopPropagation(); onActualizarCantidad(item.productoId, item.cantidad + 1); }} className="w-7 h-7 rounded-full text-sm bg-gray-200 hover:bg-gray-300 dark:bg-gray-600 dark:hover:bg-gray-500">+</button>
+                          <p className="w-20 text-right font-semibold text-sm dark:text-white">{formatPrecio(subtotal)}</p>
                         </div>
                       </div>
-                      {warning && <p className={`text-sm mt-1 ${warning.tipo === 'error' ? 'text-red-600' : 'text-yellow-600'}`}>{warning.mensaje}</p>}
+                      {warning && <p className={`text-xs mt-1 ${warning.tipo === 'error' ? 'text-red-600' : 'text-yellow-600'}`}>{warning.mensaje}</p>}
                     </div>
                   );
                 })}
@@ -479,7 +422,7 @@ const ModalPedido = memo(function ModalPedido({
               {faltantes.length > 0 && (
                 <div className="mt-2 space-y-1">
                   {faltantes.map((f, i) => (
-                    <p key={i} className="text-sm text-blue-600 bg-blue-50 dark:bg-blue-900/20 px-3 py-1.5 rounded-lg">
+                    <p key={i} className="text-xs text-blue-600 bg-blue-50 dark:bg-blue-900/20 px-3 py-1.5 rounded-lg">
                       Agrega {f.faltante} mas de <strong>{f.grupoNombre}</strong> para precio {f.etiqueta || 'mayorista'} ({formatPrecio(f.precioTier)} c/u)
                     </p>
                   ))}
@@ -487,6 +430,74 @@ const ModalPedido = memo(function ModalPedido({
               )}
             </div>
           )}
+
+          {/* Seccion Forma de Pago y Observaciones - al fondo */}
+          <div className="border-t dark:border-gray-600 pt-4 space-y-3">
+            <div className="grid grid-cols-2 gap-3">
+              <div>
+                <label className="block text-sm font-medium mb-1 dark:text-gray-200">Forma de Pago</label>
+                <select
+                  value={nuevoPedido.formaPago || 'efectivo'}
+                  onChange={e => onFormaPagoChange && onFormaPagoChange(e.target.value)}
+                  className="w-full px-3 py-2 border rounded-lg bg-white dark:bg-gray-700 dark:border-gray-600 dark:text-white text-sm"
+                >
+                  <option value="efectivo">Efectivo</option>
+                  <option value="transferencia">Transferencia</option>
+                  <option value="cheque">Cheque</option>
+                  <option value="cuenta_corriente">Cuenta Corriente</option>
+                  <option value="tarjeta">Tarjeta</option>
+                </select>
+              </div>
+              <div>
+                <label className="block text-sm font-medium mb-1 dark:text-gray-200">Estado de Pago</label>
+                <select
+                  value={nuevoPedido.estadoPago || 'pendiente'}
+                  onChange={e => onEstadoPagoChange && onEstadoPagoChange(e.target.value)}
+                  className="w-full px-3 py-2 border rounded-lg bg-white dark:bg-gray-700 dark:border-gray-600 dark:text-white text-sm"
+                >
+                  <option value="pendiente">Pendiente</option>
+                  <option value="pagado">Pagado</option>
+                  <option value="parcial">Parcial</option>
+                </select>
+              </div>
+            </div>
+
+            {/* Monto pagado si es pago parcial */}
+            {nuevoPedido.estadoPago === 'parcial' && (
+              <div className="p-3 bg-yellow-50 dark:bg-yellow-900/20 border border-yellow-200 dark:border-yellow-700 rounded-lg">
+                <label className="block text-sm font-medium mb-1 text-yellow-800 dark:text-yellow-300">Monto del pago parcial *</label>
+                <div className="flex items-center gap-2">
+                  <span className="text-lg font-semibold text-yellow-700 dark:text-yellow-400">$</span>
+                  <input
+                    type="number"
+                    min="0"
+                    step="0.01"
+                    max={calcularTotal()}
+                    value={nuevoPedido.montoPagado || ''}
+                    onChange={e => onMontoPagadoChange && onMontoPagadoChange(parseFloat(e.target.value) || 0)}
+                    className="flex-1 px-3 py-2 border border-yellow-300 rounded-lg focus:ring-2 focus:ring-yellow-500 bg-white dark:bg-gray-800 dark:border-yellow-600 dark:text-white"
+                    placeholder="Ingrese el monto pagado"
+                  />
+                </div>
+                {(nuevoPedido.montoPagado ?? 0) > 0 && (
+                  <p className="text-sm text-yellow-700 dark:text-yellow-300 mt-2">
+                    Resta por pagar: {formatPrecio(calcularTotal() - (nuevoPedido.montoPagado ?? 0))}
+                  </p>
+                )}
+              </div>
+            )}
+
+            <div>
+              <label className="block text-sm font-medium mb-1 dark:text-gray-200">Observaciones</label>
+              <textarea
+                value={nuevoPedido.notas || ''}
+                onChange={e => onNotasChange && onNotasChange(e.target.value)}
+                className="w-full px-3 py-2 border rounded-lg bg-white dark:bg-gray-700 dark:border-gray-600 dark:text-white text-sm"
+                placeholder="Observaciones para la preparacion..."
+                rows={2}
+              />
+            </div>
+          </div>
         </div>
 
         <div className="border-t bg-gray-50 p-4">


### PR DESCRIPTION
Move product list and selected items above payment/notes sections so users see more products without scrolling. Key improvements:
- Adaptive product list height (40vh mobile, 256px desktop)
- Compact date picker, category pills and item rows
- Visual indicator for already-added products
- Payment and notes moved to bottom as secondary fields