### PR TITLE
feat(clientes): aplica estetica editorial de pedidos + fix padding ficha

### DIFF
--- a/src/components/clientes/ClienteStats.tsx
+++ b/src/components/clientes/ClienteStats.tsx
@@ -1,0 +1,195 @@
+/**
+ * Componente de estadísticas/resumen de clientes
+ *
+ * Cálculos in-memory sobre el array completo de clientes (no paginado), que
+ * ya está cargado en RAM. Diseño editorial cálido — gemelo a PedidoStats.
+ *
+ * Gating:
+ *  - Si el rol no puede ver saldos (preventista_taco), se ocultan las tarjetas
+ *    "Con deuda", "Al día" y "Saldo adeudado".
+ */
+import React, { memo, useMemo } from 'react';
+import { Users, AlertTriangle, Check, DollarSign, MapPin, Tag, type LucideIcon } from 'lucide-react';
+import { formatPrecio } from '../../utils/formatters';
+import { puedeVerSaldoCliente } from '../../lib/permisos';
+import { useAuthData } from '../../contexts/AuthDataContext';
+import type { ClienteDB } from '../../types';
+
+export interface ClienteStatsProps {
+  clientes: ClienteDB[];
+}
+
+interface StatItem {
+  key: string;
+  label: string;
+  icon: LucideIcon;
+  count: number;
+  detail?: string;
+  accentBorder: string;
+  accentText: string;
+  badgeBg: string;
+  badgeIcon: string;
+  gradientFrom: string;
+  /** Si true y el rol no ve saldos, se oculta la card. */
+  requiereSaldo?: boolean;
+}
+
+function ClienteStats({ clientes }: ClienteStatsProps): React.ReactElement {
+  const { perfil } = useAuthData();
+  const verSaldo = puedeVerSaldoCliente(perfil?.rol);
+
+  const summary = useMemo(() => {
+    let conDeuda = 0;
+    let alDia = 0;
+    let saldoTotal = 0;
+    let geo = 0;
+    const rubrosSet = new Set<string>();
+
+    for (const c of clientes) {
+      const saldo = c.saldo_cuenta ?? 0;
+      if (saldo > 0) {
+        conDeuda += 1;
+        saldoTotal += saldo;
+      } else {
+        alDia += 1;
+      }
+      if (c.latitud != null && c.longitud != null) geo += 1;
+      if (c.rubro) rubrosSet.add(c.rubro);
+    }
+
+    return {
+      total: clientes.length,
+      conDeuda,
+      alDia,
+      saldoTotal,
+      geo,
+      rubros: rubrosSet.size,
+    };
+  }, [clientes]);
+
+  const items: StatItem[] = [
+    {
+      key: 'total',
+      label: 'Total clientes',
+      icon: Users,
+      count: summary.total,
+      accentBorder: 'border-l-stone-400 dark:border-l-stone-500',
+      accentText: 'text-stone-800 dark:text-stone-200',
+      badgeBg: 'bg-stone-100 dark:bg-stone-500/15',
+      badgeIcon: 'text-stone-600 dark:text-stone-300',
+      gradientFrom: 'before:from-stone-500/[0.06]',
+    },
+    {
+      key: 'conDeuda',
+      label: 'Con deuda',
+      icon: AlertTriangle,
+      count: summary.conDeuda,
+      accentBorder: 'border-l-rose-500',
+      accentText: 'text-rose-700 dark:text-rose-300',
+      badgeBg: 'bg-rose-100 dark:bg-rose-500/15',
+      badgeIcon: 'text-rose-600 dark:text-rose-400',
+      gradientFrom: 'before:from-rose-500/[0.07]',
+      requiereSaldo: true,
+    },
+    {
+      key: 'alDia',
+      label: 'Al día',
+      icon: Check,
+      count: summary.alDia,
+      accentBorder: 'border-l-emerald-500',
+      accentText: 'text-emerald-700 dark:text-emerald-300',
+      badgeBg: 'bg-emerald-100 dark:bg-emerald-500/15',
+      badgeIcon: 'text-emerald-600 dark:text-emerald-400',
+      gradientFrom: 'before:from-emerald-500/[0.07]',
+      requiereSaldo: true,
+    },
+    {
+      key: 'saldoAdeudado',
+      label: 'Saldo adeudado',
+      icon: DollarSign,
+      count: summary.conDeuda,
+      detail: formatPrecio(summary.saldoTotal),
+      accentBorder: 'border-l-amber-500',
+      accentText: 'text-amber-700 dark:text-amber-300',
+      badgeBg: 'bg-amber-100 dark:bg-amber-500/15',
+      badgeIcon: 'text-amber-600 dark:text-amber-400',
+      gradientFrom: 'before:from-amber-500/[0.07]',
+      requiereSaldo: true,
+    },
+    {
+      key: 'geo',
+      label: 'Geolocalizados',
+      icon: MapPin,
+      count: summary.geo,
+      accentBorder: 'border-l-blue-500',
+      accentText: 'text-blue-700 dark:text-blue-300',
+      badgeBg: 'bg-blue-100 dark:bg-blue-500/15',
+      badgeIcon: 'text-blue-600 dark:text-blue-400',
+      gradientFrom: 'before:from-blue-500/[0.07]',
+    },
+    {
+      key: 'rubros',
+      label: 'Rubros',
+      icon: Tag,
+      count: summary.rubros,
+      accentBorder: 'border-l-orange-500',
+      accentText: 'text-orange-700 dark:text-orange-300',
+      badgeBg: 'bg-orange-100 dark:bg-orange-500/15',
+      badgeIcon: 'text-orange-600 dark:text-orange-400',
+      gradientFrom: 'before:from-orange-500/[0.07]',
+    },
+  ];
+
+  const visibleItems = items.filter(i => verSaldo || !i.requiereSaldo);
+
+  return (
+    <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-6 gap-3">
+      {visibleItems.map((item, idx) => {
+        const IconComponent = item.icon;
+        // Para la card "Saldo adeudado" mostramos el monto como número grande
+        // (con peso 800) y el count de clientes como detail.
+        const showMontoAsMain = item.key === 'saldoAdeudado';
+        return (
+          <div
+            key={item.key}
+            className={`group relative overflow-hidden bg-white dark:bg-gray-800 border border-stone-200 dark:border-gray-700 border-l-4 ${item.accentBorder} rounded-xl px-3.5 py-3 shadow-warm hover:shadow-warm-md hover:-translate-y-px transition-[transform,box-shadow] duration-200 before:absolute before:inset-0 before:bg-gradient-to-br ${item.gradientFrom} before:to-transparent before:pointer-events-none`}
+            style={{ animation: 'card-in 0.35s cubic-bezier(0.22, 1, 0.36, 1) both', animationDelay: `${idx * 35}ms` }}
+          >
+            <div className="relative flex items-start gap-2.5">
+              <span className={`inline-flex items-center justify-center w-7 h-7 rounded-lg flex-shrink-0 ${item.badgeBg}`}>
+                <IconComponent className={`w-3.5 h-3.5 ${item.badgeIcon}`} aria-hidden="true" />
+              </span>
+              <div className="min-w-0">
+                <p className="text-[10.5px] font-semibold uppercase tracking-[0.08em] text-stone-500 dark:text-stone-400 leading-tight">
+                  {item.label}
+                </p>
+                {showMontoAsMain ? (
+                  <>
+                    <p
+                      className={`text-2xl tabular-nums leading-tight mt-0.5 ${item.accentText} truncate`}
+                      style={{ fontWeight: 800, letterSpacing: '-0.025em' }}
+                    >
+                      {item.detail}
+                    </p>
+                    <p className="text-xs tabular-nums text-stone-500 dark:text-stone-400 mt-0.5 truncate">
+                      {item.count} {item.count === 1 ? 'cliente' : 'clientes'}
+                    </p>
+                  </>
+                ) : (
+                  <p
+                    className={`text-2xl tabular-nums leading-tight mt-0.5 ${item.accentText}`}
+                    style={{ fontWeight: 800, letterSpacing: '-0.025em' }}
+                  >
+                    {item.count.toLocaleString('es-AR')}
+                  </p>
+                )}
+              </div>
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+export default memo(ClienteStats);

--- a/src/components/clientes/ClientesViewHeader.tsx
+++ b/src/components/clientes/ClientesViewHeader.tsx
@@ -1,0 +1,107 @@
+/**
+ * Header del panel de Clientes.
+ *
+ * Estructura visual (editorial cálido, gemela a PedidosViewHeader):
+ *
+ *   ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─
+ *   CARTERA  ✦  MARTES 22 DE ABRIL  ✦  649 CLIENTES
+ *
+ *   Clientes con deuda                         [actions]
+ *   ───
+ *
+ * El sufijo dinámico ("con deuda / al día / del rubro X / ...") refleja los
+ * filtros activos y se anima al cambiar.
+ */
+import React from 'react';
+
+export interface ClientesViewHeaderProps {
+  totalClientes: number;
+  loading: boolean;
+  /** Sufijo descriptivo opcional (italic). Ej: "con deuda", "del rubro Almacén". */
+  filtroDescriptivo?: string | null;
+  /** Slot derecha (típicamente botones de acción). */
+  actions?: React.ReactNode;
+}
+
+const DIAS_SEMANA = [
+  'DOMINGO', 'LUNES', 'MARTES', 'MIÉRCOLES', 'JUEVES', 'VIERNES', 'SÁBADO',
+] as const;
+
+const MESES = [
+  'ENERO', 'FEBRERO', 'MARZO', 'ABRIL', 'MAYO', 'JUNIO',
+  'JULIO', 'AGOSTO', 'SEPTIEMBRE', 'OCTUBRE', 'NOVIEMBRE', 'DICIEMBRE',
+] as const;
+
+function formatDiaLargo(now: Date): string {
+  return `${DIAS_SEMANA[now.getDay()]} ${now.getDate()} DE ${MESES[now.getMonth()]}`;
+}
+
+/** Rombito amber sutil entre items del crumb. */
+function CrumbDot() {
+  return (
+    <span
+      className="inline-block w-1 h-1 rounded-full bg-amber-500/70 align-middle mx-2.5"
+      aria-hidden="true"
+    />
+  );
+}
+
+export default function ClientesViewHeader({
+  totalClientes,
+  loading,
+  filtroDescriptivo,
+  actions,
+}: ClientesViewHeaderProps): React.ReactElement {
+  const now = React.useMemo(() => new Date(), []);
+  const diaLargo = formatDiaLargo(now);
+
+  const resultadosLabel = loading
+    ? 'ACTUALIZANDO…'
+    : `${totalClientes.toLocaleString('es-AR')} ${totalClientes === 1 ? 'CLIENTE' : 'CLIENTES'}`;
+
+  return (
+    <header className="flex flex-col sm:flex-row sm:items-end sm:justify-between gap-4 pb-1">
+      <div className="min-w-0 flex-1">
+        <p className="text-[10.5px] sm:text-xs font-semibold tracking-[0.18em] text-stone-500 dark:text-stone-400 uppercase flex items-center flex-wrap">
+          <span>Cartera</span>
+          <CrumbDot />
+          <span>{diaLargo}</span>
+          <CrumbDot />
+          <span className={loading ? 'animate-pulse' : ''}>{resultadosLabel}</span>
+        </p>
+
+        <h1
+          className="mt-2 text-3xl sm:text-4xl text-stone-900 dark:text-white leading-[1.05]"
+          style={{ fontWeight: 800, letterSpacing: '-0.035em' }}
+        >
+          <span className="bg-clip-text text-transparent bg-gradient-to-br from-stone-900 to-stone-700 dark:from-white dark:to-stone-300">
+            Clientes
+          </span>
+          {filtroDescriptivo && (
+            <>
+              {' '}
+              <em
+                key={filtroDescriptivo}
+                className="font-light italic text-stone-500 dark:text-stone-400 inline-block animate-[fadeSlideIn_300ms_ease-out]"
+                style={{ letterSpacing: '-0.02em' }}
+              >
+                {filtroDescriptivo}
+              </em>
+            </>
+          )}
+        </h1>
+
+        <div
+          className="mt-3 h-[2px] w-12 rounded-full bg-gradient-to-r from-blue-600 via-blue-500 to-transparent dark:from-blue-400 dark:via-blue-500"
+          aria-hidden="true"
+        />
+      </div>
+
+      {actions && (
+        <div className="flex-shrink-0 sm:max-w-[62%]">
+          {actions}
+        </div>
+      )}
+    </header>
+  );
+}

--- a/src/components/modals/ModalFichaCliente.tsx
+++ b/src/components/modals/ModalFichaCliente.tsx
@@ -85,7 +85,7 @@ export default function ModalFichaCliente({ cliente, onClose, onRegistrarPago, o
     <ModalBase title="Ficha Cliente" description={cliente.nombre_fantasia} onClose={onClose} maxWidth="max-w-4xl">
       <div className="flex flex-col">
         {/* Header */}
-        <div className="pb-6 border-b border-gray-200 dark:border-gray-700">
+        <div className="px-5 pt-5 pb-5 border-b border-gray-200 dark:border-gray-700">
           <div className="flex items-start gap-4">
             <div className="w-16 h-16 bg-gradient-to-br from-blue-500 to-blue-600 rounded-xl flex items-center justify-center shrink-0">
               <User className="w-8 h-8 text-white" />
@@ -195,7 +195,7 @@ export default function ModalFichaCliente({ cliente, onClose, onRegistrarPago, o
         </div>
 
         {/* Tabs (taco no ve la pestaña Pagos) */}
-        <div className="flex border-b border-gray-200 dark:border-gray-700">
+        <div className="flex border-b border-gray-200 dark:border-gray-700 px-5">
           {(([
             { id: 'resumen', label: 'Resumen', icon: TrendingUp },
             { id: 'pedidos', label: 'Pedidos', icon: ShoppingBag },
@@ -217,7 +217,7 @@ export default function ModalFichaCliente({ cliente, onClose, onRegistrarPago, o
         </div>
 
         {/* Content */}
-        <div className="flex-1 overflow-y-auto p-6">
+        <div className="flex-1 overflow-y-auto px-5 py-5">
           {loading || loadingPagos ? (
             <div className="flex items-center justify-center h-48">
               <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600" />

--- a/src/components/vistas/VistaClientes.tsx
+++ b/src/components/vistas/VistaClientes.tsx
@@ -3,14 +3,20 @@ import type { ChangeEvent } from 'react';
 import { Users, Plus, Edit2, Trash2, Search, MapPin, Phone, FileText, Tag, Building2 } from 'lucide-react';
 import LoadingSpinner from '../layout/LoadingSpinner';
 import Paginacion from '../layout/Paginacion';
+import ClientesViewHeader from '../clientes/ClientesViewHeader';
+import ClienteStats from '../clientes/ClienteStats';
 import { useZonasEstandarizadasQuery } from '../../hooks/queries';
+import { puedeVerSaldoCliente } from '../../lib/permisos';
+import { useAuthData } from '../../contexts/AuthDataContext';
+import { formatPrecio } from '../../utils/formatters';
+import { cn } from '../../lib/utils';
 import type { ClienteDB } from '../../types';
 
 const ITEMS_PER_PAGE = 18;
 
 /** Normalizar texto: colapsar espacios (incluyendo non-breaking space), trim, lowercase */
 const normalizeSearch = (s: string | null | undefined): string =>
-  s?.replace(/[\s\u00A0]+/g, ' ').trim().toLowerCase() ?? '';
+  s?.replace(/\s+/g, ' ').trim().toLowerCase() ?? '';
 
 // =============================================================================
 // INTERFACES DE PROPS
@@ -30,6 +36,10 @@ export interface VistaClientesProps {
   onGestionarZonas?: () => void;
 }
 
+// =============================================================================
+// COMPONENT
+// =============================================================================
+
 export default function VistaClientes({
   clientes,
   loading,
@@ -42,10 +52,12 @@ export default function VistaClientes({
   onVerFichaCliente,
   onGestionarZonas
 }: VistaClientesProps) {
+  const { perfil } = useAuthData();
+  const verSaldo = puedeVerSaldoCliente(perfil?.rol);
+
   const [busqueda, setBusqueda] = useState<string>('');
   const [paginaActual, setPaginaActual] = useState(1);
 
-  // Obtener rubros únicos
   const rubros = useMemo((): string[] => {
     const rubrosSet = new Set<string>(clientes.map(c => c.rubro).filter((r): r is string => Boolean(r)));
     return ['todos', ...Array.from(rubrosSet).sort()];
@@ -57,11 +69,8 @@ export default function VistaClientes({
   const [filtroZonaId, setFiltroZonaId] = useState<string>('');
   const [filtroSaldo, setFiltroSaldo] = useState<'todos' | 'deben' | 'no_deben'>('todos');
 
-  // Solo zonas activas para el dropdown de filtro (las inactivas no son
-  // útiles aquí — para verlas/reactivarlas está el ModalZonas).
   const { data: zonas = [] } = useZonasEstandarizadasQuery();
 
-  // Filtrar clientes
   const clientesFiltrados = useMemo((): ClienteDB[] => {
     const busquedaNorm = normalizeSearch(busqueda);
     return clientes.filter((c: ClienteDB) => {
@@ -77,7 +86,6 @@ export default function VistaClientes({
 
       const matchZona = !filtroZonaId || (c.zona_id != null && String(c.zona_id) === filtroZonaId);
 
-      // Saldo positivo = el cliente debe. 0 o ausente = no debe.
       const saldo = c.saldo_cuenta ?? 0;
       const matchSaldo =
         filtroSaldo === 'todos' ||
@@ -88,14 +96,12 @@ export default function VistaClientes({
     });
   }, [clientes, busqueda, filtroRubro, filtroZonaId, filtroSaldo]);
 
-  // Pagination
   const totalPaginas = Math.ceil(clientesFiltrados.length / ITEMS_PER_PAGE);
   const clientesPaginados = useMemo(() => {
     const inicio = (paginaActual - 1) * ITEMS_PER_PAGE;
     return clientesFiltrados.slice(inicio, inicio + ITEMS_PER_PAGE);
   }, [clientesFiltrados, paginaActual]);
 
-  // Reset page when filters change
   const handleBusqueda = (e: ChangeEvent<HTMLInputElement>) => { setBusqueda(e.target.value); setPaginaActual(1); };
   const handleRubro = (e: ChangeEvent<HTMLSelectElement>) => { setFiltroRubro(e.target.value); setPaginaActual(1); };
   const handleZona = (e: ChangeEvent<HTMLSelectElement>) => { setFiltroZonaId(e.target.value); setPaginaActual(1); };
@@ -104,47 +110,86 @@ export default function VistaClientes({
     setPaginaActual(1);
   };
 
-  const filtrosActivos = busqueda || filtroRubro !== 'todos' || filtroZonaId !== '' || filtroSaldo !== 'todos';
+  const filtrosActivos = !!(busqueda || filtroRubro !== 'todos' || filtroZonaId !== '' || filtroSaldo !== 'todos');
+
+  // Compone un sufijo descriptivo italic para el header (ej: "con deuda", "del
+  // rubro Almacén", "de Centro"). Prioriza por especificidad: saldo > rubro >
+  // zona > búsqueda libre.
+  const filtroDescriptivo = useMemo((): string | null => {
+    if (filtroSaldo === 'deben') return 'con deuda';
+    if (filtroSaldo === 'no_deben') return 'al día';
+    if (filtroRubro !== 'todos') return `del rubro ${filtroRubro}`;
+    if (filtroZonaId) {
+      const z = zonas.find(z => String(z.id) === filtroZonaId);
+      return z ? `de ${z.nombre}` : null;
+    }
+    if (busqueda.trim()) return `que coinciden con "${busqueda.trim()}"`;
+    return null;
+  }, [filtroSaldo, filtroRubro, filtroZonaId, busqueda, zonas]);
+
+  const canCreate = isAdmin || isPreventista || isEncargado;
 
   return (
     <div className="space-y-4">
-      {/* Header */}
-      <div className="flex flex-col sm:flex-row justify-between items-start sm:items-center gap-4">
-        <div>
-          <h1 className="text-2xl font-bold text-gray-800 dark:text-white">Clientes</h1>
-          <p className="text-sm text-gray-500 dark:text-gray-400">{clientes.length} clientes registrados</p>
-        </div>
-        <div className="flex flex-wrap gap-2">
-          {isAdmin && onGestionarZonas && (
-            <button
-              onClick={onGestionarZonas}
-              className="flex items-center space-x-2 px-4 py-2 bg-purple-100 dark:bg-purple-900/30 text-purple-700 dark:text-purple-400 rounded-lg hover:bg-purple-200 dark:hover:bg-purple-900/50 transition-colors"
-            >
-              <MapPin className="w-5 h-5" />
-              <span>Gestionar Zonas</span>
-            </button>
-          )}
-          {(isAdmin || isPreventista || isEncargado) && (
-            <button
-              onClick={onNuevoCliente}
-              className="flex items-center space-x-2 px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors"
-            >
-              <Plus className="w-5 h-5" />
-              <span>Nuevo Cliente</span>
-            </button>
-          )}
-        </div>
-      </div>
+      {/* Header editorial */}
+      <ClientesViewHeader
+        totalClientes={clientes.length}
+        loading={loading}
+        filtroDescriptivo={filtroDescriptivo}
+        actions={
+          <div className="flex flex-wrap items-center gap-2 justify-end">
+            {isAdmin && onGestionarZonas && (
+              <button
+                onClick={onGestionarZonas}
+                className={cn(
+                  'inline-flex items-center gap-2.5 h-11 px-5 rounded-lg text-[14px] font-medium',
+                  'bg-white dark:bg-gray-800 text-stone-700 dark:text-gray-200',
+                  'border border-stone-200/80 dark:border-gray-700',
+                  'shadow-warm',
+                  'hover:bg-stone-50 dark:hover:bg-gray-700/50 hover:border-stone-300 dark:hover:border-gray-600 hover:-translate-y-px hover:shadow-warm-md',
+                  'active:translate-y-0 active:shadow-warm',
+                  'transition-[transform,box-shadow,background-color,border-color] duration-150',
+                )}
+              >
+                <MapPin className="w-[18px] h-[18px] text-purple-600" aria-hidden="true" />
+                <span>Gestionar Zonas</span>
+              </button>
+            )}
+            {canCreate && (
+              <button
+                onClick={onNuevoCliente}
+                className={cn(
+                  'group relative inline-flex items-center gap-2.5 h-11 px-6 rounded-lg text-[14px] font-semibold',
+                  'text-white',
+                  'bg-gradient-to-br from-green-500 to-green-600',
+                  'shadow-[0_2px_8px_-2px_rgb(34_197_94/0.45),inset_0_1px_0_rgb(255_255_255/0.12)]',
+                  'hover:from-green-500 hover:to-green-700 hover:-translate-y-px hover:shadow-[0_6px_16px_-4px_rgb(34_197_94/0.55),inset_0_1px_0_rgb(255_255_255/0.18)]',
+                  'active:translate-y-0 active:shadow-[0_2px_4px_-2px_rgb(34_197_94/0.4)]',
+                  'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-green-500/40 focus-visible:ring-offset-2 focus-visible:ring-offset-stone-50 dark:focus-visible:ring-offset-gray-900',
+                  'transition-[transform,box-shadow,background] duration-200',
+                )}
+              >
+                <span
+                  className="absolute inset-0 rounded-lg bg-gradient-to-br from-white/10 to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-200 pointer-events-none"
+                  aria-hidden="true"
+                />
+                <Plus className="relative w-[18px] h-[18px]" aria-hidden="true" />
+                <span className="relative">Nuevo cliente</span>
+              </button>
+            )}
+          </div>
+        }
+      />
 
       {/* Filtros */}
-      <div className="flex flex-col sm:flex-row gap-4">
+      <div className="flex flex-col sm:flex-row gap-2 items-stretch">
         <div className="relative flex-1">
-          <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 text-gray-400 w-5 h-5" aria-hidden="true" />
+          <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-stone-400" aria-hidden="true" />
           <input
             type="text"
             value={busqueda}
             onChange={handleBusqueda}
-            className="w-full pl-10 pr-3 py-2 border dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-blue-500 dark:bg-gray-700 dark:text-white"
+            className="w-full h-10 sm:h-9 pl-9 pr-3 rounded-lg border text-sm bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-200 border-stone-200 dark:border-gray-700 placeholder:text-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500/40 focus:border-blue-400"
             placeholder="Buscar por nombre, CUIT, dirección o teléfono..."
             aria-label="Buscar clientes por nombre, CUIT, dirección o teléfono"
           />
@@ -156,7 +201,7 @@ export default function VistaClientes({
               id="filtro-rubro-clientes"
               value={filtroRubro}
               onChange={handleRubro}
-              className="px-4 py-2 border rounded-lg focus:ring-2 focus:ring-blue-500 dark:bg-gray-700 dark:border-gray-600 dark:text-white"
+              className="h-10 sm:h-9 pl-3 pr-8 rounded-lg border text-sm appearance-none bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-200 border-stone-200 dark:border-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-500/40 focus:border-blue-400"
             >
               {rubros.map(rubro => (
                 <option key={rubro} value={rubro}>
@@ -173,7 +218,7 @@ export default function VistaClientes({
               id="filtro-zona-clientes"
               value={filtroZonaId}
               onChange={handleZona}
-              className="px-4 py-2 border rounded-lg focus:ring-2 focus:ring-blue-500 dark:bg-gray-700 dark:border-gray-600 dark:text-white"
+              className="h-10 sm:h-9 pl-3 pr-8 rounded-lg border text-sm appearance-none bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-200 border-stone-200 dark:border-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-500/40 focus:border-blue-400"
             >
               <option value="">Todas las zonas</option>
               {zonas.map(z => (
@@ -188,7 +233,7 @@ export default function VistaClientes({
             id="filtro-saldo-clientes"
             value={filtroSaldo}
             onChange={handleSaldo}
-            className="px-4 py-2 border rounded-lg focus:ring-2 focus:ring-blue-500 dark:bg-gray-700 dark:border-gray-600 dark:text-white"
+            className="h-10 sm:h-9 pl-3 pr-8 rounded-lg border text-sm appearance-none bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-200 border-stone-200 dark:border-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-500/40 focus:border-blue-400"
           >
             <option value="todos">Estado de cuenta: Todos</option>
             <option value="deben">Deben</option>
@@ -197,111 +242,35 @@ export default function VistaClientes({
         </div>
       </div>
 
-      {/* Contador de resultados */}
+      {/* Stats */}
+      <ClienteStats clientes={clientes} />
+
+      {/* Contador de resultados (solo si hay filtros activos) */}
       {filtrosActivos && (
-        <div className="text-sm text-gray-600 dark:text-gray-400">
-          Mostrando {clientesFiltrados.length} de {clientes.length} clientes
+        <div className="text-xs font-medium uppercase tracking-[0.1em] text-stone-500 dark:text-stone-400">
+          Mostrando {clientesFiltrados.length.toLocaleString('es-AR')} de {clientes.length.toLocaleString('es-AR')} clientes
         </div>
       )}
 
       {/* Lista de clientes */}
       {loading ? <LoadingSpinner /> : clientesFiltrados.length === 0 ? (
-        <div className="text-center py-12 text-gray-500">
+        <div className="text-center py-12 text-stone-500">
           <Users className="w-12 h-12 mx-auto mb-3 opacity-50" />
           <p>{filtrosActivos ? 'No se encontraron clientes con esos criterios' : 'No hay clientes'}</p>
         </div>
       ) : (
         <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
-          {clientesPaginados.map(cliente => (
-            <div
+          {clientesPaginados.map((cliente, idx) => (
+            <ClienteCard
               key={cliente.id}
-              className="bg-white dark:bg-gray-800 border dark:border-gray-700 rounded-lg shadow-sm p-4 hover:shadow-md transition-shadow"
-            >
-              <div className="flex justify-between items-start">
-                <div className="flex-1 min-w-0">
-                  <div className="flex items-center gap-2 flex-wrap">
-                    {cliente.codigo != null && (
-                      <span className="px-1.5 py-0.5 bg-blue-100 dark:bg-blue-900/30 text-blue-700 dark:text-blue-300 rounded text-xs font-mono font-semibold">
-                        #{cliente.codigo}
-                      </span>
-                    )}
-                    <h3 className="font-semibold text-lg text-gray-800 dark:text-white truncate">
-                      {cliente.nombre_fantasia}
-                    </h3>
-                    {cliente.rubro && (
-                      <span className="px-2 py-0.5 bg-purple-100 dark:bg-purple-900/30 text-purple-700 dark:text-purple-300 rounded-full text-xs flex items-center gap-1">
-                        <Tag className="w-3 h-3" />
-                        {cliente.rubro}
-                      </span>
-                    )}
-                  </div>
-                  <p className="text-sm text-gray-600 dark:text-gray-400 truncate flex items-center gap-1">
-                    <Building2 className="w-3 h-3 flex-shrink-0" />
-                    {cliente.razon_social}
-                  </p>
-                  {cliente.cuit && (
-                    <p className="text-xs text-gray-500 dark:text-gray-400 font-mono">{cliente.cuit}</p>
-                  )}
-                </div>
-                {isAdmin && (
-                  <div className="flex space-x-1 ml-2">
-                    <button
-                      onClick={() => onEditarCliente(cliente)}
-                      className="p-2 text-blue-500 hover:bg-blue-50 dark:hover:bg-blue-900/30 rounded-lg transition-colors"
-                      aria-label={`Editar cliente ${cliente.nombre_fantasia}`}
-                    >
-                      <Edit2 className="w-4 h-4" aria-hidden="true" />
-                    </button>
-                    <button
-                      onClick={() => onEliminarCliente(cliente.id)}
-                      className="p-2 text-red-500 hover:bg-red-50 dark:hover:bg-red-900/30 rounded-lg transition-colors"
-                      aria-label={`Eliminar cliente ${cliente.nombre_fantasia}`}
-                    >
-                      <Trash2 className="w-4 h-4" aria-hidden="true" />
-                    </button>
-                  </div>
-                )}
-              </div>
-
-              <div className="mt-3 space-y-2 text-sm text-gray-500 dark:text-gray-400">
-                <div className="flex items-start space-x-2">
-                  <MapPin className="w-4 h-4 mt-0.5 flex-shrink-0 text-gray-400 dark:text-gray-500" />
-                  <span className="break-words">{cliente.direccion}</span>
-                </div>
-                {cliente.telefono && (
-                  <div className="flex items-center space-x-2">
-                    <Phone className="w-4 h-4 flex-shrink-0 text-gray-400" />
-                    <a
-                      href={`tel:${cliente.telefono}`}
-                      className="text-blue-600 hover:underline"
-                    >
-                      {cliente.telefono}
-                    </a>
-                  </div>
-                )}
-              </div>
-
-              {/* Indicador de coordenadas */}
-              {cliente.latitud && cliente.longitud && (
-                <div className="mt-3 pt-2 border-t border-gray-100 dark:border-gray-700">
-                  <span className="text-xs text-green-600 flex items-center">
-                    <MapPin className="w-3 h-3 mr-1" />
-                    Ubicación geocodificada
-                  </span>
-                </div>
-              )}
-
-              {/* Ver Ficha Button */}
-              {onVerFichaCliente && (
-                <button
-                  onClick={() => onVerFichaCliente(cliente)}
-                  className="mt-3 w-full flex items-center justify-center gap-2 px-3 py-2 bg-blue-50 dark:bg-blue-900/20 text-blue-600 dark:text-blue-400 rounded-lg hover:bg-blue-100 dark:hover:bg-blue-900/30 transition-colors text-sm font-medium"
-                >
-                  <FileText className="w-4 h-4" />
-                  Ver Ficha de Cliente
-                </button>
-              )}
-            </div>
+              cliente={cliente}
+              idx={idx}
+              isAdmin={isAdmin}
+              verSaldo={verSaldo}
+              onEditar={() => onEditarCliente(cliente)}
+              onEliminar={() => onEliminarCliente(cliente.id)}
+              onVerFicha={onVerFichaCliente ? () => onVerFichaCliente(cliente) : undefined}
+            />
           ))}
         </div>
       )}
@@ -313,6 +282,155 @@ export default function VistaClientes({
         totalItems={clientesFiltrados.length}
         itemsLabel="clientes"
       />
+    </div>
+  );
+}
+
+// =============================================================================
+// CLIENTE CARD
+// =============================================================================
+
+interface ClienteCardProps {
+  cliente: ClienteDB;
+  idx: number;
+  isAdmin: boolean;
+  verSaldo: boolean;
+  onEditar: () => void;
+  onEliminar: () => void;
+  onVerFicha?: () => void;
+}
+
+function ClienteCard({ cliente, idx, isAdmin, verSaldo, onEditar, onEliminar, onVerFicha }: ClienteCardProps) {
+  const saldo = cliente.saldo_cuenta ?? 0;
+  const saldoColor =
+    saldo > 0 ? 'text-rose-700 dark:text-rose-300'
+    : saldo < 0 ? 'text-emerald-700 dark:text-emerald-300'
+    : 'text-stone-500 dark:text-stone-400';
+
+  return (
+    <div
+      className="group bg-white dark:bg-gray-800 border border-stone-200/80 dark:border-gray-700 rounded-xl shadow-warm hover:shadow-warm-md hover:-translate-y-px hover:border-stone-300 dark:hover:border-gray-600 transition-[transform,box-shadow,border-color] duration-200 overflow-hidden flex flex-col"
+      style={{
+        animation: 'card-in 0.32s cubic-bezier(0.22, 1, 0.36, 1) both',
+        animationDelay: `${Math.min(idx, 12) * 40}ms`,
+      }}
+    >
+      {/* Crumb + acciones admin */}
+      <div className="px-4 pt-3 flex items-center justify-between gap-2">
+        <div className="text-[10.5px] font-semibold uppercase tracking-[0.18em] text-stone-500 dark:text-stone-400 flex items-center gap-0 min-w-0 flex-wrap">
+          {cliente.codigo != null && (
+            <span className="tabular-nums">#{cliente.codigo}</span>
+          )}
+          {cliente.codigo != null && cliente.rubro && (
+            <span
+              className="inline-block w-1 h-1 rounded-full bg-amber-500/70 align-middle mx-2"
+              aria-hidden="true"
+            />
+          )}
+          {cliente.rubro && (
+            <span className="inline-flex items-center gap-1 truncate">
+              <Tag className="w-3 h-3" aria-hidden="true" />
+              {cliente.rubro}
+            </span>
+          )}
+        </div>
+        {isAdmin && (
+          <div className="flex gap-0.5 flex-shrink-0">
+            <button
+              onClick={onEditar}
+              className="p-1.5 text-stone-500 hover:text-blue-600 hover:bg-blue-50 dark:hover:bg-blue-900/30 rounded-md transition-colors"
+              aria-label={`Editar cliente ${cliente.nombre_fantasia}`}
+            >
+              <Edit2 className="w-3.5 h-3.5" aria-hidden="true" />
+            </button>
+            <button
+              onClick={onEliminar}
+              className="p-1.5 text-stone-500 hover:text-rose-600 hover:bg-rose-50 dark:hover:bg-rose-900/30 rounded-md transition-colors"
+              aria-label={`Eliminar cliente ${cliente.nombre_fantasia}`}
+            >
+              <Trash2 className="w-3.5 h-3.5" aria-hidden="true" />
+            </button>
+          </div>
+        )}
+      </div>
+
+      {/* Nombre fantasía */}
+      <h3 className="px-4 mt-1 text-lg font-semibold text-stone-900 dark:text-white leading-tight break-words">
+        {cliente.nombre_fantasia}
+      </h3>
+
+      {/* Razón social */}
+      {cliente.razon_social && (
+        <p className="px-4 mt-0.5 text-sm text-stone-500 dark:text-stone-400 flex items-center gap-1.5 min-w-0">
+          <Building2 className="w-3.5 h-3.5 flex-shrink-0" aria-hidden="true" />
+          <span className="truncate">{cliente.razon_social}</span>
+        </p>
+      )}
+
+      {/* CUIT */}
+      {cliente.cuit && (
+        <p className="px-4 mt-0.5 text-xs text-stone-400 dark:text-stone-500 font-mono tabular-nums">
+          {cliente.cuit}
+        </p>
+      )}
+
+      {/* Contacto */}
+      <div className="px-4 mt-2 space-y-1.5 text-sm text-stone-600 dark:text-stone-300">
+        {cliente.direccion && (
+          <div className="flex items-start gap-1.5">
+            <MapPin className="w-4 h-4 mt-0.5 flex-shrink-0 text-stone-400 dark:text-stone-500" aria-hidden="true" />
+            <span className="break-words">{cliente.direccion}</span>
+          </div>
+        )}
+        {cliente.telefono && (
+          <div className="flex items-center gap-1.5">
+            <Phone className="w-4 h-4 flex-shrink-0 text-stone-400" aria-hidden="true" />
+            <a href={`tel:${cliente.telefono}`} className="text-blue-600 dark:text-blue-400 hover:underline">
+              {cliente.telefono}
+            </a>
+          </div>
+        )}
+      </div>
+
+      {/* Geo pill */}
+      {cliente.latitud != null && cliente.longitud != null && (
+        <span className="ml-4 mt-2 inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[11px] font-medium bg-emerald-50 text-emerald-700 border border-emerald-200/60 dark:bg-emerald-900/20 dark:text-emerald-300 dark:border-emerald-800/40 self-start">
+          <MapPin className="w-3 h-3" aria-hidden="true" />
+          Geolocalizado
+        </span>
+      )}
+
+      {/* Spacer para empujar el footer abajo */}
+      <div className="flex-1 min-h-[12px]" />
+
+      {/* Footer con gradient + saldo + botón Ver Ficha */}
+      <div className="mt-3 px-4 py-3 bg-gradient-to-br from-stone-50/70 via-stone-50/40 to-blue-50/30 dark:from-gray-900/50 dark:via-gray-900/30 dark:to-blue-900/10 border-t border-stone-200/70 dark:border-gray-700/60 flex items-end justify-between gap-2">
+        {verSaldo ? (
+          <div className="min-w-0">
+            <p className="text-[10px] font-semibold uppercase tracking-[0.14em] text-stone-500 dark:text-stone-400 leading-none">
+              Saldo
+            </p>
+            <p
+              className={`mt-1 text-base tabular-nums leading-none truncate ${saldoColor}`}
+              style={{ fontWeight: 800, letterSpacing: '-0.025em' }}
+              title={saldo > 0 ? 'Cliente con deuda' : saldo < 0 ? 'Saldo a favor del cliente' : 'Sin saldo pendiente'}
+            >
+              {formatPrecio(saldo)}
+            </p>
+          </div>
+        ) : (
+          <div className="flex-1" />
+        )}
+        {onVerFicha && (
+          <button
+            onClick={onVerFicha}
+            className="inline-flex items-center gap-1.5 h-8 px-3 rounded-lg text-xs font-semibold bg-white dark:bg-gray-800 border border-stone-200/80 dark:border-gray-700 text-stone-700 dark:text-gray-200 shadow-warm hover:shadow-warm-md hover:-translate-y-px hover:border-stone-300 dark:hover:border-gray-600 transition-[transform,box-shadow,border-color] duration-150 flex-shrink-0"
+          >
+            <FileText className="w-3.5 h-3.5" aria-hidden="true" />
+            Ver ficha
+          </button>
+        )}
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Unifica el lenguaje visual de la sección **Clientes** con el sistema editorial cálido ya aplicado en **Pedidos**, y arregla el padding del modal de ficha del cliente (los datos del cliente y las tabs estaban pegados a los bordes laterales).

## Cambios

### Nuevos componentes
- **`src/components/clientes/ClientesViewHeader.tsx`** — Header editorial gemelo a `PedidosViewHeader`:
  - Crumb `CARTERA ✦ {DÍA} ✦ {N} CLIENTES` con rombos amber
  - Título "Clientes" peso 800 con gradient stone + subrayado azul
  - Sufijo italic dinámico (`con deuda`, `del rubro Almacén`, `de Centro`, etc.) que se anima al cambiar de filtro
- **`src/components/clientes/ClienteStats.tsx`** — Fila de 6 KPIs estilo `PedidoStats`:
  - Total clientes (stone) / Con deuda (rose) / Al día (emerald) / Saldo adeudado (amber, $) / Geolocalizados (blue) / Rubros (orange)
  - `border-l-4` de color por estado, badge con icono, número peso 800 tabular-nums
  - Stagger `card-in` animation
  - Las cards "Con deuda", "Al día" y "Saldo adeudado" se ocultan automáticamente para `preventista_taco` via `puedeVerSaldoCliente`

### Vistas y modales modificados
- **`src/components/vistas/VistaClientes.tsx`** — Reescrita:
  - Botón "Nuevo cliente" primario verde con gradient (gemelo a "Nuevo pedido")
  - Botón "Gestionar Zonas" estilo *warm secondary* con icono purple
  - Filtros con focus-ring `blue-500/40`, `h-9`, rounded-lg consistentes con pedidos
  - Cards rediseñadas: `shadow-warm`, `border-stone-200/80`, hover-lift de 1px, crumb editorial con código + rubro, footer con gradient sutil que muestra saldo coloreado (rose si debe, emerald si a favor, stone si \$0) + botón "Ver ficha" warm
  - Stagger animation con delay capado a 12
- **`src/components/modals/ModalFichaCliente.tsx`** — Fix de padding:
  - Header del cliente: `pb-6 border-b` → `px-5 pt-5 pb-5 border-b`
  - Tab strip: `flex border-b` → `flex border-b px-5`
  - Content area: `p-6` → `px-5 py-5`
  - Resultado: padding lateral consistente de 20px en las tres secciones, eliminando el "pegado a los bordes"

## Notas para el reviewer

- **Sin cambios de datos ni lógica**: la migración es puramente visual. Toda la filtrería, búsqueda, paginación y handlers siguen comportándose igual.
- **Gating por rol**: el cálculo de KPIs sensibles (Con deuda / Al día / Saldo adeudado) y el saldo en las cards usan `puedeVerSaldoCliente` para que `preventista_taco` no vea esa info.
- **Animaciones reutilizadas**: `card-in` y `fadeSlideIn` ya existían en `tailwind.config.js`; no se agregaron keyframes nuevos.
- **`CrumbDot`** se duplica entre `PedidosViewHeader` y `ClientesViewHeader` (función de una línea). Decisión consciente para evitar abstracción prematura por un span.

## Test plan

- [ ] Abrir `/clientes` y verificar que el header, filtros, stats y cards se ven con la misma estética editorial cálida que `/pedidos`
- [ ] Probar los 4 filtros (búsqueda, rubro, zona, saldo): el sufijo italic del header debe actualizarse y los KPIs recalcular en vivo
- [ ] Abrir la ficha de un cliente y verificar que el avatar, datos y tab strip **no** están pegados a los bordes laterales
- [ ] Probar en mobile (375px): stats `grid-cols-2`, cards en 1 columna, botones del header apilados
- [ ] Toggle dark mode y revisar contraste en stats, cards, gradients
- [ ] Loguearse con un usuario `preventista_taco` y verificar que no se ven saldos ni los KPIs sensibles

## Verificación local

```
npm run typecheck   ✓ passes
npm run build       ✓ builds clean
npm run test:run    ✓ 674 tests pass
npx eslint          ✓ clean
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)