### PR TITLE
fix(pedidos): recalcular promos al editar y limpiar regalos huérfanos en salvedades

### DIFF
--- a/migrations/010_registrar_salvedad_resync_promos.sql
+++ b/migrations/010_registrar_salvedad_resync_promos.sql
@@ -1,0 +1,254 @@
+-- Migration 010: registrar_salvedad — limpieza de bonificaciones obsoletas
+--
+-- Motivo: cuando un item que origina una promoción se marca como "entregado
+-- con salvedad" (cantidad afectada > 0), el umbral de la promo deja de
+-- cumplirse parcial o totalmente. La versión anterior de `registrar_salvedad`
+-- sólo ajustaba el item afectado; dejaba las líneas de bonificación intactas,
+-- quedando "regalos huérfanos" en el pedido y el stock/usos_pendientes
+-- descuadrados.
+--
+-- Fix: tras reducir/eliminar el item, recorrer las bonificaciones del pedido,
+-- recomputar la cantidad esperada según las reglas de cada promo y ajustar o
+-- eliminar las líneas correspondientes, devolviendo stock cuando
+-- `regalo_mueve_stock = TRUE` y decrementando `usos_pendientes`.
+--
+-- Compatible con pedidos sin bonificaciones (el loop es no-op).
+-- Idempotente (CREATE OR REPLACE).
+
+CREATE OR REPLACE FUNCTION public.registrar_salvedad(
+  p_pedido_id       bigint,
+  p_pedido_item_id  bigint,
+  p_cantidad_afectada integer,
+  p_motivo          character varying,
+  p_descripcion     text    DEFAULT NULL,
+  p_foto_url        text    DEFAULT NULL,
+  p_devolver_stock  boolean DEFAULT true
+) RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $$
+DECLARE
+  v_sucursal          BIGINT := current_sucursal_id();
+  v_salvedad_id       BIGINT;
+  v_item              RECORD;
+  v_cantidad_entregada INTEGER;
+  v_monto_afectado    DECIMAL;
+  v_usuario_id        UUID;
+  v_es_admin          BOOLEAN;
+  v_subtotal_nuevo    DECIMAL;
+  v_stock_devuelto    BOOLEAN := FALSE;
+  v_merma_registrada  BOOLEAN := FALSE;
+  v_stock_actual      INTEGER;
+  -- Variables para la resincronización de bonificaciones
+  v_bonif             RECORD;
+  v_cant_compra       INT;
+  v_cant_bonif        INT;
+  v_total_qty         INT;
+  v_bloques           INT;
+  v_expected_bonif    INT;
+  v_diff              INT;
+  v_regalo_mueve_stock BOOLEAN;
+BEGIN
+  IF v_sucursal IS NULL THEN
+    RETURN jsonb_build_object('success', false, 'error', 'No se pudo determinar la sucursal activa');
+  END IF;
+
+  v_usuario_id := auth.uid();
+  IF v_usuario_id IS NULL THEN
+    RETURN jsonb_build_object('success', false, 'error', 'Usuario no autenticado');
+  END IF;
+
+  SELECT EXISTS (SELECT 1 FROM perfiles WHERE id = v_usuario_id AND rol = 'admin') INTO v_es_admin;
+  IF NOT v_es_admin THEN
+    IF NOT EXISTS (
+      SELECT 1 FROM pedidos
+       WHERE id = p_pedido_id AND transportista_id = v_usuario_id AND sucursal_id = v_sucursal
+    ) THEN
+      RETURN jsonb_build_object('success', false, 'error', 'No autorizado para este pedido');
+    END IF;
+  END IF;
+
+  SELECT pi.id, pi.producto_id, pi.cantidad, pi.precio_unitario, pi.subtotal
+    INTO v_item
+    FROM pedido_items pi
+   WHERE pi.id = p_pedido_item_id
+     AND pi.pedido_id = p_pedido_id
+     AND pi.sucursal_id = v_sucursal;
+
+  IF v_item IS NULL THEN
+    RETURN jsonb_build_object('success', false, 'error', 'Item de pedido no encontrado');
+  END IF;
+
+  IF p_cantidad_afectada > v_item.cantidad THEN
+    RETURN jsonb_build_object('success', false, 'error', 'Cantidad afectada mayor a cantidad del item');
+  END IF;
+  IF p_cantidad_afectada <= 0 THEN
+    RETURN jsonb_build_object('success', false, 'error', 'Cantidad debe ser mayor a 0');
+  END IF;
+
+  v_cantidad_entregada := v_item.cantidad - p_cantidad_afectada;
+  v_monto_afectado     := p_cantidad_afectada * v_item.precio_unitario;
+  v_subtotal_nuevo     := v_cantidad_entregada * v_item.precio_unitario;
+
+  IF p_motivo IN ('cliente_rechaza', 'error_pedido', 'diferencia_precio') THEN
+    v_stock_devuelto := TRUE;
+  END IF;
+
+  INSERT INTO salvedades_items (
+    pedido_id, pedido_item_id, producto_id, cantidad_original, cantidad_afectada,
+    cantidad_entregada, motivo, descripcion, foto_url, monto_afectado, precio_unitario,
+    reportado_por, stock_devuelto, stock_devuelto_at, estado_resolucion, sucursal_id
+  ) VALUES (
+    p_pedido_id, p_pedido_item_id, v_item.producto_id, v_item.cantidad, p_cantidad_afectada,
+    v_cantidad_entregada, p_motivo, p_descripcion, p_foto_url, v_monto_afectado, v_item.precio_unitario,
+    v_usuario_id, v_stock_devuelto, CASE WHEN v_stock_devuelto THEN NOW() ELSE NULL END, 'pendiente', v_sucursal
+  ) RETURNING id INTO v_salvedad_id;
+
+  IF v_salvedad_id IS NULL THEN
+    RAISE EXCEPTION 'No se pudo crear la salvedad';
+  END IF;
+
+  IF v_cantidad_entregada > 0 THEN
+    UPDATE pedido_items
+       SET cantidad = v_cantidad_entregada,
+           subtotal = v_subtotal_nuevo
+     WHERE id = p_pedido_item_id AND sucursal_id = v_sucursal;
+  ELSE
+    DELETE FROM pedido_items
+     WHERE id = p_pedido_item_id AND sucursal_id = v_sucursal;
+  END IF;
+
+  -- ===========================================================================
+  -- NUEVO: resincronizar bonificaciones tras la salvedad
+  -- Recorremos cada bonificación del pedido; recomputamos la cantidad esperada
+  -- según el total actual de items disparadores y las reglas de la promo. Si la
+  -- cantidad esperada cayó, devolvemos stock (cuando aplica) y decrementamos
+  -- usos_pendientes antes de reducir o eliminar la línea de regalo.
+  -- ===========================================================================
+  FOR v_bonif IN
+    SELECT pi.id, pi.producto_id, pi.cantidad, pi.promocion_id
+      FROM pedido_items pi
+     WHERE pi.pedido_id = p_pedido_id
+       AND pi.sucursal_id = v_sucursal
+       AND COALESCE(pi.es_bonificacion, FALSE) = TRUE
+       AND pi.promocion_id IS NOT NULL
+  LOOP
+    SELECT
+      MAX(CASE WHEN pr.clave = 'cantidad_compra'       THEN pr.valor END)::INT,
+      MAX(CASE WHEN pr.clave = 'cantidad_bonificacion' THEN pr.valor END)::INT,
+      MAX(p.regalo_mueve_stock::INT)::BOOLEAN
+    INTO v_cant_compra, v_cant_bonif, v_regalo_mueve_stock
+    FROM promociones p
+    LEFT JOIN promocion_reglas pr
+      ON pr.promocion_id = p.id
+    WHERE p.id = v_bonif.promocion_id
+      AND p.sucursal_id = v_sucursal
+    GROUP BY p.id;
+
+    -- Si la promo no existe o falta alguna regla, saltamos (sin tocar la línea).
+    IF v_cant_compra IS NULL OR v_cant_compra <= 0
+       OR v_cant_bonif IS NULL OR v_cant_bonif <= 0 THEN
+      CONTINUE;
+    END IF;
+
+    -- Total de unidades no-bonif de los productos disparadores de esta promo
+    SELECT COALESCE(SUM(pi.cantidad), 0)::INT
+      INTO v_total_qty
+      FROM pedido_items pi
+      JOIN promocion_productos pp
+        ON pp.producto_id = pi.producto_id
+       AND pp.promocion_id = v_bonif.promocion_id
+     WHERE pi.pedido_id = p_pedido_id
+       AND pi.sucursal_id = v_sucursal
+       AND COALESCE(pi.es_bonificacion, FALSE) = FALSE;
+
+    v_bloques        := v_total_qty / v_cant_compra;
+    v_expected_bonif := v_bloques * v_cant_bonif;
+
+    -- Sólo reducimos; nunca aumentamos la bonificación en este flujo
+    -- (salvedad sólo puede restar productos del pedido).
+    IF v_expected_bonif < v_bonif.cantidad THEN
+      v_diff := v_bonif.cantidad - v_expected_bonif;
+
+      IF COALESCE(v_regalo_mueve_stock, FALSE) THEN
+        UPDATE productos
+           SET stock = stock + v_diff
+         WHERE id = v_bonif.producto_id
+           AND sucursal_id = v_sucursal;
+      END IF;
+
+      UPDATE promociones
+         SET usos_pendientes = GREATEST(COALESCE(usos_pendientes, 0) - v_diff, 0)
+       WHERE id = v_bonif.promocion_id
+         AND sucursal_id = v_sucursal;
+
+      IF v_expected_bonif = 0 THEN
+        DELETE FROM pedido_items WHERE id = v_bonif.id;
+      ELSE
+        UPDATE pedido_items
+           SET cantidad = v_expected_bonif,
+               subtotal = v_expected_bonif * COALESCE(precio_unitario, 0)
+         WHERE id = v_bonif.id;
+      END IF;
+    END IF;
+  END LOOP;
+
+  -- Recalcular total del pedido DESPUÉS de la limpieza de bonificaciones.
+  UPDATE pedidos
+     SET total = (
+           SELECT COALESCE(SUM(subtotal), 0)
+             FROM pedido_items
+            WHERE pedido_id = p_pedido_id
+              AND sucursal_id = v_sucursal
+         ),
+         updated_at = NOW()
+   WHERE id = p_pedido_id AND sucursal_id = v_sucursal;
+
+  IF v_stock_devuelto THEN
+    UPDATE productos
+       SET stock = stock + p_cantidad_afectada
+     WHERE id = v_item.producto_id AND sucursal_id = v_sucursal;
+  END IF;
+
+  IF p_motivo IN ('producto_danado', 'producto_vencido') THEN
+    SELECT stock INTO v_stock_actual
+      FROM productos
+     WHERE id = v_item.producto_id AND sucursal_id = v_sucursal
+     FOR UPDATE;
+
+    INSERT INTO mermas_stock (
+      producto_id, cantidad, motivo, observaciones,
+      stock_anterior, stock_nuevo, usuario_id, sucursal_id
+    ) VALUES (
+      v_item.producto_id, p_cantidad_afectada,
+      CASE p_motivo WHEN 'producto_danado' THEN 'rotura' WHEN 'producto_vencido' THEN 'vencimiento' END,
+      COALESCE(p_descripcion, 'Salvedad pedido #' || p_pedido_id || ': ' || p_motivo),
+      v_stock_actual, GREATEST(v_stock_actual - p_cantidad_afectada, 0), v_usuario_id, v_sucursal
+    );
+
+    UPDATE productos
+       SET stock = GREATEST(stock - p_cantidad_afectada, 0)
+     WHERE id = v_item.producto_id AND sucursal_id = v_sucursal;
+
+    v_merma_registrada := TRUE;
+  END IF;
+
+  INSERT INTO salvedad_historial (salvedad_id, accion, estado_nuevo, notas, usuario_id, sucursal_id)
+  VALUES (v_salvedad_id, 'creacion', 'pendiente', p_descripcion, v_usuario_id, v_sucursal);
+
+  RETURN jsonb_build_object(
+    'success', true,
+    'salvedad_id', v_salvedad_id,
+    'monto_afectado', v_monto_afectado,
+    'cantidad_entregada', v_cantidad_entregada,
+    'stock_devuelto', v_stock_devuelto,
+    'merma_registrada', v_merma_registrada,
+    'nuevo_total_pedido', (
+      SELECT total FROM pedidos WHERE id = p_pedido_id AND sucursal_id = v_sucursal
+    )
+  );
+EXCEPTION WHEN OTHERS THEN
+  RETURN jsonb_build_object('success', false, 'error', SQLERRM);
+END;
+$$;

--- a/src/components/containers/PedidosContainer.tsx
+++ b/src/components/containers/PedidosContainer.tsx
@@ -531,7 +531,10 @@ export default function PedidosContainer(): React.ReactElement {
     setGuardando(false)
   }, [pedidoEditando, notify, queryClient])
 
-  // ModalEditarPedido: onSaveItems - guardar cambios de items via RPC
+  // ModalEditarPedido: onSaveItems - guardar cambios de items via RPC.
+  // Reenvía el desglose fiscal para que el RPC actualice correctamente
+  // total_neto/total_iva (sin esto, los COALESCE(..., precio) del RPC dejaban
+  // todo el monto como "neto" ignorando el IVA en facturas FC).
   const handleGuardarItemsEdicion = useCallback(async (items: PedidoEditItem[]) => {
     if (!pedidoEditando) return
     const itemsParaRPC = items.map(item => ({
@@ -540,6 +543,10 @@ export default function PedidosContainer(): React.ReactElement {
       precio_unitario: item.precioUnitario,
       ...(item.esBonificacion ? { es_bonificacion: true } : {}),
       ...(item.promocionId ? { promocion_id: item.promocionId } : {}),
+      ...(item.neto_unitario !== undefined ? { neto_unitario: item.neto_unitario } : {}),
+      ...(item.iva_unitario !== undefined ? { iva_unitario: item.iva_unitario } : {}),
+      ...(item.impuestos_internos_unitario !== undefined ? { impuestos_internos_unitario: item.impuestos_internos_unitario } : {}),
+      ...(item.porcentaje_iva !== undefined ? { porcentaje_iva: item.porcentaje_iva } : {}),
     }))
     const { data, error } = await supabase.rpc('actualizar_pedido_items', {
       p_pedido_id: pedidoEditando.id,

--- a/src/components/modals/ModalEditarPedido.test.jsx
+++ b/src/components/modals/ModalEditarPedido.test.jsx
@@ -15,14 +15,18 @@ vi.mock('../../lib/supabase', () => ({
   },
 }))
 
-// Mock TanStack Query hooks used by usePrecioMayorista
+// Mock TanStack Query hooks used by usePromocionPedido (price + promo maps)
 vi.mock('../../hooks/queries/useGruposPrecioQuery', () => ({
   usePricingMapQuery: () => ({ data: new Map(), isLoading: false }),
 }))
+vi.mock('../../hooks/queries/usePromocionesQuery', () => ({
+  usePromoMapQuery: () => ({ data: new Map(), isLoading: false }),
+}))
 
-// Mock formatPrecio
+// Mock formatPrecio (preserve fechaLocalISO since usePromocionesQuery uses it indirectly)
 vi.mock('../../utils/formatters', () => ({
-  formatPrecio: (value) => `$${Number(value).toFixed(2)}`
+  formatPrecio: (value) => `$${Number(value).toFixed(2)}`,
+  fechaLocalISO: () => '2026-01-01',
 }))
 
 import ModalEditarPedido from './ModalEditarPedido'
@@ -412,6 +416,82 @@ describe('ModalEditarPedido', () => {
       await user.click(btnCancelar)
 
       expect(onClose).toHaveBeenCalled()
+    })
+  })
+
+  describe('Bonificaciones en edición (regresión bug 2)', () => {
+    // Bug 2: al abrir un pedido con regalos cargados en DB e incrementar un
+    // item, el total mostrado se inflaba porque los regalos se re-cotizaban
+    // al precio base del producto (producto.precio || 0 caía a producto.precio).
+    // Con el fix, los regalos se filtran del estado editable y el total se
+    // calcula sólo a partir de los items no-bonif.
+    const pedidoConBonif = {
+      ...mockPedido,
+      total: 1000,
+      items: [
+        { producto_id: 1, cantidad: 2, precio_unitario: 250, producto: { nombre: 'Producto 1' }, es_bonificacion: false },
+        { producto_id: 2, cantidad: 1, precio_unitario: 500, producto: { nombre: 'Producto 2' }, es_bonificacion: false },
+        // Regalo: precio 0 en DB, pero producto base precio = 100. Bajo el bug
+        // viejo, este item sumaba 200 al total al recalcular.
+        { producto_id: 3, cantidad: 2, precio_unitario: 0, producto: { nombre: 'Producto 3' }, es_bonificacion: true },
+      ],
+    }
+
+    // ModalBase monta el contenido en un portal (Radix Dialog), así que
+    // querySelectorAll se hace contra document.body. El botón "+" de cantidad
+    // se identifica por su clase rounded-r-lg, única de ese control.
+    const findIncrementButtons = () =>
+      Array.from(document.body.querySelectorAll('button.rounded-r-lg'))
+
+    it('no suma el precio base de los items de regalo al incrementar otro producto', async () => {
+      const user = userEvent.setup()
+      render(<ModalEditarPedido {...defaultProps} pedido={pedidoConBonif} isAdmin={true} />)
+
+      await waitFor(() => expect(screen.getByText('Producto 1')).toBeInTheDocument())
+
+      // Incrementar Producto 1: 2 → 3
+      const incrementButtons = findIncrementButtons()
+      expect(incrementButtons.length).toBeGreaterThan(0)
+      await user.click(incrementButtons[0])
+
+      // Total esperado = 3·250 + 1·500 = $1250 (no $1450 como haría el bug viejo,
+      // que sumaba 2·100 del regalo cotizado a precio base).
+      await waitFor(() => {
+        expect(screen.getByText('$1250.00')).toBeInTheDocument()
+      }, { timeout: 3000 })
+      expect(screen.queryByText('$1450.00')).not.toBeInTheDocument()
+    })
+
+    it('guarda los items sin arrastrar el regalo al precio base del producto', async () => {
+      const user = userEvent.setup()
+      const onSaveItems = vi.fn().mockResolvedValue()
+      const onSave = vi.fn()
+      render(
+        <ModalEditarPedido
+          {...defaultProps}
+          pedido={pedidoConBonif}
+          isAdmin={true}
+          onSave={onSave}
+          onSaveItems={onSaveItems}
+        />
+      )
+
+      await waitFor(() => expect(screen.getByText('Producto 1')).toBeInTheDocument())
+
+      const incrementButtons = findIncrementButtons()
+      expect(incrementButtons.length).toBeGreaterThan(0)
+      await user.click(incrementButtons[0])
+
+      await waitFor(() => expect(screen.getByText('Guardar Todo')).toBeInTheDocument())
+      await user.click(screen.getByRole('button', { name: 'Guardar Todo' }))
+
+      expect(onSaveItems).toHaveBeenCalled()
+      const savedItems = onSaveItems.mock.calls[0][0]
+      // Ningún item del pedido persistido puede tener productoId=3 con precio>0.
+      // En un pedido sin promos activas (promoMap mockeado vacío), el regalo
+      // simplemente desaparece del guardado.
+      const producto3 = savedItems.find(i => i.productoId === 3)
+      expect(producto3).toBeUndefined()
     })
   })
 })

--- a/src/components/modals/ModalEditarPedido.tsx
+++ b/src/components/modals/ModalEditarPedido.tsx
@@ -5,12 +5,12 @@ import ModalConfirmacion, { type ModalConfirmacionConfig } from './ModalConfirma
 import { formatPrecio } from '../../utils/formatters';
 import { useZodValidation } from '../../hooks/useZodValidation';
 import { modalEditarPedidoSchema } from '../../lib/schemas';
-import { usePrecioMayorista } from '../../hooks/usePrecioMayorista';
+import { usePromocionPedido } from '../../hooks/usePromocionPedido';
 import { useRendiciones } from '../../hooks/supabase/useRendiciones';
 import { calcularNetoVenta, parsePrecio } from '../../utils/calculations';
 import type { PedidoDB, ProductoDB } from '../../types';
 
-/** Item del pedido para edición */
+/** Item del pedido para edición. Incluye fiscales opcionales que se pueblan al guardar. */
 export interface PedidoEditItem {
   productoId: string;
   nombre: string;
@@ -21,6 +21,10 @@ export interface PedidoEditItem {
   precioOverride?: boolean;
   esBonificacion?: boolean;
   promocionId?: string;
+  neto_unitario?: number;
+  iva_unitario?: number;
+  impuestos_internos_unitario?: number;
+  porcentaje_iva?: number;
 }
 
 /** Datos a guardar del pedido */
@@ -123,52 +127,64 @@ const ModalEditarPedido = memo(function ModalEditarPedido({
   // Verificar si el pedido está entregado (no editable)
   const pedidoEntregado = pedido?.estado === 'entregado';
 
-  // Inicializar items del pedido
+  // Inicializar items del pedido — sólo no-bonificaciones.
+  // Las bonificaciones se recalculan reactivamente a partir del estado no-bonif
+  // vía usePromocionPedido (ver abajo). Así, editar cantidades, agregar o
+  // eliminar productos recalcula las promos automáticamente.
   useEffect(() => {
     if (pedido?.items) {
-      const itemsFormateados = pedido.items.map(item => ({
-        productoId: item.producto_id,
-        nombre: item.producto?.nombre || 'Producto desconocido',
-        cantidad: item.cantidad,
-        precioUnitario: item.precio_unitario,
-        cantidadOriginal: item.cantidad,
-        esBonificacion: item.es_bonificacion || false,
-        promocionId: item.promocion_id || undefined,
-      }));
+      const itemsFormateados = pedido.items
+        .filter(item => !item.es_bonificacion)
+        .map(item => ({
+          productoId: item.producto_id,
+          nombre: item.producto?.nombre || 'Producto desconocido',
+          cantidad: item.cantidad,
+          precioUnitario: item.precio_unitario,
+          cantidadOriginal: item.cantidad,
+        }));
       setItems(itemsFormateados);
       setItemsOriginales(JSON.parse(JSON.stringify(itemsFormateados)));
     }
   }, [pedido]);
 
-  // Recalcular precios mayorista/minorista según cantidades actuales
-  // Usamos el precio base (retail) de cada producto para que la resolución sea correcta
+  // Armar input con precios base para la resolución. Para items con override
+  // manual usamos ese precio; para los demás, el precio base del producto
+  // (si el precio del item en DB es 0 por ser regalo legacy, igual funcionaría).
   const itemsConPrecioBase = useMemo(() => {
     return items.map(item => {
-      // Si tiene override, usar el precio manual; si no, usar precio base del producto
       if (item.precioOverride) {
         return {
           productoId: item.productoId,
           cantidad: item.cantidad,
           precioUnitario: item.precioUnitario,
-          precioOverride: true
+          precioOverride: true,
         };
       }
       const producto = productos.find(p => p.id === item.productoId);
       return {
         productoId: item.productoId,
         cantidad: item.cantidad,
-        precioUnitario: producto?.precio || item.precioUnitario
+        precioUnitario: producto?.precio || item.precioUnitario,
       };
     });
   }, [items, productos]);
 
-  const { itemsConPrecioMayorista, totalMayorista: totalCalculado, moqMap } = usePrecioMayorista(itemsConPrecioBase);
+  // Re-resolver promos + mayorista usando la FECHA DEL PEDIDO (no hoy).
+  // Así promos vigentes al momento de la creación siguen aplicando; y promos
+  // creadas DESPUÉS del pedido no se aplican retroactivamente.
+  const fechaReferenciaPromo = pedido?.fecha || undefined;
+  const {
+    itemsFinales,
+    totalFinal,
+    moqMap,
+    isLoading: promosLoading,
+  } = usePromocionPedido(itemsConPrecioBase, fechaReferenciaPromo);
 
-  // Mapa de precios resueltos para mostrar en cada item
+  // Mapa de precios resueltos para mostrar en cada item no-bonif
   const preciosResueltosMap = useMemo(() => {
     const map = new Map<string, number>();
-    for (const item of itemsConPrecioMayorista) {
-      // Si el item tiene override, usar su precio manual en vez del resuelto
+    for (const item of itemsFinales) {
+      if (item.esBonificacion) continue;
       const originalItem = items.find(i => i.productoId === item.productoId);
       if (originalItem?.precioOverride) {
         map.set(item.productoId, originalItem.precioUnitario);
@@ -177,9 +193,40 @@ const ModalEditarPedido = memo(function ModalEditarPedido({
       }
     }
     return map;
-  }, [itemsConPrecioMayorista, items]);
+  }, [itemsFinales, items]);
 
-  const total = itemsModificados ? totalCalculado : (pedido?.total || 0);
+  // Bonificaciones calculadas para mostrar como filas read-only
+  const bonificacionesCalculadas = useMemo(() => {
+    return itemsFinales
+      .filter(i => i.esBonificacion)
+      .map(bonif => {
+        const producto = productos.find(p => String(p.id) === String(bonif.productoId));
+        return {
+          productoId: String(bonif.productoId),
+          nombre: producto?.nombre || bonif.promoNombre || 'Regalo',
+          cantidad: bonif.cantidad,
+          promoNombre: bonif.promoNombre,
+          promocionId: bonif.promoId,
+        };
+      });
+  }, [itemsFinales, productos]);
+
+  // Detectar si las bonificaciones recalculadas difieren de las que estaban
+  // guardadas en el pedido. Si difieren, hay que marcar "modificado" para que
+  // el user vea el nuevo total y pueda guardar (arregla pedidos con promos
+  // obsoletas por edición previa sin recálculo).
+  const bonifDifierenDeDB = useMemo(() => {
+    if (promosLoading || !pedido?.items || items.length === 0) return false;
+    const originales = pedido.items.filter(i => i.es_bonificacion);
+    if (originales.length !== bonificacionesCalculadas.length) return true;
+    const mapOrig = new Map(originales.map(b => [String(b.producto_id), b.cantidad]));
+    for (const b of bonificacionesCalculadas) {
+      if (mapOrig.get(String(b.productoId)) !== b.cantidad) return true;
+    }
+    return false;
+  }, [promosLoading, pedido, items, bonificacionesCalculadas]);
+
+  const total = itemsModificados ? totalFinal : (pedido?.total || 0);
   const saldoPendiente = total - montoPagado;
 
   // Detectar si hubo cambios en items (cantidad, precio, agregados o eliminados)
@@ -197,8 +244,8 @@ const ModalEditarPedido = memo(function ModalEditarPedido({
       }) ||
       itemsOriginales.some(o => !items.find(i => i.productoId === o.productoId));
 
-    setItemsModificados(cambios);
-  }, [items, itemsOriginales]);
+    setItemsModificados(cambios || bonifDifierenDeDB);
+  }, [items, itemsOriginales, bonifDifierenDeDB]);
 
   // Productos disponibles para agregar
   const productosDisponibles = useMemo(() => {
@@ -379,20 +426,17 @@ const ModalEditarPedido = memo(function ModalEditarPedido({
     fechaEntregaCambio: boolean,
   ): Promise<void> => {
     try {
-      // Si hay cambios en items y es admin, guardar items con precios mayoristas resueltos y desglose fiscal
+      // Si hay cambios en items y es admin, guardar items con precios mayoristas
+      // resueltos, desglose fiscal y bonificaciones recalculadas por el hook.
       if (itemsModificados && isAdmin && onSaveItems) {
         const tipoFactura = pedido?.tipo_factura || 'ZZ';
-        const itemsParaGuardar = items.map(item => {
+
+        // Items no-bonif del estado → con precio resuelto + desglose fiscal
+        const itemsNoBonif: PedidoEditItem[] = items.map(item => {
           const precioFinal = preciosResueltosMap.get(item.productoId) ?? item.precioUnitario;
           const producto = productos.find(p => p.id === item.productoId);
           const pctIva = producto?.porcentaje_iva ?? 21;
           const pctImpInt = producto?.impuestos_internos ?? 0;
-          const esBonif = item.esBonificacion || false;
-
-          if (esBonif) {
-            return { ...item, precioUnitario: 0, neto_unitario: 0, iva_unitario: 0, impuestos_internos_unitario: 0, porcentaje_iva: 0 };
-          }
-
           const desglose = calcularNetoVenta(precioFinal, pctIva, pctImpInt, tipoFactura as 'ZZ' | 'FC');
           return {
             ...item,
@@ -403,7 +447,23 @@ const ModalEditarPedido = memo(function ModalEditarPedido({
             porcentaje_iva: pctIva,
           };
         });
-        await onSaveItems(itemsParaGuardar);
+
+        // Bonificaciones recalculadas → precio 0, promocionId del hook
+        const itemsBonif: PedidoEditItem[] = bonificacionesCalculadas.map(bonif => ({
+          productoId: bonif.productoId,
+          nombre: bonif.nombre,
+          cantidad: bonif.cantidad,
+          cantidadOriginal: 0,
+          precioUnitario: 0,
+          esBonificacion: true,
+          promocionId: bonif.promocionId,
+          neto_unitario: 0,
+          iva_unitario: 0,
+          impuestos_internos_unitario: 0,
+          porcentaje_iva: 0,
+        }));
+
+        await onSaveItems([...itemsNoBonif, ...itemsBonif]);
       }
       // Guardar el resto de los datos
       const fechaEntregaProgramadaCambio = isAdmin && !pedidoEntregado && fechaEntregaProgramada !== fechaEntregaProgramadaOriginal;
@@ -557,22 +617,6 @@ const ModalEditarPedido = memo(function ModalEditarPedido({
                   const cambio = item.cantidad - (item.cantidadOriginal || 0);
                   const precioResuelto = preciosResueltosMap.get(item.productoId) ?? item.precioUnitario;
 
-                  // Bonificacion items: show as read-only
-                  if (item.esBonificacion) {
-                    return (
-                      <div key={item.productoId} className="p-3 flex items-center justify-between bg-green-50 dark:bg-green-900/20">
-                        <div className="flex items-center gap-2 flex-1">
-                          <Gift className="w-4 h-4 text-green-600 flex-shrink-0" />
-                          <div>
-                            <p className="font-medium text-sm dark:text-white">{item.nombre}</p>
-                            <p className="text-xs text-green-600 font-medium">REGALO x{item.cantidad}</p>
-                          </div>
-                        </div>
-                        <span className="text-sm font-bold text-green-600">$0</span>
-                      </div>
-                    )
-                  }
-
                   return (
                     <div
                       key={item.productoId}
@@ -688,6 +732,26 @@ const ModalEditarPedido = memo(function ModalEditarPedido({
                   );
                 })
               )}
+
+              {/* Bonificaciones recalculadas (read-only) */}
+              {bonificacionesCalculadas.map(bonif => (
+                <div
+                  key={`bonif-${bonif.productoId}-${bonif.promocionId ?? 'anon'}`}
+                  className="p-3 flex items-center justify-between bg-green-50 dark:bg-green-900/20"
+                >
+                  <div className="flex items-center gap-2 flex-1">
+                    <Gift className="w-4 h-4 text-green-600 flex-shrink-0" />
+                    <div>
+                      <p className="font-medium text-sm dark:text-white">{bonif.nombre}</p>
+                      <p className="text-xs text-green-600 font-medium">
+                        REGALO x{bonif.cantidad}
+                        {bonif.promoNombre ? ` · ${bonif.promoNombre}` : ''}
+                      </p>
+                    </div>
+                  </div>
+                  <span className="text-sm font-bold text-green-600">$0</span>
+                </div>
+              ))}
             </div>
           </div>
         )}

--- a/src/hooks/queries/usePromocionesQuery.ts
+++ b/src/hooks/queries/usePromocionesQuery.ts
@@ -17,7 +17,8 @@ import type { PromoMap, PromocionActiva } from '../../utils/promociones'
 export const promocionesKeys = {
   all: (sucursalId: number | null) => ['promociones', sucursalId] as const,
   lists: (sucursalId: number | null) => [...promocionesKeys.all(sucursalId), 'list'] as const,
-  promoMap: (sucursalId: number | null) => [...promocionesKeys.all(sucursalId), 'promo_map'] as const,
+  promoMap: (sucursalId: number | null, fechaReferencia?: string) =>
+    [...promocionesKeys.all(sucursalId), 'promo_map', fechaReferencia ?? 'today'] as const,
 }
 
 // =============================================================================
@@ -54,18 +55,22 @@ export interface PromocionFormInput {
 // =============================================================================
 
 /**
- * Fetch denormalizado que construye el PromoMap para resolución O(1)
- * Solo trae promociones activas dentro de su rango de fechas.
+ * Fetch denormalizado que construye el PromoMap para resolución O(1).
+ *
+ * Por defecto evalúa vigencia al día de HOY. Si se pasa `fechaReferencia`
+ * (ej. la fecha del pedido que se está editando) se usa esa fecha para
+ * decidir si la promo estaba activa entonces. Imprescindible al re-resolver
+ * promos en la edición de pedidos existentes.
  */
-async function fetchPromoMap(): Promise<PromoMap> {
-  const hoy = fechaLocalISO()
+async function fetchPromoMap(fechaReferencia?: string): Promise<PromoMap> {
+  const fecha = fechaReferencia || fechaLocalISO()
 
   const { data: promos, error: errorPromos } = await supabase
     .from('promociones')
     .select('*')
     .eq('activo', true)
-    .lte('fecha_inicio', hoy)
-    .or(`fecha_fin.is.null,fecha_fin.gte.${hoy}`)
+    .lte('fecha_inicio', fecha)
+    .or(`fecha_fin.is.null,fecha_fin.gte.${fecha}`)
 
   if (errorPromos) {
     if (errorPromos.message.includes('does not exist')) return new Map()
@@ -354,13 +359,16 @@ async function ajustarStockPromo(input: AjustarStockInput): Promise<void> {
 
 /**
  * Hook para obtener el PromoMap denormalizado (para resolución de promos)
- * Cache 5 minutos (más corto que mayorista por ser temporal)
+ * Cache 5 minutos (más corto que mayorista por ser temporal).
+ *
+ * Si se pasa `fechaReferencia` (YYYY-MM-DD), se filtra por vigencia a esa fecha
+ * en vez de hoy — necesario al editar pedidos antiguos.
  */
-export function usePromoMapQuery() {
+export function usePromoMapQuery(fechaReferencia?: string) {
   const { currentSucursalId } = useSucursal()
   return useQuery({
-    queryKey: promocionesKeys.promoMap(currentSucursalId),
-    queryFn: fetchPromoMap,
+    queryKey: promocionesKeys.promoMap(currentSucursalId, fechaReferencia),
+    queryFn: () => fetchPromoMap(fechaReferencia),
     staleTime: 5 * 60 * 1000,
   })
 }

--- a/src/hooks/usePromocionPedido.ts
+++ b/src/hooks/usePromocionPedido.ts
@@ -60,9 +60,12 @@ interface UsePromocionPedidoReturn {
   violacionesMOQ: ViolacionMOQ[]
 }
 
-export function usePromocionPedido(items: ItemPedido[]): UsePromocionPedidoReturn {
+export function usePromocionPedido(
+  items: ItemPedido[],
+  fechaReferencia?: string,
+): UsePromocionPedidoReturn {
   const { data: pricingMap, isLoading: loadingPricing } = usePricingMapQuery()
-  const { data: promoMap, isLoading: loadingPromos } = usePromoMapQuery()
+  const { data: promoMap, isLoading: loadingPromos } = usePromoMapQuery(fechaReferencia)
 
   // 1. Resolver promociones
   const promoResolucion = useMemo((): PromoResolucion => {


### PR DESCRIPTION
## Summary

Arregla dos bugs de integridad de promociones reportados por una usuaria:

- **Total inflado al editar**: un pedido con regalos (2 MANAOS CITRUS 2250 + 2 MANAOS NARANJA 600 de regalo) pasaba de $55.800 a $99.400 al agregar un item de $8.400. Los items de bonificación del DB se re-cotizaban al precio base del producto (`producto.precio || 0` caía al precio base) y se sumaban al total.
- **Regalos huérfanos**: ni la edición ni la entrega con salvedad re-evaluaban las condiciones de la promo. Si se dejaba de cumplir el umbral (por salvedad total del originador o por edición del pedido), la línea de regalo seguía en el pedido, desalineada de stock y `usos_pendientes`.

## Cambios

### Cliente
- `usePromoMapQuery` acepta `fechaReferencia` y evalúa vigencia a esa fecha (no hoy) — imprescindible al re-resolver promos en pedidos antiguos.
- `usePromocionPedido` propaga `fechaReferencia`.
- `ModalEditarPedido` filtra las bonificaciones del estado editable; los regalos se recalculan reactivamente con `usePromocionPedido` usando `pedido.fecha`, se muestran como filas read-only debajo de los items y se persisten al guardar. Detecta cuando los regalos en DB difieren de los recalculados para forzar resync.
- `handleGuardarItemsEdicion` reenvía `neto_unitario`/`iva_unitario`/etc. al RPC (antes los dropeaba, dejando `total_neto = total` en facturas FC).

### Server
- **Nueva migration** `010_registrar_salvedad_resync_promos.sql`: `registrar_salvedad` ahora, tras reducir/eliminar el item afectado, recorre las bonificaciones del pedido, recomputa cuántas corresponden según las reglas de la promo, las elimina o reduce, devuelve stock cuando `regalo_mueve_stock=true` y decrementa `usos_pendientes`. Recalcula el total al final.

### Tests
- 2 regresiones nuevas cubren bug 2 (regalo no se recotiza al precio base, no se persiste con precio > 0).
- Suite completa: 578 tests pasando.

## Test plan

- [ ] **Aplicar la migration** `migrations/010_registrar_salvedad_resync_promos.sql` al proyecto Supabase (`hmuchlzmuqqxcldbzkgc`) antes del merge. Sin esto, el bug de salvedad sigue activo.
- [ ] Abrir el pedido de la usuaria (#1138 o equivalente) y verificar que el total mostrado ya no se infla al agregar un item.
- [ ] Si el pedido ya fue guardado con total inflado, re-abrir el modal, hacer cualquier cambio mínimo y guardar — el recálculo debería persistir el total correcto en DB.
- [ ] Crear un pedido nuevo con promo activa, marcar salvedad total del item originador y verificar que la línea de regalo desaparece y el total baja.
- [ ] Crear un pedido con promo 2+2, editar para reducir cantidad del originador por debajo del umbral y verificar que al guardar desaparece la bonificación.
- [ ] Crear un pedido sin llegar al umbral, editar para sumar items hasta cumplir la promo y verificar que la bonificación se agrega sola.
- [ ] Verificar en una promo con `regalo_mueve_stock=true` que al reducir/eliminar la bonificación se devuelve el stock correcto.

🤖 Generated with [Claude Code](https://claude.com/claude-code)