### PR TITLE
fix(salvedades): no permitir registrar salvedad sobre items de promocion

### DIFF
--- a/src/components/modals/ModalEntregaConSalvedad.tsx
+++ b/src/components/modals/ModalEntregaConSalvedad.tsx
@@ -4,7 +4,7 @@
  * Validación con Zod
  */
 import React, { useState, useCallback } from 'react'
-import { X, AlertTriangle, Package, Check, ChevronDown, ChevronUp, Truck } from 'lucide-react'
+import { X, AlertTriangle, Package, Check, ChevronDown, ChevronUp, Truck, Gift } from 'lucide-react'
 import { MOTIVOS_SALVEDAD_LABELS } from '../../lib/schemas'
 import type { PedidoDB, PedidoItemDB, MotivoSalvedad, RegistrarSalvedadInput, RegistrarSalvedadResult } from '../../types'
 
@@ -63,9 +63,13 @@ export default function ModalEntregaConSalvedad({
   const itemsSinProblemas = itemsSalvedad.filter(i => !i.seleccionado)
 
   const toggleItem = useCallback((itemId: string) => {
-    setItemsSalvedad(prev => prev.map(i =>
-      i.item.id === itemId ? { ...i, seleccionado: !i.seleccionado } : i
-    ))
+    setItemsSalvedad(prev => {
+      const target = prev.find(i => i.item.id === itemId)
+      if (target?.item.es_bonificacion) return prev
+      return prev.map(i =>
+        i.item.id === itemId ? { ...i, seleccionado: !i.seleccionado } : i
+      )
+    })
     setExpandido(prev => prev === itemId ? null : itemId)
   }, [])
 
@@ -187,6 +191,34 @@ export default function ModalEntregaConSalvedad({
               <div className="space-y-2">
                 {itemsSalvedad.map(itemSalv => {
                   const isExpanded = expandido === itemSalv.item.id
+                  const esRegalo = itemSalv.item.es_bonificacion === true
+
+                  if (esRegalo) {
+                    return (
+                      <div
+                        key={itemSalv.item.id}
+                        className="border rounded-lg overflow-hidden border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800/40 opacity-75"
+                      >
+                        <div className="flex items-center gap-3 p-3">
+                          <Gift className="w-5 h-5 text-emerald-500 shrink-0" />
+                          <div className="flex-1 min-w-0">
+                            <p className="font-medium text-gray-700 dark:text-gray-200 truncate">
+                              {itemSalv.item.producto?.nombre || 'Producto'}
+                            </p>
+                            <p className="text-xs text-gray-500 dark:text-gray-400">
+                              Regalo por promocion - se ajusta automaticamente
+                            </p>
+                          </div>
+                          <div className="text-right shrink-0">
+                            <p className="text-sm text-gray-500">
+                              {itemSalv.item.cantidad} ud.
+                            </p>
+                          </div>
+                        </div>
+                      </div>
+                    )
+                  }
+
                   return (
                     <div
                       key={itemSalv.item.id}


### PR DESCRIPTION
## Summary

- Una transportista reporto error "Error al registrar 1 salvedad(es): Item de pedido no encontrado" al intentar registrar salvedades en el pedido #1330 (Kiosco Gladys), que tenia la promo 3+1 (3 fardos Manaos 3000cc → 1 fardo Lima Limon de regalo).
- **Root cause**: el RPC `registrar_salvedad` ([migrations/010_registrar_salvedad_resync_promos.sql](migrations/010_registrar_salvedad_resync_promos.sql)) ya elimina automaticamente las lineas de bonificacion del pedido cuando los items disparadores no se entregan (resync de promos, lineas 122-195). Si el transportista marca tambien el regalo como salvedad, al procesarse esa salvedad la fila ya fue borrada por la salvedad anterior → "Item de pedido no encontrado".
- **Fix**: el modal de entrega con salvedad muestra los items con `es_bonificacion = true` como tarjetas informativas (no clickeables) con la leyenda "Regalo por promocion - se ajusta automaticamente". `toggleItem` tiene un guard defensivo. Sin cambios en backend/RPC/migrations.

## Test plan

- [ ] **Reproducir el bug en `main`**: crear un pedido con la promo 3+1 activa, al menos 3 fardos Manaos 3000cc disparadores y 1 regalo Lima Limon. Pasar a transportista, abrir modal "Entrega con salvedad", marcar los 3 disparadores y tambien el regalo como `cliente_rechaza`. Confirmar → debe aparecer "Error al registrar 1 salvedad(es): Item de pedido no encontrado".
- [ ] **Verificar fix en esta rama**: mismo escenario; el regalo Lima Limon aparece en gris con icono de regalo y leyenda "Regalo por promocion - se ajusta automaticamente", **sin checkbox y no expandible**. Marcar los 3 disparadores y confirmar → no aparece error, pedido pasa a `entregado`.
- [ ] **Verificar BD post-fix**: en `pedido_items` solo queda el item no-promocional (Agua); en `salvedades_items` hay 2 filas (Cola y Granadina), ninguna sobre el regalo; `pedidos.total` recalculado al subtotal del item no-promocional; `productos.stock` del Lima Limon incrementado en 1; `promociones.usos_pendientes` decrementado en 1.
- [ ] **Caso "promo se mantiene"**: pedido con 5 fardos disparadores → 1 regalo. Marcar salvedad sobre 1 disparador (siguen 4 ≥ 3, promo se cumple). Verificar que el regalo NO se elimina y el modal lo sigue mostrando deshabilitado.
- [ ] **No-regresion**: pedido sin promo, todos los items siguen siendo seleccionables y el flujo normal funciona igual.

🤖 Generated with [Claude Code](https://claude.com/claude-code)