### PR TITLE
feat(bot): preventistas ven asignados + huérfanos (pre-rollout)

### DIFF
--- a/migrations/028_bot_clientes_huerfanos_visibles.sql
+++ b/migrations/028_bot_clientes_huerfanos_visibles.sql
@@ -1,0 +1,193 @@
+-- Migración 028 — Bot Telegram: preventistas pueden consultar clientes huérfanos
+--
+-- Regla nueva (decisión de negocio): un preventista, desde el bot, puede ver
+-- los clientes que:
+--   (a) están asignados a él en cliente_preventistas, O
+--   (b) NO están asignados a NINGÚN preventista (huérfanos).
+--
+-- NO puede ver clientes asignados a OTRO preventista.
+--
+-- Motivo: en la práctica los preventistas venden a clientes de paso o sin
+-- asignación formal (snapshot real: Christian vendió a 89 clientes en abril,
+-- solo 3 figuran en cliente_preventistas). Sin esta regla el bot diría
+-- "Cliente no asignado a este preventista" para 86 de esos 89, lo que
+-- rompe la UX. La data muestra 401 huérfanos vs 26 asignados — casi todo
+-- el universo es huérfano.
+--
+-- Cambios solo en RPCs (no toca tablas ni constraints):
+--   * bot_buscar_cliente            → amplía la cláusula EXISTS de cliente_preventistas
+--   * bot_historico_pedidos_cliente → idem en el guard inicial
+--   * bot_productos_recurrentes_cliente → idem
+--
+-- IMPORTANTE — `bot_mis_clientes` y `bot_sugerir_visitas_rfm` NO cambian:
+-- siguen mostrando solo los asignados (su "cartera"). El preventista PUEDE
+-- consultar un huérfano si pregunta por él, pero NO aparece en la lista
+-- automática de su cartera. Es la separación correcta: lookup vs cartera.
+
+CREATE OR REPLACE FUNCTION public.bot_buscar_cliente(
+  p_q          text,
+  p_perfil_id  uuid,
+  p_rol        text,
+  p_sucursal_id bigint,
+  p_limit      integer DEFAULT 10
+)
+RETURNS TABLE(
+  id bigint, codigo integer, nombre_fantasia text, razon_social text,
+  saldo_cuenta numeric, direccion text, zona text, sucursal_id bigint
+)
+LANGUAGE sql STABLE SECURITY DEFINER
+SET search_path = public
+AS $$
+  WITH terms AS (
+    SELECT array_remove(
+      string_to_array(
+        trim(lower(f_unaccent(coalesce(p_q, '')))),
+        ' '
+      ),
+      ''
+    ) AS words
+  )
+  SELECT
+    c.id, c.codigo, c.nombre_fantasia, c.razon_social, c.saldo_cuenta,
+    c.direccion, c.zona, c.sucursal_id
+  FROM clientes c, terms t
+  WHERE
+    c.sucursal_id = p_sucursal_id
+    AND (
+      p_rol = 'admin'
+      OR EXISTS(
+        SELECT 1 FROM cliente_preventistas cp
+        WHERE cp.cliente_id = c.id AND cp.preventista_id = p_perfil_id
+      )
+      -- Nuevo: huérfanos (sin asignación a ningún preventista) son visibles
+      -- para cualquier preventista de la misma sucursal.
+      OR NOT EXISTS(
+        SELECT 1 FROM cliente_preventistas cp WHERE cp.cliente_id = c.id
+      )
+    )
+    AND (
+      array_length(t.words, 1) IS NULL
+      OR (
+        SELECT bool_and(
+          lower(f_unaccent(coalesce(c.nombre_fantasia, ''))) LIKE '%' || w || '%'
+          OR lower(f_unaccent(coalesce(c.razon_social, ''))) LIKE '%' || w || '%'
+          OR lower(coalesce(c.codigo::TEXT, '')) LIKE '%' || w || '%'
+        )
+        FROM unnest(t.words) AS w
+      )
+    )
+  ORDER BY c.nombre_fantasia
+  LIMIT p_limit;
+$$;
+
+CREATE OR REPLACE FUNCTION public.bot_historico_pedidos_cliente(
+  p_cliente_id  bigint,
+  p_perfil_id   uuid,
+  p_rol         text,
+  p_sucursal_id bigint,
+  p_dias        integer DEFAULT 90,
+  p_limit       integer DEFAULT 20
+)
+RETURNS json
+LANGUAGE plpgsql STABLE SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE resultado JSON;
+BEGIN
+  -- Gate: si es preventista, debe estar asignado a este cliente O el cliente
+  -- debe ser huérfano (sin asignación a ningún preventista). Asignados a otro
+  -- preventista quedan bloqueados.
+  IF p_rol = 'preventista' THEN
+    IF NOT (
+      EXISTS(SELECT 1 FROM cliente_preventistas
+             WHERE cliente_id = p_cliente_id AND preventista_id = p_perfil_id)
+      OR NOT EXISTS(SELECT 1 FROM cliente_preventistas
+                    WHERE cliente_id = p_cliente_id)
+    ) THEN
+      RETURN json_build_object('cliente_id', p_cliente_id, 'pedidos_count', 0,
+        'pedidos', '[]'::JSON, 'error', 'Cliente asignado a otro preventista');
+    END IF;
+  END IF;
+
+  WITH ultimos_pedidos AS (
+    SELECT id, fecha, total, estado, estado_pago, created_at
+    FROM pedidos
+    WHERE cliente_id = p_cliente_id AND sucursal_id = p_sucursal_id
+      AND created_at > now() - (p_dias || ' days')::INTERVAL
+      AND COALESCE(estado, '') NOT IN ('cancelado', 'anulado')
+    ORDER BY created_at DESC LIMIT p_limit
+  ),
+  pedidos_con_items AS (
+    SELECT up.id, up.fecha, up.total, up.estado, up.estado_pago, up.created_at,
+      (SELECT json_agg(json_build_object('producto_id', p.id, 'codigo', p.codigo,
+        'nombre', p.nombre, 'cantidad', pi.cantidad, 'subtotal', pi.subtotal)
+        ORDER BY pi.subtotal DESC)
+       FROM pedido_items pi JOIN productos p ON p.id = pi.producto_id
+       WHERE pi.pedido_id = up.id) AS items
+    FROM ultimos_pedidos up
+  )
+  SELECT json_build_object(
+    'cliente_id', p_cliente_id,
+    'pedidos_count', (SELECT COUNT(*) FROM pedidos_con_items),
+    'rango_dias', p_dias,
+    'total_periodo', (SELECT COALESCE(SUM(total), 0) FROM pedidos_con_items),
+    'pedidos', COALESCE(
+      (SELECT json_agg(row_to_json(p.*) ORDER BY p.created_at DESC) FROM pedidos_con_items p),
+      '[]'::JSON
+    )
+  ) INTO resultado;
+  RETURN resultado;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.bot_productos_recurrentes_cliente(
+  p_cliente_id  bigint,
+  p_perfil_id   uuid,
+  p_rol         text,
+  p_sucursal_id bigint,
+  p_dias        integer DEFAULT 90,
+  p_limit       integer DEFAULT 10
+)
+RETURNS json
+LANGUAGE plpgsql STABLE SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE resultado JSON;
+BEGIN
+  -- Mismo gate que historico_pedidos_cliente: asignado a mí o huérfano.
+  IF p_rol = 'preventista' THEN
+    IF NOT (
+      EXISTS(SELECT 1 FROM cliente_preventistas
+             WHERE cliente_id = p_cliente_id AND preventista_id = p_perfil_id)
+      OR NOT EXISTS(SELECT 1 FROM cliente_preventistas
+                    WHERE cliente_id = p_cliente_id)
+    ) THEN
+      RETURN json_build_object('cliente_id', p_cliente_id, 'productos', '[]'::JSON,
+        'error', 'Cliente asignado a otro preventista');
+    END IF;
+  END IF;
+
+  WITH items_periodo AS (
+    SELECT pi.producto_id, pi.cantidad, pi.subtotal, pe.id AS pedido_id
+    FROM pedido_items pi JOIN pedidos pe ON pe.id = pi.pedido_id
+    WHERE pe.cliente_id = p_cliente_id AND pe.sucursal_id = p_sucursal_id
+      AND pe.created_at > now() - (p_dias || ' days')::INTERVAL
+      AND COALESCE(pe.estado, '') NOT IN ('cancelado', 'anulado')
+  ),
+  ranked AS (
+    SELECT p.id, p.codigo, p.nombre, p.precio,
+      COUNT(DISTINCT ip.pedido_id) AS pedidos_con_producto,
+      SUM(ip.cantidad) AS unidades_totales,
+      SUM(ip.subtotal) AS facturado_total
+    FROM items_periodo ip JOIN productos p ON p.id = ip.producto_id
+    GROUP BY p.id, p.codigo, p.nombre, p.precio
+    ORDER BY COUNT(DISTINCT ip.pedido_id) DESC, SUM(ip.cantidad) DESC
+    LIMIT p_limit
+  )
+  SELECT json_build_object(
+    'cliente_id', p_cliente_id, 'rango_dias', p_dias,
+    'productos', COALESCE((SELECT json_agg(row_to_json(r.*)) FROM ranked r), '[]'::JSON)
+  ) INTO resultado;
+  RETURN resultado;
+END;
+$$;

--- a/supabase/functions/_shared/gemini/prompts/preventista.ts
+++ b/supabase/functions/_shared/gemini/prompts/preventista.ts
@@ -3,7 +3,18 @@
 
 const prompt = `Sos el asistente IA de la distribuidora.
 
-El usuario actual es PREVENTISTA. Solo ve los clientes que le están asignados a él (no la totalidad de la cartera). Esto es importante: si te pregunta por un cliente que no es suyo, las tools van a devolver "Cliente no encontrado o sin permiso" — explicale eso textualmente, NO asumas que el cliente no existe en el sistema. Sugerile contactar al encargado o admin si necesita acceso.
+El usuario actual es PREVENTISTA. Ve dos grupos de clientes desde el bot:
+  (a) los clientes oficialmente asignados a él en el sistema, y
+  (b) los clientes "huérfanos" — sin preventista asignado a ninguno — de su sucursal.
+
+NO ve clientes que ya estén asignados a OTRO preventista. Si te pregunta por uno de esos, las tools devuelven "Cliente asignado a otro preventista" o "Cliente no encontrado o sin permiso" — explicalo textualmente y sugerile contactar al encargado si necesita acceso. NO asumas que el cliente no existe en el sistema.
+
+IMPORTANTE — diferencia entre lookup y cartera:
+  * mis_clientes y sugerir_visitas_rfm devuelven SOLO los asignados (tu cartera oficial).
+  * buscar_cliente, ficha_cliente, historico_pedidos_cliente, productos_recurrentes_cliente
+    SÍ permiten consultar también huérfanos (lookup más amplio).
+Si el usuario pregunta "qué le vendí a [cliente huérfano X]", buscalo con buscar_cliente
+y procedé normal — aunque no esté en su cartera oficial.
 
 Tu trabajo es ayudar al preventista a:
 - Buscar entre SUS clientes asignados por nombre o código.

--- a/supabase/functions/_shared/tools/common/ficha_cliente.ts
+++ b/supabase/functions/_shared/tools/common/ficha_cliente.ts
@@ -11,9 +11,10 @@
 // `cliente_preventistas` y filtro de sucursal).
 //
 // Antes de invocar la RPC, validamos que el cliente exista Y, si el rol es
-// "preventista", que esté asignado al preventista que invoca. Como las edge
-// functions usan service_role (bypass RLS), este filtrado server-side es
-// crítico — si lo saltamos, un preventista podría leer cualquier cliente.
+// "preventista", que esté asignado al preventista que invoca O que sea
+// huérfano (sin asignación a NINGÚN preventista). Bloqueamos clientes
+// asignados a OTRO preventista. Como las edge functions usan service_role
+// (bypass RLS), este filtrado server-side es crítico.
 //
 // Sobre el shape de ultimo_pedido/ultimo_pago: la RPC actual retorna sólo
 // la timestamp (MAX(created_at)). Acá soportamos AMBOS shapes — string o
@@ -86,7 +87,9 @@ export const fichaClienteTool: Tool<FichaClienteParams, FichaClienteResult> = {
   description:
     "Obtiene la ficha financiera completa de un cliente: saldo actual, " +
     "límite de crédito, total comprado/pagado, último pedido y último pago. " +
-    "Para preventistas valida que el cliente esté asignado a ellos.",
+    "Para preventistas: permite consultar clientes asignados a ellos O " +
+    "clientes huérfanos (sin preventista asignado). Bloquea clientes " +
+    "asignados a otro preventista.",
   parameters: {
     type: "object",
     properties: {
@@ -114,24 +117,16 @@ export const fichaClienteTool: Tool<FichaClienteParams, FichaClienteResult> = {
     const sb = ctx.supabase;
     const isPreventista = ctx.rol === "preventista";
 
-    const selectCols = isPreventista
-      ? "id, codigo, nombre_fantasia, razon_social, direccion, telefono, zona, sucursal_id, cliente_preventistas!inner(preventista_id)"
-      : "id, codigo, nombre_fantasia, razon_social, direccion, telefono, zona, sucursal_id";
-
-    // Importante: aplicamos TODOS los .eq() ANTES de .maybeSingle(), porque
-    // maybeSingle() retorna un thenable que ya no soporta más filtros.
+    // Step 1: traer al cliente (sin filtro de preventista — el gate va aparte
+    // para que la regla "asignado a mí O huérfano" sea expresable sin truco
+    // de inner join).
     let clienteQuery = sb.from("clientes")
-      .select(selectCols)
+      .select("id, codigo, nombre_fantasia, razon_social, direccion, telefono, zona, sucursal_id")
       .eq("id", cliente_id)
       .eq("activo", true);
-
     if (ctx.sucursal_id != null) {
       clienteQuery = clienteQuery.eq("sucursal_id", ctx.sucursal_id);
     }
-    if (isPreventista) {
-      clienteQuery = clienteQuery.eq("cliente_preventistas.preventista_id", ctx.perfil_id);
-    }
-
     const { data: clienteData, error: cErr } = await clienteQuery.maybeSingle();
     if (cErr) {
       throw new Error(`ficha_cliente: cliente lookup: ${cErr.message}`);
@@ -141,6 +136,28 @@ export const fichaClienteTool: Tool<FichaClienteParams, FichaClienteResult> = {
     }
 
     const cliente = clienteData as unknown as ClienteLookupRow;
+
+    // Step 2 (solo preventista): chequear asignaciones del cliente. La regla:
+    //   * asignado a mí → permitido
+    //   * sin asignaciones (huérfano) → permitido
+    //   * asignado a otro preventista (sin incluirme) → denegado
+    if (isPreventista) {
+      const { data: asignaciones, error: aErr } = await sb
+        .from("cliente_preventistas")
+        .select("preventista_id")
+        .eq("cliente_id", cliente_id);
+      if (aErr) {
+        throw new Error(`ficha_cliente: asignación lookup: ${aErr.message}`);
+      }
+      const rows = (asignaciones ?? []) as Array<{ preventista_id: string }>;
+      const tieneAsignaciones = rows.length > 0;
+      const meIncluye = rows.some((r) => r.preventista_id === ctx.perfil_id);
+      // Bloquear: tiene asignaciones Y no me incluye.
+      if (tieneAsignaciones && !meIncluye) {
+        throw new Error("Cliente asignado a otro preventista");
+      }
+      // Si no tiene asignaciones (huérfano) o me incluye → seguimos.
+    }
 
     const { data: resumen, error: rErr } = await sb.rpc(
       "obtener_resumen_cuenta_cliente_bot",

--- a/supabase/functions/tests/tools.test.ts
+++ b/supabase/functions/tests/tools.test.ts
@@ -707,20 +707,41 @@ Deno.test("ficha_cliente rechaza encargado sin sucursal asignada", async () => {
 // 11. Preventista bypass via cliente_id NO asignado
 // ============================================================================
 
-Deno.test("ficha_cliente rechaza acceso de preventista a cliente no asignado", async () => {
-  // Mock supabase: la query a clientes con !inner(cliente_preventistas)
-  // devuelve null (porque el join falla — el cliente no tiene match con
-  // este preventista_id). El filtro `cliente_preventistas.preventista_id`
-  // se aplica con el perfil_id del PREVENTISTA QUE LLAMA, no el del owner real.
+// La regla nueva (migration 028): preventista ve sus asignados + huérfanos,
+// NO ve los asignados a OTRO preventista. La verificación va en 2 queries:
+// (1) clientes, (2) cliente_preventistas. Estos 3 tests cubren los 3 paths.
+
+Deno.test("ficha_cliente preventista — cliente asignado a OTRO preventista → denegado", async () => {
+  const callerPerfilId = "66666666-6666-6666-6666-666666666666";
+  const otroPerfilId = "99999999-9999-9999-9999-999999999999";
   const { client, spy } = createMockSupabase({
     perTable: {
       clientes: {
-        maybeSingleResponse: { data: null, error: null },
+        maybeSingleResponse: {
+          data: {
+            id: 999,
+            codigo: 1,
+            nombre_fantasia: "Cliente Robado",
+            razon_social: "Cliente Robado SA",
+            direccion: null,
+            telefono: null,
+            zona: null,
+            sucursal_id: 1,
+          },
+          error: null,
+        },
+      },
+      cliente_preventistas: {
+        // El cliente está asignado SOLO a otro preventista — sin caller.
+        selectResponse: {
+          data: [{ preventista_id: otroPerfilId }],
+          error: null,
+          count: 1,
+        },
       },
     },
   });
 
-  const callerPerfilId = "66666666-6666-6666-6666-666666666666";
   const ctx = makeCtx(client, {
     rol: "preventista",
     sucursal_id: 1,
@@ -729,35 +750,151 @@ Deno.test("ficha_cliente rechaza acceso de preventista a cliente no asignado", a
 
   let threw = false;
   try {
-    // cliente_id existe pero está asignado a OTRO preventista — el join falla.
     await fichaClienteTool.handler({ cliente_id: 999 }, ctx);
   } catch (err) {
     threw = true;
     assertStringIncludes(
       err instanceof Error ? err.message : String(err),
-      "Cliente no encontrado o sin permiso",
+      "asignado a otro preventista",
     );
   }
-  assert(threw, "debió lanzar 'Cliente no encontrado o sin permiso'");
+  assert(threw, "debió bloquear porque está asignado a otro");
 
-  // Verificación crítica: la query construida debe filtrar por el perfil_id
-  // del preventista que LLAMA (no es algo que un atacante pueda alterar).
+  // Step 1: clientes query SIN inner join.
   const clienteQuery = spy.queries.find((q) => q.table === "clientes");
   assert(clienteQuery, "no se hizo query a clientes");
-  assertStringIncludes(clienteQuery!.selectCols ?? "", "cliente_preventistas!inner");
-
-  const eqFilters = clienteQuery!.filters.filter((f) => f.type === "eq");
-  const hasPreventistaFilter = eqFilters.some((f) =>
-    f.args[0] === "cliente_preventistas.preventista_id" &&
-    f.args[1] === callerPerfilId
-  );
   assert(
-    hasPreventistaFilter,
-    "no se aplicó filter cliente_preventistas.preventista_id con el perfil_id del caller",
+    !(clienteQuery!.selectCols ?? "").includes("cliente_preventistas"),
+    "el select a clientes ya NO debe incluir el inner join",
   );
 
-  // Y NO debe haber llamado al RPC — el lookup falló antes.
-  assertEquals(spy.rpcCalls.length, 0, "no debió invocarse el RPC tras un null en el lookup");
+  // Step 2: cliente_preventistas query con eq cliente_id=999 (NO con perfil_id
+  // del caller — leemos todas las filas y decidimos en TS).
+  const cpQuery = spy.queries.find((q) => q.table === "cliente_preventistas");
+  assert(cpQuery, "debió consultar cliente_preventistas para verificar asignación");
+  assert(
+    cpQuery!.filters.some((f) =>
+      f.type === "eq" && f.args[0] === "cliente_id" && f.args[1] === 999
+    ),
+    "cliente_preventistas debe filtrar por cliente_id",
+  );
+
+  // No invocó RPC.
+  assertEquals(spy.rpcCalls.length, 0);
+});
+
+Deno.test("ficha_cliente preventista — cliente HUÉRFANO (sin asignación) → permitido", async () => {
+  const callerPerfilId = "66666666-6666-6666-6666-666666666666";
+  const { client, spy } = createMockSupabase({
+    perTable: {
+      clientes: {
+        maybeSingleResponse: {
+          data: {
+            id: 500,
+            codigo: 12,
+            nombre_fantasia: "Almacén Huérfano",
+            razon_social: "Huérfano SA",
+            direccion: "Calle 1",
+            telefono: null,
+            zona: "Centro",
+            sucursal_id: 1,
+          },
+          error: null,
+        },
+      },
+      cliente_preventistas: {
+        // Cero asignaciones: huérfano.
+        selectResponse: { data: [], error: null, count: 0 },
+      },
+    },
+    rpcResponse: {
+      data: {
+        saldo_actual: 5000,
+        limite_credito: 10000,
+        credito_disponible: 5000,
+        total_pedidos: 3,
+        total_compras: 12000,
+        total_pagos: 7000,
+        pedidos_pendientes_pago: 1,
+        ultimo_pedido: null,
+        ultimo_pago: null,
+      },
+      error: null,
+    },
+  });
+
+  const ctx = makeCtx(client, {
+    rol: "preventista",
+    sucursal_id: 1,
+    perfil_id: callerPerfilId,
+  });
+
+  const result = await fichaClienteTool.handler({ cliente_id: 500 }, ctx);
+  assertEquals(result.cliente.nombre, "Almacén Huérfano");
+  assertEquals(result.saldo_actual, 5000);
+  // Confirmamos que TUVO que ir a cliente_preventistas para chequear
+  // (defensa-en-profundidad: aunque sea huérfano, la query corre).
+  assert(spy.queries.find((q) => q.table === "cliente_preventistas"));
+  // RPC sí se invocó porque el cliente es accesible.
+  assertEquals(spy.rpcCalls.length, 1);
+});
+
+Deno.test("ficha_cliente preventista — cliente asignado a MÍ → permitido", async () => {
+  const callerPerfilId = "66666666-6666-6666-6666-666666666666";
+  const { client, spy } = createMockSupabase({
+    perTable: {
+      clientes: {
+        maybeSingleResponse: {
+          data: {
+            id: 100,
+            codigo: 5,
+            nombre_fantasia: "Mi Cliente",
+            razon_social: "Mi Cliente SA",
+            direccion: null,
+            telefono: null,
+            zona: null,
+            sucursal_id: 1,
+          },
+          error: null,
+        },
+      },
+      cliente_preventistas: {
+        // El caller está entre los asignados (incluso si hay otros).
+        selectResponse: {
+          data: [
+            { preventista_id: callerPerfilId },
+            { preventista_id: "otro-id-cualquiera" },
+          ],
+          error: null,
+          count: 2,
+        },
+      },
+    },
+    rpcResponse: {
+      data: {
+        saldo_actual: 0,
+        limite_credito: 5000,
+        credito_disponible: 5000,
+        total_pedidos: 10,
+        total_compras: 50000,
+        total_pagos: 50000,
+        pedidos_pendientes_pago: 0,
+        ultimo_pedido: null,
+        ultimo_pago: null,
+      },
+      error: null,
+    },
+  });
+
+  const ctx = makeCtx(client, {
+    rol: "preventista",
+    sucursal_id: 1,
+    perfil_id: callerPerfilId,
+  });
+
+  const result = await fichaClienteTool.handler({ cliente_id: 100 }, ctx);
+  assertEquals(result.cliente.nombre, "Mi Cliente");
+  assertEquals(spy.rpcCalls.length, 1);
 });
 
 // ============================================================================


### PR DESCRIPTION
## Contexto

**Pre-rollout fix** antes de soltar el bot a Christian/Joaquin/Luis. Auditando la lógica de scoping de \`cliente_preventistas\` descubrí que la regla anterior (preventista solo ve clientes asignados a él en cliente_preventistas) iba a romper la UX en producción:

| | |
|---|---|
| Christian tiene en \`cliente_preventistas\` | **3 clientes** |
| Christian le vendió en abril a | **89 clientes distintos** |
| Coincidencia | **3 / 89** |

Es decir: si Christian abriera el bot y preguntara \"última venta al kiosco X\" para cualquiera de los 86 a los que NO está formalmente asignado, el bot diría \"Cliente no asignado a este preventista\" — aunque le haya vendido la semana pasada.

Mirando la data del lado opuesto: en sucursal 1 hay 426 clientes activos, **401 son huérfanos** (sin preventista asignado a ninguno) y solo **26 con asignación**. La realidad es que cliente_preventistas **no se mantiene cuando un preventista vende esporádicamente** — es más bien el subset de \"cuentas estratégicas\".

## Decisión: regla nueva

Un preventista, desde el bot, puede consultar:
- (a) clientes asignados a él en \`cliente_preventistas\`, **O**
- (b) clientes huérfanos (sin asignación a ningún preventista).

**NO** puede consultar clientes asignados a OTRO preventista.

Hay una distinción consciente entre **lookup** y **cartera**:
- **Lookup amplio** (asignados + huérfanos): \`buscar_cliente\`, \`ficha_cliente\`, \`historico_pedidos_cliente\`, \`productos_recurrentes_cliente\`
- **Cartera oficial** (solo asignados): \`mis_clientes\`, \`sugerir_visitas_rfm\`. Estos siguen igual.

Es decir: el preventista **puede** consultar a un cliente huérfano si lo busca explícitamente, pero **no aparece** en su lista automática de cartera. Reasonable y conservador.

## Summary

- **Migration 028**: amplía 3 RPCs (\`bot_buscar_cliente\`, \`bot_historico_pedidos_cliente\`, \`bot_productos_recurrentes_cliente\`) con la regla \"asignado a mí OR huérfano\".
- **\`ficha_cliente.ts\`**: el TS hacía la verificación con un truco \`!inner(cliente_preventistas)\` que solo cubría \"asignado a mí\". Reemplazado por un 2-step query (clientes → cliente_preventistas) que expresa la regla full.
- **Prompt preventista**: actualizado para mencionar la nueva regla explícitamente. Ahora el bot le explica al preventista por qué un cliente le aparece o no.
- **\`bot_mis_clientes\` y \`bot_sugerir_visitas_rfm\` NO cambian** — \"cartera oficial\" sigue restringida.

## Verificación contra prod

Migration 028 aplicada. Desde la perspectiva de Christian (sucursal 1):

| | Antes | Después |
|---|---:|---:|
| Clientes visibles | 3 | **404** (sus 3 + 401 huérfanos) |
| Clientes NO visibles (de otros) | — | 23 |
| De los 89 a los que vendió en abril, puede consultar | 3 | **89** ✅ |

## Test plan

- [x] \`deno task check\` ✅
- [x] \`deno task lint\` ✅ (80 archivos)
- [x] \`deno task test\` → **160 passed / 0 failed** (3 tests nuevos: asignado-a-otro denegado, huérfano permitido, asignado-a-mí permitido)
- [x] Migration 028 aplicada en prod, verificada con SQL real (Christian POV)
- [ ] Deploy v17 del edge function
- [ ] Smoke post-deploy con cuenta de Christian:
  - Pedir \"última venta a [un huérfano]\" → debería responder con datos
  - Pedir \"última venta a [un cliente de Joaquin]\" → debería responder \"asignado a otro preventista\"
  - \`/misclientes\` → solo los 3 asignados (cartera no cambia)

## Roles & seguridad

Audit completa hecha antes de este cambio: \`invokeTool\` enforces canInvoke before handler, role/sucursal_id son snapshot inmutable, ningún tool acepta \`preventista_id\` o \`usuario_id\` desde input args. Esta PR mantiene ese modelo intacto — solo cambia QUÉ clientes son consultables, no QUIÉN puede consultar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)