### PR TITLE
fix(ui): ModalBase no se cierra al arrastrar click dentro

### DIFF
--- a/src/components/modals/ModalBase.tsx
+++ b/src/components/modals/ModalBase.tsx
@@ -72,8 +72,20 @@ const ModalBase = memo(function ModalBase({
     <Dialog open={true} onOpenChange={(open) => !open && onClose()}>
       <DialogContent
         className={cn(MAX_WIDTH_MAP[maxWidth] || maxWidth, className)}
+        // Bloqueo defensivo en TODAS las modalidades de cierre por interacción
+        // externa. Radix puede malinterpretar como "outside" cuando el cursor
+        // empieza el click DENTRO y se arrastra fuera (selección de texto,
+        // drag accidental). preventDefault aborta el cierre — el usuario sigue
+        // pudiendo cerrar con Escape o el botón X.
         onPointerDownOutside={(e) => e.preventDefault()}
+        onFocusOutside={(e) => e.preventDefault()}
         onInteractOutside={(e) => e.preventDefault()}
+        // Detiene la propagación de pointerdown/mousedown del propio contenido
+        // hacia los listeners globales del overlay. Sin esto, un click iniciado
+        // dentro del modal cuyo `up` cae fuera puede ser interpretado por
+        // Radix como interacción externa y disparar el cierre.
+        onPointerDown={(e) => e.stopPropagation()}
+        onMouseDown={(e) => e.stopPropagation()}
       >
         <DialogHeader onClose={onClose}>
           <div className="flex items-center justify-between flex-1 gap-3 min-w-0">


### PR DESCRIPTION
## Bug

En el modal "Vincular Telegram" (y cualquier otro que use `ModalBase`), si el usuario hace click dentro del contenido y el cursor termina arrastrado fuera (selección de texto, drag accidental), el modal se cierra. UX confuso reportado al probar la vinculación del bot.

## Causa

Radix Dialog interpreta un click iniciado dentro del contenido pero terminado fuera como interacción externa, dispara `onOpenChange(false)`. El `onPointerDownOutside.preventDefault()` solo cubría el caso donde el pointer-down landea estrictamente fuera.

## Fix

Defensa en profundidad en `src/components/modals/ModalBase.tsx`:
- `onFocusOutside.preventDefault()` para bloquear cierre por foco.
- `onPointerDown` y `onMouseDown` con `stopPropagation()` en el `DialogContent` para que un drag-out-from-inside no escale a los listeners globales del overlay.

El usuario sigue pudiendo cerrar con Escape o el botón X — sin regresión.

## Verificación

- `npm run typecheck` ✓
- `npm run test:run` → 585/585 ✓
- Manual: probar el modal de vincular Telegram, arrastrar click hacia fuera del cuadro, no debería cerrarse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)