### PR TITLE
feat(pagos): editar forma de pago antes del cierre de rendición

### DIFF
--- a/migrations/053_editar_forma_pago_pago.sql
+++ b/migrations/053_editar_forma_pago_pago.sql
@@ -1,0 +1,144 @@
+-- =========================================================================
+-- 053_editar_forma_pago_pago.sql
+--
+-- Permite a admin y encargado corregir la forma de pago de un pago ya
+-- registrado en la tabla `pagos`, siempre que la rendicion del dia del pago
+-- no este cerrada (confirmada/resuelta) en la sucursal activa.
+--
+-- Caso de uso: el operador marco un pedido pagado con la forma de pago
+-- equivocada (ej. "efectivo" cuando era "transferencia") y necesita
+-- corregirla sin tener que anular y re-registrar el pago (lo cual rompe
+-- la fecha original y el rastro de auditoria).
+--
+-- Reglas:
+--   - Solo admin o encargado (es_encargado_o_admin()).
+--   - La rendicion del dia del pago no debe estar cerrada, NI para admin ni
+--     para encargado (bloqueo unificado pedido por el usuario).
+--   - El pago debe pertenecer a la sucursal activa.
+--   - Forma de pago nueva debe estar en lista valida.
+--   - Se sincroniza `pedidos.forma_pago` (denormalizado) al forma_pago del
+--     pago con mayor monto del pedido. En empate gana el mas reciente por
+--     created_at. Esto mantiene consistentes los reportes que leen
+--     `pedidos.forma_pago` (rendicion_items, vistas legacy).
+--   - Se inserta una fila en pedido_historial con campo_modificado =
+--     'forma_pago_pago_<id>' para trazabilidad fina. El trigger BEFORE
+--     existente en pedidos ya registra el cambio del campo denormalizado
+--     `pedidos.forma_pago` cuando corresponde.
+-- =========================================================================
+
+BEGIN;
+
+CREATE OR REPLACE FUNCTION public.actualizar_forma_pago_pago(
+  p_pago_id bigint,
+  p_forma_pago text
+) RETURNS jsonb
+LANGUAGE plpgsql SECURITY DEFINER SET search_path TO 'public'
+AS $$
+DECLARE
+  v_sucursal_id bigint;
+  v_pago RECORD;
+  v_forma_anterior text;
+  v_nueva_forma_pedido text;
+BEGIN
+  v_sucursal_id := current_sucursal_id();
+  IF v_sucursal_id IS NULL THEN
+    RAISE EXCEPTION 'No hay sucursal activa' USING ERRCODE = '42501';
+  END IF;
+
+  IF NOT es_encargado_o_admin() THEN
+    RAISE EXCEPTION 'Solo encargado o admin pueden modificar la forma de pago'
+      USING ERRCODE = '42501';
+  END IF;
+
+  IF p_forma_pago NOT IN (
+    'efectivo', 'transferencia', 'cheque',
+    'cuenta_corriente', 'tarjeta', 'vale_blanco'
+  ) THEN
+    RAISE EXCEPTION 'Forma de pago invalida: %', p_forma_pago
+      USING ERRCODE = '22023';
+  END IF;
+
+  SELECT id, pedido_id, fecha, forma_pago
+    INTO v_pago
+    FROM pagos
+   WHERE id = p_pago_id
+     AND sucursal_id = v_sucursal_id
+   FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Pago no encontrado' USING ERRCODE = 'P0002';
+  END IF;
+
+  v_forma_anterior := COALESCE(v_pago.forma_pago, 'efectivo');
+
+  IF v_forma_anterior = p_forma_pago THEN
+    -- No-op: nada que cambiar.
+    RETURN jsonb_build_object(
+      'success', true,
+      'pago_id', v_pago.id,
+      'forma_pago_anterior', v_forma_anterior,
+      'forma_pago_nueva', p_forma_pago,
+      'pedido_forma_pago', NULL
+    );
+  END IF;
+
+  -- Bloqueo unificado: ni admin ni encargado pueden editar si la rendicion
+  -- del dia del pago ya esta cerrada (confirmada/resuelta).
+  IF public.rendicion_dia_cerrada(v_pago.fecha, v_sucursal_id) THEN
+    RAISE EXCEPTION 'Rendicion ya cerrada para esta fecha. No se puede modificar.'
+      USING ERRCODE = '42501';
+  END IF;
+
+  UPDATE pagos
+     SET forma_pago = p_forma_pago
+   WHERE id = p_pago_id;
+
+  -- Sincronizar pedidos.forma_pago si el pago esta asociado a un pedido.
+  -- Toma la forma_pago del pago de mayor monto; en empate, el mas reciente.
+  IF v_pago.pedido_id IS NOT NULL THEN
+    SELECT forma_pago
+      INTO v_nueva_forma_pedido
+      FROM pagos
+     WHERE pedido_id = v_pago.pedido_id
+     ORDER BY monto DESC NULLS LAST, created_at DESC NULLS LAST
+     LIMIT 1;
+
+    UPDATE pedidos
+       SET forma_pago = COALESCE(v_nueva_forma_pedido, p_forma_pago),
+           updated_at = now()
+     WHERE id = v_pago.pedido_id
+       AND sucursal_id = v_sucursal_id;
+
+    -- Trazabilidad fina del cambio puntual en `pagos`. El trigger BEFORE en
+    -- pedidos ya graba el cambio de `pedidos.forma_pago` si aplica.
+    INSERT INTO pedido_historial (
+      pedido_id, usuario_id, campo_modificado, valor_anterior, valor_nuevo, sucursal_id
+    )
+    VALUES (
+      v_pago.pedido_id,
+      auth.uid(),
+      'forma_pago_pago_' || v_pago.id::text,
+      v_forma_anterior,
+      p_forma_pago,
+      v_sucursal_id
+    );
+  END IF;
+
+  RETURN jsonb_build_object(
+    'success', true,
+    'pago_id', v_pago.id,
+    'forma_pago_anterior', v_forma_anterior,
+    'forma_pago_nueva', p_forma_pago,
+    'pedido_forma_pago', v_nueva_forma_pedido
+  );
+END;
+$$;
+
+ALTER FUNCTION public.actualizar_forma_pago_pago(bigint, text) OWNER TO postgres;
+COMMENT ON FUNCTION public.actualizar_forma_pago_pago(bigint, text) IS
+  'Corrige la forma de pago de una fila de pagos. Admin/encargado, bloqueado si la rendicion del dia del pago esta cerrada. Resincroniza pedidos.forma_pago (denormalizado) al pago de mayor monto del pedido.';
+
+GRANT EXECUTE ON FUNCTION public.actualizar_forma_pago_pago(bigint, text)
+  TO authenticated;
+
+COMMIT;

--- a/src/components/containers/PedidosContainer.tsx
+++ b/src/components/containers/PedidosContainer.tsx
@@ -110,7 +110,7 @@ export default function PedidosContainer(): React.ReactElement {
   const [filtros, setFiltros] = useState<FiltrosPedidosState>(buildDefaultFiltros)
 
   // Queries - use debounced search to avoid firing on every keystroke
-  const { registrarPago, registrarPagosBatch, fetchPagosPedido, eliminarPago } = usePagos()
+  const { registrarPago, registrarPagosBatch, fetchPagosPedido, eliminarPago, actualizarFormaPagoDePago } = usePagos()
 
   const { data: paginatedResult, isLoading: loadingPedidos } = usePedidosPaginatedQuery(
     paginaActual, ITEMS_PER_PAGE, filtros, debouncedBusqueda, authReady
@@ -726,6 +726,22 @@ export default function PedidosContainer(): React.ReactElement {
     setGuardando(false)
   }, [pedidoPago, isAdmin, eliminarPago, refreshPagosPedido, queryClient, notify])
 
+  // Editar la forma de pago de un pago previo. Admin o encargado. El RPC
+  // bloquea la edicion si la rendicion del dia del pago esta cerrada.
+  const handleEditarFormaPagoPedido = useCallback(async (pagoId: string, nuevaForma: string) => {
+    if (!pedidoPago) return
+    if (!isAdmin && !isEncargado) return
+    try {
+      await actualizarFormaPagoDePago(pagoId, nuevaForma)
+      await refreshPagosPedido(String(pedidoPago.id))
+      queryClient.invalidateQueries({ queryKey: ['pedidos'] })
+      notify.success('Forma de pago actualizada')
+    } catch (e) {
+      notify.error((e as Error).message)
+      throw e
+    }
+  }, [pedidoPago, isAdmin, isEncargado, actualizarFormaPagoDePago, refreshPagosPedido, queryClient, notify])
+
   // ModalPedido handlers
   // Estado para el modal de motivo cuando GPS != ok (timeout/unavailable/error).
   // Bloquea la creación del pedido hasta que el preventista escriba justificación
@@ -1230,6 +1246,7 @@ export default function PedidosContainer(): React.ReactElement {
             loadingPagosPrevios={loadingPagosPrevios}
             onConfirmar={pedidoEntregaConPago ? handleEntregarConPago : handleConfirmarPago}
             onAnularPago={isAdmin && !pedidoEntregaConPago ? handleAnularPagoPedido : undefined}
+            onEditarFormaPago={(isAdmin || isEncargado) && !pedidoEntregaConPago ? handleEditarFormaPagoPedido : undefined}
             modoEntregaTransportista={!!pedidoEntregaConPago}
             onEntregarSinPago={pedidoEntregaConPago ? handleEntregarSinPago : undefined}
             onClose={() => {

--- a/src/components/modals/ModalPagoPedido.tsx
+++ b/src/components/modals/ModalPagoPedido.tsx
@@ -38,6 +38,12 @@ export interface ModalPagoPedidoProps {
   onConfirmar: (payload: PagoPedidoPayload) => Promise<void>
   /** Si esta presente, se permite anular pagos previos (admin/encargado). */
   onAnularPago?: (pagoId: string) => Promise<void>
+  /**
+   * Si esta presente, se permite editar la forma de pago de pagos previos
+   * (admin/encargado). El backend bloquea la edicion si la rendicion del
+   * dia del pago esta cerrada.
+   */
+  onEditarFormaPago?: (pagoId: string, nuevaForma: string) => Promise<void>
   /** Activa el flujo "Entregar sin pago / Entregar y registrar pago". */
   modoEntregaTransportista?: boolean
   /** Solo aplica con modoEntregaTransportista. */
@@ -66,6 +72,7 @@ const ModalPagoPedido = memo(function ModalPagoPedido({
   loadingPagosPrevios,
   onConfirmar,
   onAnularPago,
+  onEditarFormaPago,
   modoEntregaTransportista,
   onEntregarSinPago,
   onClose,
@@ -84,6 +91,8 @@ const ModalPagoPedido = memo(function ModalPagoPedido({
     { formaPago: 'efectivo', monto: saldoPendiente > 0 ? saldoPendiente.toFixed(2) : '' },
   ])
   const [error, setError] = useState<string>('')
+  // pagoId en curso de edicion de forma_pago (para mostrar spinner inline).
+  const [editandoPagoId, setEditandoPagoId] = useState<string | null>(null)
 
   // Si los pagos previos cambian (anulacion), reajustar la linea por default al saldo restante.
   useEffect(() => {
@@ -153,6 +162,19 @@ const ModalPagoPedido = memo(function ModalPagoPedido({
     }
   }
 
+  const handleEditarFormaPago = async (pagoId: string, nuevaForma: string): Promise<void> => {
+    if (!onEditarFormaPago) return
+    setError('')
+    setEditandoPagoId(pagoId)
+    try {
+      await onEditarFormaPago(pagoId, nuevaForma)
+    } catch (e) {
+      setError((e as Error).message || 'Error al actualizar forma de pago')
+    } finally {
+      setEditandoPagoId(null)
+    }
+  }
+
   const handleEntregarSinPago = async (): Promise<void> => {
     if (!onEntregarSinPago) return
     setError('')
@@ -203,33 +225,55 @@ const ModalPagoPedido = memo(function ModalPagoPedido({
               Pagos previos ({pagosPrevios.length})
             </div>
             <div className="divide-y dark:divide-gray-600">
-              {pagosPrevios.map(p => (
-                <div key={p.id} className="px-3 py-2 flex items-center justify-between text-sm">
-                  <div>
-                    <p className="dark:text-white">
-                      {formatPrecio(p.monto)}{' '}
-                      <span className="text-gray-500">· {getFormaPagoLabel(p.forma_pago)}</span>
-                    </p>
-                    <p className="text-xs text-gray-500">
-                      {p.created_at && formatDateTime(p.created_at)}
-                      {p.usuario?.nombre ? ` · ${p.usuario.nombre}` : ''}
-                    </p>
-                    {p.notas && <p className="text-xs text-gray-400 italic">{p.notas}</p>}
+              {pagosPrevios.map(p => {
+                const editandoEste = editandoPagoId === p.id
+                return (
+                  <div key={p.id} className="px-3 py-2 flex items-center justify-between gap-2 text-sm">
+                    <div className="min-w-0 flex-1">
+                      <div className="flex items-center gap-2 flex-wrap">
+                        <span className="font-medium dark:text-white">{formatPrecio(p.monto)}</span>
+                        {onEditarFormaPago ? (
+                          <div className="flex items-center gap-1">
+                            <span className="text-gray-400">·</span>
+                            <select
+                              value={p.forma_pago || 'efectivo'}
+                              onChange={e => { void handleEditarFormaPago(p.id, e.target.value) }}
+                              disabled={guardando || editandoEste}
+                              className="text-xs px-1.5 py-0.5 border rounded dark:bg-gray-700 dark:border-gray-600 dark:text-white disabled:opacity-50"
+                              aria-label="Editar forma de pago"
+                              title="Editar forma de pago"
+                            >
+                              {FORMAS_PAGO_OPCIONES.map(o => (
+                                <option key={o.value} value={o.value}>{o.label}</option>
+                              ))}
+                            </select>
+                            {editandoEste && <Loader2 className="w-3 h-3 animate-spin text-gray-400" />}
+                          </div>
+                        ) : (
+                          <span className="text-gray-500">· {getFormaPagoLabel(p.forma_pago)}</span>
+                        )}
+                      </div>
+                      <p className="text-xs text-gray-500">
+                        {p.created_at && formatDateTime(p.created_at)}
+                        {p.usuario?.nombre ? ` · ${p.usuario.nombre}` : ''}
+                      </p>
+                      {p.notas && <p className="text-xs text-gray-400 italic">{p.notas}</p>}
+                    </div>
+                    {onAnularPago && (
+                      <button
+                        type="button"
+                        onClick={() => { void onAnularPago(p.id) }}
+                        disabled={guardando}
+                        className="p-1.5 text-red-500 hover:bg-red-50 dark:hover:bg-red-900/20 rounded disabled:opacity-50"
+                        aria-label="Anular pago"
+                        title="Anular pago"
+                      >
+                        <X className="w-4 h-4" />
+                      </button>
+                    )}
                   </div>
-                  {onAnularPago && (
-                    <button
-                      type="button"
-                      onClick={() => { void onAnularPago(p.id) }}
-                      disabled={guardando}
-                      className="p-1.5 text-red-500 hover:bg-red-50 dark:hover:bg-red-900/20 rounded disabled:opacity-50"
-                      aria-label="Anular pago"
-                      title="Anular pago"
-                    >
-                      <X className="w-4 h-4" />
-                    </button>
-                  )}
-                </div>
-              ))}
+                )
+              })}
             </div>
           </div>
         )}

--- a/src/components/pedidos/PedidoActions.tsx
+++ b/src/components/pedidos/PedidoActions.tsx
@@ -118,15 +118,16 @@ function AccionesDropdown({
       });
     }
 
-    // Registrar pago (admin o encargado, mientras no este pagado/cancelado)
+    // Registrar pago / ver-editar pagos (admin o encargado, mientras no este cancelado).
+    // Cuando estado_pago === 'pagado', el modal abre en modo solo-lectura + edicion de
+    // forma de pago de pagos previos (con bloqueo SQL si la rendicion esta cerrada).
     if (
       (isAdmin || isEncargado) &&
       pedido.estado !== 'cancelado' &&
-      pedido.estado_pago !== 'pagado' &&
       onRegistrarPago
     ) {
       items.push({
-        label: 'Registrar Pago',
+        label: pedido.estado_pago === 'pagado' ? 'Ver/Editar Pagos' : 'Registrar Pago',
         icon: DollarSign,
         onClick: () => onRegistrarPago(pedido),
         className: 'text-green-700 dark:text-green-400'

--- a/src/hooks/supabase/usePagos.ts
+++ b/src/hooks/supabase/usePagos.ts
@@ -184,6 +184,25 @@ export function usePagos(): UsePagosReturnExtended {
     }
   }
 
+  const actualizarFormaPagoDePago = async (
+    pagoId: string,
+    nuevaFormaPago: string,
+  ): Promise<void> => {
+    try {
+      const { error } = await supabase.rpc('actualizar_forma_pago_pago', {
+        p_pago_id: pagoId,
+        p_forma_pago: nuevaFormaPago,
+      })
+      if (error) throw error
+      setPagos(prev =>
+        prev.map(p => (p.id === pagoId ? { ...p, forma_pago: nuevaFormaPago } : p)),
+      )
+    } catch (error) {
+      notifyError('Error al actualizar forma de pago: ' + (error as Error).message)
+      throw error
+    }
+  }
+
   const obtenerResumenCuenta = async (clienteId: string): Promise<ResumenCuenta | null> => {
     try {
       const { data, error } = await supabase.rpc('obtener_resumen_cuenta_cliente', { p_cliente_id: clienteId })
@@ -242,6 +261,7 @@ export function usePagos(): UsePagosReturnExtended {
     registrarPagosBatch,
     registrarPagoFIFO,
     eliminarPago,
+    actualizarFormaPagoDePago,
     obtenerResumenCuenta,
   }
 }

--- a/src/types/hooks.ts
+++ b/src/types/hooks.ts
@@ -717,6 +717,7 @@ export interface UsePagosReturnExtended {
   registrarPagosBatch: (input: RegistrarPagoBatchInput) => Promise<PagoDBWithUsuario[]>;
   registrarPagoFIFO: (input: RegistrarPagoFifoInput) => Promise<RegistrarPagoFifoResult>;
   eliminarPago: (pagoId: string) => Promise<void>;
+  actualizarFormaPagoDePago: (pagoId: string, nuevaFormaPago: string) => Promise<void>;
   obtenerResumenCuenta: (clienteId: string) => Promise<ResumenCuenta | null>;
 }
 


### PR DESCRIPTION
## Summary

- Admin y encargados pueden corregir la **forma de pago** de un pago previo desde el modal "Ver/Editar Pagos" (dropdown inline en cada fila de pagos previos), sin tener que anular y re-registrar.
- Nuevo RPC `actualizar_forma_pago_pago(p_pago_id, p_forma_pago)` con `SECURITY DEFINER`: valida rol `es_encargado_o_admin()`, bloquea si la rendición del día del pago está cerrada (ni admin ni encargado pueden saltarla — lo pidió el usuario explícitamente), resincroniza `pedidos.forma_pago` al pago de mayor monto y registra cada cambio en `pedido_historial`.
- La acción del dropdown "Registrar Pago" ahora aparece también cuando `estado_pago === 'pagado'` con label dinámico "Ver/Editar Pagos".

## Cambios

- `migrations/053_editar_forma_pago_pago.sql` — nuevo RPC (ya aplicado en remoto via MCP).
- `src/hooks/supabase/usePagos.ts` + `src/types/hooks.ts` — método `actualizarFormaPagoDePago`.
- `src/components/modals/ModalPagoPedido.tsx` — prop `onEditarFormaPago` + `<select>` editable + loader inline en cada fila de pagos previos.
- `src/components/pedidos/PedidoActions.tsx` — condición relajada y label dinámico.
- `src/components/containers/PedidosContainer.tsx` — handler `handleEditarFormaPagoPedido` cableado al modal.

## Test plan

- [ ] Como admin: marcar pedido pagado con "efectivo", abrir "Ver/Editar Pagos", cambiar a "transferencia" → fila de `pagos` actualizada, `pedidos.forma_pago` resincronizada, fila en `pedido_historial` con `campo_modificado = 'forma_pago_pago_<id>'`.
- [ ] Como encargado: mismo flujo, debe funcionar.
- [ ] Confirmar la `rendicion_control` del día y reintentar — debe fallar con "Rendicion ya cerrada para esta fecha. No se puede modificar." (incluso como admin).
- [ ] Pedido con 2 pagos parciales (ej: 70% transferencia, 30% efectivo): editar el de 30% a cheque → `pedidos.forma_pago` debe permanecer en 'transferencia' (mayor monto).
- [ ] Como preventista: invocar el RPC directo → debe fallar con 42501.

🤖 Generated with [Claude Code](https://claude.com/claude-code)