### PR TITLE
fix(transferencias): RLS bidireccional + feat(promos): sustituir regalo profesional

### DIFF
--- a/migrations/057_transferencias_rls_bidireccional.sql
+++ b/migrations/057_transferencias_rls_bidireccional.sql
@@ -1,0 +1,61 @@
+-- =========================================================================
+-- 057_transferencias_rls_bidireccional.sql
+--
+-- Las transferencias entre sucursales involucran dos sucursales: la que
+-- registra el movimiento (`tenant_sucursal_id`) y la contraparte
+-- (`sucursal_id`). La RLS actual de SELECT solo permite ver filas donde
+-- `tenant_sucursal_id = current_sucursal_id()`, lo cual deja CIEGA a la
+-- contraparte:
+--
+--   * Egreso registrado por A hacia B: tenant=A, sucursal_id=B. Solo A ve.
+--   * Ingreso registrado por B desde A: tenant=B, sucursal_id=A. Solo B ve.
+--
+-- Sintoma reportado: "no veo los movimientos entre sucursales que ya hicimos"
+-- — el usuario en B no ve un egreso que le mando A, y viceversa.
+--
+-- Fix: la policy de SELECT acepta cualquiera de las dos columnas. Las
+-- policies de INSERT/UPDATE/DELETE (`mt_transferencias_stock_all`) quedan
+-- intactas — solo el tenant que registra puede modificar.
+--
+-- Tambien se amplia la RLS de `transferencia_items` para que el receptor
+-- pueda leer los items via el join, no solo el header.
+--
+-- Index compuesto adicional sobre (sucursal_id, fecha DESC) para soportar
+-- el filtro bidireccional + ORDER BY por fecha.
+-- =========================================================================
+
+BEGIN;
+
+-- 1) RLS SELECT bidireccional sobre transferencias_stock
+DROP POLICY IF EXISTS "mt_transferencias_stock_select" ON public.transferencias_stock;
+CREATE POLICY "mt_transferencias_stock_select"
+  ON public.transferencias_stock FOR SELECT TO authenticated
+  USING (
+    tenant_sucursal_id = public.current_sucursal_id()
+    OR sucursal_id = public.current_sucursal_id()
+  );
+
+-- 2) RLS SELECT de transferencia_items: permitir lectura si el usuario tiene
+--    acceso al header (origen o destino). El INSERT en transferencia_items
+--    setea sucursal_id = v_tenant (mig archive 066 linea 620), asi que la
+--    policy actual solo cubre al tenant. Aqui usamos EXISTS contra el header
+--    para soportar ambas puntas.
+DROP POLICY IF EXISTS "mt_transferencia_items_select" ON public.transferencia_items;
+CREATE POLICY "mt_transferencia_items_select"
+  ON public.transferencia_items FOR SELECT TO authenticated
+  USING (
+    EXISTS (
+      SELECT 1 FROM public.transferencias_stock ts
+      WHERE ts.id = transferencia_items.transferencia_id
+        AND (ts.tenant_sucursal_id = public.current_sucursal_id()
+             OR ts.sucursal_id = public.current_sucursal_id())
+    )
+  );
+
+-- 3) Index compuesto espejo: ya existe (tenant_sucursal_id) pero no
+--    (sucursal_id, fecha). Lo agregamos para que la query bidireccional
+--    + ORDER BY fecha DESC use index en ambas direcciones.
+CREATE INDEX IF NOT EXISTS idx_transferencias_destino_fecha
+  ON public.transferencias_stock (sucursal_id, fecha DESC);
+
+COMMIT;

--- a/migrations/058_pedido_item_sustituciones.sql
+++ b/migrations/058_pedido_item_sustituciones.sql
@@ -1,0 +1,255 @@
+-- =========================================================================
+-- 058_pedido_item_sustituciones.sql
+--
+-- Sustituir un regalo X (de una promocion) por otro producto Y en un pedido
+-- ya cargado. Hoy se hace "artesanal": el operador borra el item bonificacion
+-- y agrega otro a mano, sin que se devuelva el stock del producto original
+-- y sin audit trail.
+--
+-- Esta migracion:
+--   1. Crea la tabla `pedido_item_sustituciones` como audit log dedicado.
+--   2. Crea la RPC `sustituir_regalo_pedido` (SECURITY DEFINER), atomica y
+--      con idempotencia via client_request_id (mismo patron que mig 049).
+--
+-- Reglas de stock (ortogonales al gatillo de la promo):
+--   - Modo A (regalo_mueve_stock=TRUE): devuelve stock X + descuenta Y.
+--   - Modo B (regalo_mueve_stock=FALSE, ajuste_automatico=TRUE): NO revierte
+--     el bloque del contenedor (otros usos del bloque siguen vivos). Solo
+--     descuenta Y. El bloque queda como costo de la promo entregada.
+--
+-- Cosas que NUNCA toca:
+--   - promociones.usos_pendientes (el uso ya se conto)
+--   - promo_ajustes ni revertir_bloques_auto_ajuste
+--   - promocion_reglas / promocion_productos (el gatillo no cambia)
+--
+-- Solo admin o encargado pueden ejecutarla.
+-- =========================================================================
+
+BEGIN;
+
+-- -------------------------------------------------------------------------
+-- 1) Tabla audit de sustituciones
+-- -------------------------------------------------------------------------
+
+CREATE TABLE IF NOT EXISTS public.pedido_item_sustituciones (
+  id                BIGSERIAL PRIMARY KEY,
+  pedido_id         BIGINT NOT NULL REFERENCES public.pedidos(id) ON DELETE CASCADE,
+  pedido_item_id    BIGINT NOT NULL REFERENCES public.pedido_items(id) ON DELETE CASCADE,
+  promocion_id      BIGINT REFERENCES public.promociones(id),
+  producto_original_id   BIGINT NOT NULL REFERENCES public.productos(id),
+  producto_sustituto_id  BIGINT NOT NULL REFERENCES public.productos(id),
+  -- NUMERIC: pedido_items.cantidad es NUMERIC; soporta fraccion (0.5, 0.75)
+  cantidad_original      NUMERIC(10,2) NOT NULL CHECK (cantidad_original > 0),
+  cantidad_sustituta     NUMERIC(10,2) NOT NULL CHECK (cantidad_sustituta > 0),
+  -- Snapshot del modo de la promo al momento de la sustitucion
+  regalo_mueve_stock_snapshot BOOLEAN,
+  motivo            TEXT NOT NULL,
+  autorizado_por    UUID NOT NULL REFERENCES public.perfiles(id),
+  sucursal_id       BIGINT NOT NULL REFERENCES public.sucursales(id),
+  created_at        TIMESTAMPTZ DEFAULT NOW() NOT NULL,
+  client_request_id UUID
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_pedido_sustituciones_request_id
+  ON public.pedido_item_sustituciones (client_request_id)
+  WHERE client_request_id IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_pedido_sustituciones_pedido
+  ON public.pedido_item_sustituciones (pedido_id);
+
+ALTER TABLE public.pedido_item_sustituciones ENABLE ROW LEVEL SECURITY;
+
+-- Select: cualquier authenticated de la sucursal puede leer (para mostrar en
+-- el historial del pedido).
+DROP POLICY IF EXISTS "mt_sust_select" ON public.pedido_item_sustituciones;
+CREATE POLICY "mt_sust_select"
+  ON public.pedido_item_sustituciones FOR SELECT TO authenticated
+  USING (sucursal_id = public.current_sucursal_id());
+
+-- INSERT/UPDATE/DELETE: solo via la RPC SECURITY DEFINER. Sin policy directa.
+
+GRANT SELECT ON public.pedido_item_sustituciones TO authenticated;
+GRANT ALL ON public.pedido_item_sustituciones TO service_role;
+GRANT USAGE, SELECT ON SEQUENCE public.pedido_item_sustituciones_id_seq TO authenticated;
+
+-- -------------------------------------------------------------------------
+-- 2) RPC sustituir_regalo_pedido
+-- -------------------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION public.sustituir_regalo_pedido(
+  p_pedido_item_id     BIGINT,
+  p_producto_nuevo_id  BIGINT,
+  p_cantidad_nueva     NUMERIC,
+  p_motivo             TEXT,
+  p_client_request_id  UUID DEFAULT NULL
+) RETURNS JSONB
+LANGUAGE plpgsql SECURITY DEFINER SET search_path TO 'public'
+AS $$
+DECLARE
+  v_user_id            UUID := auth.uid();
+  v_user_role          TEXT;
+  v_sucursal           BIGINT := current_sucursal_id();
+  v_item               RECORD;
+  v_stock_nuevo        NUMERIC;
+  v_regalo_mueve_stock BOOLEAN;
+  v_sust_id            BIGINT;
+  v_existing           RECORD;
+  v_nuevo_nombre       TEXT;
+BEGIN
+  IF v_sucursal IS NULL THEN
+    RETURN jsonb_build_object('success', false, 'error', 'No hay sucursal activa');
+  END IF;
+  IF v_user_id IS NULL THEN
+    RETURN jsonb_build_object('success', false, 'error', 'No autenticado');
+  END IF;
+
+  -- 0) Idempotencia
+  IF p_client_request_id IS NOT NULL THEN
+    SELECT id INTO v_existing
+      FROM pedido_item_sustituciones
+     WHERE client_request_id = p_client_request_id;
+    IF FOUND THEN
+      RETURN jsonb_build_object('success', true,
+        'sustitucion_id', v_existing.id,
+        'idempotent_replay', true);
+    END IF;
+  END IF;
+
+  -- 1) Validar rol
+  SELECT rol INTO v_user_role FROM perfiles WHERE id = v_user_id;
+  IF v_user_role NOT IN ('admin', 'encargado') THEN
+    RETURN jsonb_build_object('success', false,
+      'error', 'Solo admin o encargado pueden sustituir regalos');
+  END IF;
+
+  -- 2) Validar cantidad > 0
+  IF p_cantidad_nueva IS NULL OR p_cantidad_nueva <= 0 THEN
+    RETURN jsonb_build_object('success', false,
+      'error', 'La cantidad sustituta debe ser mayor a 0');
+  END IF;
+
+  -- 3) Cargar item + pedido + lock
+  SELECT pi.id, pi.pedido_id, pi.producto_id, pi.cantidad, pi.es_bonificacion,
+         pi.promocion_id, pi.sucursal_id, p.estado AS pedido_estado
+    INTO v_item
+    FROM pedido_items pi
+    JOIN pedidos p ON p.id = pi.pedido_id
+   WHERE pi.id = p_pedido_item_id
+     AND pi.sucursal_id = v_sucursal
+   FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RETURN jsonb_build_object('success', false, 'error', 'Item no encontrado');
+  END IF;
+  IF NOT COALESCE(v_item.es_bonificacion, FALSE) THEN
+    RETURN jsonb_build_object('success', false,
+      'error', 'Solo se pueden sustituir items marcados como bonificacion');
+  END IF;
+  IF v_item.pedido_estado = 'entregado' THEN
+    RETURN jsonb_build_object('success', false,
+      'error', 'No se puede sustituir un regalo en un pedido ya entregado');
+  END IF;
+
+  -- 4) Modo de la promo
+  IF v_item.promocion_id IS NOT NULL THEN
+    SELECT regalo_mueve_stock INTO v_regalo_mueve_stock
+      FROM promociones
+     WHERE id = v_item.promocion_id AND sucursal_id = v_sucursal;
+  END IF;
+  -- Conservador: si no hay promo o si esta NULL, tratamos como Modo A
+  -- (el item se habia descontado del stock). El admin justifica via motivo.
+  v_regalo_mueve_stock := COALESCE(v_regalo_mueve_stock, TRUE);
+
+  -- 5) Validar stock disponible del producto nuevo
+  SELECT stock INTO v_stock_nuevo
+    FROM productos
+   WHERE id = p_producto_nuevo_id AND sucursal_id = v_sucursal
+   FOR UPDATE;
+  IF v_stock_nuevo IS NULL THEN
+    RETURN jsonb_build_object('success', false,
+      'error', 'Producto sustituto no existe en esta sucursal');
+  END IF;
+  IF v_stock_nuevo < p_cantidad_nueva THEN
+    RETURN jsonb_build_object('success', false,
+      'error', 'Stock insuficiente del producto sustituto (' || v_stock_nuevo || ' disponible)');
+  END IF;
+
+  -- Nombre del nuevo producto (para snapshot en descripcion_regalo)
+  SELECT nombre INTO v_nuevo_nombre
+    FROM productos WHERE id = p_producto_nuevo_id AND sucursal_id = v_sucursal;
+
+  -- 6) Contexto trigger registrar_cambio_stock (mig 038)
+  PERFORM set_config('app.stock_origen', 'sustitucion_regalo', true);
+  PERFORM set_config('app.stock_ref_tipo', 'pedido', true);
+  PERFORM set_config('app.stock_ref_id', v_item.pedido_id::TEXT, true);
+  PERFORM set_config('app.stock_user_id', v_user_id::TEXT, true);
+
+  -- 7) Stock segun modo
+  IF v_regalo_mueve_stock THEN
+    -- Modo A: devolver al producto original
+    UPDATE productos
+       SET stock = stock + v_item.cantidad
+     WHERE id = v_item.producto_id AND sucursal_id = v_sucursal;
+  END IF;
+  -- En ambos modos: descontar Y
+  UPDATE productos
+     SET stock = stock - p_cantidad_nueva
+   WHERE id = p_producto_nuevo_id AND sucursal_id = v_sucursal;
+
+  -- 8) Actualizar item: cambia producto + cantidad + descripcion.
+  --    NO cambia es_bonificacion (sigue siendo regalo), NO cambia promocion_id.
+  --    NO recalcula subtotal porque sigue siendo precio_unitario=0 (regalo).
+  UPDATE pedido_items
+     SET producto_id = p_producto_nuevo_id,
+         cantidad    = p_cantidad_nueva,
+         subtotal    = 0,
+         descripcion_regalo = COALESCE(descripcion_regalo, '') ||
+                              ' [Sustituido por: ' || COALESCE(v_nuevo_nombre, '?') || ']'
+   WHERE id = p_pedido_item_id;
+
+  -- 9) Audit
+  INSERT INTO pedido_item_sustituciones (
+    pedido_id, pedido_item_id, promocion_id,
+    producto_original_id, producto_sustituto_id,
+    cantidad_original, cantidad_sustituta,
+    regalo_mueve_stock_snapshot,
+    motivo, autorizado_por, sucursal_id, client_request_id
+  ) VALUES (
+    v_item.pedido_id, p_pedido_item_id, v_item.promocion_id,
+    v_item.producto_id, p_producto_nuevo_id,
+    v_item.cantidad, p_cantidad_nueva,
+    v_regalo_mueve_stock,
+    p_motivo, v_user_id, v_sucursal, p_client_request_id
+  ) RETURNING id INTO v_sust_id;
+
+  -- 10) Trace en historial del pedido
+  INSERT INTO pedido_historial (
+    pedido_id, usuario_id, campo_modificado, valor_anterior, valor_nuevo, sucursal_id
+  ) VALUES (
+    v_item.pedido_id, v_user_id, 'sustitucion_regalo',
+    'producto_id=' || v_item.producto_id || ' cantidad=' || v_item.cantidad,
+    'producto_id=' || p_producto_nuevo_id || ' cantidad=' || p_cantidad_nueva ||
+      ' motivo=' || p_motivo,
+    v_sucursal
+  );
+
+  RETURN jsonb_build_object(
+    'success', true,
+    'sustitucion_id', v_sust_id,
+    'modo', CASE WHEN v_regalo_mueve_stock THEN 'A' ELSE 'B' END
+  );
+EXCEPTION WHEN OTHERS THEN
+  RETURN jsonb_build_object('success', false, 'error', SQLERRM);
+END;
+$$;
+
+ALTER FUNCTION public.sustituir_regalo_pedido(BIGINT, BIGINT, NUMERIC, TEXT, UUID)
+  OWNER TO postgres;
+
+GRANT EXECUTE ON FUNCTION public.sustituir_regalo_pedido(BIGINT, BIGINT, NUMERIC, TEXT, UUID)
+  TO authenticated, service_role;
+
+COMMENT ON FUNCTION public.sustituir_regalo_pedido(BIGINT, BIGINT, NUMERIC, TEXT, UUID) IS
+  'Sustituye un item bonificacion por otro producto. Solo admin/encargado. Devuelve stock del original (Modo A) o NO lo revierte (Modo B, bloques). Idempotente via client_request_id.';
+
+COMMIT;

--- a/src/components/containers/PedidosContainer.tsx
+++ b/src/components/containers/PedidosContainer.tsx
@@ -1263,6 +1263,7 @@ export default function PedidosContainer(): React.ReactElement {
               isAdmin || isEncargado ||
               (isPreventista && preventistaPuedeEditar(pedidoEditando, user?.id))
             }
+            canSustituirRegalo={isAdmin || isEncargado}
             onSave={handleGuardarEdicion}
             onSaveItems={handleGuardarItemsEdicion}
             onClose={() => { setModalEditarOpen(false); setPedidoEditando(null) }}

--- a/src/components/containers/TransferenciasContainer.tsx
+++ b/src/components/containers/TransferenciasContainer.tsx
@@ -4,7 +4,7 @@
  * Container que carga transferencias, sucursales y productos bajo demanda usando TanStack Query.
  * Soporta salidas e ingresos entre sucursales.
  */
-import React, { lazy, Suspense, useState, useCallback } from 'react'
+import React, { lazy, Suspense, useState, useCallback, useMemo } from 'react'
 import { Loader2 } from 'lucide-react'
 import {
   useTransferenciasQuery,
@@ -16,6 +16,8 @@ import {
 } from '../../hooks/queries'
 import { useAuthData } from '../../contexts/AuthDataContext'
 import { useNotification } from '../../contexts/NotificationContext'
+import { useResetOnSucursalChange } from '../../hooks/useResetOnSucursalChange'
+import { fechaHaceDias, fechaLocalISO } from '../../utils/formatters'
 import type { TransferenciaFormInput, TransferenciaDB, TipoTransferencia } from '../../types'
 
 // Lazy load de componentes
@@ -35,8 +37,14 @@ export default function TransferenciasContainer(): React.ReactElement {
   const { user } = useAuthData()
   const notify = useNotification()
 
+  // Filtros de fecha + paginacion. Defaults: ultimos 60 dias, pagina 1.
+  const [desde, setDesde] = useState<string>(() => fechaHaceDias(60))
+  const [hasta, setHasta] = useState<string>(() => fechaLocalISO())
+  const [pagina, setPagina] = useState<number>(1)
+  const filtros = useMemo(() => ({ desde, hasta, pagina }), [desde, hasta, pagina])
+
   // Queries
-  const { data: transferencias = [], isLoading } = useTransferenciasQuery()
+  const { data: transferencias = [], isLoading } = useTransferenciasQuery(filtros)
   const { data: sucursales = [] } = useSucursalesQuery()
   const { data: productos = [] } = useProductosQuery()
 
@@ -48,6 +56,24 @@ export default function TransferenciasContainer(): React.ReactElement {
   // Estado de modales
   const [modalTipo, setModalTipo] = useState<TipoTransferencia | null>(null)
   const [detalleTransferencia, setDetalleTransferencia] = useState<TransferenciaDB | null>(null)
+
+  // Cerrar modales y volver a pagina 1 al cambiar sucursal.
+  useResetOnSucursalChange(() => {
+    setModalTipo(null)
+    setDetalleTransferencia(null)
+    setPagina(1)
+  })
+
+  // Handlers de filtros
+  const handleFechaDesde = useCallback((v: string) => {
+    setDesde(v)
+    setPagina(1)
+  }, [])
+  const handleFechaHasta = useCallback((v: string) => {
+    setHasta(v)
+    setPagina(1)
+  }, [])
+  const handlePaginaCambio = useCallback((p: number) => setPagina(p), [])
 
   // Handlers
   const handleNuevaSalida = useCallback(() => {
@@ -96,6 +122,12 @@ export default function TransferenciasContainer(): React.ReactElement {
         <VistaTransferencias
           transferencias={transferencias}
           loading={isLoading}
+          desde={desde}
+          hasta={hasta}
+          pagina={pagina}
+          onCambiarDesde={handleFechaDesde}
+          onCambiarHasta={handleFechaHasta}
+          onCambiarPagina={handlePaginaCambio}
           onNuevaSalida={handleNuevaSalida}
           onNuevoIngreso={handleNuevoIngreso}
           onVerDetalle={handleVerDetalle}

--- a/src/components/modals/ModalDetalleTransferencia.tsx
+++ b/src/components/modals/ModalDetalleTransferencia.tsx
@@ -2,10 +2,13 @@
  * ModalDetalleTransferencia
  *
  * Modal de solo lectura que muestra el detalle de un movimiento entre sucursales.
+ * Carga los items on-demand via useTransferenciaItemsQuery (el listado de
+ * transferencias no incluye items para mantener payload liviano).
  */
 import React from 'react'
-import { X, ArrowUpRight, ArrowDownLeft, Package } from 'lucide-react'
+import { X, ArrowUpRight, ArrowDownLeft, Package, Loader2 } from 'lucide-react'
 import { formatPrecio } from '../../utils/formatters'
+import { useTransferenciaItemsQuery } from '../../hooks/queries/useTransferenciasQuery'
 import type { TransferenciaDB } from '../../types'
 
 interface ModalDetalleTransferenciaProps {
@@ -30,7 +33,10 @@ export default function ModalDetalleTransferencia({
   onClose,
 }: ModalDetalleTransferenciaProps): React.ReactElement {
   const esIngreso = transferencia.tipo === 'ingreso'
-  const items = transferencia.items || []
+  const { data: itemsRemote, isLoading: itemsLoading } = useTransferenciaItemsQuery(transferencia.id)
+  // Fallback al snapshot del payload (raro pero compat) si el query aun
+  // no resolvio; preferimos los items de la query.
+  const items = itemsRemote ?? transferencia.items ?? []
 
   return (
     <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
@@ -80,7 +86,13 @@ export default function ModalDetalleTransferencia({
           )}
 
           {/* Items table */}
-          {items.length > 0 ? (
+          {itemsLoading && (
+            <div className="flex items-center justify-center py-8 text-gray-400 gap-2">
+              <Loader2 className="w-5 h-5 animate-spin" />
+              <span className="text-sm">Cargando items...</span>
+            </div>
+          )}
+          {!itemsLoading && items.length > 0 ? (
             <div className="border dark:border-gray-700 rounded-lg overflow-hidden">
               <div className="hidden sm:grid grid-cols-12 gap-2 px-4 py-2 bg-gray-50 dark:bg-gray-700/50 text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">
                 <div className="col-span-5">Producto</div>
@@ -114,10 +126,12 @@ export default function ModalDetalleTransferencia({
               ))}
             </div>
           ) : (
-            <div className="flex flex-col items-center py-8 text-gray-400">
-              <Package className="w-8 h-8 mb-2" />
-              <p className="text-sm">Sin items</p>
-            </div>
+            !itemsLoading && (
+              <div className="flex flex-col items-center py-8 text-gray-400">
+                <Package className="w-8 h-8 mb-2" />
+                <p className="text-sm">Sin items</p>
+              </div>
+            )
           )}
         </div>
 

--- a/src/components/modals/ModalEditarPedido.test.jsx
+++ b/src/components/modals/ModalEditarPedido.test.jsx
@@ -21,6 +21,7 @@ vi.mock('../../hooks/queries/useGruposPrecioQuery', () => ({
 }))
 vi.mock('../../hooks/queries/usePromocionesQuery', () => ({
   usePromoMapQuery: () => ({ data: new Map(), isLoading: false }),
+  usePromocionesListQuery: () => ({ data: [], isLoading: false }),
 }))
 
 // Mock formatPrecio (preserve fechaLocalISO since usePromocionesQuery uses it indirectly)

--- a/src/components/modals/ModalEditarPedido.tsx
+++ b/src/components/modals/ModalEditarPedido.tsx
@@ -1,5 +1,5 @@
-import { useState, memo, useEffect, useMemo } from 'react';
-import { Loader2, AlertCircle, Package, Plus, Minus, Trash2, Search, X, ShoppingCart, Pencil, Gift } from 'lucide-react';
+import { lazy, Suspense, useState, memo, useEffect, useMemo } from 'react';
+import { Loader2, AlertCircle, Package, Plus, Minus, Trash2, Search, X, ShoppingCart, Pencil, Gift, RefreshCw } from 'lucide-react';
 import ModalBase from './ModalBase';
 import ModalConfirmacion, { type ModalConfirmacionConfig } from './ModalConfirmacion';
 import { formatPrecio } from '../../utils/formatters';
@@ -7,8 +7,11 @@ import { useZodValidation } from '../../hooks/useZodValidation';
 import { modalEditarPedidoSchema } from '../../lib/schemas';
 import { usePromocionPedido } from '../../hooks/usePromocionPedido';
 import { useRendiciones } from '../../hooks/supabase/useRendiciones';
+import { usePromocionesListQuery } from '../../hooks/queries/usePromocionesQuery';
 import { calcularNetoVenta, parsePrecio } from '../../utils/calculations';
-import type { PedidoDB, ProductoDB } from '../../types';
+import type { PedidoDB, ProductoDB, PedidoItemDB } from '../../types';
+
+const ModalSustituirRegalo = lazy(() => import('./ModalSustituirRegalo'));
 
 /** Item del pedido para edición. Incluye fiscales opcionales que se pueblan al guardar. */
 export interface PedidoEditItem {
@@ -47,6 +50,8 @@ export interface ModalEditarPedidoProps {
   canEditPrices?: boolean;
   /** Permite cambiar fecha de pedido / entrega / entrega programada. Default: isAdmin. */
   canEditFechaEntrega?: boolean;
+  /** Permite sustituir el producto de un regalo de promo. Default: false. Solo admin/encargado. */
+  canSustituirRegalo?: boolean;
   /** @deprecated usar canEditItems/canEditPrices/canEditFechaEntrega. Mantiene compat. */
   isAdmin?: boolean;
   /** Callback al guardar datos */
@@ -65,6 +70,7 @@ const ModalEditarPedido = memo(function ModalEditarPedido({
   canEditItems,
   canEditPrices,
   canEditFechaEntrega,
+  canSustituirRegalo = false,
   isAdmin = false,
   onSave,
   onSaveItems,
@@ -102,8 +108,31 @@ const ModalEditarPedido = memo(function ModalEditarPedido({
   const [editingPriceId, setEditingPriceId] = useState<string | null>(null);
   const [editingPriceValue, setEditingPriceValue] = useState<string>('');
 
+  // Sustitucion de regalos: el row persistido a editar (id real de pedido_items).
+  const [sustItemTarget, setSustItemTarget] = useState<PedidoItemDB | null>(null);
+
   // Verificar si el pedido está entregado (no editable)
   const pedidoEntregado = pedido?.estado === 'entregado';
+
+  // Regalos persistidos en DB (items con es_bonificacion=true). A diferencia
+  // de las bonificacionesCalculadas que se recalculan localmente, estas son
+  // las filas REALES de pedido_items con su `id`, necesarias para invocar
+  // la RPC `sustituir_regalo_pedido`.
+  const regalosPersistidos = useMemo<PedidoItemDB[]>(
+    () => (pedido?.items ?? []).filter(i => i.es_bonificacion === true),
+    [pedido]
+  );
+
+  // Mapa promocion_id -> regalo_mueve_stock, para resolver el modo (A/B) de
+  // cada regalo persistido en el modal de sustitucion.
+  const { data: promociones = [] } = usePromocionesListQuery();
+  const promoMueveStockMap = useMemo(() => {
+    const m = new Map<string, boolean>();
+    for (const p of promociones) {
+      m.set(String(p.id), Boolean(p.regalo_mueve_stock));
+    }
+    return m;
+  }, [promociones]);
 
   // Inicializar items del pedido — sólo no-bonificaciones.
   // Las bonificaciones se recalculan reactivamente a partir del estado no-bonif
@@ -670,6 +699,51 @@ const ModalEditarPedido = memo(function ModalEditarPedido({
           </div>
         )}
 
+        {/* Regalos persistidos del pedido — solo para admin/encargado, para
+            sustituir el producto del regalo (mig 058). No se muestra si no hay
+            regalos persistidos o si el usuario no tiene permiso. */}
+        {canSustituirRegalo && regalosPersistidos.length > 0 && !pedidoEntregado && (
+          <div className="border dark:border-gray-700 rounded-lg overflow-hidden">
+            <div className="bg-gray-50 dark:bg-gray-700/50 px-3 py-2 border-b dark:border-gray-700">
+              <p className="text-sm font-medium text-gray-700 dark:text-gray-300 flex items-center gap-1.5">
+                <Gift className="w-4 h-4 text-emerald-600" />
+                Regalos del pedido (sustituibles)
+              </p>
+              <p className="text-xs text-gray-500 dark:text-gray-400 mt-0.5">
+                Cambiar el producto de un regalo deja audit trail y maneja el stock segun el modo de la promo.
+              </p>
+            </div>
+            <div className="divide-y dark:divide-gray-700">
+              {regalosPersistidos.map(regalo => (
+                <div
+                  key={`regalo-real-${regalo.id}`}
+                  className="p-3 flex items-center justify-between bg-emerald-50/40 dark:bg-emerald-900/10"
+                >
+                  <div className="flex items-center gap-2 flex-1 min-w-0">
+                    <Gift className="w-4 h-4 text-emerald-600 flex-shrink-0" />
+                    <div className="min-w-0">
+                      <p className="font-medium text-sm dark:text-white truncate">
+                        {regalo.producto?.nombre || `Producto #${regalo.producto_id}`}
+                      </p>
+                      <p className="text-xs text-emerald-700 dark:text-emerald-300 font-medium">
+                        REGALO x{regalo.cantidad}
+                        {regalo.promocion_id ? ` · promo #${regalo.promocion_id}` : ''}
+                      </p>
+                    </div>
+                  </div>
+                  <button
+                    onClick={() => setSustItemTarget(regalo)}
+                    className="flex items-center gap-1 px-3 py-1.5 text-xs font-medium text-emerald-700 dark:text-emerald-300 hover:bg-emerald-100 dark:hover:bg-emerald-900/30 border border-emerald-300 dark:border-emerald-700 rounded-lg"
+                  >
+                    <RefreshCw className="w-3.5 h-3.5" />
+                    Cambiar regalo
+                  </button>
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+
         {/* Total del pedido */}
         <div className="bg-blue-50 dark:bg-blue-900/30 rounded-lg p-4 border border-blue-200 dark:border-blue-800">
           <div className="flex justify-between items-center">
@@ -783,6 +857,23 @@ const ModalEditarPedido = memo(function ModalEditarPedido({
         </button>
       </div>
       <ModalConfirmacion config={confirmConfig} onClose={() => setConfirmConfig(null)} />
+
+      {/* Modal de sustitucion de regalo (lazy) */}
+      {sustItemTarget && sustItemTarget.producto && (
+        <Suspense fallback={null}>
+          <ModalSustituirRegalo
+            pedidoItemId={sustItemTarget.id}
+            productoOriginal={sustItemTarget.producto}
+            cantidadOriginal={sustItemTarget.cantidad}
+            regaloMueveStock={
+              sustItemTarget.promocion_id
+                ? (promoMueveStockMap.get(String(sustItemTarget.promocion_id)) ?? true)
+                : true
+            }
+            onClose={() => setSustItemTarget(null)}
+          />
+        </Suspense>
+      )}
     </ModalBase>
   );
 });

--- a/src/components/modals/ModalHistorialPedido.tsx
+++ b/src/components/modals/ModalHistorialPedido.tsx
@@ -42,7 +42,9 @@ const ModalHistorialPedido = memo(function ModalHistorialPedido({ pedido, histor
       forma_pago: "Forma de pago",
       estado_pago: "Estado de pago",
       total: "Total",
-      creacion: "Creacion"
+      creacion: "Creacion",
+      sustitucion_regalo: "Sustitucion de regalo",
+      items: "Items"
     };
     return mapeo[campo] || campo;
   };

--- a/src/components/modals/ModalSustituirRegalo.tsx
+++ b/src/components/modals/ModalSustituirRegalo.tsx
@@ -1,0 +1,227 @@
+/**
+ * ModalSustituirRegalo
+ *
+ * Permite a un admin/encargado cambiar el producto de un item bonificacion
+ * en un pedido (regalo de una promocion). Justifica con motivo y autoriza
+ * la operacion.
+ *
+ * Llama a la RPC `sustituir_regalo_pedido` (mig 058) via
+ * useSustituirRegaloMutation. Maneja:
+ *   - Idempotencia (UUID generado en el primer render).
+ *   - Modo A vs Modo B con banner visual explicativo.
+ *   - Validacion basica: cantidad > 0, producto seleccionado, motivo no vacio.
+ */
+import { useMemo, useState, memo } from 'react'
+import { Loader2, Gift, AlertTriangle, Check } from 'lucide-react'
+import ModalBase from './ModalBase'
+import { useProductosQuery } from '../../hooks/queries'
+import { useSustituirRegaloMutation } from '../../hooks/queries/useSustituirRegaloMutation'
+import { useNotification } from '../../contexts/NotificationContext'
+import type { ProductoDB } from '../../types'
+
+export interface ModalSustituirRegaloProps {
+  pedidoItemId: string
+  productoOriginal: ProductoDB
+  cantidadOriginal: number
+  /** Modo de la promo. true = Modo A (stock unitario), false = Modo B (bloques). */
+  regaloMueveStock: boolean
+  onClose: () => void
+  /** Callback al confirmar exitosamente (para que el caller refresque). */
+  onSustituido?: () => void
+}
+
+const ModalSustituirRegalo = memo(function ModalSustituirRegalo({
+  pedidoItemId,
+  productoOriginal,
+  cantidadOriginal,
+  regaloMueveStock,
+  onClose,
+  onSustituido,
+}: ModalSustituirRegaloProps) {
+  const notify = useNotification()
+  const { data: productos = [] } = useProductosQuery()
+  const sustituirMut = useSustituirRegaloMutation()
+
+  // UUID estable por instancia del modal para idempotencia (mismo UUID en
+  // reintento desde el cliente devuelve la misma sustitucion sin duplicar).
+  const clientRequestId = useMemo(() => crypto.randomUUID(), [])
+
+  const [productoNuevoId, setProductoNuevoId] = useState<string>('')
+  const [cantidadNueva, setCantidadNueva] = useState<string>(String(cantidadOriginal))
+  const [motivo, setMotivo] = useState<string>('')
+  const [error, setError] = useState<string>('')
+
+  const productoNuevo = useMemo(
+    () => productos.find(p => String(p.id) === String(productoNuevoId)) ?? null,
+    [productos, productoNuevoId]
+  )
+
+  // Productos disponibles ordenados, excluyendo el original para que no
+  // "sustituyan por el mismo".
+  const productosOpciones = useMemo(
+    () => productos
+      .filter(p => String(p.id) !== String(productoOriginal.id))
+      .slice()
+      .sort((a, b) => (a.nombre || '').localeCompare(b.nombre || '')),
+    [productos, productoOriginal.id]
+  )
+
+  const cantidadNum = parseFloat(cantidadNueva) || 0
+  const stockSuficiente = productoNuevo == null || (productoNuevo.stock ?? 0) >= cantidadNum
+  const puedeConfirmar = !!productoNuevoId
+    && cantidadNum > 0
+    && motivo.trim().length > 0
+    && stockSuficiente
+    && !sustituirMut.isPending
+
+  const handleConfirmar = async () => {
+    setError('')
+    if (!puedeConfirmar) return
+    try {
+      const result = await sustituirMut.mutateAsync({
+        pedidoItemId,
+        productoNuevoId,
+        cantidadNueva: cantidadNum,
+        motivo: motivo.trim(),
+        clientRequestId,
+      })
+      notify.success(
+        result.idempotentReplay
+          ? 'Sustitucion ya registrada'
+          : `Regalo sustituido (Modo ${result.modo})`
+      )
+      onSustituido?.()
+      onClose()
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : 'Error al sustituir el regalo'
+      setError(msg)
+    }
+  }
+
+  return (
+    <ModalBase title="Sustituir regalo de promocion" onClose={onClose} maxWidth="max-w-lg">
+      <div className="p-4 space-y-4">
+        {/* Contexto del regalo original */}
+        <div className="bg-gray-50 dark:bg-gray-700/50 rounded-lg p-3">
+          <p className="text-xs text-gray-500 dark:text-gray-400 mb-1 flex items-center gap-1">
+            <Gift className="w-3 h-3" /> Regalo actual
+          </p>
+          <p className="font-semibold text-gray-800 dark:text-white">
+            {productoOriginal.nombre}
+          </p>
+          <p className="text-sm text-gray-500 dark:text-gray-400">
+            Cantidad: <span className="font-medium">{cantidadOriginal}</span>
+          </p>
+        </div>
+
+        {/* Banner segun modo de la promo */}
+        {regaloMueveStock ? (
+          <div className="flex items-start gap-2 p-3 rounded-lg bg-emerald-50 dark:bg-emerald-900/20 border border-emerald-200 dark:border-emerald-800 text-sm text-emerald-800 dark:text-emerald-200">
+            <Check className="w-4 h-4 mt-0.5 flex-shrink-0" />
+            <p>
+              Esta promo descuenta stock por unidad. La sustitucion va a
+              <b> devolver {cantidadOriginal} de {productoOriginal.nombre}</b> al
+              deposito y descontar la cantidad del producto sustituto.
+            </p>
+          </div>
+        ) : (
+          <div className="flex items-start gap-2 p-3 rounded-lg bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800 text-sm text-amber-800 dark:text-amber-200">
+            <AlertTriangle className="w-4 h-4 mt-0.5 flex-shrink-0" />
+            <p>
+              Esta promo se ajusta por bloque del producto contenedor. La
+              sustitucion va a descontar el stock del nuevo producto pero
+              <b> NO va a reponer el contenedor original</b>. El bloque ya
+              consumido por la promo se mantiene.
+            </p>
+          </div>
+        )}
+
+        {/* Producto sustituto */}
+        <div>
+          <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+            Producto sustituto *
+          </label>
+          <select
+            value={productoNuevoId}
+            onChange={e => setProductoNuevoId(e.target.value)}
+            className="w-full px-3 py-2 border rounded-lg dark:bg-gray-700 dark:border-gray-600 dark:text-white"
+          >
+            <option value="">Elegir...</option>
+            {productosOpciones.map(p => (
+              <option key={p.id} value={p.id}>
+                {p.nombre} {(p.stock ?? 0) > 0 ? `· stock ${p.stock}` : '· sin stock'}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        {/* Cantidad */}
+        <div>
+          <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+            Cantidad nueva *
+          </label>
+          <input
+            type="number"
+            inputMode="decimal"
+            step="0.01"
+            min="0"
+            value={cantidadNueva}
+            onChange={e => setCantidadNueva(e.target.value)}
+            className="w-full px-3 py-2 border rounded-lg dark:bg-gray-700 dark:border-gray-600 dark:text-white"
+          />
+          <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
+            Se acepta fraccion (ej. 0.5). Por defecto se asume la misma
+            cantidad que el regalo original.
+          </p>
+          {productoNuevo && !stockSuficiente && (
+            <p className="text-xs text-red-600 mt-1 flex items-center gap-1">
+              <AlertTriangle className="w-3 h-3" />
+              Stock insuficiente del producto sustituto ({productoNuevo.stock ?? 0} disponible)
+            </p>
+          )}
+        </div>
+
+        {/* Motivo */}
+        <div>
+          <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+            Motivo de la sustitucion *
+          </label>
+          <textarea
+            value={motivo}
+            onChange={e => setMotivo(e.target.value)}
+            rows={2}
+            placeholder="Ej: cliente pide cambiar Naranja por Pomelo, sin stock del original, etc."
+            className="w-full px-3 py-2 border rounded-lg resize-none dark:bg-gray-700 dark:border-gray-600 dark:text-white text-sm"
+          />
+        </div>
+
+        {error && (
+          <div className="flex items-start gap-2 p-3 rounded-lg bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 text-sm text-red-700 dark:text-red-300">
+            <AlertTriangle className="w-4 h-4 mt-0.5 flex-shrink-0" />
+            <p>{error}</p>
+          </div>
+        )}
+      </div>
+
+      <div className="flex justify-end gap-2 p-4 border-t bg-gray-50 dark:bg-gray-800 dark:border-gray-700">
+        <button
+          onClick={onClose}
+          disabled={sustituirMut.isPending}
+          className="px-4 py-2 text-gray-700 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-600 rounded-lg disabled:opacity-50"
+        >
+          Cancelar
+        </button>
+        <button
+          onClick={handleConfirmar}
+          disabled={!puedeConfirmar}
+          className="flex items-center gap-2 px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded-lg disabled:opacity-50"
+        >
+          {sustituirMut.isPending && <Loader2 className="w-4 h-4 animate-spin" />}
+          Sustituir regalo
+        </button>
+      </div>
+    </ModalBase>
+  )
+})
+
+export default ModalSustituirRegalo

--- a/src/components/vistas/VistaTransferencias.tsx
+++ b/src/components/vistas/VistaTransferencias.tsx
@@ -2,16 +2,24 @@
  * VistaTransferencias
  *
  * Lista de movimientos entre sucursales (salidas e ingresos) con detalle.
+ * Paginada en server-side (50 filas por pagina) + filtro de fecha.
  */
 import React from 'react'
-import { ArrowRightLeft, Plus, Package, ArrowUpRight, ArrowDownLeft } from 'lucide-react'
+import { ArrowRightLeft, Package, ArrowUpRight, ArrowDownLeft, ChevronLeft, ChevronRight, Calendar } from 'lucide-react'
 import LoadingSpinner from '../layout/LoadingSpinner'
 import { formatPrecio } from '../../utils/formatters'
+import { TRANSFERENCIAS_PAGE_SIZE } from '../../hooks/queries/useTransferenciasQuery'
 import type { TransferenciaDB } from '../../types'
 
 interface VistaTransferenciasProps {
   transferencias: TransferenciaDB[]
   loading: boolean
+  desde: string
+  hasta: string
+  pagina: number
+  onCambiarDesde: (v: string) => void
+  onCambiarHasta: (v: string) => void
+  onCambiarPagina: (p: number) => void
   onNuevaSalida: () => void
   onNuevoIngreso: () => void
   onVerDetalle: (transferencia: TransferenciaDB) => void
@@ -32,10 +40,21 @@ function formatFecha(fecha: string): string {
 export default function VistaTransferencias({
   transferencias,
   loading,
+  desde,
+  hasta,
+  pagina,
+  onCambiarDesde,
+  onCambiarHasta,
+  onCambiarPagina,
   onNuevaSalida,
   onNuevoIngreso,
   onVerDetalle,
 }: VistaTransferenciasProps): React.ReactElement {
+  // La paginacion es server-side por offset. Como la API no devuelve el total,
+  // habilitamos "siguiente" mientras la pagina actual venga llena. Si vuelve
+  // con menos de PAGE_SIZE elementos, asumimos que es la ultima.
+  const puedeSiguiente = transferencias.length === TRANSFERENCIAS_PAGE_SIZE
+  const puedeAnterior = pagina > 1
   return (
     <div className="space-y-6">
       {/* Header */}
@@ -62,6 +81,35 @@ export default function VistaTransferencias({
             Nueva Salida
           </button>
         </div>
+      </div>
+
+      {/* Filtros de fecha */}
+      <div className="flex flex-wrap items-end gap-3 bg-white dark:bg-gray-800 rounded-xl p-3 border dark:border-gray-700 shadow-sm">
+        <div>
+          <label className="block text-xs font-medium text-gray-500 dark:text-gray-400 mb-1 flex items-center gap-1">
+            <Calendar className="w-3 h-3" /> Desde
+          </label>
+          <input
+            type="date"
+            value={desde}
+            onChange={e => onCambiarDesde(e.target.value)}
+            className="px-3 py-1.5 text-sm border rounded-lg dark:bg-gray-700 dark:border-gray-600 dark:text-white"
+          />
+        </div>
+        <div>
+          <label className="block text-xs font-medium text-gray-500 dark:text-gray-400 mb-1 flex items-center gap-1">
+            <Calendar className="w-3 h-3" /> Hasta
+          </label>
+          <input
+            type="date"
+            value={hasta}
+            onChange={e => onCambiarHasta(e.target.value)}
+            className="px-3 py-1.5 text-sm border rounded-lg dark:bg-gray-700 dark:border-gray-600 dark:text-white"
+          />
+        </div>
+        <p className="text-xs text-gray-500 dark:text-gray-400 ml-auto">
+          Por defecto, ultimos 60 dias. Ampliar manualmente si necesitan historial.
+        </p>
       </div>
 
       {/* Loading */}
@@ -98,9 +146,6 @@ export default function VistaTransferencias({
                   <th className="text-left px-4 py-3 text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
                     Sucursal
                   </th>
-                  <th className="text-center px-4 py-3 text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
-                    Items
-                  </th>
                   <th className="text-right px-4 py-3 text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
                     Total Costo
                   </th>
@@ -136,9 +181,6 @@ export default function VistaTransferencias({
                       <td className="px-4 py-3 text-sm font-medium text-gray-800 dark:text-white">
                         {t.sucursal?.nombre || 'Sin sucursal'}
                       </td>
-                      <td className="px-4 py-3 text-sm text-gray-600 dark:text-gray-300 text-center">
-                        {t.items?.length || 0}
-                      </td>
                       <td className="px-4 py-3 text-sm font-medium text-gray-800 dark:text-white text-right whitespace-nowrap">
                         {formatPrecio(t.total_costo)}
                       </td>
@@ -150,6 +192,29 @@ export default function VistaTransferencias({
                 })}
               </tbody>
             </table>
+          </div>
+
+          {/* Paginador */}
+          <div className="flex items-center justify-between px-4 py-3 border-t dark:border-gray-700 text-sm">
+            <p className="text-gray-500 dark:text-gray-400">
+              Pagina {pagina}{' · '}{transferencias.length} mov.
+            </p>
+            <div className="flex gap-2">
+              <button
+                onClick={() => onCambiarPagina(pagina - 1)}
+                disabled={!puedeAnterior}
+                className="flex items-center gap-1 px-3 py-1.5 border rounded-lg dark:border-gray-600 disabled:opacity-40 disabled:cursor-not-allowed hover:bg-gray-50 dark:hover:bg-gray-700"
+              >
+                <ChevronLeft className="w-4 h-4" /> Anterior
+              </button>
+              <button
+                onClick={() => onCambiarPagina(pagina + 1)}
+                disabled={!puedeSiguiente}
+                className="flex items-center gap-1 px-3 py-1.5 border rounded-lg dark:border-gray-600 disabled:opacity-40 disabled:cursor-not-allowed hover:bg-gray-50 dark:hover:bg-gray-700"
+              >
+                Siguiente <ChevronRight className="w-4 h-4" />
+              </button>
+            </div>
           </div>
         </div>
       )}

--- a/src/hooks/queries/index.ts
+++ b/src/hooks/queries/index.ts
@@ -147,12 +147,18 @@ export type { ZonaDB } from './useZonasQuery'
 export {
   transferenciasKeys,
   sucursalesKeys,
+  TRANSFERENCIAS_PAGE_SIZE,
   useTransferenciasQuery,
+  useTransferenciaItemsQuery,
   useSucursalesQuery,
   useCrearSucursalMutation,
   useRegistrarTransferenciaMutation,
   useRegistrarIngresoMutation,
 } from './useTransferenciasQuery'
+export type { TransferenciasFiltros } from './useTransferenciasQuery'
+
+// Sustitucion de regalos en promociones (mig 058)
+export { useSustituirRegaloMutation } from './useSustituirRegaloMutation'
 
 // Métricas
 export {

--- a/src/hooks/queries/useSustituirRegaloMutation.ts
+++ b/src/hooks/queries/useSustituirRegaloMutation.ts
@@ -1,0 +1,57 @@
+/**
+ * Hook mutation para sustituir un regalo de promocion por otro producto.
+ *
+ * Backend: RPC `sustituir_regalo_pedido` (mig 058). Solo admin/encargado.
+ * Idempotente via `client_request_id` — el caller puede pasar un UUID o
+ * dejar que el hook lo genere (default).
+ *
+ * Maneja respuestas `{ success: false, error: '...' }` del RPC convirtiendo
+ * el error a Error JS para que onError se dispare en TanStack Query.
+ */
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { supabase } from '../supabase/base'
+import type { SustituirRegaloInput, SustituirRegaloResult } from '../../types'
+
+async function sustituirRegalo(input: SustituirRegaloInput): Promise<SustituirRegaloResult> {
+  const clientRequestId = input.clientRequestId ?? crypto.randomUUID()
+
+  const { data, error } = await supabase.rpc('sustituir_regalo_pedido', {
+    p_pedido_item_id: input.pedidoItemId,
+    p_producto_nuevo_id: input.productoNuevoId,
+    p_cantidad_nueva: input.cantidadNueva,
+    p_motivo: input.motivo,
+    p_client_request_id: clientRequestId,
+  })
+  if (error) throw error
+
+  const raw = (data ?? {}) as {
+    success?: boolean
+    error?: string
+    sustitucion_id?: string
+    modo?: 'A' | 'B'
+    idempotent_replay?: boolean
+  }
+  if (!raw.success) {
+    throw new Error(raw.error || 'Error al sustituir el regalo')
+  }
+  return {
+    sustitucionId: String(raw.sustitucion_id ?? ''),
+    modo: raw.modo ?? 'A',
+    idempotentReplay: raw.idempotent_replay,
+  }
+}
+
+/**
+ * Hook que expone la mutation. En `onSuccess` invalida pedidos + productos
+ * para que la UI vea el nuevo stock y la nueva composicion del pedido.
+ */
+export function useSustituirRegaloMutation() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: sustituirRegalo,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['pedidos'] })
+      queryClient.invalidateQueries({ queryKey: ['productos'] })
+    },
+  })
+}

--- a/src/hooks/queries/useTransferenciasQuery.ts
+++ b/src/hooks/queries/useTransferenciasQuery.ts
@@ -1,16 +1,35 @@
 /**
  * TanStack Query hooks para Transferencias a Sucursales
  * Maneja envios de stock a sucursales (branch transfers)
+ *
+ * Cambios mig 057:
+ *   - La RLS ahora deja ver tanto egreso como ingreso (tenant o contraparte
+ *     coinciden con la sucursal activa). El listado puede traer movimientos
+ *     entrantes y salientes — bien.
+ *   - `fetchTransferencias` ahora pagina (LIMIT 50 + offset) y filtra por
+ *     rango de fecha (default ultimos 60 dias) para no traer todo el
+ *     historial en una sola request.
+ *   - El detalle (`items + producto`) sale del listado y se carga via
+ *     `useTransferenciaItemsQuery` solo cuando se abre el modal de detalle.
  */
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { supabase } from '../supabase/base'
-import { fechaLocalISO } from '../../utils/formatters'
+import { fechaLocalISO, fechaHaceDias } from '../../utils/formatters'
 import { useSucursal } from '../../contexts/SucursalContext'
 import type {
   TransferenciaDB,
   TransferenciaFormInput,
+  TransferenciaItemDB,
   SucursalDB,
 } from '../../types'
+
+export const TRANSFERENCIAS_PAGE_SIZE = 50
+
+export interface TransferenciasFiltros {
+  desde?: string
+  hasta?: string
+  pagina?: number
+}
 
 // Query keys
 export const transferenciasKeys = {
@@ -19,6 +38,7 @@ export const transferenciasKeys = {
   list: (sucursalId: number | null, filters: Record<string, unknown>) => [...transferenciasKeys.lists(sucursalId), filters] as const,
   details: (sucursalId: number | null) => [...transferenciasKeys.all(sucursalId), 'detail'] as const,
   detail: (sucursalId: number | null, id: string) => [...transferenciasKeys.details(sucursalId), id] as const,
+  items: (sucursalId: number | null, id: string) => [...transferenciasKeys.detail(sucursalId, id), 'items'] as const,
 }
 
 export const sucursalesKeys = {
@@ -26,23 +46,41 @@ export const sucursalesKeys = {
   lists: () => [...sucursalesKeys.all, 'list'] as const,
 }
 
+interface FetchTransferenciasOpts {
+  desde: string
+  hasta: string
+  limit: number
+  offset: number
+}
+
 // Fetch functions
-async function fetchTransferencias(): Promise<TransferenciaDB[]> {
+async function fetchTransferencias(opts: FetchTransferenciasOpts): Promise<TransferenciaDB[]> {
   const { data, error } = await supabase
     .from('transferencias_stock')
     .select(`
       *,
-      sucursal:sucursales(*),
-      items:transferencia_items(*, producto:productos(*)),
+      sucursal:sucursales(id, nombre),
       usuario:perfiles(id, nombre)
     `)
+    .gte('fecha', opts.desde)
+    .lte('fecha', opts.hasta)
     .order('created_at', { ascending: false })
+    .range(opts.offset, opts.offset + opts.limit - 1)
 
   if (error) {
     if (error.message.includes('does not exist')) return []
     throw error
   }
   return (data || []) as TransferenciaDB[]
+}
+
+async function fetchTransferenciaItems(transferenciaId: string): Promise<TransferenciaItemDB[]> {
+  const { data, error } = await supabase
+    .from('transferencia_items')
+    .select('*, producto:productos(*)')
+    .eq('transferencia_id', transferenciaId)
+  if (error) throw error
+  return (data || []) as TransferenciaItemDB[]
 }
 
 async function fetchSucursales(): Promise<SucursalDB[]> {
@@ -142,13 +180,42 @@ async function registrarIngresoSucursal(formData: TransferenciaFormInput): Promi
 // Hooks
 
 /**
- * Hook para obtener todas las transferencias
+ * Hook para obtener transferencias paginadas con filtro de fecha.
+ * Default: ultimos 60 dias, pagina 1, 50 filas. Para historial mayor, el
+ * caller puede pasar `desde` / `hasta` y `pagina`.
+ *
+ * Importante: el listado NO trae items — solo el header + sucursal contraparte
+ * + usuario. Para ver items, abrir el detalle con useTransferenciaItemsQuery.
  */
-export function useTransferenciasQuery() {
+export function useTransferenciasQuery(filtros: TransferenciasFiltros = {}) {
+  const { currentSucursalId } = useSucursal()
+  const desde = filtros.desde ?? fechaHaceDias(60)
+  const hasta = filtros.hasta ?? fechaLocalISO()
+  const pagina = filtros.pagina ?? 1
+  const limit = TRANSFERENCIAS_PAGE_SIZE
+  return useQuery({
+    queryKey: transferenciasKeys.list(currentSucursalId, { desde, hasta, pagina }),
+    queryFn: () => fetchTransferencias({
+      desde,
+      hasta,
+      limit,
+      offset: (pagina - 1) * limit,
+    }),
+    staleTime: 5 * 60 * 1000,
+  })
+}
+
+/**
+ * Hook para cargar los items de UNA transferencia. Se usa al abrir el modal
+ * de detalle. Mantiene el listado liviano y evita el N+1 que tenia el query
+ * original al traer items + producto en cada fila.
+ */
+export function useTransferenciaItemsQuery(transferenciaId: string | null | undefined) {
   const { currentSucursalId } = useSucursal()
   return useQuery({
-    queryKey: transferenciasKeys.lists(currentSucursalId),
-    queryFn: fetchTransferencias,
+    queryKey: transferenciasKeys.items(currentSucursalId, transferenciaId ?? ''),
+    queryFn: () => fetchTransferenciaItems(transferenciaId!),
+    enabled: !!transferenciaId,
     staleTime: 5 * 60 * 1000,
   })
 }
@@ -188,6 +255,7 @@ export function useRegistrarTransferenciaMutation() {
   return useMutation({
     mutationFn: registrarTransferencia,
     onSuccess: () => {
+      // Invalida TODAS las paginas y filtros del listado actual de sucursal.
       queryClient.invalidateQueries({ queryKey: transferenciasKeys.lists(currentSucursalId) })
       queryClient.invalidateQueries({ queryKey: ['productos'] })
     },
@@ -204,6 +272,7 @@ export function useRegistrarIngresoMutation() {
   return useMutation({
     mutationFn: registrarIngresoSucursal,
     onSuccess: () => {
+      // Invalida TODAS las paginas y filtros del listado actual de sucursal.
       queryClient.invalidateQueries({ queryKey: transferenciasKeys.lists(currentSucursalId) })
       queryClient.invalidateQueries({ queryKey: ['productos'] })
     },

--- a/src/types/hooks.ts
+++ b/src/types/hooks.ts
@@ -966,6 +966,42 @@ export interface UsuarioSucursalDB {
   sucursal?: SucursalDB | null;
 }
 
+/**
+ * Audit log de sustituciones de regalos (mig 058). Una fila por cambio
+ * de producto/cantidad sobre un item bonificacion.
+ */
+export interface PedidoItemSustitucionDB {
+  id: string;
+  pedido_id: string;
+  pedido_item_id: string;
+  promocion_id: string | null;
+  producto_original_id: string;
+  producto_sustituto_id: string;
+  /** NUMERIC en DB; soporta fraccion */
+  cantidad_original: number;
+  cantidad_sustituta: number;
+  regalo_mueve_stock_snapshot: boolean | null;
+  motivo: string;
+  autorizado_por: string;
+  sucursal_id: number;
+  created_at: string;
+}
+
+/** Input para la RPC sustituir_regalo_pedido */
+export interface SustituirRegaloInput {
+  pedidoItemId: string;
+  productoNuevoId: string;
+  cantidadNueva: number;  // puede ser fraccion
+  motivo: string;
+  clientRequestId?: string;
+}
+
+export interface SustituirRegaloResult {
+  sustitucionId: string;
+  modo: 'A' | 'B';
+  idempotentReplay?: boolean;
+}
+
 export interface TransferenciaItemDB {
   id: string;
   transferencia_id: string;


### PR DESCRIPTION
## Summary

Dos cambios ortogonales en mismo PR:

### Bug A — Transferencias entre sucursales lentas + no muestran movimientos (mig 057)

La RLS `mt_transferencias_stock_select` filtraba solo por `tenant_sucursal_id = current_sucursal_id()`. Como una transferencia tiene dos sucursales involucradas (la que registra y la contraparte), la sucursal **receptora** nunca veia el movimiento que le mandaron desde la otra. Sintoma reportado: "ya hicimos transferencias y no aparecen".

Adicionalmente, el query del listado traia todo el historico sin LIMIT con joins anidados (items + producto + usuario + sucursal) — explicacion de la lentitud.

**Fix**:
- Migracion 057: RLS bidireccional + index compuesto `(sucursal_id, fecha DESC)`. Misma logica en `transferencia_items` via EXISTS al header.
- Frontend: paginacion server-side (50/pagina) + filtro de fecha desde/hasta (default ultimos 60 dias) + items on-demand al abrir el modal de detalle (sin N+1 en el listado).

### Bug B — Sustitucion profesional de regalos en promociones (mig 058)

Hoy el "cambio de regalo X por Y" se resuelve artesanal: el operador borra el item bonificacion y agrega otro con `precio=0`. **Problema critico**: el item original ya descontó stock del producto X cuando se creo el pedido, y nadie lo devuelve. Tampoco queda audit trail.

**Fix**:
- Migracion 058:
  - Tabla `pedido_item_sustituciones` (audit log dedicado, separado de salvedades). `cantidad` NUMERIC para soportar fraccion (regalos de promos fraccionales).
  - RPC `sustituir_regalo_pedido` (SECURITY DEFINER, solo admin/encargado):
    - **Modo A** (`regalo_mueve_stock=true`): devuelve stock X + descuenta Y.
    - **Modo B** (`regalo_mueve_stock=false`, ajuste por bloques): **NO** revierte el bloque del contenedor (otros usos del bloque siguen vivos). Solo descuenta Y. El bloque ya consumido por la promo queda como costo de la entrega.
    - **NO toca** `usos_pendientes`, `promo_ajustes` ni reglas — la sustitucion es ortogonal al gatillo. La promo ya disparo y ya consumio su uso; solo cambia el producto entregado.
    - Idempotencia via `client_request_id` (mismo patron mig 049).
- Frontend:
  - `ModalSustituirRegalo`: banner visual del modo (verde Modo A / amarillo Modo B con explicacion), selector de producto, cantidad NUMERIC (acepta 0.5, 0.75, etc.), motivo obligatorio.
  - `ModalEditarPedido`: nueva seccion "Regalos persistidos" con boton "Cambiar regalo" visible solo para admin/encargado (`canSustituirRegalo`). Las bonificaciones recalculadas (locales) siguen mostrandose en read-only por separado.
  - `ModalHistorialPedido`: label `sustitucion_regalo` mapeado.

## Migraciones aplicadas

- `057_transferencias_rls_bidireccional` — ya aplicada via MCP.
- `058_pedido_item_sustituciones` — ya aplicada via MCP.

## Test plan

**Bug A**:
- [ ] Usuario en sucursal **destino** abre `/transferencias` -> ve los movimientos que le enviaron desde otra sucursal.
- [ ] Origen sigue viendo los que envio.
- [ ] Primera pagina carga < 1s con 50 filas (sin items).
- [ ] Abrir detalle dispara query de items independiente.
- [ ] Filtro de fecha amplia el rango sin recargar joins pesados.

**Bug B**:
- [ ] **Modo A**: admin/encargado abre pedido con regalo entero, sustituye, confirma. Stock X +cantidad, stock Y -cantidad. Audit creado con `regalo_mueve_stock_snapshot=true`.
- [ ] **Modo B**: sustituir regalo fraccional (0.5 unidades) o entero pero con promo `regalo_mueve_stock=false`. Stock X **sin cambio**, contenedor **sin cambio**, stock Y -cantidad.
- [ ] `promociones.usos_pendientes` y `promocion_reglas` no cambian en ningun caso.
- [ ] Preventista no puede sustituir (RPC rechaza con "Solo admin o encargado").
- [ ] Pedido entregado: RPC rechaza.
- [ ] Item no-bonificacion: RPC rechaza.
- [ ] Stock insuficiente del nuevo producto: rechaza con stock disponible.
- [ ] Retry con mismo UUID: retorna `idempotent_replay=true`.
- [ ] Sustitucion aparece en historial del pedido como "Sustitucion de regalo".

🤖 Generated with [Claude Code](https://claude.com/claude-code)