### PR TITLE
feat(geo): reverse geocoding GPS + navegacion turn-by-turn para tablet del chofer

### DIFF
--- a/src/components/modals/ModalCliente.tsx
+++ b/src/components/modals/ModalCliente.tsx
@@ -6,6 +6,7 @@ import { useZodValidation } from '../../hooks/useZodValidation';
 import { modalClienteSchema } from '../../lib/schemas';
 import { usePreventistasQuery, useZonasEstandarizadasQuery } from '../../hooks/queries';
 import { useGeolocationCapture } from '../../hooks/useGeolocationCapture';
+import { useReverseGeocoding } from '../../hooks/useReverseGeocoding';
 import {
   formatCuitInput,
   formatDniInput,
@@ -151,7 +152,13 @@ const ModalCliente = memo(function ModalCliente({ cliente, onSave, onClose, guar
   const [gpsCapturando, setGpsCapturando] = useState<boolean>(false);
   const [gpsError, setGpsError] = useState<string | null>(null);
   const [gpsAccuracy, setGpsAccuracy] = useState<number | null>(null);
+  // Marca cuando la direccion fue autocompletada por reverse geocoding tras
+  // un GPS. Permite mostrar un texto auxiliar invitando al usuario a corregir
+  // si la sugerencia no es exacta. Se borra al editar manualmente o usar el
+  // autocompletado de Google Places.
+  const [direccionDesdeGps, setDireccionDesdeGps] = useState<boolean>(false);
   const capturarGps = useGeolocationCapture();
+  const { reverseGeocode } = useReverseGeocoding();
 
   const handleCapturarGps = async (): Promise<void> => {
     if (gpsCapturando) return;
@@ -163,6 +170,19 @@ const ModalCliente = memo(function ModalCliente({ cliente, onSave, onClose, guar
         setForm(prev => ({ ...prev, latitud: result.lat, longitud: result.lng }));
         setGpsAccuracy(result.accuracy);
         if (errores.direccion) clearFieldError('direccion');
+        // Reverse geocoding: traducir coords a direccion legible. No bloquea
+        // el flujo si falla; el GPS ya capturo coords utiles. Sobreescribe
+        // la direccion actual con la sugerencia para que el usuario solo
+        // necesite revisar/editar.
+        try {
+          const rev = await reverseGeocode(result.lat, result.lng);
+          if (rev?.direccion) {
+            setForm(prev => ({ ...prev, direccion: rev.direccion }));
+            setDireccionDesdeGps(true);
+          }
+        } catch {
+          // Silencioso: la captura de coords ya fue exitosa.
+        }
       } else {
         const mensajes: Record<typeof result.status, string> = {
           denied: 'Permiso de ubicación denegado. Aceptá el permiso en la configuración del navegador y volvé a intentar.',
@@ -204,6 +224,7 @@ const ModalCliente = memo(function ModalCliente({ cliente, onSave, onClose, guar
     // previa para no mostrar un dato engañoso en el bloque "Coordenadas".
     setGpsAccuracy(null);
     setGpsError(null);
+    setDireccionDesdeGps(false);
     if (errores.direccion) clearFieldError('direccion');
   };
 
@@ -283,6 +304,11 @@ const ModalCliente = memo(function ModalCliente({ cliente, onSave, onClose, guar
     if (intentoGuardar && errores[field]) {
       clearFieldError(field);
     }
+    // Si el user edito manualmente la direccion, la "sugerencia GPS" deja
+    // de aplicar (ya tomo control).
+    if (field === 'direccion' && direccionDesdeGps) {
+      setDireccionDesdeGps(false);
+    }
   };
 
   const inputClass = (field: keyof ClienteFormData): string => `w-full px-3 py-2 border rounded-lg dark:bg-gray-700 dark:border-gray-600 dark:text-white ${errores[field] ? 'border-red-500 bg-red-50 dark:bg-red-900/20' : ''}`;
@@ -360,6 +386,11 @@ const ModalCliente = memo(function ModalCliente({ cliente, onSave, onClose, guar
             className={errores.direccion ? 'border-red-500' : ''}
           />
           {errores.direccion && <p {...getErrorMessageProps('direccion')} className="text-red-500 text-xs mt-1">{errores.direccion}</p>}
+          {direccionDesdeGps && !errores.direccion && (
+            <p className="text-xs text-blue-600 dark:text-blue-400 mt-1 italic">
+              Dirección sugerida por GPS — corregila si no coincide.
+            </p>
+          )}
 
           {/* Botón "Usar mi ubicación actual": complementa al autocomplete cuando
               la dirección no se encuentra o devuelve coords de otra localidad.

--- a/src/components/pedidos/VistaRutaTransportista.tsx
+++ b/src/components/pedidos/VistaRutaTransportista.tsx
@@ -2,8 +2,9 @@
  * Vista de ruta para transportista
  */
 import React, { useState, useMemo, useRef, memo } from 'react';
-import { Route, Truck, Check, MapPin, Phone, ChevronDown, ChevronUp, Navigation, AlertTriangle, Gift, WifiOff } from 'lucide-react';
+import { Route, Truck, Check, MapPin, Phone, ChevronDown, ChevronUp, Navigation, AlertTriangle, Gift, WifiOff, X } from 'lucide-react';
 import { formatPrecio, formatFecha, getFormaPagoLabel } from '../../utils/formatters';
+import { googleMapsNavUrl, wazeNavUrl, googleMapsSearchUrl } from '../../utils/navegacion';
 import type { PedidoDB, ClienteDB, ProductoDB, PedidoItemDB, MotivoSalvedad, RegistrarSalvedadResult } from '../../types';
 import { useAuthData } from '../../contexts/AuthDataContext';
 import ModalSalvedadItem from '../modals/ModalSalvedadItem';
@@ -101,16 +102,11 @@ function EntregaRutaCard({ pedido, orden, onMarcarEntregado, onReportarSalvedad 
               </span>
             </div>
 
-            {/* Direccion con link a maps */}
-            <a
-              href={`https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(pedido.cliente?.direccion || '')}`}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="flex items-start gap-2 mt-2 text-blue-600 dark:text-blue-400 hover:underline"
-            >
-              <MapPin className="w-4 h-4 mt-0.5 flex-shrink-0" />
+            {/* Direccion del cliente */}
+            <div className="flex items-start gap-2 mt-2 text-gray-700 dark:text-gray-300">
+              <MapPin className="w-4 h-4 mt-0.5 flex-shrink-0 text-gray-400" />
               <span className="text-sm">{pedido.cliente?.direccion || 'Sin direccion'}</span>
-            </a>
+            </div>
 
             {/* Aclaracion de direccion (info extra para el repartidor) */}
             {pedido.cliente?.aclaracion_direccion && (
@@ -118,6 +114,38 @@ function EntregaRutaCard({ pedido, orden, onMarcarEntregado, onReportarSalvedad 
                 {pedido.cliente.aclaracion_direccion}
               </p>
             )}
+
+            {/* Botones de navegacion turn-by-turn: Google Maps + Waze.
+                Usa lat/lng cuando estan disponibles para iniciar nav directa,
+                sino cae a search por direccion. */}
+            <div className="flex gap-2 mt-2">
+              <a
+                href={
+                  pedido.cliente?.latitud != null && pedido.cliente?.longitud != null
+                    ? googleMapsNavUrl(Number(pedido.cliente.latitud), Number(pedido.cliente.longitud))
+                    : googleMapsSearchUrl(pedido.cliente?.direccion || '')
+                }
+                target="_blank"
+                rel="noopener noreferrer"
+                className="flex items-center gap-1.5 px-3 py-1.5 bg-blue-50 dark:bg-blue-900/30 text-blue-700 dark:text-blue-300 hover:bg-blue-100 dark:hover:bg-blue-900/50 rounded-lg text-sm font-medium transition-colors"
+                aria-label="Iniciar navegacion en Google Maps"
+              >
+                <Navigation className="w-4 h-4" />
+                Google Maps
+              </a>
+              {pedido.cliente?.latitud != null && pedido.cliente?.longitud != null && (
+                <a
+                  href={wazeNavUrl(Number(pedido.cliente.latitud), Number(pedido.cliente.longitud))}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="flex items-center gap-1.5 px-3 py-1.5 bg-cyan-50 dark:bg-cyan-900/30 text-cyan-700 dark:text-cyan-300 hover:bg-cyan-100 dark:hover:bg-cyan-900/50 rounded-lg text-sm font-medium transition-colors"
+                  aria-label="Iniciar navegacion en Waze"
+                >
+                  <Navigation className="w-4 h-4" />
+                  Waze
+                </a>
+              )}
+            </div>
 
             {/* Telefono */}
             {pedido.cliente?.telefono && (
@@ -247,6 +275,10 @@ function VistaRutaTransportista({
   // entregado si el transportista cancelo).
   const pagoExitosoRef = useRef(false);
 
+  // Sheet de seleccion de app de navegacion (Maps vs Waze) para el FAB
+  // "Navegar al siguiente". Cuando es null el sheet no se muestra.
+  const [navAppSheet, setNavAppSheet] = useState<PedidoEnriquecido | null>(null);
+
   // Estado de conexion — en ruta es importante saber si quedo sin red.
   const { isOnline } = useAuthData();
 
@@ -291,6 +323,13 @@ function VistaRutaTransportista({
         return (a.orden_entrega || 999) - (b.orden_entrega || 999);
       });
   }, [pedidosEnriquecidos, userId]);
+
+  // Proxima entrega pendiente: el primer pedido en estado "asignado" segun el
+  // orden de la ruta optimizada. El FAB "Navegar al siguiente" abre nav hacia
+  // este punto. Si no hay pendientes, el FAB no se muestra.
+  const proximaEntrega = useMemo<PedidoEnriquecido | null>(() => {
+    return pedidosOrdenados.find(p => p.estado === 'asignado') || null;
+  }, [pedidosOrdenados]);
 
   const entregasPendientes = pedidosOrdenados.filter(p => p.estado === 'asignado').length;
   const entregasCompletadas = pedidosOrdenados.filter(p => p.estado === 'entregado').length;
@@ -473,6 +512,84 @@ function VistaRutaTransportista({
           onClose={handleCerrarModalPago}
           onConfirmar={handleConfirmarPago}
         />
+      )}
+
+      {/* FAB: Navegar al siguiente. Solo visible si hay un pedido pendiente.
+          Abre un sheet con dos opciones: Google Maps y Waze. */}
+      {proximaEntrega && (
+        <button
+          onClick={() => setNavAppSheet(proximaEntrega)}
+          className="fixed bottom-6 right-6 z-40 flex items-center gap-2 px-5 py-4 bg-blue-600 hover:bg-blue-700 active:bg-blue-800 text-white rounded-full shadow-lg shadow-blue-600/50 transition-colors font-semibold min-h-[56px]"
+          aria-label="Iniciar navegacion al proximo pedido pendiente"
+        >
+          <Navigation className="w-5 h-5" />
+          <span>Navegar al siguiente</span>
+        </button>
+      )}
+
+      {/* Sheet de seleccion de app de navegacion. Sticky bottom para tablets. */}
+      {navAppSheet && (
+        <div
+          className="fixed inset-0 z-50 bg-black/50 flex items-end sm:items-center justify-center"
+          role="dialog"
+          aria-modal="true"
+          aria-label="Elegir app de navegacion"
+          onClick={() => setNavAppSheet(null)}
+        >
+          <div
+            className="bg-white dark:bg-gray-800 w-full sm:max-w-md rounded-t-2xl sm:rounded-2xl p-6 shadow-2xl"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <div className="flex items-start justify-between mb-1">
+              <h3 className="text-lg font-bold text-gray-900 dark:text-white">
+                Navegar al siguiente
+              </h3>
+              <button
+                onClick={() => setNavAppSheet(null)}
+                className="text-gray-400 hover:text-gray-600 dark:hover:text-gray-200"
+                aria-label="Cerrar"
+              >
+                <X className="w-5 h-5" />
+              </button>
+            </div>
+            <p className="text-sm text-gray-600 dark:text-gray-400 mb-4 truncate">
+              {navAppSheet.cliente?.nombre_fantasia || 'Cliente'} — {navAppSheet.cliente?.direccion || 'Sin direccion'}
+            </p>
+            <div className="space-y-3">
+              <a
+                href={
+                  navAppSheet.cliente?.latitud != null && navAppSheet.cliente?.longitud != null
+                    ? googleMapsNavUrl(Number(navAppSheet.cliente.latitud), Number(navAppSheet.cliente.longitud))
+                    : googleMapsSearchUrl(navAppSheet.cliente?.direccion || '')
+                }
+                target="_blank"
+                rel="noopener noreferrer"
+                onClick={() => setNavAppSheet(null)}
+                className="flex items-center justify-center gap-2 w-full py-4 bg-blue-600 hover:bg-blue-700 active:bg-blue-800 text-white rounded-xl font-semibold text-base min-h-[56px]"
+              >
+                <Navigation className="w-5 h-5" />
+                Google Maps
+              </a>
+              {navAppSheet.cliente?.latitud != null && navAppSheet.cliente?.longitud != null && (
+                <a
+                  href={wazeNavUrl(Number(navAppSheet.cliente.latitud), Number(navAppSheet.cliente.longitud))}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  onClick={() => setNavAppSheet(null)}
+                  className="flex items-center justify-center gap-2 w-full py-4 bg-cyan-500 hover:bg-cyan-600 active:bg-cyan-700 text-white rounded-xl font-semibold text-base min-h-[56px]"
+                >
+                  <Navigation className="w-5 h-5" />
+                  Waze
+                </a>
+              )}
+              {(navAppSheet.cliente?.latitud == null || navAppSheet.cliente?.longitud == null) && (
+                <p className="text-xs text-amber-600 dark:text-amber-400 text-center">
+                  Este cliente no tiene coordenadas cargadas. Solo Google Maps por busqueda de direccion.
+                </p>
+              )}
+            </div>
+          </div>
+        </div>
       )}
     </div>
   );

--- a/src/hooks/useReverseGeocoding.ts
+++ b/src/hooks/useReverseGeocoding.ts
@@ -1,0 +1,69 @@
+/* global google */
+/**
+ * Hook para reverse geocoding (coordenadas → direccion) usando Google Maps Geocoder.
+ *
+ * Complementa al flujo de AddressAutocomplete: cuando el preventista esta parado
+ * en el local del cliente y captura GPS, este hook traduce las coordenadas a una
+ * direccion legible para autocompletar el campo de direccion.
+ *
+ * Reutiliza la misma API key (VITE_GOOGLE_API_KEY) y el SDK ya cargado por
+ * useGoogleMaps(). google.maps.Geocoder vive en el core del SDK — no requiere
+ * libraries adicionales.
+ *
+ * Costo: $5 USD / 1000 requests (Google Geocoding API).
+ */
+import { useCallback, useRef, useState } from 'react'
+import { useGoogleMaps } from './useGoogleMaps'
+import { logger } from '../utils/logger'
+
+export interface ReverseGeocodeResult {
+  direccion: string
+}
+
+interface UseReverseGeocodingReturn {
+  reverseGeocode: (lat: number, lng: number) => Promise<ReverseGeocodeResult | null>
+  loading: boolean
+  error: string | null
+}
+
+export function useReverseGeocoding(): UseReverseGeocodingReturn {
+  const { isLoaded } = useGoogleMaps()
+  const geocoderRef = useRef<google.maps.Geocoder | null>(null)
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const reverseGeocode = useCallback(
+    async (lat: number, lng: number): Promise<ReverseGeocodeResult | null> => {
+      if (!isLoaded || !window.google?.maps?.Geocoder) {
+        return null
+      }
+      if (!geocoderRef.current) {
+        geocoderRef.current = new window.google.maps.Geocoder()
+      }
+
+      setLoading(true)
+      setError(null)
+      try {
+        const response = await geocoderRef.current.geocode({ location: { lat, lng } })
+        const first = response.results?.[0]
+        if (first?.formatted_address) {
+          return { direccion: first.formatted_address }
+        }
+        return null
+      } catch (err) {
+        // Errores no bloquean: el GPS ya capturo coords utiles. Solo log.
+        const msg = err instanceof Error ? err.message : 'Error desconocido en reverse geocoding'
+        logger.warn('[useReverseGeocoding]', msg)
+        setError(msg)
+        return null
+      } finally {
+        setLoading(false)
+      }
+    },
+    [isLoaded],
+  )
+
+  return { reverseGeocode, loading, error }
+}
+
+export default useReverseGeocoding

--- a/src/utils/navegacion.ts
+++ b/src/utils/navegacion.ts
@@ -1,0 +1,35 @@
+/**
+ * Helpers para construir URLs de deep-link a apps de navegacion (Google Maps, Waze).
+ *
+ * El objetivo es que el transportista, en una tablet, inicie navegacion
+ * turn-by-turn directa hacia las coordenadas del proximo cliente sin pasos
+ * intermedios. Ambas apps son gratuitas y ampliamente conocidas en Argentina.
+ *
+ * Por que /maps/dir/ y no /maps/search/: search abre la pantalla de busqueda,
+ * dir abre navegacion turn-by-turn directa. Ademas usar lat,lng (en vez de
+ * direccion textual) evita que Maps mande al chofer a una calle parecida.
+ */
+
+/**
+ * URL para iniciar navegacion en Google Maps hacia coordenadas exactas.
+ * Si el dispositivo tiene la app instalada, se abre nativa; sino, en navegador.
+ */
+export function googleMapsNavUrl(lat: number, lng: number): string {
+  return `https://www.google.com/maps/dir/?api=1&destination=${lat},${lng}&travelmode=driving`
+}
+
+/**
+ * URL para iniciar navegacion en Waze hacia coordenadas exactas.
+ * `navigate=yes` arranca la navegacion automaticamente (sin pedir confirmacion).
+ */
+export function wazeNavUrl(lat: number, lng: number): string {
+  return `https://www.waze.com/ul?ll=${lat},${lng}&navigate=yes`
+}
+
+/**
+ * Fallback cuando el cliente no tiene coordenadas guardadas: usa la direccion
+ * textual con search. Menos preciso pero al menos lleva al chofer a un punto.
+ */
+export function googleMapsSearchUrl(direccion: string): string {
+  return `https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(direccion)}`
+}

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -138,6 +138,28 @@ declare namespace google.maps {
     lng: number;
   }
 
+  // Geocoder: usado para reverse geocoding (coords -> direccion) en useReverseGeocoding.
+  class Geocoder {
+    constructor();
+    geocode(request: GeocoderRequest): Promise<GeocoderResponse>;
+  }
+
+  interface GeocoderRequest {
+    location?: LatLng | LatLngLiteral;
+    address?: string;
+  }
+
+  interface GeocoderResponse {
+    results: GeocoderResult[];
+  }
+
+  interface GeocoderResult {
+    formatted_address: string;
+    geometry?: {
+      location?: LatLng;
+    };
+  }
+
   namespace places {
     class AutocompleteService {
       getPlacePredictions(


### PR DESCRIPTION
## Summary

Dos features complementarios para mejorar calidad de datos de ubicación y reducir errores de entrega — ambos usan solo lo que ya está pago (Google API key) y deep-links a apps gratuitas. Sin SDKs nuevos.

### 1. Reverse geocoding al usar GPS (preventista)
- Nuevo hook [`useReverseGeocoding`](src/hooks/useReverseGeocoding.ts) que envuelve `google.maps.Geocoder` (viene en el core del SDK, sin libs extra).
- Cuando el preventista toca "Usar mi ubicación actual" en `ModalCliente`, las coords se traducen automáticamente a una dirección legible y se sobreescribe el campo.
- Mientras la dirección venga del GPS, aparece bajo el campo: *"Dirección sugerida por GPS — corregila si no coincide"*. El texto desaparece apenas el usuario edita manualmente o usa el autocompletado de Google Places.

### 2. Navegación turn-by-turn para repartidores en tablet
- Nuevo módulo [`utils/navegacion`](src/utils/navegacion.ts) con helpers `googleMapsNavUrl`, `wazeNavUrl`, `googleMapsSearchUrl`.
- Diferencia clave vs el link anterior: `/maps/dir/` inicia **navegación turn-by-turn directa** (no abre búsqueda) y usa `lat,lng` en vez de dirección textual para mayor precisión.
- En `VistaRutaTransportista`:
  - Cada card ahora tiene dos botones lado a lado: **Google Maps** y **Waze**. Waze solo si el cliente tiene coords cargadas.
  - **FAB flotante "Navegar al siguiente"** abajo a la derecha: calcula el primer pedido pendiente por `orden_entrega` y abre un sheet con las dos apps. El chofer en la tablet ya no tiene que scrollear para encontrar a quién entregar próximo.
  - Si el cliente no tiene coords, cae a `googleMapsSearchUrl` con la dirección textual.

## Costos
- Reverse geocoding: Google Geocoding API a $5 USD / 1000 requests → ~$1-3 USD/mes al volumen actual.
- Apps de navegación: Google Maps y Waze son **gratis** (deep-link).
- Sin SDKs nuevos, sin Mapbox, sin licencias.

## Test plan
- [ ] `npm run build` y `npm test -- --run` pasan localmente (verificado: 674/674 tests).
- [ ] **Reverse geocoding**: abrir ModalCliente (nuevo cliente) → "Usar mi ubicación actual" → confirmar permiso GPS → el campo dirección se autocompleta con la dirección detectada + aparece la nota azul "Dirección sugerida por GPS".
- [ ] Editar manualmente la dirección → la nota azul desaparece.
- [ ] Probar el flujo donde Google no encuentra dirección (ej. coords en medio de un campo) → solo se guardan las coords, sin error visible.
- [ ] **Navegación en tablet (modo transportista)**: abrir VistaRutaTransportista con pedidos asignados con coords → cada card tiene botones Google Maps y Waze → tap a Google Maps abre la app nativa con navegación arrancada hacia las coords del cliente → tap a Waze idem.
- [ ] **FAB "Navegar al siguiente"**: si hay un pedido pendiente, el FAB aparece bottom-right → tap abre el sheet con Maps/Waze → el destino es el primer pedido sin entregar según `orden_entrega`.
- [ ] Marcar ese pedido como entregado → el FAB ahora apunta al siguiente.
- [ ] Pedido sin coords (`latitud == null`): el botón Waze por card desaparece y el sheet muestra solo Google Maps con búsqueda por dirección + warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)