### PR TITLE
feat(fase-2): resiliencia UI - modales con boundary + teclados mobile correctos

### DIFF
--- a/docs/DEPLOY_GUIDE.md
+++ b/docs/DEPLOY_GUIDE.md
@@ -91,8 +91,7 @@ Esto vuelve a correr `deploy-coolify` sobre el `main` actual.
 Ir a **Settings → Branches → Add branch protection rule** (o editar la existente) para `main` y activar:
 
 - [x] **Require a pull request before merging**
-  - [x] Require approvals: **1** (mínimo)
-  - [x] Dismiss stale pull request approvals when new commits are pushed
+  - [ ] Require approvals: **desactivado** (o `0`). Activarlo en un repo de un solo desarrollador bloquea el merge porque GitHub no permite auto-aprobarse. Si en el futuro se suma otro dev con permiso de write, cambiar a `1` y activar "Dismiss stale pull request approvals when new commits are pushed".
 - [x] **Require status checks to pass before merging**
   - [x] **Require branches to be up to date before merging**
   - Status checks requeridos (nombres exactos de los jobs de `ci.yml`):

--- a/src/components/modals/ModalBase.test.tsx
+++ b/src/components/modals/ModalBase.test.tsx
@@ -1,0 +1,46 @@
+import '@testing-library/jest-dom/vitest'
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import type { ReactElement } from 'react'
+import ModalBase from './ModalBase'
+
+function Boom(): ReactElement {
+  throw new Error('explosion en modal')
+}
+
+describe('ModalBase ErrorBoundary', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('muestra fallback en lugar de crashear cuando children tiran', () => {
+    // Silenciamos los logs esperados de React al capturar el error en el boundary.
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    // Si no hay boundary, el error no capturado haría que render() lance
+    // y el test falle con la excepción. Si lo hay, render() completa y
+    // podemos inspeccionar el fallback.
+    render(
+      <ModalBase onClose={() => {}} title="Test">
+        <Boom />
+      </ModalBase>
+    )
+
+    // El fallback de CompactErrorBoundary para un error UNKNOWN muestra
+    // el título "Error inesperado" proveniente de getRecoveryInfo. Este
+    // texto SOLO aparece si el boundary atrapó el throw.
+    expect(screen.getByText('Error inesperado')).toBeInTheDocument()
+
+    // El mensaje genérico del fallback UNKNOWN también debe estar.
+    expect(
+      screen.getByText(/ha ocurrido un error inesperado/i)
+    ).toBeInTheDocument()
+
+    // El frame del modal (header con el título) sigue presente:
+    // el boundary envuelve solo el body, no todo el modal — si el
+    // boundary estuviera afuera, al capturar perderíamos el frame.
+    expect(screen.getByText('Test')).toBeInTheDocument()
+
+    errSpy.mockRestore()
+  })
+})

--- a/src/components/modals/ModalBase.tsx
+++ b/src/components/modals/ModalBase.tsx
@@ -18,6 +18,7 @@ import {
   DialogDescription,
   DialogBody
 } from '../ui/Dialog';
+import { CompactErrorBoundary } from '../ErrorBoundary';
 import { cn } from '../../lib/utils';
 
 export type ModalMaxWidth =
@@ -79,7 +80,9 @@ const ModalBase = memo(function ModalBase({
           {description || `Modal de ${title}`}
         </DialogDescription>
         <DialogBody>
-          {children}
+          <CompactErrorBoundary componentName={title || 'Modal'} onClose={onClose}>
+            {children}
+          </CompactErrorBoundary>
         </DialogBody>
       </DialogContent>
     </Dialog>

--- a/src/components/modals/ModalCliente.tsx
+++ b/src/components/modals/ModalCliente.tsx
@@ -308,7 +308,8 @@ const ModalCliente = memo(function ModalCliente({ cliente, onSave, onClose, guar
             <label htmlFor="telefono" className="block text-sm font-medium mb-1 dark:text-gray-200">Teléfono</label>
             <input
               id="telefono"
-              type="text"
+              type="tel"
+              inputMode="tel"
               value={form.telefono}
               onChange={e => handleFieldChange('telefono', e.target.value)}
               className={inputClass('telefono')}
@@ -411,6 +412,7 @@ const ModalCliente = memo(function ModalCliente({ cliente, onSave, onClose, guar
                 <label className="block text-sm font-medium mb-1 dark:text-gray-200">Límite de Crédito ($)</label>
                 <input
                   type="number"
+                  inputMode="decimal"
                   min="0"
                   step="100"
                   value={form.limiteCredito}
@@ -424,6 +426,8 @@ const ModalCliente = memo(function ModalCliente({ cliente, onSave, onClose, guar
                 <label className="block text-sm font-medium mb-1 dark:text-gray-200">Días de Crédito</label>
                 <input
                   type="number"
+                  inputMode="numeric"
+                  step="1"
                   min="0"
                   max="365"
                   value={form.diasCredito}

--- a/src/components/modals/ModalCompra.tsx
+++ b/src/components/modals/ModalCompra.tsx
@@ -10,6 +10,7 @@ import { X, ShoppingCart, Plus, Trash2, Package, Building2, FileText, Calculator
 import { formatPrecio, fechaLocalISO } from '../../utils/formatters'
 import { parsePrecio } from '../../utils/calculations'
 import { supabase } from '../../lib/supabase'
+import { CompactErrorBoundary } from '../ErrorBoundary'
 import type { ProductoDB, ProveedorDBExtended, CompraFormInputExtended, ProveedorFormInputExtended } from '../../types'
 
 const ModalProveedor = lazy(() => import('./ModalProveedor'))
@@ -659,58 +660,60 @@ export default function ModalCompra({ productos, proveedores, onSave, onClose, o
         )}
 
         {/* Contenido scrolleable */}
-        <form onSubmit={handleSubmit} className="flex-1 overflow-y-auto p-3 sm:p-4 space-y-4">
-          {/* Sección Proveedor */}
-          <ProveedorSection
-            state={state}
-            dispatch={dispatch}
-            proveedores={proveedores}
-            onAgregarProveedor={onCrearProveedor ? () => setModalProveedorOpen(true) : undefined}
-          />
-
-          {/* Datos de la compra */}
-          <DatosCompraSection state={state} dispatch={dispatch} />
-
-          {/* Productos */}
-          <ProductosSection
-            state={state}
-            dispatch={dispatch}
-            productosFiltrados={productosFiltrados}
-            onAgregarItem={handleAgregarItem}
-            onActualizarItem={handleActualizarItem}
-            onEliminarItem={handleEliminarItem}
-            onCrearProductoRapido={onCrearProductoRapido}
-            onImportarExcel={() => setModalImportarOpen(true)}
-          />
-
-          {/* Totales */}
-          {state.items.length > 0 && (
-            <ResumenSection
-              subtotalBruto={subtotalBruto}
-              bonificacionTotal={bonificacionTotal}
-              subtotal={subtotal}
-              iva={iva}
-              impuestosInternos={impuestosInternos}
-              total={total}
+        <CompactErrorBoundary componentName="ModalCompra" onClose={onClose}>
+          <form onSubmit={handleSubmit} className="flex-1 overflow-y-auto p-3 sm:p-4 space-y-4">
+            {/* Sección Proveedor */}
+            <ProveedorSection
+              state={state}
+              dispatch={dispatch}
+              proveedores={proveedores}
+              onAgregarProveedor={onCrearProveedor ? () => setModalProveedorOpen(true) : undefined}
             />
-          )}
 
-          {/* Notas */}
-          <div>
-            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
-              <FileText className="w-4 h-4 inline mr-1" />
-              Notas (opcional)
-            </label>
-            <textarea
-              value={state.notas}
-              onChange={(e: ChangeEvent<HTMLTextAreaElement>) => dispatch({ type: 'SET_NOTAS', payload: e.target.value })}
-              placeholder="Observaciones adicionales..."
-              rows={2}
-              className="w-full px-4 py-2 border dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-green-500 dark:bg-gray-700 dark:text-white"
+            {/* Datos de la compra */}
+            <DatosCompraSection state={state} dispatch={dispatch} />
+
+            {/* Productos */}
+            <ProductosSection
+              state={state}
+              dispatch={dispatch}
+              productosFiltrados={productosFiltrados}
+              onAgregarItem={handleAgregarItem}
+              onActualizarItem={handleActualizarItem}
+              onEliminarItem={handleEliminarItem}
+              onCrearProductoRapido={onCrearProductoRapido}
+              onImportarExcel={() => setModalImportarOpen(true)}
             />
-          </div>
 
-        </form>
+            {/* Totales */}
+            {state.items.length > 0 && (
+              <ResumenSection
+                subtotalBruto={subtotalBruto}
+                bonificacionTotal={bonificacionTotal}
+                subtotal={subtotal}
+                iva={iva}
+                impuestosInternos={impuestosInternos}
+                total={total}
+              />
+            )}
+
+            {/* Notas */}
+            <div>
+              <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                <FileText className="w-4 h-4 inline mr-1" />
+                Notas (opcional)
+              </label>
+              <textarea
+                value={state.notas}
+                onChange={(e: ChangeEvent<HTMLTextAreaElement>) => dispatch({ type: 'SET_NOTAS', payload: e.target.value })}
+                placeholder="Observaciones adicionales..."
+                rows={2}
+                className="w-full px-4 py-2 border dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-green-500 dark:bg-gray-700 dark:text-white"
+              />
+            </div>
+
+          </form>
+        </CompactErrorBoundary>
 
         {/* Footer con botones */}
         <div className="p-3 sm:p-4 border-t dark:border-gray-700 shrink-0 space-y-3">

--- a/src/components/modals/ModalCompra.tsx
+++ b/src/components/modals/ModalCompra.tsx
@@ -1081,6 +1081,7 @@ function ProductosSection({ state, dispatch, productosFiltrados, onAgregarItem, 
               <label className="block text-xs text-gray-500 mb-1">Costo neto</label>
               <input
                 type="number"
+                inputMode="decimal"
                 min="0"
                 step="0.01"
                 value={itemRapido.costo || ''}
@@ -1168,6 +1169,8 @@ function ItemRow({ item, index, onActualizarItem, onEliminarItem }: ItemRowProps
             <label className="block text-xs text-gray-500 mb-1">Cant.</label>
             <input
               type="number"
+              inputMode="numeric"
+              step="1"
               min="1"
               value={item.cantidad}
               onChange={(e: ChangeEvent<HTMLInputElement>) => onActualizarItem(index, 'cantidad', parseInt(e.target.value) || 0)}
@@ -1178,6 +1181,7 @@ function ItemRow({ item, index, onActualizarItem, onEliminarItem }: ItemRowProps
             <label className="block text-xs text-gray-500 mb-1">Bonif.%</label>
             <input
               type="number"
+              inputMode="decimal"
               min="0"
               max="100"
               step="0.01"
@@ -1190,6 +1194,7 @@ function ItemRow({ item, index, onActualizarItem, onEliminarItem }: ItemRowProps
             <label className="block text-xs text-gray-500 mb-1">Neto</label>
             <input
               type="number"
+              inputMode="decimal"
               min="0"
               step="0.01"
               value={item.costoUnitario}
@@ -1201,6 +1206,7 @@ function ItemRow({ item, index, onActualizarItem, onEliminarItem }: ItemRowProps
             <label className="block text-xs text-gray-500 mb-1">II%</label>
             <input
               type="number"
+              inputMode="decimal"
               min="0"
               step="0.01"
               value={item.impuestosInternos || 0}
@@ -1224,6 +1230,8 @@ function ItemRow({ item, index, onActualizarItem, onEliminarItem }: ItemRowProps
         <div className="col-span-2">
           <input
             type="number"
+            inputMode="numeric"
+            step="1"
             min="1"
             value={item.cantidad}
             onChange={(e: ChangeEvent<HTMLInputElement>) => onActualizarItem(index, 'cantidad', parseInt(e.target.value) || 0)}
@@ -1233,6 +1241,7 @@ function ItemRow({ item, index, onActualizarItem, onEliminarItem }: ItemRowProps
         <div className="col-span-1">
           <input
             type="number"
+            inputMode="decimal"
             min="0"
             max="100"
             step="0.01"
@@ -1244,6 +1253,7 @@ function ItemRow({ item, index, onActualizarItem, onEliminarItem }: ItemRowProps
         <div className="col-span-2">
           <input
             type="number"
+            inputMode="decimal"
             min="0"
             step="0.01"
             value={item.costoUnitario}
@@ -1254,6 +1264,7 @@ function ItemRow({ item, index, onActualizarItem, onEliminarItem }: ItemRowProps
         <div className="col-span-2">
           <input
             type="number"
+            inputMode="decimal"
             min="0"
             step="0.01"
             value={item.impuestosInternos || 0}

--- a/src/components/modals/ModalEditarPedido.tsx
+++ b/src/components/modals/ModalEditarPedido.tsx
@@ -809,6 +809,7 @@ const ModalEditarPedido = memo(function ModalEditarPedido({
                     <span className="absolute left-2 top-1/2 -translate-y-1/2 text-gray-400 text-sm">$</span>
                     <input
                       type="number"
+                      inputMode="decimal"
                       step="0.01"
                       min="0"
                       value={pago.monto}
@@ -923,6 +924,7 @@ const ModalEditarPedido = memo(function ModalEditarPedido({
               <span className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-500">$</span>
               <input
                 type="number"
+                inputMode="decimal"
                 min="0"
                 max={total}
                 step="0.01"

--- a/src/components/modals/ModalEntregaConSalvedad.tsx
+++ b/src/components/modals/ModalEntregaConSalvedad.tsx
@@ -237,6 +237,8 @@ export default function ModalEntregaConSalvedad({
                             </label>
                             <input
                               type="number"
+                              inputMode="numeric"
+                              step="1"
                               min="1"
                               max={itemSalv.item.cantidad}
                               value={itemSalv.cantidadAfectada}

--- a/src/components/modals/ModalFichaCliente.tsx
+++ b/src/components/modals/ModalFichaCliente.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useMemo } from 'react'
 import type { LucideIcon } from 'lucide-react'
-import { X, User, MapPin, Phone, CreditCard, ShoppingBag, TrendingUp, DollarSign, Clock, Package, ChevronDown, ChevronUp, FileText, Plus, AlertTriangle, CheckCircle, Tag, Building2 } from 'lucide-react'
+import { User, MapPin, Phone, CreditCard, ShoppingBag, TrendingUp, DollarSign, Clock, Package, ChevronDown, ChevronUp, FileText, Plus, AlertTriangle, CheckCircle, Tag, Building2 } from 'lucide-react'
+import ModalBase from './ModalBase'
 import { useFichaCliente, usePagos } from '../../hooks/supabase'
 import { formatPrecio as formatCurrency, formatFecha as formatDate, getEstadoColor, getEstadoPagoColor } from '../../utils/formatters'
 import { logger } from '../../utils/logger'
@@ -74,62 +75,57 @@ export default function ModalFichaCliente({ cliente, onClose, onRegistrarPago, o
   if (!cliente) return null
 
   return (
-    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
-      <div className="bg-white dark:bg-gray-800 rounded-2xl w-full max-w-4xl max-h-[90vh] overflow-hidden flex flex-col">
+    <ModalBase title="Ficha Cliente" description={cliente.nombre_fantasia} onClose={onClose} maxWidth="max-w-4xl">
+      <div className="flex flex-col">
         {/* Header */}
-        <div className="p-6 border-b border-gray-200 dark:border-gray-700">
-          <div className="flex justify-between items-start">
-            <div className="flex items-start gap-4">
-              <div className="w-16 h-16 bg-gradient-to-br from-blue-500 to-blue-600 rounded-xl flex items-center justify-center">
-                <User className="w-8 h-8 text-white" />
-              </div>
-              <div className="flex-1">
-                <div className="flex items-center gap-3 flex-wrap">
-                  <h2 className="text-2xl font-bold text-gray-900 dark:text-white">{cliente.nombre_fantasia}</h2>
-                  {cliente.rubro && (
-                    <span className="px-2 py-1 bg-purple-100 dark:bg-purple-900/30 text-purple-700 dark:text-purple-300 rounded-full text-xs font-medium flex items-center gap-1">
-                      <Tag className="w-3 h-3" />
-                      {cliente.rubro}
-                    </span>
-                  )}
-                </div>
-                <p className="text-gray-600 dark:text-gray-400 flex items-center gap-1">
-                  <Building2 className="w-4 h-4" />
-                  {cliente.razon_social}
-                </p>
-                {cliente.cuit && (
-                  <p className="text-sm text-gray-500 dark:text-gray-400 mt-1">
-                    CUIT: <span className="font-mono">{cliente.cuit}</span>
-                  </p>
-                )}
-                <div className="flex items-center gap-4 mt-2 text-sm text-gray-500 dark:text-gray-400 flex-wrap">
-                  {cliente.direccion && (
-                    <span className="flex items-center gap-1">
-                      <MapPin className="w-4 h-4" />
-                      {cliente.direccion}
-                    </span>
-                  )}
-                  {cliente.telefono && (
-                    <span className="flex items-center gap-1">
-                      <Phone className="w-4 h-4" />
-                      {cliente.telefono}
-                      {cliente.contacto && (
-                        <span className="text-gray-400">({cliente.contacto})</span>
-                      )}
-                    </span>
-                  )}
-                </div>
-                {cliente.horarios_atencion && (
-                  <div className="flex items-center gap-1 mt-2 text-sm text-gray-500 dark:text-gray-400">
-                    <Clock className="w-4 h-4" />
-                    <span>{cliente.horarios_atencion}</span>
-                  </div>
-                )}
-              </div>
+        <div className="pb-6 border-b border-gray-200 dark:border-gray-700">
+          <div className="flex items-start gap-4">
+            <div className="w-16 h-16 bg-gradient-to-br from-blue-500 to-blue-600 rounded-xl flex items-center justify-center shrink-0">
+              <User className="w-8 h-8 text-white" />
             </div>
-            <button onClick={onClose} className="p-2 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-lg">
-              <X className="w-5 h-5" />
-            </button>
+            <div className="flex-1">
+              <div className="flex items-center gap-3 flex-wrap">
+                <h2 className="text-2xl font-bold text-gray-900 dark:text-white">{cliente.nombre_fantasia}</h2>
+                {cliente.rubro && (
+                  <span className="px-2 py-1 bg-purple-100 dark:bg-purple-900/30 text-purple-700 dark:text-purple-300 rounded-full text-xs font-medium flex items-center gap-1">
+                    <Tag className="w-3 h-3" />
+                    {cliente.rubro}
+                  </span>
+                )}
+              </div>
+              <p className="text-gray-600 dark:text-gray-400 flex items-center gap-1">
+                <Building2 className="w-4 h-4" />
+                {cliente.razon_social}
+              </p>
+              {cliente.cuit && (
+                <p className="text-sm text-gray-500 dark:text-gray-400 mt-1">
+                  CUIT: <span className="font-mono">{cliente.cuit}</span>
+                </p>
+              )}
+              <div className="flex items-center gap-4 mt-2 text-sm text-gray-500 dark:text-gray-400 flex-wrap">
+                {cliente.direccion && (
+                  <span className="flex items-center gap-1">
+                    <MapPin className="w-4 h-4" />
+                    {cliente.direccion}
+                  </span>
+                )}
+                {cliente.telefono && (
+                  <span className="flex items-center gap-1">
+                    <Phone className="w-4 h-4" />
+                    {cliente.telefono}
+                    {cliente.contacto && (
+                      <span className="text-gray-400">({cliente.contacto})</span>
+                    )}
+                  </span>
+                )}
+              </div>
+              {cliente.horarios_atencion && (
+                <div className="flex items-center gap-1 mt-2 text-sm text-gray-500 dark:text-gray-400">
+                  <Clock className="w-4 h-4" />
+                  <span>{cliente.horarios_atencion}</span>
+                </div>
+              )}
+            </div>
           </div>
 
           {/* Account Balance Card */}
@@ -436,7 +432,7 @@ export default function ModalFichaCliente({ cliente, onClose, onRegistrarPago, o
           ) : null}
         </div>
       </div>
-    </div>
+    </ModalBase>
   )
 }
 

--- a/src/components/modals/ModalGestionRutas.tsx
+++ b/src/components/modals/ModalGestionRutas.tsx
@@ -336,6 +336,7 @@ const ModalGestionRutas = memo(function ModalGestionRutas({
                         <label className="block text-xs font-medium mb-1">Latitud</label>
                         <input
                           type="number"
+                          inputMode="decimal"
                           step="0.000001"
                           value={depositoLat}
                           onChange={(e: ChangeEvent<HTMLInputElement>) => setDepositoLat(e.target.value)}
@@ -347,6 +348,7 @@ const ModalGestionRutas = memo(function ModalGestionRutas({
                         <label className="block text-xs font-medium mb-1">Longitud</label>
                         <input
                           type="number"
+                          inputMode="decimal"
                           step="0.000001"
                           value={depositoLng}
                           onChange={(e: ChangeEvent<HTMLInputElement>) => setDepositoLng(e.target.value)}

--- a/src/components/modals/ModalGrupoPrecio.tsx
+++ b/src/components/modals/ModalGrupoPrecio.tsx
@@ -274,6 +274,8 @@ export default function ModalGrupoPrecio({
                         {isSelected && (
                           <input
                             type="number"
+                            inputMode="numeric"
+                            step="1"
                             min="1"
                             value={moqPorProducto.get(String(p.id)) || ''}
                             onChange={e => actualizarMoqProducto(String(p.id), e.target.value)}
@@ -296,6 +298,8 @@ export default function ModalGrupoPrecio({
               <div className="flex items-center gap-2 mt-2">
                 <input
                   type="number"
+                  inputMode="numeric"
+                  step="1"
                   min="1"
                   value={moqGlobal}
                   onChange={e => setMoqGlobal(e.target.value)}
@@ -331,6 +335,8 @@ export default function ModalGrupoPrecio({
                   <div className="flex-1">
                     <input
                       type="number"
+                      inputMode="numeric"
+                      step="1"
                       min="1"
                       value={escala.cantidadMinima}
                       onChange={e => actualizarEscala(index, 'cantidadMinima', e.target.value)}
@@ -343,6 +349,7 @@ export default function ModalGrupoPrecio({
                       <span className="absolute left-3 top-1/2 transform -translate-y-1/2 text-gray-400 text-sm">$</span>
                       <input
                         type="number"
+                        inputMode="decimal"
                         min="0.01"
                         step="0.01"
                         value={escala.precioUnitario}

--- a/src/components/modals/ModalImportarPrecios.tsx
+++ b/src/components/modals/ModalImportarPrecios.tsx
@@ -1,6 +1,7 @@
 import { useState, useCallback } from 'react';
 import type { ChangeEvent, DragEvent } from 'react';
-import { X, Upload, FileSpreadsheet, AlertCircle, CheckCircle, Download, RefreshCw } from 'lucide-react';
+import { Upload, FileSpreadsheet, AlertCircle, CheckCircle, Download, RefreshCw } from 'lucide-react';
+import ModalBase from './ModalBase';
 const loadExcelUtils = () => import('../../utils/excel');
 import { validateExcelFile, validateAndSanitizeExcelData, FILE_LIMITS } from '../../utils/fileValidation';
 import { logger } from '../../utils/logger';
@@ -251,33 +252,15 @@ export default function ModalImportarPrecios({ productos, onActualizarPrecios, o
   const productosNoEncontrados: PrecioPreviewItem[] = preview.filter(p => p.estado === 'no_encontrado');
 
   return (
-    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
-      <div className="bg-white dark:bg-gray-800 rounded-xl shadow-xl w-full max-w-4xl max-h-[90vh] overflow-hidden flex flex-col">
-        {/* Header */}
-        <div className="flex items-center justify-between p-4 border-b dark:border-gray-700 shrink-0">
-          <div className="flex items-center gap-2">
-            <div className="p-2 bg-green-100 dark:bg-green-900/30 rounded-lg">
-              <FileSpreadsheet className="w-5 h-5 text-green-600" />
-            </div>
-            <div>
-              <h2 className="text-lg font-semibold text-gray-800 dark:text-white">
-                Importar Precios desde Excel
-              </h2>
-              <p className="text-sm text-gray-500">
-                Actualiza precios masivamente desde un archivo Excel
-              </p>
-            </div>
-          </div>
-          <button
-            onClick={onClose}
-            className="p-2 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-lg transition-colors"
-          >
-            <X className="w-5 h-5" />
-          </button>
-        </div>
-
+    <ModalBase
+      title="Importar Precios desde Excel"
+      description="Actualiza precios masivamente desde un archivo Excel"
+      onClose={onClose}
+      maxWidth="max-w-4xl"
+    >
+      <div className="flex flex-col">
         {/* Contenido */}
-        <div className="flex-1 overflow-y-auto p-4 space-y-4">
+        <div className="space-y-4">
           {/* Zona de carga de archivo */}
           {!archivo && (
             <div
@@ -473,7 +456,7 @@ export default function ModalImportarPrecios({ productos, onActualizarPrecios, o
         </div>
 
         {/* Footer */}
-        <div className="flex gap-3 p-4 border-t dark:border-gray-700 shrink-0">
+        <div className="flex gap-3 pt-4 mt-4 border-t dark:border-gray-700 shrink-0">
           <button
             type="button"
             onClick={onClose}
@@ -502,6 +485,6 @@ export default function ModalImportarPrecios({ productos, onActualizarPrecios, o
           )}
         </div>
       </div>
-    </div>
+    </ModalBase>
   );
 }

--- a/src/components/modals/ModalMermaStock.tsx
+++ b/src/components/modals/ModalMermaStock.tsx
@@ -156,6 +156,8 @@ export default function ModalMermaStock({
             </label>
             <input
               type="number"
+              inputMode="numeric"
+              step="1"
               min="1"
               max={producto.stock}
               value={cantidad}

--- a/src/components/modals/ModalNotaCredito.tsx
+++ b/src/components/modals/ModalNotaCredito.tsx
@@ -205,6 +205,8 @@ export default function ModalNotaCredito({
                       <td className="px-4 py-3 text-center">
                         <input
                           type="number"
+                          inputMode="numeric"
+                          step="1"
                           min={0}
                           max={max}
                           value={cant}

--- a/src/components/modals/ModalOptimizarRuta.tsx
+++ b/src/components/modals/ModalOptimizarRuta.tsx
@@ -125,6 +125,7 @@ const ModalOptimizarRuta = memo(function ModalOptimizarRuta({
                   <label className="block text-xs font-medium mb-1">Latitud</label>
                   <input
                     type="number"
+                    inputMode="decimal"
                     step="0.000001"
                     value={depositoLat}
                     onChange={(e: ChangeEvent<HTMLInputElement>) => setDepositoLat(e.target.value)}
@@ -136,6 +137,7 @@ const ModalOptimizarRuta = memo(function ModalOptimizarRuta({
                   <label className="block text-xs font-medium mb-1">Longitud</label>
                   <input
                     type="number"
+                    inputMode="decimal"
                     step="0.000001"
                     value={depositoLng}
                     onChange={(e: ChangeEvent<HTMLInputElement>) => setDepositoLng(e.target.value)}

--- a/src/components/modals/ModalOptimizarRutaPreventista.tsx
+++ b/src/components/modals/ModalOptimizarRutaPreventista.tsx
@@ -117,6 +117,7 @@ const ModalOptimizarRutaPreventista = memo(function ModalOptimizarRutaPreventist
                   <label className="block text-xs font-medium mb-1 dark:text-gray-300">Latitud</label>
                   <input
                     type="number"
+                    inputMode="decimal"
                     step="0.000001"
                     value={depositoLat}
                     onChange={(e: ChangeEvent<HTMLInputElement>) => setDepositoLat(e.target.value)}
@@ -128,6 +129,7 @@ const ModalOptimizarRutaPreventista = memo(function ModalOptimizarRutaPreventist
                   <label className="block text-xs font-medium mb-1 dark:text-gray-300">Longitud</label>
                   <input
                     type="number"
+                    inputMode="decimal"
                     step="0.000001"
                     value={depositoLng}
                     onChange={(e: ChangeEvent<HTMLInputElement>) => setDepositoLng(e.target.value)}

--- a/src/components/modals/ModalPedido.tsx
+++ b/src/components/modals/ModalPedido.tsx
@@ -628,6 +628,7 @@ const ModalPedido = memo(function ModalPedido({
                   <span className="text-lg font-semibold text-yellow-700 dark:text-yellow-400">$</span>
                   <input
                     type="number"
+                    inputMode="decimal"
                     min="0"
                     step="0.01"
                     max={hayDescuento ? totalFinal : calcularTotal()}

--- a/src/components/modals/ModalProducto.tsx
+++ b/src/components/modals/ModalProducto.tsx
@@ -188,6 +188,8 @@ const ModalProducto = memo(function ModalProducto({ producto, categorias, provee
             <label className="block text-sm font-medium mb-1">Stock *</label>
             <input
               type="number"
+              inputMode="numeric"
+              step="1"
               value={form.stock}
               onChange={(e: ChangeEvent<HTMLInputElement>) => {
                 const val = e.target.value;
@@ -205,6 +207,8 @@ const ModalProducto = memo(function ModalProducto({ producto, categorias, provee
           <label className="block text-sm font-medium mb-1">Stock Minimo de Seguridad</label>
           <input
             type="number"
+            inputMode="numeric"
+            step="1"
             value={form.stock_minimo !== undefined ? form.stock_minimo : 10}
             onChange={(e: ChangeEvent<HTMLInputElement>) => handleFieldChange('stock_minimo', parseInt(e.target.value) || 0)}
             className={inputClass('stock_minimo')}
@@ -298,6 +302,7 @@ const ModalProducto = memo(function ModalProducto({ producto, categorias, provee
               <label className="block text-xs font-medium mb-1 text-gray-600">Imp. Internos (%)</label>
               <input
                 type="number"
+                inputMode="decimal"
                 step="0.01"
                 min="0"
                 max="100"
@@ -319,6 +324,7 @@ const ModalProducto = memo(function ModalProducto({ producto, categorias, provee
               <label className="block text-xs font-medium mb-1 text-gray-600">Costo Neto</label>
               <input
                 type="number"
+                inputMode="decimal"
                 step="0.01"
                 value={form.costo_sin_iva || ''}
                 onChange={(e: ChangeEvent<HTMLInputElement>) => handleCostoSinIvaChange(e.target.value)}
@@ -330,6 +336,7 @@ const ModalProducto = memo(function ModalProducto({ producto, categorias, provee
               <label className="block text-xs font-medium mb-1 text-gray-600">Costo Total (Neto + IVA + Imp.Int.)</label>
               <input
                 type="number"
+                inputMode="decimal"
                 step="0.01"
                 value={form.costo_con_iva || ''}
                 readOnly
@@ -351,6 +358,7 @@ const ModalProducto = memo(function ModalProducto({ producto, categorias, provee
               <label className="block text-xs font-medium mb-1 text-gray-600">Precio Neto</label>
               <input
                 type="number"
+                inputMode="decimal"
                 step="0.01"
                 value={form.precio_sin_iva || ''}
                 onChange={(e: ChangeEvent<HTMLInputElement>) => handlePrecioSinIvaChange(e.target.value)}
@@ -362,6 +370,7 @@ const ModalProducto = memo(function ModalProducto({ producto, categorias, provee
               <label className="block text-xs font-medium mb-1 text-gray-600">Precio Final (Neto + IVA + Imp.Int.) *</label>
               <input
                 type="number"
+                inputMode="decimal"
                 step="0.01"
                 value={form.precio}
                 readOnly

--- a/src/components/modals/ModalPromocion.tsx
+++ b/src/components/modals/ModalPromocion.tsx
@@ -245,6 +245,8 @@ export default function ModalPromocion({
             </label>
             <input
               type="number"
+              inputMode="numeric"
+              step="1"
               min="1"
               value={limiteUsos}
               onChange={e => setLimiteUsos(e.target.value)}
@@ -427,6 +429,8 @@ export default function ModalPromocion({
                       </label>
                       <input
                         type="number"
+                        inputMode="numeric"
+                        step="1"
                         min="1"
                         value={unidadesPorBloque}
                         onChange={e => setUnidadesPorBloque(e.target.value)}
@@ -443,6 +447,8 @@ export default function ModalPromocion({
                       </label>
                       <input
                         type="number"
+                        inputMode="numeric"
+                        step="1"
                         min="1"
                         value={stockPorBloque}
                         onChange={e => setStockPorBloque(e.target.value)}
@@ -473,6 +479,8 @@ export default function ModalPromocion({
                 <label className="block text-xs text-purple-600 dark:text-purple-400 mb-1">Cantidad compra</label>
                 <input
                   type="number"
+                  inputMode="numeric"
+                  step="1"
                   min="1"
                   value={cantidadCompra}
                   onChange={e => setCantidadCompra(e.target.value)}
@@ -484,6 +492,8 @@ export default function ModalPromocion({
                 <label className="block text-xs text-purple-600 dark:text-purple-400 mb-1">Cantidad gratis</label>
                 <input
                   type="number"
+                  inputMode="numeric"
+                  step="1"
                   min="1"
                   value={cantidadBonificacion}
                   onChange={e => setCantidadBonificacion(e.target.value)}
@@ -613,6 +623,8 @@ export default function ModalPromocion({
                 </label>
                 <input
                   type="number"
+                  inputMode="numeric"
+                  step="1"
                   value={prioridad}
                   onChange={e => setPrioridad(e.target.value)}
                   placeholder="0"

--- a/src/components/modals/ModalProveedor.tsx
+++ b/src/components/modals/ModalProveedor.tsx
@@ -210,6 +210,7 @@ export default function ModalProveedor({
               </label>
               <input
                 type="tel"
+                inputMode="tel"
                 value={formData.telefono}
                 onChange={(e: ChangeEvent<HTMLInputElement>) => handleChange('telefono', e.target.value)}
                 className="w-full px-4 py-2 border dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-blue-500 dark:bg-gray-700 dark:text-white"
@@ -223,6 +224,7 @@ export default function ModalProveedor({
               </label>
               <input
                 type="email"
+                inputMode="email"
                 value={formData.email}
                 onChange={(e: ChangeEvent<HTMLInputElement>) => handleChange('email', e.target.value)}
                 className="w-full px-4 py-2 border dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-blue-500 dark:bg-gray-700 dark:text-white"

--- a/src/components/modals/ModalRegistrarPago.tsx
+++ b/src/components/modals/ModalRegistrarPago.tsx
@@ -270,6 +270,7 @@ export default function ModalRegistrarPago({
                         <DollarSign className="absolute left-2 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400" />
                         <input
                           type="number"
+                          inputMode="decimal"
                           step="0.01"
                           min="0"
                           value={pago.monto}
@@ -332,6 +333,7 @@ export default function ModalRegistrarPago({
                   <DollarSign className="absolute left-3 top-1/2 -translate-y-1/2 w-5 h-5 text-gray-400" />
                   <input
                     type="number"
+                    inputMode="decimal"
                     step="0.01"
                     min="0"
                     value={monto}

--- a/src/components/modals/ModalSalvedadItem.tsx
+++ b/src/components/modals/ModalSalvedadItem.tsx
@@ -193,6 +193,8 @@ export default function ModalSalvedadItem({
             </label>
             <input
               type="number"
+              inputMode="numeric"
+              step="1"
               min="1"
               max={item.cantidad}
               value={cantidad}

--- a/src/components/modals/ModalTransferencia.tsx
+++ b/src/components/modals/ModalTransferencia.tsx
@@ -340,6 +340,8 @@ export default function ModalTransferencia({
                     <div className="col-span-4 sm:col-span-2 flex items-center justify-center">
                       <input
                         type="number"
+                        inputMode="numeric"
+                        step="1"
                         min={1}
                         max={esIngreso ? undefined : item.stockDisponible}
                         value={item.cantidad}

--- a/src/components/ui/FormField.test.tsx
+++ b/src/components/ui/FormField.test.tsx
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import '@testing-library/jest-dom/vitest'
+import { FormField } from './FormField'
+
+describe('FormField', () => {
+  it('propaga inputMode al input hijo', () => {
+    render(
+      <FormField label="Precio" inputMode="decimal">
+        <input type="number" />
+      </FormField>
+    )
+    expect(screen.getByLabelText('Precio')).toHaveAttribute('inputmode', 'decimal')
+  })
+
+  it('no agrega inputMode si no se pasa la prop', () => {
+    render(
+      <FormField label="Nombre">
+        <input type="text" />
+      </FormField>
+    )
+    expect(screen.getByLabelText('Nombre')).not.toHaveAttribute('inputmode')
+  })
+})

--- a/src/components/ui/FormField.tsx
+++ b/src/components/ui/FormField.tsx
@@ -22,6 +22,12 @@ export interface FormFieldProps {
   children: ReactNode;
   /** Clases adicionales */
   className?: string;
+  /**
+   * Pista de teclado móvil (se propaga al input hijo).
+   * Útil para que Android/iOS muestren el teclado correcto en
+   * campos numéricos, de teléfono, email, etc.
+   */
+  inputMode?: 'none' | 'text' | 'tel' | 'url' | 'email' | 'numeric' | 'decimal' | 'search';
 }
 
 export function FormField({
@@ -30,7 +36,8 @@ export function FormField({
   required = false,
   hint,
   children,
-  className = ''
+  className = '',
+  inputMode
 }: FormFieldProps): ReactElement {
   const id = useId()
   const inputId = `field-${id}`
@@ -45,11 +52,12 @@ export function FormField({
 
   // Clone and enhance children with accessibility props
   const enhancedChildren = isValidElement(children)
-    ? cloneElement(children as ReactElement<{ id?: string; className?: string; 'aria-invalid'?: string; 'aria-required'?: string; 'aria-describedby'?: string }>, {
+    ? cloneElement(children as ReactElement<{ id?: string; className?: string; 'aria-invalid'?: string; 'aria-required'?: string; 'aria-describedby'?: string; inputMode?: string }>, {
         id: inputId,
         'aria-invalid': error ? 'true' : undefined,
         'aria-required': required ? 'true' : undefined,
         'aria-describedby': ariaDescribedBy,
+        ...(inputMode ? { inputMode } : {}),
         className: `${(children.props as { className?: string }).className || ''} ${
           error
             ? 'border-red-500 dark:border-red-400 bg-red-50 dark:bg-red-900/20 focus:ring-red-500'


### PR DESCRIPTION
## Fase 2 del plan de mejoras — Resiliencia UI + Mobile UX

Plan completo: `.claude/plans/hace-un-plan-de-pure-star.md` (local).

## Qué cambia

### 1. ErrorBoundary en todos los modales (vía ModalBase)
- `ModalBase` ahora envuelve `{children}` en `CompactErrorBoundary` automáticamente. Si cualquier modal que use `ModalBase` explota, se ve un fallback inline en vez de romper toda la app.
- Migrados a `ModalBase`: `ModalFichaCliente` y `ModalImportarPrecios` (ganan ESC, focus trap, max-w responsive, y el boundary automático).
- `ModalCompra` wrappea solo el body en `CompactErrorBoundary` sin migración completa (1400 líneas, demasiado riesgo para refactorizar ahora — header y footer quedan interactivos si el body explota).
- Test nuevo verifica que un componente hijo que tira exception NO rompe el modal.

### 2. Teclados mobile correctos (`inputMode`)
- **44 inputs** de tipo `type="number"` ahora tienen `inputMode="decimal"` o `inputMode="numeric"` según si son dinero/porcentaje (decimal) o cantidad entera (numeric).
- **1 cambio de tipo**: `ModalCliente` teléfono pasa de `type="text"` a `type="tel"`.
- **17 modales tocados** (Editar, Producto, Cliente, Grupo, Compra, Transferencia, Promoción, Merma, NotaCredito, Registrar/OptimizarRuta*3, EntregaConSalvedad, SalvedadItem, Pago, Proveedor).
- Pedí el `inputMode` a `FormField` también (componente compartido) con test TDD.
- Resultado en celular: al tocar un campo de precio aparece el teclado decimal directo, no el alfanumérico.

### 3. Fix menor de docs (branch protection para solo devs)
- `docs/DEPLOY_GUIDE.md` corregido: la recomendación original de "Require approvals: 1" bloquea el merge para un solo dev (GitHub no permite auto-approve). Ahora dice: 0 por defecto, cambiar a 1 cuando se sume otro dev.

## Commits (8)

1. `d7e4113` docs(DEPLOY_GUIDE): solo dev cannot self-approve...
2. `d4e0cbb` feat(modals): wrap ModalBase children in CompactErrorBoundary
3. `596acf9` refactor(ModalFichaCliente): use ModalBase for consistent behavior
4. `491aa72` refactor(ModalImportarPrecios): use ModalBase
5. `2d7d0a9` feat(ModalCompra): wrap body in CompactErrorBoundary
6. `67e78a8` feat(FormField): add inputMode prop for mobile keyboards
7. `3ce1e2d` feat(modals): add inputMode to core modals (Editar/Producto/Cliente/Grupo)
8. `cdd08a8` feat(modals): sweep remaining numeric inputs for inputMode

## Lo que NO hace (queda en backlog)

- No migra los otros ~14 modales inline a `ModalBase` (solo los 2 de bajo/medio riesgo). Queda como deuda técnica documentada.
- No refactoriza `ModalCompra` completo (demasiado riesgoso — 1400 líneas con nested modals, sticky dropdowns, scan de factura).
- No agrega `pattern` en campos DNI/CUIT (regex incorrecto es peor que no ponerlo).

## Test plan

- [x] `npm run typecheck` — pasa
- [x] `npm run lint` — pasa
- [x] `npm run test:run` — **543/543 tests pasan** (+3 nuevos: 2 de FormField, 1 de ModalBase)
- [x] Pre-commit hook corre tests en cada commit
- [ ] **QA manual en staging (Vercel) con dispositivo mobile real**:
  - [ ] Abrir `ModalEditarPedido` en celular → tocar input de precio → **teclado decimal** (no alfanumérico)
  - [ ] Abrir `ModalCliente` → input de teléfono → teclado numérico con `+` y `*#`
  - [ ] Abrir `ModalFichaCliente` → ver que se cierra con ESC, X, y se renderiza el contenido de tabs correctamente
  - [ ] Abrir `ModalImportarPrecios` → subir un Excel → ver preview y resultado
  - [ ] Provocar un error en un modal (ej: alterar temporalmente un componente para que tire) → ver fallback inline "Error inesperado", resto del modal sigue cerrable

## Riesgo

**Bajo**.
- `ModalBase` wrap del boundary: cambio aditivo, no rompe modales existentes.
- Migración `ModalFichaCliente` y `ModalImportarPrecios`: layout comparado cuidadosamente — se preservaron headers brandeados internos, tabs, y conditional rendering.
- `inputMode` es un atributo HTML estándar, ignorado en desktop y mejora mobile. Cero impacto en la capa de datos.

## Rollback si algo rompe

Ver [`docs/ROLLBACK.md`](docs/ROLLBACK.md). Cada commit es revertible por separado — los fixes son independientes.