### PR TITLE
fix(multi-tenant): 17 audit findings + session-scoped resolver + TP Export import

### DIFF
--- a/migrations/057_multi_tenant_schema.sql
+++ b/migrations/057_multi_tenant_schema.sql
@@ -1,0 +1,362 @@
+-- Migration 057: Multi-tenant Schema
+--
+-- Transforms the existing single-tenant database into a multi-tenant schema.
+-- This is the foundation for unifying two Supabase instances (ManaosApp + TP Export).
+--
+-- Changes:
+--   1. Seed sucursales with ManaosApp and TP Export tenants
+--   2. Create usuario_sucursales junction table
+--   3. Add sucursal_id to all tenant-scoped tables (backfill with 1)
+--   4. Create helper function current_sucursal_id()
+--   5. Create RPC cambiar_sucursal()
+--   6. Create RPC obtener_sucursales_usuario()
+--   7. Populate usuario_sucursales for existing users
+
+-- ============================================================
+-- 1. Seed sucursales table with tenant records
+-- ============================================================
+
+-- Add tipo column to distinguish tenant types
+ALTER TABLE sucursales ADD COLUMN IF NOT EXISTS tipo VARCHAR(50) DEFAULT 'distribuidora';
+
+-- Insert tenant records (idempotent)
+INSERT INTO sucursales (id, nombre, tipo)
+VALUES (1, 'ManaosApp', 'principal')
+ON CONFLICT (id) DO NOTHING;
+
+INSERT INTO sucursales (id, nombre, tipo)
+VALUES (2, 'TP Export', 'secundaria')
+ON CONFLICT (id) DO NOTHING;
+
+-- Ensure the sequence is ahead of our manually inserted IDs
+SELECT setval('sucursales_id_seq', GREATEST(nextval('sucursales_id_seq'), 3));
+
+-- ============================================================
+-- 2. Create usuario_sucursales junction table
+-- ============================================================
+
+CREATE TABLE IF NOT EXISTS usuario_sucursales (
+  id BIGSERIAL PRIMARY KEY,
+  usuario_id UUID NOT NULL REFERENCES perfiles(id) ON DELETE CASCADE,
+  sucursal_id BIGINT NOT NULL REFERENCES sucursales(id) ON DELETE CASCADE,
+  rol VARCHAR(20) DEFAULT 'mismo',
+  es_default BOOLEAN DEFAULT false,
+  created_at TIMESTAMPTZ DEFAULT NOW(),
+  UNIQUE(usuario_id, sucursal_id)
+);
+
+-- Enable RLS
+ALTER TABLE usuario_sucursales ENABLE ROW LEVEL SECURITY;
+
+-- Users can read their own sucursal assignments
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_policies WHERE tablename = 'usuario_sucursales' AND policyname = 'usuario_sucursales_select_own') THEN
+    CREATE POLICY usuario_sucursales_select_own ON usuario_sucursales
+      FOR SELECT TO authenticated
+      USING (usuario_id = auth.uid());
+  END IF;
+END $$;
+
+-- Admins can manage all usuario_sucursales
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_policies WHERE tablename = 'usuario_sucursales' AND policyname = 'usuario_sucursales_admin_all') THEN
+    CREATE POLICY usuario_sucursales_admin_all ON usuario_sucursales
+      FOR ALL TO authenticated
+      USING (
+        EXISTS (SELECT 1 FROM perfiles WHERE id = auth.uid() AND rol = 'admin')
+      )
+      WITH CHECK (
+        EXISTS (SELECT 1 FROM perfiles WHERE id = auth.uid() AND rol = 'admin')
+      );
+  END IF;
+END $$;
+
+CREATE INDEX IF NOT EXISTS idx_usuario_sucursales_usuario ON usuario_sucursales(usuario_id);
+CREATE INDEX IF NOT EXISTS idx_usuario_sucursales_sucursal ON usuario_sucursales(sucursal_id);
+CREATE INDEX IF NOT EXISTS idx_usuario_sucursales_default ON usuario_sucursales(usuario_id) WHERE es_default = true;
+
+-- ============================================================
+-- 3. Add sucursal_id to all tenant-scoped tables
+-- ============================================================
+
+-- Helper: For each table, add column nullable, backfill with 1, set NOT NULL, add index.
+-- Using DO blocks for idempotent ALTER COLUMN SET NOT NULL (avoiding error if already NOT NULL).
+
+-- --- clientes ---
+ALTER TABLE clientes ADD COLUMN IF NOT EXISTS sucursal_id BIGINT REFERENCES sucursales(id);
+UPDATE clientes SET sucursal_id = 1 WHERE sucursal_id IS NULL;
+DO $$ BEGIN ALTER TABLE clientes ALTER COLUMN sucursal_id SET NOT NULL; EXCEPTION WHEN others THEN NULL; END $$;
+CREATE INDEX IF NOT EXISTS idx_clientes_sucursal ON clientes(sucursal_id);
+
+-- --- productos ---
+ALTER TABLE productos ADD COLUMN IF NOT EXISTS sucursal_id BIGINT REFERENCES sucursales(id);
+UPDATE productos SET sucursal_id = 1 WHERE sucursal_id IS NULL;
+DO $$ BEGIN ALTER TABLE productos ALTER COLUMN sucursal_id SET NOT NULL; EXCEPTION WHEN others THEN NULL; END $$;
+CREATE INDEX IF NOT EXISTS idx_productos_sucursal ON productos(sucursal_id);
+
+-- --- pedidos ---
+ALTER TABLE pedidos ADD COLUMN IF NOT EXISTS sucursal_id BIGINT REFERENCES sucursales(id);
+UPDATE pedidos SET sucursal_id = 1 WHERE sucursal_id IS NULL;
+DO $$ BEGIN ALTER TABLE pedidos ALTER COLUMN sucursal_id SET NOT NULL; EXCEPTION WHEN others THEN NULL; END $$;
+CREATE INDEX IF NOT EXISTS idx_pedidos_sucursal ON pedidos(sucursal_id);
+
+-- --- pedido_items ---
+ALTER TABLE pedido_items ADD COLUMN IF NOT EXISTS sucursal_id BIGINT REFERENCES sucursales(id);
+UPDATE pedido_items SET sucursal_id = 1 WHERE sucursal_id IS NULL;
+DO $$ BEGIN ALTER TABLE pedido_items ALTER COLUMN sucursal_id SET NOT NULL; EXCEPTION WHEN others THEN NULL; END $$;
+CREATE INDEX IF NOT EXISTS idx_pedido_items_sucursal ON pedido_items(sucursal_id);
+
+-- --- pedido_historial ---
+ALTER TABLE pedido_historial ADD COLUMN IF NOT EXISTS sucursal_id BIGINT REFERENCES sucursales(id);
+UPDATE pedido_historial SET sucursal_id = 1 WHERE sucursal_id IS NULL;
+DO $$ BEGIN ALTER TABLE pedido_historial ALTER COLUMN sucursal_id SET NOT NULL; EXCEPTION WHEN others THEN NULL; END $$;
+CREATE INDEX IF NOT EXISTS idx_pedido_historial_sucursal ON pedido_historial(sucursal_id);
+
+-- --- pagos ---
+ALTER TABLE pagos ADD COLUMN IF NOT EXISTS sucursal_id BIGINT REFERENCES sucursales(id);
+UPDATE pagos SET sucursal_id = 1 WHERE sucursal_id IS NULL;
+DO $$ BEGIN ALTER TABLE pagos ALTER COLUMN sucursal_id SET NOT NULL; EXCEPTION WHEN others THEN NULL; END $$;
+CREATE INDEX IF NOT EXISTS idx_pagos_sucursal ON pagos(sucursal_id);
+
+-- --- compras ---
+ALTER TABLE compras ADD COLUMN IF NOT EXISTS sucursal_id BIGINT REFERENCES sucursales(id);
+UPDATE compras SET sucursal_id = 1 WHERE sucursal_id IS NULL;
+DO $$ BEGIN ALTER TABLE compras ALTER COLUMN sucursal_id SET NOT NULL; EXCEPTION WHEN others THEN NULL; END $$;
+CREATE INDEX IF NOT EXISTS idx_compras_sucursal ON compras(sucursal_id);
+
+-- --- compra_items ---
+ALTER TABLE compra_items ADD COLUMN IF NOT EXISTS sucursal_id BIGINT REFERENCES sucursales(id);
+UPDATE compra_items SET sucursal_id = 1 WHERE sucursal_id IS NULL;
+DO $$ BEGIN ALTER TABLE compra_items ALTER COLUMN sucursal_id SET NOT NULL; EXCEPTION WHEN others THEN NULL; END $$;
+CREATE INDEX IF NOT EXISTS idx_compra_items_sucursal ON compra_items(sucursal_id);
+
+-- --- proveedores ---
+ALTER TABLE proveedores ADD COLUMN IF NOT EXISTS sucursal_id BIGINT REFERENCES sucursales(id);
+UPDATE proveedores SET sucursal_id = 1 WHERE sucursal_id IS NULL;
+DO $$ BEGIN ALTER TABLE proveedores ALTER COLUMN sucursal_id SET NOT NULL; EXCEPTION WHEN others THEN NULL; END $$;
+CREATE INDEX IF NOT EXISTS idx_proveedores_sucursal ON proveedores(sucursal_id);
+
+-- --- mermas_stock ---
+ALTER TABLE mermas_stock ADD COLUMN IF NOT EXISTS sucursal_id BIGINT REFERENCES sucursales(id);
+UPDATE mermas_stock SET sucursal_id = 1 WHERE sucursal_id IS NULL;
+DO $$ BEGIN ALTER TABLE mermas_stock ALTER COLUMN sucursal_id SET NOT NULL; EXCEPTION WHEN others THEN NULL; END $$;
+CREATE INDEX IF NOT EXISTS idx_mermas_stock_sucursal ON mermas_stock(sucursal_id);
+
+-- --- stock_historico ---
+ALTER TABLE stock_historico ADD COLUMN IF NOT EXISTS sucursal_id BIGINT REFERENCES sucursales(id);
+UPDATE stock_historico SET sucursal_id = 1 WHERE sucursal_id IS NULL;
+DO $$ BEGIN ALTER TABLE stock_historico ALTER COLUMN sucursal_id SET NOT NULL; EXCEPTION WHEN others THEN NULL; END $$;
+CREATE INDEX IF NOT EXISTS idx_stock_historico_sucursal ON stock_historico(sucursal_id);
+
+-- --- recorridos ---
+ALTER TABLE recorridos ADD COLUMN IF NOT EXISTS sucursal_id BIGINT REFERENCES sucursales(id);
+UPDATE recorridos SET sucursal_id = 1 WHERE sucursal_id IS NULL;
+DO $$ BEGIN ALTER TABLE recorridos ALTER COLUMN sucursal_id SET NOT NULL; EXCEPTION WHEN others THEN NULL; END $$;
+CREATE INDEX IF NOT EXISTS idx_recorridos_sucursal ON recorridos(sucursal_id);
+
+-- --- recorrido_pedidos ---
+ALTER TABLE recorrido_pedidos ADD COLUMN IF NOT EXISTS sucursal_id BIGINT REFERENCES sucursales(id);
+UPDATE recorrido_pedidos SET sucursal_id = 1 WHERE sucursal_id IS NULL;
+DO $$ BEGIN ALTER TABLE recorrido_pedidos ALTER COLUMN sucursal_id SET NOT NULL; EXCEPTION WHEN others THEN NULL; END $$;
+CREATE INDEX IF NOT EXISTS idx_recorrido_pedidos_sucursal ON recorrido_pedidos(sucursal_id);
+
+-- --- rendiciones ---
+ALTER TABLE rendiciones ADD COLUMN IF NOT EXISTS sucursal_id BIGINT REFERENCES sucursales(id);
+UPDATE rendiciones SET sucursal_id = 1 WHERE sucursal_id IS NULL;
+DO $$ BEGIN ALTER TABLE rendiciones ALTER COLUMN sucursal_id SET NOT NULL; EXCEPTION WHEN others THEN NULL; END $$;
+CREATE INDEX IF NOT EXISTS idx_rendiciones_sucursal ON rendiciones(sucursal_id);
+
+-- --- rendicion_items ---
+ALTER TABLE rendicion_items ADD COLUMN IF NOT EXISTS sucursal_id BIGINT REFERENCES sucursales(id);
+UPDATE rendicion_items SET sucursal_id = 1 WHERE sucursal_id IS NULL;
+DO $$ BEGIN ALTER TABLE rendicion_items ALTER COLUMN sucursal_id SET NOT NULL; EXCEPTION WHEN others THEN NULL; END $$;
+CREATE INDEX IF NOT EXISTS idx_rendicion_items_sucursal ON rendicion_items(sucursal_id);
+
+-- --- rendicion_ajustes ---
+ALTER TABLE rendicion_ajustes ADD COLUMN IF NOT EXISTS sucursal_id BIGINT REFERENCES sucursales(id);
+UPDATE rendicion_ajustes SET sucursal_id = 1 WHERE sucursal_id IS NULL;
+DO $$ BEGIN ALTER TABLE rendicion_ajustes ALTER COLUMN sucursal_id SET NOT NULL; EXCEPTION WHEN others THEN NULL; END $$;
+CREATE INDEX IF NOT EXISTS idx_rendicion_ajustes_sucursal ON rendicion_ajustes(sucursal_id);
+
+-- --- salvedades_items ---
+ALTER TABLE salvedades_items ADD COLUMN IF NOT EXISTS sucursal_id BIGINT REFERENCES sucursales(id);
+UPDATE salvedades_items SET sucursal_id = 1 WHERE sucursal_id IS NULL;
+DO $$ BEGIN ALTER TABLE salvedades_items ALTER COLUMN sucursal_id SET NOT NULL; EXCEPTION WHEN others THEN NULL; END $$;
+CREATE INDEX IF NOT EXISTS idx_salvedades_items_sucursal ON salvedades_items(sucursal_id);
+
+-- --- salvedad_historial ---
+ALTER TABLE salvedad_historial ADD COLUMN IF NOT EXISTS sucursal_id BIGINT REFERENCES sucursales(id);
+UPDATE salvedad_historial SET sucursal_id = 1 WHERE sucursal_id IS NULL;
+DO $$ BEGIN ALTER TABLE salvedad_historial ALTER COLUMN sucursal_id SET NOT NULL; EXCEPTION WHEN others THEN NULL; END $$;
+CREATE INDEX IF NOT EXISTS idx_salvedad_historial_sucursal ON salvedad_historial(sucursal_id);
+
+-- --- notas_credito ---
+ALTER TABLE notas_credito ADD COLUMN IF NOT EXISTS sucursal_id BIGINT REFERENCES sucursales(id);
+UPDATE notas_credito SET sucursal_id = 1 WHERE sucursal_id IS NULL;
+DO $$ BEGIN ALTER TABLE notas_credito ALTER COLUMN sucursal_id SET NOT NULL; EXCEPTION WHEN others THEN NULL; END $$;
+CREATE INDEX IF NOT EXISTS idx_notas_credito_sucursal ON notas_credito(sucursal_id);
+
+-- --- nota_credito_items ---
+ALTER TABLE nota_credito_items ADD COLUMN IF NOT EXISTS sucursal_id BIGINT REFERENCES sucursales(id);
+UPDATE nota_credito_items SET sucursal_id = 1 WHERE sucursal_id IS NULL;
+DO $$ BEGIN ALTER TABLE nota_credito_items ALTER COLUMN sucursal_id SET NOT NULL; EXCEPTION WHEN others THEN NULL; END $$;
+CREATE INDEX IF NOT EXISTS idx_nota_credito_items_sucursal ON nota_credito_items(sucursal_id);
+
+-- --- transferencias_stock (SPECIAL: use tenant_sucursal_id, keep existing sucursal_id as-is) ---
+ALTER TABLE transferencias_stock ADD COLUMN IF NOT EXISTS tenant_sucursal_id BIGINT REFERENCES sucursales(id);
+UPDATE transferencias_stock SET tenant_sucursal_id = 1 WHERE tenant_sucursal_id IS NULL;
+DO $$ BEGIN ALTER TABLE transferencias_stock ALTER COLUMN tenant_sucursal_id SET NOT NULL; EXCEPTION WHEN others THEN NULL; END $$;
+CREATE INDEX IF NOT EXISTS idx_transferencias_stock_tenant_sucursal ON transferencias_stock(tenant_sucursal_id);
+
+-- --- transferencia_items ---
+ALTER TABLE transferencia_items ADD COLUMN IF NOT EXISTS sucursal_id BIGINT REFERENCES sucursales(id);
+UPDATE transferencia_items SET sucursal_id = 1 WHERE sucursal_id IS NULL;
+DO $$ BEGIN ALTER TABLE transferencia_items ALTER COLUMN sucursal_id SET NOT NULL; EXCEPTION WHEN others THEN NULL; END $$;
+CREATE INDEX IF NOT EXISTS idx_transferencia_items_sucursal ON transferencia_items(sucursal_id);
+
+-- --- promociones ---
+ALTER TABLE promociones ADD COLUMN IF NOT EXISTS sucursal_id BIGINT REFERENCES sucursales(id);
+UPDATE promociones SET sucursal_id = 1 WHERE sucursal_id IS NULL;
+DO $$ BEGIN ALTER TABLE promociones ALTER COLUMN sucursal_id SET NOT NULL; EXCEPTION WHEN others THEN NULL; END $$;
+CREATE INDEX IF NOT EXISTS idx_promociones_sucursal ON promociones(sucursal_id);
+
+-- --- promocion_productos ---
+ALTER TABLE promocion_productos ADD COLUMN IF NOT EXISTS sucursal_id BIGINT REFERENCES sucursales(id);
+UPDATE promocion_productos SET sucursal_id = 1 WHERE sucursal_id IS NULL;
+DO $$ BEGIN ALTER TABLE promocion_productos ALTER COLUMN sucursal_id SET NOT NULL; EXCEPTION WHEN others THEN NULL; END $$;
+CREATE INDEX IF NOT EXISTS idx_promocion_productos_sucursal ON promocion_productos(sucursal_id);
+
+-- --- promocion_reglas ---
+ALTER TABLE promocion_reglas ADD COLUMN IF NOT EXISTS sucursal_id BIGINT REFERENCES sucursales(id);
+UPDATE promocion_reglas SET sucursal_id = 1 WHERE sucursal_id IS NULL;
+DO $$ BEGIN ALTER TABLE promocion_reglas ALTER COLUMN sucursal_id SET NOT NULL; EXCEPTION WHEN others THEN NULL; END $$;
+CREATE INDEX IF NOT EXISTS idx_promocion_reglas_sucursal ON promocion_reglas(sucursal_id);
+
+-- --- promo_ajustes ---
+ALTER TABLE promo_ajustes ADD COLUMN IF NOT EXISTS sucursal_id BIGINT REFERENCES sucursales(id);
+UPDATE promo_ajustes SET sucursal_id = 1 WHERE sucursal_id IS NULL;
+DO $$ BEGIN ALTER TABLE promo_ajustes ALTER COLUMN sucursal_id SET NOT NULL; EXCEPTION WHEN others THEN NULL; END $$;
+CREATE INDEX IF NOT EXISTS idx_promo_ajustes_sucursal ON promo_ajustes(sucursal_id);
+
+-- --- grupos_precio ---
+ALTER TABLE grupos_precio ADD COLUMN IF NOT EXISTS sucursal_id BIGINT REFERENCES sucursales(id);
+UPDATE grupos_precio SET sucursal_id = 1 WHERE sucursal_id IS NULL;
+DO $$ BEGIN ALTER TABLE grupos_precio ALTER COLUMN sucursal_id SET NOT NULL; EXCEPTION WHEN others THEN NULL; END $$;
+CREATE INDEX IF NOT EXISTS idx_grupos_precio_sucursal ON grupos_precio(sucursal_id);
+
+-- --- grupo_precio_productos ---
+ALTER TABLE grupo_precio_productos ADD COLUMN IF NOT EXISTS sucursal_id BIGINT REFERENCES sucursales(id);
+UPDATE grupo_precio_productos SET sucursal_id = 1 WHERE sucursal_id IS NULL;
+DO $$ BEGIN ALTER TABLE grupo_precio_productos ALTER COLUMN sucursal_id SET NOT NULL; EXCEPTION WHEN others THEN NULL; END $$;
+CREATE INDEX IF NOT EXISTS idx_grupo_precio_productos_sucursal ON grupo_precio_productos(sucursal_id);
+
+-- --- grupo_precio_escalas ---
+ALTER TABLE grupo_precio_escalas ADD COLUMN IF NOT EXISTS sucursal_id BIGINT REFERENCES sucursales(id);
+UPDATE grupo_precio_escalas SET sucursal_id = 1 WHERE sucursal_id IS NULL;
+DO $$ BEGIN ALTER TABLE grupo_precio_escalas ALTER COLUMN sucursal_id SET NOT NULL; EXCEPTION WHEN others THEN NULL; END $$;
+CREATE INDEX IF NOT EXISTS idx_grupo_precio_escalas_sucursal ON grupo_precio_escalas(sucursal_id);
+
+-- --- pedidos_eliminados ---
+ALTER TABLE pedidos_eliminados ADD COLUMN IF NOT EXISTS sucursal_id BIGINT REFERENCES sucursales(id);
+UPDATE pedidos_eliminados SET sucursal_id = 1 WHERE sucursal_id IS NULL;
+DO $$ BEGIN ALTER TABLE pedidos_eliminados ALTER COLUMN sucursal_id SET NOT NULL; EXCEPTION WHEN others THEN NULL; END $$;
+CREATE INDEX IF NOT EXISTS idx_pedidos_eliminados_sucursal ON pedidos_eliminados(sucursal_id);
+
+-- --- audit_logs ---
+ALTER TABLE audit_logs ADD COLUMN IF NOT EXISTS sucursal_id BIGINT REFERENCES sucursales(id);
+UPDATE audit_logs SET sucursal_id = 1 WHERE sucursal_id IS NULL;
+DO $$ BEGIN ALTER TABLE audit_logs ALTER COLUMN sucursal_id SET NOT NULL; EXCEPTION WHEN others THEN NULL; END $$;
+CREATE INDEX IF NOT EXISTS idx_audit_logs_sucursal ON audit_logs(sucursal_id);
+
+-- --- zonas ---
+ALTER TABLE zonas ADD COLUMN IF NOT EXISTS sucursal_id BIGINT REFERENCES sucursales(id);
+UPDATE zonas SET sucursal_id = 1 WHERE sucursal_id IS NULL;
+DO $$ BEGIN ALTER TABLE zonas ALTER COLUMN sucursal_id SET NOT NULL; EXCEPTION WHEN others THEN NULL; END $$;
+CREATE INDEX IF NOT EXISTS idx_zonas_sucursal ON zonas(sucursal_id);
+
+-- --- preventista_zonas ---
+ALTER TABLE preventista_zonas ADD COLUMN IF NOT EXISTS sucursal_id BIGINT REFERENCES sucursales(id);
+UPDATE preventista_zonas SET sucursal_id = 1 WHERE sucursal_id IS NULL;
+DO $$ BEGIN ALTER TABLE preventista_zonas ALTER COLUMN sucursal_id SET NOT NULL; EXCEPTION WHEN others THEN NULL; END $$;
+CREATE INDEX IF NOT EXISTS idx_preventista_zonas_sucursal ON preventista_zonas(sucursal_id);
+
+-- --- historial_cambios ---
+ALTER TABLE historial_cambios ADD COLUMN IF NOT EXISTS sucursal_id BIGINT REFERENCES sucursales(id);
+UPDATE historial_cambios SET sucursal_id = 1 WHERE sucursal_id IS NULL;
+DO $$ BEGIN ALTER TABLE historial_cambios ALTER COLUMN sucursal_id SET NOT NULL; EXCEPTION WHEN others THEN NULL; END $$;
+CREATE INDEX IF NOT EXISTS idx_historial_cambios_sucursal ON historial_cambios(sucursal_id);
+
+-- ============================================================
+-- 4. Helper function: current_sucursal_id()
+-- ============================================================
+
+CREATE OR REPLACE FUNCTION current_sucursal_id()
+RETURNS BIGINT
+LANGUAGE sql STABLE SECURITY DEFINER
+SET search_path = public
+AS $$
+  SELECT sucursal_id FROM usuario_sucursales
+  WHERE usuario_id = auth.uid() AND es_default = true
+  LIMIT 1;
+$$;
+
+-- ============================================================
+-- 5. RPC: cambiar_sucursal(p_sucursal_id)
+-- ============================================================
+
+CREATE OR REPLACE FUNCTION cambiar_sucursal(p_sucursal_id BIGINT)
+RETURNS JSONB
+LANGUAGE plpgsql SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+  -- Verify user has access to this sucursal
+  IF NOT EXISTS (
+    SELECT 1 FROM usuario_sucursales
+    WHERE usuario_id = auth.uid() AND sucursal_id = p_sucursal_id
+  ) THEN
+    RETURN jsonb_build_object('success', false, 'error', 'No autorizado para esta sucursal');
+  END IF;
+
+  -- Clear all defaults for this user
+  UPDATE usuario_sucursales SET es_default = false WHERE usuario_id = auth.uid();
+  -- Set new default
+  UPDATE usuario_sucursales SET es_default = true WHERE usuario_id = auth.uid() AND sucursal_id = p_sucursal_id;
+
+  RETURN jsonb_build_object('success', true, 'sucursal_id', p_sucursal_id);
+END;
+$$;
+
+-- ============================================================
+-- 6. RPC: obtener_sucursales_usuario()
+-- ============================================================
+
+CREATE OR REPLACE FUNCTION obtener_sucursales_usuario()
+RETURNS JSONB
+LANGUAGE plpgsql STABLE SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+  RETURN (
+    SELECT jsonb_agg(jsonb_build_object(
+      'sucursal_id', us.sucursal_id,
+      'nombre', s.nombre,
+      'rol', us.rol,
+      'es_default', us.es_default
+    ))
+    FROM usuario_sucursales us
+    JOIN sucursales s ON s.id = us.sucursal_id
+    WHERE us.usuario_id = auth.uid() AND s.activa = true
+  );
+END;
+$$;
+
+-- ============================================================
+-- 7. Populate usuario_sucursales for existing ManaosApp users
+-- ============================================================
+
+INSERT INTO usuario_sucursales (usuario_id, sucursal_id, rol, es_default)
+SELECT id, 1, 'mismo', true FROM perfiles
+ON CONFLICT (usuario_id, sucursal_id) DO NOTHING;

--- a/migrations/058_multi_tenant_rls.sql
+++ b/migrations/058_multi_tenant_rls.sql
@@ -1,0 +1,896 @@
+-- ============================================================
+-- Migration 058: Multi-tenant RLS Policies
+-- ============================================================
+--
+-- Drops ALL existing RLS policies on tenant-scoped tables and replaces
+-- them with new policies that enforce sucursal_id = current_sucursal_id()
+-- filtering for multi-tenant isolation.
+--
+-- Depends on: 057_multi_tenant_schema.sql (current_sucursal_id() function)
+--
+-- Naming convention: mt_<tablename>_<operation>
+-- All policies are PERMISSIVE, TO authenticated.
+-- ============================================================
+
+
+-- ============================================================
+-- 1. CLIENTES
+-- ============================================================
+
+-- Drop all existing policies
+DROP POLICY IF EXISTS "Clientes: lectura para usuarios autenticados" ON clientes;
+DROP POLICY IF EXISTS "Clientes: insercion para admin/preventista" ON clientes;
+DROP POLICY IF EXISTS "Clientes: actualizacion para admin/preventista" ON clientes;
+DROP POLICY IF EXISTS "Clientes: eliminacion solo admin" ON clientes;
+DROP POLICY IF EXISTS "Clientes: transportista ve su zona" ON clientes;
+
+CREATE POLICY mt_clientes_select ON clientes
+  FOR SELECT TO authenticated
+  USING (sucursal_id = current_sucursal_id());
+
+CREATE POLICY mt_clientes_insert ON clientes
+  FOR INSERT TO authenticated
+  WITH CHECK (es_preventista() AND sucursal_id = current_sucursal_id());
+
+CREATE POLICY mt_clientes_update ON clientes
+  FOR UPDATE TO authenticated
+  USING (es_preventista() AND sucursal_id = current_sucursal_id())
+  WITH CHECK (es_preventista() AND sucursal_id = current_sucursal_id());
+
+CREATE POLICY mt_clientes_delete ON clientes
+  FOR DELETE TO authenticated
+  USING (es_admin() AND sucursal_id = current_sucursal_id());
+
+
+-- ============================================================
+-- 2. PRODUCTOS
+-- ============================================================
+
+DROP POLICY IF EXISTS "Productos: lectura para usuarios autenticados" ON productos;
+DROP POLICY IF EXISTS "Productos: insercion solo admin" ON productos;
+DROP POLICY IF EXISTS "Productos: actualizacion solo admin" ON productos;
+DROP POLICY IF EXISTS "Productos: eliminacion solo admin" ON productos;
+
+CREATE POLICY mt_productos_select ON productos
+  FOR SELECT TO authenticated
+  USING (sucursal_id = current_sucursal_id());
+
+CREATE POLICY mt_productos_insert ON productos
+  FOR INSERT TO authenticated
+  WITH CHECK (es_admin() AND sucursal_id = current_sucursal_id());
+
+CREATE POLICY mt_productos_update ON productos
+  FOR UPDATE TO authenticated
+  USING (
+    (es_admin() OR EXISTS (SELECT 1 FROM perfiles WHERE id = auth.uid() AND rol = 'deposito'))
+    AND sucursal_id = current_sucursal_id()
+  )
+  WITH CHECK (
+    (es_admin() OR EXISTS (SELECT 1 FROM perfiles WHERE id = auth.uid() AND rol = 'deposito'))
+    AND sucursal_id = current_sucursal_id()
+  );
+
+CREATE POLICY mt_productos_delete ON productos
+  FOR DELETE TO authenticated
+  USING (es_admin() AND sucursal_id = current_sucursal_id());
+
+
+-- ============================================================
+-- 3. PEDIDOS
+-- ============================================================
+
+DROP POLICY IF EXISTS "Pedidos: lectura segun rol" ON pedidos;
+DROP POLICY IF EXISTS "Pedidos: insercion para admin/preventista" ON pedidos;
+DROP POLICY IF EXISTS "Pedidos: actualizacion segun rol" ON pedidos;
+DROP POLICY IF EXISTS "Pedidos: eliminacion solo admin" ON pedidos;
+
+CREATE POLICY mt_pedidos_select ON pedidos
+  FOR SELECT TO authenticated
+  USING (
+    (es_encargado_o_admin() OR usuario_id = auth.uid() OR transportista_id = auth.uid())
+    AND sucursal_id = current_sucursal_id()
+  );
+
+CREATE POLICY mt_pedidos_insert ON pedidos
+  FOR INSERT TO authenticated
+  WITH CHECK (es_preventista() AND sucursal_id = current_sucursal_id());
+
+CREATE POLICY mt_pedidos_update ON pedidos
+  FOR UPDATE TO authenticated
+  USING (
+    (es_encargado_o_admin() OR usuario_id = auth.uid() OR transportista_id = auth.uid())
+    AND sucursal_id = current_sucursal_id()
+  )
+  WITH CHECK (
+    (es_encargado_o_admin() OR usuario_id = auth.uid() OR transportista_id = auth.uid())
+    AND sucursal_id = current_sucursal_id()
+  );
+
+CREATE POLICY mt_pedidos_delete ON pedidos
+  FOR DELETE TO authenticated
+  USING (es_admin() AND sucursal_id = current_sucursal_id());
+
+
+-- ============================================================
+-- 4. PEDIDO_ITEMS
+-- ============================================================
+
+DROP POLICY IF EXISTS "PedidoItems: lectura vinculada a pedido" ON pedido_items;
+DROP POLICY IF EXISTS "PedidoItems: insercion para admin/preventista" ON pedido_items;
+DROP POLICY IF EXISTS "PedidoItems: actualizacion para admin/preventista" ON pedido_items;
+DROP POLICY IF EXISTS "PedidoItems: eliminacion solo admin" ON pedido_items;
+
+CREATE POLICY mt_pedido_items_select ON pedido_items
+  FOR SELECT TO authenticated
+  USING (
+    EXISTS (
+      SELECT 1 FROM pedidos p
+      WHERE p.id = pedido_items.pedido_id
+        AND (es_encargado_o_admin() OR p.usuario_id = auth.uid() OR p.transportista_id = auth.uid())
+    )
+    AND sucursal_id = current_sucursal_id()
+  );
+
+CREATE POLICY mt_pedido_items_insert ON pedido_items
+  FOR INSERT TO authenticated
+  WITH CHECK (es_preventista() AND sucursal_id = current_sucursal_id());
+
+CREATE POLICY mt_pedido_items_update ON pedido_items
+  FOR UPDATE TO authenticated
+  USING (es_preventista() AND sucursal_id = current_sucursal_id())
+  WITH CHECK (es_preventista() AND sucursal_id = current_sucursal_id());
+
+CREATE POLICY mt_pedido_items_delete ON pedido_items
+  FOR DELETE TO authenticated
+  USING (es_admin() AND sucursal_id = current_sucursal_id());
+
+
+-- ============================================================
+-- 5. PEDIDO_HISTORIAL
+-- ============================================================
+
+DROP POLICY IF EXISTS "PedidoHistorial: lectura vinculada a pedido" ON pedido_historial;
+DROP POLICY IF EXISTS "PedidoHistorial: insercion usuarios autenticados" ON pedido_historial;
+
+CREATE POLICY mt_pedido_historial_select ON pedido_historial
+  FOR SELECT TO authenticated
+  USING (sucursal_id = current_sucursal_id());
+
+CREATE POLICY mt_pedido_historial_insert ON pedido_historial
+  FOR INSERT TO authenticated
+  WITH CHECK (sucursal_id = current_sucursal_id());
+
+CREATE POLICY mt_pedido_historial_update ON pedido_historial
+  FOR UPDATE TO authenticated
+  USING (es_admin() AND sucursal_id = current_sucursal_id())
+  WITH CHECK (es_admin() AND sucursal_id = current_sucursal_id());
+
+CREATE POLICY mt_pedido_historial_delete ON pedido_historial
+  FOR DELETE TO authenticated
+  USING (es_admin() AND sucursal_id = current_sucursal_id());
+
+
+-- ============================================================
+-- 6. PAGOS
+-- ============================================================
+
+DROP POLICY IF EXISTS "Allow authenticated users to view payments" ON pagos;
+DROP POLICY IF EXISTS "Allow authenticated users to insert payments" ON pagos;
+DROP POLICY IF EXISTS "Allow authenticated users to update payments" ON pagos;
+DROP POLICY IF EXISTS "Allow authenticated users to delete payments" ON pagos;
+DROP POLICY IF EXISTS "Pagos: lectura para admin/preventista" ON pagos;
+DROP POLICY IF EXISTS "Pagos: insercion para admin/preventista" ON pagos;
+DROP POLICY IF EXISTS "Pagos: actualizacion solo admin" ON pagos;
+DROP POLICY IF EXISTS "Pagos: eliminacion solo admin" ON pagos;
+DROP POLICY IF EXISTS "Pagos: actualizacion para admin/encargado" ON pagos;
+
+CREATE POLICY mt_pagos_select ON pagos
+  FOR SELECT TO authenticated
+  USING (es_preventista() AND sucursal_id = current_sucursal_id());
+
+CREATE POLICY mt_pagos_insert ON pagos
+  FOR INSERT TO authenticated
+  WITH CHECK (es_preventista() AND sucursal_id = current_sucursal_id());
+
+CREATE POLICY mt_pagos_update ON pagos
+  FOR UPDATE TO authenticated
+  USING (es_admin() AND sucursal_id = current_sucursal_id())
+  WITH CHECK (es_admin() AND sucursal_id = current_sucursal_id());
+
+CREATE POLICY mt_pagos_delete ON pagos
+  FOR DELETE TO authenticated
+  USING (es_admin() AND sucursal_id = current_sucursal_id());
+
+
+-- ============================================================
+-- 7. COMPRAS
+-- ============================================================
+
+DROP POLICY IF EXISTS "Admin full access compras" ON compras;
+DROP POLICY IF EXISTS "Users can view compras" ON compras;
+DROP POLICY IF EXISTS "Compras: lectura solo admin" ON compras;
+DROP POLICY IF EXISTS "Compras: insercion solo admin" ON compras;
+DROP POLICY IF EXISTS "Compras: actualizacion solo admin" ON compras;
+DROP POLICY IF EXISTS "Compras: eliminacion solo admin" ON compras;
+
+CREATE POLICY mt_compras_select ON compras
+  FOR SELECT TO authenticated
+  USING (
+    (es_admin() OR EXISTS (SELECT 1 FROM perfiles WHERE id = auth.uid() AND rol = 'deposito'))
+    AND sucursal_id = current_sucursal_id()
+  );
+
+CREATE POLICY mt_compras_insert ON compras
+  FOR INSERT TO authenticated
+  WITH CHECK (
+    (es_admin() OR EXISTS (SELECT 1 FROM perfiles WHERE id = auth.uid() AND rol = 'deposito'))
+    AND sucursal_id = current_sucursal_id()
+  );
+
+CREATE POLICY mt_compras_update ON compras
+  FOR UPDATE TO authenticated
+  USING (es_admin() AND sucursal_id = current_sucursal_id())
+  WITH CHECK (es_admin() AND sucursal_id = current_sucursal_id());
+
+CREATE POLICY mt_compras_delete ON compras
+  FOR DELETE TO authenticated
+  USING (es_admin() AND sucursal_id = current_sucursal_id());
+
+
+-- ============================================================
+-- 8. COMPRA_ITEMS
+-- ============================================================
+
+DROP POLICY IF EXISTS "Admin full access compra_items" ON compra_items;
+DROP POLICY IF EXISTS "Users can view compra_items" ON compra_items;
+DROP POLICY IF EXISTS "CompraItems: lectura solo admin" ON compra_items;
+DROP POLICY IF EXISTS "CompraItems: insercion solo admin" ON compra_items;
+DROP POLICY IF EXISTS "CompraItems: actualizacion solo admin" ON compra_items;
+DROP POLICY IF EXISTS "CompraItems: eliminacion solo admin" ON compra_items;
+
+CREATE POLICY mt_compra_items_select ON compra_items
+  FOR SELECT TO authenticated
+  USING (
+    (es_admin() OR EXISTS (SELECT 1 FROM perfiles WHERE id = auth.uid() AND rol = 'deposito'))
+    AND sucursal_id = current_sucursal_id()
+  );
+
+CREATE POLICY mt_compra_items_insert ON compra_items
+  FOR INSERT TO authenticated
+  WITH CHECK (
+    (es_admin() OR EXISTS (SELECT 1 FROM perfiles WHERE id = auth.uid() AND rol = 'deposito'))
+    AND sucursal_id = current_sucursal_id()
+  );
+
+CREATE POLICY mt_compra_items_update ON compra_items
+  FOR UPDATE TO authenticated
+  USING (es_admin() AND sucursal_id = current_sucursal_id())
+  WITH CHECK (es_admin() AND sucursal_id = current_sucursal_id());
+
+CREATE POLICY mt_compra_items_delete ON compra_items
+  FOR DELETE TO authenticated
+  USING (es_admin() AND sucursal_id = current_sucursal_id());
+
+
+-- ============================================================
+-- 9. PROVEEDORES
+-- ============================================================
+
+DROP POLICY IF EXISTS "Admin full access proveedores" ON proveedores;
+DROP POLICY IF EXISTS "Users can view proveedores" ON proveedores;
+DROP POLICY IF EXISTS "Proveedores: lectura solo admin" ON proveedores;
+DROP POLICY IF EXISTS "Proveedores: insercion solo admin" ON proveedores;
+DROP POLICY IF EXISTS "Proveedores: actualizacion solo admin" ON proveedores;
+DROP POLICY IF EXISTS "Proveedores: eliminacion solo admin" ON proveedores;
+
+CREATE POLICY mt_proveedores_select ON proveedores
+  FOR SELECT TO authenticated
+  USING (
+    (es_admin() OR EXISTS (SELECT 1 FROM perfiles WHERE id = auth.uid() AND rol = 'deposito'))
+    AND sucursal_id = current_sucursal_id()
+  );
+
+CREATE POLICY mt_proveedores_insert ON proveedores
+  FOR INSERT TO authenticated
+  WITH CHECK (es_admin() AND sucursal_id = current_sucursal_id());
+
+CREATE POLICY mt_proveedores_update ON proveedores
+  FOR UPDATE TO authenticated
+  USING (es_admin() AND sucursal_id = current_sucursal_id())
+  WITH CHECK (es_admin() AND sucursal_id = current_sucursal_id());
+
+CREATE POLICY mt_proveedores_delete ON proveedores
+  FOR DELETE TO authenticated
+  USING (es_admin() AND sucursal_id = current_sucursal_id());
+
+
+-- ============================================================
+-- 10. MERMAS_STOCK
+-- ============================================================
+
+DROP POLICY IF EXISTS "Admin full access mermas" ON mermas_stock;
+DROP POLICY IF EXISTS "Users can view mermas" ON mermas_stock;
+DROP POLICY IF EXISTS "Mermas: lectura para admin/transportista" ON mermas_stock;
+DROP POLICY IF EXISTS "Mermas: insercion para admin/transportista" ON mermas_stock;
+DROP POLICY IF EXISTS "Mermas: actualizacion solo admin" ON mermas_stock;
+DROP POLICY IF EXISTS "Mermas: eliminacion solo admin" ON mermas_stock;
+
+CREATE POLICY mt_mermas_stock_select ON mermas_stock
+  FOR SELECT TO authenticated
+  USING (
+    (es_admin() OR es_transportista())
+    AND sucursal_id = current_sucursal_id()
+  );
+
+CREATE POLICY mt_mermas_stock_insert ON mermas_stock
+  FOR INSERT TO authenticated
+  WITH CHECK (
+    (es_admin() OR es_transportista())
+    AND sucursal_id = current_sucursal_id()
+  );
+
+CREATE POLICY mt_mermas_stock_update ON mermas_stock
+  FOR UPDATE TO authenticated
+  USING (es_admin() AND sucursal_id = current_sucursal_id())
+  WITH CHECK (es_admin() AND sucursal_id = current_sucursal_id());
+
+CREATE POLICY mt_mermas_stock_delete ON mermas_stock
+  FOR DELETE TO authenticated
+  USING (es_admin() AND sucursal_id = current_sucursal_id());
+
+
+-- ============================================================
+-- 11. STOCK_HISTORICO
+-- ============================================================
+
+DROP POLICY IF EXISTS "stock_historico_select_authenticated" ON stock_historico;
+DROP POLICY IF EXISTS "stock_historico_insert_admin" ON stock_historico;
+DROP POLICY IF EXISTS "stock_historico_insert" ON stock_historico;
+
+CREATE POLICY mt_stock_historico_select ON stock_historico
+  FOR SELECT TO authenticated
+  USING (sucursal_id = current_sucursal_id());
+
+CREATE POLICY mt_stock_historico_insert ON stock_historico
+  FOR INSERT TO authenticated
+  WITH CHECK (
+    (es_admin() OR EXISTS (SELECT 1 FROM perfiles WHERE id = auth.uid() AND rol = 'deposito'))
+    AND sucursal_id = current_sucursal_id()
+  );
+
+
+-- ============================================================
+-- 12. RECORRIDOS
+-- ============================================================
+
+DROP POLICY IF EXISTS "Admins pueden ver todos los recorridos" ON recorridos;
+DROP POLICY IF EXISTS "Transportistas pueden ver sus recorridos" ON recorridos;
+DROP POLICY IF EXISTS "Admins pueden insertar recorridos" ON recorridos;
+DROP POLICY IF EXISTS "Admins pueden actualizar recorridos" ON recorridos;
+
+CREATE POLICY mt_recorridos_select ON recorridos
+  FOR SELECT TO authenticated
+  USING (
+    (es_admin() OR transportista_id = auth.uid())
+    AND sucursal_id = current_sucursal_id()
+  );
+
+CREATE POLICY mt_recorridos_insert ON recorridos
+  FOR INSERT TO authenticated
+  WITH CHECK (es_admin() AND sucursal_id = current_sucursal_id());
+
+CREATE POLICY mt_recorridos_update ON recorridos
+  FOR UPDATE TO authenticated
+  USING (
+    (es_admin() OR transportista_id = auth.uid())
+    AND sucursal_id = current_sucursal_id()
+  )
+  WITH CHECK (
+    (es_admin() OR transportista_id = auth.uid())
+    AND sucursal_id = current_sucursal_id()
+  );
+
+CREATE POLICY mt_recorridos_delete ON recorridos
+  FOR DELETE TO authenticated
+  USING (es_admin() AND sucursal_id = current_sucursal_id());
+
+
+-- ============================================================
+-- 13. RECORRIDO_PEDIDOS
+-- ============================================================
+
+DROP POLICY IF EXISTS "Admins pueden ver detalles de recorridos" ON recorrido_pedidos;
+DROP POLICY IF EXISTS "Transportistas pueden ver detalles de sus recorridos" ON recorrido_pedidos;
+DROP POLICY IF EXISTS "Admins pueden insertar detalles de recorridos" ON recorrido_pedidos;
+DROP POLICY IF EXISTS "Admins pueden actualizar detalles de recorridos" ON recorrido_pedidos;
+
+CREATE POLICY mt_recorrido_pedidos_select ON recorrido_pedidos
+  FOR SELECT TO authenticated
+  USING (
+    (
+      es_admin()
+      OR EXISTS (
+        SELECT 1 FROM recorridos r
+        WHERE r.id = recorrido_pedidos.recorrido_id
+          AND r.transportista_id = auth.uid()
+      )
+    )
+    AND sucursal_id = current_sucursal_id()
+  );
+
+CREATE POLICY mt_recorrido_pedidos_insert ON recorrido_pedidos
+  FOR INSERT TO authenticated
+  WITH CHECK (es_admin() AND sucursal_id = current_sucursal_id());
+
+CREATE POLICY mt_recorrido_pedidos_update ON recorrido_pedidos
+  FOR UPDATE TO authenticated
+  USING (es_admin() AND sucursal_id = current_sucursal_id())
+  WITH CHECK (es_admin() AND sucursal_id = current_sucursal_id());
+
+
+-- ============================================================
+-- 14. RENDICIONES
+-- ============================================================
+
+DROP POLICY IF EXISTS "Admin full access rendiciones" ON rendiciones;
+DROP POLICY IF EXISTS "Transportista ve sus rendiciones" ON rendiciones;
+DROP POLICY IF EXISTS "Transportista crea sus rendiciones" ON rendiciones;
+DROP POLICY IF EXISTS "Transportista actualiza sus rendiciones pendientes" ON rendiciones;
+
+CREATE POLICY mt_rendiciones_select ON rendiciones
+  FOR SELECT TO authenticated
+  USING (
+    (es_admin() OR transportista_id = auth.uid())
+    AND sucursal_id = current_sucursal_id()
+  );
+
+CREATE POLICY mt_rendiciones_insert ON rendiciones
+  FOR INSERT TO authenticated
+  WITH CHECK (
+    (es_admin() OR transportista_id = auth.uid())
+    AND sucursal_id = current_sucursal_id()
+  );
+
+CREATE POLICY mt_rendiciones_update ON rendiciones
+  FOR UPDATE TO authenticated
+  USING (
+    (es_admin() OR (transportista_id = auth.uid() AND estado = 'pendiente'))
+    AND sucursal_id = current_sucursal_id()
+  )
+  WITH CHECK (
+    (es_admin() OR (transportista_id = auth.uid() AND estado = 'pendiente'))
+    AND sucursal_id = current_sucursal_id()
+  );
+
+CREATE POLICY mt_rendiciones_delete ON rendiciones
+  FOR DELETE TO authenticated
+  USING (es_admin() AND sucursal_id = current_sucursal_id());
+
+
+-- ============================================================
+-- 15. RENDICION_ITEMS
+-- ============================================================
+
+DROP POLICY IF EXISTS "Admin full access rendicion_items" ON rendicion_items;
+DROP POLICY IF EXISTS "Transportista ve items de sus rendiciones" ON rendicion_items;
+DROP POLICY IF EXISTS "Transportista crea items en sus rendiciones" ON rendicion_items;
+
+CREATE POLICY mt_rendicion_items_select ON rendicion_items
+  FOR SELECT TO authenticated
+  USING (
+    (
+      es_admin()
+      OR EXISTS (
+        SELECT 1 FROM rendiciones r
+        WHERE r.id = rendicion_items.rendicion_id
+          AND r.transportista_id = auth.uid()
+      )
+    )
+    AND sucursal_id = current_sucursal_id()
+  );
+
+CREATE POLICY mt_rendicion_items_insert ON rendicion_items
+  FOR INSERT TO authenticated
+  WITH CHECK (
+    (
+      es_admin()
+      OR EXISTS (
+        SELECT 1 FROM rendiciones r
+        WHERE r.id = rendicion_items.rendicion_id
+          AND r.transportista_id = auth.uid()
+      )
+    )
+    AND sucursal_id = current_sucursal_id()
+  );
+
+
+-- ============================================================
+-- 16. RENDICION_AJUSTES
+-- ============================================================
+
+DROP POLICY IF EXISTS "Admin full access rendicion_ajustes" ON rendicion_ajustes;
+DROP POLICY IF EXISTS "Transportista ve ajustes de sus rendiciones" ON rendicion_ajustes;
+DROP POLICY IF EXISTS "Transportista crea ajustes en sus rendiciones" ON rendicion_ajustes;
+
+CREATE POLICY mt_rendicion_ajustes_select ON rendicion_ajustes
+  FOR SELECT TO authenticated
+  USING (
+    (
+      es_admin()
+      OR EXISTS (
+        SELECT 1 FROM rendiciones r
+        WHERE r.id = rendicion_ajustes.rendicion_id
+          AND r.transportista_id = auth.uid()
+      )
+    )
+    AND sucursal_id = current_sucursal_id()
+  );
+
+CREATE POLICY mt_rendicion_ajustes_insert ON rendicion_ajustes
+  FOR INSERT TO authenticated
+  WITH CHECK (
+    (
+      es_admin()
+      OR EXISTS (
+        SELECT 1 FROM rendiciones r
+        WHERE r.id = rendicion_ajustes.rendicion_id
+          AND r.transportista_id = auth.uid()
+      )
+    )
+    AND sucursal_id = current_sucursal_id()
+  );
+
+
+-- ============================================================
+-- 17. SALVEDADES_ITEMS
+-- ============================================================
+
+DROP POLICY IF EXISTS "Admin full access salvedades" ON salvedades_items;
+DROP POLICY IF EXISTS "Transportista ve salvedades de sus pedidos" ON salvedades_items;
+DROP POLICY IF EXISTS "Transportista crea salvedades" ON salvedades_items;
+DROP POLICY IF EXISTS "Preventista ve salvedades de sus pedidos" ON salvedades_items;
+
+CREATE POLICY mt_salvedades_items_select ON salvedades_items
+  FOR SELECT TO authenticated
+  USING (
+    (
+      es_admin()
+      OR EXISTS (
+        SELECT 1 FROM pedidos p
+        WHERE p.id = salvedades_items.pedido_id
+          AND (p.usuario_id = auth.uid() OR p.transportista_id = auth.uid())
+      )
+    )
+    AND sucursal_id = current_sucursal_id()
+  );
+
+CREATE POLICY mt_salvedades_items_insert ON salvedades_items
+  FOR INSERT TO authenticated
+  WITH CHECK (
+    (es_admin() OR es_transportista())
+    AND sucursal_id = current_sucursal_id()
+  );
+
+CREATE POLICY mt_salvedades_items_update ON salvedades_items
+  FOR UPDATE TO authenticated
+  USING (es_admin() AND sucursal_id = current_sucursal_id())
+  WITH CHECK (es_admin() AND sucursal_id = current_sucursal_id());
+
+CREATE POLICY mt_salvedades_items_delete ON salvedades_items
+  FOR DELETE TO authenticated
+  USING (es_admin() AND sucursal_id = current_sucursal_id());
+
+
+-- ============================================================
+-- 18. SALVEDAD_HISTORIAL
+-- ============================================================
+
+DROP POLICY IF EXISTS "Admin full access salvedad_historial" ON salvedad_historial;
+DROP POLICY IF EXISTS "Ver historial de salvedades accesibles" ON salvedad_historial;
+DROP POLICY IF EXISTS "Insertar historial" ON salvedad_historial;
+
+CREATE POLICY mt_salvedad_historial_select ON salvedad_historial
+  FOR SELECT TO authenticated
+  USING (
+    (
+      es_admin()
+      OR EXISTS (
+        SELECT 1 FROM pedidos p
+        WHERE p.id = salvedad_historial.pedido_id
+          AND (p.usuario_id = auth.uid() OR p.transportista_id = auth.uid())
+      )
+    )
+    AND sucursal_id = current_sucursal_id()
+  );
+
+CREATE POLICY mt_salvedad_historial_insert ON salvedad_historial
+  FOR INSERT TO authenticated
+  WITH CHECK (
+    (es_admin() OR es_transportista())
+    AND sucursal_id = current_sucursal_id()
+  );
+
+
+-- ============================================================
+-- 19. NOTAS_CREDITO
+-- ============================================================
+
+DROP POLICY IF EXISTS "admin_notas_credito" ON notas_credito;
+DROP POLICY IF EXISTS "read_notas_credito" ON notas_credito;
+
+CREATE POLICY mt_notas_credito_select ON notas_credito
+  FOR SELECT TO authenticated
+  USING (sucursal_id = current_sucursal_id());
+
+CREATE POLICY mt_notas_credito_all ON notas_credito
+  FOR ALL TO authenticated
+  USING (es_admin() AND sucursal_id = current_sucursal_id())
+  WITH CHECK (es_admin() AND sucursal_id = current_sucursal_id());
+
+
+-- ============================================================
+-- 20. NOTA_CREDITO_ITEMS
+-- ============================================================
+
+DROP POLICY IF EXISTS "admin_nota_credito_items" ON nota_credito_items;
+DROP POLICY IF EXISTS "read_nota_credito_items" ON nota_credito_items;
+
+CREATE POLICY mt_nota_credito_items_select ON nota_credito_items
+  FOR SELECT TO authenticated
+  USING (sucursal_id = current_sucursal_id());
+
+CREATE POLICY mt_nota_credito_items_all ON nota_credito_items
+  FOR ALL TO authenticated
+  USING (es_admin() AND sucursal_id = current_sucursal_id())
+  WITH CHECK (es_admin() AND sucursal_id = current_sucursal_id());
+
+
+-- ============================================================
+-- 21. TRANSFERENCIAS_STOCK (uses tenant_sucursal_id!)
+-- ============================================================
+
+DROP POLICY IF EXISTS "admin_transferencias_stock" ON transferencias_stock;
+DROP POLICY IF EXISTS "read_transferencias_stock" ON transferencias_stock;
+
+CREATE POLICY mt_transferencias_stock_select ON transferencias_stock
+  FOR SELECT TO authenticated
+  USING (tenant_sucursal_id = current_sucursal_id());
+
+CREATE POLICY mt_transferencias_stock_all ON transferencias_stock
+  FOR ALL TO authenticated
+  USING (es_admin() AND tenant_sucursal_id = current_sucursal_id())
+  WITH CHECK (es_admin() AND tenant_sucursal_id = current_sucursal_id());
+
+
+-- ============================================================
+-- 22. TRANSFERENCIA_ITEMS
+-- ============================================================
+
+DROP POLICY IF EXISTS "admin_transferencia_items" ON transferencia_items;
+DROP POLICY IF EXISTS "read_transferencia_items" ON transferencia_items;
+
+CREATE POLICY mt_transferencia_items_select ON transferencia_items
+  FOR SELECT TO authenticated
+  USING (sucursal_id = current_sucursal_id());
+
+CREATE POLICY mt_transferencia_items_all ON transferencia_items
+  FOR ALL TO authenticated
+  USING (es_admin() AND sucursal_id = current_sucursal_id())
+  WITH CHECK (es_admin() AND sucursal_id = current_sucursal_id());
+
+
+-- ============================================================
+-- 23. PROMOCIONES
+-- ============================================================
+
+DROP POLICY IF EXISTS "Admin full access promociones" ON promociones;
+DROP POLICY IF EXISTS "Users can view promociones" ON promociones;
+
+CREATE POLICY mt_promociones_select ON promociones
+  FOR SELECT TO authenticated
+  USING (sucursal_id = current_sucursal_id());
+
+CREATE POLICY mt_promociones_all ON promociones
+  FOR ALL TO authenticated
+  USING (es_admin() AND sucursal_id = current_sucursal_id())
+  WITH CHECK (es_admin() AND sucursal_id = current_sucursal_id());
+
+
+-- ============================================================
+-- 24. PROMOCION_PRODUCTOS
+-- ============================================================
+
+DROP POLICY IF EXISTS "Admin full access promocion_productos" ON promocion_productos;
+DROP POLICY IF EXISTS "Users can view promocion_productos" ON promocion_productos;
+
+CREATE POLICY mt_promocion_productos_select ON promocion_productos
+  FOR SELECT TO authenticated
+  USING (sucursal_id = current_sucursal_id());
+
+CREATE POLICY mt_promocion_productos_all ON promocion_productos
+  FOR ALL TO authenticated
+  USING (es_admin() AND sucursal_id = current_sucursal_id())
+  WITH CHECK (es_admin() AND sucursal_id = current_sucursal_id());
+
+
+-- ============================================================
+-- 25. PROMOCION_REGLAS
+-- ============================================================
+
+DROP POLICY IF EXISTS "Admin full access promocion_reglas" ON promocion_reglas;
+DROP POLICY IF EXISTS "Users can view promocion_reglas" ON promocion_reglas;
+
+CREATE POLICY mt_promocion_reglas_select ON promocion_reglas
+  FOR SELECT TO authenticated
+  USING (sucursal_id = current_sucursal_id());
+
+CREATE POLICY mt_promocion_reglas_all ON promocion_reglas
+  FOR ALL TO authenticated
+  USING (es_admin() AND sucursal_id = current_sucursal_id())
+  WITH CHECK (es_admin() AND sucursal_id = current_sucursal_id());
+
+
+-- ============================================================
+-- 26. PROMO_AJUSTES
+-- ============================================================
+
+DROP POLICY IF EXISTS "Admin full access promo_ajustes" ON promo_ajustes;
+DROP POLICY IF EXISTS "Users can view promo_ajustes" ON promo_ajustes;
+
+CREATE POLICY mt_promo_ajustes_select ON promo_ajustes
+  FOR SELECT TO authenticated
+  USING (sucursal_id = current_sucursal_id());
+
+CREATE POLICY mt_promo_ajustes_all ON promo_ajustes
+  FOR ALL TO authenticated
+  USING (es_admin() AND sucursal_id = current_sucursal_id())
+  WITH CHECK (es_admin() AND sucursal_id = current_sucursal_id());
+
+
+-- ============================================================
+-- 27. GRUPOS_PRECIO
+-- ============================================================
+
+DROP POLICY IF EXISTS "Admin full access grupos_precio" ON grupos_precio;
+DROP POLICY IF EXISTS "Users can view grupos_precio" ON grupos_precio;
+
+CREATE POLICY mt_grupos_precio_select ON grupos_precio
+  FOR SELECT TO authenticated
+  USING (sucursal_id = current_sucursal_id());
+
+CREATE POLICY mt_grupos_precio_all ON grupos_precio
+  FOR ALL TO authenticated
+  USING (es_admin() AND sucursal_id = current_sucursal_id())
+  WITH CHECK (es_admin() AND sucursal_id = current_sucursal_id());
+
+
+-- ============================================================
+-- 28. GRUPO_PRECIO_PRODUCTOS
+-- ============================================================
+
+DROP POLICY IF EXISTS "Admin full access grupo_precio_productos" ON grupo_precio_productos;
+DROP POLICY IF EXISTS "Users can view grupo_precio_productos" ON grupo_precio_productos;
+
+CREATE POLICY mt_grupo_precio_productos_select ON grupo_precio_productos
+  FOR SELECT TO authenticated
+  USING (sucursal_id = current_sucursal_id());
+
+CREATE POLICY mt_grupo_precio_productos_all ON grupo_precio_productos
+  FOR ALL TO authenticated
+  USING (es_admin() AND sucursal_id = current_sucursal_id())
+  WITH CHECK (es_admin() AND sucursal_id = current_sucursal_id());
+
+
+-- ============================================================
+-- 29. GRUPO_PRECIO_ESCALAS
+-- ============================================================
+
+DROP POLICY IF EXISTS "Admin full access grupo_precio_escalas" ON grupo_precio_escalas;
+DROP POLICY IF EXISTS "Users can view grupo_precio_escalas" ON grupo_precio_escalas;
+
+CREATE POLICY mt_grupo_precio_escalas_select ON grupo_precio_escalas
+  FOR SELECT TO authenticated
+  USING (sucursal_id = current_sucursal_id());
+
+CREATE POLICY mt_grupo_precio_escalas_all ON grupo_precio_escalas
+  FOR ALL TO authenticated
+  USING (es_admin() AND sucursal_id = current_sucursal_id())
+  WITH CHECK (es_admin() AND sucursal_id = current_sucursal_id());
+
+
+-- ============================================================
+-- 30. PEDIDOS_ELIMINADOS
+-- ============================================================
+
+DROP POLICY IF EXISTS "Admin puede ver pedidos eliminados" ON pedidos_eliminados;
+DROP POLICY IF EXISTS "Admin puede insertar pedidos eliminados" ON pedidos_eliminados;
+DROP POLICY IF EXISTS "PedidosEliminados: lectura para admin/encargado" ON pedidos_eliminados;
+
+CREATE POLICY mt_pedidos_eliminados_select ON pedidos_eliminados
+  FOR SELECT TO authenticated
+  USING (es_admin() AND sucursal_id = current_sucursal_id());
+
+CREATE POLICY mt_pedidos_eliminados_insert ON pedidos_eliminados
+  FOR INSERT TO authenticated
+  WITH CHECK (es_admin() AND sucursal_id = current_sucursal_id());
+
+
+-- ============================================================
+-- 31. AUDIT_LOGS
+-- ============================================================
+
+DROP POLICY IF EXISTS "audit_logs_insert" ON audit_logs;
+
+CREATE POLICY mt_audit_logs_select ON audit_logs
+  FOR SELECT TO authenticated
+  USING (es_admin() AND sucursal_id = current_sucursal_id());
+
+CREATE POLICY mt_audit_logs_insert ON audit_logs
+  FOR INSERT TO authenticated
+  WITH CHECK (es_admin() AND sucursal_id = current_sucursal_id());
+
+
+-- ============================================================
+-- 32. ZONAS
+-- ============================================================
+
+DROP POLICY IF EXISTS "Zonas: lectura usuarios autenticados" ON zonas;
+DROP POLICY IF EXISTS "Zonas: modificacion solo admin" ON zonas;
+DROP POLICY IF EXISTS "zonas_select_authenticated" ON zonas;
+DROP POLICY IF EXISTS "zonas_insert_authenticated" ON zonas;
+DROP POLICY IF EXISTS "zonas_update_authenticated" ON zonas;
+
+CREATE POLICY mt_zonas_select ON zonas
+  FOR SELECT TO authenticated
+  USING (sucursal_id = current_sucursal_id());
+
+CREATE POLICY mt_zonas_insert ON zonas
+  FOR INSERT TO authenticated
+  WITH CHECK (es_admin() AND sucursal_id = current_sucursal_id());
+
+CREATE POLICY mt_zonas_update ON zonas
+  FOR UPDATE TO authenticated
+  USING (es_admin() AND sucursal_id = current_sucursal_id())
+  WITH CHECK (es_admin() AND sucursal_id = current_sucursal_id());
+
+
+-- ============================================================
+-- 33. PREVENTISTA_ZONAS
+-- ============================================================
+
+DROP POLICY IF EXISTS "prev_zonas_select_authenticated" ON preventista_zonas;
+DROP POLICY IF EXISTS "prev_zonas_insert_authenticated" ON preventista_zonas;
+DROP POLICY IF EXISTS "prev_zonas_update_authenticated" ON preventista_zonas;
+DROP POLICY IF EXISTS "prev_zonas_delete_authenticated" ON preventista_zonas;
+
+CREATE POLICY mt_preventista_zonas_select ON preventista_zonas
+  FOR SELECT TO authenticated
+  USING (sucursal_id = current_sucursal_id());
+
+CREATE POLICY mt_preventista_zonas_insert ON preventista_zonas
+  FOR INSERT TO authenticated
+  WITH CHECK (es_admin() AND sucursal_id = current_sucursal_id());
+
+CREATE POLICY mt_preventista_zonas_update ON preventista_zonas
+  FOR UPDATE TO authenticated
+  USING (es_admin() AND sucursal_id = current_sucursal_id())
+  WITH CHECK (es_admin() AND sucursal_id = current_sucursal_id());
+
+CREATE POLICY mt_preventista_zonas_delete ON preventista_zonas
+  FOR DELETE TO authenticated
+  USING (es_admin() AND sucursal_id = current_sucursal_id());
+
+
+-- ============================================================
+-- 34. HISTORIAL_CAMBIOS
+-- ============================================================
+
+DROP POLICY IF EXISTS "Sistema puede insertar historial" ON historial_cambios;
+
+CREATE POLICY mt_historial_cambios_select ON historial_cambios
+  FOR SELECT TO authenticated
+  USING (es_admin() AND sucursal_id = current_sucursal_id());
+
+CREATE POLICY mt_historial_cambios_insert ON historial_cambios
+  FOR INSERT TO authenticated
+  WITH CHECK (es_admin() AND sucursal_id = current_sucursal_id());

--- a/migrations/059_multi_tenant_rpcs.sql
+++ b/migrations/059_multi_tenant_rpcs.sql
@@ -1,0 +1,2171 @@
+-- Migration 059: Multi-tenant RPC Functions
+--
+-- Makes ALL RPC functions multi-tenant aware using current_sucursal_id().
+--
+-- Why: RPCs use SECURITY DEFINER which BYPASSES RLS policies. Even though
+-- migration 058 added RLS policies filtering by sucursal_id, any data
+-- access through RPCs would still cross tenant boundaries without this fix.
+--
+-- Pattern for each function:
+--   1. Declare v_sucursal BIGINT := current_sucursal_id();
+--   2. Guard: IF v_sucursal IS NULL THEN return error
+--   3. Add AND sucursal_id = v_sucursal to all SELECT/UPDATE/DELETE
+--   4. Add sucursal_id = v_sucursal to all INSERT
+--
+-- Exception: transferencias_stock uses tenant_sucursal_id instead of sucursal_id
+
+-- ============================================================
+-- 1. crear_pedido_completo
+-- ============================================================
+DROP FUNCTION IF EXISTS public.crear_pedido_completo(bigint, numeric, uuid, jsonb, text, text, text, date, text, numeric, numeric, date);
+
+CREATE FUNCTION public.crear_pedido_completo(
+  p_cliente_id bigint,
+  p_total numeric,
+  p_usuario_id uuid,
+  p_items jsonb,
+  p_notas text DEFAULT NULL::text,
+  p_forma_pago text DEFAULT 'efectivo'::text,
+  p_estado_pago text DEFAULT 'pendiente'::text,
+  p_fecha date DEFAULT CURRENT_DATE,
+  p_tipo_factura text DEFAULT 'ZZ',
+  p_total_neto numeric DEFAULT NULL,
+  p_total_iva numeric DEFAULT 0,
+  p_fecha_entrega_programada date DEFAULT NULL
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $function$
+DECLARE
+  v_sucursal BIGINT := current_sucursal_id();
+  v_pedido_id INT;
+  item JSONB;
+  v_producto_id INT;
+  v_cantidad INT;
+  v_precio_unitario DECIMAL;
+  v_es_bonificacion BOOLEAN;
+  v_promocion_id BIGINT;
+  v_neto_unitario DECIMAL;
+  v_iva_unitario DECIMAL;
+  v_imp_internos_unitario DECIMAL;
+  v_porcentaje_iva DECIMAL;
+  v_stock_actual INT;
+  v_producto_nombre TEXT;
+  errores TEXT[] := '{}';
+  v_user_role TEXT;
+  v_cantidades_totales JSONB := '{}'::JSONB;
+  v_cant_acumulada INT;
+  v_fecha_entrega DATE;
+BEGIN
+  -- Multi-tenant guard
+  IF v_sucursal IS NULL THEN
+    RETURN jsonb_build_object('success', false, 'errores', jsonb_build_array('No se pudo determinar la sucursal activa'));
+  END IF;
+
+  -- Auth check: verify p_usuario_id matches the authenticated user
+  IF p_usuario_id IS DISTINCT FROM auth.uid() THEN
+    RETURN jsonb_build_object('success', false, 'errores', jsonb_build_array('ID de usuario no coincide con la sesion autenticada'));
+  END IF;
+
+  SELECT rol INTO v_user_role FROM perfiles WHERE id = p_usuario_id;
+  IF v_user_role IS NULL OR v_user_role NOT IN ('admin', 'preventista') THEN
+    RETURN jsonb_build_object('success', false, 'errores', jsonb_build_array('No tiene permisos para crear pedidos'));
+  END IF;
+
+  -- 1. Acumular cantidades totales por producto (SOLO items no bonificados)
+  FOR item IN SELECT * FROM jsonb_array_elements(p_items)
+  LOOP
+    v_producto_id := (item->>'producto_id')::INT;
+    v_cantidad := (item->>'cantidad')::INT;
+    v_es_bonificacion := COALESCE((item->>'es_bonificacion')::BOOLEAN, false);
+
+    IF v_cantidad IS NULL OR v_cantidad <= 0 THEN
+      errores := array_append(errores, 'Cantidad invalida para producto ID ' || v_producto_id || ': debe ser mayor a 0');
+      CONTINUE;
+    END IF;
+
+    IF NOT v_es_bonificacion THEN
+      v_cant_acumulada := COALESCE((v_cantidades_totales->>v_producto_id::TEXT)::INT, 0) + v_cantidad;
+      v_cantidades_totales := v_cantidades_totales || jsonb_build_object(v_producto_id::TEXT, v_cant_acumulada);
+    END IF;
+  END LOOP;
+
+  -- 2. Verificar stock usando cantidades acumuladas (con bloqueo) -- tenant-scoped
+  FOR v_producto_id IN SELECT (key)::INT FROM jsonb_each_text(v_cantidades_totales)
+  LOOP
+    v_cantidad := (v_cantidades_totales->>v_producto_id::TEXT)::INT;
+
+    SELECT stock, nombre INTO v_stock_actual, v_producto_nombre
+    FROM productos
+    WHERE id = v_producto_id AND sucursal_id = v_sucursal
+    FOR UPDATE;
+
+    IF v_stock_actual IS NULL THEN
+      errores := array_append(errores, 'Producto ID ' || v_producto_id || ' no encontrado');
+    ELSIF v_stock_actual < v_cantidad THEN
+      errores := array_append(errores, v_producto_nombre || ': stock insuficiente (disponible: ' || v_stock_actual || ', solicitado: ' || v_cantidad || ')');
+    END IF;
+  END LOOP;
+
+  IF array_length(errores, 1) > 0 THEN
+    RETURN jsonb_build_object('success', false, 'errores', to_jsonb(errores));
+  END IF;
+
+  -- Calcular fecha de entrega programada (default: dia siguiente a la fecha del pedido)
+  v_fecha_entrega := COALESCE(p_fecha_entrega_programada, (COALESCE(p_fecha, CURRENT_DATE) + INTERVAL '1 day')::date);
+
+  -- 3. Crear el pedido -- tenant-scoped INSERT
+  INSERT INTO pedidos (
+    cliente_id, fecha, total, total_neto, total_iva, tipo_factura,
+    estado, usuario_id, stock_descontado, notas, forma_pago, estado_pago,
+    fecha_entrega_programada, sucursal_id
+  )
+  VALUES (
+    p_cliente_id, p_fecha, p_total,
+    COALESCE(p_total_neto, p_total),
+    COALESCE(p_total_iva, 0),
+    COALESCE(p_tipo_factura, 'ZZ'),
+    'pendiente', p_usuario_id, true, p_notas, p_forma_pago, p_estado_pago,
+    v_fecha_entrega, v_sucursal
+  )
+  RETURNING id INTO v_pedido_id;
+
+  -- 4. Crear items y descontar stock
+  FOR item IN SELECT * FROM jsonb_array_elements(p_items)
+  LOOP
+    v_producto_id := (item->>'producto_id')::INT;
+    v_cantidad := (item->>'cantidad')::INT;
+    v_precio_unitario := (item->>'precio_unitario')::DECIMAL;
+    v_es_bonificacion := COALESCE((item->>'es_bonificacion')::BOOLEAN, false);
+    v_promocion_id := (item->>'promocion_id')::BIGINT;
+    v_neto_unitario := (item->>'neto_unitario')::DECIMAL;
+    v_iva_unitario := COALESCE((item->>'iva_unitario')::DECIMAL, 0);
+    v_imp_internos_unitario := COALESCE((item->>'impuestos_internos_unitario')::DECIMAL, 0);
+    v_porcentaje_iva := COALESCE((item->>'porcentaje_iva')::DECIMAL, 0);
+
+    -- tenant-scoped INSERT
+    INSERT INTO pedido_items (
+      pedido_id, producto_id, cantidad, precio_unitario, subtotal,
+      es_bonificacion, promocion_id,
+      neto_unitario, iva_unitario, impuestos_internos_unitario, porcentaje_iva,
+      sucursal_id
+    )
+    VALUES (
+      v_pedido_id, v_producto_id, v_cantidad, v_precio_unitario,
+      v_cantidad * v_precio_unitario,
+      v_es_bonificacion, v_promocion_id,
+      v_neto_unitario, v_iva_unitario, v_imp_internos_unitario, v_porcentaje_iva,
+      v_sucursal
+    );
+
+    -- Stock: solo descontar si NO es bonificacion -- tenant-scoped
+    IF NOT v_es_bonificacion THEN
+      UPDATE productos SET stock = stock - v_cantidad
+      WHERE id = v_producto_id AND sucursal_id = v_sucursal;
+    END IF;
+
+    -- Contador de promos -- tenant-scoped
+    IF v_es_bonificacion AND v_promocion_id IS NOT NULL THEN
+      UPDATE promociones SET usos_pendientes = usos_pendientes + v_cantidad
+      WHERE id = v_promocion_id AND sucursal_id = v_sucursal;
+    END IF;
+  END LOOP;
+
+  RETURN jsonb_build_object('success', true, 'pedido_id', v_pedido_id);
+END;
+$function$;
+
+
+-- ============================================================
+-- 2. actualizar_pedido_items
+-- ============================================================
+DROP FUNCTION IF EXISTS public.actualizar_pedido_items(bigint, jsonb, uuid);
+
+CREATE FUNCTION public.actualizar_pedido_items(
+  p_pedido_id bigint,
+  p_items_nuevos jsonb,
+  p_usuario_id uuid
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_sucursal BIGINT := current_sucursal_id();
+  v_item_nuevo JSONB;
+  v_producto_id INT;
+  v_cantidad_original INT;
+  v_cantidad_nueva INT;
+  v_diferencia INT;
+  v_es_bonificacion BOOLEAN;
+  v_stock_actual INT;
+  v_producto_nombre TEXT;
+  v_total_nuevo DECIMAL := 0;
+  v_total_neto_nuevo DECIMAL := 0;
+  v_total_iva_nuevo DECIMAL := 0;
+  v_total_anterior DECIMAL;
+  v_errores TEXT[] := '{}';
+  v_items_originales JSONB;
+  v_user_role TEXT;
+  v_neto_unitario DECIMAL;
+  v_iva_unitario DECIMAL;
+  v_imp_internos_unitario DECIMAL;
+  v_porcentaje_iva DECIMAL;
+  v_precio_unitario DECIMAL;
+  v_promocion_id BIGINT;
+BEGIN
+  -- Multi-tenant guard
+  IF v_sucursal IS NULL THEN
+    RETURN jsonb_build_object('success', false, 'errores', ARRAY['No se pudo determinar la sucursal activa']);
+  END IF;
+
+  -- Auth check
+  IF p_usuario_id IS DISTINCT FROM auth.uid() THEN
+    RETURN jsonb_build_object('success', false, 'errores', ARRAY['ID de usuario no coincide con la sesion autenticada']);
+  END IF;
+
+  SELECT rol INTO v_user_role FROM perfiles WHERE id = p_usuario_id;
+  IF v_user_role IS NULL OR v_user_role NOT IN ('admin', 'preventista') THEN
+    RETURN jsonb_build_object('success', false, 'errores', ARRAY['No autorizado']);
+  END IF;
+
+  -- tenant-scoped pedido lookup
+  SELECT total INTO v_total_anterior FROM pedidos WHERE id = p_pedido_id AND sucursal_id = v_sucursal;
+  IF NOT FOUND THEN
+    RETURN jsonb_build_object('success', false, 'errores', ARRAY['Pedido no encontrado']);
+  END IF;
+
+  IF EXISTS (SELECT 1 FROM pedidos WHERE id = p_pedido_id AND sucursal_id = v_sucursal AND estado = 'entregado') THEN
+    RETURN jsonb_build_object('success', false, 'errores', ARRAY['No se puede editar un pedido ya entregado']);
+  END IF;
+
+  -- Save original items for historial -- tenant-scoped
+  SELECT jsonb_agg(jsonb_build_object(
+    'producto_id', producto_id, 'cantidad', cantidad,
+    'precio_unitario', precio_unitario, 'es_bonificacion', COALESCE(es_bonificacion, false)))
+  INTO v_items_originales FROM pedido_items WHERE pedido_id = p_pedido_id AND sucursal_id = v_sucursal;
+
+  -- Phase 1: Validate stock for new non-bonificacion items that need MORE stock
+  FOR v_item_nuevo IN SELECT * FROM jsonb_array_elements(p_items_nuevos) LOOP
+    v_producto_id := (v_item_nuevo->>'producto_id')::INT;
+    v_cantidad_nueva := (v_item_nuevo->>'cantidad')::INT;
+    v_es_bonificacion := COALESCE((v_item_nuevo->>'es_bonificacion')::BOOLEAN, false);
+
+    IF v_es_bonificacion THEN CONTINUE; END IF;
+
+    SELECT COALESCE(cantidad, 0) INTO v_cantidad_original
+    FROM pedido_items
+    WHERE pedido_id = p_pedido_id AND producto_id = v_producto_id
+      AND COALESCE(es_bonificacion, false) = false
+      AND sucursal_id = v_sucursal;
+
+    v_diferencia := v_cantidad_nueva - COALESCE(v_cantidad_original, 0);
+
+    IF v_diferencia > 0 THEN
+      SELECT stock, nombre INTO v_stock_actual, v_producto_nombre
+      FROM productos WHERE id = v_producto_id AND sucursal_id = v_sucursal FOR UPDATE;
+
+      IF v_stock_actual IS NULL THEN
+        v_errores := array_append(v_errores, 'Producto ID ' || v_producto_id || ' no encontrado');
+      ELSIF v_stock_actual < v_diferencia THEN
+        v_errores := array_append(v_errores, COALESCE(v_producto_nombre, 'Producto ' || v_producto_id)
+          || ': stock insuficiente (disponible: ' || v_stock_actual || ', adicional: ' || v_diferencia || ')');
+      END IF;
+    END IF;
+  END LOOP;
+
+  IF array_length(v_errores, 1) > 0 THEN
+    RETURN jsonb_build_object('success', false, 'errores', to_jsonb(v_errores));
+  END IF;
+
+  -- Phase 2: Restore stock for original NON-bonificacion items only -- tenant-scoped
+  UPDATE productos p
+  SET stock = p.stock + pi.cantidad
+  FROM pedido_items pi
+  WHERE pi.pedido_id = p_pedido_id
+    AND pi.sucursal_id = v_sucursal
+    AND COALESCE(pi.es_bonificacion, false) = false
+    AND p.id = pi.producto_id
+    AND p.sucursal_id = v_sucursal;
+
+  -- Restore promo usos for original bonificacion items -- tenant-scoped
+  UPDATE promociones pr
+  SET usos_pendientes = GREATEST(pr.usos_pendientes - pi.cantidad, 0)
+  FROM pedido_items pi
+  WHERE pi.pedido_id = p_pedido_id
+    AND pi.sucursal_id = v_sucursal
+    AND COALESCE(pi.es_bonificacion, false) = true
+    AND pi.promocion_id IS NOT NULL
+    AND pr.id = pi.promocion_id
+    AND pr.sucursal_id = v_sucursal;
+
+  -- Phase 3: Delete old items and insert new ones -- tenant-scoped
+  DELETE FROM pedido_items WHERE pedido_id = p_pedido_id AND sucursal_id = v_sucursal;
+
+  FOR v_item_nuevo IN SELECT * FROM jsonb_array_elements(p_items_nuevos) LOOP
+    v_producto_id := (v_item_nuevo->>'producto_id')::INT;
+    v_cantidad_nueva := (v_item_nuevo->>'cantidad')::INT;
+    v_precio_unitario := (v_item_nuevo->>'precio_unitario')::DECIMAL;
+    v_es_bonificacion := COALESCE((v_item_nuevo->>'es_bonificacion')::BOOLEAN, false);
+    v_promocion_id := (v_item_nuevo->>'promocion_id')::BIGINT;
+    v_neto_unitario := (v_item_nuevo->>'neto_unitario')::DECIMAL;
+    v_iva_unitario := COALESCE((v_item_nuevo->>'iva_unitario')::DECIMAL, 0);
+    v_imp_internos_unitario := COALESCE((v_item_nuevo->>'impuestos_internos_unitario')::DECIMAL, 0);
+    v_porcentaje_iva := COALESCE((v_item_nuevo->>'porcentaje_iva')::DECIMAL, 0);
+
+    -- tenant-scoped INSERT
+    INSERT INTO pedido_items (
+      pedido_id, producto_id, cantidad, precio_unitario, subtotal,
+      es_bonificacion, promocion_id,
+      neto_unitario, iva_unitario, impuestos_internos_unitario, porcentaje_iva,
+      sucursal_id
+    ) VALUES (
+      p_pedido_id, v_producto_id, v_cantidad_nueva, v_precio_unitario,
+      v_cantidad_nueva * v_precio_unitario,
+      v_es_bonificacion, v_promocion_id,
+      v_neto_unitario, v_iva_unitario, v_imp_internos_unitario, v_porcentaje_iva,
+      v_sucursal
+    );
+
+    -- Deduct stock only for non-bonificacion items -- tenant-scoped
+    IF NOT v_es_bonificacion THEN
+      UPDATE productos SET stock = stock - v_cantidad_nueva
+      WHERE id = v_producto_id AND sucursal_id = v_sucursal;
+      v_total_nuevo := v_total_nuevo + (v_cantidad_nueva * v_precio_unitario);
+      v_total_neto_nuevo := v_total_neto_nuevo + (v_cantidad_nueva * COALESCE(v_neto_unitario, v_precio_unitario));
+      v_total_iva_nuevo := v_total_iva_nuevo + (v_cantidad_nueva * v_iva_unitario);
+    END IF;
+
+    -- Track promo usage for bonificaciones -- tenant-scoped
+    IF v_es_bonificacion AND v_promocion_id IS NOT NULL THEN
+      UPDATE promociones SET usos_pendientes = usos_pendientes + v_cantidad_nueva
+      WHERE id = v_promocion_id AND sucursal_id = v_sucursal;
+    END IF;
+  END LOOP;
+
+  -- Phase 4: Update pedido totals -- tenant-scoped
+  UPDATE pedidos SET
+    total = v_total_nuevo,
+    total_neto = v_total_neto_nuevo,
+    total_iva = v_total_iva_nuevo,
+    updated_at = NOW()
+  WHERE id = p_pedido_id AND sucursal_id = v_sucursal;
+
+  -- Phase 5: Record historial -- tenant-scoped INSERT
+  INSERT INTO pedido_historial (pedido_id, usuario_id, campo_modificado, valor_anterior, valor_nuevo, sucursal_id)
+  VALUES (p_pedido_id, p_usuario_id, 'items', COALESCE(v_items_originales::TEXT, '[]'), p_items_nuevos::TEXT, v_sucursal);
+
+  IF v_total_anterior IS DISTINCT FROM v_total_nuevo THEN
+    INSERT INTO pedido_historial (pedido_id, usuario_id, campo_modificado, valor_anterior, valor_nuevo, sucursal_id)
+    VALUES (p_pedido_id, p_usuario_id, 'total', v_total_anterior::TEXT, v_total_nuevo::TEXT, v_sucursal);
+  END IF;
+
+  RETURN jsonb_build_object('success', true, 'total_nuevo', v_total_nuevo);
+END;
+$$;
+
+
+-- ============================================================
+-- 3. cancelar_pedido_con_stock
+-- ============================================================
+CREATE OR REPLACE FUNCTION public.cancelar_pedido_con_stock(
+  p_pedido_id bigint,
+  p_motivo text,
+  p_usuario_id uuid DEFAULT NULL::uuid
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_sucursal BIGINT := current_sucursal_id();
+  v_pedido RECORD;
+  v_item RECORD;
+  v_total_original DECIMAL;
+  v_user_role TEXT;
+  v_acting_user uuid;
+BEGIN
+  -- Multi-tenant guard
+  IF v_sucursal IS NULL THEN
+    RETURN jsonb_build_object('success', false, 'error', 'No se pudo determinar la sucursal activa');
+  END IF;
+
+  -- Use auth.uid() as primary, p_usuario_id only if it matches
+  v_acting_user := auth.uid();
+  IF p_usuario_id IS NOT NULL AND p_usuario_id IS DISTINCT FROM v_acting_user THEN
+    RETURN jsonb_build_object('success', false, 'error', 'ID de usuario no coincide con la sesion autenticada');
+  END IF;
+
+  -- Auth check: only admin or encargado can cancel
+  SELECT rol INTO v_user_role FROM perfiles WHERE id = v_acting_user;
+  IF v_user_role IS NULL OR v_user_role NOT IN ('admin', 'encargado') THEN
+    RETURN jsonb_build_object('success', false, 'error', 'No autorizado: solo admin o encargado pueden cancelar pedidos');
+  END IF;
+
+  -- tenant-scoped pedido lookup with lock
+  SELECT * INTO v_pedido FROM pedidos WHERE id = p_pedido_id AND sucursal_id = v_sucursal FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RETURN jsonb_build_object('success', false, 'error', 'Pedido no encontrado');
+  END IF;
+
+  IF v_pedido.estado = 'cancelado' THEN
+    RETURN jsonb_build_object('success', false, 'error', 'El pedido ya esta cancelado');
+  END IF;
+
+  IF v_pedido.estado = 'entregado' THEN
+    RETURN jsonb_build_object('success', false, 'error', 'No se puede cancelar un pedido entregado');
+  END IF;
+
+  v_total_original := v_pedido.total;
+
+  -- tenant-scoped item loop
+  FOR v_item IN
+    SELECT producto_id, cantidad, COALESCE(es_bonificacion, false) as es_bonificacion, promocion_id
+    FROM pedido_items WHERE pedido_id = p_pedido_id AND sucursal_id = v_sucursal
+  LOOP
+    IF v_item.es_bonificacion THEN
+      IF v_item.promocion_id IS NOT NULL THEN
+        UPDATE promociones
+        SET usos_pendientes = GREATEST(usos_pendientes - v_item.cantidad, 0)
+        WHERE id = v_item.promocion_id AND sucursal_id = v_sucursal;
+      END IF;
+    ELSE
+      UPDATE productos SET stock = stock + v_item.cantidad
+      WHERE id = v_item.producto_id AND sucursal_id = v_sucursal;
+    END IF;
+  END LOOP;
+
+  -- tenant-scoped UPDATE
+  UPDATE pedidos
+  SET estado = 'cancelado',
+      motivo_cancelacion = p_motivo,
+      total = 0,
+      monto_pagado = 0,
+      total_neto = 0,
+      total_iva = 0,
+      updated_at = NOW()
+  WHERE id = p_pedido_id AND sucursal_id = v_sucursal;
+
+  -- tenant-scoped INSERT
+  INSERT INTO pedido_historial (pedido_id, usuario_id, campo_modificado, valor_anterior, valor_nuevo, sucursal_id)
+  VALUES (
+    p_pedido_id,
+    v_acting_user,
+    'estado',
+    v_pedido.estado,
+    'cancelado - Motivo: ' || COALESCE(p_motivo, 'Sin motivo') || ' | Total original: $' || v_total_original,
+    v_sucursal
+  );
+
+  RETURN jsonb_build_object(
+    'success', true,
+    'mensaje', 'Pedido cancelado, stock restaurado, saldo ajustado',
+    'total_original', v_total_original
+  );
+END;
+$$;
+
+
+-- ============================================================
+-- 4. eliminar_pedido_completo
+-- ============================================================
+DROP FUNCTION IF EXISTS public.eliminar_pedido_completo(bigint, uuid, text, boolean);
+
+CREATE FUNCTION public.eliminar_pedido_completo(
+  p_pedido_id bigint,
+  p_usuario_id uuid,
+  p_motivo text DEFAULT NULL::text,
+  p_restaurar_stock boolean DEFAULT true
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_sucursal BIGINT := current_sucursal_id();
+  v_pedido RECORD; v_items JSONB; v_cliente_nombre TEXT; v_cliente_direccion TEXT;
+  v_usuario_creador_nombre TEXT; v_transportista_nombre TEXT := NULL;
+  v_eliminador_nombre TEXT := NULL; v_item RECORD;
+  v_user_role TEXT;
+BEGIN
+  -- Multi-tenant guard
+  IF v_sucursal IS NULL THEN
+    RETURN jsonb_build_object('success', false, 'error', 'No se pudo determinar la sucursal activa');
+  END IF;
+
+  -- Auth check
+  IF p_usuario_id IS DISTINCT FROM auth.uid() THEN
+    RETURN jsonb_build_object('success', false, 'error', 'ID de usuario no coincide con la sesion autenticada');
+  END IF;
+
+  -- Only admin can delete orders
+  SELECT rol INTO v_user_role FROM perfiles WHERE id = p_usuario_id;
+  IF v_user_role IS NULL OR v_user_role != 'admin' THEN
+    RETURN jsonb_build_object('success', false, 'error', 'No autorizado: solo administradores pueden eliminar pedidos');
+  END IF;
+
+  -- tenant-scoped pedido lookup
+  SELECT * INTO v_pedido FROM pedidos WHERE id = p_pedido_id AND sucursal_id = v_sucursal;
+  IF NOT FOUND THEN RETURN jsonb_build_object('success', false, 'error', 'Pedido no encontrado'); END IF;
+
+  -- tenant-scoped items lookup
+  SELECT jsonb_agg(jsonb_build_object(
+    'producto_id', pi.producto_id, 'producto_nombre', pr.nombre,
+    'producto_codigo', pr.codigo, 'cantidad', pi.cantidad,
+    'precio_unitario', pi.precio_unitario, 'subtotal', pi.subtotal))
+  INTO v_items FROM pedido_items pi LEFT JOIN productos pr ON pr.id = pi.producto_id
+  WHERE pi.pedido_id = p_pedido_id AND pi.sucursal_id = v_sucursal;
+
+  SELECT nombre_fantasia, direccion INTO v_cliente_nombre, v_cliente_direccion
+  FROM clientes WHERE id = v_pedido.cliente_id AND sucursal_id = v_sucursal;
+  SELECT nombre INTO v_usuario_creador_nombre FROM perfiles WHERE id = v_pedido.usuario_id;
+  IF v_pedido.transportista_id IS NOT NULL THEN SELECT nombre INTO v_transportista_nombre FROM perfiles WHERE id = v_pedido.transportista_id; END IF;
+  IF p_usuario_id IS NOT NULL THEN SELECT nombre INTO v_eliminador_nombre FROM perfiles WHERE id = p_usuario_id; END IF;
+
+  -- tenant-scoped INSERT into pedidos_eliminados
+  INSERT INTO pedidos_eliminados (
+    pedido_id, cliente_id, cliente_nombre, cliente_direccion, total, estado,
+    estado_pago, forma_pago, monto_pagado, notas, items,
+    usuario_creador_id, usuario_creador_nombre, transportista_id, transportista_nombre,
+    fecha_pedido, fecha_entrega, eliminado_por_id, eliminado_por_nombre,
+    motivo_eliminacion, stock_restaurado, sucursal_id)
+  VALUES (
+    p_pedido_id, v_pedido.cliente_id, v_cliente_nombre, v_cliente_direccion,
+    v_pedido.total, v_pedido.estado, v_pedido.estado_pago, v_pedido.forma_pago,
+    v_pedido.monto_pagado, v_pedido.notas, COALESCE(v_items, '[]'::jsonb),
+    v_pedido.usuario_id, v_usuario_creador_nombre, v_pedido.transportista_id,
+    v_transportista_nombre, v_pedido.created_at, v_pedido.fecha_entrega,
+    p_usuario_id, v_eliminador_nombre, p_motivo, p_restaurar_stock, v_sucursal);
+
+  IF p_restaurar_stock THEN
+    FOR v_item IN SELECT producto_id, cantidad, COALESCE(es_bonificacion, false) as es_bonificacion
+    FROM pedido_items WHERE pedido_id = p_pedido_id AND sucursal_id = v_sucursal LOOP
+      IF NOT v_item.es_bonificacion THEN
+        UPDATE productos SET stock = stock + v_item.cantidad
+        WHERE id = v_item.producto_id AND sucursal_id = v_sucursal;
+      END IF;
+    END LOOP;
+  END IF;
+
+  -- tenant-scoped DELETEs
+  DELETE FROM pedido_items WHERE pedido_id = p_pedido_id AND sucursal_id = v_sucursal;
+  DELETE FROM pedido_historial WHERE pedido_id = p_pedido_id AND sucursal_id = v_sucursal;
+  DELETE FROM pedidos WHERE id = p_pedido_id AND sucursal_id = v_sucursal;
+
+  RETURN jsonb_build_object('success', true, 'mensaje', 'Pedido eliminado y registrado correctamente');
+END;
+$$;
+
+
+-- ============================================================
+-- 5. descontar_stock_atomico (jsonb overload)
+-- ============================================================
+CREATE OR REPLACE FUNCTION public.descontar_stock_atomico(p_items jsonb)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_sucursal BIGINT := current_sucursal_id();
+  v_item JSONB; v_producto_id INT; v_cantidad INT;
+  v_stock_actual INT; v_producto_nombre TEXT;
+  errores TEXT[] := '{}';
+  v_user_role TEXT;
+BEGIN
+  -- Multi-tenant guard
+  IF v_sucursal IS NULL THEN
+    RETURN jsonb_build_object('success', false, 'errores', jsonb_build_array('No se pudo determinar la sucursal activa'));
+  END IF;
+
+  SELECT rol INTO v_user_role FROM perfiles WHERE id = auth.uid();
+  IF v_user_role IS NULL OR v_user_role NOT IN ('admin', 'preventista') THEN
+    RETURN jsonb_build_object('success', false, 'errores', jsonb_build_array('No autorizado para descontar stock'));
+  END IF;
+
+  FOR v_item IN SELECT * FROM jsonb_array_elements(p_items) LOOP
+    v_producto_id := (v_item->>'producto_id')::INT;
+    v_cantidad := (v_item->>'cantidad')::INT;
+
+    IF v_cantidad IS NULL OR v_cantidad <= 0 THEN
+      errores := array_append(errores, 'Cantidad invalida para producto ' || v_producto_id);
+      CONTINUE;
+    END IF;
+
+    -- tenant-scoped SELECT FOR UPDATE
+    SELECT stock, nombre INTO v_stock_actual, v_producto_nombre
+    FROM productos WHERE id = v_producto_id AND sucursal_id = v_sucursal FOR UPDATE;
+
+    IF v_stock_actual IS NULL THEN
+      errores := array_append(errores, 'Producto ' || v_producto_id || ' no encontrado');
+    ELSIF v_stock_actual < v_cantidad THEN
+      errores := array_append(errores, v_producto_nombre || ': stock insuficiente (disponible: ' || v_stock_actual || ', solicitado: ' || v_cantidad || ')');
+    ELSE
+      -- tenant-scoped UPDATE
+      UPDATE productos SET stock = stock - v_cantidad
+      WHERE id = v_producto_id AND sucursal_id = v_sucursal;
+    END IF;
+  END LOOP;
+
+  IF array_length(errores, 1) > 0 THEN
+    RETURN jsonb_build_object('success', false, 'errores', to_jsonb(errores));
+  END IF;
+
+  RETURN jsonb_build_object('success', true, 'errores', '[]'::jsonb);
+END;
+$$;
+
+
+-- ============================================================
+-- 6. restaurar_stock_atomico (jsonb overload)
+-- ============================================================
+CREATE OR REPLACE FUNCTION public.restaurar_stock_atomico(p_items jsonb)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_sucursal BIGINT := current_sucursal_id();
+  v_item JSONB; v_producto_id INT; v_cantidad INT;
+  errores TEXT[] := '{}';
+  v_user_role TEXT;
+BEGIN
+  -- Multi-tenant guard
+  IF v_sucursal IS NULL THEN
+    RETURN jsonb_build_object('success', false, 'errores', jsonb_build_array('No se pudo determinar la sucursal activa'));
+  END IF;
+
+  SELECT rol INTO v_user_role FROM perfiles WHERE id = auth.uid();
+  IF v_user_role IS NULL OR v_user_role NOT IN ('admin', 'preventista', 'encargado') THEN
+    RETURN jsonb_build_object('success', false, 'errores', jsonb_build_array('No autorizado para restaurar stock'));
+  END IF;
+
+  FOR v_item IN SELECT * FROM jsonb_array_elements(p_items) LOOP
+    v_producto_id := (v_item->>'producto_id')::INT;
+    v_cantidad := (v_item->>'cantidad')::INT;
+
+    IF v_cantidad IS NULL OR v_cantidad <= 0 THEN
+      errores := array_append(errores, 'Cantidad invalida para producto ' || v_producto_id);
+      CONTINUE;
+    END IF;
+
+    -- tenant-scoped UPDATE
+    UPDATE productos SET stock = stock + v_cantidad
+    WHERE id = v_producto_id AND sucursal_id = v_sucursal;
+    IF NOT FOUND THEN
+      errores := array_append(errores, 'Producto ' || v_producto_id || ' no encontrado');
+    END IF;
+  END LOOP;
+
+  IF array_length(errores, 1) > 0 THEN
+    RETURN jsonb_build_object('success', false, 'errores', to_jsonb(errores));
+  END IF;
+
+  RETURN jsonb_build_object('success', true, 'errores', '[]'::jsonb);
+END;
+$$;
+
+
+-- ============================================================
+-- 7. registrar_compra_completa (12-param overload)
+-- ============================================================
+DROP FUNCTION IF EXISTS public.registrar_compra_completa(bigint, character varying, character varying, date, numeric, numeric, numeric, numeric, character varying, text, uuid, jsonb);
+
+CREATE FUNCTION public.registrar_compra_completa(
+  p_proveedor_id bigint,
+  p_proveedor_nombre character varying,
+  p_numero_factura character varying,
+  p_fecha_compra date,
+  p_subtotal numeric,
+  p_iva numeric,
+  p_otros_impuestos numeric,
+  p_total numeric,
+  p_forma_pago character varying,
+  p_notas text,
+  p_usuario_id uuid,
+  p_items jsonb
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_sucursal BIGINT := current_sucursal_id();
+  v_compra_id BIGINT; v_item JSONB; v_producto RECORD; v_stock_anterior INTEGER; v_stock_nuevo INTEGER;
+  v_items_procesados JSONB := '[]'::JSONB; v_costo_neto DECIMAL; v_costo_con_iva DECIMAL;
+  v_porcentaje_iva DECIMAL; v_impuestos_internos DECIMAL; v_bonificacion DECIMAL;
+  v_user_role TEXT;
+BEGIN
+  -- Multi-tenant guard
+  IF v_sucursal IS NULL THEN
+    RETURN jsonb_build_object('success', false, 'error', 'No se pudo determinar la sucursal activa');
+  END IF;
+
+  -- Auth check
+  IF p_usuario_id IS DISTINCT FROM auth.uid() THEN
+    RETURN jsonb_build_object('success', false, 'error', 'ID de usuario no coincide con la sesion autenticada');
+  END IF;
+
+  SELECT rol INTO v_user_role FROM perfiles WHERE id = p_usuario_id;
+  IF v_user_role IS NULL OR v_user_role NOT IN ('admin', 'encargado') THEN
+    RETURN jsonb_build_object('success', false, 'error', 'No autorizado: solo admin o encargado pueden registrar compras');
+  END IF;
+
+  -- tenant-scoped INSERT
+  INSERT INTO compras (proveedor_id, proveedor_nombre, numero_factura, fecha_compra, subtotal, iva, otros_impuestos, total, forma_pago, notas, usuario_id, estado, sucursal_id)
+  VALUES (p_proveedor_id, p_proveedor_nombre, p_numero_factura, p_fecha_compra, p_subtotal, p_iva, p_otros_impuestos, p_total, p_forma_pago, p_notas, p_usuario_id, 'recibida', v_sucursal)
+  RETURNING id INTO v_compra_id;
+
+  FOR v_item IN SELECT * FROM jsonb_array_elements(p_items) LOOP
+    -- tenant-scoped SELECT FOR UPDATE
+    SELECT id, stock INTO v_producto FROM productos
+    WHERE id = (v_item->>'producto_id')::BIGINT AND sucursal_id = v_sucursal FOR UPDATE;
+    IF NOT FOUND THEN RAISE EXCEPTION 'Producto no encontrado: %', v_item->>'producto_id'; END IF;
+
+    v_stock_anterior := COALESCE(v_producto.stock, 0);
+    v_stock_nuevo := v_stock_anterior + (v_item->>'cantidad')::INTEGER;
+    v_bonificacion := COALESCE((v_item->>'bonificacion')::DECIMAL, 0);
+    v_porcentaje_iva := COALESCE((v_item->>'porcentaje_iva')::DECIMAL, 21);
+    v_impuestos_internos := COALESCE((v_item->>'impuestos_internos')::DECIMAL, 0);
+
+    -- tenant-scoped INSERT
+    INSERT INTO compra_items (compra_id, producto_id, cantidad, costo_unitario, subtotal, stock_anterior, stock_nuevo, bonificacion, sucursal_id)
+    VALUES (v_compra_id, (v_item->>'producto_id')::BIGINT, (v_item->>'cantidad')::INTEGER,
+            COALESCE((v_item->>'costo_unitario')::DECIMAL, 0),
+            COALESCE((v_item->>'subtotal')::DECIMAL, 0),
+            v_stock_anterior, v_stock_nuevo, v_bonificacion, v_sucursal);
+
+    v_costo_neto := COALESCE((v_item->>'costo_unitario')::DECIMAL, 0) * (1 - v_bonificacion / 100);
+    v_costo_con_iva := v_costo_neto * (1 + v_porcentaje_iva / 100);
+
+    -- tenant-scoped UPDATE
+    UPDATE productos SET
+      stock = stock + (v_item->>'cantidad')::INTEGER,
+      costo_sin_iva = v_costo_neto,
+      costo_con_iva = v_costo_con_iva,
+      impuestos_internos = v_impuestos_internos,
+      porcentaje_iva = v_porcentaje_iva,
+      updated_at = NOW()
+    WHERE id = (v_item->>'producto_id')::BIGINT AND sucursal_id = v_sucursal;
+
+    v_items_procesados := v_items_procesados || jsonb_build_object(
+      'producto_id', (v_item->>'producto_id')::BIGINT,
+      'cantidad', (v_item->>'cantidad')::INTEGER,
+      'stock_anterior', v_stock_anterior,
+      'stock_nuevo', v_stock_nuevo,
+      'costo_sin_iva', v_costo_neto,
+      'costo_con_iva', v_costo_con_iva);
+  END LOOP;
+
+  RETURN jsonb_build_object('success', true, 'compra_id', v_compra_id, 'items_procesados', v_items_procesados);
+EXCEPTION WHEN OTHERS THEN
+  RETURN jsonb_build_object('success', false, 'error', SQLERRM);
+END;
+$$;
+
+
+-- ============================================================
+-- 8. actualizar_precios_masivo
+-- ============================================================
+CREATE OR REPLACE FUNCTION actualizar_precios_masivo(
+  p_productos JSONB
+)
+RETURNS JSONB AS $$
+DECLARE
+  v_sucursal BIGINT := current_sucursal_id();
+  v_item JSONB;
+  v_actualizados INT := 0;
+  v_errores TEXT[] := '{}';
+  v_producto_id INT;
+BEGIN
+  -- Multi-tenant guard
+  IF v_sucursal IS NULL THEN
+    RETURN jsonb_build_object('success', false, 'error', 'No se pudo determinar la sucursal activa');
+  END IF;
+
+  FOR v_item IN SELECT * FROM jsonb_array_elements(p_productos)
+  LOOP
+    BEGIN
+      v_producto_id := (v_item->>'producto_id')::INT;
+
+      -- tenant-scoped UPDATE
+      UPDATE productos
+      SET
+        precio_sin_iva = COALESCE((v_item->>'precio_neto')::DECIMAL, precio_sin_iva),
+        impuestos_internos = COALESCE((v_item->>'imp_internos')::DECIMAL, impuestos_internos),
+        precio = COALESCE((v_item->>'precio_final')::DECIMAL, precio),
+        updated_at = NOW()
+      WHERE id = v_producto_id AND sucursal_id = v_sucursal;
+
+      IF FOUND THEN
+        v_actualizados := v_actualizados + 1;
+      ELSE
+        v_errores := array_append(v_errores,
+          'Producto ID ' || v_producto_id || ' no encontrado');
+      END IF;
+    EXCEPTION WHEN OTHERS THEN
+      v_errores := array_append(v_errores,
+        'Error en producto ID ' || COALESCE(v_producto_id::TEXT, 'desconocido') || ': ' || SQLERRM);
+    END;
+  END LOOP;
+
+  RETURN jsonb_build_object(
+    'success', array_length(v_errores, 1) IS NULL,
+    'actualizados', v_actualizados,
+    'errores', COALESCE(to_jsonb(v_errores), '[]'::jsonb)
+  );
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = public;
+
+
+-- ============================================================
+-- 9. registrar_nota_credito
+-- ============================================================
+CREATE OR REPLACE FUNCTION public.registrar_nota_credito(
+  p_compra_id BIGINT,
+  p_numero_nota VARCHAR DEFAULT NULL,
+  p_motivo TEXT DEFAULT NULL,
+  p_subtotal DECIMAL DEFAULT 0,
+  p_iva DECIMAL DEFAULT 0,
+  p_total DECIMAL DEFAULT 0,
+  p_usuario_id UUID DEFAULT NULL,
+  p_items JSONB DEFAULT '[]'
+)
+RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_sucursal BIGINT := current_sucursal_id();
+  v_nota_id BIGINT;
+  v_item JSONB;
+  v_stock_actual INTEGER;
+  v_producto_id BIGINT;
+  v_cantidad INTEGER;
+  v_costo DECIMAL;
+  v_sub DECIMAL;
+BEGIN
+  -- Multi-tenant guard
+  IF v_sucursal IS NULL THEN
+    RETURN jsonb_build_object('success', false, 'error', 'No se pudo determinar la sucursal activa');
+  END IF;
+
+  -- tenant-scoped compra check
+  IF NOT EXISTS (SELECT 1 FROM compras WHERE id = p_compra_id AND estado != 'cancelada' AND sucursal_id = v_sucursal) THEN
+    RETURN jsonb_build_object('success', false, 'error', 'Compra no encontrada o cancelada');
+  END IF;
+
+  -- tenant-scoped INSERT
+  INSERT INTO notas_credito (compra_id, numero_nota, fecha, subtotal, iva, total, motivo, usuario_id, sucursal_id)
+  VALUES (p_compra_id, p_numero_nota, CURRENT_DATE, p_subtotal, p_iva, p_total, p_motivo, p_usuario_id, v_sucursal)
+  RETURNING id INTO v_nota_id;
+
+  FOR v_item IN SELECT * FROM jsonb_array_elements(p_items)
+  LOOP
+    v_producto_id := (v_item->>'producto_id')::BIGINT;
+    v_cantidad := (v_item->>'cantidad')::INTEGER;
+    v_costo := (v_item->>'costo_unitario')::DECIMAL;
+    v_sub := (v_item->>'subtotal')::DECIMAL;
+
+    -- tenant-scoped SELECT FOR UPDATE
+    SELECT stock INTO v_stock_actual FROM productos WHERE id = v_producto_id AND sucursal_id = v_sucursal FOR UPDATE;
+
+    IF v_stock_actual IS NULL THEN
+      RAISE EXCEPTION 'Producto % no encontrado', v_producto_id;
+    END IF;
+
+    -- tenant-scoped INSERT
+    INSERT INTO nota_credito_items (nota_credito_id, producto_id, cantidad, costo_unitario, subtotal, stock_anterior, stock_nuevo, sucursal_id)
+    VALUES (v_nota_id, v_producto_id, v_cantidad, v_costo, v_sub, v_stock_actual, GREATEST(0, v_stock_actual - v_cantidad), v_sucursal);
+
+    -- tenant-scoped UPDATE
+    UPDATE productos SET stock = GREATEST(0, v_stock_actual - v_cantidad)
+    WHERE id = v_producto_id AND sucursal_id = v_sucursal;
+  END LOOP;
+
+  RETURN jsonb_build_object('success', true, 'nota_credito_id', v_nota_id);
+END;
+$$;
+
+
+-- ============================================================
+-- 10. registrar_salvedad
+-- ============================================================
+CREATE OR REPLACE FUNCTION registrar_salvedad(
+  p_pedido_id BIGINT,
+  p_pedido_item_id BIGINT,
+  p_cantidad_afectada INTEGER,
+  p_motivo VARCHAR,
+  p_descripcion TEXT DEFAULT NULL,
+  p_foto_url TEXT DEFAULT NULL,
+  p_devolver_stock BOOLEAN DEFAULT TRUE
+)
+RETURNS JSONB AS $$
+DECLARE
+  v_sucursal BIGINT := current_sucursal_id();
+  v_salvedad_id BIGINT;
+  v_item RECORD;
+  v_cantidad_entregada INTEGER;
+  v_monto_afectado DECIMAL;
+  v_usuario_id UUID := auth.uid();
+  v_es_admin BOOLEAN;
+  v_subtotal_anterior DECIMAL;
+  v_subtotal_nuevo DECIMAL;
+BEGIN
+  -- Multi-tenant guard
+  IF v_sucursal IS NULL THEN
+    RETURN jsonb_build_object('success', false, 'error', 'No se pudo determinar la sucursal activa');
+  END IF;
+
+  v_es_admin := es_admin_salvedades();
+
+  -- Verificar que el usuario tiene permiso -- tenant-scoped
+  IF NOT v_es_admin AND NOT EXISTS (
+    SELECT 1 FROM pedidos p
+    WHERE p.id = p_pedido_id
+    AND p.sucursal_id = v_sucursal
+    AND (p.transportista_id = v_usuario_id)
+  ) THEN
+    RETURN jsonb_build_object('success', false, 'error', 'No autorizado para registrar salvedad en este pedido');
+  END IF;
+
+  -- Obtener datos del item -- tenant-scoped
+  SELECT
+    pi.id,
+    pi.producto_id,
+    pi.cantidad,
+    pi.precio_unitario,
+    pi.subtotal,
+    pr.nombre AS producto_nombre,
+    pr.stock AS stock_actual
+  INTO v_item
+  FROM pedido_items pi
+  JOIN productos pr ON pr.id = pi.producto_id AND pr.sucursal_id = v_sucursal
+  WHERE pi.id = p_pedido_item_id AND pi.pedido_id = p_pedido_id AND pi.sucursal_id = v_sucursal;
+
+  IF NOT FOUND THEN
+    RETURN jsonb_build_object('success', false, 'error', 'Item de pedido no encontrado');
+  END IF;
+
+  IF p_cantidad_afectada > v_item.cantidad THEN
+    RETURN jsonb_build_object('success', false, 'error', 'Cantidad afectada mayor a la cantidad del item');
+  END IF;
+
+  IF p_cantidad_afectada <= 0 THEN
+    RETURN jsonb_build_object('success', false, 'error', 'La cantidad afectada debe ser mayor a 0');
+  END IF;
+
+  v_cantidad_entregada := v_item.cantidad - p_cantidad_afectada;
+  v_monto_afectado := p_cantidad_afectada * v_item.precio_unitario;
+  v_subtotal_anterior := v_item.subtotal;
+  v_subtotal_nuevo := v_cantidad_entregada * v_item.precio_unitario;
+
+  -- tenant-scoped INSERT
+  INSERT INTO salvedades_items (
+    pedido_id, pedido_item_id, producto_id,
+    cantidad_original, cantidad_afectada, cantidad_entregada,
+    motivo, descripcion, foto_url,
+    monto_afectado, precio_unitario, reportado_por, sucursal_id
+  ) VALUES (
+    p_pedido_id, p_pedido_item_id, v_item.producto_id,
+    v_item.cantidad, p_cantidad_afectada, v_cantidad_entregada,
+    p_motivo, p_descripcion, p_foto_url,
+    v_monto_afectado, v_item.precio_unitario, v_usuario_id, v_sucursal
+  )
+  RETURNING id INTO v_salvedad_id;
+
+  -- Actualizar el item del pedido -- tenant-scoped
+  IF v_cantidad_entregada > 0 THEN
+    UPDATE pedido_items SET
+      cantidad = v_cantidad_entregada,
+      subtotal = v_subtotal_nuevo
+    WHERE id = p_pedido_item_id AND sucursal_id = v_sucursal;
+  ELSE
+    DELETE FROM pedido_items WHERE id = p_pedido_item_id AND sucursal_id = v_sucursal;
+  END IF;
+
+  -- Recalcular total del pedido -- tenant-scoped
+  UPDATE pedidos SET
+    total = (SELECT COALESCE(SUM(subtotal), 0) FROM pedido_items WHERE pedido_id = p_pedido_id AND sucursal_id = v_sucursal),
+    updated_at = NOW()
+  WHERE id = p_pedido_id AND sucursal_id = v_sucursal;
+
+  -- Manejar devolucion de stock segun motivo
+  IF p_devolver_stock THEN
+    IF p_motivo IN ('cliente_rechaza', 'error_pedido', 'diferencia_precio') THEN
+      -- tenant-scoped UPDATE
+      UPDATE productos SET stock = stock + p_cantidad_afectada
+      WHERE id = v_item.producto_id AND sucursal_id = v_sucursal;
+      UPDATE salvedades_items SET
+        stock_devuelto = TRUE,
+        stock_devuelto_at = NOW()
+      WHERE id = v_salvedad_id;
+    ELSE
+      UPDATE salvedades_items SET stock_devuelto = FALSE WHERE id = v_salvedad_id;
+    END IF;
+  END IF;
+
+  -- tenant-scoped historial INSERT
+  INSERT INTO salvedad_historial (salvedad_id, accion, estado_nuevo, notas, usuario_id, sucursal_id)
+  VALUES (v_salvedad_id, 'creacion', 'pendiente', p_descripcion, v_usuario_id, v_sucursal);
+
+  -- Registrar en historial del pedido
+  IF EXISTS (SELECT 1 FROM information_schema.tables WHERE table_name = 'pedido_historial') THEN
+    INSERT INTO pedido_historial (pedido_id, usuario_id, campo_modificado, valor_anterior, valor_nuevo, sucursal_id)
+    VALUES (
+      p_pedido_id,
+      v_usuario_id,
+      'salvedad_item',
+      v_item.cantidad::TEXT || ' unidades de ' || v_item.producto_nombre,
+      v_cantidad_entregada::TEXT || ' unidades (salvedad: ' || p_motivo || ')',
+      v_sucursal
+    );
+  END IF;
+
+  RETURN jsonb_build_object(
+    'success', true,
+    'salvedad_id', v_salvedad_id,
+    'monto_afectado', v_monto_afectado,
+    'cantidad_entregada', v_cantidad_entregada,
+    'stock_devuelto', CASE WHEN p_motivo IN ('cliente_rechaza', 'error_pedido', 'diferencia_precio') THEN true ELSE false END,
+    'nuevo_total_pedido', (SELECT total FROM pedidos WHERE id = p_pedido_id AND sucursal_id = v_sucursal)
+  );
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = public;
+
+
+-- ============================================================
+-- 11. resolver_salvedad
+-- ============================================================
+CREATE OR REPLACE FUNCTION resolver_salvedad(
+  p_salvedad_id BIGINT,
+  p_estado_resolucion VARCHAR,
+  p_notas TEXT DEFAULT NULL,
+  p_pedido_reprogramado_id BIGINT DEFAULT NULL
+)
+RETURNS JSONB AS $$
+DECLARE
+  v_sucursal BIGINT := current_sucursal_id();
+  v_salvedad RECORD;
+  v_estado_anterior VARCHAR;
+  v_usuario_id UUID := auth.uid();
+BEGIN
+  -- Multi-tenant guard
+  IF v_sucursal IS NULL THEN
+    RETURN jsonb_build_object('success', false, 'error', 'No se pudo determinar la sucursal activa');
+  END IF;
+
+  IF NOT es_admin_salvedades() THEN
+    RETURN jsonb_build_object('success', false, 'error', 'Solo administradores pueden resolver salvedades');
+  END IF;
+
+  IF p_estado_resolucion NOT IN ('reprogramada', 'nota_credito', 'descuento_transportista', 'absorcion_empresa', 'resuelto_otro', 'anulada') THEN
+    RETURN jsonb_build_object('success', false, 'error', 'Estado de resolucion no valido');
+  END IF;
+
+  -- tenant-scoped lookup
+  SELECT * INTO v_salvedad FROM salvedades_items WHERE id = p_salvedad_id AND sucursal_id = v_sucursal;
+
+  IF NOT FOUND THEN
+    RETURN jsonb_build_object('success', false, 'error', 'Salvedad no encontrada');
+  END IF;
+
+  IF v_salvedad.estado_resolucion != 'pendiente' THEN
+    RETURN jsonb_build_object('success', false, 'error', 'La salvedad ya fue resuelta');
+  END IF;
+
+  v_estado_anterior := v_salvedad.estado_resolucion;
+
+  -- tenant-scoped UPDATE
+  UPDATE salvedades_items SET
+    estado_resolucion = p_estado_resolucion,
+    resolucion_notas = p_notas,
+    resolucion_fecha = NOW(),
+    resuelto_por = v_usuario_id,
+    pedido_reprogramado_id = p_pedido_reprogramado_id,
+    updated_at = NOW()
+  WHERE id = p_salvedad_id AND sucursal_id = v_sucursal;
+
+  -- tenant-scoped INSERT
+  INSERT INTO salvedad_historial (salvedad_id, accion, estado_anterior, estado_nuevo, notas, usuario_id, sucursal_id)
+  VALUES (p_salvedad_id, 'resolucion', v_estado_anterior, p_estado_resolucion, p_notas, v_usuario_id, v_sucursal);
+
+  RETURN jsonb_build_object('success', true, 'nuevo_estado', p_estado_resolucion);
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = public;
+
+
+-- ============================================================
+-- 12. anular_salvedad
+-- ============================================================
+CREATE OR REPLACE FUNCTION anular_salvedad(
+  p_salvedad_id BIGINT,
+  p_notas TEXT DEFAULT NULL
+)
+RETURNS JSONB AS $$
+DECLARE
+  v_sucursal BIGINT := current_sucursal_id();
+  v_salvedad RECORD;
+  v_usuario_id UUID := auth.uid();
+BEGIN
+  -- Multi-tenant guard
+  IF v_sucursal IS NULL THEN
+    RETURN jsonb_build_object('success', false, 'error', 'No se pudo determinar la sucursal activa');
+  END IF;
+
+  IF NOT es_admin_salvedades() THEN
+    RETURN jsonb_build_object('success', false, 'error', 'Solo administradores pueden anular salvedades');
+  END IF;
+
+  -- tenant-scoped lookup
+  SELECT * INTO v_salvedad FROM salvedades_items WHERE id = p_salvedad_id AND sucursal_id = v_sucursal;
+
+  IF NOT FOUND THEN
+    RETURN jsonb_build_object('success', false, 'error', 'Salvedad no encontrada');
+  END IF;
+
+  IF v_salvedad.estado_resolucion = 'anulada' THEN
+    RETURN jsonb_build_object('success', false, 'error', 'La salvedad ya esta anulada');
+  END IF;
+
+  -- Restaurar item del pedido si aun existe -- tenant-scoped
+  IF EXISTS (SELECT 1 FROM pedido_items WHERE id = v_salvedad.pedido_item_id AND sucursal_id = v_sucursal) THEN
+    UPDATE pedido_items SET
+      cantidad = v_salvedad.cantidad_original,
+      subtotal = v_salvedad.cantidad_original * v_salvedad.precio_unitario
+    WHERE id = v_salvedad.pedido_item_id AND sucursal_id = v_sucursal;
+  ELSE
+    -- Recrear el item si fue eliminado -- tenant-scoped INSERT
+    INSERT INTO pedido_items (pedido_id, producto_id, cantidad, precio_unitario, subtotal, sucursal_id)
+    VALUES (
+      v_salvedad.pedido_id,
+      v_salvedad.producto_id,
+      v_salvedad.cantidad_original,
+      v_salvedad.precio_unitario,
+      v_salvedad.cantidad_original * v_salvedad.precio_unitario,
+      v_sucursal
+    );
+  END IF;
+
+  -- Recalcular total del pedido -- tenant-scoped
+  UPDATE pedidos SET
+    total = (SELECT COALESCE(SUM(subtotal), 0) FROM pedido_items WHERE pedido_id = v_salvedad.pedido_id AND sucursal_id = v_sucursal),
+    updated_at = NOW()
+  WHERE id = v_salvedad.pedido_id AND sucursal_id = v_sucursal;
+
+  -- Si se habia devuelto stock, revertir -- tenant-scoped
+  IF v_salvedad.stock_devuelto THEN
+    UPDATE productos SET stock = stock - v_salvedad.cantidad_afectada
+    WHERE id = v_salvedad.producto_id AND sucursal_id = v_sucursal;
+  END IF;
+
+  -- Marcar como anulada -- tenant-scoped
+  UPDATE salvedades_items SET
+    estado_resolucion = 'anulada',
+    resolucion_notas = p_notas,
+    resolucion_fecha = NOW(),
+    resuelto_por = v_usuario_id,
+    updated_at = NOW()
+  WHERE id = p_salvedad_id AND sucursal_id = v_sucursal;
+
+  -- tenant-scoped INSERT
+  INSERT INTO salvedad_historial (salvedad_id, accion, estado_anterior, estado_nuevo, notas, usuario_id, sucursal_id)
+  VALUES (p_salvedad_id, 'anulacion', v_salvedad.estado_resolucion, 'anulada', p_notas, v_usuario_id, v_sucursal);
+
+  RETURN jsonb_build_object('success', true, 'message', 'Salvedad anulada correctamente');
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = public;
+
+
+-- ============================================================
+-- 13. crear_recorrido
+-- ============================================================
+CREATE OR REPLACE FUNCTION crear_recorrido(
+  p_transportista_id UUID,
+  p_pedidos JSONB,
+  p_distancia DECIMAL DEFAULT NULL,
+  p_duracion INTEGER DEFAULT NULL
+)
+RETURNS BIGINT AS $$
+DECLARE
+  v_sucursal BIGINT := current_sucursal_id();
+  v_recorrido_id BIGINT;
+  v_pedido JSONB;
+  v_total_facturado DECIMAL := 0;
+BEGIN
+  -- Multi-tenant guard
+  IF v_sucursal IS NULL THEN
+    RAISE EXCEPTION 'No se pudo determinar la sucursal activa';
+  END IF;
+
+  -- tenant-scoped total calculation
+  SELECT COALESCE(SUM(total), 0) INTO v_total_facturado
+  FROM pedidos
+  WHERE id IN (SELECT (value->>'pedido_id')::BIGINT FROM jsonb_array_elements(p_pedidos) AS value)
+    AND sucursal_id = v_sucursal;
+
+  -- tenant-scoped INSERT
+  INSERT INTO recorridos (
+    transportista_id, fecha, distancia_total, duracion_total,
+    total_pedidos, total_facturado, estado, sucursal_id
+  )
+  VALUES (
+    p_transportista_id, CURRENT_DATE, p_distancia, p_duracion,
+    jsonb_array_length(p_pedidos), v_total_facturado, 'en_curso', v_sucursal
+  )
+  RETURNING id INTO v_recorrido_id;
+
+  -- tenant-scoped INSERT
+  FOR v_pedido IN SELECT * FROM jsonb_array_elements(p_pedidos)
+  LOOP
+    INSERT INTO recorrido_pedidos (recorrido_id, pedido_id, orden_entrega, sucursal_id)
+    VALUES (
+      v_recorrido_id,
+      (v_pedido->>'pedido_id')::BIGINT,
+      (v_pedido->>'orden_entrega')::INTEGER,
+      v_sucursal
+    );
+  END LOOP;
+
+  RETURN v_recorrido_id;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = public;
+
+
+-- ============================================================
+-- 14. crear_rendicion_recorrido
+-- ============================================================
+CREATE OR REPLACE FUNCTION crear_rendicion_recorrido(
+  p_recorrido_id BIGINT,
+  p_transportista_id UUID DEFAULT NULL
+)
+RETURNS BIGINT AS $$
+DECLARE
+  v_sucursal BIGINT := current_sucursal_id();
+  v_rendicion_id BIGINT;
+  v_total_efectivo DECIMAL := 0;
+  v_total_otros DECIMAL := 0;
+  v_pedido RECORD;
+  v_transportista_real UUID;
+  v_es_admin BOOLEAN;
+BEGIN
+  -- Multi-tenant guard
+  IF v_sucursal IS NULL THEN
+    RAISE EXCEPTION 'No se pudo determinar la sucursal activa';
+  END IF;
+
+  v_es_admin := es_admin_rendiciones();
+
+  IF v_es_admin THEN
+    IF p_transportista_id IS NULL THEN
+      SELECT transportista_id INTO v_transportista_real
+      FROM recorridos WHERE id = p_recorrido_id AND sucursal_id = v_sucursal;
+    ELSE
+      v_transportista_real := p_transportista_id;
+    END IF;
+  ELSE
+    v_transportista_real := auth.uid();
+  END IF;
+
+  -- tenant-scoped recorrido check
+  IF NOT EXISTS (
+    SELECT 1 FROM recorridos
+    WHERE id = p_recorrido_id AND sucursal_id = v_sucursal
+    AND (transportista_id = v_transportista_real OR v_es_admin)
+  ) THEN
+    RAISE EXCEPTION 'Recorrido no valido o no pertenece al transportista';
+  END IF;
+
+  -- tenant-scoped rendicion check
+  IF EXISTS (SELECT 1 FROM rendiciones WHERE recorrido_id = p_recorrido_id AND sucursal_id = v_sucursal) THEN
+    RAISE EXCEPTION 'Ya existe una rendicion para este recorrido';
+  END IF;
+
+  -- Calcular totales -- tenant-scoped
+  FOR v_pedido IN
+    SELECT p.id, COALESCE(p.monto_pagado, 0) as monto_pagado, COALESCE(p.forma_pago, 'efectivo') as forma_pago
+    FROM pedidos p
+    JOIN recorrido_pedidos rp ON rp.pedido_id = p.id
+    WHERE rp.recorrido_id = p_recorrido_id
+    AND rp.estado_entrega = 'entregado'
+    AND p.estado = 'entregado'
+    AND p.sucursal_id = v_sucursal
+  LOOP
+    IF v_pedido.forma_pago = 'efectivo' THEN
+      v_total_efectivo := v_total_efectivo + v_pedido.monto_pagado;
+    ELSE
+      v_total_otros := v_total_otros + v_pedido.monto_pagado;
+    END IF;
+  END LOOP;
+
+  -- tenant-scoped INSERT
+  INSERT INTO rendiciones (
+    recorrido_id, transportista_id, fecha,
+    total_efectivo_esperado, total_otros_medios, estado, sucursal_id
+  ) VALUES (
+    p_recorrido_id, v_transportista_real, CURRENT_DATE,
+    v_total_efectivo, v_total_otros, 'pendiente', v_sucursal
+  )
+  RETURNING id INTO v_rendicion_id;
+
+  -- tenant-scoped INSERT
+  INSERT INTO rendicion_items (rendicion_id, pedido_id, monto_cobrado, forma_pago, sucursal_id)
+  SELECT
+    v_rendicion_id, p.id,
+    COALESCE(p.monto_pagado, 0),
+    COALESCE(p.forma_pago, 'efectivo'),
+    v_sucursal
+  FROM pedidos p
+  JOIN recorrido_pedidos rp ON rp.pedido_id = p.id
+  WHERE rp.recorrido_id = p_recorrido_id
+  AND rp.estado_entrega = 'entregado'
+  AND p.estado = 'entregado'
+  AND p.sucursal_id = v_sucursal;
+
+  RETURN v_rendicion_id;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = public;
+
+
+-- ============================================================
+-- 15. crear_rendicion_por_fecha
+-- ============================================================
+CREATE OR REPLACE FUNCTION crear_rendicion_por_fecha(
+  p_transportista_id UUID,
+  p_fecha DATE DEFAULT CURRENT_DATE
+)
+RETURNS BIGINT AS $$
+DECLARE
+  v_sucursal BIGINT := current_sucursal_id();
+  v_rendicion_id BIGINT;
+  v_total_efectivo DECIMAL := 0;
+  v_total_otros DECIMAL := 0;
+  v_pedido RECORD;
+  v_count INTEGER := 0;
+BEGIN
+  -- Multi-tenant guard
+  IF v_sucursal IS NULL THEN
+    RAISE EXCEPTION 'No se pudo determinar la sucursal activa';
+  END IF;
+
+  -- tenant-scoped rendicion check
+  IF EXISTS (
+    SELECT 1 FROM rendiciones
+    WHERE transportista_id = p_transportista_id AND fecha = p_fecha AND sucursal_id = v_sucursal
+  ) THEN
+    RAISE EXCEPTION 'Ya existe una rendicion para este transportista en esta fecha';
+  END IF;
+
+  -- tenant-scoped pedidos query
+  FOR v_pedido IN
+    SELECT p.id,
+           COALESCE(p.total, 0) as total,
+           COALESCE(p.monto_pagado, p.total, 0) as monto_pagado,
+           COALESCE(p.forma_pago, 'efectivo') as forma_pago
+    FROM pedidos p
+    WHERE p.transportista_id = p_transportista_id
+      AND p.estado = 'entregado'
+      AND p.sucursal_id = v_sucursal
+      AND COALESCE(p.fecha_entrega, p.updated_at)::date = p_fecha
+  LOOP
+    v_count := v_count + 1;
+    IF v_pedido.forma_pago = 'efectivo' THEN
+      v_total_efectivo := v_total_efectivo + v_pedido.monto_pagado;
+    ELSE
+      v_total_otros := v_total_otros + v_pedido.monto_pagado;
+    END IF;
+  END LOOP;
+
+  -- tenant-scoped INSERT
+  INSERT INTO rendiciones (
+    recorrido_id, transportista_id, fecha,
+    total_efectivo_esperado, total_otros_medios, estado, sucursal_id
+  ) VALUES (
+    NULL, p_transportista_id, p_fecha,
+    v_total_efectivo, v_total_otros, 'pendiente', v_sucursal
+  ) RETURNING id INTO v_rendicion_id;
+
+  -- tenant-scoped INSERT
+  INSERT INTO rendicion_items (rendicion_id, pedido_id, monto_cobrado, forma_pago, sucursal_id)
+  SELECT v_rendicion_id, p.id,
+         COALESCE(p.monto_pagado, p.total, 0),
+         COALESCE(p.forma_pago, 'efectivo'),
+         v_sucursal
+  FROM pedidos p
+  WHERE p.transportista_id = p_transportista_id
+    AND p.estado = 'entregado'
+    AND p.sucursal_id = v_sucursal
+    AND COALESCE(p.fecha_entrega, p.updated_at)::date = p_fecha;
+
+  RETURN v_rendicion_id;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = public;
+
+
+-- ============================================================
+-- 16. presentar_rendicion
+-- ============================================================
+CREATE OR REPLACE FUNCTION presentar_rendicion(
+  p_rendicion_id BIGINT,
+  p_monto_rendido DECIMAL,
+  p_justificacion TEXT DEFAULT NULL
+)
+RETURNS JSONB AS $$
+DECLARE
+  v_sucursal BIGINT := current_sucursal_id();
+  v_transportista_id UUID;
+  v_estado VARCHAR;
+  v_diferencia DECIMAL;
+  v_es_admin BOOLEAN;
+BEGIN
+  -- Multi-tenant guard
+  IF v_sucursal IS NULL THEN
+    RETURN jsonb_build_object('success', false, 'error', 'No se pudo determinar la sucursal activa');
+  END IF;
+
+  v_es_admin := es_admin_rendiciones();
+
+  -- tenant-scoped rendicion lookup
+  SELECT transportista_id, estado INTO v_transportista_id, v_estado
+  FROM rendiciones
+  WHERE id = p_rendicion_id AND sucursal_id = v_sucursal;
+
+  IF v_transportista_id IS NULL THEN
+    RETURN jsonb_build_object('success', false, 'error', 'Rendicion no encontrada');
+  END IF;
+
+  IF v_estado NOT IN ('pendiente', 'con_observaciones') THEN
+    RETURN jsonb_build_object('success', false, 'error', 'La rendicion no esta en estado editable');
+  END IF;
+
+  IF v_transportista_id != auth.uid() AND NOT v_es_admin THEN
+    RETURN jsonb_build_object('success', false, 'error', 'No autorizado');
+  END IF;
+
+  -- tenant-scoped UPDATE
+  UPDATE rendiciones SET
+    monto_rendido = p_monto_rendido,
+    justificacion_transportista = p_justificacion,
+    estado = 'presentada',
+    presentada_at = NOW(),
+    updated_at = NOW()
+  WHERE id = p_rendicion_id AND sucursal_id = v_sucursal;
+
+  SELECT diferencia INTO v_diferencia
+  FROM rendiciones WHERE id = p_rendicion_id AND sucursal_id = v_sucursal;
+
+  RETURN jsonb_build_object(
+    'success', true,
+    'diferencia', v_diferencia,
+    'requiere_justificacion', ABS(v_diferencia) > 0
+  );
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = public;
+
+
+-- ============================================================
+-- 17. revisar_rendicion
+-- ============================================================
+CREATE OR REPLACE FUNCTION revisar_rendicion(
+  p_rendicion_id BIGINT,
+  p_accion VARCHAR,
+  p_observaciones TEXT DEFAULT NULL
+)
+RETURNS JSONB AS $$
+DECLARE
+  v_sucursal BIGINT := current_sucursal_id();
+  v_nuevo_estado VARCHAR;
+  v_recorrido_id BIGINT;
+BEGIN
+  -- Multi-tenant guard
+  IF v_sucursal IS NULL THEN
+    RETURN jsonb_build_object('success', false, 'error', 'No se pudo determinar la sucursal activa');
+  END IF;
+
+  IF NOT es_admin_rendiciones() THEN
+    RETURN jsonb_build_object('success', false, 'error', 'Solo administradores pueden revisar rendiciones');
+  END IF;
+
+  -- tenant-scoped check
+  IF NOT EXISTS (SELECT 1 FROM rendiciones WHERE id = p_rendicion_id AND estado = 'presentada' AND sucursal_id = v_sucursal) THEN
+    RETURN jsonb_build_object('success', false, 'error', 'Rendicion no encontrada o no esta presentada');
+  END IF;
+
+  v_nuevo_estado := CASE p_accion
+    WHEN 'aprobar' THEN 'aprobada'
+    WHEN 'rechazar' THEN 'rechazada'
+    WHEN 'observar' THEN 'con_observaciones'
+    ELSE NULL
+  END;
+
+  IF v_nuevo_estado IS NULL THEN
+    RETURN jsonb_build_object('success', false, 'error', 'Accion no valida');
+  END IF;
+
+  SELECT recorrido_id INTO v_recorrido_id FROM rendiciones WHERE id = p_rendicion_id AND sucursal_id = v_sucursal;
+
+  -- tenant-scoped UPDATE
+  UPDATE rendiciones SET
+    estado = v_nuevo_estado,
+    observaciones_admin = p_observaciones,
+    revisada_at = NOW(),
+    revisada_por = auth.uid(),
+    updated_at = NOW()
+  WHERE id = p_rendicion_id AND sucursal_id = v_sucursal;
+
+  -- If approved, mark recorrido as completed -- tenant-scoped
+  IF v_nuevo_estado = 'aprobada' AND v_recorrido_id IS NOT NULL THEN
+    UPDATE recorridos SET
+      estado = 'completado',
+      completed_at = NOW()
+    WHERE id = v_recorrido_id AND sucursal_id = v_sucursal;
+  END IF;
+
+  RETURN jsonb_build_object('success', true, 'nuevo_estado', v_nuevo_estado);
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = public;
+
+
+-- ============================================================
+-- 18. obtener_estadisticas_rendiciones
+-- ============================================================
+CREATE OR REPLACE FUNCTION obtener_estadisticas_rendiciones(
+  p_fecha_desde DATE DEFAULT NULL,
+  p_fecha_hasta DATE DEFAULT NULL,
+  p_transportista_id UUID DEFAULT NULL
+)
+RETURNS JSONB AS $$
+DECLARE
+  v_sucursal BIGINT := current_sucursal_id();
+  v_resultado JSONB;
+BEGIN
+  -- Multi-tenant guard
+  IF v_sucursal IS NULL THEN
+    RETURN jsonb_build_object('error', 'No se pudo determinar la sucursal activa');
+  END IF;
+
+  SELECT jsonb_build_object(
+    'total', COUNT(*),
+    'pendientes', COUNT(*) FILTER (WHERE estado IN ('pendiente', 'presentada')),
+    'aprobadas', COUNT(*) FILTER (WHERE estado = 'aprobada'),
+    'rechazadas', COUNT(*) FILTER (WHERE estado = 'rechazada'),
+    'con_observaciones', COUNT(*) FILTER (WHERE estado = 'con_observaciones'),
+    'total_efectivo_esperado', COALESCE(SUM(total_efectivo_esperado), 0),
+    'total_rendido', COALESCE(SUM(monto_rendido) FILTER (WHERE estado = 'aprobada'), 0),
+    'total_diferencias', COALESCE(SUM(diferencia) FILTER (WHERE estado = 'aprobada'), 0),
+    'por_transportista', (
+      SELECT jsonb_agg(jsonb_build_object(
+        'transportista_id', transportista_id,
+        'transportista_nombre', p.nombre,
+        'rendiciones', cnt,
+        'total_rendido', total_rend,
+        'total_diferencias', total_dif
+      ))
+      FROM (
+        SELECT
+          r.transportista_id,
+          COUNT(*) as cnt,
+          SUM(r.monto_rendido) as total_rend,
+          SUM(r.diferencia) as total_dif
+        FROM rendiciones r
+        WHERE r.sucursal_id = v_sucursal
+          AND (p_fecha_desde IS NULL OR r.fecha >= p_fecha_desde)
+          AND (p_fecha_hasta IS NULL OR r.fecha <= p_fecha_hasta)
+          AND (p_transportista_id IS NULL OR r.transportista_id = p_transportista_id)
+        GROUP BY r.transportista_id
+      ) t
+      JOIN perfiles p ON p.id = t.transportista_id
+    )
+  ) INTO v_resultado
+  FROM rendiciones
+  WHERE sucursal_id = v_sucursal
+    AND (p_fecha_desde IS NULL OR fecha >= p_fecha_desde)
+    AND (p_fecha_hasta IS NULL OR fecha <= p_fecha_hasta)
+    AND (p_transportista_id IS NULL OR transportista_id = p_transportista_id);
+
+  RETURN v_resultado;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = public;
+
+
+-- ============================================================
+-- 19. obtener_resumen_compras
+-- ============================================================
+CREATE OR REPLACE FUNCTION obtener_resumen_compras(
+  p_fecha_desde DATE DEFAULT NULL,
+  p_fecha_hasta DATE DEFAULT NULL
+)
+RETURNS TABLE (
+  total_compras BIGINT,
+  monto_total DECIMAL,
+  promedio_compra DECIMAL,
+  productos_comprados BIGINT
+) AS $$
+DECLARE
+  v_sucursal BIGINT := current_sucursal_id();
+BEGIN
+  RETURN QUERY
+  SELECT
+    COUNT(DISTINCT c.id)::BIGINT as total_compras,
+    COALESCE(SUM(c.total), 0)::DECIMAL as monto_total,
+    COALESCE(AVG(c.total), 0)::DECIMAL as promedio_compra,
+    COALESCE(SUM(ci.cantidad), 0)::BIGINT as productos_comprados
+  FROM compras c
+  LEFT JOIN compra_items ci ON c.id = ci.compra_id
+  WHERE c.estado != 'cancelada'
+    AND c.sucursal_id = v_sucursal
+    AND (p_fecha_desde IS NULL OR c.fecha_compra >= p_fecha_desde)
+    AND (p_fecha_hasta IS NULL OR c.fecha_compra <= p_fecha_hasta);
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = public;
+
+
+-- ============================================================
+-- 20. obtener_resumen_cuenta_cliente
+-- ============================================================
+CREATE OR REPLACE FUNCTION public.obtener_resumen_cuenta_cliente(p_cliente_id integer)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $function$
+DECLARE
+  v_sucursal BIGINT := current_sucursal_id();
+  v_total_pedidos NUMERIC;
+  v_total_pagado NUMERIC;
+  v_saldo NUMERIC;
+  v_user_role TEXT;
+BEGIN
+  -- Multi-tenant guard
+  IF v_sucursal IS NULL THEN
+    RETURN jsonb_build_object('error', 'No se pudo determinar la sucursal activa');
+  END IF;
+
+  SELECT rol INTO v_user_role FROM perfiles WHERE id = auth.uid();
+  IF v_user_role IS NULL OR v_user_role NOT IN ('admin', 'preventista') THEN
+    RETURN jsonb_build_object('error', 'No autorizado');
+  END IF;
+
+  -- tenant-scoped queries
+  SELECT COALESCE(SUM(total), 0) INTO v_total_pedidos
+  FROM pedidos WHERE cliente_id = p_cliente_id AND estado != 'cancelado' AND sucursal_id = v_sucursal;
+
+  SELECT COALESCE(SUM(monto), 0) INTO v_total_pagado
+  FROM pagos WHERE cliente_id = p_cliente_id AND sucursal_id = v_sucursal;
+
+  v_saldo := v_total_pedidos - v_total_pagado;
+
+  RETURN jsonb_build_object(
+    'total_pedidos', v_total_pedidos,
+    'total_pagado', v_total_pagado,
+    'saldo', v_saldo
+  );
+END;
+$function$;
+
+
+-- ============================================================
+-- 21. registrar_transferencia
+-- ============================================================
+CREATE OR REPLACE FUNCTION public.registrar_transferencia(
+  p_sucursal_id bigint,
+  p_fecha date DEFAULT CURRENT_DATE,
+  p_notas text DEFAULT NULL,
+  p_total_costo numeric DEFAULT 0,
+  p_usuario_id uuid DEFAULT NULL,
+  p_items jsonb DEFAULT '[]'::jsonb
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_sucursal BIGINT := current_sucursal_id();
+  v_transferencia_id BIGINT; v_item JSONB;
+  v_stock_actual INT; v_producto_nombre TEXT;
+  v_user_role TEXT;
+BEGIN
+  -- Multi-tenant guard
+  IF v_sucursal IS NULL THEN
+    RETURN jsonb_build_object('success', false, 'error', 'No se pudo determinar la sucursal activa');
+  END IF;
+
+  SELECT rol INTO v_user_role FROM perfiles WHERE id = COALESCE(p_usuario_id, auth.uid());
+  IF v_user_role IS NULL OR v_user_role NOT IN ('admin', 'encargado') THEN
+    RETURN jsonb_build_object('success', false, 'error', 'No autorizado');
+  END IF;
+
+  -- tenant-scoped INSERT (uses tenant_sucursal_id for transferencias_stock)
+  INSERT INTO transferencias_stock (sucursal_id, tipo, fecha, notas, total_costo, usuario_id, estado, tenant_sucursal_id)
+  VALUES (p_sucursal_id, 'egreso', p_fecha, p_notas, p_total_costo, COALESCE(p_usuario_id, auth.uid()), 'completada', v_sucursal)
+  RETURNING id INTO v_transferencia_id;
+
+  FOR v_item IN SELECT * FROM jsonb_array_elements(p_items) LOOP
+    -- tenant-scoped SELECT FOR UPDATE
+    SELECT stock, nombre INTO v_stock_actual, v_producto_nombre
+    FROM productos WHERE id = (v_item->>'producto_id')::BIGINT AND sucursal_id = v_sucursal FOR UPDATE;
+
+    IF v_stock_actual < (v_item->>'cantidad')::INT THEN
+      RAISE EXCEPTION 'Stock insuficiente para %: disponible %, solicitado %',
+        v_producto_nombre, v_stock_actual, (v_item->>'cantidad')::INT;
+    END IF;
+
+    -- tenant-scoped INSERT
+    INSERT INTO transferencia_items (transferencia_id, producto_id, cantidad, costo_unitario, sucursal_id)
+    VALUES (v_transferencia_id, (v_item->>'producto_id')::BIGINT, (v_item->>'cantidad')::INT,
+            COALESCE((v_item->>'costo_unitario')::DECIMAL, 0), v_sucursal);
+
+    -- tenant-scoped UPDATE
+    UPDATE productos SET stock = stock - (v_item->>'cantidad')::INT
+    WHERE id = (v_item->>'producto_id')::BIGINT AND sucursal_id = v_sucursal;
+  END LOOP;
+
+  RETURN jsonb_build_object('success', true, 'transferencia_id', v_transferencia_id);
+EXCEPTION WHEN OTHERS THEN
+  RETURN jsonb_build_object('success', false, 'error', SQLERRM);
+END;
+$$;
+
+
+-- ============================================================
+-- 22. registrar_ingreso_sucursal
+-- ============================================================
+CREATE OR REPLACE FUNCTION public.registrar_ingreso_sucursal(
+  p_sucursal_id bigint,
+  p_fecha date DEFAULT CURRENT_DATE,
+  p_notas text DEFAULT NULL,
+  p_total_costo numeric DEFAULT 0,
+  p_usuario_id uuid DEFAULT NULL,
+  p_items jsonb DEFAULT '[]'::jsonb
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_sucursal BIGINT := current_sucursal_id();
+  v_transferencia_id BIGINT; v_item JSONB;
+  v_user_role TEXT;
+BEGIN
+  -- Multi-tenant guard
+  IF v_sucursal IS NULL THEN
+    RETURN jsonb_build_object('success', false, 'error', 'No se pudo determinar la sucursal activa');
+  END IF;
+
+  SELECT rol INTO v_user_role FROM perfiles WHERE id = COALESCE(p_usuario_id, auth.uid());
+  IF v_user_role IS NULL OR v_user_role NOT IN ('admin', 'encargado') THEN
+    RETURN jsonb_build_object('success', false, 'error', 'No autorizado');
+  END IF;
+
+  -- tenant-scoped INSERT (uses tenant_sucursal_id for transferencias_stock)
+  INSERT INTO transferencias_stock (sucursal_id, tipo, fecha, notas, total_costo, usuario_id, estado, tenant_sucursal_id)
+  VALUES (p_sucursal_id, 'ingreso', p_fecha, p_notas, p_total_costo, COALESCE(p_usuario_id, auth.uid()), 'completada', v_sucursal)
+  RETURNING id INTO v_transferencia_id;
+
+  FOR v_item IN SELECT * FROM jsonb_array_elements(p_items) LOOP
+    -- tenant-scoped INSERT
+    INSERT INTO transferencia_items (transferencia_id, producto_id, cantidad, costo_unitario, sucursal_id)
+    VALUES (v_transferencia_id, (v_item->>'producto_id')::BIGINT, (v_item->>'cantidad')::INT,
+            COALESCE((v_item->>'costo_unitario')::DECIMAL, 0), v_sucursal);
+
+    -- tenant-scoped UPDATE
+    UPDATE productos SET stock = stock + (v_item->>'cantidad')::INT
+    WHERE id = (v_item->>'producto_id')::BIGINT AND sucursal_id = v_sucursal;
+  END LOOP;
+
+  RETURN jsonb_build_object('success', true, 'transferencia_id', v_transferencia_id);
+EXCEPTION WHEN OTHERS THEN
+  RETURN jsonb_build_object('success', false, 'error', SQLERRM);
+END;
+$$;
+
+
+-- ============================================================
+-- 23. anular_compra_atomica
+-- ============================================================
+CREATE OR REPLACE FUNCTION public.anular_compra_atomica(
+  p_compra_id bigint,
+  p_usuario_id uuid
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_sucursal BIGINT := current_sucursal_id();
+  v_compra RECORD;
+  v_item RECORD;
+  v_stock_actual INT;
+  v_producto_nombre TEXT;
+  v_user_role TEXT;
+  v_errores TEXT[] := '{}';
+BEGIN
+  -- Multi-tenant guard
+  IF v_sucursal IS NULL THEN
+    RETURN jsonb_build_object('success', false, 'error', 'No se pudo determinar la sucursal activa');
+  END IF;
+
+  IF p_usuario_id IS DISTINCT FROM auth.uid() THEN
+    RETURN jsonb_build_object('success', false, 'error', 'ID de usuario no coincide con la sesion autenticada');
+  END IF;
+
+  SELECT rol INTO v_user_role FROM perfiles WHERE id = p_usuario_id;
+  IF v_user_role IS NULL OR v_user_role NOT IN ('admin', 'encargado') THEN
+    RETURN jsonb_build_object('success', false, 'error', 'No autorizado: solo admin o encargado pueden anular compras');
+  END IF;
+
+  -- tenant-scoped compra lookup
+  SELECT * INTO v_compra FROM compras WHERE id = p_compra_id AND sucursal_id = v_sucursal;
+  IF NOT FOUND THEN
+    RETURN jsonb_build_object('success', false, 'error', 'Compra no encontrada');
+  END IF;
+
+  IF v_compra.estado = 'cancelada' THEN
+    RETURN jsonb_build_object('success', false, 'error', 'La compra ya esta cancelada');
+  END IF;
+
+  -- Validate stock availability -- tenant-scoped
+  FOR v_item IN
+    SELECT ci.producto_id, ci.cantidad, p.stock, p.nombre
+    FROM compra_items ci
+    JOIN productos p ON p.id = ci.producto_id AND p.sucursal_id = v_sucursal
+    WHERE ci.compra_id = p_compra_id AND ci.sucursal_id = v_sucursal
+    FOR UPDATE OF p
+  LOOP
+    IF v_item.stock < v_item.cantidad THEN
+      v_errores := array_append(v_errores,
+        COALESCE(v_item.nombre, 'Producto ' || v_item.producto_id)
+        || ': stock insuficiente para revertir (actual: ' || v_item.stock || ', necesario: ' || v_item.cantidad || ')');
+    END IF;
+  END LOOP;
+
+  IF array_length(v_errores, 1) > 0 THEN
+    RETURN jsonb_build_object('success', false, 'error', 'No se puede anular: ' || array_to_string(v_errores, '; '));
+  END IF;
+
+  -- Revert stock atomically -- tenant-scoped
+  UPDATE productos p
+  SET stock = p.stock - ci.cantidad,
+      updated_at = NOW()
+  FROM compra_items ci
+  WHERE ci.compra_id = p_compra_id
+    AND ci.sucursal_id = v_sucursal
+    AND p.id = ci.producto_id
+    AND p.sucursal_id = v_sucursal;
+
+  -- Mark compra as cancelled -- tenant-scoped
+  UPDATE compras
+  SET estado = 'cancelada',
+      updated_at = NOW()
+  WHERE id = p_compra_id AND sucursal_id = v_sucursal;
+
+  RETURN jsonb_build_object('success', true, 'mensaje', 'Compra anulada y stock revertido correctamente');
+END;
+$$;
+
+
+-- ============================================================
+-- 24. obtener_estadisticas_pedidos (may not exist yet as CREATE)
+--     This function is referenced in migration 033 but never fully
+--     defined in migrations. We create it here with tenant scope.
+-- ============================================================
+CREATE OR REPLACE FUNCTION public.obtener_estadisticas_pedidos(
+  p_fecha_desde TIMESTAMPTZ DEFAULT NULL,
+  p_fecha_hasta TIMESTAMPTZ DEFAULT NULL,
+  p_usuario_id UUID DEFAULT NULL
+)
+RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_sucursal BIGINT := current_sucursal_id();
+  v_resultado JSONB;
+BEGIN
+  -- Multi-tenant guard
+  IF v_sucursal IS NULL THEN
+    RETURN jsonb_build_object('error', 'No se pudo determinar la sucursal activa');
+  END IF;
+
+  SELECT jsonb_build_object(
+    'total', COUNT(*),
+    'pendientes', COUNT(*) FILTER (WHERE estado = 'pendiente'),
+    'en_preparacion', COUNT(*) FILTER (WHERE estado = 'en_preparacion'),
+    'en_reparto', COUNT(*) FILTER (WHERE estado = 'en_reparto'),
+    'entregados', COUNT(*) FILTER (WHERE estado = 'entregado'),
+    'cancelados', COUNT(*) FILTER (WHERE estado = 'cancelado'),
+    'monto_total', COALESCE(SUM(total) FILTER (WHERE estado != 'cancelado'), 0),
+    'monto_cobrado', COALESCE(SUM(monto_pagado) FILTER (WHERE estado = 'entregado'), 0)
+  ) INTO v_resultado
+  FROM pedidos
+  WHERE sucursal_id = v_sucursal
+    AND (p_fecha_desde IS NULL OR created_at >= p_fecha_desde)
+    AND (p_fecha_hasta IS NULL OR created_at <= p_fecha_hasta)
+    AND (p_usuario_id IS NULL OR usuario_id = p_usuario_id);
+
+  RETURN v_resultado;
+END;
+$$;
+
+
+-- ============================================================
+-- 25. audit_log_changes (TRIGGER FUNCTION)
+--     Copy sucursal_id from the row being modified into audit_logs
+-- ============================================================
+CREATE OR REPLACE FUNCTION public.audit_log_changes()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_old_data JSONB; v_new_data JSONB; v_campos_modificados TEXT[];
+  v_usuario_id UUID; v_usuario_email TEXT; v_usuario_rol TEXT;
+  v_registro_id TEXT; v_key TEXT;
+  v_old_changed JSONB; v_new_changed JSONB;
+  v_sucursal_id BIGINT;
+BEGIN
+  v_usuario_id := auth.uid();
+  IF v_usuario_id IS NOT NULL THEN
+    SELECT email INTO v_usuario_email FROM auth.users WHERE id = v_usuario_id;
+    SELECT rol INTO v_usuario_rol FROM public.perfiles WHERE id = v_usuario_id;
+  END IF;
+
+  -- Multi-tenant: extract sucursal_id from the row being modified
+  -- Use NEW for INSERT/UPDATE, OLD for DELETE, fallback to current_sucursal_id()
+  IF TG_OP = 'DELETE' THEN
+    v_registro_id := OLD.id::TEXT;
+    v_old_data := to_jsonb(OLD);
+    v_new_data := NULL;
+    v_sucursal_id := COALESCE((to_jsonb(OLD)->>'sucursal_id')::BIGINT, current_sucursal_id());
+  ELSIF TG_OP = 'INSERT' THEN
+    v_registro_id := NEW.id::TEXT;
+    v_old_data := NULL;
+    v_new_data := to_jsonb(NEW);
+    v_sucursal_id := COALESCE((to_jsonb(NEW)->>'sucursal_id')::BIGINT, current_sucursal_id());
+  ELSE
+    v_registro_id := NEW.id::TEXT;
+    v_old_data := to_jsonb(OLD);
+    v_new_data := to_jsonb(NEW);
+    v_sucursal_id := COALESCE((to_jsonb(NEW)->>'sucursal_id')::BIGINT, (to_jsonb(OLD)->>'sucursal_id')::BIGINT, current_sucursal_id());
+
+    -- Find changed fields and store only those
+    v_campos_modificados := ARRAY[]::TEXT[];
+    v_old_changed := '{}'::JSONB;
+    v_new_changed := '{}'::JSONB;
+
+    FOR v_key IN SELECT jsonb_object_keys(v_new_data) LOOP
+      IF v_old_data->v_key IS DISTINCT FROM v_new_data->v_key THEN
+        v_campos_modificados := array_append(v_campos_modificados, v_key);
+        v_old_changed := v_old_changed || jsonb_build_object(v_key, v_old_data->v_key);
+        v_new_changed := v_new_changed || jsonb_build_object(v_key, v_new_data->v_key);
+      END IF;
+    END LOOP;
+
+    -- Skip if nothing actually changed
+    IF array_length(v_campos_modificados, 1) IS NULL OR array_length(v_campos_modificados, 1) = 0 THEN
+      RETURN NEW;
+    END IF;
+
+    v_old_data := v_old_changed;
+    v_new_data := v_new_changed;
+  END IF;
+
+  INSERT INTO public.audit_logs (tabla, registro_id, accion, old_data, new_data, campos_modificados, usuario_id, usuario_email, usuario_rol, sucursal_id)
+  VALUES (TG_TABLE_NAME, v_registro_id, TG_OP, v_old_data, v_new_data, v_campos_modificados, v_usuario_id, v_usuario_email, v_usuario_rol, COALESCE(v_sucursal_id, 1));
+
+  IF TG_OP = 'DELETE' THEN RETURN OLD; ELSE RETURN NEW; END IF;
+END;
+$$;
+
+
+-- ============================================================
+-- 26. registrar_cambio_stock (TRIGGER FUNCTION)
+--     Copy sucursal_id from NEW into stock_historico
+-- ============================================================
+-- Note: This function was created via Supabase UI and referenced in migration 033.
+-- We recreate it here with multi-tenant support.
+CREATE OR REPLACE FUNCTION public.registrar_cambio_stock()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+  IF OLD.stock IS DISTINCT FROM NEW.stock THEN
+    INSERT INTO stock_historico (producto_id, stock_anterior, stock_nuevo, diferencia, usuario_id, sucursal_id)
+    VALUES (
+      NEW.id,
+      OLD.stock,
+      NEW.stock,
+      NEW.stock - OLD.stock,
+      auth.uid(),
+      NEW.sucursal_id
+    );
+  END IF;
+  RETURN NEW;
+END;
+$$;
+
+
+-- ============================================================
+-- 27. actualizar_saldo_pedido (TRIGGER FUNCTION)
+--     Filter clientes UPDATE by the pedido's sucursal_id
+-- ============================================================
+CREATE OR REPLACE FUNCTION actualizar_saldo_pedido()
+RETURNS TRIGGER AS $$
+DECLARE
+  saldo_anterior NUMERIC;
+  saldo_nuevo NUMERIC;
+BEGIN
+  IF TG_OP = 'INSERT' THEN
+    saldo_nuevo := NEW.total - COALESCE(NEW.monto_pagado, 0);
+    UPDATE clientes
+    SET saldo_cuenta = COALESCE(saldo_cuenta, 0) + saldo_nuevo
+    WHERE id = NEW.cliente_id AND sucursal_id = NEW.sucursal_id;
+
+  ELSIF TG_OP = 'DELETE' THEN
+    saldo_anterior := OLD.total - COALESCE(OLD.monto_pagado, 0);
+    UPDATE clientes
+    SET saldo_cuenta = COALESCE(saldo_cuenta, 0) - saldo_anterior
+    WHERE id = OLD.cliente_id AND sucursal_id = OLD.sucursal_id;
+
+  ELSIF TG_OP = 'UPDATE' THEN
+    saldo_anterior := OLD.total - COALESCE(OLD.monto_pagado, 0);
+    saldo_nuevo := NEW.total - COALESCE(NEW.monto_pagado, 0);
+
+    IF saldo_anterior != saldo_nuevo THEN
+      UPDATE clientes
+      SET saldo_cuenta = COALESCE(saldo_cuenta, 0) - saldo_anterior + saldo_nuevo
+      WHERE id = NEW.cliente_id AND sucursal_id = NEW.sucursal_id;
+    END IF;
+  END IF;
+
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+
+-- ============================================================
+-- 28. obtener_estadisticas_salvedades
+--     Add tenant filtering to all queries
+-- ============================================================
+CREATE OR REPLACE FUNCTION obtener_estadisticas_salvedades(
+  p_fecha_desde DATE DEFAULT NULL,
+  p_fecha_hasta DATE DEFAULT NULL
+)
+RETURNS JSONB AS $$
+DECLARE
+  v_sucursal BIGINT := current_sucursal_id();
+  v_resultado JSONB;
+BEGIN
+  -- Multi-tenant guard
+  IF v_sucursal IS NULL THEN
+    RETURN jsonb_build_object('error', 'No se pudo determinar la sucursal activa');
+  END IF;
+
+  SELECT jsonb_build_object(
+    'total', COUNT(*),
+    'pendientes', COUNT(*) FILTER (WHERE estado_resolucion = 'pendiente'),
+    'resueltas', COUNT(*) FILTER (WHERE estado_resolucion NOT IN ('pendiente', 'anulada')),
+    'anuladas', COUNT(*) FILTER (WHERE estado_resolucion = 'anulada'),
+    'monto_total_afectado', COALESCE(SUM(monto_afectado), 0),
+    'monto_pendiente', COALESCE(SUM(monto_afectado) FILTER (WHERE estado_resolucion = 'pendiente'), 0),
+    'por_motivo', (
+      SELECT jsonb_object_agg(motivo, cnt)
+      FROM (
+        SELECT motivo, COUNT(*) as cnt
+        FROM salvedades_items
+        WHERE sucursal_id = v_sucursal
+          AND (p_fecha_desde IS NULL OR created_at::date >= p_fecha_desde)
+          AND (p_fecha_hasta IS NULL OR created_at::date <= p_fecha_hasta)
+        GROUP BY motivo
+      ) t
+    ),
+    'por_resolucion', (
+      SELECT jsonb_object_agg(estado_resolucion, cnt)
+      FROM (
+        SELECT estado_resolucion, COUNT(*) as cnt
+        FROM salvedades_items
+        WHERE sucursal_id = v_sucursal
+          AND (p_fecha_desde IS NULL OR created_at::date >= p_fecha_desde)
+          AND (p_fecha_hasta IS NULL OR created_at::date <= p_fecha_hasta)
+        GROUP BY estado_resolucion
+      ) t
+    ),
+    'por_producto', (
+      SELECT jsonb_agg(jsonb_build_object(
+        'producto_id', producto_id,
+        'producto_nombre', producto_nombre,
+        'cantidad', cnt,
+        'monto', monto,
+        'unidades_afectadas', unidades
+      ))
+      FROM (
+        SELECT
+          s.producto_id,
+          p.nombre as producto_nombre,
+          COUNT(*) as cnt,
+          SUM(s.monto_afectado) as monto,
+          SUM(s.cantidad_afectada) as unidades
+        FROM salvedades_items s
+        JOIN productos p ON p.id = s.producto_id
+        WHERE s.sucursal_id = v_sucursal
+          AND (p_fecha_desde IS NULL OR s.created_at::date >= p_fecha_desde)
+          AND (p_fecha_hasta IS NULL OR s.created_at::date <= p_fecha_hasta)
+        GROUP BY s.producto_id, p.nombre
+        ORDER BY cnt DESC
+        LIMIT 10
+      ) t
+    ),
+    'por_transportista', (
+      SELECT jsonb_agg(jsonb_build_object(
+        'transportista_id', transportista_id,
+        'transportista_nombre', transportista_nombre,
+        'cantidad', cnt,
+        'monto', monto
+      ))
+      FROM (
+        SELECT
+          pe.transportista_id,
+          pf.nombre as transportista_nombre,
+          COUNT(*) as cnt,
+          SUM(s.monto_afectado) as monto
+        FROM salvedades_items s
+        JOIN pedidos pe ON pe.id = s.pedido_id
+        JOIN perfiles pf ON pf.id = pe.transportista_id
+        WHERE s.sucursal_id = v_sucursal
+          AND (p_fecha_desde IS NULL OR s.created_at::date >= p_fecha_desde)
+          AND (p_fecha_hasta IS NULL OR s.created_at::date <= p_fecha_hasta)
+        GROUP BY pe.transportista_id, pf.nombre
+        ORDER BY cnt DESC
+        LIMIT 10
+      ) t
+    )
+  ) INTO v_resultado
+  FROM salvedades_items
+  WHERE sucursal_id = v_sucursal
+    AND (p_fecha_desde IS NULL OR created_at::date >= p_fecha_desde)
+    AND (p_fecha_hasta IS NULL OR created_at::date <= p_fecha_hasta);
+
+  RETURN v_resultado;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = public;
+
+
+-- ============================================================
+-- End of migration 059
+-- ============================================================

--- a/migrations/060_multi_tenant_fixups.sql
+++ b/migrations/060_multi_tenant_fixups.sql
@@ -22,12 +22,22 @@ UPDATE sucursales SET tipo = 'distribuidora' WHERE id NOT IN (1, 2) AND tipo IS 
 ALTER TABLE stock_historico ADD COLUMN IF NOT EXISTS usuario_id UUID REFERENCES auth.users(id);
 
 -- =========================================================
--- 3. Drop the 13-param overload of registrar_compra_completa (with p_tipo_factura)
+-- 3. Drop the 13-param overloads of registrar_compra_completa.
+--    The legacy overload exists in BOTH `text` and `character varying`
+--    signatures depending on which historical migration created it
+--    (045 used text, later one re-declared with character varying).
+--    Drop both so only the sucursal-aware version we re-create below
+--    remains.
 -- =========================================================
 DROP FUNCTION IF EXISTS public.registrar_compra_completa(
   bigint, character varying, character varying, date,
   numeric, numeric, numeric, numeric, character varying,
   text, uuid, jsonb, character varying
+);
+DROP FUNCTION IF EXISTS public.registrar_compra_completa(
+  bigint, character varying, character varying, date,
+  numeric, numeric, numeric, numeric, character varying,
+  text, uuid, jsonb, text
 );
 
 -- =========================================================

--- a/migrations/060_multi_tenant_fixups.sql
+++ b/migrations/060_multi_tenant_fixups.sql
@@ -1,0 +1,246 @@
+-- Migration 060: Fix structural issues in 057/058/059
+--
+-- Context: Migration 057 seeded sucursales with ON CONFLICT DO NOTHING but
+-- row id=1 already existed as 'TACO POZO', so the tenant was never renamed
+-- to 'ManaosApp'. Migration 059 references columns that don't exist on
+-- stock_historico and leaves a dangerous overload of registrar_compra_completa.
+-- Migration 058 drops policies by exact legacy name -- survivors OR-permissive
+-- bypass the tenant filter.
+
+-- =========================================================
+-- 1. Rename existing sucursal id=1 to 'ManaosApp' and set tipo
+-- =========================================================
+UPDATE sucursales SET nombre = 'ManaosApp', tipo = 'principal' WHERE id = 1;
+UPDATE sucursales SET nombre = 'TP Export', tipo = 'secundaria' WHERE id = 2;
+
+-- Mark every other row as transfer-type (sub-branches used in ModalTransferencia)
+UPDATE sucursales SET tipo = 'distribuidora' WHERE id NOT IN (1, 2) AND tipo IS NULL;
+
+-- =========================================================
+-- 2. Fix stock_historico: ensure usuario_id column exists
+-- =========================================================
+ALTER TABLE stock_historico ADD COLUMN IF NOT EXISTS usuario_id UUID REFERENCES auth.users(id);
+
+-- =========================================================
+-- 3. Drop the 13-param overload of registrar_compra_completa (with p_tipo_factura)
+-- =========================================================
+DROP FUNCTION IF EXISTS public.registrar_compra_completa(
+  bigint, character varying, character varying, date,
+  numeric, numeric, numeric, numeric, character varying,
+  text, uuid, jsonb, character varying
+);
+
+-- =========================================================
+-- 4. Re-create the 13-param overload with sucursal_id support
+--    (delegates to the 12-param overload from migration 059 after adding sucursal_id)
+-- =========================================================
+CREATE OR REPLACE FUNCTION public.registrar_compra_completa(
+  p_proveedor_id BIGINT,
+  p_proveedor_nombre VARCHAR,
+  p_numero_factura VARCHAR,
+  p_fecha_compra DATE,
+  p_subtotal NUMERIC,
+  p_iva NUMERIC,
+  p_otros_impuestos NUMERIC,
+  p_total NUMERIC,
+  p_forma_pago VARCHAR,
+  p_notas TEXT,
+  p_usuario_id UUID,
+  p_items JSONB,
+  p_tipo_factura VARCHAR DEFAULT 'FC'
+) RETURNS JSONB
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = public
+AS $$
+DECLARE
+  v_sucursal BIGINT := current_sucursal_id();
+  v_compra_id BIGINT;
+  v_item JSONB;
+BEGIN
+  IF v_sucursal IS NULL THEN
+    RETURN jsonb_build_object('success', false, 'error', 'No se pudo determinar la sucursal activa');
+  END IF;
+
+  INSERT INTO compras (
+    proveedor_id, proveedor_nombre, numero_factura, fecha_compra,
+    subtotal, iva, otros_impuestos, total, forma_pago, notas,
+    usuario_id, tipo_factura, sucursal_id
+  ) VALUES (
+    p_proveedor_id, p_proveedor_nombre, p_numero_factura, p_fecha_compra,
+    p_subtotal, p_iva, p_otros_impuestos, p_total, p_forma_pago, p_notas,
+    p_usuario_id, p_tipo_factura, v_sucursal
+  )
+  RETURNING id INTO v_compra_id;
+
+  FOR v_item IN SELECT * FROM jsonb_array_elements(p_items) LOOP
+    INSERT INTO compra_items (
+      compra_id, producto_id, cantidad, costo_unitario, subtotal,
+      bonificacion, porcentaje_iva, impuestos_internos, sucursal_id
+    ) VALUES (
+      v_compra_id,
+      (v_item->>'producto_id')::BIGINT,
+      (v_item->>'cantidad')::NUMERIC,
+      (v_item->>'costo_unitario')::NUMERIC,
+      (v_item->>'subtotal')::NUMERIC,
+      COALESCE((v_item->>'bonificacion')::NUMERIC, 0),
+      COALESCE((v_item->>'porcentaje_iva')::NUMERIC, 21),
+      COALESCE((v_item->>'impuestos_internos')::NUMERIC, 0),
+      v_sucursal
+    );
+
+    UPDATE productos
+       SET stock = stock + (v_item->>'cantidad')::NUMERIC
+     WHERE id = (v_item->>'producto_id')::BIGINT AND sucursal_id = v_sucursal;
+  END LOOP;
+
+  RETURN jsonb_build_object('success', true, 'compra_id', v_compra_id);
+END;
+$$;
+
+-- =========================================================
+-- 5. Add role check to registrar_nota_credito (H8)
+-- =========================================================
+CREATE OR REPLACE FUNCTION public.registrar_nota_credito(
+  p_compra_id BIGINT,
+  p_numero_nota VARCHAR DEFAULT NULL,
+  p_motivo TEXT DEFAULT NULL,
+  p_subtotal DECIMAL DEFAULT 0,
+  p_iva DECIMAL DEFAULT 0,
+  p_total DECIMAL DEFAULT 0,
+  p_usuario_id UUID DEFAULT NULL,
+  p_items JSONB DEFAULT '[]'
+) RETURNS JSONB
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = public
+AS $$
+DECLARE
+  v_sucursal BIGINT := current_sucursal_id();
+  v_nota_id BIGINT; v_item JSONB; v_stock_actual INTEGER;
+  v_producto_id BIGINT; v_cantidad INTEGER; v_costo DECIMAL; v_sub DECIMAL;
+BEGIN
+  IF v_sucursal IS NULL THEN
+    RETURN jsonb_build_object('success', false, 'error', 'No se pudo determinar la sucursal activa');
+  END IF;
+
+  -- NEW: role check (reuse es_encargado_o_admin helper from migration 041)
+  IF NOT (es_encargado_o_admin()) THEN
+    RETURN jsonb_build_object('success', false, 'error', 'No autorizado para registrar notas de credito');
+  END IF;
+
+  IF NOT EXISTS (SELECT 1 FROM compras WHERE id = p_compra_id AND estado != 'cancelada' AND sucursal_id = v_sucursal) THEN
+    RETURN jsonb_build_object('success', false, 'error', 'Compra no encontrada o cancelada');
+  END IF;
+
+  INSERT INTO notas_credito (compra_id, numero_nota, fecha, subtotal, iva, total, motivo, usuario_id, sucursal_id)
+  VALUES (p_compra_id, p_numero_nota, CURRENT_DATE, p_subtotal, p_iva, p_total, p_motivo, p_usuario_id, v_sucursal)
+  RETURNING id INTO v_nota_id;
+
+  FOR v_item IN SELECT * FROM jsonb_array_elements(p_items) LOOP
+    v_producto_id := (v_item->>'producto_id')::BIGINT;
+    v_cantidad := (v_item->>'cantidad')::INTEGER;
+    v_costo := (v_item->>'costo_unitario')::DECIMAL;
+    v_sub := (v_item->>'subtotal')::DECIMAL;
+    SELECT stock INTO v_stock_actual FROM productos WHERE id = v_producto_id AND sucursal_id = v_sucursal FOR UPDATE;
+    IF v_stock_actual IS NULL THEN RAISE EXCEPTION 'Producto % no encontrado', v_producto_id; END IF;
+    INSERT INTO nota_credito_items (nota_credito_id, producto_id, cantidad, costo_unitario, subtotal, stock_anterior, stock_nuevo, sucursal_id)
+    VALUES (v_nota_id, v_producto_id, v_cantidad, v_costo, v_sub, v_stock_actual, GREATEST(v_stock_actual - v_cantidad, 0), v_sucursal);
+    UPDATE productos SET stock = GREATEST(stock - v_cantidad, 0) WHERE id = v_producto_id AND sucursal_id = v_sucursal;
+  END LOOP;
+
+  RETURN jsonb_build_object('success', true, 'nota_credito_id', v_nota_id);
+END;
+$$;
+
+-- =========================================================
+-- 6. audit_log_changes: FAIL instead of silent fallback to sucursal_id=1 (H7)
+-- =========================================================
+-- Replace the INSERT: drop `COALESCE(v_sucursal_id, 1)` -> require v_sucursal_id.
+-- If the row being audited has no sucursal_id and current_sucursal_id() is NULL,
+-- raise exception rather than leaking audit rows into tenant 1.
+CREATE OR REPLACE FUNCTION public.audit_log_changes()
+RETURNS TRIGGER LANGUAGE plpgsql SECURITY DEFINER SET search_path = public
+AS $$
+DECLARE
+  v_old_data JSONB; v_new_data JSONB; v_campos_modificados TEXT[];
+  v_usuario_id UUID; v_usuario_email TEXT; v_usuario_rol TEXT;
+  v_registro_id TEXT; v_key TEXT;
+  v_old_changed JSONB; v_new_changed JSONB;
+  v_sucursal_id BIGINT;
+BEGIN
+  v_usuario_id := auth.uid();
+  IF v_usuario_id IS NOT NULL THEN
+    SELECT email INTO v_usuario_email FROM auth.users WHERE id = v_usuario_id;
+    SELECT rol INTO v_usuario_rol FROM public.perfiles WHERE id = v_usuario_id;
+  END IF;
+
+  IF TG_OP = 'DELETE' THEN
+    v_registro_id := OLD.id::TEXT;
+    v_old_data := to_jsonb(OLD);
+    v_new_data := NULL;
+    v_sucursal_id := COALESCE((to_jsonb(OLD)->>'sucursal_id')::BIGINT, current_sucursal_id());
+  ELSIF TG_OP = 'INSERT' THEN
+    v_registro_id := NEW.id::TEXT;
+    v_old_data := NULL;
+    v_new_data := to_jsonb(NEW);
+    v_sucursal_id := COALESCE((to_jsonb(NEW)->>'sucursal_id')::BIGINT, current_sucursal_id());
+  ELSE
+    v_registro_id := NEW.id::TEXT;
+    v_old_data := to_jsonb(OLD);
+    v_new_data := to_jsonb(NEW);
+    v_sucursal_id := COALESCE((to_jsonb(NEW)->>'sucursal_id')::BIGINT, (to_jsonb(OLD)->>'sucursal_id')::BIGINT, current_sucursal_id());
+
+    v_campos_modificados := ARRAY[]::TEXT[];
+    v_old_changed := '{}'::JSONB;
+    v_new_changed := '{}'::JSONB;
+    FOR v_key IN SELECT jsonb_object_keys(v_new_data) LOOP
+      IF v_old_data->v_key IS DISTINCT FROM v_new_data->v_key THEN
+        v_campos_modificados := array_append(v_campos_modificados, v_key);
+        v_old_changed := v_old_changed || jsonb_build_object(v_key, v_old_data->v_key);
+        v_new_changed := v_new_changed || jsonb_build_object(v_key, v_new_data->v_key);
+      END IF;
+    END LOOP;
+    IF array_length(v_campos_modificados, 1) IS NULL OR array_length(v_campos_modificados, 1) = 0 THEN
+      RETURN NEW;
+    END IF;
+    v_old_data := v_old_changed;
+    v_new_data := v_new_changed;
+  END IF;
+
+  -- FIX H7: no silent fallback to 1
+  IF v_sucursal_id IS NULL THEN
+    RAISE EXCEPTION 'audit_log_changes: cannot determine sucursal_id for table %', TG_TABLE_NAME;
+  END IF;
+
+  INSERT INTO public.audit_logs (tabla, registro_id, accion, old_data, new_data, campos_modificados, usuario_id, usuario_email, usuario_rol, sucursal_id)
+  VALUES (TG_TABLE_NAME, v_registro_id, TG_OP, v_old_data, v_new_data, v_campos_modificados, v_usuario_id, v_usuario_email, v_usuario_rol, v_sucursal_id);
+
+  IF TG_OP = 'DELETE' THEN RETURN OLD; ELSE RETURN NEW; END IF;
+END;
+$$;
+
+-- =========================================================
+-- 7. Drop any non-mt_* policies by loop (H6) -- prevents surviving
+--    OR-permissive legacy policies on multi-tenant tables.
+-- =========================================================
+DO $$
+DECLARE r RECORD;
+BEGIN
+  FOR r IN
+    SELECT schemaname, tablename, policyname
+      FROM pg_policies
+     WHERE schemaname = 'public'
+       AND tablename IN (
+         'clientes','productos','pedidos','pedido_items','pagos','compras','compra_items',
+         'proveedores','mermas_stock','stock_historico','recorridos','recorrido_pedidos',
+         'rendiciones','rendicion_items','rendicion_ajustes','salvedades_items','salvedad_historial',
+         'notas_credito','nota_credito_items','transferencias_stock','transferencia_items',
+         'promociones','promocion_productos','promocion_reglas','promo_ajustes',
+         'grupos_precio','grupo_precio_productos','grupo_precio_escalas',
+         'pedidos_eliminados','audit_logs','zonas','preventista_zonas','historial_cambios','pedido_historial'
+       )
+       -- DO NOT drop the mt_* policies from migration 058
+       AND policyname NOT LIKE 'mt\_%' ESCAPE '\'
+       -- DO NOT touch usuario_sucursales (RLS from 057)
+       AND policyname NOT IN ('usuario_sucursales_select_own','usuario_sucursales_admin_all')
+  LOOP
+    EXECUTE format('DROP POLICY IF EXISTS %I ON %I.%I', r.policyname, r.schemaname, r.tablename);
+  END LOOP;
+END $$;

--- a/migrations/061_session_scoped_tenant.sql
+++ b/migrations/061_session_scoped_tenant.sql
@@ -1,0 +1,67 @@
+-- Migration 061: Session-scoped tenant resolver via X-Sucursal-ID header
+--
+-- Replaces the DB-state-based current_sucursal_id() (which reads
+-- usuario_sucursales.es_default) with a header-based resolver. This
+-- eliminates the multi-tab race where changing sucursal in one tab
+-- moved the active tenant globally for the same user (H10).
+--
+-- The client sends X-Sucursal-ID on every PostgREST request. PostgREST
+-- exposes it via current_setting('request.headers')::json. We parse it,
+-- validate against usuario_sucursales (authorization), and return the
+-- BIGINT. If header is missing, we fall back to es_default (backward
+-- compat for calls that don't set the header: Edge Functions, direct
+-- psql, triggers running outside a PostgREST request, etc.).
+
+CREATE OR REPLACE FUNCTION current_sucursal_id()
+RETURNS BIGINT
+LANGUAGE plpgsql STABLE SECURITY DEFINER SET search_path = public
+AS $$
+DECLARE
+  v_header_val TEXT;
+  v_sucursal_id BIGINT;
+  v_authorized BOOLEAN;
+BEGIN
+  -- Try header first (session-scoped, per-tab)
+  BEGIN
+    v_header_val := current_setting('request.headers', true)::json->>'x-sucursal-id';
+  EXCEPTION WHEN others THEN
+    v_header_val := NULL;
+  END;
+
+  IF v_header_val IS NOT NULL AND v_header_val <> '' THEN
+    BEGIN
+      v_sucursal_id := v_header_val::BIGINT;
+    EXCEPTION WHEN others THEN
+      -- Malformed header value -> treat as missing
+      v_sucursal_id := NULL;
+    END;
+
+    IF v_sucursal_id IS NOT NULL THEN
+      -- Authorization check: user must have a row in usuario_sucursales
+      SELECT EXISTS (
+        SELECT 1 FROM usuario_sucursales
+        WHERE usuario_id = auth.uid() AND sucursal_id = v_sucursal_id
+      ) INTO v_authorized;
+
+      IF v_authorized THEN
+        RETURN v_sucursal_id;
+      ELSE
+        -- Header present but user lacks access -> treat as NULL (RPCs will error)
+        RETURN NULL;
+      END IF;
+    END IF;
+  END IF;
+
+  -- Fallback: es_default (legacy path, e.g. triggers without request context)
+  RETURN (
+    SELECT sucursal_id FROM usuario_sucursales
+    WHERE usuario_id = auth.uid() AND es_default = true
+    LIMIT 1
+  );
+END;
+$$;
+
+-- cambiar_sucursal() remains from migration 057 as a best-effort
+-- default updater -- switching is now purely client-side (set the header),
+-- but we keep the es_default mutation so offline/Edge/trigger paths still
+-- resolve correctly. No redefinition needed here.

--- a/migrations/062_import_tp_export.sql
+++ b/migrations/062_import_tp_export.sql
@@ -1,0 +1,253 @@
+-- Migration 062: Import TP Export data into ManaosApp with sucursal_id=2
+--
+-- =====================================================================
+--  DO NOT RUN THIS AS PART OF THE NORMAL MIGRATION CHAIN.
+-- =====================================================================
+--
+-- This script is intentionally NOT idempotent and is intended to be run
+-- ONCE, manually, in a maintenance window, AFTER:
+--   1. Migrations 057 → 058 → 059 → 060 → 061 → 063 are applied.
+--   2. All target users (the 7 TP Export perfiles) already exist in
+--      ManaosApp's auth.users (same email — Supabase will assign a new UUID).
+--   3. You have postgres_fdw-level credentials to read from the TP Export
+--      Supabase project.
+--
+-- Expected volumes (Q1 2026 snapshot, per audit):
+--   perfiles:       7
+--   productos:     65
+--   clientes:      86
+--   pedidos:      142
+--   pedido_items: 534
+--
+-- Strategy: map TP Export auth.uid values → ManaosApp auth.uid by JOINing
+-- on email, then rewrite every user_id / usuario_id reference during
+-- INSERT. All imported rows get sucursal_id = 2.
+--
+-- See scripts/export-tp-export-dump.md for the full runbook.
+
+-- =====================================================================
+-- STEP 0. Prerequisites
+-- =====================================================================
+CREATE EXTENSION IF NOT EXISTS postgres_fdw;
+
+-- IMPORTANT: fill in the real connection details before running.
+-- Use a read-only role on the source project.
+--
+-- CREATE SERVER tp_remote
+--   FOREIGN DATA WRAPPER postgres_fdw
+--   OPTIONS (host '<tp-project-db-host>', dbname 'postgres', port '5432', sslmode 'require');
+--
+-- CREATE USER MAPPING FOR postgres
+--   SERVER tp_remote
+--   OPTIONS (user 'postgres', password '<tp-project-password>');
+--
+-- CREATE SCHEMA IF NOT EXISTS tp_remote_schema;
+--
+-- IMPORT FOREIGN SCHEMA public
+--   LIMIT TO (perfiles, clientes, productos, pedidos, pedido_items)
+--   FROM SERVER tp_remote INTO tp_remote_schema;
+
+-- Sanity check — the foreign schema must be importable.
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.schemata WHERE schema_name = 'tp_remote_schema'
+  ) THEN
+    RAISE EXCEPTION 'tp_remote_schema not found — run IMPORT FOREIGN SCHEMA first (see header)';
+  END IF;
+END $$;
+
+-- =====================================================================
+-- STEP 1. UUID remap (auth.users: TP → ManaosApp by email)
+-- =====================================================================
+-- Uses auth.users from BOTH instances; source UUIDs are stored on foreign
+-- rows (perfiles.id mirrors auth.users.id in Supabase).
+CREATE TEMP TABLE uuid_remap ON COMMIT PRESERVE ROWS AS
+SELECT
+  tp.id     AS tp_uuid,
+  local.id  AS local_uuid,
+  local.email
+FROM tp_remote_schema.perfiles AS tp
+JOIN public.perfiles           AS local ON local.email = tp.email;
+
+-- Fail loud if any TP user has no matching local account — importing rows
+-- whose owner is NULL would strand them outside RLS.
+DO $$
+DECLARE v_missing INT;
+BEGIN
+  SELECT COUNT(*) INTO v_missing
+    FROM tp_remote_schema.perfiles tp
+   WHERE NOT EXISTS (SELECT 1 FROM public.perfiles p WHERE p.email = tp.email);
+  IF v_missing > 0 THEN
+    RAISE EXCEPTION 'TP Export has % perfiles without a matching local account — create those auth.users first and re-run', v_missing;
+  END IF;
+END $$;
+
+-- =====================================================================
+-- STEP 2. usuario_sucursales — grant TP users access to sucursal 2
+-- =====================================================================
+-- Role stays 'mismo' so they inherit their perfiles.rol; es_default=false
+-- (admin can flip it later via asignar_usuario_sucursal from migration 063).
+INSERT INTO public.usuario_sucursales (usuario_id, sucursal_id, rol, es_default)
+SELECT rm.local_uuid, 2, 'mismo', false
+  FROM uuid_remap rm
+ON CONFLICT (usuario_id, sucursal_id) DO NOTHING;
+
+-- =====================================================================
+-- STEP 3. Productos
+-- =====================================================================
+-- Match by codigo (the product SKU). Rows with a codigo that already
+-- exists in sucursal 2 are assumed to have been imported previously.
+--
+-- TODO(operator): after running `SELECT column_name FROM
+-- information_schema.columns WHERE table_name='productos'` on BOTH
+-- projects, expand this SELECT to the actual column list that matches
+-- between source and target. Keep it explicit — `SELECT *` across
+-- postgres_fdw is a footgun because column order drift corrupts data.
+INSERT INTO public.productos (
+  nombre, codigo, stock, costo_sin_iva, costo_con_iva, precio_venta,
+  activo, sucursal_id
+  -- TODO: add remaining columns in schema order
+)
+SELECT
+  src.nombre,
+  src.codigo,
+  src.stock,
+  src.costo_sin_iva,
+  src.costo_con_iva,
+  src.precio_venta,
+  COALESCE(src.activo, true),
+  2
+FROM tp_remote_schema.productos AS src
+WHERE NOT EXISTS (
+  SELECT 1 FROM public.productos p
+   WHERE p.codigo = src.codigo AND p.sucursal_id = 2
+);
+
+-- Stash id remap so pedido_items can resolve new product IDs.
+CREATE TEMP TABLE producto_remap ON COMMIT PRESERVE ROWS AS
+SELECT src.id AS tp_id, local.id AS local_id
+FROM tp_remote_schema.productos src
+JOIN public.productos local
+  ON local.codigo = src.codigo
+ AND local.sucursal_id = 2;
+
+-- =====================================================================
+-- STEP 4. Clientes
+-- =====================================================================
+-- TODO(operator): expand column list (see productos TODO above). cuit
+-- is assumed unique within the tenant; adjust if collisions occur.
+INSERT INTO public.clientes (
+  razon_social, nombre_fantasia, direccion, telefono, cuit, zona,
+  sucursal_id, usuario_id
+  -- TODO: remaining columns
+)
+SELECT
+  src.razon_social,
+  src.nombre_fantasia,
+  src.direccion,
+  src.telefono,
+  src.cuit,
+  src.zona,
+  2,
+  rm.local_uuid
+FROM tp_remote_schema.clientes AS src
+LEFT JOIN uuid_remap rm ON rm.tp_uuid = src.usuario_id
+WHERE NOT EXISTS (
+  SELECT 1 FROM public.clientes c
+   WHERE c.cuit = src.cuit AND c.sucursal_id = 2
+);
+
+CREATE TEMP TABLE cliente_remap ON COMMIT PRESERVE ROWS AS
+SELECT src.id AS tp_id, local.id AS local_id
+FROM tp_remote_schema.clientes src
+JOIN public.clientes local
+  ON local.cuit = src.cuit
+ AND local.sucursal_id = 2;
+
+-- =====================================================================
+-- STEP 5. Pedidos
+-- =====================================================================
+-- Pedidos carry cliente_id (FK) and usuario_id (auth.uid). Both must be
+-- remapped. `numero_pedido` is kept as-is so operators can cross-reference
+-- the old system by ticket number; if ManaosApp generates its own sequence,
+-- remove it and let the INSERT default pick a new one.
+--
+-- TODO(operator): expand column list. The fields below are the minimum
+-- known to exist from migrations 001/008; verify with information_schema.
+INSERT INTO public.pedidos (
+  cliente_id, usuario_id, numero_pedido, fecha, estado, total,
+  sucursal_id
+  -- TODO: remaining columns (notas, forma_pago, etc.)
+)
+SELECT
+  cr.local_id,
+  rm.local_uuid,
+  src.numero_pedido,
+  src.fecha,
+  src.estado,
+  src.total,
+  2
+FROM tp_remote_schema.pedidos AS src
+JOIN cliente_remap cr ON cr.tp_id = src.cliente_id
+LEFT JOIN uuid_remap rm ON rm.tp_uuid = src.usuario_id
+WHERE NOT EXISTS (
+  -- Skip already-imported pedidos. If `numero_pedido` is not unique across
+  -- tenants, replace with a dedicated tp_import_marker column.
+  SELECT 1 FROM public.pedidos p
+   WHERE p.numero_pedido = src.numero_pedido AND p.sucursal_id = 2
+);
+
+CREATE TEMP TABLE pedido_remap ON COMMIT PRESERVE ROWS AS
+SELECT src.id AS tp_id, local.id AS local_id
+FROM tp_remote_schema.pedidos src
+JOIN public.pedidos local
+  ON local.numero_pedido = src.numero_pedido
+ AND local.sucursal_id = 2;
+
+-- =====================================================================
+-- STEP 6. Pedido_items (534 rows)
+-- =====================================================================
+-- Both pedido_id and producto_id need remapping. If a producto was not
+-- imported (missing codigo on source), the row is dropped — inspect the
+-- RAISE NOTICE below before the COMMIT to confirm zero orphans.
+WITH dropped AS (
+  SELECT src.id
+    FROM tp_remote_schema.pedido_items AS src
+   WHERE NOT EXISTS (
+     SELECT 1 FROM producto_remap pr WHERE pr.tp_id = src.producto_id
+   )
+     OR NOT EXISTS (
+     SELECT 1 FROM pedido_remap pe   WHERE pe.tp_id = src.pedido_id
+   )
+)
+SELECT COUNT(*) AS orphan_items FROM dropped;  -- inspect before COMMIT
+
+INSERT INTO public.pedido_items (
+  pedido_id, producto_id, cantidad, precio_unitario, sucursal_id
+  -- TODO: remaining columns (bonificacion, subtotal, etc.)
+)
+SELECT
+  pe.local_id,
+  pr.local_id,
+  src.cantidad,
+  src.precio_unitario,
+  2
+FROM tp_remote_schema.pedido_items AS src
+JOIN producto_remap pr ON pr.tp_id = src.producto_id
+JOIN pedido_remap   pe ON pe.tp_id = src.pedido_id;
+
+-- =====================================================================
+-- STEP 7. Post-import verification (run BEFORE COMMIT in psql)
+-- =====================================================================
+-- Each SELECT should return >0 and match the expected volume from the
+-- header comment, except orphan_items which should be 0.
+--
+-- SELECT 'productos' AS tabla, COUNT(*) FROM public.productos WHERE sucursal_id = 2
+-- UNION ALL SELECT 'clientes',  COUNT(*) FROM public.clientes  WHERE sucursal_id = 2
+-- UNION ALL SELECT 'pedidos',   COUNT(*) FROM public.pedidos   WHERE sucursal_id = 2
+-- UNION ALL SELECT 'pedido_items', COUNT(*) FROM public.pedido_items WHERE sucursal_id = 2
+-- UNION ALL SELECT 'usuario_sucursales (sucursal 2)', COUNT(*) FROM public.usuario_sucursales WHERE sucursal_id = 2;
+--
+-- If numbers match: COMMIT;
+-- If not: ROLLBACK; and investigate with the orphan_items CTE above.

--- a/migrations/063_usuario_sucursales_admin_rpcs.sql
+++ b/migrations/063_usuario_sucursales_admin_rpcs.sql
@@ -1,0 +1,53 @@
+-- Migration 063: Admin RPCs to manage usuario_sucursales
+--
+-- Since new signups are NOT auto-assigned (see SinSucursalScreen on the
+-- frontend), admins need a way to assign sucursales to users. These RPCs
+-- are invoked from the SQL Editor for now (no admin UI yet).
+
+CREATE OR REPLACE FUNCTION public.asignar_usuario_sucursal(
+  p_usuario_id UUID,
+  p_sucursal_id BIGINT,
+  p_rol VARCHAR DEFAULT 'mismo',
+  p_es_default BOOLEAN DEFAULT false
+) RETURNS JSONB
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = public
+AS $$
+BEGIN
+  IF NOT es_admin() THEN
+    RETURN jsonb_build_object('success', false, 'error', 'Solo admin puede asignar sucursales');
+  END IF;
+
+  INSERT INTO usuario_sucursales (usuario_id, sucursal_id, rol, es_default)
+  VALUES (p_usuario_id, p_sucursal_id, p_rol, p_es_default)
+  ON CONFLICT (usuario_id, sucursal_id) DO UPDATE
+    SET rol = EXCLUDED.rol,
+        es_default = EXCLUDED.es_default;
+
+  -- If this row was marked es_default, clear the flag on every other row
+  -- for the same user so only one default exists at a time.
+  IF p_es_default THEN
+    UPDATE usuario_sucursales SET es_default = false
+     WHERE usuario_id = p_usuario_id AND sucursal_id <> p_sucursal_id;
+  END IF;
+
+  RETURN jsonb_build_object('success', true);
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.desasignar_usuario_sucursal(
+  p_usuario_id UUID,
+  p_sucursal_id BIGINT
+) RETURNS JSONB
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = public
+AS $$
+BEGIN
+  IF NOT es_admin() THEN
+    RETURN jsonb_build_object('success', false, 'error', 'Solo admin puede desasignar sucursales');
+  END IF;
+
+  DELETE FROM usuario_sucursales
+   WHERE usuario_id = p_usuario_id AND sucursal_id = p_sucursal_id;
+
+  RETURN jsonb_build_object('success', true);
+END;
+$$;

--- a/scripts/export-tp-export-dump.md
+++ b/scripts/export-tp-export-dump.md
@@ -1,0 +1,188 @@
+# TP Export → ManaosApp Data Import Runbook
+
+Manual, one-shot procedure to migrate the TP Export project's business
+data into ManaosApp under `sucursal_id = 2`. Pairs with
+`migrations/062_import_tp_export.sql`.
+
+> **Run this ONCE, in a maintenance window, AFTER migrations 057–061 + 063
+> are applied in production.** The SQL file is explicitly not idempotent
+> and is not part of the normal migration chain.
+
+## Expected volumes (Q1 2026 audit snapshot)
+
+| Entity        | Rows |
+|---------------|-----:|
+| perfiles      |    7 |
+| productos     |   65 |
+| clientes      |   86 |
+| pedidos       |  142 |
+| pedido_items  |  534 |
+
+If live counts are wildly off from these, pause and investigate before
+running the import.
+
+## Preconditions
+
+1. **Backups taken.** `pg_dump` on ManaosApp AND TP Export before starting.
+2. **Migrations applied.** Verify on ManaosApp:
+   ```sql
+   SELECT name FROM supabase_migrations.schema_migrations
+    WHERE name IN ('060_multi_tenant_fixups','061_session_scoped_tenant','063_usuario_sucursales_admin_rpcs');
+   ```
+   All three rows must be present.
+3. **Users created.** Every TP Export `perfiles.email` must already exist
+   in ManaosApp's `auth.users`. Create them via the admin dashboard OR
+   Supabase CLI; re-running after creating missing accounts is safe.
+4. **FDW credentials.** You have read-only Postgres credentials for the
+   TP Export Supabase project. Use the direct connection string from
+   Supabase → Project Settings → Database → Connection string → URI.
+5. **Sucursal 2 is clean.** Confirm no prior import leftovers:
+   ```sql
+   SELECT COUNT(*) FROM productos WHERE sucursal_id = 2;
+   SELECT COUNT(*) FROM pedidos   WHERE sucursal_id = 2;
+   ```
+   If non-zero and unintentional, roll back before continuing.
+
+## Procedure
+
+### 1. Open a psql session to ManaosApp
+
+```bash
+psql "postgres://postgres.<proj-ref>:<password>@aws-0-us-east-1.pooler.supabase.com:5432/postgres"
+```
+
+### 2. Configure FDW
+
+Fill in the placeholders in the header of
+`migrations/062_import_tp_export.sql` with real TP credentials, then run
+only the `CREATE SERVER` / `CREATE USER MAPPING` / `IMPORT FOREIGN SCHEMA`
+block:
+
+```sql
+BEGIN;
+
+CREATE EXTENSION IF NOT EXISTS postgres_fdw;
+
+CREATE SERVER tp_remote
+  FOREIGN DATA WRAPPER postgres_fdw
+  OPTIONS (host '<tp-host>', dbname 'postgres', port '5432', sslmode 'require');
+
+CREATE USER MAPPING FOR postgres
+  SERVER tp_remote
+  OPTIONS (user 'postgres', password '<tp-password>');
+
+CREATE SCHEMA IF NOT EXISTS tp_remote_schema;
+
+IMPORT FOREIGN SCHEMA public
+  LIMIT TO (perfiles, clientes, productos, pedidos, pedido_items)
+  FROM SERVER tp_remote INTO tp_remote_schema;
+
+-- Sanity
+SELECT COUNT(*) FROM tp_remote_schema.perfiles;
+
+COMMIT;
+```
+
+### 3. Fill in the column TODOs in 062
+
+Before running the INSERTs, the skeleton has `-- TODO` markers where the
+exact column list must be expanded. Run on BOTH projects:
+
+```sql
+SELECT column_name
+  FROM information_schema.columns
+ WHERE table_schema = 'public'
+   AND table_name = 'productos'
+ ORDER BY ordinal_position;
+```
+
+and for each of `productos`, `clientes`, `pedidos`, `pedido_items`. Align
+the INSERT column list in 062 with columns that exist on both sides.
+Skip columns that exist only on one side — PostgREST will fill defaults.
+
+### 4. Run the import inside a single transaction
+
+```bash
+psql "<manaos-uri>" -f migrations/062_import_tp_export.sql --single-transaction
+```
+
+The file starts with `BEGIN` implicit via `--single-transaction`. All
+INSERTs and temp-table operations happen atomically.
+
+### 5. Verify BEFORE commit
+
+The psql session will leave you at the `\echo` prompt after running the
+file. Paste the verification block from the bottom of 062:
+
+```sql
+SELECT 'productos'    AS tabla, COUNT(*) FROM public.productos    WHERE sucursal_id = 2
+UNION ALL SELECT 'clientes',     COUNT(*) FROM public.clientes     WHERE sucursal_id = 2
+UNION ALL SELECT 'pedidos',      COUNT(*) FROM public.pedidos      WHERE sucursal_id = 2
+UNION ALL SELECT 'pedido_items', COUNT(*) FROM public.pedido_items WHERE sucursal_id = 2
+UNION ALL SELECT 'usuario_sucursales', COUNT(*) FROM public.usuario_sucursales WHERE sucursal_id = 2;
+```
+
+Expected: all match the volumes in the header (±10% for rows added
+between the audit snapshot and import day). `orphan_items` from the
+pedido_items CTE should be 0.
+
+- **If numbers match:** `COMMIT;`
+- **If not:** `ROLLBACK;` — the temp tables (`uuid_remap`, `*_remap`) are
+  dropped on transaction end anyway. Fix the issue and re-run.
+
+### 6. Smoke test from the app
+
+Log in as a TP Export user (same email, ManaosApp password). The app
+should:
+
+1. Show the user with TWO sucursales in the `SucursalSelector` dropdown
+   — provided that user was also in ManaosApp — OR only "TP Export" if
+   they're new. If they see zero sucursales, step 2 of "Preconditions"
+   failed; check `usuario_sucursales` for their local UUID.
+2. Switch to TP Export → pedidos list populates with the imported rows.
+3. Open one imported pedido — cliente and items render correctly (cliente
+   and producto names match the source).
+
+### 7. Clean up FDW
+
+After the import is validated, drop the FDW wiring so service credentials
+don't linger:
+
+```sql
+DROP SERVER tp_remote CASCADE;
+DROP SCHEMA tp_remote_schema CASCADE;
+-- postgres_fdw extension can stay; it's harmless without a configured SERVER.
+```
+
+## Rollback
+
+Because everything ran inside one transaction, `ROLLBACK;` during step 5
+undoes the whole import with no trace. If commit already happened and
+rollback is needed:
+
+```sql
+BEGIN;
+DELETE FROM public.pedido_items      WHERE sucursal_id = 2;
+DELETE FROM public.pedidos           WHERE sucursal_id = 2;
+DELETE FROM public.clientes          WHERE sucursal_id = 2;
+DELETE FROM public.productos         WHERE sucursal_id = 2;
+DELETE FROM public.usuario_sucursales WHERE sucursal_id = 2;
+-- ^ this last one revokes access; confirm no legitimate non-TP users were
+--   also assigned to sucursal 2 before running.
+COMMIT;
+```
+
+## Known gotchas
+
+- **`numero_pedido` collision.** The dedup in step 5 uses
+  `numero_pedido + sucursal_id`. If ManaosApp already issued `numero_pedido`
+  values that collide with TP Export's sequence for sucursal 2 (possible
+  if sucursal 2 existed before 057), add a `tp_import_marker TEXT` column
+  to `pedidos`, set it to `'tp_<src_id>'` during import, and use that for
+  dedup instead.
+- **Stock drift.** Products imported with a stock value that reflects
+  TP Export's closing inventory — not the live warehouse state in sucursal
+  2. Plan a stock recount separately.
+- **Audit log pollution.** Every INSERT fires `audit_log_changes`. Expect
+  ~840 new audit rows. The trigger (post-migration 060) correctly stamps
+  them with `sucursal_id = 2` — no cross-tenant leak.

--- a/scripts/verify-multi-tenant.sql
+++ b/scripts/verify-multi-tenant.sql
@@ -1,0 +1,285 @@
+-- Multi-tenant migration verification script
+--
+-- Run this after applying migrations 057 → 063 to confirm every fix
+-- from the audit plan (nested-gliding-crown) landed correctly.
+--
+-- Usage (local Supabase CLI):
+--   cd .claude/worktrees/unruffled-borg
+--   supabase start
+--   supabase db reset              -- applies 001 → 063 in order
+--   psql "$(supabase status -o json | jq -r '.DB_URL // .db_url')" \
+--        -f scripts/verify-multi-tenant.sql
+--
+-- Or paste blocks into the Supabase SQL editor on a preview branch.
+--
+-- Each check RAISEs NOTICE on success and RAISE EXCEPTION on failure, so
+-- the script aborts at the first broken invariant. If it finishes with
+-- "🎉 All multi-tenant checks passed", you're clear to merge.
+
+\set ON_ERROR_STOP on
+SET client_min_messages = NOTICE;
+
+-- =====================================================================
+-- Migration 060 — structural fixups (C1/C2/C3, H6/H7/H8)
+-- =====================================================================
+
+-- C1: sucursales id=1 renamed, id=2 is TP Export, others are distribuidora
+DO $$
+DECLARE v_count INT;
+BEGIN
+  SELECT COUNT(*) INTO v_count
+    FROM sucursales
+   WHERE id = 1 AND nombre = 'ManaosApp' AND tipo = 'principal';
+  IF v_count <> 1 THEN
+    RAISE EXCEPTION 'C1 FAILED: sucursal id=1 is not ManaosApp/principal (got % rows)', v_count;
+  END IF;
+
+  SELECT COUNT(*) INTO v_count
+    FROM sucursales
+   WHERE id = 2 AND nombre = 'TP Export' AND tipo = 'secundaria';
+  IF v_count <> 1 THEN
+    RAISE EXCEPTION 'C1 FAILED: sucursal id=2 is not TP Export/secundaria (got % rows)', v_count;
+  END IF;
+
+  SELECT COUNT(*) INTO v_count
+    FROM sucursales
+   WHERE id NOT IN (1, 2) AND tipo IS DISTINCT FROM 'distribuidora';
+  IF v_count > 0 THEN
+    RAISE EXCEPTION 'C1 FAILED: % sucursales with id>2 have tipo != distribuidora', v_count;
+  END IF;
+
+  RAISE NOTICE '✓ C1: sucursales tipos correctly seeded';
+END $$;
+
+-- stock_historico.usuario_id column exists (for 059 trigger)
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+     WHERE table_name = 'stock_historico' AND column_name = 'usuario_id'
+  ) THEN
+    RAISE EXCEPTION '060 FAILED: stock_historico.usuario_id column missing';
+  END IF;
+  RAISE NOTICE '✓ stock_historico.usuario_id column exists';
+END $$;
+
+-- C2: exactly one overload of registrar_compra_completa with 13 args
+DO $$
+DECLARE v_count INT;
+BEGIN
+  SELECT COUNT(*) INTO v_count
+    FROM pg_proc
+   WHERE proname = 'registrar_compra_completa' AND pronargs = 13;
+  IF v_count <> 1 THEN
+    RAISE EXCEPTION 'C2 FAILED: expected 1 registrar_compra_completa(13 args), found %', v_count;
+  END IF;
+  RAISE NOTICE '✓ C2: registrar_compra_completa 13-arg overload is unique';
+END $$;
+
+-- H8: registrar_nota_credito has the es_encargado_o_admin check
+DO $$
+DECLARE v_src TEXT;
+BEGIN
+  SELECT pg_get_functiondef(oid) INTO v_src
+    FROM pg_proc WHERE proname = 'registrar_nota_credito';
+  IF v_src IS NULL THEN
+    RAISE EXCEPTION 'H8 FAILED: registrar_nota_credito not found';
+  END IF;
+  IF v_src NOT LIKE '%es_encargado_o_admin%' THEN
+    RAISE EXCEPTION 'H8 FAILED: registrar_nota_credito missing role guard';
+  END IF;
+  RAISE NOTICE '✓ H8: registrar_nota_credito enforces es_encargado_o_admin';
+END $$;
+
+-- H7: audit_log_changes no longer COALESCEs to sucursal_id = 1
+DO $$
+DECLARE v_src TEXT;
+BEGIN
+  SELECT pg_get_functiondef(oid) INTO v_src
+    FROM pg_proc WHERE proname = 'audit_log_changes';
+  IF v_src IS NULL THEN
+    RAISE EXCEPTION 'H7 FAILED: audit_log_changes not found';
+  END IF;
+  IF v_src LIKE '%COALESCE(v_sucursal_id, 1)%' THEN
+    RAISE EXCEPTION 'H7 FAILED: audit_log_changes still has silent fallback to sucursal_id=1';
+  END IF;
+  IF v_src NOT LIKE '%cannot determine sucursal_id for table%' THEN
+    RAISE EXCEPTION 'H7 FAILED: audit_log_changes missing RAISE EXCEPTION for NULL sucursal_id';
+  END IF;
+  RAISE NOTICE '✓ H7: audit_log_changes fails loud instead of silent fallback';
+END $$;
+
+-- H6: no legacy (non-mt_) policies survived on the tenant-filtered tables
+DO $$
+DECLARE v_count INT; v_list TEXT;
+BEGIN
+  SELECT COUNT(*),
+         string_agg(tablename || '.' || policyname, ', ')
+    INTO v_count, v_list
+    FROM pg_policies
+   WHERE schemaname = 'public'
+     AND tablename IN (
+       'clientes','productos','pedidos','pedido_items','pagos','compras','compra_items',
+       'proveedores','mermas_stock','stock_historico','recorridos','recorrido_pedidos',
+       'rendiciones','rendicion_items','rendicion_ajustes','salvedades_items','salvedad_historial',
+       'notas_credito','nota_credito_items','transferencias_stock','transferencia_items',
+       'promociones','promocion_productos','promocion_reglas','promo_ajustes',
+       'grupos_precio','grupo_precio_productos','grupo_precio_escalas',
+       'pedidos_eliminados','audit_logs','zonas','preventista_zonas','historial_cambios','pedido_historial'
+     )
+     AND policyname NOT LIKE 'mt\_%' ESCAPE '\'
+     AND policyname NOT IN ('usuario_sucursales_select_own','usuario_sucursales_admin_all');
+  IF v_count > 0 THEN
+    RAISE EXCEPTION 'H6 FAILED: % legacy policies survived: %', v_count, v_list;
+  END IF;
+  RAISE NOTICE '✓ H6: no legacy RLS policies leaking past tenant filter';
+END $$;
+
+-- =====================================================================
+-- Migration 061 — session-scoped current_sucursal_id()
+-- =====================================================================
+
+-- The function body reads request.headers and validates against usuario_sucursales.
+DO $$
+DECLARE v_src TEXT;
+BEGIN
+  SELECT pg_get_functiondef(oid) INTO v_src
+    FROM pg_proc WHERE proname = 'current_sucursal_id';
+  IF v_src NOT LIKE '%request.headers%' THEN
+    RAISE EXCEPTION 'H10 FAILED: current_sucursal_id does not read request.headers';
+  END IF;
+  IF v_src NOT LIKE '%x-sucursal-id%' THEN
+    RAISE EXCEPTION 'H10 FAILED: current_sucursal_id does not parse x-sucursal-id';
+  END IF;
+  IF v_src NOT LIKE '%usuario_sucursales%' THEN
+    RAISE EXCEPTION 'H10 FAILED: current_sucursal_id missing usuario_sucursales authorization check';
+  END IF;
+  RAISE NOTICE '✓ H10 (DB): current_sucursal_id reads header and validates ownership';
+END $$;
+
+-- Functional test: header present + authorized → returns the value
+-- (Requires an auth.users row + usuario_sucursales row. Only runs if we
+-- can find one; otherwise noted and skipped.)
+DO $$
+DECLARE v_user UUID; v_sucursal BIGINT; v_result BIGINT;
+BEGIN
+  SELECT us.usuario_id, us.sucursal_id
+    INTO v_user, v_sucursal
+    FROM usuario_sucursales us
+   LIMIT 1;
+  IF v_user IS NULL THEN
+    RAISE NOTICE '– H10 functional test skipped: no usuario_sucursales rows to simulate';
+    RETURN;
+  END IF;
+
+  PERFORM set_config('request.jwt.claim.sub', v_user::text, true);
+  PERFORM set_config('request.headers', format('{"x-sucursal-id":"%s"}', v_sucursal), true);
+  v_result := current_sucursal_id();
+  IF v_result IS DISTINCT FROM v_sucursal THEN
+    RAISE EXCEPTION 'H10 FAILED: header %s → expected %, got %', v_sucursal, v_sucursal, v_result;
+  END IF;
+
+  -- Now simulate a forged header for a sucursal the user does NOT have.
+  PERFORM set_config('request.headers', '{"x-sucursal-id":"99999"}', true);
+  v_result := current_sucursal_id();
+  IF v_result IS NOT NULL THEN
+    RAISE EXCEPTION 'H10 FAILED: unauthorized header returned % instead of NULL', v_result;
+  END IF;
+
+  RAISE NOTICE '✓ H10 functional: header authorized → %, forged → NULL', v_sucursal;
+END $$;
+
+-- =====================================================================
+-- Migration 063 — admin RPCs for usuario_sucursales
+-- =====================================================================
+
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_proc WHERE proname = 'asignar_usuario_sucursal') THEN
+    RAISE EXCEPTION '063 FAILED: asignar_usuario_sucursal not found';
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_proc WHERE proname = 'desasignar_usuario_sucursal') THEN
+    RAISE EXCEPTION '063 FAILED: desasignar_usuario_sucursal not found';
+  END IF;
+  RAISE NOTICE '✓ 063: admin RPCs present';
+END $$;
+
+-- Both should be SECURITY DEFINER + gated by es_admin()
+DO $$
+DECLARE v_src TEXT;
+BEGIN
+  SELECT pg_get_functiondef(oid) INTO v_src FROM pg_proc WHERE proname = 'asignar_usuario_sucursal';
+  IF v_src NOT LIKE '%SECURITY DEFINER%' THEN
+    RAISE EXCEPTION '063 FAILED: asignar_usuario_sucursal is not SECURITY DEFINER';
+  END IF;
+  IF v_src NOT LIKE '%es_admin()%' THEN
+    RAISE EXCEPTION '063 FAILED: asignar_usuario_sucursal missing es_admin() guard';
+  END IF;
+
+  SELECT pg_get_functiondef(oid) INTO v_src FROM pg_proc WHERE proname = 'desasignar_usuario_sucursal';
+  IF v_src NOT LIKE '%SECURITY DEFINER%' THEN
+    RAISE EXCEPTION '063 FAILED: desasignar_usuario_sucursal is not SECURITY DEFINER';
+  END IF;
+  IF v_src NOT LIKE '%es_admin()%' THEN
+    RAISE EXCEPTION '063 FAILED: desasignar_usuario_sucursal missing es_admin() guard';
+  END IF;
+  RAISE NOTICE '✓ 063: admin RPCs are SECURITY DEFINER and gated by es_admin()';
+END $$;
+
+-- =====================================================================
+-- Cross-migration sanity
+-- =====================================================================
+
+-- Every public table that stores per-tenant rows must have a sucursal_id column.
+-- This catches drift where a new table was added without the tenant column.
+DO $$
+DECLARE v_missing TEXT;
+BEGIN
+  SELECT string_agg(t.table_name, ', ')
+    INTO v_missing
+    FROM information_schema.tables t
+   WHERE t.table_schema = 'public'
+     AND t.table_type = 'BASE TABLE'
+     AND t.table_name IN (
+       'clientes','productos','pedidos','pedido_items','pagos','compras','compra_items',
+       'mermas_stock','stock_historico','recorridos','rendiciones','rendicion_items',
+       'salvedades_items','notas_credito','nota_credito_items',
+       'transferencias_stock','transferencia_items',
+       'promociones','grupos_precio','pedidos_eliminados','audit_logs'
+     )
+     AND NOT EXISTS (
+       SELECT 1 FROM information_schema.columns c
+        WHERE c.table_schema = t.table_schema
+          AND c.table_name = t.table_name
+          AND c.column_name = 'sucursal_id'
+     );
+  IF v_missing IS NOT NULL THEN
+    RAISE EXCEPTION 'SCHEMA DRIFT: tables without sucursal_id: %', v_missing;
+  END IF;
+  RAISE NOTICE '✓ All expected tenant tables have sucursal_id';
+END $$;
+
+-- usuario_sucursales has the unique (usuario_id, sucursal_id) constraint
+-- needed by the ON CONFLICT in asignar_usuario_sucursal.
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+     WHERE conrelid = 'usuario_sucursales'::regclass
+       AND contype = 'u'
+       AND (SELECT array_agg(attname ORDER BY attname) FROM pg_attribute
+             WHERE attrelid = 'usuario_sucursales'::regclass
+               AND attnum = ANY(conkey)) = ARRAY['sucursal_id','usuario_id']::name[]
+  ) THEN
+    RAISE EXCEPTION '063 FAILED: usuario_sucursales missing UNIQUE(usuario_id, sucursal_id) for ON CONFLICT';
+  END IF;
+  RAISE NOTICE '✓ usuario_sucursales has UNIQUE(usuario_id, sucursal_id)';
+END $$;
+
+-- =====================================================================
+-- Done
+-- =====================================================================
+DO $$
+BEGIN
+  RAISE NOTICE '🎉 All multi-tenant checks passed';
+END $$;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -20,6 +20,7 @@ import { useRealtimeInvalidation } from './hooks/useRealtimeInvalidation'
 import { useSyncManager, type SyncDependencies } from './hooks/useSyncManager'
 import { trackFirstAuthenticatedRender } from './utils/authPerformance'
 import LoginScreen from './components/auth/LoginScreen'
+import SinSucursalScreen from './components/SinSucursalScreen'
 import ErrorBoundary from './components/ErrorBoundary'
 import TopNavigation from './components/layout/TopNavigation'
 import OfflineIndicator from './components/layout/OfflineIndicator'
@@ -145,7 +146,13 @@ function MainAppInner({ user, perfil, logout, authReady }: {
   const notify = useNotification()
   const location = useLocation()
   const offlineSync = useOfflineSync()
-  const { currentSucursalId, currentSucursalNombre, currentSucursalRol } = useSucursal()
+  const {
+    currentSucursalId,
+    currentSucursalNombre,
+    currentSucursalRol,
+    sucursales,
+    loading: sucursalLoading,
+  } = useSucursal()
   const {
     isOnline,
     pedidosPendientes,
@@ -206,6 +213,14 @@ function MainAppInner({ user, perfil, logout, authReady }: {
   const handleRetrySync = useCallback(async () => {
     await refreshPendingOperations()
   }, [refreshPendingOperations])
+
+  // Block the app if the authenticated user has no sucursales assigned.
+  // Replaces the previous phantom fallback that silently pretended the
+  // user was on sucursal id=1 (C6). Placed after all hooks so rules-of-hooks
+  // are respected.
+  if (!sucursalLoading && sucursales.length === 0) {
+    return <SinSucursalScreen onLogout={handleLogout} />
+  }
 
   return (
     <AuthDataProvider value={authDataValue}>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,6 +13,8 @@ import { useInvalidateMetricas } from './hooks/queries'
 import { ThemeProvider } from './contexts/ThemeContext'
 import { NotificationProvider, useNotification } from './contexts/NotificationContext'
 import { AuthDataProvider, type AuthDataContextValue } from './contexts/AuthDataContext'
+import { SucursalProvider, useSucursal } from './contexts/SucursalContext'
+import type { PerfilDB } from './types'
 import { useOfflineSync, type UseOfflineSyncReturn } from './hooks/useOfflineSync'
 import { useRealtimeInvalidation } from './hooks/useRealtimeInvalidation'
 import { useSyncManager, type SyncDependencies } from './hooks/useSyncManager'
@@ -119,10 +121,31 @@ function PendingSyncRuntime({
 }
 
 function MainApp(): ReactElement {
-  const { user, perfil, logout, isAdmin, isPreventista, isTransportista, isEncargado, isAdminOrEncargado, authReady } = useAuth()
+  const { user, perfil, logout, authReady } = useAuth()
+  const globalRol = perfil?.rol ?? null
+
+  return (
+    <SucursalProvider userId={user?.id ?? null} globalRol={globalRol}>
+      <MainAppInner
+        user={user}
+        perfil={perfil}
+        logout={logout}
+        authReady={authReady}
+      />
+    </SucursalProvider>
+  )
+}
+
+function MainAppInner({ user, perfil, logout, authReady }: {
+  user: { id: string; email?: string } | null
+  perfil: PerfilDB | null
+  logout: () => Promise<void>
+  authReady: boolean
+}): ReactElement {
   const notify = useNotification()
   const location = useLocation()
   const offlineSync = useOfflineSync()
+  const { currentSucursalId, currentSucursalNombre, currentSucursalRol } = useSucursal()
   const {
     isOnline,
     pedidosPendientes,
@@ -155,6 +178,14 @@ function MainApp(): ReactElement {
     }
   }, [logout])
 
+  // Use sucursal-resolved role for permissions
+  const effectiveRol = currentSucursalRol ?? perfil?.rol
+  const isAdmin = effectiveRol === 'admin'
+  const isPreventista = effectiveRol === 'preventista'
+  const isTransportista = effectiveRol === 'transportista'
+  const isEncargado = effectiveRol === 'encargado'
+  const isAdminOrEncargado = isAdmin || isEncargado
+
   const defaultRoute = (isAdmin || isPreventista || isEncargado) ? '/dashboard' : '/pedidos'
 
   const authDataValue = useMemo<AuthDataContextValue>(() => ({
@@ -167,8 +198,10 @@ function MainApp(): ReactElement {
     isEncargado,
     isAdminOrEncargado,
     isOnline,
-    logout: handleLogout
-  }), [user, perfil, authReady, isAdmin, isPreventista, isTransportista, isEncargado, isAdminOrEncargado, isOnline, handleLogout])
+    logout: handleLogout,
+    currentSucursalId,
+    currentSucursalNombre,
+  }), [user, perfil, authReady, isAdmin, isPreventista, isTransportista, isEncargado, isAdminOrEncargado, isOnline, handleLogout, currentSucursalId, currentSucursalNombre])
 
   const handleRetrySync = useCallback(async () => {
     await refreshPendingOperations()

--- a/src/components/SinSucursalScreen.tsx
+++ b/src/components/SinSucursalScreen.tsx
@@ -1,0 +1,39 @@
+import type { ReactElement } from 'react'
+import { Building2 } from 'lucide-react'
+
+interface SinSucursalScreenProps {
+  onLogout: () => void
+}
+
+/**
+ * Blocking screen shown when the authenticated user has no rows in
+ * usuario_sucursales. Replaces the previous "phantom fallback" that
+ * silently pretended the user was on sucursal id=1 (C6). The user must
+ * contact an admin to be assigned via the asignar_usuario_sucursal RPC
+ * from migration 063.
+ */
+export default function SinSucursalScreen({ onLogout }: SinSucursalScreenProps): ReactElement {
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gray-50 dark:bg-gray-900 p-6 transition-colors">
+      <div className="max-w-md w-full text-center bg-white dark:bg-gray-800 rounded-lg shadow-lg p-8">
+        <div className="mx-auto w-14 h-14 rounded-full bg-blue-50 dark:bg-blue-900/30 flex items-center justify-center mb-4">
+          <Building2 className="w-7 h-7 text-blue-600 dark:text-blue-300" />
+        </div>
+        <h1 className="text-xl font-semibold text-gray-900 dark:text-gray-100 mb-3">
+          Sin sucursal asignada
+        </h1>
+        <p className="text-gray-600 dark:text-gray-400 mb-6">
+          Tu cuenta no tiene sucursales asignadas. Por favor contactá a un administrador
+          para que te asigne al menos una sucursal antes de poder usar la aplicación.
+        </p>
+        <button
+          type="button"
+          onClick={onLogout}
+          className="px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded-lg transition-colors"
+        >
+          Cerrar sesión
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/src/components/layout/SucursalSelector.tsx
+++ b/src/components/layout/SucursalSelector.tsx
@@ -1,0 +1,78 @@
+import { useState, useRef, useEffect } from 'react'
+import { Building2, ChevronDown } from 'lucide-react'
+import { useSucursal } from '../../contexts/SucursalContext'
+
+export default function SucursalSelector() {
+  const { currentSucursalId, currentSucursalNombre, sucursales, hasMutipleSucursales, switchSucursal } = useSucursal()
+  const [open, setOpen] = useState(false)
+  const ref = useRef<HTMLDivElement>(null)
+
+  // Close on outside click
+  useEffect(() => {
+    if (!open) return
+    const handler = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) {
+        setOpen(false)
+      }
+    }
+    document.addEventListener('mousedown', handler)
+    return () => document.removeEventListener('mousedown', handler)
+  }, [open])
+
+  if (!currentSucursalId) return null
+
+  // Single sucursal: static badge, no dropdown
+  if (!hasMutipleSucursales) {
+    return (
+      <div className="flex items-center space-x-1.5 px-2 py-1 rounded-md bg-blue-50 dark:bg-blue-900/30 text-blue-700 dark:text-blue-300 text-sm">
+        <Building2 className="w-4 h-4" />
+        <span className="font-medium truncate max-w-[120px]">{currentSucursalNombre}</span>
+      </div>
+    )
+  }
+
+  // Multiple sucursales: dropdown selector
+  return (
+    <div className="relative" ref={ref}>
+      <button
+        onClick={() => setOpen(!open)}
+        aria-expanded={open}
+        aria-haspopup="listbox"
+        aria-label="Cambiar sucursal"
+        className="flex items-center space-x-1.5 px-2 py-1.5 rounded-lg bg-blue-50 dark:bg-blue-900/30 text-blue-700 dark:text-blue-300 hover:bg-blue-100 dark:hover:bg-blue-900/50 transition-colors text-sm"
+      >
+        <Building2 className="w-4 h-4" />
+        <span className="font-medium truncate max-w-[120px]">{currentSucursalNombre}</span>
+        <ChevronDown className={`w-3.5 h-3.5 transition-transform ${open ? 'rotate-180' : ''}`} />
+      </button>
+
+      {open && (
+        <div
+          role="listbox"
+          aria-label="Sucursales disponibles"
+          className="absolute right-0 top-full mt-1 w-56 bg-white dark:bg-gray-800 rounded-lg shadow-lg border border-gray-200 dark:border-gray-700 py-1 z-50"
+        >
+          {sucursales.map(suc => (
+            <button
+              key={suc.id}
+              role="option"
+              aria-selected={suc.id === currentSucursalId}
+              onClick={async () => {
+                setOpen(false)
+                await switchSucursal(suc.id)
+              }}
+              className={`w-full text-left px-3 py-2 text-sm flex items-center justify-between transition-colors ${
+                suc.id === currentSucursalId
+                  ? 'bg-blue-50 dark:bg-blue-900/30 text-blue-700 dark:text-blue-300 font-medium'
+                  : 'text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700'
+              }`}
+            >
+              <span className="truncate">{suc.nombre}</span>
+              <span className="text-xs text-gray-400 dark:text-gray-500 ml-2 capitalize">{suc.rol}</span>
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/components/layout/SucursalSelector.tsx
+++ b/src/components/layout/SucursalSelector.tsx
@@ -3,7 +3,7 @@ import { Building2, ChevronDown } from 'lucide-react'
 import { useSucursal } from '../../contexts/SucursalContext'
 
 export default function SucursalSelector() {
-  const { currentSucursalId, currentSucursalNombre, sucursales, hasMutipleSucursales, switchSucursal } = useSucursal()
+  const { currentSucursalId, currentSucursalNombre, sucursales, hasMultipleSucursales, switchSucursal } = useSucursal()
   const [open, setOpen] = useState(false)
   const ref = useRef<HTMLDivElement>(null)
 
@@ -22,7 +22,7 @@ export default function SucursalSelector() {
   if (!currentSucursalId) return null
 
   // Single sucursal: static badge, no dropdown
-  if (!hasMutipleSucursales) {
+  if (!hasMultipleSucursales) {
     return (
       <div className="flex items-center space-x-1.5 px-2 py-1 rounded-md bg-blue-50 dark:bg-blue-900/30 text-blue-700 dark:text-blue-300 text-sm">
         <Building2 className="w-4 h-4" />

--- a/src/components/layout/TopNavigation.tsx
+++ b/src/components/layout/TopNavigation.tsx
@@ -9,6 +9,7 @@ import {
 import { getRolColor, getRolLabel } from '../../utils/formatters';
 import { useTheme } from '../../contexts/ThemeContext';
 import { NotificationCenter } from '../../contexts/NotificationContext';
+import SucursalSelector from './SucursalSelector';
 import type { PerfilDB, RolUsuario } from '../../types';
 
 // =============================================================================
@@ -292,6 +293,9 @@ export default function TopNavigation({
 
             {/* Notificaciones */}
             <NotificationCenter />
+
+            {/* Sucursal */}
+            <SucursalSelector />
 
             {/* Menu de usuario */}
             <div className="relative" ref={userMenuRef}>

--- a/src/contexts/AuthDataContext.tsx
+++ b/src/contexts/AuthDataContext.tsx
@@ -22,6 +22,8 @@ export interface AuthDataContextValue {
   isAdminOrEncargado: boolean
   isOnline: boolean
   logout: () => Promise<void>
+  currentSucursalId: number | null
+  currentSucursalNombre: string | null
 }
 
 // =============================================================================

--- a/src/contexts/SucursalContext.tsx
+++ b/src/contexts/SucursalContext.tsx
@@ -1,0 +1,170 @@
+import React, { createContext, useContext, useState, useEffect, useCallback, useMemo, ReactNode } from 'react'
+import { useQueryClient } from '@tanstack/react-query'
+import { supabase } from '../lib/supabase'
+import type { UsuarioSucursalDB, RolUsuario } from '../types'
+import { logger } from '../utils/logger'
+
+const SUCURSAL_STORAGE_KEY = 'distribuidora_sucursal_activa'
+
+export interface SucursalInfo {
+  id: number
+  nombre: string
+  rol: RolUsuario // resolved role for this sucursal
+}
+
+export interface SucursalContextValue {
+  currentSucursalId: number | null
+  currentSucursalNombre: string | null
+  currentSucursalRol: RolUsuario | null
+  sucursales: SucursalInfo[]
+  loading: boolean
+  hasMutipleSucursales: boolean
+  switchSucursal: (sucursalId: number) => Promise<void>
+}
+
+const SucursalContext = createContext<SucursalContextValue | null>(null)
+
+interface SucursalProviderProps {
+  children: ReactNode
+  userId: string | null
+  globalRol: RolUsuario | null
+}
+
+export function SucursalProvider({ children, userId, globalRol }: SucursalProviderProps): React.ReactElement {
+  const [sucursales, setSucursales] = useState<SucursalInfo[]>([])
+  const [currentSucursalId, setCurrentSucursalId] = useState<number | null>(null)
+  const [loading, setLoading] = useState(true)
+  const queryClient = useQueryClient()
+
+  // Load usuario_sucursales when userId changes
+  useEffect(() => {
+    if (!userId || !globalRol) {
+      setSucursales([])
+      setCurrentSucursalId(null)
+      setLoading(false)
+      return
+    }
+
+    let cancelled = false
+
+    const loadSucursales = async () => {
+      setLoading(true)
+      try {
+        const { data, error } = await supabase
+          .from('usuario_sucursales')
+          .select('id, usuario_id, sucursal_id, rol, es_default, sucursal:sucursales(id, nombre)')
+          .eq('usuario_id', userId)
+
+        if (error) {
+          logger.error('[SucursalContext] Error loading sucursales:', error)
+          if (!cancelled) setLoading(false)
+          return
+        }
+
+        if (!data || data.length === 0) {
+          logger.warn('[SucursalContext] No sucursales found for user, defaulting to sucursal 1')
+          if (!cancelled) {
+            const fallback: SucursalInfo = { id: 1, nombre: 'Principal', rol: globalRol }
+            setSucursales([fallback])
+            setCurrentSucursalId(1)
+            setLoading(false)
+          }
+          return
+        }
+
+        if (cancelled) return
+
+        const mapped: SucursalInfo[] = (data as unknown as UsuarioSucursalDB[]).map(us => {
+          const sucNombre = (us.sucursal as unknown as { id: number; nombre: string })?.nombre ?? `Sucursal ${us.sucursal_id}`
+          const resolvedRol: RolUsuario = us.rol === 'mismo' ? globalRol : (us.rol as RolUsuario)
+          return {
+            id: us.sucursal_id,
+            nombre: sucNombre,
+            rol: resolvedRol,
+          }
+        })
+
+        setSucursales(mapped)
+
+        // Determine active sucursal: check localStorage first, then es_default, then first
+        const storedId = localStorage.getItem(SUCURSAL_STORAGE_KEY)
+        const storedNum = storedId ? parseInt(storedId, 10) : null
+        const defaultEntry = (data as unknown as UsuarioSucursalDB[]).find(us => us.es_default)
+
+        let activeId: number
+        if (storedNum && mapped.some(s => s.id === storedNum)) {
+          activeId = storedNum
+        } else if (defaultEntry) {
+          activeId = defaultEntry.sucursal_id
+        } else {
+          activeId = mapped[0].id
+        }
+
+        setCurrentSucursalId(activeId)
+        localStorage.setItem(SUCURSAL_STORAGE_KEY, String(activeId))
+      } catch (err) {
+        logger.error('[SucursalContext] Exception loading sucursales:', err)
+      } finally {
+        if (!cancelled) setLoading(false)
+      }
+    }
+
+    void loadSucursales()
+
+    return () => {
+      cancelled = true
+    }
+  }, [userId, globalRol])
+
+  const switchSucursal = useCallback(async (sucursalId: number) => {
+    if (sucursalId === currentSucursalId) return
+    if (!userId) return
+
+    try {
+      // Call RPC to update es_default in DB
+      const { error } = await supabase.rpc('cambiar_sucursal', { p_sucursal_id: sucursalId })
+      if (error) {
+        logger.error('[SucursalContext] Error switching sucursal:', error)
+        return
+      }
+
+      setCurrentSucursalId(sucursalId)
+      localStorage.setItem(SUCURSAL_STORAGE_KEY, String(sucursalId))
+
+      // Invalidate ALL queries so data refetches for new sucursal
+      await queryClient.invalidateQueries()
+    } catch (err) {
+      logger.error('[SucursalContext] Exception switching sucursal:', err)
+    }
+  }, [currentSucursalId, userId, queryClient])
+
+  const value = useMemo<SucursalContextValue>(() => {
+    const currentSucursal = sucursales.find(s => s.id === currentSucursalId)
+    return {
+      currentSucursalId,
+      currentSucursalNombre: currentSucursal?.nombre ?? null,
+      currentSucursalRol: currentSucursal?.rol ?? globalRol,
+      sucursales,
+      loading,
+      hasMutipleSucursales: sucursales.length > 1,
+      switchSucursal,
+    }
+  }, [currentSucursalId, sucursales, loading, globalRol, switchSucursal])
+
+  return (
+    <SucursalContext.Provider value={value}>
+      {children}
+    </SucursalContext.Provider>
+  )
+}
+
+// eslint-disable-next-line react-refresh/only-export-components
+export function useSucursal(): SucursalContextValue {
+  const context = useContext(SucursalContext)
+  if (!context) {
+    throw new Error('useSucursal debe usarse dentro de un SucursalProvider')
+  }
+  return context
+}
+
+export default SucursalContext

--- a/src/contexts/SucursalContext.tsx
+++ b/src/contexts/SucursalContext.tsx
@@ -18,7 +18,7 @@ export interface SucursalContextValue {
   currentSucursalRol: RolUsuario | null
   sucursales: SucursalInfo[]
   loading: boolean
-  hasMutipleSucursales: boolean
+  hasMultipleSucursales: boolean
   switchSucursal: (sucursalId: number) => Promise<void>
 }
 
@@ -63,11 +63,11 @@ export function SucursalProvider({ children, userId, globalRol }: SucursalProvid
         }
 
         if (!data || data.length === 0) {
-          logger.warn('[SucursalContext] No sucursales found for user, defaulting to sucursal 1')
+          logger.warn('[SucursalContext] Usuario sin sucursales asignadas')
           if (!cancelled) {
-            const fallback: SucursalInfo = { id: 1, nombre: 'Principal', rol: globalRol }
-            setSucursales([fallback])
-            setCurrentSucursalId(1)
+            setSucursales([])
+            setCurrentSucursalId(null)
+            setSucursalHeader(null)
             setLoading(false)
           }
           return
@@ -149,7 +149,7 @@ export function SucursalProvider({ children, userId, globalRol }: SucursalProvid
       currentSucursalRol: currentSucursal?.rol ?? globalRol,
       sucursales,
       loading,
-      hasMutipleSucursales: sucursales.length > 1,
+      hasMultipleSucursales: sucursales.length > 1,
       switchSucursal,
     }
   }, [currentSucursalId, sucursales, loading, globalRol, switchSucursal])

--- a/src/contexts/SucursalContext.tsx
+++ b/src/contexts/SucursalContext.tsx
@@ -1,6 +1,6 @@
 import React, { createContext, useContext, useState, useEffect, useCallback, useMemo, ReactNode } from 'react'
 import { useQueryClient } from '@tanstack/react-query'
-import { supabase } from '../lib/supabase'
+import { supabase, setSucursalHeader } from '../lib/supabase'
 import type { UsuarioSucursalDB, RolUsuario } from '../types'
 import { logger } from '../utils/logger'
 
@@ -41,6 +41,7 @@ export function SucursalProvider({ children, userId, globalRol }: SucursalProvid
     if (!userId || !globalRol) {
       setSucursales([])
       setCurrentSucursalId(null)
+      setSucursalHeader(null)
       setLoading(false)
       return
     }
@@ -101,6 +102,7 @@ export function SucursalProvider({ children, userId, globalRol }: SucursalProvid
         }
 
         setCurrentSucursalId(activeId)
+        setSucursalHeader(activeId)
         localStorage.setItem(SUCURSAL_STORAGE_KEY, String(activeId))
       } catch (err) {
         logger.error('[SucursalContext] Exception loading sucursales:', err)
@@ -129,6 +131,7 @@ export function SucursalProvider({ children, userId, globalRol }: SucursalProvid
       }
 
       setCurrentSucursalId(sucursalId)
+      setSucursalHeader(sucursalId)
       localStorage.setItem(SUCURSAL_STORAGE_KEY, String(sucursalId))
 
       // Invalidate ALL queries so data refetches for new sucursal

--- a/src/contexts/index.ts
+++ b/src/contexts/index.ts
@@ -40,6 +40,10 @@ export {
 } from './AppDataContext'
 export type { AppDataContextValue } from './AppDataContext'
 
+// Sucursal (multi-tenant)
+export { SucursalProvider, useSucursal } from './SucursalContext'
+export type { SucursalContextValue, SucursalInfo } from './SucursalContext'
+
 // Theme
 export { ThemeProvider, useTheme } from './ThemeContext'
 

--- a/src/hooks/__tests__/useOfflineSync.integration.test.ts
+++ b/src/hooks/__tests__/useOfflineSync.integration.test.ts
@@ -30,6 +30,29 @@ vi.mock('../../lib/offlineDb', () => ({
   cleanupOldOperations: (...args: unknown[]) => mockCleanupOldOperations(...args),
 }))
 
+// Mock del cliente Supabase y el contexto de sucursal — necesario porque
+// useOfflineSync ahora importa setSucursalHeader de ../../lib/supabase y
+// useSucursal de ../../contexts/SucursalContext para etiquetar cada op con
+// el sucursal_id activo (ver commit 9181a66 / Task 5 multi-tenant).
+vi.mock('../../lib/supabase', () => ({
+  supabase: {
+    from: vi.fn(),
+    rpc: vi.fn(),
+    rest: { headers: {} },
+  },
+  setSucursalHeader: vi.fn(),
+  getSucursalHeader: vi.fn(() => null),
+}))
+
+vi.mock('../../contexts/SucursalContext', () => ({
+  useSucursal: () => ({
+    currentSucursalId: 1,
+    sucursales: [{ id: 1, nombre: 'Test', rol: 'admin' }],
+    loading: false,
+    switchSucursal: vi.fn(),
+  }),
+}))
+
 describe('useOfflineSync Integration Tests', () => {
   // Productos de prueba
   const mockProductos: ProductoDB[] = [
@@ -117,7 +140,7 @@ describe('useOfflineSync Integration Tests', () => {
       const mockPendingOp = {
         id: 1,
         type: 'CREATE_PEDIDO',
-        status: 'pending',
+        status: 'pending', sucursalId: 1,
         payload: pedidoData,
         createdAt: new Date()
       }
@@ -294,9 +317,9 @@ describe('useOfflineSync Integration Tests', () => {
     it('debe continuar sincronizando otros pedidos si uno falla', async () => {
       // Mock getPendingOperations to return 3 pending orders
       const mockPendingOps = [
-        { id: 1, type: 'CREATE_PEDIDO', status: 'pending', payload: { clienteId: '1', items: [], total: 100 }, createdAt: new Date() },
-        { id: 2, type: 'CREATE_PEDIDO', status: 'pending', payload: { clienteId: '2', items: [], total: 200 }, createdAt: new Date() },
-        { id: 3, type: 'CREATE_PEDIDO', status: 'pending', payload: { clienteId: '3', items: [], total: 300 }, createdAt: new Date() }
+        { id: 1, type: 'CREATE_PEDIDO', status: 'pending', sucursalId: 1, payload: { clienteId: '1', items: [], total: 100 }, createdAt: new Date() },
+        { id: 2, type: 'CREATE_PEDIDO', status: 'pending', sucursalId: 1, payload: { clienteId: '2', items: [], total: 200 }, createdAt: new Date() },
+        { id: 3, type: 'CREATE_PEDIDO', status: 'pending', sucursalId: 1, payload: { clienteId: '3', items: [], total: 300 }, createdAt: new Date() }
       ]
       // First call returns all 3 (initial load), second call also returns 3 (sync reads), third returns only failed one (after sync)
       mockGetPendingOperations
@@ -335,8 +358,8 @@ describe('useOfflineSync Integration Tests', () => {
     it('debe reportar todos los errores de sincronización', async () => {
       // Mock getPendingOperations to return 2 pending orders
       const mockPendingOps = [
-        { id: 1, type: 'CREATE_PEDIDO', status: 'pending', payload: { clienteId: '1', items: [], total: 100 }, createdAt: new Date() },
-        { id: 2, type: 'CREATE_PEDIDO', status: 'pending', payload: { clienteId: '2', items: [], total: 200 }, createdAt: new Date() }
+        { id: 1, type: 'CREATE_PEDIDO', status: 'pending', sucursalId: 1, payload: { clienteId: '1', items: [], total: 100 }, createdAt: new Date() },
+        { id: 2, type: 'CREATE_PEDIDO', status: 'pending', sucursalId: 1, payload: { clienteId: '2', items: [], total: 200 }, createdAt: new Date() }
       ]
       // First call returns both (initial load), second call also returns both (sync reads), third returns both (both failed)
       mockGetPendingOperations
@@ -376,7 +399,7 @@ describe('useOfflineSync Integration Tests', () => {
     it('debe prevenir sincronización simultánea (doble click)', async () => {
       // Mock a single pending operation
       const mockPendingOps = [
-        { id: 1, type: 'CREATE_PEDIDO', status: 'pending', payload: { clienteId: '1', items: [], total: 100 }, createdAt: new Date() }
+        { id: 1, type: 'CREATE_PEDIDO', status: 'pending', sucursalId: 1, payload: { clienteId: '1', items: [], total: 100 }, createdAt: new Date() }
       ]
       // Return ops for initial load, then for sync reads (multiple times), then empty after sync
       mockGetPendingOperations
@@ -416,7 +439,7 @@ describe('useOfflineSync Integration Tests', () => {
 
     it('debe permitir sincronizar después de que termine la sincronización anterior', async () => {
       // First sync: 1 pending operation
-      const mockOp1 = { id: 1, type: 'CREATE_PEDIDO', status: 'pending', payload: { clienteId: '1', items: [], total: 100 }, createdAt: new Date() }
+      const mockOp1 = { id: 1, type: 'CREATE_PEDIDO', status: 'pending', sucursalId: 1, payload: { clienteId: '1', items: [], total: 100 }, createdAt: new Date() }
       // Initial load returns op1, first sync returns op1, after sync returns empty
       mockGetPendingOperations
         .mockResolvedValueOnce([mockOp1]) // Initial load
@@ -438,7 +461,7 @@ describe('useOfflineSync Integration Tests', () => {
       expect(mockCrearPedido).toHaveBeenCalledTimes(1)
 
       // Second sync: new pending operation
-      const mockOp2 = { id: 2, type: 'CREATE_PEDIDO', status: 'pending', payload: { clienteId: '2', items: [], total: 200 }, createdAt: new Date() }
+      const mockOp2 = { id: 2, type: 'CREATE_PEDIDO', status: 'pending', sucursalId: 1, payload: { clienteId: '2', items: [], total: 200 }, createdAt: new Date() }
       // For second sync: return op2 for sync, then empty after sync
       mockGetPendingOperations
         .mockResolvedValueOnce([mockOp2]) // Second sync reads
@@ -496,7 +519,7 @@ describe('useOfflineSync Integration Tests', () => {
       const mockMermaOp = {
         id: 1,
         type: 'CREATE_MERMA',
-        status: 'pending',
+        status: 'pending', sucursalId: 1,
         payload: mermaData,
         createdAt: new Date()
       }
@@ -520,7 +543,7 @@ describe('useOfflineSync Integration Tests', () => {
       const mockMermaOp = {
         id: 1,
         type: 'CREATE_MERMA',
-        status: 'pending',
+        status: 'pending', sucursalId: 1,
         payload: { producto_id: 'p1', cantidad: 2, tipo_merma: 'rotura', motivo: 'Producto roto' },
         createdAt: new Date()
       }
@@ -607,7 +630,7 @@ describe('useOfflineSync Integration Tests', () => {
       const mockPendingOp = {
         id: 1,
         type: 'CREATE_PEDIDO',
-        status: 'pending',
+        status: 'pending', sucursalId: 1,
         payload: { clienteId: '1', items: [], total: 100 },
         createdAt: new Date()
       }

--- a/src/hooks/queries/useClientesQuery.ts
+++ b/src/hooks/queries/useClientesQuery.ts
@@ -4,17 +4,18 @@
  */
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { supabase } from '../supabase/base'
+import { useSucursal } from '../../contexts/SucursalContext'
 import type { ClienteDB } from '../../types'
 
 // Query keys
 export const clientesKeys = {
-  all: ['clientes'] as const,
-  lists: () => [...clientesKeys.all, 'list'] as const,
-  list: (filters: Record<string, unknown>) => [...clientesKeys.lists(), filters] as const,
-  details: () => [...clientesKeys.all, 'detail'] as const,
-  detail: (id: string) => [...clientesKeys.details(), id] as const,
-  byZona: (zona: string) => [...clientesKeys.all, 'zona', zona] as const,
-  zonas: () => [...clientesKeys.all, 'zonas'] as const,
+  all: (sucursalId: number | null) => ['clientes', sucursalId] as const,
+  lists: (sucursalId: number | null) => [...clientesKeys.all(sucursalId), 'list'] as const,
+  list: (sucursalId: number | null, filters: Record<string, unknown>) => [...clientesKeys.lists(sucursalId), filters] as const,
+  details: (sucursalId: number | null) => [...clientesKeys.all(sucursalId), 'detail'] as const,
+  detail: (sucursalId: number | null, id: string) => [...clientesKeys.details(sucursalId), id] as const,
+  byZona: (sucursalId: number | null, zona: string) => [...clientesKeys.all(sucursalId), 'zona', zona] as const,
+  zonas: (sucursalId: number | null) => [...clientesKeys.all(sucursalId), 'zonas'] as const,
 }
 
 // Fetch functions
@@ -157,8 +158,9 @@ async function deleteCliente(id: string): Promise<void> {
  * Hook para obtener todos los clientes activos
  */
 export function useClientesQuery() {
+  const { currentSucursalId } = useSucursal()
   return useQuery({
-    queryKey: clientesKeys.lists(),
+    queryKey: clientesKeys.lists(currentSucursalId),
     queryFn: fetchClientes,
     staleTime: 5 * 60 * 1000, // 5 minutos
   })
@@ -168,8 +170,9 @@ export function useClientesQuery() {
  * Hook para obtener un cliente por ID
  */
 export function useClienteQuery(id: string) {
+  const { currentSucursalId } = useSucursal()
   return useQuery({
-    queryKey: clientesKeys.detail(id),
+    queryKey: clientesKeys.detail(currentSucursalId, id),
     queryFn: () => fetchClienteById(id),
     enabled: !!id,
   })
@@ -179,8 +182,9 @@ export function useClienteQuery(id: string) {
  * Hook para obtener clientes por zona
  */
 export function useClientesByZonaQuery(zona: string) {
+  const { currentSucursalId } = useSucursal()
   return useQuery({
-    queryKey: clientesKeys.byZona(zona),
+    queryKey: clientesKeys.byZona(currentSucursalId, zona),
     queryFn: () => fetchClientesByZona(zona),
     enabled: !!zona,
     staleTime: 5 * 60 * 1000,
@@ -191,8 +195,9 @@ export function useClientesByZonaQuery(zona: string) {
  * Hook para obtener zonas únicas
  */
 export function useZonasQuery() {
+  const { currentSucursalId } = useSucursal()
   return useQuery({
-    queryKey: clientesKeys.zonas(),
+    queryKey: clientesKeys.zonas(currentSucursalId),
     queryFn: fetchZonasUnicas,
     staleTime: 10 * 60 * 1000, // 10 minutos - zonas cambian poco
   })
@@ -203,22 +208,23 @@ export function useZonasQuery() {
  */
 export function useCrearClienteMutation() {
   const queryClient = useQueryClient()
+  const { currentSucursalId } = useSucursal()
 
   return useMutation({
     mutationFn: createCliente,
     onSuccess: (newCliente) => {
       // Actualizar cache de lista
-      queryClient.setQueryData<ClienteDB[]>(clientesKeys.lists(), (old) => {
+      queryClient.setQueryData<ClienteDB[]>(clientesKeys.lists(currentSucursalId), (old) => {
         if (!old) return [newCliente]
         return [...old, newCliente].sort((a, b) =>
           (a.nombre_fantasia || '').localeCompare(b.nombre_fantasia || '')
         )
       })
       // Invalidar zonas por si es una nueva zona
-      queryClient.invalidateQueries({ queryKey: clientesKeys.zonas() })
+      queryClient.invalidateQueries({ queryKey: clientesKeys.zonas(currentSucursalId) })
       // Invalidar clientes por zona si aplica
       if (newCliente.zona) {
-        queryClient.invalidateQueries({ queryKey: clientesKeys.byZona(newCliente.zona) })
+        queryClient.invalidateQueries({ queryKey: clientesKeys.byZona(currentSucursalId, newCliente.zona) })
       }
     },
   })
@@ -229,17 +235,18 @@ export function useCrearClienteMutation() {
  */
 export function useActualizarClienteMutation() {
   const queryClient = useQueryClient()
+  const { currentSucursalId } = useSucursal()
 
   return useMutation({
     mutationFn: updateCliente,
     // Optimistic update
     onMutate: async ({ id, data: cliente }) => {
-      await queryClient.cancelQueries({ queryKey: clientesKeys.lists() })
+      await queryClient.cancelQueries({ queryKey: clientesKeys.lists(currentSucursalId) })
 
-      const previousClientes = queryClient.getQueryData<ClienteDB[]>(clientesKeys.lists())
+      const previousClientes = queryClient.getQueryData<ClienteDB[]>(clientesKeys.lists(currentSucursalId))
 
       // Aplicar cambios optimistamente
-      queryClient.setQueryData<ClienteDB[]>(clientesKeys.lists(), (old) => {
+      queryClient.setQueryData<ClienteDB[]>(clientesKeys.lists(currentSucursalId), (old) => {
         if (!old) return old
         return old.map(c => c.id === id ? { ...c, ...cliente } as ClienteDB : c)
       })
@@ -249,17 +256,17 @@ export function useActualizarClienteMutation() {
     onError: (_, __, context) => {
       // Rollback on error
       if (context?.previousClientes) {
-        queryClient.setQueryData(clientesKeys.lists(), context.previousClientes)
+        queryClient.setQueryData(clientesKeys.lists(currentSucursalId), context.previousClientes)
       }
     },
     onSuccess: (updatedCliente) => {
       // Actualizar cache de detalle con datos reales del servidor
-      queryClient.setQueryData(clientesKeys.detail(updatedCliente.id), updatedCliente)
+      queryClient.setQueryData(clientesKeys.detail(currentSucursalId, updatedCliente.id), updatedCliente)
     },
     onSettled: () => {
       // Revalidar para asegurar consistencia
-      queryClient.invalidateQueries({ queryKey: clientesKeys.lists() })
-      queryClient.invalidateQueries({ queryKey: clientesKeys.zonas() })
+      queryClient.invalidateQueries({ queryKey: clientesKeys.lists(currentSucursalId) })
+      queryClient.invalidateQueries({ queryKey: clientesKeys.zonas(currentSucursalId) })
     },
   })
 }
@@ -269,14 +276,15 @@ export function useActualizarClienteMutation() {
  */
 export function useEliminarClienteMutation() {
   const queryClient = useQueryClient()
+  const { currentSucursalId } = useSucursal()
 
   return useMutation({
     mutationFn: deleteCliente,
     onSuccess: (_, deletedId) => {
       // Remover de cache de detalle
-      queryClient.removeQueries({ queryKey: clientesKeys.detail(deletedId) })
+      queryClient.removeQueries({ queryKey: clientesKeys.detail(currentSucursalId, deletedId) })
       // Actualizar cache de lista
-      queryClient.setQueryData<ClienteDB[]>(clientesKeys.lists(), (old) => {
+      queryClient.setQueryData<ClienteDB[]>(clientesKeys.lists(currentSucursalId), (old) => {
         if (!old) return []
         return old.filter(c => c.id !== deletedId)
       })

--- a/src/hooks/queries/useComprasQuery.ts
+++ b/src/hooks/queries/useComprasQuery.ts
@@ -4,6 +4,7 @@
  */
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { supabase } from '../supabase/base'
+import { useSucursal } from '../../contexts/SucursalContext'
 import { fechaLocalISO } from '../../utils/formatters'
 import type {
   CompraDBExtended,
@@ -13,13 +14,13 @@ import type {
 
 // Query keys
 export const comprasKeys = {
-  all: ['compras'] as const,
-  lists: () => [...comprasKeys.all, 'list'] as const,
-  list: (filters: Record<string, unknown>) => [...comprasKeys.lists(), filters] as const,
-  details: () => [...comprasKeys.all, 'detail'] as const,
-  detail: (id: string) => [...comprasKeys.details(), id] as const,
-  byProveedor: (proveedorId: string) => [...comprasKeys.all, 'proveedor', proveedorId] as const,
-  byProducto: (productoId: string) => [...comprasKeys.all, 'producto', productoId] as const,
+  all: (sucursalId: number | null) => ['compras', sucursalId] as const,
+  lists: (sucursalId: number | null) => [...comprasKeys.all(sucursalId), 'list'] as const,
+  list: (sucursalId: number | null, filters: Record<string, unknown>) => [...comprasKeys.lists(sucursalId), filters] as const,
+  details: (sucursalId: number | null) => [...comprasKeys.all(sucursalId), 'detail'] as const,
+  detail: (sucursalId: number | null, id: string) => [...comprasKeys.details(sucursalId), id] as const,
+  byProveedor: (sucursalId: number | null, proveedorId: string) => [...comprasKeys.all(sucursalId), 'proveedor', proveedorId] as const,
+  byProducto: (sucursalId: number | null, productoId: string) => [...comprasKeys.all(sucursalId), 'producto', productoId] as const,
 }
 
 interface CompraItemRPC {
@@ -168,8 +169,9 @@ async function anularCompra(compraId: string, compras: CompraDBExtended[]): Prom
  * Hook para obtener todas las compras
  */
 export function useComprasQuery() {
+  const { currentSucursalId } = useSucursal()
   return useQuery({
-    queryKey: comprasKeys.lists(),
+    queryKey: comprasKeys.lists(currentSucursalId),
     queryFn: fetchCompras,
     staleTime: 5 * 60 * 1000, // 5 minutos
   })
@@ -179,8 +181,9 @@ export function useComprasQuery() {
  * Hook para obtener una compra por ID
  */
 export function useCompraQuery(id: string) {
+  const { currentSucursalId } = useSucursal()
   return useQuery({
-    queryKey: comprasKeys.detail(id),
+    queryKey: comprasKeys.detail(currentSucursalId, id),
     queryFn: () => fetchCompraById(id),
     enabled: !!id,
   })
@@ -190,8 +193,9 @@ export function useCompraQuery(id: string) {
  * Hook para obtener compras por proveedor
  */
 export function useComprasByProveedorQuery(proveedorId: string) {
+  const { currentSucursalId } = useSucursal()
   return useQuery({
-    queryKey: comprasKeys.byProveedor(proveedorId),
+    queryKey: comprasKeys.byProveedor(currentSucursalId, proveedorId),
     queryFn: () => fetchComprasByProveedor(proveedorId),
     enabled: !!proveedorId,
     staleTime: 5 * 60 * 1000,
@@ -203,12 +207,13 @@ export function useComprasByProveedorQuery(proveedorId: string) {
  */
 export function useRegistrarCompraMutation() {
   const queryClient = useQueryClient()
+  const { currentSucursalId } = useSucursal()
 
   return useMutation({
     mutationFn: registrarCompra,
     onSuccess: () => {
       // Invalidar compras y productos (stock actualizado)
-      queryClient.invalidateQueries({ queryKey: comprasKeys.lists() })
+      queryClient.invalidateQueries({ queryKey: comprasKeys.lists(currentSucursalId) })
       queryClient.invalidateQueries({ queryKey: ['productos'] })
     },
   })
@@ -219,21 +224,22 @@ export function useRegistrarCompraMutation() {
  */
 export function useAnularCompraMutation() {
   const queryClient = useQueryClient()
+  const { currentSucursalId } = useSucursal()
 
   return useMutation({
     mutationFn: async (compraId: string) => {
-      const compras = queryClient.getQueryData<CompraDBExtended[]>(comprasKeys.lists()) || []
+      const compras = queryClient.getQueryData<CompraDBExtended[]>(comprasKeys.lists(currentSucursalId)) || []
       await anularCompra(compraId, compras)
       return compraId
     },
     // Optimistic update
     onMutate: async (compraId: string) => {
-      await queryClient.cancelQueries({ queryKey: comprasKeys.lists() })
+      await queryClient.cancelQueries({ queryKey: comprasKeys.lists(currentSucursalId) })
 
-      const previousCompras = queryClient.getQueryData<CompraDBExtended[]>(comprasKeys.lists())
+      const previousCompras = queryClient.getQueryData<CompraDBExtended[]>(comprasKeys.lists(currentSucursalId))
 
       // Marcar como cancelada optimistamente
-      queryClient.setQueryData<CompraDBExtended[]>(comprasKeys.lists(), (old) => {
+      queryClient.setQueryData<CompraDBExtended[]>(comprasKeys.lists(currentSucursalId), (old) => {
         if (!old) return old
         return old.map(c => c.id === compraId ? { ...c, estado: 'cancelada' as const } : c)
       })
@@ -243,12 +249,12 @@ export function useAnularCompraMutation() {
     onError: (_, __, context) => {
       // Rollback on error
       if (context?.previousCompras) {
-        queryClient.setQueryData(comprasKeys.lists(), context.previousCompras)
+        queryClient.setQueryData(comprasKeys.lists(currentSucursalId), context.previousCompras)
       }
     },
     onSettled: () => {
       // Revalidar
-      queryClient.invalidateQueries({ queryKey: comprasKeys.lists() })
+      queryClient.invalidateQueries({ queryKey: comprasKeys.lists(currentSucursalId) })
       queryClient.invalidateQueries({ queryKey: ['productos'] })
     },
   })

--- a/src/hooks/queries/useGruposPrecioQuery.ts
+++ b/src/hooks/queries/useGruposPrecioQuery.ts
@@ -4,6 +4,7 @@
  */
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { supabase } from '../supabase/base'
+import { useSucursal } from '../../contexts/SucursalContext'
 import type {
   GrupoPrecioDB,
   GrupoPrecioProductoDB,
@@ -15,11 +16,11 @@ import type { PricingMap, GrupoPrecioInfo, EscalaPrecio } from '../../utils/prec
 
 // Query keys
 export const gruposPrecioKeys = {
-  all: ['grupos_precio'] as const,
-  lists: () => [...gruposPrecioKeys.all, 'list'] as const,
-  details: () => [...gruposPrecioKeys.all, 'detail'] as const,
-  detail: (id: string) => [...gruposPrecioKeys.details(), id] as const,
-  pricingMap: () => [...gruposPrecioKeys.all, 'pricing_map'] as const,
+  all: (sucursalId: number | null) => ['grupos_precio', sucursalId] as const,
+  lists: (sucursalId: number | null) => [...gruposPrecioKeys.all(sucursalId), 'list'] as const,
+  details: (sucursalId: number | null) => [...gruposPrecioKeys.all(sucursalId), 'detail'] as const,
+  detail: (sucursalId: number | null, id: string) => [...gruposPrecioKeys.details(sucursalId), id] as const,
+  pricingMap: (sucursalId: number | null) => [...gruposPrecioKeys.all(sucursalId), 'pricing_map'] as const,
 }
 
 // =============================================================================
@@ -278,8 +279,9 @@ async function toggleGrupoPrecioActivo(id: string, activo: boolean): Promise<Gru
  * Hook para obtener todos los grupos de precio con sus productos y escalas
  */
 export function useGruposPrecioQuery() {
+  const { currentSucursalId } = useSucursal()
   return useQuery({
-    queryKey: gruposPrecioKeys.lists(),
+    queryKey: gruposPrecioKeys.lists(currentSucursalId),
     queryFn: fetchGruposPrecio,
     staleTime: 10 * 60 * 1000,
   })
@@ -290,8 +292,9 @@ export function useGruposPrecioQuery() {
  * Cache 10 minutos, usado por usePrecioMayorista
  */
 export function usePricingMapQuery() {
+  const { currentSucursalId } = useSucursal()
   return useQuery({
-    queryKey: gruposPrecioKeys.pricingMap(),
+    queryKey: gruposPrecioKeys.pricingMap(currentSucursalId),
     queryFn: fetchPricingMap,
     staleTime: 10 * 60 * 1000,
   })
@@ -302,11 +305,12 @@ export function usePricingMapQuery() {
  */
 export function useCrearGrupoPrecioMutation() {
   const queryClient = useQueryClient()
+  const { currentSucursalId } = useSucursal()
 
   return useMutation({
     mutationFn: createGrupoPrecio,
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: gruposPrecioKeys.all })
+      queryClient.invalidateQueries({ queryKey: gruposPrecioKeys.all(currentSucursalId) })
     },
   })
 }
@@ -316,11 +320,12 @@ export function useCrearGrupoPrecioMutation() {
  */
 export function useActualizarGrupoPrecioMutation() {
   const queryClient = useQueryClient()
+  const { currentSucursalId } = useSucursal()
 
   return useMutation({
     mutationFn: updateGrupoPrecio,
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: gruposPrecioKeys.all })
+      queryClient.invalidateQueries({ queryKey: gruposPrecioKeys.all(currentSucursalId) })
     },
   })
 }
@@ -330,13 +335,14 @@ export function useActualizarGrupoPrecioMutation() {
  */
 export function useEliminarGrupoPrecioMutation() {
   const queryClient = useQueryClient()
+  const { currentSucursalId } = useSucursal()
 
   return useMutation({
     mutationFn: deleteGrupoPrecio,
     onMutate: async (id: string) => {
-      await queryClient.cancelQueries({ queryKey: gruposPrecioKeys.lists() })
-      const previous = queryClient.getQueryData<GrupoPrecioConDetalles[]>(gruposPrecioKeys.lists())
-      queryClient.setQueryData<GrupoPrecioConDetalles[]>(gruposPrecioKeys.lists(), (old) => {
+      await queryClient.cancelQueries({ queryKey: gruposPrecioKeys.lists(currentSucursalId) })
+      const previous = queryClient.getQueryData<GrupoPrecioConDetalles[]>(gruposPrecioKeys.lists(currentSucursalId))
+      queryClient.setQueryData<GrupoPrecioConDetalles[]>(gruposPrecioKeys.lists(currentSucursalId), (old) => {
         if (!old) return old
         return old.filter(g => g.id !== id)
       })
@@ -344,11 +350,11 @@ export function useEliminarGrupoPrecioMutation() {
     },
     onError: (_, __, context) => {
       if (context?.previous) {
-        queryClient.setQueryData(gruposPrecioKeys.lists(), context.previous)
+        queryClient.setQueryData(gruposPrecioKeys.lists(currentSucursalId), context.previous)
       }
     },
     onSettled: () => {
-      queryClient.invalidateQueries({ queryKey: gruposPrecioKeys.all })
+      queryClient.invalidateQueries({ queryKey: gruposPrecioKeys.all(currentSucursalId) })
     },
   })
 }
@@ -358,14 +364,15 @@ export function useEliminarGrupoPrecioMutation() {
  */
 export function useToggleGrupoPrecioActivoMutation() {
   const queryClient = useQueryClient()
+  const { currentSucursalId } = useSucursal()
 
   return useMutation({
     mutationFn: ({ id, activo }: { id: string; activo: boolean }) =>
       toggleGrupoPrecioActivo(id, activo),
     onMutate: async ({ id, activo }) => {
-      await queryClient.cancelQueries({ queryKey: gruposPrecioKeys.lists() })
-      const previous = queryClient.getQueryData<GrupoPrecioConDetalles[]>(gruposPrecioKeys.lists())
-      queryClient.setQueryData<GrupoPrecioConDetalles[]>(gruposPrecioKeys.lists(), (old) => {
+      await queryClient.cancelQueries({ queryKey: gruposPrecioKeys.lists(currentSucursalId) })
+      const previous = queryClient.getQueryData<GrupoPrecioConDetalles[]>(gruposPrecioKeys.lists(currentSucursalId))
+      queryClient.setQueryData<GrupoPrecioConDetalles[]>(gruposPrecioKeys.lists(currentSucursalId), (old) => {
         if (!old) return old
         return old.map(g => g.id === id ? { ...g, activo } : g)
       })
@@ -373,11 +380,11 @@ export function useToggleGrupoPrecioActivoMutation() {
     },
     onError: (_, __, context) => {
       if (context?.previous) {
-        queryClient.setQueryData(gruposPrecioKeys.lists(), context.previous)
+        queryClient.setQueryData(gruposPrecioKeys.lists(currentSucursalId), context.previous)
       }
     },
     onSettled: () => {
-      queryClient.invalidateQueries({ queryKey: gruposPrecioKeys.all })
+      queryClient.invalidateQueries({ queryKey: gruposPrecioKeys.all(currentSucursalId) })
     },
   })
 }

--- a/src/hooks/queries/useMermasQuery.ts
+++ b/src/hooks/queries/useMermasQuery.ts
@@ -4,6 +4,7 @@
  */
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { supabase } from '../supabase/base'
+import { useSucursal } from '../../contexts/SucursalContext'
 import type {
   MermaDBExtended,
   MermaFormInputExtended,
@@ -13,13 +14,13 @@ import { productosKeys } from './useProductosQuery'
 
 // Query keys
 export const mermasKeys = {
-  all: ['mermas'] as const,
-  lists: () => [...mermasKeys.all, 'list'] as const,
-  list: (filters: Record<string, unknown>) => [...mermasKeys.lists(), filters] as const,
-  details: () => [...mermasKeys.all, 'detail'] as const,
-  detail: (id: string) => [...mermasKeys.details(), id] as const,
-  byProducto: (productoId: string) => [...mermasKeys.all, 'producto', productoId] as const,
-  byMotivo: (motivo: string) => [...mermasKeys.all, 'motivo', motivo] as const,
+  all: (sucursalId: number | null) => ['mermas', sucursalId] as const,
+  lists: (sucursalId: number | null) => [...mermasKeys.all(sucursalId), 'list'] as const,
+  list: (sucursalId: number | null, filters: Record<string, unknown>) => [...mermasKeys.lists(sucursalId), filters] as const,
+  details: (sucursalId: number | null) => [...mermasKeys.all(sucursalId), 'detail'] as const,
+  detail: (sucursalId: number | null, id: string) => [...mermasKeys.details(sucursalId), id] as const,
+  byProducto: (sucursalId: number | null, productoId: string) => [...mermasKeys.all(sucursalId), 'producto', productoId] as const,
+  byMotivo: (sucursalId: number | null, motivo: string) => [...mermasKeys.all(sucursalId), 'motivo', motivo] as const,
 }
 
 // Fetch functions
@@ -117,8 +118,9 @@ async function registrarMerma(mermaData: MermaFormInputExtended): Promise<MermaR
  * Hook para obtener todas las mermas
  */
 export function useMermasQuery() {
+  const { currentSucursalId } = useSucursal()
   return useQuery({
-    queryKey: mermasKeys.lists(),
+    queryKey: mermasKeys.lists(currentSucursalId),
     queryFn: fetchMermas,
     staleTime: 5 * 60 * 1000, // 5 minutos
   })
@@ -128,8 +130,9 @@ export function useMermasQuery() {
  * Hook para obtener mermas por producto
  */
 export function useMermasByProductoQuery(productoId: string) {
+  const { currentSucursalId } = useSucursal()
   return useQuery({
-    queryKey: mermasKeys.byProducto(productoId),
+    queryKey: mermasKeys.byProducto(currentSucursalId, productoId),
     queryFn: () => fetchMermasByProducto(productoId),
     enabled: !!productoId,
     staleTime: 5 * 60 * 1000,
@@ -140,8 +143,9 @@ export function useMermasByProductoQuery(productoId: string) {
  * Hook para obtener mermas por motivo
  */
 export function useMermasByMotivoQuery(motivo: string) {
+  const { currentSucursalId } = useSucursal()
   return useQuery({
-    queryKey: mermasKeys.byMotivo(motivo),
+    queryKey: mermasKeys.byMotivo(currentSucursalId, motivo),
     queryFn: () => fetchMermasByMotivo(motivo),
     enabled: !!motivo,
     staleTime: 5 * 60 * 1000,
@@ -153,22 +157,23 @@ export function useMermasByMotivoQuery(motivo: string) {
  */
 export function useRegistrarMermaMutation() {
   const queryClient = useQueryClient()
+  const { currentSucursalId } = useSucursal()
 
   return useMutation({
     mutationFn: registrarMerma,
     onSuccess: (result, variables) => {
       // Agregar merma al cache si fue creada
       if (result.merma) {
-        queryClient.setQueryData<MermaDBExtended[]>(mermasKeys.lists(), (old) => {
+        queryClient.setQueryData<MermaDBExtended[]>(mermasKeys.lists(currentSucursalId), (old) => {
           if (!old) return [result.merma!]
           return [result.merma!, ...old]
         })
       }
       // Invalidar mermas del producto específico
-      queryClient.invalidateQueries({ queryKey: mermasKeys.byProducto(variables.productoId) })
+      queryClient.invalidateQueries({ queryKey: mermasKeys.byProducto(currentSucursalId, variables.productoId) })
       // Invalidar productos (stock actualizado)
-      queryClient.invalidateQueries({ queryKey: productosKeys.lists() })
-      queryClient.invalidateQueries({ queryKey: productosKeys.stockBajo(10) })
+      queryClient.invalidateQueries({ queryKey: productosKeys.lists(currentSucursalId) })
+      queryClient.invalidateQueries({ queryKey: productosKeys.stockBajo(currentSucursalId, 10) })
     },
   })
 }

--- a/src/hooks/queries/useMetricasQuery.ts
+++ b/src/hooks/queries/useMetricasQuery.ts
@@ -4,6 +4,7 @@
  */
 import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { supabase } from '../supabase/base'
+import { useSucursal } from '../../contexts/SucursalContext'
 import { fechaLocalISO } from '../../utils/formatters'
 import type {
   DashboardMetricasExtended,
@@ -17,11 +18,11 @@ import type {
 
 // Query keys
 export const metricasKeys = {
-  all: ['metricas'] as const,
-  dashboard: (periodo: string, usuarioId?: string | null) =>
-    [...metricasKeys.all, 'dashboard', periodo, usuarioId] as const,
-  reportePreventistas: (fechaDesde?: string | null, fechaHasta?: string | null) =>
-    [...metricasKeys.all, 'reporte-preventistas', fechaDesde, fechaHasta] as const,
+  all: (sucursalId: number | null) => ['metricas', sucursalId] as const,
+  dashboard: (sucursalId: number | null, periodo: string, usuarioId?: string | null) =>
+    [...metricasKeys.all(sucursalId), 'dashboard', periodo, usuarioId] as const,
+  reportePreventistas: (sucursalId: number | null, fechaDesde?: string | null, fechaHasta?: string | null) =>
+    [...metricasKeys.all(sucursalId), 'reporte-preventistas', fechaDesde, fechaHasta] as const,
 }
 
 interface PedidoWithRelations {
@@ -259,8 +260,9 @@ export function useMetricasQuery(
   fechaHasta?: string | null,
   enabled = true
 ) {
+  const { currentSucursalId } = useSucursal()
   return useQuery({
-    queryKey: metricasKeys.dashboard(periodo, usuarioId),
+    queryKey: metricasKeys.dashboard(currentSucursalId, periodo, usuarioId),
     queryFn: () => calcularMetricas({ periodo, fechaDesde, fechaHasta, usuarioId }),
     staleTime: 2 * 60 * 1000, // 2 minutos - métricas cambian frecuentemente
     gcTime: 10 * 60 * 1000,
@@ -276,8 +278,9 @@ export function useReportePreventistasQuery(
   fechaHasta?: string | null,
   enabled = true
 ) {
+  const { currentSucursalId } = useSucursal()
   return useQuery({
-    queryKey: metricasKeys.reportePreventistas(fechaDesde, fechaHasta),
+    queryKey: metricasKeys.reportePreventistas(currentSucursalId, fechaDesde, fechaHasta),
     queryFn: () => calcularReportePreventistas(fechaDesde, fechaHasta),
     enabled,
     staleTime: 5 * 60 * 1000,
@@ -289,8 +292,9 @@ export function useReportePreventistasQuery(
  */
 export function useInvalidateMetricas() {
   const queryClient = useQueryClient()
+  const { currentSucursalId } = useSucursal()
 
   return () => {
-    queryClient.invalidateQueries({ queryKey: metricasKeys.all })
+    queryClient.invalidateQueries({ queryKey: metricasKeys.all(currentSucursalId) })
   }
 }

--- a/src/hooks/queries/useNotasCreditoQuery.ts
+++ b/src/hooks/queries/useNotasCreditoQuery.ts
@@ -4,6 +4,7 @@
  */
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { supabase } from '../supabase/base'
+import { useSucursal } from '../../contexts/SucursalContext'
 import type { NotaCreditoDB, NotaCreditoFormInput } from '../../types'
 import { comprasKeys } from './useComprasQuery'
 
@@ -16,10 +17,10 @@ export interface NCResumen {
 
 // Query keys
 export const notasCreditoKeys = {
-  all: ['notas_credito'] as const,
-  lists: () => [...notasCreditoKeys.all, 'list'] as const,
-  resumen: () => [...notasCreditoKeys.all, 'resumen'] as const,
-  byCompra: (compraId: string) => [...notasCreditoKeys.all, 'compra', compraId] as const,
+  all: (sucursalId: number | null) => ['notas_credito', sucursalId] as const,
+  lists: (sucursalId: number | null) => [...notasCreditoKeys.all(sucursalId), 'list'] as const,
+  resumen: (sucursalId: number | null) => [...notasCreditoKeys.all(sucursalId), 'resumen'] as const,
+  byCompra: (sucursalId: number | null, compraId: string) => [...notasCreditoKeys.all(sucursalId), 'compra', compraId] as const,
 }
 
 // Fetch functions
@@ -100,8 +101,9 @@ async function registrarNotaCredito(data: NotaCreditoFormInput): Promise<void> {
  * Hook para obtener notas de credito de una compra
  */
 export function useNotasCreditoByCompraQuery(compraId: string | undefined, enabled = true) {
+  const { currentSucursalId } = useSucursal()
   return useQuery({
-    queryKey: notasCreditoKeys.byCompra(compraId || ''),
+    queryKey: notasCreditoKeys.byCompra(currentSucursalId, compraId || ''),
     queryFn: () => fetchNotasCreditoByCompra(compraId!),
     enabled: !!compraId && enabled,
     staleTime: 5 * 60 * 1000,
@@ -112,8 +114,9 @@ export function useNotasCreditoByCompraQuery(compraId: string | undefined, enabl
  * Hook para obtener resumen de NCs por compra (para badges en lista)
  */
 export function useNotasCreditoResumenQuery() {
+  const { currentSucursalId } = useSucursal()
   return useQuery({
-    queryKey: notasCreditoKeys.resumen(),
+    queryKey: notasCreditoKeys.resumen(currentSucursalId),
     queryFn: fetchNotasCreditoResumen,
     staleTime: 5 * 60 * 1000,
   })
@@ -124,13 +127,14 @@ export function useNotasCreditoResumenQuery() {
  */
 export function useRegistrarNotaCreditoMutation() {
   const queryClient = useQueryClient()
+  const { currentSucursalId } = useSucursal()
 
   return useMutation({
     mutationFn: registrarNotaCredito,
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: comprasKeys.lists() })
+      queryClient.invalidateQueries({ queryKey: comprasKeys.lists(currentSucursalId) })
       queryClient.invalidateQueries({ queryKey: ['productos'] })
-      queryClient.invalidateQueries({ queryKey: notasCreditoKeys.all })
+      queryClient.invalidateQueries({ queryKey: notasCreditoKeys.all(currentSucursalId) })
     },
   })
 }

--- a/src/hooks/queries/usePedidosQuery.ts
+++ b/src/hooks/queries/usePedidosQuery.ts
@@ -4,22 +4,25 @@
  */
 import { useQuery, useMutation, useQueryClient, keepPreviousData } from '@tanstack/react-query'
 import { supabase } from '../supabase/base'
+import { useSucursal } from '../../contexts/SucursalContext'
 import type { PedidoDB, PedidoItemDB, PerfilDB, FiltrosPedidosState, PedidoSalvedadResumen } from '../../types'
 import { productosKeys } from './useProductosQuery'
 
 // Query keys
 export const pedidosKeys = {
-  all: ['pedidos'] as const,
-  lists: () => [...pedidosKeys.all, 'list'] as const,
-  list: (filters: Partial<FiltrosPedidosState>) => [...pedidosKeys.lists(), filters] as const,
-  details: () => [...pedidosKeys.all, 'detail'] as const,
-  detail: (id: string) => [...pedidosKeys.details(), id] as const,
-  byTransportista: (transportistaId: string) => [...pedidosKeys.all, 'transportista', transportistaId] as const,
-  byCliente: (clienteId: string) => [...pedidosKeys.all, 'cliente', clienteId] as const,
-  historial: (pedidoId: string) => [...pedidosKeys.all, 'historial', pedidoId] as const,
-  eliminados: () => [...pedidosKeys.all, 'eliminados'] as const,
-  paginated: (page: number, pageSize: number, filters: Partial<FiltrosPedidosState>) =>
-    [...pedidosKeys.all, 'paginated', page, pageSize, filters] as const,
+  all: (sucursalId: number | null) => ['pedidos', sucursalId] as const,
+  lists: (sucursalId: number | null) => [...pedidosKeys.all(sucursalId), 'list'] as const,
+  list: (sucursalId: number | null, filters: Partial<FiltrosPedidosState>) => [...pedidosKeys.lists(sucursalId), filters] as const,
+  details: (sucursalId: number | null) => [...pedidosKeys.all(sucursalId), 'detail'] as const,
+  detail: (sucursalId: number | null, id: string) => [...pedidosKeys.details(sucursalId), id] as const,
+  byTransportista: (sucursalId: number | null, transportistaId: string) => [...pedidosKeys.all(sucursalId), 'transportista', transportistaId] as const,
+  byCliente: (sucursalId: number | null, clienteId: string) => [...pedidosKeys.all(sucursalId), 'cliente', clienteId] as const,
+  historial: (sucursalId: number | null, pedidoId: string) => [...pedidosKeys.all(sucursalId), 'historial', pedidoId] as const,
+  eliminados: (sucursalId: number | null) => [...pedidosKeys.all(sucursalId), 'eliminados'] as const,
+  paginated: (sucursalId: number | null, page: number, pageSize: number, filters: Partial<FiltrosPedidosState>) =>
+    [...pedidosKeys.all(sucursalId), 'paginated', page, pageSize, filters] as const,
+  noEntregados: (sucursalId: number | null) => [...pedidosKeys.all(sucursalId), 'no-entregados'] as const,
+  noPagados: (sucursalId: number | null) => [...pedidosKeys.all(sucursalId), 'no-pagados'] as const,
 }
 
 // Types
@@ -381,8 +384,9 @@ async function eliminarPedido(id: string, motivo?: string, usuarioId?: string): 
  * Hook para obtener todos los pedidos
  */
 export function usePedidosQuery() {
+  const { currentSucursalId } = useSucursal()
   return useQuery({
-    queryKey: pedidosKeys.lists(),
+    queryKey: pedidosKeys.lists(currentSucursalId),
     queryFn: fetchPedidos,
     staleTime: 2 * 60 * 1000, // 2 minutos - pedidos cambian frecuentemente
   })
@@ -392,8 +396,9 @@ export function usePedidosQuery() {
  * Hook para obtener un pedido por ID
  */
 export function usePedidoQuery(id: string) {
+  const { currentSucursalId } = useSucursal()
   return useQuery({
-    queryKey: pedidosKeys.detail(id),
+    queryKey: pedidosKeys.detail(currentSucursalId, id),
     queryFn: () => fetchPedidoById(id),
     enabled: !!id,
   })
@@ -403,8 +408,9 @@ export function usePedidoQuery(id: string) {
  * Hook para obtener pedidos de un transportista
  */
 export function usePedidosByTransportistaQuery(transportistaId: string) {
+  const { currentSucursalId } = useSucursal()
   return useQuery({
-    queryKey: pedidosKeys.byTransportista(transportistaId),
+    queryKey: pedidosKeys.byTransportista(currentSucursalId, transportistaId),
     queryFn: () => fetchPedidosByTransportista(transportistaId),
     enabled: !!transportistaId,
     staleTime: 1 * 60 * 1000, // 1 minuto
@@ -415,8 +421,9 @@ export function usePedidosByTransportistaQuery(transportistaId: string) {
  * Hook para obtener pedidos de un cliente
  */
 export function usePedidosByClienteQuery(clienteId: string) {
+  const { currentSucursalId } = useSucursal()
   return useQuery({
-    queryKey: pedidosKeys.byCliente(clienteId),
+    queryKey: pedidosKeys.byCliente(currentSucursalId, clienteId),
     queryFn: () => fetchPedidosByCliente(clienteId),
     enabled: !!clienteId,
     staleTime: 2 * 60 * 1000,
@@ -433,8 +440,9 @@ export function usePedidosPaginatedQuery(
   search?: string,
   enabled = true
 ) {
+  const { currentSucursalId } = useSucursal()
   return useQuery({
-    queryKey: pedidosKeys.paginated(page, pageSize, { ...filters, busqueda: search } as Partial<FiltrosPedidosState>),
+    queryKey: pedidosKeys.paginated(currentSucursalId, page, pageSize, { ...filters, busqueda: search } as Partial<FiltrosPedidosState>),
     queryFn: () => fetchPedidosPaginated(page, pageSize, filters, search),
     staleTime: 2 * 60 * 1000,
     placeholderData: keepPreviousData,
@@ -447,15 +455,16 @@ export function usePedidosPaginatedQuery(
  */
 export function useCrearPedidoMutation() {
   const queryClient = useQueryClient()
+  const { currentSucursalId } = useSucursal()
 
   return useMutation({
     mutationFn: crearPedido,
     onSuccess: () => {
       // Invalidar todas las queries de pedidos (list + paginated)
-      queryClient.invalidateQueries({ queryKey: pedidosKeys.all })
+      queryClient.invalidateQueries({ queryKey: pedidosKeys.all(currentSucursalId) })
       // Invalidar productos (por cambio de stock)
-      queryClient.invalidateQueries({ queryKey: productosKeys.lists() })
-      queryClient.invalidateQueries({ queryKey: productosKeys.stockBajo(10) })
+      queryClient.invalidateQueries({ queryKey: productosKeys.lists(currentSucursalId) })
+      queryClient.invalidateQueries({ queryKey: productosKeys.stockBajo(currentSucursalId, 10) })
     },
   })
 }
@@ -465,16 +474,17 @@ export function useCrearPedidoMutation() {
  */
 export function useCambiarEstadoMutation() {
   const queryClient = useQueryClient()
+  const { currentSucursalId } = useSucursal()
 
   return useMutation({
     mutationFn: actualizarEstado,
     // Optimistic update
     onMutate: async (input) => {
-      await queryClient.cancelQueries({ queryKey: pedidosKeys.lists() })
+      await queryClient.cancelQueries({ queryKey: pedidosKeys.lists(currentSucursalId) })
 
-      const previousPedidos = queryClient.getQueryData<PedidoDB[]>(pedidosKeys.lists())
+      const previousPedidos = queryClient.getQueryData<PedidoDB[]>(pedidosKeys.lists(currentSucursalId))
 
-      queryClient.setQueryData<PedidoDB[]>(pedidosKeys.lists(), (old) => {
+      queryClient.setQueryData<PedidoDB[]>(pedidosKeys.lists(currentSucursalId), (old) => {
         if (!old) return old
         return old.map(p =>
           p.id === input.pedidoId ? { ...p, estado: input.nuevoEstado as PedidoDB['estado'] } : p
@@ -486,11 +496,11 @@ export function useCambiarEstadoMutation() {
     onError: (_, __, context) => {
       // Rollback on error
       if (context?.previousPedidos) {
-        queryClient.setQueryData(pedidosKeys.lists(), context.previousPedidos)
+        queryClient.setQueryData(pedidosKeys.lists(currentSucursalId), context.previousPedidos)
       }
     },
     onSettled: () => {
-      queryClient.invalidateQueries({ queryKey: pedidosKeys.all })
+      queryClient.invalidateQueries({ queryKey: pedidosKeys.all(currentSucursalId) })
     },
   })
 }
@@ -500,15 +510,16 @@ export function useCambiarEstadoMutation() {
  */
 export function useActualizarPagoMutation() {
   const queryClient = useQueryClient()
+  const { currentSucursalId } = useSucursal()
 
   return useMutation({
     mutationFn: actualizarPago,
     onMutate: async (input) => {
-      await queryClient.cancelQueries({ queryKey: pedidosKeys.lists() })
+      await queryClient.cancelQueries({ queryKey: pedidosKeys.lists(currentSucursalId) })
 
-      const previousPedidos = queryClient.getQueryData<PedidoDB[]>(pedidosKeys.lists())
+      const previousPedidos = queryClient.getQueryData<PedidoDB[]>(pedidosKeys.lists(currentSucursalId))
 
-      queryClient.setQueryData<PedidoDB[]>(pedidosKeys.lists(), (old) => {
+      queryClient.setQueryData<PedidoDB[]>(pedidosKeys.lists(currentSucursalId), (old) => {
         if (!old) return old
         return old.map(p =>
           p.id === input.pedidoId
@@ -521,11 +532,11 @@ export function useActualizarPagoMutation() {
     },
     onError: (_, __, context) => {
       if (context?.previousPedidos) {
-        queryClient.setQueryData(pedidosKeys.lists(), context.previousPedidos)
+        queryClient.setQueryData(pedidosKeys.lists(currentSucursalId), context.previousPedidos)
       }
     },
     onSettled: () => {
-      queryClient.invalidateQueries({ queryKey: pedidosKeys.all })
+      queryClient.invalidateQueries({ queryKey: pedidosKeys.all(currentSucursalId) })
     },
   })
 }
@@ -535,14 +546,15 @@ export function useActualizarPagoMutation() {
  */
 export function useAsignarTransportistaMutation() {
   const queryClient = useQueryClient()
+  const { currentSucursalId } = useSucursal()
 
   return useMutation({
     mutationFn: ({ pedidoId, transportistaId }: { pedidoId: string; transportistaId: string | null }) =>
       asignarTransportista(pedidoId, transportistaId),
     onSuccess: (_, { transportistaId }) => {
-      queryClient.invalidateQueries({ queryKey: pedidosKeys.all })
+      queryClient.invalidateQueries({ queryKey: pedidosKeys.all(currentSucursalId) })
       if (transportistaId) {
-        queryClient.invalidateQueries({ queryKey: pedidosKeys.byTransportista(transportistaId) })
+        queryClient.invalidateQueries({ queryKey: pedidosKeys.byTransportista(currentSucursalId, transportistaId) })
       }
     },
   })
@@ -553,22 +565,23 @@ export function useAsignarTransportistaMutation() {
  */
 export function useEliminarPedidoMutation() {
   const queryClient = useQueryClient()
+  const { currentSucursalId } = useSucursal()
 
   return useMutation({
     mutationFn: ({ id, motivo, usuarioId }: { id: string; motivo?: string; usuarioId?: string }) =>
       eliminarPedido(id, motivo, usuarioId),
     onSuccess: (_, { id }) => {
       // Remover de cache
-      queryClient.removeQueries({ queryKey: pedidosKeys.detail(id) })
+      queryClient.removeQueries({ queryKey: pedidosKeys.detail(currentSucursalId, id) })
       // Actualizar lista (optimistic for legacy query)
-      queryClient.setQueryData<PedidoDB[]>(pedidosKeys.lists(), (old) => {
+      queryClient.setQueryData<PedidoDB[]>(pedidosKeys.lists(currentSucursalId), (old) => {
         if (!old) return []
         return old.filter(p => p.id !== id)
       })
       // Invalidar todas las queries de pedidos (list + paginated)
-      queryClient.invalidateQueries({ queryKey: pedidosKeys.all })
+      queryClient.invalidateQueries({ queryKey: pedidosKeys.all(currentSucursalId) })
       // Invalidar productos (stock restaurado)
-      queryClient.invalidateQueries({ queryKey: productosKeys.lists() })
+      queryClient.invalidateQueries({ queryKey: productosKeys.lists(currentSucursalId) })
     },
   })
 }
@@ -617,8 +630,9 @@ async function fetchPedidosNoEntregados(): Promise<PedidoDB[]> {
  * Se habilita solo cuando enabled=true (modal abierto)
  */
 export function usePedidosNoEntregadosQuery(enabled = false) {
+  const { currentSucursalId } = useSucursal()
   return useQuery({
-    queryKey: [...pedidosKeys.all, 'no-entregados'] as const,
+    queryKey: pedidosKeys.noEntregados(currentSucursalId),
     queryFn: fetchPedidosNoEntregados,
     enabled,
     staleTime: 30 * 1000, // 30 segundos
@@ -655,12 +669,13 @@ async function entregarPedidosMasivo(pedidoIds: string[], transportistaId: strin
  */
 export function useEntregasMasivasMutation() {
   const queryClient = useQueryClient()
+  const { currentSucursalId } = useSucursal()
 
   return useMutation({
     mutationFn: ({ pedidoIds, transportistaId }: { pedidoIds: string[]; transportistaId: string }) =>
       entregarPedidosMasivo(pedidoIds, transportistaId),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: pedidosKeys.all })
+      queryClient.invalidateQueries({ queryKey: pedidosKeys.all(currentSucursalId) })
     },
   })
 }
@@ -689,13 +704,14 @@ async function cancelarPedido(pedidoId: string, motivo: string, usuarioId?: stri
  */
 export function useCancelarPedidoMutation() {
   const queryClient = useQueryClient()
+  const { currentSucursalId } = useSucursal()
 
   return useMutation({
     mutationFn: ({ pedidoId, motivo, usuarioId }: { pedidoId: string; motivo: string; usuarioId?: string }) =>
       cancelarPedido(pedidoId, motivo, usuarioId),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: pedidosKeys.all })
-      queryClient.invalidateQueries({ queryKey: productosKeys.all })
+      queryClient.invalidateQueries({ queryKey: pedidosKeys.all(currentSucursalId) })
+      queryClient.invalidateQueries({ queryKey: productosKeys.all(currentSucursalId) })
     },
   })
 }
@@ -745,8 +761,9 @@ async function fetchPedidosNoPagados(): Promise<PedidoDB[]> {
  * Se habilita solo cuando enabled=true (modal abierto)
  */
 export function usePedidosNoPagadosQuery(enabled = false) {
+  const { currentSucursalId } = useSucursal()
   return useQuery({
-    queryKey: [...pedidosKeys.all, 'no-pagados'] as const,
+    queryKey: pedidosKeys.noPagados(currentSucursalId),
     queryFn: fetchPedidosNoPagados,
     enabled,
     staleTime: 30 * 1000,
@@ -793,12 +810,13 @@ async function marcarPagosMasivo(pedidoIds: string[], formaPago: string): Promis
  */
 export function usePagosMasivosMutation() {
   const queryClient = useQueryClient()
+  const { currentSucursalId } = useSucursal()
 
   return useMutation({
     mutationFn: ({ pedidoIds, formaPago }: { pedidoIds: string[]; formaPago: string }) =>
       marcarPagosMasivo(pedidoIds, formaPago),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: pedidosKeys.all })
+      queryClient.invalidateQueries({ queryKey: pedidosKeys.all(currentSucursalId) })
     },
   })
 }

--- a/src/hooks/queries/useProductosQuery.ts
+++ b/src/hooks/queries/useProductosQuery.ts
@@ -5,15 +5,16 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { supabase } from '../supabase/base'
 import type { ProductoDB, ProductoFormInput } from '../../types'
+import { useSucursal } from '../../contexts/SucursalContext'
 
 // Query keys
 export const productosKeys = {
-  all: ['productos'] as const,
-  lists: () => [...productosKeys.all, 'list'] as const,
-  list: (filters: Record<string, unknown>) => [...productosKeys.lists(), filters] as const,
-  details: () => [...productosKeys.all, 'detail'] as const,
-  detail: (id: string) => [...productosKeys.details(), id] as const,
-  stockBajo: (umbral: number) => [...productosKeys.all, 'stockBajo', umbral] as const,
+  all: (sucursalId: number | null) => ['productos', sucursalId] as const,
+  lists: (sucursalId: number | null) => [...productosKeys.all(sucursalId), 'list'] as const,
+  list: (sucursalId: number | null, filters: Record<string, unknown>) => [...productosKeys.lists(sucursalId), filters] as const,
+  details: (sucursalId: number | null) => [...productosKeys.all(sucursalId), 'detail'] as const,
+  detail: (sucursalId: number | null, id: string) => [...productosKeys.details(sucursalId), id] as const,
+  stockBajo: (sucursalId: number | null, umbral: number) => [...productosKeys.all(sucursalId), 'stockBajo', umbral] as const,
 }
 
 // Fetch functions
@@ -126,8 +127,9 @@ async function deleteProducto(id: string): Promise<void> {
  * Hook para obtener todos los productos
  */
 export function useProductosQuery() {
+  const { currentSucursalId } = useSucursal()
   return useQuery({
-    queryKey: productosKeys.lists(),
+    queryKey: productosKeys.lists(currentSucursalId),
     queryFn: fetchProductos,
     staleTime: 10 * 60 * 1000, // 10 minutos - productos cambian poco
   })
@@ -137,8 +139,9 @@ export function useProductosQuery() {
  * Hook para obtener un producto por ID
  */
 export function useProductoQuery(id: string) {
+  const { currentSucursalId } = useSucursal()
   return useQuery({
-    queryKey: productosKeys.detail(id),
+    queryKey: productosKeys.detail(currentSucursalId, id),
     queryFn: () => fetchProductoById(id),
     enabled: !!id,
   })
@@ -148,8 +151,9 @@ export function useProductoQuery(id: string) {
  * Hook para obtener productos con stock bajo
  */
 export function useProductosStockBajoQuery(umbral = 10) {
+  const { currentSucursalId } = useSucursal()
   return useQuery({
-    queryKey: productosKeys.stockBajo(umbral),
+    queryKey: productosKeys.stockBajo(currentSucursalId, umbral),
     queryFn: () => fetchProductosStockBajo(umbral),
     staleTime: 5 * 60 * 1000, // 5 minutos
   })
@@ -160,17 +164,18 @@ export function useProductosStockBajoQuery(umbral = 10) {
  */
 export function useCrearProductoMutation() {
   const queryClient = useQueryClient()
+  const { currentSucursalId } = useSucursal()
 
   return useMutation({
     mutationFn: createProducto,
     onSuccess: (newProducto) => {
       // Actualizar cache de lista
-      queryClient.setQueryData<ProductoDB[]>(productosKeys.lists(), (old) => {
+      queryClient.setQueryData<ProductoDB[]>(productosKeys.lists(currentSucursalId), (old) => {
         if (!old) return [newProducto]
         return [...old, newProducto].sort((a, b) => a.nombre.localeCompare(b.nombre))
       })
       // Invalidar queries relacionadas
-      queryClient.invalidateQueries({ queryKey: productosKeys.stockBajo(10) })
+      queryClient.invalidateQueries({ queryKey: productosKeys.stockBajo(currentSucursalId, 10) })
     },
   })
 }
@@ -180,17 +185,18 @@ export function useCrearProductoMutation() {
  */
 export function useActualizarProductoMutation() {
   const queryClient = useQueryClient()
+  const { currentSucursalId } = useSucursal()
 
   return useMutation({
     mutationFn: updateProducto,
     // Optimistic update
     onMutate: async ({ id, data: producto }) => {
-      await queryClient.cancelQueries({ queryKey: productosKeys.lists() })
+      await queryClient.cancelQueries({ queryKey: productosKeys.lists(currentSucursalId) })
 
-      const previousProductos = queryClient.getQueryData<ProductoDB[]>(productosKeys.lists())
+      const previousProductos = queryClient.getQueryData<ProductoDB[]>(productosKeys.lists(currentSucursalId))
 
       // Aplicar cambios optimistamente
-      queryClient.setQueryData<ProductoDB[]>(productosKeys.lists(), (old) => {
+      queryClient.setQueryData<ProductoDB[]>(productosKeys.lists(currentSucursalId), (old) => {
         if (!old) return old
         return old.map(p => p.id === id ? { ...p, ...producto } as ProductoDB : p)
       })
@@ -200,17 +206,17 @@ export function useActualizarProductoMutation() {
     onError: (_, __, context) => {
       // Rollback on error
       if (context?.previousProductos) {
-        queryClient.setQueryData(productosKeys.lists(), context.previousProductos)
+        queryClient.setQueryData(productosKeys.lists(currentSucursalId), context.previousProductos)
       }
     },
     onSuccess: (updatedProducto) => {
       // Actualizar cache de detalle con datos reales del servidor
-      queryClient.setQueryData(productosKeys.detail(updatedProducto.id), updatedProducto)
+      queryClient.setQueryData(productosKeys.detail(currentSucursalId, updatedProducto.id), updatedProducto)
     },
     onSettled: () => {
       // Revalidar para asegurar consistencia
-      queryClient.invalidateQueries({ queryKey: productosKeys.lists() })
-      queryClient.invalidateQueries({ queryKey: productosKeys.stockBajo(10) })
+      queryClient.invalidateQueries({ queryKey: productosKeys.lists(currentSucursalId) })
+      queryClient.invalidateQueries({ queryKey: productosKeys.stockBajo(currentSucursalId, 10) })
     },
   })
 }
@@ -220,14 +226,15 @@ export function useActualizarProductoMutation() {
  */
 export function useEliminarProductoMutation() {
   const queryClient = useQueryClient()
+  const { currentSucursalId } = useSucursal()
 
   return useMutation({
     mutationFn: deleteProducto,
     onSuccess: (_, deletedId) => {
       // Remover de cache de detalle
-      queryClient.removeQueries({ queryKey: productosKeys.detail(deletedId) })
+      queryClient.removeQueries({ queryKey: productosKeys.detail(currentSucursalId, deletedId) })
       // Actualizar cache de lista
-      queryClient.setQueryData<ProductoDB[]>(productosKeys.lists(), (old) => {
+      queryClient.setQueryData<ProductoDB[]>(productosKeys.lists(currentSucursalId), (old) => {
         if (!old) return []
         return old.filter(p => p.id !== deletedId)
       })
@@ -240,6 +247,7 @@ export function useEliminarProductoMutation() {
  */
 export function useDescontarStockMutation() {
   const queryClient = useQueryClient()
+  const { currentSucursalId } = useSucursal()
 
   return useMutation({
     mutationFn: async (items: { producto_id: string; cantidad: number }[]) => {
@@ -258,7 +266,7 @@ export function useDescontarStockMutation() {
     },
     onSuccess: (items) => {
       // Actualizar cache de lista optimistamente
-      queryClient.setQueryData<ProductoDB[]>(productosKeys.lists(), (old) => {
+      queryClient.setQueryData<ProductoDB[]>(productosKeys.lists(currentSucursalId), (old) => {
         if (!old) return old
         return old.map(p => {
           const item = items.find(i => i.producto_id === p.id)
@@ -267,7 +275,7 @@ export function useDescontarStockMutation() {
         })
       })
       // Invalidar stock bajo
-      queryClient.invalidateQueries({ queryKey: productosKeys.stockBajo(10) })
+      queryClient.invalidateQueries({ queryKey: productosKeys.stockBajo(currentSucursalId, 10) })
     },
   })
 }
@@ -277,6 +285,7 @@ export function useDescontarStockMutation() {
  */
 export function useRestaurarStockMutation() {
   const queryClient = useQueryClient()
+  const { currentSucursalId } = useSucursal()
 
   return useMutation({
     mutationFn: async (items: { producto_id: string; cantidad: number }[]) => {
@@ -289,7 +298,7 @@ export function useRestaurarStockMutation() {
     },
     onSuccess: (items) => {
       // Actualizar cache de lista optimistamente
-      queryClient.setQueryData<ProductoDB[]>(productosKeys.lists(), (old) => {
+      queryClient.setQueryData<ProductoDB[]>(productosKeys.lists(currentSucursalId), (old) => {
         if (!old) return old
         return old.map(p => {
           const item = items.find(i => i.producto_id === p.id)
@@ -298,7 +307,7 @@ export function useRestaurarStockMutation() {
         })
       })
       // Invalidar stock bajo
-      queryClient.invalidateQueries({ queryKey: productosKeys.stockBajo(10) })
+      queryClient.invalidateQueries({ queryKey: productosKeys.stockBajo(currentSucursalId, 10) })
     },
   })
 }

--- a/src/hooks/queries/usePromocionesQuery.ts
+++ b/src/hooks/queries/usePromocionesQuery.ts
@@ -4,6 +4,7 @@
  */
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { supabase } from '../supabase/base'
+import { useSucursal } from '../../contexts/SucursalContext'
 import { fechaLocalISO } from '../../utils/formatters'
 import type {
   PromocionDB,
@@ -14,9 +15,9 @@ import type { PromoMap, PromocionActiva } from '../../utils/promociones'
 
 // Query keys
 export const promocionesKeys = {
-  all: ['promociones'] as const,
-  lists: () => [...promocionesKeys.all, 'list'] as const,
-  promoMap: () => [...promocionesKeys.all, 'promo_map'] as const,
+  all: (sucursalId: number | null) => ['promociones', sucursalId] as const,
+  lists: (sucursalId: number | null) => [...promocionesKeys.all(sucursalId), 'list'] as const,
+  promoMap: (sucursalId: number | null) => [...promocionesKeys.all(sucursalId), 'promo_map'] as const,
 }
 
 // =============================================================================
@@ -335,8 +336,9 @@ async function ajustarStockPromo(input: AjustarStockInput): Promise<void> {
  * Cache 5 minutos (más corto que mayorista por ser temporal)
  */
 export function usePromoMapQuery() {
+  const { currentSucursalId } = useSucursal()
   return useQuery({
-    queryKey: promocionesKeys.promoMap(),
+    queryKey: promocionesKeys.promoMap(currentSucursalId),
     queryFn: fetchPromoMap,
     staleTime: 5 * 60 * 1000,
   })
@@ -346,8 +348,9 @@ export function usePromoMapQuery() {
  * Hook para obtener todas las promociones con detalles (admin panel)
  */
 export function usePromocionesListQuery() {
+  const { currentSucursalId } = useSucursal()
   return useQuery({
-    queryKey: promocionesKeys.lists(),
+    queryKey: promocionesKeys.lists(currentSucursalId),
     queryFn: fetchPromocionesList,
     staleTime: 2 * 60 * 1000,
   })
@@ -355,50 +358,55 @@ export function usePromocionesListQuery() {
 
 export function useCrearPromocionMutation() {
   const queryClient = useQueryClient()
+  const { currentSucursalId } = useSucursal()
   return useMutation({
     mutationFn: createPromocion,
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: promocionesKeys.all })
+      queryClient.invalidateQueries({ queryKey: promocionesKeys.all(currentSucursalId) })
     },
   })
 }
 
 export function useActualizarPromocionMutation() {
   const queryClient = useQueryClient()
+  const { currentSucursalId } = useSucursal()
   return useMutation({
     mutationFn: updatePromocion,
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: promocionesKeys.all })
+      queryClient.invalidateQueries({ queryKey: promocionesKeys.all(currentSucursalId) })
     },
   })
 }
 
 export function useEliminarPromocionMutation() {
   const queryClient = useQueryClient()
+  const { currentSucursalId } = useSucursal()
   return useMutation({
     mutationFn: deletePromocion,
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: promocionesKeys.all })
+      queryClient.invalidateQueries({ queryKey: promocionesKeys.all(currentSucursalId) })
     },
   })
 }
 
 export function useTogglePromocionActivaMutation() {
   const queryClient = useQueryClient()
+  const { currentSucursalId } = useSucursal()
   return useMutation({
     mutationFn: ({ id, activo }: { id: string; activo: boolean }) => togglePromocionActiva(id, activo),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: promocionesKeys.all })
+      queryClient.invalidateQueries({ queryKey: promocionesKeys.all(currentSucursalId) })
     },
   })
 }
 
 export function useAjustarStockPromoMutation() {
   const queryClient = useQueryClient()
+  const { currentSucursalId } = useSucursal()
   return useMutation({
     mutationFn: ajustarStockPromo,
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: promocionesKeys.all })
+      queryClient.invalidateQueries({ queryKey: promocionesKeys.all(currentSucursalId) })
     },
   })
 }

--- a/src/hooks/queries/useProveedoresQuery.ts
+++ b/src/hooks/queries/useProveedoresQuery.ts
@@ -5,15 +5,16 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { supabase } from '../supabase/base'
 import type { ProveedorDBExtended, ProveedorFormInputExtended } from '../../types'
+import { useSucursal } from '../../contexts/SucursalContext'
 
 // Query keys
 export const proveedoresKeys = {
-  all: ['proveedores'] as const,
-  lists: () => [...proveedoresKeys.all, 'list'] as const,
-  list: (filters: Record<string, unknown>) => [...proveedoresKeys.lists(), filters] as const,
-  details: () => [...proveedoresKeys.all, 'detail'] as const,
-  detail: (id: string) => [...proveedoresKeys.details(), id] as const,
-  activos: () => [...proveedoresKeys.all, 'activos'] as const,
+  all: (sucursalId: number | null) => ['proveedores', sucursalId] as const,
+  lists: (sucursalId: number | null) => [...proveedoresKeys.all(sucursalId), 'list'] as const,
+  list: (sucursalId: number | null, filters: Record<string, unknown>) => [...proveedoresKeys.lists(sucursalId), filters] as const,
+  details: (sucursalId: number | null) => [...proveedoresKeys.all(sucursalId), 'detail'] as const,
+  detail: (sucursalId: number | null, id: string) => [...proveedoresKeys.details(sucursalId), id] as const,
+  activos: (sucursalId: number | null) => [...proveedoresKeys.all(sucursalId), 'activos'] as const,
 }
 
 // Fetch functions
@@ -163,8 +164,10 @@ async function deleteProveedor(id: string): Promise<void> {
  * Hook para obtener todos los proveedores
  */
 export function useProveedoresQuery() {
+  const { currentSucursalId } = useSucursal()
+
   return useQuery({
-    queryKey: proveedoresKeys.lists(),
+    queryKey: proveedoresKeys.lists(currentSucursalId),
     queryFn: fetchProveedores,
     staleTime: 10 * 60 * 1000, // 10 minutos - proveedores cambian poco
   })
@@ -174,8 +177,10 @@ export function useProveedoresQuery() {
  * Hook para obtener solo proveedores activos
  */
 export function useProveedoresActivosQuery() {
+  const { currentSucursalId } = useSucursal()
+
   return useQuery({
-    queryKey: proveedoresKeys.activos(),
+    queryKey: proveedoresKeys.activos(currentSucursalId),
     queryFn: fetchProveedoresActivos,
     staleTime: 10 * 60 * 1000,
   })
@@ -185,8 +190,10 @@ export function useProveedoresActivosQuery() {
  * Hook para obtener un proveedor por ID
  */
 export function useProveedorQuery(id: string) {
+  const { currentSucursalId } = useSucursal()
+
   return useQuery({
-    queryKey: proveedoresKeys.detail(id),
+    queryKey: proveedoresKeys.detail(currentSucursalId, id),
     queryFn: () => fetchProveedorById(id),
     enabled: !!id,
   })
@@ -197,17 +204,18 @@ export function useProveedorQuery(id: string) {
  */
 export function useCrearProveedorMutation() {
   const queryClient = useQueryClient()
+  const { currentSucursalId } = useSucursal()
 
   return useMutation({
     mutationFn: createProveedor,
     onSuccess: (newProveedor) => {
       // Actualizar cache de lista
-      queryClient.setQueryData<ProveedorDBExtended[]>(proveedoresKeys.lists(), (old) => {
+      queryClient.setQueryData<ProveedorDBExtended[]>(proveedoresKeys.lists(currentSucursalId), (old) => {
         if (!old) return [newProveedor]
         return [...old, newProveedor].sort((a, b) => a.nombre.localeCompare(b.nombre))
       })
       // Invalidar activos también
-      queryClient.invalidateQueries({ queryKey: proveedoresKeys.activos() })
+      queryClient.invalidateQueries({ queryKey: proveedoresKeys.activos(currentSucursalId) })
     },
   })
 }
@@ -217,17 +225,18 @@ export function useCrearProveedorMutation() {
  */
 export function useActualizarProveedorMutation() {
   const queryClient = useQueryClient()
+  const { currentSucursalId } = useSucursal()
 
   return useMutation({
     mutationFn: updateProveedor,
     // Optimistic update
     onMutate: async ({ id, data: proveedor }) => {
-      await queryClient.cancelQueries({ queryKey: proveedoresKeys.lists() })
+      await queryClient.cancelQueries({ queryKey: proveedoresKeys.lists(currentSucursalId) })
 
-      const previousProveedores = queryClient.getQueryData<ProveedorDBExtended[]>(proveedoresKeys.lists())
+      const previousProveedores = queryClient.getQueryData<ProveedorDBExtended[]>(proveedoresKeys.lists(currentSucursalId))
 
       // Aplicar cambios optimistamente
-      queryClient.setQueryData<ProveedorDBExtended[]>(proveedoresKeys.lists(), (old) => {
+      queryClient.setQueryData<ProveedorDBExtended[]>(proveedoresKeys.lists(currentSucursalId), (old) => {
         if (!old) return old
         return old.map(p => p.id === id ? { ...p, ...proveedor } as ProveedorDBExtended : p)
       })
@@ -237,17 +246,17 @@ export function useActualizarProveedorMutation() {
     onError: (_, __, context) => {
       // Rollback on error
       if (context?.previousProveedores) {
-        queryClient.setQueryData(proveedoresKeys.lists(), context.previousProveedores)
+        queryClient.setQueryData(proveedoresKeys.lists(currentSucursalId), context.previousProveedores)
       }
     },
     onSuccess: (updatedProveedor) => {
       // Actualizar cache de detalle
-      queryClient.setQueryData(proveedoresKeys.detail(updatedProveedor.id), updatedProveedor)
+      queryClient.setQueryData(proveedoresKeys.detail(currentSucursalId, updatedProveedor.id), updatedProveedor)
     },
     onSettled: () => {
       // Revalidar para asegurar consistencia
-      queryClient.invalidateQueries({ queryKey: proveedoresKeys.lists() })
-      queryClient.invalidateQueries({ queryKey: proveedoresKeys.activos() })
+      queryClient.invalidateQueries({ queryKey: proveedoresKeys.lists(currentSucursalId) })
+      queryClient.invalidateQueries({ queryKey: proveedoresKeys.activos(currentSucursalId) })
     },
   })
 }
@@ -257,17 +266,18 @@ export function useActualizarProveedorMutation() {
  */
 export function useToggleProveedorActivoMutation() {
   const queryClient = useQueryClient()
+  const { currentSucursalId } = useSucursal()
 
   return useMutation({
     mutationFn: ({ id, activo }: { id: string; activo: boolean }) =>
       toggleProveedorActivo(id, activo),
     // Optimistic update
     onMutate: async ({ id, activo }) => {
-      await queryClient.cancelQueries({ queryKey: proveedoresKeys.lists() })
+      await queryClient.cancelQueries({ queryKey: proveedoresKeys.lists(currentSucursalId) })
 
-      const previousProveedores = queryClient.getQueryData<ProveedorDBExtended[]>(proveedoresKeys.lists())
+      const previousProveedores = queryClient.getQueryData<ProveedorDBExtended[]>(proveedoresKeys.lists(currentSucursalId))
 
-      queryClient.setQueryData<ProveedorDBExtended[]>(proveedoresKeys.lists(), (old) => {
+      queryClient.setQueryData<ProveedorDBExtended[]>(proveedoresKeys.lists(currentSucursalId), (old) => {
         if (!old) return old
         return old.map(p => p.id === id ? { ...p, activo } : p)
       })
@@ -276,12 +286,12 @@ export function useToggleProveedorActivoMutation() {
     },
     onError: (_, __, context) => {
       if (context?.previousProveedores) {
-        queryClient.setQueryData(proveedoresKeys.lists(), context.previousProveedores)
+        queryClient.setQueryData(proveedoresKeys.lists(currentSucursalId), context.previousProveedores)
       }
     },
     onSettled: () => {
-      queryClient.invalidateQueries({ queryKey: proveedoresKeys.lists() })
-      queryClient.invalidateQueries({ queryKey: proveedoresKeys.activos() })
+      queryClient.invalidateQueries({ queryKey: proveedoresKeys.lists(currentSucursalId) })
+      queryClient.invalidateQueries({ queryKey: proveedoresKeys.activos(currentSucursalId) })
     },
   })
 }
@@ -291,13 +301,14 @@ export function useToggleProveedorActivoMutation() {
  */
 export function useEliminarProveedorMutation() {
   const queryClient = useQueryClient()
+  const { currentSucursalId } = useSucursal()
 
   return useMutation({
     mutationFn: deleteProveedor,
     onMutate: async (id: string) => {
-      await queryClient.cancelQueries({ queryKey: proveedoresKeys.lists() })
-      const previousProveedores = queryClient.getQueryData<ProveedorDBExtended[]>(proveedoresKeys.lists())
-      queryClient.setQueryData<ProveedorDBExtended[]>(proveedoresKeys.lists(), (old) => {
+      await queryClient.cancelQueries({ queryKey: proveedoresKeys.lists(currentSucursalId) })
+      const previousProveedores = queryClient.getQueryData<ProveedorDBExtended[]>(proveedoresKeys.lists(currentSucursalId))
+      queryClient.setQueryData<ProveedorDBExtended[]>(proveedoresKeys.lists(currentSucursalId), (old) => {
         if (!old) return old
         return old.filter(p => p.id !== id)
       })
@@ -305,12 +316,12 @@ export function useEliminarProveedorMutation() {
     },
     onError: (_, __, context) => {
       if (context?.previousProveedores) {
-        queryClient.setQueryData(proveedoresKeys.lists(), context.previousProveedores)
+        queryClient.setQueryData(proveedoresKeys.lists(currentSucursalId), context.previousProveedores)
       }
     },
     onSettled: () => {
-      queryClient.invalidateQueries({ queryKey: proveedoresKeys.lists() })
-      queryClient.invalidateQueries({ queryKey: proveedoresKeys.activos() })
+      queryClient.invalidateQueries({ queryKey: proveedoresKeys.lists(currentSucursalId) })
+      queryClient.invalidateQueries({ queryKey: proveedoresKeys.activos(currentSucursalId) })
     },
   })
 }

--- a/src/hooks/queries/useTransferenciasQuery.ts
+++ b/src/hooks/queries/useTransferenciasQuery.ts
@@ -5,6 +5,7 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { supabase } from '../supabase/base'
 import { fechaLocalISO } from '../../utils/formatters'
+import { useSucursal } from '../../contexts/SucursalContext'
 import type {
   TransferenciaDB,
   TransferenciaFormInput,
@@ -13,11 +14,11 @@ import type {
 
 // Query keys
 export const transferenciasKeys = {
-  all: ['transferencias'] as const,
-  lists: () => [...transferenciasKeys.all, 'list'] as const,
-  list: (filters: Record<string, unknown>) => [...transferenciasKeys.lists(), filters] as const,
-  details: () => [...transferenciasKeys.all, 'detail'] as const,
-  detail: (id: string) => [...transferenciasKeys.details(), id] as const,
+  all: (sucursalId: number | null) => ['transferencias', sucursalId] as const,
+  lists: (sucursalId: number | null) => [...transferenciasKeys.all(sucursalId), 'list'] as const,
+  list: (sucursalId: number | null, filters: Record<string, unknown>) => [...transferenciasKeys.lists(sucursalId), filters] as const,
+  details: (sucursalId: number | null) => [...transferenciasKeys.all(sucursalId), 'detail'] as const,
+  detail: (sucursalId: number | null, id: string) => [...transferenciasKeys.details(sucursalId), id] as const,
 }
 
 export const sucursalesKeys = {
@@ -138,8 +139,9 @@ async function registrarIngresoSucursal(formData: TransferenciaFormInput): Promi
  * Hook para obtener todas las transferencias
  */
 export function useTransferenciasQuery() {
+  const { currentSucursalId } = useSucursal()
   return useQuery({
-    queryKey: transferenciasKeys.lists(),
+    queryKey: transferenciasKeys.lists(currentSucursalId),
     queryFn: fetchTransferencias,
     staleTime: 5 * 60 * 1000,
   })
@@ -175,11 +177,12 @@ export function useCrearSucursalMutation() {
  */
 export function useRegistrarTransferenciaMutation() {
   const queryClient = useQueryClient()
+  const { currentSucursalId } = useSucursal()
 
   return useMutation({
     mutationFn: registrarTransferencia,
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: transferenciasKeys.lists() })
+      queryClient.invalidateQueries({ queryKey: transferenciasKeys.lists(currentSucursalId) })
       queryClient.invalidateQueries({ queryKey: ['productos'] })
     },
   })
@@ -190,11 +193,12 @@ export function useRegistrarTransferenciaMutation() {
  */
 export function useRegistrarIngresoMutation() {
   const queryClient = useQueryClient()
+  const { currentSucursalId } = useSucursal()
 
   return useMutation({
     mutationFn: registrarIngresoSucursal,
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: transferenciasKeys.lists() })
+      queryClient.invalidateQueries({ queryKey: transferenciasKeys.lists(currentSucursalId) })
       queryClient.invalidateQueries({ queryKey: ['productos'] })
     },
   })

--- a/src/hooks/queries/useTransferenciasQuery.ts
+++ b/src/hooks/queries/useTransferenciasQuery.ts
@@ -46,10 +46,16 @@ async function fetchTransferencias(): Promise<TransferenciaDB[]> {
 }
 
 async function fetchSucursales(): Promise<SucursalDB[]> {
+  // Multi-tenant (C3): filter out tenant rows (ManaosApp/TP Export, tipo
+  // 'principal' / 'secundaria') from the transfer-destination dropdown.
+  // Only sub-sucursales (tipo='distribuidora') are valid transfer targets;
+  // otherwise the UI would let a user move stock into the tenant row itself,
+  // which has no warehouse semantics.
   const { data, error } = await supabase
     .from('sucursales')
     .select('*')
     .eq('activa', true)
+    .eq('tipo', 'distribuidora')
     .order('nombre', { ascending: true })
 
   if (error) {

--- a/src/hooks/queries/useUsuariosQuery.ts
+++ b/src/hooks/queries/useUsuariosQuery.ts
@@ -1,21 +1,29 @@
 /**
  * TanStack Query hooks para Usuarios/Perfiles
  * Reemplaza el hook useUsuarios con mejor cache y gestión de estado
+ *
+ * Multi-tenant (H11): las query keys están scopeadas por sucursalId. Los
+ * usuarios visibles dependen de usuario_sucursales vía RLS, así que la
+ * misma llamada devuelve distintas filas para distintas sucursales.
  */
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { supabase } from '../supabase/base'
+import { useSucursal } from '../../contexts/SucursalContext'
 import type { PerfilDB } from '../../types'
 
-// Query keys
+// Query keys scoped by sucursalId (multi-tenant). Using function factories so
+// every cache entry lives under its own tenant prefix and a sucursal switch
+// invalidates cleanly via the `['usuarios', sucursalId]` prefix.
 export const usuariosKeys = {
-  all: ['usuarios'] as const,
-  lists: () => [...usuariosKeys.all, 'list'] as const,
-  list: (filters: Record<string, unknown>) => [...usuariosKeys.lists(), filters] as const,
-  details: () => [...usuariosKeys.all, 'detail'] as const,
-  detail: (id: string) => [...usuariosKeys.details(), id] as const,
-  byRol: (rol: string) => [...usuariosKeys.all, 'rol', rol] as const,
-  transportistas: () => [...usuariosKeys.all, 'transportistas'] as const,
-  preventistas: () => [...usuariosKeys.all, 'preventistas'] as const,
+  all: (sucursalId: number | null) => ['usuarios', sucursalId] as const,
+  lists: (sucursalId: number | null) => [...usuariosKeys.all(sucursalId), 'list'] as const,
+  list: (sucursalId: number | null, filters: Record<string, unknown>) =>
+    [...usuariosKeys.lists(sucursalId), filters] as const,
+  details: (sucursalId: number | null) => [...usuariosKeys.all(sucursalId), 'detail'] as const,
+  detail: (sucursalId: number | null, id: string) => [...usuariosKeys.details(sucursalId), id] as const,
+  byRol: (sucursalId: number | null, rol: string) => [...usuariosKeys.all(sucursalId), 'rol', rol] as const,
+  transportistas: (sucursalId: number | null) => [...usuariosKeys.all(sucursalId), 'transportistas'] as const,
+  preventistas: (sucursalId: number | null) => [...usuariosKeys.all(sucursalId), 'preventistas'] as const,
 }
 
 // Types
@@ -115,8 +123,9 @@ async function toggleUsuarioActivo(id: string, activo: boolean): Promise<PerfilD
  * Hook para obtener todos los usuarios
  */
 export function useUsuariosQuery() {
+  const { currentSucursalId } = useSucursal()
   return useQuery({
-    queryKey: usuariosKeys.lists(),
+    queryKey: usuariosKeys.lists(currentSucursalId),
     queryFn: fetchUsuarios,
     staleTime: 10 * 60 * 1000, // 10 minutos - usuarios cambian poco
   })
@@ -126,8 +135,9 @@ export function useUsuariosQuery() {
  * Hook para obtener un usuario por ID
  */
 export function useUsuarioQuery(id: string) {
+  const { currentSucursalId } = useSucursal()
   return useQuery({
-    queryKey: usuariosKeys.detail(id),
+    queryKey: usuariosKeys.detail(currentSucursalId, id),
     queryFn: () => fetchUsuarioById(id),
     enabled: !!id,
   })
@@ -137,8 +147,9 @@ export function useUsuarioQuery(id: string) {
  * Hook para obtener usuarios por rol
  */
 export function useUsuariosByRolQuery(rol: string) {
+  const { currentSucursalId } = useSucursal()
   return useQuery({
-    queryKey: usuariosKeys.byRol(rol),
+    queryKey: usuariosKeys.byRol(currentSucursalId, rol),
     queryFn: () => fetchUsuariosByRol(rol),
     enabled: !!rol,
     staleTime: 10 * 60 * 1000,
@@ -149,8 +160,9 @@ export function useUsuariosByRolQuery(rol: string) {
  * Hook para obtener transportistas activos
  */
 export function useTransportistasQuery() {
+  const { currentSucursalId } = useSucursal()
   return useQuery({
-    queryKey: usuariosKeys.transportistas(),
+    queryKey: usuariosKeys.transportistas(currentSucursalId),
     queryFn: fetchTransportistas,
     staleTime: 10 * 60 * 1000,
   })
@@ -160,8 +172,9 @@ export function useTransportistasQuery() {
  * Hook para obtener preventistas activos
  */
 export function usePreventistasQuery() {
+  const { currentSucursalId } = useSucursal()
   return useQuery({
-    queryKey: usuariosKeys.preventistas(),
+    queryKey: usuariosKeys.preventistas(currentSucursalId),
     queryFn: fetchPreventistas,
     staleTime: 10 * 60 * 1000,
   })
@@ -172,23 +185,24 @@ export function usePreventistasQuery() {
  */
 export function useActualizarUsuarioMutation() {
   const queryClient = useQueryClient()
+  const { currentSucursalId } = useSucursal()
 
   return useMutation({
     mutationFn: updateUsuario,
     onSuccess: (updatedUsuario) => {
       // Actualizar cache de detalle
-      queryClient.setQueryData(usuariosKeys.detail(updatedUsuario.id), updatedUsuario)
+      queryClient.setQueryData(usuariosKeys.detail(currentSucursalId, updatedUsuario.id), updatedUsuario)
       // Actualizar cache de lista
-      queryClient.setQueryData<PerfilDB[]>(usuariosKeys.lists(), (old) => {
+      queryClient.setQueryData<PerfilDB[]>(usuariosKeys.lists(currentSucursalId), (old) => {
         if (!old) return [updatedUsuario]
         return old.map(u => u.id === updatedUsuario.id ? updatedUsuario : u)
       })
       // Invalidar listas por rol
       if (updatedUsuario.rol) {
-        queryClient.invalidateQueries({ queryKey: usuariosKeys.byRol(updatedUsuario.rol) })
+        queryClient.invalidateQueries({ queryKey: usuariosKeys.byRol(currentSucursalId, updatedUsuario.rol) })
       }
-      queryClient.invalidateQueries({ queryKey: usuariosKeys.transportistas() })
-      queryClient.invalidateQueries({ queryKey: usuariosKeys.preventistas() })
+      queryClient.invalidateQueries({ queryKey: usuariosKeys.transportistas(currentSucursalId) })
+      queryClient.invalidateQueries({ queryKey: usuariosKeys.preventistas(currentSucursalId) })
     },
   })
 }
@@ -198,17 +212,18 @@ export function useActualizarUsuarioMutation() {
  */
 export function useToggleUsuarioActivoMutation() {
   const queryClient = useQueryClient()
+  const { currentSucursalId } = useSucursal()
 
   return useMutation({
     mutationFn: ({ id, activo }: { id: string; activo: boolean }) => toggleUsuarioActivo(id, activo),
     onSuccess: (updatedUsuario) => {
-      queryClient.setQueryData(usuariosKeys.detail(updatedUsuario.id), updatedUsuario)
-      queryClient.setQueryData<PerfilDB[]>(usuariosKeys.lists(), (old) => {
+      queryClient.setQueryData(usuariosKeys.detail(currentSucursalId, updatedUsuario.id), updatedUsuario)
+      queryClient.setQueryData<PerfilDB[]>(usuariosKeys.lists(currentSucursalId), (old) => {
         if (!old) return [updatedUsuario]
         return old.map(u => u.id === updatedUsuario.id ? updatedUsuario : u)
       })
-      queryClient.invalidateQueries({ queryKey: usuariosKeys.transportistas() })
-      queryClient.invalidateQueries({ queryKey: usuariosKeys.preventistas() })
+      queryClient.invalidateQueries({ queryKey: usuariosKeys.transportistas(currentSucursalId) })
+      queryClient.invalidateQueries({ queryKey: usuariosKeys.preventistas(currentSucursalId) })
     },
   })
 }

--- a/src/hooks/queries/useZonasQuery.ts
+++ b/src/hooks/queries/useZonasQuery.ts
@@ -4,6 +4,7 @@
  */
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { supabase } from '../supabase/base'
+import { useSucursal } from '../../contexts/SucursalContext'
 
 // Types
 export interface ZonaDB {
@@ -15,9 +16,9 @@ export interface ZonaDB {
 
 // Query keys
 export const zonasKeys = {
-  all: ['zonas'] as const,
-  lists: () => [...zonasKeys.all, 'list'] as const,
-  preventista: (perfilId: string) => [...zonasKeys.all, 'preventista', perfilId] as const,
+  all: (sucursalId: number | null) => ['zonas', sucursalId] as const,
+  lists: (sucursalId: number | null) => [...zonasKeys.all(sucursalId), 'list'] as const,
+  preventista: (sucursalId: number | null, perfilId: string) => [...zonasKeys.all(sucursalId), 'preventista', perfilId] as const,
 }
 
 // Fetch functions
@@ -84,16 +85,18 @@ async function asignarZonasPreventista(perfilId: string, zonaIds: string[]): Pro
 // Hooks
 
 export function useZonasEstandarizadasQuery() {
+  const { currentSucursalId } = useSucursal()
   return useQuery({
-    queryKey: zonasKeys.lists(),
+    queryKey: zonasKeys.lists(currentSucursalId),
     queryFn: fetchZonas,
     staleTime: 10 * 60 * 1000,
   })
 }
 
 export function usePreventistaZonasQuery(perfilId: string | undefined) {
+  const { currentSucursalId } = useSucursal()
   return useQuery({
-    queryKey: zonasKeys.preventista(perfilId || ''),
+    queryKey: zonasKeys.preventista(currentSucursalId, perfilId || ''),
     queryFn: () => fetchPreventistaZonas(perfilId!),
     enabled: !!perfilId,
     staleTime: 5 * 60 * 1000,
@@ -102,21 +105,23 @@ export function usePreventistaZonasQuery(perfilId: string | undefined) {
 
 export function useCrearZonaMutation() {
   const queryClient = useQueryClient()
+  const { currentSucursalId } = useSucursal()
   return useMutation({
     mutationFn: crearZona,
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: zonasKeys.all })
+      queryClient.invalidateQueries({ queryKey: zonasKeys.all(currentSucursalId) })
     },
   })
 }
 
 export function useAsignarZonasPrevMutation() {
   const queryClient = useQueryClient()
+  const { currentSucursalId } = useSucursal()
   return useMutation({
     mutationFn: ({ perfilId, zonaIds }: { perfilId: string; zonaIds: string[] }) =>
       asignarZonasPreventista(perfilId, zonaIds),
     onSuccess: (_data, variables) => {
-      queryClient.invalidateQueries({ queryKey: zonasKeys.preventista(variables.perfilId) })
+      queryClient.invalidateQueries({ queryKey: zonasKeys.preventista(currentSucursalId, variables.perfilId) })
     },
   })
 }

--- a/src/hooks/supabase/base.ts
+++ b/src/hooks/supabase/base.ts
@@ -3,7 +3,7 @@
  * Proporciona cliente Supabase y sistema de notificación de errores
  * @module hooks/supabase/base
  */
-import { supabase } from '../../lib/supabase'
+import { supabase, setSucursalHeader, getSucursalHeader } from '../../lib/supabase'
 
 /**
  * Function type for error notification
@@ -56,4 +56,4 @@ export const notifyError = (message: string): void => {
  * Cliente de Supabase pre-configurado
  * @see {@link https://supabase.com/docs/reference/javascript}
  */
-export { supabase }
+export { supabase, setSucursalHeader, getSucursalHeader }

--- a/src/hooks/useOfflineQueue.ts
+++ b/src/hooks/useOfflineQueue.ts
@@ -22,7 +22,8 @@ import {
   type OperationType,
   type PendingOperation
 } from '../lib/offlineDb'
-import { supabase } from './supabase/base'
+import { supabase, setSucursalHeader, getSucursalHeader } from './supabase/base'
+import { useSucursal } from '../contexts/SucursalContext'
 import { logger } from '../utils/logger'
 
 // =============================================================================
@@ -43,7 +44,10 @@ export interface SyncState {
 export interface UseOfflineQueueReturn {
   /** Estado actual de sincronización */
   syncState: SyncState
-  /** Agregar operación a la cola */
+  /**
+   * Agregar operación a la cola.
+   * Captura automáticamente la sucursal activa para preservar el tenant al replay.
+   */
   enqueue: (type: OperationType, payload: Record<string, unknown>) => Promise<number | null>
   /** Forzar sincronización */
   syncNow: () => Promise<void>
@@ -122,6 +126,11 @@ export function useOfflineQueue(): UseOfflineQueueReturn {
     lastError: null
   })
 
+  // Multi-tenant: track active sucursal for tagging queued ops and restoring header after replay.
+  const { currentSucursalId } = useSucursal()
+  const currentSucursalIdRef = useRef<number | null>(currentSucursalId)
+  currentSucursalIdRef.current = currentSucursalId
+
   const isSyncing = useRef(false)
   const syncTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
@@ -151,8 +160,19 @@ export function useOfflineQueue(): UseOfflineQueueReturn {
       return false
     }
 
+    // Multi-tenant (C7): refuse to replay ops without a sucursalId — otherwise the
+    // op would execute against whatever tenant happens to be active now, silently
+    // corrupting data across sucursales.
+    if (operation.sucursalId == null) {
+      await markAsFailed(operation.id!, 'Operación pre-migración sin sucursal asignada; descartada para evitar corrupción cross-tenant')
+      logger.warn(`[OfflineQueue] Operación ${operation.type} id=${operation.id} sin sucursalId, marcada como failed`)
+      return false
+    }
+
     try {
       await markAsProcessing(operation.id!)
+      // Set the header so current_sucursal_id() on the server returns the op's tenant.
+      setSucursalHeader(operation.sucursalId)
       await processor(operation.payload)
       await markAsCompleted(operation.id!)
       logger.info(`[OfflineQueue] Operación completada: ${operation.type}`)
@@ -175,6 +195,9 @@ export function useOfflineQueue(): UseOfflineQueueReturn {
 
     isSyncing.current = true
     setSyncState(prev => ({ ...prev, status: 'syncing' }))
+
+    // Snapshot the X-Sucursal-ID header so we can restore it after per-op overrides.
+    const headerBeforeSync = getSucursalHeader()
 
     try {
       let hasErrors = false
@@ -216,6 +239,9 @@ export function useOfflineQueue(): UseOfflineQueueReturn {
         lastError: errorMessage
       }))
     } finally {
+      // Restore header — prefer the latest active sucursal so a mid-sync switch wins.
+      const latestActive = currentSucursalIdRef.current
+      setSucursalHeader(latestActive ?? headerBeforeSync)
       isSyncing.current = false
     }
   }, [processOperation, updateCounts])
@@ -231,7 +257,14 @@ export function useOfflineQueue(): UseOfflineQueueReturn {
       // Obtener usuario actual
       const { data: { user } } = await supabase.auth.getUser()
 
-      const id = await queueOperation(type, payload, user?.id)
+      // Multi-tenant (C7): tag the op with the active sucursal so replay is safe.
+      const id = await queueOperation(
+        type,
+        payload,
+        user?.id,
+        undefined,
+        currentSucursalIdRef.current ?? undefined
+      )
 
       if (id !== null) {
         await updateCounts()

--- a/src/hooks/useOfflineSync.ts
+++ b/src/hooks/useOfflineSync.ts
@@ -10,6 +10,8 @@ import {
 } from '../lib/offlineDb'
 import { logger } from '../utils/logger'
 import type { MermaFormInput, ProductoDB } from '../types'
+import { useSucursal } from '../contexts/SucursalContext'
+import { setSucursalHeader, getSucursalHeader } from '../lib/supabase'
 
 // ============================================================================
 // TYPES
@@ -182,6 +184,12 @@ export function useOfflineSync(): UseOfflineSyncReturn {
   const [mermasPendientes, setMermasPendientes] = useState<MermaOffline[]>([])
   const [sincronizando, setSincronizando] = useState<boolean>(false)
 
+  // Multi-tenant: track the active sucursal so we can tag queued operations
+  // and reset the X-Sucursal-ID header after per-op replay.
+  const { currentSucursalId } = useSucursal()
+  const currentSucursalIdRef = useRef<number | null>(currentSucursalId)
+  currentSucursalIdRef.current = currentSucursalId
+
   // Ref para evitar race conditions en sincronización
   const sincronizandoRef = useRef<boolean>(false)
 
@@ -326,12 +334,20 @@ export function useOfflineSync(): UseOfflineSyncReturn {
     }
 
     // Encolar en IndexedDB - await to ensure persistence before reporting success (BUG-11 fix)
+    // Multi-tenant: persist the sucursal that originated the pedido so the replay
+    // after reconnection can re-set X-Sucursal-ID to the same tenant (avoids C7).
     try {
-      const opId = await queueOperation('CREATE_PEDIDO' as OperationType, {
-        ...pedidoData,
-        tempOfflineId,
-        timestamp: Date.now()
-      }, pedidoData.usuarioId)
+      const opId = await queueOperation(
+        'CREATE_PEDIDO' as OperationType,
+        {
+          ...pedidoData,
+          tempOfflineId,
+          timestamp: Date.now()
+        },
+        pedidoData.usuarioId,
+        undefined,
+        currentSucursalIdRef.current ?? undefined
+      )
 
       if (opId !== null) {
         logger.info(`[useOfflineSync] Pedido encolado con ID: ${opId}`)
@@ -366,11 +382,18 @@ export function useOfflineSync(): UseOfflineSyncReturn {
     }
 
     // Encolar en IndexedDB (async, no bloqueante)
-    queueOperation('CREATE_MERMA' as OperationType, {
-      ...mermaData,
-      tempOfflineId,
-      timestamp: Date.now()
-    })
+    // Multi-tenant: persist sucursal so replay can set the right header (C7).
+    queueOperation(
+      'CREATE_MERMA' as OperationType,
+      {
+        ...mermaData,
+        tempOfflineId,
+        timestamp: Date.now()
+      },
+      undefined,
+      undefined,
+      currentSucursalIdRef.current ?? undefined
+    )
       .then((opId) => {
         if (opId !== null) {
           logger.info(`[useOfflineSync] Merma encolada con ID: ${opId}`)
@@ -498,10 +521,29 @@ export function useOfflineSync(): UseOfflineSyncReturn {
     const conflictos: StockConflict[] = []
     let sincronizados = 0
 
+    // Snapshot the header BEFORE the replay loop so we can restore it even if
+    // the active sucursal changes mid-sync (e.g. user switches tabs). Each op
+    // temporarily sets the header to its own sucursalId.
+    const headerBeforeSync = getSucursalHeader()
+
     try {
       for (const op of pedidoOps) {
         const payload = op.payload as Record<string, unknown>
         const pedido = operationToPedidoOffline(op)
+
+        // Multi-tenant (C7): refuse to replay ops queued without a sucursalId.
+        // These are either pre-migration entries or corrupt writes — replaying
+        // them would mint rows in whatever tenant happens to be active now.
+        if (op.sucursalId == null) {
+          await markAsFailed(op.id!, 'Operación pre-migración sin sucursal asignada; descartada para evitar corrupción cross-tenant')
+          logger.warn(`[useOfflineSync] Pedido ${pedido.offlineId} sin sucursalId, marcado como failed`)
+          errores.push({ pedido, error: 'Operación sin sucursal asignada' })
+          continue
+        }
+
+        // Set the header to the sucursal that originated this op. RPCs rely on
+        // current_sucursal_id() which (migration 061) reads X-Sucursal-ID.
+        setSucursalHeader(op.sucursalId)
 
         // Validar stock si tenemos productos actuales
         if (productosActuales && productosActuales.length > 0) {
@@ -538,6 +580,10 @@ export function useOfflineSync(): UseOfflineSyncReturn {
         }
       }
     } finally {
+      // Always restore the header to whatever was active before replay. If the
+      // user switched sucursal mid-sync, prefer the latest active value.
+      const latestActive = currentSucursalIdRef.current
+      setSucursalHeader(latestActive ?? headerBeforeSync)
       sincronizandoRef.current = false
       setSincronizando(false)
       // Recargar lista de pendientes
@@ -582,10 +628,23 @@ export function useOfflineSync(): UseOfflineSyncReturn {
     const errores: SyncResult['errores'] = []
     let sincronizados = 0
 
+    // Snapshot header to restore after the loop (same pattern as sincronizarPedidos).
+    const headerBeforeSync = getSucursalHeader()
+
     try {
       for (const op of mermaOps) {
         const merma = operationToMermaOffline(op)
         const payload = op.payload as unknown as MermaFormInput
+
+        // Multi-tenant (C7): reject ops without sucursalId to prevent cross-tenant writes.
+        if (op.sucursalId == null) {
+          await markAsFailed(op.id!, 'Operación pre-migración sin sucursal asignada; descartada para evitar corrupción cross-tenant')
+          logger.warn(`[useOfflineSync] Merma ${merma.offlineId} sin sucursalId, marcada como failed`)
+          errores.push({ merma, error: 'Operación sin sucursal asignada' })
+          continue
+        }
+
+        setSucursalHeader(op.sucursalId)
 
         try {
           await registrarMermaFn(payload)
@@ -598,6 +657,8 @@ export function useOfflineSync(): UseOfflineSyncReturn {
         }
       }
     } finally {
+      const latestActive = currentSucursalIdRef.current
+      setSucursalHeader(latestActive ?? headerBeforeSync)
       sincronizandoRef.current = false
       setSincronizando(false)
       // Recargar lista de pendientes

--- a/src/hooks/useRealtimeInvalidation.ts
+++ b/src/hooks/useRealtimeInvalidation.ts
@@ -10,8 +10,6 @@
 import { useRef, useCallback, useEffect } from 'react'
 import { useQueryClient } from '@tanstack/react-query'
 import { useRealtimeSubscription } from './useRealtimeSubscription'
-import { pedidosKeys } from './queries/usePedidosQuery'
-import { productosKeys } from './queries/useProductosQuery'
 
 interface UseRealtimeInvalidationOptions {
   /** Si está habilitado (desactivar cuando offline) */
@@ -33,7 +31,7 @@ export function useRealtimeInvalidation({
       clearTimeout(pedidosTimerRef.current)
     }
     pedidosTimerRef.current = setTimeout(() => {
-      queryClient.invalidateQueries({ queryKey: pedidosKeys.all })
+      queryClient.invalidateQueries({ queryKey: ['pedidos'] })
     }, debounceMs)
   }, [queryClient, debounceMs])
 
@@ -42,7 +40,7 @@ export function useRealtimeInvalidation({
       clearTimeout(productosTimerRef.current)
     }
     productosTimerRef.current = setTimeout(() => {
-      queryClient.invalidateQueries({ queryKey: productosKeys.all })
+      queryClient.invalidateQueries({ queryKey: ['productos'] })
     }, debounceMs)
   }, [queryClient, debounceMs])
 

--- a/src/lib/offlineDb.ts
+++ b/src/lib/offlineDb.ts
@@ -52,6 +52,7 @@ export interface PendingOperation {
   createdAt: Date
   updatedAt: Date
   userId?: string
+  sucursalId?: number // Multi-tenant: sucursal que originó la operación
 }
 
 /**
@@ -147,6 +148,14 @@ function generateOperationHash(type: OperationType, payload: Record<string, unkn
 }
 
 /**
+ * Genera una clave de cache con namespace de sucursal.
+ * Permite aislar el cache por sucursal en modo offline.
+ */
+export function scopedCacheKey(key: string, sucursalId?: number | null): string {
+  return sucursalId != null ? `s${sucursalId}:${key}` : key
+}
+
+/**
  * Agregar operación a la cola
  * Retorna el ID de la operación o null si ya existe (duplicado)
  */
@@ -154,7 +163,8 @@ export async function queueOperation(
   type: OperationType,
   payload: Record<string, unknown>,
   userId?: string,
-  maxRetries = 5
+  maxRetries = 5,
+  sucursalId?: number
 ): Promise<number | null> {
   const hash = generateOperationHash(type, payload)
 
@@ -180,7 +190,8 @@ export async function queueOperation(
     hash,
     createdAt: now,
     updatedAt: now,
-    userId
+    userId,
+    sucursalId
   })
 
   // Registrar evento
@@ -304,15 +315,17 @@ export async function cleanupOldOperations(daysOld = 7): Promise<number> {
 export async function cacheData(
   key: string,
   data: unknown,
-  expiresInMinutes?: number
+  expiresInMinutes?: number,
+  sucursalId?: number | null
 ): Promise<void> {
+  const effectiveKey = scopedCacheKey(key, sucursalId)
   const now = new Date()
   const expiresAt = expiresInMinutes
     ? new Date(now.getTime() + expiresInMinutes * 60 * 1000)
     : undefined
 
   // Buscar si ya existe
-  const existing = await db.offlineCache.where('key').equals(key).first()
+  const existing = await db.offlineCache.where('key').equals(effectiveKey).first()
 
   if (existing) {
     await db.offlineCache.update(existing.id!, {
@@ -323,7 +336,7 @@ export async function cacheData(
     })
   } else {
     await db.offlineCache.add({
-      key,
+      key: effectiveKey,
       data,
       version: 1,
       updatedAt: now,
@@ -335,8 +348,9 @@ export async function cacheData(
 /**
  * Obtener datos del cache
  */
-export async function getCachedData<T>(key: string): Promise<T | null> {
-  const cached = await db.offlineCache.where('key').equals(key).first()
+export async function getCachedData<T>(key: string, sucursalId?: number | null): Promise<T | null> {
+  const effectiveKey = scopedCacheKey(key, sucursalId)
+  const cached = await db.offlineCache.where('key').equals(effectiveKey).first()
 
   if (!cached) return null
 
@@ -352,8 +366,9 @@ export async function getCachedData<T>(key: string): Promise<T | null> {
 /**
  * Invalidar cache
  */
-export async function invalidateCache(key: string): Promise<void> {
-  await db.offlineCache.where('key').equals(key).delete()
+export async function invalidateCache(key: string, sucursalId?: number | null): Promise<void> {
+  const effectiveKey = scopedCacheKey(key, sucursalId)
+  await db.offlineCache.where('key').equals(effectiveKey).delete()
 }
 
 /**

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -3,11 +3,47 @@ import { createClient } from '@supabase/supabase-js'
 const supabaseUrl = import.meta.env.VITE_SUPABASE_URL
 const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY
 
+/**
+ * Module-level sucursal id used by the fetch wrapper below to inject the
+ * X-Sucursal-ID header on every PostgREST request. This header is the
+ * session-scoped tenant resolver consumed by current_sucursal_id() in
+ * migration 061. Keeping the value at module scope (instead of mutating
+ * supabase.rest.headers) means each browser tab has its own independent
+ * value -- which is exactly the H10 fix.
+ */
+let currentSucursalId: number | null = null
+
+/**
+ * Set or clear the X-Sucursal-ID header that is attached to every
+ * subsequent Supabase REST request from this tab. Pass null to clear it
+ * (e.g. on sign-out or when the user has no sucursales assigned).
+ */
+export function setSucursalHeader(sucursalId: number | null): void {
+  currentSucursalId = sucursalId
+}
+
+/**
+ * Expose the current sucursal id that the fetch wrapper would attach.
+ * Used by offline replay to restore the header after per-op overrides.
+ */
+export function getSucursalHeader(): number | null {
+  return currentSucursalId
+}
+
 export const supabase = createClient(supabaseUrl, supabaseAnonKey, {
   auth: {
     storageKey: 'distribuidora_v2',
     persistSession: true,
     autoRefreshToken: true,
     detectSessionInUrl: true,
-  }
+  },
+  global: {
+    fetch: (input, init) => {
+      const headers = new Headers(init?.headers)
+      if (currentSucursalId != null) {
+        headers.set('X-Sucursal-ID', String(currentSucursalId))
+      }
+      return fetch(input, { ...init, headers })
+    },
+  },
 })

--- a/src/types/hooks.ts
+++ b/src/types/hooks.ts
@@ -883,7 +883,8 @@ export interface SucursalDB {
 }
 
 export interface UsuarioSucursalDB {
-  id: string;
+  // BIGSERIAL in DB — PostgREST returns this as a JS number, not string. (H12)
+  id: number;
   usuario_id: string;
   sucursal_id: number;
   rol: string; // 'mismo' | RolUsuario — 'mismo' means use global role

--- a/src/types/hooks.ts
+++ b/src/types/hooks.ts
@@ -882,6 +882,16 @@ export interface SucursalDB {
   created_at?: string;
 }
 
+export interface UsuarioSucursalDB {
+  id: string;
+  usuario_id: string;
+  sucursal_id: number;
+  rol: string; // 'mismo' | RolUsuario — 'mismo' means use global role
+  es_default: boolean;
+  created_at?: string;
+  sucursal?: SucursalDB | null;
+}
+
 export interface TransferenciaItemDB {
   id: string;
   transferencia_id: string;


### PR DESCRIPTION
## Summary

Fixes the 17 bugs (7 críticos, 7 altos, 5 medios) found in the audit of the multi-tenant migration branch. Without these, the branch would break prod on apply (triggers refer to missing columns, legacy RPC overload bypasses `sucursal_id`, new signups are broken, offline queue corrupts tenant data on replay).

Architecture approach: incremental migrations (060/061/062/063) on top of 057/058/059, plus session-scoped tenant resolver via `X-Sucursal-ID` header to eliminate the multi-tab race where switching sucursal in one tab moved the active tenant globally.

## What's in the branch

**SQL migrations (applied to ManaosApp prod today):**
- `060_multi_tenant_fixups` - renames sucursal id=1 → `ManaosApp` / id=2 → `TP Export`, adds `stock_historico.usuario_id`, drops BOTH legacy 13-param `registrar_compra_completa` overloads (text + varchar), adds role check to `registrar_nota_credito`, removes silent `sucursal_id=1` fallback from `audit_log_changes`, drops every non-mt_* policy on multi-tenant tables
- `061_session_scoped_tenant` - rewrites `current_sucursal_id()` to read the `X-Sucursal-ID` request header first, with `es_default` fallback for triggers/Edge Functions
- `063_usuario_sucursales_admin_rpcs` - `asignar_usuario_sucursal` / `desasignar_usuario_sucursal` for admin provisioning (no UI yet — admins call via SQL Editor)
- `062_import_tp_export` - FDW import of TP Export data (manual run post-merge, separate maintenance window)

**Frontend:**
- `setSucursalHeader()` helper in `src/lib/supabase.ts`, called from `SucursalContext` on load / switch / cleanup
- Phantom sucursal-1 fallback removed; zero-sucursales users now see a blocking `SinSucursalScreen`
- Typo `hasMutipleSucursales` → `hasMultipleSucursales`
- `useOfflineSync` / `useOfflineQueue` now tag each queued op with `sucursalId` and set the header per replay; legacy ops without `sucursalId` are marked failed instead of replayed cross-tenant
- `useUsuariosQuery` keys scoped by sucursal
- `fetchSucursales` in transferencias filters `.eq('tipo', 'distribuidora')` — the dropdown no longer lists `ManaosApp` / `TP Export` tenant rows
- `UsuarioSucursalDB.id` typed as `number` (BIGSERIAL)

## Verification done

**SQL (on prod ManaosApp):**
- Sucursales renamed: `id=1 ManaosApp/principal`, `id=2 TP Export/secundaria`
- `stock_historico.usuario_id` exists
- `registrar_compra_completa` has exactly 2 overloads (12-arg + 13-arg), both with `sucursal_id`
- 0 non-mt_* policies remain on 34 multi-tenant tables
- 9 usuarios, cada uno con 1 `es_default=true` → fallback works for every current user
- Security advisors: no new errors introduced by 060/061/063. Pre-existing WARNs (`audit_logs_detallado` view, `function_search_path_mutable` triggers) unchanged.
- Performance advisors: 10 new WARNs on `sucursales`/`usuario_sucursales` (`auth_rls_initplan`, `multiple_permissive_policies`) — acceptable per plan (M15/M16), cosmetic.

**Frontend (local):**
- `npm run typecheck` — clean
- `npm run test:run` — 522/522 tests, 27/27 suites
- `npm run lint` — clean
- `npm run build` — builds in ~20s, no errors

## Test plan

- [ ] Pull branch, `npm install`, `npm run dev`
- [ ] Login as existing user (ManaosApp) → SucursalSelector shows single-sucursal badge
- [ ] Crear pedido → verify `sucursal_id = 1` in DB
- [ ] Crear compra → verify no error (antes fallaba por NOT NULL)
- [ ] Signup new user without assignment → sees `SinSucursalScreen`
- [ ] Admin asigna sucursal 2 al nuevo usuario via `asignar_usuario_sucursal` → aparece dropdown
- [ ] Abrir segunda pestaña en sucursal 1, switchear sucursal 2 en la primera → pestaña 2 permanece en sucursal 1 (confirma H10 fix)
- [ ] DevTools offline, crear pedido en sucursal 1, switchear a 2 (offline), crear otro, reconectar → primer pedido `sucursal_id=1`, segundo `sucursal_id=2` (confirma C7 fix)
- [ ] ModalTransferencia: dropdown "Sucursal destino" no muestra `ManaosApp` / `TP Export`
- [ ] 062 (TP Export import) queda para ventana de mantenimiento separada post-merge

## Migraciones ya aplicadas en prod

057/058/059 ya estaban aplicadas previamente. Hoy se aplicaron 060 + 061 + 063 via MCP (aparecen en `supabase migration list`). 062 queda para correr manualmente.

🤖 Generated with [Claude Code](https://claude.com/claude-code)