### PR TITLE
feat(mayorista): precio mayorista individual por producto en escalas combinadas

### DIFF
--- a/migrations/005_mayorista_precio_por_producto.sql
+++ b/migrations/005_mayorista_precio_por_producto.sql
@@ -1,0 +1,26 @@
+-- 005_mayorista_precio_por_producto.sql
+--
+-- Permite que cada producto dentro de una escala combinada tenga su propio
+-- precio mayorista. Antes, la escala tenia un unico `precio_unitario` que
+-- aplicaba a todos los productos que activaran la escala. Con precios base
+-- distintos entre productos del grupo (ej. codito $900 / moñito $1000),
+-- usar un mismo precio mayorista no representa bien la promocion combinada.
+--
+-- Comportamiento:
+--   * Si la fila en grupo_precio_escala_minimos tiene precio_unitario_override
+--     NOT NULL, ese producto usa ese precio cuando la escala aplica.
+--   * Si es NULL, fallback al `precio_unitario` de la escala (como hoy).
+--
+-- Retrocompat total: la columna es nullable con default NULL, asi que todas
+-- las filas existentes siguen comportandose igual.
+
+BEGIN;
+
+ALTER TABLE public.grupo_precio_escala_minimos
+  ADD COLUMN IF NOT EXISTS precio_unitario_override NUMERIC(12,2)
+    CHECK (precio_unitario_override IS NULL OR precio_unitario_override > 0);
+
+COMMENT ON COLUMN public.grupo_precio_escala_minimos.precio_unitario_override IS
+  'Precio mayorista especifico para este producto cuando la escala aplica. NULL = usar el precio_unitario de la escala (fallback).';
+
+COMMIT;

--- a/src/components/modals/ModalGrupoPrecio.tsx
+++ b/src/components/modals/ModalGrupoPrecio.tsx
@@ -25,6 +25,12 @@ export interface ModalGrupoPrecioProps {
   onClose: () => void
 }
 
+interface ReglaProductoForm {
+  cantidad: string
+  /** Precio mayorista especifico para ESTE producto (override). Vacio = usa precio base de la escala. */
+  precio: string
+}
+
 interface EscalaForm {
   cantidadMinima: string
   precioUnitario: string
@@ -34,13 +40,13 @@ interface EscalaForm {
   /** UI: expandido o colapsado */
   expandido: boolean
   minProductosDistintos: string
-  /** productoId -> cantidad minima individual (string para controlar el input). */
-  minimosPorProducto: Record<string, string>
+  /** productoId -> regla individual. */
+  minimosPorProducto: Record<string, ReglaProductoForm>
 }
 
 function escalaDesdeGrupo(
   escalaDB: GrupoPrecioConDetalles['escalas'][number],
-  minimosDB: Record<string, number>
+  minimosDB: Record<string, { cantidad: number; precioOverride?: number | null }>
 ): EscalaForm {
   const combinada = Object.keys(minimosDB).length > 0 || (escalaDB.min_productos_distintos ?? 1) > 1
   return {
@@ -51,7 +57,13 @@ function escalaDesdeGrupo(
     expandido: combinada,
     minProductosDistintos: String(escalaDB.min_productos_distintos ?? 1),
     minimosPorProducto: Object.fromEntries(
-      Object.entries(minimosDB).map(([pid, v]) => [pid, String(v)])
+      Object.entries(minimosDB).map(([pid, v]) => [
+        pid,
+        {
+          cantidad: String(v.cantidad),
+          precio: v.precioOverride != null && v.precioOverride > 0 ? String(v.precioOverride) : '',
+        },
+      ])
     ),
   }
 }
@@ -84,9 +96,12 @@ export default function ModalGrupoPrecio({
   const [escalas, setEscalas] = useState<EscalaForm[]>(() => {
     if (!grupo) return [escalaVacia()]
     return grupo.escalas.map(e => {
-      const minimosDB: Record<string, number> = {}
+      const minimosDB: Record<string, { cantidad: number; precioOverride?: number | null }> = {}
       for (const m of grupo.escalaMinimos?.[String(e.id)] || []) {
-        minimosDB[String(m.producto_id)] = Number(m.cantidad_minima_por_item)
+        minimosDB[String(m.producto_id)] = {
+          cantidad: Number(m.cantidad_minima_por_item),
+          precioOverride: m.precio_unitario_override != null ? Number(m.precio_unitario_override) : null,
+        }
       }
       return escalaDesdeGrupo(e, minimosDB)
     })
@@ -133,7 +148,7 @@ export default function ModalGrupoPrecio({
   // Si se quita un producto del grupo, limpiar los minimos asociados en cada escala
   useEffect(() => {
     setEscalas(prev => prev.map(e => {
-      const nuevosMinimos: Record<string, string> = {}
+      const nuevosMinimos: Record<string, ReglaProductoForm> = {}
       for (const [pid, v] of Object.entries(e.minimosPorProducto)) {
         if (productoIds.has(pid)) nuevosMinimos[pid] = v
       }
@@ -214,8 +229,19 @@ export default function ModalGrupoPrecio({
       if (!value || value === '0' || parseInt(value) <= 0) {
         delete next[productoId]
       } else {
-        next[productoId] = value
+        next[productoId] = { cantidad: value, precio: next[productoId]?.precio || '' }
       }
+      return { ...e, minimosPorProducto: next }
+    }))
+  }
+
+  const actualizarPrecioProducto = (escalaIdx: number, productoId: string, value: string) => {
+    setEscalas(prev => prev.map((e, i) => {
+      if (i !== escalaIdx) return e
+      const prev2 = e.minimosPorProducto[productoId]
+      // Si aun no hay cantidad configurada, no tiene sentido guardar precio solo.
+      if (!prev2 || !prev2.cantidad) return e
+      const next = { ...e.minimosPorProducto, [productoId]: { ...prev2, precio: value } }
       return { ...e, minimosPorProducto: next }
     }))
   }
@@ -256,14 +282,14 @@ export default function ModalGrupoPrecio({
           setError(`Con "Requiere combinacion" activo, el minimo de productos distintos debe ser >= 2 (escala ${qty}u)`)
           return
         }
-        const minimosActivos = Object.entries(e.minimosPorProducto).filter(([, v]) => parseInt(v) > 0)
+        const minimosActivos = Object.entries(e.minimosPorProducto).filter(([, v]) => parseInt(v.cantidad) > 0)
         if (minimosActivos.length < k) {
           setError(`La escala ${qty}u requiere ${k} productos distintos pero solo ${minimosActivos.length} tienen minimo configurado.`)
           return
         }
         // Coherencia: suma de los K minimos mas bajos debe ser <= cantidad_minima total
         const minimosOrdenados = minimosActivos
-          .map(([, v]) => parseInt(v))
+          .map(([, v]) => parseInt(v.cantidad))
           .sort((a, b) => a - b)
         const sumaMinima = minimosOrdenados.slice(0, k).reduce((s, n) => s + n, 0)
         if (sumaMinima > qty) {
@@ -271,6 +297,17 @@ export default function ModalGrupoPrecio({
             `Regla inalcanzable en escala ${qty}u: sumando los ${k} minimos mas bajos da ${sumaMinima}, que excede ${qty}.`
           )
           return
+        }
+        // Precios override: si estan seteados, deben ser > 0
+        for (const [pid, regla] of minimosActivos) {
+          if (regla.precio && regla.precio.trim() !== '') {
+            const precioProd = parsePrecio(regla.precio)
+            if (isNaN(precioProd) || precioProd <= 0) {
+              const nombre = nombresProductos[pid] || `#${pid}`
+              setError(`Precio invalido para ${nombre} en escala ${qty}u.`)
+              return
+            }
+          }
         }
       }
     }
@@ -303,10 +340,13 @@ export default function ModalGrupoPrecio({
             minProductosDistintos: e.combinada ? parseInt(e.minProductosDistintos) : 1,
           }
           if (!e.combinada) return base
-          const minimos: Record<string, number> = {}
+          const minimos: Record<string, { cantidad: number; precioOverride?: number | null }> = {}
           for (const [pid, v] of Object.entries(e.minimosPorProducto)) {
-            const n = parseInt(v)
-            if (!isNaN(n) && n > 0 && productoIds.has(pid)) minimos[pid] = n
+            const cant = parseInt(v.cantidad)
+            if (isNaN(cant) || cant <= 0 || !productoIds.has(pid)) continue
+            const precioRaw = v.precio && v.precio.trim() !== '' ? parsePrecio(v.precio) : null
+            const precioOverride = precioRaw != null && !isNaN(precioRaw) && precioRaw > 0 ? precioRaw : null
+            minimos[pid] = { cantidad: cant, precioOverride }
           }
           return { ...base, minimosPorProducto: minimos }
         }),
@@ -473,8 +513,18 @@ export default function ModalGrupoPrecio({
                   minProductosDistintos: escala.combinada ? parseInt(escala.minProductosDistintos) || 1 : 1,
                   minimosPorProducto: new Map(
                     Object.entries(escala.minimosPorProducto)
-                      .map(([pid, v]) => [pid, parseInt(v) || 0] as const)
-                      .filter(([, n]) => n > 0)
+                      .map(([pid, v]) => {
+                        const cant = parseInt(v.cantidad) || 0
+                        const precioOv = v.precio && v.precio.trim() !== '' ? parsePrecio(v.precio) : null
+                        return [
+                          pid,
+                          {
+                            cantidad: cant,
+                            precioOverride: precioOv != null && !isNaN(precioOv) && precioOv > 0 ? precioOv : null,
+                          },
+                        ] as const
+                      })
+                      .filter(([, v]) => v.cantidad > 0)
                   ),
                 }
 
@@ -564,27 +614,55 @@ export default function ModalGrupoPrecio({
 
                         <div>
                           <p className="text-xs text-gray-500 dark:text-gray-400 mb-1">
-                            Cantidad mínima por producto (solo los productos marcados cuentan hacia la combinación):
+                            Cantidad mínima y precio mayorista por producto (precio vacío = usa el precio base de la escala):
                           </p>
                           {productosDelGrupo.length === 0 ? (
                             <p className="text-xs text-gray-400 italic">Primero agregá productos al grupo.</p>
                           ) : (
-                            <div className="space-y-1 max-h-40 overflow-y-auto border dark:border-gray-600 rounded p-1">
-                              {productosDelGrupo.map(p => (
-                                <div key={p.id} className="flex items-center justify-between gap-2 text-xs">
-                                  <span className="truncate dark:text-gray-200">{p.nombre}</span>
-                                  <input
-                                    type="number"
-                                    inputMode="numeric"
-                                    min="1"
-                                    step="1"
-                                    value={escala.minimosPorProducto[String(p.id)] || ''}
-                                    onChange={e => actualizarMinimoProducto(index, String(p.id), e.target.value)}
-                                    className="w-16 px-2 py-1 border rounded text-center dark:bg-gray-700 dark:border-gray-600 dark:text-white"
-                                    placeholder="Min"
-                                  />
-                                </div>
-                              ))}
+                            <div className="space-y-1 max-h-56 overflow-y-auto border dark:border-gray-600 rounded p-1">
+                              <div className="grid grid-cols-[1fr_auto_auto] gap-2 text-[10px] uppercase tracking-wide text-gray-400 dark:text-gray-500 px-1 pb-1 border-b dark:border-gray-700">
+                                <span>Producto</span>
+                                <span className="text-center w-16">Mín.</span>
+                                <span className="text-center w-24">Precio</span>
+                              </div>
+                              {productosDelGrupo.map(p => {
+                                const regla = escala.minimosPorProducto[String(p.id)]
+                                const cantidadValue = regla?.cantidad || ''
+                                const precioValue = regla?.precio || ''
+                                const tieneCantidad = !!cantidadValue && parseInt(cantidadValue) > 0
+                                return (
+                                  <div key={p.id} className="grid grid-cols-[1fr_auto_auto] gap-2 items-center text-xs">
+                                    <span className="truncate dark:text-gray-200" title={p.nombre}>
+                                      {p.nombre}
+                                    </span>
+                                    <input
+                                      type="number"
+                                      inputMode="numeric"
+                                      min="1"
+                                      step="1"
+                                      value={cantidadValue}
+                                      onChange={e => actualizarMinimoProducto(index, String(p.id), e.target.value)}
+                                      className="w-16 px-2 py-1 border rounded text-center dark:bg-gray-700 dark:border-gray-600 dark:text-white"
+                                      placeholder="Min"
+                                    />
+                                    <div className="relative w-24">
+                                      <span className="absolute left-2 top-1/2 -translate-y-1/2 text-gray-400 text-[10px]">$</span>
+                                      <input
+                                        type="number"
+                                        inputMode="decimal"
+                                        min="0.01"
+                                        step="0.01"
+                                        value={precioValue}
+                                        onChange={e => actualizarPrecioProducto(index, String(p.id), e.target.value)}
+                                        disabled={!tieneCantidad}
+                                        className="w-full pl-5 pr-2 py-1 border rounded text-center dark:bg-gray-700 dark:border-gray-600 dark:text-white disabled:bg-gray-100 dark:disabled:bg-gray-800 disabled:cursor-not-allowed"
+                                        placeholder={tieneCantidad ? 'Base' : ''}
+                                        title={tieneCantidad ? 'Dejar vacío para usar el precio base de la escala' : 'Primero ingresá la cantidad mínima'}
+                                      />
+                                    </div>
+                                  </div>
+                                )
+                              })}
                             </div>
                           )}
                         </div>

--- a/src/components/vistas/VistaGruposPrecio.tsx
+++ b/src/components/vistas/VistaGruposPrecio.tsx
@@ -222,9 +222,12 @@ export default function VistaGruposPrecio({
                     .sort((a, b) => a.cantidad_minima - b.cantidad_minima)
                     .map(escala => {
                       const minimosRows = grupo.escalaMinimos?.[String(escala.id)] || []
-                      const minimosMap = new Map<string, number>()
+                      const minimosMap = new Map<string, { cantidad: number; precioOverride?: number | null }>()
                       for (const m of minimosRows) {
-                        minimosMap.set(String(m.producto_id), Number(m.cantidad_minima_por_item))
+                        minimosMap.set(String(m.producto_id), {
+                          cantidad: Number(m.cantidad_minima_por_item),
+                          precioOverride: m.precio_unitario_override != null ? Number(m.precio_unitario_override) : null,
+                        })
                       }
                       const escalaTipada: EscalaPrecio = {
                         cantidadMinima: escala.cantidad_minima,

--- a/src/hooks/queries/useGruposPrecioQuery.ts
+++ b/src/hooks/queries/useGruposPrecioQuery.ts
@@ -113,9 +113,12 @@ async function fetchPricingMap(): Promise<PricingMap> {
       .filter(e => e.activo !== false)
       .map((e): EscalaPrecio => {
         const minimosRows = grupo.escalaMinimos?.[String(e.id)] || []
-        const minimosPorProducto = new Map<string, number>()
+        const minimosPorProducto = new Map<string, { cantidad: number; precioOverride?: number | null }>()
         for (const m of minimosRows) {
-          minimosPorProducto.set(String(m.producto_id), Number(m.cantidad_minima_por_item))
+          minimosPorProducto.set(String(m.producto_id), {
+            cantidad: Number(m.cantidad_minima_por_item),
+            precioOverride: m.precio_unitario_override != null ? Number(m.precio_unitario_override) : null,
+          })
         }
         return {
           cantidadMinima: e.cantidad_minima,
@@ -245,23 +248,33 @@ async function createGrupoPrecio(input: GrupoPrecioFormInput, sucursalId: number
  * y las escalas ya insertadas (para obtener sus IDs). Hace match por
  * cantidad_minima, que es UNIQUE dentro de un grupo.
  */
+interface FilaMinimoInsert {
+  escala_id: number
+  producto_id: number
+  cantidad_minima_por_item: number
+  precio_unitario_override: number | null
+  sucursal_id: number
+}
+
 function buildFilasMinimos(
   escalasInput: GrupoPrecioFormInput['escalas'],
   escalasDB: GrupoPrecioEscalaDB[],
   sucursalId: number
-): Array<{ escala_id: number; producto_id: number; cantidad_minima_por_item: number; sucursal_id: number }> {
-  const filas: Array<{ escala_id: number; producto_id: number; cantidad_minima_por_item: number; sucursal_id: number }> = []
+): FilaMinimoInsert[] {
+  const filas: FilaMinimoInsert[] = []
   for (const e of escalasInput) {
     if (!e.minimosPorProducto) continue
-    const entries = Object.entries(e.minimosPorProducto).filter(([, v]) => v > 0)
+    const entries = Object.entries(e.minimosPorProducto).filter(([, v]) => v && v.cantidad > 0)
     if (entries.length === 0) continue
     const escalaDB = escalasDB.find(db => db.cantidad_minima === e.cantidadMinima)
     if (!escalaDB) continue
-    for (const [productoId, cantidad] of entries) {
+    for (const [productoId, regla] of entries) {
       filas.push({
         escala_id: parseInt(String(escalaDB.id)),
         producto_id: parseInt(productoId),
-        cantidad_minima_por_item: cantidad,
+        cantidad_minima_por_item: regla.cantidad,
+        precio_unitario_override:
+          regla.precioOverride != null && regla.precioOverride > 0 ? regla.precioOverride : null,
         sucursal_id: sucursalId,
       })
     }

--- a/src/types/hooks.ts
+++ b/src/types/hooks.ts
@@ -1391,6 +1391,11 @@ export interface GrupoPrecioEscalaMinimoDB {
   escala_id: string;
   producto_id: string;
   cantidad_minima_por_item: number;
+  /**
+   * Precio mayorista especifico para este producto cuando la escala aplica.
+   * Si es null o undefined, se usa el precio_unitario de la escala.
+   */
+  precio_unitario_override?: number | null;
   sucursal_id: string;
   created_at?: string;
 }
@@ -1413,8 +1418,13 @@ export interface GrupoPrecioFormInput {
     etiqueta?: string | null;
     /** Minimo de productos distintos (default 1 = clasica). */
     minProductosDistintos?: number;
-    /** Minimo por producto para escalas combinadas: productoId -> cantidad. */
-    minimosPorProducto?: Record<string, number>;
+    /**
+     * Config por producto para escalas combinadas: cantidad minima individual
+     * y, opcionalmente, un precio mayorista especifico para ese producto. Si
+     * precioOverride es null/undefined, el producto usa el `precioUnitario`
+     * de la escala cuando aplica.
+     */
+    minimosPorProducto?: Record<string, { cantidad: number; precioOverride?: number | null }>;
   }>;
 }
 

--- a/src/utils/describirReglaEscala.ts
+++ b/src/utils/describirReglaEscala.ts
@@ -29,26 +29,42 @@ function getNombre(id: string, opts: DescribirReglaOpts): string {
 }
 
 export function describirReglaEscala(escala: EscalaPrecio, opts: DescribirReglaOpts = {}): string {
-  const precio = formatMoneda(escala.precioUnitario)
+  const precioBase = formatMoneda(escala.precioUnitario)
   const total = escala.cantidadMinima
 
   const minProdDistintos = Math.max(1, escala.minProductosDistintos)
   const minimos = Array.from(escala.minimosPorProducto.entries())
-    .filter(([, v]) => v > 0)
+    .filter(([, v]) => v.cantidad > 0)
     .sort(([a], [b]) => a.localeCompare(b))
 
   // Caso clásico: sin mínimos por producto y con K=1.
   if (minProdDistintos <= 1 && minimos.length === 0) {
-    return `Si el grupo suma ${total}+ unidades, ${precio} c/u.`
+    return `Si el grupo suma ${total}+ unidades, ${precioBase} c/u.`
   }
 
   const partes: string[] = [`${total}+ unidades totales`]
   if (minProdDistintos > 1) {
     partes.push(`al menos ${minProdDistintos} productos distintos`)
   }
+
+  // Detectar si hay precios override heterogéneos vs un precio uniforme.
+  const algunoConOverride = minimos.some(([, v]) => v.precioOverride != null && v.precioOverride > 0)
   if (minimos.length > 0) {
-    const lista = minimos.map(([pid, cant]) => `${getNombre(pid, opts)} ${cant}+`).join(', ')
+    if (algunoConOverride) {
+      // Lista con precio individual por producto.
+      const lista = minimos
+        .map(([pid, v]) => {
+          const precioProd = v.precioOverride != null && v.precioOverride > 0
+            ? formatMoneda(v.precioOverride)
+            : precioBase
+          return `${getNombre(pid, opts)} ${v.cantidad}+ a ${precioProd}`
+        })
+        .join(', ')
+      return `Si comprás ${partes.join(', ')}, con precios por producto (${lista}).`
+    }
+    // Precios uniformes: solo listar cantidades.
+    const lista = minimos.map(([pid, v]) => `${getNombre(pid, opts)} ${v.cantidad}+`).join(', ')
     partes.push(`con mínimos (${lista})`)
   }
-  return `Si comprás ${partes.join(', ')}, ${precio} c/u.`
+  return `Si comprás ${partes.join(', ')}, ${precioBase} c/u.`
 }

--- a/src/utils/precioMayorista.test.ts
+++ b/src/utils/precioMayorista.test.ts
@@ -14,11 +14,13 @@ import { describe, expect, it } from 'vitest'
 import {
   escalaAplica,
   esEscalaCombinada,
+  precioEfectivoEscala,
   resolverPreciosMayorista,
   type EscalaPrecio,
   type GrupoPrecioInfo,
   type ItemPedido,
-  type PricingMap
+  type PricingMap,
+  type ReglaProducto
 } from './precioMayorista'
 
 // Helpers para armar escalas facilmente
@@ -32,19 +34,29 @@ function escalaClasica(cantidadMinima: number, precioUnitario: number, etiqueta 
   }
 }
 
+/**
+ * Arma una escala combinada. `minimos` acepta tanto un numero (shortcut a
+ * { cantidad: N }) como un objeto { cantidad, precioOverride? } para configurar
+ * un precio mayorista especifico por producto.
+ */
 function escalaCombinada(
   cantidadMinima: number,
   precioUnitario: number,
   minProductosDistintos: number,
-  minimos: Record<string, number>,
+  minimos: Record<string, number | ReglaProducto>,
   etiqueta = ''
 ): EscalaPrecio {
+  const map = new Map<string, ReglaProducto>()
+  for (const [pid, v] of Object.entries(minimos)) {
+    if (typeof v === 'number') map.set(pid, { cantidad: v })
+    else map.set(pid, v)
+  }
   return {
     cantidadMinima,
     precioUnitario,
     etiqueta: etiqueta || null,
     minProductosDistintos,
-    minimosPorProducto: new Map(Object.entries(minimos))
+    minimosPorProducto: map
   }
 }
 
@@ -252,6 +264,101 @@ describe('resolverPreciosMayorista - coexistencia clasica + combinada', () => {
     const items = [item('A', 12, 1000), item('B', 12, 1000)]
     const res = resolverPreciosMayorista(items, pm)
     expect(res.get('A')!.precioResuelto).toBe(750)
+  })
+})
+
+describe('precioEfectivoEscala', () => {
+  it('sin override devuelve precio base de la escala', () => {
+    const e = escalaCombinada(12, 800, 2, { A: 6, B: 6 })
+    expect(precioEfectivoEscala(e, 'A')).toBe(800)
+  })
+
+  it('con override devuelve el override del producto', () => {
+    const e = escalaCombinada(12, 800, 2, {
+      A: { cantidad: 6, precioOverride: 850 },
+      B: { cantidad: 6, precioOverride: 950 }
+    })
+    expect(precioEfectivoEscala(e, 'A')).toBe(850)
+    expect(precioEfectivoEscala(e, 'B')).toBe(950)
+  })
+
+  it('override null cae a precio base', () => {
+    const e = escalaCombinada(12, 800, 2, {
+      A: { cantidad: 6, precioOverride: null },
+      B: { cantidad: 6, precioOverride: 950 }
+    })
+    expect(precioEfectivoEscala(e, 'A')).toBe(800)
+    expect(precioEfectivoEscala(e, 'B')).toBe(950)
+  })
+})
+
+describe('resolverPreciosMayorista - precios heterogeneos por producto', () => {
+  // Caso del cliente: codito $900 con mayorista $850, moñito $1000 con mayorista $950.
+  // Escala combinada exige 6 de cada uno y al menos 2 productos.
+  const g = grupo('g1', 'Fideos', ['codito', 'moñito'], [
+    escalaCombinada(12, 900, 2, {
+      codito: { cantidad: 6, precioOverride: 850 },
+      moñito: { cantidad: 6, precioOverride: 950 }
+    })
+  ])
+  const pm = pricingMap([g])
+
+  it('6 codito + 6 moñito aplica precios distintos por producto', () => {
+    const items = [item('codito', 6, 900), item('moñito', 6, 1000)]
+    const res = resolverPreciosMayorista(items, pm)
+    expect(res.get('codito')!.precioResuelto).toBe(850)
+    expect(res.get('moñito')!.precioResuelto).toBe(950)
+    expect(res.get('codito')!.esMayorista).toBe(true)
+    expect(res.get('moñito')!.esMayorista).toBe(true)
+  })
+
+  it('producto sin override en la escala usa el precio base de la escala', () => {
+    const g2 = grupo('g2', 'Fideos', ['A', 'B', 'C'], [
+      escalaCombinada(12, 800, 2, {
+        A: { cantidad: 6, precioOverride: 700 },  // override
+        B: { cantidad: 6 },                         // sin override -> 800
+        C: { cantidad: 6, precioOverride: 750 }   // override
+      })
+    ])
+    const pm2 = pricingMap([g2])
+    const items = [item('A', 6, 1000), item('B', 6, 1000), item('C', 0, 1000)]
+    const res = resolverPreciosMayorista(items, pm2)
+    expect(res.get('A')!.precioResuelto).toBe(700)
+    expect(res.get('B')!.precioResuelto).toBe(800)
+  })
+
+  it('clasica compite con combinada por el precio efectivo de cada producto', () => {
+    // Escala clasica $820 para todos + escala combinada con override $870 para A.
+    // La clasica gana para A (820 < 870), pero la combinada no subiria precios.
+    const gMixto = grupo('g3', 'Fideos', ['A', 'B'], [
+      escalaClasica(12, 820),
+      escalaCombinada(12, 900, 2, {
+        A: { cantidad: 6, precioOverride: 870 },
+        B: { cantidad: 6, precioOverride: 850 }
+      })
+    ])
+    const pm3 = pricingMap([gMixto])
+    const items = [item('A', 6, 1000), item('B', 6, 1000)]
+    const res = resolverPreciosMayorista(items, pm3)
+    // Para A, la clasica $820 gana a la combinada $870
+    expect(res.get('A')!.precioResuelto).toBe(820)
+    // Para B, la combinada $850 gana a la clasica $820? No, $820 < $850, gana clasica.
+    expect(res.get('B')!.precioResuelto).toBe(820)
+  })
+
+  it('clasica vs combinada con override mas barato por producto: gana la combinada', () => {
+    const gMixto = grupo('g4', 'Fideos', ['A', 'B'], [
+      escalaClasica(12, 820),
+      escalaCombinada(12, 900, 2, {
+        A: { cantidad: 6, precioOverride: 800 },  // mas barato que 820
+        B: { cantidad: 6, precioOverride: 850 }
+      })
+    ])
+    const pm4 = pricingMap([gMixto])
+    const items = [item('A', 6, 1000), item('B', 6, 1000)]
+    const res = resolverPreciosMayorista(items, pm4)
+    expect(res.get('A')!.precioResuelto).toBe(800)
+    expect(res.get('B')!.precioResuelto).toBe(820)
   })
 })
 

--- a/src/utils/precioMayorista.ts
+++ b/src/utils/precioMayorista.ts
@@ -13,24 +13,37 @@
 // TIPOS
 // =============================================================================
 
+/**
+ * Configuracion por producto dentro de una escala combinada:
+ *   - cantidad: cantidad minima individual que ese producto debe tener en el
+ *     pedido para "contar" hacia la activacion de la escala.
+ *   - precioOverride (opcional): precio mayorista especifico que usa ese
+ *     producto cuando la escala aplica. Si es null/undefined, cae al
+ *     precioUnitario de la escala.
+ */
+export interface ReglaProducto {
+  cantidad: number
+  precioOverride?: number | null
+}
+
 export interface EscalaPrecio {
   cantidadMinima: number
+  /** Precio unitario base de la escala. Fallback para productos sin override. */
   precioUnitario: number
   etiqueta: string | null
   /**
    * Cantidad minima de productos DISTINTOS del grupo presentes en el pedido
    * (con cantidad >= su minimo individual, o > 0 si no tienen minimo) para
-   * activar la escala. Default 1 = comportamiento clasico (no importa cuantos
-   * productos distintos haya mientras se cumpla el total).
+   * activar la escala. Default 1 = comportamiento clasico.
    */
   minProductosDistintos: number
   /**
-   * Mapa productoId -> minimo individual que ese producto debe tener en el
-   * pedido para "contar" hacia la activacion de la escala. Si un producto
-   * del grupo no esta en este mapa, basta con cantidad > 0 para contar.
-   * Ausencia total de entradas = escala clasica.
+   * Mapa productoId -> regla individual (cantidad minima + precio override).
+   * Si un producto del grupo no esta en este mapa, basta con cantidad > 0
+   * para contar y usa el precioUnitario de la escala. Ausencia total de
+   * entradas = escala clasica.
    */
-  minimosPorProducto: Map<string, number>
+  minimosPorProducto: Map<string, ReglaProducto>
 }
 
 export interface GrupoPrecioInfo {
@@ -106,9 +119,9 @@ export function escalaAplica(
 
   // 2. Si hay minimos por producto, validar que los presentes los cumplan
   if (escala.minimosPorProducto.size > 0) {
-    for (const [pid, minimo] of escala.minimosPorProducto) {
+    for (const [pid, regla] of escala.minimosPorProducto) {
       const cantidad = cantidadesPorProducto.get(pid) || 0
-      if (cantidad > 0 && cantidad < minimo) {
+      if (cantidad > 0 && cantidad < regla.cantidad) {
         return false
       }
     }
@@ -120,15 +133,27 @@ export function escalaAplica(
   for (const pid of productoIdsGrupo) {
     const cantidad = cantidadesPorProducto.get(pid) || 0
     if (cantidad <= 0) continue
-    const minimoIndividual = escala.minimosPorProducto.get(pid)
-    if (minimoIndividual !== undefined) {
-      if (cantidad >= minimoIndividual) productosQueCuentan++
+    const regla = escala.minimosPorProducto.get(pid)
+    if (regla !== undefined) {
+      if (cantidad >= regla.cantidad) productosQueCuentan++
     } else {
       // Sin minimo configurado: basta con estar presente
       productosQueCuentan++
     }
   }
   return productosQueCuentan >= minK
+}
+
+/**
+ * Devuelve el precio efectivo que usa un producto cuando una escala aplica.
+ * Respeta el override por producto si existe; si no, usa el precio de la escala.
+ */
+export function precioEfectivoEscala(escala: EscalaPrecio, productoId: string): number {
+  const regla = escala.minimosPorProducto.get(String(productoId))
+  if (regla && regla.precioOverride != null && regla.precioOverride > 0) {
+    return regla.precioOverride
+  }
+  return escala.precioUnitario
 }
 
 /**
@@ -209,24 +234,28 @@ export function resolverPreciosMayorista(
       const productoIdsStr = grupo.productoIds.map(String)
 
       // Filtrar escalas que apliquen (clasica o combinada) y quedarme con la
-      // de mayor cantidad_minima. En caso de empate por cantidad, gana la de
-      // menor precio (la mejor para el cliente), tipicamente la combinada
-      // cuando existe junto a una clasica con el mismo umbral.
+      // de mayor cantidad_minima. En caso de empate por cantidad, gana la
+      // de menor precio EFECTIVO para este producto en particular (respeta
+      // overrides por producto). Asi una combinada con override mas bajo
+      // gana a una clasica con el mismo umbral; y una clasica mas barata
+      // gana si la combinada no bajo ese producto especifico.
+      const pidStr = String(item.productoId)
       const escalasAplicables = grupo.escalas
         .filter(e => escalaAplica(e, cantidadesPorProducto, productoIdsStr))
         .sort((a, b) => {
           if (b.cantidadMinima !== a.cantidadMinima) {
             return b.cantidadMinima - a.cantidadMinima
           }
-          return a.precioUnitario - b.precioUnitario
+          return precioEfectivoEscala(a, pidStr) - precioEfectivoEscala(b, pidStr)
         })
 
       if (escalasAplicables.length === 0) continue
 
       const escalaElegida = escalasAplicables[0]
+      const precioParaEsteProducto = precioEfectivoEscala(escalaElegida, pidStr)
       // Solo aplicar si el precio mayorista es menor o igual al actual mejor
-      if (escalaElegida.precioUnitario <= mejorPrecio) {
-        mejorPrecio = escalaElegida.precioUnitario
+      if (precioParaEsteProducto <= mejorPrecio) {
+        mejorPrecio = precioParaEsteProducto
         mejorGrupoNombre = grupo.grupoNombre
         mejorEtiqueta = escalaElegida.etiqueta
         mejorCantidadEnGrupo = totalPorGrupo.get(grupo.grupoId) || 0


### PR DESCRIPTION
## Summary

Extiende el PR [#241](https://github.com/AgustinReiden/distribuidora-app/pull/241) (ya mergeado) con lo que comentaste: cuando se usa una escala combinada, cada producto puede tener **su propio precio mayorista** en lugar de un precio único para todos. Resuelve el caso de tu captura: codito \$900 → mayorista \$850, moñito \$1000 → mayorista \$950 activando la misma promo combinada.

## Cómo queda el cálculo

- Cada fila de mínimo por producto gana un campo opcional **"Precio mayorista"**.
- Si está vacío, ese producto usa el precio base de la escala (comportamiento anterior).
- Si está seteado, ese override se usa cuando la escala aplica.
- Al comparar escalas (clásica vs combinada, varios grupos), la comparación se hace con el **precio efectivo para ese producto específico**, así:
  - Una clásica \$820 le gana a una combinada con override \$870 para ese producto.
  - Una combinada con override \$800 le gana a una clásica \$820.
  - Cada producto puede terminar tomando una escala distinta si le conviene.

Ejemplo del cliente: grupo Fideos, escala 12u combinada con `codito: {6, \$850}`, `moñito: {6, \$950}`. Pedido `6 codito + 6 moñito` → \$850×6 + \$950×6.

## Base de datos (migración 005)

- Columna nullable \`grupo_precio_escala_minimos.precio_unitario_override NUMERIC(12,2)\` con check > 0.
- **Ya aplicada a ManaosApp**. Retrocompat total: las filas existentes tienen NULL y siguen usando el precio base.

## Lógica

- \`EscalaPrecio.minimosPorProducto\` pasa de \`Map<string, number>\` a \`Map<string, { cantidad, precioOverride? }>\`.
- Nueva función \`precioEfectivoEscala(escala, productoId)\` centraliza el fallback.
- \`resolverPreciosMayorista\` compara escalas con el precio efectivo por producto.
- **7 tests unitarios nuevos** en \`precioMayorista.test.ts\`:
  - caso real del cliente (codito + moñito con overrides distintos),
  - producto sin override hereda precio base,
  - clásica \$820 le gana a combinada \$870 override,
  - combinada \$800 override le gana a clásica \$820,
  - cobertura de \`precioEfectivoEscala\`.

## UX

- Tabla en el panel combinado pasa a 3 columnas: **Producto / Mín / Precio**. El input de precio queda deshabilitado si no hay cantidad configurada (no tiene sentido un precio sin cantidad). Placeholder "Base" indica que vacío = usa precio de la escala.
- Preview humano (\`describirReglaEscala\`) detecta si hay overrides heterogéneos y genera texto tipo _"Si comprás 12+ unidades, al menos 2 productos distintos, con precios por producto (Codito 6+ a \$850, Moñito 6+ a \$950)"_.
- Chip de escala combinada en la vista lista usa la misma descripción en el tooltip.

## Validación

- \`tsc --noEmit\` ✅
- \`eslint\` (archivos tocados) ✅
- \`vitest run\` ✅ **576 tests** (32 archivos)

## Test plan

- [ ] Crear grupo Fideos con codito (\$900) y moñito (\$1000). Escala 12u con combinación, K=2, mínimos 6/6.
- [ ] Dejar el precio override en blanco para ambos → pedido `6 codito + 6 moñito` paga precio uniforme de la escala (retrocompat).
- [ ] Setear override \$850 en codito y \$950 en moñito → pedido aplica esos precios distintos a cada uno.
- [ ] Agregar una escala 12u clásica con precio \$820 en el mismo grupo → pedido elige para cada producto el mejor precio posible (combinada si override más bajo, clásica si no).
- [ ] Tooltip del chip combinado en la vista lista muestra el desglose de precios.
- [ ] Auditoría: el UPDATE sobre \`grupo_precio_escala_minimos\` aparece en \`audit_logs\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)