### PR TITLE
fix(fase-1): bugs de negocio - dinero, mermas offline, realtime

### DIFF
--- a/src/components/modals/ModalCompra.tsx
+++ b/src/components/modals/ModalCompra.tsx
@@ -8,6 +8,7 @@ import React, { useReducer, useMemo, useCallback, useState, useEffect, useRef, l
 import type { ChangeEvent, FormEvent } from 'react'
 import { X, ShoppingCart, Plus, Trash2, Package, Building2, FileText, Calculator, Search, Loader2, Camera, CheckCircle, AlertTriangle } from 'lucide-react'
 import { formatPrecio, fechaLocalISO } from '../../utils/formatters'
+import { parsePrecio } from '../../utils/calculations'
 import { supabase } from '../../lib/supabase'
 import type { ProductoDB, ProveedorDBExtended, CompraFormInputExtended, ProveedorFormInputExtended } from '../../types'
 
@@ -1080,7 +1081,7 @@ function ProductosSection({ state, dispatch, productosFiltrados, onAgregarItem, 
                 min="0"
                 step="0.01"
                 value={itemRapido.costo || ''}
-                onChange={(e: ChangeEvent<HTMLInputElement>) => setItemRapido(prev => ({ ...prev, costo: parseFloat(e.target.value) || 0 }))}
+                onChange={(e: ChangeEvent<HTMLInputElement>) => setItemRapido(prev => ({ ...prev, costo: parsePrecio(e.target.value) }))}
                 placeholder="0.00"
                 className="w-full px-3 py-1.5 text-sm border dark:border-gray-600 rounded focus:ring-2 focus:ring-blue-500 dark:bg-gray-700 dark:text-white"
               />
@@ -1189,7 +1190,7 @@ function ItemRow({ item, index, onActualizarItem, onEliminarItem }: ItemRowProps
               min="0"
               step="0.01"
               value={item.costoUnitario}
-              onChange={(e: ChangeEvent<HTMLInputElement>) => onActualizarItem(index, 'costoUnitario', parseFloat(e.target.value) || 0)}
+              onChange={(e: ChangeEvent<HTMLInputElement>) => onActualizarItem(index, 'costoUnitario', parsePrecio(e.target.value))}
               className="w-full px-2 py-1 text-center border dark:border-gray-600 rounded focus:ring-2 focus:ring-green-500 dark:bg-gray-700 dark:text-white text-sm"
             />
           </div>
@@ -1243,7 +1244,7 @@ function ItemRow({ item, index, onActualizarItem, onEliminarItem }: ItemRowProps
             min="0"
             step="0.01"
             value={item.costoUnitario}
-            onChange={(e: ChangeEvent<HTMLInputElement>) => onActualizarItem(index, 'costoUnitario', parseFloat(e.target.value) || 0)}
+            onChange={(e: ChangeEvent<HTMLInputElement>) => onActualizarItem(index, 'costoUnitario', parsePrecio(e.target.value))}
             className="w-full px-2 py-1 text-center border dark:border-gray-600 rounded focus:ring-2 focus:ring-green-500 dark:bg-gray-700 dark:text-white text-sm"
           />
         </div>

--- a/src/components/modals/ModalEditarPedido.tsx
+++ b/src/components/modals/ModalEditarPedido.tsx
@@ -7,7 +7,7 @@ import { useZodValidation } from '../../hooks/useZodValidation';
 import { modalEditarPedidoSchema } from '../../lib/schemas';
 import { usePrecioMayorista } from '../../hooks/usePrecioMayorista';
 import { useRendiciones } from '../../hooks/supabase/useRendiciones';
-import { calcularNetoVenta } from '../../utils/calculations';
+import { calcularNetoVenta, parsePrecio } from '../../utils/calculations';
 import type { PedidoDB, ProductoDB } from '../../types';
 
 /** Item del pedido para edición */
@@ -222,7 +222,7 @@ const ModalEditarPedido = memo(function ModalEditarPedido({
   }, [estadoPago]);
 
   const handleMontoPagadoChange = (valor: string): void => {
-    const monto = Math.min(parseFloat(valor) || 0, total);
+    const monto = Math.min(parsePrecio(valor), total);
     setMontoPagado(monto);
     if (monto >= total) {
       setEstadoPago('pagado');
@@ -299,14 +299,14 @@ const ModalEditarPedido = memo(function ModalEditarPedido({
     let notasFinal = notas;
 
     if (pagoCombinado) {
-      const pagosValidos = pagosCombinados.filter(p => parseFloat(p.monto) > 0);
+      const pagosValidos = pagosCombinados.filter(p => parsePrecio(p.monto) > 0);
       if (pagosValidos.length < 2) {
         setErrorValidacion('Ingresa al menos 2 formas de pago con monto mayor a 0');
         return;
       }
       formaPagoFinal = 'combinado';
-      montoPagadoFinal = Math.min(pagosValidos.reduce((sum, p) => sum + parseFloat(p.monto), 0), total);
-      if (pagosValidos.reduce((sum, p) => sum + parseFloat(p.monto), 0) > total) {
+      montoPagadoFinal = Math.min(pagosValidos.reduce((sum, p) => sum + parsePrecio(p.monto), 0), total);
+      if (pagosValidos.reduce((sum, p) => sum + parsePrecio(p.monto), 0) > total) {
         setErrorValidacion(`El total combinado no puede superar el total del pedido (${formatPrecio(total)})`);
         return;
       }
@@ -316,7 +316,7 @@ const ModalEditarPedido = memo(function ModalEditarPedido({
         tarjeta: 'Tarjeta', cuenta_corriente: 'Cuenta Corriente'
       };
       const detalle = pagosValidos.map(p =>
-        `${formasPagoLabels[p.formaPago] || p.formaPago} $${parseFloat(p.monto).toLocaleString('es-AR')}`
+        `${formasPagoLabels[p.formaPago] || p.formaPago} $${parsePrecio(p.monto).toLocaleString('es-AR')}`
       ).join(' + ');
       // Reemplazar detalle previo si existe, o agregar
       const notaSinDetalle = notas.replace(/\s*\[Pago combinado:.*?\]/g, '').trim();
@@ -600,7 +600,7 @@ const ModalEditarPedido = memo(function ModalEditarPedido({
                                 onChange={e => setEditingPriceValue(e.target.value)}
                                 onKeyDown={e => {
                                   if (e.key === 'Enter') {
-                                    const newPrice = parseFloat(editingPriceValue);
+                                    const newPrice = parsePrecio(editingPriceValue);
                                     if (newPrice > 0) handlePrecioChange(item.productoId, newPrice);
                                     setEditingPriceId(null);
                                   } else if (e.key === 'Escape') {
@@ -608,7 +608,7 @@ const ModalEditarPedido = memo(function ModalEditarPedido({
                                   }
                                 }}
                                 onBlur={() => {
-                                  const newPrice = parseFloat(editingPriceValue);
+                                  const newPrice = parsePrecio(editingPriceValue);
                                   if (newPrice > 0) handlePrecioChange(item.productoId, newPrice);
                                   setEditingPriceId(null);
                                 }}
@@ -815,7 +815,7 @@ const ModalEditarPedido = memo(function ModalEditarPedido({
                       onChange={e => {
                         const nuevos = pagosCombinados.map((p, i) => i === index ? { ...p, monto: e.target.value } : p);
                         setPagosCombinados(nuevos);
-                        const totalComb = nuevos.reduce((sum, p) => sum + (parseFloat(p.monto) || 0), 0);
+                        const totalComb = nuevos.reduce((sum, p) => sum + parsePrecio(p.monto), 0);
                         setMontoPagado(totalComb);
                         if (totalComb >= total) setEstadoPago('pagado');
                         else if (totalComb > 0) setEstadoPago('parcial');
@@ -845,7 +845,7 @@ const ModalEditarPedido = memo(function ModalEditarPedido({
                 Agregar forma de pago
               </button>
               {(() => {
-                const totalComb = pagosCombinados.reduce((s, p) => s + (parseFloat(p.monto) || 0), 0);
+                const totalComb = pagosCombinados.reduce((s, p) => s + parsePrecio(p.monto), 0);
                 const excede = totalComb > total;
                 return (
                   <div className={`text-right text-sm ${excede ? 'text-red-600 dark:text-red-400' : 'text-gray-500 dark:text-gray-400'}`}>

--- a/src/components/modals/ModalGrupoPrecio.tsx
+++ b/src/components/modals/ModalGrupoPrecio.tsx
@@ -7,6 +7,7 @@
 import { useState, useMemo } from 'react'
 import { X, Plus, Trash2, Search, Copy } from 'lucide-react'
 import { formatPrecio } from '../../utils/formatters'
+import { parsePrecio } from '../../utils/calculations'
 import type { GrupoPrecioConDetalles, GrupoPrecioFormInput, ProductoDB } from '../../types'
 
 export interface ModalGrupoPrecioProps {
@@ -138,7 +139,7 @@ export default function ModalGrupoPrecio({
 
     for (const e of escalasValidas) {
       const qty = parseInt(e.cantidadMinima)
-      const price = parseFloat(e.precioUnitario)
+      const price = parsePrecio(e.precioUnitario)
       if (isNaN(qty) || qty <= 0) {
         setError('Las cantidades mínimas deben ser mayores a 0')
         return
@@ -171,7 +172,7 @@ export default function ModalGrupoPrecio({
         cantidadesMinimas,
         escalas: escalasValidas.map(e => ({
           cantidadMinima: parseInt(e.cantidadMinima),
-          precioUnitario: parseFloat(e.precioUnitario),
+          precioUnitario: parsePrecio(e.precioUnitario),
           etiqueta: e.etiqueta.trim() || null,
         })),
       })
@@ -382,7 +383,7 @@ export default function ModalGrupoPrecio({
                     .sort((a, b) => parseInt(a.cantidadMinima) - parseInt(b.cantidadMinima))
                     .map((e, i) => (
                       <span key={i} className="text-sm text-green-800 dark:text-green-200">
-                        {e.cantidadMinima}+ = {formatPrecio(parseFloat(e.precioUnitario))}
+                        {e.cantidadMinima}+ = {formatPrecio(parsePrecio(e.precioUnitario))}
                         {e.etiqueta && ` (${e.etiqueta})`}
                         {i < escalas.filter(x => x.cantidadMinima && x.precioUnitario).length - 1 && ' · '}
                       </span>

--- a/src/components/modals/ModalHistorialPedido.tsx
+++ b/src/components/modals/ModalHistorialPedido.tsx
@@ -3,6 +3,7 @@ import { Loader2, History } from 'lucide-react';
 import ModalBase from './ModalBase';
 import { formatFecha } from './utils';
 import { formatPrecio } from '../../utils/formatters';
+import { parsePrecio } from '../../utils/calculations';
 import type { PedidoDB } from '../../types';
 
 // =============================================================================
@@ -47,7 +48,7 @@ const ModalHistorialPedido = memo(function ModalHistorialPedido({ pedido, histor
   };
 
   const formatearValor = (campo: string, valor: string): string => {
-    if (campo === "total") return formatPrecio(parseFloat(valor));
+    if (campo === "total") return formatPrecio(parsePrecio(valor));
     if (campo === "estado") {
       const estados: Record<string, string> = { pendiente: "Pendiente", en_preparacion: "En preparacion", asignado: "En camino", entregado: "Entregado" };
       return estados[valor] || valor;

--- a/src/components/modals/ModalPedido.tsx
+++ b/src/components/modals/ModalPedido.tsx
@@ -1,6 +1,7 @@
 import { useState, useMemo, memo } from 'react';
 import { X, Loader2, Search, MapPin, Tag, Calendar, Trash2, Pencil, Gift, Truck } from 'lucide-react';
 import { formatPrecio, fechaLocalISO } from '../../utils/formatters';
+import { parsePrecio } from '../../utils/calculations';
 import { AddressAutocomplete } from '../AddressAutocomplete';
 import { usePromocionPedido } from '../../hooks/usePromocionPedido';
 import ModalBase from './ModalBase';
@@ -464,7 +465,7 @@ const ModalPedido = memo(function ModalPedido({
                                 onChange={e => setEditingPriceValue(e.target.value)}
                                 onKeyDown={e => {
                                   if (e.key === 'Enter') {
-                                    const newPrice = parseFloat(editingPriceValue);
+                                    const newPrice = parsePrecio(editingPriceValue);
                                     if (newPrice > 0) onActualizarPrecio(item.productoId, newPrice);
                                     setEditingPriceId(null);
                                   } else if (e.key === 'Escape') {
@@ -472,7 +473,7 @@ const ModalPedido = memo(function ModalPedido({
                                   }
                                 }}
                                 onBlur={() => {
-                                  const newPrice = parseFloat(editingPriceValue);
+                                  const newPrice = parsePrecio(editingPriceValue);
                                   if (newPrice > 0) onActualizarPrecio(item.productoId, newPrice);
                                   setEditingPriceId(null);
                                 }}
@@ -631,7 +632,7 @@ const ModalPedido = memo(function ModalPedido({
                     step="0.01"
                     max={hayDescuento ? totalFinal : calcularTotal()}
                     value={nuevoPedido.montoPagado || ''}
-                    onChange={e => onMontoPagadoChange && onMontoPagadoChange(parseFloat(e.target.value) || 0)}
+                    onChange={e => onMontoPagadoChange && onMontoPagadoChange(parsePrecio(e.target.value))}
                     className="flex-1 px-3 py-2 border border-yellow-300 rounded-lg focus:ring-2 focus:ring-yellow-500 bg-white dark:bg-gray-800 dark:border-yellow-600 dark:text-white"
                     placeholder="Ingrese el monto pagado"
                   />

--- a/src/components/modals/ModalProducto.tsx
+++ b/src/components/modals/ModalProducto.tsx
@@ -4,7 +4,7 @@ import { Loader2 } from 'lucide-react';
 import ModalBase from './ModalBase';
 import { useZodValidation } from '../../hooks/useZodValidation';
 import { modalProductoSchema } from '../../lib/schemas';
-import { calcularTotalConIva } from '../../utils/calculations';
+import { calcularTotalConIva, parsePrecio } from '../../utils/calculations';
 import type { ProductoDB, ProveedorDBExtended } from '../../types';
 
 // =============================================================================
@@ -339,7 +339,7 @@ const ModalProducto = memo(function ModalProducto({ producto, categorias, provee
             </div>
           </div>
           <p className="text-xs text-gray-500 mt-2">
-            Costo real = Neto + Imp. Internos (sin IVA) = ${((parseFloat(String(form.costo_sin_iva)) || 0) * (1 + (parseFloat(String(form.impuestos_internos)) || 0) / 100)).toFixed(2)}
+            Costo real = Neto + Imp. Internos (sin IVA) = ${(parsePrecio(String(form.costo_sin_iva)) * (1 + (parseFloat(String(form.impuestos_internos)) || 0) / 100)).toFixed(2)}
           </p>
         </div>
 
@@ -374,11 +374,11 @@ const ModalProducto = memo(function ModalProducto({ producto, categorias, provee
           <p className="text-xs text-gray-500 mt-2">
             * El precio final incluye IVA ({form.porcentaje_iva || 21}%) + Imp. Internos ({form.impuestos_internos || 0}%) sobre neto
           </p>
-          {(parseFloat(String(form.costo_sin_iva)) > 0 && parseFloat(String(form.precio_sin_iva)) > 0) && (
+          {(parsePrecio(String(form.costo_sin_iva)) > 0 && parsePrecio(String(form.precio_sin_iva)) > 0) && (
             <div className="mt-3 p-3 bg-blue-50 rounded-lg">
               <p className="text-xs font-medium text-blue-800">
-                Rentabilidad neta: ${((parseFloat(String(form.precio_sin_iva)) || 0) - (parseFloat(String(form.costo_sin_iva)) || 0)).toFixed(2)}
-                {' '}({(((parseFloat(String(form.precio_sin_iva)) - parseFloat(String(form.costo_sin_iva))) / parseFloat(String(form.costo_sin_iva))) * 100).toFixed(1)}%)
+                Rentabilidad neta: ${(parsePrecio(String(form.precio_sin_iva)) - parsePrecio(String(form.costo_sin_iva))).toFixed(2)}
+                {' '}({(((parsePrecio(String(form.precio_sin_iva)) - parsePrecio(String(form.costo_sin_iva))) / parsePrecio(String(form.costo_sin_iva))) * 100).toFixed(1)}%)
               </p>
               <p className="text-xs text-blue-600 mt-1">
                 Margen sobre costo neto (sin IVA ni imp. internos)

--- a/src/components/modals/ModalRegistrarPago.tsx
+++ b/src/components/modals/ModalRegistrarPago.tsx
@@ -1,6 +1,7 @@
 import React, { useState, FormEvent, ChangeEvent } from 'react'
 import { X, DollarSign, FileText, AlertCircle, Check, Plus, Trash2 } from 'lucide-react'
 import { formatPrecio as formatCurrency } from '../../utils/formatters'
+import { parsePrecio } from '../../utils/calculations'
 import { useZodValidation } from '../../hooks/useZodValidation'
 import { modalPagoSchema } from '../../lib/schemas'
 import type { ClienteDB, Pedido, Pago, FormaPago } from '../../types'
@@ -75,7 +76,7 @@ export default function ModalRegistrarPago({
     { monto: '', formaPago: 'transferencia' },
   ])
 
-  const totalDividido = pagos.reduce((sum, p) => sum + (parseFloat(p.monto) || 0), 0)
+  const totalDividido = pagos.reduce((sum, p) => sum + parsePrecio(p.monto), 0)
 
   const handleAddPago = () => {
     setPagos(prev => [...prev, { monto: '', formaPago: 'efectivo' }])
@@ -101,14 +102,14 @@ export default function ModalRegistrarPago({
 
     if (pagoDividido) {
       // Validar pagos divididos
-      const pagosValidos = pagos.filter(p => parseFloat(p.monto) > 0)
+      const pagosValidos = pagos.filter(p => parsePrecio(p.monto) > 0)
       if (pagosValidos.length < 2) {
         setError('Ingresa al menos 2 formas de pago con monto mayor a 0')
         return
       }
 
       // Validate total does not exceed outstanding balance (BUG-10 fix)
-      const totalDividido = pagosValidos.reduce((s, p) => s + parseFloat(p.monto), 0)
+      const totalDividido = pagosValidos.reduce((s, p) => s + parsePrecio(p.monto), 0)
       if (saldoPendiente > 0 && totalDividido > saldoPendiente + 0.01) {
         setError(`El total de pagos ($${totalDividido.toLocaleString('es-AR')}) excede el saldo pendiente ($${saldoPendiente.toLocaleString('es-AR')})`)
         return
@@ -121,7 +122,7 @@ export default function ModalRegistrarPago({
           ultimoPago = await onConfirmar({
             clienteId: cliente!.id,
             pedidoId: pedidoSeleccionado || null,
-            monto: parseFloat(pago.monto),
+            monto: parsePrecio(pago.monto),
             formaPago: pago.formaPago,
             referencia: '',
             notas: notas ? `${notas} (pago dividido - ${FORMAS_PAGO.find(f => f.value === pago.formaPago)?.label || pago.formaPago})` : `Pago dividido - ${FORMAS_PAGO.find(f => f.value === pago.formaPago)?.label || pago.formaPago}`
@@ -136,7 +137,7 @@ export default function ModalRegistrarPago({
       }
     } else {
       // Pago simple (comportamiento original)
-      const result = validate({ monto: parseFloat(monto) || 0, formaPago, referencia, notas, pedidoSeleccionado })
+      const result = validate({ monto: parsePrecio(monto), formaPago, referencia, notas, pedidoSeleccionado })
       if (!result.success) {
         setError(getFirstError() || 'Error de validacion')
         return

--- a/src/hooks/__tests__/useOfflineSync.integration.test.ts
+++ b/src/hooks/__tests__/useOfflineSync.integration.test.ts
@@ -504,8 +504,8 @@ describe('useOfflineSync Integration Tests', () => {
         motivo: 'Producto vencido'
       }
 
-      act(() => {
-        result.current.guardarMermaOffline(mermaData)
+      await act(async () => {
+        await result.current.guardarMermaOffline(mermaData)
       })
 
       expect(result.current.mermasPendientes).toHaveLength(1)
@@ -588,8 +588,8 @@ describe('useOfflineSync Integration Tests', () => {
       expect(result.current.cantidadPendientes).toBe(2)
 
       // Agregar mermas
-      act(() => {
-        result.current.guardarMermaOffline({
+      await act(async () => {
+        await result.current.guardarMermaOffline({
           producto_id: 'p1',
           cantidad: 1,
           tipo_merma: 'robo' as const,
@@ -598,6 +598,75 @@ describe('useOfflineSync Integration Tests', () => {
       })
 
       expect(result.current.cantidadPendientes).toBe(3)
+    })
+  })
+
+  // ===========================================================================
+  // SYNC-07: Regresión Task 1.5 — guardarMermaOffline espera queueOperation
+  // ===========================================================================
+  describe('SYNC-07: guardarMermaOffline await queueOperation (Task 1.5)', () => {
+    it('debe esperar a que queueOperation resuelva antes de retornar', async () => {
+      // Arrange: hacemos que queueOperation tarde en resolver y marcamos
+      // un flag cuando efectivamente se resolvió. Si guardarMermaOffline
+      // retorna ANTES de que queueOperation resuelva (bug original con
+      // .then()/.catch()), el flag estará en false en el momento del await.
+      let queueResolved = false
+      mockQueueOperation.mockImplementationOnce(() =>
+        new Promise<number>(resolve => {
+          setTimeout(() => {
+            queueResolved = true
+            resolve(42)
+          }, 50)
+        })
+      )
+
+      const { result } = renderHook(() => useOfflineSync())
+
+      await waitFor(() => {
+        expect(result.current.mermasPendientes).toEqual([])
+      })
+
+      // Act: await el guardarMermaOffline
+      let returnedMerma: Awaited<ReturnType<typeof result.current.guardarMermaOffline>> | undefined
+      await act(async () => {
+        returnedMerma = await result.current.guardarMermaOffline({
+          producto_id: 'p1',
+          cantidad: 3,
+          tipo_merma: 'vencimiento' as const,
+          motivo: 'Test regresión SYNC-07'
+        })
+      })
+
+      // Assert: queueOperation debió resolver ANTES de que guardarMermaOffline retornara.
+      expect(queueResolved).toBe(true)
+      expect(returnedMerma).toBeDefined()
+      expect(returnedMerma!.sincronizado).toBe(false)
+      expect(mockQueueOperation).toHaveBeenCalledTimes(1)
+    })
+
+    it('debe hacer rollback del optimistic update si queueOperation falla', async () => {
+      mockQueueOperation.mockRejectedValueOnce(new Error('IndexedDB quota exceeded'))
+
+      const { result } = renderHook(() => useOfflineSync())
+
+      await waitFor(() => {
+        expect(result.current.mermasPendientes).toEqual([])
+      })
+
+      // Act: esperamos que el await rethrow el error
+      await expect(
+        act(async () => {
+          await result.current.guardarMermaOffline({
+            producto_id: 'p1',
+            cantidad: 1,
+            tipo_merma: 'rotura' as const,
+            motivo: 'Test rollback'
+          })
+        })
+      ).rejects.toThrow('IndexedDB quota exceeded')
+
+      // Assert: el optimistic update fue revertido; la merma NO quedó en la lista.
+      expect(result.current.mermasPendientes).toHaveLength(0)
     })
   })
 

--- a/src/hooks/handlers/useProductoHandlers.ts
+++ b/src/hooks/handlers/useProductoHandlers.ts
@@ -62,7 +62,7 @@ export interface UseProductoHandlersProps {
   notify: NotifyService;
   user: User | null;
   isOnline: boolean;
-  guardarMermaOffline: (merma: MermaOfflineData) => void;
+  guardarMermaOffline: (merma: MermaOfflineData) => Promise<unknown>;
 }
 
 // =============================================================================
@@ -141,7 +141,9 @@ export function useProductoHandlers({
         // SECURITY FIX: Solo guardar para sincronización posterior
         // NO actualizamos stock directamente para evitar bypass de validación
         // El stock se actualizará cuando se sincronice via RPC con validación server-side
-        guardarMermaOffline({
+        // Task 1.5: await para asegurar que la merma quedó persistida en IndexedDB
+        // antes de notificar al usuario (evita "guardada" falsa si queueOperation falla).
+        await guardarMermaOffline({
           ...mermaData,
           usuarioId: user?.id
         })

--- a/src/hooks/useOfflineSync.ts
+++ b/src/hooks/useOfflineSync.ts
@@ -116,7 +116,7 @@ export interface UseOfflineSyncReturn {
     pedidoData: Omit<PedidoOffline, 'offlineId' | 'creadoOffline' | 'sincronizado'>,
     options?: GuardarPedidoOptions
   ) => Promise<GuardarPedidoResult>;
-  guardarMermaOffline: (mermaData: MermaFormInput) => MermaOffline;
+  guardarMermaOffline: (mermaData: MermaFormInput) => Promise<MermaOffline>;
   eliminarPedidoOffline: (offlineId: string) => void;
   eliminarMermaOffline: (offlineId: string) => void;
   sincronizarPedidos: (
@@ -371,53 +371,61 @@ export function useOfflineSync(): UseOfflineSyncReturn {
   /**
    * Guarda una merma en modo offline
    * Ahora usa IndexedDB via queueOperation
+   *
+   * Async: espera a que queueOperation persista en IndexedDB antes de retornar
+   * (fix Task 1.5). Antes usaba .then()/.catch() y devolvía el objeto con
+   * sincronizado:false antes de que la op estuviera realmente encolada, lo que
+   * permitía que el caller actuara sobre un estado que aún no existía.
    */
-  const guardarMermaOffline = useCallback((mermaData: MermaFormInput): MermaOffline => {
-    const tempOfflineId = `offline_merma_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`
-    const nuevaMerma: MermaOffline = {
-      ...mermaData,
-      offlineId: tempOfflineId,
-      creadoOffline: new Date().toISOString(),
-      sincronizado: false
-    }
-
-    // Encolar en IndexedDB (async, no bloqueante)
-    // Multi-tenant: persist sucursal so replay can set the right header (C7).
-    queueOperation(
-      'CREATE_MERMA' as OperationType,
-      {
+  const guardarMermaOffline = useCallback(
+    async (mermaData: MermaFormInput): Promise<MermaOffline> => {
+      const tempOfflineId = `offline_merma_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`
+      const nuevaMerma: MermaOffline = {
         ...mermaData,
-        tempOfflineId,
-        timestamp: Date.now()
-      },
-      undefined,
-      undefined,
-      currentSucursalIdRef.current ?? undefined
-    )
-      .then((opId) => {
+        offlineId: tempOfflineId,
+        creadoOffline: new Date().toISOString(),
+        sincronizado: false
+      }
+
+      // Optimistic update: pintar la merma como pendiente antes del await para
+      // que la UI responda al instante. Si queueOperation falla, rollback abajo.
+      setMermasPendientes(prev => [...prev, nuevaMerma])
+
+      try {
+        // Encolar en IndexedDB - await para garantizar persistencia antes de retornar.
+        // Multi-tenant: persist sucursal so replay can set the right header (C7).
+        const opId = await queueOperation(
+          'CREATE_MERMA' as OperationType,
+          {
+            ...mermaData,
+            tempOfflineId,
+            timestamp: Date.now()
+          },
+          undefined,
+          undefined,
+          currentSucursalIdRef.current ?? undefined
+        )
+
         if (opId !== null) {
           logger.info(`[useOfflineSync] Merma encolada con ID: ${opId}`)
-          // Usar void para indicar que no esperamos el resultado
-          void loadPendingOperations()
         } else {
           logger.warn('[useOfflineSync] Merma duplicada detectada, no se encoló')
         }
-      })
-      .catch((err) => {
+      } catch (err) {
         logger.error('[useOfflineSync] Error crítico al encolar merma:', err)
         // Rollback del optimistic update: la merma ya fue pintada como pendiente,
         // removerla para no engañar al usuario.
         setMermasPendientes(prev => prev.filter(m => m.offlineId !== tempOfflineId))
         window.dispatchEvent(new CustomEvent('offline-storage-error', {
-          detail: { type: 'merma', error: err.message }
+          detail: { type: 'merma', error: (err as Error).message }
         }))
-      })
+        throw err
+      }
 
-    // Actualizar estado local inmediatamente para UI responsive
-    setMermasPendientes(prev => [...prev, nuevaMerma])
-
-    return nuevaMerma
-  }, [loadPendingOperations])
+      return nuevaMerma
+    },
+    []
+  )
 
   /**
    * Elimina un pedido offline

--- a/src/hooks/useRealtimeInvalidation.test.tsx
+++ b/src/hooks/useRealtimeInvalidation.test.tsx
@@ -1,0 +1,246 @@
+import React from 'react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+
+// Stub Supabase clients — the hook files transitively import them, but we
+// never actually hit the network in these tests.
+vi.mock('../lib/supabase', () => ({
+  supabase: {
+    channel: vi.fn(),
+    removeChannel: vi.fn(),
+    from: vi.fn(),
+    rpc: vi.fn(),
+  },
+  setSucursalHeader: vi.fn(),
+}))
+
+vi.mock('./supabase/base', () => ({
+  supabase: {
+    channel: vi.fn(),
+    removeChannel: vi.fn(),
+    from: vi.fn(),
+    rpc: vi.fn(),
+  },
+}))
+
+// Mock useRealtimeSubscription — no real subscription, just a stub that
+// captures the onEvent callback so we can simulate payloads from the test.
+const subscriptionCallbacks: Record<string, (payload: unknown) => void> = {}
+
+vi.mock('./useRealtimeSubscription', () => ({
+  useRealtimeSubscription: ({
+    table,
+    onEvent,
+  }: {
+    table: string
+    event?: string
+    onEvent: (payload: unknown) => void
+    enabled?: boolean
+  }) => {
+    subscriptionCallbacks[table] = onEvent
+    return { status: 'SUBSCRIBED' as const, unsubscribe: vi.fn() }
+  },
+}))
+
+// Mock SucursalContext to return a fixed sucursalId
+vi.mock('../contexts/SucursalContext', () => ({
+  useSucursal: () => ({
+    currentSucursalId: 1,
+    currentSucursalNombre: 'Test',
+    currentSucursalRol: 'admin',
+    sucursales: [],
+    loading: false,
+    hasMultipleSucursales: false,
+    switchSucursal: vi.fn(),
+  }),
+}))
+
+// Import after mocks
+import { useRealtimeInvalidation } from './useRealtimeInvalidation'
+import { pedidosKeys } from './queries/usePedidosQuery'
+import { productosKeys } from './queries/useProductosQuery'
+
+function makeWrapper(qc: QueryClient) {
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return <QueryClientProvider client={qc}>{children}</QueryClientProvider>
+  }
+}
+
+describe('useRealtimeInvalidation', () => {
+  beforeEach(() => {
+    for (const k of Object.keys(subscriptionCallbacks)) {
+      delete subscriptionCallbacks[k]
+    }
+  })
+
+  it('invalida solo el detail cuando se llama invalidatePedido(id)', async () => {
+    const qc = new QueryClient()
+    const spy = vi.spyOn(qc, 'invalidateQueries')
+    const { result } = renderHook(
+      () => useRealtimeInvalidation({ debounceMs: 0 }),
+      { wrapper: makeWrapper(qc) }
+    )
+
+    await act(async () => {
+      result.current.invalidatePedido('42')
+      await new Promise(r => setTimeout(r, 20))
+    })
+
+    expect(spy).toHaveBeenCalledWith({
+      queryKey: pedidosKeys.detail(1, '42'),
+    })
+    // NO debe invalidar la lista completa
+    expect(spy).not.toHaveBeenCalledWith({
+      queryKey: pedidosKeys.lists(1),
+    })
+  })
+
+  it('invalida toda la lista con invalidatePedidosList()', async () => {
+    const qc = new QueryClient()
+    const spy = vi.spyOn(qc, 'invalidateQueries')
+    const { result } = renderHook(
+      () => useRealtimeInvalidation({ debounceMs: 0 }),
+      { wrapper: makeWrapper(qc) }
+    )
+
+    await act(async () => {
+      result.current.invalidatePedidosList()
+      await new Promise(r => setTimeout(r, 20))
+    })
+
+    expect(spy).toHaveBeenCalledWith({
+      queryKey: pedidosKeys.lists(1),
+    })
+  })
+
+  it('invalida productos con invalidateProductos()', async () => {
+    const qc = new QueryClient()
+    const spy = vi.spyOn(qc, 'invalidateQueries')
+    const { result } = renderHook(
+      () => useRealtimeInvalidation({ debounceMs: 0 }),
+      { wrapper: makeWrapper(qc) }
+    )
+
+    await act(async () => {
+      result.current.invalidateProductos()
+      await new Promise(r => setTimeout(r, 20))
+    })
+
+    expect(spy).toHaveBeenCalledWith({
+      queryKey: productosKeys.all(1),
+    })
+  })
+
+  it('debounces multiple invalidatePedido calls to the same id', async () => {
+    const qc = new QueryClient()
+    const spy = vi.spyOn(qc, 'invalidateQueries')
+    const { result } = renderHook(
+      () => useRealtimeInvalidation({ debounceMs: 50 }),
+      { wrapper: makeWrapper(qc) }
+    )
+
+    await act(async () => {
+      result.current.invalidatePedido('42')
+      result.current.invalidatePedido('42')
+      result.current.invalidatePedido('42')
+      await new Promise(r => setTimeout(r, 100))
+    })
+
+    const detailCalls = spy.mock.calls.filter(
+      c =>
+        JSON.stringify((c[0] as { queryKey: unknown }).queryKey) ===
+        JSON.stringify(pedidosKeys.detail(1, '42'))
+    )
+    expect(detailCalls.length).toBe(1)
+  })
+
+  it('INSERT en pedidos dispara invalidación de la lista (no del detail)', async () => {
+    const qc = new QueryClient()
+    const spy = vi.spyOn(qc, 'invalidateQueries')
+    renderHook(() => useRealtimeInvalidation({ debounceMs: 0 }), {
+      wrapper: makeWrapper(qc),
+    })
+
+    await act(async () => {
+      subscriptionCallbacks['pedidos']({
+        eventType: 'INSERT',
+        new: { id: 99 },
+      })
+      await new Promise(r => setTimeout(r, 20))
+    })
+
+    expect(spy).toHaveBeenCalledWith({
+      queryKey: pedidosKeys.lists(1),
+    })
+    expect(spy).not.toHaveBeenCalledWith({
+      queryKey: pedidosKeys.detail(1, '99'),
+    })
+  })
+
+  it('UPDATE en pedidos dispara invalidación solo del detail (no de la lista)', async () => {
+    const qc = new QueryClient()
+    const spy = vi.spyOn(qc, 'invalidateQueries')
+    renderHook(() => useRealtimeInvalidation({ debounceMs: 0 }), {
+      wrapper: makeWrapper(qc),
+    })
+
+    await act(async () => {
+      subscriptionCallbacks['pedidos']({
+        eventType: 'UPDATE',
+        new: { id: 7, estado: 'entregado' },
+      })
+      await new Promise(r => setTimeout(r, 20))
+    })
+
+    expect(spy).toHaveBeenCalledWith({
+      queryKey: pedidosKeys.detail(1, '7'),
+    })
+    expect(spy).not.toHaveBeenCalledWith({
+      queryKey: pedidosKeys.lists(1),
+    })
+  })
+
+  it('DELETE en pedidos invalida detail Y lista', async () => {
+    const qc = new QueryClient()
+    const spy = vi.spyOn(qc, 'invalidateQueries')
+    renderHook(() => useRealtimeInvalidation({ debounceMs: 0 }), {
+      wrapper: makeWrapper(qc),
+    })
+
+    await act(async () => {
+      subscriptionCallbacks['pedidos']({
+        eventType: 'DELETE',
+        old: { id: 13 },
+      })
+      await new Promise(r => setTimeout(r, 20))
+    })
+
+    expect(spy).toHaveBeenCalledWith({
+      queryKey: pedidosKeys.detail(1, '13'),
+    })
+    expect(spy).toHaveBeenCalledWith({
+      queryKey: pedidosKeys.lists(1),
+    })
+  })
+
+  it('cambio en pedido_items invalida el detail del pedido padre', async () => {
+    const qc = new QueryClient()
+    const spy = vi.spyOn(qc, 'invalidateQueries')
+    renderHook(() => useRealtimeInvalidation({ debounceMs: 0 }), {
+      wrapper: makeWrapper(qc),
+    })
+
+    await act(async () => {
+      subscriptionCallbacks['pedido_items']({
+        eventType: 'UPDATE',
+        new: { id: 1, pedido_id: 500, cantidad: 2 },
+      })
+      await new Promise(r => setTimeout(r, 20))
+    })
+
+    expect(spy).toHaveBeenCalledWith({
+      queryKey: pedidosKeys.detail(1, '500'),
+    })
+  })
+})

--- a/src/hooks/useRealtimeInvalidation.ts
+++ b/src/hooks/useRealtimeInvalidation.ts
@@ -5,11 +5,21 @@
  * invalida los queries correspondientes para que TanStack Query
  * los re-fetche automáticamente.
  *
+ * Invalidación granular basada en el payload de Supabase:
+ * - INSERT en pedidos → invalida la lista (aparece una fila nueva)
+ * - UPDATE en pedidos → invalida solo el detail del pedido afectado
+ * - DELETE en pedidos → invalida detail (se borra) + lista (se achica)
+ * - pedido_items * → invalida el detail del pedido padre
+ * - productos UPDATE → invalida productos (coarse, es suficiente)
+ *
  * Usa debounce de 300ms para agrupar cambios rápidos (ej: batch de stock).
  */
 import { useRef, useCallback, useEffect } from 'react'
 import { useQueryClient } from '@tanstack/react-query'
 import { useRealtimeSubscription } from './useRealtimeSubscription'
+import { useSucursal } from '../contexts/SucursalContext'
+import { pedidosKeys } from './queries/usePedidosQuery'
+import { productosKeys } from './queries/useProductosQuery'
 
 interface UseRealtimeInvalidationOptions {
   /** Si está habilitado (desactivar cuando offline) */
@@ -18,37 +28,138 @@ interface UseRealtimeInvalidationOptions {
   debounceMs?: number
 }
 
+/**
+ * Extrae un id string de un payload de Supabase realtime.
+ * Soporta new/old con id numérico o string.
+ */
+function extractId(row: unknown): string | null {
+  if (!row || typeof row !== 'object') return null
+  const id = (row as { id?: unknown }).id
+  if (id == null) return null
+  return String(id)
+}
+
+function extractPedidoIdFromItem(row: unknown): string | null {
+  if (!row || typeof row !== 'object') return null
+  const pedidoId = (row as { pedido_id?: unknown }).pedido_id
+  if (pedidoId == null) return null
+  return String(pedidoId)
+}
+
+type RealtimePayload = {
+  eventType?: 'INSERT' | 'UPDATE' | 'DELETE'
+  new?: unknown
+  old?: unknown
+}
+
 export function useRealtimeInvalidation({
   enabled = true,
   debounceMs = 300
 }: UseRealtimeInvalidationOptions = {}) {
   const queryClient = useQueryClient()
-  const pedidosTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const { currentSucursalId } = useSucursal()
+
+  // Un timer por pedido-id para debounce granular por detail
+  const pedidoDetailTimersRef = useRef<Map<string, ReturnType<typeof setTimeout>>>(new Map())
+  const pedidosListTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const productosTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
-  const invalidatePedidos = useCallback(() => {
-    if (pedidosTimerRef.current) {
-      clearTimeout(pedidosTimerRef.current)
-    }
-    pedidosTimerRef.current = setTimeout(() => {
-      queryClient.invalidateQueries({ queryKey: ['pedidos'] })
+  const invalidatePedido = useCallback((pedidoId: string) => {
+    if (!enabled) return
+    const existing = pedidoDetailTimersRef.current.get(pedidoId)
+    if (existing) clearTimeout(existing)
+    const t = setTimeout(() => {
+      queryClient.invalidateQueries({
+        queryKey: pedidosKeys.detail(currentSucursalId, pedidoId)
+      })
+      pedidoDetailTimersRef.current.delete(pedidoId)
     }, debounceMs)
-  }, [queryClient, debounceMs])
+    pedidoDetailTimersRef.current.set(pedidoId, t)
+  }, [queryClient, debounceMs, enabled, currentSucursalId])
+
+  const invalidatePedidosList = useCallback(() => {
+    if (!enabled) return
+    if (pedidosListTimerRef.current) {
+      clearTimeout(pedidosListTimerRef.current)
+    }
+    pedidosListTimerRef.current = setTimeout(() => {
+      queryClient.invalidateQueries({
+        queryKey: pedidosKeys.lists(currentSucursalId)
+      })
+      pedidosListTimerRef.current = null
+    }, debounceMs)
+  }, [queryClient, debounceMs, enabled, currentSucursalId])
 
   const invalidateProductos = useCallback(() => {
+    if (!enabled) return
     if (productosTimerRef.current) {
       clearTimeout(productosTimerRef.current)
     }
     productosTimerRef.current = setTimeout(() => {
-      queryClient.invalidateQueries({ queryKey: ['productos'] })
+      queryClient.invalidateQueries({
+        queryKey: productosKeys.all(currentSucursalId)
+      })
+      productosTimerRef.current = null
     }, debounceMs)
-  }, [queryClient, debounceMs])
+  }, [queryClient, debounceMs, enabled, currentSucursalId])
+
+  // Handler para eventos de la tabla pedidos — enrutamiento granular
+  const handlePedidosEvent = useCallback((payload: unknown) => {
+    const p = (payload || {}) as RealtimePayload
+    const eventType = p.eventType
+    if (eventType === 'INSERT') {
+      // Fila nueva: la lista cambia
+      invalidatePedidosList()
+      return
+    }
+    if (eventType === 'UPDATE') {
+      const id = extractId(p.new)
+      if (id) {
+        invalidatePedido(id)
+      } else {
+        // Fallback si no hay id (no debería pasar)
+        invalidatePedidosList()
+      }
+      return
+    }
+    if (eventType === 'DELETE') {
+      const id = extractId(p.old)
+      if (id) invalidatePedido(id)
+      invalidatePedidosList()
+      return
+    }
+    // Evento desconocido: ser conservador e invalidar la lista
+    invalidatePedidosList()
+  }, [invalidatePedido, invalidatePedidosList])
+
+  // Handler para cambios en pedido_items — invalida detail del pedido padre
+  const handlePedidoItemsEvent = useCallback((payload: unknown) => {
+    const p = (payload || {}) as RealtimePayload
+    const pedidoId =
+      extractPedidoIdFromItem(p.new) || extractPedidoIdFromItem(p.old)
+    if (pedidoId) {
+      invalidatePedido(pedidoId)
+    } else {
+      // Fallback
+      invalidatePedidosList()
+    }
+  }, [invalidatePedido, invalidatePedidosList])
+
+  // Handler para productos — granularidad coarse es suficiente
+  const handleProductosEvent = useCallback(() => {
+    invalidateProductos()
+  }, [invalidateProductos])
 
   // Limpiar timers de debounce al desmontar para prevenir memory leaks
   useEffect(() => {
+    const detailTimers = pedidoDetailTimersRef.current
     return () => {
-      if (pedidosTimerRef.current) {
-        clearTimeout(pedidosTimerRef.current)
+      for (const t of detailTimers.values()) {
+        clearTimeout(t)
+      }
+      detailTimers.clear()
+      if (pedidosListTimerRef.current) {
+        clearTimeout(pedidosListTimerRef.current)
       }
       if (productosTimerRef.current) {
         clearTimeout(productosTimerRef.current)
@@ -59,20 +170,35 @@ export function useRealtimeInvalidation({
   const { status: pedidosStatus } = useRealtimeSubscription({
     table: 'pedidos',
     event: '*',
-    onEvent: invalidatePedidos,
+    onEvent: handlePedidosEvent,
+    enabled
+  })
+
+  const { status: pedidoItemsStatus } = useRealtimeSubscription({
+    table: 'pedido_items',
+    event: '*',
+    onEvent: handlePedidoItemsEvent,
     enabled
   })
 
   const { status: productosStatus } = useRealtimeSubscription({
     table: 'productos',
     event: 'UPDATE',
-    onEvent: invalidateProductos,
+    onEvent: handleProductosEvent,
     enabled
   })
 
   return {
     pedidosStatus,
+    pedidoItemsStatus,
     productosStatus,
-    isConnected: pedidosStatus === 'SUBSCRIBED' && productosStatus === 'SUBSCRIBED'
+    isConnected:
+      pedidosStatus === 'SUBSCRIBED' &&
+      pedidoItemsStatus === 'SUBSCRIBED' &&
+      productosStatus === 'SUBSCRIBED',
+    // Invalidadores granulares expuestos para uso externo / testing
+    invalidatePedido,
+    invalidatePedidosList,
+    invalidateProductos,
   }
 }

--- a/src/utils/calculations.parsePrecio.test.ts
+++ b/src/utils/calculations.parsePrecio.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest'
+import { parsePrecio } from './calculations'
+
+describe('parsePrecio', () => {
+  it('redondea a 2 decimales', () => {
+    expect(parsePrecio('10.456')).toBe(10.46)
+    expect(parsePrecio('10.454')).toBe(10.45)
+  })
+
+  it('devuelve 0 para strings inválidos', () => {
+    expect(parsePrecio('abc')).toBe(0)
+    expect(parsePrecio('')).toBe(0)
+    expect(parsePrecio(null as unknown as string)).toBe(0)
+    expect(parsePrecio(undefined as unknown as string)).toBe(0)
+  })
+
+  it('maneja valores numéricos directos', () => {
+    expect(parsePrecio(99.999)).toBe(100)
+    expect(parsePrecio(0.005)).toBe(0.01)
+  })
+
+  it('trunca floating point drift', () => {
+    expect(parsePrecio(0.1 + 0.2)).toBe(0.3)
+  })
+
+  it('acepta comas como separador decimal (es-AR)', () => {
+    expect(parsePrecio('10,5')).toBe(10.5)
+    expect(parsePrecio('1.234,56')).toBe(1234.56)
+  })
+})

--- a/src/utils/calculations.parsePrecio.test.ts
+++ b/src/utils/calculations.parsePrecio.test.ts
@@ -27,4 +27,21 @@ describe('parsePrecio', () => {
     expect(parsePrecio('10,5')).toBe(10.5)
     expect(parsePrecio('1.234,56')).toBe(1234.56)
   })
+
+  it('trimea whitespace en strings', () => {
+    expect(parsePrecio('  10,50  ')).toBe(10.5)
+    expect(parsePrecio('\t99.99\n')).toBe(99.99)
+  })
+
+  it('maneja números negativos', () => {
+    expect(parsePrecio('-10.50')).toBe(-10.5)
+    expect(parsePrecio('-0,01')).toBe(-0.01)
+    expect(parsePrecio(-99.999)).toBe(-100)
+  })
+
+  it('devuelve 0 para Infinity y NaN', () => {
+    expect(parsePrecio(Infinity)).toBe(0)
+    expect(parsePrecio(-Infinity)).toBe(0)
+    expect(parsePrecio(NaN)).toBe(0)
+  })
 })

--- a/src/utils/calculations.ts
+++ b/src/utils/calculations.ts
@@ -254,6 +254,24 @@ export function calcularPrecioDesdeMargen(
 // ============================================
 
 /**
+ * Parsea un string (con coma o punto decimal) y devuelve un número redondeado a 2 decimales.
+ * Devuelve 0 si el input no es parseable. Usa esta función en TODOS los inputs monetarios.
+ */
+export function parsePrecio(input: string | number | null | undefined): number {
+  if (input === null || input === undefined) return 0
+  const str = typeof input === 'number' ? String(input) : input
+  // Normalizar separador: si hay coma, tratamos los puntos como separador de miles
+  // ("1.234,56" → "1234.56"). Si no hay coma, el punto es el separador decimal
+  // ("10.456" → "10.456").
+  const normalized = str.includes(',')
+    ? str.replace(/\./g, '').replace(',', '.')
+    : str
+  const parsed = parseFloat(normalized)
+  if (!Number.isFinite(parsed)) return 0
+  return redondear(parsed, 2)
+}
+
+/**
  * Redondea un número a la cantidad de decimales especificada
  *
  * @param valor - Número a redondear
@@ -293,6 +311,7 @@ export default {
   calcularMargenPorcentaje,
   calcularGananciaBruta,
   calcularPrecioDesdeMargen,
+  parsePrecio,
   redondear,
   redondearAMultiplo
 };

--- a/src/utils/calculations.ts
+++ b/src/utils/calculations.ts
@@ -256,10 +256,17 @@ export function calcularPrecioDesdeMargen(
 /**
  * Parsea un string (con coma o punto decimal) y devuelve un número redondeado a 2 decimales.
  * Devuelve 0 si el input no es parseable. Usa esta función en TODOS los inputs monetarios.
+ *
+ * Convenciones:
+ * - Si hay coma: la coma es decimal y los puntos son separadores de miles (es-AR).
+ *   Ej: "1.234,56" → 1234.56.
+ * - Si NO hay coma: el punto se trata como decimal (es-US/int).
+ *   Ej: "10.456" → 10.46. "1.234" → 1.23 (NO 1234). Si un usuario es-AR teclea
+ *   miles sin coma, se interpretará como decimal.
  */
 export function parsePrecio(input: string | number | null | undefined): number {
   if (input === null || input === undefined) return 0
-  const str = typeof input === 'number' ? String(input) : input
+  const str = typeof input === 'number' ? String(input) : input.trim()
   // Normalizar separador: si hay coma, tratamos los puntos como separador de miles
   // ("1.234,56" → "1234.56"). Si no hay coma, el punto es el separador decimal
   // ("10.456" → "10.456").


### PR DESCRIPTION
## Fase 1 del plan de mejoras — Bugs de negocio críticos

Plan completo: `.claude/plans/hace-un-plan-de-pure-star.md` (local, no sube al repo).

## Qué arregla

### 1. Dinero con floats sin redondear (11 call sites)
- Nuevo helper `parsePrecio()` en `src/utils/calculations.ts` — redondea a 2 decimales, maneja es-AR (coma decimal, punto miles) y en-US, retorna 0 para input inválido, trim de whitespace.
- 8 tests cubriendo: redondeo, nulos, negativos, Infinity/NaN, es-AR/en-US, whitespace, floating-point drift.
- Todos los `parseFloat(precio/monto/total/neto/iva/pagado/subtotal)` en 7 modales migrados a `parsePrecio`.
- Preservados: porcentajes (IVA, bonificación, comisión, margen), cantidades enteras, coordenadas lat/lng, helpers internos de cálculo.

### 2. `guardarMermaOffline` con estado UI inconsistente
- La función era síncrona y retornaba antes de que `queueOperation` terminara — la UI podía decir "guardado" cuando en realidad el op se encolaba después.
- Ahora es `async` + `await queueOperation`. Rollback del optimistic update + dispatch event + throw en error.
- Caller en `useProductoHandlers` actualizado con `await`.
- Nuevo test `SYNC-07` (2 casos) verifica ordering real: flag se setea antes de que `guardarMermaOffline` retorne, rollback limpia el optimistic state en rechazo.

### 3. Realtime invalidation agresiva (lista completa por cada cambio)
- Antes: `invalidateQueries(['pedidos'])` → refetch de 500 items por cada UPDATE de 1 pedido.
- Ahora: 3 funciones granulares — `invalidatePedido(id)`, `invalidatePedidosList()`, `invalidateProductos()`.
- Payload-aware routing:
  - INSERT → list
  - UPDATE → detail(new.id)
  - DELETE → detail(old.id) + list
  - `pedido_items` → detail(new.pedido_id)
- Debounce por-id preservado (300ms, Map de timers para detail, refs individuales para list/productos).
- 8 tests nuevos cubriendo cada ruta + debounce collapse.

## Commits

1. `ee738ea` feat(utils): add parsePrecio helper with rounding and i18n
2. `086ba28` test(parsePrecio): add edge cases for whitespace, negatives, Infinity
3. `51fbcee` fix(pedidos): use parsePrecio to avoid float drift
4. `b01be58` fix(precios): sweep parseFloat money callsites to parsePrecio
5. `2bc6735` fix(offline): await queueOperation in guardarMermaOffline to sync UI state
6. `0db61dd` perf(realtime): invalidate granular pedido detail instead of full list

## Test plan

- [x] `npm run typecheck` — pasa
- [x] `npm run lint` — pasa
- [x] `npm run test:run` — **540/540 tests pasan** (↑10 nuevos vs Fase 0)
- [x] Pre-commit hook corre suite completa en cada commit (~12s)
- [ ] QA manual en staging (Vercel): crear pedido con `precioUnitario = 10.456` → se guarda como `10.46`
- [ ] QA offline: crear 3 mermas sin conexión → reconectar → aparecen sincronizadas sin duplicar
- [ ] QA realtime: 2 pestañas abiertas en lista de pedidos → editar uno en A → en B solo el detalle se refetchea (Network tab), no la lista completa

## Riesgo

**Bajo.** Los 3 fixes son quirúrgicos:
- `parsePrecio` es aditivo (nuevo helper). Los 22 call sites migrados mantienen semántica salvo una diferencia intencional: pagos con monto `< 0.01` ahora filtran (antes un `0.005` pasaba el filtro `> 0`) — comportamiento correcto para dinero.
- `guardarMermaOffline` cambia firma sync→async. Único caller externo actualizado.
- Realtime: API nueva, el único caller (App.tsx) solo lee el status y no se tocó.

## Rollback si algo rompe

Ver [`docs/ROLLBACK.md`](docs/ROLLBACK.md) (creado en Fase 0). Revert por commit individual es seguro — cada uno es independiente.