### PR TITLE
fix(promociones): cartel de subunidades pendientes + histórico excluye cancelados

### DIFF
--- a/migrations/013_simular_salvedad_promo_impacto.sql
+++ b/migrations/013_simular_salvedad_promo_impacto.sql
@@ -1,0 +1,102 @@
+-- Migration 013: helper dry-run para detectar promos afectadas por una salvedad
+--
+-- Permite al front mostrar una alerta ANTES de confirmar la salvedad cuando
+-- el item afectado rompe una bonificación (la promo ya no cumple la condición
+-- de compra). La lógica espejea exactamente el recalculo que hace
+-- `registrar_salvedad` (migración 010) pero sin modificar nada.
+
+CREATE OR REPLACE FUNCTION public.simular_salvedad_promo_impacto(
+  p_pedido_id bigint,
+  p_pedido_item_id bigint,
+  p_cantidad_afectada integer
+) RETURNS TABLE (
+  promocion_id BIGINT,
+  promo_nombre TEXT,
+  bonif_actual INT,
+  bonif_esperada INT,
+  delta INT,
+  descripcion_regalo TEXT,
+  sera_eliminada BOOLEAN
+)
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $$
+DECLARE
+  v_sucursal BIGINT := current_sucursal_id();
+  v_item RECORD;
+BEGIN
+  IF v_sucursal IS NULL OR p_cantidad_afectada IS NULL OR p_cantidad_afectada <= 0 THEN
+    RETURN;
+  END IF;
+
+  SELECT pi.id, pi.producto_id, pi.cantidad, COALESCE(pi.es_bonificacion, FALSE) AS es_bonificacion
+    INTO v_item
+    FROM pedido_items pi
+   WHERE pi.id = p_pedido_item_id
+     AND pi.pedido_id = p_pedido_id
+     AND pi.sucursal_id = v_sucursal;
+
+  IF v_item IS NULL OR v_item.es_bonificacion THEN
+    RETURN;
+  END IF;
+
+  RETURN QUERY
+  WITH bonifs AS (
+    SELECT pi.id, pi.producto_id, pi.cantidad, pi.promocion_id
+      FROM pedido_items pi
+     WHERE pi.pedido_id = p_pedido_id
+       AND pi.sucursal_id = v_sucursal
+       AND COALESCE(pi.es_bonificacion, FALSE) = TRUE
+       AND pi.promocion_id IS NOT NULL
+  ),
+  promo_info AS (
+    SELECT
+      b.id AS bonif_id,
+      b.cantidad AS bonif_qty,
+      b.promocion_id,
+      p.nombre AS promo_nombre,
+      p.descripcion_regalo,
+      MAX(CASE WHEN pr.clave = 'cantidad_compra'       THEN pr.valor END)::INT AS cant_compra,
+      MAX(CASE WHEN pr.clave = 'cantidad_bonificacion' THEN pr.valor END)::INT AS cant_bonif
+    FROM bonifs b
+    JOIN promociones p ON p.id = b.promocion_id AND p.sucursal_id = v_sucursal
+    LEFT JOIN promocion_reglas pr ON pr.promocion_id = p.id
+    GROUP BY b.id, b.cantidad, b.promocion_id, p.nombre, p.descripcion_regalo
+  ),
+  totales AS (
+    -- Total de items disparadores de la promo (no-bonif) DESPUÉS de la salvedad
+    SELECT
+      pi.pedido_id, pp.promocion_id,
+      SUM(
+        CASE
+          WHEN pi.id = p_pedido_item_id THEN GREATEST(pi.cantidad - p_cantidad_afectada, 0)
+          ELSE pi.cantidad
+        END
+      )::INT AS total_qty_post
+    FROM pedido_items pi
+    JOIN promocion_productos pp ON pp.producto_id = pi.producto_id
+    WHERE pi.pedido_id = p_pedido_id
+      AND pi.sucursal_id = v_sucursal
+      AND COALESCE(pi.es_bonificacion, FALSE) = FALSE
+    GROUP BY pi.pedido_id, pp.promocion_id
+  )
+  SELECT
+    pi.promocion_id,
+    pi.promo_nombre::TEXT,
+    pi.bonif_qty AS bonif_actual,
+    (COALESCE(t.total_qty_post, 0) / NULLIF(pi.cant_compra, 0)) * pi.cant_bonif AS bonif_esperada,
+    pi.bonif_qty - ((COALESCE(t.total_qty_post, 0) / NULLIF(pi.cant_compra, 0)) * pi.cant_bonif) AS delta,
+    pi.descripcion_regalo,
+    ((COALESCE(t.total_qty_post, 0) / NULLIF(pi.cant_compra, 0)) * pi.cant_bonif) = 0 AS sera_eliminada
+  FROM promo_info pi
+  LEFT JOIN totales t ON t.promocion_id = pi.promocion_id
+  WHERE pi.cant_compra IS NOT NULL AND pi.cant_compra > 0
+    AND pi.cant_bonif  IS NOT NULL AND pi.cant_bonif  > 0
+    AND pi.bonif_qty > ((COALESCE(t.total_qty_post, 0) / NULLIF(pi.cant_compra, 0)) * pi.cant_bonif);
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.simular_salvedad_promo_impacto(bigint, bigint, integer) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.simular_salvedad_promo_impacto(bigint, bigint, integer) TO authenticated;

--- a/src/components/modals/ModalPromocion.tsx
+++ b/src/components/modals/ModalPromocion.tsx
@@ -61,9 +61,6 @@ export default function ModalPromocion({
   const [unidadesPorBloque, setUnidadesPorBloque] = useState<string>(
     promocion?.unidades_por_bloque ? String(promocion.unidades_por_bloque) : ''
   )
-  const [stockPorBloque, setStockPorBloque] = useState<string>(
-    promocion?.stock_por_bloque ? String(promocion.stock_por_bloque) : '1'
-  )
   const [descripcionRegalo, setDescripcionRegalo] = useState<string>(
     promocion?.descripcion_regalo ?? ''
   )
@@ -159,17 +156,12 @@ export default function ModalPromocion({
         return
       }
       if (!ajusteProductoId) {
-        setError('Seleccioná el producto que se descuenta del stock (ej: el fardo que contiene las botellas)')
+        setError('Seleccioná el producto del que se descuenta el stock (ej: el fardo contenedor)')
         return
       }
       const unidBloque = parseInt(unidadesPorBloque)
       if (!unidBloque || unidBloque <= 0) {
-        setError('Ingresá cuántas unidades bonificadas forman un bloque (ej: 12 botellas = 1 fardo)')
-        return
-      }
-      const stockBloque = parseInt(stockPorBloque)
-      if (!stockBloque || stockBloque <= 0) {
-        setError('Ingresá cuánto stock descuenta cada bloque (normalmente 1)')
+        setError('Ingresá cuántas subunidades forman una unidad del producto contenedor (ej: 6 botellas = 1 fardo)')
         return
       }
     }
@@ -178,7 +170,9 @@ export default function ModalPromocion({
     const limite = limiteUsos ? parseInt(limiteUsos) : null
     const prio = parseInt(prioridad)
     const unidBloque = parseInt(unidadesPorBloque)
-    const stockBloque = parseInt(stockPorBloque)
+    // stock_por_bloque siempre es 1 en el modelo fraccional (no es un campo
+    // visible al usuario). El backend lo usa al cerrar un bloque.
+    const stockBloque = 1
     const result = await onSave({
       nombre: nombre.trim(),
       tipo: 'bonificacion',
@@ -460,11 +454,29 @@ export default function ModalPromocion({
                     )}
                   </div>
 
-                  {/* Unidades por bloque y Stock por bloque */}
-                  <div className="grid grid-cols-2 gap-3">
+                  {/* Unidades regaladas por promocion + Subunidades por unidad + Cantidad compra */}
+                  <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
                     <div>
                       <label className="block text-xs font-medium text-blue-700 dark:text-blue-300 mb-1">
-                        Unidades bonificadas por bloque
+                        Unidades regaladas por promoción
+                      </label>
+                      <input
+                        type="number"
+                        inputMode="numeric"
+                        step="1"
+                        min="1"
+                        value={cantidadBonificacion}
+                        onChange={e => setCantidadBonificacion(e.target.value)}
+                        placeholder="Ej: 2"
+                        className="w-full px-3 py-2 border rounded-lg dark:bg-gray-700 dark:border-gray-600 dark:text-white focus:ring-2 focus:ring-blue-500 focus:outline-none text-sm"
+                      />
+                      <p className="text-[11px] text-blue-600 dark:text-blue-400 mt-1">
+                        Ej: 2 botellas por cada aplicación.
+                      </p>
+                    </div>
+                    <div>
+                      <label className="block text-xs font-medium text-blue-700 dark:text-blue-300 mb-1">
+                        Subunidades por unidad
                       </label>
                       <input
                         type="number"
@@ -473,35 +485,13 @@ export default function ModalPromocion({
                         min="1"
                         value={unidadesPorBloque}
                         onChange={e => setUnidadesPorBloque(e.target.value)}
-                        placeholder="Ej: 12"
+                        placeholder="Ej: 6"
                         className="w-full px-3 py-2 border rounded-lg dark:bg-gray-700 dark:border-gray-600 dark:text-white focus:ring-2 focus:ring-blue-500 focus:outline-none text-sm"
                       />
                       <p className="text-[11px] text-blue-600 dark:text-blue-400 mt-1">
-                        Cuántas unidades regaladas forman un bloque.
+                        Ej: 6 botellas = 1 fardo.
                       </p>
                     </div>
-                    <div>
-                      <label className="block text-xs font-medium text-blue-700 dark:text-blue-300 mb-1">
-                        Stock descontado por bloque
-                      </label>
-                      <input
-                        type="number"
-                        inputMode="numeric"
-                        step="1"
-                        min="1"
-                        value={stockPorBloque}
-                        onChange={e => setStockPorBloque(e.target.value)}
-                        placeholder="Ej: 1"
-                        className="w-full px-3 py-2 border rounded-lg dark:bg-gray-700 dark:border-gray-600 dark:text-white focus:ring-2 focus:ring-blue-500 focus:outline-none text-sm"
-                      />
-                      <p className="text-[11px] text-blue-600 dark:text-blue-400 mt-1">
-                        Cuánto se descuenta por cada bloque (normalmente 1).
-                      </p>
-                    </div>
-                  </div>
-
-                  {/* Cantidad compra y cantidad gratis (dentro del bloque fracción) */}
-                  <div className="grid grid-cols-2 gap-3 pt-2 border-t border-blue-200 dark:border-blue-800">
                     <div>
                       <label className="block text-xs font-medium text-blue-700 dark:text-blue-300 mb-1">
                         Cantidad compra
@@ -513,32 +503,20 @@ export default function ModalPromocion({
                         min="1"
                         value={cantidadCompra}
                         onChange={e => setCantidadCompra(e.target.value)}
-                        placeholder="Ej: 2"
+                        placeholder="Ej: 5"
                         className="w-full px-3 py-2 border rounded-lg dark:bg-gray-700 dark:border-gray-600 dark:text-white focus:ring-2 focus:ring-blue-500 focus:outline-none text-sm"
                       />
-                    </div>
-                    <div>
-                      <label className="block text-xs font-medium text-blue-700 dark:text-blue-300 mb-1">
-                        Cantidad gratis
-                      </label>
-                      <input
-                        type="number"
-                        inputMode="numeric"
-                        step="1"
-                        min="1"
-                        value={cantidadBonificacion}
-                        onChange={e => setCantidadBonificacion(e.target.value)}
-                        placeholder="Ej: 1"
-                        className="w-full px-3 py-2 border rounded-lg dark:bg-gray-700 dark:border-gray-600 dark:text-white focus:ring-2 focus:ring-blue-500 focus:outline-none text-sm"
-                      />
+                      <p className="text-[11px] text-blue-600 dark:text-blue-400 mt-1">
+                        Del producto disparador.
+                      </p>
                     </div>
                   </div>
 
-                  {cantidadCompra && cantidadBonificacion && unidadesPorBloque && stockPorBloque
+                  {cantidadCompra && cantidadBonificacion && unidadesPorBloque
                     && parseInt(cantidadCompra) > 0 && parseInt(cantidadBonificacion) > 0
-                    && parseInt(unidadesPorBloque) > 0 && parseInt(stockPorBloque) > 0 && (
+                    && parseInt(unidadesPorBloque) > 0 && (
                     <p className="text-xs text-blue-700 dark:text-blue-300 bg-blue-100 dark:bg-blue-900/40 rounded px-2 py-1.5">
-                      Resumen: cada {cantidadCompra} unidades compradas → {cantidadBonificacion} gratis ({descripcionRegalo.trim() || 'unidad fraccionada'}). Cada {unidadesPorBloque} unidades regaladas descuentan {stockPorBloque} del stock del producto contenedor.
+                      Resumen: cada {cantidadCompra} unidades compradas → {cantidadBonificacion} {descripcionRegalo.trim() || 'subunidad(es)'} gratis. Cada {unidadesPorBloque} subunidades regaladas se descuenta 1 del stock del producto contenedor.
                     </p>
                   )}
               </div>

--- a/src/components/vistas/VistaPromociones.tsx
+++ b/src/components/vistas/VistaPromociones.tsx
@@ -250,13 +250,39 @@ export default function VistaPromociones({
                   </div>
                 )}
 
-                {/* Contador auxiliar: solo muestra cuántas unidades faltan para el proximo bloque (fracción) */}
+                {/* Subunidades pendientes para el proximo bloque (solo fracción) */}
                 {promo.ajuste_automatico && promo.unidades_por_bloque && promo.unidades_por_bloque > 0 && (
-                  <div className="mb-3 px-3 py-2 bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-800 rounded-lg text-sm text-blue-700 dark:text-blue-300">
-                    <span className="font-medium">Progreso hacia el próximo bloque:</span>{' '}
-                    {promo.usos_pendientes} / {promo.unidades_por_bloque} unidades
-                    {promo.usos_pendientes === 0 && ' (bloque recién cerrado)'}
-                  </div>
+                  (() => {
+                    const pendientes = promo.usos_pendientes ?? 0
+                    const porBloque = promo.unidades_por_bloque ?? 0
+                    const falta = Math.max(porBloque - pendientes, 0)
+                    const progreso = porBloque > 0 ? Math.min((pendientes / porBloque) * 100, 100) : 0
+                    return (
+                      <div className="mb-3 px-3 py-2 bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-800 rounded-lg">
+                        <div className="flex items-center justify-between gap-2 text-sm text-blue-700 dark:text-blue-300 mb-1.5">
+                          <span className="font-medium">
+                            Subunidades pendientes para descontar stock:
+                          </span>
+                          <span className="font-bold tabular-nums">
+                            {pendientes} / {porBloque}
+                          </span>
+                        </div>
+                        <div className="w-full bg-blue-100 dark:bg-blue-900/40 rounded-full h-2 overflow-hidden">
+                          <div
+                            className="bg-blue-500 dark:bg-blue-400 h-full transition-all"
+                            style={{ width: `${progreso}%` }}
+                            aria-label={`${pendientes} de ${porBloque}`}
+                          />
+                        </div>
+                        <p className="text-[11px] text-blue-600 dark:text-blue-400 mt-1">
+                          {pendientes === 0
+                            ? 'Bloque recién cerrado — se descontó 1 unidad del contenedor.'
+                            : `Faltan ${falta} subunidad${falta === 1 ? '' : 'es'} para cerrar el próximo bloque y descontar 1 unidad del contenedor.`
+                          }
+                        </p>
+                      </div>
+                    )
+                  })()
                 )}
 
                 {/* Productos */}

--- a/src/hooks/queries/usePromocionesQuery.ts
+++ b/src/hooks/queries/usePromocionesQuery.ts
@@ -433,8 +433,9 @@ export function useTogglePromocionActivaMutation() {
 }
 
 /**
- * Hook para obtener el total de unidades regaladas historicas por cada promo
- * (suma de pedido_items.cantidad con es_bonificacion=true).
+ * Hook para obtener el total de unidades regaladas historicas por cada promo.
+ * Suma de pedido_items.cantidad con es_bonificacion=true, EXCLUYENDO pedidos
+ * cancelados (esas unidades ya fueron revertidas del contador/stock).
  * Multi-tenant: scoped por sucursal activa via RLS.
  */
 export function usePromoUnidadesEntregadasQuery() {
@@ -444,9 +445,10 @@ export function usePromoUnidadesEntregadasQuery() {
     queryFn: async (): Promise<Map<string, number>> => {
       const { data, error } = await supabase
         .from('pedido_items')
-        .select('promocion_id, cantidad')
+        .select('promocion_id, cantidad, pedidos!inner(estado)')
         .eq('es_bonificacion', true)
         .not('promocion_id', 'is', null)
+        .neq('pedidos.estado', 'cancelado')
       if (error) {
         if (error.message.includes('does not exist')) return new Map()
         throw error


### PR DESCRIPTION
## Contexto

Ajustes sobre el trabajo de [#255](https://github.com/AgustinReiden/distribuidora-app/pull/255) + helper SQL para preparar el flujo del transportista.

1. Badge **"X unidades regaladas"** del botón **Ver histórico** daba números inflados porque sumaba bonificaciones de pedidos cancelados. Promo #10 mostraba 93 cuando el real es 88.
2. Cartel de progreso de bloque para fracciones estaba muy discreto — no se veía.
3. Commit `ad7ab1f` (renombrar labels del modal fracción + ocultar `stock_por_bloque`) no había entrado al merge anterior.
4. **Helper SQL nuevo** `simular_salvedad_promo_impacto()` como base para la próxima PR del flujo transportista (alerta de promo rota antes de confirmar salvedad).

## Summary

### Contador histórico — excluir cancelados
[src/hooks/queries/usePromocionesQuery.ts:440-465](src/hooks/queries/usePromocionesQuery.ts:440) — `inner join` con `pedidos` + filtro `estado != 'cancelado'`. Validado en prod: promo #10 pasa de 93 → 88 (coincide con `84 descontados + 4 contador actual`).

### Cartel de subunidades pendientes
[src/components/vistas/VistaPromociones.tsx:253-286](src/components/vistas/VistaPromociones.tsx:253) — rediseñado con barra de progreso visible + mensaje: "Faltan K subunidades para cerrar el próximo bloque y descontar 1 unidad del contenedor".

### Modal de promoción (cherry-pick)
Campos renombrados: Unidades regaladas por promoción / Subunidades por unidad / Cantidad compra. `stock_por_bloque` fijo en 1 (oculto).

### Helper SQL `simular_salvedad_promo_impacto` — migración 013
Dry-run que recicla la fórmula de `registrar_salvedad`: dado un `pedido_item_id` + `cantidad_afectada`, retorna qué bonificaciones quedarían reducidas o eliminadas, con promo_nombre, descripcion_regalo, bonif_actual/esperada/delta y flag `sera_eliminada`. Aplicado en prod. **Sin consumidores todavía** — se usará en la próxima PR del flujo transportista.

## Test plan

- [x] `npm run typecheck`
- [x] 578/578 tests
- [x] Validado contra BD prod: promo #10 query nueva = 88 (antes 93).
- [ ] Vista de promociones: promo #10 con "Ver histórico" activo muestra `88 unidades regaladas`.
- [ ] Promo #10 muestra barra "4 / 12 subunidades" + texto "Faltan 8 subunidades...".

🤖 Generated with [Claude Code](https://claude.com/claude-code)