### PR TITLE
fix(cliente): renombrar 'Razon Social' y alinear asteriscos al schema

### DIFF
--- a/src/components/modals/ModalCliente.tsx
+++ b/src/components/modals/ModalCliente.tsx
@@ -299,7 +299,7 @@ const ModalCliente = memo(function ModalCliente({ cliente, onSave, onClose, guar
           </div>
           <div>
             <label htmlFor="numero_documento" className="block text-sm font-medium mb-1 dark:text-gray-200">
-              {form.tipo_documento === 'CUIT' ? 'CUIT' : 'DNI'} *
+              {form.tipo_documento === 'CUIT' ? 'CUIT' : 'DNI'}
             </label>
             <input
               id="numero_documento"
@@ -314,7 +314,7 @@ const ModalCliente = memo(function ModalCliente({ cliente, onSave, onClose, guar
             {errores.numero_documento && <p {...getErrorMessageProps('numero_documento')} className="text-red-500 text-xs mt-1">{errores.numero_documento}</p>}
           </div>
           <div>
-            <label htmlFor="razonSocial" className="block text-sm font-medium mb-1 dark:text-gray-200">Razón Social *</label>
+            <label htmlFor="razonSocial" className="block text-sm font-medium mb-1 dark:text-gray-200">Razón social/Nombre Cliente *</label>
             <input
               id="razonSocial"
               type="text"

--- a/src/components/modals/ModalPedido.tsx
+++ b/src/components/modals/ModalPedido.tsx
@@ -258,7 +258,7 @@ const ModalPedido = memo(function ModalPedido({
                   onSelect={(result) => {
                     setNuevoCliente(prev => ({ ...prev, direccion: result.direccion, latitud: result.latitud, longitud: result.longitud }));
                   }}
-                  placeholder="Buscar dirección..."
+                  placeholder="Buscar dirección... *"
                 />
                 {nuevoCliente.latitud && nuevoCliente.longitud && (
                   <div className="flex items-center text-xs text-green-600 bg-green-50 dark:bg-green-900/20 px-3 py-2 rounded-lg">


### PR DESCRIPTION
## Summary

Tres ajustes chicos en formularios de cliente para reducir errores de carga de los preventistas:

- **Rename label**: en [`ModalCliente.tsx:317`](src/components/modals/ModalCliente.tsx#L317) el label `Razón Social *` pasa a `Razón social/Nombre Cliente *`. Los preventistas no entendian "Razón Social" y a veces lo dejaban vacio o duplicaban la calle en ambos campos.
- **Quitar asterisco enganoso**: en [`ModalCliente.tsx:301-303`](src/components/modals/ModalCliente.tsx#L301) el label CUIT/DNI deja de tener `*`. `modalClienteSchema` permite `numero_documento` vacio ([`schemas.ts:518-525`](src/lib/schemas.ts#L518)), asi que el asterisco no reflejaba la realidad.
- **Sumar asterisco que faltaba**: en [`ModalPedido.tsx:261`](src/components/modals/ModalPedido.tsx#L261) el placeholder de la direccion del cliente rapido pasa a `Buscar dirección... *`. El handler `handleCrearClienteRapido` ya rechaza si esta vacia, asi que el `*` ahora coincide con el comportamiento.

### Que NO cambio

Audite el resto de los `*` en ambos modales contra el schema real (`modalClienteSchema` para el modal full, validacion inline para el quick-create):

- `Tipo Doc. *`, `Nombre Fantasía *`, `Dirección *` (full): coinciden con schema.
- `Nombre fantasia *`, `Nombre completo *` (quick-create placeholders): coinciden con la validacion inline.
- Zona en el modal full: schema la marca opcional, sin `*` en UI. Consistente.

## Test plan

- [x] `npx tsc --noEmit` limpio.
- [x] Suite completa (39 archivos, 631 tests) verde en el pre-commit hook.
- [ ] Smoke en UI: como preventista, abrir "Nuevo Cliente" desde la pantalla de clientes y confirmar el nuevo label.
- [ ] Smoke en UI: como preventista, abrir un pedido nuevo, "+ Nuevo" cliente, confirmar que la direccion muestra `*` en el placeholder.
- [ ] Smoke en UI: confirmar que CUIT/DNI ya no muestra `*`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)