### PR TITLE
feat(opcion-a): UX mobile + performance bundle

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -26,26 +26,24 @@ import TopNavigation from './components/layout/TopNavigation'
 import OfflineIndicator from './components/layout/OfflineIndicator'
 import SyncStatusBanner from './components/SyncStatusBanner'
 import SkipLinks from './components/a11y/SkipLinks'
-import {
-  AnalyticsContainer,
-  ClientesContainer,
-  ComisionesContainer,
-  ComprasContainer,
-  TransferenciasContainer,
-  DashboardContainer,
-  GruposPrecioContainer,
-  PromocionesContainer,
-  PedidosContainer,
-  ProductosContainer,
-  ProveedoresContainer,
-  RecorridoPreventistaContainer,
-  RecorridosContainer,
-  ReportesContainer,
-  UsuariosContainer
-} from './components/containers'
+import ClientesContainer from './components/containers/ClientesContainer'
+import ComprasContainer from './components/containers/ComprasContainer'
+import DashboardContainer from './components/containers/DashboardContainer'
+import GruposPrecioContainer from './components/containers/GruposPrecioContainer'
+import PedidosContainer from './components/containers/PedidosContainer'
+import ProductosContainer from './components/containers/ProductosContainer'
+import ProveedoresContainer from './components/containers/ProveedoresContainer'
+import UsuariosContainer from './components/containers/UsuariosContainer'
 
 const VistaRendiciones = lazy(() => import('./components/vistas/VistaRendiciones'))
 const VistaSalvedades = lazy(() => import('./components/vistas/VistaSalvedades'))
+const AnalyticsContainer = lazy(() => import('./components/containers/AnalyticsContainer'))
+const ReportesContainer = lazy(() => import('./components/containers/ReportesContainer'))
+const ComisionesContainer = lazy(() => import('./components/containers/ComisionesContainer'))
+const RecorridosContainer = lazy(() => import('./components/containers/RecorridosContainer'))
+const RecorridoPreventistaContainer = lazy(() => import('./components/containers/RecorridoPreventistaContainer'))
+const TransferenciasContainer = lazy(() => import('./components/containers/TransferenciasContainer'))
+const PromocionesContainer = lazy(() => import('./components/containers/PromocionesContainer'))
 
 function LoadingVista(): ReactElement {
   return (

--- a/src/components/modals/ModalPedido.tsx
+++ b/src/components/modals/ModalPedido.tsx
@@ -272,7 +272,7 @@ const ModalPedido = memo(function ModalPedido({
               <div>
                 <div className="relative">
                   <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 text-gray-400 w-5 h-5" />
-                  <input type="text" value={busquedaCliente} onChange={e => setBusquedaCliente(e.target.value)} className="w-full pl-10 pr-3 py-2 border rounded-lg dark:bg-gray-700 dark:border-gray-600 dark:text-white" placeholder="Buscar por nombre, razón social o CUIT..." />
+                  <input type="text" value={busquedaCliente} onChange={e => setBusquedaCliente(e.target.value)} autoComplete="off" className="w-full pl-10 pr-3 py-3 min-h-11 text-base border rounded-lg dark:bg-gray-700 dark:border-gray-600 dark:text-white" placeholder="Buscar por nombre, razón social o CUIT..." />
                 </div>
                 {clientesFiltrados.length > 0 && (
                   <div role="listbox" aria-label="Resultados de clientes" className="border dark:border-gray-600 rounded-lg max-h-40 overflow-y-auto mt-2">
@@ -378,7 +378,7 @@ const ModalPedido = memo(function ModalPedido({
 
             <div className="relative">
               <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 text-gray-400 w-4 h-4" />
-              <input type="text" value={busquedaProducto} onChange={e => setBusquedaProducto(e.target.value)} className="w-full pl-9 pr-3 py-2 border rounded-lg dark:bg-gray-700 dark:border-gray-600 dark:text-white" placeholder="Buscar producto..." />
+              <input type="text" value={busquedaProducto} onChange={e => setBusquedaProducto(e.target.value)} autoComplete="off" className="w-full pl-9 pr-3 py-3 min-h-11 text-base border rounded-lg dark:bg-gray-700 dark:border-gray-600 dark:text-white" placeholder="Buscar producto..." />
             </div>
           </div>
 

--- a/src/components/vistas/VistaCompras.tsx
+++ b/src/components/vistas/VistaCompras.tsx
@@ -336,47 +336,148 @@ export default function VistaCompras({
           )}
         </div>
       ) : (
-        <div className="bg-white dark:bg-gray-800 border dark:border-gray-700 rounded-lg shadow-sm overflow-x-auto">
-          <table className="w-full">
-            <thead className="bg-gray-50 dark:bg-gray-700/50">
-              <tr>
-                <th className="px-4 py-3 text-left text-sm font-medium text-gray-700 dark:text-gray-300">Fecha</th>
-                <th className="px-4 py-3 text-left text-sm font-medium text-gray-700 dark:text-gray-300">Proveedor</th>
-                <th className="px-4 py-3 text-left text-sm font-medium text-gray-700 dark:text-gray-300">N Factura</th>
-                <th className="px-4 py-3 text-center text-sm font-medium text-gray-700 dark:text-gray-300">Items</th>
-                <th className="px-4 py-3 text-center text-sm font-medium text-gray-700 dark:text-gray-300">Estado</th>
-                <th className="px-4 py-3 text-right text-sm font-medium text-gray-700 dark:text-gray-300">Total</th>
-                <th className="px-4 py-3 text-right text-sm font-medium text-gray-700 dark:text-gray-300">Acciones</th>
-              </tr>
-            </thead>
-            <tbody className="divide-y dark:divide-gray-700">
-              {comprasPaginadas.map(compra => {
-                const estadoKey = (compra.estado || 'pendiente') as EstadoCompra;
-                const estado = ESTADOS_COMPRA[estadoKey] || ESTADOS_COMPRA.pendiente;
-                const totalItems = (compra.items || []).reduce((sum: number, i: CompraItemDBExtended) => sum + i.cantidad, 0);
-                const nc = ncMap.get(String(compra.id));
+        <>
+          {/* Tabla - desktop */}
+          <div className="hidden md:block bg-white dark:bg-gray-800 border dark:border-gray-700 rounded-lg shadow-sm overflow-x-auto">
+            <table className="w-full">
+              <thead className="bg-gray-50 dark:bg-gray-700/50">
+                <tr>
+                  <th className="px-4 py-3 text-left text-sm font-medium text-gray-700 dark:text-gray-300">Fecha</th>
+                  <th className="px-4 py-3 text-left text-sm font-medium text-gray-700 dark:text-gray-300">Proveedor</th>
+                  <th className="px-4 py-3 text-left text-sm font-medium text-gray-700 dark:text-gray-300">N Factura</th>
+                  <th className="px-4 py-3 text-center text-sm font-medium text-gray-700 dark:text-gray-300">Items</th>
+                  <th className="px-4 py-3 text-center text-sm font-medium text-gray-700 dark:text-gray-300">Estado</th>
+                  <th className="px-4 py-3 text-right text-sm font-medium text-gray-700 dark:text-gray-300">Total</th>
+                  <th className="px-4 py-3 text-right text-sm font-medium text-gray-700 dark:text-gray-300">Acciones</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y dark:divide-gray-700">
+                {comprasPaginadas.map(compra => {
+                  const estadoKey = (compra.estado || 'pendiente') as EstadoCompra;
+                  const estado = ESTADOS_COMPRA[estadoKey] || ESTADOS_COMPRA.pendiente;
+                  const totalItems = (compra.items || []).reduce((sum: number, i: CompraItemDBExtended) => sum + i.cantidad, 0);
+                  const nc = ncMap.get(String(compra.id));
 
-                return (
-                  <tr key={compra.id} className="hover:bg-gray-50 dark:hover:bg-gray-700/50 transition-colors">
-                    <td className="px-4 py-3">
-                      <div className="flex items-center gap-2">
-                        <Calendar className="w-4 h-4 text-gray-400" />
-                        <span className="text-gray-800 dark:text-white">
-                          {new Date(compra.fecha_compra || compra.created_at || '').toLocaleDateString('es-AR')}
+                  return (
+                    <tr key={compra.id} className="hover:bg-gray-50 dark:hover:bg-gray-700/50 transition-colors">
+                      <td className="px-4 py-3">
+                        <div className="flex items-center gap-2">
+                          <Calendar className="w-4 h-4 text-gray-400" />
+                          <span className="text-gray-800 dark:text-white">
+                            {new Date(compra.fecha_compra || compra.created_at || '').toLocaleDateString('es-AR')}
+                          </span>
+                        </div>
+                      </td>
+                      <td className="px-4 py-3">
+                        <div className="flex items-center gap-2">
+                          <Building2 className="w-4 h-4 text-gray-400" />
+                          <span className="font-medium text-gray-800 dark:text-white">
+                            {compra.proveedor?.nombre || compra.proveedor_nombre || 'Sin proveedor'}
+                          </span>
+                        </div>
+                      </td>
+                      <td className="px-4 py-3 text-gray-500 dark:text-gray-400 font-mono text-sm">
+                        <span className="flex items-center gap-1.5">
+                          {compra.numero_factura || '-'}
+                          {compra.tipo_factura && (
+                            <span className={`text-xs px-1.5 py-0.5 rounded font-medium ${
+                              compra.tipo_factura === 'FC'
+                                ? 'bg-blue-100 text-blue-700 dark:bg-blue-900 dark:text-blue-300'
+                                : 'bg-gray-100 text-gray-600 dark:bg-gray-700 dark:text-gray-400'
+                            }`}>
+                              {compra.tipo_factura}
+                            </span>
+                          )}
                         </span>
-                      </div>
-                    </td>
-                    <td className="px-4 py-3">
-                      <div className="flex items-center gap-2">
-                        <Building2 className="w-4 h-4 text-gray-400" />
-                        <span className="font-medium text-gray-800 dark:text-white">
-                          {compra.proveedor?.nombre || compra.proveedor_nombre || 'Sin proveedor'}
-                        </span>
-                      </div>
-                    </td>
-                    <td className="px-4 py-3 text-gray-500 dark:text-gray-400 font-mono text-sm">
-                      <span className="flex items-center gap-1.5">
-                        {compra.numero_factura || '-'}
+                      </td>
+                      <td className="px-4 py-3 text-center">
+                        <div className="flex items-center justify-center gap-1">
+                          <Package className="w-4 h-4 text-gray-400" />
+                          <span className="text-gray-800 dark:text-white">{totalItems}</span>
+                        </div>
+                      </td>
+                      <td className="px-4 py-3 text-center">
+                        <div className="flex flex-col items-center gap-1">
+                          <span className={`px-2 py-1 rounded-full text-xs font-medium ${estado.color}`}>
+                            {estado.label}
+                          </span>
+                          {nc && (
+                            <span className="px-2 py-0.5 rounded-full text-xs font-medium bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-400 flex items-center gap-1">
+                              <FileText className="w-3 h-3" />
+                              {nc.cantidad} NC
+                            </span>
+                          )}
+                        </div>
+                      </td>
+                      <td className="px-4 py-3 text-right">
+                        <div>
+                          <span className="font-semibold text-green-600 dark:text-green-400">
+                            {formatPrecio(compra.total)}
+                          </span>
+                          {nc && (
+                            <p className="text-xs text-blue-600 dark:text-blue-400">
+                              NC: -{formatPrecio(nc.total)}
+                            </p>
+                          )}
+                        </div>
+                      </td>
+                      <td className="px-4 py-3 text-right">
+                        <div className="flex justify-end gap-1">
+                          <button
+                            onClick={() => onVerDetalle(compra)}
+                            className="p-2 text-blue-500 hover:bg-blue-50 dark:hover:bg-blue-900/30 rounded-lg transition-colors"
+                            title="Ver detalle"
+                          >
+                            <Eye className="w-4 h-4" />
+                          </button>
+                          {isAdmin && compra.estado !== 'cancelada' && onNotaCredito && (
+                            <button
+                              onClick={() => onNotaCredito(compra)}
+                              className="p-2 text-blue-600 hover:bg-blue-50 dark:hover:bg-blue-900/30 rounded-lg transition-colors"
+                              title="Nota de Credito"
+                            >
+                              <FileText className="w-4 h-4" />
+                            </button>
+                          )}
+                          {isAdmin && compra.estado !== 'cancelada' && (
+                            <button
+                              onClick={() => onAnularCompra(compra.id)}
+                              className="p-2 text-red-500 hover:bg-red-50 dark:hover:bg-red-900/30 rounded-lg transition-colors"
+                              title="Anular compra"
+                            >
+                              <XCircle className="w-4 h-4" />
+                            </button>
+                          )}
+                        </div>
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+
+          {/* Cards - mobile */}
+          <div className="grid gap-3 md:hidden">
+            {comprasPaginadas.map(compra => {
+              const estadoKey = (compra.estado || 'pendiente') as EstadoCompra;
+              const estado = ESTADOS_COMPRA[estadoKey] || ESTADOS_COMPRA.pendiente;
+              const totalItems = (compra.items || []).reduce((sum: number, i: CompraItemDBExtended) => sum + i.cantidad, 0);
+              const nc = ncMap.get(String(compra.id));
+              const proveedorNombre = compra.proveedor?.nombre || compra.proveedor_nombre || 'Sin proveedor';
+              const fechaStr = new Date(compra.fecha_compra || compra.created_at || '').toLocaleDateString('es-AR');
+
+              return (
+                <div
+                  key={compra.id}
+                  className="bg-white dark:bg-gray-800 border dark:border-gray-700 rounded-lg p-4 shadow-sm"
+                >
+                  <div className="flex justify-between items-start gap-3 mb-2">
+                    <div className="flex-1 min-w-0">
+                      <p className="text-xs text-gray-500 dark:text-gray-400">{fechaStr}</p>
+                      <h3 className="font-semibold text-gray-800 dark:text-white truncate">{proveedorNombre}</h3>
+                      <p className="text-sm text-gray-600 dark:text-gray-400 font-mono flex items-center gap-1.5">
+                        <span>N° {compra.numero_factura || '-'}</span>
                         {compra.tipo_factura && (
                           <span className={`text-xs px-1.5 py-0.5 rounded font-medium ${
                             compra.tipo_factura === 'FC'
@@ -386,74 +487,69 @@ export default function VistaCompras({
                             {compra.tipo_factura}
                           </span>
                         )}
+                      </p>
+                    </div>
+                    <div className="text-right shrink-0">
+                      <p className="font-bold text-green-600 dark:text-green-400">
+                        {formatPrecio(compra.total)}
+                      </p>
+                      {nc && (
+                        <p className="text-xs text-blue-600 dark:text-blue-400">
+                          NC: -{formatPrecio(nc.total)}
+                        </p>
+                      )}
+                    </div>
+                  </div>
+                  <div className="flex items-center gap-2 flex-wrap">
+                    <span className={`px-2 py-1 rounded-full text-xs font-medium ${estado.color}`}>
+                      {estado.label}
+                    </span>
+                    {nc && (
+                      <span className="px-2 py-0.5 rounded-full text-xs font-medium bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-400 flex items-center gap-1">
+                        <FileText className="w-3 h-3" />
+                        {nc.cantidad} NC
                       </span>
-                    </td>
-                    <td className="px-4 py-3 text-center">
-                      <div className="flex items-center justify-center gap-1">
-                        <Package className="w-4 h-4 text-gray-400" />
-                        <span className="text-gray-800 dark:text-white">{totalItems}</span>
-                      </div>
-                    </td>
-                    <td className="px-4 py-3 text-center">
-                      <div className="flex flex-col items-center gap-1">
-                        <span className={`px-2 py-1 rounded-full text-xs font-medium ${estado.color}`}>
-                          {estado.label}
-                        </span>
-                        {nc && (
-                          <span className="px-2 py-0.5 rounded-full text-xs font-medium bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-400 flex items-center gap-1">
-                            <FileText className="w-3 h-3" />
-                            {nc.cantidad} NC
-                          </span>
-                        )}
-                      </div>
-                    </td>
-                    <td className="px-4 py-3 text-right">
-                      <div>
-                        <span className="font-semibold text-green-600 dark:text-green-400">
-                          {formatPrecio(compra.total)}
-                        </span>
-                        {nc && (
-                          <p className="text-xs text-blue-600 dark:text-blue-400">
-                            NC: -{formatPrecio(nc.total)}
-                          </p>
-                        )}
-                      </div>
-                    </td>
-                    <td className="px-4 py-3 text-right">
-                      <div className="flex justify-end gap-1">
-                        <button
-                          onClick={() => onVerDetalle(compra)}
-                          className="p-2 text-blue-500 hover:bg-blue-50 dark:hover:bg-blue-900/30 rounded-lg transition-colors"
-                          title="Ver detalle"
-                        >
-                          <Eye className="w-4 h-4" />
-                        </button>
-                        {isAdmin && compra.estado !== 'cancelada' && onNotaCredito && (
-                          <button
-                            onClick={() => onNotaCredito(compra)}
-                            className="p-2 text-blue-600 hover:bg-blue-50 dark:hover:bg-blue-900/30 rounded-lg transition-colors"
-                            title="Nota de Credito"
-                          >
-                            <FileText className="w-4 h-4" />
-                          </button>
-                        )}
-                        {isAdmin && compra.estado !== 'cancelada' && (
-                          <button
-                            onClick={() => onAnularCompra(compra.id)}
-                            className="p-2 text-red-500 hover:bg-red-50 dark:hover:bg-red-900/30 rounded-lg transition-colors"
-                            title="Anular compra"
-                          >
-                            <XCircle className="w-4 h-4" />
-                          </button>
-                        )}
-                      </div>
-                    </td>
-                  </tr>
-                );
-              })}
-            </tbody>
-          </table>
-        </div>
+                    )}
+                    <span className="text-xs text-gray-500 dark:text-gray-400 flex items-center gap-1">
+                      <Package className="w-3.5 h-3.5" />
+                      {totalItems} items
+                    </span>
+                  </div>
+                  <div className="flex items-center justify-end gap-1 mt-3 pt-3 border-t dark:border-gray-700">
+                    <button
+                      onClick={() => onVerDetalle(compra)}
+                      className="p-2 text-blue-500 hover:bg-blue-50 dark:hover:bg-blue-900/30 rounded-lg transition-colors min-h-11 min-w-11 flex items-center justify-center"
+                      title="Ver detalle"
+                      aria-label="Ver detalle"
+                    >
+                      <Eye className="w-4 h-4" />
+                    </button>
+                    {isAdmin && compra.estado !== 'cancelada' && onNotaCredito && (
+                      <button
+                        onClick={() => onNotaCredito(compra)}
+                        className="p-2 text-blue-600 hover:bg-blue-50 dark:hover:bg-blue-900/30 rounded-lg transition-colors min-h-11 min-w-11 flex items-center justify-center"
+                        title="Nota de Credito"
+                        aria-label="Nota de Credito"
+                      >
+                        <FileText className="w-4 h-4" />
+                      </button>
+                    )}
+                    {isAdmin && compra.estado !== 'cancelada' && (
+                      <button
+                        onClick={() => onAnularCompra(compra.id)}
+                        className="p-2 text-red-500 hover:bg-red-50 dark:hover:bg-red-900/30 rounded-lg transition-colors min-h-11 min-w-11 flex items-center justify-center"
+                        title="Anular compra"
+                        aria-label="Anular compra"
+                      >
+                        <XCircle className="w-4 h-4" />
+                      </button>
+                    )}
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        </>
       )}
 
       <Paginacion

--- a/src/components/vistas/VistaProductos.tsx
+++ b/src/components/vistas/VistaProductos.tsx
@@ -221,51 +221,141 @@ export default function VistaProductos({
           <p>{busqueda || filtroCategoria !== 'todas' ? 'No se encontraron productos' : 'No hay productos'}</p>
         </div>
       ) : (
-        <div className="bg-white dark:bg-gray-800 border dark:border-gray-700 rounded-lg shadow-sm overflow-x-auto">
-          <table className="w-full" role="table">
-            <thead className="bg-gray-50 dark:bg-gray-700/50">
-              <tr>
-                <th scope="col" className="px-4 py-3 text-left text-sm font-medium text-gray-700 dark:text-gray-300">Código</th>
-                <th scope="col" className="px-4 py-3 text-left text-sm font-medium text-gray-700 dark:text-gray-300">Producto</th>
-                <th scope="col" className="px-4 py-3 text-left text-sm font-medium text-gray-700 dark:text-gray-300">Categoría</th>
-                <th scope="col" className="px-4 py-3 text-left text-sm font-medium text-gray-700 dark:text-gray-300">Proveedor</th>
-                <th scope="col" className="px-4 py-3 text-right text-sm font-medium text-gray-700 dark:text-gray-300">Precio</th>
-                <th scope="col" className="px-4 py-3 text-right text-sm font-medium text-gray-700 dark:text-gray-300">Stock</th>
-                {isAdmin && <th scope="col" className="px-4 py-3 text-right text-sm font-medium text-gray-700 dark:text-gray-300">Acciones</th>}
-              </tr>
-            </thead>
-            <tbody className="divide-y dark:divide-gray-700">
-              {productosPaginados.map(producto => (
-                <tr key={producto.id} className="hover:bg-gray-50 dark:hover:bg-gray-700/50 transition-colors">
-                  <td className="px-4 py-3 text-gray-500 dark:text-gray-400 text-sm font-mono">
-                    {producto.codigo || '-'}
-                  </td>
-                  <td className="px-4 py-3">
-                    <span className="font-medium text-gray-800 dark:text-white">{producto.nombre}</span>
-                  </td>
-                  <td className="px-4 py-3">
-                    <span className={producto.categoria ? 'px-2 py-1 bg-gray-100 dark:bg-gray-700 rounded-full text-sm text-gray-700 dark:text-gray-300' : 'text-gray-400 dark:text-gray-500'}>
-                      {producto.categoria || 'Sin categoría'}
-                    </span>
-                  </td>
-                  <td className="px-4 py-3 text-sm text-gray-600 dark:text-gray-400">
-                    {producto.proveedor_id ? (proveedoresMap.get(producto.proveedor_id) || '-') : '-'}
-                  </td>
-                  <td className="px-4 py-3 text-right font-semibold text-blue-600 dark:text-blue-400">
-                    {formatPrecio(producto.precio)}
-                  </td>
-                  <td className="px-4 py-3 text-right">
-                    <span className={`px-2 py-1 rounded-full text-sm font-medium ${getStockColor(producto)}`}>
-                      {producto.stock}
-                    </span>
-                  </td>
-                  {isAdmin && (
+        <>
+          {/* Tabla - desktop */}
+          <div className="hidden md:block bg-white dark:bg-gray-800 border dark:border-gray-700 rounded-lg shadow-sm overflow-x-auto">
+            <table className="w-full" role="table">
+              <thead className="bg-gray-50 dark:bg-gray-700/50">
+                <tr>
+                  <th scope="col" className="px-4 py-3 text-left text-sm font-medium text-gray-700 dark:text-gray-300">Código</th>
+                  <th scope="col" className="px-4 py-3 text-left text-sm font-medium text-gray-700 dark:text-gray-300">Producto</th>
+                  <th scope="col" className="px-4 py-3 text-left text-sm font-medium text-gray-700 dark:text-gray-300">Categoría</th>
+                  <th scope="col" className="px-4 py-3 text-left text-sm font-medium text-gray-700 dark:text-gray-300">Proveedor</th>
+                  <th scope="col" className="px-4 py-3 text-right text-sm font-medium text-gray-700 dark:text-gray-300">Precio</th>
+                  <th scope="col" className="px-4 py-3 text-right text-sm font-medium text-gray-700 dark:text-gray-300">Stock</th>
+                  {isAdmin && <th scope="col" className="px-4 py-3 text-right text-sm font-medium text-gray-700 dark:text-gray-300">Acciones</th>}
+                </tr>
+              </thead>
+              <tbody className="divide-y dark:divide-gray-700">
+                {productosPaginados.map(producto => (
+                  <tr key={producto.id} className="hover:bg-gray-50 dark:hover:bg-gray-700/50 transition-colors">
+                    <td className="px-4 py-3 text-gray-500 dark:text-gray-400 text-sm font-mono">
+                      {producto.codigo || '-'}
+                    </td>
+                    <td className="px-4 py-3">
+                      <span className="font-medium text-gray-800 dark:text-white">{producto.nombre}</span>
+                    </td>
+                    <td className="px-4 py-3">
+                      <span className={producto.categoria ? 'px-2 py-1 bg-gray-100 dark:bg-gray-700 rounded-full text-sm text-gray-700 dark:text-gray-300' : 'text-gray-400 dark:text-gray-500'}>
+                        {producto.categoria || 'Sin categoría'}
+                      </span>
+                    </td>
+                    <td className="px-4 py-3 text-sm text-gray-600 dark:text-gray-400">
+                      {producto.proveedor_id ? (proveedoresMap.get(producto.proveedor_id) || '-') : '-'}
+                    </td>
+                    <td className="px-4 py-3 text-right font-semibold text-blue-600 dark:text-blue-400">
+                      {formatPrecio(producto.precio)}
+                    </td>
                     <td className="px-4 py-3 text-right">
-                      <div className="flex justify-end space-x-1">
+                      <span className={`px-2 py-1 rounded-full text-sm font-medium ${getStockColor(producto)}`}>
+                        {producto.stock}
+                      </span>
+                    </td>
+                    {isAdmin && (
+                      <td className="px-4 py-3 text-right">
+                        <div className="flex justify-end space-x-1">
+                          {onBajaStock && producto.stock > 0 && (
+                            <button
+                              onClick={() => onBajaStock(producto)}
+                              className="p-2 text-orange-500 hover:bg-orange-50 dark:hover:bg-orange-900/30 rounded-lg transition-colors"
+                              title="Baja de stock"
+                              aria-label={`Baja de stock ${producto.nombre}`}
+                            >
+                              <Minus className="w-4 h-4" aria-hidden="true" />
+                            </button>
+                          )}
+                          <button
+                            onClick={() => onEditarProducto(producto)}
+                            className="p-2 text-blue-500 hover:bg-blue-50 dark:hover:bg-blue-900/30 rounded-lg transition-colors"
+                            title="Editar"
+                            aria-label={`Editar ${producto.nombre}`}
+                          >
+                            <Edit2 className="w-4 h-4" aria-hidden="true" />
+                          </button>
+                          <button
+                            onClick={() => onEliminarProducto(producto.id)}
+                            className="p-2 text-red-500 hover:bg-red-50 dark:hover:bg-red-900/30 rounded-lg transition-colors"
+                            title="Eliminar"
+                            aria-label={`Eliminar ${producto.nombre}`}
+                          >
+                            <Trash2 className="w-4 h-4" aria-hidden="true" />
+                          </button>
+                        </div>
+                      </td>
+                    )}
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+
+          {/* Cards - mobile */}
+          <div className="grid gap-3 md:hidden">
+            {productosPaginados.map(producto => {
+              const stockMinimo = producto.stock_minimo || 10;
+              const stockBajo = producto.stock < stockMinimo;
+              const proveedorNombre = producto.proveedor_id ? proveedoresMap.get(producto.proveedor_id) : null;
+              return (
+                <div
+                  key={producto.id}
+                  className="bg-white dark:bg-gray-800 border dark:border-gray-700 rounded-lg p-4 shadow-sm"
+                >
+                  <div className="flex justify-between items-start gap-3">
+                    <div className="flex-1 min-w-0">
+                      <div className="flex items-center gap-2 flex-wrap">
+                        {producto.codigo && (
+                          <span className="px-1.5 py-0.5 bg-blue-100 dark:bg-blue-900/30 text-blue-700 dark:text-blue-300 rounded text-xs font-mono font-semibold">
+                            #{producto.codigo}
+                          </span>
+                        )}
+                        <h3 className="font-semibold text-gray-800 dark:text-white truncate">
+                          {producto.nombre}
+                        </h3>
+                      </div>
+                      {producto.categoria && (
+                        <p className="text-sm text-gray-600 dark:text-gray-400 mt-1">
+                          {producto.categoria}
+                        </p>
+                      )}
+                      {proveedorNombre && (
+                        <p className="text-xs text-gray-500 dark:text-gray-500 mt-0.5">
+                          {proveedorNombre}
+                        </p>
+                      )}
+                      <div className="flex items-center gap-4 mt-2 text-sm flex-wrap">
+                        <span className="text-gray-800 dark:text-gray-200">
+                          <span className="text-gray-500 dark:text-gray-400">Precio:</span>{' '}
+                          <span className="font-semibold text-blue-600 dark:text-blue-400">
+                            {formatPrecio(producto.precio)}
+                          </span>
+                        </span>
+                        <span
+                          className={
+                            stockBajo
+                              ? 'text-red-600 dark:text-red-400 font-medium'
+                              : 'text-gray-800 dark:text-gray-200'
+                          }
+                        >
+                          <span className="text-gray-500 dark:text-gray-400">Stock:</span> {producto.stock}
+                        </span>
+                      </div>
+                    </div>
+                    {isAdmin && (
+                      <div className="flex flex-col gap-1 shrink-0">
                         {onBajaStock && producto.stock > 0 && (
                           <button
                             onClick={() => onBajaStock(producto)}
-                            className="p-2 text-orange-500 hover:bg-orange-50 dark:hover:bg-orange-900/30 rounded-lg transition-colors"
+                            className="p-2 text-orange-500 hover:bg-orange-50 dark:hover:bg-orange-900/30 rounded-lg transition-colors min-h-11 min-w-11 flex items-center justify-center"
                             title="Baja de stock"
                             aria-label={`Baja de stock ${producto.nombre}`}
                           >
@@ -274,7 +364,7 @@ export default function VistaProductos({
                         )}
                         <button
                           onClick={() => onEditarProducto(producto)}
-                          className="p-2 text-blue-500 hover:bg-blue-50 dark:hover:bg-blue-900/30 rounded-lg transition-colors"
+                          className="p-2 text-blue-500 hover:bg-blue-50 dark:hover:bg-blue-900/30 rounded-lg transition-colors min-h-11 min-w-11 flex items-center justify-center"
                           title="Editar"
                           aria-label={`Editar ${producto.nombre}`}
                         >
@@ -282,20 +372,20 @@ export default function VistaProductos({
                         </button>
                         <button
                           onClick={() => onEliminarProducto(producto.id)}
-                          className="p-2 text-red-500 hover:bg-red-50 dark:hover:bg-red-900/30 rounded-lg transition-colors"
+                          className="p-2 text-red-500 hover:bg-red-50 dark:hover:bg-red-900/30 rounded-lg transition-colors min-h-11 min-w-11 flex items-center justify-center"
                           title="Eliminar"
                           aria-label={`Eliminar ${producto.nombre}`}
                         >
                           <Trash2 className="w-4 h-4" aria-hidden="true" />
                         </button>
                       </div>
-                    </td>
-                  )}
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>
+                    )}
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        </>
       )}
 
       <Paginacion

--- a/src/hooks/queries/usePedidosQuery.ts
+++ b/src/hooks/queries/usePedidosQuery.ts
@@ -102,7 +102,9 @@ async function enrichWithSalvedades(pedidos: Record<string, unknown>[]): Promise
 async function fetchPedidos(): Promise<PedidoDB[]> {
   const { data, error } = await supabase
     .from('pedidos')
-    .select(`*, cliente:clientes(*), items:pedido_items(*, producto:productos(*))`)
+    .select(`*,
+    cliente:clientes(id, nombre_fantasia, razon_social, cuit, direccion, telefono, contacto, latitud, longitud, horarios_atencion, zona),
+    items:pedido_items(*, producto:productos(id, nombre, codigo, categoria))`)
     .order('created_at', { ascending: false })
     .limit(500) // Limitar carga inicial para evitar consumo excesivo de memoria
 
@@ -146,7 +148,9 @@ async function fetchPedidos(): Promise<PedidoDB[]> {
 async function fetchPedidoById(id: string): Promise<PedidoDB | null> {
   const { data, error } = await supabase
     .from('pedidos')
-    .select(`*, cliente:clientes(*), items:pedido_items(*, producto:productos(*))`)
+    .select(`*,
+    cliente:clientes(id, nombre_fantasia, razon_social, cuit, direccion, telefono, contacto, latitud, longitud, horarios_atencion, zona),
+    items:pedido_items(*, producto:productos(id, nombre, codigo, categoria))`)
     .eq('id', id)
     .single()
 
@@ -157,7 +161,9 @@ async function fetchPedidoById(id: string): Promise<PedidoDB | null> {
 async function fetchPedidosByTransportista(transportistaId: string): Promise<PedidoDB[]> {
   const { data, error } = await supabase
     .from('pedidos')
-    .select(`*, cliente:clientes(*), items:pedido_items(*, producto:productos(*))`)
+    .select(`*,
+    cliente:clientes(id, nombre_fantasia, razon_social, cuit, direccion, telefono, contacto, latitud, longitud, horarios_atencion, zona),
+    items:pedido_items(*, producto:productos(id, nombre, codigo, categoria))`)
     .eq('transportista_id', transportistaId)
     .in('estado', ['asignado', 'en_camino'])
     .order('orden_entrega', { ascending: true, nullsFirst: false })
@@ -169,7 +175,7 @@ async function fetchPedidosByTransportista(transportistaId: string): Promise<Ped
 async function fetchPedidosByCliente(clienteId: string): Promise<PedidoDB[]> {
   const { data, error } = await supabase
     .from('pedidos')
-    .select(`*, items:pedido_items(*, producto:productos(*))`)
+    .select(`*, items:pedido_items(*, producto:productos(id, nombre, codigo, categoria))`)
     .eq('cliente_id', clienteId)
     .order('created_at', { ascending: false })
     .limit(50)
@@ -197,8 +203,8 @@ async function fetchPedidosPaginated(
 
   // Use !inner join when searching so PostgREST filters parent rows by client fields
   const selectStr = hasSearch
-    ? '*, cliente:clientes!inner(*), items:pedido_items(*, producto:productos(*))'
-    : '*, cliente:clientes(*), items:pedido_items(*, producto:productos(*))'
+    ? '*, cliente:clientes!inner(id, nombre_fantasia, razon_social, cuit, direccion, telefono, contacto, latitud, longitud, horarios_atencion, zona), items:pedido_items(*, producto:productos(id, nombre, codigo, categoria))'
+    : '*, cliente:clientes(id, nombre_fantasia, razon_social, cuit, direccion, telefono, contacto, latitud, longitud, horarios_atencion, zona), items:pedido_items(*, producto:productos(id, nombre, codigo, categoria))'
 
   let query = supabase
     .from('pedidos')


### PR DESCRIPTION
## Opción A — UX visible + Performance mobile

Plan: `.claude/plans/hace-un-plan-de-pure-star.md` (local).

Objetivo: subir puntaje ~7.8 → **~8.5/10** con impacto **que el usuario nota en celular**.

## Qué cambia

### 1. Input de búsqueda en `ModalPedido` legible en mobile (`09b997d`)
- Ambos inputs (búsqueda de cliente y de producto): `py-2` → `py-3`, agregado `min-h-11` (44px tap target iOS/Android), `text-base` explícito, `autoComplete="off"`.
- Arregla la queja directa del usuario: "es muy chica y no se lee nada".

### 2. Card view mobile en `VistaProductos` (`521a155`)
- Desktop (md+): tabla original intacta.
- Mobile (<md): grid de cards con código, nombre, categoría, proveedor, precio, stock (rojo si <= stock_minimo), y los 3 botones de acción apilados con tap target 44×44.
- Paginación queda fuera de ambos bloques (igual en los dos viewports).

### 3. Card view mobile en `VistaCompras` (`7a2e9c4`)
- Mismo patrón que Task 2. Cards muestran: fecha, proveedor, N° factura + tipo, estado, items, total (con NC si aplica), y 3 botones de acción.
- Preservados todos los condicionales de botones (admin, estado !== 'cancelada', etc.).

### 4. Lazy-load de Containers pesados (`b4ff5e0`)
- `AnalyticsContainer`, `ReportesContainer`, `ComisionesContainer`, `RecorridosContainer`, `RecorridoPreventistaContainer`, `TransferenciasContainer`, `PromocionesContainer` ahora son `React.lazy()` en `App.tsx`.
- **Bundle main: 383 KB → 361 KB (-22 KB, -5.8%)**. Se generaron 7 chunks on-demand.
- Para evitar el warning de Rollup "dynamic + static import from same barrel", los 8 containers restantes (no-lazy) se importan por path directo en vez de via barrel `./components/containers`. El barrel sigue existiendo pero queda como dead code — aceptado para no ensuciar el diff.

### 5. Select acotado en `fetchPedidos*` (`83fb560`)
- Antes: `cliente:clientes(*)` traía 23 campos; `producto:productos(*)` traía 16.
- Después: cliente con 11 campos (los únicos que consumen PedidoCard, ModalEditarPedido, ModalGestionRutas, useOptimizarRuta, useBackup, reciboPedido.js, hojaRutaOptimizada.js); producto con 4 campos (id, nombre, codigo, categoria).
- Aplicado a **las 5 funciones** del archivo: `fetchPedidos`, `fetchPedidoById`, `fetchPedidosByTransportista`, `fetchPedidosByCliente`, y las 2 ramas de `fetchPedidosPaginated` (incluye el `!inner` de búsqueda).
- Auditoría previa confirmó con grep que ningún consumer usa los campos omitidos.
- **Ahorro estimado: ~52% menos bytes en cliente, ~75% menos en producto** por fetch.

### Task 4 (jspdf/exceljs fuera del main bundle) — verificada, sin cambios
El audit empírico del `npm run build` confirmó que ya estaba bien code-split:
- `index-*.js`: 383 KB sin rastros de jspdf/exceljs
- `lib-pdf-*.js`: 387 KB separado
- `lib-excel-*.js`: 936 KB separado
- Todos los call sites usan `await import(...)` dinámico correctamente

## Commits (5)

1. `09b997d` fix(ModalPedido): larger search inputs for better mobile readability
2. `521a155` feat(VistaProductos): responsive card view for mobile
3. `7a2e9c4` feat(VistaCompras): responsive card view for mobile
4. `b4ff5e0` perf(router): lazy-load heavy containers (Analytics, Reportes, y otros)
5. `83fb560` perf(queries): limit select fields in fetchPedidos to reduce payload

## Test plan

- [x] `npm run typecheck` — pasa
- [x] `npm run lint` — pasa
- [x] `npm run test:run` — **569/569 tests pasan**
- [x] `npm run build` — main bundle bajó de 383 KB a 361 KB, 7 chunks nuevos de containers, jspdf/exceljs confirmados fuera del main
- [ ] **QA manual en staging con celular real:**
  - [ ] Abrir `ModalPedido` → tocar input de búsqueda de producto → input grande, tipo legible, teclado aparece limpio
  - [ ] `VistaProductos` en celular → cards en vez de tabla cortada; los 3 botones de acción se tocan fácil
  - [ ] `VistaCompras` en celular → idem
  - [ ] Navegar a Analytics o Reportes → spinner breve (1ra vez) mientras carga el chunk
  - [ ] Abrir un pedido en lista → datos del cliente OK (nombre, dirección, teléfono, CUIT), sin "undefined"
  - [ ] Optimizar ruta desde pedidos → lat/lng llegan OK
  - [ ] Exportar Excel de pedidos desde backup → zona del cliente + código/categoría de producto aparecen
  - [ ] Imprimir hoja de ruta → horarios del cliente aparecen
  - [ ] Network tab: primer load de la app, comparar MB descargados vs prod actual (idealmente menor)

## Riesgo

**Medio.** 3 áreas con exposición runtime:
- Task 2/3 (cards mobile): cambio de UI puro, fácil de validar visualmente.
- Task 5 (lazy): un chunk faltante al navegar se maneja con el `<Suspense fallback>` global.
- Task 6 (select acotado): **más sensible**. Si olvidé un campo en la auditoría, ese consumer verá `undefined`. Los consumers ya usan optional chaining, así que degradan en blanco en vez de crashear. Monitorear Sentry post-deploy especialmente por errores en PDFs, exports Excel, y optimización de rutas.

## Rollback

Cada commit es independiente — `git revert <sha>` quirúrgico. Ver [`docs/ROLLBACK.md`](docs/ROLLBACK.md).