### PR TITLE
feat(bot): onboarding & navigation - /menu, /reset, /desvincular, typing (Fase 3)

### DIFF
--- a/supabase/functions/_shared/telegram-keyboards.ts
+++ b/supabase/functions/_shared/telegram-keyboards.ts
@@ -17,6 +17,7 @@ import type {
   InlineKeyboardButton,
   InlineKeyboardMarkup,
 } from "./telegram.ts";
+import type { BotRol } from "./types.ts";
 
 // ----------------------------------------------------------------------------
 // Constantes
@@ -133,6 +134,89 @@ export function buildMisClientesKeyboard(
 }
 
 // ----------------------------------------------------------------------------
+// Main menu (Fase 3)
+// ----------------------------------------------------------------------------
+
+/**
+ * Tipo de cada entrada del main menu. La `key` viaja como argumento del
+ * callback (`v1:menu:<key>`) y el handler decide cómo materializarla.
+ */
+interface MainMenuEntry {
+  text: string;
+  /** Key del callback. Sin chars `:` ni espacios. */
+  key: string;
+}
+
+/**
+ * Construye el main menu apropiado para el rol del usuario. Layout 2 cols
+ * por fila — cabe bien en mobile, es lo que el GauchOs Bot usa de
+ * referencia. Cada rol ve solo las opciones que sus tools permiten.
+ *
+ *   admin / encargado:   [👥 Buscar cliente] [📦 Buscar producto]
+ *                         [❓ Ayuda]
+ *
+ *   preventista:         [👥 Mis clientes]   [💡 Sugerencias]
+ *                         [📦 Buscar producto] [❓ Ayuda]
+ *
+ *   transportista:       [🚚 Recorrido hoy]  [📦 Buscar producto]
+ *                         [❓ Ayuda]
+ *
+ *   deposito:            [📦 Buscar producto] [❓ Ayuda]
+ *
+ * El key del callback se interpreta en handleCallbackMenu — algunos disparan
+ * un slash command sin args (mis clientes, sugerencias, recorrido, ayuda),
+ * otros piden al usuario que tipee qué buscar (cliente, producto).
+ */
+export function buildMainMenuKeyboard(rol: BotRol): InlineKeyboardMarkup {
+  const entries = mainMenuEntriesForRol(rol);
+  // Pareamos en filas de 2 cols. Si la cantidad es impar, la última fila
+  // queda con 1 botón solo (visualmente OK).
+  const rows: InlineKeyboardButton[][] = [];
+  for (let i = 0; i < entries.length; i += 2) {
+    const row: InlineKeyboardButton[] = [];
+    for (let j = i; j < Math.min(i + 2, entries.length); j++) {
+      const e = entries[j];
+      row.push({
+        text: truncate(e.text),
+        callback_data: callbackData("menu", e.key),
+      });
+    }
+    rows.push(row);
+  }
+  return { inline_keyboard: rows };
+}
+
+function mainMenuEntriesForRol(rol: BotRol): MainMenuEntry[] {
+  switch (rol) {
+    case "admin":
+    case "encargado":
+      return [
+        { text: "👥 Buscar cliente", key: "buscar_cliente" },
+        { text: "📦 Buscar producto", key: "buscar_producto" },
+        { text: "❓ Ayuda", key: "ayuda" },
+      ];
+    case "preventista":
+      return [
+        { text: "👥 Mis clientes", key: "mis_clientes" },
+        { text: "💡 Sugerencias", key: "sugerencias" },
+        { text: "📦 Buscar producto", key: "buscar_producto" },
+        { text: "❓ Ayuda", key: "ayuda" },
+      ];
+    case "transportista":
+      return [
+        { text: "🚚 Recorrido de hoy", key: "recorrido" },
+        { text: "📦 Buscar producto", key: "buscar_producto" },
+        { text: "❓ Ayuda", key: "ayuda" },
+      ];
+    case "deposito":
+      return [
+        { text: "📦 Buscar producto", key: "buscar_producto" },
+        { text: "❓ Ayuda", key: "ayuda" },
+      ];
+  }
+}
+
+// ----------------------------------------------------------------------------
 // Exports auxiliares para tests
 // ----------------------------------------------------------------------------
 
@@ -141,4 +225,5 @@ export const _internal = {
   callbackData,
   BUTTON_TEXT_MAX,
   CALLBACK_VERSION,
+  mainMenuEntriesForRol,
 };

--- a/supabase/functions/telegram-webhook/commands/desvincular.ts
+++ b/supabase/functions/telegram-webhook/commands/desvincular.ts
@@ -1,0 +1,60 @@
+// /desvincular — desactiva el bot_usuarios del que invoca, dejándolo como
+// no-vinculado. Soft delete (activo=false) en vez de DELETE para preservar
+// el audit histórico y permitir reactivar fácilmente.
+//
+// `resolveUserByTelegramId` ya filtra por `activo = true`, así que el efecto
+// inmediato del soft delete es que el siguiente mensaje cae al flow de "no
+// vinculado" y le pide /vincular CODIGO.
+//
+// La conversación (bot_conversaciones) NO se borra acá — si el usuario
+// quiere también limpiarla, hay /reset. Lo dejamos separado porque
+// desvincular es "salirme del bot" y reset es "olvidate de mi última
+// charla pero seguí siendo yo".
+
+import { sendMessage } from "../../_shared/telegram.ts";
+import { getServiceRoleClient } from "../../_shared/supabase.ts";
+import { logEvent } from "../../_shared/audit.ts";
+import type { CommandSpec } from "./types.ts";
+
+export const desvincularCommand: CommandSpec = {
+  name: "/desvincular",
+  description: "Desvincula tu cuenta de Telegram del sistema.",
+  scope: "any",
+  async handler({ chatId, user, tgUser }) {
+    if (!user) {
+      await sendMessage(chatId, "No estás vinculado, no hay nada que desvincular.");
+      return;
+    }
+
+    const sb = getServiceRoleClient();
+    const { error } = await sb
+      .from("bot_usuarios")
+      .update({ activo: false })
+      .eq("telegram_user_id", tgUser.id);
+
+    if (error) {
+      console.error("[desvincular] update failed:", error.message);
+      await sendMessage(
+        chatId,
+        "❌ No pude desvincular tu cuenta. Probá de nuevo en un momento.",
+      );
+      await logEvent({
+        telegram_user_id: tgUser.id,
+        perfil_id: user.perfil_id,
+        rol: user.rol,
+        tipo: "error",
+        tool_name: "desvincular",
+        resultado_meta: { error: error.message },
+      }).catch(() => {});
+      return;
+    }
+
+    await sendMessage(
+      chatId,
+      "✅ Te desvinculé del bot.\n\n" +
+        "Si querés volver a usarlo, generá un nuevo código en la app web " +
+        "(Perfil > Vincular Telegram) y mandalo así:\n" +
+        "/vincular ABC123",
+    );
+  },
+};

--- a/supabase/functions/telegram-webhook/commands/menu.ts
+++ b/supabase/functions/telegram-webhook/commands/menu.ts
@@ -1,0 +1,29 @@
+// /menu — muestra el main menu del bot con keyboards según el rol del
+// usuario. Cada botón dispara un callback v1:menu:<key> que handleCallbackMenu
+// resuelve en handlers.ts.
+
+import { sendMessage, sendMessageMarkdownSafe } from "../../_shared/telegram.ts";
+import { buildMainMenuKeyboard } from "../../_shared/telegram-keyboards.ts";
+import type { CommandSpec } from "./types.ts";
+
+export const menuCommand: CommandSpec = {
+  name: "/menu",
+  description: "Menú principal del bot.",
+  scope: "any",
+  async handler({ chatId, user }) {
+    if (!user) {
+      // Defensa-en-profundidad: el router ya bloquea esto, pero no asumimos.
+      await sendMessage(
+        chatId,
+        "Necesitás vincularte primero. Mandá /vincular CODIGO.",
+      );
+      return;
+    }
+    const reply_markup = buildMainMenuKeyboard(user.rol);
+    await sendMessageMarkdownSafe(
+      chatId,
+      "*¿Qué querés hacer?*",
+      { reply_markup },
+    );
+  },
+};

--- a/supabase/functions/telegram-webhook/commands/reset.ts
+++ b/supabase/functions/telegram-webhook/commands/reset.ts
@@ -1,0 +1,57 @@
+// /reset — borra la conversación del usuario actual de bot_conversaciones.
+// El bot tiene memoria conversacional (historial de turnos previos) que
+// puede llevar al LLM a responder desde caché en vez de re-invocar tools
+// (ej: "Ya busqué eso y no encontré"). /reset corta ese historial sin
+// afectar la vinculación.
+
+import { sendMessage } from "../../_shared/telegram.ts";
+import { getServiceRoleClient } from "../../_shared/supabase.ts";
+import { logEvent } from "../../_shared/audit.ts";
+import type { CommandSpec } from "./types.ts";
+
+export const resetCommand: CommandSpec = {
+  name: "/reset",
+  description: "Borra la memoria de la conversación actual con el bot.",
+  scope: "any",
+  async handler({ chatId, user, tgUser }) {
+    if (!user) {
+      await sendMessage(
+        chatId,
+        "Necesitás vincularte primero. Mandá /vincular CODIGO.",
+      );
+      return;
+    }
+
+    const sb = getServiceRoleClient();
+    const { error } = await sb
+      .from("bot_conversaciones")
+      .delete()
+      .eq("telegram_user_id", tgUser.id);
+
+    if (error) {
+      console.error("[reset] delete failed:", error.message);
+      await sendMessage(
+        chatId,
+        "❌ No pude borrar la conversación. Probá de nuevo en un momento.",
+      );
+      await logEvent({
+        telegram_user_id: tgUser.id,
+        perfil_id: user.perfil_id,
+        rol: user.rol,
+        tipo: "error",
+        tool_name: "reset",
+        resultado_meta: { error: error.message },
+      }).catch(() => {});
+      return;
+    }
+
+    await sendMessage(
+      chatId,
+      "✅ Listo, borré la memoria de la conversación.\n\n" +
+        "El próximo mensaje libre arranca sin contexto previo. Tu " +
+        "vinculación sigue activa.",
+    );
+    // El logEvent del 'comando' lo hace el router antes de invocarnos —
+    // no auditamos doble.
+  },
+};

--- a/supabase/functions/telegram-webhook/handlers.ts
+++ b/supabase/functions/telegram-webhook/handlers.ts
@@ -19,9 +19,11 @@ import { getServiceRoleClient } from "../_shared/supabase.ts";
 import {
   answerCallbackQuery,
   escapeMarkdownV2,
+  sendChatAction,
   sendMessage,
   sendMessageMarkdownSafe,
 } from "../_shared/telegram.ts";
+import { buildMainMenuKeyboard } from "../_shared/telegram-keyboards.ts";
 import { invokeTool, registerAllTools } from "../_shared/tools/index.ts";
 import type { ToolContext } from "../_shared/tools/base.ts";
 import { runAgent } from "../_shared/gemini/agent.ts";
@@ -44,6 +46,9 @@ import { saldoCommand } from "./commands/saldo.ts";
 import { misClientesCommand } from "./commands/misclientes.ts";
 import { recorridoCommand } from "./commands/recorrido.ts";
 import { sugerenciasCommand } from "./commands/sugerencias.ts";
+import { menuCommand } from "./commands/menu.ts";
+import { resetCommand } from "./commands/reset.ts";
+import { desvincularCommand } from "./commands/desvincular.ts";
 
 const CODIGO_REGEX = /^[A-Z0-9]{6}$/;
 
@@ -64,6 +69,9 @@ function bootCommands(): void {
   registerCommand(misClientesCommand);
   registerCommand(recorridoCommand);
   registerCommand(sugerenciasCommand);
+  registerCommand(menuCommand);
+  registerCommand(resetCommand);
+  registerCommand(desvincularCommand);
   _booted = true;
 }
 
@@ -208,6 +216,13 @@ export async function handleUpdate(update: TelegramUpdate): Promise<void> {
   // Markdown sin ser válido en MarkdownV2, y un parse error 400 deja al user
   // sin respuesta. Plain text es robusto. Si en el futuro queremos rich
   // formatting, hay que agregar un wrapper que sanitice MV2 (Phase 4+).
+  //
+  // Typing indicator antes de runAgent: Telegram muestra "typing..." ~5s y
+  // se autodescarta. Si runAgent tarda más, el indicator se va — preferimos
+  // eso a complejizar con un loop de re-emisión. Fire-and-forget: errores
+  // de red en sendChatAction están atrapados ahí adentro y no propagan.
+  void sendChatAction(chatId, "typing");
+
   try {
     const result = await runAgent({
       supabase: getServiceRoleClient(),
@@ -229,11 +244,30 @@ export async function handleUpdate(update: TelegramUpdate): Promise<void> {
         error: err instanceof Error ? err.message : String(err),
       },
     }).catch(() => {});
-    await sendMessage(
-      chatId,
-      "Tuve un problema procesando tu mensaje. Probá de nuevo en un momento o usá /ayuda.",
-    );
+    await sendMessage(chatId, errorMessageFor(err));
   }
+}
+
+/**
+ * Discrimina el error de runAgent y devuelve un mensaje específico para el
+ * usuario. Default mantiene el mensaje genérico de antes.
+ *
+ * - 429 / RateLimit: rate limiting de Gemini o Telegram. El usuario debería
+ *   esperar antes de reintentar.
+ * - 403 / API key issue: típicamente el bot está mal configurado a nivel
+ *   infra (key inválida o IP bloqueada). El usuario no puede arreglarlo
+ *   por sí mismo, pero le decimos algo claro.
+ * - Otro: mensaje genérico.
+ */
+function errorMessageFor(err: unknown): string {
+  const msg = err instanceof Error ? err.message : String(err);
+  if (/\b429\b|rate.?limit|too many requests/i.test(msg)) {
+    return "⏳ Estoy saturado en este momento, probá de nuevo en 30 segundos.";
+  }
+  if (/\b403\b|forbidden|unauthorized|api.?key/i.test(msg)) {
+    return "⚠️ Hay un problema de configuración del bot. Avisale al admin que revise los logs.";
+  }
+  return "❌ Tuve un problema procesando tu mensaje. Probá de nuevo en un momento o usá /ayuda.";
 }
 
 // ----------------------------------------------------------------------------
@@ -258,12 +292,16 @@ async function handleStart(
   if (user) {
     const nombre = escapeMarkdownV2(tgUser.first_name);
     const rol = escapeMarkdownV2(user.rol);
+    // Mostramos el main menu como keyboard adjunto al mensaje de bienvenida
+    // para que el usuario tenga acceso directo a las acciones principales
+    // sin tener que recordar slash commands.
+    const reply_markup = buildMainMenuKeyboard(user.rol);
     await sendMessage(
       chatId,
       `¡Hola, ${nombre}\\! Ya estás vinculado como *${rol}*\\.\n\n` +
-        `Probá /ayuda para ver lo que puedo hacer\\.\n\n` +
+        `Tocá una opción del menú o probá /ayuda\\.\n\n` +
         privacyMv2,
-      { parse_mode: "MarkdownV2" },
+      { parse_mode: "MarkdownV2", reply_markup },
     );
   } else {
     // El bloque "no vinculado" iba en plain text — para consistencia y para
@@ -623,9 +661,10 @@ export async function handleCallbackQuery(cb: TelegramCallbackQuery): Promise<vo
   switch (parsed.action) {
     case "cliente":
       return handleCallbackCliente(cb, toolCtx, parsed.args);
+    case "menu":
+      return handleCallbackMenu(cb, user, toolCtx, parsed.args);
     case "producto":
     case "visitar":
-    case "menu":
       // Reservadas: confirmamos el callback y respondemos con placeholder.
       await answerCallbackQuery(cb.id, {
         text: "Esa acción todavía no está disponible.",
@@ -689,4 +728,97 @@ async function handleCallbackCliente(
 
   // OK → confirmamos el callback (apaga el spinner).
   await answerCallbackQuery(cb.id);
+}
+
+/**
+ * Resuelve los callbacks del main menu (`v1:menu:<key>`). Los keys que
+ * mapean a un slash command sin args (ayuda, mis_clientes, sugerencias,
+ * recorrido) reusan el comando registrado para no duplicar lógica.
+ * Los keys que requieren input del usuario (buscar_cliente, buscar_producto)
+ * mandan un prompt de NL y el LLM se encarga después.
+ */
+async function handleCallbackMenu(
+  cb: TelegramCallbackQuery,
+  user: BotUser,
+  toolCtx: ToolContext,
+  args: string[],
+): Promise<void> {
+  const chatId = cb.message.chat.id;
+  const key = args[0];
+  if (!key) {
+    await answerCallbackQuery(cb.id, { text: "Opción inválida." });
+    return;
+  }
+
+  // Apagamos el spinner del botón al toque para que la UI responda fluida —
+  // el slash command que viene después puede tomar segundos.
+  await answerCallbackQuery(cb.id);
+
+  switch (key) {
+    case "ayuda":
+      await handleAyuda(chatId, cb.from.id, user);
+      return;
+
+    case "mis_clientes": {
+      const cmd = getCommand("/misclientes");
+      if (cmd) {
+        await cmd.handler({
+          user,
+          tgUser: cb.from,
+          chatId,
+          rawArgs: "",
+          toolCtx,
+        });
+      }
+      return;
+    }
+
+    case "sugerencias": {
+      const cmd = getCommand("/sugerencias");
+      if (cmd) {
+        await cmd.handler({
+          user,
+          tgUser: cb.from,
+          chatId,
+          rawArgs: "",
+          toolCtx,
+        });
+      }
+      return;
+    }
+
+    case "recorrido": {
+      const cmd = getCommand("/recorrido");
+      if (cmd) {
+        await cmd.handler({
+          user,
+          tgUser: cb.from,
+          chatId,
+          rawArgs: "",
+          toolCtx,
+        });
+      }
+      return;
+    }
+
+    case "buscar_cliente":
+      await sendMessage(
+        chatId,
+        "👥 ¿Qué cliente buscás?\n" +
+          "Mandame el nombre o código (ej: \"almacén gabriel\" o \"549\").",
+      );
+      return;
+
+    case "buscar_producto":
+      await sendMessage(
+        chatId,
+        "📦 ¿Qué producto buscás?\n" +
+          "Mandame el nombre, código, o un tipo (ej: \"coca\", \"gaseosas naranja\").",
+      );
+      return;
+
+    default:
+      await sendMessage(chatId, "Opción del menú no reconocida.");
+      return;
+  }
 }


### PR DESCRIPTION
## Summary

Cierra el ciclo del UX upgrade del bot: onboarding y navegación. Después de Fases 0/1/2 (client search fix + inline keyboards + visual polish), esta fase agrega los puntos de entrada del usuario:

- \`/menu\` con keyboard de navegación role-aware.
- \`/start\` ahora adjunta el main menu después de vincularse.
- \`/reset\` para limpiar memoria conversacional.
- \`/desvincular\` para soft-delete del bot_usuarios.
- Typing indicator (\"typing…\") mientras el LLM procesa.
- Mensajes de error específicos por tipo de fallo (429, 403, otros).

Es la última fase del plan post-mortem de la iteración 1.

## Cambios

### \`/menu\` + main menu keyboard

\`buildMainMenuKeyboard(rol)\` en \`_shared/telegram-keyboards.ts\` con layout 2 cols por rol:

| Rol | Opciones |
|---|---|
| admin / encargado | 👥 Buscar cliente · 📦 Buscar producto · ❓ Ayuda |
| preventista | 👥 Mis clientes · 💡 Sugerencias · 📦 Buscar producto · ❓ Ayuda |
| transportista | 🚚 Recorrido de hoy · 📦 Buscar producto · ❓ Ayuda |
| deposito | 📦 Buscar producto · ❓ Ayuda |

\`handleCallbackMenu\` rutea \`v1:menu:<key>\`:
- \`ayuda\` → \`handleAyuda\` directo.
- \`mis_clientes\` / \`sugerencias\` / \`recorrido\` → reusan el slash command registrado (sin duplicar lógica).
- \`buscar_cliente\` / \`buscar_producto\` → mandan prompt para que el LLM procese el siguiente mensaje del usuario.
- \`answerCallbackQuery()\` inmediato para que el spinner del botón se apague.

### \`/start\` mejorado

Si el usuario está vinculado, el mensaje de bienvenida ahora adjunta el main menu keyboard. Si no está vinculado, mensaje de vinculación sin cambios.

### \`/reset\`

\`DELETE FROM bot_conversaciones WHERE telegram_user_id = ...\`. Útil cuando el LLM responde desde memoria stale (\"ya busqué eso\") y querés limpiar el contexto sin desvincular. Auditado como \`tipo='comando'\`.

### \`/desvincular\`

\`UPDATE bot_usuarios SET activo=false WHERE telegram_user_id = ...\`. Soft delete — preserva audit y permite re-activar fácil. \`resolveUserByTelegramId\` ya filtra por \`activo=true\`, así que el siguiente mensaje del usuario cae al flow de \"no vinculado\".

NO borra la conversación — para eso hay \`/reset\`. Lo dejamos separado porque tienen semánticas distintas.

### Typing indicator

\`void sendChatAction(chatId, \"typing\")\` antes de \`runAgent\` en la rama NL del handler. Fire-and-forget — \`sendChatAction\` atrapa errores de red por dentro y no propagan. Telegram muestra \"typing…\" ~5s; si el LLM tarda más se va el indicator (preferimos eso a complejizar con re-emisión).

### \`errorMessageFor(err)\`

Discrimina el catch de \`runAgent\` por contenido del mensaje:

- \`429\` / \`rate.?limit\` / \`too many requests\` → \"⏳ Estoy saturado, probá en 30s.\"
- \`403\` / \`forbidden\` / \`unauthorized\` / \`api.?key\` → \"⚠️ Hay un problema de config, avisale al admin.\"
- Default → mensaje genérico con ❌.

## Test plan

- [x] \`deno task check\` OK
- [x] \`deno task lint\` OK (61 archivos)
- [x] \`deno task test\` 109 passed | 0 failed (no tests nuevos por compromiso de scope — se cubre con smoke real)
- [ ] **Post-deploy** smoke al bot real:
  - [ ] \`/start\` (vinculado) → ver bienvenida + keyboard \"¿Qué deseas hacer?\".
  - [ ] \`/menu\` → ver mismo keyboard.
  - [ ] Tocar \"👥 Mis clientes\" (preventista) → flujo de \`/misclientes\` arranca.
  - [ ] Tocar \"📦 Buscar producto\" (cualquier rol) → \"📦 ¿Qué producto buscás?\" + el siguiente mensaje libre del usuario lo procesa el LLM.
  - [ ] Mandar mensaje libre → ver \"typing...\" mientras el LLM piensa.
  - [ ] \`/reset\` → \"✅ Listo, borré la memoria...\". Siguiente mensaje libre arranca sin contexto.
  - [ ] \`/desvincular\` → \"✅ Te desvinculé...\". Siguiente mensaje pide \`/vincular CODIGO\`.
  - [ ] \`/vincular <CODIGO>\` con un código válido → re-vincula correctamente.

## Fuera de alcance

- Tool de detalle de producto (callback \`v1:producto:<id>\` sigue como placeholder).
- Acciones de write con confirmación inline (marcar entregado, cargar pago, etc.).
- Notifications proactivas (push de alertas de saldo vencido, stock crítico, etc.) — postpuestas a una iteración futura según decisión del plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)