### PR TITLE
fix(clientes): auto-asignacion preventista + evitar N-a-N en edits no-admin

### DIFF
--- a/migrations/002_cliente_preventistas_self_assign.sql
+++ b/migrations/002_cliente_preventistas_self_assign.sql
@@ -1,0 +1,22 @@
+-- 002_cliente_preventistas_self_assign.sql
+--
+-- Fix sobre 001: la policy cp_insert exigia es_admin(), lo cual bloqueaba el
+-- flujo de auto-asignacion cuando un preventista crea un cliente nuevo (el
+-- frontend inserta (cliente_id, auth.uid()) inmediatamente despues del INSERT
+-- en clientes).
+-- Se relaja INSERT para permitir que cualquier usuario autenticado se
+-- auto-asigne (preventista_id = auth.uid()). Los admins siguen pudiendo
+-- asignar a terceros. UPDATE y DELETE siguen siendo admin-only.
+
+BEGIN;
+
+DROP POLICY IF EXISTS "cp_insert" ON public.cliente_preventistas;
+CREATE POLICY "cp_insert"
+  ON public.cliente_preventistas
+  FOR INSERT TO authenticated
+  WITH CHECK (
+    public.es_admin()
+    OR preventista_id = auth.uid()
+  );
+
+COMMIT;

--- a/src/components/containers/ClientesContainer.tsx
+++ b/src/components/containers/ClientesContainer.tsx
@@ -106,13 +106,21 @@ export default function ClientesContainer(): React.ReactElement {
     // se espeja con el primer asignado para no romper lecturas en otros modulos
     // hasta que se elimine la columna en una migracion futura.
     const isCreating = !clienteEditando
-    const baseIds = data.preventista_ids || []
-    // Al crear, si el creador es preventista (no admin), auto-asignarse al
-    // cliente. Asi el nuevo cliente queda visible solo para el creador y admin.
-    // Admin puede luego editar la lista libremente desde el modal.
-    const ids = isCreating && isPreventista && !isAdmin && user?.id
-      ? Array.from(new Set([...baseIds, user.id]))
-      : baseIds
+    // Solo admin puede editar las asignaciones desde la UI. Un preventista
+    // editando un cliente NO debe tocar la tabla N-a-N (RLS lo rechazaria y
+    // ademas no vio el selector). La unica excepcion: al crear, el preventista
+    // se auto-asigna para que el cliente quede visible solo para el y admins.
+    const willTouchAssignments =
+      isAdmin || (isCreating && isPreventista && !isAdmin && !!user?.id)
+
+    let ids: string[] | undefined
+    if (willTouchAssignments) {
+      const baseIds = data.preventista_ids || []
+      ids = isCreating && isPreventista && !isAdmin && user?.id
+        ? Array.from(new Set([...baseIds, user.id]))
+        : baseIds
+    }
+
     const dbData = {
       razon_social: data.razonSocial || data.nombreFantasia,
       nombre_fantasia: data.nombreFantasia,
@@ -128,8 +136,7 @@ export default function ClientesContainer(): React.ReactElement {
       horarios_atencion: data.horarios_atencion || undefined,
       rubro: data.rubro || undefined,
       notas: data.notas || undefined,
-      preventista_id: ids[0] ?? null,
-      preventista_ids: ids
+      ...(ids !== undefined ? { preventista_id: ids[0] ?? null, preventista_ids: ids } : {})
     }
 
     try {


### PR DESCRIPTION
## Summary

Hotfix para [#237](https://github.com/AgustinReiden/distribuidora-app/pull/237) (ya mergeado). Dos problemas detectados al revisar el flujo tras el merge:

1. **Preventista no podía auto-asignarse al crear un cliente**: la RLS \`cp_insert\` exigía \`es_admin()\`. La policy ahora acepta \`es_admin() OR preventista_id = auth.uid()\`, habilitando el flujo de auto-asignación que implementamos en el container.
2. **Edición de un cliente como preventista rompía la tabla N-a-N**: el container mandaba \`preventista_ids\` al editar incluso si el usuario no es admin, disparando un \`delete + insert\` en \`cliente_preventistas\` que la RLS rechazaba y podía generar duplicados. Ahora el container sólo incluye \`preventista_ids\` cuando corresponde (admin editando, o preventista creando).

## Database

Migración: [\`migrations/002_cliente_preventistas_self_assign.sql\`](migrations/002_cliente_preventistas_self_assign.sql).

**Ya aplicada en ManaosApp (\`hmuchlzmuqqxcldbzkgc\`).** Queda en el repo para trazabilidad.

## Test plan

- [ ] Como preventista, crear un cliente nuevo → debe crearse sin error y quedar auto-asignado (\`cliente_preventistas\` tiene una fila con ese preventista).
- [ ] Como preventista, editar un cliente propio (modificando sólo nombre/dirección) → el update pasa sin tocar \`cliente_preventistas\`.
- [ ] Como admin, asignar 2 preventistas a un cliente desde el modal → los dos quedan en la tabla. Luego quitar uno → se elimina.

🤖 Generated with [Claude Code](https://claude.com/claude-code)