### PR TITLE
fix: incluir sucursal_id al crear cliente/producto/proveedor

### DIFF
--- a/src/hooks/queries/useProductosQuery.ts
+++ b/src/hooks/queries/useProductosQuery.ts
@@ -51,7 +51,13 @@ async function fetchProductosStockBajo(umbral: number): Promise<ProductoDB[]> {
 }
 
 // Mutation functions
-async function createProducto(producto: ProductoFormInput): Promise<ProductoDB> {
+async function createProducto(producto: ProductoFormInput, sucursalId: number | null): Promise<ProductoDB> {
+  // La RLS multi-tenant requiere sucursal_id = current_sucursal_id() y la
+  // columna es NOT NULL. Sin esto el INSERT falla.
+  if (sucursalId == null) {
+    throw new Error('No hay sucursal activa. Recargá la página e intentá de nuevo.')
+  }
+
   // Validar código duplicado
   if (producto.codigo) {
     const { data: existente } = await supabase
@@ -78,7 +84,8 @@ async function createProducto(producto: ProductoFormInput): Promise<ProductoDB> 
       costo_sin_iva: producto.costo_sin_iva ? parseFloat(String(producto.costo_sin_iva)) : null,
       costo_con_iva: producto.costo_con_iva ? parseFloat(String(producto.costo_con_iva)) : null,
       impuestos_internos: producto.impuestos_internos ? parseFloat(String(producto.impuestos_internos)) : null,
-      precio_sin_iva: producto.precio_sin_iva ? parseFloat(String(producto.precio_sin_iva)) : null
+      precio_sin_iva: producto.precio_sin_iva ? parseFloat(String(producto.precio_sin_iva)) : null,
+      sucursal_id: sucursalId
     }])
     .select()
     .single()
@@ -167,7 +174,7 @@ export function useCrearProductoMutation() {
   const { currentSucursalId } = useSucursal()
 
   return useMutation({
-    mutationFn: createProducto,
+    mutationFn: (producto: ProductoFormInput) => createProducto(producto, currentSucursalId),
     onSuccess: (newProducto) => {
       // Actualizar cache de lista
       queryClient.setQueryData<ProductoDB[]>(productosKeys.lists(currentSucursalId), (old) => {

--- a/src/hooks/queries/useProveedoresQuery.ts
+++ b/src/hooks/queries/useProveedoresQuery.ts
@@ -57,7 +57,13 @@ async function fetchProveedorById(id: string): Promise<ProveedorDBExtended | nul
 }
 
 // Mutation functions
-async function createProveedor(proveedor: ProveedorFormInputExtended): Promise<ProveedorDBExtended> {
+async function createProveedor(proveedor: ProveedorFormInputExtended, sucursalId: number | null): Promise<ProveedorDBExtended> {
+  // La RLS multi-tenant requiere sucursal_id = current_sucursal_id() y la
+  // columna es NOT NULL. Sin esto el INSERT falla.
+  if (sucursalId == null) {
+    throw new Error('No hay sucursal activa. Recargá la página e intentá de nuevo.')
+  }
+
   // Validar CUIT duplicado
   if (proveedor.cuit) {
     const cuitLimpio = proveedor.cuit.replace(/[-\s]/g, '')
@@ -95,7 +101,8 @@ async function createProveedor(proveedor: ProveedorFormInputExtended): Promise<P
       email: proveedor.email || null,
       contacto: proveedor.contacto || null,
       notas: proveedor.notas || null,
-      activo: true
+      activo: true,
+      sucursal_id: sucursalId
     }])
     .select()
     .single()
@@ -207,7 +214,7 @@ export function useCrearProveedorMutation() {
   const { currentSucursalId } = useSucursal()
 
   return useMutation({
-    mutationFn: createProveedor,
+    mutationFn: (proveedor: ProveedorFormInputExtended) => createProveedor(proveedor, currentSucursalId),
     onSuccess: (newProveedor) => {
       // Actualizar cache de lista
       queryClient.setQueryData<ProveedorDBExtended[]>(proveedoresKeys.lists(currentSucursalId), (old) => {


### PR DESCRIPTION
## Problema

Los preventistas (y cualquier rol) veían **"Error al crear cliente"** al intentar dar de alta un cliente desde el modal de "Nuevo Pedido". El mismo error ocurría al crear productos/proveedores rápidos desde `ModalCompra`.

## Causa raíz

Las migraciones multi-tenant `057` y `058` introdujeron:
- `sucursal_id BIGINT NOT NULL` en `clientes`, `productos` y `proveedores`.
- Políticas RLS que exigen `sucursal_id = current_sucursal_id()` en el `WITH CHECK` del INSERT.

Los hooks de mutación (`useCrearClienteMutation`, `useCrearProductoMutation`, `useCrearProveedorMutation`) nunca enviaban `sucursal_id` en el payload, así que el INSERT fallaba por NOT NULL + violación de RLS.

## Solución

Los tres hooks ahora toman `currentSucursalId` del `SucursalContext` y lo inyectan en el INSERT. Si no hay sucursal activa se lanza un error claro en lugar de un mensaje genérico.

Archivos:
- `src/hooks/queries/useClientesQuery.ts`
- `src/hooks/queries/useProductosQuery.ts`
- `src/hooks/queries/useProveedoresQuery.ts`

## Flujos cubiertos

- `ModalPedido` → "Crear y seleccionar" (alta rápida de cliente).
- `ClientesContainer` → alta de cliente.
- `ModalCompra` → "Crear producto rápido".
- `ProductosContainer` → alta de producto.
- `ModalCompra` → alta rápida de proveedor.

## Sin migraciones

El esquema y las RLS ya estaban bien — el fix es 100% frontend.

## Test plan

- [ ] Login como preventista, abrir "Nuevo Pedido", crear un cliente nuevo y confirmar que se selecciona sin error.
- [ ] Login como admin, ir a Compras → nueva compra → "Crear producto rápido" y verificar alta.
- [ ] Login como admin, Compras → nuevo proveedor rápido.
- [ ] Verificar que el cliente/producto/proveedor creado quede scopeado a la sucursal activa (cambiando de sucursal no debería aparecer).

https://claude.ai/code/session_01WSoHy1GFVdDYs6YQMfqYTj