### PR TITLE
feat: salvedades en detalle de items + fecha de entrega programada

### DIFF
--- a/migrations/049_fecha_entrega_programada.sql
+++ b/migrations/049_fecha_entrega_programada.sql
@@ -1,0 +1,177 @@
+-- Migration 049: Fecha de entrega programada
+--
+-- Agrega campo fecha_entrega_programada a pedidos para programar entregas futuras.
+-- Default: día siguiente a la fecha del pedido.
+-- Esto permite filtrar pedidos por día de reparto y mejorar la asignación a transportistas.
+
+-- 1. Agregar columna
+ALTER TABLE pedidos ADD COLUMN IF NOT EXISTS fecha_entrega_programada DATE;
+
+-- 2. Backfill: pedidos no entregados/cancelados → fecha del pedido + 1 día
+UPDATE pedidos
+SET fecha_entrega_programada = (COALESCE(fecha, created_at::date) + INTERVAL '1 day')::date
+WHERE fecha_entrega_programada IS NULL
+  AND estado NOT IN ('entregado', 'cancelado');
+
+-- 3. Pedidos entregados: usar fecha_entrega real
+UPDATE pedidos
+SET fecha_entrega_programada = COALESCE(fecha_entrega::date, updated_at::date)
+WHERE fecha_entrega_programada IS NULL
+  AND estado = 'entregado';
+
+-- 4. Pedidos cancelados: usar fecha + 1
+UPDATE pedidos
+SET fecha_entrega_programada = (COALESCE(fecha, created_at::date) + INTERVAL '1 day')::date
+WHERE fecha_entrega_programada IS NULL
+  AND estado = 'cancelado';
+
+-- 5. Index para filtros rápidos por fecha programada
+CREATE INDEX IF NOT EXISTS idx_pedidos_fecha_entrega_programada
+ON pedidos(fecha_entrega_programada) WHERE estado NOT IN ('entregado', 'cancelado');
+
+-- 6. Actualizar crear_pedido_completo con soporte fecha_entrega_programada
+-- Drop la versión anterior (11 params)
+DROP FUNCTION IF EXISTS public.crear_pedido_completo(bigint, numeric, uuid, jsonb, text, text, text, date, text, numeric, numeric);
+
+CREATE OR REPLACE FUNCTION public.crear_pedido_completo(
+  p_cliente_id bigint,
+  p_total numeric,
+  p_usuario_id uuid,
+  p_items jsonb,
+  p_notas text DEFAULT NULL::text,
+  p_forma_pago text DEFAULT 'efectivo'::text,
+  p_estado_pago text DEFAULT 'pendiente'::text,
+  p_fecha date DEFAULT CURRENT_DATE,
+  p_tipo_factura text DEFAULT 'ZZ',
+  p_total_neto numeric DEFAULT NULL,
+  p_total_iva numeric DEFAULT 0,
+  p_fecha_entrega_programada date DEFAULT NULL
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $function$
+DECLARE
+  v_pedido_id INT;
+  item JSONB;
+  v_producto_id INT;
+  v_cantidad INT;
+  v_precio_unitario DECIMAL;
+  v_es_bonificacion BOOLEAN;
+  v_promocion_id BIGINT;
+  v_neto_unitario DECIMAL;
+  v_iva_unitario DECIMAL;
+  v_imp_internos_unitario DECIMAL;
+  v_porcentaje_iva DECIMAL;
+  v_stock_actual INT;
+  v_producto_nombre TEXT;
+  errores TEXT[] := '{}';
+  v_user_role TEXT;
+  v_cantidades_totales JSONB := '{}'::JSONB;
+  v_cant_acumulada INT;
+  v_fecha_entrega DATE;
+BEGIN
+  SELECT rol INTO v_user_role FROM perfiles WHERE id = p_usuario_id;
+  IF v_user_role IS NULL OR v_user_role NOT IN ('admin', 'preventista') THEN
+    RETURN jsonb_build_object('success', false, 'errores', jsonb_build_array('No tiene permisos para crear pedidos'));
+  END IF;
+
+  -- 1. Acumular cantidades totales por producto (SOLO items no bonificados)
+  FOR item IN SELECT * FROM jsonb_array_elements(p_items)
+  LOOP
+    v_producto_id := (item->>'producto_id')::INT;
+    v_cantidad := (item->>'cantidad')::INT;
+    v_es_bonificacion := COALESCE((item->>'es_bonificacion')::BOOLEAN, false);
+
+    IF v_cantidad IS NULL OR v_cantidad <= 0 THEN
+      errores := array_append(errores, 'Cantidad inválida para producto ID ' || v_producto_id || ': debe ser mayor a 0');
+      CONTINUE;
+    END IF;
+
+    IF NOT v_es_bonificacion THEN
+      v_cant_acumulada := COALESCE((v_cantidades_totales->>v_producto_id::TEXT)::INT, 0) + v_cantidad;
+      v_cantidades_totales := v_cantidades_totales || jsonb_build_object(v_producto_id::TEXT, v_cant_acumulada);
+    END IF;
+  END LOOP;
+
+  -- 2. Verificar stock usando cantidades acumuladas (con bloqueo)
+  FOR v_producto_id IN SELECT (key)::INT FROM jsonb_each_text(v_cantidades_totales)
+  LOOP
+    v_cantidad := (v_cantidades_totales->>v_producto_id::TEXT)::INT;
+
+    SELECT stock, nombre INTO v_stock_actual, v_producto_nombre
+    FROM productos
+    WHERE id = v_producto_id
+    FOR UPDATE;
+
+    IF v_stock_actual IS NULL THEN
+      errores := array_append(errores, 'Producto ID ' || v_producto_id || ' no encontrado');
+    ELSIF v_stock_actual < v_cantidad THEN
+      errores := array_append(errores, v_producto_nombre || ': stock insuficiente (disponible: ' || v_stock_actual || ', solicitado: ' || v_cantidad || ')');
+    END IF;
+  END LOOP;
+
+  IF array_length(errores, 1) > 0 THEN
+    RETURN jsonb_build_object('success', false, 'errores', to_jsonb(errores));
+  END IF;
+
+  -- Calcular fecha de entrega programada (default: día siguiente a la fecha del pedido)
+  v_fecha_entrega := COALESCE(p_fecha_entrega_programada, (COALESCE(p_fecha, CURRENT_DATE) + INTERVAL '1 day')::date);
+
+  -- 3. Crear el pedido con tipo_factura, desglose y fecha_entrega_programada
+  INSERT INTO pedidos (
+    cliente_id, fecha, total, total_neto, total_iva, tipo_factura,
+    estado, usuario_id, stock_descontado, notas, forma_pago, estado_pago,
+    fecha_entrega_programada
+  )
+  VALUES (
+    p_cliente_id, p_fecha, p_total,
+    COALESCE(p_total_neto, p_total),
+    COALESCE(p_total_iva, 0),
+    COALESCE(p_tipo_factura, 'ZZ'),
+    'pendiente', p_usuario_id, true, p_notas, p_forma_pago, p_estado_pago,
+    v_fecha_entrega
+  )
+  RETURNING id INTO v_pedido_id;
+
+  -- 4. Crear items y descontar stock
+  FOR item IN SELECT * FROM jsonb_array_elements(p_items)
+  LOOP
+    v_producto_id := (item->>'producto_id')::INT;
+    v_cantidad := (item->>'cantidad')::INT;
+    v_precio_unitario := (item->>'precio_unitario')::DECIMAL;
+    v_es_bonificacion := COALESCE((item->>'es_bonificacion')::BOOLEAN, false);
+    v_promocion_id := (item->>'promocion_id')::BIGINT;
+    v_neto_unitario := (item->>'neto_unitario')::DECIMAL;
+    v_iva_unitario := COALESCE((item->>'iva_unitario')::DECIMAL, 0);
+    v_imp_internos_unitario := COALESCE((item->>'impuestos_internos_unitario')::DECIMAL, 0);
+    v_porcentaje_iva := COALESCE((item->>'porcentaje_iva')::DECIMAL, 0);
+
+    INSERT INTO pedido_items (
+      pedido_id, producto_id, cantidad, precio_unitario, subtotal,
+      es_bonificacion, promocion_id,
+      neto_unitario, iva_unitario, impuestos_internos_unitario, porcentaje_iva
+    )
+    VALUES (
+      v_pedido_id, v_producto_id, v_cantidad, v_precio_unitario,
+      v_cantidad * v_precio_unitario,
+      v_es_bonificacion, v_promocion_id,
+      v_neto_unitario, v_iva_unitario, v_imp_internos_unitario, v_porcentaje_iva
+    );
+
+    -- Stock: solo descontar si NO es bonificación
+    IF NOT v_es_bonificacion THEN
+      UPDATE productos SET stock = stock - v_cantidad WHERE id = v_producto_id;
+    END IF;
+
+    -- Contador de promos
+    IF v_es_bonificacion AND v_promocion_id IS NOT NULL THEN
+      UPDATE promociones SET usos_pendientes = usos_pendientes + v_cantidad
+      WHERE id = v_promocion_id;
+    END IF;
+  END LOOP;
+
+  RETURN jsonb_build_object('success', true, 'pedido_id', v_pedido_id);
+END;
+$function$;

--- a/src/components/containers/PedidosContainer.tsx
+++ b/src/components/containers/PedidosContainer.tsx
@@ -154,6 +154,7 @@ export default function PedidosContainer(): React.ReactElement {
     montoPagado: 0,
     fecha: fechaLocalISO(),
     tipoFactura: 'ZZ' as 'ZZ' | 'FC',
+    fechaEntregaProgramada: undefined as string | undefined,
   })
 
   const resetNuevoPedido = useCallback(() => {
@@ -162,6 +163,7 @@ export default function PedidosContainer(): React.ReactElement {
       formaPago: 'efectivo', estadoPago: 'pendiente', montoPagado: 0,
       fecha: fechaLocalISO(),
       tipoFactura: 'ZZ' as 'ZZ' | 'FC',
+      fechaEntregaProgramada: undefined,
     })
   }, [])
 
@@ -597,6 +599,7 @@ export default function PedidosContainer(): React.ReactElement {
         tipoFactura,
         totalNeto,
         totalIva,
+        fechaEntregaProgramada: nuevoPedido.fechaEntregaProgramada,
       })
       resetNuevoPedido()
       setModalPedidoOpen(false)
@@ -828,6 +831,7 @@ export default function PedidosContainer(): React.ReactElement {
             onMontoPagadoChange={(m: number) => setNuevoPedido(prev => ({ ...prev, montoPagado: m }))}
             onFechaChange={(fecha: string) => setNuevoPedido(prev => ({ ...prev, fecha }))}
             onTipoFacturaChange={(tipo: 'ZZ' | 'FC') => setNuevoPedido(prev => ({ ...prev, tipoFactura: tipo }))}
+            onFechaEntregaProgramadaChange={(fecha: string) => setNuevoPedido(prev => ({ ...prev, fechaEntregaProgramada: fecha }))}
             isOffline={!isOnline}
           />
         </Suspense>

--- a/src/components/modals/ModalPedido.tsx
+++ b/src/components/modals/ModalPedido.tsx
@@ -1,5 +1,5 @@
 import { useState, useMemo, memo } from 'react';
-import { X, Loader2, Search, MapPin, Tag, Calendar, Trash2, Pencil, Gift } from 'lucide-react';
+import { X, Loader2, Search, MapPin, Tag, Calendar, Trash2, Pencil, Gift, Truck } from 'lucide-react';
 import { formatPrecio, fechaLocalISO } from '../../utils/formatters';
 import { AddressAutocomplete } from '../AddressAutocomplete';
 import { usePromocionPedido } from '../../hooks/usePromocionPedido';
@@ -23,6 +23,7 @@ export interface NuevoPedidoState {
   montoPagado?: number;
   fecha?: string;
   tipoFactura?: 'ZZ' | 'FC';
+  fechaEntregaProgramada?: string;
 }
 
 /** Datos del cliente a crear */
@@ -87,6 +88,8 @@ export interface ModalPedidoProps {
   onFechaChange?: (fecha: string) => void;
   /** Callback al cambiar tipo de factura */
   onTipoFacturaChange?: (tipo: 'ZZ' | 'FC') => void;
+  /** Callback al cambiar fecha de entrega programada */
+  onFechaEntregaProgramadaChange?: (fecha: string) => void;
   /** Callback al actualizar precio (solo admin) */
   onActualizarPrecio?: (productoId: string, precio: number) => void;
   /** Si está offline */
@@ -114,6 +117,7 @@ const ModalPedido = memo(function ModalPedido({
   onMontoPagadoChange,
   onFechaChange,
   onTipoFacturaChange,
+  onFechaEntregaProgramadaChange,
   onActualizarPrecio
 }: ModalPedidoProps) {
   const [busquedaProducto, setBusquedaProducto] = useState<string>('');
@@ -289,19 +293,39 @@ const ModalPedido = memo(function ModalPedido({
             )}
           </div>
 
-          {/* Fecha del pedido - compact inline */}
-          <div className="flex items-center gap-3">
-            <label className="text-sm font-medium dark:text-gray-200 whitespace-nowrap flex items-center gap-1">
-              <Calendar className="w-4 h-4" />
-              Fecha
-            </label>
-            <input
-              type="date"
-              value={nuevoPedido.fecha || fechaLocalISO()}
-              onChange={e => onFechaChange && onFechaChange(e.target.value)}
-              max={fechaLocalISO()}
-              className="flex-1 px-3 py-1.5 border rounded-lg bg-white dark:bg-gray-700 dark:border-gray-600 dark:text-white text-sm"
-            />
+          {/* Fechas - pedido y entrega programada */}
+          <div className="flex flex-wrap items-center gap-3">
+            <div className="flex items-center gap-2">
+              <label className="text-sm font-medium dark:text-gray-200 whitespace-nowrap flex items-center gap-1">
+                <Calendar className="w-4 h-4" />
+                Fecha
+              </label>
+              <input
+                type="date"
+                value={nuevoPedido.fecha || fechaLocalISO()}
+                onChange={e => onFechaChange && onFechaChange(e.target.value)}
+                max={fechaLocalISO()}
+                className="px-3 py-1.5 border rounded-lg bg-white dark:bg-gray-700 dark:border-gray-600 dark:text-white text-sm"
+              />
+            </div>
+            <div className="flex items-center gap-2">
+              <label className="text-sm font-medium dark:text-gray-200 whitespace-nowrap flex items-center gap-1">
+                <Truck className="w-4 h-4" />
+                Entrega
+              </label>
+              <input
+                type="date"
+                value={nuevoPedido.fechaEntregaProgramada || (() => {
+                  const base = nuevoPedido.fecha || fechaLocalISO();
+                  const d = new Date(base + 'T12:00:00');
+                  d.setDate(d.getDate() + 1);
+                  return d.toISOString().split('T')[0];
+                })()}
+                onChange={e => onFechaEntregaProgramadaChange && onFechaEntregaProgramadaChange(e.target.value)}
+                min={nuevoPedido.fecha || fechaLocalISO()}
+                className="px-3 py-1.5 border rounded-lg bg-white dark:bg-gray-700 dark:border-gray-600 dark:text-white text-sm"
+              />
+            </div>
             {nuevoPedido.fecha && nuevoPedido.fecha !== fechaLocalISO() && (
               <p className="text-xs text-amber-600 whitespace-nowrap">Fecha distinta a hoy</p>
             )}

--- a/src/components/pedidos/PedidoCard.tsx
+++ b/src/components/pedidos/PedidoCard.tsx
@@ -179,8 +179,14 @@ function PedidoCard({
                 {pedido.cliente?.nombre_fantasia || 'Sin cliente'}
               </h3>
               <p className="text-sm text-gray-500 dark:text-gray-400">{pedido.cliente?.direccion}</p>
-              <p className="text-sm text-gray-400 dark:text-gray-500 mt-1 flex items-center gap-2">
+              <p className="text-sm text-gray-400 dark:text-gray-500 mt-1 flex items-center gap-2 flex-wrap">
                 <span>#{pedido.id} - {formatFecha(pedido.fecha || pedido.created_at)}</span>
+                {pedido.fecha_entrega_programada && pedido.estado !== 'entregado' && pedido.estado !== 'cancelado' && (
+                  <span className="inline-flex items-center gap-0.5 text-xs text-orange-600 dark:text-orange-400">
+                    <Truck className="w-3 h-3" />
+                    {formatFecha(pedido.fecha_entrega_programada)}
+                  </span>
+                )}
                 <BadgeAntiguedad dias={calcularDiasAntiguedad(pedido.fecha || pedido.created_at)} estado={pedido.estado} />
               </p>
             </div>
@@ -319,23 +325,40 @@ function PedidoCard({
               Productos ({pedido.items?.length || 0})
             </h4>
             <div className="space-y-2">
-              {pedido.items?.map(item => (
-                <div key={item.id} className={`flex justify-between items-center py-2 border-b dark:border-gray-600 last:border-0 ${item.es_bonificacion ? 'bg-green-50 dark:bg-green-900/20 rounded px-2 -mx-1' : ''}`}>
+              {pedido.items?.map(item => {
+                const salvedadItem = pedido.salvedades?.find(s => String(s.producto_id) === String(item.producto_id));
+                const cantidadOriginal = salvedadItem ? item.cantidad + salvedadItem.cantidad_afectada : item.cantidad;
+                return (
+                <div key={item.id} className={`flex justify-between items-center py-2 border-b dark:border-gray-600 last:border-0 ${salvedadItem ? 'border-l-2 border-l-amber-400 pl-2 -ml-1' : ''} ${item.es_bonificacion ? 'bg-green-50 dark:bg-green-900/20 rounded px-2 -mx-1' : ''}`}>
                   <div className="flex-1">
-                    <p className="font-medium text-gray-900 dark:text-white flex items-center gap-1.5">
+                    <p className="font-medium text-gray-900 dark:text-white flex items-center gap-1.5 flex-wrap">
                       {item.es_bonificacion && <Gift className="w-4 h-4 text-green-600 flex-shrink-0" />}
                       {item.producto?.nombre || 'Producto'}
                       {item.es_bonificacion && <span className="text-xs bg-green-100 dark:bg-green-800 text-green-700 dark:text-green-300 px-1.5 py-0.5 rounded-full font-medium">REGALO</span>}
+                      {salvedadItem && (
+                        <span className="text-xs bg-amber-100 dark:bg-amber-900/40 text-amber-700 dark:text-amber-300 px-1.5 py-0.5 rounded-full font-medium">
+                          {MOTIVOS_SALVEDAD_LABELS[salvedadItem.motivo as MotivoSalvedad] || salvedadItem.motivo}
+                        </span>
+                      )}
                     </p>
                     {!item.es_bonificacion && <p className="text-xs text-gray-500">{formatPrecio(item.precio_unitario)} c/u</p>}
+                    {salvedadItem && (
+                      <p className="text-xs text-amber-600 dark:text-amber-400">
+                        Pedido: {cantidadOriginal} → Entregado: {item.cantidad} ({salvedadItem.cantidad_afectada} no entregadas)
+                      </p>
+                    )}
                   </div>
                   <div className="text-right">
                     <p className="font-semibold text-gray-700 dark:text-gray-300">x{item.cantidad}</p>
                     {!item.es_bonificacion && <p className="text-sm font-bold text-blue-600">{formatPrecio(item.subtotal || item.precio_unitario * item.cantidad)}</p>}
                     {item.es_bonificacion && <p className="text-sm font-bold text-green-600">$0</p>}
+                    {salvedadItem && (
+                      <p className="text-xs text-red-500 dark:text-red-400">-{formatPrecio(salvedadItem.monto_afectado)}</p>
+                    )}
                   </div>
                 </div>
-              ))}
+                );
+              })}
               <div className="flex justify-between items-center pt-2 border-t-2 dark:border-gray-600">
                 <p className="font-bold text-gray-900 dark:text-white">Total</p>
                 <p className="text-xl font-bold text-blue-600">{formatPrecio(pedido.total)}</p>

--- a/src/components/pedidos/PedidoFilters.tsx
+++ b/src/components/pedidos/PedidoFilters.tsx
@@ -2,7 +2,8 @@
  * Componente de filtros para la vista de pedidos
  */
 import React, { memo, ChangeEvent } from 'react';
-import { Search, Calendar, X } from 'lucide-react';
+import { Search, Calendar, X, Truck } from 'lucide-react';
+import { fechaLocalISO } from '../../utils/formatters';
 import type { Usuario, EstadoPedido, EstadoPago } from '../../types';
 
 interface FiltrosPedido {
@@ -13,6 +14,7 @@ interface FiltrosPedido {
   fechaHasta?: string | null;
   conSalvedad?: 'todos' | 'con_salvedad' | 'sin_salvedad';
   ocultarCancelados?: boolean;
+  fechaEntregaProgramada?: string | null;
 }
 
 interface FiltrosChange {
@@ -23,6 +25,7 @@ interface FiltrosChange {
   fechaHasta?: string | null;
   conSalvedad?: 'todos' | 'con_salvedad' | 'sin_salvedad';
   ocultarCancelados?: boolean;
+  fechaEntregaProgramada?: string | null;
 }
 
 export interface PedidoFiltersProps {
@@ -153,6 +156,57 @@ function PedidoFilters({
               <option value="con_salvedad">Con salvedad</option>
               <option value="sin_salvedad">Sin salvedad</option>
             </select>
+          </div>
+          <div className="flex items-center gap-1">
+            <Truck className="w-4 h-4 text-gray-500 dark:text-gray-400" />
+            {(() => {
+              const hoy = fechaLocalISO();
+              const manana = (() => { const d = new Date(hoy + 'T12:00:00'); d.setDate(d.getDate() + 1); return d.toISOString().split('T')[0]; })();
+              const activa = filtros.fechaEntregaProgramada;
+              return (
+                <>
+                  <button
+                    onClick={() => onFiltrosChange({ fechaEntregaProgramada: activa === hoy ? null : hoy })}
+                    className={`px-2 py-1 text-xs rounded-lg border transition-colors ${
+                      activa === hoy
+                        ? 'bg-orange-100 border-orange-400 text-orange-700 dark:bg-orange-900/40 dark:border-orange-600 dark:text-orange-300'
+                        : 'border-gray-300 dark:border-gray-600 text-gray-600 dark:text-gray-400 hover:bg-gray-50 dark:hover:bg-gray-700'
+                    }`}
+                  >
+                    Hoy
+                  </button>
+                  <button
+                    onClick={() => onFiltrosChange({ fechaEntregaProgramada: activa === manana ? null : manana })}
+                    className={`px-2 py-1 text-xs rounded-lg border transition-colors ${
+                      activa === manana
+                        ? 'bg-orange-100 border-orange-400 text-orange-700 dark:bg-orange-900/40 dark:border-orange-600 dark:text-orange-300'
+                        : 'border-gray-300 dark:border-gray-600 text-gray-600 dark:text-gray-400 hover:bg-gray-50 dark:hover:bg-gray-700'
+                    }`}
+                  >
+                    Mañana
+                  </button>
+                  <input
+                    type="date"
+                    value={activa || ''}
+                    onChange={(e) => onFiltrosChange({ fechaEntregaProgramada: e.target.value || null })}
+                    className={`px-2 py-1 text-xs border rounded-lg dark:bg-gray-700 dark:border-gray-600 dark:text-white ${
+                      activa && activa !== hoy && activa !== manana
+                        ? 'bg-orange-50 border-orange-300 dark:bg-orange-900/30 dark:border-orange-600'
+                        : ''
+                    }`}
+                  />
+                  {activa && (
+                    <button
+                      onClick={() => onFiltrosChange({ fechaEntregaProgramada: null })}
+                      className="text-red-500 hover:text-red-700"
+                      aria-label="Limpiar filtro de entrega"
+                    >
+                      <X className="w-3 h-3" />
+                    </button>
+                  )}
+                </>
+              );
+            })()}
           </div>
         </div>
       )}

--- a/src/hooks/queries/usePedidosQuery.ts
+++ b/src/hooks/queries/usePedidosQuery.ts
@@ -4,7 +4,7 @@
  */
 import { useQuery, useMutation, useQueryClient, keepPreviousData } from '@tanstack/react-query'
 import { supabase } from '../supabase/base'
-import type { PedidoDB, PedidoItemDB, PerfilDB, FiltrosPedidosState } from '../../types'
+import type { PedidoDB, PedidoItemDB, PerfilDB, FiltrosPedidosState, PedidoSalvedadResumen } from '../../types'
 import { productosKeys } from './useProductosQuery'
 
 // Query keys
@@ -50,6 +50,7 @@ interface CrearPedidoInput {
   tipoFactura?: 'ZZ' | 'FC'
   totalNeto?: number
   totalIva?: number
+  fechaEntregaProgramada?: string
 }
 
 interface ActualizarEstadoInput {
@@ -61,6 +62,37 @@ interface ActualizarPagoInput {
   pedidoId: string
   estadoPago: string
   montoPagado?: number | null
+}
+
+// Helper: cargar salvedades para un conjunto de pedidos
+async function enrichWithSalvedades(pedidos: Record<string, unknown>[]): Promise<Record<string, PedidoSalvedadResumen[]>> {
+  const pedidosEntregadosIds = pedidos
+    .filter(p => p.estado === 'entregado')
+    .map(p => p.id)
+
+  if (pedidosEntregadosIds.length === 0) return {}
+
+  const { data: salvedades } = await supabase
+    .from('salvedades_items')
+    .select('id, pedido_id, motivo, cantidad_afectada, monto_afectado, estado_resolucion, producto_id')
+    .in('pedido_id', pedidosEntregadosIds)
+
+  const salvedadesMap: Record<string, PedidoSalvedadResumen[]> = {}
+  if (salvedades) {
+    for (const s of salvedades) {
+      const pedidoId = String(s.pedido_id)
+      if (!salvedadesMap[pedidoId]) salvedadesMap[pedidoId] = []
+      salvedadesMap[pedidoId].push({
+        id: String(s.id),
+        motivo: s.motivo,
+        cantidad_afectada: s.cantidad_afectada,
+        monto_afectado: Number(s.monto_afectado),
+        estado_resolucion: s.estado_resolucion,
+        producto_id: String(s.producto_id),
+      })
+    }
+  }
+  return salvedadesMap
 }
 
 // Fetch functions
@@ -94,11 +126,15 @@ async function fetchPedidos(): Promise<PedidoDB[]> {
     }
   }
 
-  // Enrich pedidos with perfil data
+  // Enrich with salvedades
+  const salvedadesMap = await enrichWithSalvedades(data || [])
+
+  // Enrich pedidos with perfil data + salvedades
   const enrichedPedidos = (data || []).map(pedido => ({
     ...pedido,
     usuario: pedido.usuario_id ? perfilesMap[pedido.usuario_id] : null,
     transportista: pedido.transportista_id ? perfilesMap[pedido.transportista_id] : null,
+    salvedades: salvedadesMap[String(pedido.id)] || [],
   }))
 
   return enrichedPedidos as PedidoDB[]
@@ -185,6 +221,9 @@ async function fetchPedidosPaginated(
   if (filters?.ocultarCancelados) {
     query = query.neq('estado', 'cancelado')
   }
+  if (filters?.fechaEntregaProgramada) {
+    query = query.eq('fecha_entrega_programada', filters.fechaEntregaProgramada)
+  }
 
   // Search by client fields using referencedTable for related table filtering
   if (hasSearch) {
@@ -222,10 +261,14 @@ async function fetchPedidosPaginated(
     }
   }
 
+  // Enrich with salvedades
+  const salvedadesMap = await enrichWithSalvedades(data || [])
+
   const enrichedPedidos = (data || []).map(pedido => ({
     ...pedido,
     usuario: pedido.usuario_id ? perfilesMap[pedido.usuario_id] : null,
     transportista: pedido.transportista_id ? perfilesMap[pedido.transportista_id] : null,
+    salvedades: salvedadesMap[String(pedido.id)] || [],
   }))
 
   return { data: enrichedPedidos as PedidoDB[], totalCount: count ?? 0 }
@@ -256,7 +299,8 @@ async function crearPedido(input: CrearPedidoInput): Promise<{ id: string }> {
     ...(input.fecha ? { p_fecha: input.fecha } : {}),
     p_tipo_factura: input.tipoFactura || 'ZZ',
     p_total_neto: input.totalNeto ?? input.total,
-    p_total_iva: input.totalIva ?? 0
+    p_total_iva: input.totalIva ?? 0,
+    ...(input.fechaEntregaProgramada ? { p_fecha_entrega_programada: input.fechaEntregaProgramada } : {})
   })
 
   if (error) throw error

--- a/src/hooks/supabase/useBackup.ts
+++ b/src/hooks/supabase/useBackup.ts
@@ -24,6 +24,7 @@ interface PedidoExportacion {
   total: number;
   notas?: string | null;
   fecha_entrega?: string | null;
+  fecha_entrega_programada?: string | null;
   created_at?: string;
   items?: Array<{
     cantidad: number;
@@ -206,6 +207,7 @@ export function useBackup(): UseBackupReturnExtended {
         'Cantidad Items': p.items?.reduce((sum, i) => sum + i.cantidad, 0) || 0,
         'Total': p.total || 0,
         'Notas': p.notas || '-',
+        'Entrega Programada': p.fecha_entrega_programada ? new Date(p.fecha_entrega_programada + 'T12:00:00').toLocaleDateString('es-AR') : '-',
         'Fecha Entrega': p.fecha_entrega ? new Date(p.fecha_entrega).toLocaleDateString('es-AR') : '-'
       }))
 

--- a/src/types/hooks.ts
+++ b/src/types/hooks.ts
@@ -110,6 +110,7 @@ export interface PedidoDB {
   stock_descontado?: boolean;
   fecha?: string;
   fecha_entrega?: string | null;
+  fecha_entrega_programada?: string | null;
   created_at?: string;
   updated_at?: string;
   deleted_at?: string | null;
@@ -267,6 +268,7 @@ export interface FiltrosPedidosState {
   busqueda: string;
   conSalvedad: 'todos' | 'con_salvedad' | 'sin_salvedad';
   ocultarCancelados?: boolean;
+  fechaEntregaProgramada?: string | null;
 }
 
 // =============================================================================

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -124,6 +124,7 @@ export interface Pedido extends BaseEntity {
   monto_pagado: number;
   notas?: string;
   fecha_entrega?: string;
+  fecha_entrega_programada?: string;
   orden_entrega?: number;
   items?: PedidoItem[];
 }


### PR DESCRIPTION
- Cargar salvedades en query paginada (usePedidosQuery) para que PedidoCard muestre datos reales de salvedades
- PedidoCard: badge de motivo y cantidad afectada inline en cada item con salvedad, mostrando cantidad original vs entregada
- Migración 049: nueva columna fecha_entrega_programada con backfill, índice parcial, y RPC crear_pedido_completo actualizada (12 params)
- ModalPedido: date picker de entrega programada (default: día siguiente)
- PedidoCard: muestra fecha programada con ícono de camión
- PedidoFilters: filtro por fecha de entrega (hoy/mañana/fecha custom)
- useBackup: incluye fecha programada en exportación Excel