### PR TITLE
feat: improve PDF exports and Excel export with format options

### DIFF
--- a/src/components/containers/PedidosContainer.tsx
+++ b/src/components/containers/PedidosContainer.tsx
@@ -326,14 +326,67 @@ export default function PedidosContainer(): React.ReactElement {
     setGuardando(false)
   }, [pagosMasivos, notify])
 
+  // Fetch todos los pedidos con filtros actuales (sin paginación) para export
+  const fetchAllFilteredPedidos = useCallback(async (): Promise<PedidoDB[]> => {
+    const hasSearch = debouncedBusqueda && debouncedBusqueda.trim().length > 0
+    const selectStr = hasSearch
+      ? '*, cliente:clientes!inner(*), items:pedido_items(*, producto:productos(*))'
+      : '*, cliente:clientes(*), items:pedido_items(*, producto:productos(*))'
+
+    let query = supabase
+      .from('pedidos')
+      .select(selectStr)
+      .order('created_at', { ascending: false })
+
+    if (filtros.estado && filtros.estado !== 'todos') query = query.eq('estado', filtros.estado)
+    if (filtros.estadoPago && filtros.estadoPago !== 'todos') query = query.eq('estado_pago', filtros.estadoPago)
+    if (filtros.transportistaId && filtros.transportistaId !== 'todos') query = query.eq('transportista_id', filtros.transportistaId)
+    if (filtros.fechaDesde) query = query.gte('fecha', filtros.fechaDesde)
+    if (filtros.fechaHasta) query = query.lte('fecha', filtros.fechaHasta)
+    if (hasSearch) {
+      const trimmed = debouncedBusqueda!.trim()
+      query = query.or(
+        `nombre_fantasia.ilike.%${trimmed}%,razon_social.ilike.%${trimmed}%,cuit.ilike.%${trimmed}%,direccion.ilike.%${trimmed}%`,
+        { referencedTable: 'clientes' }
+      )
+    }
+
+    const { data, error } = await query
+    if (error) throw error
+
+    // Enrich with perfiles
+    const perfilIds = new Set<string>()
+    for (const pedido of (data || [])) {
+      if (pedido.usuario_id) perfilIds.add(pedido.usuario_id as string)
+      if (pedido.transportista_id) perfilIds.add(pedido.transportista_id as string)
+    }
+    let perfilesMap: Record<string, PerfilDB> = {}
+    if (perfilIds.size > 0) {
+      const { data: perfiles } = await supabase
+        .from('perfiles').select('id, nombre, email').in('id', Array.from(perfilIds))
+      if (perfiles) {
+        perfilesMap = Object.fromEntries((perfiles as PerfilDB[]).map(p => [p.id, p]))
+      }
+    }
+
+    return (data || []).map(pedido => ({
+      ...pedido,
+      usuario: pedido.usuario_id ? perfilesMap[pedido.usuario_id] : null,
+      transportista: pedido.transportista_id ? perfilesMap[pedido.transportista_id] : null,
+    })) as PedidoDB[]
+  }, [debouncedBusqueda, filtros])
+
   // Excel export (multi-sheet con ExcelJS)
-  const handleExportarExcel = useCallback(async () => {
+  const handleExportarExcel = useCallback(async (modo: 'pagina' | 'filtro' = 'pagina') => {
     setExportando(true)
     try {
       const { createMultiSheetExcel } = await import('../../utils/excel')
 
+      // Determinar qué datos exportar
+      const pedidosExport = modo === 'filtro' ? await fetchAllFilteredPedidos() : pedidos
+
       // Hoja 1: Pedidos
-      const pedidosData = pedidos.map(p => ({
+      const pedidosData = pedidosExport.map(p => ({
         ID: p.id,
         Cliente: (p.cliente as { nombre_fantasia?: string })?.nombre_fantasia || '',
         Direccion: (p.cliente as { direccion?: string })?.direccion || '',
@@ -350,7 +403,7 @@ export default function PedidosContainer(): React.ReactElement {
       }))
 
       // Hoja 2: Detalle Items
-      const itemsData = pedidos.flatMap(p =>
+      const itemsData = pedidosExport.flatMap(p =>
         (p.items || []).map(item => ({
           'Pedido ID': p.id,
           Cliente: (p.cliente as { nombre_fantasia?: string })?.nombre_fantasia || '',
@@ -364,16 +417,16 @@ export default function PedidosContainer(): React.ReactElement {
 
       // Hoja 3: Resumen Estados
       const estadosCounts: Record<string, number> = {}
-      pedidos.forEach(p => { estadosCounts[p.estado] = (estadosCounts[p.estado] || 0) + 1 })
+      pedidosExport.forEach(p => { estadosCounts[p.estado] = (estadosCounts[p.estado] || 0) + 1 })
       const estadosData = Object.entries(estadosCounts).map(([estado, cantidad]) => ({
         Estado: estado,
         Cantidad: cantidad,
-        Porcentaje: `${((cantidad / pedidos.length) * 100).toFixed(1)}%`,
+        Porcentaje: `${((cantidad / pedidosExport.length) * 100).toFixed(1)}%`,
       }))
 
       // Hoja 4: Resumen Pagos
       const pagosCounts: Record<string, { cantidad: number; total: number }> = {}
-      pedidos.forEach(p => {
+      pedidosExport.forEach(p => {
         const ep = p.estado_pago || 'pendiente'
         if (!pagosCounts[ep]) pagosCounts[ep] = { cantidad: 0, total: 0 }
         pagosCounts[ep].cantidad++
@@ -385,17 +438,20 @@ export default function PedidosContainer(): React.ReactElement {
         'Total $': info.total,
       }))
 
+      const suffix = modo === 'filtro' ? 'completo' : 'pagina'
       await createMultiSheetExcel([
         { name: 'Pedidos', data: pedidosData, columnWidths: [8, 25, 30, 15, 12, 15, 12, 12, 12, 20, 20, 30, 18] },
         { name: 'Detalle Items', data: itemsData, columnWidths: [10, 25, 35, 12, 10, 12, 12] },
         { name: 'Resumen Estados', data: estadosData, columnWidths: [20, 12, 12] },
         { name: 'Resumen Pagos', data: pagosData, columnWidths: [20, 12, 15] },
-      ], `pedidos-${new Date().toISOString().split('T')[0]}`)
+      ], `pedidos-${suffix}-${new Date().toISOString().split('T')[0]}`)
+
+      notify.success(`Excel exportado: ${pedidosExport.length} pedidos`)
     } catch {
       notify.error('Error al exportar Excel')
     }
     setExportando(false)
-  }, [pedidos, notify])
+  }, [pedidos, notify, fetchAllFilteredPedidos])
 
   // Fetch pedidos eliminados
   const fetchPedidosEliminados = useCallback(async () => {

--- a/src/components/pedidos/PedidoCard.tsx
+++ b/src/components/pedidos/PedidoCard.tsx
@@ -9,9 +9,9 @@
  */
 import React, { useState, memo, useContext } from 'react';
 import { Clock, Package, Truck, Check, Eye, ChevronDown, ChevronUp, CreditCard, User, MapPin, Phone, FileText, Building2, Timer, FileDown, LucideIcon, AlertTriangle } from 'lucide-react';
-const generarReciboPedido = async (...args: Parameters<typeof import('../../lib/pdfExport').generarReciboPedido>) => {
-  const mod = await import('../../lib/pdfExport')
-  return mod.generarReciboPedido(...args)
+const generarReciboPedido = async (pedido: any, _empresa: any = {}, options: { formato?: 'a4' | 'comanda' } = {}) => {
+  const mod = await import('../../lib/pdfExport') as any
+  return mod.generarReciboPedido(pedido, _empresa, options)
 };
 import { formatPrecio, formatFecha, getEstadoColor, getEstadoPagoColor, getEstadoPagoLabel, getFormaPagoLabel } from '../../utils/formatters';
 import { MOTIVOS_SALVEDAD_LABELS } from '../../lib/schemas';
@@ -253,14 +253,7 @@ function PedidoCard({
           </div>
           <div className="flex items-center gap-2">
             {pedido.estado_pago === 'pagado' && (
-              <button
-                onClick={() => pedido.cliente && generarReciboPedido(pedido, pedido.cliente)}
-                className="flex items-center gap-1 px-3 py-1.5 text-sm bg-green-50 dark:bg-green-900/30 text-green-600 dark:text-green-400 rounded-lg hover:bg-green-100 dark:hover:bg-green-900/50 transition-colors"
-                title="Descargar recibo PDF"
-              >
-                <FileDown className="w-4 h-4" />
-                <span className="hidden sm:inline">Recibo PDF</span>
-              </button>
+              <ReciboDropdown pedido={pedido} />
             )}
             <button
               onClick={() => setExpandido(!expandido)}
@@ -424,6 +417,59 @@ function PedidoCard({
               </p>
             </div>
           </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// Dropdown para elegir formato de recibo
+function ReciboDropdown({ pedido }: { pedido: PedidoDB }) {
+  const [open, setOpen] = React.useState(false);
+  const ref = React.useRef<HTMLDivElement>(null);
+
+  React.useEffect(() => {
+    function handleClickOutside(e: MouseEvent) {
+      if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false);
+    }
+    if (open) document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, [open]);
+
+  const handleExport = async (formato: 'a4' | 'comanda') => {
+    setOpen(false);
+    if (pedido.cliente) {
+      await generarReciboPedido(pedido, pedido.cliente, { formato });
+    }
+  };
+
+  return (
+    <div className="relative" ref={ref}>
+      <button
+        onClick={() => setOpen(!open)}
+        className="flex items-center gap-1 px-3 py-1.5 text-sm bg-green-50 dark:bg-green-900/30 text-green-600 dark:text-green-400 rounded-lg hover:bg-green-100 dark:hover:bg-green-900/50 transition-colors"
+        title="Descargar recibo PDF"
+      >
+        <FileDown className="w-4 h-4" />
+        <span className="hidden sm:inline">Recibo</span>
+        <ChevronDown className="w-3 h-3" />
+      </button>
+      {open && (
+        <div className="absolute right-0 bottom-full mb-1 w-44 bg-white dark:bg-gray-800 rounded-lg shadow-lg border dark:border-gray-700 z-50 overflow-hidden">
+          <button
+            onClick={() => handleExport('a4')}
+            className="w-full px-3 py-2.5 text-left text-sm hover:bg-gray-50 dark:hover:bg-gray-700 dark:text-white border-b dark:border-gray-700"
+          >
+            <p className="font-medium">Hoja A4</p>
+            <p className="text-xs text-gray-500 dark:text-gray-400">Formato profesional</p>
+          </button>
+          <button
+            onClick={() => handleExport('comanda')}
+            className="w-full px-3 py-2.5 text-left text-sm hover:bg-gray-50 dark:hover:bg-gray-700 dark:text-white"
+          >
+            <p className="font-medium">Comanda</p>
+            <p className="text-xs text-gray-500 dark:text-gray-400">Ticket 75mm</p>
+          </button>
         </div>
       )}
     </div>

--- a/src/components/vistas/VistaPedidos.tsx
+++ b/src/components/vistas/VistaPedidos.tsx
@@ -4,7 +4,8 @@
  * Recibe datos ya paginados server-side desde PedidosContainer.
  * Renderiza lista + controles de paginación.
  */
-import { ShoppingCart, Plus, Route, FileDown, Trash2, PackageCheck, Banknote } from 'lucide-react';
+import { useState, useRef, useEffect } from 'react';
+import { ShoppingCart, Plus, Route, FileDown, Trash2, PackageCheck, Banknote, ChevronDown } from 'lucide-react';
 import LoadingSpinner from '../layout/LoadingSpinner';
 import Paginacion from '../layout/Paginacion';
 import { PedidoCard, PedidoFilters, PedidoStats, VistaRutaTransportista } from '../pedidos';
@@ -44,7 +45,7 @@ export interface VistaPedidosProps {
   onNuevoPedido: () => void;
   onOptimizarRuta: () => void;
   onExportarPDF: () => void;
-  onExportarExcel: () => void;
+  onExportarExcel: (modo: 'pagina' | 'filtro') => void;
   onModalFiltroFecha: () => void;
   onVerHistorial: (pedido: PedidoDB) => void;
   onEditarPedido: (pedido: PedidoDB) => void;
@@ -137,14 +138,7 @@ export default function VistaPedidos({
             </button>
           )}
           {isAdmin && (
-            <button
-              onClick={onExportarExcel}
-              disabled={exportando}
-              className="flex items-center space-x-2 px-4 py-2 bg-green-700 text-white rounded-lg hover:bg-green-800 transition-colors"
-            >
-              <FileDown className="w-5 h-5" />
-              <span>Excel</span>
-            </button>
+            <ExcelExportDropdown exportando={exportando} onExportarExcel={onExportarExcel} totalCount={totalCount} />
           )}
           {isAdmin && onEntregasMasivas && (
             <button
@@ -243,6 +237,63 @@ export default function VistaPedidos({
             itemsLabel="pedidos"
           />
         </>
+      )}
+    </div>
+  );
+}
+
+// =============================================================================
+// EXCEL EXPORT DROPDOWN
+// =============================================================================
+
+function ExcelExportDropdown({
+  exportando,
+  onExportarExcel,
+  totalCount
+}: {
+  exportando: boolean;
+  onExportarExcel: (modo: 'pagina' | 'filtro') => void;
+  totalCount: number;
+}) {
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    function handleClickOutside(e: MouseEvent) {
+      if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false);
+    }
+    if (open) document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, [open]);
+
+  return (
+    <div className="relative" ref={ref}>
+      <button
+        onClick={() => setOpen(!open)}
+        disabled={exportando}
+        className="flex items-center space-x-2 px-4 py-2 bg-green-700 text-white rounded-lg hover:bg-green-800 transition-colors disabled:opacity-50"
+      >
+        <FileDown className="w-5 h-5" />
+        <span>{exportando ? 'Exportando...' : 'Excel'}</span>
+        <ChevronDown className="w-4 h-4" />
+      </button>
+      {open && !exportando && (
+        <div className="absolute right-0 mt-1 w-56 bg-white dark:bg-gray-800 rounded-lg shadow-lg border dark:border-gray-700 z-50 overflow-hidden">
+          <button
+            onClick={() => { onExportarExcel('pagina'); setOpen(false); }}
+            className="w-full px-4 py-3 text-left text-sm hover:bg-gray-50 dark:hover:bg-gray-700 dark:text-white border-b dark:border-gray-700"
+          >
+            <p className="font-medium">Página actual</p>
+            <p className="text-xs text-gray-500 dark:text-gray-400">Solo los pedidos visibles en pantalla</p>
+          </button>
+          <button
+            onClick={() => { onExportarExcel('filtro'); setOpen(false); }}
+            className="w-full px-4 py-3 text-left text-sm hover:bg-gray-50 dark:hover:bg-gray-700 dark:text-white"
+          >
+            <p className="font-medium">Filtro actual ({totalCount} pedidos)</p>
+            <p className="text-xs text-gray-500 dark:text-gray-400">Todos los pedidos que coinciden con el filtro</p>
+          </button>
+        </div>
       )}
     </div>
   );

--- a/src/lib/pdf/hojaRuta.js
+++ b/src/lib/pdf/hojaRuta.js
@@ -26,7 +26,7 @@ function calcularAltura(pedidos) {
   pedidos.forEach(pedido => {
     totalHeight += 30 // Info básica del pedido
     const itemsCount = pedido.items?.length || 0
-    totalHeight += Math.ceil(itemsCount * 4) // Productos resumidos
+    totalHeight += Math.ceil(itemsCount * 5) // Productos con nombre completo + precio
     if (pedido.notas) totalHeight += 6
   })
   totalHeight += 25 // Pie de página
@@ -117,15 +117,19 @@ export function generarHojaRuta(transportista, pedidos) {
     doc.text(`${formaPagoTexto} | ${estadoPago.label}`, margin, y)
     y += 3
 
-    // Productos (formato compacto)
+    // Productos con nombre completo y precio
     doc.setFontSize(6)
-    const productosTexto = pedido.items?.map(i =>
-      `${i.cantidad}x${truncate(i.producto?.nombre || '?', 12)}`
-    ).join(', ') || ''
-    const prodLines = doc.splitTextToSize(productosTexto, ticketWidth - (margin * 2))
-    prodLines.slice(0, 2).forEach(line => {
-      doc.text(line, margin, y)
-      y += 3
+    pedido.items?.forEach(item => {
+      const productoNombre = item.producto?.nombre || 'Producto'
+      const subtotal = (item.precio_unitario || 0) * item.cantidad
+      const nombreLines = doc.splitTextToSize(`  ${item.cantidad}x ${productoNombre}`, ticketWidth - (margin * 2) - 20)
+      nombreLines.forEach((line, idx) => {
+        doc.text(line, margin, y)
+        if (idx === 0) {
+          doc.text(formatPrecio(subtotal), ticketWidth - margin, y, { align: 'right' })
+        }
+        y += 2.5
+      })
     })
 
     // Notas

--- a/src/lib/pdf/hojaRutaOptimizada.js
+++ b/src/lib/pdf/hojaRutaOptimizada.js
@@ -26,8 +26,9 @@ function calcularAltura(pedidos) {
   pedidos.forEach(pedido => {
     totalHeight += 22 // Info básica del pedido
     const itemsCount = pedido.items?.length || 0
-    totalHeight += Math.ceil(itemsCount * 4) // Productos con nombre completo
+    totalHeight += Math.ceil(itemsCount * 5) // Productos con nombre completo + precio
     if (pedido.notas) totalHeight += 5
+    totalHeight += 5 // Total del pedido
   })
   totalHeight += 35 // Cierre de jornada
   return Math.max(totalHeight, 100)
@@ -129,13 +130,30 @@ export function generarHojaRutaOptimizada(transportista, pedidos, infoRuta = {})
     doc.text(`${formatPrecio(pedido.total)} - ${estadoPago}`, margin, y)
     y += 3
 
-    // Productos con nombre completo
+    // Productos con nombre completo, precio y subtotal
     setNormalStyle(doc, 6)
     pedido.items?.forEach(item => {
       const productoNombre = item.producto?.nombre || 'Producto'
-      doc.text(`  ${item.cantidad}x ${productoNombre}`, margin, y)
-      y += 2.5
+      const subtotal = (item.precio_unitario || 0) * item.cantidad
+      // Nombre completo del producto (sin truncar)
+      const nombreLines = doc.splitTextToSize(`  ${item.cantidad}x ${productoNombre}`, contentWidth - 25)
+      nombreLines.forEach((line, idx) => {
+        doc.text(line, margin, y)
+        // Mostrar precio alineado a la derecha solo en la primera línea
+        if (idx === 0) {
+          doc.text(formatPrecio(subtotal), ticketWidth - margin, y, { align: 'right' })
+        }
+        y += 2.5
+      })
     })
+
+    // Total del pedido destacado
+    y += 1
+    setHeaderStyle(doc, 7)
+    doc.text('Total pedido:', margin + 2, y)
+    doc.text(formatPrecio(pedido.total), ticketWidth - margin, y, { align: 'right' })
+    y += 3
+    setNormalStyle(doc, 6)
 
     // Notas
     if (pedido.notas) {

--- a/src/lib/pdf/reciboPedido.js
+++ b/src/lib/pdf/reciboPedido.js
@@ -1,220 +1,266 @@
 /**
- * Genera PDF de Recibo de Pedido Pagado
- * Formato: A4 profesional con detalle completo de productos
+ * Genera PDF de Recibo de Pedido
+ * Soporta dos formatos: A4 profesional y Comanda (75mm ticket)
+ * Branding: Crecer Distribuciones
  */
 import { jsPDF } from 'jspdf'
-import { A4, COLORS, FORMAS_PAGO_LABELS } from './constants'
+import { A4, TICKET, COLORS, FORMAS_PAGO_LABELS } from './constants'
 import {
   formatPrecio,
   formatFecha,
   formatFechaHora,
-  truncate,
   generateFilename,
+  drawDivider,
   setFillColor,
-  setTextColor
+  setTextColor,
+  setHeaderStyle,
+  setNormalStyle,
+  setItalicStyle
 } from './utils'
 
-/**
- * Genera PDF de Recibo de Pedido
- * @param {Object} pedido - Datos del pedido completo (con items y cliente)
- * @param {Object} empresa - Datos de la empresa (opcional)
- * @returns {void} - Descarga el PDF
- */
-export function generarReciboPedido(pedido, empresa = {}) {
-  const doc = new jsPDF({
-    orientation: 'portrait',
-    unit: 'mm',
-    format: 'a4'
-  })
+// Colores de marca Crecer Distribuciones
+const BRAND = {
+  primary: [22, 101, 52],     // Verde oscuro
+  primaryLight: [34, 197, 94], // Verde medio
+  accent: [240, 253, 244],     // Verde muy claro (fondo)
+  dark: [15, 23, 42],          // Casi negro (slate-900)
+  warmGray: [245, 245, 244],   // Piedra claro
+}
 
+/**
+ * Genera recibo en formato A4 profesional
+ */
+function generarReciboA4(pedido) {
+  const doc = new jsPDF({ orientation: 'portrait', unit: 'mm', format: 'a4' })
   const { width: pageWidth, margin, contentWidth } = A4
   let y = margin
 
-  // === HEADER DE LA EMPRESA ===
-  setFillColor(doc, COLORS.gray[900])
-  doc.rect(0, 0, pageWidth, 40, 'F')
+  // === HEADER EMPRESA ===
+  // Barra superior de color marca
+  setFillColor(doc, BRAND.dark)
+  doc.rect(0, 0, pageWidth, 42, 'F')
 
+  // Acento verde en la barra
+  setFillColor(doc, BRAND.primary)
+  doc.rect(0, 38, pageWidth, 4, 'F')
+
+  // Nombre de la empresa
   setTextColor(doc, COLORS.white)
-  doc.setFontSize(22)
+  doc.setFontSize(24)
   doc.setFont('helvetica', 'bold')
-  doc.text(empresa.nombre || 'DISTRIBUIDORA', margin, 18)
+  doc.text('CRECER DISTRIBUCIONES', margin, 20)
 
-  if (empresa.direccion || empresa.telefono || empresa.email) {
-    doc.setFontSize(9)
-    doc.setFont('helvetica', 'normal')
-    let infoY = 25
-    if (empresa.direccion) {
-      doc.text(empresa.direccion, margin, infoY)
-      infoY += 4
-    }
-    const contactoTexto = [empresa.telefono, empresa.email].filter(Boolean).join(' | ')
-    if (contactoTexto) doc.text(contactoTexto, margin, infoY)
-  }
-
-  // Número de recibo y fecha (derecha)
-  doc.setFontSize(11)
-  doc.setFont('helvetica', 'bold')
-  doc.text('RECIBO', pageWidth - margin, 15, { align: 'right' })
-  doc.setFontSize(16)
-  doc.text(`#${pedido.id}`, pageWidth - margin, 23, { align: 'right' })
+  // Subtítulo
   doc.setFontSize(9)
   doc.setFont('helvetica', 'normal')
-  doc.text(formatFecha(pedido.created_at || new Date()), pageWidth - margin, 30, { align: 'right' })
+  setTextColor(doc, [180, 200, 180])
+  doc.text('Distribuidora mayorista', margin, 28)
 
-  y = 50
+  // Recibo info (derecha)
+  setTextColor(doc, COLORS.white)
+  doc.setFontSize(10)
+  doc.setFont('helvetica', 'bold')
+  doc.text('RECIBO DE PEDIDO', pageWidth - margin, 14, { align: 'right' })
+  doc.setFontSize(18)
+  doc.text(`#${pedido.id}`, pageWidth - margin, 24, { align: 'right' })
+  doc.setFontSize(9)
+  doc.setFont('helvetica', 'normal')
+  doc.text(formatFecha(pedido.fecha || pedido.created_at || new Date()), pageWidth - margin, 32, { align: 'right' })
+
+  y = 52
+
+  // === BADGE DE ESTADO ===
   setTextColor(doc, COLORS.black)
-
-  // === ESTADO PAGADO - Badge destacado ===
-  setFillColor(doc, COLORS.green[500])
-  doc.roundedRect(pageWidth - margin - 35, y - 5, 35, 10, 2, 2, 'F')
+  const estadoPagoLabel = pedido.estado_pago === 'pagado' ? 'PAGADO' :
+    pedido.estado_pago === 'parcial' ? 'PARCIAL' : 'PENDIENTE'
+  const badgeColor = pedido.estado_pago === 'pagado' ? BRAND.primary :
+    pedido.estado_pago === 'parcial' ? COLORS.yellow[700] : COLORS.red[500]
+  setFillColor(doc, badgeColor)
+  const badgeWidth = doc.getTextWidth(estadoPagoLabel) + 14
+  doc.roundedRect(pageWidth - margin - badgeWidth, y - 5, badgeWidth, 10, 2, 2, 'F')
   setTextColor(doc, COLORS.white)
   doc.setFontSize(9)
   doc.setFont('helvetica', 'bold')
-  doc.text('PAGADO', pageWidth - margin - 17.5, y + 1, { align: 'center' })
-  setTextColor(doc, COLORS.black)
+  doc.text(estadoPagoLabel, pageWidth - margin - badgeWidth / 2, y + 1, { align: 'center' })
 
   // === DATOS DEL CLIENTE ===
-  doc.setFontSize(10)
+  setTextColor(doc, BRAND.primary)
+  doc.setFontSize(8)
   doc.setFont('helvetica', 'bold')
-  setTextColor(doc, COLORS.gray[500])
-  doc.text('CLIENTE', margin, y)
-  y += 6
+  doc.text('DATOS DEL CLIENTE', margin, y)
+  y += 5
 
-  setFillColor(doc, COLORS.gray[50])
-  doc.roundedRect(margin, y - 3, contentWidth, 28, 2, 2, 'F')
+  // Caja del cliente
+  setFillColor(doc, BRAND.warmGray)
+  doc.roundedRect(margin, y - 2, contentWidth, 30, 3, 3, 'F')
+  // Borde izquierdo verde
+  setFillColor(doc, BRAND.primary)
+  doc.rect(margin, y - 2, 3, 30, 'F')
 
-  setTextColor(doc, COLORS.black)
-  doc.setFontSize(13)
+  setTextColor(doc, BRAND.dark)
+  doc.setFontSize(14)
   doc.setFont('helvetica', 'bold')
-  doc.text(pedido.cliente?.nombre_fantasia || 'Cliente', margin + 5, y + 4)
+  doc.text(pedido.cliente?.nombre_fantasia || 'Cliente', margin + 8, y + 6)
 
   doc.setFontSize(9)
   doc.setFont('helvetica', 'normal')
   setTextColor(doc, COLORS.gray[600])
 
-  if (pedido.cliente?.razon_social) {
-    doc.text(pedido.cliente.razon_social, margin + 5, y + 10)
-  }
-  if (pedido.cliente?.cuit) {
-    doc.text(`CUIT: ${pedido.cliente.cuit}`, margin + 5, y + 15)
+  let clienteY = y + 12
+  if (pedido.cliente?.razon_social && pedido.cliente.razon_social !== pedido.cliente.nombre_fantasia) {
+    doc.text(pedido.cliente.razon_social, margin + 8, clienteY)
+    clienteY += 5
   }
   if (pedido.cliente?.direccion) {
-    doc.text(pedido.cliente.direccion, margin + 5, y + 20)
+    doc.text(pedido.cliente.direccion, margin + 8, clienteY)
+    clienteY += 5
   }
-  if (pedido.cliente?.telefono) {
-    doc.text(`Tel: ${pedido.cliente.telefono}`, margin + 100, y + 15)
-  }
+  const contacto = [
+    pedido.cliente?.telefono ? `Tel: ${pedido.cliente.telefono}` : null,
+    pedido.cliente?.cuit ? `CUIT: ${pedido.cliente.cuit}` : null
+  ].filter(Boolean).join('  |  ')
+  if (contacto) doc.text(contacto, margin + 8, clienteY)
 
-  y += 35
+  y += 38
 
   // === TABLA DE PRODUCTOS ===
-  setTextColor(doc, COLORS.gray[500])
-  doc.setFontSize(10)
+  setTextColor(doc, BRAND.primary)
+  doc.setFontSize(8)
   doc.setFont('helvetica', 'bold')
   doc.text('DETALLE DE PRODUCTOS', margin, y)
   y += 5
 
-  // Encabezados de tabla
-  setFillColor(doc, COLORS.gray[900])
-  doc.rect(margin, y, contentWidth, 8, 'F')
+  // Header de tabla
+  setFillColor(doc, BRAND.dark)
+  doc.roundedRect(margin, y, contentWidth, 9, 2, 2, 'F')
   setTextColor(doc, COLORS.white)
   doc.setFontSize(8)
   doc.setFont('helvetica', 'bold')
-  y += 5.5
-  doc.text('PRODUCTO', margin + 3, y)
-  doc.text('CANTIDAD', margin + 100, y, { align: 'center' })
-  doc.text('P. UNIT.', margin + 125, y, { align: 'center' })
-  doc.text('SUBTOTAL', margin + 165, y, { align: 'right' })
-  y += 5
+  y += 6
+  doc.text('PRODUCTO', margin + 5, y)
+  doc.text('CANT.', margin + 105, y, { align: 'center' })
+  doc.text('P. UNIT.', margin + 130, y, { align: 'center' })
+  doc.text('SUBTOTAL', contentWidth + margin - 5, y, { align: 'right' })
+  y += 6
 
   // Filas de productos
-  setTextColor(doc, COLORS.black)
-  doc.setFont('helvetica', 'normal')
-  doc.setFontSize(9)
-
   const items = pedido.items || []
   items.forEach((item, index) => {
     // Alternar color de fila
     if (index % 2 === 0) {
-      setFillColor(doc, COLORS.gray[50])
-      doc.rect(margin, y - 4, contentWidth, 8, 'F')
+      setFillColor(doc, BRAND.accent)
+      doc.rect(margin, y - 4, contentWidth, 9, 'F')
     }
 
-    const productoNombre = item.producto?.nombre || 'Producto'
-    doc.text(truncate(productoNombre, 45), margin + 3, y)
-    doc.text(String(item.cantidad), margin + 100, y, { align: 'center' })
-    doc.text(formatPrecio(item.precio_unitario), margin + 125, y, { align: 'center' })
-    doc.text(formatPrecio(item.subtotal || item.precio_unitario * item.cantidad), margin + 165, y, { align: 'right' })
-    y += 8
+    setTextColor(doc, BRAND.dark)
+    doc.setFontSize(9)
+    doc.setFont('helvetica', 'normal')
 
-    // Verificar si necesita nueva página
-    if (y > 250) {
+    // Nombre completo del producto (sin truncar, con wrap si necesario)
+    const productoNombre = item.producto?.nombre || 'Producto'
+    const nombreLines = doc.splitTextToSize(productoNombre, 90)
+    doc.text(nombreLines[0], margin + 5, y)
+
+    doc.text(String(item.cantidad), margin + 105, y, { align: 'center' })
+    doc.text(formatPrecio(item.precio_unitario), margin + 130, y, { align: 'center' })
+
+    doc.setFont('helvetica', 'bold')
+    doc.text(
+      formatPrecio(item.subtotal || item.precio_unitario * item.cantidad),
+      contentWidth + margin - 5, y, { align: 'right' }
+    )
+
+    y += 9
+
+    // Si el nombre tiene más de una línea
+    if (nombreLines.length > 1) {
+      doc.setFont('helvetica', 'normal')
+      doc.setFontSize(8)
+      setTextColor(doc, COLORS.gray[500])
+      doc.text(nombreLines[1], margin + 5, y - 4)
+      y += 4
+    }
+
+    // Paginación
+    if (y > 255) {
       doc.addPage()
       y = margin
     }
   })
 
-  // Línea divisora
-  y += 2
-  doc.setDrawColor(200, 200, 200)
+  // Línea antes del total
+  y += 3
+  doc.setDrawColor(...COLORS.gray[200])
   doc.setLineWidth(0.5)
   doc.line(margin + 80, y, margin + contentWidth, y)
   y += 8
 
-  // === TOTALES ===
-  setFillColor(doc, COLORS.gray[900])
-  doc.roundedRect(margin + 100, y - 5, 80, 14, 2, 2, 'F')
+  // === TOTAL ===
+  setFillColor(doc, BRAND.dark)
+  doc.roundedRect(margin + 90, y - 6, contentWidth - 90, 16, 3, 3, 'F')
   setTextColor(doc, COLORS.white)
-  doc.setFontSize(10)
+  doc.setFontSize(11)
   doc.setFont('helvetica', 'bold')
-  doc.text('TOTAL:', margin + 105, y + 3)
-  doc.setFontSize(14)
-  doc.text(formatPrecio(pedido.total), margin + 175, y + 3, { align: 'right' })
+  doc.text('TOTAL:', margin + 97, y + 4)
+  doc.setFontSize(16)
+  doc.text(formatPrecio(pedido.total), contentWidth + margin - 7, y + 4, { align: 'right' })
   setTextColor(doc, COLORS.black)
 
   y += 20
 
   // === INFORMACIÓN DE PAGO ===
-  setFillColor(doc, COLORS.green[50])
-  doc.roundedRect(margin, y, contentWidth, 20, 2, 2, 'F')
+  setFillColor(doc, BRAND.accent)
+  doc.roundedRect(margin, y, contentWidth, 22, 3, 3, 'F')
+  // Borde izquierdo verde
+  setFillColor(doc, BRAND.primaryLight)
+  doc.rect(margin, y, 3, 22, 'F')
 
-  doc.setFontSize(9)
+  doc.setFontSize(8)
   doc.setFont('helvetica', 'bold')
-  setTextColor(doc, COLORS.green[500])
-  doc.text('INFORMACION DE PAGO', margin + 5, y + 6)
+  setTextColor(doc, BRAND.primary)
+  doc.text('INFORMACION DE PAGO', margin + 8, y + 6)
 
   doc.setFont('helvetica', 'normal')
   setTextColor(doc, COLORS.gray[700])
   doc.setFontSize(9)
 
   const formaPagoLabel = FORMAS_PAGO_LABELS[pedido.forma_pago] || pedido.forma_pago || 'Efectivo'
-  doc.text(`Forma de pago: ${formaPagoLabel}`, margin + 5, y + 13)
-  doc.text(`Monto pagado: ${formatPrecio(pedido.monto_pagado || pedido.total)}`, margin + 80, y + 13)
+  doc.text(`Forma de pago: ${formaPagoLabel}`, margin + 8, y + 13)
 
-  if (pedido.fecha_entrega) {
-    doc.text(`Fecha entrega: ${formatFecha(pedido.fecha_entrega)}`, margin + 140, y + 13)
+  const montoPagado = pedido.monto_pagado ?? (pedido.estado_pago === 'pagado' ? pedido.total : 0)
+  doc.text(`Monto pagado: ${formatPrecio(montoPagado)}`, margin + 80, y + 13)
+
+  if (pedido.estado_pago === 'parcial') {
+    const saldo = pedido.total - montoPagado
+    doc.setFont('helvetica', 'bold')
+    setTextColor(doc, COLORS.red[700])
+    doc.text(`Saldo pendiente: ${formatPrecio(saldo)}`, margin + 8, y + 19)
   }
 
   y += 30
 
-  // === NOTAS DEL PEDIDO ===
+  // === NOTAS ===
   if (pedido.notas) {
-    setFillColor(doc, COLORS.yellow[50])
-    doc.roundedRect(margin, y, contentWidth, 18, 2, 2, 'F')
+    setFillColor(doc, [255, 251, 235])
+    doc.roundedRect(margin, y, contentWidth, 18, 3, 3, 'F')
+    setFillColor(doc, COLORS.yellow[700])
+    doc.rect(margin, y, 3, 18, 'F')
+
     doc.setFontSize(8)
     doc.setFont('helvetica', 'bold')
     setTextColor(doc, COLORS.yellow[700])
-    doc.text('NOTAS:', margin + 5, y + 6)
+    doc.text('OBSERVACIONES', margin + 8, y + 6)
     doc.setFont('helvetica', 'normal')
     setTextColor(doc, COLORS.gray[600])
-    const notasLines = doc.splitTextToSize(pedido.notas, contentWidth - 10)
-    doc.text(notasLines.slice(0, 2), margin + 5, y + 12)
-    y += 25
+    doc.setFontSize(9)
+    const notasLines = doc.splitTextToSize(pedido.notas, contentWidth - 15)
+    doc.text(notasLines.slice(0, 2), margin + 8, y + 12)
+    y += 24
   }
 
   // === TRANSPORTISTA ===
   if (pedido.transportista?.nombre) {
-    doc.setFontSize(8)
+    doc.setFontSize(9)
     doc.setFont('helvetica', 'normal')
     setTextColor(doc, COLORS.gray[500])
     doc.text(`Entregado por: ${pedido.transportista.nombre}`, margin, y)
@@ -222,24 +268,176 @@ export function generarReciboPedido(pedido, empresa = {}) {
   }
 
   // === PIE DE PÁGINA ===
-  y = 265
-  doc.setDrawColor(200, 200, 200)
+  const footerY = 270
+  doc.setDrawColor(...COLORS.gray[200])
   doc.setLineWidth(0.3)
-  doc.line(margin, y, pageWidth - margin, y)
-  y += 5
+  doc.line(margin, footerY, pageWidth - margin, footerY)
 
   doc.setFontSize(8)
-  doc.setFont('helvetica', 'italic')
+  doc.setFont('helvetica', 'normal')
   setTextColor(doc, COLORS.gray[400])
-  doc.text('Este documento es comprobante valido de la operacion realizada.', pageWidth / 2, y, { align: 'center' })
-  y += 4
-  doc.text('Conserve este recibo para cualquier reclamo o consulta.', pageWidth / 2, y, { align: 'center' })
+  doc.text('Crecer Distribuciones', margin, footerY + 5)
+  doc.text('Este documento es comprobante valido de la operacion realizada.', pageWidth / 2, footerY + 5, { align: 'center' })
 
-  // Fecha de generación
-  y += 6
   doc.setFontSize(7)
-  doc.text(`Generado: ${formatFechaHora(new Date())}`, pageWidth / 2, y, { align: 'center' })
+  doc.setFont('helvetica', 'italic')
+  doc.text(`Generado: ${formatFechaHora(new Date())}`, pageWidth - margin, footerY + 5, { align: 'right' })
 
-  // Descargar PDF
   doc.save(generateFilename('recibo-pedido', pedido.id?.toString()))
+}
+
+/**
+ * Genera recibo en formato Comanda (75mm ticket)
+ */
+function generarReciboComanda(pedido) {
+  const { width: ticketWidth, margin, contentWidth } = TICKET
+
+  // Calcular altura dinámica
+  const items = pedido.items || []
+  let height = 30 // header
+  height += 20 // cliente
+  height += 6 // divider + header tabla
+  height += items.length * 6 // productos
+  height += 25 // total + pago
+  if (pedido.notas) height += 12
+  height += 20 // pie
+  height = Math.max(height, 80)
+
+  const doc = new jsPDF({ orientation: 'portrait', unit: 'mm', format: [ticketWidth, height] })
+  let y = margin
+
+  // === HEADER ===
+  doc.setTextColor(0, 0, 0)
+  setHeaderStyle(doc, 11)
+  doc.text('CRECER', ticketWidth / 2, y + 4, { align: 'center' })
+  y += 5
+  doc.setFontSize(7)
+  doc.setFont('helvetica', 'normal')
+  doc.text('DISTRIBUCIONES', ticketWidth / 2, y + 2, { align: 'center' })
+  y += 5
+
+  // Número de recibo y fecha
+  setHeaderStyle(doc, 8)
+  doc.text(`Recibo #${pedido.id}`, ticketWidth / 2, y, { align: 'center' })
+  y += 3
+  setNormalStyle(doc, 6)
+  doc.text(formatFechaHora(pedido.fecha || pedido.created_at || new Date()), ticketWidth / 2, y, { align: 'center' })
+  y += 3
+
+  drawDivider(doc, y, margin, ticketWidth - margin, 0.5)
+  y += 3
+
+  // === CLIENTE ===
+  setHeaderStyle(doc, 8)
+  doc.text(pedido.cliente?.nombre_fantasia || 'Cliente', margin, y)
+  y += 3
+  setNormalStyle(doc, 6)
+  if (pedido.cliente?.direccion) {
+    const dirLines = doc.splitTextToSize(pedido.cliente.direccion, contentWidth)
+    dirLines.slice(0, 2).forEach(line => {
+      doc.text(line, margin, y)
+      y += 2.5
+    })
+  }
+  if (pedido.cliente?.telefono) {
+    doc.text(`Tel: ${pedido.cliente.telefono}`, margin, y)
+    y += 2.5
+  }
+  y += 1
+
+  drawDivider(doc, y, margin, ticketWidth - margin, 0.3)
+  y += 3
+
+  // === PRODUCTOS ===
+  // Header
+  setHeaderStyle(doc, 6)
+  doc.text('PRODUCTO', margin, y)
+  doc.text('SUBT.', ticketWidth - margin, y, { align: 'right' })
+  y += 3
+
+  setNormalStyle(doc, 6)
+  items.forEach(item => {
+    const productoNombre = item.producto?.nombre || 'Producto'
+    const subtotal = item.subtotal || item.precio_unitario * item.cantidad
+
+    // Nombre completo con cantidad
+    const nombreLines = doc.splitTextToSize(`${item.cantidad}x ${productoNombre}`, contentWidth - 22)
+    nombreLines.forEach((line, idx) => {
+      doc.text(line, margin, y)
+      if (idx === 0) {
+        doc.text(formatPrecio(subtotal), ticketWidth - margin, y, { align: 'right' })
+      }
+      y += 2.8
+    })
+  })
+
+  y += 1
+  drawDivider(doc, y, margin, ticketWidth - margin, 0.5)
+  y += 3
+
+  // === TOTAL ===
+  setHeaderStyle(doc, 10)
+  doc.text('TOTAL:', margin, y)
+  doc.text(formatPrecio(pedido.total), ticketWidth - margin, y, { align: 'right' })
+  y += 4
+
+  // Estado de pago
+  setNormalStyle(doc, 7)
+  const formaPagoLabel = FORMAS_PAGO_LABELS[pedido.forma_pago] || pedido.forma_pago || 'Efectivo'
+  doc.text(`${formaPagoLabel}`, margin, y)
+
+  const estadoPagoLabel = pedido.estado_pago === 'pagado' ? 'PAGADO' :
+    pedido.estado_pago === 'parcial' ? 'PARCIAL' : 'PENDIENTE'
+  setHeaderStyle(doc, 7)
+  doc.text(estadoPagoLabel, ticketWidth - margin, y, { align: 'right' })
+  y += 3
+
+  if (pedido.estado_pago === 'parcial') {
+    setNormalStyle(doc, 6)
+    const montoPagado = pedido.monto_pagado || 0
+    doc.text(`Pagado: ${formatPrecio(montoPagado)}`, margin, y)
+    doc.text(`Saldo: ${formatPrecio(pedido.total - montoPagado)}`, ticketWidth - margin, y, { align: 'right' })
+    y += 3
+  }
+
+  // === NOTAS ===
+  if (pedido.notas) {
+    y += 1
+    drawDivider(doc, y, margin, ticketWidth - margin, 0.2)
+    y += 2
+    setItalicStyle(doc, 6)
+    const notasLines = doc.splitTextToSize(pedido.notas, contentWidth)
+    notasLines.slice(0, 3).forEach(line => {
+      doc.text(line, margin, y)
+      y += 2.5
+    })
+  }
+
+  // === PIE ===
+  y += 2
+  drawDivider(doc, y, margin, ticketWidth - margin, 0.3)
+  y += 3
+  setItalicStyle(doc, 5)
+  doc.text('Crecer Distribuciones', ticketWidth / 2, y, { align: 'center' })
+  y += 2
+  doc.text('Comprobante valido de operacion', ticketWidth / 2, y, { align: 'center' })
+
+  doc.save(generateFilename('recibo-comanda', pedido.id?.toString()))
+}
+
+/**
+ * Genera PDF de Recibo de Pedido
+ * @param {Object} pedido - Datos del pedido completo (con items y cliente)
+ * @param {Object} _empresa - (deprecated) No se usa, branding hardcodeado
+ * @param {Object} options - Opciones de generación
+ * @param {'a4'|'comanda'} options.formato - Formato de salida (default: 'a4')
+ * @returns {void} - Descarga el PDF
+ */
+export function generarReciboPedido(pedido, _empresa = {}, options = {}) {
+  const formato = options.formato || 'a4'
+  if (formato === 'comanda') {
+    generarReciboComanda(pedido)
+  } else {
+    generarReciboA4(pedido)
+  }
 }


### PR DESCRIPTION
- Hoja de ruta: show full product names with prices per item and total per order so transportistas know how much to charge
- Excel export: dropdown with two options - export current page or all orders matching the current filter (fetches all from DB)
- Recibo PDF: complete redesign with Crecer Distribuciones branding, format selection (A4 professional or 75mm comanda ticket), improved layout with brand colors, full product names, and payment status