### PR TITLE
fix(bot+panel): alinea filtro de estado y muestra timestamp en ventas_periodo

### DIFF
--- a/src/hooks/queries/usePedidoStatsQuery.ts
+++ b/src/hooks/queries/usePedidoStatsQuery.ts
@@ -70,7 +70,9 @@ async function fetchPedidoStats(
     query = query.lte('fecha', filters.fechaHasta)
   }
   if (!filters?.verCancelados && filters?.estado !== 'cancelado') {
-    query = query.neq('estado', 'cancelado')
+    // Alineado con bot_ventas_periodo (mig029): excluye 'cancelado' y 'anulado',
+    // incluye estado IS NULL. `.neq` solo excluía 'cancelado' y descartaba NULL.
+    query = query.or('estado.is.null,and(estado.neq.cancelado,estado.neq.anulado)')
   }
   if (filters?.fechaEntregaProgramada) {
     query = query.eq('fecha_entrega_programada', filters.fechaEntregaProgramada)

--- a/src/hooks/queries/usePedidosQuery.ts
+++ b/src/hooks/queries/usePedidosQuery.ts
@@ -240,7 +240,9 @@ async function fetchPedidosPaginated(
     query = query.lte('fecha', filters.fechaHasta)
   }
   if (!filters?.verCancelados && filters?.estado !== 'cancelado') {
-    query = query.neq('estado', 'cancelado')
+    // Alineado con bot_ventas_periodo (mig029): excluye 'cancelado' y 'anulado',
+    // incluye estado IS NULL. `.neq` solo excluía 'cancelado' y descartaba NULL.
+    query = query.or('estado.is.null,and(estado.neq.cancelado,estado.neq.anulado)')
   }
   if (filters?.fechaEntregaProgramada) {
     query = query.eq('fecha_entrega_programada', filters.fechaEntregaProgramada)

--- a/supabase/functions/_shared/gemini/prompts/admin.ts
+++ b/supabase/functions/_shared/gemini/prompts/admin.ts
@@ -121,6 +121,7 @@ FORMATO DE RESPUESTAS:
 - NO uses asteriscos para *bold* ni guiones bajos para _italics_ — el bot manda plain text, los marcadores quedan literales en pantalla.
 - Dejá una línea en blanco entre secciones para que respire.
 - Montos siempre con $ y separadores de miles ($12.500). Para listas con más de 10 items, mostrá los más relevantes y ofrecé filtrar.
+- Si el resultado de una tool incluye \`consulta_realizada_at\` (p.ej. ventas_periodo), agregá al final del mensaje una línea tipo "🕒 Datos al <valor>" usando el string tal cual viene. Esto le da al usuario el instante exacto del corte para que, si compara con el panel, sepa que un desfase de minutos es normal.
 `;
 
 export default prompt;

--- a/supabase/functions/_shared/tools/admin/ventas_periodo.ts
+++ b/supabase/functions/_shared/tools/admin/ventas_periodo.ts
@@ -24,6 +24,10 @@ export interface VentasPeriodoResult {
   total_ventas: number;
   pedidos_count: number;
   ticket_promedio: number;
+  // Momento en que se ejecutó el RPC (zona ART). El LLM debe mostrarlo al
+  // final de la respuesta para que el usuario pueda contrastar contra el
+  // panel sabiendo que el panel puede haberse refrescado en otro instante.
+  consulta_realizada_at: string;
   top_clientes: Array<{
     id: number;
     codigo: number | null;
@@ -46,9 +50,12 @@ export const ventasPeriodoTool: Tool<VentasPeriodoParams, VentasPeriodoResult> =
   name: "ventas_periodo",
   description:
     "Resumen de ventas en un rango de fechas (admin/encargado). Devuelve " +
-    "total facturado, cantidad de pedidos, ticket promedio, top clientes y " +
-    "top productos. Las fechas son inclusive en formato YYYY-MM-DD. Filtra " +
-    "por sucursal del bot user. Excluye pedidos cancelados/anulados.",
+    "total facturado, cantidad de pedidos, ticket promedio, top clientes, " +
+    "top productos y el timestamp ART en que se ejecutó la consulta " +
+    "(consulta_realizada_at) para que el usuario pueda contrastar contra el " +
+    "panel sabiendo cuándo se tomó el dato. Las fechas son inclusive en " +
+    "formato YYYY-MM-DD. Filtra por sucursal del bot user. Excluye pedidos " +
+    "cancelados/anulados.",
   parameters: {
     type: "object",
     properties: {
@@ -123,12 +130,23 @@ export const ventasPeriodoTool: Tool<VentasPeriodoParams, VentasPeriodoResult> =
       top_productos: RpcProducto[];
     };
 
+    const consultaRealizadaAt = new Date().toLocaleString("es-AR", {
+      timeZone: "America/Argentina/Buenos_Aires",
+      day: "2-digit",
+      month: "2-digit",
+      year: "numeric",
+      hour: "2-digit",
+      minute: "2-digit",
+      hour12: false,
+    }) + " (ART)";
+
     return {
       desde: r.desde,
       hasta: r.hasta,
       total_ventas: Number(r.total_ventas ?? 0),
       pedidos_count: Number(r.pedidos_count ?? 0),
       ticket_promedio: Number(r.ticket_promedio ?? 0),
+      consulta_realizada_at: consultaRealizadaAt,
       top_clientes: (r.top_clientes ?? []).map((c) => ({
         id: Number(c.id),
         codigo: c.codigo ?? null,

--- a/supabase/functions/tests/tools.test.ts
+++ b/supabase/functions/tests/tools.test.ts
@@ -1804,6 +1804,11 @@ Deno.test("ventas_periodo invoca el RPC y deriva nombre de cliente", async () =>
   assertEquals(result.total_ventas, 8125460);
   assertEquals(result.pedidos_count, 173);
   assertEquals(result.ticket_promedio, 46967.98);
+  // Timestamp ART para que el LLM lo muestre y el usuario vea el corte exacto.
+  assert(
+    /\d{2}\/\d{2}\/\d{4}.*\d{2}:\d{2}.*\(ART\)/.test(result.consulta_realizada_at),
+    `consulta_realizada_at con formato inesperado: ${result.consulta_realizada_at}`,
+  );
   // Primer cliente: nombre_fantasia.
   assertEquals(result.top_clientes[0].nombre, "Taco Pozo");
   assertEquals(result.top_clientes[0].total_comprado, 994200);


### PR DESCRIPTION
## Contexto

Un usuario reportó que el bot Distribot devolvía totales distintos al panel "Pedidos" para el mismo rango (mayo'26, sucursal Tucumán): bot 385 / \$12.742.990, panel 401 / \$13.069.530.

## Diagnóstico

**Causa principal — timing.** El log `bot_audit_log` muestra que la consulta del bot fue a las **11:27 ART** y el screenshot del panel a las **14:13 ART** (~2h46m después). En esas horas entraron 16 pedidos nuevos. La mig029 (que ya usa `fecha` en vez de `created_at`) está aplicada en prod y los conteos coinciden cuando se consultan al mismo instante.

**Causa secundaria — asimetría semántica latente** que hoy no afecta pero podía drift en el futuro:

| Filtro | Bot (`bot_ventas_periodo`) | Panel (`fetchPedidoStats` / `fetchPedidosPaginated`) |
|---|---|---|
| Estado excluido | `COALESCE(estado,'') NOT IN ('cancelado','anulado')` | `.neq('estado','cancelado')` |
| `'anulado'` | EXCLUYE | INCLUYE |
| `NULL` | INCLUYE | EXCLUYE (`NULL != 'cancelado'` → NULL → falso) |

## Cambios

1. **`supabase/functions/_shared/tools/admin/ventas_periodo.ts`** — agrega `consulta_realizada_at` al output del tool con timestamp ART (`DD/MM/YYYY HH:MM (ART)`).
2. **`supabase/functions/_shared/gemini/prompts/admin.ts`** — instrucción al LLM para mostrar \`🕒 Datos al <valor>\` al final de respuestas con timestamp. Hace evidente el corte para prevenir reclamos por timing.
3. **`src/hooks/queries/usePedidoStatsQuery.ts`** y **`src/hooks/queries/usePedidosQuery.ts`** — reemplaza \`.neq('estado','cancelado')\` por \`.or('estado.is.null,and(estado.neq.cancelado,estado.neq.anulado)')\` para alinear con la RPC del bot.
4. **`supabase/functions/tests/tools.test.ts`** — aserción del nuevo campo.

## Validación

- DB ahora: bot RPC, panel nuevo y panel viejo dan idéntico resultado (**403 pedidos / \$13.180.530,12** para mayo'26 suc=1).
- \`tsc --noEmit\` ✅ | \`deno check\` ✅ | \`deno test tests/tools.test.ts\` 62/62 ✅ | \`eslint\` ✅ | pre-commit hooks ✅

## Test plan

- [ ] Redeploy edge function \`telegram-webhook\` (incluye \`_shared\`)
- [ ] Vercel/build levanta el frontend nuevo
- [ ] En Telegram: preguntar al bot "¿cuánto vendí este mes?" y verificar que el mensaje termine con \`🕒 Datos al <DD/MM/YYYY HH:MM> (ART)\`
- [ ] Abrir el panel de pedidos con el mismo rango y verificar que el TOTAL FILTRADO coincida (±1-2 pedidos por delta de segundos entre ambas consultas)

🤖 Generated with [Claude Code](https://claude.com/claude-code)