### PR TITLE
feat: tipo factura ZZ/FC - precios, facturación y márgenes

### DIFF
--- a/migrations/045_tipo_factura_zz_fc.sql
+++ b/migrations/045_tipo_factura_zz_fc.sql
@@ -1,0 +1,46 @@
+-- Migration 045: Agregar tipo_factura (ZZ/FC) a pedidos y compras
+--
+-- ZZ = Sin factura (sin IVA discriminado) - default para ventas
+-- FC = Con factura (IVA discriminado) - default para compras
+--
+-- El precio final al consumidor es siempre el mismo.
+-- ZZ: ingreso neto = precio final completo
+-- FC: ingreso neto = precio neto (IVA se remite a AFIP)
+
+-- =============================================
+-- 1. PEDIDOS - agregar tipo_factura y desglose
+-- =============================================
+
+ALTER TABLE pedidos
+  ADD COLUMN IF NOT EXISTS tipo_factura VARCHAR(2) DEFAULT 'ZZ'
+    CHECK (tipo_factura IN ('ZZ', 'FC')),
+  ADD COLUMN IF NOT EXISTS total_neto DECIMAL(12,2),
+  ADD COLUMN IF NOT EXISTS total_iva DECIMAL(12,2) DEFAULT 0;
+
+-- Backfill: pedidos existentes son ZZ, total_neto = total
+UPDATE pedidos SET total_neto = total WHERE total_neto IS NULL;
+
+-- =============================================
+-- 2. PEDIDO_ITEMS - desglose por item
+-- =============================================
+
+ALTER TABLE pedido_items
+  ADD COLUMN IF NOT EXISTS neto_unitario DECIMAL(12,2),
+  ADD COLUMN IF NOT EXISTS iva_unitario DECIMAL(12,2) DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS impuestos_internos_unitario DECIMAL(12,2) DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS porcentaje_iva DECIMAL(5,2) DEFAULT 0;
+
+-- =============================================
+-- 3. COMPRAS - agregar tipo_factura
+-- =============================================
+
+ALTER TABLE compras
+  ADD COLUMN IF NOT EXISTS tipo_factura VARCHAR(2) DEFAULT 'FC'
+    CHECK (tipo_factura IN ('ZZ', 'FC'));
+
+-- =============================================
+-- 4. INDICES
+-- =============================================
+
+CREATE INDEX IF NOT EXISTS idx_pedidos_tipo_factura ON pedidos(tipo_factura);
+CREATE INDEX IF NOT EXISTS idx_compras_tipo_factura ON compras(tipo_factura);

--- a/migrations/046_update_rpcs_tipo_factura.sql
+++ b/migrations/046_update_rpcs_tipo_factura.sql
@@ -1,0 +1,467 @@
+-- Migration 046: Actualizar RPCs para soporte de tipo_factura (ZZ/FC)
+--
+-- Cambios:
+--   1. crear_pedido_completo: nuevo param p_tipo_factura, almacena desglose neto/iva
+--   2. actualizar_pedido_items: almacena desglose neto/iva en items y recalcula totales
+--   3. registrar_compra_completa: nuevo param p_tipo_factura, maneja ZZ sin IVA
+
+-- =============================================================================
+-- 1. DROP old overload de crear_pedido_completo (8 params)
+-- =============================================================================
+
+DROP FUNCTION IF EXISTS public.crear_pedido_completo(bigint, numeric, uuid, jsonb, text, text, text, date);
+
+-- =============================================================================
+-- 2. crear_pedido_completo con tipo_factura
+-- =============================================================================
+
+CREATE OR REPLACE FUNCTION public.crear_pedido_completo(
+  p_cliente_id bigint,
+  p_total numeric,
+  p_usuario_id uuid,
+  p_items jsonb,
+  p_notas text DEFAULT NULL::text,
+  p_forma_pago text DEFAULT 'efectivo'::text,
+  p_estado_pago text DEFAULT 'pendiente'::text,
+  p_fecha date DEFAULT CURRENT_DATE,
+  p_tipo_factura text DEFAULT 'ZZ',
+  p_total_neto numeric DEFAULT NULL,
+  p_total_iva numeric DEFAULT 0
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $function$
+DECLARE
+  v_pedido_id INT;
+  item JSONB;
+  v_producto_id INT;
+  v_cantidad INT;
+  v_precio_unitario DECIMAL;
+  v_es_bonificacion BOOLEAN;
+  v_promocion_id BIGINT;
+  v_neto_unitario DECIMAL;
+  v_iva_unitario DECIMAL;
+  v_imp_internos_unitario DECIMAL;
+  v_porcentaje_iva DECIMAL;
+  v_stock_actual INT;
+  v_producto_nombre TEXT;
+  errores TEXT[] := '{}';
+  v_user_role TEXT;
+  v_cantidades_totales JSONB := '{}'::JSONB;
+  v_cant_acumulada INT;
+BEGIN
+  SELECT rol INTO v_user_role FROM perfiles WHERE id = p_usuario_id;
+  IF v_user_role IS NULL OR v_user_role NOT IN ('admin', 'preventista') THEN
+    RETURN jsonb_build_object('success', false, 'errores', jsonb_build_array('No tiene permisos para crear pedidos'));
+  END IF;
+
+  -- 1. Acumular cantidades totales por producto (SOLO items no bonificados)
+  FOR item IN SELECT * FROM jsonb_array_elements(p_items)
+  LOOP
+    v_producto_id := (item->>'producto_id')::INT;
+    v_cantidad := (item->>'cantidad')::INT;
+    v_es_bonificacion := COALESCE((item->>'es_bonificacion')::BOOLEAN, false);
+
+    IF v_cantidad IS NULL OR v_cantidad <= 0 THEN
+      errores := array_append(errores, 'Cantidad inválida para producto ID ' || v_producto_id || ': debe ser mayor a 0');
+      CONTINUE;
+    END IF;
+
+    IF NOT v_es_bonificacion THEN
+      v_cant_acumulada := COALESCE((v_cantidades_totales->>v_producto_id::TEXT)::INT, 0) + v_cantidad;
+      v_cantidades_totales := v_cantidades_totales || jsonb_build_object(v_producto_id::TEXT, v_cant_acumulada);
+    END IF;
+  END LOOP;
+
+  -- 2. Verificar stock usando cantidades acumuladas (con bloqueo)
+  FOR v_producto_id IN SELECT (key)::INT FROM jsonb_each_text(v_cantidades_totales)
+  LOOP
+    v_cantidad := (v_cantidades_totales->>v_producto_id::TEXT)::INT;
+
+    SELECT stock, nombre INTO v_stock_actual, v_producto_nombre
+    FROM productos
+    WHERE id = v_producto_id
+    FOR UPDATE;
+
+    IF v_stock_actual IS NULL THEN
+      errores := array_append(errores, 'Producto ID ' || v_producto_id || ' no encontrado');
+    ELSIF v_stock_actual < v_cantidad THEN
+      errores := array_append(errores, v_producto_nombre || ': stock insuficiente (disponible: ' || v_stock_actual || ', solicitado: ' || v_cantidad || ')');
+    END IF;
+  END LOOP;
+
+  IF array_length(errores, 1) > 0 THEN
+    RETURN jsonb_build_object('success', false, 'errores', to_jsonb(errores));
+  END IF;
+
+  -- 3. Crear el pedido con tipo_factura y desglose
+  INSERT INTO pedidos (
+    cliente_id, fecha, total, total_neto, total_iva, tipo_factura,
+    estado, usuario_id, stock_descontado, notas, forma_pago, estado_pago
+  )
+  VALUES (
+    p_cliente_id, p_fecha, p_total,
+    COALESCE(p_total_neto, p_total), -- Si no viene, asumir ZZ donde neto=total
+    COALESCE(p_total_iva, 0),
+    COALESCE(p_tipo_factura, 'ZZ'),
+    'pendiente', p_usuario_id, true, p_notas, p_forma_pago, p_estado_pago
+  )
+  RETURNING id INTO v_pedido_id;
+
+  -- 4. Crear items y descontar stock
+  FOR item IN SELECT * FROM jsonb_array_elements(p_items)
+  LOOP
+    v_producto_id := (item->>'producto_id')::INT;
+    v_cantidad := (item->>'cantidad')::INT;
+    v_precio_unitario := (item->>'precio_unitario')::DECIMAL;
+    v_es_bonificacion := COALESCE((item->>'es_bonificacion')::BOOLEAN, false);
+    v_promocion_id := (item->>'promocion_id')::BIGINT;
+    v_neto_unitario := (item->>'neto_unitario')::DECIMAL;
+    v_iva_unitario := COALESCE((item->>'iva_unitario')::DECIMAL, 0);
+    v_imp_internos_unitario := COALESCE((item->>'impuestos_internos_unitario')::DECIMAL, 0);
+    v_porcentaje_iva := COALESCE((item->>'porcentaje_iva')::DECIMAL, 0);
+
+    INSERT INTO pedido_items (
+      pedido_id, producto_id, cantidad, precio_unitario, subtotal,
+      es_bonificacion, promocion_id,
+      neto_unitario, iva_unitario, impuestos_internos_unitario, porcentaje_iva
+    )
+    VALUES (
+      v_pedido_id, v_producto_id, v_cantidad, v_precio_unitario,
+      v_cantidad * v_precio_unitario,
+      v_es_bonificacion, v_promocion_id,
+      v_neto_unitario, v_iva_unitario, v_imp_internos_unitario, v_porcentaje_iva
+    );
+
+    -- Stock: solo descontar si NO es bonificación
+    IF NOT v_es_bonificacion THEN
+      UPDATE productos SET stock = stock - v_cantidad WHERE id = v_producto_id;
+    END IF;
+
+    -- Contador de promos
+    IF v_es_bonificacion AND v_promocion_id IS NOT NULL THEN
+      UPDATE promociones SET usos_pendientes = usos_pendientes + v_cantidad
+      WHERE id = v_promocion_id;
+    END IF;
+  END LOOP;
+
+  RETURN jsonb_build_object('success', true, 'pedido_id', v_pedido_id);
+END;
+$function$;
+
+-- =============================================================================
+-- 3. actualizar_pedido_items con soporte tipo_factura
+-- =============================================================================
+
+CREATE OR REPLACE FUNCTION public.actualizar_pedido_items(
+  p_pedido_id BIGINT,
+  p_items_nuevos JSONB,
+  p_usuario_id UUID DEFAULT NULL,
+  p_tipo_factura text DEFAULT NULL,
+  p_total_neto numeric DEFAULT NULL,
+  p_total_iva numeric DEFAULT 0
+)
+RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $function$
+DECLARE
+  v_item_original RECORD;
+  v_item_nuevo JSONB;
+  v_producto_id INT;
+  v_cantidad_original INT;
+  v_cantidad_nueva INT;
+  v_precio_unitario DECIMAL;
+  v_es_bonificacion BOOLEAN;
+  v_promocion_id BIGINT;
+  v_neto_unitario DECIMAL;
+  v_iva_unitario DECIMAL;
+  v_imp_internos_unitario DECIMAL;
+  v_porcentaje_iva_item DECIMAL;
+  v_diferencia INT;
+  v_stock_actual INT;
+  v_producto_nombre TEXT;
+  v_total_nuevo DECIMAL := 0;
+  v_total_anterior DECIMAL;
+  v_errores TEXT[] := '{}';
+  v_items_originales JSONB;
+  v_cantidades_nuevas JSONB := '{}'::JSONB;
+  v_cantidades_originales JSONB := '{}'::JSONB;
+  v_cant_acum INT;
+BEGIN
+  SELECT total INTO v_total_anterior FROM pedidos WHERE id = p_pedido_id;
+  IF NOT FOUND THEN
+    RETURN jsonb_build_object('success', false, 'errores', ARRAY['Pedido no encontrado']);
+  END IF;
+
+  IF EXISTS (SELECT 1 FROM pedidos WHERE id = p_pedido_id AND estado = 'entregado') THEN
+    RETURN jsonb_build_object('success', false, 'errores', ARRAY['No se puede editar un pedido ya entregado']);
+  END IF;
+
+  -- Guardar items originales para historial
+  SELECT jsonb_agg(jsonb_build_object(
+    'producto_id', producto_id,
+    'cantidad', cantidad,
+    'precio_unitario', precio_unitario,
+    'es_bonificacion', es_bonificacion
+  )) INTO v_items_originales
+  FROM pedido_items WHERE pedido_id = p_pedido_id;
+
+  -- Revertir usos_pendientes de bonificaciones anteriores
+  FOR v_item_original IN
+    SELECT promocion_id, cantidad FROM pedido_items
+    WHERE pedido_id = p_pedido_id AND es_bonificacion = true AND promocion_id IS NOT NULL
+  LOOP
+    UPDATE promociones SET usos_pendientes = GREATEST(usos_pendientes - v_item_original.cantidad, 0)
+    WHERE id = v_item_original.promocion_id;
+  END LOOP;
+
+  -- Acumular cantidades originales por producto (solo NO bonificación)
+  FOR v_item_original IN
+    SELECT producto_id, SUM(cantidad) as cant_total
+    FROM pedido_items WHERE pedido_id = p_pedido_id AND (es_bonificacion IS NULL OR es_bonificacion = false)
+    GROUP BY producto_id
+  LOOP
+    v_cantidades_originales := v_cantidades_originales || jsonb_build_object(
+      v_item_original.producto_id::TEXT, v_item_original.cant_total
+    );
+  END LOOP;
+
+  -- Acumular cantidades nuevas por producto (solo NO bonificación)
+  FOR v_item_nuevo IN SELECT * FROM jsonb_array_elements(p_items_nuevos)
+  LOOP
+    v_producto_id := (v_item_nuevo->>'producto_id')::INT;
+    v_cantidad_nueva := (v_item_nuevo->>'cantidad')::INT;
+    v_es_bonificacion := COALESCE((v_item_nuevo->>'es_bonificacion')::BOOLEAN, false);
+
+    IF NOT v_es_bonificacion THEN
+      v_cant_acum := COALESCE((v_cantidades_nuevas->>v_producto_id::TEXT)::INT, 0) + v_cantidad_nueva;
+      v_cantidades_nuevas := v_cantidades_nuevas || jsonb_build_object(v_producto_id::TEXT, v_cant_acum);
+    END IF;
+  END LOOP;
+
+  -- Validar stock para incrementos
+  FOR v_producto_id IN SELECT (key)::INT FROM jsonb_each_text(v_cantidades_nuevas)
+  LOOP
+    v_cantidad_nueva := (v_cantidades_nuevas->>v_producto_id::TEXT)::INT;
+    v_cantidad_original := COALESCE((v_cantidades_originales->>v_producto_id::TEXT)::INT, 0);
+    v_diferencia := v_cantidad_nueva - v_cantidad_original;
+
+    IF v_diferencia > 0 THEN
+      SELECT stock, nombre INTO v_stock_actual, v_producto_nombre
+      FROM productos WHERE id = v_producto_id FOR UPDATE;
+
+      IF v_stock_actual IS NULL THEN
+        v_errores := array_append(v_errores, 'Producto ID ' || v_producto_id || ' no encontrado');
+      ELSIF v_stock_actual < v_diferencia THEN
+        v_errores := array_append(v_errores,
+          COALESCE(v_producto_nombre, 'Producto ' || v_producto_id) ||
+          ': stock insuficiente (disponible: ' || v_stock_actual ||
+          ', adicional requerido: ' || v_diferencia || ')');
+      END IF;
+    END IF;
+  END LOOP;
+
+  IF array_length(v_errores, 1) > 0 THEN
+    RETURN jsonb_build_object('success', false, 'errores', to_jsonb(v_errores));
+  END IF;
+
+  -- Restaurar stock de items originales (solo NO bonificación)
+  FOR v_item_original IN
+    SELECT producto_id, cantidad FROM pedido_items
+    WHERE pedido_id = p_pedido_id AND (es_bonificacion IS NULL OR es_bonificacion = false)
+  LOOP
+    UPDATE productos SET stock = stock + v_item_original.cantidad
+    WHERE id = v_item_original.producto_id;
+  END LOOP;
+
+  -- Eliminar items actuales
+  DELETE FROM pedido_items WHERE pedido_id = p_pedido_id;
+
+  -- Insertar nuevos items con desglose fiscal
+  FOR v_item_nuevo IN SELECT * FROM jsonb_array_elements(p_items_nuevos)
+  LOOP
+    v_producto_id := (v_item_nuevo->>'producto_id')::INT;
+    v_cantidad_nueva := (v_item_nuevo->>'cantidad')::INT;
+    v_precio_unitario := (v_item_nuevo->>'precio_unitario')::DECIMAL;
+    v_es_bonificacion := COALESCE((v_item_nuevo->>'es_bonificacion')::BOOLEAN, false);
+    v_promocion_id := (v_item_nuevo->>'promocion_id')::BIGINT;
+    v_neto_unitario := (v_item_nuevo->>'neto_unitario')::DECIMAL;
+    v_iva_unitario := COALESCE((v_item_nuevo->>'iva_unitario')::DECIMAL, 0);
+    v_imp_internos_unitario := COALESCE((v_item_nuevo->>'impuestos_internos_unitario')::DECIMAL, 0);
+    v_porcentaje_iva_item := COALESCE((v_item_nuevo->>'porcentaje_iva')::DECIMAL, 0);
+
+    INSERT INTO pedido_items (
+      pedido_id, producto_id, cantidad, precio_unitario, subtotal,
+      es_bonificacion, promocion_id,
+      neto_unitario, iva_unitario, impuestos_internos_unitario, porcentaje_iva
+    )
+    VALUES (
+      p_pedido_id, v_producto_id, v_cantidad_nueva, v_precio_unitario,
+      v_cantidad_nueva * v_precio_unitario,
+      v_es_bonificacion, v_promocion_id,
+      v_neto_unitario, v_iva_unitario, v_imp_internos_unitario, v_porcentaje_iva_item
+    );
+
+    IF NOT v_es_bonificacion THEN
+      v_total_nuevo := v_total_nuevo + v_cantidad_nueva * v_precio_unitario;
+      UPDATE productos SET stock = stock - v_cantidad_nueva WHERE id = v_producto_id;
+    END IF;
+
+    IF v_es_bonificacion AND v_promocion_id IS NOT NULL THEN
+      UPDATE promociones SET usos_pendientes = usos_pendientes + v_cantidad_nueva
+      WHERE id = v_promocion_id;
+    END IF;
+  END LOOP;
+
+  -- Actualizar pedido con total y desglose fiscal
+  UPDATE pedidos SET
+    total = v_total_nuevo,
+    tipo_factura = COALESCE(p_tipo_factura, tipo_factura),
+    total_neto = COALESCE(p_total_neto, v_total_nuevo),
+    total_iva = COALESCE(p_total_iva, 0),
+    updated_at = NOW()
+  WHERE id = p_pedido_id;
+
+  INSERT INTO pedido_historial (pedido_id, usuario_id, campo_modificado, valor_anterior, valor_nuevo)
+  VALUES (p_pedido_id, p_usuario_id, 'items', COALESCE(v_items_originales::TEXT, '[]'), p_items_nuevos::TEXT);
+
+  IF v_total_anterior <> v_total_nuevo THEN
+    INSERT INTO pedido_historial (pedido_id, usuario_id, campo_modificado, valor_anterior, valor_nuevo)
+    VALUES (p_pedido_id, p_usuario_id, 'total', v_total_anterior::TEXT, v_total_nuevo::TEXT);
+  END IF;
+
+  RETURN jsonb_build_object('success', true, 'total_nuevo', v_total_nuevo);
+END;
+$function$;
+
+-- =============================================================================
+-- 4. registrar_compra_completa con tipo_factura
+-- =============================================================================
+
+CREATE OR REPLACE FUNCTION registrar_compra_completa(
+  p_proveedor_id BIGINT DEFAULT NULL,
+  p_proveedor_nombre VARCHAR DEFAULT NULL,
+  p_numero_factura VARCHAR DEFAULT NULL,
+  p_fecha_compra DATE DEFAULT CURRENT_DATE,
+  p_subtotal DECIMAL DEFAULT 0,
+  p_iva DECIMAL DEFAULT 0,
+  p_otros_impuestos DECIMAL DEFAULT 0,
+  p_total DECIMAL DEFAULT 0,
+  p_forma_pago VARCHAR DEFAULT 'efectivo',
+  p_notas TEXT DEFAULT NULL,
+  p_usuario_id UUID DEFAULT NULL,
+  p_items JSONB DEFAULT '[]',
+  p_tipo_factura TEXT DEFAULT 'FC'
+)
+RETURNS JSONB AS $$
+DECLARE
+  v_compra_id BIGINT;
+  v_item JSONB;
+  v_producto RECORD;
+  v_stock_anterior INTEGER;
+  v_stock_nuevo INTEGER;
+  v_items_procesados JSONB := '[]'::JSONB;
+  v_costo_neto DECIMAL;
+  v_costo_con_iva DECIMAL;
+  v_porcentaje_iva DECIMAL;
+  v_impuestos_internos DECIMAL;
+  v_bonificacion DECIMAL;
+  v_tipo_factura TEXT;
+BEGIN
+  v_tipo_factura := COALESCE(p_tipo_factura, 'FC');
+
+  -- Crear la compra
+  INSERT INTO compras (
+    proveedor_id, proveedor_nombre, numero_factura, fecha_compra,
+    subtotal, iva, otros_impuestos, total, forma_pago, notas, usuario_id, estado, tipo_factura
+  ) VALUES (
+    p_proveedor_id, p_proveedor_nombre, p_numero_factura, p_fecha_compra,
+    p_subtotal,
+    CASE WHEN v_tipo_factura = 'ZZ' THEN 0 ELSE p_iva END,
+    p_otros_impuestos, p_total, p_forma_pago, p_notas, p_usuario_id, 'recibida', v_tipo_factura
+  ) RETURNING id INTO v_compra_id;
+
+  -- Procesar cada item
+  FOR v_item IN SELECT * FROM jsonb_array_elements(p_items)
+  LOOP
+    SELECT id, stock INTO v_producto
+    FROM productos
+    WHERE id = (v_item->>'producto_id')::BIGINT;
+
+    IF NOT FOUND THEN
+      RAISE EXCEPTION 'Producto no encontrado: %', v_item->>'producto_id';
+    END IF;
+
+    v_stock_anterior := COALESCE(v_producto.stock, 0);
+    v_stock_nuevo := v_stock_anterior + (v_item->>'cantidad')::INTEGER;
+
+    -- Insertar item de compra
+    INSERT INTO compra_items (
+      compra_id, producto_id, cantidad, costo_unitario, subtotal,
+      stock_anterior, stock_nuevo, bonificacion
+    ) VALUES (
+      v_compra_id,
+      (v_item->>'producto_id')::BIGINT,
+      (v_item->>'cantidad')::INTEGER,
+      COALESCE((v_item->>'costo_unitario')::DECIMAL, 0),
+      COALESCE((v_item->>'subtotal')::DECIMAL, 0),
+      v_stock_anterior,
+      v_stock_nuevo,
+      COALESCE((v_item->>'bonificacion')::DECIMAL, 0)
+    );
+
+    -- Calcular costos netos para actualizar el producto
+    v_bonificacion := COALESCE((v_item->>'bonificacion')::DECIMAL, 0);
+    v_porcentaje_iva := COALESCE((v_item->>'porcentaje_iva')::DECIMAL, 21);
+    v_impuestos_internos := COALESCE((v_item->>'impuestos_internos')::DECIMAL, 0);
+
+    -- Costo neto = costo unitario con bonificación aplicada
+    v_costo_neto := COALESCE((v_item->>'costo_unitario')::DECIMAL, 0) * (1 - v_bonificacion / 100);
+
+    -- Costo con IVA depende del tipo de factura
+    IF v_tipo_factura = 'ZZ' THEN
+      -- ZZ: no hay IVA discriminado, costo_con_iva = costo_sin_iva (el IVA no existe)
+      v_costo_con_iva := v_costo_neto;
+      v_porcentaje_iva := 0;
+    ELSE
+      -- FC: IVA discriminado normalmente
+      v_costo_con_iva := v_costo_neto * (1 + v_porcentaje_iva / 100);
+    END IF;
+
+    -- Actualizar stock Y costos del producto
+    UPDATE productos
+    SET stock = v_stock_nuevo,
+        costo_sin_iva = v_costo_neto,
+        costo_con_iva = v_costo_con_iva,
+        impuestos_internos = v_impuestos_internos,
+        porcentaje_iva = v_porcentaje_iva,
+        updated_at = NOW()
+    WHERE id = (v_item->>'producto_id')::BIGINT;
+
+    v_items_procesados := v_items_procesados || jsonb_build_object(
+      'producto_id', (v_item->>'producto_id')::BIGINT,
+      'cantidad', (v_item->>'cantidad')::INTEGER,
+      'stock_anterior', v_stock_anterior,
+      'stock_nuevo', v_stock_nuevo,
+      'costo_sin_iva', v_costo_neto,
+      'costo_con_iva', v_costo_con_iva
+    );
+  END LOOP;
+
+  RETURN jsonb_build_object(
+    'success', true,
+    'compra_id', v_compra_id,
+    'items_procesados', v_items_procesados
+  );
+EXCEPTION
+  WHEN OTHERS THEN
+    RETURN jsonb_build_object(
+      'success', false,
+      'error', SQLERRM
+    );
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;

--- a/src/components/containers/PedidosContainer.tsx
+++ b/src/components/containers/PedidosContainer.tsx
@@ -6,6 +6,7 @@
  * Reemplaza el flujo legacy de App.tsx → VistaPedidos con prop drilling.
  */
 import React, { lazy, Suspense, useState, useCallback, useMemo } from 'react'
+import { calcularNetoVenta } from '../../utils/calculations'
 import { fechaLocalISO } from '../../utils/formatters'
 import { useQueryClient } from '@tanstack/react-query'
 import { Loader2 } from 'lucide-react'
@@ -152,6 +153,7 @@ export default function PedidosContainer(): React.ReactElement {
     estadoPago: 'pendiente',
     montoPagado: 0,
     fecha: fechaLocalISO(),
+    tipoFactura: 'ZZ' as 'ZZ' | 'FC',
   })
 
   const resetNuevoPedido = useCallback(() => {
@@ -159,6 +161,7 @@ export default function PedidosContainer(): React.ReactElement {
       clienteId: '', items: [], notas: '',
       formaPago: 'efectivo', estadoPago: 'pendiente', montoPagado: 0,
       fecha: fechaLocalISO(),
+      tipoFactura: 'ZZ' as 'ZZ' | 'FC',
     })
   }, [])
 
@@ -549,13 +552,38 @@ export default function PedidosContainer(): React.ReactElement {
     setGuardando(true)
     try {
       // Use promo+wholesale-resolved items and total (includes bonificaciones)
-      const itemsParaCrear = itemsFinales.map(item => ({
-        productoId: String(item.productoId),
-        cantidad: item.cantidad,
-        precioUnitario: item.precioUnitario,
-        ...(item.esBonificacion ? { esBonificacion: true as const } : {}),
-        ...(item.promoId ? { promocionId: item.promoId } : {}),
-      }))
+      const tipoFactura = nuevoPedido.tipoFactura || 'ZZ'
+      let totalNeto = 0
+      let totalIva = 0
+      const itemsParaCrear = itemsFinales.map(item => {
+        const esBonif = !!item.esBonificacion
+        if (esBonif) {
+          return {
+            productoId: String(item.productoId),
+            cantidad: item.cantidad,
+            precioUnitario: item.precioUnitario,
+            esBonificacion: true as const,
+            ...(item.promoId ? { promocionId: item.promoId } : {}),
+            neto_unitario: 0, iva_unitario: 0, impuestos_internos_unitario: 0, porcentaje_iva: 0,
+          }
+        }
+        const producto = productos.find(p => String(p.id) === String(item.productoId))
+        const pctIva = producto?.porcentaje_iva ?? 21
+        const pctImpInt = producto?.impuestos_internos ?? 0
+        const desglose = calcularNetoVenta(item.precioUnitario, pctIva, pctImpInt, tipoFactura)
+        totalNeto += desglose.neto * item.cantidad
+        totalIva += desglose.iva * item.cantidad
+        return {
+          productoId: String(item.productoId),
+          cantidad: item.cantidad,
+          precioUnitario: item.precioUnitario,
+          ...(item.promoId ? { promocionId: item.promoId } : {}),
+          neto_unitario: desglose.neto,
+          iva_unitario: desglose.iva,
+          impuestos_internos_unitario: desglose.impuestosInternos,
+          porcentaje_iva: pctIva,
+        }
+      })
       await crearPedido.mutateAsync({
         clienteId: nuevoPedido.clienteId,
         items: itemsParaCrear,
@@ -566,6 +594,9 @@ export default function PedidosContainer(): React.ReactElement {
         estadoPago: nuevoPedido.estadoPago,
         montoPagado: nuevoPedido.montoPagado,
         fecha: nuevoPedido.fecha,
+        tipoFactura,
+        totalNeto,
+        totalIva,
       })
       resetNuevoPedido()
       setModalPedidoOpen(false)
@@ -574,7 +605,7 @@ export default function PedidosContainer(): React.ReactElement {
       notify.error('Error al crear pedido: ' + (e as Error).message)
     }
     setGuardando(false)
-  }, [nuevoPedido, itemsFinales, totalFinal, crearPedido, user, resetNuevoPedido, notify])
+  }, [nuevoPedido, itemsFinales, totalFinal, crearPedido, user, resetNuevoPedido, notify, productos])
 
   // ModalFiltroFecha: onApply({ fechaDesde, fechaHasta })
   const handleFiltroFechaApply = useCallback((f: { fechaDesde: string | null; fechaHasta: string | null }) => {
@@ -793,6 +824,7 @@ export default function PedidosContainer(): React.ReactElement {
             onEstadoPagoChange={(ep: string) => setNuevoPedido(prev => ({ ...prev, estadoPago: ep }))}
             onMontoPagadoChange={(m: number) => setNuevoPedido(prev => ({ ...prev, montoPagado: m }))}
             onFechaChange={(fecha: string) => setNuevoPedido(prev => ({ ...prev, fecha }))}
+            onTipoFacturaChange={(tipo: 'ZZ' | 'FC') => setNuevoPedido(prev => ({ ...prev, tipoFactura: tipo }))}
             isOffline={!isOnline}
           />
         </Suspense>

--- a/src/components/modals/ModalCompra.tsx
+++ b/src/components/modals/ModalCompra.tsx
@@ -60,6 +60,7 @@ export interface CompraState {
   numeroFactura: string;
   fechaCompra: string;
   formaPago: string;
+  tipoFactura: 'ZZ' | 'FC';
   notas: string;
   items: CompraItemForm[];
   busquedaProducto: string;
@@ -81,12 +82,13 @@ type CompraActionType =
   | { type: 'SET_NUMERO_FACTURA'; payload: string }
   | { type: 'SET_FECHA_COMPRA'; payload: string }
   | { type: 'SET_FORMA_PAGO'; payload: string }
+  | { type: 'SET_TIPO_FACTURA'; payload: 'ZZ' | 'FC' }
   | { type: 'SET_NOTAS'; payload: string }
   | { type: 'SET_BUSQUEDA'; payload: string }
   | { type: 'SET_MOSTRAR_BUSCADOR'; payload: boolean }
   | { type: 'SET_GUARDANDO'; payload: boolean }
   | { type: 'SET_ERROR'; payload: string }
-  | { type: 'AGREGAR_ITEM'; payload: ProductoDB & { porcentaje_iva?: number } }
+  | { type: 'AGREGAR_ITEM'; payload: ProductoDB }
   | { type: 'ACTUALIZAR_ITEM'; payload: { index: number; campo: keyof CompraItemForm; valor: number | string } }
   | { type: 'ELIMINAR_ITEM'; payload: number }
   | { type: 'LIMPIAR_BUSQUEDA' }
@@ -188,6 +190,7 @@ const initialState: CompraState = {
   numeroFactura: '',
   fechaCompra: fechaLocalISO(),
   formaPago: 'efectivo',
+  tipoFactura: 'FC',
   notas: '',
   // Items
   items: [],
@@ -218,6 +221,8 @@ function compraReducer(state: CompraState, action: CompraActionType): CompraStat
       return { ...state, fechaCompra: action.payload }
     case 'SET_FORMA_PAGO':
       return { ...state, formaPago: action.payload }
+    case 'SET_TIPO_FACTURA':
+      return { ...state, tipoFactura: action.payload }
     case 'SET_NOTAS':
       return { ...state, notas: action.payload }
     case 'SET_BUSQUEDA':
@@ -344,7 +349,7 @@ function compraReducer(state: CompraState, action: CompraActionType): CompraStat
 }
 
 // Hook para cálculos de impuestos (bonificacion e imp. internos como porcentaje)
-function useCalculosImpuestos(items: CompraItemForm[]): CalculosImpuestos {
+function useCalculosImpuestos(items: CompraItemForm[], tipoFactura: 'ZZ' | 'FC' = 'FC'): CalculosImpuestos {
   return useMemo(() => {
     let subtotalBruto = 0
     let bonificacionTotal = 0
@@ -357,14 +362,17 @@ function useCalculosImpuestos(items: CompraItemForm[]): CalculosImpuestos {
       const neto = bruto - bonif
       subtotalBruto += bruto
       bonificacionTotal += bonif
-      iva += neto * ((item.porcentajeIva ?? 21) / 100)
+      // ZZ: no hay IVA discriminado
+      if (tipoFactura === 'FC') {
+        iva += neto * ((item.porcentajeIva ?? 21) / 100)
+      }
       impuestosInternos += neto * ((item.impuestosInternos || 0) / 100)
     }
 
     const subtotal = subtotalBruto - bonificacionTotal
     const total = subtotal + iva + impuestosInternos
     return { subtotalBruto, bonificacionTotal, subtotal, iva, impuestosInternos, total }
-  }, [items])
+  }, [items, tipoFactura])
 }
 
 const N8N_FACTURA_WEBHOOK_URL: string = import.meta.env.VITE_N8N_FACTURA_WEBHOOK_URL || ''
@@ -374,7 +382,7 @@ export default function ModalCompra({ productos, proveedores, onSave, onClose, o
   const [state, dispatch] = useReducer(compraReducer, initialState)
   const [modalProveedorOpen, setModalProveedorOpen] = useState(false)
   const [modalImportarOpen, setModalImportarOpen] = useState(false)
-  const { subtotalBruto, bonificacionTotal, subtotal, iva, impuestosInternos, total } = useCalculosImpuestos(state.items)
+  const { subtotalBruto, bonificacionTotal, subtotal, iva, impuestosInternos, total } = useCalculosImpuestos(state.items, state.tipoFactura)
   const fileInputRef = useRef<HTMLInputElement>(null)
 
   // Productos filtrados
@@ -554,6 +562,7 @@ export default function ModalCompra({ productos, proveedores, onSave, onClose, o
         total,
         formaPago: state.formaPago,
         notas: state.notas,
+        tipoFactura: state.tipoFactura,
         items: state.items.map(item => {
           const costoConBonif = (item.costoUnitario || 0) * (1 - (item.bonificacion || 0) / 100)
           return {
@@ -822,6 +831,38 @@ function ProveedorSection({ state, dispatch, proveedores, onAgregarProveedor }: 
 
 function DatosCompraSection({ state, dispatch }: DatosCompraSectionProps) {
   return (
+    <>
+    {/* Tipo de Comprobante */}
+    <div className="mb-3">
+      <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+        Tipo de Comprobante
+      </label>
+      <div className="flex rounded-lg overflow-hidden border dark:border-gray-600">
+        <button
+          type="button"
+          onClick={() => dispatch({ type: 'SET_TIPO_FACTURA', payload: 'FC' })}
+          className={`flex-1 px-3 py-2 text-sm font-medium transition-colors ${
+            state.tipoFactura === 'FC'
+              ? 'bg-blue-600 text-white dark:bg-blue-500'
+              : 'bg-gray-100 text-gray-600 hover:bg-gray-200 dark:bg-gray-700 dark:text-gray-300 dark:hover:bg-gray-600'
+          }`}
+        >
+          FC Con Factura / IVA
+        </button>
+        <button
+          type="button"
+          onClick={() => dispatch({ type: 'SET_TIPO_FACTURA', payload: 'ZZ' })}
+          className={`flex-1 px-3 py-2 text-sm font-medium transition-colors ${
+            state.tipoFactura === 'ZZ'
+              ? 'bg-gray-800 text-white dark:bg-gray-200 dark:text-gray-900'
+              : 'bg-gray-100 text-gray-600 hover:bg-gray-200 dark:bg-gray-700 dark:text-gray-300 dark:hover:bg-gray-600'
+          }`}
+        >
+          ZZ Sin Factura
+        </button>
+      </div>
+    </div>
+
     <div className="grid grid-cols-1 md:grid-cols-3 gap-3 sm:gap-4">
       <div>
         <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
@@ -862,6 +903,7 @@ function DatosCompraSection({ state, dispatch }: DatosCompraSectionProps) {
         </select>
       </div>
     </div>
+    </>
   )
 }
 

--- a/src/components/modals/ModalDetalleCompra.tsx
+++ b/src/components/modals/ModalDetalleCompra.tsx
@@ -53,6 +53,7 @@ interface CompraDetalle {
   total: number;
   notas?: string;
   usuario?: Usuario;
+  tipo_factura?: 'ZZ' | 'FC';
 }
 
 interface NotaCreditoResumen {
@@ -156,8 +157,17 @@ export default function ModalDetalleCompra({
                 <Hash className="w-4 h-4" />
                 <span className="text-xs">N Factura</span>
               </div>
-              <p className="font-medium text-gray-800 dark:text-white">
+              <p className="font-medium text-gray-800 dark:text-white flex items-center gap-2">
                 {compra.numero_factura || 'Sin especificar'}
+                {compra.tipo_factura && (
+                  <span className={`text-xs px-1.5 py-0.5 rounded font-medium ${
+                    compra.tipo_factura === 'FC'
+                      ? 'bg-blue-100 text-blue-700 dark:bg-blue-900 dark:text-blue-300'
+                      : 'bg-gray-100 text-gray-600 dark:bg-gray-700 dark:text-gray-400'
+                  }`}>
+                    {compra.tipo_factura}
+                  </span>
+                )}
               </p>
             </div>
             <div className="bg-gray-50 dark:bg-gray-900 rounded-lg p-3">

--- a/src/components/modals/ModalPedido.tsx
+++ b/src/components/modals/ModalPedido.tsx
@@ -22,6 +22,7 @@ export interface NuevoPedidoState {
   estadoPago?: string;
   montoPagado?: number;
   fecha?: string;
+  tipoFactura?: 'ZZ' | 'FC';
 }
 
 /** Datos del cliente a crear */
@@ -84,6 +85,8 @@ export interface ModalPedidoProps {
   onMontoPagadoChange?: (monto: number) => void;
   /** Callback al cambiar fecha del pedido */
   onFechaChange?: (fecha: string) => void;
+  /** Callback al cambiar tipo de factura */
+  onTipoFacturaChange?: (tipo: 'ZZ' | 'FC') => void;
   /** Callback al actualizar precio (solo admin) */
   onActualizarPrecio?: (productoId: string, precio: number) => void;
   /** Si está offline */
@@ -110,6 +113,7 @@ const ModalPedido = memo(function ModalPedido({
   onEstadoPagoChange,
   onMontoPagadoChange,
   onFechaChange,
+  onTipoFacturaChange,
   onActualizarPrecio
 }: ModalPedidoProps) {
   const [busquedaProducto, setBusquedaProducto] = useState<string>('');
@@ -543,8 +547,37 @@ const ModalPedido = memo(function ModalPedido({
             </div>
           )}
 
-          {/* Seccion Forma de Pago y Observaciones - al fondo */}
+          {/* Seccion Tipo Factura, Forma de Pago y Observaciones - al fondo */}
           <div className="border-t dark:border-gray-600 pt-4 space-y-3">
+            {/* Tipo de Factura */}
+            <div>
+              <label className="block text-sm font-medium mb-1 dark:text-gray-200">Tipo de Comprobante</label>
+              <div className="flex rounded-lg overflow-hidden border dark:border-gray-600">
+                <button
+                  type="button"
+                  onClick={() => onTipoFacturaChange && onTipoFacturaChange('ZZ')}
+                  className={`flex-1 px-3 py-2 text-sm font-medium transition-colors ${
+                    (nuevoPedido.tipoFactura || 'ZZ') === 'ZZ'
+                      ? 'bg-gray-800 text-white dark:bg-gray-200 dark:text-gray-900'
+                      : 'bg-gray-100 text-gray-600 hover:bg-gray-200 dark:bg-gray-700 dark:text-gray-300 dark:hover:bg-gray-600'
+                  }`}
+                >
+                  ZZ Sin Factura
+                </button>
+                <button
+                  type="button"
+                  onClick={() => onTipoFacturaChange && onTipoFacturaChange('FC')}
+                  className={`flex-1 px-3 py-2 text-sm font-medium transition-colors ${
+                    nuevoPedido.tipoFactura === 'FC'
+                      ? 'bg-blue-600 text-white dark:bg-blue-500'
+                      : 'bg-gray-100 text-gray-600 hover:bg-gray-200 dark:bg-gray-700 dark:text-gray-300 dark:hover:bg-gray-600'
+                  }`}
+                >
+                  FC Con Factura
+                </button>
+              </div>
+            </div>
+
             <div className="grid grid-cols-2 gap-3">
               <div>
                 <label className="block text-sm font-medium mb-1 dark:text-gray-200">Forma de Pago</label>

--- a/src/components/pedidos/PedidoCard.tsx
+++ b/src/components/pedidos/PedidoCard.tsx
@@ -208,6 +208,11 @@ function PedidoCard({
                 {getEstadoPagoLabel(pedido.estado_pago)}
               </span>
             )}
+            {pedido.tipo_factura === 'FC' && (
+              <span className="px-2 py-0.5 rounded text-xs font-medium bg-blue-100 text-blue-700 dark:bg-blue-900 dark:text-blue-300">
+                FC
+              </span>
+            )}
           </div>
           <AccionesDropdown
             pedido={pedido}

--- a/src/components/vistas/VistaCompras.tsx
+++ b/src/components/vistas/VistaCompras.tsx
@@ -375,7 +375,18 @@ export default function VistaCompras({
                       </div>
                     </td>
                     <td className="px-4 py-3 text-gray-500 dark:text-gray-400 font-mono text-sm">
-                      {compra.numero_factura || '-'}
+                      <span className="flex items-center gap-1.5">
+                        {compra.numero_factura || '-'}
+                        {compra.tipo_factura && (
+                          <span className={`text-xs px-1.5 py-0.5 rounded font-medium ${
+                            compra.tipo_factura === 'FC'
+                              ? 'bg-blue-100 text-blue-700 dark:bg-blue-900 dark:text-blue-300'
+                              : 'bg-gray-100 text-gray-600 dark:bg-gray-700 dark:text-gray-400'
+                          }`}>
+                            {compra.tipo_factura}
+                          </span>
+                        )}
+                      </span>
                     </td>
                     <td className="px-4 py-3 text-center">
                       <div className="flex items-center justify-center gap-1">

--- a/src/components/vistas/reportes/ReporteRentabilidad.tsx
+++ b/src/components/vistas/reportes/ReporteRentabilidad.tsx
@@ -23,29 +23,57 @@ export function ReporteRentabilidadSection({
 
   return (
     <div className="space-y-4">
-      {/* Resumen */}
+      {/* Desglose Ventas */}
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+        <div className="bg-indigo-50 dark:bg-indigo-900/20 p-4 rounded-lg">
+          <p className="text-sm text-indigo-600 dark:text-indigo-400">Ventas Brutas</p>
+          <p className="text-xl font-bold text-indigo-700 dark:text-indigo-300">
+            {formatPrecio(totales.ventasBrutas || 0)}
+          </p>
+        </div>
+        <div className="bg-orange-50 dark:bg-orange-900/20 p-4 rounded-lg">
+          <p className="text-sm text-orange-600 dark:text-orange-400">IVA Discriminado</p>
+          <p className="text-xl font-bold text-orange-700 dark:text-orange-300">
+            {formatPrecio(totales.ivaDiscriminado || 0)}
+          </p>
+        </div>
+        <div className="bg-amber-50 dark:bg-amber-900/20 p-4 rounded-lg">
+          <p className="text-sm text-amber-600 dark:text-amber-400">Imp. Internos</p>
+          <p className="text-xl font-bold text-amber-700 dark:text-amber-300">
+            {formatPrecio(totales.impuestosInternos || 0)}
+          </p>
+        </div>
+        <div className="bg-blue-50 dark:bg-blue-900/20 p-4 rounded-lg">
+          <p className="text-sm text-blue-600 dark:text-blue-400">Ventas Netas</p>
+          <p className="text-xl font-bold text-blue-700 dark:text-blue-300">
+            {formatPrecio(totales.ventasNetas || 0)}
+          </p>
+        </div>
+      </div>
+
+      {/* Resumen Rentabilidad */}
       <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
         <div className="bg-blue-50 dark:bg-blue-900/20 p-4 rounded-lg">
-          <p className="text-sm text-blue-600">Ingresos</p>
-          <p className="text-xl font-bold text-blue-700">
+          <p className="text-sm text-blue-600 dark:text-blue-400">Ingresos Netos</p>
+          <p className="text-xl font-bold text-blue-700 dark:text-blue-300">
             {formatPrecio(totales.ingresosTotales || 0)}
           </p>
         </div>
         <div className="bg-red-50 dark:bg-red-900/20 p-4 rounded-lg">
-          <p className="text-sm text-red-600">Costos</p>
-          <p className="text-xl font-bold text-red-700">
+          <p className="text-sm text-red-600 dark:text-red-400">Costos</p>
+          <p className="text-xl font-bold text-red-700 dark:text-red-300">
             {formatPrecio(totales.costosTotales || 0)}
           </p>
         </div>
         <div className="bg-green-50 dark:bg-green-900/20 p-4 rounded-lg">
-          <p className="text-sm text-green-600">Margen</p>
-          <p className="text-xl font-bold text-green-700">
+          <p className="text-sm text-green-600 dark:text-green-400">Margen</p>
+          <p className="text-xl font-bold text-green-700 dark:text-green-300">
             {formatPrecio(totales.margenTotal || 0)}
           </p>
         </div>
         <div className="bg-purple-50 dark:bg-purple-900/20 p-4 rounded-lg">
-          <p className="text-sm text-purple-600">% Margen</p>
-          <p className="text-xl font-bold text-purple-700">
+          <p className="text-sm text-purple-600 dark:text-purple-400">% Margen</p>
+          <p className="text-xl font-bold text-purple-700 dark:text-purple-300">
             {(totales.margenPorcentaje || 0).toFixed(1)}%
           </p>
         </div>

--- a/src/hooks/handlers/usePedidoHandlers.ts
+++ b/src/hooks/handlers/usePedidoHandlers.ts
@@ -9,6 +9,7 @@ import { usePricingMapQuery } from '../queries/useGruposPrecioQuery'
 import { usePromoMapQuery } from '../queries/usePromocionesQuery'
 import { resolverPreciosMayorista, aplicarPreciosMayorista, validarMOQPedido } from '../../utils/precioMayorista'
 import { resolverPromociones } from '../../utils/promociones'
+import { calcularNetoVenta } from '../../utils/calculations'
 import type { User } from '@supabase/supabase-js'
 import type {
   ProductoDB,
@@ -44,6 +45,7 @@ export interface NuevoPedidoState {
   formaPago?: string;
   estadoPago?: string;
   montoPagado?: number;
+  tipoFactura?: 'ZZ' | 'FC';
 }
 
 // =============================================================================
@@ -86,6 +88,7 @@ export interface PedidoOfflineData {
   formaPago?: string;
   estadoPago?: string;
   montoPagado?: number;
+  tipoFactura?: 'ZZ' | 'FC';
 }
 
 // =============================================================================
@@ -143,7 +146,10 @@ export interface UsePedidoHandlersProps {
     descontarStock: (items: Array<{ productoId?: string; producto_id?: string; cantidad: number }>) => Promise<void>,
     notas?: string,
     formaPago?: string,
-    estadoPago?: string
+    estadoPago?: string,
+    tipoFactura?: 'ZZ' | 'FC',
+    totalNeto?: number,
+    totalIva?: number
   ) => Promise<PedidoDB>;
   cambiarEstado: (pedidoId: string, nuevoEstado: string, usuarioId?: string) => Promise<void>;
   asignarTransportista: (pedidoId: string, transportistaId: string | null, marcarListo?: boolean) => Promise<void>;
@@ -199,6 +205,7 @@ export interface UsePedidoHandlersReturn {
   handleClienteChange: (clienteId: string) => void;
   handleNotasChange: (notas: string) => void;
   handleFormaPagoChange: (formaPago: string) => void;
+  handleTipoFacturaChange: (tipo: 'ZZ' | 'FC') => void;
   handleEstadoPagoChange: (estadoPago: string) => void;
   handleMontoPagadoChange: (montoPagado: number) => void;
   handleCrearClienteEnPedido: (nuevoCliente: ClienteFormInput) => Promise<ClienteDB>;
@@ -338,6 +345,10 @@ export function usePedidoHandlers({
     setNuevoPedido(prev => ({ ...prev, formaPago }))
   }, [setNuevoPedido])
 
+  const handleTipoFacturaChange = useCallback((tipoFactura: 'ZZ' | 'FC'): void => {
+    setNuevoPedido(prev => ({ ...prev, tipoFactura }))
+  }, [setNuevoPedido])
+
   const handleEstadoPagoChange = useCallback((estadoPago: string): void => {
     setNuevoPedido(prev => ({ ...prev, estadoPago, montoPagado: estadoPago === 'parcial' ? prev.montoPagado : 0 }))
   }, [setNuevoPedido])
@@ -419,6 +430,30 @@ export function usePedidoHandlers({
       totalFinal += item.precioUnitario * item.cantidad
     }
 
+    // Calcular desglose neto/IVA por item según tipo de factura
+    const tipoFactura = nuevoPedido.tipoFactura || 'ZZ'
+    let totalNeto = 0
+    let totalIva = 0
+    const itemsConDesglose = todosLosItems.map(item => {
+      const esBonif = 'esBonificacion' in item && item.esBonificacion
+      if (esBonif) {
+        return { ...item, neto_unitario: 0, iva_unitario: 0, impuestos_internos_unitario: 0, porcentaje_iva: 0 }
+      }
+      const producto = productosRef.current.find(p => String(p.id) === String(item.productoId))
+      const pctIva = producto?.porcentaje_iva ?? 21
+      const pctImpInt = producto?.impuestos_internos ?? 0
+      const desglose = calcularNetoVenta(item.precioUnitario, pctIva, pctImpInt, tipoFactura)
+      totalNeto += desglose.neto * item.cantidad
+      totalIva += desglose.iva * item.cantidad
+      return {
+        ...item,
+        neto_unitario: desglose.neto,
+        iva_unitario: desglose.iva,
+        impuestos_internos_unitario: desglose.impuestosInternos,
+        porcentaje_iva: pctIva,
+      }
+    })
+
     if (!isOnline) {
       guardarPedidoOffline({
         clienteId: parseInt(nuevoPedido.clienteId),
@@ -428,7 +463,8 @@ export function usePedidoHandlers({
         notas: nuevoPedido.notas,
         formaPago: nuevoPedido.formaPago,
         estadoPago: nuevoPedido.estadoPago,
-        montoPagado: nuevoPedido.montoPagado
+        montoPagado: nuevoPedido.montoPagado,
+        tipoFactura
       })
       resetNuevoPedido()
       modales.pedido.setOpen(false)
@@ -445,13 +481,16 @@ export function usePedidoHandlers({
     try {
       const pedidoCreado = await crearPedido(
         parseInt(nuevoPedido.clienteId),
-        todosLosItems,
+        itemsConDesglose,
         totalFinal,
         user?.id ?? '',
         descontarStock,
         nuevoPedido.notas,
         nuevoPedido.formaPago,
-        nuevoPedido.estadoPago
+        nuevoPedido.estadoPago,
+        tipoFactura,
+        totalNeto,
+        totalIva
       )
 
       if (nuevoPedido.estadoPago === 'parcial' && nuevoPedido.montoPagado && nuevoPedido.montoPagado > 0 && pedidoCreado?.id) {
@@ -718,6 +757,7 @@ export function usePedidoHandlers({
     handleClienteChange,
     handleNotasChange,
     handleFormaPagoChange,
+    handleTipoFacturaChange,
     handleEstadoPagoChange,
     handleMontoPagadoChange,
     handleCrearClienteEnPedido,

--- a/src/hooks/queries/useComprasQuery.ts
+++ b/src/hooks/queries/useComprasQuery.ts
@@ -112,7 +112,8 @@ async function registrarCompra(compraData: CompraFormInputExtended): Promise<Reg
     p_forma_pago: compraData.formaPago || 'efectivo',
     p_notas: compraData.notas || null,
     p_usuario_id: compraData.usuarioId || null,
-    p_items: itemsParaRPC
+    p_items: itemsParaRPC,
+    p_tipo_factura: compraData.tipoFactura || 'FC'
   })
 
   if (error) throw error

--- a/src/hooks/queries/usePedidosQuery.ts
+++ b/src/hooks/queries/usePedidosQuery.ts
@@ -31,6 +31,10 @@ interface PedidoItemInput {
   precio_unitario?: number
   esBonificacion?: boolean
   promocionId?: string
+  neto_unitario?: number
+  iva_unitario?: number
+  impuestos_internos_unitario?: number
+  porcentaje_iva?: number
 }
 
 interface CrearPedidoInput {
@@ -43,6 +47,9 @@ interface CrearPedidoInput {
   estadoPago?: string
   montoPagado?: number
   fecha?: string
+  tipoFactura?: 'ZZ' | 'FC'
+  totalNeto?: number
+  totalIva?: number
 }
 
 interface ActualizarEstadoInput {
@@ -232,6 +239,10 @@ async function crearPedido(input: CrearPedidoInput): Promise<{ id: string }> {
     precio_unitario: item.precioUnitario ?? item.precio_unitario ?? 0,
     ...(item.esBonificacion ? { es_bonificacion: true } : {}),
     ...(item.promocionId ? { promocion_id: item.promocionId } : {}),
+    ...(item.neto_unitario != null ? { neto_unitario: item.neto_unitario } : {}),
+    ...(item.iva_unitario != null ? { iva_unitario: item.iva_unitario } : {}),
+    ...(item.impuestos_internos_unitario != null ? { impuestos_internos_unitario: item.impuestos_internos_unitario } : {}),
+    ...(item.porcentaje_iva != null ? { porcentaje_iva: item.porcentaje_iva } : {}),
   }))
 
   const { data, error } = await supabase.rpc('crear_pedido_completo', {
@@ -242,7 +253,10 @@ async function crearPedido(input: CrearPedidoInput): Promise<{ id: string }> {
     p_notas: input.notas || null,
     p_forma_pago: input.formaPago || 'efectivo',
     p_estado_pago: input.estadoPago || 'pendiente',
-    ...(input.fecha ? { p_fecha: input.fecha } : {})
+    ...(input.fecha ? { p_fecha: input.fecha } : {}),
+    p_tipo_factura: input.tipoFactura || 'ZZ',
+    p_total_neto: input.totalNeto ?? input.total,
+    p_total_iva: input.totalIva ?? 0
   })
 
   if (error) throw error

--- a/src/hooks/supabase/usePedidos.ts
+++ b/src/hooks/supabase/usePedidos.ts
@@ -48,6 +48,10 @@ interface PedidoItemInput {
   precio_unitario?: number;
   esBonificacion?: boolean;
   promocionId?: string;
+  neto_unitario?: number;
+  iva_unitario?: number;
+  impuestos_internos_unitario?: number;
+  porcentaje_iva?: number;
 }
 
 interface OrdenEntregaItem {
@@ -111,7 +115,10 @@ export interface UsePedidosHookReturn {
     descontarStockFn: ((items: PedidoItemInput[]) => Promise<void>) | null,
     notas?: string,
     formaPago?: string,
-    estadoPago?: string
+    estadoPago?: string,
+    tipoFactura?: 'ZZ' | 'FC',
+    totalNeto?: number,
+    totalIva?: number
   ) => Promise<{ id: string }>;
   cambiarEstado: (id: string, nuevoEstado: string) => Promise<void>;
   asignarTransportista: (pedidoId: string, transportistaId: string | null, cambiarEstadoFlag?: boolean) => Promise<void>;
@@ -290,7 +297,10 @@ export function usePedidos(): UsePedidosHookReturn {
     _descontarStockFn: ((items: PedidoItemInput[]) => Promise<void>) | null,
     notas: string = '',
     formaPago: string = 'efectivo',
-    estadoPago: string = 'pendiente'
+    estadoPago: string = 'pendiente',
+    tipoFactura: 'ZZ' | 'FC' = 'ZZ',
+    totalNeto?: number,
+    totalIva?: number
   ): Promise<{ id: string }> => {
     const itemsParaRPC = items.map(item => ({
       producto_id: item.productoId || item.producto_id,
@@ -298,6 +308,10 @@ export function usePedidos(): UsePedidosHookReturn {
       precio_unitario: item.precioUnitario ?? item.precio_unitario ?? 0,
       ...(item.esBonificacion ? { es_bonificacion: true } : {}),
       ...(item.promocionId ? { promocion_id: item.promocionId } : {}),
+      ...(item.neto_unitario != null ? { neto_unitario: item.neto_unitario } : {}),
+      ...(item.iva_unitario != null ? { iva_unitario: item.iva_unitario } : {}),
+      ...(item.impuestos_internos_unitario != null ? { impuestos_internos_unitario: item.impuestos_internos_unitario } : {}),
+      ...(item.porcentaje_iva != null ? { porcentaje_iva: item.porcentaje_iva } : {}),
     }))
 
     const { data, error } = await supabase.rpc('crear_pedido_completo', {
@@ -307,7 +321,10 @@ export function usePedidos(): UsePedidosHookReturn {
       p_items: itemsParaRPC,
       p_notas: notas || null,
       p_forma_pago: formaPago || 'efectivo',
-      p_estado_pago: estadoPago || 'pendiente'
+      p_estado_pago: estadoPago || 'pendiente',
+      p_tipo_factura: tipoFactura || 'ZZ',
+      p_total_neto: totalNeto ?? total,
+      p_total_iva: totalIva ?? 0
     })
 
     if (error) {

--- a/src/hooks/supabase/useReportesFinancieros.ts
+++ b/src/hooks/supabase/useReportesFinancieros.ts
@@ -146,7 +146,14 @@ export function useReportesFinancieros(): UseReportesFinancierosReturn {
       const pedidosTyped = (pedidos || []) as PedidoWithItems[]
 
       const productoStats: ProductoStatsMap = {}
+      let ventasBrutas = 0
+      let ivaDiscriminado = 0
+      let impuestosInternosTotales = 0
+      let ventasNetas = 0
+
       pedidosTyped.forEach(p => {
+        const tipoFactura = (p as unknown as Record<string, unknown>).tipo_factura as string || 'ZZ'
+
         p.items?.forEach(item => {
           const prod = item.producto
           if (!prod) return
@@ -163,9 +170,26 @@ export function useReportesFinancieros(): UseReportesFinancierosReturn {
               margenPorcentaje: 0
             }
           }
+          const subtotalItem = item.subtotal || (item.cantidad * item.precio_unitario)
           productoStats[id].cantidadVendida += item.cantidad
-          productoStats[id].ingresos += item.subtotal || (item.cantidad * item.precio_unitario)
-          const costoUnitario = prod.costo_con_iva || prod.costo_sin_iva || 0
+          ventasBrutas += subtotalItem
+
+          // Usar neto_unitario si existe (pedidos nuevos), sino calcular
+          if (tipoFactura === 'FC' && (item as Record<string, unknown>).neto_unitario != null) {
+            const netoItem = ((item as Record<string, unknown>).neto_unitario as number) * item.cantidad
+            const ivaItem = ((item as Record<string, unknown>).iva_unitario as number || 0) * item.cantidad
+            const impIntItem = ((item as Record<string, unknown>).impuestos_internos_unitario as number || 0) * item.cantidad
+            productoStats[id].ingresos += netoItem
+            ivaDiscriminado += ivaItem
+            impuestosInternosTotales += impIntItem
+            ventasNetas += netoItem
+          } else {
+            // Pedidos ZZ o legacy sin desglose: neto = total
+            productoStats[id].ingresos += subtotalItem
+            ventasNetas += subtotalItem
+          }
+
+          const costoUnitario = prod.costo_sin_iva || 0
           productoStats[id].costos += costoUnitario * item.cantidad
         })
       })
@@ -181,7 +205,11 @@ export function useReportesFinancieros(): UseReportesFinancierosReturn {
         costosTotales: reporteProductos.reduce((s, p) => s + p.costos, 0),
         margenTotal: reporteProductos.reduce((s, p) => s + p.margen, 0),
         cantidadPedidos: pedidosTyped.length,
-        margenPorcentaje: 0
+        margenPorcentaje: 0,
+        ventasBrutas,
+        ivaDiscriminado,
+        impuestosInternos: impuestosInternosTotales,
+        ventasNetas
       }
       totales.margenPorcentaje = totales.ingresosTotales > 0
         ? (totales.margenTotal / totales.ingresosTotales * 100)
@@ -197,7 +225,11 @@ export function useReportesFinancieros(): UseReportesFinancierosReturn {
           costosTotales: 0,
           margenTotal: 0,
           cantidadPedidos: 0,
-          margenPorcentaje: 0
+          margenPorcentaje: 0,
+          ventasBrutas: 0,
+          ivaDiscriminado: 0,
+          impuestosInternos: 0,
+          ventasNetas: 0
         }
       }
     } finally {

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -232,7 +232,9 @@ export const pedidoSchema = z.object({
 
   notas: z.string().optional(),
 
-  fecha_entrega: z.string().optional()
+  fecha_entrega: z.string().optional(),
+
+  tipo_factura: z.enum(['ZZ', 'FC']).default('ZZ')
 }).refine(
   (data) => {
     const total = data.items.reduce((sum, item) => {
@@ -319,7 +321,9 @@ export const compraSchema = z.object({
     .array(itemCompraSchema)
     .min(1, { message: 'Debe agregar al menos un producto' }),
 
-  notas: z.string().optional()
+  notas: z.string().optional(),
+
+  tipo_factura: z.enum(['ZZ', 'FC']).default('FC')
 }).refine(
   (data) => {
     // Debe tener proveedor_id O proveedor_nombre
@@ -876,6 +880,7 @@ export const modalCompraSchema = z.object({
   formaPago: z.enum(['efectivo', 'transferencia', 'cheque', 'cuenta_corriente', 'tarjeta'], {
     message: 'Forma de pago inválida'
   }),
+  tipoFactura: z.enum(['ZZ', 'FC']).default('FC'),
   items: z.array(z.object({
     productoId: z.string(),
     cantidad: z.number().positive({ message: 'La cantidad debe ser mayor a 0' }),

--- a/src/types/hooks.ts
+++ b/src/types/hooks.ts
@@ -46,6 +46,7 @@ export interface ProductoDB {
   costo_con_iva?: number | null;
   impuestos_internos?: number | null;
   precio_sin_iva?: number | null;
+  porcentaje_iva?: number | null;
   activo?: boolean;
   created_at?: string;
   updated_at?: string;
@@ -61,6 +62,10 @@ export interface PedidoItemDB {
   subtotal?: number;
   es_bonificacion?: boolean;
   promocion_id?: string;
+  neto_unitario?: number;
+  iva_unitario?: number;
+  impuestos_internos_unitario?: number;
+  porcentaje_iva?: number;
 }
 
 export interface PerfilDB {
@@ -93,6 +98,9 @@ export interface PedidoDB {
   estado_pago?: 'pendiente' | 'parcial' | 'pagado';
   forma_pago?: string;
   total: number;
+  total_neto?: number;
+  total_iva?: number;
+  tipo_factura?: 'ZZ' | 'FC';
   monto_pagado?: number;
   notas?: string | null;
   motivo_cancelacion?: string | null;
@@ -738,6 +746,7 @@ export interface CompraDBExtended {
   forma_pago?: string;
   estado?: 'activa' | 'cancelada';
   notas?: string | null;
+  tipo_factura?: 'ZZ' | 'FC';
   items?: CompraItemDBExtended[];
   created_at?: string;
 }
@@ -754,6 +763,7 @@ export interface CompraFormInputExtended {
   formaPago?: string;
   notas?: string | null;
   usuarioId?: string | null;
+  tipoFactura?: 'ZZ' | 'FC';
   items: Array<{
     productoId: string;
     cantidad: number;
@@ -1050,6 +1060,10 @@ export interface TotalesRentabilidad {
   margenTotal: number;
   cantidadPedidos: number;
   margenPorcentaje: number;
+  ventasBrutas: number;
+  ivaDiscriminado: number;
+  impuestosInternos: number;
+  ventasNetas: number;
 }
 
 export interface ReporteRentabilidad {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -95,6 +95,8 @@ export type FormaPago = 'efectivo' | 'transferencia' | 'tarjeta' | 'cuenta_corri
 
 export type EstadoPago = 'pendiente' | 'parcial' | 'pagado';
 
+export type TipoFactura = 'ZZ' | 'FC';
+
 export interface PedidoItem {
   id?: string;
   producto_id: string;
@@ -102,6 +104,8 @@ export interface PedidoItem {
   cantidad: number;
   precio_unitario: number;
   subtotal: number;
+  neto_unitario?: number;
+  iva_unitario?: number;
 }
 
 export interface Pedido extends BaseEntity {
@@ -114,6 +118,9 @@ export interface Pedido extends BaseEntity {
   estado_pago: EstadoPago;
   forma_pago: FormaPago;
   total: number;
+  total_neto?: number;
+  total_iva?: number;
+  tipo_factura?: TipoFactura;
   monto_pagado: number;
   notas?: string;
   fecha_entrega?: string;
@@ -132,6 +139,7 @@ export interface PedidoInput {
   forma_pago?: FormaPago;
   estado_pago?: EstadoPago;
   monto_pagado?: number;
+  tipo_factura?: TipoFactura;
 }
 
 // =============================================================================

--- a/src/utils/calculations.ts
+++ b/src/utils/calculations.ts
@@ -81,6 +81,74 @@ export function calcularMontoIva(
 }
 
 // ============================================
+// CÁLCULOS POR TIPO DE FACTURA (ZZ/FC)
+// ============================================
+
+export interface DesgloseNetoVenta {
+  neto: number;
+  iva: number;
+  impuestosInternos: number;
+}
+
+/**
+ * Calcula el ingreso neto de una venta según tipo de factura
+ *
+ * ZZ (sin factura): todo el precio final es ingreso neto
+ * FC (con factura): el neto es el precio sin IVA ni impuestos, el IVA se remite a AFIP
+ *
+ * @param precioFinal - Precio final al consumidor (incluye IVA + imp internos)
+ * @param porcentajeIva - Porcentaje de IVA del producto (ej: 21, 10.5, 0)
+ * @param porcentajeImpInternos - Porcentaje de impuestos internos (ej: 5, 8)
+ * @param tipoFactura - 'ZZ' o 'FC'
+ * @returns Desglose con neto, iva e impuestos internos
+ */
+export function calcularNetoVenta(
+  precioFinal: number | string,
+  porcentajeIva: number | string = 21,
+  porcentajeImpInternos: number | string = 0,
+  tipoFactura: 'ZZ' | 'FC' = 'ZZ'
+): DesgloseNetoVenta {
+  const precio = parseFloat(String(precioFinal)) || 0;
+
+  if (tipoFactura === 'ZZ') {
+    return { neto: precio, iva: 0, impuestosInternos: 0 };
+  }
+
+  // FC: back-calculate neto from final price
+  const neto = calcularNetoDesdeTotal(precio, porcentajeIva, porcentajeImpInternos);
+  const iva = calcularMontoIva(neto, porcentajeIva);
+  const impInt = neto * (parseFloat(String(porcentajeImpInternos)) || 0) / 100;
+
+  return { neto, iva, impuestosInternos: impInt };
+}
+
+/**
+ * Calcula el costo neto de una compra según tipo de factura
+ *
+ * FC (con factura): costo neto = costo sin IVA (IVA es crédito fiscal)
+ * ZZ (sin factura): costo neto = costo total (no hay IVA que descontar)
+ *
+ * @param costoSinIva - Costo neto sin IVA del producto
+ * @param porcentajeIva - Porcentaje de IVA
+ * @param tipoFactura - 'ZZ' o 'FC'
+ * @returns Costo neto real
+ */
+export function calcularNetoCosto(
+  costoSinIva: number | string,
+  porcentajeIva: number | string = 21,
+  tipoFactura: 'ZZ' | 'FC' = 'FC'
+): number {
+  const costo = parseFloat(String(costoSinIva)) || 0;
+  const iva = parseFloat(String(porcentajeIva)) || 0;
+
+  if (tipoFactura === 'FC') {
+    return costo; // IVA es crédito fiscal, no es costo
+  }
+  // ZZ: IVA no existe, el costo total es el neto
+  return costo * (1 + iva / 100);
+}
+
+// ============================================
 // CÁLCULOS DE PEDIDOS
 // ============================================
 
@@ -218,6 +286,8 @@ export default {
   calcularPrecioTotal,
   calcularNetoDesdeTotal,
   calcularMontoIva,
+  calcularNetoVenta,
+  calcularNetoCosto,
   calcularSubtotalItem,
   calcularTotalPedido,
   calcularMargenPorcentaje,


### PR DESCRIPTION
## Summary

- **Tipo de factura por pedido/compra**: Agrega campo `tipo_factura` (ZZ = sin factura, FC = con factura) a pedidos y compras para distinguir el tratamiento contable del IVA
- **Cálculo automático de neto/IVA**: Al crear un pedido FC, el sistema desglosa automáticamente el precio final en neto + IVA + imp. internos. En ZZ todo es ingreso neto
- **Reportes con desglose completo**: El reporte de rentabilidad ahora muestra ventas brutas, IVA discriminado, impuestos internos y ventas netas
- **UI**: Toggle ZZ/FC en creación de pedidos y compras, badges visuales en cards y tablas

### Detalle técnico

| Área | Cambios |
|------|---------|
| **Migraciones** | `045_tipo_factura_zz_fc.sql` (schema), `046_update_rpcs_tipo_factura.sql` (RPCs) |
| **RPCs** | `crear_pedido_completo` (3 params nuevos), `actualizar_pedido_items`, `registrar_compra_completa` |
| **Utilidades** | `calcularNetoVenta()`, `calcularNetoCosto()` en calculations.ts |
| **Tipos** | `TipoFactura`, campos neto/iva en PedidoDB, PedidoItemDB, CompraDB |
| **UI** | ModalPedido, ModalCompra (toggle), PedidoCard, VistaCompras (badges), ReporteRentabilidad (desglose) |

### Compatibilidad

- Pedidos existentes → `tipo_factura='ZZ'`, `total_neto=total` (backfill en migración)
- Compras existentes → `tipo_factura='FC'` (default)
- Precios finales al consumidor no cambian

## Test plan

- [ ] Crear pedido ZZ: verificar `total_neto = total`, `total_iva = 0`
- [ ] Crear pedido FC: verificar `total_neto < total`, IVA discriminado correctamente
- [ ] Crear compra FC: IVA se calcula normalmente
- [ ] Crear compra ZZ: IVA = 0, costo_con_iva = costo_sin_iva
- [ ] Reporte rentabilidad: verificar desglose brutas/IVA/netas con mix ZZ+FC
- [ ] Pedidos/compras existentes siguen funcionando con defaults

🤖 Generated with [Claude Code](https://claude.com/claude-code)