### PR TITLE
fix(pedidos): manifiesto completo en hoja de ruta + 'Combinado' en card

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -159,9 +159,9 @@
       }
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.28.6.tgz",
-      "integrity": "sha512-JYgintcMjRiCvS8mMECzaEn+m3PfoQiyqukOMCCVQtoJGYJw8j/8LBJEiqkHLkfwCcs74E3pbAUFNg7d9VNJ+Q==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
+      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -216,14 +216,14 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.28.6.tgz",
-      "integrity": "sha512-lOoVRwADj8hjf7al89tvQ2a1lf53Z+7tiXMgpZJL3maQPDxh0DgLMN62B2MKUOFcoodBHLMbDM6WAbKgNy5Suw==",
+      "version": "7.29.1",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
+      "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.28.6",
-        "@babel/types": "^7.28.6",
+        "@babel/parser": "^7.29.0",
+        "@babel/types": "^7.29.0",
         "@jridgewell/gen-mapping": "^0.3.12",
         "@jridgewell/trace-mapping": "^0.3.28",
         "jsesc": "^3.0.2"
@@ -508,13 +508,13 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.6.tgz",
-      "integrity": "sha512-TeR9zWR18BvbfPmGbLampPMW+uW1NZnJlRuuHso8i87QZNq2JRF9i6RgxRqtEq+wQGsS19NNTWr2duhnE49mfQ==",
+      "version": "7.29.3",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.3.tgz",
+      "integrity": "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.28.6"
+        "@babel/types": "^7.29.0"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -1091,16 +1091,16 @@
       }
     },
     "node_modules/@babel/plugin-transform-modules-systemjs": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.28.5.tgz",
-      "integrity": "sha512-vn5Jma98LCOeBy/KpeQhXcV2WZgaRUtjwQmjoBuLNlOmkg0fB5pdvYVeWRYI69wWKwK2cD1QbMiUQnoujWvrew==",
+      "version": "7.29.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.29.4.tgz",
+      "integrity": "sha512-N7QmZ0xRZfjHOfZeQLJjwgX2zS9pdGHSVl/cjSGlo4dXMqvurfxXDMKY4RqEKzPozV78VMcd0lxyG13mlbKc4w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-module-transforms": "^7.28.3",
-        "@babel/helper-plugin-utils": "^7.27.1",
+        "@babel/helper-module-transforms": "^7.28.6",
+        "@babel/helper-plugin-utils": "^7.28.6",
         "@babel/helper-validator-identifier": "^7.28.5",
-        "@babel/traverse": "^7.28.5"
+        "@babel/traverse": "^7.29.0"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1682,18 +1682,18 @@
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.28.6.tgz",
-      "integrity": "sha512-fgWX62k02qtjqdSNTAGxmKYY/7FSL9WAS1o2Hu5+I5m9T0yxZzr4cnrfXQ/MX0rIifthCSs6FKTlzYbJcPtMNg==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
+      "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.28.6",
-        "@babel/generator": "^7.28.6",
+        "@babel/code-frame": "^7.29.0",
+        "@babel/generator": "^7.29.0",
         "@babel/helper-globals": "^7.28.0",
-        "@babel/parser": "^7.28.6",
+        "@babel/parser": "^7.29.0",
         "@babel/template": "^7.28.6",
-        "@babel/types": "^7.28.6",
+        "@babel/types": "^7.29.0",
         "debug": "^4.3.1"
       },
       "engines": {
@@ -1701,9 +1701,9 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.6.tgz",
-      "integrity": "sha512-0ZrskXVEHSWIqZM/sQZ4EV3jZJXRkio/WCxaqKZP1g//CEWEPSfeZFcms4XeKBCHU0ZKnIkdJeU/kF+eRp5lBg==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/src/components/pedidos/PedidoCard.tsx
+++ b/src/components/pedidos/PedidoCard.tsx
@@ -13,7 +13,7 @@ const generarReciboPedido = async (pedido: any, _empresa: any = {}, options: { f
   const mod = await import('../../lib/pdfExport') as any
   return mod.generarReciboPedido(pedido, _empresa, options)
 };
-import { formatPrecio, formatFecha, getEstadoColor, getEstadoPagoColor, getEstadoPagoLabel, getFormaPagoLabel } from '../../utils/formatters';
+import { formatPrecio, formatFecha, getEstadoColor, getEstadoPagoColor, getEstadoPagoLabel, getFormaPagoLabel, getFormaPagoDisplay } from '../../utils/formatters';
 import { MOTIVOS_SALVEDAD_LABELS } from '../../lib/schemas';
 import AccionesDropdown from './PedidoActions';
 import { PedidoActionsCtx } from '../../contexts/HandlersContext';
@@ -263,10 +263,10 @@ function PedidoCard({
         <div className="flex flex-wrap justify-between items-center gap-2">
           <div className="flex flex-col">
             <p className="text-lg font-bold text-blue-600">{formatPrecio(pedido.total)}</p>
-            {pedido.forma_pago && (
+            {(pedido.forma_pago || (pedido.pagos && pedido.pagos.length > 0)) && (
               <p className="text-xs text-gray-500 flex items-center">
                 <CreditCard className="w-3 h-3 mr-1" />
-                {getFormaPagoLabel(pedido.forma_pago)}
+                {getFormaPagoDisplay(pedido)}
               </p>
             )}
           </div>
@@ -449,8 +449,29 @@ function PedidoCard({
               <p className="text-xs text-gray-500 dark:text-gray-400">Forma de pago</p>
               <p className="font-medium text-gray-900 dark:text-white flex items-center gap-1">
                 <CreditCard className="w-4 h-4" />
-                {getFormaPagoLabel(pedido.forma_pago)}
+                {getFormaPagoDisplay(pedido)}
               </p>
+              {/* Desglose cuando el pago fue combinado: muestra cuanto se cobro
+                  por cada forma sin abrir el modal de pagos. */}
+              {(() => {
+                const pagos = pedido.pagos || [];
+                const formas = Array.from(new Set(pagos.map(p => p.forma_pago).filter(Boolean)));
+                if (formas.length < 2) return null;
+                const desglose = formas.map(f => ({
+                  forma: f,
+                  monto: pagos.filter(p => p.forma_pago === f).reduce((s, p) => s + (p.monto || 0), 0),
+                }));
+                return (
+                  <div className="mt-1.5 pt-1.5 border-t border-gray-200 dark:border-gray-600 space-y-0.5 text-xs text-gray-600 dark:text-gray-400">
+                    {desglose.map(d => (
+                      <div key={d.forma} className="flex justify-between">
+                        <span>{getFormaPagoLabel(d.forma)}</span>
+                        <span className="font-medium">{formatPrecio(d.monto)}</span>
+                      </div>
+                    ))}
+                  </div>
+                );
+              })()}
             </div>
             <div className="p-3 bg-gray-50 dark:bg-gray-700/50 rounded-lg">
               <p className="text-xs text-gray-500 dark:text-gray-400">Transportista</p>

--- a/src/hooks/queries/usePedidosQuery.ts
+++ b/src/hooks/queries/usePedidosQuery.ts
@@ -73,8 +73,12 @@ interface ActualizarPagoInput {
 // a GenericStringError. Mantener sincronizado con el tipo PedidoDB.
 const PEDIDO_PRODUCT_COLS = 'id, nombre, codigo, categoria, unidades_de_venta_por_fardo, etiqueta_bulto' as const
 const PEDIDO_CLIENT_COLS = 'id, nombre_fantasia, razon_social, cuit, direccion, telefono, contacto, latitud, longitud, horarios_atencion, zona' as const
-const PEDIDO_SELECT = `*, cliente:clientes(${PEDIDO_CLIENT_COLS}), items:pedido_items(*, producto:productos(${PEDIDO_PRODUCT_COLS}), promocion:promociones(unidades_por_bloque))` as const
-const PEDIDO_SELECT_CLIENTE_INNER = `*, cliente:clientes!inner(${PEDIDO_CLIENT_COLS}), items:pedido_items(*, producto:productos(${PEDIDO_PRODUCT_COLS}), promocion:promociones(unidades_por_bloque))` as const
+// pagos(forma_pago, monto): permite a la card derivar la forma de pago real
+// (incluido "Combinado") sin queries extra. Los pagos combinados se guardan
+// como N filas en `pagos` (una por forma_pago); pedidos.forma_pago es el
+// valor original al crear el pedido y queda desactualizado tras un combinado.
+const PEDIDO_SELECT = `*, cliente:clientes(${PEDIDO_CLIENT_COLS}), items:pedido_items(*, producto:productos(${PEDIDO_PRODUCT_COLS}), promocion:promociones(unidades_por_bloque)), pagos(forma_pago, monto)` as const
+const PEDIDO_SELECT_CLIENTE_INNER = `*, cliente:clientes!inner(${PEDIDO_CLIENT_COLS}), items:pedido_items(*, producto:productos(${PEDIDO_PRODUCT_COLS}), promocion:promociones(unidades_por_bloque)), pagos(forma_pago, monto)` as const
 
 // Helper: cargar salvedades para un conjunto de pedidos
 async function enrichWithSalvedades(pedidos: Record<string, unknown>[]): Promise<Record<string, PedidoSalvedadResumen[]>> {
@@ -178,7 +182,7 @@ async function fetchPedidosByTransportista(transportistaId: string): Promise<Ped
 async function fetchPedidosByCliente(clienteId: string): Promise<PedidoDB[]> {
   const { data, error } = await supabase
     .from('pedidos')
-    .select(`*, items:pedido_items(*, producto:productos(${PEDIDO_PRODUCT_COLS}), promocion:promociones(unidades_por_bloque))` as const)
+    .select(`*, items:pedido_items(*, producto:productos(${PEDIDO_PRODUCT_COLS}), promocion:promociones(unidades_por_bloque)), pagos(forma_pago, monto)` as const)
     .eq('cliente_id', clienteId)
     .order('created_at', { ascending: false })
     .limit(50)

--- a/src/lib/pdf/hojaRutaOptimizada.js
+++ b/src/lib/pdf/hojaRutaOptimizada.js
@@ -396,15 +396,55 @@ function buildManifiestoOps(pedidos) {
   return ops
 }
 
-function drawManifiestoOps(doc, ops, x, yStart) {
-  const innerX = x + CARD_INNER_PADDING
-  let y = yStart
+/**
+ * Dibuja el manifiesto fluyendo a traves de columnas/paginas.
+ * El ctx provee acceso dinamico a la columna actual y al limite inferior, mas
+ * un advanceColumn() que salta a la siguiente columna (o agrega pagina nueva).
+ * Cada fila chequea si entra antes de dibujarse, garantizando que la lista
+ * completa quede visible aunque exceda una columna o una hoja.
+ */
+function drawManifiestoOps(doc, ops, ctx) {
+  let x = ctx.columnX()
+  let innerX = x + CARD_INNER_PADDING
+  let y = ctx.startY
 
-  doc.setDrawColor(80, 80, 80)
-  doc.setLineWidth(0.4)
-  doc.line(x + 1, y - 1, x + COLUMN_WIDTH - 1, y - 1)
+  const drawSeparator = () => {
+    doc.setDrawColor(80, 80, 80)
+    doc.setLineWidth(0.4)
+    doc.line(x + 1, y - 1, x + COLUMN_WIDTH - 1, y - 1)
+  }
 
-  ops.forEach((op) => {
+  const advanceForOverflow = () => {
+    ctx.advanceColumn()
+    x = ctx.columnX()
+    innerX = x + CARD_INNER_PADDING
+    y = ctx.columnTop
+    drawSeparator()
+  }
+
+  drawSeparator()
+
+  // Orphan-prevention: si el header (titulo + subtitulo + al menos 1 fila) no
+  // entra en lo que queda de la columna, saltar antes de empezar a dibujar.
+  const titleIdx = ops.findIndex(o => o.kind === 'manifiesto-title')
+  if (titleIdx >= 0) {
+    const headerHeight = (ops[titleIdx]?.advance || 0)
+      + (ops[titleIdx + 1]?.advance || 0)
+      + (ops[titleIdx + 2]?.advance || 0)
+    if (y + headerHeight > ctx.columnBottom) {
+      advanceForOverflow()
+    }
+  }
+
+  for (const op of ops) {
+    const advance = op.advance || 0
+
+    // Si la op no entra en la columna actual, avanzar. El titulo se exime
+    // porque ya lo manejo el bloque de orphan-prevention.
+    if (op.kind !== 'manifiesto-title' && y + advance > ctx.columnBottom) {
+      advanceForOverflow()
+    }
+
     switch (op.kind) {
       case 'manifiesto-title': {
         doc.setFont('helvetica', 'bold')
@@ -448,8 +488,8 @@ function drawManifiestoOps(doc, ops, x, yStart) {
       default:
         break
     }
-    y += op.advance || 0
-  })
+    y += advance
+  }
 
   return y
 }
@@ -538,17 +578,19 @@ export function generarHojaRutaOptimizada(transportista, pedidos, infoRuta = {})
 
   y = drawCierreOps(doc, cierreOps, columnX(), y)
 
-  // Manifiesto de carga: resumen consolidado de productos para el chofer
+  // Manifiesto de carga: resumen consolidado de productos para el chofer.
+  // La paginacion la maneja drawManifiestoOps fila-por-fila para que la lista
+  // completa quede visible aunque exceda una columna o una hoja.
   const manifiestoOps = buildManifiestoOps(pedidos)
-  const manifiestoHeight = manifiestoOps.reduce((s, o) => s + (o.advance || 0), 0) + 4
+  y += 3
 
-  if (y + manifiestoHeight > columnBottom) {
-    advanceColumn()
-  } else {
-    y += 3
-  }
-
-  drawManifiestoOps(doc, manifiestoOps, columnX(), y)
+  drawManifiestoOps(doc, manifiestoOps, {
+    columnX,
+    advanceColumn,
+    get columnTop() { return columnTop },
+    columnBottom,
+    startY: y,
+  })
 
   doc.save(generateFilename('ruta', transportista?.nombre))
 }

--- a/src/types/hooks.ts
+++ b/src/types/hooks.ts
@@ -122,6 +122,9 @@ export interface PedidoDB {
   orden_entrega?: number | null;
   items?: PedidoItemDB[];
   salvedades?: PedidoSalvedadResumen[];
+  // Subset de pagos.* embebido por usePedidosQuery para que la card derive
+  // la forma de pago real (ej: "Combinado") sin queries adicionales.
+  pagos?: Array<{ forma_pago: string; monto: number }>;
   stock_descontado?: boolean;
   fecha?: string;
   fecha_entrega?: string | null;

--- a/src/utils/formatters.ts
+++ b/src/utils/formatters.ts
@@ -352,6 +352,22 @@ export const getFormaPagoLabel = (forma: FormaPago | string | null | undefined):
   forma === 'vale_blanco' ? 'Vale Blanco' :
   forma || '';
 
+// Deriva la etiqueta a mostrar en la card del pedido. Los pagos combinados se
+// guardan como N filas en `pagos` con distintos forma_pago, pero pedidos.forma_pago
+// queda con el valor original; sin esto se mostraria "Efectivo" para combinados.
+//   - 0 pagos registrados: usa pedido.forma_pago (legacy / antes de cobrar).
+//   - 1 forma distinta: muestra esa forma (la real del pago).
+//   - 2+ formas distintas: "Combinado".
+export const getFormaPagoDisplay = (
+  pedido: { forma_pago?: string | null; pagos?: Array<{ forma_pago: string }> }
+): string => {
+  const formas = (pedido.pagos || []).map(p => p.forma_pago).filter(Boolean);
+  const distintas = Array.from(new Set(formas));
+  if (distintas.length === 0) return getFormaPagoLabel(pedido.forma_pago);
+  if (distintas.length === 1) return getFormaPagoLabel(distintas[0]);
+  return 'Combinado';
+};
+
 // ============================================
 // UTILIDADES GENERALES
 // ============================================
@@ -435,6 +451,7 @@ export default {
   getEstadoPagoColor,
   getEstadoPagoLabel,
   getFormaPagoLabel,
+  getFormaPagoDisplay,
   truncate,
   capitalize,
   formatPercent,


### PR DESCRIPTION
## Resumen

Dos fixes pedidos por el usuario en la misma sesión:

### 1. Manifiesto de carga se cortaba cuando había muchos productos
`drawManifiestoOps` ([src/lib/pdf/hojaRutaOptimizada.js](src/lib/pdf/hojaRutaOptimizada.js)) iteraba todas las ops sumando `y += op.advance` sin verificar overflow. El call-site solo chequeaba la altura *total* antes de empezar; si no entraba todo, llamaba una vez a `advanceColumn()` y dibujaba desde ahí — pero si la lista excedía una columna entera, el resto se renderizaba fuera del área visible y se cortaba al final de la hoja.

**Ahora:** la función pagina **fila por fila** vía un `ctx` con `advanceColumn/columnX/columnTop/columnBottom`. Si un renglón no entra en la columna actual, salta a la siguiente columna (o a una nueva hoja cuando se acaba la página) y sigue dibujando. Incluye orphan-prevention para no dejar el título solo al fondo de una columna.

### 2. Pagos combinados aparecían como "Efectivo" en la card
`registrarPagosBatch` ([src/hooks/supabase/usePagos.ts](src/hooks/supabase/usePagos.ts)) inserta una row por forma de pago en `pagos`, y el trigger SQL `recalcular_monto_pagado_pedido` recalcula `pedidos.monto_pagado` + `estado_pago`, pero **no toca `pedidos.forma_pago`** — ese campo queda con el valor inicial del pedido (típicamente `'efectivo'` por default), así que `PedidoCard` mostraba "Efectivo" aunque hubiera N pagos con formas distintas.

**Ahora:** la query de pedidos embebe `pagos(forma_pago, monto)` (subset mínimo) y el nuevo helper `getFormaPagoDisplay(pedido)` deriva la etiqueta real:
- 0 pagos → fallback a `pedido.forma_pago` (legacy / antes de cobrar)
- 1 forma distinta → muestra esa forma
- 2+ formas distintas → **"Combinado"**

El panel expandido suma un desglose `Efectivo: \$X / Transferencia: \$Y` cuando el pago fue combinado, sin necesidad de abrir otro modal.

## Archivos

| Archivo | Cambio |
|---|---|
| `src/lib/pdf/hojaRutaOptimizada.js` | `drawManifiestoOps` paginación por-op + ajuste call-site |
| `src/hooks/queries/usePedidosQuery.ts` | `PEDIDO_SELECT` + `PEDIDO_SELECT_CLIENTE_INNER` + select inline incluyen `pagos(forma_pago, monto)` |
| `src/types/hooks.ts` | `PedidoDB.pagos?: Array<{ forma_pago, monto }>` |
| `src/utils/formatters.ts` | nuevo `getFormaPagoDisplay(pedido)` |
| `src/components/pedidos/PedidoCard.tsx` | usa `getFormaPagoDisplay` en vista compacta + expandida; agrega desglose en expandido |

## Validación

- `npm run typecheck` ✅
- `npm run lint` ✅
- `npm test` → **595 tests pasan**, sin regresiones ✅

## Test plan

- [ ] Generar hoja de ruta para un transportista con muchos productos consolidados (≥30 ítems en el manifiesto). Verificar:
  - [ ] Si la lista entra en la columna actual: se ve igual que antes.
  - [ ] Si la lista excede la columna pero entra en la siguiente: continúa al costado sin cortarse.
  - [ ] Si la lista excede la página: agrega hoja nueva con header de continuación, **todos** los renglones aparecen, la firma "Conforme de carga" sigue visible al final.
- [ ] Crear un pedido nuevo (queda con `forma_pago='efectivo'` por default) → la card muestra "Efectivo" antes de pagar.
- [ ] Registrar pago combinado (ej: \$X efectivo + \$Y transferencia, total = total del pedido). Verificar:
  - [ ] La card pasa a "Pagado" y muestra **"Combinado"** tanto en la vista compacta como en el panel expandido.
  - [ ] En el expandido se ve el desglose por forma con sus montos.
- [ ] Pagar otro pedido en una sola forma (ej: solo transferencia) → la card muestra "Transferencia", no "Combinado" ni "Efectivo".
- [ ] Anular uno de los dos pagos del combinado → la card re-renderiza mostrando la forma del pago restante.

🤖 Generated with [Claude Code](https://claude.com/claude-code)