### PR TITLE
chore(geolocalizacion): bajar umbral anomalia de 2 km a 1 km

### DIFF
--- a/migrations/043_geolocalizacion_umbral_1km.sql
+++ b/migrations/043_geolocalizacion_umbral_1km.sql
@@ -1,0 +1,147 @@
+-- =========================================================================
+-- 043_geolocalizacion_umbral_1km.sql
+--
+-- Baja el umbral "pedido lejos del cliente" de 2 km a 1 km en el campo
+-- agregado `pedidos_lejos` del RPC `obtener_geolocalizacion_preventistas`.
+-- El semaforo del frontend ya usa la constante ANOMALIA_DISTANCIA_METROS
+-- (= 1000); este RPC tenia el valor literal espejo y queda en sync.
+--
+-- CREATE OR REPLACE sobre la version de 042 cambiando un solo numero.
+-- =========================================================================
+
+BEGIN;
+
+CREATE OR REPLACE FUNCTION public.obtener_geolocalizacion_preventistas(
+  p_fecha_desde date DEFAULT NULL,
+  p_fecha_hasta date DEFAULT NULL
+) RETURNS jsonb
+LANGUAGE plpgsql SECURITY DEFINER SET search_path TO 'public'
+AS $$
+DECLARE
+  v_user_id uuid := auth.uid();
+  v_user_role text;
+  v_sucursal bigint := current_sucursal_id();
+  v_fecha_desde date := COALESCE(p_fecha_desde, (now() AT TIME ZONE 'America/Argentina/Buenos_Aires')::date);
+  v_fecha_hasta date := COALESCE(p_fecha_hasta, v_fecha_desde);
+  v_result jsonb;
+BEGIN
+  IF v_user_id IS NULL THEN
+    RAISE EXCEPTION 'No autenticado' USING ERRCODE = '42501';
+  END IF;
+  IF v_sucursal IS NULL THEN
+    RAISE EXCEPTION 'No hay sucursal activa' USING ERRCODE = '42501';
+  END IF;
+  SELECT rol INTO v_user_role FROM perfiles WHERE id = v_user_id;
+  IF v_user_role <> 'admin' THEN
+    RAISE EXCEPTION 'Solo admins pueden ver geolocalizacion de preventistas' USING ERRCODE = '42501';
+  END IF;
+  WITH pedidos_rango AS (
+    SELECT
+      p.id              AS pedido_id,
+      p.usuario_id      AS preventista_id,
+      p.fecha,
+      p.created_at      AS pedido_created_at,
+      p.total,
+      p.gps_lat,
+      p.gps_lng,
+      p.gps_accuracy,
+      p.gps_capturado_at,
+      p.gps_status,
+      p.cliente_id,
+      c.nombre_fantasia AS cliente_nombre,
+      c.latitud         AS cliente_lat,
+      c.longitud        AS cliente_lng,
+      public.haversine_m(p.gps_lat, p.gps_lng, c.latitud, c.longitud) AS distancia_m
+    FROM pedidos p
+    LEFT JOIN clientes c ON c.id = p.cliente_id
+    WHERE p.sucursal_id = v_sucursal
+      AND p.fecha BETWEEN v_fecha_desde AND v_fecha_hasta
+      AND p.usuario_id IS NOT NULL
+  ),
+  visitas_rango AS (
+    SELECT
+      v.id              AS visita_id,
+      v.preventista_id,
+      v.created_at      AS visita_created_at,
+      v.gps_lat,
+      v.gps_lng,
+      v.gps_accuracy,
+      v.gps_capturado_at,
+      v.gps_status,
+      v.cliente_id,
+      c.nombre_fantasia AS cliente_nombre,
+      c.latitud         AS cliente_lat,
+      c.longitud        AS cliente_lng,
+      public.haversine_m(v.gps_lat, v.gps_lng, c.latitud, c.longitud) AS distancia_m
+    FROM visitas_cliente v
+    LEFT JOIN clientes c ON c.id = v.cliente_id
+    WHERE v.sucursal_id = v_sucursal
+      AND (v.created_at AT TIME ZONE 'America/Argentina/Buenos_Aires')::date BETWEEN v_fecha_desde AND v_fecha_hasta
+  ),
+  preventistas_resumen AS (
+    SELECT
+      pr.preventista_id,
+      per.nombre AS preventista_nombre,
+      COUNT(*)::int AS total_pedidos,
+      COUNT(*) FILTER (WHERE pr.gps_status = 'ok')::int AS pedidos_con_gps,
+      COUNT(*) FILTER (WHERE pr.gps_status IS NULL OR pr.gps_status <> 'ok')::int AS pedidos_sin_gps,
+      COUNT(*) FILTER (
+        WHERE pr.gps_status = 'ok' AND pr.distancia_m IS NOT NULL AND pr.distancia_m >= 1000
+      )::int AS pedidos_lejos,
+      (SELECT COUNT(*) FROM visitas_rango v WHERE v.preventista_id = pr.preventista_id)::int AS total_visitas,
+      (
+        SELECT jsonb_build_object(
+          'lat', e.lat,
+          'lng', e.lng,
+          'capturado_at', e.capturado_at,
+          'tipo', e.tipo,
+          'id', e.id
+        )
+        FROM (
+          SELECT pr2.gps_lat AS lat, pr2.gps_lng AS lng, pr2.gps_capturado_at AS capturado_at,
+                 'pedido'::text AS tipo, pr2.pedido_id AS id
+          FROM pedidos_rango pr2
+          WHERE pr2.preventista_id = pr.preventista_id AND pr2.gps_status = 'ok'
+          UNION ALL
+          SELECT v.gps_lat AS lat, v.gps_lng AS lng, v.gps_capturado_at AS capturado_at,
+                 'visita'::text AS tipo, v.visita_id AS id
+          FROM visitas_rango v
+          WHERE v.preventista_id = pr.preventista_id AND v.gps_status = 'ok'
+        ) e
+        ORDER BY e.capturado_at DESC NULLS LAST
+        LIMIT 1
+      ) AS ultima_ubicacion
+    FROM pedidos_rango pr
+    LEFT JOIN perfiles per ON per.id = pr.preventista_id
+    WHERE per.rol = 'preventista'
+    GROUP BY pr.preventista_id, per.nombre
+  )
+  SELECT jsonb_build_object(
+    'fecha_desde', v_fecha_desde,
+    'fecha_hasta', v_fecha_hasta,
+    'preventistas', COALESCE(
+      (SELECT jsonb_agg(to_jsonb(preventistas_resumen.*) ORDER BY preventista_nombre)
+       FROM preventistas_resumen),
+      '[]'::jsonb
+    ),
+    'pedidos', COALESCE(
+      (SELECT jsonb_agg(to_jsonb(pr.*) ORDER BY pr.pedido_created_at NULLS LAST)
+       FROM pedidos_rango pr
+       JOIN perfiles per ON per.id = pr.preventista_id AND per.rol = 'preventista'),
+      '[]'::jsonb
+    ),
+    'visitas', COALESCE(
+      (SELECT jsonb_agg(to_jsonb(v.*) ORDER BY v.visita_created_at NULLS LAST)
+       FROM visitas_rango v
+       JOIN perfiles per ON per.id = v.preventista_id AND per.rol = 'preventista'),
+      '[]'::jsonb
+    )
+  ) INTO v_result;
+  RETURN v_result;
+END;
+$$;
+
+COMMENT ON FUNCTION public.obtener_geolocalizacion_preventistas(date, date) IS
+  'Panel admin de geolocalizacion: resumen por preventista + detalle de pedidos y visitas. Umbral pedidos_lejos = 1 km (espejo de ANOMALIA_DISTANCIA_METROS en frontend).';
+
+COMMIT;

--- a/src/components/geolocalizacion/TablaAnomalias.tsx
+++ b/src/components/geolocalizacion/TablaAnomalias.tsx
@@ -1,7 +1,7 @@
 import React, { useMemo } from 'react'
 import { AlertTriangle, ZapOff, Search, ShoppingCart, MapPin } from 'lucide-react'
 import { formatPrecio, formatHora } from '../../utils/formatters'
-import { clasificarDistancia, formatDistancia, SEMAFORO_COLORS } from '../../utils/geo'
+import { clasificarDistancia, formatDistancia, SEMAFORO_COLORS, ANOMALIA_DISTANCIA_METROS } from '../../utils/geo'
 import type { PedidoConGps, PreventistaResumen, VisitaConGps } from '../../hooks/queries'
 
 interface TablaAnomaliasProps {
@@ -56,7 +56,7 @@ export default function TablaAnomalias({
     const result: AnomaliaRow[] = []
     for (const p of pedidos) {
       const sinGps = p.gps_status !== 'ok'
-      const lejos = !sinGps && p.distancia_m != null && p.distancia_m >= 2000
+      const lejos = !sinGps && p.distancia_m != null && p.distancia_m >= ANOMALIA_DISTANCIA_METROS
       if (!sinGps && !lejos) continue
       result.push({
         key: `p-${p.pedido_id}`,
@@ -74,7 +74,7 @@ export default function TablaAnomalias({
     }
     for (const v of visitas) {
       const sinGps = v.gps_status !== 'ok'
-      const lejos = !sinGps && v.distancia_m != null && v.distancia_m >= 2000
+      const lejos = !sinGps && v.distancia_m != null && v.distancia_m >= ANOMALIA_DISTANCIA_METROS
       if (!sinGps && !lejos) continue
       result.push({
         key: `v-${v.visita_id}`,

--- a/src/components/vistas/VistaGeolocalizacion.tsx
+++ b/src/components/vistas/VistaGeolocalizacion.tsx
@@ -17,6 +17,7 @@ import {
   type VisitaConGps,
 } from '../../hooks/queries'
 import { fechaLocalISO } from '../../utils/formatters'
+import { ANOMALIA_DISTANCIA_METROS } from '../../utils/geo'
 import KpiCard from '../geolocalizacion/KpiCard'
 import SidebarPreventistas from '../geolocalizacion/SidebarPreventistas'
 import MapaPreventistas from '../geolocalizacion/MapaPreventistas'
@@ -90,11 +91,11 @@ export default function VistaGeolocalizacion(): React.ReactElement {
     const visitasTotal = visitas.length
     const anomaliasPedidos = pedidos.filter(p => {
       if (p.gps_status !== 'ok') return true
-      return p.distancia_m != null && p.distancia_m >= 2000
+      return p.distancia_m != null && p.distancia_m >= ANOMALIA_DISTANCIA_METROS
     }).length
     const anomaliasVisitas = visitas.filter(v => {
       if (v.gps_status !== 'ok') return true
-      return v.distancia_m != null && v.distancia_m >= 2000
+      return v.distancia_m != null && v.distancia_m >= ANOMALIA_DISTANCIA_METROS
     }).length
     return {
       preventistasActivos: preventistas.length,
@@ -226,7 +227,7 @@ export default function VistaGeolocalizacion(): React.ReactElement {
           value={kpis.anomalias}
           icon={AlertTriangle}
           tone={kpis.anomalias > 0 ? 'red' : 'green'}
-          hint="Sin GPS o ≥2 km del cliente"
+          hint="Sin GPS o ≥1 km del cliente"
         />
       </div>
 

--- a/src/utils/geo.test.ts
+++ b/src/utils/geo.test.ts
@@ -48,14 +48,14 @@ describe('formatDistancia', () => {
 })
 
 describe('clasificarDistancia', () => {
-  it('classifies thresholds correctly', () => {
+  it('classifies thresholds correctly (ok <500m, cerca <1km, lejos >=1km)', () => {
     expect(clasificarDistancia(null)).toBe('sin_dato')
     expect(clasificarDistancia(undefined)).toBe('sin_dato')
     expect(clasificarDistancia(0)).toBe('ok')
     expect(clasificarDistancia(499)).toBe('ok')
     expect(clasificarDistancia(500)).toBe('cerca')
-    expect(clasificarDistancia(1999)).toBe('cerca')
-    expect(clasificarDistancia(2000)).toBe('lejos')
+    expect(clasificarDistancia(999)).toBe('cerca')
+    expect(clasificarDistancia(1000)).toBe('lejos')
     expect(clasificarDistancia(10_000)).toBe('lejos')
   })
 })

--- a/src/utils/geo.ts
+++ b/src/utils/geo.ts
@@ -10,6 +10,14 @@
 
 const EARTH_RADIUS_M = 6_371_000
 
+/**
+ * Umbral en metros para considerar que un pedido o visita fue hecho "lejos"
+ * del cliente registrado. Usado tanto para el semáforo en frontend como
+ * para el campo `pedidos_lejos` del RPC del panel admin (que tiene un
+ * literal espejo en SQL — mantener en sync).
+ */
+export const ANOMALIA_DISTANCIA_METROS = 1000
+
 const PALETA_PREVENTISTAS = [
   '#2563eb', // azul
   '#dc2626', // rojo
@@ -46,7 +54,7 @@ export type ClasificacionDistancia = 'ok' | 'cerca' | 'lejos' | 'sin_dato'
 export function clasificarDistancia(metros: number | null | undefined): ClasificacionDistancia {
   if (metros == null || !Number.isFinite(metros)) return 'sin_dato'
   if (metros < 500) return 'ok'
-  if (metros < 2000) return 'cerca'
+  if (metros < ANOMALIA_DISTANCIA_METROS) return 'cerca'
   return 'lejos'
 }
 


### PR DESCRIPTION
## Summary

A pedido del admin: 2 km es demasiado tolerante. Bajamos el umbral de "lejos del cliente" a 1 km.

- Verde 🟢 sigue siendo `<500m` ("en el cliente")
- Amarillo 🟡 ahora `500m..1km` ("cerca", antes 500m..2km)
- Rojo 🔴 ahora `>=1km` ("lejos del cliente", antes >=2km)

Single source of truth: nueva constante `ANOMALIA_DISTANCIA_METROS=1000` exportada desde `src/utils/geo.ts`. La RPC del panel admin tiene el literal espejo (1000); migration 043 ya aplicada en prod.

## Test plan

- [x] Lint, typecheck, suite unitaria (test de `clasificarDistancia` actualizado)
- [ ] Verificar en `/geolocalizacion` que el contador de anomalías y el chip rojo respeten 1 km

## Nota operativa (no es parte del PR)

El admin reportó que TODOS los pedidos de hoy aparecen como anomalía "Sin check-in" y el mapa está vacío. Causa: los preventistas tienen `gps_status = null` en sus 5 pedidos, lo que significa que el código que pide GPS nunca corrió. Más probable: están con bundle viejo (service worker no actualizado en el celular) o están cargando desde el bot de Telegram. La solución es que abran/cierren la app en el celu para forzar la actualización del service worker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)