### PR TITLE
feat(rendiciones): UI - fecha en masivos, cierre con gastos, resolver disconformidad

### DIFF
--- a/src/components/containers/PedidosContainer.tsx
+++ b/src/components/containers/PedidosContainer.tsx
@@ -323,20 +323,20 @@ export default function PedidosContainer(): React.ReactElement {
     setGuardando(false)
   }, [pedidoCancelando, cancelarPedidoMut, user, notify])
 
-  const handleEntregasMasivas = useCallback(async (transportistaId: string, pedidoIds: string[]) => {
+  const handleEntregasMasivas = useCallback(async (transportistaId: string, pedidoIds: string[], fechaEntrega: string) => {
     setGuardando(true)
     try {
-      await entregasMasivas.mutateAsync({ pedidoIds, transportistaId })
+      await entregasMasivas.mutateAsync({ pedidoIds, transportistaId, fecha: fechaEntrega })
       setModalEntregasMasivasOpen(false)
       notify.success(`${pedidoIds.length} pedido${pedidoIds.length !== 1 ? 's' : ''} marcado${pedidoIds.length !== 1 ? 's' : ''} como entregado${pedidoIds.length !== 1 ? 's' : ''}`)
     } catch (e) { notify.error('Error en entregas masivas: ' + (e as Error).message) }
     setGuardando(false)
   }, [entregasMasivas, notify])
 
-  const handlePagosMasivos = useCallback(async (formaPago: string, pedidoIds: string[]) => {
+  const handlePagosMasivos = useCallback(async (formaPago: string, pedidoIds: string[], fechaPago: string) => {
     setGuardando(true)
     try {
-      await pagosMasivos.mutateAsync({ pedidoIds, formaPago })
+      await pagosMasivos.mutateAsync({ pedidoIds, formaPago, fecha: fechaPago })
       setModalPagosMasivosOpen(false)
       notify.success(`${pedidoIds.length} pedido${pedidoIds.length !== 1 ? 's' : ''} marcado${pedidoIds.length !== 1 ? 's' : ''} como pagado${pedidoIds.length !== 1 ? 's' : ''}`)
     } catch (e) { notify.error('Error en pagos masivos: ' + (e as Error).message) }

--- a/src/components/modals/ModalCerrarRendicion.tsx
+++ b/src/components/modals/ModalCerrarRendicion.tsx
@@ -1,0 +1,270 @@
+/**
+ * Modal para cerrar/confirmar una rendición diaria.
+ *
+ * Flujo:
+ *   1. Admin/encargado elige estado final: "confirmada" o "disconformidad".
+ *   2. Opcionalmente agrega observaciones (texto libre).
+ *   3. Opcionalmente agrega N gastos (descripción + monto). No mueven caja —
+ *      son solo registro auditable por `rendicion_gastos`.
+ *   4. Al submit se llama `confirmar_rendicion` (RPC) que hace upsert de
+ *      `rendiciones_control` e inserta las filas de gastos en una transacción.
+ */
+import { useState, memo, useMemo } from 'react'
+import { Loader2, Plus, Trash2, CheckCircle2, AlertTriangle, FileText } from 'lucide-react'
+import ModalBase from './ModalBase'
+import { formatPrecio } from '../../utils/formatters'
+import type { RendicionGastoInput } from '../../types'
+
+export interface ModalCerrarRendicionProps {
+  /** Fecha de la rendición (YYYY-MM-DD) para mostrar en el header */
+  fecha: string
+  /** Nombre del transportista para contexto */
+  transportistaNombre: string
+  /** Total cobrado en esa rendición, para mostrar como referencia */
+  totalCobrado: number
+  /** Total entregado en esa fecha, para que el usuario compare */
+  totalEntregado: number
+  /** Observaciones existentes (si la rendición ya tenía) para prellenar */
+  observacionesPrevias?: string | null
+  /** Callback al confirmar. Recibe estado + observaciones + gastos. */
+  onConfirmar: (
+    estado: 'confirmada' | 'disconformidad',
+    observaciones: string | null,
+    gastos: RendicionGastoInput[]
+  ) => Promise<void>
+  onClose: () => void
+  guardando: boolean
+}
+
+interface GastoRow {
+  descripcion: string
+  monto: string
+}
+
+function formatFechaCorta(fechaISO: string): string {
+  const [y, m, d] = fechaISO.split('-')
+  return `${d}/${m}/${y}`
+}
+
+const ModalCerrarRendicion = memo(function ModalCerrarRendicion({
+  fecha,
+  transportistaNombre,
+  totalCobrado,
+  totalEntregado,
+  observacionesPrevias,
+  onConfirmar,
+  onClose,
+  guardando
+}: ModalCerrarRendicionProps) {
+  const [estado, setEstado] = useState<'confirmada' | 'disconformidad'>('confirmada')
+  const [observaciones, setObservaciones] = useState<string>(observacionesPrevias || '')
+  const [gastos, setGastos] = useState<GastoRow[]>([])
+
+  const addGasto = (): void => {
+    setGastos(prev => [...prev, { descripcion: '', monto: '' }])
+  }
+
+  const removeGasto = (idx: number): void => {
+    setGastos(prev => prev.filter((_, i) => i !== idx))
+  }
+
+  const updateGasto = (idx: number, field: keyof GastoRow, value: string): void => {
+    setGastos(prev => prev.map((g, i) => (i === idx ? { ...g, [field]: value } : g)))
+  }
+
+  const gastosValidos: RendicionGastoInput[] = useMemo(
+    () => gastos
+      .map(g => ({ descripcion: g.descripcion.trim(), monto: parseFloat(g.monto) || 0 }))
+      .filter(g => g.descripcion.length > 0 && g.monto > 0),
+    [gastos]
+  )
+
+  const totalGastos = gastosValidos.reduce((sum, g) => sum + g.monto, 0)
+  const diferencia = totalCobrado - totalEntregado
+
+  const handleSubmit = async (): Promise<void> => {
+    await onConfirmar(
+      estado,
+      observaciones.trim() || null,
+      gastosValidos
+    )
+  }
+
+  return (
+    <ModalBase title="Cerrar rendición" onClose={onClose} maxWidth="max-w-2xl">
+      <div className="p-4 space-y-4">
+        {/* Contexto: fecha + transportista */}
+        <div className="bg-gray-50 dark:bg-gray-700/50 rounded-lg p-3">
+          <p className="text-sm text-gray-600 dark:text-gray-400">
+            Rendición de <span className="font-semibold text-gray-800 dark:text-white">{transportistaNombre}</span>{' '}
+            del <span className="font-semibold text-gray-800 dark:text-white">{formatFechaCorta(fecha)}</span>
+          </p>
+          <div className="grid grid-cols-3 gap-3 mt-3 text-sm">
+            <div>
+              <p className="text-xs text-gray-500">Cobrado</p>
+              <p className="font-bold text-gray-800 dark:text-white">{formatPrecio(totalCobrado)}</p>
+            </div>
+            <div>
+              <p className="text-xs text-gray-500">Entregado</p>
+              <p className="font-bold text-gray-800 dark:text-white">{formatPrecio(totalEntregado)}</p>
+            </div>
+            <div>
+              <p className="text-xs text-gray-500">Diferencia</p>
+              <p className={`font-bold ${diferencia === 0 ? 'text-gray-800 dark:text-white' : diferencia < 0 ? 'text-red-600' : 'text-emerald-600'}`}>
+                {formatPrecio(diferencia)}
+              </p>
+            </div>
+          </div>
+        </div>
+
+        {/* Estado final */}
+        <div>
+          <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+            Resultado de la rendición
+          </label>
+          <div className="grid grid-cols-2 gap-2">
+            <button
+              type="button"
+              onClick={() => setEstado('confirmada')}
+              className={`flex items-center gap-2 px-4 py-3 rounded-lg border-2 transition-colors ${
+                estado === 'confirmada'
+                  ? 'bg-emerald-50 border-emerald-500 dark:bg-emerald-900/20 dark:border-emerald-600'
+                  : 'bg-white border-gray-200 hover:bg-gray-50 dark:bg-gray-700 dark:border-gray-600'
+              }`}
+            >
+              <CheckCircle2 className={`w-5 h-5 ${estado === 'confirmada' ? 'text-emerald-600' : 'text-gray-400'}`} />
+              <div className="text-left">
+                <p className={`font-medium ${estado === 'confirmada' ? 'text-emerald-700 dark:text-emerald-300' : 'text-gray-700 dark:text-gray-300'}`}>
+                  Confirmar
+                </p>
+                <p className="text-xs text-gray-500">Todo cuadra</p>
+              </div>
+            </button>
+            <button
+              type="button"
+              onClick={() => setEstado('disconformidad')}
+              className={`flex items-center gap-2 px-4 py-3 rounded-lg border-2 transition-colors ${
+                estado === 'disconformidad'
+                  ? 'bg-red-50 border-red-500 dark:bg-red-900/20 dark:border-red-600'
+                  : 'bg-white border-gray-200 hover:bg-gray-50 dark:bg-gray-700 dark:border-gray-600'
+              }`}
+            >
+              <AlertTriangle className={`w-5 h-5 ${estado === 'disconformidad' ? 'text-red-600' : 'text-gray-400'}`} />
+              <div className="text-left">
+                <p className={`font-medium ${estado === 'disconformidad' ? 'text-red-700 dark:text-red-300' : 'text-gray-700 dark:text-gray-300'}`}>
+                  Disconformidad
+                </p>
+                <p className="text-xs text-gray-500">Hay algo para revisar</p>
+              </div>
+            </button>
+          </div>
+        </div>
+
+        {/* Observaciones */}
+        <div>
+          <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1 flex items-center gap-1">
+            <FileText className="w-4 h-4" />
+            Observaciones {estado === 'disconformidad' && <span className="text-red-500">*</span>}
+          </label>
+          <textarea
+            value={observaciones}
+            onChange={e => setObservaciones(e.target.value)}
+            rows={3}
+            placeholder={estado === 'disconformidad'
+              ? 'Describí qué hay que revisar (ej: faltan $500 en efectivo, cheque rechazado…)'
+              : 'Opcional: notas sobre el día…'}
+            className="w-full px-3 py-2 border rounded-lg resize-none dark:bg-gray-700 dark:border-gray-600 dark:text-white text-sm"
+          />
+        </div>
+
+        {/* Gastos */}
+        <div>
+          <div className="flex items-center justify-between mb-2">
+            <label className="text-sm font-medium text-gray-700 dark:text-gray-300">
+              Gastos del día
+              {gastosValidos.length > 0 && (
+                <span className="ml-2 text-xs text-gray-500">
+                  ({gastosValidos.length} — total {formatPrecio(totalGastos)})
+                </span>
+              )}
+            </label>
+            <button
+              type="button"
+              onClick={addGasto}
+              className="flex items-center gap-1 px-2 py-1 text-xs text-blue-600 hover:bg-blue-50 dark:hover:bg-blue-900/20 rounded"
+            >
+              <Plus className="w-3 h-3" />
+              Agregar
+            </button>
+          </div>
+          <p className="text-xs text-gray-500 dark:text-gray-400 mb-2">
+            No mueven caja. Son solo registro para dejar constancia (combustible, peaje, etc.).
+          </p>
+
+          {gastos.length === 0 ? (
+            <div className="text-center py-4 border border-dashed dark:border-gray-600 rounded-lg text-sm text-gray-400">
+              Sin gastos cargados
+            </div>
+          ) : (
+            <div className="space-y-2">
+              {gastos.map((g, idx) => (
+                <div key={idx} className="flex gap-2 items-start">
+                  <input
+                    type="text"
+                    value={g.descripcion}
+                    onChange={e => updateGasto(idx, 'descripcion', e.target.value)}
+                    placeholder="Descripción (ej: combustible)"
+                    className="flex-1 px-3 py-2 text-sm border rounded-lg dark:bg-gray-700 dark:border-gray-600 dark:text-white"
+                  />
+                  <input
+                    type="number"
+                    inputMode="decimal"
+                    step="0.01"
+                    min="0"
+                    value={g.monto}
+                    onChange={e => updateGasto(idx, 'monto', e.target.value)}
+                    placeholder="0.00"
+                    className="w-28 px-3 py-2 text-sm border rounded-lg dark:bg-gray-700 dark:border-gray-600 dark:text-white"
+                  />
+                  <button
+                    type="button"
+                    onClick={() => removeGasto(idx)}
+                    className="p-2 text-red-500 hover:bg-red-50 dark:hover:bg-red-900/20 rounded"
+                    aria-label="Eliminar gasto"
+                  >
+                    <Trash2 className="w-4 h-4" />
+                  </button>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* Footer */}
+      <div className="flex items-center justify-end gap-2 p-4 border-t bg-gray-50 dark:bg-gray-800 dark:border-gray-700">
+        <button
+          onClick={onClose}
+          disabled={guardando}
+          className="px-4 py-2 text-gray-700 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-600 rounded-lg disabled:opacity-50"
+        >
+          Cancelar
+        </button>
+        <button
+          onClick={handleSubmit}
+          disabled={guardando || (estado === 'disconformidad' && !observaciones.trim())}
+          className={`px-4 py-2 rounded-lg text-white flex items-center gap-2 disabled:opacity-50 ${
+            estado === 'confirmada'
+              ? 'bg-emerald-600 hover:bg-emerald-700'
+              : 'bg-red-600 hover:bg-red-700'
+          }`}
+        >
+          {guardando && <Loader2 className="w-4 h-4 animate-spin" />}
+          {estado === 'confirmada' ? 'Confirmar rendición' : 'Marcar disconformidad'}
+        </button>
+      </div>
+    </ModalBase>
+  )
+})
+
+export default ModalCerrarRendicion

--- a/src/components/modals/ModalEntregasMasivas.tsx
+++ b/src/components/modals/ModalEntregasMasivas.tsx
@@ -1,13 +1,19 @@
 import { useState, useMemo, memo } from 'react'
-import { Loader2, Search } from 'lucide-react'
+import { Loader2, Search, Calendar } from 'lucide-react'
 import ModalBase from './ModalBase'
 import { usePedidosNoEntregadosQuery } from '../../hooks/queries'
-import { getEstadoColor, getEstadoLabel, formatPrecio } from '../../utils/formatters'
+import { getEstadoColor, getEstadoLabel, formatPrecio, fechaLocalISO } from '../../utils/formatters'
 import type { PerfilDB } from '../../types'
 
 export interface ModalEntregasMasivasProps {
   transportistas: PerfilDB[]
-  onConfirm: (transportistaId: string, pedidoIds: string[]) => Promise<void>
+  /**
+   * Callback de confirmación.
+   * @param transportistaId - ID del transportista seleccionado
+   * @param pedidoIds - IDs de los pedidos seleccionados
+   * @param fechaEntrega - Fecha a asignar a la entrega (YYYY-MM-DD, hora local AR 12:00)
+   */
+  onConfirm: (transportistaId: string, pedidoIds: string[], fechaEntrega: string) => Promise<void>
   onClose: () => void
   guardando: boolean
 }
@@ -23,6 +29,7 @@ const ModalEntregasMasivas = memo(function ModalEntregasMasivas({
   const [busqueda, setBusqueda] = useState('')
   const [fechaDesde, setFechaDesde] = useState('')
   const [fechaHasta, setFechaHasta] = useState('')
+  const [fechaEntrega, setFechaEntrega] = useState<string>(fechaLocalISO())
 
   const { data: pedidos = [], isLoading } = usePedidosNoEntregadosQuery(true)
 
@@ -59,26 +66,45 @@ const ModalEntregasMasivas = memo(function ModalEntregasMasivas({
   }
 
   const allSelected = pedidosFiltrados.length > 0 && selectedIds.size === pedidosFiltrados.length
-  const canConfirm = selectedTransportista && selectedIds.size > 0 && !guardando
+  const canConfirm = selectedTransportista && selectedIds.size > 0 && !guardando && !!fechaEntrega
 
   return (
     <ModalBase title="Entregas Masivas" onClose={onClose} maxWidth="max-w-3xl">
       <div className="p-4 space-y-4">
-        {/* Selector de transportista */}
-        <div>
-          <label className="block text-sm font-medium mb-1 text-gray-700 dark:text-gray-300">
-            Transportista
-          </label>
-          <select
-            value={selectedTransportista}
-            onChange={e => setSelectedTransportista(e.target.value)}
-            className="w-full px-3 py-2 border rounded-lg dark:bg-gray-700 dark:border-gray-600 dark:text-white"
-          >
-            <option value="">Seleccionar transportista...</option>
-            {transportistas.map(t => (
-              <option key={t.id} value={t.id}>{t.nombre}</option>
-            ))}
-          </select>
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+          {/* Selector de transportista */}
+          <div>
+            <label className="block text-sm font-medium mb-1 text-gray-700 dark:text-gray-300">
+              Transportista
+            </label>
+            <select
+              value={selectedTransportista}
+              onChange={e => setSelectedTransportista(e.target.value)}
+              className="w-full px-3 py-2 border rounded-lg dark:bg-gray-700 dark:border-gray-600 dark:text-white"
+            >
+              <option value="">Seleccionar transportista...</option>
+              {transportistas.map(t => (
+                <option key={t.id} value={t.id}>{t.nombre}</option>
+              ))}
+            </select>
+          </div>
+
+          {/* Fecha de entrega a aplicar */}
+          <div>
+            <label className="block text-sm font-medium mb-1 text-gray-700 dark:text-gray-300 flex items-center gap-1">
+              <Calendar className="w-4 h-4" />
+              Fecha de entrega
+            </label>
+            <input
+              type="date"
+              value={fechaEntrega}
+              onChange={e => setFechaEntrega(e.target.value)}
+              className="w-full px-3 py-2 border rounded-lg dark:bg-gray-700 dark:border-gray-600 dark:text-white"
+            />
+            <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
+              Se aplica a todas las entregas seleccionadas. Por defecto hoy.
+            </p>
+          </div>
         </div>
 
         {/* Filtro por fechas */}
@@ -186,7 +212,7 @@ const ModalEntregasMasivas = memo(function ModalEntregasMasivas({
             Cancelar
           </button>
           <button
-            onClick={() => canConfirm && onConfirm(selectedTransportista, Array.from(selectedIds))}
+            onClick={() => canConfirm && onConfirm(selectedTransportista, Array.from(selectedIds), fechaEntrega)}
             disabled={!canConfirm}
             className="px-4 py-2 bg-teal-600 text-white rounded-lg hover:bg-teal-700 disabled:opacity-50 disabled:cursor-not-allowed flex items-center"
           >

--- a/src/components/modals/ModalPagosMasivos.tsx
+++ b/src/components/modals/ModalPagosMasivos.tsx
@@ -1,22 +1,21 @@
 import { useState, useMemo, memo } from 'react'
-import { Loader2, Search } from 'lucide-react'
+import { Loader2, Search, Calendar } from 'lucide-react'
 import ModalBase from './ModalBase'
 import { usePedidosNoPagadosQuery } from '../../hooks/queries'
-import { getEstadoPagoColor, getEstadoPagoLabel, formatPrecio } from '../../utils/formatters'
+import { getEstadoPagoColor, getEstadoPagoLabel, formatPrecio, fechaLocalISO } from '../../utils/formatters'
+import { FORMAS_PAGO } from '../../constants/formasPago'
 
 export interface ModalPagosMasivosProps {
-  onConfirm: (formaPago: string, pedidoIds: string[]) => Promise<void>
+  /**
+   * Callback de confirmación.
+   * @param formaPago - Forma de pago seleccionada
+   * @param pedidoIds - IDs de los pedidos seleccionados
+   * @param fechaPago - Fecha contable a aplicar al pago (YYYY-MM-DD)
+   */
+  onConfirm: (formaPago: string, pedidoIds: string[], fechaPago: string) => Promise<void>
   onClose: () => void
   guardando: boolean
 }
-
-const FORMAS_PAGO = [
-  { value: 'efectivo', label: 'Efectivo' },
-  { value: 'transferencia', label: 'Transferencia' },
-  { value: 'cheque', label: 'Cheque' },
-  { value: 'cuenta_corriente', label: 'Cuenta Corriente' },
-  { value: 'tarjeta', label: 'Tarjeta' },
-]
 
 const ModalPagosMasivos = memo(function ModalPagosMasivos({
   onConfirm,
@@ -28,6 +27,7 @@ const ModalPagosMasivos = memo(function ModalPagosMasivos({
   const [busqueda, setBusqueda] = useState('')
   const [fechaDesde, setFechaDesde] = useState('')
   const [fechaHasta, setFechaHasta] = useState('')
+  const [fechaPago, setFechaPago] = useState<string>(fechaLocalISO())
 
   const { data: pedidos = [], isLoading } = usePedidosNoPagadosQuery(true)
 
@@ -64,7 +64,7 @@ const ModalPagosMasivos = memo(function ModalPagosMasivos({
   }
 
   const allSelected = pedidosFiltrados.length > 0 && selectedIds.size === pedidosFiltrados.length
-  const canConfirm = selectedFormaPago && selectedIds.size > 0 && !guardando
+  const canConfirm = selectedFormaPago && selectedIds.size > 0 && !guardando && !!fechaPago
 
   // Calculate total of selected orders
   const totalSeleccionado = useMemo(() => {
@@ -76,21 +76,40 @@ const ModalPagosMasivos = memo(function ModalPagosMasivos({
   return (
     <ModalBase title="Pagos Masivos" onClose={onClose} maxWidth="max-w-3xl">
       <div className="p-4 space-y-4">
-        {/* Selector de forma de pago */}
-        <div>
-          <label className="block text-sm font-medium mb-1 text-gray-700 dark:text-gray-300">
-            Forma de pago
-          </label>
-          <select
-            value={selectedFormaPago}
-            onChange={e => setSelectedFormaPago(e.target.value)}
-            className="w-full px-3 py-2 border rounded-lg dark:bg-gray-700 dark:border-gray-600 dark:text-white"
-          >
-            <option value="">Seleccionar forma de pago...</option>
-            {FORMAS_PAGO.map(fp => (
-              <option key={fp.value} value={fp.value}>{fp.label}</option>
-            ))}
-          </select>
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+          {/* Selector de forma de pago */}
+          <div>
+            <label className="block text-sm font-medium mb-1 text-gray-700 dark:text-gray-300">
+              Forma de pago
+            </label>
+            <select
+              value={selectedFormaPago}
+              onChange={e => setSelectedFormaPago(e.target.value)}
+              className="w-full px-3 py-2 border rounded-lg dark:bg-gray-700 dark:border-gray-600 dark:text-white"
+            >
+              <option value="">Seleccionar forma de pago...</option>
+              {FORMAS_PAGO.filter(fp => fp.value !== 'otros').map(fp => (
+                <option key={fp.value} value={fp.value}>{fp.label}</option>
+              ))}
+            </select>
+          </div>
+
+          {/* Fecha contable del pago */}
+          <div>
+            <label className="block text-sm font-medium mb-1 text-gray-700 dark:text-gray-300 flex items-center gap-1">
+              <Calendar className="w-4 h-4" />
+              Fecha del pago
+            </label>
+            <input
+              type="date"
+              value={fechaPago}
+              onChange={e => setFechaPago(e.target.value)}
+              className="w-full px-3 py-2 border rounded-lg dark:bg-gray-700 dark:border-gray-600 dark:text-white"
+            />
+            <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
+              Se imputa a la rendición de esa fecha. Por defecto hoy.
+            </p>
+          </div>
         </div>
 
         {/* Filtro por fechas */}
@@ -203,7 +222,7 @@ const ModalPagosMasivos = memo(function ModalPagosMasivos({
             Cancelar
           </button>
           <button
-            onClick={() => canConfirm && onConfirm(selectedFormaPago, Array.from(selectedIds))}
+            onClick={() => canConfirm && onConfirm(selectedFormaPago, Array.from(selectedIds), fechaPago)}
             disabled={!canConfirm}
             className="px-4 py-2 bg-green-600 text-white rounded-lg hover:bg-green-700 disabled:opacity-50 disabled:cursor-not-allowed flex items-center"
           >

--- a/src/components/modals/ModalRegistrarPago.tsx
+++ b/src/components/modals/ModalRegistrarPago.tsx
@@ -1,6 +1,6 @@
 import React, { useState, FormEvent, ChangeEvent } from 'react'
-import { X, DollarSign, FileText, AlertCircle, Check, Plus, Trash2 } from 'lucide-react'
-import { formatPrecio as formatCurrency } from '../../utils/formatters'
+import { X, DollarSign, FileText, AlertCircle, Check, Plus, Trash2, Calendar } from 'lucide-react'
+import { formatPrecio as formatCurrency, fechaLocalISO } from '../../utils/formatters'
 import { parsePrecio } from '../../utils/calculations'
 import { useZodValidation } from '../../hooks/useZodValidation'
 import { modalPagoSchema } from '../../lib/schemas'
@@ -29,6 +29,8 @@ interface PagoData {
   formaPago: string;
   referencia: string;
   notas: string;
+  /** Fecha contable del pago (YYYY-MM-DD). Default hoy. */
+  fecha: string;
 }
 
 interface PagoRegistrado extends Pago {
@@ -68,6 +70,7 @@ export default function ModalRegistrarPago({
   const [loading, setLoading] = useState<boolean>(false)
   const [pagoRegistrado, setPagoRegistrado] = useState<PagoRegistrado | null>(null)
   const [error, setError] = useState<string>('')
+  const [fecha, setFecha] = useState<string>(fechaLocalISO())
 
   // Pago dividido
   const [pagoDividido, setPagoDividido] = useState<boolean>(false)
@@ -125,7 +128,8 @@ export default function ModalRegistrarPago({
             monto: parsePrecio(pago.monto),
             formaPago: pago.formaPago,
             referencia: '',
-            notas: notas ? `${notas} (pago dividido - ${FORMAS_PAGO.find(f => f.value === pago.formaPago)?.label || pago.formaPago})` : `Pago dividido - ${FORMAS_PAGO.find(f => f.value === pago.formaPago)?.label || pago.formaPago}`
+            notas: notas ? `${notas} (pago dividido - ${FORMAS_PAGO.find(f => f.value === pago.formaPago)?.label || pago.formaPago})` : `Pago dividido - ${FORMAS_PAGO.find(f => f.value === pago.formaPago)?.label || pago.formaPago}`,
+            fecha
           })
         }
         if (ultimoPago) setPagoRegistrado(ultimoPago)
@@ -151,7 +155,8 @@ export default function ModalRegistrarPago({
           monto: result.data.monto,
           formaPago,
           referencia,
-          notas
+          notas,
+          fecha
         })
         setPagoRegistrado(pago)
       } catch (err) {
@@ -245,6 +250,23 @@ export default function ModalRegistrarPago({
               {error}
             </div>
           )}
+
+          {/* Fecha contable del pago */}
+          <div>
+            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1 flex items-center gap-1">
+              <Calendar className="w-4 h-4" />
+              Fecha del pago
+            </label>
+            <input
+              type="date"
+              value={fecha}
+              onChange={(e: ChangeEvent<HTMLInputElement>) => setFecha(e.target.value)}
+              className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 text-gray-900 dark:text-white"
+            />
+            <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
+              Se imputa a la rendición de esa fecha. Por defecto hoy.
+            </p>
+          </div>
 
           {/* Toggle pago dividido */}
           <label className="flex items-center gap-2 cursor-pointer">

--- a/src/components/modals/ModalResolverRendicion.tsx
+++ b/src/components/modals/ModalResolverRendicion.tsx
@@ -1,0 +1,103 @@
+/**
+ * Modal para resolver una rendición que está en disconformidad.
+ *
+ * Flujo:
+ *   1. El usuario describe cómo se resolvió el problema (texto obligatorio).
+ *   2. Al submit se llama `resolver_rendicion` (RPC) que cambia el estado a
+ *      'resuelta' y appendea la observación al historial preservando el texto
+ *      anterior con sello de usuario y fecha.
+ */
+import { useState, memo } from 'react'
+import { Loader2, FileText, CheckCircle } from 'lucide-react'
+import ModalBase from './ModalBase'
+
+export interface ModalResolverRendicionProps {
+  fecha: string
+  transportistaNombre: string
+  observacionesPrevias: string | null
+  onResolver: (observaciones: string) => Promise<void>
+  onClose: () => void
+  guardando: boolean
+}
+
+function formatFechaCorta(fechaISO: string): string {
+  const [y, m, d] = fechaISO.split('-')
+  return `${d}/${m}/${y}`
+}
+
+const ModalResolverRendicion = memo(function ModalResolverRendicion({
+  fecha,
+  transportistaNombre,
+  observacionesPrevias,
+  onResolver,
+  onClose,
+  guardando
+}: ModalResolverRendicionProps) {
+  const [observaciones, setObservaciones] = useState<string>('')
+
+  const handleSubmit = async (): Promise<void> => {
+    if (!observaciones.trim()) return
+    await onResolver(observaciones.trim())
+  }
+
+  return (
+    <ModalBase title="Resolver disconformidad" onClose={onClose} maxWidth="max-w-xl">
+      <div className="p-4 space-y-4">
+        <div className="bg-gray-50 dark:bg-gray-700/50 rounded-lg p-3">
+          <p className="text-sm text-gray-600 dark:text-gray-400">
+            Rendición de <span className="font-semibold text-gray-800 dark:text-white">{transportistaNombre}</span>{' '}
+            del <span className="font-semibold text-gray-800 dark:text-white">{formatFechaCorta(fecha)}</span>
+          </p>
+        </div>
+
+        {observacionesPrevias && (
+          <div className="bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg p-3">
+            <p className="text-xs font-medium text-red-700 dark:text-red-300 mb-1 flex items-center gap-1">
+              <FileText className="w-3 h-3" />
+              Observaciones previas
+            </p>
+            <p className="text-sm text-red-900 dark:text-red-200 whitespace-pre-wrap">
+              {observacionesPrevias}
+            </p>
+          </div>
+        )}
+
+        <div>
+          <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+            ¿Cómo se resolvió? <span className="text-red-500">*</span>
+          </label>
+          <textarea
+            value={observaciones}
+            onChange={e => setObservaciones(e.target.value)}
+            rows={4}
+            placeholder="Ej: Se cobró el faltante en efectivo al día siguiente / cheque reemplazado por transferencia / …"
+            className="w-full px-3 py-2 border rounded-lg resize-none dark:bg-gray-700 dark:border-gray-600 dark:text-white text-sm"
+          />
+          <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
+            El texto se append-ea al historial con tu nombre y la fecha.
+          </p>
+        </div>
+      </div>
+
+      <div className="flex items-center justify-end gap-2 p-4 border-t bg-gray-50 dark:bg-gray-800 dark:border-gray-700">
+        <button
+          onClick={onClose}
+          disabled={guardando}
+          className="px-4 py-2 text-gray-700 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-600 rounded-lg disabled:opacity-50"
+        >
+          Cancelar
+        </button>
+        <button
+          onClick={handleSubmit}
+          disabled={guardando || !observaciones.trim()}
+          className="px-4 py-2 rounded-lg text-white flex items-center gap-2 disabled:opacity-50 bg-blue-600 hover:bg-blue-700"
+        >
+          {guardando ? <Loader2 className="w-4 h-4 animate-spin" /> : <CheckCircle className="w-4 h-4" />}
+          Marcar como resuelta
+        </button>
+      </div>
+    </ModalBase>
+  )
+})
+
+export default ModalResolverRendicion

--- a/src/components/vistas/VistaRendiciones.tsx
+++ b/src/components/vistas/VistaRendiciones.tsx
@@ -1,9 +1,10 @@
 /**
- * Vista de rendiciones (resumen auto-calculado + control diario)
- * Muestra resumen por (día, transportista) con breakdown por forma de pago.
- * Admin/encargado puede marcar/desmarcar como controlada.
+ * Vista de rendiciones (resumen auto-calculado + cierre + resolucion).
+ * Muestra resumen por (dia de pago, transportista) con breakdown por forma de
+ * pago, total entregado ese dia (comparador secundario), gastos del dia y
+ * estado (pendiente/confirmada/disconformidad/resuelta).
  */
-import React, { useState, useEffect, useCallback, useMemo } from 'react'
+import React, { lazy, Suspense, useState, useEffect, useCallback, useMemo } from 'react'
 import {
   Banknote,
   Calendar,
@@ -13,12 +14,19 @@ import {
   Filter,
   RefreshCw,
   ChevronDown,
-  ChevronUp
+  ChevronUp,
+  AlertTriangle,
+  FileText,
+  Receipt
 } from 'lucide-react'
 import { fechaLocalISO } from '../../utils/formatters'
 import { useRendiciones, useUsuarios } from '../../hooks/supabase'
 import { useNotification } from '../../contexts/NotificationContext'
-import type { ResumenRendicionDiaria, PerfilDB } from '../../types'
+import { FORMAS_PAGO } from '../../constants/formasPago'
+import type { ResumenRendicionDiaria, PerfilDB, EstadoRendicion, RendicionGastoInput } from '../../types'
+
+const ModalCerrarRendicion = lazy(() => import('../modals/ModalCerrarRendicion'))
+const ModalResolverRendicion = lazy(() => import('../modals/ModalResolverRendicion'))
 
 function formatMoney(value: number | undefined | null): string {
   return new Intl.NumberFormat('es-AR', { style: 'currency', currency: 'ARS' }).format(value || 0)
@@ -29,84 +37,132 @@ function formatFechaCorta(fechaISO: string): string {
   return `${d}/${m}/${y}`
 }
 
-interface ResumenCardProps {
-  resumen: ResumenRendicionDiaria
-  onMarcar: (fecha: string, transportistaId: string) => Promise<void>
-  onDesmarcar: (fecha: string, transportistaId: string) => Promise<void>
+const ESTADO_STYLES: Record<EstadoRendicion, { label: string; badge: string; border: string }> = {
+  pendiente: {
+    label: 'Pendiente',
+    badge: 'bg-gray-100 text-gray-700 dark:bg-gray-700 dark:text-gray-300',
+    border: 'border-gray-300 dark:border-gray-600'
+  },
+  confirmada: {
+    label: 'Confirmada',
+    badge: 'bg-emerald-100 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-300',
+    border: 'border-emerald-500'
+  },
+  disconformidad: {
+    label: 'Disconformidad',
+    badge: 'bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-300',
+    border: 'border-red-500'
+  },
+  resuelta: {
+    label: 'Resuelta',
+    badge: 'bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-300',
+    border: 'border-blue-500'
+  }
 }
 
-function ResumenCard({ resumen, onMarcar, onDesmarcar }: ResumenCardProps): React.ReactElement {
+interface ResumenCardProps {
+  resumen: ResumenRendicionDiaria
+  onCerrar: (resumen: ResumenRendicionDiaria) => void
+  onResolver: (resumen: ResumenRendicionDiaria) => void
+}
+
+function ResumenCard({ resumen, onCerrar, onResolver }: ResumenCardProps): React.ReactElement {
   const [expandido, setExpandido] = useState(false)
-  const [accionando, setAccionando] = useState(false)
+  const estadoStyle = ESTADO_STYLES[resumen.estado]
 
-  const handleToggle = async (): Promise<void> => {
-    setAccionando(true)
-    try {
-      if (resumen.controlada) {
-        await onDesmarcar(resumen.fecha, resumen.transportista_id)
-      } else {
-        await onMarcar(resumen.fecha, resumen.transportista_id)
-      }
-    } finally {
-      setAccionando(false)
+  const desgloses = useMemo(() => {
+    const mapa: Record<string, number> = {
+      efectivo: resumen.total_efectivo,
+      transferencia: resumen.total_transferencia,
+      cheque: resumen.total_cheque,
+      cuenta_corriente: resumen.total_cuenta_corriente,
+      tarjeta: resumen.total_tarjeta,
+      otros: resumen.total_otros
     }
-  }
+    return FORMAS_PAGO
+      .map(fp => ({ meta: fp, value: mapa[fp.value] || 0 }))
+      .filter(d => d.value > 0)
+  }, [resumen])
 
-  const formasPago = [
-    { label: 'Efectivo', value: resumen.total_efectivo, color: 'text-green-700 dark:text-green-400' },
-    { label: 'Transferencia', value: resumen.total_transferencia, color: 'text-blue-700 dark:text-blue-400' },
-    { label: 'Cheque', value: resumen.total_cheque, color: 'text-purple-700 dark:text-purple-400' },
-    { label: 'Cuenta Cte.', value: resumen.total_cuenta_corriente, color: 'text-amber-700 dark:text-amber-400' },
-    { label: 'Tarjeta', value: resumen.total_tarjeta, color: 'text-indigo-700 dark:text-indigo-400' },
-    { label: 'Otros', value: resumen.total_otros, color: 'text-gray-700 dark:text-gray-400' }
-  ].filter(fp => fp.value > 0)
+  const diferencia = resumen.total_general - resumen.total_entregado
+  const diferenciaStr = diferencia === 0
+    ? 'Cobrado igual a entregado'
+    : diferencia > 0
+      ? `+${formatMoney(diferencia)} cobrado sobre entregado`
+      : `${formatMoney(diferencia)} cobrado menos que entregado`
 
   return (
-    <div className={`bg-white dark:bg-gray-800 rounded-xl shadow-sm border-l-4 ${
-      resumen.controlada ? 'border-green-500' : 'border-gray-300'
-    } overflow-hidden`}>
+    <div className={`bg-white dark:bg-gray-800 rounded-xl shadow-sm border-l-4 ${estadoStyle.border} overflow-hidden`}>
       <div className="p-4">
         <div className="flex items-start justify-between flex-wrap gap-3">
           <div className="flex-1 min-w-[200px]">
-            <div className="flex items-center gap-2 mb-1">
+            <div className="flex items-center gap-2 mb-1 flex-wrap">
               <User className="w-4 h-4 text-gray-500" />
               <span className="font-semibold text-gray-800 dark:text-white">
                 {resumen.transportista_nombre}
               </span>
+              <span className={`px-2 py-0.5 rounded-full text-xs font-medium ${estadoStyle.badge}`}>
+                {estadoStyle.label}
+              </span>
             </div>
-            <div className="flex items-center gap-2 text-sm text-gray-600 dark:text-gray-400">
+            <div className="flex items-center gap-2 text-sm text-gray-600 dark:text-gray-400 flex-wrap">
               <Calendar className="w-4 h-4" />
               <span>{formatFechaCorta(resumen.fecha)}</span>
               <span className="px-2 py-0.5 rounded-full text-xs bg-gray-100 dark:bg-gray-700">
-                {resumen.cantidad_pedidos} {resumen.cantidad_pedidos === 1 ? 'pedido' : 'pedidos'}
+                {resumen.cantidad_pedidos} {resumen.cantidad_pedidos === 1 ? 'pedido entregado' : 'pedidos entregados'}
               </span>
             </div>
           </div>
 
           <div className="text-right">
-            <p className="text-xs text-gray-500 dark:text-gray-400">Total general</p>
+            <p className="text-xs text-gray-500 dark:text-gray-400">Cobrado ese día</p>
             <p className="text-2xl font-bold text-gray-800 dark:text-white">
               {formatMoney(resumen.total_general)}
+            </p>
+            <p className="text-xs text-gray-500 dark:text-gray-400 mt-0.5">
+              Entregado: <span className="font-medium">{formatMoney(resumen.total_entregado)}</span>
             </p>
           </div>
         </div>
 
-        <div className="grid grid-cols-2 sm:grid-cols-3 gap-3 mt-4">
-          {formasPago.map(fp => (
-            <div key={fp.label} className="bg-gray-50 dark:bg-gray-700/50 rounded-lg p-2">
-              <p className="text-xs text-gray-500 dark:text-gray-400">{fp.label}</p>
-              <p className={`font-bold ${fp.color}`}>{formatMoney(fp.value)}</p>
-            </div>
-          ))}
-        </div>
+        {/* Breakdown por forma de pago (solo las que tienen monto) */}
+        {desgloses.length > 0 && (
+          <div className="grid grid-cols-2 sm:grid-cols-3 gap-3 mt-4">
+            {desgloses.map(({ meta, value }) => (
+              <div key={meta.value} className="bg-gray-50 dark:bg-gray-700/50 rounded-lg p-2">
+                <p className="text-xs text-gray-500 dark:text-gray-400">{meta.label}</p>
+                <p className={`font-bold text-${meta.color}-700 dark:text-${meta.color}-400`}>{formatMoney(value)}</p>
+              </div>
+            ))}
+          </div>
+        )}
 
+        {/* Indicadores de gastos y observaciones */}
+        {(resumen.cantidad_gastos > 0 || resumen.observaciones) && (
+          <div className="mt-3 flex items-center gap-3 text-xs flex-wrap">
+            {resumen.cantidad_gastos > 0 && (
+              <span className="inline-flex items-center gap-1 px-2 py-1 rounded bg-amber-50 dark:bg-amber-900/20 text-amber-700 dark:text-amber-300">
+                <Receipt className="w-3 h-3" />
+                {resumen.cantidad_gastos} gasto{resumen.cantidad_gastos !== 1 ? 's' : ''} · {formatMoney(resumen.total_gastos)}
+              </span>
+            )}
+            {resumen.observaciones && (
+              <span className="inline-flex items-center gap-1 px-2 py-1 rounded bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-300">
+                <FileText className="w-3 h-3" />
+                Con observaciones
+              </span>
+            )}
+          </div>
+        )}
+
+        {/* Footer con estado + acciones */}
         <div className="flex items-center justify-between mt-4 pt-3 border-t border-gray-200 dark:border-gray-700 flex-wrap gap-2">
-          <div className="flex items-center gap-2">
-            {resumen.controlada ? (
+          <div className="flex items-center gap-2 text-sm">
+            {resumen.estado === 'confirmada' && (
               <>
-                <CheckCircle className="w-5 h-5 text-green-500" />
+                <CheckCircle className="w-5 h-5 text-emerald-500" />
                 <div>
-                  <p className="text-sm font-medium text-green-700 dark:text-green-400">Controlada</p>
+                  <p className="font-medium text-emerald-700 dark:text-emerald-400">Confirmada</p>
                   {resumen.controlada_at && (
                     <p className="text-xs text-gray-500 dark:text-gray-400">
                       {new Date(resumen.controlada_at).toLocaleString('es-AR')}
@@ -115,15 +171,44 @@ function ResumenCard({ resumen, onMarcar, onDesmarcar }: ResumenCardProps): Reac
                   )}
                 </div>
               </>
-            ) : (
+            )}
+            {resumen.estado === 'disconformidad' && (
+              <>
+                <AlertTriangle className="w-5 h-5 text-red-500" />
+                <div>
+                  <p className="font-medium text-red-700 dark:text-red-400">Disconformidad</p>
+                  {resumen.controlada_at && (
+                    <p className="text-xs text-gray-500 dark:text-gray-400">
+                      Reportada {new Date(resumen.controlada_at).toLocaleString('es-AR')}
+                      {resumen.controlada_por_nombre && ` por ${resumen.controlada_por_nombre}`}
+                    </p>
+                  )}
+                </div>
+              </>
+            )}
+            {resumen.estado === 'resuelta' && (
+              <>
+                <CheckCircle className="w-5 h-5 text-blue-500" />
+                <div>
+                  <p className="font-medium text-blue-700 dark:text-blue-400">Resuelta</p>
+                  {resumen.resuelta_at && (
+                    <p className="text-xs text-gray-500 dark:text-gray-400">
+                      {new Date(resumen.resuelta_at).toLocaleString('es-AR')}
+                      {resumen.resuelta_por_nombre && ` por ${resumen.resuelta_por_nombre}`}
+                    </p>
+                  )}
+                </div>
+              </>
+            )}
+            {resumen.estado === 'pendiente' && (
               <>
                 <Clock className="w-5 h-5 text-gray-400" />
-                <p className="text-sm text-gray-600 dark:text-gray-400">Pendiente de control</p>
+                <p className="text-gray-600 dark:text-gray-400">Pendiente de control</p>
               </>
             )}
           </div>
 
-          <div className="flex items-center gap-2">
+          <div className="flex items-center gap-2 flex-wrap">
             <button
               onClick={() => setExpandido(!expandido)}
               className="text-sm text-gray-500 hover:text-gray-700 dark:hover:text-gray-300 flex items-center gap-1"
@@ -132,35 +217,51 @@ function ResumenCard({ resumen, onMarcar, onDesmarcar }: ResumenCardProps): Reac
               Detalle
             </button>
 
-            <button
-              onClick={handleToggle}
-              disabled={accionando}
-              className={`px-4 py-2 rounded-lg text-sm font-medium transition-colors disabled:opacity-50 ${
-                resumen.controlada
-                  ? 'bg-amber-100 hover:bg-amber-200 text-amber-800 dark:bg-amber-900/40 dark:text-amber-200'
-                  : 'bg-green-600 hover:bg-green-700 text-white'
-              }`}
-            >
-              {accionando
-                ? '...'
-                : resumen.controlada
-                  ? 'Desmarcar'
-                  : 'Marcar controlada'}
-            </button>
+            {resumen.estado === 'disconformidad' ? (
+              <button
+                onClick={() => onResolver(resumen)}
+                className="px-4 py-2 rounded-lg text-sm font-medium bg-blue-600 hover:bg-blue-700 text-white"
+              >
+                Resolver
+              </button>
+            ) : (
+              <button
+                onClick={() => onCerrar(resumen)}
+                className="px-4 py-2 rounded-lg text-sm font-medium bg-blue-600 hover:bg-blue-700 text-white"
+              >
+                {resumen.estado === 'pendiente' ? 'Cerrar rendición' : 'Editar cierre'}
+              </button>
+            )}
           </div>
         </div>
 
         {expandido && (
-          <div className="mt-4 pt-3 border-t border-gray-200 dark:border-gray-700 text-sm">
-            <p className="text-xs text-gray-500 mb-2">Breakdown completo por forma de pago:</p>
-            <div className="grid grid-cols-2 sm:grid-cols-3 gap-2">
-              <div><span className="text-gray-500">Efectivo:</span> <span className="font-medium">{formatMoney(resumen.total_efectivo)}</span></div>
-              <div><span className="text-gray-500">Transferencia:</span> <span className="font-medium">{formatMoney(resumen.total_transferencia)}</span></div>
-              <div><span className="text-gray-500">Cheque:</span> <span className="font-medium">{formatMoney(resumen.total_cheque)}</span></div>
-              <div><span className="text-gray-500">Cuenta Cte.:</span> <span className="font-medium">{formatMoney(resumen.total_cuenta_corriente)}</span></div>
-              <div><span className="text-gray-500">Tarjeta:</span> <span className="font-medium">{formatMoney(resumen.total_tarjeta)}</span></div>
-              <div><span className="text-gray-500">Otros:</span> <span className="font-medium">{formatMoney(resumen.total_otros)}</span></div>
+          <div className="mt-4 pt-3 border-t border-gray-200 dark:border-gray-700 text-sm space-y-3">
+            <div>
+              <p className="text-xs text-gray-500 mb-2">Breakdown completo por forma de pago</p>
+              <div className="grid grid-cols-2 sm:grid-cols-3 gap-2">
+                <div><span className="text-gray-500">Efectivo:</span> <span className="font-medium">{formatMoney(resumen.total_efectivo)}</span></div>
+                <div><span className="text-gray-500">Transferencia:</span> <span className="font-medium">{formatMoney(resumen.total_transferencia)}</span></div>
+                <div><span className="text-gray-500">Cheque:</span> <span className="font-medium">{formatMoney(resumen.total_cheque)}</span></div>
+                <div><span className="text-gray-500">Cuenta Cte.:</span> <span className="font-medium">{formatMoney(resumen.total_cuenta_corriente)}</span></div>
+                <div><span className="text-gray-500">Tarjeta:</span> <span className="font-medium">{formatMoney(resumen.total_tarjeta)}</span></div>
+                <div><span className="text-gray-500">Otros:</span> <span className="font-medium">{formatMoney(resumen.total_otros)}</span></div>
+              </div>
             </div>
+
+            <div className="flex items-center gap-2 text-xs text-gray-500 dark:text-gray-400">
+              <Banknote className="w-3 h-3" />
+              <span>{diferenciaStr}</span>
+            </div>
+
+            {resumen.observaciones && (
+              <div>
+                <p className="text-xs text-gray-500 mb-1">Observaciones</p>
+                <p className="text-sm text-gray-700 dark:text-gray-300 whitespace-pre-wrap bg-gray-50 dark:bg-gray-700/50 p-2 rounded">
+                  {resumen.observaciones}
+                </p>
+              </div>
+            )}
           </div>
         )}
       </div>
@@ -174,8 +275,8 @@ export default function VistaRendiciones(): React.ReactElement {
     resumenes,
     loading,
     fetchResumen,
-    marcarControlada,
-    desmarcarControlada
+    confirmarRendicion,
+    resolverRendicion
   } = useRendiciones()
   const { transportistas } = useUsuarios()
 
@@ -189,7 +290,11 @@ export default function VistaRendiciones(): React.ReactElement {
   const [fechaDesde, setFechaDesde] = useState<string>(haceUnaSemana)
   const [fechaHasta, setFechaHasta] = useState<string>(hoy)
   const [transportistaFiltro, setTransportistaFiltro] = useState<string>('')
-  const [estadoFiltro, setEstadoFiltro] = useState<'todas' | 'controladas' | 'pendientes'>('todas')
+  const [estadoFiltro, setEstadoFiltro] = useState<'todas' | 'pendientes' | 'confirmadas' | 'disconformidad' | 'resueltas'>('todas')
+
+  const [cerrarResumen, setCerrarResumen] = useState<ResumenRendicionDiaria | null>(null)
+  const [resolverResumen, setResolverResumen] = useState<ResumenRendicionDiaria | null>(null)
+  const [guardando, setGuardando] = useState(false)
 
   const cargar = useCallback(async (): Promise<void> => {
     await fetchResumen(fechaDesde, fechaHasta, transportistaFiltro || null)
@@ -199,39 +304,65 @@ export default function VistaRendiciones(): React.ReactElement {
     cargar()
   }, [cargar])
 
-  const handleMarcar = async (fecha: string, transportistaId: string): Promise<void> => {
+  const handleCerrar = useCallback(async (
+    estado: 'confirmada' | 'disconformidad',
+    observaciones: string | null,
+    gastos: RendicionGastoInput[]
+  ): Promise<void> => {
+    if (!cerrarResumen) return
+    setGuardando(true)
     try {
-      await marcarControlada(fecha, transportistaId)
-      notify.success('Rendición marcada como controlada')
+      await confirmarRendicion(
+        cerrarResumen.fecha,
+        cerrarResumen.transportista_id,
+        estado,
+        observaciones,
+        gastos
+      )
+      notify.success(estado === 'confirmada' ? 'Rendición confirmada' : 'Disconformidad registrada')
+      setCerrarResumen(null)
     } catch {
-      // Error ya notificado desde el hook
+      // Error ya notificado en el hook
+    } finally {
+      setGuardando(false)
     }
-  }
+  }, [cerrarResumen, confirmarRendicion, notify])
 
-  const handleDesmarcar = async (fecha: string, transportistaId: string): Promise<void> => {
+  const handleResolver = useCallback(async (observaciones: string): Promise<void> => {
+    if (!resolverResumen) return
+    setGuardando(true)
     try {
-      await desmarcarControlada(fecha, transportistaId)
-      notify.success('Control anulado')
+      await resolverRendicion(
+        resolverResumen.fecha,
+        resolverResumen.transportista_id,
+        observaciones
+      )
+      notify.success('Disconformidad resuelta')
+      setResolverResumen(null)
     } catch {
       // Error ya notificado
+    } finally {
+      setGuardando(false)
     }
-  }
+  }, [resolverResumen, resolverRendicion, notify])
 
   const resumenesFiltrados = useMemo(() => {
-    if (estadoFiltro === 'controladas') return resumenes.filter(r => r.controlada)
-    if (estadoFiltro === 'pendientes') return resumenes.filter(r => !r.controlada)
+    if (estadoFiltro === 'todas') return resumenes
+    if (estadoFiltro === 'pendientes') return resumenes.filter(r => r.estado === 'pendiente')
+    if (estadoFiltro === 'confirmadas') return resumenes.filter(r => r.estado === 'confirmada')
+    if (estadoFiltro === 'disconformidad') return resumenes.filter(r => r.estado === 'disconformidad')
+    if (estadoFiltro === 'resueltas') return resumenes.filter(r => r.estado === 'resuelta')
     return resumenes
   }, [resumenes, estadoFiltro])
 
-  const stats = useMemo(() => {
-    return {
-      total: resumenes.length,
-      controladas: resumenes.filter(r => r.controlada).length,
-      pendientes: resumenes.filter(r => !r.controlada).length,
-      totalGeneral: resumenes.reduce((sum, r) => sum + r.total_general, 0),
-      totalEfectivo: resumenes.reduce((sum, r) => sum + r.total_efectivo, 0)
-    }
-  }, [resumenes])
+  const stats = useMemo(() => ({
+    total: resumenes.length,
+    confirmadas: resumenes.filter(r => r.estado === 'confirmada').length,
+    pendientes: resumenes.filter(r => r.estado === 'pendiente').length,
+    disconformidad: resumenes.filter(r => r.estado === 'disconformidad').length,
+    totalCobrado: resumenes.reduce((sum, r) => sum + r.total_general, 0),
+    totalEntregado: resumenes.reduce((sum, r) => sum + r.total_entregado, 0)
+  }), [resumenes])
 
   return (
     <div className="space-y-4 p-4">
@@ -243,7 +374,7 @@ export default function VistaRendiciones(): React.ReactElement {
             Rendiciones Diarias
           </h1>
           <p className="text-gray-500 mt-1 text-sm">
-            Resumen auto-calculado de pedidos entregados por transportista y día
+            Resumen auto-calculado por transportista y día (basado en fecha de pago)
           </p>
         </div>
         <button
@@ -257,26 +388,30 @@ export default function VistaRendiciones(): React.ReactElement {
       </div>
 
       {/* Stats */}
-      <div className="grid grid-cols-2 md:grid-cols-5 gap-3">
+      <div className="grid grid-cols-2 md:grid-cols-6 gap-3">
         <div className="bg-white dark:bg-gray-800 rounded-lg p-3 shadow-sm">
           <p className="text-xs text-gray-500">Total</p>
           <p className="text-2xl font-bold">{stats.total}</p>
         </div>
         <div className="bg-white dark:bg-gray-800 rounded-lg p-3 shadow-sm">
-          <p className="text-xs text-gray-500">Controladas</p>
-          <p className="text-2xl font-bold text-green-600">{stats.controladas}</p>
+          <p className="text-xs text-gray-500">Confirmadas</p>
+          <p className="text-2xl font-bold text-emerald-600">{stats.confirmadas}</p>
         </div>
         <div className="bg-white dark:bg-gray-800 rounded-lg p-3 shadow-sm">
           <p className="text-xs text-gray-500">Pendientes</p>
           <p className="text-2xl font-bold text-amber-600">{stats.pendientes}</p>
         </div>
         <div className="bg-white dark:bg-gray-800 rounded-lg p-3 shadow-sm">
-          <p className="text-xs text-gray-500">Total general</p>
-          <p className="text-lg font-bold">{formatMoney(stats.totalGeneral)}</p>
+          <p className="text-xs text-gray-500">Disconformidad</p>
+          <p className="text-2xl font-bold text-red-600">{stats.disconformidad}</p>
         </div>
         <div className="bg-white dark:bg-gray-800 rounded-lg p-3 shadow-sm">
-          <p className="text-xs text-gray-500">Total efectivo</p>
-          <p className="text-lg font-bold text-green-600">{formatMoney(stats.totalEfectivo)}</p>
+          <p className="text-xs text-gray-500">Cobrado total</p>
+          <p className="text-lg font-bold">{formatMoney(stats.totalCobrado)}</p>
+        </div>
+        <div className="bg-white dark:bg-gray-800 rounded-lg p-3 shadow-sm">
+          <p className="text-xs text-gray-500">Entregado total</p>
+          <p className="text-lg font-bold">{formatMoney(stats.totalEntregado)}</p>
         </div>
       </div>
 
@@ -322,12 +457,14 @@ export default function VistaRendiciones(): React.ReactElement {
             <label className="block text-xs text-gray-600 dark:text-gray-400 mb-1">Estado</label>
             <select
               value={estadoFiltro}
-              onChange={(e) => setEstadoFiltro(e.target.value as 'todas' | 'controladas' | 'pendientes')}
+              onChange={(e) => setEstadoFiltro(e.target.value as typeof estadoFiltro)}
               className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md bg-white dark:bg-gray-700 text-sm"
             >
               <option value="todas">Todas</option>
-              <option value="controladas">Controladas</option>
               <option value="pendientes">Pendientes</option>
+              <option value="confirmadas">Confirmadas</option>
+              <option value="disconformidad">Disconformidad</option>
+              <option value="resueltas">Resueltas</option>
             </select>
           </div>
         </div>
@@ -350,11 +487,40 @@ export default function VistaRendiciones(): React.ReactElement {
             <ResumenCard
               key={`${r.fecha}-${r.transportista_id}`}
               resumen={r}
-              onMarcar={handleMarcar}
-              onDesmarcar={handleDesmarcar}
+              onCerrar={setCerrarResumen}
+              onResolver={setResolverResumen}
             />
           ))}
         </div>
+      )}
+
+      {/* Modales */}
+      {cerrarResumen && (
+        <Suspense fallback={null}>
+          <ModalCerrarRendicion
+            fecha={cerrarResumen.fecha}
+            transportistaNombre={cerrarResumen.transportista_nombre}
+            totalCobrado={cerrarResumen.total_general}
+            totalEntregado={cerrarResumen.total_entregado}
+            observacionesPrevias={cerrarResumen.observaciones}
+            onConfirmar={handleCerrar}
+            onClose={() => setCerrarResumen(null)}
+            guardando={guardando}
+          />
+        </Suspense>
+      )}
+
+      {resolverResumen && (
+        <Suspense fallback={null}>
+          <ModalResolverRendicion
+            fecha={resolverResumen.fecha}
+            transportistaNombre={resolverResumen.transportista_nombre}
+            observacionesPrevias={resolverResumen.observaciones}
+            onResolver={handleResolver}
+            onClose={() => setResolverResumen(null)}
+            guardando={guardando}
+          />
+        </Suspense>
       )}
     </div>
   )

--- a/src/hooks/handlers/useClienteHandlers.ts
+++ b/src/hooks/handlers/useClienteHandlers.ts
@@ -42,6 +42,8 @@ export interface DatosPagoInput {
   formaPago?: string;
   referencia?: string | null;
   notas?: string | null;
+  /** Fecha contable del pago (YYYY-MM-DD). Opcional: si se omite, la BD usa CURRENT_DATE. */
+  fecha?: string | null;
 }
 
 // =============================================================================

--- a/src/hooks/queries/usePedidosQuery.ts
+++ b/src/hooks/queries/usePedidosQuery.ts
@@ -639,41 +639,47 @@ export function usePedidosNoEntregadosQuery(enabled = false) {
   })
 }
 
-async function entregarPedidosMasivo(pedidoIds: string[], transportistaId: string): Promise<void> {
-  const ahora = new Date().toISOString()
+async function entregarPedidosMasivo(
+  pedidoIds: string[],
+  transportistaId: string,
+  fecha?: string | null
+): Promise<void> {
+  // Usa la RPC marcar_entregas_masivo que acepta fecha opcional y ancla al
+  // mediodia AR para evitar corrimientos de timezone.
+  const rpcArgs: Record<string, unknown> = {
+    p_pedido_ids: pedidoIds.map(id => Number(id)),
+    p_transportista_id: transportistaId
+  }
+  if (fecha) rpcArgs.p_fecha = fecha
 
-  const { error } = await supabase
-    .from('pedidos')
-    .update({
-      transportista_id: transportistaId,
-      estado: 'entregado',
-      fecha_entrega: ahora,
-    })
-    .in('id', pedidoIds)
-
+  const { error } = await supabase.rpc('marcar_entregas_masivo', rpcArgs)
   if (error) throw error
 
-  // Registrar historial best-effort
+  // Historial best-effort (no bloquea)
+  const fechaHistorial = fecha ? `${fecha}T12:00:00-03:00` : new Date().toISOString()
   const historialEntries = pedidoIds.map(pedidoId => ({
     pedido_id: pedidoId,
     accion: 'entregado',
     descripcion: `Entrega masiva - Transportista: ${transportistaId}`,
-    fecha: ahora,
+    fecha: fechaHistorial,
   }))
 
   await supabase.from('pedido_historial').insert(historialEntries).then(() => {})
 }
 
 /**
- * Hook para marcar multiples pedidos como entregados
+ * Hook para marcar multiples pedidos como entregados (con fecha opcional)
  */
 export function useEntregasMasivasMutation() {
   const queryClient = useQueryClient()
   const { currentSucursalId } = useSucursal()
 
   return useMutation({
-    mutationFn: ({ pedidoIds, transportistaId }: { pedidoIds: string[]; transportistaId: string }) =>
-      entregarPedidosMasivo(pedidoIds, transportistaId),
+    mutationFn: ({ pedidoIds, transportistaId, fecha }: {
+      pedidoIds: string[];
+      transportistaId: string;
+      fecha?: string | null
+    }) => entregarPedidosMasivo(pedidoIds, transportistaId, fecha),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: pedidosKeys.all(currentSucursalId) })
     },
@@ -770,24 +776,34 @@ export function usePedidosNoPagadosQuery(enabled = false) {
   })
 }
 
-async function marcarPagosMasivo(pedidoIds: string[], formaPago: string): Promise<void> {
-  const { error } = await supabase.rpc('marcar_pagos_masivo', {
+async function marcarPagosMasivo(
+  pedidoIds: string[],
+  formaPago: string,
+  fecha?: string | null
+): Promise<void> {
+  const rpcArgs: Record<string, unknown> = {
     p_pedido_ids: pedidoIds.map(id => Number(id)),
     p_forma_pago: formaPago,
-  })
+  }
+  if (fecha) rpcArgs.p_fecha = fecha
+
+  const { error } = await supabase.rpc('marcar_pagos_masivo', rpcArgs)
   if (error) throw error
 }
 
 /**
- * Hook para marcar multiples pedidos como pagados
+ * Hook para marcar multiples pedidos como pagados (con fecha opcional)
  */
 export function usePagosMasivosMutation() {
   const queryClient = useQueryClient()
   const { currentSucursalId } = useSucursal()
 
   return useMutation({
-    mutationFn: ({ pedidoIds, formaPago }: { pedidoIds: string[]; formaPago: string }) =>
-      marcarPagosMasivo(pedidoIds, formaPago),
+    mutationFn: ({ pedidoIds, formaPago, fecha }: {
+      pedidoIds: string[];
+      formaPago: string;
+      fecha?: string | null
+    }) => marcarPagosMasivo(pedidoIds, formaPago, fecha),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: pedidosKeys.all(currentSucursalId) })
     },

--- a/src/hooks/supabase/usePagos.ts
+++ b/src/hooks/supabase/usePagos.ts
@@ -36,7 +36,7 @@ export function usePagos(): UsePagosReturnExtended {
 
   const registrarPago = async (pago: PagoFormInput): Promise<PagoDBWithUsuario> => {
     try {
-      const { data, error } = await supabase.from('pagos').insert([{
+      const insertRow: Record<string, unknown> = {
         cliente_id: pago.clienteId,
         pedido_id: pago.pedidoId || null,
         monto: parseFloat(String(pago.monto)),
@@ -44,7 +44,13 @@ export function usePagos(): UsePagosReturnExtended {
         referencia: pago.referencia || null,
         notas: pago.notas || null,
         usuario_id: pago.usuarioId || null
-      }]).select('*, usuario:perfiles(id, nombre)').single()
+      }
+      // fecha (YYYY-MM-DD) se pasa solo si el caller la especificó; si no,
+      // la BD usa CURRENT_DATE (default de la columna pagos.fecha).
+      if (pago.fecha) insertRow.fecha = pago.fecha
+
+      const { data, error } = await supabase.from('pagos').insert([insertRow])
+        .select('*, usuario:perfiles(id, nombre)').single()
       if (error) throw error
       const pagoData = data as PagoDBWithUsuario
       setPagos(prev => [pagoData, ...prev])

--- a/src/hooks/supabase/useRendiciones.ts
+++ b/src/hooks/supabase/useRendiciones.ts
@@ -8,7 +8,9 @@ import { fechaLocalISO } from '../../utils/formatters'
 import type {
   ResumenRendicionDiaria,
   ControlRendicionInfo,
-  UseRendicionesReturn
+  UseRendicionesReturn,
+  EstadoRendicion,
+  RendicionGastoInput
 } from '../../types'
 
 export function useRendiciones(): UseRendicionesReturn {
@@ -47,9 +49,16 @@ export function useRendiciones(): UseRendicionesReturn {
         total_otros: Number(r.total_otros) || 0,
         total_general: Number(r.total_general) || 0,
         cantidad_pedidos: Number(r.cantidad_pedidos) || 0,
+        total_entregado: Number(r.total_entregado) || 0,
+        total_gastos: Number(r.total_gastos) || 0,
+        cantidad_gastos: Number(r.cantidad_gastos) || 0,
+        estado: ((r.estado as string) || 'pendiente') as EstadoRendicion,
+        observaciones: (r.observaciones as string) || null,
         controlada: Boolean(r.controlada),
         controlada_at: (r.controlada_at as string) || null,
-        controlada_por_nombre: (r.controlada_por_nombre as string) || null
+        controlada_por_nombre: (r.controlada_por_nombre as string) || null,
+        resuelta_at: (r.resuelta_at as string) || null,
+        resuelta_por_nombre: (r.resuelta_por_nombre as string) || null
       })) as ResumenRendicionDiaria[]
 
       setResumenes(resumen)
@@ -106,6 +115,52 @@ export function useRendiciones(): UseRendicionesReturn {
     }
   }, [ultimoRango, fetchResumen])
 
+  const confirmarRendicion = useCallback(async (
+    fecha: string,
+    transportistaId: string,
+    estado: 'confirmada' | 'disconformidad',
+    observaciones?: string | null,
+    gastos?: RendicionGastoInput[]
+  ): Promise<void> => {
+    const { error } = await supabase.rpc('confirmar_rendicion', {
+      p_fecha: fecha,
+      p_transportista_id: transportistaId,
+      p_estado: estado,
+      p_observaciones: observaciones ?? null,
+      p_gastos: (gastos || []) as unknown
+    })
+
+    if (error) {
+      notifyError('Error al cerrar rendición: ' + error.message)
+      throw error
+    }
+
+    if (ultimoRango) {
+      await fetchResumen(ultimoRango.desde, ultimoRango.hasta, ultimoRango.transportistaId)
+    }
+  }, [ultimoRango, fetchResumen])
+
+  const resolverRendicion = useCallback(async (
+    fecha: string,
+    transportistaId: string,
+    observaciones: string
+  ): Promise<void> => {
+    const { error } = await supabase.rpc('resolver_rendicion', {
+      p_fecha: fecha,
+      p_transportista_id: transportistaId,
+      p_observaciones: observaciones
+    })
+
+    if (error) {
+      notifyError('Error al resolver rendición: ' + error.message)
+      throw error
+    }
+
+    if (ultimoRango) {
+      await fetchResumen(ultimoRango.desde, ultimoRango.hasta, ultimoRango.transportistaId)
+    }
+  }, [ultimoRango, fetchResumen])
+
   const consultarControl = useCallback(async (
     transportistaId: string,
     fecha: string
@@ -143,6 +198,8 @@ export function useRendiciones(): UseRendicionesReturn {
     fetchResumen,
     marcarControlada,
     desmarcarControlada,
+    confirmarRendicion,
+    resolverRendicion,
     consultarControl,
     refetch
   }

--- a/src/types/hooks.ts
+++ b/src/types/hooks.ts
@@ -635,6 +635,8 @@ export interface PagoFormInput {
   referencia?: string | null;
   notas?: string | null;
   usuarioId?: string | null;
+  /** Fecha contable del pago (YYYY-MM-DD). Si se omite, usa CURRENT_DATE. */
+  fecha?: string | null;
 }
 
 export interface ResumenCuenta {
@@ -1125,6 +1127,8 @@ export interface UseReportesFinancierosReturn {
  * Retornado por la RPC `obtener_resumen_rendiciones`. No se persiste: se
  * calcula sobre pedidos entregados.
  */
+export type EstadoRendicion = 'pendiente' | 'confirmada' | 'disconformidad' | 'resuelta';
+
 export interface ResumenRendicionDiaria {
   fecha: string;
   transportista_id: string;
@@ -1135,11 +1139,29 @@ export interface ResumenRendicionDiaria {
   total_cuenta_corriente: number;
   total_tarjeta: number;
   total_otros: number;
+  /** Total cobrado ese día (suma de pagos) */
   total_general: number;
+  /** Cantidad de pedidos entregados ese día */
   cantidad_pedidos: number;
+  /** Total facturado entregado ese día (para comparar contra cobrado) */
+  total_entregado: number;
+  /** Suma de gastos registrados al cerrar la rendición */
+  total_gastos: number;
+  cantidad_gastos: number;
+  /** Estado de la rendición: pendiente | confirmada | disconformidad | resuelta */
+  estado: EstadoRendicion;
+  observaciones: string | null;
+  /** true si estado ∈ {confirmada, resuelta}. Mantenido por compat con UI vieja. */
   controlada: boolean;
   controlada_at: string | null;
   controlada_por_nombre: string | null;
+  resuelta_at: string | null;
+  resuelta_por_nombre: string | null;
+}
+
+export interface RendicionGastoInput {
+  descripcion: string;
+  monto: number;
 }
 
 /** Fila de la tabla `rendiciones_control` (estado de control de una rendición diaria). */
@@ -1170,6 +1192,20 @@ export interface UseRendicionesReturn {
   ) => Promise<ResumenRendicionDiaria[]>;
   marcarControlada: (fecha: string, transportistaId: string) => Promise<void>;
   desmarcarControlada: (fecha: string, transportistaId: string) => Promise<void>;
+  /** Confirma una rendición (estado: confirmada | disconformidad) y registra gastos en el mismo call. */
+  confirmarRendicion: (
+    fecha: string,
+    transportistaId: string,
+    estado: 'confirmada' | 'disconformidad',
+    observaciones?: string | null,
+    gastos?: RendicionGastoInput[]
+  ) => Promise<void>;
+  /** Resuelve una rendición en disconformidad. Preserva el historial de observaciones. */
+  resolverRendicion: (
+    fecha: string,
+    transportistaId: string,
+    observaciones: string
+  ) => Promise<void>;
   consultarControl: (transportistaId: string, fecha: string) => Promise<ControlRendicionInfo>;
   refetch: () => Promise<void>;
 }


### PR DESCRIPTION
## Summary

PR #2 del refactor de rendiciones — la capa de UI que consume el backend del [#239](https://github.com/AgustinReiden/distribuidora-app/pull/239) (ya mergeado).

### Campo fecha en los 3 modales de imputación

- **Entregas Masivas** ([ModalEntregasMasivas.tsx](src/components/modals/ModalEntregasMasivas.tsx)) — nuevo campo "Fecha de entrega" (default hoy). Llama a `marcar_entregas_masivo` con la fecha elegida anclada al mediodía AR.
- **Pagos Masivos** ([ModalPagosMasivos.tsx](src/components/modals/ModalPagosMasivos.tsx)) — "Fecha del pago" (default hoy) + usa la constante `FORMAS_PAGO` compartida. La fecha se imputa a la rendición de ese día vía la RPC v2.
- **Registrar Pago individual** ([ModalRegistrarPago.tsx](src/components/modals/ModalRegistrarPago.tsx)) — "Fecha del pago". Viaja por `PagoFormInput` → `usePagos.registrarPago` → `pagos.insert({ fecha })`.

### Vista de rendiciones rediseñada

[VistaRendiciones.tsx](src/components/vistas/VistaRendiciones.tsx):
- **Badge de estado** con color — `pendiente` (gris), `confirmada` (verde), `disconformidad` (rojo), `resuelta` (azul).
- **Métrica principal**: total cobrado ese día (fuente: `pagos.fecha`).
- **Métrica secundaria chica**: "Entregado: $X" debajo, para comparar pagado vs entregado como pediste.
- **Chips de contexto**: N° de gastos + monto total si hay, marcador de "Con observaciones" si hay.
- **Botón único**:
  - Estado pendiente/confirmada/resuelta → "Cerrar rendición" / "Editar cierre" abre `ModalCerrarRendicion`.
  - Estado disconformidad → "Resolver" abre `ModalResolverRendicion`.
- **Panel expandible**: breakdown completo por forma de pago + diferencia cobrado vs entregado + observaciones.
- **Stats header**: 6 métricas ahora (agregada "Disconformidad" y "Entregado total").
- **Filtro de estado**: 5 opciones (antes 3).

### Modales nuevos

- [ModalCerrarRendicion.tsx](src/components/modals/ModalCerrarRendicion.tsx): elige "Confirmar" o "Disconformidad", observaciones (obligatorio si disconformidad), lista editable de gastos (descripción + monto, "+"/"-"). Todo viaja en un solo call a `confirmar_rendicion` que hace upsert + inserción en batch.
- [ModalResolverRendicion.tsx](src/components/modals/ModalResolverRendicion.tsx): textarea obligatorio describiendo cómo se resolvió. Llama a `resolver_rendicion` que append-ea al historial con sello de usuario + fecha.

### Types y hooks

- `FormaPago` extendido a 6 valores (`cheque` y `otros` agregados).
- `EstadoRendicion` nuevo type union.
- `ResumenRendicionDiaria` con campos nuevos (estado, observaciones, total_entregado, total_gastos, cantidad_gastos, resuelta_*).
- `useRendiciones`: agrega `confirmarRendicion(fecha, transportistaId, estado, observaciones, gastos)` y `resolverRendicion(fecha, transportistaId, observaciones)`.
- `useEntregasMasivasMutation` ahora acepta `fecha`, usa la RPC `marcar_entregas_masivo` (antes UPDATE directo).
- `usePagosMasivosMutation` ahora acepta `fecha` y la pasa a la RPC v2.

### Validación

- \`tsc --noEmit\`: ✅
- \`eslint\`: ✅
- \`vitest run\`: ✅ 543 tests, 31 archivos.

## Test plan

- [ ] Exportar hoja de ruta el 22/04 con fecha de entrega 21/04 desde entregas masivas → \`pedidos.fecha_entrega\` queda 21/04 12:00 AR.
- [ ] Pagar masivamente 2 pedidos el 22/04 con fecha 21/04 → 2 filas nuevas en \`pagos\` con \`fecha=2026-04-21\`. Aparecen en la rendición del 21 (no 22).
- [ ] Registrar pago individual con fecha pasada → fila en \`pagos\` con esa fecha.
- [ ] Abrir una rendición pendiente, click "Cerrar rendición" → elegir "Confirmar" con 2 gastos ($500 combustible, $200 peaje) → estado queda \`confirmada\`, 2 filas en \`rendicion_gastos\`, aparecen el chip de gastos en la tarjeta.
- [ ] Marcar otra rendición como "Disconformidad" con observación → badge rojo. Botón cambia a "Resolver". Abrir modal, escribir resolución, submit → estado \`resuelta\` (badge azul), observaciones incluyen el bloque nuevo.
- [ ] Tarjeta muestra "Cobrado: $X" como métrica principal y "Entregado: $Y" chiquito abajo; si difieren, el detalle expandido muestra la diferencia.

🤖 Generated with [Claude Code](https://claude.com/claude-code)