### PR TITLE
fix(pagos+pedidos): admin registra pago + preventista edita con mayorista

### DIFF
--- a/migrations/034_preventista_precio_lte_base.sql
+++ b/migrations/034_preventista_precio_lte_base.sql
@@ -1,0 +1,299 @@
+-- ============================================================================
+-- 034 — actualizar_pedido_items: preventista permite mayorista (precio <= base)
+-- ============================================================================
+-- Cambio respecto a 033:
+--   La validacion estricta `precio_unitario = productos.precio` rechazaba
+--   ediciones legitimas del preventista cuando el cliente tiene descuento
+--   mayorista (precio < base) o cuando productos.precio cambio despues de la
+--   creacion del pedido. Resultado: preventistas no podian guardar ningun
+--   cambio, ni siquiera agregar productos nuevos al pedido.
+--
+--   Ahora se permite cualquier `precio_unitario <= productos.precio`. Esto
+--   cubre tanto el precio base como descuentos mayoristas (que por contrato
+--   son siempre <= base; ver src/utils/precioMayorista.ts: "Nunca aumentar
+--   el precio"). Sigue rechazando intentos de subir el precio (>) y deja
+--   intacto el resto del flujo (ventana 17:00, creador, sin cambios sobre
+--   pedidos entregados, etc.).
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION public.actualizar_pedido_items(
+  p_pedido_id bigint, p_items_nuevos jsonb, p_usuario_id uuid
+) RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $function$
+DECLARE
+  v_sucursal BIGINT := current_sucursal_id();
+  v_item_nuevo JSONB;
+  v_producto_id INT;
+  v_cantidad_original INT;
+  v_cantidad_nueva INT;
+  v_diferencia INT;
+  v_es_bonificacion BOOLEAN;
+  v_stock_actual INT;
+  v_producto_nombre TEXT;
+  v_total_nuevo DECIMAL := 0;
+  v_total_neto_nuevo DECIMAL := 0;
+  v_total_iva_nuevo DECIMAL := 0;
+  v_total_anterior DECIMAL;
+  v_errores TEXT[] := '{}';
+  v_items_originales JSONB;
+  v_user_role TEXT;
+  v_neto_unitario DECIMAL;
+  v_iva_unitario DECIMAL;
+  v_imp_internos_unitario DECIMAL;
+  v_porcentaje_iva DECIMAL;
+  v_precio_unitario DECIMAL;
+  v_promocion_id BIGINT;
+  v_regalo_mueve_stock BOOLEAN;
+  v_descripcion_regalo TEXT;
+  v_bonif RECORD;
+  v_promo RECORD;
+  v_usos_pendientes_actual INT;
+  v_bloques_completos INT;
+  v_ajustar_usos INT;
+  v_ajustar_stock INT;
+  v_stock_ajuste_anterior INT;
+  v_stock_ajuste_nuevo INT;
+  v_ajuste_producto_nombre TEXT;
+  v_merma_id BIGINT;
+  v_pedido_creator UUID;
+  v_pedido_created_at TIMESTAMPTZ;
+  v_hora_corte CONSTANT INT := 17;
+  v_precio_actual DECIMAL;
+BEGIN
+  IF v_sucursal IS NULL THEN
+    RETURN jsonb_build_object('success', false, 'errores', ARRAY['No se pudo determinar la sucursal activa']);
+  END IF;
+  IF p_usuario_id IS DISTINCT FROM auth.uid() THEN
+    RETURN jsonb_build_object('success', false, 'errores', ARRAY['ID de usuario no coincide con la sesion autenticada']);
+  END IF;
+  SELECT rol INTO v_user_role FROM perfiles WHERE id = p_usuario_id;
+  IF v_user_role IS NULL OR v_user_role NOT IN ('admin', 'encargado', 'preventista') THEN
+    RETURN jsonb_build_object('success', false, 'errores', ARRAY['No autorizado']);
+  END IF;
+
+  SELECT total, usuario_id, created_at
+    INTO v_total_anterior, v_pedido_creator, v_pedido_created_at
+    FROM pedidos
+   WHERE id = p_pedido_id AND sucursal_id = v_sucursal;
+  IF NOT FOUND THEN
+    RETURN jsonb_build_object('success', false, 'errores', ARRAY['Pedido no encontrado']);
+  END IF;
+
+  IF EXISTS (SELECT 1 FROM pedidos WHERE id = p_pedido_id AND sucursal_id = v_sucursal AND estado = 'entregado') THEN
+    RETURN jsonb_build_object('success', false, 'errores', ARRAY['No se puede editar un pedido ya entregado']);
+  END IF;
+
+  -- Validaciones especificas para preventista.
+  IF v_user_role = 'preventista' THEN
+    IF v_pedido_creator IS DISTINCT FROM p_usuario_id THEN
+      RETURN jsonb_build_object('success', false, 'errores',
+        ARRAY['Solo el preventista que creo el pedido puede editarlo']);
+    END IF;
+
+    IF (v_pedido_created_at AT TIME ZONE 'America/Argentina/Buenos_Aires')::date
+         IS DISTINCT FROM (now() AT TIME ZONE 'America/Argentina/Buenos_Aires')::date
+       OR EXTRACT(HOUR FROM now() AT TIME ZONE 'America/Argentina/Buenos_Aires') >= v_hora_corte
+    THEN
+      RETURN jsonb_build_object('success', false, 'errores',
+        ARRAY['Como preventista solo puede editar pedidos del dia actual antes de las 17:00 (ARG)']);
+    END IF;
+
+    -- No puede SUBIR precios. Acepta precio base o cualquier descuento
+    -- mayorista (que por construccion es <= productos.precio).
+    FOR v_item_nuevo IN SELECT * FROM jsonb_array_elements(p_items_nuevos) LOOP
+      IF COALESCE((v_item_nuevo->>'es_bonificacion')::BOOLEAN, false) = true THEN
+        CONTINUE;
+      END IF;
+      v_producto_id := (v_item_nuevo->>'producto_id')::INT;
+      v_precio_unitario := (v_item_nuevo->>'precio_unitario')::DECIMAL;
+      SELECT precio INTO v_precio_actual
+        FROM productos WHERE id = v_producto_id AND sucursal_id = v_sucursal;
+      IF v_precio_actual IS NULL THEN
+        RETURN jsonb_build_object('success', false, 'errores',
+          ARRAY['Producto ID ' || v_producto_id || ' no encontrado']);
+      END IF;
+      IF v_precio_unitario IS NULL OR v_precio_unitario > v_precio_actual THEN
+        RETURN jsonb_build_object('success', false, 'errores',
+          ARRAY['Como preventista no puede aumentar precios (producto ID ' || v_producto_id || ')']);
+      END IF;
+    END LOOP;
+  END IF;
+
+  SELECT jsonb_agg(jsonb_build_object(
+    'producto_id', producto_id, 'cantidad', cantidad,
+    'precio_unitario', precio_unitario, 'es_bonificacion', COALESCE(es_bonificacion, false)))
+  INTO v_items_originales FROM pedido_items WHERE pedido_id = p_pedido_id AND sucursal_id = v_sucursal;
+
+  FOR v_item_nuevo IN SELECT * FROM jsonb_array_elements(p_items_nuevos) LOOP
+    v_producto_id := (v_item_nuevo->>'producto_id')::INT;
+    v_cantidad_nueva := (v_item_nuevo->>'cantidad')::INT;
+    v_es_bonificacion := COALESCE((v_item_nuevo->>'es_bonificacion')::BOOLEAN, false);
+    v_promocion_id := (v_item_nuevo->>'promocion_id')::BIGINT;
+
+    IF v_es_bonificacion THEN
+      IF v_promocion_id IS NULL THEN CONTINUE; END IF;
+      SELECT regalo_mueve_stock INTO v_regalo_mueve_stock FROM promociones WHERE id = v_promocion_id AND sucursal_id = v_sucursal;
+      IF NOT COALESCE(v_regalo_mueve_stock, FALSE) THEN CONTINUE; END IF;
+    END IF;
+
+    SELECT COALESCE(cantidad, 0) INTO v_cantidad_original
+    FROM pedido_items
+    WHERE pedido_id = p_pedido_id AND producto_id = v_producto_id
+      AND COALESCE(es_bonificacion, false) = v_es_bonificacion
+      AND sucursal_id = v_sucursal;
+
+    v_diferencia := v_cantidad_nueva - COALESCE(v_cantidad_original, 0);
+
+    IF v_diferencia > 0 THEN
+      SELECT stock, nombre INTO v_stock_actual, v_producto_nombre
+      FROM productos WHERE id = v_producto_id AND sucursal_id = v_sucursal FOR UPDATE;
+
+      IF v_stock_actual IS NULL THEN
+        v_errores := array_append(v_errores, 'Producto ID ' || v_producto_id || ' no encontrado');
+      ELSIF v_stock_actual < v_diferencia THEN
+        v_errores := array_append(v_errores, COALESCE(v_producto_nombre, 'Producto ' || v_producto_id)
+          || ': stock insuficiente (disponible: ' || v_stock_actual || ', adicional: ' || v_diferencia || ')');
+      END IF;
+    END IF;
+  END LOOP;
+
+  IF array_length(v_errores, 1) > 0 THEN
+    RETURN jsonb_build_object('success', false, 'errores', to_jsonb(v_errores));
+  END IF;
+
+  UPDATE productos p
+  SET stock = p.stock + pi.cantidad
+  FROM pedido_items pi
+  WHERE pi.pedido_id = p_pedido_id AND pi.sucursal_id = v_sucursal
+    AND COALESCE(pi.es_bonificacion, false) = false
+    AND p.id = pi.producto_id AND p.sucursal_id = v_sucursal;
+
+  UPDATE productos p
+  SET stock = p.stock + pi.cantidad
+  FROM pedido_items pi
+  JOIN promociones pr ON pr.id = pi.promocion_id AND pr.sucursal_id = pi.sucursal_id
+  WHERE pi.pedido_id = p_pedido_id AND pi.sucursal_id = v_sucursal
+    AND COALESCE(pi.es_bonificacion, false) = true
+    AND pi.promocion_id IS NOT NULL
+    AND COALESCE(pr.regalo_mueve_stock, FALSE) = TRUE
+    AND p.id = pi.producto_id AND p.sucursal_id = v_sucursal;
+
+  FOR v_bonif IN
+    SELECT promocion_id, SUM(cantidad)::INT AS total_cantidad
+      FROM pedido_items
+     WHERE pedido_id = p_pedido_id AND sucursal_id = v_sucursal
+       AND COALESCE(es_bonificacion, false) = true AND promocion_id IS NOT NULL
+     GROUP BY promocion_id
+  LOOP
+    PERFORM public.revertir_bloques_auto_ajuste(
+      v_bonif.promocion_id, v_bonif.total_cantidad, v_sucursal,
+      p_usuario_id, 'Edicion pedido #' || p_pedido_id
+    );
+  END LOOP;
+
+  DELETE FROM pedido_items WHERE pedido_id = p_pedido_id AND sucursal_id = v_sucursal;
+
+  FOR v_item_nuevo IN SELECT * FROM jsonb_array_elements(p_items_nuevos) LOOP
+    v_producto_id := (v_item_nuevo->>'producto_id')::INT;
+    v_cantidad_nueva := (v_item_nuevo->>'cantidad')::INT;
+    v_precio_unitario := (v_item_nuevo->>'precio_unitario')::DECIMAL;
+    v_es_bonificacion := COALESCE((v_item_nuevo->>'es_bonificacion')::BOOLEAN, false);
+    v_promocion_id := (v_item_nuevo->>'promocion_id')::BIGINT;
+    v_neto_unitario := (v_item_nuevo->>'neto_unitario')::DECIMAL;
+    v_iva_unitario := COALESCE((v_item_nuevo->>'iva_unitario')::DECIMAL, 0);
+    v_imp_internos_unitario := COALESCE((v_item_nuevo->>'impuestos_internos_unitario')::DECIMAL, 0);
+    v_porcentaje_iva := COALESCE((v_item_nuevo->>'porcentaje_iva')::DECIMAL, 0);
+
+    v_descripcion_regalo := NULL;
+    IF v_es_bonificacion AND v_promocion_id IS NOT NULL THEN
+      SELECT descripcion_regalo INTO v_descripcion_regalo FROM promociones WHERE id = v_promocion_id AND sucursal_id = v_sucursal;
+    END IF;
+
+    INSERT INTO pedido_items (
+      pedido_id, producto_id, cantidad, precio_unitario, subtotal,
+      es_bonificacion, promocion_id,
+      neto_unitario, iva_unitario, impuestos_internos_unitario, porcentaje_iva,
+      sucursal_id, descripcion_regalo
+    ) VALUES (
+      p_pedido_id, v_producto_id, v_cantidad_nueva, v_precio_unitario,
+      v_cantidad_nueva * v_precio_unitario,
+      v_es_bonificacion, v_promocion_id,
+      v_neto_unitario, v_iva_unitario, v_imp_internos_unitario, v_porcentaje_iva,
+      v_sucursal, v_descripcion_regalo
+    );
+
+    IF NOT v_es_bonificacion THEN
+      UPDATE productos SET stock = stock - v_cantidad_nueva WHERE id = v_producto_id AND sucursal_id = v_sucursal;
+      v_total_nuevo := v_total_nuevo + (v_cantidad_nueva * v_precio_unitario);
+      v_total_neto_nuevo := v_total_neto_nuevo + (v_cantidad_nueva * COALESCE(v_neto_unitario, v_precio_unitario));
+      v_total_iva_nuevo := v_total_iva_nuevo + (v_cantidad_nueva * v_iva_unitario);
+    ELSIF v_promocion_id IS NOT NULL THEN
+      SELECT regalo_mueve_stock INTO v_regalo_mueve_stock FROM promociones WHERE id = v_promocion_id AND sucursal_id = v_sucursal;
+      IF COALESCE(v_regalo_mueve_stock, FALSE) THEN
+        UPDATE productos SET stock = stock - v_cantidad_nueva WHERE id = v_producto_id AND sucursal_id = v_sucursal;
+      END IF;
+      UPDATE promociones SET usos_pendientes = usos_pendientes + v_cantidad_nueva WHERE id = v_promocion_id AND sucursal_id = v_sucursal;
+
+      SELECT id, nombre, ajuste_automatico, ajuste_producto_id, unidades_por_bloque,
+             stock_por_bloque, usos_pendientes
+      INTO v_promo
+      FROM promociones WHERE id = v_promocion_id AND sucursal_id = v_sucursal FOR UPDATE;
+
+      IF v_promo.ajuste_automatico AND v_promo.ajuste_producto_id IS NOT NULL
+         AND COALESCE(v_promo.unidades_por_bloque, 0) > 0 AND COALESCE(v_promo.stock_por_bloque, 0) > 0 THEN
+        v_usos_pendientes_actual := v_promo.usos_pendientes;
+        v_bloques_completos := v_usos_pendientes_actual / v_promo.unidades_por_bloque;
+        IF v_bloques_completos > 0 THEN
+          v_ajustar_usos := v_bloques_completos * v_promo.unidades_por_bloque;
+          v_ajustar_stock := v_bloques_completos * v_promo.stock_por_bloque;
+
+          SELECT stock, nombre INTO v_stock_ajuste_anterior, v_ajuste_producto_nombre
+          FROM productos WHERE id = v_promo.ajuste_producto_id AND sucursal_id = v_sucursal FOR UPDATE;
+
+          IF v_stock_ajuste_anterior IS NULL THEN
+            RAISE EXCEPTION 'Auto-ajuste: producto destino no encontrado (promo %)', v_promocion_id;
+          END IF;
+          IF v_stock_ajuste_anterior < v_ajustar_stock THEN
+            RAISE EXCEPTION 'Auto-ajuste: stock insuficiente en % (disponible: %, requerido: %)',
+              v_ajuste_producto_nombre, v_stock_ajuste_anterior, v_ajustar_stock;
+          END IF;
+
+          v_stock_ajuste_nuevo := v_stock_ajuste_anterior - v_ajustar_stock;
+
+          INSERT INTO mermas_stock (producto_id, cantidad, motivo, observaciones, stock_anterior, stock_nuevo, usuario_id, sucursal_id)
+          VALUES (v_promo.ajuste_producto_id, v_ajustar_stock, 'promociones',
+            'Auto-ajuste (Promo: ' || v_promo.nombre || ', Pedido #' || p_pedido_id || ', edicion)',
+            v_stock_ajuste_anterior, v_stock_ajuste_nuevo, p_usuario_id, v_sucursal)
+          RETURNING id INTO v_merma_id;
+
+          UPDATE productos SET stock = v_stock_ajuste_nuevo, updated_at = NOW()
+          WHERE id = v_promo.ajuste_producto_id AND sucursal_id = v_sucursal;
+
+          INSERT INTO promo_ajustes (promocion_id, usos_ajustados, unidades_ajustadas, producto_id, merma_id, usuario_id, observaciones, sucursal_id)
+          VALUES (v_promocion_id, v_ajustar_usos, v_ajustar_stock, v_promo.ajuste_producto_id,
+            v_merma_id, p_usuario_id, 'Auto-ajuste por edicion pedido #' || p_pedido_id, v_sucursal);
+
+          UPDATE promociones SET usos_pendientes = GREATEST(usos_pendientes - v_ajustar_usos, 0)
+          WHERE id = v_promocion_id AND sucursal_id = v_sucursal;
+        END IF;
+      END IF;
+    END IF;
+  END LOOP;
+
+  UPDATE pedidos SET total = v_total_nuevo, total_neto = v_total_neto_nuevo, total_iva = v_total_iva_nuevo, updated_at = NOW()
+  WHERE id = p_pedido_id AND sucursal_id = v_sucursal;
+
+  INSERT INTO pedido_historial (pedido_id, usuario_id, campo_modificado, valor_anterior, valor_nuevo, sucursal_id)
+  VALUES (p_pedido_id, p_usuario_id, 'items', COALESCE(v_items_originales::TEXT, '[]'), p_items_nuevos::TEXT, v_sucursal);
+
+  IF v_total_anterior IS DISTINCT FROM v_total_nuevo THEN
+    INSERT INTO pedido_historial (pedido_id, usuario_id, campo_modificado, valor_anterior, valor_nuevo, sucursal_id)
+    VALUES (p_pedido_id, p_usuario_id, 'total', v_total_anterior::TEXT, v_total_nuevo::TEXT, v_sucursal);
+  END IF;
+
+  RETURN jsonb_build_object('success', true, 'total_nuevo', v_total_nuevo);
+END;
+$function$;

--- a/src/hooks/supabase/usePagos.test.ts
+++ b/src/hooks/supabase/usePagos.test.ts
@@ -28,6 +28,10 @@ vi.mock('./base', () => ({
   notifyError: vi.fn()
 }))
 
+vi.mock('../../contexts/SucursalContext', () => ({
+  useSucursal: () => ({ currentSucursalId: 1 })
+}))
+
 import { supabase, notifyError } from './base'
 
 describe('usePagos', () => {

--- a/src/hooks/supabase/usePagos.ts
+++ b/src/hooks/supabase/usePagos.ts
@@ -1,5 +1,6 @@
 import { useState } from 'react'
 import { supabase, notifyError } from './base'
+import { useSucursal } from '../../contexts/SucursalContext'
 import type {
   PagoDBWithUsuario,
   PagoFormInput,
@@ -12,6 +13,7 @@ import type {
 } from '../../types'
 
 export function usePagos(): UsePagosReturnExtended {
+  const { currentSucursalId } = useSucursal()
   const [pagos, setPagos] = useState<PagoDBWithUsuario[]>([])
   const [loading, setLoading] = useState<boolean>(false)
 
@@ -52,6 +54,9 @@ export function usePagos(): UsePagosReturnExtended {
 
   const registrarPago = async (pago: PagoFormInput): Promise<PagoDBWithUsuario> => {
     try {
+      if (currentSucursalId == null) {
+        throw new Error('No hay sucursal activa. Recargá la página e intentá de nuevo.')
+      }
       const insertRow: Record<string, unknown> = {
         cliente_id: pago.clienteId,
         pedido_id: pago.pedidoId || null,
@@ -59,7 +64,8 @@ export function usePagos(): UsePagosReturnExtended {
         forma_pago: pago.formaPago || 'efectivo',
         referencia: pago.referencia || null,
         notas: pago.notas || null,
-        usuario_id: pago.usuarioId || null
+        usuario_id: pago.usuarioId || null,
+        sucursal_id: currentSucursalId
       }
       // fecha (YYYY-MM-DD) se pasa solo si el caller la especificó; si no,
       // la BD usa CURRENT_DATE (default de la columna pagos.fecha).
@@ -87,6 +93,9 @@ export function usePagos(): UsePagosReturnExtended {
     input: RegistrarPagoBatchInput
   ): Promise<PagoDBWithUsuario[]> => {
     try {
+      if (currentSucursalId == null) {
+        throw new Error('No hay sucursal activa. Recargá la página e intentá de nuevo.')
+      }
       const rows = input.pagos
         .filter(p => p.monto > 0)
         .map(p => ({
@@ -97,6 +106,7 @@ export function usePagos(): UsePagosReturnExtended {
           fecha: input.fecha,
           notas: input.observaciones || null,
           usuario_id: input.usuarioId || null,
+          sucursal_id: currentSucursalId,
         }))
       if (rows.length === 0) {
         throw new Error('No hay pagos validos para registrar')


### PR DESCRIPTION
Dos bugs urgentes reportados por usuarios reales que bloqueaban operaciones
en produccion:

1) Admin no podia registrar pagos - "new row violates row-level security
   policy for table pagos". usePagos.registrarPago/registrarPagosBatch no
   incluian sucursal_id en el insert; la columna es NOT NULL y la RLS
   `mt_pagos_insert` exige `sucursal_id = current_sucursal_id()`. Como
   queda NULL, NULL = X es NULL (no true) y la RLS rechaza la fila.
   Fix: tomar currentSucursalId via useSucursal() y agregarlo al payload,
   mismo patron que useMermas.registrarMerma.

2) Preventista no podia editar pedidos - "Como preventista no puede
   modificar precios". La validacion en migration 033 comparaba
   `precio_unitario IS DISTINCT FROM productos.precio` (igualdad estricta),
   lo que rechaza descuentos mayoristas legitimos (mayorista siempre <=
   base por contrato; ver src/utils/precioMayorista.ts) y tambien
   pedidos con productos cuyo precio cambio despues de la creacion.
   Fix (migration 034): permitir `precio_unitario <= productos.precio`.
   Sigue rechazando intentos de subir precios.