### PR TITLE
fix(promociones): regalo correcto para promos "Fracción de unidad"

### DIFF
--- a/migrations/030_fix_fraccion_producto_regalo.sql
+++ b/migrations/030_fix_fraccion_producto_regalo.sql
@@ -1,0 +1,57 @@
+-- Migración 030 — Fix: regalo de promos "Fracción" usa el producto disparador
+--
+-- Bug: en el modal de promos, la sección de regalo (`producto_regalo_id`) sólo
+-- se muestra para `tipo_regalo='unidad_entera'`. En modo "Fracción de unidad"
+-- el form sólo guarda `ajuste_producto_id` + `descripcion_regalo` + `unidades_por_bloque`,
+-- y persiste `producto_regalo_id = NULL`. El resolver del frontend
+-- (src/utils/promociones.ts:102) hace fallback al primer producto disparador
+-- del pedido, así que las bonificaciones se cargan apuntando al disparador
+-- (Manaos Cola, Placer Anana, etc.) en lugar del producto contenedor real.
+--
+-- Visible en la hoja de ruta del 03/05/2026: "4x MANAOS COLA 3000 cc x 6"
+-- gratis cuando deberían ser 4 botellas de Manaos Granadina, etc.
+--
+-- Fix en dos partes:
+--   A. Backfill de promos: copiar ajuste_producto_id → producto_regalo_id en
+--      promos Fracción que tienen NULL.
+--   B. Backfill de pedido_items con es_bonificacion=TRUE cuyo producto_id es
+--      un disparador de la promo (no el regalo). Reapunta al producto correcto
+--      y snapshotea descripcion_regalo. NO toca cantidad ni precio.
+--
+-- Idempotente (los WHERE filtran lo que ya está bien). Stock NO se ajusta
+-- porque las promos Fracción tienen `regalo_mueve_stock=false` — el stock
+-- siempre se descuenta vía `ajuste_producto_id` en bloques completos, no por
+-- el item bonif individual. Reapuntar el item no afecta stock alguno.
+
+BEGIN;
+
+-- ============================================================================
+-- A. Promociones Fracción sin producto_regalo_id → setearlo al contenedor.
+-- ============================================================================
+UPDATE promociones
+SET producto_regalo_id = ajuste_producto_id
+WHERE producto_regalo_id IS NULL
+  AND ajuste_producto_id IS NOT NULL
+  AND ajuste_automatico = TRUE
+  AND descripcion_regalo IS NOT NULL;
+
+-- ============================================================================
+-- B. pedido_items mal cargados: producto_id = disparador en vez de regalo.
+-- ============================================================================
+-- Sólo toca items donde el producto_id actual está en la lista de disparadores
+-- de la promo (promocion_productos), evitando modificar items legítimos.
+UPDATE pedido_items pi
+SET producto_id = pr.producto_regalo_id,
+    descripcion_regalo = pr.descripcion_regalo
+FROM promociones pr
+WHERE pi.promocion_id = pr.id
+  AND pi.es_bonificacion = TRUE
+  AND pr.producto_regalo_id IS NOT NULL
+  AND EXISTS (
+    SELECT 1 FROM promocion_productos pp
+    WHERE pp.promocion_id = pr.id
+      AND pp.producto_id = pi.producto_id
+  )
+  AND pi.producto_id IS DISTINCT FROM pr.producto_regalo_id;
+
+COMMIT;

--- a/src/components/modals/ModalPedido.tsx
+++ b/src/components/modals/ModalPedido.tsx
@@ -596,12 +596,16 @@ const ModalPedido = memo(function ModalPedido({
                       {/* Items de bonificación (gratis) */}
                       {promoResolucion.bonificaciones.map(bonif => {
                         const prod = productos.find(p => p.id === bonif.productoId);
+                        // En modo Fracción descripcionRegalo describe el regalo
+                        // como lo cargó el admin (ej: "1 botella Manaos Naranja
+                        // 600cc"). Si no hay, fallback al nombre del producto.
+                        const labelRegalo = bonif.descripcionRegalo?.trim() || prod?.nombre;
                         return (
                           <div key={`bonif-${bonif.productoId}`} className="px-3 py-2.5 bg-green-50 dark:bg-green-900/10">
                             <div className="flex justify-between items-center gap-2">
                               <div className="min-w-0 flex-1">
                                 <div className="flex items-center gap-1.5">
-                                  <p className="font-medium text-sm text-green-700 dark:text-green-400 truncate">{prod?.nombre}</p>
+                                  <p className="font-medium text-sm text-green-700 dark:text-green-400 truncate">{labelRegalo}</p>
                                   <span className="inline-flex items-center gap-0.5 text-xs px-1.5 py-0.5 bg-green-200 text-green-800 rounded-full font-medium shrink-0">
                                     <Gift className="w-3 h-3" />
                                     Bonificacion

--- a/src/components/modals/ModalPromocion.tsx
+++ b/src/components/modals/ModalPromocion.tsx
@@ -173,6 +173,12 @@ export default function ModalPromocion({
     // stock_por_bloque siempre es 1 en el modelo fraccional (no es un campo
     // visible al usuario). El backend lo usa al cerrar un bloque.
     const stockBloque = 1
+    // En fracción el "producto de regalo" canónico es el fardo contenedor:
+    // de él se descuenta stock por bloques y es lo que el chofer carga.
+    // La UI sólo muestra el campo en unidad_entera; en fracción derivamos.
+    const finalProductoRegaloId = esFraccion
+      ? (ajusteProductoId || null)
+      : (productoRegaloId || null)
     const result = await onSave({
       nombre: nombre.trim(),
       tipo: 'bonificacion',
@@ -180,7 +186,7 @@ export default function ModalPromocion({
       fechaFin: fechaFin || null,
       limiteUsos: limite && limite > 0 ? limite : null,
       productoIds: Array.from(productoIds),
-      productoRegaloId: productoRegaloId || null,
+      productoRegaloId: finalProductoRegaloId,
       reglas: [
         { clave: 'cantidad_compra', valor: compra },
         { clave: 'cantidad_bonificacion', valor: bonif },

--- a/src/hooks/queries/usePedidosQuery.ts
+++ b/src/hooks/queries/usePedidosQuery.ts
@@ -104,7 +104,7 @@ async function fetchPedidos(): Promise<PedidoDB[]> {
     .from('pedidos')
     .select(`*,
     cliente:clientes(id, nombre_fantasia, razon_social, cuit, direccion, telefono, contacto, latitud, longitud, horarios_atencion, zona),
-    items:pedido_items(*, producto:productos(id, nombre, codigo, categoria))`)
+    items:pedido_items(*, producto:productos(id, nombre, codigo, categoria), promocion:promociones(unidades_por_bloque))`)
     .order('created_at', { ascending: false })
     .limit(500) // Limitar carga inicial para evitar consumo excesivo de memoria
 
@@ -150,7 +150,7 @@ async function fetchPedidoById(id: string): Promise<PedidoDB | null> {
     .from('pedidos')
     .select(`*,
     cliente:clientes(id, nombre_fantasia, razon_social, cuit, direccion, telefono, contacto, latitud, longitud, horarios_atencion, zona),
-    items:pedido_items(*, producto:productos(id, nombre, codigo, categoria))`)
+    items:pedido_items(*, producto:productos(id, nombre, codigo, categoria), promocion:promociones(unidades_por_bloque))`)
     .eq('id', id)
     .single()
 
@@ -163,7 +163,7 @@ async function fetchPedidosByTransportista(transportistaId: string): Promise<Ped
     .from('pedidos')
     .select(`*,
     cliente:clientes(id, nombre_fantasia, razon_social, cuit, direccion, telefono, contacto, latitud, longitud, horarios_atencion, zona),
-    items:pedido_items(*, producto:productos(id, nombre, codigo, categoria))`)
+    items:pedido_items(*, producto:productos(id, nombre, codigo, categoria), promocion:promociones(unidades_por_bloque))`)
     .eq('transportista_id', transportistaId)
     .in('estado', ['asignado', 'en_camino'])
     .order('orden_entrega', { ascending: true, nullsFirst: false })
@@ -175,7 +175,7 @@ async function fetchPedidosByTransportista(transportistaId: string): Promise<Ped
 async function fetchPedidosByCliente(clienteId: string): Promise<PedidoDB[]> {
   const { data, error } = await supabase
     .from('pedidos')
-    .select(`*, items:pedido_items(*, producto:productos(id, nombre, codigo, categoria))`)
+    .select(`*, items:pedido_items(*, producto:productos(id, nombre, codigo, categoria), promocion:promociones(unidades_por_bloque))`)
     .eq('cliente_id', clienteId)
     .order('created_at', { ascending: false })
     .limit(50)
@@ -203,8 +203,8 @@ async function fetchPedidosPaginated(
 
   // Use !inner join when searching so PostgREST filters parent rows by client fields
   const selectStr = hasSearch
-    ? '*, cliente:clientes!inner(id, nombre_fantasia, razon_social, cuit, direccion, telefono, contacto, latitud, longitud, horarios_atencion, zona), items:pedido_items(*, producto:productos(id, nombre, codigo, categoria))'
-    : '*, cliente:clientes(id, nombre_fantasia, razon_social, cuit, direccion, telefono, contacto, latitud, longitud, horarios_atencion, zona), items:pedido_items(*, producto:productos(id, nombre, codigo, categoria))'
+    ? '*, cliente:clientes!inner(id, nombre_fantasia, razon_social, cuit, direccion, telefono, contacto, latitud, longitud, horarios_atencion, zona), items:pedido_items(*, producto:productos(id, nombre, codigo, categoria), promocion:promociones(unidades_por_bloque))'
+    : '*, cliente:clientes(id, nombre_fantasia, razon_social, cuit, direccion, telefono, contacto, latitud, longitud, horarios_atencion, zona), items:pedido_items(*, producto:productos(id, nombre, codigo, categoria), promocion:promociones(unidades_por_bloque))'
 
   let query = supabase
     .from('pedidos')

--- a/src/hooks/queries/usePromocionesQuery.ts
+++ b/src/hooks/queries/usePromocionesQuery.ts
@@ -125,6 +125,9 @@ async function fetchPromoMap(fechaReferencia?: string): Promise<PromoMap> {
       prioridad: promo.prioridad ?? 0,
       regaloMueveStock: promo.regalo_mueve_stock ?? false,
       modoExclusion: promo.modo_exclusion ?? 'acumulable',
+      ajusteProductoId: promo.ajuste_producto_id ? String(promo.ajuste_producto_id) : undefined,
+      unidadesPorBloque: promo.unidades_por_bloque ?? undefined,
+      descripcionRegalo: promo.descripcion_regalo ?? undefined,
     }
 
     for (const productoId of productoIds) {

--- a/src/hooks/usePromocionPedido.ts
+++ b/src/hooks/usePromocionPedido.ts
@@ -31,6 +31,8 @@ export interface ItemPedidoConPromo extends ItemPedido {
   esBonificacion?: boolean
   promoNombre?: string
   promoId?: string
+  descripcionRegalo?: string
+  unidadesPorBloque?: number
 }
 
 interface UsePromocionPedidoReturn {
@@ -129,6 +131,8 @@ export function usePromocionPedido(
         esBonificacion: true,
         promoNombre: bonif.promoNombre,
         promoId: bonif.promoId,
+        descripcionRegalo: bonif.descripcionRegalo,
+        unidadesPorBloque: bonif.unidadesPorBloque,
       })
     }
 

--- a/src/lib/pdf/hojaRutaOptimizada.js
+++ b/src/lib/pdf/hojaRutaOptimizada.js
@@ -147,7 +147,13 @@ function buildCardOps(doc, pedido, orderNumber) {
   const priceColWidth = 24
   const productWrapWidth = CARD_CONTENT_WIDTH - priceColWidth
   ;(pedido.items || []).forEach((item) => {
-    const nombre = item.producto?.nombre || 'Producto'
+    // Para regalos de tipo Fracción, descripcion_regalo es el texto manual
+    // que el admin cargó (ej: "1 botella Manaos Naranja 600cc"). Cae al
+    // nombre del producto cuando no hay snapshot (regalos antiguos / unidad
+    // entera).
+    const nombre = (item.es_bonificacion && item.descripcion_regalo?.trim())
+      ? item.descripcion_regalo.trim()
+      : (item.producto?.nombre || 'Producto')
     const subtotal = (item.precio_unitario || 0) * item.cantidad
     const itemLines = doc.splitTextToSize(`${item.cantidad}x ${nombre}`, productWrapWidth)
     itemLines.forEach((line, idx) => {
@@ -273,21 +279,54 @@ function buildCierreOps(pedidos) {
 /**
  * Suma todas las cantidades por producto entre todos los pedidos y
  * produce operaciones de layout para el manifiesto de carga del camion.
+ *
+ * Para regalos de tipo Fracción (item.es_bonificacion + unidades_por_bloque):
+ * convierte la cantidad en subunidades a "fardos completos + botellas sueltas".
+ * Los fardos se suman al producto contenedor (mismo producto_id que el item).
+ * Las botellas sueltas se listan en una fila aparte usando descripcion_regalo,
+ * para que el chofer sepa que carga 1 fardo + N botellas individuales.
  */
 function buildManifiestoOps(pedidos) {
-  const totales = {}
+  const totalesFardos = {} // por producto_id (fardos enteros)
+  const totalesBotellas = {} // por descripcion_regalo (botellas sueltas)
+
   pedidos.forEach((pedido) => {
     ;(pedido.items || []).forEach((item) => {
+      const cantidad = Number(item.cantidad) || 0
+      if (cantidad <= 0) return
+
       const key = item.producto_id ?? item.producto?.id ?? item.producto?.nombre ?? 'sin-id'
-      const nombre = item.producto?.nombre || 'Producto'
-      if (!totales[key]) {
-        totales[key] = { nombre, cantidad: 0 }
+      const nombreProducto = item.producto?.nombre || 'Producto'
+      const upb = item.promocion?.unidades_por_bloque
+      const desc = item.descripcion_regalo?.trim()
+
+      // Caso A: regalo Fracción → split en fardos + botellas sueltas.
+      if (item.es_bonificacion && upb && upb > 1 && desc) {
+        const fardos = Math.floor(cantidad / upb)
+        const sueltas = cantidad % upb
+        if (fardos > 0) {
+          if (!totalesFardos[key]) totalesFardos[key] = { nombre: nombreProducto, cantidad: 0 }
+          totalesFardos[key].cantidad += fardos
+        }
+        if (sueltas > 0) {
+          const sueltasKey = `bonif:${desc}`
+          if (!totalesBotellas[sueltasKey]) totalesBotellas[sueltasKey] = { nombre: desc, cantidad: 0 }
+          totalesBotellas[sueltasKey].cantidad += sueltas
+        }
+        return
       }
-      totales[key].cantidad += Number(item.cantidad) || 0
+
+      // Caso B: items normales (compras o regalos de unidad entera) → suma directa.
+      if (!totalesFardos[key]) totalesFardos[key] = { nombre: nombreProducto, cantidad: 0 }
+      totalesFardos[key].cantidad += cantidad
     })
   })
 
-  const filas = Object.values(totales)
+  const filasFardos = Object.values(totalesFardos)
+    .filter((t) => t.cantidad > 0)
+    .sort((a, b) => a.nombre.localeCompare(b.nombre, 'es'))
+
+  const filasBotellas = Object.values(totalesBotellas)
     .filter((t) => t.cantidad > 0)
     .sort((a, b) => a.nombre.localeCompare(b.nombre, 'es'))
 
@@ -298,7 +337,7 @@ function buildManifiestoOps(pedidos) {
     text: 'Total de productos a cargar en el vehiculo',
     advance: 5
   })
-  filas.forEach((f) => {
+  filasFardos.forEach((f) => {
     ops.push({
       kind: 'manifiesto-line',
       cantidad: `${f.cantidad}x`,
@@ -306,6 +345,22 @@ function buildManifiestoOps(pedidos) {
       advance: 4.5
     })
   })
+  if (filasBotellas.length > 0) {
+    ops.push({ kind: 'spacer', advance: 1.5 })
+    ops.push({
+      kind: 'manifiesto-subtitle',
+      text: 'Bonificaciones sueltas (de fardo abierto)',
+      advance: 4.5
+    })
+    filasBotellas.forEach((f) => {
+      ops.push({
+        kind: 'manifiesto-line',
+        cantidad: `${f.cantidad}x`,
+        nombre: f.nombre,
+        advance: 4.5
+      })
+    })
+  }
   ops.push({ kind: 'spacer', advance: 2 })
   ops.push({ kind: 'manifiesto-firma', advance: 5.5 })
   return ops

--- a/src/types/hooks.ts
+++ b/src/types/hooks.ts
@@ -69,6 +69,10 @@ export interface PedidoItemDB {
   es_bonificacion?: boolean;
   promocion_id?: string;
   descripcion_regalo?: string | null;
+  /** Datos de la promo asociada (sólo presente cuando promocion_id está set) */
+  promocion?: {
+    unidades_por_bloque?: number | null;
+  } | null;
   neto_unitario?: number;
   iva_unitario?: number;
   impuestos_internos_unitario?: number;

--- a/src/utils/promociones.ts
+++ b/src/utils/promociones.ts
@@ -29,6 +29,12 @@ export interface PromocionActiva {
   prioridad?: number
   regaloMueveStock?: boolean
   modoExclusion?: ModoExclusion
+  /** Producto contenedor del que se descuenta stock por bloques (modo Fracción). */
+  ajusteProductoId?: string
+  /** Subunidades que forman 1 unidad del producto contenedor (modo Fracción). */
+  unidadesPorBloque?: number
+  /** Texto manual del regalo a mostrar en pedido/PDF (ej: "1 botella Manaos Naranja 600cc"). */
+  descripcionRegalo?: string
 }
 
 /** Mapa de productoId → promos activas que aplican */
@@ -39,6 +45,8 @@ export interface BonificacionResult {
   promoId: string
   promoNombre: string
   cantidadBonificacion: number
+  descripcionRegalo?: string
+  unidadesPorBloque?: number
 }
 
 export interface PromoResolucion {
@@ -98,11 +106,17 @@ export function resolverPromociones(
     const cantCompra = promo.reglas['cantidad_compra']
     const cantBonif = promo.reglas['cantidad_bonificacion']
     const bloques = Math.floor(totalQty / cantCompra)
+    // Resolución del producto regalo: producto_regalo_id (configurado en form),
+    // luego ajuste_producto_id (contenedor en modo Fracción — defensa por si la
+    // promo quedó con regalo NULL antes del fix), y como último recurso el
+    // primer disparador (mantiene el comportamiento previo para promos legacy).
     bonificaciones.push({
-      productoId: promo.productoRegaloId || primerProductoId,
+      productoId: promo.productoRegaloId || promo.ajusteProductoId || primerProductoId,
       promoId: promo.id,
       promoNombre: promo.nombre,
       cantidadBonificacion: bloques * cantBonif,
+      descripcionRegalo: promo.descripcionRegalo,
+      unidadesPorBloque: promo.unidadesPorBloque,
     })
   }
 


### PR DESCRIPTION
## Resumen

Las promos tipo **Fracción de unidad** (ej: "1 Fardo 3L → 2 Botellas Granadina 3L") cargaban como regalo el **producto disparador** en vez del configurado. Visible en la hoja de ruta del 03/05/2026 con regalos de Manaos Cola/Naranja/Lima Limón cuando deberían ser Granadina, etc.

## Causa raíz

3 piezas combinadas:

1. `ModalPromocion.tsx` no exponía el campo "Producto de regalo" en modo Fracción → `producto_regalo_id = NULL` en DB.
2. `src/utils/promociones.ts:102` hacía fallback al primer disparador del pedido cuando `productoRegaloId` era undefined → bonificación apuntaba al disparador.
3. PDF y modal nunca leían `descripcion_regalo` (snapshot ya existente desde mig 011) → mostraban el nombre del producto incorrecto.

## Cambios

- **`migrations/030_fix_fraccion_producto_regalo.sql`** — backfill de promos (NULL → `ajuste_producto_id`) y de los 11 `pedido_items` que estaban mal apuntados. **Ya aplicada al proyecto ManaosApp** vía MCP. Sin impacto en stock (`regalo_mueve_stock=false`).
- **`ModalPromocion.tsx`** — `productoRegaloId` deriva de `ajusteProductoId` en modo fracción al guardar. Las nuevas promos ya nacen bien.
- **`usePromocionesQuery.ts` / `promociones.ts`** — `PromocionActiva` expone `ajusteProductoId`, `unidadesPorBloque` y `descripcionRegalo`; resolver con fallback robusto `productoRegaloId || ajusteProductoId || primerProductoId`.
- **`usePromocionPedido.ts` / `ModalPedido.tsx`** — propaga `descripcionRegalo` al item final y la modal lo muestra como label del regalo.
- **`usePedidosQuery.ts`** — agrega join `promocion:promociones(unidades_por_bloque)` en los 5 selects.
- **`hojaRutaOptimizada.js`** — card del PDF usa `descripcion_regalo` cuando hay snapshot. **Manifiesto split**: bonif Fracción → fardos enteros se suman al producto contenedor + sobrantes aparecen aparte como "Bonificaciones sueltas (de fardo abierto)".

## Verificación

- `npx tsc --noEmit` ✅
- `npx eslint <archivos tocados>` ✅
- `npx vitest run` ✅ (585/585)
- Migración aplicada en prod: 4 promos con `producto_regalo_id` ahora seteado, 0 items quedaron mal apuntados.

## Test plan

- [ ] Re-generar la hoja de ruta del 03/05/2026: las cards muestran "2 Botellas de Manaos Granadina 3L" / "1 Botella Manaos Pomelo Blanco 600cc" en vez del producto disparador.
- [ ] Manifiesto: la sección "Bonificaciones sueltas (de fardo abierto)" aparece para regalos que no completan un fardo.
- [ ] Crear pedido nuevo con 2 fardos Manaos 3L → la bonificación debe ser Granadina (4 botellas).
- [ ] Editar promo Fracción existente → guardar → confirmar `producto_regalo_id` queda seteado.
- [ ] Crear promo Fracción nueva → `producto_regalo_id` se persiste = `ajuste_producto_id`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)