### PR TITLE
feat(roles+pagos): rol preventista_taco, descuento cliente y pagos FIFO desde ficha

### DIFF
--- a/migrations/050_preventista_taco_y_descuento_cliente.sql
+++ b/migrations/050_preventista_taco_y_descuento_cliente.sql
@@ -1,0 +1,40 @@
+-- ============================================================================
+-- 050 — Rol "preventista_taco" + descuento_porcentaje en clientes
+-- ============================================================================
+-- Cambios:
+--   1. Nuevo rol 'preventista_taco' en el CHECK constraint perfiles_rol_check.
+--      Es operativamente como 'preventista' (carga pedidos, ve clientes), pero
+--      la UI le oculta toda informacion comercial agregada (ventas, saldos,
+--      historicos de compra). El gating duro de UI vive en permisos.ts; este
+--      constraint solo habilita persistir el rol.
+--
+--   2. Nueva columna clientes.descuento_porcentaje (0..100). Solo admin la edita
+--      desde la ficha. Se aplica como descuento por linea al precio_unitario
+--      cuando un usuario arma un pedido para este cliente.
+-- ============================================================================
+
+BEGIN;
+
+-- 1) Extender CHECK constraint para incluir preventista_taco
+ALTER TABLE public.perfiles DROP CONSTRAINT IF EXISTS perfiles_rol_check;
+
+ALTER TABLE public.perfiles
+  ADD CONSTRAINT perfiles_rol_check
+  CHECK (rol = ANY (ARRAY[
+    'admin',
+    'preventista',
+    'preventista_taco',
+    'transportista',
+    'deposito',
+    'encargado'
+  ]::text[]));
+
+-- 2) Columna descuento_porcentaje en clientes
+ALTER TABLE public.clientes
+  ADD COLUMN IF NOT EXISTS descuento_porcentaje numeric(5,2) NOT NULL DEFAULT 0
+  CHECK (descuento_porcentaje >= 0 AND descuento_porcentaje <= 100);
+
+COMMENT ON COLUMN public.clientes.descuento_porcentaje IS
+  'Descuento porcentual precargado por el admin. Se aplica al precio_unitario al armar pedidos.';
+
+COMMIT;

--- a/migrations/051_registrar_pago_cliente_fifo.sql
+++ b/migrations/051_registrar_pago_cliente_fifo.sql
@@ -1,0 +1,149 @@
+-- ============================================================================
+-- 051 — RPC registrar_pago_cliente_fifo
+-- ============================================================================
+-- Permite registrar un pago de cliente desde la ficha (no asociado a un pedido
+-- particular) y distribuirlo automaticamente sobre los pedidos pendientes mas
+-- antiguos primero (FIFO). El sobrante (si lo hay) queda como saldo a favor:
+-- una fila en pagos con pedido_id = NULL.
+--
+-- RBAC: solo admin o encargado. Encargado ademas:
+--   - p_fecha debe ser hoy
+--   - no puede haber rendicion confirmada/resuelta para (fecha, sucursal)
+--   (mismo gating que marcar_pagos_masivo, migracion 039).
+--
+-- Reusa la cascada existente:
+--   - trigger AFTER en pagos (migracion 035) recalcula pedidos.monto_pagado
+--   - trigger BEFORE en pedidos recalcula estado_pago.
+-- Por eso esta RPC solo hace inserts; los totales de pedidos quedan correctos.
+-- ============================================================================
+
+BEGIN;
+
+CREATE OR REPLACE FUNCTION public.registrar_pago_cliente_fifo(
+  p_cliente_id bigint,
+  p_monto numeric,
+  p_forma_pago text,
+  p_fecha date DEFAULT CURRENT_DATE,
+  p_referencia text DEFAULT NULL,
+  p_notas text DEFAULT NULL
+) RETURNS jsonb
+LANGUAGE plpgsql SECURITY DEFINER SET search_path TO 'public'
+AS $$
+DECLARE
+  v_sucursal_id bigint := current_sucursal_id();
+  v_acting_user uuid := auth.uid();
+  v_rol text;
+  v_restante numeric := p_monto;
+  v_aplicar numeric;
+  v_pedido record;
+  v_pago_id bigint;
+  v_pago_ids jsonb := '[]'::jsonb;
+  v_aplicaciones jsonb := '[]'::jsonb;
+BEGIN
+  IF v_sucursal_id IS NULL THEN
+    RAISE EXCEPTION 'No hay sucursal activa' USING ERRCODE = '42501';
+  END IF;
+
+  IF p_monto IS NULL OR p_monto <= 0 THEN
+    RAISE EXCEPTION 'Monto debe ser mayor a 0' USING ERRCODE = '22023';
+  END IF;
+
+  IF p_forma_pago IS NULL OR length(trim(p_forma_pago)) = 0 THEN
+    RAISE EXCEPTION 'Forma de pago obligatoria' USING ERRCODE = '22023';
+  END IF;
+
+  -- RBAC: solo admin o encargado
+  SELECT rol INTO v_rol FROM perfiles WHERE id = v_acting_user;
+  IF v_rol IS NULL OR v_rol NOT IN ('admin', 'encargado') THEN
+    RAISE EXCEPTION 'No autorizado: solo admin o encargado pueden registrar pagos desde ficha de cliente'
+      USING ERRCODE = '42501';
+  END IF;
+
+  IF v_rol = 'encargado' THEN
+    IF p_fecha <> CURRENT_DATE THEN
+      RAISE EXCEPTION 'Encargado solo puede registrar pagos con fecha de hoy'
+        USING ERRCODE = '42501';
+    END IF;
+    IF public.rendicion_dia_cerrada(p_fecha, v_sucursal_id) THEN
+      RAISE EXCEPTION 'Rendicion ya cerrada para esta fecha. Pedi a un admin.'
+        USING ERRCODE = '42501';
+    END IF;
+  END IF;
+
+  -- FIFO: pedidos con saldo pendiente, mas antiguos primero
+  FOR v_pedido IN
+    SELECT id, total, COALESCE(monto_pagado, 0) AS pagado, fecha
+    FROM pedidos
+    WHERE cliente_id = p_cliente_id
+      AND sucursal_id = v_sucursal_id
+      AND estado <> 'cancelado'
+      AND COALESCE(estado_pago, 'pendiente') <> 'pagado'
+      AND total > COALESCE(monto_pagado, 0)
+    ORDER BY fecha ASC, id ASC
+  LOOP
+    EXIT WHEN v_restante <= 0;
+    v_aplicar := LEAST(v_restante, v_pedido.total - v_pedido.pagado);
+
+    INSERT INTO pagos (
+      cliente_id, pedido_id, monto, forma_pago, fecha,
+      referencia, notas, usuario_id, sucursal_id
+    )
+    VALUES (
+      p_cliente_id, v_pedido.id, v_aplicar, p_forma_pago, p_fecha,
+      p_referencia, p_notas, v_acting_user, v_sucursal_id
+    )
+    RETURNING id INTO v_pago_id;
+
+    v_pago_ids := v_pago_ids || to_jsonb(v_pago_id);
+    v_aplicaciones := v_aplicaciones || jsonb_build_object(
+      'pago_id', v_pago_id,
+      'pedido_id', v_pedido.id,
+      'pedido_fecha', v_pedido.fecha,
+      'monto', v_aplicar
+    );
+
+    v_restante := v_restante - v_aplicar;
+  END LOOP;
+
+  -- Sobrante: queda como saldo a favor (pedido_id NULL)
+  IF v_restante > 0 THEN
+    INSERT INTO pagos (
+      cliente_id, pedido_id, monto, forma_pago, fecha,
+      referencia, notas, usuario_id, sucursal_id
+    )
+    VALUES (
+      p_cliente_id, NULL, v_restante, p_forma_pago, p_fecha,
+      p_referencia,
+      COALESCE(NULLIF(p_notas, '') || ' ', '') || '[saldo a favor]',
+      v_acting_user, v_sucursal_id
+    )
+    RETURNING id INTO v_pago_id;
+
+    v_pago_ids := v_pago_ids || to_jsonb(v_pago_id);
+    v_aplicaciones := v_aplicaciones || jsonb_build_object(
+      'pago_id', v_pago_id,
+      'pedido_id', NULL,
+      'monto', v_restante,
+      'saldo_a_favor', true
+    );
+  END IF;
+
+  RETURN jsonb_build_object(
+    'success', true,
+    'monto_total', p_monto,
+    'sobrante', v_restante,
+    'pago_ids', v_pago_ids,
+    'aplicaciones', v_aplicaciones
+  );
+END;
+$$;
+
+ALTER FUNCTION public.registrar_pago_cliente_fifo(bigint, numeric, text, date, text, text) OWNER TO postgres;
+
+COMMENT ON FUNCTION public.registrar_pago_cliente_fifo(bigint, numeric, text, date, text, text) IS
+  'Registra un pago de cliente y lo distribuye automaticamente sobre los pedidos mas antiguos con saldo pendiente. Sobrante queda como saldo a favor (pedido_id NULL). Solo admin o encargado. Encargado: solo fecha=hoy, sin rendicion cerrada.';
+
+GRANT EXECUTE ON FUNCTION public.registrar_pago_cliente_fifo(bigint, numeric, text, date, text, text)
+  TO authenticated, service_role;
+
+COMMIT;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -199,6 +199,8 @@ function MainAppInner({ user, perfil, logout, authReady }: {
   const effectiveRol = currentSucursalRol ?? perfil?.rol
   const isAdmin = effectiveRol === 'admin'
   const isPreventista = effectiveRol === 'preventista'
+  const isPreventistaTaco = effectiveRol === 'preventista_taco'
+  const isAnyPreventista = isPreventista || isPreventistaTaco
   const isTransportista = effectiveRol === 'transportista'
   const isEncargado = effectiveRol === 'encargado'
   const isAdminOrEncargado = isAdmin || isEncargado
@@ -211,6 +213,8 @@ function MainAppInner({ user, perfil, logout, authReady }: {
     authReady,
     isAdmin,
     isPreventista,
+    isPreventistaTaco,
+    isAnyPreventista,
     isTransportista,
     isEncargado,
     isAdminOrEncargado,
@@ -218,7 +222,7 @@ function MainAppInner({ user, perfil, logout, authReady }: {
     logout: handleLogout,
     currentSucursalId,
     currentSucursalNombre,
-  }), [user, perfil, authReady, isAdmin, isPreventista, isTransportista, isEncargado, isAdminOrEncargado, isOnline, handleLogout, currentSucursalId, currentSucursalNombre])
+  }), [user, perfil, authReady, isAdmin, isPreventista, isPreventistaTaco, isAnyPreventista, isTransportista, isEncargado, isAdminOrEncargado, isOnline, handleLogout, currentSucursalId, currentSucursalNombre])
 
   const handleRetrySync = useCallback(async () => {
     await refreshPendingOperations()
@@ -246,7 +250,7 @@ function MainAppInner({ user, perfil, logout, authReady }: {
 
                 <Route
                   path="/dashboard"
-                  element={(isAdmin || isPreventista) ? <DashboardContainer /> : <Navigate to="/pedidos" replace />}
+                  element={(isAdmin || isAnyPreventista) ? <DashboardContainer /> : <Navigate to="/pedidos" replace />}
                 />
 
                 <Route path="/pedidos" element={<PedidosContainer />} />

--- a/src/components/AppModals.tsx
+++ b/src/components/AppModals.tsx
@@ -21,7 +21,9 @@ import type {
   RutaOptimizada,
   RegistrarSalvedadInput,
   RegistrarSalvedadResult,
-  PagoDBWithUsuario
+  PagoDBWithUsuario,
+  RegistrarPagoFifoInput,
+  RegistrarPagoFifoResult
 } from '../types/hooks';
 
 // Importar tipos específicos de handlers
@@ -161,6 +163,7 @@ export interface AppModalsHandlers {
   handleGuardarCliente: (clienteData: ClienteFormInput & { id?: string }) => Promise<void>;
   handleAbrirRegistrarPago: (cliente: ClienteDB) => Promise<void>;
   handleRegistrarPago: (datosPago: DatosPagoInput) => Promise<PagoDBWithUsuario>;
+  handleRegistrarPagoFIFO?: (input: RegistrarPagoFifoInput) => Promise<RegistrarPagoFifoResult>;
   handleGenerarReciboPago: (pago: PagoDBWithUsuario, cliente: ClienteDB) => void;
 
   // Producto handlers
@@ -533,6 +536,7 @@ export default function AppModals({
               pedidos={pedidos as any}
               onClose={() => { modales.registrarPago.setOpen(false); setClientePago(null); }}
               onConfirmar={handlers.handleRegistrarPago as any}
+              onConfirmarFIFO={handlers.handleRegistrarPagoFIFO as any}
               onGenerarRecibo={handlers.handleGenerarReciboPago as any}
             />
           </CompactErrorBoundary>

--- a/src/components/containers/ClientesContainer.tsx
+++ b/src/components/containers/ClientesContainer.tsx
@@ -16,6 +16,9 @@ import {
 import { useAuthData } from '../../contexts/AuthDataContext'
 import { useNotification } from '../../contexts/NotificationContext'
 import { useFichaCliente } from '../../hooks/supabase/useFichaCliente'
+import { usePagos } from '../../hooks/supabase'
+import { useQueryClient } from '@tanstack/react-query'
+import { puedeRegistrarPagoCliente } from '../../lib/permisos'
 import type { ClienteDB } from '../../types'
 import type { ClienteSaveData } from '../modals/ModalCliente'
 
@@ -25,6 +28,7 @@ const ModalCliente = lazy(() => import('../modals/ModalCliente'))
 const ModalFichaCliente = lazy(() => import('../modals/ModalFichaCliente'))
 const ModalConfirmacion = lazy(() => import('../modals/ModalConfirmacion'))
 const ModalZonas = lazy(() => import('../modals/ModalZonas'))
+const ModalRegistrarPago = lazy(() => import('../modals/ModalRegistrarPago'))
 
 function LoadingState() {
   return (
@@ -43,8 +47,12 @@ interface ConfirmConfig {
 }
 
 export default function ClientesContainer(): React.ReactElement {
-  const { user, isAdmin, isPreventista, isEncargado } = useAuthData()
+  const { user, perfil, isAdmin, isPreventista, isEncargado } = useAuthData()
   const notify = useNotification()
+  const queryClient = useQueryClient()
+  const { registrarPago, registrarPagoFIFO, obtenerResumenCuenta } = usePagos()
+  const rol = perfil?.rol
+  const puedePago = puedeRegistrarPagoCliente(rol)
 
   // Queries
   const { data: clientes = [], isLoading } = useClientesQuery()
@@ -63,6 +71,8 @@ export default function ClientesContainer(): React.ReactElement {
   const [modalFichaOpen, setModalFichaOpen] = useState(false)
   const [modalZonasOpen, setModalZonasOpen] = useState(false)
   const [clienteFichaId, setClienteFichaId] = useState<string | null>(null)
+  const [clientePago, setClientePago] = useState<ClienteDB | null>(null)
+  const [saldoPendientePago, setSaldoPendientePago] = useState<number>(0)
 
   // Ficha cliente hook - ModalFichaCliente lo usa internamente
   useFichaCliente(clienteFichaId)
@@ -106,6 +116,59 @@ export default function ClientesContainer(): React.ReactElement {
     setClienteFichaId(cliente.id)
     setModalFichaOpen(true)
   }, [])
+
+  const handleAbrirRegistrarPago = useCallback(async (cliente: ClienteDB) => {
+    if (!puedePago) return
+    setClientePago(cliente)
+    const resumen = await obtenerResumenCuenta(cliente.id)
+    setSaldoPendientePago(resumen?.saldo_actual ?? 0)
+    setModalFichaOpen(false)
+  }, [puedePago, obtenerResumenCuenta])
+
+  const handleConfirmarPagoSimple = useCallback(async (datosPago: {
+    clienteId: string
+    pedidoId: string | null
+    monto: number
+    formaPago: string
+    referencia: string
+    notas: string
+    fecha: string
+  }) => {
+    const pago = await registrarPago({
+      clienteId: datosPago.clienteId,
+      pedidoId: datosPago.pedidoId,
+      monto: datosPago.monto,
+      formaPago: datosPago.formaPago,
+      referencia: datosPago.referencia,
+      notas: datosPago.notas,
+      fecha: datosPago.fecha,
+      usuarioId: user?.id ?? ''
+    })
+    queryClient.invalidateQueries({ queryKey: ['pedidos'] })
+    queryClient.invalidateQueries({ queryKey: ['ficha-cliente'] })
+    notify.success('Pago registrado correctamente')
+    return pago
+  }, [registrarPago, user?.id, queryClient, notify])
+
+  const handleConfirmarPagoFIFO = useCallback(async (input: {
+    clienteId: string
+    monto: number
+    formaPago: string
+    fecha?: string
+    referencia?: string
+    notas?: string
+  }) => {
+    const result = await registrarPagoFIFO(input)
+    queryClient.invalidateQueries({ queryKey: ['pedidos'] })
+    queryClient.invalidateQueries({ queryKey: ['ficha-cliente'] })
+    queryClient.invalidateQueries({ queryKey: ['clientes'] })
+    if (result.sobrante > 0) {
+      notify.success(`Pago registrado. $${result.sobrante.toLocaleString('es-AR')} quedó como saldo a favor.`)
+    } else {
+      notify.success('Pago registrado y aplicado a pedidos pendientes')
+    }
+    return result
+  }, [registrarPagoFIFO, queryClient, notify])
 
   const handleGestionarZonas = useCallback(() => {
     setModalZonasOpen(true)
@@ -156,6 +219,7 @@ export default function ClientesContainer(): React.ReactElement {
       longitud: data.longitud,
       limite_credito: data.limiteCredito,
       dias_credito: data.diasCredito,
+      descuento_porcentaje: data.descuentoPorcentaje,
       contacto: data.contacto || undefined,
       horarios_atencion: data.horarios_atencion || undefined,
       rubro: data.rubro || undefined,
@@ -221,6 +285,21 @@ export default function ClientesContainer(): React.ReactElement {
               setModalFichaOpen(false)
               setClienteFichaId(null)
             }}
+            onRegistrarPago={puedePago ? handleAbrirRegistrarPago : undefined}
+          />
+        </Suspense>
+      )}
+
+      {/* Modal Registrar Pago — flujo desde ficha de cliente con imputacion FIFO */}
+      {clientePago && (
+        <Suspense fallback={null}>
+          <ModalRegistrarPago
+            cliente={clientePago}
+            saldoPendiente={saldoPendientePago}
+            pedidos={[]}
+            onClose={() => setClientePago(null)}
+            onConfirmar={handleConfirmarPagoSimple as any}
+            onConfirmarFIFO={handleConfirmarPagoFIFO}
           />
         </Suspense>
       )}

--- a/src/components/containers/DashboardContainer.tsx
+++ b/src/components/containers/DashboardContainer.tsx
@@ -21,10 +21,11 @@ function LoadingState() {
 }
 
 export default function DashboardContainer(): React.ReactElement {
-  const { user, isAdmin, isPreventista, authReady } = useAuthData()
+  const { user, isAdmin, isPreventista, isPreventistaTaco, isAnyPreventista, isEncargado, authReady } = useAuthData()
 
-  // Determinar si debe filtrar por usuario
-  const usuarioFiltro = isPreventista && !isAdmin ? user?.id : null
+  // Determinar si debe filtrar por usuario (preventista y preventista_taco
+  // solo ven sus propios datos)
+  const usuarioFiltro = isAnyPreventista && !isAdmin ? user?.id : null
 
   // Estado local para el filtro de periodo y fechas personalizadas
   const [filtroPeriodo, setFiltroPeriodo] = React.useState('mes')
@@ -74,6 +75,8 @@ export default function DashboardContainer(): React.ReactElement {
         exportando={exportando}
         isAdmin={isAdmin}
         isPreventista={isPreventista}
+        isPreventistaTaco={isPreventistaTaco}
+        isEncargado={isEncargado}
         totalClientes={clientes.length}
       />
     </Suspense>

--- a/src/components/containers/PedidosContainer.tsx
+++ b/src/components/containers/PedidosContainer.tsx
@@ -738,8 +738,15 @@ export default function PedidosContainer(): React.ReactElement {
     try {
       // Use promo+wholesale-resolved items and total (includes bonificaciones)
       const tipoFactura = nuevoPedido.tipoFactura || 'ZZ'
+      // Descuento porcentual del cliente (admin lo precarga en la ficha).
+      // Se aplica DESPUES de promociones/precio mayorista para que el factor
+      // multiplique el precio final por linea. Items bonificacion no se tocan.
+      const clienteSel = clientes.find(c => String(c.id) === String(nuevoPedido.clienteId))
+      const dtoPct = clienteSel?.descuento_porcentaje ?? 0
+      const factorDto = dtoPct > 0 ? 1 - dtoPct / 100 : 1
       let totalNeto = 0
       let totalIva = 0
+      let totalConDescuento = 0
       const itemsParaCrear = itemsFinales.map(item => {
         const esBonif = !!item.esBonificacion
         if (esBonif) {
@@ -755,13 +762,17 @@ export default function PedidosContainer(): React.ReactElement {
         const producto = productos.find(p => String(p.id) === String(item.productoId))
         const pctIva = producto?.porcentaje_iva ?? 21
         const pctImpInt = producto?.impuestos_internos ?? 0
-        const desglose = calcularNetoVenta(item.precioUnitario, pctIva, pctImpInt, tipoFactura)
+        const precioConDto = factorDto < 1
+          ? Math.round(item.precioUnitario * factorDto * 100) / 100
+          : item.precioUnitario
+        const desglose = calcularNetoVenta(precioConDto, pctIva, pctImpInt, tipoFactura)
         totalNeto += desglose.neto * item.cantidad
         totalIva += desglose.iva * item.cantidad
+        totalConDescuento += precioConDto * item.cantidad
         return {
           productoId: String(item.productoId),
           cantidad: item.cantidad,
-          precioUnitario: item.precioUnitario,
+          precioUnitario: precioConDto,
           ...(item.promoId ? { promocionId: item.promoId } : {}),
           neto_unitario: desglose.neto,
           iva_unitario: desglose.iva,
@@ -772,7 +783,7 @@ export default function PedidosContainer(): React.ReactElement {
       const pedidoCreado = await crearPedido.mutateAsync({
         clienteId: nuevoPedido.clienteId,
         items: itemsParaCrear,
-        total: totalFinal,
+        total: factorDto < 1 ? totalConDescuento : totalFinal,
         usuarioId: user?.id ?? null,
         notas: nuevoPedido.notas,
         formaPago: nuevoPedido.formaPago,
@@ -798,7 +809,7 @@ export default function PedidosContainer(): React.ReactElement {
       notify.error('Error al crear pedido: ' + (e as Error).message)
     }
     setGuardando(false)
-  }, [nuevoPedido, itemsFinales, totalFinal, crearPedido, user, resetNuevoPedido, notify, productos, isPreventista, capturarGps, registrarGpsPedido])
+  }, [nuevoPedido, itemsFinales, totalFinal, crearPedido, user, resetNuevoPedido, notify, productos, clientes, isPreventista, capturarGps, registrarGpsPedido])
 
   // ModalFiltroFecha: onApply({ fechaDesde, fechaHasta })
   const handleFiltroFechaApply = useCallback((f: { fechaDesde: string | null; fechaHasta: string | null }) => {

--- a/src/components/modals/ModalCliente.tsx
+++ b/src/components/modals/ModalCliente.tsx
@@ -38,6 +38,7 @@ export interface ClienteFormData {
   notas: string;
   limiteCredito: number;
   diasCredito: number;
+  descuentoPorcentaje: number;
   preventista_id: string;
   preventista_ids: string[];
 }
@@ -116,6 +117,7 @@ const ModalCliente = memo(function ModalCliente({ cliente, onSave, onClose, guar
     notas: cliente.notas || '',
     limiteCredito: cliente.limite_credito || 0,
     diasCredito: cliente.dias_credito || 30,
+    descuentoPorcentaje: cliente.descuento_porcentaje || 0,
     preventista_id: cliente.preventista_id || '',
     preventista_ids: cliente.preventista_ids || []
   } : {
@@ -135,6 +137,7 @@ const ModalCliente = memo(function ModalCliente({ cliente, onSave, onClose, guar
     notas: '',
     limiteCredito: 0,
     diasCredito: 30,
+    descuentoPorcentaje: 0,
     preventista_id: '',
     preventista_ids: []
   });
@@ -570,12 +573,12 @@ const ModalCliente = memo(function ModalCliente({ cliente, onSave, onClose, guar
           />
         </div>
 
-        {/* Campos de crédito - Solo visibles y editables para admin */}
-        {isAdmin && (
+        {/* Campos de crédito y descuento - Solo admin puede editar */}
+        {isAdmin ? (
           <div className="border-t pt-4 mt-4">
             <div className="flex items-center gap-2 mb-3">
               <CreditCard className="w-5 h-5 text-blue-600" />
-              <span className="font-medium text-gray-700 dark:text-gray-200">Configuración de Crédito</span>
+              <span className="font-medium text-gray-700 dark:text-gray-200">Configuración de Crédito y Descuento</span>
             </div>
             <div className="grid grid-cols-2 gap-4">
               <div>
@@ -607,8 +610,47 @@ const ModalCliente = memo(function ModalCliente({ cliente, onSave, onClose, guar
                 />
                 <p className="text-xs text-gray-500 mt-1">Plazo de pago en días</p>
               </div>
+              <div>
+                <label className="block text-sm font-medium mb-1 dark:text-gray-200">Descuento (%)</label>
+                <input
+                  type="number"
+                  inputMode="decimal"
+                  step="0.5"
+                  min="0"
+                  max="100"
+                  value={form.descuentoPorcentaje}
+                  onChange={e => handleFieldChange('descuentoPorcentaje', e.target.value)}
+                  className="w-full px-3 py-2 border rounded-lg dark:bg-gray-700 dark:border-gray-600 dark:text-white"
+                  placeholder="0"
+                />
+                <p className="text-xs text-gray-500 mt-1">Se aplica al precio_unitario al armar pedidos</p>
+              </div>
             </div>
           </div>
+        ) : (
+          (form.descuentoPorcentaje > 0 || (form.limiteCredito ?? 0) > 0) && (
+            <div className="border-t pt-4 mt-4">
+              <div className="flex items-center gap-2 mb-3">
+                <CreditCard className="w-5 h-5 text-blue-600" />
+                <span className="font-medium text-gray-700 dark:text-gray-200">Crédito y Descuento</span>
+              </div>
+              <div className="grid grid-cols-3 gap-4 text-sm">
+                <div>
+                  <p className="text-gray-500">Límite de Crédito</p>
+                  <p className="font-medium">${form.limiteCredito.toLocaleString('es-AR')}</p>
+                </div>
+                <div>
+                  <p className="text-gray-500">Días de Crédito</p>
+                  <p className="font-medium">{form.diasCredito} días</p>
+                </div>
+                <div>
+                  <p className="text-gray-500">Descuento</p>
+                  <p className="font-medium">{form.descuentoPorcentaje}%</p>
+                </div>
+              </div>
+              <p className="text-xs text-gray-500 mt-2">Solo el administrador puede editar estos valores.</p>
+            </div>
+          )
         )}
       </div>
       <div className="flex justify-end space-x-3 p-4 border-t bg-gray-50 dark:bg-gray-800">

--- a/src/components/modals/ModalFichaCliente.tsx
+++ b/src/components/modals/ModalFichaCliente.tsx
@@ -1,8 +1,10 @@
 import { useState, useEffect, useMemo } from 'react'
 import type { LucideIcon } from 'lucide-react'
-import { User, MapPin, Phone, CreditCard, ShoppingBag, TrendingUp, DollarSign, Clock, Package, ChevronDown, ChevronUp, FileText, Plus, AlertTriangle, CheckCircle, Tag, Building2 } from 'lucide-react'
+import { User, MapPin, Phone, CreditCard, ShoppingBag, TrendingUp, DollarSign, Clock, Package, ChevronDown, ChevronUp, FileText, Plus, AlertTriangle, CheckCircle, Tag, Building2, Percent } from 'lucide-react'
 import ModalBase from './ModalBase'
 import { useFichaCliente, usePagos } from '../../hooks/supabase'
+import { useAuthData } from '../../contexts/AuthDataContext'
+import { puedeVerSaldoCliente, puedeVerHistorialVentasCliente, puedeRegistrarPagoCliente } from '../../lib/permisos'
 import { formatPrecio as formatCurrency, formatFecha as formatDate, getEstadoColor, getEstadoPagoColor } from '../../utils/formatters'
 import { logger } from '../../utils/logger'
 import type { ClienteDB, PedidoDB, PagoDBWithUsuario, ResumenCuenta, EstadisticasCliente, PedidoClienteWithItems } from '../../types'
@@ -43,6 +45,11 @@ interface TabItem {
 export default function ModalFichaCliente({ cliente, onClose, onRegistrarPago, onVerPedido }: ModalFichaClienteProps) {
   const { pedidosCliente, estadisticas, loading } = useFichaCliente(cliente?.id)
   const { pagos, loading: loadingPagos, fetchPagosCliente, obtenerResumenCuenta } = usePagos()
+  const { perfil } = useAuthData()
+  const rol = perfil?.rol
+  const verSaldo = puedeVerSaldoCliente(rol)
+  const verHistorialVentas = puedeVerHistorialVentasCliente(rol)
+  const puedeRegistrarPago = puedeRegistrarPagoCliente(rol)
   const [resumenCuenta, setResumenCuenta] = useState<ResumenCuenta | null>(null)
   const [activeTab, setActiveTab] = useState<ActiveTab>('resumen')
   const [expandedPedido, setExpandedPedido] = useState<string | null>(null)
@@ -92,6 +99,12 @@ export default function ModalFichaCliente({ cliente, onClose, onRegistrarPago, o
                     {cliente.rubro}
                   </span>
                 )}
+                {(cliente.descuento_porcentaje ?? 0) > 0 && (
+                  <span className="px-2 py-1 bg-emerald-100 dark:bg-emerald-900/30 text-emerald-700 dark:text-emerald-300 rounded-full text-xs font-medium flex items-center gap-1" title="Descuento precargado por el administrador">
+                    <Percent className="w-3 h-3" />
+                    Dto. {cliente.descuento_porcentaje}%
+                  </span>
+                )}
               </div>
               <p className="text-gray-600 dark:text-gray-400 flex items-center gap-1">
                 <Building2 className="w-4 h-4" />
@@ -129,6 +142,7 @@ export default function ModalFichaCliente({ cliente, onClose, onRegistrarPago, o
           </div>
 
           {/* Account Balance Card */}
+          {verSaldo && (
           <div className={`mt-4 p-4 rounded-xl ${excedido ? 'bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800' : 'bg-blue-50 dark:bg-blue-900/20'}`}>
             <div className="flex items-center justify-between">
               <div>
@@ -148,10 +162,11 @@ export default function ModalFichaCliente({ cliente, onClose, onRegistrarPago, o
                   </p>
                 )}
               </div>
-              {saldoActual > 0 && (
+              {puedeRegistrarPago && (
                 <button
                   onClick={() => onRegistrarPago?.(cliente)}
                   className="ml-4 px-4 py-2 bg-green-600 hover:bg-green-700 text-white rounded-lg flex items-center gap-2"
+                  title={saldoActual > 0 ? 'Registrar pago del cliente' : 'Registrar pago anticipado / saldo a favor'}
                 >
                   <Plus className="w-4 h-4" />
                   Registrar Pago
@@ -176,15 +191,16 @@ export default function ModalFichaCliente({ cliente, onClose, onRegistrarPago, o
               </div>
             )}
           </div>
+          )}
         </div>
 
-        {/* Tabs */}
+        {/* Tabs (taco no ve la pestaña Pagos) */}
         <div className="flex border-b border-gray-200 dark:border-gray-700">
-          {([
+          {(([
             { id: 'resumen', label: 'Resumen', icon: TrendingUp },
             { id: 'pedidos', label: 'Pedidos', icon: ShoppingBag },
-            { id: 'pagos', label: 'Pagos', icon: DollarSign }
-          ] as TabItem[]).map(tab => (
+            ...(verSaldo ? [{ id: 'pagos' as ActiveTab, label: 'Pagos', icon: DollarSign }] : [])
+          ]) as TabItem[]).map(tab => (
             <button
               key={tab.id}
               onClick={() => setActiveTab(tab.id)}
@@ -216,18 +232,22 @@ export default function ModalFichaCliente({ cliente, onClose, onRegistrarPago, o
                   value={estadisticas?.totalPedidos || 0}
                   color="blue"
                 />
-                <StatCard
-                  icon={DollarSign}
-                  label="Total Compras"
-                  value={formatCurrency(estadisticas?.totalCompras || 0)}
-                  color="green"
-                />
-                <StatCard
-                  icon={TrendingUp}
-                  label="Ticket Promedio"
-                  value={formatCurrency(estadisticas?.ticketPromedio || 0)}
-                  color="purple"
-                />
+                {verHistorialVentas && (
+                  <>
+                    <StatCard
+                      icon={DollarSign}
+                      label="Total Compras"
+                      value={formatCurrency(estadisticas?.totalCompras || 0)}
+                      color="green"
+                    />
+                    <StatCard
+                      icon={TrendingUp}
+                      label="Ticket Promedio"
+                      value={formatCurrency(estadisticas?.ticketPromedio || 0)}
+                      color="purple"
+                    />
+                  </>
+                )}
                 <StatCard
                   icon={Clock}
                   label="Días sin Comprar"
@@ -236,7 +256,8 @@ export default function ModalFichaCliente({ cliente, onClose, onRegistrarPago, o
                 />
               </div>
 
-              {/* Payment Status */}
+              {/* Payment Status (oculto para preventista_taco) */}
+              {verSaldo && (
               <div className="grid grid-cols-2 gap-4">
                 <div className="p-4 bg-green-50 dark:bg-green-900/20 rounded-xl">
                   <div className="flex items-center gap-2 text-green-600 dark:text-green-400 mb-2">
@@ -259,6 +280,7 @@ export default function ModalFichaCliente({ cliente, onClose, onRegistrarPago, o
                   <p className="text-sm text-yellow-600">{estadisticas?.pedidosPendientes || 0} pedidos</p>
                 </div>
               </div>
+              )}
 
               {/* Favorite Products */}
               {(estadisticas?.productosFavoritos?.length ?? 0) > 0 && estadisticas && (
@@ -281,7 +303,8 @@ export default function ModalFichaCliente({ cliente, onClose, onRegistrarPago, o
                 </div>
               )}
 
-              {/* Credit Info */}
+              {/* Credit Info (oculto para preventista_taco) */}
+              {verSaldo && (
               <div className="p-4 bg-gray-50 dark:bg-gray-700/50 rounded-xl">
                 <h3 className="font-semibold text-gray-900 dark:text-white mb-2 flex items-center gap-2">
                   <CreditCard className="w-5 h-5" />
@@ -296,12 +319,19 @@ export default function ModalFichaCliente({ cliente, onClose, onRegistrarPago, o
                     <span className="text-gray-500">Días de Crédito:</span>
                     <span className="ml-2 font-medium">{cliente.dias_credito || 30} días</span>
                   </div>
+                  {(cliente.descuento_porcentaje ?? 0) > 0 && (
+                    <div>
+                      <span className="text-gray-500">Descuento:</span>
+                      <span className="ml-2 font-medium text-emerald-600">{cliente.descuento_porcentaje}%</span>
+                    </div>
+                  )}
                   <div>
                     <span className="text-gray-500">Frecuencia de Compra:</span>
                     <span className="ml-2 font-medium">{(estadisticas?.frecuenciaCompra || 0).toFixed(1)} pedidos/mes</span>
                   </div>
                 </div>
               </div>
+              )}
 
               {/* Notas del cliente */}
               {cliente.notas && (
@@ -346,9 +376,11 @@ export default function ModalFichaCliente({ cliente, onClose, onRegistrarPago, o
                         </div>
                       </div>
                       <div className="flex items-center gap-4">
-                        <p className="text-xl font-bold text-gray-900 dark:text-white">
-                          {formatCurrency(pedido.total)}
-                        </p>
+                        {verHistorialVentas && (
+                          <p className="text-xl font-bold text-gray-900 dark:text-white">
+                            {formatCurrency(pedido.total)}
+                          </p>
+                        )}
                         {expandedPedido === pedido.id ? <ChevronUp className="w-5 h-5" /> : <ChevronDown className="w-5 h-5" />}
                       </div>
                     </div>
@@ -359,8 +391,8 @@ export default function ModalFichaCliente({ cliente, onClose, onRegistrarPago, o
                             <tr className="text-gray-500 text-left">
                               <th className="pb-2">Producto</th>
                               <th className="pb-2 text-right">Cant.</th>
-                              <th className="pb-2 text-right">Precio</th>
-                              <th className="pb-2 text-right">Subtotal</th>
+                              {verHistorialVentas && <th className="pb-2 text-right">Precio</th>}
+                              {verHistorialVentas && <th className="pb-2 text-right">Subtotal</th>}
                             </tr>
                           </thead>
                           <tbody>
@@ -368,8 +400,8 @@ export default function ModalFichaCliente({ cliente, onClose, onRegistrarPago, o
                               <tr key={item.id} className="border-t border-gray-100 dark:border-gray-700">
                                 <td className="py-2">{item.producto?.nombre || 'Producto'}</td>
                                 <td className="py-2 text-right">{item.cantidad}</td>
-                                <td className="py-2 text-right">{formatCurrency(item.precio_unitario)}</td>
-                                <td className="py-2 text-right font-medium">{formatCurrency(item.subtotal)}</td>
+                                {verHistorialVentas && <td className="py-2 text-right">{formatCurrency(item.precio_unitario)}</td>}
+                                {verHistorialVentas && <td className="py-2 text-right font-medium">{formatCurrency(item.subtotal)}</td>}
                               </tr>
                             ))}
                           </tbody>
@@ -393,7 +425,7 @@ export default function ModalFichaCliente({ cliente, onClose, onRegistrarPago, o
             <div className="space-y-3">
               <div className="flex justify-between items-center mb-4">
                 <h3 className="font-semibold text-gray-900 dark:text-white">Historial de Pagos</h3>
-                {saldoActual > 0 && (
+                {puedeRegistrarPago && (
                   <button
                     onClick={() => onRegistrarPago?.(cliente)}
                     className="px-3 py-1.5 bg-green-600 hover:bg-green-700 text-white rounded-lg text-sm flex items-center gap-1"

--- a/src/components/modals/ModalRegistrarPago.tsx
+++ b/src/components/modals/ModalRegistrarPago.tsx
@@ -1,10 +1,10 @@
 import React, { useState, FormEvent, ChangeEvent } from 'react'
-import { X, DollarSign, FileText, AlertCircle, Check, Plus, Trash2, Calendar } from 'lucide-react'
+import { X, DollarSign, FileText, AlertCircle, Check, Plus, Trash2, Calendar, ListOrdered } from 'lucide-react'
 import { formatPrecio as formatCurrency, fechaLocalISO } from '../../utils/formatters'
 import { parsePrecio } from '../../utils/calculations'
 import { useZodValidation } from '../../hooks/useZodValidation'
 import { modalPagoSchema } from '../../lib/schemas'
-import type { ClienteDB, Pedido, Pago, FormaPago } from '../../types'
+import type { ClienteDB, Pedido, Pago, FormaPago, RegistrarPagoFifoInput, RegistrarPagoFifoResult, PagoFifoAplicacion } from '../../types'
 
 // Alias for the Cliente type used in this component
 type Cliente = ClienteDB;
@@ -49,6 +49,12 @@ export interface ModalRegistrarPagoProps {
   pedidos: Pedido[];
   onClose: () => void;
   onConfirmar: (data: PagoData) => Promise<PagoRegistrado>;
+  /**
+   * Si se provee, al confirmar sin pedido especifico el modal puede llamar a
+   * esta funcion para distribuir el pago automaticamente sobre los pedidos
+   * mas antiguos (FIFO). Sobrante queda como saldo a favor.
+   */
+  onConfirmarFIFO?: (input: RegistrarPagoFifoInput) => Promise<RegistrarPagoFifoResult>;
   onGenerarRecibo?: (pago: PagoRegistrado, cliente: Cliente) => void;
 }
 
@@ -58,6 +64,7 @@ export default function ModalRegistrarPago({
   pedidos,
   onClose,
   onConfirmar,
+  onConfirmarFIFO,
   onGenerarRecibo
 }: ModalRegistrarPagoProps): React.ReactElement | null {
   // Zod validation hook
@@ -70,8 +77,11 @@ export default function ModalRegistrarPago({
   const [pedidoSeleccionado, setPedidoSeleccionado] = useState<string>('')
   const [loading, setLoading] = useState<boolean>(false)
   const [pagoRegistrado, setPagoRegistrado] = useState<PagoRegistrado | null>(null)
+  const [resultadoFIFO, setResultadoFIFO] = useState<RegistrarPagoFifoResult | null>(null)
   const [error, setError] = useState<string>('')
   const [fecha, setFecha] = useState<string>(fechaLocalISO())
+  // Toggle FIFO: por defecto on cuando hay onConfirmarFIFO disponible
+  const [aplicarFIFO, setAplicarFIFO] = useState<boolean>(Boolean(onConfirmarFIFO))
 
   // Pago dividido
   const [pagoDividido, setPagoDividido] = useState<boolean>(false)
@@ -104,6 +114,36 @@ export default function ModalRegistrarPago({
     e.preventDefault()
     setError('')
 
+    // FIFO solo aplica cuando: no es pago dividido, no hay pedido específico
+    // seleccionado, y el caller proveyó onConfirmarFIFO.
+    const usarFIFO = aplicarFIFO && !pagoDividido && !pedidoSeleccionado && !!onConfirmarFIFO
+
+    if (usarFIFO) {
+      const montoNumero = parsePrecio(monto)
+      if (!montoNumero || montoNumero <= 0) {
+        setError('Ingresá un monto válido')
+        return
+      }
+      setLoading(true)
+      try {
+        const result = await onConfirmarFIFO!({
+          clienteId: cliente!.id,
+          monto: montoNumero,
+          formaPago,
+          fecha,
+          referencia: referencia || undefined,
+          notas: notas || undefined,
+        })
+        setResultadoFIFO(result)
+      } catch (err) {
+        const errorMessage = err instanceof Error ? err.message : 'Error al registrar el pago'
+        setError(errorMessage)
+      } finally {
+        setLoading(false)
+      }
+      return
+    }
+
     if (pagoDividido) {
       // Validar pagos divididos
       const pagosValidos = pagos.filter(p => parsePrecio(p.monto) > 0)
@@ -112,12 +152,8 @@ export default function ModalRegistrarPago({
         return
       }
 
-      // Validate total does not exceed outstanding balance (BUG-10 fix)
-      const totalDividido = pagosValidos.reduce((s, p) => s + parsePrecio(p.monto), 0)
-      if (saldoPendiente > 0 && totalDividido > saldoPendiente + 0.01) {
-        setError(`El total de pagos ($${totalDividido.toLocaleString('es-AR')}) excede el saldo pendiente ($${saldoPendiente.toLocaleString('es-AR')})`)
-        return
-      }
+      // El exceso ya no bloquea: queda como saldo a favor (ver flujo FIFO).
+      // Pero si NO se eligio pedido y NO se va a usar FIFO, advertimos.
 
       setLoading(true)
       try {
@@ -141,7 +177,7 @@ export default function ModalRegistrarPago({
         setLoading(false)
       }
     } else {
-      // Pago simple (comportamiento original)
+      // Pago simple (a pedido específico o a cuenta general sin FIFO)
       const result = validate({ monto: parsePrecio(monto), formaPago, referencia, notas, pedidoSeleccionado })
       if (!result.success) {
         setError(getFirstError() || 'Error de validacion')
@@ -176,6 +212,62 @@ export default function ModalRegistrarPago({
   }
 
   if (!cliente) return null
+
+  // Success screen FIFO: muestra desglose por pedido + sobrante
+  if (resultadoFIFO) {
+    return (
+      <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
+        <div className="bg-white dark:bg-gray-800 rounded-2xl w-full max-w-md p-6 max-h-[90dvh] overflow-y-auto">
+          <div className="text-center">
+            <div className="w-16 h-16 bg-green-100 dark:bg-green-900/30 rounded-full flex items-center justify-center mx-auto mb-4">
+              <Check className="w-8 h-8 text-green-600" />
+            </div>
+            <h2 className="text-2xl font-bold text-gray-900 dark:text-white mb-2">
+              Pago Registrado
+            </h2>
+            <p className="text-gray-600 dark:text-gray-400 mb-4">
+              Total imputado: <span className="font-bold text-green-600">{formatCurrency(resultadoFIFO.montoTotal)}</span> para {cliente.nombre_fantasia}
+            </p>
+          </div>
+          <div className="mt-2 space-y-2">
+            <p className="text-sm font-medium text-gray-700 dark:text-gray-300">Desglose:</p>
+            {resultadoFIFO.aplicaciones.length === 0 ? (
+              <p className="text-sm text-gray-500">Sin aplicaciones.</p>
+            ) : resultadoFIFO.aplicaciones.map((ap: PagoFifoAplicacion) => (
+              <div key={ap.pago_id} className="flex items-center justify-between p-3 bg-gray-50 dark:bg-gray-700/50 rounded-lg text-sm">
+                <div>
+                  {ap.pedido_id ? (
+                    <>
+                      <p className="font-medium text-gray-900 dark:text-white">Pedido #{ap.pedido_id}</p>
+                      {ap.pedido_fecha && (
+                        <p className="text-xs text-gray-500">{ap.pedido_fecha}</p>
+                      )}
+                    </>
+                  ) : (
+                    <p className="font-medium text-emerald-700 dark:text-emerald-300">Saldo a favor</p>
+                  )}
+                </div>
+                <p className="font-bold text-gray-900 dark:text-white">{formatCurrency(ap.monto)}</p>
+              </div>
+            ))}
+            {resultadoFIFO.sobrante > 0 && (
+              <p className="text-xs text-emerald-600 dark:text-emerald-400">
+                Quedó un saldo a favor de {formatCurrency(resultadoFIFO.sobrante)} disponible para futuros pedidos.
+              </p>
+            )}
+          </div>
+          <div className="mt-6 flex justify-center">
+            <button
+              onClick={onClose}
+              className="px-4 py-2 bg-gray-100 hover:bg-gray-200 dark:bg-gray-700 dark:hover:bg-gray-600 text-gray-900 dark:text-white rounded-lg"
+            >
+              Cerrar
+            </button>
+          </div>
+        </div>
+      </div>
+    )
+  }
 
   // Success screen
   if (pagoRegistrado) {
@@ -282,6 +374,42 @@ export default function ModalRegistrarPago({
               Pago dividido (multiples formas de pago)
             </span>
           </label>
+
+          {/* Toggle FIFO: solo visible si el caller proveyó onConfirmarFIFO y no
+              hay pago dividido ni pedido específico seleccionado */}
+          {onConfirmarFIFO && !pagoDividido && !pedidoSeleccionado && (
+            <div className="p-3 bg-emerald-50 dark:bg-emerald-900/20 border border-emerald-200 dark:border-emerald-800 rounded-lg">
+              <label className="flex items-start gap-2 cursor-pointer">
+                <input
+                  type="checkbox"
+                  checked={aplicarFIFO}
+                  onChange={e => setAplicarFIFO(e.target.checked)}
+                  className="w-4 h-4 mt-0.5 rounded border-gray-300 text-emerald-600"
+                />
+                <span className="text-sm text-emerald-800 dark:text-emerald-200 flex items-center gap-1">
+                  <ListOrdered className="w-4 h-4" />
+                  Aplicar a pedidos más antiguos automáticamente (FIFO)
+                </span>
+              </label>
+              <p className="text-xs text-emerald-700 dark:text-emerald-300 mt-1 ml-6">
+                Imputa el monto en orden de fecha de pedido. Sobrante queda como saldo a favor.
+              </p>
+            </div>
+          )}
+
+          {/* Warning de saldo a favor */}
+          {!pagoDividido && parsePrecio(monto) > saldoPendiente && saldoPendiente > 0 && (
+            <div className="p-3 bg-yellow-50 dark:bg-yellow-900/20 border border-yellow-200 dark:border-yellow-800 rounded-lg flex items-start gap-2 text-yellow-800 dark:text-yellow-200">
+              <AlertCircle className="w-4 h-4 mt-0.5 flex-shrink-0" />
+              <p className="text-sm">
+                El monto excede el saldo pendiente en{' '}
+                <span className="font-semibold">{formatCurrency(parsePrecio(monto) - saldoPendiente)}</span>.{' '}
+                {aplicarFIFO && onConfirmarFIFO
+                  ? 'La diferencia quedará como saldo a favor.'
+                  : 'Activá FIFO o ajustá el monto si no querés generar saldo a favor.'}
+              </p>
+            </div>
+          )}
 
           {pagoDividido ? (
             <>

--- a/src/components/pedidos/PedidoCard.tsx
+++ b/src/components/pedidos/PedidoCard.tsx
@@ -344,6 +344,11 @@ function PedidoCard({
         <div className="flex flex-wrap justify-between items-center gap-2">
           <div className="flex flex-col">
             <p className="text-lg font-bold text-blue-600">{formatPrecio(pedido.total)}</p>
+            {pedido.estado_pago === 'parcial' && (
+              <p className="text-xs text-amber-700 dark:text-amber-400 font-medium">
+                Pagado: {formatPrecio(pedido.monto_pagado || 0)} de {formatPrecio(pedido.total)}
+              </p>
+            )}
             {(pedido.forma_pago || (pedido.pagos && pedido.pagos.length > 0)) && (
               <p className="text-xs text-gray-500 flex items-center">
                 <CreditCard className="w-3 h-3 mr-1" />

--- a/src/components/vistas/VistaDashboard.tsx
+++ b/src/components/vistas/VistaDashboard.tsx
@@ -62,6 +62,8 @@ export interface VistaDashboardProps {
   totalClientes?: number;
   isAdmin?: boolean;
   isPreventista?: boolean;
+  isPreventistaTaco?: boolean;
+  isEncargado?: boolean;
 }
 
 interface MetricasCalculadas {
@@ -198,8 +200,19 @@ export default function VistaDashboard({
   productosStockBajo = [],
   totalClientes = 0,
   isAdmin = false,
-  isPreventista = false
+  isPreventista = false,
+  isPreventistaTaco = false,
+  isEncargado = false
 }: VistaDashboardProps) {
+  // Visibilidad por rol:
+  //  - admin: ve todo
+  //  - encargado: solo "Ventas ultimos 7 dias" + estados de pedido (sin facturacion total ni agregados)
+  //  - preventista_taco: solo items (Top 5 productos) + estados; sin ningun monto
+  //  - preventista regular: ve montos pero filtrados a sus propias ventas
+  const verMontosAgregados = isAdmin || (isPreventista && !isPreventistaTaco)
+  const verVentasSemanales = !isPreventistaTaco // taco no ve ningun monto
+  const verTopProductos = !isEncargado || isAdmin // encargado no ve agregados de productos
+  const verEstadoPedidos = true
   const [fechaDesdeLocal, setFechaDesdeLocal] = useState<string>('');
   const [fechaHastaLocal, setFechaHastaLocal] = useState<string>('');
   const [mostrarFechasPersonalizadas, setMostrarFechasPersonalizadas] = useState<boolean>(false);
@@ -246,10 +259,12 @@ export default function VistaDashboard({
       <div className="flex flex-col sm:flex-row justify-between items-start sm:items-center gap-4">
         <div>
           <h1 className="text-2xl font-bold text-gray-800 dark:text-white">
-            {isPreventista && !isAdmin ? 'Mis Métricas' : 'Dashboard'}
+            {(isPreventista || isPreventistaTaco) && !isAdmin ? 'Mis Métricas' : 'Dashboard'}
           </h1>
           <p className="text-sm text-gray-500 dark:text-gray-400">
-            {isPreventista && !isAdmin
+            {isPreventistaTaco && !isAdmin
+              ? `Resumen de actividad - ${periodoLabels[filtroPeriodo]}`
+              : isPreventista && !isAdmin
               ? `Resumen de mis ventas - ${periodoLabels[filtroPeriodo]}`
               : `Resumen de actividad - ${periodoLabels[filtroPeriodo]}`
             }
@@ -348,14 +363,16 @@ export default function VistaDashboard({
 
       {/* Métricas principales */}
       <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
-        <MetricaCard
-          icono={DollarSign}
-          titulo="Ventas"
-          valor={formatPrecio(metricas.ventasPeriodo)}
-          subtitulo={periodoLabels[filtroPeriodo]}
-          colorClase={{ bg: 'bg-green-100 dark:bg-green-900/30', icon: 'text-green-600', text: 'text-green-600' }}
-          tendencia={<TendenciaIndicator valor={metricas.ventasPeriodo} comparacion={metricas.ventasPeriodoAnterior} />}
-        />
+        {verMontosAgregados && (
+          <MetricaCard
+            icono={DollarSign}
+            titulo="Ventas"
+            valor={formatPrecio(metricas.ventasPeriodo)}
+            subtitulo={periodoLabels[filtroPeriodo]}
+            colorClase={{ bg: 'bg-green-100 dark:bg-green-900/30', icon: 'text-green-600', text: 'text-green-600' }}
+            tendencia={<TendenciaIndicator valor={metricas.ventasPeriodo} comparacion={metricas.ventasPeriodoAnterior} />}
+          />
+        )}
         <MetricaCard
           icono={ShoppingCart}
           titulo="Pedidos"
@@ -364,13 +381,15 @@ export default function VistaDashboard({
           colorClase={{ bg: 'bg-blue-100 dark:bg-blue-900/30', icon: 'text-blue-600', text: 'text-blue-600' }}
           tendencia={<TendenciaIndicator valor={metricas.pedidosPeriodo} comparacion={metricas.pedidosPeriodoAnterior} />}
         />
-        <MetricaCard
-          icono={Target}
-          titulo="Ticket Promedio"
-          valor={formatPrecio(metricasCalculadas?.ticketPromedio || 0)}
-          subtitulo="Por pedido"
-          colorClase={{ bg: 'bg-purple-100 dark:bg-purple-900/30', icon: 'text-purple-600', text: 'text-purple-600' }}
-        />
+        {verMontosAgregados && (
+          <MetricaCard
+            icono={Target}
+            titulo="Ticket Promedio"
+            valor={formatPrecio(metricasCalculadas?.ticketPromedio || 0)}
+            subtitulo="Por pedido"
+            colorClase={{ bg: 'bg-purple-100 dark:bg-purple-900/30', icon: 'text-purple-600', text: 'text-purple-600' }}
+          />
+        )}
         <MetricaCard
           icono={Users}
           titulo="Clientes"
@@ -434,12 +453,15 @@ export default function VistaDashboard({
       {/* Gráficos */}
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
         {/* Ventas últimos 7 días */}
+        {verVentasSemanales && (
         <div className="bg-white dark:bg-gray-800 rounded-xl shadow-lg p-6">
           <div className="flex items-center justify-between mb-4">
             <h3 className="font-semibold text-gray-800 dark:text-white">Ventas últimos 7 días</h3>
-            <span className="text-sm text-gray-500 dark:text-gray-400">
-              Total: {formatPrecio(metricas.ventasPorDia.reduce((sum, d) => sum + d.ventas, 0))}
-            </span>
+            {verMontosAgregados && (
+              <span className="text-sm text-gray-500 dark:text-gray-400">
+                Total: {formatPrecio(metricas.ventasPorDia.reduce((sum, d) => sum + d.ventas, 0))}
+              </span>
+            )}
           </div>
           <div className="space-y-3">
             {metricas.ventasPorDia.map((d, i) => {
@@ -456,8 +478,10 @@ export default function VistaDashboard({
             })}
           </div>
         </div>
+        )}
 
         {/* Top 5 productos */}
+        {verTopProductos && (
         <div className="bg-white dark:bg-gray-800 rounded-xl shadow-lg p-6">
           <h3 className="font-semibold text-gray-800 dark:text-white mb-4">
             Top 5 Productos
@@ -506,10 +530,11 @@ export default function VistaDashboard({
             })}
           </div>
         </div>
+        )}
       </div>
 
       {/* Tasa de entrega */}
-      {metricasCalculadas && (
+      {metricasCalculadas && verEstadoPedidos && (
         <div className="bg-white dark:bg-gray-800 rounded-xl shadow-lg p-6">
           <h3 className="font-semibold text-gray-800 dark:text-white mb-4">Tasa de Entrega</h3>
           <div className="flex items-center space-x-4">

--- a/src/contexts/AppHandlersContext.tsx
+++ b/src/contexts/AppHandlersContext.tsx
@@ -102,6 +102,7 @@ export function useClienteHandlersContext() {
     handleVerFichaCliente: handlers.handleVerFichaCliente,
     handleAbrirRegistrarPago: handlers.handleAbrirRegistrarPago,
     handleRegistrarPago: handlers.handleRegistrarPago,
+    handleRegistrarPagoFIFO: handlers.handleRegistrarPagoFIFO,
     handleGenerarReciboPago: handlers.handleGenerarReciboPago
   }
 }

--- a/src/contexts/AuthDataContext.tsx
+++ b/src/contexts/AuthDataContext.tsx
@@ -17,6 +17,8 @@ export interface AuthDataContextValue {
   authReady: boolean
   isAdmin: boolean
   isPreventista: boolean
+  isPreventistaTaco: boolean
+  isAnyPreventista: boolean
   isTransportista: boolean
   isEncargado: boolean
   isAdminOrEncargado: boolean
@@ -70,8 +72,8 @@ export function useAuthData(): AuthDataContextValue {
  */
 // eslint-disable-next-line react-refresh/only-export-components
 export function useUserPermissions() {
-  const { user, perfil, isAdmin, isPreventista, isTransportista, isEncargado, isAdminOrEncargado } = useAuthData()
-  return { user, perfil, isAdmin, isPreventista, isTransportista, isEncargado, isAdminOrEncargado }
+  const { user, perfil, isAdmin, isPreventista, isPreventistaTaco, isAnyPreventista, isTransportista, isEncargado, isAdminOrEncargado } = useAuthData()
+  return { user, perfil, isAdmin, isPreventista, isPreventistaTaco, isAnyPreventista, isTransportista, isEncargado, isAdminOrEncargado }
 }
 
 export default AuthDataContext

--- a/src/hooks/handlers/useClienteHandlers.ts
+++ b/src/hooks/handlers/useClienteHandlers.ts
@@ -12,7 +12,9 @@ import type {
   ClienteFormInput,
   PagoFormInput,
   PagoDBWithUsuario,
-  ResumenCuenta
+  ResumenCuenta,
+  RegistrarPagoFifoInput,
+  RegistrarPagoFifoResult
 } from '../../types'
 import type { ModalControl, ConfirmModal, NotifyService } from './types'
 
@@ -55,6 +57,7 @@ export interface UseClienteHandlersProps {
   actualizarCliente: (id: string, cliente: Partial<ClienteFormInput>) => Promise<ClienteDB>;
   eliminarCliente: (id: string) => Promise<void>;
   registrarPago: (pago: PagoFormInput) => Promise<PagoDBWithUsuario>;
+  registrarPagoFIFO: (input: RegistrarPagoFifoInput) => Promise<RegistrarPagoFifoResult>;
   obtenerResumenCuenta: (clienteId: string) => Promise<ResumenCuenta | null>;
   modales: ClienteModales;
   setGuardando: (guardando: boolean) => void;
@@ -76,6 +79,7 @@ export interface UseClienteHandlersReturn {
   handleVerFichaCliente: (cliente: ClienteDB) => Promise<void>;
   handleAbrirRegistrarPago: (cliente: ClienteDB) => Promise<void>;
   handleRegistrarPago: (datosPago: DatosPagoInput) => Promise<PagoDBWithUsuario>;
+  handleRegistrarPagoFIFO: (input: RegistrarPagoFifoInput) => Promise<RegistrarPagoFifoResult>;
   handleGenerarReciboPago: (pago: PagoDBWithUsuario, cliente: ClienteDB) => void;
 }
 
@@ -84,6 +88,7 @@ export function useClienteHandlers({
   actualizarCliente,
   eliminarCliente,
   registrarPago,
+  registrarPagoFIFO,
   obtenerResumenCuenta,
   modales,
   setGuardando,
@@ -165,6 +170,24 @@ export function useClienteHandlers({
     }
   }, [registrarPago, user, notify])
 
+  const handleRegistrarPagoFIFO = useCallback(async (input: RegistrarPagoFifoInput): Promise<RegistrarPagoFifoResult> => {
+    try {
+      const result = await registrarPagoFIFO(input)
+      if (result.sobrante > 0) {
+        notify.success(
+          `Pago registrado. $${result.sobrante.toLocaleString('es-AR')} quedó como saldo a favor.`
+        )
+      } else {
+        notify.success('Pago registrado y aplicado a pedidos pendientes')
+      }
+      return result
+    } catch (e) {
+      const error = e as Error
+      notify.error('Error al registrar pago: ' + error.message)
+      throw e
+    }
+  }, [registrarPagoFIFO, notify])
+
   const handleGenerarReciboPago = useCallback((pago: PagoDBWithUsuario, cliente: ClienteDB): void => {
     try {
       generarReciboPago(pago, cliente)
@@ -181,6 +204,7 @@ export function useClienteHandlers({
     handleVerFichaCliente,
     handleAbrirRegistrarPago,
     handleRegistrarPago,
+    handleRegistrarPagoFIFO,
     handleGenerarReciboPago
   }
 }

--- a/src/hooks/handlers/usePedidoHandlers.ts
+++ b/src/hooks/handlers/usePedidoHandlers.ts
@@ -138,6 +138,7 @@ export interface HistorialCambio {
 
 export interface UsePedidoHandlersProps {
   productos: ProductoDB[];
+  clientes?: ClienteDB[];
   crearPedido: (
     clienteId: number,
     items: NuevoPedidoItem[],
@@ -233,6 +234,7 @@ export interface UsePedidoHandlersReturn {
 
 export function usePedidoHandlers({
   productos,
+  clientes,
   crearPedido,
   cambiarEstado,
   asignarTransportista,
@@ -277,6 +279,7 @@ export function usePedidoHandlers({
   // Esto evita recrear los callbacks cuando estos valores cambian
   // ==========================================================================
   const productosRef = useLatestRef(productos)
+  const clientesRef = useLatestRef(clientes ?? [])
   const nuevoPedidoRef = useLatestRef(nuevoPedido)
   const pedidoAsignandoRef = useLatestRef(pedidoAsignando)
   const pedidoEditandoRef = useLatestRef(pedidoEditando)
@@ -414,6 +417,22 @@ export function usePedidoHandlers({
       }
     }
 
+    // Aplicar descuento porcentual del cliente. Se aplica DESPUES de precio
+    // mayorista/promo para que el descuento se calcule sobre el precio final
+    // por linea. No tocamos lineas con precioOverride (admin lo fijo manual)
+    // ni items con precio 0 (bonificaciones se agregan despues).
+    const clienteSeleccionado = clientesRef.current.find(c => String(c.id) === String(nuevoPedido.clienteId))
+    const dtoPct = clienteSeleccionado?.descuento_porcentaje ?? 0
+    if (dtoPct > 0) {
+      const factor = 1 - dtoPct / 100
+      itemsFinales = itemsFinales.map(item => {
+        if (item.precioOverride) return item
+        if (!item.precioUnitario || item.precioUnitario <= 0) return item
+        const precioConDto = Math.round(item.precioUnitario * factor * 100) / 100
+        return { ...item, precioUnitario: precioConDto }
+      })
+    }
+
     // Agregar items de bonificación
     const itemsBonificacion = promoResolucion.bonificaciones.map(b => ({
       productoId: b.productoId,
@@ -516,7 +535,7 @@ export function usePedidoHandlers({
       notify.error('Error al crear pedido: ' + error.message)
     }
     setGuardando(false)
-  }, [nuevoPedidoRef, userRef, isOnlineRef, pricingMapRef, promoMapRef, productosRef, validarStock, guardarPedidoOffline, resetNuevoPedido, modales.pedido, crearPedido, descontarStock, registrarPago, refetchProductos, refetchMetricas, notify, setGuardando])
+  }, [nuevoPedidoRef, userRef, isOnlineRef, pricingMapRef, promoMapRef, productosRef, clientesRef, validarStock, guardarPedidoOffline, resetNuevoPedido, modales.pedido, crearPedido, descontarStock, registrarPago, refetchProductos, refetchMetricas, notify, setGuardando])
 
   // State change handlers
   const handleMarcarEntregado = useCallback((pedido: PedidoDB): void => {

--- a/src/hooks/queries/useClientesQuery.ts
+++ b/src/hooks/queries/useClientesQuery.ts
@@ -114,6 +114,7 @@ interface ClienteCreateInput {
   longitud?: number | null
   limite_credito?: number
   dias_credito?: number
+  descuento_porcentaje?: number
   contacto?: string
   horarios_atencion?: string
   rubro?: string
@@ -168,6 +169,7 @@ async function createCliente(cliente: ClienteCreateInput, sucursalId: number | n
       longitud: clienteFields.longitud || null,
       limite_credito: clienteFields.limite_credito || 0,
       dias_credito: clienteFields.dias_credito || 30,
+      descuento_porcentaje: clienteFields.descuento_porcentaje ?? 0,
       contacto: clienteFields.contacto || null,
       horarios_atencion: clienteFields.horarios_atencion || null,
       rubro: clienteFields.rubro || null,

--- a/src/hooks/supabase/useAuth.tsx
+++ b/src/hooks/supabase/useAuth.tsx
@@ -51,6 +51,8 @@ export interface AuthContextValue {
   logout: () => Promise<void>;
   isAdmin: boolean;
   isPreventista: boolean;
+  isPreventistaTaco: boolean;
+  isAnyPreventista: boolean;
   isTransportista: boolean;
   isEncargado: boolean;
   isAdminOrEncargado: boolean;
@@ -477,6 +479,8 @@ export function AuthProvider({ children }: AuthProviderProps) {
     logout,
     isAdmin: perfil?.rol === 'admin',
     isPreventista: perfil?.rol === 'preventista',
+    isPreventistaTaco: perfil?.rol === 'preventista_taco',
+    isAnyPreventista: perfil?.rol === 'preventista' || perfil?.rol === 'preventista_taco',
     isTransportista: perfil?.rol === 'transportista',
     isEncargado: perfil?.rol === 'encargado',
     isAdminOrEncargado: perfil?.rol === 'admin' || perfil?.rol === 'encargado',

--- a/src/hooks/supabase/useClientes.ts
+++ b/src/hooks/supabase/useClientes.ts
@@ -54,7 +54,8 @@ export function useClientes(): UseClientesReturn {
     rubro: cliente.rubro || null,
     notas: cliente.notas || null,
     limite_credito: cliente.limiteCredito ? parseFloat(String(cliente.limiteCredito)) : 0,
-    dias_credito: cliente.diasCredito ? parseInt(String(cliente.diasCredito)) : 30
+    dias_credito: cliente.diasCredito ? parseInt(String(cliente.diasCredito)) : 30,
+    descuento_porcentaje: cliente.descuentoPorcentaje != null ? parseFloat(String(cliente.descuentoPorcentaje)) : 0
   })
 
   const agregarCliente = useCallback(async (cliente: ClienteFormInput): Promise<ClienteDB> => {
@@ -101,6 +102,9 @@ export function useClientes(): UseClientesReturn {
     }
     if (cliente.diasCredito !== undefined) {
       updateData.dias_credito = parseInt(String(cliente.diasCredito)) || 30
+    }
+    if (cliente.descuentoPorcentaje !== undefined) {
+      updateData.descuento_porcentaje = parseFloat(String(cliente.descuentoPorcentaje)) || 0
     }
 
     const data = await clienteService.update(id, updateData) as unknown as ClienteDB

--- a/src/hooks/supabase/usePagos.ts
+++ b/src/hooks/supabase/usePagos.ts
@@ -5,6 +5,9 @@ import type {
   PagoDBWithUsuario,
   PagoFormInput,
   RegistrarPagoBatchInput,
+  RegistrarPagoFifoInput,
+  RegistrarPagoFifoResult,
+  PagoFifoAplicacion,
   ResumenCuenta,
   UsePagosReturnExtended,
   ClienteDB,
@@ -127,6 +130,49 @@ export function usePagos(): UsePagosReturnExtended {
     }
   }
 
+  /**
+   * Registra un pago de cliente y lo distribuye automaticamente sobre los
+   * pedidos mas antiguos con saldo pendiente (FIFO). Sobrante queda como
+   * saldo a favor (fila en pagos con pedido_id NULL).
+   *
+   * Solo admin o encargado (validado server-side en la RPC).
+   */
+  const registrarPagoFIFO = async (
+    input: RegistrarPagoFifoInput
+  ): Promise<RegistrarPagoFifoResult> => {
+    try {
+      if (currentSucursalId == null) {
+        throw new Error('No hay sucursal activa. Recargá la página e intentá de nuevo.')
+      }
+      const { data, error } = await supabase.rpc('registrar_pago_cliente_fifo', {
+        p_cliente_id: input.clienteId,
+        p_monto: input.monto,
+        p_forma_pago: input.formaPago,
+        p_fecha: input.fecha ?? null,
+        p_referencia: input.referencia ?? null,
+        p_notas: input.notas ?? null,
+      })
+      if (error) throw error
+
+      const raw = (data ?? {}) as {
+        pago_ids?: number[]
+        sobrante?: number
+        monto_total?: number
+        aplicaciones?: PagoFifoAplicacion[]
+      }
+
+      return {
+        pagoIds: raw.pago_ids ?? [],
+        sobrante: Number(raw.sobrante ?? 0),
+        montoTotal: Number(raw.monto_total ?? input.monto),
+        aplicaciones: raw.aplicaciones ?? [],
+      }
+    } catch (error) {
+      notifyError('Error al registrar pago: ' + (error as Error).message)
+      throw error
+    }
+  }
+
   const eliminarPago = async (pagoId: string): Promise<void> => {
     try {
       const { error } = await supabase.from('pagos').delete().eq('id', pagoId)
@@ -194,6 +240,7 @@ export function usePagos(): UsePagosReturnExtended {
     fetchPagosPedido,
     registrarPago,
     registrarPagosBatch,
+    registrarPagoFIFO,
     eliminarPago,
     obtenerResumenCuenta,
   }

--- a/src/hooks/useAppHandlers.ts
+++ b/src/hooks/useAppHandlers.ts
@@ -185,6 +185,7 @@ export interface UseAppHandlersParams {
 
   // Funciones Pagos
   registrarPago: (...args: any[]) => Promise<any>;
+  registrarPagoFIFO: (...args: any[]) => Promise<any>;
   obtenerResumenCuenta: (clienteId: string) => Promise<ResumenCuenta | null>;
 
   // Funciones Mermas
@@ -262,6 +263,7 @@ export interface UseAppHandlersReturn {
   handleVerFichaCliente: (cliente: ClienteDB) => Promise<void>;
   handleAbrirRegistrarPago: (cliente: ClienteDB, saldo?: number) => Promise<void>;
   handleRegistrarPago: (pago: { clienteId: string; monto: number; formaPago: string; notas?: string }) => Promise<void>;
+  handleRegistrarPagoFIFO: (input: { clienteId: string; monto: number; formaPago: string; fecha?: string; referencia?: string; notas?: string }) => Promise<unknown>;
   handleGenerarReciboPago: (pago: { clienteId: string; monto: number; fecha: string }) => void;
 
   // Productos (from useProductoHandlers)
@@ -346,6 +348,7 @@ export function useAppHandlers({
   fetchHistorialPedido,
   actualizarUsuario,
   registrarPago,
+  registrarPagoFIFO,
   obtenerResumenCuenta,
   registrarMerma,
   registrarCompra,
@@ -435,6 +438,7 @@ export function useAppHandlers({
     actualizarCliente,
     eliminarCliente,
     registrarPago,
+    registrarPagoFIFO: registrarPagoFIFO as UseClienteHandlersProps['registrarPagoFIFO'],
     obtenerResumenCuenta: obtenerResumenCuenta as UseClienteHandlersProps['obtenerResumenCuenta'],
     modales: clienteModales,
     setGuardando,

--- a/src/lib/permisos.ts
+++ b/src/lib/permisos.ts
@@ -24,7 +24,7 @@ export function puedeAnularPago(rol: RolUsuario | null | undefined): boolean {
 }
 
 export function puedeAccederDashboard(rol: RolUsuario | null | undefined): boolean {
-  return rol === 'admin' || rol === 'preventista'
+  return rol === 'admin' || rol === 'preventista' || rol === 'preventista_taco'
 }
 
 export function puedeAccederReportes(rol: RolUsuario | null | undefined): boolean {
@@ -56,11 +56,49 @@ export function puedeAccederGeolocalizacion(rol: RolUsuario | null | undefined):
 }
 
 export function puedeCrearCliente(rol: RolUsuario | null | undefined): boolean {
-  return rol === 'admin' || rol === 'preventista' || rol === 'encargado'
+  return rol === 'admin' || rol === 'preventista' || rol === 'preventista_taco' || rol === 'encargado'
 }
 
 export function puedeCrearPedido(rol: RolUsuario | null | undefined): boolean {
-  return rol === 'admin' || rol === 'preventista' || rol === 'encargado'
+  return rol === 'admin' || rol === 'preventista' || rol === 'preventista_taco' || rol === 'encargado'
+}
+
+/**
+ * Si el rol puede ver montos comerciales (ventas, totales, ticket promedio, saldos
+ * de cuenta corriente, historicos de compra). Falso para preventista_taco.
+ */
+export function puedeVerMontosYVentas(rol: RolUsuario | null | undefined): boolean {
+  return rol !== 'preventista_taco'
+}
+
+/** Si el rol puede ver el saldo de cuenta corriente en la ficha de cliente. */
+export function puedeVerSaldoCliente(rol: RolUsuario | null | undefined): boolean {
+  return rol !== 'preventista_taco'
+}
+
+/** Si el rol puede ver el historial de ventas/compras de un cliente. */
+export function puedeVerHistorialVentasCliente(rol: RolUsuario | null | undefined): boolean {
+  return rol !== 'preventista_taco'
+}
+
+/** Si el rol puede ver la facturacion total en el dashboard. Solo admin. */
+export function puedeVerFacturacionTotal(rol: RolUsuario | null | undefined): boolean {
+  return rol === 'admin'
+}
+
+/** Si el rol puede ver agregados comerciales (top productos por venta, ticket promedio). Solo admin. */
+export function puedeVerAgregadosDashboard(rol: RolUsuario | null | undefined): boolean {
+  return rol === 'admin'
+}
+
+/** Si el rol puede registrar pagos desde la ficha de cliente (admin o encargado). */
+export function puedeRegistrarPagoCliente(rol: RolUsuario | null | undefined): boolean {
+  return rol === 'admin' || rol === 'encargado'
+}
+
+/** Si el rol puede editar el descuento porcentual precargado del cliente. */
+export function puedeEditarDescuentoCliente(rol: RolUsuario | null | undefined): boolean {
+  return rol === 'admin'
 }
 
 export type PedidoStatKey =
@@ -75,6 +113,7 @@ export function mostrarMontosEnStats(
   rol: RolUsuario | null | undefined,
   key: PedidoStatKey,
 ): boolean {
+  if (rol === 'preventista_taco') return false
   if (rol === 'encargado') return key === 'impagos'
   return true
 }

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -373,7 +373,7 @@ export const usuarioSchema = z.object({
     .email({ message: 'Email inválido' })
     .min(1, { message: 'El email es obligatorio' }),
 
-  rol: z.enum(['admin', 'preventista', 'transportista', 'deposito', 'encargado'], {
+  rol: z.enum(['admin', 'preventista', 'preventista_taco', 'transportista', 'deposito', 'encargado'], {
     error: 'Rol invalido'
   }),
 
@@ -386,7 +386,7 @@ export const usuarioSchema = z.object({
 export type UsuarioFormData = z.infer<typeof usuarioSchema>
 
 /** Valid user roles */
-export type RolUsuario = 'admin' | 'preventista' | 'transportista' | 'deposito' | 'encargado'
+export type RolUsuario = 'admin' | 'preventista' | 'preventista_taco' | 'transportista' | 'deposito' | 'encargado'
 
 // ============================================
 // SCHEMAS DE PROVEEDOR
@@ -567,7 +567,8 @@ export const modalClienteSchema = z.object({
   rubro: z.string().optional(),
   notas: z.string().optional(),
   limiteCredito: z.coerce.number().nonnegative().default(0),
-  diasCredito: z.coerce.number().int().nonnegative().default(30)
+  diasCredito: z.coerce.number().int().nonnegative().default(30),
+  descuentoPorcentaje: z.coerce.number().min(0).max(100).default(0)
 })
 
 /** Inferred type for ModalCliente schema */

--- a/src/types/hooks.ts
+++ b/src/types/hooks.ts
@@ -29,6 +29,7 @@ export interface ClienteDB {
   limite_credito?: number;
   dias_credito?: number;
   saldo_cuenta?: number;
+  descuento_porcentaje?: number;
   preventista_id?: string | null;
   /**
    * IDs de preventistas asignados (N-a-N via tabla cliente_preventistas).
@@ -87,7 +88,7 @@ export interface PerfilDB {
   id: string;
   nombre: string;
   email: string;
-  rol?: 'admin' | 'preventista' | 'transportista' | 'deposito' | 'encargado';
+  rol?: 'admin' | 'preventista' | 'preventista_taco' | 'transportista' | 'deposito' | 'encargado';
   zona?: string;
   activo?: boolean;
 }
@@ -228,6 +229,7 @@ export interface ClienteFormInput {
   notas?: string;
   limiteCredito?: string | number;
   diasCredito?: string | number;
+  descuentoPorcentaje?: string | number;
   preventistaId?: string | null;
   preventista_ids?: string[];
 }
@@ -682,6 +684,30 @@ export interface RegistrarPagoBatchInput {
   usuarioId?: string | null;
 }
 
+export interface PagoFifoAplicacion {
+  pago_id: number;
+  pedido_id: number | null;
+  pedido_fecha?: string;
+  monto: number;
+  saldo_a_favor?: boolean;
+}
+
+export interface RegistrarPagoFifoInput {
+  clienteId: string;
+  monto: number;
+  formaPago: string;
+  fecha?: string;
+  referencia?: string;
+  notas?: string;
+}
+
+export interface RegistrarPagoFifoResult {
+  pagoIds: number[];
+  sobrante: number;
+  montoTotal: number;
+  aplicaciones: PagoFifoAplicacion[];
+}
+
 export interface UsePagosReturnExtended {
   pagos: PagoDBWithUsuario[];
   loading: boolean;
@@ -689,6 +715,7 @@ export interface UsePagosReturnExtended {
   fetchPagosPedido: (pedidoId: string) => Promise<PagoDBWithUsuario[]>;
   registrarPago: (pago: PagoFormInput) => Promise<PagoDBWithUsuario>;
   registrarPagosBatch: (input: RegistrarPagoBatchInput) => Promise<PagoDBWithUsuario[]>;
+  registrarPagoFIFO: (input: RegistrarPagoFifoInput) => Promise<RegistrarPagoFifoResult>;
   eliminarPago: (pagoId: string) => Promise<void>;
   obtenerResumenCuenta: (clienteId: string) => Promise<ResumenCuenta | null>;
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -162,7 +162,7 @@ export interface PedidoInput {
 // USUARIO
 // =============================================================================
 
-export type RolUsuario = 'admin' | 'preventista' | 'transportista' | 'deposito' | 'encargado';
+export type RolUsuario = 'admin' | 'preventista' | 'preventista_taco' | 'transportista' | 'deposito' | 'encargado';
 
 export interface Usuario extends BaseEntity {
   email: string;


### PR DESCRIPTION
## Resumen

Tres cambios coordinados sobre roles, dashboard y cuenta corriente:

### 1. Nuevo rol `preventista_taco`
- Migracion **050** extiende `perfiles_rol_check` con el nuevo valor.
- Tipos/schemas/permisos actualizados (`RolUsuario`, `usuarioSchema`, `permisos.ts`, `useAuth`).
- Opera identico a `preventista` pero la UI le oculta toda informacion comercial: ventas, saldos, totales, historial de compras. En dashboard solo ve items.

### 2. Encargado: dashboard sin agregados
- Encargado ya no ve facturacion total ni metricas agregadas.
- Solo ve estados de pedido y "Ventas ultimos 7 dias".
- Implementado en `VistaDashboard` + helpers nuevos en `permisos.ts`.

### 3. Descuento por cliente + pagos FIFO desde ficha
- Nueva columna `clientes.descuento_porcentaje numeric(5,2)` (migracion 050). Solo admin puede editarla en la ficha; el resto la ve read-only.
- Al armar pedido se aplica como factor sobre `precio_unitario` post promociones / precio mayorista.
- Nueva RPC `registrar_pago_cliente_fifo` (migracion **051**): recibe `(cliente_id, monto, forma_pago, fecha, referencia, notas)` y distribuye el pago sobre los pedidos pendientes mas antiguos primero. Sobrante queda como saldo a favor (`pedido_id NULL`).
- Solo `admin` o `encargado` pueden invocarla. Encargado hereda el gating de fecha/rendicion del helper `rendicion_dia_cerrada` (mig 039).
- Trigger existente (mig 035) recalcula `monto_pagado` y `estado_pago` en cascada — la `PedidoCard` muestra "Pagado: \$X de \$Y" cuando un pedido queda parcial.

## Motivacion

El encargado anoto por error un pago como `forma_pago='cuenta_corriente'`, y cuando el cliente vino con el pago real efectivo no tenia donde imputarlo. FIFO desde ficha + saldo a favor explicito resuelve este caso sin reabrir pedidos manualmente.

## Migraciones aplicadas en prod

- `20260515` 050_preventista_taco_y_descuento_cliente — aplicada
- `20260515` 051_registrar_pago_cliente_fifo — aplicada

## Cambios de UI clave

- `ModalCliente`: campo descuento visible/editable segun rol.
- `ModalFichaCliente`: botón "Registrar Pago" visible para admin/encargado.
- `ModalRegistrarPago`: toggle FIFO on por defecto si se invoca desde ficha; muestra desglose por pedido aplicado y advierte cuando hay saldo a favor (antes bloqueaba).
- `PedidoCard`: badge de pago parcial con monto pagado / total.

## Test plan

- [ ] Crear usuario con rol `preventista_taco` → login → confirmar que dashboard solo muestra items y que en pedidos no aparecen montos / totales / forma de pago.
- [ ] Login encargado → dashboard sin "Ventas del periodo", "Ticket promedio", "Top productos"; solo estados + barra 7 dias.
- [ ] Admin: ficha cliente → setear descuento 10% → armar pedido → cada `precio_unitario` debe quedar al 90% del precio resuelto.
- [ ] Encargado: desde ficha de cliente con saldo, registrar pago > saldo total → confirmar que se imputa al pedido mas viejo y el sobrante queda como saldo a favor (fila en `pagos` con `pedido_id NULL` y nota `[saldo a favor]`).
- [ ] Tarjeta de pedido refleja `Pagado: \$X de \$Y` en pedidos con pago parcial.
- [ ] Encargado con `fecha <> hoy` o `rendicion_dia_cerrada` → RPC rechaza con 42501.

🤖 Generated with [Claude Code](https://claude.com/claude-code)