### PR TITLE
Mobile UX: bottom sheet de filtros y toolbar reorganizada

### DIFF
--- a/src/components/pedidos/ModalFiltrosPedidos.tsx
+++ b/src/components/pedidos/ModalFiltrosPedidos.tsx
@@ -1,0 +1,314 @@
+/**
+ * ModalFiltrosPedidos
+ *
+ * Bottom sheet con los filtros secundarios del panel de Pedidos. Pensado
+ * para mobile (en desktop los filtros viven inline en PedidoFilters).
+ *
+ * Secciones:
+ *  - Estado del pedido
+ *  - Pago (admin)
+ *  - Transportista (admin)
+ *  - Usuario que cargó (admin)
+ *  - Salvedades (admin)
+ *  - Entrega programada (admin) — segmented Hoy/Mañana + date input
+ *  - Ver cancelados (toggle)
+ *
+ * Comportamiento "live": cada cambio aplica inmediatamente al estado de
+ * filtros (via onFiltrosChange). El footer "Listo" cierra el sheet;
+ * "Limpiar" resetea los filtros del sheet a default. Búsqueda y rango
+ * de fechaDesde/fechaHasta NO se tocan acá (viven afuera del modal).
+ */
+import React, { type ChangeEvent } from 'react';
+import { Truck, User, X } from 'lucide-react';
+import BottomSheet from '../ui/BottomSheet';
+import { fechaLocalISO } from '../../utils/formatters';
+import { cn } from '../../lib/utils';
+import type { Usuario } from '../../types';
+
+interface FiltrosPedido {
+  estado: string;
+  estadoPago?: string;
+  transportistaId?: string;
+  usuarioId?: string;
+  fechaDesde?: string | null;
+  fechaHasta?: string | null;
+  conSalvedad?: 'todos' | 'con_salvedad' | 'sin_salvedad';
+  verCancelados?: boolean;
+  fechaEntregaProgramada?: string | null;
+}
+
+interface FiltrosChange {
+  estado?: string;
+  estadoPago?: string;
+  transportistaId?: string;
+  usuarioId?: string;
+  fechaDesde?: string | null;
+  fechaHasta?: string | null;
+  conSalvedad?: 'todos' | 'con_salvedad' | 'sin_salvedad';
+  verCancelados?: boolean;
+  fechaEntregaProgramada?: string | null;
+}
+
+export interface ModalFiltrosPedidosProps {
+  open: boolean;
+  filtros: FiltrosPedido;
+  transportistas?: Usuario[];
+  usuarios?: Usuario[];
+  isAdmin: boolean;
+  activosCount: number;
+  onFiltrosChange: (f: FiltrosChange) => void;
+  onClose: () => void;
+}
+
+// =============================================================================
+// HELPERS LOCALES
+// =============================================================================
+
+const SECTION_LABEL = 'text-[11px] font-semibold uppercase tracking-[0.08em] text-stone-500 dark:text-stone-400 mb-2';
+
+const SELECT_NATIVE = cn(
+  'w-full h-11 pl-3 pr-9 rounded-lg border text-sm appearance-none',
+  'bg-white dark:bg-gray-800 text-stone-800 dark:text-gray-100',
+  'border-stone-200 dark:border-gray-700',
+  'focus:outline-none focus:ring-2 focus:ring-blue-500/40 focus:border-blue-400',
+);
+
+interface SectionProps {
+  label: string;
+  children: React.ReactNode;
+}
+
+function Section({ label, children }: SectionProps) {
+  return (
+    <div className="py-3 first:pt-0 last:pb-0 border-b border-stone-100 dark:border-gray-700 last:border-b-0">
+      <p className={SECTION_LABEL}>{label}</p>
+      {children}
+    </div>
+  );
+}
+
+// =============================================================================
+// MAIN
+// =============================================================================
+
+export default function ModalFiltrosPedidos({
+  open,
+  filtros,
+  transportistas = [],
+  usuarios = [],
+  isAdmin,
+  activosCount,
+  onFiltrosChange,
+  onClose,
+}: ModalFiltrosPedidosProps): React.ReactElement {
+  const handleLimpiar = () => {
+    onFiltrosChange({
+      estado: 'todos',
+      estadoPago: 'todos',
+      transportistaId: 'todos',
+      usuarioId: 'todos',
+      conSalvedad: 'todos',
+      fechaEntregaProgramada: null,
+      verCancelados: false,
+    });
+  };
+
+  const hoy = fechaLocalISO();
+  const manana = (() => {
+    const d = new Date(hoy + 'T12:00:00');
+    d.setDate(d.getDate() + 1);
+    return fechaLocalISO(d);
+  })();
+  const entregaActiva = filtros.fechaEntregaProgramada ?? null;
+  const esHoy = entregaActiva === hoy;
+  const esManana = entregaActiva === manana;
+  const esCustomEntrega = Boolean(entregaActiva) && !esHoy && !esManana;
+
+  return (
+    <BottomSheet
+      open={open}
+      onClose={onClose}
+      title="Filtros"
+      description={activosCount > 0 ? `${activosCount} filtro${activosCount === 1 ? '' : 's'} activo${activosCount === 1 ? '' : 's'}` : 'Refiná tu búsqueda'}
+      footer={
+        <div className="flex items-center justify-between gap-3">
+          <button
+            type="button"
+            onClick={handleLimpiar}
+            disabled={activosCount === 0}
+            className="inline-flex items-center gap-1.5 h-10 px-3 rounded-lg text-sm font-medium text-stone-600 dark:text-stone-300 hover:bg-stone-100 dark:hover:bg-gray-700/50 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+          >
+            Limpiar todo
+          </button>
+          <button
+            type="button"
+            onClick={onClose}
+            className="inline-flex items-center justify-center h-11 px-6 rounded-lg text-sm font-semibold text-white bg-gradient-to-br from-blue-500 to-blue-600 shadow-warm hover:from-blue-500 hover:to-blue-700 transition-colors"
+          >
+            Listo
+          </button>
+        </div>
+      }
+    >
+      {/* Estado del pedido */}
+      <Section label="Estado del pedido">
+        <select
+          value={filtros.estado}
+          onChange={(e: ChangeEvent<HTMLSelectElement>) => onFiltrosChange({ estado: e.target.value })}
+          className={SELECT_NATIVE}
+        >
+          <option value="todos">Todos los estados</option>
+          <option value="pendiente">Pendientes</option>
+          <option value="en_preparacion">En preparación</option>
+          <option value="asignado">En camino</option>
+          <option value="entregado">Entregados</option>
+          <option value="cancelado">Cancelados</option>
+        </select>
+      </Section>
+
+      {/* Pago (admin) */}
+      {isAdmin && (
+        <Section label="Pago">
+          <select
+            value={filtros.estadoPago || 'todos'}
+            onChange={(e: ChangeEvent<HTMLSelectElement>) => onFiltrosChange({ estadoPago: e.target.value })}
+            className={SELECT_NATIVE}
+          >
+            <option value="todos">Todos los pagos</option>
+            <option value="pendiente">Pago pendiente</option>
+            <option value="parcial">Pago parcial</option>
+            <option value="pagado">Pagado</option>
+          </select>
+        </Section>
+      )}
+
+      {/* Transportista (admin) */}
+      {isAdmin && (
+        <Section label="Transportista">
+          <div className="relative">
+            <Truck className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-stone-400 pointer-events-none" aria-hidden="true" />
+            <select
+              value={filtros.transportistaId || 'todos'}
+              onChange={(e: ChangeEvent<HTMLSelectElement>) => onFiltrosChange({ transportistaId: e.target.value })}
+              className={cn(SELECT_NATIVE, 'pl-9')}
+            >
+              <option value="todos">Todos los transportistas</option>
+              <option value="sin_asignar">Sin asignar</option>
+              {transportistas.map(t => (
+                <option key={t.id} value={t.id}>{t.nombre}</option>
+              ))}
+            </select>
+          </div>
+        </Section>
+      )}
+
+      {/* Usuario (admin) */}
+      {isAdmin && (
+        <Section label="Cargado por">
+          <div className="relative">
+            <User className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-stone-400 pointer-events-none" aria-hidden="true" />
+            <select
+              value={filtros.usuarioId || 'todos'}
+              onChange={(e: ChangeEvent<HTMLSelectElement>) => onFiltrosChange({ usuarioId: e.target.value })}
+              className={cn(SELECT_NATIVE, 'pl-9')}
+            >
+              <option value="todos">Todos los usuarios</option>
+              {usuarios.map(u => (
+                <option key={u.id} value={u.id}>{u.nombre}</option>
+              ))}
+            </select>
+          </div>
+        </Section>
+      )}
+
+      {/* Salvedades (admin) */}
+      {isAdmin && (
+        <Section label="Entregas con salvedad">
+          <select
+            value={filtros.conSalvedad || 'todos'}
+            onChange={(e: ChangeEvent<HTMLSelectElement>) => onFiltrosChange({ conSalvedad: e.target.value as 'todos' | 'con_salvedad' | 'sin_salvedad' })}
+            className={SELECT_NATIVE}
+          >
+            <option value="todos">Todas las entregas</option>
+            <option value="con_salvedad">Con salvedad</option>
+            <option value="sin_salvedad">Sin salvedad</option>
+          </select>
+        </Section>
+      )}
+
+      {/* Entrega programada (admin) */}
+      {isAdmin && (
+        <Section label="Entrega programada">
+          <div className="space-y-2">
+            <div className="inline-flex items-center w-full p-1 rounded-lg border border-stone-200 dark:border-gray-700 bg-stone-100 dark:bg-gray-800/70">
+              <button
+                type="button"
+                onClick={() => onFiltrosChange({ fechaEntregaProgramada: esHoy ? null : hoy })}
+                className={cn(
+                  'flex-1 h-9 rounded-md text-sm font-medium transition-colors',
+                  esHoy
+                    ? 'bg-white dark:bg-gray-700 text-blue-700 dark:text-blue-200 shadow-warm'
+                    : 'text-stone-600 dark:text-stone-300',
+                )}
+              >
+                Hoy
+              </button>
+              <button
+                type="button"
+                onClick={() => onFiltrosChange({ fechaEntregaProgramada: esManana ? null : manana })}
+                className={cn(
+                  'flex-1 h-9 rounded-md text-sm font-medium transition-colors',
+                  esManana
+                    ? 'bg-white dark:bg-gray-700 text-blue-700 dark:text-blue-200 shadow-warm'
+                    : 'text-stone-600 dark:text-stone-300',
+                )}
+              >
+                Mañana
+              </button>
+            </div>
+            <div className="flex items-center gap-2">
+              <input
+                type="date"
+                value={entregaActiva || ''}
+                onChange={(e) => onFiltrosChange({ fechaEntregaProgramada: e.target.value || null })}
+                className={cn(
+                  'flex-1 h-10 px-3 rounded-lg border text-sm',
+                  'bg-white dark:bg-gray-800 text-stone-800 dark:text-gray-100',
+                  esCustomEntrega
+                    ? 'bg-blue-50 dark:bg-blue-900/20 border-blue-300 dark:border-blue-700'
+                    : 'border-stone-200 dark:border-gray-700',
+                  'focus:outline-none focus:ring-2 focus:ring-blue-500/40 focus:border-blue-400',
+                )}
+              />
+              {entregaActiva && (
+                <button
+                  type="button"
+                  onClick={() => onFiltrosChange({ fechaEntregaProgramada: null })}
+                  className="inline-flex items-center justify-center w-10 h-10 rounded-lg text-stone-500 hover:text-rose-600 hover:bg-rose-50 dark:hover:bg-rose-900/15 transition-colors"
+                  aria-label="Limpiar filtro de entrega"
+                >
+                  <X className="w-4 h-4" />
+                </button>
+              )}
+            </div>
+          </div>
+        </Section>
+      )}
+
+      {/* Ver cancelados */}
+      <Section label="Otros">
+        <label className="flex items-center justify-between gap-3 h-11 px-3 rounded-lg border border-stone-200 dark:border-gray-700 cursor-pointer bg-white dark:bg-gray-800">
+          <span className="text-sm text-stone-700 dark:text-gray-200">
+            Incluir cancelados
+          </span>
+          <input
+            type="checkbox"
+            checked={filtros.verCancelados || false}
+            onChange={(e: ChangeEvent<HTMLInputElement>) => onFiltrosChange({ verCancelados: e.target.checked })}
+            className="w-5 h-5 rounded border-stone-300 text-blue-600 focus:ring-blue-500"
+          />
+        </label>
+      </Section>
+    </BottomSheet>
+  );
+}

--- a/src/components/pedidos/PedidoFilters.tsx
+++ b/src/components/pedidos/PedidoFilters.tsx
@@ -1,15 +1,25 @@
 /**
- * Componente de filtros para la vista de pedidos
+ * Componente de filtros para la vista de pedidos.
  *
- * Diseño: dropdowns con un único estilo de pill (border sutil, fondo blanco).
- * Cuando un filtro tiene valor distinto al "todos" por default, su pill
- * adquiere acento azul para señalar que está activo, en lugar de usar un
- * color distinto por tipo de filtro (eso causaba el "carnaval" en mobile).
+ * Dos layouts (responsive con Tailwind, sin JS):
+ *
+ *  MOBILE (<sm):
+ *    [ 🔍 Buscar...                            ]
+ *    [ 📅 Fechas ]    [ ⚙ Filtros (N) ]
+ *    [ Chip "Filtrado: 2026-04-15 – ..." si activo ]
+ *
+ *  DESKTOP (sm+):
+ *    Dos filas inline igual que antes (sin cambios desde PR #318).
+ *
+ * Los filtros secundarios (estado, pago, transportista, usuario, salvedades,
+ * entrega) en mobile viven dentro del bottom sheet `ModalFiltrosPedidos`
+ * para no convertir esta zona en un muro de UI.
  */
-import React, { memo, ChangeEvent } from 'react';
-import { Search, Calendar, X, Truck, User } from 'lucide-react';
+import React, { memo, useState, type ChangeEvent } from 'react';
+import { Search, Calendar, X, Truck, User, SlidersHorizontal } from 'lucide-react';
 import { fechaLocalISO } from '../../utils/formatters';
 import { cn } from '../../lib/utils';
+import ModalFiltrosPedidos from './ModalFiltrosPedidos';
 import type { Usuario } from '../../types';
 
 interface FiltrosPedido {
@@ -65,6 +75,22 @@ function selectClass(activo: boolean): string {
   return cn(SELECT_BASE, activo && SELECT_ACTIVE);
 }
 
+/**
+ * Cuenta filtros activos (excluyendo búsqueda y fechaDesde/fechaHasta que
+ * viven afuera del modal). Se usa para el badge "(N)" del botón mobile.
+ */
+function contarFiltrosActivos(filtros: FiltrosPedido): number {
+  let n = 0;
+  if (filtros.estado && filtros.estado !== 'todos') n++;
+  if (filtros.estadoPago && filtros.estadoPago !== 'todos') n++;
+  if (filtros.transportistaId && filtros.transportistaId !== 'todos') n++;
+  if (filtros.usuarioId && filtros.usuarioId !== 'todos') n++;
+  if (filtros.conSalvedad && filtros.conSalvedad !== 'todos') n++;
+  if (filtros.fechaEntregaProgramada) n++;
+  if (filtros.verCancelados) n++;
+  return n;
+}
+
 // =============================================================================
 // MAIN
 // =============================================================================
@@ -77,13 +103,15 @@ function PedidoFilters({
   isAdmin,
   onBusquedaChange,
   onFiltrosChange,
-  onModalFiltroFecha
+  onModalFiltroFecha,
 }: PedidoFiltersProps): React.ReactElement {
   const fechaActiva = Boolean(filtros.fechaDesde || filtros.fechaHasta);
+  const activosCount = contarFiltrosActivos(filtros);
+  const [sheetOpen, setSheetOpen] = useState(false);
 
   return (
-    <div className="flex flex-col gap-3">
-      {/* ─── Primera fila: Busqueda + filtros principales ─── */}
+    <div className="flex flex-col gap-2.5 sm:gap-3">
+      {/* ╔══ Búsqueda (compartida mobile + desktop) ══╗ */}
       <div className="flex flex-col sm:flex-row gap-2">
         <div className="relative flex-1 min-w-0">
           <Search className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400 w-4 h-4" aria-hidden="true" />
@@ -92,7 +120,7 @@ function PedidoFilters({
             value={busqueda}
             onChange={(e: ChangeEvent<HTMLInputElement>) => onBusquedaChange(e.target.value)}
             className={cn(
-              'w-full h-9 pl-9 pr-3 rounded-lg border text-sm',
+              'w-full h-10 sm:h-9 pl-9 pr-3 rounded-lg border text-sm',
               'bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-200',
               'border-stone-200 dark:border-gray-700 placeholder:text-gray-400',
               'focus:outline-none focus:ring-2 focus:ring-blue-500/40 focus:border-blue-400',
@@ -101,48 +129,89 @@ function PedidoFilters({
             aria-label="Buscar pedidos por cliente, dirección o número de pedido"
           />
         </div>
-        <label htmlFor="filtro-estado" className="sr-only">Filtrar por estado del pedido</label>
-        <select
-          id="filtro-estado"
-          value={filtros.estado}
-          onChange={(e: ChangeEvent<HTMLSelectElement>) => onFiltrosChange({ estado: e.target.value })}
-          className={selectClass(filtros.estado !== 'todos')}
-        >
-          <option value="todos">Todos los estados</option>
-          <option value="pendiente">Pendientes</option>
-          <option value="en_preparacion">En preparación</option>
-          <option value="asignado">En camino</option>
-          <option value="entregado">Entregados</option>
-          <option value="cancelado">Cancelados</option>
-        </select>
-        <label className="inline-flex items-center gap-2 h-9 px-3 rounded-lg border border-stone-200 dark:border-gray-700 bg-white dark:bg-gray-800 cursor-pointer select-none hover:bg-gray-50 dark:hover:bg-gray-700/50">
-          <input
-            type="checkbox"
-            checked={filtros.verCancelados || false}
-            onChange={(e: ChangeEvent<HTMLInputElement>) => onFiltrosChange({ verCancelados: e.target.checked })}
-            className="w-4 h-4 rounded text-blue-600 focus:ring-blue-500"
-          />
-          <span className="text-sm text-gray-700 dark:text-gray-300 whitespace-nowrap">Ver cancelados</span>
-        </label>
+
+        {/* ─── DESKTOP: Estado + Ver cancelados + Fechas ─── */}
+        <div className="hidden sm:flex items-center gap-2">
+          <label htmlFor="filtro-estado" className="sr-only">Filtrar por estado del pedido</label>
+          <select
+            id="filtro-estado"
+            value={filtros.estado}
+            onChange={(e: ChangeEvent<HTMLSelectElement>) => onFiltrosChange({ estado: e.target.value })}
+            className={selectClass(filtros.estado !== 'todos')}
+          >
+            <option value="todos">Todos los estados</option>
+            <option value="pendiente">Pendientes</option>
+            <option value="en_preparacion">En preparación</option>
+            <option value="asignado">En camino</option>
+            <option value="entregado">Entregados</option>
+            <option value="cancelado">Cancelados</option>
+          </select>
+          <label className="inline-flex items-center gap-2 h-9 px-3 rounded-lg border border-stone-200 dark:border-gray-700 bg-white dark:bg-gray-800 cursor-pointer select-none hover:bg-gray-50 dark:hover:bg-gray-700/50">
+            <input
+              type="checkbox"
+              checked={filtros.verCancelados || false}
+              onChange={(e: ChangeEvent<HTMLInputElement>) => onFiltrosChange({ verCancelados: e.target.checked })}
+              className="w-4 h-4 rounded text-blue-600 focus:ring-blue-500"
+            />
+            <span className="text-sm text-gray-700 dark:text-gray-300 whitespace-nowrap">Ver cancelados</span>
+          </label>
+          <button
+            type="button"
+            onClick={onModalFiltroFecha}
+            aria-label="Filtrar pedidos por rango de fechas"
+            className={cn(
+              'inline-flex items-center gap-2 h-9 px-3 rounded-lg border text-sm transition-colors',
+              fechaActiva
+                ? 'bg-blue-50 dark:bg-blue-900/20 border-blue-300 dark:border-blue-700 text-blue-700 dark:text-blue-200'
+                : 'bg-white dark:bg-gray-800 border-stone-200 dark:border-gray-700 text-gray-700 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-700/50',
+            )}
+          >
+            <Calendar className="w-4 h-4" aria-hidden="true" />
+            <span>Fechas</span>
+          </button>
+        </div>
+      </div>
+
+      {/* ╔══ MOBILE: [Fechas] [Filtros (N)] en una fila ══╗ */}
+      <div className="grid grid-cols-2 gap-2 sm:hidden">
         <button
           type="button"
           onClick={onModalFiltroFecha}
           aria-label="Filtrar pedidos por rango de fechas"
           className={cn(
-            'inline-flex items-center gap-2 h-9 px-3 rounded-lg border text-sm transition-colors',
+            'inline-flex items-center justify-center gap-2 h-10 px-3 rounded-lg border text-sm font-medium transition-colors',
             fechaActiva
               ? 'bg-blue-50 dark:bg-blue-900/20 border-blue-300 dark:border-blue-700 text-blue-700 dark:text-blue-200'
-              : 'bg-white dark:bg-gray-800 border-stone-200 dark:border-gray-700 text-gray-700 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-700/50',
+              : 'bg-white dark:bg-gray-800 border-stone-200 dark:border-gray-700 text-gray-700 dark:text-gray-200',
           )}
         >
           <Calendar className="w-4 h-4" aria-hidden="true" />
           <span>Fechas</span>
         </button>
+        <button
+          type="button"
+          onClick={() => setSheetOpen(true)}
+          aria-label="Abrir filtros avanzados"
+          className={cn(
+            'inline-flex items-center justify-center gap-2 h-10 px-3 rounded-lg border text-sm font-medium transition-colors',
+            activosCount > 0
+              ? 'bg-blue-50 dark:bg-blue-900/20 border-blue-300 dark:border-blue-700 text-blue-700 dark:text-blue-200'
+              : 'bg-white dark:bg-gray-800 border-stone-200 dark:border-gray-700 text-gray-700 dark:text-gray-200',
+          )}
+        >
+          <SlidersHorizontal className="w-4 h-4" aria-hidden="true" />
+          <span>Filtros</span>
+          {activosCount > 0 && (
+            <span className="inline-flex items-center justify-center min-w-[1.25rem] h-5 px-1 rounded-full bg-blue-600 text-white text-[11px] font-bold tabular-nums">
+              {activosCount}
+            </span>
+          )}
+        </button>
       </div>
 
-      {/* ─── Segunda fila: Filtros adicionales para admin ─── */}
+      {/* ─── DESKTOP: Segunda fila de filtros admin ─── */}
       {isAdmin && (
-        <div className="flex flex-wrap items-center gap-2">
+        <div className="hidden sm:flex flex-wrap items-center gap-2">
           <label htmlFor="filtro-pago" className="sr-only">Filtrar por estado de pago</label>
           <select
             id="filtro-pago"
@@ -206,7 +275,7 @@ function PedidoFilters({
         </div>
       )}
 
-      {/* ─── Chip de filtro de fechas activo ─── */}
+      {/* ╔══ Chip de filtro de fechas activo (común) ══╗ */}
       {fechaActiva && (
         <div
           className="inline-flex items-center gap-2 self-start px-3 py-1.5 rounded-full bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-800 text-sm text-blue-700 dark:text-blue-200"
@@ -227,12 +296,25 @@ function PedidoFilters({
           </button>
         </div>
       )}
+
+      {/* Bottom sheet de filtros (solo mobile lo dispara). El componente
+          sigue montado pero su visibilidad la controla `sheetOpen`. */}
+      <ModalFiltrosPedidos
+        open={sheetOpen}
+        filtros={filtros}
+        transportistas={transportistas}
+        usuarios={usuarios}
+        isAdmin={isAdmin}
+        activosCount={activosCount}
+        onFiltrosChange={onFiltrosChange}
+        onClose={() => setSheetOpen(false)}
+      />
     </div>
   );
 }
 
 // =============================================================================
-// SEGMENTED CONTROL DE ENTREGA (Hoy / Mañana + date input)
+// SEGMENTED CONTROL DE ENTREGA (Hoy / Mañana + date input) — solo desktop
 // =============================================================================
 
 interface EntregaSegmentedControlProps {

--- a/src/components/pedidos/PedidoToolbar.tsx
+++ b/src/components/pedidos/PedidoToolbar.tsx
@@ -112,7 +112,7 @@ function ToolbarDropdown({
   label,
   mobileLabel,
   children,
-  menuClassName = 'w-64',
+  menuClassName = 'w-[min(16rem,calc(100vw-2rem))]',
 }: ToolbarDropdownProps) {
   return (
     // modal={false} evita que Radix bloquee el scroll del body al abrir,
@@ -140,7 +140,7 @@ function ToolbarDropdown({
  * Botón primario verde para "Nuevo pedido". Único color de fondo saturado
  * en toda la toolbar.
  */
-function PrimaryNewButton({ onClick }: { onClick: () => void }) {
+function PrimaryNewButton({ onClick, fullWidth = false }: { onClick: () => void; fullWidth?: boolean }) {
   return (
     <button
       type="button"
@@ -154,6 +154,7 @@ function PrimaryNewButton({ onClick }: { onClick: () => void }) {
         'active:translate-y-0 active:shadow-[0_2px_4px_-2px_rgb(34_197_94/0.4)]',
         'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-green-500/40 focus-visible:ring-offset-2 focus-visible:ring-offset-stone-50 dark:focus-visible:ring-offset-gray-900',
         'transition-[transform,box-shadow,background] duration-200',
+        fullWidth && 'w-full justify-center',
       )}
     >
       <span
@@ -161,10 +162,7 @@ function PrimaryNewButton({ onClick }: { onClick: () => void }) {
         aria-hidden="true"
       />
       <Plus className={cn('relative', TOOLBAR_ICON_SIZE)} aria-hidden="true" />
-      <span className="relative">
-        <span className="hidden sm:inline">Nuevo pedido</span>
-        <span className="sm:hidden">Nuevo</span>
-      </span>
+      <span className="relative">Nuevo pedido</span>
     </button>
   );
 }
@@ -198,116 +196,171 @@ export default function PedidoToolbar({
     onAsignarTransportistaMasivo || onPagosMasivos || onEntregasMasivas,
   );
 
+  // Dropdowns "Acciones masivas" y "Exportaciones" — reusados en ambos layouts.
+  const masivasDropdown = hasMasivas && (
+    <ToolbarDropdown
+      triggerIcon={Boxes}
+      label="Acciones masivas"
+      mobileLabel="Masivas"
+    >
+      <DropdownMenuLabel>Acciones masivas</DropdownMenuLabel>
+      {onAsignarTransportistaMasivo && (
+        <DropdownMenuItem onSelect={onAsignarTransportistaMasivo}>
+          <Truck className="w-4 h-4 text-blue-600" />
+          <span>Asignar Transportista</span>
+        </DropdownMenuItem>
+      )}
+      {onPagosMasivos && (
+        <DropdownMenuItem onSelect={onPagosMasivos}>
+          <Banknote className="w-4 h-4 text-green-600" />
+          <span>Pagos Masivos</span>
+        </DropdownMenuItem>
+      )}
+      {onEntregasMasivas && (
+        <DropdownMenuItem onSelect={onEntregasMasivas}>
+          <PackageCheck className="w-4 h-4 text-teal-600" />
+          <span>Entregas Masivas</span>
+        </DropdownMenuItem>
+      )}
+    </ToolbarDropdown>
+  );
+
+  const exportarDropdown = (
+    <ToolbarDropdown
+      triggerIcon={Download}
+      label="Exportaciones"
+      mobileLabel="Exportar"
+      menuClassName="w-[min(18rem,calc(100vw-2rem))]"
+    >
+      <DropdownMenuLabel>Exportaciones</DropdownMenuLabel>
+      <DropdownMenuItem
+        onSelect={() => onExportarExcel('pagina')}
+        disabled={exportando}
+      >
+        <FileDown className="w-4 h-4 text-emerald-600" />
+        <div className="flex flex-col gap-0.5 min-w-0">
+          <span className="font-medium">Excel — Página actual</span>
+          <span className="text-xs text-stone-500 dark:text-gray-400">
+            Solo los pedidos visibles
+          </span>
+        </div>
+      </DropdownMenuItem>
+      <DropdownMenuItem
+        onSelect={() => onExportarExcel('filtro')}
+        disabled={exportando}
+      >
+        <FileDown className="w-4 h-4 text-emerald-600" />
+        <div className="flex flex-col gap-0.5 min-w-0">
+          <span className="font-medium">
+            Excel — Filtro actual ({totalCount.toLocaleString('es-AR')})
+          </span>
+          <span className="text-xs text-stone-500 dark:text-gray-400">
+            Todos los pedidos que coinciden
+          </span>
+        </div>
+      </DropdownMenuItem>
+      <DropdownMenuItem onSelect={onExportarPDF}>
+        <FileDown className="w-4 h-4 text-rose-600" />
+        <span>PDF</span>
+      </DropdownMenuItem>
+    </ToolbarDropdown>
+  );
+
   return (
-    <div className="flex items-center gap-2 justify-end flex-wrap">
-      {showOpsGroups && (
-        <>
-          {hasMasivas && (
-            <ToolbarDropdown
-              triggerIcon={Boxes}
-              label="Acciones masivas"
-              mobileLabel="Masivas"
-            >
-              <DropdownMenuLabel>Acciones masivas</DropdownMenuLabel>
-              {onAsignarTransportistaMasivo && (
-                <DropdownMenuItem onSelect={onAsignarTransportistaMasivo}>
-                  <Truck className="w-4 h-4 text-blue-600" />
-                  <span>Asignar Transportista</span>
-                </DropdownMenuItem>
-              )}
-              {onPagosMasivos && (
-                <DropdownMenuItem onSelect={onPagosMasivos}>
-                  <Banknote className="w-4 h-4 text-green-600" />
-                  <span>Pagos Masivos</span>
-                </DropdownMenuItem>
-              )}
-              {onEntregasMasivas && (
-                <DropdownMenuItem onSelect={onEntregasMasivas}>
-                  <PackageCheck className="w-4 h-4 text-teal-600" />
-                  <span>Entregas Masivas</span>
-                </DropdownMenuItem>
-              )}
-            </ToolbarDropdown>
-          )}
-
-          <ToolbarDropdown
-            triggerIcon={Download}
-            label="Exportaciones"
-            mobileLabel="Exportar"
-            menuClassName="w-72"
-          >
-            <DropdownMenuLabel>Exportaciones</DropdownMenuLabel>
-            <DropdownMenuItem
-              onSelect={() => onExportarExcel('pagina')}
-              disabled={exportando}
-            >
-              <FileDown className="w-4 h-4 text-emerald-600" />
-              <div className="flex flex-col gap-0.5 min-w-0">
-                <span className="font-medium">Excel — Página actual</span>
-                <span className="text-xs text-stone-500 dark:text-gray-400">
-                  Solo los pedidos visibles
-                </span>
-              </div>
-            </DropdownMenuItem>
-            <DropdownMenuItem
-              onSelect={() => onExportarExcel('filtro')}
-              disabled={exportando}
-            >
-              <FileDown className="w-4 h-4 text-emerald-600" />
-              <div className="flex flex-col gap-0.5 min-w-0">
-                <span className="font-medium">
-                  Excel — Filtro actual ({totalCount.toLocaleString('es-AR')})
-                </span>
-                <span className="text-xs text-stone-500 dark:text-gray-400">
-                  Todos los pedidos que coinciden
-                </span>
-              </div>
-            </DropdownMenuItem>
-            <DropdownMenuItem onSelect={onExportarPDF}>
-              <FileDown className="w-4 h-4 text-rose-600" />
-              <span>PDF</span>
-            </DropdownMenuItem>
-          </ToolbarDropdown>
-
-          <ToolbarButton
-            icon={Route}
-            iconClassName="text-blue-600"
-            mobileLabel="Ruta"
-            onClick={onOptimizarRuta}
-          >
-            Optimizar Ruta
-          </ToolbarButton>
-        </>
-      )}
-
-      {showPreventistaActions && (
-        <>
-          {onVerVisitasHoy && (
+    <>
+      {/* ╔══ MOBILE (<sm): grid 3-col arriba + primary full-width abajo ══╗ */}
+      <div className="flex flex-col gap-2 sm:hidden">
+        {showOpsGroups && (
+          <div className="grid grid-cols-3 gap-1.5 [&>*]:w-full [&>*]:justify-center [&>*]:px-2">
+            {masivasDropdown}
+            {exportarDropdown}
             <ToolbarButton
-              icon={History}
-              iconClassName="text-stone-500"
-              mobileLabel="Visitas"
-              onClick={onVerVisitasHoy}
-              title="Ver clientes que visitaste hoy"
+              icon={Route}
+              iconClassName="text-blue-600"
+              mobileLabel="Ruta"
+              onClick={onOptimizarRuta}
             >
-              Visitas del día
+              Optimizar Ruta
             </ToolbarButton>
-          )}
-          {onMarcarVisita && (
-            <ToolbarButton
-              icon={MapPin}
-              iconClassName="text-indigo-600"
-              mobileLabel="Marcar"
-              onClick={onMarcarVisita}
-              title="Marcar visita a un cliente sin necesidad de cargar pedido"
-            >
-              Marcar visita
-            </ToolbarButton>
-          )}
-        </>
-      )}
+          </div>
+        )}
 
-      {canCreate && <PrimaryNewButton onClick={onNuevoPedido} />}
-    </div>
+        {showPreventistaActions && (
+          <div className="grid grid-cols-2 gap-1.5 [&>*]:w-full [&>*]:justify-center [&>*]:px-2">
+            {onVerVisitasHoy && (
+              <ToolbarButton
+                icon={History}
+                iconClassName="text-stone-500"
+                mobileLabel="Visitas"
+                onClick={onVerVisitasHoy}
+                title="Ver clientes que visitaste hoy"
+              >
+                Visitas del día
+              </ToolbarButton>
+            )}
+            {onMarcarVisita && (
+              <ToolbarButton
+                icon={MapPin}
+                iconClassName="text-indigo-600"
+                mobileLabel="Marcar"
+                onClick={onMarcarVisita}
+                title="Marcar visita a un cliente sin necesidad de cargar pedido"
+              >
+                Marcar visita
+              </ToolbarButton>
+            )}
+          </div>
+        )}
+
+        {canCreate && <PrimaryNewButton onClick={onNuevoPedido} fullWidth />}
+      </div>
+
+      {/* ╔══ DESKTOP (sm+): layout original — fila a la derecha ══╗ */}
+      <div className="hidden sm:flex items-center gap-2 justify-end flex-wrap">
+        {showOpsGroups && (
+          <>
+            {masivasDropdown}
+            {exportarDropdown}
+            <ToolbarButton
+              icon={Route}
+              iconClassName="text-blue-600"
+              mobileLabel="Ruta"
+              onClick={onOptimizarRuta}
+            >
+              Optimizar Ruta
+            </ToolbarButton>
+          </>
+        )}
+
+        {showPreventistaActions && (
+          <>
+            {onVerVisitasHoy && (
+              <ToolbarButton
+                icon={History}
+                iconClassName="text-stone-500"
+                mobileLabel="Visitas"
+                onClick={onVerVisitasHoy}
+                title="Ver clientes que visitaste hoy"
+              >
+                Visitas del día
+              </ToolbarButton>
+            )}
+            {onMarcarVisita && (
+              <ToolbarButton
+                icon={MapPin}
+                iconClassName="text-indigo-600"
+                mobileLabel="Marcar"
+                onClick={onMarcarVisita}
+                title="Marcar visita a un cliente sin necesidad de cargar pedido"
+              >
+                Marcar visita
+              </ToolbarButton>
+            )}
+          </>
+        )}
+
+        {canCreate && <PrimaryNewButton onClick={onNuevoPedido} />}
+      </div>
+    </>
   );
 }

--- a/src/components/productos/ProductoToolbar.tsx
+++ b/src/components/productos/ProductoToolbar.tsx
@@ -63,7 +63,7 @@ function ToolbarDropdown({
   label,
   mobileLabel,
   children,
-  menuClassName = 'w-72',
+  menuClassName = 'w-[min(18rem,calc(100vw-2rem))]',
 }: ToolbarDropdownProps) {
   return (
     <DropdownMenu modal={false}>
@@ -118,7 +118,7 @@ function StockBajoButton({ count, onClick }: { count: number; onClick?: () => vo
   );
 }
 
-function PrimaryNewButton({ onClick }: { onClick: () => void }) {
+function PrimaryNewButton({ onClick, fullWidth = false }: { onClick: () => void; fullWidth?: boolean }) {
   return (
     <button
       type="button"
@@ -132,6 +132,7 @@ function PrimaryNewButton({ onClick }: { onClick: () => void }) {
         'active:translate-y-0 active:shadow-[0_2px_4px_-2px_rgb(34_197_94/0.4)]',
         'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-green-500/40 focus-visible:ring-offset-2 focus-visible:ring-offset-stone-50 dark:focus-visible:ring-offset-gray-900',
         'transition-[transform,box-shadow,background] duration-200',
+        fullWidth && 'w-full justify-center',
       )}
     >
       <span
@@ -139,10 +140,7 @@ function PrimaryNewButton({ onClick }: { onClick: () => void }) {
         aria-hidden="true"
       />
       <Plus className={cn('relative', TOOLBAR_ICON_SIZE)} aria-hidden="true" />
-      <span className="relative">
-        <span className="hidden sm:inline">Nuevo producto</span>
-        <span className="sm:hidden">Nuevo</span>
-      </span>
+      <span className="relative">Nuevo producto</span>
     </button>
   );
 }
@@ -169,60 +167,77 @@ export default function ProductoToolbar({
     return null;
   }
 
+  // Dropdowns reusados en ambos layouts (mobile y desktop).
+  const catalogoDropdown = hayCatálogo && (
+    <ToolbarDropdown triggerIcon={Tag} label="Catálogo" mobileLabel="Catálogo">
+      <DropdownMenuLabel>Catálogo</DropdownMenuLabel>
+      {onGestionarCategorias && (
+        <DropdownMenuItem onSelect={onGestionarCategorias}>
+          <Tag className="w-4 h-4 text-purple-600" />
+          <span>Categorías</span>
+        </DropdownMenuItem>
+      )}
+      {onCambioProducto && (
+        <DropdownMenuItem onSelect={onCambioProducto}>
+          <ArrowLeftRight className="w-4 h-4 text-indigo-600" />
+          <span>Cambio de productos</span>
+        </DropdownMenuItem>
+      )}
+      {onActualizacionMasivaPrecios && (
+        <DropdownMenuItem onSelect={onActualizacionMasivaPrecios}>
+          <Percent className="w-4 h-4 text-indigo-600" />
+          <span>Actualización masiva de precios</span>
+        </DropdownMenuItem>
+      )}
+    </ToolbarDropdown>
+  );
+
+  const inventarioDropdown = hayInventario && (
+    <ToolbarDropdown triggerIcon={Package2} label="Inventario" mobileLabel="Inventario">
+      <DropdownMenuLabel>Inventario</DropdownMenuLabel>
+      {onControlStock && (
+        <DropdownMenuItem onSelect={onControlStock}>
+          <ClipboardCheck className="w-4 h-4 text-amber-600" />
+          <div className="flex flex-col gap-0.5 min-w-0">
+            <span className="font-medium">Control de stock</span>
+            <span className="text-xs text-stone-500 dark:text-gray-400">
+              Descarga Excel con el inventario actual
+            </span>
+          </div>
+        </DropdownMenuItem>
+      )}
+      {onVerHistorialMermas && (
+        <DropdownMenuItem onSelect={onVerHistorialMermas}>
+          <TrendingDown className="w-4 h-4 text-rose-600" />
+          <span>Historial de mermas</span>
+        </DropdownMenuItem>
+      )}
+    </ToolbarDropdown>
+  );
+
+  const stockBajoBtn = hayStockBajo && (
+    <StockBajoButton count={productosStockBajoCount} onClick={onAbrirStockBajo} />
+  );
+
   return (
-    <div className="flex items-center gap-2 justify-end flex-wrap">
-      {hayCatálogo && (
-        <ToolbarDropdown triggerIcon={Tag} label="Catálogo" mobileLabel="Catálogo">
-          <DropdownMenuLabel>Catálogo</DropdownMenuLabel>
-          {onGestionarCategorias && (
-            <DropdownMenuItem onSelect={onGestionarCategorias}>
-              <Tag className="w-4 h-4 text-purple-600" />
-              <span>Categorías</span>
-            </DropdownMenuItem>
-          )}
-          {onCambioProducto && (
-            <DropdownMenuItem onSelect={onCambioProducto}>
-              <ArrowLeftRight className="w-4 h-4 text-indigo-600" />
-              <span>Cambio de productos</span>
-            </DropdownMenuItem>
-          )}
-          {onActualizacionMasivaPrecios && (
-            <DropdownMenuItem onSelect={onActualizacionMasivaPrecios}>
-              <Percent className="w-4 h-4 text-indigo-600" />
-              <span>Actualización masiva de precios</span>
-            </DropdownMenuItem>
-          )}
-        </ToolbarDropdown>
-      )}
+    <>
+      {/* ╔══ MOBILE (<sm): grid 3-col + primary full-width abajo ══╗ */}
+      <div className="flex flex-col gap-2 sm:hidden">
+        <div className="grid grid-cols-3 gap-1.5 [&>*]:w-full [&>*]:justify-center [&>*]:px-2">
+          {catalogoDropdown}
+          {inventarioDropdown}
+          {stockBajoBtn}
+        </div>
+        {hayNuevo && onNuevoProducto && <PrimaryNewButton onClick={onNuevoProducto} fullWidth />}
+      </div>
 
-      {hayInventario && (
-        <ToolbarDropdown triggerIcon={Package2} label="Inventario" mobileLabel="Inventario">
-          <DropdownMenuLabel>Inventario</DropdownMenuLabel>
-          {onControlStock && (
-            <DropdownMenuItem onSelect={onControlStock}>
-              <ClipboardCheck className="w-4 h-4 text-amber-600" />
-              <div className="flex flex-col gap-0.5 min-w-0">
-                <span className="font-medium">Control de stock</span>
-                <span className="text-xs text-stone-500 dark:text-gray-400">
-                  Descarga Excel con el inventario actual
-                </span>
-              </div>
-            </DropdownMenuItem>
-          )}
-          {onVerHistorialMermas && (
-            <DropdownMenuItem onSelect={onVerHistorialMermas}>
-              <TrendingDown className="w-4 h-4 text-rose-600" />
-              <span>Historial de mermas</span>
-            </DropdownMenuItem>
-          )}
-        </ToolbarDropdown>
-      )}
-
-      {hayStockBajo && (
-        <StockBajoButton count={productosStockBajoCount} onClick={onAbrirStockBajo} />
-      )}
-
-      {hayNuevo && onNuevoProducto && <PrimaryNewButton onClick={onNuevoProducto} />}
-    </div>
+      {/* ╔══ DESKTOP (sm+): layout original ══╗ */}
+      <div className="hidden sm:flex items-center gap-2 justify-end flex-wrap">
+        {catalogoDropdown}
+        {inventarioDropdown}
+        {stockBajoBtn}
+        {hayNuevo && onNuevoProducto && <PrimaryNewButton onClick={onNuevoProducto} />}
+      </div>
+    </>
   );
 }

--- a/src/components/ui/BottomSheet.tsx
+++ b/src/components/ui/BottomSheet.tsx
@@ -1,0 +1,134 @@
+/**
+ * BottomSheet
+ *
+ * Sheet (drawer) que sube desde el borde inferior. Pensado para mobile,
+ * donde un Dialog centrado se siente menos natural que un sheet.
+ *
+ * Basado en Radix Dialog (mismo wrapper que ModalBase) pero con styling
+ * de panel anclado al bottom + slide-up animation + drag handle visual.
+ *
+ * Uso típico (en mobile):
+ *   <BottomSheet
+ *     open={open}
+ *     onClose={...}
+ *     title="Filtros"
+ *     footer={<FooterButtons />}
+ *   >
+ *     <FilterSections />
+ *   </BottomSheet>
+ *
+ * Notas:
+ *  - El drag handle es puramente visual. No implementamos drag-to-dismiss
+ *    porque agrega complejidad y no es esencial; tap fuera + Escape cierran.
+ *  - max-h-[85vh] con scroll interno deja el header + drag handle siempre
+ *    visibles, y el footer (si existe) sticky abajo.
+ *  - El padding-bottom respeta safe-area-inset-bottom (notch iOS).
+ *  - Aria ya está cubierto por DialogPrimitive (role="dialog", focus trap,
+ *    Escape, etc.).
+ */
+import * as React from 'react';
+import * as DialogPrimitive from '@radix-ui/react-dialog';
+import { X } from 'lucide-react';
+import { cn } from '../../lib/utils';
+
+export interface BottomSheetProps {
+  open: boolean;
+  onClose: () => void;
+  title: string;
+  /** Descripción opcional para accesibilidad y para mostrar bajo el título. */
+  description?: string;
+  children: React.ReactNode;
+  /** Slot sticky en el fondo (típicamente botones "Limpiar" / "Listo"). */
+  footer?: React.ReactNode;
+  /** Max-height del sheet. Default '85vh'. */
+  maxHeight?: string;
+}
+
+export function BottomSheet({
+  open,
+  onClose,
+  title,
+  description,
+  children,
+  footer,
+  maxHeight = '85vh',
+}: BottomSheetProps): React.ReactElement {
+  return (
+    <DialogPrimitive.Root open={open} onOpenChange={(v) => !v && onClose()}>
+      <DialogPrimitive.Portal>
+        {/* Overlay con fade */}
+        <DialogPrimitive.Overlay
+          className={cn(
+            'fixed inset-0 z-50 bg-black/40 backdrop-blur-[2px]',
+            'data-[state=open]:animate-fade-in data-[state=closed]:animate-fade-out',
+          )}
+        />
+        {/* Panel anclado al fondo */}
+        <DialogPrimitive.Content
+          className={cn(
+            'fixed bottom-0 left-0 right-0 z-50',
+            'flex flex-col',
+            'bg-white dark:bg-gray-800',
+            'rounded-t-2xl shadow-2xl border-t border-stone-200 dark:border-gray-700',
+            'data-[state=open]:animate-slide-up data-[state=closed]:animate-slide-down',
+            'focus:outline-none',
+          )}
+          style={{ maxHeight }}
+          onPointerDownOutside={(e) => {
+            // Asegurar cierre por tap en overlay (default de Radix ya lo hace,
+            // dejamos pasar el evento).
+            void e;
+          }}
+        >
+          {/* Drag handle visual */}
+          <div className="flex-shrink-0 pt-2 pb-1 flex items-center justify-center">
+            <div
+              className="w-10 h-1 rounded-full bg-stone-300 dark:bg-stone-600"
+              aria-hidden="true"
+            />
+          </div>
+
+          {/* Header: título + close */}
+          <div className="flex-shrink-0 px-5 pt-1 pb-3 flex items-start justify-between gap-3 border-b border-stone-200 dark:border-gray-700">
+            <div className="min-w-0 flex-1">
+              <DialogPrimitive.Title className="text-lg font-semibold text-stone-900 dark:text-white leading-tight">
+                {title}
+              </DialogPrimitive.Title>
+              {description && (
+                <DialogPrimitive.Description className="text-xs text-stone-500 dark:text-stone-400 mt-0.5">
+                  {description}
+                </DialogPrimitive.Description>
+              )}
+            </div>
+            <DialogPrimitive.Close asChild>
+              <button
+                type="button"
+                className="flex-shrink-0 inline-flex items-center justify-center w-8 h-8 rounded-lg text-stone-500 dark:text-stone-400 hover:bg-stone-100 dark:hover:bg-gray-700 transition-colors"
+                aria-label="Cerrar"
+              >
+                <X className="w-5 h-5" aria-hidden="true" />
+              </button>
+            </DialogPrimitive.Close>
+          </div>
+
+          {/* Contenido scrolleable */}
+          <div className="flex-1 overflow-y-auto overscroll-contain px-5 py-3">
+            {children}
+          </div>
+
+          {/* Footer sticky */}
+          {footer && (
+            <div
+              className="flex-shrink-0 px-5 py-3 border-t border-stone-200 dark:border-gray-700 bg-white dark:bg-gray-800"
+              style={{ paddingBottom: 'max(0.75rem, env(safe-area-inset-bottom))' }}
+            >
+              {footer}
+            </div>
+          )}
+        </DialogPrimitive.Content>
+      </DialogPrimitive.Portal>
+    </DialogPrimitive.Root>
+  );
+}
+
+export default BottomSheet;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -14,6 +14,8 @@ export default {
         'scale-in': 'scale-in 0.2s ease-out',
         'fadeSlideIn': 'fadeSlideIn 0.3s ease-out',
         'card-in': 'card-in 0.35s cubic-bezier(0.22, 1, 0.36, 1)',
+        'slide-up': 'slide-up 0.28s cubic-bezier(0.22, 1, 0.36, 1)',
+        'slide-down': 'slide-down 0.22s cubic-bezier(0.55, 0, 0.55, 0.2)',
       },
       keyframes: {
         'slide-in': {
@@ -41,6 +43,15 @@ export default {
         'card-in': {
           '0%': { opacity: '0', transform: 'translateY(6px) scale(0.99)' },
           '100%': { opacity: '1', transform: 'translateY(0) scale(1)' },
+        },
+        /* Bottom sheet: sube desde el borde inferior. */
+        'slide-up': {
+          '0%': { transform: 'translateY(100%)' },
+          '100%': { transform: 'translateY(0)' },
+        },
+        'slide-down': {
+          '0%': { transform: 'translateY(0)' },
+          '100%': { transform: 'translateY(100%)' },
         },
       },
       /* Sombras cálidas (tinte stone en vez de gray puro) */


### PR DESCRIPTION
## Summary

Mejora la UX mobile del rediseño aprobado en #318. En desktop **nada cambia visualmente** (las versiones de >= 640px están intactas). En mobile (<640px) la toolbar y los filtros se sentían apretados y desordenados; este PR los reorganiza con un patrón nativo de mobile.

## Problemas que resuelve

En #318 la versión mobile de `/pedidos` y `/productos` tenía:
1. **Toolbar rota en 2 líneas con tamaños distintos** — el verde "Nuevo" enorme al lado de "Ruta" chiquito, "Masivas" + "Exportar" en otra fila.
2. **Muro de filtros**: para admin son 5 selects + segmented control sin breakpoint responsive, ocupando ~5 filas verticales antes de llegar a la lista.
3. **Dropdowns** con `w-64`/`w-72` fijos podían salirse del viewport en 390px.

## Lo que cambia

### Toolbar mobile
**Antes**: 4 botones `flex-wrap` que se rompen feo. **Ahora**:
- Fila 1: `[Masivas ▾] [Exportaciones ▾] [Optimizar Ruta]` en grid 3-col iguales (admin/encargado).
- Fila 2: `[+ Nuevo pedido]` verde primary **full-width** abajo, con peso visual claro.

Para preventista: `[Visitas del día] [Marcar visita]` en grid 2-col + Nuevo full-width.

Mismo patrón en `/productos`: `[Catálogo] [Inventario] [Stock bajo (N)]` arriba + `[+ Nuevo producto]` abajo.

### Filtros mobile → bottom sheet
**Antes**: 5+ selects apilados verticalmente. **Ahora**:
- Búsqueda full-width arriba (lo más usado).
- Una fila con `[📅 Fechas] [⚙ Filtros (N)]` en grid 2-col.
- El botón "Filtros" muestra count de filtros activos (badge azul `(3)`).
- Al toque abre **bottom sheet** con todos los filtros en secciones: Estado, Pago, Transportista, Cargado por, Salvedades, Entrega programada, Ver cancelados.
- Footer sticky con "Limpiar todo" y "Listo". Cambios aplican en tiempo real.

### BottomSheet (nuevo componente reutilizable)
`src/components/ui/BottomSheet.tsx` — wrapper de Radix Dialog anclado al borde inferior:
- Drag handle visual arriba (no draggable interactivo — sería complejo y poco valor)
- Slide-up animation (cubic-bezier orgánico)
- `max-h-[85vh]` con scroll interno
- Footer sticky opcional
- `safe-area-inset-bottom` respetado (iPhone notch)
- Aria completo via DialogPrimitive (role, focus trap, Escape)

### Fix de dropdowns en mobile
DropdownMenu width pasó de `w-64`/`w-72` a `w-[min(NN,calc(100vw-2rem))]` — respeta viewport en pantallas chicas y evita overflow horizontal.

## Test plan

- [x] `npm run typecheck` — limpio
- [x] `TZ=UTC npm run test:run` — **674/674 tests pasan**, sin regresiones
- [x] `npm run build` — limpio
- [x] Preview 375×812 (mobile): cero overflow horizontal en body
- [ ] Smoke manual en iPhone real (vos): toolbar ordenada, bottom sheet abre con slide-up, filtros aplican en vivo, "Listo" cierra
- [ ] Smoke manual en desktop: confirmar que **nada cambió** visualmente

## Archivos

**Nuevos**:
- `src/components/ui/BottomSheet.tsx` (~120 líneas)
- `src/components/pedidos/ModalFiltrosPedidos.tsx` (~280 líneas)

**Modificados**:
- `src/components/pedidos/PedidoFilters.tsx` — dos layouts CSS responsive + helper `contarFiltrosActivos`
- `src/components/pedidos/PedidoToolbar.tsx` — versión mobile en grid 3-col + `fullWidth` prop en PrimaryNewButton
- `src/components/productos/ProductoToolbar.tsx` — mismo patrón
- `tailwind.config.js` — animaciones `slide-up` / `slide-down`

**NO se modifica**: Dialog/ModalBase existente, Dashboard, VistaProductos, PedidoCard, PedidoStats, lógica de queries, permisos por rol, helpers de título.

🤖 Generated with [Claude Code](https://claude.com/claude-code)