### PR TITLE
Rediseño editorial cálido: Pedidos, Productos y Dashboard

### DIFF
--- a/src/components/containers/ProductosContainer.tsx
+++ b/src/components/containers/ProductosContainer.tsx
@@ -31,6 +31,7 @@ const ModalActualizacionMasivaPrecios = lazy(() => import('../modals/ModalActual
 const ModalConfirmacion = lazy(() => import('../modals/ModalConfirmacion'))
 const ModalCategorias = lazy(() => import('../modals/ModalCategorias'))
 const ModalCambioProducto = lazy(() => import('../modals/ModalCambioProducto'))
+const ModalStockBajo = lazy(() => import('../modals/ModalStockBajo'))
 
 function LoadingState() {
   return (
@@ -74,6 +75,7 @@ export default function ProductosContainer(): React.ReactElement {
   const [modalActualizacionMasivaOpen, setModalActualizacionMasivaOpen] = useState(false)
   const [modalCategoriasOpen, setModalCategoriasOpen] = useState(false)
   const [modalCambioOpen, setModalCambioOpen] = useState(false)
+  const [modalStockBajoOpen, setModalStockBajoOpen] = useState(false)
 
   // Estado de edición
   const [productoEditando, setProductoEditando] = useState<ProductoDB | null>(null)
@@ -147,6 +149,37 @@ export default function ProductosContainer(): React.ReactElement {
     setModalCambioOpen(true)
   }, [])
 
+  const handleAbrirStockBajo = useCallback(() => {
+    setModalStockBajoOpen(true)
+  }, [])
+
+  // Control de stock: descarga Excel con el inventario actual.
+  // Antes vivía inline en VistaProductos; movido al container para que la
+  // toolbar pueda recibirlo como handler simple.
+  const handleControlStock = useCallback(async () => {
+    try {
+      const { exportControlStock } = await import('../../utils/excel')
+      await exportControlStock(productos)
+    } catch {
+      notify.error('Error al exportar el control de stock')
+    }
+  }, [productos, notify])
+
+  // Productos con stock bajo: una sola fuente de verdad. El toolbar usa
+  // el count y el modal usa la lista. La fórmula respeta exactamente la
+  // que estaba en VistaProductos: stock < (stock_minimo || 10).
+  const productosStockBajo = useMemo(() => {
+    return productos.filter(p => p.stock < (p.stock_minimo || 10))
+  }, [productos])
+
+  // Handler de "Editar" desde el modal de stock bajo: cierra el modal
+  // y abre el modal de edición del producto.
+  const handleEditarDesdeStockBajo = useCallback((producto: ProductoDB) => {
+    setModalStockBajoOpen(false)
+    setProductoEditando(producto)
+    setModalProductoOpen(true)
+  }, [])
+
   const handleGuardarCambioProducto = useCallback(async (data: RegistrarCambioInput) => {
     try {
       await registrarCambioProducto.mutateAsync(data)
@@ -203,6 +236,7 @@ export default function ProductosContainer(): React.ReactElement {
       <Suspense fallback={<LoadingState />}>
         <VistaProductos
           productos={productos}
+          productosStockBajo={productosStockBajo}
           proveedores={proveedores}
           loading={isLoading}
           isAdmin={isAdmin}
@@ -214,6 +248,8 @@ export default function ProductosContainer(): React.ReactElement {
           onActualizacionMasivaPrecios={handleAbrirActualizacionMasiva}
           onGestionarCategorias={handleGestionarCategorias}
           onCambioProducto={puedeCambiarProductos ? handleAbrirCambioProducto : undefined}
+          onControlStock={handleControlStock}
+          onAbrirStockBajo={handleAbrirStockBajo}
         />
       </Suspense>
 
@@ -289,6 +325,17 @@ export default function ProductosContainer(): React.ReactElement {
             productos={productos}
             onSave={handleGuardarCambioProducto}
             onClose={() => setModalCambioOpen(false)}
+          />
+        </Suspense>
+      )}
+
+      {/* Modal Stock bajo */}
+      {modalStockBajoOpen && (
+        <Suspense fallback={null}>
+          <ModalStockBajo
+            productos={productosStockBajo}
+            onEditarProducto={handleEditarDesdeStockBajo}
+            onClose={() => setModalStockBajoOpen(false)}
           />
         </Suspense>
       )}

--- a/src/components/dashboard/DashboardToolbar.tsx
+++ b/src/components/dashboard/DashboardToolbar.tsx
@@ -1,0 +1,90 @@
+/**
+ * DashboardToolbar
+ *
+ * Barra de acciones del Dashboard. Mantiene exactamente las mismas
+ * acciones que el original ("Actualizar" para todos, "Backup" para admin),
+ * pero las refunde con la estética cálida (stone + warm shadow) que se
+ * aplicó en /pedidos y /productos.
+ *
+ * Cantidad de botones es chica (1-2), así que no hay agrupación en
+ * dropdowns — solo botones directos.
+ */
+import React from 'react';
+import { RefreshCw, Download } from 'lucide-react';
+import { cn } from '../../lib/utils';
+
+export interface DashboardToolbarProps {
+  loading: boolean;
+  exportando: boolean;
+  isAdmin: boolean;
+  onRefetch: () => void;
+  onDescargarBackup: (tipo: string) => void;
+}
+
+const BUTTON_BASE = cn(
+  'inline-flex items-center gap-2.5 h-11 px-5 rounded-lg text-[14px] font-medium',
+  'bg-white dark:bg-gray-800 text-stone-700 dark:text-gray-200',
+  'border border-stone-200/80 dark:border-gray-700',
+  'shadow-warm',
+  'hover:bg-stone-50 dark:hover:bg-gray-700/50 hover:border-stone-300 dark:hover:border-gray-600 hover:-translate-y-px hover:shadow-warm-md',
+  'active:translate-y-0 active:shadow-warm',
+  'transition-[transform,box-shadow,background-color,border-color] duration-150',
+  'disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:translate-y-0',
+);
+
+const TOOLBAR_ICON_SIZE = 'w-[18px] h-[18px]';
+
+export default function DashboardToolbar({
+  loading,
+  exportando,
+  isAdmin,
+  onRefetch,
+  onDescargarBackup,
+}: DashboardToolbarProps): React.ReactElement {
+  return (
+    <div className="flex items-center gap-2 justify-end flex-wrap">
+      <button
+        type="button"
+        onClick={onRefetch}
+        disabled={loading}
+        className={BUTTON_BASE}
+        aria-label="Actualizar datos"
+      >
+        <RefreshCw
+          className={cn(TOOLBAR_ICON_SIZE, 'flex-shrink-0 text-blue-600', loading && 'animate-spin')}
+          aria-hidden="true"
+        />
+        <span>Actualizar</span>
+      </button>
+
+      {isAdmin && (
+        <button
+          type="button"
+          onClick={() => onDescargarBackup('completo')}
+          disabled={exportando}
+          className={cn(
+            'group relative inline-flex items-center gap-2.5 h-11 px-6 rounded-lg text-[14px] font-semibold text-white',
+            'bg-gradient-to-br from-green-500 to-green-600',
+            'shadow-[0_2px_8px_-2px_rgb(34_197_94/0.45),inset_0_1px_0_rgb(255_255_255/0.12)]',
+            'hover:from-green-500 hover:to-green-700 hover:-translate-y-px hover:shadow-[0_6px_16px_-4px_rgb(34_197_94/0.55),inset_0_1px_0_rgb(255_255_255/0.18)]',
+            'active:translate-y-0 active:shadow-[0_2px_4px_-2px_rgb(34_197_94/0.4)]',
+            'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-green-500/40 focus-visible:ring-offset-2 focus-visible:ring-offset-stone-50 dark:focus-visible:ring-offset-gray-900',
+            'transition-[transform,box-shadow,background] duration-200',
+            'disabled:opacity-60 disabled:cursor-not-allowed',
+          )}
+          aria-label="Descargar backup"
+        >
+          <span
+            className="absolute inset-0 rounded-lg bg-gradient-to-br from-white/10 to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-200 pointer-events-none"
+            aria-hidden="true"
+          />
+          <Download className={cn('relative', TOOLBAR_ICON_SIZE)} aria-hidden="true" />
+          <span className="relative">
+            <span className="hidden sm:inline">{exportando ? 'Generando…' : 'Backup'}</span>
+            <span className="sm:hidden">{exportando ? '…' : 'Backup'}</span>
+          </span>
+        </button>
+      )}
+    </div>
+  );
+}

--- a/src/components/dashboard/DashboardViewHeader.tsx
+++ b/src/components/dashboard/DashboardViewHeader.tsx
@@ -1,0 +1,117 @@
+/**
+ * Header del panel Dashboard.
+ *
+ * Estructura visual paralela a PedidosViewHeader / ProductosViewHeader:
+ *
+ *   ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─
+ *   DASHBOARD  ✦  VIERNES 15 DE MAYO  ✦  ESTE MES
+ *
+ *   Resumen del mes                              [actions]
+ *   ───
+ *
+ * El período se deriva con `labelPeriodoDashboard`.
+ */
+import React from 'react';
+import { labelPeriodoDashboard, type FiltroPeriodoDashboard } from '../../utils/labelPeriodoDashboard';
+
+export interface DashboardViewHeaderProps {
+  filtroPeriodo: FiltroPeriodoDashboard;
+  fechaDesde?: string | null;
+  fechaHasta?: string | null;
+  /** 'Resumen' (admin) o 'Mis métricas' (preventista) */
+  verbo?: string;
+  /** Texto del crumb superior derecho ("Este mes", "Hoy", etc.) */
+  periodoLabel: string;
+  loading: boolean;
+  actions?: React.ReactNode;
+}
+
+const DIAS_SEMANA = [
+  'DOMINGO', 'LUNES', 'MARTES', 'MIÉRCOLES', 'JUEVES', 'VIERNES', 'SÁBADO',
+] as const;
+
+const MESES = [
+  'ENERO', 'FEBRERO', 'MARZO', 'ABRIL', 'MAYO', 'JUNIO',
+  'JULIO', 'AGOSTO', 'SEPTIEMBRE', 'OCTUBRE', 'NOVIEMBRE', 'DICIEMBRE',
+] as const;
+
+function formatDiaLargo(now: Date): string {
+  return `${DIAS_SEMANA[now.getDay()]} ${now.getDate()} DE ${MESES[now.getMonth()]}`;
+}
+
+function CrumbDot() {
+  return (
+    <span
+      className="inline-block w-1 h-1 rounded-full bg-amber-500/70 align-middle mx-2.5"
+      aria-hidden="true"
+    />
+  );
+}
+
+export default function DashboardViewHeader({
+  filtroPeriodo,
+  fechaDesde,
+  fechaHasta,
+  verbo = 'Resumen',
+  periodoLabel,
+  loading,
+  actions,
+}: DashboardViewHeaderProps): React.ReactElement {
+  const now = React.useMemo(() => new Date(), []);
+  const diaLargo = formatDiaLargo(now);
+  const { verbo: verboFinal, periodo } = labelPeriodoDashboard(
+    { filtroPeriodo, fechaDesde, fechaHasta },
+    verbo,
+  );
+
+  const periodoCrumb = loading ? 'ACTUALIZANDO…' : periodoLabel.toUpperCase();
+
+  return (
+    <header className="flex flex-col sm:flex-row sm:items-end sm:justify-between gap-4 pb-1">
+      <div className="min-w-0 flex-1">
+        {/* Crumb editorial con separadores decorativos */}
+        <p className="text-[10.5px] sm:text-xs font-semibold tracking-[0.18em] text-stone-500 dark:text-stone-400 uppercase flex items-center flex-wrap">
+          <span>Dashboard</span>
+          <CrumbDot />
+          <span>{diaLargo}</span>
+          <CrumbDot />
+          <span className={loading ? 'animate-pulse' : ''}>{periodoCrumb}</span>
+        </p>
+
+        {/* Título editorial con período en cursiva */}
+        <h1
+          className="mt-2 text-3xl sm:text-4xl text-stone-900 dark:text-white leading-[1.05]"
+          style={{ fontWeight: 800, letterSpacing: '-0.035em' }}
+        >
+          <span className="bg-clip-text text-transparent bg-gradient-to-br from-stone-900 to-stone-700 dark:from-white dark:to-stone-300">
+            {verboFinal}
+          </span>
+          {periodo && (
+            <>
+              {' '}
+              <em
+                key={periodo}
+                className="font-light italic text-stone-500 dark:text-stone-400 inline-block animate-[fadeSlideIn_300ms_ease-out]"
+                style={{ letterSpacing: '-0.02em' }}
+              >
+                {periodo}
+              </em>
+            </>
+          )}
+        </h1>
+
+        {/* Acento decorativo */}
+        <div
+          className="mt-3 h-[2px] w-12 rounded-full bg-gradient-to-r from-blue-600 via-blue-500 to-transparent dark:from-blue-400 dark:via-blue-500"
+          aria-hidden="true"
+        />
+      </div>
+
+      {actions && (
+        <div className="flex-shrink-0 sm:max-w-[60%]">
+          {actions}
+        </div>
+      )}
+    </header>
+  );
+}

--- a/src/components/layout/TopNavigation.tsx
+++ b/src/components/layout/TopNavigation.tsx
@@ -216,14 +216,14 @@ export default function TopNavigation({
                       <button
                         key={item.id}
                         onClick={() => handleVistaChange(item.id)}
-                        className={`flex items-center space-x-2 px-4 py-2 rounded-lg transition-all ${
+                        className={`flex items-center space-x-2 px-3 py-2 rounded-lg transition-colors ${
                           vista === item.id
-                            ? 'bg-blue-600 text-white shadow-md'
-                            : 'text-gray-600 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700'
+                            ? 'bg-blue-50 dark:bg-blue-900/30 text-blue-700 dark:text-blue-200 font-semibold'
+                            : 'text-gray-600 dark:text-gray-300 font-medium hover:bg-gray-100 dark:hover:bg-gray-700/60'
                         }`}
                       >
-                        <ItemIcon className="w-4 h-4" />
-                        <span className="font-medium text-sm">{item.label}</span>
+                        <ItemIcon className={`w-4 h-4 ${vista === item.id ? 'text-blue-600 dark:text-blue-300' : ''}`} />
+                        <span className="text-sm">{item.label}</span>
                       </button>
                     );
                   });
@@ -244,15 +244,15 @@ export default function TopNavigation({
                       onClick={() => toggleDropdown(group.id)}
                       aria-expanded={isOpen}
                       aria-haspopup="true"
-                      className={`flex items-center space-x-2 px-4 py-2 rounded-lg transition-all ${
+                      className={`flex items-center space-x-2 px-3 py-2 rounded-lg transition-colors ${
                         isActive
-                          ? 'bg-blue-100 dark:bg-blue-900/30 text-blue-600 dark:text-blue-400'
-                          : 'text-gray-600 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700'
+                          ? 'bg-blue-50 dark:bg-blue-900/30 text-blue-700 dark:text-blue-200 font-semibold'
+                          : 'text-gray-600 dark:text-gray-300 font-medium hover:bg-gray-100 dark:hover:bg-gray-700/60'
                       }`}
                     >
-                      <GroupIcon className="w-4 h-4" />
-                      <span className="font-medium text-sm">{group.label}</span>
-                      <ChevronDown className={`w-3 h-3 transition-transform ${isOpen ? 'rotate-180' : ''}`} />
+                      <GroupIcon className={`w-4 h-4 ${isActive ? 'text-blue-600 dark:text-blue-300' : ''}`} />
+                      <span className="text-sm">{group.label}</span>
+                      <ChevronDown className={`w-3 h-3 transition-transform ${isOpen ? 'rotate-180' : ''} ${isActive ? 'text-blue-600 dark:text-blue-300' : ''}`} />
                     </button>
 
                     {/* Dropdown */}
@@ -265,13 +265,13 @@ export default function TopNavigation({
                               key={item.id}
                               role="menuitem"
                               onClick={() => handleVistaChange(item.id)}
-                              className={`w-full flex items-center space-x-3 px-4 py-3 transition-colors ${
+                              className={`w-full flex items-center space-x-3 px-4 py-2.5 transition-colors border-l-2 ${
                                 vista === item.id
-                                  ? 'bg-blue-50 dark:bg-blue-900/20 text-blue-600 dark:text-blue-400'
-                                  : 'text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700'
+                                  ? 'bg-blue-50/70 dark:bg-blue-900/20 text-blue-700 dark:text-blue-200 border-blue-500'
+                                  : 'text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700 border-transparent'
                               }`}
                             >
-                              <ItemIcon className="w-4 h-4" />
+                              <ItemIcon className={`w-4 h-4 ${vista === item.id ? 'text-blue-600 dark:text-blue-300' : ''}`} />
                               <span className="font-medium text-sm">{item.label}</span>
                             </button>
                           );

--- a/src/components/modals/ModalStockBajo.tsx
+++ b/src/components/modals/ModalStockBajo.tsx
@@ -1,0 +1,253 @@
+/**
+ * ModalStockBajo
+ *
+ * Reemplaza el banner gigante que ocupaba ~80px verticales en la pantalla
+ * de Productos. Se accede vía botón de la toolbar (con count badge).
+ *
+ * Estructura:
+ *   - Header: titulo + descripción ("N productos requieren reposición")
+ *   - Filtros internos: búsqueda + dropdown de categoría
+ *   - Lista ordenada por urgencia (sin stock → stock bajo → bajo de minimo)
+ *   - Cada fila: código, nombre, categoría, stock actual / mínimo, % cobertura
+ *   - Acción rápida: chip "Editar" que cierra el modal y abre ModalProducto
+ *
+ * No hace nuevos queries — recibe `productos` ya filtrados desde el container.
+ */
+import React, { memo, useMemo, useState } from 'react';
+import { Edit2, Search, X, AlertTriangle, ChevronDown } from 'lucide-react';
+import ModalBase from './ModalBase';
+import { cn } from '../../lib/utils';
+import type { ProductoDB } from '../../types';
+
+export interface ModalStockBajoProps {
+  /** Productos con stock bajo, ya filtrados por el container. */
+  productos: ProductoDB[];
+  /** Click en "Editar" de una fila: cierra el modal y abre ModalProducto. */
+  onEditarProducto: (producto: ProductoDB) => void;
+  /** Cerrar el modal. */
+  onClose: () => void;
+}
+
+interface ProductoConUrgencia extends ProductoDB {
+  stockMinimo: number;
+  cobertura: number;
+  urgencia: 'sin-stock' | 'bajo' | 'critico';
+}
+
+function clasificarUrgencia(producto: ProductoDB): ProductoConUrgencia {
+  const stockMinimo = producto.stock_minimo || 10;
+  const cobertura = stockMinimo === 0 ? 0 : (producto.stock / stockMinimo) * 100;
+  const urgencia: ProductoConUrgencia['urgencia'] =
+    producto.stock === 0 ? 'sin-stock' :
+    producto.stock < stockMinimo ? 'bajo' :
+    'critico';
+  return { ...producto, stockMinimo, cobertura, urgencia };
+}
+
+const URGENCIA_ORDER: Record<ProductoConUrgencia['urgencia'], number> = {
+  'sin-stock': 0,
+  'bajo': 1,
+  'critico': 2,
+};
+
+const URGENCIA_STYLES: Record<ProductoConUrgencia['urgencia'], {
+  borderLeft: string;
+  badgeBg: string;
+  badgeText: string;
+  barBg: string;
+  label: string;
+}> = {
+  'sin-stock': {
+    borderLeft: 'border-l-rose-500',
+    badgeBg: 'bg-rose-100 dark:bg-rose-900/30',
+    badgeText: 'text-rose-700 dark:text-rose-300',
+    barBg: 'bg-rose-500',
+    label: 'Sin stock',
+  },
+  'bajo': {
+    borderLeft: 'border-l-amber-500',
+    badgeBg: 'bg-amber-100 dark:bg-amber-900/30',
+    badgeText: 'text-amber-700 dark:text-amber-300',
+    barBg: 'bg-amber-500',
+    label: 'Stock bajo',
+  },
+  'critico': {
+    borderLeft: 'border-l-orange-500',
+    badgeBg: 'bg-orange-100 dark:bg-orange-900/30',
+    badgeText: 'text-orange-700 dark:text-orange-300',
+    barBg: 'bg-orange-500',
+    label: 'Bajo del mínimo',
+  },
+};
+
+const ModalStockBajo = memo(function ModalStockBajo({
+  productos,
+  onEditarProducto,
+  onClose,
+}: ModalStockBajoProps): React.ReactElement {
+  const [busqueda, setBusqueda] = useState('');
+  const [filtroCategoria, setFiltroCategoria] = useState<string>('todas');
+
+  // Categorías disponibles dentro del subset de stock bajo
+  const categorias = useMemo<string[]>(() => {
+    const set = new Set<string>();
+    productos.forEach(p => { if (p.categoria) set.add(p.categoria); });
+    return ['todas', ...Array.from(set).sort()];
+  }, [productos]);
+
+  // Enriquecer y ordenar por urgencia
+  const productosOrdenados = useMemo<ProductoConUrgencia[]>(() => {
+    const enriched = productos.map(clasificarUrgencia);
+    return enriched.sort((a, b) => {
+      const orderDiff = URGENCIA_ORDER[a.urgencia] - URGENCIA_ORDER[b.urgencia];
+      if (orderDiff !== 0) return orderDiff;
+      return a.cobertura - b.cobertura;
+    });
+  }, [productos]);
+
+  // Aplicar filtros internos del modal
+  const productosFiltrados = useMemo(() => {
+    const q = busqueda.trim().toLowerCase();
+    return productosOrdenados.filter(p => {
+      const matchBusqueda = !q
+        || p.nombre?.toLowerCase().includes(q)
+        || p.codigo?.toLowerCase().includes(q);
+      const matchCategoria = filtroCategoria === 'todas' || p.categoria === filtroCategoria;
+      return matchBusqueda && matchCategoria;
+    });
+  }, [productosOrdenados, busqueda, filtroCategoria]);
+
+  const totalLabel = productos.length === 1
+    ? '1 producto requiere reposición'
+    : `${productos.length.toLocaleString('es-AR')} productos requieren reposición`;
+
+  return (
+    <ModalBase
+      title="Productos con stock bajo"
+      description={totalLabel}
+      onClose={onClose}
+      maxWidth="max-w-3xl"
+    >
+      {/* Filtros internos */}
+      <div className="px-5 pt-4 pb-3 flex flex-col sm:flex-row gap-2 border-b border-stone-200 dark:border-gray-700">
+        <div className="relative flex-1 min-w-0">
+          <Search className="absolute left-3 top-1/2 -translate-y-1/2 text-stone-400 w-4 h-4" aria-hidden="true" />
+          <input
+            type="text"
+            value={busqueda}
+            onChange={e => setBusqueda(e.target.value)}
+            placeholder="Buscar por nombre o código…"
+            className="w-full h-9 pl-9 pr-3 rounded-lg border border-stone-200 dark:border-gray-700 bg-white dark:bg-gray-800 text-sm text-stone-700 dark:text-gray-200 placeholder:text-stone-400 focus:outline-none focus:ring-2 focus:ring-blue-500/40 focus:border-blue-400"
+          />
+        </div>
+        {categorias.length > 1 && (
+          <div className="relative">
+            <select
+              value={filtroCategoria}
+              onChange={e => setFiltroCategoria(e.target.value)}
+              className={cn(
+                'h-9 pl-3 pr-9 rounded-lg border text-sm appearance-none cursor-pointer',
+                'bg-white dark:bg-gray-800 text-stone-700 dark:text-gray-200',
+                'border-stone-200 dark:border-gray-700',
+                'focus:outline-none focus:ring-2 focus:ring-blue-500/40 focus:border-blue-400',
+                filtroCategoria !== 'todas' && 'bg-blue-50 dark:bg-blue-900/20 border-blue-300 text-blue-700',
+              )}
+            >
+              {categorias.map(c => (
+                <option key={c} value={c}>{c === 'todas' ? 'Todas las categorías' : c}</option>
+              ))}
+            </select>
+            <ChevronDown className="absolute right-2.5 top-1/2 -translate-y-1/2 w-4 h-4 text-stone-400 pointer-events-none" aria-hidden="true" />
+          </div>
+        )}
+      </div>
+
+      {/* Lista */}
+      <div className="flex-1 overflow-y-auto px-5 py-3 space-y-2">
+        {productosFiltrados.length === 0 ? (
+          <div className="text-center py-12 text-stone-500 dark:text-gray-400">
+            <AlertTriangle className="w-10 h-10 mx-auto mb-3 opacity-40" aria-hidden="true" />
+            <p className="text-sm">No se encontraron productos con los filtros actuales</p>
+          </div>
+        ) : (
+          productosFiltrados.map(p => {
+            const styles = URGENCIA_STYLES[p.urgencia];
+            const coberturaWidth = Math.min(100, Math.max(0, p.cobertura));
+            return (
+              <div
+                key={p.id}
+                className={cn(
+                  'flex items-center gap-3 bg-white dark:bg-gray-800 border border-stone-200 dark:border-gray-700 border-l-4 rounded-lg px-3 py-2.5 shadow-warm hover:shadow-warm-md transition-shadow',
+                  styles.borderLeft,
+                )}
+              >
+                <div className="min-w-0 flex-1">
+                  <div className="flex items-baseline gap-2 flex-wrap">
+                    {p.codigo && (
+                      <span className="text-[11px] font-mono font-semibold tabular-nums text-stone-500 dark:text-gray-400">
+                        #{p.codigo}
+                      </span>
+                    )}
+                    <span className="font-semibold text-stone-900 dark:text-white text-[14px] truncate">
+                      {p.nombre}
+                    </span>
+                  </div>
+                  <div className="flex items-center gap-3 mt-1.5 flex-wrap">
+                    {p.categoria && (
+                      <span className="text-[11px] text-stone-500 dark:text-gray-400">
+                        {p.categoria}
+                      </span>
+                    )}
+                    <span className={cn('text-[11px] font-semibold uppercase tracking-wide px-1.5 py-0.5 rounded', styles.badgeBg, styles.badgeText)}>
+                      {styles.label}
+                    </span>
+                  </div>
+                  {/* Mini barra de cobertura */}
+                  <div className="mt-2 flex items-center gap-2">
+                    <div className="flex-1 h-1.5 rounded-full bg-stone-100 dark:bg-gray-700 overflow-hidden">
+                      <div
+                        className={cn('h-full rounded-full transition-all', styles.barBg)}
+                        style={{ width: `${coberturaWidth}%` }}
+                      />
+                    </div>
+                    <span className="text-[11px] tabular-nums text-stone-600 dark:text-gray-300 font-medium whitespace-nowrap">
+                      {p.stock} / {p.stockMinimo}
+                    </span>
+                  </div>
+                </div>
+                <button
+                  type="button"
+                  onClick={() => { onEditarProducto(p); onClose(); }}
+                  className="inline-flex items-center gap-1.5 h-8 px-2.5 rounded-md text-xs font-medium bg-blue-50 dark:bg-blue-900/20 text-blue-700 dark:text-blue-300 border border-blue-200/70 dark:border-blue-800/40 hover:bg-blue-100 dark:hover:bg-blue-900/30 hover:border-blue-300 hover:-translate-y-px active:translate-y-0 transition-[transform,background-color,border-color] flex-shrink-0"
+                  title={`Editar ${p.nombre}`}
+                >
+                  <Edit2 className="w-3.5 h-3.5" aria-hidden="true" />
+                  <span>Editar</span>
+                </button>
+              </div>
+            );
+          })
+        )}
+      </div>
+
+      {/* Footer */}
+      <div className="px-5 py-3 border-t border-stone-200 dark:border-gray-700 flex items-center justify-between gap-3 bg-stone-50/50 dark:bg-gray-900/40">
+        <p className="text-xs text-stone-500 dark:text-gray-400">
+          {productosFiltrados.length === productos.length
+            ? totalLabel
+            : `Mostrando ${productosFiltrados.length} de ${productos.length}`}
+        </p>
+        <button
+          type="button"
+          onClick={onClose}
+          className="inline-flex items-center gap-1.5 h-9 px-4 rounded-lg text-sm font-medium text-stone-700 dark:text-gray-200 bg-white dark:bg-gray-800 border border-stone-200 dark:border-gray-700 hover:bg-stone-50 dark:hover:bg-gray-700/50 hover:border-stone-300 transition-colors"
+        >
+          <X className="w-4 h-4" aria-hidden="true" />
+          Cerrar
+        </button>
+      </div>
+    </ModalBase>
+  );
+});
+
+export default ModalStockBajo;

--- a/src/components/pedidos/PedidoCard.tsx
+++ b/src/components/pedidos/PedidoCard.tsx
@@ -91,8 +91,8 @@ function BadgeAntiguedad({ dias, estado }: BadgeAntiguedadProps): React.ReactEle
     : 'bg-amber-100 text-amber-700 border-amber-300';
 
   return (
-    <span className={`inline-flex items-center gap-1 px-2 py-0.5 text-xs font-medium rounded-full border ${colorClass}`}>
-      <Timer className="w-3 h-3" />
+    <span className={`inline-flex items-center gap-1 px-2 py-0.5 text-[12.5px] font-medium rounded-full border ${colorClass}`}>
+      <Timer className="w-3.5 h-3.5" />
       {dias}d
     </span>
   );
@@ -119,9 +119,9 @@ function BadgeGeolocalizacion({ pedido }: BadgeGeolocalizacionProps): React.Reac
     return (
       <span
         title={motivo}
-        className={`inline-flex items-center gap-1 px-2 py-0.5 text-xs font-medium rounded-full border border-gray-200 ${SEMAFORO_COLORS.sin_dato.bg}`}
+        className={`inline-flex items-center gap-1 px-2 py-0.5 text-[12.5px] font-medium rounded-full border border-gray-200 ${SEMAFORO_COLORS.sin_dato.bg}`}
       >
-        <MapPin className="w-3 h-3" />
+        <MapPin className="w-3.5 h-3.5" />
         Sin GPS
       </span>
     );
@@ -137,9 +137,9 @@ function BadgeGeolocalizacion({ pedido }: BadgeGeolocalizacionProps): React.Reac
     return (
       <span
         title="Cliente sin coordenadas cargadas"
-        className={`inline-flex items-center gap-1 px-2 py-0.5 text-xs font-medium rounded-full border border-gray-200 ${SEMAFORO_COLORS.sin_dato.bg}`}
+        className={`inline-flex items-center gap-1 px-2 py-0.5 text-[12.5px] font-medium rounded-full border border-gray-200 ${SEMAFORO_COLORS.sin_dato.bg}`}
       >
-        <MapPin className="w-3 h-3" />
+        <MapPin className="w-3.5 h-3.5" />
         s/ref
       </span>
     );
@@ -155,9 +155,9 @@ function BadgeGeolocalizacion({ pedido }: BadgeGeolocalizacionProps): React.Reac
   return (
     <span
       title={`${cfg.label} · ${formatDistancia(metros)}`}
-      className={`inline-flex items-center gap-1 px-2 py-0.5 text-xs font-medium rounded-full border border-transparent ${cfg.bg}`}
+      className={`inline-flex items-center gap-1 px-2 py-0.5 text-[12.5px] font-medium rounded-full border border-transparent ${cfg.bg}`}
     >
-      <MapPin className="w-3 h-3" />
+      <MapPin className="w-3.5 h-3.5" />
       {formatDistancia(metros)}
     </span>
   );
@@ -239,72 +239,78 @@ function PedidoCard({
   const handleMarcarEntregado = onMarcarEntregado ?? pedidoActions?.handleMarcarEntregado;
   const handleDesmarcarEntregado = onDesmarcarEntregado ?? pedidoActions?.handleDesmarcarEntregado;
   const handleRegistrarPago = onRegistrarPago ?? pedidoActions?.handleRegistrarPago;
+  const diasAntiguedad = calcularDiasAntiguedad(pedido.fecha || pedido.created_at);
+  const fechaCreacionLabel = formatFecha(pedido.fecha || pedido.created_at);
+  const horaCreacion = pedido.created_at ? formatHora(pedido.created_at) : null;
+  const mostrarEntrega = pedido.fecha_entrega_programada
+    && pedido.estado !== 'entregado'
+    && pedido.estado !== 'cancelado';
+
   return (
-    <div className="bg-white dark:bg-gray-800 border dark:border-gray-700 rounded-lg shadow-sm p-4 hover:shadow-md transition-shadow">
-      {/* Header del pedido */}
-      <div className="flex justify-between items-start">
-        <div className="flex-1">
-          <div className="flex items-start justify-between">
-            <div>
-              <h3 className="font-semibold text-lg text-gray-800 dark:text-white">
-                {pedido.cliente?.nombre_fantasia || 'Sin cliente'}
-              </h3>
-              <p className="text-sm text-gray-500 dark:text-gray-400">{pedido.cliente?.direccion}</p>
-              <p className="text-sm text-gray-400 dark:text-gray-500 mt-1 flex items-center gap-2 flex-wrap">
-                <span>#{pedido.id} - {formatFecha(pedido.fecha || pedido.created_at)}</span>
-                {pedido.created_at && (
-                  <span className="inline-flex items-center gap-0.5 text-xs text-gray-400 dark:text-gray-500" title="Hora de creación del pedido">
-                    <Clock className="w-3 h-3" />
-                    {formatHora(pedido.created_at)}
-                  </span>
-                )}
-                {pedido.fecha_entrega_programada && pedido.estado !== 'entregado' && pedido.estado !== 'cancelado' && (
-                  <span className="inline-flex items-center gap-0.5 text-xs text-orange-600 dark:text-orange-400">
-                    <Truck className="w-3 h-3" />
-                    {formatFecha(pedido.fecha_entrega_programada)}
-                  </span>
-                )}
-                <BadgeAntiguedad dias={calcularDiasAntiguedad(pedido.fecha || pedido.created_at)} estado={pedido.estado} />
-                {(isAdmin || (isPreventista && user?.id === pedido.usuario_id)) && (
-                  <BadgeGeolocalizacion pedido={pedido} />
-                )}
-              </p>
-            </div>
-          </div>
-          {pedido.usuario?.nombre && (
-            <div className="mt-2 inline-flex items-center px-2 py-1 bg-purple-100 text-purple-700 dark:bg-purple-900/30 dark:text-purple-300 rounded-full text-sm" title="Pedido cargado por">
-              <User className="w-4 h-4 mr-1" />
-              Cargado por {pedido.usuario.nombre}
-            </div>
-          )}
-          {pedido.transportista && (
-            <div className="mt-2 inline-flex items-center px-2 py-1 bg-orange-100 text-orange-700 rounded-full text-sm">
-              <Truck className="w-4 h-4 mr-1" />
-              {pedido.transportista.nombre}
-            </div>
-          )}
-          {pedido.estado === 'cancelado' && pedido.motivo_cancelacion && (
-            <div className="mt-2 inline-flex items-center px-2 py-1 bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400 rounded-full text-sm">
-              <AlertTriangle className="w-3 h-3 mr-1" />
-              <span className="truncate max-w-xs">{pedido.motivo_cancelacion}</span>
-            </div>
+    <div className="group bg-white dark:bg-gray-800 border border-stone-200/80 dark:border-gray-700 rounded-xl shadow-warm hover:shadow-warm-md hover:-translate-y-px hover:border-stone-300 dark:hover:border-gray-600 transition-[transform,box-shadow,border-color] duration-200 overflow-hidden">
+
+      {/* ╔══ ZONA 1: META-LINE editorial (todos los datos secundarios en una línea) ══╗
+           Nota: el ID conserva tracking editorial; el resto del texto va en case
+           natural (más legible) con peso medium. Tamaño 13px — antes era 11px,
+           se leía con esfuerzo. */}
+      <div className="px-5 pt-4 flex flex-wrap items-center gap-x-2.5 gap-y-1 text-[13px] text-stone-500 dark:text-stone-400">
+        <span className="tabular-nums font-semibold uppercase tracking-wide text-stone-600 dark:text-stone-300">#{pedido.id}</span>
+        <span className="text-stone-300 dark:text-stone-600" aria-hidden="true">·</span>
+        <span className="font-medium">{fechaCreacionLabel}</span>
+        {horaCreacion && (
+          <>
+            <span className="text-stone-300 dark:text-stone-600" aria-hidden="true">·</span>
+            <span className="inline-flex items-center gap-1 font-medium" title="Hora de creación">
+              <Clock className="w-3.5 h-3.5" />
+              {horaCreacion}
+            </span>
+          </>
+        )}
+        {mostrarEntrega && (
+          <>
+            <span className="text-stone-300 dark:text-stone-600" aria-hidden="true">·</span>
+            <span className="inline-flex items-center gap-1 font-medium text-orange-600 dark:text-orange-400" title="Entrega programada">
+              <Truck className="w-3.5 h-3.5" />
+              entrega {formatFecha(pedido.fecha_entrega_programada)}
+            </span>
+          </>
+        )}
+        <BadgeAntiguedad dias={diasAntiguedad} estado={pedido.estado} />
+        {(isAdmin || (isPreventista && user?.id === pedido.usuario_id)) && (
+          <BadgeGeolocalizacion pedido={pedido} />
+        )}
+      </div>
+
+      {/* ╔══ ZONA 2: HEADER PRINCIPAL — cliente prominente + estado a la derecha ══╗ */}
+      <div className="px-5 pt-2 flex items-start justify-between gap-4">
+        <div className="min-w-0 flex-1">
+          <h3 className="text-lg font-semibold text-stone-900 dark:text-white leading-tight">
+            {pedido.cliente?.nombre_fantasia || 'Sin cliente'}
+          </h3>
+          {pedido.cliente?.direccion && (
+            <p className="mt-1 text-sm text-stone-500 dark:text-gray-400 flex items-start gap-1.5">
+              <MapPin className="w-3.5 h-3.5 mt-0.5 flex-shrink-0 text-stone-400 dark:text-stone-500" aria-hidden="true" />
+              <span className="truncate">{pedido.cliente.direccion}</span>
+            </p>
           )}
         </div>
 
-        {/* Acciones */}
-        <div className="flex items-start space-x-2">
+        {/* Columna derecha: stepper + acciones */}
+        <div className="flex items-start gap-2 flex-shrink-0">
           <div className="flex flex-col items-end gap-2">
             <EstadoStepper estado={pedido.estado} tieneSalvedad={tieneSalvedad} />
-            {pedido.estado_pago && (
-              <span className={`px-3 py-1 rounded-full text-xs font-medium ${getEstadoPagoColor(pedido.estado_pago)}`}>
-                {getEstadoPagoLabel(pedido.estado_pago)}
-              </span>
-            )}
-            {pedido.tipo_factura === 'FC' && (
-              <span className="px-2 py-0.5 rounded text-xs font-medium bg-blue-100 text-blue-700 dark:bg-blue-900 dark:text-blue-300">
-                FC
-              </span>
-            )}
+            <div className="flex items-center gap-1.5 flex-wrap justify-end">
+              {pedido.estado_pago && (
+                <span className={`px-2.5 py-1 rounded-full text-[12.5px] font-semibold ${getEstadoPagoColor(pedido.estado_pago)}`}>
+                  {getEstadoPagoLabel(pedido.estado_pago)}
+                </span>
+              )}
+              {pedido.tipo_factura === 'FC' && (
+                <span className="px-2 py-0.5 rounded text-[11px] font-bold tracking-wider bg-blue-100 text-blue-700 dark:bg-blue-900/40 dark:text-blue-300">
+                  FC
+                </span>
+              )}
+            </div>
           </div>
           <AccionesDropdown
             pedido={pedido}
@@ -328,51 +334,98 @@ function PedidoCard({
         </div>
       </div>
 
-      {/* Resumen del pedido */}
-      <div className="mt-3 pt-3 border-t dark:border-gray-700">
-        <div className="flex flex-wrap items-center gap-2 mb-2">
+      {/* ╔══ ZONA 3: PERSONAS (compactas, en una sola fila) ══╗ */}
+      {(pedido.usuario?.nombre || pedido.transportista || (pedido.estado === 'cancelado' && pedido.motivo_cancelacion)) && (
+        <div className="px-5 mt-3 flex flex-wrap items-center gap-1.5">
+          {pedido.usuario?.nombre && (
+            <span
+              className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-[13px] bg-purple-50 text-purple-700 border border-purple-200/60 dark:bg-purple-900/20 dark:text-purple-300 dark:border-purple-800/40"
+              title="Pedido cargado por"
+            >
+              <User className="w-3.5 h-3.5" />
+              <span className="font-medium">{pedido.usuario.nombre}</span>
+            </span>
+          )}
+          {pedido.transportista && (
+            <span
+              className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-[13px] bg-orange-50 text-orange-700 border border-orange-200/60 dark:bg-orange-900/20 dark:text-orange-300 dark:border-orange-800/40"
+              title="Transportista asignado"
+            >
+              <Truck className="w-3.5 h-3.5" />
+              <span className="font-medium">{pedido.transportista.nombre}</span>
+            </span>
+          )}
+          {pedido.estado === 'cancelado' && pedido.motivo_cancelacion && (
+            <span className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-[13px] bg-red-50 text-red-700 border border-red-200/60 dark:bg-red-900/20 dark:text-red-300 dark:border-red-800/40">
+              <AlertTriangle className="w-3.5 h-3.5" />
+              <span className="font-medium truncate max-w-xs">{pedido.motivo_cancelacion}</span>
+            </span>
+          )}
+        </div>
+      )}
+
+      {/* ╔══ ZONA 4: PRODUCTOS ══╗ */}
+      <div className="px-5 mt-4">
+        {/* Divider editorial: gradiente sutil */}
+        <div className="h-px bg-gradient-to-r from-transparent via-stone-200 dark:via-gray-700 to-transparent" aria-hidden="true" />
+        <div className="mt-3 flex flex-wrap items-center gap-1.5">
           {pedido.items?.slice(0, 3).map(i => (
-            <span key={i.id} className="inline-block px-2 py-0.5 bg-gray-100 dark:bg-gray-700 rounded text-xs dark:text-gray-300">
-              {i.producto?.nombre} x{i.cantidad}
+            <span
+              key={i.id}
+              className="inline-flex items-baseline gap-1 px-2.5 py-1 bg-stone-50 dark:bg-gray-700/70 border border-stone-200/80 dark:border-gray-700 rounded-md text-[13px] text-stone-700 dark:text-gray-300"
+            >
+              <span className="truncate max-w-[22ch]">{i.producto?.nombre}</span>
+              <span className="tabular-nums text-stone-500 dark:text-gray-400 font-semibold">×{i.cantidad}</span>
             </span>
           ))}
           {pedido.items && pedido.items.length > 3 && (
-            <span className="text-xs text-gray-500">+{pedido.items.length - 3} mas</span>
+            <span className="text-[13px] text-stone-500 dark:text-gray-400 font-medium">
+              +{pedido.items.length - 3} más
+            </span>
           )}
         </div>
+      </div>
 
-        <div className="flex flex-wrap justify-between items-center gap-2">
-          <div className="flex flex-col">
-            <p className="text-lg font-bold text-blue-600">{formatPrecio(pedido.total)}</p>
-            {(pedido.forma_pago || (pedido.pagos && pedido.pagos.length > 0)) && (
-              <p className="text-xs text-gray-500 flex items-center">
-                <CreditCard className="w-3 h-3 mr-1" />
-                {getFormaPagoDisplay(pedido)}
-              </p>
-            )}
-          </div>
-          <div className="flex items-center gap-2">
-            {pedido.estado_pago === 'pagado' && (
-              <ReciboDropdown pedido={pedido} />
-            )}
-            <button
-              onClick={() => setExpandido(!expandido)}
-              className="flex items-center gap-1 px-3 py-1.5 text-sm bg-blue-50 dark:bg-blue-900/30 text-blue-600 dark:text-blue-400 rounded-lg hover:bg-blue-100 dark:hover:bg-blue-900/50 transition-colors"
-              aria-expanded={expandido}
-              aria-controls={`pedido-detalle-${pedido.id}`}
-              aria-label={expandido ? 'Ocultar detalle del pedido' : 'Ver detalle del pedido'}
-            >
-              <Eye className="w-4 h-4" aria-hidden="true" />
-              {expandido ? 'Ocultar' : 'Ver detalle'}
-              {expandido ? <ChevronUp className="w-4 h-4" aria-hidden="true" /> : <ChevronDown className="w-4 h-4" aria-hidden="true" />}
-            </button>
-          </div>
+      {/* ╔══ ZONA 5: FOOTER (total destacado en su propio compartimento) ══╗ */}
+      <div className="mt-4 px-5 py-3.5 bg-gradient-to-br from-stone-50/70 via-stone-50/40 to-blue-50/30 dark:from-gray-900/50 dark:via-gray-900/30 dark:to-blue-900/10 border-t border-stone-200/70 dark:border-gray-700/60 flex flex-wrap items-end justify-between gap-3">
+        <div className="min-w-0">
+          <p className="text-[11px] font-semibold uppercase tracking-[0.14em] text-stone-500 dark:text-stone-400 leading-none">
+            Total
+          </p>
+          <p
+            className="mt-1 text-2xl text-blue-700 dark:text-blue-300 tabular-nums leading-none"
+            style={{ fontWeight: 800, letterSpacing: '-0.03em' }}
+          >
+            {formatPrecio(pedido.total)}
+          </p>
+          {(pedido.forma_pago || (pedido.pagos && pedido.pagos.length > 0)) && (
+            <p className="mt-1.5 text-[13px] text-stone-500 dark:text-gray-400 flex items-center gap-1.5">
+              <CreditCard className="w-3.5 h-3.5" aria-hidden="true" />
+              {getFormaPagoDisplay(pedido)}
+            </p>
+          )}
+        </div>
+        <div className="flex items-center gap-3">
+          {pedido.estado_pago === 'pagado' && (
+            <ReciboDropdown pedido={pedido} />
+          )}
+          <button
+            onClick={() => setExpandido(!expandido)}
+            className="inline-flex items-center gap-1.5 text-sm font-semibold text-blue-700 dark:text-blue-300 hover:text-blue-800 dark:hover:text-blue-200 hover:gap-2 transition-[gap,color] duration-200"
+            aria-expanded={expandido}
+            aria-controls={`pedido-detalle-${pedido.id}`}
+            aria-label={expandido ? 'Ocultar detalle del pedido' : 'Ver detalle del pedido'}
+          >
+            <Eye className="w-4 h-4" aria-hidden="true" />
+            {expandido ? 'Ocultar detalle' : 'Ver detalle'}
+            {expandido ? <ChevronUp className="w-4 h-4" aria-hidden="true" /> : <ChevronDown className="w-4 h-4" aria-hidden="true" />}
+          </button>
         </div>
       </div>
 
       {/* Contenido expandido del pedido */}
       {expandido && (
-        <div id={`pedido-detalle-${pedido.id}`} className="mt-4 pt-4 border-t dark:border-gray-700 space-y-4 animate-fadeIn">
+        <div id={`pedido-detalle-${pedido.id}`} className="px-5 pt-4 pb-5 border-t border-stone-200 dark:border-gray-700 space-y-4 animate-fadeIn">
           {/* Informacion del cliente */}
           <div className="p-3 bg-gray-50 dark:bg-gray-700/50 rounded-lg">
             <h4 className="text-sm font-semibold text-gray-700 dark:text-gray-300 mb-2 flex items-center gap-2">

--- a/src/components/pedidos/PedidoFilters.tsx
+++ b/src/components/pedidos/PedidoFilters.tsx
@@ -1,10 +1,16 @@
 /**
  * Componente de filtros para la vista de pedidos
+ *
+ * Diseño: dropdowns con un único estilo de pill (border sutil, fondo blanco).
+ * Cuando un filtro tiene valor distinto al "todos" por default, su pill
+ * adquiere acento azul para señalar que está activo, en lugar de usar un
+ * color distinto por tipo de filtro (eso causaba el "carnaval" en mobile).
  */
 import React, { memo, ChangeEvent } from 'react';
 import { Search, Calendar, X, Truck, User } from 'lucide-react';
 import { fechaLocalISO } from '../../utils/formatters';
-import type { Usuario, EstadoPedido, EstadoPago } from '../../types';
+import { cn } from '../../lib/utils';
+import type { Usuario } from '../../types';
 
 interface FiltrosPedido {
   estado: string;
@@ -41,6 +47,28 @@ export interface PedidoFiltersProps {
   onModalFiltroFecha: () => void;
 }
 
+// =============================================================================
+// HELPERS LOCALES
+// =============================================================================
+
+const SELECT_BASE = cn(
+  'h-9 pl-3 pr-8 rounded-lg border text-sm appearance-none',
+  'bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-200',
+  'border-stone-200 dark:border-gray-700',
+  'focus:outline-none focus:ring-2 focus:ring-blue-500/40 focus:border-blue-400',
+  'transition-colors',
+);
+
+const SELECT_ACTIVE = 'bg-blue-50 dark:bg-blue-900/20 border-blue-300 dark:border-blue-700 text-blue-700 dark:text-blue-200';
+
+function selectClass(activo: boolean): string {
+  return cn(SELECT_BASE, activo && SELECT_ACTIVE);
+}
+
+// =============================================================================
+// MAIN
+// =============================================================================
+
 function PedidoFilters({
   busqueda,
   filtros,
@@ -51,112 +79,105 @@ function PedidoFilters({
   onFiltrosChange,
   onModalFiltroFecha
 }: PedidoFiltersProps): React.ReactElement {
+  const fechaActiva = Boolean(filtros.fechaDesde || filtros.fechaHasta);
+
   return (
-    <div className="flex flex-col gap-4">
-      {/* Primera fila: Busqueda y filtros principales */}
-      <div className="flex flex-col sm:flex-row gap-4">
-        <div className="relative flex-1">
-          <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 text-gray-400 w-5 h-5" aria-hidden="true" />
+    <div className="flex flex-col gap-3">
+      {/* ─── Primera fila: Busqueda + filtros principales ─── */}
+      <div className="flex flex-col sm:flex-row gap-2">
+        <div className="relative flex-1 min-w-0">
+          <Search className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400 w-4 h-4" aria-hidden="true" />
           <input
             type="text"
             value={busqueda}
             onChange={(e: ChangeEvent<HTMLInputElement>) => onBusquedaChange(e.target.value)}
-            className="w-full pl-10 pr-3 py-2 border dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-blue-500 dark:bg-gray-700 dark:text-white"
-            placeholder="Buscar por cliente, direccion o ID..."
+            className={cn(
+              'w-full h-9 pl-9 pr-3 rounded-lg border text-sm',
+              'bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-200',
+              'border-stone-200 dark:border-gray-700 placeholder:text-gray-400',
+              'focus:outline-none focus:ring-2 focus:ring-blue-500/40 focus:border-blue-400',
+            )}
+            placeholder="Buscar por cliente, dirección o ID…"
             aria-label="Buscar pedidos por cliente, dirección o número de pedido"
           />
         </div>
-        <div>
-          <label htmlFor="filtro-estado" className="sr-only">Filtrar por estado del pedido</label>
-          <select
-            id="filtro-estado"
-            value={filtros.estado}
-            onChange={(e: ChangeEvent<HTMLSelectElement>) => onFiltrosChange({ estado: e.target.value })}
-            className="px-4 py-2 border rounded-lg focus:ring-2 focus:ring-blue-500 dark:bg-gray-700 dark:border-gray-600 dark:text-white"
-          >
-            <option value="todos">Todos los estados</option>
-            <option value="pendiente">Pendientes</option>
-            <option value="en_preparacion">En preparacion</option>
-            <option value="asignado">En camino</option>
-            <option value="entregado">Entregados</option>
-            <option value="cancelado">Cancelados</option>
-          </select>
-        </div>
-        <label className="flex items-center gap-2 px-3 py-2 border rounded-lg cursor-pointer select-none dark:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-700">
+        <label htmlFor="filtro-estado" className="sr-only">Filtrar por estado del pedido</label>
+        <select
+          id="filtro-estado"
+          value={filtros.estado}
+          onChange={(e: ChangeEvent<HTMLSelectElement>) => onFiltrosChange({ estado: e.target.value })}
+          className={selectClass(filtros.estado !== 'todos')}
+        >
+          <option value="todos">Todos los estados</option>
+          <option value="pendiente">Pendientes</option>
+          <option value="en_preparacion">En preparación</option>
+          <option value="asignado">En camino</option>
+          <option value="entregado">Entregados</option>
+          <option value="cancelado">Cancelados</option>
+        </select>
+        <label className="inline-flex items-center gap-2 h-9 px-3 rounded-lg border border-stone-200 dark:border-gray-700 bg-white dark:bg-gray-800 cursor-pointer select-none hover:bg-gray-50 dark:hover:bg-gray-700/50">
           <input
             type="checkbox"
             checked={filtros.verCancelados || false}
             onChange={(e: ChangeEvent<HTMLInputElement>) => onFiltrosChange({ verCancelados: e.target.checked })}
-            className="w-4 h-4 rounded text-blue-600"
+            className="w-4 h-4 rounded text-blue-600 focus:ring-blue-500"
           />
           <span className="text-sm text-gray-700 dark:text-gray-300 whitespace-nowrap">Ver cancelados</span>
         </label>
         <button
+          type="button"
           onClick={onModalFiltroFecha}
           aria-label="Filtrar pedidos por rango de fechas"
-          className={`flex items-center space-x-2 px-4 py-2 border rounded-lg transition-colors ${
-            filtros.fechaDesde || filtros.fechaHasta
-              ? 'bg-blue-50 border-blue-300 dark:bg-blue-900/30 dark:border-blue-600'
-              : 'hover:bg-gray-50 dark:hover:bg-gray-700'
-          } dark:border-gray-600`}
+          className={cn(
+            'inline-flex items-center gap-2 h-9 px-3 rounded-lg border text-sm transition-colors',
+            fechaActiva
+              ? 'bg-blue-50 dark:bg-blue-900/20 border-blue-300 dark:border-blue-700 text-blue-700 dark:text-blue-200'
+              : 'bg-white dark:bg-gray-800 border-stone-200 dark:border-gray-700 text-gray-700 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-700/50',
+          )}
         >
-          <Calendar className="w-5 h-5" aria-hidden="true" />
+          <Calendar className="w-4 h-4" aria-hidden="true" />
           <span>Fechas</span>
         </button>
       </div>
 
-      {/* Segunda fila: Filtros adicionales para admin */}
+      {/* ─── Segunda fila: Filtros adicionales para admin ─── */}
       {isAdmin && (
-        <div className="flex flex-wrap gap-4">
-          <div>
-            <label htmlFor="filtro-pago" className="sr-only">Filtrar por estado de pago</label>
-            <select
-              id="filtro-pago"
-              value={filtros.estadoPago || 'todos'}
-              onChange={(e: ChangeEvent<HTMLSelectElement>) => onFiltrosChange({ estadoPago: e.target.value })}
-              className={`px-4 py-2 border rounded-lg focus:ring-2 focus:ring-blue-500 dark:bg-gray-700 dark:border-gray-600 dark:text-white ${
-                filtros.estadoPago && filtros.estadoPago !== 'todos'
-                  ? 'bg-red-50 border-red-300 dark:bg-red-900/30 dark:border-red-600'
-                  : ''
-              }`}
-            >
-              <option value="todos">Todos los pagos</option>
-              <option value="pendiente">Pago Pendiente</option>
-              <option value="parcial">Pago Parcial</option>
-              <option value="pagado">Pagado</option>
-            </select>
-          </div>
-          <div>
-            <label htmlFor="filtro-transportista" className="sr-only">Filtrar por transportista</label>
-            <select
-              id="filtro-transportista"
-              value={filtros.transportistaId || 'todos'}
-              onChange={(e: ChangeEvent<HTMLSelectElement>) => onFiltrosChange({ transportistaId: e.target.value })}
-              className={`px-4 py-2 border rounded-lg focus:ring-2 focus:ring-blue-500 dark:bg-gray-700 dark:border-gray-600 dark:text-white ${
-                filtros.transportistaId && filtros.transportistaId !== 'todos'
-                  ? 'bg-orange-50 border-orange-300 dark:bg-orange-900/30 dark:border-orange-600'
-                  : ''
-              }`}
-            >
-              <option value="todos">Todos los transportistas</option>
-              <option value="sin_asignar">Sin asignar</option>
-              {transportistas.map(t => (
-                <option key={t.id} value={t.id}>{t.nombre}</option>
-              ))}
-            </select>
-          </div>
-          <div className="flex items-center gap-1">
-            <User className="w-4 h-4 text-gray-500 dark:text-gray-400" />
+        <div className="flex flex-wrap items-center gap-2">
+          <label htmlFor="filtro-pago" className="sr-only">Filtrar por estado de pago</label>
+          <select
+            id="filtro-pago"
+            value={filtros.estadoPago || 'todos'}
+            onChange={(e: ChangeEvent<HTMLSelectElement>) => onFiltrosChange({ estadoPago: e.target.value })}
+            className={selectClass(Boolean(filtros.estadoPago) && filtros.estadoPago !== 'todos')}
+          >
+            <option value="todos">Todos los pagos</option>
+            <option value="pendiente">Pago pendiente</option>
+            <option value="parcial">Pago parcial</option>
+            <option value="pagado">Pagado</option>
+          </select>
+
+          <label htmlFor="filtro-transportista" className="sr-only">Filtrar por transportista</label>
+          <select
+            id="filtro-transportista"
+            value={filtros.transportistaId || 'todos'}
+            onChange={(e: ChangeEvent<HTMLSelectElement>) => onFiltrosChange({ transportistaId: e.target.value })}
+            className={selectClass(Boolean(filtros.transportistaId) && filtros.transportistaId !== 'todos')}
+          >
+            <option value="todos">Todos los transportistas</option>
+            <option value="sin_asignar">Sin asignar</option>
+            {transportistas.map(t => (
+              <option key={t.id} value={t.id}>{t.nombre}</option>
+            ))}
+          </select>
+
+          <div className="inline-flex items-center gap-1.5">
+            <User className="w-4 h-4 text-gray-500 dark:text-gray-400" aria-hidden="true" />
             <label htmlFor="filtro-usuario" className="sr-only">Filtrar por usuario que cargó el pedido</label>
             <select
               id="filtro-usuario"
               value={filtros.usuarioId || 'todos'}
               onChange={(e: ChangeEvent<HTMLSelectElement>) => onFiltrosChange({ usuarioId: e.target.value })}
-              className={`px-4 py-2 border rounded-lg focus:ring-2 focus:ring-blue-500 dark:bg-gray-700 dark:border-gray-600 dark:text-white ${
-                filtros.usuarioId && filtros.usuarioId !== 'todos'
-                  ? 'bg-blue-50 border-blue-300 dark:bg-blue-900/30 dark:border-blue-600'
-                  : ''
-              }`}
+              className={selectClass(Boolean(filtros.usuarioId) && filtros.usuarioId !== 'todos')}
             >
               <option value="todos">Todos los usuarios</option>
               {usuarios.map(u => (
@@ -164,90 +185,119 @@ function PedidoFilters({
               ))}
             </select>
           </div>
-          <div>
-            <label htmlFor="filtro-salvedad" className="sr-only">Filtrar por salvedades en entrega</label>
-            <select
-              id="filtro-salvedad"
-              value={filtros.conSalvedad || 'todos'}
-              onChange={(e: ChangeEvent<HTMLSelectElement>) => onFiltrosChange({ conSalvedad: e.target.value as 'todos' | 'con_salvedad' | 'sin_salvedad' })}
-              className={`px-4 py-2 border rounded-lg focus:ring-2 focus:ring-blue-500 dark:bg-gray-700 dark:border-gray-600 dark:text-white ${
-                filtros.conSalvedad && filtros.conSalvedad !== 'todos'
-                  ? 'bg-amber-50 border-amber-300 dark:bg-amber-900/30 dark:border-amber-600'
-                  : ''
-              }`}
-            >
-              <option value="todos">Todas las entregas</option>
-              <option value="con_salvedad">Con salvedad</option>
-              <option value="sin_salvedad">Sin salvedad</option>
-            </select>
-          </div>
-          <div className="flex items-center gap-1">
-            <Truck className="w-4 h-4 text-gray-500 dark:text-gray-400" />
-            {(() => {
-              const hoy = fechaLocalISO();
-              const manana = (() => { const d = new Date(hoy + 'T12:00:00'); d.setDate(d.getDate() + 1); return fechaLocalISO(d); })();
-              const activa = filtros.fechaEntregaProgramada;
-              return (
-                <>
-                  <button
-                    onClick={() => onFiltrosChange({ fechaEntregaProgramada: activa === hoy ? null : hoy })}
-                    className={`px-2 py-1 text-xs rounded-lg border transition-colors ${
-                      activa === hoy
-                        ? 'bg-orange-100 border-orange-400 text-orange-700 dark:bg-orange-900/40 dark:border-orange-600 dark:text-orange-300'
-                        : 'border-gray-300 dark:border-gray-600 text-gray-600 dark:text-gray-400 hover:bg-gray-50 dark:hover:bg-gray-700'
-                    }`}
-                  >
-                    Hoy
-                  </button>
-                  <button
-                    onClick={() => onFiltrosChange({ fechaEntregaProgramada: activa === manana ? null : manana })}
-                    className={`px-2 py-1 text-xs rounded-lg border transition-colors ${
-                      activa === manana
-                        ? 'bg-orange-100 border-orange-400 text-orange-700 dark:bg-orange-900/40 dark:border-orange-600 dark:text-orange-300'
-                        : 'border-gray-300 dark:border-gray-600 text-gray-600 dark:text-gray-400 hover:bg-gray-50 dark:hover:bg-gray-700'
-                    }`}
-                  >
-                    Mañana
-                  </button>
-                  <input
-                    type="date"
-                    value={activa || ''}
-                    onChange={(e) => onFiltrosChange({ fechaEntregaProgramada: e.target.value || null })}
-                    className={`px-2 py-1 text-xs border rounded-lg dark:bg-gray-700 dark:border-gray-600 dark:text-white ${
-                      activa && activa !== hoy && activa !== manana
-                        ? 'bg-orange-50 border-orange-300 dark:bg-orange-900/30 dark:border-orange-600'
-                        : ''
-                    }`}
-                  />
-                  {activa && (
-                    <button
-                      onClick={() => onFiltrosChange({ fechaEntregaProgramada: null })}
-                      className="text-red-500 hover:text-red-700"
-                      aria-label="Limpiar filtro de entrega"
-                    >
-                      <X className="w-3 h-3" />
-                    </button>
-                  )}
-                </>
-              );
-            })()}
-          </div>
+
+          <label htmlFor="filtro-salvedad" className="sr-only">Filtrar por salvedades en entrega</label>
+          <select
+            id="filtro-salvedad"
+            value={filtros.conSalvedad || 'todos'}
+            onChange={(e: ChangeEvent<HTMLSelectElement>) => onFiltrosChange({ conSalvedad: e.target.value as 'todos' | 'con_salvedad' | 'sin_salvedad' })}
+            className={selectClass(Boolean(filtros.conSalvedad) && filtros.conSalvedad !== 'todos')}
+          >
+            <option value="todos">Todas las entregas</option>
+            <option value="con_salvedad">Con salvedad</option>
+            <option value="sin_salvedad">Sin salvedad</option>
+          </select>
+
+          {/* Quick filters de fecha entrega: segmented control */}
+          <EntregaSegmentedControl
+            value={filtros.fechaEntregaProgramada ?? null}
+            onChange={value => onFiltrosChange({ fechaEntregaProgramada: value })}
+          />
         </div>
       )}
 
-      {/* Filtro de fechas activo */}
-      {(filtros.fechaDesde || filtros.fechaHasta) && (
-        <div className="flex items-center space-x-2 text-sm text-blue-600" role="status" aria-live="polite">
+      {/* ─── Chip de filtro de fechas activo ─── */}
+      {fechaActiva && (
+        <div
+          className="inline-flex items-center gap-2 self-start px-3 py-1.5 rounded-full bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-800 text-sm text-blue-700 dark:text-blue-200"
+          role="status"
+          aria-live="polite"
+        >
           <Calendar className="w-4 h-4" aria-hidden="true" />
-          <span>Filtrado: {filtros.fechaDesde || '...'} - {filtros.fechaHasta || '...'}</span>
+          <span>
+            Filtrado: <span className="font-medium tabular-nums">{filtros.fechaDesde || '…'}</span> – <span className="font-medium tabular-nums">{filtros.fechaHasta || '…'}</span>
+          </span>
           <button
+            type="button"
             onClick={() => onFiltrosChange({ fechaDesde: null, fechaHasta: null })}
-            className="text-red-500 hover:text-red-700"
+            className="text-blue-700/60 dark:text-blue-200/60 hover:text-red-600 dark:hover:text-red-400 transition-colors"
             aria-label="Limpiar filtro de fechas"
           >
             <X className="w-4 h-4" aria-hidden="true" />
           </button>
         </div>
+      )}
+    </div>
+  );
+}
+
+// =============================================================================
+// SEGMENTED CONTROL DE ENTREGA (Hoy / Mañana + date input)
+// =============================================================================
+
+interface EntregaSegmentedControlProps {
+  value: string | null;
+  onChange: (value: string | null) => void;
+}
+
+function EntregaSegmentedControl({ value, onChange }: EntregaSegmentedControlProps) {
+  const hoy = fechaLocalISO();
+  const manana = (() => {
+    const d = new Date(hoy + 'T12:00:00');
+    d.setDate(d.getDate() + 1);
+    return fechaLocalISO(d);
+  })();
+  const esHoy = value === hoy;
+  const esManana = value === manana;
+  const esCustom = Boolean(value) && !esHoy && !esManana;
+
+  const segmentClass = (active: boolean) => cn(
+    'h-7 px-3 text-xs font-medium transition-colors',
+    active
+      ? 'bg-white dark:bg-gray-700 text-blue-700 dark:text-blue-200 shadow-sm'
+      : 'text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-100',
+  );
+
+  return (
+    <div className="inline-flex items-center gap-1.5">
+      <Truck className="w-4 h-4 text-gray-500 dark:text-gray-400" aria-hidden="true" />
+      <span className="text-xs text-gray-500 dark:text-gray-400 mr-1">Entrega:</span>
+      <div className="inline-flex items-center p-0.5 rounded-lg border border-stone-200 dark:border-gray-700 bg-gray-100 dark:bg-gray-800">
+        <button
+          type="button"
+          onClick={() => onChange(esHoy ? null : hoy)}
+          className={cn(segmentClass(esHoy), 'rounded-md')}
+        >
+          Hoy
+        </button>
+        <button
+          type="button"
+          onClick={() => onChange(esManana ? null : manana)}
+          className={cn(segmentClass(esManana), 'rounded-md')}
+        >
+          Mañana
+        </button>
+      </div>
+      <input
+        type="date"
+        value={value || ''}
+        onChange={(e) => onChange(e.target.value || null)}
+        className={cn(
+          'h-7 px-2 text-xs rounded-md border',
+          esCustom
+            ? 'bg-blue-50 dark:bg-blue-900/20 border-blue-300 dark:border-blue-700 text-blue-700 dark:text-blue-200'
+            : 'bg-white dark:bg-gray-800 border-stone-200 dark:border-gray-700 text-gray-700 dark:text-gray-200',
+        )}
+      />
+      {value && (
+        <button
+          type="button"
+          onClick={() => onChange(null)}
+          className="text-gray-400 hover:text-red-600 transition-colors"
+          aria-label="Limpiar filtro de entrega"
+        >
+          <X className="w-3.5 h-3.5" />
+        </button>
       )}
     </div>
   );

--- a/src/components/pedidos/PedidoStats.tsx
+++ b/src/components/pedidos/PedidoStats.tsx
@@ -3,6 +3,14 @@
  *
  * Recibe los totales ya calculados sobre todos los pedidos filtrados (no sólo
  * la página visible) para que las cards reflejen el estado completo.
+ *
+ * Diseño editorial cálido:
+ *  - Fondo blanco con leve gradient hacia el color semántico (8% opacity).
+ *  - Borde sutil stone-200 + franja izquierda con el color del estado.
+ *  - Icono dentro de un badge circular (bg-color-100) con el icono color-600.
+ *  - Hover: leve lift y sombra cálida más profunda.
+ *  - Número grande con tabular-nums y peso 800 para que se sienta "editorial"
+ *    en vez de "dato sin alma".
  */
 import React, { memo } from 'react';
 import { Clock, Package, Truck, Check, DollarSign, ShoppingCart, LucideIcon } from 'lucide-react';
@@ -25,9 +33,16 @@ interface StatItem {
   icon: LucideIcon;
   count: number;
   total: number;
-  colorClass: string;
-  iconColor: string;
-  textColor: string;
+  /** Franja izquierda */
+  accentBorder: string;
+  /** Color del número grande */
+  accentText: string;
+  /** Fondo del badge del icono */
+  badgeBg: string;
+  /** Color del icono dentro del badge */
+  badgeIcon: string;
+  /** Gradient overlay sutil (linear-gradient con el color hacia bg) */
+  gradientFrom: string;
 }
 
 // =============================================================================
@@ -43,19 +58,23 @@ function PedidoStats({ summary, isEncargado }: PedidoStatsProps): React.ReactEle
       icon: Clock,
       count: summary.pendientes.count,
       total: summary.pendientes.monto,
-      colorClass: 'bg-yellow-50 dark:bg-yellow-900/20 border-yellow-200 dark:border-yellow-800',
-      iconColor: 'text-yellow-600',
-      textColor: 'text-yellow-800 dark:text-yellow-400'
+      accentBorder: 'border-l-amber-500',
+      accentText: 'text-amber-700 dark:text-amber-300',
+      badgeBg: 'bg-amber-100 dark:bg-amber-500/15',
+      badgeIcon: 'text-amber-600 dark:text-amber-400',
+      gradientFrom: 'before:from-amber-500/[0.07]',
     },
     {
       key: 'enPreparacion',
-      label: 'En preparacion',
+      label: 'En preparación',
       icon: Package,
       count: summary.enPreparacion.count,
       total: summary.enPreparacion.monto,
-      colorClass: 'bg-orange-50 dark:bg-orange-900/20 border-orange-200 dark:border-orange-800',
-      iconColor: 'text-orange-600',
-      textColor: 'text-orange-800 dark:text-orange-400'
+      accentBorder: 'border-l-orange-500',
+      accentText: 'text-orange-700 dark:text-orange-300',
+      badgeBg: 'bg-orange-100 dark:bg-orange-500/15',
+      badgeIcon: 'text-orange-600 dark:text-orange-400',
+      gradientFrom: 'before:from-orange-500/[0.07]',
     },
     {
       key: 'enCamino',
@@ -63,9 +82,11 @@ function PedidoStats({ summary, isEncargado }: PedidoStatsProps): React.ReactEle
       icon: Truck,
       count: summary.enCamino.count,
       total: summary.enCamino.monto,
-      colorClass: 'bg-blue-50 dark:bg-blue-900/20 border-blue-200 dark:border-blue-800',
-      iconColor: 'text-blue-600',
-      textColor: 'text-blue-800 dark:text-blue-400'
+      accentBorder: 'border-l-blue-500',
+      accentText: 'text-blue-700 dark:text-blue-300',
+      badgeBg: 'bg-blue-100 dark:bg-blue-500/15',
+      badgeIcon: 'text-blue-600 dark:text-blue-400',
+      gradientFrom: 'before:from-blue-500/[0.07]',
     },
     {
       key: 'entregados',
@@ -73,9 +94,11 @@ function PedidoStats({ summary, isEncargado }: PedidoStatsProps): React.ReactEle
       icon: Check,
       count: summary.entregados.count,
       total: summary.entregados.monto,
-      colorClass: 'bg-green-50 dark:bg-green-900/20 border-green-200 dark:border-green-800',
-      iconColor: 'text-green-600',
-      textColor: 'text-green-800 dark:text-green-400'
+      accentBorder: 'border-l-emerald-500',
+      accentText: 'text-emerald-700 dark:text-emerald-300',
+      badgeBg: 'bg-emerald-100 dark:bg-emerald-500/15',
+      badgeIcon: 'text-emerald-600 dark:text-emerald-400',
+      gradientFrom: 'before:from-emerald-500/[0.07]',
     },
     {
       key: 'impagos',
@@ -83,36 +106,58 @@ function PedidoStats({ summary, isEncargado }: PedidoStatsProps): React.ReactEle
       icon: DollarSign,
       count: summary.impagos.count,
       total: summary.impagos.monto,
-      colorClass: 'bg-red-50 dark:bg-red-900/20 border-red-200 dark:border-red-800',
-      iconColor: 'text-red-600',
-      textColor: 'text-red-800 dark:text-red-400'
+      accentBorder: 'border-l-rose-500',
+      accentText: 'text-rose-700 dark:text-rose-300',
+      badgeBg: 'bg-rose-100 dark:bg-rose-500/15',
+      badgeIcon: 'text-rose-600 dark:text-rose-400',
+      gradientFrom: 'before:from-rose-500/[0.07]',
     },
     {
       key: 'total',
-      label: 'Total Filtrado',
+      label: 'Total filtrado',
       icon: ShoppingCart,
       count: summary.total.count,
       total: summary.total.monto,
-      colorClass: 'bg-purple-50 dark:bg-purple-900/20 border-purple-200 dark:border-purple-800',
-      iconColor: 'text-purple-600',
-      textColor: 'text-purple-800 dark:text-purple-400'
-    }
+      accentBorder: 'border-l-stone-400 dark:border-l-stone-500',
+      accentText: 'text-stone-800 dark:text-stone-200',
+      badgeBg: 'bg-stone-100 dark:bg-stone-500/15',
+      badgeIcon: 'text-stone-600 dark:text-stone-300',
+      gradientFrom: 'before:from-stone-500/[0.06]',
+    },
   ];
 
   return (
     <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-6 gap-3">
-      {items.map(item => {
+      {items.map((item, idx) => {
         const IconComponent = item.icon;
+        const showMonto = mostrarMontosEnStats(rol, item.key);
         return (
-          <div key={item.key} className={`border rounded-lg p-3 ${item.colorClass}`}>
-            <div className="flex items-center justify-between">
-              <IconComponent className={`w-5 h-5 ${item.iconColor}`} />
-              {mostrarMontosEnStats(rol, item.key) && (
-                <span className={`text-xs ${item.iconColor}`}>{formatPrecio(item.total)}</span>
-              )}
+          <div
+            key={item.key}
+            className={`group relative overflow-hidden bg-white dark:bg-gray-800 border border-stone-200 dark:border-gray-700 border-l-4 ${item.accentBorder} rounded-xl px-3.5 py-3 shadow-warm hover:shadow-warm-md hover:-translate-y-px transition-[transform,box-shadow] duration-200 before:absolute before:inset-0 before:bg-gradient-to-br ${item.gradientFrom} before:to-transparent before:pointer-events-none`}
+            style={{ animation: 'card-in 0.35s cubic-bezier(0.22, 1, 0.36, 1) both', animationDelay: `${idx * 35}ms` }}
+          >
+            <div className="relative flex items-start gap-2.5">
+              <span className={`inline-flex items-center justify-center w-7 h-7 rounded-lg flex-shrink-0 ${item.badgeBg}`}>
+                <IconComponent className={`w-3.5 h-3.5 ${item.badgeIcon}`} aria-hidden="true" />
+              </span>
+              <div className="min-w-0">
+                <p className="text-[10.5px] font-semibold uppercase tracking-[0.08em] text-stone-500 dark:text-stone-400 leading-tight">
+                  {item.label}
+                </p>
+                <p
+                  className={`text-2xl tabular-nums leading-tight mt-0.5 ${item.accentText}`}
+                  style={{ fontWeight: 800, letterSpacing: '-0.025em' }}
+                >
+                  {item.count.toLocaleString('es-AR')}
+                </p>
+                {showMonto && (
+                  <p className="text-xs tabular-nums text-stone-500 dark:text-stone-400 mt-0.5 truncate">
+                    {formatPrecio(item.total)}
+                  </p>
+                )}
+              </div>
             </div>
-            <p className={`text-xl font-bold ${item.iconColor}`}>{item.count}</p>
-            <p className={`text-sm ${item.textColor}`}>{item.label}</p>
           </div>
         );
       })}

--- a/src/components/pedidos/PedidoToolbar.tsx
+++ b/src/components/pedidos/PedidoToolbar.tsx
@@ -1,0 +1,313 @@
+/**
+ * PedidoToolbar
+ *
+ * Barra de acciones del panel /pedidos.
+ *
+ * Diseño (consensuado con usuario):
+ *   Admin/Encargado:
+ *     [ Acciones masivas ▾ ] [ Exportaciones ▾ ] [ Optimizar Ruta ] [ Nuevo pedido ]
+ *
+ *     Donde "Acciones masivas" agrupa: Asignar Transportista, Pagos Masivos,
+ *     Entregas Masivas. Y "Exportaciones" agrupa: Excel, PDF. Cada opción
+ *     dentro del dropdown mantiene su icono coloreado individual.
+ *
+ *   Preventista:
+ *     [ Visitas del día ] [ Marcar visita ] [ Nuevo pedido ]
+ *
+ *     (Son sólo 2 acciones contextuales, no justifica agruparlas en dropdown.)
+ *
+ * "Nuevo pedido" es la única acción con fondo de color saturado (verde).
+ * Todo lo demás es botón neutral con icono coloreado para mantener
+ * identidad sin caer en el carnaval de fondos.
+ */
+import React from 'react';
+import {
+  Plus, Route, FileDown, PackageCheck, Banknote, ChevronDown, Truck,
+  MapPin, History, Boxes, Download, type LucideIcon,
+} from 'lucide-react';
+import {
+  DropdownMenu, DropdownMenuTrigger, DropdownMenuContent,
+  DropdownMenuItem, DropdownMenuLabel,
+} from '../ui/DropdownMenu';
+import { cn } from '../../lib/utils';
+
+// =============================================================================
+// PROPS
+// =============================================================================
+
+export interface PedidoToolbarProps {
+  isAdmin: boolean;
+  isEncargado?: boolean;
+  isPreventista: boolean;
+  exportando: boolean;
+  totalCount: number;
+  onNuevoPedido: () => void;
+  onOptimizarRuta: () => void;
+  onExportarPDF: () => void;
+  onExportarExcel: (modo: 'pagina' | 'filtro') => void;
+  onEntregasMasivas?: () => void;
+  onPagosMasivos?: () => void;
+  onAsignarTransportistaMasivo?: () => void;
+  onMarcarVisita?: () => void;
+  onVerVisitasHoy?: () => void;
+}
+
+// =============================================================================
+// HELPERS LOCALES
+// =============================================================================
+
+const BUTTON_BASE = cn(
+  'inline-flex items-center gap-2.5 h-11 px-5 rounded-lg text-[14px] font-medium',
+  'bg-white dark:bg-gray-800 text-stone-700 dark:text-gray-200',
+  'border border-stone-200/80 dark:border-gray-700',
+  'shadow-warm',
+  'hover:bg-stone-50 dark:hover:bg-gray-700/50 hover:border-stone-300 dark:hover:border-gray-600 hover:-translate-y-px hover:shadow-warm-md',
+  'active:translate-y-0 active:shadow-warm',
+  'data-[state=open]:bg-stone-50 data-[state=open]:border-stone-300 data-[state=open]:shadow-warm-md dark:data-[state=open]:bg-gray-700/50',
+  'transition-[transform,box-shadow,background-color,border-color] duration-150',
+  'disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:translate-y-0',
+);
+
+/** Tamaño de iconos en la toolbar: levemente más grandes que el default
+ *  (18px en vez de 16px) para que respiren con los botones h-11. */
+const TOOLBAR_ICON_SIZE = 'w-[18px] h-[18px]';
+
+interface ToolbarButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  icon: LucideIcon;
+  iconClassName?: string;
+  /** Label corto para mobile (`<sm`). Si no se provee, se usa `children`. */
+  mobileLabel?: string;
+}
+
+const ToolbarButton = React.forwardRef<HTMLButtonElement, ToolbarButtonProps>(
+  ({ icon: Icon, iconClassName, mobileLabel, className, children, ...props }, ref) => (
+    <button ref={ref} type="button" {...props} className={cn(BUTTON_BASE, className)}>
+      <Icon className={cn(TOOLBAR_ICON_SIZE, 'flex-shrink-0', iconClassName)} aria-hidden="true" />
+      {mobileLabel ? (
+        <>
+          <span className="hidden sm:inline">{children}</span>
+          <span className="sm:hidden">{mobileLabel}</span>
+        </>
+      ) : (
+        <span>{children}</span>
+      )}
+    </button>
+  ),
+);
+ToolbarButton.displayName = 'ToolbarButton';
+
+interface ToolbarDropdownProps {
+  triggerIcon: LucideIcon;
+  triggerIconClassName?: string;
+  label: string;
+  mobileLabel: string;
+  children: React.ReactNode;
+  /** Ancho del menú; default: w-60 */
+  menuClassName?: string;
+}
+
+function ToolbarDropdown({
+  triggerIcon: TriggerIcon,
+  triggerIconClassName = 'text-stone-500',
+  label,
+  mobileLabel,
+  children,
+  menuClassName = 'w-64',
+}: ToolbarDropdownProps) {
+  return (
+    // modal={false} evita que Radix bloquee el scroll del body al abrir,
+    // lo que estaba causando un layout shift visible (~15px) en el header
+    // y el resto del contenido cuando se desplegaba la lista. En una toolbar
+    // dropdown no necesitamos focus trap completo; el cierre por outside-click
+    // y Escape siguen funcionando.
+    <DropdownMenu modal={false}>
+      <DropdownMenuTrigger asChild>
+        <button type="button" className={BUTTON_BASE}>
+          <TriggerIcon className={cn(TOOLBAR_ICON_SIZE, 'flex-shrink-0', triggerIconClassName)} aria-hidden="true" />
+          <span className="hidden sm:inline">{label}</span>
+          <span className="sm:hidden">{mobileLabel}</span>
+          <ChevronDown className="w-4 h-4 text-stone-400 dark:text-stone-500 flex-shrink-0 -mr-1" aria-hidden="true" />
+        </button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className={menuClassName}>
+        {children}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}
+
+/**
+ * Botón primario verde para "Nuevo pedido". Único color de fondo saturado
+ * en toda la toolbar.
+ */
+function PrimaryNewButton({ onClick }: { onClick: () => void }) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={cn(
+        'group relative inline-flex items-center gap-2.5 h-11 px-6 rounded-lg text-[14px] font-semibold',
+        'text-white',
+        'bg-gradient-to-br from-green-500 to-green-600',
+        'shadow-[0_2px_8px_-2px_rgb(34_197_94/0.45),inset_0_1px_0_rgb(255_255_255/0.12)]',
+        'hover:from-green-500 hover:to-green-700 hover:-translate-y-px hover:shadow-[0_6px_16px_-4px_rgb(34_197_94/0.55),inset_0_1px_0_rgb(255_255_255/0.18)]',
+        'active:translate-y-0 active:shadow-[0_2px_4px_-2px_rgb(34_197_94/0.4)]',
+        'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-green-500/40 focus-visible:ring-offset-2 focus-visible:ring-offset-stone-50 dark:focus-visible:ring-offset-gray-900',
+        'transition-[transform,box-shadow,background] duration-200',
+      )}
+    >
+      <span
+        className="absolute inset-0 rounded-lg bg-gradient-to-br from-white/10 to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-200 pointer-events-none"
+        aria-hidden="true"
+      />
+      <Plus className={cn('relative', TOOLBAR_ICON_SIZE)} aria-hidden="true" />
+      <span className="relative">
+        <span className="hidden sm:inline">Nuevo pedido</span>
+        <span className="sm:hidden">Nuevo</span>
+      </span>
+    </button>
+  );
+}
+
+// =============================================================================
+// MAIN
+// =============================================================================
+
+export default function PedidoToolbar({
+  isAdmin,
+  isEncargado,
+  isPreventista,
+  exportando,
+  totalCount,
+  onNuevoPedido,
+  onOptimizarRuta,
+  onExportarPDF,
+  onExportarExcel,
+  onEntregasMasivas,
+  onPagosMasivos,
+  onAsignarTransportistaMasivo,
+  onMarcarVisita,
+  onVerVisitasHoy,
+}: PedidoToolbarProps): React.ReactElement {
+  const canCreate = isAdmin || isEncargado || isPreventista;
+  const showOpsGroups = isAdmin || isEncargado;
+  const showPreventistaActions = isPreventista && !isAdmin && !isEncargado;
+
+  // ¿Hay al menos una acción masiva habilitada? (para mostrar el dropdown)
+  const hasMasivas = Boolean(
+    onAsignarTransportistaMasivo || onPagosMasivos || onEntregasMasivas,
+  );
+
+  return (
+    <div className="flex items-center gap-2 justify-end flex-wrap">
+      {showOpsGroups && (
+        <>
+          {hasMasivas && (
+            <ToolbarDropdown
+              triggerIcon={Boxes}
+              label="Acciones masivas"
+              mobileLabel="Masivas"
+            >
+              <DropdownMenuLabel>Acciones masivas</DropdownMenuLabel>
+              {onAsignarTransportistaMasivo && (
+                <DropdownMenuItem onSelect={onAsignarTransportistaMasivo}>
+                  <Truck className="w-4 h-4 text-blue-600" />
+                  <span>Asignar Transportista</span>
+                </DropdownMenuItem>
+              )}
+              {onPagosMasivos && (
+                <DropdownMenuItem onSelect={onPagosMasivos}>
+                  <Banknote className="w-4 h-4 text-green-600" />
+                  <span>Pagos Masivos</span>
+                </DropdownMenuItem>
+              )}
+              {onEntregasMasivas && (
+                <DropdownMenuItem onSelect={onEntregasMasivas}>
+                  <PackageCheck className="w-4 h-4 text-teal-600" />
+                  <span>Entregas Masivas</span>
+                </DropdownMenuItem>
+              )}
+            </ToolbarDropdown>
+          )}
+
+          <ToolbarDropdown
+            triggerIcon={Download}
+            label="Exportaciones"
+            mobileLabel="Exportar"
+            menuClassName="w-72"
+          >
+            <DropdownMenuLabel>Exportaciones</DropdownMenuLabel>
+            <DropdownMenuItem
+              onSelect={() => onExportarExcel('pagina')}
+              disabled={exportando}
+            >
+              <FileDown className="w-4 h-4 text-emerald-600" />
+              <div className="flex flex-col gap-0.5 min-w-0">
+                <span className="font-medium">Excel — Página actual</span>
+                <span className="text-xs text-stone-500 dark:text-gray-400">
+                  Solo los pedidos visibles
+                </span>
+              </div>
+            </DropdownMenuItem>
+            <DropdownMenuItem
+              onSelect={() => onExportarExcel('filtro')}
+              disabled={exportando}
+            >
+              <FileDown className="w-4 h-4 text-emerald-600" />
+              <div className="flex flex-col gap-0.5 min-w-0">
+                <span className="font-medium">
+                  Excel — Filtro actual ({totalCount.toLocaleString('es-AR')})
+                </span>
+                <span className="text-xs text-stone-500 dark:text-gray-400">
+                  Todos los pedidos que coinciden
+                </span>
+              </div>
+            </DropdownMenuItem>
+            <DropdownMenuItem onSelect={onExportarPDF}>
+              <FileDown className="w-4 h-4 text-rose-600" />
+              <span>PDF</span>
+            </DropdownMenuItem>
+          </ToolbarDropdown>
+
+          <ToolbarButton
+            icon={Route}
+            iconClassName="text-blue-600"
+            mobileLabel="Ruta"
+            onClick={onOptimizarRuta}
+          >
+            Optimizar Ruta
+          </ToolbarButton>
+        </>
+      )}
+
+      {showPreventistaActions && (
+        <>
+          {onVerVisitasHoy && (
+            <ToolbarButton
+              icon={History}
+              iconClassName="text-stone-500"
+              mobileLabel="Visitas"
+              onClick={onVerVisitasHoy}
+              title="Ver clientes que visitaste hoy"
+            >
+              Visitas del día
+            </ToolbarButton>
+          )}
+          {onMarcarVisita && (
+            <ToolbarButton
+              icon={MapPin}
+              iconClassName="text-indigo-600"
+              mobileLabel="Marcar"
+              onClick={onMarcarVisita}
+              title="Marcar visita a un cliente sin necesidad de cargar pedido"
+            >
+              Marcar visita
+            </ToolbarButton>
+          )}
+        </>
+      )}
+
+      {canCreate && <PrimaryNewButton onClick={onNuevoPedido} />}
+    </div>
+  );
+}

--- a/src/components/pedidos/PedidosViewHeader.tsx
+++ b/src/components/pedidos/PedidosViewHeader.tsx
@@ -1,0 +1,126 @@
+/**
+ * Header del panel de Pedidos.
+ *
+ * Estructura visual (editorial cálido):
+ *
+ *   ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─
+ *   OPERACIONES  ✦  MARTES 22 DE ABRIL  ✦  649 RESULTADOS
+ *
+ *   Pedidos del día                         [actions]
+ *   ───
+ *
+ * El sufijo dinámico ("del día / del mes / para entregar hoy / ...") se
+ * deriva de los filtros activos (ver labelPeriodoPedidos).
+ *
+ * El verbo "Pedidos" usa peso 800 con kerning negativo para sentirse
+ * editorial y compacto; el período usa cursiva italic real con un color
+ * cálido (stone-500) para diferenciarse sin gritar.
+ */
+import React from 'react';
+import type { FiltrosPedidosState } from '../../types';
+import { labelPeriodoPedidos } from '../../utils/labelPeriodoPedidos';
+
+export interface PedidosViewHeaderProps {
+  filtros: FiltrosPedidosState;
+  totalCount: number;
+  loading: boolean;
+  /** Slot derecha (típicamente PedidoToolbar). */
+  actions?: React.ReactNode;
+}
+
+const DIAS_SEMANA = [
+  'DOMINGO', 'LUNES', 'MARTES', 'MIÉRCOLES', 'JUEVES', 'VIERNES', 'SÁBADO',
+] as const;
+
+const MESES = [
+  'ENERO', 'FEBRERO', 'MARZO', 'ABRIL', 'MAYO', 'JUNIO',
+  'JULIO', 'AGOSTO', 'SEPTIEMBRE', 'OCTUBRE', 'NOVIEMBRE', 'DICIEMBRE',
+] as const;
+
+function formatDiaLargo(now: Date): string {
+  return `${DIAS_SEMANA[now.getDay()]} ${now.getDate()} DE ${MESES[now.getMonth()]}`;
+}
+
+/** Separador decorativo del crumb: un pequeño rombo en amber sutil que
+ *  rompe la monotonía sin gritar. */
+function CrumbDot() {
+  return (
+    <span
+      className="inline-block w-1 h-1 rounded-full bg-amber-500/70 align-middle mx-2.5"
+      aria-hidden="true"
+    />
+  );
+}
+
+export default function PedidosViewHeader({
+  filtros,
+  totalCount,
+  loading,
+  actions,
+}: PedidosViewHeaderProps): React.ReactElement {
+  const now = React.useMemo(() => new Date(), []);
+  const diaLargo = formatDiaLargo(now);
+  const { verbo, periodo } = labelPeriodoPedidos(
+    {
+      fechaDesde: filtros.fechaDesde ?? null,
+      fechaHasta: filtros.fechaHasta ?? null,
+      fechaEntregaProgramada: filtros.fechaEntregaProgramada ?? null,
+    },
+    undefined,
+    now,
+  );
+
+  const resultadosLabel = loading
+    ? 'ACTUALIZANDO…'
+    : `${totalCount.toLocaleString('es-AR')} ${totalCount === 1 ? 'RESULTADO' : 'RESULTADOS'}`;
+
+  return (
+    <header className="flex flex-col sm:flex-row sm:items-end sm:justify-between gap-4 pb-1">
+      <div className="min-w-0 flex-1">
+        {/* Crumb editorial con separadores decorativos */}
+        <p className="text-[10.5px] sm:text-xs font-semibold tracking-[0.18em] text-stone-500 dark:text-stone-400 uppercase flex items-center flex-wrap">
+          <span>Operaciones</span>
+          <CrumbDot />
+          <span>{diaLargo}</span>
+          <CrumbDot />
+          <span className={loading ? 'animate-pulse' : ''}>{resultadosLabel}</span>
+        </p>
+
+        {/* Título editorial con período en cursiva */}
+        <h1
+          className="mt-2 text-3xl sm:text-4xl text-stone-900 dark:text-white leading-[1.05]"
+          style={{ fontWeight: 800, letterSpacing: '-0.035em' }}
+        >
+          <span className="bg-clip-text text-transparent bg-gradient-to-br from-stone-900 to-stone-700 dark:from-white dark:to-stone-300">
+            {verbo}
+          </span>
+          {periodo && (
+            <>
+              {' '}
+              <em
+                key={periodo /* trigger re-mount → fade animation cuando cambia */}
+                className="font-light italic text-stone-500 dark:text-stone-400 inline-block animate-[fadeSlideIn_300ms_ease-out]"
+                style={{ letterSpacing: '-0.02em' }}
+              >
+                {periodo}
+              </em>
+            </>
+          )}
+        </h1>
+
+        {/* Acento decorativo: línea pequeña debajo del título.
+            Gradiente sutil de azul a transparente, evoca un subrayado editorial. */}
+        <div
+          className="mt-3 h-[2px] w-12 rounded-full bg-gradient-to-r from-blue-600 via-blue-500 to-transparent dark:from-blue-400 dark:via-blue-500"
+          aria-hidden="true"
+        />
+      </div>
+
+      {actions && (
+        <div className="flex-shrink-0 sm:max-w-[62%]">
+          {actions}
+        </div>
+      )}
+    </header>
+  );
+}

--- a/src/components/productos/ProductoToolbar.tsx
+++ b/src/components/productos/ProductoToolbar.tsx
@@ -1,0 +1,228 @@
+/**
+ * ProductoToolbar
+ *
+ * Barra de acciones del panel /productos. Reemplaza los 6 botones inline
+ * de colores variados que tenia VistaProductos.
+ *
+ * Estructura (admin):
+ *   [ Catálogo ] [ Inventario ] [ Stock bajo (N) ] [ + Nuevo producto ]
+ *
+ * Filosofia: una sola accion saturada (verde primary). El resto neutral
+ * con icono coloreado para mantener identidad sin saturar.
+ */
+import React from 'react';
+import {
+  Plus, ChevronDown, Tag, Package2, AlertTriangle,
+  ArrowLeftRight, Percent, ClipboardCheck, TrendingDown,
+  type LucideIcon,
+} from 'lucide-react';
+import {
+  DropdownMenu, DropdownMenuTrigger, DropdownMenuContent,
+  DropdownMenuItem, DropdownMenuLabel,
+} from '../ui/DropdownMenu';
+import { cn } from '../../lib/utils';
+
+export interface ProductoToolbarProps {
+  isAdmin: boolean;
+  productosStockBajoCount: number;
+  onGestionarCategorias?: () => void;
+  onCambioProducto?: () => void;
+  onActualizacionMasivaPrecios?: () => void;
+  onControlStock?: () => void;
+  onVerHistorialMermas?: () => void;
+  onAbrirStockBajo?: () => void;
+  onNuevoProducto?: () => void;
+}
+
+const BUTTON_BASE = cn(
+  'inline-flex items-center gap-2.5 h-11 px-5 rounded-lg text-[14px] font-medium',
+  'bg-white dark:bg-gray-800 text-stone-700 dark:text-gray-200',
+  'border border-stone-200/80 dark:border-gray-700',
+  'shadow-warm',
+  'hover:bg-stone-50 dark:hover:bg-gray-700/50 hover:border-stone-300 dark:hover:border-gray-600 hover:-translate-y-px hover:shadow-warm-md',
+  'active:translate-y-0 active:shadow-warm',
+  'data-[state=open]:bg-stone-50 data-[state=open]:border-stone-300 data-[state=open]:shadow-warm-md dark:data-[state=open]:bg-gray-700/50',
+  'transition-[transform,box-shadow,background-color,border-color] duration-150',
+  'disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:translate-y-0',
+);
+
+const TOOLBAR_ICON_SIZE = 'w-[18px] h-[18px]';
+
+interface ToolbarDropdownProps {
+  triggerIcon: LucideIcon;
+  triggerIconClassName?: string;
+  label: string;
+  mobileLabel: string;
+  children: React.ReactNode;
+  menuClassName?: string;
+}
+
+function ToolbarDropdown({
+  triggerIcon: TriggerIcon,
+  triggerIconClassName = 'text-stone-500',
+  label,
+  mobileLabel,
+  children,
+  menuClassName = 'w-72',
+}: ToolbarDropdownProps) {
+  return (
+    <DropdownMenu modal={false}>
+      <DropdownMenuTrigger asChild>
+        <button type="button" className={BUTTON_BASE}>
+          <TriggerIcon className={cn(TOOLBAR_ICON_SIZE, 'flex-shrink-0', triggerIconClassName)} aria-hidden="true" />
+          <span className="hidden sm:inline">{label}</span>
+          <span className="sm:hidden">{mobileLabel}</span>
+          <ChevronDown className="w-4 h-4 text-stone-400 dark:text-stone-500 flex-shrink-0 -mr-1" aria-hidden="true" />
+        </button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className={menuClassName}>
+        {children}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}
+
+function StockBajoButton({ count, onClick }: { count: number; onClick?: () => void }) {
+  const hasItems = count > 0;
+  return (
+    <button
+      type="button"
+      onClick={hasItems ? onClick : undefined}
+      disabled={!hasItems}
+      className={cn(
+        'inline-flex items-center gap-2 h-11 px-4 rounded-lg text-[14px] font-medium shadow-warm',
+        'transition-[transform,box-shadow,background-color,border-color] duration-150',
+        'hover:-translate-y-px hover:shadow-warm-md active:translate-y-0 active:shadow-warm',
+        hasItems
+          ? 'bg-amber-50 dark:bg-amber-900/15 text-amber-800 dark:text-amber-200 border border-amber-200/80 dark:border-amber-700/40 hover:bg-amber-100/80 dark:hover:bg-amber-900/25 hover:border-amber-300'
+          : 'bg-white dark:bg-gray-800 text-stone-400 dark:text-stone-500 border border-stone-200/80 dark:border-gray-700 cursor-not-allowed hover:translate-y-0 hover:shadow-warm',
+      )}
+    >
+      <AlertTriangle
+        className={cn(TOOLBAR_ICON_SIZE, 'flex-shrink-0', hasItems ? 'text-amber-600' : 'text-stone-400')}
+        aria-hidden="true"
+      />
+      <span className="hidden sm:inline">Stock bajo</span>
+      <span className="sm:hidden">Stock</span>
+      <span
+        className={cn(
+          'inline-flex items-center justify-center min-w-[1.5rem] h-5 px-1.5 rounded-full text-[11.5px] font-bold tabular-nums',
+          hasItems
+            ? 'bg-amber-200/70 dark:bg-amber-700/40 text-amber-800 dark:text-amber-200'
+            : 'bg-stone-100 dark:bg-gray-700 text-stone-500',
+        )}
+      >
+        {count}
+      </span>
+    </button>
+  );
+}
+
+function PrimaryNewButton({ onClick }: { onClick: () => void }) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={cn(
+        'group relative inline-flex items-center gap-2.5 h-11 px-6 rounded-lg text-[14px] font-semibold',
+        'text-white',
+        'bg-gradient-to-br from-green-500 to-green-600',
+        'shadow-[0_2px_8px_-2px_rgb(34_197_94/0.45),inset_0_1px_0_rgb(255_255_255/0.12)]',
+        'hover:from-green-500 hover:to-green-700 hover:-translate-y-px hover:shadow-[0_6px_16px_-4px_rgb(34_197_94/0.55),inset_0_1px_0_rgb(255_255_255/0.18)]',
+        'active:translate-y-0 active:shadow-[0_2px_4px_-2px_rgb(34_197_94/0.4)]',
+        'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-green-500/40 focus-visible:ring-offset-2 focus-visible:ring-offset-stone-50 dark:focus-visible:ring-offset-gray-900',
+        'transition-[transform,box-shadow,background] duration-200',
+      )}
+    >
+      <span
+        className="absolute inset-0 rounded-lg bg-gradient-to-br from-white/10 to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-200 pointer-events-none"
+        aria-hidden="true"
+      />
+      <Plus className={cn('relative', TOOLBAR_ICON_SIZE)} aria-hidden="true" />
+      <span className="relative">
+        <span className="hidden sm:inline">Nuevo producto</span>
+        <span className="sm:hidden">Nuevo</span>
+      </span>
+    </button>
+  );
+}
+
+export default function ProductoToolbar({
+  isAdmin,
+  productosStockBajoCount,
+  onGestionarCategorias,
+  onCambioProducto,
+  onActualizacionMasivaPrecios,
+  onControlStock,
+  onVerHistorialMermas,
+  onAbrirStockBajo,
+  onNuevoProducto,
+}: ProductoToolbarProps): React.ReactElement | null {
+  const hayCatálogo = isAdmin && (
+    Boolean(onGestionarCategorias) || Boolean(onCambioProducto) || Boolean(onActualizacionMasivaPrecios)
+  );
+  const hayInventario = isAdmin && (Boolean(onControlStock) || Boolean(onVerHistorialMermas));
+  const hayStockBajo = isAdmin;
+  const hayNuevo = isAdmin && Boolean(onNuevoProducto);
+
+  if (!hayCatálogo && !hayInventario && !hayStockBajo && !hayNuevo) {
+    return null;
+  }
+
+  return (
+    <div className="flex items-center gap-2 justify-end flex-wrap">
+      {hayCatálogo && (
+        <ToolbarDropdown triggerIcon={Tag} label="Catálogo" mobileLabel="Catálogo">
+          <DropdownMenuLabel>Catálogo</DropdownMenuLabel>
+          {onGestionarCategorias && (
+            <DropdownMenuItem onSelect={onGestionarCategorias}>
+              <Tag className="w-4 h-4 text-purple-600" />
+              <span>Categorías</span>
+            </DropdownMenuItem>
+          )}
+          {onCambioProducto && (
+            <DropdownMenuItem onSelect={onCambioProducto}>
+              <ArrowLeftRight className="w-4 h-4 text-indigo-600" />
+              <span>Cambio de productos</span>
+            </DropdownMenuItem>
+          )}
+          {onActualizacionMasivaPrecios && (
+            <DropdownMenuItem onSelect={onActualizacionMasivaPrecios}>
+              <Percent className="w-4 h-4 text-indigo-600" />
+              <span>Actualización masiva de precios</span>
+            </DropdownMenuItem>
+          )}
+        </ToolbarDropdown>
+      )}
+
+      {hayInventario && (
+        <ToolbarDropdown triggerIcon={Package2} label="Inventario" mobileLabel="Inventario">
+          <DropdownMenuLabel>Inventario</DropdownMenuLabel>
+          {onControlStock && (
+            <DropdownMenuItem onSelect={onControlStock}>
+              <ClipboardCheck className="w-4 h-4 text-amber-600" />
+              <div className="flex flex-col gap-0.5 min-w-0">
+                <span className="font-medium">Control de stock</span>
+                <span className="text-xs text-stone-500 dark:text-gray-400">
+                  Descarga Excel con el inventario actual
+                </span>
+              </div>
+            </DropdownMenuItem>
+          )}
+          {onVerHistorialMermas && (
+            <DropdownMenuItem onSelect={onVerHistorialMermas}>
+              <TrendingDown className="w-4 h-4 text-rose-600" />
+              <span>Historial de mermas</span>
+            </DropdownMenuItem>
+          )}
+        </ToolbarDropdown>
+      )}
+
+      {hayStockBajo && (
+        <StockBajoButton count={productosStockBajoCount} onClick={onAbrirStockBajo} />
+      )}
+
+      {hayNuevo && onNuevoProducto && <PrimaryNewButton onClick={onNuevoProducto} />}
+    </div>
+  );
+}

--- a/src/components/productos/ProductosViewHeader.tsx
+++ b/src/components/productos/ProductosViewHeader.tsx
@@ -1,0 +1,118 @@
+/**
+ * Header del panel de Productos.
+ *
+ * Estructura visual paralela a PedidosViewHeader (editorial cálido):
+ *
+ *   ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─
+ *   CATÁLOGO  ✦  JUEVES 15 DE MAYO  ✦  90 PRODUCTOS
+ *
+ *   Productos de Manaos                         [actions]
+ *   ───
+ *
+ * El período se deriva con `labelCategoriaProductos` según los filtros activos
+ * (categoría, búsqueda, stock bajo).
+ */
+import React from 'react';
+import { labelCategoriaProductos } from '../../utils/labelCategoriaProductos';
+
+export interface ProductosViewHeaderProps {
+  busqueda: string;
+  categoriaSeleccionada: string;
+  mostrarSoloStockBajo: boolean;
+  totalCount: number;
+  loading: boolean;
+  /** Slot derecha (típicamente ProductoToolbar). */
+  actions?: React.ReactNode;
+}
+
+const DIAS_SEMANA = [
+  'DOMINGO', 'LUNES', 'MARTES', 'MIÉRCOLES', 'JUEVES', 'VIERNES', 'SÁBADO',
+] as const;
+
+const MESES = [
+  'ENERO', 'FEBRERO', 'MARZO', 'ABRIL', 'MAYO', 'JUNIO',
+  'JULIO', 'AGOSTO', 'SEPTIEMBRE', 'OCTUBRE', 'NOVIEMBRE', 'DICIEMBRE',
+] as const;
+
+function formatDiaLargo(now: Date): string {
+  return `${DIAS_SEMANA[now.getDay()]} ${now.getDate()} DE ${MESES[now.getMonth()]}`;
+}
+
+function CrumbDot() {
+  return (
+    <span
+      className="inline-block w-1 h-1 rounded-full bg-amber-500/70 align-middle mx-2.5"
+      aria-hidden="true"
+    />
+  );
+}
+
+export default function ProductosViewHeader({
+  busqueda,
+  categoriaSeleccionada,
+  mostrarSoloStockBajo,
+  totalCount,
+  loading,
+  actions,
+}: ProductosViewHeaderProps): React.ReactElement {
+  const now = React.useMemo(() => new Date(), []);
+  const diaLargo = formatDiaLargo(now);
+  const { verbo, periodo } = labelCategoriaProductos({
+    busqueda,
+    categoriaSeleccionada,
+    mostrarSoloStockBajo,
+  });
+
+  const resultadosLabel = loading
+    ? 'ACTUALIZANDO…'
+    : `${totalCount.toLocaleString('es-AR')} ${totalCount === 1 ? 'PRODUCTO' : 'PRODUCTOS'}`;
+
+  return (
+    <header className="flex flex-col sm:flex-row sm:items-end sm:justify-between gap-4 pb-1">
+      <div className="min-w-0 flex-1">
+        {/* Crumb editorial con separadores decorativos */}
+        <p className="text-[10.5px] sm:text-xs font-semibold tracking-[0.18em] text-stone-500 dark:text-stone-400 uppercase flex items-center flex-wrap">
+          <span>Catálogo</span>
+          <CrumbDot />
+          <span>{diaLargo}</span>
+          <CrumbDot />
+          <span className={loading ? 'animate-pulse' : ''}>{resultadosLabel}</span>
+        </p>
+
+        {/* Título editorial con período en cursiva */}
+        <h1
+          className="mt-2 text-3xl sm:text-4xl text-stone-900 dark:text-white leading-[1.05]"
+          style={{ fontWeight: 800, letterSpacing: '-0.035em' }}
+        >
+          <span className="bg-clip-text text-transparent bg-gradient-to-br from-stone-900 to-stone-700 dark:from-white dark:to-stone-300">
+            {verbo}
+          </span>
+          {periodo && (
+            <>
+              {' '}
+              <em
+                key={periodo}
+                className="font-light italic text-stone-500 dark:text-stone-400 inline-block animate-[fadeSlideIn_300ms_ease-out]"
+                style={{ letterSpacing: '-0.02em' }}
+              >
+                {periodo}
+              </em>
+            </>
+          )}
+        </h1>
+
+        {/* Acento decorativo: línea pequeña debajo del título */}
+        <div
+          className="mt-3 h-[2px] w-12 rounded-full bg-gradient-to-r from-blue-600 via-blue-500 to-transparent dark:from-blue-400 dark:via-blue-500"
+          aria-hidden="true"
+        />
+      </div>
+
+      {actions && (
+        <div className="flex-shrink-0 sm:max-w-[62%]">
+          {actions}
+        </div>
+      )}
+    </header>
+  );
+}

--- a/src/components/vistas/VistaDashboard.tsx
+++ b/src/components/vistas/VistaDashboard.tsx
@@ -1,12 +1,18 @@
 import React, { useState, useMemo, memo } from 'react';
 import type { LucideIcon } from 'lucide-react';
-import { RefreshCw, Download, DollarSign, ShoppingCart, Clock, Package, Truck, Check, TrendingUp, TrendingDown, Minus, Target, Users, AlertTriangle } from 'lucide-react';
+import {
+  DollarSign, ShoppingCart, Clock, Package, Truck, Check,
+  TrendingUp, TrendingDown, Minus, Target, Users, AlertTriangle,
+} from 'lucide-react';
 import { formatPrecio } from '../../utils/formatters';
 import LoadingSpinner from '../layout/LoadingSpinner';
+import DashboardViewHeader from '../dashboard/DashboardViewHeader';
+import DashboardToolbar from '../dashboard/DashboardToolbar';
+import { cn } from '../../lib/utils';
 import type {
   ProductoDB,
   DashboardMetricasExtended,
-  FiltroPeriodo
+  FiltroPeriodo,
 } from '../../types';
 
 // =============================================================================
@@ -19,11 +25,17 @@ interface TendenciaIndicatorProps {
   invertido?: boolean;
 }
 
-interface ColorClase {
-  bg: string;
-  icon: string;
-  text: string;
-  border?: string;
+interface MetricaSemantica {
+  /** Border-left coloreado (border-l-...) */
+  accentBorder: string;
+  /** Color del número y el icono dentro del badge */
+  accentText: string;
+  /** Fondo del badge circular del icono */
+  badgeBg: string;
+  /** Color del icono en el badge */
+  badgeIcon: string;
+  /** Gradient overlay sutil (before:from-...) */
+  gradientFrom: string;
 }
 
 interface MetricaCardProps {
@@ -31,15 +43,22 @@ interface MetricaCardProps {
   titulo: string;
   valor: string | number;
   subtitulo?: string;
-  colorClase: ColorClase;
+  semantica: MetricaSemantica;
   tendencia?: React.ReactNode;
+}
+
+interface EstadoSemantica {
+  accentBorder: string;
+  accentText: string;
+  badgeBg: string;
+  badgeIcon: string;
 }
 
 interface EstadoCardProps {
   icono: LucideIcon;
   titulo: string;
   valor: number;
-  colorClase: ColorClase;
+  semantica: EstadoSemantica;
   onClick?: () => void;
 }
 
@@ -75,15 +94,18 @@ const periodoLabels: Record<string, string> = {
   mes: 'Este mes',
   anio: 'Este año',
   historico: 'Histórico',
-  personalizado: 'Personalizado'
+  personalizado: 'Personalizado',
 };
 
-// Componente de indicador de tendencia
+// =============================================================================
+// SUB-COMPONENTES
+// =============================================================================
+
 const TendenciaIndicator = memo(function TendenciaIndicator({ valor, comparacion, invertido = false }: TendenciaIndicatorProps) {
   if (!comparacion || comparacion === 0) {
     return (
-      <span className="flex items-center text-xs text-gray-500">
-        <Minus className="w-3 h-3 mr-1" />
+      <span className="inline-flex items-center gap-1 text-[11px] text-stone-400 dark:text-stone-500">
+        <Minus className="w-3 h-3" />
         Sin datos previos
       </span>
     );
@@ -95,97 +117,190 @@ const TendenciaIndicator = memo(function TendenciaIndicator({ valor, comparacion
 
   if (esNeutro) {
     return (
-      <span className="flex items-center text-xs text-gray-500">
-        <Minus className="w-3 h-3 mr-1" />
+      <span className="inline-flex items-center gap-1 text-[11px] text-stone-400 dark:text-stone-500">
+        <Minus className="w-3 h-3" />
         Sin cambios
       </span>
     );
   }
 
   return (
-    <span className={`flex items-center text-xs ${esPositivo ? 'text-green-600' : 'text-red-600'}`}>
-      {esPositivo ? <TrendingUp className="w-3 h-3 mr-1" /> : <TrendingDown className="w-3 h-3 mr-1" />}
-      {Math.abs(porcentaje).toFixed(1)}% vs período anterior
+    <span className={cn(
+      'inline-flex items-center gap-1 text-[11px] font-medium tabular-nums px-1.5 py-0.5 rounded-md',
+      esPositivo
+        ? 'bg-emerald-50 text-emerald-700 dark:bg-emerald-900/20 dark:text-emerald-300'
+        : 'bg-rose-50 text-rose-700 dark:bg-rose-900/20 dark:text-rose-300',
+    )}>
+      {esPositivo ? <TrendingUp className="w-3 h-3" /> : <TrendingDown className="w-3 h-3" />}
+      {Math.abs(porcentaje).toFixed(1)}%
     </span>
   );
 });
 
-// Componente de tarjeta de métrica grande
-const MetricaCard = memo(function MetricaCard({ icono, titulo, valor, subtitulo, colorClase, tendencia }: MetricaCardProps) {
+const MetricaCard = memo(function MetricaCard({ icono, titulo, valor, subtitulo, semantica, tendencia }: MetricaCardProps) {
   const Icono = icono;
   return (
-    <div className="bg-white dark:bg-gray-800 rounded-xl shadow-lg p-6 hover:shadow-xl transition-shadow">
-      <div className="flex items-start justify-between">
-        <div className={`p-3 ${colorClase.bg} rounded-xl`}>
-          <Icono className={`w-7 h-7 ${colorClase.icon}`} />
-        </div>
-        {tendencia && (
-          <div className="text-right">
-            {tendencia}
-          </div>
-        )}
+    <div
+      className={cn(
+        'group relative overflow-hidden bg-white dark:bg-gray-800 border border-stone-200 dark:border-gray-700 border-l-4 rounded-xl px-5 py-4 shadow-warm hover:shadow-warm-md hover:-translate-y-px transition-[transform,box-shadow] duration-200',
+        semantica.accentBorder,
+        'before:absolute before:inset-0 before:bg-gradient-to-br before:to-transparent before:pointer-events-none',
+        semantica.gradientFrom,
+      )}
+    >
+      <div className="relative flex items-start justify-between gap-3">
+        <span className={cn('inline-flex items-center justify-center w-9 h-9 rounded-lg flex-shrink-0', semantica.badgeBg)}>
+          <Icono className={cn('w-[18px] h-[18px]', semantica.badgeIcon)} aria-hidden="true" />
+        </span>
+        {tendencia && <div className="flex-shrink-0 mt-1">{tendencia}</div>}
       </div>
-      <div className="mt-4">
-        <p className="text-sm text-gray-500 dark:text-gray-400">{titulo}</p>
-        <p className={`text-3xl font-bold mt-1 ${colorClase.text}`}>{valor}</p>
-        {subtitulo && <p className="text-xs text-gray-400 mt-1">{subtitulo}</p>}
+      <div className="relative mt-3">
+        <p className="text-[11px] font-semibold uppercase tracking-[0.08em] text-stone-500 dark:text-stone-400">
+          {titulo}
+        </p>
+        <p
+          className={cn('text-[28px] tabular-nums leading-tight mt-1', semantica.accentText)}
+          style={{ fontWeight: 800, letterSpacing: '-0.025em' }}
+        >
+          {valor}
+        </p>
+        {subtitulo && (
+          <p className="text-xs text-stone-500 dark:text-stone-400 mt-0.5">{subtitulo}</p>
+        )}
       </div>
     </div>
   );
 });
 
-// Componente de tarjeta de estado pequeña
-const EstadoCard = memo(function EstadoCard({ icono, titulo, valor, colorClase, onClick }: EstadoCardProps) {
+const EstadoCard = memo(function EstadoCard({ icono, titulo, valor, semantica, onClick }: EstadoCardProps) {
   const Icono = icono;
+  const Container: React.ElementType = onClick ? 'button' : 'div';
   return (
-    <button
+    <Container
       onClick={onClick}
-      className={`${colorClase.bg} border ${colorClase.border} rounded-xl p-4 text-left hover:scale-105 transition-transform w-full`}
+      className={cn(
+        'group relative overflow-hidden text-left bg-white dark:bg-gray-800 border border-stone-200 dark:border-gray-700 border-l-4 rounded-xl px-4 py-3 shadow-warm hover:shadow-warm-md hover:-translate-y-px transition-[transform,box-shadow] duration-200 w-full',
+        semantica.accentBorder,
+        onClick && 'cursor-pointer',
+      )}
     >
-      <div className="flex items-center justify-between">
-        <div className="flex items-center space-x-2">
-          <Icono className={`w-5 h-5 ${colorClase.icon}`} />
-          <span className={`${colorClase.text} font-medium text-sm`}>{titulo}</span>
-        </div>
+      <div className="flex items-center gap-2.5">
+        <span className={cn('inline-flex items-center justify-center w-7 h-7 rounded-lg flex-shrink-0', semantica.badgeBg)}>
+          <Icono className={cn('w-3.5 h-3.5', semantica.badgeIcon)} aria-hidden="true" />
+        </span>
+        <span className="text-[11px] font-semibold uppercase tracking-[0.08em] text-stone-500 dark:text-stone-400 leading-tight">
+          {titulo}
+        </span>
       </div>
-      <p className={`text-3xl font-bold ${colorClase.icon} mt-2`}>{valor}</p>
-    </button>
+      <p
+        className={cn('text-[26px] tabular-nums leading-tight mt-1.5', semantica.accentText)}
+        style={{ fontWeight: 800, letterSpacing: '-0.025em' }}
+      >
+        {valor.toLocaleString('es-AR')}
+      </p>
+    </Container>
   );
 });
 
-// Componente de barra de progreso animada
 const BarraProgreso = memo(function BarraProgreso({ dia, ventas, maxVenta, index }: BarraProgresoProps) {
   const porcentaje = maxVenta > 0 ? (ventas / maxVenta) * 100 : 0;
-  const esHoy = index === 6; // Último día es hoy
+  const esHoy = index === 6;
 
   return (
-    <div className="flex items-center space-x-3 group">
-      <span className={`w-12 text-sm ${esHoy ? 'font-bold text-blue-600' : 'text-gray-600'}`}>
+    <div className="flex items-center gap-3 group">
+      <span className={cn(
+        'w-12 text-sm tabular-nums',
+        esHoy ? 'font-bold text-blue-700 dark:text-blue-300' : 'text-stone-500 dark:text-stone-400',
+      )}>
         {dia}
       </span>
-      <div className="flex-1 bg-gray-200 dark:bg-gray-700 rounded-full h-8 overflow-hidden">
+      <div className="flex-1 bg-stone-100 dark:bg-gray-700 rounded-full h-7 overflow-hidden">
         <div
-          className={`h-8 rounded-full flex items-center justify-end pr-3 transition-all duration-500 ${
+          className={cn(
+            'h-7 rounded-full flex items-center justify-end pr-3 transition-all duration-500',
             esHoy
               ? 'bg-gradient-to-r from-blue-500 to-blue-600'
-              : 'bg-gradient-to-r from-blue-400 to-blue-500'
-          }`}
+              : 'bg-gradient-to-r from-blue-400/80 to-blue-500/80',
+          )}
           style={{
-            width: `${Math.max(porcentaje, 15)}%`,
-            animationDelay: `${index * 100}ms`
+            width: `${Math.max(porcentaje, 14)}%`,
+            animationDelay: `${index * 100}ms`,
           }}
         >
-          <span className="text-xs text-white font-medium truncate">
+          <span className="text-xs text-white font-semibold tabular-nums truncate">
             {formatPrecio(ventas)}
           </span>
         </div>
       </div>
-      <div className="w-16 text-right opacity-0 group-hover:opacity-100 transition-opacity">
-        <span className="text-xs text-gray-500">{porcentaje.toFixed(0)}%</span>
+      <div className="w-12 text-right opacity-0 group-hover:opacity-100 transition-opacity">
+        <span className="text-xs text-stone-500 dark:text-stone-400 tabular-nums">{porcentaje.toFixed(0)}%</span>
       </div>
     </div>
   );
 });
+
+// Mapping de semánticas (consistente con KPI cards de Pedidos)
+const METRICAS_SEMANTICA: Record<'ventas' | 'pedidos' | 'ticket' | 'clientes', MetricaSemantica> = {
+  ventas: {
+    accentBorder: 'border-l-emerald-500',
+    accentText: 'text-emerald-700 dark:text-emerald-300',
+    badgeBg: 'bg-emerald-100 dark:bg-emerald-500/15',
+    badgeIcon: 'text-emerald-600 dark:text-emerald-400',
+    gradientFrom: 'before:from-emerald-500/[0.07]',
+  },
+  pedidos: {
+    accentBorder: 'border-l-blue-500',
+    accentText: 'text-blue-700 dark:text-blue-300',
+    badgeBg: 'bg-blue-100 dark:bg-blue-500/15',
+    badgeIcon: 'text-blue-600 dark:text-blue-400',
+    gradientFrom: 'before:from-blue-500/[0.07]',
+  },
+  ticket: {
+    accentBorder: 'border-l-purple-500',
+    accentText: 'text-purple-700 dark:text-purple-300',
+    badgeBg: 'bg-purple-100 dark:bg-purple-500/15',
+    badgeIcon: 'text-purple-600 dark:text-purple-400',
+    gradientFrom: 'before:from-purple-500/[0.07]',
+  },
+  clientes: {
+    accentBorder: 'border-l-indigo-500',
+    accentText: 'text-indigo-700 dark:text-indigo-300',
+    badgeBg: 'bg-indigo-100 dark:bg-indigo-500/15',
+    badgeIcon: 'text-indigo-600 dark:text-indigo-400',
+    gradientFrom: 'before:from-indigo-500/[0.07]',
+  },
+};
+
+const ESTADOS_SEMANTICA: Record<'pendiente' | 'preparacion' | 'camino' | 'entregado', EstadoSemantica> = {
+  pendiente: {
+    accentBorder: 'border-l-amber-500',
+    accentText: 'text-amber-700 dark:text-amber-300',
+    badgeBg: 'bg-amber-100 dark:bg-amber-500/15',
+    badgeIcon: 'text-amber-600 dark:text-amber-400',
+  },
+  preparacion: {
+    accentBorder: 'border-l-orange-500',
+    accentText: 'text-orange-700 dark:text-orange-300',
+    badgeBg: 'bg-orange-100 dark:bg-orange-500/15',
+    badgeIcon: 'text-orange-600 dark:text-orange-400',
+  },
+  camino: {
+    accentBorder: 'border-l-blue-500',
+    accentText: 'text-blue-700 dark:text-blue-300',
+    badgeBg: 'bg-blue-100 dark:bg-blue-500/15',
+    badgeIcon: 'text-blue-600 dark:text-blue-400',
+  },
+  entregado: {
+    accentBorder: 'border-l-emerald-500',
+    accentText: 'text-emerald-700 dark:text-emerald-300',
+    badgeBg: 'bg-emerald-100 dark:bg-emerald-500/15',
+    badgeIcon: 'text-emerald-600 dark:text-emerald-400',
+  },
+};
+
+// =============================================================================
+// VISTA PRINCIPAL
+// =============================================================================
 
 export default function VistaDashboard({
   metricas,
@@ -198,13 +313,12 @@ export default function VistaDashboard({
   productosStockBajo = [],
   totalClientes = 0,
   isAdmin = false,
-  isPreventista = false
+  isPreventista = false,
 }: VistaDashboardProps) {
   const [fechaDesdeLocal, setFechaDesdeLocal] = useState<string>('');
   const [fechaHastaLocal, setFechaHastaLocal] = useState<string>('');
   const [mostrarFechasPersonalizadas, setMostrarFechasPersonalizadas] = useState<boolean>(false);
 
-  // Calcular métricas adicionales
   const metricasCalculadas = useMemo((): MetricasCalculadas | null => {
     if (!metricas) return null;
 
@@ -240,74 +354,61 @@ export default function VistaDashboard({
 
   if (loading) return <LoadingSpinner />;
 
-  return (
-    <div className="space-y-6">
-      {/* Header */}
-      <div className="flex flex-col sm:flex-row justify-between items-start sm:items-center gap-4">
-        <div>
-          <h1 className="text-2xl font-bold text-gray-800 dark:text-white">
-            {isPreventista && !isAdmin ? 'Mis Métricas' : 'Dashboard'}
-          </h1>
-          <p className="text-sm text-gray-500 dark:text-gray-400">
-            {isPreventista && !isAdmin
-              ? `Resumen de mis ventas - ${periodoLabels[filtroPeriodo]}`
-              : `Resumen de actividad - ${periodoLabels[filtroPeriodo]}`
-            }
-          </p>
-        </div>
-        <div className="flex flex-wrap gap-2">
-          <button
-            onClick={onRefetch}
-            disabled={loading}
-            className="flex items-center space-x-2 px-4 py-2 bg-white dark:bg-gray-800 border dark:border-gray-700 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors"
-            aria-label="Actualizar datos"
-          >
-            <RefreshCw className={`w-5 h-5 ${loading ? 'animate-spin' : ''}`} />
-            <span>Actualizar</span>
-          </button>
-          {isAdmin && (
-            <button
-              onClick={() => onDescargarBackup('completo')}
-              disabled={exportando}
-              className="flex items-center space-x-2 px-4 py-2 bg-green-600 text-white rounded-lg hover:bg-green-700 transition-colors"
-              aria-label="Descargar backup"
-            >
-              <Download className="w-5 h-5" />
-              <span>Backup</span>
-            </button>
-          )}
-        </div>
-      </div>
+  const verbo = isPreventista && !isAdmin ? 'Mis métricas' : 'Resumen';
 
-      {/* Alerta de stock bajo */}
+  return (
+    <div className="space-y-5">
+      {/* Header editorial con toolbar */}
+      <DashboardViewHeader
+        filtroPeriodo={filtroPeriodo}
+        fechaDesde={mostrarFechasPersonalizadas ? fechaDesdeLocal || null : null}
+        fechaHasta={mostrarFechasPersonalizadas ? fechaHastaLocal || null : null}
+        verbo={verbo}
+        periodoLabel={periodoLabels[filtroPeriodo] || filtroPeriodo}
+        loading={loading}
+        actions={
+          <DashboardToolbar
+            loading={loading}
+            exportando={exportando}
+            isAdmin={isAdmin}
+            onRefetch={onRefetch}
+            onDescargarBackup={onDescargarBackup}
+          />
+        }
+      />
+
+      {/* Alerta de stock bajo: chip compacto (no banner) */}
       {productosStockBajo.length > 0 && (
-        <div className="bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800 rounded-xl p-4 flex items-start space-x-3">
-          <AlertTriangle className="w-5 h-5 text-amber-600 flex-shrink-0 mt-0.5" />
-          <div>
+        <div className="inline-flex items-start gap-2.5 bg-amber-50 dark:bg-amber-900/15 border border-amber-200 dark:border-amber-800/40 rounded-lg px-3.5 py-2.5 text-sm">
+          <AlertTriangle className="w-4 h-4 text-amber-600 dark:text-amber-400 flex-shrink-0 mt-0.5" aria-hidden="true" />
+          <div className="min-w-0">
             <p className="font-medium text-amber-800 dark:text-amber-200">
-              Atención: {productosStockBajo.length} producto(s) con stock bajo
+              {productosStockBajo.length} producto{productosStockBajo.length === 1 ? '' : 's'} con stock bajo
             </p>
-            <p className="text-sm text-amber-600 dark:text-amber-300 mt-1">
-              {productosStockBajo.slice(0, 3).map(p => p.nombre).join(', ')}
-              {productosStockBajo.length > 3 && ` y ${productosStockBajo.length - 3} más`}
+            <p className="text-xs text-amber-700/80 dark:text-amber-300/80 mt-0.5 truncate">
+              {productosStockBajo.slice(0, 3).map(p => p.nombre).join(' · ')}
+              {productosStockBajo.length > 3 && ` · +${productosStockBajo.length - 3} más`}
             </p>
           </div>
         </div>
       )}
 
-      {/* Filtro de período */}
-      <div className="bg-white dark:bg-gray-800 rounded-xl shadow p-4">
-        <div className="flex flex-wrap items-center gap-2">
-          <span className="text-sm font-medium text-gray-600 dark:text-gray-300 mr-2">Período:</span>
+      {/* Filtro de período: chips horizontales */}
+      <div className="bg-white dark:bg-gray-800 border border-stone-200 dark:border-gray-700 rounded-xl shadow-warm p-4">
+        <div className="flex flex-wrap items-center gap-1.5">
+          <span className="text-[11px] font-semibold uppercase tracking-[0.08em] text-stone-500 dark:text-stone-400 mr-2">
+            Período
+          </span>
           {Object.entries(periodoLabels).map(([key, label]) => (
             <button
               key={key}
               onClick={() => handlePeriodoChange(key)}
-              className={`px-3 py-1.5 rounded-lg text-sm font-medium transition-all ${
+              className={cn(
+                'h-8 px-3 rounded-lg text-sm font-medium transition-colors',
                 filtroPeriodo === key
-                  ? 'bg-blue-600 text-white shadow-md'
-                  : 'bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-600'
-              }`}
+                  ? 'bg-blue-600 text-white shadow-warm'
+                  : 'bg-stone-100 dark:bg-gray-700 text-stone-700 dark:text-stone-200 hover:bg-stone-200 dark:hover:bg-gray-600',
+              )}
               aria-pressed={filtroPeriodo === key}
             >
               {label}
@@ -315,30 +416,30 @@ export default function VistaDashboard({
           ))}
         </div>
         {mostrarFechasPersonalizadas && (
-          <div className="mt-4 flex flex-wrap items-end gap-3">
+          <div className="mt-4 pt-4 border-t border-stone-200 dark:border-gray-700 flex flex-wrap items-end gap-3">
             <div>
-              <label htmlFor="fecha-desde" className="block text-xs text-gray-500 dark:text-gray-400 mb-1">Desde</label>
+              <label htmlFor="fecha-desde" className="block text-[10px] font-semibold uppercase tracking-[0.08em] text-stone-500 dark:text-stone-400 mb-1">Desde</label>
               <input
                 id="fecha-desde"
                 type="date"
                 value={fechaDesdeLocal}
                 onChange={e => setFechaDesdeLocal(e.target.value)}
-                className="px-3 py-2 border dark:border-gray-600 rounded-lg text-sm focus:ring-2 focus:ring-blue-500 dark:bg-gray-700 dark:text-white"
+                className="h-9 px-3 rounded-lg border border-stone-200 dark:border-gray-700 text-sm bg-white dark:bg-gray-800 text-stone-700 dark:text-stone-200 focus:outline-none focus:ring-2 focus:ring-blue-500/40 focus:border-blue-400"
               />
             </div>
             <div>
-              <label htmlFor="fecha-hasta" className="block text-xs text-gray-500 dark:text-gray-400 mb-1">Hasta</label>
+              <label htmlFor="fecha-hasta" className="block text-[10px] font-semibold uppercase tracking-[0.08em] text-stone-500 dark:text-stone-400 mb-1">Hasta</label>
               <input
                 id="fecha-hasta"
                 type="date"
                 value={fechaHastaLocal}
                 onChange={e => setFechaHastaLocal(e.target.value)}
-                className="px-3 py-2 border dark:border-gray-600 rounded-lg text-sm focus:ring-2 focus:ring-blue-500 dark:bg-gray-700 dark:text-white"
+                className="h-9 px-3 rounded-lg border border-stone-200 dark:border-gray-700 text-sm bg-white dark:bg-gray-800 text-stone-700 dark:text-stone-200 focus:outline-none focus:ring-2 focus:ring-blue-500/40 focus:border-blue-400"
               />
             </div>
             <button
               onClick={aplicarFechasPersonalizadas}
-              className="px-4 py-2 bg-blue-600 text-white rounded-lg text-sm hover:bg-blue-700 transition-colors"
+              className="h-9 px-4 rounded-lg text-sm font-semibold bg-blue-600 text-white hover:bg-blue-700 transition-colors"
             >
               Aplicar
             </button>
@@ -347,101 +448,63 @@ export default function VistaDashboard({
       </div>
 
       {/* Métricas principales */}
-      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-3">
         <MetricaCard
           icono={DollarSign}
           titulo="Ventas"
           valor={formatPrecio(metricas.ventasPeriodo)}
           subtitulo={periodoLabels[filtroPeriodo]}
-          colorClase={{ bg: 'bg-green-100 dark:bg-green-900/30', icon: 'text-green-600', text: 'text-green-600' }}
+          semantica={METRICAS_SEMANTICA.ventas}
           tendencia={<TendenciaIndicator valor={metricas.ventasPeriodo} comparacion={metricas.ventasPeriodoAnterior} />}
         />
         <MetricaCard
           icono={ShoppingCart}
           titulo="Pedidos"
-          valor={metricas.pedidosPeriodo}
+          valor={metricas.pedidosPeriodo.toLocaleString('es-AR')}
           subtitulo={periodoLabels[filtroPeriodo]}
-          colorClase={{ bg: 'bg-blue-100 dark:bg-blue-900/30', icon: 'text-blue-600', text: 'text-blue-600' }}
+          semantica={METRICAS_SEMANTICA.pedidos}
           tendencia={<TendenciaIndicator valor={metricas.pedidosPeriodo} comparacion={metricas.pedidosPeriodoAnterior} />}
         />
         <MetricaCard
           icono={Target}
-          titulo="Ticket Promedio"
+          titulo="Ticket promedio"
           valor={formatPrecio(metricasCalculadas?.ticketPromedio || 0)}
           subtitulo="Por pedido"
-          colorClase={{ bg: 'bg-purple-100 dark:bg-purple-900/30', icon: 'text-purple-600', text: 'text-purple-600' }}
+          semantica={METRICAS_SEMANTICA.ticket}
         />
         <MetricaCard
           icono={Users}
           titulo="Clientes"
-          valor={totalClientes}
+          valor={totalClientes.toLocaleString('es-AR')}
           subtitulo="Registrados"
-          colorClase={{ bg: 'bg-indigo-100 dark:bg-indigo-900/30', icon: 'text-indigo-600', text: 'text-indigo-600' }}
+          semantica={METRICAS_SEMANTICA.clientes}
         />
       </div>
 
       {/* Estados de pedidos */}
       <div>
-        <h3 className="text-lg font-semibold text-gray-800 dark:text-white mb-3">Estado de Pedidos</h3>
-        <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
-          <EstadoCard
-            icono={Clock}
-            titulo="Pendientes"
-            valor={metricas.pedidosPorEstado.pendiente}
-            colorClase={{
-              bg: 'bg-yellow-50 dark:bg-yellow-900/20',
-              border: 'border-yellow-200 dark:border-yellow-800',
-              icon: 'text-yellow-600',
-              text: 'text-yellow-800 dark:text-yellow-200'
-            }}
-          />
-          <EstadoCard
-            icono={Package}
-            titulo="En preparación"
-            valor={metricas.pedidosPorEstado.en_preparacion || 0}
-            colorClase={{
-              bg: 'bg-orange-50 dark:bg-orange-900/20',
-              border: 'border-orange-200 dark:border-orange-800',
-              icon: 'text-orange-600',
-              text: 'text-orange-800 dark:text-orange-200'
-            }}
-          />
-          <EstadoCard
-            icono={Truck}
-            titulo="En camino"
-            valor={metricas.pedidosPorEstado.asignado}
-            colorClase={{
-              bg: 'bg-blue-50 dark:bg-blue-900/20',
-              border: 'border-blue-200 dark:border-blue-800',
-              icon: 'text-blue-600',
-              text: 'text-blue-800 dark:text-blue-200'
-            }}
-          />
-          <EstadoCard
-            icono={Check}
-            titulo="Entregados"
-            valor={metricas.pedidosPorEstado.entregado}
-            colorClase={{
-              bg: 'bg-green-50 dark:bg-green-900/20',
-              border: 'border-green-200 dark:border-green-800',
-              icon: 'text-green-600',
-              text: 'text-green-800 dark:text-green-200'
-            }}
-          />
+        <h3 className="text-[11px] font-semibold uppercase tracking-[0.14em] text-stone-500 dark:text-stone-400 mb-2.5">
+          Estado de pedidos
+        </h3>
+        <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
+          <EstadoCard icono={Clock} titulo="Pendientes" valor={metricas.pedidosPorEstado.pendiente} semantica={ESTADOS_SEMANTICA.pendiente} />
+          <EstadoCard icono={Package} titulo="En preparación" valor={metricas.pedidosPorEstado.en_preparacion || 0} semantica={ESTADOS_SEMANTICA.preparacion} />
+          <EstadoCard icono={Truck} titulo="En camino" valor={metricas.pedidosPorEstado.asignado} semantica={ESTADOS_SEMANTICA.camino} />
+          <EstadoCard icono={Check} titulo="Entregados" valor={metricas.pedidosPorEstado.entregado} semantica={ESTADOS_SEMANTICA.entregado} />
         </div>
       </div>
 
       {/* Gráficos */}
-      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-5">
         {/* Ventas últimos 7 días */}
-        <div className="bg-white dark:bg-gray-800 rounded-xl shadow-lg p-6">
+        <div className="bg-white dark:bg-gray-800 border border-stone-200 dark:border-gray-700 rounded-xl shadow-warm p-5">
           <div className="flex items-center justify-between mb-4">
-            <h3 className="font-semibold text-gray-800 dark:text-white">Ventas últimos 7 días</h3>
-            <span className="text-sm text-gray-500 dark:text-gray-400">
-              Total: {formatPrecio(metricas.ventasPorDia.reduce((sum, d) => sum + d.ventas, 0))}
+            <h3 className="text-base font-semibold text-stone-900 dark:text-white">Ventas últimos 7 días</h3>
+            <span className="text-xs text-stone-500 dark:text-stone-400 tabular-nums">
+              Total: <span className="font-semibold text-stone-700 dark:text-stone-200">{formatPrecio(metricas.ventasPorDia.reduce((sum, d) => sum + d.ventas, 0))}</span>
             </span>
           </div>
-          <div className="space-y-3">
+          <div className="space-y-2.5">
             {metricas.ventasPorDia.map((d, i) => {
               const maxVenta = Math.max(...metricas.ventasPorDia.map(x => x.ventas)) || 1;
               return (
@@ -458,45 +521,51 @@ export default function VistaDashboard({
         </div>
 
         {/* Top 5 productos */}
-        <div className="bg-white dark:bg-gray-800 rounded-xl shadow-lg p-6">
-          <h3 className="font-semibold text-gray-800 dark:text-white mb-4">
-            Top 5 Productos
-            <span className="text-sm font-normal text-gray-500 dark:text-gray-400 ml-2">
-              ({periodoLabels[filtroPeriodo]})
+        <div className="bg-white dark:bg-gray-800 border border-stone-200 dark:border-gray-700 rounded-xl shadow-warm p-5">
+          <div className="flex items-center justify-between mb-4">
+            <h3 className="text-base font-semibold text-stone-900 dark:text-white">
+              Top 5 productos
+            </h3>
+            <span className="text-xs text-stone-500 dark:text-stone-400">
+              {periodoLabels[filtroPeriodo]}
             </span>
-          </h3>
-          <div className="space-y-4">
+          </div>
+          <div className="space-y-3.5">
             {metricas.productosMasVendidos.length === 0 ? (
-              <p className="text-gray-500 dark:text-gray-400 text-center py-8">
+              <p className="text-stone-500 dark:text-stone-400 text-center py-8 text-sm">
                 Sin datos en este período
               </p>
             ) : metricas.productosMasVendidos.map((p, i) => {
               const maxCantidad = metricas.productosMasVendidos[0]?.cantidad || 1;
               const porcentaje = (p.cantidad / maxCantidad) * 100;
-
+              const rankClass =
+                i === 0 ? 'bg-gradient-to-br from-amber-400 to-amber-500 text-amber-900' :
+                i === 1 ? 'bg-gradient-to-br from-stone-300 to-stone-400 text-stone-800' :
+                i === 2 ? 'bg-gradient-to-br from-orange-400 to-orange-500 text-orange-900' :
+                'bg-stone-100 dark:bg-gray-700 text-stone-600 dark:text-stone-300';
+              const barColor =
+                i === 0 ? 'bg-amber-500' :
+                i === 1 ? 'bg-stone-400' :
+                i === 2 ? 'bg-orange-500' :
+                'bg-blue-500';
               return (
-                <div key={p.id} className="flex items-center space-x-3">
-                  <span className={`w-8 h-8 rounded-full flex items-center justify-center text-sm font-bold shadow-sm ${
-                    i === 0 ? 'bg-gradient-to-br from-yellow-400 to-yellow-500 text-yellow-900' :
-                    i === 1 ? 'bg-gradient-to-br from-gray-300 to-gray-400 text-gray-700' :
-                    i === 2 ? 'bg-gradient-to-br from-orange-400 to-orange-500 text-orange-900' :
-                    'bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-300'
-                  }`}>
+                <div key={p.id} className="flex items-center gap-3">
+                  <span className={cn(
+                    'w-8 h-8 rounded-full flex items-center justify-center text-sm font-bold shadow-warm flex-shrink-0',
+                    rankClass,
+                  )}>
                     {i + 1}
                   </span>
                   <div className="flex-1 min-w-0">
-                    <div className="flex items-center justify-between mb-1">
-                      <span className="font-medium text-gray-800 dark:text-white truncate">{p.nombre}</span>
-                      <span className="text-sm text-gray-600 dark:text-gray-400 ml-2">{p.cantidad} unid.</span>
+                    <div className="flex items-center justify-between mb-1.5 gap-2">
+                      <span className="font-medium text-sm text-stone-800 dark:text-white truncate">{p.nombre}</span>
+                      <span className="text-xs text-stone-600 dark:text-stone-300 tabular-nums flex-shrink-0">
+                        {p.cantidad.toLocaleString('es-AR')} <span className="text-stone-400">unid.</span>
+                      </span>
                     </div>
-                    <div className="w-full bg-gray-200 dark:bg-gray-700 rounded-full h-2">
+                    <div className="w-full bg-stone-100 dark:bg-gray-700 rounded-full h-1.5 overflow-hidden">
                       <div
-                        className={`h-2 rounded-full transition-all duration-500 ${
-                          i === 0 ? 'bg-yellow-500' :
-                          i === 1 ? 'bg-gray-400' :
-                          i === 2 ? 'bg-orange-500' :
-                          'bg-blue-500'
-                        }`}
+                        className={cn('h-1.5 rounded-full transition-all duration-500', barColor)}
                         style={{ width: `${porcentaje}%` }}
                       />
                     </div>
@@ -510,24 +579,25 @@ export default function VistaDashboard({
 
       {/* Tasa de entrega */}
       {metricasCalculadas && (
-        <div className="bg-white dark:bg-gray-800 rounded-xl shadow-lg p-6">
-          <h3 className="font-semibold text-gray-800 dark:text-white mb-4">Tasa de Entrega</h3>
-          <div className="flex items-center space-x-4">
-            <div className="flex-1">
-              <div className="w-full bg-gray-200 dark:bg-gray-700 rounded-full h-4">
-                <div
-                  className="bg-gradient-to-r from-green-500 to-green-600 h-4 rounded-full transition-all duration-500"
-                  style={{ width: `${metricasCalculadas.tasaEntrega}%` }}
-                />
-              </div>
+        <div className="bg-white dark:bg-gray-800 border border-stone-200 dark:border-gray-700 rounded-xl shadow-warm p-5">
+          <div className="flex items-center justify-between mb-3">
+            <div>
+              <h3 className="text-base font-semibold text-stone-900 dark:text-white">Tasa de entrega</h3>
+              <p className="text-xs text-stone-500 dark:text-stone-400 mt-0.5">Porcentaje de pedidos entregados del total</p>
             </div>
-            <span className="text-2xl font-bold text-green-600">
+            <span
+              className="text-3xl text-emerald-700 dark:text-emerald-300 tabular-nums"
+              style={{ fontWeight: 800, letterSpacing: '-0.025em' }}
+            >
               {metricasCalculadas.tasaEntrega.toFixed(1)}%
             </span>
           </div>
-          <p className="text-sm text-gray-500 dark:text-gray-400 mt-2">
-            Porcentaje de pedidos entregados del total
-          </p>
+          <div className="w-full bg-stone-100 dark:bg-gray-700 rounded-full h-3 overflow-hidden">
+            <div
+              className="bg-gradient-to-r from-emerald-500 to-emerald-600 h-3 rounded-full transition-all duration-500"
+              style={{ width: `${metricasCalculadas.tasaEntrega}%` }}
+            />
+          </div>
         </div>
       )}
     </div>

--- a/src/components/vistas/VistaPedidos.tsx
+++ b/src/components/vistas/VistaPedidos.tsx
@@ -4,11 +4,12 @@
  * Recibe datos ya paginados server-side desde PedidosContainer.
  * Renderiza lista + controles de paginación.
  */
-import { useState, useRef, useEffect } from 'react';
-import { ShoppingCart, Plus, Route, FileDown, PackageCheck, Banknote, ChevronDown, Truck, MapPin, History } from 'lucide-react';
+import { ShoppingCart } from 'lucide-react';
 import LoadingSpinner from '../layout/LoadingSpinner';
 import Paginacion from '../layout/Paginacion';
 import { PedidoCard, PedidoFilters, PedidoStats, VistaRutaTransportista } from '../pedidos';
+import PedidosViewHeader from '../pedidos/PedidosViewHeader';
+import PedidoToolbar from '../pedidos/PedidoToolbar';
 import type {
   PedidoDB,
   ClienteDB,
@@ -158,89 +159,30 @@ export default function VistaPedidos({
 
   return (
     <div className="space-y-4">
-      {/* Header */}
-      <div className="flex flex-col sm:flex-row justify-between items-start sm:items-center gap-4">
-        <h1 className="text-2xl font-bold text-gray-800 dark:text-white">Pedidos</h1>
-        <div className="flex flex-wrap gap-2">
-          {(isAdmin || isEncargado) && (
-            <button
-              onClick={onOptimizarRuta}
-              className="flex items-center space-x-2 px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors"
-            >
-              <Route className="w-5 h-5" />
-              <span>Optimizar Ruta</span>
-            </button>
-          )}
-          {(isAdmin || isEncargado) && (
-            <button
-              onClick={onExportarPDF}
-              className="flex items-center space-x-2 px-4 py-2 bg-purple-600 text-white rounded-lg hover:bg-purple-700 transition-colors"
-            >
-              <FileDown className="w-5 h-5" />
-              <span>Exportar PDF</span>
-            </button>
-          )}
-          {(isAdmin || isEncargado) && (
-            <ExcelExportDropdown exportando={exportando} onExportarExcel={onExportarExcel} totalCount={totalCount} />
-          )}
-          {(isAdmin || isEncargado) && onEntregasMasivas && (
-            <button
-              onClick={onEntregasMasivas}
-              className="flex items-center space-x-2 px-4 py-2 bg-teal-600 text-white rounded-lg hover:bg-teal-700 transition-colors"
-            >
-              <PackageCheck className="w-5 h-5" />
-              <span className="hidden sm:inline">Entregas Masivas</span>
-            </button>
-          )}
-          {(isAdmin || isEncargado) && onAsignarTransportistaMasivo && (
-            <button
-              onClick={onAsignarTransportistaMasivo}
-              className="flex items-center space-x-2 px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors"
-            >
-              <Truck className="w-5 h-5" />
-              <span className="hidden sm:inline">Asignar Transportista</span>
-            </button>
-          )}
-          {(isAdmin || isEncargado) && onPagosMasivos && (
-            <button
-              onClick={onPagosMasivos}
-              className="flex items-center space-x-2 px-4 py-2 bg-green-600 text-white rounded-lg hover:bg-green-700 transition-colors"
-            >
-              <Banknote className="w-5 h-5" />
-              <span className="hidden sm:inline">Pagos Masivos</span>
-            </button>
-          )}
-          {isPreventista && onVerVisitasHoy && (
-            <button
-              onClick={onVerVisitasHoy}
-              className="flex items-center space-x-2 px-4 py-2 bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-200 rounded-lg hover:bg-gray-200 dark:hover:bg-gray-600 transition-colors"
-              title="Ver clientes que visitaste hoy"
-            >
-              <History className="w-5 h-5" />
-              <span className="hidden sm:inline">Visitas del día</span>
-            </button>
-          )}
-          {isPreventista && onMarcarVisita && (
-            <button
-              onClick={onMarcarVisita}
-              className="flex items-center space-x-2 px-4 py-2 bg-indigo-600 text-white rounded-lg hover:bg-indigo-700 transition-colors"
-              title="Marcar visita a un cliente sin necesidad de cargar pedido"
-            >
-              <MapPin className="w-5 h-5" />
-              <span>Marcar visita</span>
-            </button>
-          )}
-          {(isAdmin || isEncargado || isPreventista) && (
-            <button
-              onClick={onNuevoPedido}
-              className="flex items-center space-x-2 px-4 py-2 bg-green-600 text-white rounded-lg hover:bg-green-700 transition-colors"
-            >
-              <Plus className="w-5 h-5" />
-              <span>Nuevo</span>
-            </button>
-          )}
-        </div>
-      </div>
+      {/* Header con título dinámico + toolbar */}
+      <PedidosViewHeader
+        filtros={filtros}
+        totalCount={totalCount}
+        loading={loading}
+        actions={
+          <PedidoToolbar
+            isAdmin={isAdmin}
+            isEncargado={isEncargado}
+            isPreventista={isPreventista}
+            exportando={exportando}
+            totalCount={totalCount}
+            onNuevoPedido={onNuevoPedido}
+            onOptimizarRuta={onOptimizarRuta}
+            onExportarPDF={onExportarPDF}
+            onExportarExcel={onExportarExcel}
+            onEntregasMasivas={onEntregasMasivas}
+            onPagosMasivos={onPagosMasivos}
+            onAsignarTransportistaMasivo={onAsignarTransportistaMasivo}
+            onMarcarVisita={onMarcarVisita}
+            onVerVisitasHoy={onVerVisitasHoy}
+          />
+        }
+      />
 
       {/* Filtros */}
       <PedidoFilters
@@ -268,26 +210,35 @@ export default function VistaPedidos({
       ) : (
         <>
           <div className="space-y-3">
-            {pedidos.map(pedido => (
-              <PedidoCard
+            {pedidos.map((pedido, idx) => (
+              <div
                 key={pedido.id}
-                pedido={pedido}
-                isAdmin={isAdmin}
-                isPreventista={isPreventista}
-                isTransportista={isTransportista}
-                isEncargado={isEncargado}
-                onVerHistorial={onVerHistorial}
-                onEditarPedido={onEditarPedido}
-                onEditarNotas={onEditarNotas}
-                onMarcarEnPreparacion={onMarcarEnPreparacion}
-                onVolverAPendiente={onVolverAPendiente}
-                onAsignarTransportista={onAsignarTransportista}
-                onMarcarEntregado={onMarcarEntregado}
-                onMarcarEntregadoConSalvedad={onMarcarEntregadoConSalvedad}
-                onDesmarcarEntregado={onDesmarcarEntregado}
-                onCancelarPedido={onCancelarPedido}
-                onRegistrarPago={onAbrirPagoPedido}
-              />
+                style={{
+                  // Stagger fade-in: cada card entra 40ms después de la anterior,
+                  // cap a 12 items para que no se sienta lento en páginas largas.
+                  animation: 'card-in 0.32s cubic-bezier(0.22, 1, 0.36, 1) both',
+                  animationDelay: `${Math.min(idx, 12) * 40}ms`,
+                }}
+              >
+                <PedidoCard
+                  pedido={pedido}
+                  isAdmin={isAdmin}
+                  isPreventista={isPreventista}
+                  isTransportista={isTransportista}
+                  isEncargado={isEncargado}
+                  onVerHistorial={onVerHistorial}
+                  onEditarPedido={onEditarPedido}
+                  onEditarNotas={onEditarNotas}
+                  onMarcarEnPreparacion={onMarcarEnPreparacion}
+                  onVolverAPendiente={onVolverAPendiente}
+                  onAsignarTransportista={onAsignarTransportista}
+                  onMarcarEntregado={onMarcarEntregado}
+                  onMarcarEntregadoConSalvedad={onMarcarEntregadoConSalvedad}
+                  onDesmarcarEntregado={onDesmarcarEntregado}
+                  onCancelarPedido={onCancelarPedido}
+                  onRegistrarPago={onAbrirPagoPedido}
+                />
+              </div>
             ))}
           </div>
 
@@ -304,59 +255,3 @@ export default function VistaPedidos({
   );
 }
 
-// =============================================================================
-// EXCEL EXPORT DROPDOWN
-// =============================================================================
-
-function ExcelExportDropdown({
-  exportando,
-  onExportarExcel,
-  totalCount
-}: {
-  exportando: boolean;
-  onExportarExcel: (modo: 'pagina' | 'filtro') => void;
-  totalCount: number;
-}) {
-  const [open, setOpen] = useState(false);
-  const ref = useRef<HTMLDivElement>(null);
-
-  useEffect(() => {
-    function handleClickOutside(e: MouseEvent) {
-      if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false);
-    }
-    if (open) document.addEventListener('mousedown', handleClickOutside);
-    return () => document.removeEventListener('mousedown', handleClickOutside);
-  }, [open]);
-
-  return (
-    <div className="relative" ref={ref}>
-      <button
-        onClick={() => setOpen(!open)}
-        disabled={exportando}
-        className="flex items-center space-x-2 px-4 py-2 bg-green-700 text-white rounded-lg hover:bg-green-800 transition-colors disabled:opacity-50"
-      >
-        <FileDown className="w-5 h-5" />
-        <span>{exportando ? 'Exportando...' : 'Excel'}</span>
-        <ChevronDown className="w-4 h-4" />
-      </button>
-      {open && !exportando && (
-        <div className="absolute right-0 mt-1 w-56 bg-white dark:bg-gray-800 rounded-lg shadow-lg border dark:border-gray-700 z-50 overflow-hidden">
-          <button
-            onClick={() => { onExportarExcel('pagina'); setOpen(false); }}
-            className="w-full px-4 py-3 text-left text-sm hover:bg-gray-50 dark:hover:bg-gray-700 dark:text-white border-b dark:border-gray-700"
-          >
-            <p className="font-medium">Página actual</p>
-            <p className="text-xs text-gray-500 dark:text-gray-400">Solo los pedidos visibles en pantalla</p>
-          </button>
-          <button
-            onClick={() => { onExportarExcel('filtro'); setOpen(false); }}
-            className="w-full px-4 py-3 text-left text-sm hover:bg-gray-50 dark:hover:bg-gray-700 dark:text-white"
-          >
-            <p className="font-medium">Filtro actual ({totalCount} pedidos)</p>
-            <p className="text-xs text-gray-500 dark:text-gray-400">Todos los pedidos que coinciden con el filtro</p>
-          </button>
-        </div>
-      )}
-    </div>
-  );
-}

--- a/src/components/vistas/VistaProductos.tsx
+++ b/src/components/vistas/VistaProductos.tsx
@@ -1,9 +1,15 @@
 import { useState, useMemo, useRef } from 'react';
 import type { ChangeEvent } from 'react';
-import { Package, Plus, Edit2, Trash2, Search, AlertTriangle, Minus, TrendingDown, Percent, ClipboardCheck, Tag, ChevronLeft, ChevronRight, ArrowLeftRight } from 'lucide-react';
+import {
+  Package, Edit2, Trash2, Search, Minus,
+  ChevronLeft, ChevronRight,
+} from 'lucide-react';
 import { formatPrecio } from '../../utils/formatters';
 import LoadingSpinner from '../layout/LoadingSpinner';
 import Paginacion from '../layout/Paginacion';
+import ProductosViewHeader from '../productos/ProductosViewHeader';
+import ProductoToolbar from '../productos/ProductoToolbar';
+import { cn } from '../../lib/utils';
 import type { ProductoDB, ProveedorDBExtended } from '../../types';
 
 const ITEMS_PER_PAGE = 20;
@@ -14,6 +20,7 @@ const ITEMS_PER_PAGE = 20;
 
 export interface VistaProductosProps {
   productos: ProductoDB[];
+  productosStockBajo: ProductoDB[];
   proveedores?: ProveedorDBExtended[];
   loading: boolean;
   isAdmin: boolean;
@@ -25,10 +32,13 @@ export interface VistaProductosProps {
   onActualizacionMasivaPrecios?: () => void;
   onGestionarCategorias?: () => void;
   onCambioProducto?: () => void;
+  onControlStock?: () => void;
+  onAbrirStockBajo?: () => void;
 }
 
 export default function VistaProductos({
   productos,
+  productosStockBajo,
   proveedores = [],
   loading,
   isAdmin,
@@ -39,7 +49,9 @@ export default function VistaProductos({
   onVerHistorialMermas,
   onActualizacionMasivaPrecios,
   onGestionarCategorias,
-  onCambioProducto
+  onCambioProducto,
+  onControlStock,
+  onAbrirStockBajo,
 }: VistaProductosProps) {
   const [busqueda, setBusqueda] = useState<string>('');
   const [filtroCategoria, setFiltroCategoria] = useState<string>('todas');
@@ -53,17 +65,12 @@ export default function VistaProductos({
     return ['todas', ...Array.from(catsSet).sort()];
   }, [productos]);
 
-  // Productos con stock bajo
-  const productosStockBajo = useMemo((): ProductoDB[] => {
-    return productos.filter((p: ProductoDB) => p.stock < (p.stock_minimo || 10));
-  }, [productos]);
-
   // Filtrar productos
   const productosFiltrados = useMemo((): ProductoDB[] => {
     return productos.filter((p: ProductoDB) => {
-      const matchBusqueda = !busqueda ||
-        p.nombre?.toLowerCase().includes(busqueda.toLowerCase()) ||
-        p.codigo?.toLowerCase().includes(busqueda.toLowerCase());
+      const matchBusqueda = !busqueda
+        || p.nombre?.toLowerCase().includes(busqueda.toLowerCase())
+        || p.codigo?.toLowerCase().includes(busqueda.toLowerCase());
 
       const matchCategoria = filtroCategoria === 'todas' || p.categoria === filtroCategoria;
 
@@ -80,164 +87,85 @@ export default function VistaProductos({
     return productosFiltrados.slice(inicio, inicio + ITEMS_PER_PAGE);
   }, [productosFiltrados, paginaActual]);
 
-  // Reset page when filters change
   const handleBusqueda = (e: ChangeEvent<HTMLInputElement>) => { setBusqueda(e.target.value); setPaginaActual(1); };
   const handleCategoria = (cat: string) => { setFiltroCategoria(cat); setPaginaActual(1); };
-  const handleStockBajo = () => { setMostrarSoloStockBajo(!mostrarSoloStockBajo); setPaginaActual(1); };
+  const handleStockBajoToggle = () => { setMostrarSoloStockBajo(!mostrarSoloStockBajo); setPaginaActual(1); };
 
-  // Mapa de proveedores para lookup rápido
   const proveedoresMap = useMemo(() => {
-    return new Map(proveedores.map(p => [p.id, p.nombre]))
-  }, [proveedores])
+    return new Map(proveedores.map(p => [p.id, p.nombre]));
+  }, [proveedores]);
 
+  // Color de la pill de stock — alineado con la paleta de Pedidos (rose/amber/orange/emerald).
   const getStockColor = (producto: ProductoDB): string => {
     const stockMinimo = producto.stock_minimo || 10;
-    if (producto.stock === 0) return 'bg-red-100 dark:bg-red-900/30 text-red-700 dark:text-red-400';
-    if (producto.stock < stockMinimo) return 'bg-yellow-100 dark:bg-yellow-900/30 text-yellow-700 dark:text-yellow-400';
-    if (producto.stock < stockMinimo * 2) return 'bg-orange-100 dark:bg-orange-900/30 text-orange-700 dark:text-orange-400';
-    return 'bg-green-100 dark:bg-green-900/30 text-green-700 dark:text-green-400';
+    if (producto.stock === 0) return 'bg-rose-100 dark:bg-rose-900/30 text-rose-700 dark:text-rose-300';
+    if (producto.stock < stockMinimo) return 'bg-amber-100 dark:bg-amber-900/30 text-amber-700 dark:text-amber-300';
+    if (producto.stock < stockMinimo * 2) return 'bg-orange-100 dark:bg-orange-900/30 text-orange-700 dark:text-orange-300';
+    return 'bg-emerald-100 dark:bg-emerald-900/30 text-emerald-700 dark:text-emerald-300';
   };
 
   return (
     <div className="space-y-4">
-      {/* Header */}
-      <div className="flex flex-col sm:flex-row justify-between items-start sm:items-center gap-4">
-        <div>
-          <h1 className="text-2xl font-bold text-gray-800 dark:text-white">Productos</h1>
-          <p className="text-sm text-gray-500 dark:text-gray-400">{productos.length} productos en catálogo</p>
-        </div>
-        {(isAdmin || onCambioProducto) && (
-          <div className="flex flex-wrap gap-2">
-            {isAdmin && onGestionarCategorias && (
-              <button
-                onClick={onGestionarCategorias}
-                className="flex items-center space-x-2 px-4 py-2 bg-purple-100 dark:bg-purple-900/30 text-purple-700 dark:text-purple-400 rounded-lg hover:bg-purple-200 dark:hover:bg-purple-900/50 transition-colors"
-              >
-                <Tag className="w-5 h-5" />
-                <span>Categorías</span>
-              </button>
-            )}
-            {isAdmin && (
-              <button
-                onClick={async () => {
-                  const { exportControlStock } = await import('../../utils/excel');
-                  await exportControlStock(productos);
-                }}
-                className="flex items-center space-x-2 px-4 py-2 bg-amber-100 dark:bg-amber-900/30 text-amber-700 dark:text-amber-400 rounded-lg hover:bg-amber-200 dark:hover:bg-amber-900/50 transition-colors"
-              >
-                <ClipboardCheck className="w-5 h-5" />
-                <span>Control de Stock</span>
-              </button>
-            )}
-            {isAdmin && onVerHistorialMermas && (
-              <button
-                onClick={onVerHistorialMermas}
-                className="flex items-center space-x-2 px-4 py-2 bg-red-100 dark:bg-red-900/30 text-red-700 dark:text-red-400 rounded-lg hover:bg-red-200 dark:hover:bg-red-900/50 transition-colors"
-              >
-                <TrendingDown className="w-5 h-5" />
-                <span>Historial Mermas</span>
-              </button>
-            )}
-            {isAdmin && onActualizacionMasivaPrecios && (
-              <button
-                onClick={onActualizacionMasivaPrecios}
-                className="flex items-center space-x-2 px-4 py-2 bg-indigo-100 dark:bg-indigo-900/30 text-indigo-700 dark:text-indigo-400 rounded-lg hover:bg-indigo-200 dark:hover:bg-indigo-900/50 transition-colors"
-              >
-                <Percent className="w-5 h-5" />
-                <span>Actualización masiva</span>
-              </button>
-            )}
-            {onCambioProducto && (
-              <button
-                onClick={onCambioProducto}
-                className="flex items-center space-x-2 px-4 py-2 bg-indigo-100 dark:bg-indigo-900/30 text-indigo-700 dark:text-indigo-400 rounded-lg hover:bg-indigo-200 dark:hover:bg-indigo-900/50 transition-colors"
-              >
-                <ArrowLeftRight className="w-5 h-5" />
-                <span>Cambio de productos</span>
-              </button>
-            )}
-            {isAdmin && (
-              <button
-                onClick={onNuevoProducto}
-                className="flex items-center space-x-2 px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors"
-              >
-                <Plus className="w-5 h-5" />
-                <span>Nuevo Producto</span>
-              </button>
-            )}
-          </div>
-        )}
-      </div>
-
-      {/* Alerta de stock bajo */}
-      {productosStockBajo.length > 0 && (
-        <div className="bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg p-4" role="alert">
-          <div className="flex items-start space-x-3">
-            <AlertTriangle className="w-5 h-5 text-red-600 dark:text-red-400 flex-shrink-0 mt-0.5" aria-hidden="true" />
-            <div className="flex-1">
-              <p className="text-red-700 dark:text-red-300 font-medium">
-                {productosStockBajo.length} producto(s) con stock bajo
-              </p>
-              <div className="mt-2 flex flex-wrap gap-2">
-                {productosStockBajo.slice(0, 5).map(p => (
-                  <span key={p.id} className="text-xs px-2 py-1 bg-red-100 dark:bg-red-900/40 text-red-700 dark:text-red-300 rounded-full">
-                    {p.nombre} ({p.stock})
-                  </span>
-                ))}
-                {productosStockBajo.length > 5 && (
-                  <span className="text-xs px-2 py-1 bg-red-100 dark:bg-red-900/40 text-red-700 dark:text-red-300 rounded-full">
-                    +{productosStockBajo.length - 5} más
-                  </span>
-                )}
-              </div>
-              <button
-                onClick={handleStockBajo}
-                className="mt-2 text-sm text-red-600 dark:text-red-400 hover:underline"
-              >
-                {mostrarSoloStockBajo ? 'Mostrar todos' : 'Ver solo productos con stock bajo'}
-              </button>
-            </div>
-          </div>
-        </div>
-      )}
+      {/* Header con título dinámico + toolbar */}
+      <ProductosViewHeader
+        busqueda={busqueda}
+        categoriaSeleccionada={filtroCategoria}
+        mostrarSoloStockBajo={mostrarSoloStockBajo}
+        totalCount={productosFiltrados.length}
+        loading={loading}
+        actions={
+          <ProductoToolbar
+            isAdmin={isAdmin}
+            productosStockBajoCount={productosStockBajo.length}
+            onGestionarCategorias={onGestionarCategorias}
+            onCambioProducto={onCambioProducto}
+            onActualizacionMasivaPrecios={onActualizacionMasivaPrecios}
+            onControlStock={onControlStock}
+            onVerHistorialMermas={onVerHistorialMermas}
+            onAbrirStockBajo={onAbrirStockBajo}
+            onNuevoProducto={onNuevoProducto}
+          />
+        }
+      />
 
       {/* Búsqueda — full width */}
       <div className="relative w-full">
-        <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 text-gray-400 dark:text-gray-500 w-5 h-5" aria-hidden="true" />
+        <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 text-stone-400 dark:text-gray-500 w-4 h-4" aria-hidden="true" />
         <input
           type="text"
           value={busqueda}
           onChange={handleBusqueda}
-          className="w-full pl-10 pr-3 py-2 border dark:border-gray-600 rounded-lg bg-white dark:bg-gray-800 text-gray-900 dark:text-white focus:ring-2 focus:ring-blue-500"
-          placeholder="Buscar por nombre o código..."
+          className="w-full h-10 pl-10 pr-3 rounded-lg border border-stone-200 dark:border-gray-700 bg-white dark:bg-gray-800 text-sm text-stone-700 dark:text-white placeholder:text-stone-400 focus:outline-none focus:ring-2 focus:ring-blue-500/40 focus:border-blue-400"
+          placeholder="Buscar por nombre o código…"
           aria-label="Buscar productos"
         />
       </div>
 
       {/* Filtros de categoría — carrusel horizontal con flechas */}
       {categorias.length > 1 && (
-        <div className="relative" role="group" aria-label="Filtrar por categoría">
+        <div className="relative flex items-center gap-2" role="group" aria-label="Filtrar por categoría">
           <button
             type="button"
             onClick={() => categoriasScrollRef.current?.scrollBy({ left: -200, behavior: 'smooth' })}
-            className="hidden sm:flex absolute left-0 top-1/2 -translate-y-1/2 z-10 items-center justify-center w-8 h-8 bg-white/95 dark:bg-gray-800 rounded-full shadow-md border dark:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-700"
+            className="hidden sm:flex absolute left-0 top-1/2 -translate-y-1/2 z-10 items-center justify-center w-8 h-8 bg-white/95 dark:bg-gray-800 rounded-full shadow-warm border border-stone-200 dark:border-gray-700 hover:bg-stone-50 dark:hover:bg-gray-700"
             aria-label="Scroll categorías a la izquierda"
           >
-            <ChevronLeft className="w-4 h-4 text-gray-600 dark:text-gray-300" />
+            <ChevronLeft className="w-4 h-4 text-stone-600 dark:text-gray-300" />
           </button>
           <div
             ref={categoriasScrollRef}
-            className="flex gap-2 overflow-x-auto scroll-smooth sm:px-10 py-1 scrollbar-hide"
+            className="flex gap-1.5 overflow-x-auto scroll-smooth sm:px-10 py-1 scrollbar-hide flex-1"
           >
             {categorias.map(cat => (
               <button
                 key={cat}
                 onClick={() => handleCategoria(cat)}
-                className={`shrink-0 px-3 py-2 rounded-lg text-sm font-medium transition-colors ${
+                className={cn(
+                  'shrink-0 px-3 py-2 rounded-lg text-sm font-medium transition-colors',
                   filtroCategoria === cat
-                    ? 'bg-blue-600 text-white'
-                    : 'bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-600'
-                }`}
+                    ? 'bg-blue-600 text-white shadow-warm'
+                    : 'bg-stone-100 dark:bg-gray-700 text-stone-700 dark:text-gray-300 hover:bg-stone-200 dark:hover:bg-gray-600',
+                )}
                 aria-pressed={filtroCategoria === cat}
               >
                 {cat === 'todas' ? 'Todas' : cat}
@@ -247,107 +175,131 @@ export default function VistaProductos({
           <button
             type="button"
             onClick={() => categoriasScrollRef.current?.scrollBy({ left: 200, behavior: 'smooth' })}
-            className="hidden sm:flex absolute right-0 top-1/2 -translate-y-1/2 z-10 items-center justify-center w-8 h-8 bg-white/95 dark:bg-gray-800 rounded-full shadow-md border dark:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-700"
+            className="hidden sm:flex absolute right-0 top-1/2 -translate-y-1/2 z-10 items-center justify-center w-8 h-8 bg-white/95 dark:bg-gray-800 rounded-full shadow-warm border border-stone-200 dark:border-gray-700 hover:bg-stone-50 dark:hover:bg-gray-700"
             aria-label="Scroll categorías a la derecha"
           >
-            <ChevronRight className="w-4 h-4 text-gray-600 dark:text-gray-300" />
+            <ChevronRight className="w-4 h-4 text-stone-600 dark:text-gray-300" />
           </button>
         </div>
       )}
 
-      {/* Contador de resultados */}
-      {(busqueda || filtroCategoria !== 'todas' || mostrarSoloStockBajo) && (
-        <div className="text-sm text-gray-600 dark:text-gray-400" aria-live="polite">
-          Mostrando {productosFiltrados.length} de {productos.length} productos
+      {/* Toggle "Ver solo stock bajo" — chip discreto */}
+      {productosStockBajo.length > 0 && (
+        <div className="flex items-center justify-end">
+          <button
+            type="button"
+            onClick={handleStockBajoToggle}
+            className={cn(
+              'inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full text-xs font-medium transition-colors',
+              mostrarSoloStockBajo
+                ? 'bg-amber-100 dark:bg-amber-900/30 text-amber-800 dark:text-amber-200 border border-amber-300 dark:border-amber-700/50'
+                : 'bg-white dark:bg-gray-800 text-stone-600 dark:text-gray-300 border border-stone-200 dark:border-gray-700 hover:bg-stone-50 dark:hover:bg-gray-700/50',
+            )}
+            aria-pressed={mostrarSoloStockBajo}
+          >
+            <span
+              className={cn(
+                'inline-block w-1.5 h-1.5 rounded-full',
+                mostrarSoloStockBajo ? 'bg-amber-500' : 'bg-stone-300 dark:bg-gray-600',
+              )}
+              aria-hidden="true"
+            />
+            {mostrarSoloStockBajo ? 'Mostrando solo stock bajo' : 'Ver solo stock bajo'}
+          </button>
         </div>
       )}
 
       {/* Tabla de productos */}
       {loading ? <LoadingSpinner /> : productosFiltrados.length === 0 ? (
-        <div className="text-center py-12 text-gray-500 dark:text-gray-400">
+        <div className="text-center py-12 text-stone-500 dark:text-gray-400">
           <Package className="w-12 h-12 mx-auto mb-3 opacity-50" aria-hidden="true" />
           <p>{busqueda || filtroCategoria !== 'todas' ? 'No se encontraron productos' : 'No hay productos'}</p>
         </div>
       ) : (
         <>
-          {/* Tabla - desktop */}
-          <div className="hidden md:block bg-white dark:bg-gray-800 border dark:border-gray-700 rounded-lg shadow-sm overflow-x-auto">
-            <table className="w-full" role="table">
-              <thead className="bg-gray-50 dark:bg-gray-700/50">
-                <tr>
-                  <th scope="col" className="px-4 py-3 text-left text-sm font-medium text-gray-700 dark:text-gray-300">Código</th>
-                  <th scope="col" className="px-4 py-3 text-left text-sm font-medium text-gray-700 dark:text-gray-300">Producto</th>
-                  <th scope="col" className="px-4 py-3 text-left text-sm font-medium text-gray-700 dark:text-gray-300">Categoría</th>
-                  <th scope="col" className="px-4 py-3 text-left text-sm font-medium text-gray-700 dark:text-gray-300">Proveedor</th>
-                  <th scope="col" className="px-4 py-3 text-right text-sm font-medium text-gray-700 dark:text-gray-300">Precio</th>
-                  <th scope="col" className="px-4 py-3 text-right text-sm font-medium text-gray-700 dark:text-gray-300">Stock</th>
-                  {isAdmin && <th scope="col" className="px-4 py-3 text-right text-sm font-medium text-gray-700 dark:text-gray-300">Acciones</th>}
-                </tr>
-              </thead>
-              <tbody className="divide-y dark:divide-gray-700">
-                {productosPaginados.map(producto => (
-                  <tr key={producto.id} className="hover:bg-gray-50 dark:hover:bg-gray-700/50 transition-colors">
-                    <td className="px-4 py-3 text-gray-500 dark:text-gray-400 text-sm font-mono">
-                      {producto.codigo || '-'}
-                    </td>
-                    <td className="px-4 py-3">
-                      <span className="font-medium text-gray-800 dark:text-white">{producto.nombre}</span>
-                    </td>
-                    <td className="px-4 py-3">
-                      <span className={producto.categoria ? 'px-2 py-1 bg-gray-100 dark:bg-gray-700 rounded-full text-sm text-gray-700 dark:text-gray-300' : 'text-gray-400 dark:text-gray-500'}>
-                        {producto.categoria || 'Sin categoría'}
-                      </span>
-                    </td>
-                    <td className="px-4 py-3 text-sm text-gray-600 dark:text-gray-400">
-                      {producto.proveedor_id ? (proveedoresMap.get(producto.proveedor_id) || '-') : '-'}
-                    </td>
-                    <td className="px-4 py-3 text-right font-semibold text-blue-600 dark:text-blue-400">
-                      {formatPrecio(producto.precio)}
-                    </td>
-                    <td className="px-4 py-3 text-right">
-                      <span className={`px-2 py-1 rounded-full text-sm font-medium ${getStockColor(producto)}`}>
-                        {producto.stock}
-                      </span>
-                    </td>
-                    {isAdmin && (
-                      <td className="px-4 py-3 text-right">
-                        <div className="flex justify-end space-x-1">
-                          {onBajaStock && producto.stock > 0 && (
-                            <button
-                              onClick={() => onBajaStock(producto)}
-                              className="p-2 text-orange-500 hover:bg-orange-50 dark:hover:bg-orange-900/30 rounded-lg transition-colors"
-                              title="Baja de stock"
-                              aria-label={`Baja de stock ${producto.nombre}`}
-                            >
-                              <Minus className="w-4 h-4" aria-hidden="true" />
-                            </button>
-                          )}
-                          <button
-                            onClick={() => onEditarProducto(producto)}
-                            className="p-2 text-blue-500 hover:bg-blue-50 dark:hover:bg-blue-900/30 rounded-lg transition-colors"
-                            title="Editar"
-                            aria-label={`Editar ${producto.nombre}`}
-                          >
-                            <Edit2 className="w-4 h-4" aria-hidden="true" />
-                          </button>
-                          <button
-                            onClick={() => onEliminarProducto(producto.id)}
-                            className="p-2 text-red-500 hover:bg-red-50 dark:hover:bg-red-900/30 rounded-lg transition-colors"
-                            title="Eliminar"
-                            aria-label={`Eliminar ${producto.nombre}`}
-                          >
-                            <Trash2 className="w-4 h-4" aria-hidden="true" />
-                          </button>
-                        </div>
-                      </td>
-                    )}
+          {/* Tabla — desktop */}
+          <div className="hidden md:block bg-white dark:bg-gray-800 border border-stone-200 dark:border-gray-700 rounded-xl shadow-warm overflow-hidden">
+            <div className="overflow-x-auto">
+              <table className="w-full" role="table">
+                <thead className="bg-stone-50/70 dark:bg-gray-700/50 border-b border-stone-200 dark:border-gray-700">
+                  <tr>
+                    <th scope="col" className="px-4 py-3 text-left text-[11px] font-semibold uppercase tracking-wider text-stone-500 dark:text-gray-400">Código</th>
+                    <th scope="col" className="px-4 py-3 text-left text-[11px] font-semibold uppercase tracking-wider text-stone-500 dark:text-gray-400">Producto</th>
+                    <th scope="col" className="px-4 py-3 text-left text-[11px] font-semibold uppercase tracking-wider text-stone-500 dark:text-gray-400">Categoría</th>
+                    <th scope="col" className="px-4 py-3 text-left text-[11px] font-semibold uppercase tracking-wider text-stone-500 dark:text-gray-400">Proveedor</th>
+                    <th scope="col" className="px-4 py-3 text-right text-[11px] font-semibold uppercase tracking-wider text-stone-500 dark:text-gray-400">Precio</th>
+                    <th scope="col" className="px-4 py-3 text-right text-[11px] font-semibold uppercase tracking-wider text-stone-500 dark:text-gray-400">Stock</th>
+                    {isAdmin && <th scope="col" className="px-4 py-3 text-right text-[11px] font-semibold uppercase tracking-wider text-stone-500 dark:text-gray-400">Acciones</th>}
                   </tr>
-                ))}
-              </tbody>
-            </table>
+                </thead>
+                <tbody className="divide-y divide-stone-200 dark:divide-gray-700">
+                  {productosPaginados.map(producto => (
+                    <tr key={producto.id} className="hover:bg-stone-50/70 dark:hover:bg-gray-700/40 transition-colors">
+                      <td className="px-4 py-3 text-stone-500 dark:text-gray-400 text-sm font-mono tabular-nums">
+                        {producto.codigo || '-'}
+                      </td>
+                      <td className="px-4 py-3">
+                        <span className="font-medium text-stone-800 dark:text-white">{producto.nombre}</span>
+                      </td>
+                      <td className="px-4 py-3">
+                        <span className={producto.categoria ? 'px-2 py-0.5 bg-stone-100 dark:bg-gray-700 rounded-full text-xs text-stone-700 dark:text-gray-300' : 'text-stone-400 dark:text-gray-500 text-xs'}>
+                          {producto.categoria || 'Sin categoría'}
+                        </span>
+                      </td>
+                      <td className="px-4 py-3 text-sm text-stone-600 dark:text-gray-400">
+                        {producto.proveedor_id ? (proveedoresMap.get(producto.proveedor_id) || '-') : '-'}
+                      </td>
+                      <td className="px-4 py-3 text-right font-semibold text-blue-700 dark:text-blue-300 tabular-nums">
+                        {formatPrecio(producto.precio)}
+                      </td>
+                      <td className="px-4 py-3 text-right">
+                        <span className={`inline-flex items-center justify-center px-2.5 py-0.5 rounded-full text-sm font-semibold tabular-nums ${getStockColor(producto)}`}>
+                          {producto.stock}
+                        </span>
+                      </td>
+                      {isAdmin && (
+                        <td className="px-4 py-3 text-right">
+                          <div className="flex justify-end gap-1.5">
+                            {onBajaStock && producto.stock > 0 && (
+                              <button
+                                onClick={() => onBajaStock(producto)}
+                                className="inline-flex items-center gap-1.5 h-8 px-2.5 rounded-md text-xs font-medium bg-orange-50 dark:bg-orange-900/15 text-orange-700 dark:text-orange-300 border border-orange-200/70 dark:border-orange-800/40 hover:bg-orange-100 dark:hover:bg-orange-900/25 hover:border-orange-300 hover:-translate-y-px active:translate-y-0 transition-[transform,background-color,border-color]"
+                                title="Registrar baja de stock"
+                                aria-label={`Baja de stock ${producto.nombre}`}
+                              >
+                                <Minus className="w-3.5 h-3.5" aria-hidden="true" />
+                                <span>Baja</span>
+                              </button>
+                            )}
+                            <button
+                              onClick={() => onEditarProducto(producto)}
+                              className="inline-flex items-center gap-1.5 h-8 px-2.5 rounded-md text-xs font-medium bg-blue-50 dark:bg-blue-900/15 text-blue-700 dark:text-blue-300 border border-blue-200/70 dark:border-blue-800/40 hover:bg-blue-100 dark:hover:bg-blue-900/25 hover:border-blue-300 hover:-translate-y-px active:translate-y-0 transition-[transform,background-color,border-color]"
+                              title="Editar"
+                              aria-label={`Editar ${producto.nombre}`}
+                            >
+                              <Edit2 className="w-3.5 h-3.5" aria-hidden="true" />
+                              <span>Editar</span>
+                            </button>
+                            <button
+                              onClick={() => onEliminarProducto(producto.id)}
+                              className="inline-flex items-center gap-1.5 h-8 px-2.5 rounded-md text-xs font-medium bg-rose-50 dark:bg-rose-900/15 text-rose-700 dark:text-rose-300 border border-rose-200/70 dark:border-rose-800/40 hover:bg-rose-100 dark:hover:bg-rose-900/25 hover:border-rose-300 hover:-translate-y-px active:translate-y-0 transition-[transform,background-color,border-color]"
+                              title="Eliminar"
+                              aria-label={`Eliminar ${producto.nombre}`}
+                            >
+                              <Trash2 className="w-3.5 h-3.5" aria-hidden="true" />
+                              <span>Borrar</span>
+                            </button>
+                          </div>
+                        </td>
+                      )}
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
           </div>
 
-          {/* Cards - mobile */}
+          {/* Cards — mobile */}
           <div className="grid gap-3 md:hidden">
             {productosPaginados.map(producto => {
               const stockMinimo = producto.stock_minimo || 10;
@@ -356,79 +308,83 @@ export default function VistaProductos({
               return (
                 <div
                   key={producto.id}
-                  className="bg-white dark:bg-gray-800 border dark:border-gray-700 rounded-lg p-4 shadow-sm"
+                  className="bg-white dark:bg-gray-800 border border-stone-200 dark:border-gray-700 rounded-xl p-4 shadow-warm hover:shadow-warm-md transition-shadow"
                 >
                   <div className="flex justify-between items-start gap-3">
                     <div className="flex-1 min-w-0">
                       <div className="flex items-center gap-2 flex-wrap">
                         {producto.codigo && (
-                          <span className="px-1.5 py-0.5 bg-blue-100 dark:bg-blue-900/30 text-blue-700 dark:text-blue-300 rounded text-xs font-mono font-semibold">
+                          <span className="px-1.5 py-0.5 bg-blue-100 dark:bg-blue-900/30 text-blue-700 dark:text-blue-300 rounded text-xs font-mono font-semibold tabular-nums">
                             #{producto.codigo}
                           </span>
                         )}
-                        <h3 className="font-semibold text-gray-800 dark:text-white truncate">
+                        <h3 className="font-semibold text-stone-800 dark:text-white truncate">
                           {producto.nombre}
                         </h3>
                       </div>
                       {producto.categoria && (
-                        <p className="text-sm text-gray-600 dark:text-gray-400 mt-1">
+                        <p className="text-sm text-stone-600 dark:text-gray-400 mt-1">
                           {producto.categoria}
                         </p>
                       )}
                       {proveedorNombre && (
-                        <p className="text-xs text-gray-500 dark:text-gray-500 mt-0.5">
+                        <p className="text-xs text-stone-500 dark:text-gray-500 mt-0.5">
                           {proveedorNombre}
                         </p>
                       )}
                       <div className="flex items-center gap-4 mt-2 text-sm flex-wrap">
-                        <span className="text-gray-800 dark:text-gray-200">
-                          <span className="text-gray-500 dark:text-gray-400">Precio:</span>{' '}
-                          <span className="font-semibold text-blue-600 dark:text-blue-400">
+                        <span className="text-stone-800 dark:text-gray-200">
+                          <span className="text-stone-500 dark:text-gray-400">Precio:</span>{' '}
+                          <span className="font-semibold text-blue-700 dark:text-blue-300 tabular-nums">
                             {formatPrecio(producto.precio)}
                           </span>
                         </span>
                         <span
-                          className={
+                          className={cn(
+                            'tabular-nums',
                             stockBajo
-                              ? 'text-red-600 dark:text-red-400 font-medium'
-                              : 'text-gray-800 dark:text-gray-200'
-                          }
+                              ? 'text-rose-600 dark:text-rose-400 font-semibold'
+                              : 'text-stone-800 dark:text-gray-200',
+                          )}
                         >
-                          <span className="text-gray-500 dark:text-gray-400">Stock:</span> {producto.stock}
+                          <span className="text-stone-500 dark:text-gray-400">Stock:</span> {producto.stock}
                         </span>
                       </div>
                     </div>
-                    {isAdmin && (
-                      <div className="flex flex-col gap-1 shrink-0">
-                        {onBajaStock && producto.stock > 0 && (
-                          <button
-                            onClick={() => onBajaStock(producto)}
-                            className="p-2 text-orange-500 hover:bg-orange-50 dark:hover:bg-orange-900/30 rounded-lg transition-colors min-h-11 min-w-11 flex items-center justify-center"
-                            title="Baja de stock"
-                            aria-label={`Baja de stock ${producto.nombre}`}
-                          >
-                            <Minus className="w-4 h-4" aria-hidden="true" />
-                          </button>
-                        )}
-                        <button
-                          onClick={() => onEditarProducto(producto)}
-                          className="p-2 text-blue-500 hover:bg-blue-50 dark:hover:bg-blue-900/30 rounded-lg transition-colors min-h-11 min-w-11 flex items-center justify-center"
-                          title="Editar"
-                          aria-label={`Editar ${producto.nombre}`}
-                        >
-                          <Edit2 className="w-4 h-4" aria-hidden="true" />
-                        </button>
-                        <button
-                          onClick={() => onEliminarProducto(producto.id)}
-                          className="p-2 text-red-500 hover:bg-red-50 dark:hover:bg-red-900/30 rounded-lg transition-colors min-h-11 min-w-11 flex items-center justify-center"
-                          title="Eliminar"
-                          aria-label={`Eliminar ${producto.nombre}`}
-                        >
-                          <Trash2 className="w-4 h-4" aria-hidden="true" />
-                        </button>
-                      </div>
-                    )}
                   </div>
+                  {isAdmin && (
+                    <div className="flex items-center gap-1.5 mt-3 pt-3 border-t border-stone-200 dark:border-gray-700">
+                      {onBajaStock && producto.stock > 0 && (
+                        <button
+                          onClick={() => onBajaStock(producto)}
+                          className="inline-flex items-center gap-1.5 h-8 px-2.5 rounded-md text-xs font-medium bg-orange-50 text-orange-700 border border-orange-200/70 hover:bg-orange-100 transition-colors"
+                          title="Baja de stock"
+                          aria-label={`Baja de stock ${producto.nombre}`}
+                        >
+                          <Minus className="w-3.5 h-3.5" aria-hidden="true" />
+                          <span>Baja</span>
+                        </button>
+                      )}
+                      <button
+                        onClick={() => onEditarProducto(producto)}
+                        className="inline-flex items-center gap-1.5 h-8 px-2.5 rounded-md text-xs font-medium bg-blue-50 text-blue-700 border border-blue-200/70 hover:bg-blue-100 transition-colors"
+                        title="Editar"
+                        aria-label={`Editar ${producto.nombre}`}
+                      >
+                        <Edit2 className="w-3.5 h-3.5" aria-hidden="true" />
+                        <span>Editar</span>
+                      </button>
+                      <button
+                        onClick={() => onEliminarProducto(producto.id)}
+                        className="inline-flex items-center gap-1.5 h-8 px-2.5 rounded-md text-xs font-medium bg-rose-50 text-rose-700 border border-rose-200/70 hover:bg-rose-100 transition-colors"
+                        title="Eliminar"
+                        aria-label={`Eliminar ${producto.nombre}`}
+                      >
+                        <Trash2 className="w-3.5 h-3.5" aria-hidden="true" />
+                        <span>Borrar</span>
+                      </button>
+                    </div>
+                  )}
                 </div>
               );
             })}

--- a/src/index.css
+++ b/src/index.css
@@ -2,10 +2,24 @@
 @tailwind components;
 @tailwind utilities;
 
-/* Estilos base */
+/* Estilos base.
+   Body background usa `stone` en lugar de `gray` puro para dar un tinte
+   cálido apenas perceptible — la diferencia visual con gray-100 es mínima
+   pero el feel general gana en calidez. Es la base del "editorial cálido"
+   del panel de Pedidos sin tocar el resto de la app. */
 body {
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, sans-serif;
-  @apply bg-gray-100 dark:bg-gray-900 text-gray-900 dark:text-gray-100;
+  @apply bg-stone-50 dark:bg-gray-900 text-gray-900 dark:text-gray-100;
+  letter-spacing: -0.005em;
+}
+
+/* Personalidad para titulares: kerning levemente apretado +
+   anti-aliasing mejorado en webkit para que `font-weight: 800` se vea
+   crisp en lugar de borrosa. */
+h1, h2, h3 {
+  letter-spacing: -0.02em;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
 }
 
 /* Transición suave para el cambio de tema */

--- a/src/utils/labelCategoriaProductos.test.ts
+++ b/src/utils/labelCategoriaProductos.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect } from 'vitest';
+import { labelCategoriaProductos } from './labelCategoriaProductos';
+
+describe('labelCategoriaProductos', () => {
+  it('sin filtros → periodo null', () => {
+    expect(labelCategoriaProductos({
+      busqueda: '',
+      categoriaSeleccionada: 'todas',
+      mostrarSoloStockBajo: false,
+    })).toEqual({ verbo: 'Productos', periodo: null });
+  });
+
+  it('stock bajo activo → "con stock bajo" (prevalece sobre todo lo demás)', () => {
+    expect(labelCategoriaProductos({
+      busqueda: 'agua',
+      categoriaSeleccionada: 'MANAOS',
+      mostrarSoloStockBajo: true,
+    })).toEqual({ verbo: 'Productos', periodo: 'con stock bajo' });
+  });
+
+  it('solo categoría seleccionada → "de <cat>" en Title Case si viene all-caps', () => {
+    expect(labelCategoriaProductos({
+      busqueda: '',
+      categoriaSeleccionada: 'MANAOS',
+      mostrarSoloStockBajo: false,
+    })).toEqual({ verbo: 'Productos', periodo: 'de Manaos' });
+  });
+
+  it('categoría all-caps multi-palabra → Title Case de cada palabra', () => {
+    expect(labelCategoriaProductos({
+      busqueda: '',
+      categoriaSeleccionada: 'PAPAS FRITAS',
+      mostrarSoloStockBajo: false,
+    })).toEqual({ verbo: 'Productos', periodo: 'de Papas Fritas' });
+  });
+
+  it('categoría que ya viene en case mixto → se respeta', () => {
+    expect(labelCategoriaProductos({
+      busqueda: '',
+      categoriaSeleccionada: 'Cepillo dientes',
+      mostrarSoloStockBajo: false,
+    })).toEqual({ verbo: 'Productos', periodo: 'de Cepillo dientes' });
+  });
+
+  it('solo búsqueda → "que coinciden con \\"X\\""', () => {
+    expect(labelCategoriaProductos({
+      busqueda: 'agua',
+      categoriaSeleccionada: 'todas',
+      mostrarSoloStockBajo: false,
+    })).toEqual({ verbo: 'Productos', periodo: 'que coinciden con "agua"' });
+  });
+
+  it('categoría + búsqueda combinadas', () => {
+    expect(labelCategoriaProductos({
+      busqueda: 'cola',
+      categoriaSeleccionada: 'MANAOS',
+      mostrarSoloStockBajo: false,
+    })).toEqual({
+      verbo: 'Productos',
+      periodo: 'de Manaos que coinciden con "cola"',
+    });
+  });
+
+  it('busqueda con solo espacios se trata como vacía', () => {
+    expect(labelCategoriaProductos({
+      busqueda: '   ',
+      categoriaSeleccionada: 'todas',
+      mostrarSoloStockBajo: false,
+    })).toEqual({ verbo: 'Productos', periodo: null });
+  });
+
+  it('categoriaSeleccionada como string vacío se trata como sin filtro', () => {
+    expect(labelCategoriaProductos({
+      busqueda: '',
+      categoriaSeleccionada: '',
+      mostrarSoloStockBajo: false,
+    })).toEqual({ verbo: 'Productos', periodo: null });
+  });
+});

--- a/src/utils/labelCategoriaProductos.ts
+++ b/src/utils/labelCategoriaProductos.ts
@@ -1,0 +1,87 @@
+/**
+ * Deriva un label legible del filtro activo en el panel de Productos.
+ *
+ * Lo usa el header del panel de Productos para mostrar un título dinámico:
+ *   "Productos" / "Productos con stock bajo" / "Productos de Manaos" /
+ *   "Productos que coinciden con \"agua\"" / etc.
+ *
+ * Paralelo a `labelPeriodoPedidos` — mismo patrón de API y testing.
+ *
+ * Prioridad de filtros (de más específico a menos):
+ *   1. `mostrarSoloStockBajo === true` → "con stock bajo"
+ *   2. Combinación `categoria + busqueda` → "de {cat} que coinciden con \"X\""
+ *   3. Solo `busqueda` → 'que coinciden con "X"'
+ *   4. Solo `categoria` !== 'todas' → "de {cat}"
+ *   5. Nada → null (el título queda solo "Productos")
+ */
+
+export interface LabelCategoriaInput {
+  /** Texto de búsqueda actual (puede tener espacios o ser vacío). */
+  busqueda: string;
+  /** Categoría seleccionada. 'todas' significa "sin filtro de categoría". */
+  categoriaSeleccionada: string;
+  /** Toggle "Ver solo productos con stock bajo". */
+  mostrarSoloStockBajo: boolean;
+}
+
+export interface LabelCategoriaProductos {
+  /** Siempre 'Productos' por ahora. Reservado para extensión. */
+  verbo: string;
+  /** Período legible o null si no hay filtro activo. */
+  periodo: string | null;
+}
+
+/**
+ * Normaliza el nombre de la categoría para el título: convierte SCREAMING
+ * a Title Case si todo está en mayúsculas (los nombres vienen así de la DB).
+ *
+ *   "MANAOS"          → "Manaos"
+ *   "PAPAS FRITAS"    → "Papas Fritas"
+ *   "Cepillo dientes" → "Cepillo dientes"  (deja como está si no es all-caps)
+ */
+function normalizarCategoria(cat: string): string {
+  const trimmed = cat.trim();
+  if (!trimmed) return trimmed;
+  // Si está todo en mayúsculas, convertir a Title Case.
+  if (trimmed === trimmed.toUpperCase()) {
+    return trimmed
+      .toLowerCase()
+      .split(/(\s+)/)
+      .map(p => p.length > 0 && /\S/.test(p) ? p.charAt(0).toUpperCase() + p.slice(1) : p)
+      .join('');
+  }
+  return trimmed;
+}
+
+export function labelCategoriaProductos(input: LabelCategoriaInput): LabelCategoriaProductos {
+  const busqueda = input.busqueda.trim();
+  const cat = input.categoriaSeleccionada;
+  const hayCategoria = Boolean(cat) && cat !== 'todas';
+  const hayBusqueda = busqueda.length > 0;
+
+  // --- Prioridad 1: stock bajo (filtro más operativo) ---
+  if (input.mostrarSoloStockBajo) {
+    return { verbo: 'Productos', periodo: 'con stock bajo' };
+  }
+
+  // --- Prioridad 2: combinación categoría + búsqueda ---
+  if (hayCategoria && hayBusqueda) {
+    return {
+      verbo: 'Productos',
+      periodo: `de ${normalizarCategoria(cat)} que coinciden con "${busqueda}"`,
+    };
+  }
+
+  // --- Prioridad 3: solo búsqueda ---
+  if (hayBusqueda) {
+    return { verbo: 'Productos', periodo: `que coinciden con "${busqueda}"` };
+  }
+
+  // --- Prioridad 4: solo categoría ---
+  if (hayCategoria) {
+    return { verbo: 'Productos', periodo: `de ${normalizarCategoria(cat)}` };
+  }
+
+  // --- Default: sin filtros ---
+  return { verbo: 'Productos', periodo: null };
+}

--- a/src/utils/labelPeriodoDashboard.test.ts
+++ b/src/utils/labelPeriodoDashboard.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect } from 'vitest';
+import { labelPeriodoDashboard } from './labelPeriodoDashboard';
+
+describe('labelPeriodoDashboard', () => {
+  it('hoy → "del día"', () => {
+    expect(labelPeriodoDashboard({ filtroPeriodo: 'hoy' })).toEqual({
+      verbo: 'Resumen',
+      periodo: 'del día',
+    });
+  });
+
+  it('semana → "de la semana"', () => {
+    expect(labelPeriodoDashboard({ filtroPeriodo: 'semana' })).toEqual({
+      verbo: 'Resumen',
+      periodo: 'de la semana',
+    });
+  });
+
+  it('mes → "del mes"', () => {
+    expect(labelPeriodoDashboard({ filtroPeriodo: 'mes' })).toEqual({
+      verbo: 'Resumen',
+      periodo: 'del mes',
+    });
+  });
+
+  it('anio → "del año"', () => {
+    expect(labelPeriodoDashboard({ filtroPeriodo: 'anio' })).toEqual({
+      verbo: 'Resumen',
+      periodo: 'del año',
+    });
+  });
+
+  it('historico → periodo null', () => {
+    expect(labelPeriodoDashboard({ filtroPeriodo: 'historico' })).toEqual({
+      verbo: 'Resumen',
+      periodo: null,
+    });
+  });
+
+  it('personalizado sin fechas → "personalizado"', () => {
+    expect(labelPeriodoDashboard({ filtroPeriodo: 'personalizado' })).toEqual({
+      verbo: 'Resumen',
+      periodo: 'personalizado',
+    });
+  });
+
+  it('personalizado con rango mismo mes → "del X al Y de <mes>"', () => {
+    expect(labelPeriodoDashboard({
+      filtroPeriodo: 'personalizado',
+      fechaDesde: '2026-05-10',
+      fechaHasta: '2026-05-23',
+    })).toEqual({
+      verbo: 'Resumen',
+      periodo: 'del 10 al 23 de mayo',
+    });
+  });
+
+  it('personalizado con rango distinto mes → "del X de <mes> al Y de <mes>"', () => {
+    expect(labelPeriodoDashboard({
+      filtroPeriodo: 'personalizado',
+      fechaDesde: '2026-04-25',
+      fechaHasta: '2026-05-05',
+    })).toEqual({
+      verbo: 'Resumen',
+      periodo: 'del 25 de abril al 5 de mayo',
+    });
+  });
+
+  it('personalizado un solo día → "del X de <mes>"', () => {
+    expect(labelPeriodoDashboard({
+      filtroPeriodo: 'personalizado',
+      fechaDesde: '2026-05-15',
+      fechaHasta: '2026-05-15',
+    })).toEqual({
+      verbo: 'Resumen',
+      periodo: 'del 15 de mayo',
+    });
+  });
+
+  it('personalizado solo fechaDesde → "desde el X de <mes>"', () => {
+    expect(labelPeriodoDashboard({
+      filtroPeriodo: 'personalizado',
+      fechaDesde: '2026-05-10',
+      fechaHasta: null,
+    })).toEqual({
+      verbo: 'Resumen',
+      periodo: 'desde el 10 de mayo',
+    });
+  });
+
+  it('personalizado solo fechaHasta → "hasta el X de <mes>"', () => {
+    expect(labelPeriodoDashboard({
+      filtroPeriodo: 'personalizado',
+      fechaDesde: null,
+      fechaHasta: '2026-05-23',
+    })).toEqual({
+      verbo: 'Resumen',
+      periodo: 'hasta el 23 de mayo',
+    });
+  });
+
+  it('verbo "Mis métricas" para preventista', () => {
+    expect(labelPeriodoDashboard({ filtroPeriodo: 'hoy' }, 'Mis métricas')).toEqual({
+      verbo: 'Mis métricas',
+      periodo: 'del día',
+    });
+  });
+});

--- a/src/utils/labelPeriodoDashboard.ts
+++ b/src/utils/labelPeriodoDashboard.ts
@@ -1,0 +1,94 @@
+/**
+ * Deriva un label legible del período activo en el panel Dashboard.
+ *
+ * Lo usa el header del Dashboard para mostrar un título dinámico:
+ *   "Resumen del día" / "Resumen del mes" / "Resumen del 14 al 23 de mayo" / etc.
+ *
+ * Paralelo a `labelPeriodoPedidos` y `labelCategoriaProductos`.
+ */
+import { parseDateSafe } from './formatters';
+
+export type FiltroPeriodoDashboard =
+  | 'hoy'
+  | 'semana'
+  | 'mes'
+  | 'anio'
+  | 'historico'
+  | 'personalizado'
+  | string;
+
+export interface LabelPeriodoDashboardInput {
+  /** Identificador del período activo. */
+  filtroPeriodo: FiltroPeriodoDashboard;
+  /** Si es 'personalizado', fecha de inicio del rango. */
+  fechaDesde?: string | null;
+  /** Si es 'personalizado', fecha de fin del rango. */
+  fechaHasta?: string | null;
+}
+
+export interface LabelPeriodoDashboard {
+  /** "Resumen" o "Mis métricas" según rol. Pasarlo desde el header. */
+  verbo: string;
+  /** Período legible o null si es histórico (sin filtro). */
+  periodo: string | null;
+}
+
+const MESES_AR = [
+  'enero', 'febrero', 'marzo', 'abril', 'mayo', 'junio',
+  'julio', 'agosto', 'septiembre', 'octubre', 'noviembre', 'diciembre',
+] as const;
+
+function formatFechaCorta(iso: string): string {
+  const d = parseDateSafe(iso);
+  return `${d.getDate()} de ${MESES_AR[d.getMonth()]}`;
+}
+
+function mismoMesYAnio(a: Date, b: Date): boolean {
+  return a.getFullYear() === b.getFullYear() && a.getMonth() === b.getMonth();
+}
+
+/**
+ * @param input    Filtro de período + fechas (si personalizado)
+ * @param verbo    "Resumen" (admin/encargado) o "Mis métricas" (preventista). Default "Resumen".
+ */
+export function labelPeriodoDashboard(
+  input: LabelPeriodoDashboardInput,
+  verbo: string = 'Resumen',
+): LabelPeriodoDashboard {
+  switch (input.filtroPeriodo) {
+    case 'hoy':
+      return { verbo, periodo: 'del día' };
+    case 'semana':
+      return { verbo, periodo: 'de la semana' };
+    case 'mes':
+      return { verbo, periodo: 'del mes' };
+    case 'anio':
+      return { verbo, periodo: 'del año' };
+    case 'historico':
+      return { verbo, periodo: null };
+    case 'personalizado': {
+      const fd = input.fechaDesde ?? null;
+      const fh = input.fechaHasta ?? null;
+      if (!fd && !fh) return { verbo, periodo: 'personalizado' };
+      if (fd && fh) {
+        if (fd === fh) {
+          return { verbo, periodo: `del ${formatFechaCorta(fd)}` };
+        }
+        const dFrom = parseDateSafe(fd);
+        const dTo = parseDateSafe(fh);
+        if (mismoMesYAnio(dFrom, dTo)) {
+          return {
+            verbo,
+            periodo: `del ${dFrom.getDate()} al ${dTo.getDate()} de ${MESES_AR[dFrom.getMonth()]}`,
+          };
+        }
+        return { verbo, periodo: `del ${formatFechaCorta(fd)} al ${formatFechaCorta(fh)}` };
+      }
+      if (fd && !fh) return { verbo, periodo: `desde el ${formatFechaCorta(fd)}` };
+      if (!fd && fh) return { verbo, periodo: `hasta el ${formatFechaCorta(fh)}` };
+      return { verbo, periodo: 'personalizado' };
+    }
+    default:
+      return { verbo, periodo: null };
+  }
+}

--- a/src/utils/labelPeriodoPedidos.test.ts
+++ b/src/utils/labelPeriodoPedidos.test.ts
@@ -1,0 +1,156 @@
+import { describe, it, expect } from 'vitest';
+import { labelPeriodoPedidos } from './labelPeriodoPedidos';
+
+// Fecha base estable para todos los tests: viernes 15 de mayo de 2026, 14:00 ART.
+// Usamos UTC-3 implícita porque `fechaLocalISO` formatea TZ Argentina.
+// El día 15/05 en hora local Buenos Aires corresponde a 17:00 UTC.
+const NOW = new Date('2026-05-15T17:00:00.000Z');
+
+describe('labelPeriodoPedidos', () => {
+  it('sin filtros → periodo null', () => {
+    expect(labelPeriodoPedidos(null, null, NOW)).toEqual({
+      verbo: 'Pedidos',
+      periodo: null,
+    });
+  });
+
+  it('rango = hoy → "del día"', () => {
+    expect(labelPeriodoPedidos('2026-05-15', '2026-05-15', NOW)).toEqual({
+      verbo: 'Pedidos',
+      periodo: 'del día',
+    });
+  });
+
+  it('rango = ayer → "de ayer"', () => {
+    expect(labelPeriodoPedidos('2026-05-14', '2026-05-14', NOW)).toEqual({
+      verbo: 'Pedidos',
+      periodo: 'de ayer',
+    });
+  });
+
+  it('rango = mañana → "de mañana"', () => {
+    expect(labelPeriodoPedidos('2026-05-16', '2026-05-16', NOW)).toEqual({
+      verbo: 'Pedidos',
+      periodo: 'de mañana',
+    });
+  });
+
+  it('mes actual completo (primer al último día) → "del mes"', () => {
+    expect(labelPeriodoPedidos('2026-05-01', '2026-05-31', NOW)).toEqual({
+      verbo: 'Pedidos',
+      periodo: 'del mes',
+    });
+  });
+
+  it('primer día del mes actual sin hasta → "del mes"', () => {
+    expect(labelPeriodoPedidos('2026-05-01', null, NOW)).toEqual({
+      verbo: 'Pedidos',
+      periodo: 'del mes',
+    });
+  });
+
+  it('mes pasado completo → "de <mes>"', () => {
+    expect(labelPeriodoPedidos('2026-04-01', '2026-04-30', NOW)).toEqual({
+      verbo: 'Pedidos',
+      periodo: 'de abril',
+    });
+  });
+
+  it('mes de otro año → incluye el año', () => {
+    expect(labelPeriodoPedidos('2025-12-01', '2025-12-31', NOW)).toEqual({
+      verbo: 'Pedidos',
+      periodo: 'de diciembre de 2025',
+    });
+  });
+
+  it('rango custom mismo mes → "del X al Y de <mes>"', () => {
+    expect(labelPeriodoPedidos('2026-05-10', '2026-05-23', NOW)).toEqual({
+      verbo: 'Pedidos',
+      periodo: 'del 10 al 23 de mayo',
+    });
+  });
+
+  it('rango custom meses distintos → "del X de <mes> al Y de <mes>"', () => {
+    expect(labelPeriodoPedidos('2026-04-25', '2026-05-05', NOW)).toEqual({
+      verbo: 'Pedidos',
+      periodo: 'del 25 de abril al 5 de mayo',
+    });
+  });
+
+  it('solo fechaDesde (no es 1° del mes) → "desde el X de <mes>"', () => {
+    expect(labelPeriodoPedidos('2026-05-10', null, NOW)).toEqual({
+      verbo: 'Pedidos',
+      periodo: 'desde el 10 de mayo',
+    });
+  });
+
+  it('solo fechaHasta → "hasta el X de <mes>"', () => {
+    expect(labelPeriodoPedidos(null, '2026-05-23', NOW)).toEqual({
+      verbo: 'Pedidos',
+      periodo: 'hasta el 23 de mayo',
+    });
+  });
+
+  it('rango de un solo día arbitrario (no hoy/ayer/mañana) → "del X de <mes>"', () => {
+    expect(labelPeriodoPedidos('2026-05-03', '2026-05-03', NOW)).toEqual({
+      verbo: 'Pedidos',
+      periodo: 'del 3 de mayo',
+    });
+  });
+
+  describe('con fechaEntregaProgramada (prioridad sobre rango de creación)', () => {
+    it('fechaEntregaProgramada = hoy → "para entregar hoy"', () => {
+      expect(
+        labelPeriodoPedidos(
+          { fechaDesde: null, fechaHasta: null, fechaEntregaProgramada: '2026-05-15' },
+          undefined,
+          NOW,
+        ),
+      ).toEqual({ verbo: 'Pedidos', periodo: 'para entregar hoy' });
+    });
+
+    it('fechaEntregaProgramada = mañana → "para entregar mañana"', () => {
+      expect(
+        labelPeriodoPedidos(
+          { fechaDesde: null, fechaHasta: null, fechaEntregaProgramada: '2026-05-16' },
+          undefined,
+          NOW,
+        ),
+      ).toEqual({ verbo: 'Pedidos', periodo: 'para entregar mañana' });
+    });
+
+    it('fechaEntregaProgramada = ayer → "que entregamos ayer"', () => {
+      expect(
+        labelPeriodoPedidos(
+          { fechaDesde: null, fechaHasta: null, fechaEntregaProgramada: '2026-05-14' },
+          undefined,
+          NOW,
+        ),
+      ).toEqual({ verbo: 'Pedidos', periodo: 'que entregamos ayer' });
+    });
+
+    it('fechaEntregaProgramada custom → "para entregar el X de <mes>"', () => {
+      expect(
+        labelPeriodoPedidos(
+          { fechaDesde: null, fechaHasta: null, fechaEntregaProgramada: '2026-05-22' },
+          undefined,
+          NOW,
+        ),
+      ).toEqual({ verbo: 'Pedidos', periodo: 'para entregar el 22 de mayo' });
+    });
+
+    it('fechaEntregaProgramada prevalece sobre rango de creación', () => {
+      expect(
+        labelPeriodoPedidos(
+          {
+            fechaDesde: '2026-04-01',
+            fechaHasta: '2026-04-30',
+            fechaEntregaProgramada: '2026-05-15',
+          },
+          undefined,
+          NOW,
+        ),
+      ).toEqual({ verbo: 'Pedidos', periodo: 'para entregar hoy' });
+    });
+  });
+});

--- a/src/utils/labelPeriodoPedidos.ts
+++ b/src/utils/labelPeriodoPedidos.ts
@@ -1,0 +1,165 @@
+/**
+ * Deriva un label legible del rango de fechas activo en el filtro de pedidos.
+ *
+ * Lo usa el header del panel de Pedidos para mostrar un título dinámico:
+ *   "Pedidos del día" / "Pedidos del mes" / "Pedidos para entregar hoy" / etc.
+ *
+ * El estado tiene dos campos de fecha con semántica distinta:
+ *   - `fechaDesde` / `fechaHasta`: rango por fecha de CREACIÓN del pedido
+ *     (lo cambia el usuario desde el modal "Fechas").
+ *   - `fechaEntregaProgramada`: filtro por fecha de ENTREGA prevista
+ *     (lo cambia el usuario con los quick filters "Hoy" / "Mañana").
+ *
+ * Reglas de prioridad para el título:
+ *   1. Si hay `fechaEntregaProgramada` (es el filtro más operativo), prevalece.
+ *   2. Si no, se deriva del rango fechaDesde/fechaHasta.
+ *   3. Si no hay nada, el título es solo "Pedidos".
+ *
+ * Las fechas vienen como strings 'YYYY-MM-DD' en zona horaria Argentina.
+ */
+import { fechaLocalISO, parseDateSafe } from './formatters';
+
+const MESES_AR = [
+  'enero', 'febrero', 'marzo', 'abril', 'mayo', 'junio',
+  'julio', 'agosto', 'septiembre', 'octubre', 'noviembre', 'diciembre',
+] as const;
+
+export interface LabelPeriodoPedidos {
+  /** Siempre 'Pedidos' por ahora. Reservado para extensión. */
+  verbo: string;
+  /** Período legible o null si no hay filtro activo. */
+  periodo: string | null;
+}
+
+export interface LabelPeriodoInput {
+  fechaDesde: string | null;
+  fechaHasta: string | null;
+  fechaEntregaProgramada?: string | null;
+}
+
+function formatFechaCorta(iso: string): string {
+  const d = parseDateSafe(iso);
+  return `${d.getDate()} de ${MESES_AR[d.getMonth()]}`;
+}
+
+function mismoMesYAnio(a: Date, b: Date): boolean {
+  return a.getFullYear() === b.getFullYear() && a.getMonth() === b.getMonth();
+}
+
+/** Devuelve el primer día del mes (YYYY-MM-DD) en TZ Argentina. */
+function primerDiaDelMesISO(d: Date): string {
+  return fechaLocalISO(new Date(d.getFullYear(), d.getMonth(), 1));
+}
+
+/** Devuelve el último día del mes (YYYY-MM-DD) en TZ Argentina. */
+function ultimoDiaDelMesISO(d: Date): string {
+  return fechaLocalISO(new Date(d.getFullYear(), d.getMonth() + 1, 0));
+}
+
+function isoOffsetDias(now: Date, offset: number): string {
+  const d = new Date(now);
+  d.setDate(d.getDate() + offset);
+  return fechaLocalISO(d);
+}
+
+/**
+ * Helper que genera el label cuando hay un filtro de fecha de ENTREGA activo.
+ * "Pedidos para entregar hoy / mañana / ayer / el 14 de abril"
+ */
+function labelEntrega(fechaEntrega: string, now: Date): string {
+  const hoyISO = fechaLocalISO(now);
+  const ayerISO = isoOffsetDias(now, -1);
+  const mananaISO = isoOffsetDias(now, +1);
+  if (fechaEntrega === hoyISO) return 'para entregar hoy';
+  if (fechaEntrega === ayerISO) return 'que entregamos ayer';
+  if (fechaEntrega === mananaISO) return 'para entregar mañana';
+  return `para entregar el ${formatFechaCorta(fechaEntrega)}`;
+}
+
+/**
+ * Acepta tanto la firma vieja (string|null, string|null, Date?)
+ * como la nueva con objeto, para que los call-sites se puedan migrar
+ * gradualmente sin romper tests.
+ */
+export function labelPeriodoPedidos(
+  fechaDesdeOrInput: string | null | LabelPeriodoInput,
+  fechaHasta?: string | null,
+  now?: Date,
+): LabelPeriodoPedidos {
+  // Normalizar inputs (firma nueva con objeto, firma vieja con args).
+  const input: LabelPeriodoInput = typeof fechaDesdeOrInput === 'object' && fechaDesdeOrInput !== null
+    ? fechaDesdeOrInput
+    : { fechaDesde: fechaDesdeOrInput, fechaHasta: fechaHasta ?? null };
+  const fd = input.fechaDesde ?? null;
+  const fh = input.fechaHasta ?? null;
+  const fe = input.fechaEntregaProgramada ?? null;
+  const ref = now ?? new Date();
+
+  // --- Prioridad 1: filtro de entrega activo ---
+  if (fe) {
+    return { verbo: 'Pedidos', periodo: labelEntrega(fe, ref) };
+  }
+
+  const hoyISO = fechaLocalISO(ref);
+  const ayerISO = isoOffsetDias(ref, -1);
+  const mananaISO = isoOffsetDias(ref, +1);
+
+  // --- Sin filtros ---
+  if (!fd && !fh) {
+    return { verbo: 'Pedidos', periodo: null };
+  }
+
+  // --- Rango de un solo día (desde === hasta) ---
+  if (fd && fh && fd === fh) {
+    if (fd === hoyISO) return { verbo: 'Pedidos', periodo: 'del día' };
+    if (fd === ayerISO) return { verbo: 'Pedidos', periodo: 'de ayer' };
+    if (fd === mananaISO) return { verbo: 'Pedidos', periodo: 'de mañana' };
+    return { verbo: 'Pedidos', periodo: `del ${formatFechaCorta(fd)}` };
+  }
+
+  // --- Mes completo ---
+  if (fd) {
+    const desdeDate = parseDateSafe(fd);
+    const esPrimerDia = fd === primerDiaDelMesISO(desdeDate);
+    const esMesCompleto = esPrimerDia && (
+      !fh || fh === ultimoDiaDelMesISO(desdeDate)
+    );
+    if (esMesCompleto) {
+      if (mismoMesYAnio(desdeDate, ref)) {
+        return { verbo: 'Pedidos', periodo: 'del mes' };
+      }
+      const anio = desdeDate.getFullYear() === ref.getFullYear()
+        ? ''
+        : ` de ${desdeDate.getFullYear()}`;
+      return { verbo: 'Pedidos', periodo: `de ${MESES_AR[desdeDate.getMonth()]}${anio}` };
+    }
+  }
+
+  // --- Solo fechaDesde (sin fechaHasta y no era mes completo) ---
+  if (fd && !fh) {
+    return { verbo: 'Pedidos', periodo: `desde el ${formatFechaCorta(fd)}` };
+  }
+
+  // --- Solo fechaHasta ---
+  if (!fd && fh) {
+    return { verbo: 'Pedidos', periodo: `hasta el ${formatFechaCorta(fh)}` };
+  }
+
+  // --- Rango diferente ---
+  if (fd && fh) {
+    const desdeDate = parseDateSafe(fd);
+    const hastaDate = parseDateSafe(fh);
+    if (mismoMesYAnio(desdeDate, hastaDate)) {
+      return {
+        verbo: 'Pedidos',
+        periodo: `del ${desdeDate.getDate()} al ${hastaDate.getDate()} de ${MESES_AR[desdeDate.getMonth()]}`,
+      };
+    }
+    return {
+      verbo: 'Pedidos',
+      periodo: `del ${formatFechaCorta(fd)} al ${formatFechaCorta(fh)}`,
+    };
+  }
+
+  return { verbo: 'Pedidos', periodo: null };
+}

--- a/src/utils/labelPeriodoPedidos.ts
+++ b/src/utils/labelPeriodoPedidos.ts
@@ -19,6 +19,10 @@
  */
 import { fechaLocalISO, parseDateSafe } from './formatters';
 
+function pad2(n: number): string {
+  return String(n).padStart(2, '0');
+}
+
 const MESES_AR = [
   'enero', 'febrero', 'marzo', 'abril', 'mayo', 'junio',
   'julio', 'agosto', 'septiembre', 'octubre', 'noviembre', 'diciembre',
@@ -46,14 +50,23 @@ function mismoMesYAnio(a: Date, b: Date): boolean {
   return a.getFullYear() === b.getFullYear() && a.getMonth() === b.getMonth();
 }
 
-/** Devuelve el primer día del mes (YYYY-MM-DD) en TZ Argentina. */
+/** Primer día del mes (YYYY-MM-DD). Construye el ISO directo desde year+month
+ *  para evitar que la TZ del runtime mueva el día al construir un Date local
+ *  (bug que aparecía en CI corriendo en UTC: new Date(2026, 4, 1) en UTC se
+ *  reinterpretaba como '2026-04-30' al pasarlo por fechaLocalISO en TZ AR). */
 function primerDiaDelMesISO(d: Date): string {
-  return fechaLocalISO(new Date(d.getFullYear(), d.getMonth(), 1));
+  return `${d.getFullYear()}-${pad2(d.getMonth() + 1)}-01`;
 }
 
-/** Devuelve el último día del mes (YYYY-MM-DD) en TZ Argentina. */
+/** Último día del mes (YYYY-MM-DD). Calcula el último día usando
+ *  new Date(year, month+1, 0).getDate() — esto es TZ-safe porque getDate()
+ *  extrae el día en la misma TZ con la que se construyó el Date, y el
+ *  resultado (28-31) es independiente de TZ. */
 function ultimoDiaDelMesISO(d: Date): string {
-  return fechaLocalISO(new Date(d.getFullYear(), d.getMonth() + 1, 0));
+  const year = d.getFullYear();
+  const month = d.getMonth();
+  const lastDay = new Date(year, month + 1, 0).getDate();
+  return `${year}-${pad2(month + 1)}-${pad2(lastDay)}`;
 }
 
 function isoOffsetDias(now: Date, offset: number): string {

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -12,6 +12,8 @@ export default {
         'fade-in': 'fade-in 0.2s ease-out',
         'fade-out': 'fade-out 0.15s ease-in',
         'scale-in': 'scale-in 0.2s ease-out',
+        'fadeSlideIn': 'fadeSlideIn 0.3s ease-out',
+        'card-in': 'card-in 0.35s cubic-bezier(0.22, 1, 0.36, 1)',
       },
       keyframes: {
         'slide-in': {
@@ -30,6 +32,22 @@ export default {
           '0%': { opacity: '0', transform: 'scale(0.95)' },
           '100%': { opacity: '1', transform: 'scale(1)' },
         },
+        /* Fade + slide leve para el período del título cuando cambia */
+        'fadeSlideIn': {
+          '0%': { opacity: '0', transform: 'translateY(-3px)' },
+          '100%': { opacity: '1', transform: 'translateY(0)' },
+        },
+        /* Card entrance: fade desde abajo, leve scale */
+        'card-in': {
+          '0%': { opacity: '0', transform: 'translateY(6px) scale(0.99)' },
+          '100%': { opacity: '1', transform: 'translateY(0) scale(1)' },
+        },
+      },
+      /* Sombras cálidas (tinte stone en vez de gray puro) */
+      boxShadow: {
+        'warm': '0 1px 2px 0 rgb(120 113 108 / 0.06), 0 1px 3px 0 rgb(120 113 108 / 0.05)',
+        'warm-md': '0 4px 6px -1px rgb(120 113 108 / 0.08), 0 2px 4px -2px rgb(120 113 108 / 0.06)',
+        'warm-lg': '0 10px 15px -3px rgb(120 113 108 / 0.08), 0 4px 6px -4px rgb(120 113 108 / 0.04)',
       },
     },
   },


### PR DESCRIPTION
## Summary

Rediseño visual unificado de los 3 paneles más usados (`/pedidos`, `/productos`, `/dashboard`) aplicando un mismo lenguaje de diseño: **editorial cálido con guiños orgánicos**. La funcionalidad y los permisos por rol quedan exactamente como estaban; lo que cambia es el carbon visual.

**Por qué este rediseño:**
- La toolbar de cada panel tenía 6-9 botones de colores distintos sin jerarquía (carnaval visual).
- Los headers eran genéricos sin contexto del filtro activo.
- Las KPI cards estaban saturadas (cada una con su fondo de color completo).
- Los banners de stock bajo eran invasivos.
- Las cards de pedido tenían información apretada sin respiración.

## Lo que cambia

### Sistema de diseño (foundation)
- Body bg pasó a `stone-50` (warm grays) y bordes a `stone-200` — calidez sutil sin perder limpieza.
- Tipografía editorial: `font-weight: 800` + `letter-spacing: -0.035em` + gradient en títulos h1, cursivas reales en períodos dinámicos, kerning generoso en crumbs uppercase.
- Sombras `shadow-warm` con tinte stone (en vez de gris frío).
- Animación `fadeSlideIn` para el período del título cuando cambia (`key={periodo}` re-mount).
- Stagger fade-in en las listas (cada item con 40ms de delay).

### Helpers nuevos (funciones puras + tests)
| Helper | Tests | Output |
|---|---|---|
| `labelPeriodoPedidos` | 18 | "del día / del mes / del 14 al 23 de mayo / para entregar hoy / ..." |
| `labelCategoriaProductos` | 9 | "de Manaos / que coinciden con \"agua\" / con stock bajo / ..." |
| `labelPeriodoDashboard` | 12 | "del día / de la semana / del mes / del año / del 14 al 23 de mayo / ..." |

### Toolbars unificadas (4 elementos en línea)

**Pedidos**: `[Acciones masivas ▾] [Exportaciones ▾] [Optimizar Ruta] [+ Nuevo pedido]`
**Productos**: `[Catálogo ▾] [Inventario ▾] [🔔 Stock bajo (N)] [+ Nuevo producto]`
**Dashboard**: `[Actualizar] [+ Backup]` (solo 2 acciones)

- Verde primary con gradient + glow para la acción de creación.
- Resto de botones neutrales con icono coloreado (mantienen identidad sin saturar).
- `modal={false}` en los DropdownMenu para evitar layout shift al abrir.
- Labels cortos en mobile (`Masivas`, `Exportar`, `Catálogo`, etc.).

### KPI cards (Pedidos + Dashboard) con icon-badge
- Border-left de 4px coloreado (semantic).
- Icon badge cuadrado con `bg-color-100` + icon `color-600`.
- Número editorial: `font-weight: 800` + `tabular-nums` + 24-28px.
- Gradient sutil (7% opacity) del color hacia transparent.
- Hover lift + shadow-warm-md.

### PedidoCard rearquitecturada
5 zonas con respiración:
1. **Meta-line**: `#1795 · 14/5 · 03:52 · entrega 15/5` (13px legible, antes 11px)
2. **Header**: cliente prominente + dirección con icono + stepper a la derecha
3. **Personas**: chips compactos con borde sutil (Joaquin, Marcos)
4. **Productos**: chips con `max-w-[22ch]` y `tabular-nums` en cantidad
5. **Footer**: total destacado en un compartimento con fondo gradient + "Ver detalle" como link

### Banner de stock bajo → `ModalStockBajo` (Productos)
Reemplazado por un botón con count badge en la toolbar. El modal muestra:
- Lista ordenada por urgencia: Sin stock → Stock bajo → Bajo del mínimo.
- Barra de cobertura visual (% stock vs mínimo).
- Acción rápida "Editar" inline que cierra el modal y abre `ModalProducto`.
- Filtros internos (búsqueda + categoría) que no afectan los filtros de la pantalla.

### Acciones por producto: chips con icono + label
Antes: 3 íconos `p-2` sin label que solo se distinguían por color en hover.
Ahora: 3 chips con borde coloreado, icono y label (`[Baja] [Editar] [Borrar]`), con hover lift.

## Coherencia con permisos y roles

- Verificado que admin, encargado, preventista, transportista (vista propia), depósito ven exactamente lo mismo que antes (mismos botones, mismos modales, misma data).
- `BadgeGeolocalizacion`, permisos de KPI cards, condicionales de toolbar — todos respetados.
- Mobile (375px) verificado: cero overflow horizontal, toolbars colapsan labels, cards apilan elementos.

## Test plan

- [x] `npm run typecheck` — limpio
- [x] `npm test` — **674/674 tests pasan** (frente a 648 antes; 26 nuevos para los 3 helpers + Button/Badge ya existentes)
- [x] `npm run build` — limpio (3937 KiB precache, +9 KiB neto)
- [x] Smoke visual en localhost:5173: login → /pedidos, /productos, /dashboard
- [x] Layout shift verificado: header no se mueve al abrir dropdowns
- [x] Filtro de fechas en /pedidos: título cambia dinámicamente
- [x] Filtro de categoría en /productos: título cambia
- [x] Filtro de período en /dashboard: título cambia
- [x] Modal de stock bajo abre correctamente con productos ordenados
- [x] Acciones por producto (Baja/Editar/Borrar) abren los mismos modales que antes

🤖 Generated with [Claude Code](https://claude.com/claude-code)