### PR TITLE
fix(mayorista): columna id en grupo_precio_escala_minimos para el audit trigger

### DIFF
--- a/migrations/006_mayorista_escala_minimos_id.sql
+++ b/migrations/006_mayorista_escala_minimos_id.sql
@@ -1,0 +1,33 @@
+-- 006_mayorista_escala_minimos_id.sql
+--
+-- Bugfix: el trigger genérico `audit_log_changes` del sistema accede a
+-- NEW.id y OLD.id directamente (no via to_jsonb), lo cual falla con
+-- "record \"new\" has no field \"id\"" en tablas de PK compuesta como
+-- `grupo_precio_escala_minimos`. Resultado: INSERT/UPDATE/DELETE fallan
+-- con 400 desde el frontend.
+--
+-- Fix minimo: agregar columna `id` BIGSERIAL con UNIQUE (manteniendo la
+-- PK compuesta existente como identidad logica de la fila). Asi la funcion
+-- de audit encuentra el campo sin tocar su implementacion compartida con
+-- el resto de las tablas.
+
+BEGIN;
+
+ALTER TABLE public.grupo_precio_escala_minimos
+  ADD COLUMN IF NOT EXISTS id BIGSERIAL;
+
+-- UNIQUE para consistencia con el resto de tablas auditadas.
+-- (No reemplaza la PK compuesta, solo garantiza unicidad tecnica del id.)
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'grupo_precio_escala_minimos_id_key'
+      AND conrelid = 'public.grupo_precio_escala_minimos'::regclass
+  ) THEN
+    ALTER TABLE public.grupo_precio_escala_minimos
+      ADD CONSTRAINT grupo_precio_escala_minimos_id_key UNIQUE (id);
+  END IF;
+END $$;
+
+COMMIT;

--- a/src/types/hooks.ts
+++ b/src/types/hooks.ts
@@ -1388,6 +1388,12 @@ export interface GrupoPrecioEscalaDB {
 
 /** Fila de la tabla grupo_precio_escala_minimos: minimo individual por producto por escala. */
 export interface GrupoPrecioEscalaMinimoDB {
+  /**
+   * Identificador tecnico (BIGSERIAL) agregado en la migracion 006 para
+   * compatibilidad con el audit trigger generico (que accede a NEW.id).
+   * La identidad logica sigue siendo (escala_id, producto_id).
+   */
+  id?: string;
   escala_id: string;
   producto_id: string;
   cantidad_minima_por_item: number;


### PR DESCRIPTION
## Summary

Bugfix 400 al crear una condición mayorista con escala combinada. Al guardar, el POST a \`grupo_precio_escala_minimos\` fallaba con \`400 Bad Request\`. Logs de Supabase mostraban:

\`\`\`
ERROR: record "new" has no field "id"
\`\`\`

## Causa raíz

La función compartida \`audit_log_changes\` accede directamente a \`NEW.id\` / \`OLD.id\` (migraciones baseline, líneas 786/791/796) en lugar de \`to_jsonb(NEW)->>'id'\`. La tabla \`grupo_precio_escala_minimos\` — creada en la migración 004 — usa PK **compuesta** \`(escala_id, producto_id)\` sin columna \`id\`. El trigger reventaba y abortaba el INSERT.

## Fix (migración 006)

- \`ADD COLUMN id BIGSERIAL\` con UNIQUE constraint. Idempotente.
- La PK compuesta se mantiene como identidad lógica; el \`id\` nuevo es solo un identificador técnico para el audit trigger.
- **No** toca la función de audit compartida con el resto del sistema.
- **Ya aplicada a ManaosApp**.

También agregué \`id?: string\` al type \`GrupoPrecioEscalaMinimoDB\` (opcional; el fetch no lo necesita explícitamente, pero documenta el schema).

## Validación

- \`tsc --noEmit\` ✅
- Migración aplicada y verificada: columna existe con default \`nextval('grupo_precio_escala_minimos_id_seq')\`.

## Test plan

- [ ] Guardar grupo con escala combinada y precios por producto → INSERT exitoso.
- [ ] \`audit_logs\` registra correctamente INSERT/UPDATE/DELETE en \`grupo_precio_escala_minimos\` con \`registro_id\` = id técnico.

🤖 Generated with [Claude Code](https://claude.com/claude-code)