### PR TITLE
feat(visitas): ping de visita de preventistas + integracion en panel admin

### DIFF
--- a/migrations/042_visitas_cliente.sql
+++ b/migrations/042_visitas_cliente.sql
@@ -1,0 +1,366 @@
+-- =========================================================================
+-- 042_visitas_cliente.sql
+--
+-- "Marcar visita": permite a un preventista registrar que paso por un
+-- cliente sin necesariamente cerrar pedido. Cada apretada del boton crea
+-- un registro nuevo (sin dedup) para reflejar fielmente revisitas.
+--
+--   1. Tabla public.visitas_cliente
+--   2. RLS: preventista ve/inserta las suyas, admin ve todas las de su
+--      sucursal, encargado las de su sucursal en read-only.
+--   3. RPC registrar_visita_cliente: SECURITY DEFINER, valida que el
+--      cliente pertenezca a la sucursal y que el preventista pueda verlo
+--      (cliente sin preventista_ids asignados o asignado a el).
+--   4. RPC listar_visitas_hoy: devuelve las visitas de HOY del preventista
+--      logueado (timeline modal del preventista).
+--   5. Update obtener_geolocalizacion_preventistas: agrega array `visitas`
+--      al output JSON para que el panel admin las muestre.
+-- =========================================================================
+
+BEGIN;
+
+-- -------------------------------------------------------------------------
+-- 1. Tabla visitas_cliente
+-- -------------------------------------------------------------------------
+
+CREATE TABLE IF NOT EXISTS public.visitas_cliente (
+  id            bigint GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+  preventista_id uuid NOT NULL REFERENCES public.perfiles(id) ON DELETE CASCADE,
+  cliente_id    bigint NOT NULL REFERENCES public.clientes(id) ON DELETE CASCADE,
+  sucursal_id   bigint NOT NULL REFERENCES public.sucursales(id),
+  gps_lat       numeric(10,7),
+  gps_lng       numeric(10,7),
+  gps_accuracy  numeric(8,2),
+  gps_capturado_at timestamptz,
+  gps_status    text,
+  created_at    timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT visitas_cliente_gps_status_check
+    CHECK (gps_status IS NULL OR gps_status IN ('ok','denied','unavailable','timeout','error'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_visitas_cliente_preventista_created
+  ON public.visitas_cliente (preventista_id, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_visitas_cliente_sucursal_created
+  ON public.visitas_cliente (sucursal_id, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_visitas_cliente_cliente_created
+  ON public.visitas_cliente (cliente_id, created_at DESC);
+
+COMMENT ON TABLE public.visitas_cliente IS
+  'Pings de visita marcados por el preventista (independientes de pedidos). Cada apretada de "Marcar visita" en la PWA crea un registro.';
+
+-- -------------------------------------------------------------------------
+-- 2. RLS
+-- -------------------------------------------------------------------------
+
+ALTER TABLE public.visitas_cliente ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS visitas_cliente_select ON public.visitas_cliente;
+CREATE POLICY visitas_cliente_select ON public.visitas_cliente
+  FOR SELECT
+  TO authenticated
+  USING (
+    sucursal_id = public.current_sucursal_id()
+    AND (
+      preventista_id = auth.uid()
+      OR EXISTS (
+        SELECT 1 FROM public.perfiles p
+        WHERE p.id = auth.uid() AND p.rol IN ('admin', 'encargado')
+      )
+    )
+  );
+
+-- INSERT: solo via RPC (SECURITY DEFINER); no abrimos INSERT directo via
+-- PostgREST para mantener invariantes (sucursal correcta, autorizacion,
+-- snapshot de coordenadas).
+DROP POLICY IF EXISTS visitas_cliente_insert ON public.visitas_cliente;
+CREATE POLICY visitas_cliente_insert ON public.visitas_cliente
+  FOR INSERT
+  TO authenticated
+  WITH CHECK (false);
+
+-- -------------------------------------------------------------------------
+-- 3. RPC registrar_visita_cliente
+-- -------------------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION public.registrar_visita_cliente(
+  p_cliente_id bigint,
+  p_status text,
+  p_lat numeric DEFAULT NULL,
+  p_lng numeric DEFAULT NULL,
+  p_accuracy numeric DEFAULT NULL,
+  p_capturado_at timestamptz DEFAULT NULL
+) RETURNS jsonb
+LANGUAGE plpgsql SECURITY DEFINER SET search_path TO 'public'
+AS $$
+DECLARE
+  v_user_id uuid := auth.uid();
+  v_user_role text;
+  v_sucursal bigint := current_sucursal_id();
+  v_cliente RECORD;
+  v_autorizado boolean;
+  v_visita_id bigint;
+BEGIN
+  IF v_user_id IS NULL THEN
+    RETURN jsonb_build_object('success', false, 'error', 'No autenticado');
+  END IF;
+  IF v_sucursal IS NULL THEN
+    RETURN jsonb_build_object('success', false, 'error', 'No hay sucursal activa');
+  END IF;
+
+  IF p_status NOT IN ('ok','denied','unavailable','timeout','error') THEN
+    RETURN jsonb_build_object('success', false, 'error', 'gps_status invalido');
+  END IF;
+  IF p_status = 'ok' AND (p_lat IS NULL OR p_lng IS NULL) THEN
+    RETURN jsonb_build_object('success', false, 'error', 'lat y lng requeridos cuando status=ok');
+  END IF;
+
+  SELECT rol INTO v_user_role FROM perfiles WHERE id = v_user_id;
+  IF v_user_role NOT IN ('preventista', 'admin') THEN
+    RETURN jsonb_build_object('success', false, 'error', 'Rol no autorizado para marcar visitas');
+  END IF;
+
+  -- Cliente debe existir y pertenecer a la sucursal activa.
+  SELECT id, sucursal_id INTO v_cliente FROM clientes WHERE id = p_cliente_id;
+  IF NOT FOUND THEN
+    RETURN jsonb_build_object('success', false, 'error', 'Cliente no existe');
+  END IF;
+  IF v_cliente.sucursal_id IS DISTINCT FROM v_sucursal THEN
+    RETURN jsonb_build_object('success', false, 'error', 'Cliente fuera de la sucursal activa');
+  END IF;
+
+  -- Si es preventista, validar que el cliente este sin asignar a nadie o
+  -- asignado a el (misma logica que el resto de la app). Admin: libre.
+  IF v_user_role = 'preventista' THEN
+    SELECT (
+      NOT EXISTS (SELECT 1 FROM cliente_preventistas cp WHERE cp.cliente_id = p_cliente_id)
+      OR EXISTS (SELECT 1 FROM cliente_preventistas cp WHERE cp.cliente_id = p_cliente_id AND cp.preventista_id = v_user_id)
+    ) INTO v_autorizado;
+    IF NOT v_autorizado THEN
+      RETURN jsonb_build_object('success', false, 'error', 'Cliente asignado a otro preventista');
+    END IF;
+  END IF;
+
+  INSERT INTO visitas_cliente (
+    preventista_id, cliente_id, sucursal_id,
+    gps_lat, gps_lng, gps_accuracy, gps_capturado_at, gps_status
+  ) VALUES (
+    v_user_id, p_cliente_id, v_sucursal,
+    CASE WHEN p_status = 'ok' THEN p_lat ELSE NULL END,
+    CASE WHEN p_status = 'ok' THEN p_lng ELSE NULL END,
+    CASE WHEN p_status = 'ok' THEN p_accuracy ELSE NULL END,
+    COALESCE(p_capturado_at, now()),
+    p_status
+  ) RETURNING id INTO v_visita_id;
+
+  RETURN jsonb_build_object('success', true, 'visita_id', v_visita_id);
+END;
+$$;
+
+ALTER FUNCTION public.registrar_visita_cliente(bigint, text, numeric, numeric, numeric, timestamptz) OWNER TO postgres;
+
+COMMENT ON FUNCTION public.registrar_visita_cliente(bigint, text, numeric, numeric, numeric, timestamptz) IS
+  'Registra una visita de cliente (ping del preventista). Cada llamada crea un registro nuevo. Valida sucursal y visibilidad del cliente para el rol preventista.';
+
+GRANT EXECUTE ON FUNCTION public.registrar_visita_cliente(bigint, text, numeric, numeric, numeric, timestamptz)
+  TO authenticated, service_role;
+
+-- -------------------------------------------------------------------------
+-- 4. RPC listar_visitas_hoy
+-- -------------------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION public.listar_visitas_hoy()
+RETURNS jsonb
+LANGUAGE plpgsql SECURITY DEFINER SET search_path TO 'public'
+AS $$
+DECLARE
+  v_user_id uuid := auth.uid();
+  v_sucursal bigint := current_sucursal_id();
+  v_hoy date := (now() AT TIME ZONE 'America/Argentina/Buenos_Aires')::date;
+  v_result jsonb;
+BEGIN
+  IF v_user_id IS NULL THEN
+    RETURN '[]'::jsonb;
+  END IF;
+  IF v_sucursal IS NULL THEN
+    RETURN '[]'::jsonb;
+  END IF;
+
+  SELECT COALESCE(jsonb_agg(to_jsonb(t) ORDER BY t.created_at), '[]'::jsonb)
+  INTO v_result
+  FROM (
+    SELECT
+      v.id              AS visita_id,
+      v.cliente_id,
+      c.nombre_fantasia AS cliente_nombre,
+      c.direccion       AS cliente_direccion,
+      c.latitud         AS cliente_lat,
+      c.longitud        AS cliente_lng,
+      v.gps_lat,
+      v.gps_lng,
+      v.gps_status,
+      v.gps_capturado_at,
+      v.created_at,
+      public.haversine_m(v.gps_lat, v.gps_lng, c.latitud, c.longitud) AS distancia_m
+    FROM visitas_cliente v
+    LEFT JOIN clientes c ON c.id = v.cliente_id
+    WHERE v.preventista_id = v_user_id
+      AND v.sucursal_id = v_sucursal
+      AND (v.created_at AT TIME ZONE 'America/Argentina/Buenos_Aires')::date = v_hoy
+  ) t;
+
+  RETURN v_result;
+END;
+$$;
+
+ALTER FUNCTION public.listar_visitas_hoy() OWNER TO postgres;
+
+COMMENT ON FUNCTION public.listar_visitas_hoy() IS
+  'Devuelve las visitas marcadas HOY por el preventista logueado, con datos del cliente y distancia. Usado por el modal "Visitas del dia".';
+
+GRANT EXECUTE ON FUNCTION public.listar_visitas_hoy() TO authenticated, service_role;
+
+-- -------------------------------------------------------------------------
+-- 5. Update obtener_geolocalizacion_preventistas (suma array `visitas`)
+-- -------------------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION public.obtener_geolocalizacion_preventistas(
+  p_fecha_desde date DEFAULT NULL,
+  p_fecha_hasta date DEFAULT NULL
+) RETURNS jsonb
+LANGUAGE plpgsql SECURITY DEFINER SET search_path TO 'public'
+AS $$
+DECLARE
+  v_user_id uuid := auth.uid();
+  v_user_role text;
+  v_sucursal bigint := current_sucursal_id();
+  v_fecha_desde date := COALESCE(p_fecha_desde, (now() AT TIME ZONE 'America/Argentina/Buenos_Aires')::date);
+  v_fecha_hasta date := COALESCE(p_fecha_hasta, v_fecha_desde);
+  v_result jsonb;
+BEGIN
+  IF v_user_id IS NULL THEN
+    RAISE EXCEPTION 'No autenticado' USING ERRCODE = '42501';
+  END IF;
+  IF v_sucursal IS NULL THEN
+    RAISE EXCEPTION 'No hay sucursal activa' USING ERRCODE = '42501';
+  END IF;
+
+  SELECT rol INTO v_user_role FROM perfiles WHERE id = v_user_id;
+  IF v_user_role <> 'admin' THEN
+    RAISE EXCEPTION 'Solo admins pueden ver geolocalizacion de preventistas' USING ERRCODE = '42501';
+  END IF;
+
+  WITH pedidos_rango AS (
+    SELECT
+      p.id              AS pedido_id,
+      p.usuario_id      AS preventista_id,
+      p.fecha,
+      p.created_at      AS pedido_created_at,
+      p.total,
+      p.gps_lat,
+      p.gps_lng,
+      p.gps_accuracy,
+      p.gps_capturado_at,
+      p.gps_status,
+      p.cliente_id,
+      c.nombre_fantasia AS cliente_nombre,
+      c.latitud         AS cliente_lat,
+      c.longitud        AS cliente_lng,
+      public.haversine_m(p.gps_lat, p.gps_lng, c.latitud, c.longitud) AS distancia_m
+    FROM pedidos p
+    LEFT JOIN clientes c ON c.id = p.cliente_id
+    WHERE p.sucursal_id = v_sucursal
+      AND p.fecha BETWEEN v_fecha_desde AND v_fecha_hasta
+      AND p.usuario_id IS NOT NULL
+  ),
+  visitas_rango AS (
+    SELECT
+      v.id              AS visita_id,
+      v.preventista_id,
+      v.created_at      AS visita_created_at,
+      v.gps_lat,
+      v.gps_lng,
+      v.gps_accuracy,
+      v.gps_capturado_at,
+      v.gps_status,
+      v.cliente_id,
+      c.nombre_fantasia AS cliente_nombre,
+      c.latitud         AS cliente_lat,
+      c.longitud        AS cliente_lng,
+      public.haversine_m(v.gps_lat, v.gps_lng, c.latitud, c.longitud) AS distancia_m
+    FROM visitas_cliente v
+    LEFT JOIN clientes c ON c.id = v.cliente_id
+    WHERE v.sucursal_id = v_sucursal
+      AND (v.created_at AT TIME ZONE 'America/Argentina/Buenos_Aires')::date BETWEEN v_fecha_desde AND v_fecha_hasta
+  ),
+  preventistas_resumen AS (
+    SELECT
+      pr.preventista_id,
+      per.nombre AS preventista_nombre,
+      COUNT(*)::int AS total_pedidos,
+      COUNT(*) FILTER (WHERE pr.gps_status = 'ok')::int AS pedidos_con_gps,
+      COUNT(*) FILTER (WHERE pr.gps_status IS NULL OR pr.gps_status <> 'ok')::int AS pedidos_sin_gps,
+      COUNT(*) FILTER (
+        WHERE pr.gps_status = 'ok' AND pr.distancia_m IS NOT NULL AND pr.distancia_m >= 2000
+      )::int AS pedidos_lejos,
+      (
+        SELECT COUNT(*) FROM visitas_rango v WHERE v.preventista_id = pr.preventista_id
+      )::int AS total_visitas,
+      (
+        SELECT jsonb_build_object(
+          'lat', e.lat,
+          'lng', e.lng,
+          'capturado_at', e.capturado_at,
+          'tipo', e.tipo,
+          'id', e.id
+        )
+        FROM (
+          SELECT pr2.gps_lat AS lat, pr2.gps_lng AS lng, pr2.gps_capturado_at AS capturado_at,
+                 'pedido'::text AS tipo, pr2.pedido_id AS id
+          FROM pedidos_rango pr2
+          WHERE pr2.preventista_id = pr.preventista_id AND pr2.gps_status = 'ok'
+          UNION ALL
+          SELECT v.gps_lat AS lat, v.gps_lng AS lng, v.gps_capturado_at AS capturado_at,
+                 'visita'::text AS tipo, v.visita_id AS id
+          FROM visitas_rango v
+          WHERE v.preventista_id = pr.preventista_id AND v.gps_status = 'ok'
+        ) e
+        ORDER BY e.capturado_at DESC NULLS LAST
+        LIMIT 1
+      ) AS ultima_ubicacion
+    FROM pedidos_rango pr
+    LEFT JOIN perfiles per ON per.id = pr.preventista_id
+    WHERE per.rol = 'preventista'
+    GROUP BY pr.preventista_id, per.nombre
+  )
+  SELECT jsonb_build_object(
+    'fecha_desde', v_fecha_desde,
+    'fecha_hasta', v_fecha_hasta,
+    'preventistas', COALESCE(
+      (SELECT jsonb_agg(to_jsonb(preventistas_resumen.*) ORDER BY preventista_nombre)
+       FROM preventistas_resumen),
+      '[]'::jsonb
+    ),
+    'pedidos', COALESCE(
+      (SELECT jsonb_agg(to_jsonb(pr.*) ORDER BY pr.pedido_created_at NULLS LAST)
+       FROM pedidos_rango pr
+       JOIN perfiles per ON per.id = pr.preventista_id AND per.rol = 'preventista'),
+      '[]'::jsonb
+    ),
+    'visitas', COALESCE(
+      (SELECT jsonb_agg(to_jsonb(v.*) ORDER BY v.visita_created_at NULLS LAST)
+       FROM visitas_rango v
+       JOIN perfiles per ON per.id = v.preventista_id AND per.rol = 'preventista'),
+      '[]'::jsonb
+    )
+  ) INTO v_result;
+
+  RETURN v_result;
+END;
+$$;
+
+COMMENT ON FUNCTION public.obtener_geolocalizacion_preventistas(date, date) IS
+  'Panel admin de geolocalizacion: resumen por preventista + detalle de pedidos y visitas con GPS, distancia al cliente y timestamp. Scope a current_sucursal_id().';
+
+COMMIT;

--- a/src/components/containers/PedidosContainer.tsx
+++ b/src/components/containers/PedidosContainer.tsx
@@ -55,6 +55,8 @@ const ModalEntregasMasivas = lazy(() => import('../modals/ModalEntregasMasivas')
 const ModalCancelarPedido = lazy(() => import('../modals/ModalCancelarPedido'))
 const ModalPagosMasivos = lazy(() => import('../modals/ModalPagosMasivos'))
 const ModalAsignarTransportistaMasivo = lazy(() => import('../modals/ModalAsignarTransportistaMasivo'))
+const ModalMarcarVisita = lazy(() => import('../modals/ModalMarcarVisita'))
+const ModalVisitasHoy = lazy(() => import('../modals/ModalVisitasHoy'))
 
 const ITEMS_PER_PAGE = 15
 
@@ -161,6 +163,8 @@ export default function PedidosContainer(): React.ReactElement {
   const [modalAsignarMasivoOpen, setModalAsignarMasivoOpen] = useState(false)
   const [modalNotasOpen, setModalNotasOpen] = useState(false)
   const [modalPagoPedidoOpen, setModalPagoPedidoOpen] = useState(false)
+  const [modalMarcarVisitaOpen, setModalMarcarVisitaOpen] = useState(false)
+  const [modalVisitasHoyOpen, setModalVisitasHoyOpen] = useState(false)
   const [pedidoPago, setPedidoPago] = useState<PedidoDB | null>(null)
   const [pagosPreviosPedido, setPagosPreviosPedido] = useState<PagoDBWithUsuario[]>([])
   const [loadingPagosPrevios, setLoadingPagosPrevios] = useState(false)
@@ -978,6 +982,8 @@ export default function PedidosContainer(): React.ReactElement {
           onEntregasMasivas={() => setModalEntregasMasivasOpen(true)}
           onPagosMasivos={() => setModalPagosMasivosOpen(true)}
           onAsignarTransportistaMasivo={() => setModalAsignarMasivoOpen(true)}
+          onMarcarVisita={() => setModalMarcarVisitaOpen(true)}
+          onVerVisitasHoy={() => setModalVisitasHoyOpen(true)}
           onRegistrarSalvedad={handleRegistrarSalvedadSingle}
           onRegistrarPago={handleRegistrarPagoTransportista}
           onAbrirPagoPedido={handleAbrirRegistrarPago}
@@ -1251,6 +1257,28 @@ export default function PedidosContainer(): React.ReactElement {
             guardando={guardando}
             isEncargado={isEncargado}
             isAdmin={isAdmin}
+          />
+        </Suspense>
+      )}
+
+      {/* Modal Marcar Visita (preventista) */}
+      {modalMarcarVisitaOpen && (
+        <Suspense fallback={null}>
+          <ModalMarcarVisita
+            clientes={clientes}
+            userId={user?.id ?? null}
+            isAdmin={isAdmin}
+            onClose={() => setModalMarcarVisitaOpen(false)}
+          />
+        </Suspense>
+      )}
+
+      {/* Modal Visitas del día (preventista) */}
+      {modalVisitasHoyOpen && (
+        <Suspense fallback={null}>
+          <ModalVisitasHoy
+            userId={user?.id ?? null}
+            onClose={() => setModalVisitasHoyOpen(false)}
           />
         </Suspense>
       )}

--- a/src/components/geolocalizacion/MapaPreventistas.tsx
+++ b/src/components/geolocalizacion/MapaPreventistas.tsx
@@ -4,11 +4,12 @@ import { Loader2, MapPin } from 'lucide-react'
 import { useGoogleMaps } from '../../hooks/useGoogleMaps'
 import { colorPreventista, formatDistancia, clasificarDistancia, SEMAFORO_COLORS } from '../../utils/geo'
 import { formatPrecio, formatHora } from '../../utils/formatters'
-import type { PreventistaResumen, PedidoConGps } from '../../hooks/queries'
+import type { PreventistaResumen, PedidoConGps, VisitaConGps } from '../../hooks/queries'
 
 interface MapaPreventistasProps {
   preventistas: PreventistaResumen[]
   pedidos: PedidoConGps[]
+  visitas: VisitaConGps[]
   preventistaSelectedId: string | null
   pedidoSelectedId: number | null
   onSelectPreventista: (id: string | null) => void
@@ -32,11 +33,11 @@ function escapeHtml(s: string): string {
   })
 }
 
-function pinSymbol(color: string, scale = 8): google.maps.Symbol {
+function pinSymbol(color: string, scale = 8, opacity = 1): google.maps.Symbol {
   return {
     path: google.maps.SymbolPath.CIRCLE,
     fillColor: color,
-    fillOpacity: 1,
+    fillOpacity: opacity,
     strokeColor: '#ffffff',
     strokeWeight: 2,
     scale,
@@ -46,6 +47,7 @@ function pinSymbol(color: string, scale = 8): google.maps.Symbol {
 export default function MapaPreventistas({
   preventistas,
   pedidos,
+  visitas,
   preventistaSelectedId,
   pedidoSelectedId,
   onSelectPreventista,
@@ -97,59 +99,101 @@ export default function MapaPreventistas({
     let pointCount = 0
 
     if (preventistaSelectedId) {
-      // Vista de recorrido: pins por pedido del preventista seleccionado +
-      // markers gris claro para los clientes (contexto) + polilínea conectando
-      // por hora.
-      const propios = pedidos
+      // Vista de recorrido: pedidos del preventista (pins numerados + grandes)
+      // + visitas del preventista (pins pequeños sin número) + clientes
+      // referenciados en gris claro + polilínea cronológica que conecta
+      // pedidos y visitas en una sola secuencia.
+      const pedidosPropios = pedidos
         .filter(p => p.preventista_id === preventistaSelectedId)
-        .sort((a, b) => {
-          const ta = a.gps_capturado_at ? Date.parse(a.gps_capturado_at) : 0
-          const tb = b.gps_capturado_at ? Date.parse(b.gps_capturado_at) : 0
-          return ta - tb
-        })
+      const visitasPropias = visitas
+        .filter(v => v.preventista_id === preventistaSelectedId)
 
       const color = colorPreventista(preventistaSelectedId)
-      const path: google.maps.LatLngLiteral[] = []
 
-      // Markers de clientes (contexto): pequeños grises
-      for (const p of propios) {
-        if (p.cliente_lat != null && p.cliente_lng != null) {
-          const marker = new g.Marker({
-            position: { lat: Number(p.cliente_lat), lng: Number(p.cliente_lng) },
-            map,
-            title: p.cliente_nombre || 'Cliente',
-            icon: pinSymbol('#cbd5e1', 5),
-            zIndex: 1,
-          })
-          markersRef.current.push(marker)
-          bounds.extend({ lat: Number(p.cliente_lat), lng: Number(p.cliente_lng) })
-          pointCount++
-        }
+      // Markers de clientes (contexto): pequeños grises, sin duplicar si el
+      // mismo cliente aparece en pedido y visita.
+      const clientesDibujados = new Set<number>()
+      const dibujarCliente = (id: number | null, lat: number | null, lng: number | null, nombre: string | null) => {
+        if (id == null || lat == null || lng == null) return
+        if (clientesDibujados.has(id)) return
+        clientesDibujados.add(id)
+        const marker = new g.Marker({
+          position: { lat: Number(lat), lng: Number(lng) },
+          map,
+          title: nombre || 'Cliente',
+          icon: pinSymbol('#cbd5e1', 5),
+          zIndex: 1,
+        })
+        markersRef.current.push(marker)
+        bounds.extend({ lat: Number(lat), lng: Number(lng) })
+        pointCount++
       }
+      for (const p of pedidosPropios) dibujarCliente(p.cliente_id, p.cliente_lat, p.cliente_lng, p.cliente_nombre)
+      for (const v of visitasPropias) dibujarCliente(v.cliente_id, v.cliente_lat, v.cliente_lng, v.cliente_nombre)
 
-      // Markers de check-ins (numerados)
-      propios
-        .filter(p => p.gps_status === 'ok' && p.gps_lat != null && p.gps_lng != null)
-        .forEach((p, idx) => {
+      // Secuencia cronológica unificada para la polilínea y la numeración.
+      type Evento =
+        | { tipo: 'pedido'; ts: number; pedido: PedidoConGps }
+        | { tipo: 'visita'; ts: number; visita: VisitaConGps }
+      const eventos: Evento[] = []
+      for (const p of pedidosPropios) {
+        if (p.gps_status !== 'ok' || p.gps_lat == null || p.gps_lng == null) continue
+        const ts = Date.parse(p.pedido_created_at ?? p.gps_capturado_at ?? '') || 0
+        eventos.push({ tipo: 'pedido', ts, pedido: p })
+      }
+      for (const v of visitasPropias) {
+        if (v.gps_status !== 'ok' || v.gps_lat == null || v.gps_lng == null) continue
+        const ts = Date.parse(v.visita_created_at ?? v.gps_capturado_at ?? '') || 0
+        eventos.push({ tipo: 'visita', ts, visita: v })
+      }
+      eventos.sort((a, b) => a.ts - b.ts)
+
+      const path: google.maps.LatLngLiteral[] = []
+      let pedidoIdx = 0
+      let selectedAnchor: { marker: google.maps.Marker; pedido: PedidoConGps } | null = null
+
+      for (const ev of eventos) {
+        if (ev.tipo === 'pedido') {
+          const p = ev.pedido
           const pos = { lat: Number(p.gps_lat!), lng: Number(p.gps_lng!) }
           const isSelected = pedidoSelectedId === p.pedido_id
+          pedidoIdx++
           const marker = new g.Marker({
             position: pos,
             map,
             title: p.cliente_nombre || `Pedido #${p.pedido_id}`,
-            label: { text: String(idx + 1), color: '#ffffff', fontWeight: '700', fontSize: '11px' },
+            label: { text: String(pedidoIdx), color: '#ffffff', fontWeight: '700', fontSize: '11px' },
             icon: pinSymbol(color, isSelected ? 14 : 11),
-            zIndex: isSelected ? 1000 : 100 + idx,
+            zIndex: isSelected ? 1000 : 100 + pedidoIdx,
           })
           marker.addListener('click', () => {
             onSelectPedido(p.pedido_id)
             openPedidoInfoWindow(p, marker)
           })
           markersRef.current.push(marker)
+          if (isSelected) selectedAnchor = { marker, pedido: p }
           path.push(pos)
           bounds.extend(pos)
           pointCount++
-        })
+        } else {
+          const v = ev.visita
+          const pos = { lat: Number(v.gps_lat!), lng: Number(v.gps_lng!) }
+          const marker = new g.Marker({
+            position: pos,
+            map,
+            title: `Visita · ${v.cliente_nombre || 'Cliente'} · ${formatHora(v.visita_created_at)}`,
+            icon: pinSymbol(color, 6, 0.75),
+            zIndex: 50,
+          })
+          marker.addListener('click', () => {
+            openVisitaInfoWindow(v, marker)
+          })
+          markersRef.current.push(marker)
+          path.push(pos)
+          bounds.extend(pos)
+          pointCount++
+        }
+      }
 
       if (path.length >= 2) {
         polylineRef.current = new g.Polyline({
@@ -162,17 +206,13 @@ export default function MapaPreventistas({
         })
       }
 
-      // Si hay un pedido seleccionado, abrir su info window al final.
-      if (pedidoSelectedId != null) {
-        const idx = propios.findIndex(p => p.pedido_id === pedidoSelectedId && p.gps_status === 'ok')
-        if (idx >= 0) {
-          const clienteMarkersOffset = propios.filter(p => p.cliente_lat != null && p.cliente_lng != null).length
-          const target = markersRef.current[clienteMarkersOffset + idx]
-          if (target) openPedidoInfoWindow(propios[idx], target)
-        }
+      if (selectedAnchor) {
+        openPedidoInfoWindow(selectedAnchor.pedido, selectedAnchor.marker)
       }
     } else {
-      // Vista global: 1 pin por preventista (su última ubicación).
+      // Vista global: 1 pin grande por preventista (última ubicación) + puntos
+      // pequeños semi-transparentes para todas las visitas del rango. Esto
+      // permite ver "dónde anduvieron" sin sobrecargar.
       for (const p of preventistas) {
         const ult = p.ultima_ubicacion
         if (!ult || ult.lat == null || ult.lng == null) continue
@@ -182,13 +222,31 @@ export default function MapaPreventistas({
         const marker = new g.Marker({
           position: pos,
           map,
-          title: `${p.preventista_nombre} · ${formatHora(ult.capturado_at)}`,
+          title: `${p.preventista_nombre} · ${formatHora(ult.capturado_at)} (${ult.tipo === 'visita' ? 'visita' : 'pedido'})`,
           label: { text: inicial, color: '#ffffff', fontWeight: '700', fontSize: '11px' },
           icon: pinSymbol(color, 13),
         })
         marker.addListener('click', () => {
           onSelectPreventista(p.preventista_id)
         })
+        markersRef.current.push(marker)
+        bounds.extend(pos)
+        pointCount++
+      }
+
+      // Visitas globales como puntitos discretos (no clickeables, contexto).
+      for (const v of visitas) {
+        if (v.gps_status !== 'ok' || v.gps_lat == null || v.gps_lng == null) continue
+        const pos = { lat: Number(v.gps_lat), lng: Number(v.gps_lng) }
+        const color = colorPreventista(v.preventista_id)
+        const marker = new g.Marker({
+          position: pos,
+          map,
+          title: `Visita · ${v.cliente_nombre || 'Cliente'}`,
+          icon: pinSymbol(color, 4, 0.45),
+          zIndex: 10,
+        })
+        marker.addListener('click', () => onSelectPreventista(v.preventista_id))
         markersRef.current.push(marker)
         bounds.extend(pos)
         pointCount++
@@ -229,7 +287,29 @@ export default function MapaPreventistas({
       infoWindowRef.current.setContent(html)
       infoWindowRef.current.open(mapRef.current, anchor)
     }
-  }, [mapReady, preventistas, pedidos, preventistaSelectedId, pedidoSelectedId, onSelectPedido, onSelectPreventista])
+
+    function openVisitaInfoWindow(v: VisitaConGps, anchor: google.maps.Marker) {
+      if (!infoWindowRef.current || !mapRef.current) return
+      const clasif = clasificarDistancia(v.distancia_m)
+      const cfg = SEMAFORO_COLORS[clasif]
+      const html = `
+        <div style="font-family: ui-sans-serif, system-ui; padding: 4px 2px; max-width: 260px;">
+          <div style="font-weight: 600; color: #111827; font-size: 13px;">${escapeHtml(v.cliente_nombre || 'Cliente sin nombre')}</div>
+          <div style="color: #6b7280; font-size: 11px; margin-top: 2px;">
+            Visita · ${formatHora(v.visita_created_at)}
+          </div>
+          <div style="margin-top: 6px; font-size: 12px;">
+            <span style="padding: 1px 6px; border-radius: 9999px; font-size: 11px;"
+                  class="${cfg.bg}">
+              ${cfg.label} · ${escapeHtml(formatDistancia(v.distancia_m))}
+            </span>
+          </div>
+        </div>
+      `
+      infoWindowRef.current.setContent(html)
+      infoWindowRef.current.open(mapRef.current, anchor)
+    }
+  }, [mapReady, preventistas, pedidos, visitas, preventistaSelectedId, pedidoSelectedId, onSelectPedido, onSelectPreventista])
 
   // Cleanup
   useEffect(() => {

--- a/src/components/geolocalizacion/TablaAnomalias.tsx
+++ b/src/components/geolocalizacion/TablaAnomalias.tsx
@@ -1,17 +1,24 @@
 import React, { useMemo } from 'react'
-import { AlertTriangle, ZapOff, Search } from 'lucide-react'
+import { AlertTriangle, ZapOff, Search, ShoppingCart, MapPin } from 'lucide-react'
 import { formatPrecio, formatHora } from '../../utils/formatters'
 import { clasificarDistancia, formatDistancia, SEMAFORO_COLORS } from '../../utils/geo'
-import type { PedidoConGps, PreventistaResumen } from '../../hooks/queries'
+import type { PedidoConGps, PreventistaResumen, VisitaConGps } from '../../hooks/queries'
 
 interface TablaAnomaliasProps {
   pedidos: PedidoConGps[]
+  visitas: VisitaConGps[]
   preventistas: PreventistaResumen[]
+  /** Click "Ver" en una fila pedido: lleva al mapa centrando ese pedido. */
   onSelectPedido: (pedidoId: number, preventistaId: string) => void
+  /** Click "Ver" en una fila visita: selecciona el preventista (drill-down). */
+  onSelectVisitaPreventista: (preventistaId: string) => void
 }
 
 interface AnomaliaRow {
-  pedido_id: number
+  key: string
+  tipo: 'pedido' | 'visita'
+  /** ID del pedido o visita (para el handler del botón Ver). */
+  refId: number
   preventista_id: string
   preventista_nombre: string
   cliente_nombre: string
@@ -19,10 +26,26 @@ interface AnomaliaRow {
   motivo: 'sin_gps' | 'lejos'
   motivo_label: string
   distancia_m: number | null
-  total: number
+  total: number | null
 }
 
-export default function TablaAnomalias({ pedidos, preventistas, onSelectPedido }: TablaAnomaliasProps): React.ReactElement {
+function statusToLabel(s: string | null | undefined): string {
+  switch (s) {
+    case 'denied': return 'GPS denegado'
+    case 'timeout': return 'GPS sin respuesta'
+    case 'unavailable': return 'GPS no disponible'
+    case 'error': return 'GPS con error'
+    default: return 'Sin check-in'
+  }
+}
+
+export default function TablaAnomalias({
+  pedidos,
+  visitas,
+  preventistas,
+  onSelectPedido,
+  onSelectVisitaPreventista,
+}: TablaAnomaliasProps): React.ReactElement {
   const nombresMap = useMemo(() => {
     const map: Record<string, string> = {}
     for (const p of preventistas) map[p.preventista_id] = p.preventista_nombre || 'Sin nombre'
@@ -36,29 +59,43 @@ export default function TablaAnomalias({ pedidos, preventistas, onSelectPedido }
       const lejos = !sinGps && p.distancia_m != null && p.distancia_m >= 2000
       if (!sinGps && !lejos) continue
       result.push({
-        pedido_id: p.pedido_id,
+        key: `p-${p.pedido_id}`,
+        tipo: 'pedido',
+        refId: p.pedido_id,
         preventista_id: p.preventista_id,
         preventista_nombre: nombresMap[p.preventista_id] ?? '—',
         cliente_nombre: p.cliente_nombre || 'Sin cliente',
         hora: formatHora(p.pedido_created_at ?? p.gps_capturado_at),
         motivo: sinGps ? 'sin_gps' : 'lejos',
-        motivo_label: sinGps
-          ? (p.gps_status === 'denied' ? 'GPS denegado'
-            : p.gps_status === 'timeout' ? 'GPS sin respuesta'
-            : p.gps_status === 'unavailable' ? 'GPS no disponible'
-            : p.gps_status === 'error' ? 'GPS con error'
-            : 'Sin check-in')
-          : 'Lejos del cliente',
+        motivo_label: sinGps ? statusToLabel(p.gps_status) : 'Pedido lejos del cliente',
         distancia_m: p.distancia_m,
         total: Number(p.total) || 0,
       })
     }
-    // Ordenar: lejos primero, luego sin GPS
+    for (const v of visitas) {
+      const sinGps = v.gps_status !== 'ok'
+      const lejos = !sinGps && v.distancia_m != null && v.distancia_m >= 2000
+      if (!sinGps && !lejos) continue
+      result.push({
+        key: `v-${v.visita_id}`,
+        tipo: 'visita',
+        refId: v.visita_id,
+        preventista_id: v.preventista_id,
+        preventista_nombre: nombresMap[v.preventista_id] ?? '—',
+        cliente_nombre: v.cliente_nombre || 'Sin cliente',
+        hora: formatHora(v.visita_created_at),
+        motivo: sinGps ? 'sin_gps' : 'lejos',
+        motivo_label: sinGps ? statusToLabel(v.gps_status) : 'Visita lejos del cliente',
+        distancia_m: v.distancia_m,
+        total: null,
+      })
+    }
+    // Ordenar: lejos primero, luego sin GPS; dentro de cada grupo por distancia desc.
     return result.sort((a, b) => {
       if (a.motivo !== b.motivo) return a.motivo === 'lejos' ? -1 : 1
       return (b.distancia_m ?? 0) - (a.distancia_m ?? 0)
     })
-  }, [pedidos, nombresMap])
+  }, [pedidos, visitas, nombresMap])
 
   if (rows.length === 0) {
     return (
@@ -80,6 +117,7 @@ export default function TablaAnomalias({ pedidos, preventistas, onSelectPedido }
         <table className="min-w-full text-sm">
           <thead className="bg-gray-50 dark:bg-gray-900/40 text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400">
             <tr>
+              <th className="px-4 py-2 text-left font-medium">Tipo</th>
               <th className="px-4 py-2 text-left font-medium">Preventista</th>
               <th className="px-4 py-2 text-left font-medium">Hora</th>
               <th className="px-4 py-2 text-left font-medium">Cliente</th>
@@ -94,7 +132,13 @@ export default function TablaAnomalias({ pedidos, preventistas, onSelectPedido }
               const clasif = r.motivo === 'sin_gps' ? 'sin_dato' : clasificarDistancia(r.distancia_m)
               const cfg = SEMAFORO_COLORS[clasif]
               return (
-                <tr key={r.pedido_id} className="hover:bg-gray-50 dark:hover:bg-gray-700/40">
+                <tr key={r.key} className="hover:bg-gray-50 dark:hover:bg-gray-700/40">
+                  <td className="px-4 py-2 text-gray-600 dark:text-gray-300">
+                    <span className="inline-flex items-center gap-1 text-xs">
+                      {r.tipo === 'pedido' ? <ShoppingCart className="w-3.5 h-3.5" /> : <MapPin className="w-3.5 h-3.5" />}
+                      {r.tipo === 'pedido' ? 'Pedido' : 'Visita'}
+                    </span>
+                  </td>
                   <td className="px-4 py-2 text-gray-900 dark:text-white">{r.preventista_nombre}</td>
                   <td className="px-4 py-2 text-gray-700 dark:text-gray-300 tabular-nums">{r.hora}</td>
                   <td className="px-4 py-2 text-gray-900 dark:text-white">{r.cliente_nombre}</td>
@@ -108,12 +152,15 @@ export default function TablaAnomalias({ pedidos, preventistas, onSelectPedido }
                     {r.motivo === 'sin_gps' ? '—' : formatDistancia(r.distancia_m)}
                   </td>
                   <td className="px-4 py-2 text-right tabular-nums text-gray-700 dark:text-gray-300">
-                    {formatPrecio(r.total)}
+                    {r.total == null ? '—' : formatPrecio(r.total)}
                   </td>
                   <td className="px-4 py-2 text-right">
                     <button
                       type="button"
-                      onClick={() => onSelectPedido(r.pedido_id, r.preventista_id)}
+                      onClick={() => {
+                        if (r.tipo === 'pedido') onSelectPedido(r.refId, r.preventista_id)
+                        else onSelectVisitaPreventista(r.preventista_id)
+                      }}
                       className="inline-flex items-center gap-1 text-xs text-blue-600 dark:text-blue-400 hover:underline"
                       title="Ver en el mapa"
                     >

--- a/src/components/geolocalizacion/TimelineRecorrido.tsx
+++ b/src/components/geolocalizacion/TimelineRecorrido.tsx
@@ -1,24 +1,46 @@
-import React from 'react'
-import { Clock, MapPin, AlertCircle } from 'lucide-react'
+import React, { useMemo } from 'react'
+import { Clock, MapPin, AlertCircle, ShoppingCart } from 'lucide-react'
 import { formatPrecio, formatHora } from '../../utils/formatters'
 import { clasificarDistancia, formatDistancia, SEMAFORO_COLORS, colorPreventista } from '../../utils/geo'
-import type { PedidoConGps } from '../../hooks/queries'
+import type { PedidoConGps, VisitaConGps } from '../../hooks/queries'
 
 interface TimelineRecorridoProps {
   pedidos: PedidoConGps[]
+  visitas: VisitaConGps[]
   preventistaId: string | null
   preventistaNombre: string | null
   selectedPedidoId: number | null
   onSelectPedido: (pedidoId: number | null) => void
 }
 
+type EventoTimeline =
+  | { tipo: 'pedido'; ts: number; pedido: PedidoConGps }
+  | { tipo: 'visita'; ts: number; visita: VisitaConGps }
+
 export default function TimelineRecorrido({
   pedidos,
+  visitas,
   preventistaId,
   preventistaNombre,
   selectedPedidoId,
   onSelectPedido,
 }: TimelineRecorridoProps): React.ReactElement {
+  const eventos = useMemo<EventoTimeline[]>(() => {
+    if (!preventistaId) return []
+    const list: EventoTimeline[] = []
+    for (const p of pedidos) {
+      if (p.preventista_id !== preventistaId) continue
+      const ts = Date.parse(p.pedido_created_at ?? p.gps_capturado_at ?? '') || 0
+      list.push({ tipo: 'pedido', ts, pedido: p })
+    }
+    for (const v of visitas) {
+      if (v.preventista_id !== preventistaId) continue
+      const ts = Date.parse(v.visita_created_at ?? v.gps_capturado_at ?? '') || 0
+      list.push({ tipo: 'visita', ts, visita: v })
+    }
+    return list.sort((a, b) => a.ts - b.ts)
+  }, [pedidos, visitas, preventistaId])
+
   if (!preventistaId) {
     return (
       <div className="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-xl p-6 text-center text-sm text-gray-500 dark:text-gray-400">
@@ -27,27 +49,17 @@ export default function TimelineRecorrido({
     )
   }
 
-  // Ordenamos por created_at del pedido para que el timeline refleje el
-  // orden real de creación, independiente de si hubo o no check-in GPS.
-  // Fallback a gps_capturado_at para pedidos previos a la migración 041.
-  const propios = pedidos
-    .filter(p => p.preventista_id === preventistaId)
-    .sort((a, b) => {
-      const ta = Date.parse(a.pedido_created_at ?? a.gps_capturado_at ?? '') || 0
-      const tb = Date.parse(b.pedido_created_at ?? b.gps_capturado_at ?? '') || 0
-      return ta - tb
-    })
-
-  if (propios.length === 0) {
+  if (eventos.length === 0) {
     return (
       <div className="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-xl p-6 text-center text-sm text-gray-500 dark:text-gray-400">
-        Este preventista no tiene pedidos en el rango seleccionado.
+        Este preventista no tiene pedidos ni visitas en el rango seleccionado.
       </div>
     )
   }
 
   const color = colorPreventista(preventistaId)
-  const conGps = propios.filter(p => p.gps_status === 'ok').length
+  const pedidosCount = eventos.filter(e => e.tipo === 'pedido').length
+  const visitasCount = eventos.filter(e => e.tipo === 'visita').length
 
   return (
     <div className="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-xl overflow-hidden">
@@ -59,54 +71,98 @@ export default function TimelineRecorrido({
           </h3>
         </div>
         <span className="text-xs text-gray-500 dark:text-gray-400">
-          {propios.length} pedido{propios.length === 1 ? '' : 's'} · {conGps} con GPS
+          {pedidosCount} pedido{pedidosCount === 1 ? '' : 's'}
+          {visitasCount > 0 && ` · ${visitasCount} visita${visitasCount === 1 ? '' : 's'}`}
         </span>
       </div>
       <ol className="divide-y divide-gray-100 dark:divide-gray-700 max-h-[40vh] overflow-y-auto">
-        {propios.map((p, idx) => {
-          const isSelected = selectedPedidoId === p.pedido_id
-          const clasif = clasificarDistancia(p.distancia_m)
-          const cfg = SEMAFORO_COLORS[clasif]
-          const sinGps = p.gps_status !== 'ok'
-
-          return (
-            <li key={p.pedido_id}>
-              <button
-                type="button"
-                onClick={() => onSelectPedido(isSelected ? null : p.pedido_id)}
-                className={`w-full text-left px-4 py-3 flex items-start gap-3 transition-colors ${
-                  isSelected
-                    ? 'bg-blue-50 dark:bg-blue-900/20'
-                    : 'hover:bg-gray-50 dark:hover:bg-gray-700/50'
-                }`}
-                aria-pressed={isSelected}
-              >
+        {(() => {
+          let pedidoIdx = 0
+          return eventos.map(ev => {
+            if (ev.tipo === 'pedido') {
+              const p = ev.pedido
+              pedidoIdx++
+              const isSelected = selectedPedidoId === p.pedido_id
+              const clasif = clasificarDistancia(p.distancia_m)
+              const cfg = SEMAFORO_COLORS[clasif]
+              const sinGps = p.gps_status !== 'ok'
+              return (
+                <li key={`p-${p.pedido_id}`}>
+                  <button
+                    type="button"
+                    onClick={() => onSelectPedido(isSelected ? null : p.pedido_id)}
+                    className={`w-full text-left px-4 py-3 flex items-start gap-3 transition-colors ${
+                      isSelected
+                        ? 'bg-blue-50 dark:bg-blue-900/20'
+                        : 'hover:bg-gray-50 dark:hover:bg-gray-700/50'
+                    }`}
+                    aria-pressed={isSelected}
+                  >
+                    <span
+                      className={`shrink-0 w-7 h-7 rounded-full flex items-center justify-center text-white text-xs font-semibold ${
+                        sinGps ? 'bg-gray-300 dark:bg-gray-600' : ''
+                      }`}
+                      style={sinGps ? undefined : { backgroundColor: color }}
+                      aria-hidden
+                    >
+                      {pedidoIdx}
+                    </span>
+                    <div className="min-w-0 flex-1">
+                      <div className="flex items-center justify-between gap-2">
+                        <p className="text-sm font-medium text-gray-900 dark:text-white truncate inline-flex items-center gap-1">
+                          <ShoppingCart className="w-3.5 h-3.5 text-gray-400" aria-hidden />
+                          {p.cliente_nombre || 'Cliente sin nombre'}
+                        </p>
+                        <span className="shrink-0 text-xs text-gray-500 dark:text-gray-400 inline-flex items-center gap-1" title="Hora de creación del pedido">
+                          <Clock className="w-3 h-3" />
+                          {formatHora(p.pedido_created_at ?? p.gps_capturado_at)}
+                        </span>
+                      </div>
+                      <div className="mt-1 flex items-center justify-between gap-2 flex-wrap">
+                        <span className="text-xs text-gray-500 dark:text-gray-400">
+                          Pedido #{p.pedido_id} · {formatPrecio(Number(p.total) || 0)}
+                        </span>
+                        {sinGps ? (
+                          <span className={`inline-flex items-center gap-1 px-2 py-0.5 text-xs font-medium rounded-full ${SEMAFORO_COLORS.sin_dato.bg}`}>
+                            <AlertCircle className="w-3 h-3" />
+                            Sin GPS
+                          </span>
+                        ) : (
+                          <span className={`inline-flex items-center gap-1 px-2 py-0.5 text-xs font-medium rounded-full ${cfg.bg}`} title={cfg.label}>
+                            <MapPin className="w-3 h-3" />
+                            {formatDistancia(p.distancia_m)}
+                          </span>
+                        )}
+                      </div>
+                    </div>
+                  </button>
+                </li>
+              )
+            }
+            const v = ev.visita
+            const clasif = clasificarDistancia(v.distancia_m)
+            const cfg = SEMAFORO_COLORS[clasif]
+            const sinGps = v.gps_status !== 'ok'
+            return (
+              <li key={`v-${v.visita_id}`} className="px-4 py-3 flex items-start gap-3">
                 <span
-                  className={`shrink-0 w-7 h-7 rounded-full flex items-center justify-center text-white text-xs font-semibold ${
-                    sinGps ? 'bg-gray-300 dark:bg-gray-600' : ''
-                  }`}
-                  style={sinGps ? undefined : { backgroundColor: color }}
+                  className="shrink-0 w-5 h-5 mt-1 rounded-full ring-2 ring-white dark:ring-gray-800"
+                  style={{ backgroundColor: color, opacity: sinGps ? 0.4 : 0.75 }}
                   aria-hidden
-                >
-                  {idx + 1}
-                </span>
+                />
                 <div className="min-w-0 flex-1">
                   <div className="flex items-center justify-between gap-2">
-                    <p className="text-sm font-medium text-gray-900 dark:text-white truncate">
-                      {p.cliente_nombre || 'Cliente sin nombre'}
+                    <p className="text-sm font-medium text-gray-700 dark:text-gray-200 truncate inline-flex items-center gap-1">
+                      <MapPin className="w-3.5 h-3.5 text-gray-400" aria-hidden />
+                      {v.cliente_nombre || 'Cliente sin nombre'}
                     </p>
-                    <span
-                      className="shrink-0 text-xs text-gray-500 dark:text-gray-400 inline-flex items-center gap-1"
-                      title="Hora de creación del pedido"
-                    >
+                    <span className="shrink-0 text-xs text-gray-500 dark:text-gray-400 inline-flex items-center gap-1" title="Hora del ping de visita">
                       <Clock className="w-3 h-3" />
-                      {formatHora(p.pedido_created_at ?? p.gps_capturado_at)}
+                      {formatHora(v.visita_created_at)}
                     </span>
                   </div>
                   <div className="mt-1 flex items-center justify-between gap-2 flex-wrap">
-                    <span className="text-xs text-gray-500 dark:text-gray-400">
-                      #{p.pedido_id} · {formatPrecio(Number(p.total) || 0)}
-                    </span>
+                    <span className="text-xs text-gray-500 dark:text-gray-400">Visita marcada</span>
                     {sinGps ? (
                       <span className={`inline-flex items-center gap-1 px-2 py-0.5 text-xs font-medium rounded-full ${SEMAFORO_COLORS.sin_dato.bg}`}>
                         <AlertCircle className="w-3 h-3" />
@@ -115,15 +171,15 @@ export default function TimelineRecorrido({
                     ) : (
                       <span className={`inline-flex items-center gap-1 px-2 py-0.5 text-xs font-medium rounded-full ${cfg.bg}`} title={cfg.label}>
                         <MapPin className="w-3 h-3" />
-                        {formatDistancia(p.distancia_m)}
+                        {formatDistancia(v.distancia_m)}
                       </span>
                     )}
                   </div>
                 </div>
-              </button>
-            </li>
-          )
-        })}
+              </li>
+            )
+          })
+        })()}
       </ol>
     </div>
   )

--- a/src/components/modals/ModalMarcarVisita.tsx
+++ b/src/components/modals/ModalMarcarVisita.tsx
@@ -1,0 +1,171 @@
+/**
+ * Modal "Marcar visita".
+ *
+ * Permite a un preventista registrar una visita a un cliente sin tener
+ * que cargar pedido. Captura GPS en paralelo a la búsqueda del cliente y
+ * dispara `registrar_visita_cliente` al confirmar.
+ *
+ * Filtro de clientes: misma regla que el resto de la app — preventista ve
+ * clientes sin `preventista_ids` asignados o asignados a él mismo. Admin ve
+ * todos. (El backend re-valida en el RPC.)
+ */
+import React, { useMemo, useState, useRef, useEffect } from 'react'
+import { Search, MapPin, Loader2, Check } from 'lucide-react'
+import ModalBase from './ModalBase'
+import { useRegistrarVisitaMutation } from '../../hooks/queries'
+import { useGeolocationCapture } from '../../hooks/useGeolocationCapture'
+import { useNotification } from '../../contexts/NotificationContext'
+import type { ClienteDB } from '../../types'
+
+interface ModalMarcarVisitaProps {
+  clientes: ClienteDB[]
+  userId: string | null
+  isAdmin: boolean
+  onClose: () => void
+}
+
+function matchSearch(c: ClienteDB, q: string): boolean {
+  if (!q) return true
+  const needle = q.toLowerCase().trim()
+  return (
+    (c.nombre_fantasia || '').toLowerCase().includes(needle) ||
+    (c.razon_social || '').toLowerCase().includes(needle) ||
+    (c.direccion || '').toLowerCase().includes(needle) ||
+    (c.cuit || '').toLowerCase().includes(needle)
+  )
+}
+
+export default function ModalMarcarVisita({
+  clientes,
+  userId,
+  isAdmin,
+  onClose,
+}: ModalMarcarVisitaProps): React.ReactElement {
+  const [search, setSearch] = useState('')
+  const [pendienteId, setPendienteId] = useState<string | null>(null)
+  const capturarGps = useGeolocationCapture()
+  const registrar = useRegistrarVisitaMutation()
+  const notify = useNotification()
+  const inputRef = useRef<HTMLInputElement>(null)
+
+  useEffect(() => {
+    inputRef.current?.focus()
+  }, [])
+
+  // Filtrado por rol: admin ve todos, preventista ve sin asignar + asignados a él.
+  const clientesVisibles = useMemo<ClienteDB[]>(() => {
+    const activos = clientes.filter(c => c.activo !== false)
+    if (isAdmin) return activos
+    if (!userId) return []
+    return activos.filter(c => {
+      const ids = c.preventista_ids
+      if (!ids || ids.length === 0) return true
+      return ids.includes(userId)
+    })
+  }, [clientes, isAdmin, userId])
+
+  const filtrados = useMemo<ClienteDB[]>(() => {
+    return clientesVisibles
+      .filter(c => matchSearch(c, search))
+      .sort((a, b) => (a.nombre_fantasia || '').localeCompare(b.nombre_fantasia || ''))
+      .slice(0, 50) // tope de render para no congelar el list
+  }, [clientesVisibles, search])
+
+  const handleMarcar = async (cliente: ClienteDB) => {
+    if (pendienteId) return
+    setPendienteId(cliente.id)
+    try {
+      const gps = await capturarGps()
+      const res = await registrar.mutateAsync({
+        clienteId: Number(cliente.id),
+        status: gps.status,
+        ...(gps.status === 'ok'
+          ? { lat: gps.lat, lng: gps.lng, accuracy: gps.accuracy, capturadoAt: gps.capturadoAt }
+          : {}),
+      })
+      if (!res.success) {
+        notify.error(res.error || 'No se pudo registrar la visita')
+        return
+      }
+      const msg =
+        gps.status === 'ok'
+          ? `Visita registrada en ${cliente.nombre_fantasia}`
+          : `Visita registrada en ${cliente.nombre_fantasia} (sin GPS)`
+      notify.success(msg)
+      onClose()
+    } catch (e) {
+      notify.error('Error registrando visita: ' + (e as Error).message)
+    } finally {
+      setPendienteId(null)
+    }
+  }
+
+  return (
+    <ModalBase title="Marcar visita" onClose={onClose} maxWidth="max-w-lg">
+      <div className="space-y-3">
+        <p className="text-sm text-gray-500 dark:text-gray-400">
+          Elegí el cliente que estás visitando. Vamos a registrar tu ubicación actual junto con la visita.
+        </p>
+        <div className="relative">
+          <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400" aria-hidden />
+          <input
+            ref={inputRef}
+            type="text"
+            value={search}
+            onChange={e => setSearch(e.target.value)}
+            placeholder="Buscar por nombre, razón social, CUIT o dirección"
+            className="w-full pl-9 pr-3 py-2 text-sm rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-900 text-gray-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-blue-500"
+          />
+        </div>
+
+        {filtrados.length === 0 ? (
+          <div className="py-8 text-center text-sm text-gray-500 dark:text-gray-400">
+            {clientesVisibles.length === 0
+              ? 'No tenés clientes visibles para marcar visita.'
+              : 'Ningún cliente coincide con la búsqueda.'}
+          </div>
+        ) : (
+          <ul className="max-h-[55vh] overflow-y-auto divide-y divide-gray-100 dark:divide-gray-700 rounded-lg border border-gray-200 dark:border-gray-700">
+            {filtrados.map(c => {
+              const isPending = pendienteId === c.id
+              const isAnyPending = pendienteId !== null
+              return (
+                <li key={c.id}>
+                  <button
+                    type="button"
+                    onClick={() => handleMarcar(c)}
+                    disabled={isAnyPending}
+                    className="w-full text-left px-3 py-2.5 hover:bg-gray-50 dark:hover:bg-gray-700/50 disabled:opacity-50 disabled:cursor-not-allowed transition-colors flex items-center gap-3"
+                  >
+                    <div className="min-w-0 flex-1">
+                      <p className="text-sm font-medium text-gray-900 dark:text-white truncate">
+                        {c.nombre_fantasia || c.razon_social || 'Sin nombre'}
+                      </p>
+                      {c.direccion && (
+                        <p className="text-xs text-gray-500 dark:text-gray-400 truncate flex items-center gap-1">
+                          <MapPin className="w-3 h-3" />
+                          {c.direccion}
+                        </p>
+                      )}
+                    </div>
+                    {isPending ? (
+                      <Loader2 className="w-4 h-4 text-blue-500 animate-spin shrink-0" />
+                    ) : (
+                      <Check className="w-4 h-4 text-gray-300 dark:text-gray-600 shrink-0" />
+                    )}
+                  </button>
+                </li>
+              )
+            })}
+          </ul>
+        )}
+
+        {clientesVisibles.length > filtrados.length && (
+          <p className="text-xs text-gray-400 dark:text-gray-500 text-center">
+            Mostrando {filtrados.length} de {clientesVisibles.length}. Afiná la búsqueda para ver más.
+          </p>
+        )}
+      </div>
+    </ModalBase>
+  )
+}

--- a/src/components/modals/ModalVisitasHoy.tsx
+++ b/src/components/modals/ModalVisitasHoy.tsx
@@ -1,0 +1,94 @@
+/**
+ * Modal "Visitas del día".
+ *
+ * Lista cronológica de las visitas que el preventista marcó hoy. Pensado
+ * para que pueda ver de un vistazo a qué clientes ya pasó y cuáles le
+ * faltan, sin tener que abrir el panel admin (que no ve).
+ *
+ * Datos vienen del RPC `listar_visitas_hoy` (scope al preventista logueado
+ * + sucursal activa).
+ */
+import React from 'react'
+import { Loader2, MapPin, Clock, AlertCircle } from 'lucide-react'
+import ModalBase from './ModalBase'
+import { useVisitasHoyQuery } from '../../hooks/queries'
+import { formatHora } from '../../utils/formatters'
+import { clasificarDistancia, formatDistancia, SEMAFORO_COLORS } from '../../utils/geo'
+
+interface ModalVisitasHoyProps {
+  userId: string | null
+  onClose: () => void
+}
+
+export default function ModalVisitasHoy({ userId, onClose }: ModalVisitasHoyProps): React.ReactElement {
+  const { data: visitas = [], isLoading, error } = useVisitasHoyQuery(userId, { enabled: !!userId })
+
+  return (
+    <ModalBase title="Visitas del día" onClose={onClose} maxWidth="max-w-lg">
+      {isLoading ? (
+        <div className="py-12 flex items-center justify-center text-gray-500">
+          <Loader2 className="w-5 h-5 mr-2 animate-spin" />
+          Cargando…
+        </div>
+      ) : error ? (
+        <div className="rounded-lg border border-red-200 bg-red-50 dark:bg-red-900/20 text-red-700 dark:text-red-300 px-4 py-3 text-sm">
+          Error: {(error as Error).message}
+        </div>
+      ) : visitas.length === 0 ? (
+        <div className="py-12 text-center text-sm text-gray-500 dark:text-gray-400">
+          <MapPin className="w-6 h-6 mx-auto mb-2 opacity-40" />
+          Todavía no marcaste ninguna visita hoy.
+        </div>
+      ) : (
+        <>
+          <p className="text-xs text-gray-500 dark:text-gray-400 mb-3">
+            {visitas.length} visita{visitas.length === 1 ? '' : 's'} marcada{visitas.length === 1 ? '' : 's'} hoy. Ordenadas por hora.
+          </p>
+          <ol className="divide-y divide-gray-100 dark:divide-gray-700 rounded-lg border border-gray-200 dark:border-gray-700 max-h-[60vh] overflow-y-auto">
+            {visitas.map((v, idx) => {
+              const sinGps = v.gps_status !== 'ok'
+              const clasif = clasificarDistancia(v.distancia_m)
+              const cfg = SEMAFORO_COLORS[clasif]
+              return (
+                <li key={v.visita_id} className="px-3 py-2.5 flex items-start gap-3">
+                  <span className="shrink-0 w-7 h-7 rounded-full bg-blue-100 dark:bg-blue-900/40 text-blue-700 dark:text-blue-300 flex items-center justify-center text-xs font-semibold">
+                    {idx + 1}
+                  </span>
+                  <div className="min-w-0 flex-1">
+                    <div className="flex items-center justify-between gap-2">
+                      <p className="text-sm font-medium text-gray-900 dark:text-white truncate">
+                        {v.cliente_nombre || 'Cliente sin nombre'}
+                      </p>
+                      <span className="shrink-0 text-xs text-gray-500 dark:text-gray-400 inline-flex items-center gap-1">
+                        <Clock className="w-3 h-3" />
+                        {formatHora(v.created_at)}
+                      </span>
+                    </div>
+                    {v.cliente_direccion && (
+                      <p className="text-xs text-gray-500 dark:text-gray-400 truncate mt-0.5">
+                        {v.cliente_direccion}
+                      </p>
+                    )}
+                    <div className="mt-1">
+                      {sinGps ? (
+                        <span className={`inline-flex items-center gap-1 px-2 py-0.5 text-xs font-medium rounded-full ${SEMAFORO_COLORS.sin_dato.bg}`}>
+                          <AlertCircle className="w-3 h-3" />
+                          Sin GPS
+                        </span>
+                      ) : (
+                        <span className={`inline-flex items-center gap-1 px-2 py-0.5 text-xs font-medium rounded-full ${cfg.bg}`} title={cfg.label}>
+                          <MapPin className="w-3 h-3" />
+                          {formatDistancia(v.distancia_m)}
+                        </span>
+                      )}
+                    </div>
+                  </div>
+                </li>
+              )
+            })}
+          </ol>
+        </>
+      )}
+    </ModalBase>
+  )
+}

--- a/src/components/vistas/VistaGeolocalizacion.tsx
+++ b/src/components/vistas/VistaGeolocalizacion.tsx
@@ -14,6 +14,7 @@ import { MapPin, Users, ShoppingCart, AlertTriangle, RefreshCw, Calendar } from 
 import {
   useGeolocalizacionPreventistasQuery,
   type PedidoConGps,
+  type VisitaConGps,
 } from '../../hooks/queries'
 import { fechaLocalISO } from '../../utils/formatters'
 import KpiCard from '../geolocalizacion/KpiCard'
@@ -79,23 +80,30 @@ export default function VistaGeolocalizacion(): React.ReactElement {
   // re-disparen en cada render cuando `data` es undefined.
   const preventistas = useMemo(() => data?.preventistas ?? [], [data?.preventistas])
   const pedidos: PedidoConGps[] = useMemo(() => data?.pedidos ?? [], [data?.pedidos])
+  const visitas: VisitaConGps[] = useMemo(() => data?.visitas ?? [], [data?.visitas])
 
   // KPIs
   const kpis = useMemo(() => {
     const total = pedidos.length
     const conGps = pedidos.filter(p => p.gps_status === 'ok').length
     const sinGps = total - conGps
-    const anomalias = pedidos.filter(p => {
+    const visitasTotal = visitas.length
+    const anomaliasPedidos = pedidos.filter(p => {
       if (p.gps_status !== 'ok') return true
       return p.distancia_m != null && p.distancia_m >= 2000
+    }).length
+    const anomaliasVisitas = visitas.filter(v => {
+      if (v.gps_status !== 'ok') return true
+      return v.distancia_m != null && v.distancia_m >= 2000
     }).length
     return {
       preventistasActivos: preventistas.length,
       conGps,
       sinGps,
-      anomalias,
+      visitas: visitasTotal,
+      anomalias: anomaliasPedidos + anomaliasVisitas,
     }
-  }, [pedidos, preventistas])
+  }, [pedidos, visitas, preventistas])
 
   const preventistaSelectedNombre = useMemo(() => {
     if (!preventistaSelectedId) return null
@@ -186,7 +194,7 @@ export default function VistaGeolocalizacion(): React.ReactElement {
       </header>
 
       {/* KPIs */}
-      <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
+      <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 gap-3">
         <KpiCard
           label="Preventistas activos"
           value={kpis.preventistasActivos}
@@ -197,13 +205,20 @@ export default function VistaGeolocalizacion(): React.ReactElement {
         <KpiCard
           label="Pedidos con GPS"
           value={kpis.conGps}
-          icon={MapPin}
+          icon={ShoppingCart}
           tone="green"
+        />
+        <KpiCard
+          label="Visitas marcadas"
+          value={kpis.visitas}
+          icon={MapPin}
+          tone="blue"
+          hint="Pings sin pedido asociado"
         />
         <KpiCard
           label="Sin ubicación"
           value={kpis.sinGps}
-          icon={ShoppingCart}
+          icon={MapPin}
           tone="slate"
         />
         <KpiCard
@@ -240,6 +255,7 @@ export default function VistaGeolocalizacion(): React.ReactElement {
           <MapaPreventistas
             preventistas={preventistas}
             pedidos={pedidos}
+            visitas={visitas}
             preventistaSelectedId={preventistaSelectedId}
             pedidoSelectedId={pedidoSelectedId}
             onSelectPreventista={handleSelectPreventista}
@@ -285,6 +301,7 @@ export default function VistaGeolocalizacion(): React.ReactElement {
           {tab === 'timeline' ? (
             <TimelineRecorrido
               pedidos={pedidos}
+              visitas={visitas}
               preventistaId={preventistaSelectedId}
               preventistaNombre={preventistaSelectedNombre}
               selectedPedidoId={pedidoSelectedId}
@@ -293,8 +310,14 @@ export default function VistaGeolocalizacion(): React.ReactElement {
           ) : (
             <TablaAnomalias
               pedidos={pedidos}
+              visitas={visitas}
               preventistas={preventistas}
               onSelectPedido={handleSelectAnomalia}
+              onSelectVisitaPreventista={(preventistaId) => {
+                setPreventistaSelectedId(preventistaId)
+                setPedidoSelectedId(null)
+                setTab('timeline')
+              }}
             />
           )}
         </div>

--- a/src/components/vistas/VistaPedidos.tsx
+++ b/src/components/vistas/VistaPedidos.tsx
@@ -5,7 +5,7 @@
  * Renderiza lista + controles de paginación.
  */
 import { useState, useRef, useEffect } from 'react';
-import { ShoppingCart, Plus, Route, FileDown, PackageCheck, Banknote, ChevronDown, Truck } from 'lucide-react';
+import { ShoppingCart, Plus, Route, FileDown, PackageCheck, Banknote, ChevronDown, Truck, MapPin, History } from 'lucide-react';
 import LoadingSpinner from '../layout/LoadingSpinner';
 import Paginacion from '../layout/Paginacion';
 import { PedidoCard, PedidoFilters, PedidoStats, VistaRutaTransportista } from '../pedidos';
@@ -67,6 +67,10 @@ export interface VistaPedidosProps {
   onEntregasMasivas?: () => void;
   onPagosMasivos?: () => void;
   onAsignarTransportistaMasivo?: () => void;
+  /** Abre el modal para que el preventista marque una visita a un cliente. */
+  onMarcarVisita?: () => void;
+  /** Abre el modal con el timeline de visitas del día del preventista logueado. */
+  onVerVisitasHoy?: () => void;
   /** Handler para registrar una salvedad individual desde la vista transportista. */
   onRegistrarSalvedad?: (data: {
     pedidoId: string;
@@ -131,6 +135,8 @@ export default function VistaPedidos({
   onEntregasMasivas,
   onPagosMasivos,
   onAsignarTransportistaMasivo,
+  onMarcarVisita,
+  onVerVisitasHoy,
   onRegistrarSalvedad,
   onRegistrarPago,
   onAbrirPagoPedido,
@@ -202,6 +208,26 @@ export default function VistaPedidos({
             >
               <Banknote className="w-5 h-5" />
               <span className="hidden sm:inline">Pagos Masivos</span>
+            </button>
+          )}
+          {isPreventista && onVerVisitasHoy && (
+            <button
+              onClick={onVerVisitasHoy}
+              className="flex items-center space-x-2 px-4 py-2 bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-200 rounded-lg hover:bg-gray-200 dark:hover:bg-gray-600 transition-colors"
+              title="Ver clientes que visitaste hoy"
+            >
+              <History className="w-5 h-5" />
+              <span className="hidden sm:inline">Visitas del día</span>
+            </button>
+          )}
+          {isPreventista && onMarcarVisita && (
+            <button
+              onClick={onMarcarVisita}
+              className="flex items-center space-x-2 px-4 py-2 bg-indigo-600 text-white rounded-lg hover:bg-indigo-700 transition-colors"
+              title="Marcar visita a un cliente sin necesidad de cargar pedido"
+            >
+              <MapPin className="w-5 h-5" />
+              <span>Marcar visita</span>
             </button>
           )}
           {(isAdmin || isEncargado || isPreventista) && (

--- a/src/hooks/queries/index.ts
+++ b/src/hooks/queries/index.ts
@@ -168,8 +168,17 @@ export type {
   UltimaUbicacion,
   PreventistaResumen,
   PedidoConGps,
+  VisitaConGps,
   GeolocalizacionPanelData,
 } from './useGeolocalizacionPreventistasQuery'
+
+// Visitas (ping de preventista a cliente)
+export {
+  visitasKeys,
+  useVisitasHoyQuery,
+  useRegistrarVisitaMutation,
+} from './useVisitasQuery'
+export type { VisitaHoy, RegistrarVisitaInput } from './useVisitasQuery'
 
 // Promociones
 export {

--- a/src/hooks/queries/useGeolocalizacionPreventistasQuery.ts
+++ b/src/hooks/queries/useGeolocalizacionPreventistasQuery.ts
@@ -15,11 +15,16 @@ import { useSucursal } from '../../contexts/SucursalContext'
 
 export type GpsStatus = 'ok' | 'denied' | 'unavailable' | 'timeout' | 'error'
 
+export type EventoTipo = 'pedido' | 'visita'
+
 export interface UltimaUbicacion {
   lat: number
   lng: number
   capturado_at: string
-  pedido_id: number
+  /** Origen del último ping: confirmación de pedido o ping de visita manual. */
+  tipo: EventoTipo
+  /** ID del evento (pedido_id si tipo='pedido', visita_id si tipo='visita'). */
+  id: number
 }
 
 export interface PreventistaResumen {
@@ -29,6 +34,8 @@ export interface PreventistaResumen {
   pedidos_con_gps: number
   pedidos_sin_gps: number
   pedidos_lejos: number
+  /** Total de visitas (sin distinguir GPS ok) en el rango. */
+  total_visitas: number
   ultima_ubicacion: UltimaUbicacion | null
 }
 
@@ -55,11 +62,28 @@ export interface PedidoConGps {
   distancia_m: number | null
 }
 
+export interface VisitaConGps {
+  visita_id: number
+  preventista_id: string
+  visita_created_at: string
+  gps_lat: number | null
+  gps_lng: number | null
+  gps_accuracy: number | null
+  gps_capturado_at: string | null
+  gps_status: GpsStatus | null
+  cliente_id: number | null
+  cliente_nombre: string | null
+  cliente_lat: number | null
+  cliente_lng: number | null
+  distancia_m: number | null
+}
+
 export interface GeolocalizacionPanelData {
   fecha_desde: string
   fecha_hasta: string
   preventistas: PreventistaResumen[]
   pedidos: PedidoConGps[]
+  visitas: VisitaConGps[]
 }
 
 const EMPTY: GeolocalizacionPanelData = {
@@ -67,6 +91,7 @@ const EMPTY: GeolocalizacionPanelData = {
   fecha_hasta: '',
   preventistas: [],
   pedidos: [],
+  visitas: [],
 }
 
 async function fetchGeolocalizacion(

--- a/src/hooks/queries/useVisitasQuery.ts
+++ b/src/hooks/queries/useVisitasQuery.ts
@@ -1,0 +1,96 @@
+/**
+ * Hooks de TanStack Query para "Visitas de cliente" (ping del preventista).
+ *
+ * - `useVisitasHoyQuery`: lista las visitas que el preventista logueado
+ *   hizo hoy. Solo se llama cuando isPreventista, scope a la sucursal
+ *   activa (vía la RPC `listar_visitas_hoy`).
+ * - `useRegistrarVisitaMutation`: dispara el RPC `registrar_visita_cliente`
+ *   con el GPS capturado. Cada llamada crea un registro nuevo (sin dedup).
+ */
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { supabase } from '../supabase/base'
+import { useSucursal } from '../../contexts/SucursalContext'
+import { geolocalizacionKeys } from './useGeolocalizacionPreventistasQuery'
+import type { GpsStatus } from './useGeolocalizacionPreventistasQuery'
+
+export interface VisitaHoy {
+  visita_id: number
+  cliente_id: number
+  cliente_nombre: string | null
+  cliente_direccion: string | null
+  cliente_lat: number | null
+  cliente_lng: number | null
+  gps_lat: number | null
+  gps_lng: number | null
+  gps_status: GpsStatus | null
+  gps_capturado_at: string | null
+  created_at: string
+  distancia_m: number | null
+}
+
+export const visitasKeys = {
+  all: (sucursalId: number | null) => ['visitas', sucursalId] as const,
+  hoy: (sucursalId: number | null, userId: string | null) =>
+    ['visitas', sucursalId, 'hoy', userId] as const,
+}
+
+async function fetchVisitasHoy(): Promise<VisitaHoy[]> {
+  const { data, error } = await supabase.rpc('listar_visitas_hoy')
+  if (error) throw error
+  return (data as VisitaHoy[]) ?? []
+}
+
+export function useVisitasHoyQuery(userId: string | null, options: { enabled?: boolean } = {}) {
+  const { currentSucursalId } = useSucursal()
+  const { enabled = true } = options
+  return useQuery({
+    queryKey: visitasKeys.hoy(currentSucursalId, userId),
+    queryFn: fetchVisitasHoy,
+    enabled: enabled && !!userId,
+    staleTime: 15_000,
+  })
+}
+
+export interface RegistrarVisitaInput {
+  clienteId: number
+  status: GpsStatus
+  lat?: number | null
+  lng?: number | null
+  accuracy?: number | null
+  capturadoAt?: string | null
+}
+
+interface RegistrarVisitaResponse {
+  success: boolean
+  error?: string
+  visita_id?: number
+}
+
+async function registrarVisita(input: RegistrarVisitaInput): Promise<RegistrarVisitaResponse> {
+  const params: Record<string, unknown> = {
+    p_cliente_id: input.clienteId,
+    p_status: input.status,
+  }
+  if (input.status === 'ok') {
+    params.p_lat = input.lat
+    params.p_lng = input.lng
+    params.p_accuracy = input.accuracy
+    params.p_capturado_at = input.capturadoAt
+  }
+  const { data, error } = await supabase.rpc('registrar_visita_cliente', params)
+  if (error) throw error
+  return data as RegistrarVisitaResponse
+}
+
+export function useRegistrarVisitaMutation() {
+  const queryClient = useQueryClient()
+  const { currentSucursalId } = useSucursal()
+  return useMutation({
+    mutationFn: registrarVisita,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: visitasKeys.all(currentSucursalId) })
+      // El panel admin también refleja visitas en su data combinada.
+      queryClient.invalidateQueries({ queryKey: geolocalizacionKeys.all(currentSucursalId) })
+    },
+  })
+}


### PR DESCRIPTION
## Summary

Pedido del admin: además del check-in al confirmar pedido, que el preventista pueda **marcar visita** a un cliente (ping) sin tener que cargar venta. Y que esas visitas aparezcan en el mapa del panel admin de forma más discreta para ver qué clientes están recorriendo.

## Para preventistas

Dos botones nuevos en el header de Pedidos (visibles sólo a `isPreventista`):

- **Marcar visita** → modal con buscador de clientes (mismo filtro de visibilidad que el resto de la app: sin asignar + asignados a él). Al elegir cliente, captura GPS y dispara el RPC. No bloquea si el GPS falla.
- **Visitas del día** → modal con timeline cronológico de los clientes que marcó hoy, con semáforo de distancia para cada uno.

Cada apretada de "Marcar visita" crea un registro nuevo — si pasó dos veces por el mismo cliente, son dos pings.

## Para admin (panel /geolocalizacion)

- **Mapa global**: pin grande de "última ubicación" por preventista (puede ser pedido o visita, el más reciente) + puntitos chicos y semitransparentes para cada visita del rango. Da vista de "dónde anduvieron" sin sobrecargar.
- **Drill-down**: pins de pedidos numerados y prominentes + visitas como puntos más chicos sin número, todos mezclados en una sola polilínea cronológica.
- **Timeline**: pedidos y visitas intercalados por hora, con icono distintivo (🛒 carrito vs 📍 pin).
- **Anomalías**: visitas sin GPS o a ≥2 km del cliente aparecen junto con los pedidos problemáticos, identificadas por columna "Tipo".
- **KPI nuevo**: "Visitas marcadas".

## Migration 042 (ya aplicada en prod)

- Tabla `public.visitas_cliente` con FK a preventista, cliente, sucursal y columnas `gps_*` simétricas a las de `pedidos`.
- RLS: preventista ve las suyas, admin/encargado las de la sucursal activa, INSERT solo via RPC.
- RPC `registrar_visita_cliente`: valida sucursal y visibilidad del cliente para el rol preventista (sin asignar o asignado a él).
- RPC `listar_visitas_hoy`: para el modal del preventista.
- RPC `obtener_geolocalizacion_preventistas`: suma array `visitas` al output JSON; `ultima_ubicacion` ahora resuelve sobre la unión de pedidos+visitas.

## Test plan

- [x] Lint
- [x] `tsc --noEmit`
- [x] Suite unitaria completa (631 tests)
- [ ] Logear como preventista → header de Pedidos muestra "Marcar visita" y "Visitas del día"
- [ ] Logear como admin/encargado → los botones NO aparecen
- [ ] Marcar visita a un cliente asignado al preventista → success notification + cliente aparece en el modal "Visitas del día"
- [ ] Intentar marcar visita a un cliente asignado a OTRO preventista (vía consola, simulando) → RPC rechaza
- [ ] Logear como admin → `/geolocalizacion` muestra KPI "Visitas marcadas" y puntitos pequeños en el mapa global
- [ ] Click en preventista → drill-down muestra pedidos y visitas mezclados en la polilínea cronológica
- [ ] Tab Anomalías muestra las visitas a >=2km del cliente con motivo "Visita lejos del cliente"

🤖 Generated with [Claude Code](https://claude.com/claude-code)