### PR TITLE
fix(multi-tenant): filtrar transportistas y pedidos por sucursal activa

### DIFF
--- a/src/components/vistas/VistaRendiciones.tsx
+++ b/src/components/vistas/VistaRendiciones.tsx
@@ -20,7 +20,8 @@ import {
   Receipt
 } from 'lucide-react'
 import { fechaLocalISO } from '../../utils/formatters'
-import { useRendiciones, useUsuarios } from '../../hooks/supabase'
+import { useRendiciones } from '../../hooks/supabase'
+import { useTransportistasQuery } from '../../hooks/queries'
 import { useNotification } from '../../contexts/NotificationContext'
 import { FORMAS_PAGO } from '../../constants/formasPago'
 import type { ResumenRendicionDiaria, PerfilDB, EstadoRendicion, RendicionGastoInput } from '../../types'
@@ -278,7 +279,7 @@ export default function VistaRendiciones(): React.ReactElement {
     confirmarRendicion,
     resolverRendicion
   } = useRendiciones()
-  const { transportistas } = useUsuarios()
+  const { data: transportistas = [] } = useTransportistasQuery()
 
   const hoy = fechaLocalISO()
   const haceUnaSemana = useMemo(() => {

--- a/src/hooks/queries/usePedidosQuery.ts
+++ b/src/hooks/queries/usePedidosQuery.ts
@@ -596,12 +596,17 @@ export function useEliminarPedidoMutation() {
 // Entregas Masivas
 // =========================================================================
 
-async function fetchPedidosNoEntregados(): Promise<PedidoDB[]> {
-  const { data, error } = await supabase
+async function fetchPedidosNoEntregados(sucursalId: number | null): Promise<PedidoDB[]> {
+  let query = supabase
     .from('pedidos')
     .select('*, cliente:clientes(id, nombre_fantasia, direccion)')
     .not('estado', 'in', '("entregado","cancelado")')
-    .order('created_at', { ascending: false })
+
+  if (sucursalId != null) {
+    query = query.eq('sucursal_id', sucursalId)
+  }
+
+  const { data, error } = await query.order('created_at', { ascending: false })
 
   if (error) throw error
 
@@ -639,8 +644,8 @@ export function usePedidosNoEntregadosQuery(enabled = false) {
   const { currentSucursalId } = useSucursal()
   return useQuery({
     queryKey: pedidosKeys.noEntregados(currentSucursalId),
-    queryFn: fetchPedidosNoEntregados,
-    enabled,
+    queryFn: () => fetchPedidosNoEntregados(currentSucursalId),
+    enabled: enabled && !!currentSucursalId,
     staleTime: 30 * 1000, // 30 segundos
   })
 }
@@ -732,13 +737,18 @@ export function useCancelarPedidoMutation() {
 // Pagos Masivos
 // =========================================================================
 
-async function fetchPedidosNoPagados(): Promise<PedidoDB[]> {
-  const { data, error } = await supabase
+async function fetchPedidosNoPagados(sucursalId: number | null): Promise<PedidoDB[]> {
+  let query = supabase
     .from('pedidos')
     .select('*, cliente:clientes(id, nombre_fantasia, direccion)')
     .neq('estado_pago', 'pagado')
     .neq('estado', 'cancelado')
-    .order('created_at', { ascending: false })
+
+  if (sucursalId != null) {
+    query = query.eq('sucursal_id', sucursalId)
+  }
+
+  const { data, error } = await query.order('created_at', { ascending: false })
 
   if (error) throw error
 
@@ -776,8 +786,8 @@ export function usePedidosNoPagadosQuery(enabled = false) {
   const { currentSucursalId } = useSucursal()
   return useQuery({
     queryKey: pedidosKeys.noPagados(currentSucursalId),
-    queryFn: fetchPedidosNoPagados,
-    enabled,
+    queryFn: () => fetchPedidosNoPagados(currentSucursalId),
+    enabled: enabled && !!currentSucursalId,
     staleTime: 30 * 1000,
   })
 }


### PR DESCRIPTION
## Contexto

En la sucursal 2 (Taco Pozo) aparecían transportistas de la sucursal 1 (Tucumán) — concretamente, **Marcos** se listaba en Rendiciones, Pagos Masivos, Entregas Masivas y Asignaciones Masivas de Taco Pozo. Causas (todas corregidas):

1. `VistaRendiciones` usaba el hook **deprecated** `useUsuarios()` que hace `SELECT * FROM perfiles` sin filtro de sucursal.
2. `fetchPedidosNoPagados` y `fetchPedidosNoEntregados` no pasaban `sucursalId` al fetcher; dependían únicamente de RLS vía el header `X-Sucursal-ID`, sin `.eq('sucursal_id', ...)` explícito como el resto de queries.
3. **Bug de datos**: Marcos estaba asignado en `usuario_sucursales` a **ambas** sucursales (1 como default + 2 extra).

## Summary

- `src/components/vistas/VistaRendiciones.tsx`: migrar `useUsuarios()` → `useTransportistasQuery()` (hace inner join con `usuario_sucursales` filtrado por `currentSucursalId`).
- `src/hooks/queries/usePedidosQuery.ts`: `fetchPedidosNoPagados` / `fetchPedidosNoEntregados` reciben `sucursalId` y filtran explícitamente (defensa en profundidad).
- Los consumidores (`ModalPagosMasivos`, `ModalEntregasMasivas`, `ModalAsignarTransportistaMasivo`) no cambian.

## Acciones ya ejecutadas en producción (ManaosApp)

- ✅ Borrada la fila duplicada de Marcos en `usuario_sucursales` para sucursal 2.
- ✅ Creado el transportista `transporte@crecertp.com` (rol `transportista`, asignado exclusivamente a Taco Pozo, email confirmado). Password: `crecertptp2026`.

## Test plan

- [x] `npm run typecheck` → OK
- [x] `npm test -- --run` → 578/578 passing
- [x] pre-commit hooks (lint + tests) pasaron
- [ ] Manual: loguearse en sucursal 2 (Taco Pozo) y verificar que Marcos **no** aparece en Rendiciones, Pagos Masivos, Entregas Masivas ni Asignaciones.
- [ ] Manual: loguearse en sucursal 1 (Tucumán) y verificar que Marcos **sí** aparece (no se rompió el flujo actual).
- [ ] Manual: login con `transporte@crecertp.com` / `crecertptp2026` → debe entrar como transportista en Taco Pozo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)