### PR TITLE
fix(security): habilitar RLS en bot_pedidos_pendientes

### DIFF
--- a/migrations/047_enable_rls_bot_pedidos_pendientes.sql
+++ b/migrations/047_enable_rls_bot_pedidos_pendientes.sql
@@ -1,0 +1,34 @@
+-- ============================================================================
+-- 047 — Habilitar RLS en bot_pedidos_pendientes
+-- ============================================================================
+-- Cierra el alerta CRITICAL del Supabase Advisor (rls_disabled_in_public)
+-- sobre la unica tabla del schema public que estaba expuesta sin RLS.
+--
+-- La tabla es un buffer efimero del bot Telegram: la edge function inserta
+-- un pedido tentativo (perfil_id, cliente_id, items, totales) con TTL 10
+-- min y luego lo consume cuando el preventista confirma desde el chat.
+--
+-- Quien la accede:
+--   - Edge function "telegram-webhook" (supabase/functions): usa el cliente
+--     service_role (getServiceRoleClient) tanto para INSERT (en
+--     previsualizar_pedido.ts) como para UPDATE (handlers.ts L913-918,
+--     callback Cancelar). service_role tiene BYPASSRLS → no afectado.
+--   - RPC public.crear_pedido_completo_bot: SECURITY DEFINER → corre como
+--     dueno de la funcion (postgres), no afectado por RLS.
+--   - Frontend / supabase-js como anon o authenticated: NUNCA debe leer
+--     ni escribir esta tabla. Hoy estaba abierta, lo cual era el bug.
+--
+-- Estrategia: ENABLE RLS sin agregar policies. Por default, sin policy
+-- los roles anon y authenticated quedan denegados; service_role y
+-- SECURITY DEFINER funcs conservan su acceso normal. Es exactamente lo
+-- que queremos.
+--
+-- (El Supabase Advisor puede listar la tabla en el lint INFO
+-- "rls_enabled_no_policy" — eso es ruido informativo, no vulnerabilidad.
+-- Documentamos la intencion en el COMMENT abajo.)
+-- ============================================================================
+
+ALTER TABLE public.bot_pedidos_pendientes ENABLE ROW LEVEL SECURITY;
+
+COMMENT ON TABLE public.bot_pedidos_pendientes IS
+  'Buffer efimero del bot Telegram (TTL 10 min). Solo accesible via service_role (edge function) y SECURITY DEFINER RPCs (crear_pedido_completo_bot). RLS habilitado sin policies intencionalmente — anon/authenticated no deben verla.';


### PR DESCRIPTION
## Summary

Cierra el unico alerta **CRITICAL** del Supabase Advisor (`rls_disabled_in_public`) que disparo el mail de seguridad. Era la unica tabla en `public` con RLS desactivado.

`bot_pedidos_pendientes` es un buffer efimero del bot Telegram (TTL 10 min). La operan solo:

- **Edge function** `telegram-webhook` via `getServiceRoleClient()` ([handlers.ts:913-918](supabase/functions/telegram-webhook/handlers.ts#L913) para UPDATE consumido / [previsualizar_pedido.ts:333-344](supabase/functions/_shared/tools/preventista/previsualizar_pedido.ts#L333) para INSERT). `service_role` tiene `BYPASSRLS` → no le afecta.
- **RPC SECURITY DEFINER** `public.crear_pedido_completo_bot` → corre como dueno, tampoco le afecta.
- **Frontend / supabase-js como anon o authenticated** → nunca debe verla. Hoy estaba abierta, eso era el bug.

`ENABLE ROW LEVEL SECURITY` **sin policies** bloquea exactamente anon y authenticated, manteniendo intacto el flow del bot.

## Estado post-aplicacion

Migracion ya aplicada en Supabase prod (`hmuchlzmuqqxcldbzkgc`). Verificacion:

- `pg_tables.rowsecurity = true, policies = 0` en `bot_pedidos_pendientes` (intencional).
- Query `SELECT * FROM pg_tables WHERE schemaname='public' AND rowsecurity=false` → 0 filas.
- Suite del repo (40 archivos, 641 tests) verde en el pre-commit hook.

## Sobre el segundo mail de Supabase (rollout 30/may - 30/oct)

No es vulnerabilidad ni se aborda en este PR. Las tablas existentes mantienen sus GRANT. Cambio cosmetico para tablas **nuevas** a partir de oct/2026: deberan incluir `GRANT ... TO anon, authenticated, service_role` en la migracion. Conviene agregarlo como convencion al `migrations/README.md` en un PR aparte cuando arme la limpieza de los warnings restantes del advisor (4 `function_search_path_mutable` + `extension_in_public` + `auth_leaked_password_protection`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)