### PR TITLE
fix(backups): usar pg_dump 17 en vez del 16 default del runner

### DIFF
--- a/.github/workflows/backup.yml
+++ b/.github/workflows/backup.yml
@@ -48,6 +48,10 @@ jobs:
             | sudo tee /etc/apt/sources.list.d/pgdg.list >/dev/null
           sudo apt-get update -qq
           sudo apt-get install -y -qq postgresql-client-17
+          # PG 17 binarios viven en /usr/lib/postgresql/17/bin; el runner trae PG 16
+          # por default en /usr/bin. Anteponer al PATH para todos los steps siguientes.
+          echo "/usr/lib/postgresql/17/bin" >> "$GITHUB_PATH"
+          export PATH="/usr/lib/postgresql/17/bin:$PATH"
           # rclone (oficial)
           curl -fsSL https://rclone.org/install.sh | sudo bash
           pg_dump --version


### PR DESCRIPTION
## Summary

El primer run del workflow de backups falló con:
\`\`\`
pg_dump: error: aborting because of server version mismatch
pg_dump: detail: server version: 17.6; pg_dump version: 16.13
\`\`\`

`postgresql-client-17` instala binarios en `/usr/lib/postgresql/17/bin/`, pero el runner Ubuntu trae PG 16 en `/usr/bin/` que tiene precedencia. Antepongo `/usr/lib/postgresql/17/bin` a `GITHUB_PATH` para que `pg_dump 17` sea el primero encontrado.

## Test plan

- [x] YAML valida.
- [x] Diff mínima: 4 líneas en un solo step.
- [ ] Después del merge: re-disparar `gh workflow run backup.yml` y confirmar que `pg_dump --version` reporta 17.x y termina en verde.

🤖 Generated with [Claude Code](https://claude.com/claude-code)