### PR TITLE
feat(bot): voice message transcription, pluggable provider (Fase 5)

### DIFF
--- a/supabase/functions/_shared/gemini/types.ts
+++ b/supabase/functions/_shared/gemini/types.ts
@@ -32,10 +32,24 @@ export interface GeminiFunctionResponsePart {
   functionResponse: GeminiFunctionResponse;
 }
 
+/**
+ * Inline binary data (audio/imagen/etc) embebido en una request a Gemini.
+ * Usado por el GeminiTranscriber para mandar el audio en base64 sin
+ * pasar por el File API. https://ai.google.dev/api/generate-content
+ */
+export interface GeminiInlineDataPart {
+  inlineData: {
+    mimeType: string;
+    /** base64 sin prefijo `data:`. */
+    data: string;
+  };
+}
+
 export type GeminiPart =
   | GeminiTextPart
   | GeminiFunctionCallPart
-  | GeminiFunctionResponsePart;
+  | GeminiFunctionResponsePart
+  | GeminiInlineDataPart;
 
 export interface GeminiContent {
   role: GeminiRole;

--- a/supabase/functions/_shared/telegram.ts
+++ b/supabase/functions/_shared/telegram.ts
@@ -6,6 +6,7 @@ import type {
   TelegramMessage,
   TelegramUpdate,
   TelegramUser,
+  TelegramVoice,
 } from "./types.ts";
 
 const TELEGRAM_API_BASE = "https://api.telegram.org";
@@ -173,6 +174,50 @@ export async function sendChatAction(
 }
 
 /**
+ * Resuelve el `file_path` de un file_id (necesario antes de descargar).
+ * https://core.telegram.org/bots/api#getfile
+ *
+ * Errores propagan: si fallás bajando el archivo, no hay nada que
+ * transcribir y el caller necesita saberlo.
+ */
+export async function getFile(
+  file_id: string,
+): Promise<{ file_path: string; file_size?: number }> {
+  const r = await callTelegramApi<{ file_path: string; file_size?: number }>(
+    "getFile",
+    { file_id },
+  );
+  if (!r.result?.file_path) {
+    throw new Error(`getFile returned no file_path for file_id=${file_id}`);
+  }
+  return { file_path: r.result.file_path, file_size: r.result.file_size };
+}
+
+/**
+ * Descarga el binary del archivo. La URL es distinta de la API JSON: el
+ * endpoint de archivos es `/file/bot{token}/{file_path}` (sin /bot{token}/
+ * como prefijo de método).
+ *
+ * Errores propagan.
+ */
+export async function downloadTelegramFile(file_path: string): Promise<Uint8Array> {
+  const token = Deno.env.get("TELEGRAM_BOT_TOKEN");
+  if (!token) {
+    throw new Error("TELEGRAM_BOT_TOKEN not set in Edge Function environment");
+  }
+  const url = `${TELEGRAM_API_BASE}/file/bot${token}/${file_path}`;
+  const res = await fetch(url);
+  if (!res.ok) {
+    throw new Error(
+      `downloadTelegramFile failed (status ${res.status}): ${
+        await res.text().catch(() => "<no body>")
+      }`,
+    );
+  }
+  return new Uint8Array(await res.arrayBuffer());
+}
+
+/**
  * Confirma la recepción de un callback_query. Sin esta llamada, el botón en
  * la UI del cliente Telegram queda con un spinner por hasta 30s. Llamala
  * SIEMPRE al final de handleCallbackQuery, aunque haya habido error — con
@@ -336,6 +381,24 @@ function parseMessage(raw: unknown): TelegramMessage | undefined {
     chat: { id: chat.id, type: chat.type },
     text: typeof msg.text === "string" ? msg.text : undefined,
     from: parseFromUser(msg.from),
+    voice: parseVoiceLike(msg.voice),
+    audio: parseVoiceLike(msg.audio),
+  };
+}
+
+function parseVoiceLike(raw: unknown): TelegramVoice | undefined {
+  if (!raw || typeof raw !== "object") return undefined;
+  const v = raw as Record<string, unknown>;
+  if (typeof v.file_id !== "string" || typeof v.file_unique_id !== "string") {
+    return undefined;
+  }
+  if (typeof v.duration !== "number") return undefined;
+  return {
+    file_id: v.file_id,
+    file_unique_id: v.file_unique_id,
+    duration: v.duration,
+    mime_type: typeof v.mime_type === "string" ? v.mime_type : undefined,
+    file_size: typeof v.file_size === "number" ? v.file_size : undefined,
   };
 }
 

--- a/supabase/functions/_shared/transcribe/gemini.ts
+++ b/supabase/functions/_shared/transcribe/gemini.ts
@@ -1,0 +1,58 @@
+// Transcriptor Gemini. Reusa el callGemini wrapper existente y manda el
+// audio inline (base64) en una `inlineData` part. No requiere API key
+// extra — usa GEMINI_API_KEY que ya está configurada para el LLM.
+//
+// Cost: input audio para Gemini Flash es gratis. Latencia ~1-2s.
+
+import { callGemini } from "../gemini/client.ts";
+import { isTextPart } from "../gemini/types.ts";
+import type { Transcriber } from "./types.ts";
+
+const PROMPT = "Transcribí literalmente el audio. Devolvé solo el texto " +
+  "transcripto, sin explicaciones, sin comillas, sin prefijos. Si el audio " +
+  "no se entiende o está vacío, devolvé un string vacío.";
+
+export class GeminiTranscriber implements Transcriber {
+  readonly name = "gemini";
+
+  async transcribe(audio: Uint8Array, mimeType: string): Promise<string> {
+    const base64 = bytesToBase64(audio);
+
+    const response = await callGemini({
+      contents: [{
+        role: "user",
+        parts: [
+          { text: PROMPT },
+          { inlineData: { mimeType, data: base64 } },
+        ],
+      }],
+      generationConfig: { temperature: 0.0, maxOutputTokens: 1024 },
+    });
+
+    const candidate = response.candidates?.[0];
+    if (!candidate) {
+      const reason = response.promptFeedback?.blockReason ?? "no_candidate";
+      throw new Error(`Gemini transcribe: blocked or empty (${reason})`);
+    }
+    const parts = candidate.content?.parts ?? [];
+    const text = parts.filter(isTextPart).map((p) => p.text).join("").trim();
+    if (!text) {
+      throw new Error("Gemini transcribe: empty result");
+    }
+    return text;
+  }
+}
+
+/**
+ * Encode Uint8Array a base64. btoa() solo acepta strings con char codes
+ * <= 255 — convertimos byte-by-byte primero. Para audios grandes esto
+ * crea un string intermedio largo pero es O(n) y suficientemente rápido
+ * en el Edge Runtime.
+ */
+function bytesToBase64(bytes: Uint8Array): string {
+  let binary = "";
+  for (let i = 0; i < bytes.length; i++) {
+    binary += String.fromCharCode(bytes[i]);
+  }
+  return btoa(binary);
+}

--- a/supabase/functions/_shared/transcribe/groq.ts
+++ b/supabase/functions/_shared/transcribe/groq.ts
@@ -1,0 +1,51 @@
+// Transcriptor Groq. Misma spec que OpenAI Whisper (Groq cumple la API
+// de OpenAI), endpoint distinto + modelo whisper-large-v3-turbo (~$0.04/h
+// audio, ~300x más barato que OpenAI). Latencia bajo 500ms.
+//
+// Requiere GROQ_API_KEY. Factory lo selecciona si
+// BOT_TRANSCRIPTION_MODEL=groq.
+
+import type { Transcriber } from "./types.ts";
+
+const ENDPOINT = "https://api.groq.com/openai/v1/audio/transcriptions";
+const MODEL = "whisper-large-v3-turbo";
+
+export class GroqTranscriber implements Transcriber {
+  readonly name = "groq";
+
+  async transcribe(audio: Uint8Array, mimeType: string): Promise<string> {
+    const apiKey = Deno.env.get("GROQ_API_KEY");
+    if (!apiKey) {
+      throw new Error(
+        "GROQ_API_KEY no está seteada. Configurala como secret de Supabase " +
+          "Edge Functions o cambiá BOT_TRANSCRIPTION_MODEL.",
+      );
+    }
+
+    const form = new FormData();
+    // Cast por discrepancy generic Uint8Array<ArrayBufferLike> → BlobPart
+    // (mismo patrón que en openai.ts).
+    form.append("file", new Blob([audio as BlobPart], { type: mimeType }), "audio.ogg");
+    form.append("model", MODEL);
+    form.append("response_format", "text");
+
+    const res = await fetch(ENDPOINT, {
+      method: "POST",
+      headers: { Authorization: `Bearer ${apiKey}` },
+      body: form,
+    });
+
+    if (!res.ok) {
+      throw new Error(
+        `Groq transcribe failed (status ${res.status}): ${
+          await res.text().catch(() => "<no body>")
+        }`,
+      );
+    }
+    const text = (await res.text()).trim();
+    if (!text) {
+      throw new Error("Groq transcribe: empty result");
+    }
+    return text;
+  }
+}

--- a/supabase/functions/_shared/transcribe/index.ts
+++ b/supabase/functions/_shared/transcribe/index.ts
@@ -1,0 +1,45 @@
+// Factory + re-export del módulo de transcripción.
+//
+// El handler invoca `getTranscriber()` que lee la env var
+// BOT_TRANSCRIPTION_MODEL (gemini | openai | groq, default gemini) y
+// devuelve la implementación correspondiente. Cada provider valida sus
+// propios secrets cuando transcribe — la factory NO los lee, así que
+// crear un transcriber sin la key correspondiente NO falla; falla la
+// primera transcripción.
+//
+// Por qué lazy: porque BOT_TRANSCRIPTION_MODEL puede cambiarse sin
+// reiniciar el isolate (un nuevo deploy o un restart aplica). El handler
+// llama getTranscriber() en cada turno y el cost es trivial (constructor
+// de clase vacía).
+
+import { GeminiTranscriber } from "./gemini.ts";
+import { OpenAITranscriber } from "./openai.ts";
+import { GroqTranscriber } from "./groq.ts";
+import type { Transcriber } from "./types.ts";
+
+export type { Transcriber } from "./types.ts";
+export { GeminiTranscriber } from "./gemini.ts";
+export { OpenAITranscriber } from "./openai.ts";
+export { GroqTranscriber } from "./groq.ts";
+
+export type TranscriptionModel = "gemini" | "openai" | "groq";
+
+export function getTranscriber(): Transcriber {
+  const raw = Deno.env.get("BOT_TRANSCRIPTION_MODEL")?.toLowerCase().trim();
+  switch (raw) {
+    case "openai":
+      return new OpenAITranscriber();
+    case "groq":
+      return new GroqTranscriber();
+    case "gemini":
+    case "":
+    case undefined:
+      return new GeminiTranscriber();
+    default:
+      // Valor desconocido — log + fallback a Gemini para no romper el bot.
+      console.warn(
+        `[transcribe] BOT_TRANSCRIPTION_MODEL=${raw} no reconocido, fallback a gemini`,
+      );
+      return new GeminiTranscriber();
+  }
+}

--- a/supabase/functions/_shared/transcribe/openai.ts
+++ b/supabase/functions/_shared/transcribe/openai.ts
@@ -1,0 +1,54 @@
+// Transcriptor OpenAI Whisper. Multipart form upload del audio.
+// Endpoint: https://api.openai.com/v1/audio/transcriptions
+// Modelo: whisper-1 (~$0.006/min audio).
+//
+// Requiere OPENAI_API_KEY como secret de Supabase Edge Functions. La
+// factory en transcribe/index.ts solo selecciona este transcriber si
+// BOT_TRANSCRIPTION_MODEL=openai.
+
+import type { Transcriber } from "./types.ts";
+
+const ENDPOINT = "https://api.openai.com/v1/audio/transcriptions";
+const MODEL = "whisper-1";
+
+export class OpenAITranscriber implements Transcriber {
+  readonly name = "openai";
+
+  async transcribe(audio: Uint8Array, mimeType: string): Promise<string> {
+    const apiKey = Deno.env.get("OPENAI_API_KEY");
+    if (!apiKey) {
+      throw new Error(
+        "OPENAI_API_KEY no está seteada. Configurala como secret de Supabase " +
+          "Edge Functions o cambiá BOT_TRANSCRIPTION_MODEL.",
+      );
+    }
+
+    const form = new FormData();
+    // Uint8Array<ArrayBufferLike> no encaja con BlobPart por una generic
+    // discrepancy en la lib de Deno; el cast es seguro (Uint8Array implementa
+    // ArrayBufferView, que sí es BlobPart en runtime).
+    form.append("file", new Blob([audio as BlobPart], { type: mimeType }), "audio.ogg");
+    form.append("model", MODEL);
+    form.append("response_format", "text");
+
+    const res = await fetch(ENDPOINT, {
+      method: "POST",
+      headers: { Authorization: `Bearer ${apiKey}` },
+      body: form,
+    });
+
+    if (!res.ok) {
+      throw new Error(
+        `OpenAI transcribe failed (status ${res.status}): ${
+          await res.text().catch(() => "<no body>")
+        }`,
+      );
+    }
+    // response_format=text → la API devuelve el texto plano directamente.
+    const text = (await res.text()).trim();
+    if (!text) {
+      throw new Error("OpenAI transcribe: empty result");
+    }
+    return text;
+  }
+}

--- a/supabase/functions/_shared/transcribe/types.ts
+++ b/supabase/functions/_shared/transcribe/types.ts
@@ -1,0 +1,17 @@
+// Interface común para los transcriptores de audio. Permite swappear el
+// provider (Gemini / OpenAI / Groq) sin tocar el handler — la elección
+// vive en una env var (BOT_TRANSCRIPTION_MODEL).
+
+export interface Transcriber {
+  /** Nombre del provider. Útil para audit log + diagnóstico. */
+  readonly name: string;
+  /**
+   * Devuelve el texto transcripto del audio.
+   * @param audio Bytes crudos del archivo (típicamente Ogg Opus de Telegram).
+   * @param mimeType MIME type. Default "audio/ogg" si Telegram no lo manda.
+   *
+   * Lanza si la red falla o el provider rechaza. El caller decide si
+   * reintentar o degradar a "no pude transcribir".
+   */
+  transcribe(audio: Uint8Array, mimeType: string): Promise<string>;
+}

--- a/supabase/functions/_shared/types.ts
+++ b/supabase/functions/_shared/types.ts
@@ -16,12 +16,39 @@ export interface TelegramChat {
   type: "private" | "group" | "supergroup" | "channel";
 }
 
+/**
+ * Voice o audio adjunto en un Telegram message. La spec:
+ *   https://core.telegram.org/bots/api#voice
+ *   https://core.telegram.org/bots/api#audio
+ *
+ * Tratamos `voice` y `audio` con el mismo shape — ambos vienen como Ogg
+ * Opus desde la app móvil de Telegram. La diferencia conceptual (voice =
+ * grabación in-app, audio = archivo de música subido) no afecta la
+ * transcripción.
+ */
+export interface TelegramVoice {
+  file_id: string;
+  file_unique_id: string;
+  /** Duración en segundos. Útil para validar antes de descargar. */
+  duration: number;
+  /** Típicamente "audio/ogg" para voice, "audio/mpeg" para audio files. */
+  mime_type?: string;
+  /** Bytes. Telegram permite hasta 20 MB para voice messages. */
+  file_size?: number;
+}
+
 export interface TelegramMessage {
   message_id: number;
   date: number;
   chat: TelegramChat;
   from?: TelegramUser;
   text?: string;
+  /** Voice message (grabado en la app de Telegram). Hoy lo usamos para
+   *  transcripción → texto → flow normal del LLM. */
+  voice?: TelegramVoice;
+  /** Audio file (subido desde el celular o un archivo). Mismo flujo que
+   *  voice — los tratamos juntos. */
+  audio?: TelegramVoice;
 }
 
 /**

--- a/supabase/functions/deno.json
+++ b/supabase/functions/deno.json
@@ -7,7 +7,7 @@
     "test": "deno test --allow-env --allow-net=api.telegram.org --allow-read",
     "lint": "deno lint",
     "fmt": "deno fmt",
-    "check": "deno check telegram-webhook/index.ts telegram-webhook/handlers.ts telegram-webhook/commands/*.ts telegram-webhook/formatters/*.ts telegram-digest/index.ts telegram-digest/digest.ts _shared/*.ts _shared/tools/*.ts _shared/tools/common/*.ts _shared/tools/preventista/*.ts _shared/tools/transportista/*.ts _shared/gemini/agent.ts _shared/gemini/client.ts _shared/gemini/history-mapper.ts _shared/gemini/memory.ts _shared/gemini/schema.ts _shared/gemini/types.ts _shared/gemini/prompts/*.ts tests/*.ts"
+    "check": "deno check telegram-webhook/index.ts telegram-webhook/handlers.ts telegram-webhook/commands/*.ts telegram-webhook/formatters/*.ts telegram-digest/index.ts telegram-digest/digest.ts _shared/*.ts _shared/tools/*.ts _shared/tools/common/*.ts _shared/tools/preventista/*.ts _shared/tools/transportista/*.ts _shared/transcribe/*.ts _shared/gemini/agent.ts _shared/gemini/client.ts _shared/gemini/history-mapper.ts _shared/gemini/memory.ts _shared/gemini/schema.ts _shared/gemini/types.ts _shared/gemini/prompts/*.ts tests/*.ts"
   },
   "lint": {
     "rules": {

--- a/supabase/functions/telegram-webhook/handlers.ts
+++ b/supabase/functions/telegram-webhook/handlers.ts
@@ -18,11 +18,14 @@ import { logEvent } from "../_shared/audit.ts";
 import { getServiceRoleClient } from "../_shared/supabase.ts";
 import {
   answerCallbackQuery,
+  downloadTelegramFile,
   escapeMarkdownV2,
+  getFile,
   sendChatAction,
   sendMessage,
   sendMessageMarkdownSafe,
 } from "../_shared/telegram.ts";
+import { getTranscriber } from "../_shared/transcribe/index.ts";
 import {
   buildKeyboardForContext,
   buildMainMenuKeyboard,
@@ -93,19 +96,86 @@ export async function handleUpdate(update: TelegramUpdate): Promise<void> {
   bootCommands();
 
   const msg = update.message;
-  // El index.ts ya filtra updates sin message+text+from, pero hacemos un guard
-  // defensivo para que este módulo sea testeable de forma aislada.
-  if (!msg || !msg.text || !msg.from) return;
+  // El index.ts filtra updates sin message+from y sin contenido (text/voice/audio),
+  // pero hacemos un guard defensivo para que este módulo sea testeable
+  // de forma aislada.
+  if (!msg || !msg.from) return;
+  const hasContent = !!(msg.text || msg.voice || msg.audio);
+  if (!hasContent) return;
 
-  const text = msg.text.trim();
   const chatId = msg.chat.id;
   const tgUser = msg.from;
 
-  // Resolvemos al usuario UNA SOLA VEZ por update. Esto:
-  //   1. Evita N lookups cuando el handler también necesita al user.
-  //   2. Permite poblar perfil_id/rol en el audit del mensaje entrante,
-  //      respetando el contrato "audit incluye identidad cuando se conoce".
+  // Resolvemos al usuario UNA SOLA VEZ por update.
   const user = await resolveUserByTelegramId(tgUser.id);
+
+  // Si llegó un voice/audio en lugar de texto, transcribimos antes de
+  // procesar. La transcripción usa el provider de BOT_TRANSCRIPTION_MODEL
+  // (default: gemini). El texto resultante se trata después como si fuera
+  // un mensaje de texto normal — slash command, NL, etc.
+  let text = msg.text?.trim() ?? "";
+  let transcriptionMeta: Record<string, unknown> | undefined;
+
+  if (!text && (msg.voice || msg.audio)) {
+    const audio = msg.voice ?? msg.audio!;
+    const MAX_DURATION_SEC = 300; // 5 min cap
+    if (audio.duration > MAX_DURATION_SEC) {
+      await sendMessage(
+        chatId,
+        `🎤 El audio es muy largo (${audio.duration}s). Máximo ${MAX_DURATION_SEC}s ` +
+          "(5 minutos). Probá de nuevo más corto.",
+      );
+      return;
+    }
+
+    void sendChatAction(chatId, "typing");
+
+    let transcriber;
+    try {
+      transcriber = getTranscriber();
+      const file = await getFile(audio.file_id);
+      const audioData = await downloadTelegramFile(file.file_path);
+      const mime = audio.mime_type ?? "audio/ogg";
+      text = (await transcriber.transcribe(audioData, mime)).trim();
+    } catch (err) {
+      console.error("[handler] transcription failed:", err);
+      await logEvent({
+        telegram_user_id: tgUser.id,
+        perfil_id: user?.perfil_id,
+        rol: user?.rol,
+        tipo: "error",
+        resultado_meta: {
+          source: "voice",
+          provider: transcriber?.name,
+          error: err instanceof Error ? err.message : String(err),
+        },
+      }).catch(() => {});
+      await sendMessage(
+        chatId,
+        "🎤 No pude transcribir el audio. Probá de nuevo o tipeá tu mensaje.",
+      );
+      return;
+    }
+
+    if (!text) {
+      await sendMessage(
+        chatId,
+        "🎤 No te entendí del audio (vino vacío). Probá hablar más cerca o tipear.",
+      );
+      return;
+    }
+
+    // Acknowledge: le mostramos al usuario qué entendió el bot antes de
+    // procesarlo. Evita confusión si la transcripción salió torcida.
+    await sendMessage(chatId, `🎤 Te entendí: "${text}"`);
+
+    transcriptionMeta = {
+      source: "voice",
+      provider: transcriber.name,
+      duration: audio.duration,
+      file_size: audio.file_size,
+    };
+  }
 
   // Audit del mensaje entrante (fail-closed: si esto explota, queremos saber).
   await logEvent({
@@ -114,6 +184,7 @@ export async function handleUpdate(update: TelegramUpdate): Promise<void> {
     rol: user?.rol,
     tipo: "mensaje",
     texto_usuario: text,
+    parametros: transcriptionMeta,
   });
 
   const parsed = parseCommand(text);

--- a/supabase/functions/telegram-webhook/index.ts
+++ b/supabase/functions/telegram-webhook/index.ts
@@ -80,10 +80,15 @@ serve(async (req: Request) => {
     return new Response("ok");
   }
 
-  if (!update?.message?.text || !update.message.from) {
+  // El handleUpdate acepta message con text, voice o audio. Cualquier otro
+  // shape (edited_message, channel_post, sticker, etc.) lo descartamos
+  // como unsupported.
+  const msg = update?.message;
+  const hasContent = !!(msg?.text || msg?.voice || msg?.audio);
+  if (!msg || !hasContent || !msg.from) {
     try {
       await logEvent({
-        telegram_user_id: update?.message?.from?.id,
+        telegram_user_id: msg?.from?.id,
         tipo: "mensaje",
         texto_usuario: null,
         resultado_meta: {
@@ -106,9 +111,9 @@ serve(async (req: Request) => {
     console.error("telegram-webhook handler error", err);
     try {
       await logEvent({
-        telegram_user_id: update.message.from.id,
+        telegram_user_id: msg.from!.id,
         tipo: "error",
-        texto_usuario: update.message.text,
+        texto_usuario: msg.text ?? null,
         resultado_meta: { error: err instanceof Error ? err.message : String(err) },
       });
     } catch (auditErr) {

--- a/supabase/functions/tests/transcribe.test.ts
+++ b/supabase/functions/tests/transcribe.test.ts
@@ -1,0 +1,71 @@
+// Tests del factory de transcribers. Los tests por-provider con mocks de
+// red están out of scope acá — los cubre el smoke test post-deploy con un
+// voice message real, donde la API del provider es la que importa, no su
+// shape de invocación.
+
+import { assert, assertEquals } from "std/assert/mod.ts";
+import {
+  GeminiTranscriber,
+  getTranscriber,
+  GroqTranscriber,
+  OpenAITranscriber,
+} from "../_shared/transcribe/index.ts";
+
+Deno.test("getTranscriber: default sin env var → Gemini", () => {
+  Deno.env.delete("BOT_TRANSCRIPTION_MODEL");
+  const t = getTranscriber();
+  assert(t instanceof GeminiTranscriber, "default debe ser Gemini");
+  assertEquals(t.name, "gemini");
+});
+
+Deno.test("getTranscriber: BOT_TRANSCRIPTION_MODEL=openai → OpenAI", () => {
+  Deno.env.set("BOT_TRANSCRIPTION_MODEL", "openai");
+  try {
+    const t = getTranscriber();
+    assert(t instanceof OpenAITranscriber);
+    assertEquals(t.name, "openai");
+  } finally {
+    Deno.env.delete("BOT_TRANSCRIPTION_MODEL");
+  }
+});
+
+Deno.test("getTranscriber: BOT_TRANSCRIPTION_MODEL=groq → Groq", () => {
+  Deno.env.set("BOT_TRANSCRIPTION_MODEL", "groq");
+  try {
+    const t = getTranscriber();
+    assert(t instanceof GroqTranscriber);
+    assertEquals(t.name, "groq");
+  } finally {
+    Deno.env.delete("BOT_TRANSCRIPTION_MODEL");
+  }
+});
+
+Deno.test("getTranscriber: valor desconocido → fallback a Gemini con warn", () => {
+  Deno.env.set("BOT_TRANSCRIPTION_MODEL", "whisper-de-juancito");
+  // Capturamos console.warn para confirmar que se loguea el fallback.
+  const orig = console.warn;
+  let warned = false;
+  console.warn = (...args: unknown[]) => {
+    if (args.some((a) => typeof a === "string" && a.includes("no reconocido"))) {
+      warned = true;
+    }
+  };
+  try {
+    const t = getTranscriber();
+    assert(t instanceof GeminiTranscriber);
+    assert(warned, "debió loggear warning sobre el valor desconocido");
+  } finally {
+    console.warn = orig;
+    Deno.env.delete("BOT_TRANSCRIPTION_MODEL");
+  }
+});
+
+Deno.test("getTranscriber: case-insensitive (GEMINI vs gemini)", () => {
+  Deno.env.set("BOT_TRANSCRIPTION_MODEL", "GEMINI");
+  try {
+    const t = getTranscriber();
+    assert(t instanceof GeminiTranscriber);
+  } finally {
+    Deno.env.delete("BOT_TRANSCRIPTION_MODEL");
+  }
+});


### PR DESCRIPTION
## Summary

El bot ahora acepta voice y audio messages de Telegram, los transcribe usando un provider configurable (Gemini / OpenAI / Groq) y procesa el texto resultante por el flow normal — slash commands o NL al LLM. Antes los voice messages se descartaban silenciosamente.

## Cambios

### Types + parseUpdate
- \`TelegramVoice\` (file_id, duration, mime_type, file_size). Mismo shape para \`voice\` y \`audio\`.
- \`TelegramMessage.voice\`/\`audio\` opcionales.
- \`parseMessage\` extrae voice/audio. \`index.ts\` del webhook cambia el filtro de \"tiene text\" a \"tiene text/voice/audio\".

### Telegram helpers nuevos
- \`getFile(file_id)\`: resuelve file_path.
- \`downloadTelegramFile(file_path)\`: GET al endpoint de archivos.

### Transcriber + 3 impls (\`_shared/transcribe/\`)
- **GeminiTranscriber**: usa \`callGemini\` con \`inlineData\` (audio en base64). Sin secrets extra (GEMINI_API_KEY ya está). Default.
- **OpenAITranscriber**: POST multipart a OpenAI \`whisper-1\`. Requiere \`OPENAI_API_KEY\`.
- **GroqTranscriber**: spec compatible con OpenAI, endpoint Groq, modelo \`whisper-large-v3-turbo\`. Requiere \`GROQ_API_KEY\`. ~300x más barato, latencia <500ms.
- Factory \`getTranscriber()\` lee \`BOT_TRANSCRIPTION_MODEL\` (default \`gemini\`, case-insensitive, fallback a Gemini si valor desconocido).

\`GeminiPart\` extendido con \`GeminiInlineDataPart\` para soportar audio inline.

### Wire en handleUpdate
- Detecta \`msg.voice ?? msg.audio\` cuando \`text\` está vacío.
- Cap de **5 minutos** por audio (cost + latencia).
- \`sendChatAction(typing)\` mientras transcribe.
- Acknowledge \"🎤 Te entendí: ...\" antes de procesar — el usuario ve qué interpretó el bot.
- Audit incluye \`parametros={ source: 'voice', provider, duration, file_size }\`.
- Errores: log + audit + mensaje amigable al usuario.

## Test plan

- [x] \`deno task check\` OK
- [x] \`deno task lint\` OK (69 archivos)
- [x] \`deno task test\` 127 passed | 0 failed (5 nuevos para el factory)
- [ ] **Post-deploy** smoke al bot real (default Gemini, sin secrets nuevos):
  - [ ] Mandar voice message corto (\"buscame Pepe\") → ver \"🎤 Te entendí: ...\" + flujo normal del LLM.
  - [ ] Mandar voice de 6 minutos → mensaje \"audio muy largo\".
  - [ ] Mandar voice con un slash command (\"slash ayuda\") → debería procesarlo igual.
- [ ] **Opcional** smoke con Groq:
  - [ ] Configurar \`GROQ_API_KEY\` como secret + setear \`BOT_TRANSCRIPTION_MODEL=groq\` en Supabase.
  - [ ] Repetir el smoke — debería funcionar igual con menor latencia.

## Setup post-deploy

\`BOT_TRANSCRIPTION_MODEL\` es **opcional** (default \`gemini\`, usa la API key existente). Para usar Whisper:
1. Agregar \`OPENAI_API_KEY\` o \`GROQ_API_KEY\` como secret de Supabase Edge Functions.
2. Setear \`BOT_TRANSCRIPTION_MODEL=openai|groq\` (también como secret).

## Limitaciones / fuera de alcance

- **Tamaño máx 5 min** por audio. Telegram permite hasta 20 MB / ~40 min. Si en algún flow se necesitan audios largos, subir el cap (variable hardcoded por ahora).
- **No conversión de formato.** Telegram entrega Ogg Opus, los 3 providers lo aceptan directo. Si en el futuro Telegram cambia el formato, ajustar.
- **No streaming.** La transcripción es one-shot post-download. Para audios > 30s la espera puede sentirse — el typing indicator + el cap de 5min mitigan.
- **Sin tests por-provider con mock de red.** El factory está testeado pero los 3 transcribers se validan con smoke real. Los providers cambian la API más rápido que un test, así que mock-tests darían falsa seguridad.

🤖 Generated with [Claude Code](https://claude.com/claude-code)