### PR TITLE
fix: bonificacion items in orders, producto regalo, and usage counter

### DIFF
--- a/migrations/040_promo_display_counter.sql
+++ b/migrations/040_promo_display_counter.sql
@@ -2,13 +2,21 @@
 --
 -- Cambios:
 --   1. Agregar columna promocion_id a pedido_items para trazabilidad
---   2. Actualizar RPCs para incluir promocion_id en INSERT y usar v_cantidad en contador
+--   2. Agregar columna producto_regalo_id a promociones (producto que se regala)
+--   3. Actualizar RPCs para incluir promocion_id en INSERT y usar v_cantidad en contador
 
 -- =============================================================================
 -- 1. Agregar promocion_id a pedido_items
 -- =============================================================================
 
 ALTER TABLE pedido_items ADD COLUMN IF NOT EXISTS promocion_id BIGINT REFERENCES promociones(id) ON DELETE SET NULL;
+
+-- =============================================================================
+-- 2. Agregar producto_regalo_id a promociones
+-- =============================================================================
+
+ALTER TABLE promociones ADD COLUMN IF NOT EXISTS producto_regalo_id BIGINT REFERENCES productos(id) ON DELETE SET NULL;
+COMMENT ON COLUMN promociones.producto_regalo_id IS 'Producto específico que se regala en la bonificación (si NULL, se usa el primer producto del pedido)';
 
 -- =============================================================================
 -- 2. RPC crear_pedido_completo — incluir promocion_id + contador por cantidad

--- a/src/components/containers/PedidosContainer.tsx
+++ b/src/components/containers/PedidosContainer.tsx
@@ -25,7 +25,7 @@ import {
 import { useAuthData } from '../../contexts/AuthDataContext'
 import { useNotification } from '../../contexts/NotificationContext'
 import { useOptimizarRuta } from '../../hooks/useOptimizarRuta'
-import { usePrecioMayorista } from '../../hooks/usePrecioMayorista'
+import { usePromocionPedido } from '../../hooks/usePromocionPedido'
 import { useDebounce } from '../../hooks/useAsync'
 import { supabase } from '../../hooks/supabase/base'
 import type { PedidoDB, FiltrosPedidosState, PerfilDB, RegistrarSalvedadInput, RegistrarSalvedadResult } from '../../types'
@@ -161,7 +161,7 @@ export default function PedidosContainer(): React.ReactElement {
   }, [])
 
   // Resolve wholesale prices for current pedido items
-  const { itemsConPrecioMayorista, totalMayorista } = usePrecioMayorista(nuevoPedido.items)
+  const { itemsFinales, totalFinal } = usePromocionPedido(nuevoPedido.items)
 
   // =========================================================================
   // VistaPedidos handlers
@@ -527,11 +527,18 @@ export default function PedidosContainer(): React.ReactElement {
     }
     setGuardando(true)
     try {
-      // Use wholesale-resolved items and total (falls back to original if no mayorista applies)
+      // Use promo+wholesale-resolved items and total (includes bonificaciones)
+      const itemsParaCrear = itemsFinales.map(item => ({
+        productoId: String(item.productoId),
+        cantidad: item.cantidad,
+        precioUnitario: item.precioUnitario,
+        ...(item.esBonificacion ? { esBonificacion: true as const } : {}),
+        ...(item.promoId ? { promocionId: item.promoId } : {}),
+      }))
       await crearPedido.mutateAsync({
         clienteId: nuevoPedido.clienteId,
-        items: itemsConPrecioMayorista,
-        total: totalMayorista,
+        items: itemsParaCrear,
+        total: totalFinal,
         usuarioId: user?.id ?? null,
         notas: nuevoPedido.notas,
         formaPago: nuevoPedido.formaPago,
@@ -546,7 +553,7 @@ export default function PedidosContainer(): React.ReactElement {
       notify.error('Error al crear pedido: ' + (e as Error).message)
     }
     setGuardando(false)
-  }, [nuevoPedido, itemsConPrecioMayorista, totalMayorista, crearPedido, user, resetNuevoPedido, notify])
+  }, [nuevoPedido, itemsFinales, totalFinal, crearPedido, user, resetNuevoPedido, notify])
 
   // ModalFiltroFecha: onApply({ fechaDesde, fechaHasta })
   const handleFiltroFechaApply = useCallback((f: { fechaDesde: string | null; fechaHasta: string | null }) => {

--- a/src/components/modals/ModalPromocion.tsx
+++ b/src/components/modals/ModalPromocion.tsx
@@ -5,7 +5,7 @@
  * Incluye: nombre, fechas, selector de productos, reglas (cantidad_compra, cantidad_bonificacion).
  */
 import { useState, useMemo } from 'react'
-import { X, Search } from 'lucide-react'
+import { X, Search, Gift } from 'lucide-react'
 import type { ProductoDB } from '../../types'
 import type { PromocionConDetalles, PromocionFormInput } from '../../hooks/queries/usePromocionesQuery'
 
@@ -42,7 +42,11 @@ export default function ModalPromocion({
       return regla ? String(Number(regla.valor)) : ''
     }
   )
+  const [productoRegaloId, setProductoRegaloId] = useState<string>(
+    promocion?.producto_regalo_id ? String(promocion.producto_regalo_id) : ''
+  )
   const [busqueda, setBusqueda] = useState('')
+  const [busquedaRegalo, setBusquedaRegalo] = useState('')
   const [saving, setSaving] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
@@ -54,6 +58,15 @@ export default function ModalPromocion({
       p.codigo?.toLowerCase().includes(q)
     )
   }, [productos, busqueda])
+
+  const productosRegaloFiltrados = useMemo(() => {
+    if (!busquedaRegalo.trim()) return productos
+    const q = busquedaRegalo.toLowerCase()
+    return productos.filter(p =>
+      p.nombre.toLowerCase().includes(q) ||
+      p.codigo?.toLowerCase().includes(q)
+    )
+  }, [productos, busquedaRegalo])
 
   const handleToggleProducto = (id: string) => {
     setProductoIds(prev => {
@@ -97,6 +110,7 @@ export default function ModalPromocion({
       fechaInicio,
       fechaFin: fechaFin || null,
       productoIds: Array.from(productoIds),
+      productoRegaloId: productoRegaloId || null,
       reglas: [
         { clave: 'cantidad_compra', valor: compra },
         { clave: 'cantidad_bonificacion', valor: bonif },
@@ -192,10 +206,63 @@ export default function ModalPromocion({
             )}
           </div>
 
-          {/* Selector de productos */}
+          {/* Producto regalo */}
           <div>
             <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
-              Productos ({productoIds.size} seleccionados)
+              Producto de regalo
+            </label>
+            <p className="text-xs text-gray-500 dark:text-gray-400 mb-2">
+              El producto que se entrega gratis al cumplir la condicion
+            </p>
+            {productoRegaloId && (
+              <div className="flex items-center gap-2 mb-2 px-3 py-2 bg-green-50 dark:bg-green-900/20 border border-green-200 dark:border-green-800 rounded-lg">
+                <Gift className="w-4 h-4 text-green-600 flex-shrink-0" />
+                <span className="text-sm text-green-700 dark:text-green-300 font-medium flex-1">
+                  {productos.find(p => String(p.id) === productoRegaloId)?.nombre || `Producto #${productoRegaloId}`}
+                </span>
+                <button
+                  onClick={() => setProductoRegaloId('')}
+                  className="text-green-600 hover:text-green-800 text-xs underline"
+                >
+                  Quitar
+                </button>
+              </div>
+            )}
+            <div className="relative mb-2">
+              <Search className="absolute left-3 top-2.5 w-4 h-4 text-gray-400" />
+              <input
+                type="text"
+                value={busquedaRegalo}
+                onChange={e => setBusquedaRegalo(e.target.value)}
+                placeholder="Buscar producto de regalo..."
+                className="w-full pl-9 pr-3 py-2 border rounded-lg dark:bg-gray-700 dark:border-gray-600 dark:text-white focus:ring-2 focus:ring-green-500 focus:outline-none text-sm"
+              />
+            </div>
+            {busquedaRegalo.trim() && (
+              <div className="max-h-32 overflow-y-auto border dark:border-gray-600 rounded-lg divide-y dark:divide-gray-700">
+                {productosRegaloFiltrados.map(prod => (
+                  <button
+                    key={prod.id}
+                    onClick={() => { setProductoRegaloId(String(prod.id)); setBusquedaRegalo('') }}
+                    className={`w-full text-left flex items-center gap-2 px-3 py-2 hover:bg-green-50 dark:hover:bg-green-900/20 text-sm ${
+                      String(prod.id) === productoRegaloId ? 'bg-green-50 dark:bg-green-900/20' : ''
+                    }`}
+                  >
+                    <Gift className="w-3.5 h-3.5 text-green-500 flex-shrink-0" />
+                    <span className="dark:text-white truncate">{prod.nombre}</span>
+                  </button>
+                ))}
+                {productosRegaloFiltrados.length === 0 && (
+                  <p className="text-sm text-gray-400 px-3 py-4 text-center">Sin resultados</p>
+                )}
+              </div>
+            )}
+          </div>
+
+          {/* Selector de productos (que activan la promo) */}
+          <div>
+            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+              Productos que activan la promo ({productoIds.size} seleccionados)
             </label>
             <div className="relative mb-2">
               <Search className="absolute left-3 top-2.5 w-4 h-4 text-gray-400" />

--- a/src/components/vistas/VistaPromociones.tsx
+++ b/src/components/vistas/VistaPromociones.tsx
@@ -175,11 +175,23 @@ export default function VistaPromociones({
                   <div className="mb-3 px-3 py-2 bg-purple-50 dark:bg-purple-900/20 border border-purple-200 dark:border-purple-800 rounded-lg">
                     <p className="text-sm font-medium text-purple-700 dark:text-purple-300">
                       <Gift className="w-4 h-4 inline mr-1" />
-                      Compra {cantCompra} → Lleva {cantBonif} gratis
+                      Comprando {cantCompra} fardos → {cantBonif} {promo.producto_regalo_id ? getProductoNombre(String(promo.producto_regalo_id)) : 'del mismo producto'} gratis
                       <span className="text-xs text-purple-500 ml-2">(acumulable)</span>
                     </p>
                   </div>
                 )}
+
+                {/* Contador de usos */}
+                <div className="mb-3 px-3 py-2 bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-800 rounded-lg flex items-center justify-between">
+                  <p className="text-sm text-blue-700 dark:text-blue-300">
+                    <span className="font-medium">Unidades regaladas:</span> {promo.usos_pendientes} pendientes de ajuste
+                  </p>
+                  {promo.usos_pendientes > 0 && (
+                    <span className="text-xs bg-orange-100 dark:bg-orange-900/30 text-orange-700 dark:text-orange-300 px-2 py-0.5 rounded-full font-medium">
+                      Ajustar stock
+                    </span>
+                  )}
+                </div>
 
                 {/* Productos */}
                 <div className="mb-3">

--- a/src/hooks/queries/usePromocionesQuery.ts
+++ b/src/hooks/queries/usePromocionesQuery.ts
@@ -34,6 +34,7 @@ export interface PromocionFormInput {
   fechaInicio: string
   fechaFin?: string | null
   productoIds: string[]
+  productoRegaloId?: string | null
   reglas: { clave: string; valor: number }[]
 }
 
@@ -103,6 +104,7 @@ async function fetchPromoMap(): Promise<PromoMap> {
       tipo: promo.tipo,
       productoIds,
       reglas: reglasMap,
+      productoRegaloId: promo.producto_regalo_id ? String(promo.producto_regalo_id) : undefined,
     }
 
     for (const productoId of productoIds) {
@@ -164,6 +166,7 @@ async function createPromocion(input: PromocionFormInput): Promise<PromocionConD
       tipo: input.tipo,
       fecha_inicio: input.fechaInicio,
       fecha_fin: input.fechaFin || null,
+      producto_regalo_id: input.productoRegaloId ? parseInt(input.productoRegaloId) : null,
     }])
     .select()
     .single()
@@ -221,6 +224,7 @@ async function updatePromocion(
       tipo: input.tipo,
       fecha_inicio: input.fechaInicio,
       fecha_fin: input.fechaFin || null,
+      producto_regalo_id: input.productoRegaloId ? parseInt(input.productoRegaloId) : null,
     })
     .eq('id', id)
     .select()

--- a/src/hooks/usePromocionPedido.ts
+++ b/src/hooks/usePromocionPedido.ts
@@ -30,6 +30,7 @@ import {
 export interface ItemPedidoConPromo extends ItemPedido {
   esBonificacion?: boolean
   promoNombre?: string
+  promoId?: string
 }
 
 interface UsePromocionPedidoReturn {
@@ -124,6 +125,7 @@ export function usePromocionPedido(items: ItemPedido[]): UsePromocionPedidoRetur
         precioUnitario: 0,
         esBonificacion: true,
         promoNombre: bonif.promoNombre,
+        promoId: bonif.promoId,
       })
     }
 

--- a/src/types/hooks.ts
+++ b/src/types/hooks.ts
@@ -1403,6 +1403,8 @@ export interface PromocionDB {
   activo: boolean;
   fecha_inicio: string;
   fecha_fin: string | null;
+  producto_regalo_id?: string | null;
+  usos_pendientes?: number;
   created_at: string;
   updated_at: string;
 }

--- a/src/utils/promociones.ts
+++ b/src/utils/promociones.ts
@@ -23,6 +23,7 @@ export interface PromocionActiva {
   tipo: 'bonificacion'
   productoIds: string[]
   reglas: Record<string, number>
+  productoRegaloId?: string
 }
 
 /** Mapa de productoId → promos activas que aplican */
@@ -97,7 +98,7 @@ export function resolverPromociones(
     if (bloques <= 0) continue
 
     bonificaciones.push({
-      productoId: primerProductoId,
+      productoId: promo.productoRegaloId || primerProductoId,
       promoId: promo.id,
       promoNombre: promo.nombre,
       cantidadBonificacion: bloques * cantBonif,


### PR DESCRIPTION
- PedidosContainer now uses usePromocionPedido instead of usePrecioMayorista, so bonificacion items are actually included in orders
- Add producto_regalo_id to promociones for specifying which product is the gift (e.g. Manaos Citrus) instead of defaulting to first cart item
- Show usage counter (unidades regaladas) in promo admin panel always
- Update promo config modal with producto regalo selector
- Better promo description showing actual regalo product name