### PR TITLE
feat(geolocalizacion): mostrar hora de creacion del pedido

### DIFF
--- a/migrations/041_geolocalizacion_pedido_created_at.sql
+++ b/migrations/041_geolocalizacion_pedido_created_at.sql
@@ -1,0 +1,115 @@
+-- =========================================================================
+-- 041_geolocalizacion_pedido_created_at.sql
+--
+-- Agrega el campo `created_at` del pedido al output de la RPC
+-- `obtener_geolocalizacion_preventistas`. El panel admin lo usa para
+-- mostrar la hora exacta en que se creo cada pedido (no depende de
+-- gps_capturado_at, que puede ser null si el preventista no autorizo GPS).
+--
+-- CREATE OR REPLACE sobre la definicion de la migracion 040, agregando
+-- `p.created_at AS pedido_created_at` al SELECT del CTE pedidos_rango.
+-- =========================================================================
+
+BEGIN;
+
+CREATE OR REPLACE FUNCTION public.obtener_geolocalizacion_preventistas(
+  p_fecha_desde date DEFAULT NULL,
+  p_fecha_hasta date DEFAULT NULL
+) RETURNS jsonb
+LANGUAGE plpgsql SECURITY DEFINER SET search_path TO 'public'
+AS $$
+DECLARE
+  v_user_id uuid := auth.uid();
+  v_user_role text;
+  v_sucursal bigint := current_sucursal_id();
+  v_fecha_desde date := COALESCE(p_fecha_desde, (now() AT TIME ZONE 'America/Argentina/Buenos_Aires')::date);
+  v_fecha_hasta date := COALESCE(p_fecha_hasta, v_fecha_desde);
+  v_result jsonb;
+BEGIN
+  IF v_user_id IS NULL THEN
+    RAISE EXCEPTION 'No autenticado' USING ERRCODE = '42501';
+  END IF;
+  IF v_sucursal IS NULL THEN
+    RAISE EXCEPTION 'No hay sucursal activa' USING ERRCODE = '42501';
+  END IF;
+
+  SELECT rol INTO v_user_role FROM perfiles WHERE id = v_user_id;
+  IF v_user_role <> 'admin' THEN
+    RAISE EXCEPTION 'Solo admins pueden ver geolocalizacion de preventistas' USING ERRCODE = '42501';
+  END IF;
+
+  WITH pedidos_rango AS (
+    SELECT
+      p.id              AS pedido_id,
+      p.usuario_id      AS preventista_id,
+      p.fecha,
+      p.created_at      AS pedido_created_at,
+      p.total,
+      p.gps_lat,
+      p.gps_lng,
+      p.gps_accuracy,
+      p.gps_capturado_at,
+      p.gps_status,
+      p.cliente_id,
+      c.nombre_fantasia AS cliente_nombre,
+      c.latitud         AS cliente_lat,
+      c.longitud        AS cliente_lng,
+      public.haversine_m(p.gps_lat, p.gps_lng, c.latitud, c.longitud) AS distancia_m
+    FROM pedidos p
+    LEFT JOIN clientes c ON c.id = p.cliente_id
+    WHERE p.sucursal_id = v_sucursal
+      AND p.fecha BETWEEN v_fecha_desde AND v_fecha_hasta
+      AND p.usuario_id IS NOT NULL
+  ),
+  preventistas_resumen AS (
+    SELECT
+      pr.preventista_id,
+      per.nombre AS preventista_nombre,
+      COUNT(*)::int AS total_pedidos,
+      COUNT(*) FILTER (WHERE pr.gps_status = 'ok')::int AS pedidos_con_gps,
+      COUNT(*) FILTER (WHERE pr.gps_status IS NULL OR pr.gps_status <> 'ok')::int AS pedidos_sin_gps,
+      COUNT(*) FILTER (
+        WHERE pr.gps_status = 'ok' AND pr.distancia_m IS NOT NULL AND pr.distancia_m >= 2000
+      )::int AS pedidos_lejos,
+      (
+        SELECT jsonb_build_object(
+          'lat', pr2.gps_lat,
+          'lng', pr2.gps_lng,
+          'capturado_at', pr2.gps_capturado_at,
+          'pedido_id', pr2.pedido_id
+        )
+        FROM pedidos_rango pr2
+        WHERE pr2.preventista_id = pr.preventista_id
+          AND pr2.gps_status = 'ok'
+        ORDER BY pr2.gps_capturado_at DESC NULLS LAST
+        LIMIT 1
+      ) AS ultima_ubicacion
+    FROM pedidos_rango pr
+    LEFT JOIN perfiles per ON per.id = pr.preventista_id
+    WHERE per.rol = 'preventista'
+    GROUP BY pr.preventista_id, per.nombre
+  )
+  SELECT jsonb_build_object(
+    'fecha_desde', v_fecha_desde,
+    'fecha_hasta', v_fecha_hasta,
+    'preventistas', COALESCE(
+      (SELECT jsonb_agg(to_jsonb(preventistas_resumen.*) ORDER BY preventista_nombre)
+       FROM preventistas_resumen),
+      '[]'::jsonb
+    ),
+    'pedidos', COALESCE(
+      (SELECT jsonb_agg(to_jsonb(pr.*) ORDER BY pr.pedido_created_at NULLS LAST)
+       FROM pedidos_rango pr
+       JOIN perfiles per ON per.id = pr.preventista_id AND per.rol = 'preventista'),
+      '[]'::jsonb
+    )
+  ) INTO v_result;
+
+  RETURN v_result;
+END;
+$$;
+
+COMMENT ON FUNCTION public.obtener_geolocalizacion_preventistas(date, date) IS
+  'Panel admin de geolocalizacion: resumen por preventista + detalle de pedidos con GPS, distancia al cliente y created_at del pedido. Scope a current_sucursal_id().';
+
+COMMIT;

--- a/src/components/geolocalizacion/MapaPreventistas.tsx
+++ b/src/components/geolocalizacion/MapaPreventistas.tsx
@@ -3,7 +3,7 @@ import React, { useEffect, useRef, useState } from 'react'
 import { Loader2, MapPin } from 'lucide-react'
 import { useGoogleMaps } from '../../hooks/useGoogleMaps'
 import { colorPreventista, formatDistancia, clasificarDistancia, SEMAFORO_COLORS } from '../../utils/geo'
-import { formatPrecio } from '../../utils/formatters'
+import { formatPrecio, formatHora } from '../../utils/formatters'
 import type { PreventistaResumen, PedidoConGps } from '../../hooks/queries'
 
 interface MapaPreventistasProps {
@@ -30,15 +30,6 @@ function escapeHtml(s: string): string {
       default: return ch
     }
   })
-}
-
-function formatHora(iso: string | null | undefined): string {
-  if (!iso) return '—'
-  try {
-    return new Date(iso).toLocaleTimeString('es-AR', { hour: '2-digit', minute: '2-digit' })
-  } catch {
-    return '—'
-  }
 }
 
 function pinSymbol(color: string, scale = 8): google.maps.Symbol {
@@ -224,7 +215,7 @@ export default function MapaPreventistas({
         <div style="font-family: ui-sans-serif, system-ui; padding: 4px 2px; max-width: 260px;">
           <div style="font-weight: 600; color: #111827; font-size: 13px;">${escapeHtml(p.cliente_nombre || 'Cliente sin nombre')}</div>
           <div style="color: #6b7280; font-size: 11px; margin-top: 2px;">
-            Pedido #${p.pedido_id} · ${formatHora(p.gps_capturado_at)}
+            Pedido #${p.pedido_id} · ${formatHora(p.pedido_created_at ?? p.gps_capturado_at)}
           </div>
           <div style="margin-top: 6px; font-size: 12px; color: #374151;">
             <strong>${formatPrecio(Number(p.total) || 0)}</strong>

--- a/src/components/geolocalizacion/SidebarPreventistas.tsx
+++ b/src/components/geolocalizacion/SidebarPreventistas.tsx
@@ -1,21 +1,13 @@
 import React, { useMemo } from 'react'
 import { MapPin, ShoppingCart, AlertTriangle } from 'lucide-react'
 import { colorPreventista } from '../../utils/geo'
+import { formatHora } from '../../utils/formatters'
 import type { PreventistaResumen } from '../../hooks/queries'
 
 interface SidebarPreventistasProps {
   preventistas: PreventistaResumen[]
   selectedId: string | null
   onSelect: (id: string | null) => void
-}
-
-function formatHora(iso: string | null | undefined): string {
-  if (!iso) return '—'
-  try {
-    return new Date(iso).toLocaleTimeString('es-AR', { hour: '2-digit', minute: '2-digit' })
-  } catch {
-    return '—'
-  }
 }
 
 export default function SidebarPreventistas({ preventistas, selectedId, onSelect }: SidebarPreventistasProps): React.ReactElement {

--- a/src/components/geolocalizacion/TablaAnomalias.tsx
+++ b/src/components/geolocalizacion/TablaAnomalias.tsx
@@ -1,6 +1,6 @@
 import React, { useMemo } from 'react'
 import { AlertTriangle, ZapOff, Search } from 'lucide-react'
-import { formatPrecio } from '../../utils/formatters'
+import { formatPrecio, formatHora } from '../../utils/formatters'
 import { clasificarDistancia, formatDistancia, SEMAFORO_COLORS } from '../../utils/geo'
 import type { PedidoConGps, PreventistaResumen } from '../../hooks/queries'
 
@@ -22,15 +22,6 @@ interface AnomaliaRow {
   total: number
 }
 
-function formatHora(iso: string | null | undefined): string {
-  if (!iso) return '—'
-  try {
-    return new Date(iso).toLocaleTimeString('es-AR', { hour: '2-digit', minute: '2-digit' })
-  } catch {
-    return '—'
-  }
-}
-
 export default function TablaAnomalias({ pedidos, preventistas, onSelectPedido }: TablaAnomaliasProps): React.ReactElement {
   const nombresMap = useMemo(() => {
     const map: Record<string, string> = {}
@@ -49,7 +40,7 @@ export default function TablaAnomalias({ pedidos, preventistas, onSelectPedido }
         preventista_id: p.preventista_id,
         preventista_nombre: nombresMap[p.preventista_id] ?? '—',
         cliente_nombre: p.cliente_nombre || 'Sin cliente',
-        hora: formatHora(p.gps_capturado_at),
+        hora: formatHora(p.pedido_created_at ?? p.gps_capturado_at),
         motivo: sinGps ? 'sin_gps' : 'lejos',
         motivo_label: sinGps
           ? (p.gps_status === 'denied' ? 'GPS denegado'

--- a/src/components/geolocalizacion/TimelineRecorrido.tsx
+++ b/src/components/geolocalizacion/TimelineRecorrido.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { Clock, MapPin, AlertCircle } from 'lucide-react'
-import { formatPrecio } from '../../utils/formatters'
+import { formatPrecio, formatHora } from '../../utils/formatters'
 import { clasificarDistancia, formatDistancia, SEMAFORO_COLORS, colorPreventista } from '../../utils/geo'
 import type { PedidoConGps } from '../../hooks/queries'
 
@@ -10,15 +10,6 @@ interface TimelineRecorridoProps {
   preventistaNombre: string | null
   selectedPedidoId: number | null
   onSelectPedido: (pedidoId: number | null) => void
-}
-
-function formatHora(iso: string | null | undefined): string {
-  if (!iso) return '—'
-  try {
-    return new Date(iso).toLocaleTimeString('es-AR', { hour: '2-digit', minute: '2-digit' })
-  } catch {
-    return '—'
-  }
 }
 
 export default function TimelineRecorrido({
@@ -36,11 +27,14 @@ export default function TimelineRecorrido({
     )
   }
 
+  // Ordenamos por created_at del pedido para que el timeline refleje el
+  // orden real de creación, independiente de si hubo o no check-in GPS.
+  // Fallback a gps_capturado_at para pedidos previos a la migración 041.
   const propios = pedidos
     .filter(p => p.preventista_id === preventistaId)
     .sort((a, b) => {
-      const ta = a.gps_capturado_at ? Date.parse(a.gps_capturado_at) : 0
-      const tb = b.gps_capturado_at ? Date.parse(b.gps_capturado_at) : 0
+      const ta = Date.parse(a.pedido_created_at ?? a.gps_capturado_at ?? '') || 0
+      const tb = Date.parse(b.pedido_created_at ?? b.gps_capturado_at ?? '') || 0
       return ta - tb
     })
 
@@ -101,9 +95,12 @@ export default function TimelineRecorrido({
                     <p className="text-sm font-medium text-gray-900 dark:text-white truncate">
                       {p.cliente_nombre || 'Cliente sin nombre'}
                     </p>
-                    <span className="shrink-0 text-xs text-gray-500 dark:text-gray-400 inline-flex items-center gap-1">
+                    <span
+                      className="shrink-0 text-xs text-gray-500 dark:text-gray-400 inline-flex items-center gap-1"
+                      title="Hora de creación del pedido"
+                    >
                       <Clock className="w-3 h-3" />
-                      {formatHora(p.gps_capturado_at)}
+                      {formatHora(p.pedido_created_at ?? p.gps_capturado_at)}
                     </span>
                   </div>
                   <div className="mt-1 flex items-center justify-between gap-2 flex-wrap">

--- a/src/components/pedidos/PedidoCard.tsx
+++ b/src/components/pedidos/PedidoCard.tsx
@@ -13,7 +13,7 @@ const generarReciboPedido = async (pedido: any, _empresa: any = {}, options: { f
   const mod = await import('../../lib/pdfExport') as any
   return mod.generarReciboPedido(pedido, _empresa, options)
 };
-import { formatPrecio, formatFecha, getEstadoColor, getEstadoPagoColor, getEstadoPagoLabel, getFormaPagoLabel, getFormaPagoDisplay } from '../../utils/formatters';
+import { formatPrecio, formatFecha, formatHora, getEstadoColor, getEstadoPagoColor, getEstadoPagoLabel, getFormaPagoLabel, getFormaPagoDisplay } from '../../utils/formatters';
 import { MOTIVOS_SALVEDAD_LABELS } from '../../lib/schemas';
 import AccionesDropdown from './PedidoActions';
 import { PedidoActionsCtx } from '../../contexts/HandlersContext';
@@ -252,6 +252,12 @@ function PedidoCard({
               <p className="text-sm text-gray-500 dark:text-gray-400">{pedido.cliente?.direccion}</p>
               <p className="text-sm text-gray-400 dark:text-gray-500 mt-1 flex items-center gap-2 flex-wrap">
                 <span>#{pedido.id} - {formatFecha(pedido.fecha || pedido.created_at)}</span>
+                {pedido.created_at && (
+                  <span className="inline-flex items-center gap-0.5 text-xs text-gray-400 dark:text-gray-500" title="Hora de creación del pedido">
+                    <Clock className="w-3 h-3" />
+                    {formatHora(pedido.created_at)}
+                  </span>
+                )}
                 {pedido.fecha_entrega_programada && pedido.estado !== 'entregado' && pedido.estado !== 'cancelado' && (
                   <span className="inline-flex items-center gap-0.5 text-xs text-orange-600 dark:text-orange-400">
                     <Truck className="w-3 h-3" />

--- a/src/hooks/queries/useGeolocalizacionPreventistasQuery.ts
+++ b/src/hooks/queries/useGeolocalizacionPreventistasQuery.ts
@@ -36,6 +36,12 @@ export interface PedidoConGps {
   pedido_id: number
   preventista_id: string
   fecha: string
+  /**
+   * Timestamp ISO en que se creó el pedido (`pedidos.created_at`). Se usa
+   * para mostrar la hora de creación en el panel admin. Disponible a partir
+   * de la migración 041; antes de eso el RPC no lo devolvía y queda null.
+   */
+  pedido_created_at: string | null
   total: number
   gps_lat: number | null
   gps_lng: number | null

--- a/src/utils/formatters.ts
+++ b/src/utils/formatters.ts
@@ -102,6 +102,24 @@ export const formatFecha = (f: string | Date | null | undefined): string => {
 }
 
 /**
+ * Formatea sólo la hora (HH:mm) en horario Argentina. Para fechas date-only
+ * devuelve '—' porque no hay hora que mostrar.
+ */
+export const formatHora = (f: string | Date | null | undefined): string => {
+  if (!f) return '—'
+  if (typeof f === 'string' && /^\d{4}-\d{2}-\d{2}$/.test(f)) return '—'
+  try {
+    return parseDateSafe(f).toLocaleTimeString('es-AR', {
+      hour: '2-digit',
+      minute: '2-digit',
+      timeZone: 'America/Argentina/Buenos_Aires',
+    })
+  } catch {
+    return '—'
+  }
+}
+
+/**
  * Formatea una fecha en formato local
  */
 export function formatDate(date: string | Date | null | undefined, options: Intl.DateTimeFormatOptions = {}): string {
@@ -442,6 +460,7 @@ export default {
   fechaLocalISO,
   fechaHaceDias,
   formatFecha,
+  formatHora,
   formatDate,
   formatDateTime,
   formatTimeAgo,


### PR DESCRIPTION
## Summary

- **PedidoCard**: chip con la hora de `pedido.created_at` junto al número y fecha. Visible a todos los roles que ven el card. Ayuda a entender en qué momento del día se cargó cada pedido sin abrir el detalle.
- **Panel Geolocalización** (Timeline, Anomalías y popover del mapa): ahora muestran y ordenan por `pedido_created_at` en vez de `gps_capturado_at`. La diferencia importa cuando el preventista no autorizó GPS — antes no se podía ver la hora; ahora sí.
- **Util compartido** `formatHora(iso)` en `utils/formatters` reemplaza cuatro copias locales en componentes de geolocalización.

## Migration 041 (ya aplicada en prod)

`CREATE OR REPLACE` sobre `obtener_geolocalizacion_preventistas` agregando `p.created_at AS pedido_created_at` al CTE `pedidos_rango` y ordenando el agregado por ese campo. No toca esquema, sólo la función. Backward-compatible: el front trae fallback a `gps_capturado_at` mientras no esté aplicada.

## Test plan

- [x] Lint
- [x] `tsc --noEmit`
- [x] Suite unitaria (302 tests del subset `utils` + `hooks`)
- [ ] Logear como admin → `/geolocalizacion` → confirmar que la columna "Hora" en Timeline y Anomalías muestra la hora del `created_at` del pedido (no la del GPS)
- [ ] Confirmar que un pedido con `gps_status='denied'` ahora muestra hora en lugar de "—"
- [ ] PedidoCard de cualquier vista lista la hora junto a `#id - fecha`

🤖 Generated with [Claude Code](https://claude.com/claude-code)