### PR TITLE
feat(bot): tomar pedido (write tool fase 1) — preventistas pueden cargar pedidos por Telegram

### DIFF
--- a/migrations/030_bot_tomar_pedido.sql
+++ b/migrations/030_bot_tomar_pedido.sql
@@ -1,0 +1,319 @@
+-- Migración 030 — Bot Telegram: schema para tomar pedido (write tool fase 1)
+--
+-- Componentes:
+--   1. pedidos.canal (varchar) — distingue 'app' vs 'bot' para filtrar/auditar.
+--   2. bot_pedidos_pendientes — tabla efímera con TTL 10 min para anti doble-click
+--      y para que el callback del Confirmar tenga datos confiables.
+--   3. crear_pedido_completo_bot — variante de crear_pedido_completo que NO
+--      chequea auth.uid() (las edge functions corren con service_role) y
+--      acepta los items desde bot_pedidos_pendientes vía confirmacion_id.
+--
+-- NOTA: el cálculo de precios mayoristas/promos lo hace el edge function en
+-- TS (reusa src/utils/precioMayorista.ts y promociones.ts). El RPC solo
+-- INSERTa pedidos+items con los precios ya pre-computados, igual que
+-- crear_pedido_completo (que recibe precio_unitario en el JSONB).
+
+-- ============================================================================
+-- 1. Columna canal
+-- ============================================================================
+ALTER TABLE public.pedidos
+  ADD COLUMN IF NOT EXISTS canal VARCHAR(20) NOT NULL DEFAULT 'app';
+
+COMMENT ON COLUMN public.pedidos.canal IS
+  'Canal de origen del pedido: app | bot. Forward-compat para futuros canales (whatsapp, etc).';
+
+-- Index parcial — solo para queries del filtro "cargados via bot" (no necesitamos
+-- indexar el caso common 'app' que es 99% del tráfico).
+CREATE INDEX IF NOT EXISTS idx_pedidos_canal_no_app
+  ON public.pedidos (canal, sucursal_id)
+  WHERE canal <> 'app';
+
+-- ============================================================================
+-- 2. Tabla bot_pedidos_pendientes (efímera, TTL 10 min)
+-- ============================================================================
+-- Cada vez que el bot muestra un resumen para confirmar, persiste un row acá.
+-- El callback de Confirmar lee el row, valida (no expirado, no consumido,
+-- pertenece al usuario) y ejecuta el INSERT real del pedido.
+
+CREATE TABLE IF NOT EXISTS public.bot_pedidos_pendientes (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  perfil_id UUID NOT NULL,
+  sucursal_id BIGINT NOT NULL,
+  cliente_id BIGINT NOT NULL,
+  -- items: JSONB con shape [{producto_id, cantidad, precio_unitario, neto_unitario,
+  -- iva_unitario, impuestos_internos_unitario, porcentaje_iva, es_bonificacion,
+  -- promocion_id}, ...] — mismo shape que el p_items que crear_pedido_completo
+  -- ya espera de la app web.
+  items JSONB NOT NULL,
+  total NUMERIC NOT NULL,
+  total_neto NUMERIC,
+  total_iva NUMERIC NOT NULL DEFAULT 0,
+  forma_pago TEXT NOT NULL DEFAULT 'efectivo',
+  notas TEXT,
+  consumido BOOLEAN NOT NULL DEFAULT FALSE,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  expires_at TIMESTAMPTZ NOT NULL DEFAULT (now() + INTERVAL '10 minutes')
+);
+
+COMMENT ON TABLE public.bot_pedidos_pendientes IS
+  'Borradores de pedido del bot Telegram. TTL 10 min. consumido=true al crear el pedido real.';
+
+-- Index parcial: solo nos interesan los no-consumidos no-expirados.
+CREATE INDEX IF NOT EXISTS idx_bot_pedidos_pendientes_perfil_active
+  ON public.bot_pedidos_pendientes (perfil_id, expires_at)
+  WHERE NOT consumido;
+
+ALTER TABLE public.bot_pedidos_pendientes OWNER TO postgres;
+REVOKE ALL ON public.bot_pedidos_pendientes FROM PUBLIC;
+GRANT SELECT, INSERT, UPDATE ON public.bot_pedidos_pendientes TO service_role;
+
+-- ============================================================================
+-- 3. crear_pedido_completo_bot
+-- ============================================================================
+-- Variante de crear_pedido_completo (mig 000_baseline:1013) sin el check de
+-- auth.uid() (porque la edge function corre con service_role, sin sesión).
+-- Recibe el confirmacion_id, lee bot_pedidos_pendientes, valida, y ejecuta
+-- el INSERT clonando la lógica de crear_pedido_completo (incluido el
+-- auto-ajuste de promos).
+--
+-- Devuelve {success: bool, pedido_id?, total?, error?, errores?}.
+
+CREATE OR REPLACE FUNCTION public.crear_pedido_completo_bot(
+  p_perfil_id      UUID,
+  p_confirmacion_id UUID
+)
+RETURNS JSONB
+LANGUAGE plpgsql SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_pendiente RECORD;
+  v_user_role TEXT;
+  v_pedido_id INT;
+  v_fecha_pedido DATE := (now() AT TIME ZONE 'America/Argentina/Buenos_Aires')::date;
+  v_fecha_entrega DATE := (v_fecha_pedido + INTERVAL '1 day')::date;
+  v_cantidades_totales JSONB := '{}'::JSONB;
+  v_cant_acumulada INT;
+  v_regalo_mueve_stock BOOLEAN;
+  v_stock_actual INT;
+  v_producto_nombre TEXT;
+  errores TEXT[] := '{}';
+  item JSONB;
+  v_producto_id INT;
+  v_cantidad INT;
+  v_precio_unitario DECIMAL;
+  v_es_bonificacion BOOLEAN;
+  v_promocion_id BIGINT;
+  v_neto_unitario DECIMAL;
+  v_iva_unitario DECIMAL;
+  v_imp_internos_unitario DECIMAL;
+  v_porcentaje_iva DECIMAL;
+  v_promo RECORD;
+  v_usos_pendientes_actual INT;
+  v_bloques_completos INT;
+  v_ajustar_usos INT;
+  v_ajustar_stock INT;
+  v_stock_ajuste_anterior INT;
+  v_stock_ajuste_nuevo INT;
+  v_ajuste_producto_nombre TEXT;
+  v_merma_id BIGINT;
+BEGIN
+  -- 1) Validar el confirmacion_id
+  SELECT * INTO v_pendiente
+    FROM bot_pedidos_pendientes
+    WHERE id = p_confirmacion_id
+    FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RETURN jsonb_build_object('success', false, 'error', 'Confirmación inválida');
+  END IF;
+
+  IF v_pendiente.consumido THEN
+    RETURN jsonb_build_object('success', false, 'error', 'Pedido ya creado, revisalo en la app');
+  END IF;
+
+  IF v_pendiente.expires_at < now() THEN
+    RETURN jsonb_build_object('success', false, 'error', 'La confirmación expiró, hacé el pedido de nuevo');
+  END IF;
+
+  IF v_pendiente.perfil_id <> p_perfil_id THEN
+    -- Defensa: confirmacion_id no pertenece al usuario que llama.
+    RETURN jsonb_build_object('success', false, 'error', 'Confirmación no pertenece al usuario');
+  END IF;
+
+  -- 2) Validar rol del perfil (admin, encargado o preventista)
+  SELECT rol INTO v_user_role FROM perfiles WHERE id = p_perfil_id;
+  IF v_user_role IS NULL OR v_user_role NOT IN ('admin', 'encargado', 'preventista') THEN
+    RETURN jsonb_build_object('success', false, 'error', 'No tiene permisos para crear pedidos');
+  END IF;
+
+  -- 3) Re-check de stock atómico (entre preview y confirmar pueden haber pasado segundos)
+  -- Sumamos cantidades por producto contemplando bonificaciones que mueven stock.
+  FOR item IN SELECT * FROM jsonb_array_elements(v_pendiente.items) LOOP
+    v_producto_id := (item->>'producto_id')::INT;
+    v_cantidad := (item->>'cantidad')::INT;
+    v_es_bonificacion := COALESCE((item->>'es_bonificacion')::BOOLEAN, false);
+
+    IF v_cantidad IS NULL OR v_cantidad <= 0 THEN
+      errores := array_append(errores, 'Cantidad inválida para producto ID ' || v_producto_id);
+      CONTINUE;
+    END IF;
+
+    IF v_es_bonificacion THEN
+      v_promocion_id := (item->>'promocion_id')::BIGINT;
+      IF v_promocion_id IS NOT NULL THEN
+        SELECT regalo_mueve_stock INTO v_regalo_mueve_stock
+          FROM promociones WHERE id = v_promocion_id AND sucursal_id = v_pendiente.sucursal_id;
+        IF COALESCE(v_regalo_mueve_stock, FALSE) THEN
+          v_cant_acumulada := COALESCE((v_cantidades_totales->>v_producto_id::TEXT)::INT, 0) + v_cantidad;
+          v_cantidades_totales := v_cantidades_totales || jsonb_build_object(v_producto_id::TEXT, v_cant_acumulada);
+        END IF;
+      END IF;
+    ELSE
+      v_cant_acumulada := COALESCE((v_cantidades_totales->>v_producto_id::TEXT)::INT, 0) + v_cantidad;
+      v_cantidades_totales := v_cantidades_totales || jsonb_build_object(v_producto_id::TEXT, v_cant_acumulada);
+    END IF;
+  END LOOP;
+
+  FOR v_producto_id IN SELECT (key)::INT FROM jsonb_each_text(v_cantidades_totales) LOOP
+    v_cantidad := (v_cantidades_totales->>v_producto_id::TEXT)::INT;
+    SELECT stock, nombre INTO v_stock_actual, v_producto_nombre
+      FROM productos WHERE id = v_producto_id AND sucursal_id = v_pendiente.sucursal_id FOR UPDATE;
+    IF v_stock_actual IS NULL THEN
+      errores := array_append(errores, 'Producto ID ' || v_producto_id || ' no encontrado');
+    ELSIF v_stock_actual < v_cantidad THEN
+      errores := array_append(errores, v_producto_nombre || ': stock insuficiente (disponible: ' || v_stock_actual || ', solicitado: ' || v_cantidad || ')');
+    END IF;
+  END LOOP;
+
+  IF array_length(errores, 1) > 0 THEN
+    RETURN jsonb_build_object('success', false, 'errores', to_jsonb(errores));
+  END IF;
+
+  -- 4) INSERT pedidos con canal='bot'
+  INSERT INTO pedidos (
+    cliente_id, fecha, total, total_neto, total_iva, tipo_factura,
+    estado, usuario_id, stock_descontado, notas, forma_pago,
+    estado_pago, fecha_entrega_programada, sucursal_id, canal
+  )
+  VALUES (
+    v_pendiente.cliente_id, v_fecha_pedido, v_pendiente.total,
+    COALESCE(v_pendiente.total_neto, v_pendiente.total),
+    COALESCE(v_pendiente.total_iva, 0),
+    'ZZ',
+    'pendiente', p_perfil_id, true, v_pendiente.notas, v_pendiente.forma_pago,
+    'pendiente', v_fecha_entrega, v_pendiente.sucursal_id, 'bot'
+  )
+  RETURNING id INTO v_pedido_id;
+
+  -- 5) INSERT pedido_items + UPDATE stock (mismo bloque que crear_pedido_completo)
+  FOR item IN SELECT * FROM jsonb_array_elements(v_pendiente.items) LOOP
+    v_producto_id := (item->>'producto_id')::INT;
+    v_cantidad := (item->>'cantidad')::INT;
+    v_precio_unitario := (item->>'precio_unitario')::DECIMAL;
+    v_es_bonificacion := COALESCE((item->>'es_bonificacion')::BOOLEAN, false);
+    v_promocion_id := (item->>'promocion_id')::BIGINT;
+    v_neto_unitario := (item->>'neto_unitario')::DECIMAL;
+    v_iva_unitario := COALESCE((item->>'iva_unitario')::DECIMAL, 0);
+    v_imp_internos_unitario := COALESCE((item->>'impuestos_internos_unitario')::DECIMAL, 0);
+    v_porcentaje_iva := COALESCE((item->>'porcentaje_iva')::DECIMAL, 0);
+
+    INSERT INTO pedido_items (
+      pedido_id, producto_id, cantidad, precio_unitario, subtotal,
+      es_bonificacion, promocion_id, neto_unitario, iva_unitario,
+      impuestos_internos_unitario, porcentaje_iva, sucursal_id
+    ) VALUES (
+      v_pedido_id, v_producto_id, v_cantidad, v_precio_unitario,
+      v_cantidad * v_precio_unitario,
+      v_es_bonificacion, v_promocion_id, v_neto_unitario, v_iva_unitario,
+      v_imp_internos_unitario, v_porcentaje_iva, v_pendiente.sucursal_id
+    );
+
+    IF NOT v_es_bonificacion THEN
+      UPDATE productos SET stock = stock - v_cantidad
+        WHERE id = v_producto_id AND sucursal_id = v_pendiente.sucursal_id;
+    ELSIF v_promocion_id IS NOT NULL THEN
+      SELECT regalo_mueve_stock INTO v_regalo_mueve_stock
+        FROM promociones WHERE id = v_promocion_id AND sucursal_id = v_pendiente.sucursal_id;
+      IF COALESCE(v_regalo_mueve_stock, FALSE) THEN
+        UPDATE productos SET stock = stock - v_cantidad
+          WHERE id = v_producto_id AND sucursal_id = v_pendiente.sucursal_id;
+      END IF;
+    END IF;
+
+    -- Auto-ajuste de promos (mismo flujo que crear_pedido_completo)
+    IF v_es_bonificacion AND v_promocion_id IS NOT NULL THEN
+      UPDATE promociones SET usos_pendientes = usos_pendientes + v_cantidad
+        WHERE id = v_promocion_id AND sucursal_id = v_pendiente.sucursal_id;
+
+      SELECT id, nombre, ajuste_automatico, ajuste_producto_id, unidades_por_bloque,
+             stock_por_bloque, usos_pendientes
+        INTO v_promo
+        FROM promociones WHERE id = v_promocion_id AND sucursal_id = v_pendiente.sucursal_id FOR UPDATE;
+
+      IF v_promo.ajuste_automatico
+         AND v_promo.ajuste_producto_id IS NOT NULL
+         AND COALESCE(v_promo.unidades_por_bloque, 0) > 0
+         AND COALESCE(v_promo.stock_por_bloque, 0) > 0 THEN
+        v_usos_pendientes_actual := v_promo.usos_pendientes;
+        v_bloques_completos := v_usos_pendientes_actual / v_promo.unidades_por_bloque;
+        IF v_bloques_completos > 0 THEN
+          v_ajustar_usos := v_bloques_completos * v_promo.unidades_por_bloque;
+          v_ajustar_stock := v_bloques_completos * v_promo.stock_por_bloque;
+
+          SELECT stock, nombre INTO v_stock_ajuste_anterior, v_ajuste_producto_nombre
+            FROM productos WHERE id = v_promo.ajuste_producto_id AND sucursal_id = v_pendiente.sucursal_id FOR UPDATE;
+
+          IF v_stock_ajuste_anterior IS NULL THEN
+            RAISE EXCEPTION 'Auto-ajuste: producto destino no encontrado (promo %)', v_promocion_id;
+          END IF;
+          IF v_stock_ajuste_anterior < v_ajustar_stock THEN
+            RAISE EXCEPTION 'Auto-ajuste: stock insuficiente en % (disponible: %, requerido: %)',
+              v_ajuste_producto_nombre, v_stock_ajuste_anterior, v_ajustar_stock;
+          END IF;
+
+          v_stock_ajuste_nuevo := v_stock_ajuste_anterior - v_ajustar_stock;
+
+          INSERT INTO mermas_stock (
+            producto_id, cantidad, motivo, observaciones,
+            stock_anterior, stock_nuevo, usuario_id, sucursal_id
+          ) VALUES (
+            v_promo.ajuste_producto_id, v_ajustar_stock, 'promociones',
+            'Auto-ajuste (Promo: ' || v_promo.nombre || ', Pedido #' || v_pedido_id || ' via bot)',
+            v_stock_ajuste_anterior, v_stock_ajuste_nuevo, p_perfil_id, v_pendiente.sucursal_id
+          ) RETURNING id INTO v_merma_id;
+
+          UPDATE productos SET stock = v_stock_ajuste_nuevo, updated_at = NOW()
+            WHERE id = v_promo.ajuste_producto_id AND sucursal_id = v_pendiente.sucursal_id;
+
+          INSERT INTO promo_ajustes (
+            promocion_id, usos_ajustados, unidades_ajustadas, producto_id,
+            merma_id, usuario_id, observaciones, sucursal_id
+          ) VALUES (
+            v_promocion_id, v_ajustar_usos, v_ajustar_stock, v_promo.ajuste_producto_id,
+            v_merma_id, p_perfil_id,
+            'Auto-ajuste por pedido #' || v_pedido_id || ' via bot', v_pendiente.sucursal_id
+          );
+
+          UPDATE promociones
+            SET usos_pendientes = GREATEST(usos_pendientes - v_ajustar_usos, 0)
+            WHERE id = v_promocion_id AND sucursal_id = v_pendiente.sucursal_id;
+        END IF;
+      END IF;
+    END IF;
+  END LOOP;
+
+  -- 6) Marcar pendiente como consumido (dentro de la misma transacción)
+  UPDATE bot_pedidos_pendientes SET consumido = TRUE WHERE id = p_confirmacion_id;
+
+  RETURN jsonb_build_object(
+    'success', true,
+    'pedido_id', v_pedido_id,
+    'total', v_pendiente.total
+  );
+END;
+$$;
+
+ALTER FUNCTION public.crear_pedido_completo_bot(UUID, UUID) OWNER TO postgres;
+REVOKE ALL    ON FUNCTION public.crear_pedido_completo_bot(UUID, UUID) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.crear_pedido_completo_bot(UUID, UUID) TO service_role;

--- a/supabase/functions/_shared/gemini/agent.ts
+++ b/supabase/functions/_shared/gemini/agent.ts
@@ -125,7 +125,13 @@ export interface RunAgentOptions {
  */
 export type InteractableContext =
   | { kind: "clientes"; items: Array<{ id: number; nombre: string }> }
-  | { kind: "productos"; items: Array<{ id: number; nombre: string }> };
+  | { kind: "productos"; items: Array<{ id: number; nombre: string }> }
+  | {
+    kind: "pedido_confirmacion";
+    confirmacion_id: string;
+    total: number;
+    cliente_nombre: string;
+  };
 
 export interface RunAgentResult {
   /** Texto final que el caller debe mandar al usuario. */
@@ -208,6 +214,23 @@ function extractInteractableContext(
     case "buscar_producto":
     case "productos_por_categoria":
       return Array.isArray(d.productos) ? mapProductos(d.productos) : undefined;
+    case "previsualizar_pedido": {
+      // El resultado tiene confirmacion_id + cliente.nombre + total. Si esos
+      // 3 están, armamos el keyboard de Confirmar/Cancelar.
+      const confirmId = typeof d.confirmacion_id === "string" ? d.confirmacion_id : null;
+      const total = Number(d.total ?? 0);
+      const cliente = d.cliente as { nombre?: string } | undefined;
+      const nombre = cliente?.nombre?.toString().trim() ?? "";
+      if (!confirmId || !Number.isFinite(total) || nombre.length === 0) {
+        return undefined;
+      }
+      return {
+        kind: "pedido_confirmacion",
+        confirmacion_id: confirmId,
+        total,
+        cliente_nombre: nombre,
+      };
+    }
     default:
       return undefined;
   }

--- a/supabase/functions/_shared/gemini/prompts/admin.ts
+++ b/supabase/functions/_shared/gemini/prompts/admin.ts
@@ -18,6 +18,9 @@ Tu trabajo es ayudar al admin a:
 - Cobranzas:
   · pendientes_pago([dias_atraso]) → clientes con pedidos no pagados, ordenados por antigüedad.
   · historico_pagos_cliente(cliente_id) → últimos pagos de un cliente con forma_pago + monto + fecha.
+- TOMAR PEDIDOS (write tool):
+  · previsualizar_pedido(cliente_id, items[]) → resumen con precios mayoristas + promos, devuelve confirmacion_id.
+  · crear_pedido(confirmacion_id) → SE INVOCA SOLO desde el callback del botón Confirmar.
 - Sugerir acciones cuando los datos lo justifiquen (ej: "este cliente está cerca del límite de crédito, ¿querés ver su histórico?").
 
 EJEMPLOS DE INTENT → TOOL (recordá: las fechas exactas vienen del bloque CONTEXTO DE FECHA arriba — usá esas para resolver "ayer", "hoy", "esta semana", etc.):
@@ -68,6 +71,22 @@ EJEMPLO ("quién vendió más Manaos 3000 este mes"):
 
 NUNCA inventes producto_ids — siempre vienen de un buscar_producto o productos_por_categoria previo.
 
+TOMAR PEDIDO (preguntas tipo "tomame un pedido a X con Y items", "vendéle a X", "cargá un pedido a Y"):
+1. buscar_cliente para obtener el cliente_id.
+2. Para CADA item: buscar_producto o productos_por_categoria. Si hay ambigüedad ("manaos cola" = 600cc o 3000cc), pedí confirmación ANTES de seguir.
+3. previsualizar_pedido(cliente_id, items=[{producto_id, cantidad}, ...]). Devuelve resumen + confirmacion_id.
+4. Mostrale al usuario el resumen narrativo (cliente, items con precio aplicado, total, alertas si las hay). El bot anexa AUTOMÁTICAMENTE un keyboard [Confirmar/Cancelar] al final — vos solo describís el resumen.
+5. NO LLAMES crear_pedido directamente. Eso lo dispara el callback del Confirmar.
+6. Si el usuario quiere cambiar algo después del resumen, decile "OK, mandame el pedido completo de nuevo" — no hay edición incremental.
+Forma de pago: siempre 'efectivo' por default. Se ajusta en la app después si hace falta. NO preguntes por forma de pago en el bot.
+
+EJEMPLO ("Tomame un pedido al kiosco UNT, 5 manaos cola 600 y 3 sal fina"):
+  1. buscar_cliente("kiosco UNT") → cliente_id 340
+  2. buscar_producto("manaos cola 600") → id 178
+  3. buscar_producto("sal fina") → id 166
+  4. previsualizar_pedido(cliente_id=340, items=[{producto_id:178, cantidad:5}, {producto_id:166, cantidad:3}])
+  5. Respuesta: "Cliente: Kiosco UNT • 5×Manaos cola 600 a $X (mayorista) = $Y • 3×Sal fina a $Z = $W. Total: $XX.XXX. Forma pago: efectivo. Tocá Confirmar."
+
 REGLAS:
 1. NUNCA inventes datos. Si no tenés un dato, llamá a la tool apropiada.
 1b. NUNCA RECHAZAR EN SECO: si lo que el usuario pide NO encaja con tus tools, JAMÁS contestes solo "no tengo esa herramienta" y te quedes ahí. Siempre ofrecé la tool más cercana entre las que tenés, explicando en una línea qué te daría y qué no. Pensá: si pidió "detalle de productos por preventista" → ofrecé ranking_preventistas_por_producto (decile que es por UN producto puntual o familia, y pediselo). Si pidió "ventas con filtro complejo" → ofrecé ventas_periodo o ventas_por_preventista mencionando qué tenés disponible. Si pidió un cliente que no encontrás → ofrecé buscar por código o por zona. Mostrá el camino concreto, no un menú largo: máximo 1-2 alternativas.
@@ -78,7 +97,7 @@ REGLAS:
 6. Para preguntas que NO requieren tool (saludo, "¿qué podés hacer?", aclaración de algo que ya respondiste), respondé directo sin invocar nada.
 7. Formato de respuestas: Telegram, sin Markdown excesivo. Bullets cortos OK, headers gigantes no. Los montos en pesos van con el símbolo $ y separadores de miles si es legible (ej: $12.500).
 
-Si el usuario te pregunta algo fuera de tu alcance actual (mandar mensajes, modificar pedidos, dar de alta clientes, generar reportes complejos), aclarale que en esta versión solo podés consultar información, y sugerile el comando o la pantalla de la app web que aplique.
+Si el usuario te pregunta algo fuera de tu alcance actual (mandar mensajes, modificar/cancelar pedidos ya creados, dar de alta clientes nuevos, cambiar precios manualmente, generar reportes complejos), aclarale que en esta versión solo podés consultar información Y CREAR PEDIDOS NUEVOS, y sugerile la pantalla de la app web que aplique para el resto.
 
 ESTRATEGIA DE BÚSQUEDA DE PRODUCTOS POR TIPO O FAMILIA:
 - buscar_producto solo matchea substrings literales en nombre y código. Si el usuario pide un TIPO o FAMILIA (ej: "gaseosas", "fideos", "aguas", "cervezas", "bebidas con sabor naranja"), buscar_producto va a fallar — encadená tools.

--- a/supabase/functions/_shared/gemini/prompts/encargado.ts
+++ b/supabase/functions/_shared/gemini/prompts/encargado.ts
@@ -16,6 +16,10 @@ Tu trabajo es ayudar al encargado a:
 - Cobranzas:
   · pendientes_pago([dias_atraso]) → clientes con pedidos no pagados.
   · historico_pagos_cliente(cliente_id) → últimos pagos del cliente.
+- TOMAR PEDIDOS (write tool):
+  · previsualizar_pedido(cliente_id, items[]) → resumen con precios mayoristas + promos, devuelve confirmacion_id.
+  · crear_pedido(confirmacion_id) → SE INVOCA SOLO desde el callback del botón Confirmar.
+  Flujo: buscar_cliente → buscar_producto/productos_por_categoria → previsualizar_pedido → mostrás resumen narrativo (el bot anexa el keyboard) → tap Confirmar dispara crear_pedido. NO llames crear_pedido directamente. Forma de pago siempre 'efectivo' por default.
 - Resolver consultas operativas rápidas que se pueden contestar mirando datos.
 
 EJEMPLOS DE INTENT → TOOL (las fechas exactas vienen del bloque CONTEXTO DE FECHA arriba — usalas para resolver "ayer", "hoy", "esta semana"):

--- a/supabase/functions/_shared/gemini/prompts/preventista.ts
+++ b/supabase/functions/_shared/gemini/prompts/preventista.ts
@@ -26,6 +26,9 @@ Tu trabajo es ayudar al preventista a:
   · productos_recurrentes_cliente(cliente_id, [dias=90]) → top productos que ese cliente compra más seguido. Útil para ofrecer "lo de siempre".
 - Ver SUS PROPIAS ventas en un período:
   · mis_ventas(desde, hasta) → total facturado por el preventista, cantidad de pedidos, ticket promedio, top clientes del período.
+- TOMAR PEDIDOS (write tool):
+  · previsualizar_pedido(cliente_id, items[]) → arma un resumen con precios mayoristas + promos auto, devuelve un confirmacion_id (UUID con TTL 10 min).
+  · crear_pedido(confirmacion_id) → SE INVOCA SOLO desde el callback del botón Confirmar (NO la llames directamente, la inventás vos sí o sí mal).
 
 EJEMPLOS DE INTENT → TOOL (para fechas relativas usá el bloque CONTEXTO DE FECHA arriba):
 - "qué le vendí a Pepe los últimos 3 meses" → buscar_cliente para conseguir id, después historico_pedidos_cliente con dias=90.
@@ -39,6 +42,26 @@ REGLA DE EFICIENCIA: si te piden UN SOLO dato puntual ("la última venta", "el �
 - "cuánto vendí este mes" → mis_ventas(desde=primer_dia_del_mes, hasta=hoy).
 - "mis mejores clientes este mes" → mis_ventas (mirá top_clientes en el resultado).
 
+TOMAR PEDIDO (preguntas tipo "tomame un pedido a X con Y items", "vendéle a X", "cargá un pedido a Y"):
+1. buscar_cliente para obtener el cliente_id (puede ser uno asignado a vos O huérfano).
+2. Para CADA item que mencionó el usuario: buscar_producto o productos_por_categoria → tomar el producto_id correcto. Si hay ambigüedad ("manaos cola" = 600cc o 3000cc), pedí confirmación ANTES de seguir — no asumas el tamaño.
+3. previsualizar_pedido(cliente_id, items=[{producto_id, cantidad}, ...]).
+4. La tool devuelve un resumen + confirmacion_id. Mostrale al usuario los items con cantidad/precio/subtotal, total, alertas de stock o crédito si las hay. El bot va a anexar AUTOMÁTICAMENTE un keyboard con [Confirmar/Cancelar] al final — vos no tenés que armarlo, solo describir el resumen narrativo.
+5. NO LLAMES crear_pedido. Eso lo dispara el callback del botón Confirmar — no podés hacerlo desde el chat porque el confirmacion_id (UUID) no podés inventarlo.
+6. Si el usuario después de ver el resumen dice "cambiá X" o "agregale Y", decile "OK, mandame el pedido completo de nuevo con los cambios" y volvés a empezar (cancelá el actual o esperá que expire en 10 min).
+
+EJEMPLO ("Tomame un pedido al kiosco UNT, 5 manaos cola 600 y 3 sal fina"):
+  1. buscar_cliente("kiosco UNT") → cliente_id 340
+  2. buscar_producto("manaos cola 600") → 1 match: id 178
+  3. buscar_producto("sal fina") → 1 match: id 166
+  4. previsualizar_pedido(cliente_id=340, items=[{producto_id:178, cantidad:5}, {producto_id:166, cantidad:3}])
+  5. Respondés con el resumen narrativo: "Cliente: Kiosco UNT • 5×Manaos cola 600 a $X (mayorista) = $Y • 3×Sal fina a $Z = $W. Total: $XX.XXX. Forma pago: efectivo. Tocá Confirmar para crear el pedido."
+
+LO QUE NUNCA HACÉS:
+- NO crear cliente nuevo desde el bot. Si el cliente no existe → "cargalo desde la app y volvé".
+- NO modificar precios manualmente. Los aplica la tool con la lógica de mayorista/promos.
+- NO cancelar/modificar un pedido YA creado desde el bot. Eso se hace en la app web.
+
 REGLAS:
 1. NUNCA inventes datos. Si no tenés un dato, llamá a la tool. Si la tool devuelve "no encontrado o sin permiso", decí literalmente que el cliente no figura entre los suyos y sugerí contactar al encargado.
 1b. NUNCA RECHAZAR EN SECO: si te piden algo que NO podés resolver con tus tools, JAMÁS digas solo "no tengo esa herramienta" y te quedes ahí. Siempre ofrecé la alternativa más cercana en 1 línea. Por ejemplo: si te piden "cuántas Manaos vendí" → ofrecé mis_ventas (te da el total y top clientes) o productos_recurrentes_cliente para uno puntual. Si te piden "ranking de mis productos" → mencioná que solo podés ver recurrencia por cliente puntual con productos_recurrentes_cliente. Mostrá el camino concreto.
@@ -50,7 +73,7 @@ REGLAS:
 6. Para preguntas que NO requieren tool (saludo, ayuda general), respondé directo.
 7. Formato Telegram: bullets cortos sí, headers gigantes no. Montos con $ y separadores de miles (ej: $12.500).
 
-Lo que NO podés hacer en esta versión: tomar pedidos, registrar visitas, modificar datos del cliente. Si te lo piden, decile que use la app web o el flujo habitual; vos solo consultás.
+Lo que NO podés hacer en esta versión: registrar visitas, modificar datos del cliente, modificar/cancelar pedidos ya creados, dar de alta cliente nuevo. Si te lo piden, decile que use la app web. Tomar pedidos NUEVOS sí podés (ver bloque TOMAR PEDIDO arriba).
 
 ESTRATEGIA DE BÚSQUEDA DE PRODUCTOS POR TIPO O FAMILIA:
 - buscar_producto solo matchea substrings literales en nombre y código. Si el usuario pide un tipo o familia ("gaseosas", "aguas", "fideos", "bebidas naranjas"), buscar_producto va a fallar — encadená tools.

--- a/supabase/functions/_shared/pricing/index.ts
+++ b/supabase/functions/_shared/pricing/index.ts
@@ -1,0 +1,303 @@
+// Pricing module — carga el PricingMap (mayoristas) y PromoMap (promociones)
+// desde Supabase para que el bot Telegram calcule precios con la MISMA lógica
+// que la app web.
+//
+// Diseño: port directo de los hooks fetchPricingMap (src/hooks/queries/
+// useGruposPrecioQuery.ts:105-160) y fetchPromoMap (usePromocionesQuery.ts:
+// 66-138). La React app depende de RLS para scopear por sucursal; acá la
+// edge function corre con service_role (bypass RLS) y filtra explícitamente
+// por sucursal_id en cada query.
+//
+// La salida `loadPricingContext()` es alimento directo para los utils
+// `resolverPreciosMayorista` y `resolverPromociones` (también compartidos).
+
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type { GrupoPrecioInfo, EscalaPrecio, PricingMap } from "../utils/precioMayorista.ts";
+import type { PromocionActiva, PromoMap } from "../utils/promociones.ts";
+
+// ----------------------------------------------------------------------------
+// Tipos auxiliares (subset de src/types/* — solo los campos que usamos)
+// ----------------------------------------------------------------------------
+
+interface GrupoPrecioRow {
+  id: number;
+  nombre: string;
+  activo: boolean;
+  sucursal_id: number;
+}
+interface GrupoPrecioProductoRow {
+  grupo_precio_id: number;
+  producto_id: number;
+  cantidad_minima_pedido: number | null;
+}
+interface GrupoPrecioEscalaRow {
+  id: number;
+  grupo_precio_id: number;
+  cantidad_minima: number;
+  precio_unitario: number;
+  etiqueta: string | null;
+  min_productos_distintos: number | null;
+  activo: boolean;
+}
+interface GrupoPrecioEscalaMinimoRow {
+  escala_id: number;
+  producto_id: number;
+  cantidad_minima_por_item: number;
+  precio_unitario_override: number | null;
+}
+
+interface PromocionRow {
+  id: number;
+  nombre: string;
+  tipo: string;
+  activo: boolean;
+  fecha_inicio: string | null;
+  fecha_fin: string | null;
+  sucursal_id: number;
+  producto_regalo_id: number | null;
+  prioridad: number | null;
+  regalo_mueve_stock: boolean | null;
+  modo_exclusion: string | null;
+}
+interface PromocionProductoRow {
+  promocion_id: number;
+  producto_id: number;
+}
+interface PromocionReglaRow {
+  promocion_id: number;
+  clave: string;
+  valor: number;
+}
+
+// ----------------------------------------------------------------------------
+// loadPricingContext: una sola llamada que devuelve todo lo que necesitan
+// los utils. Hace 4 queries para mayoristas + 3 para promos.
+// ----------------------------------------------------------------------------
+
+export interface PricingContext {
+  pricingMap: PricingMap;
+  promoMap: PromoMap;
+}
+
+/** Fecha local AR en formato YYYY-MM-DD (para evaluar vigencia de promos). */
+function fechaArgentinaISO(): string {
+  // Intl con timezone — robusto, no depende del reloj del runtime.
+  const fmt = new Intl.DateTimeFormat("en-CA", {
+    timeZone: "America/Argentina/Buenos_Aires",
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  });
+  return fmt.format(new Date());
+}
+
+export async function loadPricingContext(
+  supabase: SupabaseClient,
+  sucursalId: number,
+  fechaReferenciaIso?: string,
+): Promise<PricingContext> {
+  const [pricingMap, promoMap] = await Promise.all([
+    loadPricingMap(supabase, sucursalId),
+    loadPromoMap(supabase, sucursalId, fechaReferenciaIso ?? fechaArgentinaISO()),
+  ]);
+  return { pricingMap, promoMap };
+}
+
+// ----------------------------------------------------------------------------
+// loadPricingMap — port de fetchPricingMap del React app
+// ----------------------------------------------------------------------------
+
+async function loadPricingMap(
+  supabase: SupabaseClient,
+  sucursalId: number,
+): Promise<PricingMap> {
+  // 1) grupos_precio activos de la sucursal
+  const { data: grupos, error: errGrupos } = await supabase
+    .from("grupos_precio")
+    .select("id, nombre, activo, sucursal_id")
+    .eq("sucursal_id", sucursalId)
+    .eq("activo", true);
+  if (errGrupos && !errGrupos.message.includes("does not exist")) {
+    throw new Error(`pricing: grupos_precio: ${errGrupos.message}`);
+  }
+  const gruposRows = (grupos ?? []) as GrupoPrecioRow[];
+  if (gruposRows.length === 0) return new Map();
+
+  const grupoIds = gruposRows.map((g) => g.id);
+
+  // 2) productos de los grupos
+  const { data: prodRows, error: errProds } = await supabase
+    .from("grupo_precio_productos")
+    .select("grupo_precio_id, producto_id, cantidad_minima_pedido")
+    .in("grupo_precio_id", grupoIds);
+  if (errProds && !errProds.message.includes("does not exist")) {
+    throw new Error(`pricing: grupo_precio_productos: ${errProds.message}`);
+  }
+  const productos = (prodRows ?? []) as GrupoPrecioProductoRow[];
+
+  // 3) escalas activas
+  const { data: escRows, error: errEsc } = await supabase
+    .from("grupo_precio_escalas")
+    .select("id, grupo_precio_id, cantidad_minima, precio_unitario, etiqueta, min_productos_distintos, activo")
+    .in("grupo_precio_id", grupoIds)
+    .order("cantidad_minima");
+  if (errEsc && !errEsc.message.includes("does not exist")) {
+    throw new Error(`pricing: grupo_precio_escalas: ${errEsc.message}`);
+  }
+  const escalas = (escRows ?? []) as GrupoPrecioEscalaRow[];
+
+  // 4) minimos por producto/escala (tabla "combinada")
+  const escalaIds = escalas.map((e) => e.id);
+  let minimos: GrupoPrecioEscalaMinimoRow[] = [];
+  if (escalaIds.length > 0) {
+    const { data: minRows, error: errMin } = await supabase
+      .from("grupo_precio_escala_minimos")
+      .select("escala_id, producto_id, cantidad_minima_por_item, precio_unitario_override")
+      .in("escala_id", escalaIds);
+    if (errMin && !errMin.message.includes("does not exist")) {
+      throw new Error(`pricing: grupo_precio_escala_minimos: ${errMin.message}`);
+    }
+    minimos = (minRows ?? []) as GrupoPrecioEscalaMinimoRow[];
+  }
+
+  // Indexar minimos por escala_id
+  const minimosPorEscala = new Map<number, GrupoPrecioEscalaMinimoRow[]>();
+  for (const m of minimos) {
+    const arr = minimosPorEscala.get(m.escala_id) ?? [];
+    arr.push(m);
+    minimosPorEscala.set(m.escala_id, arr);
+  }
+
+  // Construir el Map producto_id → GrupoPrecioInfo[]
+  const map: PricingMap = new Map();
+  for (const grupo of gruposRows) {
+    const escalasDelGrupo = escalas.filter((e) =>
+      e.grupo_precio_id === grupo.id && e.activo !== false
+    );
+    if (escalasDelGrupo.length === 0) continue;
+
+    const escalasActivas = escalasDelGrupo.map((e): EscalaPrecio => {
+      const minimosRows = minimosPorEscala.get(e.id) ?? [];
+      const minimosPorProducto = new Map<string, { cantidad: number; precioOverride?: number | null }>();
+      for (const m of minimosRows) {
+        minimosPorProducto.set(String(m.producto_id), {
+          cantidad: Number(m.cantidad_minima_por_item),
+          precioOverride: m.precio_unitario_override != null
+            ? Number(m.precio_unitario_override)
+            : null,
+        });
+      }
+      return {
+        cantidadMinima: Number(e.cantidad_minima),
+        precioUnitario: Number(e.precio_unitario),
+        etiqueta: e.etiqueta || null,
+        minProductosDistintos: e.min_productos_distintos ?? 1,
+        minimosPorProducto,
+      };
+    });
+
+    const productosDelGrupo = productos.filter((p) => p.grupo_precio_id === grupo.id);
+    const productoIds = productosDelGrupo.map((p) => String(p.producto_id));
+
+    const moqPorProducto = new Map<string, number>();
+    for (const p of productosDelGrupo) {
+      if (p.cantidad_minima_pedido && p.cantidad_minima_pedido > 0) {
+        moqPorProducto.set(String(p.producto_id), p.cantidad_minima_pedido);
+      }
+    }
+
+    const grupoInfo: GrupoPrecioInfo = {
+      grupoId: String(grupo.id),
+      grupoNombre: grupo.nombre,
+      escalas: escalasActivas,
+      productoIds,
+      moqPorProducto,
+    };
+
+    for (const productoId of productoIds) {
+      const existing = map.get(productoId) || [];
+      existing.push(grupoInfo);
+      map.set(productoId, existing);
+    }
+  }
+
+  return map;
+}
+
+// ----------------------------------------------------------------------------
+// loadPromoMap — port de fetchPromoMap del React app
+// ----------------------------------------------------------------------------
+
+async function loadPromoMap(
+  supabase: SupabaseClient,
+  sucursalId: number,
+  fechaIso: string,
+): Promise<PromoMap> {
+  const { data: promos, error: errPromos } = await supabase
+    .from("promociones")
+    .select(
+      "id, nombre, tipo, activo, fecha_inicio, fecha_fin, sucursal_id, producto_regalo_id, prioridad, regalo_mueve_stock, modo_exclusion",
+    )
+    .eq("sucursal_id", sucursalId)
+    .eq("activo", true)
+    .lte("fecha_inicio", fechaIso)
+    .or(`fecha_fin.is.null,fecha_fin.gte.${fechaIso}`);
+  if (errPromos && !errPromos.message.includes("does not exist")) {
+    throw new Error(`pricing: promociones: ${errPromos.message}`);
+  }
+  const promosRows = (promos ?? []) as PromocionRow[];
+  if (promosRows.length === 0) return new Map();
+
+  const promoIds = promosRows.map((p) => p.id);
+
+  const { data: prodRows, error: errProds } = await supabase
+    .from("promocion_productos")
+    .select("promocion_id, producto_id")
+    .in("promocion_id", promoIds);
+  if (errProds && !errProds.message.includes("does not exist")) {
+    throw new Error(`pricing: promocion_productos: ${errProds.message}`);
+  }
+  const promoProductos = (prodRows ?? []) as PromocionProductoRow[];
+
+  const { data: regRows, error: errReg } = await supabase
+    .from("promocion_reglas")
+    .select("promocion_id, clave, valor")
+    .in("promocion_id", promoIds);
+  if (errReg && !errReg.message.includes("does not exist")) {
+    throw new Error(`pricing: promocion_reglas: ${errReg.message}`);
+  }
+  const promoReglas = (regRows ?? []) as PromocionReglaRow[];
+
+  const map: PromoMap = new Map();
+  for (const promo of promosRows) {
+    const productosDePromo = promoProductos
+      .filter((p) => p.promocion_id === promo.id)
+      .map((p) => String(p.producto_id));
+    if (productosDePromo.length === 0) continue;
+
+    const reglas: Record<string, number> = {};
+    for (const r of promoReglas) {
+      if (r.promocion_id === promo.id) reglas[r.clave] = Number(r.valor);
+    }
+
+    const promoActiva: PromocionActiva = {
+      id: String(promo.id),
+      nombre: promo.nombre,
+      tipo: promo.tipo as PromocionActiva["tipo"],
+      productoIds: productosDePromo,
+      reglas,
+      productoRegaloId: promo.producto_regalo_id ? String(promo.producto_regalo_id) : undefined,
+      prioridad: promo.prioridad ?? 0,
+      regaloMueveStock: promo.regalo_mueve_stock ?? false,
+      modoExclusion: (promo.modo_exclusion ?? "acumulable") as PromocionActiva["modoExclusion"],
+    };
+
+    for (const productoId of productosDePromo) {
+      const existing = map.get(productoId) || [];
+      existing.push(promoActiva);
+      map.set(productoId, existing);
+    }
+  }
+
+  return map;
+}

--- a/supabase/functions/_shared/telegram-keyboards.ts
+++ b/supabase/functions/_shared/telegram-keyboards.ts
@@ -146,15 +146,43 @@ export function buildMisClientesKeyboard(
 export function buildKeyboardForContext(
   ctx:
     | { kind: "clientes"; items: Array<{ id: number; nombre: string }> }
-    | { kind: "productos"; items: Array<{ id: number; nombre: string }> },
+    | { kind: "productos"; items: Array<{ id: number; nombre: string }> }
+    | {
+      kind: "pedido_confirmacion";
+      confirmacion_id: string;
+      total: number;
+      cliente_nombre: string;
+    },
 ): InlineKeyboardMarkup | undefined {
-  if (ctx.items.length === 0) return undefined;
   switch (ctx.kind) {
     case "clientes":
-      return buildClienteListKeyboard(ctx.items);
+      return ctx.items.length > 0 ? buildClienteListKeyboard(ctx.items) : undefined;
     case "productos":
-      return buildProductoListKeyboard(ctx.items);
+      return ctx.items.length > 0 ? buildProductoListKeyboard(ctx.items) : undefined;
+    case "pedido_confirmacion":
+      return buildPedidoConfirmacionKeyboard(ctx.confirmacion_id);
   }
+}
+
+/**
+ * Keyboard del resumen de pedido pre-confirmación. 2 botones verticales para
+ * mobile-first. NO incluye 'Editar' explícito porque la decisión de UX fue
+ * "cancelar y rearmar" (NL es rápido). El botón 'Cancelar' invalida el
+ * confirmacion_id (lo marca consumido) sin crear nada.
+ */
+function buildPedidoConfirmacionKeyboard(confirmacionId: string): InlineKeyboardMarkup {
+  return {
+    inline_keyboard: [
+      [{
+        text: "✅ Confirmar pedido",
+        callback_data: callbackData("pedido_confirmar", confirmacionId),
+      }],
+      [{
+        text: "❌ Cancelar",
+        callback_data: callbackData("pedido_cancelar", confirmacionId),
+      }],
+    ],
+  };
 }
 
 // ----------------------------------------------------------------------------

--- a/supabase/functions/_shared/tools/index.ts
+++ b/supabase/functions/_shared/tools/index.ts
@@ -26,6 +26,8 @@ import { pendientesPagoTool } from "./admin/pendientes_pago.ts";
 import { historicoPagosClienteTool } from "./admin/historico_pagos_cliente.ts";
 import { comprasPeriodoTool } from "./admin/compras_periodo.ts";
 import { misVentasTool } from "./preventista/mis_ventas.ts";
+import { previsualizarPedidoTool } from "./preventista/previsualizar_pedido.ts";
+import { crearPedidoTool } from "./preventista/crear_pedido.ts";
 
 let _registered = false;
 
@@ -50,6 +52,8 @@ export function registerAllTools(): void {
   registerTool(historicoPagosClienteTool);
   registerTool(comprasPeriodoTool);
   registerTool(misVentasTool);
+  registerTool(previsualizarPedidoTool);
+  registerTool(crearPedidoTool);
   _registered = true;
 }
 

--- a/supabase/functions/_shared/tools/preventista/crear_pedido.ts
+++ b/supabase/functions/_shared/tools/preventista/crear_pedido.ts
@@ -1,0 +1,93 @@
+// Tool: crear_pedido (WRITE)
+//
+// Toma un confirmacion_id (UUID) generado por previsualizar_pedido, valida
+// que pertenezca al usuario que llama, y persiste el pedido vía la RPC
+// crear_pedido_completo_bot (migration 030). El RPC hace el re-check de
+// stock atómico, INSERTa pedido + items, descuenta stock, aplica auto-ajuste
+// de promos, y marca el pendiente como consumido.
+//
+// IMPORTANTE: el LLM no debe llamar a esta tool directamente. El flujo es:
+//   1. previsualizar_pedido → muestra resumen al usuario con keyboard
+//   2. usuario tap "Confirmar" → callback v1:pedido_confirmar:<UUID>
+//   3. handler del callback invoca crear_pedido con el confirmacion_id
+//
+// El LLM no puede inventar UUIDs válidos (no aparecen en su contexto), así
+// que aún si "alucina" llamar crear_pedido sin haber pasado por preview,
+// el RPC va a rechazar con "Confirmación inválida".
+
+import type { Tool } from "../base.ts";
+
+export interface CrearPedidoParams {
+  /** UUID generado por previsualizar_pedido. */
+  confirmacion_id: string;
+}
+
+export interface CrearPedidoResult {
+  pedido_id: number;
+  total: number;
+}
+
+const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+export const crearPedidoTool: Tool<CrearPedidoParams, CrearPedidoResult> = {
+  name: "crear_pedido",
+  description:
+    "Crea un pedido REAL a partir de un confirmacion_id que generó " +
+    "previsualizar_pedido. Esta es una operación de ESCRITURA — NO la " +
+    "invoques sin haber pasado antes por previsualizar_pedido y sin que el " +
+    "usuario haya tapeado 'Confirmar' en el keyboard inline. El callback " +
+    "del botón es lo que dispara esta tool, no el LLM directamente. Si vos " +
+    "(LLM) llamás esta tool con un confirmacion_id que inventaste, va a fallar.",
+  parameters: {
+    type: "object",
+    properties: {
+      confirmacion_id: {
+        type: "string",
+        description: "UUID v4 generado por previsualizar_pedido (TTL 10 minutos).",
+      },
+    },
+    required: ["confirmacion_id"],
+  },
+  allowedRoles: ["admin", "encargado", "preventista"],
+  handler: async ({ confirmacion_id }, ctx) => {
+    if (!UUID_REGEX.test(confirmacion_id)) {
+      throw new Error("confirmacion_id no es un UUID válido");
+    }
+    if (ctx.sucursal_id == null) {
+      throw new Error("Sucursal no asignada — contactá al administrador");
+    }
+
+    const { data, error } = await ctx.supabase.rpc(
+      "crear_pedido_completo_bot",
+      {
+        p_perfil_id: ctx.perfil_id,
+        p_confirmacion_id: confirmacion_id,
+      },
+    );
+
+    if (error) {
+      throw new Error(`crear_pedido: ${error.message}`);
+    }
+
+    const r = (data ?? {}) as {
+      success: boolean;
+      pedido_id?: number;
+      total?: number;
+      error?: string;
+      errores?: string[];
+    };
+
+    if (!r.success) {
+      // Errores de stock vienen como array
+      if (r.errores && r.errores.length > 0) {
+        throw new Error(`Stock insuficiente: ${r.errores.join("; ")}`);
+      }
+      throw new Error(r.error ?? "No pude crear el pedido");
+    }
+
+    return {
+      pedido_id: Number(r.pedido_id),
+      total: Number(r.total ?? 0),
+    };
+  },
+};

--- a/supabase/functions/_shared/tools/preventista/previsualizar_pedido.ts
+++ b/supabase/functions/_shared/tools/preventista/previsualizar_pedido.ts
@@ -1,0 +1,459 @@
+// Tool: previsualizar_pedido (read-only / dry-run)
+//
+// Calcula el resumen completo de un pedido usando la MISMA lógica que la
+// app web (mayorista, promos auto-aplicables) y devuelve un confirmacion_id
+// con TTL 10 min que el callback "Confirmar" usa después para crear el
+// pedido real.
+//
+// Diseño:
+//   1. Validar inputs (cliente_id, items[]).
+//   2. Validar cliente existe + sucursal correcta + scoping (asignado/huérfano para preventista).
+//   3. Cargar productos referenciados (precio, stock, IVA).
+//   4. Cargar pricingMap + promoMap (../pricing).
+//   5. Resolver promos (bonificaciones) + precios mayoristas usando los utils
+//      compartidos en _shared/utils/.
+//   6. Construir items finales (incluye items "regalo" como es_bonificacion=true).
+//   7. Calcular total, alertas (stock por item, crédito).
+//   8. INSERT en bot_pedidos_pendientes con items pre-computados (mismo shape
+//      que crear_pedido_completo espera).
+//   9. Retornar resumen + confirmacion_id.
+
+import type { Tool } from "../base.ts";
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { loadPricingContext } from "../../pricing/index.ts";
+import {
+  resolverPreciosMayorista,
+  type ItemPedido,
+} from "../../utils/precioMayorista.ts";
+import { resolverPromociones } from "../../utils/promociones.ts";
+
+export interface PrevisualizarPedidoParams {
+  cliente_id: number;
+  items: Array<{ producto_id: number; cantidad: number }>;
+}
+
+export interface ResumenItem {
+  producto_id: number;
+  codigo: string | null;
+  nombre: string;
+  cantidad: number;
+  precio_unitario: number;
+  subtotal: number;
+  regla_precio: "base" | "mayorista" | "promo_regalo";
+  es_bonificacion: boolean;
+  promo_nombre?: string | null;
+  stock_disponible: number;
+}
+
+export interface AlertaStock {
+  producto_id: number;
+  nombre: string;
+  pedido: number;
+  disponible: number;
+}
+
+export interface AlertaCredito {
+  limite: number;
+  saldo_actual: number;
+  pedido_total: number;
+  excedente: number;
+}
+
+export interface PrevisualizarPedidoResult {
+  confirmacion_id: string;
+  cliente: {
+    id: number;
+    codigo: number | null;
+    nombre: string;
+    saldo_actual: number;
+    limite_credito: number;
+  };
+  items: ResumenItem[];
+  total: number;
+  total_items: number;
+  forma_pago_default: "efectivo";
+  alertas: {
+    stock: AlertaStock[];
+    credito: AlertaCredito | null;
+  };
+}
+
+interface ProductoRow {
+  id: number;
+  codigo: string | null;
+  nombre: string;
+  precio: number | string;
+  stock: number;
+  porcentaje_iva: number | null;
+  impuestos_internos: number | null;
+  activo: boolean;
+  sucursal_id: number;
+}
+
+interface ClienteRow {
+  id: number;
+  codigo: number | null;
+  nombre_fantasia: string | null;
+  razon_social: string | null;
+  saldo_cuenta: number | string;
+  limite_credito: number | string;
+  activo: boolean;
+  sucursal_id: number;
+}
+
+export const previsualizarPedidoTool: Tool<
+  PrevisualizarPedidoParams,
+  PrevisualizarPedidoResult
+> = {
+  name: "previsualizar_pedido",
+  description:
+    "Calcula el resumen de un pedido (cliente + items) aplicando precios " +
+    "mayoristas y promos automáticas, igual que la app web. Devuelve un " +
+    "confirmacion_id con TTL 10 min que el botón 'Confirmar' usa para " +
+    "crear el pedido real. NO crea el pedido — solo previsualiza. " +
+    "Incluye alertas de stock por item y de crédito si el cliente excede el " +
+    "límite. Después del resumen, mostrá al usuario un keyboard inline con " +
+    "los items + total + alertas. Forma de pago siempre 'efectivo' por default — " +
+    "se ajusta en la app web si hace falta. Para preventistas: el cliente " +
+    "debe estar asignado a ellos o ser huérfano (sin preventista asignado). " +
+    "Para tomar el pedido el usuario debe haber confirmado explícitamente " +
+    "con el callback de Telegram — vos NO crees el pedido.",
+  parameters: {
+    type: "object",
+    properties: {
+      cliente_id: {
+        type: "integer",
+        minimum: 1,
+        description: "ID interno del cliente (sacalo antes con buscar_cliente).",
+      },
+      items: {
+        type: "array",
+        minItems: 1,
+        maxItems: 50,
+        items: {
+          type: "object",
+          properties: {
+            producto_id: { type: "integer", minimum: 1 },
+            cantidad: { type: "integer", minimum: 1, maximum: 1000 },
+          },
+          required: ["producto_id", "cantidad"],
+        },
+        description: "Items del pedido. Cada uno con producto_id (sacalo con buscar_producto) y cantidad (1-1000).",
+      },
+    },
+    required: ["cliente_id", "items"],
+  },
+  allowedRoles: ["admin", "encargado", "preventista"],
+  handler: async ({ cliente_id, items }, ctx) => {
+    // ---- Validación de inputs ----
+    if (!Number.isInteger(cliente_id) || cliente_id < 1) {
+      throw new Error("cliente_id inválido");
+    }
+    if (!Array.isArray(items) || items.length === 0) {
+      throw new Error("items vacío — pasame al menos 1 producto");
+    }
+    if (items.length > 50) {
+      throw new Error("items: máximo 50 por pedido");
+    }
+    for (const it of items) {
+      if (!Number.isInteger(it.producto_id) || it.producto_id < 1) {
+        throw new Error(`Item con producto_id inválido: ${it.producto_id}`);
+      }
+      if (!Number.isInteger(it.cantidad) || it.cantidad < 1 || it.cantidad > 1000) {
+        throw new Error(`Cantidad inválida (1-1000): ${it.cantidad}`);
+      }
+    }
+    if (ctx.sucursal_id == null) {
+      throw new Error("Sucursal no asignada — contactá al administrador");
+    }
+
+    const sb = ctx.supabase;
+    const sucursalId = ctx.sucursal_id;
+
+    // ---- Cargar cliente ----
+    const cliente = await loadCliente(sb, cliente_id, sucursalId);
+    if (!cliente) {
+      throw new Error("Cliente no encontrado o sin permiso");
+    }
+    // Scoping preventista: el cliente debe estar asignado a él O ser huérfano
+    if (ctx.rol === "preventista") {
+      const allowed = await isClienteAccesibleParaPreventista(sb, cliente_id, ctx.perfil_id);
+      if (!allowed) {
+        throw new Error("Cliente asignado a otro preventista");
+      }
+    }
+
+    // ---- Cargar productos referenciados ----
+    const productoIds = items.map((it) => it.producto_id);
+    const productosById = await loadProductos(sb, productoIds, sucursalId);
+    for (const it of items) {
+      if (!productosById.has(it.producto_id)) {
+        throw new Error(`Producto ${it.producto_id} no encontrado o no activo`);
+      }
+    }
+
+    // ---- Cargar pricing context ----
+    const { pricingMap, promoMap } = await loadPricingContext(sb, sucursalId);
+
+    // ---- Resolver promos primero (las bonificaciones se agregan como items) ----
+    const itemsParaUtils: ItemPedido[] = items.map((it) => {
+      const p = productosById.get(it.producto_id)!;
+      return {
+        productoId: String(it.producto_id),
+        cantidad: it.cantidad,
+        precioUnitario: Number(p.precio),
+      };
+    });
+    const promoRes = resolverPromociones(itemsParaUtils, promoMap);
+
+    // ---- Resolver precios mayoristas ----
+    const precios = resolverPreciosMayorista(itemsParaUtils, pricingMap);
+
+    // ---- Construir items finales (los del usuario + las bonificaciones) ----
+    const resumen: ResumenItem[] = [];
+    let total = 0;
+
+    for (const it of items) {
+      const p = productosById.get(it.producto_id)!;
+      const precioRes = precios.get(String(it.producto_id));
+      const precioUnitario = precioRes ? precioRes.precioResuelto : Number(p.precio);
+      const subtotal = precioUnitario * it.cantidad;
+      total += subtotal;
+
+      resumen.push({
+        producto_id: it.producto_id,
+        codigo: p.codigo,
+        nombre: p.nombre,
+        cantidad: it.cantidad,
+        precio_unitario: precioUnitario,
+        subtotal,
+        regla_precio: precioRes?.esMayorista ? "mayorista" : "base",
+        es_bonificacion: false,
+        stock_disponible: p.stock,
+      });
+    }
+
+    // Bonificaciones (regalos, no suman al total)
+    for (const bonif of promoRes.bonificaciones) {
+      const productoId = Number(bonif.productoId);
+      // El producto regalo puede no estar entre los productos que pidió el user
+      // — si no está, lo cargamos puntualmente.
+      let p = productosById.get(productoId);
+      if (!p) {
+        p = await loadProducto(sb, productoId, sucursalId) ?? undefined;
+        if (p) productosById.set(productoId, p);
+      }
+      if (!p) continue; // producto regalo no encontrado — skip silently
+
+      resumen.push({
+        producto_id: productoId,
+        codigo: p.codigo,
+        nombre: p.nombre,
+        cantidad: bonif.cantidadBonificacion,
+        precio_unitario: 0,
+        subtotal: 0,
+        regla_precio: "promo_regalo",
+        es_bonificacion: true,
+        promo_nombre: bonif.promoNombre,
+        stock_disponible: p.stock,
+      });
+    }
+
+    // ---- Alertas de stock ----
+    // Acumulamos cantidad total por producto (incluyendo bonificaciones que mueven stock).
+    const cantidadTotalPorProducto = new Map<number, number>();
+    for (const r of resumen) {
+      const cur = cantidadTotalPorProducto.get(r.producto_id) ?? 0;
+      cantidadTotalPorProducto.set(r.producto_id, cur + r.cantidad);
+    }
+    const alertasStock: AlertaStock[] = [];
+    for (const [pid, cantidad] of cantidadTotalPorProducto) {
+      const p = productosById.get(pid)!;
+      if (p.stock < cantidad) {
+        alertasStock.push({
+          producto_id: pid,
+          nombre: p.nombre,
+          pedido: cantidad,
+          disponible: p.stock,
+        });
+      }
+    }
+
+    // ---- Alerta de crédito ----
+    const limiteCredito = Number(cliente.limite_credito ?? 0);
+    const saldoActual = Number(cliente.saldo_cuenta ?? 0);
+    let alertaCredito: AlertaCredito | null = null;
+    if (limiteCredito > 0 && (saldoActual + total) > limiteCredito) {
+      alertaCredito = {
+        limite: limiteCredito,
+        saldo_actual: saldoActual,
+        pedido_total: total,
+        excedente: (saldoActual + total) - limiteCredito,
+      };
+    }
+
+    // ---- Persistir en bot_pedidos_pendientes ----
+    // El items shape coincide con el que crear_pedido_completo_bot lee.
+    const itemsParaPersistir = resumen.map((r) => {
+      const p = productosById.get(r.producto_id)!;
+      const porcentajeIva = Number(p.porcentaje_iva ?? 0);
+      const impInternos = Number(p.impuestos_internos ?? 0);
+      // ZZ (consumidor final) usa el precio como total con IVA incluido.
+      const netoUnitario = porcentajeIva > 0
+        ? Number((r.precio_unitario / (1 + porcentajeIva / 100)).toFixed(4))
+        : r.precio_unitario;
+      const ivaUnitario = porcentajeIva > 0
+        ? Number((r.precio_unitario - netoUnitario).toFixed(4))
+        : 0;
+
+      const promoId = r.es_bonificacion ? findPromoIdByName(promoRes.bonificaciones, r.promo_nombre ?? "") : null;
+
+      return {
+        producto_id: r.producto_id,
+        cantidad: r.cantidad,
+        precio_unitario: r.precio_unitario,
+        neto_unitario: netoUnitario,
+        iva_unitario: ivaUnitario,
+        impuestos_internos_unitario: impInternos,
+        porcentaje_iva: porcentajeIva,
+        es_bonificacion: r.es_bonificacion,
+        promocion_id: promoId,
+      };
+    });
+
+    const totalNeto = itemsParaPersistir.reduce(
+      (acc, it) => acc + (it.neto_unitario * it.cantidad),
+      0,
+    );
+    const totalIva = itemsParaPersistir.reduce(
+      (acc, it) => acc + (it.iva_unitario * it.cantidad),
+      0,
+    );
+
+    const { data: insertData, error: insertErr } = await sb
+      .from("bot_pedidos_pendientes")
+      .insert({
+        perfil_id: ctx.perfil_id,
+        sucursal_id: sucursalId,
+        cliente_id,
+        items: itemsParaPersistir,
+        total,
+        total_neto: Number(totalNeto.toFixed(2)),
+        total_iva: Number(totalIva.toFixed(2)),
+        forma_pago: "efectivo",
+      })
+      .select("id")
+      .single();
+    if (insertErr) {
+      throw new Error(`previsualizar_pedido: insert pendiente: ${insertErr.message}`);
+    }
+    const confirmacionId = (insertData as { id: string }).id;
+
+    return {
+      confirmacion_id: confirmacionId,
+      cliente: {
+        id: cliente.id,
+        codigo: cliente.codigo,
+        nombre: cliente.nombre_fantasia?.trim() || cliente.razon_social?.trim() || "(sin nombre)",
+        saldo_actual: saldoActual,
+        limite_credito: limiteCredito,
+      },
+      items: resumen,
+      total,
+      total_items: items.length,
+      forma_pago_default: "efectivo",
+      alertas: {
+        stock: alertasStock,
+        credito: alertaCredito,
+      },
+    };
+  },
+};
+
+// ----------------------------------------------------------------------------
+// Helpers internos
+// ----------------------------------------------------------------------------
+
+async function loadCliente(
+  sb: SupabaseClient,
+  clienteId: number,
+  sucursalId: number,
+): Promise<ClienteRow | null> {
+  const { data, error } = await sb
+    .from("clientes")
+    .select("id, codigo, nombre_fantasia, razon_social, saldo_cuenta, limite_credito, activo, sucursal_id")
+    .eq("id", clienteId)
+    .eq("sucursal_id", sucursalId)
+    .eq("activo", true)
+    .maybeSingle();
+  if (error) {
+    throw new Error(`previsualizar_pedido: cliente lookup: ${error.message}`);
+  }
+  return (data as ClienteRow | null);
+}
+
+async function isClienteAccesibleParaPreventista(
+  sb: SupabaseClient,
+  clienteId: number,
+  perfilId: string,
+): Promise<boolean> {
+  const { data, error } = await sb
+    .from("cliente_preventistas")
+    .select("preventista_id")
+    .eq("cliente_id", clienteId);
+  if (error) {
+    throw new Error(`previsualizar_pedido: scoping check: ${error.message}`);
+  }
+  const rows = (data ?? []) as Array<{ preventista_id: string }>;
+  if (rows.length === 0) return true; // huérfano
+  return rows.some((r) => r.preventista_id === perfilId);
+}
+
+async function loadProductos(
+  sb: SupabaseClient,
+  ids: number[],
+  sucursalId: number,
+): Promise<Map<number, ProductoRow>> {
+  const uniqIds = [...new Set(ids)];
+  const { data, error } = await sb
+    .from("productos")
+    .select("id, codigo, nombre, precio, stock, porcentaje_iva, impuestos_internos, activo, sucursal_id")
+    .in("id", uniqIds)
+    .eq("sucursal_id", sucursalId)
+    .eq("activo", true);
+  if (error) {
+    throw new Error(`previsualizar_pedido: productos lookup: ${error.message}`);
+  }
+  const out = new Map<number, ProductoRow>();
+  for (const row of ((data ?? []) as ProductoRow[])) {
+    out.set(row.id, row);
+  }
+  return out;
+}
+
+async function loadProducto(
+  sb: SupabaseClient,
+  id: number,
+  sucursalId: number,
+): Promise<ProductoRow | null> {
+  const { data, error } = await sb
+    .from("productos")
+    .select("id, codigo, nombre, precio, stock, porcentaje_iva, impuestos_internos, activo, sucursal_id")
+    .eq("id", id)
+    .eq("sucursal_id", sucursalId)
+    .eq("activo", true)
+    .maybeSingle();
+  if (error) {
+    throw new Error(`previsualizar_pedido: producto regalo lookup: ${error.message}`);
+  }
+  return (data as ProductoRow | null);
+}
+
+function findPromoIdByName(
+  bonifs: Array<{ promoId: string; promoNombre: string }>,
+  nombre: string,
+): number | null {
+  if (!nombre) return null;
+  const match = bonifs.find((b) => b.promoNombre === nombre);
+  return match ? Number(match.promoId) : null;
+}

--- a/supabase/functions/_shared/utils/precioMayorista.ts
+++ b/supabase/functions/_shared/utils/precioMayorista.ts
@@ -1,0 +1,443 @@
+/**
+ * Utilidades para resolución de precios mayoristas por volumen
+ *
+ * ⚠ AUTO-SYNCED desde src/utils/precioMayorista.ts — NO EDITAR ACÁ.
+ * El bot edge function (Deno) y la app web (Vite) comparten esta lógica
+ * para que los precios calculados desde Telegram coincidan con los de la
+ * app. Cualquier cambio se hace primero en src/utils/precioMayorista.ts y
+ * después se propaga acá.
+ *
+ * Sync verification: el test `tests/sync_utils.test.ts` valida que ambas
+ * copias matcheen byte-a-byte. Si falla, ejecutá:
+ *   cp src/utils/precioMayorista.ts supabase/functions/_shared/utils/
+ *   cp src/utils/promociones.ts    supabase/functions/_shared/utils/
+ *
+ * Algoritmo:
+ * 1. Para cada producto en el pedido, buscar sus grupos en el pricingMap
+ * 2. Para cada grupo, sumar cantidades de TODOS los items del pedido que pertenecen al grupo
+ * 3. Encontrar la escala más alta cuyo cantidad_minima <= total del grupo
+ * 4. Si el producto pertenece a varios grupos, tomar el precio más bajo
+ * 5. Nunca aumentar el precio (mayorista siempre <= regular)
+ */
+
+// =============================================================================
+// TIPOS
+// =============================================================================
+
+/**
+ * Configuracion por producto dentro de una escala combinada:
+ *   - cantidad: cantidad minima individual que ese producto debe tener en el
+ *     pedido para "contar" hacia la activacion de la escala.
+ *   - precioOverride (opcional): precio mayorista especifico que usa ese
+ *     producto cuando la escala aplica. Si es null/undefined, cae al
+ *     precioUnitario de la escala.
+ */
+export interface ReglaProducto {
+  cantidad: number
+  precioOverride?: number | null
+}
+
+export interface EscalaPrecio {
+  cantidadMinima: number
+  /** Precio unitario base de la escala. Fallback para productos sin override. */
+  precioUnitario: number
+  etiqueta: string | null
+  /**
+   * Cantidad minima de productos DISTINTOS del grupo presentes en el pedido
+   * (con cantidad >= su minimo individual, o > 0 si no tienen minimo) para
+   * activar la escala. Default 1 = comportamiento clasico.
+   */
+  minProductosDistintos: number
+  /**
+   * Mapa productoId -> regla individual (cantidad minima + precio override).
+   * Si un producto del grupo no esta en este mapa, basta con cantidad > 0
+   * para contar y usa el precioUnitario de la escala. Ausencia total de
+   * entradas = escala clasica.
+   */
+  minimosPorProducto: Map<string, ReglaProducto>
+}
+
+export interface GrupoPrecioInfo {
+  grupoId: string
+  grupoNombre: string
+  escalas: EscalaPrecio[]
+  productoIds: string[]
+  moqPorProducto: Map<string, number>
+}
+
+/** Mapa de productoId → grupos a los que pertenece */
+export type PricingMap = Map<string, GrupoPrecioInfo[]>
+
+export interface PrecioResuelto {
+  precioOriginal: number
+  precioResuelto: number
+  esMayorista: boolean
+  grupoNombre: string | null
+  etiqueta: string | null
+  cantidadEnGrupo: number
+  cantidadMinima: number | null
+}
+
+export interface FaltanteParaTier {
+  grupoNombre: string
+  faltante: number
+  precioTier: number
+  etiqueta: string | null
+}
+
+export interface ItemPedido {
+  productoId: string
+  cantidad: number
+  precioUnitario: number
+  precioOverride?: boolean
+}
+
+// =============================================================================
+// FUNCIONES PRINCIPALES
+// =============================================================================
+
+/**
+ * Indica si una escala es "combinada" (exige reglas mas alla del total del grupo).
+ * Default (sin filas en minimosPorProducto y minProductosDistintos <= 1) = clasica.
+ */
+export function esEscalaCombinada(escala: EscalaPrecio): boolean {
+  return escala.minProductosDistintos > 1 || escala.minimosPorProducto.size > 0
+}
+
+/**
+ * Evalua si una escala aplica dadas las cantidades por producto del grupo en el pedido.
+ *
+ * Reglas:
+ *   1. total del grupo >= escala.cantidadMinima.
+ *   2. Si hay minimos por producto: ningun producto presente en el pedido con
+ *      minimo configurado puede tener cantidad < minimo (si lo tiene, la escala
+ *      falla incluso aunque ese producto no "cuente" individualmente).
+ *   3. Cantidad de productos DISTINTOS del grupo que "cuentan" (presentes con
+ *      cantidad >= su minimo individual, o >0 si no tienen minimo) debe ser
+ *      >= escala.minProductosDistintos.
+ */
+export function escalaAplica(
+  escala: EscalaPrecio,
+  cantidadesPorProducto: Map<string, number>,
+  productoIdsGrupo: string[]
+): boolean {
+  // 1. Total del grupo
+  let totalGrupo = 0
+  for (const pid of productoIdsGrupo) {
+    totalGrupo += cantidadesPorProducto.get(pid) || 0
+  }
+  if (totalGrupo < escala.cantidadMinima) return false
+
+  // 2. Si hay minimos por producto, validar que los presentes los cumplan
+  if (escala.minimosPorProducto.size > 0) {
+    for (const [pid, regla] of escala.minimosPorProducto) {
+      const cantidad = cantidadesPorProducto.get(pid) || 0
+      if (cantidad > 0 && cantidad < regla.cantidad) {
+        return false
+      }
+    }
+  }
+
+  // 3. Contar productos distintos que cuentan
+  const minK = Math.max(1, escala.minProductosDistintos)
+  let productosQueCuentan = 0
+  for (const pid of productoIdsGrupo) {
+    const cantidad = cantidadesPorProducto.get(pid) || 0
+    if (cantidad <= 0) continue
+    const regla = escala.minimosPorProducto.get(pid)
+    if (regla !== undefined) {
+      if (cantidad >= regla.cantidad) productosQueCuentan++
+    } else {
+      // Sin minimo configurado: basta con estar presente
+      productosQueCuentan++
+    }
+  }
+  return productosQueCuentan >= minK
+}
+
+/**
+ * Devuelve el precio efectivo que usa un producto cuando una escala aplica.
+ * Respeta el override por producto si existe; si no, usa el precio de la escala.
+ */
+export function precioEfectivoEscala(escala: EscalaPrecio, productoId: string): number {
+  const regla = escala.minimosPorProducto.get(String(productoId))
+  if (regla && regla.precioOverride != null && regla.precioOverride > 0) {
+    return regla.precioOverride
+  }
+  return escala.precioUnitario
+}
+
+/**
+ * Resuelve los precios mayoristas para cada item del pedido
+ *
+ * @param items - Items del pedido actual
+ * @param pricingMap - Mapa de productoId → grupos con escalas
+ * @returns Mapa de productoId → precio resuelto
+ */
+export function resolverPreciosMayorista(
+  items: ItemPedido[],
+  pricingMap: PricingMap
+): Map<string, PrecioResuelto> {
+  const result = new Map<string, PrecioResuelto>()
+
+  // Mapa productoId -> cantidad total en el pedido
+  const cantidadesPorProducto = new Map<string, number>()
+  for (const item of items) {
+    const pid = String(item.productoId)
+    cantidadesPorProducto.set(pid, (cantidadesPorProducto.get(pid) || 0) + item.cantidad)
+  }
+
+  // Pre-calcular total por grupo (compat con el campo cantidadEnGrupo del resultado)
+  const totalPorGrupo = new Map<string, number>()
+  const gruposVistos = new Set<string>()
+  for (const item of items) {
+    const grupos = pricingMap.get(String(item.productoId))
+    if (!grupos) continue
+    for (const grupo of grupos) {
+      if (gruposVistos.has(grupo.grupoId)) continue
+      gruposVistos.add(grupo.grupoId)
+      let total = 0
+      for (const pid of grupo.productoIds) {
+        total += cantidadesPorProducto.get(String(pid)) || 0
+      }
+      totalPorGrupo.set(grupo.grupoId, total)
+    }
+  }
+
+  // Resolver precio para cada item
+  for (const item of items) {
+    // Si el precio fue overrideado manualmente, respetar el precio manual
+    if (item.precioOverride) {
+      result.set(String(item.productoId), {
+        precioOriginal: item.precioUnitario,
+        precioResuelto: item.precioUnitario,
+        esMayorista: false,
+        grupoNombre: null,
+        etiqueta: null,
+        cantidadEnGrupo: item.cantidad,
+        cantidadMinima: null
+      })
+      continue
+    }
+
+    const grupos = pricingMap.get(String(item.productoId))
+
+    if (!grupos || grupos.length === 0) {
+      result.set(String(item.productoId), {
+        precioOriginal: item.precioUnitario,
+        precioResuelto: item.precioUnitario,
+        esMayorista: false,
+        grupoNombre: null,
+        etiqueta: null,
+        cantidadEnGrupo: item.cantidad,
+        cantidadMinima: null
+      })
+      continue
+    }
+
+    let mejorPrecio = item.precioUnitario
+    let mejorGrupoNombre: string | null = null
+    let mejorEtiqueta: string | null = null
+    let mejorCantidadEnGrupo = item.cantidad
+    let mejorCantidadMinima: number | null = null
+
+    for (const grupo of grupos) {
+      const productoIdsStr = grupo.productoIds.map(String)
+
+      // Filtrar escalas que apliquen (clasica o combinada) y quedarme con la
+      // de mayor cantidad_minima. En caso de empate por cantidad, gana la
+      // de menor precio EFECTIVO para este producto en particular (respeta
+      // overrides por producto). Asi una combinada con override mas bajo
+      // gana a una clasica con el mismo umbral; y una clasica mas barata
+      // gana si la combinada no bajo ese producto especifico.
+      const pidStr = String(item.productoId)
+      const escalasAplicables = grupo.escalas
+        .filter(e => escalaAplica(e, cantidadesPorProducto, productoIdsStr))
+        .sort((a, b) => {
+          if (b.cantidadMinima !== a.cantidadMinima) {
+            return b.cantidadMinima - a.cantidadMinima
+          }
+          return precioEfectivoEscala(a, pidStr) - precioEfectivoEscala(b, pidStr)
+        })
+
+      if (escalasAplicables.length === 0) continue
+
+      const escalaElegida = escalasAplicables[0]
+      const precioParaEsteProducto = precioEfectivoEscala(escalaElegida, pidStr)
+      // Solo aplicar si el precio mayorista es menor o igual al actual mejor
+      if (precioParaEsteProducto <= mejorPrecio) {
+        mejorPrecio = precioParaEsteProducto
+        mejorGrupoNombre = grupo.grupoNombre
+        mejorEtiqueta = escalaElegida.etiqueta
+        mejorCantidadEnGrupo = totalPorGrupo.get(grupo.grupoId) || 0
+        mejorCantidadMinima = escalaElegida.cantidadMinima
+      }
+    }
+
+    result.set(String(item.productoId), {
+      precioOriginal: item.precioUnitario,
+      precioResuelto: mejorPrecio,
+      esMayorista: mejorPrecio < item.precioUnitario,
+      grupoNombre: mejorGrupoNombre,
+      etiqueta: mejorEtiqueta,
+      cantidadEnGrupo: mejorCantidadEnGrupo,
+      cantidadMinima: mejorCantidadMinima
+    })
+  }
+
+  return result
+}
+
+/**
+ * Calcula cuánto falta para alcanzar el próximo tier de precio
+ *
+ * @param items - Items del pedido actual
+ * @param pricingMap - Mapa de pricing
+ * @returns Array de nudges indicando faltantes para cada tier alcanzable
+ */
+export function calcularFaltanteParaTier(
+  items: ItemPedido[],
+  pricingMap: PricingMap
+): FaltanteParaTier[] {
+  const faltantes: FaltanteParaTier[] = []
+  const gruposVistos = new Set<string>()
+
+  // Calcular cantidades totales por grupo
+  const cantidadesPorGrupo = new Map<string, number>()
+  for (const item of items) {
+    const grupos = pricingMap.get(String(item.productoId))
+    if (!grupos) continue
+    for (const grupo of grupos) {
+      if (!cantidadesPorGrupo.has(grupo.grupoId)) {
+        let totalGrupo = 0
+        for (const otroItem of items) {
+          if (grupo.productoIds.includes(String(otroItem.productoId))) {
+            totalGrupo += otroItem.cantidad
+          }
+        }
+        cantidadesPorGrupo.set(grupo.grupoId, totalGrupo)
+      }
+    }
+  }
+
+  for (const item of items) {
+    const grupos = pricingMap.get(String(item.productoId))
+    if (!grupos) continue
+
+    for (const grupo of grupos) {
+      if (gruposVistos.has(grupo.grupoId)) continue
+      gruposVistos.add(grupo.grupoId)
+
+      const totalGrupo = cantidadesPorGrupo.get(grupo.grupoId) || 0
+
+      // Encontrar el proximo tier que no se ha alcanzado.
+      // Las escalas combinadas no participan del nudge porque el mensaje
+      // "te faltan X unidades" no puede expresar combinaciones requeridas.
+      const escalasOrdenadas = grupo.escalas
+        .filter(e => !esEscalaCombinada(e))
+        .sort((a, b) => a.cantidadMinima - b.cantidadMinima)
+
+      for (const escala of escalasOrdenadas) {
+        if (escala.cantidadMinima > totalGrupo) {
+          const faltante = escala.cantidadMinima - totalGrupo
+          // Solo mostrar nudge si falta poco (menos del 50% del umbral)
+          if (faltante <= Math.ceil(escala.cantidadMinima * 0.5)) {
+            faltantes.push({
+              grupoNombre: grupo.grupoNombre,
+              faltante,
+              precioTier: escala.precioUnitario,
+              etiqueta: escala.etiqueta
+            })
+          }
+          break // Solo el próximo tier
+        }
+      }
+    }
+  }
+
+  return faltantes
+}
+
+/**
+ * Aplica precios mayoristas a los items del pedido
+ * Retorna nuevos items con precioUnitario actualizado
+ */
+export function aplicarPreciosMayorista(
+  items: ItemPedido[],
+  preciosResueltos: Map<string, PrecioResuelto>
+): ItemPedido[] {
+  return items.map(item => {
+    if (item.precioOverride) return item
+    const resuelto = preciosResueltos.get(String(item.productoId))
+    if (resuelto && resuelto.esMayorista) {
+      return { ...item, precioUnitario: resuelto.precioResuelto }
+    }
+    return item
+  })
+}
+
+// =============================================================================
+// CANTIDAD MÍNIMA DE PEDIDO (MOQ)
+// =============================================================================
+
+export interface ViolacionMOQ {
+  productoId: string
+  cantidadActual: number
+  cantidadMinima: number
+  grupoNombre: string
+}
+
+/**
+ * Obtiene el MOQ efectivo de un producto.
+ * Si pertenece a varios grupos, toma el más restrictivo (máximo).
+ * Retorna 1 si no tiene MOQ configurado.
+ */
+export function obtenerMOQ(productoId: string, pricingMap: PricingMap): number {
+  const grupos = pricingMap.get(String(productoId))
+  if (!grupos) return 1
+  let maxMoq = 1
+  for (const grupo of grupos) {
+    const moq = grupo.moqPorProducto.get(String(productoId))
+    if (moq && moq > maxMoq) maxMoq = moq
+  }
+  return maxMoq
+}
+
+/**
+ * Construye un mapa de productoId → MOQ efectivo para una lista de items.
+ */
+export function construirMOQMap(items: ItemPedido[], pricingMap: PricingMap): Map<string, number> {
+  const map = new Map<string, number>()
+  for (const item of items) {
+    const moq = obtenerMOQ(item.productoId, pricingMap)
+    if (moq > 1) {
+      map.set(String(item.productoId), moq)
+    }
+  }
+  return map
+}
+
+/**
+ * Valida que todos los items cumplan con su cantidad mínima de pedido.
+ * Retorna las violaciones encontradas.
+ */
+export function validarMOQPedido(items: ItemPedido[], pricingMap: PricingMap): ViolacionMOQ[] {
+  const violaciones: ViolacionMOQ[] = []
+  for (const item of items) {
+    const grupos = pricingMap.get(String(item.productoId))
+    if (!grupos) continue
+    for (const grupo of grupos) {
+      const moq = grupo.moqPorProducto.get(String(item.productoId))
+      if (moq && item.cantidad < moq) {
+        violaciones.push({
+          productoId: String(item.productoId),
+          cantidadActual: item.cantidad,
+          cantidadMinima: moq,
+          grupoNombre: grupo.grupoNombre,
+        })
+        break // Una violación por producto es suficiente
+      }
+    }
+  }
+  return violaciones
+}

--- a/supabase/functions/_shared/utils/promociones.ts
+++ b/supabase/functions/_shared/utils/promociones.ts
@@ -1,0 +1,323 @@
+/**
+ * Utilidades para resolución de promociones temporales
+ *
+ * ⚠ AUTO-SYNCED desde src/utils/promociones.ts — NO EDITAR ACÁ.
+ * Ver el header de precioMayorista.ts para detalles del sync.
+ *
+ * Tipos de promoción soportados:
+ *   1. bonificacion: Compra X, lleva Y gratis (acumulable)
+ *
+ * La cantidad se acumula entre TODOS los productos de la misma promo.
+ * Ejemplo: promo "Manaos 2+2" con 3 sabores → 1 de cada uno = 3 total → aplica 1 vez.
+ *
+ * Las promociones tienen prioridad sobre los precios mayoristas:
+ * si un producto tiene promo activa, se usa la promo en vez del mayorista.
+ */
+
+// Deno requiere extensión .ts explícita en imports relativos.
+import type { ItemPedido } from './precioMayorista.ts'
+
+// =============================================================================
+// TIPOS
+// =============================================================================
+
+export type ModoExclusion = 'acumulable' | 'excluyente'
+
+export interface PromocionActiva {
+  id: string
+  nombre: string
+  tipo: 'bonificacion'
+  productoIds: string[]
+  reglas: Record<string, number>
+  productoRegaloId?: string
+  prioridad?: number
+  regaloMueveStock?: boolean
+  modoExclusion?: ModoExclusion
+}
+
+/** Mapa de productoId → promos activas que aplican */
+export type PromoMap = Map<string, PromocionActiva[]>
+
+export interface BonificacionResult {
+  productoId: string
+  promoId: string
+  promoNombre: string
+  cantidadBonificacion: number
+}
+
+export interface PromoResolucion {
+  bonificaciones: BonificacionResult[]
+  productosConPromo: Set<string>
+}
+
+// =============================================================================
+// FUNCIONES PRINCIPALES
+// =============================================================================
+
+/**
+ * Resuelve todas las promociones activas para los items del pedido.
+ *
+ * La bonificación se calcula sumando cantidades de TODOS los productos
+ * que pertenecen a la misma promo (igual que las escalas mayoristas por grupo).
+ * La bonificación se asigna al primer producto del pedido que pertenece a la promo.
+ */
+export function resolverPromociones(
+  items: ItemPedido[],
+  promoMap: PromoMap
+): PromoResolucion {
+  const bonificaciones: BonificacionResult[] = []
+  const productosConPromo = new Set<string>()
+
+  // 1. Recolectar promos vistas en el pedido
+  const promosVistas = acumularPromos(items, promoMap, { skipOverride: true })
+
+  for (const entry of promosVistas.values()) {
+    for (const pid of entry.productoIdsEnPedido) productosConPromo.add(pid)
+  }
+
+  // 2. Filtrar solo las que DISPARAN (bloques >= 1) — clave para el fix del bug
+  //    "2+2 con 2 fardos debe ganar sobre 3+1 con prio mayor si 3+1 no llega"
+  const queDisparan: PromoEntry[] = []
+  for (const entry of promosVistas.values()) {
+    const { promo, totalQty } = entry
+    const cantCompra = promo.reglas['cantidad_compra']
+    const cantBonif = promo.reglas['cantidad_bonificacion']
+    if (!cantCompra || !cantBonif || cantCompra <= 0) continue
+    const bloques = Math.floor(totalQty / cantCompra)
+    if (bloques <= 0) continue
+    queDisparan.push(entry)
+  }
+
+  // 3. Separar acumulables (siempre pasan) vs excluyentes (se resuelven por grupo)
+  const acumulables = queDisparan.filter(e => (e.promo.modoExclusion ?? 'acumulable') === 'acumulable')
+  const excluyentes = queDisparan.filter(e => e.promo.modoExclusion === 'excluyente')
+
+  // 4. Entre excluyentes: agrupar por productos compartidos y elegir ganador
+  //    por tier más alto (mayor cantidad_compra), tiebreak prioridad, tiebreak id.
+  const ganadoresExcluyentes = resolverConflictosExcluyentes(excluyentes)
+
+  const finales = [...acumulables, ...ganadoresExcluyentes]
+
+  for (const { promo, totalQty, primerProductoId } of finales) {
+    const cantCompra = promo.reglas['cantidad_compra']
+    const cantBonif = promo.reglas['cantidad_bonificacion']
+    const bloques = Math.floor(totalQty / cantCompra)
+    bonificaciones.push({
+      productoId: promo.productoRegaloId || primerProductoId,
+      promoId: promo.id,
+      promoNombre: promo.nombre,
+      cantidadBonificacion: bloques * cantBonif,
+    })
+  }
+
+  return { bonificaciones, productosConPromo }
+}
+
+// =============================================================================
+// HELPERS DE EXCLUSIÓN
+// =============================================================================
+
+interface PromoEntry {
+  promo: PromocionActiva
+  totalQty: number
+  primerProductoId: string
+  productoIdsEnPedido: Set<string>
+}
+
+function acumularPromos(
+  items: ItemPedido[],
+  promoMap: PromoMap,
+  opts: { skipOverride: boolean },
+): Map<string, PromoEntry> {
+  const promosVistas = new Map<string, PromoEntry>()
+
+  for (const item of items) {
+    if (opts.skipOverride && item.precioOverride) continue
+
+    const promos = promoMap.get(String(item.productoId))
+    if (!promos) continue
+
+    for (const promo of promos) {
+      if (promo.tipo !== 'bonificacion') continue
+
+      const existing = promosVistas.get(promo.id)
+      if (existing) {
+        existing.totalQty += item.cantidad
+        existing.productoIdsEnPedido.add(String(item.productoId))
+      } else {
+        promosVistas.set(promo.id, {
+          promo,
+          totalQty: item.cantidad,
+          primerProductoId: String(item.productoId),
+          productoIdsEnPedido: new Set([String(item.productoId)]),
+        })
+      }
+    }
+  }
+
+  return promosVistas
+}
+
+/**
+ * Union-find: dos promos son "vecinas" si comparten al menos 1 producto del pedido.
+ * Por cada componente conectado, gana la de mayor cantidad_compra (tier más alto).
+ * Desempates: mayor prioridad manual; luego id menor (promo creada antes).
+ *
+ * Importante: sólo opera sobre promos que YA disparan. Así, si "3+1 fardo" (tier
+ * superior) no llega al umbral, la "2+2 botellas" de tier menor aplica igual.
+ */
+function resolverConflictosExcluyentes(excluyentes: PromoEntry[]): PromoEntry[] {
+  if (excluyentes.length === 0) return []
+
+  const byId = new Map<string, PromoEntry>()
+  for (const e of excluyentes) byId.set(e.promo.id, e)
+
+  const parent = new Map<string, string>()
+  for (const id of byId.keys()) parent.set(id, id)
+
+  const find = (x: string): string => {
+    let r = x
+    while (parent.get(r)! !== r) r = parent.get(r)!
+    let cur = x
+    while (parent.get(cur)! !== r) {
+      const next = parent.get(cur)!
+      parent.set(cur, r)
+      cur = next
+    }
+    return r
+  }
+
+  const union = (a: string, b: string) => {
+    const ra = find(a), rb = find(b)
+    if (ra !== rb) parent.set(ra, rb)
+  }
+
+  // Indexar productos → promos (entre las excluyentes que disparan)
+  const productoToPromos = new Map<string, string[]>()
+  for (const [promoId, entry] of byId) {
+    for (const pid of entry.productoIdsEnPedido) {
+      const arr = productoToPromos.get(pid) || []
+      arr.push(promoId)
+      productoToPromos.set(pid, arr)
+    }
+  }
+  for (const promoIds of productoToPromos.values()) {
+    for (let i = 1; i < promoIds.length; i++) union(promoIds[0], promoIds[i])
+  }
+
+  // Agrupar por componente y elegir ganador: tier más alto, luego prioridad, luego id
+  const porComponente = new Map<string, PromoEntry[]>()
+  for (const [promoId, entry] of byId) {
+    const root = find(promoId)
+    const arr = porComponente.get(root) || []
+    arr.push(entry)
+    porComponente.set(root, arr)
+  }
+
+  const ganadores: PromoEntry[] = []
+  for (const grupo of porComponente.values()) {
+    grupo.sort((a, b) => {
+      const ca = a.promo.reglas['cantidad_compra'] ?? 0
+      const cb = b.promo.reglas['cantidad_compra'] ?? 0
+      if (ca !== cb) return cb - ca // tier más alto gana (mayor cantidad_compra)
+      const pa = a.promo.prioridad ?? 0
+      const pb = b.promo.prioridad ?? 0
+      if (pa !== pb) return pb - pa
+      const ia = Number(a.promo.id), ib = Number(b.promo.id)
+      if (!Number.isNaN(ia) && !Number.isNaN(ib)) return ia - ib
+      return a.promo.id.localeCompare(b.promo.id)
+    })
+    ganadores.push(grupo[0])
+  }
+  return ganadores
+}
+
+// =============================================================================
+// HELPERS
+// =============================================================================
+
+/**
+ * Calcula cuánto falta para activar una bonificación.
+ * Usa cantidad acumulada de todos los productos de la promo.
+ */
+export function calcularFaltanteParaBonificacion(
+  items: ItemPedido[],
+  promoMap: PromoMap
+): Array<{ productoId: string; promoNombre: string; faltante: number; bonificacion: number }> {
+  const faltantes: Array<{ productoId: string; promoNombre: string; faltante: number; bonificacion: number }> = []
+
+  // Mostramos nudges para promos que AÚN NO disparan. Para promos acumulables,
+  // no hay conflicto. Para excluyentes, evitamos nudgear la que ya perdería el
+  // conflicto con otra excluyente del mismo grupo que SÍ dispara y tiene mayor tier.
+  const promosAcumuladas = acumularPromos(items, promoMap, { skipOverride: false })
+
+  const ganadorasEnMismoGrupo = calcularGanadoresActualesPorGrupo(promosAcumuladas)
+
+  for (const [promoId, { promo, totalQty, primerProductoId, productoIdsEnPedido }] of promosAcumuladas) {
+    const cantCompra = promo.reglas['cantidad_compra']
+    const cantBonif = promo.reglas['cantidad_bonificacion']
+    if (!cantCompra || !cantBonif) continue
+
+    const resto = totalQty % cantCompra
+    if (resto === 0) continue
+
+    // Si es excluyente y hay otra excluyente en el mismo grupo que ya dispara
+    // y tiene tier superior, no nudgeamos (esta promo está bloqueada).
+    if (promo.modoExclusion === 'excluyente') {
+      const ganadora = findGanadoraEnGrupo(ganadorasEnMismoGrupo, productoIdsEnPedido)
+      if (ganadora && ganadora.promo.id !== promoId) {
+        const cantCompraGanadora = ganadora.promo.reglas['cantidad_compra'] ?? 0
+        if (cantCompraGanadora > cantCompra) continue
+      }
+    }
+
+    const faltante = cantCompra - resto
+    if (faltante <= Math.ceil(cantCompra * 0.5)) {
+      faltantes.push({
+        productoId: primerProductoId,
+        promoNombre: promo.nombre,
+        faltante,
+        bonificacion: cantBonif,
+      })
+    }
+  }
+
+  return faltantes
+}
+
+/**
+ * Para cada producto del pedido, indica cuál promo excluyente (de las que ya
+ * disparan) es la ganadora actual. Se usa para suprimir nudges de excluyentes
+ * perdedoras.
+ */
+function calcularGanadoresActualesPorGrupo(
+  promosVistas: Map<string, PromoEntry>,
+): Map<string, PromoEntry> {
+  const disparan: PromoEntry[] = []
+  for (const entry of promosVistas.values()) {
+    const cantCompra = entry.promo.reglas['cantidad_compra']
+    if (!cantCompra || cantCompra <= 0) continue
+    if (Math.floor(entry.totalQty / cantCompra) <= 0) continue
+    if (entry.promo.modoExclusion !== 'excluyente') continue
+    disparan.push(entry)
+  }
+  const ganadoresPorProducto = new Map<string, PromoEntry>()
+  const ganadores = resolverConflictosExcluyentes(disparan)
+  for (const g of ganadores) {
+    for (const pid of g.productoIdsEnPedido) {
+      ganadoresPorProducto.set(pid, g)
+    }
+  }
+  return ganadoresPorProducto
+}
+
+function findGanadoraEnGrupo(
+  ganadoresPorProducto: Map<string, PromoEntry>,
+  productoIds: Set<string>,
+): PromoEntry | undefined {
+  for (const pid of productoIds) {
+    const g = ganadoresPorProducto.get(pid)
+    if (g) return g
+  }
+  return undefined
+}

--- a/supabase/functions/_shared/utils/promociones.ts
+++ b/supabase/functions/_shared/utils/promociones.ts
@@ -33,6 +33,12 @@ export interface PromocionActiva {
   prioridad?: number
   regaloMueveStock?: boolean
   modoExclusion?: ModoExclusion
+  /** Producto contenedor del que se descuenta stock por bloques (modo Fracción). */
+  ajusteProductoId?: string
+  /** Subunidades que forman 1 unidad del producto contenedor (modo Fracción). */
+  unidadesPorBloque?: number
+  /** Texto manual del regalo a mostrar en pedido/PDF (ej: "1 botella Manaos Naranja 600cc"). */
+  descripcionRegalo?: string
 }
 
 /** Mapa de productoId → promos activas que aplican */
@@ -43,6 +49,8 @@ export interface BonificacionResult {
   promoId: string
   promoNombre: string
   cantidadBonificacion: number
+  descripcionRegalo?: string
+  unidadesPorBloque?: number
 }
 
 export interface PromoResolucion {
@@ -102,11 +110,17 @@ export function resolverPromociones(
     const cantCompra = promo.reglas['cantidad_compra']
     const cantBonif = promo.reglas['cantidad_bonificacion']
     const bloques = Math.floor(totalQty / cantCompra)
+    // Resolución del producto regalo: producto_regalo_id (configurado en form),
+    // luego ajuste_producto_id (contenedor en modo Fracción — defensa por si la
+    // promo quedó con regalo NULL antes del fix), y como último recurso el
+    // primer disparador (mantiene el comportamiento previo para promos legacy).
     bonificaciones.push({
-      productoId: promo.productoRegaloId || primerProductoId,
+      productoId: promo.productoRegaloId || promo.ajusteProductoId || primerProductoId,
       promoId: promo.id,
       promoNombre: promo.nombre,
       cantidadBonificacion: bloques * cantBonif,
+      descripcionRegalo: promo.descripcionRegalo,
+      unidadesPorBloque: promo.unidadesPorBloque,
     })
   }
 

--- a/supabase/functions/telegram-webhook/handlers.ts
+++ b/supabase/functions/telegram-webhook/handlers.ts
@@ -752,6 +752,10 @@ export async function handleCallbackQuery(cb: TelegramCallbackQuery): Promise<vo
       return handleCallbackMenu(cb, user, toolCtx, parsed.args);
     case "sucursal_switch":
       return handleCallbackSucursalSwitch(cb, user, parsed.args);
+    case "pedido_confirmar":
+      return handleCallbackPedidoConfirmar(cb, user, toolCtx, parsed.args);
+    case "pedido_cancelar":
+      return handleCallbackPedidoCancelar(cb, user, parsed.args);
     case "visitar":
       // Reservada: confirmamos el callback y respondemos con placeholder.
       // Acciones de write con confirmación están out of scope hasta una
@@ -821,6 +825,110 @@ async function handleCallbackSucursalSwitch(
       show_alert: true,
     });
   }
+}
+
+// ----------------------------------------------------------------------------
+// Pedido confirmar/cancelar — write tools del bot (Phase A iter 1)
+// ----------------------------------------------------------------------------
+//
+// El flujo:
+//   1. previsualizar_pedido (read-only) deja una row en bot_pedidos_pendientes
+//      con TTL 10 min y devuelve confirmacion_id (UUID).
+//   2. agent.ts arma keyboard inline con [Confirmar / Cancelar] basado en el
+//      InteractableContext "pedido_confirmacion".
+//   3. Tap "Confirmar" → callback v1:pedido_confirmar:<UUID> → invoca tool
+//      crear_pedido (que llama RPC crear_pedido_completo_bot).
+//   4. Tap "Cancelar" → callback v1:pedido_cancelar:<UUID> → marca el pendiente
+//      como consumido (sin crear pedido) + edita el mensaje original con
+//      "❌ Cancelado".
+//
+// Defensa-en-profundidad: solo admin/encargado/preventista pueden invocar.
+// El RPC además valida que el confirmacion_id pertenezca al perfil_id.
+
+const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+async function handleCallbackPedidoConfirmar(
+  cb: TelegramCallbackQuery,
+  user: BotUser,
+  toolCtx: ToolContext,
+  args: string[],
+): Promise<void> {
+  const chatId = cb.message.chat.id;
+  if (!["admin", "encargado", "preventista"].includes(user.rol)) {
+    await answerCallbackQuery(cb.id, {
+      text: "No tenés permiso para crear pedidos.",
+      show_alert: true,
+    });
+    return;
+  }
+  const confirmacionId = args[0];
+  if (!confirmacionId || !UUID_REGEX.test(confirmacionId)) {
+    await answerCallbackQuery(cb.id, { text: "Confirmación inválida." });
+    return;
+  }
+
+  // Apagar el spinner ya — el resto puede tomar 1-2 seg.
+  await answerCallbackQuery(cb.id, { text: "Creando pedido..." });
+
+  const result = await invokeTool(
+    "crear_pedido",
+    { confirmacion_id: confirmacionId },
+    toolCtx,
+  );
+
+  if (!result.ok) {
+    const errMsg = result.error === "permiso_denegado"
+      ? "No tenés permiso para crear pedidos."
+      : `❌ No pude crear el pedido: ${result.error}`;
+    await sendMessage(chatId, errMsg);
+    return;
+  }
+
+  const data = result.data as { pedido_id: number; total: number };
+  const totalFmt = new Intl.NumberFormat("es-AR", {
+    style: "currency",
+    currency: "ARS",
+    maximumFractionDigits: 0,
+  }).format(data.total);
+  await sendMessage(
+    chatId,
+    `✅ Pedido #${data.pedido_id} creado por ${totalFmt}.\n\n` +
+      `Lo podés ver/ajustar en la app web (filtrá por "cargados via bot" si lo querés revisar).`,
+  );
+}
+
+async function handleCallbackPedidoCancelar(
+  cb: TelegramCallbackQuery,
+  user: BotUser,
+  args: string[],
+): Promise<void> {
+  const chatId = cb.message.chat.id;
+  const confirmacionId = args[0];
+  if (!confirmacionId || !UUID_REGEX.test(confirmacionId)) {
+    await answerCallbackQuery(cb.id, { text: "Confirmación inválida." });
+    return;
+  }
+  // Marcar el pendiente como consumido (sin crear pedido). UPDATE limitado a
+  // pendientes del propio user — defensa contra hijack del callback_data.
+  const sb = getServiceRoleClient();
+  const { error } = await sb
+    .from("bot_pedidos_pendientes")
+    .update({ consumido: true })
+    .eq("id", confirmacionId)
+    .eq("perfil_id", user.perfil_id);
+  if (error) {
+    console.error("[callback pedido_cancelar]:", error.message);
+    await answerCallbackQuery(cb.id, {
+      text: "No pude cancelar. Igual el borrador expira en 10 min.",
+      show_alert: false,
+    });
+    return;
+  }
+  await answerCallbackQuery(cb.id, { text: "Cancelado" });
+  await sendMessage(
+    chatId,
+    "❌ Cancelado. Si querés cargarlo de nuevo, mandame el pedido completo otra vez.",
+  );
 }
 
 async function handleCallbackCliente(

--- a/supabase/functions/tests/agent.test.ts
+++ b/supabase/functions/tests/agent.test.ts
@@ -769,9 +769,13 @@ Deno.test("runAgent: buscar_cliente popula interactableContext={kind:'clientes'}
 
     assert(result.interactableContext, "interactableContext debe estar populado");
     assertEquals(result.interactableContext!.kind, "clientes");
-    assertEquals(result.interactableContext!.items.length, 2);
-    assertEquals(result.interactableContext!.items[0], { id: 42, nombre: "Pepito SA" });
-    assertEquals(result.interactableContext!.items[1], { id: 100, nombre: "Almacén Centro" });
+    // Narrow al kind "clientes" para acceder a items.
+    if (result.interactableContext!.kind !== "clientes") {
+      throw new Error("expected kind='clientes'");
+    }
+    assertEquals(result.interactableContext.items.length, 2);
+    assertEquals(result.interactableContext.items[0], { id: 42, nombre: "Pepito SA" });
+    assertEquals(result.interactableContext.items[1], { id: 100, nombre: "Almacén Centro" });
   } finally {
     fetchStub.restore();
     teardownAgentEnv();

--- a/supabase/functions/tests/sync_utils.test.ts
+++ b/supabase/functions/tests/sync_utils.test.ts
@@ -1,0 +1,88 @@
+// Test de sincronización: verifica que los utils compartidos entre la app
+// web (src/utils/) y el bot edge function (supabase/functions/_shared/utils/)
+// estén byte-a-byte iguales (excepto el header de comentarios que documenta
+// el sync requirement).
+//
+// Si este test falla, ejecutá:
+//   cp src/utils/precioMayorista.ts supabase/functions/_shared/utils/
+//   cp src/utils/promociones.ts    supabase/functions/_shared/utils/
+// y después restablecé los headers de "AUTO-SYNCED" en cada archivo.
+//
+// Razón: la app web calcula precios en TS y se los pasa pre-computados
+// a `crear_pedido_completo`. El bot Telegram debe usar EXACTAMENTE la misma
+// lógica para que el preventista vea los mismos precios via Telegram que
+// via app. La forma más simple de garantizarlo es compartir el código.
+
+import { assert, assertEquals } from "std/assert/mod.ts";
+
+const FILES = [
+  ["src/utils/precioMayorista.ts", "supabase/functions/_shared/utils/precioMayorista.ts"],
+  ["src/utils/promociones.ts", "supabase/functions/_shared/utils/promociones.ts"],
+];
+
+// Strip de TODO comment block leading + líneas en blanco hasta la primera
+// línea de código real, y normaliza el import sin/con extensión .ts.
+function stripHeader(text: string): string {
+  const lines = text.split("\n");
+  let i = 0;
+  // Avanzar mientras la línea esté vacía o sea parte de un comment block
+  // (empieza con `/*`, `//`, `*` o ` *`).
+  while (i < lines.length) {
+    const trimmed = lines[i].trim();
+    if (trimmed === "") { i++; continue; }
+    if (
+      trimmed.startsWith("/*") || trimmed.startsWith("//") ||
+      trimmed.startsWith("*") || trimmed.endsWith("*/")
+    ) {
+      i++;
+      continue;
+    }
+    break;
+  }
+  // Normalizar el import: la app usa `'./precioMayorista'`, Deno requiere `.ts`.
+  return lines.slice(i).join("\n").replace(
+    /from\s+'\.\/precioMayorista'/g,
+    "from './precioMayorista.ts'",
+  );
+}
+
+// Resolvemos el path absoluto al repo root subiendo desde supabase/functions/tests/
+const REPO_ROOT = new URL("../../../", import.meta.url).pathname.replace(/^\/([A-Z]:)/, "$1");
+
+for (const [appPath, botPath] of FILES) {
+  Deno.test(`utils sync: ${appPath} == ${botPath}`, async () => {
+    const appText = await Deno.readTextFile(`${REPO_ROOT}${appPath}`);
+    const botText = await Deno.readTextFile(`${REPO_ROOT}${botPath}`);
+    const appBody = stripHeader(appText);
+    const botBody = stripHeader(botText);
+    if (appBody !== botBody) {
+      // Encontrar la primera línea que difiere — diagnóstico útil.
+      const appLines = appBody.split("\n");
+      const botLines = botBody.split("\n");
+      const max = Math.max(appLines.length, botLines.length);
+      for (let i = 0; i < max; i++) {
+        if (appLines[i] !== botLines[i]) {
+          console.error(
+            `Diff at line ${i + 1}:\n  app: ${appLines[i] ?? "(EOF)"}\n  bot: ${botLines[i] ?? "(EOF)"}`,
+          );
+          break;
+        }
+      }
+    }
+    assertEquals(
+      appBody,
+      botBody,
+      `Los utils del bot y la app divergieron. Re-sincronizá con: cp ${appPath} ${botPath}`,
+    );
+  });
+}
+
+Deno.test("utils sync: el bot tiene el header AUTO-SYNCED", async () => {
+  const text = await Deno.readTextFile(
+    `${REPO_ROOT}supabase/functions/_shared/utils/precioMayorista.ts`,
+  );
+  assert(
+    text.includes("AUTO-SYNCED"),
+    "El header AUTO-SYNCED no está presente — alguien editó el archivo del bot directamente",
+  );
+});


### PR DESCRIPTION
## Contexto

Primer write tool del bot. Hasta hoy era 100% read-only — los preventistas consultan pero cargan los pedidos en la app web. Esta PR habilita el flujo:

1. Preventista (en la calle, Telegram): **"Tomame un pedido al kiosco UNT, 5 manaos cola 600 y 3 sal fina"**
2. Bot resuelve cliente + productos + ambigüedad, calcula precios mayoristas + promos auto, muestra resumen con keyboard inline.
3. Preventista tap **✅ Confirmar pedido** → pedido real creado con `canal='bot'`.

## Diseño aprobado en brainstorming

| Decisión | Elección |
|---|---|
| Flujo | Híbrido NL + keyboard de confirmación |
| Cálculo de precios | "Pro" — misma lógica que la app web (mayorista, escalas, promos auto) |
| Implementación pricing | TS compartido (utils copiados con sync test, no plpgsql port) |
| Sin stock | Avisa y deja decidir + re-check atómico al confirmar |
| Sobre crédito | Avisa pero permite confirmar |
| Editar | Cancelar + rearmar (NL es rápido) |
| Forma de pago | Default \`efectivo\` + tag \`canal='bot'\` para filtrar en la app |
| TTL de confirmación | 10 minutos |
| Cancelar pedido via bot | Out of scope (se hace en la app) |

## Componentes

### Migration 030
- \`pedidos.canal varchar(20) DEFAULT 'app'\` + index parcial.
- Tabla \`bot_pedidos_pendientes\` (TTL 10min, consumido flag, items JSONB).
- RPC \`crear_pedido_completo_bot(perfil_id, confirmacion_id)\` — variante de \`crear_pedido_completo\` sin auth.uid() check, con re-check de stock atómico, INSERT con canal='bot' y mark consumido.

### Pricing module (\`_shared/pricing/index.ts\`)
- \`loadPricingContext(supabase, sucursalId)\` carga \`pricingMap\` + \`promoMap\`. Port directo de los hooks \`useGruposPrecioQuery\` + \`usePromocionesQuery\` de la React app.

### Utils compartidos (\`_shared/utils/\`)
- Copia byte-a-byte de \`src/utils/precioMayorista.ts\` y \`src/utils/promociones.ts\`.
- Test \`sync_utils.test.ts\` valida que no diverjan.

### Tools
- \`previsualizar_pedido\` (read-only, admin/encargado/preventista): valida, scoping huérfanos, calcula precios + bonificaciones, alertas, INSERTa pendiente, devuelve confirmacion_id.
- \`crear_pedido\` (WRITE, mismos roles): recibe confirmacion_id (UUID), llama el RPC. El LLM no puede inventar UUIDs — defensa anti-replay.

### UI flow (callbacks + keyboards)
- \`agent.ts\`: nuevo kind \`pedido_confirmacion\` en \`InteractableContext\`. \`extractInteractableContext\` detecta output de \`previsualizar_pedido\`.
- \`telegram-keyboards.ts\`: builder \`buildPedidoConfirmacionKeyboard\` con \`[✅ Confirmar]\` / \`[❌ Cancelar]\`.
- \`handlers.ts\`: \`handleCallbackPedidoConfirmar\` invoca crear_pedido y envía resultado; \`handleCallbackPedidoCancelar\` marca consumido (filtrado por perfil_id, anti-hijack).

### Prompts
- Admin / encargado / preventista: bloque "TOMAR PEDIDO" con flujo y ejemplo concreto.
- Regla crítica: NO llamar \`crear_pedido\` directamente — solo dispara desde el callback.

## Test plan

- [x] Migration 030 aplicada en prod
- [x] RPC \`crear_pedido_completo_bot\` rechaza confirmaciones inválidas (smoke)
- [x] \`deno task check\` ✅
- [x] \`deno task lint\` ✅ (86 archivos)
- [x] \`deno task test\` → **163 passed / 0 failed** (incluye sync_utils test)
- [ ] Deploy v18 + smoke E2E desde tu cuenta de Telegram:
  - Pedido simple (1 producto): "tomame un pedido al kiosco UNT, 5 manaos cola 600"
  - Pedido con ambigüedad: "5 manaos cola" sin tamaño → bot pregunta
  - Pedido con familia agrupada: "10 manaos 3000 surtidas" → mayorista debería aplicar
  - Confirmar → pedido aparece en la app con \`canal='bot'\`
  - Cancelar → no se crea nada
  - Doble click rápido en Confirmar → segundo click rechaza con "Pedido ya creado"

## Out of scope (futuro)

- Cancelar/modificar pedido via bot (en la app)
- Crear cliente nuevo via bot (en la app)
- Cambiar forma de pago en bot (siempre efectivo, ajustar en app)
- Promos manuales / opcionales
- Filtro y badge en la app web (Phase B, PR separado)

## Notas

- Cálculo de precios mayoristas/promos = MISMA lógica que la app. Preventista no nota diferencia.
- Si la lógica de precios cambia en \`src/utils/\`, el test sync_utils detecta el drift y obliga a re-sincronizar el bot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)