### PR TITLE
feat: fix salvedad validation, add movimiento entre sucursales

### DIFF
--- a/migrations/042_movimientos_sucursales.sql
+++ b/migrations/042_movimientos_sucursales.sql
@@ -1,0 +1,59 @@
+-- ============================================================================
+-- 042: Movimientos entre Sucursales - soporte ingreso desde sucursal
+-- ============================================================================
+
+-- 1. Agregar columna tipo a transferencias_stock
+ALTER TABLE transferencias_stock
+ADD COLUMN IF NOT EXISTS tipo VARCHAR(20) NOT NULL DEFAULT 'salida';
+
+-- 2. RPC para registrar ingreso desde sucursal (aumenta stock)
+CREATE OR REPLACE FUNCTION public.registrar_ingreso_sucursal(
+  p_sucursal_id BIGINT,
+  p_fecha DATE DEFAULT CURRENT_DATE,
+  p_notas TEXT DEFAULT NULL,
+  p_total_costo DECIMAL DEFAULT 0,
+  p_usuario_id UUID DEFAULT NULL,
+  p_items JSONB DEFAULT '[]'
+)
+RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_trans_id BIGINT;
+  v_item JSONB;
+  v_stock_actual INTEGER;
+  v_producto_id BIGINT;
+  v_cantidad INTEGER;
+  v_costo DECIMAL;
+  v_sub DECIMAL;
+BEGIN
+  INSERT INTO transferencias_stock (sucursal_id, fecha, notas, total_costo, usuario_id, tipo)
+  VALUES (p_sucursal_id, p_fecha, p_notas, p_total_costo, p_usuario_id, 'ingreso')
+  RETURNING id INTO v_trans_id;
+
+  FOR v_item IN SELECT * FROM jsonb_array_elements(p_items)
+  LOOP
+    v_producto_id := (v_item->>'producto_id')::BIGINT;
+    v_cantidad := (v_item->>'cantidad')::INTEGER;
+    v_costo := (v_item->>'costo_unitario')::DECIMAL;
+    v_sub := (v_item->>'subtotal')::DECIMAL;
+
+    SELECT stock INTO v_stock_actual FROM productos WHERE id = v_producto_id FOR UPDATE;
+
+    IF v_stock_actual IS NULL THEN
+      RAISE EXCEPTION 'Producto % no encontrado', v_producto_id;
+    END IF;
+
+    INSERT INTO transferencia_items (transferencia_id, producto_id, cantidad, costo_unitario, subtotal, stock_anterior, stock_nuevo)
+    VALUES (v_trans_id, v_producto_id, v_cantidad, v_costo, v_sub, v_stock_actual, v_stock_actual + v_cantidad);
+
+    UPDATE productos SET stock = v_stock_actual + v_cantidad WHERE id = v_producto_id;
+  END LOOP;
+
+  RETURN jsonb_build_object('success', true, 'transferencia_id', v_trans_id);
+END;
+$$;
+
+COMMENT ON FUNCTION registrar_ingreso_sucursal IS 'Registra un ingreso de stock desde una sucursal (aumenta stock central)';

--- a/src/components/containers/TransferenciasContainer.tsx
+++ b/src/components/containers/TransferenciasContainer.tsx
@@ -2,6 +2,7 @@
  * TransferenciasContainer
  *
  * Container que carga transferencias, sucursales y productos bajo demanda usando TanStack Query.
+ * Soporta salidas e ingresos entre sucursales.
  */
 import React, { lazy, Suspense, useState, useCallback } from 'react'
 import { Loader2 } from 'lucide-react'
@@ -9,16 +10,18 @@ import {
   useTransferenciasQuery,
   useSucursalesQuery,
   useRegistrarTransferenciaMutation,
+  useRegistrarIngresoMutation,
   useCrearSucursalMutation,
   useProductosQuery,
 } from '../../hooks/queries'
 import { useAuthData } from '../../contexts/AuthDataContext'
 import { useNotification } from '../../contexts/NotificationContext'
-import type { TransferenciaFormInput } from '../../types'
+import type { TransferenciaFormInput, TransferenciaDB, TipoTransferencia } from '../../types'
 
 // Lazy load de componentes
 const VistaTransferencias = lazy(() => import('../vistas/VistaTransferencias'))
 const ModalTransferencia = lazy(() => import('../modals/ModalTransferencia'))
+const ModalDetalleTransferencia = lazy(() => import('../modals/ModalDetalleTransferencia'))
 
 function LoadingState() {
   return (
@@ -39,29 +42,47 @@ export default function TransferenciasContainer(): React.ReactElement {
 
   // Mutations
   const registrarTransferencia = useRegistrarTransferenciaMutation()
+  const registrarIngreso = useRegistrarIngresoMutation()
   const crearSucursal = useCrearSucursalMutation()
 
-  // Estado de modal
-  const [modalOpen, setModalOpen] = useState(false)
+  // Estado de modales
+  const [modalTipo, setModalTipo] = useState<TipoTransferencia | null>(null)
+  const [detalleTransferencia, setDetalleTransferencia] = useState<TransferenciaDB | null>(null)
 
   // Handlers
-  const handleNuevaTransferencia = useCallback(() => {
-    setModalOpen(true)
+  const handleNuevaSalida = useCallback(() => {
+    setModalTipo('salida')
+  }, [])
+
+  const handleNuevoIngreso = useCallback(() => {
+    setModalTipo('ingreso')
+  }, [])
+
+  const handleVerDetalle = useCallback((transferencia: TransferenciaDB) => {
+    setDetalleTransferencia(transferencia)
   }, [])
 
   const handleGuardarTransferencia = useCallback(async (data: TransferenciaFormInput) => {
     try {
-      await registrarTransferencia.mutateAsync({
-        ...data,
-        usuarioId: user?.id || null,
-      })
-      notify.success('Envio registrado correctamente')
+      if (data.tipo === 'ingreso') {
+        await registrarIngreso.mutateAsync({
+          ...data,
+          usuarioId: user?.id || null,
+        })
+        notify.success('Ingreso registrado correctamente')
+      } else {
+        await registrarTransferencia.mutateAsync({
+          ...data,
+          usuarioId: user?.id || null,
+        })
+        notify.success('Salida registrada correctamente')
+      }
     } catch (err) {
-      const msg = err instanceof Error ? err.message : 'Error al registrar envio'
+      const msg = err instanceof Error ? err.message : 'Error al registrar movimiento'
       notify.error(msg)
       throw err
     }
-  }, [registrarTransferencia, notify, user])
+  }, [registrarTransferencia, registrarIngreso, notify, user])
 
   const handleCrearSucursal = useCallback(async (data: { nombre: string; direccion?: string }) => {
     const nueva = await crearSucursal.mutateAsync(data)
@@ -75,19 +96,32 @@ export default function TransferenciasContainer(): React.ReactElement {
         <VistaTransferencias
           transferencias={transferencias}
           loading={isLoading}
-          onNuevaTransferencia={handleNuevaTransferencia}
+          onNuevaSalida={handleNuevaSalida}
+          onNuevoIngreso={handleNuevoIngreso}
+          onVerDetalle={handleVerDetalle}
         />
       </Suspense>
 
-      {/* Modal Nueva Transferencia */}
-      {modalOpen && (
+      {/* Modal Nueva Salida / Nuevo Ingreso */}
+      {modalTipo && (
         <Suspense fallback={null}>
           <ModalTransferencia
+            tipo={modalTipo}
             productos={productos}
             sucursales={sucursales}
             onSave={handleGuardarTransferencia}
             onCrearSucursal={handleCrearSucursal}
-            onClose={() => setModalOpen(false)}
+            onClose={() => setModalTipo(null)}
+          />
+        </Suspense>
+      )}
+
+      {/* Modal Detalle */}
+      {detalleTransferencia && (
+        <Suspense fallback={null}>
+          <ModalDetalleTransferencia
+            transferencia={detalleTransferencia}
+            onClose={() => setDetalleTransferencia(null)}
           />
         </Suspense>
       )}

--- a/src/components/layout/TopNavigation.tsx
+++ b/src/components/layout/TopNavigation.tsx
@@ -72,7 +72,7 @@ const menuGroups: MenuGroup[] = [
       { id: 'proveedores', icon: Building2, label: 'Proveedores', roles: ['admin', 'encargado'] },
       { id: 'condiciones-mayoristas', icon: Tag, label: 'Condiciones Mayoristas', roles: ['admin', 'encargado'] },
       { id: 'promociones', icon: Gift, label: 'Promociones', roles: ['admin', 'encargado'] },
-      { id: 'transferencias', icon: ArrowRightLeft, label: 'Envios a Sucursal', roles: ['admin', 'encargado'] },
+      { id: 'transferencias', icon: ArrowRightLeft, label: 'Mov. Sucursales', roles: ['admin', 'encargado'] },
     ]
   },
   {

--- a/src/components/modals/ModalDetalleTransferencia.tsx
+++ b/src/components/modals/ModalDetalleTransferencia.tsx
@@ -1,0 +1,139 @@
+/**
+ * ModalDetalleTransferencia
+ *
+ * Modal de solo lectura que muestra el detalle de un movimiento entre sucursales.
+ */
+import React from 'react'
+import { X, ArrowUpRight, ArrowDownLeft, Package } from 'lucide-react'
+import { formatPrecio } from '../../utils/formatters'
+import type { TransferenciaDB } from '../../types'
+
+interface ModalDetalleTransferenciaProps {
+  transferencia: TransferenciaDB
+  onClose: () => void
+}
+
+function formatFecha(fecha: string): string {
+  try {
+    return new Date(fecha).toLocaleDateString('es-AR', {
+      day: '2-digit',
+      month: '2-digit',
+      year: 'numeric',
+    })
+  } catch {
+    return fecha
+  }
+}
+
+export default function ModalDetalleTransferencia({
+  transferencia,
+  onClose,
+}: ModalDetalleTransferenciaProps): React.ReactElement {
+  const esIngreso = transferencia.tipo === 'ingreso'
+  const items = transferencia.items || []
+
+  return (
+    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
+      <div className="bg-white dark:bg-gray-800 rounded-xl shadow-2xl w-full max-w-2xl max-h-[90vh] flex flex-col">
+        {/* Header */}
+        <div className="flex items-center justify-between px-6 py-4 border-b dark:border-gray-700">
+          <div className="flex items-center gap-3">
+            <div className={`p-2 rounded-lg ${
+              esIngreso
+                ? 'bg-green-100 dark:bg-green-900/30'
+                : 'bg-blue-100 dark:bg-blue-900/30'
+            }`}>
+              {esIngreso
+                ? <ArrowDownLeft className="w-5 h-5 text-green-600" />
+                : <ArrowUpRight className="w-5 h-5 text-blue-600" />
+              }
+            </div>
+            <div>
+              <h2 className="text-lg font-semibold text-gray-800 dark:text-white">
+                {esIngreso ? 'Ingreso desde Sucursal' : 'Salida a Sucursal'}
+              </h2>
+              <p className="text-sm text-gray-500 dark:text-gray-400">
+                {formatFecha(transferencia.fecha)} - {transferencia.sucursal?.nombre || 'Sin sucursal'}
+              </p>
+            </div>
+          </div>
+          <button
+            onClick={onClose}
+            className="p-2 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors"
+          >
+            <X className="w-5 h-5 text-gray-500 dark:text-gray-400" />
+          </button>
+        </div>
+
+        {/* Body */}
+        <div className="flex-1 overflow-y-auto px-6 py-4 space-y-4">
+          {/* Info */}
+          {(transferencia.notas || transferencia.usuario) && (
+            <div className="space-y-1 text-sm text-gray-600 dark:text-gray-400">
+              {transferencia.usuario && (
+                <p>Registrado por: <span className="font-medium text-gray-800 dark:text-white">{transferencia.usuario.nombre}</span></p>
+              )}
+              {transferencia.notas && (
+                <p>Notas: <span className="text-gray-800 dark:text-white">{transferencia.notas}</span></p>
+              )}
+            </div>
+          )}
+
+          {/* Items table */}
+          {items.length > 0 ? (
+            <div className="border dark:border-gray-700 rounded-lg overflow-hidden">
+              <div className="hidden sm:grid grid-cols-12 gap-2 px-4 py-2 bg-gray-50 dark:bg-gray-700/50 text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">
+                <div className="col-span-5">Producto</div>
+                <div className="col-span-2 text-center">Cantidad</div>
+                <div className="col-span-2 text-right">Costo Unit.</div>
+                <div className="col-span-3 text-right">Subtotal</div>
+              </div>
+              {items.map(item => (
+                <div
+                  key={item.id}
+                  className="grid grid-cols-12 gap-2 px-4 py-3 items-center border-t dark:border-gray-700 first:border-t-0"
+                >
+                  <div className="col-span-12 sm:col-span-5">
+                    <p className="text-sm font-medium text-gray-800 dark:text-white">
+                      {item.producto?.nombre || `Producto #${item.producto_id}`}
+                    </p>
+                    {item.producto?.codigo && (
+                      <p className="text-xs text-gray-500">{item.producto.codigo}</p>
+                    )}
+                  </div>
+                  <div className="col-span-4 sm:col-span-2 text-center text-sm text-gray-800 dark:text-white">
+                    {item.cantidad}
+                  </div>
+                  <div className="col-span-4 sm:col-span-2 text-right text-sm text-gray-600 dark:text-gray-300">
+                    {formatPrecio(item.costo_unitario)}
+                  </div>
+                  <div className="col-span-4 sm:col-span-3 text-right text-sm font-medium text-gray-800 dark:text-white">
+                    {formatPrecio(item.subtotal)}
+                  </div>
+                </div>
+              ))}
+            </div>
+          ) : (
+            <div className="flex flex-col items-center py-8 text-gray-400">
+              <Package className="w-8 h-8 mb-2" />
+              <p className="text-sm">Sin items</p>
+            </div>
+          )}
+        </div>
+
+        {/* Footer */}
+        <div className="flex items-center justify-between px-6 py-4 border-t dark:border-gray-700 bg-gray-50 dark:bg-gray-800/50">
+          <div className="text-lg font-semibold text-gray-800 dark:text-white">
+            Total: {formatPrecio(transferencia.total_costo)}
+          </div>
+          <button
+            onClick={onClose}
+            className="px-4 py-2 border dark:border-gray-600 rounded-lg text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors font-medium"
+          >
+            Cerrar
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/components/modals/ModalEntregaConSalvedad.tsx
+++ b/src/components/modals/ModalEntregaConSalvedad.tsx
@@ -5,7 +5,7 @@
  */
 import React, { useState, useCallback } from 'react'
 import { X, AlertTriangle, Package, Check, ChevronDown, ChevronUp, Truck } from 'lucide-react'
-import { MOTIVOS_SALVEDAD_LABELS, itemSalvedadSchema } from '../../lib/schemas'
+import { MOTIVOS_SALVEDAD_LABELS } from '../../lib/schemas'
 import type { PedidoDB, PedidoItemDB, MotivoSalvedad, RegistrarSalvedadInput, RegistrarSalvedadResult } from '../../types'
 
 interface MotivoOption {
@@ -79,23 +79,24 @@ export default function ModalEntregaConSalvedad({
     for (const itemSalv of itemsConSalvedad) {
       const productoNombre = itemSalv.item.producto?.nombre || 'Producto'
 
-      // Validar con Zod schema
-      const result = itemSalvedadSchema.safeParse({
-        itemId: itemSalv.item.id,
-        cantidadAfectada: itemSalv.cantidadAfectada,
-        motivo: itemSalv.motivo || undefined,
-        descripcion: itemSalv.descripcion
-      })
-
-      if (!result.success) {
-        const firstError = result.error.issues[0]?.message || 'Error de validación'
-        setError(`${productoNombre}: ${firstError}`)
+      // Validaciones explícitas antes de Zod (Zod 4 da mensajes genéricos para enum/undefined)
+      if (!itemSalv.motivo) {
+        setError(`${productoNombre}: Debe seleccionar un motivo`)
         return false
       }
 
-      // Validación adicional: cantidad no puede exceder la cantidad del item
+      if (!itemSalv.cantidadAfectada || itemSalv.cantidadAfectada <= 0 || !Number.isInteger(itemSalv.cantidadAfectada)) {
+        setError(`${productoNombre}: La cantidad debe ser un número entero mayor a 0`)
+        return false
+      }
+
       if (itemSalv.cantidadAfectada > itemSalv.item.cantidad) {
-        setError(`La cantidad no puede exceder ${itemSalv.item.cantidad} para "${productoNombre}"`)
+        setError(`${productoNombre}: La cantidad no puede exceder ${itemSalv.item.cantidad}`)
+        return false
+      }
+
+      if (itemSalv.motivo === 'otro' && (!itemSalv.descripcion || itemSalv.descripcion.trim().length < 10)) {
+        setError(`${productoNombre}: Debe especificar una descripción (mínimo 10 caracteres)`)
         return false
       }
     }

--- a/src/components/modals/ModalTransferencia.tsx
+++ b/src/components/modals/ModalTransferencia.tsx
@@ -7,9 +7,10 @@
 import React, { useState, useMemo } from 'react'
 import { X, Search, Trash2, Plus, ArrowRightLeft } from 'lucide-react'
 import { formatPrecio } from '../../utils/formatters'
-import type { ProductoDB, SucursalDB, TransferenciaFormInput } from '../../types'
+import type { ProductoDB, SucursalDB, TransferenciaFormInput, TipoTransferencia } from '../../types'
 
 interface ModalTransferenciaProps {
+  tipo: TipoTransferencia
   productos: ProductoDB[]
   sucursales: SucursalDB[]
   onSave: (data: TransferenciaFormInput) => Promise<void>
@@ -30,12 +31,14 @@ function getCosto(producto: ProductoDB): number {
 }
 
 export default function ModalTransferencia({
+  tipo,
   productos,
   sucursales,
   onSave,
   onCrearSucursal,
   onClose,
 }: ModalTransferenciaProps): React.ReactElement {
+  const esIngreso = tipo === 'ingreso'
   // Form state
   const [sucursalId, setSucursalId] = useState('')
   const [fecha, setFecha] = useState(() => new Date().toISOString().split('T')[0])
@@ -61,13 +64,13 @@ export default function ModalTransferencia({
     return productos
       .filter(p =>
         !idsAgregados.has(p.id) &&
-        p.stock > 0 &&
+        (esIngreso || p.stock > 0) &&
         (p.nombre.toLowerCase().includes(termino) ||
          (p.categoria && p.categoria.toLowerCase().includes(termino)) ||
          (p.codigo && p.codigo.toLowerCase().includes(termino)))
       )
       .slice(0, 20)
-  }, [busqueda, productos, idsAgregados])
+  }, [busqueda, productos, idsAgregados, esIngreso])
 
   // Total
   const totalCosto = useMemo(
@@ -95,7 +98,7 @@ export default function ModalTransferencia({
     setItems(prev =>
       prev.map(item =>
         item.productoId === productoId
-          ? { ...item, cantidad: Math.max(1, Math.min(cantidad, item.stockDisponible)) }
+          ? { ...item, cantidad: esIngreso ? Math.max(1, cantidad) : Math.max(1, Math.min(cantidad, item.stockDisponible)) }
           : item
       )
     )
@@ -136,7 +139,7 @@ export default function ModalTransferencia({
       setError('Agrega al menos un producto')
       return
     }
-    const itemInvalido = items.find(i => i.cantidad <= 0 || i.cantidad > i.stockDisponible)
+    const itemInvalido = items.find(i => i.cantidad <= 0 || (!esIngreso && i.cantidad > i.stockDisponible))
     if (itemInvalido) {
       setError(`Cantidad invalida para "${itemInvalido.nombre}"`)
       return
@@ -149,6 +152,7 @@ export default function ModalTransferencia({
         fecha,
         notas: notas.trim() || null,
         totalCosto,
+        tipo,
         items: items.map(item => ({
           productoId: item.productoId,
           cantidad: item.cantidad,
@@ -172,7 +176,9 @@ export default function ModalTransferencia({
         <div className="flex items-center justify-between px-6 py-4 border-b dark:border-gray-700">
           <div className="flex items-center gap-3">
             <ArrowRightLeft className="w-5 h-5 text-blue-600" />
-            <h2 className="text-lg font-semibold text-gray-800 dark:text-white">Envio a Sucursal</h2>
+            <h2 className="text-lg font-semibold text-gray-800 dark:text-white">
+              {esIngreso ? 'Ingreso desde Sucursal' : 'Salida a Sucursal'}
+            </h2>
           </div>
           <button
             onClick={onClose}
@@ -194,7 +200,7 @@ export default function ModalTransferencia({
           {/* Sucursal selector */}
           <div>
             <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
-              Sucursal destino
+              {esIngreso ? 'Sucursal origen' : 'Sucursal destino'}
             </label>
             <div className="flex gap-2">
               <select
@@ -308,7 +314,7 @@ export default function ModalTransferencia({
           {items.length > 0 && (
             <div>
               <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
-                Productos a enviar ({items.length})
+                {esIngreso ? 'Productos a ingresar' : 'Productos a enviar'} ({items.length})
               </label>
               <div className="border dark:border-gray-600 rounded-lg overflow-hidden">
                 <div className="hidden sm:grid grid-cols-12 gap-2 px-4 py-2 bg-gray-50 dark:bg-gray-700/50 text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">
@@ -335,7 +341,7 @@ export default function ModalTransferencia({
                       <input
                         type="number"
                         min={1}
-                        max={item.stockDisponible}
+                        max={esIngreso ? undefined : item.stockDisponible}
                         value={item.cantidad}
                         onChange={e => handleCantidadChange(item.productoId, parseInt(e.target.value) || 1)}
                         className="w-20 text-center border dark:border-gray-600 rounded-lg px-2 py-1 bg-white dark:bg-gray-700 text-gray-800 dark:text-white text-sm focus:ring-2 focus:ring-blue-500"
@@ -399,7 +405,7 @@ export default function ModalTransferencia({
               disabled={guardando || items.length === 0 || !sucursalId}
               className="px-6 py-2 bg-blue-600 hover:bg-blue-700 disabled:opacity-50 text-white rounded-lg font-medium transition-colors"
             >
-              {guardando ? 'Registrando...' : 'Registrar Envio'}
+              {guardando ? 'Registrando...' : esIngreso ? 'Registrar Ingreso' : 'Registrar Salida'}
             </button>
           </div>
         </div>

--- a/src/components/vistas/VistaTransferencias.tsx
+++ b/src/components/vistas/VistaTransferencias.tsx
@@ -1,10 +1,10 @@
 /**
  * VistaTransferencias
  *
- * Lista de envios a sucursales con boton para crear uno nuevo.
+ * Lista de movimientos entre sucursales (salidas e ingresos) con detalle.
  */
 import React from 'react'
-import { ArrowRightLeft, Plus, Package } from 'lucide-react'
+import { ArrowRightLeft, Plus, Package, ArrowUpRight, ArrowDownLeft } from 'lucide-react'
 import LoadingSpinner from '../layout/LoadingSpinner'
 import { formatPrecio } from '../../utils/formatters'
 import type { TransferenciaDB } from '../../types'
@@ -12,7 +12,9 @@ import type { TransferenciaDB } from '../../types'
 interface VistaTransferenciasProps {
   transferencias: TransferenciaDB[]
   loading: boolean
-  onNuevaTransferencia: () => void
+  onNuevaSalida: () => void
+  onNuevoIngreso: () => void
+  onVerDetalle: (transferencia: TransferenciaDB) => void
 }
 
 function formatFecha(fecha: string): string {
@@ -30,29 +32,40 @@ function formatFecha(fecha: string): string {
 export default function VistaTransferencias({
   transferencias,
   loading,
-  onNuevaTransferencia,
+  onNuevaSalida,
+  onNuevoIngreso,
+  onVerDetalle,
 }: VistaTransferenciasProps): React.ReactElement {
   return (
     <div className="space-y-6">
       {/* Header */}
-      <div className="flex items-center justify-between">
+      <div className="flex items-center justify-between flex-wrap gap-3">
         <div className="flex items-center gap-3">
           <ArrowRightLeft className="w-6 h-6 text-blue-600" />
           <h1 className="text-2xl font-bold text-gray-800 dark:text-white">
-            Envios a Sucursal
+            Movimiento entre Sucursales
           </h1>
         </div>
-        <button
-          onClick={onNuevaTransferencia}
-          className="flex items-center gap-2 px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded-lg font-medium transition-colors"
-        >
-          <Plus className="w-4 h-4" />
-          Nuevo Envio
-        </button>
+        <div className="flex gap-2">
+          <button
+            onClick={onNuevoIngreso}
+            className="flex items-center gap-2 px-4 py-2 bg-green-600 hover:bg-green-700 text-white rounded-lg font-medium transition-colors"
+          >
+            <ArrowDownLeft className="w-4 h-4" />
+            Nuevo Ingreso
+          </button>
+          <button
+            onClick={onNuevaSalida}
+            className="flex items-center gap-2 px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded-lg font-medium transition-colors"
+          >
+            <ArrowUpRight className="w-4 h-4" />
+            Nueva Salida
+          </button>
+        </div>
       </div>
 
       {/* Loading */}
-      {loading && <LoadingSpinner text="Cargando envios..." />}
+      {loading && <LoadingSpinner text="Cargando movimientos..." />}
 
       {/* Empty state */}
       {!loading && transferencias.length === 0 && (
@@ -61,10 +74,10 @@ export default function VistaTransferencias({
             <Package className="w-10 h-10 text-gray-400 dark:text-gray-500" />
           </div>
           <h3 className="text-lg font-medium text-gray-600 dark:text-gray-300 mb-1">
-            No hay envios registrados
+            No hay movimientos registrados
           </h3>
           <p className="text-sm text-gray-500 dark:text-gray-400">
-            Crea tu primer envio a sucursal usando el boton de arriba.
+            Registra una salida o ingreso de sucursal usando los botones de arriba.
           </p>
         </div>
       )}
@@ -78,6 +91,9 @@ export default function VistaTransferencias({
                 <tr className="bg-gray-50 dark:bg-gray-700/50 border-b dark:border-gray-700">
                   <th className="text-left px-4 py-3 text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
                     Fecha
+                  </th>
+                  <th className="text-left px-4 py-3 text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
+                    Tipo
                   </th>
                   <th className="text-left px-4 py-3 text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
                     Sucursal
@@ -94,28 +110,44 @@ export default function VistaTransferencias({
                 </tr>
               </thead>
               <tbody className="divide-y dark:divide-gray-700">
-                {transferencias.map(t => (
-                  <tr
-                    key={t.id}
-                    className="hover:bg-gray-50 dark:hover:bg-gray-700/30 transition-colors"
-                  >
-                    <td className="px-4 py-3 text-sm text-gray-800 dark:text-gray-200 whitespace-nowrap">
-                      {formatFecha(t.fecha)}
-                    </td>
-                    <td className="px-4 py-3 text-sm font-medium text-gray-800 dark:text-white">
-                      {t.sucursal?.nombre || 'Sin sucursal'}
-                    </td>
-                    <td className="px-4 py-3 text-sm text-gray-600 dark:text-gray-300 text-center">
-                      {t.items?.length || 0}
-                    </td>
-                    <td className="px-4 py-3 text-sm font-medium text-gray-800 dark:text-white text-right whitespace-nowrap">
-                      {formatPrecio(t.total_costo)}
-                    </td>
-                    <td className="px-4 py-3 text-sm text-gray-500 dark:text-gray-400 hidden md:table-cell max-w-xs truncate">
-                      {t.notas || '-'}
-                    </td>
-                  </tr>
-                ))}
+                {transferencias.map(t => {
+                  const esIngreso = t.tipo === 'ingreso'
+                  return (
+                    <tr
+                      key={t.id}
+                      onClick={() => onVerDetalle(t)}
+                      className="hover:bg-gray-50 dark:hover:bg-gray-700/30 transition-colors cursor-pointer"
+                    >
+                      <td className="px-4 py-3 text-sm text-gray-800 dark:text-gray-200 whitespace-nowrap">
+                        {formatFecha(t.fecha)}
+                      </td>
+                      <td className="px-4 py-3">
+                        <span className={`inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium ${
+                          esIngreso
+                            ? 'bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400'
+                            : 'bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400'
+                        }`}>
+                          {esIngreso
+                            ? <><ArrowDownLeft className="w-3 h-3" /> Ingreso</>
+                            : <><ArrowUpRight className="w-3 h-3" /> Salida</>
+                          }
+                        </span>
+                      </td>
+                      <td className="px-4 py-3 text-sm font-medium text-gray-800 dark:text-white">
+                        {t.sucursal?.nombre || 'Sin sucursal'}
+                      </td>
+                      <td className="px-4 py-3 text-sm text-gray-600 dark:text-gray-300 text-center">
+                        {t.items?.length || 0}
+                      </td>
+                      <td className="px-4 py-3 text-sm font-medium text-gray-800 dark:text-white text-right whitespace-nowrap">
+                        {formatPrecio(t.total_costo)}
+                      </td>
+                      <td className="px-4 py-3 text-sm text-gray-500 dark:text-gray-400 hidden md:table-cell max-w-xs truncate">
+                        {t.notas || '-'}
+                      </td>
+                    </tr>
+                  )
+                })}
               </tbody>
             </table>
           </div>

--- a/src/hooks/queries/index.ts
+++ b/src/hooks/queries/index.ts
@@ -124,6 +124,7 @@ export {
   useSucursalesQuery,
   useCrearSucursalMutation,
   useRegistrarTransferenciaMutation,
+  useRegistrarIngresoMutation,
 } from './useTransferenciasQuery'
 
 // Métricas

--- a/src/hooks/queries/useTransferenciasQuery.ts
+++ b/src/hooks/queries/useTransferenciasQuery.ts
@@ -78,13 +78,17 @@ interface RPCResult {
   error?: string
 }
 
-async function registrarTransferencia(formData: TransferenciaFormInput): Promise<{ success: boolean; transferenciaId: string }> {
-  const itemsParaRPC = formData.items.map(item => ({
+function buildItemsParaRPC(items: TransferenciaFormInput['items']) {
+  return items.map(item => ({
     producto_id: item.productoId,
     cantidad: item.cantidad,
     costo_unitario: item.costoUnitario,
     subtotal: item.subtotal,
   }))
+}
+
+async function registrarTransferencia(formData: TransferenciaFormInput): Promise<{ success: boolean; transferenciaId: string }> {
+  const itemsParaRPC = buildItemsParaRPC(formData.items)
 
   const { data, error } = await supabase.rpc('registrar_transferencia', {
     p_sucursal_id: formData.sucursalId,
@@ -100,6 +104,28 @@ async function registrarTransferencia(formData: TransferenciaFormInput): Promise
   const result = data as RPCResult
   if (!result.success) {
     throw new Error(result.error || 'Error al registrar transferencia')
+  }
+
+  return { success: true, transferenciaId: result.transferencia_id }
+}
+
+async function registrarIngresoSucursal(formData: TransferenciaFormInput): Promise<{ success: boolean; transferenciaId: string }> {
+  const itemsParaRPC = buildItemsParaRPC(formData.items)
+
+  const { data, error } = await supabase.rpc('registrar_ingreso_sucursal', {
+    p_sucursal_id: formData.sucursalId,
+    p_fecha: formData.fecha || new Date().toISOString().split('T')[0],
+    p_notas: formData.notas || null,
+    p_total_costo: formData.totalCosto,
+    p_usuario_id: formData.usuarioId || null,
+    p_items: itemsParaRPC,
+  })
+
+  if (error) throw error
+
+  const result = data as RPCResult
+  if (!result.success) {
+    throw new Error(result.error || 'Error al registrar ingreso')
   }
 
   return { success: true, transferenciaId: result.transferencia_id }
@@ -144,13 +170,28 @@ export function useCrearSucursalMutation() {
 }
 
 /**
- * Hook para registrar una transferencia
+ * Hook para registrar una transferencia (salida)
  */
 export function useRegistrarTransferenciaMutation() {
   const queryClient = useQueryClient()
 
   return useMutation({
     mutationFn: registrarTransferencia,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: transferenciasKeys.lists() })
+      queryClient.invalidateQueries({ queryKey: ['productos'] })
+    },
+  })
+}
+
+/**
+ * Hook para registrar un ingreso desde sucursal
+ */
+export function useRegistrarIngresoMutation() {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: registrarIngresoSucursal,
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: transferenciasKeys.lists() })
       queryClient.invalidateQueries({ queryKey: ['productos'] })

--- a/src/types/hooks.ts
+++ b/src/types/hooks.ts
@@ -883,11 +883,14 @@ export interface TransferenciaItemDB {
   created_at?: string;
 }
 
+export type TipoTransferencia = 'salida' | 'ingreso';
+
 export interface TransferenciaDB {
   id: string;
   sucursal_id: string;
   sucursal?: SucursalDB | null;
   fecha: string;
+  tipo: TipoTransferencia;
   notas?: string | null;
   total_costo: number;
   usuario_id?: string | null;
@@ -902,6 +905,7 @@ export interface TransferenciaFormInput {
   notas?: string | null;
   totalCosto: number;
   usuarioId?: string | null;
+  tipo?: TipoTransferencia;
   items: Array<{
     productoId: string;
     cantidad: number;


### PR DESCRIPTION
Fix Zod 4 "Invalid input" error in Entrega con Salvedad by replacing generic schema validation with explicit Spanish error messages.

Rename "Envios a Sucursal" to "Movimiento entre Sucursales" with support for both outgoing (salida) and incoming (ingreso) transfers at cost price. Add detail modal for viewing transfer products, and new ingreso RPC that increases stock.