### PR TITLE
feat(auth): trigger handle_new_user asigna sucursal default

### DIFF
--- a/migrations/008_handle_new_user_con_sucursal_default.sql
+++ b/migrations/008_handle_new_user_con_sucursal_default.sql
@@ -1,0 +1,64 @@
+-- Mejora handle_new_user(): además de crear el perfil, asigna automáticamente
+-- al usuario nuevo a la sucursal default (1 = Tucuman, salvo override por
+-- raw_user_meta_data->>'sucursal_id'). Antes solo se creaba el perfil y había
+-- que insertar manualmente en usuario_sucursales — un usuario sin entrada en
+-- esa tabla no puede usar la app porque SucursalContext.tsx queda en estado
+-- "Usuario sin sucursales asignadas".
+--
+-- Comportamiento:
+--   - Si raw_user_meta_data trae 'sucursal_id' válido (existe en sucursales),
+--     usa ese.
+--   - Si no, default a sucursal 1 (Tucuman).
+--   - es_default = true para que SucursalContext la elija al login.
+--   - rol en usuario_sucursales = 'mismo' (resuelve al rol global del perfil).
+--
+-- Idempotente: ON CONFLICT DO NOTHING evita errores si el trigger se re-dispara.
+
+CREATE OR REPLACE FUNCTION public.handle_new_user()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $$
+DECLARE
+  v_sucursal_id BIGINT;
+  v_meta_sucursal TEXT;
+BEGIN
+  -- 1) Crear el perfil (idéntico a la versión previa)
+  INSERT INTO public.perfiles (id, email, nombre, rol, activo)
+  VALUES (
+    NEW.id,
+    NEW.email,
+    COALESCE(NEW.raw_user_meta_data->>'nombre', split_part(NEW.email, '@', 1)),
+    COALESCE(NEW.raw_user_meta_data->>'rol', 'preventista'),
+    true
+  )
+  ON CONFLICT (id) DO NOTHING;
+
+  -- 2) Resolver sucursal: meta override > default 1 (Tucuman)
+  v_meta_sucursal := NEW.raw_user_meta_data->>'sucursal_id';
+  IF v_meta_sucursal IS NOT NULL AND v_meta_sucursal <> '' THEN
+    BEGIN
+      v_sucursal_id := v_meta_sucursal::BIGINT;
+      -- Validar que la sucursal exista; si no, fallback a 1
+      IF NOT EXISTS (SELECT 1 FROM public.sucursales WHERE id = v_sucursal_id) THEN
+        v_sucursal_id := 1;
+      END IF;
+    EXCEPTION WHEN others THEN
+      v_sucursal_id := 1;
+    END;
+  ELSE
+    v_sucursal_id := 1;
+  END IF;
+
+  -- 3) Asignar a la sucursal con es_default=true
+  INSERT INTO public.usuario_sucursales (usuario_id, sucursal_id, rol, es_default)
+  VALUES (NEW.id, v_sucursal_id, 'mismo', true)
+  ON CONFLICT (usuario_id, sucursal_id) DO NOTHING;
+
+  RETURN NEW;
+END;
+$$;
+
+-- El trigger ya existe (on_auth_user_created en auth.users); solo se reemplaza
+-- la función. No hace falta DROP/CREATE TRIGGER.


### PR DESCRIPTION
## Summary

Un usuario nuevo creado via Supabase Auth obtenía su fila en \`perfiles\` (gracias al trigger existente \`handle_new_user\`) pero NO se asignaba a ninguna sucursal, dejando a \`usuario_sucursales\` vacío. El frontend (\`SucursalContext.tsx\`) marca ese caso como "Usuario sin sucursales asignadas" y el usuario no puede operar.

Caso concreto que disparó esto: \`preventista3.crecer@gmail.com\` (UID \`2bf3fffa-48b8-488e-a89e-614377ef6b6c\`), creado vía Authentication. Ya fue asignado manualmente a Tucuman (sucursal 1) como \`es_default=true\` en la misma sesión.

## Cambios

**Migración \`008_handle_new_user_con_sucursal_default.sql\`** — reemplaza la función \`handle_new_user()\`:

- Inserta el perfil (como antes) con \`ON CONFLICT (id) DO NOTHING\`.
- **Asigna al usuario a \`usuario_sucursales\`** con sucursal por defecto = **1 (Tucuman)**.
- Admite override vía \`raw_user_meta_data->>'sucursal_id'\` al crear el auth user; si la sucursal indicada no existe, fallback a 1.
- \`es_default = true\` para que \`SucursalContext\` la elija automáticamente al login.
- \`rol = 'mismo'\` → resuelve al rol global del perfil.
- Idempotente: \`ON CONFLICT (usuario_id, sucursal_id) DO NOTHING\`.

## Migración aplicada

Aplicada a ManaosApp (\`hmuchlzmuqqxcldbzkgc\`) vía Supabase MCP → \`success: true\`.

Verificación post-migración:
- \`perfiles\` y \`usuario_sucursales\` del usuario \`preventista3.crecer@gmail.com\` → OK
- \`handle_new_user\` existe, trigger \`on_auth_user_created\` en \`auth.users\` activo

## Cambiar la sucursal default

Editar el literal \`v_sucursal_id := 1;\` en la función (2 lugares) — es el fallback tanto cuando no hay \`raw_user_meta_data.sucursal_id\` como cuando la sucursal indicada no existe. O pasar \`raw_user_meta_data: { sucursal_id: X }\` al crear el auth user.

## Test plan

- [x] Perfil + usuario_sucursales de preventista3.crecer asignados a Tucuman como default
- [ ] Crear un usuario de prueba en Authentication y verificar que queda en \`usuario_sucursales\` con \`sucursal_id=1, es_default=true\`
- [ ] Login del usuario → puede usar la app sin error de "sin sucursales asignadas"

🤖 Generated with [Claude Code](https://claude.com/claude-code)