### PR TITLE
fix(usuarios): exponer rol preventista_taco en ModalUsuario

### DIFF
--- a/src/components/modals/ModalUsuario.tsx
+++ b/src/components/modals/ModalUsuario.tsx
@@ -7,7 +7,7 @@ import { useZonasEstandarizadasQuery, usePreventistaZonasQuery, useAsignarZonasP
 import type { PerfilDB } from '../../types';
 
 /** Roles disponibles para usuarios */
-export type RolUsuario = 'admin' | 'preventista' | 'transportista' | 'deposito' | 'encargado';
+export type RolUsuario = 'admin' | 'preventista' | 'preventista_taco' | 'transportista' | 'deposito' | 'encargado';
 
 /** Datos del formulario de usuario */
 export interface UsuarioFormData {
@@ -63,8 +63,8 @@ const ModalUsuario = memo(function ModalUsuario({ usuario, onSave, onClose, guar
     }
   }, [prevZonaIds]);
 
-  // Mostrar campo de zona solo para preventistas
-  const mostrarZona = form.rol === 'preventista';
+  // Mostrar campo de zona para preventistas (regular y taco)
+  const mostrarZona = form.rol === 'preventista' || form.rol === 'preventista_taco';
 
   const handleFieldChange = (field: keyof UsuarioFormData, value: string | boolean): void => {
     setForm({ ...form, [field]: value });
@@ -102,7 +102,7 @@ const ModalUsuario = memo(function ModalUsuario({ usuario, onSave, onClose, guar
     await onSave({ ...form, id: usuario?.id });
 
     // Guardar zonas del preventista en tabla pivot
-    if (usuario?.id && form.rol === 'preventista') {
+    if (usuario?.id && (form.rol === 'preventista' || form.rol === 'preventista_taco')) {
       try {
         await asignarZonasMut.mutateAsync({ perfilId: usuario.id, zonaIds });
       } catch {
@@ -145,13 +145,15 @@ const ModalUsuario = memo(function ModalUsuario({ usuario, onSave, onClose, guar
             value={form.rol}
             onChange={e => {
               const newRol = e.target.value as RolUsuario;
-              setForm({ ...form, rol: newRol, zona: newRol !== 'preventista' ? '' : form.zona });
+              const esPreventista = newRol === 'preventista' || newRol === 'preventista_taco';
+              setForm({ ...form, rol: newRol, zona: esPreventista ? form.zona : '' });
               if (hasAttemptedSubmit && errors.rol) clearFieldError('rol');
             }}
             className={inputClass('rol')}
             {...getAriaProps('rol', true)}
           >
             <option value="preventista">Preventista</option>
+            <option value="preventista_taco">Preventista Taco</option>
             <option value="transportista">Transportista</option>
             <option value="deposito">Deposito</option>
             <option value="encargado">Encargado</option>


### PR DESCRIPTION
## Resumen

El select de rol en el modal "Editar Usuario" no listaba `preventista_taco` (rol agregado en [#319](https://github.com/AgustinReiden/distribuidora-app/pull/319) via migracion 050), por lo que no se podia asignar el rol desde la UI.

## Cambios

- `ModalUsuario.tsx`:
  - Tipo local `RolUsuario` extendido con `'preventista_taco'`.
  - Nueva `<option value="preventista_taco">Preventista Taco</option>` despues de Preventista.
  - El gate `mostrarZona` y el guard de asignacion de zonas ahora incluyen al taco: opera como preventista regular para asignacion de zonas, solo difiere en visibilidad de montos.

## Test plan

- [ ] Abrir admin → Configuracion → Users → Editar usuario.
- [ ] Confirmar que el dropdown muestra "Preventista Taco" entre Preventista y Transportista.
- [ ] Seleccionarlo → aparece el panel de zonas → guardar → DB persiste `rol='preventista_taco'`.
- [ ] Login con ese usuario → dashboard sin ventas / montos (verificacion del comportamiento ya implementado en #319).

🤖 Generated with [Claude Code](https://claude.com/claude-code)