### PR TITLE
fix: total_neto en salvedad + permisos encargado + diag transferencias

### DIFF
--- a/migrations/064_registrar_salvedad_total_neto_iva.sql
+++ b/migrations/064_registrar_salvedad_total_neto_iva.sql
@@ -1,0 +1,537 @@
+-- ============================================================================
+-- 064 - registrar_salvedad: recalcular tambien total_neto y total_iva
+-- ============================================================================
+-- Bug: la rutina recalcula `total` (SUM(subtotal)) tras alterar pedido_items
+-- pero NO recalcula `total_neto` ni `total_iva`. Resultado: pedidos editados
+-- por salvedad quedan con total correcto pero neto/iva desactualizados, lo
+-- que rompe reportes contables (~0,8% de las ventas del mes).
+--
+-- Fix: actualizar las DOS overloads de registrar_salvedad (la legacy de
+-- mig 011 sin client_request_id y la idempotente de mig 049) para que el
+-- UPDATE final tambien sume cantidad*neto_unitario y cantidad*iva_unitario
+-- de los pedido_items no bonificados (los regalos no aportan a neto/iva).
+--
+-- Hotfix: UPDATE de los 27 pedidos detectados con total_neto desincronizado
+-- (sucursales 1 y 2, abril+mayo 2026). Se recalcula desde pedido_items.
+-- ============================================================================
+
+-- ----------------------------------------------------------------------------
+-- 1. registrar_salvedad LEGACY (sin p_client_request_id) - reemplazo
+-- ----------------------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION public.registrar_salvedad(
+  p_pedido_id         BIGINT,
+  p_pedido_item_id    BIGINT,
+  p_cantidad_afectada INTEGER,
+  p_motivo            CHARACTER VARYING,
+  p_descripcion       TEXT    DEFAULT NULL,
+  p_foto_url          TEXT    DEFAULT NULL,
+  p_devolver_stock    BOOLEAN DEFAULT TRUE
+) RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $function$
+DECLARE
+  v_sucursal          BIGINT := current_sucursal_id();
+  v_salvedad_id       BIGINT;
+  v_item              RECORD;
+  v_cantidad_entregada INTEGER;
+  v_monto_afectado    DECIMAL;
+  v_usuario_id        UUID;
+  v_es_admin          BOOLEAN;
+  v_subtotal_nuevo    DECIMAL;
+  v_stock_devuelto    BOOLEAN := FALSE;
+  v_merma_registrada  BOOLEAN := FALSE;
+  v_stock_actual      INTEGER;
+  v_bonif             RECORD;
+  v_cant_compra       INT;
+  v_cant_bonif        INT;
+  v_total_qty         INT;
+  v_bloques           INT;
+  v_expected_bonif    INT;
+  v_diff              INT;
+  v_regalo_mueve_stock BOOLEAN;
+BEGIN
+  IF v_sucursal IS NULL THEN
+    RETURN jsonb_build_object('success', false, 'error', 'No se pudo determinar la sucursal activa');
+  END IF;
+
+  v_usuario_id := auth.uid();
+  IF v_usuario_id IS NULL THEN
+    RETURN jsonb_build_object('success', false, 'error', 'Usuario no autenticado');
+  END IF;
+
+  SELECT EXISTS (SELECT 1 FROM perfiles WHERE id = v_usuario_id AND rol = 'admin') INTO v_es_admin;
+  IF NOT v_es_admin THEN
+    IF NOT EXISTS (
+      SELECT 1 FROM pedidos
+       WHERE id = p_pedido_id AND transportista_id = v_usuario_id AND sucursal_id = v_sucursal
+    ) THEN
+      RETURN jsonb_build_object('success', false, 'error', 'No autorizado para este pedido');
+    END IF;
+  END IF;
+
+  SELECT pi.id, pi.producto_id, pi.cantidad, pi.precio_unitario, pi.subtotal
+    INTO v_item
+    FROM pedido_items pi
+   WHERE pi.id = p_pedido_item_id
+     AND pi.pedido_id = p_pedido_id
+     AND pi.sucursal_id = v_sucursal;
+
+  IF v_item IS NULL THEN
+    RETURN jsonb_build_object('success', false, 'error', 'Item de pedido no encontrado');
+  END IF;
+
+  IF p_cantidad_afectada > v_item.cantidad THEN
+    RETURN jsonb_build_object('success', false, 'error', 'Cantidad afectada mayor a cantidad del item');
+  END IF;
+  IF p_cantidad_afectada <= 0 THEN
+    RETURN jsonb_build_object('success', false, 'error', 'Cantidad debe ser mayor a 0');
+  END IF;
+
+  v_cantidad_entregada := v_item.cantidad - p_cantidad_afectada;
+  v_monto_afectado     := p_cantidad_afectada * v_item.precio_unitario;
+  v_subtotal_nuevo     := v_cantidad_entregada * v_item.precio_unitario;
+
+  IF p_motivo IN ('cliente_rechaza', 'error_pedido', 'diferencia_precio') THEN
+    v_stock_devuelto := TRUE;
+  END IF;
+
+  INSERT INTO salvedades_items (
+    pedido_id, pedido_item_id, producto_id, cantidad_original, cantidad_afectada,
+    cantidad_entregada, motivo, descripcion, foto_url, monto_afectado, precio_unitario,
+    reportado_por, stock_devuelto, stock_devuelto_at, estado_resolucion, sucursal_id
+  ) VALUES (
+    p_pedido_id, p_pedido_item_id, v_item.producto_id, v_item.cantidad, p_cantidad_afectada,
+    v_cantidad_entregada, p_motivo, p_descripcion, p_foto_url, v_monto_afectado, v_item.precio_unitario,
+    v_usuario_id, v_stock_devuelto, CASE WHEN v_stock_devuelto THEN NOW() ELSE NULL END, 'pendiente', v_sucursal
+  ) RETURNING id INTO v_salvedad_id;
+
+  IF v_salvedad_id IS NULL THEN
+    RAISE EXCEPTION 'No se pudo crear la salvedad';
+  END IF;
+
+  IF v_cantidad_entregada > 0 THEN
+    UPDATE pedido_items SET cantidad = v_cantidad_entregada, subtotal = v_subtotal_nuevo
+     WHERE id = p_pedido_item_id AND sucursal_id = v_sucursal;
+  ELSE
+    DELETE FROM pedido_items WHERE id = p_pedido_item_id AND sucursal_id = v_sucursal;
+  END IF;
+
+  FOR v_bonif IN
+    SELECT pi.id, pi.producto_id, pi.cantidad, pi.promocion_id
+      FROM pedido_items pi
+     WHERE pi.pedido_id = p_pedido_id AND pi.sucursal_id = v_sucursal
+       AND COALESCE(pi.es_bonificacion, FALSE) = TRUE
+       AND pi.promocion_id IS NOT NULL
+  LOOP
+    SELECT
+      MAX(CASE WHEN pr.clave = 'cantidad_compra'       THEN pr.valor END)::INT,
+      MAX(CASE WHEN pr.clave = 'cantidad_bonificacion' THEN pr.valor END)::INT,
+      MAX(p.regalo_mueve_stock::INT)::BOOLEAN
+    INTO v_cant_compra, v_cant_bonif, v_regalo_mueve_stock
+    FROM promociones p
+    LEFT JOIN promocion_reglas pr ON pr.promocion_id = p.id
+    WHERE p.id = v_bonif.promocion_id AND p.sucursal_id = v_sucursal
+    GROUP BY p.id;
+
+    IF v_cant_compra IS NULL OR v_cant_compra <= 0
+       OR v_cant_bonif IS NULL OR v_cant_bonif <= 0 THEN
+      CONTINUE;
+    END IF;
+
+    SELECT COALESCE(SUM(pi.cantidad), 0)::INT
+      INTO v_total_qty
+      FROM pedido_items pi
+      JOIN promocion_productos pp ON pp.producto_id = pi.producto_id AND pp.promocion_id = v_bonif.promocion_id
+     WHERE pi.pedido_id = p_pedido_id AND pi.sucursal_id = v_sucursal
+       AND COALESCE(pi.es_bonificacion, FALSE) = FALSE;
+
+    v_bloques        := v_total_qty / v_cant_compra;
+    v_expected_bonif := v_bloques * v_cant_bonif;
+
+    IF v_expected_bonif < v_bonif.cantidad THEN
+      v_diff := v_bonif.cantidad - v_expected_bonif;
+
+      IF COALESCE(v_regalo_mueve_stock, FALSE) THEN
+        UPDATE productos SET stock = stock + v_diff
+         WHERE id = v_bonif.producto_id AND sucursal_id = v_sucursal;
+      END IF;
+
+      PERFORM public.revertir_bloques_auto_ajuste(
+        v_bonif.promocion_id, v_diff, v_sucursal,
+        v_usuario_id, 'Salvedad pedido #' || p_pedido_id
+      );
+
+      IF v_expected_bonif = 0 THEN
+        DELETE FROM pedido_items WHERE id = v_bonif.id;
+      ELSE
+        UPDATE pedido_items
+           SET cantidad = v_expected_bonif, subtotal = v_expected_bonif * COALESCE(precio_unitario, 0)
+         WHERE id = v_bonif.id;
+      END IF;
+    END IF;
+  END LOOP;
+
+  UPDATE pedidos
+     SET total = sub.total_recalc,
+         total_neto = sub.neto_recalc,
+         total_iva = sub.iva_recalc,
+         updated_at = NOW()
+    FROM (
+      SELECT
+        COALESCE(SUM(subtotal), 0) AS total_recalc,
+        COALESCE(SUM(CASE WHEN COALESCE(es_bonificacion, FALSE) = FALSE
+                          THEN cantidad * COALESCE(neto_unitario, precio_unitario)
+                          ELSE 0 END), 0) AS neto_recalc,
+        COALESCE(SUM(CASE WHEN COALESCE(es_bonificacion, FALSE) = FALSE
+                          THEN cantidad * COALESCE(iva_unitario, 0)
+                          ELSE 0 END), 0) AS iva_recalc
+        FROM pedido_items
+       WHERE pedido_id = p_pedido_id AND sucursal_id = v_sucursal
+    ) sub
+   WHERE id = p_pedido_id AND sucursal_id = v_sucursal;
+
+  IF v_stock_devuelto THEN
+    UPDATE productos SET stock = stock + p_cantidad_afectada
+     WHERE id = v_item.producto_id AND sucursal_id = v_sucursal;
+  END IF;
+
+  IF p_motivo IN ('producto_danado', 'producto_vencido') THEN
+    SELECT stock INTO v_stock_actual
+      FROM productos WHERE id = v_item.producto_id AND sucursal_id = v_sucursal FOR UPDATE;
+
+    INSERT INTO mermas_stock (producto_id, cantidad, motivo, observaciones, stock_anterior, stock_nuevo, usuario_id, sucursal_id)
+    VALUES (v_item.producto_id, p_cantidad_afectada,
+      CASE p_motivo WHEN 'producto_danado' THEN 'rotura' WHEN 'producto_vencido' THEN 'vencimiento' END,
+      COALESCE(p_descripcion, 'Salvedad pedido #' || p_pedido_id || ': ' || p_motivo),
+      v_stock_actual, GREATEST(v_stock_actual - p_cantidad_afectada, 0), v_usuario_id, v_sucursal);
+
+    UPDATE productos SET stock = GREATEST(stock - p_cantidad_afectada, 0)
+     WHERE id = v_item.producto_id AND sucursal_id = v_sucursal;
+    v_merma_registrada := TRUE;
+  END IF;
+
+  INSERT INTO salvedad_historial (salvedad_id, accion, estado_nuevo, notas, usuario_id, sucursal_id)
+  VALUES (v_salvedad_id, 'creacion', 'pendiente', p_descripcion, v_usuario_id, v_sucursal);
+
+  RETURN jsonb_build_object(
+    'success', true, 'salvedad_id', v_salvedad_id,
+    'monto_afectado', v_monto_afectado, 'cantidad_entregada', v_cantidad_entregada,
+    'stock_devuelto', v_stock_devuelto, 'merma_registrada', v_merma_registrada,
+    'nuevo_total_pedido', (SELECT total FROM pedidos WHERE id = p_pedido_id AND sucursal_id = v_sucursal)
+  );
+EXCEPTION WHEN OTHERS THEN
+  RETURN jsonb_build_object('success', false, 'error', SQLERRM);
+END;
+$function$;
+
+-- ----------------------------------------------------------------------------
+-- 2. registrar_salvedad IDEMPOTENTE (con p_client_request_id) - reemplazo
+-- ----------------------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION public.registrar_salvedad(
+  p_pedido_id         BIGINT,
+  p_pedido_item_id    BIGINT,
+  p_cantidad_afectada INTEGER,
+  p_motivo            CHARACTER VARYING,
+  p_descripcion       TEXT    DEFAULT NULL,
+  p_foto_url          TEXT    DEFAULT NULL,
+  p_devolver_stock    BOOLEAN DEFAULT TRUE,
+  p_client_request_id UUID    DEFAULT NULL
+) RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $function$
+DECLARE
+  v_sucursal           BIGINT := current_sucursal_id();
+  v_salvedad_id        BIGINT;
+  v_item               RECORD;
+  v_existing           RECORD;
+  v_cantidad_entregada INTEGER;
+  v_monto_afectado     DECIMAL;
+  v_usuario_id         UUID;
+  v_es_admin           BOOLEAN;
+  v_subtotal_nuevo     DECIMAL;
+  v_stock_devuelto     BOOLEAN := FALSE;
+  v_merma_registrada   BOOLEAN := FALSE;
+  v_stock_actual       INTEGER;
+  v_bonif              RECORD;
+  v_cant_compra        INT;
+  v_cant_bonif         INT;
+  v_total_qty          INT;
+  v_bloques            INT;
+  v_expected_bonif     INT;
+  v_diff               INT;
+  v_regalo_mueve_stock BOOLEAN;
+BEGIN
+  IF p_client_request_id IS NOT NULL THEN
+    SELECT id, motivo, monto_afectado, cantidad_entregada, stock_devuelto, pedido_id
+      INTO v_existing
+      FROM salvedades_items
+     WHERE client_request_id = p_client_request_id;
+
+    IF FOUND THEN
+      RETURN jsonb_build_object(
+        'success', true,
+        'salvedad_id', v_existing.id,
+        'monto_afectado', v_existing.monto_afectado,
+        'cantidad_entregada', v_existing.cantidad_entregada,
+        'stock_devuelto', v_existing.stock_devuelto,
+        'merma_registrada', v_existing.motivo IN ('producto_danado', 'producto_vencido'),
+        'nuevo_total_pedido', (
+          SELECT total FROM pedidos
+           WHERE id = v_existing.pedido_id AND sucursal_id = v_sucursal
+        ),
+        'idempotent_replay', true
+      );
+    END IF;
+  END IF;
+
+  IF v_sucursal IS NULL THEN
+    RETURN jsonb_build_object('success', false, 'error', 'No se pudo determinar la sucursal activa');
+  END IF;
+
+  v_usuario_id := auth.uid();
+  IF v_usuario_id IS NULL THEN
+    RETURN jsonb_build_object('success', false, 'error', 'Usuario no autenticado');
+  END IF;
+
+  SELECT EXISTS (SELECT 1 FROM perfiles WHERE id = v_usuario_id AND rol = 'admin') INTO v_es_admin;
+  IF NOT v_es_admin THEN
+    IF NOT EXISTS (
+      SELECT 1 FROM pedidos
+       WHERE id = p_pedido_id AND transportista_id = v_usuario_id AND sucursal_id = v_sucursal
+    ) THEN
+      RETURN jsonb_build_object('success', false, 'error', 'No autorizado para este pedido');
+    END IF;
+  END IF;
+
+  SELECT pi.id, pi.producto_id, pi.cantidad, pi.precio_unitario, pi.subtotal
+    INTO v_item
+    FROM pedido_items pi
+   WHERE pi.id = p_pedido_item_id
+     AND pi.pedido_id = p_pedido_id
+     AND pi.sucursal_id = v_sucursal;
+
+  IF NOT FOUND THEN
+    RETURN jsonb_build_object('success', false, 'error', 'Item de pedido no encontrado');
+  END IF;
+
+  IF p_cantidad_afectada > v_item.cantidad THEN
+    RETURN jsonb_build_object('success', false, 'error', 'Cantidad afectada mayor a cantidad del item');
+  END IF;
+  IF p_cantidad_afectada <= 0 THEN
+    RETURN jsonb_build_object('success', false, 'error', 'Cantidad debe ser mayor a 0');
+  END IF;
+
+  v_cantidad_entregada := v_item.cantidad - p_cantidad_afectada;
+  v_monto_afectado     := p_cantidad_afectada * v_item.precio_unitario;
+  v_subtotal_nuevo     := v_cantidad_entregada * v_item.precio_unitario;
+
+  IF p_motivo IN ('cliente_rechaza', 'error_pedido', 'diferencia_precio') THEN
+    v_stock_devuelto := TRUE;
+  END IF;
+
+  PERFORM set_config('app.stock_origen', 'salvedad', true);
+  PERFORM set_config('app.stock_ref_tipo', 'pedido', true);
+  PERFORM set_config('app.stock_ref_id', p_pedido_id::TEXT, true);
+  PERFORM set_config('app.stock_user_id', v_usuario_id::TEXT, true);
+
+  INSERT INTO salvedades_items (
+    pedido_id, pedido_item_id, producto_id, cantidad_original, cantidad_afectada,
+    cantidad_entregada, motivo, descripcion, foto_url, monto_afectado, precio_unitario,
+    reportado_por, stock_devuelto, stock_devuelto_at, estado_resolucion, sucursal_id,
+    client_request_id
+  ) VALUES (
+    p_pedido_id, p_pedido_item_id, v_item.producto_id, v_item.cantidad, p_cantidad_afectada,
+    v_cantidad_entregada, p_motivo, p_descripcion, p_foto_url, v_monto_afectado, v_item.precio_unitario,
+    v_usuario_id, v_stock_devuelto, CASE WHEN v_stock_devuelto THEN NOW() ELSE NULL END, 'pendiente', v_sucursal,
+    p_client_request_id
+  ) RETURNING id INTO v_salvedad_id;
+
+  IF v_salvedad_id IS NULL THEN
+    RAISE EXCEPTION 'No se pudo crear la salvedad';
+  END IF;
+
+  IF v_cantidad_entregada > 0 THEN
+    UPDATE pedido_items
+       SET cantidad = v_cantidad_entregada,
+           subtotal = v_subtotal_nuevo
+     WHERE id = p_pedido_item_id AND sucursal_id = v_sucursal;
+  ELSE
+    DELETE FROM pedido_items
+     WHERE id = p_pedido_item_id AND sucursal_id = v_sucursal;
+  END IF;
+
+  FOR v_bonif IN
+    SELECT pi.id, pi.producto_id, pi.cantidad, pi.promocion_id
+      FROM pedido_items pi
+     WHERE pi.pedido_id = p_pedido_id
+       AND pi.sucursal_id = v_sucursal
+       AND COALESCE(pi.es_bonificacion, FALSE) = TRUE
+       AND pi.promocion_id IS NOT NULL
+  LOOP
+    SELECT
+      MAX(CASE WHEN pr.clave = 'cantidad_compra'       THEN pr.valor END)::INT,
+      MAX(CASE WHEN pr.clave = 'cantidad_bonificacion' THEN pr.valor END)::INT,
+      MAX(p.regalo_mueve_stock::INT)::BOOLEAN
+    INTO v_cant_compra, v_cant_bonif, v_regalo_mueve_stock
+    FROM promociones p
+    LEFT JOIN promocion_reglas pr
+      ON pr.promocion_id = p.id
+    WHERE p.id = v_bonif.promocion_id
+      AND p.sucursal_id = v_sucursal
+    GROUP BY p.id;
+
+    IF v_cant_compra IS NULL OR v_cant_compra <= 0
+       OR v_cant_bonif IS NULL OR v_cant_bonif <= 0 THEN
+      CONTINUE;
+    END IF;
+
+    SELECT COALESCE(SUM(pi.cantidad), 0)::INT
+      INTO v_total_qty
+      FROM pedido_items pi
+      JOIN promocion_productos pp
+        ON pp.producto_id = pi.producto_id
+       AND pp.promocion_id = v_bonif.promocion_id
+     WHERE pi.pedido_id = p_pedido_id
+       AND pi.sucursal_id = v_sucursal
+       AND COALESCE(pi.es_bonificacion, FALSE) = FALSE;
+
+    v_bloques        := v_total_qty / v_cant_compra;
+    v_expected_bonif := v_bloques * v_cant_bonif;
+
+    IF v_expected_bonif < v_bonif.cantidad THEN
+      v_diff := v_bonif.cantidad - v_expected_bonif;
+
+      IF COALESCE(v_regalo_mueve_stock, FALSE) THEN
+        UPDATE productos
+           SET stock = stock + v_diff
+         WHERE id = v_bonif.producto_id
+           AND sucursal_id = v_sucursal;
+      END IF;
+
+      UPDATE promociones
+         SET usos_pendientes = GREATEST(COALESCE(usos_pendientes, 0) - v_diff, 0)
+       WHERE id = v_bonif.promocion_id
+         AND sucursal_id = v_sucursal;
+
+      IF v_expected_bonif = 0 THEN
+        DELETE FROM pedido_items WHERE id = v_bonif.id;
+      ELSE
+        UPDATE pedido_items
+           SET cantidad = v_expected_bonif,
+               subtotal = v_expected_bonif * COALESCE(precio_unitario, 0)
+         WHERE id = v_bonif.id;
+      END IF;
+    END IF;
+  END LOOP;
+
+  UPDATE pedidos
+     SET total = sub.total_recalc,
+         total_neto = sub.neto_recalc,
+         total_iva = sub.iva_recalc,
+         updated_at = NOW()
+    FROM (
+      SELECT
+        COALESCE(SUM(subtotal), 0) AS total_recalc,
+        COALESCE(SUM(CASE WHEN COALESCE(es_bonificacion, FALSE) = FALSE
+                          THEN cantidad * COALESCE(neto_unitario, precio_unitario)
+                          ELSE 0 END), 0) AS neto_recalc,
+        COALESCE(SUM(CASE WHEN COALESCE(es_bonificacion, FALSE) = FALSE
+                          THEN cantidad * COALESCE(iva_unitario, 0)
+                          ELSE 0 END), 0) AS iva_recalc
+        FROM pedido_items
+       WHERE pedido_id = p_pedido_id AND sucursal_id = v_sucursal
+    ) sub
+   WHERE id = p_pedido_id AND sucursal_id = v_sucursal;
+
+  IF v_stock_devuelto THEN
+    UPDATE productos
+       SET stock = stock + p_cantidad_afectada
+     WHERE id = v_item.producto_id AND sucursal_id = v_sucursal;
+  END IF;
+
+  IF p_motivo IN ('producto_danado', 'producto_vencido') THEN
+    SELECT stock INTO v_stock_actual
+      FROM productos
+     WHERE id = v_item.producto_id AND sucursal_id = v_sucursal
+     FOR UPDATE;
+
+    INSERT INTO mermas_stock (
+      producto_id, cantidad, motivo, observaciones,
+      stock_anterior, stock_nuevo, usuario_id, sucursal_id
+    ) VALUES (
+      v_item.producto_id, p_cantidad_afectada,
+      CASE p_motivo WHEN 'producto_danado' THEN 'rotura' WHEN 'producto_vencido' THEN 'vencimiento' END,
+      COALESCE(p_descripcion, 'Salvedad pedido #' || p_pedido_id || ': ' || p_motivo),
+      v_stock_actual, GREATEST(v_stock_actual - p_cantidad_afectada, 0), v_usuario_id, v_sucursal
+    );
+
+    UPDATE productos
+       SET stock = GREATEST(stock - p_cantidad_afectada, 0)
+     WHERE id = v_item.producto_id AND sucursal_id = v_sucursal;
+
+    v_merma_registrada := TRUE;
+  END IF;
+
+  INSERT INTO salvedad_historial (salvedad_id, accion, estado_nuevo, notas, usuario_id, sucursal_id)
+  VALUES (v_salvedad_id, 'creacion', 'pendiente', p_descripcion, v_usuario_id, v_sucursal);
+
+  RETURN jsonb_build_object(
+    'success', true,
+    'salvedad_id', v_salvedad_id,
+    'monto_afectado', v_monto_afectado,
+    'cantidad_entregada', v_cantidad_entregada,
+    'stock_devuelto', v_stock_devuelto,
+    'merma_registrada', v_merma_registrada,
+    'nuevo_total_pedido', (
+      SELECT total FROM pedidos WHERE id = p_pedido_id AND sucursal_id = v_sucursal
+    )
+  );
+EXCEPTION WHEN OTHERS THEN
+  RETURN jsonb_build_object('success', false, 'error', SQLERRM);
+END;
+$function$;
+
+-- ----------------------------------------------------------------------------
+-- 3. Hotfix: resincronizar total_neto y total_iva en los 27 pedidos afectados
+-- ----------------------------------------------------------------------------
+-- Se filtra a pedidos donde total ya esta correcto (= SUM(subtotal) o = 0 si
+-- no quedan items) pero total_neto / total_iva no coinciden. Asi no tocamos
+-- pedidos pre-columna (NULL legacy) que pueden ser un caso aparte.
+
+WITH recalc AS (
+  SELECT p.id AS pedido_id, p.sucursal_id,
+         COALESCE((SELECT SUM(pi.subtotal)
+                     FROM pedido_items pi
+                    WHERE pi.pedido_id = p.id AND pi.sucursal_id = p.sucursal_id), 0)
+           AS total_recalc,
+         COALESCE((SELECT SUM(pi.cantidad * COALESCE(pi.neto_unitario, pi.precio_unitario))
+                     FROM pedido_items pi
+                    WHERE pi.pedido_id = p.id AND pi.sucursal_id = p.sucursal_id
+                      AND COALESCE(pi.es_bonificacion, FALSE) = FALSE), 0)
+           AS neto_recalc,
+         COALESCE((SELECT SUM(pi.cantidad * COALESCE(pi.iva_unitario, 0))
+                     FROM pedido_items pi
+                    WHERE pi.pedido_id = p.id AND pi.sucursal_id = p.sucursal_id
+                      AND COALESCE(pi.es_bonificacion, FALSE) = FALSE), 0)
+           AS iva_recalc
+    FROM pedidos p
+   WHERE p.total_neto IS NOT NULL
+)
+UPDATE pedidos p
+   SET total_neto = r.neto_recalc,
+       total_iva  = r.iva_recalc,
+       updated_at = NOW()
+  FROM recalc r
+ WHERE p.id = r.pedido_id
+   AND p.sucursal_id = r.sucursal_id
+   AND p.total = r.total_recalc
+   AND (
+     p.total_neto IS DISTINCT FROM r.neto_recalc
+     OR p.total_iva IS DISTINCT FROM r.iva_recalc
+   );

--- a/src/components/containers/PedidosContainer.tsx
+++ b/src/components/containers/PedidosContainer.tsx
@@ -1239,6 +1239,7 @@ export default function PedidosContainer(): React.ReactElement {
             guardando={guardando}
             isAdmin={isAdmin}
             isPreventista={isPreventista}
+            isEncargado={isEncargado}
             onNotasChange={(notas: string) => setNuevoPedido(prev => ({ ...prev, notas }))}
             onFormaPagoChange={(fp: string) => setNuevoPedido(prev => ({ ...prev, formaPago: fp }))}
             onEstadoPagoChange={(ep: string) => setNuevoPedido(prev => ({ ...prev, estadoPago: ep }))}

--- a/src/components/containers/TransferenciasContainer.tsx
+++ b/src/components/containers/TransferenciasContainer.tsx
@@ -15,6 +15,7 @@ import {
   useProductosQuery,
 } from '../../hooks/queries'
 import { useAuthData } from '../../contexts/AuthDataContext'
+import { useSucursal } from '../../contexts/SucursalContext'
 import { useNotification } from '../../contexts/NotificationContext'
 import { useResetOnSucursalChange } from '../../hooks/useResetOnSucursalChange'
 import { fechaHaceDias, fechaLocalISO } from '../../utils/formatters'
@@ -35,6 +36,7 @@ function LoadingState() {
 
 export default function TransferenciasContainer(): React.ReactElement {
   const { user } = useAuthData()
+  const { currentSucursalId } = useSucursal()
   const notify = useNotification()
 
   // Filtros de fecha + paginacion. Defaults: ultimos 60 dias, pagina 1.
@@ -116,8 +118,26 @@ export default function TransferenciasContainer(): React.ReactElement {
     return nueva
   }, [crearSucursal, notify])
 
+  // Banner defensivo: si la sucursal activa quedo null (ej. localStorage stale
+  // apuntando a una sucursal a la que el usuario perdio acceso),
+  // current_sucursal_id() en la DB devuelve NULL y la RLS oculta todos los
+  // movimientos, incluso los que el mismo usuario creo. Avisamos en vez de
+  // mostrar "No hay movimientos" silenciosamente.
+  const sucursalInvalida = !currentSucursalId
+
   return (
     <>
+      {sucursalInvalida && (
+        <div className="mb-4 rounded-lg border border-amber-300 bg-amber-50 dark:bg-amber-900/20 dark:border-amber-800 px-4 py-3 text-sm text-amber-800 dark:text-amber-200">
+          <p className="font-medium">No se detecta una sucursal activa.</p>
+          <p className="mt-1 text-xs">
+            Es probable que tu sesion haya quedado apuntando a una sucursal vieja. Cerra
+            sesion y volve a entrar, o cambia de sucursal desde el menu superior.
+            Mientras tanto, el panel mostrara vacio porque la base oculta los movimientos
+            que no pueda asociar a una sucursal autorizada.
+          </p>
+        </div>
+      )}
       <Suspense fallback={<LoadingState />}>
         <VistaTransferencias
           transferencias={transferencias}

--- a/src/components/modals/ModalPedido.tsx
+++ b/src/components/modals/ModalPedido.tsx
@@ -84,6 +84,8 @@ export interface ModalPedidoProps {
   isAdmin?: boolean;
   /** Si es preventista */
   isPreventista?: boolean;
+  /** Si es encargado */
+  isEncargado?: boolean;
   /** Callback al cambiar notas */
   onNotasChange?: (notas: string) => void;
   /** Callback al cambiar forma de pago */
@@ -123,6 +125,7 @@ const ModalPedido = memo(function ModalPedido({
   guardando,
   isAdmin,
   isPreventista,
+  isEncargado,
   onNotasChange,
   onFormaPagoChange,
   onEstadoPagoChange,
@@ -287,7 +290,7 @@ const ModalPedido = memo(function ModalPedido({
           <div>
             <div className="flex justify-between items-center mb-1">
               <label className="block text-sm font-medium dark:text-gray-200">Cliente *</label>
-              {(isAdmin || isPreventista) && (
+              {(isAdmin || isPreventista || isEncargado) && (
                 <button onClick={() => { setMostrarNuevoCliente(!mostrarNuevoCliente); setErrorCliente(''); setGpsError(null); setGpsAccuracy(null); }} className="text-sm text-blue-600">
                   {mostrarNuevoCliente ? 'Cancelar' : '+ Nuevo'}
                 </button>

--- a/src/components/modals/ModalTransferencia.tsx
+++ b/src/components/modals/ModalTransferencia.tsx
@@ -162,8 +162,9 @@ export default function ModalTransferencia({
       }
       await onSave(formData)
       onClose()
-    } catch {
-      setError('Error al registrar el envio')
+    } catch (err) {
+      const msg = err instanceof Error && err.message ? err.message : 'Error al registrar el envio'
+      setError(msg)
     } finally {
       setGuardando(false)
     }

--- a/src/components/vistas/VistaClientes.tsx
+++ b/src/components/vistas/VistaClientes.tsx
@@ -266,6 +266,7 @@ export default function VistaClientes({
               cliente={cliente}
               idx={idx}
               isAdmin={isAdmin}
+              canEditar={isAdmin || isEncargado}
               verSaldo={verSaldo}
               onEditar={() => onEditarCliente(cliente)}
               onEliminar={() => onEliminarCliente(cliente.id)}
@@ -294,13 +295,14 @@ interface ClienteCardProps {
   cliente: ClienteDB;
   idx: number;
   isAdmin: boolean;
+  canEditar: boolean;
   verSaldo: boolean;
   onEditar: () => void;
   onEliminar: () => void;
   onVerFicha?: () => void;
 }
 
-function ClienteCard({ cliente, idx, isAdmin, verSaldo, onEditar, onEliminar, onVerFicha }: ClienteCardProps) {
+function ClienteCard({ cliente, idx, isAdmin, canEditar, verSaldo, onEditar, onEliminar, onVerFicha }: ClienteCardProps) {
   const saldo = cliente.saldo_cuenta ?? 0;
   const saldoColor =
     saldo > 0 ? 'text-rose-700 dark:text-rose-300'
@@ -334,22 +336,26 @@ function ClienteCard({ cliente, idx, isAdmin, verSaldo, onEditar, onEliminar, on
             </span>
           )}
         </div>
-        {isAdmin && (
+        {(canEditar || isAdmin) && (
           <div className="flex gap-0.5 flex-shrink-0">
-            <button
-              onClick={onEditar}
-              className="p-1.5 text-stone-500 hover:text-blue-600 hover:bg-blue-50 dark:hover:bg-blue-900/30 rounded-md transition-colors"
-              aria-label={`Editar cliente ${cliente.nombre_fantasia}`}
-            >
-              <Edit2 className="w-3.5 h-3.5" aria-hidden="true" />
-            </button>
-            <button
-              onClick={onEliminar}
-              className="p-1.5 text-stone-500 hover:text-rose-600 hover:bg-rose-50 dark:hover:bg-rose-900/30 rounded-md transition-colors"
-              aria-label={`Eliminar cliente ${cliente.nombre_fantasia}`}
-            >
-              <Trash2 className="w-3.5 h-3.5" aria-hidden="true" />
-            </button>
+            {canEditar && (
+              <button
+                onClick={onEditar}
+                className="p-1.5 text-stone-500 hover:text-blue-600 hover:bg-blue-50 dark:hover:bg-blue-900/30 rounded-md transition-colors"
+                aria-label={`Editar cliente ${cliente.nombre_fantasia}`}
+              >
+                <Edit2 className="w-3.5 h-3.5" aria-hidden="true" />
+              </button>
+            )}
+            {isAdmin && (
+              <button
+                onClick={onEliminar}
+                className="p-1.5 text-stone-500 hover:text-rose-600 hover:bg-rose-50 dark:hover:bg-rose-900/30 rounded-md transition-colors"
+                aria-label={`Eliminar cliente ${cliente.nombre_fantasia}`}
+              >
+                <Trash2 className="w-3.5 h-3.5" aria-hidden="true" />
+              </button>
+            )}
           </div>
         )}
       </div>


### PR DESCRIPTION
## Summary

Tres fixes independientes en un solo PR (reportes del owner el 25/05):

- **Bug `total_neto` al editar pedidos entregados (14 pedidos · $108K del mes).** `registrar_salvedad` (las dos overloads) recalculaba `total = SUM(subtotal)` pero NO `total_neto` ni `total_iva`. Ej: pedido #1457 quedó con `total=53.200` pero `total_neto=61.600`. Fix forward en ambas overloads + hotfix UPDATE para 27 pedidos detectados (14 de mayo + 13 de abril con el mismo patrón).
- **Encargado puede editar dirección y usar GPS.** Backend ya lo permitía (RLS `mt_clientes_update` via `es_preventista()`). Solo era gate de UI: ahora `VistaClientes` le muestra el botón Editar y `ModalPedido` le habilita "+ Nuevo" cliente rápido con autocomplete + GPS / reverse geocoding.
- **Diagnóstico transferencias (caso Virginia).** Reportó panel vacío total tras crear ingreso+egreso. Solo el egreso quedó persistido en DB; el ingreso falló silenciosamente porque el modal se comía el mensaje del RPC. Cambios: (a) propagar `err.message` del RPC en `ModalTransferencia`; (b) banner defensivo en `TransferenciasContainer` cuando `currentSucursalId === null` — caso típico de `localStorage` apuntando a sucursal sin acceso, que hace `current_sucursal_id()` devolver NULL y la RLS ocultar todo.

## Cambios

### Migración (ya aplicada en prod)
- `migrations/064_registrar_salvedad_total_neto_iva.sql` — DDL de ambas overloads + hotfix UPDATE.

### UI
- `src/components/vistas/VistaClientes.tsx` — botón Editar para encargado (Eliminar sigue solo admin).
- `src/components/modals/ModalPedido.tsx` — nueva prop `isEncargado`, gate de "+ Nuevo" cliente abierto a encargado.
- `src/components/containers/PedidosContainer.tsx` — pasa `isEncargado` al modal.
- `src/components/modals/ModalTransferencia.tsx` — propaga error real del RPC.
- `src/components/containers/TransferenciasContainer.tsx` — banner cuando sucursal activa = null.

## Test plan

- [x] `tsc --noEmit` pasa.
- [x] Pre-commit (eslint + vitest) pasa.
- [x] Hotfix UPDATE corrió en prod y devolvió las 27 filas esperadas (incluyó #1457, #1866, #1856 con los valores correctos).
- [ ] **Verificación manual con Virginia**: cerrar sesión, volver a entrar, intentar el ingreso de nuevo. Si vuelve a fallar, ahora debería ver el mensaje real del RPC (no el genérico).
- [ ] **Verificación encargado**: loguearse con rol encargado y confirmar que aparece el botón Editar en clientes y "+ Nuevo" en ModalPedido.
- [ ] **Verificación salvedad**: registrar una salvedad sobre un pedido entregado y verificar que `total`, `total_neto` y `total_iva` quedan los tres recalculados.

🤖 Generated with [Claude Code](https://claude.com/claude-code)