### PR TITLE
fix(usuarios): badge y zona del rol preventista_taco

### DIFF
--- a/src/components/containers/UsuariosContainer.tsx
+++ b/src/components/containers/UsuariosContainer.tsx
@@ -47,7 +47,7 @@ export default function UsuariosContainer(): React.ReactElement {
           nombre: usuario.nombre,
           rol: usuario.rol,
           activo: usuario.activo,
-          zona: usuario.rol === 'preventista' ? usuario.zona || null : null
+          zona: (usuario.rol === 'preventista' || usuario.rol === 'preventista_taco') ? usuario.zona || null : null
         }
       })
       notify.success('Usuario actualizado')

--- a/src/hooks/supabase/useUsuarios.ts
+++ b/src/hooks/supabase/useUsuarios.ts
@@ -47,7 +47,7 @@ export function useUsuarios(): UseUsuariosReturn {
       nombre: datos.nombre,
       rol: datos.rol,
       activo: datos.activo,
-      zona: datos.rol === 'preventista' ? (datos.zona || null) : null
+      zona: (datos.rol === 'preventista' || datos.rol === 'preventista_taco') ? (datos.zona || null) : null
     }
     const { data, error } = await supabase.from('perfiles').update(updateData).eq('id', id).select().single()
     if (error) throw error

--- a/src/utils/formatters.ts
+++ b/src/utils/formatters.ts
@@ -352,6 +352,7 @@ export const getRolColor = (r: RolUsuario | string | null | undefined): string =
   r === 'deposito' ? 'bg-emerald-100 text-emerald-700' :
   r === 'transportista' ? 'bg-orange-100 text-orange-700' :
   r === 'preventista' ? 'bg-blue-100 text-blue-700' :
+  r === 'preventista_taco' ? 'bg-cyan-100 text-cyan-700' :
   'bg-gray-100 text-gray-700';
 
 export const getRolLabel = (r: RolUsuario | string | null | undefined): string =>
@@ -360,6 +361,7 @@ export const getRolLabel = (r: RolUsuario | string | null | undefined): string =
   r === 'deposito' ? 'Deposito' :
   r === 'transportista' ? 'Transportista' :
   r === 'preventista' ? 'Preventista' :
+  r === 'preventista_taco' ? 'Preventista Taco' :
   'Sin rol';
 
 export const getEstadoPagoColor = (estado: EstadoPago | string | null | undefined): string =>


### PR DESCRIPTION
## Resumen

Al asignar el rol `preventista_taco` desde Configuracion → Users, dos cosas fallaban silenciosamente:

1. La tabla de usuarios mostraba el badge **"Sin rol"** en gris en lugar de "Preventista Taco".
2. La **zona** asignada se borraba al guardar (quedaba en `null` en `perfiles.zona`), porque el upsert solo preservaba zona cuando `rol === 'preventista'`.

## Cambios

- `utils/formatters.ts` — `getRolColor` agrega chip cyan para `preventista_taco`; `getRolLabel` devuelve `"Preventista Taco"` en vez del fallback `"Sin rol"`.
- `hooks/supabase/useUsuarios.ts` — `actualizarUsuario` preserva `zona` cuando `rol === 'preventista' || rol === 'preventista_taco'`.
- `components/containers/UsuariosContainer.tsx` — mismo arreglo en `handleGuardarUsuario`.

## Test plan

- [ ] Editar usuario → asignar "Preventista Taco" + zona → guardar.
- [ ] La fila vuelve con badge cyan "Preventista Taco" (no "Sin rol").
- [ ] Reabrir el modal: la zona quedo persistida.
- [ ] Loguear con ese usuario: ve clientes solo de su zona, dashboard sin montos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)