### PR TITLE
fix(multi-tenant): record TP Export import hotfixes (migrations 064 + 065 + 062 rewrite)

### DIFF
--- a/migrations/062_import_tp_export.sql
+++ b/migrations/062_import_tp_export.sql
@@ -4,250 +4,321 @@
 --  DO NOT RUN THIS AS PART OF THE NORMAL MIGRATION CHAIN.
 -- =====================================================================
 --
--- This script is intentionally NOT idempotent and is intended to be run
--- ONCE, manually, in a maintenance window, AFTER:
---   1. Migrations 057 → 058 → 059 → 060 → 061 → 063 are applied.
---   2. All target users (the 7 TP Export perfiles) already exist in
---      ManaosApp's auth.users (same email — Supabase will assign a new UUID).
---   3. You have postgres_fdw-level credentials to read from the TP Export
---      Supabase project.
+-- This file is a REPRODUCIBILITY RECORD of the one-shot TP Export →
+-- ManaosApp data import executed in April 2026. It was NOT run as a
+-- single transaction: the real import used MCP cross-project SQL calls
+-- (mcp__supabase-distapp-tp__sql_query to read TP, mcp__261fd064-...__
+-- execute_sql to write ManaosApp) interleaved in a live session.
 --
--- Expected volumes (Q1 2026 snapshot, per audit):
---   perfiles:       7
---   productos:     65
---   clientes:      86
---   pedidos:      142
---   pedido_items: 534
+-- The original plan assumed postgres_fdw; that was scrapped because
+-- neither project exposes the fdw extension with cross-project network
+-- access under Supabase's managed environment. The live import used the
+-- MCP pattern below, which is:
 --
--- Strategy: map TP Export auth.uid values → ManaosApp auth.uid by JOINing
--- on email, then rewrite every user_id / usuario_id reference during
--- INSERT. All imported rows get sucursal_id = 2.
+--   1. Pull a page of rows from TP via MCP as JSONB arrays-of-arrays.
+--   2. Send the payload as an inline CTE into ManaosApp, unpacking with
+--      jsonb_array_elements + (r->>N)::type indexed access.
+--   3. Remap UUIDs (auth users) and FKs (producto_id, cliente_id,
+--      pedido_id) by joining on stable business keys (email, codigo,
+--      cuit, tp_import_id).
 --
--- See scripts/export-tp-export-dump.md for the full runbook.
-
--- =====================================================================
--- STEP 0. Prerequisites
--- =====================================================================
-CREATE EXTENSION IF NOT EXISTS postgres_fdw;
-
--- IMPORTANT: fill in the real connection details before running.
--- Use a read-only role on the source project.
+-- The DDL (tp_import_id columns) and the uuid_remap CTE are static and
+-- reproducible. The per-table data payloads are NOT inlined here — a
+-- fresh import would re-query TP live. See scripts/export-tp-export-dump.md
+-- for the operator runbook that regenerates the payloads from the source.
 --
--- CREATE SERVER tp_remote
---   FOREIGN DATA WRAPPER postgres_fdw
---   OPTIONS (host '<tp-project-db-host>', dbname 'postgres', port '5432', sslmode 'require');
+-- Prereqs (same as the original plan):
+--   1. Migrations 057 → 064 applied to ManaosApp.
+--   2. The 7 TP Export perfile emails exist in ManaosApp auth.users
+--      (Supabase assigns a new UUID per instance; we remap by email).
+--   3. Operator has read access to the TP Export project.
 --
--- CREATE USER MAPPING FOR postgres
---   SERVER tp_remote
---   OPTIONS (user 'postgres', password '<tp-project-password>');
+-- Actual volumes landed (verified post-import):
+--   usuario_sucursales (sucursal 2):   6  (7 TP users, 2 share 1 email)
+--   productos:                        69
+--   clientes:                         89
+--   pedidos:                         165
+--   pedido_items:                    628
+
+-- =====================================================================
+-- STEP 1. Add tp_import_id tracking columns for FK remap + dedup
+-- =====================================================================
+-- tp_import_id stores the original TP primary key so we can:
+--   (a) skip rows that already came over (WHERE NOT EXISTS on this col),
+--   (b) resolve FKs from TP → ManaosApp ids after a prior chunk landed.
 --
--- CREATE SCHEMA IF NOT EXISTS tp_remote_schema;
+-- These columns are additive and safe to leave in place permanently —
+-- NULL for every non-imported row.
+
+ALTER TABLE public.productos     ADD COLUMN IF NOT EXISTS tp_import_id BIGINT;
+ALTER TABLE public.clientes      ADD COLUMN IF NOT EXISTS tp_import_id BIGINT;
+ALTER TABLE public.pedidos       ADD COLUMN IF NOT EXISTS tp_import_id BIGINT;
+
+CREATE INDEX IF NOT EXISTS idx_productos_tp_import_id ON public.productos (tp_import_id) WHERE tp_import_id IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_clientes_tp_import_id  ON public.clientes  (tp_import_id) WHERE tp_import_id IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_pedidos_tp_import_id   ON public.pedidos   (tp_import_id) WHERE tp_import_id IS NOT NULL;
+
+-- =====================================================================
+-- STEP 2. UUID remap (TP auth.uid → ManaosApp auth.uid, by email)
+-- =====================================================================
+-- TP has 7 perfiles. Two of them share a single email with one
+-- ManaosApp account (consolidation was intentional), so the CTE has
+-- 7 source rows mapping to 6 distinct local uuids.
 --
--- IMPORT FOREIGN SCHEMA public
---   LIMIT TO (perfiles, clientes, productos, pedidos, pedido_items)
---   FROM SERVER tp_remote INTO tp_remote_schema;
-
--- Sanity check — the foreign schema must be importable.
-DO $$
-BEGIN
-  IF NOT EXISTS (
-    SELECT 1 FROM information_schema.schemata WHERE schema_name = 'tp_remote_schema'
-  ) THEN
-    RAISE EXCEPTION 'tp_remote_schema not found — run IMPORT FOREIGN SCHEMA first (see header)';
-  END IF;
-END $$;
-
--- =====================================================================
--- STEP 1. UUID remap (auth.users: TP → ManaosApp by email)
--- =====================================================================
--- Uses auth.users from BOTH instances; source UUIDs are stored on foreign
--- rows (perfiles.id mirrors auth.users.id in Supabase).
-CREATE TEMP TABLE uuid_remap ON COMMIT PRESERVE ROWS AS
-SELECT
-  tp.id     AS tp_uuid,
-  local.id  AS local_uuid,
-  local.email
-FROM tp_remote_schema.perfiles AS tp
-JOIN public.perfiles           AS local ON local.email = tp.email;
-
--- Fail loud if any TP user has no matching local account — importing rows
--- whose owner is NULL would strand them outside RLS.
-DO $$
-DECLARE v_missing INT;
-BEGIN
-  SELECT COUNT(*) INTO v_missing
-    FROM tp_remote_schema.perfiles tp
-   WHERE NOT EXISTS (SELECT 1 FROM public.perfiles p WHERE p.email = tp.email);
-  IF v_missing > 0 THEN
-    RAISE EXCEPTION 'TP Export has % perfiles without a matching local account — create those auth.users first and re-run', v_missing;
-  END IF;
-END $$;
-
--- =====================================================================
--- STEP 2. usuario_sucursales — grant TP users access to sucursal 2
--- =====================================================================
--- Role stays 'mismo' so they inherit their perfiles.rol; es_default=false
--- (admin can flip it later via asignar_usuario_sucursal from migration 063).
-INSERT INTO public.usuario_sucursales (usuario_id, sucursal_id, rol, es_default)
-SELECT rm.local_uuid, 2, 'mismo', false
-  FROM uuid_remap rm
-ON CONFLICT (usuario_id, sucursal_id) DO NOTHING;
-
--- =====================================================================
--- STEP 3. Productos
--- =====================================================================
--- Match by codigo (the product SKU). Rows with a codigo that already
--- exists in sucursal 2 are assumed to have been imported previously.
+-- The operator generates these pairs by running in TP:
+--   SELECT id, email FROM public.perfiles;
+-- and in ManaosApp:
+--   SELECT id, email FROM public.perfiles WHERE email IN (<tp emails>);
+-- then hand-assembles the VALUES list below. Do NOT derive this from a
+-- JOIN at import time: if a TP email does not exist locally, we want to
+-- FAIL LOUD (no orphan rows), not silently drop.
 --
--- TODO(operator): after running `SELECT column_name FROM
--- information_schema.columns WHERE table_name='productos'` on BOTH
--- projects, expand this SELECT to the actual column list that matches
--- between source and target. Keep it explicit — `SELECT *` across
--- postgres_fdw is a footgun because column order drift corrupts data.
-INSERT INTO public.productos (
-  nombre, codigo, stock, costo_sin_iva, costo_con_iva, precio_venta,
-  activo, sucursal_id
-  -- TODO: add remaining columns in schema order
-)
-SELECT
-  src.nombre,
-  src.codigo,
-  src.stock,
-  src.costo_sin_iva,
-  src.costo_con_iva,
-  src.precio_venta,
-  COALESCE(src.activo, true),
-  2
-FROM tp_remote_schema.productos AS src
-WHERE NOT EXISTS (
-  SELECT 1 FROM public.productos p
-   WHERE p.codigo = src.codigo AND p.sucursal_id = 2
-);
+-- Replace the placeholder UUIDs with the real pairs before re-running.
 
--- Stash id remap so pedido_items can resolve new product IDs.
-CREATE TEMP TABLE producto_remap ON COMMIT PRESERVE ROWS AS
-SELECT src.id AS tp_id, local.id AS local_id
-FROM tp_remote_schema.productos src
-JOIN public.productos local
-  ON local.codigo = src.codigo
- AND local.sucursal_id = 2;
+-- CREATE TEMP TABLE uuid_remap (tp_uuid UUID PRIMARY KEY, local_uuid UUID NOT NULL);
+-- INSERT INTO uuid_remap (tp_uuid, local_uuid) VALUES
+--   ('<tp-uuid-1>', '<local-uuid-1>'),
+--   ('<tp-uuid-2>', '<local-uuid-2>'),
+--   -- ... one row per TP perfile ...
+--   ('<tp-uuid-7>', '<local-uuid-7>');
+
+-- Assertion: every TP user has a local target. Fail before writing any data.
+-- DO $$
+-- DECLARE v_missing INT;
+-- BEGIN
+--   SELECT COUNT(*) INTO v_missing FROM uuid_remap WHERE local_uuid IS NULL;
+--   IF v_missing > 0 THEN
+--     RAISE EXCEPTION 'uuid_remap has % TP users without a local account', v_missing;
+--   END IF;
+-- END $$;
 
 -- =====================================================================
--- STEP 4. Clientes
+-- STEP 3. Grant TP users access to sucursal 2
 -- =====================================================================
--- TODO(operator): expand column list (see productos TODO above). cuit
--- is assumed unique within the tenant; adjust if collisions occur.
-INSERT INTO public.clientes (
-  razon_social, nombre_fantasia, direccion, telefono, cuit, zona,
-  sucursal_id, usuario_id
-  -- TODO: remaining columns
-)
-SELECT
-  src.razon_social,
-  src.nombre_fantasia,
-  src.direccion,
-  src.telefono,
-  src.cuit,
-  src.zona,
-  2,
-  rm.local_uuid
-FROM tp_remote_schema.clientes AS src
-LEFT JOIN uuid_remap rm ON rm.tp_uuid = src.usuario_id
-WHERE NOT EXISTS (
-  SELECT 1 FROM public.clientes c
-   WHERE c.cuit = src.cuit AND c.sucursal_id = 2
-);
+-- rol='mismo' inherits from perfiles.rol; es_default=false (admin can
+-- flip later via asignar_usuario_sucursal from migration 063).
+-- ON CONFLICT DO NOTHING makes this safe to re-run.
 
-CREATE TEMP TABLE cliente_remap ON COMMIT PRESERVE ROWS AS
-SELECT src.id AS tp_id, local.id AS local_id
-FROM tp_remote_schema.clientes src
-JOIN public.clientes local
-  ON local.cuit = src.cuit
- AND local.sucursal_id = 2;
+-- INSERT INTO public.usuario_sucursales (usuario_id, sucursal_id, rol, es_default)
+-- SELECT DISTINCT rm.local_uuid, 2, 'mismo', false
+--   FROM uuid_remap rm
+-- ON CONFLICT (usuario_id, sucursal_id) DO NOTHING;
 
 -- =====================================================================
--- STEP 5. Pedidos
+-- STEP 4. Productos (69 rows)
 -- =====================================================================
--- Pedidos carry cliente_id (FK) and usuario_id (auth.uid). Both must be
--- remapped. `numero_pedido` is kept as-is so operators can cross-reference
--- the old system by ticket number; if ManaosApp generates its own sequence,
--- remove it and let the INSERT default pick a new one.
+-- TP payload pulled via:
+--   SELECT jsonb_agg(jsonb_build_array(
+--     id, codigo, nombre, COALESCE(stock, 0),
+--     COALESCE(costo_sin_iva, 0), COALESCE(costo_con_iva, 0),
+--     COALESCE(precio_venta_sin_iva, 0), COALESCE(precio_venta_con_iva, 0)
+--   )) FROM public.productos ORDER BY id;
 --
--- TODO(operator): expand column list. The fields below are the minimum
--- known to exist from migrations 001/008; verify with information_schema.
-INSERT INTO public.pedidos (
-  cliente_id, usuario_id, numero_pedido, fecha, estado, total,
-  sucursal_id
-  -- TODO: remaining columns (notas, forma_pago, etc.)
-)
-SELECT
-  cr.local_id,
-  rm.local_uuid,
-  src.numero_pedido,
-  src.fecha,
-  src.estado,
-  src.total,
-  2
-FROM tp_remote_schema.pedidos AS src
-JOIN cliente_remap cr ON cr.tp_id = src.cliente_id
-LEFT JOIN uuid_remap rm ON rm.tp_uuid = src.usuario_id
-WHERE NOT EXISTS (
-  -- Skip already-imported pedidos. If `numero_pedido` is not unique across
-  -- tenants, replace with a dedicated tp_import_marker column.
-  SELECT 1 FROM public.pedidos p
-   WHERE p.numero_pedido = src.numero_pedido AND p.sucursal_id = 2
-);
+-- The JSON array-of-arrays was then fed into ManaosApp as an inline CTE.
+-- Template below — replace :tp_productos_json with the real JSONB from TP.
 
-CREATE TEMP TABLE pedido_remap ON COMMIT PRESERVE ROWS AS
-SELECT src.id AS tp_id, local.id AS local_id
-FROM tp_remote_schema.pedidos src
-JOIN public.pedidos local
-  ON local.numero_pedido = src.numero_pedido
- AND local.sucursal_id = 2;
+-- WITH tp AS (
+--   SELECT r FROM jsonb_array_elements(:tp_productos_json::jsonb) AS r
+-- )
+-- INSERT INTO public.productos (
+--   tp_import_id, codigo, nombre, stock,
+--   costo_sin_iva, costo_con_iva,
+--   precio_venta_sin_iva, precio_venta_con_iva,
+--   activo, sucursal_id
+-- )
+-- SELECT
+--   (r->>0)::BIGINT,
+--   (r->>1)::TEXT,
+--   (r->>2)::TEXT,
+--   (r->>3)::INTEGER,
+--   (r->>4)::NUMERIC,
+--   (r->>5)::NUMERIC,
+--   (r->>6)::NUMERIC,
+--   (r->>7)::NUMERIC,
+--   true,
+--   2
+-- FROM tp
+-- WHERE NOT EXISTS (
+--   SELECT 1 FROM public.productos p
+--    WHERE p.tp_import_id = (r->>0)::BIGINT
+-- );
 
 -- =====================================================================
--- STEP 6. Pedido_items (534 rows)
+-- STEP 5. Clientes (89 rows)
 -- =====================================================================
--- Both pedido_id and producto_id need remapping. If a producto was not
--- imported (missing codigo on source), the row is dropped — inspect the
--- RAISE NOTICE below before the COMMIT to confirm zero orphans.
-WITH dropped AS (
-  SELECT src.id
-    FROM tp_remote_schema.pedido_items AS src
-   WHERE NOT EXISTS (
-     SELECT 1 FROM producto_remap pr WHERE pr.tp_id = src.producto_id
-   )
-     OR NOT EXISTS (
-     SELECT 1 FROM pedido_remap pe   WHERE pe.tp_id = src.pedido_id
-   )
-)
-SELECT COUNT(*) AS orphan_items FROM dropped;  -- inspect before COMMIT
+-- TP payload:
+--   SELECT jsonb_agg(jsonb_build_array(
+--     id, razon_social, nombre_fantasia, cuit, direccion,
+--     telefono, email, zona, usuario_id
+--   )) FROM public.clientes ORDER BY id;
 
-INSERT INTO public.pedido_items (
-  pedido_id, producto_id, cantidad, precio_unitario, sucursal_id
-  -- TODO: remaining columns (bonificacion, subtotal, etc.)
-)
-SELECT
-  pe.local_id,
-  pr.local_id,
-  src.cantidad,
-  src.precio_unitario,
-  2
-FROM tp_remote_schema.pedido_items AS src
-JOIN producto_remap pr ON pr.tp_id = src.producto_id
-JOIN pedido_remap   pe ON pe.tp_id = src.pedido_id;
+-- WITH tp AS (
+--   SELECT r FROM jsonb_array_elements(:tp_clientes_json::jsonb) AS r
+-- )
+-- INSERT INTO public.clientes (
+--   tp_import_id, razon_social, nombre_fantasia, cuit, direccion,
+--   telefono, email, zona, usuario_id, sucursal_id
+-- )
+-- SELECT
+--   (r->>0)::BIGINT,
+--   (r->>1)::TEXT,
+--   (r->>2)::TEXT,
+--   (r->>3)::TEXT,
+--   (r->>4)::TEXT,
+--   (r->>5)::TEXT,
+--   (r->>6)::TEXT,
+--   (r->>7)::TEXT,
+--   rm.local_uuid,
+--   2
+-- FROM tp
+-- LEFT JOIN uuid_remap rm ON rm.tp_uuid = (r->>8)::UUID
+-- WHERE NOT EXISTS (
+--   SELECT 1 FROM public.clientes c
+--    WHERE c.tp_import_id = (r->>0)::BIGINT
+-- );
 
 -- =====================================================================
--- STEP 7. Post-import verification (run BEFORE COMMIT in psql)
+-- STEP 6. Pedidos (165 rows, sent in 3 chunks of ~55 by id range)
 -- =====================================================================
--- Each SELECT should return >0 and match the expected volume from the
--- header comment, except orphan_items which should be 0.
+-- TP payload (per chunk):
+--   SELECT jsonb_agg(jsonb_build_array(
+--     id, cliente_id, usuario_id, transportista_id,
+--     fecha, estado, estado_pago, total, COALESCE(monto_pagado, 0),
+--     created_at, updated_at, motivo_cancelacion,
+--     COALESCE(total_neto, 0), fecha_entrega_programada
+--   ) ORDER BY id)
+--   FROM public.pedidos
+--   WHERE id BETWEEN :lo AND :hi;
 --
--- SELECT 'productos' AS tabla, COUNT(*) FROM public.productos WHERE sucursal_id = 2
--- UNION ALL SELECT 'clientes',  COUNT(*) FROM public.clientes  WHERE sucursal_id = 2
--- UNION ALL SELECT 'pedidos',   COUNT(*) FROM public.pedidos   WHERE sucursal_id = 2
+-- Chunks were sent separately because Supabase's statement_timeout
+-- trips on single large inserts with the historial trigger firing.
+--
+-- Constants hardcoded (verified against TP source):
+--   stock_descontado = true  — TP already decremented stock on create
+--   forma_pago       = 'efectivo'  — TP had no forma_pago column
+--   tipo_factura     = 'ZZ'  — placeholder; real value unknown per row
+--   total_iva        = 0     — TP stores totals inclusive
+--
+-- The CTE-wrapped pattern below is used instead of plain RETURNING
+-- because the MCP tool echoes every returned row — the CTE lets us
+-- return just counts + id ranges.
+
+-- WITH tp AS (
+--   SELECT r FROM jsonb_array_elements(:tp_pedidos_chunk_json::jsonb) AS r
+-- ),
+-- inserted AS (
+--   INSERT INTO public.pedidos (
+--     tp_import_id, cliente_id, usuario_id, transportista_id,
+--     fecha, estado, estado_pago, total, monto_pagado,
+--     created_at, updated_at, motivo_cancelacion,
+--     total_neto, fecha_entrega_programada,
+--     stock_descontado, forma_pago, tipo_factura, total_iva, sucursal_id
+--   )
+--   SELECT
+--     (r->>0)::BIGINT,
+--     c.id,
+--     rm_u.local_uuid,
+--     rm_t.local_uuid,
+--     (r->>4)::TIMESTAMPTZ,
+--     (r->>5)::TEXT,
+--     (r->>6)::TEXT,
+--     (r->>7)::NUMERIC,
+--     (r->>8)::NUMERIC,
+--     (r->>9)::TIMESTAMPTZ,
+--     (r->>10)::TIMESTAMPTZ,
+--     NULLIF(r->>11, ''),
+--     (r->>12)::NUMERIC,
+--     NULLIF(r->>13, '')::TIMESTAMPTZ,
+--     true,
+--     'efectivo',
+--     'ZZ',
+--     0,
+--     2
+--   FROM tp
+--   JOIN public.clientes c
+--     ON c.tp_import_id = (r->>1)::BIGINT AND c.sucursal_id = 2
+--   LEFT JOIN uuid_remap rm_u ON rm_u.tp_uuid = (r->>2)::UUID
+--   LEFT JOIN uuid_remap rm_t ON rm_t.tp_uuid = NULLIF(r->>3, '')::UUID
+--   WHERE NOT EXISTS (
+--     SELECT 1 FROM public.pedidos p WHERE p.tp_import_id = (r->>0)::BIGINT
+--   )
+--   RETURNING id, tp_import_id
+-- )
+-- SELECT COUNT(*) AS inserted_count,
+--        MIN(id) AS min_id, MAX(id) AS max_id,
+--        MIN(tp_import_id) AS min_tp, MAX(tp_import_id) AS max_tp
+--   FROM inserted;
+
+-- =====================================================================
+-- STEP 7. Pedido_items (628 rows, sent in 4 chunks by pedido_id range)
+-- =====================================================================
+-- TP payload (per chunk):
+--   SELECT jsonb_agg(jsonb_build_array(
+--     pedido_id, producto_id, cantidad, precio_unitario, subtotal,
+--     neto_unitario, porcentaje_iva
+--   ) ORDER BY id)
+--   FROM public.pedido_items
+--   WHERE pedido_id BETWEEN :lo AND :hi;
+--
+-- Constants verified against TP source (SELECT COUNT(*) FILTER (...) :
+--   es_bonificacion            = false  (0/628 rows were true)
+--   promocion_id               = NULL   (0/628 non-null)
+--   iva_unitario               = 0      (628/628 were 0)
+--   impuestos_internos_unitario = 0     (628/628 were 0)
+--
+-- neto_unitario and porcentaje_iva: bimodal data — 370 rows have
+-- NULL/0, 258 rows have a neto and porcentaje_iva=21. Passed through
+-- as-is; NOT coalesced, because downstream reports distinguish the two.
+
+-- WITH tp AS (
+--   SELECT r FROM jsonb_array_elements(:tp_pedido_items_chunk_json::jsonb) AS r
+-- )
+-- INSERT INTO public.pedido_items (
+--   pedido_id, producto_id, cantidad, precio_unitario, subtotal,
+--   es_bonificacion, promocion_id,
+--   neto_unitario, iva_unitario, impuestos_internos_unitario,
+--   porcentaje_iva, sucursal_id
+-- )
+-- SELECT
+--   p.id,
+--   pr.id,
+--   (r->>2)::NUMERIC,
+--   (r->>3)::NUMERIC,
+--   (r->>4)::NUMERIC,
+--   false,
+--   NULL,
+--   NULLIF(r->>5, '')::NUMERIC,
+--   0,
+--   0,
+--   NULLIF(r->>6, '')::NUMERIC,
+--   2
+-- FROM tp
+-- JOIN public.pedidos   p  ON p.tp_import_id  = (r->>0)::BIGINT AND p.sucursal_id  = 2
+-- JOIN public.productos pr ON pr.tp_import_id = (r->>1)::BIGINT AND pr.sucursal_id = 2;
+-- -- No WHERE NOT EXISTS guard: pedido_items is only written once per
+-- -- parent pedido, and the parent dedup upstream already prevents
+-- -- duplicate pedidos. Running STEP 7 twice against the same chunk
+-- -- WILL duplicate items — operator must track chunk completion.
+
+-- =====================================================================
+-- STEP 8. Post-import verification (RUN AFTER each chunk batch)
+-- =====================================================================
+-- Expected counts (April 2026 import):
+--
+-- SELECT 'productos'    AS tabla, COUNT(*) FROM public.productos    WHERE sucursal_id = 2
+-- UNION ALL SELECT 'clientes',     COUNT(*) FROM public.clientes     WHERE sucursal_id = 2
+-- UNION ALL SELECT 'pedidos',      COUNT(*) FROM public.pedidos      WHERE sucursal_id = 2
 -- UNION ALL SELECT 'pedido_items', COUNT(*) FROM public.pedido_items WHERE sucursal_id = 2
--- UNION ALL SELECT 'usuario_sucursales (sucursal 2)', COUNT(*) FROM public.usuario_sucursales WHERE sucursal_id = 2;
+-- UNION ALL SELECT 'usuario_sucursales', COUNT(*) FROM public.usuario_sucursales WHERE sucursal_id = 2;
 --
--- If numbers match: COMMIT;
--- If not: ROLLBACK; and investigate with the orphan_items CTE above.
+-- Expected:
+--   productos          = 69
+--   clientes           = 89
+--   pedidos            = 165
+--   pedido_items       = 628
+--   usuario_sucursales =   6
+--
+-- Cross-check tp_import_id coverage (every imported row must be tagged):
+--   SELECT COUNT(*) FROM productos WHERE sucursal_id = 2 AND tp_import_id IS NULL;  -- 0
+--   SELECT COUNT(*) FROM clientes  WHERE sucursal_id = 2 AND tp_import_id IS NULL;  -- 0
+--   SELECT COUNT(*) FROM pedidos   WHERE sucursal_id = 2 AND tp_import_id IS NULL;  -- 0

--- a/migrations/064_audit_log_allow_global_tables.sql
+++ b/migrations/064_audit_log_allow_global_tables.sql
@@ -1,0 +1,105 @@
+-- Migration 064: audit_log_changes must tolerate global (non-tenant) tables
+--
+-- Context: Migration 060 hardened the trigger to RAISE EXCEPTION when
+-- sucursal_id cannot be resolved — correct for tenant-scoped tables, but
+-- a regression for GLOBAL tables (perfiles, sucursales, usuario_sucursales,
+-- etc.) whose rows legitimately have no sucursal_id column at all. That
+-- broke `handle_new_user`: signing up a new auth user inserts into
+-- public.perfiles, which fires this trigger, which raised because
+-- current_sucursal_id() was NULL for the Supabase Auth internal connection.
+--
+-- Fix: detect whether the audited table has a sucursal_id column via
+-- information_schema. If it does and we still couldn't resolve one, fail
+-- (the original H7 fail-fast). If it doesn't, log with NULL sucursal_id —
+-- global-table audit rows are intentionally untenanted.
+--
+-- Also relaxes audit_logs.sucursal_id to be nullable to accommodate the
+-- global-table rows. Tenant-scoped rows remain enforced by the trigger's
+-- fail-fast path.
+--
+-- This migration was originally applied as an emergency hotfix directly to
+-- production while running the TP Export import preparation; it is recorded
+-- here so the migration chain stays reproducible from a clean DB.
+
+ALTER TABLE public.audit_logs ALTER COLUMN sucursal_id DROP NOT NULL;
+
+CREATE OR REPLACE FUNCTION public.audit_log_changes()
+RETURNS TRIGGER LANGUAGE plpgsql SECURITY DEFINER SET search_path = public
+AS $$
+DECLARE
+  v_old_data JSONB; v_new_data JSONB; v_campos_modificados TEXT[];
+  v_usuario_id UUID; v_usuario_email TEXT; v_usuario_rol TEXT;
+  v_registro_id TEXT; v_key TEXT;
+  v_old_changed JSONB; v_new_changed JSONB;
+  v_sucursal_id BIGINT;
+  v_has_sucursal_col BOOLEAN;
+BEGIN
+  v_usuario_id := auth.uid();
+  IF v_usuario_id IS NOT NULL THEN
+    SELECT email INTO v_usuario_email FROM auth.users WHERE id = v_usuario_id;
+    SELECT rol INTO v_usuario_rol FROM public.perfiles WHERE id = v_usuario_id;
+  END IF;
+
+  -- Does the audited table have a sucursal_id column?
+  SELECT EXISTS (
+    SELECT 1 FROM information_schema.columns
+     WHERE table_schema = TG_TABLE_SCHEMA
+       AND table_name   = TG_TABLE_NAME
+       AND column_name  = 'sucursal_id'
+  ) INTO v_has_sucursal_col;
+
+  IF TG_OP = 'DELETE' THEN
+    v_registro_id := OLD.id::TEXT;
+    v_old_data := to_jsonb(OLD);
+    v_new_data := NULL;
+    v_sucursal_id := COALESCE((to_jsonb(OLD)->>'sucursal_id')::BIGINT, current_sucursal_id());
+  ELSIF TG_OP = 'INSERT' THEN
+    v_registro_id := NEW.id::TEXT;
+    v_old_data := NULL;
+    v_new_data := to_jsonb(NEW);
+    v_sucursal_id := COALESCE((to_jsonb(NEW)->>'sucursal_id')::BIGINT, current_sucursal_id());
+  ELSE
+    v_registro_id := NEW.id::TEXT;
+    v_old_data := to_jsonb(OLD);
+    v_new_data := to_jsonb(NEW);
+    v_sucursal_id := COALESCE(
+      (to_jsonb(NEW)->>'sucursal_id')::BIGINT,
+      (to_jsonb(OLD)->>'sucursal_id')::BIGINT,
+      current_sucursal_id()
+    );
+
+    v_campos_modificados := ARRAY[]::TEXT[];
+    v_old_changed := '{}'::JSONB;
+    v_new_changed := '{}'::JSONB;
+    FOR v_key IN SELECT jsonb_object_keys(v_new_data) LOOP
+      IF v_old_data->v_key IS DISTINCT FROM v_new_data->v_key THEN
+        v_campos_modificados := array_append(v_campos_modificados, v_key);
+        v_old_changed := v_old_changed || jsonb_build_object(v_key, v_old_data->v_key);
+        v_new_changed := v_new_changed || jsonb_build_object(v_key, v_new_data->v_key);
+      END IF;
+    END LOOP;
+    IF array_length(v_campos_modificados, 1) IS NULL OR array_length(v_campos_modificados, 1) = 0 THEN
+      RETURN NEW;
+    END IF;
+    v_old_data := v_old_changed;
+    v_new_data := v_new_changed;
+  END IF;
+
+  -- FIX H7 (refined): only fail when the table HAS sucursal_id but we
+  -- couldn't resolve one. For global tables (perfiles, sucursales, etc.)
+  -- log with NULL sucursal_id - those rows are not tenant-scoped.
+  IF v_has_sucursal_col AND v_sucursal_id IS NULL THEN
+    RAISE EXCEPTION 'audit_log_changes: cannot determine sucursal_id for tenant-scoped table %', TG_TABLE_NAME;
+  END IF;
+
+  INSERT INTO public.audit_logs (
+    tabla, registro_id, accion, old_data, new_data, campos_modificados,
+    usuario_id, usuario_email, usuario_rol, sucursal_id
+  ) VALUES (
+    TG_TABLE_NAME, v_registro_id, TG_OP, v_old_data, v_new_data, v_campos_modificados,
+    v_usuario_id, v_usuario_email, v_usuario_rol, v_sucursal_id
+  );
+
+  IF TG_OP = 'DELETE' THEN RETURN OLD; ELSE RETURN NEW; END IF;
+END;
+$$;

--- a/migrations/065_pedido_historial_sucursal_id_on_trigger.sql
+++ b/migrations/065_pedido_historial_sucursal_id_on_trigger.sql
@@ -1,0 +1,106 @@
+-- Migration 065: pedido_historial.sucursal_id must be set by trigger
+--
+-- Context: Migration 057 added `sucursal_id BIGINT NOT NULL` to
+-- pedido_historial but left the two trigger functions that write into it
+-- untouched. Any INSERT or UPDATE on public.pedidos after 057 therefore
+-- fails with `null value in column "sucursal_id" of relation
+-- "pedido_historial" violates not-null constraint`.
+--
+-- The regression was latent — no pedido traffic hit the codebase between
+-- when 057 was applied and when the TP Export import started (the last
+-- natural pedido was from just before 057's deployment), so the failure
+-- only surfaced when migration 062 tried to INSERT imported pedidos.
+-- Without this fix, 062 aborts after its first row.
+--
+-- Fix: both trigger functions append `NEW.sucursal_id` as the 6th column
+-- to every INSERT INTO pedido_historial they emit. On UPDATE the tenant
+-- is the current row's (NEW) sucursal; cross-tenant moves are not a
+-- supported operation.
+--
+-- This migration was originally applied as an emergency hotfix directly
+-- to production while preparing the TP Export import; it is recorded
+-- here so the migration chain stays reproducible from a clean DB.
+
+CREATE OR REPLACE FUNCTION public.registrar_creacion_pedido()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SET search_path TO 'public'
+AS $$
+DECLARE
+  usuario_actual UUID;
+BEGIN
+  BEGIN
+    usuario_actual := current_setting('app.current_user_id', true)::UUID;
+  EXCEPTION WHEN OTHERS THEN
+    usuario_actual := NEW.usuario_id;
+  END;
+
+  INSERT INTO pedido_historial (pedido_id, usuario_id, campo_modificado, valor_anterior, valor_nuevo, sucursal_id)
+  VALUES (NEW.id, COALESCE(usuario_actual, NEW.usuario_id), 'creacion', NULL, 'Pedido creado', NEW.sucursal_id);
+
+  RETURN NEW;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.registrar_cambio_pedido()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SET search_path TO 'public'
+AS $$
+DECLARE
+  usuario_actual UUID;
+BEGIN
+  BEGIN
+    usuario_actual := current_setting('app.current_user_id', true)::UUID;
+  EXCEPTION WHEN OTHERS THEN
+    usuario_actual := NULL;
+  END;
+
+  IF OLD.estado IS DISTINCT FROM NEW.estado THEN
+    INSERT INTO pedido_historial (pedido_id, usuario_id, campo_modificado, valor_anterior, valor_nuevo, sucursal_id)
+    VALUES (NEW.id, usuario_actual, 'estado', OLD.estado, NEW.estado, NEW.sucursal_id);
+  END IF;
+
+  IF OLD.transportista_id IS DISTINCT FROM NEW.transportista_id THEN
+    INSERT INTO pedido_historial (pedido_id, usuario_id, campo_modificado, valor_anterior, valor_nuevo, sucursal_id)
+    VALUES (NEW.id, usuario_actual, 'transportista_id',
+            COALESCE(OLD.transportista_id::TEXT, 'sin asignar'),
+            COALESCE(NEW.transportista_id::TEXT, 'sin asignar'),
+            NEW.sucursal_id);
+  END IF;
+
+  IF OLD.notas IS DISTINCT FROM NEW.notas THEN
+    INSERT INTO pedido_historial (pedido_id, usuario_id, campo_modificado, valor_anterior, valor_nuevo, sucursal_id)
+    VALUES (NEW.id, usuario_actual, 'notas',
+            COALESCE(OLD.notas, '(sin notas)'),
+            COALESCE(NEW.notas, '(sin notas)'),
+            NEW.sucursal_id);
+  END IF;
+
+  IF OLD.forma_pago IS DISTINCT FROM NEW.forma_pago THEN
+    INSERT INTO pedido_historial (pedido_id, usuario_id, campo_modificado, valor_anterior, valor_nuevo, sucursal_id)
+    VALUES (NEW.id, usuario_actual, 'forma_pago',
+            COALESCE(OLD.forma_pago, 'efectivo'),
+            COALESCE(NEW.forma_pago, 'efectivo'),
+            NEW.sucursal_id);
+  END IF;
+
+  IF OLD.estado_pago IS DISTINCT FROM NEW.estado_pago THEN
+    INSERT INTO pedido_historial (pedido_id, usuario_id, campo_modificado, valor_anterior, valor_nuevo, sucursal_id)
+    VALUES (NEW.id, usuario_actual, 'estado_pago',
+            COALESCE(OLD.estado_pago, 'pendiente'),
+            COALESCE(NEW.estado_pago, 'pendiente'),
+            NEW.sucursal_id);
+  END IF;
+
+  IF OLD.total IS DISTINCT FROM NEW.total THEN
+    INSERT INTO pedido_historial (pedido_id, usuario_id, campo_modificado, valor_anterior, valor_nuevo, sucursal_id)
+    VALUES (NEW.id, usuario_actual, 'total',
+            OLD.total::TEXT,
+            NEW.total::TEXT,
+            NEW.sucursal_id);
+  END IF;
+
+  RETURN NEW;
+END;
+$$;


### PR DESCRIPTION
## Summary

Follow-up to #219. Records the two emergency hotfixes applied directly to production during the TP Export → ManaosApp import, plus rewrites the stale migration 062 to reflect what actually ran.

- **Migration 064** — `audit_log_changes` now tolerates global (non-tenant) tables. Migration 060's fail-fast on NULL `sucursal_id` was a regression for tables without that column (perfiles, sucursales, usuario_sucursales). Breaks `handle_new_user` on signup. Fix checks `information_schema` first and logs with NULL for global tables; tenant-scoped tables still fail loud.
- **Migration 065** — adds `NEW.sucursal_id` to the pedido_historial trigger inserts. Migration 057 added a NOT NULL to `pedido_historial.sucursal_id` but never updated `registrar_creacion_pedido` / `registrar_cambio_pedido`. Latent until migration 062 tried to insert pedidos — first row failed with a NOT NULL violation.
- **Migration 062 rewrite** — replaces the postgres_fdw skeleton with the MCP cross-project SQL pattern actually used (neither Supabase project exposes fdw with the required network access). Documents the real column lists, FK remap via new `tp_import_id` tracking columns, hardcoded constants verified against the source, and the 3 pedidos / 4 pedido_items chunk splits. Landed volumes: 69 productos / 89 clientes / 165 pedidos / 628 pedido_items / 6 usuario_sucursales.

Both 064 and 065 were applied to the ManaosApp project live; recording them here keeps the migration chain reproducible from a clean DB.

## Test plan

- [x] `npm run test:run` — 522/522 passing
- [x] Post-import counts verified against TP source (productos/clientes/pedidos/pedido_items match, every imported row has a non-NULL `tp_import_id`)
- [ ] Reviewer: confirm migration 064's `information_schema` lookup is acceptable at trigger-fire cost (runs once per audited row)
- [ ] Reviewer: confirm migration 065 header accurately describes the root cause (057 added NOT NULL without updating two trigger bodies)

🤖 Generated with [Claude Code](https://claude.com/claude-code)