### PR TITLE
fix(productos): mostrar categorias recien creadas en el modal de producto

### DIFF
--- a/src/components/containers/ProductosContainer.tsx
+++ b/src/components/containers/ProductosContainer.tsx
@@ -16,6 +16,7 @@ import { useMermasQuery, useRegistrarMermaMutation } from '../../hooks/queries'
 import { useProveedoresActivosQuery } from '../../hooks/queries'
 import { useClientesQuery } from '../../hooks/queries'
 import { useRegistrarCambioProductoMutation, type RegistrarCambioInput } from '../../hooks/queries'
+import { useCategoriasQuery } from '../../hooks/queries'
 import { useAuthData } from '../../contexts/AuthDataContext'
 import { useNotification } from '../../contexts/NotificationContext'
 import { formatPrecio } from '../../utils/formatters'
@@ -57,6 +58,7 @@ export default function ProductosContainer(): React.ReactElement {
   const { data: mermas = [] } = useMermasQuery()
   const { data: proveedores = [] } = useProveedoresActivosQuery()
   const { data: clientes = [] } = useClientesQuery()
+  const { data: categoriasTabla = [] } = useCategoriasQuery()
 
   // Mutations
   const crearProducto = useCrearProductoMutation()
@@ -80,14 +82,20 @@ export default function ProductosContainer(): React.ReactElement {
   // Confirm modal state
   const [confirmConfig, setConfirmConfig] = useState<ConfirmConfig>({ visible: false })
 
-  // Categorías derivadas
+  // Categorías para el selector del modal: une la tabla `categorias` (solo
+  // activas) con las categorías derivadas de productos (strings heredados que
+  // todavía no se migraron a la tabla). Sin esto, una categoría recién creada
+  // no aparece hasta que se le asigna a algún producto.
   const categorias = useMemo(() => {
-    const cats = new Set<string>()
-    productos.forEach(p => {
-      if (p.categoria) cats.add(p.categoria)
+    const set = new Set<string>()
+    categoriasTabla.forEach(c => {
+      if (c.activa !== false) set.add(c.nombre)
     })
-    return Array.from(cats).sort()
-  }, [productos])
+    productos.forEach(p => {
+      if (p.categoria) set.add(p.categoria)
+    })
+    return Array.from(set).sort((a, b) => a.localeCompare(b))
+  }, [categoriasTabla, productos])
 
   // Handlers
   const handleNuevoProducto = useCallback(() => {


### PR DESCRIPTION
## Summary
- `ProductosContainer` armaba el listado pasado al selector del modal de producto solo desde `productos.categoria`, ignorando la tabla `categorias`. Una categoria recien creada via "Gestionar Categorias" no aparecia en el desplegable hasta asignarsela a algun producto.
- Ahora el container une la tabla `categorias` (filtrando inactivas via `activa !== false`) con las categorias derivadas de productos heredados, deduplicado por nombre y ordenado con `localeCompare`. Sin cambios de DB ni de API.
- `ModalProducto` ya soportaba `string[] | CategoriaOption[]`, asi que la firma no cambia.

## Test plan
- [ ] `npm run dev` → entrar al panel **Productos** como admin.
- [ ] Abrir "Gestionar Categorias" → crear una nueva (ej. `TestQA-<timestamp>`) → cerrar el modal.
- [ ] Abrir "Nuevo Producto" → la categoria recien creada aparece en el desplegable.
- [ ] Guardar el producto con esa categoria → reabrirlo y verificar que persiste.
- [ ] Negativo: desactivar (toggle) una categoria desde "Gestionar Categorias" → ya **no** aparece en el desplegable de "Nuevo Producto" (pero sigue visible en `ModalCategorias` para re-activar).
- [ ] Derivada: un producto con `categoria` heredada (string sin fila en `categorias`) sigue mostrando esa opcion en el desplegable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)