### PR TITLE
chore(fase-0): fortalecer salvaguardas de deploy

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,7 +1,10 @@
-# Pre-commit hook: Verifica secretos y ejecuta lint
+# Pre-commit hook: Verifica secretos, ejecuta lint y corre tests
 
 # Verificar secretos antes del commit
 ./scripts/check-secrets.sh
 
 # Ejecutar lint en archivos staged
 npx lint-staged
+
+# Ejecutar unit tests
+npm run test:run

--- a/docs/DEPLOY_GUIDE.md
+++ b/docs/DEPLOY_GUIDE.md
@@ -1,0 +1,160 @@
+# Guía de Deploy
+
+## Resumen
+
+El código llega a producción en **Coolify** (Hostinger) automáticamente al mergear a `main` vía webhook, y opcionalmente se despliega a **Vercel** (staging) mediante un `workflow_dispatch` manual. Todo push o PR a `main`/`develop` dispara primero el workflow de CI (`.github/workflows/ci.yml`) con lint, typecheck, tests, auditoría de seguridad, build y E2E antes de cualquier deploy.
+
+### Comandos rápidos
+
+```bash
+# Deploy manual a staging (Vercel)
+gh workflow run deploy.yml -f environment=staging
+
+# Re-disparar deploy a producción (Coolify) sobre el main actual
+gh workflow run deploy.yml -f environment=production
+
+# Ver estado del último run de deploy
+gh run list --workflow=deploy.yml --limit 5
+
+# Ver logs del último run del CI
+gh run view --log
+```
+
+## Entornos
+
+| Entorno | Plataforma | Trigger | URL | Vars de build |
+|---------|-----------|---------|-----|---------------|
+| Producción | Coolify (Docker + Nginx) | Push a `main` (webhook `COOLIFY_WEBHOOK_URL`) | Dominio productivo (Hostinger) | `VITE_SUPABASE_URL`, `VITE_SUPABASE_ANON_KEY`, `VITE_SENTRY_DSN`, `VITE_GOOGLE_API_KEY`, `VITE_N8N_WEBHOOK_URL`, `VITE_N8N_FACTURA_WEBHOOK_URL`, `VITE_APP_VERSION`, `N8N_UPSTREAM` (runtime) |
+| Staging | Vercel | `workflow_dispatch` manual con `environment=staging` | Preview URL Vercel | `STAGING_SUPABASE_URL`, `STAGING_SUPABASE_ANON_KEY`, `SENTRY_DSN`, `VITE_GOOGLE_API_KEY`, `VITE_N8N_WEBHOOK_URL`, `VITE_N8N_FACTURA_WEBHOOK_URL` |
+| Local | Vite dev server | `npm run dev` | `http://localhost:5173` | `.env` local (ver `.env.example`) |
+
+## Flujo de Deploy a Producción
+
+Cuando se mergea un PR a `main`:
+
+1. **CI (`.github/workflows/ci.yml`)** corre en el push a `main`:
+   - `lint` - ESLint
+   - `typecheck` - TypeScript
+   - `test` - Vitest (unit + coverage)
+   - `security` - `npm audit --audit-level=high` + `npm run check-secrets`
+   - `build` - depende de `lint`, `test`, `typecheck`, `security`
+   - `e2e` - Playwright (Chromium), depende de `build`
+2. **Deploy (`.github/workflows/deploy.yml`)** corre en paralelo al CI en el mismo push a `main`:
+   - Job `deploy-coolify` dispara `POST` al `COOLIFY_WEBHOOK_URL` (timeout 30s).
+   - Coolify hace `git pull` del repo y construye el `Dockerfile` (Node 20-alpine → Nginx 1.27-alpine, multi-stage).
+   - El contenedor tiene un `HEALTHCHECK` cada 30s (`wget http://localhost/`), con `start-period=5s` y 3 reintentos.
+3. Coolify levanta el nuevo contenedor; Nginx sirve `/usr/share/nginx/html` y proxy-pasea `/api/n8n/` al `N8N_UPSTREAM` configurado en runtime.
+
+> Nota: CI y deploy son workflows separados. El deploy a Coolify **no espera** a que CI termine; si CI falla después de mergear, hay que revertir manualmente (ver `docs/ROLLBACK.md`). La branch protection (abajo) es lo que evita que llegue código sin CI verde a `main`.
+
+### Timing esperado
+
+| Paso | Duración típica |
+|------|-----------------|
+| CI completo (lint + typecheck + test + security + build + e2e) | 6-10 min |
+| Webhook Coolify → nuevo contenedor `healthy` | 2-4 min |
+| Service worker hereda bundle nuevo en clientes activos | Siguiente reload completo |
+
+Si algún paso se dispara al doble de ese tiempo sin avanzar, revisar Actions y los logs de Coolify.
+
+## Deploy a Staging
+
+Staging es manual. Desde la terminal (requiere `gh` autenticado):
+
+```bash
+gh workflow run deploy.yml -f environment=staging
+```
+
+O desde la UI: **Actions → Deploy → Run workflow → environment: staging**.
+
+El job `deploy-staging`:
+1. Instala dependencias (`npm ci`).
+2. Corre `npm run test:run`.
+3. Buildea con los secrets `STAGING_SUPABASE_URL` / `STAGING_SUPABASE_ANON_KEY` (apunta a un proyecto Supabase distinto al de producción).
+4. Sube a Vercel con `amondnet/vercel-action@v25` (requiere `VERCEL_TOKEN`, `VERCEL_ORG_ID`, `VERCEL_PROJECT_ID`).
+5. Si el deploy falla, sube el `dist/` como artifact `staging-build-<sha>` (retención 30 días) para deploy manual.
+
+### Re-deploy manual a producción
+
+Si el webhook de Coolify no se disparó (por ejemplo falla transitoria):
+
+```bash
+gh workflow run deploy.yml -f environment=production
+```
+
+Esto vuelve a correr `deploy-coolify` sobre el `main` actual.
+
+## Branch Protection Policy
+
+**Estado actual:** debe configurarse manualmente en GitHub. Esta guía documenta el target.
+
+Ir a **Settings → Branches → Add branch protection rule** (o editar la existente) para `main` y activar:
+
+- [x] **Require a pull request before merging**
+  - [x] Require approvals: **1** (mínimo)
+  - [x] Dismiss stale pull request approvals when new commits are pushed
+- [x] **Require status checks to pass before merging**
+  - [x] **Require branches to be up to date before merging**
+  - Status checks requeridos (nombres exactos de los jobs de `ci.yml`):
+    - `Lint`
+    - `TypeScript Check`
+    - `Unit Tests`
+    - `Security Audit`
+    - `Build`
+    - `E2E Tests`
+- [x] **Require conversation resolution before merging**
+- [x] **Do not allow bypassing the above settings** (aplica también a admins)
+- [ ] Allow force pushes: **desactivado**
+- [ ] Allow deletions: **desactivado**
+
+> Los nombres de los status checks deben coincidir con el `name:` de cada job, no con el `id`. Si se renombra un job en `ci.yml`, hay que actualizar el nombre acá o el PR quedará bloqueado esperando un check que no existe.
+
+## Variables de Entorno Críticas
+
+Fuente: `.env.example`. Todas las `VITE_*` quedan horneadas en el bundle en build-time (Vite las reemplaza como strings estáticos) — **nunca poner secretos reales** en variables `VITE_*`.
+
+| Variable | Requerido | Descripción |
+|----------|-----------|-------------|
+| `VITE_SUPABASE_URL` | Sí | URL del proyecto Supabase (`https://<ref>.supabase.co`). |
+| `VITE_SUPABASE_ANON_KEY` | Sí | Clave anon pública de Supabase. RLS protege los datos; no es un secreto. |
+| `VITE_GOOGLE_API_KEY` | No | Google Routes API key para optimización de rutas en cliente. Preferiblemente usar n8n en backend. |
+| `VITE_N8N_WEBHOOK_URL` | Sí | Ruta al webhook de optimización de ruta. En prod: `/api/n8n/webhook/optimizar-ruta` (proxy nginx). |
+| `VITE_N8N_FACTURA_WEBHOOK_URL` | Sí | Ruta al webhook de escaneo de factura. En prod: `/api/n8n/webhook/escanear-factura`. |
+| `VITE_SENTRY_DSN` | Recomendado | DSN de Sentry para reportar errores de producción. Vacío desactiva Sentry. |
+| `VITE_APP_VERSION` | Recomendado | Versión de la app para releases de Sentry. En CI se usa `${{ github.sha }}`. |
+| `N8N_UPSTREAM` | Sí (solo Coolify) | URL base del n8n upstream (ej. `https://n8n.shycia.com.ar`). Runtime-only, usada por `envsubst` en el CMD del Dockerfile. |
+
+### Dónde se configuran
+
+- **Coolify:** Environment Variables del servicio (se pasan como `ARG` al build del Dockerfile, excepto `N8N_UPSTREAM` que va como `ENV` runtime).
+- **Vercel:** Project Settings → Environment Variables, o como secrets del workflow (`STAGING_*`).
+- **GitHub Actions secrets:** `Settings → Secrets and variables → Actions`. Requeridos: `COOLIFY_WEBHOOK_URL`, `VITE_SUPABASE_URL`, `VITE_SUPABASE_ANON_KEY`, `STAGING_SUPABASE_URL`, `STAGING_SUPABASE_ANON_KEY`, `SENTRY_DSN`, `VERCEL_TOKEN`, `VERCEL_ORG_ID`, `VERCEL_PROJECT_ID`, `VITE_GOOGLE_API_KEY`, `VITE_N8N_WEBHOOK_URL`, `VITE_N8N_FACTURA_WEBHOOK_URL`.
+
+## Monitoreo Post-Deploy
+
+### Automático
+
+- **Sentry:** dashboard del proyecto muestra errores nuevos y release health por `VITE_APP_VERSION`. Buscar picos de error rate en los primeros 15 minutos del deploy.
+- **Coolify healthcheck:** `wget http://localhost/` cada 30s dentro del contenedor. Si falla 3 veces, el contenedor queda `unhealthy`.
+
+### Checklist manual (smoke test, ~2 minutos)
+
+Correr inmediatamente después de que Coolify reporte deploy exitoso:
+
+- [ ] Login con usuario de prueba funciona.
+- [ ] Vista de pedidos carga sin errores en consola.
+- [ ] Crear pedido nuevo → guarda → aparece en la lista.
+- [ ] Editar un pedido existente → persiste el cambio.
+- [ ] Toggle de modo offline → la app sigue usable con datos cacheados.
+- [ ] Service worker activo (DevTools → Application → Service Workers).
+- [ ] Sin errores 4xx/5xx en la pestaña Network al navegar las vistas principales.
+
+## Si algo falla
+
+Ver **[`docs/ROLLBACK.md`](./ROLLBACK.md)** para el procedimiento de reversión (revert del commit, re-deploy manual, rollback de migraciones Supabase si aplica).
+
+Síntomas que justifican rollback inmediato:
+- Error rate en Sentry > 5× el baseline tras el deploy.
+- Login quebrado o pedidos no se guardan.
+- Healthcheck de Coolify falla de forma sostenida.
+- 5xx masivos en Nginx.

--- a/docs/DEPLOY_GUIDE.md
+++ b/docs/DEPLOY_GUIDE.md
@@ -25,7 +25,7 @@ gh run view --log
 | Entorno | Plataforma | Trigger | URL | Vars de build |
 |---------|-----------|---------|-----|---------------|
 | Producción | Coolify (Docker + Nginx) | Push a `main` (webhook `COOLIFY_WEBHOOK_URL`) | Dominio productivo (Hostinger) | `VITE_SUPABASE_URL`, `VITE_SUPABASE_ANON_KEY`, `VITE_SENTRY_DSN`, `VITE_GOOGLE_API_KEY`, `VITE_N8N_WEBHOOK_URL`, `VITE_N8N_FACTURA_WEBHOOK_URL`, `VITE_APP_VERSION`, `N8N_UPSTREAM` (runtime) |
-| Staging | Vercel | `workflow_dispatch` manual con `environment=staging` | Preview URL Vercel | `STAGING_SUPABASE_URL`, `STAGING_SUPABASE_ANON_KEY`, `SENTRY_DSN`, `VITE_GOOGLE_API_KEY`, `VITE_N8N_WEBHOOK_URL`, `VITE_N8N_FACTURA_WEBHOOK_URL` |
+| Staging | Vercel | `workflow_dispatch` manual con `environment=staging` | Preview URL Vercel | `STAGING_SUPABASE_URL`, `STAGING_SUPABASE_ANON_KEY`, `SENTRY_DSN` (secret GitHub) → `VITE_SENTRY_DSN` (env de build), `VITE_GOOGLE_API_KEY`, `VITE_N8N_WEBHOOK_URL`, `VITE_N8N_FACTURA_WEBHOOK_URL` |
 | Local | Vite dev server | `npm run dev` | `http://localhost:5173` | `.env` local (ver `.env.example`) |
 
 ## Flujo de Deploy a Producción
@@ -39,7 +39,7 @@ Cuando se mergea un PR a `main`:
    - `security` - `npm audit --audit-level=high` + `npm run check-secrets`
    - `build` - depende de `lint`, `test`, `typecheck`, `security`
    - `e2e` - Playwright (Chromium), depende de `build`
-2. **Deploy (`.github/workflows/deploy.yml`)** corre en paralelo al CI en el mismo push a `main`:
+2. **Deploy (`.github/workflows/deploy.yml`)**: el job `deploy-coolify` corre en paralelo al CI en cada push a `main`. El job `deploy-staging` **solo** corre con `workflow_dispatch` manual con `environment=staging` (ver sección de staging), no en el push a `main`.
    - Job `deploy-coolify` dispara `POST` al `COOLIFY_WEBHOOK_URL` (timeout 30s).
    - Coolify hace `git pull` del repo y construye el `Dockerfile` (Node 20-alpine → Nginx 1.27-alpine, multi-stage).
    - El contenedor tiene un `HEALTHCHECK` cada 30s (`wget http://localhost/`), con `start-period=5s` y 3 reintentos.
@@ -111,7 +111,7 @@ Ir a **Settings → Branches → Add branch protection rule** (o editar la exist
 
 ## Variables de Entorno Críticas
 
-Fuente: `.env.example`. Todas las `VITE_*` quedan horneadas en el bundle en build-time (Vite las reemplaza como strings estáticos) — **nunca poner secretos reales** en variables `VITE_*`.
+Fuente: `.env.example` para las `VITE_*` (build-time). `N8N_UPSTREAM` es runtime-only y solo se configura en Coolify (no está en `.env.example`). Todas las `VITE_*` quedan horneadas en el bundle en build-time (Vite las reemplaza como strings estáticos) — **nunca poner secretos reales** en variables `VITE_*`.
 
 | Variable | Requerido | Descripción |
 |----------|-----------|-------------|
@@ -121,7 +121,7 @@ Fuente: `.env.example`. Todas las `VITE_*` quedan horneadas en el bundle en buil
 | `VITE_N8N_WEBHOOK_URL` | Sí | Ruta al webhook de optimización de ruta. En prod: `/api/n8n/webhook/optimizar-ruta` (proxy nginx). |
 | `VITE_N8N_FACTURA_WEBHOOK_URL` | Sí | Ruta al webhook de escaneo de factura. En prod: `/api/n8n/webhook/escanear-factura`. |
 | `VITE_SENTRY_DSN` | Recomendado | DSN de Sentry para reportar errores de producción. Vacío desactiva Sentry. |
-| `VITE_APP_VERSION` | Recomendado | Versión de la app para releases de Sentry. En CI se usa `${{ github.sha }}`. |
+| `VITE_APP_VERSION` | Recomendado | Versión de la app para releases de Sentry. En staging (job `deploy-staging`) el workflow pasa `${{ github.sha }}`. En producción (Coolify) se configura como env var en el dashboard de Coolify y se pasa como `ARG` al build del Dockerfile; el `ARG VITE_APP_VERSION` del Dockerfile no define default, así que si no se setea queda vacío. |
 | `N8N_UPSTREAM` | Sí (solo Coolify) | URL base del n8n upstream (ej. `https://n8n.shycia.com.ar`). Runtime-only, usada por `envsubst` en el CMD del Dockerfile. |
 
 ### Dónde se configuran

--- a/docs/ROLLBACK.md
+++ b/docs/ROLLBACK.md
@@ -1,0 +1,116 @@
+# Rollback de Producción (Coolify)
+
+Runbook corto para revertir producción cuando un deploy rompe algo. Complementa a [`docs/DEPLOY_GUIDE.md`](./DEPLOY_GUIDE.md).
+
+## Comandos rápidos (copy-paste)
+
+```bash
+# 1. Revert del commit problemático (en main, con el hash a revertir)
+git revert <commit-hash> -m 1
+git push origin main
+
+# 2. Si el revert no basta y hay que re-disparar el webhook de Coolify
+gh workflow run deploy.yml -f environment=production
+
+# 3. Verificar que el nuevo run se disparó
+gh run list --workflow=deploy.yml --limit 3
+
+# 4. Sentry: abrir dashboard del proyecto y filtrar por "Last 15 minutes"
+#    (ver VITE_SENTRY_DSN en .env o en Environment Variables de Coolify)
+```
+
+## Cuándo usar
+
+Disparar rollback si ocurre alguno de estos síntomas post-deploy:
+
+- Error rate en Sentry > 5× el baseline en los primeros 15 minutos.
+- Login quebrado, o crear/editar pedidos tira error.
+- Healthcheck de Coolify falla de forma sostenida (contenedor `unhealthy`).
+- 5xx masivos en Nginx o usuario reporta ruptura de un flujo clave (pedidos, rutas, factura).
+
+Si dudás, rollback. Es más barato revertir y re-investigar que dejar prod rota.
+
+## Pasos (< 5 min)
+
+### Opción A: Revert via Git (preferido)
+
+Esta es la ruta por defecto. Deja historial auditable y vuelve a pasar por CI.
+
+1. Identificar el commit problemático en `main` (`git log --oneline -10`).
+2. En una working copy limpia de `main`:
+   ```bash
+   git checkout main
+   git pull origin main
+   git revert <commit-hash> -m 1
+   git push origin main
+   ```
+   - `-m 1` solo hace falta si el commit es un merge; para commits directos, omitirlo.
+3. El push a `main` dispara el webhook de Coolify automáticamente (`deploy-coolify` en `.github/workflows/deploy.yml`).
+4. Esperar 2-4 min a que Coolify levante el contenedor nuevo con `HEALTHCHECK` verde.
+
+### Opción B: Re-disparar deploy manual en Coolify
+
+Usar si el revert en git ya se pusheó pero el webhook no se disparó, o si querés forzar un rebuild sobre el `main` actual sin commit nuevo.
+
+Desde terminal:
+
+```bash
+gh workflow run deploy.yml -f environment=production
+```
+
+O desde la UI de GitHub: **Actions → Deploy → Run workflow → environment: production**.
+
+Alternativa directa en Coolify: **Dashboard → App de Distribuidora → Redeploy** sobre el último deployment verde conocido. Esperar healthcheck (~2-3 min).
+
+## Rollback de DB (migración Supabase)
+
+Las migraciones están en `migrations/` (ver [`migrations/README.md`](../migrations/README.md)). El scheme actual es:
+
+- `000_baseline.sql` — dump fiel del schema de prod. No se re-ejecuta.
+- Migraciones nuevas numeradas `001_...`, `002_...`, aplicadas **manualmente** vía SQL Editor de Supabase o `npx supabase db push`.
+
+**No hay mecanismo de revert automático en el repo.** Supabase tampoco tiene "undo migration" built-in desde el CLI. Opciones:
+
+1. **Migración inversa manual** (preferido si el cambio es chico): escribir un `NNN_revert_<cosa>.sql` con el `DROP` / `ALTER` opuesto y aplicarlo vía SQL Editor. Commitearlo al repo para dejar registro.
+2. **Point-in-time recovery (PITR) de Supabase**: solo disponible en el plan Pro+. Requiere dashboard de Supabase → Database → Backups → PITR. Restaura la DB entera a un timestamp — **destructivo para datos escritos después**. Último recurso.
+3. **Backup manual previo**: si se anticipaba riesgo, debería haberse corrido un `pg_dump` antes. Ver [`docs/RLS_MIGRATION_GUIDE.md`](./RLS_MIGRATION_GUIDE.md) que menciona "Backup de la base de datos (recomendado)" como pre-requisito.
+
+Si el rollback de código (Opción A arriba) ya resolvió el síntoma y la migración no rompe por sí misma, **dejá la migración aplicada** y seguí. Revertir DDL innecesariamente introduce más riesgo.
+
+## Validación post-rollback
+
+Correr este checklist no bien Coolify reporte healthy el contenedor nuevo:
+
+- [ ] Sentry: sin errores nuevos en los últimos 5 min (filtro por release = versión revertida).
+- [ ] Login manual con cuenta de testing funciona.
+- [ ] Vista de pedidos carga sin errores en consola del browser.
+- [ ] Crear pedido + guardar → aparece en la lista.
+- [ ] Editar un pedido existente → persiste.
+- [ ] Toggle de modo offline → app sigue usable, operación queda queueada.
+- [ ] Service worker activo (DevTools → Application → Service Workers).
+- [ ] Sin 4xx/5xx en Network en las vistas principales.
+
+Si algún paso falla, NO seguir con el día. Escalar.
+
+## Qué NO hacer
+
+- **No hacer `git push --force` a `main`.** La branch protection debería bloquearlo, pero igual — reescribir historia de prod rompe a todos los colaboradores y deja Coolify en estado indefinido.
+- **No hacer `git reset --hard` sobre `main` local y pushear.** Mismo problema que el anterior. Usar `git revert`, que es aditivo.
+- **No borrar el deployment anterior en Coolify** hasta haber validado el rollback en vivo. Lo necesitás como vuelta atrás de la vuelta atrás.
+- **No tocar la DB de producción** (`DROP`, `DELETE` masivos, `TRUNCATE`) sin backup previo y sin un segundo par de ojos.
+- **No saltarse el CI** con `[skip ci]` en el commit del revert. Queremos que el revert pase por lint + typecheck + tests como cualquier cambio.
+- **No deployar fix-forward a las apuradas** si no estás seguro del diagnóstico. Primero revert, después investigás con calma.
+
+## Referencias
+
+- [`docs/DEPLOY_GUIDE.md`](./DEPLOY_GUIDE.md) — flujo de deploy, entornos y variables.
+- [`migrations/README.md`](../migrations/README.md) — scheme de migraciones Supabase.
+- [`docs/RLS_MIGRATION_GUIDE.md`](./RLS_MIGRATION_GUIDE.md) — políticas RLS y pre-requisitos de backup.
+- `.github/workflows/deploy.yml` — job `deploy-coolify` y trigger del webhook.
+
+## Contactos
+
+- Responsable técnico: Agustín Reiden (`<email en contacto interno>`).
+- Dashboard Supabase: https://supabase.com/dashboard/project/hmuchlzmuqqxcldbzkgc
+- Dashboard Coolify: `<ver link interno / panel de Hostinger>`.
+- Sentry: `<ver VITE_SENTRY_DSN en .env o en Environment Variables de Coolify>`.

--- a/docs/ROLLBACK.md
+++ b/docs/ROLLBACK.md
@@ -6,7 +6,7 @@ Runbook corto para revertir producción cuando un deploy rompe algo. Complementa
 
 ```bash
 # 1. Revert del commit problemático (en main, con el hash a revertir)
-git revert <commit-hash> -m 1
+git revert <commit-hash>    # si es merge commit, agregá: -m 1
 git push origin main
 
 # 2. Si el revert no basta y hay que re-disparar el webhook de Coolify
@@ -14,10 +14,9 @@ gh workflow run deploy.yml -f environment=production
 
 # 3. Verificar que el nuevo run se disparó
 gh run list --workflow=deploy.yml --limit 3
-
-# 4. Sentry: abrir dashboard del proyecto y filtrar por "Last 15 minutes"
-#    (ver VITE_SENTRY_DSN en .env o en Environment Variables de Coolify)
 ```
+
+- Sentry: abrir dashboard del proyecto y filtrar por "Last 15 minutes" (ver `VITE_SENTRY_DSN` en `.env` o en Environment Variables de Coolify; más detalle en [`docs/DEPLOY_GUIDE.md`](./DEPLOY_GUIDE.md)).
 
 ## Cuándo usar
 
@@ -41,10 +40,9 @@ Esta es la ruta por defecto. Deja historial auditable y vuelve a pasar por CI.
    ```bash
    git checkout main
    git pull origin main
-   git revert <commit-hash> -m 1
+   git revert <commit-hash>    # si es merge commit, agregá: -m 1
    git push origin main
    ```
-   - `-m 1` solo hace falta si el commit es un merge; para commits directos, omitirlo.
 3. El push a `main` dispara el webhook de Coolify automáticamente (`deploy-coolify` en `.github/workflows/deploy.yml`).
 4. Esperar 2-4 min a que Coolify levante el contenedor nuevo con `HEALTHCHECK` verde.
 


### PR DESCRIPTION
## Fase 0 del plan de mejoras — Salvaguardas de deploy

Plan completo: `.claude/plans/hace-un-plan-de-pure-star.md` (worktree local, no sube al repo).

**Objetivo:** Antes de tocar lógica, fortalecer las salvaguardas para que cualquier error futuro se detecte o revierta rápido. Cero cambios de código — solo docs + hook.

## Qué cambia

- `docs/DEPLOY_GUIDE.md` (nuevo, ~160 líneas) — runbook de deploy: flujo Coolify prod + Vercel staging, branch-protection policy que hay que configurar manualmente en GitHub, env vars críticas, monitoreo post-deploy.
- `docs/ROLLBACK.md` (nuevo, ~114 líneas) — runbook de rollback: cheatsheet copy-paste, cuándo usar, `git revert` + Coolify manual redeploy, rollback de DB honesto, qué NO hacer.
- `.husky/pre-commit` (modificado) — agrega `npm run test:run` después de lint-staged. Mide ~12s en local, muy por debajo del umbral de 25s.

## Commits

1. `8ac2953` docs: add DEPLOY_GUIDE with branch protection policy
2. `97d6fb7` docs: tighten DEPLOY_GUIDE accuracy on deploy-staging, VITE_APP_VERSION, N8N_UPSTREAM, SENTRY_DSN
3. `6106076` chore: run unit tests on pre-commit
4. `68d62a5` docs: add ROLLBACK runbook for Coolify
5. `7ebf89f` docs: ROLLBACK safer revert cheatsheet and inline Sentry instruction

## Acción manual post-merge (no se puede automatizar)

Configurar branch protection en **Settings → Branches → Add rule** para `main`:
- Require a pull request before merging (approvals ≥ 1)
- Require status checks to pass: `Lint`, `TypeScript Check`, `Unit Tests`, `Security Audit`, `Build`, `E2E Tests`
- Require branches to be up to date before merging
- Do not allow bypassing
- Disable force push + deletions

(Los nombres exactos de los status checks están verificados contra `.github/workflows/ci.yml`.)

## Test plan

- [x] `npm run typecheck` — pasa (pre-existente, no toca código)
- [x] `npm run lint` — pasa
- [x] `npm run test:run` — 522/522 tests pasan en ~12s
- [x] `bash .husky/pre-commit` — end-to-end funciona (este commit mismo pasó por el hook)
- [ ] Staging deploy manual: `gh workflow run deploy.yml -f environment=staging` (a disparar post-merge si se quiere validar doc en entorno real)
- [ ] Activar branch protection en Settings (ver arriba)

## Riesgo

**Cero.** No toca código de la app. Solo añade docs y suma 1 paso al hook pre-commit (que se puede saltear con `--no-verify` si hiciera falta).