### PR TITLE
fix: cancelación completa, rendiciones sin recorrido, toggle ZZ/FC di…

### DIFF
--- a/migrations/047_fix_cancelar_pedido_completo.sql
+++ b/migrations/047_fix_cancelar_pedido_completo.sql
@@ -1,0 +1,90 @@
+-- Migration 047: Fix cancelar_pedido_con_stock para revertir TODOS los side-effects
+--
+-- Problemas en la versión anterior (migration 041):
+--   1. No ajustaba saldo_cuenta del cliente (trigger solo escucha total/monto_pagado)
+--   2. No decrementaba usos_pendientes de promociones para items bonificados
+--   3. Restauraba stock de items bonificados (no debería: bonificados no descuentan stock)
+--
+-- Solución:
+--   - Solo restaurar stock de items NO bonificados
+--   - Decrementar usos_pendientes de promos para items bonificados
+--   - Poner total=0 y monto_pagado=0 para activar trigger de saldo automáticamente
+
+CREATE OR REPLACE FUNCTION cancelar_pedido_con_stock(
+  p_pedido_id BIGINT,
+  p_motivo TEXT,
+  p_usuario_id UUID DEFAULT NULL
+)
+RETURNS JSONB AS $$
+DECLARE
+  v_pedido RECORD;
+  v_item RECORD;
+  v_total_original DECIMAL;
+BEGIN
+  -- Lock the pedido row for atomic update
+  SELECT * INTO v_pedido FROM pedidos WHERE id = p_pedido_id FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RETURN jsonb_build_object('success', false, 'error', 'Pedido no encontrado');
+  END IF;
+
+  IF v_pedido.estado = 'cancelado' THEN
+    RETURN jsonb_build_object('success', false, 'error', 'El pedido ya está cancelado');
+  END IF;
+
+  IF v_pedido.estado = 'entregado' THEN
+    RETURN jsonb_build_object('success', false, 'error', 'No se puede cancelar un pedido entregado');
+  END IF;
+
+  -- Guardar total original para el historial
+  v_total_original := v_pedido.total;
+
+  -- 1. Restaurar stock SOLO de items NO bonificados
+  -- 2. Decrementar usos_pendientes de promos para items bonificados
+  FOR v_item IN
+    SELECT producto_id, cantidad, COALESCE(es_bonificacion, false) as es_bonificacion, promocion_id
+    FROM pedido_items WHERE pedido_id = p_pedido_id
+  LOOP
+    IF v_item.es_bonificacion THEN
+      -- Bonificados: revertir contador de promo (no restaurar stock porque nunca se descontó)
+      IF v_item.promocion_id IS NOT NULL THEN
+        UPDATE promociones
+        SET usos_pendientes = GREATEST(usos_pendientes - v_item.cantidad, 0)
+        WHERE id = v_item.promocion_id;
+      END IF;
+    ELSE
+      -- No bonificados: restaurar stock
+      UPDATE productos SET stock = stock + v_item.cantidad WHERE id = v_item.producto_id;
+    END IF;
+  END LOOP;
+
+  -- 3. Cancelar pedido y poner total=0 para que el trigger de saldo revierta automáticamente
+  --    El trigger actualizar_saldo_pedido() escucha UPDATE OF total, monto_pagado
+  --    y calculará: saldo -= (total_viejo - monto_pagado_viejo) y sumará (0 - 0) = 0
+  UPDATE pedidos
+  SET estado = 'cancelado',
+      motivo_cancelacion = p_motivo,
+      total = 0,
+      monto_pagado = 0,
+      total_neto = 0,
+      total_iva = 0,
+      updated_at = NOW()
+  WHERE id = p_pedido_id;
+
+  -- 4. Registrar en historial con total original para auditoría
+  INSERT INTO pedido_historial (pedido_id, usuario_id, campo_modificado, valor_anterior, valor_nuevo)
+  VALUES (
+    p_pedido_id,
+    p_usuario_id,
+    'estado',
+    v_pedido.estado,
+    'cancelado - Motivo: ' || COALESCE(p_motivo, 'Sin motivo') || ' | Total original: $' || v_total_original
+  );
+
+  RETURN jsonb_build_object(
+    'success', true,
+    'mensaje', 'Pedido cancelado, stock restaurado, saldo ajustado',
+    'total_original', v_total_original
+  );
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = public;

--- a/migrations/048_rendiciones_sin_recorrido.sql
+++ b/migrations/048_rendiciones_sin_recorrido.sql
@@ -1,0 +1,80 @@
+-- Migration 048: Rendiciones sin dependencia de recorridos
+--
+-- Problema: crear_rendicion_recorrido() requiere un recorrido existente.
+-- Solución: Nueva RPC crear_rendicion_por_fecha() que busca pedidos entregados
+--           directamente por transportista_id + fecha, sin necesitar recorrido.
+--
+-- También hace recorrido_id nullable para soportar rendiciones creadas sin recorrido.
+
+-- 1. Hacer recorrido_id nullable
+ALTER TABLE rendiciones ALTER COLUMN recorrido_id DROP NOT NULL;
+
+-- 2. Nueva RPC: crear rendición por transportista + fecha
+CREATE OR REPLACE FUNCTION crear_rendicion_por_fecha(
+  p_transportista_id UUID,
+  p_fecha DATE DEFAULT CURRENT_DATE
+)
+RETURNS BIGINT AS $$
+DECLARE
+  v_rendicion_id BIGINT;
+  v_total_efectivo DECIMAL := 0;
+  v_total_otros DECIMAL := 0;
+  v_pedido RECORD;
+  v_count INTEGER := 0;
+BEGIN
+  -- Verificar que no existe ya rendición para este transportista/fecha
+  IF EXISTS (
+    SELECT 1 FROM rendiciones
+    WHERE transportista_id = p_transportista_id AND fecha = p_fecha
+  ) THEN
+    RAISE EXCEPTION 'Ya existe una rendición para este transportista en esta fecha';
+  END IF;
+
+  -- Calcular totales desde pedidos entregados por este transportista en esta fecha
+  -- Usa COALESCE(fecha_entrega, updated_at) porque no todos los entregados tienen fecha_entrega
+  FOR v_pedido IN
+    SELECT p.id,
+           COALESCE(p.total, 0) as total,
+           COALESCE(p.monto_pagado, p.total, 0) as monto_pagado,
+           COALESCE(p.forma_pago, 'efectivo') as forma_pago
+    FROM pedidos p
+    WHERE p.transportista_id = p_transportista_id
+      AND p.estado = 'entregado'
+      AND COALESCE(p.fecha_entrega, p.updated_at)::date = p_fecha
+  LOOP
+    v_count := v_count + 1;
+    IF v_pedido.forma_pago = 'efectivo' THEN
+      v_total_efectivo := v_total_efectivo + v_pedido.monto_pagado;
+    ELSE
+      v_total_otros := v_total_otros + v_pedido.monto_pagado;
+    END IF;
+  END LOOP;
+
+  -- Crear rendición (recorrido_id = NULL)
+  INSERT INTO rendiciones (
+    recorrido_id, transportista_id, fecha,
+    total_efectivo_esperado, total_otros_medios, estado
+  ) VALUES (
+    NULL, p_transportista_id, p_fecha,
+    v_total_efectivo, v_total_otros, 'pendiente'
+  ) RETURNING id INTO v_rendicion_id;
+
+  -- Crear items para cada pedido entregado
+  INSERT INTO rendicion_items (rendicion_id, pedido_id, monto_cobrado, forma_pago)
+  SELECT v_rendicion_id, p.id,
+         COALESCE(p.monto_pagado, p.total, 0),
+         COALESCE(p.forma_pago, 'efectivo')
+  FROM pedidos p
+  WHERE p.transportista_id = p_transportista_id
+    AND p.estado = 'entregado'
+    AND COALESCE(p.fecha_entrega, p.updated_at)::date = p_fecha;
+
+  RETURN v_rendicion_id;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = public;
+
+-- 3. Backfill: setear fecha_entrega para pedidos entregados que no la tienen
+UPDATE pedidos
+SET fecha_entrega = updated_at
+WHERE estado = 'entregado'
+  AND fecha_entrega IS NULL;

--- a/src/components/containers/PedidosContainer.tsx
+++ b/src/components/containers/PedidosContainer.tsx
@@ -683,8 +683,11 @@ export default function PedidosContainer(): React.ReactElement {
         })
       }
     }
+    // Invalidar cache de productos y pedidos para reflejar cambios de stock y totales
+    queryClient.invalidateQueries({ queryKey: ['productos'] })
+    queryClient.invalidateQueries({ queryKey: ['pedidos'] })
     return results
-  }, [])
+  }, [queryClient])
 
   const handleMarcarEntregadoConSalvedadConfirm = useCallback(async () => {
     if (!pedidoParaSalvedad) return

--- a/src/components/modals/ModalPedido.tsx
+++ b/src/components/modals/ModalPedido.tsx
@@ -210,7 +210,17 @@ const ModalPedido = memo(function ModalPedido({
     <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center p-4 z-50">
       <div className="bg-white dark:bg-gray-800 rounded-xl shadow-xl w-full max-w-2xl max-h-[90vh] overflow-hidden flex flex-col">
         <div className="flex justify-between items-center p-4 border-b dark:border-gray-700">
-          <h2 className="text-xl font-semibold dark:text-white">Nuevo Pedido</h2>
+          <div className="flex items-center gap-2">
+            <h2 className="text-xl font-semibold dark:text-white">Nuevo Pedido</h2>
+            <select
+              value={nuevoPedido.tipoFactura || 'ZZ'}
+              onChange={(e) => onTipoFacturaChange?.(e.target.value as 'ZZ' | 'FC')}
+              className="px-2 py-1 text-xs font-medium border rounded bg-white dark:bg-gray-700 dark:border-gray-600 dark:text-white"
+            >
+              <option value="ZZ">ZZ</option>
+              <option value="FC">FC</option>
+            </select>
+          </div>
           <button onClick={onClose}><X className="w-6 h-6 text-gray-500 dark:text-gray-400" /></button>
         </div>
 
@@ -549,35 +559,6 @@ const ModalPedido = memo(function ModalPedido({
 
           {/* Seccion Tipo Factura, Forma de Pago y Observaciones - al fondo */}
           <div className="border-t dark:border-gray-600 pt-4 space-y-3">
-            {/* Tipo de Factura */}
-            <div>
-              <label className="block text-sm font-medium mb-1 dark:text-gray-200">Tipo de Comprobante</label>
-              <div className="flex rounded-lg overflow-hidden border dark:border-gray-600">
-                <button
-                  type="button"
-                  onClick={() => onTipoFacturaChange && onTipoFacturaChange('ZZ')}
-                  className={`flex-1 px-3 py-2 text-sm font-medium transition-colors ${
-                    (nuevoPedido.tipoFactura || 'ZZ') === 'ZZ'
-                      ? 'bg-gray-800 text-white dark:bg-gray-200 dark:text-gray-900'
-                      : 'bg-gray-100 text-gray-600 hover:bg-gray-200 dark:bg-gray-700 dark:text-gray-300 dark:hover:bg-gray-600'
-                  }`}
-                >
-                  ZZ Sin Factura
-                </button>
-                <button
-                  type="button"
-                  onClick={() => onTipoFacturaChange && onTipoFacturaChange('FC')}
-                  className={`flex-1 px-3 py-2 text-sm font-medium transition-colors ${
-                    nuevoPedido.tipoFactura === 'FC'
-                      ? 'bg-blue-600 text-white dark:bg-blue-500'
-                      : 'bg-gray-100 text-gray-600 hover:bg-gray-200 dark:bg-gray-700 dark:text-gray-300 dark:hover:bg-gray-600'
-                  }`}
-                >
-                  FC Con Factura
-                </button>
-              </div>
-            </div>
-
             <div className="grid grid-cols-2 gap-3">
               <div>
                 <label className="block text-sm font-medium mb-1 dark:text-gray-200">Forma de Pago</label>

--- a/src/components/vistas/VistaRendiciones.tsx
+++ b/src/components/vistas/VistaRendiciones.tsx
@@ -20,16 +20,22 @@ import {
   X
 } from 'lucide-react'
 import { fechaLocalISO } from '../../utils/formatters'
-import { useRendiciones, useUsuarios, useRecorridos } from '../../hooks/supabase'
+import { useRendiciones, useUsuarios } from '../../hooks/supabase'
 import { useNotification } from '../../contexts/NotificationContext'
 import type { RendicionDBExtended, EstadoRendicion, PerfilDB } from '../../types'
+
+interface RendicionItemDetalle {
+  pedido_id: string | number;
+  monto_cobrado: number;
+  forma_pago: string;
+}
 
 interface RendicionCardProps {
   rendicion: RendicionDBExtended;
   onAprobar: (id: string) => void;
   onRechazar: (id: string, observaciones: string) => void;
   onObservar: (id: string, observaciones: string) => void;
-  onVerDetalle: (rendicion: RendicionDBExtended) => void;
+  onLoadDetalle: (rendicionId: string) => Promise<RendicionItemDetalle[]>;
 }
 
 const ESTADO_CONFIG: Record<EstadoRendicion, { label: string; color: string; icon: React.ElementType }> = {
@@ -40,10 +46,12 @@ const ESTADO_CONFIG: Record<EstadoRendicion, { label: string; color: string; ico
   con_observaciones: { label: 'Con Observaciones', color: 'amber', icon: AlertTriangle }
 }
 
-function RendicionCard({ rendicion, onAprobar, onRechazar, onObservar, onVerDetalle }: RendicionCardProps) {
+function RendicionCard({ rendicion, onAprobar, onRechazar, onObservar, onLoadDetalle }: RendicionCardProps) {
   const [expandido, setExpandido] = useState(false)
   const [observaciones, setObservaciones] = useState('')
   const [accionando, setAccionando] = useState(false)
+  const [items, setItems] = useState<RendicionItemDetalle[]>([])
+  const [cargandoItems, setCargandoItems] = useState(false)
 
   const estadoConfig = ESTADO_CONFIG[rendicion.estado]
   const Icon = estadoConfig.icon
@@ -71,12 +79,25 @@ function RendicionCard({ rendicion, onAprobar, onRechazar, onObservar, onVerDeta
     }
   }
 
+  const handleToggleExpand = async () => {
+    const nuevoEstado = !expandido
+    setExpandido(nuevoEstado)
+    if (nuevoEstado && items.length === 0 && !cargandoItems) {
+      setCargandoItems(true)
+      try {
+        const detalle = await onLoadDetalle(rendicion.id)
+        setItems(detalle)
+      } catch { /* error ya notificado */ }
+      finally { setCargandoItems(false) }
+    }
+  }
+
   return (
     <div className="bg-white dark:bg-gray-800 rounded-lg border dark:border-gray-700 overflow-hidden">
       {/* Header */}
       <div
         className="p-4 cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-750"
-        onClick={() => setExpandido(!expandido)}
+        onClick={handleToggleExpand}
       >
         <div className="flex items-center justify-between">
           <div className="flex items-center gap-3">
@@ -209,14 +230,46 @@ function RendicionCard({ rendicion, onAprobar, onRechazar, onObservar, onVerDeta
             </div>
           )}
 
-          {/* Boton ver detalle */}
-          <button
-            onClick={() => onVerDetalle(rendicion)}
-            className="w-full px-3 py-2 border dark:border-gray-600 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-700 text-sm flex items-center justify-center gap-1"
-          >
-            <Eye className="w-4 h-4" />
-            Ver detalle completo
-          </button>
+          {/* Detalle de pedidos */}
+          {cargandoItems ? (
+            <div className="flex items-center justify-center py-4">
+              <RefreshCw className="w-5 h-5 animate-spin text-blue-600" />
+              <span className="ml-2 text-sm text-gray-500">Cargando detalle...</span>
+            </div>
+          ) : items.length > 0 ? (
+            <div className="border dark:border-gray-700 rounded-lg overflow-hidden">
+              <table className="w-full text-sm">
+                <thead className="bg-gray-50 dark:bg-gray-900">
+                  <tr>
+                    <th className="px-3 py-2 text-left text-gray-500">Pedido</th>
+                    <th className="px-3 py-2 text-right text-gray-500">Monto</th>
+                    <th className="px-3 py-2 text-right text-gray-500">Forma de pago</th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y dark:divide-gray-700">
+                  {items.map((item) => (
+                    <tr key={item.pedido_id} className="hover:bg-gray-50 dark:hover:bg-gray-700/50">
+                      <td className="px-3 py-2 text-gray-800 dark:text-gray-200">#{item.pedido_id}</td>
+                      <td className="px-3 py-2 text-right font-medium text-gray-800 dark:text-gray-200">
+                        {formatMoney(item.monto_cobrado)}
+                      </td>
+                      <td className="px-3 py-2 text-right">
+                        <span className={`px-2 py-0.5 rounded text-xs ${
+                          item.forma_pago === 'efectivo'
+                            ? 'bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400'
+                            : 'bg-purple-100 text-purple-700 dark:bg-purple-900/30 dark:text-purple-400'
+                        }`}>
+                          {item.forma_pago}
+                        </span>
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          ) : (
+            <p className="text-center text-sm text-gray-500 py-2">Sin pedidos en esta rendición</p>
+          )}
         </div>
       )}
     </div>
@@ -317,12 +370,12 @@ export default function VistaRendiciones(): React.ReactElement {
     rendiciones,
     loading,
     fetchRendicionesPorFecha,
+    fetchRendicionById,
     revisarRendicion,
-    crearRendicion,
+    crearRendicionPorFecha,
     getEstadisticas
   } = useRendiciones()
   const { transportistas } = useUsuarios()
-  const { fetchRecorridosPorFecha, recorridos } = useRecorridos()
 
   const [fechaFiltro, setFechaFiltro] = useState<string>(fechaLocalISO())
   const [estadoFiltro, setEstadoFiltro] = useState<EstadoRendicion | 'todas'>('todas')
@@ -338,31 +391,20 @@ export default function VistaRendiciones(): React.ReactElement {
   } | null>(null)
 
   const cargarDatos = useCallback(async () => {
-    await Promise.all([
-      fetchRendicionesPorFecha(fechaFiltro),
-      fetchRecorridosPorFecha(fechaFiltro)
-    ])
-  }, [fechaFiltro, fetchRendicionesPorFecha, fetchRecorridosPorFecha])
+    await fetchRendicionesPorFecha(fechaFiltro)
+  }, [fechaFiltro, fetchRendicionesPorFecha])
 
   const handleCrearRendicion = async (transportistaId: string) => {
     setCreandoRendicion(true)
     try {
-      // Buscar recorrido del transportista en esta fecha
-      const recorrido = recorridos.find(r => r.transportista_id === transportistaId)
-
-      if (!recorrido) {
-        notify.error('No hay recorrido para este transportista en la fecha seleccionada')
-        return
-      }
-
-      // Verificar si ya existe una rendicion para este recorrido
-      const yaExiste = rendiciones.some(r => r.recorrido_id === recorrido.id)
+      // Verificar si ya existe rendición para este transportista/fecha
+      const yaExiste = rendiciones.some(r => r.transportista_id === transportistaId)
       if (yaExiste) {
         notify.warning('Ya existe una rendicion para este transportista en esta fecha')
         return
       }
 
-      await crearRendicion(String(recorrido.id), transportistaId)
+      await crearRendicionPorFecha(transportistaId, fechaFiltro)
       notify.success('Rendicion creada correctamente')
       setModalCrearOpen(false)
       await cargarDatos()
@@ -514,7 +556,14 @@ export default function VistaRendiciones(): React.ReactElement {
               onAprobar={handleAprobar}
               onRechazar={handleRechazar}
               onObservar={handleObservar}
-              onVerDetalle={() => {}}
+              onLoadDetalle={async (rendicionId) => {
+                const detalle = await fetchRendicionById(rendicionId)
+                return (detalle?.items || []).map((item) => ({
+                  pedido_id: item.pedido_id,
+                  monto_cobrado: item.monto_cobrado || 0,
+                  forma_pago: item.forma_pago || 'efectivo',
+                }))
+              }}
             />
           ))}
         </div>

--- a/src/hooks/supabase/useRendiciones.ts
+++ b/src/hooks/supabase/useRendiciones.ts
@@ -196,6 +196,23 @@ export function useRendiciones(): UseRendicionesReturn {
     return rendicionId
   }
 
+  // Crear rendición por transportista + fecha (sin recorrido)
+  const crearRendicionPorFecha = async (transportistaId: string, fecha: string): Promise<string> => {
+    const { data, error } = await supabase.rpc('crear_rendicion_por_fecha', {
+      p_transportista_id: transportistaId,
+      p_fecha: fecha
+    })
+
+    if (error) {
+      notifyError('Error al crear rendición: ' + error.message)
+      throw error
+    }
+
+    const rendicionId = String(data)
+    await fetchRendicionActual(transportistaId)
+    return rendicionId
+  }
+
   // Presentar rendición
   const presentarRendicion = async (input: PresentarRendicionInput): Promise<{ success: boolean; diferencia: number }> => {
     const { data, error } = await supabase.rpc('presentar_rendicion', {
@@ -307,6 +324,7 @@ export function useRendiciones(): UseRendicionesReturn {
     rendicionActual,
     loading,
     crearRendicion,
+    crearRendicionPorFecha,
     presentarRendicion,
     agregarAjuste,
     revisarRendicion,

--- a/src/hooks/supabase/useReportesFinancieros.ts
+++ b/src/hooks/supabase/useReportesFinancieros.ts
@@ -137,6 +137,7 @@ export function useReportesFinancieros(): UseReportesFinancierosReturn {
     setLoading(true)
     try {
       let query = supabase.from('pedidos').select(`*, items:pedido_items(*, producto:productos(*))`)
+        .neq('estado', 'cancelado')
       if (fechaDesde) query = query.gte('created_at', `${fechaDesde}T00:00:00`)
       if (fechaHasta) query = query.lte('created_at', `${fechaHasta}T23:59:59`)
 

--- a/src/types/hooks.ts
+++ b/src/types/hooks.ts
@@ -1206,6 +1206,7 @@ export interface UseRendicionesReturn {
   loading: boolean;
   // Crear y presentar (transportista o admin)
   crearRendicion: (recorridoId: string, transportistaId?: string) => Promise<string>;
+  crearRendicionPorFecha: (transportistaId: string, fecha: string) => Promise<string>;
   presentarRendicion: (input: PresentarRendicionInput) => Promise<{ success: boolean; diferencia: number }>;
   agregarAjuste: (rendicionId: string, ajuste: RendicionAjusteInput) => Promise<void>;
   // Admin


### PR DESCRIPTION
…screto

- Migración 047: reescribir cancelar_pedido_con_stock() para revertir stock (solo no-bonificados), promos (usos_pendientes), y saldo (via trigger)
- Migración 048: rendiciones sin dependencia de recorridos, nueva RPC crear_rendicion_por_fecha() por transportista+fecha, backfill fecha_entrega
- VistaRendiciones: selector transportista+fecha, detalle expandible con items
- ModalPedido: toggle ZZ/FC como select pequeño en el header
- PedidosContainer: invalidar cache de productos/pedidos tras salvedades
- useReportesFinancieros: excluir pedidos cancelados del reporte rentabilidad