### PR TITLE
feat: admin-only inline price override per item in orders

### DIFF
--- a/src/components/AppModals.tsx
+++ b/src/components/AppModals.tsx
@@ -180,6 +180,7 @@ export interface AppModalsHandlers {
   handleClienteChange: (clienteId: string) => void;
   agregarItemPedido: (productoId: string) => void;
   actualizarCantidadItem: (productoId: string, cantidad: number) => void;
+  actualizarPrecioItem: (productoId: string, precio: number) => void;
   handleCrearClienteEnPedido: (clienteData: ClienteFormInput) => Promise<ClienteDB>;
   handleGuardarPedidoConOffline: () => Promise<void>;
   handleNotasChange: (notas: string) => void;
@@ -421,6 +422,7 @@ export default function AppModals({
               onClienteChange={handlers.handleClienteChange}
               onAgregarItem={handlers.agregarItemPedido as any}
               onActualizarCantidad={handlers.actualizarCantidadItem}
+              onActualizarPrecio={handlers.actualizarPrecioItem}
               onCrearCliente={handlers.handleCrearClienteEnPedido as any}
               onGuardar={handlers.handleGuardarPedidoConOffline}
               isOffline={!isOnline}

--- a/src/components/containers/PedidosContainer.tsx
+++ b/src/components/containers/PedidosContainer.tsx
@@ -663,6 +663,16 @@ export default function PedidosContainer(): React.ReactElement {
                 setNuevoPedido(prev => ({ ...prev, items: prev.items.map(i => i.productoId === productoId ? { ...i, cantidad } : i) }))
               }
             }}
+            onActualizarPrecio={(productoId: string, precio: number) => {
+              setNuevoPedido(prev => ({
+                ...prev,
+                items: prev.items.map(i =>
+                  i.productoId === productoId
+                    ? { ...i, precioUnitario: precio, precioOverride: true }
+                    : i
+                )
+              }))
+            }}
             onCrearCliente={async (clienteData: Record<string, unknown>) => {
               try {
                 const dbData = {

--- a/src/components/modals/ModalEditarPedido.tsx
+++ b/src/components/modals/ModalEditarPedido.tsx
@@ -1,5 +1,5 @@
 import { useState, memo, useEffect, useMemo } from 'react';
-import { Loader2, DollarSign, AlertCircle, Package, Plus, Minus, Trash2, Search, X, ShoppingCart } from 'lucide-react';
+import { Loader2, DollarSign, AlertCircle, Package, Plus, Minus, Trash2, Search, X, ShoppingCart, Pencil } from 'lucide-react';
 import ModalBase from './ModalBase';
 import { formatPrecio } from '../../utils/formatters';
 import { useZodValidation } from '../../hooks/useZodValidation';
@@ -15,6 +15,7 @@ export interface PedidoEditItem {
   precioUnitario: number;
   cantidadOriginal: number;
   esNuevo?: boolean;
+  precioOverride?: boolean;
 }
 
 /** Datos a guardar del pedido */
@@ -68,6 +69,8 @@ const ModalEditarPedido = memo(function ModalEditarPedido({
   const [busquedaProducto, setBusquedaProducto] = useState<string>('');
   const [itemsModificados, setItemsModificados] = useState<boolean>(false);
   const [errorStock, setErrorStock] = useState<string | null>(null);
+  const [editingPriceId, setEditingPriceId] = useState<string | null>(null);
+  const [editingPriceValue, setEditingPriceValue] = useState<string>('');
 
   // Verificar si el pedido está entregado (no editable)
   const pedidoEntregado = pedido?.estado === 'entregado';
@@ -91,6 +94,15 @@ const ModalEditarPedido = memo(function ModalEditarPedido({
   // Usamos el precio base (retail) de cada producto para que la resolución sea correcta
   const itemsConPrecioBase = useMemo(() => {
     return items.map(item => {
+      // Si tiene override, usar el precio manual; si no, usar precio base del producto
+      if (item.precioOverride) {
+        return {
+          productoId: item.productoId,
+          cantidad: item.cantidad,
+          precioUnitario: item.precioUnitario,
+          precioOverride: true
+        };
+      }
       const producto = productos.find(p => p.id === item.productoId);
       return {
         productoId: item.productoId,
@@ -106,10 +118,16 @@ const ModalEditarPedido = memo(function ModalEditarPedido({
   const preciosResueltosMap = useMemo(() => {
     const map = new Map<string, number>();
     for (const item of itemsConPrecioMayorista) {
-      map.set(item.productoId, item.precioUnitario);
+      // Si el item tiene override, usar su precio manual en vez del resuelto
+      const originalItem = items.find(i => i.productoId === item.productoId);
+      if (originalItem?.precioOverride) {
+        map.set(item.productoId, originalItem.precioUnitario);
+      } else {
+        map.set(item.productoId, item.precioUnitario);
+      }
     }
     return map;
-  }, [itemsConPrecioMayorista]);
+  }, [itemsConPrecioMayorista, items]);
 
   const total = itemsModificados ? totalCalculado : (pedido?.total || 0);
   const saldoPendiente = total - montoPagado;
@@ -192,6 +210,15 @@ const ModalEditarPedido = memo(function ModalEditarPedido({
 
   const handleEliminarItem = (productoId: string): void => {
     setItems(prev => prev.filter(item => item.productoId !== productoId));
+  };
+
+  const handlePrecioChange = (productoId: string, nuevoPrecio: number): void => {
+    if (nuevoPrecio <= 0) return;
+    setItems(prev => prev.map(item =>
+      item.productoId === productoId
+        ? { ...item, precioUnitario: nuevoPrecio, precioOverride: true }
+        : item
+    ));
   };
 
   const handleAgregarProducto = (producto: ProductoDB): void => {
@@ -382,9 +409,59 @@ const ModalEditarPedido = memo(function ModalEditarPedido({
                       }`}
                     >
                       <div className="flex-1">
-                        <p className="font-medium text-sm dark:text-white">{item.nombre}</p>
+                        <div className="flex items-center gap-1.5">
+                          <p className="font-medium text-sm dark:text-white">{item.nombre}</p>
+                          {item.precioOverride && (
+                            <span className="inline-flex items-center gap-0.5 text-xs px-1.5 py-0.5 bg-orange-100 text-orange-700 rounded-full font-medium shrink-0">
+                              <Pencil className="w-3 h-3" />
+                              Manual
+                            </span>
+                          )}
+                        </div>
                         <div className="flex items-center gap-2 text-xs text-gray-500">
-                          <span>{formatPrecio(precioResuelto)} c/u</span>
+                          {editingPriceId === item.productoId ? (
+                            <div className="flex items-center gap-1">
+                              <span className="text-orange-600">$</span>
+                              <input
+                                type="number"
+                                inputMode="decimal"
+                                step="0.01"
+                                min="0.01"
+                                value={editingPriceValue}
+                                onChange={e => setEditingPriceValue(e.target.value)}
+                                onKeyDown={e => {
+                                  if (e.key === 'Enter') {
+                                    const newPrice = parseFloat(editingPriceValue);
+                                    if (newPrice > 0) handlePrecioChange(item.productoId, newPrice);
+                                    setEditingPriceId(null);
+                                  } else if (e.key === 'Escape') {
+                                    setEditingPriceId(null);
+                                  }
+                                }}
+                                onBlur={() => {
+                                  const newPrice = parseFloat(editingPriceValue);
+                                  if (newPrice > 0) handlePrecioChange(item.productoId, newPrice);
+                                  setEditingPriceId(null);
+                                }}
+                                className="w-24 px-2 py-0.5 text-xs border border-orange-300 rounded bg-orange-50 dark:bg-orange-900/20 dark:border-orange-600 dark:text-white focus:ring-1 focus:ring-orange-500 focus:outline-none"
+                                autoFocus
+                              />
+                              <span className="text-orange-600">c/u</span>
+                            </div>
+                          ) : (
+                            <span
+                              className={`${item.precioOverride ? 'text-orange-600 font-medium' : ''} ${isAdmin ? 'cursor-pointer hover:underline' : ''}`}
+                              onClick={() => {
+                                if (isAdmin) {
+                                  setEditingPriceId(item.productoId);
+                                  setEditingPriceValue(String(precioResuelto));
+                                }
+                              }}
+                            >
+                              {formatPrecio(precioResuelto)} c/u
+                              {isAdmin && <Pencil className="w-3 h-3 inline ml-0.5 text-gray-400" />}
+                            </span>
+                          )}
                           <span>-</span>
                           <span>Stock disp: {stockDisponible}</span>
                           {item.esNuevo && (

--- a/src/components/modals/ModalPedido.tsx
+++ b/src/components/modals/ModalPedido.tsx
@@ -1,5 +1,5 @@
 import { useState, useMemo, memo } from 'react';
-import { X, Loader2, Search, MapPin, Tag, Calendar, Trash2 } from 'lucide-react';
+import { X, Loader2, Search, MapPin, Tag, Calendar, Trash2, Pencil } from 'lucide-react';
 import { formatPrecio } from '../../utils/formatters';
 import { AddressAutocomplete } from '../AddressAutocomplete';
 import { usePrecioMayorista } from '../../hooks/usePrecioMayorista';
@@ -10,6 +10,7 @@ export interface PedidoItem {
   productoId: string;
   cantidad: number;
   precioUnitario: number;
+  precioOverride?: boolean;
 }
 
 /** Estado del nuevo pedido */
@@ -83,6 +84,8 @@ export interface ModalPedidoProps {
   onMontoPagadoChange?: (monto: number) => void;
   /** Callback al cambiar fecha del pedido */
   onFechaChange?: (fecha: string) => void;
+  /** Callback al actualizar precio (solo admin) */
+  onActualizarPrecio?: (productoId: string, precio: number) => void;
   /** Si está offline */
   isOffline?: boolean;
 }
@@ -106,10 +109,13 @@ const ModalPedido = memo(function ModalPedido({
   onFormaPagoChange,
   onEstadoPagoChange,
   onMontoPagadoChange,
-  onFechaChange
+  onFechaChange,
+  onActualizarPrecio
 }: ModalPedidoProps) {
   const [busquedaProducto, setBusquedaProducto] = useState<string>('');
   const [busquedaCliente, setBusquedaCliente] = useState<string>('');
+  const [editingPriceId, setEditingPriceId] = useState<string | null>(null);
+  const [editingPriceValue, setEditingPriceValue] = useState<string>('');
   const [categoriaSeleccionada, setCategoriaSeleccionada] = useState<string>('');
   const [mostrarNuevoCliente, setMostrarNuevoCliente] = useState<boolean>(false);
   const [nuevoCliente, setNuevoCliente] = useState<NuevoClienteData>({ nombre: '', nombreFantasia: '', direccion: '', telefono: '', zona: '', latitud: null, longitud: null });
@@ -374,17 +380,25 @@ const ModalPedido = memo(function ModalPedido({
                   const prod = productos.find(p => p.id === item.productoId);
                   const warning = getStockWarning(item.productoId, item.cantidad);
                   const precioInfo = preciosResueltos.get(String(item.productoId));
-                  const esMayorista = precioInfo?.esMayorista || false;
-                  const precioMostrar = esMayorista ? precioInfo!.precioResuelto : item.precioUnitario;
+                  const esOverride = item.precioOverride || false;
+                  const esMayorista = !esOverride && (precioInfo?.esMayorista || false);
+                  const precioMostrar = esOverride ? item.precioUnitario : (esMayorista ? precioInfo!.precioResuelto : item.precioUnitario);
                   const subtotal = precioMostrar * item.cantidad;
                   const itemMoq = moqMap.get(String(item.productoId));
                   const minCantidad = itemMoq && itemMoq > 1 ? itemMoq : 1;
+                  const isEditingPrice = editingPriceId === item.productoId;
                   return (
                     <div key={item.productoId} className="px-3 py-2.5">
                       <div className="flex justify-between items-center gap-2">
                         <div className="min-w-0 flex-1">
                           <div className="flex items-center gap-1.5">
                             <p className="font-medium text-sm dark:text-white truncate">{prod?.nombre}</p>
+                            {esOverride && (
+                              <span className="inline-flex items-center gap-0.5 text-xs px-1.5 py-0.5 bg-orange-100 text-orange-700 rounded-full font-medium shrink-0">
+                                <Pencil className="w-3 h-3" />
+                                Manual
+                              </span>
+                            )}
                             {esMayorista && (
                               <span className="inline-flex items-center gap-0.5 text-xs px-1.5 py-0.5 bg-green-100 text-green-700 rounded-full font-medium shrink-0">
                                 <Tag className="w-3 h-3" />
@@ -392,13 +406,72 @@ const ModalPedido = memo(function ModalPedido({
                               </span>
                             )}
                           </div>
-                          {esMayorista ? (
-                            <p className="text-xs">
+                          {isEditingPrice && isAdmin && onActualizarPrecio ? (
+                            <div className="flex items-center gap-1 mt-0.5">
+                              <span className="text-xs text-orange-600">$</span>
+                              <input
+                                type="number"
+                                inputMode="decimal"
+                                step="0.01"
+                                min="0.01"
+                                value={editingPriceValue}
+                                onChange={e => setEditingPriceValue(e.target.value)}
+                                onKeyDown={e => {
+                                  if (e.key === 'Enter') {
+                                    const newPrice = parseFloat(editingPriceValue);
+                                    if (newPrice > 0) onActualizarPrecio(item.productoId, newPrice);
+                                    setEditingPriceId(null);
+                                  } else if (e.key === 'Escape') {
+                                    setEditingPriceId(null);
+                                  }
+                                }}
+                                onBlur={() => {
+                                  const newPrice = parseFloat(editingPriceValue);
+                                  if (newPrice > 0) onActualizarPrecio(item.productoId, newPrice);
+                                  setEditingPriceId(null);
+                                }}
+                                className="w-24 px-2 py-0.5 text-xs border border-orange-300 rounded bg-orange-50 dark:bg-orange-900/20 dark:border-orange-600 dark:text-white focus:ring-1 focus:ring-orange-500 focus:outline-none"
+                                autoFocus
+                              />
+                              <span className="text-xs text-orange-600">c/u</span>
+                            </div>
+                          ) : esOverride ? (
+                            <p
+                              className={`text-xs text-orange-600 font-medium ${isAdmin && onActualizarPrecio ? 'cursor-pointer hover:underline' : ''}`}
+                              onClick={() => {
+                                if (isAdmin && onActualizarPrecio) {
+                                  setEditingPriceId(item.productoId);
+                                  setEditingPriceValue(String(item.precioUnitario));
+                                }
+                              }}
+                            >
+                              {formatPrecio(item.precioUnitario)} c/u {isAdmin && onActualizarPrecio && <Pencil className="w-3 h-3 inline ml-0.5" />}
+                            </p>
+                          ) : esMayorista ? (
+                            <p className={`text-xs ${isAdmin && onActualizarPrecio ? 'cursor-pointer hover:underline' : ''}`}
+                              onClick={() => {
+                                if (isAdmin && onActualizarPrecio) {
+                                  setEditingPriceId(item.productoId);
+                                  setEditingPriceValue(String(precioInfo!.precioResuelto));
+                                }
+                              }}
+                            >
                               <span className="text-gray-400 line-through">{formatPrecio(item.precioUnitario)}</span>
                               <span className="ml-1 text-green-600 font-medium">{formatPrecio(precioInfo!.precioResuelto)} c/u</span>
+                              {isAdmin && onActualizarPrecio && <Pencil className="w-3 h-3 inline ml-1 text-gray-400" />}
                             </p>
                           ) : (
-                            <p className="text-xs text-gray-500 dark:text-gray-400">{formatPrecio(item.precioUnitario)} c/u</p>
+                            <p
+                              className={`text-xs text-gray-500 dark:text-gray-400 ${isAdmin && onActualizarPrecio ? 'cursor-pointer hover:underline' : ''}`}
+                              onClick={() => {
+                                if (isAdmin && onActualizarPrecio) {
+                                  setEditingPriceId(item.productoId);
+                                  setEditingPriceValue(String(item.precioUnitario));
+                                }
+                              }}
+                            >
+                              {formatPrecio(item.precioUnitario)} c/u {isAdmin && onActualizarPrecio && <Pencil className="w-3 h-3 inline ml-0.5 text-gray-400" />}
+                            </p>
                           )}
                           {itemMoq && itemMoq > 1 && (
                             <p className="text-xs text-amber-600 mt-0.5">Min: {itemMoq} uds</p>

--- a/src/hooks/handlers/usePedidoHandlers.ts
+++ b/src/hooks/handlers/usePedidoHandlers.ts
@@ -33,6 +33,7 @@ export interface NuevoPedidoItem {
   productoId: string;
   cantidad: number;
   precioUnitario: number;
+  precioOverride?: boolean;
 }
 
 export interface NuevoPedidoState {
@@ -193,6 +194,7 @@ export interface UsePedidoHandlersReturn {
   // Item management
   agregarItemPedido: (productoId: string) => void;
   actualizarCantidadItem: (productoId: string, cantidad: number) => void;
+  actualizarPrecioItem: (productoId: string, precio: number) => void;
   handleClienteChange: (clienteId: string) => void;
   handleNotasChange: (notas: string) => void;
   handleFormaPagoChange: (formaPago: string) => void;
@@ -305,6 +307,17 @@ export function usePedidoHandlers({
     } else {
       setNuevoPedido(prev => ({ ...prev, items: prev.items.map(i => i.productoId === productoId ? { ...i, cantidad } : i) }))
     }
+  }, [setNuevoPedido])
+
+  const actualizarPrecioItem = useCallback((productoId: string, precio: number): void => {
+    setNuevoPedido(prev => ({
+      ...prev,
+      items: prev.items.map(i =>
+        i.productoId === productoId
+          ? { ...i, precioUnitario: precio, precioOverride: true }
+          : i
+      )
+    }))
   }, [setNuevoPedido])
 
   // Form field handlers
@@ -669,6 +682,7 @@ export function usePedidoHandlers({
     // Item management
     agregarItemPedido,
     actualizarCantidadItem,
+    actualizarPrecioItem,
     handleClienteChange,
     handleNotasChange,
     handleFormaPagoChange,

--- a/src/utils/precioMayorista.ts
+++ b/src/utils/precioMayorista.ts
@@ -51,6 +51,7 @@ export interface ItemPedido {
   productoId: string
   cantidad: number
   precioUnitario: number
+  precioOverride?: boolean
 }
 
 // =============================================================================
@@ -93,6 +94,20 @@ export function resolverPreciosMayorista(
 
   // Resolver precio para cada item
   for (const item of items) {
+    // Si el precio fue overrideado manualmente, respetar el precio manual
+    if (item.precioOverride) {
+      result.set(String(item.productoId), {
+        precioOriginal: item.precioUnitario,
+        precioResuelto: item.precioUnitario,
+        esMayorista: false,
+        grupoNombre: null,
+        etiqueta: null,
+        cantidadEnGrupo: item.cantidad,
+        cantidadMinima: null
+      })
+      continue
+    }
+
     const grupos = pricingMap.get(String(item.productoId))
 
     if (!grupos || grupos.length === 0) {
@@ -225,6 +240,7 @@ export function aplicarPreciosMayorista(
   preciosResueltos: Map<string, PrecioResuelto>
 ): ItemPedido[] {
   return items.map(item => {
+    if (item.precioOverride) return item
     const resuelto = preciosResueltos.get(String(item.productoId))
     if (resuelto && resuelto.esMayorista) {
       return { ...item, precioUnitario: resuelto.precioResuelto }


### PR DESCRIPTION
Allow administrators to manually change the unit price of individual items when creating or editing orders. Prices are editable via inline tap-to-edit input. Manual prices show an orange "Manual" badge and are respected by the wholesale pricing system without being overwritten.