### PR TITLE
feat: filtro cancelados en pedidos, fix fecha PDFs y horario en exports

### DIFF
--- a/src/components/containers/PedidosContainer.tsx
+++ b/src/components/containers/PedidosContainer.tsx
@@ -378,7 +378,7 @@ export default function PedidosContainer(): React.ReactElement {
     if (filtros.transportistaId && filtros.transportistaId !== 'todos') query = query.eq('transportista_id', filtros.transportistaId)
     if (filtros.fechaDesde) query = query.gte('fecha', filtros.fechaDesde)
     if (filtros.fechaHasta) query = query.lte('fecha', filtros.fechaHasta)
-    if (!filtros.verCancelados) query = query.neq('estado', 'cancelado')
+    if (!filtros.verCancelados && filtros.estado !== 'cancelado') query = query.neq('estado', 'cancelado')
     if (hasSearch) {
       const trimmed = debouncedBusqueda!.trim()
       query = query.or(

--- a/src/components/pedidos/PedidoFilters.tsx
+++ b/src/components/pedidos/PedidoFilters.tsx
@@ -75,6 +75,7 @@ function PedidoFilters({
             <option value="en_preparacion">En preparacion</option>
             <option value="asignado">En camino</option>
             <option value="entregado">Entregados</option>
+            <option value="cancelado">Cancelados</option>
           </select>
         </div>
         <label className="flex items-center gap-2 px-3 py-2 border rounded-lg cursor-pointer select-none dark:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-700">

--- a/src/hooks/queries/usePedidoStatsQuery.ts
+++ b/src/hooks/queries/usePedidoStatsQuery.ts
@@ -66,7 +66,7 @@ async function fetchPedidoStats(
   if (filters?.fechaHasta) {
     query = query.lte('fecha', filters.fechaHasta)
   }
-  if (!filters?.verCancelados) {
+  if (!filters?.verCancelados && filters?.estado !== 'cancelado') {
     query = query.neq('estado', 'cancelado')
   }
   if (filters?.fechaEntregaProgramada) {

--- a/src/hooks/queries/usePedidosQuery.ts
+++ b/src/hooks/queries/usePedidosQuery.ts
@@ -227,7 +227,7 @@ async function fetchPedidosPaginated(
   if (filters?.fechaHasta) {
     query = query.lte('fecha', filters.fechaHasta)
   }
-  if (!filters?.verCancelados) {
+  if (!filters?.verCancelados && filters?.estado !== 'cancelado') {
     query = query.neq('estado', 'cancelado')
   }
   if (filters?.fechaEntregaProgramada) {

--- a/src/lib/pdf/ordenPreparacion.js
+++ b/src/lib/pdf/ordenPreparacion.js
@@ -23,7 +23,8 @@ import {
 function calcularAltura(pedidos) {
   let totalHeight = 25 // Encabezado inicial
   pedidos.forEach(pedido => {
-    totalHeight += 18 // Cabecera del pedido
+    totalHeight += 18 // Cabecera del pedido (cliente + direccion + telefono)
+    if (pedido.cliente?.horarios_atencion) totalHeight += 3 // Horario
     totalHeight += (pedido.items?.length || 0) * 5 // Productos
     if (pedido.notas) totalHeight += 8
     totalHeight += 5 // Separador
@@ -85,6 +86,12 @@ export function generarOrdenPreparacion(pedidos) {
     // Teléfono
     if (pedido.cliente?.telefono) {
       doc.text(`Tel: ${pedido.cliente.telefono}`, margin, y)
+      y += 3
+    }
+
+    // Horario de atencion
+    if (pedido.cliente?.horarios_atencion) {
+      doc.text(`Hor: ${truncate(pedido.cliente.horarios_atencion, 35)}`, margin, y)
       y += 3
     }
 

--- a/src/lib/pdf/reciboPedido.js
+++ b/src/lib/pdf/reciboPedido.js
@@ -90,12 +90,13 @@ function generarReciboA4(pedido) {
   doc.text('DATOS DEL CLIENTE', margin, y)
   y += 5
 
-  // Caja del cliente
+  // Caja del cliente (alto dinamico si hay horarios)
+  const boxHeight = pedido.cliente?.horarios_atencion ? 36 : 30
   setFillColor(doc, BRAND.warmGray)
-  doc.roundedRect(margin, y - 2, contentWidth, 30, 3, 3, 'F')
+  doc.roundedRect(margin, y - 2, contentWidth, boxHeight, 3, 3, 'F')
   // Borde izquierdo verde
   setFillColor(doc, BRAND.primary)
-  doc.rect(margin, y - 2, 3, 30, 'F')
+  doc.rect(margin, y - 2, 3, boxHeight, 'F')
 
   setTextColor(doc, BRAND.dark)
   doc.setFontSize(14)
@@ -119,9 +120,17 @@ function generarReciboA4(pedido) {
     pedido.cliente?.telefono ? `Tel: ${pedido.cliente.telefono}` : null,
     pedido.cliente?.cuit ? `CUIT: ${pedido.cliente.cuit}` : null
   ].filter(Boolean).join('  |  ')
-  if (contacto) doc.text(contacto, margin + 8, clienteY)
+  if (contacto) {
+    doc.text(contacto, margin + 8, clienteY)
+    clienteY += 5
+  }
+  if (pedido.cliente?.horarios_atencion) {
+    const horarioTxt = `Horario: ${pedido.cliente.horarios_atencion}`
+    const horLine = doc.splitTextToSize(horarioTxt, contentWidth - 16)[0] || horarioTxt
+    doc.text(horLine, margin + 8, clienteY)
+  }
 
-  y += 38
+  y += boxHeight + 8
 
   // === TABLA DE PRODUCTOS ===
   setTextColor(doc, BRAND.primary)
@@ -293,6 +302,7 @@ function calcularAlturaComanda(pedido) {
   const items = pedido.items || []
   let height = 40 // header empresa + nro recibo + fecha
   height += 28 // cliente (nombre + direccion 2 lineas + telefono)
+  if (pedido.cliente?.horarios_atencion) height += 8 // horario (hasta 2 lineas)
   height += 10 // divider + header tabla productos
   height += items.length * 12 // productos (nombre puede envolver + detalle precio unit)
   height += 32 // total + forma pago + estado
@@ -348,6 +358,13 @@ function dibujarComanda(doc, pedido) {
   if (pedido.cliente?.telefono) {
     doc.text(`Tel: ${pedido.cliente.telefono}`, margin, y)
     y += 4
+  }
+  if (pedido.cliente?.horarios_atencion) {
+    const horLines = doc.splitTextToSize(`Hor: ${pedido.cliente.horarios_atencion}`, contentWidth)
+    horLines.slice(0, 2).forEach(line => {
+      doc.text(line, margin, y)
+      y += 4
+    })
   }
   y += 1
 

--- a/src/lib/pdf/utils.js
+++ b/src/lib/pdf/utils.js
@@ -1,6 +1,7 @@
 /**
  * Utilidades compartidas para generación de PDFs
  */
+import { parseDateSafe } from '../../utils/formatters'
 
 const AR_TZ = 'America/Argentina/Buenos_Aires'
 
@@ -18,7 +19,7 @@ export const formatPrecio = (p) =>
  * @returns {string} Fecha formateada
  */
 export const formatFecha = (fecha) =>
-  new Date(fecha || new Date()).toLocaleDateString('es-AR', {
+  parseDateSafe(fecha || new Date()).toLocaleDateString('es-AR', {
     day: '2-digit',
     month: '2-digit',
     year: 'numeric',
@@ -31,7 +32,7 @@ export const formatFecha = (fecha) =>
  * @returns {string} Fecha y hora formateadas
  */
 export const formatFechaHora = (fecha) =>
-  new Date(fecha || new Date()).toLocaleString('es-AR', {
+  parseDateSafe(fecha || new Date()).toLocaleString('es-AR', {
     day: '2-digit',
     month: '2-digit',
     year: 'numeric',

--- a/src/utils/formatters.ts
+++ b/src/utils/formatters.ts
@@ -70,7 +70,7 @@ export function fechaLocalISO(date: Date = new Date()): string {
  * que JavaScript los interprete como UTC medianoche (lo cual causa
  * que se muestre el día anterior en zonas UTC-).
  */
-function parseDateSafe(f: string | Date): Date {
+export function parseDateSafe(f: string | Date): Date {
   if (typeof f === 'string' && /^\d{4}-\d{2}-\d{2}$/.test(f)) {
     return new Date(f + 'T12:00:00')
   }


### PR DESCRIPTION
- pedidos: agrega opcion "Cancelados" al select de estados. La guarda neq('cancelado') ahora respeta el filtro explicito por estado para evitar la contradiccion eq+neq que devolvia vacio. Aplica a la lista, las stats y a las exportaciones (Excel + PDFs).
- pdf/utils: formatFecha/formatFechaHora usan parseDateSafe (exportada desde utils/formatters) para anclar strings YYYY-MM-DD a mediodia local. Arregla el bug por el que la comanda y el recibo A4 mostraban un dia menos cuando pedido.fecha venia como DATE de Postgres (parseado como UTC midnight).
- comanda/recibo A4/orden de preparacion: muestran horarios_atencion del cliente debajo del telefono cuando esta cargado. La caja del cliente A4 y la altura del ticket se ajustan dinamicamente para no romper el layout.