### PR TITLE
fix(geo): elimina dependencia de Permissions API en GeolocationGate (v2)

### DIFF
--- a/src/components/GeolocationGate.tsx
+++ b/src/components/GeolocationGate.tsx
@@ -3,23 +3,29 @@
  *
  * Wrappea UI que requiere GPS obligatorio (visitas, pedidos de preventistas).
  *
- * - `granted` / `unsupported`: render `children` (en `unsupported` el flujo
- *   legacy del hook de captura igual maneja los errores).
- * - `prompt`: render una pantalla con CTA "Activar GPS" que dispara el dialog
- *   nativo del browser. Solo el primer permiso intencional viene por acá; en
- *   subsiguientes ya queda `granted` o `denied`.
- * - `denied`: render una pantalla bloqueante con instrucciones específicas por
- *   browser/SO (Chrome Android, iOS Safari, Chrome desktop, Firefox). Una vez
- *   que el usuario reactiva el permiso desde settings, el botón "Ya lo activé"
- *   re-consulta y desbloquea.
+ * Diseño: el gate es totalmente driven por `navigator.geolocation.getCurrentPosition`,
+ * sin depender de `navigator.permissions.query({name:'geolocation'})`. La
+ * Permissions API es notoriamente poco confiable en Chrome Android: puede
+ * devolver `'prompt'` indefinidamente después de que el usuario aprueba el
+ * permiso, y a veces nunca dispara el evento `change`. El síntoma en campo era
+ * "el preventista activa la ubicación pero la pantalla 'Activá la ubicación'
+ * no se va, no lo deja crear el pedido". Acá confiamos solo en lo que el
+ * propio geolocation API reporta:
  *
- * El gate sólo se aplica cuando `enabled` es true (típicamente
- * `isPreventista`). Para roles que no requieren GPS (admin, encargado), el
- * componente renderiza `children` directo sin chequear nada.
+ * - Click en "Activar GPS" → `getCurrentPosition`.
+ * - Success → pasa a `'allowed'` y renderiza children.
+ * - Error `PERMISSION_DENIED` → pantalla `'blocked'` con instrucciones por SO.
+ * - Cualquier otro error (timeout / position_unavailable / generic) → también
+ *   pasa a `'allowed'`: el permiso fue otorgado y solo falló el sensor. El
+ *   flujo de captura GPS al confirmar el pedido se encarga del motivo de
+ *   omisión via ModalMotivoSinGps — no queremos trabar al preventista en el
+ *   gate por una falla del sensor.
+ *
+ * El gate sólo se aplica cuando `enabled` es true (típicamente `isPreventista`).
+ * Para roles que no requieren GPS (admin, encargado), renderiza children direct.
  */
 import { useCallback, useEffect, useState, type ReactNode } from 'react'
 import { MapPin, AlertTriangle, Loader2 } from 'lucide-react'
-import { useGeolocationPermission } from '../hooks/useGeolocationPermission'
 
 export interface GeolocationGateProps {
   enabled: boolean
@@ -28,6 +34,7 @@ export interface GeolocationGateProps {
 }
 
 type Browser = 'chrome-android' | 'ios-safari' | 'chrome-desktop' | 'firefox' | 'other'
+type GateState = 'idle' | 'requesting' | 'allowed' | 'blocked'
 
 function detectBrowser(): Browser {
   if (typeof navigator === 'undefined') return 'other'
@@ -85,82 +92,110 @@ export default function GeolocationGate({
   children,
   onCancel,
 }: GeolocationGateProps) {
-  const { state, refetch } = useGeolocationPermission()
-  const [requesting, setRequesting] = useState(false)
+  const [gateState, setGateState] = useState<GateState>('idle')
   const [browser, setBrowser] = useState<Browser>('other')
-  // Override local: si `getCurrentPosition` resuelve con éxito o con cualquier
-  // error que no sea PERMISSION_DENIED, sabemos que el permiso fue otorgado y
-  // dejamos pasar — aunque `navigator.permissions.query` siga reportando
-  // 'prompt'. Es un bug conocido de Chrome Android y otros browsers móviles
-  // donde el estado de Permissions API no se actualiza inmediatamente ni
-  // dispara el evento `change` después de que el usuario aprueba el prompt.
-  // Sin este override, el preventista "activa la ubicación pero no lo deja
-  // pasar" — exactamente el síntoma reportado en campo.
-  const [grantedOverride, setGrantedOverride] = useState(false)
 
   useEffect(() => {
     setBrowser(detectBrowser())
   }, [])
 
-  const handleRequest = useCallback(() => {
-    if (typeof navigator === 'undefined' || !navigator.geolocation) return
-    setRequesting(true)
+  // Probe silencioso al montar: usa la posición cacheada del browser (no fuerza
+  // alta precisión, no dispara nuevo fix). Si el preventista ya tiene permiso
+  // granted en una sesión anterior, esto retorna posición inmediatamente y
+  // deja pasar sin requerir click. Si nunca pidió permiso, el browser puede
+  // disparar prompt — el preventista lo aprueba y también pasa.
+  // En cualquier escenario "el permiso está disponible" pasamos a allowed sin
+  // depender de Permissions API.
+  useEffect(() => {
+    if (!enabled) return
+    if (typeof navigator === 'undefined' || !navigator.geolocation) {
+      // Sin geolocation API: dejar pasar (el flujo legacy de captura maneja la
+      // ausencia con status='unavailable').
+      setGateState('allowed')
+      return
+    }
+    let cancelled = false
     navigator.geolocation.getCurrentPosition(
       () => {
-        setRequesting(false)
-        setGrantedOverride(true)
-        void refetch()
+        if (!cancelled) setGateState('allowed')
       },
       (err) => {
-        setRequesting(false)
-        // Solo PERMISSION_DENIED indica que el usuario bloqueó el permiso.
-        // Timeout / position_unavailable / otros errores son problemas del
-        // sensor o de cobertura: el permiso SÍ fue otorgado, así que dejamos
-        // pasar para que el flujo de captura al confirmar el pedido capture
-        // motivo de omisión sin trabar al preventista en el gate.
-        if (err.code !== err.PERMISSION_DENIED) {
-          setGrantedOverride(true)
+        if (cancelled) return
+        if (err.code === err.PERMISSION_DENIED) {
+          setGateState('blocked')
         }
-        void refetch()
+        // timeout/unavailable/error en probe silencioso: dejar en 'idle' para
+        // que el preventista vea el botón "Activar GPS" y dispare un intento
+        // explícito con alta precisión.
+      },
+      { enableHighAccuracy: false, timeout: 5_000, maximumAge: 5 * 60_000 },
+    )
+    return () => {
+      cancelled = true
+    }
+  }, [enabled])
+
+  const handleRequest = useCallback(() => {
+    if (typeof navigator === 'undefined' || !navigator.geolocation) {
+      setGateState('allowed')
+      return
+    }
+    setGateState('requesting')
+    navigator.geolocation.getCurrentPosition(
+      () => {
+        setGateState('allowed')
+      },
+      (err) => {
+        if (err.code === err.PERMISSION_DENIED) {
+          setGateState('blocked')
+        } else {
+          // El usuario otorgó el permiso pero el sensor falló (timeout en
+          // interior, position_unavailable, etc.). Dejar pasar: al confirmar
+          // el pedido se vuelve a intentar y, si falla de nuevo, el flujo de
+          // ModalMotivoSinGps captura el motivo. No queremos atascar al
+          // preventista en el gate por una falla transitoria del GPS.
+          setGateState('allowed')
+        }
       },
       { enableHighAccuracy: true, timeout: 10_000, maximumAge: 30_000 },
     )
-  }, [refetch])
+  }, [])
 
   if (!enabled) return <>{children}</>
-  if (grantedOverride || state === 'granted' || state === 'unsupported') return <>{children}</>
+  if (gateState === 'allowed') return <>{children}</>
 
-  if (state === 'prompt') {
+  if (gateState === 'blocked') {
     return (
       <div className="space-y-4 p-2">
-        <div className="flex flex-col items-center text-center gap-3 py-4">
-          <div className="w-14 h-14 rounded-full bg-blue-100 dark:bg-blue-900/30 flex items-center justify-center">
-            <MapPin className="w-7 h-7 text-blue-600 dark:text-blue-400" />
+        <div className="flex flex-col items-center text-center gap-3 py-2">
+          <div className="w-14 h-14 rounded-full bg-red-100 dark:bg-red-900/30 flex items-center justify-center">
+            <AlertTriangle className="w-7 h-7 text-red-600 dark:text-red-400" />
           </div>
           <h3 className="text-lg font-semibold text-gray-900 dark:text-white">
-            Activá la ubicación para continuar
+            Ubicación bloqueada
           </h3>
           <p className="text-sm text-gray-600 dark:text-gray-400 max-w-md">
-            Para registrar visitas y pedidos como preventista necesitamos tu ubicación
-            actual. Cuando aprietes el botón el navegador te va a preguntar — elegí
-            <strong> "Permitir"</strong>.
+            El navegador tiene bloqueado el acceso a tu ubicación. Para registrar
+            visitas y pedidos tenés que reactivarlo manualmente desde la
+            configuración del navegador.
           </p>
+        </div>
+        <div className="bg-gray-50 dark:bg-gray-700/30 border border-gray-200 dark:border-gray-700 rounded-lg p-3">
+          <p className="text-xs font-semibold text-gray-700 dark:text-gray-300 mb-2">
+            Cómo reactivarlo:
+          </p>
+          <ol className="text-xs text-gray-700 dark:text-gray-300 space-y-1.5">
+            {instructionsFor(browser).map((line, i) => (
+              <li key={i}>{line}</li>
+            ))}
+          </ol>
         </div>
         <button
           type="button"
           onClick={handleRequest}
-          disabled={requesting}
-          className="w-full py-3 bg-blue-600 hover:bg-blue-700 disabled:bg-blue-400 text-white font-semibold rounded-lg flex items-center justify-center gap-2"
+          className="w-full py-3 bg-blue-600 hover:bg-blue-700 text-white font-semibold rounded-lg"
         >
-          {requesting ? (
-            <>
-              <Loader2 className="w-4 h-4 animate-spin" /> Esperando respuesta…
-            </>
-          ) : (
-            <>
-              <MapPin className="w-4 h-4" /> Activar GPS
-            </>
-          )}
+          Ya lo activé, reintentar
         </button>
         {onCancel && (
           <button
@@ -175,38 +210,37 @@ export default function GeolocationGate({
     )
   }
 
-  // denied
+  // idle / requesting
   return (
     <div className="space-y-4 p-2">
-      <div className="flex flex-col items-center text-center gap-3 py-2">
-        <div className="w-14 h-14 rounded-full bg-red-100 dark:bg-red-900/30 flex items-center justify-center">
-          <AlertTriangle className="w-7 h-7 text-red-600 dark:text-red-400" />
+      <div className="flex flex-col items-center text-center gap-3 py-4">
+        <div className="w-14 h-14 rounded-full bg-blue-100 dark:bg-blue-900/30 flex items-center justify-center">
+          <MapPin className="w-7 h-7 text-blue-600 dark:text-blue-400" />
         </div>
         <h3 className="text-lg font-semibold text-gray-900 dark:text-white">
-          Ubicación bloqueada
+          Activá la ubicación para continuar
         </h3>
         <p className="text-sm text-gray-600 dark:text-gray-400 max-w-md">
-          El navegador tiene bloqueado el acceso a tu ubicación. Para registrar
-          visitas y pedidos tenés que reactivarlo manualmente desde la
-          configuración del navegador.
+          Para registrar visitas y pedidos como preventista necesitamos tu ubicación
+          actual. Cuando aprietes el botón el navegador te va a preguntar — elegí
+          <strong> "Permitir"</strong>.
         </p>
-      </div>
-      <div className="bg-gray-50 dark:bg-gray-700/30 border border-gray-200 dark:border-gray-700 rounded-lg p-3">
-        <p className="text-xs font-semibold text-gray-700 dark:text-gray-300 mb-2">
-          Cómo reactivarlo:
-        </p>
-        <ol className="text-xs text-gray-700 dark:text-gray-300 space-y-1.5">
-          {instructionsFor(browser).map((line, i) => (
-            <li key={i}>{line}</li>
-          ))}
-        </ol>
       </div>
       <button
         type="button"
-        onClick={() => void refetch()}
-        className="w-full py-3 bg-blue-600 hover:bg-blue-700 text-white font-semibold rounded-lg"
+        onClick={handleRequest}
+        disabled={gateState === 'requesting'}
+        className="w-full py-3 bg-blue-600 hover:bg-blue-700 disabled:bg-blue-400 text-white font-semibold rounded-lg flex items-center justify-center gap-2"
       >
-        Ya lo activé, reintentar
+        {gateState === 'requesting' ? (
+          <>
+            <Loader2 className="w-4 h-4 animate-spin" /> Esperando respuesta…
+          </>
+        ) : (
+          <>
+            <MapPin className="w-4 h-4" /> Activar GPS
+          </>
+        )}
       </button>
       {onCancel && (
         <button


### PR DESCRIPTION
## Contexto urgente
Segundo intento del fix de \"el preventista activa la ubicación pero la pantalla 'Activá la ubicación' no se va, no lo deja crear el pedido\". El primer fix (PR #341) agregaba un \`grantedOverride\` pero el gate seguía consultando \`navigator.permissions.query()\` al montar — y en Chrome Android esa API es notoriamente poco confiable: puede devolver \`'prompt'\` indefinidamente después de que el usuario aprueba el permiso, y a veces nunca dispara el evento \`change\`. El preventista refrescó la app después del deploy del #341 y sigue atascado.

## Causa raíz definitiva
Cualquier lógica que dependa de \`navigator.permissions.query({name:'geolocation'})\` para abrir el gate va a ser frágil en Chrome Android. Hay que arbitrar el gate exclusivamente con lo que reporta \`navigator.geolocation.getCurrentPosition\` — que sí es confiable.

## Cambios
Refactor completo de [\`GeolocationGate\`](src/components/GeolocationGate.tsx):

- **Sin Permissions API.** Se elimina el uso de \`useGeolocationPermission\` (queda huérfano, no se borra por compatibilidad).
- **Estado simple:** \`idle | requesting | allowed | blocked\`.
- **Probe silencioso al montar** (cuando \`enabled=true\`): \`getCurrentPosition\` con \`enableHighAccuracy: false, timeout: 5s, maximumAge: 5min\`. Si el preventista ya tiene permiso \`granted\` en una sesión anterior, deja pasar inmediatamente sin clicks ni prompt. Si no, queda en \`idle\` mostrando el botón.
- **Click en \"Activar GPS\":** \`getCurrentPosition\` con alta precisión, timeout 10s.
  - \`success\` → \`allowed\` → renderiza children.
  - \`PERMISSION_DENIED\` → \`blocked\` → pantalla con instrucciones por SO + botón \"Ya lo activé, reintentar\".
  - \`TIMEOUT\` / \`POSITION_UNAVAILABLE\` / \`error\` genérico → \`allowed\`. El permiso fue otorgado y solo falló el sensor; el flujo de captura GPS al confirmar el pedido se encarga de capturar motivo via \`ModalMotivoSinGps\` — no atascamos al preventista en el gate por una falla del sensor.

## Comportamiento esperado en Chrome Android
- **Primera vez (sin permiso):** preventista abre Nuevo Pedido → ve pantalla \"Activá la ubicación\" → toca \"Activar GPS\" → prompt nativo de Chrome → toca \"Permitir\" → renderiza form. Si fallara el sensor, también pasa al form y captura motivo al confirmar.
- **Sesiones siguientes (permiso ya granted):** abre Nuevo Pedido → probe silencioso al montar → renderiza form directo sin click adicional.
- **Permiso bloqueado:** abre Nuevo Pedido → probe falla con denied → pantalla bloqueante con instrucciones por SO.

## Acción recomendada para el preventista después del merge
Como la app es PWA con \`autoUpdate\`, el SW debería actualizarse solo. Pero por las dudas, si el preventista sigue viendo la pantalla atascada después del deploy:
1. Cerrar **todas** las pestañas/instancias de la PWA.
2. Reabrir la PWA.
3. Si persiste: en Chrome Android tocar el ícono de la app → \"Información del sitio\" → \"Borrar datos\" → reabrir.

## Test plan
- [ ] Login como preventista en Chrome Android con permiso ya granted → form aparece directo sin pasar por gate.
- [ ] Login como preventista con permiso 'prompt' → ve gate, toca \"Activar GPS\", aprueba prompt → form.
- [ ] Login como preventista en interior sin señal → toca \"Activar GPS\", timeout 10s → pasa al form igual, captura motivo al confirmar.
- [ ] Permiso explícitamente denegado → muestra pantalla \"Ubicación bloqueada\" con instrucciones por SO.
- [ ] Login como admin/encargado → no afectado (\`enabled=false\`, render directo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)