### PR TITLE
fix: actualizar tipo de retorno de guardarPedidoOffline a Promise

### DIFF
--- a/src/hooks/useOfflineSync.ts
+++ b/src/hooks/useOfflineSync.ts
@@ -113,7 +113,7 @@ export interface UseOfflineSyncReturn {
   guardarPedidoOffline: (
     pedidoData: Omit<PedidoOffline, 'offlineId' | 'creadoOffline' | 'sincronizado'>,
     options?: GuardarPedidoOptions
-  ) => GuardarPedidoResult;
+  ) => Promise<GuardarPedidoResult>;
   guardarMermaOffline: (mermaData: MermaFormInput) => MermaOffline;
   eliminarPedidoOffline: (offlineId: string) => void;
   eliminarMermaOffline: (offlineId: string) => void;


### PR DESCRIPTION
La función se hizo async pero la interfaz UseOfflineSyncReturn aún declaraba el retorno como GuardarPedidoResult en vez de Promise<GuardarPedidoResult>.