### PR TITLE
fix(geo): escape hatch GPS para preventistas trabados con permiso denied

### DIFF
--- a/src/components/GeolocationGate.tsx
+++ b/src/components/GeolocationGate.tsx
@@ -31,6 +31,13 @@ export interface GeolocationGateProps {
   enabled: boolean
   children: ReactNode
   onCancel?: () => void
+  /**
+   * Permite al preventista saltar el gate cuando el navegador devuelve
+   * PERMISSION_DENIED y no logra desbloquearlo. El pedido se crea igual
+   * (queda gps_status='denied' en la fila). Solo aparece en la pantalla
+   * 'blocked', no en idle.
+   */
+  allowBypass?: boolean
 }
 
 type Browser = 'chrome-android' | 'ios-safari' | 'chrome-desktop' | 'firefox' | 'other'
@@ -91,6 +98,7 @@ export default function GeolocationGate({
   enabled,
   children,
   onCancel,
+  allowBypass = true,
 }: GeolocationGateProps) {
   const [gateState, setGateState] = useState<GateState>('idle')
   const [browser, setBrowser] = useState<Browser>('other')
@@ -197,6 +205,15 @@ export default function GeolocationGate({
         >
           Ya lo activé, reintentar
         </button>
+        {allowBypass && (
+          <button
+            type="button"
+            onClick={() => setGateState('allowed')}
+            className="w-full py-2 text-sm font-medium text-amber-700 hover:text-amber-800 dark:text-amber-400 dark:hover:text-amber-300 underline underline-offset-2"
+          >
+            Continuar sin GPS
+          </button>
+        )}
         {onCancel && (
           <button
             type="button"

--- a/src/components/containers/PedidosContainer.tsx
+++ b/src/components/containers/PedidosContainer.tsx
@@ -914,21 +914,20 @@ export default function PedidosContainer(): React.ReactElement {
     }
 
     // Preventista: capturar GPS sincrónicamente antes de crear el pedido.
+    // - 'ok' o 'denied' → crear pedido directo (denied queda registrado en
+    //   gps_status para auditoría; el preventista llegó acá habiendo pasado
+    //   el gate, no lo bloqueamos al confirmar).
+    // - timeout/unavailable/error → ModalMotivoSinGps para justificar.
     const gps = await capturarGps()
-    if (gps.status === 'denied') {
-      notify.error('Permiso de GPS bloqueado. Activalo desde el navegador y reintentá.')
-      setGuardando(false)
+    if (gps.status === 'ok' || gps.status === 'denied') {
+      await ejecutarCreacionPedido(gps)
       return
     }
-    if (gps.status !== 'ok') {
-      // Guardamos el GpsResult y dejamos que el ModalMotivoSinGps maneje el
-      // resto. El botón Confirmar del ModalPedido queda deshabilitado porque
-      // guardando sigue en true hasta que se confirme o cancele el motivo.
-      gpsPendingRef.current = gps
-      setMotivoGpsPending({ status: gps.status })
-      return
-    }
-    await ejecutarCreacionPedido(gps)
+    // Guardamos el GpsResult y dejamos que el ModalMotivoSinGps maneje el
+    // resto. El botón Confirmar del ModalPedido queda deshabilitado porque
+    // guardando sigue en true hasta que se confirme o cancele el motivo.
+    gpsPendingRef.current = gps
+    setMotivoGpsPending({ status: gps.status })
   }, [nuevoPedido, isPreventista, capturarGps, ejecutarCreacionPedido, notify])
 
   const handleConfirmarMotivoGps = useCallback(async (motivo: string) => {

--- a/src/components/modals/ModalMarcarVisita.tsx
+++ b/src/components/modals/ModalMarcarVisita.tsx
@@ -5,12 +5,13 @@
  * que cargar pedido. Captura GPS y dispara `registrar_visita_cliente` al
  * confirmar.
  *
- * Reglas de geolocalización (post-052):
+ * Reglas de geolocalización (post-052, con escape hatch):
  * - Para preventistas, el modal está envuelto en `<GeolocationGate>` —
- *   si el permiso está `denied`, ven una pantalla bloqueante con
- *   instrucciones y nunca llegan al listado.
- * - Si la captura devuelve `denied` (raza con un cambio de permiso entre
- *   gate y click), bloqueamos y avisamos.
+ *   si el permiso está `denied`, ven la pantalla bloqueante; el gate ofrece
+ *   "Continuar sin GPS" como escape hatch cuando no logran desbloquear.
+ * - Si la captura devuelve `denied` (preventista pasó el gate con bypass o
+ *   permiso revocado entre gate y click), registramos igual con
+ *   gps_status='denied' — no bloqueamos al preventista en el confirmar.
  * - Si devuelve `timeout`/`unavailable`/`error`, abrimos `ModalMotivoSinGps`
  *   pidiendo justificación escrita; sin motivo no se registra.
  * - Admin sigue pudiendo marcar visitas con o sin GPS (flujo histórico).
@@ -134,18 +135,18 @@ export default function ModalMarcarVisita({
         return
       }
 
-      // Preventista — reglas estrictas:
-      if (gps.status === 'denied') {
-        notify.error('Permiso de GPS bloqueado. Activalo desde el navegador y reintentá.')
+      // Preventista:
+      // - 'ok' o 'denied' → registrar visita directo (denied queda en
+      //   gps_status para auditoría; si llegó acá habiendo pasado el gate,
+      //   no lo bloqueamos al confirmar).
+      // - timeout/unavailable/error → ModalMotivoSinGps para justificar.
+      if (gps.status === 'ok' || gps.status === 'denied') {
+        const ok = await persistir(cliente, gps)
+        if (ok) onClose()
         return
       }
-      if (gps.status !== 'ok') {
-        // Pasamos a ModalMotivoSinGps (permanece pendienteId hasta que confirme/cancele).
-        setMotivoPending({ cliente, status: gps.status })
-        return
-      }
-      const ok = await persistir(cliente, gps)
-      if (ok) onClose()
+      // Pasamos a ModalMotivoSinGps (permanece pendienteId hasta que confirme/cancele).
+      setMotivoPending({ cliente, status: gps.status })
     } finally {
       // Si quedó esperando motivo, no liberamos aún para que el listado no quede clickeable.
       if (!motivoPending) setPendienteId(null)


### PR DESCRIPTION
Cuando el navegador devuelve PERMISSION_DENIED de forma persistente (caso
tipico en Chrome Android donde el permiso a nivel SO esta denegado pero
el usuario solo activo el permiso por sitio), el preventista quedaba sin
forma de registrar pedidos ni visitas:

- GeolocationGate mostraba "Ubicacion bloqueada" indefinidamente.
- handleGuardarPedido bloqueaba el confirmar con "Permiso de GPS bloqueado".
- ModalMarcarVisita hacia lo mismo en handleMarcar.

Cambios:

- GeolocationGate: nuevo boton "Continuar sin GPS" en la pantalla blocked
  (allowBypass, default true). Permite saltar el gate cuando el permiso
  realmente no se puede activar.
- PedidosContainer.handleGuardarPedido: tratar 'denied' igual que 'ok'
  (crear pedido directo). El pedido queda con gps_status='denied' para
  auditoria. ModalMotivoSinGps sigue saliendo solo para timeout/unavailable/error.
- ModalMarcarVisita.handleMarcar: misma simetria, registrar visita directo
  cuando el status es 'denied'.

El RPC registrar_geolocalizacion_pedido y registrar_visita_cliente ya
aceptan status='denied' sin motivo (migracion 052), asi que no hace falta
tocar backend.