### PR TITLE
fix(salvedades): idempotencia + retry para Load failed en iOS PWA

### DIFF
--- a/migrations/049_registrar_salvedad_idempotente.sql
+++ b/migrations/049_registrar_salvedad_idempotente.sql
@@ -1,0 +1,297 @@
+-- ============================================================================
+-- 049 — registrar_salvedad: idempotencia via client_request_id
+-- ============================================================================
+-- Motivo: una admin reporta "TypeError: Load failed" al confirmar una salvedad
+-- desde iOS PWA. El error proviene del fetch del navegador (no del RPC). Si la
+-- request llega al server pero la respuesta no llega al cliente, un retry
+-- "ingenuo" desde el frontend crearia salvedades duplicadas.
+--
+-- Fix: aceptar un UUID `p_client_request_id` que identifica univocamente cada
+-- intento del cliente. La primera llamada con un UUID crea la salvedad y lo
+-- guarda; llamadas subsecuentes con el mismo UUID retornan el resultado
+-- existente sin crear duplicado (short-circuit antes de cualquier validacion).
+--
+-- Backwards-compatible: si el caller no pasa el UUID (DEFAULT NULL), se ejecuta
+-- el flujo original (validar, crear, resincronizar promociones, recalcular).
+-- ============================================================================
+
+ALTER TABLE public.salvedades_items
+  ADD COLUMN IF NOT EXISTS client_request_id UUID;
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_salvedades_items_client_request_id
+  ON public.salvedades_items (client_request_id)
+  WHERE client_request_id IS NOT NULL;
+
+COMMENT ON COLUMN public.salvedades_items.client_request_id IS
+  'UUID generado por el cliente para deduplicar reintentos de registrar_salvedad. NULL en filas previas a la migracion 049.';
+
+-- ============================================================================
+-- registrar_salvedad con idempotencia
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION public.registrar_salvedad(
+  p_pedido_id         BIGINT,
+  p_pedido_item_id    BIGINT,
+  p_cantidad_afectada INTEGER,
+  p_motivo            CHARACTER VARYING,
+  p_descripcion       TEXT    DEFAULT NULL,
+  p_foto_url          TEXT    DEFAULT NULL,
+  p_devolver_stock    BOOLEAN DEFAULT TRUE,
+  p_client_request_id UUID    DEFAULT NULL
+) RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $$
+DECLARE
+  v_sucursal           BIGINT := current_sucursal_id();
+  v_salvedad_id        BIGINT;
+  v_item               RECORD;
+  v_existing           RECORD;
+  v_cantidad_entregada INTEGER;
+  v_monto_afectado     DECIMAL;
+  v_usuario_id         UUID;
+  v_es_admin           BOOLEAN;
+  v_subtotal_nuevo     DECIMAL;
+  v_stock_devuelto     BOOLEAN := FALSE;
+  v_merma_registrada   BOOLEAN := FALSE;
+  v_stock_actual       INTEGER;
+  v_bonif              RECORD;
+  v_cant_compra        INT;
+  v_cant_bonif         INT;
+  v_total_qty          INT;
+  v_bloques            INT;
+  v_expected_bonif     INT;
+  v_diff               INT;
+  v_regalo_mueve_stock BOOLEAN;
+BEGIN
+  -- =====================================================================
+  -- 0) Idempotencia: si recibimos un client_request_id y ya existe una
+  --    salvedad con ese UUID, retornar el resultado de la creacion original
+  --    sin re-ejecutar nada.
+  -- =====================================================================
+  IF p_client_request_id IS NOT NULL THEN
+    SELECT id, motivo, monto_afectado, cantidad_entregada, stock_devuelto,
+           pedido_id
+      INTO v_existing
+      FROM salvedades_items
+     WHERE client_request_id = p_client_request_id;
+
+    IF FOUND THEN
+      RETURN jsonb_build_object(
+        'success', true,
+        'salvedad_id', v_existing.id,
+        'monto_afectado', v_existing.monto_afectado,
+        'cantidad_entregada', v_existing.cantidad_entregada,
+        'stock_devuelto', v_existing.stock_devuelto,
+        'merma_registrada', v_existing.motivo IN ('producto_danado', 'producto_vencido'),
+        'nuevo_total_pedido', (
+          SELECT total FROM pedidos
+           WHERE id = v_existing.pedido_id AND sucursal_id = v_sucursal
+        ),
+        'idempotent_replay', true
+      );
+    END IF;
+  END IF;
+
+  IF v_sucursal IS NULL THEN
+    RETURN jsonb_build_object('success', false, 'error', 'No se pudo determinar la sucursal activa');
+  END IF;
+
+  v_usuario_id := auth.uid();
+  IF v_usuario_id IS NULL THEN
+    RETURN jsonb_build_object('success', false, 'error', 'Usuario no autenticado');
+  END IF;
+
+  SELECT EXISTS (SELECT 1 FROM perfiles WHERE id = v_usuario_id AND rol = 'admin') INTO v_es_admin;
+  IF NOT v_es_admin THEN
+    IF NOT EXISTS (
+      SELECT 1 FROM pedidos
+       WHERE id = p_pedido_id AND transportista_id = v_usuario_id AND sucursal_id = v_sucursal
+    ) THEN
+      RETURN jsonb_build_object('success', false, 'error', 'No autorizado para este pedido');
+    END IF;
+  END IF;
+
+  SELECT pi.id, pi.producto_id, pi.cantidad, pi.precio_unitario, pi.subtotal
+    INTO v_item
+    FROM pedido_items pi
+   WHERE pi.id = p_pedido_item_id
+     AND pi.pedido_id = p_pedido_id
+     AND pi.sucursal_id = v_sucursal;
+
+  IF NOT FOUND THEN
+    RETURN jsonb_build_object('success', false, 'error', 'Item de pedido no encontrado');
+  END IF;
+
+  IF p_cantidad_afectada > v_item.cantidad THEN
+    RETURN jsonb_build_object('success', false, 'error', 'Cantidad afectada mayor a cantidad del item');
+  END IF;
+  IF p_cantidad_afectada <= 0 THEN
+    RETURN jsonb_build_object('success', false, 'error', 'Cantidad debe ser mayor a 0');
+  END IF;
+
+  v_cantidad_entregada := v_item.cantidad - p_cantidad_afectada;
+  v_monto_afectado     := p_cantidad_afectada * v_item.precio_unitario;
+  v_subtotal_nuevo     := v_cantidad_entregada * v_item.precio_unitario;
+
+  IF p_motivo IN ('cliente_rechaza', 'error_pedido', 'diferencia_precio') THEN
+    v_stock_devuelto := TRUE;
+  END IF;
+
+  -- Contexto para trigger registrar_cambio_stock (mig 038): que cualquier
+  -- UPDATE de productos.stock generado por esta salvedad quede trazable.
+  PERFORM set_config('app.stock_origen', 'salvedad', true);
+  PERFORM set_config('app.stock_ref_tipo', 'pedido', true);
+  PERFORM set_config('app.stock_ref_id', p_pedido_id::TEXT, true);
+  PERFORM set_config('app.stock_user_id', v_usuario_id::TEXT, true);
+
+  INSERT INTO salvedades_items (
+    pedido_id, pedido_item_id, producto_id, cantidad_original, cantidad_afectada,
+    cantidad_entregada, motivo, descripcion, foto_url, monto_afectado, precio_unitario,
+    reportado_por, stock_devuelto, stock_devuelto_at, estado_resolucion, sucursal_id,
+    client_request_id
+  ) VALUES (
+    p_pedido_id, p_pedido_item_id, v_item.producto_id, v_item.cantidad, p_cantidad_afectada,
+    v_cantidad_entregada, p_motivo, p_descripcion, p_foto_url, v_monto_afectado, v_item.precio_unitario,
+    v_usuario_id, v_stock_devuelto, CASE WHEN v_stock_devuelto THEN NOW() ELSE NULL END, 'pendiente', v_sucursal,
+    p_client_request_id
+  ) RETURNING id INTO v_salvedad_id;
+
+  IF v_salvedad_id IS NULL THEN
+    RAISE EXCEPTION 'No se pudo crear la salvedad';
+  END IF;
+
+  IF v_cantidad_entregada > 0 THEN
+    UPDATE pedido_items
+       SET cantidad = v_cantidad_entregada,
+           subtotal = v_subtotal_nuevo
+     WHERE id = p_pedido_item_id AND sucursal_id = v_sucursal;
+  ELSE
+    DELETE FROM pedido_items
+     WHERE id = p_pedido_item_id AND sucursal_id = v_sucursal;
+  END IF;
+
+  -- Resincronizar bonificaciones tras la salvedad (igual que en mig 010).
+  FOR v_bonif IN
+    SELECT pi.id, pi.producto_id, pi.cantidad, pi.promocion_id
+      FROM pedido_items pi
+     WHERE pi.pedido_id = p_pedido_id
+       AND pi.sucursal_id = v_sucursal
+       AND COALESCE(pi.es_bonificacion, FALSE) = TRUE
+       AND pi.promocion_id IS NOT NULL
+  LOOP
+    SELECT
+      MAX(CASE WHEN pr.clave = 'cantidad_compra'       THEN pr.valor END)::INT,
+      MAX(CASE WHEN pr.clave = 'cantidad_bonificacion' THEN pr.valor END)::INT,
+      MAX(p.regalo_mueve_stock::INT)::BOOLEAN
+    INTO v_cant_compra, v_cant_bonif, v_regalo_mueve_stock
+    FROM promociones p
+    LEFT JOIN promocion_reglas pr
+      ON pr.promocion_id = p.id
+    WHERE p.id = v_bonif.promocion_id
+      AND p.sucursal_id = v_sucursal
+    GROUP BY p.id;
+
+    IF v_cant_compra IS NULL OR v_cant_compra <= 0
+       OR v_cant_bonif IS NULL OR v_cant_bonif <= 0 THEN
+      CONTINUE;
+    END IF;
+
+    SELECT COALESCE(SUM(pi.cantidad), 0)::INT
+      INTO v_total_qty
+      FROM pedido_items pi
+      JOIN promocion_productos pp
+        ON pp.producto_id = pi.producto_id
+       AND pp.promocion_id = v_bonif.promocion_id
+     WHERE pi.pedido_id = p_pedido_id
+       AND pi.sucursal_id = v_sucursal
+       AND COALESCE(pi.es_bonificacion, FALSE) = FALSE;
+
+    v_bloques        := v_total_qty / v_cant_compra;
+    v_expected_bonif := v_bloques * v_cant_bonif;
+
+    IF v_expected_bonif < v_bonif.cantidad THEN
+      v_diff := v_bonif.cantidad - v_expected_bonif;
+
+      IF COALESCE(v_regalo_mueve_stock, FALSE) THEN
+        UPDATE productos
+           SET stock = stock + v_diff
+         WHERE id = v_bonif.producto_id
+           AND sucursal_id = v_sucursal;
+      END IF;
+
+      UPDATE promociones
+         SET usos_pendientes = GREATEST(COALESCE(usos_pendientes, 0) - v_diff, 0)
+       WHERE id = v_bonif.promocion_id
+         AND sucursal_id = v_sucursal;
+
+      IF v_expected_bonif = 0 THEN
+        DELETE FROM pedido_items WHERE id = v_bonif.id;
+      ELSE
+        UPDATE pedido_items
+           SET cantidad = v_expected_bonif,
+               subtotal = v_expected_bonif * COALESCE(precio_unitario, 0)
+         WHERE id = v_bonif.id;
+      END IF;
+    END IF;
+  END LOOP;
+
+  -- Recalcular total del pedido tras limpieza de bonificaciones.
+  UPDATE pedidos
+     SET total = (
+           SELECT COALESCE(SUM(subtotal), 0)
+             FROM pedido_items
+            WHERE pedido_id = p_pedido_id
+              AND sucursal_id = v_sucursal
+         ),
+         updated_at = NOW()
+   WHERE id = p_pedido_id AND sucursal_id = v_sucursal;
+
+  IF v_stock_devuelto THEN
+    UPDATE productos
+       SET stock = stock + p_cantidad_afectada
+     WHERE id = v_item.producto_id AND sucursal_id = v_sucursal;
+  END IF;
+
+  IF p_motivo IN ('producto_danado', 'producto_vencido') THEN
+    SELECT stock INTO v_stock_actual
+      FROM productos
+     WHERE id = v_item.producto_id AND sucursal_id = v_sucursal
+     FOR UPDATE;
+
+    INSERT INTO mermas_stock (
+      producto_id, cantidad, motivo, observaciones,
+      stock_anterior, stock_nuevo, usuario_id, sucursal_id
+    ) VALUES (
+      v_item.producto_id, p_cantidad_afectada,
+      CASE p_motivo WHEN 'producto_danado' THEN 'rotura' WHEN 'producto_vencido' THEN 'vencimiento' END,
+      COALESCE(p_descripcion, 'Salvedad pedido #' || p_pedido_id || ': ' || p_motivo),
+      v_stock_actual, GREATEST(v_stock_actual - p_cantidad_afectada, 0), v_usuario_id, v_sucursal
+    );
+
+    UPDATE productos
+       SET stock = GREATEST(stock - p_cantidad_afectada, 0)
+     WHERE id = v_item.producto_id AND sucursal_id = v_sucursal;
+
+    v_merma_registrada := TRUE;
+  END IF;
+
+  INSERT INTO salvedad_historial (salvedad_id, accion, estado_nuevo, notas, usuario_id, sucursal_id)
+  VALUES (v_salvedad_id, 'creacion', 'pendiente', p_descripcion, v_usuario_id, v_sucursal);
+
+  RETURN jsonb_build_object(
+    'success', true,
+    'salvedad_id', v_salvedad_id,
+    'monto_afectado', v_monto_afectado,
+    'cantidad_entregada', v_cantidad_entregada,
+    'stock_devuelto', v_stock_devuelto,
+    'merma_registrada', v_merma_registrada,
+    'nuevo_total_pedido', (
+      SELECT total FROM pedidos WHERE id = p_pedido_id AND sucursal_id = v_sucursal
+    )
+  );
+EXCEPTION WHEN OTHERS THEN
+  RETURN jsonb_build_object('success', false, 'error', SQLERRM);
+END;
+$$;

--- a/src/components/containers/PedidosContainer.tsx
+++ b/src/components/containers/PedidosContainer.tsx
@@ -35,6 +35,7 @@ import { useDebounce } from '../../hooks/useAsync'
 import { useRegistrarGeolocalizacionPedido } from '../../hooks/useRegistrarGeolocalizacionPedido'
 import { supabase } from '../../hooks/supabase/base'
 import { usePagos } from '../../hooks/supabase/usePagos'
+import { retryWithBackoff, isTransientNetworkError } from '../../utils/retryWithBackoff'
 import type { PedidoDB, FiltrosPedidosState, PerfilDB, RegistrarSalvedadInput, RegistrarSalvedadResult, PagoDBWithUsuario } from '../../types'
 import type { PedidoEditItem } from '../modals/ModalEditarPedido'
 
@@ -853,26 +854,56 @@ export default function PedidosContainer(): React.ReactElement {
   }, [notify])
 
   // ModalEntregaConSalvedad handlers
+  // Idempotente via client_request_id (mig 049): un UUID por salvedad persiste
+  // entre reintentos. El RPC short-circuit si ya creo la salvedad con ese UUID.
+  // Retry automatico con backoff cubre "TypeError: Load failed" (iOS Safari /
+  // PWA) y otros errores transient de red sin riesgo de duplicar.
   const handleSaveSalvedades = useCallback(async (salvedades: RegistrarSalvedadInput[]): Promise<RegistrarSalvedadResult[]> => {
     const results: RegistrarSalvedadResult[] = []
     for (const salvedad of salvedades) {
-      const { data, error } = await supabase.rpc('registrar_salvedad', {
-        p_pedido_id: parseInt(String(salvedad.pedidoId), 10),
-        p_pedido_item_id: parseInt(String(salvedad.pedidoItemId), 10),
-        p_cantidad_afectada: salvedad.cantidadAfectada,
-        p_motivo: salvedad.motivo,
-        p_descripcion: salvedad.descripcion || null,
-        p_foto_url: salvedad.fotoUrl || null,
-        p_devolver_stock: salvedad.devolverStock !== false
-      })
-      if (error) {
-        results.push({ success: false, error: error.message })
-      } else {
-        const result = data as Record<string, unknown> | null
-        results.push({
-          success: !!result?.success,
-          error: result?.success ? undefined : String(result?.error || 'Error desconocido')
-        })
+      const clientRequestId = (typeof crypto !== 'undefined' && 'randomUUID' in crypto)
+        ? crypto.randomUUID()
+        : `${Date.now()}-${Math.random().toString(36).slice(2)}`
+      try {
+        const { data, error } = await retryWithBackoff(
+          async () => {
+            const response = await supabase.rpc('registrar_salvedad', {
+              p_pedido_id: parseInt(String(salvedad.pedidoId), 10),
+              p_pedido_item_id: parseInt(String(salvedad.pedidoItemId), 10),
+              p_cantidad_afectada: salvedad.cantidadAfectada,
+              p_motivo: salvedad.motivo,
+              p_descripcion: salvedad.descripcion || null,
+              p_foto_url: salvedad.fotoUrl || null,
+              p_devolver_stock: salvedad.devolverStock !== false,
+              p_client_request_id: clientRequestId,
+            })
+            // supabase-js puede devolver errores de red en `error` en lugar de
+            // lanzarlos. Re-lanzamos como Error para que retryWithBackoff
+            // pueda capturarlo y decidir reintentar.
+            if (response.error && isTransientNetworkError(response.error)) {
+              const e = new Error(response.error.message || 'Load failed')
+              throw e
+            }
+            return response
+          },
+          { shouldRetry: isTransientNetworkError },
+        )
+        if (error) {
+          results.push({ success: false, error: error.message })
+        } else {
+          const result = data as Record<string, unknown> | null
+          results.push({
+            success: !!result?.success,
+            error: result?.success ? undefined : String(result?.error || 'Error desconocido'),
+          })
+        }
+      } catch (err) {
+        const msg = err instanceof Error
+          ? (isTransientNetworkError(err)
+              ? 'Sin conexion estable. Volve a intentar cuando tengas senal.'
+              : err.message)
+          : 'Error desconocido'
+        results.push({ success: false, error: msg })
       }
     }
     // Invalidar cache de productos y pedidos para reflejar cambios de stock y totales

--- a/src/utils/retryWithBackoff.ts
+++ b/src/utils/retryWithBackoff.ts
@@ -1,0 +1,53 @@
+/**
+ * Retry generico con backoff exponencial para operaciones que pueden fallar
+ * transientemente (errores de fetch, network, timeout).
+ *
+ * Tipico uso: envolver una llamada a supabase.rpc cuando el RPC es idempotente
+ * server-side (ej. acepta client_request_id). NO usar para operaciones no
+ * idempotentes: el retry duplicaria efectos si la primera request llego al
+ * servidor pero la respuesta se perdio.
+ */
+
+export interface RetryOptions {
+  maxAttempts?: number
+  initialDelayMs?: number
+  multiplier?: number
+  shouldRetry: (err: unknown) => boolean
+}
+
+export async function retryWithBackoff<T>(
+  fn: () => Promise<T>,
+  opts: RetryOptions,
+): Promise<T> {
+  const { maxAttempts = 3, initialDelayMs = 500, multiplier = 2, shouldRetry } = opts
+  let lastError: unknown
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    try {
+      return await fn()
+    } catch (err) {
+      lastError = err
+      if (attempt === maxAttempts || !shouldRetry(err)) throw err
+      const delay = initialDelayMs * Math.pow(multiplier, attempt - 1)
+      await new Promise((r) => setTimeout(r, delay))
+    }
+  }
+  throw lastError
+}
+
+/**
+ * Heuristica de errores de red transitorios. Cubre Safari/WebKit ("Load
+ * failed"), Chrome/Android ("Failed to fetch"), variantes de timeout y
+ * NetworkError. NO matchea PostgrestError con codigo semantico (esos vienen
+ * con `error.code` y NO se lanzan como Error desde supabase-js).
+ */
+export function isTransientNetworkError(err: unknown): boolean {
+  if (!(err instanceof Error)) return false
+  const m = err.message?.toLowerCase() ?? ''
+  return (
+    m.includes('load failed') ||
+    m.includes('failed to fetch') ||
+    m.includes('network request failed') ||
+    m.includes('networkerror') ||
+    m.includes('timeout')
+  )
+}


### PR DESCRIPTION
## Summary

Una admin reporta el error **\"Error al registrar 1 salvedad(es): TypeError: Load failed (hmuchlzmuqqxcldbzkgc.supabase.co)\"** al confirmar Entrega con Salvedad desde iOS PWA (pedido #1694).

Investigación:
- El error \"Load failed\" es de fetch del navegador (Safari/WebKit), no del RPC.
- Los logs API de Supabase (últimas 24h) **no muestran ningún POST a /rest/v1/rpc/registrar_salvedad** ni errores HTTP ≥ 400.
- El RPC actual tiene `EXCEPTION WHEN OTHERS RETURN jsonb_build_object('success', false, 'error', SQLERRM)` → errores semánticos llegarían como JSON. \"Load failed\" es claramente network/cliente.
- El handler frontend hace `for` secuencial sin retry y propaga `error.message` directo al usuario.
- Si la request llegó al server pero la respuesta no llegó al cliente, un retry ingenuo **duplicaría la salvedad**.

Fix robusto en dos capas: **idempotencia server-side + retry frontend con backoff**.

## Files

- `migrations/049_registrar_salvedad_idempotente.sql` (NUEVO):
  - `ALTER TABLE salvedades_items ADD COLUMN client_request_id UUID` + índice UNIQUE parcial.
  - `CREATE OR REPLACE FUNCTION registrar_salvedad(..., p_client_request_id UUID DEFAULT NULL)`. Si recibe un UUID que ya existe, retorna el payload original sin re-ejecutar nada (short-circuit antes de validaciones).
  - Setea `app.stock_origen = 'salvedad'` para que los cambios de stock queden trazables en `stock_historico` (consistencia con mig 048).
- `src/utils/retryWithBackoff.ts` (NUEVO): helper genérico de retry + `isTransientNetworkError` que matchea Safari (\"Load failed\"), Chrome (\"Failed to fetch\"), NetworkError, timeout.
- `src/components/containers/PedidosContainer.tsx`: `handleSaveSalvedades` genera un `crypto.randomUUID()` por salvedad (persiste entre intentos), wrap en `retryWithBackoff` (3 intentos, 500/1000/2000ms), mensaje amigable al usuario cuando agota retries.

## Backwards compatibility

- `p_client_request_id UUID DEFAULT NULL` → callers viejos siguen funcionando sin cambios.
- Columna `client_request_id` es nullable; salvedades históricas no se ven afectadas.
- Si el frontend se mergea **antes** de aplicar la migración, PostgREST rechaza el parámetro desconocido con error claro y el retry no causa duplicación (porque el server ni siquiera procesa).

## Test plan

### Migration (aplicar en Supabase ManaosApp `hmuchlzmuqqxcldbzkgc` antes de mergear)

```sql
SELECT column_name FROM information_schema.columns
 WHERE table_schema='public' AND table_name='salvedades_items' AND column_name='client_request_id';

SELECT indexdef FROM pg_indexes
 WHERE tablename='salvedades_items' AND indexname='idx_salvedades_items_client_request_id';

SELECT pg_get_function_identity_arguments(oid)
  FROM pg_proc WHERE proname='registrar_salvedad';
-- esperado: ..., p_client_request_id uuid
```

- [ ] Aplicar mig 049 en Supabase.
- [ ] Crear una salvedad de prueba con el mismo UUID dos veces → segunda devuelve `{success: true, idempotent_replay: true}` sin crear fila nueva.
- [ ] DevTools Network → Slow 3G mientras se confirma salvedad → 3 reintentos visibles, último falla con mensaje amigable.
- [ ] Probar offline → online a mitad de intento → no se duplica salvedad (`SELECT COUNT(*) FROM salvedades_items WHERE client_request_id=<uuid>` = 1).
- [ ] Regression: salvedad por motivos \"producto_danado\" / \"producto_vencido\" sigue insertando en `mermas_stock`.
- [ ] Regression: pedido con bonificaciones → resincronización de regalos sigue funcionando.

### Frontend

- [ ] Reproducir el bug en iOS PWA con la admin original → ya no aparece \"Load failed\"; o si la red sigue fallando, recibe \"Sin conexión estable. Volvé a intentar...\".

🤖 Generated with [Claude Code](https://claude.com/claude-code)