### PR TITLE
fix(promociones): corrige regalo de pedidos viejos (Pomelo Blanco / Lima Limón)

### DIFF
--- a/migrations/067_revertir_pomelo_blanco_4_pedidos.sql
+++ b/migrations/067_revertir_pomelo_blanco_4_pedidos.sql
@@ -1,0 +1,65 @@
+-- 067_revertir_pomelo_blanco_4_pedidos.sql
+--
+-- Contexto: la promo 13 ("Promo Manaos 6 + 2 3L") cambio su producto regalo de
+-- Pomelo Blanco (81) a Manzana (82) a mitad del 26/05/2026. Los usuarios ya
+-- habian comprometido entregar Pomelo Blanco para los pedidos viejos y recien
+-- entregan Manzana desde el 27/05. La migracion 066 retropropago "Manzana" a
+-- esos pedidos, que quedo al reves.
+--
+-- Regla: pedidos creados <= 26/05 -> Pomelo Blanco (81); creados >= 27/05 ->
+-- Manzana (82). Solo 4 pedidos creados el 26/05 quedaron mal: 2077, 2093, 2097,
+-- 2108. Los 7 del 27/05 y la promo (apunta a Manzana) quedan como estan.
+--
+-- Stock (modo fraccion: 6 botellas regaladas = 1 fardo): mover las 18 botellas
+-- de esos 4 pedidos de Manzana a Pomelo = exactamente 3 fardos. Ajuste neto:
+-- Pomelo (81) -3, Manzana (82) +3. El contador promociones.usos_pendientes no
+-- cambia (movimiento de bloques completos). No se tocan inconsistencias
+-- historicas previas del ledger ni promo_acumuladores.
+
+-- Paso 1: corregir producto + texto del regalo en los 4 pedidos (lo que ven
+-- tarjetas, hoja de ruta y comandas). Sin triggers de stock sobre pedido_items.
+UPDATE pedido_items
+   SET producto_id = 81,
+       descripcion_regalo = '2 Botellas Manaos Pomelo Blanco 3L'
+ WHERE promocion_id = 13
+   AND es_bonificacion = true
+   AND producto_id = 82
+   AND pedido_id IN (2077, 2093, 2097, 2108);
+
+-- Paso 2: ajuste neto de stock (3 fardos) + auditoria en mermas_stock /
+-- promo_ajustes. Idempotente via marcador en observaciones.
+DO $$
+DECLARE
+  v_suc     bigint := 1;
+  v_marker  text   := 'Correccion Promo 13 (mig 067): 4 pedidos 26/05 reasignados Manzana->Pomelo Blanco';
+  v_old     int;
+  v_new     int;
+  v_merma   bigint;
+BEGIN
+  IF EXISTS (SELECT 1 FROM mermas_stock WHERE observaciones = v_marker) THEN
+    RAISE NOTICE 'Ajuste de stock 067 ya aplicado; se omite.';
+    RETURN;
+  END IF;
+
+  PERFORM set_config('app.stock_origen', 'correccion_mig_067', true);
+
+  -- Pomelo Blanco (81): descontar 3 fardos
+  SELECT stock INTO v_old FROM productos WHERE id = 81 AND sucursal_id = v_suc FOR UPDATE;
+  v_new := v_old - 3;
+  UPDATE productos SET stock = v_new WHERE id = 81 AND sucursal_id = v_suc;
+  INSERT INTO mermas_stock (producto_id, cantidad, motivo, observaciones, stock_anterior, stock_nuevo, sucursal_id)
+  VALUES (81, 3, 'promociones', v_marker, v_old, v_new, v_suc)
+  RETURNING id INTO v_merma;
+  INSERT INTO promo_ajustes (promocion_id, usos_ajustados, unidades_ajustadas, producto_id, merma_id, sucursal_id, observaciones)
+  VALUES (13, 18, 3, 81, v_merma, v_suc, v_marker);
+
+  -- Manzana (82): devolver 3 fardos
+  SELECT stock INTO v_old FROM productos WHERE id = 82 AND sucursal_id = v_suc FOR UPDATE;
+  v_new := v_old + 3;
+  UPDATE productos SET stock = v_new WHERE id = 82 AND sucursal_id = v_suc;
+  INSERT INTO mermas_stock (producto_id, cantidad, motivo, observaciones, stock_anterior, stock_nuevo, sucursal_id)
+  VALUES (82, -3, 'promociones_reversion', v_marker, v_old, v_new, v_suc)
+  RETURNING id INTO v_merma;
+  INSERT INTO promo_ajustes (promocion_id, usos_ajustados, unidades_ajustadas, producto_id, merma_id, sucursal_id, observaciones)
+  VALUES (13, -18, -3, 82, v_merma, v_suc, v_marker);
+END $$;

--- a/migrations/068_fix_lima_limon_2112_2124.sql
+++ b/migrations/068_fix_lima_limon_2112_2124.sql
@@ -1,0 +1,29 @@
+-- 068_fix_lima_limon_2112_2124.sql
+--
+-- Contexto: la promo 12 ("1 Fardo Placer 500cc + 1 Manaos 600cc") cambio su
+-- regalo a Lima Limon (producto 85) para entregas del 28/05 en adelante. Todos
+-- los pedidos de promo 12 con entrega >= 28/05 quedaron en Lima Limon, salvo
+-- DOS que se crearon el 27/05 y nunca se re-editaron, por lo que conservaron el
+-- snapshot viejo "Pomelo Blanco 600cc" (producto 87):
+--   - #2112 (item 7134, cantidad 2)
+--   - #2124 (item 7167, cantidad 1)
+-- La usuaria confirma que fisicamente se entrego Lima Limon en ambos.
+--
+-- Esto NO fue causado por las migraciones 066/067 (esas filtran promocion_id=13;
+-- esto es promocion_id=12). Es el mismo problema de snapshot al cambiar el
+-- regalo de una promo, que no se propaga a pedidos ya creados/no editados.
+--
+-- Stock: el modelo descuenta 1 fardo cada 12 botellas regaladas. Mover 3
+-- botellas de Pomelo Blanco (87) a Lima Limon (85) no cruza ningun limite de
+-- bloque:
+--   Lima Limon 27 -> 30 botellas (floor/12 = 2 fardos, sin cambio)
+--   Pomelo Blanco 449 -> 446 botellas (floor/12 = 37 fardos, sin cambio)
+-- => No hay ajuste de fardos. Correccion solo de display + nomenclatura.
+
+UPDATE pedido_items
+   SET producto_id = 85,
+       descripcion_regalo = '1 Botella Manaos Lima Limon 600cc'
+ WHERE promocion_id = 12
+   AND es_bonificacion = true
+   AND producto_id = 87
+   AND pedido_id IN (2112, 2124);


### PR DESCRIPTION
## Contexto

Continuación del PR #344 (ya mergeado). Al cambiar el producto regalo de una promo, los pedidos ya creados que no se re-editan conservan el sabor viejo como snapshot en `pedido_items` (`producto_id` + `descripcion_regalo`), que es lo que se imprime en hoja de ruta y comandas. Dos correcciones de datos puntuales, sobre pedidos donde lo entregado no coincidía con lo mostrado.

Ambas migraciones **ya fueron aplicadas en producción** vía Supabase MCP.

## Migración 067 — Promo 13 (Manaos 6+2 3L): revertir 4 pedidos a Pomelo Blanco

La promo 13 cambió su regalo de Pomelo Blanco (81) a Manzana (82) a mitad del 26/05. Los choferes ya habían comprometido entregar **Pomelo Blanco** para los pedidos viejos; Manzana aplica desde el 27/05. La corrección previa (mig 066, en PR #344) había retropropagado Manzana, que quedó al revés.

- Revierte `producto_id` + `descripcion_regalo` a Pomelo Blanco en los 4 pedidos creados el 26/05 (#2077, #2093, #2097, #2108). Los 7 del 27/05 y la promo (apunta a Manzana) quedan intactos.
- Ajuste neto de stock por las 18 botellas reasignadas = 3 fardos: Pomelo (81) −3, Manzana (82) +3, con auditoría en `mermas_stock`/`promo_ajustes`. Idempotente.

## Migración 068 — Promo 12 (Placer + Manaos 600cc): corregir 2 pedidos a Lima Limón

La promo 12 pasó su regalo a Lima Limón (85) para entregas del 28/05 en adelante. De todos los pedidos con entrega ≥ 28/05, los únicos dos que quedaron con Pomelo Blanco (87) fueron #2112 y #2124 (creados el 27/05, nunca re-editados). Se entregó Lima Limón en ambos.

- Corrige `producto_id` (87→85) y `descripcion_regalo` a Lima Limón en los 2 items de regalo de promo 12.
- Sin ajuste de stock: mover 3 botellas no cruza ningún límite de bloque (Lima Limón 27→30 = 2 fardos; Pomelo Blanco 449→446 = 37 fardos).

## Test plan

- [x] Migraciones 067 y 068 aplicadas en Supabase (`list_migrations` las muestra).
- [x] Promo 13: los 4 pedidos (#2077, #2093, #2097, #2108) → `producto_id=81` + "2 Botellas Manaos Pomelo Blanco 3L". Stock 81=72, 82=75.
- [x] Promo 12: #2112 y #2124 → `producto_id=85` + "1 Botella Manaos Lima Limon 600cc".
- [ ] Generar hoja de ruta / comanda de un pedido pendiente de cada promo y confirmar el sabor correcto.

https://claude.ai/code/session_017dWQshZZ75nDfuprApMEZD

---
_Generated by [Claude Code](https://claude.ai/code/session_017dWQshZZ75nDfuprApMEZD)_