### PR TITLE
fix(bot): repair NL queries + add product discovery (categorias)

### DIFF
--- a/supabase/functions/_shared/gemini/agent.ts
+++ b/supabase/functions/_shared/gemini/agent.ts
@@ -46,17 +46,18 @@ import type { ToolContext } from "../tools/base.ts";
 
 /**
  * Cap del loop de tool-calls. Configurable via env var `BOT_MAX_TOOL_ITERATIONS`
- * (entero entre 1 y 20). Default 5 — suficiente para la mayoría de los flows
- * y bajo enough para que un loop infinito del modelo no explote latencia ni
- * costo. Subir a 7-10 si vemos hit_max_iterations frecuentes en producción.
+ * (entero entre 1 y 20). Default 8 — sube de 5 para acomodar flujos multi-tool
+ * que ahora son explícitos en los prompts (listar_categorias →
+ * productos_por_categoria → eventual fallback con sinónimo). Bajo enough
+ * para que un loop infinito del modelo no explote latencia ni costo.
  */
 function getMaxToolIterations(): number {
   const raw = Deno.env.get("BOT_MAX_TOOL_ITERATIONS");
-  if (!raw) return 5;
+  if (!raw) return 8;
   const n = parseInt(raw, 10);
   // Out-of-range / NaN → default. No queremos que un typo en el secret deje
   // el bot con MAX=0 (no responde) o MAX=1000 (loops gigantes).
-  if (!Number.isFinite(n) || n < 1 || n > 20) return 5;
+  if (!Number.isFinite(n) || n < 1 || n > 20) return 8;
   return n;
 }
 

--- a/supabase/functions/_shared/gemini/prompts/admin.ts
+++ b/supabase/functions/_shared/gemini/prompts/admin.ts
@@ -1,4 +1,9 @@
-Sos el asistente IA de la distribuidora.
+// System prompt para rol admin. Embebido como módulo TS (no .txt) para que
+// el bundle de Supabase Edge Functions lo incluya — Deno.readTextFile sobre
+// import.meta.url falla en el runtime deployado porque los assets no-TS no
+// se copian al sandbox.
+
+const prompt = `Sos el asistente IA de la distribuidora.
 
 El usuario actual es ADMIN. Tiene acceso a información de las sucursales asignadas a su cuenta. Por defecto operás sobre la sucursal default del admin; si el admin no tiene sucursal asignada, podés ver todas las que correspondan.
 
@@ -18,3 +23,6 @@ REGLAS:
 7. Formato de respuestas: Telegram, sin Markdown excesivo. Bullets cortos OK, headers gigantes no. Los montos en pesos van con el símbolo $ y separadores de miles si es legible (ej: $12.500).
 
 Si el usuario te pregunta algo fuera de tu alcance actual (mandar mensajes, modificar pedidos, dar de alta clientes, generar reportes complejos), aclarale que en esta versión solo podés consultar información, y sugerile el comando o la pantalla de la app web que aplique.
+`;
+
+export default prompt;

--- a/supabase/functions/_shared/gemini/prompts/admin.ts
+++ b/supabase/functions/_shared/gemini/prompts/admin.ts
@@ -23,6 +23,22 @@ REGLAS:
 7. Formato de respuestas: Telegram, sin Markdown excesivo. Bullets cortos OK, headers gigantes no. Los montos en pesos van con el símbolo $ y separadores de miles si es legible (ej: $12.500).
 
 Si el usuario te pregunta algo fuera de tu alcance actual (mandar mensajes, modificar pedidos, dar de alta clientes, generar reportes complejos), aclarale que en esta versión solo podés consultar información, y sugerile el comando o la pantalla de la app web que aplique.
+
+ESTRATEGIA DE BÚSQUEDA DE PRODUCTOS POR TIPO O FAMILIA:
+- buscar_producto solo matchea substrings literales en nombre y código. Si el usuario pide un TIPO o FAMILIA (ej: "gaseosas", "fideos", "aguas", "cervezas", "bebidas con sabor naranja"), buscar_producto va a fallar — encadená tools.
+- Paso 1: llamá a listar_categorias para ver las categorías reales (vienen del catálogo, en mayúsculas y a veces con variantes históricas tipo "FIDEOS"/"FIDEO" o "AGUAS"/"AGUAS SABORIZADAS").
+- Paso 2: llamá a productos_por_categoria con la categoría más probable. Si el usuario mencionó un atributo (sabor, marca, tamaño), pasalo en el parámetro \`q\` para filtrar dentro de la categoría.
+- Paso 3: respondé con la lista (nombre + precio + stock si es relevante) o avisá honestamente que no hay coincidencias.
+
+EJEMPLO ("qué gaseosas naranjas hay"):
+  1. listar_categorias → ves "GASEOSAS", "AGUAS", "FIDEOS", ...
+  2. productos_por_categoria(categoria="GASEOSAS", q="naranja")
+  3. Si hay resultados, listalos. Si no, ofrecé listar todas las gaseosas o probar otra categoría.
+
+QUÉ HACER ANTE 0 RESULTADOS:
+- Antes de decir "no encontré nada", probá UNA variante razonable: cambiar la categoría a una parecida (si "AGUAS" no tuvo, probá "AGUAS SABORIZADAS"), o quitar el calificativo del \`q\` para listar la categoría completa. Máximo dos intentos — después preguntale al usuario.
+- Si tras 1-2 intentos sigue sin haber resultados, decilo con honestidad y ofrecé qué hacer (ej: "no encontré gaseosas con 'naranja' en el nombre, ¿querés que liste todas las gaseosas?").
+- Nunca inventes productos.
 `;
 
 export default prompt;

--- a/supabase/functions/_shared/gemini/prompts/base.ts
+++ b/supabase/functions/_shared/gemini/prompts/base.ts
@@ -1,36 +1,44 @@
 // Carga de system prompts por rol.
 //
-// Los prompts viven como archivos .txt al lado de este módulo. Razón: son
-// texto largo, los queremos editar sin tocar código TS, y mantenerlos fuera
-// del bundle hace los diffs más legibles. En Deno los .txt no se importan
-// como módulos, así que los leemos con `Deno.readTextFile` resolviendo
-// `import.meta.url`. Los prompts pesan pocos KB, los cacheamos en memoria
-// tras la primera lectura.
+// Los prompts se embeben como módulos TS (uno por rol) y se importan
+// estáticamente. Razón: en el deploy de Supabase Edge Functions el bundler
+// solo incluye archivos TS/JS, así que un Deno.readTextFile sobre un .txt
+// resuelto via import.meta.url falla con "path not found" en producción.
+// Los .ts viajan en el bundle siempre — esto es portable, type-safe y
+// elimina permisos de --allow-read en runtime.
 //
-// El cache es per-isolate. En edge functions el isolate persiste warm entre
-// invocations del mismo deploy, así que los prompts se leen del FS solo en el
-// primer cold start. Reset manual disponible para tests via
-// `clearSystemPromptCache`.
+// API pública (`getSystemPrompt`, `setSystemPromptForTests`,
+// `clearSystemPromptCache`) se mantiene compatible con los call sites previos
+// para no romper tests ni callers.
 
 import type { BotRol } from "../../types.ts";
+import adminPrompt from "./admin.ts";
+import preventistaPrompt from "./preventista.ts";
+import transportistaPrompt from "./transportista.ts";
+import encargadoPrompt from "./encargado.ts";
+import depositoPrompt from "./deposito.ts";
 
-const PROMPTS = new Map<BotRol, string>();
+const DEFAULTS: Record<BotRol, string> = {
+  admin: adminPrompt,
+  preventista: preventistaPrompt,
+  transportista: transportistaPrompt,
+  encargado: encargadoPrompt,
+  deposito: depositoPrompt,
+};
 
-async function loadPromptOnce(rol: BotRol): Promise<string> {
-  const cached = PROMPTS.get(rol);
-  if (cached !== undefined) return cached;
-  const url = new URL(`./${rol}.txt`, import.meta.url);
-  const text = await Deno.readTextFile(url);
-  PROMPTS.set(rol, text);
-  return text;
-}
+// Overrides aplicables solo desde tests via setSystemPromptForTests.
+const OVERRIDES = new Map<BotRol, string>();
 
 /**
- * Carga el system prompt para el rol del usuario.
- * Cachea en memoria — los prompts son estáticos.
+ * Carga el system prompt para el rol del usuario. Async por compat con la
+ * implementación previa basada en FS — el contenido viene de un módulo
+ * importado estáticamente, no se va al disco.
  */
+// deno-lint-ignore require-await
 export async function getSystemPrompt(rol: BotRol): Promise<string> {
-  return await loadPromptOnce(rol);
+  const override = OVERRIDES.get(rol);
+  if (override !== undefined) return override;
+  return DEFAULTS[rol];
 }
 
 // ----------------------------------------------------------------------------
@@ -39,10 +47,14 @@ export async function getSystemPrompt(rol: BotRol): Promise<string> {
 
 /** Override del prompt en memoria. Útil para tests sin tocar el FS. */
 export function setSystemPromptForTests(rol: BotRol, text: string): void {
-  PROMPTS.set(rol, text);
+  OVERRIDES.set(rol, text);
 }
 
-/** Limpia el cache. Llamar entre tests para evitar bleed. */
+/**
+ * Limpia los overrides de tests. El nombre se mantiene por compat con los
+ * tests existentes — ya no hay un "cache" propiamente dicho, los defaults
+ * son constantes inmutables del módulo.
+ */
 export function clearSystemPromptCache(): void {
-  PROMPTS.clear();
+  OVERRIDES.clear();
 }

--- a/supabase/functions/_shared/gemini/prompts/deposito.ts
+++ b/supabase/functions/_shared/gemini/prompts/deposito.ts
@@ -18,6 +18,12 @@ REGLAS:
 6. Formato Telegram: bullets cortos, sin Markdown pesado.
 
 Mensaje claro cuando te pidan algo fuera de scope: "Para esta versión solo puedo buscar productos. Para [stock/pedidos pendientes/marcar armado] coordiná con el encargado o usá la app correspondiente." Sin disculpas largas, directo.
+
+BÚSQUEDA DE PRODUCTOS POR TIPO O FAMILIA:
+- buscar_producto solo matchea substrings de nombre/código. Si te piden un tipo ("gaseosas", "fideos", "aguas"), encadená:
+  1. listar_categorias → ves las categorías reales (mayúsculas, ej: "GASEOSAS", "FIDEOS").
+  2. productos_por_categoria(categoria=..., q="atributo") si mencionaron sabor/marca.
+- Si no hay matches, probá UNA variante razonable. Si sigue vacío, decilo con honestidad. No inventes productos.
 `;
 
 export default prompt;

--- a/supabase/functions/_shared/gemini/prompts/deposito.ts
+++ b/supabase/functions/_shared/gemini/prompts/deposito.ts
@@ -1,4 +1,7 @@
-Sos el asistente IA de la distribuidora.
+// System prompt para rol deposito. Embebido como módulo TS — ver admin.ts
+// para el motivo.
+
+const prompt = `Sos el asistente IA de la distribuidora.
 
 El usuario actual está en DEPÓSITO. Su trabajo es preparar pedidos y manejar stock. En esta versión las tools disponibles para depósito son MUY ACOTADAS — solo búsqueda de productos del catálogo de la sucursal. El resto (consultar stock detallado, marcar productos como armados, registrar faltantes) viene en la próxima fase.
 
@@ -15,3 +18,6 @@ REGLAS:
 6. Formato Telegram: bullets cortos, sin Markdown pesado.
 
 Mensaje claro cuando te pidan algo fuera de scope: "Para esta versión solo puedo buscar productos. Para [stock/pedidos pendientes/marcar armado] coordiná con el encargado o usá la app correspondiente." Sin disculpas largas, directo.
+`;
+
+export default prompt;

--- a/supabase/functions/_shared/gemini/prompts/digest_admin.ts
+++ b/supabase/functions/_shared/gemini/prompts/digest_admin.ts
@@ -1,4 +1,7 @@
-Sos analista ejecutivo de la distribuidora. Vas a recibir un JSON con métricas operativas del día anterior.
+// System prompt para el digest ejecutivo diario del admin. Embebido como
+// módulo TS — ver admin.ts para el motivo.
+
+const prompt = `Sos analista ejecutivo de la distribuidora. Vas a recibir un JSON con métricas operativas del día anterior.
 
 Tu trabajo: redactar un mensaje breve para Telegram (máx 1500 caracteres en plain text, sin Markdown excesivo, sin headers grandes — viñetas y números crudos están bien) que resuma lo importante para el admin que va a leerlo en su celular a las 7 AM.
 
@@ -21,3 +24,6 @@ EJEMPLO de buen output:
 • Stock crítico: 4 productos bajo mínimo (Coca 2.25L, Yerba 1Kg, Aceite girasol, Harina 000).
 • Deuda vencida: $89.300 en 6 pedidos > 30 días.
 • Acción sugerida: revisar la rendición de Juan Pérez del lunes (sin controlar hace 4 días)."
+`;
+
+export default prompt;

--- a/supabase/functions/_shared/gemini/prompts/encargado.ts
+++ b/supabase/functions/_shared/gemini/prompts/encargado.ts
@@ -1,4 +1,7 @@
-Sos el asistente IA de la distribuidora.
+// System prompt para rol encargado. Embebido como módulo TS — ver admin.ts
+// para el motivo.
+
+const prompt = `Sos el asistente IA de la distribuidora.
 
 El usuario actual es ENCARGADO de sucursal. Tiene visibilidad de todos los clientes, productos y pedidos de SU sucursal (no de otras). Operás siempre con el filtro de sucursal del encargado — si te pregunta por algo de otra sucursal, aclarale que solo ves la suya.
 
@@ -18,3 +21,6 @@ REGLAS:
 7. Formato Telegram: bullets cortos, sin headers grandes. Montos con $ y separadores de miles (ej: $12.500).
 
 Esta versión es acotada — todavía no podés generar reportes complejos, modificar datos, asignar preventistas a clientes ni operar sobre otras sucursales. Si te lo piden, decile que use la app web. En las próximas versiones se van a sumar más capacidades para encargado.
+`;
+
+export default prompt;

--- a/supabase/functions/_shared/gemini/prompts/encargado.ts
+++ b/supabase/functions/_shared/gemini/prompts/encargado.ts
@@ -21,6 +21,22 @@ REGLAS:
 7. Formato Telegram: bullets cortos, sin headers grandes. Montos con $ y separadores de miles (ej: $12.500).
 
 Esta versión es acotada — todavía no podés generar reportes complejos, modificar datos, asignar preventistas a clientes ni operar sobre otras sucursales. Si te lo piden, decile que use la app web. En las próximas versiones se van a sumar más capacidades para encargado.
+
+ESTRATEGIA DE BÚSQUEDA DE PRODUCTOS POR TIPO O FAMILIA:
+- buscar_producto solo matchea substrings literales en nombre y código. Si el usuario pide un tipo o familia ("gaseosas", "fideos", "aguas", "cervezas", "bebidas naranjas"), encadená tools.
+- Paso 1: listar_categorias para ver las categorías reales del catálogo (en MAYÚSCULAS, con variantes históricas tipo "FIDEOS"/"FIDEO" o "AGUAS"/"AGUAS SABORIZADAS").
+- Paso 2: productos_por_categoria con la categoría más probable. Si hay un atributo (sabor, marca, tamaño), pasalo en \`q\`.
+- Paso 3: respondé con nombre + precio + stock cuando aplique, o un "no hay" honesto.
+
+EJEMPLO ("qué gaseosas naranjas hay"):
+  1. listar_categorias → ves "GASEOSAS", "AGUAS", "FIDEOS", ...
+  2. productos_por_categoria(categoria="GASEOSAS", q="naranja")
+  3. Listá los matches o avisá que no hay.
+
+QUÉ HACER ANTE 0 RESULTADOS:
+- Probá UNA variante razonable (categoría parecida, o quitar el \`q\` para listar la categoría completa). Máximo dos intentos.
+- Si sigue vacío, decilo con honestidad y ofrecé alternativas concretas ("no encontré 'naranja' en gaseosas, ¿querés que liste todas las gaseosas?").
+- Nunca inventes productos.
 `;
 
 export default prompt;

--- a/supabase/functions/_shared/gemini/prompts/preventista.ts
+++ b/supabase/functions/_shared/gemini/prompts/preventista.ts
@@ -1,4 +1,7 @@
-Sos el asistente IA de la distribuidora.
+// System prompt para rol preventista. Embebido como módulo TS — ver admin.ts
+// para el motivo (los .txt no se incluyen en el bundle de Edge Functions).
+
+const prompt = `Sos el asistente IA de la distribuidora.
 
 El usuario actual es PREVENTISTA. Solo ve los clientes que le están asignados a él (no la totalidad de la cartera). Esto es importante: si te pregunta por un cliente que no es suyo, las tools van a devolver "Cliente no encontrado o sin permiso" — explicale eso textualmente, NO asumas que el cliente no existe en el sistema. Sugerile contactar al encargado o admin si necesita acceso.
 
@@ -13,9 +16,12 @@ REGLAS:
 2. Si una tool falla, decí el motivo y ofrecé alternativa concreta (ej: "no pude abrir la ficha, probá con /cliente <código>").
 3. Hablá en español rioplatense, voseo, conciso. Las respuestas deben ser breves — el preventista las lee en la calle, en el celular.
 4. Usá el nombre del cliente, NUNCA el ID interno.
-5. Si te pide "mis clientes con deuda" o "clientes que no compraron en X días", llamá a `mis_clientes` con los filtros que correspondan.
-5b. Si te pide sugerencias proactivas tipo "a quién visito hoy", "priorizá mi ruta" o "qué clientes están atrasados", llamá a `sugerir_visitas_rfm` y armá una respuesta narrativa con los top clientes y sus motivos.
+5. Si te pide "mis clientes con deuda" o "clientes que no compraron en X días", llamá a \`mis_clientes\` con los filtros que correspondan.
+5b. Si te pide sugerencias proactivas tipo "a quién visito hoy", "priorizá mi ruta" o "qué clientes están atrasados", llamá a \`sugerir_visitas_rfm\` y armá una respuesta narrativa con los top clientes y sus motivos.
 6. Para preguntas que NO requieren tool (saludo, ayuda general), respondé directo.
 7. Formato Telegram: bullets cortos sí, headers gigantes no. Montos con $ y separadores de miles (ej: $12.500).
 
 Lo que NO podés hacer en esta versión: tomar pedidos, registrar visitas, modificar datos del cliente. Si te lo piden, decile que use la app web o el flujo habitual; vos solo consultás.
+`;
+
+export default prompt;

--- a/supabase/functions/_shared/gemini/prompts/preventista.ts
+++ b/supabase/functions/_shared/gemini/prompts/preventista.ts
@@ -22,6 +22,22 @@ REGLAS:
 7. Formato Telegram: bullets cortos sí, headers gigantes no. Montos con $ y separadores de miles (ej: $12.500).
 
 Lo que NO podés hacer en esta versión: tomar pedidos, registrar visitas, modificar datos del cliente. Si te lo piden, decile que use la app web o el flujo habitual; vos solo consultás.
+
+ESTRATEGIA DE BÚSQUEDA DE PRODUCTOS POR TIPO O FAMILIA:
+- buscar_producto solo matchea substrings literales en nombre y código. Si el usuario pide un tipo o familia ("gaseosas", "aguas", "fideos", "bebidas naranjas"), buscar_producto va a fallar — encadená tools.
+- Paso 1: listar_categorias para ver las categorías reales del catálogo (en MAYÚSCULAS, a veces con variantes tipo "FIDEOS"/"FIDEO").
+- Paso 2: productos_por_categoria con la categoría más probable. Si el usuario mencionó un atributo (sabor, marca), pasalo como \`q\` para filtrar dentro.
+- Paso 3: contestá con nombre + precio (lo que el cliente te va a pedir en la calle).
+
+EJEMPLO ("qué gaseosas naranjas hay"):
+  1. listar_categorias → "GASEOSAS", "AGUAS", "FIDEOS", ...
+  2. productos_por_categoria(categoria="GASEOSAS", q="naranja")
+  3. Listá los matches o avisá que no hay.
+
+QUÉ HACER ANTE 0 RESULTADOS:
+- Probá UNA variante razonable: otra categoría parecida o quitar el calificativo del \`q\` para listar toda la categoría. Máximo dos intentos.
+- Después decilo con honestidad y ofrecé qué hacer ("no encontré 'naranja' en gaseosas, ¿querés que liste todas las gaseosas?").
+- Nunca inventes productos.
 `;
 
 export default prompt;

--- a/supabase/functions/_shared/gemini/prompts/transportista.ts
+++ b/supabase/functions/_shared/gemini/prompts/transportista.ts
@@ -20,6 +20,12 @@ REGLAS:
 7. Formato Telegram: bullets cortos, sin Markdown pesado. Direcciones y nombres tal cual vienen, sin acortar.
 
 Lo que NO podés hacer en esta versión: registrar entregas, marcar como pagado, mover pedidos, generar comprobantes. Si te lo piden, aclarale que use la app de transportista o pase por el flujo habitual; vos solo consultás.
+
+BÚSQUEDA DE PRODUCTOS POR TIPO:
+- buscar_producto solo matchea substrings de nombre/código. Si el cliente o vos preguntan por un tipo ("gaseosas", "aguas", "fideos"), encadená:
+  1. listar_categorias → ves las categorías reales (mayúsculas, ej: "GASEOSAS").
+  2. productos_por_categoria(categoria=..., q="atributo") si hay sabor/marca.
+- Si no hay matches, probá UNA variante razonable y si sigue vacío decilo con honestidad. No inventes productos.
 `;
 
 export default prompt;

--- a/supabase/functions/_shared/gemini/prompts/transportista.ts
+++ b/supabase/functions/_shared/gemini/prompts/transportista.ts
@@ -1,6 +1,9 @@
-Sos el asistente IA de la distribuidora.
+// System prompt para rol transportista. Embebido como módulo TS — ver
+// admin.ts para el motivo.
 
-El usuario actual es TRANSPORTISTA. Su trabajo es entregar los pedidos del recorrido del día. Cuando el transportista te hable de "los pedidos", "el recorrido", "lo que tengo hoy", asumí por default que se refiere al recorrido del día actual y llamá a `mi_recorrido_hoy`.
+const prompt = `Sos el asistente IA de la distribuidora.
+
+El usuario actual es TRANSPORTISTA. Su trabajo es entregar los pedidos del recorrido del día. Cuando el transportista te hable de "los pedidos", "el recorrido", "lo que tengo hoy", asumí por default que se refiere al recorrido del día actual y llamá a \`mi_recorrido_hoy\`.
 
 Tu trabajo es ayudar al transportista a:
 - Ver su recorrido del día (pedidos asignados, orden de entrega, dirección, total, estado de pago).
@@ -17,3 +20,6 @@ REGLAS:
 7. Formato Telegram: bullets cortos, sin Markdown pesado. Direcciones y nombres tal cual vienen, sin acortar.
 
 Lo que NO podés hacer en esta versión: registrar entregas, marcar como pagado, mover pedidos, generar comprobantes. Si te lo piden, aclarale que use la app de transportista o pase por el flujo habitual; vos solo consultás.
+`;
+
+export default prompt;

--- a/supabase/functions/_shared/tools/common/listar_categorias.ts
+++ b/supabase/functions/_shared/tools/common/listar_categorias.ts
@@ -1,0 +1,83 @@
+// Tool: listar_categorias
+//
+// Devuelve la lista de categorías distintas presentes en productos de la
+// sucursal actual. Pensada para ser la PRIMERA llamada cuando el usuario
+// pregunta por un tipo o familia de productos ("gaseosas", "fideos", "aguas")
+// — el LLM la usa para descubrir las categorías reales (que son free-form
+// text en BD, en mayúsculas y con variantes históricas) antes de filtrar
+// con productos_por_categoria.
+//
+// No usa la tabla `categorias` (migration 009) — esa es backfill estática
+// y no se mantiene en sync con productos.categoria. Ir directo a productos.
+//
+// Implementación: select de la columna categoria + scoping por sucursal,
+// dedupe + filter de null/"" en JS. Se podría hacer DISTINCT en SQL, pero
+// supabase-js no expone DISTINCT y armar un RPC custom para esto sería
+// over-engineering — el catálogo por sucursal pesa cientos de filas, no
+// decenas de miles, así que dedupe en memoria es trivial.
+
+import type { Tool } from "../base.ts";
+
+export interface ListarCategoriasParams {
+  // Sin parámetros — la sucursal viene del ctx.
+  [k: string]: never;
+}
+
+export interface ListarCategoriasResult {
+  total: number;
+  categorias: string[];
+}
+
+interface CategoriaRow {
+  categoria: string | null;
+}
+
+export const listarCategoriasTool: Tool<
+  ListarCategoriasParams,
+  ListarCategoriasResult
+> = {
+  name: "listar_categorias",
+  description:
+    "Devuelve la lista de categorías de productos disponibles en la sucursal actual. " +
+    "Usala como PRIMERA llamada cuando el usuario pregunta por un tipo o familia de " +
+    "productos (ej: 'gaseosas', 'fideos', 'aguas') — primero descubrí qué categorías " +
+    "existen, después usá productos_por_categoria con la más probable.",
+  parameters: { type: "object", properties: {}, required: [] },
+  allowedRoles: ["admin", "preventista", "transportista", "encargado", "deposito"],
+  handler: async (_params, ctx) => {
+    // Multi-tenancy guard idéntico al resto de tools comunes: solo admin
+    // puede operar sin sucursal asignada.
+    if (ctx.sucursal_id == null && ctx.rol !== "admin") {
+      throw new Error(
+        "Sucursal no asignada en bot_usuarios — contactá al administrador",
+      );
+    }
+
+    const sb = ctx.supabase;
+    let query = sb.from("productos")
+      .select("categoria")
+      .order("categoria", { ascending: true });
+
+    if (ctx.sucursal_id != null) {
+      query = query.eq("sucursal_id", ctx.sucursal_id);
+    }
+
+    const { data, error } = await query;
+    if (error) {
+      throw new Error(`listar_categorias: ${error.message}`);
+    }
+
+    const rows = (data ?? []) as unknown as CategoriaRow[];
+    const seen = new Set<string>();
+    const unique: string[] = [];
+    for (const row of rows) {
+      const c = row.categoria;
+      if (typeof c === "string" && c.trim() !== "" && !seen.has(c)) {
+        seen.add(c);
+        unique.push(c);
+      }
+    }
+
+    return { total: unique.length, categorias: unique };
+  },
+};

--- a/supabase/functions/_shared/tools/common/productos_por_categoria.ts
+++ b/supabase/functions/_shared/tools/common/productos_por_categoria.ts
@@ -1,0 +1,152 @@
+// Tool: productos_por_categoria
+//
+// Lista productos filtrados por categoría exacta (case-insensitive) con un
+// `q` opcional para refinar dentro de la categoría por nombre/código.
+// Pensada para usarse después de listar_categorias: el LLM descubre la
+// categoría real ("GASEOSAS"), y entonces filtra por ella + atributo del
+// usuario ("naranja", "mendocino", etc).
+//
+// Patrón calcado de buscar_producto.ts: mismo shape de salida, mismo
+// escape de metacaracteres PostgREST en `q`, mismo guard de sucursal.
+
+import type { Tool } from "../base.ts";
+
+export interface ProductosPorCategoriaParams {
+  categoria: string;
+  q?: string;
+  limit?: number;
+}
+
+export interface ProductosPorCategoriaResult {
+  total: number;
+  categoria: string;
+  productos: Array<{
+    id: number;
+    codigo: string | null;
+    nombre: string;
+    precio: number;
+    stock: number;
+    stock_minimo: number;
+    bajo_stock: boolean;
+    categoria: string | null;
+  }>;
+}
+
+interface ProductoRow {
+  id: number;
+  codigo: string | null;
+  nombre: string;
+  precio: number | string | null;
+  stock: number | null;
+  stock_minimo: number | null;
+  categoria: string | null;
+}
+
+export const productosPorCategoriaTool: Tool<
+  ProductosPorCategoriaParams,
+  ProductosPorCategoriaResult
+> = {
+  name: "productos_por_categoria",
+  description:
+    "Lista productos de una categoría dada en la sucursal actual. La categoría " +
+    "se matchea case-insensitive contra productos.categoria. Opcionalmente " +
+    "filtra dentro de la categoría con `q` (ILIKE sobre nombre/código). Llamala " +
+    "DESPUÉS de listar_categorias cuando el usuario pidió un tipo o familia de " +
+    "producto (ej: 'gaseosas naranjas' → categoria='GASEOSAS', q='naranja').",
+  parameters: {
+    type: "object",
+    properties: {
+      categoria: {
+        type: "string",
+        description:
+          "Nombre de la categoría tal como vino de listar_categorias " +
+          "(case-insensitive — el matching no distingue mayúsculas).",
+      },
+      q: {
+        type: "string",
+        description:
+          "Texto opcional para refinar dentro de la categoría — matchea ILIKE " +
+          "contra nombre y código del producto. Útil para 'sabor naranja', 'marca X'.",
+      },
+      limit: {
+        type: "integer",
+        minimum: 1,
+        maximum: 25,
+        description: "Cantidad máxima de resultados (default 10, máx 25).",
+      },
+    },
+    required: ["categoria"],
+  },
+  allowedRoles: ["admin", "preventista", "transportista", "encargado", "deposito"],
+  handler: async ({ categoria, q, limit = 10 }, ctx) => {
+    if (typeof categoria !== "string") {
+      throw new Error("Parámetro 'categoria' debe ser texto");
+    }
+    const cat = categoria.trim();
+    if (cat.length === 0) {
+      throw new Error("Categoría vacía");
+    }
+    if (!Number.isFinite(limit) || limit < 1 || limit > 25) {
+      throw new Error("Límite fuera de rango (1-25)");
+    }
+
+    if (ctx.sucursal_id == null && ctx.rol !== "admin") {
+      throw new Error(
+        "Sucursal no asignada en bot_usuarios — contactá al administrador",
+      );
+    }
+
+    const sb = ctx.supabase;
+
+    // Escape de metacaracteres PostgREST. Se aplica a la categoría (que
+    // entra al ilike) y al q (que entra al .or() con ILIKE doble). Mismo
+    // set que buscar_producto / buscar_cliente.
+    const escapeFilter = (s: string) => s.replace(/[%_,()\.:]/g, "\\$&");
+
+    let query = sb.from("productos")
+      .select(
+        "id, codigo, nombre, precio, stock, stock_minimo, categoria, sucursal_id",
+        { count: "exact" },
+      )
+      .ilike("categoria", escapeFilter(cat))
+      .order("nombre", { ascending: true })
+      .limit(limit);
+
+    if (ctx.sucursal_id != null) {
+      query = query.eq("sucursal_id", ctx.sucursal_id);
+    }
+
+    if (typeof q === "string" && q.trim().length > 0) {
+      const escaped = escapeFilter(q.trim());
+      query = query.or(
+        `nombre.ilike.%${escaped}%,codigo.ilike.%${escaped}%`,
+      );
+    }
+
+    const { data, error, count } = await query;
+    if (error) {
+      throw new Error(`productos_por_categoria: ${error.message}`);
+    }
+
+    const rows = (data ?? []) as unknown as ProductoRow[];
+
+    return {
+      total: count ?? rows.length,
+      categoria: cat,
+      productos: rows.map((p) => {
+        const stock = Number(p.stock ?? 0);
+        const stockMin = Number(p.stock_minimo ?? 0);
+        return {
+          id: Number(p.id),
+          codigo: p.codigo ?? null,
+          nombre: p.nombre,
+          precio: Number(p.precio ?? 0),
+          stock,
+          stock_minimo: stockMin,
+          bajo_stock: stock <= stockMin,
+          categoria: p.categoria ?? null,
+        };
+      }),
+    };
+  },
+};

--- a/supabase/functions/_shared/tools/index.ts
+++ b/supabase/functions/_shared/tools/index.ts
@@ -10,6 +10,8 @@ import { registerTool } from "./registry.ts";
 import { buscarClienteTool } from "./common/buscar_cliente.ts";
 import { buscarProductoTool } from "./common/buscar_producto.ts";
 import { fichaClienteTool } from "./common/ficha_cliente.ts";
+import { listarCategoriasTool } from "./common/listar_categorias.ts";
+import { productosPorCategoriaTool } from "./common/productos_por_categoria.ts";
 import { misClientesTool } from "./preventista/mis_clientes.ts";
 import { sugerirVisitasRfmTool } from "./preventista/sugerir_visitas_rfm.ts";
 import { miRecorridoHoyTool } from "./transportista/mi_recorrido_hoy.ts";
@@ -21,6 +23,8 @@ export function registerAllTools(): void {
   registerTool(buscarClienteTool);
   registerTool(buscarProductoTool);
   registerTool(fichaClienteTool);
+  registerTool(listarCategoriasTool);
+  registerTool(productosPorCategoriaTool);
   registerTool(misClientesTool);
   registerTool(sugerirVisitasRfmTool);
   registerTool(miRecorridoHoyTool);

--- a/supabase/functions/telegram-digest/digest.ts
+++ b/supabase/functions/telegram-digest/digest.ts
@@ -24,6 +24,7 @@ import { callGemini } from "../_shared/gemini/client.ts";
 import { sendMessage } from "../_shared/telegram.ts";
 import { logEvent } from "../_shared/audit.ts";
 import { isTextPart } from "../_shared/gemini/types.ts";
+import digestAdminPrompt from "../_shared/gemini/prompts/digest_admin.ts";
 
 export interface DigestArgs {
   telegram_user_id: number;
@@ -38,27 +39,23 @@ export interface DigestResult {
   reason?: string;
 }
 
-// Cache en memoria del prompt (per-isolate, mismo patrón que prompts/base.ts).
-let _cachedDigestPrompt: string | null = null;
+// Override de tests (null = usar el módulo importado estáticamente). Mantiene
+// el patrón de los seams previos: nombres y semántica intactos para no romper
+// los tests existentes.
+let _digestPromptOverride: string | null = null;
 
-async function getDigestPrompt(): Promise<string> {
-  if (_cachedDigestPrompt !== null) return _cachedDigestPrompt;
-  const url = new URL(
-    "../_shared/gemini/prompts/digest_admin.txt",
-    import.meta.url,
-  );
-  _cachedDigestPrompt = await Deno.readTextFile(url);
-  return _cachedDigestPrompt;
+function getDigestPrompt(): string {
+  return _digestPromptOverride ?? digestAdminPrompt;
 }
 
-/** Test seam: limpia el cache del prompt entre tests. */
+/** Test seam: limpia el override del prompt entre tests. */
 export function _clearDigestPromptCacheForTests(): void {
-  _cachedDigestPrompt = null;
+  _digestPromptOverride = null;
 }
 
-/** Test seam: setea el prompt sin tocar el FS. */
+/** Test seam: setea el prompt sin tocar el módulo. */
 export function _setDigestPromptForTests(text: string): void {
-  _cachedDigestPrompt = text;
+  _digestPromptOverride = text;
 }
 
 /**
@@ -102,7 +99,7 @@ export async function runDigestForAdmin(
   // 2. Prompt + 3. Gemini.
   let texto: string;
   try {
-    const systemPrompt = await getDigestPrompt();
+    const systemPrompt = getDigestPrompt();
     const userMessage = `Métricas del ${fecha} (sucursal ${sucursal_id ?? "todas"}):\n\n${
       JSON.stringify(metricas, null, 2)
     }`;

--- a/supabase/functions/tests/agent.test.ts
+++ b/supabase/functions/tests/agent.test.ts
@@ -463,8 +463,11 @@ Deno.test("runAgent max iterations: tool calls infinitos → hitMaxIterations tr
   };
   registerTool(loopTool);
 
-  // Programamos MAX_TOOL_ITERATIONS=5 respuestas, todas con functionCall.
-  const responses = Array.from({ length: 5 }, () => ({
+  // Programamos MAX_TOOL_ITERATIONS=8 respuestas (default actual), todas con
+  // functionCall. La constante se lee del env var en module init de agent.ts,
+  // así que el test usa el default. Si más adelante se quiere parametrizar
+  // por test, hay que reestructurar agent.ts para leer per-call.
+  const responses = Array.from({ length: 8 }, () => ({
     candidates: [
       {
         content: {
@@ -487,9 +490,9 @@ Deno.test("runAgent max iterations: tool calls infinitos → hitMaxIterations tr
     });
 
     assertEquals(result.hitMaxIterations, true);
-    assertEquals(result.iterations, 5);
-    assertEquals(result.toolCallsCount, 5);
-    assertEquals(result.totalTokens, 50);
+    assertEquals(result.iterations, 8);
+    assertEquals(result.toolCallsCount, 8);
+    assertEquals(result.totalTokens, 80);
     assertStringIncludes(result.text, "complejo");
 
     // Audit: tipo='error' con hit_max_iterations=true.

--- a/supabase/functions/tests/tools.test.ts
+++ b/supabase/functions/tests/tools.test.ts
@@ -29,6 +29,8 @@ import {
 import { buscarClienteTool } from "../_shared/tools/common/buscar_cliente.ts";
 import { buscarProductoTool } from "../_shared/tools/common/buscar_producto.ts";
 import { fichaClienteTool } from "../_shared/tools/common/ficha_cliente.ts";
+import { listarCategoriasTool } from "../_shared/tools/common/listar_categorias.ts";
+import { productosPorCategoriaTool } from "../_shared/tools/common/productos_por_categoria.ts";
 import { misClientesTool } from "../_shared/tools/preventista/mis_clientes.ts";
 import { sugerirVisitasRfmTool } from "../_shared/tools/preventista/sugerir_visitas_rfm.ts";
 import { miRecorridoHoyTool } from "../_shared/tools/transportista/mi_recorrido_hoy.ts";
@@ -40,7 +42,7 @@ import { _setServiceRoleClientForTests } from "../_shared/supabase.ts";
 // ============================================================================
 
 interface QueryFilter {
-  type: "eq" | "or";
+  type: "eq" | "or" | "ilike";
   args: unknown[];
 }
 
@@ -102,6 +104,10 @@ function createMockSupabase(opts: MockSupabaseOpts = {}): {
       },
       or(expr: string) {
         record.filters.push({ type: "or", args: [expr] });
+        return builder;
+      },
+      ilike(col: string, pattern: string) {
+        record.filters.push({ type: "ilike", args: [col, pattern] });
         return builder;
       },
       order(col: string, orderOpts?: Record<string, unknown>) {
@@ -534,6 +540,8 @@ Deno.test("registerAllTools registra todas las tools esperadas", () => {
   assert(getTool("buscar_cliente"), "buscar_cliente no registrada");
   assert(getTool("buscar_producto"), "buscar_producto no registrada");
   assert(getTool("ficha_cliente"), "ficha_cliente no registrada");
+  assert(getTool("listar_categorias"), "listar_categorias no registrada");
+  assert(getTool("productos_por_categoria"), "productos_por_categoria no registrada");
   assert(getTool("mis_clientes"), "mis_clientes no registrada");
   assert(getTool("sugerir_visitas_rfm"), "sugerir_visitas_rfm no registrada");
   assert(getTool("mi_recorrido_hoy"), "mi_recorrido_hoy no registrada");
@@ -542,6 +550,8 @@ Deno.test("registerAllTools registra todas las tools esperadas", () => {
   assertEquals(getTool("buscar_cliente"), buscarClienteTool);
   assertEquals(getTool("buscar_producto"), buscarProductoTool);
   assertEquals(getTool("ficha_cliente"), fichaClienteTool);
+  assertEquals(getTool("listar_categorias"), listarCategoriasTool);
+  assertEquals(getTool("productos_por_categoria"), productosPorCategoriaTool);
   assertEquals(getTool("mis_clientes"), misClientesTool);
   assertEquals(getTool("sugerir_visitas_rfm"), sugerirVisitasRfmTool);
   assertEquals(getTool("mi_recorrido_hoy"), miRecorridoHoyTool);
@@ -1181,4 +1191,259 @@ Deno.test("sugerir_visitas_rfm happy path retorna shape esperado y mapea campos"
   assertEquals(call.params.p_preventista_id, "ffffffff-ffff-ffff-ffff-ffffffffffff");
   assertEquals(call.params.p_sucursal_id, 2);
   assertEquals(call.params.p_limit, 10);
+});
+
+// ============================================================================
+// 21. listar_categorias: happy path con dedupe + filtro de null/empty
+// ============================================================================
+
+Deno.test("listar_categorias dedupe y filtra null/'' del resultado", async () => {
+  // Mock devuelve filas con categorías repetidas, una null, una "". El handler
+  // debe dedupear preservando orden de aparición y descartar null/"".
+  const { client, spy } = createMockSupabase({
+    selectResponse: {
+      data: [
+        { categoria: "AGUAS" },
+        { categoria: "FIDEOS" },
+        { categoria: "GASEOSAS" },
+        { categoria: "GASEOSAS" }, // duplicado
+        { categoria: null },
+        { categoria: "" },
+        { categoria: "FIDEOS" }, // duplicado
+      ],
+      error: null,
+      count: 7,
+    },
+  });
+
+  const ctx = makeCtx(client, { rol: "admin", sucursal_id: 1 });
+  const result = await listarCategoriasTool.handler({} as never, ctx);
+
+  assertEquals(result.total, 3);
+  assertEquals(result.categorias, ["AGUAS", "FIDEOS", "GASEOSAS"]);
+
+  // Sanity: scoping por sucursal aplicado.
+  const q = spy.queries.find((qq) => qq.table === "productos");
+  assert(q, "no se hizo query a productos");
+  const eqFilters = q!.filters.filter((f) => f.type === "eq");
+  assert(
+    eqFilters.some((f) => f.args[0] === "sucursal_id" && f.args[1] === 1),
+    "no se aplicó filter sucursal_id",
+  );
+});
+
+// ============================================================================
+// 22. listar_categorias: catalogo vacío → total 0, categorias []
+// ============================================================================
+
+Deno.test("listar_categorias retorna shape vacío cuando no hay productos", async () => {
+  const { client } = createMockSupabase({
+    selectResponse: { data: [], error: null, count: 0 },
+  });
+  const ctx = makeCtx(client, { rol: "encargado", sucursal_id: 7 });
+  const result = await listarCategoriasTool.handler({} as never, ctx);
+  assertEquals(result.total, 0);
+  assertEquals(result.categorias, []);
+});
+
+// ============================================================================
+// 23. listar_categorias: rechaza preventista sin sucursal asignada
+// ============================================================================
+
+Deno.test("listar_categorias rechaza preventista sin sucursal asignada", async () => {
+  const { client } = createMockSupabase({});
+  const ctx = makeCtx(client, {
+    rol: "preventista",
+    sucursal_id: null,
+    perfil_id: "11111111-2222-3333-4444-555555555555",
+  });
+
+  let threw = false;
+  try {
+    await listarCategoriasTool.handler({} as never, ctx);
+  } catch (err) {
+    threw = true;
+    assertStringIncludes(
+      err instanceof Error ? err.message : String(err),
+      "Sucursal no asignada",
+    );
+  }
+  assert(threw, "debió lanzar 'Sucursal no asignada'");
+});
+
+// ============================================================================
+// 24. productos_por_categoria: happy path con categoria + q
+// ============================================================================
+
+Deno.test("productos_por_categoria filtra por categoria y refina con q", async () => {
+  const { client, spy } = createMockSupabase({
+    selectResponse: {
+      data: [
+        {
+          id: 10,
+          codigo: "G001",
+          nombre: "Coca Naranja 2.25L",
+          precio: "850.50",
+          stock: 12,
+          stock_minimo: 4,
+          categoria: "GASEOSAS",
+          sucursal_id: 1,
+        },
+      ],
+      error: null,
+      count: 1,
+    },
+  });
+
+  const ctx = makeCtx(client, { rol: "admin", sucursal_id: 1 });
+  const result = await productosPorCategoriaTool.handler(
+    { categoria: "GASEOSAS", q: "naranja" },
+    ctx,
+  );
+
+  assertEquals(result.total, 1);
+  assertEquals(result.categoria, "GASEOSAS");
+  assertEquals(result.productos.length, 1);
+  assertEquals(result.productos[0].id, 10);
+  assertEquals(result.productos[0].nombre, "Coca Naranja 2.25L");
+  assertEquals(result.productos[0].precio, 850.5);
+  assertEquals(result.productos[0].bajo_stock, false); // 12 > 4
+
+  // Verifico shape de la query: ilike sobre categoria + or sobre nombre/codigo.
+  const q = spy.queries.find((qq) => qq.table === "productos");
+  assert(q, "no se hizo query a productos");
+
+  const ilikeFilters = q!.filters.filter((f) => f.type === "ilike");
+  assert(
+    ilikeFilters.some((f) =>
+      f.args[0] === "categoria" && f.args[1] === "GASEOSAS"
+    ),
+    "no se aplicó ilike(categoria)",
+  );
+
+  const orFilter = q!.filters.find((f) => f.type === "or");
+  assert(orFilter, "no se aplicó .or() para refinar con q");
+  assertStringIncludes(orFilter!.args[0] as string, "nombre.ilike.%naranja%");
+  assertStringIncludes(orFilter!.args[0] as string, "codigo.ilike.%naranja%");
+
+  // Sucursal scoping.
+  const eqFilters = q!.filters.filter((f) => f.type === "eq");
+  assert(
+    eqFilters.some((f) => f.args[0] === "sucursal_id" && f.args[1] === 1),
+    "no se aplicó filter sucursal_id",
+  );
+});
+
+// ============================================================================
+// 25. productos_por_categoria: sin q solo filtra por categoria
+// ============================================================================
+
+Deno.test("productos_por_categoria sin q omite el .or() de refinamiento", async () => {
+  const { client, spy } = createMockSupabase({
+    selectResponse: {
+      data: [
+        {
+          id: 1,
+          codigo: "F001",
+          nombre: "Fideo Spaghetti 500g",
+          precio: 350,
+          stock: 20,
+          stock_minimo: 5,
+          categoria: "FIDEOS",
+          sucursal_id: 2,
+        },
+      ],
+      error: null,
+      count: 1,
+    },
+  });
+
+  const ctx = makeCtx(client, { rol: "preventista", sucursal_id: 2, perfil_id: "preventista-uuid" });
+  const result = await productosPorCategoriaTool.handler(
+    { categoria: "FIDEOS" },
+    ctx,
+  );
+
+  assertEquals(result.total, 1);
+  const q = spy.queries.find((qq) => qq.table === "productos");
+  assert(q, "no se hizo query a productos");
+  // No debió haber .or() porque no se pasó q.
+  const orFilter = q!.filters.find((f) => f.type === "or");
+  assertEquals(
+    orFilter,
+    undefined,
+    "no debió aplicarse .or() cuando no se pasa q",
+  );
+});
+
+// ============================================================================
+// 26. productos_por_categoria: rechaza sucursal_id null para no-admin
+// ============================================================================
+
+Deno.test("productos_por_categoria rechaza transportista sin sucursal asignada", async () => {
+  const { client } = createMockSupabase({});
+  const ctx = makeCtx(client, {
+    rol: "transportista",
+    sucursal_id: null,
+    perfil_id: "trans-no-suc",
+  });
+
+  let threw = false;
+  try {
+    await productosPorCategoriaTool.handler({ categoria: "AGUAS" }, ctx);
+  } catch (err) {
+    threw = true;
+    assertStringIncludes(
+      err instanceof Error ? err.message : String(err),
+      "Sucursal no asignada",
+    );
+  }
+  assert(threw, "debió lanzar 'Sucursal no asignada'");
+});
+
+// ============================================================================
+// 27. productos_por_categoria: escapa metacaracteres PostgREST en q
+// ============================================================================
+
+Deno.test("productos_por_categoria escapa metacaracteres PostgREST en q", async () => {
+  const { client, spy } = createMockSupabase({
+    selectResponse: { data: [], error: null, count: 0 },
+  });
+  const ctx = makeCtx(client, { rol: "admin", sucursal_id: 1 });
+
+  await productosPorCategoriaTool.handler(
+    { categoria: "GASEOSAS", q: "foo.bar:baz(x)" },
+    ctx,
+  );
+
+  const q = spy.queries.find((qq) => qq.table === "productos");
+  assert(q, "no se hizo query a productos");
+  const orFilter = q!.filters.find((f) => f.type === "or");
+  assert(orFilter, "no se aplicó .or()");
+  const expr = orFilter!.args[0] as string;
+  assertStringIncludes(expr, "nombre.ilike.%foo\\.bar\\:baz\\(x\\)%");
+});
+
+// ============================================================================
+// 28. productos_por_categoria: limit fuera de rango lanza error
+// ============================================================================
+
+Deno.test("productos_por_categoria rechaza limit fuera de rango", async () => {
+  const { client } = createMockSupabase({});
+  const ctx = makeCtx(client, { rol: "admin", sucursal_id: 1 });
+
+  let threw = false;
+  try {
+    await productosPorCategoriaTool.handler(
+      { categoria: "GASEOSAS", limit: 100 },
+      ctx,
+    );
+  } catch (err) {
+    threw = true;
+    assertStringIncludes(
+      err instanceof Error ? err.message : String(err),
+      "Límite fuera de rango",
+    );
+  }
+  assert(threw, "debió lanzar 'Límite fuera de rango'");
 });


### PR DESCRIPTION
## Summary

Arregla el bug crítico que hacía que el bot crashee en cualquier query de lenguaje natural (\`path not found\` al cargar prompts), agrega capacidad de descubrimiento del catálogo por categorías, y enseña al LLM a encadenar tools.

**Bug original (audit log lo confirma):**
\`\`\`
2026-04-28 00:27:56  tipo=mensaje   "Decime todas las gaseosas sabor naranja..."
2026-04-28 00:27:57  tipo=error     {"crashed":true, "gemini":true,
                                     "error":"path not found:
                                       /var/tmp/sb-compile-edge-runtime/.../admin.txt"}
\`\`\`

El runtime de Supabase Edge Functions no incluye archivos no-TS en el bundle, así que \`Deno.readTextFile(import.meta.url)\` sobre los \`.txt\` de prompts fallaba antes de llegar al LLM.

## Cambios

- **fix:** Embebe los 6 prompts (5 roles + digest) como módulos TS con import estático. Single source of truth, type-safe, portable. \`telegram-digest\` también queda arreglado de paso (mismo bug latente).
- **feat:** Dos tools nuevas:
  - \`listar_categorias\`: SELECT distinct categoria de productos con scoping por sucursal.
  - \`productos_por_categoria(categoria, q?, limit?)\`: filtra por categoría (case-insensitive) + refina con \`q\` opcional. Mismo escape de metacaracteres PostgREST que las otras tools.
- **feat:** Los 5 system prompts ahora explican explícitamente el chain \`listar_categorias → productos_por_categoria(cat, q)\` con ejemplo \"qué gaseosas naranjas hay\" y reglas de 0-resultados (1-2 retries con variantes, después honestidad — nunca inventar).
- **chore:** Default \`BOT_MAX_TOOL_ITERATIONS\` 5 → 8 para acomodar multi-tool + retry sin truncar respuestas válidas. Env var sigue overrideando.

## Test plan

- [x] \`deno task check\` (typecheck) OK
- [x] \`deno task lint\` (52 archivos) OK
- [x] \`deno task test\` 87 passed | 0 failed (8 nuevos tests para las tools, asserts ajustados para iter cap nuevo)
- [x] Pre-commit hook (vitest + eslint del frontend) OK
- [ ] **Smoke test post-deploy** (próxima fase A6):
  - [ ] \"Decime todas las gaseosas sabor naranja que hay\" responde sin crashear y encadena listar_categorias + productos_por_categoria
  - [ ] \"¿Qué categorías de productos hay?\" llama listar_categorias directo
  - [ ] \"Buscame el cliente Pepe\" sigue funcionando con buscar_cliente
  - [ ] \`bot_audit_log\` muestra \`tipo=tool_call\` consecutivos sin \`tipo=error\` para los flows nuevos
  - [ ] \`telegram-digest\` (cron) sigue ejecutando — mismo fix de prompt loading aplica

## Fuera de alcance (próxima iteración)

Inline keyboards (Fase B), typing indicator + mensajes de error específicos + \`/reset\` y \`/desvincular\` (Fase C) del plan original. Se hacen en PRs separados después de validar A6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)