### PR TITLE
feat(encargado): completar restricciones de rol (UI + RPC + bot)

### DIFF
--- a/migrations/039_encargado_restricciones.sql
+++ b/migrations/039_encargado_restricciones.sql
@@ -1,0 +1,240 @@
+-- =========================================================================
+-- 039_encargado_restricciones.sql
+--
+-- Refuerzo SQL de las restricciones del rol "encargado":
+--
+--   1. Helper public.rendicion_dia_cerrada(p_fecha, p_sucursal_id) -> boolean.
+--      Devuelve true si existe rendicion confirmada o resuelta para esa
+--      fecha y sucursal. Consumido por el frontend (banner en pagos masivos)
+--      y por marcar_pagos_masivo (defensa en profundidad).
+--
+--   2. Reemplazo de marcar_pagos_masivo agregando guardas para encargado:
+--        - fecha del pago debe ser CURRENT_DATE
+--        - no puede haber rendicion cerrada para esa fecha + sucursal
+--      Admin no se ve afectado.
+--
+--   3. Reemplazo de cancelar_pedido_con_stock: solo admin puede cancelar
+--      pedidos (antes admitia admin o encargado).
+-- =========================================================================
+
+BEGIN;
+
+-- -------------------------------------------------------------------------
+-- 1. Helper: rendicion_dia_cerrada
+-- -------------------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION public.rendicion_dia_cerrada(
+  p_fecha date,
+  p_sucursal_id bigint DEFAULT NULL
+) RETURNS boolean
+LANGUAGE plpgsql STABLE SECURITY DEFINER SET search_path TO 'public'
+AS $$
+DECLARE
+  v_sucursal bigint;
+BEGIN
+  v_sucursal := COALESCE(p_sucursal_id, current_sucursal_id());
+  IF v_sucursal IS NULL THEN
+    RETURN false;
+  END IF;
+  RETURN EXISTS (
+    SELECT 1 FROM rendiciones_control
+    WHERE fecha = p_fecha
+      AND sucursal_id = v_sucursal
+      AND estado IN ('confirmada', 'resuelta')
+  );
+END;
+$$;
+
+ALTER FUNCTION public.rendicion_dia_cerrada(date, bigint) OWNER TO postgres;
+COMMENT ON FUNCTION public.rendicion_dia_cerrada(date, bigint) IS
+  'Devuelve true si existe rendicion confirmada o resuelta para (fecha, sucursal). Usado para bloquear pagos del encargado en dias ya cerrados.';
+
+GRANT ALL ON FUNCTION public.rendicion_dia_cerrada(date, bigint) TO anon, authenticated, service_role;
+
+-- -------------------------------------------------------------------------
+-- 2. Reemplazo de marcar_pagos_masivo con restricciones de encargado
+-- -------------------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION public.marcar_pagos_masivo(
+  p_pedido_ids bigint[],
+  p_forma_pago text,
+  p_fecha date DEFAULT CURRENT_DATE
+) RETURNS integer
+LANGUAGE plpgsql SECURITY DEFINER SET search_path TO 'public'
+AS $$
+DECLARE
+  v_sucursal_id BIGINT;
+  v_affected INTEGER;
+  v_pedido RECORD;
+  v_rol TEXT;
+BEGIN
+  v_sucursal_id := current_sucursal_id();
+  IF v_sucursal_id IS NULL THEN
+    RAISE EXCEPTION 'No hay sucursal activa' USING ERRCODE = '42501';
+  END IF;
+
+  IF NOT es_encargado_o_admin() THEN
+    RAISE EXCEPTION 'Solo encargado o admin pueden marcar pagos masivos'
+      USING ERRCODE = '42501';
+  END IF;
+
+  SELECT rol INTO v_rol FROM perfiles WHERE id = auth.uid();
+
+  IF v_rol = 'encargado' THEN
+    IF p_fecha <> CURRENT_DATE THEN
+      RAISE EXCEPTION 'Encargado solo puede registrar pagos con fecha de hoy'
+        USING ERRCODE = '42501';
+    END IF;
+    IF public.rendicion_dia_cerrada(p_fecha, v_sucursal_id) THEN
+      RAISE EXCEPTION 'Rendicion ya cerrada para esta fecha. Pedi a un admin.'
+        USING ERRCODE = '42501';
+    END IF;
+  END IF;
+
+  IF p_pedido_ids IS NULL OR array_length(p_pedido_ids, 1) IS NULL THEN
+    RETURN 0;
+  END IF;
+
+  -- Insertar una fila en pagos por cada pedido pendiente. Monto = saldo
+  -- pendiente (total - monto_pagado actual) para no duplicar parciales.
+  FOR v_pedido IN
+    SELECT id, cliente_id, total, COALESCE(monto_pagado, 0) AS ya_pagado
+    FROM pedidos
+    WHERE id = ANY(p_pedido_ids)
+      AND sucursal_id = v_sucursal_id
+      AND COALESCE(estado_pago, 'pendiente') <> 'pagado'
+      AND total > COALESCE(monto_pagado, 0)
+  LOOP
+    INSERT INTO pagos (cliente_id, pedido_id, monto, forma_pago, fecha, usuario_id, sucursal_id)
+    VALUES (
+      v_pedido.cliente_id,
+      v_pedido.id,
+      v_pedido.total - v_pedido.ya_pagado,
+      p_forma_pago,
+      p_fecha,
+      auth.uid(),
+      v_sucursal_id
+    );
+  END LOOP;
+
+  UPDATE pedidos
+     SET monto_pagado = total,
+         forma_pago = p_forma_pago,
+         updated_at = now()
+   WHERE id = ANY(p_pedido_ids)
+     AND sucursal_id = v_sucursal_id;
+
+  GET DIAGNOSTICS v_affected = ROW_COUNT;
+  RETURN v_affected;
+END;
+$$;
+
+ALTER FUNCTION public.marcar_pagos_masivo(bigint[], text, date) OWNER TO postgres;
+COMMENT ON FUNCTION public.marcar_pagos_masivo(bigint[], text, date) IS
+  'Marca multiples pedidos como pagados en batch en una fecha dada. Encargado: solo p_fecha=hoy y sin rendicion cerrada. Admin: sin restricciones extra.';
+
+-- -------------------------------------------------------------------------
+-- 3. Reemplazo de cancelar_pedido_con_stock: solo admin
+-- -------------------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION public.cancelar_pedido_con_stock(
+  p_pedido_id bigint,
+  p_motivo text,
+  p_usuario_id uuid DEFAULT NULL
+) RETURNS jsonb
+LANGUAGE plpgsql SECURITY DEFINER SET search_path TO 'public'
+AS $$
+DECLARE
+  v_sucursal BIGINT := current_sucursal_id();
+  v_pedido RECORD;
+  v_item RECORD;
+  v_total_original DECIMAL;
+  v_user_role TEXT;
+  v_acting_user uuid;
+BEGIN
+  IF v_sucursal IS NULL THEN
+    RETURN jsonb_build_object('success', false, 'error', 'No se pudo determinar la sucursal activa');
+  END IF;
+
+  v_acting_user := auth.uid();
+  IF p_usuario_id IS NOT NULL AND p_usuario_id IS DISTINCT FROM v_acting_user THEN
+    RETURN jsonb_build_object('success', false, 'error', 'ID de usuario no coincide con la sesion autenticada');
+  END IF;
+
+  SELECT rol INTO v_user_role FROM perfiles WHERE id = v_acting_user;
+  IF v_user_role IS NULL OR v_user_role <> 'admin' THEN
+    RETURN jsonb_build_object('success', false, 'error', 'No autorizado: solo admin puede cancelar pedidos');
+  END IF;
+
+  SELECT * INTO v_pedido FROM pedidos WHERE id = p_pedido_id AND sucursal_id = v_sucursal FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RETURN jsonb_build_object('success', false, 'error', 'Pedido no encontrado');
+  END IF;
+
+  IF v_pedido.estado = 'cancelado' THEN
+    RETURN jsonb_build_object('success', false, 'error', 'El pedido ya esta cancelado');
+  END IF;
+
+  IF v_pedido.estado = 'entregado' THEN
+    RETURN jsonb_build_object('success', false, 'error', 'No se puede cancelar un pedido entregado');
+  END IF;
+
+  v_total_original := v_pedido.total;
+
+  FOR v_item IN
+    SELECT pi.producto_id, pi.cantidad, COALESCE(pi.es_bonificacion, false) AS es_bonificacion,
+           pi.promocion_id, COALESCE(pr.regalo_mueve_stock, FALSE) AS regalo_mueve_stock
+    FROM pedido_items pi
+    LEFT JOIN promociones pr ON pr.id = pi.promocion_id AND pr.sucursal_id = pi.sucursal_id
+    WHERE pi.pedido_id = p_pedido_id AND pi.sucursal_id = v_sucursal
+  LOOP
+    IF v_item.es_bonificacion THEN
+      IF v_item.promocion_id IS NOT NULL THEN
+        UPDATE promociones
+        SET usos_pendientes = GREATEST(usos_pendientes - v_item.cantidad, 0)
+        WHERE id = v_item.promocion_id AND sucursal_id = v_sucursal;
+      END IF;
+      IF v_item.regalo_mueve_stock THEN
+        UPDATE productos SET stock = stock + v_item.cantidad
+        WHERE id = v_item.producto_id AND sucursal_id = v_sucursal;
+      END IF;
+    ELSE
+      UPDATE productos SET stock = stock + v_item.cantidad
+      WHERE id = v_item.producto_id AND sucursal_id = v_sucursal;
+    END IF;
+  END LOOP;
+
+  UPDATE pedidos
+  SET estado = 'cancelado',
+      motivo_cancelacion = p_motivo,
+      total = 0,
+      monto_pagado = 0,
+      total_neto = 0,
+      total_iva = 0,
+      updated_at = NOW()
+  WHERE id = p_pedido_id AND sucursal_id = v_sucursal;
+
+  INSERT INTO pedido_historial (pedido_id, usuario_id, campo_modificado, valor_anterior, valor_nuevo, sucursal_id)
+  VALUES (
+    p_pedido_id,
+    v_acting_user,
+    'estado',
+    v_pedido.estado,
+    'cancelado - Motivo: ' || COALESCE(p_motivo, 'Sin motivo') || ' | Total original: $' || v_total_original,
+    v_sucursal
+  );
+
+  RETURN jsonb_build_object(
+    'success', true,
+    'mensaje', 'Pedido cancelado, stock restaurado, saldo ajustado',
+    'total_original', v_total_original
+  );
+END;
+$$;
+
+ALTER FUNCTION public.cancelar_pedido_con_stock(bigint, text, uuid) OWNER TO postgres;
+COMMENT ON FUNCTION public.cancelar_pedido_con_stock(bigint, text, uuid) IS
+  'Cancela un pedido restaurando stock y revirtiendo promos. Solo admin (encargado bloqueado desde 039).';
+
+COMMIT;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -245,7 +245,7 @@ function MainAppInner({ user, perfil, logout, authReady }: {
 
                 <Route
                   path="/dashboard"
-                  element={(isAdminOrEncargado || isPreventista) ? <DashboardContainer /> : <Navigate to="/pedidos" replace />}
+                  element={(isAdmin || isPreventista) ? <DashboardContainer /> : <Navigate to="/pedidos" replace />}
                 />
 
                 <Route path="/pedidos" element={<PedidosContainer />} />
@@ -254,7 +254,7 @@ function MainAppInner({ user, perfil, logout, authReady }: {
 
                 <Route
                   path="/reportes"
-                  element={isAdminOrEncargado ? <ReportesContainer /> : <Navigate to="/pedidos" replace />}
+                  element={isAdmin ? <ReportesContainer /> : <Navigate to="/pedidos" replace />}
                 />
 
                 <Route
@@ -279,22 +279,22 @@ function MainAppInner({ user, perfil, logout, authReady }: {
 
                 <Route
                   path="/proveedores"
-                  element={isAdminOrEncargado ? <ProveedoresContainer /> : <Navigate to="/pedidos" replace />}
+                  element={isAdmin ? <ProveedoresContainer /> : <Navigate to="/pedidos" replace />}
                 />
 
                 <Route
                   path="/condiciones-mayoristas"
-                  element={isAdminOrEncargado ? <GruposPrecioContainer /> : <Navigate to="/pedidos" replace />}
+                  element={isAdmin ? <GruposPrecioContainer /> : <Navigate to="/pedidos" replace />}
                 />
 
                 <Route
                   path="/promociones"
-                  element={isAdminOrEncargado ? <PromocionesContainer /> : <Navigate to="/pedidos" replace />}
+                  element={isAdmin ? <PromocionesContainer /> : <Navigate to="/pedidos" replace />}
                 />
 
                 <Route
                   path="/transferencias"
-                  element={isAdminOrEncargado ? <TransferenciasContainer /> : <Navigate to="/pedidos" replace />}
+                  element={isAdmin ? <TransferenciasContainer /> : <Navigate to="/pedidos" replace />}
                 />
 
                 <Route
@@ -309,12 +309,12 @@ function MainAppInner({ user, perfil, logout, authReady }: {
 
                 <Route
                   path="/analytics"
-                  element={isAdminOrEncargado ? <AnalyticsContainer /> : <Navigate to="/pedidos" replace />}
+                  element={isAdmin ? <AnalyticsContainer /> : <Navigate to="/pedidos" replace />}
                 />
 
                 <Route
                   path="/comisiones"
-                  element={isAdminOrEncargado ? <ComisionesContainer /> : <Navigate to="/pedidos" replace />}
+                  element={isAdmin ? <ComisionesContainer /> : <Navigate to="/pedidos" replace />}
                 />
 
                 <Route

--- a/src/components/containers/PedidosContainer.tsx
+++ b/src/components/containers/PedidosContainer.tsx
@@ -696,7 +696,7 @@ export default function PedidosContainer(): React.ReactElement {
 
   const handleAnularPagoPedido = useCallback(async (pagoId: string) => {
     if (!pedidoPago) return
-    if (!(isAdmin || isEncargado)) return
+    if (!isAdmin) return
     setGuardando(true)
     try {
       await eliminarPago(pagoId)
@@ -705,7 +705,7 @@ export default function PedidosContainer(): React.ReactElement {
       notify.success('Pago anulado')
     } catch (e) { notify.error((e as Error).message) }
     setGuardando(false)
-  }, [pedidoPago, isAdmin, isEncargado, eliminarPago, refreshPagosPedido, queryClient, notify])
+  }, [pedidoPago, isAdmin, eliminarPago, refreshPagosPedido, queryClient, notify])
 
   // ModalPedido handlers
   const handleGuardarPedido = useCallback(async () => {
@@ -1078,7 +1078,7 @@ export default function PedidosContainer(): React.ReactElement {
               isAdmin || isEncargado ||
               (isPreventista && preventistaPuedeEditar(pedidoEditando, user?.id))
             }
-            canEditPrices={isAdmin || isEncargado}
+            canEditPrices={isAdmin}
             canEditFechaEntrega={
               isAdmin || isEncargado ||
               (isPreventista && preventistaPuedeEditar(pedidoEditando, user?.id))
@@ -1101,7 +1101,7 @@ export default function PedidosContainer(): React.ReactElement {
             pagosPrevios={pagosPreviosPedido}
             loadingPagosPrevios={loadingPagosPrevios}
             onConfirmar={pedidoEntregaConPago ? handleEntregarConPago : handleConfirmarPago}
-            onAnularPago={(isAdmin || isEncargado) && !pedidoEntregaConPago ? handleAnularPagoPedido : undefined}
+            onAnularPago={isAdmin && !pedidoEntregaConPago ? handleAnularPagoPedido : undefined}
             modoEntregaTransportista={!!pedidoEntregaConPago}
             onEntregarSinPago={pedidoEntregaConPago ? handleEntregarSinPago : undefined}
             onClose={() => {
@@ -1226,6 +1226,8 @@ export default function PedidosContainer(): React.ReactElement {
             onConfirm={handlePagosMasivos}
             onClose={() => setModalPagosMasivosOpen(false)}
             guardando={guardando}
+            isEncargado={isEncargado}
+            isAdmin={isAdmin}
           />
         </Suspense>
       )}

--- a/src/components/containers/ProductosContainer.tsx
+++ b/src/components/containers/ProductosContainer.tsx
@@ -48,8 +48,8 @@ interface ConfirmConfig {
 }
 
 export default function ProductosContainer(): React.ReactElement {
-  const { isAdmin, isEncargado } = useAuthData()
-  const puedeCambiarProductos = isAdmin || isEncargado
+  const { isAdmin } = useAuthData()
+  const puedeCambiarProductos = isAdmin
   const notify = useNotification()
 
   // Queries

--- a/src/components/layout/TopNavigation.tsx
+++ b/src/components/layout/TopNavigation.tsx
@@ -47,7 +47,7 @@ const menuGroups: MenuGroup[] = [
     id: 'principal',
     label: null, // Items sin grupo (se muestran directo)
     items: [
-      { id: 'dashboard', icon: BarChart3, label: 'Dashboard', roles: ['admin', 'encargado', 'preventista'] },
+      { id: 'dashboard', icon: BarChart3, label: 'Dashboard', roles: ['admin', 'preventista'] },
       { id: 'pedidos', icon: ShoppingCart, label: 'Pedidos', roles: ['admin', 'encargado', 'preventista', 'transportista', 'deposito'] },
     ]
   },
@@ -58,10 +58,10 @@ const menuGroups: MenuGroup[] = [
     roles: ['admin', 'encargado', 'preventista'],
     items: [
       { id: 'clientes', icon: Users, label: 'Clientes', roles: ['admin', 'encargado', 'preventista'] },
-      { id: 'recorrido-preventista', icon: Route, label: 'Recorrido Preventista', roles: ['admin', 'encargado'], hidden: true },
-      { id: 'reportes', icon: TrendingUp, label: 'Reportes', roles: ['admin', 'encargado'] },
-      { id: 'analytics', icon: Database, label: 'Centro de Analisis', roles: ['admin', 'encargado'], hidden: true },
-      { id: 'comisiones', icon: Percent, label: 'Comisiones', roles: ['admin', 'encargado'] },
+      { id: 'recorrido-preventista', icon: Route, label: 'Recorrido Preventista', roles: ['admin'], hidden: true },
+      { id: 'reportes', icon: TrendingUp, label: 'Reportes', roles: ['admin'] },
+      { id: 'analytics', icon: Database, label: 'Centro de Analisis', roles: ['admin'], hidden: true },
+      { id: 'comisiones', icon: Percent, label: 'Comisiones', roles: ['admin'] },
     ]
   },
   {
@@ -72,10 +72,10 @@ const menuGroups: MenuGroup[] = [
     items: [
       { id: 'productos', icon: Package, label: 'Productos', roles: ['admin', 'encargado', 'preventista', 'deposito'] },
       { id: 'compras', icon: ShoppingBag, label: 'Compras', roles: ['admin', 'encargado'] },
-      { id: 'proveedores', icon: Building2, label: 'Proveedores', roles: ['admin', 'encargado'] },
-      { id: 'condiciones-mayoristas', icon: Tag, label: 'Condiciones Mayoristas', roles: ['admin', 'encargado'] },
-      { id: 'promociones', icon: Gift, label: 'Promociones', roles: ['admin', 'encargado'] },
-      { id: 'transferencias', icon: ArrowRightLeft, label: 'Mov. Sucursales', roles: ['admin', 'encargado'] },
+      { id: 'proveedores', icon: Building2, label: 'Proveedores', roles: ['admin'] },
+      { id: 'condiciones-mayoristas', icon: Tag, label: 'Condiciones Mayoristas', roles: ['admin'] },
+      { id: 'promociones', icon: Gift, label: 'Promociones', roles: ['admin'] },
+      { id: 'transferencias', icon: ArrowRightLeft, label: 'Mov. Sucursales', roles: ['admin'] },
     ]
   },
   {

--- a/src/components/modals/ModalPagoPedido.tsx
+++ b/src/components/modals/ModalPagoPedido.tsx
@@ -14,7 +14,7 @@
  * y `pedidos.monto_pagado` automaticamente.
  *
  * Sobrepago bloqueado en frontend (totalIngresado > saldoPendiente). Anulacion
- * de pagos previos solo si el caller pasa `onAnularPago` (admin/encargado).
+ * de pagos previos solo si el caller pasa `onAnularPago` (solo admin).
  */
 import { memo, useEffect, useMemo, useState } from 'react'
 import { Loader2, DollarSign, Plus, Trash2, AlertCircle, X } from 'lucide-react'

--- a/src/components/modals/ModalPagosMasivos.tsx
+++ b/src/components/modals/ModalPagosMasivos.tsx
@@ -1,7 +1,7 @@
 import { useState, useMemo, memo } from 'react'
-import { Loader2, Search, Calendar } from 'lucide-react'
+import { Loader2, Search, Calendar, AlertTriangle } from 'lucide-react'
 import ModalBase from './ModalBase'
-import { usePedidosNoPagadosQuery } from '../../hooks/queries'
+import { usePedidosNoPagadosQuery, useRendicionCerradaQuery } from '../../hooks/queries'
 import { getEstadoPagoColor, getEstadoPagoLabel, formatPrecio, fechaLocalISO } from '../../utils/formatters'
 import { FORMAS_PAGO } from '../../constants/formasPago'
 
@@ -15,21 +15,29 @@ export interface ModalPagosMasivosProps {
   onConfirm: (formaPago: string, pedidoIds: string[], fechaPago: string) => Promise<void>
   onClose: () => void
   guardando: boolean
+  /** Si el caller es encargado (no admin): fecha bloqueada a hoy y check de rendicion. */
+  isEncargado?: boolean
+  isAdmin?: boolean
 }
 
 const ModalPagosMasivos = memo(function ModalPagosMasivos({
   onConfirm,
   onClose,
   guardando,
+  isEncargado = false,
+  isAdmin = false,
 }: ModalPagosMasivosProps) {
+  const hoy = fechaLocalISO()
+  const fechaBloqueada = isEncargado && !isAdmin
   const [selectedFormaPago, setSelectedFormaPago] = useState('')
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set())
   const [busqueda, setBusqueda] = useState('')
   const [fechaDesde, setFechaDesde] = useState('')
   const [fechaHasta, setFechaHasta] = useState('')
-  const [fechaPago, setFechaPago] = useState<string>(fechaLocalISO())
+  const [fechaPago, setFechaPago] = useState<string>(hoy)
 
   const { data: pedidos = [], isLoading } = usePedidosNoPagadosQuery(true)
+  const { data: rendicionCerrada = false } = useRendicionCerradaQuery(fechaPago, fechaBloqueada)
 
   const pedidosFiltrados = useMemo(() => {
     let resultado = pedidos
@@ -64,7 +72,13 @@ const ModalPagosMasivos = memo(function ModalPagosMasivos({
   }
 
   const allSelected = pedidosFiltrados.length > 0 && selectedIds.size === pedidosFiltrados.length
-  const canConfirm = selectedFormaPago && selectedIds.size > 0 && !guardando && !!fechaPago
+  const bloqueadoPorRendicion = fechaBloqueada && rendicionCerrada
+  const canConfirm =
+    !!selectedFormaPago &&
+    selectedIds.size > 0 &&
+    !guardando &&
+    !!fechaPago &&
+    !bloqueadoPorRendicion
 
   // Calculate total of selected orders
   const totalSeleccionado = useMemo(() => {
@@ -104,13 +118,28 @@ const ModalPagosMasivos = memo(function ModalPagosMasivos({
               type="date"
               value={fechaPago}
               onChange={e => setFechaPago(e.target.value)}
-              className="w-full px-3 py-2 border rounded-lg dark:bg-gray-700 dark:border-gray-600 dark:text-white"
+              disabled={fechaBloqueada}
+              min={fechaBloqueada ? hoy : undefined}
+              max={fechaBloqueada ? hoy : undefined}
+              className="w-full px-3 py-2 border rounded-lg dark:bg-gray-700 dark:border-gray-600 dark:text-white disabled:bg-gray-100 dark:disabled:bg-gray-800 disabled:cursor-not-allowed"
             />
             <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
-              Se imputa a la rendición de esa fecha. Por defecto hoy.
+              {fechaBloqueada
+                ? 'Como encargado solo podés registrar pagos con fecha de hoy. Si necesitás otra fecha pedíselo a un admin.'
+                : 'Se imputa a la rendición de esa fecha. Por defecto hoy.'}
             </p>
           </div>
         </div>
+
+        {bloqueadoPorRendicion && (
+          <div className="flex items-start gap-2 p-3 rounded-lg border border-amber-300 bg-amber-50 dark:bg-amber-900/20 dark:border-amber-700">
+            <AlertTriangle className="w-5 h-5 text-amber-600 dark:text-amber-400 flex-shrink-0 mt-0.5" />
+            <div className="text-sm text-amber-900 dark:text-amber-200">
+              <p className="font-medium">Rendición cerrada</p>
+              <p>La rendición de hoy ya fue confirmada. No podés registrar más pagos a esta fecha. Pedile a un admin si necesitás corregir algo.</p>
+            </div>
+          </div>
+        )}
 
         {/* Filtro por fechas */}
         <div className="grid grid-cols-2 gap-3">

--- a/src/components/pedidos/PedidoActions.tsx
+++ b/src/components/pedidos/PedidoActions.tsx
@@ -193,8 +193,9 @@ function AccionesDropdown({
       });
     }
 
-    // Admin o encargado puede cancelar si no esta entregado ni cancelado
-    if ((isAdmin || isEncargado) && pedido.estado !== 'entregado' && pedido.estado !== 'cancelado' && onCancelarPedido) {
+    // Solo admin puede cancelar pedidos (encargado bloqueado por defensa en profundidad
+    // en cancelar_pedido_con_stock; ver migracion 039).
+    if (isAdmin && pedido.estado !== 'entregado' && pedido.estado !== 'cancelado' && onCancelarPedido) {
       items.push({
         label: 'Cancelar Pedido',
         icon: XCircle,

--- a/src/components/pedidos/PedidoStats.tsx
+++ b/src/components/pedidos/PedidoStats.tsx
@@ -8,6 +8,7 @@ import React, { memo } from 'react';
 import { Clock, Package, Truck, Check, DollarSign, ShoppingCart, LucideIcon } from 'lucide-react';
 import { formatPrecio } from '../../utils/formatters';
 import type { PedidoStatsSummary } from '../../hooks/queries';
+import { mostrarMontosEnStats, type PedidoStatKey } from '../../lib/permisos';
 
 // =============================================================================
 // PROPS INTERFACES
@@ -15,10 +16,11 @@ import type { PedidoStatsSummary } from '../../hooks/queries';
 
 export interface PedidoStatsProps {
   summary: PedidoStatsSummary;
+  isEncargado?: boolean;
 }
 
 interface StatItem {
-  key: string;
+  key: PedidoStatKey;
   label: string;
   icon: LucideIcon;
   count: number;
@@ -32,7 +34,8 @@ interface StatItem {
 // COMPONENT
 // =============================================================================
 
-function PedidoStats({ summary }: PedidoStatsProps): React.ReactElement {
+function PedidoStats({ summary, isEncargado }: PedidoStatsProps): React.ReactElement {
+  const rol = isEncargado ? 'encargado' : 'admin';
   const items: StatItem[] = [
     {
       key: 'pendientes',
@@ -104,7 +107,9 @@ function PedidoStats({ summary }: PedidoStatsProps): React.ReactElement {
           <div key={item.key} className={`border rounded-lg p-3 ${item.colorClass}`}>
             <div className="flex items-center justify-between">
               <IconComponent className={`w-5 h-5 ${item.iconColor}`} />
-              <span className={`text-xs ${item.iconColor}`}>{formatPrecio(item.total)}</span>
+              {mostrarMontosEnStats(rol, item.key) && (
+                <span className={`text-xs ${item.iconColor}`}>{formatPrecio(item.total)}</span>
+              )}
             </div>
             <p className={`text-xl font-bold ${item.iconColor}`}>{item.count}</p>
             <p className={`text-sm ${item.textColor}`}>{item.label}</p>

--- a/src/components/vistas/VistaPedidos.tsx
+++ b/src/components/vistas/VistaPedidos.tsx
@@ -229,7 +229,7 @@ export default function VistaPedidos({
       />
 
       {/* Resumen de estados (totales sobre todos los pedidos filtrados) */}
-      <PedidoStats summary={statsSummary} />
+      <PedidoStats summary={statsSummary} isEncargado={isEncargado} />
 
       {/* Lista de pedidos */}
       {loading ? (

--- a/src/hooks/queries/index.ts
+++ b/src/hooks/queries/index.ts
@@ -183,6 +183,12 @@ export {
 } from './useNotasCreditoQuery'
 export type { NCResumen } from './useNotasCreditoQuery'
 
+// Rendicion del dia (helper para pagos masivos)
+export {
+  rendicionCerradaKeys,
+  useRendicionCerradaQuery,
+} from './useRendicionCerradaQuery'
+
 // Bot Telegram - Vinculación
 export {
   botVinculacionKeys,

--- a/src/hooks/queries/useRendicionCerradaQuery.ts
+++ b/src/hooks/queries/useRendicionCerradaQuery.ts
@@ -1,0 +1,38 @@
+/**
+ * Hook para consultar si la rendicion de un dia/sucursal ya esta cerrada
+ * (confirmada o resuelta). Lo usa ModalPagosMasivos para bloquear al
+ * encargado cuando intenta registrar pagos a una fecha cuya rendicion
+ * ya fue confirmada.
+ *
+ * El RPC `rendicion_dia_cerrada` se define en migracion 039.
+ */
+import { useQuery } from '@tanstack/react-query'
+import { supabase } from '../supabase/base'
+import { useSucursal } from '../../contexts/SucursalContext'
+
+export const rendicionCerradaKeys = {
+  all: ['rendicion_dia_cerrada'] as const,
+  forDate: (sucursalId: number | null, fecha: string) =>
+    [...rendicionCerradaKeys.all, sucursalId, fecha] as const,
+}
+
+async function fetchRendicionCerrada(fecha: string, sucursalId: number | null): Promise<boolean> {
+  if (!fecha || sucursalId == null) return false
+  const { data, error } = await supabase.rpc('rendicion_dia_cerrada', {
+    p_fecha: fecha,
+    p_sucursal_id: sucursalId,
+  })
+  if (error) throw error
+  return Boolean(data)
+}
+
+export function useRendicionCerradaQuery(fecha: string | null | undefined, enabled = true) {
+  const { currentSucursalId } = useSucursal()
+  const fechaSafe = fecha || ''
+  return useQuery({
+    queryKey: rendicionCerradaKeys.forDate(currentSucursalId, fechaSafe),
+    queryFn: () => fetchRendicionCerrada(fechaSafe, currentSucursalId),
+    enabled: enabled && !!fechaSafe && currentSucursalId != null,
+    staleTime: 30 * 1000,
+  })
+}

--- a/src/lib/permisos.test.ts
+++ b/src/lib/permisos.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect } from 'vitest'
+import {
+  puedeEditarProductos,
+  puedeEditarPreciosPedido,
+  puedeCancelarPedido,
+  puedeAnularPago,
+  puedeAccederDashboard,
+  puedeAccederReportes,
+  puedeAccederComisiones,
+  puedeAccederProveedores,
+  puedeAccederPromociones,
+  puedeAccederCondicionesMayoristas,
+  puedeAccederTransferencias,
+  mostrarMontosEnStats,
+} from './permisos'
+import type { RolUsuario } from '@/types'
+
+const ROLES: RolUsuario[] = ['admin', 'preventista', 'transportista', 'deposito', 'encargado']
+
+describe('permisos por rol', () => {
+  describe('acciones solo admin', () => {
+    it.each([
+      ['puedeEditarProductos', puedeEditarProductos],
+      ['puedeEditarPreciosPedido', puedeEditarPreciosPedido],
+      ['puedeCancelarPedido', puedeCancelarPedido],
+      ['puedeAnularPago', puedeAnularPago],
+      ['puedeAccederReportes', puedeAccederReportes],
+      ['puedeAccederComisiones', puedeAccederComisiones],
+      ['puedeAccederProveedores', puedeAccederProveedores],
+      ['puedeAccederPromociones', puedeAccederPromociones],
+      ['puedeAccederCondicionesMayoristas', puedeAccederCondicionesMayoristas],
+      ['puedeAccederTransferencias', puedeAccederTransferencias],
+    ] as const)('%s solo permite admin', (_name, fn) => {
+      expect(fn('admin')).toBe(true)
+      for (const rol of ROLES.filter((r) => r !== 'admin')) {
+        expect(fn(rol)).toBe(false)
+      }
+      expect(fn(null)).toBe(false)
+      expect(fn(undefined)).toBe(false)
+    })
+  })
+
+  describe('puedeAccederDashboard', () => {
+    it('permite admin y preventista', () => {
+      expect(puedeAccederDashboard('admin')).toBe(true)
+      expect(puedeAccederDashboard('preventista')).toBe(true)
+    })
+
+    it('bloquea encargado, transportista, deposito', () => {
+      expect(puedeAccederDashboard('encargado')).toBe(false)
+      expect(puedeAccederDashboard('transportista')).toBe(false)
+      expect(puedeAccederDashboard('deposito')).toBe(false)
+      expect(puedeAccederDashboard(null)).toBe(false)
+    })
+  })
+
+  describe('mostrarMontosEnStats', () => {
+    it('encargado solo ve monto en impagos', () => {
+      expect(mostrarMontosEnStats('encargado', 'impagos')).toBe(true)
+      expect(mostrarMontosEnStats('encargado', 'pendientes')).toBe(false)
+      expect(mostrarMontosEnStats('encargado', 'enPreparacion')).toBe(false)
+      expect(mostrarMontosEnStats('encargado', 'enCamino')).toBe(false)
+      expect(mostrarMontosEnStats('encargado', 'entregados')).toBe(false)
+      expect(mostrarMontosEnStats('encargado', 'total')).toBe(false)
+    })
+
+    it('admin ve monto en todas', () => {
+      const keys = ['pendientes', 'enPreparacion', 'enCamino', 'entregados', 'impagos', 'total'] as const
+      for (const k of keys) {
+        expect(mostrarMontosEnStats('admin', k)).toBe(true)
+      }
+    })
+
+    it('otros roles ven monto en todas (sin restriccion)', () => {
+      expect(mostrarMontosEnStats('preventista', 'pendientes')).toBe(true)
+      expect(mostrarMontosEnStats('transportista', 'entregados')).toBe(true)
+    })
+  })
+})

--- a/src/lib/permisos.ts
+++ b/src/lib/permisos.ts
@@ -1,0 +1,68 @@
+/**
+ * Permisos centralizados por rol.
+ *
+ * Reglas de negocio puras: dado un rol devuelve si la accion esta permitida.
+ * No usar hooks ni contexto: se consumen desde containers que ya tienen el rol.
+ */
+
+import type { RolUsuario } from '@/types'
+
+export function puedeEditarProductos(rol: RolUsuario | null | undefined): boolean {
+  return rol === 'admin'
+}
+
+export function puedeEditarPreciosPedido(rol: RolUsuario | null | undefined): boolean {
+  return rol === 'admin'
+}
+
+export function puedeCancelarPedido(rol: RolUsuario | null | undefined): boolean {
+  return rol === 'admin'
+}
+
+export function puedeAnularPago(rol: RolUsuario | null | undefined): boolean {
+  return rol === 'admin'
+}
+
+export function puedeAccederDashboard(rol: RolUsuario | null | undefined): boolean {
+  return rol === 'admin' || rol === 'preventista'
+}
+
+export function puedeAccederReportes(rol: RolUsuario | null | undefined): boolean {
+  return rol === 'admin'
+}
+
+export function puedeAccederComisiones(rol: RolUsuario | null | undefined): boolean {
+  return rol === 'admin'
+}
+
+export function puedeAccederProveedores(rol: RolUsuario | null | undefined): boolean {
+  return rol === 'admin'
+}
+
+export function puedeAccederPromociones(rol: RolUsuario | null | undefined): boolean {
+  return rol === 'admin'
+}
+
+export function puedeAccederCondicionesMayoristas(rol: RolUsuario | null | undefined): boolean {
+  return rol === 'admin'
+}
+
+export function puedeAccederTransferencias(rol: RolUsuario | null | undefined): boolean {
+  return rol === 'admin'
+}
+
+export type PedidoStatKey =
+  | 'pendientes'
+  | 'enPreparacion'
+  | 'enCamino'
+  | 'entregados'
+  | 'impagos'
+  | 'total'
+
+export function mostrarMontosEnStats(
+  rol: RolUsuario | null | undefined,
+  key: PedidoStatKey,
+): boolean {
+  if (rol === 'encargado') return key === 'impagos'
+  return true
+}

--- a/supabase/functions/_shared/gemini/prompts/encargado.ts
+++ b/supabase/functions/_shared/gemini/prompts/encargado.ts
@@ -8,11 +8,6 @@ El usuario actual es ENCARGADO de sucursal. Tiene visibilidad de todos los clien
 Tu trabajo es ayudar al encargado a:
 - Buscar clientes y productos de su sucursal (por nombre o código).
 - Consultar fichas: ficha_cliente (saldo, crédito, últimos movimientos), ficha_producto (precio, stock, ventas 30d).
-- Reportes de ventas y compras de la sucursal:
-  · ventas_periodo(desde, hasta) → total facturado, top productos, top clientes (sucursal entera).
-  · ventas_por_preventista(desde, hasta, [solo_preventistas]) → ranking de ventas por usuario (preventista).
-  · ranking_preventistas_por_producto(producto_ids, desde, hasta) → quién vendió más unidades de UNO o varios productos agrupados (ej: "Manaos 3000cc" puede ser varios sabores). Útil para bonificaciones / sales contests. Conseguí los producto_ids antes con buscar_producto o productos_por_categoria.
-  · compras_periodo(desde, hasta) → total comprado, top proveedores.
 - Cobranzas:
   · pendientes_pago([dias_atraso]) → clientes con pedidos no pagados.
   · historico_pagos_cliente(cliente_id) → últimos pagos del cliente.
@@ -20,19 +15,16 @@ Tu trabajo es ayudar al encargado a:
   · previsualizar_pedido(cliente_id, items[]) → resumen con precios mayoristas + promos, devuelve confirmacion_id.
   · crear_pedido(confirmacion_id) → SE INVOCA SOLO desde el callback del botón Confirmar.
   Flujo: buscar_cliente → buscar_producto/productos_por_categoria → previsualizar_pedido → mostrás resumen narrativo (el bot anexa el keyboard) → tap Confirmar dispara crear_pedido. NO llames crear_pedido directamente. Forma de pago siempre 'efectivo' por default.
-- Resolver consultas operativas rápidas que se pueden contestar mirando datos.
+- Resolver consultas operativas rápidas que se pueden contestar mirando datos puntuales.
+
+REPORTES AGREGADOS NO DISPONIBLES PARA ENCARGADO:
+- Ventas del período, ventas por preventista, ranking por producto y compras del período son tools de admin. Si te las piden, decile al encargado que pida a un admin o que use la app web (sección Reportes / Comisiones). No intentes invocarlas.
 
 EJEMPLOS DE INTENT → TOOL (las fechas exactas vienen del bloque CONTEXTO DE FECHA arriba — usalas para resolver "ayer", "hoy", "esta semana"):
-- "cuánto vendimos ayer" → ventas_periodo(desde=ayer, hasta=ayer).
-- "ventas de la semana" → ventas_periodo(desde=lunes_de_esta_semana, hasta=hoy).
-- "ventas por preventista de la semana" → ventas_por_preventista(desde=lunes, hasta=hoy).
-- "quién vendió más ayer" → ventas_por_preventista(desde=ayer, hasta=ayer).
 - "deuda total de la sucursal" → pendientes_pago.
-- "qué le compré al proveedor X" → compras_periodo y mirá top_proveedores.
 - "cómo me paga Pepe" → buscar_cliente → historico_pagos_cliente.
 - "última venta al kiosco X" / "cuándo me compró Pepe" → buscar_cliente → historico_pedidos_cliente(cliente_id, limit=1, dias=180).
-- "quién vendió más sal fina este mes" → buscar_producto → ranking_preventistas_por_producto(producto_ids=[id], desde=1ro_mes, hasta=hoy).
-- "quién vendió más Manaos 3000 este mes" → listar_categorias → productos_por_categoria(categoria="MANAOS", q="3000") → ranking_preventistas_por_producto(producto_ids=[id1, id2, ...]) con TODOS los IDs que matcheen 3000cc. Mencioná al final qué sabores agrupaste.
+- "cuánto vendimos ayer" / "ventas por preventista" / "qué le compré al proveedor X" → no es para vos; redirigí a admin o app web.
 
 REGLA DE EFICIENCIA: si te piden UN SOLO dato puntual ("la última venta", "el primer pedido", "el top 3"), pasá limit=N exacto. No traigas 20 si te piden 1.
 
@@ -46,6 +38,7 @@ REGLAS:
 5. Para listas con más de 10 ítems, resumí los más relevantes y sugerí filtrar.
 6. Para preguntas que NO requieren tool (saludo, "¿qué podés hacer?"), respondé directo.
 7. Formato Telegram: bullets cortos, sin headers grandes. Montos con $ y separadores de miles (ej: $12.500).
+8. Al LISTAR pedidos que NO sean impagos, no muestres montos por pedido a menos que el usuario los pida explícitamente. Para pedidos impagos sí mostrá monto (es el dato útil de cobranza).
 
 Esta versión es acotada — todavía no podés generar reportes complejos, modificar datos, asignar preventistas a clientes ni operar sobre otras sucursales. Si te lo piden, decile que use la app web. En las próximas versiones se van a sumar más capacidades para encargado.
 

--- a/supabase/functions/_shared/tools/admin/compras_periodo.ts
+++ b/supabase/functions/_shared/tools/admin/compras_periodo.ts
@@ -54,7 +54,7 @@ export const comprasPeriodoTool: Tool<ComprasPeriodoParams, ComprasPeriodoResult
     },
     required: ["desde", "hasta"],
   },
-  allowedRoles: ["admin", "encargado"],
+  allowedRoles: ["admin"],
   handler: async ({ desde, hasta, limit = 10 }, ctx) => {
     if (!FECHA_REGEX.test(desde) || !FECHA_REGEX.test(hasta)) {
       throw new Error("Fechas inválidas (esperado YYYY-MM-DD)");

--- a/supabase/functions/_shared/tools/admin/ranking_preventistas_por_producto.ts
+++ b/supabase/functions/_shared/tools/admin/ranking_preventistas_por_producto.ts
@@ -102,7 +102,7 @@ export const rankingPreventistasPorProductoTool: Tool<
     },
     required: ["producto_ids", "desde", "hasta"],
   },
-  allowedRoles: ["admin", "encargado"],
+  allowedRoles: ["admin"],
   handler: async ({ producto_ids, desde, hasta, limit = 10 }, ctx) => {
     if (!Array.isArray(producto_ids) || producto_ids.length === 0) {
       throw new Error("producto_ids debe tener al menos 1 ID");

--- a/supabase/functions/_shared/tools/admin/ventas_periodo.ts
+++ b/supabase/functions/_shared/tools/admin/ventas_periodo.ts
@@ -69,7 +69,7 @@ export const ventasPeriodoTool: Tool<VentasPeriodoParams, VentasPeriodoResult> =
     },
     required: ["desde", "hasta"],
   },
-  allowedRoles: ["admin", "encargado"],
+  allowedRoles: ["admin"],
   handler: async ({ desde, hasta, limit = 10 }, ctx) => {
     if (!FECHA_REGEX.test(desde) || !FECHA_REGEX.test(hasta)) {
       throw new Error("Fechas inválidas (esperado YYYY-MM-DD)");

--- a/supabase/functions/_shared/tools/admin/ventas_por_preventista.ts
+++ b/supabase/functions/_shared/tools/admin/ventas_por_preventista.ts
@@ -82,7 +82,7 @@ export const ventasPorPreventistaTool: Tool<
     },
     required: ["desde", "hasta"],
   },
-  allowedRoles: ["admin", "encargado"],
+  allowedRoles: ["admin"],
   handler: async (
     { desde, hasta, solo_preventistas = true, limit = 10 },
     ctx,

--- a/supabase/functions/tests/tools.test.ts
+++ b/supabase/functions/tests/tools.test.ts
@@ -234,6 +234,23 @@ Deno.test("canInvoke deniega rol no autorizado", () => {
   assertEquals(canInvoke("transportista", adminOnly), false);
 });
 
+// Las tools de reporte agregado son admin-only desde migracion 039:
+// encargado pierde acceso a ventas_periodo, ventas_por_preventista,
+// ranking_preventistas_por_producto y compras_periodo (defensa en profundidad
+// para el filtrado de tools que ve Gemini).
+Deno.test("canInvoke bloquea reportes agregados al encargado", () => {
+  const adminOnlyReports = [
+    ventasPeriodoTool,
+    ventasPorPreventistaTool,
+    rankingPreventistasPorProductoTool,
+    comprasPeriodoTool,
+  ] as unknown as Tool[];
+  for (const t of adminOnlyReports) {
+    assertEquals(canInvoke("encargado", t), false);
+    assertEquals(canInvoke("admin", t), true);
+  }
+});
+
 // ============================================================================
 // 3. buscar_cliente: invoca el RPC bot_buscar_cliente con los params correctos
 // ============================================================================


### PR DESCRIPTION
## Summary

Cierra las restricciones del rol `encargado` que estaban a medio camino. UI + RPCs como doble defensa.

### Reglas aplicadas

| Área | Encargado puede | Encargado NO puede |
|---|---|---|
| Inventario | Ver Productos + Compras (read-only) | Crear/editar/eliminar productos, mermas, importar precios, categorías, Proveedores, Promociones, Condiciones Mayoristas, Transferencias |
| Pedidos | Editar items y cantidades, marcar pagos masivos, asignar transportista, entregas masivas, exportar, optimizar ruta | Editar precios, cancelar pedidos, anular pagos |
| Stats pedidos | Counts en todas las cards, monto solo en "Impagos" | Montos del resto de cards |
| Dashboard / Reportes / Comisiones | — | Acceder (redirect a /pedidos) |
| Pagos masivos | Solo fecha = hoy, y solo si la rendición del día no está cerrada | Pagar a otra fecha o si hay rendición confirmada/resuelta |
| Bot Telegram | Tools operativas (pendientes_pago, históricos, crear pedido, fichas) | `ventas_periodo`, `ventas_por_preventista`, `ranking_preventistas_por_producto`, `compras_periodo` |

### Backend (migración 039)

- Helper `rendicion_dia_cerrada(fecha, sucursal_id) → boolean` para que el frontend chequee antes de habilitar pagos.
- `marcar_pagos_masivo`: si caller es encargado, bloquea `p_fecha != CURRENT_DATE` y `rendicion_dia_cerrada=true`. Admin sin cambios.
- `cancelar_pedido_con_stock`: solo admin (antes admitía encargado).

### Centralización

Nuevo `src/lib/permisos.ts` con funciones puras (`puedeEditarProductos`, `mostrarMontosEnStats(rol, key)`, etc.) + tests.

## Test plan

- [ ] Aplicar migración 039 a producción (`SELECT rendicion_dia_cerrada(CURRENT_DATE, NULL);` debe devolver bool)
- [ ] Login como encargado: menú sin Dashboard, Reportes, Comisiones, Proveedores, Promociones, Condiciones Mayoristas, Transferencias
- [ ] Tipear `/dashboard`, `/reportes`, `/comisiones`, etc. en URL → redirige a `/pedidos`
- [ ] `/productos`: no aparecen botones de mutar (Nuevo, Categorías, Stock, Mermas, Importar, Cambio de productos)
- [ ] `/compras`: no aparecen botones de mutar
- [ ] Cards de pedidos: solo "Impagos" muestra monto al encargado; admin ve todos
- [ ] Menú "..." de pedido: encargado no ve "Cancelar Pedido"
- [ ] Editar pedido: items/cantidades sí; precio readonly
- [ ] ModalPagoPedido: encargado no puede anular pagos previos
- [ ] Pagos masivos encargado: input fecha disabled (hoy), banner amarillo si rendición cerrada, botón disabled
- [ ] RPC `marcar_pagos_masivo` con `p_fecha = CURRENT_DATE - 1` como encargado → falla con `42501`
- [ ] RPC `cancelar_pedido_con_stock` como encargado → falla "solo admin puede cancelar pedidos"
- [ ] Bot Telegram: encargado pregunta "cuánto vendimos ayer" → bot redirige a admin/web
- [ ] `pendientes_pago` y `historico_pagos_cliente` siguen funcionando para encargado en el bot

## Tests automáticos

- `src/lib/permisos.test.ts` → 15/15 ✅
- `supabase/functions/tests/tools.test.ts` → 62/62 ✅ (incluye nuevo caso `canInvoke('encargado', ventas_periodo) === false` para las 4 tools removidas)
- `tsc --noEmit` limpio ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)