### PR TITLE
feat(bot): inyectar fecha en prompt + ventas_por_preventista + mis_ventas

### DIFF
--- a/migrations/025_bot_ventas_por_preventista.sql
+++ b/migrations/025_bot_ventas_por_preventista.sql
@@ -1,0 +1,149 @@
+-- Migración 025 — Bot Telegram: ventas agregadas por preventista y "mis ventas"
+--
+-- Agrega dos RPCs para reportes tipo Power BI:
+--
+--   1. bot_ventas_por_preventista(desde, hasta, sucursal, [solo_preventistas], [limit])
+--      Ranking de ventas agrupadas por usuario_id (preventista). Permite responder
+--      "ventas de ayer por preventista", "quién vendió más esta semana", etc.
+--      `solo_preventistas` filtra por perfiles.rol='preventista' para excluir
+--      ventas registradas a nombre de un admin/encargado del mostrador.
+--
+--   2. bot_mis_ventas(preventista_id, desde, hasta, sucursal)
+--      Resumen de las ventas del propio preventista en el período: total, conteo
+--      de pedidos, ticket promedio, clientes distintos, top clientes.
+--
+-- Convenciones tomadas de migration 022 (bot_ventas_periodo):
+--   * Filtro por created_at (NO por fecha) — para que los totales matcheen 1:1
+--     contra bot_ventas_periodo. Mezclar columnas daría números distintos para
+--     la misma pregunta.
+--   * Excluye estados 'cancelado' y 'anulado'.
+--   * SECURITY DEFINER + grant explícito a service_role; la edge function valida
+--     rol y sucursal antes de invocar.
+
+-- ============================================================================
+-- 1. bot_ventas_por_preventista
+-- ============================================================================
+CREATE OR REPLACE FUNCTION public.bot_ventas_por_preventista(
+  p_desde DATE,
+  p_hasta DATE,
+  p_sucursal_id BIGINT,
+  p_solo_preventistas BOOLEAN DEFAULT TRUE,
+  p_limit INT DEFAULT 25
+)
+RETURNS JSON
+LANGUAGE plpgsql STABLE SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE resultado JSON;
+BEGIN
+  WITH ventas_filtradas AS (
+    SELECT p.id, p.usuario_id, p.total
+    FROM pedidos p
+    LEFT JOIN perfiles pf ON pf.id = p.usuario_id
+    WHERE p.sucursal_id = p_sucursal_id
+      AND p.created_at >= p_desde::TIMESTAMPTZ
+      AND p.created_at < (p_hasta::DATE + 1)::TIMESTAMPTZ
+      AND COALESCE(p.estado, '') NOT IN ('cancelado', 'anulado')
+      AND (NOT p_solo_preventistas OR pf.rol = 'preventista')
+  ),
+  por_usuario AS (
+    SELECT
+      v.usuario_id,
+      pf.nombre,
+      pf.rol,
+      COUNT(*)         AS pedidos,
+      SUM(v.total)     AS total_vendido,
+      ROUND(AVG(v.total), 2) AS ticket_promedio
+    FROM ventas_filtradas v
+    LEFT JOIN perfiles pf ON pf.id = v.usuario_id
+    GROUP BY v.usuario_id, pf.nombre, pf.rol
+    ORDER BY SUM(v.total) DESC
+    LIMIT p_limit
+  )
+  SELECT json_build_object(
+    'desde', p_desde,
+    'hasta', p_hasta,
+    'solo_preventistas', p_solo_preventistas,
+    'total_ventas', (SELECT COALESCE(SUM(total), 0) FROM ventas_filtradas),
+    'pedidos_count', (SELECT COUNT(*) FROM ventas_filtradas),
+    'preventistas_count', (SELECT COUNT(*) FROM por_usuario),
+    'preventistas', COALESCE(
+      (SELECT json_agg(row_to_json(pu.*)) FROM por_usuario pu),
+      '[]'::JSON
+    )
+  ) INTO resultado;
+  RETURN resultado;
+END;
+$$;
+
+ALTER FUNCTION public.bot_ventas_por_preventista(DATE, DATE, BIGINT, BOOLEAN, INT) OWNER TO postgres;
+REVOKE ALL    ON FUNCTION public.bot_ventas_por_preventista(DATE, DATE, BIGINT, BOOLEAN, INT) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.bot_ventas_por_preventista(DATE, DATE, BIGINT, BOOLEAN, INT) TO service_role;
+
+-- ============================================================================
+-- 2. bot_mis_ventas — resumen del propio preventista
+-- ============================================================================
+-- p_preventista_id es el caller (perfil_id del bot). Como solo se exporta a
+-- service_role y la edge function pasa siempre ctx.perfil_id, no hay forma
+-- desde el bot de pedir las ventas de OTRO preventista. La edge function
+-- valida adicionalmente que rol='preventista' antes de invocar.
+
+CREATE OR REPLACE FUNCTION public.bot_mis_ventas(
+  p_preventista_id UUID,
+  p_desde DATE,
+  p_hasta DATE,
+  p_sucursal_id BIGINT,
+  p_limit INT DEFAULT 10
+)
+RETURNS JSON
+LANGUAGE plpgsql STABLE SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE resultado JSON;
+BEGIN
+  WITH ventas_filtradas AS (
+    SELECT p.id, p.cliente_id, p.total
+    FROM pedidos p
+    WHERE p.sucursal_id = p_sucursal_id
+      AND p.usuario_id  = p_preventista_id
+      AND p.created_at >= p_desde::TIMESTAMPTZ
+      AND p.created_at < (p_hasta::DATE + 1)::TIMESTAMPTZ
+      AND COALESCE(p.estado, '') NOT IN ('cancelado', 'anulado')
+  ),
+  top_clientes AS (
+    SELECT
+      c.id          AS cliente_id,
+      c.codigo      AS cliente_codigo,
+      c.nombre_fantasia,
+      c.razon_social,
+      SUM(v.total)  AS total_comprado,
+      COUNT(*)      AS pedidos
+    FROM ventas_filtradas v
+    JOIN clientes c ON c.id = v.cliente_id
+    GROUP BY c.id, c.codigo, c.nombre_fantasia, c.razon_social
+    ORDER BY SUM(v.total) DESC
+    LIMIT p_limit
+  )
+  SELECT json_build_object(
+    'desde', p_desde,
+    'hasta', p_hasta,
+    'preventista_id', p_preventista_id,
+    'total_ventas', (SELECT COALESCE(SUM(total), 0) FROM ventas_filtradas),
+    'pedidos_count', (SELECT COUNT(*) FROM ventas_filtradas),
+    'ticket_promedio', (
+      SELECT CASE WHEN COUNT(*) > 0 THEN ROUND(AVG(total), 2) ELSE 0 END
+      FROM ventas_filtradas
+    ),
+    'clientes_distintos', (SELECT COUNT(DISTINCT cliente_id) FROM ventas_filtradas),
+    'top_clientes', COALESCE(
+      (SELECT json_agg(row_to_json(tc.*)) FROM top_clientes tc),
+      '[]'::JSON
+    )
+  ) INTO resultado;
+  RETURN resultado;
+END;
+$$;
+
+ALTER FUNCTION public.bot_mis_ventas(UUID, DATE, DATE, BIGINT, INT) OWNER TO postgres;
+REVOKE ALL    ON FUNCTION public.bot_mis_ventas(UUID, DATE, DATE, BIGINT, INT) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.bot_mis_ventas(UUID, DATE, DATE, BIGINT, INT) TO service_role;

--- a/supabase/functions/_shared/gemini/agent.ts
+++ b/supabase/functions/_shared/gemini/agent.ts
@@ -328,9 +328,15 @@ export async function runAgent(opts: RunAgentOptions): Promise<RunAgentResult> {
         .filter(isTextPart)
         .map((p) => p.text)
         .join("");
-      let text = textParts.trim().length > 0
-        ? textParts
+      // MALFORMED_FUNCTION_CALL: Gemini intentó emitir un function call
+      // pero el JSON no validó contra el schema. Suele pasar cuando el
+      // modelo no puede resolver un argumento (ej: "ayer" sin saber la
+      // fecha). Damos un mensaje accionable en vez del fallback genérico.
+      const isMalformed = lastFinishReason === "MALFORMED_FUNCTION_CALL";
+      const fallback = isMalformed
+        ? "No logré armar la consulta correctamente. ¿Podés ser más específico con el período (ej: 'ventas del 15 al 22 de abril') o el dato que querés ver?"
         : "No pude generar una respuesta. Probá reformular.";
+      let text = textParts.trim().length > 0 ? textParts : fallback;
 
       // Si Gemini cortó por límite de tokens, avisamos al usuario para que
       // sepa que la respuesta puede estar incompleta y pueda pedir más detalle.
@@ -364,6 +370,7 @@ export async function runAgent(opts: RunAgentOptions): Promise<RunAgentResult> {
           iterations: iter + 1,
           toolCallsCount,
           finishReason: lastFinishReason,
+          malformed: isMalformed || undefined,
         },
       }).catch(() => {});
 

--- a/supabase/functions/_shared/gemini/prompts/admin.ts
+++ b/supabase/functions/_shared/gemini/prompts/admin.ts
@@ -11,15 +11,21 @@ Tu trabajo es ayudar al admin a:
 - Buscar clientes y productos por nombre o código.
 - Consultar fichas: ficha_cliente (saldo, crédito, últimos movimientos), ficha_producto (precio, stock, ventas 30d).
 - Reportes de ventas y compras en períodos:
-  · ventas_periodo(desde, hasta) → total facturado, top productos, top clientes, ticket promedio.
+  · ventas_periodo(desde, hasta) → total facturado, top productos, top clientes, ticket promedio (sucursal entera).
+  · ventas_por_preventista(desde, hasta, [solo_preventistas]) → ranking de ventas por usuario (preventista). Ideal para "quién vendió más", "ventas por preventista", "ventas de ayer por vendedor".
   · compras_periodo(desde, hasta) → total comprado a proveedores, top proveedores.
 - Cobranzas:
   · pendientes_pago([dias_atraso]) → clientes con pedidos no pagados, ordenados por antigüedad.
   · historico_pagos_cliente(cliente_id) → últimos pagos de un cliente con forma_pago + monto + fecha.
 - Sugerir acciones cuando los datos lo justifiquen (ej: "este cliente está cerca del límite de crédito, ¿querés ver su histórico?").
 
-EJEMPLOS DE INTENT → TOOL:
-- "¿cuánto vendí este mes?" → ventas_periodo con desde=primer día del mes, hasta=hoy.
+EJEMPLOS DE INTENT → TOOL (recordá: las fechas exactas vienen del bloque CONTEXTO DE FECHA arriba — usá esas para resolver "ayer", "hoy", "esta semana", etc.):
+- "cuánto vendimos ayer" → ventas_periodo(desde=ayer, hasta=ayer).
+- "ventas de ayer por preventista" → ventas_por_preventista(desde=ayer, hasta=ayer).
+- "quién vendió más esta semana" → ventas_por_preventista(desde=lunes_de_esta_semana, hasta=hoy).
+- "ventas del mes por vendedor" → ventas_por_preventista(desde=primer_dia_del_mes, hasta=hoy).
+- "ventas del 15 al 22 de abril" → ventas_periodo(desde="2026-04-15", hasta="2026-04-22") (las fechas explícitas las pasás literalmente).
+- "cuánto vendí este mes" → ventas_periodo(desde=primer_dia_del_mes, hasta=hoy).
 - "qué producto vendo más" → ventas_periodo y mirá top_productos.
 - "quiénes me deben más" → pendientes_pago (sin filtros) y mostrá top por monto/atraso.
 - "deuda de más de 30 días" → pendientes_pago(dias_atraso=30).

--- a/supabase/functions/_shared/gemini/prompts/base.ts
+++ b/supabase/functions/_shared/gemini/prompts/base.ts
@@ -10,6 +10,12 @@
 // API pública (`getSystemPrompt`, `setSystemPromptForTests`,
 // `clearSystemPromptCache`) se mantiene compatible con los call sites previos
 // para no romper tests ni callers.
+//
+// Nota — bloque de fecha: anteponemos a cada prompt default un encabezado
+// dinámico con la fecha actual en TZ AR. Sin esto Gemini no tiene cómo
+// resolver "ayer" / "esta semana" a un YYYY-MM-DD concreto y termina
+// emitiendo function calls malformados (finishReason=MALFORMED_FUNCTION_CALL).
+// Solo se prepende a los DEFAULTS — los overrides de tests quedan exactos.
 
 import type { BotRol } from "../../types.ts";
 import adminPrompt from "./admin.ts";
@@ -26,19 +32,129 @@ const DEFAULTS: Record<BotRol, string> = {
   deposito: depositoPrompt,
 };
 
+const TZ = "America/Argentina/Buenos_Aires";
+
 // Overrides aplicables solo desde tests via setSystemPromptForTests.
 const OVERRIDES = new Map<BotRol, string>();
+// Override de "now" para tests deterministas (evita flakes por reloj).
+let NOW_OVERRIDE: Date | null = null;
 
 /**
  * Carga el system prompt para el rol del usuario. Async por compat con la
  * implementación previa basada en FS — el contenido viene de un módulo
  * importado estáticamente, no se va al disco.
+ *
+ * Para los DEFAULTS antepone un bloque con la fecha actual en TZ AR.
+ * Los OVERRIDES de tests se devuelven tal cual (sin prefijo) para no
+ * romper assertions exactas.
  */
 // deno-lint-ignore require-await
 export async function getSystemPrompt(rol: BotRol): Promise<string> {
   const override = OVERRIDES.get(rol);
   if (override !== undefined) return override;
-  return DEFAULTS[rol];
+  return buildDateContext() + "\n\n" + DEFAULTS[rol];
+}
+
+// ----------------------------------------------------------------------------
+// Date context — calculado en TZ AR independientemente del reloj del runtime.
+// ----------------------------------------------------------------------------
+
+/**
+ * Convierte un Date a {y, m, d, dow} en TZ AR. Usamos `Intl.DateTimeFormat`
+ * con `formatToParts` porque Deno/V8 no expone una API directa para
+ * "fecha calendario en otra timezone".
+ */
+function partsInTZ(date: Date): {
+  y: number;
+  m: number;
+  d: number;
+  dowEs: string;
+} {
+  const fmt = new Intl.DateTimeFormat("en-CA", {
+    timeZone: TZ,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    weekday: "long",
+  });
+  const parts = fmt.formatToParts(date);
+  const get = (t: string) => parts.find((p) => p.type === t)?.value ?? "";
+  const y = parseInt(get("year"), 10);
+  const m = parseInt(get("month"), 10);
+  const d = parseInt(get("day"), 10);
+  const dowEn = get("weekday").toLowerCase();
+  const dowMap: Record<string, string> = {
+    monday: "lunes",
+    tuesday: "martes",
+    wednesday: "miércoles",
+    thursday: "jueves",
+    friday: "viernes",
+    saturday: "sábado",
+    sunday: "domingo",
+  };
+  return { y, m, d, dowEs: dowMap[dowEn] ?? dowEn };
+}
+
+function pad2(n: number): string {
+  return n < 10 ? `0${n}` : String(n);
+}
+
+function isoFromYMD(y: number, m: number, d: number): string {
+  return `${y}-${pad2(m)}-${pad2(d)}`;
+}
+
+function addDaysAR(y: number, m: number, d: number, days: number): {
+  y: number;
+  m: number;
+  d: number;
+} {
+  // Anclamos al mediodía UTC para evitar saltos por DST cuando AR la tenía
+  // (hoy AR no aplica DST, pero defendamos el helper). Mediodía UTC en
+  // cualquier offset razonable cae en el mismo día calendario.
+  const anchor = new Date(Date.UTC(y, m - 1, d, 12, 0, 0));
+  anchor.setUTCDate(anchor.getUTCDate() + days);
+  return partsInTZ(anchor);
+}
+
+/** Construye el bloque de contexto de fecha. Visible para tests. */
+export function buildDateContext(now: Date = NOW_OVERRIDE ?? new Date()): string {
+  const today = partsInTZ(now);
+  const yesterday = addDaysAR(today.y, today.m, today.d, -1);
+  // Lunes de esta semana. Intl day-of-week como número: usamos el nombre
+  // y mapeamos.
+  const dowIndex: Record<string, number> = {
+    lunes: 0,
+    martes: 1,
+    miércoles: 2,
+    jueves: 3,
+    viernes: 4,
+    sábado: 5,
+    domingo: 6,
+  };
+  const offsetToMonday = -(dowIndex[today.dowEs] ?? 0);
+  const monday = addDaysAR(today.y, today.m, today.d, offsetToMonday);
+
+  const todayISO = isoFromYMD(today.y, today.m, today.d);
+  const yesterdayISO = isoFromYMD(yesterday.y, yesterday.m, yesterday.d);
+  const mondayISO = isoFromYMD(monday.y, monday.m, monday.d);
+  const firstOfMonthISO = isoFromYMD(today.y, today.m, 1);
+  // Hace 7 / 30 días (ventanas comunes).
+  const minus7 = addDaysAR(today.y, today.m, today.d, -7);
+  const minus30 = addDaysAR(today.y, today.m, today.d, -30);
+  const minus7ISO = isoFromYMD(minus7.y, minus7.m, minus7.d);
+  const minus30ISO = isoFromYMD(minus30.y, minus30.m, minus30.d);
+
+  return [
+    `CONTEXTO DE FECHA (zona horaria America/Argentina/Buenos_Aires):`,
+    `- Hoy es ${today.dowEs}, ${todayISO}.`,
+    `- Ayer fue ${yesterdayISO}.`,
+    `- Esta semana: ${mondayISO} a ${todayISO} (lunes a hoy).`,
+    `- Este mes: ${firstOfMonthISO} a ${todayISO}.`,
+    `- Últimos 7 días: ${minus7ISO} a ${todayISO}.`,
+    `- Últimos 30 días: ${minus30ISO} a ${todayISO}.`,
+    ``,
+    `Cuando el usuario use referencias relativas ("ayer", "hoy", "esta semana", "el mes pasado", "últimos N días"), traducí SIEMPRE a fechas ISO YYYY-MM-DD ANTES de armar la tool call. NUNCA pases strings como "ayer" o "esta semana" como argumento — las tools requieren YYYY-MM-DD literal.`,
+  ].join("\n");
 }
 
 // ----------------------------------------------------------------------------
@@ -57,4 +173,10 @@ export function setSystemPromptForTests(rol: BotRol, text: string): void {
  */
 export function clearSystemPromptCache(): void {
   OVERRIDES.clear();
+  NOW_OVERRIDE = null;
+}
+
+/** Override de la fecha "actual" para tests deterministas. */
+export function setNowForTests(now: Date | null): void {
+  NOW_OVERRIDE = now;
 }

--- a/supabase/functions/_shared/gemini/prompts/encargado.ts
+++ b/supabase/functions/_shared/gemini/prompts/encargado.ts
@@ -9,15 +9,19 @@ Tu trabajo es ayudar al encargado a:
 - Buscar clientes y productos de su sucursal (por nombre o código).
 - Consultar fichas: ficha_cliente (saldo, crédito, últimos movimientos), ficha_producto (precio, stock, ventas 30d).
 - Reportes de ventas y compras de la sucursal:
-  · ventas_periodo(desde, hasta) → total facturado, top productos, top clientes.
+  · ventas_periodo(desde, hasta) → total facturado, top productos, top clientes (sucursal entera).
+  · ventas_por_preventista(desde, hasta, [solo_preventistas]) → ranking de ventas por usuario (preventista).
   · compras_periodo(desde, hasta) → total comprado, top proveedores.
 - Cobranzas:
   · pendientes_pago([dias_atraso]) → clientes con pedidos no pagados.
   · historico_pagos_cliente(cliente_id) → últimos pagos del cliente.
 - Resolver consultas operativas rápidas que se pueden contestar mirando datos.
 
-EJEMPLOS DE INTENT → TOOL:
-- "ventas de la semana" → ventas_periodo con desde=lunes, hasta=hoy.
+EJEMPLOS DE INTENT → TOOL (las fechas exactas vienen del bloque CONTEXTO DE FECHA arriba — usalas para resolver "ayer", "hoy", "esta semana"):
+- "cuánto vendimos ayer" → ventas_periodo(desde=ayer, hasta=ayer).
+- "ventas de la semana" → ventas_periodo(desde=lunes_de_esta_semana, hasta=hoy).
+- "ventas por preventista de la semana" → ventas_por_preventista(desde=lunes, hasta=hoy).
+- "quién vendió más ayer" → ventas_por_preventista(desde=ayer, hasta=ayer).
 - "deuda total de la sucursal" → pendientes_pago.
 - "qué le compré al proveedor X" → compras_periodo y mirá top_proveedores.
 - "cómo me paga Pepe" → buscar_cliente → historico_pagos_cliente.

--- a/supabase/functions/_shared/gemini/prompts/preventista.ts
+++ b/supabase/functions/_shared/gemini/prompts/preventista.ts
@@ -13,11 +13,17 @@ Tu trabajo es ayudar al preventista a:
 - Drill-down de un cliente:
   · historico_pedidos_cliente(cliente_id, [dias=90]) → últimos pedidos con items.
   · productos_recurrentes_cliente(cliente_id, [dias=90]) → top productos que ese cliente compra más seguido. Útil para ofrecer "lo de siempre".
+- Ver SUS PROPIAS ventas en un período:
+  · mis_ventas(desde, hasta) → total facturado por el preventista, cantidad de pedidos, ticket promedio, top clientes del período.
 
-EJEMPLOS DE INTENT → TOOL:
+EJEMPLOS DE INTENT → TOOL (para fechas relativas usá el bloque CONTEXTO DE FECHA arriba):
 - "qué le vendí a Pepe los últimos 3 meses" → buscar_cliente para conseguir id, después historico_pedidos_cliente con dias=90.
 - "qué productos compra siempre Pepe" → buscar_cliente → productos_recurrentes_cliente.
 - "lo de siempre de almacén gabriel" → buscar_cliente → productos_recurrentes_cliente con dias=60-90.
+- "cuánto vendí ayer" → mis_ventas(desde=ayer, hasta=ayer).
+- "cuánto vendí esta semana" → mis_ventas(desde=lunes_de_esta_semana, hasta=hoy).
+- "cuánto vendí este mes" → mis_ventas(desde=primer_dia_del_mes, hasta=hoy).
+- "mis mejores clientes este mes" → mis_ventas (mirá top_clientes en el resultado).
 
 REGLAS:
 1. NUNCA inventes datos. Si no tenés un dato, llamá a la tool. Si la tool devuelve "no encontrado o sin permiso", decí literalmente que el cliente no figura entre los suyos y sugerí contactar al encargado.

--- a/supabase/functions/_shared/tools/admin/ventas_por_preventista.ts
+++ b/supabase/functions/_shared/tools/admin/ventas_por_preventista.ts
@@ -1,0 +1,153 @@
+// Tool: ventas_por_preventista
+//
+// Devuelve el ranking de ventas agrupadas por usuario_id (preventista) en un
+// rango de fechas. Permite responder "ventas de ayer por preventista", "quién
+// vendió más esta semana", "ventas del mes por vendedor", etc.
+//
+// Delega 100% a la RPC bot_ventas_por_preventista (migration 025). Mismas
+// convenciones que ventas_periodo: filtro por created_at, excluye estados
+// 'cancelado' / 'anulado', filtra por sucursal del bot user.
+
+import type { Tool } from "../base.ts";
+
+export interface VentasPorPreventistaParams {
+  /** Fecha inicio inclusive (YYYY-MM-DD). */
+  desde: string;
+  /** Fecha fin inclusive (YYYY-MM-DD). */
+  hasta: string;
+  /**
+   * Si true (default), solo cuenta pedidos cuyo usuario_id corresponda a un
+   * perfil con rol='preventista'. Excluye ventas registradas a nombre de un
+   * admin/encargado del mostrador. Pasá false para ver TODOS los usuarios.
+   */
+  solo_preventistas?: boolean;
+  /** Top N para el ranking. Default 10, max 25. */
+  limit?: number;
+}
+
+export interface VentasPorPreventistaResult {
+  desde: string;
+  hasta: string;
+  solo_preventistas: boolean;
+  total_ventas: number;
+  pedidos_count: number;
+  preventistas_count: number;
+  preventistas: Array<{
+    usuario_id: string | null;
+    nombre: string;
+    rol: string | null;
+    pedidos: number;
+    total_vendido: number;
+    ticket_promedio: number;
+  }>;
+}
+
+const FECHA_REGEX = /^\d{4}-\d{2}-\d{2}$/;
+
+export const ventasPorPreventistaTool: Tool<
+  VentasPorPreventistaParams,
+  VentasPorPreventistaResult
+> = {
+  name: "ventas_por_preventista",
+  description:
+    "Ranking de ventas agrupadas por preventista (usuario_id) en un rango de " +
+    "fechas (admin/encargado). Devuelve total vendido, cantidad de pedidos y " +
+    "ticket promedio por cada preventista. Útil para 'ventas de ayer por " +
+    "preventista', 'quién vendió más esta semana', etc. Las fechas son " +
+    "inclusive en formato YYYY-MM-DD. Filtra por sucursal del bot user. " +
+    "Excluye pedidos cancelados/anulados.",
+  parameters: {
+    type: "object",
+    properties: {
+      desde: {
+        type: "string",
+        description: "Fecha de inicio inclusive (YYYY-MM-DD).",
+      },
+      hasta: {
+        type: "string",
+        description: "Fecha de fin inclusive (YYYY-MM-DD).",
+      },
+      solo_preventistas: {
+        type: "boolean",
+        description:
+          "Si true (default), solo cuenta usuarios con rol='preventista'. " +
+          "Pasá false para incluir admins/encargados que hayan registrado pedidos.",
+      },
+      limit: {
+        type: "integer",
+        minimum: 1,
+        maximum: 25,
+        description: "Top N para el ranking (default 10, max 25).",
+      },
+    },
+    required: ["desde", "hasta"],
+  },
+  allowedRoles: ["admin", "encargado"],
+  handler: async (
+    { desde, hasta, solo_preventistas = true, limit = 10 },
+    ctx,
+  ) => {
+    if (!FECHA_REGEX.test(desde) || !FECHA_REGEX.test(hasta)) {
+      throw new Error("Fechas inválidas (esperado YYYY-MM-DD)");
+    }
+    if (desde > hasta) {
+      throw new Error("Fecha 'desde' debe ser <= 'hasta'");
+    }
+    if (!Number.isFinite(limit) || limit < 1 || limit > 25) {
+      throw new Error("Límite fuera de rango (1-25)");
+    }
+    if (ctx.sucursal_id == null) {
+      throw new Error("Sucursal no asignada — contactá al administrador");
+    }
+
+    const { data, error } = await ctx.supabase.rpc(
+      "bot_ventas_por_preventista",
+      {
+        p_desde: desde,
+        p_hasta: hasta,
+        p_sucursal_id: ctx.sucursal_id,
+        p_solo_preventistas: solo_preventistas,
+        p_limit: limit,
+      },
+    );
+
+    if (error) {
+      throw new Error(`ventas_por_preventista: ${error.message}`);
+    }
+
+    type RpcRow = {
+      usuario_id: string | null;
+      nombre: string | null;
+      rol: string | null;
+      pedidos: number;
+      total_vendido: number | string;
+      ticket_promedio: number | string;
+    };
+    const r = data as {
+      desde: string;
+      hasta: string;
+      solo_preventistas: boolean;
+      total_ventas: number | string;
+      pedidos_count: number;
+      preventistas_count: number;
+      preventistas: RpcRow[];
+    };
+
+    return {
+      desde: r.desde,
+      hasta: r.hasta,
+      solo_preventistas: Boolean(r.solo_preventistas),
+      total_ventas: Number(r.total_ventas ?? 0),
+      pedidos_count: Number(r.pedidos_count ?? 0),
+      preventistas_count: Number(r.preventistas_count ?? 0),
+      preventistas: (r.preventistas ?? []).map((p) => ({
+        usuario_id: p.usuario_id ?? null,
+        nombre: p.nombre?.trim() || "(sin asignar)",
+        rol: p.rol ?? null,
+        pedidos: Number(p.pedidos ?? 0),
+        total_vendido: Number(p.total_vendido ?? 0),
+        ticket_promedio: Number(p.ticket_promedio ?? 0),
+      })),
+    };
+  },
+};

--- a/supabase/functions/_shared/tools/index.ts
+++ b/supabase/functions/_shared/tools/index.ts
@@ -20,9 +20,11 @@ import { productosRecurrentesTool } from "./preventista/productos_recurrentes.ts
 import { miRecorridoHoyTool } from "./transportista/mi_recorrido_hoy.ts";
 import { recorridoResumenTool } from "./transportista/recorrido_resumen.ts";
 import { ventasPeriodoTool } from "./admin/ventas_periodo.ts";
+import { ventasPorPreventistaTool } from "./admin/ventas_por_preventista.ts";
 import { pendientesPagoTool } from "./admin/pendientes_pago.ts";
 import { historicoPagosClienteTool } from "./admin/historico_pagos_cliente.ts";
 import { comprasPeriodoTool } from "./admin/compras_periodo.ts";
+import { misVentasTool } from "./preventista/mis_ventas.ts";
 
 let _registered = false;
 
@@ -41,9 +43,11 @@ export function registerAllTools(): void {
   registerTool(miRecorridoHoyTool);
   registerTool(recorridoResumenTool);
   registerTool(ventasPeriodoTool);
+  registerTool(ventasPorPreventistaTool);
   registerTool(pendientesPagoTool);
   registerTool(historicoPagosClienteTool);
   registerTool(comprasPeriodoTool);
+  registerTool(misVentasTool);
   _registered = true;
 }
 

--- a/supabase/functions/_shared/tools/preventista/mis_ventas.ts
+++ b/supabase/functions/_shared/tools/preventista/mis_ventas.ts
@@ -1,0 +1,138 @@
+// Tool: mis_ventas
+//
+// Resumen de ventas del propio preventista en un rango de fechas: total
+// facturado, cantidad de pedidos, ticket promedio, clientes distintos y top
+// N clientes del período. Pensada para que el preventista pregunte "cuánto
+// vendí ayer / esta semana / este mes" desde Telegram.
+//
+// El RPC bot_mis_ventas filtra hard-coded por usuario_id = perfil_id del
+// caller, así que NO hay forma de ver ventas de otro preventista. Defense-
+// in-depth: este handler solo acepta rol='preventista'.
+
+import type { Tool } from "../base.ts";
+
+export interface MisVentasParams {
+  /** Fecha inicio inclusive (YYYY-MM-DD). */
+  desde: string;
+  /** Fecha fin inclusive (YYYY-MM-DD). */
+  hasta: string;
+  /** Top N clientes del período. Default 10, max 25. */
+  limit?: number;
+}
+
+export interface MisVentasResult {
+  desde: string;
+  hasta: string;
+  total_ventas: number;
+  pedidos_count: number;
+  ticket_promedio: number;
+  clientes_distintos: number;
+  top_clientes: Array<{
+    cliente_id: number;
+    cliente_codigo: number | null;
+    nombre: string;
+    total_comprado: number;
+    pedidos: number;
+  }>;
+}
+
+const FECHA_REGEX = /^\d{4}-\d{2}-\d{2}$/;
+
+export const misVentasTool: Tool<MisVentasParams, MisVentasResult> = {
+  name: "mis_ventas",
+  description:
+    "Resumen de las ventas del preventista actual en un rango de fechas. " +
+    "Devuelve total facturado, cantidad de pedidos, ticket promedio, " +
+    "clientes distintos y top clientes del período. Las fechas son " +
+    "inclusive en formato YYYY-MM-DD. Solo ve sus propias ventas (las que " +
+    "tiene como usuario_id en pedidos). Excluye pedidos cancelados/anulados.",
+  parameters: {
+    type: "object",
+    properties: {
+      desde: {
+        type: "string",
+        description: "Fecha de inicio inclusive (YYYY-MM-DD).",
+      },
+      hasta: {
+        type: "string",
+        description: "Fecha de fin inclusive (YYYY-MM-DD).",
+      },
+      limit: {
+        type: "integer",
+        minimum: 1,
+        maximum: 25,
+        description: "Top N clientes del período (default 10, max 25).",
+      },
+    },
+    required: ["desde", "hasta"],
+  },
+  allowedRoles: ["preventista"],
+  handler: async ({ desde, hasta, limit = 10 }, ctx) => {
+    // Defense-in-depth: allowedRoles ya garantiza esto en invokeTool, pero
+    // si alguien llama el handler directo lo bloqueamos acá.
+    if (ctx.rol !== "preventista") {
+      throw new Error("mis_ventas solo está disponible para preventistas");
+    }
+    if (!FECHA_REGEX.test(desde) || !FECHA_REGEX.test(hasta)) {
+      throw new Error("Fechas inválidas (esperado YYYY-MM-DD)");
+    }
+    if (desde > hasta) {
+      throw new Error("Fecha 'desde' debe ser <= 'hasta'");
+    }
+    if (!Number.isFinite(limit) || limit < 1 || limit > 25) {
+      throw new Error("Límite fuera de rango (1-25)");
+    }
+    if (ctx.sucursal_id == null) {
+      throw new Error(
+        "Sucursal no asignada en bot_usuarios — contactá al administrador",
+      );
+    }
+
+    const { data, error } = await ctx.supabase.rpc("bot_mis_ventas", {
+      p_preventista_id: ctx.perfil_id,
+      p_desde: desde,
+      p_hasta: hasta,
+      p_sucursal_id: ctx.sucursal_id,
+      p_limit: limit,
+    });
+
+    if (error) {
+      throw new Error(`mis_ventas: ${error.message}`);
+    }
+
+    type RpcCliente = {
+      cliente_id: number;
+      cliente_codigo: number | null;
+      nombre_fantasia: string | null;
+      razon_social: string | null;
+      total_comprado: number | string;
+      pedidos: number;
+    };
+    const r = data as {
+      desde: string;
+      hasta: string;
+      total_ventas: number | string;
+      pedidos_count: number;
+      ticket_promedio: number | string;
+      clientes_distintos: number;
+      top_clientes: RpcCliente[];
+    };
+
+    return {
+      desde: r.desde,
+      hasta: r.hasta,
+      total_ventas: Number(r.total_ventas ?? 0),
+      pedidos_count: Number(r.pedidos_count ?? 0),
+      ticket_promedio: Number(r.ticket_promedio ?? 0),
+      clientes_distintos: Number(r.clientes_distintos ?? 0),
+      top_clientes: (r.top_clientes ?? []).map((c) => ({
+        cliente_id: Number(c.cliente_id),
+        cliente_codigo: c.cliente_codigo ?? null,
+        nombre: c.nombre_fantasia?.trim() || c.razon_social?.trim() ||
+          "(sin nombre)",
+        total_comprado: Number(c.total_comprado ?? 0),
+        pedidos: Number(c.pedidos ?? 0),
+      })),
+    };
+  },
+};

--- a/supabase/functions/tests/agent.test.ts
+++ b/supabase/functions/tests/agent.test.ts
@@ -843,3 +843,55 @@ Deno.test("runAgent: tool no reconocida (ej ficha_cliente) NO popula interactabl
     teardownAgentEnv();
   }
 });
+
+// ============================================================================
+// 9. MALFORMED_FUNCTION_CALL → mensaje accionable (no fallback genérico)
+// ============================================================================
+
+Deno.test("runAgent MALFORMED_FUNCTION_CALL devuelve un mensaje accionable", async () => {
+  setupAgentEnv();
+  const { client, spy } = createMockSupabase({ conversacionData: null });
+  // deno-lint-ignore no-explicit-any
+  _setServiceRoleClientForTests(client as any);
+
+  // Gemini emite parts vacías + finishReason MALFORMED_FUNCTION_CALL
+  // (este es el shape real cuando rechaza un function call mal formado).
+  const fetchStub = installGeminiFetchStub([
+    {
+      candidates: [
+        {
+          content: { role: "model", parts: [] },
+          finishReason: "MALFORMED_FUNCTION_CALL",
+        },
+      ],
+      usageMetadata: { totalTokenCount: 3880 },
+    },
+  ]);
+
+  try {
+    const result = await runAgent({
+      supabase: client,
+      user: makeUser("admin"),
+      telegram_user_id: 42,
+      userMessage: "Decime cuánto vendimos ayer",
+    });
+
+    assertEquals(result.finishReason, "MALFORMED_FUNCTION_CALL");
+    assertEquals(result.toolCallsCount, 0);
+    assertEquals(result.hitMaxIterations, false);
+    assertStringIncludes(result.text, "No logré armar la consulta");
+    assertStringIncludes(result.text, "ej:");
+
+    // Audit con malformed=true.
+    const auditResp = spy.inserts.find((i) =>
+      i.table === "bot_audit_log" && i.row.tipo === "respuesta"
+    );
+    assert(auditResp, "debió haber audit tipo='respuesta'");
+    const meta = auditResp!.row.resultado_meta as Record<string, unknown>;
+    assertEquals(meta.malformed, true);
+    assertEquals(meta.finishReason, "MALFORMED_FUNCTION_CALL");
+  } finally {
+    fetchStub.restore();
+    teardownAgentEnv();
+  }
+});

--- a/supabase/functions/tests/gemini.test.ts
+++ b/supabase/functions/tests/gemini.test.ts
@@ -301,3 +301,59 @@ Deno.test("setSystemPromptForTests permite override sin tocar el FS", async () =
   assertEquals(got, "PROMPT_DE_TEST_FAKE");
   clearSystemPromptCache();
 });
+
+// ============================================================================
+// 8. Bloque CONTEXTO DE FECHA: anteponer fechas reales al prompt default
+// ============================================================================
+
+Deno.test("getSystemPrompt antepone bloque CONTEXTO DE FECHA al prompt default", async () => {
+  clearSystemPromptCache();
+  const prompt = await getSystemPrompt("admin");
+  assertStringIncludes(prompt, "CONTEXTO DE FECHA");
+  assertStringIncludes(prompt, "America/Argentina/Buenos_Aires");
+  assertStringIncludes(prompt, "Hoy es ");
+  assertStringIncludes(prompt, "Ayer fue ");
+  assertStringIncludes(prompt, "Esta semana:");
+  assertStringIncludes(prompt, "Este mes:");
+  // Y aún incluye el contenido del prompt admin original.
+  assertStringIncludes(prompt.toLowerCase(), "admin");
+  assertStringIncludes(prompt, "ventas_por_preventista");
+});
+
+Deno.test("buildDateContext usa la fecha override y formato YYYY-MM-DD", async () => {
+  // Importamos buildDateContext y setNowForTests vía el módulo.
+  const mod = await import("../_shared/gemini/prompts/base.ts");
+  // 2026-04-29 es miércoles en TZ AR.
+  const fakeNow = new Date("2026-04-29T15:37:33Z");
+  mod.setNowForTests(fakeNow);
+  try {
+    const ctx = mod.buildDateContext();
+    assertStringIncludes(ctx, "Hoy es miércoles, 2026-04-29");
+    assertStringIncludes(ctx, "Ayer fue 2026-04-28");
+    // Lunes de la semana de 2026-04-29 (mié) = 2026-04-27.
+    assertStringIncludes(ctx, "Esta semana: 2026-04-27 a 2026-04-29");
+    // Primer día del mes.
+    assertStringIncludes(ctx, "Este mes: 2026-04-01 a 2026-04-29");
+    // Últimos 7 días = 2026-04-22; últimos 30 = 2026-03-30.
+    assertStringIncludes(ctx, "Últimos 7 días: 2026-04-22 a 2026-04-29");
+    assertStringIncludes(ctx, "Últimos 30 días: 2026-03-30 a 2026-04-29");
+  } finally {
+    mod.setNowForTests(null);
+  }
+});
+
+Deno.test("buildDateContext maneja inicio de mes (1ro de mes)", async () => {
+  const mod = await import("../_shared/gemini/prompts/base.ts");
+  // 2026-05-01 es viernes. "Ayer" cruza mes → 2026-04-30. Lunes de la semana
+  // del 1ro/05 = 2026-04-27.
+  mod.setNowForTests(new Date("2026-05-01T03:00:00Z"));
+  try {
+    const ctx = mod.buildDateContext();
+    assertStringIncludes(ctx, "Hoy es viernes, 2026-05-01");
+    assertStringIncludes(ctx, "Ayer fue 2026-04-30");
+    assertStringIncludes(ctx, "Esta semana: 2026-04-27 a 2026-05-01");
+    assertStringIncludes(ctx, "Este mes: 2026-05-01 a 2026-05-01");
+  } finally {
+    mod.setNowForTests(null);
+  }
+});

--- a/supabase/functions/tests/tools.test.ts
+++ b/supabase/functions/tests/tools.test.ts
@@ -33,6 +33,8 @@ import { fichaProductoTool } from "../_shared/tools/common/ficha_producto.ts";
 import { listarCategoriasTool } from "../_shared/tools/common/listar_categorias.ts";
 import { productosPorCategoriaTool } from "../_shared/tools/common/productos_por_categoria.ts";
 import { ventasPeriodoTool } from "../_shared/tools/admin/ventas_periodo.ts";
+import { ventasPorPreventistaTool } from "../_shared/tools/admin/ventas_por_preventista.ts";
+import { misVentasTool } from "../_shared/tools/preventista/mis_ventas.ts";
 import { pendientesPagoTool } from "../_shared/tools/admin/pendientes_pago.ts";
 import { historicoPagosClienteTool } from "../_shared/tools/admin/historico_pagos_cliente.ts";
 import { comprasPeriodoTool } from "../_shared/tools/admin/compras_periodo.ts";
@@ -545,9 +547,11 @@ Deno.test("registerAllTools registra todas las tools esperadas", () => {
   assert(getTool("listar_categorias"), "listar_categorias no registrada");
   assert(getTool("productos_por_categoria"), "productos_por_categoria no registrada");
   assert(getTool("ventas_periodo"), "ventas_periodo no registrada");
+  assert(getTool("ventas_por_preventista"), "ventas_por_preventista no registrada");
   assert(getTool("pendientes_pago"), "pendientes_pago no registrada");
   assert(getTool("historico_pagos_cliente"), "historico_pagos_cliente no registrada");
   assert(getTool("compras_periodo"), "compras_periodo no registrada");
+  assert(getTool("mis_ventas"), "mis_ventas no registrada");
   assert(getTool("historico_pedidos_cliente"), "historico_pedidos_cliente no registrada");
   assert(getTool("productos_recurrentes_cliente"), "productos_recurrentes_cliente no registrada");
   assert(getTool("recorrido_resumen"), "recorrido_resumen no registrada");
@@ -563,9 +567,11 @@ Deno.test("registerAllTools registra todas las tools esperadas", () => {
   assertEquals(getTool("listar_categorias"), listarCategoriasTool);
   assertEquals(getTool("productos_por_categoria"), productosPorCategoriaTool);
   assertEquals(getTool("ventas_periodo"), ventasPeriodoTool);
+  assertEquals(getTool("ventas_por_preventista"), ventasPorPreventistaTool);
   assertEquals(getTool("pendientes_pago"), pendientesPagoTool);
   assertEquals(getTool("historico_pagos_cliente"), historicoPagosClienteTool);
   assertEquals(getTool("compras_periodo"), comprasPeriodoTool);
+  assertEquals(getTool("mis_ventas"), misVentasTool);
   assertEquals(getTool("historico_pedidos_cliente"), historicoClienteTool);
   assertEquals(getTool("productos_recurrentes_cliente"), productosRecurrentesTool);
   assertEquals(getTool("recorrido_resumen"), recorridoResumenTool);
@@ -1948,4 +1954,202 @@ Deno.test("recorrido_resumen sin recorrido devuelto lanza mensaje claro", async 
     );
   }
   assert(threw, "debió lanzar 'No tenés recorrido'");
+});
+
+// ============================================================================
+// 50. ventas_por_preventista: invoca el RPC y mapea el ranking
+// ============================================================================
+
+Deno.test("ventas_por_preventista invoca el RPC y mapea preventistas", async () => {
+  const { client, spy } = createMockSupabase({
+    rpcResponse: {
+      data: {
+        desde: "2026-04-28",
+        hasta: "2026-04-28",
+        solo_preventistas: true,
+        total_ventas: "1266750",
+        pedidos_count: 47,
+        preventistas_count: 4,
+        preventistas: [
+          {
+            usuario_id: "aaa", nombre: "Christian", rol: "preventista",
+            pedidos: 18, total_vendido: "420020", ticket_promedio: "23334.44",
+          },
+          {
+            usuario_id: "bbb", nombre: "Joaquin", rol: "preventista",
+            pedidos: 12, total_vendido: 355870, ticket_promedio: 29655.83,
+          },
+        ],
+      },
+      error: null,
+    },
+  });
+  const ctx = makeCtx(client, { rol: "admin", sucursal_id: 1 });
+  const result = await ventasPorPreventistaTool.handler(
+    { desde: "2026-04-28", hasta: "2026-04-28", limit: 10 },
+    ctx,
+  );
+
+  assertEquals(result.total_ventas, 1266750);
+  assertEquals(result.pedidos_count, 47);
+  assertEquals(result.preventistas_count, 4);
+  assertEquals(result.preventistas.length, 2);
+  assertEquals(result.preventistas[0].nombre, "Christian");
+  assertEquals(result.preventistas[0].total_vendido, 420020);
+  assertEquals(result.preventistas[1].nombre, "Joaquin");
+  assertEquals(result.preventistas[1].ticket_promedio, 29655.83);
+
+  // RPC params correctos.
+  assertEquals(spy.rpcCalls.length, 1);
+  const call = spy.rpcCalls[0];
+  assertEquals(call.fn, "bot_ventas_por_preventista");
+  assertEquals(call.params.p_desde, "2026-04-28");
+  assertEquals(call.params.p_hasta, "2026-04-28");
+  assertEquals(call.params.p_sucursal_id, 1);
+  assertEquals(call.params.p_solo_preventistas, true);
+  assertEquals(call.params.p_limit, 10);
+});
+
+Deno.test("ventas_por_preventista respeta solo_preventistas=false", async () => {
+  const { client, spy } = createMockSupabase({
+    rpcResponse: {
+      data: {
+        desde: "2026-04-28", hasta: "2026-04-28", solo_preventistas: false,
+        total_ventas: 0, pedidos_count: 0, preventistas_count: 0,
+        preventistas: [],
+      },
+      error: null,
+    },
+  });
+  const ctx = makeCtx(client, { rol: "admin", sucursal_id: 1 });
+  await ventasPorPreventistaTool.handler(
+    { desde: "2026-04-28", hasta: "2026-04-28", solo_preventistas: false },
+    ctx,
+  );
+  assertEquals(spy.rpcCalls[0].params.p_solo_preventistas, false);
+});
+
+Deno.test("ventas_por_preventista valida fechas y rango", async () => {
+  const { client } = createMockSupabase({});
+  const ctx = makeCtx(client, { rol: "admin", sucursal_id: 1 });
+  let threw = 0;
+  try {
+    await ventasPorPreventistaTool.handler(
+      { desde: "ayer", hasta: "2026-04-28" },
+      ctx,
+    );
+  } catch (err) {
+    threw++;
+    assertStringIncludes(err instanceof Error ? err.message : "", "Fechas inválidas");
+  }
+  try {
+    await ventasPorPreventistaTool.handler(
+      { desde: "2026-04-28", hasta: "2026-04-01" },
+      ctx,
+    );
+  } catch (err) {
+    threw++;
+    assertStringIncludes(err instanceof Error ? err.message : "", "desde");
+  }
+  assertEquals(threw, 2);
+});
+
+// ============================================================================
+// 51. mis_ventas: solo preventista, scopea al perfil_id propio
+// ============================================================================
+
+Deno.test("mis_ventas invoca el RPC con perfil_id del caller y mapea top_clientes", async () => {
+  const { client, spy } = createMockSupabase({
+    rpcResponse: {
+      data: {
+        desde: "2026-04-01",
+        hasta: "2026-04-29",
+        total_ventas: "1500000",
+        pedidos_count: 25,
+        ticket_promedio: "60000",
+        clientes_distintos: 14,
+        top_clientes: [
+          {
+            cliente_id: 100, cliente_codigo: 12,
+            nombre_fantasia: "Almacén Pepe", razon_social: "Pepe SA",
+            total_comprado: "350000", pedidos: 5,
+          },
+          {
+            cliente_id: 101, cliente_codigo: null,
+            nombre_fantasia: null, razon_social: "María SRL",
+            total_comprado: 200000, pedidos: 3,
+          },
+        ],
+      },
+      error: null,
+    },
+  });
+  const ctx = makeCtx(client, {
+    rol: "preventista",
+    sucursal_id: 1,
+    perfil_id: "PERFIL-CHRISTIAN",
+  });
+  const result = await misVentasTool.handler(
+    { desde: "2026-04-01", hasta: "2026-04-29" },
+    ctx,
+  );
+
+  assertEquals(result.total_ventas, 1500000);
+  assertEquals(result.pedidos_count, 25);
+  assertEquals(result.ticket_promedio, 60000);
+  assertEquals(result.clientes_distintos, 14);
+  assertEquals(result.top_clientes[0].nombre, "Almacén Pepe");
+  assertEquals(result.top_clientes[1].nombre, "María SRL");
+
+  assertEquals(spy.rpcCalls.length, 1);
+  const call = spy.rpcCalls[0];
+  assertEquals(call.fn, "bot_mis_ventas");
+  assertEquals(call.params.p_preventista_id, "PERFIL-CHRISTIAN");
+  assertEquals(call.params.p_desde, "2026-04-01");
+  assertEquals(call.params.p_hasta, "2026-04-29");
+  assertEquals(call.params.p_sucursal_id, 1);
+});
+
+Deno.test("mis_ventas rechaza si el rol no es preventista", async () => {
+  const { client } = createMockSupabase({});
+  const ctxAdmin = makeCtx(client, { rol: "admin", sucursal_id: 1 });
+  let threw = false;
+  try {
+    await misVentasTool.handler(
+      { desde: "2026-04-28", hasta: "2026-04-28" },
+      ctxAdmin,
+    );
+  } catch (err) {
+    threw = true;
+    assertStringIncludes(
+      err instanceof Error ? err.message : "",
+      "preventista",
+    );
+  }
+  assert(threw, "debió rechazar a admin (defense-in-depth)");
+});
+
+Deno.test("mis_ventas valida fechas y rango", async () => {
+  const { client } = createMockSupabase({});
+  const ctx = makeCtx(client, { rol: "preventista", sucursal_id: 1 });
+  let threw = 0;
+  try {
+    await misVentasTool.handler(
+      { desde: "01-01-2026", hasta: "2026-04-28" },
+      ctx,
+    );
+  } catch (err) {
+    threw++;
+    assertStringIncludes(err instanceof Error ? err.message : "", "Fechas inválidas");
+  }
+  try {
+    await misVentasTool.handler(
+      { desde: "2026-05-01", hasta: "2026-04-01" },
+      ctx,
+    );
+  } catch (err) {
+    threw++;
+    assertStringIncludes(err instanceof Error ? err.message : "", "desde");
+  }
+  assertEquals(threw, 2);
 });


### PR DESCRIPTION
## Contexto

El usuario mandó un audio "Decime cuánto vendimos ayer" al bot Telegram. La transcripción funcionó pero el agente respondió **"No pude generar una respuesta. Probá reformular."**

Audit log:
\`\`\`
2026-04-29 15:37:33  tipo=mensaje    "Decime cuánto vendimos ayer."
2026-04-29 15:37:36  tipo=respuesta  "No pude generar una respuesta..."
   resultado_meta = { gemini: true, iterations: 1, totalTokens: 3880,
                      finishReason: "MALFORMED_FUNCTION_CALL",
                      toolCallsCount: 0 }
\`\`\`

**Causa raíz:** Gemini 2.5 Flash intentó invocar \`ventas_periodo\` pero no podía construir \`desde\`/\`hasta\` en \`YYYY-MM-DD\` porque **el modelo no sabe qué día es hoy**. El JSON de la function call no validó contra el schema y la API cortó con \`MALFORMED_FUNCTION_CALL\`. El loop del agente caía al fallback genérico.

## Summary

- **Bug fix**: \`getSystemPrompt\` ahora antepone un bloque \`CONTEXTO DE FECHA\` (TZ AR) con hoy, ayer, lunes de esta semana, 1ro del mes, últimos 7 y 30 días — todo como ISO YYYY-MM-DD. Defense-in-depth: \`agent.ts\` reconoce \`finishReason=MALFORMED_FUNCTION_CALL\` y devuelve un mensaje accionable ("¿Podés ser más específico con el período…?") en vez del fallback genérico, y lo audita con \`malformed=true\`.
- **Nuevas tools** para acercarse al reemplazo de Power BI:
  - \`ventas_por_preventista(desde, hasta, [solo_preventistas], [limit])\` — admin/encargado. Ranking por usuario_id, con filtro opcional por \`perfiles.rol='preventista'\`.
  - \`mis_ventas(desde, hasta, [limit])\` — preventista. Scopeada hard a \`usuario_id = ctx.perfil_id\` en el RPC + defense-in-depth en el handler.
- **Migración 025** con los dos RPCs (\`SECURITY DEFINER\`, GRANT solo a \`service_role\`, mismo patrón de migration 022). Filtro por \`created_at\` para que los totales matcheen 1:1 contra \`bot_ventas_periodo\` (verificado contra prod: 35 pedidos / \$938.310 reconcilia exacto).
- Prompts admin/encargado/preventista actualizados con ejemplos concretos.
- 6 tests nuevos (147 pass / 0 fail). Incluye fecha override determinista para no flakear con el reloj.

## Roles & alcance (para reviewers)

- Todos los roles vinculados pueden usar el bot — **los preventistas también**, y **solo ven sus clientes asignados** (\`bot_mis_clientes\` filtra por \`p_preventista_id\`; \`bot_historico_pedidos_cliente\` rechaza con "Cliente no asignado a este preventista" si no figura en \`cliente_preventistas\`). Coincide 1:1 con lo que ven en la app.
- \`mis_ventas\` (NEW) sigue ese mismo patrón: el RPC filtra hard por \`usuario_id = caller\`, así que un preventista no puede pedir las ventas de otro.
- Filtrado por sucursal sigue intacto vía \`ToolContext.sucursal_id\` (snapshot en \`bot_usuarios\`).

## Test plan

- [x] \`deno task check\` ✅
- [x] \`deno task lint\` ✅
- [x] \`deno task test\` → 147 passed / 0 failed
- [x] Migración aplicada en prod; \`bot_ventas_por_preventista(false)\` reconcilia con \`bot_ventas_periodo\` (\$938.310 / 35 pedidos para 2026-04-28 sucursal 1)
- [ ] **Pendiente**: deploy del edge function \`telegram-webhook\` para activar prompts + nuevas tools en el bot
- [ ] **Pendiente post-deploy**: enviar el audio "Decime cuánto vendimos ayer" desde el admin → debería responder con monto real
- [ ] **Pendiente post-deploy**: enviar "ventas de ayer por preventista" → ranking con Christian/Joaquin/Luis
- [ ] **Pendiente post-deploy**: enviar desde Christian (preventista) "cuánto vendí ayer" → \$402.820 (vía \`mis_ventas\`)
- [ ] Routine programada para 2026-05-13 9am AR que mide \`MALFORMED_FUNCTION_CALL\` count en \`bot_audit_log\` y reporta si el fix se sostiene

🤖 Generated with [Claude Code](https://claude.com/claude-code)