### PR TITLE
feat(transportista): pago combinado al entregar + alerta de promo rota en salvedad

### DIFF
--- a/src/components/containers/PedidosContainer.tsx
+++ b/src/components/containers/PedidosContainer.tsx
@@ -31,6 +31,7 @@ import { useOptimizarRuta } from '../../hooks/useOptimizarRuta'
 import { usePromocionPedido } from '../../hooks/usePromocionPedido'
 import { useDebounce } from '../../hooks/useAsync'
 import { supabase } from '../../hooks/supabase/base'
+import { usePagos } from '../../hooks/supabase/usePagos'
 import type { PedidoDB, FiltrosPedidosState, PerfilDB, RegistrarSalvedadInput, RegistrarSalvedadResult } from '../../types'
 import type { PedidoEditItem } from '../modals/ModalEditarPedido'
 
@@ -92,6 +93,8 @@ export default function PedidosContainer(): React.ReactElement {
   const [filtros, setFiltros] = useState<FiltrosPedidosState>(DEFAULT_FILTROS)
 
   // Queries - use debounced search to avoid firing on every keystroke
+  const { registrarPago } = usePagos()
+
   const { data: paginatedResult, isLoading: loadingPedidos } = usePedidosPaginatedQuery(
     paginaActual, ITEMS_PER_PAGE, filtros, debouncedBusqueda, authReady
   )
@@ -709,6 +712,45 @@ export default function PedidosContainer(): React.ReactElement {
     return results
   }, [queryClient])
 
+  // Handler single-salvedad para la vista transportista (wrapper sobre bulk)
+  const handleRegistrarSalvedadSingle = useCallback(async (data: {
+    pedidoId: string;
+    pedidoItemId: string;
+    cantidadAfectada: number;
+    motivo: import('../../types').MotivoSalvedad;
+    descripcion?: string;
+    fotoUrl?: string;
+    devolverStock: boolean;
+  }): Promise<RegistrarSalvedadResult> => {
+    const results = await handleSaveSalvedades([data])
+    return results[0] ?? { success: false, error: 'Sin respuesta del servidor' }
+  }, [handleSaveSalvedades])
+
+  // Handler de registrar pago desde la vista transportista. Usa usePagos +
+  // invalida cache de pedidos para refrescar monto_pagado / estado_pago.
+  const handleRegistrarPagoTransportista = useCallback(async (data: {
+    clienteId: string;
+    pedidoId: string | null;
+    monto: number;
+    formaPago: string;
+    referencia: string;
+    notas: string;
+    fecha: string;
+  }) => {
+    const pago = await registrarPago({
+      clienteId: data.clienteId,
+      pedidoId: data.pedidoId,
+      monto: data.monto,
+      formaPago: data.formaPago,
+      referencia: data.referencia,
+      notas: data.notas,
+      fecha: data.fecha,
+      usuarioId: user?.id ?? null,
+    })
+    queryClient.invalidateQueries({ queryKey: ['pedidos'] })
+    return pago
+  }, [registrarPago, queryClient, user?.id])
+
   const handleMarcarEntregadoConSalvedadConfirm = useCallback(async () => {
     if (!pedidoParaSalvedad) return
     try {
@@ -770,6 +812,8 @@ export default function PedidosContainer(): React.ReactElement {
           onEntregasMasivas={() => setModalEntregasMasivasOpen(true)}
           onPagosMasivos={() => setModalPagosMasivosOpen(true)}
           onAsignarTransportistaMasivo={() => setModalAsignarMasivoOpen(true)}
+          onRegistrarSalvedad={handleRegistrarSalvedadSingle}
+          onRegistrarPago={handleRegistrarPagoTransportista}
         />
       </Suspense>
 

--- a/src/components/modals/ModalSalvedadItem.tsx
+++ b/src/components/modals/ModalSalvedadItem.tsx
@@ -3,8 +3,9 @@
  * Usado por transportistas y admin cuando un item no puede ser entregado
  */
 import React, { useState, FormEvent, ChangeEvent } from 'react'
-import { X, AlertTriangle, Package, FileText, AlertCircle } from 'lucide-react'
+import { X, AlertTriangle, Package, FileText, AlertCircle, Gift } from 'lucide-react'
 import { MOTIVOS_SALVEDAD_LABELS } from '../../lib/schemas'
+import { useSimularSalvedadPromoImpactoQuery } from '../../hooks/queries'
 import type { PedidoItemDB, MotivoSalvedad, RegistrarSalvedadResult } from '../../types'
 
 interface MotivoOption {
@@ -148,6 +149,14 @@ export default function ModalSalvedadItem({
   const montoAfectado = cantidadNum * item.precio_unitario
   const cantidadRestante = item.cantidad - cantidadNum
 
+  // Dry-run: detecta si esta salvedad rompe alguna bonificacion de promo.
+  const { data: promosAfectadas = [] } = useSimularSalvedadPromoImpactoQuery(
+    pedidoId,
+    item.id,
+    cantidadNum > 0 && cantidadNum <= item.cantidad ? cantidadNum : 0,
+  )
+  const tienePromoRota = promosAfectadas.length > 0
+
   return (
     <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
       <div className="bg-white dark:bg-gray-800 rounded-xl shadow-xl w-full max-w-lg max-h-[90vh] overflow-y-auto">
@@ -287,6 +296,45 @@ export default function ModalSalvedadItem({
             </div>
           )}
 
+          {/* Alerta de promocion rota */}
+          {tienePromoRota && (
+            <div
+              role="alert"
+              className="p-3 bg-red-50 dark:bg-red-900/20 border-2 border-red-400 dark:border-red-700 rounded-lg space-y-2"
+            >
+              <div className="flex items-start gap-2">
+                <Gift className="w-5 h-5 text-red-600 dark:text-red-400 flex-shrink-0 mt-0.5" />
+                <div className="flex-1">
+                  <p className="text-sm font-bold text-red-700 dark:text-red-300">
+                    Atención: esta salvedad afecta {promosAfectadas.length === 1 ? 'una promoción' : 'varias promociones'}
+                  </p>
+                  <ul className="mt-1.5 space-y-1">
+                    {promosAfectadas.map(p => (
+                      <li key={p.promocion_id} className="text-sm text-red-700 dark:text-red-300">
+                        •{' '}
+                        <span className="font-semibold">{p.promo_nombre}:</span>{' '}
+                        {p.sera_eliminada ? (
+                          <>
+                            se cancela por completo el regalo{' '}
+                            <span className="italic">
+                              &ldquo;{p.descripcion_regalo || `${p.bonif_actual} unidades`}&rdquo;
+                            </span>
+                          </>
+                        ) : (
+                          <>
+                            el regalo baja de <span className="font-bold">{p.bonif_actual}</span> a{' '}
+                            <span className="font-bold">{p.bonif_esperada}</span> unidades
+                            {p.descripcion_regalo && ` (${p.descripcion_regalo})`}
+                          </>
+                        )}
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              </div>
+            </div>
+          )}
+
           {/* Error */}
           {error && (
             <div className="p-3 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg">
@@ -306,7 +354,11 @@ export default function ModalSalvedadItem({
             <button
               type="submit"
               disabled={guardando || !motivo || cantidadNum <= 0}
-              className="flex-1 px-4 py-2 bg-amber-600 hover:bg-amber-700 disabled:bg-amber-400 text-white rounded-lg transition-colors flex items-center justify-center gap-2"
+              className={`flex-1 px-4 py-2 text-white rounded-lg transition-colors flex items-center justify-center gap-2 ${
+                tienePromoRota
+                  ? 'bg-red-600 hover:bg-red-700 disabled:bg-red-400'
+                  : 'bg-amber-600 hover:bg-amber-700 disabled:bg-amber-400'
+              }`}
             >
               {guardando ? (
                 <>
@@ -316,7 +368,7 @@ export default function ModalSalvedadItem({
               ) : (
                 <>
                   <AlertTriangle className="w-4 h-4" />
-                  Registrar Salvedad
+                  {tienePromoRota ? 'Confirmar (se pierde promo)' : 'Registrar Salvedad'}
                 </>
               )}
             </button>

--- a/src/components/pedidos/VistaRutaTransportista.tsx
+++ b/src/components/pedidos/VistaRutaTransportista.tsx
@@ -1,11 +1,12 @@
 /**
  * Vista de ruta para transportista
  */
-import React, { useState, useMemo, memo } from 'react';
+import React, { useState, useMemo, useRef, memo } from 'react';
 import { Route, Truck, Check, MapPin, Phone, ChevronDown, ChevronUp, Navigation, AlertTriangle, Gift } from 'lucide-react';
 import { formatPrecio, formatFecha, getFormaPagoLabel } from '../../utils/formatters';
 import type { PedidoDB, ClienteDB, ProductoDB, PedidoItemDB, MotivoSalvedad, RegistrarSalvedadResult } from '../../types';
 import ModalSalvedadItem from '../modals/ModalSalvedadItem';
+import ModalRegistrarPago from '../modals/ModalRegistrarPago';
 
 // =============================================================================
 // INTERFACES DE PROPS Y TIPOS
@@ -26,6 +27,20 @@ export interface VistaRutaTransportistaProps {
     fotoUrl?: string;
     devolverStock: boolean;
   }) => Promise<RegistrarSalvedadResult>;
+  /**
+   * Handler para registrar un pago al marcar entregado. Si el pedido ya esta
+   * pagado o no se provee este handler, se salta el modal y se marca
+   * entregado directamente.
+   */
+  onRegistrarPago?: (data: {
+    clienteId: string;
+    pedidoId: string | null;
+    monto: number;
+    formaPago: string;
+    referencia: string;
+    notas: string;
+    fecha: string;
+  }) => Promise<unknown>;
 }
 
 interface PedidoEnriquecido extends PedidoDB {
@@ -207,13 +222,20 @@ function VistaRutaTransportista({
   userId,
   clientes,
   productos,
-  onRegistrarSalvedad
+  onRegistrarSalvedad,
+  onRegistrarPago
 }: VistaRutaTransportistaProps): React.ReactElement {
   // Estado para modal de salvedad
   const [salvedadModal, setSalvedadModal] = useState<{
     pedidoId: string;
     item: PedidoItemDB & { producto?: ProductoDB };
   } | null>(null);
+
+  // Estado para modal de pago al marcar entregado. Si null, no hay modal.
+  const [pedidoParaCobrar, setPedidoParaCobrar] = useState<PedidoEnriquecido | null>(null);
+  // Ref para saber si el pago del modal fue exitoso (no queremos marcar
+  // entregado si el transportista cancelo).
+  const pagoExitosoRef = useRef(false);
 
   // Enriquecer pedidos con datos de clientes y productos
   const pedidosEnriquecidos = useMemo<PedidoEnriquecido[]>(() => {
@@ -263,7 +285,38 @@ function VistaRutaTransportista({
   const totalPendienteCobro = pedidosOrdenados.filter(p => p.estado === 'asignado' && p.estado_pago !== 'pagado').reduce((sum, p) => sum + (p.total || 0), 0);
 
   const handleMarcarEntregado = (pedido: PedidoEnriquecido): void => {
+    // Si el pedido no esta pagado y hay handler de pago disponible, abrimos
+    // modal de cobranza. Si ya esta pagado o no hay handler, marcamos directo.
+    if (onRegistrarPago && pedido.estado_pago !== 'pagado' && pedido.cliente) {
+      pagoExitosoRef.current = false;
+      setPedidoParaCobrar(pedido);
+      return;
+    }
     onMarcarEntregado(pedido as PedidoDB);
+  };
+
+  const handleConfirmarPago = async (data: {
+    clienteId: string;
+    pedidoId: string | null;
+    monto: number;
+    formaPago: string;
+    referencia: string;
+    notas: string;
+    fecha: string;
+  }): Promise<import('../../types').Pago & { monto: number }> => {
+    if (!onRegistrarPago) throw new Error('Handler de pago no disponible');
+    const pago = await onRegistrarPago(data);
+    pagoExitosoRef.current = true;
+    return pago as import('../../types').Pago & { monto: number };
+  };
+
+  const handleCerrarModalPago = (): void => {
+    const pedido = pedidoParaCobrar;
+    setPedidoParaCobrar(null);
+    if (pagoExitosoRef.current && pedido) {
+      onMarcarEntregado(pedido as PedidoDB);
+    }
+    pagoExitosoRef.current = false;
   };
 
   const handleReportarSalvedad = (pedidoId: string, item: PedidoItemDB & { producto?: ProductoDB }): void => {
@@ -375,6 +428,17 @@ function VistaRutaTransportista({
           item={salvedadModal.item}
           onSave={handleGuardarSalvedad}
           onClose={() => setSalvedadModal(null)}
+        />
+      )}
+
+      {/* Modal de registrar pago al marcar entregado */}
+      {pedidoParaCobrar && pedidoParaCobrar.cliente && (
+        <ModalRegistrarPago
+          cliente={pedidoParaCobrar.cliente}
+          saldoPendiente={(pedidoParaCobrar.total || 0) - (pedidoParaCobrar.monto_pagado || 0)}
+          pedidos={[pedidoParaCobrar as unknown as import('../../types').Pedido]}
+          onClose={handleCerrarModalPago}
+          onConfirmar={handleConfirmarPago}
         />
       )}
     </div>

--- a/src/components/vistas/VistaPedidos.tsx
+++ b/src/components/vistas/VistaPedidos.tsx
@@ -14,7 +14,9 @@ import type {
   ClienteDB,
   ProductoDB,
   PerfilDB,
-  FiltrosPedidosState
+  FiltrosPedidosState,
+  MotivoSalvedad,
+  RegistrarSalvedadResult
 } from '../../types';
 import type { PedidoStatsSummary } from '../../hooks/queries';
 
@@ -64,6 +66,26 @@ export interface VistaPedidosProps {
   onEntregasMasivas?: () => void;
   onPagosMasivos?: () => void;
   onAsignarTransportistaMasivo?: () => void;
+  /** Handler para registrar una salvedad individual desde la vista transportista. */
+  onRegistrarSalvedad?: (data: {
+    pedidoId: string;
+    pedidoItemId: string;
+    cantidadAfectada: number;
+    motivo: MotivoSalvedad;
+    descripcion?: string;
+    fotoUrl?: string;
+    devolverStock: boolean;
+  }) => Promise<RegistrarSalvedadResult>;
+  /** Handler para registrar un pago (reutiliza el flujo del admin). */
+  onRegistrarPago?: (data: {
+    clienteId: string;
+    pedidoId: string | null;
+    monto: number;
+    formaPago: string;
+    referencia: string;
+    notas: string;
+    fecha: string;
+  }) => Promise<unknown>;
 }
 
 export default function VistaPedidos({
@@ -105,6 +127,8 @@ export default function VistaPedidos({
   onEntregasMasivas,
   onPagosMasivos,
   onAsignarTransportistaMasivo,
+  onRegistrarSalvedad,
+  onRegistrarPago,
 }: VistaPedidosProps) {
   // Si es transportista, mostrar vista especial de ruta
   if (isTransportista && !isAdmin && !isPreventista) {
@@ -115,6 +139,8 @@ export default function VistaPedidos({
         userId={userId}
         clientes={clientes}
         productos={productos}
+        onRegistrarSalvedad={onRegistrarSalvedad}
+        onRegistrarPago={onRegistrarPago}
       />
     );
   }

--- a/src/hooks/queries/index.ts
+++ b/src/hooks/queries/index.ts
@@ -160,6 +160,8 @@ export {
   useAjustarStockPromoMutation,
   usePromoUnidadesEntregadasQuery,
 } from './usePromocionesQuery'
+export { useSimularSalvedadPromoImpactoQuery } from './useSimularSalvedadQuery'
+export type { PromoImpactoSalvedad } from './useSimularSalvedadQuery'
 export type { PromocionConDetalles, PromocionFormInput } from './usePromocionesQuery'
 
 // Notas de Crédito

--- a/src/hooks/queries/useSimularSalvedadQuery.ts
+++ b/src/hooks/queries/useSimularSalvedadQuery.ts
@@ -1,0 +1,61 @@
+/**
+ * Hook dry-run para detectar promos afectadas por una salvedad antes de confirmarla.
+ * Llama al RPC `simular_salvedad_promo_impacto` (migración 013).
+ */
+import { useQuery } from '@tanstack/react-query'
+import { supabase } from '../supabase/base'
+import { useSucursal } from '../../contexts/SucursalContext'
+
+export interface PromoImpactoSalvedad {
+  promocion_id: number
+  promo_nombre: string
+  bonif_actual: number
+  bonif_esperada: number
+  delta: number
+  descripcion_regalo: string | null
+  sera_eliminada: boolean
+}
+
+async function fetchSimularSalvedad(
+  pedidoId: string | number,
+  pedidoItemId: string | number,
+  cantidadAfectada: number,
+): Promise<PromoImpactoSalvedad[]> {
+  if (!cantidadAfectada || cantidadAfectada <= 0) return []
+  const { data, error } = await supabase.rpc('simular_salvedad_promo_impacto', {
+    p_pedido_id: Number(pedidoId),
+    p_pedido_item_id: Number(pedidoItemId),
+    p_cantidad_afectada: cantidadAfectada,
+  })
+  if (error) {
+    if (error.message.includes('does not exist')) return []
+    throw error
+  }
+  return (data as PromoImpactoSalvedad[]) ?? []
+}
+
+/**
+ * Retorna las bonificaciones que quedarian reducidas/eliminadas por una salvedad
+ * sobre el item indicado. Array vacio = la salvedad no rompe ninguna promo.
+ * Se refresca reactivamente al cambiar `cantidadAfectada`.
+ */
+export function useSimularSalvedadPromoImpactoQuery(
+  pedidoId: string | number | null | undefined,
+  pedidoItemId: string | number | null | undefined,
+  cantidadAfectada: number,
+) {
+  const { currentSucursalId } = useSucursal()
+  const enabled = !!pedidoId && !!pedidoItemId && cantidadAfectada > 0 && !!currentSucursalId
+  return useQuery({
+    queryKey: [
+      'simular_salvedad_promo_impacto',
+      currentSucursalId,
+      pedidoId,
+      pedidoItemId,
+      cantidadAfectada,
+    ] as const,
+    queryFn: () => fetchSimularSalvedad(pedidoId!, pedidoItemId!, cantidadAfectada),
+    enabled,
+    staleTime: 10 * 1000,
+  })
+}


### PR DESCRIPTION
## Contexto

Dos huecos de la auditoría de la vista transportista (reportada en PR [#256](https://github.com/AgustinReiden/distribuidora-app/pull/256)):

1. **No había modal de pago al marcar entregado**. El handler solo cambiaba estado; nunca capturaba forma de pago ni importe.
2. **No había aviso cuando la salvedad rompía una promo**. El RPC `registrar_salvedad` limpiaba la bonificación post-commit pero sin feedback visible.

Adicional: el prop `onRegistrarSalvedad` ya existía en `VistaRutaTransportista` pero el container nunca lo conectaba, así que el modal de salvedad del transportista caía en "Funcion no disponible".

## Summary

### 1. Hook `useSimularSalvedadPromoImpactoQuery`
[src/hooks/queries/useSimularSalvedadQuery.ts](src/hooks/queries/useSimularSalvedadQuery.ts) — llama al RPC `simular_salvedad_promo_impacto` (migración 013 ya en prod). Retorna array de bonificaciones afectadas con `promo_nombre`, `descripcion_regalo`, `bonif_actual`, `bonif_esperada`, `sera_eliminada`. Se refresca reactivamente al cambiar la cantidad.

### 2. Alerta en `ModalSalvedadItem`
[src/components/modals/ModalSalvedadItem.tsx](src/components/modals/ModalSalvedadItem.tsx) — banner rojo destacado arriba del botón confirmar cuando la salvedad rompe bonificaciones. Texto por promo: "se cancela por completo el regalo X" o "el regalo baja de A a B unidades". El botón cambia a **"Confirmar (se pierde promo)"** y de color. No bloquea.

### 3. `onRegistrarSalvedad` + `onRegistrarPago` conectados
[VistaPedidos.tsx](src/components/vistas/VistaPedidos.tsx) acepta y baja ambos props a `VistaRutaTransportista`.
[PedidosContainer.tsx](src/components/containers/PedidosContainer.tsx) arma:
- `handleRegistrarSalvedadSingle` — wrapper single-salvedad sobre `handleSaveSalvedades` que ya existía para bulk.
- `handleRegistrarPagoTransportista` — usa `usePagos.registrarPago` y pasa `fecha` de hoy + `usuario_id`. Invalida cache de pedidos.

### 4. Flujo de pago al marcar entregado
[VistaRutaTransportista.tsx](src/components/pedidos/VistaRutaTransportista.tsx) — al click en "Marcar entregado":
- Si el pedido **no está pagado** y hay handler disponible → abre `ModalRegistrarPago` (ya soportaba pago combinado: efectivo, transferencia, tarjeta, cheque, cuenta corriente, con fecha editable).
- Si el pedido **ya está pagado** o no hay handler → marca entregado directo como antes.
- Al confirmar el último pago del modal, dispara `onMarcarEntregado(pedido)`. Si cancela, no cambia estado.
- `fecha` del pago = hoy del transportista → cae automáticamente en la rendición del día vía `crear_rendicion_por_fecha`.

## Test plan

- [x] `npm run typecheck`
- [x] 578/578 tests
- [ ] Loguearse como transportista (`transporte@crecertp.com`), ir a Ruta.
- [ ] Tomar un pedido con `estado_pago=pendiente` → tocar "Marcar entregado": abre modal con monto pre-cargado.
- [ ] Dividir pago ($X efectivo + $Y transferencia) → confirmar → pedido queda entregado y pagado, 2 filas en `pagos` con `fecha=hoy`.
- [ ] Desde un pedido con promo fraccional aplicada (ej. #10 Naranja), tocar ⚠ en un item disparador → modal de salvedad muestra banner rojo "se cancela el regalo 1 botella Manaos Naranja 600cc" si la cantidad rompe la promo. Confirmar: salvedad se aplica + bonificación se elimina (comportamiento ya existente).
- [ ] Rendición del día del transportista suma los pagos recién registrados.

🤖 Generated with [Claude Code](https://claude.com/claude-code)