### PR TITLE
refactor(promociones): layout entera/fracción + histórico + soft-delete categorías

### DIFF
--- a/migrations/012_categorias_activa_y_promo_bundle_pedidos.sql
+++ b/migrations/012_categorias_activa_y_promo_bundle_pedidos.sql
@@ -1,0 +1,225 @@
+-- Migration 012: soft-delete de categorias + bundle de pedidos en auto-ajuste
+--
+-- A) categorias.activa: soft-delete. Una categoria desactivada desaparece de
+--    todos los selectores/filtros pero permanece en la BD para auditar
+--    productos historicamente asociados (el front asigna null a productos
+--    que referencian una categoria recien desactivada via trigger opcional,
+--    pero el scope de esta migracion es agregar la columna y el indice).
+--
+-- B) Auto-ajuste de promos fraccionales: cuando al cerrar un bloque se
+--    descuenta un fardo, la observacion de la merma incluye los pedidos
+--    que alimentaron el bloque (bundle) en lugar del unico pedido que
+--    cerro el bloque. Esto da trazabilidad completa sobre que pedidos
+--    contribuyeron a ese fardo descontado.
+
+-- ============================================================================
+-- A. categorias.activa
+-- ============================================================================
+
+ALTER TABLE public.categorias
+  ADD COLUMN IF NOT EXISTS activa BOOLEAN NOT NULL DEFAULT TRUE;
+
+CREATE INDEX IF NOT EXISTS idx_categorias_activa
+  ON public.categorias (sucursal_id, activa);
+
+-- ============================================================================
+-- B. Helper: pedido_ids bundle para una promo
+-- ============================================================================
+-- Devuelve un TEXT con los ultimos N pedido_ids (DESC) que tienen
+-- bonificacion de la promo, formateados como '#123, #122, #121, ...'.
+-- Incluye el pedido actual (que ya tiene INSERT en pedido_items al llamarla).
+
+CREATE OR REPLACE FUNCTION public.pedido_bundle_para_promo(
+  p_promocion_id bigint,
+  p_sucursal_id  bigint,
+  p_limit        int DEFAULT 10
+) RETURNS TEXT
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $$
+  SELECT string_agg('#' || t.pedido_id::text, ', ' ORDER BY t.pedido_id DESC)
+  FROM (
+    SELECT DISTINCT pi.pedido_id
+    FROM pedido_items pi
+    WHERE pi.promocion_id = p_promocion_id
+      AND pi.sucursal_id = p_sucursal_id
+      AND COALESCE(pi.es_bonificacion, false) = TRUE
+    ORDER BY pi.pedido_id DESC
+    LIMIT p_limit
+  ) t;
+$$;
+
+REVOKE ALL ON FUNCTION public.pedido_bundle_para_promo(bigint, bigint, int) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.pedido_bundle_para_promo(bigint, bigint, int) TO authenticated;
+
+-- ============================================================================
+-- C. crear_pedido_completo: usar bundle en observacion de merma auto-ajuste
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION public.crear_pedido_completo(
+  p_cliente_id bigint, p_total numeric, p_usuario_id uuid, p_items jsonb,
+  p_notas text DEFAULT NULL::text, p_forma_pago text DEFAULT 'efectivo'::text,
+  p_estado_pago text DEFAULT 'pendiente'::text, p_fecha date DEFAULT NULL::date,
+  p_tipo_factura text DEFAULT 'ZZ'::text, p_total_neto numeric DEFAULT NULL::numeric,
+  p_total_iva numeric DEFAULT 0, p_fecha_entrega_programada date DEFAULT NULL::date
+) RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $function$
+DECLARE
+  v_sucursal BIGINT := current_sucursal_id();
+  v_pedido_id INT; item JSONB; v_producto_id INT; v_cantidad INT;
+  v_precio_unitario DECIMAL; v_es_bonificacion BOOLEAN; v_promocion_id BIGINT;
+  v_neto_unitario DECIMAL; v_iva_unitario DECIMAL; v_imp_internos_unitario DECIMAL;
+  v_porcentaje_iva DECIMAL; v_stock_actual INT; v_producto_nombre TEXT;
+  errores TEXT[] := '{}'; v_user_role TEXT;
+  v_cantidades_totales JSONB := '{}'::JSONB; v_cant_acumulada INT;
+  v_regalo_mueve_stock BOOLEAN;
+  v_descripcion_regalo TEXT;
+  v_fecha_pedido DATE := COALESCE(p_fecha, (now() AT TIME ZONE 'America/Argentina/Buenos_Aires')::date);
+  v_fecha_entrega DATE := COALESCE(p_fecha_entrega_programada, (v_fecha_pedido + INTERVAL '1 day')::date);
+  v_promo RECORD;
+  v_usos_pendientes_actual INT;
+  v_bloques_completos INT;
+  v_ajustar_usos INT;
+  v_ajustar_stock INT;
+  v_stock_ajuste_anterior INT;
+  v_stock_ajuste_nuevo INT;
+  v_ajuste_producto_nombre TEXT;
+  v_merma_id BIGINT;
+  v_pedidos_bundle TEXT;
+  v_observacion TEXT;
+BEGIN
+  IF v_sucursal IS NULL THEN RETURN jsonb_build_object('success', false, 'errores', jsonb_build_array('No se pudo determinar la sucursal activa')); END IF;
+  IF p_usuario_id IS DISTINCT FROM auth.uid() THEN RETURN jsonb_build_object('success', false, 'errores', jsonb_build_array('ID de usuario no coincide con la sesion autenticada')); END IF;
+  SELECT rol INTO v_user_role FROM perfiles WHERE id = p_usuario_id;
+  IF v_user_role IS NULL OR v_user_role NOT IN ('admin', 'preventista') THEN RETURN jsonb_build_object('success', false, 'errores', jsonb_build_array('No tiene permisos para crear pedidos')); END IF;
+
+  FOR item IN SELECT * FROM jsonb_array_elements(p_items) LOOP
+    v_producto_id := (item->>'producto_id')::INT; v_cantidad := (item->>'cantidad')::INT;
+    v_es_bonificacion := COALESCE((item->>'es_bonificacion')::BOOLEAN, false);
+    IF v_cantidad IS NULL OR v_cantidad <= 0 THEN errores := array_append(errores, 'Cantidad invalida para producto ID ' || v_producto_id); CONTINUE; END IF;
+
+    IF v_es_bonificacion THEN
+      v_promocion_id := (item->>'promocion_id')::BIGINT;
+      IF v_promocion_id IS NOT NULL THEN
+        SELECT regalo_mueve_stock INTO v_regalo_mueve_stock FROM promociones WHERE id = v_promocion_id AND sucursal_id = v_sucursal;
+        IF COALESCE(v_regalo_mueve_stock, FALSE) THEN
+          v_cant_acumulada := COALESCE((v_cantidades_totales->>v_producto_id::TEXT)::INT, 0) + v_cantidad;
+          v_cantidades_totales := v_cantidades_totales || jsonb_build_object(v_producto_id::TEXT, v_cant_acumulada);
+        END IF;
+      END IF;
+    ELSE
+      v_cant_acumulada := COALESCE((v_cantidades_totales->>v_producto_id::TEXT)::INT, 0) + v_cantidad;
+      v_cantidades_totales := v_cantidades_totales || jsonb_build_object(v_producto_id::TEXT, v_cant_acumulada);
+    END IF;
+  END LOOP;
+
+  FOR v_producto_id IN SELECT (key)::INT FROM jsonb_each_text(v_cantidades_totales) LOOP
+    v_cantidad := (v_cantidades_totales->>v_producto_id::TEXT)::INT;
+    SELECT stock, nombre INTO v_stock_actual, v_producto_nombre FROM productos WHERE id = v_producto_id AND sucursal_id = v_sucursal FOR UPDATE;
+    IF v_stock_actual IS NULL THEN errores := array_append(errores, 'Producto ID ' || v_producto_id || ' no encontrado');
+    ELSIF v_stock_actual < v_cantidad THEN errores := array_append(errores, v_producto_nombre || ': stock insuficiente (disponible: ' || v_stock_actual || ', solicitado: ' || v_cantidad || ')'); END IF;
+  END LOOP;
+
+  IF array_length(errores, 1) > 0 THEN RETURN jsonb_build_object('success', false, 'errores', to_jsonb(errores)); END IF;
+
+  INSERT INTO pedidos (cliente_id, fecha, total, total_neto, total_iva, tipo_factura, estado, usuario_id, stock_descontado, notas, forma_pago, estado_pago, fecha_entrega_programada, sucursal_id)
+  VALUES (p_cliente_id, v_fecha_pedido, p_total, COALESCE(p_total_neto, p_total), COALESCE(p_total_iva, 0), COALESCE(p_tipo_factura, 'ZZ'), 'pendiente', p_usuario_id, true, p_notas, p_forma_pago, p_estado_pago, v_fecha_entrega, v_sucursal)
+  RETURNING id INTO v_pedido_id;
+
+  FOR item IN SELECT * FROM jsonb_array_elements(p_items) LOOP
+    v_producto_id := (item->>'producto_id')::INT; v_cantidad := (item->>'cantidad')::INT;
+    v_precio_unitario := (item->>'precio_unitario')::DECIMAL;
+    v_es_bonificacion := COALESCE((item->>'es_bonificacion')::BOOLEAN, false);
+    v_promocion_id := (item->>'promocion_id')::BIGINT;
+    v_neto_unitario := (item->>'neto_unitario')::DECIMAL;
+    v_iva_unitario := COALESCE((item->>'iva_unitario')::DECIMAL, 0);
+    v_imp_internos_unitario := COALESCE((item->>'impuestos_internos_unitario')::DECIMAL, 0);
+    v_porcentaje_iva := COALESCE((item->>'porcentaje_iva')::DECIMAL, 0);
+
+    v_descripcion_regalo := NULL;
+    IF v_es_bonificacion AND v_promocion_id IS NOT NULL THEN
+      SELECT descripcion_regalo INTO v_descripcion_regalo FROM promociones WHERE id = v_promocion_id AND sucursal_id = v_sucursal;
+    END IF;
+
+    INSERT INTO pedido_items (
+      pedido_id, producto_id, cantidad, precio_unitario, subtotal,
+      es_bonificacion, promocion_id,
+      neto_unitario, iva_unitario, impuestos_internos_unitario, porcentaje_iva,
+      sucursal_id, descripcion_regalo
+    ) VALUES (
+      v_pedido_id, v_producto_id, v_cantidad, v_precio_unitario, v_cantidad * v_precio_unitario,
+      v_es_bonificacion, v_promocion_id,
+      v_neto_unitario, v_iva_unitario, v_imp_internos_unitario, v_porcentaje_iva,
+      v_sucursal, v_descripcion_regalo
+    );
+
+    IF NOT v_es_bonificacion THEN
+      UPDATE productos SET stock = stock - v_cantidad WHERE id = v_producto_id AND sucursal_id = v_sucursal;
+    ELSIF v_promocion_id IS NOT NULL THEN
+      SELECT regalo_mueve_stock INTO v_regalo_mueve_stock FROM promociones WHERE id = v_promocion_id AND sucursal_id = v_sucursal;
+      IF COALESCE(v_regalo_mueve_stock, FALSE) THEN
+        UPDATE productos SET stock = stock - v_cantidad WHERE id = v_producto_id AND sucursal_id = v_sucursal;
+      END IF;
+    END IF;
+
+    IF v_es_bonificacion AND v_promocion_id IS NOT NULL THEN
+      UPDATE promociones SET usos_pendientes = usos_pendientes + v_cantidad WHERE id = v_promocion_id AND sucursal_id = v_sucursal;
+
+      SELECT id, nombre, ajuste_automatico, ajuste_producto_id, unidades_por_bloque,
+             stock_por_bloque, usos_pendientes
+      INTO v_promo
+      FROM promociones WHERE id = v_promocion_id AND sucursal_id = v_sucursal FOR UPDATE;
+
+      IF v_promo.ajuste_automatico AND v_promo.ajuste_producto_id IS NOT NULL
+         AND COALESCE(v_promo.unidades_por_bloque, 0) > 0 AND COALESCE(v_promo.stock_por_bloque, 0) > 0 THEN
+        v_usos_pendientes_actual := v_promo.usos_pendientes;
+        v_bloques_completos := v_usos_pendientes_actual / v_promo.unidades_por_bloque;
+        IF v_bloques_completos > 0 THEN
+          v_ajustar_usos := v_bloques_completos * v_promo.unidades_por_bloque;
+          v_ajustar_stock := v_bloques_completos * v_promo.stock_por_bloque;
+
+          SELECT stock, nombre INTO v_stock_ajuste_anterior, v_ajuste_producto_nombre
+          FROM productos WHERE id = v_promo.ajuste_producto_id AND sucursal_id = v_sucursal FOR UPDATE;
+
+          IF v_stock_ajuste_anterior IS NULL THEN
+            RAISE EXCEPTION 'Auto-ajuste: producto destino no encontrado (promo %)', v_promocion_id;
+          END IF;
+          IF v_stock_ajuste_anterior < v_ajustar_stock THEN
+            RAISE EXCEPTION 'Auto-ajuste: stock insuficiente en % (disponible: %, requerido: %)',
+              v_ajuste_producto_nombre, v_stock_ajuste_anterior, v_ajustar_stock;
+          END IF;
+
+          v_stock_ajuste_nuevo := v_stock_ajuste_anterior - v_ajustar_stock;
+
+          -- Bundle de pedidos que alimentaron el bloque que cerro
+          v_pedidos_bundle := public.pedido_bundle_para_promo(v_promocion_id, v_sucursal, 20);
+          v_observacion := 'Auto-ajuste (Promo: ' || v_promo.nombre
+                           || ', Pedidos: ' || COALESCE(v_pedidos_bundle, '#' || v_pedido_id) || ')';
+
+          INSERT INTO mermas_stock (producto_id, cantidad, motivo, observaciones, stock_anterior, stock_nuevo, usuario_id, sucursal_id)
+          VALUES (v_promo.ajuste_producto_id, v_ajustar_stock, 'promociones', v_observacion,
+            v_stock_ajuste_anterior, v_stock_ajuste_nuevo, p_usuario_id, v_sucursal)
+          RETURNING id INTO v_merma_id;
+
+          UPDATE productos SET stock = v_stock_ajuste_nuevo, updated_at = NOW()
+          WHERE id = v_promo.ajuste_producto_id AND sucursal_id = v_sucursal;
+
+          INSERT INTO promo_ajustes (promocion_id, usos_ajustados, unidades_ajustadas, producto_id, merma_id, usuario_id, observaciones, sucursal_id)
+          VALUES (v_promocion_id, v_ajustar_usos, v_ajustar_stock, v_promo.ajuste_producto_id,
+            v_merma_id, p_usuario_id, v_observacion, v_sucursal);
+
+          UPDATE promociones SET usos_pendientes = GREATEST(usos_pendientes - v_ajustar_usos, 0)
+          WHERE id = v_promocion_id AND sucursal_id = v_sucursal;
+        END IF;
+      END IF;
+    END IF;
+  END LOOP;
+
+  RETURN jsonb_build_object('success', true, 'pedido_id', v_pedido_id);
+END;
+$function$;

--- a/src/components/containers/PromocionesContainer.tsx
+++ b/src/components/containers/PromocionesContainer.tsx
@@ -3,7 +3,7 @@
  *
  * Container que gestiona promociones usando TanStack Query.
  */
-import React, { lazy, Suspense, useState, useCallback } from 'react'
+import React, { lazy, Suspense, useMemo, useState, useCallback } from 'react'
 import { Loader2 } from 'lucide-react'
 import {
   usePromocionesListQuery,
@@ -12,11 +12,10 @@ import {
   useActualizarPromocionMutation,
   useEliminarPromocionMutation,
   useTogglePromocionActivaMutation,
-  useAjustarStockPromoMutation,
+  usePromoUnidadesEntregadasQuery,
 } from '../../hooks/queries'
 import type { PromocionConDetalles, PromocionFormInput } from '../../hooks/queries/usePromocionesQuery'
 import { useNotification } from '../../contexts/NotificationContext'
-import { useAuthData } from '../../contexts/AuthDataContext'
 
 const VistaPromociones = lazy(() => import('../vistas/VistaPromociones'))
 const ModalPromocion = lazy(() => import('../modals/ModalPromocion'))
@@ -40,18 +39,23 @@ interface ConfirmConfig {
 
 export default function PromocionesContainer(): React.ReactElement {
   const notify = useNotification()
-  const { user } = useAuthData()
 
   // Queries
   const { data: promociones = [], isLoading } = usePromocionesListQuery()
   const { data: productos = [] } = useProductosQuery()
+  const { data: unidadesEntregadas } = usePromoUnidadesEntregadasQuery()
+
+  const productoNombres = useMemo(() => {
+    const m = new Map<string, string>()
+    productos.forEach(p => m.set(String(p.id), p.nombre))
+    return m
+  }, [productos])
 
   // Mutations
   const crearPromocion = useCrearPromocionMutation()
   const actualizarPromocion = useActualizarPromocionMutation()
   const eliminarPromocion = useEliminarPromocionMutation()
   const toggleActivo = useTogglePromocionActivaMutation()
-  const ajustarStock = useAjustarStockPromoMutation()
 
   // Estado modal
   const [modalOpen, setModalOpen] = useState(false)
@@ -95,26 +99,6 @@ export default function PromocionesContainer(): React.ReactElement {
     }
   }, [toggleActivo, notify])
 
-  const handleAjustarStock = useCallback(async (
-    promo: PromocionConDetalles,
-    payload: { productoRegaloId: string; cantidadStock: number; usosAjustados: number; observaciones: string },
-  ) => {
-    try {
-      await ajustarStock.mutateAsync({
-        promocionId: promo.id,
-        productoRegaloId: payload.productoRegaloId,
-        cantidadStock: payload.cantidadStock,
-        usosAjustados: payload.usosAjustados,
-        usuarioId: user?.id ?? '',
-        observaciones: payload.observaciones || undefined,
-      })
-      notify.success(`Stock ajustado: -${payload.cantidadStock} unidades (${payload.usosAjustados} usos resueltos)`)
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : 'Error al ajustar stock'
-      notify.error(msg)
-    }
-  }, [ajustarStock, notify, user])
-
   const handleGuardarPromocion = useCallback(async (data: PromocionFormInput) => {
     try {
       if (promoEditando) {
@@ -139,13 +123,13 @@ export default function PromocionesContainer(): React.ReactElement {
       <Suspense fallback={<LoadingState />}>
         <VistaPromociones
           promociones={promociones}
-          productos={productos}
+          productoNombres={productoNombres}
+          unidadesEntregadas={unidadesEntregadas}
           loading={isLoading}
           onNuevaPromocion={handleNuevaPromocion}
           onEditarPromocion={handleEditarPromocion}
           onEliminarPromocion={handleEliminarPromocion}
           onToggleActivo={handleToggleActivo}
-          onAjustarStock={handleAjustarStock}
         />
       </Suspense>
 

--- a/src/components/modals/ModalCategorias.tsx
+++ b/src/components/modals/ModalCategorias.tsx
@@ -7,13 +7,14 @@
  * normalizarlas). Renombrar/eliminar actualizan en bloque `productos.categoria`.
  */
 import { memo, useMemo, useState } from 'react';
-import { Loader2, Plus, Pencil, Trash2, Check, X, Tag, AlertCircle } from 'lucide-react';
+import { Loader2, Plus, Pencil, Trash2, Check, X, Tag, AlertCircle, ToggleLeft, ToggleRight } from 'lucide-react';
 import ModalBase from './ModalBase';
 import {
   useCategoriasQuery,
   useCrearCategoriaMutation,
   useRenombrarCategoriaMutation,
   useEliminarCategoriaMutation,
+  useToggleCategoriaActivaMutation,
 } from '../../hooks/queries';
 import type { CategoriaDB } from '../../hooks/queries';
 import type { ProductoDB } from '../../types';
@@ -31,6 +32,7 @@ interface CategoriaEntry {
   nombre: string;
   productCount: number;
   source: 'tabla' | 'derivada' | 'ambas';
+  activa: boolean;
 }
 
 const ModalCategorias = memo(function ModalCategorias({ productos, onClose }: ModalCategoriasProps) {
@@ -38,6 +40,7 @@ const ModalCategorias = memo(function ModalCategorias({ productos, onClose }: Mo
   const crearMut = useCrearCategoriaMutation();
   const renameMut = useRenombrarCategoriaMutation();
   const deleteMut = useEliminarCategoriaMutation();
+  const toggleMut = useToggleCategoriaActivaMutation();
 
   const [nuevoNombre, setNuevoNombre] = useState('');
   const [error, setError] = useState('');
@@ -60,11 +63,13 @@ const ModalCategorias = memo(function ModalCategorias({ productos, onClose }: Mo
     names.forEach(nombre => {
       const enTabla = tablaMap.has(nombre);
       const enProductos = counts.has(nombre);
+      const cat = enTabla ? tablaMap.get(nombre)! : null;
       combined.push({
-        id: enTabla ? tablaMap.get(nombre)!.id : null,
+        id: cat ? cat.id : null,
         nombre,
         productCount: counts.get(nombre) || 0,
         source: enTabla && enProductos ? 'ambas' : enTabla ? 'tabla' : 'derivada',
+        activa: cat ? cat.activa !== false : true,
       });
     });
     return combined.sort((a, b) => a.nombre.localeCompare(b.nombre));
@@ -138,7 +143,17 @@ const ModalCategorias = memo(function ModalCategorias({ productos, onClose }: Mo
     }
   };
 
-  const working = crearMut.isPending || renameMut.isPending || deleteMut.isPending;
+  const handleToggleActiva = async (entry: CategoriaEntry) => {
+    if (!entry.id) return;
+    setError('');
+    try {
+      await toggleMut.mutateAsync({ id: entry.id, activa: !entry.activa, nombre: entry.nombre });
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Error al cambiar estado');
+    }
+  };
+
+  const working = crearMut.isPending || renameMut.isPending || deleteMut.isPending || toggleMut.isPending;
 
   return (
     <ModalBase title="Gestionar categorías" onClose={onClose} maxWidth="max-w-2xl">
@@ -222,11 +237,16 @@ const ModalCategorias = memo(function ModalCategorias({ productos, onClose }: Mo
                         disabled={renameMut.isPending}
                       />
                     ) : (
-                      <div className="flex-1 min-w-0 flex items-center gap-2 flex-wrap">
+                      <div className={`flex-1 min-w-0 flex items-center gap-2 flex-wrap ${!entry.activa ? 'opacity-60' : ''}`}>
                         <span className="font-medium dark:text-white truncate">{entry.nombre}</span>
                         <span className="text-xs px-2 py-0.5 bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-300 rounded-full">
                           {entry.productCount} {entry.productCount === 1 ? 'producto' : 'productos'}
                         </span>
+                        {!entry.activa && (
+                          <span className="text-xs px-2 py-0.5 bg-gray-200 dark:bg-gray-600 text-gray-600 dark:text-gray-300 rounded-full font-medium">
+                            inactiva
+                          </span>
+                        )}
                         {entry.source === 'derivada' && (
                           <span
                             className="text-xs px-2 py-0.5 bg-amber-100 dark:bg-amber-900/30 text-amber-700 dark:text-amber-300 rounded-full"
@@ -273,6 +293,21 @@ const ModalCategorias = memo(function ModalCategorias({ productos, onClose }: Mo
                         >
                           <Pencil className="w-4 h-4" />
                         </button>
+                        {entry.id && (
+                          <button
+                            type="button"
+                            onClick={() => handleToggleActiva(entry)}
+                            disabled={working}
+                            className="p-1.5 hover:bg-gray-100 dark:hover:bg-gray-700 rounded disabled:opacity-50"
+                            title={entry.activa ? `Desactivar ${entry.nombre}` : `Activar ${entry.nombre}`}
+                            aria-label={entry.activa ? `Desactivar ${entry.nombre}` : `Activar ${entry.nombre}`}
+                          >
+                            {entry.activa
+                              ? <ToggleRight className="w-5 h-5 text-green-600" />
+                              : <ToggleLeft className="w-5 h-5 text-gray-400" />
+                            }
+                          </button>
+                        )}
                         <button
                           type="button"
                           onClick={() => setConfirmDelete(entry)}

--- a/src/components/modals/ModalPromocion.tsx
+++ b/src/components/modals/ModalPromocion.tsx
@@ -52,9 +52,6 @@ export default function ModalPromocion({
   const [prioridad, setPrioridad] = useState<string>(
     promocion?.prioridad != null ? String(promocion.prioridad) : '0'
   )
-  const [regaloMueveStock, setRegaloMueveStock] = useState<boolean>(
-    promocion?.regalo_mueve_stock ?? false
-  )
   const [modoExclusion, setModoExclusion] = useState<'acumulable' | 'excluyente'>(
     (promocion?.modo_exclusion as 'acumulable' | 'excluyente') ?? 'acumulable'
   )
@@ -147,11 +144,14 @@ export default function ModalPromocion({
       return
     }
 
-    // Derivados segun tipo de regalo. Fraccion fuerza ajuste automatico y
-    // regalo NO mueve stock directamente (el auto-ajuste descuenta bloques).
+    // Derivados segun tipo de regalo.
+    // - Fraccion: ajuste_automatico=true (descuenta fardo al cerrar bloque),
+    //   regalo_mueve_stock=false (no descuenta al entregar la botella suelta).
+    // - Unidad entera: ajuste_automatico=false, regalo_mueve_stock=true
+    //   (el stock se descuenta al entregar cada unidad completa).
     const esFraccion = tipoRegalo === 'fraccion'
-    const finalAjusteAutomatico = esFraccion ? true : false
-    const finalRegaloMueveStock = esFraccion ? false : regaloMueveStock
+    const finalAjusteAutomatico = esFraccion
+    const finalRegaloMueveStock = !esFraccion
 
     if (esFraccion) {
       if (!descripcionRegalo.trim()) {
@@ -375,35 +375,6 @@ export default function ModalPromocion({
             </div>
           </div>
 
-          {/* Mueve stock (solo para unidad entera) */}
-          {tipoRegalo === 'unidad_entera' && (
-            <div className="flex items-center justify-between gap-3 p-3 bg-amber-50 dark:bg-amber-900/20 rounded-lg border border-amber-200 dark:border-amber-800">
-              <div className="flex-1 min-w-0">
-                <p className="text-sm font-medium text-amber-800 dark:text-amber-200">
-                  El regalo descuenta stock automáticamente
-                </p>
-                <p className="text-xs text-amber-700 dark:text-amber-300 mt-1">
-                  Si se regala una unidad que existe como producto en el stock, dejalo encendido. Apagalo si lo ajustás manualmente después.
-                </p>
-              </div>
-              <button
-                type="button"
-                role="switch"
-                aria-checked={regaloMueveStock}
-                onClick={() => setRegaloMueveStock(v => !v)}
-                className={`relative inline-flex h-6 w-11 flex-shrink-0 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-amber-500 focus:ring-offset-2 ${
-                  regaloMueveStock ? 'bg-amber-600' : 'bg-gray-300 dark:bg-gray-600'
-                }`}
-              >
-                <span
-                  className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform ${
-                    regaloMueveStock ? 'translate-x-6' : 'translate-x-1'
-                  }`}
-                />
-              </button>
-            </div>
-          )}
-
           {/* Descripción manual del regalo (solo fracción) */}
           {tipoRegalo === 'fraccion' && (
             <div>
@@ -423,15 +394,15 @@ export default function ModalPromocion({
             </div>
           )}
 
-          {/* Ajuste automatico por bloques (solo fracción — siempre visible/requerido) */}
+          {/* Regla de bonificación — layout fracción (incluye producto contenedor, bloque y cantidades) */}
           {tipoRegalo === 'fraccion' && (
             <div className="p-3 bg-blue-50 dark:bg-blue-900/20 rounded-lg border border-blue-200 dark:border-blue-800 space-y-3">
               <div>
                 <p className="text-sm font-medium text-blue-800 dark:text-blue-200">
-                  Ajuste automático de stock por bloques
+                  Regla de bonificación
                 </p>
                 <p className="text-xs text-blue-700 dark:text-blue-300 mt-1">
-                  Cuando se acumulan suficientes regalos como para formar un bloque exacto (ej: 12 botellas = 1 fardo), el sistema descuenta el stock y registra la merma. Las unidades sueltas quedan pendientes hasta completar el próximo bloque.
+                  Al acumularse las unidades sueltas hasta formar un bloque exacto (ej: 12 botellas = 1 fardo), el sistema descuenta el stock del producto contenedor y registra la merma automáticamente.
                 </p>
               </div>
 
@@ -529,54 +500,93 @@ export default function ModalPromocion({
                     </div>
                   </div>
 
-                  {unidadesPorBloque && stockPorBloque && parseInt(unidadesPorBloque) > 0 && parseInt(stockPorBloque) > 0 && (
+                  {/* Cantidad compra y cantidad gratis (dentro del bloque fracción) */}
+                  <div className="grid grid-cols-2 gap-3 pt-2 border-t border-blue-200 dark:border-blue-800">
+                    <div>
+                      <label className="block text-xs font-medium text-blue-700 dark:text-blue-300 mb-1">
+                        Cantidad compra
+                      </label>
+                      <input
+                        type="number"
+                        inputMode="numeric"
+                        step="1"
+                        min="1"
+                        value={cantidadCompra}
+                        onChange={e => setCantidadCompra(e.target.value)}
+                        placeholder="Ej: 2"
+                        className="w-full px-3 py-2 border rounded-lg dark:bg-gray-700 dark:border-gray-600 dark:text-white focus:ring-2 focus:ring-blue-500 focus:outline-none text-sm"
+                      />
+                    </div>
+                    <div>
+                      <label className="block text-xs font-medium text-blue-700 dark:text-blue-300 mb-1">
+                        Cantidad gratis
+                      </label>
+                      <input
+                        type="number"
+                        inputMode="numeric"
+                        step="1"
+                        min="1"
+                        value={cantidadBonificacion}
+                        onChange={e => setCantidadBonificacion(e.target.value)}
+                        placeholder="Ej: 1"
+                        className="w-full px-3 py-2 border rounded-lg dark:bg-gray-700 dark:border-gray-600 dark:text-white focus:ring-2 focus:ring-blue-500 focus:outline-none text-sm"
+                      />
+                    </div>
+                  </div>
+
+                  {cantidadCompra && cantidadBonificacion && unidadesPorBloque && stockPorBloque
+                    && parseInt(cantidadCompra) > 0 && parseInt(cantidadBonificacion) > 0
+                    && parseInt(unidadesPorBloque) > 0 && parseInt(stockPorBloque) > 0 && (
                     <p className="text-xs text-blue-700 dark:text-blue-300 bg-blue-100 dark:bg-blue-900/40 rounded px-2 py-1.5">
-                      Resumen: cada {unidadesPorBloque} unidades bonificadas descuentan {stockPorBloque} del stock del producto elegido y generan una merma.
+                      Resumen: cada {cantidadCompra} unidades compradas → {cantidadBonificacion} gratis ({descripcionRegalo.trim() || 'unidad fraccionada'}). Cada {unidadesPorBloque} unidades regaladas descuentan {stockPorBloque} del stock del producto contenedor.
                     </p>
                   )}
               </div>
             </div>
           )}
 
-          {/* Reglas de bonificacion */}
-          <div className="p-3 bg-purple-50 dark:bg-purple-900/20 rounded-lg border border-purple-200 dark:border-purple-800">
-            <p className="text-sm font-medium text-purple-700 dark:text-purple-300 mb-2">Regla de bonificacion</p>
-            <div className="grid grid-cols-2 gap-3">
-              <div>
-                <label className="block text-xs text-purple-600 dark:text-purple-400 mb-1">Cantidad compra</label>
-                <input
-                  type="number"
-                  inputMode="numeric"
-                  step="1"
-                  min="1"
-                  value={cantidadCompra}
-                  onChange={e => setCantidadCompra(e.target.value)}
-                  placeholder="Ej: 12"
-                  className="w-full px-3 py-2 border rounded-lg dark:bg-gray-700 dark:border-gray-600 dark:text-white focus:ring-2 focus:ring-purple-500 focus:outline-none text-sm"
-                />
+          {/* Regla de bonificacion — layout unidad entera */}
+          {tipoRegalo === 'unidad_entera' && (
+            <div className="p-3 bg-purple-50 dark:bg-purple-900/20 rounded-lg border border-purple-200 dark:border-purple-800">
+              <p className="text-sm font-medium text-purple-700 dark:text-purple-300 mb-2">Regla de bonificación</p>
+              <div className="grid grid-cols-2 gap-3">
+                <div>
+                  <label className="block text-xs text-purple-600 dark:text-purple-400 mb-1">Cantidad compra</label>
+                  <input
+                    type="number"
+                    inputMode="numeric"
+                    step="1"
+                    min="1"
+                    value={cantidadCompra}
+                    onChange={e => setCantidadCompra(e.target.value)}
+                    placeholder="Ej: 12"
+                    className="w-full px-3 py-2 border rounded-lg dark:bg-gray-700 dark:border-gray-600 dark:text-white focus:ring-2 focus:ring-purple-500 focus:outline-none text-sm"
+                  />
+                </div>
+                <div>
+                  <label className="block text-xs text-purple-600 dark:text-purple-400 mb-1">Cantidad gratis</label>
+                  <input
+                    type="number"
+                    inputMode="numeric"
+                    step="1"
+                    min="1"
+                    value={cantidadBonificacion}
+                    onChange={e => setCantidadBonificacion(e.target.value)}
+                    placeholder="Ej: 2"
+                    className="w-full px-3 py-2 border rounded-lg dark:bg-gray-700 dark:border-gray-600 dark:text-white focus:ring-2 focus:ring-purple-500 focus:outline-none text-sm"
+                  />
+                </div>
               </div>
-              <div>
-                <label className="block text-xs text-purple-600 dark:text-purple-400 mb-1">Cantidad gratis</label>
-                <input
-                  type="number"
-                  inputMode="numeric"
-                  step="1"
-                  min="1"
-                  value={cantidadBonificacion}
-                  onChange={e => setCantidadBonificacion(e.target.value)}
-                  placeholder="Ej: 2"
-                  className="w-full px-3 py-2 border rounded-lg dark:bg-gray-700 dark:border-gray-600 dark:text-white focus:ring-2 focus:ring-purple-500 focus:outline-none text-sm"
-                />
-              </div>
+              {cantidadCompra && cantidadBonificacion && parseInt(cantidadCompra) > 0 && parseInt(cantidadBonificacion) > 0 && (
+                <p className="text-xs text-purple-600 mt-2">
+                  Cada {cantidadCompra} unidades compradas → {cantidadBonificacion} gratis (acumulable)
+                </p>
+              )}
             </div>
-            {cantidadCompra && cantidadBonificacion && parseInt(cantidadCompra) > 0 && parseInt(cantidadBonificacion) > 0 && (
-              <p className="text-xs text-purple-600 mt-2">
-                Cada {cantidadCompra} unidades compradas → {cantidadBonificacion} gratis (acumulable)
-              </p>
-            )}
-          </div>
+          )}
 
-          {/* Producto regalo */}
+          {/* Producto regalo (solo unidad entera) */}
+          {tipoRegalo === 'unidad_entera' && (
           <div>
             <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
               Producto de regalo
@@ -628,6 +638,7 @@ export default function ModalPromocion({
               </div>
             )}
           </div>
+          )}
 
           {/* Selector de productos (que activan la promo) */}
           <div>

--- a/src/components/vistas/VistaPromociones.tsx
+++ b/src/components/vistas/VistaPromociones.tsx
@@ -2,96 +2,44 @@
  * VistaPromociones
  *
  * Vista admin para gestionar promociones (bonificacion).
- * Muestra lista de promos con productos, reglas, contador de usos y ajuste de stock.
+ * Todas las promos descuentan stock automaticamente (unidad entera en
+ * cada venta o fraccion al cerrar bloque), por eso no hay ajuste manual.
  */
-import React, { useState } from 'react'
-import { Plus, Edit2, Trash2, ToggleLeft, ToggleRight, Package, Gift, AlertTriangle, Check, Layers, Ban, Zap } from 'lucide-react'
+import React, { useMemo, useState } from 'react'
+import { Plus, Edit2, Trash2, ToggleLeft, ToggleRight, Package, Gift, Layers, Ban, Zap, History, Filter } from 'lucide-react'
 import { fechaLocalISO } from '../../utils/formatters'
-import type { ProductoDB } from '../../types'
 import type { PromocionConDetalles } from '../../hooks/queries/usePromocionesQuery'
 
-export interface AjustePayload {
-  productoRegaloId: string
-  cantidadStock: number
-  usosAjustados: number
-  observaciones: string
-}
+type FiltroEstado = 'vigentes' | 'todas' | 'inactivas'
 
 export interface VistaPromocionesProps {
   promociones: PromocionConDetalles[]
-  productos: ProductoDB[]
   loading: boolean
   onNuevaPromocion: () => void
   onEditarPromocion: (promo: PromocionConDetalles) => void
   onEliminarPromocion: (id: string) => void
   onToggleActivo: (promo: PromocionConDetalles) => void
-  onAjustarStock: (promo: PromocionConDetalles, payload: AjustePayload) => void
+  /** Map producto_id -> nombre (para render de chips de productos asignados) */
+  productoNombres: Map<string, string>
+  /** Map promo_id -> total unidades regaladas historicas (suma de pedido_items.cantidad con es_bonificacion=true) */
+  unidadesEntregadas?: Map<string, number>
 }
 
 export default function VistaPromociones({
   promociones,
-  productos,
   loading,
   onNuevaPromocion,
   onEditarPromocion,
   onEliminarPromocion,
   onToggleActivo,
-  onAjustarStock,
+  productoNombres,
+  unidadesEntregadas,
 }: VistaPromocionesProps): React.ReactElement {
-  const [ajustandoId, setAjustandoId] = useState<string | null>(null)
-  const [observaciones, setObservaciones] = useState('')
-  const [ajusteProductoId, setAjusteProductoId] = useState<string>('')
-  const [ajusteCantidadStock, setAjusteCantidadStock] = useState<string>('')
-  const [ajusteUsos, setAjusteUsos] = useState<string>('')
-  const [ajusteError, setAjusteError] = useState<string | null>(null)
-
-  const iniciarAjuste = (promo: PromocionConDetalles) => {
-    setAjustandoId(promo.id)
-    setAjusteProductoId(promo.producto_regalo_id ? String(promo.producto_regalo_id) : '')
-    setAjusteCantidadStock('')
-    setAjusteUsos(String(promo.usos_pendientes))
-    setObservaciones('')
-    setAjusteError(null)
-  }
-
-  const cancelarAjuste = () => {
-    setAjustandoId(null)
-    setObservaciones('')
-    setAjusteProductoId('')
-    setAjusteCantidadStock('')
-    setAjusteUsos('')
-    setAjusteError(null)
-  }
-
-  const confirmarAjuste = (promo: PromocionConDetalles) => {
-    setAjusteError(null)
-    const pid = ajusteProductoId.trim()
-    if (!pid) {
-      setAjusteError('Elegi el producto al que descontar stock')
-      return
-    }
-    const stock = parseInt(ajusteCantidadStock)
-    if (!stock || stock <= 0) {
-      setAjusteError('Cantidad de stock a descontar debe ser mayor a 0')
-      return
-    }
-    const usos = parseInt(ajusteUsos)
-    if (!usos || usos <= 0 || usos > promo.usos_pendientes) {
-      setAjusteError(`Usos a resolver debe estar entre 1 y ${promo.usos_pendientes}`)
-      return
-    }
-    onAjustarStock(promo, {
-      productoRegaloId: pid,
-      cantidadStock: stock,
-      usosAjustados: usos,
-      observaciones,
-    })
-    cancelarAjuste()
-  }
+  const [filtro, setFiltro] = useState<FiltroEstado>('vigentes')
+  const [mostrarHistorico, setMostrarHistorico] = useState(false)
 
   const getProductoNombre = (productoId: string): string => {
-    const prod = productos.find(p => String(p.id) === String(productoId))
-    return prod?.nombre || `Producto #${productoId}`
+    return productoNombres.get(String(productoId)) || `Producto #${productoId}`
   }
 
   const getReglaValor = (promo: PromocionConDetalles, clave: string): number | null => {
@@ -111,6 +59,12 @@ export default function VistaPromociones({
     return true
   }
 
+  const promosFiltradas = useMemo(() => {
+    if (filtro === 'todas') return promociones
+    if (filtro === 'inactivas') return promociones.filter(p => !isPromoVigente(p))
+    return promociones.filter(p => isPromoVigente(p))
+  }, [promociones, filtro])  
+
   if (loading) {
     return (
       <div className="flex items-center justify-center py-20">
@@ -122,24 +76,57 @@ export default function VistaPromociones({
   return (
     <div className="space-y-6">
       {/* Header */}
-      <div className="flex justify-between items-center">
+      <div className="flex justify-between items-center flex-wrap gap-3">
         <div>
           <h1 className="text-2xl font-bold dark:text-white">Promociones</h1>
           <p className="text-sm text-gray-500 dark:text-gray-400 mt-1">
-            Gestiona promociones de bonificacion para productos
+            Gestiona promociones de bonificación para productos
           </p>
         </div>
-        <button
-          onClick={onNuevaPromocion}
-          className="flex items-center gap-2 px-4 py-2 bg-purple-600 text-white rounded-lg hover:bg-purple-700 transition-colors"
-        >
-          <Plus className="w-4 h-4" />
-          Nueva Promocion
-        </button>
+        <div className="flex items-center gap-2">
+          <button
+            onClick={() => setMostrarHistorico(v => !v)}
+            className={`flex items-center gap-2 px-3 py-2 rounded-lg border text-sm transition-colors ${
+              mostrarHistorico
+                ? 'bg-purple-50 dark:bg-purple-900/20 border-purple-400 text-purple-700 dark:text-purple-300'
+                : 'bg-white dark:bg-gray-800 border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700'
+            }`}
+            title="Mostrar unidades regaladas históricas por promo"
+          >
+            <History className="w-4 h-4" />
+            {mostrarHistorico ? 'Ocultar' : 'Ver'} histórico
+          </button>
+          <button
+            onClick={onNuevaPromocion}
+            className="flex items-center gap-2 px-4 py-2 bg-purple-600 text-white rounded-lg hover:bg-purple-700 transition-colors"
+          >
+            <Plus className="w-4 h-4" />
+            Nueva Promoción
+          </button>
+        </div>
+      </div>
+
+      {/* Filtros de estado */}
+      <div className="flex items-center gap-2 flex-wrap">
+        <Filter className="w-4 h-4 text-gray-400" />
+        {(['vigentes', 'todas', 'inactivas'] as FiltroEstado[]).map(f => (
+          <button
+            key={f}
+            onClick={() => setFiltro(f)}
+            className={`px-3 py-1 rounded-full text-sm capitalize transition-colors ${
+              filtro === f
+                ? 'bg-purple-600 text-white'
+                : 'bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-300 border border-gray-300 dark:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-700'
+            }`}
+          >
+            {f === 'vigentes' ? 'Vigentes' : f === 'todas' ? 'Todas' : 'Inactivas / vencidas'}
+          </button>
+        ))}
+        <span className="text-xs text-gray-500 ml-auto">{promosFiltradas.length} / {promociones.length}</span>
       </div>
 
       {/* Lista de promos */}
-      {promociones.length === 0 ? (
+      {promosFiltradas.length === 0 ? (
         <div className="text-center py-16 bg-white dark:bg-gray-800 rounded-xl border dark:border-gray-700">
           <Gift className="w-12 h-12 text-gray-300 mx-auto mb-4" />
           <h3 className="text-lg font-medium text-gray-500 dark:text-gray-400">Sin promociones</h3>
@@ -155,7 +142,7 @@ export default function VistaPromociones({
         </div>
       ) : (
         <div className="grid gap-4">
-          {promociones.map(promo => {
+          {promosFiltradas.map(promo => {
             const cantCompra = getReglaValor(promo, 'cantidad_compra')
             const cantBonif = getReglaValor(promo, 'cantidad_bonificacion')
             const vigente = isPromoVigente(promo)
@@ -185,12 +172,6 @@ export default function VistaPromociones({
                           Fuera de rango
                         </span>
                       )}
-                      {promo.usos_pendientes > 0 && (
-                        <span className="inline-flex items-center gap-1 text-xs px-2 py-0.5 bg-orange-100 text-orange-700 rounded-full font-medium">
-                          <AlertTriangle className="w-3 h-3" />
-                          {promo.usos_pendientes} uso{promo.usos_pendientes !== 1 ? 's' : ''} pendiente{promo.usos_pendientes !== 1 ? 's' : ''}
-                        </span>
-                      )}
                       {promo.limite_usos && (
                         <span className={`text-xs px-2 py-0.5 rounded-full font-medium ${
                           promo.usos_pendientes >= promo.limite_usos
@@ -215,6 +196,12 @@ export default function VistaPromociones({
                         <span className="inline-flex items-center gap-1 text-xs px-2 py-0.5 bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-300 rounded-full font-medium">
                           <Zap className="w-3 h-3" />
                           Auto-ajuste
+                        </span>
+                      )}
+                      {mostrarHistorico && unidadesEntregadas && (
+                        <span className="inline-flex items-center gap-1 text-xs px-2 py-0.5 bg-emerald-100 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-300 rounded-full font-medium">
+                          <History className="w-3 h-3" />
+                          {unidadesEntregadas.get(String(promo.id)) ?? 0} unidades regaladas
                         </span>
                       )}
                     </div>
@@ -263,25 +250,14 @@ export default function VistaPromociones({
                   </div>
                 )}
 
-                {/* Contador de usos */}
-                <div className="mb-3 px-3 py-2 bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-800 rounded-lg flex items-center justify-between">
-                  <p className="text-sm text-blue-700 dark:text-blue-300">
-                    <span className="font-medium">Unidades regaladas:</span>{' '}
-                    {promo.regalo_mueve_stock
-                      ? `${promo.usos_pendientes} entregadas (stock ya descontado)`
-                      : `${promo.usos_pendientes} pendientes de ajuste`}
-                  </p>
-                  {promo.usos_pendientes > 0 && !promo.regalo_mueve_stock && !promo.ajuste_automatico && (
-                    <span className="text-xs bg-orange-100 dark:bg-orange-900/30 text-orange-700 dark:text-orange-300 px-2 py-0.5 rounded-full font-medium">
-                      Ajustar stock
-                    </span>
-                  )}
-                  {promo.ajuste_automatico && promo.unidades_por_bloque && (
-                    <span className="text-xs bg-blue-100 dark:bg-blue-900/30 text-blue-700 dark:text-blue-300 px-2 py-0.5 rounded-full font-medium">
-                      Auto-ajuste cada {promo.unidades_por_bloque} u.
-                    </span>
-                  )}
-                </div>
+                {/* Contador auxiliar: solo muestra cuántas unidades faltan para el proximo bloque (fracción) */}
+                {promo.ajuste_automatico && promo.unidades_por_bloque && promo.unidades_por_bloque > 0 && (
+                  <div className="mb-3 px-3 py-2 bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-800 rounded-lg text-sm text-blue-700 dark:text-blue-300">
+                    <span className="font-medium">Progreso hacia el próximo bloque:</span>{' '}
+                    {promo.usos_pendientes} / {promo.unidades_por_bloque} unidades
+                    {promo.usos_pendientes === 0 && ' (bloque recién cerrado)'}
+                  </div>
+                )}
 
                 {/* Productos */}
                 <div className="mb-3">
@@ -304,97 +280,6 @@ export default function VistaPromociones({
                   </div>
                 </div>
 
-                {/* Ajuste de stock (solo si no es auto-ajuste ni mueve stock directo) */}
-                {promo.usos_pendientes > 0 && !promo.regalo_mueve_stock && !promo.ajuste_automatico && (
-                  <div className="mt-3 pt-3 border-t dark:border-gray-700">
-                    {ajustandoId === promo.id ? (
-                      <div className="space-y-2 p-3 bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800 rounded-lg">
-                        <p className="text-xs text-amber-700 dark:text-amber-300">
-                          Ajusta stock acumulado por bonificaciones entregadas. Tenes {promo.usos_pendientes} pendientes.
-                        </p>
-                        <div>
-                          <label className="block text-xs font-medium text-gray-600 dark:text-gray-300 mb-1">
-                            Producto a descontar
-                          </label>
-                          <select
-                            value={ajusteProductoId}
-                            onChange={e => setAjusteProductoId(e.target.value)}
-                            className="w-full px-2 py-1.5 text-sm border rounded-lg dark:bg-gray-700 dark:border-gray-600 dark:text-white"
-                          >
-                            <option value="">Elegir producto...</option>
-                            {productos.map(p => (
-                              <option key={p.id} value={String(p.id)}>
-                                {p.nombre} {p.stock !== undefined ? `(stock: ${p.stock})` : ''}
-                              </option>
-                            ))}
-                          </select>
-                        </div>
-                        <div className="grid grid-cols-2 gap-2">
-                          <div>
-                            <label className="block text-xs font-medium text-gray-600 dark:text-gray-300 mb-1">
-                              Stock a descontar
-                            </label>
-                            <input
-                              type="number"
-                              min="1"
-                              value={ajusteCantidadStock}
-                              onChange={e => setAjusteCantidadStock(e.target.value)}
-                              placeholder="Ej: 1 (fardo)"
-                              className="w-full px-2 py-1.5 text-sm border rounded-lg dark:bg-gray-700 dark:border-gray-600 dark:text-white"
-                            />
-                          </div>
-                          <div>
-                            <label className="block text-xs font-medium text-gray-600 dark:text-gray-300 mb-1">
-                              Usos a resolver
-                            </label>
-                            <input
-                              type="number"
-                              min="1"
-                              max={promo.usos_pendientes}
-                              value={ajusteUsos}
-                              onChange={e => setAjusteUsos(e.target.value)}
-                              placeholder={`1-${promo.usos_pendientes}`}
-                              className="w-full px-2 py-1.5 text-sm border rounded-lg dark:bg-gray-700 dark:border-gray-600 dark:text-white"
-                            />
-                          </div>
-                        </div>
-                        <input
-                          type="text"
-                          placeholder="Observaciones (opcional)"
-                          value={observaciones}
-                          onChange={e => setObservaciones(e.target.value)}
-                          className="w-full px-3 py-1.5 text-sm border rounded-lg dark:bg-gray-700 dark:border-gray-600 dark:text-white"
-                        />
-                        {ajusteError && (
-                          <p className="text-xs text-red-600 dark:text-red-400">{ajusteError}</p>
-                        )}
-                        <div className="flex justify-end gap-2">
-                          <button
-                            onClick={cancelarAjuste}
-                            className="px-3 py-1.5 text-sm text-gray-500 hover:text-gray-700 dark:text-gray-400"
-                          >
-                            Cancelar
-                          </button>
-                          <button
-                            onClick={() => confirmarAjuste(promo)}
-                            className="flex items-center gap-1 px-3 py-1.5 bg-green-600 text-white text-sm rounded-lg hover:bg-green-700"
-                          >
-                            <Check className="w-4 h-4" />
-                            Confirmar ajuste
-                          </button>
-                        </div>
-                      </div>
-                    ) : (
-                      <button
-                        onClick={() => iniciarAjuste(promo)}
-                        className="flex items-center gap-2 px-3 py-1.5 bg-orange-100 text-orange-700 text-sm rounded-lg hover:bg-orange-200 transition-colors"
-                      >
-                        <Check className="w-4 h-4" />
-                        Ajustar stock ({promo.usos_pendientes} uso{promo.usos_pendientes !== 1 ? 's' : ''} pendientes)
-                      </button>
-                    )}
-                  </div>
-                )}
               </div>
             )
           })}

--- a/src/hooks/queries/index.ts
+++ b/src/hooks/queries/index.ts
@@ -25,6 +25,7 @@ export {
   useCrearCategoriaMutation,
   useRenombrarCategoriaMutation,
   useEliminarCategoriaMutation,
+  useToggleCategoriaActivaMutation,
 } from './useCategoriasQuery'
 export type { CategoriaDB } from './useCategoriasQuery'
 
@@ -157,6 +158,7 @@ export {
   useEliminarPromocionMutation,
   useTogglePromocionActivaMutation,
   useAjustarStockPromoMutation,
+  usePromoUnidadesEntregadasQuery,
 } from './usePromocionesQuery'
 export type { PromocionConDetalles, PromocionFormInput } from './usePromocionesQuery'
 

--- a/src/hooks/queries/useCategoriasQuery.ts
+++ b/src/hooks/queries/useCategoriasQuery.ts
@@ -21,6 +21,7 @@ export interface CategoriaDB {
   id: string
   nombre: string
   sucursal_id: number
+  activa: boolean
   created_at: string
   updated_at: string
 }
@@ -194,6 +195,48 @@ export function useEliminarCategoriaMutation() {
 
   return useMutation({
     mutationFn: deleteCategoria,
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: categoriasKeys.lists(currentSucursalId) })
+      queryClient.invalidateQueries({ queryKey: productosKeys.lists(currentSucursalId) })
+    },
+  })
+}
+
+/**
+ * Toggle soft-delete: marca la categoria como activa/inactiva sin borrarla.
+ * Una categoria inactiva no aparece en selectores ni filtros. Los productos
+ * que la tenian asignada se dejan con categoria NULL.
+ */
+async function toggleCategoriaActiva(
+  { id, activa, nombre }: { id: string; activa: boolean; nombre: string }
+): Promise<CategoriaDB> {
+  const { data, error } = await supabase
+    .from('categorias')
+    .update({ activa })
+    .eq('id', id)
+    .select()
+    .single()
+  if (error) throw error
+
+  // Si estamos desactivando, soltar la asignacion en productos para que no
+  // sigan apareciendo con esa categoria en filtros.
+  if (!activa) {
+    const { error: bulkErr } = await supabase
+      .from('productos')
+      .update({ categoria: null })
+      .eq('categoria', nombre)
+    if (bulkErr) throw bulkErr
+  }
+
+  return data as CategoriaDB
+}
+
+export function useToggleCategoriaActivaMutation() {
+  const queryClient = useQueryClient()
+  const { currentSucursalId } = useSucursal()
+
+  return useMutation({
+    mutationFn: toggleCategoriaActiva,
     onSettled: () => {
       queryClient.invalidateQueries({ queryKey: categoriasKeys.lists(currentSucursalId) })
       queryClient.invalidateQueries({ queryKey: productosKeys.lists(currentSucursalId) })

--- a/src/hooks/queries/usePromocionesQuery.ts
+++ b/src/hooks/queries/usePromocionesQuery.ts
@@ -432,6 +432,37 @@ export function useTogglePromocionActivaMutation() {
   })
 }
 
+/**
+ * Hook para obtener el total de unidades regaladas historicas por cada promo
+ * (suma de pedido_items.cantidad con es_bonificacion=true).
+ * Multi-tenant: scoped por sucursal activa via RLS.
+ */
+export function usePromoUnidadesEntregadasQuery() {
+  const { currentSucursalId } = useSucursal()
+  return useQuery({
+    queryKey: [...promocionesKeys.all(currentSucursalId), 'unidades_entregadas'] as const,
+    queryFn: async (): Promise<Map<string, number>> => {
+      const { data, error } = await supabase
+        .from('pedido_items')
+        .select('promocion_id, cantidad')
+        .eq('es_bonificacion', true)
+        .not('promocion_id', 'is', null)
+      if (error) {
+        if (error.message.includes('does not exist')) return new Map()
+        throw error
+      }
+      const map = new Map<string, number>()
+      for (const row of (data ?? []) as { promocion_id: string | number; cantidad: number }[]) {
+        const key = String(row.promocion_id)
+        map.set(key, (map.get(key) ?? 0) + Number(row.cantidad ?? 0))
+      }
+      return map
+    },
+    enabled: !!currentSucursalId,
+    staleTime: 60 * 1000,
+  })
+}
+
 export function useAjustarStockPromoMutation() {
   const queryClient = useQueryClient()
   const { currentSucursalId } = useSucursal()


### PR DESCRIPTION
## Contexto

Afinando el trabajo del PR #254 según feedback:

1. **Cartel "X usos pendientes"** seguía apareciendo en promos de unidad entera con `regalo_mueve_stock=true` (ej. promo #9 Lima Limón), donde el stock ya se descuenta en cada venta — no hay nada "pendiente". Se oculta permanentemente.
2. **Layout del modal de promoción** quedaba confuso en modo fracción (reglas separadas arriba del todo + producto regalo innecesario + bloque azul separado). Se reorganiza en un único bloque cohesivo cuando es fracción.
3. **Bundle de pedidos en auto-ajuste**: al cerrar un bloque, la merma sólo referenciaba el pedido que cruzó el umbral. Ahora lista los pedidos que contribuyeron.
4. **Toggle activar/desactivar categorías** (soft-delete total en productos).

## Summary

### Modal de promoción
- Se elimina el toggle "el regalo descuenta stock automáticamente". Ahora se deriva del tipo: unidad entera → mueve stock, fracción → auto-ajuste. Todos los regalos descuentan stock según su regla.
- Fracción: un único bloque azul "Regla de bonificación" con todo adentro (producto contenedor + unidades_por_bloque + stock_por_bloque + cantidad_compra + cantidad_bonificacion). Elimina el bloque violeta y la sección "Producto de regalo".
- Unidad entera: layout viejo intacto.

### Vista de promociones
- Se ocultan los carteles `X usos pendientes` y el form de ajuste manual de stock. Para fracciones se muestra "Progreso hacia el próximo bloque: N/M unidades".
- Filtro de estado: Vigentes / Todas / Inactivas+vencidas.
- Botón "Ver histórico" que muestra en cada tarjeta un badge con el total de unidades regaladas (suma de `pedido_items.cantidad` con `es_bonificacion=true`).

### Migración 012
- `crear_pedido_completo`: observación de merma auto-ajuste ahora usa `pedido_bundle_para_promo()` → `"Auto-ajuste (Promo: X, Pedidos: #A, #B, #C, ...)"`.
- `categorias.activa` BOOLEAN NOT NULL DEFAULT TRUE + índice.

### Categorías
- Nuevo hook `useToggleCategoriaActivaMutation`. Al desactivar: setea `activa=false` + `UPDATE productos SET categoria=null` donde coincide. Los selectores de categoría se derivan de `productos.categoria`, así que desaparece de todos lados.
- Toggle visual entre el lápiz y el tacho en `ModalCategorias`. Badge "inactiva" + opacidad reducida en la fila.

## Test plan

- [x] `npm run typecheck`
- [x] 578/578 tests
- [ ] Abrir modal de promo #9 (unidad entera) → layout violeta clásico.
- [ ] Abrir modal de promo #1 (fracción) → todo dentro del bloque azul, sin producto de regalo separado.
- [ ] En la vista de promos: la promo #9 no debe mostrar cartel de pendientes. Toggle "Ver histórico" activa el badge de unidades regaladas.
- [ ] Crear un pedido que cierre un bloque de promo fraccional → chequear en Supabase que la merma tiene `"Pedidos: #N, #M, ..."` en observaciones.
- [ ] Desactivar una categoría desde Gestionar categorías → productos asignados quedan sin categoría, la categoría desaparece del selector al editar producto.

🤖 Generated with [Claude Code](https://claude.com/claude-code)