### PR TITLE
fix(transferencias): embed PostgREST ambiguo deja panel vacío

### DIFF
--- a/src/components/containers/TransferenciasContainer.tsx
+++ b/src/components/containers/TransferenciasContainer.tsx
@@ -46,7 +46,7 @@ export default function TransferenciasContainer(): React.ReactElement {
   const filtros = useMemo(() => ({ desde, hasta, pagina }), [desde, hasta, pagina])
 
   // Queries
-  const { data: transferencias = [], isLoading } = useTransferenciasQuery(filtros)
+  const { data: transferencias = [], isLoading, error: queryError } = useTransferenciasQuery(filtros)
   const { data: sucursales = [] } = useSucursalesQuery()
   const { data: productos = [] } = useProductosQuery()
 
@@ -135,6 +135,14 @@ export default function TransferenciasContainer(): React.ReactElement {
             sesion y volve a entrar, o cambia de sucursal desde el menu superior.
             Mientras tanto, el panel mostrara vacio porque la base oculta los movimientos
             que no pueda asociar a una sucursal autorizada.
+          </p>
+        </div>
+      )}
+      {queryError && !sucursalInvalida && (
+        <div className="mb-4 rounded-lg border border-rose-300 bg-rose-50 dark:bg-rose-900/20 dark:border-rose-800 px-4 py-3 text-sm text-rose-800 dark:text-rose-200">
+          <p className="font-medium">No se pudieron cargar los movimientos.</p>
+          <p className="mt-1 text-xs font-mono break-all">
+            {queryError instanceof Error ? queryError.message : String(queryError)}
           </p>
         </div>
       )}

--- a/src/hooks/queries/useTransferenciasQuery.ts
+++ b/src/hooks/queries/useTransferenciasQuery.ts
@@ -55,12 +55,17 @@ interface FetchTransferenciasOpts {
 
 // Fetch functions
 async function fetchTransferencias(opts: FetchTransferenciasOpts): Promise<TransferenciaDB[]> {
+  // IMPORTANTE: transferencias_stock tiene DOS FK a sucursales (sucursal_id y
+  // tenant_sucursal_id desde mig 057). Sin hint explicito de FK, PostgREST
+  // devuelve "Could not embed because more than one relationship..." y la
+  // tabla se ve vacia. Por eso especificamos !sucursal_id (la contraparte
+  // del movimiento, que es lo que ya espera la vista).
   const { data, error } = await supabase
     .from('transferencias_stock')
     .select(`
       *,
-      sucursal:sucursales(id, nombre),
-      usuario:perfiles(id, nombre)
+      sucursal:sucursales!sucursal_id(id, nombre),
+      usuario:perfiles!usuario_id(id, nombre)
     `)
     .gte('fecha', opts.desde)
     .lte('fecha', opts.hasta)


### PR DESCRIPTION
## Summary

Follow-up del PR #338. Agustín reportó que el panel de **Movimiento entre Sucursales** sigue vacío y carga lento, aunque la sucursal activa es Tucumán (1) y hay 4 movimientos en la DB con `tenant_sucursal_id=1`.

**Causa raíz encontrada:** desde la mig 057 `transferencias_stock` tiene DOS FK a `sucursales` (`sucursal_id` para la contraparte + `tenant_sucursal_id` para el tenant del movimiento). El embed PostgREST sin hint:

```ts
.select('*, sucursal:sucursales(id, nombre), usuario:perfiles(id, nombre)')
```

es ambiguo y PostgREST devuelve `"Could not embed because more than one relationship was found between 'transferencias_stock' and 'sucursales'"`. `fetchTransferencias` hace `throw error` pero la vista solo mira `loading` y `data`, así que el error se renderiza como "No hay movimientos registrados". La **lentitud** que notó es PostgREST resolviendo la ambigüedad antes de fallar.

Verifiqué simulando el JWT de Agustín con `x-sucursal-id=1` directamente en la DB y la consulta sin embed sí devuelve los 4 movimientos — confirma que ni la RLS ni los datos están rotos.

## Cambios

### `src/hooks/queries/useTransferenciasQuery.ts`
Embed con hint explícito de FK:
```ts
sucursal:sucursales!sucursal_id(id, nombre),
usuario:perfiles!usuario_id(id, nombre)
```
`!sucursal_id` apunta a la contraparte del movimiento, que es lo que la vista ya esperaba (lo muestra como columna "Sucursal").

### `src/components/containers/TransferenciasContainer.tsx`
Banner rojo cuando la query falla, mostrando el mensaje real del error. Así futuros errores de PostgREST o RLS no se vuelven a comer silenciosamente.

## Test plan

- [x] `tsc --noEmit` pasa.
- [x] Pre-commit (eslint + vitest 674 tests) pasa.
- [x] Simulación SQL con JWT de Agustín devuelve los 4 movimientos sin ambigüedad.
- [ ] **Verificación en prod**: Agustín abre /transferencias y debe ver los 4 movimientos (3 viejos de abril con tipo='salida' + el egreso del 22/05 a TACO POZO). La carga debe ser rápida.

🤖 Generated with [Claude Code](https://claude.com/claude-code)