### PR TITLE
feat: manifiesto carga + horarios en hoja de ruta, fix fecha comanda, preventistas N-a-N

### DIFF
--- a/migrations/001_cliente_preventistas_nm.sql
+++ b/migrations/001_cliente_preventistas_nm.sql
@@ -1,0 +1,95 @@
+-- 001_cliente_preventistas_nm.sql
+--
+-- Permite asignar uno o mas preventistas a un cliente (N-a-N).
+-- Regla de visibilidad:
+--   * rol 'preventista' solo ve clientes sin asignaciones O asignados a el.
+--   * Resto de roles (admin, encargado, transportista, deposito, etc.) sigue
+--     viendo todos los clientes de su sucursal.
+-- La columna clientes.preventista_id queda como legado (deprecated) y se
+-- migran sus valores a la nueva tabla. Se elimina en una migracion futura.
+
+BEGIN;
+
+-- 1. Tabla N-a-N
+CREATE TABLE IF NOT EXISTS public.cliente_preventistas (
+  cliente_id BIGINT NOT NULL REFERENCES public.clientes(id) ON DELETE CASCADE,
+  preventista_id UUID NOT NULL REFERENCES public.perfiles(id) ON DELETE CASCADE,
+  creado_en TIMESTAMPTZ NOT NULL DEFAULT now(),
+  PRIMARY KEY (cliente_id, preventista_id)
+);
+
+COMMENT ON TABLE public.cliente_preventistas IS
+  'Asignacion N-a-N entre clientes y preventistas. Si un cliente tiene filas aqui, solo esos preventistas (y admins/roles no-preventista) pueden verlo.';
+
+CREATE INDEX IF NOT EXISTS idx_cliente_preventistas_prev
+  ON public.cliente_preventistas(preventista_id);
+
+CREATE INDEX IF NOT EXISTS idx_cliente_preventistas_cliente
+  ON public.cliente_preventistas(cliente_id);
+
+-- 2. Migrar asignaciones existentes desde clientes.preventista_id
+INSERT INTO public.cliente_preventistas (cliente_id, preventista_id)
+SELECT c.id, c.preventista_id
+FROM public.clientes c
+WHERE c.preventista_id IS NOT NULL
+ON CONFLICT DO NOTHING;
+
+-- 3. Marcar la columna legado (deprecated) sin eliminarla todavia
+COMMENT ON COLUMN public.clientes.preventista_id IS
+  'DEPRECATED: usar public.cliente_preventistas. Mantenido por compatibilidad; se eliminara en una migracion futura.';
+
+-- 4. RLS en cliente_preventistas
+ALTER TABLE public.cliente_preventistas ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "cp_select" ON public.cliente_preventistas;
+CREATE POLICY "cp_select"
+  ON public.cliente_preventistas
+  FOR SELECT TO authenticated
+  USING (true);
+
+DROP POLICY IF EXISTS "cp_insert" ON public.cliente_preventistas;
+CREATE POLICY "cp_insert"
+  ON public.cliente_preventistas
+  FOR INSERT TO authenticated
+  WITH CHECK (public.es_admin());
+
+DROP POLICY IF EXISTS "cp_update" ON public.cliente_preventistas;
+CREATE POLICY "cp_update"
+  ON public.cliente_preventistas
+  FOR UPDATE TO authenticated
+  USING (public.es_admin())
+  WITH CHECK (public.es_admin());
+
+DROP POLICY IF EXISTS "cp_delete" ON public.cliente_preventistas;
+CREATE POLICY "cp_delete"
+  ON public.cliente_preventistas
+  FOR DELETE TO authenticated
+  USING (public.es_admin());
+
+-- 5. Reemplazar policy de SELECT en clientes para filtrar preventistas
+DROP POLICY IF EXISTS "mt_clientes_select" ON public.clientes;
+CREATE POLICY "mt_clientes_select"
+  ON public.clientes
+  FOR SELECT TO authenticated
+  USING (
+    sucursal_id = public.current_sucursal_id()
+    AND (
+      -- Roles que no son preventista ven todos los clientes de su sucursal
+      NOT EXISTS (
+        SELECT 1 FROM public.perfiles p
+        WHERE p.id = auth.uid() AND p.rol = 'preventista'
+      )
+      -- Preventistas: solo clientes sin asignaciones
+      OR NOT EXISTS (
+        SELECT 1 FROM public.cliente_preventistas cp
+        WHERE cp.cliente_id = clientes.id
+      )
+      -- ...o clientes asignados a ellos
+      OR EXISTS (
+        SELECT 1 FROM public.cliente_preventistas cp
+        WHERE cp.cliente_id = clientes.id AND cp.preventista_id = auth.uid()
+      )
+    )
+  );
+
+COMMIT;

--- a/src/components/containers/ClientesContainer.tsx
+++ b/src/components/containers/ClientesContainer.tsx
@@ -41,7 +41,7 @@ interface ConfirmConfig {
 }
 
 export default function ClientesContainer(): React.ReactElement {
-  const { isAdmin, isPreventista } = useAuthData()
+  const { user, isAdmin, isPreventista } = useAuthData()
   const notify = useNotification()
 
   // Queries
@@ -102,6 +102,17 @@ export default function ClientesContainer(): React.ReactElement {
 
   const handleGuardarCliente = useCallback(async (data: ClienteSaveData) => {
     // Transform from camelCase (form) to snake_case (database)
+    // preventista_ids (N-a-N) es la fuente de verdad; preventista_id (legado)
+    // se espeja con el primer asignado para no romper lecturas en otros modulos
+    // hasta que se elimine la columna en una migracion futura.
+    const isCreating = !clienteEditando
+    const baseIds = data.preventista_ids || []
+    // Al crear, si el creador es preventista (no admin), auto-asignarse al
+    // cliente. Asi el nuevo cliente queda visible solo para el creador y admin.
+    // Admin puede luego editar la lista libremente desde el modal.
+    const ids = isCreating && isPreventista && !isAdmin && user?.id
+      ? Array.from(new Set([...baseIds, user.id]))
+      : baseIds
     const dbData = {
       razon_social: data.razonSocial || data.nombreFantasia,
       nombre_fantasia: data.nombreFantasia,
@@ -117,7 +128,8 @@ export default function ClientesContainer(): React.ReactElement {
       horarios_atencion: data.horarios_atencion || undefined,
       rubro: data.rubro || undefined,
       notas: data.notas || undefined,
-      ...(data.preventista_id ? { preventista_id: data.preventista_id } : {})
+      preventista_id: ids[0] ?? null,
+      preventista_ids: ids
     }
 
     try {
@@ -134,7 +146,7 @@ export default function ClientesContainer(): React.ReactElement {
       notify.error((error as Error).message || 'Error al guardar cliente')
       throw error
     }
-  }, [clienteEditando, actualizarCliente, crearCliente, notify])
+  }, [clienteEditando, actualizarCliente, crearCliente, notify, isAdmin, isPreventista, user])
 
   return (
     <>

--- a/src/components/modals/ModalCliente.tsx
+++ b/src/components/modals/ModalCliente.tsx
@@ -35,6 +35,7 @@ export interface ClienteFormData {
   limiteCredito: number;
   diasCredito: number;
   preventista_id: string;
+  preventista_ids: string[];
 }
 
 /** Datos para guardar cliente */
@@ -111,7 +112,8 @@ const ModalCliente = memo(function ModalCliente({ cliente, onSave, onClose, guar
     notas: cliente.notas || '',
     limiteCredito: cliente.limite_credito || 0,
     diasCredito: cliente.dias_credito || 30,
-    preventista_id: cliente.preventista_id || ''
+    preventista_id: cliente.preventista_id || '',
+    preventista_ids: cliente.preventista_ids || []
   } : {
     tipo_documento: 'CUIT',
     numero_documento: '',
@@ -128,8 +130,25 @@ const ModalCliente = memo(function ModalCliente({ cliente, onSave, onClose, guar
     notas: '',
     limiteCredito: 0,
     diasCredito: 30,
-    preventista_id: ''
+    preventista_id: '',
+    preventista_ids: []
   });
+
+  const [preventistasFiltro, setPreventistasFiltro] = useState('');
+  const togglePreventista = (id: string): void => {
+    setForm(prev => {
+      const exists = prev.preventista_ids.includes(id);
+      return {
+        ...prev,
+        preventista_ids: exists
+          ? prev.preventista_ids.filter(x => x !== id)
+          : [...prev.preventista_ids, id]
+      };
+    });
+  };
+  const preventistasVisibles = preventistas.filter(p =>
+    (p.nombre || '').toLowerCase().includes(preventistasFiltro.trim().toLowerCase())
+  );
 
   const handleAddressSelect = (result: AddressSelectResult): void => {
     setForm(prev => ({
@@ -350,23 +369,53 @@ const ModalCliente = memo(function ModalCliente({ cliente, onSave, onClose, guar
           </div>
         </div>
 
-        {/* Preventista asignado */}
+        {/* Preventistas asignados (N-a-N) */}
         {isAdmin && preventistas.length > 0 && (
           <div>
             <label className="block text-sm font-medium mb-1 dark:text-gray-200 flex items-center gap-1">
               <Users className="w-4 h-4" />
-              Preventista asignado
+              Preventistas asignados
+              {form.preventista_ids.length > 0 && (
+                <span className="ml-auto text-xs text-gray-500 dark:text-gray-400">
+                  {form.preventista_ids.length} seleccionado{form.preventista_ids.length === 1 ? '' : 's'}
+                </span>
+              )}
             </label>
-            <select
-              value={form.preventista_id}
-              onChange={e => handleFieldChange('preventista_id', e.target.value)}
-              className="w-full px-3 py-2 border rounded-lg dark:bg-gray-700 dark:border-gray-600 dark:text-white"
-            >
-              <option value="">Sin asignar</option>
-              {preventistas.map(p => (
-                <option key={p.id} value={p.id}>{p.nombre}</option>
-              ))}
-            </select>
+            <p className="text-xs text-gray-500 dark:text-gray-400 mb-2">
+              Si no seleccionás ninguno, todos los preventistas ven este cliente. Si seleccionás uno o más, solo ellos (y admin) lo verán.
+            </p>
+            <input
+              type="text"
+              value={preventistasFiltro}
+              onChange={e => setPreventistasFiltro(e.target.value)}
+              placeholder="Buscar preventista..."
+              className="w-full px-3 py-2 mb-2 border rounded-lg dark:bg-gray-700 dark:border-gray-600 dark:text-white text-sm"
+            />
+            <div className="max-h-40 overflow-y-auto border rounded-lg dark:border-gray-600 divide-y dark:divide-gray-700">
+              {preventistasVisibles.length === 0 ? (
+                <div className="px-3 py-2 text-sm text-gray-500 dark:text-gray-400">
+                  Sin resultados
+                </div>
+              ) : (
+                preventistasVisibles.map(p => {
+                  const checked = form.preventista_ids.includes(p.id);
+                  return (
+                    <label
+                      key={p.id}
+                      className="flex items-center gap-2 px-3 py-2 cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-700 dark:text-gray-200"
+                    >
+                      <input
+                        type="checkbox"
+                        checked={checked}
+                        onChange={() => togglePreventista(p.id)}
+                        className="rounded"
+                      />
+                      <span className="text-sm">{p.nombre}</span>
+                    </label>
+                  );
+                })
+              )}
+            </div>
           </div>
         )}
 

--- a/src/hooks/queries/useClientesQuery.ts
+++ b/src/hooks/queries/useClientesQuery.ts
@@ -18,26 +18,61 @@ export const clientesKeys = {
   zonas: (sucursalId: number | null) => [...clientesKeys.all(sucursalId), 'zonas'] as const,
 }
 
+type ClienteRow = ClienteDB & {
+  cliente_preventistas?: { preventista_id: string }[] | null
+}
+
+function flattenPreventistaIds(row: ClienteRow): ClienteDB {
+  const { cliente_preventistas, ...rest } = row
+  return {
+    ...rest,
+    preventista_ids: (cliente_preventistas || []).map(cp => cp.preventista_id)
+  }
+}
+
 // Fetch functions
 async function fetchClientes(): Promise<ClienteDB[]> {
   const { data, error } = await supabase
     .from('clientes')
-    .select('*')
+    .select('*, cliente_preventistas(preventista_id)')
     .order('nombre_fantasia')
 
   if (error) throw error
-  return (data as ClienteDB[]) || []
+  return ((data as ClienteRow[]) || []).map(flattenPreventistaIds)
 }
 
 async function fetchClienteById(id: string): Promise<ClienteDB | null> {
   const { data, error } = await supabase
     .from('clientes')
-    .select('*')
+    .select('*, cliente_preventistas(preventista_id)')
     .eq('id', id)
     .single()
 
   if (error) throw error
-  return data as ClienteDB
+  return data ? flattenPreventistaIds(data as ClienteRow) : null
+}
+
+/**
+ * Reemplaza las filas en `cliente_preventistas` para un cliente dado.
+ * Idempotente: si el array viene vacío borra todas las asignaciones.
+ */
+async function replacePreventistaAssignments(
+  clienteId: string,
+  preventistaIds: string[]
+): Promise<void> {
+  const { error: delError } = await supabase
+    .from('cliente_preventistas')
+    .delete()
+    .eq('cliente_id', clienteId)
+  if (delError) throw delError
+
+  if (preventistaIds.length === 0) return
+
+  const rows = preventistaIds.map(pid => ({ cliente_id: clienteId, preventista_id: pid }))
+  const { error: insError } = await supabase
+    .from('cliente_preventistas')
+    .insert(rows)
+  if (insError) throw insError
 }
 
 async function fetchClientesByZona(zona: string): Promise<ClienteDB[]> {
@@ -80,6 +115,7 @@ interface ClienteCreateInput {
   rubro?: string
   notas?: string
   preventista_id?: string | null
+  preventista_ids?: string[]
 }
 
 // Mutation functions
@@ -111,43 +147,60 @@ async function createCliente(cliente: ClienteCreateInput, sucursalId: number | n
     }
   }
 
+  const { preventista_ids, ...clienteFields } = cliente
   const { data, error } = await supabase
     .from('clientes')
     .insert([{
-      razon_social: cliente.razon_social,
-      nombre_fantasia: cliente.nombre_fantasia,
-      direccion: cliente.direccion,
-      telefono: cliente.telefono || null,
-      cuit: cliente.cuit || null,
-      zona: cliente.zona || null,
-      latitud: cliente.latitud || null,
-      longitud: cliente.longitud || null,
-      limite_credito: cliente.limite_credito || 0,
-      dias_credito: cliente.dias_credito || 30,
-      contacto: cliente.contacto || null,
-      horarios_atencion: cliente.horarios_atencion || null,
-      rubro: cliente.rubro || null,
-      notas: cliente.notas || null,
+      razon_social: clienteFields.razon_social,
+      nombre_fantasia: clienteFields.nombre_fantasia,
+      direccion: clienteFields.direccion,
+      telefono: clienteFields.telefono || null,
+      cuit: clienteFields.cuit || null,
+      zona: clienteFields.zona || null,
+      latitud: clienteFields.latitud || null,
+      longitud: clienteFields.longitud || null,
+      limite_credito: clienteFields.limite_credito || 0,
+      dias_credito: clienteFields.dias_credito || 30,
+      contacto: clienteFields.contacto || null,
+      horarios_atencion: clienteFields.horarios_atencion || null,
+      rubro: clienteFields.rubro || null,
+      notas: clienteFields.notas || null,
       sucursal_id: sucursalId,
-      ...(cliente.preventista_id ? { preventista_id: cliente.preventista_id } : {})
+      ...(clienteFields.preventista_id ? { preventista_id: clienteFields.preventista_id } : {})
     }])
     .select()
     .single()
 
   if (error) throw error
-  return data as ClienteDB
+  const newCliente = data as ClienteDB
+
+  if (preventista_ids !== undefined) {
+    await replacePreventistaAssignments(newCliente.id, preventista_ids)
+    newCliente.preventista_ids = preventista_ids
+  }
+
+  return newCliente
 }
 
 async function updateCliente({ id, data: cliente }: { id: string; data: Partial<ClienteCreateInput> }): Promise<ClienteDB> {
+  const { preventista_ids, ...clienteFields } = cliente
+
   const { data, error } = await supabase
     .from('clientes')
-    .update(cliente)
+    .update(clienteFields)
     .eq('id', id)
     .select()
     .single()
 
   if (error) throw error
-  return data as ClienteDB
+  const updated = data as ClienteDB
+
+  if (preventista_ids !== undefined) {
+    await replacePreventistaAssignments(id, preventista_ids)
+    updated.preventista_ids = preventista_ids
+  }
+
+  return updated
 }
 
 async function deleteCliente(id: string): Promise<void> {

--- a/src/lib/pdf/hojaRutaOptimizada.js
+++ b/src/lib/pdf/hojaRutaOptimizada.js
@@ -119,6 +119,19 @@ function buildCardOps(doc, pedido, orderNumber) {
     })
   }
 
+  // Horarios de atencion
+  if (pedido.cliente?.horarios_atencion) {
+    doc.setFont('helvetica', 'normal')
+    doc.setFontSize(9)
+    const horLines = doc.splitTextToSize(
+      `Horario: ${pedido.cliente.horarios_atencion}`,
+      CARD_CONTENT_WIDTH
+    )
+    horLines.slice(0, 2).forEach((line) => {
+      ops.push({ kind: 'text', text: line, fontSize: 9, bold: false, advance: 4 })
+    })
+  }
+
   // Total + estado
   ops.push({
     kind: 'text',
@@ -257,6 +270,105 @@ function buildCierreOps(pedidos) {
   return ops
 }
 
+/**
+ * Suma todas las cantidades por producto entre todos los pedidos y
+ * produce operaciones de layout para el manifiesto de carga del camion.
+ */
+function buildManifiestoOps(pedidos) {
+  const totales = {}
+  pedidos.forEach((pedido) => {
+    ;(pedido.items || []).forEach((item) => {
+      const key = item.producto_id ?? item.producto?.id ?? item.producto?.nombre ?? 'sin-id'
+      const nombre = item.producto?.nombre || 'Producto'
+      if (!totales[key]) {
+        totales[key] = { nombre, cantidad: 0 }
+      }
+      totales[key].cantidad += Number(item.cantidad) || 0
+    })
+  })
+
+  const filas = Object.values(totales)
+    .filter((t) => t.cantidad > 0)
+    .sort((a, b) => a.nombre.localeCompare(b.nombre, 'es'))
+
+  const ops = []
+  ops.push({ kind: 'manifiesto-title', text: 'MANIFIESTO DE CARGA', advance: 5.5 })
+  ops.push({
+    kind: 'manifiesto-subtitle',
+    text: 'Total de productos a cargar en el vehiculo',
+    advance: 5
+  })
+  filas.forEach((f) => {
+    ops.push({
+      kind: 'manifiesto-line',
+      cantidad: `${f.cantidad}x`,
+      nombre: f.nombre,
+      advance: 4.5
+    })
+  })
+  ops.push({ kind: 'spacer', advance: 2 })
+  ops.push({ kind: 'manifiesto-firma', advance: 5.5 })
+  return ops
+}
+
+function drawManifiestoOps(doc, ops, x, yStart) {
+  const innerX = x + CARD_INNER_PADDING
+  let y = yStart
+
+  doc.setDrawColor(80, 80, 80)
+  doc.setLineWidth(0.4)
+  doc.line(x + 1, y - 1, x + COLUMN_WIDTH - 1, y - 1)
+
+  ops.forEach((op) => {
+    switch (op.kind) {
+      case 'manifiesto-title': {
+        doc.setFont('helvetica', 'bold')
+        doc.setFontSize(11)
+        doc.setTextColor(0, 0, 0)
+        doc.text(op.text, x + COLUMN_WIDTH / 2, y + 3, { align: 'center' })
+        break
+      }
+      case 'manifiesto-subtitle': {
+        doc.setFont('helvetica', 'italic')
+        doc.setFontSize(8)
+        doc.setTextColor(60, 60, 60)
+        doc.text(op.text, x + COLUMN_WIDTH / 2, y + 3, { align: 'center' })
+        doc.setTextColor(0, 0, 0)
+        break
+      }
+      case 'manifiesto-line': {
+        doc.setFont('helvetica', 'normal')
+        doc.setFontSize(9)
+        doc.setTextColor(0, 0, 0)
+        const cantidadWidth = 12
+        doc.setFont('helvetica', 'bold')
+        doc.text(op.cantidad, innerX, y + 3)
+        doc.setFont('helvetica', 'normal')
+        const nombreLineas = doc.splitTextToSize(
+          op.nombre,
+          CARD_CONTENT_WIDTH - cantidadWidth
+        )
+        doc.text(nombreLineas[0] || '', innerX + cantidadWidth, y + 3)
+        break
+      }
+      case 'manifiesto-firma': {
+        doc.setFont('helvetica', 'normal')
+        doc.setFontSize(9)
+        doc.setTextColor(0, 0, 0)
+        drawCheckbox(doc, innerX, y, 3)
+        doc.text('Conforme de carga - Firma: __________', innerX + 4.5, y + 2.5)
+        break
+      }
+      case 'spacer':
+      default:
+        break
+    }
+    y += op.advance || 0
+  })
+
+  return y
+}
+
 function drawCierreOps(doc, ops, x, yStart) {
   const innerX = x + CARD_INNER_PADDING
   let y = yStart
@@ -339,7 +451,19 @@ export function generarHojaRutaOptimizada(transportista, pedidos, infoRuta = {})
     advanceColumn()
   }
 
-  drawCierreOps(doc, cierreOps, columnX(), y)
+  y = drawCierreOps(doc, cierreOps, columnX(), y)
+
+  // Manifiesto de carga: resumen consolidado de productos para el chofer
+  const manifiestoOps = buildManifiestoOps(pedidos)
+  const manifiestoHeight = manifiestoOps.reduce((s, o) => s + (o.advance || 0), 0) + 4
+
+  if (y + manifiestoHeight > columnBottom) {
+    advanceColumn()
+  } else {
+    y += 3
+  }
+
+  drawManifiestoOps(doc, manifiestoOps, columnX(), y)
 
   doc.save(generateFilename('ruta', transportista?.nombre))
 }

--- a/src/lib/pdf/utils.js
+++ b/src/lib/pdf/utils.js
@@ -2,6 +2,8 @@
  * Utilidades compartidas para generación de PDFs
  */
 
+const AR_TZ = 'America/Argentina/Buenos_Aires'
+
 /**
  * Formatea un precio en formato de moneda argentina
  * @param {number} p - Precio a formatear
@@ -19,7 +21,8 @@ export const formatFecha = (fecha) =>
   new Date(fecha || new Date()).toLocaleDateString('es-AR', {
     day: '2-digit',
     month: '2-digit',
-    year: 'numeric'
+    year: 'numeric',
+    timeZone: AR_TZ
   })
 
 /**
@@ -33,7 +36,8 @@ export const formatFechaHora = (fecha) =>
     month: '2-digit',
     year: 'numeric',
     hour: '2-digit',
-    minute: '2-digit'
+    minute: '2-digit',
+    timeZone: AR_TZ
   })
 
 /**

--- a/src/types/hooks.ts
+++ b/src/types/hooks.ts
@@ -28,6 +28,12 @@ export interface ClienteDB {
   dias_credito?: number;
   saldo_cuenta?: number;
   preventista_id?: string | null;
+  /**
+   * IDs de preventistas asignados (N-a-N via tabla cliente_preventistas).
+   * Si el array está vacío o ausente, cualquier preventista lo puede ver.
+   * Si contiene uno o más IDs, solo esos preventistas (y admin) lo ven.
+   */
+  preventista_ids?: string[];
   activo?: boolean;
   created_at?: string;
   updated_at?: string;
@@ -202,6 +208,7 @@ export interface ClienteFormInput {
   limiteCredito?: string | number;
   diasCredito?: string | number;
   preventistaId?: string | null;
+  preventista_ids?: string[];
 }
 
 export interface ProductoFormInput {


### PR DESCRIPTION
## Summary

- **Manifiesto de carga** al final de la hoja de ruta con resumen consolidado por producto + checkbox de conformidad para el chofer.
- **Horarios de atención** del cliente se imprimen en cada tarjeta de pedido de la hoja de ruta (solo si están cargados).
- **Fix fecha comanda**: `formatFecha` y `formatFechaHora` ahora usan `timeZone: America/Argentina/Buenos_Aires` — la comanda ya no sale con el día anterior. Arreglo cubre también hoja de ruta y recibos.
- **Preventistas N-a-N**: nueva tabla `cliente_preventistas` con RLS — si un cliente tiene preventistas asignados, solo esos (y admin) lo ven en el listado. Al crear un cliente como preventista, se auto-asigna. Modal con checkboxes + buscador. Legacy `preventista_id` se espeja con el primero asignado.

## Database

Aplicar migración: [`migrations/001_cliente_preventistas_nm.sql`](migrations/001_cliente_preventistas_nm.sql).

Crea la tabla N-a-N, migra los `preventista_id` existentes, reemplaza la policy `mt_clientes_select` para filtrar por rol=preventista.

## Test plan

- [ ] Exportar hoja de ruta con >1 pedido — verificar manifiesto al final con cantidades totales correctas por producto.
- [ ] Cargar `horarios_atencion` en un cliente y exportar hoja de ruta — ver "Horario: …" bajo el teléfono.
- [ ] Imprimir comanda con un pedido creado — la fecha mostrada debe ser la del día correcto (AR) y no el anterior.
- [ ] Como admin, crear un cliente y asignarle 2 preventistas desde el modal. Login como un 3er preventista → ese cliente no debe aparecer en su listado; el 3ro no lo ve.
- [ ] Como preventista (no admin), crear un cliente nuevo → otros preventistas no lo ven; admin sí.
- [ ] Como admin, quitar todos los preventistas asignados a un cliente → vuelve a ser visible para todos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)