### PR TITLE
fix(promociones): sincroniza descripcion_regalo cuando cambia el producto

### DIFF
--- a/migrations/066_fix_descripcion_regalo_promo_manaos_manzana.sql
+++ b/migrations/066_fix_descripcion_regalo_promo_manaos_manzana.sql
@@ -1,0 +1,26 @@
+-- 066_fix_descripcion_regalo_promo_manaos_manzana.sql
+--
+-- Fix: la promoción "Promo Manaos 6 + 2 3L" (id=13) cambió de producto regalo
+-- de POMELO BLANCO a MANZANA el 2026-05-26, pero el texto `descripcion_regalo`
+-- quedó stale ("2 Botellas Manaos Pomelo Blanco 3L"). Ese texto se copia a
+-- pedido_items.descripcion_regalo en cada pedido nuevo (RPC crear_pedido_completo,
+-- ver migration 011) y es lo que imprimen la hoja de ruta y las comandas.
+--
+-- Esta migración:
+--   a) Actualiza el snapshot en la promoción para que los pedidos nuevos
+--      arranquen con el texto correcto.
+--   b) Backfilea los pedido_items donde producto_id ya apunta al nuevo regalo
+--      (Manzana, id=82) pero el texto quedó con "Pomelo Blanco". El match
+--      estricto evita pisar pedidos viejos de la era Pomelo Blanco.
+
+UPDATE promociones
+   SET descripcion_regalo = '2 Botellas Manaos Manzana 3000 cc'
+ WHERE id = 13
+   AND descripcion_regalo = '2 Botellas Manaos Pomelo Blanco 3L';
+
+UPDATE pedido_items
+   SET descripcion_regalo = '2 Botellas Manaos Manzana 3000 cc'
+ WHERE promocion_id = 13
+   AND es_bonificacion = true
+   AND producto_id = 82
+   AND descripcion_regalo = '2 Botellas Manaos Pomelo Blanco 3L';

--- a/package-lock.json
+++ b/package-lock.json
@@ -189,7 +189,6 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -1812,7 +1811,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -1856,7 +1854,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -4649,7 +4646,6 @@
       "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.90.20.tgz",
       "integrity": "sha512-vXBxa+qeyveVO7OA0jX1z+DeyCA4JKnThKv411jd5SORpBKgkcVnYKCiBgECvADvniBX7tobwBmg01qq9JmMJw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@tanstack/query-core": "5.90.20"
       },
@@ -4773,7 +4769,8 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -4896,7 +4893,6 @@
       "integrity": "sha512-MWtvHrGZLFttgeEj28VXHxpmwYbor/ATPYbBfSFZEIRK0ecCFLl2Qo55z52Hss+UV9CRN7trSeq1zbgx7YDWWg==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -4907,7 +4903,6 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -5000,7 +4995,6 @@
       "integrity": "sha512-nm3cvFN9SqZGXjmw5bZ6cGmvJSyJPn0wU9gHAZZHDnZl2wF9PhHv78Xf06E0MaNk4zLVHL8hb2/c32XvyJOLQg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.53.1",
         "@typescript-eslint/types": "8.53.1",
@@ -5368,7 +5362,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -5402,7 +5395,6 @@
       "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -5905,9 +5897,9 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
@@ -5949,7 +5941,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -6694,7 +6685,8 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/dompurify": {
       "version": "3.4.2",
@@ -7045,7 +7037,6 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -8729,7 +8720,6 @@
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -8759,7 +8749,6 @@
       "integrity": "sha512-mjzqwWRD9Y1J1KUi7W97Gja1bwOOM5Ug0EZ6UDK3xS7j7mndrkwozHtSblfomlzyB4NepioNt+B2sOSzczVgtQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@acemir/cssom": "^0.9.28",
         "@asamuzakjp/dom-selector": "^6.7.6",
@@ -9280,6 +9269,7 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -9945,7 +9935,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -10118,6 +10107,7 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -10133,6 +10123,7 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -10209,7 +10200,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.3.tgz",
       "integrity": "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -10219,7 +10209,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -10232,7 +10221,8 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/react-refresh": {
       "version": "0.18.0",
@@ -10658,7 +10648,6 @@
       "integrity": "sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -11785,9 +11774,9 @@
       "license": "MIT"
     },
     "node_modules/tmp": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
-      "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.6.tgz",
+      "integrity": "sha512-5sJPdPjfI5Kx+qbrDesxkglRBxW//g7hCsqspEjwkewGvBMGIKMOTKzLt1hFVJzyadba3lDUN20O9qhvbQUSTA==",
       "license": "MIT",
       "engines": {
         "node": ">=14.14"
@@ -11977,7 +11966,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -12252,7 +12240,6 @@
       "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -12359,7 +12346,6 @@
       "integrity": "sha512-FQMeF0DJdWY0iOnbv466n/0BudNdKj1l5jYgl5JVTwjSsZSlqyXFt/9+1sEyhR6CLowbZpV7O1sCHrzBhucKKg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.0.17",
         "@vitest/mocker": "4.0.17",
@@ -12848,7 +12834,6 @@
       "integrity": "sha512-cIFJOD1DESzpjOBl763Kp1AH7UE/0fcdHe6rZXUdQ9c50uvgigvW97u3IcSeBwOkgqL/PXPBktBCh0KEu5L8XQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "rollup": "dist/bin/rollup"
       },
@@ -13116,9 +13101,9 @@
       "license": "ISC"
     },
     "node_modules/ws": {
-      "version": "8.18.3",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
-      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
@@ -13228,7 +13213,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.5.tgz",
       "integrity": "sha512-k7Nwx6vuWx1IJ9Bjuf4Zt1PEllcwe7cls3VNzm4CQ1/hgtFUK2bRNG3rvnpPUhFjmqJKAKtjV576KnUkHocg/g==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/components/modals/ModalPromocion.tsx
+++ b/src/components/modals/ModalPromocion.tsx
@@ -106,6 +106,29 @@ export default function ModalPromocion({
     )
   }, [productos, busquedaAjusteProd])
 
+  // Salvaguarda: cuando se edita una promo en modo fracción y se cambia el
+  // producto contenedor, alertar si descripcion_regalo (que es lo que imprimen
+  // hoja de ruta y comandas) ya no menciona el producto seleccionado.
+  const productoAjusteSeleccionado = useMemo(
+    () => productos.find(p => String(p.id) === ajusteProductoId),
+    [productos, ajusteProductoId]
+  )
+  const descripcionMencionaProducto = useMemo(() => {
+    if (tipoRegalo !== 'fraccion') return true
+    if (!productoAjusteSeleccionado || !descripcionRegalo.trim()) return true
+    const stoplist = new Set([
+      'manaos', 'botella', 'botellas', 'fardo', 'fardos', 'unidad', 'unidades',
+      'pack', 'packs', 'cajon', 'cajones', 'litro', 'litros', 'lata', 'latas',
+    ])
+    const tokens = productoAjusteSeleccionado.nombre
+      .toLowerCase()
+      .split(/[^a-záéíóúñ]+/i)
+      .filter(t => t.length > 3 && !stoplist.has(t))
+    if (tokens.length === 0) return true
+    const desc = descripcionRegalo.toLowerCase()
+    return tokens.some(t => desc.includes(t))
+  }, [tipoRegalo, productoAjusteSeleccionado, descripcionRegalo])
+
   const handleToggleProducto = (id: string) => {
     setProductoIds(prev => {
       const next = new Set(prev)
@@ -391,6 +414,13 @@ export default function ModalPromocion({
                 placeholder='Ej: 1 botella Manaos Naranja 600cc'
                 className="w-full px-3 py-2 border rounded-lg dark:bg-gray-700 dark:border-gray-600 dark:text-white focus:ring-2 focus:ring-emerald-500 focus:outline-none"
               />
+              {!descripcionMencionaProducto && productoAjusteSeleccionado && (
+                <div className="mt-2 p-2.5 bg-amber-50 dark:bg-amber-900/20 border border-amber-300 dark:border-amber-700 rounded-lg text-xs text-amber-800 dark:text-amber-200">
+                  <p>
+                    ⚠ La descripción no menciona <strong>{productoAjusteSeleccionado.nombre}</strong>. Este texto es el que se imprime en hoja de ruta y comandas — si cambiaste el producto, actualizá la descripción para que coincida.
+                  </p>
+                </div>
+              )}
             </div>
           )}
 


### PR DESCRIPTION
## Contexto

Ayer (2026-05-26) se cambió el producto regalo de la promoción **"Promo Manaos 6 + 2 3L"** (id=13) de **MANAOS POMELO BLANCO 3000 cc x 6** a **MANAOS MANZANA 3000 cc x 6**. El cambio quedó hecho en `promociones.producto_regalo_id` y `promociones.ajuste_producto_id`, pero el campo de texto `promociones.descripcion_regalo` quedó con el valor viejo (`"2 Botellas Manaos Pomelo Blanco 3L"`).

Ese texto es un snapshot que el RPC `crear_pedido_completo` (ver `migrations/011`) copia a `pedido_items.descripcion_regalo` en cada pedido nuevo, y es lo que las exportaciones (`src/lib/pdf/hojaRutaOptimizada.js:175-177` y `src/lib/pdf/reciboPedido.js:473-481`) priorizan al imprimir. Resultado: hoja de ruta y comandas seguían mostrando "Pomelo Blanco" aunque la tarjeta del pedido (`PedidoCard.tsx`, que lee `item.producto?.nombre`) mostraba "Manzana".

## Summary

- **Migración `066`**: actualiza `promociones.descripcion_regalo` para la promo id=13 a `"2 Botellas Manaos Manzana 3000 cc"` y backfilea los 4 `pedido_items` posteriores al cambio (pedidos 2077, 2093, 2097, 2108) que tenían `producto_id=82` (Manzana) pero el texto stale "Pomelo Blanco". Los UPDATEs usan condiciones de igualdad estricta para que sean idempotentes y no toquen pedidos viejos de la era Pomelo Blanco. **Ya aplicada en producción** vía Supabase MCP `apply_migration`.
- **Salvaguarda en `ModalPromocion.tsx`**: en modo fracción, muestra un aviso ámbar bajo el input de descripción cuando la descripción no menciona el producto contenedor seleccionado, explicando que ese texto es el que se imprime en hoja de ruta y comandas. Evita que este desfase vuelva a pasar silenciosamente.

## Test plan

- [x] Migración aplicada: `SELECT descripcion_regalo FROM promociones WHERE id=13` devuelve "2 Botellas Manaos Manzana 3000 cc".
- [x] Backfill verificado: los 4 `pedido_items` (ids 7044, 7078, 7089, 7123) actualizados a "2 Botellas Manaos Manzana 3000 cc".
- [ ] Generar hoja de ruta de un pedido reciente con la promo: el regalo debe decir "2 Botellas Manaos Manzana 3000 cc".
- [ ] Generar comanda de ese mismo pedido: misma verificación.
- [ ] Crear un pedido nuevo que dispare la promo y verificar que el `pedido_item` de regalo arranca con el texto correcto.
- [ ] Abrir el modal en modo edición de una promo en fracción, cambiar el producto contenedor por uno que no aparezca en la descripción → debe aparecer el aviso ámbar. Editar la descripción para que mencione el producto nuevo → el aviso desaparece.

https://claude.ai/code/session_017dWQshZZ75nDfuprApMEZD

---
_Generated by [Claude Code](https://claude.ai/code/session_017dWQshZZ75nDfuprApMEZD)_