### PR TITLE
feat(pedidos): filtro por defecto de últimos 30 días

### DIFF
--- a/src/components/containers/PedidosContainer.tsx
+++ b/src/components/containers/PedidosContainer.tsx
@@ -7,7 +7,7 @@
  */
 import React, { lazy, Suspense, useState, useCallback, useMemo } from 'react'
 import { calcularNetoVenta } from '../../utils/calculations'
-import { fechaLocalISO } from '../../utils/formatters'
+import { fechaLocalISO, fechaHaceDias } from '../../utils/formatters'
 import { preventistaPuedeEditar } from '../../utils/permisosPedido'
 import { useQueryClient } from '@tanstack/react-query'
 import { Loader2 } from 'lucide-react'
@@ -57,15 +57,22 @@ const ModalAsignarTransportistaMasivo = lazy(() => import('../modals/ModalAsigna
 
 const ITEMS_PER_PAGE = 15
 
-const DEFAULT_FILTROS: FiltrosPedidosState = {
-  fechaDesde: null,
-  fechaHasta: null,
-  estado: 'todos',
-  estadoPago: 'todos',
-  transportistaId: 'todos',
-  usuarioId: 'todos',
-  busqueda: '',
-  conSalvedad: 'todos',
+// Ventana por defecto al abrir /pedidos: ultimos N dias.
+// El usuario puede ampliar/limpiar el rango con el chip o el modal de filtro
+// de fecha. La eleccion no persiste entre sesiones (cada visita arranca aca).
+const VENTANA_DEFAULT_DIAS = 30
+
+function buildDefaultFiltros(): FiltrosPedidosState {
+  return {
+    fechaDesde: fechaHaceDias(VENTANA_DEFAULT_DIAS),
+    fechaHasta: null,
+    estado: 'todos',
+    estadoPago: 'todos',
+    transportistaId: 'todos',
+    usuarioId: 'todos',
+    busqueda: '',
+    conSalvedad: 'todos',
+  }
 }
 
 function LoadingState() {
@@ -94,7 +101,7 @@ export default function PedidosContainer(): React.ReactElement {
   const [paginaActual, setPaginaActual] = useState(1)
   const [busqueda, setBusqueda] = useState('')
   const debouncedBusqueda = useDebounce(busqueda, 350)
-  const [filtros, setFiltros] = useState<FiltrosPedidosState>(DEFAULT_FILTROS)
+  const [filtros, setFiltros] = useState<FiltrosPedidosState>(buildDefaultFiltros)
 
   // Queries - use debounced search to avoid firing on every keystroke
   const { registrarPago, registrarPagosBatch, fetchPagosPedido, eliminarPago } = usePagos()

--- a/src/utils/formatters.test.js
+++ b/src/utils/formatters.test.js
@@ -19,7 +19,9 @@ import {
   capitalize,
   formatPercent,
   formatNumber,
-  isValidEmail
+  isValidEmail,
+  fechaLocalISO,
+  fechaHaceDias,
 } from './formatters'
 
 describe('Formatters de Moneda', () => {
@@ -367,6 +369,40 @@ describe('Utilidades Generales', () => {
       expect(isValidEmail('@domain.com')).toBe(false)
       expect(isValidEmail('')).toBe(false)
       expect(isValidEmail(null)).toBe(false)
+    })
+  })
+})
+
+describe('Fechas', () => {
+  describe('fechaHaceDias', () => {
+    // base fija al mediodia para evitar bordes de TZ ARG (UTC-3)
+    const base = new Date('2026-05-11T15:00:00Z') // 12:00 ARG
+
+    it('0 dias = mismo dia que la base', () => {
+      expect(fechaHaceDias(0, base)).toBe(fechaLocalISO(base))
+    })
+
+    it('30 dias atras desde 11 mayo = 11 abril', () => {
+      expect(fechaHaceDias(30, base)).toBe('2026-04-11')
+    })
+
+    it('maneja cruce de mes corto (28 dias atras desde 5 marzo cae en febrero)', () => {
+      const marzo5 = new Date('2026-03-05T15:00:00Z')
+      expect(fechaHaceDias(28, marzo5)).toBe('2026-02-05')
+    })
+
+    it('maneja cruce de año (10 dias atras desde 5 enero = 26 diciembre)', () => {
+      const enero5 = new Date('2026-01-05T15:00:00Z')
+      expect(fechaHaceDias(10, enero5)).toBe('2025-12-26')
+    })
+
+    it('default base = hoy', () => {
+      const hoy = fechaLocalISO()
+      const ayer = fechaHaceDias(1)
+      // No comparamos un valor fijo (depende de cuando corre el test) pero
+      // ayer debe ser un string YYYY-MM-DD distinto de hoy.
+      expect(ayer).toMatch(/^\d{4}-\d{2}-\d{2}$/)
+      expect(ayer).not.toBe(hoy)
     })
   })
 })

--- a/src/utils/formatters.ts
+++ b/src/utils/formatters.ts
@@ -65,6 +65,17 @@ export function fechaLocalISO(date: Date = new Date()): string {
 }
 
 /**
+ * Restar N dias a la fecha base (default hoy) y devolver YYYY-MM-DD en
+ * TZ Argentina. Usa setDate del Date local, que normaliza correctamente
+ * el rollover entre meses (ej. 11 mayo - 30 dias = 11 abril).
+ */
+export function fechaHaceDias(dias: number, base: Date = new Date()): string {
+  const d = new Date(base)
+  d.setDate(d.getDate() - dias)
+  return fechaLocalISO(d)
+}
+
+/**
  * Parsea un string de fecha de forma segura.
  * Para strings date-only (YYYY-MM-DD), agrega T12:00:00 para evitar
  * que JavaScript los interprete como UTC medianoche (lo cual causa
@@ -429,6 +440,7 @@ export default {
   formatCurrency,
   formatCurrencyCompact,
   fechaLocalISO,
+  fechaHaceDias,
   formatFecha,
   formatDate,
   formatDateTime,


### PR DESCRIPTION
## Summary

La pantalla `/pedidos` arranca con `fechaDesde = hoy - 30 días`, `fechaHasta = null`. El listado y las 6 cards de stats (incluida Impagos) reflejan solo ese rango. Reduce el volumen de filas cargado por defecto en una sucursal con histórico largo.

- Nuevo helper `fechaHaceDias(dias, base?)` en `utils/formatters.ts` (TZ Argentina) + 5 tests.
- `DEFAULT_FILTROS` en `PedidosContainer.tsx` reemplazado por `buildDefaultFiltros()` con lazy init en `useState` (recalcula al montar, no se atasca con la fecha del bundle si la pestaña queda abierta cruzando medianoche).
- Ventana acordada con el usuario: sliding window, no persiste entre sesiones, todos los roles.

## UX

El chip "Filtrado: `<hoy-30>` - ..." que ya renderiza `PedidoFilters` aparece automáticamente con el rango activo. Botón "X" del chip → limpia a "ver todo" (comportamiento previo). `ModalFiltroFecha` sigue funcionando para elegir otros rangos.

## Caveat

La card "Impagos" en el default solo refleja deuda de los últimos 30 días. Si esto oculta demasiada deuda vieja en uso real, se puede cambiar a "Impagos siempre global" con un fetch separado para esa card.

## Test plan

- [ ] Abrir `/pedidos`: aparece el chip "Filtrado: 2026-04-11 - ..." y las cards muestran solo los últimos 30 días
- [ ] Click en "X" del chip: ven todo como antes
- [ ] Abrir `ModalFiltroFecha`, elegir rango: chip se actualiza, cards y listado siguen el rango
- [ ] Refresh: vuelve al default de 30 días (esperado, sin persistencia)
- [ ] Login como preventista / transportista: misma lógica de default (los filtros de rol siguen aplicándose por encima)

## Tests automáticos

- `src/utils/formatters.test.js` → 64/64 (5 nuevos para `fechaHaceDias`: 0 días, 30 desde 11-may, cruce de mes corto, cruce de año, default base = hoy)
- `tsc --noEmit` limpio

🤖 Generated with [Claude Code](https://claude.com/claude-code)