### PR TITLE
fix(usuarios): permitir rol encargado al editar/crear usuario

### DIFF
--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -373,7 +373,7 @@ export const usuarioSchema = z.object({
     .email({ message: 'Email inválido' })
     .min(1, { message: 'El email es obligatorio' }),
 
-  rol: z.enum(['admin', 'preventista', 'transportista', 'deposito'], {
+  rol: z.enum(['admin', 'preventista', 'transportista', 'deposito', 'encargado'], {
     error: 'Rol invalido'
   }),
 
@@ -386,7 +386,7 @@ export const usuarioSchema = z.object({
 export type UsuarioFormData = z.infer<typeof usuarioSchema>
 
 /** Valid user roles */
-export type RolUsuario = 'admin' | 'preventista' | 'transportista' | 'deposito'
+export type RolUsuario = 'admin' | 'preventista' | 'transportista' | 'deposito' | 'encargado'
 
 // ============================================
 // SCHEMAS DE PROVEEDOR


### PR DESCRIPTION
## Problema

Al editar un usuario y elegir rol "Encargado" en `ModalUsuario`, al guardar aparece error "Rol invalido" y no se puede asignar el rol.

## Causa

El schema Zod `usuarioSchema.rol` en `src/lib/schemas.ts:376` tenía el enum hardcoded a `('admin','preventista','transportista','deposito')`. Cuando se agregó el rol `'encargado'` (migración 041, tipo `RolUsuario` en `types/index.ts`, dropdown del modal en `ModalUsuario.tsx:157`), este schema quedó desactualizado. La validación frontend rechaza el rol antes de llegar al backend.

## Fix

- `src/lib/schemas.ts:376` — agregar `'encargado'` al `z.enum`.
- `src/lib/schemas.ts:389` — agregar `'encargado'` al tipo local `RolUsuario` para que el archivo quede consistente (ese tipo local no lo usa nadie externamente, pero conviene mantenerlo en sync).

## Test plan

- [ ] `/usuarios` → editar un usuario → elegir "Encargado" en el dropdown → guardar → ya no aparece "Rol invalido", se persiste el cambio
- [ ] Verificar en Supabase que `perfiles.rol = 'encargado'` quedó guardado
- [ ] El resto de roles (admin, preventista, transportista, deposito) siguen funcionando

## Tests automáticos

- `src/lib/schemas.test.js` → 25/25 verde
- `tsc --noEmit` limpio

🤖 Generated with [Claude Code](https://claude.com/claude-code)