### PR TITLE
fix(pedido): nombre completo del producto en items del carrito en mobile

### DIFF
--- a/src/components/modals/ModalPedido.tsx
+++ b/src/components/modals/ModalPedido.tsx
@@ -493,10 +493,10 @@ const ModalPedido = memo(function ModalPedido({
                         const isEditingPrice = editingPriceId === item.productoId;
                         return (
                           <div key={item.productoId} className="px-3 py-2.5">
-                            <div className="flex justify-between items-center gap-2">
-                              <div className="min-w-0 flex-1">
-                                <div className="flex items-center gap-1.5">
-                                  <p className="font-medium text-sm dark:text-white truncate">{prod?.nombre}</p>
+                            <div className="flex flex-col sm:flex-row sm:justify-between sm:items-center gap-2">
+                              <div className="min-w-0 sm:flex-1">
+                                <div className="flex items-center gap-1.5 flex-wrap">
+                                  <p className="font-medium text-sm dark:text-white sm:truncate break-words">{prod?.nombre}</p>
                                   {esOverride && (
                                     <span className="inline-flex items-center gap-0.5 text-xs px-1.5 py-0.5 bg-orange-100 text-orange-700 rounded-full font-medium shrink-0">
                                       <Pencil className="w-3 h-3" />
@@ -581,7 +581,7 @@ const ModalPedido = memo(function ModalPedido({
                                   <p className="text-xs text-amber-600 mt-0.5">Min: {itemMoq} uds</p>
                                 )}
                               </div>
-                              <div className="flex items-center gap-2 shrink-0">
+                              <div className="flex items-center gap-2 shrink-0 self-end sm:self-auto">
                                 <button onClick={(e) => { e.stopPropagation(); onActualizarCantidad(item.productoId, 0); }} className="p-1 text-red-500 hover:bg-red-50 dark:hover:bg-red-900/20 rounded" title="Eliminar producto"><Trash2 className="w-4 h-4" /></button>
                                 <button onClick={(e) => { e.stopPropagation(); onActualizarCantidad(item.productoId, Math.max(item.cantidad - 1, minCantidad)); }} className={`w-7 h-7 rounded-full text-sm ${item.cantidad <= minCantidad ? 'bg-gray-100 text-gray-400 dark:bg-gray-700' : 'bg-gray-200 hover:bg-gray-300 dark:bg-gray-600 dark:hover:bg-gray-500'}`} disabled={item.cantidad <= minCantidad}>-</button>
                                 <span className="w-6 text-center font-medium text-sm dark:text-white">{item.cantidad}</span>


### PR DESCRIPTION
## Resumen

En el modal **Nuevo Pedido**, en pantallas de celular los controles de la derecha (papelera, `-`, cantidad, `+`, subtotal) le quitaban tanto ancho a la columna del nombre que el producto se truncaba con elipsis (ej. *"AGUA VILLAM…"*) y el usuario no podía saber qué producto cargó.

## Cambio

En [src/components/modals/ModalPedido.tsx:495-593](https://github.com/AgustinReiden/distribuidora-app/blob/claude/great-beaver-218021/src/components/modals/ModalPedido.tsx#L495-L593) la fila ahora se apila verticalmente en mobile y queda horizontal a partir de `sm` (≥ 640 px):

- **Mobile**: nombre + badges arriba ocupando todo el ancho (con `flex-wrap` y `break-words` para envolver nombres largos), precio unitario debajo, y los controles en una segunda fila alineados a la derecha (`self-end`).
- **Desktop**: idéntico al layout actual (nombre + precio a la izquierda, controles a la derecha en la misma fila — el `truncate` original se conserva como `sm:truncate`).

Tres clases tocadas, sin cambios de lógica:
- `flex justify-between items-center gap-2` → `flex flex-col sm:flex-row sm:justify-between sm:items-center gap-2`
- `min-w-0 flex-1` → `min-w-0 sm:flex-1`
- `flex items-center gap-1.5` (badges) → `flex items-center gap-1.5 flex-wrap`
- `truncate` (nombre) → `sm:truncate break-words`
- `flex items-center gap-2 shrink-0` (controles) → `flex items-center gap-2 shrink-0 self-end sm:self-auto`

## Test plan

- [ ] **Mobile** (DevTools, ~375 px): cargar productos con nombres largos. El nombre se ve completo (con wrap si hace falta), sin "…". Los controles bajan a una segunda fila pegados a la derecha.
- [ ] Badges *Manual* / *Mayorista* siguen visibles (probar editando precio como admin y con cliente con lista mayorista).
- [ ] Editor inline de precio (lápiz como admin) entra bien en la fila y no rompe el layout.
- [ ] **Desktop** (≥ 640 px): layout idéntico al actual, sin regresiones.
- [ ] Confirmar pedido y verificar cantidades y subtotales (cambio puramente visual).

🤖 Generated with [Claude Code](https://claude.com/claude-code)