### PR TITLE
feat(pedidos): edición preventista hasta 17:00 + modal de pago independiente

### DIFF
--- a/migrations/033_actualizar_pedido_items_preventista_ventana.sql
+++ b/migrations/033_actualizar_pedido_items_preventista_ventana.sql
@@ -1,0 +1,294 @@
+-- ============================================================================
+-- 033 — actualizar_pedido_items: ventana de edicion para preventistas
+-- ============================================================================
+-- Cambios respecto a la version anterior:
+--   1) Incluir 'encargado' en los roles autorizados (estaba ausente y ya
+--      tenia UI; era inconsistente).
+--   2) Cuando el rol es 'preventista': validar que sea el creador del pedido,
+--      que el pedido haya sido creado el mismo dia ARG y que la hora ARG sea
+--      < 17:00. Tambien rechazar cambios de precio: para items no-bonificacion
+--      el precio_unitario enviado debe coincidir con productos.precio actual
+--      (que ya es lo que el frontend lee y envia).
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION public.actualizar_pedido_items(
+  p_pedido_id bigint, p_items_nuevos jsonb, p_usuario_id uuid
+) RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $function$
+DECLARE
+  v_sucursal BIGINT := current_sucursal_id();
+  v_item_nuevo JSONB;
+  v_producto_id INT;
+  v_cantidad_original INT;
+  v_cantidad_nueva INT;
+  v_diferencia INT;
+  v_es_bonificacion BOOLEAN;
+  v_stock_actual INT;
+  v_producto_nombre TEXT;
+  v_total_nuevo DECIMAL := 0;
+  v_total_neto_nuevo DECIMAL := 0;
+  v_total_iva_nuevo DECIMAL := 0;
+  v_total_anterior DECIMAL;
+  v_errores TEXT[] := '{}';
+  v_items_originales JSONB;
+  v_user_role TEXT;
+  v_neto_unitario DECIMAL;
+  v_iva_unitario DECIMAL;
+  v_imp_internos_unitario DECIMAL;
+  v_porcentaje_iva DECIMAL;
+  v_precio_unitario DECIMAL;
+  v_promocion_id BIGINT;
+  v_regalo_mueve_stock BOOLEAN;
+  v_descripcion_regalo TEXT;
+  v_bonif RECORD;
+  v_promo RECORD;
+  v_usos_pendientes_actual INT;
+  v_bloques_completos INT;
+  v_ajustar_usos INT;
+  v_ajustar_stock INT;
+  v_stock_ajuste_anterior INT;
+  v_stock_ajuste_nuevo INT;
+  v_ajuste_producto_nombre TEXT;
+  v_merma_id BIGINT;
+  v_pedido_creator UUID;
+  v_pedido_created_at TIMESTAMPTZ;
+  v_hora_corte CONSTANT INT := 17;
+  v_precio_actual DECIMAL;
+BEGIN
+  IF v_sucursal IS NULL THEN
+    RETURN jsonb_build_object('success', false, 'errores', ARRAY['No se pudo determinar la sucursal activa']);
+  END IF;
+  IF p_usuario_id IS DISTINCT FROM auth.uid() THEN
+    RETURN jsonb_build_object('success', false, 'errores', ARRAY['ID de usuario no coincide con la sesion autenticada']);
+  END IF;
+  SELECT rol INTO v_user_role FROM perfiles WHERE id = p_usuario_id;
+  IF v_user_role IS NULL OR v_user_role NOT IN ('admin', 'encargado', 'preventista') THEN
+    RETURN jsonb_build_object('success', false, 'errores', ARRAY['No autorizado']);
+  END IF;
+
+  SELECT total, usuario_id, created_at
+    INTO v_total_anterior, v_pedido_creator, v_pedido_created_at
+    FROM pedidos
+   WHERE id = p_pedido_id AND sucursal_id = v_sucursal;
+  IF NOT FOUND THEN
+    RETURN jsonb_build_object('success', false, 'errores', ARRAY['Pedido no encontrado']);
+  END IF;
+
+  IF EXISTS (SELECT 1 FROM pedidos WHERE id = p_pedido_id AND sucursal_id = v_sucursal AND estado = 'entregado') THEN
+    RETURN jsonb_build_object('success', false, 'errores', ARRAY['No se puede editar un pedido ya entregado']);
+  END IF;
+
+  -- Validaciones especificas para preventista.
+  IF v_user_role = 'preventista' THEN
+    IF v_pedido_creator IS DISTINCT FROM p_usuario_id THEN
+      RETURN jsonb_build_object('success', false, 'errores',
+        ARRAY['Solo el preventista que creo el pedido puede editarlo']);
+    END IF;
+
+    IF (v_pedido_created_at AT TIME ZONE 'America/Argentina/Buenos_Aires')::date
+         IS DISTINCT FROM (now() AT TIME ZONE 'America/Argentina/Buenos_Aires')::date
+       OR EXTRACT(HOUR FROM now() AT TIME ZONE 'America/Argentina/Buenos_Aires') >= v_hora_corte
+    THEN
+      RETURN jsonb_build_object('success', false, 'errores',
+        ARRAY['Como preventista solo puede editar pedidos del dia actual antes de las 17:00 (ARG)']);
+    END IF;
+
+    -- No puede modificar precios. Validamos contra productos.precio (que es
+    -- la fuente que el frontend lee y envia).
+    FOR v_item_nuevo IN SELECT * FROM jsonb_array_elements(p_items_nuevos) LOOP
+      IF COALESCE((v_item_nuevo->>'es_bonificacion')::BOOLEAN, false) = true THEN
+        CONTINUE;
+      END IF;
+      v_producto_id := (v_item_nuevo->>'producto_id')::INT;
+      v_precio_unitario := (v_item_nuevo->>'precio_unitario')::DECIMAL;
+      SELECT precio INTO v_precio_actual
+        FROM productos WHERE id = v_producto_id AND sucursal_id = v_sucursal;
+      IF v_precio_actual IS NULL THEN
+        RETURN jsonb_build_object('success', false, 'errores',
+          ARRAY['Producto ID ' || v_producto_id || ' no encontrado']);
+      END IF;
+      IF v_precio_unitario IS DISTINCT FROM v_precio_actual THEN
+        RETURN jsonb_build_object('success', false, 'errores',
+          ARRAY['Como preventista no puede modificar precios (producto ID ' || v_producto_id || ')']);
+      END IF;
+    END LOOP;
+  END IF;
+
+  SELECT jsonb_agg(jsonb_build_object(
+    'producto_id', producto_id, 'cantidad', cantidad,
+    'precio_unitario', precio_unitario, 'es_bonificacion', COALESCE(es_bonificacion, false)))
+  INTO v_items_originales FROM pedido_items WHERE pedido_id = p_pedido_id AND sucursal_id = v_sucursal;
+
+  FOR v_item_nuevo IN SELECT * FROM jsonb_array_elements(p_items_nuevos) LOOP
+    v_producto_id := (v_item_nuevo->>'producto_id')::INT;
+    v_cantidad_nueva := (v_item_nuevo->>'cantidad')::INT;
+    v_es_bonificacion := COALESCE((v_item_nuevo->>'es_bonificacion')::BOOLEAN, false);
+    v_promocion_id := (v_item_nuevo->>'promocion_id')::BIGINT;
+
+    IF v_es_bonificacion THEN
+      IF v_promocion_id IS NULL THEN CONTINUE; END IF;
+      SELECT regalo_mueve_stock INTO v_regalo_mueve_stock FROM promociones WHERE id = v_promocion_id AND sucursal_id = v_sucursal;
+      IF NOT COALESCE(v_regalo_mueve_stock, FALSE) THEN CONTINUE; END IF;
+    END IF;
+
+    SELECT COALESCE(cantidad, 0) INTO v_cantidad_original
+    FROM pedido_items
+    WHERE pedido_id = p_pedido_id AND producto_id = v_producto_id
+      AND COALESCE(es_bonificacion, false) = v_es_bonificacion
+      AND sucursal_id = v_sucursal;
+
+    v_diferencia := v_cantidad_nueva - COALESCE(v_cantidad_original, 0);
+
+    IF v_diferencia > 0 THEN
+      SELECT stock, nombre INTO v_stock_actual, v_producto_nombre
+      FROM productos WHERE id = v_producto_id AND sucursal_id = v_sucursal FOR UPDATE;
+
+      IF v_stock_actual IS NULL THEN
+        v_errores := array_append(v_errores, 'Producto ID ' || v_producto_id || ' no encontrado');
+      ELSIF v_stock_actual < v_diferencia THEN
+        v_errores := array_append(v_errores, COALESCE(v_producto_nombre, 'Producto ' || v_producto_id)
+          || ': stock insuficiente (disponible: ' || v_stock_actual || ', adicional: ' || v_diferencia || ')');
+      END IF;
+    END IF;
+  END LOOP;
+
+  IF array_length(v_errores, 1) > 0 THEN
+    RETURN jsonb_build_object('success', false, 'errores', to_jsonb(v_errores));
+  END IF;
+
+  UPDATE productos p
+  SET stock = p.stock + pi.cantidad
+  FROM pedido_items pi
+  WHERE pi.pedido_id = p_pedido_id AND pi.sucursal_id = v_sucursal
+    AND COALESCE(pi.es_bonificacion, false) = false
+    AND p.id = pi.producto_id AND p.sucursal_id = v_sucursal;
+
+  UPDATE productos p
+  SET stock = p.stock + pi.cantidad
+  FROM pedido_items pi
+  JOIN promociones pr ON pr.id = pi.promocion_id AND pr.sucursal_id = pi.sucursal_id
+  WHERE pi.pedido_id = p_pedido_id AND pi.sucursal_id = v_sucursal
+    AND COALESCE(pi.es_bonificacion, false) = true
+    AND pi.promocion_id IS NOT NULL
+    AND COALESCE(pr.regalo_mueve_stock, FALSE) = TRUE
+    AND p.id = pi.producto_id AND p.sucursal_id = v_sucursal;
+
+  FOR v_bonif IN
+    SELECT promocion_id, SUM(cantidad)::INT AS total_cantidad
+      FROM pedido_items
+     WHERE pedido_id = p_pedido_id AND sucursal_id = v_sucursal
+       AND COALESCE(es_bonificacion, false) = true AND promocion_id IS NOT NULL
+     GROUP BY promocion_id
+  LOOP
+    PERFORM public.revertir_bloques_auto_ajuste(
+      v_bonif.promocion_id, v_bonif.total_cantidad, v_sucursal,
+      p_usuario_id, 'Edicion pedido #' || p_pedido_id
+    );
+  END LOOP;
+
+  DELETE FROM pedido_items WHERE pedido_id = p_pedido_id AND sucursal_id = v_sucursal;
+
+  FOR v_item_nuevo IN SELECT * FROM jsonb_array_elements(p_items_nuevos) LOOP
+    v_producto_id := (v_item_nuevo->>'producto_id')::INT;
+    v_cantidad_nueva := (v_item_nuevo->>'cantidad')::INT;
+    v_precio_unitario := (v_item_nuevo->>'precio_unitario')::DECIMAL;
+    v_es_bonificacion := COALESCE((v_item_nuevo->>'es_bonificacion')::BOOLEAN, false);
+    v_promocion_id := (v_item_nuevo->>'promocion_id')::BIGINT;
+    v_neto_unitario := (v_item_nuevo->>'neto_unitario')::DECIMAL;
+    v_iva_unitario := COALESCE((v_item_nuevo->>'iva_unitario')::DECIMAL, 0);
+    v_imp_internos_unitario := COALESCE((v_item_nuevo->>'impuestos_internos_unitario')::DECIMAL, 0);
+    v_porcentaje_iva := COALESCE((v_item_nuevo->>'porcentaje_iva')::DECIMAL, 0);
+
+    v_descripcion_regalo := NULL;
+    IF v_es_bonificacion AND v_promocion_id IS NOT NULL THEN
+      SELECT descripcion_regalo INTO v_descripcion_regalo FROM promociones WHERE id = v_promocion_id AND sucursal_id = v_sucursal;
+    END IF;
+
+    INSERT INTO pedido_items (
+      pedido_id, producto_id, cantidad, precio_unitario, subtotal,
+      es_bonificacion, promocion_id,
+      neto_unitario, iva_unitario, impuestos_internos_unitario, porcentaje_iva,
+      sucursal_id, descripcion_regalo
+    ) VALUES (
+      p_pedido_id, v_producto_id, v_cantidad_nueva, v_precio_unitario,
+      v_cantidad_nueva * v_precio_unitario,
+      v_es_bonificacion, v_promocion_id,
+      v_neto_unitario, v_iva_unitario, v_imp_internos_unitario, v_porcentaje_iva,
+      v_sucursal, v_descripcion_regalo
+    );
+
+    IF NOT v_es_bonificacion THEN
+      UPDATE productos SET stock = stock - v_cantidad_nueva WHERE id = v_producto_id AND sucursal_id = v_sucursal;
+      v_total_nuevo := v_total_nuevo + (v_cantidad_nueva * v_precio_unitario);
+      v_total_neto_nuevo := v_total_neto_nuevo + (v_cantidad_nueva * COALESCE(v_neto_unitario, v_precio_unitario));
+      v_total_iva_nuevo := v_total_iva_nuevo + (v_cantidad_nueva * v_iva_unitario);
+    ELSIF v_promocion_id IS NOT NULL THEN
+      SELECT regalo_mueve_stock INTO v_regalo_mueve_stock FROM promociones WHERE id = v_promocion_id AND sucursal_id = v_sucursal;
+      IF COALESCE(v_regalo_mueve_stock, FALSE) THEN
+        UPDATE productos SET stock = stock - v_cantidad_nueva WHERE id = v_producto_id AND sucursal_id = v_sucursal;
+      END IF;
+      UPDATE promociones SET usos_pendientes = usos_pendientes + v_cantidad_nueva WHERE id = v_promocion_id AND sucursal_id = v_sucursal;
+
+      SELECT id, nombre, ajuste_automatico, ajuste_producto_id, unidades_por_bloque,
+             stock_por_bloque, usos_pendientes
+      INTO v_promo
+      FROM promociones WHERE id = v_promocion_id AND sucursal_id = v_sucursal FOR UPDATE;
+
+      IF v_promo.ajuste_automatico AND v_promo.ajuste_producto_id IS NOT NULL
+         AND COALESCE(v_promo.unidades_por_bloque, 0) > 0 AND COALESCE(v_promo.stock_por_bloque, 0) > 0 THEN
+        v_usos_pendientes_actual := v_promo.usos_pendientes;
+        v_bloques_completos := v_usos_pendientes_actual / v_promo.unidades_por_bloque;
+        IF v_bloques_completos > 0 THEN
+          v_ajustar_usos := v_bloques_completos * v_promo.unidades_por_bloque;
+          v_ajustar_stock := v_bloques_completos * v_promo.stock_por_bloque;
+
+          SELECT stock, nombre INTO v_stock_ajuste_anterior, v_ajuste_producto_nombre
+          FROM productos WHERE id = v_promo.ajuste_producto_id AND sucursal_id = v_sucursal FOR UPDATE;
+
+          IF v_stock_ajuste_anterior IS NULL THEN
+            RAISE EXCEPTION 'Auto-ajuste: producto destino no encontrado (promo %)', v_promocion_id;
+          END IF;
+          IF v_stock_ajuste_anterior < v_ajustar_stock THEN
+            RAISE EXCEPTION 'Auto-ajuste: stock insuficiente en % (disponible: %, requerido: %)',
+              v_ajuste_producto_nombre, v_stock_ajuste_anterior, v_ajustar_stock;
+          END IF;
+
+          v_stock_ajuste_nuevo := v_stock_ajuste_anterior - v_ajustar_stock;
+
+          INSERT INTO mermas_stock (producto_id, cantidad, motivo, observaciones, stock_anterior, stock_nuevo, usuario_id, sucursal_id)
+          VALUES (v_promo.ajuste_producto_id, v_ajustar_stock, 'promociones',
+            'Auto-ajuste (Promo: ' || v_promo.nombre || ', Pedido #' || p_pedido_id || ', edicion)',
+            v_stock_ajuste_anterior, v_stock_ajuste_nuevo, p_usuario_id, v_sucursal)
+          RETURNING id INTO v_merma_id;
+
+          UPDATE productos SET stock = v_stock_ajuste_nuevo, updated_at = NOW()
+          WHERE id = v_promo.ajuste_producto_id AND sucursal_id = v_sucursal;
+
+          INSERT INTO promo_ajustes (promocion_id, usos_ajustados, unidades_ajustadas, producto_id, merma_id, usuario_id, observaciones, sucursal_id)
+          VALUES (v_promocion_id, v_ajustar_usos, v_ajustar_stock, v_promo.ajuste_producto_id,
+            v_merma_id, p_usuario_id, 'Auto-ajuste por edicion pedido #' || p_pedido_id, v_sucursal);
+
+          UPDATE promociones SET usos_pendientes = GREATEST(usos_pendientes - v_ajustar_usos, 0)
+          WHERE id = v_promocion_id AND sucursal_id = v_sucursal;
+        END IF;
+      END IF;
+    END IF;
+  END LOOP;
+
+  UPDATE pedidos SET total = v_total_nuevo, total_neto = v_total_neto_nuevo, total_iva = v_total_iva_nuevo, updated_at = NOW()
+  WHERE id = p_pedido_id AND sucursal_id = v_sucursal;
+
+  INSERT INTO pedido_historial (pedido_id, usuario_id, campo_modificado, valor_anterior, valor_nuevo, sucursal_id)
+  VALUES (p_pedido_id, p_usuario_id, 'items', COALESCE(v_items_originales::TEXT, '[]'), p_items_nuevos::TEXT, v_sucursal);
+
+  IF v_total_anterior IS DISTINCT FROM v_total_nuevo THEN
+    INSERT INTO pedido_historial (pedido_id, usuario_id, campo_modificado, valor_anterior, valor_nuevo, sucursal_id)
+    VALUES (p_pedido_id, p_usuario_id, 'total', v_total_anterior::TEXT, v_total_nuevo::TEXT, v_sucursal);
+  END IF;
+
+  RETURN jsonb_build_object('success', true, 'total_nuevo', v_total_nuevo);
+END;
+$function$;

--- a/src/components/containers/PedidosContainer.tsx
+++ b/src/components/containers/PedidosContainer.tsx
@@ -8,6 +8,7 @@
 import React, { lazy, Suspense, useState, useCallback, useMemo } from 'react'
 import { calcularNetoVenta } from '../../utils/calculations'
 import { fechaLocalISO } from '../../utils/formatters'
+import { preventistaPuedeEditar } from '../../utils/permisosPedido'
 import { useQueryClient } from '@tanstack/react-query'
 import { Loader2 } from 'lucide-react'
 import {
@@ -33,7 +34,7 @@ import { usePromocionPedido } from '../../hooks/usePromocionPedido'
 import { useDebounce } from '../../hooks/useAsync'
 import { supabase } from '../../hooks/supabase/base'
 import { usePagos } from '../../hooks/supabase/usePagos'
-import type { PedidoDB, FiltrosPedidosState, PerfilDB, RegistrarSalvedadInput, RegistrarSalvedadResult } from '../../types'
+import type { PedidoDB, FiltrosPedidosState, PerfilDB, RegistrarSalvedadInput, RegistrarSalvedadResult, PagoDBWithUsuario } from '../../types'
 import type { PedidoEditItem } from '../modals/ModalEditarPedido'
 
 // Lazy load de componentes
@@ -43,6 +44,7 @@ const ModalConfirmacion = lazy(() => import('../modals/ModalConfirmacion'))
 const ModalAsignarTransportista = lazy(() => import('../modals/ModalAsignarTransportista'))
 const ModalHistorialPedido = lazy(() => import('../modals/ModalHistorialPedido'))
 const ModalEditarPedido = lazy(() => import('../modals/ModalEditarPedido'))
+const ModalPagoPedido = lazy(() => import('../modals/ModalPagoPedido'))
 const ModalEditarNotas = lazy(() => import('../modals/ModalEditarNotas'))
 const ModalFiltroFecha = lazy(() => import('../modals/ModalFiltroFecha'))
 const ModalExportarPDF = lazy(() => import('../modals/ModalExportarPDF'))
@@ -95,7 +97,7 @@ export default function PedidosContainer(): React.ReactElement {
   const [filtros, setFiltros] = useState<FiltrosPedidosState>(DEFAULT_FILTROS)
 
   // Queries - use debounced search to avoid firing on every keystroke
-  const { registrarPago } = usePagos()
+  const { registrarPago, registrarPagosBatch, fetchPagosPedido, eliminarPago } = usePagos()
 
   const { data: paginatedResult, isLoading: loadingPedidos } = usePedidosPaginatedQuery(
     paginaActual, ITEMS_PER_PAGE, filtros, debouncedBusqueda, authReady
@@ -146,6 +148,10 @@ export default function PedidosContainer(): React.ReactElement {
   const [modalPagosMasivosOpen, setModalPagosMasivosOpen] = useState(false)
   const [modalAsignarMasivoOpen, setModalAsignarMasivoOpen] = useState(false)
   const [modalNotasOpen, setModalNotasOpen] = useState(false)
+  const [modalPagoPedidoOpen, setModalPagoPedidoOpen] = useState(false)
+  const [pedidoPago, setPedidoPago] = useState<PedidoDB | null>(null)
+  const [pagosPreviosPedido, setPagosPreviosPedido] = useState<PagoDBWithUsuario[]>([])
+  const [loadingPagosPrevios, setLoadingPagosPrevios] = useState(false)
   const [confirmConfig, setConfirmConfig] = useState<ConfirmConfig>({ visible: false })
 
   // Pedido-specific state for modals
@@ -203,20 +209,46 @@ export default function PedidosContainer(): React.ReactElement {
     setPaginaActual(page)
   }, [])
 
-  // Estado changes with confirmation dialog
-  const handleMarcarEntregado = useCallback((pedido: PedidoDB) => {
-    setConfirmConfig({
-      visible: true, titulo: 'Confirmar entrega',
-      mensaje: `¿Confirmar entrega del pedido #${pedido.id}?`, tipo: 'success',
-      onConfirm: async () => {
-        try {
-          await cambiarEstado.mutateAsync({ pedidoId: pedido.id, nuevoEstado: 'entregado' })
-          notify.success('Pedido entregado')
-        } catch (e) { notify.error((e as Error).message) }
-        setConfirmConfig({ visible: false })
-      },
-    })
-  }, [cambiarEstado, notify])
+  // Estado: marcar entregado.
+  // Si el pedido ya esta pagado completamente → confirm simple.
+  // Si queda saldo pendiente → abrir ModalPagoPedido en modoEntregaTransportista
+  // para que el usuario pueda registrar el cobro o entregar sin pago en el mismo gesto.
+  const [pedidoEntregaConPago, setPedidoEntregaConPago] = useState<PedidoDB | null>(null)
+
+  // Cargar pagos previos del pedido seleccionado para mostrar en el modal de pago.
+  // Definido antes de handleMarcarEntregado porque este lo invoca al abrir el modal.
+  const refreshPagosPedido = useCallback(async (pedidoId: string) => {
+    setLoadingPagosPrevios(true)
+    try {
+      const previos = await fetchPagosPedido(pedidoId)
+      setPagosPreviosPedido(previos)
+    } finally {
+      setLoadingPagosPrevios(false)
+    }
+  }, [fetchPagosPedido])
+
+  const handleMarcarEntregado = useCallback(async (pedido: PedidoDB) => {
+    if (pedido.estado_pago === 'pagado') {
+      setConfirmConfig({
+        visible: true, titulo: 'Confirmar entrega',
+        mensaje: `¿Confirmar entrega del pedido #${pedido.id}?`, tipo: 'success',
+        onConfirm: async () => {
+          try {
+            await cambiarEstado.mutateAsync({ pedidoId: pedido.id, nuevoEstado: 'entregado' })
+            notify.success('Pedido entregado')
+          } catch (e) { notify.error((e as Error).message) }
+          setConfirmConfig({ visible: false })
+        },
+      })
+      return
+    }
+    // Saldo pendiente: abrir modal de pago en modo entrega
+    setPedidoEntregaConPago(pedido)
+    setPedidoPago(pedido)
+    setPagosPreviosPedido([])
+    setModalPagoPedidoOpen(true)
+    await refreshPagosPedido(String(pedido.id))
+  }, [cambiarEstado, notify, refreshPagosPedido])
 
   const handleDesmarcarEntregado = useCallback((pedido: PedidoDB) => {
     setConfirmConfig({
@@ -516,15 +548,13 @@ export default function PedidosContainer(): React.ReactElement {
     setGuardando(false)
   }, [pedidoAsignando, asignarTransportistaMut, cambiarEstado, notify])
 
-  // ModalEditarPedido: onSave({ notas, formaPago, estadoPago, montoPagado, fecha?, fechaEntrega?, fechaEntregaProgramada? })
-  const handleGuardarEdicion = useCallback(async (data: { notas: string; formaPago: string; estadoPago: string; montoPagado: number; fecha?: string; fechaEntrega?: string; fechaEntregaProgramada?: string }) => {
+  // ModalEditarPedido: onSave({ notas, fecha?, fechaEntrega?, fechaEntregaProgramada? })
+  // Pago se gestiona desde ModalRegistrarPago (separate flow).
+  const handleGuardarEdicion = useCallback(async (data: { notas: string; fecha?: string; fechaEntrega?: string; fechaEntregaProgramada?: string }) => {
     if (!pedidoEditando) return
     setGuardando(true)
     try {
-      const updateData: Record<string, unknown> = {
-        notas: data.notas, forma_pago: data.formaPago,
-        estado_pago: data.estadoPago, monto_pagado: data.montoPagado ?? 0,
-      }
+      const updateData: Record<string, unknown> = { notas: data.notas }
       if (data.fecha) updateData.fecha = data.fecha
       if (data.fechaEntrega) {
         updateData.fecha_entrega = data.fechaEntrega.includes('T') ? data.fechaEntrega : `${data.fechaEntrega}T12:00:00Z`
@@ -571,6 +601,111 @@ export default function PedidosContainer(): React.ReactElement {
     // Invalidar cache de pedidos para refrescar datos
     queryClient.invalidateQueries({ queryKey: ['pedidos'] })
   }, [pedidoEditando, user, queryClient])
+
+  // ===========================================================================
+  // ModalPagoPedido handlers (registrar/anular pagos sobre un pedido)
+  // ===========================================================================
+
+  const handleAbrirRegistrarPago = useCallback(async (pedido: PedidoDB) => {
+    setPedidoPago(pedido)
+    setPagosPreviosPedido([])
+    setModalPagoPedidoOpen(true)
+    await refreshPagosPedido(String(pedido.id))
+  }, [refreshPagosPedido])
+
+  // El error ya fue notificado por usePagos.registrarPagosBatch via notifyError;
+  // dejamos que se propague para que el modal lo muestre tambien.
+  const handleConfirmarPago = useCallback(async (payload: { pedidoId: string; clienteId: string; fechaPago: string; observaciones?: string; pagos: Array<{ formaPago: string; monto: number }> }) => {
+    setGuardando(true)
+    try {
+      await registrarPagosBatch({
+        clienteId: payload.clienteId,
+        pedidoId: payload.pedidoId,
+        fecha: payload.fechaPago,
+        observaciones: payload.observaciones || null,
+        pagos: payload.pagos,
+        usuarioId: user?.id ?? null,
+      })
+      queryClient.invalidateQueries({ queryKey: ['pedidos'] })
+      setModalPagoPedidoOpen(false)
+      setPedidoPago(null)
+      notify.success('Pago registrado')
+    } finally {
+      setGuardando(false)
+    }
+  }, [registrarPagosBatch, user, queryClient, notify])
+
+  // Modo entrega transportista: "Entregar sin pago" → solo cambia estado.
+  const handleEntregarSinPago = useCallback(async () => {
+    const pedido = pedidoEntregaConPago
+    if (!pedido) return
+    setGuardando(true)
+    try {
+      await cambiarEstado.mutateAsync({ pedidoId: pedido.id, nuevoEstado: 'entregado' })
+      queryClient.invalidateQueries({ queryKey: ['pedidos'] })
+      setModalPagoPedidoOpen(false)
+      setPedidoPago(null)
+      setPedidoEntregaConPago(null)
+      notify.success('Pedido entregado sin pago registrado')
+    } catch (e) { notify.error((e as Error).message) }
+    setGuardando(false)
+  }, [pedidoEntregaConPago, cambiarEstado, queryClient, notify])
+
+  // Modo entrega transportista: "Entregar y registrar pago" → cambia estado y registra pagos.
+  // Orden: primero entrega (mas critica), luego pagos. Si falla algun pago, queda
+  // entregado y el usuario puede usar "Registrar Pago" desde el dropdown.
+  const handleEntregarConPago = useCallback(async (payload: { pedidoId: string; clienteId: string; fechaPago: string; observaciones?: string; pagos: Array<{ formaPago: string; monto: number }> }) => {
+    const pedido = pedidoEntregaConPago
+    if (!pedido) {
+      // Fallback: comportamiento normal de registrar pago sin entrega
+      await handleConfirmarPago(payload)
+      return
+    }
+    setGuardando(true)
+    try {
+      await cambiarEstado.mutateAsync({ pedidoId: pedido.id, nuevoEstado: 'entregado' })
+      try {
+        await registrarPagosBatch({
+          clienteId: payload.clienteId,
+          pedidoId: payload.pedidoId,
+          fecha: payload.fechaPago,
+          observaciones: payload.observaciones || null,
+          pagos: payload.pagos,
+          usuarioId: user?.id ?? null,
+        })
+      } catch (pagoErr) {
+        notify.error('Pedido entregado pero falló el pago: ' + (pagoErr as Error).message + '. Registralo desde el menú de pago.')
+        queryClient.invalidateQueries({ queryKey: ['pedidos'] })
+        setModalPagoPedidoOpen(false)
+        setPedidoPago(null)
+        setPedidoEntregaConPago(null)
+        return
+      }
+      queryClient.invalidateQueries({ queryKey: ['pedidos'] })
+      setModalPagoPedidoOpen(false)
+      setPedidoPago(null)
+      setPedidoEntregaConPago(null)
+      notify.success('Pedido entregado y pago registrado')
+    } catch (e) {
+      notify.error((e as Error).message)
+      throw e
+    } finally {
+      setGuardando(false)
+    }
+  }, [pedidoEntregaConPago, cambiarEstado, registrarPagosBatch, user, queryClient, notify, handleConfirmarPago])
+
+  const handleAnularPagoPedido = useCallback(async (pagoId: string) => {
+    if (!pedidoPago) return
+    if (!(isAdmin || isEncargado)) return
+    setGuardando(true)
+    try {
+      await eliminarPago(pagoId)
+      await refreshPagosPedido(String(pedidoPago.id))
+      queryClient.invalidateQueries({ queryKey: ['pedidos'] })
+      notify.success('Pago anulado')
+    } catch (e) { notify.error((e as Error).message) }
+    setGuardando(false)
+  }, [pedidoPago, isAdmin, isEncargado, eliminarPago, refreshPagosPedido, queryClient, notify])
 
   // ModalPedido handlers
   const handleGuardarPedido = useCallback(async () => {
@@ -822,6 +957,7 @@ export default function PedidosContainer(): React.ReactElement {
           onAsignarTransportistaMasivo={() => setModalAsignarMasivoOpen(true)}
           onRegistrarSalvedad={handleRegistrarSalvedadSingle}
           onRegistrarPago={handleRegistrarPagoTransportista}
+          onAbrirPagoPedido={handleAbrirRegistrarPago}
         />
       </Suspense>
 
@@ -938,10 +1074,42 @@ export default function PedidosContainer(): React.ReactElement {
           <ModalEditarPedido
             pedido={pedidoEditando}
             productos={productos}
-            isAdmin={isAdmin}
+            canEditItems={
+              isAdmin || isEncargado ||
+              (isPreventista && preventistaPuedeEditar(pedidoEditando, user?.id))
+            }
+            canEditPrices={isAdmin || isEncargado}
+            canEditFechaEntrega={
+              isAdmin || isEncargado ||
+              (isPreventista && preventistaPuedeEditar(pedidoEditando, user?.id))
+            }
             onSave={handleGuardarEdicion}
             onSaveItems={handleGuardarItemsEdicion}
             onClose={() => { setModalEditarOpen(false); setPedidoEditando(null) }}
+            guardando={guardando}
+          />
+        </Suspense>
+      )}
+
+      {/* Modal Pago Pedido — registrar/anular pagos sobre un pedido.
+          modoEntregaTransportista=true cuando el pedido fue abierto via Marcar Entregado
+          (estado_pago != 'pagado'); habilita "Entregar sin pago" + "Entregar y registrar pago". */}
+      {modalPagoPedidoOpen && pedidoPago && (
+        <Suspense fallback={null}>
+          <ModalPagoPedido
+            pedido={pedidoPago}
+            pagosPrevios={pagosPreviosPedido}
+            loadingPagosPrevios={loadingPagosPrevios}
+            onConfirmar={pedidoEntregaConPago ? handleEntregarConPago : handleConfirmarPago}
+            onAnularPago={(isAdmin || isEncargado) && !pedidoEntregaConPago ? handleAnularPagoPedido : undefined}
+            modoEntregaTransportista={!!pedidoEntregaConPago}
+            onEntregarSinPago={pedidoEntregaConPago ? handleEntregarSinPago : undefined}
+            onClose={() => {
+              setModalPagoPedidoOpen(false)
+              setPedidoPago(null)
+              setPedidoEntregaConPago(null)
+              setPagosPreviosPedido([])
+            }}
             guardando={guardando}
           />
         </Suspense>

--- a/src/components/modals/ModalEditarPedido.test.jsx
+++ b/src/components/modals/ModalEditarPedido.test.jsx
@@ -124,145 +124,8 @@ describe('ModalEditarPedido', () => {
     })
   })
 
-  describe('Forma de pago', () => {
-    it('muestra la forma de pago inicial', () => {
-      render(<ModalEditarPedido {...defaultProps} />)
-      const select = screen.getByRole('combobox')
-      expect(select.value).toBe('efectivo')
-    })
-
-    it('permite cambiar la forma de pago', async () => {
-      const user = userEvent.setup()
-      render(<ModalEditarPedido {...defaultProps} />)
-
-      const select = screen.getByRole('combobox')
-      await user.selectOptions(select, 'transferencia')
-
-      expect(select.value).toBe('transferencia')
-    })
-  })
-
-  describe('Estado de pago', () => {
-    it('muestra estado pendiente por defecto', () => {
-      render(<ModalEditarPedido {...defaultProps} />)
-      const btnPendiente = screen.getByRole('button', { name: 'Pendiente' })
-      expect(btnPendiente.className).toContain('border-red-500')
-    })
-
-    it('cambia a pagado y actualiza monto al total', async () => {
-      const user = userEvent.setup()
-      render(<ModalEditarPedido {...defaultProps} />)
-
-      const btnPagado = screen.getByRole('button', { name: 'Pagado' })
-      await user.click(btnPagado)
-
-      expect(btnPagado.className).toContain('border-green-500')
-      const inputMonto = screen.getByPlaceholderText('0.00')
-      expect(inputMonto.value).toBe('1000')
-    })
-
-    it('cambia a pendiente y resetea monto a 0', async () => {
-      const user = userEvent.setup()
-      const pedidoPagado = { ...mockPedido, estado_pago: 'pagado', monto_pagado: 1000 }
-      render(<ModalEditarPedido {...defaultProps} pedido={pedidoPagado} />)
-
-      const btnPendiente = screen.getByRole('button', { name: 'Pendiente' })
-      await user.click(btnPendiente)
-
-      const inputMonto = screen.getByPlaceholderText('0.00')
-      expect(inputMonto.value).toBe('0')
-    })
-
-    it('muestra alerta de pago parcial con saldo pendiente', async () => {
-      const user = userEvent.setup()
-      render(<ModalEditarPedido {...defaultProps} />)
-
-      const btnParcial = screen.getByRole('button', { name: 'Parcial' })
-      await user.click(btnParcial)
-
-      const inputMonto = screen.getByPlaceholderText('0.00')
-      await user.clear(inputMonto)
-      await user.type(inputMonto, '300')
-
-      expect(screen.getByText('Pago Parcial')).toBeInTheDocument()
-      // Verify the paid amount shows in the partial payment section
-      expect(screen.getByText(/Pagado:/)).toBeInTheDocument()
-    })
-  })
-
-  describe('Botones de porcentaje', () => {
-    it('aplica 25% del total', async () => {
-      const user = userEvent.setup()
-      render(<ModalEditarPedido {...defaultProps} />)
-
-      const btn25 = screen.getByRole('button', { name: '25%' })
-      await user.click(btn25)
-
-      const inputMonto = screen.getByPlaceholderText('0.00')
-      expect(inputMonto.value).toBe('250')
-    })
-
-    it('aplica 50% del total', async () => {
-      const user = userEvent.setup()
-      render(<ModalEditarPedido {...defaultProps} />)
-
-      const btn50 = screen.getByRole('button', { name: '50%' })
-      await user.click(btn50)
-
-      const inputMonto = screen.getByPlaceholderText('0.00')
-      expect(inputMonto.value).toBe('500')
-    })
-
-    it('aplica 100% y cambia estado a pagado', async () => {
-      const user = userEvent.setup()
-      render(<ModalEditarPedido {...defaultProps} />)
-
-      const btn100 = screen.getByRole('button', { name: '100%' })
-      await user.click(btn100)
-
-      const btnPagado = screen.getByRole('button', { name: 'Pagado' })
-      expect(btnPagado.className).toContain('border-green-500')
-    })
-  })
-
-  describe('Lógica de monto y estado', () => {
-    it('cambia a pagado cuando monto >= total', async () => {
-      const user = userEvent.setup()
-      render(<ModalEditarPedido {...defaultProps} />)
-
-      const inputMonto = screen.getByPlaceholderText('0.00')
-      await user.clear(inputMonto)
-      await user.type(inputMonto, '1000')
-
-      const btnPagado = screen.getByRole('button', { name: 'Pagado' })
-      expect(btnPagado.className).toContain('border-green-500')
-    })
-
-    it('cambia a parcial cuando monto > 0 y < total', async () => {
-      const user = userEvent.setup()
-      render(<ModalEditarPedido {...defaultProps} />)
-
-      const inputMonto = screen.getByPlaceholderText('0.00')
-      await user.clear(inputMonto)
-      await user.type(inputMonto, '500')
-
-      const btnParcial = screen.getByRole('button', { name: 'Parcial' })
-      expect(btnParcial.className).toContain('border-yellow-500')
-    })
-
-    it('cambia a pendiente cuando monto = 0', async () => {
-      const user = userEvent.setup()
-      const pedidoParcial = { ...mockPedido, estado_pago: 'parcial', monto_pagado: 500 }
-      render(<ModalEditarPedido {...defaultProps} pedido={pedidoParcial} />)
-
-      const inputMonto = screen.getByPlaceholderText('0.00')
-      await user.clear(inputMonto)
-      await user.type(inputMonto, '0')
-
-      const btnPendiente = screen.getByRole('button', { name: 'Pendiente' })
-      expect(btnPendiente.className).toContain('border-red-500')
-    })
-  })
+  // Nota: La gestion de pago (forma, estado, monto, combinado, %) fue movida a
+  // ModalRegistrarPago. Sus tests viven en src/components/modals/ModalRegistrarPago.test.tsx.
 
   describe('Pedido entregado', () => {
     it('muestra alerta cuando el pedido está entregado', () => {
@@ -351,12 +214,7 @@ describe('ModalEditarPedido', () => {
       const btnGuardar = screen.getByRole('button', { name: 'Guardar' })
       await user.click(btnGuardar)
 
-      expect(onSave).toHaveBeenCalledWith({
-        notas: 'Nota inicial',
-        formaPago: 'efectivo',
-        estadoPago: 'pendiente',
-        montoPagado: 0
-      })
+      expect(onSave).toHaveBeenCalledWith({ notas: 'Nota inicial' })
     })
 
     it('llama onSaveItems cuando hay items modificados (admin)', async () => {

--- a/src/components/modals/ModalEditarPedido.tsx
+++ b/src/components/modals/ModalEditarPedido.tsx
@@ -1,5 +1,5 @@
 import { useState, memo, useEffect, useMemo } from 'react';
-import { Loader2, DollarSign, AlertCircle, Package, Plus, Minus, Trash2, Search, X, ShoppingCart, Pencil, Gift } from 'lucide-react';
+import { Loader2, AlertCircle, Package, Plus, Minus, Trash2, Search, X, ShoppingCart, Pencil, Gift } from 'lucide-react';
 import ModalBase from './ModalBase';
 import ModalConfirmacion, { type ModalConfirmacionConfig } from './ModalConfirmacion';
 import { formatPrecio } from '../../utils/formatters';
@@ -27,12 +27,9 @@ export interface PedidoEditItem {
   porcentaje_iva?: number;
 }
 
-/** Datos a guardar del pedido */
+/** Datos a guardar del pedido. Pago se gestiona en ModalRegistrarPago. */
 export interface PedidoSaveData {
   notas: string;
-  formaPago: string;
-  estadoPago: string;
-  montoPagado: number;
   fecha?: string;
   fechaEntrega?: string;
   fechaEntregaProgramada?: string;
@@ -44,7 +41,13 @@ export interface ModalEditarPedidoProps {
   pedido: PedidoDB | null;
   /** Lista de productos disponibles */
   productos?: ProductoDB[];
-  /** Si es admin (puede editar items) */
+  /** Permite agregar/eliminar items y modificar cantidades. Default: isAdmin. */
+  canEditItems?: boolean;
+  /** Permite editar precios unitarios. Default: isAdmin. */
+  canEditPrices?: boolean;
+  /** Permite cambiar fecha de pedido / entrega / entrega programada. Default: isAdmin. */
+  canEditFechaEntrega?: boolean;
+  /** @deprecated usar canEditItems/canEditPrices/canEditFechaEntrega. Mantiene compat. */
   isAdmin?: boolean;
   /** Callback al guardar datos */
   onSave: (data: PedidoSaveData) => void | Promise<void>;
@@ -59,56 +62,31 @@ export interface ModalEditarPedidoProps {
 const ModalEditarPedido = memo(function ModalEditarPedido({
   pedido,
   productos = [],
+  canEditItems,
+  canEditPrices,
+  canEditFechaEntrega,
   isAdmin = false,
   onSave,
   onSaveItems,
   onClose,
   guardando
 }: ModalEditarPedidoProps) {
+  // Resolver flags de permiso. Si el caller pasa los flags nuevos los usamos;
+  // si no, fallback al isAdmin legacy.
+  const puedeEditarItems = canEditItems ?? isAdmin;
+  const puedeEditarPrecios = canEditPrices ?? isAdmin;
+  const puedeEditarFechas = canEditFechaEntrega ?? isAdmin;
+
   const [notas, setNotas] = useState<string>(pedido?.notas || "");
   const [fecha, setFecha] = useState<string>(pedido?.fecha || "");
   const fechaEntregaOriginal = pedido?.fecha_entrega ? pedido.fecha_entrega.split('T')[0] : "";
   const [fechaEntrega, setFechaEntrega] = useState<string>(fechaEntregaOriginal);
   const fechaEntregaProgramadaOriginal = pedido?.fecha_entrega_programada || "";
   const [fechaEntregaProgramada, setFechaEntregaProgramada] = useState<string>(fechaEntregaProgramadaOriginal);
-  const [formaPago, setFormaPago] = useState<string>(pedido?.forma_pago === 'combinado' ? 'combinado' : (pedido?.forma_pago || "efectivo"));
-  const [estadoPago, setEstadoPago] = useState<string>(pedido?.estado_pago || "pendiente");
-  const [montoPagado, setMontoPagado] = useState<number>(pedido?.monto_pagado || 0);
   const [errorValidacion, setErrorValidacion] = useState<string>('');
   const [confirmConfig, setConfirmConfig] = useState<ModalConfirmacionConfig | null>(null);
 
-  // Pago combinado
-  const [pagoCombinado, setPagoCombinado] = useState<boolean>(pedido?.forma_pago === 'combinado');
-  // Parseo pragmático del detalle guardado en notas — formato frágil (depende de es-AR toLocaleString).
-  // Si falla, cae al default. Fix robusto requeriría columna metadata_pago jsonb (fuera de alcance).
-  const [pagosCombinados, setPagosCombinados] = useState<{ monto: string; formaPago: string }[]>(() => {
-    if (pedido?.forma_pago === 'combinado' && pedido?.notas) {
-      const match = pedido.notas.match(/\[Pago combinado:\s*([^\]]+)\]/);
-      if (match) {
-        const mapaLabels: Record<string, string> = {
-          'efectivo': 'efectivo',
-          'transferencia': 'transferencia',
-          'cheque': 'cheque',
-          'tarjeta': 'tarjeta',
-          'cuenta corriente': 'cuenta_corriente',
-        };
-        const parsed = match[1].split('+').map(s => s.trim()).map(parte => {
-          const m = parte.match(/^(.+?)\s*\$([0-9.,]+)$/);
-          if (!m) return null;
-          const key = m[1].trim().toLowerCase();
-          const montoNum = m[2].replace(/\./g, '').replace(',', '.');
-          return { formaPago: mapaLabels[key] || 'efectivo', monto: montoNum };
-        }).filter((x): x is { formaPago: string; monto: string } => x !== null);
-        if (parsed.length >= 2) return parsed;
-      }
-    }
-    return [
-      { monto: '', formaPago: 'efectivo' },
-      { monto: '', formaPago: 'transferencia' },
-    ];
-  });
-
-  // Zod validation
+  // Zod validation (solo notas; el pago se maneja en ModalRegistrarPago)
   const { validate } = useZodValidation(modalEditarPedidoSchema);
 
   // Consulta de control de rendición (para warning al cambiar fecha_entrega)
@@ -227,7 +205,6 @@ const ModalEditarPedido = memo(function ModalEditarPedido({
   }, [promosLoading, pedido, items, bonificacionesCalculadas]);
 
   const total = itemsModificados ? totalFinal : (pedido?.total || 0);
-  const saldoPendiente = total - montoPagado;
 
   // Detectar si hubo cambios en items (cantidad, precio, agregados o eliminados)
   useEffect(() => {
@@ -259,35 +236,6 @@ const ModalEditarPedido = memo(function ModalEditarPedido({
       )
       .slice(0, 10);
   }, [productos, items, busquedaProducto]);
-
-  // Cuando cambia el estado de pago, ajustar el monto
-  // NOTE: Only react to estadoPago changes, NOT total changes.
-  // If total is in deps, editing items while estadoPago='pagado' silently overwrites montoPagado.
-  useEffect(() => {
-    if (estadoPago === 'pagado') {
-      setMontoPagado(total);
-    } else if (estadoPago === 'pendiente') {
-      setMontoPagado(0);
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [estadoPago]);
-
-  const handleMontoPagadoChange = (valor: string): void => {
-    const monto = Math.min(parsePrecio(valor), total);
-    setMontoPagado(monto);
-    if (monto >= total) {
-      setEstadoPago('pagado');
-    } else if (monto > 0) {
-      setEstadoPago('parcial');
-    } else {
-      setEstadoPago('pendiente');
-    }
-  };
-
-  const aplicarPorcentaje = (porcentaje: number): void => {
-    const monto = (total * porcentaje) / 100;
-    handleMontoPagadoChange(String(monto));
-  };
 
   // Funciones para editar items
   const handleCantidadChange = (productoId: string, delta: number): void => {
@@ -344,46 +292,16 @@ const ModalEditarPedido = memo(function ModalEditarPedido({
     setErrorValidacion('');
     setErrorStock(null);
 
-    // Preparar datos de pago
-    let formaPagoFinal = formaPago;
-    let montoPagadoFinal = montoPagado || 0;
-    let notasFinal = notas;
-
-    if (pagoCombinado) {
-      const pagosValidos = pagosCombinados.filter(p => parsePrecio(p.monto) > 0);
-      if (pagosValidos.length < 2) {
-        setErrorValidacion('Ingresa al menos 2 formas de pago con monto mayor a 0');
-        return;
-      }
-      formaPagoFinal = 'combinado';
-      montoPagadoFinal = Math.min(pagosValidos.reduce((sum, p) => sum + parsePrecio(p.monto), 0), total);
-      if (pagosValidos.reduce((sum, p) => sum + parsePrecio(p.monto), 0) > total) {
-        setErrorValidacion(`El total combinado no puede superar el total del pedido (${formatPrecio(total)})`);
-        return;
-      }
-      // Agregar detalle de pagos combinados a las notas
-      const formasPagoLabels: Record<string, string> = {
-        efectivo: 'Efectivo', transferencia: 'Transferencia', cheque: 'Cheque',
-        tarjeta: 'Tarjeta', cuenta_corriente: 'Cuenta Corriente'
-      };
-      const detalle = pagosValidos.map(p =>
-        `${formasPagoLabels[p.formaPago] || p.formaPago} $${parsePrecio(p.monto).toLocaleString('es-AR')}`
-      ).join(' + ');
-      // Reemplazar detalle previo si existe, o agregar
-      const notaSinDetalle = notas.replace(/\s*\[Pago combinado:.*?\]/g, '').trim();
-      notasFinal = notaSinDetalle ? `${notaSinDetalle} [Pago combinado: ${detalle}]` : `[Pago combinado: ${detalle}]`;
-    }
-
-    // Validar con Zod
-    const result = validate({ notas: notasFinal, formaPago: formaPagoFinal, estadoPago, montoPagado: montoPagadoFinal });
+    // Validar con Zod (solo notas)
+    const result = validate({ notas });
     if (!result.success) {
       const firstError = Object.values(result.errors || {})[0] || 'Error de validación';
       setErrorValidacion(firstError);
       return;
     }
 
-    // Si cambió la fecha_entrega (solo admin + pedido entregado), consultar control de rendición
-    const fechaEntregaCambio = isAdmin && pedidoEntregado && fechaEntrega && fechaEntrega !== fechaEntregaOriginal;
+    // Si cambió la fecha_entrega (admin/encargado + pedido entregado), consultar control de rendición
+    const fechaEntregaCambio = puedeEditarFechas && pedidoEntregado && fechaEntrega && fechaEntrega !== fechaEntregaOriginal;
     if (fechaEntregaCambio && pedido?.transportista_id) {
       try {
         const [origen, destino] = await Promise.all([
@@ -406,7 +324,7 @@ const ModalEditarPedido = memo(function ModalEditarPedido({
             mensaje,
             onConfirm: () => {
               setConfirmConfig(null);
-              void doGuardar(notasFinal, formaPagoFinal, montoPagadoFinal, true);
+              void doGuardar(notas, true);
             },
           });
           return;
@@ -416,19 +334,17 @@ const ModalEditarPedido = memo(function ModalEditarPedido({
       }
     }
 
-    await doGuardar(notasFinal, formaPagoFinal, montoPagadoFinal, !!fechaEntregaCambio);
+    await doGuardar(notas, !!fechaEntregaCambio);
   };
 
   const doGuardar = async (
     notasFinal: string,
-    formaPagoFinal: string,
-    montoPagadoFinal: number,
     fechaEntregaCambio: boolean,
   ): Promise<void> => {
     try {
-      // Si hay cambios en items y es admin, guardar items con precios mayoristas
-      // resueltos, desglose fiscal y bonificaciones recalculadas por el hook.
-      if (itemsModificados && isAdmin && onSaveItems) {
+      // Si hay cambios en items y el usuario puede editarlos, guardar items con
+      // precios mayoristas resueltos, desglose fiscal y bonificaciones recalculadas.
+      if (itemsModificados && puedeEditarItems && onSaveItems) {
         const tipoFactura = pedido?.tipo_factura || 'ZZ';
 
         // Items no-bonif del estado → con precio resuelto + desglose fiscal
@@ -466,13 +382,10 @@ const ModalEditarPedido = memo(function ModalEditarPedido({
         await onSaveItems([...itemsNoBonif, ...itemsBonif]);
       }
       // Guardar el resto de los datos
-      const fechaEntregaProgramadaCambio = isAdmin && !pedidoEntregado && fechaEntregaProgramada !== fechaEntregaProgramadaOriginal;
+      const fechaEntregaProgramadaCambio = puedeEditarFechas && !pedidoEntregado && fechaEntregaProgramada !== fechaEntregaProgramadaOriginal;
       await onSave({
         notas: notasFinal,
-        formaPago: formaPagoFinal,
-        estadoPago,
-        montoPagado: montoPagadoFinal,
-        ...(isAdmin && fecha ? { fecha } : {}),
+        ...(puedeEditarFechas && fecha ? { fecha } : {}),
         ...(fechaEntregaCambio ? { fechaEntrega } : {}),
         ...(fechaEntregaProgramadaCambio ? { fechaEntregaProgramada } : {})
       });
@@ -491,7 +404,7 @@ const ModalEditarPedido = memo(function ModalEditarPedido({
   return (
     <ModalBase
       title={`Editar Pedido #${pedido?.id}`}
-      description="Editar notas, forma de pago, estado de pago y productos del pedido"
+      description="Editar items, fechas y notas del pedido. El pago se gestiona desde el menú del pedido."
       onClose={onClose}
       maxWidth="max-w-2xl"
     >
@@ -515,8 +428,8 @@ const ModalEditarPedido = memo(function ModalEditarPedido({
           </div>
         )}
 
-        {/* Sección de productos - Vista de solo lectura para no-admin o pedido entregado */}
-        {(!isAdmin || pedidoEntregado) && pedido && (pedido.items?.length ?? 0) > 0 && (
+        {/* Sección de productos - Vista de solo lectura cuando no se pueden editar items o el pedido está entregado */}
+        {(!puedeEditarItems || pedidoEntregado) && pedido && (pedido.items?.length ?? 0) > 0 && (
           <div className="border dark:border-gray-600 rounded-lg overflow-hidden">
             <div className="bg-gray-50 dark:bg-gray-700 px-4 py-3 flex items-center gap-2">
               <ShoppingCart className="w-5 h-5 text-blue-600" />
@@ -540,8 +453,8 @@ const ModalEditarPedido = memo(function ModalEditarPedido({
           </div>
         )}
 
-        {/* Sección de productos editable (solo admin y pedido no entregado) */}
-        {isAdmin && !pedidoEntregado && (
+        {/* Sección de productos editable (puede editar items y pedido no entregado) */}
+        {puedeEditarItems && !pedidoEntregado && (
           <div className="border dark:border-gray-600 rounded-lg overflow-hidden">
             <div className="bg-gray-50 dark:bg-gray-700 px-4 py-3 flex items-center justify-between">
               <div className="flex items-center gap-2">
@@ -668,16 +581,16 @@ const ModalEditarPedido = memo(function ModalEditarPedido({
                             </div>
                           ) : (
                             <span
-                              className={`${item.precioOverride ? 'text-orange-600 font-medium' : ''} ${isAdmin ? 'cursor-pointer hover:underline' : ''}`}
+                              className={`${item.precioOverride ? 'text-orange-600 font-medium' : ''} ${puedeEditarPrecios ? 'cursor-pointer hover:underline' : ''}`}
                               onClick={() => {
-                                if (isAdmin) {
+                                if (puedeEditarPrecios) {
                                   setEditingPriceId(item.productoId);
                                   setEditingPriceValue(String(precioResuelto));
                                 }
                               }}
                             >
                               {formatPrecio(precioResuelto)} c/u
-                              {isAdmin && <Pencil className="w-3 h-3 inline ml-0.5 text-gray-400" />}
+                              {puedeEditarPrecios && <Pencil className="w-3 h-3 inline ml-0.5 text-gray-400" />}
                             </span>
                           )}
                           <span>-</span>
@@ -771,8 +684,8 @@ const ModalEditarPedido = memo(function ModalEditarPedido({
           </div>
         </div>
 
-        {/* Fecha del pedido (solo admin) */}
-        {isAdmin && (
+        {/* Fecha del pedido (solo admin/encargado) */}
+        {puedeEditarFechas && (
           <div>
             <label className="block text-sm font-medium mb-1 dark:text-gray-200">Fecha del Pedido</label>
             <input
@@ -784,8 +697,8 @@ const ModalEditarPedido = memo(function ModalEditarPedido({
           </div>
         )}
 
-        {/* Fecha programada de entrega (solo admin + pedido NO entregado) */}
-        {isAdmin && !pedidoEntregado && (
+        {/* Fecha programada de entrega (puede editar fechas + pedido NO entregado) */}
+        {puedeEditarFechas && !pedidoEntregado && (
           <div>
             <label className="block text-sm font-medium mb-1 dark:text-gray-200">
               Fecha programada de entrega
@@ -804,8 +717,8 @@ const ModalEditarPedido = memo(function ModalEditarPedido({
           </div>
         )}
 
-        {/* Fecha de entrega (solo admin + pedido entregado) - determina el día de rendición */}
-        {isAdmin && pedidoEntregado && (
+        {/* Fecha de entrega (admin/encargado + pedido entregado) - determina el día de rendición */}
+        {puedeEditarFechas && pedidoEntregado && (
           <div>
             <label className="block text-sm font-medium mb-1 dark:text-gray-200">
               Fecha de Entrega
@@ -836,205 +749,6 @@ const ModalEditarPedido = memo(function ModalEditarPedido({
             rows={2}
           />
         </div>
-
-        {/* Forma de Pago */}
-        <div>
-          <div className="flex items-center justify-between mb-1">
-            <label className="block text-sm font-medium dark:text-gray-200">Forma de Pago</label>
-            <label className="flex items-center gap-2 cursor-pointer">
-              <input
-                type="checkbox"
-                checked={pagoCombinado}
-                onChange={e => {
-                  setPagoCombinado(e.target.checked);
-                  if (!e.target.checked) {
-                    setFormaPago('efectivo');
-                    setMontoPagado(pedido?.monto_pagado || 0);
-                    setEstadoPago(pedido?.estado_pago || 'pendiente');
-                  }
-                }}
-                className="w-4 h-4 rounded border-gray-300 text-blue-600"
-              />
-              <span className="text-xs text-gray-500 dark:text-gray-400">Pago combinado</span>
-            </label>
-          </div>
-
-          {pagoCombinado ? (
-            <div className="space-y-2">
-              {pagosCombinados.map((pago, index) => (
-                <div key={index} className="flex items-center gap-2">
-                  <select
-                    value={pago.formaPago}
-                    onChange={e => setPagosCombinados(prev => prev.map((p, i) => i === index ? { ...p, formaPago: e.target.value } : p))}
-                    className="flex-1 px-2 py-2 text-sm border rounded-lg dark:bg-gray-700 dark:border-gray-600 dark:text-white"
-                  >
-                    <option value="efectivo">Efectivo</option>
-                    <option value="transferencia">Transferencia</option>
-                    <option value="cheque">Cheque</option>
-                    <option value="cuenta_corriente">Cuenta Corriente</option>
-                    <option value="tarjeta">Tarjeta</option>
-                  </select>
-                  <div className="relative flex-1">
-                    <span className="absolute left-2 top-1/2 -translate-y-1/2 text-gray-400 text-sm">$</span>
-                    <input
-                      type="number"
-                      inputMode="decimal"
-                      step="0.01"
-                      min="0"
-                      value={pago.monto}
-                      onChange={e => {
-                        const nuevos = pagosCombinados.map((p, i) => i === index ? { ...p, monto: e.target.value } : p);
-                        setPagosCombinados(nuevos);
-                        const totalComb = nuevos.reduce((sum, p) => sum + parsePrecio(p.monto), 0);
-                        setMontoPagado(totalComb);
-                        if (totalComb >= total) setEstadoPago('pagado');
-                        else if (totalComb > 0) setEstadoPago('parcial');
-                        else setEstadoPago('pendiente');
-                      }}
-                      placeholder="0.00"
-                      className="w-full pl-6 pr-2 py-2 text-sm border rounded-lg dark:bg-gray-700 dark:border-gray-600 dark:text-white font-semibold"
-                    />
-                  </div>
-                  {pagosCombinados.length > 2 && (
-                    <button
-                      type="button"
-                      onClick={() => setPagosCombinados(prev => prev.filter((_, i) => i !== index))}
-                      className="p-1 text-red-500 hover:bg-red-50 dark:hover:bg-red-900/20 rounded"
-                    >
-                      <Trash2 className="w-4 h-4" />
-                    </button>
-                  )}
-                </div>
-              ))}
-              <button
-                type="button"
-                onClick={() => setPagosCombinados(prev => [...prev, { monto: '', formaPago: 'efectivo' }])}
-                className="w-full flex items-center justify-center gap-1 px-3 py-1.5 text-xs text-blue-600 hover:bg-blue-50 dark:hover:bg-blue-900/20 rounded-lg border border-dashed border-blue-300 dark:border-blue-700"
-              >
-                <Plus className="w-3 h-3" />
-                Agregar forma de pago
-              </button>
-              {(() => {
-                const totalComb = pagosCombinados.reduce((s, p) => s + parsePrecio(p.monto), 0);
-                const excede = totalComb > total;
-                return (
-                  <div className={`text-right text-sm ${excede ? 'text-red-600 dark:text-red-400' : 'text-gray-500 dark:text-gray-400'}`}>
-                    Total combinado: <span className={`font-bold ${excede ? 'text-red-600 dark:text-red-400' : 'text-gray-800 dark:text-white'}`}>{formatPrecio(totalComb)}</span>
-                    {excede && <span className="block text-xs">Excede el total del pedido ({formatPrecio(total)})</span>}
-                  </div>
-                );
-              })()}
-            </div>
-          ) : (
-            <select
-              value={formaPago}
-              onChange={e => setFormaPago(e.target.value)}
-              className="w-full px-3 py-2 border rounded-lg dark:bg-gray-700 dark:border-gray-600 dark:text-white"
-            >
-              <option value="efectivo">Efectivo</option>
-              <option value="transferencia">Transferencia</option>
-              <option value="cheque">Cheque</option>
-              <option value="cuenta_corriente">Cuenta Corriente</option>
-              <option value="tarjeta">Tarjeta</option>
-            </select>
-          )}
-        </div>
-
-        {/* Sección de pago */}
-        <div className="border dark:border-gray-600 rounded-lg p-4 space-y-4">
-          <div className="flex items-center gap-2">
-            <DollarSign className="w-5 h-5 text-green-600" />
-            <span className="font-medium dark:text-gray-200">Estado de Pago</span>
-          </div>
-
-          {/* Estado de pago */}
-          <div className="grid grid-cols-3 gap-2">
-            <button
-              type="button"
-              onClick={() => setEstadoPago('pendiente')}
-              className={`py-2 px-3 rounded-lg text-sm font-medium transition-colors ${
-                estadoPago === 'pendiente'
-                  ? 'bg-red-100 text-red-700 border-2 border-red-500 dark:bg-red-900/30 dark:text-red-400 dark:border-red-600'
-                  : 'bg-gray-100 text-gray-600 border border-gray-300 hover:bg-gray-200 dark:bg-gray-700 dark:text-gray-400 dark:border-gray-600'
-              }`}
-            >
-              Pendiente
-            </button>
-            <button
-              type="button"
-              onClick={() => setEstadoPago('parcial')}
-              className={`py-2 px-3 rounded-lg text-sm font-medium transition-colors ${
-                estadoPago === 'parcial'
-                  ? 'bg-yellow-100 text-yellow-700 border-2 border-yellow-500 dark:bg-yellow-900/30 dark:text-yellow-400 dark:border-yellow-600'
-                  : 'bg-gray-100 text-gray-600 border border-gray-300 hover:bg-gray-200 dark:bg-gray-700 dark:text-gray-400 dark:border-gray-600'
-              }`}
-            >
-              Parcial
-            </button>
-            <button
-              type="button"
-              onClick={() => setEstadoPago('pagado')}
-              className={`py-2 px-3 rounded-lg text-sm font-medium transition-colors ${
-                estadoPago === 'pagado'
-                  ? 'bg-green-100 text-green-700 border-2 border-green-500 dark:bg-green-900/30 dark:text-green-400 dark:border-green-600'
-                  : 'bg-gray-100 text-gray-600 border border-gray-300 hover:bg-gray-200 dark:bg-gray-700 dark:text-gray-400 dark:border-gray-600'
-              }`}
-            >
-              Pagado
-            </button>
-          </div>
-
-          {/* Monto pagado */}
-          <div>
-            <label className="block text-sm font-medium mb-1 dark:text-gray-200">
-              Monto Pagado
-            </label>
-            <div className="relative">
-              <span className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-500">$</span>
-              <input
-                type="number"
-                inputMode="decimal"
-                min="0"
-                max={total}
-                step="0.01"
-                value={montoPagado}
-                onChange={e => handleMontoPagadoChange(e.target.value)}
-                className="w-full pl-8 pr-3 py-2 border rounded-lg dark:bg-gray-700 dark:border-gray-600 dark:text-white"
-                placeholder="0.00"
-              />
-            </div>
-
-            {/* Botones de porcentaje rápido */}
-            <div className="flex gap-2 mt-2">
-              {[25, 50, 75, 100].map(pct => (
-                <button
-                  key={pct}
-                  type="button"
-                  onClick={() => aplicarPorcentaje(pct)}
-                  className="flex-1 py-1 text-xs bg-gray-100 hover:bg-gray-200 dark:bg-gray-700 dark:hover:bg-gray-600 rounded transition-colors dark:text-gray-300"
-                >
-                  {pct}%
-                </button>
-              ))}
-            </div>
-          </div>
-
-          {/* Resumen de pagos */}
-          {estadoPago === 'parcial' && saldoPendiente > 0 && (
-            <div className="bg-yellow-50 dark:bg-yellow-900/20 border border-yellow-200 dark:border-yellow-800 rounded-lg p-3">
-              <div className="flex items-start gap-2">
-                <AlertCircle className="w-5 h-5 text-yellow-600 flex-shrink-0 mt-0.5" />
-                <div className="text-sm">
-                  <p className="font-medium text-yellow-800 dark:text-yellow-300">Pago Parcial</p>
-                  <div className="mt-1 space-y-1 text-yellow-700 dark:text-yellow-400">
-                    <p>Pagado: <span className="font-semibold">{formatPrecio(montoPagado)}</span></p>
-                    <p>Pendiente: <span className="font-semibold text-red-600 dark:text-red-400">{formatPrecio(saldoPendiente)}</span></p>
-                  </div>
-                </div>
-              </div>
-            </div>
-          )}
-        </div>
       </div>
 
       {/* Error de stock */}
@@ -1060,7 +774,7 @@ const ModalEditarPedido = memo(function ModalEditarPedido({
         </button>
         <button
           onClick={handleGuardar}
-          disabled={guardando || (isAdmin && !pedidoEntregado && items.length === 0)}
+          disabled={guardando || (puedeEditarItems && !pedidoEntregado && items.length === 0)}
           className="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 flex items-center disabled:opacity-50"
         >
           {guardando && <Loader2 className="w-4 h-4 mr-2 animate-spin" />}

--- a/src/components/modals/ModalPagoPedido.tsx
+++ b/src/components/modals/ModalPagoPedido.tsx
@@ -1,0 +1,365 @@
+/**
+ * ModalPagoPedido — registrar/anular pagos asociados a un pedido especifico.
+ *
+ * Reemplaza la seccion de pago que vivia dentro de ModalEditarPedido. Soporta
+ * dos modos de invocacion:
+ *  - Estandar: admin/encargado lo abre desde el dropdown "Registrar Pago".
+ *  - `modoEntregaTransportista`: el transportista lo abre cuando marca como
+ *    entregado, y puede confirmar "entregar sin pago" o "entregar y registrar
+ *    pago" en una misma operacion.
+ *
+ * Persistencia: cada forma de pago se guarda como una row separada en `pagos`
+ * (mejor para reportes que el formato `[Pago combinado: ...]` en notas). El
+ * trigger SQL `actualizar_estado_pago_pedido` recalcula `pedidos.estado_pago`
+ * y `pedidos.monto_pagado` automaticamente.
+ *
+ * Sobrepago bloqueado en frontend (totalIngresado > saldoPendiente). Anulacion
+ * de pagos previos solo si el caller pasa `onAnularPago` (admin/encargado).
+ */
+import { memo, useEffect, useMemo, useState } from 'react'
+import { Loader2, DollarSign, Plus, Trash2, AlertCircle, X } from 'lucide-react'
+import ModalBase from './ModalBase'
+import { formatPrecio, fechaLocalISO, formatDateTime, getFormaPagoLabel } from '../../utils/formatters'
+import { parsePrecio } from '../../utils/calculations'
+import type { PedidoDB, PagoDBWithUsuario } from '../../types'
+
+export interface PagoPedidoPayload {
+  pedidoId: string
+  clienteId: string
+  fechaPago: string
+  observaciones?: string
+  pagos: Array<{ formaPago: string; monto: number }>
+}
+
+export interface ModalPagoPedidoProps {
+  pedido: PedidoDB
+  pagosPrevios: PagoDBWithUsuario[]
+  loadingPagosPrevios?: boolean
+  onConfirmar: (payload: PagoPedidoPayload) => Promise<void>
+  /** Si esta presente, se permite anular pagos previos (admin/encargado). */
+  onAnularPago?: (pagoId: string) => Promise<void>
+  /** Activa el flujo "Entregar sin pago / Entregar y registrar pago". */
+  modoEntregaTransportista?: boolean
+  /** Solo aplica con modoEntregaTransportista. */
+  onEntregarSinPago?: () => Promise<void>
+  onClose: () => void
+  guardando: boolean
+}
+
+interface LineaPago {
+  formaPago: string
+  monto: string
+}
+
+const FORMAS_PAGO_OPCIONES: Array<{ value: string; label: string }> = [
+  { value: 'efectivo', label: 'Efectivo' },
+  { value: 'transferencia', label: 'Transferencia' },
+  { value: 'cheque', label: 'Cheque' },
+  { value: 'cuenta_corriente', label: 'Cuenta Corriente' },
+  { value: 'tarjeta', label: 'Tarjeta' },
+]
+
+const ModalPagoPedido = memo(function ModalPagoPedido({
+  pedido,
+  pagosPrevios,
+  loadingPagosPrevios,
+  onConfirmar,
+  onAnularPago,
+  modoEntregaTransportista,
+  onEntregarSinPago,
+  onClose,
+  guardando,
+}: ModalPagoPedidoProps) {
+  const yaPagado = useMemo(
+    () => pagosPrevios.reduce((s, p) => s + (p.monto || 0), 0),
+    [pagosPrevios],
+  )
+  const total = pedido.total || 0
+  const saldoPendiente = Math.max(0, total - yaPagado)
+
+  const [fechaPago, setFechaPago] = useState<string>(fechaLocalISO())
+  const [observaciones, setObservaciones] = useState<string>('')
+  const [lineas, setLineas] = useState<LineaPago[]>([
+    { formaPago: 'efectivo', monto: saldoPendiente > 0 ? saldoPendiente.toFixed(2) : '' },
+  ])
+  const [error, setError] = useState<string>('')
+
+  // Si los pagos previos cambian (anulacion), reajustar la linea por default al saldo restante.
+  useEffect(() => {
+    if (saldoPendiente > 0 && lineas.length === 1 && (!lineas[0].monto || parsePrecio(lineas[0].monto) === 0)) {
+      setLineas([{ formaPago: lineas[0].formaPago, monto: saldoPendiente.toFixed(2) }])
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [saldoPendiente])
+
+  const totalIngresado = useMemo(
+    () => lineas.reduce((s, l) => s + parsePrecio(l.monto), 0),
+    [lineas],
+  )
+  const excedeSaldo = totalIngresado > saldoPendiente + 0.001
+  const algunMontoValido = lineas.some(l => parsePrecio(l.monto) > 0)
+
+  const handleAgregarLinea = (): void => {
+    setLineas(prev => [...prev, { formaPago: 'transferencia', monto: '' }])
+  }
+
+  const handleQuitarLinea = (index: number): void => {
+    setLineas(prev => prev.filter((_, i) => i !== index))
+  }
+
+  const handleLineaChange = (index: number, patch: Partial<LineaPago>): void => {
+    setLineas(prev => prev.map((l, i) => (i === index ? { ...l, ...patch } : l)))
+  }
+
+  const handleSubmit = async (): Promise<void> => {
+    setError('')
+    if (saldoPendiente <= 0) {
+      setError('El pedido ya esta completamente pagado.')
+      return
+    }
+    if (!algunMontoValido) {
+      setError('Ingresa al menos un monto mayor a 0.')
+      return
+    }
+    if (excedeSaldo) {
+      setError(
+        `El total ingresado (${formatPrecio(totalIngresado)}) excede el saldo pendiente (${formatPrecio(saldoPendiente)}).`,
+      )
+      return
+    }
+    if (!fechaPago) {
+      setError('Ingresa la fecha de pago.')
+      return
+    }
+    try {
+      await onConfirmar({
+        pedidoId: String(pedido.id),
+        clienteId: String(pedido.cliente_id),
+        fechaPago,
+        observaciones: observaciones.trim() || undefined,
+        pagos: lineas
+          .filter(l => parsePrecio(l.monto) > 0)
+          .map(l => ({ formaPago: l.formaPago, monto: parsePrecio(l.monto) })),
+      })
+    } catch (e) {
+      setError((e as Error).message || 'Error al registrar el pago')
+    }
+  }
+
+  const handleEntregarSinPago = async (): Promise<void> => {
+    if (!onEntregarSinPago) return
+    setError('')
+    try {
+      await onEntregarSinPago()
+    } catch (e) {
+      setError((e as Error).message || 'Error al marcar como entregado')
+    }
+  }
+
+  return (
+    <ModalBase
+      title={modoEntregaTransportista ? `Entregar Pedido #${pedido.id}` : `Registrar Pago — Pedido #${pedido.id}`}
+      description="Registrar o anular pagos del pedido. Cada forma de pago se guarda como un movimiento separado."
+      onClose={onClose}
+      maxWidth="max-w-xl"
+    >
+      <div className="p-4 space-y-4 max-h-[70vh] overflow-y-auto">
+        {/* Header con totales */}
+        <div className="bg-gray-50 dark:bg-gray-700 rounded-lg p-3 border dark:border-gray-600">
+          <p className="text-sm text-gray-600 dark:text-gray-400">{pedido.cliente?.nombre_fantasia}</p>
+          <div className="mt-2 grid grid-cols-3 gap-2 text-sm">
+            <div>
+              <p className="text-xs text-gray-500">Total pedido</p>
+              <p className="font-semibold dark:text-white">{formatPrecio(total)}</p>
+            </div>
+            <div>
+              <p className="text-xs text-gray-500">Ya pagado</p>
+              <p className="font-semibold text-green-700 dark:text-green-400">{formatPrecio(yaPagado)}</p>
+            </div>
+            <div>
+              <p className="text-xs text-gray-500">Saldo pendiente</p>
+              <p className={`font-semibold ${saldoPendiente > 0 ? 'text-red-600 dark:text-red-400' : 'text-gray-500'}`}>
+                {formatPrecio(saldoPendiente)}
+              </p>
+            </div>
+          </div>
+        </div>
+
+        {/* Pagos previos */}
+        {loadingPagosPrevios ? (
+          <div className="flex items-center gap-2 text-sm text-gray-500">
+            <Loader2 className="w-4 h-4 animate-spin" /> Cargando pagos previos...
+          </div>
+        ) : pagosPrevios.length > 0 && (
+          <div className="border dark:border-gray-600 rounded-lg overflow-hidden">
+            <div className="bg-gray-50 dark:bg-gray-700 px-3 py-2 text-sm font-medium dark:text-white">
+              Pagos previos ({pagosPrevios.length})
+            </div>
+            <div className="divide-y dark:divide-gray-600">
+              {pagosPrevios.map(p => (
+                <div key={p.id} className="px-3 py-2 flex items-center justify-between text-sm">
+                  <div>
+                    <p className="dark:text-white">
+                      {formatPrecio(p.monto)}{' '}
+                      <span className="text-gray-500">· {getFormaPagoLabel(p.forma_pago)}</span>
+                    </p>
+                    <p className="text-xs text-gray-500">
+                      {p.created_at && formatDateTime(p.created_at)}
+                      {p.usuario?.nombre ? ` · ${p.usuario.nombre}` : ''}
+                    </p>
+                    {p.notas && <p className="text-xs text-gray-400 italic">{p.notas}</p>}
+                  </div>
+                  {onAnularPago && (
+                    <button
+                      type="button"
+                      onClick={() => { void onAnularPago(p.id) }}
+                      disabled={guardando}
+                      className="p-1.5 text-red-500 hover:bg-red-50 dark:hover:bg-red-900/20 rounded disabled:opacity-50"
+                      aria-label="Anular pago"
+                      title="Anular pago"
+                    >
+                      <X className="w-4 h-4" />
+                    </button>
+                  )}
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {/* Form nuevo pago */}
+        {saldoPendiente > 0 ? (
+          <>
+            <div>
+              <label className="block text-sm font-medium mb-1 dark:text-gray-200">Fecha de pago</label>
+              <input
+                type="date"
+                value={fechaPago}
+                onChange={e => setFechaPago(e.target.value)}
+                className="w-full px-3 py-2 border rounded-lg dark:bg-gray-700 dark:border-gray-600 dark:text-white"
+              />
+            </div>
+
+            <div>
+              <div className="flex items-center justify-between mb-1">
+                <label className="text-sm font-medium dark:text-gray-200 flex items-center gap-2">
+                  <DollarSign className="w-4 h-4 text-green-600" /> Pago
+                </label>
+                <button
+                  type="button"
+                  onClick={handleAgregarLinea}
+                  className="text-xs text-blue-600 hover:underline flex items-center gap-1"
+                >
+                  <Plus className="w-3 h-3" /> Agregar forma de pago
+                </button>
+              </div>
+              <div className="space-y-2">
+                {lineas.map((linea, index) => (
+                  <div key={index} className="flex items-center gap-2">
+                    <select
+                      value={linea.formaPago}
+                      onChange={e => handleLineaChange(index, { formaPago: e.target.value })}
+                      className="flex-1 px-2 py-2 text-sm border rounded-lg dark:bg-gray-700 dark:border-gray-600 dark:text-white"
+                    >
+                      {FORMAS_PAGO_OPCIONES.map(o => (
+                        <option key={o.value} value={o.value}>{o.label}</option>
+                      ))}
+                    </select>
+                    <div className="relative flex-1">
+                      <span className="absolute left-2 top-1/2 -translate-y-1/2 text-gray-400 text-sm">$</span>
+                      <input
+                        type="number"
+                        inputMode="decimal"
+                        step="0.01"
+                        min="0"
+                        value={linea.monto}
+                        onChange={e => handleLineaChange(index, { monto: e.target.value })}
+                        placeholder="0.00"
+                        className="w-full pl-6 pr-2 py-2 text-sm border rounded-lg dark:bg-gray-700 dark:border-gray-600 dark:text-white font-semibold"
+                      />
+                    </div>
+                    {lineas.length > 1 && (
+                      <button
+                        type="button"
+                        onClick={() => handleQuitarLinea(index)}
+                        className="p-1 text-red-500 hover:bg-red-50 dark:hover:bg-red-900/20 rounded"
+                        aria-label="Quitar linea de pago"
+                      >
+                        <Trash2 className="w-4 h-4" />
+                      </button>
+                    )}
+                  </div>
+                ))}
+              </div>
+              <div className={`mt-2 text-right text-sm ${excedeSaldo ? 'text-red-600 dark:text-red-400' : 'text-gray-500 dark:text-gray-400'}`}>
+                Total a registrar:{' '}
+                <span className={`font-bold ${excedeSaldo ? 'text-red-600 dark:text-red-400' : 'text-gray-800 dark:text-white'}`}>
+                  {formatPrecio(totalIngresado)}
+                </span>
+                {excedeSaldo && (
+                  <span className="block text-xs">Excede el saldo pendiente ({formatPrecio(saldoPendiente)})</span>
+                )}
+              </div>
+            </div>
+
+            <div>
+              <label className="block text-sm font-medium mb-1 dark:text-gray-200">Observaciones (opcional)</label>
+              <textarea
+                value={observaciones}
+                onChange={e => setObservaciones(e.target.value)}
+                rows={2}
+                className="w-full px-3 py-2 border rounded-lg dark:bg-gray-700 dark:border-gray-600 dark:text-white"
+                placeholder="Notas sobre el pago, numero de transferencia, cheque, etc."
+              />
+            </div>
+          </>
+        ) : (
+          <div className="bg-green-50 dark:bg-green-900/20 border border-green-200 dark:border-green-800 rounded-lg p-3 flex items-start gap-2">
+            <AlertCircle className="w-5 h-5 text-green-600 flex-shrink-0 mt-0.5" />
+            <div className="text-sm">
+              <p className="font-medium text-green-800 dark:text-green-300">Pedido completamente pagado</p>
+              <p className="text-green-700 dark:text-green-400">No queda saldo pendiente.</p>
+            </div>
+          </div>
+        )}
+      </div>
+
+      {error && (
+        <div className="mx-4 mb-2 p-3 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg">
+          <p className="text-sm text-red-600 dark:text-red-400">{error}</p>
+        </div>
+      )}
+
+      <div className="flex justify-end gap-2 p-4 border-t bg-gray-50 dark:bg-gray-800">
+        <button
+          onClick={onClose}
+          className="px-4 py-2 text-gray-700 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-700 rounded-lg"
+        >
+          Cancelar
+        </button>
+        {modoEntregaTransportista && onEntregarSinPago && (
+          <button
+            onClick={() => { void handleEntregarSinPago() }}
+            disabled={guardando}
+            className="px-4 py-2 bg-amber-600 text-white rounded-lg hover:bg-amber-700 flex items-center disabled:opacity-50"
+          >
+            {guardando && <Loader2 className="w-4 h-4 mr-2 animate-spin" />}
+            Entregar sin pago
+          </button>
+        )}
+        {saldoPendiente > 0 && (
+          <button
+            onClick={() => { void handleSubmit() }}
+            disabled={guardando || excedeSaldo || !algunMontoValido}
+            className="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 flex items-center disabled:opacity-50"
+          >
+            {guardando && <Loader2 className="w-4 h-4 mr-2 animate-spin" />}
+            {modoEntregaTransportista ? 'Entregar y registrar pago' : 'Registrar pago'}
+          </button>
+        )}
+      </div>
+    </ModalBase>
+  )
+})
+
+export default ModalPagoPedido

--- a/src/components/pedidos/PedidoActions.tsx
+++ b/src/components/pedidos/PedidoActions.tsx
@@ -9,7 +9,7 @@
  * - Focus visible en items
  */
 import React, { memo, useMemo } from 'react';
-import { MoreVertical, History, Edit2, Package, User, Check, AlertTriangle, RotateCcw, AlertCircle, XCircle, LucideIcon } from 'lucide-react';
+import { MoreVertical, History, Edit2, Package, User, Check, AlertTriangle, RotateCcw, AlertCircle, XCircle, DollarSign, LucideIcon } from 'lucide-react';
 import {
   DropdownMenu,
   DropdownMenuTrigger,
@@ -18,6 +18,7 @@ import {
   DropdownMenuSeparator
 } from '../ui/DropdownMenu';
 import type { PedidoDB } from '../../types';
+import { preventistaPuedeEditar } from '../../utils/permisosPedido';
 
 // =============================================================================
 // PROPS INTERFACES
@@ -29,6 +30,7 @@ export interface AccionesDropdownProps {
   isPreventista?: boolean;
   isTransportista?: boolean;
   isEncargado?: boolean;
+  currentUserId?: string;
   onHistorial?: (pedido: PedidoDB) => void;
   onEditar?: (pedido: PedidoDB) => void;
   onEditarNotas?: (pedido: PedidoDB) => void;
@@ -39,6 +41,7 @@ export interface AccionesDropdownProps {
   onEntregadoConSalvedad?: (pedido: PedidoDB) => void;
   onRevertir?: (pedido: PedidoDB) => void;
   onCancelarPedido?: (pedido: PedidoDB) => void;
+  onRegistrarPago?: (pedido: PedidoDB) => void;
 }
 
 interface AccionItem {
@@ -59,6 +62,7 @@ function AccionesDropdown({
   isPreventista,
   isTransportista,
   isEncargado,
+  currentUserId,
   onHistorial,
   onEditar,
   onEditarNotas,
@@ -69,6 +73,7 @@ function AccionesDropdown({
   onEntregadoConSalvedad,
   onRevertir,
   onCancelarPedido,
+  onRegistrarPago,
 }: AccionesDropdownProps): React.ReactElement {
   // Memoizar acciones para evitar recalculos innecesarios
   const acciones = useMemo((): AccionItem[] => {
@@ -92,15 +97,39 @@ function AccionesDropdown({
         onClick: () => onEditar(pedido),
         className: 'text-blue-700 dark:text-blue-400'
       });
-    }
-
-    // Preventista solo puede editar observaciones
-    if (isPreventista && !isAdmin && !isEncargado && onEditarNotas) {
+    } else if (
+      isPreventista && !isAdmin && !isEncargado &&
+      onEditar && preventistaPuedeEditar(pedido, currentUserId)
+    ) {
+      // Preventista creador: edicion limitada del pedido (items, fechas) hasta 17:00 ARG
+      items.push({
+        label: 'Editar Pedido',
+        icon: Edit2,
+        onClick: () => onEditar(pedido),
+        className: 'text-blue-700 dark:text-blue-400'
+      });
+    } else if (isPreventista && !isAdmin && !isEncargado && onEditarNotas) {
+      // Preventista fuera de ventana: solo observaciones
       items.push({
         label: 'Editar Observaciones',
         icon: Edit2,
         onClick: () => onEditarNotas(pedido),
         className: 'text-blue-700 dark:text-blue-400'
+      });
+    }
+
+    // Registrar pago (admin o encargado, mientras no este pagado/cancelado)
+    if (
+      (isAdmin || isEncargado) &&
+      pedido.estado !== 'cancelado' &&
+      pedido.estado_pago !== 'pagado' &&
+      onRegistrarPago
+    ) {
+      items.push({
+        label: 'Registrar Pago',
+        icon: DollarSign,
+        onClick: () => onRegistrarPago(pedido),
+        className: 'text-green-700 dark:text-green-400'
       });
     }
 
@@ -176,7 +205,7 @@ function AccionesDropdown({
     }
 
     return items;
-  }, [pedido, isAdmin, isPreventista, isTransportista, isEncargado, onHistorial, onEditar, onEditarNotas, onPreparar, onVolverAPendiente, onAsignar, onEntregado, onEntregadoConSalvedad, onRevertir, onCancelarPedido]);
+  }, [pedido, isAdmin, isPreventista, isTransportista, isEncargado, currentUserId, onHistorial, onEditar, onEditarNotas, onPreparar, onVolverAPendiente, onAsignar, onEntregado, onEntregadoConSalvedad, onRevertir, onCancelarPedido, onRegistrarPago]);
 
   return (
     <DropdownMenu>

--- a/src/components/pedidos/PedidoCard.tsx
+++ b/src/components/pedidos/PedidoCard.tsx
@@ -17,6 +17,7 @@ import { formatPrecio, formatFecha, getEstadoColor, getEstadoPagoColor, getEstad
 import { MOTIVOS_SALVEDAD_LABELS } from '../../lib/schemas';
 import AccionesDropdown from './PedidoActions';
 import { PedidoActionsCtx } from '../../contexts/HandlersContext';
+import { useAuthData } from '../../contexts/AuthDataContext';
 import type { PedidoDB, MotivoSalvedad } from '../../types';
 
 // =============================================================================
@@ -49,6 +50,7 @@ export interface PedidoCardProps {
   onMarcarEntregadoConSalvedad?: (pedido: PedidoDB) => void;
   onDesmarcarEntregado?: (pedido: PedidoDB) => void;
   onCancelarPedido?: (pedido: PedidoDB) => void;
+  onRegistrarPago?: (pedido: PedidoDB) => void;
 }
 
 interface EstadoConfig {
@@ -154,12 +156,14 @@ function PedidoCard({
   onMarcarEntregadoConSalvedad,
   onDesmarcarEntregado,
   onCancelarPedido,
+  onRegistrarPago,
 }: PedidoCardProps): React.ReactElement {
   const [expandido, setExpandido] = useState<boolean>(false);
   const tieneSalvedad = pedido.salvedades && pedido.salvedades.length > 0;
 
   // Intentar usar contexto si está disponible (migración gradual)
   const pedidoActions = useContext(PedidoActionsCtx);
+  const { user } = useAuthData();
 
   // Usar handlers del contexto si están disponibles, de lo contrario usar props
   const handleVerHistorial = onVerHistorial ?? pedidoActions?.handleVerHistorial;
@@ -168,6 +172,7 @@ function PedidoCard({
   const handleVolverAPendiente = onVolverAPendiente ?? pedidoActions?.handleVolverAPendiente;
   const handleMarcarEntregado = onMarcarEntregado ?? pedidoActions?.handleMarcarEntregado;
   const handleDesmarcarEntregado = onDesmarcarEntregado ?? pedidoActions?.handleDesmarcarEntregado;
+  const handleRegistrarPago = onRegistrarPago ?? pedidoActions?.handleRegistrarPago;
   return (
     <div className="bg-white dark:bg-gray-800 border dark:border-gray-700 rounded-lg shadow-sm p-4 hover:shadow-md transition-shadow">
       {/* Header del pedido */}
@@ -226,6 +231,7 @@ function PedidoCard({
             isPreventista={isPreventista}
             isTransportista={isTransportista}
             isEncargado={isEncargado}
+            currentUserId={user?.id}
             onHistorial={handleVerHistorial}
             onEditar={handleEditarPedido}
             onEditarNotas={onEditarNotas}
@@ -236,6 +242,7 @@ function PedidoCard({
             onEntregadoConSalvedad={onMarcarEntregadoConSalvedad}
             onRevertir={handleDesmarcarEntregado}
             onCancelarPedido={onCancelarPedido}
+            onRegistrarPago={handleRegistrarPago}
           />
         </div>
       </div>

--- a/src/components/pedidos/VirtualizedPedidoList.tsx
+++ b/src/components/pedidos/VirtualizedPedidoList.tsx
@@ -49,6 +49,8 @@ export interface VirtualizedPedidoListProps {
   onMarcarEntregado?: (pedido: PedidoDB) => void;
   onMarcarEntregadoConSalvedad?: (pedido: PedidoDB) => void;
   onDesmarcarEntregado?: (pedido: PedidoDB) => void;
+  onCancelarPedido?: (pedido: PedidoDB) => void;
+  onRegistrarPago?: (pedido: PedidoDB) => void;
   height?: number;
 }
 
@@ -100,6 +102,8 @@ const PedidoRow = memo(function PedidoRow({ index, style, ariaAttributes }: Pedi
           onMarcarEntregado={handlers?.onMarcarEntregado}
           onMarcarEntregadoConSalvedad={handlers?.onMarcarEntregadoConSalvedad}
           onDesmarcarEntregado={handlers?.onDesmarcarEntregado}
+          onCancelarPedido={handlers?.onCancelarPedido}
+          onRegistrarPago={handlers?.onRegistrarPago}
         />
       </div>
     </div>
@@ -184,6 +188,8 @@ function VirtualizedPedidoList({
   onMarcarEntregado,
   onMarcarEntregadoConSalvedad,
   onDesmarcarEntregado,
+  onCancelarPedido,
+  onRegistrarPago,
   height: propHeight
 }: VirtualizedPedidoListProps): React.ReactElement {
   const containerRef = useRef<HTMLDivElement>(null)
@@ -220,8 +226,10 @@ function VirtualizedPedidoList({
     onAsignarTransportista,
     onMarcarEntregado,
     onMarcarEntregadoConSalvedad,
-    onDesmarcarEntregado
-  }), [onVerHistorial, onEditarPedido, onMarcarEnPreparacion, onVolverAPendiente, onAsignarTransportista, onMarcarEntregado, onMarcarEntregadoConSalvedad, onDesmarcarEntregado])
+    onDesmarcarEntregado,
+    onCancelarPedido,
+    onRegistrarPago
+  }), [onVerHistorial, onEditarPedido, onMarcarEnPreparacion, onVolverAPendiente, onAsignarTransportista, onMarcarEntregado, onMarcarEntregadoConSalvedad, onDesmarcarEntregado, onCancelarPedido, onRegistrarPago])
 
   // Preparar permisos para el Context (memoizados)
   const permissions = useMemo<VirtualizedListPermissions>(() => ({

--- a/src/components/vistas/VistaPedidos.tsx
+++ b/src/components/vistas/VistaPedidos.tsx
@@ -77,7 +77,7 @@ export interface VistaPedidosProps {
     fotoUrl?: string;
     devolverStock: boolean;
   }) => Promise<RegistrarSalvedadResult>;
-  /** Handler para registrar un pago (reutiliza el flujo del admin). */
+  /** Handler legacy para registrar un pago desde la vista transportista (modal cliente). */
   onRegistrarPago?: (data: {
     clienteId: string;
     pedidoId: string | null;
@@ -87,6 +87,8 @@ export interface VistaPedidosProps {
     notas: string;
     fecha: string;
   }) => Promise<unknown>;
+  /** Handler para abrir ModalPagoPedido desde el dropdown del PedidoCard. */
+  onAbrirPagoPedido?: (pedido: PedidoDB) => void;
 }
 
 export default function VistaPedidos({
@@ -131,6 +133,7 @@ export default function VistaPedidos({
   onAsignarTransportistaMasivo,
   onRegistrarSalvedad,
   onRegistrarPago,
+  onAbrirPagoPedido,
 }: VistaPedidosProps) {
   // Si es transportista, mostrar vista especial de ruta
   if (isTransportista && !isAdmin && !isPreventista) {
@@ -257,6 +260,7 @@ export default function VistaPedidos({
                 onMarcarEntregadoConSalvedad={onMarcarEntregadoConSalvedad}
                 onDesmarcarEntregado={onDesmarcarEntregado}
                 onCancelarPedido={onCancelarPedido}
+                onRegistrarPago={onAbrirPagoPedido}
               />
             ))}
           </div>

--- a/src/contexts/HandlersContext.tsx
+++ b/src/contexts/HandlersContext.tsx
@@ -47,6 +47,7 @@ export interface PedidoActionsContext {
   handleVolverAPendiente: (pedido: PedidoDB) => void;
   handleAsignarTransportista: (transportistaId: string | null, marcarListo?: boolean) => Promise<void>;
   handleEliminarPedido: (id: string) => void;
+  handleRegistrarPago?: (pedido: PedidoDB) => void;
 
   // Historial y edición
   handleVerHistorial: (pedido: PedidoDB) => Promise<void>;

--- a/src/contexts/VirtualizedListContext.tsx
+++ b/src/contexts/VirtualizedListContext.tsx
@@ -26,6 +26,8 @@ export interface VirtualizedListHandlers {
   onMarcarEntregado?: (pedido: PedidoDB) => void
   onMarcarEntregadoConSalvedad?: (pedido: PedidoDB) => void
   onDesmarcarEntregado?: (pedido: PedidoDB) => void
+  onCancelarPedido?: (pedido: PedidoDB) => void
+  onRegistrarPago?: (pedido: PedidoDB) => void
 }
 
 export interface VirtualizedListPermissions {

--- a/src/hooks/handlers/usePedidoHandlers.ts
+++ b/src/hooks/handlers/usePedidoHandlers.ts
@@ -113,10 +113,9 @@ export interface OrdenOptimizadoData {
 
 export interface EdicionPedidoData {
   notas: string;
-  formaPago: string;
-  estadoPago: string;
-  montoPagado?: number;
+  fecha?: string;
   fechaEntrega?: string;
+  fechaEntregaProgramada?: string;
 }
 
 // =============================================================================
@@ -239,8 +238,8 @@ export function usePedidoHandlers({
   asignarTransportista,
   eliminarPedido,
   actualizarNotasPedido,
-  actualizarEstadoPago,
-  actualizarFormaPago,
+  actualizarEstadoPago: _actualizarEstadoPago, // pago se gestiona en ModalRegistrarPago
+  actualizarFormaPago: _actualizarFormaPago,
   actualizarFechaEntrega,
   actualizarOrdenEntrega,
   actualizarItemsPedido: _actualizarItemsPedido, // Passed for potential future use
@@ -683,14 +682,12 @@ export function usePedidoHandlers({
     modales.editarPedido.setOpen(true)
   }, [setPedidoEditando, modales.editarPedido])
 
-  const handleGuardarEdicionPedido = useCallback(async ({ notas, formaPago, estadoPago, montoPagado, fechaEntrega }: EdicionPedidoData): Promise<void> => {
+  const handleGuardarEdicionPedido = useCallback(async ({ notas, fechaEntrega }: EdicionPedidoData): Promise<void> => {
     const pedidoEditando = pedidoEditandoRef.current
     if (!pedidoEditando) return
     setGuardando(true)
     try {
       await actualizarNotasPedido(pedidoEditando.id, notas)
-      await actualizarFormaPago(pedidoEditando.id, formaPago)
-      await actualizarEstadoPago(pedidoEditando.id, estadoPago, montoPagado)
       if (fechaEntrega && fechaEntrega !== pedidoEditando.fecha_entrega?.split('T')[0]) {
         await actualizarFechaEntrega(pedidoEditando.id, fechaEntrega)
       }
@@ -702,7 +699,7 @@ export function usePedidoHandlers({
       notify.error('Error al actualizar pedido: ' + error.message)
     }
     setGuardando(false)
-  }, [pedidoEditandoRef, actualizarNotasPedido, actualizarFormaPago, actualizarEstadoPago, actualizarFechaEntrega, modales.editarPedido, setPedidoEditando, notify, setGuardando])
+  }, [pedidoEditandoRef, actualizarNotasPedido, actualizarFechaEntrega, modales.editarPedido, setPedidoEditando, notify, setGuardando])
 
   // Route optimization
   const handleAplicarOrdenOptimizado = useCallback(async (data: OrdenOptimizadoData | OrdenOptimizadoItem[]): Promise<void> => {

--- a/src/hooks/supabase/usePagos.ts
+++ b/src/hooks/supabase/usePagos.ts
@@ -3,6 +3,7 @@ import { supabase, notifyError } from './base'
 import type {
   PagoDBWithUsuario,
   PagoFormInput,
+  RegistrarPagoBatchInput,
   ResumenCuenta,
   UsePagosReturnExtended,
   ClienteDB,
@@ -34,6 +35,21 @@ export function usePagos(): UsePagosReturnExtended {
     }
   }
 
+  const fetchPagosPedido = async (pedidoId: string): Promise<PagoDBWithUsuario[]> => {
+    try {
+      const { data, error } = await supabase
+        .from('pagos')
+        .select('*, usuario:perfiles(id, nombre)')
+        .eq('pedido_id', pedidoId)
+        .order('created_at', { ascending: false })
+      if (error) throw error
+      return (data || []) as PagoDBWithUsuario[]
+    } catch (error) {
+      notifyError('Error al cargar pagos del pedido: ' + (error as Error).message)
+      return []
+    }
+  }
+
   const registrarPago = async (pago: PagoFormInput): Promise<PagoDBWithUsuario> => {
     try {
       const insertRow: Record<string, unknown> = {
@@ -57,6 +73,44 @@ export function usePagos(): UsePagosReturnExtended {
       return pagoData
     } catch (error) {
       notifyError('Error al registrar pago: ' + (error as Error).message)
+      throw error
+    }
+  }
+
+  /**
+   * Registra N pagos del mismo pedido en una sola operacion (uno por forma_pago).
+   * Util para pagos combinados: cada forma genera una row separada en `pagos`,
+   * facilitando los reportes. El trigger SQL `actualizar_estado_pago_pedido`
+   * recalcula `pedidos.monto_pagado` y `pedidos.estado_pago` automaticamente.
+   */
+  const registrarPagosBatch = async (
+    input: RegistrarPagoBatchInput
+  ): Promise<PagoDBWithUsuario[]> => {
+    try {
+      const rows = input.pagos
+        .filter(p => p.monto > 0)
+        .map(p => ({
+          cliente_id: input.clienteId,
+          pedido_id: input.pedidoId,
+          monto: p.monto,
+          forma_pago: p.formaPago,
+          fecha: input.fecha,
+          notas: input.observaciones || null,
+          usuario_id: input.usuarioId || null,
+        }))
+      if (rows.length === 0) {
+        throw new Error('No hay pagos validos para registrar')
+      }
+      const { data, error } = await supabase
+        .from('pagos')
+        .insert(rows)
+        .select('*, usuario:perfiles(id, nombre)')
+      if (error) throw error
+      const pagosData = (data || []) as PagoDBWithUsuario[]
+      setPagos(prev => [...pagosData, ...prev])
+      return pagosData
+    } catch (error) {
+      notifyError('Error al registrar pagos: ' + (error as Error).message)
       throw error
     }
   }
@@ -121,5 +175,14 @@ export function usePagos(): UsePagosReturnExtended {
     }
   }
 
-  return { pagos, loading, fetchPagosCliente, registrarPago, eliminarPago, obtenerResumenCuenta }
+  return {
+    pagos,
+    loading,
+    fetchPagosCliente,
+    fetchPagosPedido,
+    registrarPago,
+    registrarPagosBatch,
+    eliminarPago,
+    obtenerResumenCuenta,
+  }
 }

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -880,17 +880,11 @@ export const modalCompraSchema = z.object({
 export type ModalCompraFormData = z.infer<typeof modalCompraSchema>
 
 /**
- * Schema para ModalEditarPedido
+ * Schema para ModalEditarPedido.
+ * Pago se gestiona en ModalRegistrarPago (separate flow), no aqui.
  */
 export const modalEditarPedidoSchema = z.object({
-  notas: z.string().optional(),
-  formaPago: z.enum(['efectivo', 'transferencia', 'cheque', 'cuenta_corriente', 'tarjeta', 'combinado'], {
-    error: 'Forma de pago inválida'
-  }),
-  estadoPago: z.enum(['pendiente', 'pagado', 'parcial'], {
-    error: 'Estado de pago inválido'
-  }),
-  montoPagado: z.coerce.number().nonnegative({ message: 'El monto no puede ser negativo' })
+  notas: z.string().optional()
 })
 
 export type ModalEditarPedidoFormData = z.infer<typeof modalEditarPedidoSchema>

--- a/src/types/hooks.ts
+++ b/src/types/hooks.ts
@@ -665,11 +665,22 @@ export interface ResumenCuenta {
   ultimo_pago: string | null;
 }
 
+export interface RegistrarPagoBatchInput {
+  clienteId: string;
+  pedidoId: string;
+  fecha: string; // YYYY-MM-DD
+  observaciones?: string | null;
+  pagos: Array<{ formaPago: string; monto: number }>;
+  usuarioId?: string | null;
+}
+
 export interface UsePagosReturnExtended {
   pagos: PagoDBWithUsuario[];
   loading: boolean;
   fetchPagosCliente: (clienteId: string) => Promise<PagoDBWithUsuario[]>;
+  fetchPagosPedido: (pedidoId: string) => Promise<PagoDBWithUsuario[]>;
   registrarPago: (pago: PagoFormInput) => Promise<PagoDBWithUsuario>;
+  registrarPagosBatch: (input: RegistrarPagoBatchInput) => Promise<PagoDBWithUsuario[]>;
   eliminarPago: (pagoId: string) => Promise<void>;
   obtenerResumenCuenta: (clienteId: string) => Promise<ResumenCuenta | null>;
 }

--- a/src/utils/permisosPedido.test.ts
+++ b/src/utils/permisosPedido.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from 'vitest'
+import { preventistaPuedeEditar, HORA_CORTE_PREVENTISTA } from './permisosPedido'
+
+const USER_ID = 'user-1'
+const OTRO_USER = 'user-2'
+
+// Helper: construye un Date "real" en hora ARG.
+// Argentina = UTC-3 (sin DST). Para simular "hoy 14:00 ARG" => 17:00 UTC.
+function argDate(yyyymmdd: string, hh: number, mm = 0): Date {
+  const [y, m, d] = yyyymmdd.split('-').map(Number)
+  return new Date(Date.UTC(y, m - 1, d, hh + 3, mm))
+}
+
+describe('preventistaPuedeEditar', () => {
+  describe('cuando NO debe permitir edicion', () => {
+    it('niega si no hay currentUserId', () => {
+      const pedido = { usuario_id: USER_ID, created_at: argDate('2026-05-06', 10).toISOString(), estado: 'pendiente' as const }
+      const now = argDate('2026-05-06', 14)
+      expect(preventistaPuedeEditar(pedido, undefined, now)).toBe(false)
+    })
+
+    it('niega si el pedido pertenece a otro preventista', () => {
+      const pedido = { usuario_id: OTRO_USER, created_at: argDate('2026-05-06', 10).toISOString(), estado: 'pendiente' as const }
+      const now = argDate('2026-05-06', 14)
+      expect(preventistaPuedeEditar(pedido, USER_ID, now)).toBe(false)
+    })
+
+    it('niega si el pedido esta entregado', () => {
+      const pedido = { usuario_id: USER_ID, created_at: argDate('2026-05-06', 10).toISOString(), estado: 'entregado' as const }
+      const now = argDate('2026-05-06', 14)
+      expect(preventistaPuedeEditar(pedido, USER_ID, now)).toBe(false)
+    })
+
+    it('niega si el pedido esta cancelado', () => {
+      const pedido = { usuario_id: USER_ID, created_at: argDate('2026-05-06', 10).toISOString(), estado: 'cancelado' as const }
+      const now = argDate('2026-05-06', 14)
+      expect(preventistaPuedeEditar(pedido, USER_ID, now)).toBe(false)
+    })
+
+    it('niega si created_at es null/undefined', () => {
+      const pedido = { usuario_id: USER_ID, created_at: undefined, estado: 'pendiente' as const }
+      const now = argDate('2026-05-06', 14)
+      expect(preventistaPuedeEditar(pedido, USER_ID, now)).toBe(false)
+    })
+
+    it('niega si el pedido fue creado ayer (ARG)', () => {
+      const pedido = { usuario_id: USER_ID, created_at: argDate('2026-05-05', 10).toISOString(), estado: 'pendiente' as const }
+      const now = argDate('2026-05-06', 10)
+      expect(preventistaPuedeEditar(pedido, USER_ID, now)).toBe(false)
+    })
+
+    it('niega justo a las 17:00:00 ARG', () => {
+      const pedido = { usuario_id: USER_ID, created_at: argDate('2026-05-06', 10).toISOString(), estado: 'pendiente' as const }
+      const now = argDate('2026-05-06', HORA_CORTE_PREVENTISTA)
+      expect(preventistaPuedeEditar(pedido, USER_ID, now)).toBe(false)
+    })
+
+    it('niega despues de las 17:00 ARG', () => {
+      const pedido = { usuario_id: USER_ID, created_at: argDate('2026-05-06', 10).toISOString(), estado: 'pendiente' as const }
+      const now = argDate('2026-05-06', 18, 30)
+      expect(preventistaPuedeEditar(pedido, USER_ID, now)).toBe(false)
+    })
+  })
+
+  describe('cuando SI debe permitir edicion', () => {
+    it('permite si es el creador, mismo dia ARG, antes de 17:00, estado pendiente', () => {
+      const pedido = { usuario_id: USER_ID, created_at: argDate('2026-05-06', 10).toISOString(), estado: 'pendiente' as const }
+      const now = argDate('2026-05-06', 14)
+      expect(preventistaPuedeEditar(pedido, USER_ID, now)).toBe(true)
+    })
+
+    it('permite a las 16:59 ARG (justo antes del corte)', () => {
+      const pedido = { usuario_id: USER_ID, created_at: argDate('2026-05-06', 8).toISOString(), estado: 'pendiente' as const }
+      const now = argDate('2026-05-06', 16, 59)
+      expect(preventistaPuedeEditar(pedido, USER_ID, now)).toBe(true)
+    })
+
+    it('permite incluso si el estado es en_preparacion o asignado (no entregado/cancelado)', () => {
+      const pedidoBase = { usuario_id: USER_ID, created_at: argDate('2026-05-06', 10).toISOString() }
+      const now = argDate('2026-05-06', 14)
+      expect(preventistaPuedeEditar({ ...pedidoBase, estado: 'en_preparacion' }, USER_ID, now)).toBe(true)
+      expect(preventistaPuedeEditar({ ...pedidoBase, estado: 'asignado' }, USER_ID, now)).toBe(true)
+    })
+
+    it('cruce de medianoche UTC: pedido creado a las 02:00 ARG (= 05:00 UTC) sigue siendo del mismo dia ARG a las 14:00 ARG', () => {
+      // 2026-05-06 02:00 ARG === 2026-05-06 05:00 UTC
+      const pedido = { usuario_id: USER_ID, created_at: argDate('2026-05-06', 2).toISOString(), estado: 'pendiente' as const }
+      const now = argDate('2026-05-06', 14)
+      expect(preventistaPuedeEditar(pedido, USER_ID, now)).toBe(true)
+    })
+
+    it('borde TZ: pedido creado a las 23:30 ARG del 5/5 NO permite edicion el 6/5 (es del dia anterior ARG)', () => {
+      // 2026-05-05 23:30 ARG = 2026-05-06 02:30 UTC. En ARG sigue siendo 5/5.
+      const pedido = { usuario_id: USER_ID, created_at: argDate('2026-05-05', 23, 30).toISOString(), estado: 'pendiente' as const }
+      const now = argDate('2026-05-06', 10)
+      expect(preventistaPuedeEditar(pedido, USER_ID, now)).toBe(false)
+    })
+  })
+})

--- a/src/utils/permisosPedido.ts
+++ b/src/utils/permisosPedido.ts
@@ -1,0 +1,47 @@
+/**
+ * Permisos de edicion de pedidos por preventista.
+ *
+ * Regla: el preventista creador puede editar items, cantidades y fecha de entrega
+ * de su pedido propio mientras siga siendo el mismo dia (zona ARG) y la hora
+ * actual ARG sea estrictamente menor a HORA_CORTE_PREVENTISTA.
+ * Despues del corte, solo admin/encargado pueden editar.
+ *
+ * No permite editar precios — eso se hace cumplir tambien en el RPC SQL.
+ */
+
+import { fechaLocalISO } from './formatters'
+import type { EstadoPedido } from '@/types'
+
+export const HORA_CORTE_PREVENTISTA = 17
+
+interface PedidoLike {
+  usuario_id?: string | null
+  created_at?: string | null | undefined
+  estado?: EstadoPedido | string | null
+}
+
+function horaArg(date: Date): number {
+  const hh = new Intl.DateTimeFormat('en-GB', {
+    hour: '2-digit',
+    hour12: false,
+    timeZone: 'America/Argentina/Buenos_Aires',
+  }).format(date)
+  return parseInt(hh, 10)
+}
+
+export function preventistaPuedeEditar(
+  pedido: PedidoLike,
+  currentUserId: string | undefined,
+  now: Date = new Date(),
+): boolean {
+  if (!currentUserId) return false
+  if (!pedido.usuario_id || pedido.usuario_id !== currentUserId) return false
+  if (pedido.estado === 'entregado' || pedido.estado === 'cancelado') return false
+  if (!pedido.created_at) return false
+
+  const hoyArg = fechaLocalISO(now)
+  const creadoArg = fechaLocalISO(new Date(pedido.created_at))
+  if (creadoArg !== hoyArg) return false
+
+  return horaArg(now) < HORA_CORTE_PREVENTISTA
+}


### PR DESCRIPTION
## Context

Dos pedidos de usuarios reales atacados juntos porque comparten superficie (modal de edición + dropdown de tres puntos):

1. **Preventistas no pueden corregir un pedido recién tomado.** Hoy solo pueden editar observaciones; el cliente llama 10 minutos después y deben pedirle a admin.
2. **No se puede registrar el pago de un pedido entregado.** El botón vivía dentro del modal de edición, que está bloqueado para entregados (correcto), pero esto deja sin forma de asentar pagos posteriores a la entrega.

## Cambios

### Parte 1 — Preventista puede editar su pedido del día hasta las 17:00 ARG

- **Helper nuevo** `src/utils/permisosPedido.ts` con `preventistaPuedeEditar(pedido, currentUserId, now)`. Valida creador, mismo día ARG y hora ARG < 17:00. **13 tests unitarios** en `permisosPedido.test.ts` cubren edge cases (cruce de medianoche UTC, 16:59 vs 17:00, otro preventista, pedido cancelado, etc.).
- **`PedidoActions.tsx`** ahora expone "Editar Pedido" al preventista creador dentro de la ventana; "Editar Observaciones" sigue siendo el fallback fuera de ventana.
- **`PedidoCard.tsx`** lee `useAuthData().user.id` y lo pasa al dropdown.
- **`ModalEditarPedido.tsx`** acepta flags `canEditItems` / `canEditPrices` / `canEditFechaEntrega` (con fallback a `isAdmin`). Los preventistas dentro de ventana ven los precios pero no los pueden editar.
- **Migration 033** (`033_actualizar_pedido_items_preventista_ventana.sql`, ya aplicada al proyecto Supabase `hmuchlzmuqqxcldbzkgc`):
  - Suma `'encargado'` a la lista de roles autorizados (estaba ausente — bug pre-existente).
  - Agrega validación específica para preventistas: solo el creador, mismo día ARG, hora ARG < 17:00, y `precio_unitario` debe coincidir con `productos.precio` actual (no puede inventar precios).

### Parte 2 — Modal de pago independiente

- **Nuevo componente** `ModalPagoPedido.tsx`:
  - Header con Total / Ya pagado / Saldo pendiente.
  - Lista de pagos previos con botón anular (solo admin/encargado).
  - Form dinámico: N líneas `{ formaPago, monto }` con botón "Agregar forma de pago".
  - Bloquea sobrepago (validación visual + botón submit deshabilitado).
  - Modo `modoEntregaTransportista`: muestra botones "Entregar sin pago" / "Entregar y registrar pago".
- **`usePagos`** extendido con `registrarPagosBatch()` (insert N rows en una sola operación) y `fetchPagosPedido()`.
- **`PedidoActions.tsx`** agrega acción "Registrar Pago" para admin/encargado cuando el pedido no está cancelado ni totalmente pagado.
- **Flujo del transportista**: `handleMarcarEntregado` ahora chequea `estado_pago`. Si está pagado → confirm tradicional. Si no → abre `ModalPagoPedido` en modo entrega y permite confirmar entrega + cobro en un solo gesto. Orden: primero entrega, luego pago, para que un pago fallido no deje un pedido sin entregar.
- **Sección de pago removida del `ModalEditarPedido`**: ~200 líneas eliminadas (`pagoCombinado`, `pagosCombinados`, `formaPago`, `estadoPago`, `montoPagado`, `aplicarPorcentaje`, etc.). El payload de `onSave` ya no incluye campos de pago. El parsing frágil de `[Pago combinado: ...]` desde notas se reemplaza por una row por forma_pago en tabla `pagos`.
- **Trigger SQL existente** `actualizar_estado_pago_pedido` recalcula `pedidos.estado_pago` y `monto_pagado` automáticamente cuando se insertan/eliminan pagos — no se necesita updates manuales.

### Decisiones tomadas con el usuario

- Ventana 17:00: solo pedidos creados HOY hora ARG, no de días previos.
- Solo el creador del pedido puede editar (no cualquier preventista).
- Alcance preventista: cantidades, eliminar, agregar items, fecha de entrega. **No precios.**
- Modal de pago removido completamente del modal de edición (una sola fuente de verdad).
- Permisos pago: admin, encargado, transportista (este último vía flujo de Marcar Entregado).
- Pago combinado: una row por forma de pago en `pagos`.
- Anular pago: solo admin/encargado.
- Sobrepago: bloqueado.

## Test plan

- [x] `npm run typecheck` ✅
- [x] `npm run lint` ✅
- [x] `npx vitest run` → **595 tests passing** (incluye 13 nuevos en `permisosPedido.test.ts`, eliminados 13 obsoletos de la sección de pago removida)
- [ ] Smoke manual: preventista edita su pedido a las 14:00 → modificar cantidad, agregar item, cambiar fecha entrega → guardar → reabrir y verificar.
- [ ] Smoke manual: preventista intenta editar a las 17:30 → dropdown solo muestra "Editar Observaciones".
- [ ] Smoke manual: admin/encargado → tres puntos → "Registrar Pago" en pedido entregado no pagado → registrar pago combinado → verificar `estado_pago='pagado'` y dos rows en `pagos`.
- [ ] Smoke manual: anular pago previo como admin → estado se recalcula.
- [ ] Smoke manual: transportista marca entregado de pedido con saldo → modal de pago abre → "Entregar y registrar pago" → ambas operaciones OK.
- [ ] Smoke manual: transportista "Entregar sin pago" → solo cambio de estado.
- [ ] Smoke manual: sobrepago bloqueado.

🤖 Generated with [Claude Code](https://claude.com/claude-code)