### PR TITLE
fix: modal export button hidden on smaller screens

### DIFF
--- a/src/components/modals/ModalExportarPDF.tsx
+++ b/src/components/modals/ModalExportarPDF.tsx
@@ -357,7 +357,7 @@ const ModalExportarPDF = memo(function ModalExportarPDF({
         </div>
       </div>
 
-      <div className="flex justify-between items-center p-4 border-t bg-gray-50">
+      <div className="flex justify-between items-center p-4 border-t bg-gray-50 dark:bg-gray-800 sticky bottom-0">
         <p className="text-sm text-gray-600">
           {pedidosSeleccionados.length > 0 && (
             <>

--- a/src/components/ui/Dialog.tsx
+++ b/src/components/ui/Dialog.tsx
@@ -84,7 +84,7 @@ const DialogContent = React.forwardRef<
     <DialogPrimitive.Content
       ref={ref}
       className={cn(
-        'fixed left-[50%] top-[50%] z-50 grid w-full max-w-md translate-x-[-50%] translate-y-[-50%] gap-0 bg-white dark:bg-gray-800 shadow-xl rounded-xl max-h-[90vh] overflow-hidden',
+        'fixed left-[50%] top-[50%] z-50 flex flex-col w-full max-w-md translate-x-[-50%] translate-y-[-50%] bg-white dark:bg-gray-800 shadow-xl rounded-xl max-h-[90vh] overflow-hidden',
         'data-[state=open]:animate-scale-in data-[state=closed]:animate-fade-out',
         'focus:outline-none',
         className


### PR DESCRIPTION
## Summary
- **Bug:** The "Exportar PDF" button in the export modal was invisible on smaller screens (iPhones, smaller Macs) because `DialogContent` used CSS `grid` layout while `DialogBody` relied on `flex-1` (a flexbox property) — in grid context `flex-1` has no effect, so the footer was clipped by `overflow-hidden`
- **Fix:** Switch `DialogContent` from `grid` to `flex flex-col` so `DialogBody` properly fills remaining space and scrolls. Added `sticky bottom-0` to the export modal footer so the button is always visible
- **Impact:** Fixes all modals with long content, not just the PDF export modal

## Test plan
- [ ] Open "Exportar Pedidos a PDF" modal on a mobile device (iPhone) and verify the "Exportar PDF" button is visible
- [ ] Open the same modal on a small laptop screen and verify the button is visible
- [ ] Select "Hoja de Ruta", pick a transportista with many orders, verify footer stays sticky
- [ ] Test other modals (Editar Pedido, Nuevo Pedido, Gestión de Rutas) to confirm no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)