### PR TITLE
fix(mayorista): precio base opcional cuando la combinada tiene precios por producto

### DIFF
--- a/src/components/modals/ModalGrupoPrecio.tsx
+++ b/src/components/modals/ModalGrupoPrecio.tsx
@@ -258,7 +258,17 @@ export default function ModalGrupoPrecio({
       return
     }
 
-    const escalasValidas = escalas.filter(e => e.cantidadMinima && e.precioUnitario)
+    // Una escala es valida si tiene cantidad Y (precio base o, si es combinada,
+    // todos los productos con minimo tienen precio override).
+    const escalasValidas = escalas.filter(e => {
+      if (!e.cantidadMinima) return false
+      if (e.precioUnitario && parsePrecio(e.precioUnitario) > 0) return true
+      if (!e.combinada) return false
+      const minimosActivos = Object.values(e.minimosPorProducto)
+        .filter(v => parseInt(v.cantidad) > 0)
+      if (minimosActivos.length === 0) return false
+      return minimosActivos.every(v => v.precio && parsePrecio(v.precio) > 0)
+    })
     if (escalasValidas.length === 0) {
       setError('Agrega al menos una escala de precio')
       return
@@ -266,14 +276,21 @@ export default function ModalGrupoPrecio({
 
     for (const e of escalasValidas) {
       const qty = parseInt(e.cantidadMinima)
-      const price = parsePrecio(e.precioUnitario)
       if (isNaN(qty) || qty <= 0) {
         setError('Las cantidades minimas deben ser mayores a 0')
         return
       }
-      if (isNaN(price) || price <= 0) {
+      const tienePrecioBase = e.precioUnitario && parsePrecio(e.precioUnitario) > 0
+      if (!tienePrecioBase && !e.combinada) {
         setError('Los precios deben ser mayores a 0')
         return
+      }
+      if (tienePrecioBase) {
+        const price = parsePrecio(e.precioUnitario)
+        if (isNaN(price) || price <= 0) {
+          setError('Los precios deben ser mayores a 0')
+          return
+        }
       }
 
       if (e.combinada) {
@@ -286,6 +303,19 @@ export default function ModalGrupoPrecio({
         if (minimosActivos.length < k) {
           setError(`La escala ${qty}u requiere ${k} productos distintos pero solo ${minimosActivos.length} tienen minimo configurado.`)
           return
+        }
+        // Si no hay precio base, todos los productos con minimo DEBEN tener override.
+        if (!tienePrecioBase) {
+          const sinOverride = minimosActivos.filter(([, v]) => !v.precio || parsePrecio(v.precio) <= 0)
+          if (sinOverride.length > 0) {
+            const nombres = sinOverride
+              .map(([pid]) => nombresProductos[pid] || `#${pid}`)
+              .join(', ')
+            setError(
+              `Escala ${qty}u: ingresá un precio base o un precio mayorista para todos los productos con mínimo. Faltan: ${nombres}.`
+            )
+            return
+          }
         }
         // Coherencia: suma de los K minimos mas bajos debe ser <= cantidad_minima total
         const minimosOrdenados = minimosActivos
@@ -333,9 +363,23 @@ export default function ModalGrupoPrecio({
         productoIds: Array.from(productoIds),
         cantidadesMinimas,
         escalas: escalasValidas.map(e => {
+          let precioBase = parsePrecio(e.precioUnitario)
+          const sinPrecioBase = !e.precioUnitario || isNaN(precioBase) || precioBase <= 0
+
+          // Si es combinada y el precio base quedo vacio, usar el maximo override
+          // como fallback (la BD exige precio_unitario > 0; el cálculo no lo usará
+          // porque todos los productos con minimo tienen override configurado).
+          if (sinPrecioBase && e.combinada) {
+            const overrides = Object.values(e.minimosPorProducto)
+              .filter(v => parseInt(v.cantidad) > 0 && v.precio)
+              .map(v => parsePrecio(v.precio))
+              .filter(n => !isNaN(n) && n > 0)
+            if (overrides.length > 0) precioBase = Math.max(...overrides)
+          }
+
           const base = {
             cantidadMinima: parseInt(e.cantidadMinima),
-            precioUnitario: parsePrecio(e.precioUnitario),
+            precioUnitario: precioBase,
             etiqueta: e.etiqueta.trim() || null,
             minProductosDistintos: e.combinada ? parseInt(e.minProductosDistintos) : 1,
           }
@@ -551,7 +595,10 @@ export default function ModalGrupoPrecio({
                           value={escala.precioUnitario}
                           onChange={e => actualizarEscala(index, { precioUnitario: e.target.value })}
                           className="w-full pl-7 pr-3 py-2 border rounded-lg text-sm dark:bg-gray-700 dark:border-gray-600 dark:text-white"
-                          placeholder="Precio c/u"
+                          placeholder={escala.combinada ? 'Precio base (opcional)' : 'Precio c/u'}
+                          title={escala.combinada
+                            ? 'Opcional si todos los productos tienen precio propio. Sirve de fallback.'
+                            : undefined}
                         />
                       </div>
                       <input


### PR DESCRIPTION
## Summary

Fix sobre [#243](https://github.com/AgustinReiden/distribuidora-app/pull/243) (mergeado). Reportado: no se podía crear una condición combinada aunque todos los productos tuvieran precio mayorista configurado — el modal pedía igualmente el campo \"Precio c/u\" de la escala y bloqueaba el submit.

## Cambios

- La validación ahora considera una escala válida si:
  - tiene cantidad mínima, **y**
  - tiene precio base > 0, **o** es combinada con todos los productos con mínimo teniendo precio override > 0.
- Si combinada sin precio base y faltan overrides en algunos productos, el mensaje es claro: _\"Escala 12u: ingresá un precio base o un precio mayorista para todos los productos con mínimo. Faltan: X, Y.\"_
- Al guardar, si la escala combinada quedó sin precio base, se autocompleta con el **máximo** de los overrides. Así se satisface el \`CHECK precio_unitario > 0\` de la BD y queda un fallback razonable por si en el futuro alguien agrega un producto al grupo sin override individual.
- El placeholder del input de precio cambia: _\"Precio base (opcional)\"_ cuando la escala es combinada, _\"Precio c/u\"_ en las clásicas. Tooltip explicativo al pasar el mouse.

Sin migración — solo cambio cliente. La lógica de cálculo (\`precioMayorista.ts\`) ya manejaba correctamente el caso cuando cada producto tiene override, así que no requiere cambios.

## Validación

- \`tsc --noEmit\` ✅
- \`eslint\` ✅
- \`vitest run\` ✅ **576 tests**

## Test plan

- [ ] Crear grupo con N productos, escala 12u con combinación activa, dejar \"Precio c/u\" vacío, ingresar precio mayorista en cada producto del panel → submit se guarda sin error.
- [ ] Misma escala pero dejar un producto con mínimo sin precio override → error explícito con el nombre del producto faltante.
- [ ] Escala clásica sin precio → sigue mostrando el error anterior \"Los precios deben ser mayores a 0\".
- [ ] Con precio base y overrides mezclados → se usa el override si está, el base si no (comportamiento previo intacto).

🤖 Generated with [Claude Code](https://claude.com/claude-code)