### PR TITLE
fix(pagos): refresh post-pago + auto-completar diferencia + Vale Blanco

### DIFF
--- a/migrations/035_recalcular_monto_pagado_pedido.sql
+++ b/migrations/035_recalcular_monto_pagado_pedido.sql
@@ -1,0 +1,116 @@
+-- ============================================================================
+-- 035 — recalcular pedidos.monto_pagado al insertar/anular pagos
+-- ============================================================================
+-- Bug historico: al registrar pagos en el modal "Registrar Pago — Pedido #N"
+-- (ModalPagoPedido), las filas se insertan en `pagos` pero `pedidos.monto_pagado`
+-- nunca se actualiza, por lo que el trigger BEFORE en `pedidos`
+-- (`actualizar_estado_pago_pedido`) jamas recalcula `estado_pago`. Resultado:
+-- la card sigue mostrando "Pago Pendiente" aunque el pedido este pagado.
+--
+-- Causa: el unico trigger AFTER INSERT/DELETE en `pagos`
+-- (`trigger_actualizar_saldo_pago`) apunta a `actualizar_saldo_cliente()`, que
+-- esta neutralizada en 000_baseline.sql (solo devuelve OLD/NEW; ver comentario
+-- "NEUTRALIZED: saldo_cuenta is managed exclusively by actualizar_saldo_pedido").
+-- Cuando se neutralizo, nadie cubrio el gap de actualizar `pedidos.monto_pagado`.
+--
+-- Fix: nuevo trigger AFTER en `pagos` que recalcula `pedidos.monto_pagado` como
+-- SUM(pagos.monto WHERE pedido_id = X). El trigger BEFORE existente en
+-- `pedidos` se encarga de recalcular `estado_pago` en cascada.
+--
+-- Incluye backfill para los pedidos rotos en produccion (ej: #1540 con
+-- monto_pagado=0 y dos pagos sumando $24.700).
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION public.recalcular_monto_pagado_pedido()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $$
+BEGIN
+  -- Se recalcula para el(los) pedido(s) afectado(s) por la operacion.
+  -- Skip cuando pedido_id IS NULL (caso "pago a cuenta general del cliente").
+
+  IF TG_OP = 'INSERT' THEN
+    IF NEW.pedido_id IS NOT NULL THEN
+      UPDATE pedidos
+         SET monto_pagado = COALESCE((
+           SELECT SUM(monto) FROM pagos WHERE pedido_id = NEW.pedido_id
+         ), 0)
+       WHERE id = NEW.pedido_id;
+    END IF;
+    RETURN NEW;
+
+  ELSIF TG_OP = 'DELETE' THEN
+    IF OLD.pedido_id IS NOT NULL THEN
+      UPDATE pedidos
+         SET monto_pagado = COALESCE((
+           SELECT SUM(monto) FROM pagos WHERE pedido_id = OLD.pedido_id
+         ), 0)
+       WHERE id = OLD.pedido_id;
+    END IF;
+    RETURN OLD;
+
+  ELSIF TG_OP = 'UPDATE' THEN
+    -- Si cambio el pedido_id, hay que recalcular tanto el anterior como el nuevo.
+    IF OLD.pedido_id IS DISTINCT FROM NEW.pedido_id THEN
+      IF OLD.pedido_id IS NOT NULL THEN
+        UPDATE pedidos
+           SET monto_pagado = COALESCE((
+             SELECT SUM(monto) FROM pagos WHERE pedido_id = OLD.pedido_id
+           ), 0)
+         WHERE id = OLD.pedido_id;
+      END IF;
+      IF NEW.pedido_id IS NOT NULL THEN
+        UPDATE pedidos
+           SET monto_pagado = COALESCE((
+             SELECT SUM(monto) FROM pagos WHERE pedido_id = NEW.pedido_id
+           ), 0)
+         WHERE id = NEW.pedido_id;
+      END IF;
+    ELSIF NEW.pedido_id IS NOT NULL THEN
+      -- Mismo pedido pero cambio el monto.
+      UPDATE pedidos
+         SET monto_pagado = COALESCE((
+           SELECT SUM(monto) FROM pagos WHERE pedido_id = NEW.pedido_id
+         ), 0)
+       WHERE id = NEW.pedido_id;
+    END IF;
+    RETURN NEW;
+  END IF;
+
+  RETURN NULL;
+END;
+$$;
+
+ALTER FUNCTION public.recalcular_monto_pagado_pedido() OWNER TO postgres;
+
+GRANT ALL ON FUNCTION public.recalcular_monto_pagado_pedido() TO anon;
+GRANT ALL ON FUNCTION public.recalcular_monto_pagado_pedido() TO authenticated;
+GRANT ALL ON FUNCTION public.recalcular_monto_pagado_pedido() TO service_role;
+
+-- Trigger AFTER: necesita ver la fila ya insertada/borrada al hacer el SUM.
+-- Se incluye UPDATE OF monto, pedido_id por completitud (la app no edita pagos
+-- in-place hoy, pero deja la red de seguridad si en el futuro se hace).
+CREATE OR REPLACE TRIGGER trigger_recalcular_monto_pagado_pedido
+  AFTER INSERT OR UPDATE OF monto, pedido_id OR DELETE
+  ON public.pagos
+  FOR EACH ROW
+  EXECUTE FUNCTION public.recalcular_monto_pagado_pedido();
+
+-- ============================================================================
+-- Backfill: corregir pedidos donde monto_pagado quedo desincronizado.
+-- El trigger BEFORE en pedidos (trigger_actualizar_estado_pago) recalcula
+-- estado_pago automaticamente cuando se updatea monto_pagado.
+-- ============================================================================
+
+UPDATE pedidos p
+   SET monto_pagado = sub.suma
+  FROM (
+    SELECT pedido_id, SUM(monto) AS suma
+      FROM pagos
+     WHERE pedido_id IS NOT NULL
+     GROUP BY pedido_id
+  ) sub
+ WHERE p.id = sub.pedido_id
+   AND COALESCE(p.monto_pagado, 0) <> sub.suma;

--- a/migrations/036_rendiciones_vale_blanco.sql
+++ b/migrations/036_rendiciones_vale_blanco.sql
@@ -1,0 +1,153 @@
+-- ============================================================================
+-- 036 — agregar columna total_vale_blanco a la RPC obtener_resumen_rendiciones
+-- ============================================================================
+-- Suma la nueva forma de pago "vale_blanco" como su propio bucket en el
+-- desglose por dia/transportista, alineado con el comportamiento de las
+-- otras formas (total_efectivo, total_transferencia, etc).
+--
+-- DROP FUNCTION (no CREATE OR REPLACE) porque el RETURNS TABLE cambia.
+-- ============================================================================
+
+DROP FUNCTION IF EXISTS public.obtener_resumen_rendiciones(date, date, uuid);
+
+CREATE OR REPLACE FUNCTION public.obtener_resumen_rendiciones(
+  p_fecha_desde date DEFAULT ((CURRENT_DATE - '30 days'::interval))::date,
+  p_fecha_hasta date DEFAULT CURRENT_DATE,
+  p_transportista_id uuid DEFAULT NULL::uuid
+)
+RETURNS TABLE(
+  fecha date,
+  transportista_id uuid,
+  transportista_nombre text,
+  total_efectivo numeric,
+  total_transferencia numeric,
+  total_cheque numeric,
+  total_cuenta_corriente numeric,
+  total_tarjeta numeric,
+  total_vale_blanco numeric,
+  total_otros numeric,
+  total_general numeric,
+  cantidad_pedidos bigint,
+  total_entregado numeric,
+  total_gastos numeric,
+  cantidad_gastos bigint,
+  estado text,
+  observaciones text,
+  controlada boolean,
+  controlada_at timestamp with time zone,
+  controlada_por_nombre text,
+  resuelta_at timestamp with time zone,
+  resuelta_por_nombre text
+)
+LANGUAGE plpgsql
+STABLE SECURITY DEFINER
+SET search_path TO 'public'
+AS $function$
+DECLARE
+  v_sucursal_id BIGINT;
+BEGIN
+  v_sucursal_id := current_sucursal_id();
+  IF v_sucursal_id IS NULL THEN
+    RAISE EXCEPTION 'Sucursal no seleccionada';
+  END IF;
+  IF NOT es_encargado_o_admin() THEN
+    RAISE EXCEPTION 'No autorizado';
+  END IF;
+
+  RETURN QUERY
+  WITH pagos_agg AS (
+    SELECT
+      pd.transportista_id AS t_id,
+      pg.fecha AS f,
+      SUM(CASE WHEN pg.forma_pago = 'efectivo' THEN pg.monto ELSE 0 END)::numeric AS tot_ef,
+      SUM(CASE WHEN pg.forma_pago = 'transferencia' THEN pg.monto ELSE 0 END)::numeric AS tot_tr,
+      SUM(CASE WHEN pg.forma_pago = 'cheque' THEN pg.monto ELSE 0 END)::numeric AS tot_ch,
+      SUM(CASE WHEN pg.forma_pago = 'cuenta_corriente' THEN pg.monto ELSE 0 END)::numeric AS tot_cc,
+      SUM(CASE WHEN pg.forma_pago = 'tarjeta' THEN pg.monto ELSE 0 END)::numeric AS tot_tj,
+      SUM(CASE WHEN pg.forma_pago = 'vale_blanco' THEN pg.monto ELSE 0 END)::numeric AS tot_vb,
+      SUM(CASE WHEN pg.forma_pago NOT IN ('efectivo','transferencia','cheque','cuenta_corriente','tarjeta','vale_blanco')
+                OR pg.forma_pago IS NULL THEN pg.monto ELSE 0 END)::numeric AS tot_ot,
+      SUM(pg.monto)::numeric AS tot_gen
+    FROM pagos pg
+    JOIN pedidos pd ON pd.id = pg.pedido_id
+    WHERE pg.fecha BETWEEN p_fecha_desde AND p_fecha_hasta
+      AND pd.sucursal_id = v_sucursal_id
+      AND pd.transportista_id IS NOT NULL
+      AND (p_transportista_id IS NULL OR pd.transportista_id = p_transportista_id)
+    GROUP BY pd.transportista_id, pg.fecha
+  ),
+  entregas_agg AS (
+    SELECT
+      pd.transportista_id AS t_id,
+      pd.fecha_entrega::date AS f,
+      SUM(pd.total)::numeric AS tot_entregado,
+      COUNT(*)::bigint AS cant
+    FROM pedidos pd
+    WHERE pd.estado = 'entregado'
+      AND pd.fecha_entrega IS NOT NULL
+      AND pd.transportista_id IS NOT NULL
+      AND pd.fecha_entrega::date BETWEEN p_fecha_desde AND p_fecha_hasta
+      AND pd.sucursal_id = v_sucursal_id
+      AND (p_transportista_id IS NULL OR pd.transportista_id = p_transportista_id)
+    GROUP BY pd.transportista_id, pd.fecha_entrega::date
+  ),
+  gastos_agg AS (
+    SELECT
+      rg.transportista_id AS t_id,
+      rg.fecha AS f,
+      SUM(rg.monto)::numeric AS tot_g,
+      COUNT(*)::bigint AS cant_g
+    FROM rendicion_gastos rg
+    WHERE rg.fecha BETWEEN p_fecha_desde AND p_fecha_hasta
+      AND rg.sucursal_id = v_sucursal_id
+      AND (p_transportista_id IS NULL OR rg.transportista_id = p_transportista_id)
+    GROUP BY rg.transportista_id, rg.fecha
+  ),
+  fechas_activas AS (
+    SELECT t_id, f FROM pagos_agg
+    UNION
+    SELECT t_id, f FROM entregas_agg
+  )
+  SELECT
+    fa.f::date AS fecha,
+    fa.t_id AS transportista_id,
+    tr.nombre::text AS transportista_nombre,
+    COALESCE(pagos_agg.tot_ef, 0)::numeric AS total_efectivo,
+    COALESCE(pagos_agg.tot_tr, 0)::numeric AS total_transferencia,
+    COALESCE(pagos_agg.tot_ch, 0)::numeric AS total_cheque,
+    COALESCE(pagos_agg.tot_cc, 0)::numeric AS total_cuenta_corriente,
+    COALESCE(pagos_agg.tot_tj, 0)::numeric AS total_tarjeta,
+    COALESCE(pagos_agg.tot_vb, 0)::numeric AS total_vale_blanco,
+    COALESCE(pagos_agg.tot_ot, 0)::numeric AS total_otros,
+    COALESCE(pagos_agg.tot_gen, 0)::numeric AS total_general,
+    COALESCE(entregas_agg.cant, 0)::bigint AS cantidad_pedidos,
+    COALESCE(entregas_agg.tot_entregado, 0)::numeric AS total_entregado,
+    COALESCE(gastos_agg.tot_g, 0)::numeric AS total_gastos,
+    COALESCE(gastos_agg.cant_g, 0)::bigint AS cantidad_gastos,
+    COALESCE(rc.estado, 'pendiente')::text AS estado,
+    rc.observaciones,
+    (rc.id IS NOT NULL AND COALESCE(rc.estado, 'pendiente') IN ('confirmada','resuelta')) AS controlada,
+    rc.controlada_at,
+    cp.nombre::text AS controlada_por_nombre,
+    rc.resuelta_at,
+    rp.nombre::text AS resuelta_por_nombre
+  FROM fechas_activas fa
+  JOIN perfiles tr ON tr.id = fa.t_id
+  LEFT JOIN pagos_agg ON pagos_agg.t_id = fa.t_id AND pagos_agg.f = fa.f
+  LEFT JOIN entregas_agg ON entregas_agg.t_id = fa.t_id AND entregas_agg.f = fa.f
+  LEFT JOIN gastos_agg ON gastos_agg.t_id = fa.t_id AND gastos_agg.f = fa.f
+  LEFT JOIN rendiciones_control rc
+    ON rc.fecha = fa.f
+   AND rc.transportista_id = fa.t_id
+   AND rc.sucursal_id = v_sucursal_id
+  LEFT JOIN perfiles cp ON cp.id = rc.controlada_por
+  LEFT JOIN perfiles rp ON rp.id = rc.resuelta_por
+  ORDER BY fa.f DESC, tr.nombre ASC;
+END;
+$function$;
+
+ALTER FUNCTION public.obtener_resumen_rendiciones(date, date, uuid) OWNER TO postgres;
+
+GRANT ALL ON FUNCTION public.obtener_resumen_rendiciones(date, date, uuid) TO anon;
+GRANT ALL ON FUNCTION public.obtener_resumen_rendiciones(date, date, uuid) TO authenticated;
+GRANT ALL ON FUNCTION public.obtener_resumen_rendiciones(date, date, uuid) TO service_role;

--- a/src/components/modals/ModalPagoPedido.tsx
+++ b/src/components/modals/ModalPagoPedido.tsx
@@ -57,6 +57,7 @@ const FORMAS_PAGO_OPCIONES: Array<{ value: string; label: string }> = [
   { value: 'cheque', label: 'Cheque' },
   { value: 'cuenta_corriente', label: 'Cuenta Corriente' },
   { value: 'tarjeta', label: 'Tarjeta' },
+  { value: 'vale_blanco', label: 'Vale Blanco' },
 ]
 
 const ModalPagoPedido = memo(function ModalPagoPedido({
@@ -100,7 +101,13 @@ const ModalPagoPedido = memo(function ModalPagoPedido({
   const algunMontoValido = lineas.some(l => parsePrecio(l.monto) > 0)
 
   const handleAgregarLinea = (): void => {
-    setLineas(prev => [...prev, { formaPago: 'transferencia', monto: '' }])
+    // Auto-sugerir el saldo restante: cliente pidio que el monto del nuevo
+    // renglon se prellene con (saldo - sumaActual). Sigue siendo editable.
+    const restante = Math.max(0, saldoPendiente - totalIngresado)
+    setLineas(prev => [
+      ...prev,
+      { formaPago: 'transferencia', monto: restante > 0 ? restante.toFixed(2) : '' },
+    ])
   }
 
   const handleQuitarLinea = (index: number): void => {

--- a/src/components/modals/ModalRegistrarPago.tsx
+++ b/src/components/modals/ModalRegistrarPago.tsx
@@ -19,7 +19,8 @@ const FORMAS_PAGO: FormaPagoOption[] = [
   { value: 'transferencia', label: 'Transferencia' },
   { value: 'cheque', label: 'Cheque' },
   { value: 'tarjeta', label: 'Tarjeta' },
-  { value: 'cuenta_corriente', label: 'Cuenta Corriente' }
+  { value: 'cuenta_corriente', label: 'Cuenta Corriente' },
+  { value: 'vale_blanco', label: 'Vale Blanco' }
 ]
 
 interface PagoData {

--- a/src/components/vistas/VistaRendiciones.tsx
+++ b/src/components/vistas/VistaRendiciones.tsx
@@ -78,6 +78,7 @@ function ResumenCard({ resumen, onCerrar, onResolver }: ResumenCardProps): React
       cheque: resumen.total_cheque,
       cuenta_corriente: resumen.total_cuenta_corriente,
       tarjeta: resumen.total_tarjeta,
+      vale_blanco: resumen.total_vale_blanco,
       otros: resumen.total_otros
     }
     return FORMAS_PAGO
@@ -246,6 +247,7 @@ function ResumenCard({ resumen, onCerrar, onResolver }: ResumenCardProps): React
                 <div><span className="text-gray-500">Cheque:</span> <span className="font-medium">{formatMoney(resumen.total_cheque)}</span></div>
                 <div><span className="text-gray-500">Cuenta Cte.:</span> <span className="font-medium">{formatMoney(resumen.total_cuenta_corriente)}</span></div>
                 <div><span className="text-gray-500">Tarjeta:</span> <span className="font-medium">{formatMoney(resumen.total_tarjeta)}</span></div>
+                <div><span className="text-gray-500">Vale Blanco:</span> <span className="font-medium">{formatMoney(resumen.total_vale_blanco)}</span></div>
                 <div><span className="text-gray-500">Otros:</span> <span className="font-medium">{formatMoney(resumen.total_otros)}</span></div>
               </div>
             </div>

--- a/src/constants/formasPago.ts
+++ b/src/constants/formasPago.ts
@@ -1,11 +1,11 @@
 /**
  * Formas de pago soportadas por la app.
  *
- * Sincronizado con la RPC `obtener_resumen_rendiciones` (migraciones 003+): las
- * columnas `total_efectivo`, `total_transferencia`, `total_cheque`,
- * `total_cuenta_corriente`, `total_tarjeta` y `total_otros` se calculan según
- * estas claves. Cualquier forma de pago que se guarde en `pagos.forma_pago`
- * fuera de este set cae en el bucket `otros`.
+ * Sincronizado con la RPC `obtener_resumen_rendiciones` (migraciones 003+ y 036):
+ * las columnas `total_efectivo`, `total_transferencia`, `total_cheque`,
+ * `total_cuenta_corriente`, `total_tarjeta`, `total_vale_blanco` y `total_otros`
+ * se calculan según estas claves. Cualquier forma de pago que se guarde en
+ * `pagos.forma_pago` fuera de este set cae en el bucket `otros`.
  */
 
 import type { FormaPago } from '../types'
@@ -26,6 +26,7 @@ export const FORMAS_PAGO: readonly FormaPagoMeta[] = [
   { value: 'cheque', label: 'Cheque', short: 'Ch.', color: 'purple' },
   { value: 'cuenta_corriente', label: 'Cuenta corriente', short: 'Cta. Cte.', color: 'amber' },
   { value: 'tarjeta', label: 'Tarjeta', short: 'Tj.', color: 'indigo' },
+  { value: 'vale_blanco', label: 'Vale Blanco', short: 'V.B.', color: 'rose' },
   { value: 'otros', label: 'Otros', short: 'Otros', color: 'slate' }
 ] as const
 

--- a/src/hooks/supabase/usePagos.ts
+++ b/src/hooks/supabase/usePagos.ts
@@ -86,8 +86,10 @@ export function usePagos(): UsePagosReturnExtended {
   /**
    * Registra N pagos del mismo pedido en una sola operacion (uno por forma_pago).
    * Util para pagos combinados: cada forma genera una row separada en `pagos`,
-   * facilitando los reportes. El trigger SQL `actualizar_estado_pago_pedido`
-   * recalcula `pedidos.monto_pagado` y `pedidos.estado_pago` automaticamente.
+   * facilitando los reportes. El trigger SQL `recalcular_monto_pagado_pedido`
+   * (migration 035) recalcula `pedidos.monto_pagado` al insertar/anular pagos,
+   * y a su vez el trigger BEFORE `actualizar_estado_pago_pedido` recalcula
+   * `pedidos.estado_pago` en cascada.
    */
   const registrarPagosBatch = async (
     input: RegistrarPagoBatchInput

--- a/src/hooks/supabase/useRendiciones.ts
+++ b/src/hooks/supabase/useRendiciones.ts
@@ -46,6 +46,7 @@ export function useRendiciones(): UseRendicionesReturn {
         total_cheque: Number(r.total_cheque) || 0,
         total_cuenta_corriente: Number(r.total_cuenta_corriente) || 0,
         total_tarjeta: Number(r.total_tarjeta) || 0,
+        total_vale_blanco: Number(r.total_vale_blanco) || 0,
         total_otros: Number(r.total_otros) || 0,
         total_general: Number(r.total_general) || 0,
         cantidad_pedidos: Number(r.cantidad_pedidos) || 0,

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -224,7 +224,7 @@ export const pedidoSchema = z.object({
     .array(itemPedidoSchema)
     .min(1, { message: 'Debe agregar al menos un producto' }),
 
-  forma_pago: z.enum(['efectivo', 'transferencia', 'cheque', 'cuenta_corriente', 'tarjeta'], {
+  forma_pago: z.enum(['efectivo', 'transferencia', 'cheque', 'cuenta_corriente', 'tarjeta', 'vale_blanco'], {
     error: 'Forma de pago inválida'
   }),
 
@@ -251,7 +251,7 @@ export const pedidoSchema = z.object({
 export type PedidoFormData = z.infer<typeof pedidoSchema>
 
 /** Valid payment methods for orders */
-export type FormaPagoPedido = 'efectivo' | 'transferencia' | 'cheque' | 'cuenta_corriente' | 'tarjeta'
+export type FormaPagoPedido = 'efectivo' | 'transferencia' | 'cheque' | 'cuenta_corriente' | 'tarjeta' | 'vale_blanco'
 
 // ============================================
 // SCHEMAS DE PAGO
@@ -262,7 +262,7 @@ export const pagoSchema = z.object({
 
   monto: montoPositivoSchema,
 
-  forma_pago: z.enum(['efectivo', 'transferencia', 'cheque', 'tarjeta'], {
+  forma_pago: z.enum(['efectivo', 'transferencia', 'cheque', 'tarjeta', 'vale_blanco'], {
     error: 'Forma de pago inválida'
   }),
 
@@ -288,7 +288,7 @@ export const pagoSchema = z.object({
 export type PagoFormData = z.infer<typeof pagoSchema>
 
 /** Valid payment methods */
-export type FormaPago = 'efectivo' | 'transferencia' | 'cheque' | 'tarjeta'
+export type FormaPago = 'efectivo' | 'transferencia' | 'cheque' | 'tarjeta' | 'vale_blanco'
 
 // ============================================
 // SCHEMAS DE COMPRA
@@ -641,7 +641,7 @@ export const modalPagoSchema = z.object({
     .number({ error: 'El monto debe ser un número' })
     .positive({ message: 'El monto debe ser mayor a $0' }),
 
-  formaPago: z.enum(['efectivo', 'transferencia', 'cheque', 'tarjeta', 'cuenta_corriente'], {
+  formaPago: z.enum(['efectivo', 'transferencia', 'cheque', 'tarjeta', 'cuenta_corriente', 'vale_blanco'], {
     error: 'Forma de pago inválida'
   }),
 
@@ -662,7 +662,7 @@ export const modalPagoSchema = z.object({
 export type ModalPagoFormData = z.infer<typeof modalPagoSchema>
 
 /** Valid payment methods for modal */
-export type ModalFormaPago = 'efectivo' | 'transferencia' | 'cheque' | 'tarjeta' | 'cuenta_corriente'
+export type ModalFormaPago = 'efectivo' | 'transferencia' | 'cheque' | 'tarjeta' | 'cuenta_corriente' | 'vale_blanco'
 
 /**
  * Schema para ModalMermaStock

--- a/src/types/hooks.ts
+++ b/src/types/hooks.ts
@@ -1163,6 +1163,7 @@ export interface ResumenRendicionDiaria {
   total_cheque: number;
   total_cuenta_corriente: number;
   total_tarjeta: number;
+  total_vale_blanco: number;
   total_otros: number;
   /** Total cobrado ese día (suma de pagos) */
   total_general: number;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -105,6 +105,7 @@ export type FormaPago =
   | 'tarjeta'
   | 'cuenta_corriente'
   | 'cheque'
+  | 'vale_blanco'
   | 'otros';
 
 export type EstadoPago = 'pendiente' | 'parcial' | 'pagado';

--- a/src/utils/formatters.ts
+++ b/src/utils/formatters.ts
@@ -349,6 +349,7 @@ export const getFormaPagoLabel = (forma: FormaPago | string | null | undefined):
   forma === 'cheque' ? 'Cheque' :
   forma === 'cuenta_corriente' ? 'Cta. Cte.' :
   forma === 'tarjeta' ? 'Tarjeta' :
+  forma === 'vale_blanco' ? 'Vale Blanco' :
   forma || '';
 
 // ============================================


### PR DESCRIPTION
## Summary

Tres cambios pedidos por Virginia (preventista Tucumán) sobre el modal "Registrar Pago — Pedido #N" (`ModalPagoPedido`).

### 1. Bug crítico de producción: card no se actualiza tras registrar pago

**Causa:** Ningún trigger actualizaba `pedidos.monto_pagado` al insertar/anular pagos. El único trigger AFTER en `pagos` (`trigger_actualizar_saldo_pago`) apunta a `actualizar_saldo_cliente()` que está neutralizada (solo retorna `NEW`/`OLD`). El trigger BEFORE en `pedidos` (`actualizar_estado_pago_pedido`) jamás se disparaba, por lo que `estado_pago` quedaba en `'pendiente'` para siempre. Verificado en producción: pedido #1540 tenía $24.700 en `pagos` pero `monto_pagado=0, estado_pago='pendiente'`.

**Fix (migration 035):** Nuevo trigger AFTER INSERT/UPDATE/DELETE en `pagos` que recalcula `pedidos.monto_pagado = SUM(pagos.monto WHERE pedido_id = ...)`. El trigger BEFORE existente recalcula `estado_pago` en cascada. Incluye **backfill** que dejó 0 pedidos desincronizados (pedido #1540 ahora con `monto_pagado=24700, estado_pago='pagado'`).

### 2. Auto-completar diferencia en pago combinado

`handleAgregarLinea` en `ModalPagoPedido.tsx` ahora pre-carga el monto del nuevo renglón con `max(0, saldoPendiente - totalIngresado)`. Editable después. Si saldo=0, queda vacío.

### 3. Nueva forma de pago "Vale Blanco"

End-to-end: tipos (`FormaPago`, `ResumenRendicionDiaria`), schemas Zod (skip compras por `compras_forma_pago_check` en DB), constantes, modales (`ModalPagoPedido` + `ModalRegistrarPago`), formatters, RPC `obtener_resumen_rendiciones` (migration 036 agrega columna `total_vale_blanco` propia, no cae en "Otros"), `useRendiciones`, `VistaRendiciones` (compact grid + breakdown completo).

## Migraciones aplicadas en Supabase

- ✅ `035_recalcular_monto_pagado_pedido` (incluye backfill)
- ✅ `036_rendiciones_vale_blanco`

## Test Plan

- [x] `npm run typecheck` ✅
- [x] `npm run lint` ✅
- [x] `npm run test` 595/595 ✅
- [ ] Browser: registrar pago combinado en un pedido → modal cierra → la card pasa de "Pago Pendiente" a "Pagado" sin recargar.
- [ ] Browser: pago combinado, ingresar $X en Efectivo y click "Agregar forma de pago" → el nuevo renglón aparece con (saldo - X) prellenado y editable.
- [ ] Browser: anular pago de un pedido → `pedidos.estado_pago` revierte y la card se actualiza.
- [ ] Browser: el dropdown "Forma de pago" muestra "Vale Blanco" (en `ModalPagoPedido` y `ModalRegistrarPago`).
- [ ] Browser: registrar un pago con Vale Blanco → en `VistaRendiciones` aparece la celda "Vale Blanco" con el monto correcto (no en "Otros").

🤖 Generated with [Claude Code](https://claude.com/claude-code)