### PR TITLE
fix: corregir 12 bugs críticos/altos/medios + migración 056

### DIFF
--- a/migrations/056_fix_all_bugs.sql
+++ b/migrations/056_fix_all_bugs.sql
@@ -1,0 +1,671 @@
+-- Migration 056: Fix all bugs from comprehensive audit
+--
+-- Fixes:
+--   1. DROP orphaned actualizar_pedido_items 6-param overload (causes PostgREST ambiguity error)
+--   2. Add auth.uid() validation to all SECURITY DEFINER RPCs (SEC-2)
+--   3. Create anular_compra_atomica RPC (BUG-1: non-atomic stock reversal)
+
+-- ============================================================
+-- 1. CRITICAL: Drop orphaned 6-param overload from migration 046
+--    Migration 053 recreated the 3-param version but never dropped the 6-param.
+--    PostgREST cannot resolve which function to call.
+-- ============================================================
+DROP FUNCTION IF EXISTS public.actualizar_pedido_items(bigint, jsonb, uuid, text, numeric, numeric);
+
+-- ============================================================
+-- 2. Fix actualizar_pedido_items (3-param) - add auth.uid() check
+-- ============================================================
+DROP FUNCTION IF EXISTS public.actualizar_pedido_items(bigint, jsonb, uuid);
+
+CREATE FUNCTION public.actualizar_pedido_items(
+  p_pedido_id bigint,
+  p_items_nuevos jsonb,
+  p_usuario_id uuid
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_item_nuevo JSONB;
+  v_producto_id INT;
+  v_cantidad_original INT;
+  v_cantidad_nueva INT;
+  v_diferencia INT;
+  v_es_bonificacion BOOLEAN;
+  v_stock_actual INT;
+  v_producto_nombre TEXT;
+  v_total_nuevo DECIMAL := 0;
+  v_total_neto_nuevo DECIMAL := 0;
+  v_total_iva_nuevo DECIMAL := 0;
+  v_total_anterior DECIMAL;
+  v_errores TEXT[] := '{}';
+  v_items_originales JSONB;
+  v_user_role TEXT;
+  v_neto_unitario DECIMAL;
+  v_iva_unitario DECIMAL;
+  v_imp_internos_unitario DECIMAL;
+  v_porcentaje_iva DECIMAL;
+  v_precio_unitario DECIMAL;
+  v_promocion_id BIGINT;
+BEGIN
+  -- Auth check: verify p_usuario_id matches the authenticated user
+  IF p_usuario_id IS DISTINCT FROM auth.uid() THEN
+    RETURN jsonb_build_object('success', false, 'errores', ARRAY['ID de usuario no coincide con la sesión autenticada']);
+  END IF;
+
+  SELECT rol INTO v_user_role FROM perfiles WHERE id = p_usuario_id;
+  IF v_user_role IS NULL OR v_user_role NOT IN ('admin', 'preventista') THEN
+    RETURN jsonb_build_object('success', false, 'errores', ARRAY['No autorizado']);
+  END IF;
+
+  SELECT total INTO v_total_anterior FROM pedidos WHERE id = p_pedido_id;
+  IF NOT FOUND THEN
+    RETURN jsonb_build_object('success', false, 'errores', ARRAY['Pedido no encontrado']);
+  END IF;
+
+  IF EXISTS (SELECT 1 FROM pedidos WHERE id = p_pedido_id AND estado = 'entregado') THEN
+    RETURN jsonb_build_object('success', false, 'errores', ARRAY['No se puede editar un pedido ya entregado']);
+  END IF;
+
+  -- Save original items for historial
+  SELECT jsonb_agg(jsonb_build_object(
+    'producto_id', producto_id, 'cantidad', cantidad,
+    'precio_unitario', precio_unitario, 'es_bonificacion', COALESCE(es_bonificacion, false)))
+  INTO v_items_originales FROM pedido_items WHERE pedido_id = p_pedido_id;
+
+  -- Phase 1: Validate stock for new non-bonificacion items that need MORE stock
+  FOR v_item_nuevo IN SELECT * FROM jsonb_array_elements(p_items_nuevos) LOOP
+    v_producto_id := (v_item_nuevo->>'producto_id')::INT;
+    v_cantidad_nueva := (v_item_nuevo->>'cantidad')::INT;
+    v_es_bonificacion := COALESCE((v_item_nuevo->>'es_bonificacion')::BOOLEAN, false);
+
+    IF v_es_bonificacion THEN CONTINUE; END IF;
+
+    SELECT COALESCE(cantidad, 0) INTO v_cantidad_original
+    FROM pedido_items
+    WHERE pedido_id = p_pedido_id AND producto_id = v_producto_id
+      AND COALESCE(es_bonificacion, false) = false;
+
+    v_diferencia := v_cantidad_nueva - COALESCE(v_cantidad_original, 0);
+
+    IF v_diferencia > 0 THEN
+      SELECT stock, nombre INTO v_stock_actual, v_producto_nombre
+      FROM productos WHERE id = v_producto_id FOR UPDATE;
+
+      IF v_stock_actual IS NULL THEN
+        v_errores := array_append(v_errores, 'Producto ID ' || v_producto_id || ' no encontrado');
+      ELSIF v_stock_actual < v_diferencia THEN
+        v_errores := array_append(v_errores, COALESCE(v_producto_nombre, 'Producto ' || v_producto_id)
+          || ': stock insuficiente (disponible: ' || v_stock_actual || ', adicional: ' || v_diferencia || ')');
+      END IF;
+    END IF;
+  END LOOP;
+
+  IF array_length(v_errores, 1) > 0 THEN
+    RETURN jsonb_build_object('success', false, 'errores', to_jsonb(v_errores));
+  END IF;
+
+  -- Phase 2: Restore stock for original NON-bonificacion items only
+  UPDATE productos p
+  SET stock = p.stock + pi.cantidad
+  FROM pedido_items pi
+  WHERE pi.pedido_id = p_pedido_id
+    AND COALESCE(pi.es_bonificacion, false) = false
+    AND p.id = pi.producto_id;
+
+  -- Restore promo usos for original bonificacion items
+  UPDATE promociones pr
+  SET usos_pendientes = GREATEST(pr.usos_pendientes - pi.cantidad, 0)
+  FROM pedido_items pi
+  WHERE pi.pedido_id = p_pedido_id
+    AND COALESCE(pi.es_bonificacion, false) = true
+    AND pi.promocion_id IS NOT NULL
+    AND pr.id = pi.promocion_id;
+
+  -- Phase 3: Delete old items and insert new ones
+  DELETE FROM pedido_items WHERE pedido_id = p_pedido_id;
+
+  FOR v_item_nuevo IN SELECT * FROM jsonb_array_elements(p_items_nuevos) LOOP
+    v_producto_id := (v_item_nuevo->>'producto_id')::INT;
+    v_cantidad_nueva := (v_item_nuevo->>'cantidad')::INT;
+    v_precio_unitario := (v_item_nuevo->>'precio_unitario')::DECIMAL;
+    v_es_bonificacion := COALESCE((v_item_nuevo->>'es_bonificacion')::BOOLEAN, false);
+    v_promocion_id := (v_item_nuevo->>'promocion_id')::BIGINT;
+    v_neto_unitario := (v_item_nuevo->>'neto_unitario')::DECIMAL;
+    v_iva_unitario := COALESCE((v_item_nuevo->>'iva_unitario')::DECIMAL, 0);
+    v_imp_internos_unitario := COALESCE((v_item_nuevo->>'impuestos_internos_unitario')::DECIMAL, 0);
+    v_porcentaje_iva := COALESCE((v_item_nuevo->>'porcentaje_iva')::DECIMAL, 0);
+
+    INSERT INTO pedido_items (
+      pedido_id, producto_id, cantidad, precio_unitario, subtotal,
+      es_bonificacion, promocion_id,
+      neto_unitario, iva_unitario, impuestos_internos_unitario, porcentaje_iva
+    ) VALUES (
+      p_pedido_id, v_producto_id, v_cantidad_nueva, v_precio_unitario,
+      v_cantidad_nueva * v_precio_unitario,
+      v_es_bonificacion, v_promocion_id,
+      v_neto_unitario, v_iva_unitario, v_imp_internos_unitario, v_porcentaje_iva
+    );
+
+    -- Deduct stock only for non-bonificacion items
+    IF NOT v_es_bonificacion THEN
+      UPDATE productos SET stock = stock - v_cantidad_nueva WHERE id = v_producto_id;
+      v_total_nuevo := v_total_nuevo + (v_cantidad_nueva * v_precio_unitario);
+      v_total_neto_nuevo := v_total_neto_nuevo + (v_cantidad_nueva * COALESCE(v_neto_unitario, v_precio_unitario));
+      v_total_iva_nuevo := v_total_iva_nuevo + (v_cantidad_nueva * v_iva_unitario);
+    END IF;
+
+    -- Track promo usage for bonificaciones
+    IF v_es_bonificacion AND v_promocion_id IS NOT NULL THEN
+      UPDATE promociones SET usos_pendientes = usos_pendientes + v_cantidad_nueva
+      WHERE id = v_promocion_id;
+    END IF;
+  END LOOP;
+
+  -- Phase 4: Update pedido totals including fiscal fields
+  UPDATE pedidos SET
+    total = v_total_nuevo,
+    total_neto = v_total_neto_nuevo,
+    total_iva = v_total_iva_nuevo,
+    updated_at = NOW()
+  WHERE id = p_pedido_id;
+
+  -- Phase 5: Record historial
+  INSERT INTO pedido_historial (pedido_id, usuario_id, campo_modificado, valor_anterior, valor_nuevo)
+  VALUES (p_pedido_id, p_usuario_id, 'items', COALESCE(v_items_originales::TEXT, '[]'), p_items_nuevos::TEXT);
+
+  IF v_total_anterior IS DISTINCT FROM v_total_nuevo THEN
+    INSERT INTO pedido_historial (pedido_id, usuario_id, campo_modificado, valor_anterior, valor_nuevo)
+    VALUES (p_pedido_id, p_usuario_id, 'total', v_total_anterior::TEXT, v_total_nuevo::TEXT);
+  END IF;
+
+  RETURN jsonb_build_object('success', true, 'total_nuevo', v_total_nuevo);
+END;
+$$;
+
+-- ============================================================
+-- 3. Fix crear_pedido_completo - add auth.uid() validation
+-- ============================================================
+DROP FUNCTION IF EXISTS public.crear_pedido_completo(bigint, numeric, uuid, jsonb, text, text, text, date, text, numeric, numeric, date);
+
+CREATE OR REPLACE FUNCTION public.crear_pedido_completo(
+  p_cliente_id bigint,
+  p_total numeric,
+  p_usuario_id uuid,
+  p_items jsonb,
+  p_notas text DEFAULT NULL::text,
+  p_forma_pago text DEFAULT 'efectivo'::text,
+  p_estado_pago text DEFAULT 'pendiente'::text,
+  p_fecha date DEFAULT CURRENT_DATE,
+  p_tipo_factura text DEFAULT 'ZZ',
+  p_total_neto numeric DEFAULT NULL,
+  p_total_iva numeric DEFAULT 0,
+  p_fecha_entrega_programada date DEFAULT NULL
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $function$
+DECLARE
+  v_pedido_id INT;
+  item JSONB;
+  v_producto_id INT;
+  v_cantidad INT;
+  v_precio_unitario DECIMAL;
+  v_es_bonificacion BOOLEAN;
+  v_promocion_id BIGINT;
+  v_neto_unitario DECIMAL;
+  v_iva_unitario DECIMAL;
+  v_imp_internos_unitario DECIMAL;
+  v_porcentaje_iva DECIMAL;
+  v_stock_actual INT;
+  v_producto_nombre TEXT;
+  errores TEXT[] := '{}';
+  v_user_role TEXT;
+  v_cantidades_totales JSONB := '{}'::JSONB;
+  v_cant_acumulada INT;
+  v_fecha_entrega DATE;
+BEGIN
+  -- Auth check: verify p_usuario_id matches the authenticated user
+  IF p_usuario_id IS DISTINCT FROM auth.uid() THEN
+    RETURN jsonb_build_object('success', false, 'errores', jsonb_build_array('ID de usuario no coincide con la sesión autenticada'));
+  END IF;
+
+  SELECT rol INTO v_user_role FROM perfiles WHERE id = p_usuario_id;
+  IF v_user_role IS NULL OR v_user_role NOT IN ('admin', 'preventista') THEN
+    RETURN jsonb_build_object('success', false, 'errores', jsonb_build_array('No tiene permisos para crear pedidos'));
+  END IF;
+
+  -- 1. Acumular cantidades totales por producto (SOLO items no bonificados)
+  FOR item IN SELECT * FROM jsonb_array_elements(p_items)
+  LOOP
+    v_producto_id := (item->>'producto_id')::INT;
+    v_cantidad := (item->>'cantidad')::INT;
+    v_es_bonificacion := COALESCE((item->>'es_bonificacion')::BOOLEAN, false);
+
+    IF v_cantidad IS NULL OR v_cantidad <= 0 THEN
+      errores := array_append(errores, 'Cantidad inválida para producto ID ' || v_producto_id || ': debe ser mayor a 0');
+      CONTINUE;
+    END IF;
+
+    IF NOT v_es_bonificacion THEN
+      v_cant_acumulada := COALESCE((v_cantidades_totales->>v_producto_id::TEXT)::INT, 0) + v_cantidad;
+      v_cantidades_totales := v_cantidades_totales || jsonb_build_object(v_producto_id::TEXT, v_cant_acumulada);
+    END IF;
+  END LOOP;
+
+  -- 2. Verificar stock usando cantidades acumuladas (con bloqueo)
+  FOR v_producto_id IN SELECT (key)::INT FROM jsonb_each_text(v_cantidades_totales)
+  LOOP
+    v_cantidad := (v_cantidades_totales->>v_producto_id::TEXT)::INT;
+
+    SELECT stock, nombre INTO v_stock_actual, v_producto_nombre
+    FROM productos
+    WHERE id = v_producto_id
+    FOR UPDATE;
+
+    IF v_stock_actual IS NULL THEN
+      errores := array_append(errores, 'Producto ID ' || v_producto_id || ' no encontrado');
+    ELSIF v_stock_actual < v_cantidad THEN
+      errores := array_append(errores, v_producto_nombre || ': stock insuficiente (disponible: ' || v_stock_actual || ', solicitado: ' || v_cantidad || ')');
+    END IF;
+  END LOOP;
+
+  IF array_length(errores, 1) > 0 THEN
+    RETURN jsonb_build_object('success', false, 'errores', to_jsonb(errores));
+  END IF;
+
+  -- Calcular fecha de entrega programada (default: día siguiente a la fecha del pedido)
+  v_fecha_entrega := COALESCE(p_fecha_entrega_programada, (COALESCE(p_fecha, CURRENT_DATE) + INTERVAL '1 day')::date);
+
+  -- 3. Crear el pedido con tipo_factura, desglose y fecha_entrega_programada
+  INSERT INTO pedidos (
+    cliente_id, fecha, total, total_neto, total_iva, tipo_factura,
+    estado, usuario_id, stock_descontado, notas, forma_pago, estado_pago,
+    fecha_entrega_programada
+  )
+  VALUES (
+    p_cliente_id, p_fecha, p_total,
+    COALESCE(p_total_neto, p_total),
+    COALESCE(p_total_iva, 0),
+    COALESCE(p_tipo_factura, 'ZZ'),
+    'pendiente', p_usuario_id, true, p_notas, p_forma_pago, p_estado_pago,
+    v_fecha_entrega
+  )
+  RETURNING id INTO v_pedido_id;
+
+  -- 4. Crear items y descontar stock
+  FOR item IN SELECT * FROM jsonb_array_elements(p_items)
+  LOOP
+    v_producto_id := (item->>'producto_id')::INT;
+    v_cantidad := (item->>'cantidad')::INT;
+    v_precio_unitario := (item->>'precio_unitario')::DECIMAL;
+    v_es_bonificacion := COALESCE((item->>'es_bonificacion')::BOOLEAN, false);
+    v_promocion_id := (item->>'promocion_id')::BIGINT;
+    v_neto_unitario := (item->>'neto_unitario')::DECIMAL;
+    v_iva_unitario := COALESCE((item->>'iva_unitario')::DECIMAL, 0);
+    v_imp_internos_unitario := COALESCE((item->>'impuestos_internos_unitario')::DECIMAL, 0);
+    v_porcentaje_iva := COALESCE((item->>'porcentaje_iva')::DECIMAL, 0);
+
+    INSERT INTO pedido_items (
+      pedido_id, producto_id, cantidad, precio_unitario, subtotal,
+      es_bonificacion, promocion_id,
+      neto_unitario, iva_unitario, impuestos_internos_unitario, porcentaje_iva
+    )
+    VALUES (
+      v_pedido_id, v_producto_id, v_cantidad, v_precio_unitario,
+      v_cantidad * v_precio_unitario,
+      v_es_bonificacion, v_promocion_id,
+      v_neto_unitario, v_iva_unitario, v_imp_internos_unitario, v_porcentaje_iva
+    );
+
+    -- Stock: solo descontar si NO es bonificación
+    IF NOT v_es_bonificacion THEN
+      UPDATE productos SET stock = stock - v_cantidad WHERE id = v_producto_id;
+    END IF;
+
+    -- Contador de promos
+    IF v_es_bonificacion AND v_promocion_id IS NOT NULL THEN
+      UPDATE promociones SET usos_pendientes = usos_pendientes + v_cantidad
+      WHERE id = v_promocion_id;
+    END IF;
+  END LOOP;
+
+  RETURN jsonb_build_object('success', true, 'pedido_id', v_pedido_id);
+END;
+$function$;
+
+-- ============================================================
+-- 4. Fix eliminar_pedido_completo - add auth.uid() validation
+-- ============================================================
+DROP FUNCTION IF EXISTS public.eliminar_pedido_completo(bigint, uuid, text, boolean);
+
+CREATE FUNCTION public.eliminar_pedido_completo(
+  p_pedido_id bigint,
+  p_usuario_id uuid,
+  p_motivo text DEFAULT NULL::text,
+  p_restaurar_stock boolean DEFAULT true
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_pedido RECORD; v_items JSONB; v_cliente_nombre TEXT; v_cliente_direccion TEXT;
+  v_usuario_creador_nombre TEXT; v_transportista_nombre TEXT := NULL;
+  v_eliminador_nombre TEXT := NULL; v_item RECORD;
+  v_user_role TEXT;
+BEGIN
+  -- Auth check: verify p_usuario_id matches the authenticated user
+  IF p_usuario_id IS DISTINCT FROM auth.uid() THEN
+    RETURN jsonb_build_object('success', false, 'error', 'ID de usuario no coincide con la sesión autenticada');
+  END IF;
+
+  -- Only admin can delete orders
+  SELECT rol INTO v_user_role FROM perfiles WHERE id = p_usuario_id;
+  IF v_user_role IS NULL OR v_user_role != 'admin' THEN
+    RETURN jsonb_build_object('success', false, 'error', 'No autorizado: solo administradores pueden eliminar pedidos');
+  END IF;
+
+  SELECT * INTO v_pedido FROM pedidos WHERE id = p_pedido_id;
+  IF NOT FOUND THEN RETURN jsonb_build_object('success', false, 'error', 'Pedido no encontrado'); END IF;
+
+  SELECT jsonb_agg(jsonb_build_object(
+    'producto_id', pi.producto_id, 'producto_nombre', pr.nombre,
+    'producto_codigo', pr.codigo, 'cantidad', pi.cantidad,
+    'precio_unitario', pi.precio_unitario, 'subtotal', pi.subtotal))
+  INTO v_items FROM pedido_items pi LEFT JOIN productos pr ON pr.id = pi.producto_id WHERE pi.pedido_id = p_pedido_id;
+
+  SELECT nombre_fantasia, direccion INTO v_cliente_nombre, v_cliente_direccion FROM clientes WHERE id = v_pedido.cliente_id;
+  SELECT nombre INTO v_usuario_creador_nombre FROM perfiles WHERE id = v_pedido.usuario_id;
+  IF v_pedido.transportista_id IS NOT NULL THEN SELECT nombre INTO v_transportista_nombre FROM perfiles WHERE id = v_pedido.transportista_id; END IF;
+  IF p_usuario_id IS NOT NULL THEN SELECT nombre INTO v_eliminador_nombre FROM perfiles WHERE id = p_usuario_id; END IF;
+
+  INSERT INTO pedidos_eliminados (
+    pedido_id, cliente_id, cliente_nombre, cliente_direccion, total, estado,
+    estado_pago, forma_pago, monto_pagado, notas, items,
+    usuario_creador_id, usuario_creador_nombre, transportista_id, transportista_nombre,
+    fecha_pedido, fecha_entrega, eliminado_por_id, eliminado_por_nombre,
+    motivo_eliminacion, stock_restaurado)
+  VALUES (
+    p_pedido_id, v_pedido.cliente_id, v_cliente_nombre, v_cliente_direccion,
+    v_pedido.total, v_pedido.estado, v_pedido.estado_pago, v_pedido.forma_pago,
+    v_pedido.monto_pagado, v_pedido.notas, COALESCE(v_items, '[]'::jsonb),
+    v_pedido.usuario_id, v_usuario_creador_nombre, v_pedido.transportista_id,
+    v_transportista_nombre, v_pedido.created_at, v_pedido.fecha_entrega,
+    p_usuario_id, v_eliminador_nombre, p_motivo, p_restaurar_stock);
+
+  IF p_restaurar_stock THEN
+    FOR v_item IN SELECT producto_id, cantidad, COALESCE(es_bonificacion, false) as es_bonificacion
+    FROM pedido_items WHERE pedido_id = p_pedido_id LOOP
+      IF NOT v_item.es_bonificacion THEN
+        UPDATE productos SET stock = stock + v_item.cantidad WHERE id = v_item.producto_id;
+      END IF;
+    END LOOP;
+  END IF;
+
+  DELETE FROM pedido_items WHERE pedido_id = p_pedido_id;
+  DELETE FROM pedido_historial WHERE pedido_id = p_pedido_id;
+  DELETE FROM pedidos WHERE id = p_pedido_id;
+
+  RETURN jsonb_build_object('success', true, 'mensaje', 'Pedido eliminado y registrado correctamente');
+END;
+$$;
+
+-- ============================================================
+-- 5. Fix cancelar_pedido_con_stock - add auth.uid() validation
+-- ============================================================
+CREATE OR REPLACE FUNCTION public.cancelar_pedido_con_stock(
+  p_pedido_id bigint,
+  p_motivo text,
+  p_usuario_id uuid DEFAULT NULL::uuid
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_pedido RECORD;
+  v_item RECORD;
+  v_total_original DECIMAL;
+  v_user_role TEXT;
+  v_acting_user uuid;
+BEGIN
+  -- Use auth.uid() as primary, p_usuario_id only if it matches
+  v_acting_user := auth.uid();
+  IF p_usuario_id IS NOT NULL AND p_usuario_id IS DISTINCT FROM v_acting_user THEN
+    RETURN jsonb_build_object('success', false, 'error', 'ID de usuario no coincide con la sesión autenticada');
+  END IF;
+
+  -- Auth check: only admin or encargado can cancel
+  SELECT rol INTO v_user_role FROM perfiles WHERE id = v_acting_user;
+  IF v_user_role IS NULL OR v_user_role NOT IN ('admin', 'encargado') THEN
+    RETURN jsonb_build_object('success', false, 'error', 'No autorizado: solo admin o encargado pueden cancelar pedidos');
+  END IF;
+
+  SELECT * INTO v_pedido FROM pedidos WHERE id = p_pedido_id FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RETURN jsonb_build_object('success', false, 'error', 'Pedido no encontrado');
+  END IF;
+
+  IF v_pedido.estado = 'cancelado' THEN
+    RETURN jsonb_build_object('success', false, 'error', 'El pedido ya esta cancelado');
+  END IF;
+
+  IF v_pedido.estado = 'entregado' THEN
+    RETURN jsonb_build_object('success', false, 'error', 'No se puede cancelar un pedido entregado');
+  END IF;
+
+  v_total_original := v_pedido.total;
+
+  FOR v_item IN
+    SELECT producto_id, cantidad, COALESCE(es_bonificacion, false) as es_bonificacion, promocion_id
+    FROM pedido_items WHERE pedido_id = p_pedido_id
+  LOOP
+    IF v_item.es_bonificacion THEN
+      IF v_item.promocion_id IS NOT NULL THEN
+        UPDATE promociones
+        SET usos_pendientes = GREATEST(usos_pendientes - v_item.cantidad, 0)
+        WHERE id = v_item.promocion_id;
+      END IF;
+    ELSE
+      UPDATE productos SET stock = stock + v_item.cantidad WHERE id = v_item.producto_id;
+    END IF;
+  END LOOP;
+
+  UPDATE pedidos
+  SET estado = 'cancelado',
+      motivo_cancelacion = p_motivo,
+      total = 0,
+      monto_pagado = 0,
+      total_neto = 0,
+      total_iva = 0,
+      updated_at = NOW()
+  WHERE id = p_pedido_id;
+
+  INSERT INTO pedido_historial (pedido_id, usuario_id, campo_modificado, valor_anterior, valor_nuevo)
+  VALUES (
+    p_pedido_id,
+    v_acting_user,
+    'estado',
+    v_pedido.estado,
+    'cancelado - Motivo: ' || COALESCE(p_motivo, 'Sin motivo') || ' | Total original: $' || v_total_original
+  );
+
+  RETURN jsonb_build_object(
+    'success', true,
+    'mensaje', 'Pedido cancelado, stock restaurado, saldo ajustado',
+    'total_original', v_total_original
+  );
+END;
+$$;
+
+-- ============================================================
+-- 6. Fix registrar_compra_completa - add auth.uid() validation
+-- ============================================================
+DROP FUNCTION IF EXISTS public.registrar_compra_completa(bigint, character varying, character varying, date, numeric, numeric, numeric, numeric, character varying, text, uuid, jsonb);
+
+CREATE FUNCTION public.registrar_compra_completa(
+  p_proveedor_id bigint,
+  p_proveedor_nombre character varying,
+  p_numero_factura character varying,
+  p_fecha_compra date,
+  p_subtotal numeric,
+  p_iva numeric,
+  p_otros_impuestos numeric,
+  p_total numeric,
+  p_forma_pago character varying,
+  p_notas text,
+  p_usuario_id uuid,
+  p_items jsonb
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_compra_id BIGINT; v_item JSONB; v_producto RECORD; v_stock_anterior INTEGER; v_stock_nuevo INTEGER;
+  v_items_procesados JSONB := '[]'::JSONB; v_costo_neto DECIMAL; v_costo_con_iva DECIMAL;
+  v_porcentaje_iva DECIMAL; v_impuestos_internos DECIMAL; v_bonificacion DECIMAL;
+  v_user_role TEXT;
+BEGIN
+  -- Auth check: verify p_usuario_id matches the authenticated user
+  IF p_usuario_id IS DISTINCT FROM auth.uid() THEN
+    RETURN jsonb_build_object('success', false, 'error', 'ID de usuario no coincide con la sesión autenticada');
+  END IF;
+
+  SELECT rol INTO v_user_role FROM perfiles WHERE id = p_usuario_id;
+  IF v_user_role IS NULL OR v_user_role NOT IN ('admin', 'encargado') THEN
+    RETURN jsonb_build_object('success', false, 'error', 'No autorizado: solo admin o encargado pueden registrar compras');
+  END IF;
+
+  INSERT INTO compras (proveedor_id, proveedor_nombre, numero_factura, fecha_compra, subtotal, iva, otros_impuestos, total, forma_pago, notas, usuario_id, estado)
+  VALUES (p_proveedor_id, p_proveedor_nombre, p_numero_factura, p_fecha_compra, p_subtotal, p_iva, p_otros_impuestos, p_total, p_forma_pago, p_notas, p_usuario_id, 'recibida')
+  RETURNING id INTO v_compra_id;
+
+  FOR v_item IN SELECT * FROM jsonb_array_elements(p_items) LOOP
+    SELECT id, stock INTO v_producto FROM productos WHERE id = (v_item->>'producto_id')::BIGINT FOR UPDATE;
+    IF NOT FOUND THEN RAISE EXCEPTION 'Producto no encontrado: %', v_item->>'producto_id'; END IF;
+
+    v_stock_anterior := COALESCE(v_producto.stock, 0);
+    v_stock_nuevo := v_stock_anterior + (v_item->>'cantidad')::INTEGER;
+    v_bonificacion := COALESCE((v_item->>'bonificacion')::DECIMAL, 0);
+    v_porcentaje_iva := COALESCE((v_item->>'porcentaje_iva')::DECIMAL, 21);
+    v_impuestos_internos := COALESCE((v_item->>'impuestos_internos')::DECIMAL, 0);
+
+    INSERT INTO compra_items (compra_id, producto_id, cantidad, costo_unitario, subtotal, stock_anterior, stock_nuevo, bonificacion)
+    VALUES (v_compra_id, (v_item->>'producto_id')::BIGINT, (v_item->>'cantidad')::INTEGER,
+            COALESCE((v_item->>'costo_unitario')::DECIMAL, 0),
+            COALESCE((v_item->>'subtotal')::DECIMAL, 0),
+            v_stock_anterior, v_stock_nuevo, v_bonificacion);
+
+    v_costo_neto := COALESCE((v_item->>'costo_unitario')::DECIMAL, 0) * (1 - v_bonificacion / 100);
+    v_costo_con_iva := v_costo_neto * (1 + v_porcentaje_iva / 100);
+
+    UPDATE productos SET
+      stock = stock + (v_item->>'cantidad')::INTEGER,
+      costo_sin_iva = v_costo_neto,
+      costo_con_iva = v_costo_con_iva,
+      impuestos_internos = v_impuestos_internos,
+      porcentaje_iva = v_porcentaje_iva,
+      updated_at = NOW()
+    WHERE id = (v_item->>'producto_id')::BIGINT;
+
+    v_items_procesados := v_items_procesados || jsonb_build_object(
+      'producto_id', (v_item->>'producto_id')::BIGINT,
+      'cantidad', (v_item->>'cantidad')::INTEGER,
+      'stock_anterior', v_stock_anterior,
+      'stock_nuevo', v_stock_nuevo,
+      'costo_sin_iva', v_costo_neto,
+      'costo_con_iva', v_costo_con_iva);
+  END LOOP;
+
+  RETURN jsonb_build_object('success', true, 'compra_id', v_compra_id, 'items_procesados', v_items_procesados);
+EXCEPTION WHEN OTHERS THEN
+  RETURN jsonb_build_object('success', false, 'error', SQLERRM);
+END;
+$$;
+
+-- ============================================================
+-- 7. NEW: anular_compra_atomica RPC (BUG-1)
+--    Replaces non-atomic client-side stock reversal in useCompras.ts
+-- ============================================================
+CREATE OR REPLACE FUNCTION public.anular_compra_atomica(
+  p_compra_id bigint,
+  p_usuario_id uuid
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_compra RECORD;
+  v_item RECORD;
+  v_stock_actual INT;
+  v_producto_nombre TEXT;
+  v_user_role TEXT;
+  v_errores TEXT[] := '{}';
+BEGIN
+  -- Auth check: verify p_usuario_id matches the authenticated user
+  IF p_usuario_id IS DISTINCT FROM auth.uid() THEN
+    RETURN jsonb_build_object('success', false, 'error', 'ID de usuario no coincide con la sesión autenticada');
+  END IF;
+
+  SELECT rol INTO v_user_role FROM perfiles WHERE id = p_usuario_id;
+  IF v_user_role IS NULL OR v_user_role NOT IN ('admin', 'encargado') THEN
+    RETURN jsonb_build_object('success', false, 'error', 'No autorizado: solo admin o encargado pueden anular compras');
+  END IF;
+
+  SELECT * INTO v_compra FROM compras WHERE id = p_compra_id;
+  IF NOT FOUND THEN
+    RETURN jsonb_build_object('success', false, 'error', 'Compra no encontrada');
+  END IF;
+
+  IF v_compra.estado = 'cancelada' THEN
+    RETURN jsonb_build_object('success', false, 'error', 'La compra ya está cancelada');
+  END IF;
+
+  -- Validate stock availability before reverting (prevent negative stock)
+  FOR v_item IN
+    SELECT ci.producto_id, ci.cantidad, p.stock, p.nombre
+    FROM compra_items ci
+    JOIN productos p ON p.id = ci.producto_id
+    WHERE ci.compra_id = p_compra_id
+    FOR UPDATE OF p  -- Lock product rows
+  LOOP
+    IF v_item.stock < v_item.cantidad THEN
+      v_errores := array_append(v_errores,
+        COALESCE(v_item.nombre, 'Producto ' || v_item.producto_id)
+        || ': stock insuficiente para revertir (actual: ' || v_item.stock || ', necesario: ' || v_item.cantidad || ')');
+    END IF;
+  END LOOP;
+
+  IF array_length(v_errores, 1) > 0 THEN
+    RETURN jsonb_build_object('success', false, 'error', 'No se puede anular: ' || array_to_string(v_errores, '; '));
+  END IF;
+
+  -- Revert stock atomically
+  UPDATE productos p
+  SET stock = p.stock - ci.cantidad,
+      updated_at = NOW()
+  FROM compra_items ci
+  WHERE ci.compra_id = p_compra_id
+    AND p.id = ci.producto_id;
+
+  -- Mark compra as cancelled
+  UPDATE compras
+  SET estado = 'cancelada',
+      updated_at = NOW()
+  WHERE id = p_compra_id;
+
+  RETURN jsonb_build_object('success', true, 'mensaje', 'Compra anulada y stock revertido correctamente');
+END;
+$$;

--- a/src/components/modals/ModalEditarPedido.tsx
+++ b/src/components/modals/ModalEditarPedido.tsx
@@ -5,6 +5,7 @@ import { formatPrecio } from '../../utils/formatters';
 import { useZodValidation } from '../../hooks/useZodValidation';
 import { modalEditarPedidoSchema } from '../../lib/schemas';
 import { usePrecioMayorista } from '../../hooks/usePrecioMayorista';
+import { calcularNetoVenta } from '../../utils/calculations';
 import type { PedidoDB, ProductoDB } from '../../types';
 
 /** Item del pedido para edición */
@@ -182,13 +183,16 @@ const ModalEditarPedido = memo(function ModalEditarPedido({
   }, [productos, items, busquedaProducto]);
 
   // Cuando cambia el estado de pago, ajustar el monto
+  // NOTE: Only react to estadoPago changes, NOT total changes.
+  // If total is in deps, editing items while estadoPago='pagado' silently overwrites montoPagado.
   useEffect(() => {
     if (estadoPago === 'pagado') {
       setMontoPagado(total);
     } else if (estadoPago === 'pendiente') {
       setMontoPagado(0);
     }
-  }, [estadoPago, total]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [estadoPago]);
 
   const handleMontoPagadoChange = (valor: string): void => {
     const monto = Math.min(parseFloat(valor) || 0, total);
@@ -301,12 +305,30 @@ const ModalEditarPedido = memo(function ModalEditarPedido({
     }
 
     try {
-      // Si hay cambios en items y es admin, guardar items con precios mayoristas resueltos
+      // Si hay cambios en items y es admin, guardar items con precios mayoristas resueltos y desglose fiscal
       if (itemsModificados && isAdmin && onSaveItems) {
-        const itemsParaGuardar = items.map(item => ({
-          ...item,
-          precioUnitario: preciosResueltosMap.get(item.productoId) ?? item.precioUnitario
-        }));
+        const tipoFactura = pedido?.tipo_factura || 'ZZ';
+        const itemsParaGuardar = items.map(item => {
+          const precioFinal = preciosResueltosMap.get(item.productoId) ?? item.precioUnitario;
+          const producto = productos.find(p => p.id === item.productoId);
+          const pctIva = producto?.porcentaje_iva ?? 21;
+          const pctImpInt = producto?.impuestos_internos ?? 0;
+          const esBonif = item.esBonificacion || false;
+
+          if (esBonif) {
+            return { ...item, precioUnitario: 0, neto_unitario: 0, iva_unitario: 0, impuestos_internos_unitario: 0, porcentaje_iva: 0 };
+          }
+
+          const desglose = calcularNetoVenta(precioFinal, pctIva, pctImpInt, tipoFactura as 'ZZ' | 'FC');
+          return {
+            ...item,
+            precioUnitario: precioFinal,
+            neto_unitario: desglose.neto,
+            iva_unitario: desglose.iva,
+            impuestos_internos_unitario: desglose.impuestosInternos,
+            porcentaje_iva: pctIva,
+          };
+        });
         await onSaveItems(itemsParaGuardar);
       }
       // Guardar el resto de los datos
@@ -638,6 +660,8 @@ const ModalEditarPedido = memo(function ModalEditarPedido({
                   setPagoCombinado(e.target.checked);
                   if (!e.target.checked) {
                     setFormaPago('efectivo');
+                    setMontoPagado(pedido?.monto_pagado || 0);
+                    setEstadoPago(pedido?.estado_pago || 'pendiente');
                   }
                 }}
                 className="w-4 h-4 rounded border-gray-300 text-blue-600"

--- a/src/components/modals/ModalPedido.tsx
+++ b/src/components/modals/ModalPedido.tsx
@@ -622,7 +622,7 @@ const ModalPedido = memo(function ModalPedido({
                     type="number"
                     min="0"
                     step="0.01"
-                    max={calcularTotal()}
+                    max={hayDescuento ? totalFinal : calcularTotal()}
                     value={nuevoPedido.montoPagado || ''}
                     onChange={e => onMontoPagadoChange && onMontoPagadoChange(parseFloat(e.target.value) || 0)}
                     className="flex-1 px-3 py-2 border border-yellow-300 rounded-lg focus:ring-2 focus:ring-yellow-500 bg-white dark:bg-gray-800 dark:border-yellow-600 dark:text-white"
@@ -631,7 +631,7 @@ const ModalPedido = memo(function ModalPedido({
                 </div>
                 {(nuevoPedido.montoPagado ?? 0) > 0 && (
                   <p className="text-sm text-yellow-700 dark:text-yellow-300 mt-2">
-                    Resta por pagar: {formatPrecio(calcularTotal() - (nuevoPedido.montoPagado ?? 0))}
+                    Resta por pagar: {formatPrecio((hayDescuento ? totalFinal : calcularTotal()) - (nuevoPedido.montoPagado ?? 0))}
                   </p>
                 )}
               </div>

--- a/src/components/modals/ModalRegistrarPago.tsx
+++ b/src/components/modals/ModalRegistrarPago.tsx
@@ -107,6 +107,13 @@ export default function ModalRegistrarPago({
         return
       }
 
+      // Validate total does not exceed outstanding balance (BUG-10 fix)
+      const totalDividido = pagosValidos.reduce((s, p) => s + parseFloat(p.monto), 0)
+      if (saldoPendiente > 0 && totalDividido > saldoPendiente + 0.01) {
+        setError(`El total de pagos ($${totalDividido.toLocaleString('es-AR')}) excede el saldo pendiente ($${saldoPendiente.toLocaleString('es-AR')})`)
+        return
+      }
+
       setLoading(true)
       try {
         let ultimoPago: PagoRegistrado | null = null

--- a/src/hooks/__tests__/useOfflineSync.integration.test.ts
+++ b/src/hooks/__tests__/useOfflineSync.integration.test.ts
@@ -101,9 +101,9 @@ describe('useOfflineSync Integration Tests', () => {
         usuarioId: 'user1'
       }
 
-      let saveResult: ReturnType<typeof result.current.guardarPedidoOffline>
-      act(() => {
-        saveResult = result.current.guardarPedidoOffline(pedidoData, {
+      let saveResult: Awaited<ReturnType<typeof result.current.guardarPedidoOffline>>
+      await act(async () => {
+        saveResult = await result.current.guardarPedidoOffline(pedidoData, {
           productos: mockProductos,
           validarStock: true
         })
@@ -160,14 +160,12 @@ describe('useOfflineSync Integration Tests', () => {
         total: 200
       }
 
-      act(() => {
-        result.current.guardarPedidoOffline(pedidoData)
+      await act(async () => {
+        await result.current.guardarPedidoOffline(pedidoData)
       })
 
       // Verificar que se llamó a queueOperation
-      await waitFor(() => {
-        expect(mockQueueOperation).toHaveBeenCalled()
-      })
+      expect(mockQueueOperation).toHaveBeenCalled()
 
       const lastCall = mockQueueOperation.mock.calls.at(-1)
       expect(lastCall?.[0]).toBe('CREATE_PEDIDO')
@@ -197,9 +195,9 @@ describe('useOfflineSync Integration Tests', () => {
         total: 2000
       }
 
-      let saveResult: ReturnType<typeof result.current.guardarPedidoOffline>
-      act(() => {
-        saveResult = result.current.guardarPedidoOffline(pedidoData, {
+      let saveResult: Awaited<ReturnType<typeof result.current.guardarPedidoOffline>>
+      await act(async () => {
+        saveResult = await result.current.guardarPedidoOffline(pedidoData, {
           productos: mockProductos,
           validarStock: true
         })
@@ -225,8 +223,8 @@ describe('useOfflineSync Integration Tests', () => {
       })
 
       // Primer pedido: usa 3 de 5 unidades disponibles
-      act(() => {
-        result.current.guardarPedidoOffline(
+      await act(async () => {
+        await result.current.guardarPedidoOffline(
           {
             clienteId: '1',
             items: [{ productoId: 'p2', cantidad: 3, precioUnitario: 200 }],
@@ -239,9 +237,9 @@ describe('useOfflineSync Integration Tests', () => {
       expect(result.current.pedidosPendientes).toHaveLength(1)
 
       // Segundo pedido: intenta usar 4 más (solo quedan 2)
-      let saveResult: ReturnType<typeof result.current.guardarPedidoOffline>
-      act(() => {
-        saveResult = result.current.guardarPedidoOffline(
+      let saveResult: Awaited<ReturnType<typeof result.current.guardarPedidoOffline>>
+      await act(async () => {
+        saveResult = await result.current.guardarPedidoOffline(
           {
             clienteId: '2',
             items: [{ productoId: 'p2', cantidad: 4, precioUnitario: 200 }],
@@ -272,9 +270,9 @@ describe('useOfflineSync Integration Tests', () => {
         total: 200
       }
 
-      let saveResult: ReturnType<typeof result.current.guardarPedidoOffline>
-      act(() => {
-        saveResult = result.current.guardarPedidoOffline(pedidoData, {
+      let saveResult: Awaited<ReturnType<typeof result.current.guardarPedidoOffline>>
+      await act(async () => {
+        saveResult = await result.current.guardarPedidoOffline(pedidoData, {
           productos: mockProductos,
           validarStock: true
         })
@@ -447,8 +445,8 @@ describe('useOfflineSync Integration Tests', () => {
         .mockResolvedValue([]) // After second sync
 
       // Guardar segundo pedido (updates local state)
-      act(() => {
-        result.current.guardarPedidoOffline({ clienteId: '2', items: [], total: 200 })
+      await act(async () => {
+        await result.current.guardarPedidoOffline({ clienteId: '2', items: [], total: 200 })
       })
 
       // Segunda sincronización (debe funcionar)
@@ -559,9 +557,9 @@ describe('useOfflineSync Integration Tests', () => {
       })
 
       // Agregar pedidos
-      act(() => {
-        result.current.guardarPedidoOffline({ clienteId: '1', items: [], total: 100 })
-        result.current.guardarPedidoOffline({ clienteId: '2', items: [], total: 200 })
+      await act(async () => {
+        await result.current.guardarPedidoOffline({ clienteId: '1', items: [], total: 100 })
+        await result.current.guardarPedidoOffline({ clienteId: '2', items: [], total: 200 })
       })
 
       expect(result.current.cantidadPendientes).toBe(2)
@@ -651,9 +649,9 @@ describe('useOfflineSync Integration Tests', () => {
       })
 
       // Agregar pedidos
-      act(() => {
-        result.current.guardarPedidoOffline({ clienteId: '1', items: [], total: 100 })
-        result.current.guardarPedidoOffline({ clienteId: '2', items: [], total: 200 })
+      await act(async () => {
+        await result.current.guardarPedidoOffline({ clienteId: '1', items: [], total: 100 })
+        await result.current.guardarPedidoOffline({ clienteId: '2', items: [], total: 200 })
       })
 
       expect(result.current.pedidosPendientes).toHaveLength(2)
@@ -681,9 +679,9 @@ describe('useOfflineSync Integration Tests', () => {
       let pedido1: PedidoOffline | undefined
       let pedido2: PedidoOffline | undefined
 
-      act(() => {
-        const result1 = result.current.guardarPedidoOffline({ clienteId: '1', items: [], total: 100 })
-        const result2 = result.current.guardarPedidoOffline({ clienteId: '2', items: [], total: 200 })
+      await act(async () => {
+        const result1 = await result.current.guardarPedidoOffline({ clienteId: '1', items: [], total: 100 })
+        const result2 = await result.current.guardarPedidoOffline({ clienteId: '2', items: [], total: 200 })
         pedido1 = result1.pedido
         pedido2 = result2.pedido
       })

--- a/src/hooks/supabase/useCompras.ts
+++ b/src/hooks/supabase/useCompras.ts
@@ -48,6 +48,14 @@ export function useCompras(): UseComprasReturnExtended {
   const [compras, setCompras] = useState<CompraDBExtended[]>([])
   const [proveedores, setProveedores] = useState<ProveedorDBExtended[]>([])
   const [loading, setLoading] = useState<boolean>(false)
+  const [usuarioId, setUsuarioId] = useState<string | null>(null)
+
+  // Get current user ID for RPC calls
+  useEffect(() => {
+    supabase.auth.getUser().then(({ data }) => {
+      setUsuarioId(data.user?.id ?? null)
+    })
+  }, [])
 
   const fetchCompras = async (): Promise<void> => {
     setLoading(true)
@@ -239,39 +247,19 @@ export function useCompras(): UseComprasReturnExtended {
   }
 
   const anularCompra = async (compraId: string): Promise<void> => {
-    const compra = compras.find(c => c.id === compraId)
-    if (!compra) throw new Error('Compra no encontrada')
-
-    // Obtener stock ACTUAL de todos los productos afectados
-    const productIds = (compra.items || []).map(i => i.producto_id).filter(Boolean)
-    if (productIds.length > 0) {
-      const { data: productosActuales } = await supabase
-        .from('productos')
-        .select('id, stock')
-        .in('id', productIds)
-
-      const stockMap: Record<string, number> = Object.fromEntries(
-        ((productosActuales || []) as Array<{ id: string; stock: number }>).map(p => [p.id, p.stock || 0])
-      )
-
-      // Revertir stock de cada item (restar del stock ACTUAL, no del guardado)
-      for (const item of (compra.items || [])) {
-        const stockActual = stockMap[item.producto_id] || 0
-        const nuevoStock = stockActual - item.cantidad
-        await supabase
-          .from('productos')
-          .update({ stock: Math.max(0, nuevoStock) })
-          .eq('id', item.producto_id)
-      }
-    }
-
-    // Marcar compra como cancelada
-    const { error } = await supabase
-      .from('compras')
-      .update({ estado: 'cancelada' })
-      .eq('id', compraId)
+    // Use atomic RPC to revert stock in a single transaction (BUG-1 fix)
+    const { data, error } = await supabase.rpc('anular_compra_atomica', {
+      p_compra_id: compraId,
+      p_usuario_id: usuarioId
+    })
 
     if (error) throw error
+
+    const response = data as { success: boolean; error?: string; mensaje?: string }
+    if (!response.success) {
+      throw new Error(response.error || 'Error al anular compra')
+    }
+
     await fetchCompras()
   }
 

--- a/src/hooks/supabase/useFichaCliente.ts
+++ b/src/hooks/supabase/useFichaCliente.ts
@@ -51,9 +51,13 @@ export function useFichaCliente(clienteId: string | null | undefined): UseFichaC
       const pedidosPagados = pedidosData.filter(p => p.estado_pago === 'pagado')
       const pedidosPendientes = pedidosData.filter(p => p.estado_pago !== 'pagado')
 
-      // Calcular montos considerando monto_pagado (pagos parciales y directos)
-      const totalPagadoEnPedidos = pedidosData.reduce((s, p) => s + (p.monto_pagado || 0), 0)
-      const totalPendienteReal = pedidosData.reduce((s, p) => s + ((p.total || 0) - (p.monto_pagado || 0)), 0)
+      // Fetch pagos from the pagos table (source of truth for payments)
+      const { data: pagosCliente } = await supabase
+        .from('pagos')
+        .select('monto')
+        .eq('cliente_id', clienteId)
+      const totalPagosRegistrados = (pagosCliente || []).reduce((s: number, p: { monto: number }) => s + (p.monto || 0), 0)
+      const totalPendienteReal = totalCompras - totalPagosRegistrados
 
       const productosFrecuencia: ProductosFrecuenciaMap = {}
       pedidosData.forEach(p => {
@@ -87,7 +91,7 @@ export function useFichaCliente(clienteId: string | null | undefined): UseFichaC
         totalPedidos: pedidosData.length,
         totalCompras,
         pedidosPagados: pedidosPagados.length,
-        montoPagado: totalPagadoEnPedidos,
+        montoPagado: totalPagosRegistrados,
         pedidosPendientes: pedidosPendientes.length,
         montoPendiente: totalPendienteReal,
         ticketPromedio,

--- a/src/hooks/supabase/usePagos.ts
+++ b/src/hooks/supabase/usePagos.ts
@@ -79,9 +79,10 @@ export function usePagos(): UsePagosReturnExtended {
         const pagosTyped = (pagosCliente || []) as PagoDB[]
 
         const totalCompras = pedidosTyped.reduce((s, p) => s + (p.total || 0), 0)
-        const totalPagadoEnPedidos = pedidosTyped.reduce((s, p) => s + (p.monto_pagado || 0), 0)
+        // Use only pagos table as source of truth to avoid double-counting.
+        // monto_pagado on pedidos is informational and often reflects the same payments.
         const totalPagosRegistrados = pagosTyped.reduce((s, p) => s + (p.monto || 0), 0)
-        const saldoActual = totalCompras - totalPagadoEnPedidos - totalPagosRegistrados
+        const saldoActual = totalCompras - totalPagosRegistrados
 
         // Obtener última fecha correctamente (Math.max no funciona con Date)
         const ultimoPedidoFecha = pedidosTyped.reduce((max: Date, p) => {
@@ -100,7 +101,7 @@ export function usePagos(): UsePagosReturnExtended {
           credito_disponible: (clienteTyped?.limite_credito || 0) - saldoActual,
           total_pedidos: pedidosTyped.length,
           total_compras: totalCompras,
-          total_pagos: totalPagadoEnPedidos + totalPagosRegistrados,
+          total_pagos: totalPagosRegistrados,
           pedidos_pendientes_pago: pedidosTyped.filter(p => p.estado_pago !== 'pagado').length,
           ultimo_pedido: pedidosTyped.length ? ultimoPedidoFecha.toISOString() : null,
           ultimo_pago: pagosTyped.length ? ultimoPagoFecha.toISOString() : null

--- a/src/hooks/supabase/usePedidos.ts
+++ b/src/hooks/supabase/usePedidos.ts
@@ -511,6 +511,10 @@ export function usePedidos(): UsePedidosHookReturn {
       precio_unitario: item.precioUnitario ?? item.precio_unitario ?? 0,
       ...(item.esBonificacion ? { es_bonificacion: true } : {}),
       ...(item.promocionId ? { promocion_id: item.promocionId } : {}),
+      ...(item.neto_unitario != null ? { neto_unitario: item.neto_unitario } : {}),
+      ...(item.iva_unitario != null ? { iva_unitario: item.iva_unitario } : {}),
+      ...(item.impuestos_internos_unitario != null ? { impuestos_internos_unitario: item.impuestos_internos_unitario } : {}),
+      ...(item.porcentaje_iva != null ? { porcentaje_iva: item.porcentaje_iva } : {}),
     }))
 
     const { data, error } = await supabase.rpc('actualizar_pedido_items', {

--- a/src/hooks/supabase/useReportesFinancieros.ts
+++ b/src/hooks/supabase/useReportesFinancieros.ts
@@ -100,11 +100,14 @@ export function useReportesFinancieros(): UseReportesFinancierosReturn {
           const fechaVencimiento = new Date(fechaPedido)
           fechaVencimiento.setDate(fechaVencimiento.getDate() + diasCredito)
           const diasVencido = Math.floor((hoy.getTime() - fechaVencimiento.getTime()) / (1000 * 60 * 60 * 24))
+          // Use outstanding balance per order, not full total (BUG-9 fix)
+          const saldoPedido = (p.total || 0) - (p.monto_pagado || 0)
+          if (saldoPedido <= 0) return // Skip fully paid orders
 
-          if (diasVencido <= 0) corriente += p.total || 0
-          else if (diasVencido <= 30) vencido30 += p.total || 0
-          else if (diasVencido <= 60) vencido60 += p.total || 0
-          else vencido90 += p.total || 0
+          if (diasVencido <= 0) corriente += saldoPedido
+          else if (diasVencido <= 30) vencido30 += saldoPedido
+          else if (diasVencido <= 60) vencido60 += saldoPedido
+          else vencido90 += saldoPedido
         })
 
         const aging: AgingDeuda = { corriente, vencido30, vencido60, vencido90 }

--- a/src/hooks/useOfflineQueue.ts
+++ b/src/hooks/useOfflineQueue.ts
@@ -296,11 +296,14 @@ export function useOfflineQueue(): UseOfflineQueueReturn {
   // Efectos: Listeners de conectividad
   // -------------------------------------------------------------------------
   useEffect(() => {
+    let initialSyncTimeout: ReturnType<typeof setTimeout> | undefined
+    let onlineTimeout: ReturnType<typeof setTimeout> | undefined
+
     const handleOnline = () => {
       logger.info('[OfflineQueue] Conexión restaurada')
       setSyncState(prev => ({ ...prev, isOnline: true, status: 'online' }))
       // Sincronizar después de un pequeño delay
-      setTimeout(() => syncNow(), 1000)
+      onlineTimeout = setTimeout(() => syncNow(), 1000)
     }
 
     const handleOffline = () => {
@@ -316,7 +319,7 @@ export function useOfflineQueue(): UseOfflineQueueReturn {
 
     // Si hay operaciones pendientes y estamos online, sincronizar
     if (navigator.onLine) {
-      setTimeout(() => syncNow(), 2000)
+      initialSyncTimeout = setTimeout(() => syncNow(), 2000)
     }
 
     // Limpieza periódica (cada hora)
@@ -326,6 +329,8 @@ export function useOfflineQueue(): UseOfflineQueueReturn {
       window.removeEventListener('online', handleOnline)
       window.removeEventListener('offline', handleOffline)
       clearInterval(cleanupInterval)
+      clearTimeout(initialSyncTimeout)
+      clearTimeout(onlineTimeout)
       if (syncTimeoutRef.current) {
         clearTimeout(syncTimeoutRef.current)
       }

--- a/src/hooks/useOfflineSync.ts
+++ b/src/hooks/useOfflineSync.ts
@@ -260,10 +260,10 @@ export function useOfflineSync(): UseOfflineSyncReturn {
    * Ahora usa IndexedDB via queueOperation
    * Usa pedidosPendientesRef para evitar re-renders innecesarios
    */
-  const guardarPedidoOffline = useCallback((
+  const guardarPedidoOffline = useCallback(async (
     pedidoData: Omit<PedidoOffline, 'offlineId' | 'creadoOffline' | 'sincronizado'>,
     options: GuardarPedidoOptions = {}
-  ): GuardarPedidoResult => {
+  ): Promise<GuardarPedidoResult> => {
     const { productos = [], validarStock = true } = options
 
     // Validar stock si se proporciona lista de productos
@@ -325,33 +325,32 @@ export function useOfflineSync(): UseOfflineSyncReturn {
       sincronizado: false
     }
 
-    // Encolar en IndexedDB (async, no bloqueante)
-    queueOperation('CREATE_PEDIDO' as OperationType, {
-      ...pedidoData,
-      tempOfflineId,
-      timestamp: Date.now()
-    }, pedidoData.usuarioId)
-      .then((opId) => {
-        if (opId !== null) {
-          logger.info(`[useOfflineSync] Pedido encolado con ID: ${opId}`)
-          // Actualizar lista local (void para indicar que no esperamos el resultado)
-          void loadPendingOperations()
-        } else {
-          logger.warn('[useOfflineSync] Pedido duplicado detectado, no se encoló')
-        }
-      })
-      .catch((err) => {
-        logger.error('[useOfflineSync] Error crítico al encolar pedido:', err)
-        window.dispatchEvent(new CustomEvent('offline-storage-error', {
-          detail: { type: 'pedido', error: err.message }
-        }))
-      })
+    // Encolar en IndexedDB - await to ensure persistence before reporting success (BUG-11 fix)
+    try {
+      const opId = await queueOperation('CREATE_PEDIDO' as OperationType, {
+        ...pedidoData,
+        tempOfflineId,
+        timestamp: Date.now()
+      }, pedidoData.usuarioId)
 
-    // Actualizar estado local inmediatamente para UI responsive
+      if (opId !== null) {
+        logger.info(`[useOfflineSync] Pedido encolado con ID: ${opId}`)
+      } else {
+        logger.warn('[useOfflineSync] Pedido duplicado detectado, no se encoló')
+      }
+    } catch (err) {
+      logger.error('[useOfflineSync] Error crítico al encolar pedido:', err)
+      window.dispatchEvent(new CustomEvent('offline-storage-error', {
+        detail: { type: 'pedido', error: (err as Error).message }
+      }))
+      return { success: false, pedido: nuevoPedido }
+    }
+
+    // Actualizar estado local after confirmed IndexedDB write
     setPedidosPendientes(prev => [...prev, nuevoPedido])
 
     return { success: true, pedido: nuevoPedido }
-  }, [loadPendingOperations]) // pedidosPendientes removido, usamos ref
+  }, []) // pedidosPendientes removido, usamos ref
 
   /**
    * Guarda una merma en modo offline

--- a/src/hooks/useSyncManager.ts
+++ b/src/hooks/useSyncManager.ts
@@ -153,8 +153,7 @@ export function useSyncManager({
     if (isOnline && (pedidosPendientes.length > 0 || mermasPendientes.length > 0)) {
       ejecutarSincronizacion()
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isOnline])
+  }, [isOnline, ejecutarSincronizacion, pedidosPendientes.length, mermasPendientes.length])
 
   // Handler para sincronización manual
   const handleSincronizar = useCallback(async (): Promise<void> => {


### PR DESCRIPTION
- CRÍTICO: Eliminar overload duplicado de actualizar_pedido_items (PostgREST ambiguity error)
- CRÍTICO: Agregar campos fiscales (neto/iva) en edición de pedidos (fix FC guardaba como ZZ)
- SEC: Validar auth.uid() en 5 RPCs SECURITY DEFINER
- BUG-1: Crear RPC anular_compra_atomica (reemplaza loop no-atómico)
- BUG-2: Fix doble-conteo de pagos en saldo de clientes (usePagos)
- BUG-3: Fix max pago parcial con descuento (ModalPedido)
- BUG-4: Fix stale closure en useSyncManager
- BUG-7: Fix timeout cleanup en useOfflineQueue
- BUG-8: Incluir pagos generales en ficha cliente
- BUG-9: Fix aging report usa saldo pendiente real
- BUG-10: Validar sobrepago en ModalRegistrarPago
- BUG-11: Hacer guardarPedidoOffline async con await
- BUG-13: Reset montoPagado al desactivar pagoCombinado