### PR TITLE
fix(perfiles): ampliar CHECK perfiles_rol_check con deposito y encargado

### DIFF
--- a/migrations/040_perfiles_rol_check_encargado.sql
+++ b/migrations/040_perfiles_rol_check_encargado.sql
@@ -1,0 +1,23 @@
+-- =========================================================================
+-- 040_perfiles_rol_check_encargado.sql
+--
+-- El CHECK constraint perfiles_rol_check quedo desactualizado: solo permite
+-- 'admin', 'preventista', 'transportista'. Cuando se agrego 'encargado' (y
+-- 'deposito' antes), el constraint no fue refrescado y ahora bloquea editar
+-- usuarios a esos roles con:
+--   ERROR: new row for relation "perfiles" violates check constraint
+--          "perfiles_rol_check"
+--
+-- Reemplazamos el constraint con la lista completa de roles del enum
+-- RolUsuario (src/types/index.ts) y BotRol (supabase/functions/_shared/types.ts).
+-- =========================================================================
+
+BEGIN;
+
+ALTER TABLE public.perfiles DROP CONSTRAINT IF EXISTS perfiles_rol_check;
+
+ALTER TABLE public.perfiles
+  ADD CONSTRAINT perfiles_rol_check
+  CHECK (rol = ANY (ARRAY['admin', 'preventista', 'transportista', 'deposito', 'encargado']::text[]));
+
+COMMIT;


### PR DESCRIPTION
## Problema

Después del fix del schema Zod (#295), al guardar un usuario con rol "Encargado" ahora aparece el error del backend:

> `new row for relation "perfiles" violates check constraint "perfiles_rol_check"`

## Causa

El CHECK constraint en producción seguía con la lista vieja:

```
CHECK (rol = ANY (ARRAY['admin', 'preventista', 'transportista']))
```

Faltaban `'deposito'` y `'encargado'`. La migración `archive/041_encargado_cancelar_stock.sql` que iba a actualizar este constraint quedó archivada y nunca se aplicó.

## Fix

Migración 040 que reemplaza el CHECK con la lista completa de roles del enum `RolUsuario` (`src/types/index.ts`):

```sql
ALTER TABLE public.perfiles DROP CONSTRAINT IF EXISTS perfiles_rol_check;
ALTER TABLE public.perfiles
  ADD CONSTRAINT perfiles_rol_check
  CHECK (rol = ANY (ARRAY['admin','preventista','transportista','deposito','encargado']::text[]));
```

**Ya aplicada en producción** (proyecto Supabase `hmuchlzmuqqxcldbzkgc`).

## Test plan

- [ ] `/usuarios` → editar Jony → rol "Encargado" → Guardar → persiste sin error
- [ ] Mismo flujo con rol "Depósito" → funciona
- [ ] Resto de roles siguen funcionando

🤖 Generated with [Claude Code](https://claude.com/claude-code)