### PR TITLE
feat(bot): agrupar productos en ranking + nunca rechazar en seco

### DIFF
--- a/migrations/027_bot_ranking_preventistas_array.sql
+++ b/migrations/027_bot_ranking_preventistas_array.sql
@@ -1,0 +1,93 @@
+-- Migración 027 — Bot Telegram: ranking de preventistas por GRUPO de productos
+--
+-- Cambio respecto a migration 026: el RPC ahora acepta un ARRAY de productos
+-- en vez de uno solo. Permite agrupar (ej: "Manaos 3000cc" puede matchear
+-- 3 sabores distintos, cada uno con su propio producto_id; el bot los junta
+-- y consulta el ranking agregado).
+--
+-- Diseño:
+--   * El bot encadena: productos_por_categoria("MANAOS", q="3000") → toma
+--     los IDs matcheados → ranking_preventistas_por_producto({producto_ids:[...]})
+--   * Output incluye `productos`: lista con id+codigo+nombre de los productos
+--     considerados, para que el modelo pueda explicar qué incluyó.
+--   * Mantiene el resto de las convenciones (created_at, excluye cancelado/anulado,
+--     SECURITY DEFINER + grant a service_role).
+--
+-- Estrategia para evitar window de incompatibilidad: la migration ALTER
+-- (drop + create con misma name) corre en una transacción. Hay un breve
+-- período entre la apply y el deploy del edge function donde la versión
+-- vieja del bot (que pasa p_producto_id singular) no encuentra la firma.
+-- Aceptable: tráfico de prod durante esta ventana es ~nulo y la firma
+-- vieja era nuestra (deploy de ayer, sin otros consumidores).
+
+DROP FUNCTION IF EXISTS public.bot_ranking_preventistas_por_producto(
+  BIGINT, DATE, DATE, BIGINT, INT
+);
+
+CREATE OR REPLACE FUNCTION public.bot_ranking_preventistas_por_producto(
+  p_producto_ids BIGINT[],
+  p_desde DATE,
+  p_hasta DATE,
+  p_sucursal_id BIGINT,
+  p_limit INT DEFAULT 10
+)
+RETURNS JSON
+LANGUAGE plpgsql STABLE SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE resultado JSON;
+BEGIN
+  WITH ventas_filtradas AS (
+    SELECT p.usuario_id, pi.producto_id, pi.cantidad, pi.subtotal
+    FROM pedidos p
+    JOIN pedido_items pi ON pi.pedido_id = p.id
+    WHERE p.sucursal_id = p_sucursal_id
+      AND p.created_at >= p_desde::TIMESTAMPTZ
+      AND p.created_at < (p_hasta::DATE + 1)::TIMESTAMPTZ
+      AND COALESCE(p.estado, '') NOT IN ('cancelado', 'anulado')
+      AND pi.producto_id = ANY(p_producto_ids)
+  ),
+  por_usuario AS (
+    SELECT
+      v.usuario_id,
+      pf.nombre,
+      pf.rol,
+      SUM(v.cantidad)             AS unidades,
+      SUM(v.subtotal)             AS facturado,
+      COUNT(DISTINCT v.producto_id) AS productos_distintos,
+      COUNT(*)                    AS line_items
+    FROM ventas_filtradas v
+    LEFT JOIN perfiles pf ON pf.id = v.usuario_id
+    GROUP BY v.usuario_id, pf.nombre, pf.rol
+    ORDER BY SUM(v.cantidad) DESC
+    LIMIT p_limit
+  ),
+  productos_info AS (
+    SELECT id, codigo, nombre
+    FROM productos
+    WHERE id = ANY(p_producto_ids)
+    ORDER BY id
+  )
+  SELECT json_build_object(
+    'producto_ids', to_json(p_producto_ids),
+    'productos', COALESCE(
+      (SELECT json_agg(row_to_json(pi.*)) FROM productos_info pi),
+      '[]'::JSON
+    ),
+    'desde', p_desde,
+    'hasta', p_hasta,
+    'unidades_total', (SELECT COALESCE(SUM(cantidad), 0) FROM ventas_filtradas),
+    'facturado_total', (SELECT COALESCE(SUM(subtotal), 0) FROM ventas_filtradas),
+    'preventistas_count', (SELECT COUNT(*) FROM por_usuario),
+    'preventistas', COALESCE(
+      (SELECT json_agg(row_to_json(pu.*)) FROM por_usuario pu),
+      '[]'::JSON
+    )
+  ) INTO resultado;
+  RETURN resultado;
+END;
+$$;
+
+ALTER FUNCTION public.bot_ranking_preventistas_por_producto(BIGINT[], DATE, DATE, BIGINT, INT) OWNER TO postgres;
+REVOKE ALL    ON FUNCTION public.bot_ranking_preventistas_por_producto(BIGINT[], DATE, DATE, BIGINT, INT) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.bot_ranking_preventistas_por_producto(BIGINT[], DATE, DATE, BIGINT, INT) TO service_role;

--- a/supabase/functions/_shared/gemini/prompts/admin.ts
+++ b/supabase/functions/_shared/gemini/prompts/admin.ts
@@ -13,7 +13,7 @@ Tu trabajo es ayudar al admin a:
 - Reportes de ventas y compras en períodos:
   · ventas_periodo(desde, hasta) → total facturado, top productos, top clientes, ticket promedio (sucursal entera).
   · ventas_por_preventista(desde, hasta, [solo_preventistas]) → ranking de ventas por usuario (preventista). Ideal para "quién vendió más", "ventas por preventista", "ventas de ayer por vendedor".
-  · ranking_preventistas_por_producto(producto_id, desde, hasta) → quién vendió más unidades de UN producto puntual en un rango. Útil para bonificaciones, sales contests o "quién vendió más [producto]". Hay que conseguir el producto_id antes con buscar_producto.
+  · ranking_preventistas_por_producto(producto_ids, desde, hasta) → quién vendió más unidades de UNO o VARIOS productos agrupados (ej: "Manaos 3000cc" puede ser varios sabores juntos). Útil para bonificaciones, sales contests o "quién vendió más [producto/familia]". Conseguí los producto_ids antes con buscar_producto o productos_por_categoria.
   · compras_periodo(desde, hasta) → total comprado a proveedores, top proveedores.
 - Cobranzas:
   · pendientes_pago([dias_atraso]) → clientes con pedidos no pagados, ordenados por antigüedad.
@@ -46,15 +46,31 @@ EJEMPLOS:
 
 REGLA DE EFICIENCIA (importante): cuando el usuario pide UN SOLO dato puntual, pasá limit=1. No traigas 20 pedidos si solo te preguntan por uno. Vale para cualquier tool con limit: si te piden "el top 3", pasá limit=3, no 10. Esto ahorra tokens y la respuesta sale antes.
 
-TOP DE PREVENTISTAS POR UN PRODUCTO ESPECÍFICO (preguntas tipo "quién vendió más Manaos 3000", "top vendedores de aceite girasol", "para darle una bonificación al que más vendió X"):
+TOP DE PREVENTISTAS POR PRODUCTO O FAMILIA (preguntas tipo "quién vendió más Manaos 3000", "top vendedores de aceite girasol", "para darle una bonificación al que más vendió X"):
+
+CASO A — UN producto puntual (ej: "quién vendió más sal fina"):
 1. buscar_producto con el nombre/marca/código que dijo el usuario.
-2. Tomá el producto_id del primer match razonable. Si hay variantes (ej: "Manaos cola" matchea cola 600cc y 3000cc), elegí la que el usuario mencionó por tamaño o pedile aclaración.
-3. ranking_preventistas_por_producto(producto_id, desde, hasta, limit) con las fechas del CONTEXTO DE FECHA. Para "este mes", desde=primer_día_del_mes, hasta=hoy.
-4. La respuesta incluye unidades, facturado y pedidos_con_producto por preventista. Resumí el ranking con nombres (no IDs) y mencioná el total general.
-NUNCA inventes producto_id — siempre pasalo después de buscar_producto.
+2. Tomá el producto_id del match más razonable.
+3. ranking_preventistas_por_producto(producto_ids=[id], desde, hasta) con fechas del CONTEXTO DE FECHA.
+
+CASO B — FAMILIA o GRUPO (ej: "Manaos 3000cc" puede ser varios sabores; "aguas saborizadas"; "fideos largos"):
+1. listar_categorias para encontrar la familia (ej: "MANAOS", "AGUAS").
+2. productos_por_categoria(categoria="MANAOS", q="3000") → te devuelve la lista filtrada con todos los matches (ej: Manaos cola 3000, Manaos naranja 3000, Manaos pomelo 3000, cada uno con su id).
+3. Tomá TODOS los producto_id que correspondan al pedido del usuario. Si el usuario fue ambiguo y hay variantes que claramente NO van (ej: "Manaos 3000" no debe incluir 600cc), excluilas.
+4. ranking_preventistas_por_producto(producto_ids=[id1, id2, id3, ...], desde, hasta).
+5. La respuesta incluye \`productos[]\` con los nombres de lo que se contó — mencionalos brevemente al final ("agrupé Manaos cola 3000, Manaos naranja 3000 y Manaos pomelo 3000") así el usuario sabe qué incluiste.
+
+EJEMPLO ("quién vendió más Manaos 3000 este mes"):
+  1. listar_categorias → ves "MANAOS"
+  2. productos_por_categoria(categoria="MANAOS", q="3000") → 3 matches: ids 10, 17, 23
+  3. ranking_preventistas_por_producto(producto_ids=[10, 17, 23], desde="2026-04-01", hasta="2026-04-30")
+  4. Respondés: "🥇 Christian (X uds), 🥈 Joaquin (Y), 🥉 Luis (Z). Agrupé los 3 sabores de Manaos 3000cc."
+
+NUNCA inventes producto_ids — siempre vienen de un buscar_producto o productos_por_categoria previo.
 
 REGLAS:
-1. NUNCA inventes datos. Si no tenés un dato, llamá a la tool apropiada. Si la tool no cubre lo que el usuario pide, decilo claro.
+1. NUNCA inventes datos. Si no tenés un dato, llamá a la tool apropiada.
+1b. NUNCA RECHAZAR EN SECO: si lo que el usuario pide NO encaja con tus tools, JAMÁS contestes solo "no tengo esa herramienta" y te quedes ahí. Siempre ofrecé la tool más cercana entre las que tenés, explicando en una línea qué te daría y qué no. Pensá: si pidió "detalle de productos por preventista" → ofrecé ranking_preventistas_por_producto (decile que es por UN producto puntual o familia, y pediselo). Si pidió "ventas con filtro complejo" → ofrecé ventas_periodo o ventas_por_preventista mencionando qué tenés disponible. Si pidió un cliente que no encontrás → ofrecé buscar por código o por zona. Mostrá el camino concreto, no un menú largo: máximo 1-2 alternativas.
 2. Si una tool falla, decí el motivo en una línea y ofrecé una alternativa concreta.
 3. Hablá en español rioplatense, voseo, conciso. Una respuesta no debe pasar 1500 caracteres salvo que sea un listado largo justificado.
 4. Cuando muestres información de un cliente, usá su nombre, no el ID interno. Los IDs son internos al sistema, los usuarios no los ven en la app.

--- a/supabase/functions/_shared/gemini/prompts/encargado.ts
+++ b/supabase/functions/_shared/gemini/prompts/encargado.ts
@@ -11,7 +11,7 @@ Tu trabajo es ayudar al encargado a:
 - Reportes de ventas y compras de la sucursal:
   · ventas_periodo(desde, hasta) → total facturado, top productos, top clientes (sucursal entera).
   · ventas_por_preventista(desde, hasta, [solo_preventistas]) → ranking de ventas por usuario (preventista).
-  · ranking_preventistas_por_producto(producto_id, desde, hasta) → quién vendió más unidades de UN producto puntual en un rango. Útil para bonificaciones / sales contests.
+  · ranking_preventistas_por_producto(producto_ids, desde, hasta) → quién vendió más unidades de UNO o varios productos agrupados (ej: "Manaos 3000cc" puede ser varios sabores). Útil para bonificaciones / sales contests. Conseguí los producto_ids antes con buscar_producto o productos_por_categoria.
   · compras_periodo(desde, hasta) → total comprado, top proveedores.
 - Cobranzas:
   · pendientes_pago([dias_atraso]) → clientes con pedidos no pagados.
@@ -27,9 +27,12 @@ EJEMPLOS DE INTENT → TOOL (las fechas exactas vienen del bloque CONTEXTO DE FE
 - "qué le compré al proveedor X" → compras_periodo y mirá top_proveedores.
 - "cómo me paga Pepe" → buscar_cliente → historico_pagos_cliente.
 - "última venta al kiosco X" / "cuándo me compró Pepe" → buscar_cliente → historico_pedidos_cliente(cliente_id, limit=1, dias=180).
-- "quién vendió más Manaos 3000 este mes" → buscar_producto → ranking_preventistas_por_producto(producto_id, desde=1ro_mes, hasta=hoy).
+- "quién vendió más sal fina este mes" → buscar_producto → ranking_preventistas_por_producto(producto_ids=[id], desde=1ro_mes, hasta=hoy).
+- "quién vendió más Manaos 3000 este mes" → listar_categorias → productos_por_categoria(categoria="MANAOS", q="3000") → ranking_preventistas_por_producto(producto_ids=[id1, id2, ...]) con TODOS los IDs que matcheen 3000cc. Mencioná al final qué sabores agrupaste.
 
 REGLA DE EFICIENCIA: si te piden UN SOLO dato puntual ("la última venta", "el primer pedido", "el top 3"), pasá limit=N exacto. No traigas 20 si te piden 1.
+
+REGLA "NUNCA RECHAZAR EN SECO": si te piden algo fuera del scope de las tools, JAMÁS digas solo "no tengo esa herramienta". Siempre ofrecé la tool más cercana (1-2 max) explicando en una línea qué te daría y qué no. Mostrá el camino concreto.
 
 REGLAS:
 1. NUNCA inventes datos. Si no tenés un dato, llamá a la tool. Si pide algo fuera del scope (ver otra sucursal, cambiar precios), decilo claro.

--- a/supabase/functions/_shared/gemini/prompts/preventista.ts
+++ b/supabase/functions/_shared/gemini/prompts/preventista.ts
@@ -30,6 +30,7 @@ REGLA DE EFICIENCIA: si te piden UN SOLO dato puntual ("la última venta", "el �
 
 REGLAS:
 1. NUNCA inventes datos. Si no tenés un dato, llamá a la tool. Si la tool devuelve "no encontrado o sin permiso", decí literalmente que el cliente no figura entre los suyos y sugerí contactar al encargado.
+1b. NUNCA RECHAZAR EN SECO: si te piden algo que NO podés resolver con tus tools, JAMÁS digas solo "no tengo esa herramienta" y te quedes ahí. Siempre ofrecé la alternativa más cercana en 1 línea. Por ejemplo: si te piden "cuántas Manaos vendí" → ofrecé mis_ventas (te da el total y top clientes) o productos_recurrentes_cliente para uno puntual. Si te piden "ranking de mis productos" → mencioná que solo podés ver recurrencia por cliente puntual con productos_recurrentes_cliente. Mostrá el camino concreto.
 2. Si una tool falla, decí el motivo y ofrecé alternativa concreta (ej: "no pude abrir la ficha, probá con /cliente <código>").
 3. Hablá en español rioplatense, voseo, conciso. Las respuestas deben ser breves — el preventista las lee en la calle, en el celular.
 4. Usá el nombre del cliente, NUNCA el ID interno.

--- a/supabase/functions/_shared/tools/admin/ranking_preventistas_por_producto.ts
+++ b/supabase/functions/_shared/tools/admin/ranking_preventistas_por_producto.ts
@@ -1,20 +1,29 @@
 // Tool: ranking_preventistas_por_producto
 //
-// Top de preventistas que más vendieron UN producto puntual en un rango de
-// fechas. Pensada para preguntas de bonificación / sales contest tipo
-// "quién vendió más Manaos 3000 este mes". El modelo debe conseguir el
-// producto_id antes con buscar_producto — esta tool no acepta búsqueda
-// libre por nombre, mantiene el output acotado.
+// Top de preventistas que más vendieron uno o varios productos puntuales en
+// un rango de fechas. Acepta un ARRAY de producto_ids para que el modelo
+// pueda agrupar productos relacionados (ej: "Manaos 3000cc" puede matchear
+// 3 sabores distintos cada uno con su producto_id propio).
 //
-// Delega a la RPC bot_ranking_preventistas_por_producto (migration 026).
-// Mismas convenciones de fecha/estado que ventas_periodo y ventas_por_preventista
-// (filtro por created_at, excluye cancelado/anulado, scoping por sucursal).
+// El modelo encadena:
+//   1. productos_por_categoria("MANAOS", q="3000") → lista de matches
+//   2. Toma los producto_id que correspondan al pedido del usuario
+//   3. ranking_preventistas_por_producto({ producto_ids: [10, 17, 23], ... })
+//
+// Output incluye `productos[]` con id+codigo+nombre de cada uno para que el
+// modelo pueda explicar qué incluyó (auditable y transparente).
+//
+// Delega a la RPC bot_ranking_preventistas_por_producto (migration 027 —
+// reemplazó la firma escalar de la migration 026).
 
 import type { Tool } from "../base.ts";
 
 export interface RankingPreventistasPorProductoParams {
-  /** ID del producto (sacar antes con buscar_producto). */
-  producto_id: number;
+  /**
+   * IDs de los productos a agrupar. Mínimo 1, máximo 25. Conseguilos antes
+   * con buscar_producto o productos_por_categoria.
+   */
+  producto_ids: number[];
   /** Fecha inicio inclusive (YYYY-MM-DD). */
   desde: string;
   /** Fecha fin inclusive (YYYY-MM-DD). */
@@ -24,9 +33,12 @@ export interface RankingPreventistasPorProductoParams {
 }
 
 export interface RankingPreventistasPorProductoResult {
-  producto_id: number;
-  producto_codigo: string | null;
-  producto_nombre: string | null;
+  producto_ids: number[];
+  productos: Array<{
+    id: number;
+    codigo: string | null;
+    nombre: string;
+  }>;
   desde: string;
   hasta: string;
   unidades_total: number;
@@ -38,7 +50,8 @@ export interface RankingPreventistasPorProductoResult {
     rol: string | null;
     unidades: number;
     facturado: number;
-    pedidos_con_producto: number;
+    productos_distintos: number;
+    line_items: number;
   }>;
 }
 
@@ -50,20 +63,27 @@ export const rankingPreventistasPorProductoTool: Tool<
 > = {
   name: "ranking_preventistas_por_producto",
   description:
-    "Ranking de preventistas que más vendieron UN producto específico en " +
-    "un rango de fechas (admin/encargado). Útil para 'quién vendió más " +
-    "[producto]', 'top vendedores de [producto] del mes', bonificaciones " +
-    "por sales contest. Requiere producto_id — conseguilo antes con " +
-    "buscar_producto. Devuelve unidades + facturado + cantidad de pedidos " +
-    "con el producto, por preventista, ordenado por unidades. Filtra por " +
-    "sucursal del bot user. Excluye pedidos cancelados/anulados.",
+    "Ranking de preventistas que más vendieron UN producto o un GRUPO de " +
+    "productos relacionados en un rango de fechas (admin/encargado). Útil " +
+    "para 'quién vendió más [producto]', 'top vendedores de [familia]', " +
+    "bonificaciones por sales contest. Aceptá un array de producto_ids: si " +
+    "el usuario pide algo agregable (ej: 'Manaos 3000cc' puede ser varios " +
+    "sabores), conseguí los IDs antes con productos_por_categoria y pasalos " +
+    "todos juntos. La respuesta agrupa unidades + facturado por preventista " +
+    "y devuelve la lista de productos considerados. Filtra por sucursal del " +
+    "bot user. Excluye pedidos cancelados/anulados.",
   parameters: {
     type: "object",
     properties: {
-      producto_id: {
-        type: "integer",
-        minimum: 1,
-        description: "ID interno del producto. Conseguilo con buscar_producto antes.",
+      producto_ids: {
+        type: "array",
+        items: { type: "integer", minimum: 1 },
+        minItems: 1,
+        maxItems: 25,
+        description:
+          "Lista de IDs de productos a agrupar. Min 1, max 25. " +
+          "Para UN solo producto pasá [id]. Para una familia (ej: 'Manaos 3000') " +
+          "pasá los IDs que matcheen tras buscar con productos_por_categoria.",
       },
       desde: {
         type: "string",
@@ -80,12 +100,20 @@ export const rankingPreventistasPorProductoTool: Tool<
         description: "Top N preventistas (default 10, max 25).",
       },
     },
-    required: ["producto_id", "desde", "hasta"],
+    required: ["producto_ids", "desde", "hasta"],
   },
   allowedRoles: ["admin", "encargado"],
-  handler: async ({ producto_id, desde, hasta, limit = 10 }, ctx) => {
-    if (!Number.isInteger(producto_id) || producto_id < 1) {
-      throw new Error("producto_id inválido (entero > 0)");
+  handler: async ({ producto_ids, desde, hasta, limit = 10 }, ctx) => {
+    if (!Array.isArray(producto_ids) || producto_ids.length === 0) {
+      throw new Error("producto_ids debe tener al menos 1 ID");
+    }
+    if (producto_ids.length > 25) {
+      throw new Error("producto_ids no puede tener más de 25 IDs");
+    }
+    for (const pid of producto_ids) {
+      if (!Number.isInteger(pid) || pid < 1) {
+        throw new Error("producto_ids contiene un ID inválido (debe ser entero > 0)");
+      }
     }
     if (!FECHA_REGEX.test(desde) || !FECHA_REGEX.test(hasta)) {
       throw new Error("Fechas inválidas (esperado YYYY-MM-DD)");
@@ -103,7 +131,7 @@ export const rankingPreventistasPorProductoTool: Tool<
     const { data, error } = await ctx.supabase.rpc(
       "bot_ranking_preventistas_por_producto",
       {
-        p_producto_id: producto_id,
+        p_producto_ids: producto_ids,
         p_desde: desde,
         p_hasta: hasta,
         p_sucursal_id: ctx.sucursal_id,
@@ -121,12 +149,17 @@ export const rankingPreventistasPorProductoTool: Tool<
       rol: string | null;
       unidades: number | string;
       facturado: number | string;
-      pedidos_con_producto: number;
+      productos_distintos: number;
+      line_items: number;
+    };
+    type RpcProducto = {
+      id: number;
+      codigo: string | null;
+      nombre: string | null;
     };
     const r = data as {
-      producto_id: number;
-      producto_codigo: string | null;
-      producto_nombre: string | null;
+      producto_ids: number[];
+      productos: RpcProducto[];
       desde: string;
       hasta: string;
       unidades_total: number | string;
@@ -136,9 +169,12 @@ export const rankingPreventistasPorProductoTool: Tool<
     };
 
     return {
-      producto_id: Number(r.producto_id),
-      producto_codigo: r.producto_codigo ?? null,
-      producto_nombre: r.producto_nombre ?? null,
+      producto_ids: r.producto_ids ?? producto_ids,
+      productos: (r.productos ?? []).map((p) => ({
+        id: Number(p.id),
+        codigo: p.codigo ?? null,
+        nombre: p.nombre?.trim() || "(sin nombre)",
+      })),
       desde: r.desde,
       hasta: r.hasta,
       unidades_total: Number(r.unidades_total ?? 0),
@@ -150,7 +186,8 @@ export const rankingPreventistasPorProductoTool: Tool<
         rol: p.rol ?? null,
         unidades: Number(p.unidades ?? 0),
         facturado: Number(p.facturado ?? 0),
-        pedidos_con_producto: Number(p.pedidos_con_producto ?? 0),
+        productos_distintos: Number(p.productos_distintos ?? 0),
+        line_items: Number(p.line_items ?? 0),
       })),
     };
   },

--- a/supabase/functions/tests/tools.test.ts
+++ b/supabase/functions/tests/tools.test.ts
@@ -2161,16 +2161,19 @@ Deno.test("mis_ventas valida fechas y rango", async () => {
 });
 
 // ============================================================================
-// 52. ranking_preventistas_por_producto: invoca RPC y mapea ranking
+// 52. ranking_preventistas_por_producto: invoca RPC con producto_ids array
 // ============================================================================
 
-Deno.test("ranking_preventistas_por_producto invoca el RPC y mapea preventistas", async () => {
+Deno.test("ranking_preventistas_por_producto invoca el RPC con producto_ids array y mapea ranking agregado", async () => {
   const { client, spy } = createMockSupabase({
     rpcResponse: {
       data: {
-        producto_id: 178,
-        producto_codigo: "M00002",
-        producto_nombre: "MANAOS COLA 3000CC X 6",
+        producto_ids: [10, 17, 23],
+        productos: [
+          { id: 10, codigo: "M0010", nombre: "MANAOS COLA 3000CC X 6" },
+          { id: 17, codigo: "M0017", nombre: "MANAOS NARANJA 3000CC X 6" },
+          { id: 23, codigo: "M0023", nombre: "MANAOS POMELO 3000CC X 6" },
+        ],
         desde: "2026-04-01",
         hasta: "2026-04-30",
         unidades_total: 240,
@@ -2183,7 +2186,8 @@ Deno.test("ranking_preventistas_por_producto invoca el RPC y mapea preventistas"
             rol: "preventista",
             unidades: 120,
             facturado: "600000",
-            pedidos_con_producto: 18,
+            productos_distintos: 3,
+            line_items: 18,
           },
           {
             usuario_id: "bbb",
@@ -2191,7 +2195,8 @@ Deno.test("ranking_preventistas_por_producto invoca el RPC y mapea preventistas"
             rol: "preventista",
             unidades: 80,
             facturado: 400000,
-            pedidos_con_producto: 10,
+            productos_distintos: 2,
+            line_items: 10,
           },
           {
             usuario_id: null,
@@ -2199,7 +2204,8 @@ Deno.test("ranking_preventistas_por_producto invoca el RPC y mapea preventistas"
             rol: null,
             unidades: 40,
             facturado: 200000,
-            pedidos_con_producto: 5,
+            productos_distintos: 1,
+            line_items: 5,
           },
         ],
       },
@@ -2209,7 +2215,7 @@ Deno.test("ranking_preventistas_por_producto invoca el RPC y mapea preventistas"
   const ctx = makeCtx(client, { rol: "admin", sucursal_id: 1 });
   const result = await rankingPreventistasPorProductoTool.handler(
     {
-      producto_id: 178,
+      producto_ids: [10, 17, 23],
       desde: "2026-04-01",
       hasta: "2026-04-30",
       limit: 10,
@@ -2217,45 +2223,120 @@ Deno.test("ranking_preventistas_por_producto invoca el RPC y mapea preventistas"
     ctx,
   );
 
-  assertEquals(result.producto_id, 178);
-  assertEquals(result.producto_codigo, "M00002");
-  assertEquals(result.producto_nombre, "MANAOS COLA 3000CC X 6");
+  assertEquals(result.producto_ids, [10, 17, 23]);
+  assertEquals(result.productos.length, 3);
+  assertEquals(result.productos[0].nombre, "MANAOS COLA 3000CC X 6");
   assertEquals(result.unidades_total, 240);
   assertEquals(result.facturado_total, 1200000);
   assertEquals(result.preventistas_count, 3);
   assertEquals(result.preventistas.length, 3);
   assertEquals(result.preventistas[0].nombre, "Christian");
   assertEquals(result.preventistas[0].unidades, 120);
-  assertEquals(result.preventistas[1].facturado, 400000);
+  assertEquals(result.preventistas[0].productos_distintos, 3);
+  assertEquals(result.preventistas[1].line_items, 10);
   assertEquals(result.preventistas[2].nombre, "(sin asignar)");
 
   assertEquals(spy.rpcCalls.length, 1);
   const call = spy.rpcCalls[0];
   assertEquals(call.fn, "bot_ranking_preventistas_por_producto");
-  assertEquals(call.params.p_producto_id, 178);
+  assertEquals(call.params.p_producto_ids, [10, 17, 23]);
   assertEquals(call.params.p_desde, "2026-04-01");
   assertEquals(call.params.p_hasta, "2026-04-30");
   assertEquals(call.params.p_sucursal_id, 1);
   assertEquals(call.params.p_limit, 10);
 });
 
-Deno.test("ranking_preventistas_por_producto rechaza producto_id <= 0", async () => {
+Deno.test("ranking_preventistas_por_producto acepta un solo producto_id en el array", async () => {
+  const { client, spy } = createMockSupabase({
+    rpcResponse: {
+      data: {
+        producto_ids: [166],
+        productos: [{ id: 166, codigo: "SAL01", nombre: "SAL FINA X 500 GRS" }],
+        desde: "2026-04-01",
+        hasta: "2026-04-30",
+        unidades_total: 780,
+        facturado_total: 160200,
+        preventistas_count: 1,
+        preventistas: [
+          {
+            usuario_id: "aaa",
+            nombre: "Christian",
+            rol: "preventista",
+            unidades: 510,
+            facturado: 104700,
+            productos_distintos: 1,
+            line_items: 22,
+          },
+        ],
+      },
+      error: null,
+    },
+  });
+  const ctx = makeCtx(client, { rol: "admin", sucursal_id: 1 });
+  const result = await rankingPreventistasPorProductoTool.handler(
+    { producto_ids: [166], desde: "2026-04-01", hasta: "2026-04-30" },
+    ctx,
+  );
+  assertEquals(result.producto_ids, [166]);
+  assertEquals(spy.rpcCalls[0].params.p_producto_ids, [166]);
+});
+
+Deno.test("ranking_preventistas_por_producto rechaza array vacío", async () => {
   const { client } = createMockSupabase({});
   const ctx = makeCtx(client, { rol: "admin", sucursal_id: 1 });
   let threw = false;
   try {
     await rankingPreventistasPorProductoTool.handler(
-      { producto_id: 0, desde: "2026-04-01", hasta: "2026-04-30" },
+      { producto_ids: [], desde: "2026-04-01", hasta: "2026-04-30" },
       ctx,
     );
   } catch (err) {
     threw = true;
     assertStringIncludes(
       err instanceof Error ? err.message : "",
-      "producto_id",
+      "al menos 1",
     );
   }
-  assert(threw, "debió rechazar producto_id=0");
+  assert(threw, "debió rechazar array vacío");
+});
+
+Deno.test("ranking_preventistas_por_producto rechaza array con ID inválido", async () => {
+  const { client } = createMockSupabase({});
+  const ctx = makeCtx(client, { rol: "admin", sucursal_id: 1 });
+  let threw = false;
+  try {
+    await rankingPreventistasPorProductoTool.handler(
+      { producto_ids: [10, 0, 23], desde: "2026-04-01", hasta: "2026-04-30" },
+      ctx,
+    );
+  } catch (err) {
+    threw = true;
+    assertStringIncludes(
+      err instanceof Error ? err.message : "",
+      "ID inválido",
+    );
+  }
+  assert(threw, "debió rechazar ID 0");
+});
+
+Deno.test("ranking_preventistas_por_producto rechaza array de >25 elementos", async () => {
+  const { client } = createMockSupabase({});
+  const ctx = makeCtx(client, { rol: "admin", sucursal_id: 1 });
+  const big = Array.from({ length: 26 }, (_, i) => i + 1);
+  let threw = false;
+  try {
+    await rankingPreventistasPorProductoTool.handler(
+      { producto_ids: big, desde: "2026-04-01", hasta: "2026-04-30" },
+      ctx,
+    );
+  } catch (err) {
+    threw = true;
+    assertStringIncludes(
+      err instanceof Error ? err.message : "",
+      "más de 25",
+    );
+  }
+  assert(threw, "debió rechazar array > 25");
 });
 
 Deno.test("ranking_preventistas_por_producto valida fechas y rango", async () => {
@@ -2264,7 +2345,7 @@ Deno.test("ranking_preventistas_por_producto valida fechas y rango", async () =>
   let threw = 0;
   try {
     await rankingPreventistasPorProductoTool.handler(
-      { producto_id: 1, desde: "ayer", hasta: "2026-04-30" },
+      { producto_ids: [1], desde: "ayer", hasta: "2026-04-30" },
       ctx,
     );
   } catch (err) {
@@ -2276,7 +2357,7 @@ Deno.test("ranking_preventistas_por_producto valida fechas y rango", async () =>
   }
   try {
     await rankingPreventistasPorProductoTool.handler(
-      { producto_id: 1, desde: "2026-04-30", hasta: "2026-04-01" },
+      { producto_ids: [1], desde: "2026-04-30", hasta: "2026-04-01" },
       ctx,
     );
   } catch (err) {


### PR DESCRIPTION
## Contexto

Iteración 3. Smoke test post-#275 reveló dos cosas:

1. **"Quién vendió más Manaos 3000cc"** funcionaba pero con un solo \`producto_id\`. Manaos 3000cc es una FAMILIA — varios sabores (cola, naranja, pomelo, etc.) cada uno con su id. El ranking quedaba parcial.

2. Cuando el bot recibía algo fuera de scope (ej: "detalle de productos por preventista"), respondía "no tengo esa herramienta" y se quedaba ahí. El usuario quería que SIEMPRE ofrezca la alternativa más cercana.

## Summary

### 1. Agrupar productos en \`ranking_preventistas_por_producto\`

- **Migration 027** reemplaza la firma escalar de la 026: ahora es \`bot_ranking_preventistas_por_producto(p_producto_ids BIGINT[], ...)\`.
- **Tool wrapper** ahora pide \`producto_ids: number[]\` (1-25, validados como enteros >0).
- **El modelo encadena**: \`listar_categorias\` → \`productos_por_categoria(\"MANAOS\", q=\"3000\")\` → tomar todos los IDs que matcheen → \`ranking_preventistas_por_producto({ producto_ids: [78, 79, 80, 81, 82, 83, 178, 183, 185, 187, 189, 198, 199] })\`.
- **Output** incluye \`productos[]\` con id+codigo+nombre de los productos considerados — para que el bot pueda explicar qué agrupó (auditabilidad).
- **Por preventista**: además de unidades+facturado, ahora devuelve \`productos_distintos\` (cuántos sabores/variantes vendió cada uno) y \`line_items\` (cantidad de items en pedidos).
- **Verificado contra prod** abril 2026 sucursal 1: 191 unidades totales, Christian #1 con 113 uds de 6 sabores distintos.

### 2. Regla "nunca rechazar en seco"

Una sola regla agregada a los 3 prompts (admin/encargado/preventista):

> Si lo que pide el usuario NO encaja con tus tools, JAMÁS contestes solo \"no tengo esa herramienta\". Siempre ofrecé la tool más cercana (1-2 max) explicando qué te daría y qué no. Mostrá el camino concreto, no un menú largo.

Ejemplos esperados después del deploy:

> ❌ Antes: \"No tengo una herramienta para ver qué productos vendió cada preventista individualmente.\"
> ✅ Ahora: \"No tengo el detalle completo por preventista, pero te puedo dar el ranking para UN producto/familia con \`ranking_preventistas_por_producto\`. Decime qué producto querés.\"

## Test plan

- [x] \`deno task check\` ✅
- [x] \`deno task lint\` ✅ (80 archivos)
- [x] \`deno task test\` → **158 passed / 0 failed** (5 tests nuevos: array vacío, ID inválido, >25 elementos, single-id, mapping del nuevo shape).
- [x] Migration 027 aplicada en prod (drop + create de la firma).
- [x] RPC verificado contra datos reales: \`bot_ranking_preventistas_por_producto(ARRAY[78,79,80,81,82,83,178,183,185,187,189,198,199], '2026-04-01', '2026-04-30', 1, 10)\` → 191 uds totales, Christian 113/6sabores, Joaquin 46, Luis 16, Virginia H 16.
- [ ] Deploy v16 del edge function (en flight).
- [ ] Smoke post-deploy:
  - \"quién vendió más Manaos 3000 este mes\" → debe encadenar \`productos_por_categoria\` y mostrar el ranking agregado mencionando los sabores incluidos
  - \"detalle de productos por preventista\" → debe ofrecer \`ranking_preventistas_por_producto\` como alternativa
  - \"quién vendió más sal fina este mes\" (single product) → debe seguir funcionando: \`buscar_producto\` → \`ranking({ producto_ids: [166] })\`

## Riesgo de la migración

Drop + create cambia la firma. Hay una ventana de ~30 segundos entre apply y deploy donde el bot v15 manda \`p_producto_id\` y el RPC ya no existe → user ve un error técnico. Aceptable porque:
- La firma anterior se deployó hace 1 día, sin otros consumidores.
- Tráfico durante la ventana es ~nulo (yo soy el único usuario activo del bot ahora).
- Después del deploy de v16 todo va a los rieles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)