### PR TITLE
chore(deps): npm audit fix - dompurify, fast-uri, postcss

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6697,9 +6697,9 @@
       "license": "MIT"
     },
     "node_modules/dompurify": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.3.tgz",
-      "integrity": "sha512-Oj6pzI2+RqBfFG+qOaOLbFXLQ90ARpcGG6UePL82bJLtdsa6CYJD7nmiU8MW9nQNOtCHV3lZ/Bzq1X0QYbBZCA==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.2.tgz",
+      "integrity": "sha512-lHeS9SA/IKeIFFyYciHBr2n0v1VMPlSj843HdLOwjb2OxNwdq9Xykxqhk+FE42MzAdHvInbAolSE4mhahPpjXA==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
@@ -7393,9 +7393,9 @@
       }
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "dev": true,
       "funding": [
         {
@@ -9926,9 +9926,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.6",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "version": "8.5.14",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
+      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
## Summary

Bumps transitivos en `package-lock.json` (package.json sin cambios) que resuelven 3 advisories de seguridad publicadas en GHSA entre ayer y hoy. `main` está fallando el CI desde el merge del PR #287 por estas advisories — este PR lo destraba.

## Cambios

| Paquete | Severidad | Issue |
|---|---|---|
| `dompurify` <=3.3.3 | moderate | XSS bypass via FORBID_TAGS / SAFE_FOR_TEMPLATES |
| `fast-uri` <=3.1.1 | **high** | Path traversal + host confusion |
| `postcss` <8.5.10 | moderate | XSS via CSS stringify output |

`npm audit fix` (sin `--force`) → solo bumps de transitivas dentro de los `^` ranges existentes.

## Test plan

- [x] `npm audit` → `0 vulnerabilities`
- [x] `npm run typecheck` → clean
- [x] `npm run test:run` → 595/595 passing
- [ ] CI checks en este PR todos verdes

🤖 Generated with [Claude Code](https://claude.com/claude-code)