### PR TITLE
feat(backups): workflow diario de backup encriptado a Drive

### DIFF
--- a/.github/workflows/backup.yml
+++ b/.github/workflows/backup.yml
@@ -1,0 +1,233 @@
+name: Backup Supabase DB
+
+on:
+  schedule:
+    # 06:00 UTC = 03:00 ART (Argentina, baja carga operativa)
+    - cron: '0 6 * * *'
+  workflow_dispatch:
+    inputs:
+      tier:
+        description: 'Forzar tier de retencion (auto detecta por fecha si se deja en auto)'
+        required: false
+        default: 'auto'
+        type: choice
+        options:
+          - auto
+          - daily
+          - weekly
+          - monthly
+
+permissions:
+  contents: read
+
+concurrency:
+  group: supabase-backup
+  cancel-in-progress: false
+
+jobs:
+  backup:
+    name: pg_dump + encrypt + upload
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    env:
+      BACKUP_DIR: /tmp/supabase-backup
+      RCLONE_REMOTE: gdrive:Backups/distribuidora-app
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install postgresql-client-17 and rclone
+        run: |
+          set -euo pipefail
+          # PostgreSQL 17 client (matchea la version de produccion en Supabase)
+          sudo install -d /usr/share/postgresql-common/pgdg
+          sudo curl -fsSL -o /usr/share/postgresql-common/pgdg/apt.postgresql.org.asc \
+            https://www.postgresql.org/media/keys/ACCC4CF8.asc
+          echo "deb [signed-by=/usr/share/postgresql-common/pgdg/apt.postgresql.org.asc] https://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" \
+            | sudo tee /etc/apt/sources.list.d/pgdg.list >/dev/null
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq postgresql-client-17
+          # rclone (oficial)
+          curl -fsSL https://rclone.org/install.sh | sudo bash
+          pg_dump --version
+          rclone --version | head -n1
+
+      - name: Configure rclone from secret
+        env:
+          RCLONE_CONFIG_BASE64: ${{ secrets.RCLONE_CONFIG_BASE64 }}
+        run: |
+          set -euo pipefail
+          if [ -z "${RCLONE_CONFIG_BASE64:-}" ]; then
+            echo "ERROR: RCLONE_CONFIG_BASE64 no esta configurado en secrets"
+            exit 1
+          fi
+          mkdir -p "$HOME/.config/rclone"
+          echo "$RCLONE_CONFIG_BASE64" | base64 -d > "$HOME/.config/rclone/rclone.conf"
+          chmod 600 "$HOME/.config/rclone/rclone.conf"
+          # Sanity: verificar que el remote existe
+          rclone listremotes | grep -q '^gdrive:$' || { echo "ERROR: remote gdrive: no encontrado en rclone.conf"; exit 1; }
+
+      - name: pg_dump
+        id: dump
+        env:
+          SUPABASE_DB_URL: ${{ secrets.SUPABASE_DB_URL }}
+        run: |
+          set -euo pipefail
+          if [ -z "${SUPABASE_DB_URL:-}" ]; then
+            echo "ERROR: SUPABASE_DB_URL no esta configurado en secrets"
+            exit 1
+          fi
+          mkdir -p "$BACKUP_DIR"
+          DUMP_FILE="$BACKUP_DIR/dump.sql"
+          # -Fc = custom format (comprimido + restaurable selectivamente)
+          # --no-owner / --no-acl = portable a otro proyecto Supabase
+          pg_dump \
+            --format=custom \
+            --no-owner \
+            --no-acl \
+            --verbose \
+            --file="$DUMP_FILE" \
+            "$SUPABASE_DB_URL" 2>"$BACKUP_DIR/pg_dump.log" || {
+              echo "pg_dump fallo. Ultimas lineas del log:"
+              tail -n 30 "$BACKUP_DIR/pg_dump.log"
+              exit 1
+            }
+          SIZE_BYTES=$(stat -c%s "$DUMP_FILE")
+          echo "Dump size: $SIZE_BYTES bytes"
+          # Sanity: dump < 100KB casi seguro indica falla parcial
+          if [ "$SIZE_BYTES" -lt 102400 ]; then
+            echo "ERROR: dump menor a 100KB ($SIZE_BYTES bytes), probablemente fallo"
+            tail -n 30 "$BACKUP_DIR/pg_dump.log"
+            exit 1
+          fi
+          echo "size_bytes=$SIZE_BYTES" >> "$GITHUB_OUTPUT"
+          echo "size_human=$(numfmt --to=iec --suffix=B $SIZE_BYTES)" >> "$GITHUB_OUTPUT"
+
+      - name: Encrypt with gpg
+        id: encrypt
+        env:
+          BACKUP_PASSPHRASE: ${{ secrets.BACKUP_PASSPHRASE }}
+        run: |
+          set -euo pipefail
+          if [ -z "${BACKUP_PASSPHRASE:-}" ]; then
+            echo "ERROR: BACKUP_PASSPHRASE no esta configurado en secrets"
+            exit 1
+          fi
+          DUMP_FILE="$BACKUP_DIR/dump.sql"
+          ENC_FILE="$DUMP_FILE.gpg"
+          gpg --batch --yes --quiet \
+            --passphrase "$BACKUP_PASSPHRASE" \
+            --symmetric --cipher-algo AES256 \
+            --output "$ENC_FILE" \
+            "$DUMP_FILE"
+          rm -f "$DUMP_FILE"
+          SHA=$(sha256sum "$ENC_FILE" | awk '{print $1}')
+          echo "sha256=$SHA" >> "$GITHUB_OUTPUT"
+          echo "enc_file=$ENC_FILE" >> "$GITHUB_OUTPUT"
+
+      - name: Determine retention tier
+        id: tier
+        run: |
+          set -euo pipefail
+          INPUT_TIER="${{ github.event.inputs.tier }}"
+          if [ -n "$INPUT_TIER" ] && [ "$INPUT_TIER" != "auto" ]; then
+            TIER="$INPUT_TIER"
+          else
+            DAY_OF_MONTH=$(date -u +%d)
+            DAY_OF_WEEK=$(date -u +%u)  # 1=Mon ... 7=Sun
+            if [ "$DAY_OF_MONTH" = "01" ]; then
+              TIER=monthly
+            elif [ "$DAY_OF_WEEK" = "7" ]; then
+              TIER=weekly
+            else
+              TIER=daily
+            fi
+          fi
+          DATE_TAG=$(date -u +%Y-%m-%d)
+          echo "tier=$TIER" >> "$GITHUB_OUTPUT"
+          echo "date_tag=$DATE_TAG" >> "$GITHUB_OUTPUT"
+          echo "Tier seleccionado: $TIER (date $DATE_TAG)"
+
+      - name: Upload to Google Drive
+        id: upload
+        run: |
+          set -euo pipefail
+          REMOTE_PATH="$RCLONE_REMOTE/${{ steps.tier.outputs.tier }}/${{ steps.tier.outputs.date_tag }}.sql.gpg"
+          rclone copyto "${{ steps.encrypt.outputs.enc_file }}" "$REMOTE_PATH" --progress
+          # Verificar tamaño remoto
+          REMOTE_SIZE=$(rclone size "$REMOTE_PATH" --json | python3 -c "import sys,json;print(json.load(sys.stdin)['bytes'])")
+          if [ "$REMOTE_SIZE" -lt 100 ]; then
+            echo "ERROR: archivo subido tiene tamaño anomalo ($REMOTE_SIZE bytes)"
+            exit 1
+          fi
+          echo "remote_path=$REMOTE_PATH" >> "$GITHUB_OUTPUT"
+
+      - name: Apply retention policy
+        run: |
+          set -euo pipefail
+          chmod +x scripts/backup/retention.sh
+          ./scripts/backup/retention.sh "$RCLONE_REMOTE"
+
+      - name: Notify Telegram (success)
+        if: success()
+        env:
+          TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
+          TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_BACKUP_CHAT_ID }}
+          TIER: ${{ steps.tier.outputs.tier }}
+          DATE_TAG: ${{ steps.tier.outputs.date_tag }}
+          SIZE_HUMAN: ${{ steps.dump.outputs.size_human }}
+          SHA256: ${{ steps.encrypt.outputs.sha256 }}
+          REMOTE_PATH: ${{ steps.upload.outputs.remote_path }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          if [ -z "${TELEGRAM_BOT_TOKEN:-}" ] || [ -z "${TELEGRAM_CHAT_ID:-}" ]; then
+            echo "Telegram no configurado, skipping notify"
+            exit 0
+          fi
+          MSG=$(printf '[OK] Backup Supabase\nFecha: %s\nTier: %s\nTamaño dump: %s\nSHA256: %s\nPath: %s\nRun: %s' \
+            "$DATE_TAG" "$TIER" "$SIZE_HUMAN" "$SHA256" "$REMOTE_PATH" "$RUN_URL")
+          curl -fsS -X POST "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage" \
+            --data-urlencode "chat_id=${TELEGRAM_CHAT_ID}" \
+            --data-urlencode "text=${MSG}" \
+            --data-urlencode "disable_web_page_preview=true" \
+            -o /dev/null
+
+      - name: Notify Telegram (failure)
+        if: failure()
+        env:
+          TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
+          TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_BACKUP_CHAT_ID }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          if [ -z "${TELEGRAM_BOT_TOKEN:-}" ] || [ -z "${TELEGRAM_CHAT_ID:-}" ]; then
+            echo "Telegram no configurado, skipping notify"
+            exit 0
+          fi
+          DATE_TAG=$(date -u +%Y-%m-%d)
+          MSG=$(printf '[FAIL] Backup Supabase fallo\nFecha: %s\nRun: %s\nRevisar logs y arreglar antes del proximo cron.' \
+            "$DATE_TAG" "$RUN_URL")
+          curl -fsS -X POST "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage" \
+            --data-urlencode "chat_id=${TELEGRAM_CHAT_ID}" \
+            --data-urlencode "text=${MSG}" \
+            --data-urlencode "disable_web_page_preview=true" \
+            -o /dev/null || true
+
+      - name: Cleanup local files
+        if: always()
+        run: |
+          rm -rf "$BACKUP_DIR" || true
+
+      - name: Job summary
+        if: always()
+        run: |
+          {
+            echo "## Backup Supabase"
+            echo "- **Fecha:** ${{ steps.tier.outputs.date_tag }}"
+            echo "- **Tier:** ${{ steps.tier.outputs.tier }}"
+            echo "- **Tamaño dump:** ${{ steps.dump.outputs.size_human }}"
+            echo "- **SHA256:** \`${{ steps.encrypt.outputs.sha256 }}\`"
+            echo "- **Path remoto:** \`${{ steps.upload.outputs.remote_path }}\`"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,13 @@ temp/
 .cache/
 .parcel-cache/
 .eslintcache
+
+# Backups locales (dumps Supabase)
+*.sql
+*.sql.gpg
+*.dump
+backups/
+!supabase/migrations/*.sql
+!scripts/verify-multi-tenant.sql
+!migrations/*.sql
+!migrations/**/*.sql

--- a/scripts/backup/restore-runbook.md
+++ b/scripts/backup/restore-runbook.md
@@ -1,0 +1,171 @@
+# Runbook: restaurar backup de Supabase
+
+**RTO objetivo:** < 30 min desde decision hasta DB restaurada.
+**RPO actual:** 24 h (ultimo backup diario).
+
+## Cuando ejecutar este runbook
+
+| Caso | Accion |
+|---|---|
+| Drill mensual (dia 1) | Restaurar a proyecto staging y comparar conteos. Documentar tiempos. |
+| Borrado accidental de datos | Restaurar a staging, exportar tablas afectadas, importar a produccion. NO sobreescribir produccion entera sin pensar. |
+| Corrupcion total | Crear proyecto Supabase nuevo, restaurar, reapuntar `VITE_SUPABASE_URL` en deploys. |
+| Migracion fallida | Restaurar a produccion si la corrida es muy reciente y no entraron datos nuevos. Sino, restore a staging y reconciliar diff. |
+
+## Prerequisitos locales
+
+- `pg_restore` versión 17 instalado (`postgresql-client-17`).
+- `gpg` instalado.
+- `rclone` configurado con remote `gdrive` (ver [setup.md](setup.md) paso 3).
+- Acceso al gestor de contraseñas con `BACKUP_PASSPHRASE distribuidora-app`.
+- Acceso al dashboard de Supabase.
+
+## Paso 1 — Crear proyecto Supabase de destino
+
+**Para drill o corrupcion total:**
+1. https://supabase.com/dashboard → **New project**.
+2. Region: `sa-east-1` (mismo que prod, latencia menor).
+3. Plan: Free tier OK para drill.
+4. Anotar el **project ref** y el **DB password** generado.
+
+**Para borrado accidental (recuperacion quirurgica):**
+- Restaurar a un proyecto staging dedicado, no a produccion.
+
+## Paso 2 — Descargar el backup
+
+Decidir que dia restaurar:
+- Para drill: el ultimo `daily/` disponible.
+- Para incidente: el ultimo backup ANTES del evento que se quiere revertir.
+
+```bash
+# Listar backups disponibles
+rclone ls gdrive:Backups/distribuidora-app/daily/
+rclone ls gdrive:Backups/distribuidora-app/weekly/
+rclone ls gdrive:Backups/distribuidora-app/monthly/
+
+# Descargar
+mkdir -p /tmp/restore && cd /tmp/restore
+rclone copy gdrive:Backups/distribuidora-app/daily/YYYY-MM-DD.sql.gpg .
+```
+
+## Paso 3 — Verificar integridad
+
+```bash
+sha256sum YYYY-MM-DD.sql.gpg
+```
+
+Comparar contra el SHA256 que mando el bot a Telegram el dia que se hizo el backup. Si no coincide: archivo corrupto, intentar otro dia o investigar.
+
+## Paso 4 — Desencriptar
+
+```bash
+gpg --batch --passphrase 'PEGAR_PASSPHRASE_AQUI' \
+  --decrypt YYYY-MM-DD.sql.gpg > dump.sql
+```
+
+Verificar que `dump.sql` tenga tamaño razonable (debe ser comparable o un poco mayor que el `.gpg`).
+
+## Paso 5 — Obtener connection string del destino
+
+Dashboard del proyecto destino → **Settings → Database → Connection string → URI** (modo Session pooler).
+
+```bash
+export DEST_DB_URL='postgresql://postgres.REF:PASSWORD@aws-0-REGION.pooler.supabase.com:5432/postgres'
+```
+
+## Paso 6 — pg_restore
+
+```bash
+pg_restore \
+  --no-owner \
+  --no-acl \
+  --verbose \
+  --dbname "$DEST_DB_URL" \
+  dump.sql 2>&1 | tee restore.log
+```
+
+**Errores tolerables (esperados):**
+- `role "supabase_admin" does not exist` — supabase_admin lo crea Supabase, no nuestro dump. Ignorar.
+- Errores en extensiones ya creadas por Supabase (`extension "X" already exists`).
+- Errores en schemas internos (`auth`, `storage`) — Supabase los maneja.
+
+**Errores criticos (parar y diagnosticar):**
+- Cualquier `ERROR` que mencione tablas de negocio (`pedidos`, `clientes`, `productos`, `pagos`, `audit_logs`, etc.).
+- `connection refused` o `authentication failed`.
+
+## Paso 7 — Validacion de sanidad
+
+Ejecutar via Supabase SQL Editor o `psql "$DEST_DB_URL"`:
+
+```sql
+-- Conteos esperados (comparar con los reales de produccion)
+SELECT 'perfiles' AS tabla, count(*) FROM perfiles
+UNION ALL SELECT 'clientes', count(*) FROM clientes
+UNION ALL SELECT 'productos', count(*) FROM productos
+UNION ALL SELECT 'pedidos', count(*) FROM pedidos
+UNION ALL SELECT 'pedido_items', count(*) FROM pedido_items
+UNION ALL SELECT 'pagos', count(*) FROM pagos
+UNION ALL SELECT 'compras', count(*) FROM compras
+UNION ALL SELECT 'compra_items', count(*) FROM compra_items
+UNION ALL SELECT 'notas_credito', count(*) FROM notas_credito
+UNION ALL SELECT 'audit_logs', count(*) FROM audit_logs
+ORDER BY tabla;
+
+-- Validar que las RLS estan activas
+SELECT tablename, rowsecurity
+FROM pg_tables
+WHERE schemaname = 'public' AND rowsecurity = false
+  AND tablename NOT LIKE 'pg_%';
+-- Esperado: 0 filas (todas las tablas con RLS habilitada).
+
+-- Validar que las funciones criticas existen
+SELECT count(*) AS funciones_publicas
+FROM pg_proc p
+JOIN pg_namespace n ON p.pronamespace = n.oid
+WHERE n.nspname = 'public';
+-- Esperado: ~73 (segun baseline de migrations/000_baseline.sql).
+```
+
+## Paso 8 — Si era drill: documentar y limpiar
+
+Agregar entrada a `scripts/backup/drill-log.md` con:
+- Fecha del drill
+- Backup usado (fecha del archivo)
+- Tiempo total (descarga + decrypt + restore + validacion)
+- Conteos: filas restauradas vs filas en prod ese dia
+- Anomalias encontradas
+
+Despues:
+- Pausar el proyecto staging desde el dashboard (free tier permite proyectos pausados sin costo).
+- O eliminarlo si no se reusara: dashboard → Settings → General → Delete project.
+
+## Paso 9 — Si era incidente real
+
+**Para corrupcion total:**
+1. Validacion sanidad OK → reapuntar la app:
+   - Vercel/Coolify env vars: `VITE_SUPABASE_URL`, `VITE_SUPABASE_ANON_KEY` al nuevo proyecto.
+   - Edge functions secrets en el proyecto nuevo (`TELEGRAM_BOT_TOKEN`, `GEMINI_API_KEY`, etc.).
+   - Re-deployar webhook de Telegram al nuevo proyecto.
+2. Comunicar a usuarios la perdida desde el ultimo backup (RPO 24h max).
+3. Pausar el proyecto viejo (no eliminar inmediatamente — por si hay datos rescatables).
+4. Postmortem dentro de 48h.
+
+**Para borrado accidental quirurgico:**
+1. Identificar tablas/filas afectadas.
+2. Exportar desde staging con `pg_dump --table=NOMBRE --data-only`.
+3. Revisar manualmente antes de importar a produccion.
+4. Importar con `psql "$PROD_DB_URL" < export.sql`.
+
+## Tiempos esperados (referencia)
+
+| Paso | Tiempo (volumen actual) |
+|---|---|
+| Crear proyecto Supabase | 2-3 min (provisioning) |
+| Descargar de Drive | 30 s |
+| Decrypt | 5 s |
+| pg_restore | 1-3 min |
+| Validacion | 2 min |
+| **Total drill** | **~10 min** |
+| **Total con app reapuntada (incidente real)** | **~30 min** |
+
+A medida que crezca la DB, actualizar estas estimaciones.

--- a/scripts/backup/retention.sh
+++ b/scripts/backup/retention.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# Aplica politica de retencion sobre backups en rclone remote.
+#
+# Politica:
+#   daily/   -> mantener ultimos 7 archivos
+#   weekly/  -> mantener ultimos 4 archivos
+#   monthly/ -> mantener ultimos 12 archivos
+#
+# Uso:
+#   ./retention.sh gdrive:Backups/distribuidora-app
+#
+# Requiere: rclone configurado con el remote indicado.
+
+set -euo pipefail
+
+REMOTE="${1:-}"
+if [ -z "$REMOTE" ]; then
+  echo "Uso: $0 <rclone-remote-path>" >&2
+  echo "Ejemplo: $0 gdrive:Backups/distribuidora-app" >&2
+  exit 1
+fi
+
+prune_tier() {
+  local tier="$1"
+  local keep="$2"
+  local path="$REMOTE/$tier"
+
+  echo "[retention] Tier=$tier keep=$keep path=$path"
+
+  # Listar archivos ordenados por nombre (YYYY-MM-DD ordena cronologicamente)
+  # Filtrar solo .sql.gpg para no tocar nada mas
+  local files
+  files=$(rclone lsf "$path" --files-only --include '*.sql.gpg' 2>/dev/null | sort)
+
+  if [ -z "$files" ]; then
+    echo "[retention] $tier: sin archivos, skip"
+    return
+  fi
+
+  local total
+  total=$(echo "$files" | wc -l)
+  echo "[retention] $tier: $total archivos encontrados"
+
+  if [ "$total" -le "$keep" ]; then
+    echo "[retention] $tier: <= $keep, nada que podar"
+    return
+  fi
+
+  local to_delete
+  to_delete=$(echo "$files" | head -n "$((total - keep))")
+
+  echo "[retention] $tier: borrando $((total - keep)) archivos viejos"
+  while IFS= read -r f; do
+    [ -z "$f" ] && continue
+    echo "[retention]   delete $tier/$f"
+    rclone deletefile "$path/$f"
+  done <<< "$to_delete"
+}
+
+prune_tier daily 7
+prune_tier weekly 4
+prune_tier monthly 12
+
+echo "[retention] OK"

--- a/scripts/backup/setup.md
+++ b/scripts/backup/setup.md
@@ -1,0 +1,130 @@
+# Setup inicial de backups Supabase
+
+Esto se hace **una sola vez**. Despues el workflow corre solo todos los dias a las 03:00 ART.
+
+## Paso 1 — Crear estructura en Google Drive
+
+En tu cuenta personal de Drive, crea las carpetas:
+
+```
+Backups/
+  distribuidora-app/
+    daily/
+    weekly/
+    monthly/
+```
+
+## Paso 2 — Generar passphrase de encriptacion
+
+**Critico:** sin la passphrase los dumps son irrecuperables. Guardala en al menos 2 lugares (gestor de contraseñas + segundo backup, ej. sobre fisico o segundo gestor).
+
+```bash
+openssl rand -base64 32
+```
+
+Guardar en gestor de contraseñas con label exacto: `BACKUP_PASSPHRASE distribuidora-app`.
+
+## Paso 3 — Configurar rclone localmente
+
+Esto es solo para generar el archivo de config que despues va como secret a GitHub.
+
+### 3.1 Instalar rclone
+
+- Linux/Mac: `curl https://rclone.org/install.sh | sudo bash`
+- Windows: descargar de https://rclone.org/downloads/ o `winget install Rclone.Rclone`
+
+### 3.2 Configurar remote `gdrive`
+
+```bash
+rclone config
+```
+
+Responder:
+- `n` (new remote)
+- name: `gdrive`
+- Storage: buscar `drive` (Google Drive)
+- `client_id` / `client_secret`: dejar vacios (usa los publicos de rclone, OK para uso personal)
+- scope: `1` (Full access — necesario para escribir y borrar)
+- service_account_file: vacio
+- Edit advanced config: `n`
+- Use auto config: `y` (abre browser para OAuth)
+- Configure as Shared Drive: `n`
+- Confirmar `y`
+
+### 3.3 Verificar
+
+```bash
+rclone lsd gdrive:Backups/distribuidora-app
+```
+
+Deberias ver `daily`, `weekly`, `monthly`.
+
+### 3.4 Exportar config como base64
+
+**Linux/Mac:**
+```bash
+base64 -w 0 ~/.config/rclone/rclone.conf
+```
+
+**Windows PowerShell:**
+```powershell
+[Convert]::ToBase64String([IO.File]::ReadAllBytes("$env:APPDATA\rclone\rclone.conf"))
+```
+
+Copiar el string resultante. Es lo que va al secret `RCLONE_CONFIG_BASE64`.
+
+## Paso 4 — Obtener connection string de Supabase
+
+1. Ir a https://supabase.com/dashboard/project/hmuchlzmuqqxcldbzkgc/settings/database
+2. En **Connection string**, elegir tab **URI** y modo **Session pooler** (NO Transaction — `pg_dump` requiere session).
+3. Reemplazar `[YOUR-PASSWORD]` por el password de la DB (esta en el dashboard, **Database password**).
+4. El string completo va al secret `SUPABASE_DB_URL`.
+
+Formato esperado: `postgresql://postgres.PROJECTREF:PASSWORD@aws-0-REGION.pooler.supabase.com:5432/postgres`
+
+## Paso 5 — Configurar bot de Telegram para notificaciones
+
+Reusar el bot existente del proyecto (`TELEGRAM_BOT_TOKEN` ya existe en Supabase Edge Functions).
+
+Para obtener el chat ID:
+1. Crear un canal o chat privado para alertas (recomendado: canal "Backups Distribuidora").
+2. Agregar el bot como admin.
+3. Mandar un mensaje cualquiera al canal.
+4. `curl https://api.telegram.org/bot<TOKEN>/getUpdates` y leer `chat.id`.
+
+## Paso 6 — Cargar secrets en GitHub
+
+Ir a **Settings → Secrets and variables → Actions → New repository secret**.
+
+| Nombre | Valor |
+|---|---|
+| `SUPABASE_DB_URL` | Connection string del paso 4 |
+| `BACKUP_PASSPHRASE` | Passphrase del paso 2 |
+| `RCLONE_CONFIG_BASE64` | Base64 del paso 3.4 |
+| `TELEGRAM_BOT_TOKEN` | Token del bot existente (ya en Supabase Edge Functions) |
+| `TELEGRAM_BACKUP_CHAT_ID` | Chat ID del paso 5 |
+
+## Paso 7 — Primera corrida
+
+```bash
+gh workflow run backup.yml
+```
+
+O desde la UI: **Actions → Backup Supabase DB → Run workflow**.
+
+Verificar:
+1. Workflow termina en verde (~2-5 min con datos actuales).
+2. Aparece mensaje en Telegram con tamaño y SHA256.
+3. En Drive: `Backups/distribuidora-app/daily/YYYY-MM-DD.sql.gpg` existe y pesa similar al reportado.
+
+## Paso 8 — Drill de restauracion (no skipear)
+
+Seguir [restore-runbook.md](restore-runbook.md) en un proyecto Supabase staging vacio.
+Sin este drill, el backup no esta validado.
+
+## Mantenimiento
+
+- **Mensual:** ejecutar drill de restore (runbook).
+- **Cuando rotes el password de DB:** actualizar el secret `SUPABASE_DB_URL`.
+- **Cuando expire el OAuth de rclone (raro, ~6 meses inactivo):** repetir paso 3 y actualizar `RCLONE_CONFIG_BASE64`.
+- **Si las notificaciones dejan de llegar:** revisar `Actions` en GitHub. Si workflow no corre durante 60 dias, GitHub auto-deshabilita los crons en repos privados — re-habilitar manualmente.


### PR DESCRIPTION
## Summary

- Workflow GitHub Actions corre `pg_dump` diario (03:00 ART), encripta con gpg AES256 y sube a Google Drive vía rclone.
- Notifica éxito/falla a Telegram con tamaño y SHA256 (necesario para verificar integridad al restaurar).
- Retención escalonada: 7 daily / 4 weekly / 12 monthly via `scripts/backup/retention.sh`.
- Documentación: setup one-time + runbook de restauración con queries de validación.

## Por qué

Plan gratuito de Supabase no tiene PITR ni retención de backups diarios. Sin esto, una corrupción o borrado accidental no es recuperable.

## Test plan

- [x] YAML del workflow valida (parsea con `yaml.safe_load`).
- [x] Bash de `retention.sh` pasa `bash -n`.
- [x] `check-secrets.sh` no flaggea ninguno de los archivos nuevos.
- [ ] **Después del merge:** disparar `gh workflow run backup.yml` manualmente y verificar:
  - Archivo `.sql.gpg` aparece en `Backups/distribuidora-app/daily/` en Drive.
  - Mensaje `[OK]` llega a Telegram con tamaño y SHA256.
  - Run en GitHub Actions termina en verde.
- [ ] Drill de restore a un proyecto Supabase staging vacío (siguiendo `scripts/backup/restore-runbook.md`).

## Out of scope

- PITR / backups continuos (requiere plan Pro de Supabase).
- Backup de Supabase Storage (la app no usa Storage actualmente).

🤖 Generated with [Claude Code](https://claude.com/claude-code)