### PR TITLE
feat(bot): MVP completion - ficha_producto + Fase 3 tests + LLM keyboards (Fase 4)

### DIFF
--- a/migrations/021_bot_ficha_producto.sql
+++ b/migrations/021_bot_ficha_producto.sql
@@ -1,0 +1,72 @@
+-- Migración 021 — Bot Telegram: ficha de producto
+--
+-- Función para que el bot pueda devolver el detalle de un producto con
+-- métricas de ventas básicas (cantidad vendida en los últimos 30 días,
+-- fecha de última venta). Diseñada para alimentar:
+--   * el callback `v1:producto:<id>` del inline keyboard de /producto.
+--   * un futuro slash command /producto-ficha si lo necesitamos.
+--
+-- Patrón de seguridad calcado de obtener_resumen_cuenta_cliente_bot
+-- (migration 015): SECURITY DEFINER + REVOKE FROM PUBLIC + GRANT solo a
+-- service_role. La edge function valida rol/sucursal antes de invocar.
+
+CREATE OR REPLACE FUNCTION public.bot_ficha_producto(
+  p_producto_id BIGINT,
+  p_sucursal_id BIGINT
+)
+RETURNS JSON
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  resultado JSON;
+BEGIN
+  SELECT json_build_object(
+    'producto', json_build_object(
+      'id', p.id,
+      'codigo', p.codigo,
+      'nombre', p.nombre,
+      'precio', p.precio,
+      'precio_sin_iva', p.precio_sin_iva,
+      'stock', p.stock,
+      'stock_minimo', p.stock_minimo,
+      'categoria', p.categoria,
+      'proveedor_id', p.proveedor_id
+    ),
+    -- Cantidad total vendida en los últimos 30 días para esta sucursal.
+    -- Filtramos por sucursal_id directo en pedido_items (la tabla la tiene)
+    -- para evitar el join cuando no hace falta.
+    'ventas_30d_cantidad', (
+      SELECT COALESCE(SUM(pi.cantidad), 0)::INTEGER
+      FROM pedido_items pi
+      JOIN pedidos pe ON pe.id = pi.pedido_id
+      WHERE pi.producto_id = p_producto_id
+        AND pi.sucursal_id = p_sucursal_id
+        AND pe.created_at > now() - interval '30 days'
+    ),
+    -- Fecha de la última venta de este producto en esta sucursal.
+    -- NULL si nunca se vendió.
+    'ultima_venta', (
+      SELECT MAX(pe.created_at)
+      FROM pedido_items pi
+      JOIN pedidos pe ON pe.id = pi.pedido_id
+      WHERE pi.producto_id = p_producto_id
+        AND pi.sucursal_id = p_sucursal_id
+    )
+  ) INTO resultado
+  FROM productos p
+  WHERE p.id = p_producto_id
+    AND p.sucursal_id = p_sucursal_id;
+
+  -- Si el producto no existe o es de otra sucursal, devolvemos NULL.
+  -- La tool TS lo interpreta como "Producto no encontrado o sin permiso".
+  RETURN resultado;
+END;
+$$;
+
+ALTER FUNCTION public.bot_ficha_producto(BIGINT, BIGINT) OWNER TO postgres;
+
+REVOKE ALL    ON FUNCTION public.bot_ficha_producto(BIGINT, BIGINT) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.bot_ficha_producto(BIGINT, BIGINT) TO service_role;

--- a/supabase/functions/_shared/gemini/agent.ts
+++ b/supabase/functions/_shared/gemini/agent.ts
@@ -112,6 +112,21 @@ export interface RunAgentOptions {
   ephemeral?: boolean;
 }
 
+/**
+ * Lista de items "interactables" extraída de la última tool call relevante
+ * del turno. El handler la usa para armar un inline keyboard que adjunta
+ * a result.text — así las respuestas NL del LLM también tienen botones,
+ * matching la UX de los slash commands.
+ *
+ * Se popula con la ÚLTIMA tool call cuyo result devolvió una lista con
+ * IDs + nombres. Si una tool posterior devuelve otra lista, sobreescribe
+ * (vale la más reciente — es la que probablemente esté más relacionada
+ * con el texto final del LLM).
+ */
+export type InteractableContext =
+  | { kind: "clientes"; items: Array<{ id: number; nombre: string }> }
+  | { kind: "productos"; items: Array<{ id: number; nombre: string }> };
+
 export interface RunAgentResult {
   /** Texto final que el caller debe mandar al usuario. */
   text: string;
@@ -125,6 +140,77 @@ export interface RunAgentResult {
   totalTokens: number;
   /** True si terminó por hit del cap MAX_TOOL_ITERATIONS sin respuesta final. */
   hitMaxIterations: boolean;
+  /** Última tool call que devolvió una lista de items con IDs.
+   *  El handler arma un inline keyboard a partir de esto. */
+  interactableContext?: InteractableContext;
+}
+
+/**
+ * Extrae el `InteractableContext` correspondiente al output de una tool.
+ * Cubre las tools que retornan listas con IDs + nombres. Para tools que
+ * retornan single-items (ficha_cliente, ficha_producto), retorna undefined
+ * — un keyboard de un solo botón sería ruido.
+ */
+function extractInteractableContext(
+  name: string,
+  data: unknown,
+): InteractableContext | undefined {
+  if (!data || typeof data !== "object") return undefined;
+  const d = data as Record<string, unknown>;
+
+  // Limit a 10 items para evitar mensajes con keyboards gigantes.
+  const TAKE = 10;
+
+  const mapClientes = (
+    arr: unknown[],
+    idKey: string,
+  ): InteractableContext | undefined => {
+    const items = arr
+      .slice(0, TAKE)
+      .map((c) => {
+        const r = c as Record<string, unknown>;
+        const id = Number(r[idKey]);
+        const nombre = typeof r.nombre === "string" ? r.nombre : "";
+        return Number.isFinite(id) && id > 0 && nombre.length > 0
+          ? { id, nombre }
+          : null;
+      })
+      .filter((x): x is { id: number; nombre: string } => x !== null);
+    return items.length > 0 ? { kind: "clientes", items } : undefined;
+  };
+
+  const mapProductos = (
+    arr: unknown[],
+  ): InteractableContext | undefined => {
+    const items = arr
+      .slice(0, TAKE)
+      .map((p) => {
+        const r = p as Record<string, unknown>;
+        const id = Number(r.id);
+        const nombre = typeof r.nombre === "string" ? r.nombre : "";
+        return Number.isFinite(id) && id > 0 && nombre.length > 0
+          ? { id, nombre }
+          : null;
+      })
+      .filter((x): x is { id: number; nombre: string } => x !== null);
+    return items.length > 0 ? { kind: "productos", items } : undefined;
+  };
+
+  switch (name) {
+    case "buscar_cliente":
+    case "mis_clientes":
+      return Array.isArray(d.clientes) ? mapClientes(d.clientes, "id") : undefined;
+    case "sugerir_visitas_rfm":
+      // sugerencias usan `cliente_id` como key, no `id`.
+      return Array.isArray(d.sugerencias)
+        ? mapClientes(d.sugerencias, "cliente_id")
+        : undefined;
+    case "buscar_producto":
+    case "productos_por_categoria":
+      return Array.isArray(d.productos) ? mapProductos(d.productos) : undefined;
+    default:
+      return undefined;
+  }
 }
 
 /**
@@ -163,6 +249,9 @@ export async function runAgent(opts: RunAgentOptions): Promise<RunAgentResult> {
   let toolCallsCount = 0;
   let totalTokens = 0;
   let lastFinishReason = "UNKNOWN";
+  // Última tool call que devolvió una lista interactable. Se sobreescribe
+  // si una tool posterior emite otra (vale la más reciente).
+  let lastInteractableContext: InteractableContext | undefined;
 
   for (let iter = 0; iter < MAX_TOOL_ITERATIONS; iter++) {
     const response = await callGemini({
@@ -285,6 +374,7 @@ export async function runAgent(opts: RunAgentOptions): Promise<RunAgentResult> {
         finishReason: lastFinishReason,
         totalTokens,
         hitMaxIterations: false,
+        interactableContext: lastInteractableContext,
       };
     }
 
@@ -306,6 +396,12 @@ export async function runAgent(opts: RunAgentOptions): Promise<RunAgentResult> {
         ? { result: result.data }
         : { error: result.error };
       history = appendFunctionResponse(history, name, responseObj);
+      // Si la tool devolvió un result OK con shape de lista interactable,
+      // lo guardamos para que el handler arme un keyboard al final.
+      if (result.ok) {
+        const ctx = extractInteractableContext(name, result.data);
+        if (ctx) lastInteractableContext = ctx;
+      }
     }
     // Loop sigue: el próximo callGemini verá los functionResponse que acabamos
     // de appendear y decidirá si emitir texto final o más function calls.

--- a/supabase/functions/_shared/telegram-keyboards.ts
+++ b/supabase/functions/_shared/telegram-keyboards.ts
@@ -134,6 +134,30 @@ export function buildMisClientesKeyboard(
 }
 
 // ----------------------------------------------------------------------------
+// Builder genérico para respuestas NL del LLM (Fase 4 / Task 4.3)
+// ----------------------------------------------------------------------------
+
+/**
+ * Discrimina por kind y reusa el builder específico. El handler de la rama
+ * NL del LLM usa esto cuando `runAgent` devuelve un `interactableContext`.
+ *
+ * Items vacíos → undefined (no queremos un keyboard vacío en la UI).
+ */
+export function buildKeyboardForContext(
+  ctx:
+    | { kind: "clientes"; items: Array<{ id: number; nombre: string }> }
+    | { kind: "productos"; items: Array<{ id: number; nombre: string }> },
+): InlineKeyboardMarkup | undefined {
+  if (ctx.items.length === 0) return undefined;
+  switch (ctx.kind) {
+    case "clientes":
+      return buildClienteListKeyboard(ctx.items);
+    case "productos":
+      return buildProductoListKeyboard(ctx.items);
+  }
+}
+
+// ----------------------------------------------------------------------------
 // Main menu (Fase 3)
 // ----------------------------------------------------------------------------
 

--- a/supabase/functions/_shared/tools/common/ficha_producto.ts
+++ b/supabase/functions/_shared/tools/common/ficha_producto.ts
@@ -1,0 +1,122 @@
+// Tool: ficha_producto
+//
+// Devuelve detalle de un producto + métricas básicas (cantidad vendida en
+// los últimos 30 días, fecha de última venta). Pensada para alimentar el
+// callback `v1:producto:<id>` de los inline keyboards y para que el LLM
+// pueda responder consultas de detalle ("dame los datos del producto X").
+//
+// Delega 100% al RPC bot_ficha_producto (migration 021). El gate de
+// sucursal lo hace el RPC (filtra por sucursal_id), igual que ficha_cliente.
+
+import type { Tool } from "../base.ts";
+
+export interface FichaProductoParams {
+  producto_id: number;
+}
+
+export interface FichaProductoResult {
+  producto: {
+    id: number;
+    codigo: string | null;
+    nombre: string;
+    precio: number;
+    precio_sin_iva: number | null;
+    stock: number;
+    stock_minimo: number;
+    bajo_stock: boolean;
+    categoria: string | null;
+    proveedor_id: number | null;
+  };
+  ventas_30d_cantidad: number;
+  ultima_venta: string | null;
+}
+
+interface RpcRow {
+  producto: {
+    id: number;
+    codigo: string | null;
+    nombre: string;
+    precio: number | string | null;
+    precio_sin_iva: number | string | null;
+    stock: number | null;
+    stock_minimo: number | null;
+    categoria: string | null;
+    proveedor_id: number | null;
+  };
+  ventas_30d_cantidad: number;
+  ultima_venta: string | null;
+}
+
+export const fichaProductoTool: Tool<FichaProductoParams, FichaProductoResult> = {
+  name: "ficha_producto",
+  description:
+    "Devuelve el detalle completo de un producto: precio, stock, stock " +
+    "mínimo, categoría, proveedor + métricas (cantidad vendida en los " +
+    "últimos 30 días, fecha de última venta). Filtra por sucursal del " +
+    "bot user.",
+  parameters: {
+    type: "object",
+    properties: {
+      producto_id: {
+        type: "integer",
+        description: "ID del producto (entero positivo).",
+      },
+    },
+    required: ["producto_id"],
+  },
+  allowedRoles: ["admin", "preventista", "transportista", "encargado", "deposito"],
+  handler: async ({ producto_id }, ctx) => {
+    if (!Number.isInteger(producto_id) || producto_id <= 0) {
+      throw new Error("producto_id debe ser un entero positivo");
+    }
+    if (ctx.sucursal_id == null && ctx.rol !== "admin") {
+      throw new Error(
+        "Sucursal no asignada en bot_usuarios — contactá al administrador",
+      );
+    }
+    if (ctx.sucursal_id == null) {
+      // Admin sin sucursal default — necesitamos una. Hoy no hay forma de
+      // pasar la sucursal explícitamente; rechazamos hasta que el plan de
+      // multi-sucursal switch (próxima iter) la resuelva.
+      throw new Error(
+        "Sucursal no resuelta para esta consulta. Mencionale al admin que " +
+          "te asigne una sucursal default en bot_usuarios.",
+      );
+    }
+
+    const { data, error } = await ctx.supabase.rpc("bot_ficha_producto", {
+      p_producto_id: producto_id,
+      p_sucursal_id: ctx.sucursal_id,
+    });
+
+    if (error) {
+      throw new Error(`ficha_producto: ${error.message}`);
+    }
+    if (data === null || data === undefined) {
+      throw new Error("Producto no encontrado o de otra sucursal");
+    }
+
+    const row = data as RpcRow;
+    const stock = Number(row.producto.stock ?? 0);
+    const stockMin = Number(row.producto.stock_minimo ?? 0);
+
+    return {
+      producto: {
+        id: Number(row.producto.id),
+        codigo: row.producto.codigo ?? null,
+        nombre: row.producto.nombre,
+        precio: Number(row.producto.precio ?? 0),
+        precio_sin_iva: row.producto.precio_sin_iva == null
+          ? null
+          : Number(row.producto.precio_sin_iva),
+        stock,
+        stock_minimo: stockMin,
+        bajo_stock: stock <= stockMin,
+        categoria: row.producto.categoria ?? null,
+        proveedor_id: row.producto.proveedor_id ?? null,
+      },
+      ventas_30d_cantidad: Number(row.ventas_30d_cantidad ?? 0),
+      ultima_venta: row.ultima_venta ?? null,
+    };
+  },
+};

--- a/supabase/functions/_shared/tools/index.ts
+++ b/supabase/functions/_shared/tools/index.ts
@@ -10,6 +10,7 @@ import { registerTool } from "./registry.ts";
 import { buscarClienteTool } from "./common/buscar_cliente.ts";
 import { buscarProductoTool } from "./common/buscar_producto.ts";
 import { fichaClienteTool } from "./common/ficha_cliente.ts";
+import { fichaProductoTool } from "./common/ficha_producto.ts";
 import { listarCategoriasTool } from "./common/listar_categorias.ts";
 import { productosPorCategoriaTool } from "./common/productos_por_categoria.ts";
 import { misClientesTool } from "./preventista/mis_clientes.ts";
@@ -23,6 +24,7 @@ export function registerAllTools(): void {
   registerTool(buscarClienteTool);
   registerTool(buscarProductoTool);
   registerTool(fichaClienteTool);
+  registerTool(fichaProductoTool);
   registerTool(listarCategoriasTool);
   registerTool(productosPorCategoriaTool);
   registerTool(misClientesTool);

--- a/supabase/functions/telegram-webhook/formatters/ficha-producto.ts
+++ b/supabase/functions/telegram-webhook/formatters/ficha-producto.ts
@@ -1,0 +1,60 @@
+// Formatter para `ficha_producto` — análogo a formatFichaCliente. Header
+// con emoji 📦 + bold del nombre + bloque numérico (precio, stock,
+// categoría) + bloque de métricas (ventas 30d, última venta).
+
+import {
+  bullet,
+  divider,
+  escapeMarkdownV2,
+  formatCurrency,
+  formatFechaCorta,
+  header,
+  kvRowRaw,
+  statusBadge,
+} from "../../_shared/format.ts";
+import type { FichaProductoResult } from "../../_shared/tools/common/ficha_producto.ts";
+
+export function formatFichaProducto(r: FichaProductoResult): string {
+  const p = r.producto;
+  const parts: string[] = [];
+
+  // ----- Cabecera del producto -------------------------------------------
+  parts.push(header(p.nombre, "📦"));
+  if (p.codigo) {
+    parts.push(`Código: \`${escapeMarkdownV2(p.codigo)}\``);
+  }
+  if (p.categoria) {
+    parts.push(bullet(escapeMarkdownV2(p.categoria), "🏷️"));
+  }
+
+  // ----- Bloque numérico --------------------------------------------------
+  parts.push(divider());
+  parts.push(
+    kvRowRaw("Precio", `*${escapeMarkdownV2(formatCurrency(p.precio))}*`),
+  );
+
+  // Stock con badge si está bajo el mínimo.
+  const stockBadge = p.bajo_stock ? `${statusBadge("warn")} ` : "";
+  const stockTxt = p.bajo_stock
+    ? `*${p.stock}*/${p.stock_minimo} \\(bajo mínimo\\)`
+    : `${p.stock} \\(mínimo: ${p.stock_minimo}\\)`;
+  parts.push(`*Stock:* ${stockBadge}${stockTxt}`);
+
+  // ----- Métricas de ventas ----------------------------------------------
+  parts.push(divider());
+  parts.push(
+    bullet(`Ventas \\(30d\\): *${r.ventas_30d_cantidad}* unidades`, "📊"),
+  );
+  if (r.ultima_venta) {
+    parts.push(
+      bullet(
+        `Última venta: ${escapeMarkdownV2(formatFechaCorta(r.ultima_venta))}`,
+        "📅",
+      ),
+    );
+  } else {
+    parts.push(bullet("Sin ventas registradas", "📅"));
+  }
+
+  return parts.join("\n");
+}

--- a/supabase/functions/telegram-webhook/handlers.ts
+++ b/supabase/functions/telegram-webhook/handlers.ts
@@ -261,7 +261,7 @@ export async function handleUpdate(update: TelegramUpdate): Promise<void> {
  *   por sí mismo, pero le decimos algo claro.
  * - Otro: mensaje genérico.
  */
-function errorMessageFor(err: unknown): string {
+export function errorMessageFor(err: unknown): string {
   const msg = err instanceof Error ? err.message : String(err);
   if (/\b429\b|rate.?limit|too many requests/i.test(msg)) {
     return "⏳ Estoy saturado en este momento, probá de nuevo en 30 segundos.";

--- a/supabase/functions/telegram-webhook/handlers.ts
+++ b/supabase/functions/telegram-webhook/handlers.ts
@@ -35,7 +35,9 @@ import type {
   TelegramUser,
 } from "../_shared/types.ts";
 import { formatFichaCliente } from "./formatters/cliente.ts";
+import { formatFichaProducto } from "./formatters/ficha-producto.ts";
 import type { FichaClienteResult } from "../_shared/tools/common/ficha_cliente.ts";
+import type { FichaProductoResult } from "../_shared/tools/common/ficha_producto.ts";
 
 import { parseCommand } from "./commands/parser.ts";
 import { getCommand, listCommands, registerCommand } from "./commands/router.ts";
@@ -661,11 +663,14 @@ export async function handleCallbackQuery(cb: TelegramCallbackQuery): Promise<vo
   switch (parsed.action) {
     case "cliente":
       return handleCallbackCliente(cb, toolCtx, parsed.args);
+    case "producto":
+      return handleCallbackProducto(cb, toolCtx, parsed.args);
     case "menu":
       return handleCallbackMenu(cb, user, toolCtx, parsed.args);
-    case "producto":
     case "visitar":
-      // Reservadas: confirmamos el callback y respondemos con placeholder.
+      // Reservada: confirmamos el callback y respondemos con placeholder.
+      // Acciones de write con confirmación están out of scope hasta una
+      // iteración futura.
       await answerCallbackQuery(cb.id, {
         text: "Esa acción todavía no está disponible.",
       });
@@ -727,6 +732,51 @@ async function handleCallbackCliente(
   }
 
   // OK → confirmamos el callback (apaga el spinner).
+  await answerCallbackQuery(cb.id);
+}
+
+async function handleCallbackProducto(
+  cb: TelegramCallbackQuery,
+  toolCtx: ToolContext,
+  args: string[],
+): Promise<void> {
+  // Mismo patrón que handleCallbackCliente — el rol y el scope los hace
+  // invokeTool basándose en `toolCtx`.
+  const chatId = cb.message.chat.id;
+  const idStr = args[0];
+  const producto_id = idStr ? parseInt(idStr, 10) : NaN;
+  if (!Number.isFinite(producto_id) || producto_id <= 0) {
+    await answerCallbackQuery(cb.id, { text: "ID de producto inválido." });
+    return;
+  }
+
+  const result = await invokeTool(
+    "ficha_producto",
+    { producto_id },
+    toolCtx,
+  );
+
+  if (!result.ok) {
+    const errMsg = result.error === "permiso_denegado"
+      ? "No tenés permiso para ver este producto."
+      : "No pude abrir la ficha del producto.";
+    await answerCallbackQuery(cb.id, { text: errMsg, show_alert: true });
+    return;
+  }
+
+  const ficha = result.data as FichaProductoResult;
+  const text = formatFichaProducto(ficha);
+  try {
+    await sendMessageMarkdownSafe(chatId, text);
+  } catch (err) {
+    console.error("[callback producto] sendMessage failed:", err);
+    await answerCallbackQuery(cb.id, {
+      text: "No pude enviar la ficha. Probá de nuevo.",
+      show_alert: true,
+    });
+    return;
+  }
+
   await answerCallbackQuery(cb.id);
 }
 

--- a/supabase/functions/telegram-webhook/handlers.ts
+++ b/supabase/functions/telegram-webhook/handlers.ts
@@ -23,7 +23,10 @@ import {
   sendMessage,
   sendMessageMarkdownSafe,
 } from "../_shared/telegram.ts";
-import { buildMainMenuKeyboard } from "../_shared/telegram-keyboards.ts";
+import {
+  buildKeyboardForContext,
+  buildMainMenuKeyboard,
+} from "../_shared/telegram-keyboards.ts";
 import { invokeTool, registerAllTools } from "../_shared/tools/index.ts";
 import type { ToolContext } from "../_shared/tools/base.ts";
 import { runAgent } from "../_shared/gemini/agent.ts";
@@ -232,7 +235,14 @@ export async function handleUpdate(update: TelegramUpdate): Promise<void> {
       telegram_user_id: tgUser.id,
       userMessage: text,
     });
-    await sendMessage(chatId, result.text);
+    // Si la última tool call relevante devolvió una lista de clientes o
+    // productos, adjuntamos un inline keyboard al mensaje de respuesta —
+    // así las respuestas NL del LLM se sienten consistentes con los slash
+    // commands (que ya tienen keyboards desde Fase 1).
+    const reply_markup = result.interactableContext
+      ? buildKeyboardForContext(result.interactableContext)
+      : undefined;
+    await sendMessage(chatId, result.text, { reply_markup });
   } catch (err) {
     console.error("[handler] runAgent failed:", err);
     await logEvent({

--- a/supabase/functions/tests/agent.test.ts
+++ b/supabase/functions/tests/agent.test.ts
@@ -698,3 +698,148 @@ Deno.test("truncateHistory no toca history de longitud <= cap", () => {
   const tr = truncateHistory(h, 12);
   assertEquals(tr, h);
 });
+
+// ============================================================================
+// interactableContext (Task 4.3): runAgent expone la última tool call
+// que devolvió una lista de items con id+nombre, así el handler arma un
+// inline keyboard al final.
+// ============================================================================
+
+Deno.test("runAgent: buscar_cliente popula interactableContext={kind:'clientes'}", async () => {
+  setupAgentEnv();
+  const { client } = createMockSupabase({ conversacionData: null });
+  // deno-lint-ignore no-explicit-any
+  _setServiceRoleClientForTests(client as any);
+
+  // Tool con el name reconocido por extractInteractableContext.
+  // Devuelve el shape que la tool real produce.
+  const fakeBuscarCliente: Tool<
+    { q: string },
+    { total: number; clientes: Array<{ id: number; nombre: string }> }
+  > = {
+    name: "buscar_cliente",
+    description: "test tool",
+    parameters: {
+      type: "object",
+      properties: { q: { type: "string" } },
+      required: ["q"],
+    },
+    allowedRoles: ["admin"],
+    handler: () =>
+      Promise.resolve({
+        total: 2,
+        clientes: [
+          { id: 42, nombre: "Pepito SA" },
+          { id: 100, nombre: "Almacén Centro" },
+        ],
+      }),
+  };
+  registerTool(fakeBuscarCliente);
+
+  const fetchStub = installGeminiFetchStub([
+    {
+      candidates: [{
+        content: {
+          role: "model",
+          parts: [{ functionCall: { name: "buscar_cliente", args: { q: "Pe" } } }],
+        },
+        finishReason: "STOP",
+      }],
+      usageMetadata: { totalTokenCount: 50 },
+    },
+    {
+      candidates: [{
+        content: {
+          role: "model",
+          parts: [{ text: "Encontré 2 clientes." }],
+        },
+        finishReason: "STOP",
+      }],
+      usageMetadata: { totalTokenCount: 30 },
+    },
+  ]);
+
+  try {
+    const result = await runAgent({
+      supabase: client,
+      user: makeUser("admin"),
+      telegram_user_id: 42,
+      userMessage: "buscame pe",
+    });
+
+    assert(result.interactableContext, "interactableContext debe estar populado");
+    assertEquals(result.interactableContext!.kind, "clientes");
+    assertEquals(result.interactableContext!.items.length, 2);
+    assertEquals(result.interactableContext!.items[0], { id: 42, nombre: "Pepito SA" });
+    assertEquals(result.interactableContext!.items[1], { id: 100, nombre: "Almacén Centro" });
+  } finally {
+    fetchStub.restore();
+    teardownAgentEnv();
+  }
+});
+
+Deno.test("runAgent: tool no reconocida (ej ficha_cliente) NO popula interactableContext", async () => {
+  setupAgentEnv();
+  const { client } = createMockSupabase({ conversacionData: null });
+  // deno-lint-ignore no-explicit-any
+  _setServiceRoleClientForTests(client as any);
+
+  // Tool con shape de single-item — extractInteractableContext debe
+  // retornar undefined (un keyboard de 1 botón sería ruido).
+  const fakeFichaCliente: Tool<
+    { cliente_id: number },
+    { cliente: { id: number; nombre: string } }
+  > = {
+    name: "ficha_cliente",
+    description: "test tool",
+    parameters: {
+      type: "object",
+      properties: { cliente_id: { type: "integer" } },
+      required: ["cliente_id"],
+    },
+    allowedRoles: ["admin"],
+    handler: () => Promise.resolve({ cliente: { id: 42, nombre: "Pepito" } }),
+  };
+  registerTool(fakeFichaCliente);
+
+  const fetchStub = installGeminiFetchStub([
+    {
+      candidates: [{
+        content: {
+          role: "model",
+          parts: [{ functionCall: { name: "ficha_cliente", args: { cliente_id: 42 } } }],
+        },
+        finishReason: "STOP",
+      }],
+      usageMetadata: { totalTokenCount: 50 },
+    },
+    {
+      candidates: [{
+        content: {
+          role: "model",
+          parts: [{ text: "Pepito tiene saldo X." }],
+        },
+        finishReason: "STOP",
+      }],
+      usageMetadata: { totalTokenCount: 30 },
+    },
+  ]);
+
+  try {
+    const result = await runAgent({
+      supabase: client,
+      user: makeUser("admin"),
+      telegram_user_id: 42,
+      userMessage: "ficha de pepito",
+    });
+
+    assertEquals(
+      result.interactableContext,
+      undefined,
+      "ficha_cliente NO debe popular interactableContext",
+    );
+  } finally {
+    fetchStub.restore();
+    teardownAgentEnv();
+  }
+});

--- a/supabase/functions/tests/telegram-webhook.test.ts
+++ b/supabase/functions/tests/telegram-webhook.test.ts
@@ -590,6 +590,8 @@ interface RouterMockSpy {
   rpcCalls: Array<{ fn: string; params: Record<string, unknown> }>;
   inserts: Array<{ table: string; row: Record<string, unknown> }>;
   selectQueries: Array<{ table: string; cols: string; filters: unknown[] }>;
+  deletes: Array<{ table: string; filters: unknown[] }>;
+  updates: Array<{ table: string; row: Record<string, unknown>; filters: unknown[] }>;
 }
 
 interface RouterMockOpts {
@@ -610,11 +612,19 @@ interface RouterMockOpts {
 
 // deno-lint-ignore no-explicit-any
 function createRouterMockSupabase(opts: RouterMockOpts = {}): { client: any; spy: RouterMockSpy } {
-  const spy: RouterMockSpy = { rpcCalls: [], inserts: [], selectQueries: [] };
+  const spy: RouterMockSpy = {
+    rpcCalls: [],
+    inserts: [],
+    selectQueries: [],
+    deletes: [],
+    updates: [],
+  };
 
   function makeBuilder(table: string) {
     const filters: unknown[] = [];
     let isSelect = false;
+    let isDelete = false;
+    let isUpdate = false;
     let cols = "";
 
     // deno-lint-ignore no-explicit-any
@@ -627,6 +637,16 @@ function createRouterMockSupabase(opts: RouterMockOpts = {}): { client: any; spy
         isSelect = true;
         cols = c;
         spy.selectQueries.push({ table, cols, filters });
+        return builder;
+      },
+      delete() {
+        isDelete = true;
+        spy.deletes.push({ table, filters });
+        return builder;
+      },
+      update(row: Record<string, unknown>) {
+        isUpdate = true;
+        spy.updates.push({ table, row, filters });
         return builder;
       },
       eq(col: string, val: unknown) {
@@ -651,9 +671,13 @@ function createRouterMockSupabase(opts: RouterMockOpts = {}): { client: any; spy
         return Promise.resolve(r);
       },
       // Thenable: cuando se hace `await query` sin terminator explícito,
-      // resolvemos con selectResponseByTable[table].
+      // resolvemos con selectResponseByTable[table] o {error: null} para
+      // delete/update.
       // deno-lint-ignore no-explicit-any
       then(onFulfilled?: (v: any) => any, onRejected?: (e: any) => any) {
+        if (isDelete || isUpdate) {
+          return Promise.resolve({ error: null }).then(onFulfilled, onRejected);
+        }
         if (!isSelect) {
           return Promise.resolve({ data: [], error: null }).then(
             onFulfilled,
@@ -1244,4 +1268,201 @@ Deno.test("/sugerencias con rol admin: bloqueado por scope", async () => {
     _setServiceRoleClientForTests(null);
     Deno.env.delete("TELEGRAM_BOT_TOKEN");
   }
+});
+
+// ============================================================================
+// Fase 3 commands: /menu, /reset, /desvincular, errorMessageFor
+// ============================================================================
+
+const linkedAdmin = {
+  telegram_user_id: 999,
+  perfil_id: "11111111-1111-1111-1111-111111111111",
+  rol: "admin",
+  sucursal_id: 1,
+  activo: true,
+};
+const linkedPreventista = {
+  telegram_user_id: 888,
+  perfil_id: "22222222-2222-2222-2222-222222222222",
+  rol: "preventista",
+  sucursal_id: 1,
+  activo: true,
+};
+
+Deno.test("/menu (admin) manda keyboard con opciones para admin", async () => {
+  const handleUpdate = await freshHandleUpdate();
+  Deno.env.set("TELEGRAM_BOT_TOKEN", "test-token");
+  const { client } = createRouterMockSupabase({
+    maybeSingleByTable: { bot_usuarios: { data: linkedAdmin, error: null } },
+  });
+  // deno-lint-ignore no-explicit-any
+  _setServiceRoleClientForTests(client as any);
+  const fetchMock = mockTelegramFetch();
+
+  try {
+    await handleUpdate({
+      update_id: 1,
+      message: {
+        message_id: 1,
+        date: 1700000000,
+        chat: { id: 999, type: "private" },
+        from: { id: 999, is_bot: false, first_name: "Admin" },
+        text: "/menu",
+      },
+    });
+    const sent = fetchMock.sent.find((s) =>
+      ((s as { body?: string }).body ?? "").includes("¿Qué querés hacer?")
+    );
+    assert(sent, "no se mandó el mensaje del menú");
+    const body = (sent as { body?: string }).body ?? "";
+    assertStringIncludes(body, "Buscar cliente");
+    assertStringIncludes(body, "Buscar producto");
+    assertStringIncludes(body, "Ayuda");
+    assertStringIncludes(body, "v1:menu:buscar_cliente");
+    assertStringIncludes(body, "v1:menu:buscar_producto");
+    assertStringIncludes(body, "v1:menu:ayuda");
+  } finally {
+    fetchMock.restore();
+    _setServiceRoleClientForTests(null);
+    Deno.env.delete("TELEGRAM_BOT_TOKEN");
+  }
+});
+
+Deno.test("/menu (preventista) keyboard incluye Mis clientes y Sugerencias", async () => {
+  const handleUpdate = await freshHandleUpdate();
+  Deno.env.set("TELEGRAM_BOT_TOKEN", "test-token");
+  const { client } = createRouterMockSupabase({
+    maybeSingleByTable: { bot_usuarios: { data: linkedPreventista, error: null } },
+  });
+  // deno-lint-ignore no-explicit-any
+  _setServiceRoleClientForTests(client as any);
+  const fetchMock = mockTelegramFetch();
+
+  try {
+    await handleUpdate({
+      update_id: 1,
+      message: {
+        message_id: 1,
+        date: 1700000000,
+        chat: { id: 888, type: "private" },
+        from: { id: 888, is_bot: false, first_name: "Vendedor" },
+        text: "/menu",
+      },
+    });
+    const sent = fetchMock.sent.find((s) =>
+      ((s as { body?: string }).body ?? "").includes("Mis clientes")
+    );
+    assert(sent, "no se mandó el menú con 'Mis clientes'");
+    const body = (sent as { body?: string }).body ?? "";
+    assertStringIncludes(body, "Sugerencias");
+    assertStringIncludes(body, "v1:menu:mis_clientes");
+    assertStringIncludes(body, "v1:menu:sugerencias");
+  } finally {
+    fetchMock.restore();
+    _setServiceRoleClientForTests(null);
+    Deno.env.delete("TELEGRAM_BOT_TOKEN");
+  }
+});
+
+Deno.test("/reset borra bot_conversaciones y manda confirmación", async () => {
+  const handleUpdate = await freshHandleUpdate();
+  Deno.env.set("TELEGRAM_BOT_TOKEN", "test-token");
+  const { client, spy } = createRouterMockSupabase({
+    maybeSingleByTable: { bot_usuarios: { data: linkedAdmin, error: null } },
+  });
+  // deno-lint-ignore no-explicit-any
+  _setServiceRoleClientForTests(client as any);
+  const fetchMock = mockTelegramFetch();
+
+  try {
+    await handleUpdate({
+      update_id: 1,
+      message: {
+        message_id: 1,
+        date: 1700000000,
+        chat: { id: 999, type: "private" },
+        from: { id: 999, is_bot: false, first_name: "Admin" },
+        text: "/reset",
+      },
+    });
+    const del = spy.deletes.find((d) => d.table === "bot_conversaciones");
+    assert(del, "no se hizo delete sobre bot_conversaciones");
+    const eq = (del!.filters as Array<Record<string, unknown>>).find((f) =>
+      f.type === "eq" && f.col === "telegram_user_id"
+    );
+    assert(eq, "delete debió tener eq(telegram_user_id)");
+    assertEquals(eq!.val, 999);
+
+    const confirm = fetchMock.sent.find((s) =>
+      ((s as { body?: string }).body ?? "").includes("borré la memoria")
+    );
+    assert(confirm, "no se mandó confirmación de reset");
+  } finally {
+    fetchMock.restore();
+    _setServiceRoleClientForTests(null);
+    Deno.env.delete("TELEGRAM_BOT_TOKEN");
+  }
+});
+
+Deno.test("/desvincular hace soft delete (activo=false) y confirma", async () => {
+  const handleUpdate = await freshHandleUpdate();
+  Deno.env.set("TELEGRAM_BOT_TOKEN", "test-token");
+  const { client, spy } = createRouterMockSupabase({
+    maybeSingleByTable: { bot_usuarios: { data: linkedAdmin, error: null } },
+  });
+  // deno-lint-ignore no-explicit-any
+  _setServiceRoleClientForTests(client as any);
+  const fetchMock = mockTelegramFetch();
+
+  try {
+    await handleUpdate({
+      update_id: 1,
+      message: {
+        message_id: 1,
+        date: 1700000000,
+        chat: { id: 999, type: "private" },
+        from: { id: 999, is_bot: false, first_name: "Admin" },
+        text: "/desvincular",
+      },
+    });
+    const upd = spy.updates.find((u) => u.table === "bot_usuarios");
+    assert(upd, "no se hizo update sobre bot_usuarios");
+    assertEquals(upd!.row.activo, false);
+    const eq = (upd!.filters as Array<Record<string, unknown>>).find((f) =>
+      f.type === "eq" && f.col === "telegram_user_id"
+    );
+    assert(eq, "update debió tener eq(telegram_user_id)");
+    assertEquals(eq!.val, 999);
+
+    const confirm = fetchMock.sent.find((s) =>
+      ((s as { body?: string }).body ?? "").includes("desvinculé")
+    );
+    assert(confirm, "no se mandó confirmación de desvincular");
+  } finally {
+    fetchMock.restore();
+    _setServiceRoleClientForTests(null);
+    Deno.env.delete("TELEGRAM_BOT_TOKEN");
+  }
+});
+
+Deno.test("errorMessageFor: 429/rate limit -> mensaje 'saturado'", async () => {
+  const { errorMessageFor } = await import("../telegram-webhook/handlers.ts");
+  const r1 = errorMessageFor(new Error("Gemini 429: rate limited"));
+  assertStringIncludes(r1, "saturado");
+  const r2 = errorMessageFor(new Error("too many requests"));
+  assertStringIncludes(r2, "saturado");
+});
+
+Deno.test("errorMessageFor: 403/forbidden -> mensaje de config", async () => {
+  const { errorMessageFor } = await import("../telegram-webhook/handlers.ts");
+  const r1 = errorMessageFor(new Error("Gemini 403: forbidden"));
+  assertStringIncludes(r1, "config");
+  const r2 = errorMessageFor(new Error("API_KEY_IP_ADDRESS_BLOCKED"));
+  assertStringIncludes(r2, "config");
+});
+
+Deno.test("errorMessageFor: error genérico -> mensaje default", async () => {
+  const { errorMessageFor } = await import("../telegram-webhook/handlers.ts");
+  const r = errorMessageFor(new Error("ECONNRESET pillin"));
+  assertStringIncludes(r, "problema procesando");
 });

--- a/supabase/functions/tests/tools.test.ts
+++ b/supabase/functions/tests/tools.test.ts
@@ -29,6 +29,7 @@ import {
 import { buscarClienteTool } from "../_shared/tools/common/buscar_cliente.ts";
 import { buscarProductoTool } from "../_shared/tools/common/buscar_producto.ts";
 import { fichaClienteTool } from "../_shared/tools/common/ficha_cliente.ts";
+import { fichaProductoTool } from "../_shared/tools/common/ficha_producto.ts";
 import { listarCategoriasTool } from "../_shared/tools/common/listar_categorias.ts";
 import { productosPorCategoriaTool } from "../_shared/tools/common/productos_por_categoria.ts";
 import { misClientesTool } from "../_shared/tools/preventista/mis_clientes.ts";
@@ -533,6 +534,7 @@ Deno.test("registerAllTools registra todas las tools esperadas", () => {
   assert(getTool("buscar_cliente"), "buscar_cliente no registrada");
   assert(getTool("buscar_producto"), "buscar_producto no registrada");
   assert(getTool("ficha_cliente"), "ficha_cliente no registrada");
+  assert(getTool("ficha_producto"), "ficha_producto no registrada");
   assert(getTool("listar_categorias"), "listar_categorias no registrada");
   assert(getTool("productos_por_categoria"), "productos_por_categoria no registrada");
   assert(getTool("mis_clientes"), "mis_clientes no registrada");
@@ -543,6 +545,7 @@ Deno.test("registerAllTools registra todas las tools esperadas", () => {
   assertEquals(getTool("buscar_cliente"), buscarClienteTool);
   assertEquals(getTool("buscar_producto"), buscarProductoTool);
   assertEquals(getTool("ficha_cliente"), fichaClienteTool);
+  assertEquals(getTool("ficha_producto"), fichaProductoTool);
   assertEquals(getTool("listar_categorias"), listarCategoriasTool);
   assertEquals(getTool("productos_por_categoria"), productosPorCategoriaTool);
   assertEquals(getTool("mis_clientes"), misClientesTool);
@@ -1457,4 +1460,118 @@ Deno.test("productos_por_categoria rechaza limit fuera de rango", async () => {
     );
   }
   assert(threw, "debió lanzar 'Límite fuera de rango'");
+});
+
+// ============================================================================
+// 29. ficha_producto: invoca el RPC bot_ficha_producto y mapea bajo_stock
+// ============================================================================
+
+Deno.test("ficha_producto invoca el RPC y derivado bajo_stock cuando stock <= minimo", async () => {
+  const { client, spy } = createMockSupabase({
+    rpcResponse: {
+      data: {
+        producto: {
+          id: 215,
+          codigo: "M00025",
+          nombre: "MANAOS CITRUS 2250CC X 6",
+          precio: "9100",
+          precio_sin_iva: 9100,
+          stock: 5,
+          stock_minimo: 10,
+          categoria: "GASEOSAS",
+          proveedor_id: null,
+        },
+        ventas_30d_cantidad: 3,
+        ultima_venta: "2026-04-21T15:53:48.330307+00:00",
+      },
+      error: null,
+    },
+  });
+
+  const ctx = makeCtx(client, { rol: "admin", sucursal_id: 2 });
+  const result = await fichaProductoTool.handler({ producto_id: 215 }, ctx);
+
+  assertEquals(result.producto.id, 215);
+  assertEquals(result.producto.nombre, "MANAOS CITRUS 2250CC X 6");
+  assertEquals(result.producto.precio, 9100);
+  assertEquals(result.producto.bajo_stock, true); // 5 <= 10
+  assertEquals(result.ventas_30d_cantidad, 3);
+  assert(result.ultima_venta?.startsWith("2026-04-21"));
+
+  // RPC se llamó con los params correctos.
+  assertEquals(spy.rpcCalls.length, 1);
+  const call = spy.rpcCalls[0];
+  assertEquals(call.fn, "bot_ficha_producto");
+  assertEquals(call.params.p_producto_id, 215);
+  assertEquals(call.params.p_sucursal_id, 2);
+});
+
+// ============================================================================
+// 30. ficha_producto: producto no encontrado lanza error claro
+// ============================================================================
+
+Deno.test("ficha_producto lanza si el RPC retorna null (producto no existe)", async () => {
+  const { client } = createMockSupabase({
+    rpcResponse: { data: null, error: null },
+  });
+  const ctx = makeCtx(client, { rol: "admin", sucursal_id: 1 });
+
+  let threw = false;
+  try {
+    await fichaProductoTool.handler({ producto_id: 99999 }, ctx);
+  } catch (err) {
+    threw = true;
+    assertStringIncludes(
+      err instanceof Error ? err.message : String(err),
+      "Producto no encontrado",
+    );
+  }
+  assert(threw, "debió lanzar 'Producto no encontrado'");
+});
+
+// ============================================================================
+// 31. ficha_producto: rechaza preventista sin sucursal asignada
+// ============================================================================
+
+Deno.test("ficha_producto rechaza preventista sin sucursal asignada", async () => {
+  const { client } = createMockSupabase({});
+  const ctx = makeCtx(client, {
+    rol: "preventista",
+    sucursal_id: null,
+    perfil_id: "no-sucursal",
+  });
+
+  let threw = false;
+  try {
+    await fichaProductoTool.handler({ producto_id: 1 }, ctx);
+  } catch (err) {
+    threw = true;
+    assertStringIncludes(
+      err instanceof Error ? err.message : String(err),
+      "Sucursal no asignada",
+    );
+  }
+  assert(threw, "debió lanzar 'Sucursal no asignada'");
+});
+
+// ============================================================================
+// 32. ficha_producto: producto_id inválido lanza error
+// ============================================================================
+
+Deno.test("ficha_producto rechaza producto_id no entero", async () => {
+  const { client } = createMockSupabase({});
+  const ctx = makeCtx(client, { rol: "admin", sucursal_id: 1 });
+
+  let threw = false;
+  try {
+    // deno-lint-ignore no-explicit-any
+    await fichaProductoTool.handler({ producto_id: "abc" as any }, ctx);
+  } catch (err) {
+    threw = true;
+    assertStringIncludes(
+      err instanceof Error ? err.message : String(err),
+      "entero positivo",
+    );
+  }
+  assert(threw, "debió lanzar error de producto_id inválido");
 });


### PR DESCRIPTION
## Summary

Cierra los 3 placeholders dejados en iter 1 (PRs #265–268). El bot queda con su MVP completo antes de empezar las features grandes (audio + ventas/compras) que vienen en Fases 5/6/7.

## Cambios

### Task 4.1 — \`ficha_producto\` tool

Cierra el callback \`v1:producto:<id>\` que en Fase 1 quedó como placeholder ("acción no disponible"). Ahora tocar "📦 Ver detalle" en /producto abre la ficha del producto con precio, stock + badge ⚠️ si bajo mínimo, categoría, ventas en últimos 30d y fecha de última venta.

- **Migration 021**: RPC \`bot_ficha_producto(p_producto_id, p_sucursal_id)\` SECURITY DEFINER que devuelve producto + métricas de ventas. Filtra por sucursal_id (multi-tenancy a nivel SQL).
- **Tool TS**: delega 100% al RPC, valida producto_id entero positivo, mapea \`bajo_stock\` derivado.
- **Formatter**: header 📦 + bloque numérico con kvRow + bloque métricas con bullets.
- **handleCallbackProducto** clonado de handleCallbackCliente. Sólo \`v1:visitar:*\` queda como placeholder (acciones de write a futuro).

### Task 4.2 — Tests para Fase 3 commands

7 tests nuevos para cerrar la cobertura que quedó pendiente del PR #268:

- \`/menu\` (admin) → keyboard con \"Buscar cliente\", \"Buscar producto\", \"Ayuda\".
- \`/menu\` (preventista) → keyboard con \"Mis clientes\", \"Sugerencias\", \"Buscar producto\", \"Ayuda\".
- \`/reset\` → \`.delete()\` sobre \`bot_conversaciones\` con eq(telegram_user_id) + confirmación.
- \`/desvincular\` → \`.update({activo: false})\` sobre \`bot_usuarios\` + confirmación.
- \`errorMessageFor\` 3 tests unitarios: 429 → \"saturado\", 403 → \"config\", default → \"problema procesando\".

Cambios en infra de tests: \`RouterMockSpy\` ahora trackea \`deletes\` y \`updates\`; el builder soporta \`.delete()\` y \`.update()\`. \`errorMessageFor\` exportada de handlers.ts para test unitario.

### Task 4.3 — Inline keyboards en respuestas NL del LLM

Cuando el usuario pregunta en NL (\"¿quiénes me deben más?\", \"buscame Pepe en clientes\"), el LLM responde texto + keyboard con botones \"Ver ficha\". Antes solo los slash commands tenían keyboards.

- \`runAgent\` ahora traque la última tool call que devolvió una lista interactable (\`buscar_cliente\`, \`mis_clientes\`, \`sugerir_visitas_rfm\`, \`buscar_producto\`, \`productos_por_categoria\`). Limit a 10 items.
- \`RunAgentResult.interactableContext?: { kind: \"clientes\" | \"productos\"; items }\` opcional.
- \`buildKeyboardForContext\` (nuevo en telegram-keyboards.ts): discrimina por kind y reusa los builders existentes.
- handler NL: si \`runAgent\` devuelve context, arma el keyboard y lo adjunta a \`sendMessage\`.
- 2 tests nuevos en agent.test.ts: buscar_cliente popula el context, ficha_cliente NO lo popula.

## Test plan

- [x] \`deno task check\` OK
- [x] \`deno task lint\` OK (63 archivos)
- [x] \`deno task test\` 122 passed | 0 failed (109 antes + 13 nuevos)
- [ ] **Post-deploy** smoke al bot real:
  - [ ] \`/producto coca\` → tocar \"📦 Ver detalle\" → ahora muestra ficha (precio, stock, ventas 30d, etc.).
  - [ ] \"¿quiénes me deben más?\" en NL → respuesta + botones \"Ver ficha\" por cada cliente.
  - [ ] \"buscame Pepe en clientes\" en NL → respuesta + keyboard.
  - [ ] \"buscame agua\" en NL → respuesta + keyboard de productos.
  - [ ] \"qué saldo tiene Almacén Gabriel\" → ficha del cliente (single-item) SIN keyboard adicional (correcto).

## Fuera de alcance

Las próximas fases del plan iter 2:
- **Fase 5** (PR #2): Audio transcription multi-provider (Gemini + OpenAI + Groq).
- **Fase 6** (PR #3): Tools de ventas/compras para admin/encargado + data model de compras a proveedores.
- **Fase 7** (PR #4): Tools de preventista/transportista + cierre.

🤖 Generated with [Claude Code](https://claude.com/claude-code)