### PR TITLE
fix(geo): desbloquea preventista cuando Permissions API queda stale

### DIFF
--- a/src/components/GeolocationGate.tsx
+++ b/src/components/GeolocationGate.tsx
@@ -88,6 +88,15 @@ export default function GeolocationGate({
   const { state, refetch } = useGeolocationPermission()
   const [requesting, setRequesting] = useState(false)
   const [browser, setBrowser] = useState<Browser>('other')
+  // Override local: si `getCurrentPosition` resuelve con éxito o con cualquier
+  // error que no sea PERMISSION_DENIED, sabemos que el permiso fue otorgado y
+  // dejamos pasar — aunque `navigator.permissions.query` siga reportando
+  // 'prompt'. Es un bug conocido de Chrome Android y otros browsers móviles
+  // donde el estado de Permissions API no se actualiza inmediatamente ni
+  // dispara el evento `change` después de que el usuario aprueba el prompt.
+  // Sin este override, el preventista "activa la ubicación pero no lo deja
+  // pasar" — exactamente el síntoma reportado en campo.
+  const [grantedOverride, setGrantedOverride] = useState(false)
 
   useEffect(() => {
     setBrowser(detectBrowser())
@@ -99,10 +108,19 @@ export default function GeolocationGate({
     navigator.geolocation.getCurrentPosition(
       () => {
         setRequesting(false)
+        setGrantedOverride(true)
         void refetch()
       },
-      () => {
+      (err) => {
         setRequesting(false)
+        // Solo PERMISSION_DENIED indica que el usuario bloqueó el permiso.
+        // Timeout / position_unavailable / otros errores son problemas del
+        // sensor o de cobertura: el permiso SÍ fue otorgado, así que dejamos
+        // pasar para que el flujo de captura al confirmar el pedido capture
+        // motivo de omisión sin trabar al preventista en el gate.
+        if (err.code !== err.PERMISSION_DENIED) {
+          setGrantedOverride(true)
+        }
         void refetch()
       },
       { enableHighAccuracy: true, timeout: 10_000, maximumAge: 30_000 },
@@ -110,7 +128,7 @@ export default function GeolocationGate({
   }, [refetch])
 
   if (!enabled) return <>{children}</>
-  if (state === 'granted' || state === 'unsupported') return <>{children}</>
+  if (grantedOverride || state === 'granted' || state === 'unsupported') return <>{children}</>
 
   if (state === 'prompt') {
     return (


### PR DESCRIPTION
## Síntoma (reportado en campo, urgente)
Un preventista intenta crear un pedido. El sistema le pide activar la ubicación, la activa, y aun así la pantalla \"Activá la ubicación para continuar\" sigue visible — **no lo deja crear el pedido**.

## Causa raíz
[\`GeolocationGate\`](src/components/GeolocationGate.tsx) dependía exclusivamente de \`navigator.permissions.query({name:'geolocation'})\` (vía [\`useGeolocationPermission\`](src/hooks/useGeolocationPermission.ts)) para decidir si renderizar el children o la pantalla bloqueante.

En **Chrome Android** y otros browsers móviles, la Permissions API puede seguir devolviendo \`'prompt'\` durante varios segundos después de que el usuario aprueba el prompt nativo de geolocalización, y el evento \`change\` del PermissionStatus a veces no dispara. Como \`handleRequest\` solo refetcheaba el mismo estado stale, el componente nunca renderizaba los children. El preventista quedaba atrapado en la pantalla \"Activar GPS\" en loop.

## Fix
- Agrega \`grantedOverride\` local al \`GeolocationGate\`.
- Cuando \`getCurrentPosition\` resuelve con éxito (= permiso otorgado), se setea \`grantedOverride=true\` sin depender de Permissions API.
- Si el error es \`PERMISSION_DENIED\`, NO se overridea (la rama 'denied' sigue mostrando la pantalla con instrucciones por SO).
- Si el error es \`TIMEOUT\` / \`POSITION_UNAVAILABLE\` / \`error\` genérico, también se overridea: el permiso fue otorgado pero el sensor falló — el preventista pasa al form y el flujo de captura al confirmar el pedido registra el motivo de omisión vía \`ModalMotivoSinGps\`, sin trabarlo en el gate.
- Sin migraciones, sin tocar RPCs. Solo frontend.

## Test plan
- [ ] Login como preventista en Chrome Android, abrir \"Nuevo Pedido\", tocar \"Activar GPS\", aceptar el prompt nativo → el form de pedido debe aparecer inmediatamente.
- [ ] Repetir el flujo con el permiso ya granted de una sesión anterior → form aparece sin pasar por la pantalla de activación.
- [ ] Tocar \"Activar GPS\" y **rechazar** el prompt nativo → debe seguir mostrando la pantalla con instrucciones de cómo reactivarlo desde settings (rama 'denied').
- [ ] Activar permiso pero estar en interior sin señal (timeout) → preventista entra al form y al confirmar el pedido se le pide motivo vía ModalMotivoSinGps.
- [ ] Login como admin o encargado → no se afecta (\`enabled=false\`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)