### PR TITLE
feat(bot): última venta por cliente, ranking por producto, /sucursal

### DIFF
--- a/migrations/026_bot_ranking_preventistas_por_producto.sql
+++ b/migrations/026_bot_ranking_preventistas_por_producto.sql
@@ -1,0 +1,77 @@
+-- Migración 026 — Bot Telegram: ranking de preventistas por un producto puntual
+--
+-- RPC token-eficiente para responder "quién vendió más Manaos 3000 este mes",
+-- "top vendedores de aceite girasol", "para darle una bonificación al que más
+-- vendió X". Requiere producto_id (el bot lo consigue antes con buscar_producto).
+--
+-- Diseño: por diseño NO hacemos un cross-tab (preventista × todos los productos)
+-- — devolvería tablas inmanejables. La tool fuerza un producto específico.
+--
+-- Convenciones (calcadas de migrations 022 y 025):
+--   * Filtro por created_at (consistente con bot_ventas_periodo / bot_ventas_por_preventista).
+--   * Excluye estados 'cancelado' y 'anulado'.
+--   * SECURITY DEFINER + grant explícito a service_role.
+
+CREATE OR REPLACE FUNCTION public.bot_ranking_preventistas_por_producto(
+  p_producto_id BIGINT,
+  p_desde DATE,
+  p_hasta DATE,
+  p_sucursal_id BIGINT,
+  p_limit INT DEFAULT 10
+)
+RETURNS JSON
+LANGUAGE plpgsql STABLE SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE resultado JSON;
+BEGIN
+  WITH ventas_filtradas AS (
+    SELECT p.usuario_id, pi.cantidad, pi.subtotal
+    FROM pedidos p
+    JOIN pedido_items pi ON pi.pedido_id = p.id
+    WHERE p.sucursal_id = p_sucursal_id
+      AND p.created_at >= p_desde::TIMESTAMPTZ
+      AND p.created_at < (p_hasta::DATE + 1)::TIMESTAMPTZ
+      AND COALESCE(p.estado, '') NOT IN ('cancelado', 'anulado')
+      AND pi.producto_id = p_producto_id
+  ),
+  por_usuario AS (
+    SELECT
+      v.usuario_id,
+      pf.nombre,
+      pf.rol,
+      SUM(v.cantidad)             AS unidades,
+      SUM(v.subtotal)             AS facturado,
+      COUNT(*)                    AS pedidos_con_producto
+    FROM ventas_filtradas v
+    LEFT JOIN perfiles pf ON pf.id = v.usuario_id
+    GROUP BY v.usuario_id, pf.nombre, pf.rol
+    ORDER BY SUM(v.cantidad) DESC
+    LIMIT p_limit
+  ),
+  producto_info AS (
+    SELECT id, codigo, nombre
+    FROM productos
+    WHERE id = p_producto_id
+  )
+  SELECT json_build_object(
+    'producto_id', p_producto_id,
+    'producto_codigo', (SELECT codigo FROM producto_info),
+    'producto_nombre', (SELECT nombre FROM producto_info),
+    'desde', p_desde,
+    'hasta', p_hasta,
+    'unidades_total', (SELECT COALESCE(SUM(cantidad), 0) FROM ventas_filtradas),
+    'facturado_total', (SELECT COALESCE(SUM(subtotal), 0) FROM ventas_filtradas),
+    'preventistas_count', (SELECT COUNT(*) FROM por_usuario),
+    'preventistas', COALESCE(
+      (SELECT json_agg(row_to_json(pu.*)) FROM por_usuario pu),
+      '[]'::JSON
+    )
+  ) INTO resultado;
+  RETURN resultado;
+END;
+$$;
+
+ALTER FUNCTION public.bot_ranking_preventistas_por_producto(BIGINT, DATE, DATE, BIGINT, INT) OWNER TO postgres;
+REVOKE ALL    ON FUNCTION public.bot_ranking_preventistas_por_producto(BIGINT, DATE, DATE, BIGINT, INT) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.bot_ranking_preventistas_por_producto(BIGINT, DATE, DATE, BIGINT, INT) TO service_role;

--- a/supabase/functions/_shared/gemini/agent.ts
+++ b/supabase/functions/_shared/gemini/agent.ts
@@ -333,8 +333,16 @@ export async function runAgent(opts: RunAgentOptions): Promise<RunAgentResult> {
       // modelo no puede resolver un argumento (ej: "ayer" sin saber la
       // fecha). Damos un mensaje accionable en vez del fallback genérico.
       const isMalformed = lastFinishReason === "MALFORMED_FUNCTION_CALL";
+      // SILENT STOP: Gemini terminó "limpio" (STOP) pero sin emitir tools
+      // ni texto. Suele pasar con thinking on cuando el modelo "se queda"
+      // sin patrón claro. Pasa cuando el prompt no tiene ejemplo del flujo
+      // que necesita encadenar — distinto al fallback genérico para visibilidad.
+      const isSilentStop = lastFinishReason === "STOP" &&
+        textParts.trim().length === 0;
       const fallback = isMalformed
         ? "No logré armar la consulta correctamente. ¿Podés ser más específico con el período (ej: 'ventas del 15 al 22 de abril') o el dato que querés ver?"
+        : isSilentStop
+        ? "No estoy seguro qué consulta hacer para esto. ¿Podés agregar un poco más de contexto (cliente, producto, período)?"
         : "No pude generar una respuesta. Probá reformular.";
       let text = textParts.trim().length > 0 ? textParts : fallback;
 
@@ -371,6 +379,7 @@ export async function runAgent(opts: RunAgentOptions): Promise<RunAgentResult> {
           toolCallsCount,
           finishReason: lastFinishReason,
           malformed: isMalformed || undefined,
+          silent_stop: isSilentStop || undefined,
         },
       }).catch(() => {});
 

--- a/supabase/functions/_shared/gemini/prompts/admin.ts
+++ b/supabase/functions/_shared/gemini/prompts/admin.ts
@@ -5,7 +5,7 @@
 
 const prompt = `Sos el asistente IA de la distribuidora.
 
-El usuario actual es ADMIN. Tiene acceso a información de las sucursales asignadas a su cuenta. Por defecto operás sobre la sucursal default del admin; si el admin no tiene sucursal asignada, podés ver todas las que correspondan.
+El usuario actual es ADMIN. Tiene acceso a información de las sucursales asignadas a su cuenta. Por defecto operás sobre la sucursal ACTIVA del admin (la que figura en bot_usuarios.sucursal_id). Si el admin tiene varias sucursales asignadas y quiere consultar otra, decile explícitamente que use el comando /sucursal para listar/cambiar la activa antes de preguntar — NO inventes datos de otras sucursales ni asumas que podés mezclarlas.
 
 Tu trabajo es ayudar al admin a:
 - Buscar clientes y productos por nombre o código.
@@ -13,6 +13,7 @@ Tu trabajo es ayudar al admin a:
 - Reportes de ventas y compras en períodos:
   · ventas_periodo(desde, hasta) → total facturado, top productos, top clientes, ticket promedio (sucursal entera).
   · ventas_por_preventista(desde, hasta, [solo_preventistas]) → ranking de ventas por usuario (preventista). Ideal para "quién vendió más", "ventas por preventista", "ventas de ayer por vendedor".
+  · ranking_preventistas_por_producto(producto_id, desde, hasta) → quién vendió más unidades de UN producto puntual en un rango. Útil para bonificaciones, sales contests o "quién vendió más [producto]". Hay que conseguir el producto_id antes con buscar_producto.
   · compras_periodo(desde, hasta) → total comprado a proveedores, top proveedores.
 - Cobranzas:
   · pendientes_pago([dias_atraso]) → clientes con pedidos no pagados, ordenados por antigüedad.
@@ -31,6 +32,26 @@ EJEMPLOS DE INTENT → TOOL (recordá: las fechas exactas vienen del bloque CONT
 - "deuda de más de 30 días" → pendientes_pago(dias_atraso=30).
 - "qué le compré a Coca-Cola este mes" → compras_periodo del mes corriente; en top_proveedores buscá el que matchee.
 - "cómo me paga Pepe" → primero buscar_cliente para conseguir el id, después historico_pagos_cliente.
+
+ÚLTIMA VENTA / HISTÓRICO DE UN CLIENTE (preguntas tipo "última venta a X", "cuándo me compró Y", "qué le vendí a Z el mes pasado"):
+1. buscar_cliente con el nombre tal cual viene (matchea fantasy y razón social, acentos no importan).
+2. Tomá el id del primer match. Si hay ambigüedad y los matches difieren claramente, pedí confirmación al usuario.
+3. historico_pedidos_cliente(cliente_id, limit=1, dias=180) si pide solo "la última". Si pide "los últimos N pedidos", usá limit=N. Para "este mes", pasá dias = días transcurridos del mes hasta hoy. La respuesta incluye fecha, total, estado, y los items con cantidad/subtotal — usá esos datos directamente.
+4. NO uses ficha_cliente para "última venta": ficha_cliente es para saldo y resumen general; historico_pedidos_cliente trae el detalle real.
+
+EJEMPLOS:
+- "última venta al kiosco arquitectura UNT" → buscar_cliente("kiosco arquitectura UNT") → tomar id → historico_pedidos_cliente(cliente_id, limit=1, dias=180).
+- "qué le vendí a almacén Pepe los últimos 3 meses" → buscar_cliente → historico_pedidos_cliente(cliente_id, dias=90).
+- "el último pedido de Maxikiosco" → buscar_cliente → historico_pedidos_cliente(limit=1).
+
+REGLA DE EFICIENCIA (importante): cuando el usuario pide UN SOLO dato puntual, pasá limit=1. No traigas 20 pedidos si solo te preguntan por uno. Vale para cualquier tool con limit: si te piden "el top 3", pasá limit=3, no 10. Esto ahorra tokens y la respuesta sale antes.
+
+TOP DE PREVENTISTAS POR UN PRODUCTO ESPECÍFICO (preguntas tipo "quién vendió más Manaos 3000", "top vendedores de aceite girasol", "para darle una bonificación al que más vendió X"):
+1. buscar_producto con el nombre/marca/código que dijo el usuario.
+2. Tomá el producto_id del primer match razonable. Si hay variantes (ej: "Manaos cola" matchea cola 600cc y 3000cc), elegí la que el usuario mencionó por tamaño o pedile aclaración.
+3. ranking_preventistas_por_producto(producto_id, desde, hasta, limit) con las fechas del CONTEXTO DE FECHA. Para "este mes", desde=primer_día_del_mes, hasta=hoy.
+4. La respuesta incluye unidades, facturado y pedidos_con_producto por preventista. Resumí el ranking con nombres (no IDs) y mencioná el total general.
+NUNCA inventes producto_id — siempre pasalo después de buscar_producto.
 
 REGLAS:
 1. NUNCA inventes datos. Si no tenés un dato, llamá a la tool apropiada. Si la tool no cubre lo que el usuario pide, decilo claro.

--- a/supabase/functions/_shared/gemini/prompts/encargado.ts
+++ b/supabase/functions/_shared/gemini/prompts/encargado.ts
@@ -11,6 +11,7 @@ Tu trabajo es ayudar al encargado a:
 - Reportes de ventas y compras de la sucursal:
   · ventas_periodo(desde, hasta) → total facturado, top productos, top clientes (sucursal entera).
   · ventas_por_preventista(desde, hasta, [solo_preventistas]) → ranking de ventas por usuario (preventista).
+  · ranking_preventistas_por_producto(producto_id, desde, hasta) → quién vendió más unidades de UN producto puntual en un rango. Útil para bonificaciones / sales contests.
   · compras_periodo(desde, hasta) → total comprado, top proveedores.
 - Cobranzas:
   · pendientes_pago([dias_atraso]) → clientes con pedidos no pagados.
@@ -25,6 +26,10 @@ EJEMPLOS DE INTENT → TOOL (las fechas exactas vienen del bloque CONTEXTO DE FE
 - "deuda total de la sucursal" → pendientes_pago.
 - "qué le compré al proveedor X" → compras_periodo y mirá top_proveedores.
 - "cómo me paga Pepe" → buscar_cliente → historico_pagos_cliente.
+- "última venta al kiosco X" / "cuándo me compró Pepe" → buscar_cliente → historico_pedidos_cliente(cliente_id, limit=1, dias=180).
+- "quién vendió más Manaos 3000 este mes" → buscar_producto → ranking_preventistas_por_producto(producto_id, desde=1ro_mes, hasta=hoy).
+
+REGLA DE EFICIENCIA: si te piden UN SOLO dato puntual ("la última venta", "el primer pedido", "el top 3"), pasá limit=N exacto. No traigas 20 si te piden 1.
 
 REGLAS:
 1. NUNCA inventes datos. Si no tenés un dato, llamá a la tool. Si pide algo fuera del scope (ver otra sucursal, cambiar precios), decilo claro.

--- a/supabase/functions/_shared/gemini/prompts/preventista.ts
+++ b/supabase/functions/_shared/gemini/prompts/preventista.ts
@@ -18,8 +18,11 @@ Tu trabajo es ayudar al preventista a:
 
 EJEMPLOS DE INTENT → TOOL (para fechas relativas usá el bloque CONTEXTO DE FECHA arriba):
 - "qué le vendí a Pepe los últimos 3 meses" → buscar_cliente para conseguir id, después historico_pedidos_cliente con dias=90.
+- "última venta a almacén Gabriel" / "el último pedido de Pepe" → buscar_cliente → historico_pedidos_cliente(cliente_id, limit=1, dias=180).
 - "qué productos compra siempre Pepe" → buscar_cliente → productos_recurrentes_cliente.
 - "lo de siempre de almacén gabriel" → buscar_cliente → productos_recurrentes_cliente con dias=60-90.
+
+REGLA DE EFICIENCIA: si te piden UN SOLO dato puntual ("la última venta", "el último pedido", "el top 3 productos"), pasá limit=N exacto. No traigas 20 pedidos si solo te preguntan por uno. Vale para mis_ventas también: "mis 3 mejores clientes este mes" → mis_ventas(...) con limit=3.
 - "cuánto vendí ayer" → mis_ventas(desde=ayer, hasta=ayer).
 - "cuánto vendí esta semana" → mis_ventas(desde=lunes_de_esta_semana, hasta=hoy).
 - "cuánto vendí este mes" → mis_ventas(desde=primer_dia_del_mes, hasta=hoy).

--- a/supabase/functions/_shared/tools/admin/ranking_preventistas_por_producto.ts
+++ b/supabase/functions/_shared/tools/admin/ranking_preventistas_por_producto.ts
@@ -1,0 +1,157 @@
+// Tool: ranking_preventistas_por_producto
+//
+// Top de preventistas que más vendieron UN producto puntual en un rango de
+// fechas. Pensada para preguntas de bonificación / sales contest tipo
+// "quién vendió más Manaos 3000 este mes". El modelo debe conseguir el
+// producto_id antes con buscar_producto — esta tool no acepta búsqueda
+// libre por nombre, mantiene el output acotado.
+//
+// Delega a la RPC bot_ranking_preventistas_por_producto (migration 026).
+// Mismas convenciones de fecha/estado que ventas_periodo y ventas_por_preventista
+// (filtro por created_at, excluye cancelado/anulado, scoping por sucursal).
+
+import type { Tool } from "../base.ts";
+
+export interface RankingPreventistasPorProductoParams {
+  /** ID del producto (sacar antes con buscar_producto). */
+  producto_id: number;
+  /** Fecha inicio inclusive (YYYY-MM-DD). */
+  desde: string;
+  /** Fecha fin inclusive (YYYY-MM-DD). */
+  hasta: string;
+  /** Top N para el ranking. Default 10, max 25. */
+  limit?: number;
+}
+
+export interface RankingPreventistasPorProductoResult {
+  producto_id: number;
+  producto_codigo: string | null;
+  producto_nombre: string | null;
+  desde: string;
+  hasta: string;
+  unidades_total: number;
+  facturado_total: number;
+  preventistas_count: number;
+  preventistas: Array<{
+    usuario_id: string | null;
+    nombre: string;
+    rol: string | null;
+    unidades: number;
+    facturado: number;
+    pedidos_con_producto: number;
+  }>;
+}
+
+const FECHA_REGEX = /^\d{4}-\d{2}-\d{2}$/;
+
+export const rankingPreventistasPorProductoTool: Tool<
+  RankingPreventistasPorProductoParams,
+  RankingPreventistasPorProductoResult
+> = {
+  name: "ranking_preventistas_por_producto",
+  description:
+    "Ranking de preventistas que más vendieron UN producto específico en " +
+    "un rango de fechas (admin/encargado). Útil para 'quién vendió más " +
+    "[producto]', 'top vendedores de [producto] del mes', bonificaciones " +
+    "por sales contest. Requiere producto_id — conseguilo antes con " +
+    "buscar_producto. Devuelve unidades + facturado + cantidad de pedidos " +
+    "con el producto, por preventista, ordenado por unidades. Filtra por " +
+    "sucursal del bot user. Excluye pedidos cancelados/anulados.",
+  parameters: {
+    type: "object",
+    properties: {
+      producto_id: {
+        type: "integer",
+        minimum: 1,
+        description: "ID interno del producto. Conseguilo con buscar_producto antes.",
+      },
+      desde: {
+        type: "string",
+        description: "Fecha de inicio inclusive (YYYY-MM-DD).",
+      },
+      hasta: {
+        type: "string",
+        description: "Fecha de fin inclusive (YYYY-MM-DD).",
+      },
+      limit: {
+        type: "integer",
+        minimum: 1,
+        maximum: 25,
+        description: "Top N preventistas (default 10, max 25).",
+      },
+    },
+    required: ["producto_id", "desde", "hasta"],
+  },
+  allowedRoles: ["admin", "encargado"],
+  handler: async ({ producto_id, desde, hasta, limit = 10 }, ctx) => {
+    if (!Number.isInteger(producto_id) || producto_id < 1) {
+      throw new Error("producto_id inválido (entero > 0)");
+    }
+    if (!FECHA_REGEX.test(desde) || !FECHA_REGEX.test(hasta)) {
+      throw new Error("Fechas inválidas (esperado YYYY-MM-DD)");
+    }
+    if (desde > hasta) {
+      throw new Error("Fecha 'desde' debe ser <= 'hasta'");
+    }
+    if (!Number.isFinite(limit) || limit < 1 || limit > 25) {
+      throw new Error("Límite fuera de rango (1-25)");
+    }
+    if (ctx.sucursal_id == null) {
+      throw new Error("Sucursal no asignada — contactá al administrador");
+    }
+
+    const { data, error } = await ctx.supabase.rpc(
+      "bot_ranking_preventistas_por_producto",
+      {
+        p_producto_id: producto_id,
+        p_desde: desde,
+        p_hasta: hasta,
+        p_sucursal_id: ctx.sucursal_id,
+        p_limit: limit,
+      },
+    );
+
+    if (error) {
+      throw new Error(`ranking_preventistas_por_producto: ${error.message}`);
+    }
+
+    type RpcRow = {
+      usuario_id: string | null;
+      nombre: string | null;
+      rol: string | null;
+      unidades: number | string;
+      facturado: number | string;
+      pedidos_con_producto: number;
+    };
+    const r = data as {
+      producto_id: number;
+      producto_codigo: string | null;
+      producto_nombre: string | null;
+      desde: string;
+      hasta: string;
+      unidades_total: number | string;
+      facturado_total: number | string;
+      preventistas_count: number;
+      preventistas: RpcRow[];
+    };
+
+    return {
+      producto_id: Number(r.producto_id),
+      producto_codigo: r.producto_codigo ?? null,
+      producto_nombre: r.producto_nombre ?? null,
+      desde: r.desde,
+      hasta: r.hasta,
+      unidades_total: Number(r.unidades_total ?? 0),
+      facturado_total: Number(r.facturado_total ?? 0),
+      preventistas_count: Number(r.preventistas_count ?? 0),
+      preventistas: (r.preventistas ?? []).map((p) => ({
+        usuario_id: p.usuario_id ?? null,
+        nombre: p.nombre?.trim() || "(sin asignar)",
+        rol: p.rol ?? null,
+        unidades: Number(p.unidades ?? 0),
+        facturado: Number(p.facturado ?? 0),
+        pedidos_con_producto: Number(p.pedidos_con_producto ?? 0),
+      })),
+    };
+  },
+};

--- a/supabase/functions/_shared/tools/index.ts
+++ b/supabase/functions/_shared/tools/index.ts
@@ -21,6 +21,7 @@ import { miRecorridoHoyTool } from "./transportista/mi_recorrido_hoy.ts";
 import { recorridoResumenTool } from "./transportista/recorrido_resumen.ts";
 import { ventasPeriodoTool } from "./admin/ventas_periodo.ts";
 import { ventasPorPreventistaTool } from "./admin/ventas_por_preventista.ts";
+import { rankingPreventistasPorProductoTool } from "./admin/ranking_preventistas_por_producto.ts";
 import { pendientesPagoTool } from "./admin/pendientes_pago.ts";
 import { historicoPagosClienteTool } from "./admin/historico_pagos_cliente.ts";
 import { comprasPeriodoTool } from "./admin/compras_periodo.ts";
@@ -44,6 +45,7 @@ export function registerAllTools(): void {
   registerTool(recorridoResumenTool);
   registerTool(ventasPeriodoTool);
   registerTool(ventasPorPreventistaTool);
+  registerTool(rankingPreventistasPorProductoTool);
   registerTool(pendientesPagoTool);
   registerTool(historicoPagosClienteTool);
   registerTool(comprasPeriodoTool);

--- a/supabase/functions/telegram-webhook/commands/sucursal.ts
+++ b/supabase/functions/telegram-webhook/commands/sucursal.ts
@@ -1,0 +1,211 @@
+// /sucursal — para admins multi-sucursal (vinculados a >1 sucursal vía
+// usuario_sucursales). Permite listar las sucursales asignadas y switchear
+// la activa del bot (bot_usuarios.sucursal_id).
+//
+// Uso:
+//   /sucursal                  → lista con la activa marcada + inline keyboard
+//   /sucursal <id>             → switch directo por id
+//   /sucursal <nombre>         → switch directo por nombre exacto (case-insens)
+//
+// El switch es persistente — UPDATE bot_usuarios. Se valida que la sucursal
+// destino esté en usuario_sucursales para el perfil_id del caller (si no,
+// se rechaza con error claro).
+
+import { sendMessage } from "../../_shared/telegram.ts";
+import { getServiceRoleClient } from "../../_shared/supabase.ts";
+import { logEvent } from "../../_shared/audit.ts";
+import type { CommandSpec } from "./types.ts";
+
+interface SucursalRow {
+  id: number;
+  nombre: string;
+}
+
+/** Lista las sucursales asignadas al usuario vía usuario_sucursales JOIN sucursales. */
+async function listSucursalesAsignadas(perfil_id: string): Promise<SucursalRow[]> {
+  const sb = getServiceRoleClient();
+  // Inner join: solo activas. Ordenado por nombre para consistencia.
+  const { data, error } = await sb
+    .from("usuario_sucursales")
+    .select("sucursal_id, sucursales!inner(id, nombre, activa)")
+    .eq("usuario_id", perfil_id);
+  if (error) {
+    throw new Error(`No pude leer tus sucursales: ${error.message}`);
+  }
+  type Row = {
+    sucursal_id: number;
+    sucursales: { id: number; nombre: string; activa: boolean } | null;
+  };
+  const rows = (data as unknown as Row[]) ?? [];
+  return rows
+    .filter((r) => r.sucursales?.activa)
+    .map((r) => ({
+      id: r.sucursales!.id,
+      nombre: r.sucursales!.nombre,
+    }))
+    .sort((a, b) => a.nombre.localeCompare(b.nombre, "es"));
+}
+
+/** UPDATE bot_usuarios.sucursal_id. No valida — lo hace el caller. */
+async function updateBotSucursal(
+  telegram_user_id: number,
+  sucursal_id: number,
+): Promise<void> {
+  const sb = getServiceRoleClient();
+  const { error } = await sb
+    .from("bot_usuarios")
+    .update({ sucursal_id })
+    .eq("telegram_user_id", telegram_user_id);
+  if (error) {
+    throw new Error(`No pude cambiar la sucursal: ${error.message}`);
+  }
+}
+
+/**
+ * Resuelve el switch end-to-end:
+ *  1. Lista las asignadas.
+ *  2. Si la lista tiene 0/1, mensaje informativo (no hay nada que switchear).
+ *  3. Sin args: lista con activa marcada + inline keyboard.
+ *  4. Con arg numérico: matchea id contra asignadas; switch o error.
+ *  5. Con arg texto: matchea nombre case-insens contra asignadas.
+ *
+ * Visible para reuso desde el callback handler (sucursal_switch:<id>).
+ */
+export async function handleSucursalSwitch(opts: {
+  telegram_user_id: number;
+  perfil_id: string;
+  current_sucursal_id: number | null;
+  /** "id" forzado por callback; el handler de slash command lo arma desde rawArgs. */
+  target_id: number;
+}): Promise<{ ok: true; nombre: string } | { ok: false; error: string }> {
+  const asignadas = await listSucursalesAsignadas(opts.perfil_id);
+  const match = asignadas.find((s) => s.id === opts.target_id);
+  if (!match) {
+    return {
+      ok: false,
+      error: "Esa sucursal no está asignada a tu cuenta.",
+    };
+  }
+  if (opts.current_sucursal_id === match.id) {
+    return { ok: true, nombre: match.nombre };
+  }
+  await updateBotSucursal(opts.telegram_user_id, match.id);
+  return { ok: true, nombre: match.nombre };
+}
+
+export const sucursalCommand: CommandSpec = {
+  name: "/sucursal",
+  description: "Listar/cambiar la sucursal activa del bot (admins multi-sucursal).",
+  scope: ["admin"],
+  async handler({ chatId, user, tgUser, rawArgs }) {
+    if (!user) {
+      await sendMessage(
+        chatId,
+        "Necesitás vincularte primero. Mandá /vincular CODIGO.",
+      );
+      return;
+    }
+
+    let asignadas: SucursalRow[];
+    try {
+      asignadas = await listSucursalesAsignadas(user.perfil_id);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      console.error("[sucursal] list failed:", msg);
+      await sendMessage(chatId, `❌ ${msg}`);
+      return;
+    }
+
+    if (asignadas.length === 0) {
+      await sendMessage(
+        chatId,
+        "No tenés sucursales asignadas en la app. Pedile a un admin que te asigne.",
+      );
+      return;
+    }
+    if (asignadas.length === 1) {
+      const only = asignadas[0];
+      const isActive = user.sucursal_id === only.id;
+      await sendMessage(
+        chatId,
+        isActive
+          ? `🏪 Tu única sucursal asignada es ${only.nombre}. Ya es la activa.`
+          : `🏪 Tu única sucursal asignada es ${only.nombre} — la pongo como activa.`,
+      );
+      if (!isActive) {
+        try {
+          await updateBotSucursal(tgUser.id, only.id);
+        } catch (err) {
+          const msg = err instanceof Error ? err.message : String(err);
+          await sendMessage(chatId, `❌ ${msg}`);
+        }
+      }
+      return;
+    }
+
+    const arg = rawArgs.trim();
+
+    // Sin args → lista + inline keyboard.
+    if (arg.length === 0) {
+      const lines = ["🏪 Sucursales asignadas:"];
+      for (const s of asignadas) {
+        const marker = s.id === user.sucursal_id ? "✓ " : "  ";
+        lines.push(`${marker}${s.nombre}`);
+      }
+      lines.push("");
+      lines.push("Tocá una para cambiar la activa, o escribí /sucursal <nombre|id>.");
+      const reply_markup = {
+        inline_keyboard: asignadas.map((s) => [{
+          text: s.id === user.sucursal_id ? `✓ ${s.nombre}` : s.nombre,
+          callback_data: `v1:sucursal_switch:${s.id}`,
+        }]),
+      };
+      await sendMessage(chatId, lines.join("\n"), { reply_markup });
+      return;
+    }
+
+    // Con arg: numérico → id; texto → nombre case-insens.
+    let target_id: number | null = null;
+    if (/^\d+$/.test(arg)) {
+      target_id = parseInt(arg, 10);
+    } else {
+      const argLower = arg.toLowerCase();
+      const byName = asignadas.find((s) => s.nombre.toLowerCase() === argLower);
+      target_id = byName ? byName.id : null;
+    }
+
+    if (target_id == null) {
+      await sendMessage(
+        chatId,
+        `❌ No encontré una sucursal con "${arg}". Usá /sucursal sin argumentos para ver la lista.`,
+      );
+      return;
+    }
+
+    const result = await handleSucursalSwitch({
+      telegram_user_id: tgUser.id,
+      perfil_id: user.perfil_id,
+      current_sucursal_id: user.sucursal_id,
+      target_id,
+    });
+
+    if (!result.ok) {
+      await sendMessage(chatId, `❌ ${result.error}`);
+      await logEvent({
+        telegram_user_id: tgUser.id,
+        perfil_id: user.perfil_id,
+        rol: user.rol,
+        tipo: "error",
+        tool_name: "sucursal",
+        resultado_meta: { error: result.error, target_id },
+      }).catch(() => {});
+      return;
+    }
+
+    await sendMessage(
+      chatId,
+      `✅ Sucursal activa: ${result.nombre}.\n\n` +
+        `Las próximas consultas (ventas, deuda, etc.) van a ser de esa sucursal.`,
+    );
+  },
+};

--- a/supabase/functions/telegram-webhook/handlers.ts
+++ b/supabase/functions/telegram-webhook/handlers.ts
@@ -57,6 +57,7 @@ import { sugerenciasCommand } from "./commands/sugerencias.ts";
 import { menuCommand } from "./commands/menu.ts";
 import { resetCommand } from "./commands/reset.ts";
 import { desvincularCommand } from "./commands/desvincular.ts";
+import { handleSucursalSwitch, sucursalCommand } from "./commands/sucursal.ts";
 
 const CODIGO_REGEX = /^[A-Z0-9]{6}$/;
 
@@ -80,6 +81,7 @@ function bootCommands(): void {
   registerCommand(menuCommand);
   registerCommand(resetCommand);
   registerCommand(desvincularCommand);
+  registerCommand(sucursalCommand);
   _booted = true;
 }
 
@@ -748,6 +750,8 @@ export async function handleCallbackQuery(cb: TelegramCallbackQuery): Promise<vo
       return handleCallbackProducto(cb, toolCtx, parsed.args);
     case "menu":
       return handleCallbackMenu(cb, user, toolCtx, parsed.args);
+    case "sucursal_switch":
+      return handleCallbackSucursalSwitch(cb, user, parsed.args);
     case "visitar":
       // Reservada: confirmamos el callback y respondemos con placeholder.
       // Acciones de write con confirmación están out of scope hasta una
@@ -761,6 +765,61 @@ export async function handleCallbackQuery(cb: TelegramCallbackQuery): Promise<vo
         text: "Acción desconocida.",
       });
       return;
+  }
+}
+
+async function handleCallbackSucursalSwitch(
+  cb: TelegramCallbackQuery,
+  user: BotUser,
+  args: string[],
+): Promise<void> {
+  const chatId = cb.message.chat.id;
+  // Defense-in-depth: el comando /sucursal hoy es solo admin, así que el
+  // botón también debe ser admin-only. (Aún si un usuario se las arregla
+  // para mandar el callback_data crudo, lo bloqueamos acá.)
+  if (user.rol !== "admin") {
+    await answerCallbackQuery(cb.id, {
+      text: "Solo admins pueden cambiar la sucursal activa.",
+      show_alert: true,
+    });
+    return;
+  }
+  const idStr = args[0];
+  const target_id = idStr ? parseInt(idStr, 10) : NaN;
+  if (!Number.isFinite(target_id) || target_id <= 0) {
+    await answerCallbackQuery(cb.id, { text: "ID de sucursal inválido." });
+    return;
+  }
+
+  try {
+    const result = await handleSucursalSwitch({
+      telegram_user_id: cb.from.id,
+      perfil_id: user.perfil_id,
+      current_sucursal_id: user.sucursal_id,
+      target_id,
+    });
+    if (!result.ok) {
+      await answerCallbackQuery(cb.id, {
+        text: result.error,
+        show_alert: true,
+      });
+      return;
+    }
+    await answerCallbackQuery(cb.id, {
+      text: `✅ ${result.nombre}`,
+    });
+    await sendMessage(
+      chatId,
+      `✅ Sucursal activa: ${result.nombre}.\n\n` +
+        `Las próximas consultas (ventas, deuda, etc.) van a ser de esa sucursal.`,
+    );
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.error("[callback sucursal_switch] failed:", msg);
+    await answerCallbackQuery(cb.id, {
+      text: "No pude cambiar la sucursal. Probá de nuevo.",
+      show_alert: true,
+    });
   }
 }
 

--- a/supabase/functions/tests/agent.test.ts
+++ b/supabase/functions/tests/agent.test.ts
@@ -895,3 +895,61 @@ Deno.test("runAgent MALFORMED_FUNCTION_CALL devuelve un mensaje accionable", asy
     teardownAgentEnv();
   }
 });
+
+// ============================================================================
+// 10. Silent STOP (finishReason=STOP, sin tools, sin texto) → mensaje accionable
+// ============================================================================
+
+Deno.test("runAgent silent STOP devuelve mensaje accionable distinto al genérico", async () => {
+  setupAgentEnv();
+  const { client, spy } = createMockSupabase({ conversacionData: null });
+  // deno-lint-ignore no-explicit-any
+  _setServiceRoleClientForTests(client as any);
+
+  // Gemini emite parts vacías + finishReason STOP — el modelo "pensó" pero
+  // no se anima a tool-callear ni a producir texto. Caso real visto en prod
+  // con Gemini 2.5 Flash con thinking on.
+  const fetchStub = installGeminiFetchStub([
+    {
+      candidates: [
+        {
+          content: { role: "model", parts: [] },
+          finishReason: "STOP",
+        },
+      ],
+      usageMetadata: { totalTokenCount: 5223 },
+    },
+  ]);
+
+  try {
+    const result = await runAgent({
+      supabase: client,
+      user: makeUser("admin"),
+      telegram_user_id: 42,
+      userMessage: "Decime cuál fue la última venta al kiosco arquitectura UNT",
+    });
+
+    assertEquals(result.finishReason, "STOP");
+    assertEquals(result.toolCallsCount, 0);
+    assertEquals(result.hitMaxIterations, false);
+    assertStringIncludes(result.text, "No estoy seguro");
+    assertStringIncludes(result.text, "contexto");
+    // No debe ser ni el de MALFORMED ni el genérico viejo.
+    assert(!result.text.includes("No logré armar"));
+    assert(!result.text.includes("Probá reformular"));
+
+    // Audit con silent_stop=true.
+    const auditResp = spy.inserts.find((i) =>
+      i.table === "bot_audit_log" && i.row.tipo === "respuesta"
+    );
+    assert(auditResp, "debió haber audit tipo='respuesta'");
+    const meta = auditResp!.row.resultado_meta as Record<string, unknown>;
+    assertEquals(meta.silent_stop, true);
+    assertEquals(meta.finishReason, "STOP");
+    // malformed NO debe estar marcado.
+    assertEquals(meta.malformed, undefined);
+  } finally {
+    fetchStub.restore();
+    teardownAgentEnv();
+  }
+});

--- a/supabase/functions/tests/telegram-webhook.test.ts
+++ b/supabase/functions/tests/telegram-webhook.test.ts
@@ -1466,3 +1466,201 @@ Deno.test("errorMessageFor: error genérico -> mensaje default", async () => {
   const r = errorMessageFor(new Error("ECONNRESET pillin"));
   assertStringIncludes(r, "problema procesando");
 });
+
+// ============================================================================
+// /sucursal command (multi-sucursal)
+// ============================================================================
+
+const dosSucursalesAdmin = [
+  {
+    sucursal_id: 1,
+    sucursales: { id: 1, nombre: "Tucuman", activa: true },
+  },
+  {
+    sucursal_id: 2,
+    sucursales: { id: 2, nombre: "Taco Pozo", activa: true },
+  },
+];
+
+Deno.test("/sucursal sin args lista las asignadas con la activa marcada", async () => {
+  const handleUpdate = await freshHandleUpdate();
+  Deno.env.set("TELEGRAM_BOT_TOKEN", "test-token");
+  const { client, spy } = createRouterMockSupabase({
+    maybeSingleByTable: { bot_usuarios: { data: linkedAdmin, error: null } },
+    selectResponseByTable: {
+      usuario_sucursales: {
+        data: dosSucursalesAdmin,
+        error: null,
+      },
+    },
+  });
+  // deno-lint-ignore no-explicit-any
+  _setServiceRoleClientForTests(client as any);
+  const fetchMock = mockTelegramFetch();
+
+  try {
+    await handleUpdate({
+      update_id: 1,
+      message: {
+        message_id: 1,
+        date: 1700000000,
+        chat: { id: 999, type: "private" },
+        from: { id: 999, is_bot: false, first_name: "Admin" },
+        text: "/sucursal",
+      },
+    });
+
+    const sent = fetchMock.sent.find((s) =>
+      ((s as { body?: string }).body ?? "").includes("Sucursales asignadas")
+    );
+    assert(sent, "no se mandó la lista de sucursales");
+    const body = (sent as { body: string }).body;
+    assertStringIncludes(body, "Tucuman");
+    assertStringIncludes(body, "Taco Pozo");
+    // Tucumán es la activa (linkedAdmin.sucursal_id=1) → debe llevar el ✓.
+    assertStringIncludes(body, "✓");
+    // Inline keyboard con callback_data sucursal_switch:1 y :2.
+    assertStringIncludes(body, "sucursal_switch:1");
+    assertStringIncludes(body, "sucursal_switch:2");
+
+    // No debe haber UPDATE sobre bot_usuarios — solo listó.
+    const upd = spy.updates.find((u) => u.table === "bot_usuarios");
+    assertEquals(upd, undefined, "no debió hacer update solo por listar");
+  } finally {
+    fetchMock.restore();
+    _setServiceRoleClientForTests(null);
+    Deno.env.delete("TELEGRAM_BOT_TOKEN");
+  }
+});
+
+Deno.test("/sucursal 2 cambia la activa y confirma", async () => {
+  const handleUpdate = await freshHandleUpdate();
+  Deno.env.set("TELEGRAM_BOT_TOKEN", "test-token");
+  const { client, spy } = createRouterMockSupabase({
+    maybeSingleByTable: { bot_usuarios: { data: linkedAdmin, error: null } },
+    selectResponseByTable: {
+      usuario_sucursales: {
+        data: dosSucursalesAdmin,
+        error: null,
+      },
+    },
+  });
+  // deno-lint-ignore no-explicit-any
+  _setServiceRoleClientForTests(client as any);
+  const fetchMock = mockTelegramFetch();
+
+  try {
+    await handleUpdate({
+      update_id: 1,
+      message: {
+        message_id: 1,
+        date: 1700000000,
+        chat: { id: 999, type: "private" },
+        from: { id: 999, is_bot: false, first_name: "Admin" },
+        text: "/sucursal 2",
+      },
+    });
+
+    // UPDATE bot_usuarios SET sucursal_id=2 WHERE telegram_user_id=999
+    const upd = spy.updates.find((u) => u.table === "bot_usuarios");
+    assert(upd, "debió updatear bot_usuarios");
+    assertEquals(upd!.row.sucursal_id, 2);
+    const eq = (upd!.filters as Array<Record<string, unknown>>).find((f) =>
+      f.type === "eq" && f.col === "telegram_user_id"
+    );
+    assertEquals(eq!.val, 999);
+
+    // Confirmación.
+    const sent = fetchMock.sent.find((s) =>
+      ((s as { body?: string }).body ?? "").includes("Sucursal activa")
+    );
+    assert(sent, "no se mandó confirmación");
+    assertStringIncludes((sent as { body: string }).body, "Taco Pozo");
+  } finally {
+    fetchMock.restore();
+    _setServiceRoleClientForTests(null);
+    Deno.env.delete("TELEGRAM_BOT_TOKEN");
+  }
+});
+
+Deno.test("/sucursal con id no asignado rechaza sin update", async () => {
+  const handleUpdate = await freshHandleUpdate();
+  Deno.env.set("TELEGRAM_BOT_TOKEN", "test-token");
+  const { client, spy } = createRouterMockSupabase({
+    maybeSingleByTable: { bot_usuarios: { data: linkedAdmin, error: null } },
+    selectResponseByTable: {
+      usuario_sucursales: {
+        data: dosSucursalesAdmin,
+        error: null,
+      },
+    },
+  });
+  // deno-lint-ignore no-explicit-any
+  _setServiceRoleClientForTests(client as any);
+  const fetchMock = mockTelegramFetch();
+
+  try {
+    await handleUpdate({
+      update_id: 1,
+      message: {
+        message_id: 1,
+        date: 1700000000,
+        chat: { id: 999, type: "private" },
+        from: { id: 999, is_bot: false, first_name: "Admin" },
+        text: "/sucursal 99",
+      },
+    });
+
+    // No debe hacer update.
+    const upd = spy.updates.find((u) => u.table === "bot_usuarios");
+    assertEquals(upd, undefined, "no debió updatear bot_usuarios");
+
+    // Mensaje de error claro.
+    const sent = fetchMock.sent.find((s) =>
+      ((s as { body?: string }).body ?? "").includes("no está asignada")
+    );
+    assert(sent, "debió responder con error de no asignada");
+  } finally {
+    fetchMock.restore();
+    _setServiceRoleClientForTests(null);
+    Deno.env.delete("TELEGRAM_BOT_TOKEN");
+  }
+});
+
+Deno.test("/sucursal con rol preventista es bloqueado por scope", async () => {
+  const handleUpdate = await freshHandleUpdate();
+  Deno.env.set("TELEGRAM_BOT_TOKEN", "test-token");
+  const { client, spy } = createRouterMockSupabase({
+    maybeSingleByTable: { bot_usuarios: { data: linkedPreventista, error: null } },
+  });
+  // deno-lint-ignore no-explicit-any
+  _setServiceRoleClientForTests(client as any);
+  const fetchMock = mockTelegramFetch();
+
+  try {
+    await handleUpdate({
+      update_id: 1,
+      message: {
+        message_id: 1,
+        date: 1700000000,
+        chat: { id: 888, type: "private" },
+        from: { id: 888, is_bot: false, first_name: "Prev" },
+        text: "/sucursal",
+      },
+    });
+
+    // No debe haber select sobre usuario_sucursales — el router cortó por scope.
+    const sel = spy.selectQueries.find((q) => q.table === "usuario_sucursales");
+    assertEquals(sel, undefined, "no debió tocar usuario_sucursales");
+
+    // Mensaje de "comando es solo para".
+    const sent = fetchMock.sent.find((s) =>
+      ((s as { body?: string }).body ?? "").toLowerCase().includes("solo para")
+    );
+    assert(sent, "debió responder con 'comando solo para X'");
+  } finally {
+    fetchMock.restore();
+    _setServiceRoleClientForTests(null);
+    Deno.env.delete("TELEGRAM_BOT_TOKEN");
+  }
+});

--- a/supabase/functions/tests/tools.test.ts
+++ b/supabase/functions/tests/tools.test.ts
@@ -34,6 +34,7 @@ import { listarCategoriasTool } from "../_shared/tools/common/listar_categorias.
 import { productosPorCategoriaTool } from "../_shared/tools/common/productos_por_categoria.ts";
 import { ventasPeriodoTool } from "../_shared/tools/admin/ventas_periodo.ts";
 import { ventasPorPreventistaTool } from "../_shared/tools/admin/ventas_por_preventista.ts";
+import { rankingPreventistasPorProductoTool } from "../_shared/tools/admin/ranking_preventistas_por_producto.ts";
 import { misVentasTool } from "../_shared/tools/preventista/mis_ventas.ts";
 import { pendientesPagoTool } from "../_shared/tools/admin/pendientes_pago.ts";
 import { historicoPagosClienteTool } from "../_shared/tools/admin/historico_pagos_cliente.ts";
@@ -548,6 +549,7 @@ Deno.test("registerAllTools registra todas las tools esperadas", () => {
   assert(getTool("productos_por_categoria"), "productos_por_categoria no registrada");
   assert(getTool("ventas_periodo"), "ventas_periodo no registrada");
   assert(getTool("ventas_por_preventista"), "ventas_por_preventista no registrada");
+  assert(getTool("ranking_preventistas_por_producto"), "ranking_preventistas_por_producto no registrada");
   assert(getTool("pendientes_pago"), "pendientes_pago no registrada");
   assert(getTool("historico_pagos_cliente"), "historico_pagos_cliente no registrada");
   assert(getTool("compras_periodo"), "compras_periodo no registrada");
@@ -568,6 +570,10 @@ Deno.test("registerAllTools registra todas las tools esperadas", () => {
   assertEquals(getTool("productos_por_categoria"), productosPorCategoriaTool);
   assertEquals(getTool("ventas_periodo"), ventasPeriodoTool);
   assertEquals(getTool("ventas_por_preventista"), ventasPorPreventistaTool);
+  assertEquals(
+    getTool("ranking_preventistas_por_producto"),
+    rankingPreventistasPorProductoTool,
+  );
   assertEquals(getTool("pendientes_pago"), pendientesPagoTool);
   assertEquals(getTool("historico_pagos_cliente"), historicoPagosClienteTool);
   assertEquals(getTool("compras_periodo"), comprasPeriodoTool);
@@ -2145,6 +2151,132 @@ Deno.test("mis_ventas valida fechas y rango", async () => {
   try {
     await misVentasTool.handler(
       { desde: "2026-05-01", hasta: "2026-04-01" },
+      ctx,
+    );
+  } catch (err) {
+    threw++;
+    assertStringIncludes(err instanceof Error ? err.message : "", "desde");
+  }
+  assertEquals(threw, 2);
+});
+
+// ============================================================================
+// 52. ranking_preventistas_por_producto: invoca RPC y mapea ranking
+// ============================================================================
+
+Deno.test("ranking_preventistas_por_producto invoca el RPC y mapea preventistas", async () => {
+  const { client, spy } = createMockSupabase({
+    rpcResponse: {
+      data: {
+        producto_id: 178,
+        producto_codigo: "M00002",
+        producto_nombre: "MANAOS COLA 3000CC X 6",
+        desde: "2026-04-01",
+        hasta: "2026-04-30",
+        unidades_total: 240,
+        facturado_total: "1200000",
+        preventistas_count: 3,
+        preventistas: [
+          {
+            usuario_id: "aaa",
+            nombre: "Christian",
+            rol: "preventista",
+            unidades: 120,
+            facturado: "600000",
+            pedidos_con_producto: 18,
+          },
+          {
+            usuario_id: "bbb",
+            nombre: "Joaquin",
+            rol: "preventista",
+            unidades: 80,
+            facturado: 400000,
+            pedidos_con_producto: 10,
+          },
+          {
+            usuario_id: null,
+            nombre: null,
+            rol: null,
+            unidades: 40,
+            facturado: 200000,
+            pedidos_con_producto: 5,
+          },
+        ],
+      },
+      error: null,
+    },
+  });
+  const ctx = makeCtx(client, { rol: "admin", sucursal_id: 1 });
+  const result = await rankingPreventistasPorProductoTool.handler(
+    {
+      producto_id: 178,
+      desde: "2026-04-01",
+      hasta: "2026-04-30",
+      limit: 10,
+    },
+    ctx,
+  );
+
+  assertEquals(result.producto_id, 178);
+  assertEquals(result.producto_codigo, "M00002");
+  assertEquals(result.producto_nombre, "MANAOS COLA 3000CC X 6");
+  assertEquals(result.unidades_total, 240);
+  assertEquals(result.facturado_total, 1200000);
+  assertEquals(result.preventistas_count, 3);
+  assertEquals(result.preventistas.length, 3);
+  assertEquals(result.preventistas[0].nombre, "Christian");
+  assertEquals(result.preventistas[0].unidades, 120);
+  assertEquals(result.preventistas[1].facturado, 400000);
+  assertEquals(result.preventistas[2].nombre, "(sin asignar)");
+
+  assertEquals(spy.rpcCalls.length, 1);
+  const call = spy.rpcCalls[0];
+  assertEquals(call.fn, "bot_ranking_preventistas_por_producto");
+  assertEquals(call.params.p_producto_id, 178);
+  assertEquals(call.params.p_desde, "2026-04-01");
+  assertEquals(call.params.p_hasta, "2026-04-30");
+  assertEquals(call.params.p_sucursal_id, 1);
+  assertEquals(call.params.p_limit, 10);
+});
+
+Deno.test("ranking_preventistas_por_producto rechaza producto_id <= 0", async () => {
+  const { client } = createMockSupabase({});
+  const ctx = makeCtx(client, { rol: "admin", sucursal_id: 1 });
+  let threw = false;
+  try {
+    await rankingPreventistasPorProductoTool.handler(
+      { producto_id: 0, desde: "2026-04-01", hasta: "2026-04-30" },
+      ctx,
+    );
+  } catch (err) {
+    threw = true;
+    assertStringIncludes(
+      err instanceof Error ? err.message : "",
+      "producto_id",
+    );
+  }
+  assert(threw, "debió rechazar producto_id=0");
+});
+
+Deno.test("ranking_preventistas_por_producto valida fechas y rango", async () => {
+  const { client } = createMockSupabase({});
+  const ctx = makeCtx(client, { rol: "admin", sucursal_id: 1 });
+  let threw = 0;
+  try {
+    await rankingPreventistasPorProductoTool.handler(
+      { producto_id: 1, desde: "ayer", hasta: "2026-04-30" },
+      ctx,
+    );
+  } catch (err) {
+    threw++;
+    assertStringIncludes(
+      err instanceof Error ? err.message : "",
+      "Fechas inválidas",
+    );
+  }
+  try {
+    await rankingPreventistasPorProductoTool.handler(
+      { producto_id: 1, desde: "2026-04-30", hasta: "2026-04-01" },
       ctx,
     );
   } catch (err) {


### PR DESCRIPTION
## Contexto

Iteración 2 del bot. Después del deploy de la #274, audit log mostró dos fallos nuevos:

**Fallo 1 — "última venta al kiosco arquitectura UNT"** (audit log 2026-04-30 13:52):
- `finishReason="STOP"`, `toolCallsCount=0`, `iterations=1`, `totalTokens=5223`
- Distinto al MALFORMED de la iter anterior. El modelo "pensó" 5K tokens y se rindió silenciosamente sin emitir tools ni texto.
- La pregunta requería encadenar `buscar_cliente → historico_pedidos_cliente(limit=1)` — tools que ya existen.

**Fallo 2 — "detalle de productos vendidos por cada preventista"** (audit log 2026-04-30 13:55):
- El bot respondió correctamente "no tengo herramienta para eso".
- La necesidad real era _"quién vendió más Manaos 3000 para darle una bonificación"_ — un ranking enfocado a UN producto, no un dump.

**Improvement 3 — Multi-sucursal**: Agustín y jareiden son admins multi-sucursal pero el bot solo veía la default.

## Summary

### Fix kiosco UNT (silent STOP)
- Prompts admin/encargado/preventista: ejemplos explícitos para "última venta a X" / "qué le vendí a Y" → `buscar_cliente` → `historico_pedidos_cliente(limit=1, dias=180)`.
- `agent.ts` diferencia `STOP+empty` (silent stop) del fallback genérico → mensaje accionable: "No estoy seguro qué consulta hacer. ¿Podés agregar un poco más de contexto?". Audita con `silent_stop=true` para visibilidad.
- **Regla de eficiencia (token budget)** en todos los prompts: pasar `limit=N` exacto cuando el user pide N. No traer 20 si pide 1.

### Top preventistas por producto (gap real)
- **Migration 026** [`bot_ranking_preventistas_por_producto(producto_id, desde, hasta, sucursal, [limit])`](migrations/026_bot_ranking_preventistas_por_producto.sql).
- **Tool** `ranking_preventistas_por_producto` (admin, encargado).
- Por diseño requiere `producto_id` (el modelo lo consigue antes con `buscar_producto`) → output acotado, ningún cross-tab.
- Verificado contra prod: para Sal Fina (id=166) en abril 2026 sucursal 1 → Christian #1 con 510 unidades (22 pedidos), reconcilia con 780 unidades totales por suma directa.

### Multi-sucursal con `/sucursal`
- Comando admin-only: `/sucursal` lista las asignadas vía `usuario_sucursales` con la activa marcada + inline keyboard. `/sucursal <id>` o `<nombre>` switch directo.
- Validación: solo permite switch a sucursales del usuario en `usuario_sucursales`. Persistente: `UPDATE bot_usuarios.sucursal_id`.
- Callback handler `v1:sucursal_switch:N` reusa la misma lógica.
- Prompt nudge en admin: si te piden otra sucursal, decile que use `/sucursal` antes — no inventes.

## Roles & permisos

- `/sucursal`: scope `["admin"]`. Hoy solo Agustín y jareiden son multi-sucursal; el resto del equipo tiene una sola y no necesita el comando. Si en el futuro un encargado pasa a tener varias, ampliar.
- `ranking_preventistas_por_producto`: `["admin", "encargado"]`. Mismo patrón que `ventas_por_preventista`.
- Defense-in-depth en el callback handler: aún si alguien manda crudo el `callback_data`, lo rechaza si el rol ≠ admin.

## Test plan

- [x] `deno task check` ✅
- [x] `deno task lint` ✅ (80 archivos)
- [x] `deno task test` → **155 passed / 0 failed** (8 nuevos: silent_stop, ranking handler + validations + registry-includes, /sucursal sin args + con id válido + con id no asignado + bloqueo por scope para preventista)
- [x] Migration 026 aplicada en prod, RPC verificado contra datos reales
- [ ] **Pendiente**: deploy del edge function `telegram-webhook`
- [ ] Smoke post-deploy:
  - "última venta al kiosco arquitectura UNT" → ahora responde con fecha + monto
  - "quién vendió más Sal Fina este mes" → ranking con Christian primero
  - "Top 3 vendedores de aceite del 1 al 15 de abril" → confirma `limit=3`
  - `/sucursal` → lista con Tucumán (✓) + Taco Pozo
  - Tap en Taco Pozo → "✅ Cambié a Taco Pozo"
  - Después: "ventas de ayer" → totales de Taco Pozo (sucursal 2), no Tucumán
  - Volver a Tucumán al final
- [ ] Audit log check: `silent_stop=true` count debería caer a ~0

🤖 Generated with [Claude Code](https://claude.com/claude-code)