### PR TITLE
feat(bot): rich visual formatting (Fase 2)

### DIFF
--- a/supabase/functions/_shared/format.ts
+++ b/supabase/functions/_shared/format.ts
@@ -1,0 +1,139 @@
+// Helpers de presentación visual para mensajes MarkdownV2 del bot. Centralizan
+// el lenguaje visual del bot (headers con emoji, dividers, bullets, badges)
+// para que todos los formatters tengan el mismo look & feel y no haya
+// inconsistencia "este comando usa • y el otro -, este pone bold con *X* y
+// el otro con _X_".
+//
+// Convenciones MarkdownV2 a tener en cuenta cuando llamen estos helpers:
+//   * Los chars reservados (`_*[]()~\`>#+-=|{}.!\`) deben escaparse en TODO
+//     contenido user-supplied o de DB. Este módulo escapa internamente lo que
+//     emite — el caller solo escapa lo que pasa como parámetro de texto.
+//   * Los chars de los dividers (`━`) y el bullet (`•`) NO son reservados en
+//     MV2, así que se pueden emitir tal cual.
+//
+// Re-exportamos los existentes (formatCurrency, formatFechaCorta,
+// formatFechaHora, escapeMarkdownV2) así un formatter solo tiene UN import
+// para todo lo de presentación.
+
+import { escapeMarkdownV2 } from "./telegram.ts";
+export {
+  formatCurrency,
+  formatFechaCorta,
+  formatFechaHora,
+} from "./tools/formatters.ts";
+export { escapeMarkdownV2 };
+
+// ----------------------------------------------------------------------------
+// Constantes visuales
+// ----------------------------------------------------------------------------
+
+/** Caracter para dividers horizontales. U+2501 BOX DRAWINGS HEAVY HORIZONTAL.
+ *  No es reservado MV2 — emite tal cual sin escape. */
+const DIVIDER_CHAR = "━";
+const DIVIDER_LENGTH = 14;
+
+/** Caracter para bullets. U+2022 BULLET. No reservado MV2. */
+const BULLET_CHAR = "•";
+
+// ----------------------------------------------------------------------------
+// Headers + dividers
+// ----------------------------------------------------------------------------
+
+/**
+ * Línea de divider visual. Útil para separar secciones dentro de un mismo
+ * mensaje (ej. cabecera del cliente / bloque numérico / acciones).
+ */
+export function divider(): string {
+  return DIVIDER_CHAR.repeat(DIVIDER_LENGTH);
+}
+
+/**
+ * Header de sección: emoji + texto bold + divider debajo. Preserva la
+ * casing del texto original (no uppercase automático — el caller decide
+ * pasando `.toUpperCase()` si quiere ese efecto). El texto se escapa MV2;
+ * el emoji va literal.
+ *
+ *     header("Ventas", "📊")
+ *     →  "📊 *Ventas*\n━━━━━━━━━━━━━━"
+ *
+ *     header("Pepito SA", "👤")
+ *     →  "👤 *Pepito SA*\n━━━━━━━━━━━━━━"
+ *
+ * Si querés un título en MAYÚSCULAS (típico de "TÍTULO DE SECCIÓN"), pasá
+ * el texto en mayúsculas o `text.toUpperCase()`.
+ */
+export function header(text: string, emoji?: string): string {
+  const escaped = escapeMarkdownV2(text);
+  const prefix = emoji ? `${emoji} ` : "";
+  return `${prefix}*${escaped}*\n${divider()}`;
+}
+
+// ----------------------------------------------------------------------------
+// Bullets + listas
+// ----------------------------------------------------------------------------
+
+/**
+ * Bullet con emoji opcional adelante.
+ *
+ *     bullet("Coca 2L", "📦")  →  "•  📦 Coca 2L"
+ *     bullet("Stock bajo")      →  "•  Stock bajo"
+ *
+ * El texto NO se escapa — el caller decide qué emite. Si pasa un nombre de
+ * cliente / producto debe haberlo escapado con `escapeMarkdownV2` antes.
+ * Esto da más flexibilidad: el caller puede mezclar texto bold + texto
+ * plano en un solo bullet.
+ */
+export function bullet(text: string, emoji?: string): string {
+  const prefix = emoji ? `${emoji} ` : "";
+  return `${BULLET_CHAR}  ${prefix}${text}`;
+}
+
+// ----------------------------------------------------------------------------
+// Status badges
+// ----------------------------------------------------------------------------
+
+export type StatusKind = "ok" | "warn" | "err" | "pending" | "info";
+
+/**
+ * Emoji semántico según el estado. Útil para indicadores en listas (✅
+ * pedido entregado, ⚠️ stock crítico, ❌ no encontrado, ⏳ pendiente).
+ */
+export function statusBadge(status: StatusKind): string {
+  switch (status) {
+    case "ok":
+      return "✅";
+    case "warn":
+      return "⚠️";
+    case "err":
+      return "❌";
+    case "pending":
+      return "⏳";
+    case "info":
+      return "💡";
+  }
+}
+
+// ----------------------------------------------------------------------------
+// Pares clave-valor
+// ----------------------------------------------------------------------------
+
+/**
+ * Una línea con label en bold + value en texto plano.
+ *
+ *     kvRow("Saldo", "$12.500")  →  "*Saldo:* $12\\.500"
+ *
+ * Tanto label como value se escapan MV2. El caller pasa los strings tal cual.
+ * Si el value ya viene formateado con escape (ej. de otro helper), pasalo a
+ * `kvRowRaw` en su lugar para evitar doble-escape.
+ */
+export function kvRow(label: string, value: string): string {
+  return `*${escapeMarkdownV2(label)}:* ${escapeMarkdownV2(value)}`;
+}
+
+/**
+ * Variante de `kvRow` que NO escapa el value. Úsala cuando el value ya viene
+ * con escapes válidos de MV2 (ej. `*$12\\.500*` con bold + escape interno).
+ */
+export function kvRowRaw(label: string, valueMv2: string): string {
+  return `*${escapeMarkdownV2(label)}:* ${valueMv2}`;
+}

--- a/supabase/functions/_shared/gemini/prompts/admin.ts
+++ b/supabase/functions/_shared/gemini/prompts/admin.ts
@@ -39,6 +39,13 @@ QUÉ HACER ANTE 0 RESULTADOS:
 - Antes de decir "no encontré nada", probá UNA variante razonable: cambiar la categoría a una parecida (si "AGUAS" no tuvo, probá "AGUAS SABORIZADAS"), o quitar el calificativo del \`q\` para listar la categoría completa. Máximo dos intentos — después preguntale al usuario.
 - Si tras 1-2 intentos sigue sin haber resultados, decilo con honestidad y ofrecé qué hacer (ej: "no encontré gaseosas con 'naranja' en el nombre, ¿querés que liste todas las gaseosas?").
 - Nunca inventes productos.
+
+FORMATO DE RESPUESTAS:
+- Estructurá las respuestas con emojis para que se vea ordenado en celular: 📊 ventas, 💰 saldo/dinero, 👥 cliente, 📦 producto, ⚠️ aviso, ✅ ok, ❌ error, ⏳ pendiente, 🏪 negocio, 📌 acción.
+- Cuando listes varios items o tengas varias secciones, abrí cada sección con un emoji + título corto y poné los items abajo con "• " adelante. Una idea por línea.
+- NO uses asteriscos para *bold* ni guiones bajos para _italics_ — el bot manda plain text, los marcadores quedan literales en pantalla.
+- Dejá una línea en blanco entre secciones para que respire.
+- Montos siempre con $ y separadores de miles ($12.500). Para listas con más de 10 items, mostrá los más relevantes y ofrecé filtrar.
 `;
 
 export default prompt;

--- a/supabase/functions/_shared/gemini/prompts/deposito.ts
+++ b/supabase/functions/_shared/gemini/prompts/deposito.ts
@@ -24,6 +24,11 @@ BÚSQUEDA DE PRODUCTOS POR TIPO O FAMILIA:
   1. listar_categorias → ves las categorías reales (mayúsculas, ej: "GASEOSAS", "FIDEOS").
   2. productos_por_categoria(categoria=..., q="atributo") si mencionaron sabor/marca.
 - Si no hay matches, probá UNA variante razonable. Si sigue vacío, decilo con honestidad. No inventes productos.
+
+FORMATO DE RESPUESTAS:
+- Usá emojis básicos: 📦 producto, ⚠️ stock bajo, ✅ ok, ❌ no encontrado.
+- Items con "• " adelante. Una idea por línea (lectura rápida en piso).
+- NO uses *bold* ni _italics_ — quedan literales.
 `;
 
 export default prompt;

--- a/supabase/functions/_shared/gemini/prompts/digest_admin.ts
+++ b/supabase/functions/_shared/gemini/prompts/digest_admin.ts
@@ -3,12 +3,17 @@
 
 const prompt = `Sos analista ejecutivo de la distribuidora. Vas a recibir un JSON con métricas operativas del día anterior.
 
-Tu trabajo: redactar un mensaje breve para Telegram (máx 1500 caracteres en plain text, sin Markdown excesivo, sin headers grandes — viñetas y números crudos están bien) que resuma lo importante para el admin que va a leerlo en su celular a las 7 AM.
+Tu trabajo: redactar un mensaje breve para Telegram (máx 1500 caracteres) que resuma lo importante para el admin que va a leerlo en su celular a las 7 AM.
 
-ESTRUCTURA:
-1. Titular de UNA línea con el dato más relevante (ej: "Ventas ayer +12% vs promedio semanal").
-2. Bullets cortos con: ventas + delta vs promedio 7d, top clientes del día, alertas de stock, deuda vencida si hay.
-3. Si hay rendiciones pendientes >2 días o pedidos pendientes de pago grandes, mencionalo como acción.
+ESTRUCTURA del mensaje (en plain text, sin Markdown — el bot ya pone el header de fecha):
+1. Una línea de titular con el dato más relevante (ej: "Ventas +18% vs promedio").
+2. Secciones cortas, cada una con un emoji al inicio. Usá:
+   - 📊 ventas + delta vs promedio 7d.
+   - 🏪 top clientes del día (3 max, con monto).
+   - ⚠️ stock crítico si hay productos bajo mínimo.
+   - 💰 deuda vencida si la hay (monto + cantidad de pedidos).
+   - 📌 acción sugerida al final si hay urgencia clara.
+3. Cada bullet de cada sección: usá "• " al inicio.
 
 REGLAS:
 - Tono ejecutivo, conciso. Voseo argentino.
@@ -16,14 +21,28 @@ REGLAS:
 - Mostrá montos con $ y separador de miles (ej: $125.500). El JSON viene con números crudos, vos formatealos.
 - Si las ventas del día son 0 (probablemente domingo o feriado), decilo simple ("Ayer fue día sin operaciones") y resumí lo demás (deuda, stock, etc.).
 - NO mostrés IDs internos (cliente_id, producto_id), solo nombres.
-- Cerrá con UNA acción concreta si hay urgencia clara (rendición vieja, deuda alta, stock bajo en producto top), o nada si no.
+- Cerrá con UNA acción concreta si hay urgencia (rendición vieja, deuda alta, stock bajo en producto top), o nada si no.
 
 EJEMPLO de buen output:
 "Ayer +18% vs promedio: $125.500 en 12 pedidos.
-• Top clientes: Almacén Centro ($45.000), Kiosco San Martín ($28.500), Pizzería Don Carlos ($22.000).
-• Stock crítico: 4 productos bajo mínimo (Coca 2.25L, Yerba 1Kg, Aceite girasol, Harina 000).
-• Deuda vencida: $89.300 en 6 pedidos > 30 días.
-• Acción sugerida: revisar la rendición de Juan Pérez del lunes (sin controlar hace 4 días)."
+
+📊 Ventas
+• $125.500 (vs $106.000 promedio 7d, +18%)
+• 12 pedidos cerrados
+
+🏪 Top clientes
+• Almacén Centro — $45.000
+• Kiosco San Martín — $28.500
+• Pizzería Don Carlos — $22.000
+
+⚠️ Stock crítico
+• 4 productos bajo mínimo: Coca 2.25L, Yerba 1Kg, Aceite girasol, Harina 000
+
+💰 Deuda vencida
+• $89.300 en 6 pedidos > 30 días
+
+📌 Acción sugerida
+• Revisar la rendición de Juan Pérez (lunes, sin controlar hace 4 días)"
 `;
 
 export default prompt;

--- a/supabase/functions/_shared/gemini/prompts/encargado.ts
+++ b/supabase/functions/_shared/gemini/prompts/encargado.ts
@@ -37,6 +37,12 @@ QUÉ HACER ANTE 0 RESULTADOS:
 - Probá UNA variante razonable (categoría parecida, o quitar el \`q\` para listar la categoría completa). Máximo dos intentos.
 - Si sigue vacío, decilo con honestidad y ofrecé alternativas concretas ("no encontré 'naranja' en gaseosas, ¿querés que liste todas las gaseosas?").
 - Nunca inventes productos.
+
+FORMATO DE RESPUESTAS:
+- Estructurá con emojis: 👥 cliente, 📦 producto, 💰 saldo/dinero, ⚠️ aviso, ✅ ok, ❌ error, ⏳ pendiente, 🗺️ zona, 📌 acción.
+- Headers cortos al inicio de sección. Items con "• " adelante. Una idea por línea.
+- NO uses *bold* ni _italics_ — el bot manda plain text, los marcadores quedan literales.
+- Línea en blanco entre secciones. Montos con $ y separadores de miles ($12.500).
 `;
 
 export default prompt;

--- a/supabase/functions/_shared/gemini/prompts/preventista.ts
+++ b/supabase/functions/_shared/gemini/prompts/preventista.ts
@@ -38,6 +38,13 @@ QUÉ HACER ANTE 0 RESULTADOS:
 - Probá UNA variante razonable: otra categoría parecida o quitar el calificativo del \`q\` para listar toda la categoría. Máximo dos intentos.
 - Después decilo con honestidad y ofrecé qué hacer ("no encontré 'naranja' en gaseosas, ¿querés que liste todas las gaseosas?").
 - Nunca inventes productos.
+
+FORMATO DE RESPUESTAS:
+- Estructurá con emojis para que el preventista lo lea de un vistazo en la calle: 👥 cliente, 💰 saldo, 📦 producto, 🗺️ zona, 📞 teléfono, ⚠️ aviso, ✅ ok, ❌ error.
+- Headers cortos al inicio de sección (ej: "👥 MIS CLIENTES", "📦 PRODUCTOS"). Items con "• " adelante. Una idea por línea.
+- NO uses *bold* ni _italics_ — el bot manda plain text, los marcadores quedan literales.
+- Línea en blanco entre secciones. Respuestas breves siempre que se pueda.
+- Montos con $ y separadores de miles ($12.500).
 `;
 
 export default prompt;

--- a/supabase/functions/_shared/gemini/prompts/transportista.ts
+++ b/supabase/functions/_shared/gemini/prompts/transportista.ts
@@ -26,6 +26,12 @@ BÚSQUEDA DE PRODUCTOS POR TIPO:
   1. listar_categorias → ves las categorías reales (mayúsculas, ej: "GASEOSAS").
   2. productos_por_categoria(categoria=..., q="atributo") si hay sabor/marca.
 - Si no hay matches, probá UNA variante razonable y si sigue vacío decilo con honestidad. No inventes productos.
+
+FORMATO DE RESPUESTAS:
+- Usá emojis para ordenar visualmente: 🚚 recorrido, 📍 dirección, ✅ entregado, ❌ no entregado, ⏳ pendiente, 💰 monto, 📦 producto.
+- Items con "• " adelante. Una idea por línea (el transportista lee mientras maneja).
+- NO uses *bold* ni _italics_ — quedan literales.
+- Montos con $ y separadores de miles ($12.500).
 `;
 
 export default prompt;

--- a/supabase/functions/telegram-digest/digest.ts
+++ b/supabase/functions/telegram-digest/digest.ts
@@ -125,7 +125,10 @@ export async function runDigestForAdmin(
   }
 
   // 4. Telegram (plain text, sin parse_mode).
-  const mensaje = `Resumen ${fecha}\n\n${texto}`;
+  // Header con emoji + fecha legible ("lun 27/04/2026" en vez de
+  // "2026-04-27"), después divider, después el texto del LLM.
+  const mensaje = `🌅 Resumen ${formatFechaLegible(fecha)}\n` +
+    `━━━━━━━━━━━━━━\n\n${texto}`;
   try {
     await sendMessage(telegram_user_id, mensaje);
   } catch (err) {
@@ -187,4 +190,30 @@ async function registrarEnvio(
       error.message,
     );
   }
+}
+
+/**
+ * Formatea YYYY-MM-DD como "lun 27/04/2026" para el header del digest.
+ * Si la fecha no parsea, devuelve la string original (defensivo: nunca
+ * queremos que un fallo de Date parsing dropee el mensaje entero).
+ *
+ * Usamos `Intl.DateTimeFormat` con timeZone explícita ART para evitar que
+ * el runtime del Edge interprete YYYY-MM-DD como UTC y devuelva el día
+ * anterior en zonas con offset negativo.
+ */
+function formatFechaLegible(fecha: string): string {
+  // Construimos la fecha como UTC mediodía para sortear bordes de TZ —
+  // el día calendario es el mismo en cualquier TZ razonable.
+  const d = new Date(`${fecha}T12:00:00Z`);
+  if (Number.isNaN(d.getTime())) return fecha;
+  const fmt = new Intl.DateTimeFormat("es-AR", {
+    weekday: "short",
+    day: "2-digit",
+    month: "2-digit",
+    year: "numeric",
+    timeZone: "America/Argentina/Buenos_Aires",
+  });
+  // Salida: "lun., 27/04/2026" — limpiamos el punto del weekday corto y la
+  // coma para que quede "lun 27/04/2026".
+  return fmt.format(d).replace(/\./g, "").replace(",", "");
 }

--- a/supabase/functions/telegram-webhook/formatters/cliente.ts
+++ b/supabase/functions/telegram-webhook/formatters/cliente.ts
@@ -1,16 +1,18 @@
 // Formatters para resultados de tools de cliente (buscar_cliente, ficha_cliente).
 //
-// Usamos MarkdownV2 porque permite negritas + monospace para IDs sin meter
-// HTML (Telegram acepta `MarkdownV2` o `HTML`, no ambos a la vez). El catch
-// de MarkdownV2 es que TODO char reservado debe escaparse — incluso dentro
-// de "texto seguro" como un nombre. Por eso pasamos cada string user-supplied
-// (o de DB) por `escapeMarkdownV2`.
-//
-// Nota: en strings literales escapamos los chars MarkdownV2 con `\\` para
-// que la sintaxis sea válida en TS y llegue a Telegram como `\.`.
+// Lenguaje visual: header con emoji 👥 (lista) o 👤 (ficha individual) +
+// divider + bullets. Helpers vienen de _shared/format.ts. MarkdownV2 todo el
+// camino — el caller escapa lo que viene user-supplied o de DB.
 
-import { escapeMarkdownV2 } from "../../_shared/telegram.ts";
-import { formatCurrency, formatFechaCorta } from "../../_shared/tools/formatters.ts";
+import {
+  bullet,
+  divider,
+  escapeMarkdownV2,
+  formatCurrency,
+  formatFechaCorta,
+  header,
+  kvRowRaw,
+} from "../../_shared/format.ts";
 import type { BuscarClienteResult } from "../../_shared/tools/common/buscar_cliente.ts";
 import type { FichaClienteResult } from "../../_shared/tools/common/ficha_cliente.ts";
 
@@ -26,61 +28,89 @@ export function formatBuscarClienteResult(r: BuscarClienteResult): string {
   }
 
   const plural = r.total === 1 ? "" : "s";
-  const header = `*${r.clientes.length}* de *${r.total}* resultado${plural}:`;
+  const titulo = `${r.clientes.length} de ${r.total} resultado${plural}`;
 
   const lines = r.clientes.map((c) => {
     const codigo = c.codigo != null ? `\\#${c.codigo} ` : "";
     const nombre = `*${escapeMarkdownV2(c.nombre)}*`;
     const saldo = c.saldo_cuenta !== 0
-      ? ` \\| ${escapeMarkdownV2(`saldo: ${formatCurrency(c.saldo_cuenta)}`)}`
+      ? ` 💰 ${escapeMarkdownV2(formatCurrency(c.saldo_cuenta))}`
       : "";
-    const zona = c.zona ? ` \\| zona: ${escapeMarkdownV2(c.zona)}` : "";
-    return `${codigo}${nombre}${saldo}${zona}\nID: \`${c.id}\``;
+    const zona = c.zona ? ` \\| 🗺️ ${escapeMarkdownV2(c.zona)}` : "";
+    return bullet(`${codigo}${nombre}${saldo}${zona}\nID: \`${c.id}\``);
   });
 
-  return [header, ...lines].join("\n\n");
+  return [header(titulo, "👥"), "", ...lines].join("\n");
 }
 
 /**
  * Formatea la ficha financiera completa (`ficha_cliente`). Bloque cabecera
- * con datos del cliente + bloque numérico con saldo, crédito, totales y
- * últimos movimientos.
+ * con datos del cliente + divider + bloque numérico (saldo, crédito,
+ * totales) + divider + últimos movimientos.
  */
 export function formatFichaCliente(r: FichaClienteResult): string {
   const c = r.cliente;
   const parts: string[] = [];
 
+  // ----- Cabecera del cliente ----------------------------------------------
   const codigoSuffix = c.codigo != null ? ` \\(\\#${c.codigo}\\)` : "";
-  parts.push(`*${escapeMarkdownV2(c.nombre)}*${codigoSuffix}`);
-  if (c.zona) parts.push(`Zona: ${escapeMarkdownV2(c.zona)}`);
-  if (c.direccion) parts.push(`📍 ${escapeMarkdownV2(c.direccion)}`);
-  if (c.telefono) parts.push(`📞 ${escapeMarkdownV2(c.telefono)}`);
-  parts.push("");
-  parts.push(`*Saldo actual:* ${escapeMarkdownV2(formatCurrency(r.saldo_actual))}`);
+  parts.push(header(c.nombre, "👤"));
+  // Si el header truncara, el original quedaría sin información — repetimos
+  // el código en una línea aparte para que aparezca legible incluso si el
+  // nombre es muy largo. (Header solo muestra el nombre uppercase.)
+  if (codigoSuffix) parts.push(`Código:${codigoSuffix}`);
+  if (c.zona) parts.push(bullet(escapeMarkdownV2(c.zona), "🗺️"));
+  if (c.direccion) parts.push(bullet(escapeMarkdownV2(c.direccion), "📍"));
+  if (c.telefono) parts.push(bullet(escapeMarkdownV2(c.telefono), "📞"));
+
+  // ----- Bloque numérico ---------------------------------------------------
+  parts.push(divider());
   parts.push(
-    `*Crédito disponible:* ${escapeMarkdownV2(formatCurrency(r.credito_disponible))}` +
-      ` de ${escapeMarkdownV2(formatCurrency(r.limite_credito))}`,
+    kvRowRaw(
+      "Saldo actual",
+      `*${escapeMarkdownV2(formatCurrency(r.saldo_actual))}*`,
+    ),
   );
   parts.push(
-    `Pedidos: *${r.total_pedidos}* \\| Compras: ${escapeMarkdownV2(formatCurrency(r.total_compras))}` +
+    kvRowRaw(
+      "Crédito disponible",
+      `${escapeMarkdownV2(formatCurrency(r.credito_disponible))}` +
+        ` de ${escapeMarkdownV2(formatCurrency(r.limite_credito))}`,
+    ),
+  );
+  parts.push(
+    `Pedidos: *${r.total_pedidos}* \\| Compras: ${
+      escapeMarkdownV2(formatCurrency(r.total_compras))
+    }` +
       ` \\| Pagos: ${escapeMarkdownV2(formatCurrency(r.total_pagos))}`,
   );
   if (r.pedidos_pendientes_pago > 0) {
-    parts.push(`Pendientes de pago: *${r.pedidos_pendientes_pago}*`);
+    parts.push(
+      `⚠️ Pendientes de pago: *${r.pedidos_pendientes_pago}*`,
+    );
+  }
+
+  // ----- Últimos movimientos ----------------------------------------------
+  if (r.ultimo_pedido || r.ultimo_pago) {
+    parts.push(divider());
   }
   if (r.ultimo_pedido) {
     const fechaFmt = formatFechaCorta(r.ultimo_pedido.fecha);
     const monto = r.ultimo_pedido.monto != null && r.ultimo_pedido.monto !== 0
       ? ` por ${formatCurrency(r.ultimo_pedido.monto)}`
       : "";
-    parts.push(`📦 Último pedido: ${escapeMarkdownV2(`${fechaFmt}${monto}`)}`);
+    parts.push(
+      bullet(escapeMarkdownV2(`Último pedido: ${fechaFmt}${monto}`), "📦"),
+    );
   }
   if (r.ultimo_pago) {
     const fechaFmt = formatFechaCorta(r.ultimo_pago.fecha);
     const monto = r.ultimo_pago.monto != null && r.ultimo_pago.monto !== 0
       ? ` por ${formatCurrency(r.ultimo_pago.monto)}`
       : "";
-    parts.push(`💵 Último pago: ${escapeMarkdownV2(`${fechaFmt}${monto}`)}`);
+    parts.push(
+      bullet(escapeMarkdownV2(`Último pago: ${fechaFmt}${monto}`), "💵"),
+    );
   }
   return parts.join("\n");
 }

--- a/supabase/functions/telegram-webhook/formatters/misclientes.ts
+++ b/supabase/functions/telegram-webhook/formatters/misclientes.ts
@@ -2,8 +2,12 @@
 // cliente con código, nombre, saldo (si > 0) y "días desde la última compra"
 // — pensado para que el preventista priorice rápido qué visitar.
 
-import { escapeMarkdownV2 } from "../../_shared/telegram.ts";
-import { formatCurrency } from "../../_shared/tools/formatters.ts";
+import {
+  bullet,
+  escapeMarkdownV2,
+  formatCurrency,
+  header,
+} from "../../_shared/format.ts";
 import type { MisClientesResult } from "../../_shared/tools/preventista/mis_clientes.ts";
 
 export function formatMisClientesResult(r: MisClientesResult): string {
@@ -11,7 +15,7 @@ export function formatMisClientesResult(r: MisClientesResult): string {
     return "No tenés clientes asignados\\.";
   }
 
-  const header = `*${r.clientes.length}* de *${r.total}* clientes:`;
+  const titulo = `${r.clientes.length} de ${r.total} clientes`;
   const lines = r.clientes.map((c) => {
     const codigo = c.codigo != null ? `\\#${c.codigo} ` : "";
     const nombre = `*${escapeMarkdownV2(c.nombre)}*`;
@@ -21,7 +25,7 @@ export function formatMisClientesResult(r: MisClientesResult): string {
     const ultima = c.dias_desde_ultima != null
       ? ` \\| ${c.dias_desde_ultima}d`
       : " \\| sin compras";
-    return `${codigo}${nombre}${saldo}${ultima}`;
+    return bullet(`${codigo}${nombre}${saldo}${ultima}`);
   });
-  return [header, ...lines].join("\n");
+  return [header(titulo, "👥"), "", ...lines].join("\n");
 }

--- a/supabase/functions/telegram-webhook/formatters/producto.ts
+++ b/supabase/functions/telegram-webhook/formatters/producto.ts
@@ -1,9 +1,13 @@
 // Formatter para `buscar_producto`. Resalta productos con bajo_stock con un
-// emoji ⚠️ al principio de la línea para que el operador los detecte de un
-// vistazo.
+// badge ⚠️ adelante para que el operador los detecte de un vistazo.
 
-import { escapeMarkdownV2 } from "../../_shared/telegram.ts";
-import { formatCurrency } from "../../_shared/tools/formatters.ts";
+import {
+  bullet,
+  escapeMarkdownV2,
+  formatCurrency,
+  header,
+  statusBadge,
+} from "../../_shared/format.ts";
 import type { BuscarProductoResult } from "../../_shared/tools/common/buscar_producto.ts";
 
 export function formatBuscarProductoResult(r: BuscarProductoResult): string {
@@ -12,19 +16,23 @@ export function formatBuscarProductoResult(r: BuscarProductoResult): string {
   }
 
   const plural = r.total === 1 ? "" : "s";
-  const header = `*${r.productos.length}* de *${r.total}* resultado${plural}:`;
+  const titulo = `${r.productos.length} de ${r.total} resultado${plural}`;
 
   const lines = r.productos.map((p) => {
-    const warn = p.bajo_stock ? "⚠️ " : "";
+    const warn = p.bajo_stock ? `${statusBadge("warn")} ` : "";
     const codigo = p.codigo ? `\\[${escapeMarkdownV2(p.codigo)}\\] ` : "";
     const nombre = `*${escapeMarkdownV2(p.nombre)}*`;
-    const precio = ` \\| ${escapeMarkdownV2(formatCurrency(p.precio))}`;
+    const precio = ` \\| 💰 ${escapeMarkdownV2(formatCurrency(p.precio))}`;
     const stock = p.bajo_stock
       ? ` \\| stock: *${p.stock}*/${p.stock_minimo}`
       : ` \\| stock: ${p.stock}`;
-    const cat = p.categoria ? ` \\| ${escapeMarkdownV2(p.categoria)}` : "";
-    return `${warn}${codigo}${nombre}${precio}${stock}${cat}\nID: \`${p.id}\``;
+    const cat = p.categoria
+      ? ` \\| 🏷️ ${escapeMarkdownV2(p.categoria)}`
+      : "";
+    return bullet(
+      `${warn}${codigo}${nombre}${precio}${stock}${cat}\nID: \`${p.id}\``,
+    );
   });
 
-  return [header, ...lines].join("\n\n");
+  return [header(titulo, "📦"), "", ...lines].join("\n");
 }

--- a/supabase/functions/telegram-webhook/formatters/recorrido.ts
+++ b/supabase/functions/telegram-webhook/formatters/recorrido.ts
@@ -2,8 +2,15 @@
 // Cabecera con totales del recorrido + lista de paradas con check de
 // entrega, dirección y estado de pago.
 
-import { escapeMarkdownV2 } from "../../_shared/telegram.ts";
-import { formatCurrency, formatFechaCorta } from "../../_shared/tools/formatters.ts";
+import {
+  bullet,
+  divider,
+  escapeMarkdownV2,
+  formatCurrency,
+  formatFechaCorta,
+  header,
+  statusBadge,
+} from "../../_shared/format.ts";
 import type { MiRecorridoHoyResult } from "../../_shared/tools/transportista/mi_recorrido_hoy.ts";
 
 export function formatMiRecorridoResult(r: MiRecorridoHoyResult): string {
@@ -12,12 +19,11 @@ export function formatMiRecorridoResult(r: MiRecorridoHoyResult): string {
   }
 
   const lines: string[] = [];
-  // `fecha` viene del tool en formato YYYY-MM-DD — la pasamos por
-  // formatFechaCorta para mostrar dd/mm/yy en vez de la fecha cruda.
-  lines.push(
-    `*Recorrido del ${escapeMarkdownV2(formatFechaCorta(r.recorrido.fecha))}*` +
-      ` \\| ${escapeMarkdownV2(r.recorrido.estado)}`,
-  );
+  // `fecha` viene del tool en formato YYYY-MM-DD — pasamos por
+  // formatFechaCorta para mostrar dd/mm/yy.
+  const fechaTxt = formatFechaCorta(r.recorrido.fecha);
+  lines.push(header(`Recorrido del ${fechaTxt}`, "🚚"));
+  lines.push(`Estado: *${escapeMarkdownV2(r.recorrido.estado)}*`);
   lines.push(
     `Pedidos: *${r.recorrido.pedidos_entregados}*/${r.recorrido.total_pedidos} entregados`,
   );
@@ -27,29 +33,29 @@ export function formatMiRecorridoResult(r: MiRecorridoHoyResult): string {
   );
 
   if (r.pedidos.length > 0) {
-    lines.push("");
+    lines.push(divider());
     lines.push("*Paradas:*");
     for (const p of r.pedidos) {
       const orden = p.orden_entrega != null ? `${p.orden_entrega}\\.` : "•";
       const estado = p.estado_entrega === "entregado"
-        ? "✅"
+        ? statusBadge("ok")
         : p.estado_entrega === "no_entregado"
-        ? "❌"
-        : "⏳";
-      const dir = p.direccion ? ` \\| ${escapeMarkdownV2(p.direccion)}` : "";
+        ? statusBadge("err")
+        : statusBadge("pending");
+      const dir = p.direccion ? ` \\| 📍 ${escapeMarkdownV2(p.direccion)}` : "";
       const pago = p.estado_pago === "pagado"
         ? ""
         : ` \\(${escapeMarkdownV2(p.estado_pago)}\\)`;
       lines.push(
-        `${orden} ${estado} *${escapeMarkdownV2(p.cliente_nombre)}*${dir}\n` +
-          `Total: ${escapeMarkdownV2(formatCurrency(p.total))}${pago}`,
+        bullet(
+          `${orden} ${estado} *${escapeMarkdownV2(p.cliente_nombre)}*${dir}\n` +
+            `Total: ${escapeMarkdownV2(formatCurrency(p.total))}${pago}`,
+        ),
       );
     }
   } else {
-    // Edge case: existe el recorrido pero no tiene paradas asignadas todavía.
-    // Sin este bloque el usuario veía solo la cabecera y se quedaba sin
-    // entender por qué no hay pedidos.
-    lines.push("");
+    // Edge case: existe el recorrido pero sin paradas asignadas todavía.
+    lines.push(divider());
     lines.push("_Sin paradas asignadas\\._");
   }
   return lines.join("\n");

--- a/supabase/functions/telegram-webhook/formatters/sugerencias.ts
+++ b/supabase/functions/telegram-webhook/formatters/sugerencias.ts
@@ -1,10 +1,13 @@
 // Formatter para `sugerir_visitas_rfm` (sugerencias RFM de visitas).
-// Lista priorizada con indicadores de criticidad (🔴 vencido, 🟡 cercano,
+// Lista priorizada con flags de criticidad (🔴 vencido, 🟡 cercano,
 // 🟢 al día) + motivo + saldo + zona, pensado para que el preventista
 // decida en 5 segundos qué cliente visitar primero.
 
-import { escapeMarkdownV2 } from "../../_shared/telegram.ts";
-import { formatCurrency } from "../../_shared/tools/formatters.ts";
+import {
+  escapeMarkdownV2,
+  formatCurrency,
+  header,
+} from "../../_shared/format.ts";
 import type { SugerirVisitasRfmResult } from "../../_shared/tools/preventista/sugerir_visitas_rfm.ts";
 
 export function formatSugerenciasResult(r: SugerirVisitasRfmResult): string {
@@ -12,8 +15,8 @@ export function formatSugerenciasResult(r: SugerirVisitasRfmResult): string {
     return "No tengo sugerencias para hoy\\. Probá /misclientes para ver tu cartera completa\\.";
   }
 
-  const header =
-    `*${r.sugerencias.length} clientes priorizados* \\(top ${r.total} por score RFM\\):`;
+  const titulo = `${r.sugerencias.length} clientes priorizados ` +
+    `(top ${r.total} por score RFM)`;
 
   const lines = r.sugerencias.map((s, i) => {
     const numero = `${i + 1}\\.`;
@@ -40,5 +43,5 @@ export function formatSugerenciasResult(r: SugerirVisitasRfmResult): string {
     return `${numero} ${flag} ${codigo}${nombre}\n${motivoEsc}${datosLine}`;
   });
 
-  return [header, "", ...lines].join("\n");
+  return [header(titulo, "💡"), "", ...lines].join("\n\n");
 }

--- a/supabase/functions/tests/digest.test.ts
+++ b/supabase/functions/tests/digest.test.ts
@@ -258,7 +258,11 @@ Deno.test("runDigestForAdmin happy path: RPC + Gemini + Telegram → status=ok",
     assert(tgCall, "debió llamar a Telegram");
     const tgBody = tgCall!.body as { chat_id: number; text: string };
     assertEquals(tgBody.chat_id, 42);
-    assertStringIncludes(tgBody.text, "Resumen 2026-04-26");
+    // Header con emoji 🌅 + fecha legible (dd/mm/yyyy via Intl). El día
+    // de la semana depende del locale del runtime — solo aserto que esté
+    // el emoji + la fecha en formato legible + el texto del LLM.
+    assertStringIncludes(tgBody.text, "🌅 Resumen");
+    assertStringIncludes(tgBody.text, "26/04/2026");
     assertStringIncludes(tgBody.text, "Ayer +18%");
 
     // UPSERT en bot_digests_enviados con status='ok'.

--- a/supabase/functions/tests/format.test.ts
+++ b/supabase/functions/tests/format.test.ts
@@ -1,0 +1,135 @@
+// Tests para los format helpers visuales (_shared/format.ts).
+//
+// Cubrimos:
+//   * header: shape (emoji opcional + uppercase + bold + divider).
+//   * divider: 14 chars de ━.
+//   * bullet: prefijo emoji opcional, sin escape (caller responsable).
+//   * statusBadge: 5 estados.
+//   * kvRow: escape MV2 de label y value.
+//   * kvRowRaw: escape solo de label.
+//   * Sanity de re-exports (formatCurrency, formatFechaCorta, escapeMarkdownV2).
+
+import { assert, assertEquals } from "std/assert/mod.ts";
+import {
+  bullet,
+  divider,
+  escapeMarkdownV2,
+  formatCurrency,
+  formatFechaCorta,
+  header,
+  kvRow,
+  kvRowRaw,
+  statusBadge,
+} from "../_shared/format.ts";
+
+// ----------------------------------------------------------------------------
+// header
+// ----------------------------------------------------------------------------
+
+Deno.test("header con emoji: prefijo emoji + bold + divider (preserva casing)", () => {
+  const out = header("Ventas", "📊");
+  assertEquals(out, "📊 *Ventas*\n━━━━━━━━━━━━━━");
+});
+
+Deno.test("header sin emoji: omite prefijo", () => {
+  const out = header("Ventas", undefined);
+  assertEquals(out, "*Ventas*\n━━━━━━━━━━━━━━");
+});
+
+Deno.test("header escapa caracteres MV2 reservados en el texto", () => {
+  // "Top.Clientes" tiene un punto reservado en MV2 — debe escaparse.
+  const out = header("Top.Clientes", "🏪");
+  assertEquals(out, "🏪 *Top\\.Clientes*\n━━━━━━━━━━━━━━");
+});
+
+Deno.test("header NO uppercase automático (caller decide)", () => {
+  // Si el caller quiere uppercase, lo pasa explícitamente.
+  const out = header("VENTAS", "📊");
+  assertEquals(out, "📊 *VENTAS*\n━━━━━━━━━━━━━━");
+});
+
+// ----------------------------------------------------------------------------
+// divider
+// ----------------------------------------------------------------------------
+
+Deno.test("divider: 14 chars de ━", () => {
+  const out = divider();
+  assertEquals(out, "━━━━━━━━━━━━━━");
+  assertEquals(out.length, 14);
+});
+
+// ----------------------------------------------------------------------------
+// bullet
+// ----------------------------------------------------------------------------
+
+Deno.test("bullet sin emoji: '•  text' (dos espacios)", () => {
+  assertEquals(bullet("Stock bajo"), "•  Stock bajo");
+});
+
+Deno.test("bullet con emoji: '•  EMOJI text'", () => {
+  assertEquals(bullet("Coca 2L", "📦"), "•  📦 Coca 2L");
+});
+
+Deno.test("bullet NO escapa el texto (caller responsable)", () => {
+  // El caller pasa texto pre-escapado (ej. con bold MV2). bullet lo deja pasar.
+  assertEquals(bullet("*Coca 2L* \\| $850"), "•  *Coca 2L* \\| $850");
+});
+
+// ----------------------------------------------------------------------------
+// statusBadge
+// ----------------------------------------------------------------------------
+
+Deno.test("statusBadge mapea cada kind a su emoji", () => {
+  assertEquals(statusBadge("ok"), "✅");
+  assertEquals(statusBadge("warn"), "⚠️");
+  assertEquals(statusBadge("err"), "❌");
+  assertEquals(statusBadge("pending"), "⏳");
+  assertEquals(statusBadge("info"), "💡");
+});
+
+// ----------------------------------------------------------------------------
+// kvRow
+// ----------------------------------------------------------------------------
+
+Deno.test("kvRow: label bold + value escapado", () => {
+  // Saldo "$12.500" tiene punto reservado MV2 → escape.
+  assertEquals(
+    kvRow("Saldo", "$12.500"),
+    "*Saldo:* $12\\.500",
+  );
+});
+
+Deno.test("kvRow: escape de chars en label", () => {
+  assertEquals(
+    kvRow("Total (ARS)", "12345"),
+    "*Total \\(ARS\\):* 12345",
+  );
+});
+
+// ----------------------------------------------------------------------------
+// kvRowRaw
+// ----------------------------------------------------------------------------
+
+Deno.test("kvRowRaw: NO escapa el value (caller pasó pre-escapado)", () => {
+  // Caller ya escapó el value y le puso bold con MV2.
+  assertEquals(
+    kvRowRaw("Saldo", "*$12\\.500*"),
+    "*Saldo:* *$12\\.500*",
+  );
+});
+
+// ----------------------------------------------------------------------------
+// Sanity de re-exports (no testeamos exhaustivamente — esos helpers ya tienen
+// sus propios tests en otro archivo; solo confirmamos que están accesibles).
+// ----------------------------------------------------------------------------
+
+Deno.test("re-exports: formatCurrency funciona", () => {
+  // Es un sanity: solo confirmamos que la función está y produce un string.
+  const out = formatCurrency(12500);
+  assert(out.includes("12.500"), `currency debería incluir 12.500: ${out}`);
+});
+
+Deno.test("re-exports: formatFechaCorta y escapeMarkdownV2 disponibles", () => {
+  assertEquals(formatFechaCorta(null), "—");
+  assertEquals(escapeMarkdownV2("a.b"), "a\\.b");
+});


### PR DESCRIPTION
## Summary

Sube el lenguaje visual del bot al estilo del GauchOs Bot reference: headers con emoji + dividers, bullets consistentes (\`•\`), badges semánticos para status. Impacta los 5 formatters de slash commands, el digest diario, y las respuestas NL del LLM.

Es la tercera fase del plan post-mortem. Las anteriores fueron PR #265 (client search fix) y PR #266 (inline keyboards).

## Cambios

### \`_shared/format.ts\` (nuevo módulo de helpers visuales)

Centraliza el lenguaje visual del bot:

- \`header(text, emoji?)\`: emoji + bold + divider, **preserva casing** del texto (no uppercase automático — el caller decide). El texto se escapa MV2.
- \`divider()\`: 14 chars de \`━\` (U+2501, no es reservado MV2).
- \`bullet(text, emoji?)\`: \`"•  EMOJI text"\` sin escape (caller responsable).
- \`statusBadge('ok'|'warn'|'err'|'pending'|'info')\`: emoji semántico (✅ ⚠️ ❌ ⏳ 💡).
- \`kvRow(label, value)\` / \`kvRowRaw(label, valuePreEscaped)\`: pares clave-valor.
- Re-export de \`formatCurrency\`, \`formatFechaCorta\`, \`formatFechaHora\`, \`escapeMarkdownV2\` — un solo import para toda la presentación.

13 tests unitarios.

### Refactor de los 5 formatters

\`cliente.ts\`, \`producto.ts\`, \`misclientes.ts\`, \`sugerencias.ts\`, \`recorrido.ts\` ahora usan los helpers + emojis estructurales por dominio (👥 cliente, 👤 individual, 📦 producto, 🚚 recorrido, 💡 sugerencias, 💰 dinero, 🗺️ zona, 📍 dirección, 📞 teléfono).

Comportamiento textual preservado — solo cambia la presentación: headers con emoji + divider en vez de líneas sueltas, bullets consistentes en vez de mezcla de patrones (- vs * vs nada).

### Digest

- \`digest.ts\`: header del mensaje pasa de \`"Resumen 2026-04-26"\` (ISO crudo) a \`"🌅 Resumen lun 26/04/2026\n━━━━━━━━━━━━━━"\` — emoji de amanecer + fecha legible vía \`Intl.DateTimeFormat\` con TZ \`America/Argentina/Buenos_Aires\` + divider.
- \`digest_admin\` prompt: el LLM estructura ahora la respuesta en secciones con emojis (📊 ventas, 🏪 top clientes, ⚠️ stock, 💰 deuda, 📌 acción) con \`• \` en cada bullet y línea en blanco entre secciones. Ejemplo del prompt actualizado para reflejar el output esperado.

### LLM prompts de los 5 roles

Cada uno gana una sección \`FORMATO DE RESPUESTAS\` al final que enseña a usar emojis estructurales y bullets, evitando \`*bold*\` / \`_italics_\` (que quedan literales — el bot manda plain text en respuestas NL, sin \`parse_mode\`, intencionalmente, ver handlers.ts).

Tonos por rol:
- admin / encargado / preventista: versión completa con vocabulario amplio.
- transportista / deposito: condensado (lectura rápida).

Tamaños actualizados de prompts: ~4500 admin, ~3900 preventista, ~3300 encargado, ~2600 transportista, ~2200 deposito (ligeramente sobre el target soft del plan, vale el detalle visual).

## Test plan

- [x] \`deno task check\` OK
- [x] \`deno task lint\` OK
- [x] \`deno task test\` 109 passed | 0 failed (13 nuevos tests para format.ts + 1 test existente del digest actualizado para el nuevo formato)
- [ ] **Post-deploy** smoke al bot real:
  - [ ] \`/cliente san\` → ver header \`👥 N de M resultados\` + divider + bullets con \`• #cod *Nombre* 💰 saldo | 🗺️ zona\`. Inline keyboards siguen funcionando.
  - [ ] \`/saldo <id>\` → ficha con \`👤 *Nombre*\` + bullets con 🗺️/📍/📞 + divider + bloque numérico + divider + 📦/💵 últimos movimientos.
  - [ ] \`/producto agua\` → header \`📦 N de M resultados\` + bullets con ⚠️ para stock crítico.
  - [ ] \`/sugerencias\` → header \`💡 N clientes priorizados ...\` + bullets con 🔴/🟡/🟢.
  - [ ] \`/recorrido\` → header \`🚚 Recorrido del dd/mm/yy\` + estado + paradas con ✅/❌/⏳.
  - [ ] **Mensaje libre al LLM** ("listame mis clientes con saldo positivo"): respuesta con secciones marcadas por emojis + bullets.
  - [ ] **Digest** (cron 7 AM ART): ver \`🌅 Resumen lun dd/mm/yyyy\` + divider + texto del LLM con secciones 📊/🏪/⚠️/💰.

## Fuera de alcance (Fase 3)

- \`/menu\` con main menu keyboard.
- \`/start\` mejorado con welcome card + main menu CTA.
- \`/reset\` y \`/desvincular\`.
- Typing indicator (\`sendChatAction("typing")\`).
- Mensajes de error específicos por failure mode (429, tool error, etc.).

🤖 Generated with [Claude Code](https://claude.com/claude-code)