### PR TITLE
feat(productos): gestión de categorías + arreglos de header

### DIFF
--- a/migrations/009_categorias_table.sql
+++ b/migrations/009_categorias_table.sql
@@ -1,0 +1,88 @@
+-- Tabla `categorias` para gestionar categorías de productos como entidad propia
+-- (hasta ahora `productos.categoria` era solo un string libre).
+--
+-- Motivo: el admin necesita poder agregar/renombrar/eliminar categorías desde
+-- la UI sin depender de crear un producto antes. Se mantiene `productos.categoria`
+-- como string para no romper queries existentes; la tabla `categorias` actúa
+-- como fuente de verdad para la lista editable, y la UI muestra el UNION de
+-- ambas fuentes (categorías de la tabla + derivadas de productos).
+--
+-- Multi-tenant: `sucursal_id` + RLS con current_sucursal_id() siguiendo el
+-- patrón de `productos` (ver mt_productos_* en 000_baseline.sql).
+-- Insert/update/delete restringidos a admin; select abierto a todos los
+-- usuarios de la sucursal.
+--
+-- Idempotente: seguro para re-aplicar.
+
+-- =============================================================================
+-- TABLA
+-- =============================================================================
+CREATE TABLE IF NOT EXISTS public.categorias (
+  id           uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  nombre       text NOT NULL CHECK (length(btrim(nombre)) > 0),
+  sucursal_id  bigint NOT NULL REFERENCES public.sucursales(id) ON DELETE CASCADE,
+  created_at   timestamptz NOT NULL DEFAULT now(),
+  updated_at   timestamptz NOT NULL DEFAULT now(),
+  UNIQUE (sucursal_id, nombre)
+);
+
+CREATE INDEX IF NOT EXISTS idx_categorias_sucursal ON public.categorias (sucursal_id);
+
+COMMENT ON TABLE public.categorias IS
+  'Categorías de productos por sucursal. Fuente de verdad para la lista editable en UI. productos.categoria (string) se sigue usando para compatibilidad.';
+
+-- =============================================================================
+-- TRIGGER updated_at
+-- =============================================================================
+CREATE OR REPLACE FUNCTION public.categorias_set_updated_at()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  NEW.updated_at = now();
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_categorias_updated_at ON public.categorias;
+CREATE TRIGGER trg_categorias_updated_at
+  BEFORE UPDATE ON public.categorias
+  FOR EACH ROW
+  EXECUTE FUNCTION public.categorias_set_updated_at();
+
+-- =============================================================================
+-- RLS POLICIES (patrón mt_productos_*)
+-- =============================================================================
+ALTER TABLE public.categorias ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS mt_categorias_select ON public.categorias;
+CREATE POLICY mt_categorias_select
+  ON public.categorias FOR SELECT TO authenticated
+  USING (sucursal_id = public.current_sucursal_id());
+
+DROP POLICY IF EXISTS mt_categorias_insert ON public.categorias;
+CREATE POLICY mt_categorias_insert
+  ON public.categorias FOR INSERT TO authenticated
+  WITH CHECK (public.es_admin() AND sucursal_id = public.current_sucursal_id());
+
+DROP POLICY IF EXISTS mt_categorias_update ON public.categorias;
+CREATE POLICY mt_categorias_update
+  ON public.categorias FOR UPDATE TO authenticated
+  USING (public.es_admin() AND sucursal_id = public.current_sucursal_id())
+  WITH CHECK (public.es_admin() AND sucursal_id = public.current_sucursal_id());
+
+DROP POLICY IF EXISTS mt_categorias_delete ON public.categorias;
+CREATE POLICY mt_categorias_delete
+  ON public.categorias FOR DELETE TO authenticated
+  USING (public.es_admin() AND sucursal_id = public.current_sucursal_id());
+
+-- =============================================================================
+-- BACKFILL: poblar con categorías existentes en productos
+-- =============================================================================
+INSERT INTO public.categorias (nombre, sucursal_id)
+SELECT DISTINCT btrim(p.categoria), p.sucursal_id
+FROM public.productos p
+WHERE p.categoria IS NOT NULL
+  AND btrim(p.categoria) <> ''
+  AND p.sucursal_id IS NOT NULL
+ON CONFLICT (sucursal_id, nombre) DO NOTHING;

--- a/src/components/containers/ProductosContainer.tsx
+++ b/src/components/containers/ProductosContainer.tsx
@@ -25,6 +25,7 @@ const ModalMermaStock = lazy(() => import('../modals/ModalMermaStock'))
 const ModalHistorialMermas = lazy(() => import('../modals/ModalHistorialMermas'))
 const ModalImportarPrecios = lazy(() => import('../modals/ModalImportarPrecios'))
 const ModalConfirmacion = lazy(() => import('../modals/ModalConfirmacion'))
+const ModalCategorias = lazy(() => import('../modals/ModalCategorias'))
 
 function LoadingState() {
   return (
@@ -62,6 +63,7 @@ export default function ProductosContainer(): React.ReactElement {
   const [modalMermaOpen, setModalMermaOpen] = useState(false)
   const [modalHistorialOpen, setModalHistorialOpen] = useState(false)
   const [modalImportarOpen, setModalImportarOpen] = useState(false)
+  const [modalCategoriasOpen, setModalCategoriasOpen] = useState(false)
 
   // Estado de edición
   const [productoEditando, setProductoEditando] = useState<ProductoDB | null>(null)
@@ -119,6 +121,10 @@ export default function ProductosContainer(): React.ReactElement {
 
   const handleImportarPrecios = useCallback(() => {
     setModalImportarOpen(true)
+  }, [])
+
+  const handleGestionarCategorias = useCallback(() => {
+    setModalCategoriasOpen(true)
   }, [])
 
   const handleGuardarProducto = useCallback(async (data: ProductoFormInput) => {
@@ -180,6 +186,7 @@ export default function ProductosContainer(): React.ReactElement {
           onBajaStock={handleBajaStock}
           onVerHistorialMermas={handleVerHistorialMermas}
           onImportarPrecios={handleImportarPrecios}
+          onGestionarCategorias={handleGestionarCategorias}
         />
       </Suspense>
 
@@ -232,6 +239,16 @@ export default function ProductosContainer(): React.ReactElement {
             productos={productos}
             onActualizarPrecios={handleActualizarPreciosMasivo}
             onClose={() => setModalImportarOpen(false)}
+          />
+        </Suspense>
+      )}
+
+      {/* Modal Categorías */}
+      {modalCategoriasOpen && (
+        <Suspense fallback={null}>
+          <ModalCategorias
+            productos={productos}
+            onClose={() => setModalCategoriasOpen(false)}
           />
         </Suspense>
       )}

--- a/src/components/modals/ModalCategorias.tsx
+++ b/src/components/modals/ModalCategorias.tsx
@@ -1,0 +1,344 @@
+/**
+ * Modal para gestionar categorías de productos.
+ *
+ * Permite agregar, renombrar y eliminar categorías. La fuente de verdad es la
+ * tabla `categorias` (migración 009) pero la lista muestra también categorías
+ * que existen solo como string en productos (para que el admin pueda
+ * normalizarlas). Renombrar/eliminar actualizan en bloque `productos.categoria`.
+ */
+import { memo, useMemo, useState } from 'react';
+import { Loader2, Plus, Pencil, Trash2, Check, X, Tag, AlertCircle } from 'lucide-react';
+import ModalBase from './ModalBase';
+import {
+  useCategoriasQuery,
+  useCrearCategoriaMutation,
+  useRenombrarCategoriaMutation,
+  useEliminarCategoriaMutation,
+} from '../../hooks/queries';
+import type { CategoriaDB } from '../../hooks/queries';
+import type { ProductoDB } from '../../types';
+
+export interface ModalCategoriasProps {
+  /** Productos actuales de la sucursal (para contar por categoría y mostrar las derivadas) */
+  productos: ProductoDB[];
+  /** Callback al cerrar */
+  onClose: () => void;
+}
+
+/** Entrada unificada que combina categorías de la tabla y derivadas de productos */
+interface CategoriaEntry {
+  id: string | null;       // null cuando solo existe como string en productos
+  nombre: string;
+  productCount: number;
+  source: 'tabla' | 'derivada' | 'ambas';
+}
+
+const ModalCategorias = memo(function ModalCategorias({ productos, onClose }: ModalCategoriasProps) {
+  const { data: categoriasTabla = [], isLoading } = useCategoriasQuery();
+  const crearMut = useCrearCategoriaMutation();
+  const renameMut = useRenombrarCategoriaMutation();
+  const deleteMut = useEliminarCategoriaMutation();
+
+  const [nuevoNombre, setNuevoNombre] = useState('');
+  const [error, setError] = useState('');
+  const [editandoId, setEditandoId] = useState<string | null>(null); // `tabla-uuid` o `derivada-nombre`
+  const [editNombre, setEditNombre] = useState('');
+  const [confirmDelete, setConfirmDelete] = useState<CategoriaEntry | null>(null);
+
+  // Unir categorías de tabla + derivadas de productos
+  const entries = useMemo((): CategoriaEntry[] => {
+    const tablaMap = new Map<string, CategoriaDB>();
+    categoriasTabla.forEach(c => tablaMap.set(c.nombre, c));
+
+    const counts = new Map<string, number>();
+    productos.forEach(p => {
+      if (p.categoria) counts.set(p.categoria, (counts.get(p.categoria) || 0) + 1);
+    });
+
+    const names = new Set<string>([...tablaMap.keys(), ...counts.keys()]);
+    const combined: CategoriaEntry[] = [];
+    names.forEach(nombre => {
+      const enTabla = tablaMap.has(nombre);
+      const enProductos = counts.has(nombre);
+      combined.push({
+        id: enTabla ? tablaMap.get(nombre)!.id : null,
+        nombre,
+        productCount: counts.get(nombre) || 0,
+        source: enTabla && enProductos ? 'ambas' : enTabla ? 'tabla' : 'derivada',
+      });
+    });
+    return combined.sort((a, b) => a.nombre.localeCompare(b.nombre));
+  }, [categoriasTabla, productos]);
+
+  const handleCrear = async () => {
+    const nombre = nuevoNombre.trim();
+    if (!nombre) {
+      setError('Ingresá un nombre');
+      return;
+    }
+    if (entries.some(e => e.nombre.toLowerCase() === nombre.toLowerCase())) {
+      setError(`Ya existe una categoría "${nombre}"`);
+      return;
+    }
+    setError('');
+    try {
+      await crearMut.mutateAsync(nombre);
+      setNuevoNombre('');
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Error al crear categoría');
+    }
+  };
+
+  const handleIniciarRename = (entry: CategoriaEntry) => {
+    setEditandoId(entry.id ? `tabla-${entry.id}` : `derivada-${entry.nombre}`);
+    setEditNombre(entry.nombre);
+    setError('');
+  };
+
+  const handleCancelarRename = () => {
+    setEditandoId(null);
+    setEditNombre('');
+    setError('');
+  };
+
+  const handleConfirmarRename = async (entry: CategoriaEntry) => {
+    const nuevo = editNombre.trim();
+    if (!nuevo) {
+      setError('El nombre no puede estar vacío');
+      return;
+    }
+    if (nuevo === entry.nombre) {
+      handleCancelarRename();
+      return;
+    }
+    if (entries.some(e => e.nombre.toLowerCase() === nuevo.toLowerCase() && e.nombre !== entry.nombre)) {
+      setError(`Ya existe una categoría "${nuevo}"`);
+      return;
+    }
+    setError('');
+    try {
+      await renameMut.mutateAsync({
+        id: entry.id,
+        nombreViejo: entry.nombre,
+        nombreNuevo: nuevo,
+      });
+      handleCancelarRename();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Error al renombrar categoría');
+    }
+  };
+
+  const handleEliminar = async (entry: CategoriaEntry) => {
+    setError('');
+    try {
+      await deleteMut.mutateAsync({ id: entry.id, nombre: entry.nombre });
+      setConfirmDelete(null);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Error al eliminar categoría');
+    }
+  };
+
+  const working = crearMut.isPending || renameMut.isPending || deleteMut.isPending;
+
+  return (
+    <ModalBase title="Gestionar categorías" onClose={onClose} maxWidth="max-w-2xl">
+      <div className="p-4 space-y-4">
+        {/* Agregar nueva */}
+        <div>
+          <label htmlFor="nueva-categoria" className="block text-sm font-medium mb-1 dark:text-gray-200">
+            Nueva categoría
+          </label>
+          <div className="flex gap-2">
+            <input
+              id="nueva-categoria"
+              type="text"
+              value={nuevoNombre}
+              onChange={e => setNuevoNombre(e.target.value)}
+              onKeyDown={e => {
+                if (e.key === 'Enter') {
+                  e.preventDefault();
+                  void handleCrear();
+                }
+              }}
+              placeholder="Ej.: AGUAS SABORIZADAS"
+              className="flex-1 px-3 py-2 border rounded-lg bg-white dark:bg-gray-700 dark:border-gray-600 dark:text-white focus:ring-2 focus:ring-blue-500 focus:outline-none"
+              disabled={crearMut.isPending}
+            />
+            <button
+              type="button"
+              onClick={handleCrear}
+              disabled={crearMut.isPending || !nuevoNombre.trim()}
+              className="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 disabled:bg-gray-400 disabled:cursor-not-allowed flex items-center gap-1.5 font-medium"
+            >
+              {crearMut.isPending ? <Loader2 className="w-4 h-4 animate-spin" /> : <Plus className="w-4 h-4" />}
+              Agregar
+            </button>
+          </div>
+        </div>
+
+        {error && (
+          <div role="alert" className="flex items-start gap-2 p-3 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg text-sm text-red-700 dark:text-red-300">
+            <AlertCircle className="w-4 h-4 flex-shrink-0 mt-0.5" />
+            <span>{error}</span>
+          </div>
+        )}
+
+        {/* Lista */}
+        <div>
+          <h3 className="text-sm font-medium mb-2 dark:text-gray-200 flex items-center gap-1.5">
+            <Tag className="w-4 h-4" />
+            Categorías ({entries.length})
+          </h3>
+
+          {isLoading ? (
+            <div className="flex items-center justify-center py-8">
+              <Loader2 className="w-6 h-6 animate-spin text-blue-600" />
+            </div>
+          ) : entries.length === 0 ? (
+            <p className="text-center text-sm text-gray-500 dark:text-gray-400 py-6">
+              Todavía no hay categorías. Agregá la primera arriba.
+            </p>
+          ) : (
+            <ul className="border dark:border-gray-600 rounded-lg divide-y dark:divide-gray-700 max-h-[50vh] overflow-y-auto">
+              {entries.map(entry => {
+                const editing = editandoId === (entry.id ? `tabla-${entry.id}` : `derivada-${entry.nombre}`);
+                return (
+                  <li key={entry.id ?? entry.nombre} className="flex items-center gap-2 px-3 py-2.5">
+                    {editing ? (
+                      <input
+                        type="text"
+                        value={editNombre}
+                        onChange={e => setEditNombre(e.target.value)}
+                        onKeyDown={e => {
+                          if (e.key === 'Enter') {
+                            e.preventDefault();
+                            void handleConfirmarRename(entry);
+                          } else if (e.key === 'Escape') {
+                            handleCancelarRename();
+                          }
+                        }}
+                        className="flex-1 px-2 py-1 border rounded bg-white dark:bg-gray-700 dark:border-gray-600 dark:text-white focus:ring-2 focus:ring-blue-500 focus:outline-none text-sm"
+                        autoFocus
+                        disabled={renameMut.isPending}
+                      />
+                    ) : (
+                      <div className="flex-1 min-w-0 flex items-center gap-2 flex-wrap">
+                        <span className="font-medium dark:text-white truncate">{entry.nombre}</span>
+                        <span className="text-xs px-2 py-0.5 bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-300 rounded-full">
+                          {entry.productCount} {entry.productCount === 1 ? 'producto' : 'productos'}
+                        </span>
+                        {entry.source === 'derivada' && (
+                          <span
+                            className="text-xs px-2 py-0.5 bg-amber-100 dark:bg-amber-900/30 text-amber-700 dark:text-amber-300 rounded-full"
+                            title="Solo existe como texto en productos. Al renombrarla se formaliza en la tabla de categorías."
+                          >
+                            pendiente
+                          </span>
+                        )}
+                      </div>
+                    )}
+
+                    {editing ? (
+                      <div className="flex gap-1 shrink-0">
+                        <button
+                          type="button"
+                          onClick={() => handleConfirmarRename(entry)}
+                          disabled={renameMut.isPending}
+                          className="p-1.5 text-green-600 hover:bg-green-50 dark:hover:bg-green-900/20 rounded disabled:opacity-50"
+                          title="Guardar"
+                          aria-label="Guardar"
+                        >
+                          {renameMut.isPending ? <Loader2 className="w-4 h-4 animate-spin" /> : <Check className="w-4 h-4" />}
+                        </button>
+                        <button
+                          type="button"
+                          onClick={handleCancelarRename}
+                          disabled={renameMut.isPending}
+                          className="p-1.5 text-gray-500 hover:bg-gray-50 dark:hover:bg-gray-700 rounded disabled:opacity-50"
+                          title="Cancelar"
+                          aria-label="Cancelar"
+                        >
+                          <X className="w-4 h-4" />
+                        </button>
+                      </div>
+                    ) : (
+                      <div className="flex gap-1 shrink-0">
+                        <button
+                          type="button"
+                          onClick={() => handleIniciarRename(entry)}
+                          disabled={working}
+                          className="p-1.5 text-blue-600 hover:bg-blue-50 dark:hover:bg-blue-900/20 rounded disabled:opacity-50"
+                          title={`Renombrar ${entry.nombre}`}
+                          aria-label={`Renombrar ${entry.nombre}`}
+                        >
+                          <Pencil className="w-4 h-4" />
+                        </button>
+                        <button
+                          type="button"
+                          onClick={() => setConfirmDelete(entry)}
+                          disabled={working}
+                          className="p-1.5 text-red-500 hover:bg-red-50 dark:hover:bg-red-900/20 rounded disabled:opacity-50"
+                          title={`Eliminar ${entry.nombre}`}
+                          aria-label={`Eliminar ${entry.nombre}`}
+                        >
+                          <Trash2 className="w-4 h-4" />
+                        </button>
+                      </div>
+                    )}
+                  </li>
+                );
+              })}
+            </ul>
+          )}
+        </div>
+      </div>
+
+      {/* Confirmación de eliminación inline */}
+      {confirmDelete && (
+        <div className="p-4 border-t dark:border-gray-600 bg-amber-50 dark:bg-amber-900/20">
+          <p className="text-sm text-amber-900 dark:text-amber-200 mb-3">
+            <strong>Eliminar "{confirmDelete.nombre}"?</strong>
+            {confirmDelete.productCount > 0 ? (
+              <>
+                {' '}{confirmDelete.productCount} {confirmDelete.productCount === 1 ? 'producto quedará sin categoría' : 'productos quedarán sin categoría'}. No se borran productos.
+              </>
+            ) : (
+              <> No hay productos asociados.</>
+            )}
+          </p>
+          <div className="flex justify-end gap-2">
+            <button
+              type="button"
+              onClick={() => setConfirmDelete(null)}
+              disabled={deleteMut.isPending}
+              className="px-3 py-1.5 text-sm font-medium text-gray-700 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-700 rounded-lg"
+            >
+              Cancelar
+            </button>
+            <button
+              type="button"
+              onClick={() => handleEliminar(confirmDelete)}
+              disabled={deleteMut.isPending}
+              className="px-3 py-1.5 text-sm bg-red-600 text-white font-medium rounded-lg hover:bg-red-700 disabled:bg-gray-400 flex items-center gap-1.5"
+            >
+              {deleteMut.isPending && <Loader2 className="w-4 h-4 animate-spin" />}
+              Eliminar
+            </button>
+          </div>
+        </div>
+      )}
+
+      <div className="p-4 border-t dark:border-gray-600 flex justify-end">
+        <button
+          type="button"
+          onClick={onClose}
+          className="px-4 py-2 text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-lg"
+        >
+          Cerrar
+        </button>
+      </div>
+    </ModalBase>
+  );
+});
+
+export default ModalCategorias;

--- a/src/components/vistas/VistaProductos.tsx
+++ b/src/components/vistas/VistaProductos.tsx
@@ -1,6 +1,6 @@
-import { useState, useMemo } from 'react';
+import { useState, useMemo, useRef } from 'react';
 import type { ChangeEvent } from 'react';
-import { Package, Plus, Edit2, Trash2, Search, AlertTriangle, Minus, TrendingDown, FileSpreadsheet, ClipboardCheck } from 'lucide-react';
+import { Package, Plus, Edit2, Trash2, Search, AlertTriangle, Minus, TrendingDown, FileSpreadsheet, ClipboardCheck, Tag, ChevronLeft, ChevronRight } from 'lucide-react';
 import { formatPrecio } from '../../utils/formatters';
 import LoadingSpinner from '../layout/LoadingSpinner';
 import Paginacion from '../layout/Paginacion';
@@ -23,6 +23,7 @@ export interface VistaProductosProps {
   onBajaStock?: (producto: ProductoDB) => void;
   onVerHistorialMermas?: () => void;
   onImportarPrecios?: () => void;
+  onGestionarCategorias?: () => void;
 }
 
 export default function VistaProductos({
@@ -35,12 +36,14 @@ export default function VistaProductos({
   onEliminarProducto,
   onBajaStock,
   onVerHistorialMermas,
-  onImportarPrecios
+  onImportarPrecios,
+  onGestionarCategorias
 }: VistaProductosProps) {
   const [busqueda, setBusqueda] = useState<string>('');
   const [filtroCategoria, setFiltroCategoria] = useState<string>('todas');
   const [mostrarSoloStockBajo, setMostrarSoloStockBajo] = useState<boolean>(false);
   const [paginaActual, setPaginaActual] = useState(1);
+  const categoriasScrollRef = useRef<HTMLDivElement>(null);
 
   // Obtener categorías únicas
   const categorias = useMemo((): string[] => {
@@ -102,7 +105,16 @@ export default function VistaProductos({
           <p className="text-sm text-gray-500 dark:text-gray-400">{productos.length} productos en catálogo</p>
         </div>
         {isAdmin && (
-          <div className="flex gap-2">
+          <div className="flex flex-wrap gap-2">
+            {onGestionarCategorias && (
+              <button
+                onClick={onGestionarCategorias}
+                className="flex items-center space-x-2 px-4 py-2 bg-purple-100 dark:bg-purple-900/30 text-purple-700 dark:text-purple-400 rounded-lg hover:bg-purple-200 dark:hover:bg-purple-900/50 transition-colors"
+              >
+                <Tag className="w-5 h-5" />
+                <span>Categorías</span>
+              </button>
+            )}
             <button
               onClick={async () => {
                 const { exportControlStock } = await import('../../utils/excel');
@@ -174,26 +186,39 @@ export default function VistaProductos({
         </div>
       )}
 
-      {/* Filtros */}
-      <div className="flex flex-col sm:flex-row gap-4">
-        <div className="relative flex-1">
-          <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 text-gray-400 dark:text-gray-500 w-5 h-5" aria-hidden="true" />
-          <input
-            type="text"
-            value={busqueda}
-            onChange={handleBusqueda}
-            className="w-full pl-10 pr-3 py-2 border dark:border-gray-600 rounded-lg bg-white dark:bg-gray-800 text-gray-900 dark:text-white focus:ring-2 focus:ring-blue-500"
-            placeholder="Buscar por nombre o código..."
-            aria-label="Buscar productos"
-          />
-        </div>
-        {categorias.length > 1 && (
-          <div className="flex flex-wrap gap-2" role="group" aria-label="Filtrar por categoría">
+      {/* Búsqueda — full width */}
+      <div className="relative w-full">
+        <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 text-gray-400 dark:text-gray-500 w-5 h-5" aria-hidden="true" />
+        <input
+          type="text"
+          value={busqueda}
+          onChange={handleBusqueda}
+          className="w-full pl-10 pr-3 py-2 border dark:border-gray-600 rounded-lg bg-white dark:bg-gray-800 text-gray-900 dark:text-white focus:ring-2 focus:ring-blue-500"
+          placeholder="Buscar por nombre o código..."
+          aria-label="Buscar productos"
+        />
+      </div>
+
+      {/* Filtros de categoría — carrusel horizontal con flechas */}
+      {categorias.length > 1 && (
+        <div className="relative" role="group" aria-label="Filtrar por categoría">
+          <button
+            type="button"
+            onClick={() => categoriasScrollRef.current?.scrollBy({ left: -200, behavior: 'smooth' })}
+            className="hidden sm:flex absolute left-0 top-1/2 -translate-y-1/2 z-10 items-center justify-center w-8 h-8 bg-white/95 dark:bg-gray-800 rounded-full shadow-md border dark:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-700"
+            aria-label="Scroll categorías a la izquierda"
+          >
+            <ChevronLeft className="w-4 h-4 text-gray-600 dark:text-gray-300" />
+          </button>
+          <div
+            ref={categoriasScrollRef}
+            className="flex gap-2 overflow-x-auto scroll-smooth sm:px-10 py-1 scrollbar-hide"
+          >
             {categorias.map(cat => (
               <button
                 key={cat}
                 onClick={() => handleCategoria(cat)}
-                className={`px-3 py-2 rounded-lg text-sm font-medium transition-colors ${
+                className={`shrink-0 px-3 py-2 rounded-lg text-sm font-medium transition-colors ${
                   filtroCategoria === cat
                     ? 'bg-blue-600 text-white'
                     : 'bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-600'
@@ -204,8 +229,16 @@ export default function VistaProductos({
               </button>
             ))}
           </div>
-        )}
-      </div>
+          <button
+            type="button"
+            onClick={() => categoriasScrollRef.current?.scrollBy({ left: 200, behavior: 'smooth' })}
+            className="hidden sm:flex absolute right-0 top-1/2 -translate-y-1/2 z-10 items-center justify-center w-8 h-8 bg-white/95 dark:bg-gray-800 rounded-full shadow-md border dark:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-700"
+            aria-label="Scroll categorías a la derecha"
+          >
+            <ChevronRight className="w-4 h-4 text-gray-600 dark:text-gray-300" />
+          </button>
+        </div>
+      )}
 
       {/* Contador de resultados */}
       {(busqueda || filtroCategoria !== 'todas' || mostrarSoloStockBajo) && (

--- a/src/hooks/queries/index.ts
+++ b/src/hooks/queries/index.ts
@@ -18,6 +18,16 @@ export {
   useRestaurarStockMutation,
 } from './useProductosQuery'
 
+// Categorías
+export {
+  categoriasKeys,
+  useCategoriasQuery,
+  useCrearCategoriaMutation,
+  useRenombrarCategoriaMutation,
+  useEliminarCategoriaMutation,
+} from './useCategoriasQuery'
+export type { CategoriaDB } from './useCategoriasQuery'
+
 // Clientes
 export {
   clientesKeys,

--- a/src/hooks/queries/useCategoriasQuery.ts
+++ b/src/hooks/queries/useCategoriasQuery.ts
@@ -1,0 +1,202 @@
+/**
+ * TanStack Query hooks para Categorías.
+ *
+ * La tabla `categorias` es la fuente de verdad para la gestión manual de
+ * categorías (agregar, renombrar, eliminar). El campo `productos.categoria`
+ * (string libre) se mantiene para compatibilidad y se actualiza en bloque
+ * cuando se renombra o elimina una categoría.
+ *
+ * Requiere la migración 009_categorias_table.sql aplicada en Supabase.
+ */
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import { supabase } from '../supabase/base'
+import { useSucursal } from '../../contexts/SucursalContext'
+import { productosKeys } from './useProductosQuery'
+
+// =============================================================================
+// TYPES
+// =============================================================================
+
+export interface CategoriaDB {
+  id: string
+  nombre: string
+  sucursal_id: number
+  created_at: string
+  updated_at: string
+}
+
+// =============================================================================
+// QUERY KEYS
+// =============================================================================
+
+export const categoriasKeys = {
+  all: (sucursalId: number | null) => ['categorias', sucursalId] as const,
+  lists: (sucursalId: number | null) => [...categoriasKeys.all(sucursalId), 'list'] as const,
+}
+
+// =============================================================================
+// FETCH
+// =============================================================================
+
+async function fetchCategorias(): Promise<CategoriaDB[]> {
+  const { data, error } = await supabase
+    .from('categorias')
+    .select('*')
+    .order('nombre')
+
+  if (error) throw error
+  return (data as CategoriaDB[]) || []
+}
+
+// =============================================================================
+// MUTATIONS
+// =============================================================================
+
+async function createCategoria(nombre: string, sucursalId: number | null): Promise<CategoriaDB> {
+  if (sucursalId == null) {
+    throw new Error('No hay sucursal activa. Recargá la página e intentá de nuevo.')
+  }
+
+  const nombreLimpio = nombre.trim()
+  if (!nombreLimpio) throw new Error('El nombre de la categoría no puede estar vacío')
+
+  const { data, error } = await supabase
+    .from('categorias')
+    .insert([{ nombre: nombreLimpio, sucursal_id: sucursalId }])
+    .select()
+    .single()
+
+  if (error) {
+    // Conflict por unique (sucursal_id, nombre)
+    if (error.code === '23505') {
+      throw new Error(`Ya existe una categoría llamada "${nombreLimpio}"`)
+    }
+    throw error
+  }
+  return data as CategoriaDB
+}
+
+/**
+ * Renombra una categoría y actualiza en bloque todos los productos que usan
+ * el nombre viejo. Si la categoría no existe en la tabla (solo deriva de
+ * productos) se hace UPSERT.
+ */
+async function renameCategoria(
+  { id, nombreViejo, nombreNuevo, sucursalId }:
+  { id: string | null; nombreViejo: string; nombreNuevo: string; sucursalId: number | null }
+): Promise<void> {
+  if (sucursalId == null) {
+    throw new Error('No hay sucursal activa. Recargá la página e intentá de nuevo.')
+  }
+
+  const nuevoLimpio = nombreNuevo.trim()
+  if (!nuevoLimpio) throw new Error('El nombre nuevo no puede estar vacío')
+  if (nuevoLimpio === nombreViejo) return
+
+  // 1) Update / upsert en la tabla de categorías
+  if (id) {
+    const { error: updateErr } = await supabase
+      .from('categorias')
+      .update({ nombre: nuevoLimpio })
+      .eq('id', id)
+    if (updateErr) {
+      if (updateErr.code === '23505') {
+        throw new Error(`Ya existe una categoría llamada "${nuevoLimpio}"`)
+      }
+      throw updateErr
+    }
+  } else {
+    // Categoría solo derivada: insertarla con el nombre nuevo
+    const { error: insertErr } = await supabase
+      .from('categorias')
+      .insert([{ nombre: nuevoLimpio, sucursal_id: sucursalId }])
+    if (insertErr && insertErr.code !== '23505') throw insertErr
+  }
+
+  // 2) Bulk update de productos que usan el nombre viejo
+  const { error: bulkErr } = await supabase
+    .from('productos')
+    .update({ categoria: nuevoLimpio })
+    .eq('categoria', nombreViejo)
+  if (bulkErr) throw bulkErr
+}
+
+/**
+ * Elimina una categoría de la tabla y deja `productos.categoria = NULL` para
+ * todos los productos que la usaban (no se borran los productos).
+ */
+async function deleteCategoria(
+  { id, nombre }: { id: string | null; nombre: string }
+): Promise<void> {
+  // 1) Borrar de la tabla (si existe)
+  if (id) {
+    const { error: delErr } = await supabase
+      .from('categorias')
+      .delete()
+      .eq('id', id)
+    if (delErr) throw delErr
+  }
+
+  // 2) Dejar sin categoría a los productos afectados
+  const { error: bulkErr } = await supabase
+    .from('productos')
+    .update({ categoria: null })
+    .eq('categoria', nombre)
+  if (bulkErr) throw bulkErr
+}
+
+// =============================================================================
+// HOOKS
+// =============================================================================
+
+export function useCategoriasQuery() {
+  const { currentSucursalId } = useSucursal()
+  return useQuery({
+    queryKey: categoriasKeys.lists(currentSucursalId),
+    queryFn: fetchCategorias,
+    staleTime: 10 * 60 * 1000,
+  })
+}
+
+export function useCrearCategoriaMutation() {
+  const queryClient = useQueryClient()
+  const { currentSucursalId } = useSucursal()
+
+  return useMutation({
+    mutationFn: (nombre: string) => createCategoria(nombre, currentSucursalId),
+    onSuccess: (nueva) => {
+      queryClient.setQueryData<CategoriaDB[]>(categoriasKeys.lists(currentSucursalId), (old) => {
+        if (!old) return [nueva]
+        return [...old, nueva].sort((a, b) => a.nombre.localeCompare(b.nombre))
+      })
+    },
+  })
+}
+
+export function useRenombrarCategoriaMutation() {
+  const queryClient = useQueryClient()
+  const { currentSucursalId } = useSucursal()
+
+  return useMutation({
+    mutationFn: (args: { id: string | null; nombreViejo: string; nombreNuevo: string }) =>
+      renameCategoria({ ...args, sucursalId: currentSucursalId }),
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: categoriasKeys.lists(currentSucursalId) })
+      // Los productos cambiaron su string de categoría; invalidar la lista
+      queryClient.invalidateQueries({ queryKey: productosKeys.lists(currentSucursalId) })
+    },
+  })
+}
+
+export function useEliminarCategoriaMutation() {
+  const queryClient = useQueryClient()
+  const { currentSucursalId } = useSucursal()
+
+  return useMutation({
+    mutationFn: deleteCategoria,
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: categoriasKeys.lists(currentSucursalId) })
+      queryClient.invalidateQueries({ queryKey: productosKeys.lists(currentSucursalId) })
+    },
+  })
+}

--- a/src/lib/sentry.ts
+++ b/src/lib/sentry.ts
@@ -255,7 +255,11 @@ export function initSentry(): void {
         block: ['.sensitive-data', '[data-sentry-block]']
       }),
       // Feedback del usuario
+      // NOTE: autoInject deshabilitado porque el botón flotante molestaba al
+      // layout y no se usaba. La integración queda configurada en código para
+      // poder habilitarla rápido si más adelante la necesitamos.
       Sentry.feedbackIntegration({
+        autoInject: false,
         colorScheme: 'system',
         showBranding: false,
         buttonLabel: 'Reportar problema',


### PR DESCRIPTION
## Resumen

Tres cambios de UX en el panel de Productos + el arreglo previo de Sentry.

### 1. Búsqueda ya no se comprime
El input pasa a ocupar toda la fila; los filtros de categoría bajan a su propia fila debajo. Antes peleaban espacio horizontal con `flex-row` y el input se estrangulaba cuando había muchas categorías.

### 2. Filtros de categoría como carrusel
Mismo patrón que el `ModalPedido`: scroll horizontal táctil con `overflow-x-auto`, flechas (`ChevronLeft`/`ChevronRight`) visibles en `sm:`+ para scrollear con el mouse. Evita que el header crezca a lo alto cuando hay muchas categorías.

### 3. Botón "Categorías" + modal CRUD
Admin puede agregar, renombrar y eliminar categorías desde un modal nuevo accesible desde el header (al lado de Control de Stock, con ícono `Tag`).

**DB:**
- Nueva tabla `categorias` (migración `009_categorias_table.sql`): una entrada por sucursal, RLS con `current_sucursal_id()` siguiendo el patrón `mt_productos_*`, restricción `UNIQUE(sucursal_id, nombre)`, trigger `updated_at`.
- Backfill idempotente: al aplicar la migración, se insertan todas las categorías existentes derivadas de `productos.categoria`.
- `productos.categoria` se mantiene como string para compatibilidad. Todas las queries existentes (filtros, ModalPedido, ModalProducto) siguen funcionando sin cambios.

**Comportamiento CRUD:**
- **Agregar**: `INSERT INTO categorias`. Error claro si el nombre ya existe.
- **Renombrar**: `UPDATE categorias` + bulk `UPDATE productos SET categoria = nuevo WHERE categoria = viejo`. Si la categoría solo existía como string en productos (no en la tabla), la formaliza con un INSERT previo.
- **Eliminar**: `DELETE FROM categorias` + bulk `UPDATE productos SET categoria = NULL WHERE categoria = nombre`. Los productos no se borran.

**UI:**
- Modal muestra la UNION de la tabla + categorías derivadas de productos con badge "pendiente" en las que solo existen como string.
- Cada fila muestra el conteo de productos asociados.
- Edición inline (Enter = guardar, Escape = cancelar).
- Confirmación expandible al eliminar, que aclara cuántos productos quedarán sin categoría.

### 4. Botón Reportar bug oculto (cherry-pick)
Commit `3f08038` del PR #250 que quedó sin mergear: `autoInject: false` en `feedbackIntegration` de Sentry. El botón flotante ya no aparece pero la configuración queda para habilitar rápido.

---

## ⚠️ Acción requerida antes de mergear

Aplicar la migración en Supabase:
```bash
# Opción A — SQL Editor de Supabase, pegar contenido de migrations/009_categorias_table.sql
# Opción B — CLI
npx supabase db push --db-url "postgresql://..."
```

Sin la migración, el modal Categorías falla al leer/escribir.

---

## Archivos tocados

- `migrations/009_categorias_table.sql` — nueva
- `src/hooks/queries/useCategoriasQuery.ts` — nueva, con mutations de crear/renombrar/eliminar
- `src/hooks/queries/index.ts` — exporta el hook nuevo
- `src/components/modals/ModalCategorias.tsx` — nueva
- `src/components/containers/ProductosContainer.tsx` — registra el modal + handler
- `src/components/vistas/VistaProductos.tsx` — botón Categorías, fix de búsqueda, carrusel
- `src/lib/sentry.ts` — `autoInject: false` (cherry-pick del PR #250)

---

## Test plan

- [ ] Aplicar migración 009 en Supabase antes de cualquier test
- [ ] Panel de Productos: la barra de búsqueda ocupa todo el ancho, los filtros de categoría están abajo como carrusel con flechas (en desktop)
- [ ] Botón "Categorías" (violeta) visible en el header al lado de "Control de Stock"
- [ ] Abrir modal Categorías: se listan todas las categorías con conteo de productos
- [ ] Agregar una categoría nueva → aparece en la lista, aparece también en los filtros del panel y en el carrusel del ModalPedido
- [ ] Renombrar "AGUAS" a "AGUAS MINERALES" → todos los productos con esa categoría se actualizan (revisar en la tabla de productos)
- [ ] Eliminar una categoría usada por N productos → esos productos quedan con "Sin categoría", la categoría desaparece del carrusel
- [ ] El botón flotante de Sentry "Reportar problema" no aparece en ninguna pantalla
- [ ] Non-admin (preventista/transportista): el botón Categorías no se muestra (protegido por `isAdmin`)

## Chequeos

- `npm run typecheck` ✅
- `npm run lint` ✅
- `npm run test:run` — 576 tests ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)