### PR TITLE
feat(bot): inline keyboards & callback queries (Fase 1)

### DIFF
--- a/supabase/functions/_shared/telegram-keyboards.ts
+++ b/supabase/functions/_shared/telegram-keyboards.ts
@@ -1,0 +1,144 @@
+// Builders de inline keyboards. Funciones puras que toman los mismos arrays
+// que reciben los formatters de slash commands y devuelven un
+// `InlineKeyboardMarkup` listo para adjuntar a `sendMessage` via la opción
+// `reply_markup`.
+//
+// Decisiones:
+//   * Una fila por item, un botón por fila — cabe bien en mobile y deja
+//     espacio si en el futuro agregamos un segundo botón ("marcar visitado",
+//     "llamar", etc.) sin reflowing.
+//   * Texto del botón truncado a un visualmente legible (~28 chars max).
+//     El callback_data sí tiene un hard cap de 64 bytes UTF-8 (Telegram), pero
+//     el formato `v1:<action>:<id>` con un id numérico nunca lo supera.
+//   * Versión `v1` en el callback_data por si el protocolo cambia. handleCallbackQuery
+//     valida el prefijo y rechaza otras versiones.
+
+import type {
+  InlineKeyboardButton,
+  InlineKeyboardMarkup,
+} from "./telegram.ts";
+
+// ----------------------------------------------------------------------------
+// Constantes
+// ----------------------------------------------------------------------------
+
+/** Máximo visual de texto en un botón. Telegram acepta hasta 64 bytes
+ *  pero textos largos se ven feo en mobile — truncamos antes. */
+const BUTTON_TEXT_MAX = 28;
+
+/** Versión del protocolo de callback_data. Match con handleCallbackQuery. */
+const CALLBACK_VERSION = "v1";
+
+// ----------------------------------------------------------------------------
+// Helpers internos
+// ----------------------------------------------------------------------------
+
+function truncate(text: string, max = BUTTON_TEXT_MAX): string {
+  if (text.length <= max) return text;
+  return text.slice(0, max - 1).trimEnd() + "…";
+}
+
+function callbackData(action: string, ...args: Array<string | number>): string {
+  return [CALLBACK_VERSION, action, ...args.map(String)].join(":");
+}
+
+function rowsFromButtons(buttons: InlineKeyboardButton[]): InlineKeyboardButton[][] {
+  // Una fila por botón. Patrón: builders más complejos pueden usar layouts
+  // multi-columna (ej. main menu) — esos pasan su propio shape directo.
+  return buttons.map((b) => [b]);
+}
+
+// ----------------------------------------------------------------------------
+// Builders
+// ----------------------------------------------------------------------------
+
+export interface ClienteListItem {
+  id: number;
+  nombre: string;
+}
+
+/**
+ * "Ver ficha — <nombre>" por cada cliente. callback_data: `v1:cliente:<id>`.
+ * Útil después de /cliente, /sugerencias y /misclientes — la acción siempre
+ * abre la ficha, sin distinción del comando que originó la lista.
+ */
+export function buildClienteListKeyboard(
+  items: ClienteListItem[],
+): InlineKeyboardMarkup {
+  const buttons: InlineKeyboardButton[] = items.map((c) => ({
+    text: truncate(`👤 Ver ficha — ${c.nombre}`),
+    callback_data: callbackData("cliente", c.id),
+  }));
+  return { inline_keyboard: rowsFromButtons(buttons) };
+}
+
+export interface ProductoListItem {
+  id: number;
+  nombre: string;
+}
+
+/**
+ * "Ver detalle — <nombre>" por cada producto. callback_data: `v1:producto:<id>`.
+ * En Fase 1 el callback responde con placeholder ("acción no disponible") —
+ * el wiring se reserva para no requerir cambios cuando se implemente la
+ * tool de detalle.
+ */
+export function buildProductoListKeyboard(
+  items: ProductoListItem[],
+): InlineKeyboardMarkup {
+  const buttons: InlineKeyboardButton[] = items.map((p) => ({
+    text: truncate(`📦 Ver detalle — ${p.nombre}`),
+    callback_data: callbackData("producto", p.id),
+  }));
+  return { inline_keyboard: rowsFromButtons(buttons) };
+}
+
+export interface SugerenciaItem {
+  cliente_id: number;
+  nombre: string;
+}
+
+/**
+ * "Ver ficha" por cada sugerencia (preventista). callback_data va al mismo
+ * action 'cliente' que el de buildClienteListKeyboard — la ficha es la misma
+ * vista, no necesitamos un action separado.
+ */
+export function buildSugerenciasKeyboard(
+  items: SugerenciaItem[],
+): InlineKeyboardMarkup {
+  const buttons: InlineKeyboardButton[] = items.map((s) => ({
+    text: truncate(`👤 Ver ficha — ${s.nombre}`),
+    callback_data: callbackData("cliente", s.cliente_id),
+  }));
+  return { inline_keyboard: rowsFromButtons(buttons) };
+}
+
+export interface MisClientesItem {
+  id: number;
+  nombre: string;
+}
+
+/**
+ * "Ver ficha" por cada cliente del preventista. Misma action que las otras
+ * dos: routea a la ficha.
+ */
+export function buildMisClientesKeyboard(
+  items: MisClientesItem[],
+): InlineKeyboardMarkup {
+  const buttons: InlineKeyboardButton[] = items.map((c) => ({
+    text: truncate(`👤 Ver ficha — ${c.nombre}`),
+    callback_data: callbackData("cliente", c.id),
+  }));
+  return { inline_keyboard: rowsFromButtons(buttons) };
+}
+
+// ----------------------------------------------------------------------------
+// Exports auxiliares para tests
+// ----------------------------------------------------------------------------
+
+export const _internal = {
+  truncate,
+  callbackData,
+  BUTTON_TEXT_MAX,
+  CALLBACK_VERSION,
+};

--- a/supabase/functions/_shared/telegram.ts
+++ b/supabase/functions/_shared/telegram.ts
@@ -1,15 +1,46 @@
-// Helpers para hablar con la Bot API de Telegram. Solo lo mínimo necesario
-// para Task 1.2 (sendMessage + parser de updates + escapeMarkdownV2).
+// Helpers para hablar con la Bot API de Telegram.
 // Referencia: https://core.telegram.org/bots/api
 
-import type { TelegramUpdate, TelegramUser } from "./types.ts";
+import type {
+  TelegramCallbackQuery,
+  TelegramMessage,
+  TelegramUpdate,
+  TelegramUser,
+} from "./types.ts";
 
 const TELEGRAM_API_BASE = "https://api.telegram.org";
+
+// ----------------------------------------------------------------------------
+// Tipos compartidos: keyboards, mensajes, chat actions
+// ----------------------------------------------------------------------------
+
+/**
+ * Botón de inline keyboard. La Bot API permite varios tipos de botones — acá
+ * solo modelamos los dos que usa el bot: callback (genera un callback_query)
+ * y url (abre link externo). Los demás (`switch_inline_query`, `pay`, etc.)
+ * se pueden agregar cuando aparezca un caso de uso real.
+ *
+ * Restricción de Telegram: `callback_data` ≤ 64 bytes UTF-8. El bot usa el
+ * formato `v1:<action>:<arg1>[:<arg2>...]` — los keyboard builders truncan
+ * texto largo pero el callback_data en sí debe ser corto por diseño.
+ */
+export interface InlineKeyboardButton {
+  text: string;
+  callback_data?: string;
+  url?: string;
+}
+
+export interface InlineKeyboardMarkup {
+  /** Filas de botones. Cada fila es un array horizontal. */
+  inline_keyboard: InlineKeyboardButton[][];
+}
 
 export interface SendMessageOptions {
   parse_mode?: "MarkdownV2" | "HTML";
   disable_web_page_preview?: boolean;
   reply_to_message_id?: number;
+  /** Inline keyboard que aparece debajo del mensaje. */
+  reply_markup?: InlineKeyboardMarkup;
 }
 
 export interface SendMessageResult {
@@ -20,6 +51,89 @@ export interface SendMessageResult {
 }
 
 /**
+ * Acciones que el bot puede mostrar al usuario para indicar "estoy
+ * trabajando". Telegram las muestra ~5s y se autodescartan. Las que usa el
+ * bot son básicamente `typing` (mientras LLM procesa). El resto está acá por
+ * compatibilidad con la spec.
+ * https://core.telegram.org/bots/api#sendchataction
+ */
+export type ChatAction =
+  | "typing"
+  | "upload_photo"
+  | "record_video"
+  | "upload_video"
+  | "record_voice"
+  | "upload_voice"
+  | "upload_document"
+  | "choose_sticker"
+  | "find_location"
+  | "record_video_note"
+  | "upload_video_note";
+
+export interface AnswerCallbackQueryOptions {
+  /** Texto opcional que aparece como notification (≤ 200 chars). */
+  text?: string;
+  /** Si true, modal en vez de notification. Útil para errores claros. */
+  show_alert?: boolean;
+  /** Cache del client para evitar repreguntar (segundos). Default 0. */
+  cache_time?: number;
+}
+
+// ----------------------------------------------------------------------------
+// Helper interno: invocación cruda de Bot API
+// ----------------------------------------------------------------------------
+
+/**
+ * POST genérico al endpoint `/bot{token}/{method}` de Telegram. Lanza con un
+ * Error descriptivo si la red falla o si la API devuelve `ok: false`. Cada
+ * helper público decide si propagar el error o capturarlo (best-effort).
+ */
+async function callTelegramApi<T = unknown>(
+  method: string,
+  body: Record<string, unknown>,
+): Promise<{ ok: true; result?: T }> {
+  const token = Deno.env.get("TELEGRAM_BOT_TOKEN");
+  if (!token) {
+    throw new Error("TELEGRAM_BOT_TOKEN not set in Edge Function environment");
+  }
+
+  const url = `${TELEGRAM_API_BASE}/bot${token}/${method}`;
+  const res = await fetch(url, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+
+  let payload: {
+    ok?: boolean;
+    result?: T;
+    description?: string;
+    error_code?: number;
+  };
+  try {
+    payload = await res.json();
+  } catch {
+    throw new Error(
+      `Telegram ${method} returned non-JSON (status ${res.status})`,
+    );
+  }
+
+  if (!res.ok || !payload.ok) {
+    throw new Error(
+      `Telegram ${method} failed (status ${res.status}, code ${payload.error_code}): ${
+        payload.description ?? "<no description>"
+      }`,
+    );
+  }
+
+  return { ok: true, result: payload.result };
+}
+
+// ----------------------------------------------------------------------------
+// API pública
+// ----------------------------------------------------------------------------
+
+/**
  * POST a sendMessage. Lee TELEGRAM_BOT_TOKEN del env. Lanza si la API
  * responde con `ok: false` o si la red falla — el caller decide qué hacer.
  */
@@ -28,40 +142,61 @@ export async function sendMessage(
   text: string,
   opts: SendMessageOptions = {},
 ): Promise<SendMessageResult> {
-  const token = Deno.env.get("TELEGRAM_BOT_TOKEN");
-  if (!token) {
-    throw new Error("TELEGRAM_BOT_TOKEN not set in Edge Function environment");
-  }
-
-  const url = `${TELEGRAM_API_BASE}/bot${token}/sendMessage`;
   const body: Record<string, unknown> = {
     chat_id: chatId,
     text,
     ...opts,
   };
+  const r = await callTelegramApi("sendMessage", body);
+  return { ok: true, result: r.result };
+}
 
-  const res = await fetch(url, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify(body),
-  });
-
-  let payload: SendMessageResult;
+/**
+ * Indica al usuario que el bot está procesando ("typing…"). Telegram muestra
+ * el indicador ~5s y se autodescarta — si el LLM tarda más, no loopeamos.
+ *
+ * Best-effort: errores se loguean y se descartan. NO queremos que un fallo
+ * en sendChatAction aborte el flujo principal del handler.
+ */
+export async function sendChatAction(
+  chatId: number,
+  action: ChatAction,
+): Promise<void> {
   try {
-    payload = (await res.json()) as SendMessageResult;
-  } catch {
-    throw new Error(`Telegram sendMessage returned non-JSON (status ${res.status})`);
-  }
-
-  if (!res.ok || !payload.ok) {
-    throw new Error(
-      `Telegram sendMessage failed (status ${res.status}, code ${payload.error_code}): ${
-        payload.description ?? "<no description>"
-      }`,
+    await callTelegramApi("sendChatAction", { chat_id: chatId, action });
+  } catch (err) {
+    console.warn(
+      "[telegram] sendChatAction failed (non-fatal):",
+      err instanceof Error ? err.message : String(err),
     );
   }
+}
 
-  return payload;
+/**
+ * Confirma la recepción de un callback_query. Sin esta llamada, el botón en
+ * la UI del cliente Telegram queda con un spinner por hasta 30s. Llamala
+ * SIEMPRE al final de handleCallbackQuery, aunque haya habido error — con
+ * un texto distinto en cada caso.
+ *
+ * Best-effort: errores se loguean. Si esto falla, el usuario ve el spinner
+ * más tiempo, pero el resto del flujo (mensaje nuevo, audit log) ya pasó.
+ */
+export async function answerCallbackQuery(
+  callbackQueryId: string,
+  opts: AnswerCallbackQueryOptions = {},
+): Promise<void> {
+  const body: Record<string, unknown> = {
+    callback_query_id: callbackQueryId,
+    ...opts,
+  };
+  try {
+    await callTelegramApi("answerCallbackQuery", body);
+  } catch (err) {
+    console.warn(
+      "[telegram] answerCallbackQuery failed (non-fatal):",
+      err instanceof Error ? err.message : String(err),
+    );
+  }
 }
 
 /**
@@ -101,9 +236,13 @@ function isMarkdownParseError(err: unknown): boolean {
 export async function sendMessageMarkdownSafe(
   chatId: number,
   markdownV2Text: string,
+  opts: Omit<SendMessageOptions, "parse_mode"> = {},
 ): Promise<void> {
   try {
-    await sendMessage(chatId, markdownV2Text, { parse_mode: "MarkdownV2" });
+    await sendMessage(chatId, markdownV2Text, {
+      ...opts,
+      parse_mode: "MarkdownV2",
+    });
     return;
   } catch (err) {
     if (!isMarkdownParseError(err)) {
@@ -118,10 +257,11 @@ export async function sendMessageMarkdownSafe(
   // Despojamos de la sintaxis MarkdownV2 más obvia para que se lea.
   // 1) Unescape de los chars MarkdownV2 (`\\.` → `.`).
   // 2) Strip de markers `*` `_` `` ` ``  (bold/italic/mono).
+  // El reply_markup (si vino) se preserva intacto — no es markdown.
   const plain = markdownV2Text
     .replace(/\\([_*\[\]()~`>#+\-=|{}.!])/g, "$1")
     .replace(/[*_`]/g, "");
-  await sendMessage(chatId, plain);
+  await sendMessage(chatId, plain, opts);
 }
 
 /**
@@ -146,6 +286,14 @@ export function timingSafeEqual(a: string, b: string): boolean {
  * Type guard mínimo: verifica que `body` tenga la forma de un Update válido
  * (al menos `update_id: number`). Retorna null si no parsea — el caller
  * responde 200 OK igualmente para no causar reintento de Telegram.
+ *
+ * Acepta dos shapes principales:
+ *   - `message`: mensaje de texto (slash command o NL).
+ *   - `callback_query`: usuario tocó un inline keyboard.
+ *
+ * Otros shapes (edited_message, channel_post, etc.) se ignoran — el caller
+ * los detecta por la ausencia de ambos campos y los loguea como
+ * `unsupported_update_shape`.
  */
 export function parseUpdate(body: unknown): TelegramUpdate | null {
   if (!body || typeof body !== "object") return null;
@@ -155,31 +303,63 @@ export function parseUpdate(body: unknown): TelegramUpdate | null {
 
   const update: TelegramUpdate = { update_id: candidate.update_id };
 
-  if (candidate.message && typeof candidate.message === "object") {
-    const msg = candidate.message as Record<string, unknown>;
-    if (
-      typeof msg.message_id === "number" &&
-      typeof msg.date === "number" &&
-      msg.chat && typeof msg.chat === "object"
-    ) {
-      const chat = msg.chat as Record<string, unknown>;
-      if (
-        typeof chat.id === "number" && typeof chat.type === "string" &&
-        (chat.type === "private" || chat.type === "group" ||
-          chat.type === "supergroup" || chat.type === "channel")
-      ) {
-        update.message = {
-          message_id: msg.message_id,
-          date: msg.date,
-          chat: { id: chat.id, type: chat.type },
-          text: typeof msg.text === "string" ? msg.text : undefined,
-          from: parseFromUser(msg.from),
-        };
-      }
-    }
-  }
+  const parsedMessage = parseMessage(candidate.message);
+  if (parsedMessage) update.message = parsedMessage;
+
+  const parsedCallback = parseCallbackQuery(candidate.callback_query);
+  if (parsedCallback) update.callback_query = parsedCallback;
 
   return update;
+}
+
+function parseMessage(raw: unknown): TelegramMessage | undefined {
+  if (!raw || typeof raw !== "object") return undefined;
+  const msg = raw as Record<string, unknown>;
+  if (
+    typeof msg.message_id !== "number" ||
+    typeof msg.date !== "number" ||
+    !msg.chat || typeof msg.chat !== "object"
+  ) {
+    return undefined;
+  }
+  const chat = msg.chat as Record<string, unknown>;
+  if (
+    typeof chat.id !== "number" || typeof chat.type !== "string" ||
+    (chat.type !== "private" && chat.type !== "group" &&
+      chat.type !== "supergroup" && chat.type !== "channel")
+  ) {
+    return undefined;
+  }
+  return {
+    message_id: msg.message_id,
+    date: msg.date,
+    chat: { id: chat.id, type: chat.type },
+    text: typeof msg.text === "string" ? msg.text : undefined,
+    from: parseFromUser(msg.from),
+  };
+}
+
+function parseCallbackQuery(raw: unknown): TelegramCallbackQuery | undefined {
+  if (!raw || typeof raw !== "object") return undefined;
+  const cb = raw as Record<string, unknown>;
+  // id, from, message son requeridos para un callback útil. data es opcional
+  // (puede venir vacío si el botón usaba `url`, aunque ese caso no genera
+  // callback_query — más bien defense-in-depth).
+  if (typeof cb.id !== "string") return undefined;
+  const from = parseFromUser(cb.from);
+  if (!from) return undefined;
+  const message = parseMessage(cb.message);
+  if (!message) return undefined;
+
+  return {
+    id: cb.id,
+    from,
+    message,
+    data: typeof cb.data === "string" ? cb.data : undefined,
+    chat_instance: typeof cb.chat_instance === "string"
+      ? cb.chat_instance
+      : undefined,
+  };
 }
 
 function parseFromUser(raw: unknown): TelegramUser | undefined {

--- a/supabase/functions/_shared/types.ts
+++ b/supabase/functions/_shared/types.ts
@@ -24,9 +24,28 @@ export interface TelegramMessage {
   text?: string;
 }
 
+/**
+ * Update generado cuando el usuario toca un botón de inline keyboard.
+ * Telegram entrega `data` (el callback_data del botón, ≤ 64 bytes) y el
+ * mensaje al que pertenecía el keyboard. El bot debe responder con
+ * `answerCallbackQuery` para apagar el spinner del cliente.
+ * https://core.telegram.org/bots/api#callbackquery
+ */
+export interface TelegramCallbackQuery {
+  id: string;
+  from: TelegramUser;
+  /** Mensaje original que tenía el inline keyboard. */
+  message: TelegramMessage;
+  /** Payload del botón (callback_data). Vacío si el botón usaba `url`. */
+  data?: string;
+  /** Hash que Telegram usa para deduplicar — informativo, no lo validamos. */
+  chat_instance?: string;
+}
+
 export interface TelegramUpdate {
   update_id: number;
   message?: TelegramMessage;
+  callback_query?: TelegramCallbackQuery;
 }
 
 // ----------------------------------------------------------------------------

--- a/supabase/functions/telegram-webhook/commands/cliente.ts
+++ b/supabase/functions/telegram-webhook/commands/cliente.ts
@@ -2,6 +2,7 @@
 
 import { invokeTool } from "../../_shared/tools/registry.ts";
 import { sendMessage, sendMessageMarkdownSafe } from "../../_shared/telegram.ts";
+import { buildClienteListKeyboard } from "../../_shared/telegram-keyboards.ts";
 import { formatBuscarClienteResult } from "../formatters/cliente.ts";
 import type {
   BuscarClienteParams,
@@ -47,6 +48,13 @@ export const clienteCommand: CommandSpec = {
     }
 
     const text = formatBuscarClienteResult(result.data);
-    await sendMessageMarkdownSafe(chatId, text);
+    // Inline keyboard "Ver ficha" por cada cliente — mismo callback que
+    // /sugerencias y /misclientes (action='cliente' va a la ficha).
+    const reply_markup = result.data.clientes.length > 0
+      ? buildClienteListKeyboard(
+        result.data.clientes.map((c) => ({ id: c.id, nombre: c.nombre })),
+      )
+      : undefined;
+    await sendMessageMarkdownSafe(chatId, text, { reply_markup });
   },
 };

--- a/supabase/functions/telegram-webhook/commands/misclientes.ts
+++ b/supabase/functions/telegram-webhook/commands/misclientes.ts
@@ -7,6 +7,7 @@
 
 import { invokeTool } from "../../_shared/tools/registry.ts";
 import { sendMessage, sendMessageMarkdownSafe } from "../../_shared/telegram.ts";
+import { buildMisClientesKeyboard } from "../../_shared/telegram-keyboards.ts";
 import { formatMisClientesResult } from "../formatters/misclientes.ts";
 import type {
   MisClientesParams,
@@ -63,6 +64,15 @@ export const misClientesCommand: CommandSpec = {
       return;
     }
 
-    await sendMessageMarkdownSafe(chatId, formatMisClientesResult(result.data));
+    const reply_markup = result.data.clientes.length > 0
+      ? buildMisClientesKeyboard(
+        result.data.clientes.map((c) => ({ id: c.id, nombre: c.nombre })),
+      )
+      : undefined;
+    await sendMessageMarkdownSafe(
+      chatId,
+      formatMisClientesResult(result.data),
+      { reply_markup },
+    );
   },
 };

--- a/supabase/functions/telegram-webhook/commands/producto.ts
+++ b/supabase/functions/telegram-webhook/commands/producto.ts
@@ -2,6 +2,7 @@
 
 import { invokeTool } from "../../_shared/tools/registry.ts";
 import { sendMessage, sendMessageMarkdownSafe } from "../../_shared/telegram.ts";
+import { buildProductoListKeyboard } from "../../_shared/telegram-keyboards.ts";
 import { formatBuscarProductoResult } from "../formatters/producto.ts";
 import type {
   BuscarProductoParams,
@@ -45,6 +46,15 @@ export const productoCommand: CommandSpec = {
     }
 
     const text = formatBuscarProductoResult(result.data);
-    await sendMessageMarkdownSafe(chatId, text);
+    // Inline keyboard "Ver detalle" — callback v1:producto:<id> está reservado
+    // pero responde con placeholder hasta que se implemente la tool de
+    // detalle (Fase futura). Igual ofrecemos el botón para que el preventista
+    // se acostumbre al patrón.
+    const reply_markup = result.data.productos.length > 0
+      ? buildProductoListKeyboard(
+        result.data.productos.map((p) => ({ id: p.id, nombre: p.nombre })),
+      )
+      : undefined;
+    await sendMessageMarkdownSafe(chatId, text, { reply_markup });
   },
 };

--- a/supabase/functions/telegram-webhook/commands/sugerencias.ts
+++ b/supabase/functions/telegram-webhook/commands/sugerencias.ts
@@ -4,6 +4,7 @@
 
 import { invokeTool } from "../../_shared/tools/registry.ts";
 import { sendMessage, sendMessageMarkdownSafe } from "../../_shared/telegram.ts";
+import { buildSugerenciasKeyboard } from "../../_shared/telegram-keyboards.ts";
 import { formatSugerenciasResult } from "../formatters/sugerencias.ts";
 import type {
   SugerirVisitasRfmParams,
@@ -49,6 +50,18 @@ export const sugerenciasCommand: CommandSpec = {
       return;
     }
 
-    await sendMessageMarkdownSafe(chatId, formatSugerenciasResult(result.data));
+    const reply_markup = result.data.sugerencias.length > 0
+      ? buildSugerenciasKeyboard(
+        result.data.sugerencias.map((s) => ({
+          cliente_id: s.cliente_id,
+          nombre: s.nombre,
+        })),
+      )
+      : undefined;
+    await sendMessageMarkdownSafe(
+      chatId,
+      formatSugerenciasResult(result.data),
+      { reply_markup },
+    );
   },
 };

--- a/supabase/functions/telegram-webhook/handlers.ts
+++ b/supabase/functions/telegram-webhook/handlers.ts
@@ -622,7 +622,7 @@ export async function handleCallbackQuery(cb: TelegramCallbackQuery): Promise<vo
 
   switch (parsed.action) {
     case "cliente":
-      return handleCallbackCliente(cb, user, toolCtx, parsed.args);
+      return handleCallbackCliente(cb, toolCtx, parsed.args);
     case "producto":
     case "visitar":
     case "menu":
@@ -641,10 +641,12 @@ export async function handleCallbackQuery(cb: TelegramCallbackQuery): Promise<vo
 
 async function handleCallbackCliente(
   cb: TelegramCallbackQuery,
-  user: BotUser,
   toolCtx: ToolContext,
   args: string[],
 ): Promise<void> {
+  // `user` no es necesario acá — su info (perfil_id, rol, sucursal_id) ya
+  // viaja en `toolCtx`, y los permission gates los hace `invokeTool`
+  // basándose en `toolCtx.rol`.
   const chatId = cb.message.chat.id;
   const idStr = args[0];
   const cliente_id = idStr ? parseInt(idStr, 10) : NaN;

--- a/supabase/functions/telegram-webhook/handlers.ts
+++ b/supabase/functions/telegram-webhook/handlers.ts
@@ -16,11 +16,24 @@
 import { canjearCodigo, resolveUserByTelegramId } from "../_shared/auth.ts";
 import { logEvent } from "../_shared/audit.ts";
 import { getServiceRoleClient } from "../_shared/supabase.ts";
-import { escapeMarkdownV2, sendMessage } from "../_shared/telegram.ts";
-import { registerAllTools } from "../_shared/tools/index.ts";
+import {
+  answerCallbackQuery,
+  escapeMarkdownV2,
+  sendMessage,
+  sendMessageMarkdownSafe,
+} from "../_shared/telegram.ts";
+import { invokeTool, registerAllTools } from "../_shared/tools/index.ts";
 import type { ToolContext } from "../_shared/tools/base.ts";
 import { runAgent } from "../_shared/gemini/agent.ts";
-import type { BotRol, BotUser, TelegramUpdate, TelegramUser } from "../_shared/types.ts";
+import type {
+  BotRol,
+  BotUser,
+  TelegramCallbackQuery,
+  TelegramUpdate,
+  TelegramUser,
+} from "../_shared/types.ts";
+import { formatFichaCliente } from "./formatters/cliente.ts";
+import type { FichaClienteResult } from "../_shared/tools/common/ficha_cliente.ts";
 
 import { parseCommand } from "./commands/parser.ts";
 import { getCommand, listCommands, registerCommand } from "./commands/router.ts";
@@ -494,4 +507,184 @@ function mensajeErrorVincular(
     case "rpc_error":
       return "❌ Hubo un error procesando tu código. Probá de nuevo en un momento.";
   }
+}
+
+// ----------------------------------------------------------------------------
+// handleCallbackQuery — entry point cuando el usuario toca un inline keyboard.
+// ----------------------------------------------------------------------------
+//
+// Formato esperado de callback_data: `v1:<action>:<arg1>[:<arg2>...]`
+//
+// Acciones soportadas en Fase 1:
+//   - v1:cliente:<id>  → muestra la ficha del cliente.
+//
+// Acciones reservadas (responden con un placeholder hasta que se implementen):
+//   - v1:producto:<id> → ver detalle producto.
+//   - v1:visitar:<id>  → marcar visita (write futuro).
+//   - v1:menu:<key>    → main menu (Fase 3).
+//
+// Auditoría: cada callback genera una fila en bot_audit_log con `tipo='comando'`
+// y `parametros: { source: 'callback', action, args }`. NO ampliamos el enum
+// `tipo` con un valor 'callback' nuevo en este PR — eso requeriría una
+// migration y no agrega valor inmediato (se puede filtrar por
+// `parametros->>'source' = 'callback'`).
+
+const CALLBACK_VERSION = "v1";
+
+interface ParsedCallback {
+  action: string;
+  args: string[];
+}
+
+function parseCallbackData(raw: string | undefined): ParsedCallback | null {
+  if (!raw || typeof raw !== "string") return null;
+  const parts = raw.split(":");
+  if (parts.length < 2) return null;
+  if (parts[0] !== CALLBACK_VERSION) return null;
+  const [, action, ...args] = parts;
+  if (!action) return null;
+  return { action, args };
+}
+
+export async function handleCallbackQuery(cb: TelegramCallbackQuery): Promise<void> {
+  bootCommands();
+
+  const tgUser = cb.from;
+  const chatId = cb.message.chat.id;
+
+  // Defense-in-depth: el caller (index.ts) ya garantiza que cb.from existe,
+  // pero parseamos los args con cuidado igual.
+  const parsed = parseCallbackData(cb.data);
+  if (!parsed) {
+    await answerCallbackQuery(cb.id, {
+      text: "Acción no reconocida.",
+      show_alert: false,
+    });
+    await logEvent({
+      telegram_user_id: tgUser.id,
+      tipo: "error",
+      resultado_meta: {
+        source: "callback",
+        error: "callback_data_inválido",
+        raw: cb.data ?? null,
+      },
+    }).catch(() => {});
+    return;
+  }
+
+  const user = await resolveUserByTelegramId(tgUser.id);
+  if (!user) {
+    await answerCallbackQuery(cb.id, {
+      text: "Vinculá tu cuenta primero.",
+      show_alert: true,
+    });
+    await sendMessage(
+      chatId,
+      "Para usar los botones necesito que estés vinculado.\n\n" +
+        "Pedí un código en la app web (Perfil > Vincular Telegram) y mandalo " +
+        "así: /vincular ABC123",
+    );
+    await logEvent({
+      telegram_user_id: tgUser.id,
+      tipo: "comando",
+      tool_name: parsed.action,
+      parametros: {
+        source: "callback",
+        action: parsed.action,
+        args: parsed.args,
+      },
+      resultado_meta: { blocked: "no_vinculado" },
+    }).catch(() => {});
+    return;
+  }
+
+  // Audit del callback ANTES de ejecutar (mismo patrón que comandos en el
+  // router): si el handler explota, queda registro del intento.
+  await logEvent({
+    telegram_user_id: tgUser.id,
+    perfil_id: user.perfil_id,
+    rol: user.rol,
+    tipo: "comando",
+    tool_name: parsed.action,
+    parametros: {
+      source: "callback",
+      action: parsed.action,
+      args: parsed.args,
+    },
+  });
+
+  const toolCtx: ToolContext = {
+    perfil_id: user.perfil_id,
+    rol: user.rol,
+    sucursal_id: user.sucursal_id,
+    supabase: getServiceRoleClient(),
+  };
+
+  switch (parsed.action) {
+    case "cliente":
+      return handleCallbackCliente(cb, user, toolCtx, parsed.args);
+    case "producto":
+    case "visitar":
+    case "menu":
+      // Reservadas: confirmamos el callback y respondemos con placeholder.
+      await answerCallbackQuery(cb.id, {
+        text: "Esa acción todavía no está disponible.",
+      });
+      return;
+    default:
+      await answerCallbackQuery(cb.id, {
+        text: "Acción desconocida.",
+      });
+      return;
+  }
+}
+
+async function handleCallbackCliente(
+  cb: TelegramCallbackQuery,
+  user: BotUser,
+  toolCtx: ToolContext,
+  args: string[],
+): Promise<void> {
+  const chatId = cb.message.chat.id;
+  const idStr = args[0];
+  const cliente_id = idStr ? parseInt(idStr, 10) : NaN;
+  if (!Number.isFinite(cliente_id) || cliente_id <= 0) {
+    await answerCallbackQuery(cb.id, { text: "ID de cliente inválido." });
+    return;
+  }
+
+  const result = await invokeTool(
+    "ficha_cliente",
+    { cliente_id },
+    toolCtx,
+  );
+
+  if (!result.ok) {
+    // invokeTool devuelve ok:false con códigos como 'permiso_denegado',
+    // 'tool_no_existe' o un error genérico desde el handler. El audit ya
+    // queda registrado por invokeTool — solo respondemos al usuario.
+    const errMsg = result.error === "permiso_denegado"
+      ? "No tenés permiso para ver este cliente."
+      : "No pude abrir la ficha del cliente.";
+    await answerCallbackQuery(cb.id, { text: errMsg, show_alert: true });
+    return;
+  }
+
+  const ficha = result.data as FichaClienteResult;
+  const text = formatFichaCliente(ficha);
+  // Mandamos el mensaje con MarkdownV2 + fallback plain (mismo patrón que
+  // los slash commands de cliente).
+  try {
+    await sendMessageMarkdownSafe(chatId, text);
+  } catch (err) {
+    console.error("[callback cliente] sendMessage failed:", err);
+    await answerCallbackQuery(cb.id, {
+      text: "No pude enviar la ficha. Probá de nuevo.",
+      show_alert: true,
+    });
+    return;
+  }
+
+  // OK → confirmamos el callback (apaga el spinner).
+  await answerCallbackQuery(cb.id);
 }

--- a/supabase/functions/telegram-webhook/index.ts
+++ b/supabase/functions/telegram-webhook/index.ts
@@ -20,7 +20,7 @@
 import { serve } from "std/http/server.ts";
 import { logEvent } from "../_shared/audit.ts";
 import { parseUpdate, timingSafeEqual } from "../_shared/telegram.ts";
-import { handleUpdate } from "./handlers.ts";
+import { handleCallbackQuery, handleUpdate } from "./handlers.ts";
 
 serve(async (req: Request) => {
   if (req.method !== "POST") {
@@ -54,10 +54,32 @@ serve(async (req: Request) => {
 
   const update = parseUpdate(body);
 
-  // Updates sin message+text+from no nos interesan en Fase 1.2 (callbacks,
-  // ediciones, etc. los ignoramos). Igual respondemos 200 para que Telegram
-  // no reintente — pero auditamos para mantener el contrato "todo update
-  // recibido queda registrado".
+  // Discriminamos por shape:
+  //   - callback_query: usuario tocó un inline keyboard.
+  //   - message con text+from: slash command o NL.
+  //   - cualquier otro shape (edited_message, channel_post, sin texto, etc.)
+  //     se ignora — auditamos para visibilidad.
+  if (update?.callback_query) {
+    try {
+      await handleCallbackQuery(update.callback_query);
+    } catch (err) {
+      console.error("telegram-webhook callback handler error", err);
+      try {
+        await logEvent({
+          telegram_user_id: update.callback_query.from.id,
+          tipo: "error",
+          resultado_meta: {
+            error: err instanceof Error ? err.message : String(err),
+            source: "callback_query",
+          },
+        });
+      } catch (auditErr) {
+        console.error("telegram-webhook audit-of-callback-error failed", auditErr);
+      }
+    }
+    return new Response("ok");
+  }
+
   if (!update?.message?.text || !update.message.from) {
     try {
       await logEvent({
@@ -72,8 +94,6 @@ serve(async (req: Request) => {
         },
       });
     } catch (auditErr) {
-      // Best-effort: no queremos que un fallo de audit haga reintentar a
-      // Telegram. Logueamos a consola y seguimos.
       console.error("telegram-webhook audit dropped-update failed", auditErr);
     }
     return new Response("ok");
@@ -84,8 +104,6 @@ serve(async (req: Request) => {
     await handleUpdate(update);
   } catch (err) {
     console.error("telegram-webhook handler error", err);
-    // Best-effort audit del error. Si esto también falla, ya logeamos a
-    // la consola arriba.
     try {
       await logEvent({
         telegram_user_id: update.message.from.id,

--- a/supabase/functions/tests/telegram-keyboards.test.ts
+++ b/supabase/functions/tests/telegram-keyboards.test.ts
@@ -1,0 +1,129 @@
+// Tests para los inline keyboard builders.
+//
+// Cubrimos:
+//   * Forma del shape: 1 fila por item, 1 botón por fila.
+//   * callback_data armado con prefijo de versión + action + id.
+//   * Truncate del texto del botón si supera 28 chars.
+//   * callback_data dentro del límite de 64 bytes UTF-8.
+//   * Lista vacía → keyboard sin filas (el caller decide si mandarlo o no).
+
+import { assert, assertEquals } from "std/assert/mod.ts";
+import {
+  _internal,
+  buildClienteListKeyboard,
+  buildMisClientesKeyboard,
+  buildProductoListKeyboard,
+  buildSugerenciasKeyboard,
+} from "../_shared/telegram-keyboards.ts";
+
+// ----------------------------------------------------------------------------
+// 1. cliente list: shape básico
+// ----------------------------------------------------------------------------
+
+Deno.test("buildClienteListKeyboard: 1 fila por cliente con callback_data v1:cliente:<id>", () => {
+  // Nombres deliberadamente cortos para no caer en truncate — la truncación
+  // se verifica en su propio test más abajo.
+  const kb = buildClienteListKeyboard([
+    { id: 42, nombre: "Pepito" },
+    { id: 100, nombre: "Don Tito" },
+  ]);
+
+  assertEquals(kb.inline_keyboard.length, 2);
+  assertEquals(kb.inline_keyboard[0].length, 1);
+  assertEquals(kb.inline_keyboard[1].length, 1);
+
+  const b0 = kb.inline_keyboard[0][0];
+  assertEquals(b0.text, "👤 Ver ficha — Pepito");
+  assertEquals(b0.callback_data, "v1:cliente:42");
+
+  const b1 = kb.inline_keyboard[1][0];
+  assertEquals(b1.text, "👤 Ver ficha — Don Tito");
+  assertEquals(b1.callback_data, "v1:cliente:100");
+});
+
+// ----------------------------------------------------------------------------
+// 2. cliente list: vacío
+// ----------------------------------------------------------------------------
+
+Deno.test("buildClienteListKeyboard: lista vacía retorna inline_keyboard vacío", () => {
+  const kb = buildClienteListKeyboard([]);
+  assertEquals(kb.inline_keyboard.length, 0);
+});
+
+// ----------------------------------------------------------------------------
+// 3. truncate: textos largos quedan bajo el max
+// ----------------------------------------------------------------------------
+
+Deno.test("buildClienteListKeyboard: truncate de nombres largos", () => {
+  const kb = buildClienteListKeyboard([
+    {
+      id: 1,
+      nombre: "Distribuidora de Productos del Sur Sociedad Anónima",
+    },
+  ]);
+  const text = kb.inline_keyboard[0][0].text;
+  assert(
+    text.length <= _internal.BUTTON_TEXT_MAX,
+    `texto del botón excede ${_internal.BUTTON_TEXT_MAX} chars: "${text}" (${text.length})`,
+  );
+  // Debe terminar con ellipsis cuando se truncó.
+  assert(text.endsWith("…"), `texto truncado debe terminar con elipsis: "${text}"`);
+});
+
+// ----------------------------------------------------------------------------
+// 4. callback_data: bajo el límite de 64 bytes UTF-8
+// ----------------------------------------------------------------------------
+
+Deno.test("buildClienteListKeyboard: callback_data bajo 64 bytes", () => {
+  const kb = buildClienteListKeyboard([
+    { id: 999999999, nombre: "Test" },
+  ]);
+  const cb = kb.inline_keyboard[0][0].callback_data!;
+  const bytes = new TextEncoder().encode(cb).length;
+  assert(bytes <= 64, `callback_data de ${bytes} bytes excede 64`);
+});
+
+// ----------------------------------------------------------------------------
+// 5. producto list: action='producto'
+// ----------------------------------------------------------------------------
+
+Deno.test("buildProductoListKeyboard: action es 'producto'", () => {
+  const kb = buildProductoListKeyboard([
+    { id: 1234, nombre: "Coca 2L" },
+  ]);
+  assertEquals(kb.inline_keyboard[0][0].callback_data, "v1:producto:1234");
+  assertEquals(kb.inline_keyboard[0][0].text, "📦 Ver detalle — Coca 2L");
+});
+
+// ----------------------------------------------------------------------------
+// 6. sugerencias: routea al action 'cliente' (no 'sugerencia')
+// ----------------------------------------------------------------------------
+
+Deno.test("buildSugerenciasKeyboard: callback va a action='cliente' con cliente_id", () => {
+  const kb = buildSugerenciasKeyboard([
+    { cliente_id: 555, nombre: "Almacén Norte" },
+  ]);
+  assertEquals(kb.inline_keyboard[0][0].callback_data, "v1:cliente:555");
+});
+
+// ----------------------------------------------------------------------------
+// 7. misclientes: action='cliente'
+// ----------------------------------------------------------------------------
+
+Deno.test("buildMisClientesKeyboard: callback va a action='cliente' con id", () => {
+  const kb = buildMisClientesKeyboard([
+    { id: 7, nombre: "Boliche Don Tito" },
+  ]);
+  assertEquals(kb.inline_keyboard[0][0].callback_data, "v1:cliente:7");
+});
+
+// ----------------------------------------------------------------------------
+// 8. truncate helper: comportamiento exacto
+// ----------------------------------------------------------------------------
+
+Deno.test("truncate: respeta el max y agrega elipsis", () => {
+  assertEquals(_internal.truncate("hola", 10), "hola");
+  assertEquals(_internal.truncate("hola mundo!", 5), "hola…");
+  // Espacio antes del elipsis se trimmea.
+  assertEquals(_internal.truncate("hola mundo!", 6), "hola…");
+});

--- a/supabase/functions/tests/telegram-webhook.test.ts
+++ b/supabase/functions/tests/telegram-webhook.test.ts
@@ -766,6 +766,21 @@ Deno.test("/cliente Pe flow: invoca buscar_cliente y manda mensaje MarkdownV2", 
     });
     assert(msg, "no se mandó el mensaje formateado de buscar_cliente");
 
+    // Inline keyboard adjunto: callback_data v1:cliente:42 (action=cliente)
+    // y label con el nombre del cliente.
+    const msgBody = (msg as { body?: string }).body ?? "";
+    assertStringIncludes(
+      msgBody,
+      "reply_markup",
+      "el mensaje debe llevar reply_markup con el inline keyboard",
+    );
+    assertStringIncludes(
+      msgBody,
+      "v1:cliente:42",
+      "el callback_data del botón debe ser v1:cliente:<id>",
+    );
+    assertStringIncludes(msgBody, "Ver ficha", "el botón debe decir Ver ficha");
+
     // Se logueó el comando (tipo=comando, tool_name=cliente).
     const auditCmd = spy.inserts.find((i) =>
       i.table === "bot_audit_log" && i.row.tool_name === "cliente" &&


### PR DESCRIPTION
## Summary

Sube el bot de slash-command-only a UX con inline keyboards. Después de cada \`/cliente\`, \`/producto\`, \`/sugerencias\` y \`/misclientes\`, aparecen botones "Ver ficha — <nombre>" (o "Ver detalle — <nombre>" para productos) debajo del mensaje. Tocando uno se abre la ficha del cliente en un nuevo mensaje, sin tipear comandos.

Es la primera fase del UX upgrade definido en el plan post-mortem de la iteración 1. Las siguientes (visual polish, /menu de navegación, /reset, typing indicator) salen en PRs separados.

## Cambios

### Foundations (commit 1)
- Tipos nuevos en \`telegram.ts\`: \`InlineKeyboardButton\`, \`InlineKeyboardMarkup\`, \`ChatAction\`, \`AnswerCallbackQueryOptions\`, \`TelegramCallbackQuery\`.
- \`SendMessageOptions.reply_markup\` opcional.
- Helper interno \`callTelegramApi\` que extrae el fetch/parse plumbing — sendMessage lo reusa, y las funciones nuevas \`sendChatAction\` y \`answerCallbackQuery\` también, atrapando errores de red en lugar de propagarlos (best-effort).
- \`parseUpdate\` ahora acepta \`callback_query\` además de \`message\`.
- \`telegram-webhook/index.ts\` rutea callback_query a \`handleCallbackQuery\`, message a \`handleUpdate\`, otros shapes a audit "unsupported".
- \`handleCallbackQuery\` (handlers.ts):
  - Format de callback_data: \`v1:<action>:<arg1>[:<arg2>...]\` — versionado.
  - Validación, scope check, audit con \`tipo='comando'\` y \`parametros: { source: 'callback', action, args }\`.
  - Routing inicial: \`v1:cliente:<id>\` invoca \`ficha_cliente\` con permission gate via invokeTool y formatea con formatFichaCliente. Acciones reservadas (producto, visitar, menu) responden placeholder.

### Inline keyboards (commit 2)
- \`_shared/telegram-keyboards.ts\` (NEW): builders puros para 4 keyboards, cada uno toma el mismo shape que el formatter recibe. Truncate de texto del botón a 28 chars; callback_data dentro del límite de 64 bytes UTF-8.
- 4 commands handlers (\`/cliente\`, \`/producto\`, \`/sugerencias\`, \`/misclientes\`) ahora arman el keyboard con su builder y pasan reply_markup a \`sendMessageMarkdownSafe\`. Si el resultado es vacío, no se manda reply_markup.

### Decisiones de diseño

- **Formatters quedan sin tocar.** Los commands handlers arman el keyboard por separado (no se cambió la firma de los formatters). Más fácil de evolucionar y permite que un futuro caller (LLM tool result formatter, notifications) reuse el mismo formatter sin keyboard.
- **\`v1:cliente:<id>\` como única action para abrir la ficha**, sin diferenciar el origen (búsqueda / sugerencias / misclientes). El destino siempre es la ficha y separar las actions sería duplicación.
- **No expandir el enum \`tipo\` de \`bot_audit_log\`.** Los callbacks se loguean como \`tipo='comando'\` con \`parametros.source='callback'\` — se filtran fácil con SQL y evita una migration.

## Test plan

- [x] \`deno task check\` OK
- [x] \`deno task lint\` OK
- [x] \`deno task test\` 95 passed | 0 failed (8 nuevos tests para keyboards + 1 test existente extendido para verificar reply_markup en \`/cliente\`)
- [ ] **Post-deploy** smoke al bot real:
  - [ ] \`/cliente san\` → ver botones "Ver ficha — …" debajo. Tocar uno → ficha + spinner del botón se va.
  - [ ] \`/sugerencias\` (preventista) → botones "Ver ficha". Tocar.
  - [ ] \`/misclientes\` → botones "Ver ficha".
  - [ ] \`/producto agua\` → ver botones "Ver detalle — …". Tocar uno → spinner se va + mensaje "esa acción todavía no está disponible" (placeholder esperado).
  - [ ] \`bot_audit_log\` muestra filas \`tipo='comando'\` con \`parametros->>'source' = 'callback'\` después de las pulsaciones.

## Fuera de alcance (próximas fases)

- Visual polish de formatters (headers, dividers, emojis estructurales) — Fase 2.
- \`/menu\` con main menu keyboard — Fase 3.
- \`/reset\`, \`/desvincular\`, typing indicator, errores específicos — Fase 3.
- Tool de detalle de producto (callback \`v1:producto:<id>\` queda como placeholder) — iteración futura.
- Acciones de write con confirmación inline ("Marcar visitado", "Marcar entregado", etc.) — iteración futura.

🤖 Generated with [Claude Code](https://claude.com/claude-code)