### PR TITLE
fix: criticos de auditoria - seg/perf/bugs/offline

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -170,6 +170,16 @@ function MainAppInner({ user, perfil, logout, authReady }: {
   }, [notify])
 
   useEffect(() => {
+    const handler = (event: Event): void => {
+      const detail = (event as CustomEvent<{ type?: string; error?: string }>).detail
+      const tipo = detail?.type === 'merma' ? 'merma' : detail?.type === 'pedido' ? 'pedido' : 'dato'
+      notify.error(`No se pudo guardar ${tipo} offline: ${detail?.error ?? 'error de almacenamiento'}`)
+    }
+    window.addEventListener('offline-storage-error', handler)
+    return () => window.removeEventListener('offline-storage-error', handler)
+  }, [notify])
+
+  useEffect(() => {
     if (user && perfil) {
       trackFirstAuthenticatedRender(location.pathname || '/')
     }

--- a/src/hooks/queries/useMetricasQuery.ts
+++ b/src/hooks/queries/useMetricasQuery.ts
@@ -19,8 +19,14 @@ import type {
 // Query keys
 export const metricasKeys = {
   all: (sucursalId: number | null) => ['metricas', sucursalId] as const,
-  dashboard: (sucursalId: number | null, periodo: string, usuarioId?: string | null) =>
-    [...metricasKeys.all(sucursalId), 'dashboard', periodo, usuarioId] as const,
+  dashboard: (
+    sucursalId: number | null,
+    periodo: string,
+    usuarioId?: string | null,
+    fechaDesde?: string | null,
+    fechaHasta?: string | null
+  ) =>
+    [...metricasKeys.all(sucursalId), 'dashboard', periodo, usuarioId, fechaDesde, fechaHasta] as const,
   reportePreventistas: (sucursalId: number | null, fechaDesde?: string | null, fechaHasta?: string | null) =>
     [...metricasKeys.all(sucursalId), 'reporte-preventistas', fechaDesde, fechaHasta] as const,
 }
@@ -56,30 +62,8 @@ interface MetricasParams {
 async function calcularMetricas(params: MetricasParams): Promise<DashboardMetricasExtended> {
   const { periodo, fechaDesde, fechaHasta, usuarioId } = params
 
-  let query = supabase
-    .from('pedidos')
-    .select(`*, cliente:clientes(*), items:pedido_items(*, producto:productos(*))`)
-
-  if (usuarioId) {
-    query = query.eq('usuario_id', usuarioId)
-  }
-
-  const { data: todosPedidos, error } = await query.order('created_at', { ascending: false })
-
-  if (error) throw error
-  if (!todosPedidos) {
-    return {
-      ventasPeriodo: 0,
-      pedidosPeriodo: 0,
-      productosMasVendidos: [],
-      clientesMasActivos: [],
-      pedidosPorEstado: { pendiente: 0, en_preparacion: 0, asignado: 0, entregado: 0 },
-      ventasPorDia: []
-    }
-  }
-
-  const pedidosTyped = (todosPedidos as PedidoWithRelations[]).filter(p => p.estado !== 'cancelado')
-
+  // Calcular ventana de fecha ANTES de la query para poder filtrar server-side.
+  // Con 10k+ pedidos, traer todo y filtrar en JS es KB/MB innecesarios.
   const hoy = new Date()
   const hoyStr = fechaLocalISO(hoy)
   let fechaInicioStr: string | null = null
@@ -113,6 +97,46 @@ async function calcularMetricas(params: MetricasParams): Promise<DashboardMetric
       break
   }
 
+  let query = supabase
+    .from('pedidos')
+    .select(`*, cliente:clientes(*), items:pedido_items(*, producto:productos(*))`)
+
+  if (usuarioId) {
+    query = query.eq('usuario_id', usuarioId)
+  }
+
+  // Filtro server-side: evita descargar histórico completo.
+  // Para 'historico' (sin fechaInicioStr) se respeta el comportamiento actual
+  // de descargar todo (export ilimitado intencional).
+  if (fechaInicioStr) {
+    query = query.gte('created_at', fechaInicioStr)
+  }
+  if (periodo === 'personalizado' && fechaHasta) {
+    // Sumar un día para incluir pedidos de fechaHasta (timestamptz vs date).
+    const hastaDate = new Date(fechaHasta)
+    hastaDate.setDate(hastaDate.getDate() + 1)
+    query = query.lt('created_at', fechaLocalISO(hastaDate))
+  }
+
+  const { data: todosPedidos, error } = await query.order('created_at', { ascending: false })
+
+  if (error) throw error
+  if (!todosPedidos) {
+    return {
+      ventasPeriodo: 0,
+      pedidosPeriodo: 0,
+      productosMasVendidos: [],
+      clientesMasActivos: [],
+      pedidosPorEstado: { pendiente: 0, en_preparacion: 0, asignado: 0, entregado: 0 },
+      ventasPorDia: []
+    }
+  }
+
+  const pedidosTyped = (todosPedidos as PedidoWithRelations[]).filter(p => p.estado !== 'cancelado')
+
+  // Redundant client-side filter preservado: la columna `fecha` puede diferir
+  // de `created_at` (ej. pedidos reprogramados) y algunos cálculos de UI
+  // (ventasPorDia) usan `fecha` cuando existe.
   let pedidosFiltrados = pedidosTyped
   if (fechaInicioStr) {
     pedidosFiltrados = pedidosTyped.filter(p => (p.fecha ?? p.created_at?.split('T')[0] ?? '') >= fechaInicioStr!)
@@ -262,7 +286,7 @@ export function useMetricasQuery(
 ) {
   const { currentSucursalId } = useSucursal()
   return useQuery({
-    queryKey: metricasKeys.dashboard(currentSucursalId, periodo, usuarioId),
+    queryKey: metricasKeys.dashboard(currentSucursalId, periodo, usuarioId, fechaDesde, fechaHasta),
     queryFn: () => calcularMetricas({ periodo, fechaDesde, fechaHasta, usuarioId }),
     staleTime: 2 * 60 * 1000, // 2 minutos - métricas cambian frecuentemente
     gcTime: 10 * 60 * 1000,

--- a/src/hooks/queries/usePedidosQuery.ts
+++ b/src/hooks/queries/usePedidosQuery.ts
@@ -771,38 +771,11 @@ export function usePedidosNoPagadosQuery(enabled = false) {
 }
 
 async function marcarPagosMasivo(pedidoIds: string[], formaPago: string): Promise<void> {
-  // First get the totals for each pedido to set monto_pagado correctly
-  const { data: pedidos, error: fetchError } = await supabase
-    .from('pedidos')
-    .select('id, total')
-    .in('id', pedidoIds)
-
-  if (fetchError) throw fetchError
-
-  // Update each pedido with its own total as monto_pagado
-  for (const pedido of (pedidos || [])) {
-    const { error } = await supabase
-      .from('pedidos')
-      .update({
-        estado_pago: 'pagado',
-        monto_pagado: pedido.total,
-        forma_pago: formaPago,
-      })
-      .eq('id', pedido.id)
-
-    if (error) throw error
-  }
-
-  // Registrar historial best-effort
-  const ahora = new Date().toISOString()
-  const historialEntries = pedidoIds.map(pedidoId => ({
-    pedido_id: pedidoId,
-    accion: 'pago_registrado',
-    descripcion: `Pago masivo - Forma: ${formaPago}`,
-    fecha: ahora,
-  }))
-
-  await supabase.from('pedido_historial').insert(historialEntries).then(() => {})
+  const { error } = await supabase.rpc('marcar_pagos_masivo', {
+    p_pedido_ids: pedidoIds.map(id => Number(id)),
+    p_forma_pago: formaPago,
+  })
+  if (error) throw error
 }
 
 /**

--- a/src/hooks/supabase/useDashboard.ts
+++ b/src/hooks/supabase/useDashboard.ts
@@ -79,21 +79,6 @@ export function useDashboard(usuarioFiltro: string | null = null): UseDashboardR
   ): Promise<void> => {
     setLoading(true)
     try {
-      let query = supabase
-        .from('pedidos')
-        .select(`*, cliente:clientes(*), items:pedido_items(*, producto:productos(*))`)
-
-      if (usuarioFiltro) {
-        query = query.eq('usuario_id', usuarioFiltro)
-      }
-
-      const { data: todosPedidos, error: errorTodos } = await query.order('created_at', { ascending: false })
-
-      if (errorTodos) throw errorTodos
-      if (!todosPedidos) { setLoading(false); return }
-
-      const pedidosTyped = (todosPedidos as PedidoWithRelations[]).filter(p => p.estado !== 'cancelado')
-
       const hoy = new Date()
       const hoyStr = fechaLocalISO(hoy)
       let fechaInicioStr: string | null = null
@@ -126,6 +111,31 @@ export function useDashboard(usuarioFiltro: string | null = null): UseDashboardR
           fechaInicioStr = null
           break
       }
+
+      let query = supabase
+        .from('pedidos')
+        .select(`*, cliente:clientes(*), items:pedido_items(*, producto:productos(*))`)
+
+      if (usuarioFiltro) {
+        query = query.eq('usuario_id', usuarioFiltro)
+      }
+
+      // Filtro server-side: evita descargar histórico completo.
+      if (fechaInicioStr) {
+        query = query.gte('created_at', fechaInicioStr)
+      }
+      if (periodo === 'personalizado' && fHasta) {
+        const hastaDate = new Date(fHasta)
+        hastaDate.setDate(hastaDate.getDate() + 1)
+        query = query.lt('created_at', fechaLocalISO(hastaDate))
+      }
+
+      const { data: todosPedidos, error: errorTodos } = await query.order('created_at', { ascending: false })
+
+      if (errorTodos) throw errorTodos
+      if (!todosPedidos) { setLoading(false); return }
+
+      const pedidosTyped = (todosPedidos as PedidoWithRelations[]).filter(p => p.estado !== 'cancelado')
 
       let pedidosFiltrados = pedidosTyped
       if (fechaInicioStr) {

--- a/src/hooks/supabase/usePagos.ts
+++ b/src/hooks/supabase/usePagos.ts
@@ -78,14 +78,16 @@ export function usePagos(): UsePagosReturnExtended {
         const pedidosTyped = (pedidosCliente || []) as PedidoDB[]
         const pagosTyped = (pagosCliente || []) as PagoDB[]
 
-        const totalCompras = pedidosTyped.reduce((s, p) => s + (p.total || 0), 0)
+        const pedidosValidos = pedidosTyped.filter(p => p.estado !== 'cancelado')
+
+        const totalCompras = pedidosValidos.reduce((s, p) => s + (p.total || 0), 0)
         // Use only pagos table as source of truth to avoid double-counting.
         // monto_pagado on pedidos is informational and often reflects the same payments.
         const totalPagosRegistrados = pagosTyped.reduce((s, p) => s + (p.monto || 0), 0)
         const saldoActual = totalCompras - totalPagosRegistrados
 
         // Obtener última fecha correctamente (Math.max no funciona con Date)
-        const ultimoPedidoFecha = pedidosTyped.reduce((max: Date, p) => {
+        const ultimoPedidoFecha = pedidosValidos.reduce((max: Date, p) => {
           const fecha = new Date(p.created_at || 0)
           return fecha > max ? fecha : max
         }, new Date(0))
@@ -99,11 +101,11 @@ export function usePagos(): UsePagosReturnExtended {
           saldo_actual: saldoActual,
           limite_credito: clienteTyped?.limite_credito || 0,
           credito_disponible: (clienteTyped?.limite_credito || 0) - saldoActual,
-          total_pedidos: pedidosTyped.length,
+          total_pedidos: pedidosValidos.length,
           total_compras: totalCompras,
           total_pagos: totalPagosRegistrados,
-          pedidos_pendientes_pago: pedidosTyped.filter(p => p.estado_pago !== 'pagado').length,
-          ultimo_pedido: pedidosTyped.length ? ultimoPedidoFecha.toISOString() : null,
+          pedidos_pendientes_pago: pedidosValidos.filter(p => p.estado_pago !== 'pagado').length,
+          ultimo_pedido: pedidosValidos.length ? ultimoPedidoFecha.toISOString() : null,
           ultimo_pago: pagosTyped.length ? ultimoPagoFecha.toISOString() : null
         }
       }

--- a/src/hooks/supabase/usePedidos.ts
+++ b/src/hooks/supabase/usePedidos.ts
@@ -342,9 +342,8 @@ export function usePedidos(): UsePedidosHookReturn {
   }
 
   const cambiarEstado = async (id: string, nuevoEstado: string): Promise<void> => {
-    const updateData: { estado: PedidoDB['estado']; fecha_entrega: string | null } = {
+    const updateData: Partial<PedidoDB> = {
       estado: nuevoEstado as PedidoDB['estado'],
-      fecha_entrega: null
     }
     if (nuevoEstado === 'entregado') {
       updateData.fecha_entrega = new Date().toISOString()

--- a/src/hooks/useOfflineSync.ts
+++ b/src/hooks/useOfflineSync.ts
@@ -405,6 +405,9 @@ export function useOfflineSync(): UseOfflineSyncReturn {
       })
       .catch((err) => {
         logger.error('[useOfflineSync] Error crítico al encolar merma:', err)
+        // Rollback del optimistic update: la merma ya fue pintada como pendiente,
+        // removerla para no engañar al usuario.
+        setMermasPendientes(prev => prev.filter(m => m.offlineId !== tempOfflineId))
         window.dispatchEvent(new CustomEvent('offline-storage-error', {
           detail: { type: 'merma', error: err.message }
         }))

--- a/src/services/__tests__/pedidoService.test.ts
+++ b/src/services/__tests__/pedidoService.test.ts
@@ -501,26 +501,24 @@ describe('PedidoService', () => {
   })
 
   // =========================================================================
-  // getEstadisticas
+  // getEstadisticas (backed by RPC obtener_estadisticas_pedidos)
   // =========================================================================
   describe('getEstadisticas', () => {
-    it('should calculate statistics correctly from pedido data', async () => {
-      const pedidos = [
-        { id: '1', estado: 'pendiente', total: 100 },
-        { id: '2', estado: 'pendiente', total: 200 },
-        { id: '3', estado: 'entregado', total: 300 },
-        { id: '4', estado: 'entregado', total: 500 },
-        { id: '5', estado: 'cancelado', total: 50 },
-        { id: '6', estado: 'en_preparacion', total: 150 }
-      ]
-
-      // getEstadisticas does: from('pedidos').select('*') then awaits
-      // The last call in the non-filtered path is `select`, which is also
-      // the awaitable.  But Supabase query builder is `then`-able. In our
-      // mock the chain goes: from -> select (if no gte/lte) then await.
-      // We need select to resolve:
-      const mock = chainable({ select: { data: pedidos, error: null } })
-      vi.mocked(supabase.from).mockReturnValue(mock as any)
+    it('should map RPC aggregated response into PedidoEstadisticas', async () => {
+      vi.mocked(supabase.rpc).mockResolvedValue({
+        data: {
+          total: 6,
+          pendientes: 2,
+          en_preparacion: 1,
+          en_reparto: 0,
+          entregados: 2,
+          cancelados: 1,
+          total_ventas: '800.00',
+          promedio_ticket: '400.00',
+          por_estado: { pendiente: 2, entregado: 2, cancelado: 1, en_preparacion: 1 }
+        },
+        error: null
+      } as any)
 
       const stats = await pedidoService.getEstadisticas()
 
@@ -531,33 +529,32 @@ describe('PedidoService', () => {
         cancelado: 1,
         en_preparacion: 1
       })
-      // totalVentas = sum of totals for entregados only: 300 + 500
       expect(stats.totalVentas).toBe(800)
-      // promedioTicket = 800 / 2
       expect(stats.promedioTicket).toBe(400)
       expect(stats.pendientes).toBe(2)
       expect(stats.entregados).toBe(2)
     })
 
-    it('should apply date filters when desde and hasta are provided', async () => {
-      const mock = chainable()
-      // When gte/lte are chained, the terminal `await` still resolves through
-      // the last method call.  Since lte is last, make it resolve.
-      mock.lte = vi.fn().mockResolvedValue({ data: [], error: null })
-      vi.mocked(supabase.from).mockReturnValue(mock as any)
+    it('should pass date filters as RPC parameters', async () => {
+      vi.mocked(supabase.rpc).mockResolvedValue({ data: null, error: null } as any)
 
       const desde = new Date('2026-01-01T00:00:00Z')
       const hasta = new Date('2026-01-31T23:59:59Z')
 
       await pedidoService.getEstadisticas(desde, hasta)
 
-      expect(mock.gte).toHaveBeenCalledWith('fecha_creacion', desde.toISOString())
-      expect(mock.lte).toHaveBeenCalledWith('fecha_creacion', hasta.toISOString())
+      expect(supabase.rpc).toHaveBeenCalledWith('obtener_estadisticas_pedidos', {
+        p_fecha_desde: desde.toISOString(),
+        p_fecha_hasta: hasta.toISOString(),
+        p_usuario_id: null
+      })
     })
 
-    it('should return zero-value statistics on error', async () => {
-      const mock = chainable({ select: { data: null, error: new Error('Query failed') } })
-      vi.mocked(supabase.from).mockReturnValue(mock as any)
+    it('should return zero-value statistics when RPC errors', async () => {
+      vi.mocked(supabase.rpc).mockResolvedValue({
+        data: null,
+        error: new Error('No hay sucursal activa')
+      } as any)
 
       const stats = await pedidoService.getEstadisticas()
 
@@ -571,20 +568,14 @@ describe('PedidoService', () => {
       })
     })
 
-    it('should handle zero entregados without division by zero', async () => {
-      const pedidos = [
-        { id: '1', estado: 'pendiente', total: 100 },
-        { id: '2', estado: 'cancelado', total: 200 }
-      ]
-      const mock = chainable({ select: { data: pedidos, error: null } })
-      vi.mocked(supabase.from).mockReturnValue(mock as any)
+    it('should return zero-value statistics when RPC returns null data', async () => {
+      vi.mocked(supabase.rpc).mockResolvedValue({ data: null, error: null } as any)
 
       const stats = await pedidoService.getEstadisticas()
 
+      expect(stats.total).toBe(0)
       expect(stats.totalVentas).toBe(0)
       expect(stats.promedioTicket).toBe(0)
-      expect(stats.entregados).toBe(0)
-      expect(stats.pendientes).toBe(1)
     })
   })
 })

--- a/src/services/api/pedidoService.ts
+++ b/src/services/api/pedidoService.ts
@@ -311,22 +311,19 @@ class PedidoService extends BaseService<Pedido> {
   }
 
   /**
-   * Obtiene estadísticas de pedidos
+   * Obtiene estadísticas agregadas para la sucursal activa.
+   * Usa la RPC obtener_estadisticas_pedidos (agrega en el servidor,
+   * respeta aislamiento multi-tenant via current_sucursal_id()).
    */
   async getEstadisticas(desde: Date | null = null, hasta: Date | null = null): Promise<PedidoEstadisticas> {
-    let query = this.db.from(this.table).select('*')
+    const { data, error } = await this.db.rpc('obtener_estadisticas_pedidos', {
+      p_fecha_desde: desde ? desde.toISOString() : null,
+      p_fecha_hasta: hasta ? hasta.toISOString() : null,
+      p_usuario_id: null
+    })
 
-    if (desde) {
-      query = query.gte('fecha_creacion', desde.toISOString())
-    }
-    if (hasta) {
-      query = query.lte('fecha_creacion', hasta.toISOString())
-    }
-
-    const { data, error } = await query
-
-    if (error) {
-      this.handleError('obtener estadísticas', error)
+    if (error || !data) {
+      if (error) this.handleError('obtener estadísticas', error)
       return {
         total: 0,
         porEstado: {},
@@ -337,28 +334,22 @@ class PedidoService extends BaseService<Pedido> {
       }
     }
 
-    const pedidos = (data || []) as Pedido[]
-
-    // Calcular estadísticas
-    const porEstado = pedidos.reduce((acc: Record<string, number>, p) => {
-      acc[p.estado] = (acc[p.estado] || 0) + 1
-      return acc
-    }, {})
-
-    const pedidosEntregados = pedidos.filter(p => p.estado === 'entregado')
-    const totalVentas = pedidosEntregados.reduce((sum, p) => sum + (p.total || 0), 0)
-
-    const promedioTicket = pedidosEntregados.length > 0
-      ? totalVentas / pedidosEntregados.length
-      : 0
+    const r = data as {
+      total: number
+      por_estado?: Record<string, number>
+      total_ventas: number | string
+      promedio_ticket: number | string
+      pendientes: number
+      entregados: number
+    }
 
     return {
-      total: pedidos.length,
-      porEstado,
-      totalVentas,
-      promedioTicket,
-      pendientes: porEstado.pendiente || 0,
-      entregados: porEstado.entregado || 0
+      total: r.total ?? 0,
+      porEstado: r.por_estado ?? {},
+      totalVentas: Number(r.total_ventas ?? 0),
+      promedioTicket: Number(r.promedio_ticket ?? 0),
+      pendientes: r.pendientes ?? 0,
+      entregados: r.entregados ?? 0
     }
   }
 }

--- a/supabase/migrations/20260420_fix_estadisticas_pedidos_sucursal.sql
+++ b/supabase/migrations/20260420_fix_estadisticas_pedidos_sucursal.sql
@@ -1,0 +1,79 @@
+-- ============================================================================
+-- Fix: obtener_estadisticas_pedidos ahora filtra por sucursal activa
+--
+-- Antes: SECURITY DEFINER sin filtro multi-tenant. Cualquier usuario
+-- autenticado podia leer totales de ventas globales cross-sucursal.
+--
+-- Ahora: filtra por current_sucursal_id(). Si no hay sucursal activa,
+-- lanza excepcion 42501 (insufficient_privilege).
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION public.obtener_estadisticas_pedidos(
+  p_fecha_desde TIMESTAMPTZ DEFAULT NULL,
+  p_fecha_hasta TIMESTAMPTZ DEFAULT NULL,
+  p_usuario_id  UUID DEFAULT NULL
+)
+RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $$
+DECLARE
+  v_sucursal_id BIGINT;
+  v_result JSONB;
+BEGIN
+  v_sucursal_id := current_sucursal_id();
+  IF v_sucursal_id IS NULL THEN
+    RAISE EXCEPTION 'No hay sucursal activa' USING ERRCODE = '42501';
+  END IF;
+
+  SELECT jsonb_build_object(
+    'total', COUNT(*)::int,
+    'pendientes', COUNT(*) FILTER (WHERE estado = 'pendiente')::int,
+    'en_preparacion', COUNT(*) FILTER (WHERE estado = 'en_preparacion')::int,
+    'en_reparto', COUNT(*) FILTER (WHERE estado IN ('en_reparto', 'asignado'))::int,
+    'entregados', COUNT(*) FILTER (WHERE estado = 'entregado')::int,
+    'cancelados', COUNT(*) FILTER (WHERE estado = 'cancelado')::int,
+    'total_ventas', COALESCE(SUM(total) FILTER (WHERE estado = 'entregado'), 0)::numeric(12,2),
+    'promedio_ticket', COALESCE(AVG(total) FILTER (WHERE estado = 'entregado'), 0)::numeric(12,2),
+    'por_estado', COALESCE(
+      (SELECT jsonb_object_agg(estado, cnt)
+       FROM (
+         SELECT p.estado, COUNT(*)::int AS cnt
+         FROM pedidos p
+         WHERE p.sucursal_id = v_sucursal_id
+           AND (p_fecha_desde IS NULL OR p.created_at >= p_fecha_desde)
+           AND (p_fecha_hasta IS NULL OR p.created_at <= p_fecha_hasta)
+           AND (p_usuario_id IS NULL OR p.usuario_id = p_usuario_id)
+         GROUP BY p.estado
+       ) s),
+      '{}'::jsonb
+    )
+  ) INTO v_result
+  FROM pedidos p
+  WHERE p.sucursal_id = v_sucursal_id
+    AND (p_fecha_desde IS NULL OR p.created_at >= p_fecha_desde)
+    AND (p_fecha_hasta IS NULL OR p.created_at <= p_fecha_hasta)
+    AND (p_usuario_id IS NULL OR p.usuario_id = p_usuario_id);
+
+  IF v_result IS NULL THEN
+    v_result := jsonb_build_object(
+      'total', 0,
+      'pendientes', 0,
+      'en_preparacion', 0,
+      'en_reparto', 0,
+      'entregados', 0,
+      'cancelados', 0,
+      'total_ventas', 0,
+      'promedio_ticket', 0,
+      'por_estado', '{}'::jsonb
+    );
+  END IF;
+
+  RETURN v_result;
+END;
+$$;
+
+COMMENT ON FUNCTION public.obtener_estadisticas_pedidos IS
+  'Estadisticas agregadas de pedidos para la sucursal activa. '
+  'Requiere current_sucursal_id() no nulo. Filtra por rango opcional de fechas y usuario.';

--- a/supabase/migrations/20260420_marcar_pagos_masivo.sql
+++ b/supabase/migrations/20260420_marcar_pagos_masivo.sql
@@ -1,0 +1,52 @@
+-- ============================================================================
+-- RPC: marcar_pagos_masivo
+--
+-- Reemplaza el loop cliente-side que hacia N+1 UPDATEs individuales.
+-- Un solo UPDATE batch filtrado por sucursal activa y rol.
+-- Los triggers existentes (audit_pedidos, trigger_registrar_cambio_pedido,
+-- trigger_actualizar_estado_pago) registran el historial automaticamente.
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION public.marcar_pagos_masivo(
+  p_pedido_ids BIGINT[],
+  p_forma_pago TEXT
+)
+RETURNS INTEGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $$
+DECLARE
+  v_sucursal_id BIGINT;
+  v_affected INTEGER;
+BEGIN
+  v_sucursal_id := current_sucursal_id();
+  IF v_sucursal_id IS NULL THEN
+    RAISE EXCEPTION 'No hay sucursal activa' USING ERRCODE = '42501';
+  END IF;
+
+  IF NOT es_encargado_o_admin() THEN
+    RAISE EXCEPTION 'Solo encargado o admin pueden marcar pagos masivos'
+      USING ERRCODE = '42501';
+  END IF;
+
+  IF p_pedido_ids IS NULL OR array_length(p_pedido_ids, 1) IS NULL THEN
+    RETURN 0;
+  END IF;
+
+  UPDATE pedidos
+     SET estado_pago = 'pagado',
+         monto_pagado = total,
+         forma_pago = p_forma_pago,
+         updated_at = now()
+   WHERE id = ANY(p_pedido_ids)
+     AND sucursal_id = v_sucursal_id;
+
+  GET DIAGNOSTICS v_affected = ROW_COUNT;
+  RETURN v_affected;
+END;
+$$;
+
+COMMENT ON FUNCTION public.marcar_pagos_masivo IS
+  'Marca multiples pedidos como pagados en batch. Restringido a encargado/admin '
+  'y a la sucursal activa. Retorna cantidad de filas afectadas.';

--- a/vite.config.js
+++ b/vite.config.js
@@ -48,7 +48,11 @@ export default defineConfig({
     VitePWA({
       injectRegister: false,
       registerType: 'prompt',
-      selfDestroying: true,
+      // selfDestroying debe estar en false para que el SW persista y la PWA
+      // funcione offline (Workbox precache + Dexie). El deploy previo con
+      // selfDestroying:true ya desregistró SW corruptos; ahora los usuarios
+      // registran un SW válido que habilita el modo offline real.
+      selfDestroying: false,
       includeAssets: ['favicon.ico', 'apple-touch-icon.png', 'icon.svg'],
       manifest: {
         name: 'Distribuidora App',


### PR DESCRIPTION
## Summary

Cierra los items críticos de la auditoría (seguridad + performance + bugs de datos + PWA offline). Todos los hallazgos fueron validados contra prod **ManaosApp** vía Supabase MCP antes de implementar — 3 items quedaron descartados porque las migraciones en disco estaban desactualizadas respecto al estado real de prod.

### Cambios

**Seguridad**
- `obtener_estadisticas_pedidos` RPC ahora filtra por `current_sucursal_id()`. Antes, al ser `SECURITY DEFINER` sin filtro multi-tenant, un user de sucursal A podía leer totales globales cross-sucursal.
- `PedidoService.getEstadisticas` reemplazado por llamada a RPC (elimina `SELECT *` client-side además).

**Performance**
- Nueva RPC `marcar_pagos_masivo` batch: 50 pedidos pasan de 51 requests (loop + historial) a 1 request. El historial lo generan los triggers existentes (`audit_pedidos`, `trigger_registrar_cambio_pedido`).
- Dashboard filtra fechas server-side (`.gte/lt('created_at', …)`) antes de descargar pedidos. Para `'historico'` se preserva el comportamiento actual (sin cap) porque el usuario pidió explícitamente no paginar.
- `useMetricasQuery` queryKey incluye `fechaDesde/fechaHasta` para no colisionar caches con rangos distintos.

**Bugs de datos**
- `cambiarEstado` (hook legacy) ya no inicializa `fecha_entrega: null`, por lo que deja de pisar fechas programadas al cambiar a estados distintos de `entregado`.
- `obtenerResumenCuenta` excluye pedidos `cancelado` del saldo/contador (fallback cliente — el RPC de prod ya lo hace correctamente).
- `guardarMermaOffline`: si falla el write a IndexedDB, se revierte el optimistic update (removiendo la merma del estado local) y se emite toast global vía listener `offline-storage-error` en `App.tsx`.

**PWA offline**
- `vite.config.js` pasa de `selfDestroying: true` a `false`. El deploy previo ya desregistró SW corruptos; ahora los usuarios registran un SW válido que habilita Workbox precache + Dexie. Sin este cambio, el módulo offline es inoperante.

### SQL nuevo (requiere aplicar a prod)
- `supabase/migrations/20260420_fix_estadisticas_pedidos_sucursal.sql`
- `supabase/migrations/20260420_marcar_pagos_masivo.sql`

## Test plan

- [x] `npm run typecheck` verde
- [x] `npm run lint` verde
- [x] `npm run test:run` — 522/522 tests
- [ ] Aplicar migraciones a prod ManaosApp
- [ ] **Seguridad:** user sucursal A invoca `rpc('obtener_estadisticas_pedidos')` → no ve totales de sucursal B
- [ ] **Datos:** asignar `fecha_entrega` programada → cambiar estado a `asignado` → fecha sigue
- [ ] **Datos:** crear pedido → cancelar → ficha cliente: saldo no lo incluye
- [ ] **Performance:** dashboard con `periodo=semana` → Network tab muestra payload reducido
- [ ] **Performance:** seleccionar 20 pedidos → marcar pagados → Network tab = 1 request
- [ ] **Offline:** DevTools → Application → Service Workers: SW activo después del deploy. Red offline → app sigue cargando

🤖 Generated with [Claude Code](https://claude.com/claude-code)