### PR TITLE
feat(pedidos): badge de usuario que cargó el pedido en PedidoCard

### DIFF
--- a/src/components/pedidos/PedidoCard.tsx
+++ b/src/components/pedidos/PedidoCard.tsx
@@ -271,6 +271,12 @@ function PedidoCard({
               </p>
             </div>
           </div>
+          {pedido.usuario?.nombre && (
+            <div className="mt-2 inline-flex items-center px-2 py-1 bg-purple-100 text-purple-700 dark:bg-purple-900/30 dark:text-purple-300 rounded-full text-sm" title="Pedido cargado por">
+              <User className="w-4 h-4 mr-1" />
+              Cargado por {pedido.usuario.nombre}
+            </div>
+          )}
           {pedido.transportista && (
             <div className="mt-2 inline-flex items-center px-2 py-1 bg-orange-100 text-orange-700 rounded-full text-sm">
               <Truck className="w-4 h-4 mr-1" />


### PR DESCRIPTION
## Summary

Agrega una etiqueta visible en cada tarjeta de pedido (`PedidoCard`) que muestra el nombre del usuario que cargó el pedido, con el formato "Cargado por <nombre>". Se posiciona antes del badge del transportista para hacer evidente la atribución del pedido al admin/preventista/encargado que lo creó.

## Files

- `src/components/pedidos/PedidoCard.tsx` — bloque condicional `pedido.usuario?.nombre` con badge violeta + ícono `User`.

## Notas

- El dato `pedido.usuario` ya viene hidratado desde [usePedidosQuery.ts:151](https://github.com/AgustinReiden/distribuidora-app/blob/main/src/hooks/queries/usePedidosQuery.ts) via `perfilesMap[pedido.usuario_id]`, así que no requiere cambios en queries ni tipos (`PedidoDB.usuario?: PerfilDB | null` ya existe).
- Se muestra a todos los roles (admin, preventista, transportista, encargado). Si después se quiere restringir, se agrega un guard de rol en el render.
- El ícono `User` de `lucide-react` ya estaba importado.

## Test plan

- [ ] Abrir Vista Pedidos como admin → cada tarjeta muestra "Cargado por <nombre>" en una badge violeta.
- [ ] Verificar dark mode: badge legible (bg `purple-900/30`, text `purple-300`).
- [ ] Verificar pedidos cargados por distintos roles (admin, preventista, encargado, bot) → todos muestran el nombre del usuario correspondiente.
- [ ] Pedido sin `usuario_id` (legacy si los hay) → badge no se renderiza (no rompe layout).
- [ ] Pedido con transportista asignado → ambas badges aparecen apiladas (usuario primero, transportista debajo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)