### PR TITLE
fix(promos): barras paralelas por producto regalado al sustituir (modo B)

### DIFF
--- a/migrations/059_promo_acumuladores_paralelos.sql
+++ b/migrations/059_promo_acumuladores_paralelos.sql
@@ -1,0 +1,485 @@
+-- =========================================================================
+-- 059_promo_acumuladores_paralelos.sql
+--
+-- Soporta "barras paralelas" en promociones con `ajuste_automatico=true`:
+-- una promo puede tener varios productos regalados a la vez (cuando admin
+-- sustituye un regalo por otro vía `sustituir_regalo_pedido`). Cada
+-- (promo, producto_regalo, sucursal) lleva su propio `usos_pendientes` y
+-- su propio contenedor; cuando un acumulador completa un bloque se descuenta
+-- 1 fardo del contenedor; cuando cruza hacia abajo (porque se sustituyo),
+-- se devuelve 1 fardo al stock.
+--
+-- Estrategia de minimo invasivo:
+--   * NO se refactorizan `crear_pedido_completo`, `actualizar_pedido_items`
+--     ni `registrar_salvedad`. Esas RPCs siguen actualizando solo
+--     `promociones.usos_pendientes` global (que corresponde al producto
+--     regalado default).
+--   * `sustituir_regalo_pedido` se encarga de sincronizar
+--     `promociones.usos_pendientes` <-> `promo_acumuladores` (entry default)
+--     al inicio y al final, y aplicar los deltas por producto en
+--     `promo_acumuladores` via el helper.
+--   * `promo_acumuladores` es la fuente para multi-barra en UI; cuando una
+--     entry NO existe en la tabla (porque la promo nunca tuvo sustituciones)
+--     la UI cae a `promociones.usos_pendientes` para mostrar la barra default.
+--
+-- Tambien:
+--   * Se agrega columna `ajuste_producto_id_nuevo` a `pedido_item_sustituciones`
+--     para auditar que contenedor eligio el admin al sustituir.
+-- =========================================================================
+
+BEGIN;
+
+-- -------------------------------------------------------------------------
+-- 1) Tabla promo_acumuladores
+-- -------------------------------------------------------------------------
+
+CREATE TABLE IF NOT EXISTS public.promo_acumuladores (
+  id                  BIGSERIAL PRIMARY KEY,
+  promocion_id        BIGINT NOT NULL REFERENCES public.promociones(id) ON DELETE CASCADE,
+  producto_regalo_id  BIGINT NOT NULL REFERENCES public.productos(id),
+  ajuste_producto_id  BIGINT REFERENCES public.productos(id),
+  unidades_por_bloque INT,
+  stock_por_bloque    INT,
+  usos_pendientes     NUMERIC(10,2) NOT NULL DEFAULT 0,
+  sucursal_id         BIGINT NOT NULL REFERENCES public.sucursales(id),
+  created_at          TIMESTAMPTZ DEFAULT NOW() NOT NULL,
+  updated_at          TIMESTAMPTZ DEFAULT NOW() NOT NULL,
+  UNIQUE (promocion_id, producto_regalo_id, sucursal_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_promo_acumuladores_promo
+  ON public.promo_acumuladores (promocion_id, sucursal_id);
+
+CREATE INDEX IF NOT EXISTS idx_promo_acumuladores_producto
+  ON public.promo_acumuladores (sucursal_id, producto_regalo_id);
+
+ALTER TABLE public.promo_acumuladores ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "mt_promo_acumuladores_select" ON public.promo_acumuladores;
+CREATE POLICY "mt_promo_acumuladores_select"
+  ON public.promo_acumuladores FOR SELECT TO authenticated
+  USING (sucursal_id = public.current_sucursal_id());
+
+-- INSERT/UPDATE/DELETE: solo via RPCs SECURITY DEFINER. No policy directa.
+
+GRANT SELECT ON public.promo_acumuladores TO authenticated;
+GRANT ALL ON public.promo_acumuladores TO service_role;
+GRANT USAGE, SELECT ON SEQUENCE public.promo_acumuladores_id_seq TO authenticated;
+
+-- -------------------------------------------------------------------------
+-- 2) Backfill: una fila por promo con ajuste_automatico=true
+-- -------------------------------------------------------------------------
+
+INSERT INTO public.promo_acumuladores (
+  promocion_id, producto_regalo_id, ajuste_producto_id,
+  unidades_por_bloque, stock_por_bloque,
+  usos_pendientes, sucursal_id
+)
+SELECT id, producto_regalo_id, ajuste_producto_id,
+       unidades_por_bloque, stock_por_bloque,
+       COALESCE(usos_pendientes, 0), sucursal_id
+FROM public.promociones
+WHERE ajuste_automatico = TRUE
+  AND producto_regalo_id IS NOT NULL
+ON CONFLICT (promocion_id, producto_regalo_id, sucursal_id) DO NOTHING;
+
+-- -------------------------------------------------------------------------
+-- 3) Helper: aplicar_uso_promo_acumulador
+-- -------------------------------------------------------------------------
+-- Aplica un delta (positivo o negativo) al acumulador y maneja:
+--   * cruce hacia arriba de multiplo de unidades_por_bloque -> descuenta
+--     stock_por_bloque del contenedor.
+--   * cruce hacia abajo -> devuelve stock_por_bloque al contenedor.
+-- Loguea en promo_ajustes con valores positivos o negativos segun corresponda.
+-- Solo opera si la promo es modo B (ajuste_automatico=true) y la entry tiene
+-- contenedor + unidades_por_bloque + stock_por_bloque validos.
+-- Crea la entry si no existe.
+
+CREATE OR REPLACE FUNCTION public.aplicar_uso_promo_acumulador(
+  p_promocion_id            BIGINT,
+  p_producto_regalo_id      BIGINT,
+  p_delta                   NUMERIC,
+  p_ajuste_producto_id_def  BIGINT,
+  p_sucursal_id             BIGINT,
+  p_usuario_id              UUID,
+  p_motivo                  TEXT
+) RETURNS JSONB
+LANGUAGE plpgsql SECURITY DEFINER SET search_path TO 'public'
+AS $$
+DECLARE
+  v_promo RECORD;
+  v_acc   RECORD;
+  v_old_blocks INT;
+  v_new_blocks INT;
+  v_delta_blocks INT;
+  v_usos_nuevo NUMERIC;
+BEGIN
+  SELECT id, unidades_por_bloque, stock_por_bloque, ajuste_automatico,
+         ajuste_producto_id, regalo_mueve_stock
+    INTO v_promo
+    FROM promociones
+   WHERE id = p_promocion_id
+     AND sucursal_id = p_sucursal_id
+   FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RETURN jsonb_build_object('aplicado', false, 'razon', 'promo no encontrada');
+  END IF;
+  IF NOT COALESCE(v_promo.ajuste_automatico, FALSE) THEN
+    RETURN jsonb_build_object('aplicado', false, 'razon', 'promo no es modo B');
+  END IF;
+  IF COALESCE(v_promo.unidades_por_bloque, 0) <= 0
+     OR COALESCE(v_promo.stock_por_bloque, 0) <= 0 THEN
+    RETURN jsonb_build_object('aplicado', false, 'razon', 'config bloque invalida');
+  END IF;
+
+  -- Obtener / crear acumulador con FOR UPDATE
+  SELECT id, ajuste_producto_id, unidades_por_bloque, stock_por_bloque, usos_pendientes
+    INTO v_acc
+    FROM promo_acumuladores
+   WHERE promocion_id = p_promocion_id
+     AND producto_regalo_id = p_producto_regalo_id
+     AND sucursal_id = p_sucursal_id
+   FOR UPDATE;
+
+  IF NOT FOUND THEN
+    INSERT INTO promo_acumuladores (
+      promocion_id, producto_regalo_id, ajuste_producto_id,
+      unidades_por_bloque, stock_por_bloque, usos_pendientes, sucursal_id
+    ) VALUES (
+      p_promocion_id, p_producto_regalo_id, p_ajuste_producto_id_def,
+      v_promo.unidades_por_bloque, v_promo.stock_por_bloque, 0, p_sucursal_id
+    )
+    RETURNING id, ajuste_producto_id, unidades_por_bloque, stock_por_bloque, usos_pendientes
+    INTO v_acc;
+  END IF;
+
+  v_old_blocks := FLOOR(GREATEST(v_acc.usos_pendientes, 0) / v_acc.unidades_por_bloque)::INT;
+  v_usos_nuevo := v_acc.usos_pendientes + p_delta;
+
+  UPDATE promo_acumuladores
+     SET usos_pendientes = v_usos_nuevo,
+         updated_at = NOW()
+   WHERE id = v_acc.id;
+
+  v_new_blocks := FLOOR(GREATEST(v_usos_nuevo, 0) / v_acc.unidades_por_bloque)::INT;
+  v_delta_blocks := v_new_blocks - v_old_blocks;
+
+  IF v_delta_blocks != 0 AND v_acc.ajuste_producto_id IS NOT NULL THEN
+    -- Contexto para trigger registrar_cambio_stock (mig 038)
+    PERFORM set_config('app.stock_origen', 'auto_ajuste_promo', true);
+    PERFORM set_config('app.stock_ref_tipo', 'promocion', true);
+    PERFORM set_config('app.stock_ref_id', p_promocion_id::TEXT, true);
+    PERFORM set_config('app.stock_user_id', p_usuario_id::TEXT, true);
+
+    -- v_delta_blocks > 0: completa bloque => descontar stock (resta).
+    -- v_delta_blocks < 0: revierte bloque => devolver stock (suma).
+    UPDATE productos
+       SET stock = stock - (v_delta_blocks * v_acc.stock_por_bloque),
+           updated_at = NOW()
+     WHERE id = v_acc.ajuste_producto_id
+       AND sucursal_id = p_sucursal_id;
+
+    INSERT INTO promo_ajustes (
+      promocion_id, usos_ajustados, unidades_ajustadas,
+      producto_id, usuario_id, observaciones, sucursal_id
+    ) VALUES (
+      p_promocion_id,
+      v_delta_blocks * v_acc.unidades_por_bloque,
+      v_delta_blocks * v_acc.stock_por_bloque,
+      v_acc.ajuste_producto_id, p_usuario_id, p_motivo, p_sucursal_id
+    );
+  END IF;
+
+  RETURN jsonb_build_object(
+    'aplicado', true,
+    'acumulador_id', v_acc.id,
+    'usos_pendientes', v_usos_nuevo,
+    'bloques_delta', v_delta_blocks
+  );
+END;
+$$;
+
+ALTER FUNCTION public.aplicar_uso_promo_acumulador(BIGINT, BIGINT, NUMERIC, BIGINT, BIGINT, UUID, TEXT)
+  OWNER TO postgres;
+
+GRANT EXECUTE ON FUNCTION public.aplicar_uso_promo_acumulador(BIGINT, BIGINT, NUMERIC, BIGINT, BIGINT, UUID, TEXT)
+  TO authenticated, service_role;
+
+COMMENT ON FUNCTION public.aplicar_uso_promo_acumulador(BIGINT, BIGINT, NUMERIC, BIGINT, BIGINT, UUID, TEXT) IS
+  'Aplica delta al acumulador (promo,producto_regalo,sucursal). Cruza umbrales hacia arriba/abajo y descuenta/devuelve fardos del contenedor. Crea entry si no existe.';
+
+-- -------------------------------------------------------------------------
+-- 4) Ampliacion de pedido_item_sustituciones: audit del contenedor sustituto
+-- -------------------------------------------------------------------------
+
+ALTER TABLE public.pedido_item_sustituciones
+  ADD COLUMN IF NOT EXISTS ajuste_producto_id_nuevo BIGINT REFERENCES public.productos(id);
+
+COMMENT ON COLUMN public.pedido_item_sustituciones.ajuste_producto_id_nuevo IS
+  'Contenedor (fardo) que el admin eligio para el producto sustituto en Modo B. NULL si Modo A o si admin opto por "sin contenedor".';
+
+-- -------------------------------------------------------------------------
+-- 5) Redefinir sustituir_regalo_pedido
+-- -------------------------------------------------------------------------
+-- Cambios respecto a mig 058:
+--   * Acepta p_ajuste_producto_id_nuevo (contenedor del sustituto).
+--   * Modo B: NO mueve stock unitario. Usa aplicar_uso_promo_acumulador
+--     para ajustar acumuladores y disparar reversion/descuento de bloques.
+--   * Modo A: comportamiento sigue igual (devuelve original, descuenta nuevo).
+--   * Modo B: sincroniza promociones.usos_pendientes <-> entry default
+--     al inicio y al final (porque crear_pedido_completo solo actualiza
+--     promociones.usos_pendientes).
+
+DROP FUNCTION IF EXISTS public.sustituir_regalo_pedido(BIGINT, BIGINT, NUMERIC, TEXT, UUID);
+
+CREATE OR REPLACE FUNCTION public.sustituir_regalo_pedido(
+  p_pedido_item_id           BIGINT,
+  p_producto_nuevo_id        BIGINT,
+  p_cantidad_nueva           NUMERIC,
+  p_motivo                   TEXT,
+  p_ajuste_producto_id_nuevo BIGINT DEFAULT NULL,
+  p_client_request_id        UUID   DEFAULT NULL
+) RETURNS JSONB
+LANGUAGE plpgsql SECURITY DEFINER SET search_path TO 'public'
+AS $$
+DECLARE
+  v_user_id            UUID := auth.uid();
+  v_user_role          TEXT;
+  v_sucursal           BIGINT := current_sucursal_id();
+  v_item               RECORD;
+  v_promo              RECORD;
+  v_stock_nuevo        NUMERIC;
+  v_regalo_mueve_stock BOOLEAN;
+  v_sust_id            BIGINT;
+  v_existing           RECORD;
+  v_nuevo_nombre       TEXT;
+  v_promo_usos_default NUMERIC;
+  v_acc_default        RECORD;
+BEGIN
+  IF v_sucursal IS NULL THEN
+    RETURN jsonb_build_object('success', false, 'error', 'No hay sucursal activa');
+  END IF;
+  IF v_user_id IS NULL THEN
+    RETURN jsonb_build_object('success', false, 'error', 'No autenticado');
+  END IF;
+
+  -- 0) Idempotencia
+  IF p_client_request_id IS NOT NULL THEN
+    SELECT id INTO v_existing
+      FROM pedido_item_sustituciones
+     WHERE client_request_id = p_client_request_id;
+    IF FOUND THEN
+      RETURN jsonb_build_object('success', true,
+        'sustitucion_id', v_existing.id,
+        'idempotent_replay', true);
+    END IF;
+  END IF;
+
+  -- 1) Rol
+  SELECT rol INTO v_user_role FROM perfiles WHERE id = v_user_id;
+  IF v_user_role NOT IN ('admin', 'encargado') THEN
+    RETURN jsonb_build_object('success', false,
+      'error', 'Solo admin o encargado pueden sustituir regalos');
+  END IF;
+
+  -- 2) Cantidad > 0
+  IF p_cantidad_nueva IS NULL OR p_cantidad_nueva <= 0 THEN
+    RETURN jsonb_build_object('success', false,
+      'error', 'La cantidad sustituta debe ser mayor a 0');
+  END IF;
+
+  -- 3) Cargar item + pedido + lock
+  SELECT pi.id, pi.pedido_id, pi.producto_id, pi.cantidad, pi.es_bonificacion,
+         pi.promocion_id, pi.sucursal_id, p.estado AS pedido_estado
+    INTO v_item
+    FROM pedido_items pi
+    JOIN pedidos p ON p.id = pi.pedido_id
+   WHERE pi.id = p_pedido_item_id
+     AND pi.sucursal_id = v_sucursal
+   FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RETURN jsonb_build_object('success', false, 'error', 'Item no encontrado');
+  END IF;
+  IF NOT COALESCE(v_item.es_bonificacion, FALSE) THEN
+    RETURN jsonb_build_object('success', false,
+      'error', 'Solo se pueden sustituir items marcados como bonificacion');
+  END IF;
+  IF v_item.pedido_estado = 'entregado' THEN
+    RETURN jsonb_build_object('success', false,
+      'error', 'No se puede sustituir un regalo en un pedido ya entregado');
+  END IF;
+
+  -- 4) Modo de la promo
+  IF v_item.promocion_id IS NOT NULL THEN
+    SELECT id, regalo_mueve_stock, ajuste_automatico, producto_regalo_id,
+           ajuste_producto_id, unidades_por_bloque, stock_por_bloque,
+           usos_pendientes
+      INTO v_promo
+      FROM promociones
+     WHERE id = v_item.promocion_id AND sucursal_id = v_sucursal;
+  END IF;
+  v_regalo_mueve_stock := COALESCE(v_promo.regalo_mueve_stock, TRUE);
+
+  SELECT nombre INTO v_nuevo_nombre
+    FROM productos WHERE id = p_producto_nuevo_id AND sucursal_id = v_sucursal;
+
+  -- 5) Stock movement segun modo
+  IF v_regalo_mueve_stock THEN
+    -- Modo A: validar stock + devolver X + descontar Y
+    SELECT stock INTO v_stock_nuevo
+      FROM productos
+     WHERE id = p_producto_nuevo_id AND sucursal_id = v_sucursal
+     FOR UPDATE;
+    IF v_stock_nuevo IS NULL THEN
+      RETURN jsonb_build_object('success', false,
+        'error', 'Producto sustituto no existe en esta sucursal');
+    END IF;
+    IF v_stock_nuevo < p_cantidad_nueva THEN
+      RETURN jsonb_build_object('success', false,
+        'error', 'Stock insuficiente del producto sustituto (' || v_stock_nuevo || ' disponible)');
+    END IF;
+
+    PERFORM set_config('app.stock_origen', 'sustitucion_regalo', true);
+    PERFORM set_config('app.stock_ref_tipo', 'pedido', true);
+    PERFORM set_config('app.stock_ref_id', v_item.pedido_id::TEXT, true);
+    PERFORM set_config('app.stock_user_id', v_user_id::TEXT, true);
+
+    UPDATE productos
+       SET stock = stock + v_item.cantidad
+     WHERE id = v_item.producto_id AND sucursal_id = v_sucursal;
+
+    UPDATE productos
+       SET stock = stock - p_cantidad_nueva
+     WHERE id = p_producto_nuevo_id AND sucursal_id = v_sucursal;
+  ELSE
+    -- Modo B: barras paralelas. NO se mueve stock unitario.
+    -- 5.B.1) Sincronizar promociones.usos_pendientes -> promo_acumuladores
+    -- para la entry default (producto regalo original de la promo) ANTES
+    -- de aplicar los deltas. Esto cubre incrementos hechos por
+    -- crear_pedido_completo que no escribieron en promo_acumuladores.
+    IF v_promo.producto_regalo_id IS NOT NULL THEN
+      SELECT id, usos_pendientes
+        INTO v_acc_default
+        FROM promo_acumuladores
+       WHERE promocion_id = v_promo.id
+         AND producto_regalo_id = v_promo.producto_regalo_id
+         AND sucursal_id = v_sucursal
+       FOR UPDATE;
+
+      IF FOUND THEN
+        -- Si el acumulador default difiere de promociones.usos_pendientes,
+        -- "alinear" el acumulador al valor global ANTES de aplicar el delta
+        -- de la sustitucion. Esto reproduce los cierres de bloque que
+        -- ya ocurrieron en crear_pedido_completo SIN tocar stock (porque
+        -- el stock ya fue descontado por la RPC vieja).
+        IF v_acc_default.usos_pendientes IS DISTINCT FROM COALESCE(v_promo.usos_pendientes, 0) THEN
+          UPDATE promo_acumuladores
+             SET usos_pendientes = COALESCE(v_promo.usos_pendientes, 0),
+                 updated_at = NOW()
+           WHERE id = v_acc_default.id;
+        END IF;
+      ELSE
+        -- No habia entry default (backfill no la creo porque la promo
+        -- no era ajuste_automatico al momento del backfill, p.ej.).
+        -- Crearla con el usos_pendientes actual.
+        INSERT INTO promo_acumuladores (
+          promocion_id, producto_regalo_id, ajuste_producto_id,
+          unidades_por_bloque, stock_por_bloque,
+          usos_pendientes, sucursal_id
+        ) VALUES (
+          v_promo.id, v_promo.producto_regalo_id, v_promo.ajuste_producto_id,
+          v_promo.unidades_por_bloque, v_promo.stock_por_bloque,
+          COALESCE(v_promo.usos_pendientes, 0), v_sucursal
+        )
+        ON CONFLICT (promocion_id, producto_regalo_id, sucursal_id) DO NOTHING;
+      END IF;
+    END IF;
+
+    -- 5.B.2) Decrementar acumulador del producto original.
+    PERFORM public.aplicar_uso_promo_acumulador(
+      v_promo.id, v_item.producto_id, -v_item.cantidad,
+      v_promo.ajuste_producto_id, v_sucursal, v_user_id,
+      'sustitucion: salida del producto regalo original'
+    );
+
+    -- 5.B.3) Incrementar acumulador del producto sustituto.
+    PERFORM public.aplicar_uso_promo_acumulador(
+      v_promo.id, p_producto_nuevo_id, p_cantidad_nueva,
+      COALESCE(p_ajuste_producto_id_nuevo, v_promo.ajuste_producto_id),
+      v_sucursal, v_user_id,
+      'sustitucion: entrada del producto regalo sustituto'
+    );
+
+    -- 5.B.4) Re-sincronizar promociones.usos_pendientes <- entry default.
+    IF v_promo.producto_regalo_id IS NOT NULL THEN
+      SELECT usos_pendientes INTO v_promo_usos_default
+        FROM promo_acumuladores
+       WHERE promocion_id = v_promo.id
+         AND producto_regalo_id = v_promo.producto_regalo_id
+         AND sucursal_id = v_sucursal;
+
+      UPDATE promociones
+         SET usos_pendientes = GREATEST(COALESCE(v_promo_usos_default, 0)::INT, 0)
+       WHERE id = v_promo.id AND sucursal_id = v_sucursal;
+    END IF;
+  END IF;
+
+  -- 6) Update pedido_item
+  UPDATE pedido_items
+     SET producto_id = p_producto_nuevo_id,
+         cantidad    = p_cantidad_nueva,
+         subtotal    = 0,
+         descripcion_regalo = COALESCE(descripcion_regalo, '') ||
+                              ' [Sustituido por: ' || COALESCE(v_nuevo_nombre, '?') || ']'
+   WHERE id = p_pedido_item_id;
+
+  -- 7) Audit en pedido_item_sustituciones
+  INSERT INTO pedido_item_sustituciones (
+    pedido_id, pedido_item_id, promocion_id,
+    producto_original_id, producto_sustituto_id,
+    cantidad_original, cantidad_sustituta,
+    regalo_mueve_stock_snapshot,
+    ajuste_producto_id_nuevo,
+    motivo, autorizado_por, sucursal_id, client_request_id
+  ) VALUES (
+    v_item.pedido_id, p_pedido_item_id, v_item.promocion_id,
+    v_item.producto_id, p_producto_nuevo_id,
+    v_item.cantidad, p_cantidad_nueva,
+    v_regalo_mueve_stock,
+    p_ajuste_producto_id_nuevo,
+    p_motivo, v_user_id, v_sucursal, p_client_request_id
+  ) RETURNING id INTO v_sust_id;
+
+  -- 8) Trace en pedido_historial
+  INSERT INTO pedido_historial (
+    pedido_id, usuario_id, campo_modificado, valor_anterior, valor_nuevo, sucursal_id
+  ) VALUES (
+    v_item.pedido_id, v_user_id, 'sustitucion_regalo',
+    'producto_id=' || v_item.producto_id || ' cantidad=' || v_item.cantidad,
+    'producto_id=' || p_producto_nuevo_id || ' cantidad=' || p_cantidad_nueva ||
+      ' motivo=' || p_motivo,
+    v_sucursal
+  );
+
+  RETURN jsonb_build_object(
+    'success', true,
+    'sustitucion_id', v_sust_id,
+    'modo', CASE WHEN v_regalo_mueve_stock THEN 'A' ELSE 'B' END
+  );
+EXCEPTION WHEN OTHERS THEN
+  RETURN jsonb_build_object('success', false, 'error', SQLERRM);
+END;
+$$;
+
+ALTER FUNCTION public.sustituir_regalo_pedido(BIGINT, BIGINT, NUMERIC, TEXT, BIGINT, UUID)
+  OWNER TO postgres;
+
+GRANT EXECUTE ON FUNCTION public.sustituir_regalo_pedido(BIGINT, BIGINT, NUMERIC, TEXT, BIGINT, UUID)
+  TO authenticated, service_role;
+
+COMMENT ON FUNCTION public.sustituir_regalo_pedido(BIGINT, BIGINT, NUMERIC, TEXT, BIGINT, UUID) IS
+  'Sustituye un item bonificacion. Modo A: devuelve stock X + descuenta Y. Modo B: ajusta barras paralelas en promo_acumuladores, devuelve/descuenta fardos al cruzar umbrales de bloque. Solo admin/encargado. Idempotente.';
+
+COMMIT;

--- a/src/components/containers/PromocionesContainer.tsx
+++ b/src/components/containers/PromocionesContainer.tsx
@@ -13,6 +13,7 @@ import {
   useEliminarPromocionMutation,
   useTogglePromocionActivaMutation,
   usePromoUnidadesEntregadasQuery,
+  usePromoAcumuladoresMapQuery,
 } from '../../hooks/queries'
 import type { PromocionConDetalles, PromocionFormInput } from '../../hooks/queries/usePromocionesQuery'
 import { useNotification } from '../../contexts/NotificationContext'
@@ -44,6 +45,7 @@ export default function PromocionesContainer(): React.ReactElement {
   const { data: promociones = [], isLoading } = usePromocionesListQuery()
   const { data: productos = [] } = useProductosQuery()
   const { data: unidadesEntregadas } = usePromoUnidadesEntregadasQuery()
+  const { data: acumuladoresPorPromo } = usePromoAcumuladoresMapQuery()
 
   const productoNombres = useMemo(() => {
     const m = new Map<string, string>()
@@ -125,6 +127,7 @@ export default function PromocionesContainer(): React.ReactElement {
           promociones={promociones}
           productoNombres={productoNombres}
           unidadesEntregadas={unidadesEntregadas}
+          acumuladoresPorPromo={acumuladoresPorPromo}
           loading={isLoading}
           onNuevaPromocion={handleNuevaPromocion}
           onEditarPromocion={handleEditarPromocion}

--- a/src/components/modals/ModalEditarPedido.tsx
+++ b/src/components/modals/ModalEditarPedido.tsx
@@ -123,13 +123,16 @@ const ModalEditarPedido = memo(function ModalEditarPedido({
     [pedido]
   );
 
-  // Mapa promocion_id -> regalo_mueve_stock, para resolver el modo (A/B) de
-  // cada regalo persistido en el modal de sustitucion.
+  // Mapa promocion_id -> { regalo_mueve_stock, ajuste_producto_id } para
+  // resolver modo (A/B) y default del contenedor sustituto en el modal.
   const { data: promociones = [] } = usePromocionesListQuery();
-  const promoMueveStockMap = useMemo(() => {
-    const m = new Map<string, boolean>();
+  const promoInfoMap = useMemo(() => {
+    const m = new Map<string, { mueveStock: boolean; ajusteProductoId: string | null }>();
     for (const p of promociones) {
-      m.set(String(p.id), Boolean(p.regalo_mueve_stock));
+      m.set(String(p.id), {
+        mueveStock: Boolean(p.regalo_mueve_stock),
+        ajusteProductoId: p.ajuste_producto_id ? String(p.ajuste_producto_id) : null,
+      });
     }
     return m;
   }, [promociones]);
@@ -861,17 +864,21 @@ const ModalEditarPedido = memo(function ModalEditarPedido({
       {/* Modal de sustitucion de regalo (lazy) */}
       {sustItemTarget && sustItemTarget.producto && (
         <Suspense fallback={null}>
-          <ModalSustituirRegalo
-            pedidoItemId={sustItemTarget.id}
-            productoOriginal={sustItemTarget.producto}
-            cantidadOriginal={sustItemTarget.cantidad}
-            regaloMueveStock={
-              sustItemTarget.promocion_id
-                ? (promoMueveStockMap.get(String(sustItemTarget.promocion_id)) ?? true)
-                : true
-            }
-            onClose={() => setSustItemTarget(null)}
-          />
+          {(() => {
+            const info = sustItemTarget.promocion_id
+              ? promoInfoMap.get(String(sustItemTarget.promocion_id))
+              : null;
+            return (
+              <ModalSustituirRegalo
+                pedidoItemId={sustItemTarget.id}
+                productoOriginal={sustItemTarget.producto}
+                cantidadOriginal={sustItemTarget.cantidad}
+                regaloMueveStock={info?.mueveStock ?? true}
+                ajusteProductoIdOriginal={info?.ajusteProductoId ?? null}
+                onClose={() => setSustItemTarget(null)}
+              />
+            );
+          })()}
         </Suspense>
       )}
     </ModalBase>

--- a/src/components/modals/ModalSustituirRegalo.tsx
+++ b/src/components/modals/ModalSustituirRegalo.tsx
@@ -25,6 +25,9 @@ export interface ModalSustituirRegaloProps {
   cantidadOriginal: number
   /** Modo de la promo. true = Modo A (stock unitario), false = Modo B (bloques). */
   regaloMueveStock: boolean
+  /** Contenedor (fardo) configurado en la promo original. Default sugerido
+   *  para el selector de "contenedor del sustituto" en Modo B. */
+  ajusteProductoIdOriginal?: string | null
   onClose: () => void
   /** Callback al confirmar exitosamente (para que el caller refresque). */
   onSustituido?: () => void
@@ -35,6 +38,7 @@ const ModalSustituirRegalo = memo(function ModalSustituirRegalo({
   productoOriginal,
   cantidadOriginal,
   regaloMueveStock,
+  ajusteProductoIdOriginal = null,
   onClose,
   onSustituido,
 }: ModalSustituirRegaloProps) {
@@ -49,6 +53,12 @@ const ModalSustituirRegalo = memo(function ModalSustituirRegalo({
   const [productoNuevoId, setProductoNuevoId] = useState<string>('')
   const [cantidadNueva, setCantidadNueva] = useState<string>(String(cantidadOriginal))
   const [motivo, setMotivo] = useState<string>('')
+  // Contenedor del sustituto. Default = el de la promo original. El admin
+  // puede cambiarlo (otro fardo) o ponerlo en "" (= sin acumulacion de bloque).
+  // Solo aplica para Modo B.
+  const [ajusteProductoIdNuevo, setAjusteProductoIdNuevo] = useState<string>(
+    ajusteProductoIdOriginal ? String(ajusteProductoIdOriginal) : ''
+  )
   const [error, setError] = useState<string>('')
 
   const productoNuevo = useMemo(
@@ -67,7 +77,11 @@ const ModalSustituirRegalo = memo(function ModalSustituirRegalo({
   )
 
   const cantidadNum = parseFloat(cantidadNueva) || 0
-  const stockSuficiente = productoNuevo == null || (productoNuevo.stock ?? 0) >= cantidadNum
+  // Modo A descuenta stock unitario del nuevo producto -> hay que validar.
+  // Modo B no mueve stock unitario, solo acumula bloques -> no se valida acá.
+  const stockSuficiente = !regaloMueveStock
+    || productoNuevo == null
+    || (productoNuevo.stock ?? 0) >= cantidadNum
   const puedeConfirmar = !!productoNuevoId
     && cantidadNum > 0
     && motivo.trim().length > 0
@@ -83,6 +97,9 @@ const ModalSustituirRegalo = memo(function ModalSustituirRegalo({
         productoNuevoId,
         cantidadNueva: cantidadNum,
         motivo: motivo.trim(),
+        ajusteProductoIdNuevo: regaloMueveStock
+          ? null
+          : (ajusteProductoIdNuevo || null),
         clientRequestId,
       })
       notify.success(
@@ -119,19 +136,20 @@ const ModalSustituirRegalo = memo(function ModalSustituirRegalo({
           <div className="flex items-start gap-2 p-3 rounded-lg bg-emerald-50 dark:bg-emerald-900/20 border border-emerald-200 dark:border-emerald-800 text-sm text-emerald-800 dark:text-emerald-200">
             <Check className="w-4 h-4 mt-0.5 flex-shrink-0" />
             <p>
-              Esta promo descuenta stock por unidad. La sustitucion va a
+              <b>Modo A — stock por unidad.</b> La sustitucion va a
               <b> devolver {cantidadOriginal} de {productoOriginal.nombre}</b> al
               deposito y descontar la cantidad del producto sustituto.
             </p>
           </div>
         ) : (
-          <div className="flex items-start gap-2 p-3 rounded-lg bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800 text-sm text-amber-800 dark:text-amber-200">
+          <div className="flex items-start gap-2 p-3 rounded-lg bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-800 text-sm text-blue-800 dark:text-blue-200">
             <AlertTriangle className="w-4 h-4 mt-0.5 flex-shrink-0" />
             <p>
-              Esta promo se ajusta por bloque del producto contenedor. La
-              sustitucion va a descontar el stock del nuevo producto pero
-              <b> NO va a reponer el contenedor original</b>. El bloque ya
-              consumido por la promo se mantiene.
+              <b>Modo B — ajuste por bloque.</b> Esta sustitucion <b>no mueve stock unitario</b>.
+              El acumulador del producto original baja en {cantidadOriginal} y se crea/incrementa
+              una <b>barra paralela</b> para el sustituto. Si la baja cruza un bloque cerrado,
+              <b> se devuelve el fardo original al stock</b>. Cuando la barra del sustituto complete
+              un bloque, se descuenta 1 fardo del contenedor que elijas abajo.
             </p>
           </div>
         )}
@@ -155,6 +173,34 @@ const ModalSustituirRegalo = memo(function ModalSustituirRegalo({
           </select>
         </div>
 
+        {/* Contenedor sustituto (solo modo B) */}
+        {!regaloMueveStock && (
+          <div>
+            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+              Contenedor del regalo sustituto
+              <span className="ml-1 text-xs text-gray-500 font-normal">
+                (fardo a descontar cuando complete bloque)
+              </span>
+            </label>
+            <select
+              value={ajusteProductoIdNuevo}
+              onChange={e => setAjusteProductoIdNuevo(e.target.value)}
+              className="w-full px-3 py-2 border rounded-lg dark:bg-gray-700 dark:border-gray-600 dark:text-white"
+            >
+              <option value="">Sin contenedor — el sustituto no acumula bloque</option>
+              {productosOpciones.map(p => (
+                <option key={`cont-${p.id}`} value={p.id}>
+                  {p.nombre}{ajusteProductoIdOriginal && String(p.id) === String(ajusteProductoIdOriginal) ? ' · default de la promo' : ''}
+                </option>
+              ))}
+            </select>
+            <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
+              Por defecto se sugiere el mismo contenedor de la promo original. Cambialo
+              si el sustituto pertenece a otro fardo.
+            </p>
+          </div>
+        )}
+
         {/* Cantidad */}
         <div>
           <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
@@ -173,7 +219,7 @@ const ModalSustituirRegalo = memo(function ModalSustituirRegalo({
             Se acepta fraccion (ej. 0.5). Por defecto se asume la misma
             cantidad que el regalo original.
           </p>
-          {productoNuevo && !stockSuficiente && (
+          {productoNuevo && regaloMueveStock && !stockSuficiente && (
             <p className="text-xs text-red-600 mt-1 flex items-center gap-1">
               <AlertTriangle className="w-3 h-3" />
               Stock insuficiente del producto sustituto ({productoNuevo.stock ?? 0} disponible)

--- a/src/components/vistas/VistaPromociones.tsx
+++ b/src/components/vistas/VistaPromociones.tsx
@@ -9,6 +9,7 @@ import React, { useMemo, useState } from 'react'
 import { Plus, Edit2, Trash2, ToggleLeft, ToggleRight, Package, Gift, Layers, Ban, Zap, History, Filter } from 'lucide-react'
 import { fechaLocalISO } from '../../utils/formatters'
 import type { PromocionConDetalles } from '../../hooks/queries/usePromocionesQuery'
+import type { PromoAcumuladorDB } from '../../types'
 
 type FiltroEstado = 'vigentes' | 'todas' | 'inactivas'
 
@@ -23,6 +24,10 @@ export interface VistaPromocionesProps {
   productoNombres: Map<string, string>
   /** Map promo_id -> total unidades regaladas historicas (suma de pedido_items.cantidad con es_bonificacion=true) */
   unidadesEntregadas?: Map<string, number>
+  /** Map promo_id -> acumuladores paralelos (mig 059). Si una promo tiene
+   *  entries, renderizamos una barra por entry; si no, fallback a la barra
+   *  unica basada en promo.usos_pendientes. */
+  acumuladoresPorPromo?: Map<string, PromoAcumuladorDB[]>
 }
 
 export default function VistaPromociones({
@@ -34,6 +39,7 @@ export default function VistaPromociones({
   onToggleActivo,
   productoNombres,
   unidadesEntregadas,
+  acumuladoresPorPromo,
 }: VistaPromocionesProps): React.ReactElement {
   const [filtro, setFiltro] = useState<FiltroEstado>('vigentes')
   const [mostrarHistorico, setMostrarHistorico] = useState(false)
@@ -250,36 +256,88 @@ export default function VistaPromociones({
                   </div>
                 )}
 
-                {/* Subunidades pendientes para el proximo bloque (solo fracción) */}
+                {/* Subunidades pendientes para descontar stock — multi-barra (mig 059).
+                    Si hay acumuladores en promo_acumuladores los mostramos uno por uno;
+                    para el regalo default siempre se muestra incluso si esta en 0/N
+                    (con leyenda "Bloque recien cerrado"); los acumuladores
+                    alternativos (sustituciones) solo se muestran si usos_pendientes > 0. */}
                 {promo.ajuste_automatico && promo.unidades_por_bloque && promo.unidades_por_bloque > 0 && (
                   (() => {
-                    const pendientes = promo.usos_pendientes ?? 0
-                    const porBloque = promo.unidades_por_bloque ?? 0
-                    const falta = Math.max(porBloque - pendientes, 0)
-                    const progreso = porBloque > 0 ? Math.min((pendientes / porBloque) * 100, 100) : 0
+                    const acumuladores = (acumuladoresPorPromo?.get(String(promo.id)) ?? []).slice()
+                    const defaultProductoId = promo.producto_regalo_id ? String(promo.producto_regalo_id) : null
+
+                    // Si NO hay acumuladores en la tabla, sintetizamos uno default desde promo.usos_pendientes.
+                    if (acumuladores.length === 0 && defaultProductoId) {
+                      acumuladores.push({
+                        id: `legacy-${promo.id}`,
+                        promocion_id: String(promo.id),
+                        producto_regalo_id: defaultProductoId,
+                        ajuste_producto_id: promo.ajuste_producto_id ? String(promo.ajuste_producto_id) : null,
+                        unidades_por_bloque: promo.unidades_por_bloque,
+                        stock_por_bloque: promo.stock_por_bloque,
+                        usos_pendientes: promo.usos_pendientes ?? 0,
+                        sucursal_id: 0,
+                        created_at: '',
+                        updated_at: '',
+                      } as PromoAcumuladorDB)
+                    }
+
+                    // Filtrar: mostrar default siempre, alternativos solo si > 0.
+                    const visibles = acumuladores.filter(acc => {
+                      const esDefault = defaultProductoId !== null
+                        && String(acc.producto_regalo_id) === defaultProductoId
+                      return esDefault || acc.usos_pendientes > 0
+                    })
+
+                    if (visibles.length === 0) return null
+
                     return (
-                      <div className="mb-3 px-3 py-2 bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-800 rounded-lg">
-                        <div className="flex items-center justify-between gap-2 text-sm text-blue-700 dark:text-blue-300 mb-1.5">
-                          <span className="font-medium">
-                            Subunidades pendientes para descontar stock:
-                          </span>
-                          <span className="font-bold tabular-nums">
-                            {pendientes} / {porBloque}
-                          </span>
-                        </div>
-                        <div className="w-full bg-blue-100 dark:bg-blue-900/40 rounded-full h-2 overflow-hidden">
-                          <div
-                            className="bg-blue-500 dark:bg-blue-400 h-full transition-all"
-                            style={{ width: `${progreso}%` }}
-                            aria-label={`${pendientes} de ${porBloque}`}
-                          />
-                        </div>
-                        <p className="text-[11px] text-blue-600 dark:text-blue-400 mt-1">
-                          {pendientes === 0
-                            ? 'Bloque recién cerrado — se descontó 1 unidad del contenedor.'
-                            : `Faltan ${falta} subunidad${falta === 1 ? '' : 'es'} para cerrar el próximo bloque y descontar 1 unidad del contenedor.`
-                          }
-                        </p>
+                      <div className="mb-3 space-y-2">
+                        {visibles.map(acc => {
+                          const porBloque = acc.unidades_por_bloque ?? promo.unidades_por_bloque ?? 1
+                          const pendientes = acc.usos_pendientes
+                          const falta = Math.max(porBloque - pendientes, 0)
+                          const progreso = porBloque > 0 ? Math.min((pendientes / porBloque) * 100, 100) : 0
+                          const esDefault = defaultProductoId !== null
+                            && String(acc.producto_regalo_id) === defaultProductoId
+                          const colorClasses = esDefault
+                            ? { bg: 'bg-blue-50 dark:bg-blue-900/20', border: 'border-blue-200 dark:border-blue-800',
+                                text: 'text-blue-700 dark:text-blue-300', textLight: 'text-blue-600 dark:text-blue-400',
+                                track: 'bg-blue-100 dark:bg-blue-900/40', fill: 'bg-blue-500 dark:bg-blue-400' }
+                            : { bg: 'bg-emerald-50 dark:bg-emerald-900/20', border: 'border-emerald-200 dark:border-emerald-800',
+                                text: 'text-emerald-700 dark:text-emerald-300', textLight: 'text-emerald-600 dark:text-emerald-400',
+                                track: 'bg-emerald-100 dark:bg-emerald-900/40', fill: 'bg-emerald-500 dark:bg-emerald-400' }
+                          const nombreRegalo = getProductoNombre(String(acc.producto_regalo_id))
+                          const nombreContenedor = acc.ajuste_producto_id
+                            ? getProductoNombre(String(acc.ajuste_producto_id))
+                            : null
+                          return (
+                            <div key={String(acc.id)} className={`px-3 py-2 ${colorClasses.bg} border ${colorClasses.border} rounded-lg`}>
+                              <div className={`flex items-center justify-between gap-2 text-sm ${colorClasses.text} mb-1.5`}>
+                                <span className="font-medium flex items-center gap-1.5">
+                                  {!esDefault && <span className="text-[10px] uppercase tracking-wide px-1.5 py-0.5 rounded bg-emerald-200/60 dark:bg-emerald-700/40 text-emerald-800 dark:text-emerald-200 font-bold">Sustituto</span>}
+                                  {nombreRegalo}
+                                </span>
+                                <span className="font-bold tabular-nums">
+                                  {pendientes} / {porBloque}
+                                </span>
+                              </div>
+                              <div className={`w-full ${colorClasses.track} rounded-full h-2 overflow-hidden`}>
+                                <div
+                                  className={`${colorClasses.fill} h-full transition-all`}
+                                  style={{ width: `${progreso}%` }}
+                                  aria-label={`${pendientes} de ${porBloque}`}
+                                />
+                              </div>
+                              <p className={`text-[11px] ${colorClasses.textLight} mt-1`}>
+                                {pendientes === 0
+                                  ? `Bloque recién cerrado — se descontó 1 unidad del contenedor${nombreContenedor ? ` (${nombreContenedor})` : ''}.`
+                                  : `Faltan ${falta} subunidad${falta === 1 ? '' : 'es'} para cerrar el próximo bloque y descontar 1 unidad${nombreContenedor ? ` de ${nombreContenedor}` : ' del contenedor'}.`
+                                }
+                              </p>
+                            </div>
+                          )
+                        })}
                       </div>
                     )
                   })()

--- a/src/hooks/queries/index.ts
+++ b/src/hooks/queries/index.ts
@@ -201,6 +201,7 @@ export {
   useTogglePromocionActivaMutation,
   useAjustarStockPromoMutation,
   usePromoUnidadesEntregadasQuery,
+  usePromoAcumuladoresMapQuery,
 } from './usePromocionesQuery'
 export { useSimularSalvedadPromoImpactoQuery } from './useSimularSalvedadQuery'
 export type { PromoImpactoSalvedad } from './useSimularSalvedadQuery'

--- a/src/hooks/queries/usePromocionesQuery.ts
+++ b/src/hooks/queries/usePromocionesQuery.ts
@@ -10,6 +10,7 @@ import type {
   PromocionDB,
   PromocionProductoDB,
   PromocionReglaDB,
+  PromoAcumuladorDB,
 } from '../../types'
 import type { PromoMap, PromocionActiva } from '../../utils/promociones'
 
@@ -465,6 +466,41 @@ export function usePromoUnidadesEntregadasQuery() {
     },
     enabled: !!currentSucursalId,
     staleTime: 60 * 1000,
+  })
+}
+
+/**
+ * Hook que trae todos los acumuladores de promos (mig 059) de la sucursal
+ * activa. Una promo modo B puede tener varios acumuladores cuando admin
+ * sustituye regalos. Devuelve un mapa `promocion_id -> PromoAcumuladorDB[]`
+ * para que las vistas rendericen multiples barras por promo.
+ *
+ * `staleTime` corto (30s) porque el acumulador cambia con cada pedido
+ * que dispare la promo o cada sustitucion.
+ */
+export function usePromoAcumuladoresMapQuery() {
+  const { currentSucursalId } = useSucursal()
+  return useQuery({
+    queryKey: [...promocionesKeys.all(currentSucursalId), 'acumuladores'] as const,
+    queryFn: async (): Promise<Map<string, PromoAcumuladorDB[]>> => {
+      const { data, error } = await supabase
+        .from('promo_acumuladores')
+        .select('*')
+      if (error) {
+        if (error.message.includes('does not exist')) return new Map()
+        throw error
+      }
+      const map = new Map<string, PromoAcumuladorDB[]>()
+      for (const row of (data ?? []) as PromoAcumuladorDB[]) {
+        const key = String(row.promocion_id)
+        const list = map.get(key) ?? []
+        list.push(row)
+        map.set(key, list)
+      }
+      return map
+    },
+    enabled: !!currentSucursalId,
+    staleTime: 30 * 1000,
   })
 }
 

--- a/src/hooks/queries/useSustituirRegaloMutation.ts
+++ b/src/hooks/queries/useSustituirRegaloMutation.ts
@@ -20,6 +20,7 @@ async function sustituirRegalo(input: SustituirRegaloInput): Promise<SustituirRe
     p_producto_nuevo_id: input.productoNuevoId,
     p_cantidad_nueva: input.cantidadNueva,
     p_motivo: input.motivo,
+    p_ajuste_producto_id_nuevo: input.ajusteProductoIdNuevo ?? null,
     p_client_request_id: clientRequestId,
   })
   if (error) throw error

--- a/src/types/hooks.ts
+++ b/src/types/hooks.ts
@@ -981,6 +981,8 @@ export interface PedidoItemSustitucionDB {
   cantidad_original: number;
   cantidad_sustituta: number;
   regalo_mueve_stock_snapshot: boolean | null;
+  /** Contenedor que el admin eligio para el sustituto (modo B). Mig 059. */
+  ajuste_producto_id_nuevo: string | null;
   motivo: string;
   autorizado_por: string;
   sucursal_id: number;
@@ -993,7 +995,27 @@ export interface SustituirRegaloInput {
   productoNuevoId: string;
   cantidadNueva: number;  // puede ser fraccion
   motivo: string;
+  /** Contenedor del producto sustituto (modo B). Default: el ajuste_producto_id
+   *  de la promo original. Si NULL/undefined: el sustituto no acumula bloque. */
+  ajusteProductoIdNuevo?: string | null;
   clientRequestId?: string;
+}
+
+/**
+ * Acumulador por (promo, producto regalado, sucursal). Una promo modo B
+ * puede tener varios acumuladores cuando admin sustituye regalos. Mig 059.
+ */
+export interface PromoAcumuladorDB {
+  id: string;
+  promocion_id: string;
+  producto_regalo_id: string;
+  ajuste_producto_id: string | null;
+  unidades_por_bloque: number | null;
+  stock_por_bloque: number | null;
+  usos_pendientes: number;
+  sucursal_id: number;
+  created_at: string;
+  updated_at: string;
 }
 
 export interface SustituirRegaloResult {


### PR DESCRIPTION
## Summary

Corrige el manejo del Modo B en `sustituir_regalo_pedido` (mig 058 → 059). El comportamiento anterior era:
- Descontaba stock unitario del producto sustituto, ignorando el modelo de bloques.
- NO reponía el contenedor del producto original aunque la sustitución cruzara un bloque ya cerrado.
- `promociones.usos_pendientes` quedaba intacto: el sistema seguía contando como "entregado" el producto original.

Después del cambio, el comportamiento sigue exactamente lo que pediste:

1. **Setup ejemplo** — Promo "Manaos 6+2 3L": compra 1 fardo Manaos → 2 botellas Pomelo Blanco 3L gratis. `unidades_por_bloque=6`, `regalo_mueve_stock=false`.

2. Acumulador Pomelo Blanco va en 4/6. Llega pedido → +2 → 6/6 → descuenta 1 fardo Pomelo Blanco.

3. **Admin sustituye** las 2 Pomelo Blanco por 2 Naranja en el modal:
   - Acumulador Pomelo Blanco baja a 4/6. Como cruzó hacia abajo el umbral 6 → **se devuelve 1 fardo Pomelo Blanco al stock**.
   - Se crea barra paralela `(promo, Naranja)` con 2/6.
   - Cuando esa barra llene 6/6, se descuenta 1 fardo Naranja del contenedor que el admin eligió en el modal.
   - **Cero movimiento de stock unitario** — todo via bloques.

4. Panel `/promociones` muestra **2 barras** por promo (Pomelo Blanco 4/6 default + Naranja 2/6 sustituto). Cuando una alternativa cae a 0 desaparece.

## Cambios

### Backend (mig 059)
- Tabla nueva `promo_acumuladores(promo, producto_regalo, ajuste_producto, unidades_por_bloque, stock_por_bloque, usos_pendientes, sucursal)` con backfill desde promos existentes.
- Helper `aplicar_uso_promo_acumulador()`: aplica delta (+/-) y maneja cruce de umbrales (hacia arriba descuenta fardo, hacia abajo lo devuelve). Audit en `promo_ajustes` con valores negativos para reversiones.
- `sustituir_regalo_pedido` redefinida:
  - Acepta `p_ajuste_producto_id_nuevo` (contenedor sustituto).
  - Modo A: igual que antes (devuelve X, descuenta Y).
  - Modo B: sincroniza `promociones.usos_pendientes ↔ promo_acumuladores`, ajusta los dos acumuladores, NO mueve stock unitario.
- `pedido_item_sustituciones` ampliada con `ajuste_producto_id_nuevo` (audit).

Migración 059 ya **aplicada en Supabase** via MCP.

### Frontend
- `usePromoAcumuladoresMapQuery`: hook nuevo que devuelve `Map<promo_id, PromoAcumuladorDB[]>`.
- `ModalSustituirRegalo`: nuevo selector "Contenedor del regalo sustituto" (Modo B) con default = `ajuste_producto_id` original. Banner Modo B reescrito explicando la nueva mecánica. Validación de stock unitario solo en Modo A.
- `VistaPromociones`: multi-barra. Default siempre visible; alternativos solo si `usos_pendientes > 0`. Etiqueta "Sustituto" en barras alternativas + nombre del contenedor en cada barra.
- Tipos: `PromoAcumuladorDB`, `SustituirRegaloInput.ajusteProductoIdNuevo`, `PedidoItemSustitucionDB.ajuste_producto_id_nuevo`.

### Estrategia de mínimo invasivo
`crear_pedido_completo`, `actualizar_pedido_items` y `registrar_salvedad` quedaron **sin tocar**. Siguen escribiendo solo en `promociones.usos_pendientes`. La sincronización con `promo_acumuladores` se hace puntualmente en `sustituir_regalo_pedido` (lee `promociones.usos_pendientes` al inicio, lo aplica al acumulador default, ejecuta el cambio, y re-sincroniza al final). Eso evita refactorizar 3 RPCs grandes en este PR.

## Test plan

- [ ] Promo modo B con acumulador default 4/6. Crear pedido que dispare la promo (+2). Verificar que va a 6/6 y descuenta 1 fardo original.
- [ ] Admin abre el pedido recién creado → "Cambiar regalo" → elige Naranja + contenedor=fardo Naranja + cantidad 2 + motivo. Confirma.
- [ ] Verificar: `productos.stock` fardo original +1 (devuelto), fardo Naranja sin cambio, botellas sin cambio. `promo_acumuladores`: default=4/6, Naranja=2/6.
- [ ] Otro pedido que dispare la promo sin sustitución → acumulador default sube a 6/6 → descuenta otro fardo original.
- [ ] 3 sustituciones más a Naranja → acumulador Naranja llega a 8/6 → descuenta 1 fardo Naranja → queda en 2/6.
- [ ] `/promociones`: la promo muestra 2 barras (Pomelo Blanco + Naranja). La barra Naranja desaparece cuando llegue a 0.
- [ ] Modo A sigue funcionando idénticamente.
- [ ] Idempotencia: retry con mismo UUID no duplica.
- [ ] Sustitución sin contenedor (selector vacío): el sustituto no acumula bloque, solo se loguea en audit.

## Migración aplicada

`059_promo_acumuladores_paralelos` — aplicada via MCP. Backfill: 1 fila en `promo_acumuladores` por cada promo con `ajuste_automatico=true` y `producto_regalo_id` no nulo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)