### PR TITLE
feat(export): mostrar razon social en comanda y hoja de ruta

### DIFF
--- a/src/lib/pdf/hojaRutaOptimizada.js
+++ b/src/lib/pdf/hojaRutaOptimizada.js
@@ -99,6 +99,16 @@ function buildCardOps(doc, pedido, orderNumber) {
     ops.push({ kind: 'text', text: line, fontSize: 11, bold: true, advance: 5 })
   })
 
+  // Razon social en linea aparte si existe y difiere del nombre de fantasia
+  if (pedido.cliente?.razon_social && pedido.cliente.razon_social !== pedido.cliente.nombre_fantasia) {
+    doc.setFont('helvetica', 'normal')
+    doc.setFontSize(9)
+    const razonLines = doc.splitTextToSize(pedido.cliente.razon_social, CARD_CONTENT_WIDTH)
+    razonLines.slice(0, 2).forEach((line) => {
+      ops.push({ kind: 'text', text: line, fontSize: 9, bold: false, advance: 4 })
+    })
+  }
+
   // Direccion
   if (pedido.cliente?.direccion) {
     doc.setFont('helvetica', 'normal')

--- a/src/lib/pdf/reciboPedido.js
+++ b/src/lib/pdf/reciboPedido.js
@@ -357,6 +357,13 @@ function dibujarComanda(doc, pedido) {
   doc.text(pedido.cliente?.nombre_fantasia || 'Cliente', margin, y)
   y += 5
   setNormalStyle(doc, 9)
+  if (pedido.cliente?.razon_social && pedido.cliente.razon_social !== pedido.cliente.nombre_fantasia) {
+    const razonLines = doc.splitTextToSize(pedido.cliente.razon_social, contentWidth)
+    razonLines.slice(0, 2).forEach(line => {
+      doc.text(line, margin, y)
+      y += 4
+    })
+  }
   if (pedido.cliente?.direccion) {
     const dirLines = doc.splitTextToSize(pedido.cliente.direccion, contentWidth)
     dirLines.slice(0, 2).forEach(line => {


### PR DESCRIPTION
## Summary

Cuando un cliente tiene `razon_social` distinta del `nombre_fantasia`, los exports de **Comanda** y **Hoja de Ruta** ahora muestran ambos en dos lineas separadas — fantasia en grande + razon_social en linea aparte mas chica, mismo tamano que la direccion. Si solo hay uno, o ambos coinciden, el output queda igual que antes.

- [`reciboPedido.js`](src/lib/pdf/reciboPedido.js) (dibujarComanda) — inserta razon_social entre el nombre de fantasia y la direccion.
- [`hojaRutaOptimizada.js`](src/lib/pdf/hojaRutaOptimizada.js) (buildCardOps) — agrega ops al builder, asi el dry-run de medicion de altura de la card ya incluye la linea extra (no se rompe el calculo de cuantas cards entran por pagina).

Replica el patron que ya usaba el A4 recibo (`dibujarReciboPagina`, L112-115) para mantener consistencia visual entre los tres documentos.

## Test plan

- [x] `npx tsc --noEmit` limpio.
- [x] Suite completa (39 archivos, 631 tests) verde en el pre-commit hook.
- [ ] Smoke en UI: imprimir una comanda de un cliente con razon_social y fantasia distintos — debe aparecer fantasia arriba (negrita 12pt) y razon_social abajo (normal 9pt).
- [ ] Smoke en UI: exportar hoja de ruta con un transportista; verificar que ninguna card se corta y que las que tienen razon_social distinta muestran la linea extra.
- [ ] Smoke en UI: imprimir/exportar un cliente donde razon_social == fantasia (o uno vacio) — el output no debe duplicar la linea.

🤖 Generated with [Claude Code](https://claude.com/claude-code)