### PR TITLE
feat(promos): modal sustituir regalo didactico + auto-inferir contenedor

### DIFF
--- a/migrations/063_sustitucion_default_contenedor.sql
+++ b/migrations/063_sustitucion_default_contenedor.sql
@@ -1,0 +1,264 @@
+-- =========================================================================
+-- 063_sustitucion_default_contenedor.sql
+--
+-- Dos fixes complementarios al PR #334:
+--
+-- 1) RPC sustituir_regalo_pedido: cuando admin no indica contenedor del
+--    sustituto, usar producto_sustituto_id como default (auto-inferencia).
+--    En el 99% de los casos el producto regalo y su contenedor son el
+--    mismo (ej: MANAOS POMELO BLANCO 3000 cc x 6 es a la vez el regalo y
+--    el fardo a descontar). Antes pasaba NULL si no se elegia, dejando
+--    al acumulador sin contenedor (no se descontaba nunca al cerrar bloque).
+--
+-- 2) Reconciliacion de acumuladores existentes con ajuste_producto_id mal
+--    asignado o NULL: si un acumulador apunta a un contenedor distinto al
+--    propio producto_regalo_id y la promo asociada tiene
+--    producto_regalo_id = ajuste_producto_id (auto-contenedor), corregir
+--    el acumulador para que use el propio producto_regalo_id.
+-- =========================================================================
+
+BEGIN;
+
+-- 1) Refactor sustituir_regalo_pedido: COALESCE al producto sustituto
+
+CREATE OR REPLACE FUNCTION public.sustituir_regalo_pedido(
+  p_pedido_item_id           BIGINT,
+  p_producto_nuevo_id        BIGINT,
+  p_cantidad_nueva           NUMERIC,
+  p_motivo                   TEXT,
+  p_ajuste_producto_id_nuevo BIGINT DEFAULT NULL,
+  p_client_request_id        UUID   DEFAULT NULL
+) RETURNS JSONB
+LANGUAGE plpgsql SECURITY DEFINER SET search_path TO 'public'
+AS $$
+DECLARE
+  v_user_id            UUID := auth.uid();
+  v_user_role          TEXT;
+  v_sucursal           BIGINT := current_sucursal_id();
+  v_item               RECORD;
+  v_promo              RECORD;
+  v_stock_nuevo        NUMERIC;
+  v_regalo_mueve_stock BOOLEAN;
+  v_sust_id            BIGINT;
+  v_existing           RECORD;
+  v_nuevo_nombre       TEXT;
+  v_promo_usos_default NUMERIC;
+  v_acc_default        RECORD;
+  v_ajuste_sustituto_efectivo BIGINT;
+BEGIN
+  IF v_sucursal IS NULL THEN
+    RETURN jsonb_build_object('success', false, 'error', 'No hay sucursal activa');
+  END IF;
+  IF v_user_id IS NULL THEN
+    RETURN jsonb_build_object('success', false, 'error', 'No autenticado');
+  END IF;
+
+  IF p_client_request_id IS NOT NULL THEN
+    SELECT id INTO v_existing
+      FROM pedido_item_sustituciones
+     WHERE client_request_id = p_client_request_id;
+    IF FOUND THEN
+      RETURN jsonb_build_object('success', true,
+        'sustitucion_id', v_existing.id,
+        'idempotent_replay', true);
+    END IF;
+  END IF;
+
+  SELECT rol INTO v_user_role FROM perfiles WHERE id = v_user_id;
+  IF v_user_role NOT IN ('admin', 'encargado') THEN
+    RETURN jsonb_build_object('success', false,
+      'error', 'Solo admin o encargado pueden sustituir regalos');
+  END IF;
+
+  IF p_cantidad_nueva IS NULL OR p_cantidad_nueva <= 0 THEN
+    RETURN jsonb_build_object('success', false,
+      'error', 'La cantidad sustituta debe ser mayor a 0');
+  END IF;
+
+  SELECT pi.id, pi.pedido_id, pi.producto_id, pi.cantidad, pi.es_bonificacion,
+         pi.promocion_id, pi.sucursal_id, p.estado AS pedido_estado
+    INTO v_item
+    FROM pedido_items pi
+    JOIN pedidos p ON p.id = pi.pedido_id
+   WHERE pi.id = p_pedido_item_id
+     AND pi.sucursal_id = v_sucursal
+   FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RETURN jsonb_build_object('success', false, 'error', 'Item no encontrado');
+  END IF;
+  IF NOT COALESCE(v_item.es_bonificacion, FALSE) THEN
+    RETURN jsonb_build_object('success', false,
+      'error', 'Solo se pueden sustituir items marcados como bonificacion');
+  END IF;
+  IF v_item.pedido_estado = 'entregado' THEN
+    RETURN jsonb_build_object('success', false,
+      'error', 'No se puede sustituir un regalo en un pedido ya entregado');
+  END IF;
+
+  IF v_item.promocion_id IS NOT NULL THEN
+    SELECT id, regalo_mueve_stock, ajuste_automatico, producto_regalo_id,
+           ajuste_producto_id, unidades_por_bloque, stock_por_bloque,
+           usos_pendientes
+      INTO v_promo
+      FROM promociones
+     WHERE id = v_item.promocion_id AND sucursal_id = v_sucursal;
+  END IF;
+  v_regalo_mueve_stock := COALESCE(v_promo.regalo_mueve_stock, TRUE);
+
+  -- DEFAULT auto-inferido del contenedor del sustituto: si el admin no
+  -- eligio, usar el producto sustituto como su propio contenedor (cubre
+  -- el 99% de casos donde producto_regalo_id = ajuste_producto_id).
+  v_ajuste_sustituto_efectivo := COALESCE(p_ajuste_producto_id_nuevo, p_producto_nuevo_id);
+
+  SELECT nombre INTO v_nuevo_nombre
+    FROM productos WHERE id = p_producto_nuevo_id AND sucursal_id = v_sucursal;
+
+  IF v_regalo_mueve_stock THEN
+    SELECT stock INTO v_stock_nuevo
+      FROM productos
+     WHERE id = p_producto_nuevo_id AND sucursal_id = v_sucursal
+     FOR UPDATE;
+    IF v_stock_nuevo IS NULL THEN
+      RETURN jsonb_build_object('success', false,
+        'error', 'Producto sustituto no existe en esta sucursal');
+    END IF;
+    IF v_stock_nuevo < p_cantidad_nueva THEN
+      RETURN jsonb_build_object('success', false,
+        'error', 'Stock insuficiente del producto sustituto (' || v_stock_nuevo || ' disponible)');
+    END IF;
+
+    PERFORM set_config('app.stock_origen', 'sustitucion_regalo', true);
+    PERFORM set_config('app.stock_ref_tipo', 'pedido', true);
+    PERFORM set_config('app.stock_ref_id', v_item.pedido_id::TEXT, true);
+    PERFORM set_config('app.stock_user_id', v_user_id::TEXT, true);
+
+    UPDATE productos
+       SET stock = stock + v_item.cantidad
+     WHERE id = v_item.producto_id AND sucursal_id = v_sucursal;
+
+    UPDATE productos
+       SET stock = stock - p_cantidad_nueva
+     WHERE id = p_producto_nuevo_id AND sucursal_id = v_sucursal;
+  ELSE
+    IF v_promo.producto_regalo_id IS NOT NULL THEN
+      SELECT id, usos_pendientes
+        INTO v_acc_default
+        FROM promo_acumuladores
+       WHERE promocion_id = v_promo.id
+         AND producto_regalo_id = v_promo.producto_regalo_id
+         AND sucursal_id = v_sucursal
+       FOR UPDATE;
+
+      IF FOUND THEN
+        IF v_acc_default.usos_pendientes IS DISTINCT FROM COALESCE(v_promo.usos_pendientes, 0) THEN
+          UPDATE promo_acumuladores
+             SET usos_pendientes = COALESCE(v_promo.usos_pendientes, 0),
+                 updated_at = NOW()
+           WHERE id = v_acc_default.id;
+        END IF;
+      ELSE
+        INSERT INTO promo_acumuladores (
+          promocion_id, producto_regalo_id, ajuste_producto_id,
+          unidades_por_bloque, stock_por_bloque,
+          usos_pendientes, sucursal_id
+        ) VALUES (
+          v_promo.id, v_promo.producto_regalo_id, v_promo.ajuste_producto_id,
+          v_promo.unidades_por_bloque, v_promo.stock_por_bloque,
+          COALESCE(v_promo.usos_pendientes, 0), v_sucursal
+        )
+        ON CONFLICT (promocion_id, producto_regalo_id, sucursal_id) DO NOTHING;
+      END IF;
+    END IF;
+
+    PERFORM public.aplicar_uso_promo_acumulador(
+      v_promo.id, v_item.producto_id, -v_item.cantidad,
+      v_promo.ajuste_producto_id, v_sucursal, v_user_id,
+      'sustitucion: salida del producto regalo original'
+    );
+
+    -- USAR v_ajuste_sustituto_efectivo (auto-inferido a producto_nuevo si NULL).
+    PERFORM public.aplicar_uso_promo_acumulador(
+      v_promo.id, p_producto_nuevo_id, p_cantidad_nueva,
+      v_ajuste_sustituto_efectivo, v_sucursal, v_user_id,
+      'sustitucion: entrada del producto regalo sustituto'
+    );
+
+    IF v_promo.producto_regalo_id IS NOT NULL THEN
+      SELECT usos_pendientes INTO v_promo_usos_default
+        FROM promo_acumuladores
+       WHERE promocion_id = v_promo.id
+         AND producto_regalo_id = v_promo.producto_regalo_id
+         AND sucursal_id = v_sucursal;
+
+      UPDATE promociones
+         SET usos_pendientes = GREATEST(COALESCE(v_promo_usos_default, 0)::INT, 0)
+       WHERE id = v_promo.id AND sucursal_id = v_sucursal;
+    END IF;
+  END IF;
+
+  UPDATE pedido_items
+     SET producto_id = p_producto_nuevo_id,
+         cantidad    = p_cantidad_nueva,
+         subtotal    = 0,
+         descripcion_regalo = COALESCE(descripcion_regalo, '') ||
+                              ' [Sustituido por: ' || COALESCE(v_nuevo_nombre, '?') || ']'
+   WHERE id = p_pedido_item_id;
+
+  INSERT INTO pedido_item_sustituciones (
+    pedido_id, pedido_item_id, promocion_id,
+    producto_original_id, producto_sustituto_id,
+    cantidad_original, cantidad_sustituta,
+    regalo_mueve_stock_snapshot,
+    ajuste_producto_id_nuevo,
+    motivo, autorizado_por, sucursal_id, client_request_id
+  ) VALUES (
+    v_item.pedido_id, p_pedido_item_id, v_item.promocion_id,
+    v_item.producto_id, p_producto_nuevo_id,
+    v_item.cantidad, p_cantidad_nueva,
+    v_regalo_mueve_stock,
+    v_ajuste_sustituto_efectivo,  -- guardar el efectivo (no el original NULL)
+    p_motivo, v_user_id, v_sucursal, p_client_request_id
+  ) RETURNING id INTO v_sust_id;
+
+  INSERT INTO pedido_historial (
+    pedido_id, usuario_id, campo_modificado, valor_anterior, valor_nuevo, sucursal_id
+  ) VALUES (
+    v_item.pedido_id, v_user_id, 'sustitucion_regalo',
+    'producto_id=' || v_item.producto_id || ' cantidad=' || v_item.cantidad,
+    'producto_id=' || p_producto_nuevo_id || ' cantidad=' || p_cantidad_nueva ||
+      ' motivo=' || p_motivo,
+    v_sucursal
+  );
+
+  RETURN jsonb_build_object(
+    'success', true,
+    'sustitucion_id', v_sust_id,
+    'modo', CASE WHEN v_regalo_mueve_stock THEN 'A' ELSE 'B' END
+  );
+EXCEPTION WHEN OTHERS THEN
+  RETURN jsonb_build_object('success', false, 'error', SQLERRM);
+END;
+$$;
+
+ALTER FUNCTION public.sustituir_regalo_pedido(BIGINT, BIGINT, NUMERIC, TEXT, BIGINT, UUID)
+  OWNER TO postgres;
+
+-- 2) Reconciliacion: acumuladores con ajuste_producto_id mal seteado a un
+--    producto distinto del propio producto_regalo_id, en promos donde la
+--    config canonica es producto_regalo_id == ajuste_producto_id.
+--
+-- En el pedido 2000: el acumulador id=7 (promo=13, regalo=83) tiene
+-- ajuste_producto_id=81 (heredado del original). Cuando se complete el
+-- bloque del sustituto Granadina, descontaria 1 fardo Pomelo Blanco
+-- (incorrecto). Lo cambiamos a 83 (Granadina = su propio fardo).
+UPDATE public.promo_acumuladores acc
+   SET ajuste_producto_id = acc.producto_regalo_id,
+       updated_at = NOW()
+  FROM public.promociones p
+ WHERE acc.promocion_id = p.id
+   AND p.producto_regalo_id = p.ajuste_producto_id  -- promo auto-contenedor
+   AND acc.ajuste_producto_id IS DISTINCT FROM acc.producto_regalo_id
+   AND acc.producto_regalo_id <> p.producto_regalo_id;  -- solo alternos (no default)
+
+COMMIT;

--- a/src/components/modals/ModalEditarPedido.tsx
+++ b/src/components/modals/ModalEditarPedido.tsx
@@ -131,15 +131,20 @@ const ModalEditarPedido = memo(function ModalEditarPedido({
     [pedido]
   );
 
-  // Mapa promocion_id -> { regalo_mueve_stock, ajuste_producto_id } para
-  // resolver modo (A/B) y default del contenedor sustituto en el modal.
+  // Mapa promocion_id -> { regalo_mueve_stock, ajuste_producto_id,
+  // unidades_por_bloque } para el modal de sustitucion (modo y barras).
   const { data: promociones = [] } = usePromocionesListQuery();
   const promoInfoMap = useMemo(() => {
-    const m = new Map<string, { mueveStock: boolean; ajusteProductoId: string | null }>();
+    const m = new Map<string, {
+      mueveStock: boolean;
+      ajusteProductoId: string | null;
+      unidadesPorBloque: number | null;
+    }>();
     for (const p of promociones) {
       m.set(String(p.id), {
         mueveStock: Boolean(p.regalo_mueve_stock),
         ajusteProductoId: p.ajuste_producto_id ? String(p.ajuste_producto_id) : null,
+        unidadesPorBloque: p.unidades_por_bloque ?? null,
       });
     }
     return m;
@@ -936,6 +941,8 @@ const ModalEditarPedido = memo(function ModalEditarPedido({
                 productoOriginal={sustItemTarget.producto}
                 cantidadOriginal={sustItemTarget.cantidad}
                 regaloMueveStock={info?.mueveStock ?? true}
+                promocionId={sustItemTarget.promocion_id ?? null}
+                unidadesPorBloque={info?.unidadesPorBloque ?? null}
                 ajusteProductoIdOriginal={info?.ajusteProductoId ?? null}
                 onClose={() => setSustItemTarget(null)}
               />

--- a/src/components/modals/ModalSustituirRegalo.tsx
+++ b/src/components/modals/ModalSustituirRegalo.tsx
@@ -5,16 +5,23 @@
  * en un pedido (regalo de una promocion). Justifica con motivo y autoriza
  * la operacion.
  *
- * Llama a la RPC `sustituir_regalo_pedido` (mig 058) via
- * useSustituirRegaloMutation. Maneja:
- *   - Idempotencia (UUID generado en el primer render).
- *   - Modo A vs Modo B con banner visual explicativo.
- *   - Validacion basica: cantidad > 0, producto seleccionado, motivo no vacio.
+ * Diseno didactico (rediseno mig 063):
+ *   - Solo 3 campos visibles: producto nuevo, cantidad, motivo.
+ *   - Banner explica en lenguaje de negocio con NUMEROS REALES del caso
+ *     (nombres de productos, barra de progreso actual y proyectada). Sin
+ *     jerga tecnica "Modo A/B", "fardo", "acumulador", "contenedor" en
+ *     la vista principal.
+ *   - El campo "contenedor del sustituto" se esconde en "Configuracion
+ *     avanzada" (collapsible). Default: el propio producto sustituto
+ *     (auto-inferido por el RPC con mig 063 si se manda NULL).
+ *
+ * Llama a la RPC `sustituir_regalo_pedido` via useSustituirRegaloMutation.
+ * Maneja idempotencia (UUID generado en el primer render).
  */
 import { useMemo, useState, memo } from 'react'
-import { Loader2, Gift, AlertTriangle, Check } from 'lucide-react'
+import { Loader2, Gift, AlertTriangle, ChevronDown, ChevronUp, Info } from 'lucide-react'
 import ModalBase from './ModalBase'
-import { useProductosQuery } from '../../hooks/queries'
+import { useProductosQuery, usePromoAcumuladorQuery } from '../../hooks/queries'
 import { useSustituirRegaloMutation } from '../../hooks/queries/useSustituirRegaloMutation'
 import { useNotification } from '../../contexts/NotificationContext'
 import type { ProductoDB } from '../../types'
@@ -23,10 +30,13 @@ export interface ModalSustituirRegaloProps {
   pedidoItemId: string
   productoOriginal: ProductoDB
   cantidadOriginal: number
-  /** Modo de la promo. true = Modo A (stock unitario), false = Modo B (bloques). */
+  /** Modo de la promo. true = stock por unidad, false = ajuste por bloque. */
   regaloMueveStock: boolean
-  /** Contenedor (fardo) configurado en la promo original. Default sugerido
-   *  para el selector de "contenedor del sustituto" en Modo B. */
+  /** Promo asociada al regalo. Necesaria para cargar el acumulador. */
+  promocionId?: string | number | null
+  /** Unidades por bloque de la promo (modo B). Para mostrar X/N en banner. */
+  unidadesPorBloque?: number | null
+  /** Contenedor configurado en la promo original. Se muestra en avanzado. */
   ajusteProductoIdOriginal?: string | null
   onClose: () => void
   /** Callback al confirmar exitosamente (para que el caller refresque). */
@@ -38,6 +48,8 @@ const ModalSustituirRegalo = memo(function ModalSustituirRegalo({
   productoOriginal,
   cantidadOriginal,
   regaloMueveStock,
+  promocionId = null,
+  unidadesPorBloque = null,
   ajusteProductoIdOriginal = null,
   onClose,
   onSustituido,
@@ -46,28 +58,37 @@ const ModalSustituirRegalo = memo(function ModalSustituirRegalo({
   const { data: productos = [] } = useProductosQuery()
   const sustituirMut = useSustituirRegaloMutation()
 
-  // UUID estable por instancia del modal para idempotencia (mismo UUID en
-  // reintento desde el cliente devuelve la misma sustitucion sin duplicar).
+  // Acumuladores para mostrar barras "antes" y proyeccion "despues" (modo B)
+  const { data: acumuladorOriginal } = usePromoAcumuladorQuery(
+    !regaloMueveStock ? promocionId : null,
+    productoOriginal.id,
+  )
+
+  // UUID estable por instancia del modal para idempotencia
   const clientRequestId = useMemo(() => crypto.randomUUID(), [])
 
   const [productoNuevoId, setProductoNuevoId] = useState<string>('')
   const [cantidadNueva, setCantidadNueva] = useState<string>(String(cantidadOriginal))
   const [motivo, setMotivo] = useState<string>('')
-  // Contenedor del sustituto. Default = el de la promo original. El admin
-  // puede cambiarlo (otro fardo) o ponerlo en "" (= sin acumulacion de bloque).
-  // Solo aplica para Modo B.
-  const [ajusteProductoIdNuevo, setAjusteProductoIdNuevo] = useState<string>(
-    ajusteProductoIdOriginal ? String(ajusteProductoIdOriginal) : ''
-  )
   const [error, setError] = useState<string>('')
+  const [avanzadoOpen, setAvanzadoOpen] = useState<boolean>(false)
+  // Contenedor del sustituto. Default vacio = el RPC infiere automaticamente
+  // (mig 063): usa el propio producto sustituto como su contenedor. El admin
+  // solo lo cambia si abre "Configuracion avanzada" y elige otro fardo.
+  const [ajusteProductoIdNuevo, setAjusteProductoIdNuevo] = useState<string>('')
 
   const productoNuevo = useMemo(
     () => productos.find(p => String(p.id) === String(productoNuevoId)) ?? null,
     [productos, productoNuevoId]
   )
 
-  // Productos disponibles ordenados, excluyendo el original para que no
-  // "sustituyan por el mismo".
+  // Acumulador del sustituto (puede no existir aun)
+  const { data: acumuladorSustituto } = usePromoAcumuladorQuery(
+    !regaloMueveStock && productoNuevoId ? promocionId : null,
+    productoNuevoId || null,
+  )
+
+  // Productos ordenados, excluyendo el original
   const productosOpciones = useMemo(
     () => productos
       .filter(p => String(p.id) !== String(productoOriginal.id))
@@ -77,8 +98,8 @@ const ModalSustituirRegalo = memo(function ModalSustituirRegalo({
   )
 
   const cantidadNum = parseFloat(cantidadNueva) || 0
-  // Modo A descuenta stock unitario del nuevo producto -> hay que validar.
-  // Modo B no mueve stock unitario, solo acumula bloques -> no se valida acá.
+  // Modo A descuenta stock inmediato → validar stock disponible.
+  // Modo B no mueve stock unitario → no se valida.
   const stockSuficiente = !regaloMueveStock
     || productoNuevo == null
     || (productoNuevo.stock ?? 0) >= cantidadNum
@@ -87,6 +108,15 @@ const ModalSustituirRegalo = memo(function ModalSustituirRegalo({
     && motivo.trim().length > 0
     && stockSuficiente
     && !sustituirMut.isPending
+
+  // Calculos para el banner didactico (modo B)
+  const usosOrigAntes = Number(acumuladorOriginal?.usos_pendientes ?? 0)
+  const usosOrigDespues = usosOrigAntes - cantidadOriginal
+  const usosSustAntes = Number(acumuladorSustituto?.usos_pendientes ?? 0)
+  const usosSustDespues = usosSustAntes + cantidadNum
+  const bloque = unidadesPorBloque ?? acumuladorOriginal?.unidades_por_bloque ?? 1
+  const cruzaAbajo = Math.floor(usosOrigDespues / bloque) < Math.floor(usosOrigAntes / bloque)
+  const cruzaArriba = Math.floor(usosSustDespues / bloque) > Math.floor(usosSustAntes / bloque)
 
   const handleConfirmar = async () => {
     setError('')
@@ -97,6 +127,9 @@ const ModalSustituirRegalo = memo(function ModalSustituirRegalo({
         productoNuevoId,
         cantidadNueva: cantidadNum,
         motivo: motivo.trim(),
+        // Si el admin no abrio avanzado o no eligio nada, mandamos null y
+        // el RPC (mig 063) auto-infiere = productoSustitutoId. Si lo eligio
+        // explicito, mandamos su eleccion.
         ajusteProductoIdNuevo: regaloMueveStock
           ? null
           : (ajusteProductoIdNuevo || null),
@@ -104,67 +137,44 @@ const ModalSustituirRegalo = memo(function ModalSustituirRegalo({
       })
       notify.success(
         result.idempotentReplay
-          ? 'Sustitucion ya registrada'
-          : `Regalo sustituido (Modo ${result.modo})`
+          ? 'Sustitucion ya estaba registrada'
+          : 'Regalo cambiado correctamente'
       )
       onSustituido?.()
       onClose()
     } catch (err) {
-      const msg = err instanceof Error ? err.message : 'Error al sustituir el regalo'
+      const msg = err instanceof Error ? err.message : 'Error al cambiar el regalo'
       setError(msg)
     }
   }
 
   return (
-    <ModalBase title="Sustituir regalo de promocion" onClose={onClose} maxWidth="max-w-lg">
+    <ModalBase title="Cambiar regalo" onClose={onClose} maxWidth="max-w-md">
       <div className="p-4 space-y-4">
-        {/* Contexto del regalo original */}
-        <div className="bg-gray-50 dark:bg-gray-700/50 rounded-lg p-3">
-          <p className="text-xs text-gray-500 dark:text-gray-400 mb-1 flex items-center gap-1">
+        {/* Header: regalo actual */}
+        <div className="bg-emerald-50 dark:bg-emerald-900/15 border border-emerald-200 dark:border-emerald-800 rounded-lg p-3">
+          <p className="text-xs text-emerald-700 dark:text-emerald-300 mb-1 flex items-center gap-1">
             <Gift className="w-3 h-3" /> Regalo actual
           </p>
-          <p className="font-semibold text-gray-800 dark:text-white">
+          <p className="font-semibold text-emerald-900 dark:text-emerald-100">
             {productoOriginal.nombre}
           </p>
-          <p className="text-sm text-gray-500 dark:text-gray-400">
+          <p className="text-sm text-emerald-700 dark:text-emerald-300">
             Cantidad: <span className="font-medium">{cantidadOriginal}</span>
           </p>
         </div>
 
-        {/* Banner segun modo de la promo */}
-        {regaloMueveStock ? (
-          <div className="flex items-start gap-2 p-3 rounded-lg bg-emerald-50 dark:bg-emerald-900/20 border border-emerald-200 dark:border-emerald-800 text-sm text-emerald-800 dark:text-emerald-200">
-            <Check className="w-4 h-4 mt-0.5 flex-shrink-0" />
-            <p>
-              <b>Modo A — stock por unidad.</b> La sustitucion va a
-              <b> devolver {cantidadOriginal} de {productoOriginal.nombre}</b> al
-              deposito y descontar la cantidad del producto sustituto.
-            </p>
-          </div>
-        ) : (
-          <div className="flex items-start gap-2 p-3 rounded-lg bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-800 text-sm text-blue-800 dark:text-blue-200">
-            <AlertTriangle className="w-4 h-4 mt-0.5 flex-shrink-0" />
-            <p>
-              <b>Modo B — ajuste por bloque.</b> Esta sustitucion <b>no mueve stock unitario</b>.
-              El acumulador del producto original baja en {cantidadOriginal} y se crea/incrementa
-              una <b>barra paralela</b> para el sustituto. Si la baja cruza un bloque cerrado,
-              <b> se devuelve el fardo original al stock</b>. Cuando la barra del sustituto complete
-              un bloque, se descuenta 1 fardo del contenedor que elijas abajo.
-            </p>
-          </div>
-        )}
-
         {/* Producto sustituto */}
         <div>
           <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
-            Producto sustituto *
+            Cambiarlo por *
           </label>
           <select
             value={productoNuevoId}
             onChange={e => setProductoNuevoId(e.target.value)}
             className="w-full px-3 py-2 border rounded-lg dark:bg-gray-700 dark:border-gray-600 dark:text-white"
           >
-            <option value="">Elegir...</option>
+            <option value="">Elegir producto nuevo...</option>
             {productosOpciones.map(p => (
               <option key={p.id} value={p.id}>
                 {p.nombre} {(p.stock ?? 0) > 0 ? `· stock ${p.stock}` : '· sin stock'}
@@ -173,38 +183,10 @@ const ModalSustituirRegalo = memo(function ModalSustituirRegalo({
           </select>
         </div>
 
-        {/* Contenedor sustituto (solo modo B) */}
-        {!regaloMueveStock && (
-          <div>
-            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
-              Contenedor del regalo sustituto
-              <span className="ml-1 text-xs text-gray-500 font-normal">
-                (fardo a descontar cuando complete bloque)
-              </span>
-            </label>
-            <select
-              value={ajusteProductoIdNuevo}
-              onChange={e => setAjusteProductoIdNuevo(e.target.value)}
-              className="w-full px-3 py-2 border rounded-lg dark:bg-gray-700 dark:border-gray-600 dark:text-white"
-            >
-              <option value="">Sin contenedor — el sustituto no acumula bloque</option>
-              {productosOpciones.map(p => (
-                <option key={`cont-${p.id}`} value={p.id}>
-                  {p.nombre}{ajusteProductoIdOriginal && String(p.id) === String(ajusteProductoIdOriginal) ? ' · default de la promo' : ''}
-                </option>
-              ))}
-            </select>
-            <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
-              Por defecto se sugiere el mismo contenedor de la promo original. Cambialo
-              si el sustituto pertenece a otro fardo.
-            </p>
-          </div>
-        )}
-
         {/* Cantidad */}
         <div>
           <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
-            Cantidad nueva *
+            Cantidad *
           </label>
           <input
             type="number"
@@ -215,14 +197,10 @@ const ModalSustituirRegalo = memo(function ModalSustituirRegalo({
             onChange={e => setCantidadNueva(e.target.value)}
             className="w-full px-3 py-2 border rounded-lg dark:bg-gray-700 dark:border-gray-600 dark:text-white"
           />
-          <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
-            Se acepta fraccion (ej. 0.5). Por defecto se asume la misma
-            cantidad que el regalo original.
-          </p>
           {productoNuevo && regaloMueveStock && !stockSuficiente && (
             <p className="text-xs text-red-600 mt-1 flex items-center gap-1">
               <AlertTriangle className="w-3 h-3" />
-              Stock insuficiente del producto sustituto ({productoNuevo.stock ?? 0} disponible)
+              No hay stock suficiente del nuevo producto ({productoNuevo.stock ?? 0} disponible)
             </p>
           )}
         </div>
@@ -230,16 +208,100 @@ const ModalSustituirRegalo = memo(function ModalSustituirRegalo({
         {/* Motivo */}
         <div>
           <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
-            Motivo de la sustitucion *
+            Motivo del cambio *
           </label>
           <textarea
             value={motivo}
             onChange={e => setMotivo(e.target.value)}
             rows={2}
-            placeholder="Ej: cliente pide cambiar Naranja por Pomelo, sin stock del original, etc."
+            placeholder="Ej: el cliente prefiere otro sabor, no hay stock del original..."
             className="w-full px-3 py-2 border rounded-lg resize-none dark:bg-gray-700 dark:border-gray-600 dark:text-white text-sm"
           />
         </div>
+
+        {/* Banner didactico: que va a pasar cuando confirmes */}
+        {productoNuevo && cantidadNum > 0 && (
+          <div className="flex items-start gap-2 p-3 rounded-lg bg-blue-50 dark:bg-blue-900/15 border border-blue-200 dark:border-blue-800 text-sm">
+            <Info className="w-4 h-4 mt-0.5 flex-shrink-0 text-blue-600 dark:text-blue-400" />
+            <div className="space-y-1 text-blue-900 dark:text-blue-100">
+              <p className="font-medium">Cuando confirmes:</p>
+              {regaloMueveStock ? (
+                <>
+                  <p>✓ Se devolveran <b>{cantidadOriginal} de {productoOriginal.nombre}</b> al stock.</p>
+                  <p>✓ Se descontaran <b>{cantidadNum} de {productoNuevo.nombre}</b> del stock.</p>
+                </>
+              ) : (
+                <>
+                  <p>
+                    ✓ El contador de <b>{productoOriginal.nombre}</b> baja
+                    de <b>{usosOrigAntes}/{bloque}</b> a <b>{usosOrigDespues}/{bloque}</b>.
+                  </p>
+                  {cruzaAbajo && (
+                    <p className="text-emerald-700 dark:text-emerald-300 ml-3">
+                      → Se devolvera 1 fardo de {productoOriginal.nombre} al stock.
+                    </p>
+                  )}
+                  <p>
+                    ✓ El contador de <b>{productoNuevo.nombre}</b> sube
+                    de <b>{usosSustAntes}/{bloque}</b> a <b>{usosSustDespues}/{bloque}</b>.
+                  </p>
+                  {cruzaArriba ? (
+                    <p className="text-orange-700 dark:text-orange-300 ml-3">
+                      → Se descontara 1 fardo de {productoNuevo.nombre} del stock ahora.
+                    </p>
+                  ) : (
+                    <p className="text-gray-600 dark:text-gray-300 ml-3 text-xs">
+                      → El stock no cambia ahora. Cuando el contador llegue a {bloque} se descontara 1 fardo de {productoNuevo.nombre} automaticamente.
+                    </p>
+                  )}
+                </>
+              )}
+            </div>
+          </div>
+        )}
+
+        {/* Configuracion avanzada — colapsada por default. Solo modo B. */}
+        {!regaloMueveStock && (
+          <div className="border-t border-gray-200 dark:border-gray-700 pt-3">
+            <button
+              type="button"
+              onClick={() => setAvanzadoOpen(v => !v)}
+              className="flex items-center gap-1 text-xs text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200"
+            >
+              {avanzadoOpen ? <ChevronUp className="w-3 h-3" /> : <ChevronDown className="w-3 h-3" />}
+              Configuracion avanzada (opcional)
+            </button>
+            {avanzadoOpen && (
+              <div className="mt-3 space-y-2">
+                <label className="block text-sm font-medium text-gray-700 dark:text-gray-300">
+                  Producto donde descontar el sustituto
+                </label>
+                <select
+                  value={ajusteProductoIdNuevo}
+                  onChange={e => setAjusteProductoIdNuevo(e.target.value)}
+                  className="w-full px-3 py-2 border rounded-lg dark:bg-gray-700 dark:border-gray-600 dark:text-white text-sm"
+                >
+                  <option value="">
+                    Automatico — usar el mismo producto sustituto (recomendado)
+                  </option>
+                  {productosOpciones.map(p => (
+                    <option key={`cont-${p.id}`} value={p.id}>
+                      {p.nombre}
+                      {ajusteProductoIdOriginal && String(p.id) === String(ajusteProductoIdOriginal)
+                        ? ' · era el de la promo original'
+                        : ''}
+                    </option>
+                  ))}
+                </select>
+                <p className="text-xs text-gray-500 dark:text-gray-400">
+                  Por defecto el sistema usa el mismo producto sustituto como su propio
+                  fardo (que es lo que tienen la mayoria de las promos). Cambialo solo
+                  si el sustituto se descuenta de OTRO fardo distinto.
+                </p>
+              </div>
+            )}
+          </div>
+        )}
 
         {error && (
           <div className="flex items-start gap-2 p-3 rounded-lg bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 text-sm text-red-700 dark:text-red-300">
@@ -263,7 +325,7 @@ const ModalSustituirRegalo = memo(function ModalSustituirRegalo({
           className="flex items-center gap-2 px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded-lg disabled:opacity-50"
         >
           {sustituirMut.isPending && <Loader2 className="w-4 h-4 animate-spin" />}
-          Sustituir regalo
+          Cambiar regalo
         </button>
       </div>
     </ModalBase>

--- a/src/hooks/queries/index.ts
+++ b/src/hooks/queries/index.ts
@@ -203,6 +203,7 @@ export {
   useAjustarStockPromoMutation,
   usePromoUnidadesEntregadasQuery,
   usePromoAcumuladoresMapQuery,
+  usePromoAcumuladorQuery,
   usePedidoSustitucionesQuery,
 } from './usePromocionesQuery'
 export { useSimularSalvedadPromoImpactoQuery } from './useSimularSalvedadQuery'

--- a/src/hooks/queries/usePromocionesQuery.ts
+++ b/src/hooks/queries/usePromocionesQuery.ts
@@ -500,6 +500,39 @@ export function usePedidoSustitucionesQuery(pedidoId: string | number | null | u
 }
 
 /**
+ * Hook que trae UN acumulador especifico (promo, producto_regalo) para la
+ * sucursal activa. Util en el modal de sustitucion para mostrar el estado
+ * actual de la barra del regalo original ANTES de sustituir, y proyectar
+ * el DESPUES.
+ */
+export function usePromoAcumuladorQuery(
+  promocionId: string | number | null | undefined,
+  productoRegaloId: string | number | null | undefined
+) {
+  const { currentSucursalId } = useSucursal()
+  const pid = promocionId == null ? '' : String(promocionId)
+  const rid = productoRegaloId == null ? '' : String(productoRegaloId)
+  return useQuery({
+    queryKey: [...promocionesKeys.all(currentSucursalId), 'acumulador', pid, rid] as const,
+    queryFn: async (): Promise<PromoAcumuladorDB | null> => {
+      const { data, error } = await supabase
+        .from('promo_acumuladores')
+        .select('*')
+        .eq('promocion_id', pid)
+        .eq('producto_regalo_id', rid)
+        .maybeSingle()
+      if (error) {
+        if (error.message.includes('does not exist')) return null
+        throw error
+      }
+      return (data ?? null) as PromoAcumuladorDB | null
+    },
+    enabled: !!promocionId && !!productoRegaloId && !!currentSucursalId,
+    staleTime: 30 * 1000,
+  })
+}
+
+/**
  * Hook que trae todos los acumuladores de promos (mig 059) de la sucursal
  * activa. Una promo modo B puede tener varios acumuladores cuando admin
  * sustituye regalos. Devuelve un mapa `promocion_id -> PromoAcumuladorDB[]`


### PR DESCRIPTION
## Summary

Dos fixes complementarios al PR #334 reportados por una usuaria al sustituir un regalo en el pedido 2000:

### Bug 1 — Stock no se movió al sustituir
- Sustituyó 2 botellas Pomelo Blanco → 2 Granadina (promo 13 modo B).
- Stock Pomelo 80 → 80, Granadina 11 → 11 (cero movimiento). La usuaria eligió "Sin contenedor" en el modal porque no entendía qué era.
- Causa: si admin no elige contenedor, mi RPC pasaba `NULL` al helper → el acumulador del sustituto queda sin `ajuste_producto_id` → cuando se complete el bloque (6 usos) no descuenta nada del stock.

### Bug 2 — Módulo "Contenedor del regalo sustituto" no se entiende
- La usuaria lo dijo explícito.
- Causa: jerga técnica ("Modo B", "contenedor", "fardo", "acumulador") + 2 selectores + banner técnico.

## Fix integrado

### Migración 063
- `sustituir_regalo_pedido`: `COALESCE(p_ajuste_producto_id_nuevo, p_producto_nuevo_id)`. Si admin no elige contenedor, **usa el producto sustituto como su propio contenedor** (lo que hacen el 99% de las promos donde `producto_regalo_id = ajuste_producto_id`).
- Reconciliación: UPDATE en `promo_acumuladores` para alternos en promos auto-contenedor con `ajuste_producto_id` mal seteado al original. Cubre el caso del pedido 2000 (acumulador id=7 ahora tiene `ajuste_producto_id=83` Granadina, antes era 81 Pomelo Blanco).

### Frontend — rediseño didáctico
- **3 campos visibles**: producto sustituto + cantidad + motivo. Punto.
- **Banner con números reales** sin jerga: "Cuando confirmes: El contador de Pomelo Blanco baja de 2/6 a 0/6. El contador de Granadina sube de 0/6 a 2/6. El stock no cambia ahora. Cuando el contador llegue a 6 se descontará 1 fardo de Granadina automáticamente."
- **Sin** las palabras "Modo A/B", "fardo", "acumulador", "contenedor" en la vista principal.
- Campo "contenedor" escondido en `<details>` **"Configuración avanzada (opcional)"** colapsada por default. Default ahora dice: *"Automático — usar el mismo producto sustituto (recomendado)"*.
- Hook nuevo `usePromoAcumuladorQuery` que trae el acumulador específico para mostrar las barras antes/después.

## Test plan

- [ ] Crear pedido nuevo con promo modo B. Abrir Cambiar Regalo.
- [ ] Modal muestra solo 3 campos visibles + banner didáctico con números reales del caso.
- [ ] "Configuración avanzada" está colapsada. Al abrirla el default es "Automático".
- [ ] Confirmar la sustitución. Verificar:
  - `pedido_items.producto_id` = sustituto.
  - `pedido_item_sustituciones`: fila con `ajuste_producto_id_nuevo` = sustituto (auto-inferido).
  - `promo_acumuladores`: acumulador alterno con `ajuste_producto_id` = sustituto (no NULL, no el original).
- [ ] Cuando el acumulador alterno llene un bloque (ej. 6 sustituciones), descontar 1 fardo del sustituto.

Migración 063 aplicada via MCP. El acumulador id=7 del pedido 2000 ya está reconciliado: `ajuste_producto_id=83` (antes era 81).

🤖 Generated with [Claude Code](https://claude.com/claude-code)