### PR TITLE
feat(geolocalizacion): check-in GPS al confirmar pedido + panel admin

### DIFF
--- a/migrations/040_pedidos_geolocalizacion.sql
+++ b/migrations/040_pedidos_geolocalizacion.sql
@@ -1,0 +1,272 @@
+-- =========================================================================
+-- 040_pedidos_geolocalizacion.sql
+--
+-- Geolocalizacion de preventistas via check-in al confirmar un pedido.
+--
+--   1. Columnas gps_* en public.pedidos (todas nullable, retro-compatibles).
+--
+--   2. Helper public.haversine_m(lat1, lng1, lat2, lng2) -> numeric (metros).
+--
+--   3. RPC public.registrar_geolocalizacion_pedido(p_pedido_id, p_lat, p_lng,
+--      p_accuracy, p_status). Permite al preventista que creo el pedido (o un
+--      admin) setear el GPS una sola vez. Idempotente: si gps_status ya esta
+--      seteado, no se sobrescribe.
+--
+--   4. RPC public.obtener_geolocalizacion_preventistas(p_fecha_desde,
+--      p_fecha_hasta) -> jsonb. Solo admin. Devuelve el resumen por
+--      preventista + detalle por pedido para el panel de control admin.
+--      Scope a current_sucursal_id().
+-- =========================================================================
+
+BEGIN;
+
+-- -------------------------------------------------------------------------
+-- 1. Columnas GPS en pedidos
+-- -------------------------------------------------------------------------
+
+ALTER TABLE public.pedidos
+  ADD COLUMN IF NOT EXISTS gps_lat numeric(10,7),
+  ADD COLUMN IF NOT EXISTS gps_lng numeric(10,7),
+  ADD COLUMN IF NOT EXISTS gps_accuracy numeric(8,2),
+  ADD COLUMN IF NOT EXISTS gps_capturado_at timestamptz,
+  ADD COLUMN IF NOT EXISTS gps_status text;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'pedidos_gps_status_check'
+      AND conrelid = 'public.pedidos'::regclass
+  ) THEN
+    ALTER TABLE public.pedidos
+      ADD CONSTRAINT pedidos_gps_status_check
+      CHECK (gps_status IS NULL OR gps_status IN ('ok','denied','unavailable','timeout','error'));
+  END IF;
+END $$;
+
+COMMENT ON COLUMN public.pedidos.gps_lat IS 'Latitud del preventista al confirmar el pedido (check-in). Null si no se capturo.';
+COMMENT ON COLUMN public.pedidos.gps_lng IS 'Longitud del preventista al confirmar el pedido.';
+COMMENT ON COLUMN public.pedidos.gps_accuracy IS 'Precision del GPS en metros (acc del navegador).';
+COMMENT ON COLUMN public.pedidos.gps_capturado_at IS 'Timestamp del check-in (lado cliente).';
+COMMENT ON COLUMN public.pedidos.gps_status IS 'Estado del check-in: ok | denied | unavailable | timeout | error. Null para pedidos previos a la migracion.';
+
+-- Indice para queries del panel admin (pedidos del dia con GPS por preventista)
+CREATE INDEX IF NOT EXISTS idx_pedidos_gps_capturado_at
+  ON public.pedidos (gps_capturado_at DESC)
+  WHERE gps_status = 'ok';
+
+-- -------------------------------------------------------------------------
+-- 2. Helper haversine_m
+-- -------------------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION public.haversine_m(
+  lat1 numeric, lng1 numeric, lat2 numeric, lng2 numeric
+) RETURNS numeric
+LANGUAGE sql IMMUTABLE PARALLEL SAFE
+AS $$
+  SELECT CASE
+    WHEN lat1 IS NULL OR lng1 IS NULL OR lat2 IS NULL OR lng2 IS NULL THEN NULL
+    ELSE (
+      6371000 * 2 * asin(
+        sqrt(
+          power(sin(radians((lat2 - lat1) / 2)), 2) +
+          cos(radians(lat1)) * cos(radians(lat2)) *
+          power(sin(radians((lng2 - lng1) / 2)), 2)
+        )
+      )
+    )::numeric
+  END;
+$$;
+
+COMMENT ON FUNCTION public.haversine_m(numeric, numeric, numeric, numeric) IS
+  'Distancia en metros entre dos coordenadas (lat,lng) usando formula haversine. Devuelve NULL si algun argumento es NULL.';
+
+GRANT EXECUTE ON FUNCTION public.haversine_m(numeric, numeric, numeric, numeric) TO anon, authenticated, service_role;
+
+-- -------------------------------------------------------------------------
+-- 3. RPC registrar_geolocalizacion_pedido
+-- -------------------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION public.registrar_geolocalizacion_pedido(
+  p_pedido_id bigint,
+  p_status text,
+  p_lat numeric DEFAULT NULL,
+  p_lng numeric DEFAULT NULL,
+  p_accuracy numeric DEFAULT NULL,
+  p_capturado_at timestamptz DEFAULT NULL
+) RETURNS jsonb
+LANGUAGE plpgsql SECURITY DEFINER SET search_path TO 'public'
+AS $$
+DECLARE
+  v_user_id uuid := auth.uid();
+  v_user_role text;
+  v_pedido RECORD;
+BEGIN
+  IF v_user_id IS NULL THEN
+    RETURN jsonb_build_object('success', false, 'error', 'No autenticado');
+  END IF;
+
+  IF p_status NOT IN ('ok','denied','unavailable','timeout','error') THEN
+    RETURN jsonb_build_object('success', false, 'error', 'gps_status invalido');
+  END IF;
+
+  -- Si status='ok', lat y lng son obligatorios.
+  IF p_status = 'ok' AND (p_lat IS NULL OR p_lng IS NULL) THEN
+    RETURN jsonb_build_object('success', false, 'error', 'lat y lng requeridos cuando status=ok');
+  END IF;
+
+  SELECT rol INTO v_user_role FROM perfiles WHERE id = v_user_id;
+
+  SELECT id, usuario_id, sucursal_id, gps_status INTO v_pedido
+  FROM pedidos
+  WHERE id = p_pedido_id;
+
+  IF NOT FOUND THEN
+    RETURN jsonb_build_object('success', false, 'error', 'Pedido no existe');
+  END IF;
+
+  -- Sucursal: el RPC ya corre con SECURITY DEFINER asi que no depende de
+  -- current_sucursal_id(); igual validamos que el pedido pertenezca a la
+  -- sucursal activa para evitar cross-sucursal en multi-tenant.
+  IF v_pedido.sucursal_id IS DISTINCT FROM current_sucursal_id() THEN
+    RETURN jsonb_build_object('success', false, 'error', 'Pedido fuera de la sucursal activa');
+  END IF;
+
+  -- Autorizacion: dueño del pedido (preventista que lo creo) o admin.
+  IF v_pedido.usuario_id IS DISTINCT FROM v_user_id AND v_user_role <> 'admin' THEN
+    RETURN jsonb_build_object('success', false, 'error', 'No autorizado');
+  END IF;
+
+  -- Idempotente: no sobrescribir un check-in ya registrado.
+  IF v_pedido.gps_status IS NOT NULL THEN
+    RETURN jsonb_build_object('success', true, 'ya_registrado', true);
+  END IF;
+
+  UPDATE pedidos SET
+    gps_status = p_status,
+    gps_lat = CASE WHEN p_status = 'ok' THEN p_lat ELSE NULL END,
+    gps_lng = CASE WHEN p_status = 'ok' THEN p_lng ELSE NULL END,
+    gps_accuracy = CASE WHEN p_status = 'ok' THEN p_accuracy ELSE NULL END,
+    gps_capturado_at = COALESCE(p_capturado_at, now())
+  WHERE id = p_pedido_id;
+
+  RETURN jsonb_build_object('success', true);
+END;
+$$;
+
+ALTER FUNCTION public.registrar_geolocalizacion_pedido(bigint, text, numeric, numeric, numeric, timestamptz) OWNER TO postgres;
+
+COMMENT ON FUNCTION public.registrar_geolocalizacion_pedido(bigint, text, numeric, numeric, numeric, timestamptz) IS
+  'Registra el check-in GPS de un pedido. Solo el preventista dueño o un admin. Idempotente: no sobrescribe un check-in existente.';
+
+GRANT EXECUTE ON FUNCTION public.registrar_geolocalizacion_pedido(bigint, text, numeric, numeric, numeric, timestamptz)
+  TO authenticated, service_role;
+
+-- -------------------------------------------------------------------------
+-- 4. RPC obtener_geolocalizacion_preventistas
+-- -------------------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION public.obtener_geolocalizacion_preventistas(
+  p_fecha_desde date DEFAULT NULL,
+  p_fecha_hasta date DEFAULT NULL
+) RETURNS jsonb
+LANGUAGE plpgsql SECURITY DEFINER SET search_path TO 'public'
+AS $$
+DECLARE
+  v_user_id uuid := auth.uid();
+  v_user_role text;
+  v_sucursal bigint := current_sucursal_id();
+  v_fecha_desde date := COALESCE(p_fecha_desde, (now() AT TIME ZONE 'America/Argentina/Buenos_Aires')::date);
+  v_fecha_hasta date := COALESCE(p_fecha_hasta, v_fecha_desde);
+  v_result jsonb;
+BEGIN
+  IF v_user_id IS NULL THEN
+    RAISE EXCEPTION 'No autenticado' USING ERRCODE = '42501';
+  END IF;
+  IF v_sucursal IS NULL THEN
+    RAISE EXCEPTION 'No hay sucursal activa' USING ERRCODE = '42501';
+  END IF;
+
+  SELECT rol INTO v_user_role FROM perfiles WHERE id = v_user_id;
+  IF v_user_role <> 'admin' THEN
+    RAISE EXCEPTION 'Solo admins pueden ver geolocalizacion de preventistas' USING ERRCODE = '42501';
+  END IF;
+
+  WITH pedidos_rango AS (
+    SELECT
+      p.id              AS pedido_id,
+      p.usuario_id      AS preventista_id,
+      p.fecha,
+      p.total,
+      p.gps_lat,
+      p.gps_lng,
+      p.gps_accuracy,
+      p.gps_capturado_at,
+      p.gps_status,
+      p.cliente_id,
+      c.nombre          AS cliente_nombre,
+      c.latitud         AS cliente_lat,
+      c.longitud        AS cliente_lng,
+      public.haversine_m(p.gps_lat, p.gps_lng, c.latitud, c.longitud) AS distancia_m
+    FROM pedidos p
+    LEFT JOIN clientes c ON c.id = p.cliente_id
+    WHERE p.sucursal_id = v_sucursal
+      AND p.fecha BETWEEN v_fecha_desde AND v_fecha_hasta
+      AND p.usuario_id IS NOT NULL
+  ),
+  preventistas_resumen AS (
+    SELECT
+      pr.preventista_id,
+      per.nombre AS preventista_nombre,
+      COUNT(*)::int AS total_pedidos,
+      COUNT(*) FILTER (WHERE pr.gps_status = 'ok')::int AS pedidos_con_gps,
+      COUNT(*) FILTER (WHERE pr.gps_status IS NULL OR pr.gps_status <> 'ok')::int AS pedidos_sin_gps,
+      COUNT(*) FILTER (
+        WHERE pr.gps_status = 'ok' AND pr.distancia_m IS NOT NULL AND pr.distancia_m >= 2000
+      )::int AS pedidos_lejos,
+      (
+        SELECT jsonb_build_object(
+          'lat', pr2.gps_lat,
+          'lng', pr2.gps_lng,
+          'capturado_at', pr2.gps_capturado_at,
+          'pedido_id', pr2.pedido_id
+        )
+        FROM pedidos_rango pr2
+        WHERE pr2.preventista_id = pr.preventista_id
+          AND pr2.gps_status = 'ok'
+        ORDER BY pr2.gps_capturado_at DESC NULLS LAST
+        LIMIT 1
+      ) AS ultima_ubicacion
+    FROM pedidos_rango pr
+    LEFT JOIN perfiles per ON per.id = pr.preventista_id
+    WHERE per.rol = 'preventista'
+    GROUP BY pr.preventista_id, per.nombre
+  )
+  SELECT jsonb_build_object(
+    'fecha_desde', v_fecha_desde,
+    'fecha_hasta', v_fecha_hasta,
+    'preventistas', COALESCE(
+      (SELECT jsonb_agg(to_jsonb(preventistas_resumen.*) ORDER BY preventista_nombre)
+       FROM preventistas_resumen),
+      '[]'::jsonb
+    ),
+    'pedidos', COALESCE(
+      (SELECT jsonb_agg(to_jsonb(pr.*) ORDER BY pr.gps_capturado_at NULLS LAST)
+       FROM pedidos_rango pr
+       JOIN perfiles per ON per.id = pr.preventista_id AND per.rol = 'preventista'),
+      '[]'::jsonb
+    )
+  ) INTO v_result;
+
+  RETURN v_result;
+END;
+$$;
+
+ALTER FUNCTION public.obtener_geolocalizacion_preventistas(date, date) OWNER TO postgres;
+
+COMMENT ON FUNCTION public.obtener_geolocalizacion_preventistas(date, date) IS
+  'Panel admin de geolocalizacion: resumen por preventista + detalle de pedidos con GPS y distancia al cliente. Scope a current_sucursal_id().';
+
+GRANT EXECUTE ON FUNCTION public.obtener_geolocalizacion_preventistas(date, date) TO authenticated, service_role;
+
+COMMIT;

--- a/src/components/AppRouter.tsx
+++ b/src/components/AppRouter.tsx
@@ -26,6 +26,7 @@ const VistaCompras = lazy(() => import('./vistas/VistaCompras'))
 const VistaProveedores = lazy(() => import('./vistas/VistaProveedores'))
 const VistaRendiciones = lazy(() => import('./vistas/VistaRendiciones'))
 const VistaSalvedades = lazy(() => import('./vistas/VistaSalvedades'))
+const VistaGeolocalizacion = lazy(() => import('./vistas/VistaGeolocalizacion'))
 
 // =============================================================================
 // LOADING FALLBACK
@@ -197,6 +198,16 @@ export default function AppRouter({ vistaProps }: AppRouterProps): ReactElement 
           element={
             <ProtectedRoute requireAdmin>
               <VistaSalvedades />
+            </ProtectedRoute>
+          }
+        />
+
+        {/* Geolocalización - solo admin */}
+        <Route
+          path="/geolocalizacion"
+          element={
+            <ProtectedRoute requireAdmin>
+              <VistaGeolocalizacion />
             </ProtectedRoute>
           }
         />

--- a/src/components/containers/PedidosContainer.tsx
+++ b/src/components/containers/PedidosContainer.tsx
@@ -32,6 +32,7 @@ import { useNotification } from '../../contexts/NotificationContext'
 import { useOptimizarRuta } from '../../hooks/useOptimizarRuta'
 import { usePromocionPedido } from '../../hooks/usePromocionPedido'
 import { useDebounce } from '../../hooks/useAsync'
+import { useRegistrarGeolocalizacionPedido } from '../../hooks/useRegistrarGeolocalizacionPedido'
 import { supabase } from '../../hooks/supabase/base'
 import { usePagos } from '../../hooks/supabase/usePagos'
 import type { PedidoDB, FiltrosPedidosState, PerfilDB, RegistrarSalvedadInput, RegistrarSalvedadResult, PagoDBWithUsuario } from '../../types'
@@ -123,6 +124,10 @@ export default function PedidosContainer(): React.ReactElement {
 
   // Mutations
   const crearPedido = useCrearPedidoMutation()
+  // Geolocalización: solo se captura cuando el usuario es preventista. El
+  // RPC backend valida igualmente la autorización; este flag solo evita
+  // mostrar el prompt nativo de GPS a roles que no son target.
+  const { capturarGps, registrarGpsPedido } = useRegistrarGeolocalizacionPedido()
   const cambiarEstado = useCambiarEstadoMutation()
   const asignarTransportistaMut = useAsignarTransportistaMutation()
   const entregasMasivas = useEntregasMasivasMutation()
@@ -721,6 +726,10 @@ export default function PedidosContainer(): React.ReactElement {
       return
     }
     setGuardando(true)
+    // Disparamos la captura de GPS en paralelo a la creación del pedido para
+    // no agregar latencia al flujo. Sólo si el usuario es preventista (target
+    // del feature). El RPC vuelve a validar la autorización en el backend.
+    const gpsPromise = isPreventista ? capturarGps() : null
     try {
       // Use promo+wholesale-resolved items and total (includes bonificaciones)
       const tipoFactura = nuevoPedido.tipoFactura || 'ZZ'
@@ -755,7 +764,7 @@ export default function PedidosContainer(): React.ReactElement {
           porcentaje_iva: pctIva,
         }
       })
-      await crearPedido.mutateAsync({
+      const pedidoCreado = await crearPedido.mutateAsync({
         clienteId: nuevoPedido.clienteId,
         items: itemsParaCrear,
         total: totalFinal,
@@ -770,6 +779,13 @@ export default function PedidosContainer(): React.ReactElement {
         totalIva,
         fechaEntregaProgramada: nuevoPedido.fechaEntregaProgramada,
       })
+      // Check-in GPS: fire-and-forget. La promesa de captura ya está corriendo
+      // en paralelo desde el inicio del handler; cuando resuelva, mandamos el
+      // resultado al RPC. No bloquea el toast de éxito.
+      if (gpsPromise && pedidoCreado?.id) {
+        const pedidoId = pedidoCreado.id
+        gpsPromise.then(gps => { void registrarGpsPedido(pedidoId, gps) })
+      }
       resetNuevoPedido()
       setModalPedidoOpen(false)
       notify.success('Pedido creado correctamente')
@@ -777,7 +793,7 @@ export default function PedidosContainer(): React.ReactElement {
       notify.error('Error al crear pedido: ' + (e as Error).message)
     }
     setGuardando(false)
-  }, [nuevoPedido, itemsFinales, totalFinal, crearPedido, user, resetNuevoPedido, notify, productos])
+  }, [nuevoPedido, itemsFinales, totalFinal, crearPedido, user, resetNuevoPedido, notify, productos, isPreventista, capturarGps, registrarGpsPedido])
 
   // ModalFiltroFecha: onApply({ fechaDesde, fechaHasta })
   const handleFiltroFechaApply = useCallback((f: { fechaDesde: string | null; fechaHasta: string | null }) => {

--- a/src/components/geolocalizacion/KpiCard.tsx
+++ b/src/components/geolocalizacion/KpiCard.tsx
@@ -1,0 +1,38 @@
+import React from 'react'
+import type { LucideIcon } from 'lucide-react'
+
+interface KpiCardProps {
+  label: string
+  value: number | string
+  icon: LucideIcon
+  /** Tono del icono y barrita superior. Default: blue. */
+  tone?: 'blue' | 'green' | 'amber' | 'red' | 'slate'
+  hint?: string
+}
+
+const TONES: Record<NonNullable<KpiCardProps['tone']>, { bg: string; icon: string; bar: string }> = {
+  blue:  { bg: 'bg-blue-50 dark:bg-blue-900/20',   icon: 'text-blue-600 dark:text-blue-400',   bar: 'bg-blue-500' },
+  green: { bg: 'bg-green-50 dark:bg-green-900/20', icon: 'text-green-600 dark:text-green-400', bar: 'bg-green-500' },
+  amber: { bg: 'bg-amber-50 dark:bg-amber-900/20', icon: 'text-amber-600 dark:text-amber-400', bar: 'bg-amber-500' },
+  red:   { bg: 'bg-red-50 dark:bg-red-900/20',     icon: 'text-red-600 dark:text-red-400',     bar: 'bg-red-500' },
+  slate: { bg: 'bg-slate-50 dark:bg-slate-800/40', icon: 'text-slate-600 dark:text-slate-300', bar: 'bg-slate-400' },
+}
+
+export default function KpiCard({ label, value, icon: Icon, tone = 'blue', hint }: KpiCardProps): React.ReactElement {
+  const t = TONES[tone]
+  return (
+    <div className="relative overflow-hidden rounded-xl bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 shadow-sm hover:shadow-md transition-shadow p-4">
+      <div className={`absolute top-0 left-0 right-0 h-0.5 ${t.bar}`} aria-hidden />
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0">
+          <p className="text-xs font-medium uppercase tracking-wide text-gray-500 dark:text-gray-400 truncate">{label}</p>
+          <p className="mt-1 text-2xl font-semibold text-gray-900 dark:text-white tabular-nums">{value}</p>
+          {hint && <p className="mt-1 text-xs text-gray-400 dark:text-gray-500 truncate">{hint}</p>}
+        </div>
+        <div className={`shrink-0 rounded-lg p-2 ${t.bg}`}>
+          <Icon className={`w-5 h-5 ${t.icon}`} aria-hidden />
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/components/geolocalizacion/MapaPreventistas.tsx
+++ b/src/components/geolocalizacion/MapaPreventistas.tsx
@@ -1,0 +1,275 @@
+/* global google */
+import React, { useEffect, useRef, useState } from 'react'
+import { Loader2, MapPin } from 'lucide-react'
+import { useGoogleMaps } from '../../hooks/useGoogleMaps'
+import { colorPreventista, formatDistancia, clasificarDistancia, SEMAFORO_COLORS } from '../../utils/geo'
+import { formatPrecio } from '../../utils/formatters'
+import type { PreventistaResumen, PedidoConGps } from '../../hooks/queries'
+
+interface MapaPreventistasProps {
+  preventistas: PreventistaResumen[]
+  pedidos: PedidoConGps[]
+  preventistaSelectedId: string | null
+  pedidoSelectedId: number | null
+  onSelectPreventista: (id: string | null) => void
+  onSelectPedido: (pedidoId: number | null) => void
+}
+
+// Tucumán fallback si no hay datos en el rango.
+const FALLBACK_CENTER = { lat: -26.8083, lng: -65.2176 }
+const FALLBACK_ZOOM = 12
+
+function escapeHtml(s: string): string {
+  return s.replace(/[&<>"']/g, ch => {
+    switch (ch) {
+      case '&': return '&amp;'
+      case '<': return '&lt;'
+      case '>': return '&gt;'
+      case '"': return '&quot;'
+      case "'": return '&#39;'
+      default: return ch
+    }
+  })
+}
+
+function formatHora(iso: string | null | undefined): string {
+  if (!iso) return '—'
+  try {
+    return new Date(iso).toLocaleTimeString('es-AR', { hour: '2-digit', minute: '2-digit' })
+  } catch {
+    return '—'
+  }
+}
+
+function pinSymbol(color: string, scale = 8): google.maps.Symbol {
+  return {
+    path: google.maps.SymbolPath.CIRCLE,
+    fillColor: color,
+    fillOpacity: 1,
+    strokeColor: '#ffffff',
+    strokeWeight: 2,
+    scale,
+  }
+}
+
+export default function MapaPreventistas({
+  preventistas,
+  pedidos,
+  preventistaSelectedId,
+  pedidoSelectedId,
+  onSelectPreventista,
+  onSelectPedido,
+}: MapaPreventistasProps): React.ReactElement {
+  const { isLoaded, isLoading, error } = useGoogleMaps()
+  const containerRef = useRef<HTMLDivElement | null>(null)
+  const mapRef = useRef<google.maps.Map | null>(null)
+  const markersRef = useRef<google.maps.Marker[]>([])
+  const polylineRef = useRef<google.maps.Polyline | null>(null)
+  const infoWindowRef = useRef<google.maps.InfoWindow | null>(null)
+  const [mapReady, setMapReady] = useState(false)
+
+  // Inicializar el mapa una sola vez.
+  useEffect(() => {
+    if (!isLoaded || !containerRef.current || mapRef.current) return
+    const g = (window.google as unknown as { maps: typeof google.maps } | undefined)?.maps
+    if (!g) return
+
+    mapRef.current = new g.Map(containerRef.current, {
+      center: FALLBACK_CENTER,
+      zoom: FALLBACK_ZOOM,
+      mapTypeControl: false,
+      streetViewControl: false,
+      fullscreenControl: true,
+      clickableIcons: false,
+    })
+    infoWindowRef.current = new g.InfoWindow({ maxWidth: 280 })
+    setMapReady(true)
+  }, [isLoaded])
+
+  // Re-render de markers + polyline cada vez que cambia la selección o data.
+  useEffect(() => {
+    if (!mapReady || !mapRef.current) return
+    const g = (window.google as unknown as { maps: typeof google.maps } | undefined)?.maps
+    if (!g) return
+    const map = mapRef.current
+
+    // Limpiar markers y polyline anteriores
+    for (const m of markersRef.current) m.setMap(null)
+    markersRef.current = []
+    if (polylineRef.current) {
+      polylineRef.current.setMap(null)
+      polylineRef.current = null
+    }
+    infoWindowRef.current?.close()
+
+    const bounds = new g.LatLngBounds()
+    let pointCount = 0
+
+    if (preventistaSelectedId) {
+      // Vista de recorrido: pins por pedido del preventista seleccionado +
+      // markers gris claro para los clientes (contexto) + polilínea conectando
+      // por hora.
+      const propios = pedidos
+        .filter(p => p.preventista_id === preventistaSelectedId)
+        .sort((a, b) => {
+          const ta = a.gps_capturado_at ? Date.parse(a.gps_capturado_at) : 0
+          const tb = b.gps_capturado_at ? Date.parse(b.gps_capturado_at) : 0
+          return ta - tb
+        })
+
+      const color = colorPreventista(preventistaSelectedId)
+      const path: google.maps.LatLngLiteral[] = []
+
+      // Markers de clientes (contexto): pequeños grises
+      for (const p of propios) {
+        if (p.cliente_lat != null && p.cliente_lng != null) {
+          const marker = new g.Marker({
+            position: { lat: Number(p.cliente_lat), lng: Number(p.cliente_lng) },
+            map,
+            title: p.cliente_nombre || 'Cliente',
+            icon: pinSymbol('#cbd5e1', 5),
+            zIndex: 1,
+          })
+          markersRef.current.push(marker)
+          bounds.extend({ lat: Number(p.cliente_lat), lng: Number(p.cliente_lng) })
+          pointCount++
+        }
+      }
+
+      // Markers de check-ins (numerados)
+      propios
+        .filter(p => p.gps_status === 'ok' && p.gps_lat != null && p.gps_lng != null)
+        .forEach((p, idx) => {
+          const pos = { lat: Number(p.gps_lat!), lng: Number(p.gps_lng!) }
+          const isSelected = pedidoSelectedId === p.pedido_id
+          const marker = new g.Marker({
+            position: pos,
+            map,
+            title: p.cliente_nombre || `Pedido #${p.pedido_id}`,
+            label: { text: String(idx + 1), color: '#ffffff', fontWeight: '700', fontSize: '11px' },
+            icon: pinSymbol(color, isSelected ? 14 : 11),
+            zIndex: isSelected ? 1000 : 100 + idx,
+          })
+          marker.addListener('click', () => {
+            onSelectPedido(p.pedido_id)
+            openPedidoInfoWindow(p, marker)
+          })
+          markersRef.current.push(marker)
+          path.push(pos)
+          bounds.extend(pos)
+          pointCount++
+        })
+
+      if (path.length >= 2) {
+        polylineRef.current = new g.Polyline({
+          path,
+          map,
+          geodesic: false,
+          strokeColor: color,
+          strokeOpacity: 0.7,
+          strokeWeight: 3,
+        })
+      }
+
+      // Si hay un pedido seleccionado, abrir su info window al final.
+      if (pedidoSelectedId != null) {
+        const idx = propios.findIndex(p => p.pedido_id === pedidoSelectedId && p.gps_status === 'ok')
+        if (idx >= 0) {
+          const clienteMarkersOffset = propios.filter(p => p.cliente_lat != null && p.cliente_lng != null).length
+          const target = markersRef.current[clienteMarkersOffset + idx]
+          if (target) openPedidoInfoWindow(propios[idx], target)
+        }
+      }
+    } else {
+      // Vista global: 1 pin por preventista (su última ubicación).
+      for (const p of preventistas) {
+        const ult = p.ultima_ubicacion
+        if (!ult || ult.lat == null || ult.lng == null) continue
+        const color = colorPreventista(p.preventista_id)
+        const pos = { lat: Number(ult.lat), lng: Number(ult.lng) }
+        const inicial = (p.preventista_nombre || '?').trim().charAt(0).toUpperCase()
+        const marker = new g.Marker({
+          position: pos,
+          map,
+          title: `${p.preventista_nombre} · ${formatHora(ult.capturado_at)}`,
+          label: { text: inicial, color: '#ffffff', fontWeight: '700', fontSize: '11px' },
+          icon: pinSymbol(color, 13),
+        })
+        marker.addListener('click', () => {
+          onSelectPreventista(p.preventista_id)
+        })
+        markersRef.current.push(marker)
+        bounds.extend(pos)
+        pointCount++
+      }
+    }
+
+    // Encuadrar el mapa
+    if (pointCount === 1) {
+      // Un solo punto: centrar y mantener zoom moderado
+      map.setCenter(bounds.getCenter())
+      map.setZoom(15)
+    } else if (pointCount > 1) {
+      map.fitBounds(bounds, 60)
+    } else {
+      map.setCenter(FALLBACK_CENTER)
+      map.setZoom(FALLBACK_ZOOM)
+    }
+
+    function openPedidoInfoWindow(p: PedidoConGps, anchor: google.maps.Marker) {
+      if (!infoWindowRef.current || !mapRef.current) return
+      const clasif = clasificarDistancia(p.distancia_m)
+      const cfg = SEMAFORO_COLORS[clasif]
+      const html = `
+        <div style="font-family: ui-sans-serif, system-ui; padding: 4px 2px; max-width: 260px;">
+          <div style="font-weight: 600; color: #111827; font-size: 13px;">${escapeHtml(p.cliente_nombre || 'Cliente sin nombre')}</div>
+          <div style="color: #6b7280; font-size: 11px; margin-top: 2px;">
+            Pedido #${p.pedido_id} · ${formatHora(p.gps_capturado_at)}
+          </div>
+          <div style="margin-top: 6px; font-size: 12px; color: #374151;">
+            <strong>${formatPrecio(Number(p.total) || 0)}</strong>
+            <span style="margin-left: 8px; padding: 1px 6px; border-radius: 9999px; font-size: 11px;"
+                  class="${cfg.bg}">
+              ${cfg.label} · ${escapeHtml(formatDistancia(p.distancia_m))}
+            </span>
+          </div>
+        </div>
+      `
+      infoWindowRef.current.setContent(html)
+      infoWindowRef.current.open(mapRef.current, anchor)
+    }
+  }, [mapReady, preventistas, pedidos, preventistaSelectedId, pedidoSelectedId, onSelectPedido, onSelectPreventista])
+
+  // Cleanup
+  useEffect(() => {
+    return () => {
+      for (const m of markersRef.current) m.setMap(null)
+      markersRef.current = []
+      if (polylineRef.current) polylineRef.current.setMap(null)
+      infoWindowRef.current?.close()
+    }
+  }, [])
+
+  if (error) {
+    return (
+      <div className="h-[60vh] bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-xl flex items-center justify-center text-sm text-red-600 dark:text-red-400 p-4 text-center">
+        <div>
+          <MapPin className="w-6 h-6 mx-auto mb-2" />
+          No se pudo cargar el mapa. {error}
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="relative h-[60vh] bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-xl overflow-hidden">
+      <div ref={containerRef} className="absolute inset-0" />
+      {(isLoading || !isLoaded) && (
+        <div className="absolute inset-0 bg-white/70 dark:bg-gray-900/60 flex items-center justify-center text-sm text-gray-600 dark:text-gray-300">
+          <Loader2 className="w-5 h-5 mr-2 animate-spin" />
+          Cargando mapa…
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/components/geolocalizacion/SidebarPreventistas.tsx
+++ b/src/components/geolocalizacion/SidebarPreventistas.tsx
@@ -1,0 +1,106 @@
+import React, { useMemo } from 'react'
+import { MapPin, ShoppingCart, AlertTriangle } from 'lucide-react'
+import { colorPreventista } from '../../utils/geo'
+import type { PreventistaResumen } from '../../hooks/queries'
+
+interface SidebarPreventistasProps {
+  preventistas: PreventistaResumen[]
+  selectedId: string | null
+  onSelect: (id: string | null) => void
+}
+
+function formatHora(iso: string | null | undefined): string {
+  if (!iso) return '—'
+  try {
+    return new Date(iso).toLocaleTimeString('es-AR', { hour: '2-digit', minute: '2-digit' })
+  } catch {
+    return '—'
+  }
+}
+
+export default function SidebarPreventistas({ preventistas, selectedId, onSelect }: SidebarPreventistasProps): React.ReactElement {
+  const ordenadas = useMemo(() => {
+    return [...preventistas].sort((a, b) => {
+      const ta = a.ultima_ubicacion?.capturado_at ? Date.parse(a.ultima_ubicacion.capturado_at) : 0
+      const tb = b.ultima_ubicacion?.capturado_at ? Date.parse(b.ultima_ubicacion.capturado_at) : 0
+      return tb - ta
+    })
+  }, [preventistas])
+
+  if (ordenadas.length === 0) {
+    return (
+      <div className="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-xl p-6 text-center text-sm text-gray-500 dark:text-gray-400">
+        Sin preventistas con pedidos en el rango seleccionado.
+      </div>
+    )
+  }
+
+  return (
+    <div className="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-xl overflow-hidden">
+      <div className="px-4 py-3 border-b border-gray-200 dark:border-gray-700 flex items-center justify-between">
+        <h3 className="text-sm font-semibold text-gray-700 dark:text-gray-200">
+          Preventistas <span className="text-gray-400 font-normal">({ordenadas.length})</span>
+        </h3>
+        {selectedId && (
+          <button
+            type="button"
+            onClick={() => onSelect(null)}
+            className="text-xs text-blue-600 dark:text-blue-400 hover:underline"
+          >
+            Ver todos
+          </button>
+        )}
+      </div>
+      <ul className="divide-y divide-gray-100 dark:divide-gray-700 max-h-[60vh] overflow-y-auto">
+        {ordenadas.map(p => {
+          const color = colorPreventista(p.preventista_id)
+          const isSelected = selectedId === p.preventista_id
+          const inicial = (p.preventista_nombre || '?').trim().charAt(0).toUpperCase()
+          return (
+            <li key={p.preventista_id}>
+              <button
+                type="button"
+                onClick={() => onSelect(isSelected ? null : p.preventista_id)}
+                className={`w-full text-left px-4 py-3 transition-colors flex items-center gap-3 ${
+                  isSelected
+                    ? 'bg-blue-50 dark:bg-blue-900/20'
+                    : 'hover:bg-gray-50 dark:hover:bg-gray-700/50'
+                }`}
+                aria-pressed={isSelected}
+              >
+                <span
+                  className="shrink-0 w-9 h-9 rounded-full flex items-center justify-center text-white font-semibold text-sm"
+                  style={{ backgroundColor: color }}
+                  aria-hidden
+                >
+                  {inicial}
+                </span>
+                <div className="min-w-0 flex-1">
+                  <p className="text-sm font-medium text-gray-900 dark:text-white truncate">
+                    {p.preventista_nombre || 'Sin nombre'}
+                  </p>
+                  <div className="mt-0.5 flex items-center gap-3 text-xs text-gray-500 dark:text-gray-400">
+                    <span className="inline-flex items-center gap-1" title="Hora del último check-in">
+                      <MapPin className="w-3 h-3" />
+                      {formatHora(p.ultima_ubicacion?.capturado_at)}
+                    </span>
+                    <span className="inline-flex items-center gap-1" title="Pedidos del día">
+                      <ShoppingCart className="w-3 h-3" />
+                      {p.total_pedidos}
+                    </span>
+                    {p.pedidos_lejos > 0 && (
+                      <span className="inline-flex items-center gap-1 text-red-600 dark:text-red-400" title="Pedidos lejos del cliente">
+                        <AlertTriangle className="w-3 h-3" />
+                        {p.pedidos_lejos}
+                      </span>
+                    )}
+                  </div>
+                </div>
+              </button>
+            </li>
+          )
+        })}
+      </ul>
+    </div>
+  )
+}

--- a/src/components/geolocalizacion/TablaAnomalias.tsx
+++ b/src/components/geolocalizacion/TablaAnomalias.tsx
@@ -1,0 +1,141 @@
+import React, { useMemo } from 'react'
+import { AlertTriangle, ZapOff, Search } from 'lucide-react'
+import { formatPrecio } from '../../utils/formatters'
+import { clasificarDistancia, formatDistancia, SEMAFORO_COLORS } from '../../utils/geo'
+import type { PedidoConGps, PreventistaResumen } from '../../hooks/queries'
+
+interface TablaAnomaliasProps {
+  pedidos: PedidoConGps[]
+  preventistas: PreventistaResumen[]
+  onSelectPedido: (pedidoId: number, preventistaId: string) => void
+}
+
+interface AnomaliaRow {
+  pedido_id: number
+  preventista_id: string
+  preventista_nombre: string
+  cliente_nombre: string
+  hora: string
+  motivo: 'sin_gps' | 'lejos'
+  motivo_label: string
+  distancia_m: number | null
+  total: number
+}
+
+function formatHora(iso: string | null | undefined): string {
+  if (!iso) return '—'
+  try {
+    return new Date(iso).toLocaleTimeString('es-AR', { hour: '2-digit', minute: '2-digit' })
+  } catch {
+    return '—'
+  }
+}
+
+export default function TablaAnomalias({ pedidos, preventistas, onSelectPedido }: TablaAnomaliasProps): React.ReactElement {
+  const nombresMap = useMemo(() => {
+    const map: Record<string, string> = {}
+    for (const p of preventistas) map[p.preventista_id] = p.preventista_nombre || 'Sin nombre'
+    return map
+  }, [preventistas])
+
+  const rows = useMemo<AnomaliaRow[]>(() => {
+    const result: AnomaliaRow[] = []
+    for (const p of pedidos) {
+      const sinGps = p.gps_status !== 'ok'
+      const lejos = !sinGps && p.distancia_m != null && p.distancia_m >= 2000
+      if (!sinGps && !lejos) continue
+      result.push({
+        pedido_id: p.pedido_id,
+        preventista_id: p.preventista_id,
+        preventista_nombre: nombresMap[p.preventista_id] ?? '—',
+        cliente_nombre: p.cliente_nombre || 'Sin cliente',
+        hora: formatHora(p.gps_capturado_at),
+        motivo: sinGps ? 'sin_gps' : 'lejos',
+        motivo_label: sinGps
+          ? (p.gps_status === 'denied' ? 'GPS denegado'
+            : p.gps_status === 'timeout' ? 'GPS sin respuesta'
+            : p.gps_status === 'unavailable' ? 'GPS no disponible'
+            : p.gps_status === 'error' ? 'GPS con error'
+            : 'Sin check-in')
+          : 'Lejos del cliente',
+        distancia_m: p.distancia_m,
+        total: Number(p.total) || 0,
+      })
+    }
+    // Ordenar: lejos primero, luego sin GPS
+    return result.sort((a, b) => {
+      if (a.motivo !== b.motivo) return a.motivo === 'lejos' ? -1 : 1
+      return (b.distancia_m ?? 0) - (a.distancia_m ?? 0)
+    })
+  }, [pedidos, nombresMap])
+
+  if (rows.length === 0) {
+    return (
+      <div className="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-xl p-6 text-center text-sm text-gray-500 dark:text-gray-400">
+        <AlertTriangle className="w-6 h-6 mx-auto mb-2 text-green-500" />
+        Sin anomalías en el rango seleccionado.
+      </div>
+    )
+  }
+
+  return (
+    <div className="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-xl overflow-hidden">
+      <div className="px-4 py-3 border-b border-gray-200 dark:border-gray-700 flex items-center justify-between">
+        <h3 className="text-sm font-semibold text-gray-700 dark:text-gray-200">
+          Anomalías <span className="text-gray-400 font-normal">({rows.length})</span>
+        </h3>
+      </div>
+      <div className="overflow-x-auto">
+        <table className="min-w-full text-sm">
+          <thead className="bg-gray-50 dark:bg-gray-900/40 text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400">
+            <tr>
+              <th className="px-4 py-2 text-left font-medium">Preventista</th>
+              <th className="px-4 py-2 text-left font-medium">Hora</th>
+              <th className="px-4 py-2 text-left font-medium">Cliente</th>
+              <th className="px-4 py-2 text-left font-medium">Motivo</th>
+              <th className="px-4 py-2 text-right font-medium">Distancia</th>
+              <th className="px-4 py-2 text-right font-medium">Total</th>
+              <th className="px-4 py-2"></th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-gray-100 dark:divide-gray-700">
+            {rows.map(r => {
+              const clasif = r.motivo === 'sin_gps' ? 'sin_dato' : clasificarDistancia(r.distancia_m)
+              const cfg = SEMAFORO_COLORS[clasif]
+              return (
+                <tr key={r.pedido_id} className="hover:bg-gray-50 dark:hover:bg-gray-700/40">
+                  <td className="px-4 py-2 text-gray-900 dark:text-white">{r.preventista_nombre}</td>
+                  <td className="px-4 py-2 text-gray-700 dark:text-gray-300 tabular-nums">{r.hora}</td>
+                  <td className="px-4 py-2 text-gray-900 dark:text-white">{r.cliente_nombre}</td>
+                  <td className="px-4 py-2">
+                    <span className={`inline-flex items-center gap-1 px-2 py-0.5 text-xs font-medium rounded-full ${cfg.bg}`}>
+                      {r.motivo === 'sin_gps' ? <ZapOff className="w-3 h-3" /> : <AlertTriangle className="w-3 h-3" />}
+                      {r.motivo_label}
+                    </span>
+                  </td>
+                  <td className="px-4 py-2 text-right tabular-nums text-gray-700 dark:text-gray-300">
+                    {r.motivo === 'sin_gps' ? '—' : formatDistancia(r.distancia_m)}
+                  </td>
+                  <td className="px-4 py-2 text-right tabular-nums text-gray-700 dark:text-gray-300">
+                    {formatPrecio(r.total)}
+                  </td>
+                  <td className="px-4 py-2 text-right">
+                    <button
+                      type="button"
+                      onClick={() => onSelectPedido(r.pedido_id, r.preventista_id)}
+                      className="inline-flex items-center gap-1 text-xs text-blue-600 dark:text-blue-400 hover:underline"
+                      title="Ver en el mapa"
+                    >
+                      <Search className="w-3 h-3" />
+                      Ver
+                    </button>
+                  </td>
+                </tr>
+              )
+            })}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  )
+}

--- a/src/components/geolocalizacion/TimelineRecorrido.tsx
+++ b/src/components/geolocalizacion/TimelineRecorrido.tsx
@@ -1,0 +1,133 @@
+import React from 'react'
+import { Clock, MapPin, AlertCircle } from 'lucide-react'
+import { formatPrecio } from '../../utils/formatters'
+import { clasificarDistancia, formatDistancia, SEMAFORO_COLORS, colorPreventista } from '../../utils/geo'
+import type { PedidoConGps } from '../../hooks/queries'
+
+interface TimelineRecorridoProps {
+  pedidos: PedidoConGps[]
+  preventistaId: string | null
+  preventistaNombre: string | null
+  selectedPedidoId: number | null
+  onSelectPedido: (pedidoId: number | null) => void
+}
+
+function formatHora(iso: string | null | undefined): string {
+  if (!iso) return '—'
+  try {
+    return new Date(iso).toLocaleTimeString('es-AR', { hour: '2-digit', minute: '2-digit' })
+  } catch {
+    return '—'
+  }
+}
+
+export default function TimelineRecorrido({
+  pedidos,
+  preventistaId,
+  preventistaNombre,
+  selectedPedidoId,
+  onSelectPedido,
+}: TimelineRecorridoProps): React.ReactElement {
+  if (!preventistaId) {
+    return (
+      <div className="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-xl p-6 text-center text-sm text-gray-500 dark:text-gray-400">
+        Seleccioná un preventista en la lista o en el mapa para ver su recorrido del día.
+      </div>
+    )
+  }
+
+  const propios = pedidos
+    .filter(p => p.preventista_id === preventistaId)
+    .sort((a, b) => {
+      const ta = a.gps_capturado_at ? Date.parse(a.gps_capturado_at) : 0
+      const tb = b.gps_capturado_at ? Date.parse(b.gps_capturado_at) : 0
+      return ta - tb
+    })
+
+  if (propios.length === 0) {
+    return (
+      <div className="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-xl p-6 text-center text-sm text-gray-500 dark:text-gray-400">
+        Este preventista no tiene pedidos en el rango seleccionado.
+      </div>
+    )
+  }
+
+  const color = colorPreventista(preventistaId)
+  const conGps = propios.filter(p => p.gps_status === 'ok').length
+
+  return (
+    <div className="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-xl overflow-hidden">
+      <div className="px-4 py-3 border-b border-gray-200 dark:border-gray-700 flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <span className="w-3 h-3 rounded-full" style={{ backgroundColor: color }} aria-hidden />
+          <h3 className="text-sm font-semibold text-gray-700 dark:text-gray-200">
+            Recorrido de {preventistaNombre ?? 'preventista'}
+          </h3>
+        </div>
+        <span className="text-xs text-gray-500 dark:text-gray-400">
+          {propios.length} pedido{propios.length === 1 ? '' : 's'} · {conGps} con GPS
+        </span>
+      </div>
+      <ol className="divide-y divide-gray-100 dark:divide-gray-700 max-h-[40vh] overflow-y-auto">
+        {propios.map((p, idx) => {
+          const isSelected = selectedPedidoId === p.pedido_id
+          const clasif = clasificarDistancia(p.distancia_m)
+          const cfg = SEMAFORO_COLORS[clasif]
+          const sinGps = p.gps_status !== 'ok'
+
+          return (
+            <li key={p.pedido_id}>
+              <button
+                type="button"
+                onClick={() => onSelectPedido(isSelected ? null : p.pedido_id)}
+                className={`w-full text-left px-4 py-3 flex items-start gap-3 transition-colors ${
+                  isSelected
+                    ? 'bg-blue-50 dark:bg-blue-900/20'
+                    : 'hover:bg-gray-50 dark:hover:bg-gray-700/50'
+                }`}
+                aria-pressed={isSelected}
+              >
+                <span
+                  className={`shrink-0 w-7 h-7 rounded-full flex items-center justify-center text-white text-xs font-semibold ${
+                    sinGps ? 'bg-gray-300 dark:bg-gray-600' : ''
+                  }`}
+                  style={sinGps ? undefined : { backgroundColor: color }}
+                  aria-hidden
+                >
+                  {idx + 1}
+                </span>
+                <div className="min-w-0 flex-1">
+                  <div className="flex items-center justify-between gap-2">
+                    <p className="text-sm font-medium text-gray-900 dark:text-white truncate">
+                      {p.cliente_nombre || 'Cliente sin nombre'}
+                    </p>
+                    <span className="shrink-0 text-xs text-gray-500 dark:text-gray-400 inline-flex items-center gap-1">
+                      <Clock className="w-3 h-3" />
+                      {formatHora(p.gps_capturado_at)}
+                    </span>
+                  </div>
+                  <div className="mt-1 flex items-center justify-between gap-2 flex-wrap">
+                    <span className="text-xs text-gray-500 dark:text-gray-400">
+                      #{p.pedido_id} · {formatPrecio(Number(p.total) || 0)}
+                    </span>
+                    {sinGps ? (
+                      <span className={`inline-flex items-center gap-1 px-2 py-0.5 text-xs font-medium rounded-full ${SEMAFORO_COLORS.sin_dato.bg}`}>
+                        <AlertCircle className="w-3 h-3" />
+                        Sin GPS
+                      </span>
+                    ) : (
+                      <span className={`inline-flex items-center gap-1 px-2 py-0.5 text-xs font-medium rounded-full ${cfg.bg}`} title={cfg.label}>
+                        <MapPin className="w-3 h-3" />
+                        {formatDistancia(p.distancia_m)}
+                      </span>
+                    )}
+                  </div>
+                </div>
+              </button>
+            </li>
+          )
+        })}
+      </ol>
+    </div>
+  )
+}

--- a/src/components/layout/TopNavigation.tsx
+++ b/src/components/layout/TopNavigation.tsx
@@ -4,7 +4,7 @@ import type { LucideIcon } from 'lucide-react';
 import {
   Truck, Menu, X, LogOut, Moon, Sun, ChevronDown,
   BarChart3, ShoppingCart, Users, Package, TrendingUp,
-  UserCog, Route, ShoppingBag, Building2, Banknote, AlertTriangle, Database, Tag, Percent, ArrowRightLeft, Gift, Send
+  UserCog, Route, ShoppingBag, Building2, Banknote, AlertTriangle, Database, Tag, Percent, ArrowRightLeft, Gift, Send, MapPin
 } from 'lucide-react';
 import { getRolColor, getRolLabel } from '../../utils/formatters';
 import { useTheme } from '../../contexts/ThemeContext';
@@ -87,6 +87,7 @@ const menuGroups: MenuGroup[] = [
       { id: 'recorridos', icon: Route, label: 'Recorridos', roles: ['admin', 'encargado'] },
       { id: 'rendiciones', icon: Banknote, label: 'Rendiciones', roles: ['admin', 'encargado'] },
       { id: 'salvedades', icon: AlertTriangle, label: 'Salvedades', roles: ['admin', 'encargado'] },
+      { id: 'geolocalizacion', icon: MapPin, label: 'Geolocalización', roles: ['admin'] },
       { id: 'usuarios', icon: UserCog, label: 'Usuarios', roles: ['admin'] },
       { id: 'bot-telegram', icon: Send, label: 'Bot Telegram', roles: ['admin'] },
     ]

--- a/src/components/pedidos/PedidoCard.tsx
+++ b/src/components/pedidos/PedidoCard.tsx
@@ -18,6 +18,7 @@ import { MOTIVOS_SALVEDAD_LABELS } from '../../lib/schemas';
 import AccionesDropdown from './PedidoActions';
 import { PedidoActionsCtx } from '../../contexts/HandlersContext';
 import { useAuthData } from '../../contexts/AuthDataContext';
+import { haversineMeters, formatDistancia, clasificarDistancia, SEMAFORO_COLORS } from '../../utils/geo';
 import type { PedidoDB, MotivoSalvedad } from '../../types';
 
 // =============================================================================
@@ -93,6 +94,71 @@ function BadgeAntiguedad({ dias, estado }: BadgeAntiguedadProps): React.ReactEle
     <span className={`inline-flex items-center gap-1 px-2 py-0.5 text-xs font-medium rounded-full border ${colorClass}`}>
       <Timer className="w-3 h-3" />
       {dias}d
+    </span>
+  );
+}
+
+// Badge: distancia entre el GPS del check-in del preventista y la dirección
+// del cliente. Solo se muestra a admin (y al preventista dueño). Si no hubo
+// check-in (gps_status null), no renderiza nada para no contaminar las cards
+// históricas previas a la migración 040.
+interface BadgeGeolocalizacionProps {
+  pedido: PedidoDB;
+}
+
+function BadgeGeolocalizacion({ pedido }: BadgeGeolocalizacionProps): React.ReactElement | null {
+  if (!pedido.gps_status) return null;
+
+  // GPS fallido: mostrar chip neutro indicando el motivo.
+  if (pedido.gps_status !== 'ok') {
+    const motivo =
+      pedido.gps_status === 'denied' ? 'GPS denegado' :
+      pedido.gps_status === 'timeout' ? 'GPS sin respuesta' :
+      pedido.gps_status === 'unavailable' ? 'GPS no disponible' :
+      'GPS con error';
+    return (
+      <span
+        title={motivo}
+        className={`inline-flex items-center gap-1 px-2 py-0.5 text-xs font-medium rounded-full border border-gray-200 ${SEMAFORO_COLORS.sin_dato.bg}`}
+      >
+        <MapPin className="w-3 h-3" />
+        Sin GPS
+      </span>
+    );
+  }
+
+  // GPS ok: si el cliente no tiene coordenadas, no podemos calcular distancia.
+  const clienteLat = pedido.cliente?.latitud;
+  const clienteLng = pedido.cliente?.longitud;
+  const pedidoLat = pedido.gps_lat;
+  const pedidoLng = pedido.gps_lng;
+
+  if (clienteLat == null || clienteLng == null || pedidoLat == null || pedidoLng == null) {
+    return (
+      <span
+        title="Cliente sin coordenadas cargadas"
+        className={`inline-flex items-center gap-1 px-2 py-0.5 text-xs font-medium rounded-full border border-gray-200 ${SEMAFORO_COLORS.sin_dato.bg}`}
+      >
+        <MapPin className="w-3 h-3" />
+        s/ref
+      </span>
+    );
+  }
+
+  const metros = haversineMeters(
+    { lat: Number(pedidoLat), lng: Number(pedidoLng) },
+    { lat: Number(clienteLat), lng: Number(clienteLng) },
+  );
+  const clasif = clasificarDistancia(metros);
+  const cfg = SEMAFORO_COLORS[clasif];
+
+  return (
+    <span
+      title={`${cfg.label} · ${formatDistancia(metros)}`}
+      className={`inline-flex items-center gap-1 px-2 py-0.5 text-xs font-medium rounded-full border border-transparent ${cfg.bg}`}
+    >
+      <MapPin className="w-3 h-3" />
+      {formatDistancia(metros)}
     </span>
   );
 }
@@ -193,6 +259,9 @@ function PedidoCard({
                   </span>
                 )}
                 <BadgeAntiguedad dias={calcularDiasAntiguedad(pedido.fecha || pedido.created_at)} estado={pedido.estado} />
+                {(isAdmin || (isPreventista && user?.id === pedido.usuario_id)) && (
+                  <BadgeGeolocalizacion pedido={pedido} />
+                )}
               </p>
             </div>
           </div>

--- a/src/components/vistas/VistaGeolocalizacion.tsx
+++ b/src/components/vistas/VistaGeolocalizacion.tsx
@@ -1,0 +1,304 @@
+/**
+ * Vista admin "Geolocalización"
+ *
+ * Panel unificado que consolida los tres usos del check-in GPS:
+ *   1. Última ubicación conocida (mapa con un pin por preventista)
+ *   2. Recorrido del día (drill-down al seleccionar un preventista)
+ *   3. Verificación de visita (anomalías + chip de distancia en cada pedido)
+ *
+ * Solo accesible a `rol === 'admin'`. La fuente de datos es la RPC
+ * `obtener_geolocalizacion_preventistas`, scope a la sucursal activa.
+ */
+import React, { useMemo, useState } from 'react'
+import { MapPin, Users, ShoppingCart, AlertTriangle, RefreshCw, Calendar } from 'lucide-react'
+import {
+  useGeolocalizacionPreventistasQuery,
+  type PedidoConGps,
+} from '../../hooks/queries'
+import { fechaLocalISO } from '../../utils/formatters'
+import KpiCard from '../geolocalizacion/KpiCard'
+import SidebarPreventistas from '../geolocalizacion/SidebarPreventistas'
+import MapaPreventistas from '../geolocalizacion/MapaPreventistas'
+import TimelineRecorrido from '../geolocalizacion/TimelineRecorrido'
+import TablaAnomalias from '../geolocalizacion/TablaAnomalias'
+
+type RangoPreset = 'hoy' | 'ayer' | 'semana' | 'custom'
+
+interface Rango {
+  desde: string
+  hasta: string
+  preset: RangoPreset
+}
+
+function diasAtras(n: number): string {
+  const d = new Date()
+  d.setDate(d.getDate() - n)
+  return d.toISOString().slice(0, 10)
+}
+
+function buildRangoDefault(): Rango {
+  const hoy = fechaLocalISO()
+  return { desde: hoy, hasta: hoy, preset: 'hoy' }
+}
+
+function rangoFromPreset(preset: Exclude<RangoPreset, 'custom'>): Rango {
+  if (preset === 'hoy') {
+    const hoy = fechaLocalISO()
+    return { desde: hoy, hasta: hoy, preset }
+  }
+  if (preset === 'ayer') {
+    const ayer = diasAtras(1)
+    return { desde: ayer, hasta: ayer, preset }
+  }
+  // semana: últimos 7 días incluyendo hoy
+  return { desde: diasAtras(6), hasta: fechaLocalISO(), preset }
+}
+
+const PRESET_LABELS: Record<Exclude<RangoPreset, 'custom'>, string> = {
+  hoy: 'Hoy',
+  ayer: 'Ayer',
+  semana: 'Últimos 7 días',
+}
+
+export default function VistaGeolocalizacion(): React.ReactElement {
+  const [rango, setRango] = useState<Rango>(buildRangoDefault)
+  const [preventistaSelectedId, setPreventistaSelectedId] = useState<string | null>(null)
+  const [pedidoSelectedId, setPedidoSelectedId] = useState<number | null>(null)
+  const [tab, setTab] = useState<'timeline' | 'anomalias'>('timeline')
+
+  // Auto-refresh solo si el rango incluye hoy.
+  const autoRefresh = rango.hasta === fechaLocalISO()
+
+  const { data, isLoading, isFetching, error, refetch } = useGeolocalizacionPreventistasQuery(
+    rango.desde,
+    rango.hasta,
+    { autoRefresh },
+  )
+
+  // Estabilizamos las referencias para que los useMemo de KPIs no se
+  // re-disparen en cada render cuando `data` es undefined.
+  const preventistas = useMemo(() => data?.preventistas ?? [], [data?.preventistas])
+  const pedidos: PedidoConGps[] = useMemo(() => data?.pedidos ?? [], [data?.pedidos])
+
+  // KPIs
+  const kpis = useMemo(() => {
+    const total = pedidos.length
+    const conGps = pedidos.filter(p => p.gps_status === 'ok').length
+    const sinGps = total - conGps
+    const anomalias = pedidos.filter(p => {
+      if (p.gps_status !== 'ok') return true
+      return p.distancia_m != null && p.distancia_m >= 2000
+    }).length
+    return {
+      preventistasActivos: preventistas.length,
+      conGps,
+      sinGps,
+      anomalias,
+    }
+  }, [pedidos, preventistas])
+
+  const preventistaSelectedNombre = useMemo(() => {
+    if (!preventistaSelectedId) return null
+    return preventistas.find(p => p.preventista_id === preventistaSelectedId)?.preventista_nombre ?? null
+  }, [preventistaSelectedId, preventistas])
+
+  // Handlers
+  const setPreset = (preset: Exclude<RangoPreset, 'custom'>) => {
+    setRango(rangoFromPreset(preset))
+    setPreventistaSelectedId(null)
+    setPedidoSelectedId(null)
+  }
+
+  const handleSelectPreventista = (id: string | null) => {
+    setPreventistaSelectedId(id)
+    setPedidoSelectedId(null)
+    if (id) setTab('timeline')
+  }
+
+  const handleSelectAnomalia = (pedidoId: number, preventistaId: string) => {
+    setPreventistaSelectedId(preventistaId)
+    setPedidoSelectedId(pedidoId)
+    setTab('timeline')
+  }
+
+  return (
+    <div className="space-y-4 p-4 max-w-7xl mx-auto">
+      {/* Header con filtros */}
+      <header className="flex flex-col sm:flex-row sm:items-center justify-between gap-3">
+        <div>
+          <h1 className="text-xl sm:text-2xl font-semibold text-gray-900 dark:text-white flex items-center gap-2">
+            <MapPin className="w-6 h-6 text-blue-600" />
+            Control de geolocalización
+          </h1>
+          <p className="text-sm text-gray-500 dark:text-gray-400">
+            Última ubicación, recorrido del día y verificación de visitas de los preventistas.
+          </p>
+        </div>
+        <div className="flex items-center gap-2 flex-wrap">
+          <div className="inline-flex rounded-lg overflow-hidden border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800">
+            {(Object.keys(PRESET_LABELS) as Array<Exclude<RangoPreset, 'custom'>>).map(p => (
+              <button
+                key={p}
+                type="button"
+                onClick={() => setPreset(p)}
+                className={`px-3 py-2 text-sm font-medium transition-colors ${
+                  rango.preset === p
+                    ? 'bg-blue-600 text-white'
+                    : 'text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700'
+                }`}
+              >
+                {PRESET_LABELS[p]}
+              </button>
+            ))}
+          </div>
+          <div className="inline-flex items-center gap-1 px-3 py-2 text-sm rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-200">
+            <Calendar className="w-4 h-4 text-gray-400" aria-hidden />
+            <input
+              type="date"
+              value={rango.desde}
+              max={rango.hasta}
+              onChange={e => setRango(r => ({ ...r, desde: e.target.value, preset: 'custom' }))}
+              className="bg-transparent outline-none text-sm tabular-nums"
+              aria-label="Fecha desde"
+            />
+            <span className="text-gray-400">→</span>
+            <input
+              type="date"
+              value={rango.hasta}
+              min={rango.desde}
+              onChange={e => setRango(r => ({ ...r, hasta: e.target.value, preset: 'custom' }))}
+              className="bg-transparent outline-none text-sm tabular-nums"
+              aria-label="Fecha hasta"
+            />
+          </div>
+          <button
+            type="button"
+            onClick={() => refetch()}
+            disabled={isFetching}
+            className="inline-flex items-center gap-1 px-3 py-2 text-sm font-medium rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-700 disabled:opacity-60"
+            aria-label="Actualizar"
+            title={autoRefresh ? 'Auto-refresca cada 60 s' : 'Refrescar'}
+          >
+            <RefreshCw className={`w-4 h-4 ${isFetching ? 'animate-spin' : ''}`} />
+            <span className="hidden sm:inline">Actualizar</span>
+          </button>
+        </div>
+      </header>
+
+      {/* KPIs */}
+      <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
+        <KpiCard
+          label="Preventistas activos"
+          value={kpis.preventistasActivos}
+          icon={Users}
+          tone="blue"
+          hint={autoRefresh ? 'Actualizado en tiempo real' : undefined}
+        />
+        <KpiCard
+          label="Pedidos con GPS"
+          value={kpis.conGps}
+          icon={MapPin}
+          tone="green"
+        />
+        <KpiCard
+          label="Sin ubicación"
+          value={kpis.sinGps}
+          icon={ShoppingCart}
+          tone="slate"
+        />
+        <KpiCard
+          label="Anomalías"
+          value={kpis.anomalias}
+          icon={AlertTriangle}
+          tone={kpis.anomalias > 0 ? 'red' : 'green'}
+          hint="Sin GPS o ≥2 km del cliente"
+        />
+      </div>
+
+      {error && (
+        <div className="rounded-lg border border-red-200 bg-red-50 dark:bg-red-900/20 text-red-700 dark:text-red-300 px-4 py-3 text-sm">
+          Error cargando datos: {(error as Error).message}
+        </div>
+      )}
+
+      {/* Grid principal: sidebar + mapa */}
+      <div className="grid grid-cols-1 lg:grid-cols-[18rem_1fr] gap-4">
+        <aside className="lg:order-1">
+          {isLoading ? (
+            <div className="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-xl p-8 text-center text-sm text-gray-500">
+              Cargando preventistas…
+            </div>
+          ) : (
+            <SidebarPreventistas
+              preventistas={preventistas}
+              selectedId={preventistaSelectedId}
+              onSelect={handleSelectPreventista}
+            />
+          )}
+        </aside>
+        <section className="lg:order-2">
+          <MapaPreventistas
+            preventistas={preventistas}
+            pedidos={pedidos}
+            preventistaSelectedId={preventistaSelectedId}
+            pedidoSelectedId={pedidoSelectedId}
+            onSelectPreventista={handleSelectPreventista}
+            onSelectPedido={setPedidoSelectedId}
+          />
+        </section>
+      </div>
+
+      {/* Tabs: timeline / anomalias */}
+      <div>
+        <div className="border-b border-gray-200 dark:border-gray-700 flex items-center gap-1">
+          <button
+            type="button"
+            onClick={() => setTab('timeline')}
+            className={`px-4 py-2 text-sm font-medium border-b-2 transition-colors -mb-px ${
+              tab === 'timeline'
+                ? 'border-blue-600 text-blue-600 dark:text-blue-400'
+                : 'border-transparent text-gray-500 hover:text-gray-700 dark:hover:text-gray-300'
+            }`}
+            aria-pressed={tab === 'timeline'}
+          >
+            Timeline
+          </button>
+          <button
+            type="button"
+            onClick={() => setTab('anomalias')}
+            className={`px-4 py-2 text-sm font-medium border-b-2 transition-colors -mb-px ${
+              tab === 'anomalias'
+                ? 'border-blue-600 text-blue-600 dark:text-blue-400'
+                : 'border-transparent text-gray-500 hover:text-gray-700 dark:hover:text-gray-300'
+            }`}
+            aria-pressed={tab === 'anomalias'}
+          >
+            Anomalías
+            {kpis.anomalias > 0 && (
+              <span className="ml-2 inline-flex items-center px-1.5 py-0.5 rounded-full text-xs bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-300">
+                {kpis.anomalias}
+              </span>
+            )}
+          </button>
+        </div>
+        <div className="mt-3">
+          {tab === 'timeline' ? (
+            <TimelineRecorrido
+              pedidos={pedidos}
+              preventistaId={preventistaSelectedId}
+              preventistaNombre={preventistaSelectedNombre}
+              selectedPedidoId={pedidoSelectedId}
+              onSelectPedido={setPedidoSelectedId}
+            />
+          ) : (
+            <TablaAnomalias
+              pedidos={pedidos}
+              preventistas={preventistas}
+              onSelectPedido={handleSelectAnomalia}
+            />
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/hooks/queries/index.ts
+++ b/src/hooks/queries/index.ts
@@ -158,6 +158,19 @@ export {
   useInvalidateMetricas,
 } from './useMetricasQuery'
 
+// Geolocalización de preventistas (panel admin)
+export {
+  geolocalizacionKeys,
+  useGeolocalizacionPreventistasQuery,
+} from './useGeolocalizacionPreventistasQuery'
+export type {
+  GpsStatus,
+  UltimaUbicacion,
+  PreventistaResumen,
+  PedidoConGps,
+  GeolocalizacionPanelData,
+} from './useGeolocalizacionPreventistasQuery'
+
 // Promociones
 export {
   promocionesKeys,

--- a/src/hooks/queries/useGeolocalizacionPreventistasQuery.ts
+++ b/src/hooks/queries/useGeolocalizacionPreventistasQuery.ts
@@ -1,0 +1,99 @@
+/**
+ * useGeolocalizacionPreventistasQuery
+ *
+ * Hook que consume la RPC `obtener_geolocalizacion_preventistas`. Devuelve
+ * el shape consolidado del panel admin "Geolocalización": resumen por
+ * preventista + detalle de pedidos con coordenadas y distancia al cliente.
+ *
+ * - RPC: scope a `current_sucursal_id()`, solo admin.
+ * - Auto-refresh cada 60 s cuando el rango incluye HOY (regla en el caller
+ *   vía el flag `autoRefresh`).
+ */
+import { useQuery } from '@tanstack/react-query'
+import { supabase } from '../supabase/base'
+import { useSucursal } from '../../contexts/SucursalContext'
+
+export type GpsStatus = 'ok' | 'denied' | 'unavailable' | 'timeout' | 'error'
+
+export interface UltimaUbicacion {
+  lat: number
+  lng: number
+  capturado_at: string
+  pedido_id: number
+}
+
+export interface PreventistaResumen {
+  preventista_id: string
+  preventista_nombre: string
+  total_pedidos: number
+  pedidos_con_gps: number
+  pedidos_sin_gps: number
+  pedidos_lejos: number
+  ultima_ubicacion: UltimaUbicacion | null
+}
+
+export interface PedidoConGps {
+  pedido_id: number
+  preventista_id: string
+  fecha: string
+  total: number
+  gps_lat: number | null
+  gps_lng: number | null
+  gps_accuracy: number | null
+  gps_capturado_at: string | null
+  gps_status: GpsStatus | null
+  cliente_id: number | null
+  cliente_nombre: string | null
+  cliente_lat: number | null
+  cliente_lng: number | null
+  distancia_m: number | null
+}
+
+export interface GeolocalizacionPanelData {
+  fecha_desde: string
+  fecha_hasta: string
+  preventistas: PreventistaResumen[]
+  pedidos: PedidoConGps[]
+}
+
+const EMPTY: GeolocalizacionPanelData = {
+  fecha_desde: '',
+  fecha_hasta: '',
+  preventistas: [],
+  pedidos: [],
+}
+
+async function fetchGeolocalizacion(
+  fechaDesde: string,
+  fechaHasta: string,
+): Promise<GeolocalizacionPanelData> {
+  const { data, error } = await supabase.rpc('obtener_geolocalizacion_preventistas', {
+    p_fecha_desde: fechaDesde,
+    p_fecha_hasta: fechaHasta,
+  })
+  if (error) throw error
+  return (data as GeolocalizacionPanelData) ?? EMPTY
+}
+
+export const geolocalizacionKeys = {
+  all: (sucursalId: number | null) => ['geolocalizacion', 'preventistas', sucursalId] as const,
+  range: (sucursalId: number | null, desde: string, hasta: string) =>
+    ['geolocalizacion', 'preventistas', sucursalId, desde, hasta] as const,
+}
+
+export function useGeolocalizacionPreventistasQuery(
+  fechaDesde: string,
+  fechaHasta: string,
+  options: { enabled?: boolean; autoRefresh?: boolean } = {},
+) {
+  const { currentSucursalId } = useSucursal()
+  const { enabled = true, autoRefresh = false } = options
+
+  return useQuery({
+    queryKey: geolocalizacionKeys.range(currentSucursalId, fechaDesde, fechaHasta),
+    queryFn: () => fetchGeolocalizacion(fechaDesde, fechaHasta),
+    enabled: enabled && !!fechaDesde && !!fechaHasta,
+    refetchInterval: autoRefresh ? 60_000 : false,
+    staleTime: autoRefresh ? 0 : 30_000,
+  })
+}

--- a/src/hooks/useGeolocationCapture.test.ts
+++ b/src/hooks/useGeolocationCapture.test.ts
@@ -1,0 +1,144 @@
+/**
+ * Tests del hook `useGeolocationCapture`.
+ *
+ * Mockean `navigator.geolocation` para verificar los 4 escenarios:
+ *   - ok (happy path)
+ *   - denied (usuario rechaza el prompt)
+ *   - timeout (sin señal)
+ *   - unavailable (POSITION_UNAVAILABLE / sin API)
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { useGeolocationCapture } from './useGeolocationCapture'
+
+// Constantes equivalentes a `PositionError`
+const PERMISSION_DENIED = 1
+const POSITION_UNAVAILABLE = 2
+const TIMEOUT = 3
+
+interface MockGeolocation {
+  getCurrentPosition: ReturnType<typeof vi.fn>
+}
+
+function setGeolocation(mock: MockGeolocation | null) {
+  if (mock === null) {
+    // Simular ausencia total de la API
+    // @ts-expect-error - intentionally unsetting
+    delete (navigator as Navigator).geolocation
+    return
+  }
+  Object.defineProperty(navigator, 'geolocation', {
+    value: mock,
+    configurable: true,
+    writable: true,
+  })
+}
+
+describe('useGeolocationCapture', () => {
+  const originalGeolocation = (navigator as Navigator).geolocation
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    // Restore original geolocation if it existed
+    if (originalGeolocation !== undefined) {
+      Object.defineProperty(navigator, 'geolocation', {
+        value: originalGeolocation,
+        configurable: true,
+        writable: true,
+      })
+    }
+  })
+
+  it('returns ok with coordinates when permission is granted', async () => {
+    setGeolocation({
+      getCurrentPosition: vi.fn((success: (pos: GeolocationPosition) => void) => {
+        success({
+          coords: {
+            latitude: -26.81,
+            longitude: -65.22,
+            accuracy: 18,
+            altitude: null,
+            altitudeAccuracy: null,
+            heading: null,
+            speed: null,
+          },
+          timestamp: Date.now(),
+        } as GeolocationPosition)
+      }),
+    })
+
+    const { result } = renderHook(() => useGeolocationCapture())
+    const gps = await act(() => result.current())
+
+    expect(gps.status).toBe('ok')
+    if (gps.status === 'ok') {
+      expect(gps.lat).toBeCloseTo(-26.81)
+      expect(gps.lng).toBeCloseTo(-65.22)
+      expect(gps.accuracy).toBe(18)
+      expect(gps.capturadoAt).toMatch(/^\d{4}-\d{2}-\d{2}T/)
+    }
+  })
+
+  it('returns denied when user rejects the permission prompt', async () => {
+    setGeolocation({
+      getCurrentPosition: vi.fn((_success, error) => {
+        error?.({ code: PERMISSION_DENIED, PERMISSION_DENIED, POSITION_UNAVAILABLE, TIMEOUT, message: 'User denied' } as GeolocationPositionError)
+      }),
+    })
+
+    const { result } = renderHook(() => useGeolocationCapture())
+    const gps = await act(() => result.current())
+
+    expect(gps.status).toBe('denied')
+  })
+
+  it('returns timeout when the browser does not respond in time', async () => {
+    setGeolocation({
+      getCurrentPosition: vi.fn((_success, error) => {
+        error?.({ code: TIMEOUT, PERMISSION_DENIED, POSITION_UNAVAILABLE, TIMEOUT, message: 'Timeout' } as GeolocationPositionError)
+      }),
+    })
+
+    const { result } = renderHook(() => useGeolocationCapture())
+    const gps = await act(() => result.current())
+
+    expect(gps.status).toBe('timeout')
+  })
+
+  it('returns unavailable when POSITION_UNAVAILABLE is reported', async () => {
+    setGeolocation({
+      getCurrentPosition: vi.fn((_success, error) => {
+        error?.({ code: POSITION_UNAVAILABLE, PERMISSION_DENIED, POSITION_UNAVAILABLE, TIMEOUT, message: 'Unavailable' } as GeolocationPositionError)
+      }),
+    })
+
+    const { result } = renderHook(() => useGeolocationCapture())
+    const gps = await act(() => result.current())
+
+    expect(gps.status).toBe('unavailable')
+  })
+
+  it('returns unavailable when navigator.geolocation is missing', async () => {
+    setGeolocation(null)
+
+    const { result } = renderHook(() => useGeolocationCapture())
+    const gps = await act(() => result.current())
+
+    expect(gps.status).toBe('unavailable')
+  })
+
+  it('never rejects when the underlying call throws', async () => {
+    setGeolocation({
+      getCurrentPosition: vi.fn(() => {
+        throw new Error('boom')
+      }),
+    })
+
+    const { result } = renderHook(() => useGeolocationCapture())
+    await expect(act(() => result.current())).resolves.toMatchObject({ status: 'error' })
+  })
+})

--- a/src/hooks/useGeolocationCapture.ts
+++ b/src/hooks/useGeolocationCapture.ts
@@ -1,0 +1,84 @@
+import { useCallback } from 'react'
+
+export type GpsStatus = 'ok' | 'denied' | 'unavailable' | 'timeout' | 'error'
+
+export type GpsResult =
+  | {
+      status: 'ok'
+      lat: number
+      lng: number
+      accuracy: number
+      capturadoAt: string
+    }
+  | { status: Exclude<GpsStatus, 'ok'> }
+
+export interface UseGeolocationCaptureOptions {
+  timeoutMs?: number
+  enableHighAccuracy?: boolean
+  maximumAgeMs?: number
+}
+
+/**
+ * Captura la posición GPS actual del navegador en una sola llamada.
+ *
+ * - Resuelve siempre (nunca rechaza). En cualquier escenario de error
+ *   devuelve un objeto `{ status: 'denied' | 'unavailable' | 'timeout' | 'error' }`
+ *   para que el caller pueda persistir el motivo sin bloquear el flujo de
+ *   negocio (ej: confirmar pedido).
+ * - Por defecto: timeout 10s, alta precisión, cache de hasta 30s.
+ */
+export function useGeolocationCapture(options: UseGeolocationCaptureOptions = {}) {
+  const {
+    timeoutMs = 10_000,
+    enableHighAccuracy = true,
+    maximumAgeMs = 30_000,
+  } = options
+
+  return useCallback((): Promise<GpsResult> => {
+    return new Promise((resolve) => {
+      if (typeof navigator === 'undefined' || !navigator.geolocation) {
+        resolve({ status: 'unavailable' })
+        return
+      }
+
+      let settled = false
+      const safeResolve = (result: GpsResult) => {
+        if (settled) return
+        settled = true
+        resolve(result)
+      }
+
+      try {
+        navigator.geolocation.getCurrentPosition(
+          (pos) => {
+            safeResolve({
+              status: 'ok',
+              lat: pos.coords.latitude,
+              lng: pos.coords.longitude,
+              accuracy: pos.coords.accuracy,
+              capturadoAt: new Date().toISOString(),
+            })
+          },
+          (err) => {
+            if (err.code === err.PERMISSION_DENIED) {
+              safeResolve({ status: 'denied' })
+            } else if (err.code === err.TIMEOUT) {
+              safeResolve({ status: 'timeout' })
+            } else if (err.code === err.POSITION_UNAVAILABLE) {
+              safeResolve({ status: 'unavailable' })
+            } else {
+              safeResolve({ status: 'error' })
+            }
+          },
+          {
+            enableHighAccuracy,
+            timeout: timeoutMs,
+            maximumAge: maximumAgeMs,
+          },
+        )
+      } catch {
+        safeResolve({ status: 'error' })
+      }
+    })
+  }, [enableHighAccuracy, maximumAgeMs, timeoutMs])
+}

--- a/src/hooks/useRegistrarGeolocalizacionPedido.ts
+++ b/src/hooks/useRegistrarGeolocalizacionPedido.ts
@@ -1,0 +1,49 @@
+import { useCallback } from 'react'
+import { supabase } from './supabase/base'
+import { logger } from '../utils/logger'
+import { useGeolocationCapture, type GpsResult } from './useGeolocationCapture'
+
+/**
+ * Wraps `useGeolocationCapture` + el RPC `registrar_geolocalizacion_pedido`.
+ *
+ * Devuelve dos primitivas:
+ * - `capturarGps()`: dispara la captura del navegador en cuanto el usuario
+ *   confirma el pedido (en paralelo a la creación). Devuelve siempre una
+ *   `Promise<GpsResult>` que nunca rechaza.
+ * - `registrarGpsPedido(pedidoId, gps)`: persiste el resultado contra el RPC.
+ *   No lanza; loguea errores silenciosamente.
+ *
+ * Diseño: el componente arranca `capturarGps()` en paralelo con la mutation
+ * de creación; al volver la creación con un id válido, envía el GPS capturado
+ * vía RPC. El usuario ve "Pedido creado" sin esperar el GPS, y el check-in
+ * queda registrado a más tardar en `timeout` segundos.
+ */
+export function useRegistrarGeolocalizacionPedido() {
+  const capturarGps = useGeolocationCapture()
+
+  const registrarGpsPedido = useCallback(
+    async (pedidoId: string | number, gps: GpsResult): Promise<void> => {
+      try {
+        const params: Record<string, unknown> = {
+          p_pedido_id: typeof pedidoId === 'string' ? Number(pedidoId) : pedidoId,
+          p_status: gps.status,
+        }
+        if (gps.status === 'ok') {
+          params.p_lat = gps.lat
+          params.p_lng = gps.lng
+          params.p_accuracy = gps.accuracy
+          params.p_capturado_at = gps.capturadoAt
+        }
+        const { error } = await supabase.rpc('registrar_geolocalizacion_pedido', params)
+        if (error) {
+          logger.warn('[registrar_geolocalizacion_pedido] RPC error:', error.message)
+        }
+      } catch (err) {
+        logger.warn('[registrar_geolocalizacion_pedido] unexpected error:', (err as Error).message)
+      }
+    },
+    [],
+  )
+
+  return { capturarGps, registrarGpsPedido }
+}

--- a/src/lib/permisos.ts
+++ b/src/lib/permisos.ts
@@ -51,6 +51,10 @@ export function puedeAccederTransferencias(rol: RolUsuario | null | undefined): 
   return rol === 'admin'
 }
 
+export function puedeAccederGeolocalizacion(rol: RolUsuario | null | undefined): boolean {
+  return rol === 'admin'
+}
+
 export type PedidoStatKey =
   | 'pendientes'
   | 'enPreparacion'

--- a/src/types/hooks.ts
+++ b/src/types/hooks.ts
@@ -132,6 +132,13 @@ export interface PedidoDB {
   created_at?: string;
   updated_at?: string;
   deleted_at?: string | null;
+  // Geolocalizacion del check-in del preventista al confirmar el pedido.
+  // Null en pedidos previos a migration 040 o creados por roles que no capturan GPS.
+  gps_lat?: number | null;
+  gps_lng?: number | null;
+  gps_accuracy?: number | null;
+  gps_capturado_at?: string | null;
+  gps_status?: 'ok' | 'denied' | 'unavailable' | 'timeout' | 'error' | null;
 }
 
 export interface MermaDB {

--- a/src/utils/geo.test.ts
+++ b/src/utils/geo.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from 'vitest'
+import {
+  haversineMeters,
+  formatDistancia,
+  clasificarDistancia,
+  colorPreventista,
+} from './geo'
+
+describe('haversineMeters', () => {
+  it('returns 0 for identical coordinates', () => {
+    const c = { lat: -26.8, lng: -65.2 }
+    expect(haversineMeters(c, c)).toBeCloseTo(0, 3)
+  })
+
+  it('matches known distance Tucumán → Salta (~250 km)', () => {
+    const tucuman = { lat: -26.8083, lng: -65.2176 }
+    const salta = { lat: -24.7821, lng: -65.4232 }
+    const meters = haversineMeters(tucuman, salta)
+    expect(meters).toBeGreaterThan(220_000)
+    expect(meters).toBeLessThan(260_000)
+  })
+
+  it('is symmetric', () => {
+    const a = { lat: -26.8, lng: -65.2 }
+    const b = { lat: -26.9, lng: -65.3 }
+    expect(haversineMeters(a, b)).toBeCloseTo(haversineMeters(b, a), 5)
+  })
+})
+
+describe('formatDistancia', () => {
+  it('returns dash for null/undefined/NaN', () => {
+    expect(formatDistancia(null)).toBe('—')
+    expect(formatDistancia(undefined)).toBe('—')
+    expect(formatDistancia(NaN)).toBe('—')
+  })
+
+  it('uses meters under 1000', () => {
+    expect(formatDistancia(0)).toBe('0 m')
+    expect(formatDistancia(320)).toBe('320 m')
+    expect(formatDistancia(999.4)).toBe('999 m')
+  })
+
+  it('uses km with one decimal above 1000', () => {
+    expect(formatDistancia(1000)).toBe('1.0 km')
+    expect(formatDistancia(1432)).toBe('1.4 km')
+    expect(formatDistancia(5234)).toBe('5.2 km')
+  })
+})
+
+describe('clasificarDistancia', () => {
+  it('classifies thresholds correctly', () => {
+    expect(clasificarDistancia(null)).toBe('sin_dato')
+    expect(clasificarDistancia(undefined)).toBe('sin_dato')
+    expect(clasificarDistancia(0)).toBe('ok')
+    expect(clasificarDistancia(499)).toBe('ok')
+    expect(clasificarDistancia(500)).toBe('cerca')
+    expect(clasificarDistancia(1999)).toBe('cerca')
+    expect(clasificarDistancia(2000)).toBe('lejos')
+    expect(clasificarDistancia(10_000)).toBe('lejos')
+  })
+})
+
+describe('colorPreventista', () => {
+  it('returns deterministic color for the same id', () => {
+    const id = 'b1f2c3d4-1234-5678-9abc-def012345678'
+    expect(colorPreventista(id)).toBe(colorPreventista(id))
+  })
+
+  it('returns a hex color from the palette', () => {
+    const c = colorPreventista('abc')
+    expect(c).toMatch(/^#[0-9a-f]{6}$/i)
+  })
+
+  it('different ids tend to get different colors', () => {
+    const ids = ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h']
+    const colors = new Set(ids.map(colorPreventista))
+    // Palette has 8 entries; expect at least 3 distinct values across 8 inputs.
+    expect(colors.size).toBeGreaterThanOrEqual(3)
+  })
+})

--- a/src/utils/geo.ts
+++ b/src/utils/geo.ts
@@ -1,0 +1,71 @@
+/**
+ * Utilidades de geolocalización.
+ *
+ * - `haversineMeters`: distancia en metros entre dos coordenadas (lat,lng).
+ * - `formatDistancia`: formatea metros como "320 m" / "1.4 km" / "—".
+ * - `clasificarDistancia`: semáforo del panel admin (ok / cerca / lejos / sin-dato).
+ * - `colorPreventista`: paleta determinística por id (consistente entre mapa,
+ *   sidebar y timeline).
+ */
+
+const EARTH_RADIUS_M = 6_371_000
+
+const PALETA_PREVENTISTAS = [
+  '#2563eb', // azul
+  '#dc2626', // rojo
+  '#16a34a', // verde
+  '#ea580c', // naranja
+  '#9333ea', // violeta
+  '#0891b2', // cyan
+  '#ca8a04', // amarillo oscuro
+  '#db2777', // rosa
+] as const
+
+export type Coord = { lat: number; lng: number }
+
+export function haversineMeters(a: Coord, b: Coord): number {
+  const toRad = (deg: number) => (deg * Math.PI) / 180
+  const dLat = toRad(b.lat - a.lat)
+  const dLng = toRad(b.lng - a.lng)
+  const lat1 = toRad(a.lat)
+  const lat2 = toRad(b.lat)
+  const h =
+    Math.sin(dLat / 2) ** 2 +
+    Math.cos(lat1) * Math.cos(lat2) * Math.sin(dLng / 2) ** 2
+  return 2 * EARTH_RADIUS_M * Math.asin(Math.sqrt(h))
+}
+
+export function formatDistancia(metros: number | null | undefined): string {
+  if (metros == null || !Number.isFinite(metros)) return '—'
+  if (metros < 1000) return `${Math.round(metros)} m`
+  return `${(metros / 1000).toFixed(1)} km`
+}
+
+export type ClasificacionDistancia = 'ok' | 'cerca' | 'lejos' | 'sin_dato'
+
+export function clasificarDistancia(metros: number | null | undefined): ClasificacionDistancia {
+  if (metros == null || !Number.isFinite(metros)) return 'sin_dato'
+  if (metros < 500) return 'ok'
+  if (metros < 2000) return 'cerca'
+  return 'lejos'
+}
+
+export const SEMAFORO_COLORS: Record<ClasificacionDistancia, { bg: string; text: string; label: string }> = {
+  ok:       { bg: 'bg-green-100 text-green-800',   text: 'text-green-700',   label: 'En el cliente' },
+  cerca:    { bg: 'bg-yellow-100 text-yellow-800', text: 'text-yellow-700',  label: 'Cerca del cliente' },
+  lejos:    { bg: 'bg-red-100 text-red-800',       text: 'text-red-700',     label: 'Lejos del cliente' },
+  sin_dato: { bg: 'bg-gray-100 text-gray-600',     text: 'text-gray-500',    label: 'Sin ubicación' },
+}
+
+/**
+ * Devuelve un color consistente de la paleta para un preventista dado.
+ * El mismo preventista_id siempre obtiene el mismo color en sidebar, pin y timeline.
+ */
+export function colorPreventista(preventistaId: string): string {
+  let hash = 0
+  for (let i = 0; i < preventistaId.length; i++) {
+    hash = (hash * 31 + preventistaId.charCodeAt(i)) | 0
+  }
+  const idx = Math.abs(hash) % PALETA_PREVENTISTAS.length
+  return PALETA_PREVENTISTAS[idx]
+}

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -28,11 +28,109 @@ declare namespace google.maps {
 
   class Map {
     constructor(mapDiv: Element, opts?: MapOptions);
+    fitBounds(bounds: LatLngBounds, padding?: number | Padding): void;
+    panTo(latLng: LatLng | LatLngLiteral): void;
+    setCenter(latLng: LatLng | LatLngLiteral): void;
+    setZoom(zoom: number): void;
+    getZoom(): number;
+  }
+
+  interface Padding {
+    top?: number;
+    right?: number;
+    bottom?: number;
+    left?: number;
   }
 
   interface MapOptions {
     center?: LatLng | LatLngLiteral;
     zoom?: number;
+    disableDefaultUI?: boolean;
+    mapTypeControl?: boolean;
+    streetViewControl?: boolean;
+    fullscreenControl?: boolean;
+    zoomControl?: boolean;
+    clickableIcons?: boolean;
+    styles?: unknown[];
+  }
+
+  class LatLngBounds {
+    constructor(sw?: LatLng | LatLngLiteral, ne?: LatLng | LatLngLiteral);
+    extend(point: LatLng | LatLngLiteral): LatLngBounds;
+    isEmpty(): boolean;
+    getCenter(): LatLng;
+  }
+
+  class Marker {
+    constructor(opts?: MarkerOptions);
+    setMap(map: Map | null): void;
+    setPosition(latLng: LatLng | LatLngLiteral): void;
+    setIcon(icon: unknown): void;
+    addListener(event: string, handler: (...args: unknown[]) => void): MapsEventListener;
+    getPosition(): LatLng | null;
+  }
+
+  interface MarkerOptions {
+    position?: LatLng | LatLngLiteral;
+    map?: Map;
+    title?: string;
+    label?: string | { text: string; color?: string; fontWeight?: string; fontSize?: string };
+    icon?: unknown;
+    zIndex?: number;
+    opacity?: number;
+  }
+
+  interface MapsEventListener {
+    remove(): void;
+  }
+
+  class Polyline {
+    constructor(opts?: PolylineOptions);
+    setMap(map: Map | null): void;
+    setPath(path: Array<LatLng | LatLngLiteral>): void;
+  }
+
+  interface PolylineOptions {
+    path?: Array<LatLng | LatLngLiteral>;
+    map?: Map;
+    geodesic?: boolean;
+    strokeColor?: string;
+    strokeOpacity?: number;
+    strokeWeight?: number;
+  }
+
+  class InfoWindow {
+    constructor(opts?: InfoWindowOptions);
+    open(map?: Map, anchor?: Marker): void;
+    close(): void;
+    setContent(content: string | HTMLElement): void;
+    setPosition(position: LatLng | LatLngLiteral): void;
+  }
+
+  interface InfoWindowOptions {
+    content?: string | HTMLElement;
+    position?: LatLng | LatLngLiteral;
+    maxWidth?: number;
+  }
+
+  interface Symbol {
+    path: string | number;
+    fillColor?: string;
+    fillOpacity?: number;
+    strokeColor?: string;
+    strokeWeight?: number;
+    scale?: number;
+    labelOrigin?: { x: number; y: number };
+  }
+
+  const SymbolPath: {
+    CIRCLE: number;
+    BACKWARD_CLOSED_ARROW: number;
+    FORWARD_CLOSED_ARROW: number;
+  };
+
+  namespace event {
+    function clearInstanceListeners(instance: object): void;
   }
 
   interface LatLngLiteral {


### PR DESCRIPTION
## Summary

- **Check-in GPS al confirmar pedido**: cada preventista deja un pin con su ubicación al cerrar venta. La captura corre en paralelo a `crearPedido.mutateAsync` y se persiste fire-and-forget vía RPC, sin agregar latencia al flujo. Si el navegador rechaza, falla o no tiene señal, el pedido se confirma igual con `gps_status='denied'|'timeout'|'unavailable'|'error'`.
- **Panel admin profesional** en `/geolocalizacion` (solo admin): Google Maps con dos modos (global = 1 pin por preventista, drill-down = pins numerados + polilínea del recorrido), sidebar ordenada por actividad reciente, timeline del día, tabla de anomalías (sin GPS o ≥2 km del cliente), KPIs y auto-refresh 60s cuando el rango incluye hoy.
- **Verificación de visita** integrada en `VistaPedidos`: badge con semáforo de distancia (🟢 <500 m, 🟡 <2 km, 🔴 ≥2 km, ⚫ sin GPS) en cada `PedidoCard`, visible al admin y al preventista dueño.

## Modelo de datos (migration 040)

`pedidos`: `gps_lat`, `gps_lng`, `gps_accuracy`, `gps_capturado_at`, `gps_status` (check constraint). Helper `haversine_m()` SQL. Dos RPCs nuevas:
- `registrar_geolocalizacion_pedido(p_pedido_id, p_status, p_lat?, p_lng?, p_accuracy?, p_capturado_at?)` — idempotente (no sobrescribe), autoriza dueño o admin, valida sucursal activa.
- `obtener_geolocalizacion_preventistas(p_fecha_desde?, p_fecha_hasta?)` — admin only, scope a `current_sucursal_id()`, devuelve resumen + detalle en un solo JSON.

**La migration ya está aplicada al proyecto productivo `hmuchlzmuqqxcldbzkgc`.**

## Decisiones de producto

- **Modelo**: check-in por evento (no continuo, no background). Único disparador: confirmar pedido. Decidido junto con el usuario para arrancar minimalista — si después hay demanda de densificar el recorrido, se agrega botón "Visita sin pedido" o heartbeat.
- **Sin consentimiento explícito** en UI (solo el prompt nativo del navegador). Decisión del producto.
- **Implicación conocida**: si un preventista no carga pedidos en un tramo del día, los admins no verán datos en ese tramo.

## Out of scope

- Bot Telegram: pedidos creados desde el bot quedan con `gps_status=null` por ahora.
- App nativa / background tracking.
- Heatmaps históricos.

## Test plan

- [x] Lint limpio
- [x] `tsc --noEmit` limpio
- [x] Suite unitaria completa (631 tests, incluyendo 6 nuevos de `useGeolocationCapture` con mock de `navigator.geolocation` y 10 de `utils/geo`)
- [ ] Logear como **preventista**, crear pedido, aceptar prompt de GPS → verificar columnas `gps_*` seteadas en `pedidos`
- [ ] Repetir denegando el prompt → `gps_status='denied'` y coords null
- [ ] DevTools → Sensors → Location: Unavailable → confirmar pedido → `gps_status='timeout'` o `'unavailable'`
- [ ] Logear como **admin** y abrir `/geolocalizacion` → ver KPIs, sidebar con preventistas, mapa con pins
- [ ] Click en un preventista → drill-down muestra polilínea numerada y timeline poblado
- [ ] Tab "Anomalías" lista pedidos sin GPS / lejos del cliente; el botón "Ver" centra el mapa
- [ ] Crear pedido para cliente con lat/lng cargados estando a >2 km (DevTools location spoof) → badge 🔴 en `PedidoCard`
- [ ] Logear como **transportista** o **encargado** → no se pide GPS al crear pedido y la entrada "Geolocalización" del menú no aparece

🤖 Generated with [Claude Code](https://claude.com/claude-code)