### PR TITLE
fix(productos): mostrar error de validacion que bloqueaba Guardar

### DIFF
--- a/migrations/037_etiqueta_bulto_default_null.sql
+++ b/migrations/037_etiqueta_bulto_default_null.sql
@@ -1,0 +1,33 @@
+-- Migration 037: etiqueta_bulto sin default 'FARDO' + backfill huérfanos
+--
+-- Contexto:
+-- La migración 031 creó productos.etiqueta_bulto con DEFAULT 'FARDO'. Como
+-- consecuencia, todo producto creado o tocado después de esa migración quedó
+-- con etiqueta_bulto='FARDO' aunque nunca se configuraran fardos. La validación
+-- cruzada del schema Zod (modalProductoSchema.refine) exigía
+-- unidades_de_venta_por_fardo cuando había etiqueta, lo que dejó al 94%
+-- del catálogo (152 de 161 productos en producción) sin poder guardarse.
+--
+-- Modelo correcto: la etiqueta es accesoria al fardo. Si un producto no tiene
+-- unidades_de_venta_por_fardo configurado, no tiene concepto de fardo y la
+-- etiqueta debe ser NULL. El refine del schema Zod se elimina en este mismo
+-- cambio (src/lib/schemas.ts).
+--
+-- Idempotente: el UPDATE filtra por la condición a normalizar; correr dos veces
+-- no produce cambios adicionales. El DROP DEFAULT también es idempotente.
+
+-- 1) Quitar el default 'FARDO' para que los nuevos productos arranquen con NULL.
+ALTER TABLE productos
+  ALTER COLUMN etiqueta_bulto DROP DEFAULT;
+
+-- 2) Backfill: limpiar etiqueta_bulto en productos que nunca configuraron
+--    unidades. El 'FARDO' que tienen vino del DEFAULT, no de una decisión
+--    del usuario, así que no se pierde información.
+UPDATE productos
+SET etiqueta_bulto = NULL
+WHERE unidades_de_venta_por_fardo IS NULL
+  AND etiqueta_bulto IS NOT NULL;
+
+-- 3) Documentar la nueva semántica.
+COMMENT ON COLUMN productos.etiqueta_bulto IS
+  'Etiqueta del bulto (FARDO, CAJA, PACK, BULTO). NULL si el producto no usa fardos. Solo se persiste con valor cuando unidades_de_venta_por_fardo IS NOT NULL.';

--- a/src/components/modals/ModalProducto.tsx
+++ b/src/components/modals/ModalProducto.tsx
@@ -173,7 +173,14 @@ const ModalProducto = memo(function ModalProducto({ producto, categorias, provee
         ? nuevaCategoria.trim()
         : form.categoria;
       onSave({ ...form, categoria: categoriaFinal, id: producto?.id });
+      return;
     }
+    // Validación falló: scrollear al primer mensaje de error inline para que sea visible
+    // (el body del modal tiene overflow-y-auto y el error puede quedar fuera del viewport).
+    requestAnimationFrame(() => {
+      const firstErrorMsg = document.querySelector<HTMLElement>('p.text-red-500');
+      firstErrorMsg?.scrollIntoView({ behavior: 'smooth', block: 'center' });
+    });
   };
 
   const inputClass = (field: string): string => `w-full px-3 py-2 border rounded-lg ${errores[field] ? 'border-red-500 bg-red-50' : ''}`;
@@ -306,28 +313,42 @@ const ModalProducto = memo(function ModalProducto({ producto, categorias, provee
                   ...form,
                   unidades_de_venta_por_fardo: val === '' ? undefined : Number(val)
                 })
+                if (intentoGuardar && errores.unidades_de_venta_por_fardo) {
+                  clearFieldError('unidades_de_venta_por_fardo');
+                }
               }}
-              className="w-full px-3 py-2 border rounded-lg"
+              className={inputClass('unidades_de_venta_por_fardo')}
               placeholder="ej. 2"
             />
             <p className="text-xs text-gray-500 mt-1">
               Cuántas unidades de venta hacen 1 fardo. Si 1 unidad = medio fardo, poné 2.
             </p>
+            {errores.unidades_de_venta_por_fardo && (
+              <p className="text-red-500 text-xs mt-1">{errores.unidades_de_venta_por_fardo}</p>
+            )}
           </div>
           <div>
             <label className="block text-sm font-medium mb-1">Etiqueta del bulto</label>
             <input
               type="text"
               value={form.etiqueta_bulto ?? ''}
-              onChange={(e: ChangeEvent<HTMLInputElement>) => setForm({
-                ...form,
-                etiqueta_bulto: e.target.value === '' ? undefined : e.target.value.toUpperCase()
-              })}
-              className="w-full px-3 py-2 border rounded-lg uppercase"
+              onChange={(e: ChangeEvent<HTMLInputElement>) => {
+                setForm({
+                  ...form,
+                  etiqueta_bulto: e.target.value === '' ? undefined : e.target.value.toUpperCase()
+                })
+                if (intentoGuardar && errores.etiqueta_bulto) {
+                  clearFieldError('etiqueta_bulto');
+                }
+              }}
+              className={`${inputClass('etiqueta_bulto')} uppercase`}
               placeholder="FARDO"
               maxLength={20}
             />
             <p className="text-xs text-gray-500 mt-1">FARDO, CAJA, PACK, BULTO...</p>
+            {errores.etiqueta_bulto && (
+              <p className="text-red-500 text-xs mt-1">{errores.etiqueta_bulto}</p>
+            )}
           </div>
         </div>
 

--- a/src/components/modals/ModalProducto.tsx
+++ b/src/components/modals/ModalProducto.tsx
@@ -167,12 +167,18 @@ const ModalProducto = memo(function ModalProducto({ producto, categorias, provee
   };
 
   const handleSubmit = (): void => {
-    const result = validate(form);
+    // La etiqueta es accesoria al fardo: sin unidades configuradas no tiene
+    // sentido persistirla. Normalizar acá hace de defensa en profundidad por
+    // si la UI dejó pasar un valor (ej. autocompletado del browser).
+    const formNormalizado: ProductoFormData = form.unidades_de_venta_por_fardo
+      ? form
+      : { ...form, etiqueta_bulto: undefined };
+    const result = validate(formNormalizado);
     if (result.success) {
       const categoriaFinal = mostrarNuevaCategoria && nuevaCategoria.trim()
         ? nuevaCategoria.trim()
-        : form.categoria;
-      onSave({ ...form, categoria: categoriaFinal, id: producto?.id });
+        : formNormalizado.categoria;
+      onSave({ ...formNormalizado, categoria: categoriaFinal, id: producto?.id });
       return;
     }
     // Validación falló: scrollear al primer mensaje de error inline para que sea visible
@@ -298,6 +304,8 @@ const ModalProducto = memo(function ModalProducto({ producto, categorias, provee
         )}
 
         {/* Bulto / Fardo: cuántas unidades de venta hacen un fardo y cómo lo llamamos */}
+        {/* La etiqueta es accesoria al fardo: si no hay unidades configuradas, */}
+        {/* la etiqueta queda deshabilitada y no se persiste. */}
         <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
           <div>
             <label className="block text-sm font-medium mb-1">Unidades por bulto/fardo</label>
@@ -309,9 +317,13 @@ const ModalProducto = memo(function ModalProducto({ producto, categorias, provee
               value={form.unidades_de_venta_por_fardo ?? ''}
               onChange={(e: ChangeEvent<HTMLInputElement>) => {
                 const val = e.target.value
+                const nuevasUnidades = val === '' ? undefined : Number(val)
                 setForm({
                   ...form,
-                  unidades_de_venta_por_fardo: val === '' ? undefined : Number(val)
+                  unidades_de_venta_por_fardo: nuevasUnidades,
+                  // Si dejan unidades vacío, también limpiar la etiqueta — la etiqueta
+                  // sola no tiene sentido y antes generaba un guardado bloqueado.
+                  ...(nuevasUnidades ? {} : { etiqueta_bulto: undefined })
                 })
                 if (intentoGuardar && errores.unidades_de_venta_por_fardo) {
                   clearFieldError('unidades_de_venta_por_fardo');
@@ -331,7 +343,7 @@ const ModalProducto = memo(function ModalProducto({ producto, categorias, provee
             <label className="block text-sm font-medium mb-1">Etiqueta del bulto</label>
             <input
               type="text"
-              value={form.etiqueta_bulto ?? ''}
+              value={form.unidades_de_venta_por_fardo ? (form.etiqueta_bulto ?? '') : ''}
               onChange={(e: ChangeEvent<HTMLInputElement>) => {
                 setForm({
                   ...form,
@@ -341,8 +353,9 @@ const ModalProducto = memo(function ModalProducto({ producto, categorias, provee
                   clearFieldError('etiqueta_bulto');
                 }
               }}
-              className={`${inputClass('etiqueta_bulto')} uppercase`}
-              placeholder="FARDO"
+              disabled={!form.unidades_de_venta_por_fardo}
+              className={`${inputClass('etiqueta_bulto')} uppercase disabled:bg-gray-100 disabled:cursor-not-allowed`}
+              placeholder={form.unidades_de_venta_por_fardo ? 'FARDO' : 'Configura unidades primero'}
               maxLength={20}
             />
             <p className="text-xs text-gray-500 mt-1">FARDO, CAJA, PACK, BULTO...</p>

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -619,16 +619,14 @@ export const modalProductoSchema = z.object({
     .optional(),
 
   // Etiqueta del bulto: FARDO, CAJA, PACK, BULTO...
-  // Default a 'FARDO' en el form; si queda vacío se persiste como null.
+  // Solo se persiste con valor cuando hay unidades_de_venta_por_fardo.
+  // Sin unidades, el form normaliza la etiqueta a undefined antes de mandar.
   etiqueta_bulto: z
     .string()
     .trim()
     .max(20, { message: 'Máximo 20 caracteres' })
     .optional()
-}).refine(
-  d => !d.etiqueta_bulto || d.unidades_de_venta_por_fardo,
-  { message: 'Si configurás una etiqueta de bulto, también poné las unidades por fardo', path: ['unidades_de_venta_por_fardo'] }
-)
+})
 
 /** Inferred type for ModalProducto schema */
 export type ModalProductoFormData = z.infer<typeof modalProductoSchema>


### PR DESCRIPTION
## Summary

Fix del modal **Editar Producto** + corrección sistémica de la causa raíz que afectaba al 94% del catálogo.

### Causa raíz extendida
La migración 031 creó `productos.etiqueta_bulto` con `DEFAULT 'FARDO'`. Eso sembró ese valor en **152 de 161 productos** (medido en prod) sin que el usuario lo configurara. El `.refine()` agregado en [`2da7e85`](https://github.com/AgustinReiden/distribuidora-app/commit/2da7e85) exigía `unidades_de_venta_por_fardo` cuando había `etiqueta_bulto` → todos esos productos quedaban imposibles de guardar desde el modal, sin error visible.

### Cambios

**`migrations/037_etiqueta_bulto_default_null.sql`** — aplicada a producción (ManaosApp):
- `DROP DEFAULT 'FARDO'` en `productos.etiqueta_bulto` para que los nuevos productos arranquen NULL.
- Backfill: `UPDATE productos SET etiqueta_bulto = NULL WHERE unidades_de_venta_por_fardo IS NULL AND etiqueta_bulto IS NOT NULL` → 152 filas normalizadas. Idempotente.
- Comentario actualizado.

**`src/lib/schemas.ts`**:
- Removido el `.refine()` cruzado del `modalProductoSchema`. La etiqueta es decorativa: el form garantiza que no se persista huérfana.

**`src/components/modals/ModalProducto.tsx`**:
- Input de etiqueta **deshabilitado** y visualmente vacío cuando no hay `unidades_de_venta_por_fardo`. Placeholder cambia a *"Configura unidades primero"* como pista.
- `onChange` de unidades: al vaciarse, también limpia `etiqueta_bulto` automáticamente (consistente con el modelo).
- `handleSubmit` normaliza `etiqueta_bulto: undefined` cuando no hay unidades — defensa en profundidad ante autofill del browser.
- Errores inline visibles para `unidades_de_venta_por_fardo` y `etiqueta_bulto` (del fix original `50a9dad`).
- Scroll al primer error cuando la validación falla (cubre futuros refines que apunten a campos sin error rendering).

### Comportamiento resultante
- Si un producto no tiene unidades por fardo → la etiqueta queda en NULL y no se expone en exports (recibo, hoja de ruta). [`formatAclaracionBulto`](src/lib/pdf/utils/formatBulto.ts:18) ya retornaba null sin unidades, así que las exportaciones no cambian.
- Si el usuario configura unidades → recién ahí el input de etiqueta se habilita y permite escribir el nombre del bulto (FARDO, CAJA, etc.).

## Test plan

- [ ] Editar el producto que reportó el bug (`AZUCAR X 1KG X 10`): el campo "Etiqueta del bulto" aparece vacío y deshabilitado, "Unidades por bulto/fardo" también vacío. **Guardar funciona** y persiste sin error.
- [ ] Cambiar el precio de cualquier producto sin tocar campos de fardo y guardar → debe funcionar (antes fallaba en silencio para el 94% del catálogo).
- [ ] Configurar fardo: tipear `10` en "Unidades por bulto/fardo" → el campo "Etiqueta del bulto" se habilita; placeholder pasa a `FARDO`. Tipear `CAJA` y guardar → persiste ambos campos.
- [ ] Borrar las unidades de un producto que tenía fardo configurado → la etiqueta se borra automáticamente al vaciar unidades. Guardar → ambos campos quedan NULL en DB.
- [ ] Verificar exportación: `formatAclaracionBulto` no imprime sufijo cuando unidades es NULL (recibo de pedido / hoja de ruta limpios).
- [x] Migración 037 aplicada a `hmuchlzmuqqxcldbzkgc` (ManaosApp). 0 productos huérfanos restantes.
- [x] `tsc --noEmit` y `eslint` limpios. 595 tests verdes (corridos por husky en pre-commit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)