### PR TITLE
feat: aclaración (N FARDO) en recibos + zonas como entidad + home=pedidos

### DIFF
--- a/docs/plans/2026-05-05-mejoras-fardo-zonas-home.md
+++ b/docs/plans/2026-05-05-mejoras-fardo-zonas-home.md
@@ -1,0 +1,1110 @@
+# Mejoras Usuarios — Fardo en Recibos, Zonas en Clientes, Home → Pedidos
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Implementar 3 mejoras pedidas por usuarios: (1) imprimir aclaración "(1 FARDO)" / "(MEDIO FARDO)" en recibos y comandas, (2) gestionar Zonas como entidad con panel admin y filtros en clientes, (3) que la home por defecto sea Pedidos para todos los roles.
+
+**Architecture:**
+- **Mejora 1**: 1 columna nueva en `productos` + función pura `formatAclaracionBulto()` reusada en los 4 puntos de impresión PDF (recibo comanda, recibo A4, hoja de ruta, manifiesto). TDD sobre la función pura.
+- **Mejora 2**: Migración SQL que backfilla `clientes.zona_id` desde el campo texto `clientes.zona`, agrega RLS en `zonas`, extiende `useZonasQuery.ts` con CRUD admin, espeja `ModalCategorias.tsx` → `ModalZonas.tsx`, agrega filtros en `ClientesContainer`.
+- **Mejora 3**: Cambio de 1 línea en `App.tsx`.
+
+**Tech Stack:** React 19, TypeScript, Vite, TanStack Query, Supabase (PostgreSQL/PL-pgSQL, RLS), jsPDF, Vitest, Playwright, Tailwind, lucide-react.
+
+**Reference design:** `C:\Users\jorge\.claude\plans\te-paso-las-siguientes-purring-tiger.md`
+
+---
+
+## Mejora 3 — Home = Pedidos (HACEMOS PRIMERO: 1 línea, baja a cero el riesgo)
+
+### Task 1: Cambiar default route a /pedidos
+
+**Files:**
+- Modify: `src/App.tsx:205`
+- Modify: `src/components/AppRouter.tsx:107` (si existe y no está deprecado)
+
+**Step 1: Verificar que AppRouter.tsx no está en uso**
+
+Run: `grep -rn "AppRouter" src/ --include="*.tsx" --include="*.ts" | grep -v "AppRouter.tsx"`
+Expected: 0 referencias (si no, listar dónde se importa).
+
+**Step 2: Cambio en App.tsx línea 205**
+
+```typescript
+// Antes
+const defaultRoute = (isAdmin || isPreventista || isEncargado) ? '/dashboard' : '/pedidos'
+
+// Después
+const defaultRoute = '/pedidos'
+```
+
+**Step 3: Cambio en AppRouter.tsx línea 107 (si está en uso)**
+
+```typescript
+// Antes
+const defaultRoute = (isAdmin || isPreventista) ? '/dashboard' : '/pedidos'
+
+// Después
+const defaultRoute = '/pedidos'
+```
+
+**Step 4: Verificación manual**
+
+Run: `npm run dev`
+- Login como admin → debe abrir en `/pedidos` (no `/dashboard`)
+- Click en "Dashboard" del menú → entra a `/dashboard` sin loop
+- F5 estando en `/clientes` → permanece en `/clientes`
+
+**Step 5: Typecheck + lint**
+
+Run: `npm run typecheck && npm run lint`
+Expected: 0 errores.
+
+**Step 6: Commit**
+
+```bash
+git add src/App.tsx src/components/AppRouter.tsx
+git commit -m "feat(home): default route is /pedidos for all roles
+
+Users requested opening directly into the Pedidos panel (operational view)
+instead of the Dashboard (analytical view). Removes role-based defaultRoute
+branching."
+```
+
+---
+
+## Mejora 1 — Aclaración de fardo en recibos
+
+### Task 2: Migración SQL — agregar columna unidades_de_venta_por_fardo
+
+**Files:**
+- Create: `migrations/031_producto_unidades_por_fardo.sql`
+
+**Step 1: Crear archivo de migración**
+
+```sql
+-- Migration 031: Agregar campo de unidades por fardo en productos
+-- Permite imprimir aclaración "(1 FARDO)" / "(MEDIO FARDO)" en recibos cuando
+-- la cantidad vendida coincide con un múltiplo (entero o medio) del fardo.
+--
+-- Ejemplo: SAL FINA con unidades_de_venta_por_fardo=2 →
+--   1 unidad vendida → "(MEDIO FARDO)"
+--   2 unidades       → "(1 FARDO)"
+--   3 unidades       → "(1 FARDO Y MEDIO)"
+--   4 unidades       → "(2 FARDOS)"
+
+ALTER TABLE productos
+  ADD COLUMN IF NOT EXISTS unidades_de_venta_por_fardo numeric(10,2),
+  ADD COLUMN IF NOT EXISTS etiqueta_bulto text DEFAULT 'FARDO';
+
+COMMENT ON COLUMN productos.unidades_de_venta_por_fardo IS
+  'Cantidad de unidades de venta que componen 1 fardo. Si NULL, no se imprime aclaración.';
+COMMENT ON COLUMN productos.etiqueta_bulto IS
+  'Etiqueta del bulto (FARDO, CAJA, PACK, BULTO). Default FARDO.';
+```
+
+**Step 2: Aplicar la migración en branch de Supabase**
+
+Use el MCP `mcp__261fd064-3c3d-4985-9770-d22ee93274b2__apply_migration` con el SQL anterior, en proyecto `hmuchlzmuqqxcldbzkgc` (ManaosApp). Si necesitás un branch primero, crearlo con `create_branch`.
+
+**Step 3: Verificar columnas creadas**
+
+Use `mcp__261fd064-3c3d-4985-9770-d22ee93274b2__execute_sql`:
+```sql
+SELECT column_name, data_type, column_default
+FROM information_schema.columns
+WHERE table_name='productos'
+  AND column_name IN ('unidades_de_venta_por_fardo','etiqueta_bulto');
+```
+Expected: 2 filas, una numeric, una text con default 'FARDO'.
+
+**Step 4: Commit**
+
+```bash
+git add migrations/031_producto_unidades_por_fardo.sql
+git commit -m "feat(productos): add unidades_de_venta_por_fardo y etiqueta_bulto
+
+Permite imprimir aclaración (1 FARDO) / (MEDIO FARDO) en recibos cuando la
+cantidad vendida coincide con un múltiplo del fardo configurado."
+```
+
+---
+
+### Task 3: Función pura formatAclaracionBulto + tests
+
+**Files:**
+- Create: `src/lib/pdf/utils/formatBulto.ts`
+- Create: `src/lib/pdf/utils/formatBulto.test.ts`
+
+**Step 1: Escribir el test que falla**
+
+```typescript
+// src/lib/pdf/utils/formatBulto.test.ts
+import { describe, it, expect } from 'vitest';
+import { formatAclaracionBulto } from './formatBulto';
+
+describe('formatAclaracionBulto', () => {
+  it('returns null when unidadesPorFardo is missing', () => {
+    expect(formatAclaracionBulto(2, undefined, 'FARDO')).toBeNull();
+    expect(formatAclaracionBulto(2, null, 'FARDO')).toBeNull();
+    expect(formatAclaracionBulto(2, 0, 'FARDO')).toBeNull();
+  });
+
+  it('returns null when cantidad is 0 or invalid', () => {
+    expect(formatAclaracionBulto(0, 2, 'FARDO')).toBeNull();
+    expect(formatAclaracionBulto(NaN, 2, 'FARDO')).toBeNull();
+  });
+
+  it('returns "(MEDIO FARDO)" when cantidad/upf === 0.5', () => {
+    expect(formatAclaracionBulto(1, 2, 'FARDO')).toBe('(MEDIO FARDO)');
+    expect(formatAclaracionBulto(2, 4, 'FARDO')).toBe('(MEDIO FARDO)');
+  });
+
+  it('returns "(1 FARDO)" when cantidad/upf === 1', () => {
+    expect(formatAclaracionBulto(2, 2, 'FARDO')).toBe('(1 FARDO)');
+    expect(formatAclaracionBulto(5, 5, 'FARDO')).toBe('(1 FARDO)');
+  });
+
+  it('returns "(1 FARDO Y MEDIO)" when cantidad/upf === 1.5', () => {
+    expect(formatAclaracionBulto(3, 2, 'FARDO')).toBe('(1 FARDO Y MEDIO)');
+  });
+
+  it('returns "(N FARDOS)" plural for integer multiples >= 2', () => {
+    expect(formatAclaracionBulto(4, 2, 'FARDO')).toBe('(2 FARDOS)');
+    expect(formatAclaracionBulto(6, 2, 'FARDO')).toBe('(3 FARDOS)');
+    expect(formatAclaracionBulto(20, 2, 'FARDO')).toBe('(10 FARDOS)');
+  });
+
+  it('returns null for ambiguous fractions (not 0.5 / integer / 1.5)', () => {
+    expect(formatAclaracionBulto(1, 3, 'FARDO')).toBeNull();   // 0.33
+    expect(formatAclaracionBulto(2, 3, 'FARDO')).toBeNull();   // 0.66
+    expect(formatAclaracionBulto(5, 2, 'FARDO')).toBe('(2 FARDOS Y MEDIO)'); // 2.5 → soportar
+  });
+
+  it('uses custom etiqueta when provided', () => {
+    expect(formatAclaracionBulto(2, 2, 'CAJA')).toBe('(1 CAJA)');
+    expect(formatAclaracionBulto(4, 2, 'CAJA')).toBe('(2 CAJAS)');
+    expect(formatAclaracionBulto(1, 2, 'CAJA')).toBe('(MEDIA CAJA)');
+  });
+
+  it('falls back to FARDO when etiqueta is empty/null', () => {
+    expect(formatAclaracionBulto(2, 2, undefined)).toBe('(1 FARDO)');
+    expect(formatAclaracionBulto(2, 2, '')).toBe('(1 FARDO)');
+  });
+});
+```
+
+**Step 2: Run test — debe FAIL (módulo no existe)**
+
+Run: `npx vitest run src/lib/pdf/utils/formatBulto.test.ts`
+Expected: FAIL — "Cannot find module './formatBulto'".
+
+**Step 3: Implementar formatAclaracionBulto**
+
+```typescript
+// src/lib/pdf/utils/formatBulto.ts
+
+/**
+ * Devuelve una aclaración entre paréntesis indicando cuántos fardos representa
+ * la cantidad vendida, basado en `unidadesPorFardo` configurado en el producto.
+ *
+ * Reglas:
+ * - 0.5 fardo → "(MEDIO FARDO)" / "(MEDIA CAJA)" (femenino para CAJA)
+ * - N entero → "(N FARDO)" o "(N FARDOS)" (plural si N>=2)
+ * - N.5 con N>=1 → "(N FARDO Y MEDIO)" o "(N FARDOS Y MEDIO)"
+ * - Fracciones distintas (1/3, 2/3, etc.) → null
+ * - cantidad o unidadesPorFardo inválidos/0 → null
+ *
+ * @param cantidad Cantidad vendida (item.cantidad)
+ * @param unidadesPorFardo Producto.unidades_de_venta_por_fardo
+ * @param etiqueta Producto.etiqueta_bulto (default 'FARDO')
+ */
+export function formatAclaracionBulto(
+  cantidad: number,
+  unidadesPorFardo: number | null | undefined,
+  etiqueta: string | null | undefined,
+): string | null {
+  if (!cantidad || !Number.isFinite(cantidad) || cantidad <= 0) return null;
+  if (!unidadesPorFardo || !Number.isFinite(unidadesPorFardo) || unidadesPorFardo <= 0) return null;
+
+  const ratio = cantidad / unidadesPorFardo;
+  const label = (etiqueta && etiqueta.trim()) ? etiqueta.trim().toUpperCase() : 'FARDO';
+
+  // Plural y "medio/media" según género de la palabra (CAJA/MEDIA, FARDO/MEDIO).
+  // Heurística: termina en 'A' → femenino.
+  const isFem = label.endsWith('A');
+  const medio = isFem ? 'MEDIA' : 'MEDIO';
+  const labelPlural = isFem ? `${label}S` : `${label}S`; // FARDOS / CAJAS
+
+  // Caso medio fardo
+  if (ratio === 0.5) return `(${medio} ${label})`;
+
+  // Caso entero
+  if (Number.isInteger(ratio)) {
+    return ratio === 1 ? `(1 ${label})` : `(${ratio} ${labelPlural})`;
+  }
+
+  // Caso N.5 con N>=1
+  const entero = Math.floor(ratio);
+  const fraccion = ratio - entero;
+  if (fraccion === 0.5 && entero >= 1) {
+    const palabra = entero === 1 ? label : labelPlural;
+    return `(${entero} ${palabra} Y MEDIO)`;
+  }
+
+  return null;
+}
+```
+
+**Step 4: Run test — debe PASS**
+
+Run: `npx vitest run src/lib/pdf/utils/formatBulto.test.ts`
+Expected: 8 tests passed.
+
+**Step 5: Commit**
+
+```bash
+git add src/lib/pdf/utils/formatBulto.ts src/lib/pdf/utils/formatBulto.test.ts
+git commit -m "feat(pdf): add formatAclaracionBulto pure helper + tests
+
+Calcula la aclaración (1 FARDO / MEDIO FARDO / 1 FARDO Y MEDIO / N FARDOS)
+desde cantidad y unidadesPorFardo. Soporta etiquetas custom (CAJA/MEDIA CAJA).
+Devuelve null para fracciones ambiguas (1/3, 2/3, etc.)."
+```
+
+---
+
+### Task 4: Tipos TypeScript de Producto
+
+**Files:**
+- Modify: `src/types/index.ts:51-74` (Producto, ProductoInput)
+
+**Step 1: Agregar campos opcionales**
+
+```typescript
+// src/types/index.ts (Producto)
+export interface Producto extends BaseEntity {
+  codigo?: string;
+  nombre: string;
+  descripcion?: string;
+  precio_unitario: number;
+  precio_mayorista?: number;
+  stock: number;
+  stock_minimo?: number;
+  categoria_id?: string;
+  activo: boolean;
+  unidad?: string;
+  // NUEVOS
+  unidades_de_venta_por_fardo?: number;
+  etiqueta_bulto?: string;
+}
+
+export interface ProductoInput {
+  codigo?: string;
+  nombre: string;
+  descripcion?: string;
+  precio_unitario: number;
+  precio_mayorista?: number;
+  stock?: number;
+  stock_minimo?: number;
+  categoria_id?: string;
+  unidad?: string;
+  // NUEVOS
+  unidades_de_venta_por_fardo?: number;
+  etiqueta_bulto?: string;
+}
+```
+
+**Step 2: Verificar el tipo `ProductoDB` de hooks queries**
+
+Run: `grep -n "ProductoDB" src/hooks/queries/ -r`
+Si existe un tipo `ProductoDB` espejado a la tabla, agregar también allí los 2 campos opcionales (mismos nombres exactos que en SQL).
+
+**Step 3: Typecheck**
+
+Run: `npm run typecheck`
+Expected: 0 errores.
+
+**Step 4: Commit**
+
+```bash
+git add src/types/index.ts src/hooks/queries/
+git commit -m "types(producto): add unidades_de_venta_por_fardo y etiqueta_bulto"
+```
+
+---
+
+### Task 5: Form de Producto (ModalProducto.tsx)
+
+**Files:**
+- Modify: `src/components/modals/ModalProducto.tsx`
+
+**Step 1: Leer el form actual y ubicar el campo `unidad`**
+
+Run: `grep -n "unidad" src/components/modals/ModalProducto.tsx`
+Anotar las líneas para ubicar dónde agregar los nuevos inputs (justo debajo).
+
+**Step 2: Agregar inputs al form**
+
+Después del input de `unidad`, agregar:
+
+```tsx
+<div className="grid grid-cols-2 gap-3">
+  <div>
+    <label className="block text-sm font-medium text-gray-700 dark:text-gray-300">
+      Unidades por bulto/fardo
+    </label>
+    <input
+      type="number"
+      step="0.5"
+      min="0"
+      value={formData.unidades_de_venta_por_fardo ?? ''}
+      onChange={(e) => setFormData({
+        ...formData,
+        unidades_de_venta_por_fardo: e.target.value === '' ? undefined : Number(e.target.value),
+      })}
+      className="mt-1 block w-full rounded-md border-gray-300 ..."
+      placeholder="ej. 2"
+    />
+    <p className="text-xs text-gray-500 mt-1">
+      Cuántas unidades de venta hacen 1 fardo. Si 1 unidad = medio fardo, poné 2.
+    </p>
+  </div>
+  <div>
+    <label className="block text-sm font-medium text-gray-700 dark:text-gray-300">
+      Etiqueta del bulto
+    </label>
+    <input
+      type="text"
+      value={formData.etiqueta_bulto ?? 'FARDO'}
+      onChange={(e) => setFormData({ ...formData, etiqueta_bulto: e.target.value.toUpperCase() })}
+      className="mt-1 block w-full rounded-md border-gray-300 ..."
+      placeholder="FARDO"
+      maxLength={20}
+    />
+    <p className="text-xs text-gray-500 mt-1">
+      FARDO, CAJA, PACK, BULTO...
+    </p>
+  </div>
+</div>
+```
+
+(Usar las mismas clases Tailwind que los otros inputs del form para consistencia visual — leer el archivo y copiar el patrón.)
+
+**Step 3: Asegurar que se envían en el insert/update**
+
+Buscar el callback `onSubmit` o mutación `useCrearProductoMutation`/`useActualizarProductoMutation`. Verificar que el payload incluya `unidades_de_venta_por_fardo` y `etiqueta_bulto`. Si la mutación filtra campos por allowlist, agregarlos.
+
+**Step 4: Verificación manual**
+
+Run: `npm run dev`
+- Editar un producto, setear unidades_por_fardo=2 y guardar.
+- Verificar en Supabase que se guardó:
+  ```sql
+  SELECT id, nombre, unidades_de_venta_por_fardo, etiqueta_bulto
+  FROM productos WHERE id = <id>;
+  ```
+
+**Step 5: Typecheck + lint + commit**
+
+```bash
+npm run typecheck && npm run lint
+git add src/components/modals/ModalProducto.tsx src/hooks/queries/
+git commit -m "feat(productos): UI form para unidades_por_fardo y etiqueta_bulto"
+```
+
+---
+
+### Task 6: Integrar en recibo comanda (reciboPedido.js:386)
+
+**Files:**
+- Modify: `src/lib/pdf/reciboPedido.js:382-393`
+
+**Step 1: Importar la función pura**
+
+Al tope del archivo:
+```javascript
+import { formatAclaracionBulto } from './utils/formatBulto';
+```
+
+**Step 2: Modificar el loop de items en `dibujarComanda`**
+
+```javascript
+items.forEach(item => {
+  const productoNombre = item.producto?.nombre || 'Producto'
+  const subtotal = item.subtotal || item.precio_unitario * item.cantidad
+
+  const aclaracion = formatAclaracionBulto(
+    item.cantidad,
+    item.producto?.unidades_de_venta_por_fardo,
+    item.producto?.etiqueta_bulto,
+  );
+  const lineaProducto = aclaracion
+    ? `${item.cantidad}x ${productoNombre} ${aclaracion}`
+    : `${item.cantidad}x ${productoNombre}`;
+
+  const nombreLines = doc.splitTextToSize(lineaProducto, contentWidth - 26)
+  // ... resto igual
+})
+```
+
+**Step 3: Repetir cambio en `generarReciboA4` (mismo archivo)**
+
+Run: `grep -n "generarReciboA4\|item.cantidad.*productoNombre\|item\.cantidad}x" src/lib/pdf/reciboPedido.js`
+Encontrar el loop equivalente en el A4 y aplicar la misma transformación.
+
+**Step 4: Verificación manual**
+
+Run: `npm run dev`
+- Crear pedido con 1 ud del producto editado en Task 5 → imprimir comanda → debe mostrar `1x ... (MEDIO FARDO)`.
+- Editar a 2 uds → reimprimir → `2x ... (1 FARDO)`.
+- Editar a 4 uds → `4x ... (2 FARDOS)`.
+
+**Step 5: Commit**
+
+```bash
+git add src/lib/pdf/reciboPedido.js
+git commit -m "feat(recibo): imprimir aclaración (N FARDO) en comanda y A4"
+```
+
+---
+
+### Task 7: Integrar en hoja de ruta y manifiesto
+
+**Files:**
+- Modify: `src/lib/pdf/hojaRutaOptimizada.js:158` (buildCardOps)
+- Modify: `src/lib/pdf/hojaRutaOptimizada.js:289+` (buildManifiestoOps)
+
+**Step 1: Importar la función**
+
+```javascript
+import { formatAclaracionBulto } from './utils/formatBulto';
+```
+
+**Step 2: Modificar `buildCardOps` línea ~158**
+
+Buscar la línea `doc.splitTextToSize(\`${item.cantidad}x ${nombre}\`, ...)` y cambiar:
+
+```javascript
+const aclaracion = formatAclaracionBulto(
+  item.cantidad,
+  item.producto?.unidades_de_venta_por_fardo,
+  item.producto?.etiqueta_bulto,
+);
+const linea = aclaracion ? `${item.cantidad}x ${nombre} ${aclaracion}` : `${item.cantidad}x ${nombre}`;
+doc.splitTextToSize(linea, ...);
+```
+
+**Step 3: Modificar `buildManifiestoOps` línea ~289**
+
+El manifiesto consolida cantidades por producto. Aplicar la aclaración basada en la cantidad TOTAL consolidada (no por pedido individual). Buscar dónde se renderiza la línea final del manifiesto y agregar la aclaración usando el `producto` de cada totales[key].
+
+**Step 4: Verificación manual**
+
+- Crear 2 pedidos con el mismo producto (1 ud y 2 uds) → imprimir hoja de ruta → cada tarjeta debe mostrar la aclaración correcta + el manifiesto debe mostrar `3 uds → (1 FARDO Y MEDIO)`.
+
+**Step 5: Commit**
+
+```bash
+git add src/lib/pdf/hojaRutaOptimizada.js
+git commit -m "feat(hoja-ruta): imprimir aclaración (N FARDO) en tarjetas y manifiesto"
+```
+
+---
+
+### Task 8: Asegurar que `item.producto` se carga en queries de pedido
+
+**Files:**
+- Posiblemente: `src/hooks/queries/usePedidosQuery.ts` o similar
+
+**Step 1: Verificar que la query de items incluye los nuevos campos**
+
+Run: `grep -rn "from.*pedido_items\|select.*producto" src/hooks/queries/ | head -20`
+Las queries que hacen `.select('*, producto:producto_id (*)')` ya traerán los nuevos campos. Las que usan select explícito por columnas (ej. `.select('id,nombre,precio')`) deben actualizarse para incluir `unidades_de_venta_por_fardo, etiqueta_bulto`.
+
+**Step 2: Verificar en runtime**
+
+En DevTools console, durante un pedido cargado:
+```js
+console.log(pedido.items[0].producto.unidades_de_venta_por_fardo)
+```
+Debe ser un número, no `undefined`.
+
+**Step 3: Si falta, ajustar el select y commit**
+
+```bash
+git add src/hooks/queries/
+git commit -m "fix(pedidos): incluir campos de fardo en select de productos"
+```
+
+---
+
+## Mejora 2 — Zonas en clientes (entidad + filtros)
+
+### Task 9: Migración SQL — backfill zona_id y RLS de zonas
+
+**Files:**
+- Create: `migrations/032_migrar_clientes_zona_a_zona_id.sql`
+
+**Step 1: Crear migración**
+
+```sql
+-- Migration 032: Migrar clientes.zona (texto) → clientes.zona_id (FK a zonas)
+-- También asegura que tabla `zonas` tenga RLS configurado (admin para mutaciones,
+-- select para usuarios de la sucursal).
+--
+-- Mantiene clientes.zona como columna deprecada un release para rollback seguro.
+
+-- 0. RLS de zonas si no existe (parcial — mt_zonas_*)
+ALTER TABLE zonas ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS mt_zonas_select ON zonas;
+CREATE POLICY mt_zonas_select ON zonas
+  FOR SELECT TO authenticated
+  USING (sucursal_id = current_sucursal_id());
+
+DROP POLICY IF EXISTS mt_zonas_insert ON zonas;
+CREATE POLICY mt_zonas_insert ON zonas
+  FOR INSERT TO authenticated
+  WITH CHECK (es_admin() AND sucursal_id = current_sucursal_id());
+
+DROP POLICY IF EXISTS mt_zonas_update ON zonas;
+CREATE POLICY mt_zonas_update ON zonas
+  FOR UPDATE TO authenticated
+  USING (es_admin() AND sucursal_id = current_sucursal_id())
+  WITH CHECK (es_admin() AND sucursal_id = current_sucursal_id());
+
+DROP POLICY IF EXISTS mt_zonas_delete ON zonas;
+CREATE POLICY mt_zonas_delete ON zonas
+  FOR DELETE TO authenticated
+  USING (es_admin() AND sucursal_id = current_sucursal_id());
+
+-- 1. Insertar zonas únicas que existen como texto en clientes pero no en zonas
+INSERT INTO zonas (nombre, sucursal_id, activo)
+SELECT DISTINCT trim(c.zona), c.sucursal_id, true
+FROM clientes c
+WHERE c.zona IS NOT NULL
+  AND trim(c.zona) <> ''
+  AND NOT EXISTS (
+    SELECT 1 FROM zonas z
+    WHERE lower(trim(z.nombre)) = lower(trim(c.zona))
+      AND z.sucursal_id = c.sucursal_id
+  );
+
+-- 2. Backfill clientes.zona_id desde clientes.zona
+UPDATE clientes c
+SET zona_id = z.id
+FROM zonas z
+WHERE c.zona_id IS NULL
+  AND c.zona IS NOT NULL
+  AND lower(trim(z.nombre)) = lower(trim(c.zona))
+  AND z.sucursal_id = c.sucursal_id;
+
+-- 3. Recrear vista del bot que referencia c.zona como texto
+DROP VIEW IF EXISTS bot_clientes_huerfanos_visibles;
+CREATE VIEW bot_clientes_huerfanos_visibles AS
+SELECT c.id, c.nombre, c.telefono, c.saldo_cuenta, c.direccion,
+       z.nombre AS zona, c.sucursal_id
+FROM clientes c
+LEFT JOIN zonas z ON z.id = c.zona_id
+WHERE NOT EXISTS (
+  SELECT 1 FROM cliente_preventistas cp WHERE cp.cliente_id = c.id
+);
+
+GRANT SELECT ON bot_clientes_huerfanos_visibles TO authenticated, anon, service_role;
+
+-- 4. Comentar deprecación
+COMMENT ON COLUMN clientes.zona IS
+  'DEPRECADO desde 2026-05-05 — usar zona_id (FK a zonas). Se mantiene para rollback.';
+```
+
+**Step 2: Verificar la firma actual de la vista bot_clientes_huerfanos_visibles**
+
+Run con MCP `execute_sql`:
+```sql
+SELECT pg_get_viewdef('bot_clientes_huerfanos_visibles', true);
+```
+Si la vista tiene más columnas o WHERE distinto, ajustar el CREATE VIEW arriba.
+
+**Step 3: Aplicar migración (en branch de Supabase)**
+
+Use `mcp__261fd064-3c3d-4985-9770-d22ee93274b2__create_branch` y luego `apply_migration`.
+
+**Step 4: Verificar resultados**
+
+```sql
+-- ¿Cuántas zonas se crearon?
+SELECT count(*) FROM zonas;
+-- ¿Cuántos clientes quedaron con zona_id?
+SELECT count(*) FROM clientes WHERE zona_id IS NOT NULL;
+SELECT count(*) FROM clientes WHERE zona IS NOT NULL AND zona_id IS NULL;
+-- (la 2ª query debería ser 0 si todas las zonas texto matchean — si no, listar para revisión manual)
+```
+
+**Step 5: Verificar RLS**
+
+```sql
+SELECT polname, polcmd FROM pg_policy
+WHERE polrelid = 'zonas'::regclass;
+```
+Expected: 4 policies (select/insert/update/delete) con prefijo mt_zonas_.
+
+**Step 6: Commit migración**
+
+```bash
+git add migrations/032_migrar_clientes_zona_a_zona_id.sql
+git commit -m "feat(zonas): RLS + backfill clientes.zona_id desde texto
+
+- Habilita RLS en tabla zonas con políticas mt_zonas_* (admin para mutaciones).
+- Backfill de zonas existentes en clientes.zona (texto) hacia tabla zonas.
+- Update de clientes.zona_id apuntando a la zona correspondiente.
+- Recrea bot_clientes_huerfanos_visibles para joinear con zonas.
+- Marca clientes.zona como deprecado (se mantiene un release para rollback)."
+```
+
+---
+
+### Task 10: Extender useZonasQuery.ts con CRUD admin
+
+**Files:**
+- Modify: `src/hooks/queries/useZonasQuery.ts`
+- Create: `src/hooks/queries/useZonasQuery.test.ts` (opcional pero recomendado)
+
+**Step 1: Agregar funciones de mutación**
+
+```typescript
+// src/hooks/queries/useZonasQuery.ts — agregar al final, antes del export
+
+async function renombrarZona(id: string, nombre: string): Promise<void> {
+  const trimmed = nombre.trim();
+  if (!trimmed) throw new Error('El nombre de la zona es requerido');
+  const { error } = await supabase.from('zonas').update({ nombre: trimmed }).eq('id', id);
+  if (error) {
+    if (error.code === '23505') throw new Error(`La zona "${trimmed}" ya existe`);
+    throw error;
+  }
+}
+
+async function eliminarZona(id: string): Promise<void> {
+  // Validar que no haya clientes asignados
+  const { count, error: countError } = await supabase
+    .from('clientes')
+    .select('id', { count: 'exact', head: true })
+    .eq('zona_id', id);
+  if (countError) throw countError;
+  if ((count ?? 0) > 0) {
+    throw new Error(`No se puede eliminar: hay ${count} cliente(s) asignados a esta zona. Reasignalos primero.`);
+  }
+  const { error } = await supabase.from('zonas').delete().eq('id', id);
+  if (error) throw error;
+}
+
+async function toggleZonaActiva(id: string, activo: boolean): Promise<void> {
+  const { error } = await supabase.from('zonas').update({ activo }).eq('id', id);
+  if (error) throw error;
+}
+
+export function useRenombrarZonaMutation() {
+  const queryClient = useQueryClient();
+  const { currentSucursalId } = useSucursal();
+  return useMutation({
+    mutationFn: ({ id, nombre }: { id: string; nombre: string }) => renombrarZona(id, nombre),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: zonasKeys.all(currentSucursalId) });
+    },
+  });
+}
+
+export function useEliminarZonaMutation() {
+  const queryClient = useQueryClient();
+  const { currentSucursalId } = useSucursal();
+  return useMutation({
+    mutationFn: eliminarZona,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: zonasKeys.all(currentSucursalId) });
+    },
+  });
+}
+
+export function useToggleZonaActivaMutation() {
+  const queryClient = useQueryClient();
+  const { currentSucursalId } = useSucursal();
+  return useMutation({
+    mutationFn: ({ id, activo }: { id: string; activo: boolean }) => toggleZonaActiva(id, activo),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: zonasKeys.all(currentSucursalId) });
+    },
+  });
+}
+```
+
+**Step 2: Cambiar `fetchZonas` para que liste también inactivas (usadas por panel admin)**
+
+```typescript
+async function fetchZonas(includeInactive = false): Promise<ZonaDB[]> {
+  let q = supabase.from('zonas').select('*').order('nombre');
+  if (!includeInactive) q = q.eq('activo', true);
+  const { data, error } = await q;
+  if (error) throw error;
+  return (data as ZonaDB[]) || [];
+}
+
+export function useZonasEstandarizadasQuery(opts?: { includeInactive?: boolean }) {
+  const { currentSucursalId } = useSucursal();
+  return useQuery({
+    queryKey: [...zonasKeys.lists(currentSucursalId), opts?.includeInactive ?? false],
+    queryFn: () => fetchZonas(opts?.includeInactive),
+    staleTime: 10 * 60 * 1000,
+  });
+}
+```
+
+**Step 3: Typecheck**
+
+Run: `npm run typecheck`
+
+**Step 4: Commit**
+
+```bash
+git add src/hooks/queries/useZonasQuery.ts
+git commit -m "feat(zonas): hooks renombrar/eliminar/toggle + includeInactive"
+```
+
+---
+
+### Task 11: ModalZonas (espejo de ModalCategorias)
+
+**Files:**
+- Create: `src/components/modals/ModalZonas.tsx`
+
+**Step 1: Leer ModalCategorias completo**
+
+Run: `cat src/components/modals/ModalCategorias.tsx`
+Identificar el patrón completo (estado local, render, mutaciones).
+
+**Step 2: Crear ModalZonas.tsx adaptado**
+
+Copia simplificada (sin "derivadas", porque al haber FK no hay strings huérfanos):
+
+```typescript
+// src/components/modals/ModalZonas.tsx
+import { memo, useState } from 'react';
+import { Loader2, Plus, Pencil, Trash2, Check, X, MapPin, AlertCircle, ToggleLeft, ToggleRight } from 'lucide-react';
+import ModalBase from './ModalBase';
+import {
+  useZonasEstandarizadasQuery,
+  useCrearZonaMutation,
+  useRenombrarZonaMutation,
+  useEliminarZonaMutation,
+  useToggleZonaActivaMutation,
+} from '../../hooks/queries/useZonasQuery';
+import type { ZonaDB } from '../../hooks/queries/useZonasQuery';
+
+export interface ModalZonasProps {
+  onClose: () => void;
+}
+
+const ModalZonas = memo(function ModalZonas({ onClose }: ModalZonasProps) {
+  const { data: zonas = [], isLoading } = useZonasEstandarizadasQuery({ includeInactive: true });
+  const crearMut = useCrearZonaMutation();
+  const renameMut = useRenombrarZonaMutation();
+  const deleteMut = useEliminarZonaMutation();
+  const toggleMut = useToggleZonaActivaMutation();
+
+  const [nuevoNombre, setNuevoNombre] = useState('');
+  const [error, setError] = useState('');
+  const [editandoId, setEditandoId] = useState<string | null>(null);
+  const [editNombre, setEditNombre] = useState('');
+  const [confirmDelete, setConfirmDelete] = useState<ZonaDB | null>(null);
+
+  const handleCrear = async () => {
+    const nombre = nuevoNombre.trim();
+    if (!nombre) { setError('El nombre es requerido'); return; }
+    try {
+      await crearMut.mutateAsync(nombre);
+      setNuevoNombre('');
+      setError('');
+    } catch (e: any) {
+      setError(e.message || 'Error creando zona');
+    }
+  };
+
+  // ... (espejar el resto de handlers de ModalCategorias: handleRename, handleDelete, handleToggleActiva)
+  // ... (renderizar ModalBase con la misma estructura visual)
+
+  return (
+    <ModalBase isOpen onClose={onClose} title="Gestionar Zonas">
+      {/* INPUT crear */}
+      <div className="flex gap-2 mb-4">
+        <input
+          type="text"
+          value={nuevoNombre}
+          onChange={(e) => setNuevoNombre(e.target.value)}
+          onKeyDown={(e) => e.key === 'Enter' && handleCrear()}
+          placeholder="Nueva zona..."
+          className="flex-1 rounded-md border-gray-300 ..."
+        />
+        <button onClick={handleCrear} disabled={crearMut.isPending} className="...">
+          <Plus className="w-4 h-4" /> Crear
+        </button>
+      </div>
+      {error && <p className="text-red-600 text-sm mb-2"><AlertCircle className="inline w-4 h-4" /> {error}</p>}
+
+      {/* LISTA */}
+      {isLoading ? <Loader2 className="animate-spin" /> : (
+        <ul className="divide-y">
+          {zonas.map(z => (
+            <li key={z.id} className="py-2 flex items-center gap-2">
+              {/* ... edit/toggle/delete buttons como en ModalCategorias */}
+            </li>
+          ))}
+        </ul>
+      )}
+    </ModalBase>
+  );
+});
+
+export default ModalZonas;
+```
+
+(Completar con fidelidad al patrón de ModalCategorias.)
+
+**Step 3: Typecheck + lint**
+
+```bash
+npm run typecheck && npm run lint
+```
+
+**Step 4: Commit**
+
+```bash
+git add src/components/modals/ModalZonas.tsx
+git commit -m "feat(zonas): ModalZonas para gestión admin (espejo de ModalCategorias)"
+```
+
+---
+
+### Task 12: Tipo Cliente + ModalCliente con select de zona
+
+**Files:**
+- Modify: `src/types/index.ts:23-45` (Cliente, ClienteInput)
+- Modify: `src/components/modals/ModalCliente.tsx`
+
+**Step 1: Agregar zona_id a tipos**
+
+```typescript
+export interface Cliente extends BaseEntity {
+  nombre: string;
+  direccion?: string;
+  telefono?: string;
+  email?: string;
+  /** @deprecated usar zona_id */
+  zona?: string;
+  zona_id?: string;
+  tipo?: 'minorista' | 'mayorista' | 'distribuidor';
+  activo: boolean;
+  saldo_pendiente?: number;
+  notas?: string;
+  latitud?: number;
+  longitud?: number;
+}
+
+export interface ClienteInput {
+  nombre: string;
+  direccion?: string;
+  telefono?: string;
+  email?: string;
+  /** @deprecated usar zona_id */
+  zona?: string;
+  zona_id?: string;
+  tipo?: 'minorista' | 'mayorista' | 'distribuidor';
+  notas?: string;
+}
+```
+
+**Step 2: Reemplazar input texto `zona` por select**
+
+En `ModalCliente.tsx`, ubicar el campo `zona` (texto) y reemplazar:
+
+```tsx
+import { useZonasEstandarizadasQuery } from '../../hooks/queries/useZonasQuery';
+// ...
+const { data: zonas = [] } = useZonasEstandarizadasQuery();
+// ...
+<div>
+  <label className="block text-sm font-medium">Zona</label>
+  <select
+    value={formData.zona_id ?? ''}
+    onChange={(e) => setFormData({ ...formData, zona_id: e.target.value || undefined })}
+    className="mt-1 block w-full rounded-md border-gray-300 ..."
+  >
+    <option value="">(Sin zona)</option>
+    {zonas.map(z => (
+      <option key={z.id} value={z.id}>{z.nombre}</option>
+    ))}
+  </select>
+</div>
+```
+
+**Step 3: Asegurar que el payload del crear/actualizar manda zona_id en vez de zona**
+
+Buscar la mutación correspondiente y verificar que envía `zona_id` (no `zona`). Si la mutación tipa estricto, ya estará alineado.
+
+**Step 4: Verificación manual**
+
+- Editar un cliente, cambiar zona en select, guardar.
+- Verificar en Supabase: `SELECT zona, zona_id FROM clientes WHERE id=<id>;` — `zona_id` debe ser un bigint, `zona` queda como estaba (deprecado).
+
+**Step 5: Typecheck + lint + commit**
+
+```bash
+npm run typecheck && npm run lint
+git add src/types/index.ts src/components/modals/ModalCliente.tsx
+git commit -m "feat(clientes): select de zona usando zona_id (FK)"
+```
+
+---
+
+### Task 13: Botón "Gestionar Zonas" + filtros en ClientesContainer
+
+**Files:**
+- Modify: `src/components/containers/ClientesContainer.tsx`
+- Posiblemente: `src/components/vistas/VistaClientes.tsx` (donde se renderizan filtros)
+
+**Step 1: Leer el container y la vista actuales**
+
+Run: `cat src/components/containers/ClientesContainer.tsx | head -100`
+Ubicar dónde se renderizan los botones de acción (similar a "Categorías" en ProductosContainer) y los filtros.
+
+**Step 2: Importar ModalZonas y agregar estado**
+
+```typescript
+import { lazy, Suspense, useState } from 'react';
+const ModalZonas = lazy(() => import('../modals/ModalZonas'));
+import { useAuthData } from '../../contexts/AuthDataContext';
+// ...
+const { isAdmin } = useAuthData();
+const [showZonasModal, setShowZonasModal] = useState(false);
+```
+
+**Step 3: Botón visible solo a admin**
+
+Donde estén los botones de toolbar:
+```tsx
+{isAdmin && (
+  <button
+    onClick={() => setShowZonasModal(true)}
+    className="..."
+  >
+    <MapPin className="w-4 h-4" /> Gestionar Zonas
+  </button>
+)}
+```
+
+Y al final del JSX:
+```tsx
+{showZonasModal && (
+  <Suspense fallback={null}>
+    <ModalZonas onClose={() => setShowZonasModal(false)} />
+  </Suspense>
+)}
+```
+
+**Step 4: Filtros — Zona y Estado de cuenta**
+
+Identificar el lugar donde se aplican filtros existentes (search, tipo, etc.) y agregar:
+
+```typescript
+const [filtroZonaId, setFiltroZonaId] = useState<string>(''); // '' = todas
+const [filtroSaldo, setFiltroSaldo] = useState<'todos' | 'deben' | 'no_deben'>('todos');
+
+const clientesFiltrados = useMemo(() => {
+  return clientes.filter(c => {
+    if (filtroZonaId && String(c.zona_id) !== filtroZonaId) return false;
+    const saldo = c.saldo_pendiente ?? 0;
+    if (filtroSaldo === 'deben' && saldo <= 0) return false;
+    if (filtroSaldo === 'no_deben' && saldo > 0) return false;
+    return true;
+  });
+}, [clientes, filtroZonaId, filtroSaldo]);
+```
+
+UI de filtros:
+```tsx
+<select value={filtroZonaId} onChange={(e) => setFiltroZonaId(e.target.value)}>
+  <option value="">Todas las zonas</option>
+  {zonas.map(z => <option key={z.id} value={z.id}>{z.nombre}</option>)}
+</select>
+
+<select value={filtroSaldo} onChange={(e) => setFiltroSaldo(e.target.value as any)}>
+  <option value="todos">Todos</option>
+  <option value="deben">Deben</option>
+  <option value="no_deben">No deben</option>
+</select>
+```
+
+**Step 5: Verificación manual**
+
+- Como admin: ver el botón "Gestionar Zonas". Como preventista: NO debe verse.
+- Filtrar por zona "X" → solo aparecen clientes con `zona_id = X`.
+- Filtrar "Deben" → solo `saldo_pendiente > 0`.
+- Combinar ambos filtros → AND lógico.
+
+**Step 6: Typecheck + lint + commit**
+
+```bash
+npm run typecheck && npm run lint
+git add src/components/containers/ClientesContainer.tsx src/components/vistas/VistaClientes.tsx
+git commit -m "feat(clientes): filtros por zona y estado de cuenta + botón admin"
+```
+
+---
+
+## Verificación Final
+
+### Task 14: Smoke test E2E + linting global
+
+**Step 1: Typecheck completo**
+
+Run: `npm run typecheck`
+Expected: 0 errores.
+
+**Step 2: Lint**
+
+Run: `npm run lint`
+Expected: 0 errores.
+
+**Step 3: Test unitarios**
+
+Run: `npm run test:run`
+Expected: todos los tests verdes (incluyendo `formatBulto.test.ts`).
+
+**Step 4: Build**
+
+Run: `npm run build`
+Expected: build exitoso.
+
+**Step 5: Smoke manual end-to-end**
+
+Seguir la sección "Verificación end-to-end" del design doc en `C:\Users\jorge\.claude\plans\te-paso-las-siguientes-purring-tiger.md`:
+- Mejora 1: 7 escenarios (1 ud, 2 uds, 3 uds, 4 uds, sin campo, hoja de ruta, manifiesto).
+- Mejora 2: 7 escenarios (migración aplicada, modal admin solo visible para admin, select en form, filtros, RLS, bot view).
+- Mejora 3: 4 escenarios (login por rol, dashboard accesible desde menú, F5 sin redirect).
+
+**Step 6: Smoke E2E playwright (opcional pero recomendado)**
+
+Run: `npm run test:e2e -- --grep "clientes|pedidos"` (si hay tests existentes que cubran estos flows).
+
+**Step 7: PR**
+
+Crear PR con cuerpo enlazando este plan, el design doc, y la foto de referencia del recibo #1450.
+
+---
+
+## Notas de Implementación
+
+- **Orden recomendado de ejecución**: Mejora 3 (1 línea) → Mejora 1 (function pura → migración → form → PDFs) → Mejora 2 (migración → hooks → modal → form cliente → filtros). Permite shipear cambios incrementalmente.
+- **Si una migración SQL falla**: usar `rebase_branch` o `reset_branch` del MCP supabase para volver atrás antes de reintentar.
+- **El campo `clientes.zona` (texto) NO se borra en este release** — se elimina en migración futura una vez confirmado que nadie lo lee desde el frontend.
+- **La RLS de zonas no estaba en el baseline** — la creamos en Task 9. Verificar que no rompe queries existentes (la `useZonasEstandarizadasQuery` ya existe y se usa para preventistas).
+- **Para clientes con `zona` (texto) que no matchea ninguna zona normalizada**: la migración 032 crea la zona automáticamente con el nombre exacto. Después se puede limpiar/normalizar desde el modal admin.

--- a/migrations/031_producto_unidades_por_fardo.sql
+++ b/migrations/031_producto_unidades_por_fardo.sql
@@ -1,0 +1,18 @@
+-- Migration 031: Agregar campo de unidades por fardo en productos
+-- Permite imprimir aclaración "(1 FARDO)" / "(MEDIO FARDO)" en recibos cuando
+-- la cantidad vendida coincide con un múltiplo (entero o medio) del fardo.
+--
+-- Ejemplo: SAL FINA con unidades_de_venta_por_fardo=2 →
+--   1 unidad vendida → "(MEDIO FARDO)"
+--   2 unidades       → "(1 FARDO)"
+--   3 unidades       → "(1 FARDO Y MEDIO)"
+--   4 unidades       → "(2 FARDOS)"
+
+ALTER TABLE productos
+  ADD COLUMN IF NOT EXISTS unidades_de_venta_por_fardo numeric(10,2),
+  ADD COLUMN IF NOT EXISTS etiqueta_bulto text DEFAULT 'FARDO';
+
+COMMENT ON COLUMN productos.unidades_de_venta_por_fardo IS
+  'Cantidad de unidades de venta que componen 1 fardo. Si NULL, no se imprime aclaración.';
+COMMENT ON COLUMN productos.etiqueta_bulto IS
+  'Etiqueta del bulto (FARDO, CAJA, PACK, BULTO). Default FARDO.';

--- a/migrations/032_migrar_clientes_zona_a_zona_id.sql
+++ b/migrations/032_migrar_clientes_zona_a_zona_id.sql
@@ -1,0 +1,62 @@
+-- Migration 032: Completar la migración clientes.zona (texto) → clientes.zona_id (FK a zonas)
+--
+-- Estado al momento de aplicar (verificado en main): la tabla `zonas` ya existe con
+-- RLS habilitado y 3 policies (mt_zonas_insert, mt_zonas_select, mt_zonas_update)
+-- ya con la semántica correcta (admin para mutaciones, select por sucursal). Faltan:
+--  1. La policy DELETE.
+--  2. El UNIQUE constraint actual es `UNIQUE(nombre)` GLOBAL, lo cual contradice
+--     el modelo multi-sucursal (sucursal_id NOT NULL en la tabla). Lo corregimos
+--     a `UNIQUE(nombre, sucursal_id)` para que dos sucursales puedan tener
+--     una zona "Centro" cada una sin colisionar.
+--
+-- Hay 16 zonas existentes (todas en sucursal_id=1); 261 de 268 clientes con zona
+-- ya tienen zona_id seteado — solo 7 quedan por backfill (1 en sucursal=2, 6 en
+-- sucursal=1 que probablemente nunca fueron procesados por una migración anterior).
+--
+-- Esta migración:
+--  1. Cambia UNIQUE(nombre) → UNIQUE(nombre, sucursal_id) en zonas.
+--  2. Agrega la policy mt_zonas_delete que falta (admin-only por sucursal).
+--  3. Crea las zonas faltantes (las que existen como texto en clientes pero no
+--     en zonas para esa sucursal).
+--  4. Backfillea zona_id de los clientes restantes (case-insensitive match).
+--  5. Marca clientes.zona como deprecada (comentario; no se borra para rollback).
+--
+-- La vista `bot_clientes_huerfanos_visibles` NO existe en este schema (fue eliminada
+-- en una migración posterior), por lo que el plan original de recrearla no aplica.
+
+-- 1. Cambiar UNIQUE constraint a (nombre, sucursal_id)
+ALTER TABLE public.zonas DROP CONSTRAINT IF EXISTS zonas_nombre_unique;
+ALTER TABLE public.zonas DROP CONSTRAINT IF EXISTS zonas_nombre_sucursal_unique;
+ALTER TABLE public.zonas
+  ADD CONSTRAINT zonas_nombre_sucursal_unique UNIQUE (nombre, sucursal_id);
+
+-- 2. Policy DELETE faltante en zonas
+DROP POLICY IF EXISTS mt_zonas_delete ON public.zonas;
+CREATE POLICY mt_zonas_delete ON public.zonas
+  FOR DELETE TO authenticated
+  USING (es_admin() AND sucursal_id = current_sucursal_id());
+
+-- 3. Insertar zonas únicas que existen como texto en clientes pero no en zonas
+INSERT INTO public.zonas (nombre, sucursal_id, activo)
+SELECT DISTINCT trim(c.zona), c.sucursal_id, true
+FROM public.clientes c
+WHERE c.zona IS NOT NULL
+  AND trim(c.zona) <> ''
+  AND NOT EXISTS (
+    SELECT 1 FROM public.zonas z
+    WHERE lower(trim(z.nombre)) = lower(trim(c.zona))
+      AND z.sucursal_id = c.sucursal_id
+  );
+
+-- 4. Backfill clientes.zona_id desde clientes.zona (case-insensitive match)
+UPDATE public.clientes c
+SET zona_id = z.id
+FROM public.zonas z
+WHERE c.zona_id IS NULL
+  AND c.zona IS NOT NULL
+  AND lower(trim(z.nombre)) = lower(trim(c.zona))
+  AND z.sucursal_id = c.sucursal_id;
+
+-- 5. Marcar deprecación de clientes.zona (no se borra; rollback safe)
+COMMENT ON COLUMN public.clientes.zona IS
+  'DEPRECADO desde 2026-05-05 — usar zona_id (FK a zonas). Se mantiene un release para rollback seguro.';

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -202,7 +202,7 @@ function MainAppInner({ user, perfil, logout, authReady }: {
   const isEncargado = effectiveRol === 'encargado'
   const isAdminOrEncargado = isAdmin || isEncargado
 
-  const defaultRoute = (isAdmin || isPreventista || isEncargado) ? '/dashboard' : '/pedidos'
+  const defaultRoute = '/pedidos'
 
   const authDataValue = useMemo<AuthDataContextValue>(() => ({
     user,

--- a/src/components/AppModals.tsx
+++ b/src/components/AppModals.tsx
@@ -328,8 +328,6 @@ export default function AppModals({
     setFiltros
   } = appState;
 
-  const zonasExistentes: string[] = [...new Set(clientes.map(c => c.zona).filter((z): z is string => Boolean(z)))];
-
   // Handlers para PDF con lazy loading
   const handleExportarOrdenPreparacion = async (pedidosSeleccionados: PedidoDB[]): Promise<void> => {
     const { generarOrdenPreparacion } = await loadPdfUtils();
@@ -375,7 +373,6 @@ export default function AppModals({
             onClose={() => { modales.cliente.setOpen(false); setClienteEditando(null); }}
             guardando={guardando}
             isAdmin={isAdmin}
-            zonasExistentes={zonasExistentes}
           />
         </Suspense>
       )}

--- a/src/components/containers/ClientesContainer.tsx
+++ b/src/components/containers/ClientesContainer.tsx
@@ -23,6 +23,7 @@ const VistaClientes = lazy(() => import('../vistas/VistaClientes'))
 const ModalCliente = lazy(() => import('../modals/ModalCliente'))
 const ModalFichaCliente = lazy(() => import('../modals/ModalFichaCliente'))
 const ModalConfirmacion = lazy(() => import('../modals/ModalConfirmacion'))
+const ModalZonas = lazy(() => import('../modals/ModalZonas'))
 
 function LoadingState() {
   return (
@@ -55,6 +56,7 @@ export default function ClientesContainer(): React.ReactElement {
   // Estado de modales
   const [modalClienteOpen, setModalClienteOpen] = useState(false)
   const [modalFichaOpen, setModalFichaOpen] = useState(false)
+  const [modalZonasOpen, setModalZonasOpen] = useState(false)
   const [clienteFichaId, setClienteFichaId] = useState<string | null>(null)
 
   // Ficha cliente hook - ModalFichaCliente lo usa internamente
@@ -98,6 +100,10 @@ export default function ClientesContainer(): React.ReactElement {
   const handleVerFichaCliente = useCallback((cliente: ClienteDB) => {
     setClienteFichaId(cliente.id)
     setModalFichaOpen(true)
+  }, [])
+
+  const handleGestionarZonas = useCallback(() => {
+    setModalZonasOpen(true)
   }, [])
 
   const handleGuardarCliente = useCallback(async (data: ClienteSaveData) => {
@@ -171,6 +177,7 @@ export default function ClientesContainer(): React.ReactElement {
           onEditarCliente={handleEditarCliente}
           onEliminarCliente={handleEliminarCliente}
           onVerFichaCliente={handleVerFichaCliente}
+          onGestionarZonas={isAdmin ? handleGestionarZonas : undefined}
         />
       </Suspense>
 
@@ -200,6 +207,13 @@ export default function ClientesContainer(): React.ReactElement {
               setClienteFichaId(null)
             }}
           />
+        </Suspense>
+      )}
+
+      {/* Modal Zonas (admin) */}
+      {modalZonasOpen && (
+        <Suspense fallback={null}>
+          <ModalZonas onClose={() => setModalZonasOpen(false)} />
         </Suspense>
       )}
 

--- a/src/components/containers/ClientesContainer.tsx
+++ b/src/components/containers/ClientesContainer.tsx
@@ -127,7 +127,10 @@ export default function ClientesContainer(): React.ReactElement {
       direccion: data.direccion,
       telefono: data.telefono || undefined,
       cuit: data.cuit || undefined,
+      // zona (texto) está deprecada — se mantiene un release por compat de lecturas legacy.
       zona: data.zona || undefined,
+      // Empty string from "(Sin zona)" → null para limpiar la FK (no '' que rompe FK validation).
+      zona_id: data.zona_id ? data.zona_id : null,
       latitud: data.latitud,
       longitud: data.longitud,
       limite_credito: data.limiteCredito,

--- a/src/components/containers/ClientesContainer.tsx
+++ b/src/components/containers/ClientesContainer.tsx
@@ -10,7 +10,8 @@ import {
   useClientesQuery,
   useCrearClienteMutation,
   useActualizarClienteMutation,
-  useEliminarClienteMutation
+  useEliminarClienteMutation,
+  useZonasEstandarizadasQuery
 } from '../../hooks/queries'
 import { useAuthData } from '../../contexts/AuthDataContext'
 import { useNotification } from '../../contexts/NotificationContext'
@@ -47,6 +48,10 @@ export default function ClientesContainer(): React.ReactElement {
 
   // Queries
   const { data: clientes = [], isLoading } = useClientesQuery()
+  // includeInactive: true para no perder el texto cuando una zona se desactiva
+  // entre ediciones del cliente — el espejo legacy debe seguir resolviendo
+  // aunque la zona ya no esté disponible en el selector activo.
+  const { data: zonas = [] } = useZonasEstandarizadasQuery({ includeInactive: true })
 
   // Mutations
   const crearCliente = useCrearClienteMutation()
@@ -127,14 +132,23 @@ export default function ClientesContainer(): React.ReactElement {
         : baseIds
     }
 
+    // Dual-write zona text + zona_id durante el deprecation window:
+    // muchos read paths legacy (PDFs, reportes, bot Telegram) leen cliente.zona
+    // como string. Cuando se borre clientes.zona del schema, eliminar este lookup.
+    const zonaSeleccionada = data.zona_id
+      ? zonas.find(z => String(z.id) === String(data.zona_id))
+      : null
+
     const dbData = {
       razon_social: data.razonSocial || data.nombreFantasia,
       nombre_fantasia: data.nombreFantasia,
       direccion: data.direccion,
       telefono: data.telefono || undefined,
       cuit: data.cuit || undefined,
-      // zona (texto) está deprecada — se mantiene un release por compat de lecturas legacy.
-      zona: data.zona || undefined,
+      // zona (texto) deprecada — se espeja desde zona_id resolviendo contra el
+      // cache de zonas (incluye inactivas) para que PDFs/reportes/bot vean el
+      // nombre correcto. Sin esto, clientes nuevos mostraban "Sin zona".
+      zona: zonaSeleccionada?.nombre ?? null,
       // La coerción '' → null para zona_id vive en useClientesQuery (createCliente y
       // updateCliente). Acá solo pasamos el valor del form sin transform.
       zona_id: data.zona_id,
@@ -163,7 +177,7 @@ export default function ClientesContainer(): React.ReactElement {
       notify.error((error as Error).message || 'Error al guardar cliente')
       throw error
     }
-  }, [clienteEditando, actualizarCliente, crearCliente, notify, isAdmin, isPreventista, user])
+  }, [clienteEditando, actualizarCliente, crearCliente, notify, isAdmin, isPreventista, user, zonas])
 
   return (
     <>

--- a/src/components/containers/ClientesContainer.tsx
+++ b/src/components/containers/ClientesContainer.tsx
@@ -129,8 +129,9 @@ export default function ClientesContainer(): React.ReactElement {
       cuit: data.cuit || undefined,
       // zona (texto) está deprecada — se mantiene un release por compat de lecturas legacy.
       zona: data.zona || undefined,
-      // Empty string from "(Sin zona)" → null para limpiar la FK (no '' que rompe FK validation).
-      zona_id: data.zona_id ? data.zona_id : null,
+      // La coerción '' → null para zona_id vive en useClientesQuery (createCliente y
+      // updateCliente). Acá solo pasamos el valor del form sin transform.
+      zona_id: data.zona_id,
       latitud: data.latitud,
       longitud: data.longitud,
       limite_credito: data.limiteCredito,

--- a/src/components/modals/ModalCliente.tsx
+++ b/src/components/modals/ModalCliente.tsx
@@ -66,8 +66,6 @@ export interface ModalClienteProps {
   guardando: boolean;
   /** Si el usuario es admin (puede editar crédito) */
   isAdmin?: boolean;
-  /** Zonas existentes para sugerencias */
-  zonasExistentes?: string[];
 }
 
 // Las zonas ahora vienen de la tabla `zonas` via useZonasEstandarizadasQuery
@@ -91,7 +89,7 @@ const ModalCliente = memo(function ModalCliente({ cliente, onSave, onClose, guar
   // Ref para scroll a errores
   const formRef = useRef<HTMLDivElement>(null);
   const { data: preventistas = [] } = usePreventistasQuery();
-  const { data: zonas = [] } = useZonasEstandarizadasQuery();
+  const { data: zonas = [] } = useZonasEstandarizadasQuery({ includeInactive: true });
 
   // Zod validation hook with accessibility helpers
   const { errors: errores, validate, clearFieldError, hasAttemptedSubmit: intentoGuardar, getAriaProps, getErrorMessageProps } = useZodValidation(modalClienteSchema);
@@ -385,7 +383,9 @@ const ModalCliente = memo(function ModalCliente({ cliente, onSave, onClose, guar
             >
               <option value="">(Sin zona)</option>
               {zonas.map(z => (
-                <option key={z.id} value={String(z.id)}>{z.nombre}</option>
+                <option key={z.id} value={String(z.id)}>
+                  {z.nombre}{z.activo === false ? ' (inactiva)' : ''}
+                </option>
               ))}
             </select>
           </div>

--- a/src/components/modals/ModalCliente.tsx
+++ b/src/components/modals/ModalCliente.tsx
@@ -4,7 +4,7 @@ import ModalBase from './ModalBase';
 import { AddressAutocomplete } from '../AddressAutocomplete';
 import { useZodValidation } from '../../hooks/useZodValidation';
 import { modalClienteSchema } from '../../lib/schemas';
-import { usePreventistasQuery } from '../../hooks/queries';
+import { usePreventistasQuery, useZonasEstandarizadasQuery } from '../../hooks/queries';
 import {
   formatCuitInput,
   formatDniInput,
@@ -28,7 +28,10 @@ export interface ClienteFormData {
   longitud: number | null;
   telefono: string;
   contacto: string;
+  /** @deprecated usar zona_id. Se mantiene para compat de lecturas. */
   zona: string;
+  /** FK a tabla zonas. Cadena vacía representa "sin zona". */
+  zona_id: string;
   horarios_atencion: string;
   rubro: string;
   notas: string;
@@ -88,6 +91,7 @@ const ModalCliente = memo(function ModalCliente({ cliente, onSave, onClose, guar
   // Ref para scroll a errores
   const formRef = useRef<HTMLDivElement>(null);
   const { data: preventistas = [] } = usePreventistasQuery();
+  const { data: zonas = [] } = useZonasEstandarizadasQuery();
 
   // Zod validation hook with accessibility helpers
   const { errors: errores, validate, clearFieldError, hasAttemptedSubmit: intentoGuardar, getAriaProps, getErrorMessageProps } = useZodValidation(modalClienteSchema);
@@ -107,6 +111,7 @@ const ModalCliente = memo(function ModalCliente({ cliente, onSave, onClose, guar
     telefono: cliente.telefono || '',
     contacto: cliente.contacto || '',
     zona: cliente.zona || '',
+    zona_id: cliente.zona_id ? String(cliente.zona_id) : '',
     horarios_atencion: cliente.horarios_atencion || '',
     rubro: cliente.rubro || '',
     notas: cliente.notas || '',
@@ -125,6 +130,7 @@ const ModalCliente = memo(function ModalCliente({ cliente, onSave, onClose, guar
     telefono: '',
     contacto: '',
     zona: '',
+    zona_id: '',
     horarios_atencion: '',
     rubro: '',
     notas: '',
@@ -349,7 +355,7 @@ const ModalCliente = memo(function ModalCliente({ cliente, onSave, onClose, guar
           </div>
         </div>
 
-        {/* Rubro */}
+        {/* Rubro y Zona */}
         <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
           <div>
             <label className="block text-sm font-medium mb-1 dark:text-gray-200 flex items-center gap-1">
@@ -364,6 +370,22 @@ const ModalCliente = memo(function ModalCliente({ cliente, onSave, onClose, guar
               <option value="">Seleccionar rubro...</option>
               {RUBROS_OPCIONES.map(rubro => (
                 <option key={rubro} value={rubro}>{rubro}</option>
+              ))}
+            </select>
+          </div>
+          <div>
+            <label className="block text-sm font-medium mb-1 dark:text-gray-200 flex items-center gap-1">
+              <MapPin className="w-4 h-4" />
+              Zona
+            </label>
+            <select
+              value={form.zona_id}
+              onChange={e => handleFieldChange('zona_id', e.target.value)}
+              className="w-full px-3 py-2 border rounded-lg dark:bg-gray-700 dark:border-gray-600 dark:text-white"
+            >
+              <option value="">(Sin zona)</option>
+              {zonas.map(z => (
+                <option key={z.id} value={String(z.id)}>{z.nombre}</option>
               ))}
             </select>
           </div>

--- a/src/components/modals/ModalProducto.tsx
+++ b/src/components/modals/ModalProducto.tsx
@@ -26,6 +26,10 @@ export interface ProductoFormData {
   impuestos_internos: number | string;
   precio_sin_iva: number | string;
   precio: number | string;
+  /** Cuántas unidades de venta hacen 1 fardo/bulto (ej: 2 = vendés medio fardo) */
+  unidades_de_venta_por_fardo?: number;
+  /** Etiqueta del bulto: FARDO, CAJA, PACK, BULTO... */
+  etiqueta_bulto?: string;
 }
 
 /** Opción de IVA */
@@ -94,7 +98,10 @@ const ModalProducto = memo(function ModalProducto({ producto, categorias, provee
     costo_con_iva: producto.costo_con_iva ?? '',
     impuestos_internos: producto.impuestos_internos ?? '',
     precio_sin_iva: producto.precio_sin_iva ?? '',
-    precio: producto.precio ?? ''
+    precio: producto.precio ?? '',
+    // ProductoDB usa `?: T | null`; el form usa `?: T`. Mapeo explícito null → undefined.
+    unidades_de_venta_por_fardo: producto.unidades_de_venta_por_fardo ?? undefined,
+    etiqueta_bulto: producto.etiqueta_bulto ?? undefined
   } : {
     nombre: '',
     codigo: '',
@@ -107,7 +114,9 @@ const ModalProducto = memo(function ModalProducto({ producto, categorias, provee
     costo_con_iva: '',
     impuestos_internos: '',
     precio_sin_iva: '',
-    precio: '' // precio_con_iva (precio final al cliente)
+    precio: '', // precio_con_iva (precio final al cliente)
+    unidades_de_venta_por_fardo: undefined,
+    etiqueta_bulto: undefined
   });
   const [nuevaCategoria, setNuevaCategoria] = useState<string>('');
   const [mostrarNuevaCategoria, setMostrarNuevaCategoria] = useState<boolean>(false);
@@ -280,6 +289,47 @@ const ModalProducto = memo(function ModalProducto({ producto, categorias, provee
             </select>
           </div>
         )}
+
+        {/* Bulto / Fardo: cuántas unidades de venta hacen un fardo y cómo lo llamamos */}
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+          <div>
+            <label className="block text-sm font-medium mb-1">Unidades por bulto/fardo</label>
+            <input
+              type="number"
+              inputMode="decimal"
+              step="0.5"
+              min="0"
+              value={form.unidades_de_venta_por_fardo ?? ''}
+              onChange={(e: ChangeEvent<HTMLInputElement>) => {
+                const val = e.target.value
+                setForm({
+                  ...form,
+                  unidades_de_venta_por_fardo: val === '' ? undefined : Number(val)
+                })
+              }}
+              className="w-full px-3 py-2 border rounded-lg"
+              placeholder="ej. 2"
+            />
+            <p className="text-xs text-gray-500 mt-1">
+              Cuántas unidades de venta hacen 1 fardo. Si 1 unidad = medio fardo, poné 2.
+            </p>
+          </div>
+          <div>
+            <label className="block text-sm font-medium mb-1">Etiqueta del bulto</label>
+            <input
+              type="text"
+              value={form.etiqueta_bulto ?? ''}
+              onChange={(e: ChangeEvent<HTMLInputElement>) => setForm({
+                ...form,
+                etiqueta_bulto: e.target.value === '' ? undefined : e.target.value.toUpperCase()
+              })}
+              className="w-full px-3 py-2 border rounded-lg uppercase"
+              placeholder="FARDO"
+              maxLength={20}
+            />
+            <p className="text-xs text-gray-500 mt-1">FARDO, CAJA, PACK, BULTO...</p>
+          </div>
+        </div>
 
         {/* Seccion de IVA */}
         <div className="border-t pt-4">

--- a/src/components/modals/ModalZonas.tsx
+++ b/src/components/modals/ModalZonas.tsx
@@ -1,0 +1,332 @@
+/**
+ * Modal para gestionar zonas (panel admin).
+ *
+ * Espejo simplificado de ModalCategorias. La fuente de verdad es la tabla
+ * `zonas` (FK desde `clientes.zona_id` y `proveedores.zona_id` con
+ * RESTRICT) — no existe el concepto de "derivada" como en categorías,
+ * así que no se cuentan/mergean strings sueltos. El admin ve también las
+ * inactivas para poder reactivarlas o eliminarlas.
+ */
+import { memo, useMemo, useState } from 'react';
+import { Loader2, Plus, Pencil, Trash2, Check, X, MapPin, AlertCircle, ToggleLeft, ToggleRight } from 'lucide-react';
+import ModalBase from './ModalBase';
+import {
+  useZonasEstandarizadasQuery,
+  useCrearZonaMutation,
+  useRenombrarZonaMutation,
+  useEliminarZonaMutation,
+  useToggleZonaActivaMutation,
+} from '../../hooks/queries';
+import type { ZonaDB } from '../../hooks/queries/useZonasQuery';
+
+export interface ModalZonasProps {
+  /** Callback al cerrar */
+  onClose: () => void;
+}
+
+const ModalZonas = memo(function ModalZonas({ onClose }: ModalZonasProps) {
+  // Admin view: incluye inactivas para que puedan reactivarse/eliminarse.
+  const { data: zonas = [], isLoading } = useZonasEstandarizadasQuery({ includeInactive: true });
+  const crearMut = useCrearZonaMutation();
+  const renameMut = useRenombrarZonaMutation();
+  const deleteMut = useEliminarZonaMutation();
+  const toggleMut = useToggleZonaActivaMutation();
+
+  const [nuevoNombre, setNuevoNombre] = useState('');
+  const [error, setError] = useState('');
+  const [editandoId, setEditandoId] = useState<string | null>(null);
+  const [editNombre, setEditNombre] = useState('');
+  const [confirmDelete, setConfirmDelete] = useState<ZonaDB | null>(null);
+
+  // Activas primero, luego alfabético dentro de cada grupo.
+  const entries = useMemo((): ZonaDB[] => {
+    return [...zonas].sort((a, b) => {
+      const aActiva = a.activo !== false;
+      const bActiva = b.activo !== false;
+      if (aActiva !== bActiva) return aActiva ? -1 : 1;
+      return a.nombre.localeCompare(b.nombre);
+    });
+  }, [zonas]);
+
+  const handleCrear = async () => {
+    const nombre = nuevoNombre.trim();
+    if (!nombre) {
+      setError('Ingresá un nombre');
+      return;
+    }
+    if (entries.some(e => e.nombre.toLowerCase() === nombre.toLowerCase())) {
+      setError(`Ya existe una zona "${nombre}"`);
+      return;
+    }
+    setError('');
+    try {
+      await crearMut.mutateAsync(nombre);
+      setNuevoNombre('');
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Error al crear zona');
+    }
+  };
+
+  const handleIniciarRename = (entry: ZonaDB) => {
+    setEditandoId(entry.id);
+    setEditNombre(entry.nombre);
+    setError('');
+  };
+
+  const handleCancelarRename = () => {
+    setEditandoId(null);
+    setEditNombre('');
+    setError('');
+  };
+
+  const handleConfirmarRename = async (entry: ZonaDB) => {
+    const nuevo = editNombre.trim();
+    if (!nuevo) {
+      setError('El nombre no puede estar vacío');
+      return;
+    }
+    if (nuevo === entry.nombre) {
+      handleCancelarRename();
+      return;
+    }
+    if (entries.some(e => e.nombre.toLowerCase() === nuevo.toLowerCase() && e.nombre !== entry.nombre)) {
+      setError(`Ya existe una zona "${nuevo}"`);
+      return;
+    }
+    setError('');
+    try {
+      await renameMut.mutateAsync({ id: entry.id, nombre: nuevo });
+      handleCancelarRename();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Error al renombrar zona');
+    }
+  };
+
+  const handleEliminar = async (entry: ZonaDB) => {
+    setError('');
+    try {
+      await deleteMut.mutateAsync(entry.id);
+      setConfirmDelete(null);
+    } catch (e) {
+      // El helper enriquece el mensaje con cuántos clientes/proveedores
+      // siguen referenciando la zona; lo mostramos tal cual.
+      setError(e instanceof Error ? e.message : 'Error al eliminar zona');
+    }
+  };
+
+  const handleToggleActiva = async (entry: ZonaDB) => {
+    setError('');
+    try {
+      await toggleMut.mutateAsync({ id: entry.id, activo: entry.activo === false });
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Error al cambiar estado');
+    }
+  };
+
+  const working = crearMut.isPending || renameMut.isPending || deleteMut.isPending || toggleMut.isPending;
+
+  return (
+    <ModalBase title="Gestionar Zonas" onClose={onClose} maxWidth="max-w-2xl">
+      <div className="p-4 space-y-4">
+        {/* Agregar nueva */}
+        <div>
+          <label htmlFor="nueva-zona" className="block text-sm font-medium mb-1 dark:text-gray-200">
+            Nueva zona
+          </label>
+          <div className="flex gap-2">
+            <input
+              id="nueva-zona"
+              type="text"
+              value={nuevoNombre}
+              onChange={e => setNuevoNombre(e.target.value)}
+              onKeyDown={e => {
+                if (e.key === 'Enter') {
+                  e.preventDefault();
+                  void handleCrear();
+                }
+              }}
+              placeholder="Ej.: ZONA NORTE"
+              className="flex-1 px-3 py-2 border rounded-lg bg-white dark:bg-gray-700 dark:border-gray-600 dark:text-white focus:ring-2 focus:ring-blue-500 focus:outline-none"
+              disabled={crearMut.isPending}
+            />
+            <button
+              type="button"
+              onClick={handleCrear}
+              disabled={crearMut.isPending || !nuevoNombre.trim()}
+              className="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 disabled:bg-gray-400 disabled:cursor-not-allowed flex items-center gap-1.5 font-medium"
+            >
+              {crearMut.isPending ? <Loader2 className="w-4 h-4 animate-spin" /> : <Plus className="w-4 h-4" />}
+              Agregar
+            </button>
+          </div>
+        </div>
+
+        {error && (
+          <div role="alert" className="flex items-start gap-2 p-3 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg text-sm text-red-700 dark:text-red-300">
+            <AlertCircle className="w-4 h-4 flex-shrink-0 mt-0.5" />
+            <span>{error}</span>
+          </div>
+        )}
+
+        {/* Lista */}
+        <div>
+          <h3 className="text-sm font-medium mb-2 dark:text-gray-200 flex items-center gap-1.5">
+            <MapPin className="w-4 h-4" />
+            Zonas ({entries.length})
+          </h3>
+
+          {isLoading ? (
+            <div className="flex items-center justify-center py-8">
+              <Loader2 className="w-6 h-6 animate-spin text-blue-600" />
+            </div>
+          ) : entries.length === 0 ? (
+            <p className="text-center text-sm text-gray-500 dark:text-gray-400 py-6">
+              No hay zonas creadas todavía. Creá la primera con el formulario de arriba.
+            </p>
+          ) : (
+            <ul className="border dark:border-gray-600 rounded-lg divide-y dark:divide-gray-700 max-h-[50vh] overflow-y-auto">
+              {entries.map(entry => {
+                const editing = editandoId === entry.id;
+                const activa = entry.activo !== false;
+                return (
+                  <li key={entry.id} className="flex items-center gap-2 px-3 py-2.5">
+                    {editing ? (
+                      <input
+                        type="text"
+                        value={editNombre}
+                        onChange={e => setEditNombre(e.target.value)}
+                        onKeyDown={e => {
+                          if (e.key === 'Enter') {
+                            e.preventDefault();
+                            void handleConfirmarRename(entry);
+                          } else if (e.key === 'Escape') {
+                            handleCancelarRename();
+                          }
+                        }}
+                        className="flex-1 px-2 py-1 border rounded bg-white dark:bg-gray-700 dark:border-gray-600 dark:text-white focus:ring-2 focus:ring-blue-500 focus:outline-none text-sm"
+                        autoFocus
+                        disabled={renameMut.isPending}
+                      />
+                    ) : (
+                      <div className={`flex-1 min-w-0 flex items-center gap-2 flex-wrap ${!activa ? 'opacity-60' : ''}`}>
+                        <span className="font-medium dark:text-white truncate">{entry.nombre}</span>
+                        {!activa && (
+                          <span className="text-xs px-2 py-0.5 bg-gray-200 dark:bg-gray-600 text-gray-600 dark:text-gray-300 rounded-full font-medium">
+                            inactiva
+                          </span>
+                        )}
+                      </div>
+                    )}
+
+                    {editing ? (
+                      <div className="flex gap-1 shrink-0">
+                        <button
+                          type="button"
+                          onClick={() => handleConfirmarRename(entry)}
+                          disabled={renameMut.isPending}
+                          className="p-1.5 text-green-600 hover:bg-green-50 dark:hover:bg-green-900/20 rounded disabled:opacity-50"
+                          title="Guardar"
+                          aria-label="Guardar"
+                        >
+                          {renameMut.isPending ? <Loader2 className="w-4 h-4 animate-spin" /> : <Check className="w-4 h-4" />}
+                        </button>
+                        <button
+                          type="button"
+                          onClick={handleCancelarRename}
+                          disabled={renameMut.isPending}
+                          className="p-1.5 text-gray-500 hover:bg-gray-50 dark:hover:bg-gray-700 rounded disabled:opacity-50"
+                          title="Cancelar"
+                          aria-label="Cancelar"
+                        >
+                          <X className="w-4 h-4" />
+                        </button>
+                      </div>
+                    ) : (
+                      <div className="flex gap-1 shrink-0">
+                        <button
+                          type="button"
+                          onClick={() => handleIniciarRename(entry)}
+                          disabled={working}
+                          className="p-1.5 text-blue-600 hover:bg-blue-50 dark:hover:bg-blue-900/20 rounded disabled:opacity-50"
+                          title={`Renombrar ${entry.nombre}`}
+                          aria-label={`Renombrar ${entry.nombre}`}
+                        >
+                          <Pencil className="w-4 h-4" />
+                        </button>
+                        <button
+                          type="button"
+                          onClick={() => handleToggleActiva(entry)}
+                          disabled={working}
+                          className="p-1.5 hover:bg-gray-100 dark:hover:bg-gray-700 rounded disabled:opacity-50"
+                          title={activa ? `Desactivar ${entry.nombre}` : `Activar ${entry.nombre}`}
+                          aria-label={activa ? `Desactivar ${entry.nombre}` : `Activar ${entry.nombre}`}
+                        >
+                          {activa
+                            ? <ToggleRight className="w-5 h-5 text-green-600" />
+                            : <ToggleLeft className="w-5 h-5 text-gray-400" />
+                          }
+                        </button>
+                        <button
+                          type="button"
+                          onClick={() => setConfirmDelete(entry)}
+                          disabled={working}
+                          className="p-1.5 text-red-500 hover:bg-red-50 dark:hover:bg-red-900/20 rounded disabled:opacity-50"
+                          title={`Eliminar ${entry.nombre}`}
+                          aria-label={`Eliminar ${entry.nombre}`}
+                        >
+                          <Trash2 className="w-4 h-4" />
+                        </button>
+                      </div>
+                    )}
+                  </li>
+                );
+              })}
+            </ul>
+          )}
+        </div>
+      </div>
+
+      {/* Confirmación de eliminación inline */}
+      {confirmDelete && (
+        <div className="p-4 border-t dark:border-gray-600 bg-amber-50 dark:bg-amber-900/20">
+          <p className="text-sm text-amber-900 dark:text-amber-200 mb-3">
+            <strong>Eliminar "{confirmDelete.nombre}"?</strong>{' '}
+            Si hay clientes o proveedores asignados a esta zona, la base de datos
+            rechazará la operación y deberás reasignarlos primero.
+          </p>
+          <div className="flex justify-end gap-2">
+            <button
+              type="button"
+              onClick={() => setConfirmDelete(null)}
+              disabled={deleteMut.isPending}
+              className="px-3 py-1.5 text-sm font-medium text-gray-700 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-700 rounded-lg"
+            >
+              Cancelar
+            </button>
+            <button
+              type="button"
+              onClick={() => handleEliminar(confirmDelete)}
+              disabled={deleteMut.isPending}
+              className="px-3 py-1.5 text-sm bg-red-600 text-white font-medium rounded-lg hover:bg-red-700 disabled:bg-gray-400 flex items-center gap-1.5"
+            >
+              {deleteMut.isPending && <Loader2 className="w-4 h-4 animate-spin" />}
+              Eliminar
+            </button>
+          </div>
+        </div>
+      )}
+
+      <div className="p-4 border-t dark:border-gray-600 flex justify-end">
+        <button
+          type="button"
+          onClick={onClose}
+          className="px-4 py-2 text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-lg"
+        >
+          Cerrar
+        </button>
+      </div>
+    </ModalBase>
+  );
+});
+
+export default ModalZonas;

--- a/src/components/vistas/VistaClientes.tsx
+++ b/src/components/vistas/VistaClientes.tsx
@@ -3,6 +3,7 @@ import type { ChangeEvent } from 'react';
 import { Users, Plus, Edit2, Trash2, Search, MapPin, Phone, FileText, Tag, Building2 } from 'lucide-react';
 import LoadingSpinner from '../layout/LoadingSpinner';
 import Paginacion from '../layout/Paginacion';
+import { useZonasEstandarizadasQuery } from '../../hooks/queries';
 import type { ClienteDB } from '../../types';
 
 const ITEMS_PER_PAGE = 18;
@@ -24,6 +25,8 @@ export interface VistaClientesProps {
   onEditarCliente: (cliente: ClienteDB) => void;
   onEliminarCliente: (id: string) => void;
   onVerFichaCliente?: (cliente: ClienteDB) => void;
+  /** Solo se pasa cuando el usuario es admin (gating en el container). */
+  onGestionarZonas?: () => void;
 }
 
 export default function VistaClientes({
@@ -34,7 +37,8 @@ export default function VistaClientes({
   onNuevoCliente,
   onEditarCliente,
   onEliminarCliente,
-  onVerFichaCliente
+  onVerFichaCliente,
+  onGestionarZonas
 }: VistaClientesProps) {
   const [busqueda, setBusqueda] = useState<string>('');
   const [paginaActual, setPaginaActual] = useState(1);
@@ -46,6 +50,14 @@ export default function VistaClientes({
   }, [clientes]);
 
   const [filtroRubro, setFiltroRubro] = useState<string>('todos');
+  // '' = todas las zonas (incluye clientes sin zona). Filtramos por id de zona
+  // estandarizada — ignoramos el campo legado `zona` (texto).
+  const [filtroZonaId, setFiltroZonaId] = useState<string>('');
+  const [filtroSaldo, setFiltroSaldo] = useState<'todos' | 'deben' | 'no_deben'>('todos');
+
+  // Solo zonas activas para el dropdown de filtro (las inactivas no son
+  // útiles aquí — para verlas/reactivarlas está el ModalZonas).
+  const { data: zonas = [] } = useZonasEstandarizadasQuery();
 
   // Filtrar clientes
   const clientesFiltrados = useMemo((): ClienteDB[] => {
@@ -61,9 +73,18 @@ export default function VistaClientes({
 
       const matchRubro = filtroRubro === 'todos' || c.rubro === filtroRubro;
 
-      return matchBusqueda && matchRubro;
+      const matchZona = !filtroZonaId || (c.zona_id != null && String(c.zona_id) === filtroZonaId);
+
+      // Saldo positivo = el cliente debe. 0 o ausente = no debe.
+      const saldo = c.saldo_cuenta ?? 0;
+      const matchSaldo =
+        filtroSaldo === 'todos' ||
+        (filtroSaldo === 'deben' && saldo > 0) ||
+        (filtroSaldo === 'no_deben' && saldo <= 0);
+
+      return matchBusqueda && matchRubro && matchZona && matchSaldo;
     });
-  }, [clientes, busqueda, filtroRubro]);
+  }, [clientes, busqueda, filtroRubro, filtroZonaId, filtroSaldo]);
 
   // Pagination
   const totalPaginas = Math.ceil(clientesFiltrados.length / ITEMS_PER_PAGE);
@@ -75,6 +96,13 @@ export default function VistaClientes({
   // Reset page when filters change
   const handleBusqueda = (e: ChangeEvent<HTMLInputElement>) => { setBusqueda(e.target.value); setPaginaActual(1); };
   const handleRubro = (e: ChangeEvent<HTMLSelectElement>) => { setFiltroRubro(e.target.value); setPaginaActual(1); };
+  const handleZona = (e: ChangeEvent<HTMLSelectElement>) => { setFiltroZonaId(e.target.value); setPaginaActual(1); };
+  const handleSaldo = (e: ChangeEvent<HTMLSelectElement>) => {
+    setFiltroSaldo(e.target.value as 'todos' | 'deben' | 'no_deben');
+    setPaginaActual(1);
+  };
+
+  const filtrosActivos = busqueda || filtroRubro !== 'todos' || filtroZonaId !== '' || filtroSaldo !== 'todos';
 
   return (
     <div className="space-y-4">
@@ -84,15 +112,26 @@ export default function VistaClientes({
           <h1 className="text-2xl font-bold text-gray-800 dark:text-white">Clientes</h1>
           <p className="text-sm text-gray-500 dark:text-gray-400">{clientes.length} clientes registrados</p>
         </div>
-        {(isAdmin || isPreventista) && (
-          <button
-            onClick={onNuevoCliente}
-            className="flex items-center space-x-2 px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors"
-          >
-            <Plus className="w-5 h-5" />
-            <span>Nuevo Cliente</span>
-          </button>
-        )}
+        <div className="flex flex-wrap gap-2">
+          {isAdmin && onGestionarZonas && (
+            <button
+              onClick={onGestionarZonas}
+              className="flex items-center space-x-2 px-4 py-2 bg-purple-100 dark:bg-purple-900/30 text-purple-700 dark:text-purple-400 rounded-lg hover:bg-purple-200 dark:hover:bg-purple-900/50 transition-colors"
+            >
+              <MapPin className="w-5 h-5" />
+              <span>Gestionar Zonas</span>
+            </button>
+          )}
+          {(isAdmin || isPreventista) && (
+            <button
+              onClick={onNuevoCliente}
+              className="flex items-center space-x-2 px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors"
+            >
+              <Plus className="w-5 h-5" />
+              <span>Nuevo Cliente</span>
+            </button>
+          )}
+        </div>
       </div>
 
       {/* Filtros */}
@@ -125,10 +164,39 @@ export default function VistaClientes({
             </select>
           </div>
         )}
+        {zonas.length > 0 && (
+          <div>
+            <label htmlFor="filtro-zona-clientes" className="sr-only">Filtrar clientes por zona</label>
+            <select
+              id="filtro-zona-clientes"
+              value={filtroZonaId}
+              onChange={handleZona}
+              className="px-4 py-2 border rounded-lg focus:ring-2 focus:ring-blue-500 dark:bg-gray-700 dark:border-gray-600 dark:text-white"
+            >
+              <option value="">Todas las zonas</option>
+              {zonas.map(z => (
+                <option key={z.id} value={z.id}>{z.nombre}</option>
+              ))}
+            </select>
+          </div>
+        )}
+        <div>
+          <label htmlFor="filtro-saldo-clientes" className="sr-only">Filtrar clientes por estado de cuenta</label>
+          <select
+            id="filtro-saldo-clientes"
+            value={filtroSaldo}
+            onChange={handleSaldo}
+            className="px-4 py-2 border rounded-lg focus:ring-2 focus:ring-blue-500 dark:bg-gray-700 dark:border-gray-600 dark:text-white"
+          >
+            <option value="todos">Estado de cuenta: Todos</option>
+            <option value="deben">Deben</option>
+            <option value="no_deben">No deben</option>
+          </select>
+        </div>
       </div>
 
       {/* Contador de resultados */}
-      {(busqueda || filtroRubro !== 'todos') && (
+      {filtrosActivos && (
         <div className="text-sm text-gray-600 dark:text-gray-400">
           Mostrando {clientesFiltrados.length} de {clientes.length} clientes
         </div>
@@ -138,7 +206,7 @@ export default function VistaClientes({
       {loading ? <LoadingSpinner /> : clientesFiltrados.length === 0 ? (
         <div className="text-center py-12 text-gray-500">
           <Users className="w-12 h-12 mx-auto mb-3 opacity-50" />
-          <p>{busqueda || filtroRubro !== 'todos' ? 'No se encontraron clientes con esos criterios' : 'No hay clientes'}</p>
+          <p>{filtrosActivos ? 'No se encontraron clientes con esos criterios' : 'No hay clientes'}</p>
         </div>
       ) : (
         <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">

--- a/src/hooks/queries/index.ts
+++ b/src/hooks/queries/index.ts
@@ -133,6 +133,9 @@ export {
   usePreventistaZonasQuery,
   useCrearZonaMutation,
   useAsignarZonasPrevMutation,
+  useRenombrarZonaMutation,
+  useEliminarZonaMutation,
+  useToggleZonaActivaMutation,
 } from './useZonasQuery'
 export type { ZonaDB } from './useZonasQuery'
 

--- a/src/hooks/queries/useClientesQuery.ts
+++ b/src/hooks/queries/useClientesQuery.ts
@@ -105,8 +105,10 @@ interface ClienteCreateInput {
   direccion: string
   telefono?: string
   cuit?: string
-  /** @deprecated usar zona_id (FK a tabla zonas). Se mantiene un release. */
-  zona?: string
+  /** @deprecated usar zona_id (FK a tabla zonas). Se mantiene un release.
+   *  Acepta null para que el container pueda limpiar el espejo legacy cuando
+   *  el usuario selecciona "(Sin zona)". */
+  zona?: string | null
   zona_id?: string | null
   latitud?: number | null
   longitud?: number | null

--- a/src/hooks/queries/useClientesQuery.ts
+++ b/src/hooks/queries/useClientesQuery.ts
@@ -190,9 +190,17 @@ async function createCliente(cliente: ClienteCreateInput, sucursalId: number | n
 async function updateCliente({ id, data: cliente }: { id: string; data: Partial<ClienteCreateInput> }): Promise<ClienteDB> {
   const { preventista_ids, ...clienteFields } = cliente
 
+  // Coerce '' → null para zona_id (FK column). PostgREST rechaza '' en columnas FK.
+  // Solo aplicamos si el campo viene en el patch (Partial), preservando undefined
+  // para no sobrescribir campos no enviados.
+  const payload: Partial<ClienteCreateInput> = { ...clienteFields }
+  if ('zona_id' in payload) {
+    payload.zona_id = payload.zona_id ? payload.zona_id : null
+  }
+
   const { data, error } = await supabase
     .from('clientes')
-    .update(clienteFields)
+    .update(payload)
     .eq('id', id)
     .select()
     .single()

--- a/src/hooks/queries/useClientesQuery.ts
+++ b/src/hooks/queries/useClientesQuery.ts
@@ -105,7 +105,9 @@ interface ClienteCreateInput {
   direccion: string
   telefono?: string
   cuit?: string
+  /** @deprecated usar zona_id (FK a tabla zonas). Se mantiene un release. */
   zona?: string
+  zona_id?: string | null
   latitud?: number | null
   longitud?: number | null
   limite_credito?: number
@@ -156,7 +158,10 @@ async function createCliente(cliente: ClienteCreateInput, sucursalId: number | n
       direccion: clienteFields.direccion,
       telefono: clienteFields.telefono || null,
       cuit: clienteFields.cuit || null,
+      // zona (texto) deprecada: se sigue escribiendo un release por compat de lecturas legacy.
       zona: clienteFields.zona || null,
+      // zona_id es la FK canónica. '' (string vacío) y undefined → null para limpiar la FK.
+      zona_id: clienteFields.zona_id ? clienteFields.zona_id : null,
       latitud: clienteFields.latitud || null,
       longitud: clienteFields.longitud || null,
       limite_credito: clienteFields.limite_credito || 0,

--- a/src/hooks/queries/usePedidosQuery.ts
+++ b/src/hooks/queries/usePedidosQuery.ts
@@ -71,7 +71,7 @@ interface ActualizarPagoInput {
 // Se usan template literals con `as const` para que `.select()` conserve la
 // inferencia de PostgREST: un string sin literal-type degradaria el resultado
 // a GenericStringError. Mantener sincronizado con el tipo PedidoDB.
-const PEDIDO_PRODUCT_COLS = 'id, nombre, codigo, categoria' as const
+const PEDIDO_PRODUCT_COLS = 'id, nombre, codigo, categoria, unidades_de_venta_por_fardo, etiqueta_bulto' as const
 const PEDIDO_CLIENT_COLS = 'id, nombre_fantasia, razon_social, cuit, direccion, telefono, contacto, latitud, longitud, horarios_atencion, zona' as const
 const PEDIDO_SELECT = `*, cliente:clientes(${PEDIDO_CLIENT_COLS}), items:pedido_items(*, producto:productos(${PEDIDO_PRODUCT_COLS}), promocion:promociones(unidades_por_bloque))` as const
 const PEDIDO_SELECT_CLIENTE_INNER = `*, cliente:clientes!inner(${PEDIDO_CLIENT_COLS}), items:pedido_items(*, producto:productos(${PEDIDO_PRODUCT_COLS}), promocion:promociones(unidades_por_bloque))` as const

--- a/src/hooks/queries/useProductosQuery.ts
+++ b/src/hooks/queries/useProductosQuery.ts
@@ -85,6 +85,9 @@ async function createProducto(producto: ProductoFormInput, sucursalId: number | 
       costo_con_iva: producto.costo_con_iva ? parseFloat(String(producto.costo_con_iva)) : null,
       impuestos_internos: producto.impuestos_internos ? parseFloat(String(producto.impuestos_internos)) : null,
       precio_sin_iva: producto.precio_sin_iva ? parseFloat(String(producto.precio_sin_iva)) : null,
+      // Bulto/fardo (migración 031): 0 es válido, sólo usamos null cuando viene undefined
+      unidades_de_venta_por_fardo: producto.unidades_de_venta_por_fardo == null ? null : producto.unidades_de_venta_por_fardo,
+      etiqueta_bulto: producto.etiqueta_bulto || null,
       sucursal_id: sucursalId
     }])
     .select()
@@ -107,6 +110,13 @@ async function updateProducto({ id, data: producto }: { id: string; data: Partia
   if (producto.costo_con_iva !== undefined) updateData.costo_con_iva = producto.costo_con_iva ? parseFloat(String(producto.costo_con_iva)) : null
   if (producto.impuestos_internos !== undefined) updateData.impuestos_internos = producto.impuestos_internos ? parseFloat(String(producto.impuestos_internos)) : null
   if (producto.precio_sin_iva !== undefined) updateData.precio_sin_iva = producto.precio_sin_iva ? parseFloat(String(producto.precio_sin_iva)) : null
+  // Bulto/fardo (migración 031): tratá undefined como "no tocar", null como "limpiar"
+  if (producto.unidades_de_venta_por_fardo !== undefined) {
+    updateData.unidades_de_venta_por_fardo = producto.unidades_de_venta_por_fardo
+  }
+  if (producto.etiqueta_bulto !== undefined) {
+    updateData.etiqueta_bulto = producto.etiqueta_bulto || null
+  }
 
   const { data, error } = await supabase
     .from('productos')

--- a/src/hooks/queries/useZonasQuery.ts
+++ b/src/hooks/queries/useZonasQuery.ts
@@ -40,13 +40,14 @@ async function fetchPreventistaZonas(perfilId: string): Promise<string[]> {
   return (data || []).map(d => String(d.zona_id))
 }
 
-async function crearZona(nombre: string): Promise<ZonaDB> {
+async function crearZona(nombre: string, sucursalId: number): Promise<ZonaDB> {
   const trimmed = nombre.trim()
   if (!trimmed) throw new Error('El nombre de la zona es requerido')
+  if (!sucursalId) throw new Error('Se requiere sucursal para crear la zona')
 
   const { data, error } = await supabase
     .from('zonas')
-    .insert({ nombre: trimmed })
+    .insert({ nombre: trimmed, sucursal_id: sucursalId })
     .select()
     .single()
 
@@ -134,7 +135,12 @@ export function useCrearZonaMutation() {
   const queryClient = useQueryClient()
   const { currentSucursalId } = useSucursal()
   return useMutation({
-    mutationFn: crearZona,
+    mutationFn: (nombre: string) => {
+      if (!currentSucursalId) {
+        return Promise.reject(new Error('No hay sucursal activa'))
+      }
+      return crearZona(nombre, currentSucursalId)
+    },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: zonasKeys.all(currentSucursalId) })
     },

--- a/src/hooks/queries/useZonasQuery.ts
+++ b/src/hooks/queries/useZonasQuery.ts
@@ -22,15 +22,12 @@ export const zonasKeys = {
 }
 
 // Fetch functions
-async function fetchZonas(): Promise<ZonaDB[]> {
-  const { data, error } = await supabase
-    .from('zonas')
-    .select('*')
-    .eq('activo', true)
-    .order('nombre')
-
-  if (error) throw error
-  return (data as ZonaDB[]) || []
+async function fetchZonas(includeInactive = false): Promise<ZonaDB[]> {
+  let q = supabase.from('zonas').select('*').order('nombre');
+  if (!includeInactive) q = q.eq('activo', true);
+  const { data, error } = await q;
+  if (error) throw error;
+  return (data as ZonaDB[]) || [];
 }
 
 async function fetchPreventistaZonas(perfilId: string): Promise<string[]> {
@@ -82,13 +79,43 @@ async function asignarZonasPreventista(perfilId: string, zonaIds: string[]): Pro
   }
 }
 
+async function renombrarZona(id: string, nombre: string): Promise<void> {
+  const trimmed = nombre.trim();
+  if (!trimmed) throw new Error('El nombre de la zona es requerido');
+  const { error } = await supabase.from('zonas').update({ nombre: trimmed }).eq('id', id);
+  if (error) {
+    if (error.code === '23505') throw new Error(`La zona "${trimmed}" ya existe`);
+    throw error;
+  }
+}
+
+async function eliminarZona(id: string): Promise<void> {
+  // Validar que no haya clientes asignados
+  const { count, error: countError } = await supabase
+    .from('clientes')
+    .select('id', { count: 'exact', head: true })
+    .eq('zona_id', id);
+  if (countError) throw countError;
+  if ((count ?? 0) > 0) {
+    throw new Error(`No se puede eliminar: hay ${count} cliente(s) asignados a esta zona. Reasignalos primero.`);
+  }
+  const { error } = await supabase.from('zonas').delete().eq('id', id);
+  if (error) throw error;
+}
+
+async function toggleZonaActiva(id: string, activo: boolean): Promise<void> {
+  const { error } = await supabase.from('zonas').update({ activo }).eq('id', id);
+  if (error) throw error;
+}
+
 // Hooks
 
-export function useZonasEstandarizadasQuery() {
+export function useZonasEstandarizadasQuery(opts?: { includeInactive?: boolean }) {
   const { currentSucursalId } = useSucursal()
+  const includeInactive = opts?.includeInactive ?? false;
   return useQuery({
-    queryKey: zonasKeys.lists(currentSucursalId),
-    queryFn: fetchZonas,
+    queryKey: [...zonasKeys.lists(currentSucursalId), includeInactive],
+    queryFn: () => fetchZonas(includeInactive),
     staleTime: 10 * 60 * 1000,
   })
 }
@@ -122,6 +149,39 @@ export function useAsignarZonasPrevMutation() {
       asignarZonasPreventista(perfilId, zonaIds),
     onSuccess: (_data, variables) => {
       queryClient.invalidateQueries({ queryKey: zonasKeys.preventista(currentSucursalId, variables.perfilId) })
+    },
+  })
+}
+
+export function useRenombrarZonaMutation() {
+  const queryClient = useQueryClient()
+  const { currentSucursalId } = useSucursal()
+  return useMutation({
+    mutationFn: ({ id, nombre }: { id: string; nombre: string }) => renombrarZona(id, nombre),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: zonasKeys.all(currentSucursalId) })
+    },
+  })
+}
+
+export function useEliminarZonaMutation() {
+  const queryClient = useQueryClient()
+  const { currentSucursalId } = useSucursal()
+  return useMutation({
+    mutationFn: eliminarZona,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: zonasKeys.all(currentSucursalId) })
+    },
+  })
+}
+
+export function useToggleZonaActivaMutation() {
+  const queryClient = useQueryClient()
+  const { currentSucursalId } = useSucursal()
+  return useMutation({
+    mutationFn: ({ id, activo }: { id: string; activo: boolean }) => toggleZonaActiva(id, activo),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: zonasKeys.all(currentSucursalId) })
     },
   })
 }

--- a/src/hooks/queries/useZonasQuery.ts
+++ b/src/hooks/queries/useZonasQuery.ts
@@ -91,17 +91,28 @@ async function renombrarZona(id: string, nombre: string): Promise<void> {
 }
 
 async function eliminarZona(id: string): Promise<void> {
-  // Validar que no haya clientes asignados
-  const { count, error: countError } = await supabase
-    .from('clientes')
-    .select('id', { count: 'exact', head: true })
-    .eq('zona_id', id);
-  if (countError) throw countError;
-  if ((count ?? 0) > 0) {
-    throw new Error(`No se puede eliminar: hay ${count} cliente(s) asignados a esta zona. Reasignalos primero.`);
-  }
+  // Best-effort UX hint: count related rows for a friendlier message if delete fails.
+  // The DB is the source of truth — clientes_fk and proveedores_fk are both RESTRICT.
   const { error } = await supabase.from('zonas').delete().eq('id', id);
-  if (error) throw error;
+  if (error) {
+    if (error.code === '23503') {
+      // Try to enrich the message with a count (best effort, ignore if it fails)
+      const { count: nClientes } = await supabase
+        .from('clientes')
+        .select('id', { count: 'exact', head: true })
+        .eq('zona_id', id);
+      const { count: nProveedores } = await supabase
+        .from('proveedores')
+        .select('id', { count: 'exact', head: true })
+        .eq('zona_id', id);
+      const partes: string[] = [];
+      if (nClientes && nClientes > 0) partes.push(`${nClientes} cliente${nClientes === 1 ? '' : 's'}`);
+      if (nProveedores && nProveedores > 0) partes.push(`${nProveedores} proveedor${nProveedores === 1 ? '' : 'es'}`);
+      const ref = partes.length > 0 ? partes.join(' y ') : 'registros';
+      throw new Error(`No se puede eliminar: hay ${ref} asignados a esta zona. Reasignalos primero.`);
+    }
+    throw error;
+  }
 }
 
 async function toggleZonaActiva(id: string, activo: boolean): Promise<void> {
@@ -187,6 +198,10 @@ export function useToggleZonaActivaMutation() {
   return useMutation({
     mutationFn: ({ id, activo }: { id: string; activo: boolean }) => toggleZonaActiva(id, activo),
     onSuccess: () => {
+      // zonasKeys.all is the prefix that includes both `lists(*, includeInactive)` and
+      // `preventista(*)` keys — TanStack prefix-match clears all variants in one call.
+      // CASCADE on preventista_zonas means deleted zonas already have their assignments
+      // wiped DB-side; toggling activo just hides them from selectors.
       queryClient.invalidateQueries({ queryKey: zonasKeys.all(currentSucursalId) })
     },
   })

--- a/src/hooks/supabase/useProductos.ts
+++ b/src/hooks/supabase/useProductos.ts
@@ -83,7 +83,10 @@ export function useProductos(): UseProductosReturn {
       costo_sin_iva: producto.costo_sin_iva ? parseFloat(String(producto.costo_sin_iva)) : null,
       costo_con_iva: producto.costo_con_iva ? parseFloat(String(producto.costo_con_iva)) : null,
       impuestos_internos: producto.impuestos_internos ? parseFloat(String(producto.impuestos_internos)) : null,
-      precio_sin_iva: producto.precio_sin_iva ? parseFloat(String(producto.precio_sin_iva)) : null
+      precio_sin_iva: producto.precio_sin_iva ? parseFloat(String(producto.precio_sin_iva)) : null,
+      // Bulto/fardo (migración 031)
+      unidades_de_venta_por_fardo: producto.unidades_de_venta_por_fardo == null ? null : producto.unidades_de_venta_por_fardo,
+      etiqueta_bulto: producto.etiqueta_bulto || null
     }]).select().single()
     if (error) throw error
     const newProducto = data as ProductoDB
@@ -103,6 +106,13 @@ export function useProductos(): UseProductosReturn {
     if (producto.costo_con_iva !== undefined) updateData.costo_con_iva = producto.costo_con_iva ? parseFloat(String(producto.costo_con_iva)) : null
     if (producto.impuestos_internos !== undefined) updateData.impuestos_internos = producto.impuestos_internos ? parseFloat(String(producto.impuestos_internos)) : null
     if (producto.precio_sin_iva !== undefined) updateData.precio_sin_iva = producto.precio_sin_iva ? parseFloat(String(producto.precio_sin_iva)) : null
+    // Bulto/fardo (migración 031)
+    if (producto.unidades_de_venta_por_fardo !== undefined) {
+      updateData.unidades_de_venta_por_fardo = producto.unidades_de_venta_por_fardo
+    }
+    if (producto.etiqueta_bulto !== undefined) {
+      updateData.etiqueta_bulto = producto.etiqueta_bulto || null
+    }
 
     const { data, error } = await supabase.from('productos').update(updateData).eq('id', id).select().single()
     if (error) throw error

--- a/src/lib/pdf/hojaRutaOptimizada.js
+++ b/src/lib/pdf/hojaRutaOptimizada.js
@@ -10,6 +10,7 @@ import {
   generateFilename,
   drawCheckbox
 } from './utils'
+import { formatAclaracionBulto } from './utils/formatBulto'
 
 // === Layout A4 horizontal ===
 const PAGE_WIDTH = 297
@@ -155,7 +156,15 @@ function buildCardOps(doc, pedido, orderNumber) {
       ? item.descripcion_regalo.trim()
       : (item.producto?.nombre || 'Producto')
     const subtotal = (item.precio_unitario || 0) * item.cantidad
-    const itemLines = doc.splitTextToSize(`${item.cantidad}x ${nombre}`, productWrapWidth)
+    const aclaracion = formatAclaracionBulto(
+      item.cantidad,
+      item.producto?.unidades_de_venta_por_fardo,
+      item.producto?.etiqueta_bulto,
+    )
+    const linea = aclaracion
+      ? `${item.cantidad}x ${nombre} ${aclaracion}`
+      : `${item.cantidad}x ${nombre}`
+    const itemLines = doc.splitTextToSize(linea, productWrapWidth)
     itemLines.forEach((line, idx) => {
       ops.push({
         kind: 'product',
@@ -307,6 +316,10 @@ function buildManifiestoOps(pedidos) {
         if (fardos > 0) {
           if (!totalesFardos[key]) totalesFardos[key] = { nombre: nombreProducto, cantidad: 0 }
           totalesFardos[key].cantidad += fardos
+          // La cantidad acumulada para esta key ya no está en unidades de venta
+          // (mezcla fardos enteros pre-convertidos), así que no aplicar la
+          // aclaración (N FARDO) sobre el total consolidado para esta key.
+          totalesFardos[key].mixedFardo = true
         }
         if (sueltas > 0) {
           const sueltasKey = `bonif:${desc}`
@@ -319,6 +332,16 @@ function buildManifiestoOps(pedidos) {
       // Caso B: items normales (compras o regalos de unidad entera) → suma directa.
       if (!totalesFardos[key]) totalesFardos[key] = { nombre: nombreProducto, cantidad: 0 }
       totalesFardos[key].cantidad += cantidad
+      // Capturar campos de fardo del producto para mostrar la aclaración
+      // (N FARDO) sobre la cantidad consolidada. Solo aplican a Caso B; si la
+      // entrada también recibió Caso A, mixedFardo bloquea la aclaración.
+      if (totalesFardos[key].unidades_de_venta_por_fardo == null) {
+        totalesFardos[key].unidades_de_venta_por_fardo =
+          item.producto?.unidades_de_venta_por_fardo ?? null
+      }
+      if (totalesFardos[key].etiqueta_bulto == null) {
+        totalesFardos[key].etiqueta_bulto = item.producto?.etiqueta_bulto ?? null
+      }
     })
   })
 
@@ -338,10 +361,17 @@ function buildManifiestoOps(pedidos) {
     advance: 5
   })
   filasFardos.forEach((f) => {
+    const aclaracion = f.mixedFardo
+      ? null
+      : formatAclaracionBulto(
+          f.cantidad,
+          f.unidades_de_venta_por_fardo,
+          f.etiqueta_bulto,
+        )
     ops.push({
       kind: 'manifiesto-line',
       cantidad: `${f.cantidad}x`,
-      nombre: f.nombre,
+      nombre: aclaracion ? `${f.nombre} ${aclaracion}` : f.nombre,
       advance: 4.5
     })
   })

--- a/src/lib/pdf/reciboPedido.js
+++ b/src/lib/pdf/reciboPedido.js
@@ -17,6 +17,7 @@ import {
   setNormalStyle,
   setItalicStyle
 } from './utils'
+import { formatAclaracionBulto } from './utils/formatBulto'
 
 // Colores de marca Crecer Distribuciones
 const BRAND = {
@@ -167,7 +168,15 @@ function generarReciboA4(pedido) {
 
     // Nombre completo del producto (sin truncar, con wrap si necesario)
     const productoNombre = item.producto?.nombre || 'Producto'
-    const nombreLines = doc.splitTextToSize(productoNombre, 90)
+    const aclaracion = formatAclaracionBulto(
+      item.cantidad,
+      item.producto?.unidades_de_venta_por_fardo,
+      item.producto?.etiqueta_bulto,
+    )
+    const nombreCompleto = aclaracion
+      ? `${productoNombre} ${aclaracion}`
+      : productoNombre
+    const nombreLines = doc.splitTextToSize(nombreCompleto, 90)
     doc.text(nombreLines[0], margin + 5, y)
 
     doc.text(String(item.cantidad), margin + 105, y, { align: 'center' })
@@ -383,7 +392,16 @@ function dibujarComanda(doc, pedido) {
     const productoNombre = item.producto?.nombre || 'Producto'
     const subtotal = item.subtotal || item.precio_unitario * item.cantidad
 
-    const nombreLines = doc.splitTextToSize(`${item.cantidad}x ${productoNombre}`, contentWidth - 26)
+    const aclaracion = formatAclaracionBulto(
+      item.cantidad,
+      item.producto?.unidades_de_venta_por_fardo,
+      item.producto?.etiqueta_bulto,
+    )
+    const lineaProducto = aclaracion
+      ? `${item.cantidad}x ${productoNombre} ${aclaracion}`
+      : `${item.cantidad}x ${productoNombre}`
+
+    const nombreLines = doc.splitTextToSize(lineaProducto, contentWidth - 26)
     nombreLines.forEach((line, idx) => {
       doc.text(line, margin, y)
       if (idx === 0) {

--- a/src/lib/pdf/utils/formatBulto.test.ts
+++ b/src/lib/pdf/utils/formatBulto.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest';
+import { formatAclaracionBulto } from './formatBulto';
+
+describe('formatAclaracionBulto', () => {
+  it('returns null when unidadesPorFardo is missing', () => {
+    expect(formatAclaracionBulto(2, undefined, 'FARDO')).toBeNull();
+    expect(formatAclaracionBulto(2, null, 'FARDO')).toBeNull();
+    expect(formatAclaracionBulto(2, 0, 'FARDO')).toBeNull();
+  });
+
+  it('returns null when cantidad is 0 or invalid', () => {
+    expect(formatAclaracionBulto(0, 2, 'FARDO')).toBeNull();
+    expect(formatAclaracionBulto(NaN, 2, 'FARDO')).toBeNull();
+  });
+
+  it('returns "(MEDIO FARDO)" when cantidad/upf === 0.5', () => {
+    expect(formatAclaracionBulto(1, 2, 'FARDO')).toBe('(MEDIO FARDO)');
+    expect(formatAclaracionBulto(2, 4, 'FARDO')).toBe('(MEDIO FARDO)');
+  });
+
+  it('returns "(1 FARDO)" when cantidad/upf === 1', () => {
+    expect(formatAclaracionBulto(2, 2, 'FARDO')).toBe('(1 FARDO)');
+    expect(formatAclaracionBulto(5, 5, 'FARDO')).toBe('(1 FARDO)');
+  });
+
+  it('returns "(1 FARDO Y MEDIO)" when cantidad/upf === 1.5', () => {
+    expect(formatAclaracionBulto(3, 2, 'FARDO')).toBe('(1 FARDO Y MEDIO)');
+  });
+
+  it('returns "(N FARDOS)" plural for integer multiples >= 2', () => {
+    expect(formatAclaracionBulto(4, 2, 'FARDO')).toBe('(2 FARDOS)');
+    expect(formatAclaracionBulto(6, 2, 'FARDO')).toBe('(3 FARDOS)');
+    expect(formatAclaracionBulto(20, 2, 'FARDO')).toBe('(10 FARDOS)');
+  });
+
+  it('returns null for ambiguous fractions (not 0.5 / integer / 1.5)', () => {
+    expect(formatAclaracionBulto(1, 3, 'FARDO')).toBeNull();   // 0.33
+    expect(formatAclaracionBulto(2, 3, 'FARDO')).toBeNull();   // 0.66
+    expect(formatAclaracionBulto(5, 2, 'FARDO')).toBe('(2 FARDOS Y MEDIO)'); // 2.5 → soportar
+  });
+
+  it('uses custom etiqueta when provided', () => {
+    expect(formatAclaracionBulto(2, 2, 'CAJA')).toBe('(1 CAJA)');
+    expect(formatAclaracionBulto(4, 2, 'CAJA')).toBe('(2 CAJAS)');
+    expect(formatAclaracionBulto(1, 2, 'CAJA')).toBe('(MEDIA CAJA)');
+  });
+
+  it('falls back to FARDO when etiqueta is empty/null', () => {
+    expect(formatAclaracionBulto(2, 2, undefined)).toBe('(1 FARDO)');
+    expect(formatAclaracionBulto(2, 2, '')).toBe('(1 FARDO)');
+  });
+});

--- a/src/lib/pdf/utils/formatBulto.ts
+++ b/src/lib/pdf/utils/formatBulto.ts
@@ -1,0 +1,42 @@
+/**
+ * Devuelve una aclaración entre paréntesis indicando cuántos fardos representa
+ * la cantidad vendida, basado en `unidadesPorFardo` configurado en el producto.
+ *
+ * Reglas:
+ * - 0.5 fardo → "(MEDIO FARDO)" / "(MEDIA CAJA)" (femenino para CAJA)
+ * - N entero → "(N FARDO)" o "(N FARDOS)" (plural si N>=2)
+ * - N.5 con N>=1 → "(N FARDO Y MEDIO)" o "(N FARDOS Y MEDIO)"
+ * - Fracciones distintas (1/3, 2/3, etc.) → null
+ * - cantidad o unidadesPorFardo inválidos/0 → null
+ */
+export function formatAclaracionBulto(
+  cantidad: number,
+  unidadesPorFardo: number | null | undefined,
+  etiqueta: string | null | undefined,
+): string | null {
+  if (!cantidad || !Number.isFinite(cantidad) || cantidad <= 0) return null;
+  if (!unidadesPorFardo || !Number.isFinite(unidadesPorFardo) || unidadesPorFardo <= 0) return null;
+
+  const ratio = cantidad / unidadesPorFardo;
+  const label = (etiqueta && etiqueta.trim()) ? etiqueta.trim().toUpperCase() : 'FARDO';
+
+  // Heurística de género: termina en 'A' → femenino (CAJA → MEDIA, FARDO → MEDIO)
+  const isFem = label.endsWith('A');
+  const medio = isFem ? 'MEDIA' : 'MEDIO';
+  const labelPlural = `${label}S`;
+
+  if (ratio === 0.5) return `(${medio} ${label})`;
+
+  if (Number.isInteger(ratio)) {
+    return ratio === 1 ? `(1 ${label})` : `(${ratio} ${labelPlural})`;
+  }
+
+  const entero = Math.floor(ratio);
+  const fraccion = ratio - entero;
+  if (fraccion === 0.5 && entero >= 1) {
+    const palabra = entero === 1 ? label : labelPlural;
+    return `(${entero} ${palabra} Y MEDIO)`;
+  }
+
+  return null;
+}

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -606,7 +606,23 @@ export const modalProductoSchema = z.object({
 
   precio: z.coerce
     .number({ error: 'El precio debe ser un número' })
-    .positive({ message: 'El precio debe ser mayor a 0' })
+    .positive({ message: 'El precio debe ser mayor a 0' }),
+
+  // Cuántas unidades de venta hacen 1 fardo/bulto.
+  // Ej: si vendés "medio fardo" como 1 unidad, acá poné 2.
+  // Permite decimales (0.5) por si alguien vende "doble fardo" como 1 unidad.
+  unidades_de_venta_por_fardo: z.coerce
+    .number({ error: 'Debe ser un número' })
+    .nonnegative({ message: 'No puede ser negativo' })
+    .optional(),
+
+  // Etiqueta del bulto: FARDO, CAJA, PACK, BULTO...
+  // Default a 'FARDO' en el form; si queda vacío se persiste como null.
+  etiqueta_bulto: z
+    .string()
+    .trim()
+    .max(20, { message: 'Máximo 20 caracteres' })
+    .optional()
 })
 
 /** Inferred type for ModalProducto schema */

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -560,7 +560,9 @@ export const modalClienteSchema = z.object({
     .nullable()
     .optional(),
   contacto: z.string().optional(),
+  /** @deprecated usar zona_id. Se mantiene para compat. */
   zona: z.string().optional(),
+  zona_id: z.string().optional().nullable(),
   horarios_atencion: z.string().optional(),
   rubro: z.string().optional(),
   notas: z.string().optional(),

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -613,7 +613,7 @@ export const modalProductoSchema = z.object({
   // Permite decimales (0.5) por si alguien vende "doble fardo" como 1 unidad.
   unidades_de_venta_por_fardo: z.coerce
     .number({ error: 'Debe ser un número' })
-    .nonnegative({ message: 'No puede ser negativo' })
+    .positive({ message: 'Debe ser mayor a 0' })
     .optional(),
 
   // Etiqueta del bulto: FARDO, CAJA, PACK, BULTO...
@@ -623,7 +623,10 @@ export const modalProductoSchema = z.object({
     .trim()
     .max(20, { message: 'Máximo 20 caracteres' })
     .optional()
-})
+}).refine(
+  d => !d.etiqueta_bulto || d.unidades_de_venta_por_fardo,
+  { message: 'Si configurás una etiqueta de bulto, también poné las unidades por fardo', path: ['unidades_de_venta_por_fardo'] }
+)
 
 /** Inferred type for ModalProducto schema */
 export type ModalProductoFormData = z.infer<typeof modalProductoSchema>

--- a/src/services/api/pedidoService.ts
+++ b/src/services/api/pedidoService.ts
@@ -77,7 +77,7 @@ class PedidoService extends BaseService<Pedido> {
           cantidad,
           precio_unitario,
           subtotal,
-          producto:productos(id, nombre, codigo)
+          producto:productos(id, nombre, codigo, unidades_de_venta_por_fardo, etiqueta_bulto)
         )
       `
     })

--- a/src/types/hooks.ts
+++ b/src/types/hooks.ts
@@ -56,6 +56,8 @@ export interface ProductoDB {
   activo?: boolean;
   created_at?: string;
   updated_at?: string;
+  unidades_de_venta_por_fardo?: number | null;
+  etiqueta_bulto?: string | null;
 }
 
 export interface PedidoItemDB {

--- a/src/types/hooks.ts
+++ b/src/types/hooks.ts
@@ -20,7 +20,9 @@ export interface ClienteDB {
   telefono?: string | null;
   email?: string | null;
   contacto?: string | null;
+  /** @deprecated usar zona_id (FK a tabla zonas). Se mantiene un release para rollback. */
   zona?: string | null;
+  zona_id?: string | null;
   horarios_atencion?: string | null;
   rubro?: string | null;
   notas?: string | null;
@@ -208,7 +210,9 @@ export interface ClienteFormInput {
   telefono?: string;
   email?: string;
   contacto?: string;
+  /** @deprecated usar zona_id (FK a tabla zonas). Se mantiene un release para rollback. */
   zona?: string;
+  zona_id?: string | null;
   horarios_atencion?: string;
   rubro?: string;
   notas?: string;

--- a/src/types/hooks.ts
+++ b/src/types/hooks.ts
@@ -230,6 +230,8 @@ export interface ProductoFormInput {
   costo_con_iva?: number | string;
   impuestos_internos?: number | string;
   precio_sin_iva?: number | string;
+  unidades_de_venta_por_fardo?: number | null;
+  etiqueta_bulto?: string | null;
 }
 
 export interface PedidoFormInput {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -25,7 +25,9 @@ export interface Cliente extends BaseEntity {
   direccion?: string;
   telefono?: string;
   email?: string;
+  /** @deprecated usar zona_id (FK a tabla zonas). Se mantiene un release para rollback. */
   zona?: string;
+  zona_id?: string;
   tipo?: 'minorista' | 'mayorista' | 'distribuidor';
   activo: boolean;
   saldo_pendiente?: number;
@@ -39,7 +41,9 @@ export interface ClienteInput {
   direccion?: string;
   telefono?: string;
   email?: string;
+  /** @deprecated usar zona_id (FK a tabla zonas). Se mantiene un release para rollback. */
   zona?: string;
+  zona_id?: string;
   tipo?: 'minorista' | 'mayorista' | 'distribuidor';
   notas?: string;
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -59,6 +59,8 @@ export interface Producto extends BaseEntity {
   categoria_id?: string;
   activo: boolean;
   unidad?: string;
+  unidades_de_venta_por_fardo?: number;
+  etiqueta_bulto?: string;
 }
 
 export interface ProductoInput {
@@ -71,6 +73,8 @@ export interface ProductoInput {
   stock_minimo?: number;
   categoria_id?: string;
   unidad?: string;
+  unidades_de_venta_por_fardo?: number;
+  etiqueta_bulto?: string;
 }
 
 export interface Categoria extends BaseEntity {


### PR DESCRIPTION
## Summary

Tres mejoras independientes pedidas por usuarios:

**Mejora 1 — Aclaración (N FARDO) en recibos y hojas de ruta**
Productos pueden configurar `unidades_de_venta_por_fardo` + `etiqueta_bulto`. Al imprimir recibos (comanda + A4), tarjetas de hoja-de-ruta y manifiesto consolidado, se agrega automáticamente `(1 FARDO)` / `(MEDIO FARDO)` / `(1 FARDO Y MEDIO)` / `(N FARDOS)` cuando la cantidad vendida coincide con un múltiplo. Helper puro `formatAclaracionBulto` (TDD, 9 tests) — devuelve `null` para fracciones ambiguas o productos sin config (backwards-compatible).

**Mejora 2 — Zonas como entidad gestionada en Clientes**
- Migración 032: `UNIQUE(nombre)` global → `UNIQUE(nombre, sucursal_id)` (modelo multi-sucursal correcto), policy DELETE faltante en RLS, backfill de los 7 clientes restantes con `zona_id` (ahora 268/268).
- Hooks CRUD admin (`useRenombrarZonaMutation`, `useEliminarZonaMutation`, `useToggleZonaActivaMutation`) + opción `includeInactive`. `eliminarZona` es FK-driven y mapea 23503 a mensaje amigable con conteo de clientes y proveedores afectados.
- `ModalZonas.tsx` (admin-only): CRUD completo, espejo simplificado de `ModalCategorias`.
- `ModalCliente.tsx`: input de texto reemplazado por `<select>` poblado con FK-backed zonas; muestra inactivas con sufijo `(inactiva)` para no perder asignaciones silenciosamente.
- `ClientesContainer`: botón \"Gestionar Zonas\" admin-only + 2 filtros (zona, estado de cuenta deben/no_deben) con AND lógico sobre los filtros existentes.
- Dual-write: `clientes.zona_id` (canonical) se mirrorea a `clientes.zona` (texto, deprecated) en cada save para que legacy read paths (PDFs, reportes, bot Telegram) sigan funcionando durante el deprecation window.
- Fix bug pre-existente: `crearZona` no pasaba `sucursal_id` (NOT NULL).

**Mejora 3 — Home = Pedidos para todos los roles**
Una línea en `App.tsx:205`: ahora todos los roles abren en \`/pedidos\` (operativo) en lugar del Dashboard. El Dashboard sigue accesible desde el menú.

## Migrations

Aplicadas en main (\`hmuchlzmuqqxcldbzkgc\`) — Free plan no soporta branches:
- \`031_producto_unidades_por_fardo.sql\` — 2 columnas opcionales, IF NOT EXISTS guarded.
- \`032_migrar_clientes_zona_a_zona_id.sql\` — idempotente (DROP IF EXISTS, WHERE NOT EXISTS, WHERE zona_id IS NULL).

## Test Plan

### Mejora 1 (fardo)
- [ ] Editar producto \"SAL FINA X 500 GRS X 10 UDS\" → setear \`unidades_de_venta_por_fardo=2\`, \`etiqueta_bulto='FARDO'\` → guardar.
- [ ] Crear pedido con 1 ud → recibo PDF debe mostrar \`1x SAL FINA ... (MEDIO FARDO)\`.
- [ ] Editar pedido a 2/3/4 uds → \`(1 FARDO)\` / \`(1 FARDO Y MEDIO)\` / \`(2 FARDOS)\`.
- [ ] Producto sin config → recibo no muestra paréntesis (backwards compat).
- [ ] Imprimir hoja de ruta con varios pedidos → tarjetas + manifiesto consolidado muestran aclaración.

### Mejora 2 (zonas)
- [ ] Como admin: panel clientes → click \"Gestionar Zonas\" → crear, renombrar, desactivar, eliminar (con confirm dialog).
- [ ] Como preventista: el botón \"Gestionar Zonas\" NO se ve.
- [ ] Editar cliente: el select muestra zonas activas + las inactivas con sufijo \"(inactiva)\".
- [ ] Filtro \"Zona Norte\" → solo aparecen los clientes de esa zona.
- [ ] Filtro \"Deben\" → solo \`saldo_cuenta > 0\`.
- [ ] Como preventista: sigue viendo todos los clientes de su sucursal (no se rompió RLS).
- [ ] Bot Telegram (\`mis_clientes\`, \`buscar_cliente\`): muestra zona texto correctamente para clientes nuevos creados desde el form.

### Mejora 3 (home)
- [ ] Login como admin → abre en \`/pedidos\` (no \`/dashboard\`).
- [ ] Login como preventista, encargado, transportista, depósito → todos abren en \`/pedidos\`.
- [ ] Click \"Dashboard\" en el menú → entra a \`/dashboard\` sin redirect loop.
- [ ] F5 estando en \`/clientes\` → permanece en \`/clientes\`.

### Verificación automática (ya green)
- [x] \`npm run typecheck\`
- [x] \`npm run lint\`
- [x] \`npm run test:run\` (594/594)
- [x] \`npm run build\`

## Notas

- 19 commits, rebased sobre main (incluye DRY refactor de PR #282 — \`PEDIDO_PRODUCT_COLS\` extendido con los nuevos campos).
- Plan de implementación detallado: \`docs/plans/2026-05-05-mejoras-fardo-zonas-home.md\`.
- Documento de diseño previo: \`~/.claude/plans/te-paso-las-siguientes-purring-tiger.md\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)