### PR TITLE
feat: promociones UX v2 - modo acumulable/excluyente + auto-ajuste po…

### DIFF
--- a/src/components/modals/ModalPromocion.tsx
+++ b/src/components/modals/ModalPromocion.tsx
@@ -5,7 +5,7 @@
  * Incluye: nombre, fechas, selector de productos, reglas (cantidad_compra, cantidad_bonificacion).
  */
 import { useState, useMemo } from 'react'
-import { X, Search, Gift } from 'lucide-react'
+import { X, Search, Gift, ChevronDown, ChevronRight, Layers, Ban } from 'lucide-react'
 import { fechaLocalISO } from '../../utils/formatters'
 import type { ProductoDB } from '../../types'
 import type { PromocionConDetalles, PromocionFormInput } from '../../hooks/queries/usePromocionesQuery'
@@ -55,6 +55,23 @@ export default function ModalPromocion({
   const [regaloMueveStock, setRegaloMueveStock] = useState<boolean>(
     promocion?.regalo_mueve_stock ?? false
   )
+  const [modoExclusion, setModoExclusion] = useState<'acumulable' | 'excluyente'>(
+    (promocion?.modo_exclusion as 'acumulable' | 'excluyente') ?? 'acumulable'
+  )
+  const [ajusteAutomatico, setAjusteAutomatico] = useState<boolean>(
+    promocion?.ajuste_automatico ?? false
+  )
+  const [ajusteProductoId, setAjusteProductoId] = useState<string>(
+    promocion?.ajuste_producto_id ? String(promocion.ajuste_producto_id) : ''
+  )
+  const [unidadesPorBloque, setUnidadesPorBloque] = useState<string>(
+    promocion?.unidades_por_bloque ? String(promocion.unidades_por_bloque) : ''
+  )
+  const [stockPorBloque, setStockPorBloque] = useState<string>(
+    promocion?.stock_por_bloque ? String(promocion.stock_por_bloque) : '1'
+  )
+  const [busquedaAjusteProd, setBusquedaAjusteProd] = useState('')
+  const [mostrarAvanzadas, setMostrarAvanzadas] = useState(false)
   const [busqueda, setBusqueda] = useState('')
   const [busquedaRegalo, setBusquedaRegalo] = useState('')
   const [saving, setSaving] = useState(false)
@@ -77,6 +94,15 @@ export default function ModalPromocion({
       p.codigo?.toLowerCase().includes(q)
     )
   }, [productos, busquedaRegalo])
+
+  const productosAjusteFiltrados = useMemo(() => {
+    if (!busquedaAjusteProd.trim()) return productos
+    const q = busquedaAjusteProd.toLowerCase()
+    return productos.filter(p =>
+      p.nombre.toLowerCase().includes(q) ||
+      p.codigo?.toLowerCase().includes(q)
+    )
+  }, [productos, busquedaAjusteProd])
 
   const handleToggleProducto = (id: string) => {
     setProductoIds(prev => {
@@ -113,9 +139,29 @@ export default function ModalPromocion({
       return
     }
 
+    // Validaciones para ajuste automatico
+    if (ajusteAutomatico) {
+      if (!ajusteProductoId) {
+        setError('Seleccioná el producto que se descuenta del stock en el ajuste automático')
+        return
+      }
+      const unidBloque = parseInt(unidadesPorBloque)
+      if (!unidBloque || unidBloque <= 0) {
+        setError('Ingresá cuántas unidades bonificadas forman un bloque (ej: 12 botellas = 1 fardo)')
+        return
+      }
+      const stockBloque = parseInt(stockPorBloque)
+      if (!stockBloque || stockBloque <= 0) {
+        setError('Ingresá cuánto stock descuenta cada bloque (normalmente 1)')
+        return
+      }
+    }
+
     setSaving(true)
     const limite = limiteUsos ? parseInt(limiteUsos) : null
     const prio = parseInt(prioridad)
+    const unidBloque = parseInt(unidadesPorBloque)
+    const stockBloque = parseInt(stockPorBloque)
     const result = await onSave({
       nombre: nombre.trim(),
       tipo: 'bonificacion',
@@ -130,6 +176,11 @@ export default function ModalPromocion({
       ],
       prioridad: Number.isFinite(prio) ? prio : 0,
       regaloMueveStock,
+      modoExclusion,
+      ajusteAutomatico,
+      ajusteProductoId: ajusteAutomatico ? (ajusteProductoId || null) : null,
+      unidadesPorBloque: ajusteAutomatico && Number.isFinite(unidBloque) && unidBloque > 0 ? unidBloque : null,
+      stockPorBloque: ajusteAutomatico && Number.isFinite(stockBloque) && stockBloque > 0 ? stockBloque : null,
     })
     setSaving(false)
 
@@ -205,41 +256,214 @@ export default function ModalPromocion({
             </p>
           </div>
 
-          {/* Prioridad (para exclusion entre promos) */}
+          {/* Modo de exclusion: acumulable vs excluyente */}
           <div>
-            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
-              Prioridad
+            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+              ¿Cómo convive con otras promos?
             </label>
-            <input
-              type="number"
-              value={prioridad}
-              onChange={e => setPrioridad(e.target.value)}
-              placeholder="0"
-              className="w-full px-3 py-2 border rounded-lg dark:bg-gray-700 dark:border-gray-600 dark:text-white focus:ring-2 focus:ring-purple-500 focus:outline-none text-sm"
-            />
-            <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
-              Si dos promos aplican al mismo pedido, gana la de mayor prioridad. Dejar 0 si no hay conflictos.
-            </p>
+            <div className="grid grid-cols-2 gap-2">
+              <button
+                type="button"
+                onClick={() => setModoExclusion('acumulable')}
+                className={`flex items-start gap-2 p-3 rounded-lg border text-left transition ${
+                  modoExclusion === 'acumulable'
+                    ? 'bg-purple-50 dark:bg-purple-900/30 border-purple-400 dark:border-purple-600 ring-2 ring-purple-200 dark:ring-purple-800'
+                    : 'bg-white dark:bg-gray-700 border-gray-200 dark:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-600'
+                }`}
+              >
+                <Layers className={`w-4 h-4 mt-0.5 flex-shrink-0 ${modoExclusion === 'acumulable' ? 'text-purple-600 dark:text-purple-400' : 'text-gray-400'}`} />
+                <div className="flex-1">
+                  <p className={`text-sm font-medium ${modoExclusion === 'acumulable' ? 'text-purple-700 dark:text-purple-300' : 'text-gray-700 dark:text-gray-300'}`}>
+                    Acumulable
+                  </p>
+                  <p className="text-xs text-gray-500 dark:text-gray-400 mt-0.5">
+                    Se aplica junto con otras promos del pedido.
+                  </p>
+                </div>
+              </button>
+              <button
+                type="button"
+                onClick={() => setModoExclusion('excluyente')}
+                className={`flex items-start gap-2 p-3 rounded-lg border text-left transition ${
+                  modoExclusion === 'excluyente'
+                    ? 'bg-purple-50 dark:bg-purple-900/30 border-purple-400 dark:border-purple-600 ring-2 ring-purple-200 dark:ring-purple-800'
+                    : 'bg-white dark:bg-gray-700 border-gray-200 dark:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-600'
+                }`}
+              >
+                <Ban className={`w-4 h-4 mt-0.5 flex-shrink-0 ${modoExclusion === 'excluyente' ? 'text-purple-600 dark:text-purple-400' : 'text-gray-400'}`} />
+                <div className="flex-1">
+                  <p className={`text-sm font-medium ${modoExclusion === 'excluyente' ? 'text-purple-700 dark:text-purple-300' : 'text-gray-700 dark:text-gray-300'}`}>
+                    Excluyente
+                  </p>
+                  <p className="text-xs text-gray-500 dark:text-gray-400 mt-0.5">
+                    Si choca con otra excluyente, gana la de mayor cantidad.
+                  </p>
+                </div>
+              </button>
+            </div>
+            {modoExclusion === 'excluyente' && (
+              <p className="text-xs text-gray-500 dark:text-gray-400 mt-2">
+                Ejemplo: si tenés una promo "2+2 botellas" y otra "3+1 fardo" excluyentes sobre el mismo producto, al pedir 3 fardos gana la 3+1 (tier más alto). Con sólo 2 fardos, aplica la 2+2.
+              </p>
+            )}
           </div>
 
-          {/* Mueve stock (toggle) */}
-          <div className="flex items-start gap-2 p-3 bg-amber-50 dark:bg-amber-900/20 rounded-lg border border-amber-200 dark:border-amber-800">
-            <input
-              id="regalo-mueve-stock"
-              type="checkbox"
-              checked={regaloMueveStock}
-              onChange={e => setRegaloMueveStock(e.target.checked)}
-              className="mt-1 rounded border-gray-300 text-amber-600 focus:ring-amber-500"
-            />
-            <div className="flex-1">
-              <label htmlFor="regalo-mueve-stock" className="block text-sm font-medium text-amber-800 dark:text-amber-200 cursor-pointer">
-                El regalo descuenta stock automaticamente
-              </label>
+          {/* Mueve stock (switch style) */}
+          <div className="flex items-center justify-between gap-3 p-3 bg-amber-50 dark:bg-amber-900/20 rounded-lg border border-amber-200 dark:border-amber-800">
+            <div className="flex-1 min-w-0">
+              <p className="text-sm font-medium text-amber-800 dark:text-amber-200">
+                El regalo descuenta stock automáticamente
+              </p>
               <p className="text-xs text-amber-700 dark:text-amber-300 mt-1">
-                Apagalo cuando el regalo es una unidad menor al stock (ej: regalar una botella cuando el stock se lleva por fardo). Vas a ajustar manualmente desde "Ajustar stock" cuando se acumulen suficientes unidades.
+                Apagalo cuando el regalo es una unidad menor al stock (ej: regalar una botella cuando el stock se lleva por fardo).
               </p>
             </div>
+            <button
+              type="button"
+              role="switch"
+              aria-checked={regaloMueveStock}
+              onClick={() => setRegaloMueveStock(v => !v)}
+              className={`relative inline-flex h-6 w-11 flex-shrink-0 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-amber-500 focus:ring-offset-2 ${
+                regaloMueveStock ? 'bg-amber-600' : 'bg-gray-300 dark:bg-gray-600'
+              }`}
+            >
+              <span
+                className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform ${
+                  regaloMueveStock ? 'translate-x-6' : 'translate-x-1'
+                }`}
+              />
+            </button>
           </div>
+
+          {/* Ajuste automatico de stock */}
+          {!regaloMueveStock && (
+            <div className="p-3 bg-blue-50 dark:bg-blue-900/20 rounded-lg border border-blue-200 dark:border-blue-800 space-y-3">
+              <div className="flex items-center justify-between gap-3">
+                <div className="flex-1 min-w-0">
+                  <p className="text-sm font-medium text-blue-800 dark:text-blue-200">
+                    Ajustar stock automáticamente por bloques
+                  </p>
+                  <p className="text-xs text-blue-700 dark:text-blue-300 mt-1">
+                    Cuando se acumulan suficientes bonificaciones como para formar un bloque exacto (ej: 12 botellas = 1 fardo), el sistema descuenta el stock y registra la merma automáticamente. Las unidades que sobran quedan pendientes hasta completar el próximo bloque.
+                  </p>
+                </div>
+                <button
+                  type="button"
+                  role="switch"
+                  aria-checked={ajusteAutomatico}
+                  onClick={() => setAjusteAutomatico(v => !v)}
+                  className={`relative inline-flex h-6 w-11 flex-shrink-0 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 ${
+                    ajusteAutomatico ? 'bg-blue-600' : 'bg-gray-300 dark:bg-gray-600'
+                  }`}
+                >
+                  <span
+                    className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform ${
+                      ajusteAutomatico ? 'translate-x-6' : 'translate-x-1'
+                    }`}
+                  />
+                </button>
+              </div>
+
+              {ajusteAutomatico && (
+                <div className="space-y-3 pt-2 border-t border-blue-200 dark:border-blue-800">
+                  {/* Producto a descontar */}
+                  <div>
+                    <label className="block text-xs font-medium text-blue-700 dark:text-blue-300 mb-1">
+                      Producto del que se descuenta el stock
+                    </label>
+                    {ajusteProductoId && (
+                      <div className="flex items-center gap-2 mb-2 px-3 py-2 bg-white dark:bg-gray-700 border border-blue-200 dark:border-blue-700 rounded-lg">
+                        <span className="text-sm text-gray-700 dark:text-gray-200 flex-1 truncate">
+                          {productos.find(p => String(p.id) === ajusteProductoId)?.nombre || `Producto #${ajusteProductoId}`}
+                        </span>
+                        <button
+                          onClick={() => setAjusteProductoId('')}
+                          className="text-blue-600 hover:text-blue-800 text-xs underline"
+                        >
+                          Cambiar
+                        </button>
+                      </div>
+                    )}
+                    {!ajusteProductoId && (
+                      <>
+                        <div className="relative mb-1">
+                          <Search className="absolute left-3 top-2.5 w-4 h-4 text-gray-400" />
+                          <input
+                            type="text"
+                            value={busquedaAjusteProd}
+                            onChange={e => setBusquedaAjusteProd(e.target.value)}
+                            placeholder="Buscar producto (ej: fardo)..."
+                            className="w-full pl-9 pr-3 py-2 border rounded-lg dark:bg-gray-700 dark:border-gray-600 dark:text-white focus:ring-2 focus:ring-blue-500 focus:outline-none text-sm"
+                          />
+                        </div>
+                        {busquedaAjusteProd.trim() && (
+                          <div className="max-h-32 overflow-y-auto border dark:border-gray-600 rounded-lg divide-y dark:divide-gray-700 bg-white dark:bg-gray-700">
+                            {productosAjusteFiltrados.map(prod => (
+                              <button
+                                key={prod.id}
+                                onClick={() => { setAjusteProductoId(String(prod.id)); setBusquedaAjusteProd('') }}
+                                className="w-full text-left flex items-center gap-2 px-3 py-2 hover:bg-blue-50 dark:hover:bg-blue-900/20 text-sm"
+                              >
+                                <span className="dark:text-white truncate">{prod.nombre}</span>
+                                {prod.codigo && (
+                                  <span className="text-xs text-gray-400 ml-auto shrink-0">{prod.codigo}</span>
+                                )}
+                              </button>
+                            ))}
+                            {productosAjusteFiltrados.length === 0 && (
+                              <p className="text-sm text-gray-400 px-3 py-4 text-center">Sin resultados</p>
+                            )}
+                          </div>
+                        )}
+                      </>
+                    )}
+                  </div>
+
+                  {/* Unidades por bloque y Stock por bloque */}
+                  <div className="grid grid-cols-2 gap-3">
+                    <div>
+                      <label className="block text-xs font-medium text-blue-700 dark:text-blue-300 mb-1">
+                        Unidades bonificadas por bloque
+                      </label>
+                      <input
+                        type="number"
+                        min="1"
+                        value={unidadesPorBloque}
+                        onChange={e => setUnidadesPorBloque(e.target.value)}
+                        placeholder="Ej: 12"
+                        className="w-full px-3 py-2 border rounded-lg dark:bg-gray-700 dark:border-gray-600 dark:text-white focus:ring-2 focus:ring-blue-500 focus:outline-none text-sm"
+                      />
+                      <p className="text-[11px] text-blue-600 dark:text-blue-400 mt-1">
+                        Cuántas unidades regaladas forman un bloque.
+                      </p>
+                    </div>
+                    <div>
+                      <label className="block text-xs font-medium text-blue-700 dark:text-blue-300 mb-1">
+                        Stock descontado por bloque
+                      </label>
+                      <input
+                        type="number"
+                        min="1"
+                        value={stockPorBloque}
+                        onChange={e => setStockPorBloque(e.target.value)}
+                        placeholder="Ej: 1"
+                        className="w-full px-3 py-2 border rounded-lg dark:bg-gray-700 dark:border-gray-600 dark:text-white focus:ring-2 focus:ring-blue-500 focus:outline-none text-sm"
+                      />
+                      <p className="text-[11px] text-blue-600 dark:text-blue-400 mt-1">
+                        Cuánto se descuenta por cada bloque (normalmente 1).
+                      </p>
+                    </div>
+                  </div>
+
+                  {unidadesPorBloque && stockPorBloque && parseInt(unidadesPorBloque) > 0 && parseInt(stockPorBloque) > 0 && (
+                    <p className="text-xs text-blue-700 dark:text-blue-300 bg-blue-100 dark:bg-blue-900/40 rounded px-2 py-1.5">
+                      Resumen: cada {unidadesPorBloque} unidades bonificadas descuentan {stockPorBloque} del stock del producto elegido y generan una merma.
+                    </p>
+                  )}
+                </div>
+              )}
+            </div>
+          )}
 
           {/* Reglas de bonificacion */}
           <div className="p-3 bg-purple-50 dark:bg-purple-900/20 rounded-lg border border-purple-200 dark:border-purple-800">
@@ -370,6 +594,35 @@ export default function ModalPromocion({
                 <p className="text-sm text-gray-400 px-3 py-4 text-center">Sin resultados</p>
               )}
             </div>
+          </div>
+
+          {/* Opciones avanzadas (collapsible) */}
+          <div className="border-t dark:border-gray-700 pt-3">
+            <button
+              type="button"
+              onClick={() => setMostrarAvanzadas(v => !v)}
+              className="flex items-center gap-1.5 text-sm text-gray-600 dark:text-gray-400 hover:text-gray-800 dark:hover:text-gray-200"
+            >
+              {mostrarAvanzadas ? <ChevronDown className="w-4 h-4" /> : <ChevronRight className="w-4 h-4" />}
+              <span>Opciones avanzadas</span>
+            </button>
+            {mostrarAvanzadas && (
+              <div className="mt-3 pl-1">
+                <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                  Prioridad (desempate entre excluyentes)
+                </label>
+                <input
+                  type="number"
+                  value={prioridad}
+                  onChange={e => setPrioridad(e.target.value)}
+                  placeholder="0"
+                  className="w-full px-3 py-2 border rounded-lg dark:bg-gray-700 dark:border-gray-600 dark:text-white focus:ring-2 focus:ring-purple-500 focus:outline-none text-sm"
+                />
+                <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
+                  Sólo se usa entre promos <strong>excluyentes</strong> con igual cantidad de compra. Gana la de mayor prioridad. Casi nunca hace falta tocarlo.
+                </p>
+              </div>
+            )}
           </div>
 
           {error && (

--- a/src/components/vistas/VistaPromociones.tsx
+++ b/src/components/vistas/VistaPromociones.tsx
@@ -5,7 +5,7 @@
  * Muestra lista de promos con productos, reglas, contador de usos y ajuste de stock.
  */
 import React, { useState } from 'react'
-import { Plus, Edit2, Trash2, ToggleLeft, ToggleRight, Package, Gift, AlertTriangle, Check } from 'lucide-react'
+import { Plus, Edit2, Trash2, ToggleLeft, ToggleRight, Package, Gift, AlertTriangle, Check, Layers, Ban, Zap } from 'lucide-react'
 import { fechaLocalISO } from '../../utils/formatters'
 import type { ProductoDB } from '../../types'
 import type { PromocionConDetalles } from '../../hooks/queries/usePromocionesQuery'
@@ -200,6 +200,23 @@ export default function VistaPromociones({
                           {promo.usos_pendientes}/{promo.limite_usos} usos
                         </span>
                       )}
+                      {promo.modo_exclusion === 'excluyente' ? (
+                        <span className="inline-flex items-center gap-1 text-xs px-2 py-0.5 bg-rose-100 text-rose-700 dark:bg-rose-900/30 dark:text-rose-300 rounded-full font-medium">
+                          <Ban className="w-3 h-3" />
+                          Excluyente
+                        </span>
+                      ) : (
+                        <span className="inline-flex items-center gap-1 text-xs px-2 py-0.5 bg-purple-100 text-purple-700 dark:bg-purple-900/30 dark:text-purple-300 rounded-full font-medium">
+                          <Layers className="w-3 h-3" />
+                          Acumulable
+                        </span>
+                      )}
+                      {promo.ajuste_automatico && (
+                        <span className="inline-flex items-center gap-1 text-xs px-2 py-0.5 bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-300 rounded-full font-medium">
+                          <Zap className="w-3 h-3" />
+                          Auto-ajuste
+                        </span>
+                      )}
                     </div>
                     <p className="text-sm text-gray-500 dark:text-gray-400 mt-1">
                       {formatFecha(promo.fecha_inicio)}
@@ -249,11 +266,19 @@ export default function VistaPromociones({
                 {/* Contador de usos */}
                 <div className="mb-3 px-3 py-2 bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-800 rounded-lg flex items-center justify-between">
                   <p className="text-sm text-blue-700 dark:text-blue-300">
-                    <span className="font-medium">Unidades regaladas:</span> {promo.usos_pendientes} pendientes de ajuste
+                    <span className="font-medium">Unidades regaladas:</span>{' '}
+                    {promo.regalo_mueve_stock
+                      ? `${promo.usos_pendientes} entregadas (stock ya descontado)`
+                      : `${promo.usos_pendientes} pendientes de ajuste`}
                   </p>
-                  {promo.usos_pendientes > 0 && (
+                  {promo.usos_pendientes > 0 && !promo.regalo_mueve_stock && !promo.ajuste_automatico && (
                     <span className="text-xs bg-orange-100 dark:bg-orange-900/30 text-orange-700 dark:text-orange-300 px-2 py-0.5 rounded-full font-medium">
                       Ajustar stock
+                    </span>
+                  )}
+                  {promo.ajuste_automatico && promo.unidades_por_bloque && (
+                    <span className="text-xs bg-blue-100 dark:bg-blue-900/30 text-blue-700 dark:text-blue-300 px-2 py-0.5 rounded-full font-medium">
+                      Auto-ajuste cada {promo.unidades_por_bloque} u.
                     </span>
                   )}
                 </div>
@@ -279,8 +304,8 @@ export default function VistaPromociones({
                   </div>
                 </div>
 
-                {/* Ajuste de stock */}
-                {promo.usos_pendientes > 0 && !promo.regalo_mueve_stock && (
+                {/* Ajuste de stock (solo si no es auto-ajuste ni mueve stock directo) */}
+                {promo.usos_pendientes > 0 && !promo.regalo_mueve_stock && !promo.ajuste_automatico && (
                   <div className="mt-3 pt-3 border-t dark:border-gray-700">
                     {ajustandoId === promo.id ? (
                       <div className="space-y-2 p-3 bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800 rounded-lg">

--- a/src/hooks/queries/usePromocionesQuery.ts
+++ b/src/hooks/queries/usePromocionesQuery.ts
@@ -42,6 +42,11 @@ export interface PromocionFormInput {
   reglas: { clave: string; valor: number }[]
   prioridad?: number
   regaloMueveStock?: boolean
+  modoExclusion?: 'acumulable' | 'excluyente'
+  ajusteAutomatico?: boolean
+  ajusteProductoId?: string | null
+  unidadesPorBloque?: number | null
+  stockPorBloque?: number | null
 }
 
 // =============================================================================
@@ -113,6 +118,7 @@ async function fetchPromoMap(): Promise<PromoMap> {
       productoRegaloId: promo.producto_regalo_id ? String(promo.producto_regalo_id) : undefined,
       prioridad: promo.prioridad ?? 0,
       regaloMueveStock: promo.regalo_mueve_stock ?? false,
+      modoExclusion: promo.modo_exclusion ?? 'acumulable',
     }
 
     for (const productoId of productoIds) {
@@ -178,6 +184,11 @@ async function createPromocion(input: PromocionFormInput): Promise<PromocionConD
       producto_regalo_id: input.productoRegaloId ? parseInt(input.productoRegaloId) : null,
       prioridad: input.prioridad ?? 0,
       regalo_mueve_stock: input.regaloMueveStock ?? false,
+      modo_exclusion: input.modoExclusion ?? 'acumulable',
+      ajuste_automatico: input.ajusteAutomatico ?? false,
+      ajuste_producto_id: input.ajusteProductoId ? parseInt(input.ajusteProductoId) : null,
+      unidades_por_bloque: input.unidadesPorBloque ?? null,
+      stock_por_bloque: input.stockPorBloque ?? null,
     }])
     .select()
     .single()
@@ -239,6 +250,11 @@ async function updatePromocion(
       producto_regalo_id: input.productoRegaloId ? parseInt(input.productoRegaloId) : null,
       prioridad: input.prioridad ?? 0,
       regalo_mueve_stock: input.regaloMueveStock ?? false,
+      modo_exclusion: input.modoExclusion ?? 'acumulable',
+      ajuste_automatico: input.ajusteAutomatico ?? false,
+      ajuste_producto_id: input.ajusteProductoId ? parseInt(input.ajusteProductoId) : null,
+      unidades_por_bloque: input.unidadesPorBloque ?? null,
+      stock_por_bloque: input.stockPorBloque ?? null,
     })
     .eq('id', id)
     .select()

--- a/src/types/hooks.ts
+++ b/src/types/hooks.ts
@@ -1364,6 +1364,8 @@ export interface GrupoPrecioFormInput {
 
 export type TipoPromocion = 'bonificacion';
 
+export type ModoExclusionPromocion = 'acumulable' | 'excluyente';
+
 export interface PromocionDB {
   id: string;
   nombre: string;
@@ -1375,6 +1377,11 @@ export interface PromocionDB {
   usos_pendientes?: number;
   prioridad?: number;
   regalo_mueve_stock?: boolean;
+  modo_exclusion?: ModoExclusionPromocion;
+  ajuste_automatico?: boolean;
+  ajuste_producto_id?: string | null;
+  unidades_por_bloque?: number | null;
+  stock_por_bloque?: number | null;
   created_at: string;
   updated_at: string;
 }

--- a/src/utils/promociones.ts
+++ b/src/utils/promociones.ts
@@ -17,6 +17,8 @@ import type { ItemPedido } from './precioMayorista'
 // TIPOS
 // =============================================================================
 
+export type ModoExclusion = 'acumulable' | 'excluyente'
+
 export interface PromocionActiva {
   id: string
   nombre: string
@@ -26,6 +28,7 @@ export interface PromocionActiva {
   productoRegaloId?: string
   prioridad?: number
   regaloMueveStock?: boolean
+  modoExclusion?: ModoExclusion
 }
 
 /** Mapa de productoId → promos activas que aplican */
@@ -61,11 +64,71 @@ export function resolverPromociones(
   const bonificaciones: BonificacionResult[] = []
   const productosConPromo = new Set<string>()
 
-  // Recolectar promos vistas + qué productos del pedido las activaron (para exclusión)
+  // 1. Recolectar promos vistas en el pedido
+  const promosVistas = acumularPromos(items, promoMap, { skipOverride: true })
+
+  for (const entry of promosVistas.values()) {
+    for (const pid of entry.productoIdsEnPedido) productosConPromo.add(pid)
+  }
+
+  // 2. Filtrar solo las que DISPARAN (bloques >= 1) — clave para el fix del bug
+  //    "2+2 con 2 fardos debe ganar sobre 3+1 con prio mayor si 3+1 no llega"
+  const queDisparan: PromoEntry[] = []
+  for (const entry of promosVistas.values()) {
+    const { promo, totalQty } = entry
+    const cantCompra = promo.reglas['cantidad_compra']
+    const cantBonif = promo.reglas['cantidad_bonificacion']
+    if (!cantCompra || !cantBonif || cantCompra <= 0) continue
+    const bloques = Math.floor(totalQty / cantCompra)
+    if (bloques <= 0) continue
+    queDisparan.push(entry)
+  }
+
+  // 3. Separar acumulables (siempre pasan) vs excluyentes (se resuelven por grupo)
+  const acumulables = queDisparan.filter(e => (e.promo.modoExclusion ?? 'acumulable') === 'acumulable')
+  const excluyentes = queDisparan.filter(e => e.promo.modoExclusion === 'excluyente')
+
+  // 4. Entre excluyentes: agrupar por productos compartidos y elegir ganador
+  //    por tier más alto (mayor cantidad_compra), tiebreak prioridad, tiebreak id.
+  const ganadoresExcluyentes = resolverConflictosExcluyentes(excluyentes)
+
+  const finales = [...acumulables, ...ganadoresExcluyentes]
+
+  for (const { promo, totalQty, primerProductoId } of finales) {
+    const cantCompra = promo.reglas['cantidad_compra']
+    const cantBonif = promo.reglas['cantidad_bonificacion']
+    const bloques = Math.floor(totalQty / cantCompra)
+    bonificaciones.push({
+      productoId: promo.productoRegaloId || primerProductoId,
+      promoId: promo.id,
+      promoNombre: promo.nombre,
+      cantidadBonificacion: bloques * cantBonif,
+    })
+  }
+
+  return { bonificaciones, productosConPromo }
+}
+
+// =============================================================================
+// HELPERS DE EXCLUSIÓN
+// =============================================================================
+
+interface PromoEntry {
+  promo: PromocionActiva
+  totalQty: number
+  primerProductoId: string
+  productoIdsEnPedido: Set<string>
+}
+
+function acumularPromos(
+  items: ItemPedido[],
+  promoMap: PromoMap,
+  opts: { skipOverride: boolean },
+): Map<string, PromoEntry> {
   const promosVistas = new Map<string, PromoEntry>()
 
   for (const item of items) {
-    if (item.precioOverride) continue
+    if (opts.skipOverride && item.precioOverride) continue
 
     const promos = promoMap.get(String(item.productoId))
     if (!promos) continue
@@ -85,55 +148,28 @@ export function resolverPromociones(
           productoIdsEnPedido: new Set([String(item.productoId)]),
         })
       }
-
-      productosConPromo.add(String(item.productoId))
     }
   }
 
-  // Exclusión: entre promos que compiten por el mismo producto, gana la de mayor prioridad
-  const resueltas = resolverConflictos(promosVistas)
-
-  for (const { promo, totalQty, primerProductoId } of resueltas) {
-    const cantCompra = promo.reglas['cantidad_compra']
-    const cantBonif = promo.reglas['cantidad_bonificacion']
-
-    if (!cantCompra || !cantBonif || cantCompra <= 0) continue
-
-    const bloques = Math.floor(totalQty / cantCompra)
-    if (bloques <= 0) continue
-
-    bonificaciones.push({
-      productoId: promo.productoRegaloId || primerProductoId,
-      promoId: promo.id,
-      promoNombre: promo.nombre,
-      cantidadBonificacion: bloques * cantBonif,
-    })
-  }
-
-  return { bonificaciones, productosConPromo }
-}
-
-// =============================================================================
-// EXCLUSIÓN POR PRIORIDAD
-// =============================================================================
-
-interface PromoEntry {
-  promo: PromocionActiva
-  totalQty: number
-  primerProductoId: string
-  productoIdsEnPedido: Set<string>
+  return promosVistas
 }
 
 /**
- * Agrupa promos en "componentes conectados" (dos promos son vecinas si comparten
- * al menos un producto del pedido). Por cada componente deja sólo la ganadora:
- * mayor prioridad; en empate, id menor (creada antes) gana.
+ * Union-find: dos promos son "vecinas" si comparten al menos 1 producto del pedido.
+ * Por cada componente conectado, gana la de mayor cantidad_compra (tier más alto).
+ * Desempates: mayor prioridad manual; luego id menor (promo creada antes).
+ *
+ * Importante: sólo opera sobre promos que YA disparan. Así, si "3+1 fardo" (tier
+ * superior) no llega al umbral, la "2+2 botellas" de tier menor aplica igual.
  */
-function resolverConflictos(promosVistas: Map<string, PromoEntry>): PromoEntry[] {
-  if (promosVistas.size === 0) return []
+function resolverConflictosExcluyentes(excluyentes: PromoEntry[]): PromoEntry[] {
+  if (excluyentes.length === 0) return []
+
+  const byId = new Map<string, PromoEntry>()
+  for (const e of excluyentes) byId.set(e.promo.id, e)
 
   const parent = new Map<string, string>()
-  for (const id of promosVistas.keys()) parent.set(id, id)
+  for (const id of byId.keys()) parent.set(id, id)
 
   const find = (x: string): string => {
     let r = x
@@ -152,9 +188,9 @@ function resolverConflictos(promosVistas: Map<string, PromoEntry>): PromoEntry[]
     if (ra !== rb) parent.set(ra, rb)
   }
 
-  // Para cada producto del pedido, unir todas las promos que lo cubren
+  // Indexar productos → promos (entre las excluyentes que disparan)
   const productoToPromos = new Map<string, string[]>()
-  for (const [promoId, entry] of promosVistas) {
+  for (const [promoId, entry] of byId) {
     for (const pid of entry.productoIdsEnPedido) {
       const arr = productoToPromos.get(pid) || []
       arr.push(promoId)
@@ -165,9 +201,9 @@ function resolverConflictos(promosVistas: Map<string, PromoEntry>): PromoEntry[]
     for (let i = 1; i < promoIds.length; i++) union(promoIds[0], promoIds[i])
   }
 
-  // Por componente elegir mejor (mayor prioridad, tiebreak id menor)
+  // Agrupar por componente y elegir ganador: tier más alto, luego prioridad, luego id
   const porComponente = new Map<string, PromoEntry[]>()
-  for (const [promoId, entry] of promosVistas) {
+  for (const [promoId, entry] of byId) {
     const root = find(promoId)
     const arr = porComponente.get(root) || []
     arr.push(entry)
@@ -177,6 +213,9 @@ function resolverConflictos(promosVistas: Map<string, PromoEntry>): PromoEntry[]
   const ganadores: PromoEntry[] = []
   for (const grupo of porComponente.values()) {
     grupo.sort((a, b) => {
+      const ca = a.promo.reglas['cantidad_compra'] ?? 0
+      const cb = b.promo.reglas['cantidad_compra'] ?? 0
+      if (ca !== cb) return cb - ca // tier más alto gana (mayor cantidad_compra)
       const pa = a.promo.prioridad ?? 0
       const pb = b.promo.prioridad ?? 0
       if (pa !== pb) return pb - pa
@@ -203,40 +242,30 @@ export function calcularFaltanteParaBonificacion(
 ): Array<{ productoId: string; promoNombre: string; faltante: number; bonificacion: number }> {
   const faltantes: Array<{ productoId: string; promoNombre: string; faltante: number; bonificacion: number }> = []
 
-  const promosAcumuladas = new Map<string, PromoEntry>()
+  // Mostramos nudges para promos que AÚN NO disparan. Para promos acumulables,
+  // no hay conflicto. Para excluyentes, evitamos nudgear la que ya perdería el
+  // conflicto con otra excluyente del mismo grupo que SÍ dispara y tiene mayor tier.
+  const promosAcumuladas = acumularPromos(items, promoMap, { skipOverride: false })
 
-  for (const item of items) {
-    const promos = promoMap.get(String(item.productoId))
-    if (!promos) continue
+  const ganadorasEnMismoGrupo = calcularGanadoresActualesPorGrupo(promosAcumuladas)
 
-    for (const promo of promos) {
-      if (promo.tipo !== 'bonificacion') continue
-
-      const existing = promosAcumuladas.get(promo.id)
-      if (existing) {
-        existing.totalQty += item.cantidad
-        existing.productoIdsEnPedido.add(String(item.productoId))
-      } else {
-        promosAcumuladas.set(promo.id, {
-          promo,
-          totalQty: item.cantidad,
-          primerProductoId: String(item.productoId),
-          productoIdsEnPedido: new Set([String(item.productoId)]),
-        })
-      }
-    }
-  }
-
-  // No nudgear promos que ya perdieron el conflicto por prioridad
-  const ganadoras = resolverConflictos(promosAcumuladas)
-
-  for (const { promo, totalQty, primerProductoId } of ganadoras) {
+  for (const [promoId, { promo, totalQty, primerProductoId, productoIdsEnPedido }] of promosAcumuladas) {
     const cantCompra = promo.reglas['cantidad_compra']
     const cantBonif = promo.reglas['cantidad_bonificacion']
     if (!cantCompra || !cantBonif) continue
 
     const resto = totalQty % cantCompra
     if (resto === 0) continue
+
+    // Si es excluyente y hay otra excluyente en el mismo grupo que ya dispara
+    // y tiene tier superior, no nudgeamos (esta promo está bloqueada).
+    if (promo.modoExclusion === 'excluyente') {
+      const ganadora = findGanadoraEnGrupo(ganadorasEnMismoGrupo, productoIdsEnPedido)
+      if (ganadora && ganadora.promo.id !== promoId) {
+        const cantCompraGanadora = ganadora.promo.reglas['cantidad_compra'] ?? 0
+        if (cantCompraGanadora > cantCompra) continue
+      }
+    }
 
     const faltante = cantCompra - resto
     if (faltante <= Math.ceil(cantCompra * 0.5)) {
@@ -250,4 +279,41 @@ export function calcularFaltanteParaBonificacion(
   }
 
   return faltantes
+}
+
+/**
+ * Para cada producto del pedido, indica cuál promo excluyente (de las que ya
+ * disparan) es la ganadora actual. Se usa para suprimir nudges de excluyentes
+ * perdedoras.
+ */
+function calcularGanadoresActualesPorGrupo(
+  promosVistas: Map<string, PromoEntry>,
+): Map<string, PromoEntry> {
+  const disparan: PromoEntry[] = []
+  for (const entry of promosVistas.values()) {
+    const cantCompra = entry.promo.reglas['cantidad_compra']
+    if (!cantCompra || cantCompra <= 0) continue
+    if (Math.floor(entry.totalQty / cantCompra) <= 0) continue
+    if (entry.promo.modoExclusion !== 'excluyente') continue
+    disparan.push(entry)
+  }
+  const ganadoresPorProducto = new Map<string, PromoEntry>()
+  const ganadores = resolverConflictosExcluyentes(disparan)
+  for (const g of ganadores) {
+    for (const pid of g.productoIdsEnPedido) {
+      ganadoresPorProducto.set(pid, g)
+    }
+  }
+  return ganadoresPorProducto
+}
+
+function findGanadoraEnGrupo(
+  ganadoresPorProducto: Map<string, PromoEntry>,
+  productoIds: Set<string>,
+): PromoEntry | undefined {
+  for (const pid of productoIds) {
+    const g = ganadoresPorProducto.get(pid)
+    if (g) return g
+  }
+  return undefined
 }

--- a/supabase/migrations/20260420_promociones_ux_v2.sql
+++ b/supabase/migrations/20260420_promociones_ux_v2.sql
@@ -1,0 +1,207 @@
+-- Promociones UX v2: modo acumulable/excluyente + auto-ajuste de stock
+--
+-- Reemplaza el concepto contraintuitivo de "prioridad number" por:
+--   - modo_exclusion: 'acumulable' (siempre aplica) | 'excluyente' (mutuamente
+--     exclusiva con otras excluyentes sobre los mismos productos)
+--   - Entre excluyentes que disparan juntas, gana la de mayor cantidad_compra
+--     (el tier mas alto). Prioridad queda como override opcional.
+--
+-- Agrega auto-ajuste de stock: cuando se regalan bloques completos (ej: 12
+-- botellas = 1 fardo) el stock se descuenta solo. Las unidades sueltas que no
+-- completan bloque quedan pendientes hasta completarse.
+
+-- ============================================================================
+-- 1. Columnas nuevas en promociones
+-- ============================================================================
+
+ALTER TABLE promociones
+  ADD COLUMN IF NOT EXISTS modo_exclusion TEXT NOT NULL DEFAULT 'acumulable'
+    CHECK (modo_exclusion IN ('acumulable', 'excluyente')),
+  ADD COLUMN IF NOT EXISTS ajuste_automatico BOOLEAN NOT NULL DEFAULT FALSE,
+  ADD COLUMN IF NOT EXISTS ajuste_producto_id BIGINT REFERENCES productos(id) ON DELETE SET NULL,
+  ADD COLUMN IF NOT EXISTS unidades_por_bloque INT,
+  ADD COLUMN IF NOT EXISTS stock_por_bloque INT;
+
+CREATE INDEX IF NOT EXISTS idx_promociones_modo_exclusion
+  ON promociones(sucursal_id, activo, modo_exclusion);
+
+-- ============================================================================
+-- 2. crear_pedido_completo: auto-ajuste por bloque completo
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION public.crear_pedido_completo(
+  p_cliente_id bigint,
+  p_total numeric,
+  p_usuario_id uuid,
+  p_items jsonb,
+  p_notas text DEFAULT NULL::text,
+  p_forma_pago text DEFAULT 'efectivo'::text,
+  p_estado_pago text DEFAULT 'pendiente'::text,
+  p_fecha date DEFAULT NULL::date,
+  p_tipo_factura text DEFAULT 'ZZ'::text,
+  p_total_neto numeric DEFAULT NULL::numeric,
+  p_total_iva numeric DEFAULT 0,
+  p_fecha_entrega_programada date DEFAULT NULL::date
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $function$
+DECLARE
+  v_sucursal BIGINT := current_sucursal_id();
+  v_pedido_id INT; item JSONB; v_producto_id INT; v_cantidad INT;
+  v_precio_unitario DECIMAL; v_es_bonificacion BOOLEAN; v_promocion_id BIGINT;
+  v_neto_unitario DECIMAL; v_iva_unitario DECIMAL; v_imp_internos_unitario DECIMAL;
+  v_porcentaje_iva DECIMAL; v_stock_actual INT; v_producto_nombre TEXT;
+  errores TEXT[] := '{}'; v_user_role TEXT;
+  v_cantidades_totales JSONB := '{}'::JSONB; v_cant_acumulada INT;
+  v_regalo_mueve_stock BOOLEAN;
+  v_fecha_pedido DATE := COALESCE(
+    p_fecha,
+    (now() AT TIME ZONE 'America/Argentina/Buenos_Aires')::date
+  );
+  v_fecha_entrega DATE := COALESCE(
+    p_fecha_entrega_programada,
+    (v_fecha_pedido + INTERVAL '1 day')::date
+  );
+  -- Auto-ajuste
+  v_promo RECORD;
+  v_usos_pendientes_actual INT;
+  v_bloques_completos INT;
+  v_ajustar_usos INT;
+  v_ajustar_stock INT;
+  v_stock_ajuste_anterior INT;
+  v_stock_ajuste_nuevo INT;
+  v_ajuste_producto_nombre TEXT;
+  v_merma_id BIGINT;
+BEGIN
+  IF v_sucursal IS NULL THEN RETURN jsonb_build_object('success', false, 'errores', jsonb_build_array('No se pudo determinar la sucursal activa')); END IF;
+  IF p_usuario_id IS DISTINCT FROM auth.uid() THEN RETURN jsonb_build_object('success', false, 'errores', jsonb_build_array('ID de usuario no coincide con la sesion autenticada')); END IF;
+  SELECT rol INTO v_user_role FROM perfiles WHERE id = p_usuario_id;
+  IF v_user_role IS NULL OR v_user_role NOT IN ('admin', 'preventista') THEN RETURN jsonb_build_object('success', false, 'errores', jsonb_build_array('No tiene permisos para crear pedidos')); END IF;
+
+  FOR item IN SELECT * FROM jsonb_array_elements(p_items) LOOP
+    v_producto_id := (item->>'producto_id')::INT; v_cantidad := (item->>'cantidad')::INT;
+    v_es_bonificacion := COALESCE((item->>'es_bonificacion')::BOOLEAN, false);
+    IF v_cantidad IS NULL OR v_cantidad <= 0 THEN errores := array_append(errores, 'Cantidad invalida para producto ID ' || v_producto_id); CONTINUE; END IF;
+
+    -- Sumar al total por producto solo si la bonif no mueve stock. Si mueve
+    -- stock, tambien hay que validar stock igual que una venta normal.
+    IF v_es_bonificacion THEN
+      v_promocion_id := (item->>'promocion_id')::BIGINT;
+      IF v_promocion_id IS NOT NULL THEN
+        SELECT regalo_mueve_stock INTO v_regalo_mueve_stock
+        FROM promociones WHERE id = v_promocion_id AND sucursal_id = v_sucursal;
+        IF COALESCE(v_regalo_mueve_stock, FALSE) THEN
+          v_cant_acumulada := COALESCE((v_cantidades_totales->>v_producto_id::TEXT)::INT, 0) + v_cantidad;
+          v_cantidades_totales := v_cantidades_totales || jsonb_build_object(v_producto_id::TEXT, v_cant_acumulada);
+        END IF;
+      END IF;
+    ELSE
+      v_cant_acumulada := COALESCE((v_cantidades_totales->>v_producto_id::TEXT)::INT, 0) + v_cantidad;
+      v_cantidades_totales := v_cantidades_totales || jsonb_build_object(v_producto_id::TEXT, v_cant_acumulada);
+    END IF;
+  END LOOP;
+
+  FOR v_producto_id IN SELECT (key)::INT FROM jsonb_each_text(v_cantidades_totales) LOOP
+    v_cantidad := (v_cantidades_totales->>v_producto_id::TEXT)::INT;
+    SELECT stock, nombre INTO v_stock_actual, v_producto_nombre FROM productos WHERE id = v_producto_id AND sucursal_id = v_sucursal FOR UPDATE;
+    IF v_stock_actual IS NULL THEN errores := array_append(errores, 'Producto ID ' || v_producto_id || ' no encontrado');
+    ELSIF v_stock_actual < v_cantidad THEN errores := array_append(errores, v_producto_nombre || ': stock insuficiente (disponible: ' || v_stock_actual || ', solicitado: ' || v_cantidad || ')'); END IF;
+  END LOOP;
+
+  IF array_length(errores, 1) > 0 THEN RETURN jsonb_build_object('success', false, 'errores', to_jsonb(errores)); END IF;
+
+  INSERT INTO pedidos (cliente_id, fecha, total, total_neto, total_iva, tipo_factura, estado, usuario_id, stock_descontado, notas, forma_pago, estado_pago, fecha_entrega_programada, sucursal_id)
+  VALUES (p_cliente_id, v_fecha_pedido, p_total, COALESCE(p_total_neto, p_total), COALESCE(p_total_iva, 0), COALESCE(p_tipo_factura, 'ZZ'), 'pendiente', p_usuario_id, true, p_notas, p_forma_pago, p_estado_pago, v_fecha_entrega, v_sucursal)
+  RETURNING id INTO v_pedido_id;
+
+  FOR item IN SELECT * FROM jsonb_array_elements(p_items) LOOP
+    v_producto_id := (item->>'producto_id')::INT; v_cantidad := (item->>'cantidad')::INT;
+    v_precio_unitario := (item->>'precio_unitario')::DECIMAL;
+    v_es_bonificacion := COALESCE((item->>'es_bonificacion')::BOOLEAN, false);
+    v_promocion_id := (item->>'promocion_id')::BIGINT;
+    v_neto_unitario := (item->>'neto_unitario')::DECIMAL;
+    v_iva_unitario := COALESCE((item->>'iva_unitario')::DECIMAL, 0);
+    v_imp_internos_unitario := COALESCE((item->>'impuestos_internos_unitario')::DECIMAL, 0);
+    v_porcentaje_iva := COALESCE((item->>'porcentaje_iva')::DECIMAL, 0);
+    INSERT INTO pedido_items (pedido_id, producto_id, cantidad, precio_unitario, subtotal, es_bonificacion, promocion_id, neto_unitario, iva_unitario, impuestos_internos_unitario, porcentaje_iva, sucursal_id)
+    VALUES (v_pedido_id, v_producto_id, v_cantidad, v_precio_unitario, v_cantidad * v_precio_unitario, v_es_bonificacion, v_promocion_id, v_neto_unitario, v_iva_unitario, v_imp_internos_unitario, v_porcentaje_iva, v_sucursal);
+
+    -- Stock movement
+    IF NOT v_es_bonificacion THEN
+      UPDATE productos SET stock = stock - v_cantidad WHERE id = v_producto_id AND sucursal_id = v_sucursal;
+    ELSIF v_promocion_id IS NOT NULL THEN
+      SELECT regalo_mueve_stock INTO v_regalo_mueve_stock
+      FROM promociones WHERE id = v_promocion_id AND sucursal_id = v_sucursal;
+      IF COALESCE(v_regalo_mueve_stock, FALSE) THEN
+        UPDATE productos SET stock = stock - v_cantidad WHERE id = v_producto_id AND sucursal_id = v_sucursal;
+      END IF;
+    END IF;
+
+    -- Incrementar usos_pendientes y correr auto-ajuste si aplica
+    IF v_es_bonificacion AND v_promocion_id IS NOT NULL THEN
+      UPDATE promociones SET usos_pendientes = usos_pendientes + v_cantidad
+      WHERE id = v_promocion_id AND sucursal_id = v_sucursal;
+
+      SELECT id, nombre, ajuste_automatico, ajuste_producto_id, unidades_por_bloque,
+             stock_por_bloque, usos_pendientes
+      INTO v_promo
+      FROM promociones WHERE id = v_promocion_id AND sucursal_id = v_sucursal FOR UPDATE;
+
+      IF v_promo.ajuste_automatico
+         AND v_promo.ajuste_producto_id IS NOT NULL
+         AND COALESCE(v_promo.unidades_por_bloque, 0) > 0
+         AND COALESCE(v_promo.stock_por_bloque, 0) > 0 THEN
+        v_usos_pendientes_actual := v_promo.usos_pendientes;
+        v_bloques_completos := v_usos_pendientes_actual / v_promo.unidades_por_bloque;
+        IF v_bloques_completos > 0 THEN
+          v_ajustar_usos := v_bloques_completos * v_promo.unidades_por_bloque;
+          v_ajustar_stock := v_bloques_completos * v_promo.stock_por_bloque;
+
+          SELECT stock, nombre INTO v_stock_ajuste_anterior, v_ajuste_producto_nombre
+          FROM productos WHERE id = v_promo.ajuste_producto_id AND sucursal_id = v_sucursal FOR UPDATE;
+
+          IF v_stock_ajuste_anterior IS NULL THEN
+            RAISE EXCEPTION 'Auto-ajuste: producto destino no encontrado (promo %)', v_promocion_id;
+          END IF;
+          IF v_stock_ajuste_anterior < v_ajustar_stock THEN
+            RAISE EXCEPTION 'Auto-ajuste: stock insuficiente en % (disponible: %, requerido: %)',
+              v_ajuste_producto_nombre, v_stock_ajuste_anterior, v_ajustar_stock;
+          END IF;
+
+          v_stock_ajuste_nuevo := v_stock_ajuste_anterior - v_ajustar_stock;
+
+          INSERT INTO mermas_stock (
+            producto_id, cantidad, motivo, observaciones,
+            stock_anterior, stock_nuevo, usuario_id, sucursal_id
+          ) VALUES (
+            v_promo.ajuste_producto_id, v_ajustar_stock, 'promociones',
+            'Auto-ajuste (Promo: ' || v_promo.nombre || ', Pedido #' || v_pedido_id || ')',
+            v_stock_ajuste_anterior, v_stock_ajuste_nuevo, p_usuario_id, v_sucursal
+          ) RETURNING id INTO v_merma_id;
+
+          UPDATE productos SET stock = v_stock_ajuste_nuevo, updated_at = NOW()
+          WHERE id = v_promo.ajuste_producto_id AND sucursal_id = v_sucursal;
+
+          INSERT INTO promo_ajustes (
+            promocion_id, usos_ajustados, unidades_ajustadas, producto_id,
+            merma_id, usuario_id, observaciones, sucursal_id
+          ) VALUES (
+            v_promocion_id, v_ajustar_usos, v_ajustar_stock, v_promo.ajuste_producto_id,
+            v_merma_id, p_usuario_id,
+            'Auto-ajuste por pedido #' || v_pedido_id, v_sucursal
+          );
+
+          UPDATE promociones
+          SET usos_pendientes = GREATEST(usos_pendientes - v_ajustar_usos, 0)
+          WHERE id = v_promocion_id AND sucursal_id = v_sucursal;
+        END IF;
+      END IF;
+    END IF;
+  END LOOP;
+
+  RETURN jsonb_build_object('success', true, 'pedido_id', v_pedido_id);
+END;
+$function$;


### PR DESCRIPTION
…r bloques

- Reemplaza "prioridad" numérica por selector acumulable/excluyente más intuitivo. Entre excluyentes que disparan, gana la de mayor cantidad_compra (tier); prioridad queda sólo como desempate, oculta en "Opciones avanzadas".
- Fix bug: promos de tier menor ya no quedan bloqueadas si la de tier mayor no llega a activarse (2+2 funciona aunque 3+1 con mayor prio no dispare).
- Toggle "mueve stock" ahora con estilo switch en vez de checkbox.
- Nueva opción "Ajuste automático por bloques": cuando se acumulan N unidades bonificadas exactas (ej: 12 botellas = 1 fardo), el RPC descuenta stock e inserta merma automáticamente. Las unidades sobrantes quedan pendientes hasta el próximo bloque — evita ajustes parciales que rompen el stock.
- VistaPromociones muestra badges de modo (acumulable/excluyente) y auto-ajuste; oculta el UI manual de ajuste cuando el auto-ajuste está activo.