### PR TITLE
fix: timezone ARG + UX fecha entrega preventistas + admin editar fech…

### DIFF
--- a/src/components/containers/PedidosContainer.tsx
+++ b/src/components/containers/PedidosContainer.tsx
@@ -501,8 +501,8 @@ export default function PedidosContainer(): React.ReactElement {
     setGuardando(false)
   }, [pedidoAsignando, asignarTransportistaMut, cambiarEstado, notify])
 
-  // ModalEditarPedido: onSave({ notas, formaPago, estadoPago, montoPagado })
-  const handleGuardarEdicion = useCallback(async (data: { notas: string; formaPago: string; estadoPago: string; montoPagado: number; fecha?: string }) => {
+  // ModalEditarPedido: onSave({ notas, formaPago, estadoPago, montoPagado, fecha?, fechaEntrega?, fechaEntregaProgramada? })
+  const handleGuardarEdicion = useCallback(async (data: { notas: string; formaPago: string; estadoPago: string; montoPagado: number; fecha?: string; fechaEntrega?: string; fechaEntregaProgramada?: string }) => {
     if (!pedidoEditando) return
     setGuardando(true)
     try {
@@ -511,6 +511,10 @@ export default function PedidosContainer(): React.ReactElement {
         estado_pago: data.estadoPago, monto_pagado: data.montoPagado ?? 0,
       }
       if (data.fecha) updateData.fecha = data.fecha
+      if (data.fechaEntrega) {
+        updateData.fecha_entrega = data.fechaEntrega.includes('T') ? data.fechaEntrega : `${data.fechaEntrega}T12:00:00Z`
+      }
+      if (data.fechaEntregaProgramada) updateData.fecha_entrega_programada = data.fechaEntregaProgramada
       const { error } = await supabase.from('pedidos').update(updateData).eq('id', pedidoEditando.id)
       if (error) throw error
       // Invalidar cache para que los cambios se reflejen en la UI

--- a/src/components/modals/ModalEditarPedido.tsx
+++ b/src/components/modals/ModalEditarPedido.tsx
@@ -30,6 +30,7 @@ export interface PedidoSaveData {
   montoPagado: number;
   fecha?: string;
   fechaEntrega?: string;
+  fechaEntregaProgramada?: string;
 }
 
 /** Props del componente ModalEditarPedido */
@@ -63,6 +64,8 @@ const ModalEditarPedido = memo(function ModalEditarPedido({
   const [fecha, setFecha] = useState<string>(pedido?.fecha || "");
   const fechaEntregaOriginal = pedido?.fecha_entrega ? pedido.fecha_entrega.split('T')[0] : "";
   const [fechaEntrega, setFechaEntrega] = useState<string>(fechaEntregaOriginal);
+  const fechaEntregaProgramadaOriginal = pedido?.fecha_entrega_programada || "";
+  const [fechaEntregaProgramada, setFechaEntregaProgramada] = useState<string>(fechaEntregaProgramadaOriginal);
   const [formaPago, setFormaPago] = useState<string>(pedido?.forma_pago === 'combinado' ? 'combinado' : (pedido?.forma_pago || "efectivo"));
   const [estadoPago, setEstadoPago] = useState<string>(pedido?.estado_pago || "pendiente");
   const [montoPagado, setMontoPagado] = useState<number>(pedido?.monto_pagado || 0);
@@ -363,13 +366,15 @@ const ModalEditarPedido = memo(function ModalEditarPedido({
         await onSaveItems(itemsParaGuardar);
       }
       // Guardar el resto de los datos
+      const fechaEntregaProgramadaCambio = isAdmin && !pedidoEntregado && fechaEntregaProgramada !== fechaEntregaProgramadaOriginal;
       await onSave({
         notas: notasFinal,
         formaPago: formaPagoFinal,
         estadoPago,
         montoPagado: montoPagadoFinal,
         ...(isAdmin && fecha ? { fecha } : {}),
-        ...(fechaEntregaCambio ? { fechaEntrega } : {})
+        ...(fechaEntregaCambio ? { fechaEntrega } : {}),
+        ...(fechaEntregaProgramadaCambio ? { fechaEntregaProgramada } : {})
       });
     } catch (err) {
       const error = err as Error;
@@ -671,6 +676,26 @@ const ModalEditarPedido = memo(function ModalEditarPedido({
               onChange={e => setFecha(e.target.value)}
               className="w-full px-3 py-2 border rounded-lg dark:bg-gray-700 dark:border-gray-600 dark:text-white"
             />
+          </div>
+        )}
+
+        {/* Fecha programada de entrega (solo admin + pedido NO entregado) */}
+        {isAdmin && !pedidoEntregado && (
+          <div>
+            <label className="block text-sm font-medium mb-1 dark:text-gray-200">
+              Fecha programada de entrega
+            </label>
+            <input
+              type="date"
+              value={fechaEntregaProgramada}
+              onChange={e => setFechaEntregaProgramada(e.target.value)}
+              className="w-full px-3 py-2 border rounded-lg dark:bg-gray-700 dark:border-gray-600 dark:text-white"
+            />
+            {fechaEntregaProgramada !== fechaEntregaProgramadaOriginal && (
+              <p className="mt-1 text-xs text-amber-600 dark:text-amber-400">
+                Se actualizará la fecha estimada de entrega del pedido.
+              </p>
+            )}
           </div>
         )}
 

--- a/src/components/modals/ModalPedido.tsx
+++ b/src/components/modals/ModalPedido.tsx
@@ -294,24 +294,27 @@ const ModalPedido = memo(function ModalPedido({
           </div>
 
           {/* Fechas - pedido y entrega programada */}
-          <div className="flex flex-wrap items-center gap-3">
-            <div className="flex items-center gap-2">
-              <label className="text-sm font-medium dark:text-gray-200 whitespace-nowrap flex items-center gap-1">
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+            <div>
+              <label className="text-sm font-medium mb-1 dark:text-gray-200 flex items-center gap-1">
                 <Calendar className="w-4 h-4" />
-                Fecha
+                Fecha del pedido
               </label>
               <input
                 type="date"
                 value={nuevoPedido.fecha || fechaLocalISO()}
                 onChange={e => onFechaChange && onFechaChange(e.target.value)}
                 max={fechaLocalISO()}
-                className="px-3 py-1.5 border rounded-lg bg-white dark:bg-gray-700 dark:border-gray-600 dark:text-white text-sm"
+                className="w-full px-3 py-2 border rounded-lg bg-white dark:bg-gray-700 dark:border-gray-600 dark:text-white text-sm"
               />
+              {nuevoPedido.fecha && nuevoPedido.fecha !== fechaLocalISO() && (
+                <p className="mt-1 text-xs text-amber-600">Fecha distinta a hoy</p>
+              )}
             </div>
-            <div className="flex items-center gap-2">
-              <label className="text-sm font-medium dark:text-gray-200 whitespace-nowrap flex items-center gap-1">
+            <div>
+              <label className="text-sm font-medium mb-1 dark:text-gray-200 flex items-center gap-1">
                 <Truck className="w-4 h-4" />
-                Entrega
+                Fecha de entrega
               </label>
               <input
                 type="date"
@@ -319,16 +322,16 @@ const ModalPedido = memo(function ModalPedido({
                   const base = nuevoPedido.fecha || fechaLocalISO();
                   const d = new Date(base + 'T12:00:00');
                   d.setDate(d.getDate() + 1);
-                  return d.toISOString().split('T')[0];
+                  return fechaLocalISO(d);
                 })()}
                 onChange={e => onFechaEntregaProgramadaChange && onFechaEntregaProgramadaChange(e.target.value)}
                 min={nuevoPedido.fecha || fechaLocalISO()}
-                className="px-3 py-1.5 border rounded-lg bg-white dark:bg-gray-700 dark:border-gray-600 dark:text-white text-sm"
+                className="w-full px-3 py-2 border rounded-lg bg-white dark:bg-gray-700 dark:border-gray-600 dark:text-white text-sm"
               />
+              <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
+                ¿Cuándo se va a entregar este pedido?
+              </p>
             </div>
-            {nuevoPedido.fecha && nuevoPedido.fecha !== fechaLocalISO() && (
-              <p className="text-xs text-amber-600 whitespace-nowrap">Fecha distinta a hoy</p>
-            )}
           </div>
 
           {/* Seccion Productos con filtro por categoria */}

--- a/src/components/pedidos/PedidoFilters.tsx
+++ b/src/components/pedidos/PedidoFilters.tsx
@@ -161,7 +161,7 @@ function PedidoFilters({
             <Truck className="w-4 h-4 text-gray-500 dark:text-gray-400" />
             {(() => {
               const hoy = fechaLocalISO();
-              const manana = (() => { const d = new Date(hoy + 'T12:00:00'); d.setDate(d.getDate() + 1); return d.toISOString().split('T')[0]; })();
+              const manana = (() => { const d = new Date(hoy + 'T12:00:00'); d.setDate(d.getDate() + 1); return fechaLocalISO(d); })();
               const activa = filtros.fechaEntregaProgramada;
               return (
                 <>

--- a/src/components/vistas/VistaRendiciones.tsx
+++ b/src/components/vistas/VistaRendiciones.tsx
@@ -183,7 +183,7 @@ export default function VistaRendiciones(): React.ReactElement {
   const haceUnaSemana = useMemo(() => {
     const d = new Date()
     d.setDate(d.getDate() - 7)
-    return d.toISOString().split('T')[0]
+    return fechaLocalISO(d)
   }, [])
 
   const [fechaDesde, setFechaDesde] = useState<string>(haceUnaSemana)

--- a/supabase/migrations/20260420_fix_crear_pedido_timezone.sql
+++ b/supabase/migrations/20260420_fix_crear_pedido_timezone.sql
@@ -1,0 +1,91 @@
+-- Fix timezone bug en crear_pedido_completo
+--
+-- Problema: el default p_fecha = CURRENT_DATE usa la zona del DB (UTC).
+-- A las 23:30 ARG son las 02:30 UTC del día siguiente → fecha incorrecta.
+-- El default p_fecha_entrega_programada también heredaba la fecha UTC.
+--
+-- Fix: default en NULL, y cálculo de v_fecha_pedido / v_fecha_entrega
+-- usando explícitamente 'America/Argentina/Buenos_Aires'. Preserva firma.
+
+CREATE OR REPLACE FUNCTION public.crear_pedido_completo(
+  p_cliente_id bigint,
+  p_total numeric,
+  p_usuario_id uuid,
+  p_items jsonb,
+  p_notas text DEFAULT NULL::text,
+  p_forma_pago text DEFAULT 'efectivo'::text,
+  p_estado_pago text DEFAULT 'pendiente'::text,
+  p_fecha date DEFAULT NULL::date,
+  p_tipo_factura text DEFAULT 'ZZ'::text,
+  p_total_neto numeric DEFAULT NULL::numeric,
+  p_total_iva numeric DEFAULT 0,
+  p_fecha_entrega_programada date DEFAULT NULL::date
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $function$
+DECLARE
+  v_sucursal BIGINT := current_sucursal_id();
+  v_pedido_id INT; item JSONB; v_producto_id INT; v_cantidad INT;
+  v_precio_unitario DECIMAL; v_es_bonificacion BOOLEAN; v_promocion_id BIGINT;
+  v_neto_unitario DECIMAL; v_iva_unitario DECIMAL; v_imp_internos_unitario DECIMAL;
+  v_porcentaje_iva DECIMAL; v_stock_actual INT; v_producto_nombre TEXT;
+  errores TEXT[] := '{}'; v_user_role TEXT;
+  v_cantidades_totales JSONB := '{}'::JSONB; v_cant_acumulada INT;
+  v_fecha_pedido DATE := COALESCE(
+    p_fecha,
+    (now() AT TIME ZONE 'America/Argentina/Buenos_Aires')::date
+  );
+  v_fecha_entrega DATE := COALESCE(
+    p_fecha_entrega_programada,
+    (v_fecha_pedido + INTERVAL '1 day')::date
+  );
+BEGIN
+  IF v_sucursal IS NULL THEN RETURN jsonb_build_object('success', false, 'errores', jsonb_build_array('No se pudo determinar la sucursal activa')); END IF;
+  IF p_usuario_id IS DISTINCT FROM auth.uid() THEN RETURN jsonb_build_object('success', false, 'errores', jsonb_build_array('ID de usuario no coincide con la sesion autenticada')); END IF;
+  SELECT rol INTO v_user_role FROM perfiles WHERE id = p_usuario_id;
+  IF v_user_role IS NULL OR v_user_role NOT IN ('admin', 'preventista') THEN RETURN jsonb_build_object('success', false, 'errores', jsonb_build_array('No tiene permisos para crear pedidos')); END IF;
+
+  FOR item IN SELECT * FROM jsonb_array_elements(p_items) LOOP
+    v_producto_id := (item->>'producto_id')::INT; v_cantidad := (item->>'cantidad')::INT;
+    v_es_bonificacion := COALESCE((item->>'es_bonificacion')::BOOLEAN, false);
+    IF v_cantidad IS NULL OR v_cantidad <= 0 THEN errores := array_append(errores, 'Cantidad invalida para producto ID ' || v_producto_id); CONTINUE; END IF;
+    IF NOT v_es_bonificacion THEN
+      v_cant_acumulada := COALESCE((v_cantidades_totales->>v_producto_id::TEXT)::INT, 0) + v_cantidad;
+      v_cantidades_totales := v_cantidades_totales || jsonb_build_object(v_producto_id::TEXT, v_cant_acumulada);
+    END IF;
+  END LOOP;
+
+  FOR v_producto_id IN SELECT (key)::INT FROM jsonb_each_text(v_cantidades_totales) LOOP
+    v_cantidad := (v_cantidades_totales->>v_producto_id::TEXT)::INT;
+    SELECT stock, nombre INTO v_stock_actual, v_producto_nombre FROM productos WHERE id = v_producto_id AND sucursal_id = v_sucursal FOR UPDATE;
+    IF v_stock_actual IS NULL THEN errores := array_append(errores, 'Producto ID ' || v_producto_id || ' no encontrado');
+    ELSIF v_stock_actual < v_cantidad THEN errores := array_append(errores, v_producto_nombre || ': stock insuficiente (disponible: ' || v_stock_actual || ', solicitado: ' || v_cantidad || ')'); END IF;
+  END LOOP;
+
+  IF array_length(errores, 1) > 0 THEN RETURN jsonb_build_object('success', false, 'errores', to_jsonb(errores)); END IF;
+
+  INSERT INTO pedidos (cliente_id, fecha, total, total_neto, total_iva, tipo_factura, estado, usuario_id, stock_descontado, notas, forma_pago, estado_pago, fecha_entrega_programada, sucursal_id)
+  VALUES (p_cliente_id, v_fecha_pedido, p_total, COALESCE(p_total_neto, p_total), COALESCE(p_total_iva, 0), COALESCE(p_tipo_factura, 'ZZ'), 'pendiente', p_usuario_id, true, p_notas, p_forma_pago, p_estado_pago, v_fecha_entrega, v_sucursal)
+  RETURNING id INTO v_pedido_id;
+
+  FOR item IN SELECT * FROM jsonb_array_elements(p_items) LOOP
+    v_producto_id := (item->>'producto_id')::INT; v_cantidad := (item->>'cantidad')::INT;
+    v_precio_unitario := (item->>'precio_unitario')::DECIMAL;
+    v_es_bonificacion := COALESCE((item->>'es_bonificacion')::BOOLEAN, false);
+    v_promocion_id := (item->>'promocion_id')::BIGINT;
+    v_neto_unitario := (item->>'neto_unitario')::DECIMAL;
+    v_iva_unitario := COALESCE((item->>'iva_unitario')::DECIMAL, 0);
+    v_imp_internos_unitario := COALESCE((item->>'impuestos_internos_unitario')::DECIMAL, 0);
+    v_porcentaje_iva := COALESCE((item->>'porcentaje_iva')::DECIMAL, 0);
+    INSERT INTO pedido_items (pedido_id, producto_id, cantidad, precio_unitario, subtotal, es_bonificacion, promocion_id, neto_unitario, iva_unitario, impuestos_internos_unitario, porcentaje_iva, sucursal_id)
+    VALUES (v_pedido_id, v_producto_id, v_cantidad, v_precio_unitario, v_cantidad * v_precio_unitario, v_es_bonificacion, v_promocion_id, v_neto_unitario, v_iva_unitario, v_imp_internos_unitario, v_porcentaje_iva, v_sucursal);
+    IF NOT v_es_bonificacion THEN UPDATE productos SET stock = stock - v_cantidad WHERE id = v_producto_id AND sucursal_id = v_sucursal; END IF;
+    IF v_es_bonificacion AND v_promocion_id IS NOT NULL THEN UPDATE promociones SET usos_pendientes = usos_pendientes + v_cantidad WHERE id = v_promocion_id AND sucursal_id = v_sucursal; END IF;
+  END LOOP;
+
+  RETURN jsonb_build_object('success', true, 'pedido_id', v_pedido_id);
+END;
+$function$;


### PR DESCRIPTION
…a programada

- RPC crear_pedido_completo: defaults usan America/Argentina/Buenos_Aires en lugar de CURRENT_DATE UTC
- Reemplaza 3 usos de toISOString().split('T')[0] por fechaLocalISO() en VistaRendiciones, PedidoFilters y ModalPedido
- Rediseño del bloque fecha/entrega en ModalPedido: grid con labels prominentes y helper text
- ModalEditarPedido: admin puede editar fecha_entrega_programada en pedidos no-entregados; cablea persistencia en PedidosContainer (también arregla fechaEntrega silently dropped)