### PR TITLE
fix: use nullish coalescing for precio_unitario to allow zero values

### DIFF
--- a/src/hooks/queries/usePedidosQuery.ts
+++ b/src/hooks/queries/usePedidosQuery.ts
@@ -226,7 +226,7 @@ async function crearPedido(input: CrearPedidoInput): Promise<{ id: string }> {
   const itemsParaRPC = input.items.map(item => ({
     producto_id: item.productoId || item.producto_id,
     cantidad: item.cantidad,
-    precio_unitario: item.precioUnitario || item.precio_unitario,
+    precio_unitario: item.precioUnitario ?? item.precio_unitario ?? 0,
     ...(item.esBonificacion ? { es_bonificacion: true } : {}),
     ...(item.promocionId ? { promocion_id: item.promocionId } : {}),
   }))

--- a/src/hooks/supabase/usePedidos.ts
+++ b/src/hooks/supabase/usePedidos.ts
@@ -295,7 +295,7 @@ export function usePedidos(): UsePedidosHookReturn {
     const itemsParaRPC = items.map(item => ({
       producto_id: item.productoId || item.producto_id,
       cantidad: item.cantidad,
-      precio_unitario: item.precioUnitario || item.precio_unitario,
+      precio_unitario: item.precioUnitario ?? item.precio_unitario ?? 0,
       ...(item.esBonificacion ? { es_bonificacion: true } : {}),
       ...(item.promocionId ? { promocion_id: item.promocionId } : {}),
     }))
@@ -491,7 +491,7 @@ export function usePedidos(): UsePedidosHookReturn {
     const itemsParaRPC = items.map(item => ({
       producto_id: item.productoId || item.producto_id,
       cantidad: item.cantidad,
-      precio_unitario: item.precioUnitario || item.precio_unitario,
+      precio_unitario: item.precioUnitario ?? item.precio_unitario ?? 0,
       ...(item.esBonificacion ? { es_bonificacion: true } : {}),
       ...(item.promocionId ? { promocion_id: item.promocionId } : {}),
     }))


### PR DESCRIPTION
Bonificacion items have precioUnitario=0, but the || operator treated 0 as falsy, falling through to undefined and causing a NOT NULL violation in pedido_items.precio_unitario. Replace || with ?? across all RPC mappings.