### PR TITLE
fix(geolocalizacion): registrar ruta en App.tsx (router activo)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -37,6 +37,7 @@ import UsuariosContainer from './components/containers/UsuariosContainer'
 
 const VistaRendiciones = lazy(() => import('./components/vistas/VistaRendiciones'))
 const VistaSalvedades = lazy(() => import('./components/vistas/VistaSalvedades'))
+const VistaGeolocalizacion = lazy(() => import('./components/vistas/VistaGeolocalizacion'))
 const AnalyticsContainer = lazy(() => import('./components/containers/AnalyticsContainer'))
 const ReportesContainer = lazy(() => import('./components/containers/ReportesContainer'))
 const ComisionesContainer = lazy(() => import('./components/containers/ComisionesContainer'))
@@ -320,6 +321,11 @@ function MainAppInner({ user, perfil, logout, authReady }: {
                 <Route
                   path="/bot-telegram"
                   element={isAdmin ? <VistaBotTelegramContainer /> : <Navigate to="/dashboard" replace />}
+                />
+
+                <Route
+                  path="/geolocalizacion"
+                  element={isAdmin ? <VistaGeolocalizacion /> : <Navigate to="/pedidos" replace />}
                 />
 
                 <Route path="*" element={<Navigate to={defaultRoute} replace />} />


### PR DESCRIPTION
## Summary

- El PR #298 dejó la ruta `/geolocalizacion` en `src/components/AppRouter.tsx`, pero ese archivo es legacy y no se monta en runtime. El router activo vive en `src/App.tsx`, donde el path no estaba registrado y caía al catch-all → redirect a `/pedidos`.
- Resultado: el botón "Operaciones > Geolocalización" en el menú admin parecía no hacer nada (se abría la vista de Pedidos).
- Fix: registrar la ruta en `App.tsx` con guard `isAdmin`, siguiendo el patrón de las demás vistas admin.

## Test plan

- [x] Lint
- [x] `tsc --noEmit`
- [x] Suite unitaria (631 tests)
- [ ] Logear como admin → click "Operaciones > Geolocalización" → debe abrirse `VistaGeolocalizacion`
- [ ] Logear como no-admin → entrar manualmente a `/geolocalizacion` → debe redirigir a `/pedidos`

## Nota de seguimiento (fuera de scope)

`src/components/AppRouter.tsx` está muerto: no se importa en ningún lado. Es código de una migración que no se completó. Eliminarlo o terminar la migración es una tarea aparte.

🤖 Generated with [Claude Code](https://claude.com/claude-code)