### PR TITLE
feat: add promotions system (bonificacion + pair pricing)

### DIFF
--- a/migrations/038_promociones.sql
+++ b/migrations/038_promociones.sql
@@ -1,0 +1,403 @@
+-- Migración 038: Sistema de Promociones Temporales
+--
+-- Soporta dos tipos de promoción:
+--   1. bonificacion: Compra X unidades, lleva Y gratis (acumulable)
+--      Ejemplo: Manaos Citrus — cada 12 uds comprás, te regalan 2
+--   2. precio_par: Descuento por pares con umbral de precio completo
+--      Ejemplo: Alfajores — de a 2 salen $4.000 c/u, 1 suelto $4.200, 4+ todo $4.000
+--
+-- Las bonificaciones se almacenan como líneas separadas en pedido_items con es_bonificacion=true
+-- El stock se descuenta para TODOS los items incluyendo bonificaciones.
+
+-- =============================================================================
+-- 1. Tabla de promociones
+-- =============================================================================
+
+CREATE TABLE IF NOT EXISTS promociones (
+  id BIGSERIAL PRIMARY KEY,
+  nombre VARCHAR(200) NOT NULL,
+  tipo VARCHAR(30) NOT NULL CHECK (tipo IN ('bonificacion', 'precio_par')),
+  activo BOOLEAN DEFAULT true,
+  fecha_inicio DATE NOT NULL,
+  fecha_fin DATE,
+  created_at TIMESTAMPTZ DEFAULT NOW(),
+  updated_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_promociones_activas ON promociones(activo, fecha_inicio, fecha_fin);
+
+-- =============================================================================
+-- 2. Productos de cada promoción
+-- =============================================================================
+
+CREATE TABLE IF NOT EXISTS promocion_productos (
+  id BIGSERIAL PRIMARY KEY,
+  promocion_id BIGINT NOT NULL REFERENCES promociones(id) ON DELETE CASCADE,
+  producto_id BIGINT NOT NULL REFERENCES productos(id) ON DELETE CASCADE,
+  UNIQUE(promocion_id, producto_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_pp_producto ON promocion_productos(producto_id);
+
+-- =============================================================================
+-- 3. Reglas de cada promoción (key-value)
+-- =============================================================================
+--
+-- Bonificación:
+--   cantidad_compra = 12       (comprar esta cantidad)
+--   cantidad_bonificacion = 2  (recibir esta cantidad gratis)
+--
+-- Precio por pares:
+--   precio_regular = 4200      (precio sin promo / unidad suelta)
+--   precio_promo = 4000        (precio con promo / par completo)
+--   umbral_todo_promo = 4      (a partir de esta qty, todo al precio promo)
+
+CREATE TABLE IF NOT EXISTS promocion_reglas (
+  id BIGSERIAL PRIMARY KEY,
+  promocion_id BIGINT NOT NULL REFERENCES promociones(id) ON DELETE CASCADE,
+  clave VARCHAR(50) NOT NULL,
+  valor NUMERIC NOT NULL,
+  UNIQUE(promocion_id, clave)
+);
+
+-- =============================================================================
+-- 4. Columna es_bonificacion en pedido_items
+-- =============================================================================
+
+ALTER TABLE pedido_items ADD COLUMN IF NOT EXISTS es_bonificacion BOOLEAN DEFAULT false;
+
+-- =============================================================================
+-- 5. RLS — mismo patrón que grupos_precio
+-- =============================================================================
+
+ALTER TABLE promociones ENABLE ROW LEVEL SECURITY;
+ALTER TABLE promocion_productos ENABLE ROW LEVEL SECURITY;
+ALTER TABLE promocion_reglas ENABLE ROW LEVEL SECURITY;
+
+-- promociones
+DROP POLICY IF EXISTS "Admin full access promociones" ON promociones;
+CREATE POLICY "Admin full access promociones" ON promociones
+  FOR ALL USING (
+    EXISTS (SELECT 1 FROM perfiles WHERE id = auth.uid() AND rol = 'admin')
+  );
+
+DROP POLICY IF EXISTS "Users can view promociones" ON promociones;
+CREATE POLICY "Users can view promociones" ON promociones
+  FOR SELECT USING (
+    EXISTS (SELECT 1 FROM perfiles WHERE id = auth.uid() AND activo = true)
+  );
+
+-- promocion_productos
+DROP POLICY IF EXISTS "Admin full access promocion_productos" ON promocion_productos;
+CREATE POLICY "Admin full access promocion_productos" ON promocion_productos
+  FOR ALL USING (
+    EXISTS (SELECT 1 FROM perfiles WHERE id = auth.uid() AND rol = 'admin')
+  );
+
+DROP POLICY IF EXISTS "Users can view promocion_productos" ON promocion_productos;
+CREATE POLICY "Users can view promocion_productos" ON promocion_productos
+  FOR SELECT USING (
+    EXISTS (SELECT 1 FROM perfiles WHERE id = auth.uid() AND activo = true)
+  );
+
+-- promocion_reglas
+DROP POLICY IF EXISTS "Admin full access promocion_reglas" ON promocion_reglas;
+CREATE POLICY "Admin full access promocion_reglas" ON promocion_reglas
+  FOR ALL USING (
+    EXISTS (SELECT 1 FROM perfiles WHERE id = auth.uid() AND rol = 'admin')
+  );
+
+DROP POLICY IF EXISTS "Users can view promocion_reglas" ON promocion_reglas;
+CREATE POLICY "Users can view promocion_reglas" ON promocion_reglas
+  FOR SELECT USING (
+    EXISTS (SELECT 1 FROM perfiles WHERE id = auth.uid() AND activo = true)
+  );
+
+-- =============================================================================
+-- 6. Trigger para updated_at
+-- =============================================================================
+
+CREATE OR REPLACE FUNCTION update_promociones_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = NOW();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS trigger_update_promociones_timestamp ON promociones;
+CREATE TRIGGER trigger_update_promociones_timestamp
+  BEFORE UPDATE ON promociones
+  FOR EACH ROW
+  EXECUTE FUNCTION update_promociones_updated_at();
+
+-- =============================================================================
+-- 7. Actualizar RPC crear_pedido_completo para soportar bonificaciones y subtotal override
+-- =============================================================================
+
+CREATE OR REPLACE FUNCTION public.crear_pedido_completo(
+  p_cliente_id integer,
+  p_total numeric,
+  p_usuario_id uuid,
+  p_items jsonb,
+  p_notas text DEFAULT NULL::text,
+  p_forma_pago text DEFAULT 'efectivo'::text,
+  p_estado_pago text DEFAULT 'pendiente'::text,
+  p_fecha date DEFAULT CURRENT_DATE
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $function$
+DECLARE
+  v_pedido_id INT;
+  item JSONB;
+  v_producto_id INT;
+  v_cantidad INT;
+  v_precio_unitario DECIMAL;
+  v_es_bonificacion BOOLEAN;
+  v_subtotal_override DECIMAL;
+  v_stock_actual INT;
+  v_producto_nombre TEXT;
+  errores TEXT[] := '{}';
+  v_user_role TEXT;
+  -- Para acumular cantidades por producto (regular + bonificación)
+  v_cantidades_totales JSONB := '{}'::JSONB;
+  v_cant_acumulada INT;
+BEGIN
+  -- Authorization check: only admin and preventista can create orders
+  SELECT rol INTO v_user_role FROM perfiles WHERE id = p_usuario_id;
+  IF v_user_role IS NULL OR v_user_role NOT IN ('admin', 'preventista') THEN
+    RETURN jsonb_build_object('success', false, 'errores', jsonb_build_array('No tiene permisos para crear pedidos'));
+  END IF;
+
+  -- 1. Acumular cantidades totales por producto (sumando regular + bonificación)
+  FOR item IN SELECT * FROM jsonb_array_elements(p_items)
+  LOOP
+    v_producto_id := (item->>'producto_id')::INT;
+    v_cantidad := (item->>'cantidad')::INT;
+
+    IF v_cantidad IS NULL OR v_cantidad <= 0 THEN
+      errores := array_append(errores, 'Cantidad inválida para producto ID ' || v_producto_id || ': debe ser mayor a 0');
+      CONTINUE;
+    END IF;
+
+    v_cant_acumulada := COALESCE((v_cantidades_totales->>v_producto_id::TEXT)::INT, 0) + v_cantidad;
+    v_cantidades_totales := v_cantidades_totales || jsonb_build_object(v_producto_id::TEXT, v_cant_acumulada);
+  END LOOP;
+
+  -- 2. Verificar stock usando cantidades acumuladas (con bloqueo)
+  FOR v_producto_id IN SELECT (key)::INT FROM jsonb_each_text(v_cantidades_totales)
+  LOOP
+    v_cantidad := (v_cantidades_totales->>v_producto_id::TEXT)::INT;
+
+    SELECT stock, nombre INTO v_stock_actual, v_producto_nombre
+    FROM productos
+    WHERE id = v_producto_id
+    FOR UPDATE;
+
+    IF v_stock_actual IS NULL THEN
+      errores := array_append(errores, 'Producto ID ' || v_producto_id || ' no encontrado');
+    ELSIF v_stock_actual < v_cantidad THEN
+      errores := array_append(errores, v_producto_nombre || ': stock insuficiente (disponible: ' || v_stock_actual || ', solicitado: ' || v_cantidad || ')');
+    END IF;
+  END LOOP;
+
+  IF array_length(errores, 1) > 0 THEN
+    RETURN jsonb_build_object('success', false, 'errores', to_jsonb(errores));
+  END IF;
+
+  -- 3. Crear el pedido con fecha seleccionada
+  INSERT INTO pedidos (cliente_id, fecha, total, estado, usuario_id, stock_descontado, notas, forma_pago, estado_pago)
+  VALUES (p_cliente_id, p_fecha, p_total, 'pendiente', p_usuario_id, true, p_notas, p_forma_pago, p_estado_pago)
+  RETURNING id INTO v_pedido_id;
+
+  -- 4. Crear items y descontar stock
+  FOR item IN SELECT * FROM jsonb_array_elements(p_items)
+  LOOP
+    v_producto_id := (item->>'producto_id')::INT;
+    v_cantidad := (item->>'cantidad')::INT;
+    v_precio_unitario := (item->>'precio_unitario')::DECIMAL;
+    v_es_bonificacion := COALESCE((item->>'es_bonificacion')::BOOLEAN, false);
+    v_subtotal_override := (item->>'subtotal')::DECIMAL;
+
+    INSERT INTO pedido_items (pedido_id, producto_id, cantidad, precio_unitario, subtotal, es_bonificacion)
+    VALUES (
+      v_pedido_id,
+      v_producto_id,
+      v_cantidad,
+      v_precio_unitario,
+      COALESCE(v_subtotal_override, v_cantidad * v_precio_unitario),
+      v_es_bonificacion
+    );
+
+    -- Stock se descuenta para TODOS los items (incluyendo bonificaciones)
+    UPDATE productos
+    SET stock = stock - v_cantidad
+    WHERE id = v_producto_id;
+  END LOOP;
+
+  RETURN jsonb_build_object('success', true, 'pedido_id', v_pedido_id);
+END;
+$function$;
+
+-- =============================================================================
+-- 8. Actualizar RPC actualizar_pedido_items para soportar bonificaciones y subtotal
+-- =============================================================================
+
+CREATE OR REPLACE FUNCTION public.actualizar_pedido_items(
+  p_pedido_id BIGINT,
+  p_items_nuevos JSONB,
+  p_usuario_id UUID DEFAULT NULL
+)
+RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $function$
+DECLARE
+  v_item_original RECORD;
+  v_item_nuevo JSONB;
+  v_producto_id INT;
+  v_cantidad_original INT;
+  v_cantidad_nueva INT;
+  v_precio_unitario DECIMAL;
+  v_es_bonificacion BOOLEAN;
+  v_subtotal_override DECIMAL;
+  v_diferencia INT;
+  v_stock_actual INT;
+  v_producto_nombre TEXT;
+  v_total_nuevo DECIMAL := 0;
+  v_total_anterior DECIMAL;
+  v_errores TEXT[] := '{}';
+  v_items_originales JSONB;
+  -- Para acumular cantidades por producto
+  v_cantidades_nuevas JSONB := '{}'::JSONB;
+  v_cantidades_originales JSONB := '{}'::JSONB;
+  v_cant_acum INT;
+BEGIN
+  SELECT total INTO v_total_anterior FROM pedidos WHERE id = p_pedido_id;
+  IF NOT FOUND THEN
+    RETURN jsonb_build_object('success', false, 'errores', ARRAY['Pedido no encontrado']);
+  END IF;
+
+  IF EXISTS (SELECT 1 FROM pedidos WHERE id = p_pedido_id AND estado = 'entregado') THEN
+    RETURN jsonb_build_object('success', false, 'errores', ARRAY['No se puede editar un pedido ya entregado']);
+  END IF;
+
+  -- Guardar items originales para historial
+  SELECT jsonb_agg(jsonb_build_object(
+    'producto_id', producto_id,
+    'cantidad', cantidad,
+    'precio_unitario', precio_unitario,
+    'es_bonificacion', es_bonificacion
+  )) INTO v_items_originales
+  FROM pedido_items WHERE pedido_id = p_pedido_id;
+
+  -- Acumular cantidades originales por producto
+  FOR v_item_original IN
+    SELECT producto_id, SUM(cantidad) as cant_total
+    FROM pedido_items WHERE pedido_id = p_pedido_id
+    GROUP BY producto_id
+  LOOP
+    v_cantidades_originales := v_cantidades_originales || jsonb_build_object(
+      v_item_original.producto_id::TEXT, v_item_original.cant_total
+    );
+  END LOOP;
+
+  -- Acumular cantidades nuevas por producto
+  FOR v_item_nuevo IN SELECT * FROM jsonb_array_elements(p_items_nuevos)
+  LOOP
+    v_producto_id := (v_item_nuevo->>'producto_id')::INT;
+    v_cantidad_nueva := (v_item_nuevo->>'cantidad')::INT;
+    v_cant_acum := COALESCE((v_cantidades_nuevas->>v_producto_id::TEXT)::INT, 0) + v_cantidad_nueva;
+    v_cantidades_nuevas := v_cantidades_nuevas || jsonb_build_object(v_producto_id::TEXT, v_cant_acum);
+  END LOOP;
+
+  -- Validar stock para incrementos (comparando totales acumulados por producto)
+  FOR v_producto_id IN SELECT (key)::INT FROM jsonb_each_text(v_cantidades_nuevas)
+  LOOP
+    v_cantidad_nueva := (v_cantidades_nuevas->>v_producto_id::TEXT)::INT;
+    v_cantidad_original := COALESCE((v_cantidades_originales->>v_producto_id::TEXT)::INT, 0);
+    v_diferencia := v_cantidad_nueva - v_cantidad_original;
+
+    IF v_diferencia > 0 THEN
+      SELECT stock, nombre INTO v_stock_actual, v_producto_nombre
+      FROM productos WHERE id = v_producto_id FOR UPDATE;
+
+      IF v_stock_actual IS NULL THEN
+        v_errores := array_append(v_errores, 'Producto ID ' || v_producto_id || ' no encontrado');
+      ELSIF v_stock_actual < v_diferencia THEN
+        v_errores := array_append(v_errores,
+          COALESCE(v_producto_nombre, 'Producto ' || v_producto_id) ||
+          ': stock insuficiente (disponible: ' || v_stock_actual ||
+          ', adicional requerido: ' || v_diferencia || ')');
+      END IF;
+    END IF;
+  END LOOP;
+
+  IF array_length(v_errores, 1) > 0 THEN
+    RETURN jsonb_build_object('success', false, 'errores', to_jsonb(v_errores));
+  END IF;
+
+  -- Restaurar stock de todos los items originales
+  FOR v_item_original IN
+    SELECT producto_id, cantidad FROM pedido_items WHERE pedido_id = p_pedido_id
+  LOOP
+    UPDATE productos SET stock = stock + v_item_original.cantidad
+    WHERE id = v_item_original.producto_id;
+  END LOOP;
+
+  -- Eliminar items actuales
+  DELETE FROM pedido_items WHERE pedido_id = p_pedido_id;
+
+  -- Insertar nuevos items y descontar stock
+  FOR v_item_nuevo IN SELECT * FROM jsonb_array_elements(p_items_nuevos)
+  LOOP
+    v_producto_id := (v_item_nuevo->>'producto_id')::INT;
+    v_cantidad_nueva := (v_item_nuevo->>'cantidad')::INT;
+    v_precio_unitario := (v_item_nuevo->>'precio_unitario')::DECIMAL;
+    v_es_bonificacion := COALESCE((v_item_nuevo->>'es_bonificacion')::BOOLEAN, false);
+    v_subtotal_override := (v_item_nuevo->>'subtotal')::DECIMAL;
+
+    INSERT INTO pedido_items (pedido_id, producto_id, cantidad, precio_unitario, subtotal, es_bonificacion)
+    VALUES (
+      p_pedido_id,
+      v_producto_id,
+      v_cantidad_nueva,
+      v_precio_unitario,
+      COALESCE(v_subtotal_override, v_cantidad_nueva * v_precio_unitario),
+      v_es_bonificacion
+    );
+
+    -- Solo sumar al total si NO es bonificación
+    IF NOT v_es_bonificacion THEN
+      v_total_nuevo := v_total_nuevo + COALESCE(v_subtotal_override, v_cantidad_nueva * v_precio_unitario);
+    END IF;
+
+    UPDATE productos SET stock = stock - v_cantidad_nueva WHERE id = v_producto_id;
+  END LOOP;
+
+  UPDATE pedidos SET total = v_total_nuevo, updated_at = NOW() WHERE id = p_pedido_id;
+
+  INSERT INTO pedido_historial (pedido_id, usuario_id, campo_modificado, valor_anterior, valor_nuevo)
+  VALUES (p_pedido_id, p_usuario_id, 'items', COALESCE(v_items_originales::TEXT, '[]'), p_items_nuevos::TEXT);
+
+  IF v_total_anterior <> v_total_nuevo THEN
+    INSERT INTO pedido_historial (pedido_id, usuario_id, campo_modificado, valor_anterior, valor_nuevo)
+    VALUES (p_pedido_id, p_usuario_id, 'total', v_total_anterior::TEXT, v_total_nuevo::TEXT);
+  END IF;
+
+  RETURN jsonb_build_object('success', true, 'total_nuevo', v_total_nuevo);
+END;
+$function$;
+
+-- =============================================================================
+-- 9. Comentarios
+-- =============================================================================
+
+COMMENT ON TABLE promociones IS 'Promociones temporales con fecha inicio/fin';
+COMMENT ON TABLE promocion_productos IS 'Productos asociados a cada promoción';
+COMMENT ON TABLE promocion_reglas IS 'Parámetros key-value de cada promoción (cantidad_compra, precio_promo, etc.)';
+COMMENT ON COLUMN pedido_items.es_bonificacion IS 'true = unidad gratis por promoción (precio_unitario=0, stock se descuenta)';

--- a/src/components/modals/ModalPedido.tsx
+++ b/src/components/modals/ModalPedido.tsx
@@ -1,8 +1,8 @@
 import { useState, useMemo, memo } from 'react';
-import { X, Loader2, Search, MapPin, Tag, Calendar, Trash2, Pencil } from 'lucide-react';
+import { X, Loader2, Search, MapPin, Tag, Calendar, Trash2, Pencil, Gift } from 'lucide-react';
 import { formatPrecio } from '../../utils/formatters';
 import { AddressAutocomplete } from '../AddressAutocomplete';
-import { usePrecioMayorista } from '../../hooks/usePrecioMayorista';
+import { usePromocionPedido } from '../../hooks/usePromocionPedido';
 import type { ProductoDB, ClienteDB } from '../../types';
 
 /** Item en el pedido */
@@ -189,7 +189,10 @@ const ModalPedido = memo(function ModalPedido({
   const getStockWarning = (productoId: string, cantidadEnPedido: number): StockWarning | null => {
     const producto = productos.find(p => p.id === productoId);
     if (!producto) return null;
-    const stockDisponible = producto.stock - cantidadEnPedido;
+    // Sumar cantidad de bonificación al cálculo de stock
+    const bonif = promoResolucion.bonificaciones.find(b => b.productoId === productoId);
+    const cantidadTotal = cantidadEnPedido + (bonif?.cantidadBonificacion || 0);
+    const stockDisponible = producto.stock - cantidadTotal;
     const stockMinimo = producto.stock_minimo || 10;
     if (stockDisponible < 0) return { tipo: 'error', mensaje: `Sin stock! Disponible: ${producto.stock}` };
     if (stockDisponible < stockMinimo) return { tipo: 'warning', mensaje: `Stock bajo: quedaran ${stockDisponible}` };
@@ -198,8 +201,8 @@ const ModalPedido = memo(function ModalPedido({
 
   const calcularTotal = (): number => nuevoPedido.items.reduce((t, i) => t + (i.precioUnitario * i.cantidad), 0);
 
-  // Precios mayoristas y cantidades mínimas
-  const { preciosResueltos, faltantes, totalMayorista, totalOriginal, ahorro, hayMayorista, moqMap, violacionesMOQ } = usePrecioMayorista(nuevoPedido.items);
+  // Precios mayoristas, promociones y cantidades mínimas
+  const { preciosResueltos, faltantes, faltantesBonificacion, promoResolucion, totalFinal, totalOriginal, ahorro, hayDescuento, moqMap, violacionesMOQ } = usePromocionPedido(nuevoPedido.items);
 
   return (
     <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center p-4 z-50">
@@ -380,10 +383,12 @@ const ModalPedido = memo(function ModalPedido({
                   const prod = productos.find(p => p.id === item.productoId);
                   const warning = getStockWarning(item.productoId, item.cantidad);
                   const precioInfo = preciosResueltos.get(String(item.productoId));
+                  const precioParInfo = promoResolucion.preciosPar.get(String(item.productoId));
                   const esOverride = item.precioOverride || false;
-                  const esMayorista = !esOverride && (precioInfo?.esMayorista || false);
+                  const esMayorista = !esOverride && !precioParInfo && (precioInfo?.esMayorista || false);
+                  const esPromoPar = !esOverride && !!precioParInfo;
                   const precioMostrar = esOverride ? item.precioUnitario : (esMayorista ? precioInfo!.precioResuelto : item.precioUnitario);
-                  const subtotal = precioMostrar * item.cantidad;
+                  const subtotal = esPromoPar ? precioParInfo!.subtotalPromo : precioMostrar * item.cantidad;
                   const itemMoq = moqMap.get(String(item.productoId));
                   const minCantidad = itemMoq && itemMoq > 1 ? itemMoq : 1;
                   const isEditingPrice = editingPriceId === item.productoId;
@@ -403,6 +408,12 @@ const ModalPedido = memo(function ModalPedido({
                               <span className="inline-flex items-center gap-0.5 text-xs px-1.5 py-0.5 bg-green-100 text-green-700 rounded-full font-medium shrink-0">
                                 <Tag className="w-3 h-3" />
                                 {precioInfo?.etiqueta || 'Mayorista'}
+                              </span>
+                            )}
+                            {esPromoPar && (
+                              <span className="inline-flex items-center gap-0.5 text-xs px-1.5 py-0.5 bg-purple-100 text-purple-700 rounded-full font-medium shrink-0">
+                                <Tag className="w-3 h-3" />
+                                Promo
                               </span>
                             )}
                           </div>
@@ -460,6 +471,11 @@ const ModalPedido = memo(function ModalPedido({
                               <span className="ml-1 text-green-600 font-medium">{formatPrecio(precioInfo!.precioResuelto)} c/u</span>
                               {isAdmin && onActualizarPrecio && <Pencil className="w-3 h-3 inline ml-1 text-gray-400" />}
                             </p>
+                          ) : esPromoPar ? (
+                            <p className="text-xs">
+                              <span className="text-gray-400 line-through">{formatPrecio(precioParInfo!.precioEfectivo !== item.precioUnitario ? item.precioUnitario : 0)}</span>
+                              <span className="ml-1 text-purple-600 font-medium">{formatPrecio(precioParInfo!.precioEfectivo)} c/u</span>
+                            </p>
                           ) : (
                             <p
                               className={`text-xs text-gray-500 dark:text-gray-400 ${isAdmin && onActualizarPrecio ? 'cursor-pointer hover:underline' : ''}`}
@@ -472,6 +488,9 @@ const ModalPedido = memo(function ModalPedido({
                             >
                               {formatPrecio(item.precioUnitario)} c/u {isAdmin && onActualizarPrecio && <Pencil className="w-3 h-3 inline ml-0.5 text-gray-400" />}
                             </p>
+                          )}
+                          {esPromoPar && (
+                            <p className="text-xs text-purple-600 mt-0.5">{precioParInfo!.detalle}</p>
                           )}
                           {itemMoq && itemMoq > 1 && (
                             <p className="text-xs text-amber-600 mt-0.5">Min: {itemMoq} uds</p>
@@ -489,6 +508,30 @@ const ModalPedido = memo(function ModalPedido({
                     </div>
                   );
                 })}
+                {/* Items de bonificación (gratis) */}
+                {promoResolucion.bonificaciones.map(bonif => {
+                  const prod = productos.find(p => p.id === bonif.productoId);
+                  return (
+                    <div key={`bonif-${bonif.productoId}`} className="px-3 py-2.5 bg-green-50 dark:bg-green-900/10">
+                      <div className="flex justify-between items-center gap-2">
+                        <div className="min-w-0 flex-1">
+                          <div className="flex items-center gap-1.5">
+                            <p className="font-medium text-sm text-green-700 dark:text-green-400 truncate">{prod?.nombre}</p>
+                            <span className="inline-flex items-center gap-0.5 text-xs px-1.5 py-0.5 bg-green-200 text-green-800 rounded-full font-medium shrink-0">
+                              <Gift className="w-3 h-3" />
+                              Bonificacion
+                            </span>
+                          </div>
+                          <p className="text-xs text-green-600 dark:text-green-400">{bonif.promoNombre}</p>
+                        </div>
+                        <div className="flex items-center gap-2 shrink-0">
+                          <span className="w-6 text-center font-medium text-sm text-green-700 dark:text-green-400">{bonif.cantidadBonificacion}</span>
+                          <p className="w-20 text-right font-semibold text-sm text-green-600">GRATIS</p>
+                        </div>
+                      </div>
+                    </div>
+                  );
+                })}
               </div>
 
               {/* Nudges para alcanzar siguiente tier */}
@@ -499,6 +542,20 @@ const ModalPedido = memo(function ModalPedido({
                       Agrega {f.faltante} mas de <strong>{f.grupoNombre}</strong> para precio {f.etiqueta || 'mayorista'} ({formatPrecio(f.precioTier)} c/u)
                     </p>
                   ))}
+                </div>
+              )}
+
+              {/* Nudges para alcanzar bonificación */}
+              {faltantesBonificacion.length > 0 && (
+                <div className="mt-2 space-y-1">
+                  {faltantesBonificacion.map((f, i) => {
+                    const prod = productos.find(p => p.id === f.productoId);
+                    return (
+                      <p key={`bonif-nudge-${i}`} className="text-xs text-green-600 bg-green-50 dark:bg-green-900/20 px-3 py-1.5 rounded-lg">
+                        Agrega {f.faltante} mas de <strong>{prod?.nombre || f.promoNombre}</strong> y te llevas {f.bonificacion} gratis!
+                      </p>
+                    );
+                  })}
                 </div>
               )}
             </div>
@@ -577,10 +634,10 @@ const ModalPedido = memo(function ModalPedido({
           <div className="flex justify-between items-center mb-4">
             <span className="text-lg font-medium">Total</span>
             <div className="text-right">
-              {hayMayorista ? (
+              {hayDescuento ? (
                 <>
                   <span className="text-sm text-gray-400 line-through mr-2">{formatPrecio(totalOriginal)}</span>
-                  <span className="text-2xl font-bold text-green-600">{formatPrecio(totalMayorista)}</span>
+                  <span className="text-2xl font-bold text-green-600">{formatPrecio(totalFinal)}</span>
                   <p className="text-xs text-green-600 font-medium">Ahorro: {formatPrecio(ahorro)}</p>
                 </>
               ) : (

--- a/src/hooks/handlers/usePedidoHandlers.ts
+++ b/src/hooks/handlers/usePedidoHandlers.ts
@@ -5,9 +5,10 @@
  */
 import { useCallback, type Dispatch, type SetStateAction } from 'react'
 import { useLatestRef } from '../useLatestRef'
-import { calcularTotalPedido } from '../useAppState'
 import { usePricingMapQuery } from '../queries/useGruposPrecioQuery'
+import { usePromoMapQuery } from '../queries/usePromocionesQuery'
 import { resolverPreciosMayorista, aplicarPreciosMayorista, validarMOQPedido } from '../../utils/precioMayorista'
+import { resolverPromociones } from '../../utils/promociones'
 import type { User } from '@supabase/supabase-js'
 import type {
   ProductoDB,
@@ -278,6 +279,10 @@ export function usePedidoHandlers({
   const { data: pricingMap } = usePricingMapQuery()
   const pricingMapRef = useLatestRef(pricingMap)
 
+  // Promo map for active promotions
+  const { data: promoMap } = usePromoMapQuery()
+  const promoMapRef = useLatestRef(promoMap)
+
   // ==========================================================================
   // HANDLERS - Usan refs para valores frecuentes, deps estables para funciones
   // ==========================================================================
@@ -379,18 +384,58 @@ export function usePedidoHandlers({
       }
     }
 
-    // Aplicar precios mayoristas si hay pricing map disponible
+    // Resolver promociones activas
+    const currentPromoMap = promoMapRef.current
+    let promoResolucion = { bonificaciones: [] as Array<{ productoId: string; promoNombre: string; cantidadBonificacion: number }>, preciosPar: new Map<string, { subtotalPromo: number }>(), productosConPromo: new Set<string>() }
+    if (currentPromoMap && currentPromoMap.size > 0) {
+      promoResolucion = resolverPromociones(nuevoPedido.items, currentPromoMap)
+    }
+
+    // Aplicar precios mayoristas (excluyendo productos con promo)
     let itemsFinales = nuevoPedido.items
     if (currentPricingMap && currentPricingMap.size > 0) {
-      const preciosResueltos = resolverPreciosMayorista(nuevoPedido.items, currentPricingMap)
-      itemsFinales = aplicarPreciosMayorista(nuevoPedido.items, preciosResueltos)
+      const itemsSinPromo = nuevoPedido.items.filter(i => !promoResolucion.productosConPromo.has(String(i.productoId)))
+      if (itemsSinPromo.length > 0) {
+        const preciosResueltos = resolverPreciosMayorista(itemsSinPromo, currentPricingMap)
+        itemsFinales = aplicarPreciosMayorista(nuevoPedido.items, preciosResueltos)
+      }
     }
-    const totalFinal = calcularTotalPedido(itemsFinales)
+
+    // Aplicar subtotal override para items con precio por pares
+    const itemsConPromo = itemsFinales.map(item => {
+      const precioPar = promoResolucion.preciosPar.get(String(item.productoId))
+      if (precioPar) {
+        return { ...item, subtotalOverride: precioPar.subtotalPromo }
+      }
+      return item
+    })
+
+    // Agregar items de bonificación
+    const itemsBonificacion = promoResolucion.bonificaciones.map(b => ({
+      productoId: b.productoId,
+      cantidad: b.cantidadBonificacion,
+      precioUnitario: 0,
+      esBonificacion: true as const,
+    }))
+
+    const todosLosItems = [...itemsConPromo, ...itemsBonificacion]
+
+    // Calcular total (solo items no bonificados, usando subtotalOverride cuando existe)
+    let totalFinal = 0
+    for (const item of todosLosItems) {
+      if ('esBonificacion' in item && item.esBonificacion) continue
+      const override = (item as { subtotalOverride?: number }).subtotalOverride
+      if (override != null) {
+        totalFinal += override
+      } else {
+        totalFinal += item.precioUnitario * item.cantidad
+      }
+    }
 
     if (!isOnline) {
       guardarPedidoOffline({
         clienteId: parseInt(nuevoPedido.clienteId),
-        items: itemsFinales,
+        items: todosLosItems,
         total: totalFinal,
         usuarioId: user?.id ?? '',
         notas: nuevoPedido.notas,
@@ -413,7 +458,7 @@ export function usePedidoHandlers({
     try {
       const pedidoCreado = await crearPedido(
         parseInt(nuevoPedido.clienteId),
-        itemsFinales,
+        todosLosItems,
         totalFinal,
         user?.id ?? '',
         descontarStock,
@@ -443,7 +488,7 @@ export function usePedidoHandlers({
       notify.error('Error al crear pedido: ' + error.message)
     }
     setGuardando(false)
-  }, [nuevoPedidoRef, userRef, isOnlineRef, pricingMapRef, productosRef, validarStock, guardarPedidoOffline, resetNuevoPedido, modales.pedido, crearPedido, descontarStock, registrarPago, refetchProductos, refetchMetricas, notify, setGuardando])
+  }, [nuevoPedidoRef, userRef, isOnlineRef, pricingMapRef, promoMapRef, productosRef, validarStock, guardarPedidoOffline, resetNuevoPedido, modales.pedido, crearPedido, descontarStock, registrarPago, refetchProductos, refetchMetricas, notify, setGuardando])
 
   // State change handlers
   const handleMarcarEntregado = useCallback((pedido: PedidoDB): void => {

--- a/src/hooks/queries/usePedidosQuery.ts
+++ b/src/hooks/queries/usePedidosQuery.ts
@@ -29,6 +29,8 @@ interface PedidoItemInput {
   cantidad: number
   precioUnitario?: number
   precio_unitario?: number
+  esBonificacion?: boolean
+  subtotalOverride?: number
 }
 
 interface CrearPedidoInput {
@@ -224,7 +226,9 @@ async function crearPedido(input: CrearPedidoInput): Promise<{ id: string }> {
   const itemsParaRPC = input.items.map(item => ({
     producto_id: item.productoId || item.producto_id,
     cantidad: item.cantidad,
-    precio_unitario: item.precioUnitario || item.precio_unitario
+    precio_unitario: item.precioUnitario || item.precio_unitario,
+    ...(item.esBonificacion ? { es_bonificacion: true } : {}),
+    ...(item.subtotalOverride != null ? { subtotal: item.subtotalOverride } : {}),
   }))
 
   const { data, error } = await supabase.rpc('crear_pedido_completo', {

--- a/src/hooks/queries/usePromocionesQuery.ts
+++ b/src/hooks/queries/usePromocionesQuery.ts
@@ -1,0 +1,117 @@
+/**
+ * TanStack Query hooks para Promociones
+ * Fetch de promos activas y construcción del PromoMap para resolución
+ */
+import { useQuery } from '@tanstack/react-query'
+import { supabase } from '../supabase/base'
+import type {
+  PromocionDB,
+  PromocionProductoDB,
+  PromocionReglaDB,
+} from '../../types'
+import type { PromoMap, PromocionActiva } from '../../utils/promociones'
+
+// Query keys
+export const promocionesKeys = {
+  all: ['promociones'] as const,
+  lists: () => [...promocionesKeys.all, 'list'] as const,
+  promoMap: () => [...promocionesKeys.all, 'promo_map'] as const,
+}
+
+// =============================================================================
+// FETCH FUNCTIONS
+// =============================================================================
+
+/**
+ * Fetch denormalizado que construye el PromoMap para resolución O(1)
+ * Solo trae promociones activas dentro de su rango de fechas.
+ */
+async function fetchPromoMap(): Promise<PromoMap> {
+  const hoy = new Date().toISOString().split('T')[0]
+
+  // 1. Fetch promos activas en rango de fecha
+  const { data: promos, error: errorPromos } = await supabase
+    .from('promociones')
+    .select('*')
+    .eq('activo', true)
+    .lte('fecha_inicio', hoy)
+    .or(`fecha_fin.is.null,fecha_fin.gte.${hoy}`)
+
+  if (errorPromos) {
+    if (errorPromos.message.includes('does not exist')) return new Map()
+    throw errorPromos
+  }
+  if (!promos || promos.length === 0) return new Map()
+
+  const promoIds = (promos as PromocionDB[]).map(p => p.id)
+
+  // 2. Fetch productos de esas promos
+  const { data: productos, error: errorProductos } = await supabase
+    .from('promocion_productos')
+    .select('*')
+    .in('promocion_id', promoIds)
+
+  if (errorProductos && !errorProductos.message.includes('does not exist')) {
+    throw errorProductos
+  }
+
+  // 3. Fetch reglas de esas promos
+  const { data: reglas, error: errorReglas } = await supabase
+    .from('promocion_reglas')
+    .select('*')
+    .in('promocion_id', promoIds)
+
+  if (errorReglas && !errorReglas.message.includes('does not exist')) {
+    throw errorReglas
+  }
+
+  // 4. Build PromoMap
+  const map: PromoMap = new Map()
+
+  for (const promo of promos as PromocionDB[]) {
+    const promoProductos = ((productos || []) as PromocionProductoDB[])
+      .filter(p => String(p.promocion_id) === String(promo.id))
+    const promoReglas = ((reglas || []) as PromocionReglaDB[])
+      .filter(r => String(r.promocion_id) === String(promo.id))
+
+    const productoIds = promoProductos.map(p => String(p.producto_id))
+    if (productoIds.length === 0) continue
+
+    const reglasMap: Record<string, number> = {}
+    for (const r of promoReglas) {
+      reglasMap[r.clave] = Number(r.valor)
+    }
+
+    const promoActiva: PromocionActiva = {
+      id: String(promo.id),
+      nombre: promo.nombre,
+      tipo: promo.tipo,
+      productoIds,
+      reglas: reglasMap,
+    }
+
+    for (const productoId of productoIds) {
+      const existing = map.get(productoId) || []
+      existing.push(promoActiva)
+      map.set(productoId, existing)
+    }
+  }
+
+  return map
+}
+
+// =============================================================================
+// HOOKS
+// =============================================================================
+
+/**
+ * Hook para obtener el PromoMap denormalizado (para resolución de promos)
+ * Cache 5 minutos (más corto que mayorista por ser temporal)
+ */
+export function usePromoMapQuery() {
+  return useQuery({
+    queryKey: promocionesKeys.promoMap(),
+    queryFn: fetchPromoMap,
+    staleTime: 5 * 60 * 1000,
+  })
+}

--- a/src/hooks/supabase/usePedidos.ts
+++ b/src/hooks/supabase/usePedidos.ts
@@ -46,6 +46,8 @@ interface PedidoItemInput {
   cantidad: number;
   precioUnitario?: number;
   precio_unitario?: number;
+  esBonificacion?: boolean;
+  subtotalOverride?: number;
 }
 
 interface OrdenEntregaItem {
@@ -293,7 +295,9 @@ export function usePedidos(): UsePedidosHookReturn {
     const itemsParaRPC = items.map(item => ({
       producto_id: item.productoId || item.producto_id,
       cantidad: item.cantidad,
-      precio_unitario: item.precioUnitario || item.precio_unitario
+      precio_unitario: item.precioUnitario || item.precio_unitario,
+      ...(item.esBonificacion ? { es_bonificacion: true } : {}),
+      ...(item.subtotalOverride != null ? { subtotal: item.subtotalOverride } : {}),
     }))
 
     const { data, error } = await supabase.rpc('crear_pedido_completo', {
@@ -487,7 +491,9 @@ export function usePedidos(): UsePedidosHookReturn {
     const itemsParaRPC = items.map(item => ({
       producto_id: item.productoId || item.producto_id,
       cantidad: item.cantidad,
-      precio_unitario: item.precioUnitario || item.precio_unitario
+      precio_unitario: item.precioUnitario || item.precio_unitario,
+      ...(item.esBonificacion ? { es_bonificacion: true } : {}),
+      ...(item.subtotalOverride != null ? { subtotal: item.subtotalOverride } : {}),
     }))
 
     const { data, error } = await supabase.rpc('actualizar_pedido_items', {

--- a/src/hooks/usePromocionPedido.ts
+++ b/src/hooks/usePromocionPedido.ts
@@ -1,0 +1,207 @@
+/**
+ * Hook reactivo para resolución de promociones + precios mayoristas
+ *
+ * Orquesta:
+ * 1. Promos activas (bonificación, precio por pares)
+ * 2. Precios mayoristas (excluyendo productos con promo)
+ * 3. Genera items finales con bonificaciones incluidas
+ * 4. Calcula totales correctos
+ */
+import { useMemo } from 'react'
+import { usePricingMapQuery } from './queries/useGruposPrecioQuery'
+import { usePromoMapQuery } from './queries/usePromocionesQuery'
+import {
+  resolverPreciosMayorista,
+  calcularFaltanteParaTier,
+  construirMOQMap,
+  validarMOQPedido,
+  type ItemPedido,
+  type PrecioResuelto,
+  type FaltanteParaTier,
+  type ViolacionMOQ,
+} from '../utils/precioMayorista'
+import {
+  resolverPromociones,
+  calcularFaltanteParaBonificacion,
+  type PromoResolucion,
+  type BonificacionResult,
+  type PrecioParResult,
+} from '../utils/promociones'
+
+export interface ItemPedidoConPromo extends ItemPedido {
+  esBonificacion?: boolean
+  subtotalOverride?: number
+  promoDetalle?: string
+  promoNombre?: string
+}
+
+interface UsePromocionPedidoReturn {
+  /** Mapa de productoId → precio resuelto (mayorista) */
+  preciosResueltos: Map<string, PrecioResuelto>
+  /** Nudges de mayorista */
+  faltantes: FaltanteParaTier[]
+  /** Resolución de promociones */
+  promoResolucion: PromoResolucion
+  /** Nudges de bonificación */
+  faltantesBonificacion: Array<{ productoId: string; promoNombre: string; faltante: number; bonificacion: number }>
+  /** Items finales con bonificaciones añadidas y precios ajustados */
+  itemsFinales: ItemPedidoConPromo[]
+  /** Total calculado correctamente con promos */
+  totalFinal: number
+  /** Total original sin ningún descuento */
+  totalOriginal: number
+  /** Ahorro total */
+  ahorro: number
+  /** Si hay al menos un item con precio mayorista o promo */
+  hayDescuento: boolean
+  /** Loading */
+  isLoading: boolean
+  /** Mapa MOQ */
+  moqMap: Map<string, number>
+  /** Violaciones MOQ */
+  violacionesMOQ: ViolacionMOQ[]
+}
+
+export function usePromocionPedido(items: ItemPedido[]): UsePromocionPedidoReturn {
+  const { data: pricingMap, isLoading: loadingPricing } = usePricingMapQuery()
+  const { data: promoMap, isLoading: loadingPromos } = usePromoMapQuery()
+
+  // 1. Resolver promociones
+  const promoResolucion = useMemo((): PromoResolucion => {
+    if (!promoMap || promoMap.size === 0 || items.length === 0) {
+      return { bonificaciones: [], preciosPar: new Map(), productosConPromo: new Set() }
+    }
+    return resolverPromociones(items, promoMap)
+  }, [items, promoMap])
+
+  // 2. Resolver mayorista EXCLUYENDO productos con promo
+  const preciosResueltos = useMemo(() => {
+    if (!pricingMap || pricingMap.size === 0 || items.length === 0) {
+      return new Map<string, PrecioResuelto>()
+    }
+    // Filtrar items que NO tienen promo para resolver mayorista
+    const itemsSinPromo = items.filter(
+      i => !promoResolucion.productosConPromo.has(String(i.productoId))
+    )
+    if (itemsSinPromo.length === 0) return new Map<string, PrecioResuelto>()
+    return resolverPreciosMayorista(itemsSinPromo, pricingMap)
+  }, [items, pricingMap, promoResolucion.productosConPromo])
+
+  // 3. Nudges mayorista
+  const faltantes = useMemo(() => {
+    if (!pricingMap || pricingMap.size === 0 || items.length === 0) return []
+    const itemsSinPromo = items.filter(
+      i => !promoResolucion.productosConPromo.has(String(i.productoId))
+    )
+    return calcularFaltanteParaTier(itemsSinPromo, pricingMap)
+  }, [items, pricingMap, promoResolucion.productosConPromo])
+
+  // 4. Nudges bonificación
+  const faltantesBonificacion = useMemo(() => {
+    if (!promoMap || promoMap.size === 0 || items.length === 0) return []
+    return calcularFaltanteParaBonificacion(items, promoMap)
+  }, [items, promoMap])
+
+  // 5. Construir items finales
+  const itemsFinales = useMemo((): ItemPedidoConPromo[] => {
+    const result: ItemPedidoConPromo[] = []
+
+    for (const item of items) {
+      const pid = String(item.productoId)
+      const precioParResult = promoResolucion.preciosPar.get(pid)
+      const precioMayorista = preciosResueltos.get(pid)
+
+      if (precioParResult) {
+        // Producto con promo de precio por pares
+        result.push({
+          ...item,
+          subtotalOverride: precioParResult.subtotalPromo,
+          promoDetalle: precioParResult.detalle,
+          promoNombre: precioParResult.promoNombre,
+        })
+      } else if (precioMayorista && precioMayorista.esMayorista && !item.precioOverride) {
+        // Producto con precio mayorista (sin promo)
+        result.push({
+          ...item,
+          precioUnitario: precioMayorista.precioResuelto,
+        })
+      } else {
+        result.push({ ...item })
+      }
+    }
+
+    // Agregar items de bonificación
+    for (const bonif of promoResolucion.bonificaciones) {
+      result.push({
+        productoId: bonif.productoId,
+        cantidad: bonif.cantidadBonificacion,
+        precioUnitario: 0,
+        esBonificacion: true,
+        promoNombre: bonif.promoNombre,
+      })
+    }
+
+    return result
+  }, [items, promoResolucion, preciosResueltos])
+
+  // 6. Calcular totales
+  const { totalFinal, totalOriginal } = useMemo(() => {
+    let total = 0
+    let original = 0
+
+    for (const item of items) {
+      const pid = String(item.productoId)
+      original += item.precioUnitario * item.cantidad
+
+      const precioParResult = promoResolucion.preciosPar.get(pid)
+      if (precioParResult) {
+        total += precioParResult.subtotalPromo
+        continue
+      }
+
+      const precioMayorista = preciosResueltos.get(pid)
+      if (precioMayorista) {
+        total += precioMayorista.precioResuelto * item.cantidad
+      } else {
+        total += item.precioUnitario * item.cantidad
+      }
+    }
+
+    return { totalFinal: total, totalOriginal: original }
+  }, [items, promoResolucion.preciosPar, preciosResueltos])
+
+  // 7. Hay descuento?
+  const hayDescuento = useMemo(() => {
+    if (promoResolucion.productosConPromo.size > 0) return true
+    for (const [, r] of preciosResueltos) {
+      if (r.esMayorista) return true
+    }
+    return false
+  }, [promoResolucion.productosConPromo, preciosResueltos])
+
+  // 8. MOQ
+  const moqMap = useMemo(() => {
+    if (!pricingMap || pricingMap.size === 0) return new Map<string, number>()
+    return construirMOQMap(items, pricingMap)
+  }, [items, pricingMap])
+
+  const violacionesMOQ = useMemo(() => {
+    if (!pricingMap || pricingMap.size === 0 || items.length === 0) return []
+    return validarMOQPedido(items, pricingMap)
+  }, [items, pricingMap])
+
+  return {
+    preciosResueltos,
+    faltantes,
+    promoResolucion,
+    faltantesBonificacion,
+    itemsFinales,
+    totalFinal,
+    totalOriginal,
+    ahorro: totalOriginal - totalFinal,
+    hayDescuento,
+    isLoading: loadingPricing || loadingPromos,
+    moqMap,
+    violacionesMOQ,
+  }
+}

--- a/src/types/hooks.ts
+++ b/src/types/hooks.ts
@@ -1387,3 +1387,33 @@ export interface GrupoPrecioFormInput {
     etiqueta?: string | null;
   }>;
 }
+
+// =============================================================================
+// PROMOCIONES TYPES
+// =============================================================================
+
+export type TipoPromocion = 'bonificacion' | 'precio_par';
+
+export interface PromocionDB {
+  id: string;
+  nombre: string;
+  tipo: TipoPromocion;
+  activo: boolean;
+  fecha_inicio: string;
+  fecha_fin: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface PromocionProductoDB {
+  id: string;
+  promocion_id: string;
+  producto_id: string;
+}
+
+export interface PromocionReglaDB {
+  id: string;
+  promocion_id: string;
+  clave: string;
+  valor: number;
+}

--- a/src/utils/promociones.ts
+++ b/src/utils/promociones.ts
@@ -1,0 +1,223 @@
+/**
+ * Utilidades para resolución de promociones temporales
+ *
+ * Tipos de promoción soportados:
+ *   1. bonificacion: Compra X, lleva Y gratis (acumulable)
+ *   2. precio_par: Descuento por pares con umbral de precio completo
+ *
+ * Las promociones tienen prioridad sobre los precios mayoristas:
+ * si un producto tiene promo activa, se usa la promo en vez del mayorista.
+ */
+
+import type { ItemPedido } from './precioMayorista'
+
+// =============================================================================
+// TIPOS
+// =============================================================================
+
+export interface PromocionActiva {
+  id: string
+  nombre: string
+  tipo: 'bonificacion' | 'precio_par'
+  productoIds: string[]
+  reglas: Record<string, number>
+}
+
+/** Mapa de productoId → promos activas que aplican */
+export type PromoMap = Map<string, PromocionActiva[]>
+
+export interface BonificacionResult {
+  productoId: string
+  promoId: string
+  promoNombre: string
+  cantidadBonificacion: number
+}
+
+export interface PrecioParResult {
+  productoId: string
+  promoId: string
+  promoNombre: string
+  subtotalPromo: number
+  precioEfectivo: number
+  detalle: string
+}
+
+export interface PromoResolucion {
+  bonificaciones: BonificacionResult[]
+  preciosPar: Map<string, PrecioParResult>
+  productosConPromo: Set<string>
+}
+
+// =============================================================================
+// FUNCIONES PRINCIPALES
+// =============================================================================
+
+/**
+ * Resuelve todas las promociones activas para los items del pedido.
+ *
+ * @param items - Items del pedido actual
+ * @param promoMap - Mapa de productoId → promos activas
+ * @returns Bonificaciones a agregar, precios por pares ajustados, y set de productos con promo
+ */
+export function resolverPromociones(
+  items: ItemPedido[],
+  promoMap: PromoMap
+): PromoResolucion {
+  const bonificaciones: BonificacionResult[] = []
+  const preciosPar = new Map<string, PrecioParResult>()
+  const productosConPromo = new Set<string>()
+
+  for (const item of items) {
+    if (item.precioOverride) continue
+
+    const promos = promoMap.get(String(item.productoId))
+    if (!promos) continue
+
+    for (const promo of promos) {
+      if (promo.tipo === 'bonificacion') {
+        const result = resolverBonificacion(item, promo)
+        if (result) {
+          bonificaciones.push(result)
+          productosConPromo.add(String(item.productoId))
+        }
+      }
+
+      if (promo.tipo === 'precio_par') {
+        const result = resolverPrecioPar(item, promo)
+        if (result) {
+          preciosPar.set(String(item.productoId), result)
+          productosConPromo.add(String(item.productoId))
+        }
+      }
+    }
+  }
+
+  return { bonificaciones, preciosPar, productosConPromo }
+}
+
+// =============================================================================
+// RESOLUCIÓN POR TIPO
+// =============================================================================
+
+/**
+ * Resuelve una promo de bonificación para un item.
+ * Acumulable: cada N unidades compradas se bonifican M.
+ */
+function resolverBonificacion(
+  item: ItemPedido,
+  promo: PromocionActiva
+): BonificacionResult | null {
+  const cantCompra = promo.reglas['cantidad_compra']
+  const cantBonif = promo.reglas['cantidad_bonificacion']
+
+  if (!cantCompra || !cantBonif || cantCompra <= 0) return null
+
+  const bloques = Math.floor(item.cantidad / cantCompra)
+  if (bloques <= 0) return null
+
+  return {
+    productoId: String(item.productoId),
+    promoId: promo.id,
+    promoNombre: promo.nombre,
+    cantidadBonificacion: bloques * cantBonif,
+  }
+}
+
+/**
+ * Resuelve una promo de precio por pares.
+ *
+ * Lógica:
+ *   - qty >= umbral_todo_promo → todas las unidades al precio promo
+ *   - qty < umbral → pares al precio promo, sueltas al precio regular
+ */
+function resolverPrecioPar(
+  item: ItemPedido,
+  promo: PromocionActiva
+): PrecioParResult | null {
+  const precioPromo = promo.reglas['precio_promo']
+  const precioRegular = promo.reglas['precio_regular'] ?? item.precioUnitario
+  const umbral = promo.reglas['umbral_todo_promo'] ?? Infinity
+
+  if (precioPromo == null || precioPromo <= 0) return null
+  // Solo aplicar si el precio promo es realmente menor que el regular
+  if (precioPromo >= precioRegular) return null
+
+  const qty = item.cantidad
+  let subtotal: number
+  let detalle: string
+
+  if (qty >= umbral) {
+    subtotal = qty * precioPromo
+    detalle = `${qty}×$${formatPrecio(precioPromo)}`
+  } else {
+    const pares = Math.floor(qty / 2)
+    const sueltas = qty % 2
+    subtotal = (pares * 2 * precioPromo) + (sueltas * precioRegular)
+
+    if (pares > 0 && sueltas > 0) {
+      detalle = `${pares * 2}×$${formatPrecio(precioPromo)} + ${sueltas}×$${formatPrecio(precioRegular)}`
+    } else if (pares > 0) {
+      detalle = `${qty}×$${formatPrecio(precioPromo)}`
+    } else {
+      // Solo sueltas, no hay descuento real
+      return null
+    }
+  }
+
+  return {
+    productoId: String(item.productoId),
+    promoId: promo.id,
+    promoNombre: promo.nombre,
+    subtotalPromo: subtotal,
+    precioEfectivo: subtotal / qty,
+    detalle,
+  }
+}
+
+// =============================================================================
+// HELPERS
+// =============================================================================
+
+function formatPrecio(precio: number): string {
+  return precio.toLocaleString('es-AR', { maximumFractionDigits: 0 })
+}
+
+/**
+ * Calcula cuánto falta para activar una bonificación.
+ * Útil para nudges tipo "agrega X más para recibir Y gratis".
+ */
+export function calcularFaltanteParaBonificacion(
+  items: ItemPedido[],
+  promoMap: PromoMap
+): Array<{ productoId: string; promoNombre: string; faltante: number; bonificacion: number }> {
+  const faltantes: Array<{ productoId: string; promoNombre: string; faltante: number; bonificacion: number }> = []
+
+  for (const item of items) {
+    const promos = promoMap.get(String(item.productoId))
+    if (!promos) continue
+
+    for (const promo of promos) {
+      if (promo.tipo !== 'bonificacion') continue
+
+      const cantCompra = promo.reglas['cantidad_compra']
+      const cantBonif = promo.reglas['cantidad_bonificacion']
+      if (!cantCompra || !cantBonif) continue
+
+      const resto = item.cantidad % cantCompra
+      if (resto === 0) continue // Ya califica exacto
+
+      const faltante = cantCompra - resto
+      // Solo mostrar nudge si falta poco (menos del 50%)
+      if (faltante <= Math.ceil(cantCompra * 0.5)) {
+        faltantes.push({
+          productoId: String(item.productoId),
+          promoNombre: promo.nombre,
+          faltante,
+          bonificacion: cantBonif,
+        })
+      }
+    }
+  }
+
+  return faltantes
+}


### PR DESCRIPTION
Add two new promotion types:
- Bonificacion: buy X units, get Y free (accumulative). Free items appear as separate $0 line items with es_bonificacion flag.
- Pair pricing: discount per pair with full-discount threshold. Correctly handles odd quantities (qty=3: 2×promo + 1×regular).

Includes DB migration (tables, RLS, updated RPCs), pure resolution logic, reactive hooks, and ModalPedido UI integration with badges, nudges, and stock warnings that account for bonus units.