### PR TITLE
chore(pwa): registerType autoUpdate + skipWaiting/clientsClaim

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -47,7 +47,13 @@ export default defineConfig({
     react(),
     VitePWA({
       injectRegister: false,
-      registerType: 'prompt',
+      // autoUpdate: el SW nuevo se descarga en segundo plano y la página se
+      // recarga sola cuando está listo. Sin cartel manual "Actualizar ahora".
+      // Trade-off conocido: si el preventista está cargando un pedido cuando
+      // baja el update, el reload pierde lo tipeado. En esta app ese caso es
+      // raro (sesiones cortas, pedidos rápidos) y vale la pena para evitar
+      // que se queden con bundles viejos por días.
+      registerType: 'autoUpdate',
       // selfDestroying debe estar en false para que el SW persista y la PWA
       // funcione offline (Workbox precache + Dexie). El deploy previo con
       // selfDestroying:true ya desregistró SW corruptos; ahora los usuarios
@@ -161,8 +167,11 @@ export default defineConfig({
         globPatterns: ['**/*.{js,css,html,ico,png,svg,woff2}'],
         globIgnores: ['**/*.map'],
         cleanupOutdatedCaches: true,
-        skipWaiting: false,
-        clientsClaim: false
+        // Pareja con registerType:'autoUpdate'. El SW nuevo activa de inmediato
+        // (skipWaiting) y toma control de las pestañas existentes (clientsClaim)
+        // sin esperar a que se cierren. El reload lo dispara el plugin.
+        skipWaiting: true,
+        clientsClaim: true
       },
       devOptions: {
         enabled: false,


### PR DESCRIPTION
## Summary

A pedido del admin: que las actualizaciones lleguen **solas** al celular del preventista sin tener que apretar "Actualizar ahora". Bajamos de modo manual a modo automático.

Cambios en `vite.config.js`:
- `registerType: 'prompt'` → **`'autoUpdate'`**. El plugin instala y activa el SW nuevo, y recarga la página solo.
- `workbox.skipWaiting: false` → **`true`**. El SW nuevo no espera a que se cierren todas las pestañas.
- `workbox.clientsClaim: false` → **`true`**. El SW nuevo toma control de las pestañas existentes.

`PWAPrompt.tsx` no se toca: con `autoUpdate` el plugin nunca emite `needRefresh=true`, así que el cartel azul "Nueva versión disponible" simplemente deja de aparecer. La notificación verde "Listo para usar offline" sigue funcionando en el primer registro.

## Limitación importante (operativa)

Este modo solo aplica **una vez que el preventista recibió el bundle con este cambio**. Los celulares de Joaquín y Luis que están con bundle viejo todavía necesitan que toquen el cartel "Actualizar ahora" **una última vez** después de mergear este PR. A partir de ahí, todas las actualizaciones futuras son silenciosas.

## Trade-off

Si un preventista está cargando un pedido **exactamente** cuando baja un deploy, el reload automático puede hacerle perder lo tipeado. En esta app las sesiones son cortas (cargan pedido en ~3 min y cierran) y la ventana es mínima. Vale la pena el riesgo para evitar que se queden con bundles viejos por días.

## Test plan

- [x] Lint, typecheck, suite PWAPrompt verde
- [x] `npm run build` completa sin error generando SW con la nueva config
- [ ] Deploy → en una pestaña con código viejo, ver que el cartel "Actualizar ahora" siga apareciendo (es esperado para esta transición)
- [ ] Tras aceptar ese cartel y recargar, la app queda en modo `autoUpdate`
- [ ] Deploy siguiente (cualquier change posterior) → la app se actualiza sola sin cartel

🤖 Generated with [Claude Code](https://claude.com/claude-code)