### PR TITLE
feat: filtro de pedidos por usuario + cambio de productos

### DIFF
--- a/migrations/024_cambios_productos.sql
+++ b/migrations/024_cambios_productos.sql
@@ -1,0 +1,187 @@
+-- Migración 024 — Cambios de productos cliente↔depósito
+--
+-- Permite registrar un intercambio: el cliente devuelve un producto (sube
+-- stock) y se le entrega otro (baja stock). La diferencia de precio impacta
+-- saldo_cuenta del cliente (positivo = cliente debe; negativo = a favor).
+--
+-- El trigger existente registrar_cambio_stock alimenta stock_historico ante
+-- cualquier UPDATE de productos.stock, así que no replicamos esa escritura
+-- desde la RPC.
+
+-- ============================================================================
+-- 1. Tabla cambios_productos
+-- ============================================================================
+
+CREATE TABLE IF NOT EXISTS public.cambios_productos (
+  id BIGSERIAL PRIMARY KEY,
+  cliente_id INTEGER NOT NULL REFERENCES public.clientes(id),
+  producto_devuelto_id BIGINT NOT NULL REFERENCES public.productos(id),
+  cantidad_devuelta INTEGER NOT NULL CHECK (cantidad_devuelta > 0),
+  precio_devuelto NUMERIC(12,2) NOT NULL DEFAULT 0,
+  producto_entregado_id BIGINT NOT NULL REFERENCES public.productos(id),
+  cantidad_entregada INTEGER NOT NULL CHECK (cantidad_entregada > 0),
+  precio_entregado NUMERIC(12,2) NOT NULL DEFAULT 0,
+  diferencia_monto NUMERIC(12,2) NOT NULL DEFAULT 0,
+  observaciones TEXT,
+  usuario_id UUID REFERENCES public.perfiles(id) ON DELETE SET NULL,
+  sucursal_id BIGINT NOT NULL REFERENCES public.sucursales(id),
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  CONSTRAINT cambios_productos_distintos CHECK (producto_devuelto_id <> producto_entregado_id)
+);
+
+ALTER TABLE public.cambios_productos OWNER TO postgres;
+
+CREATE INDEX IF NOT EXISTS idx_cambios_productos_cliente
+  ON public.cambios_productos (cliente_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_cambios_productos_sucursal
+  ON public.cambios_productos (sucursal_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_cambios_productos_producto_devuelto
+  ON public.cambios_productos (producto_devuelto_id);
+CREATE INDEX IF NOT EXISTS idx_cambios_productos_producto_entregado
+  ON public.cambios_productos (producto_entregado_id);
+
+-- ============================================================================
+-- 2. RLS — solo admin/encargado de la sucursal activa
+-- ============================================================================
+
+ALTER TABLE public.cambios_productos ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY mt_cambios_productos_select ON public.cambios_productos
+  FOR SELECT TO authenticated
+  USING (public.es_encargado_o_admin() AND sucursal_id = public.current_sucursal_id());
+
+CREATE POLICY mt_cambios_productos_insert ON public.cambios_productos
+  FOR INSERT TO authenticated
+  WITH CHECK (public.es_encargado_o_admin() AND sucursal_id = public.current_sucursal_id());
+
+CREATE POLICY mt_cambios_productos_delete ON public.cambios_productos
+  FOR DELETE TO authenticated
+  USING (public.es_admin() AND sucursal_id = public.current_sucursal_id());
+
+GRANT SELECT, INSERT, DELETE ON TABLE public.cambios_productos TO authenticated;
+GRANT USAGE, SELECT ON SEQUENCE public.cambios_productos_id_seq TO authenticated;
+
+-- ============================================================================
+-- 3. RPC registrar_cambio_producto
+-- ============================================================================
+-- Operación atómica:
+--   * Lock FOR UPDATE de ambos productos (orden estable por id para evitar
+--     deadlocks bajo concurrencia).
+--   * Valida stock del producto a entregar.
+--   * Suma stock al devuelto, resta al entregado (trigger
+--     registrar_cambio_stock se encarga de stock_historico).
+--   * Calcula diferencia = precio_entregado*cant_entregada -
+--     precio_devuelto*cant_devuelta y la suma a clientes.saldo_cuenta.
+--   * Inserta el registro de auditoría en cambios_productos.
+
+CREATE OR REPLACE FUNCTION public.registrar_cambio_producto(
+  p_cliente_id INTEGER,
+  p_producto_devuelto_id BIGINT,
+  p_cantidad_devuelta INTEGER,
+  p_producto_entregado_id BIGINT,
+  p_cantidad_entregada INTEGER,
+  p_observaciones TEXT DEFAULT NULL
+) RETURNS BIGINT
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = public
+AS $$
+DECLARE
+  v_sucursal BIGINT := public.current_sucursal_id();
+  v_user UUID := auth.uid();
+  v_precio_devuelto NUMERIC(12,2);
+  v_precio_entregado NUMERIC(12,2);
+  v_stock_entregado INT;
+  v_diferencia NUMERIC(12,2);
+  v_cambio_id BIGINT;
+  v_first BIGINT;
+  v_second BIGINT;
+BEGIN
+  IF v_sucursal IS NULL THEN
+    RAISE EXCEPTION 'Sin sucursal activa';
+  END IF;
+
+  IF NOT public.es_encargado_o_admin() THEN
+    RAISE EXCEPTION 'No autorizado';
+  END IF;
+
+  IF p_producto_devuelto_id = p_producto_entregado_id THEN
+    RAISE EXCEPTION 'Los productos deben ser distintos';
+  END IF;
+
+  IF p_cantidad_devuelta <= 0 OR p_cantidad_entregada <= 0 THEN
+    RAISE EXCEPTION 'Las cantidades deben ser mayores a 0';
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM clientes WHERE id = p_cliente_id AND sucursal_id = v_sucursal
+  ) THEN
+    RAISE EXCEPTION 'Cliente no encontrado en la sucursal';
+  END IF;
+
+  -- Lock en orden estable para evitar deadlocks
+  IF p_producto_devuelto_id < p_producto_entregado_id THEN
+    v_first := p_producto_devuelto_id;
+    v_second := p_producto_entregado_id;
+  ELSE
+    v_first := p_producto_entregado_id;
+    v_second := p_producto_devuelto_id;
+  END IF;
+
+  PERFORM 1 FROM productos
+   WHERE id = v_first AND sucursal_id = v_sucursal FOR UPDATE;
+  PERFORM 1 FROM productos
+   WHERE id = v_second AND sucursal_id = v_sucursal FOR UPDATE;
+
+  SELECT precio, stock INTO v_precio_entregado, v_stock_entregado
+    FROM productos
+   WHERE id = p_producto_entregado_id AND sucursal_id = v_sucursal;
+  IF v_precio_entregado IS NULL THEN
+    RAISE EXCEPTION 'Producto a entregar no encontrado';
+  END IF;
+  IF v_stock_entregado < p_cantidad_entregada THEN
+    RAISE EXCEPTION 'Stock insuficiente del producto a entregar (% disponibles)', v_stock_entregado;
+  END IF;
+
+  SELECT precio INTO v_precio_devuelto
+    FROM productos
+   WHERE id = p_producto_devuelto_id AND sucursal_id = v_sucursal;
+  IF v_precio_devuelto IS NULL THEN
+    RAISE EXCEPTION 'Producto a devolver no encontrado';
+  END IF;
+
+  UPDATE productos SET stock = stock + p_cantidad_devuelta
+   WHERE id = p_producto_devuelto_id;
+  UPDATE productos SET stock = stock - p_cantidad_entregada
+   WHERE id = p_producto_entregado_id;
+
+  v_diferencia := (v_precio_entregado * p_cantidad_entregada)
+                - (v_precio_devuelto * p_cantidad_devuelta);
+
+  UPDATE clientes
+     SET saldo_cuenta = COALESCE(saldo_cuenta, 0) + v_diferencia
+   WHERE id = p_cliente_id;
+
+  INSERT INTO cambios_productos (
+    cliente_id, producto_devuelto_id, cantidad_devuelta, precio_devuelto,
+    producto_entregado_id, cantidad_entregada, precio_entregado,
+    diferencia_monto, observaciones, usuario_id, sucursal_id
+  ) VALUES (
+    p_cliente_id, p_producto_devuelto_id, p_cantidad_devuelta, v_precio_devuelto,
+    p_producto_entregado_id, p_cantidad_entregada, v_precio_entregado,
+    v_diferencia, p_observaciones, v_user, v_sucursal
+  ) RETURNING id INTO v_cambio_id;
+
+  RETURN v_cambio_id;
+END;
+$$;
+
+ALTER FUNCTION public.registrar_cambio_producto(
+  INTEGER, BIGINT, INTEGER, BIGINT, INTEGER, TEXT
+) OWNER TO postgres;
+
+GRANT EXECUTE ON FUNCTION public.registrar_cambio_producto(
+  INTEGER, BIGINT, INTEGER, BIGINT, INTEGER, TEXT
+) TO authenticated;
+
+COMMENT ON FUNCTION public.registrar_cambio_producto(
+  INTEGER, BIGINT, INTEGER, BIGINT, INTEGER, TEXT
+) IS 'Registra un cambio de productos cliente↔depósito de forma atómica. Suma stock al devuelto, resta al entregado, ajusta saldo_cuenta del cliente con la diferencia de precio.';

--- a/src/components/containers/PedidosContainer.tsx
+++ b/src/components/containers/PedidosContainer.tsx
@@ -23,6 +23,7 @@ import {
   useClientesQuery,
   useProductosQuery,
   useTransportistasQuery,
+  useUsuariosQuery,
   useCrearClienteMutation,
 } from '../../hooks/queries'
 import { useAuthData } from '../../contexts/AuthDataContext'
@@ -60,6 +61,7 @@ const DEFAULT_FILTROS: FiltrosPedidosState = {
   estado: 'todos',
   estadoPago: 'todos',
   transportistaId: 'todos',
+  usuarioId: 'todos',
   busqueda: '',
   conSalvedad: 'todos',
 }
@@ -104,6 +106,11 @@ export default function PedidosContainer(): React.ReactElement {
   const { data: clientes = [] } = useClientesQuery()
   const { data: productos = [] } = useProductosQuery()
   const { data: transportistas = [] } = useTransportistasQuery()
+  const { data: usuariosTodos = [] } = useUsuariosQuery()
+  const usuarios = useMemo(
+    () => (isAdmin ? usuariosTodos : []),
+    [isAdmin, usuariosTodos],
+  )
 
   // Mutations
   const crearPedido = useCrearPedidoMutation()
@@ -789,6 +796,7 @@ export default function PedidosContainer(): React.ReactElement {
           clientes={clientes}
           productos={productos}
           transportistas={transportistas}
+          usuarios={usuarios}
           loading={loadingPedidos}
           exportando={exportando}
           onBusquedaChange={handleBusquedaChange}

--- a/src/components/containers/ProductosContainer.tsx
+++ b/src/components/containers/ProductosContainer.tsx
@@ -14,8 +14,11 @@ import {
 } from '../../hooks/queries'
 import { useMermasQuery, useRegistrarMermaMutation } from '../../hooks/queries'
 import { useProveedoresActivosQuery } from '../../hooks/queries'
+import { useClientesQuery } from '../../hooks/queries'
+import { useRegistrarCambioProductoMutation, type RegistrarCambioInput } from '../../hooks/queries'
 import { useAuthData } from '../../contexts/AuthDataContext'
 import { useNotification } from '../../contexts/NotificationContext'
+import { formatPrecio } from '../../utils/formatters'
 import type { ProductoDB, ProductoFormInput, MermaFormInputExtended } from '../../types'
 
 // Lazy load de componentes
@@ -26,6 +29,7 @@ const ModalHistorialMermas = lazy(() => import('../modals/ModalHistorialMermas')
 const ModalImportarPrecios = lazy(() => import('../modals/ModalImportarPrecios'))
 const ModalConfirmacion = lazy(() => import('../modals/ModalConfirmacion'))
 const ModalCategorias = lazy(() => import('../modals/ModalCategorias'))
+const ModalCambioProducto = lazy(() => import('../modals/ModalCambioProducto'))
 
 function LoadingState() {
   return (
@@ -44,19 +48,22 @@ interface ConfirmConfig {
 }
 
 export default function ProductosContainer(): React.ReactElement {
-  const { isAdmin } = useAuthData()
+  const { isAdmin, isEncargado } = useAuthData()
+  const puedeCambiarProductos = isAdmin || isEncargado
   const notify = useNotification()
 
   // Queries
   const { data: productos = [], isLoading } = useProductosQuery()
   const { data: mermas = [] } = useMermasQuery()
   const { data: proveedores = [] } = useProveedoresActivosQuery()
+  const { data: clientes = [] } = useClientesQuery()
 
   // Mutations
   const crearProducto = useCrearProductoMutation()
   const actualizarProducto = useActualizarProductoMutation()
   const eliminarProducto = useEliminarProductoMutation()
   const registrarMerma = useRegistrarMermaMutation()
+  const registrarCambioProducto = useRegistrarCambioProductoMutation()
 
   // Estado de modales
   const [modalProductoOpen, setModalProductoOpen] = useState(false)
@@ -64,6 +71,7 @@ export default function ProductosContainer(): React.ReactElement {
   const [modalHistorialOpen, setModalHistorialOpen] = useState(false)
   const [modalImportarOpen, setModalImportarOpen] = useState(false)
   const [modalCategoriasOpen, setModalCategoriasOpen] = useState(false)
+  const [modalCambioOpen, setModalCambioOpen] = useState(false)
 
   // Estado de edición
   const [productoEditando, setProductoEditando] = useState<ProductoDB | null>(null)
@@ -127,6 +135,31 @@ export default function ProductosContainer(): React.ReactElement {
     setModalCategoriasOpen(true)
   }, [])
 
+  const handleAbrirCambioProducto = useCallback(() => {
+    setModalCambioOpen(true)
+  }, [])
+
+  const handleGuardarCambioProducto = useCallback(async (data: RegistrarCambioInput) => {
+    try {
+      await registrarCambioProducto.mutateAsync(data)
+      const productoDevuelto = productos.find(p => p.id === data.productoDevueltoId)
+      const productoEntregado = productos.find(p => p.id === data.productoEntregadoId)
+      const diferencia = (productoEntregado?.precio || 0) * data.cantidadEntregada
+                       - (productoDevuelto?.precio || 0) * data.cantidadDevuelta
+      const detalle = diferencia === 0
+        ? 'sin diferencia de precio'
+        : diferencia > 0
+        ? `el cliente debe ${formatPrecio(diferencia)}`
+        : `saldo a favor del cliente por ${formatPrecio(Math.abs(diferencia))}`
+      notify.success(`Cambio registrado · ${detalle}`)
+      setModalCambioOpen(false)
+    } catch (err) {
+      const mensaje = err instanceof Error ? err.message : 'Error al registrar el cambio'
+      notify.error(mensaje)
+      throw err
+    }
+  }, [registrarCambioProducto, productos, notify])
+
   const handleGuardarProducto = useCallback(async (data: ProductoFormInput) => {
     try {
       if (productoEditando) {
@@ -187,6 +220,7 @@ export default function ProductosContainer(): React.ReactElement {
           onVerHistorialMermas={handleVerHistorialMermas}
           onImportarPrecios={handleImportarPrecios}
           onGestionarCategorias={handleGestionarCategorias}
+          onCambioProducto={puedeCambiarProductos ? handleAbrirCambioProducto : undefined}
         />
       </Suspense>
 
@@ -249,6 +283,18 @@ export default function ProductosContainer(): React.ReactElement {
           <ModalCategorias
             productos={productos}
             onClose={() => setModalCategoriasOpen(false)}
+          />
+        </Suspense>
+      )}
+
+      {/* Modal Cambio de productos */}
+      {modalCambioOpen && (
+        <Suspense fallback={null}>
+          <ModalCambioProducto
+            clientes={clientes}
+            productos={productos}
+            onSave={handleGuardarCambioProducto}
+            onClose={() => setModalCambioOpen(false)}
           />
         </Suspense>
       )}

--- a/src/components/modals/ModalCambioProducto.tsx
+++ b/src/components/modals/ModalCambioProducto.tsx
@@ -1,0 +1,448 @@
+import React, { useState, useMemo, FormEvent, ChangeEvent } from 'react'
+import { X, ArrowLeftRight, ArrowDown, ArrowUp, FileText, Search, Package, AlertTriangle, User as UserIcon } from 'lucide-react'
+import { useZodValidation } from '../../hooks/useZodValidation'
+import { modalCambioProductoSchema } from '../../lib/schemas'
+import { formatPrecio } from '../../utils/formatters'
+import type { ClienteDB, ProductoDB } from '../../types'
+
+export interface CambioProductoSaveData {
+  clienteId: string
+  productoDevueltoId: string
+  cantidadDevuelta: number
+  productoEntregadoId: string
+  cantidadEntregada: number
+  observaciones: string
+}
+
+export interface ModalCambioProductoProps {
+  clientes: ClienteDB[]
+  productos: ProductoDB[]
+  onSave: (data: CambioProductoSaveData) => Promise<void>
+  onClose: () => void
+}
+
+function normalizar(s: string | null | undefined): string {
+  return (s || '').replace(/[\s\u00A0]+/g, ' ').trim().toLowerCase()
+}
+
+export default function ModalCambioProducto({
+  clientes,
+  productos,
+  onSave,
+  onClose,
+}: ModalCambioProductoProps): React.ReactElement {
+  const { validate, getFirstError } = useZodValidation(modalCambioProductoSchema)
+
+  const [clienteId, setClienteId] = useState<string>('')
+  const [busquedaCliente, setBusquedaCliente] = useState<string>('')
+
+  const [productoDevueltoId, setProductoDevueltoId] = useState<string>('')
+  const [busquedaDevuelto, setBusquedaDevuelto] = useState<string>('')
+  const [cantidadDevuelta, setCantidadDevuelta] = useState<number | string>(1)
+
+  const [productoEntregadoId, setProductoEntregadoId] = useState<string>('')
+  const [busquedaEntregado, setBusquedaEntregado] = useState<string>('')
+  const [cantidadEntregada, setCantidadEntregada] = useState<number | string>(1)
+
+  const [observaciones, setObservaciones] = useState<string>('')
+  const [guardando, setGuardando] = useState<boolean>(false)
+  const [error, setError] = useState<string>('')
+
+  const clienteSeleccionado = useMemo(
+    () => clientes.find(c => c.id === clienteId) || null,
+    [clientes, clienteId],
+  )
+
+  const productoDevuelto = useMemo(
+    () => productos.find(p => p.id === productoDevueltoId) || null,
+    [productos, productoDevueltoId],
+  )
+
+  const productoEntregado = useMemo(
+    () => productos.find(p => p.id === productoEntregadoId) || null,
+    [productos, productoEntregadoId],
+  )
+
+  const clientesFiltrados = useMemo<ClienteDB[]>(() => {
+    if (busquedaCliente.length < 2) return []
+    const q = normalizar(busquedaCliente)
+    const cuit = busquedaCliente.replace(/[-\s]/g, '')
+    return clientes.filter(c =>
+      normalizar(c.nombre_fantasia).includes(q) ||
+      normalizar(c.razon_social).includes(q) ||
+      normalizar(c.direccion).includes(q) ||
+      (c.cuit || '').includes(cuit) ||
+      String(c.codigo || '').includes(busquedaCliente.trim())
+    ).slice(0, 8)
+  }, [clientes, busquedaCliente])
+
+  const filtrarProductos = (busqueda: string, excluirId: string): ProductoDB[] => {
+    const termino = normalizar(busqueda)
+    if (!termino) return []
+    return productos
+      .filter(p => p.id !== excluirId)
+      .filter(p =>
+        normalizar(p.nombre).includes(termino) ||
+        normalizar(p.codigo).includes(termino),
+      )
+      .slice(0, 8)
+  }
+
+  const productosDevueltoFiltrados = useMemo(
+    () => filtrarProductos(busquedaDevuelto, productoEntregadoId),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [productos, busquedaDevuelto, productoEntregadoId],
+  )
+
+  const productosEntregadoFiltrados = useMemo(
+    () => filtrarProductos(busquedaEntregado, productoDevueltoId),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [productos, busquedaEntregado, productoDevueltoId],
+  )
+
+  const cantDevNum = typeof cantidadDevuelta === 'string' ? parseInt(cantidadDevuelta) || 0 : cantidadDevuelta
+  const cantEntNum = typeof cantidadEntregada === 'string' ? parseInt(cantidadEntregada) || 0 : cantidadEntregada
+
+  const stockEntregadoInsuficiente =
+    productoEntregado != null && cantEntNum > productoEntregado.stock
+
+  const diferencia = useMemo(() => {
+    const d = (productoEntregado?.precio || 0) * cantEntNum
+            - (productoDevuelto?.precio || 0) * cantDevNum
+    return Number.isFinite(d) ? d : 0
+  }, [productoEntregado, productoDevuelto, cantEntNum, cantDevNum])
+
+  const handleSeleccionarCliente = (c: ClienteDB) => {
+    setClienteId(c.id)
+    setBusquedaCliente(c.nombre_fantasia || c.razon_social || '')
+  }
+
+  const handleSeleccionarDevuelto = (p: ProductoDB) => {
+    setProductoDevueltoId(p.id)
+    setBusquedaDevuelto(p.nombre)
+  }
+
+  const handleSeleccionarEntregado = (p: ProductoDB) => {
+    setProductoEntregadoId(p.id)
+    setBusquedaEntregado(p.nombre)
+  }
+
+  const handleSubmit = async (e: FormEvent<HTMLFormElement>): Promise<void> => {
+    e.preventDefault()
+    setError('')
+
+    const result = validate({
+      clienteId,
+      productoDevueltoId,
+      cantidadDevuelta: cantDevNum,
+      productoEntregadoId,
+      cantidadEntregada: cantEntNum,
+      observaciones,
+    })
+    if (!result.success) {
+      setError(getFirstError() || 'Error de validación')
+      return
+    }
+
+    if (stockEntregadoInsuficiente) {
+      setError(`Stock insuficiente del producto a entregar (${productoEntregado?.stock} disponibles)`)
+      return
+    }
+
+    setGuardando(true)
+    try {
+      await onSave({
+        clienteId: result.data.clienteId,
+        productoDevueltoId: result.data.productoDevueltoId,
+        cantidadDevuelta: result.data.cantidadDevuelta,
+        productoEntregadoId: result.data.productoEntregadoId,
+        cantidadEntregada: result.data.cantidadEntregada,
+        observaciones: result.data.observaciones || '',
+      })
+      onClose()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Error al registrar el cambio')
+    } finally {
+      setGuardando(false)
+    }
+  }
+
+  const submitDeshabilitado = guardando
+    || !clienteId
+    || !productoDevueltoId
+    || !productoEntregadoId
+    || cantDevNum <= 0
+    || cantEntNum <= 0
+    || stockEntregadoInsuficiente
+
+  return (
+    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
+      <div className="bg-white dark:bg-gray-800 rounded-xl shadow-xl w-full max-w-lg max-h-[90vh] overflow-y-auto">
+        {/* Header */}
+        <div className="flex items-center justify-between p-4 border-b dark:border-gray-700 sticky top-0 bg-white dark:bg-gray-800 z-10">
+          <div className="flex items-center gap-2">
+            <div className="p-2 bg-indigo-100 dark:bg-indigo-900/30 rounded-lg">
+              <ArrowLeftRight className="w-5 h-5 text-indigo-600 dark:text-indigo-400" />
+            </div>
+            <div>
+              <h2 className="text-lg font-semibold text-gray-800 dark:text-white">Cambio de productos</h2>
+              <p className="text-sm text-gray-500">El cliente devuelve uno y se le entrega otro</p>
+            </div>
+          </div>
+          <button onClick={onClose} className="p-2 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-lg" aria-label="Cerrar">
+            <X className="w-5 h-5" />
+          </button>
+        </div>
+
+        <form onSubmit={handleSubmit} className="p-4 space-y-4">
+          {/* Cliente */}
+          <div className="relative">
+            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+              <UserIcon className="w-4 h-4 inline mr-1" />
+              Cliente *
+            </label>
+            <div className="relative">
+              <Search className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400 w-4 h-4" aria-hidden="true" />
+              <input
+                type="text"
+                value={busquedaCliente}
+                onChange={(e: ChangeEvent<HTMLInputElement>) => {
+                  setBusquedaCliente(e.target.value)
+                  setClienteId('')
+                }}
+                placeholder="Buscar por nombre, razón social o CUIT..."
+                className="w-full pl-10 pr-3 py-2 border dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-indigo-500 dark:bg-gray-700 dark:text-white"
+              />
+            </div>
+            {!clienteId && clientesFiltrados.length > 0 && (
+              <ul className="absolute z-20 mt-1 w-full bg-white dark:bg-gray-800 border dark:border-gray-700 rounded-lg shadow-lg max-h-56 overflow-auto">
+                {clientesFiltrados.map(c => (
+                  <li key={c.id}>
+                    <button
+                      type="button"
+                      onClick={() => handleSeleccionarCliente(c)}
+                      className="w-full px-3 py-2 text-left hover:bg-gray-100 dark:hover:bg-gray-700 text-sm"
+                    >
+                      <p className="font-medium text-gray-800 dark:text-white">{c.nombre_fantasia || c.razon_social}</p>
+                      <p className="text-xs text-gray-500">{c.direccion}{c.cuit ? ` · CUIT ${c.cuit}` : ''}</p>
+                    </button>
+                  </li>
+                ))}
+              </ul>
+            )}
+            {clienteSeleccionado && (
+              <p className="mt-1 text-xs text-gray-500">
+                Saldo actual: <span className="font-semibold">{formatPrecio(clienteSeleccionado.saldo_cuenta || 0)}</span>
+              </p>
+            )}
+          </div>
+
+          {/* Producto a devolver */}
+          <div className="relative border border-green-200 dark:border-green-800 rounded-lg p-3 bg-green-50/50 dark:bg-green-900/10">
+            <label className="block text-sm font-medium text-green-700 dark:text-green-400 mb-1">
+              <ArrowDown className="w-4 h-4 inline mr-1" />
+              Producto que devuelve el cliente (entra al depósito) *
+            </label>
+            <div className="relative">
+              <Search className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400 w-4 h-4" aria-hidden="true" />
+              <input
+                type="text"
+                value={busquedaDevuelto}
+                onChange={(e: ChangeEvent<HTMLInputElement>) => {
+                  setBusquedaDevuelto(e.target.value)
+                  setProductoDevueltoId('')
+                }}
+                placeholder="Buscar por nombre o código..."
+                className="w-full pl-10 pr-3 py-2 border dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-green-500 dark:bg-gray-700 dark:text-white"
+              />
+            </div>
+            {!productoDevueltoId && productosDevueltoFiltrados.length > 0 && (
+              <ul className="absolute z-20 mt-1 left-3 right-3 bg-white dark:bg-gray-800 border dark:border-gray-700 rounded-lg shadow-lg max-h-56 overflow-auto">
+                {productosDevueltoFiltrados.map(p => (
+                  <li key={p.id}>
+                    <button
+                      type="button"
+                      onClick={() => handleSeleccionarDevuelto(p)}
+                      className="w-full px-3 py-2 text-left hover:bg-gray-100 dark:hover:bg-gray-700 text-sm"
+                    >
+                      <p className="font-medium text-gray-800 dark:text-white">{p.nombre}</p>
+                      <p className="text-xs text-gray-500">
+                        {p.codigo ? `Código: ${p.codigo} · ` : ''}Stock: {p.stock} · {formatPrecio(p.precio)}
+                      </p>
+                    </button>
+                  </li>
+                ))}
+              </ul>
+            )}
+            {productoDevuelto && (
+              <div className="mt-2 flex items-center gap-3 p-2 bg-white dark:bg-gray-800 border dark:border-gray-700 rounded-lg">
+                <Package className="w-5 h-5 text-gray-400" />
+                <div className="flex-1 min-w-0">
+                  <p className="text-sm font-medium text-gray-800 dark:text-white truncate">{productoDevuelto.nombre}</p>
+                  <p className="text-xs text-gray-500">
+                    Precio: {formatPrecio(productoDevuelto.precio)} · Stock actual: {productoDevuelto.stock}
+                  </p>
+                </div>
+                <input
+                  type="number"
+                  inputMode="numeric"
+                  min="1"
+                  step="1"
+                  value={cantidadDevuelta}
+                  onChange={(e: ChangeEvent<HTMLInputElement>) => setCantidadDevuelta(e.target.value)}
+                  className="w-20 px-2 py-1 border dark:border-gray-600 rounded text-right dark:bg-gray-700 dark:text-white"
+                  aria-label="Cantidad devuelta"
+                />
+              </div>
+            )}
+          </div>
+
+          {/* Producto a entregar */}
+          <div className="relative border border-red-200 dark:border-red-800 rounded-lg p-3 bg-red-50/50 dark:bg-red-900/10">
+            <label className="block text-sm font-medium text-red-700 dark:text-red-400 mb-1">
+              <ArrowUp className="w-4 h-4 inline mr-1" />
+              Producto que se entrega al cliente (sale del depósito) *
+            </label>
+            <div className="relative">
+              <Search className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400 w-4 h-4" aria-hidden="true" />
+              <input
+                type="text"
+                value={busquedaEntregado}
+                onChange={(e: ChangeEvent<HTMLInputElement>) => {
+                  setBusquedaEntregado(e.target.value)
+                  setProductoEntregadoId('')
+                }}
+                placeholder="Buscar por nombre o código..."
+                className="w-full pl-10 pr-3 py-2 border dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-red-500 dark:bg-gray-700 dark:text-white"
+              />
+            </div>
+            {!productoEntregadoId && productosEntregadoFiltrados.length > 0 && (
+              <ul className="absolute z-20 mt-1 left-3 right-3 bg-white dark:bg-gray-800 border dark:border-gray-700 rounded-lg shadow-lg max-h-56 overflow-auto">
+                {productosEntregadoFiltrados.map(p => (
+                  <li key={p.id}>
+                    <button
+                      type="button"
+                      onClick={() => handleSeleccionarEntregado(p)}
+                      className="w-full px-3 py-2 text-left hover:bg-gray-100 dark:hover:bg-gray-700 text-sm"
+                    >
+                      <p className="font-medium text-gray-800 dark:text-white">{p.nombre}</p>
+                      <p className="text-xs text-gray-500">
+                        {p.codigo ? `Código: ${p.codigo} · ` : ''}Stock: {p.stock} · {formatPrecio(p.precio)}
+                      </p>
+                    </button>
+                  </li>
+                ))}
+              </ul>
+            )}
+            {productoEntregado && (
+              <div className="mt-2 flex items-center gap-3 p-2 bg-white dark:bg-gray-800 border dark:border-gray-700 rounded-lg">
+                <Package className="w-5 h-5 text-gray-400" />
+                <div className="flex-1 min-w-0">
+                  <p className="text-sm font-medium text-gray-800 dark:text-white truncate">{productoEntregado.nombre}</p>
+                  <p className="text-xs text-gray-500">
+                    Precio: {formatPrecio(productoEntregado.precio)} · Stock actual: {productoEntregado.stock}
+                  </p>
+                </div>
+                <input
+                  type="number"
+                  inputMode="numeric"
+                  min="1"
+                  step="1"
+                  max={productoEntregado.stock}
+                  value={cantidadEntregada}
+                  onChange={(e: ChangeEvent<HTMLInputElement>) => setCantidadEntregada(e.target.value)}
+                  className="w-20 px-2 py-1 border dark:border-gray-600 rounded text-right dark:bg-gray-700 dark:text-white"
+                  aria-label="Cantidad entregada"
+                />
+              </div>
+            )}
+            {stockEntregadoInsuficiente && (
+              <p className="mt-2 text-xs text-red-600 dark:text-red-400 flex items-center gap-1">
+                <AlertTriangle className="w-3 h-3" />
+                Stock insuficiente. Disponible: {productoEntregado?.stock}
+              </p>
+            )}
+          </div>
+
+          {/* Diferencia de precio */}
+          {productoDevuelto && productoEntregado && cantDevNum > 0 && cantEntNum > 0 && (
+            <div className={`p-3 rounded-lg border ${
+              diferencia > 0
+                ? 'bg-orange-50 dark:bg-orange-900/20 border-orange-200 dark:border-orange-800'
+                : diferencia < 0
+                ? 'bg-emerald-50 dark:bg-emerald-900/20 border-emerald-200 dark:border-emerald-800'
+                : 'bg-gray-50 dark:bg-gray-900 border-gray-200 dark:border-gray-700'
+            }`}>
+              <div className="flex items-center justify-between">
+                <span className="text-sm text-gray-700 dark:text-gray-300">Diferencia de precio</span>
+                <span className={`text-base font-semibold ${
+                  diferencia > 0
+                    ? 'text-orange-700 dark:text-orange-400'
+                    : diferencia < 0
+                    ? 'text-emerald-700 dark:text-emerald-400'
+                    : 'text-gray-700 dark:text-gray-300'
+                }`}>
+                  {formatPrecio(diferencia)}
+                </span>
+              </div>
+              <p className="mt-1 text-xs text-gray-600 dark:text-gray-400">
+                {diferencia > 0
+                  ? `Se sumarán ${formatPrecio(diferencia)} a la cuenta del cliente.`
+                  : diferencia < 0
+                  ? `El cliente queda con saldo a favor por ${formatPrecio(Math.abs(diferencia))}.`
+                  : 'El cambio no afecta la cuenta corriente.'}
+              </p>
+            </div>
+          )}
+
+          {/* Observaciones */}
+          <div>
+            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+              <FileText className="w-4 h-4 inline mr-1" />
+              Observaciones (motivo del cambio)
+            </label>
+            <textarea
+              value={observaciones}
+              onChange={(e: ChangeEvent<HTMLTextAreaElement>) => setObservaciones(e.target.value)}
+              placeholder="Detalle del motivo, condición del producto devuelto, etc."
+              rows={3}
+              className="w-full px-4 py-2 border dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-indigo-500 dark:bg-gray-700 dark:text-white"
+            />
+          </div>
+
+          {/* Error */}
+          {error && (
+            <div className="p-3 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg">
+              <p className="text-sm text-red-600 dark:text-red-400">{error}</p>
+            </div>
+          )}
+
+          {/* Botones */}
+          <div className="flex gap-3 pt-2">
+            <button
+              type="button"
+              onClick={onClose}
+              className="flex-1 px-4 py-2 border dark:border-gray-600 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors"
+            >
+              Cancelar
+            </button>
+            <button
+              type="submit"
+              disabled={submitDeshabilitado}
+              className="flex-1 px-4 py-2 bg-indigo-600 hover:bg-indigo-700 disabled:bg-indigo-300 dark:disabled:bg-indigo-800 text-white rounded-lg transition-colors flex items-center justify-center gap-2"
+            >
+              {guardando ? (
+                <span className="animate-pulse">Registrando...</span>
+              ) : (
+                <>
+                  <ArrowLeftRight className="w-4 h-4" />
+                  Registrar cambio
+                </>
+              )}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  )
+}

--- a/src/components/pedidos/PedidoFilters.tsx
+++ b/src/components/pedidos/PedidoFilters.tsx
@@ -2,7 +2,7 @@
  * Componente de filtros para la vista de pedidos
  */
 import React, { memo, ChangeEvent } from 'react';
-import { Search, Calendar, X, Truck } from 'lucide-react';
+import { Search, Calendar, X, Truck, User } from 'lucide-react';
 import { fechaLocalISO } from '../../utils/formatters';
 import type { Usuario, EstadoPedido, EstadoPago } from '../../types';
 
@@ -10,6 +10,7 @@ interface FiltrosPedido {
   estado: string;
   estadoPago?: string;
   transportistaId?: string;
+  usuarioId?: string;
   fechaDesde?: string | null;
   fechaHasta?: string | null;
   conSalvedad?: 'todos' | 'con_salvedad' | 'sin_salvedad';
@@ -21,6 +22,7 @@ interface FiltrosChange {
   estado?: string;
   estadoPago?: string;
   transportistaId?: string;
+  usuarioId?: string;
   fechaDesde?: string | null;
   fechaHasta?: string | null;
   conSalvedad?: 'todos' | 'con_salvedad' | 'sin_salvedad';
@@ -32,6 +34,7 @@ export interface PedidoFiltersProps {
   busqueda: string;
   filtros: FiltrosPedido;
   transportistas?: Usuario[];
+  usuarios?: Usuario[];
   isAdmin: boolean;
   onBusquedaChange: (value: string) => void;
   onFiltrosChange: (filtros: FiltrosChange) => void;
@@ -42,6 +45,7 @@ function PedidoFilters({
   busqueda,
   filtros,
   transportistas = [],
+  usuarios = [],
   isAdmin,
   onBusquedaChange,
   onFiltrosChange,
@@ -138,6 +142,25 @@ function PedidoFilters({
               <option value="sin_asignar">Sin asignar</option>
               {transportistas.map(t => (
                 <option key={t.id} value={t.id}>{t.nombre}</option>
+              ))}
+            </select>
+          </div>
+          <div className="flex items-center gap-1">
+            <User className="w-4 h-4 text-gray-500 dark:text-gray-400" />
+            <label htmlFor="filtro-usuario" className="sr-only">Filtrar por usuario que cargó el pedido</label>
+            <select
+              id="filtro-usuario"
+              value={filtros.usuarioId || 'todos'}
+              onChange={(e: ChangeEvent<HTMLSelectElement>) => onFiltrosChange({ usuarioId: e.target.value })}
+              className={`px-4 py-2 border rounded-lg focus:ring-2 focus:ring-blue-500 dark:bg-gray-700 dark:border-gray-600 dark:text-white ${
+                filtros.usuarioId && filtros.usuarioId !== 'todos'
+                  ? 'bg-blue-50 border-blue-300 dark:bg-blue-900/30 dark:border-blue-600'
+                  : ''
+              }`}
+            >
+              <option value="todos">Todos los usuarios</option>
+              {usuarios.map(u => (
+                <option key={u.id} value={u.id}>{u.nombre}</option>
               ))}
             </select>
           </div>

--- a/src/components/vistas/VistaPedidos.tsx
+++ b/src/components/vistas/VistaPedidos.tsx
@@ -43,6 +43,7 @@ export interface VistaPedidosProps {
   clientes: ClienteDB[];
   productos: ProductoDB[];
   transportistas?: PerfilDB[];
+  usuarios?: PerfilDB[];
   loading: boolean;
   exportando: boolean;
   onBusquedaChange: (busqueda: string) => void;
@@ -104,6 +105,7 @@ export default function VistaPedidos({
   clientes,
   productos,
   transportistas = [],
+  usuarios = [],
   loading,
   exportando,
   onBusquedaChange,
@@ -216,6 +218,7 @@ export default function VistaPedidos({
         busqueda={busqueda}
         filtros={filtros}
         transportistas={transportistas as import('../../types').Usuario[]}
+        usuarios={usuarios as import('../../types').Usuario[]}
         isAdmin={isAdmin}
         onBusquedaChange={onBusquedaChange}
         onFiltrosChange={onFiltrosChange}

--- a/src/components/vistas/VistaProductos.tsx
+++ b/src/components/vistas/VistaProductos.tsx
@@ -1,6 +1,6 @@
 import { useState, useMemo, useRef } from 'react';
 import type { ChangeEvent } from 'react';
-import { Package, Plus, Edit2, Trash2, Search, AlertTriangle, Minus, TrendingDown, FileSpreadsheet, ClipboardCheck, Tag, ChevronLeft, ChevronRight } from 'lucide-react';
+import { Package, Plus, Edit2, Trash2, Search, AlertTriangle, Minus, TrendingDown, FileSpreadsheet, ClipboardCheck, Tag, ChevronLeft, ChevronRight, ArrowLeftRight } from 'lucide-react';
 import { formatPrecio } from '../../utils/formatters';
 import LoadingSpinner from '../layout/LoadingSpinner';
 import Paginacion from '../layout/Paginacion';
@@ -24,6 +24,7 @@ export interface VistaProductosProps {
   onVerHistorialMermas?: () => void;
   onImportarPrecios?: () => void;
   onGestionarCategorias?: () => void;
+  onCambioProducto?: () => void;
 }
 
 export default function VistaProductos({
@@ -37,7 +38,8 @@ export default function VistaProductos({
   onBajaStock,
   onVerHistorialMermas,
   onImportarPrecios,
-  onGestionarCategorias
+  onGestionarCategorias,
+  onCambioProducto
 }: VistaProductosProps) {
   const [busqueda, setBusqueda] = useState<string>('');
   const [filtroCategoria, setFiltroCategoria] = useState<string>('todas');
@@ -104,9 +106,9 @@ export default function VistaProductos({
           <h1 className="text-2xl font-bold text-gray-800 dark:text-white">Productos</h1>
           <p className="text-sm text-gray-500 dark:text-gray-400">{productos.length} productos en catálogo</p>
         </div>
-        {isAdmin && (
+        {(isAdmin || onCambioProducto) && (
           <div className="flex flex-wrap gap-2">
-            {onGestionarCategorias && (
+            {isAdmin && onGestionarCategorias && (
               <button
                 onClick={onGestionarCategorias}
                 className="flex items-center space-x-2 px-4 py-2 bg-purple-100 dark:bg-purple-900/30 text-purple-700 dark:text-purple-400 rounded-lg hover:bg-purple-200 dark:hover:bg-purple-900/50 transition-colors"
@@ -115,17 +117,19 @@ export default function VistaProductos({
                 <span>Categorías</span>
               </button>
             )}
-            <button
-              onClick={async () => {
-                const { exportControlStock } = await import('../../utils/excel');
-                await exportControlStock(productos);
-              }}
-              className="flex items-center space-x-2 px-4 py-2 bg-amber-100 dark:bg-amber-900/30 text-amber-700 dark:text-amber-400 rounded-lg hover:bg-amber-200 dark:hover:bg-amber-900/50 transition-colors"
-            >
-              <ClipboardCheck className="w-5 h-5" />
-              <span>Control de Stock</span>
-            </button>
-            {onVerHistorialMermas && (
+            {isAdmin && (
+              <button
+                onClick={async () => {
+                  const { exportControlStock } = await import('../../utils/excel');
+                  await exportControlStock(productos);
+                }}
+                className="flex items-center space-x-2 px-4 py-2 bg-amber-100 dark:bg-amber-900/30 text-amber-700 dark:text-amber-400 rounded-lg hover:bg-amber-200 dark:hover:bg-amber-900/50 transition-colors"
+              >
+                <ClipboardCheck className="w-5 h-5" />
+                <span>Control de Stock</span>
+              </button>
+            )}
+            {isAdmin && onVerHistorialMermas && (
               <button
                 onClick={onVerHistorialMermas}
                 className="flex items-center space-x-2 px-4 py-2 bg-red-100 dark:bg-red-900/30 text-red-700 dark:text-red-400 rounded-lg hover:bg-red-200 dark:hover:bg-red-900/50 transition-colors"
@@ -134,7 +138,7 @@ export default function VistaProductos({
                 <span>Historial Mermas</span>
               </button>
             )}
-            {onImportarPrecios && (
+            {isAdmin && onImportarPrecios && (
               <button
                 onClick={onImportarPrecios}
                 className="flex items-center space-x-2 px-4 py-2 bg-green-100 dark:bg-green-900/30 text-green-700 dark:text-green-400 rounded-lg hover:bg-green-200 dark:hover:bg-green-900/50 transition-colors"
@@ -143,13 +147,24 @@ export default function VistaProductos({
                 <span>Importar Precios</span>
               </button>
             )}
-            <button
-              onClick={onNuevoProducto}
-              className="flex items-center space-x-2 px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors"
-            >
-              <Plus className="w-5 h-5" />
-              <span>Nuevo Producto</span>
-            </button>
+            {onCambioProducto && (
+              <button
+                onClick={onCambioProducto}
+                className="flex items-center space-x-2 px-4 py-2 bg-indigo-100 dark:bg-indigo-900/30 text-indigo-700 dark:text-indigo-400 rounded-lg hover:bg-indigo-200 dark:hover:bg-indigo-900/50 transition-colors"
+              >
+                <ArrowLeftRight className="w-5 h-5" />
+                <span>Cambio de productos</span>
+              </button>
+            )}
+            {isAdmin && (
+              <button
+                onClick={onNuevoProducto}
+                className="flex items-center space-x-2 px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors"
+              >
+                <Plus className="w-5 h-5" />
+                <span>Nuevo Producto</span>
+              </button>
+            )}
           </div>
         )}
       </div>

--- a/src/hooks/queries/index.ts
+++ b/src/hooks/queries/index.ts
@@ -108,6 +108,13 @@ export {
   useMermasResumen,
 } from './useMermasQuery'
 
+// Cambios de productos cliente↔depósito
+export {
+  cambiosProductosKeys,
+  useRegistrarCambioProductoMutation,
+} from './useCambiosProductosQuery'
+export type { RegistrarCambioInput } from './useCambiosProductosQuery'
+
 // Grupos de Precio Mayorista
 export {
   gruposPrecioKeys,

--- a/src/hooks/queries/useCambiosProductosQuery.ts
+++ b/src/hooks/queries/useCambiosProductosQuery.ts
@@ -1,0 +1,61 @@
+/**
+ * TanStack Query hooks para Cambios de Productos cliente↔depósito
+ *
+ * Llama a la RPC atómica registrar_cambio_producto que:
+ *   - Suma stock al producto devuelto
+ *   - Resta stock al producto entregado
+ *   - Ajusta saldo_cuenta del cliente con la diferencia de precio
+ *   - Inserta el registro en cambios_productos
+ */
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { supabase } from '../supabase/base'
+import { useSucursal } from '../../contexts/SucursalContext'
+import { productosKeys } from './useProductosQuery'
+import { clientesKeys } from './useClientesQuery'
+
+export const cambiosProductosKeys = {
+  all: (sucursalId: number | null) => ['cambios_productos', sucursalId] as const,
+  lists: (sucursalId: number | null) => [...cambiosProductosKeys.all(sucursalId), 'list'] as const,
+}
+
+export interface RegistrarCambioInput {
+  clienteId: string
+  productoDevueltoId: string
+  cantidadDevuelta: number
+  productoEntregadoId: string
+  cantidadEntregada: number
+  observaciones?: string
+}
+
+async function registrarCambio(input: RegistrarCambioInput): Promise<number> {
+  const { data, error } = await supabase.rpc('registrar_cambio_producto', {
+    p_cliente_id: Number(input.clienteId),
+    p_producto_devuelto_id: Number(input.productoDevueltoId),
+    p_cantidad_devuelta: input.cantidadDevuelta,
+    p_producto_entregado_id: Number(input.productoEntregadoId),
+    p_cantidad_entregada: input.cantidadEntregada,
+    p_observaciones: input.observaciones || null,
+  })
+
+  if (error) throw error
+  return data as number
+}
+
+/**
+ * Hook para registrar un cambio de productos.
+ * Invalida cache de productos (stock) y clientes (saldo_cuenta).
+ */
+export function useRegistrarCambioProductoMutation() {
+  const queryClient = useQueryClient()
+  const { currentSucursalId } = useSucursal()
+
+  return useMutation({
+    mutationFn: registrarCambio,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: productosKeys.lists(currentSucursalId) })
+      queryClient.invalidateQueries({ queryKey: productosKeys.stockBajo(currentSucursalId, 10) })
+      queryClient.invalidateQueries({ queryKey: clientesKeys.lists(currentSucursalId) })
+      queryClient.invalidateQueries({ queryKey: cambiosProductosKeys.lists(currentSucursalId) })
+    },
+  })
+}

--- a/src/hooks/queries/usePedidoStatsQuery.ts
+++ b/src/hooks/queries/usePedidoStatsQuery.ts
@@ -60,6 +60,9 @@ async function fetchPedidoStats(
   if (filters?.transportistaId && filters.transportistaId !== 'todos') {
     query = query.eq('transportista_id', filters.transportistaId)
   }
+  if (filters?.usuarioId && filters.usuarioId !== 'todos') {
+    query = query.eq('usuario_id', filters.usuarioId)
+  }
   if (filters?.fechaDesde) {
     query = query.gte('fecha', filters.fechaDesde)
   }

--- a/src/hooks/queries/usePedidosQuery.ts
+++ b/src/hooks/queries/usePedidosQuery.ts
@@ -221,6 +221,9 @@ async function fetchPedidosPaginated(
   if (filters?.transportistaId && filters.transportistaId !== 'todos') {
     query = query.eq('transportista_id', filters.transportistaId)
   }
+  if (filters?.usuarioId && filters.usuarioId !== 'todos') {
+    query = query.eq('usuario_id', filters.usuarioId)
+  }
   if (filters?.fechaDesde) {
     query = query.gte('fecha', filters.fechaDesde)
   }

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -663,6 +663,30 @@ export const modalMermaSchema = z.object({
 export type ModalMermaFormData = z.infer<typeof modalMermaSchema>
 
 /**
+ * Schema para ModalCambioProducto
+ */
+export const modalCambioProductoSchema = z.object({
+  clienteId: z.string().min(1, { message: 'Debe seleccionar un cliente' }),
+  productoDevueltoId: z.string().min(1, { message: 'Debe seleccionar el producto a devolver' }),
+  cantidadDevuelta: z.coerce
+    .number({ error: 'La cantidad debe ser un número' })
+    .int({ message: 'La cantidad debe ser un número entero' })
+    .positive({ message: 'La cantidad debe ser mayor a 0' }),
+  productoEntregadoId: z.string().min(1, { message: 'Debe seleccionar el producto a entregar' }),
+  cantidadEntregada: z.coerce
+    .number({ error: 'La cantidad debe ser un número' })
+    .int({ message: 'La cantidad debe ser un número entero' })
+    .positive({ message: 'La cantidad debe ser mayor a 0' }),
+  observaciones: z.string().optional()
+}).refine(d => d.productoDevueltoId !== d.productoEntregadoId, {
+  message: 'Los productos deben ser distintos',
+  path: ['productoEntregadoId']
+})
+
+/** Inferred type for ModalCambioProducto schema */
+export type ModalCambioProductoFormData = z.infer<typeof modalCambioProductoSchema>
+
+/**
  * Schema para ModalProveedor
  */
 export const modalProveedorSchema = z.object({

--- a/src/types/hooks.ts
+++ b/src/types/hooks.ts
@@ -273,6 +273,7 @@ export interface FiltrosPedidosState {
   estado: string;
   estadoPago: string;
   transportistaId: string;
+  usuarioId?: string;
   busqueda: string;
   conSalvedad: 'todos' | 'con_salvedad' | 'sin_salvedad';
   verCancelados?: boolean;


### PR DESCRIPTION
## Summary

- **Pedidos**: nuevo filtro admin-only por **usuario creador** (`pedidos.usuario_id`) en el panel de pedidos. La lista y las cards de stats reaccionan al instante. El select se renderiza solo si `isAdmin`.
- **Productos**: nueva acción **"Cambio de productos"** disponible para admin y encargado en la toolbar de productos. Modal con búsqueda de cliente, selector de producto a devolver / a entregar, cantidades independientes, observaciones y vista previa de la diferencia de precio.
- **DB**: migración `024_cambios_productos.sql` (ya aplicada en Supabase) — tabla `cambios_productos` con RLS por sucursal + RPC atómica `registrar_cambio_producto` que: lockea ambos productos `FOR UPDATE`, valida stock, ajusta `productos.stock` (el trigger existente alimenta `stock_historico`), suma la diferencia a `clientes.saldo_cuenta` y registra el evento.

## Test plan

- [ ] Como **admin** en `/pedidos`: aparece el select "Usuario" en la fila de filtros admin. Filtrar → lista y stats coinciden.
- [ ] Como **preventista** o **transportista**: el select **no** aparece.
- [ ] Como **admin** o **encargado** en `/productos`: aparece el botón "Cambio de productos".
- [ ] Flujo feliz del cambio: stock del devuelto sube, del entregado baja, `cambios_productos` tiene la fila, `stock_historico` tiene 2 entradas (trigger), `clientes.saldo_cuenta` se ajustó por la diferencia.
- [ ] Stock insuficiente del producto a entregar: la RPC aborta, no debe quedar el devuelto sumado (transacción).
- [ ] Mismo producto en ambos lados: bloqueado por Zod + CHECK constraint.
- [ ] `npm run typecheck` y `npm run lint` pasan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)