### PR TITLE
fix(encargado): habilitar creacion clientes/pedidos + forma_pago real en export

### DIFF
--- a/migrations/044_encargado_crear_pedido.sql
+++ b/migrations/044_encargado_crear_pedido.sql
@@ -1,0 +1,203 @@
+-- Migration 044: habilitar encargado en crear_pedido_completo
+--
+-- Reemplaza crear_pedido_completo de la migracion 038 cambiando solo la
+-- linea del role check: ahora encargado tambien puede crear pedidos via
+-- esta RPC. Consistente con crear_pedido_completo_bot (mig 030:146),
+-- actualizar_pedido_items_preventista_ventana (mig 033) y
+-- preventista_precio_lte_base (mig 034), todas las cuales ya admiten
+-- ('admin', 'encargado', 'preventista').
+--
+-- El cuerpo del funcion es identico al de migracion 038. Mantener firma,
+-- SECURITY DEFINER, search_path y comportamiento sin cambios.
+
+CREATE OR REPLACE FUNCTION public.crear_pedido_completo(
+  p_cliente_id bigint, p_total numeric, p_usuario_id uuid, p_items jsonb,
+  p_notas text DEFAULT NULL::text, p_forma_pago text DEFAULT 'efectivo'::text,
+  p_estado_pago text DEFAULT 'pendiente'::text, p_fecha date DEFAULT NULL::date,
+  p_tipo_factura text DEFAULT 'ZZ'::text, p_total_neto numeric DEFAULT NULL::numeric,
+  p_total_iva numeric DEFAULT 0, p_fecha_entrega_programada date DEFAULT NULL::date
+) RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $function$
+DECLARE
+  v_sucursal BIGINT := current_sucursal_id();
+  v_pedido_id INT; item JSONB; v_producto_id INT; v_cantidad INT;
+  v_precio_unitario DECIMAL; v_es_bonificacion BOOLEAN; v_promocion_id BIGINT;
+  v_neto_unitario DECIMAL; v_iva_unitario DECIMAL; v_imp_internos_unitario DECIMAL;
+  v_porcentaje_iva DECIMAL; v_stock_actual INT; v_producto_nombre TEXT;
+  errores TEXT[] := '{}'; v_user_role TEXT;
+  v_cantidades_totales JSONB := '{}'::JSONB; v_cant_acumulada INT;
+  v_stock_snapshot JSONB := '{}'::JSONB;
+  v_stock_al_crear INT;
+  v_es_regalo_no_mueve_stock JSONB := '{}'::JSONB;
+  v_regalo_mueve_stock BOOLEAN;
+  v_descripcion_regalo TEXT;
+  v_fecha_pedido DATE := COALESCE(p_fecha, (now() AT TIME ZONE 'America/Argentina/Buenos_Aires')::date);
+  v_fecha_entrega DATE := COALESCE(p_fecha_entrega_programada, (v_fecha_pedido + INTERVAL '1 day')::date);
+  v_promo RECORD;
+  v_usos_pendientes_actual INT;
+  v_bloques_completos INT;
+  v_ajustar_usos INT;
+  v_ajustar_stock INT;
+  v_stock_ajuste_anterior INT;
+  v_stock_ajuste_nuevo INT;
+  v_ajuste_producto_nombre TEXT;
+  v_merma_id BIGINT;
+  v_pedidos_bundle TEXT;
+  v_observacion TEXT;
+BEGIN
+  IF v_sucursal IS NULL THEN RETURN jsonb_build_object('success', false, 'errores', jsonb_build_array('No se pudo determinar la sucursal activa')); END IF;
+  IF p_usuario_id IS DISTINCT FROM auth.uid() THEN RETURN jsonb_build_object('success', false, 'errores', jsonb_build_array('ID de usuario no coincide con la sesion autenticada')); END IF;
+  SELECT rol INTO v_user_role FROM perfiles WHERE id = p_usuario_id;
+  IF v_user_role IS NULL OR v_user_role NOT IN ('admin', 'preventista', 'encargado') THEN RETURN jsonb_build_object('success', false, 'errores', jsonb_build_array('No tiene permisos para crear pedidos')); END IF;
+
+  -- Loop 1: acumular cantidades por producto (incluye TODOS: ventas y regalos).
+  -- Se marca por aparte si el item es regalo-no-mueve-stock para diferenciar
+  -- el mensaje de error en la validacion.
+  FOR item IN SELECT * FROM jsonb_array_elements(p_items) LOOP
+    v_producto_id := (item->>'producto_id')::INT; v_cantidad := (item->>'cantidad')::INT;
+    v_es_bonificacion := COALESCE((item->>'es_bonificacion')::BOOLEAN, false);
+    IF v_cantidad IS NULL OR v_cantidad <= 0 THEN errores := array_append(errores, 'Cantidad invalida para producto ID ' || v_producto_id); CONTINUE; END IF;
+
+    v_cant_acumulada := COALESCE((v_cantidades_totales->>v_producto_id::TEXT)::INT, 0) + v_cantidad;
+    v_cantidades_totales := v_cantidades_totales || jsonb_build_object(v_producto_id::TEXT, v_cant_acumulada);
+
+    IF v_es_bonificacion THEN
+      v_promocion_id := (item->>'promocion_id')::BIGINT;
+      IF v_promocion_id IS NOT NULL THEN
+        SELECT regalo_mueve_stock INTO v_regalo_mueve_stock FROM promociones WHERE id = v_promocion_id AND sucursal_id = v_sucursal;
+        IF NOT COALESCE(v_regalo_mueve_stock, FALSE) THEN
+          v_es_regalo_no_mueve_stock := v_es_regalo_no_mueve_stock || jsonb_build_object(v_producto_id::TEXT, true);
+        END IF;
+      ELSE
+        v_es_regalo_no_mueve_stock := v_es_regalo_no_mueve_stock || jsonb_build_object(v_producto_id::TEXT, true);
+      END IF;
+    END IF;
+  END LOOP;
+
+  -- Loop 2: validar stock por producto + capturar snapshot. Lock con FOR UPDATE.
+  FOR v_producto_id IN SELECT (key)::INT FROM jsonb_each_text(v_cantidades_totales) LOOP
+    v_cantidad := (v_cantidades_totales->>v_producto_id::TEXT)::INT;
+    SELECT stock, nombre INTO v_stock_actual, v_producto_nombre FROM productos WHERE id = v_producto_id AND sucursal_id = v_sucursal FOR UPDATE;
+    IF v_stock_actual IS NULL THEN
+      errores := array_append(errores, 'Producto ID ' || v_producto_id || ' no encontrado');
+    ELSIF v_stock_actual < v_cantidad THEN
+      IF COALESCE((v_es_regalo_no_mueve_stock->>v_producto_id::TEXT)::BOOLEAN, FALSE) THEN
+        errores := array_append(errores, v_producto_nombre || ': stock insuficiente para regalo (disponible: ' || v_stock_actual || ', solicitado: ' || v_cantidad || ')');
+      ELSE
+        errores := array_append(errores, v_producto_nombre || ': stock insuficiente (disponible: ' || v_stock_actual || ', solicitado: ' || v_cantidad || ')');
+      END IF;
+    END IF;
+    -- snapshot incluso si fallo (sirve para diagnostico aguas abajo)
+    IF v_stock_actual IS NOT NULL THEN
+      v_stock_snapshot := v_stock_snapshot || jsonb_build_object(v_producto_id::TEXT, v_stock_actual);
+    END IF;
+  END LOOP;
+
+  IF array_length(errores, 1) > 0 THEN RETURN jsonb_build_object('success', false, 'errores', to_jsonb(errores)); END IF;
+
+  INSERT INTO pedidos (cliente_id, fecha, total, total_neto, total_iva, tipo_factura, estado, usuario_id, stock_descontado, notas, forma_pago, estado_pago, fecha_entrega_programada, sucursal_id)
+  VALUES (p_cliente_id, v_fecha_pedido, p_total, COALESCE(p_total_neto, p_total), COALESCE(p_total_iva, 0), COALESCE(p_tipo_factura, 'ZZ'), 'pendiente', p_usuario_id, true, p_notas, p_forma_pago, p_estado_pago, v_fecha_entrega, v_sucursal)
+  RETURNING id INTO v_pedido_id;
+
+  -- Setear contexto para el trigger registrar_cambio_stock antes de los UPDATEs.
+  PERFORM set_config('app.stock_origen', 'pedido_creado', true);
+  PERFORM set_config('app.stock_ref_tipo', 'pedido', true);
+  PERFORM set_config('app.stock_ref_id', v_pedido_id::TEXT, true);
+  PERFORM set_config('app.stock_user_id', p_usuario_id::TEXT, true);
+
+  -- Loop 3: INSERT items + UPDATE stock + auto-ajuste promos.
+  FOR item IN SELECT * FROM jsonb_array_elements(p_items) LOOP
+    v_producto_id := (item->>'producto_id')::INT; v_cantidad := (item->>'cantidad')::INT;
+    v_precio_unitario := (item->>'precio_unitario')::DECIMAL;
+    v_es_bonificacion := COALESCE((item->>'es_bonificacion')::BOOLEAN, false);
+    v_promocion_id := (item->>'promocion_id')::BIGINT;
+    v_neto_unitario := (item->>'neto_unitario')::DECIMAL;
+    v_iva_unitario := COALESCE((item->>'iva_unitario')::DECIMAL, 0);
+    v_imp_internos_unitario := COALESCE((item->>'impuestos_internos_unitario')::DECIMAL, 0);
+    v_porcentaje_iva := COALESCE((item->>'porcentaje_iva')::DECIMAL, 0);
+    v_stock_al_crear := (v_stock_snapshot->>v_producto_id::TEXT)::INT;
+
+    v_descripcion_regalo := NULL;
+    IF v_es_bonificacion AND v_promocion_id IS NOT NULL THEN
+      SELECT descripcion_regalo INTO v_descripcion_regalo FROM promociones WHERE id = v_promocion_id AND sucursal_id = v_sucursal;
+    END IF;
+
+    INSERT INTO pedido_items (
+      pedido_id, producto_id, cantidad, precio_unitario, subtotal,
+      es_bonificacion, promocion_id,
+      neto_unitario, iva_unitario, impuestos_internos_unitario, porcentaje_iva,
+      sucursal_id, descripcion_regalo, stock_al_crear
+    ) VALUES (
+      v_pedido_id, v_producto_id, v_cantidad, v_precio_unitario, v_cantidad * v_precio_unitario,
+      v_es_bonificacion, v_promocion_id,
+      v_neto_unitario, v_iva_unitario, v_imp_internos_unitario, v_porcentaje_iva,
+      v_sucursal, v_descripcion_regalo, v_stock_al_crear
+    );
+
+    IF NOT v_es_bonificacion THEN
+      UPDATE productos SET stock = stock - v_cantidad WHERE id = v_producto_id AND sucursal_id = v_sucursal;
+    ELSIF v_promocion_id IS NOT NULL THEN
+      SELECT regalo_mueve_stock INTO v_regalo_mueve_stock FROM promociones WHERE id = v_promocion_id AND sucursal_id = v_sucursal;
+      IF COALESCE(v_regalo_mueve_stock, FALSE) THEN
+        UPDATE productos SET stock = stock - v_cantidad WHERE id = v_producto_id AND sucursal_id = v_sucursal;
+      END IF;
+    END IF;
+
+    IF v_es_bonificacion AND v_promocion_id IS NOT NULL THEN
+      UPDATE promociones SET usos_pendientes = usos_pendientes + v_cantidad WHERE id = v_promocion_id AND sucursal_id = v_sucursal;
+
+      SELECT id, nombre, ajuste_automatico, ajuste_producto_id, unidades_por_bloque,
+             stock_por_bloque, usos_pendientes
+      INTO v_promo
+      FROM promociones WHERE id = v_promocion_id AND sucursal_id = v_sucursal FOR UPDATE;
+
+      IF v_promo.ajuste_automatico AND v_promo.ajuste_producto_id IS NOT NULL
+         AND COALESCE(v_promo.unidades_por_bloque, 0) > 0 AND COALESCE(v_promo.stock_por_bloque, 0) > 0 THEN
+        v_usos_pendientes_actual := v_promo.usos_pendientes;
+        v_bloques_completos := v_usos_pendientes_actual / v_promo.unidades_por_bloque;
+        IF v_bloques_completos > 0 THEN
+          v_ajustar_usos := v_bloques_completos * v_promo.unidades_por_bloque;
+          v_ajustar_stock := v_bloques_completos * v_promo.stock_por_bloque;
+
+          SELECT stock, nombre INTO v_stock_ajuste_anterior, v_ajuste_producto_nombre
+          FROM productos WHERE id = v_promo.ajuste_producto_id AND sucursal_id = v_sucursal FOR UPDATE;
+
+          IF v_stock_ajuste_anterior IS NULL THEN
+            RAISE EXCEPTION 'Auto-ajuste: producto destino no encontrado (promo %)', v_promocion_id;
+          END IF;
+          IF v_stock_ajuste_anterior < v_ajustar_stock THEN
+            RAISE EXCEPTION 'Auto-ajuste: stock insuficiente en % (disponible: %, requerido: %)',
+              v_ajuste_producto_nombre, v_stock_ajuste_anterior, v_ajustar_stock;
+          END IF;
+
+          v_stock_ajuste_nuevo := v_stock_ajuste_anterior - v_ajustar_stock;
+
+          v_pedidos_bundle := public.pedido_bundle_para_promo(v_promocion_id, v_sucursal, 20);
+          v_observacion := 'Auto-ajuste (Promo: ' || v_promo.nombre
+                           || ', Pedidos: ' || COALESCE(v_pedidos_bundle, '#' || v_pedido_id) || ')';
+
+          INSERT INTO mermas_stock (producto_id, cantidad, motivo, observaciones, stock_anterior, stock_nuevo, usuario_id, sucursal_id)
+          VALUES (v_promo.ajuste_producto_id, v_ajustar_stock, 'promociones', v_observacion,
+            v_stock_ajuste_anterior, v_stock_ajuste_nuevo, p_usuario_id, v_sucursal)
+          RETURNING id INTO v_merma_id;
+
+          UPDATE productos SET stock = v_stock_ajuste_nuevo, updated_at = NOW()
+          WHERE id = v_promo.ajuste_producto_id AND sucursal_id = v_sucursal;
+
+          INSERT INTO promo_ajustes (promocion_id, usos_ajustados, unidades_ajustadas, producto_id, merma_id, usuario_id, observaciones, sucursal_id)
+          VALUES (v_promocion_id, v_ajustar_usos, v_ajustar_stock, v_promo.ajuste_producto_id,
+            v_merma_id, p_usuario_id, v_observacion, v_sucursal);
+
+          UPDATE promociones SET usos_pendientes = GREATEST(usos_pendientes - v_ajustar_usos, 0)
+          WHERE id = v_promocion_id AND sucursal_id = v_sucursal;
+        END IF;
+      END IF;
+    END IF;
+  END LOOP;
+
+  RETURN jsonb_build_object('success', true, 'pedido_id', v_pedido_id);
+END;
+$function$;

--- a/src/components/containers/ClientesContainer.tsx
+++ b/src/components/containers/ClientesContainer.tsx
@@ -43,7 +43,7 @@ interface ConfirmConfig {
 }
 
 export default function ClientesContainer(): React.ReactElement {
-  const { user, isAdmin, isPreventista } = useAuthData()
+  const { user, isAdmin, isPreventista, isEncargado } = useAuthData()
   const notify = useNotification()
 
   // Queries
@@ -187,6 +187,7 @@ export default function ClientesContainer(): React.ReactElement {
           loading={isLoading}
           isAdmin={isAdmin}
           isPreventista={isPreventista}
+          isEncargado={isEncargado}
           onNuevoCliente={handleNuevoCliente}
           onEditarCliente={handleEditarCliente}
           onEliminarCliente={handleEliminarCliente}

--- a/src/components/containers/PedidosContainer.tsx
+++ b/src/components/containers/PedidosContainer.tsx
@@ -7,7 +7,7 @@
  */
 import React, { lazy, Suspense, useState, useCallback, useMemo } from 'react'
 import { calcularNetoVenta } from '../../utils/calculations'
-import { fechaLocalISO, fechaHaceDias } from '../../utils/formatters'
+import { fechaLocalISO, fechaHaceDias, getFormaPagoDisplay } from '../../utils/formatters'
 import { preventistaPuedeEditar } from '../../utils/permisosPedido'
 import { useQueryClient } from '@tanstack/react-query'
 import { Loader2 } from 'lucide-react'
@@ -420,8 +420,8 @@ export default function PedidosContainer(): React.ReactElement {
   const fetchAllFilteredPedidos = useCallback(async (): Promise<PedidoDB[]> => {
     const hasSearch = debouncedBusqueda && debouncedBusqueda.trim().length > 0
     const selectStr = hasSearch
-      ? '*, cliente:clientes!inner(*), items:pedido_items(*, producto:productos(*))'
-      : '*, cliente:clientes(*), items:pedido_items(*, producto:productos(*))'
+      ? '*, cliente:clientes!inner(*), items:pedido_items(*, producto:productos(*)), pagos(forma_pago, monto)'
+      : '*, cliente:clientes(*), items:pedido_items(*, producto:productos(*)), pagos(forma_pago, monto)'
 
     let query = supabase
       .from('pedidos')
@@ -483,7 +483,7 @@ export default function PedidosContainer(): React.ReactElement {
         Direccion: (p.cliente as { direccion?: string })?.direccion || '',
         Telefono: (p.cliente as { telefono?: string })?.telefono || '',
         Estado: p.estado,
-        'Forma Pago': p.forma_pago || '',
+        'Forma Pago': getFormaPagoDisplay(p as { forma_pago?: string | null; pagos?: Array<{ forma_pago: string }> }),
         'Estado Pago': p.estado_pago || '',
         Total: p.total,
         'Monto Pagado': p.monto_pagado || 0,

--- a/src/components/vistas/VistaClientes.tsx
+++ b/src/components/vistas/VistaClientes.tsx
@@ -21,6 +21,7 @@ export interface VistaClientesProps {
   loading: boolean;
   isAdmin: boolean;
   isPreventista: boolean;
+  isEncargado: boolean;
   onNuevoCliente: () => void;
   onEditarCliente: (cliente: ClienteDB) => void;
   onEliminarCliente: (id: string) => void;
@@ -34,6 +35,7 @@ export default function VistaClientes({
   loading,
   isAdmin,
   isPreventista,
+  isEncargado,
   onNuevoCliente,
   onEditarCliente,
   onEliminarCliente,
@@ -122,7 +124,7 @@ export default function VistaClientes({
               <span>Gestionar Zonas</span>
             </button>
           )}
-          {(isAdmin || isPreventista) && (
+          {(isAdmin || isPreventista || isEncargado) && (
             <button
               onClick={onNuevoCliente}
               className="flex items-center space-x-2 px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors"

--- a/src/hooks/supabase/useBackup.ts
+++ b/src/hooks/supabase/useBackup.ts
@@ -1,7 +1,7 @@
 import { useState } from 'react'
 
 import { supabase } from './base'
-import { fechaLocalISO } from '../../utils/formatters'
+import { fechaLocalISO, getFormaPagoDisplay } from '../../utils/formatters'
 import type {
   BackupData,
   FiltrosExportacion,
@@ -32,6 +32,7 @@ interface PedidoExportacion {
     subtotal?: number;
     producto?: ProductoDB | null;
   }>;
+  pagos?: Array<{ forma_pago: string; monto: number }>;
 }
 
 interface InfoFiltro {
@@ -101,7 +102,7 @@ export function useBackup(): UseBackupReturnExtended {
         backup.productos = (data || []) as ProductoDB[]
       }
       if (tipo === 'completo' || tipo === 'pedidos') {
-        const { data } = await supabase.from('pedidos').select(`*, cliente:clientes(*), items:pedido_items(*, producto:productos(*))`)
+        const { data } = await supabase.from('pedidos').select(`*, cliente:clientes(*), items:pedido_items(*, producto:productos(*)), pagos(forma_pago, monto)`)
         backup.pedidos = (data || []) as PedidoDB[]
       }
       return backup
@@ -139,14 +140,6 @@ export function useBackup(): UseBackupReturnExtended {
         parcial: 'Parcial',
         pagado: 'Pagado'
       }
-      const formaPagoLabels: Record<string, string> = {
-        efectivo: 'Efectivo',
-        transferencia: 'Transferencia',
-        cheque: 'Cheque',
-        cuenta_corriente: 'Cuenta Corriente',
-        tarjeta: 'Tarjeta'
-      }
-
       const getTransportistaNombre = (id: string | null | undefined): string | null => {
         if (!id || id === 'todos') return null
         if (id === 'sin_asignar') return 'Sin asignar'
@@ -200,7 +193,7 @@ export function useBackup(): UseBackupReturnExtended {
         'Zona': p.cliente?.zona || '-',
         'Estado Pedido': estadoLabels[p.estado] || p.estado,
         'Estado Pago': estadoPagoLabels[p.estado_pago || ''] || p.estado_pago || 'Pendiente',
-        'Forma de Pago': formaPagoLabels[p.forma_pago || ''] || p.forma_pago || 'Efectivo',
+        'Forma de Pago': getFormaPagoDisplay(p),
         'Transportista': p.transportista?.nombre || 'Sin asignar',
         'Preventista': p.usuario?.nombre || '-',
         'Productos': p.items?.map(i => `${i.producto?.nombre || 'Producto'} x${i.cantidad}`).join(', ') || '-',

--- a/src/lib/permisos.ts
+++ b/src/lib/permisos.ts
@@ -55,6 +55,14 @@ export function puedeAccederGeolocalizacion(rol: RolUsuario | null | undefined):
   return rol === 'admin'
 }
 
+export function puedeCrearCliente(rol: RolUsuario | null | undefined): boolean {
+  return rol === 'admin' || rol === 'preventista' || rol === 'encargado'
+}
+
+export function puedeCrearPedido(rol: RolUsuario | null | undefined): boolean {
+  return rol === 'admin' || rol === 'preventista' || rol === 'encargado'
+}
+
 export type PedidoStatKey =
   | 'pendientes'
   | 'enPreparacion'


### PR DESCRIPTION
## Summary

- **Rol encargado**: restaura la capacidad de crear clientes y pedidos.
  - `crear_pedido_completo` agrega `'encargado'` a los roles permitidos (consistente con `_bot` y las RPCs de edición que ya lo aceptaban). Migración 044 ya aplicada en Supabase prod.
  - `VistaClientes` ahora muestra el botón "Nuevo Cliente" al encargado (la RLS de `clientes` vía `es_preventista()` ya lo permitía).
  - Nuevos helpers `puedeCrearCliente` / `puedeCrearPedido` en `permisos.ts` para documentar el contrato.
- **Bug "todo Efectivo" en export Excel**: reemplaza la lectura del campo stale `pedidos.forma_pago` por `getFormaPagoDisplay()` (que ya existía para la PedidoCard). Deriva la forma real desde la tabla `pagos`, incluyendo "Combinado" para pagos mixtos. Afecta a `PedidosContainer.handleExportarExcel` y `useBackup.exportarPedidosExcel`; ambos SELECTs ahora incluyen `pagos(forma_pago, monto)`.

## Test plan

- [x] `npm run typecheck` limpio
- [x] `npm run lint` limpio
- [x] `npm run test:run` — 631 tests passing
- [x] Migración 044 aplicada a Supabase ManaosApp (`hmuchlzmuqqxcldbzkgc`) — `{"success":true}`
- [ ] Login como encargado: crear cliente desde `/clientes` → guarda OK
- [ ] Login como encargado: crear pedido desde `/pedidos` → guarda OK (antes "No tiene permisos")
- [ ] Export Excel sobre pedido con forma_pago original = `transferencia` pero pago registrado en efectivo → columna "Forma Pago" muestra "Efectivo"
- [ ] Export Excel sobre pedido con pago combinado (efectivo + transferencia) → columna "Forma Pago" muestra "Combinado"
- [ ] Login como admin/preventista: flujos previos siguen funcionando

🤖 Generated with [Claude Code](https://claude.com/claude-code)