### PR TITLE
Auditoría 2026-05: hardening seguridad/permisos + integridad (P0/P1)

### DIFF
--- a/docs/AUDIT_REPORT_2026-05.md
+++ b/docs/AUDIT_REPORT_2026-05.md
@@ -1,0 +1,217 @@
+# Auditoría integral 2026-05 — Distribuidora App
+
+**Fecha:** 2026-05-28 · **Alcance:** código (React 19 + TS + PWA) + DB en vivo (Supabase `hmuchlzmuqqxcldbzkgc`) + Edge Functions/bot · **Roles cubiertos:** admin, preventista, preventista_taco, transportista, encargado, deposito.
+**Método:** advisors de Supabase + introspección read-only de la DB de producción + suite de reconciliación de datos + auditoría de código por dominio. Las migraciones del repo NO reflejan el estado real (archivadas/renumeradas); la fuente de verdad fue la DB en vivo.
+
+---
+
+## 1. Resumen ejecutivo
+
+La app está **más sana de lo que sugería la documentación previa**: los fixes críticos de febrero/abril (eliminación de `run_sql`, RLS en todas las tablas, fix de doble conteo de saldos, índices) **están aplicados en producción**. Saldos, totales de pedidos y stock están **íntegros** (0 divergencias en la reconciliación).
+
+El riesgo real hoy se concentra en **permisos a nivel base de datos**, no en los datos:
+
+- **P0 confirmado:** cualquier usuario autenticado puede **auto-ascenderse a `admin`** vía un `UPDATE` directo a `perfiles` (la RLS lo permite). Explotable con una request REST, sin pasar por la UI.
+- **P0 confirmado:** **todas** las funciones `SECURITY DEFINER` (que bypassan RLS) son ejecutables por `anon` (sin login) y `authenticated`. Las RPCs del bot (`bot_ventas_periodo`, `bot_metricas_admin_dia`, `bot_historico_pagos_cliente`…) permiten leer ventas/pagos/PII de **cualquier sucursal** pasando un `sucursal_id` arbitrario.
+- **P1:** el ledger de pagos no reconcilia contra pedidos (52 clientes / $2,6M) por pagos sobre pedidos cancelados no revertidos + dos mecanismos paralelos de `monto_pagado`. Los saldos igual cierran, pero la trazabilidad pago→pedido es poco confiable (relevante para AFIP/auditoría).
+- **P1:** la sincronización offline puede **duplicar pedidos** (sin idempotencia), con doble descuento de stock.
+
+Buenas noticias adicionales: el **bot de Telegram está muy bien construido** (webhook fail-closed, secret en tiempo constante, autorización por rol/sucursal consistente, escritura con confirmación humana e idempotente, sin inyección de prompt explotable). El único agujero del bot es que sus RPCs son llamables también desde la web (P0-2, ya cubierto por la migración 069).
+
+**Migración [`069_audit_2026_05_hardening.sql`](../migrations/069_audit_2026_05_hardening.sql) preparada** con los fixes P0/P1 seguros y reversibles. **Pendiente de tu OK para aplicar** (ver §6).
+
+---
+
+## 2. Lo que está SANO (verificado en vivo) — no re-trabajar
+
+| Verificación | Resultado |
+|---|---|
+| `run_sql`/`exec_sql`/`execute_sql` (inyección SQL) | **No existen** ✅ |
+| Tablas `public` sin RLS | **0** (cobertura RLS completa) ✅ |
+| `clientes.saldo_cuenta` vs `Σ(total − monto_pagado)` | **0 divergencias / $0 drift** (664 clientes) ✅ |
+| `pedidos.total` vs `Σ(pedido_items.subtotal)` | **0 divergencias** ✅ |
+| `pedidos.total` vs `total_neto + total_iva` | **0 divergencias** ✅ |
+| `productos.stock` vs último `stock_historico` | **0 divergencias** · 0 stock negativo ✅ |
+| `current_sucursal_id()` valida pertenencia del header `X-Sucursal-ID` | **Sí** — header forjado → NULL → 0 filas ✅ |
+| RLS de escritura en productos/clientes/pedidos | Gateadas por `es_admin()`/`es_preventista()` + `sucursal_id` ✅ |
+| Bot Telegram (webhook, secrets, authz, prompt-injection) | Sólido ✅ |
+
+---
+
+## 3. Hallazgos priorizados
+
+> Severidad: **P0** crítico (arreglar ya) · **P1** alto · **P2** medio · **P3** bajo / nice-to-have / state-of-the-art.
+> Estado: **069** = corregido en la migración preparada · **pendiente** = requiere código/decisión.
+
+### P0 — Crítico
+
+**P0-1 · Escalada de privilegios en `perfiles`** · `migrations/000_baseline.sql` (policy `perfiles_update_self`)
+La policy `UPDATE` de `perfiles` para `public` usa `with_check (id = auth.uid())` **sin restringir columnas**. Cualquier usuario autenticado puede `PATCH /rest/v1/perfiles?id=eq.<su_id>` con `{"rol":"admin"}` y volverse admin. La UI solo expone esto a admins (`/usuarios` con `isAdmin`), pero el ataque es por API directa.
+**Impacto:** toma de control total (cualquier rol → admin).
+**Fix (069):** trigger `BEFORE UPDATE` que rechaza cambios de `rol`/`activo` salvo `es_admin()`.
+
+**P0-2 · RPCs `SECURITY DEFINER` ejecutables por anon/authenticated** · 105 funciones; grants `PUBLIC` por defecto
+Todas las funciones `SECURITY DEFINER` (bypassan RLS) tienen `EXECUTE` para `anon` y `authenticated` (proacl nulo = PUBLIC; los `DROP/CREATE` de migraciones resetearon los grants). Las más graves no tienen gate interno:
+- **Bot/lectura sensible** (toman `sucursal_id`/`perfil_id` por parámetro, sin auth): `bot_ventas_periodo`, `bot_metricas_admin_dia`, `bot_ventas_por_preventista`, `bot_historico_pagos_cliente`, `bot_historico_pedidos_cliente`, `bot_mis_ventas`, `bot_buscar_cliente`, `obtener_resumen_cuenta_cliente_bot`, etc. → **un `preventista_taco` (o un anónimo) lee ventas/pagos/PII de cualquier sucursal**.
+- **Escritura** sin auth: `crear_pedido_completo_bot`, `actualizar_orden_entrega_batch`, `limpiar_orden_entrega`, `aplicar_uso_promo_acumulador`, `revertir_bloques_auto_ajuste`.
+**Impacto:** fuga de datos cross-sucursal + escalada + escritura no autorizada, incluso sin login.
+**Fix (069):** RPCs del bot → solo `service_role`; funciones trigger → sin EXECUTE directo; RPCs mutadoras sin gate → se cierra `anon` (queda `authenticated`; falta gate de rol/sucursal → P1-3).
+
+### P1 — Alto
+
+**P1-1 · Trazabilidad pago→pedido + 2 pagos sobre pedidos cancelados** · `registrar_pago_cliente_fifo` + trigger `recalcular_monto_pagado_pedido`
+**Los saldos de clientes son correctos**: `saldo_cuenta` vs `Σ(total − monto_pagado)` reconcilia con **0 divergencias**. La diferencia por cliente entre `Σ(pagos.monto)` y `Σ(pedidos.monto_pagado)` (52 clientes) es un **artefacto de atribución del FIFO** (reparte `monto_pagado` entre varios pedidos sin una fila de pago por pedido) — **NO es plata perdida**. Corrige el encuadre alarmista del "$2,6M".
+Lo que sí requiere acción concreta (~7 casos):
+- **2 pagos sobre pedidos cancelados ($68.200)**: pago **1599** (cliente 688, $61.200, 2026-05-20) y pago **275** (cliente 10, $7.000, 2026-04-13). Al cancelar, `monto_pagado→0` y el pago quedó sin destino (no acreditado al saldo del cliente).
+- **5 pedidos sobrepagados** (`monto_pagado > total`): ej. pedido 1142 (total $20.800 / pagado $46.360).
+**Estado: requiere tu decisión** para esos casos (reembolsar / acreditar a cuenta / reasignar a otros pedidos). Mejora opcional de trazabilidad: guardar `pago_id`↔`pedido_id` por aplicación FIFO.
+
+**Resuelto (2026-05-28):** se descartaron los 2 pagos sobre pedidos cancelados (pago **1599** y **275**) y se cerró correctamente el pedido **733** (`total=0`, `monto_pagado=0`). Reconciliación global de saldos post-fix: **0 divergencias / $0 drift** (cliente 10 = $8.900, cliente 688 = $0, sin alterar saldos correctos).
+
+**Decisión sobre los 5 sobrepagados (2026-05-28):** regla del negocio → **no modificar saldos con fecha ≥ 07/04/2026**. Los 5 sobrepagados (pedidos 1142, 1148, 1656, 1821, 2083) son **todos del 22/04/2026 o posterior** ⇒ **protegidos, no se tocan**. Se dejan como **crédito legítimo del cliente** (sobrepago reflejado en saldo negativo); los libros ya reconcilian (0 drift). No hay anomalías de saldo pre-07/04. **P1-1 cerrado.**
+
+**Hallazgo nuevo (ligado a P1-6) — trigger de saldo por deltas:** `actualizar_saldo_pedido` mantiene `clientes.saldo_cuenta` por **deltas y NO excluye cancelados**. Si un pedido se cancela sin zerolear (como estaba el 733) o se zerolea más tarde, el saldo puede driftear (lo vi en vivo: zerolear el 733 sumó +$500 de más, corregido al instante). **Recomendado:** que la cancelación SIEMPRE zerolee `total`/`monto_pagado`, y/o que el trigger ignore estados `cancelado`/`anulado`. ⚠️ **Foot-gun para futuros fixes de datos: cualquier UPDATE a `pedidos` recalcula saldo por delta sin excluir cancelados.**
+
+**Resuelto (2026-05-28, migración 072):** `actualizar_saldo_pedido` ahora trata `cancelado`/`anulado` como contribución 0. Fix **forward-only**: `CREATE OR REPLACE` no re-disparó sobre filas existentes → checksums de saldos/stock/ítems **idénticos** al baseline, reconciliación 0 drift. El foot-gun queda cerrado para futuras cancelaciones sin tocar nada histórico.
+
+**P1-2 · Duplicación de pedidos en sync offline** · `src/hooks/useOfflineSync.ts:574`, `src/hooks/supabase/usePedidos.ts:321`, RPC `crear_pedido_completo`
+No hay idempotencia end-to-end: si el `INSERT` se ejecuta pero la respuesta se pierde (corte de red post-commit), la op vuelve a `pending` y se **reinserta** → pedido duplicado + doble descuento de stock. La RPC del bot (`crear_pedido_completo_bot`) sí es idempotente; la web no replicó el patrón.
+**Fix (pendiente):** `offline_id` UUID por pedido + columna `UNIQUE` + `INSERT ... ON CONFLICT (offline_id) DO NOTHING RETURNING id`. Igual para `CREATE_MERMA`.
+
+**P1-3 · RPCs mutadoras sin gate de rol/sucursal (authenticated)** · `actualizar_orden_entrega_batch`, `limpiar_orden_entrega`, `aplicar_uso_promo_acumulador`, `revertir_bloques_auto_ajuste`
+Hacen `UPDATE` ciego (ej. `UPDATE pedidos SET orden_entrega WHERE id=...`) sin verificar rol ni sucursal. 069 cierra `anon`, pero un `authenticated` cualquiera todavía puede invocarlas para pedidos/promos de **otra sucursal**.
+**Fix (pendiente):** agregar al cuerpo `IF NOT es_encargado_o_admin() THEN RAISE...` + filtrar/validar `sucursal_id = current_sucursal_id()`.
+
+**P1-4 · `obtener_resumen_compras` sin filtro de sucursal** · función homónima
+Agrega compras de **todas las sucursales** (`FROM compras WHERE estado!='cancelada'`, sin `sucursal_id`). Fuga + dato incorrecto si la UI espera la sucursal activa.
+**Fix (pendiente):** filtrar por `current_sucursal_id()` (o parámetro validado).
+
+**P1-5 · `preventista_taco` ve montos que no debería** · `src/components/pedidos/PedidoStats.tsx:53`, `PedidoCard.tsx:443-577`, `src/components/vistas/VistaPedidos.tsx:200`
+`PedidoStats` mapea taco a la rama `'admin'` (nunca recibe `isPreventistaTaco`) y `PedidoCard` muestra `total`/`monto_pagado`/precios **sin chequear rol**. Además `fetchClientes` (`useClientesQuery.ts:34`) trae `saldo_cuenta` y `obtenerResumenCuenta`/`fetchPagosCliente` se llaman **también para taco** → los datos viajan al browser aunque la UI los oculte.
+**Fix (pendiente):** pasar `isPreventistaTaco` y gatear render; y a nivel DB, no devolver columnas sensibles a taco (vista/column-level o RPC que filtre por rol).
+
+**P1-6 · `pedidos` editable por el preventista fuera de la ventana 15:30** · policy `mt_pedidos_update`
+La RLS permite a `usuario_id = auth.uid()` actualizar su pedido sin límite temporal; la regla "mismo día < 15:30" vive solo en UI/RPC (`permisosPedido.ts`). Por API directa un preventista puede editar `total`/`estado` de su pedido en cualquier momento. Relacionado: las RLS usan el **rol global** (`es_admin()` lee `perfiles.rol`), así que el **rol por-sucursal** (`usuario_sucursales.rol`) no se aplica en escrituras.
+**Fix (pendiente):** mover la regla temporal a la policy/trigger; decidir si el rol efectivo debe ser por-sucursal.
+
+**P1-7 · Protección de contraseñas filtradas deshabilitada** · Auth settings
+`auth_leaked_password_protection` off. **Fix:** activar en Dashboard → Authentication → Policies (1 click; no es SQL).
+
+### P2 — Medio
+
+| ID | Hallazgo | Ubicación | Nota |
+|---|---|---|---|
+| P2-1 | **`auth_rls_initplan`** x38: las policies re-evalúan `auth.uid()`/`current_sucursal_id()` por fila | 23+ tablas | Envolver en `(SELECT auth.uid())`. Gran mejora de performance a escala, bajo riesgo |
+| P2-2 | **Múltiples policies permisivas** por acción (se evalúan todas) | `perfiles` (4 SELECT, 3 UPDATE), `usuario_sucursales` (2 SELECT), +otras | Consolidar |
+| P2-3 | **IVA/neto sin redondear** → acumulación de centavos en `total_neto`/`total_iva` (fiscal) | `src/utils/calculations.ts:53,74,105` | `redondear(_,2)` por ítem. Hoy bajo impacto (totales reconcilian), pero riesgo en FC/AFIP |
+| P2-4 | Offline: **logout no limpia cola/cache** → cross-usuario en el mismo dispositivo | `src/App.tsx:190`, `offlineDb.ts:216` | Llamar `clearAllData()`/`invalidateAllCache()` o filtrar por `userId` |
+| P2-5 | Conflicto de stock offline: la venta se descarta como `failed` sin flujo de resolución | `useOfflineSync.ts:466-499` | Estado propio de conflicto + UI de resolución |
+| P2-6 | `telegram-digest` compara el bearer con `!==` (no tiempo constante) | `supabase/functions/telegram-digest/index.ts:48` | Usar `timingSafeEqual` (consistencia) |
+| P2-7 | `historico_pagos_cliente` no pre-valida sucursal del cliente antes del RPC | `_shared/tools/admin/historico_pagos_cliente.ts:56` | Confirmar que `bot_historico_pagos_cliente` filtra por `p_sucursal_id` |
+| P2-8 | Descuento de cliente: el total mostrado ≠ guardado, y `ModalEditarPedido` lo pierde al editar | `usePromocionPedido`, `usePedidoHandlers.ts:434`, `ModalEditarPedido.tsx:420` | **Latente: 0/664 clientes usan `descuento_porcentaje`.** Arreglar antes de habilitar la feature |
+| P2-9 | Calidad de datos | DB | 91 pedidos sin desglose fiscal; 5 sobrepagados; 5 clientes con saldo negativo; 2 productos sin histórico de stock |
+
+### P3 — Bajo / nice-to-have / state-of-the-art
+
+| ID | Tema | Detalle |
+|---|---|---|
+| P3-1 | **Cobertura de tests de plata = 0** | Sin tests de `calcularNetoVenta`/IVA, `useCalculosImpuestos`, ni del flujo guardar-pedido (descuento+promo+mayorista). Umbrales `vite.config.js`: 50/40/45/50. Subir a ~95% en `calculations.ts`/`precioMayorista.ts` |
+| P3-2 | **Componentes gigantes** | `ModalCompra.tsx` (1799), `PedidosContainer.tsx` (1485), `ModalEditarPedido.tsx` (1008), `ModalPedido.tsx` (933), `AppModals.tsx` (643). Extraer hooks/subcomponentes |
+| P3-3 | **Deuda de tipos** | `as any` 42 (26 en `AppModals.tsx`), `as unknown as` 47, `any` 21, `eslint-disable` 45 (10 `exhaustive-deps` = riesgo de stale closures en hooks de plata) |
+| P3-4 | **3 fuentes de verdad de rol** | `perfil.rol` (global, menú), `effectiveRol` (por-sucursal, rutas), `permisos.ts`. Menú (rol global) vs rutas (rol sucursal) pueden divergir. Unificar |
+| P3-5 | **Índices sin uso** x58 + duplicados x6 | Duplicados → 069. Revisar/eliminar los no usados (costo de escritura) |
+| P3-6 | **Crecimiento sin tope** | `bot_audit_log`, `bot_conversaciones`, `audit_logs` → retención con `pg_cron` + `CHECK jsonb_array_length` |
+| P3-7 | **Helpers de rol duplicados** | `is_admin`/`is_preventista`/`is_transportista` (SQL) coexisten con `es_admin`/… Limpiar |
+| P3-8 | **Observabilidad** | Sentry OK; falta structured logging y enviar Web Vitals → Sentry |
+| P3-9 | **Sync: dos sistemas sobre la misma cola** | `useOfflineQueue` (código muerto, procesadores rotos) coexiste con `useOfflineSync`. Eliminar uno |
+| P3-10 | **`perfiles_select_all` USING(true)** | Todo usuario lee todos los perfiles (nombres/roles/sucursal). Aceptable para app interna; documentado. La escalada real era por UPDATE (P0-1), no por SELECT |
+| P3-11 | **Bot multi-sucursal** | El bot usa `bot_usuarios.sucursal_id` (snapshot); un admin con 2 sucursales (Agustín, jareiden) recibe datos filtrados a 1 sin aviso. Comando `/sucursal` o parámetro opcional |
+| P3-12 | **`baseService` cache sin scope de sucursal** | Latente (TTL=0 hoy). Si se activa, fuga cross-sucursal. Incluir `sucursalId` en la key |
+
+---
+
+## 4. Matriz por rol (verificada)
+
+**Rutas** (guard en `src/App.tsx` por `effectiveRol`). **Escritura DB** gateada por helpers RLS: `es_admin()`=admin · `es_encargado_o_admin()`=admin+encargado · `es_preventista()`=admin+preventista+preventista_taco+encargado · `es_transportista()`=admin+transportista.
+
+| Capacidad | admin | preventista | preventista_taco | transportista | encargado | deposito |
+|---|:--:|:--:|:--:|:--:|:--:|:--:|
+| Crear cliente/pedido (`es_preventista`) | ✅ | ✅ | ✅ | ❌ | ✅ | ❌ |
+| Ver montos/ventas/saldos | ✅ | ✅ | **❌ (pero hoy SÍ los ve — P1-5)** | ✅ | ✅ | ✅ |
+| Editar productos/precios | ✅ | ❌ | ❌ | ❌ | ❌ | ✅ stock (rol `deposito` en RLS productos) |
+| Editar items de pedido | ✅ | ✅ propio < 15:30 (UI; **DB sin límite — P1-6**) | ✅ propio | ❌ | ✅ | ❌ |
+| Cancelar/eliminar pedido | ✅ | ❌ | ❌ | ❌ | cancelar sí / eliminar ❌ | ❌ |
+| Registrar pago | ✅ | ❌ | ❌ | ❌ | ✅ | ❌ |
+| Compras / rendiciones / recorridos | ✅ | ❌ | ❌ | ❌ | ✅ | ❌ |
+| Reportes/usuarios/proveedores/promos/transferencias | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| **Auto-ascenderse a admin (API directa)** | — | **SÍ (P0-1)** | **SÍ** | **SÍ** | **SÍ** | **SÍ** |
+| **Leer ventas/pagos de otra sucursal vía RPC bot** | sí | **SÍ (P0-2)** | **SÍ** | **SÍ** | **SÍ** | **SÍ** |
+
+Negativos a verificar tras los fixes: taco no ve montos (P1-5); ningún rol se auto-asciende (P0-1/069); ninguna RPC del bot responde a `authenticated` (P0-2/069); preventista no edita pedido ajeno ni de otra sucursal (RLS OK) ni el propio fuera de hora (P1-6).
+
+---
+
+## 5. Estado de fixes
+
+| Hallazgo | Acción | Estado |
+|---|---|---|
+| P0-1, P0-2, P2 search_path, P3-5 dup índices | Migración **069** | ✅ Aplicada y verificada |
+| P1-3 (gate rol/sucursal orden entrega), P1-4 (sucursal en resumen_compras) | Migración **070** | ✅ Aplicada y verificada |
+| P1-2 (idempotencia offline) | Migración **071** (`crear_pedido_idempotente`) + frontend | ✅ Aplicada; typecheck + 40 tests + lint OK. Recomendado smoke test offline real |
+| P1-5 (taco ve montos) | Frontend (PedidoCard/PedidoStats/VistaPedidos/PedidosContainer) | ✅ Aplicada; typecheck/lint OK |
+| P1-1 (reconciliación pagos) | Saneo pagos de cancelados + regla "no tocar saldos ≥ 07/04" | ✅ Cerrado: 2 pagos de cancelados descartados, pedido 733 cerrado, 5 sobrepagados (todos ≥ 22/04) dejados como crédito. 0 drift global |
+| P1-6 (trigger de saldo no excluía cancelados) | Migración **072** (forward-only) | ✅ Aplicada — checksums saldo/stock/ítems **intactos**, 0 drift. Ventana 15:30 ya estaba en `actualizar_pedido_items`. Rol por-sucursal en writes: pendiente (decisión de diseño, toca toda la RLS) |
+| P1-7 (leaked password) | Toggle en Dashboard | ⏳ Manual (1 click) |
+| P2/P3 | Backlog priorizado | Pendiente |
+
+---
+
+## 6. Migración 069 — qué hace y cómo aplicar/revertir
+
+Archivo: [`migrations/069_audit_2026_05_hardening.sql`](../migrations/069_audit_2026_05_hardening.sql). **Reversible, no toca datos.**
+1. Trigger anti auto-escalada en `perfiles` (P0-1).
+2. RPCs del bot → solo `service_role` (P0-2). *La app web no las llama (verificado en el inventario de `.rpc()`); el bot usa `service_role`.*
+3. Funciones trigger → sin EXECUTE directo (siguen disparándose).
+4. Cierra `anon` en RPCs mutadoras sin gate (queda `authenticated`).
+5. `search_path` fijo en 4 funciones.
+6. Elimina 6 índices duplicados.
+
+**Aplicar** (SQL Editor de Supabase o `supabase db push`), o pedímelo y la aplico vía MCP.
+**Verificar después:** re-correr advisors (deben bajar los lints de search_path); confirmar que las RPCs del bot ya no son `authenticated`; smoke test de login y de cada rol; que un admin todavía puede cambiar roles en `/usuarios`.
+**Rollback:** re-`GRANT EXECUTE ... TO authenticated`, `DROP TRIGGER trg_prevenir_autoescalada_perfil`, recrear índices.
+
+---
+
+## 7. Verificación end-to-end (cuando se apliquen los fixes)
+- **DB:** `get_advisors` security+performance; queries read-only: ninguna RPC del bot con `authenticated`; reconciliaciones de §2 siguen en 0.
+- **Código:** `npm run typecheck`, `npm run lint`, `npm run test:run`, `npm run build`; e2e por rol.
+- **Funcional por rol:** loguear cada rol y verificar los negativos de §4 (taco sin montos; nadie se auto-asciende; no cross-sucursal).
+- **No regresión:** crear/editar/cancelar pedido, registrar pago, compra, sync offline.
+
+## 8. Checklist reutilizable (trimestral)
+1. `get_advisors` (security + performance) → revisar nuevos lints.
+2. Grants: 0 funciones `SECURITY DEFINER` con `EXECUTE` para `anon`; bot solo `service_role`.
+3. Reconciliación §2 (saldos, totales, stock, pagos) → 0 divergencias.
+4. Policies nuevas sin `USING(true)` salvo justificación; sin múltiples permisivas redundantes.
+5. Cobertura de `calculations.ts`/`precioMayorista.ts` ≥ 95%.
+6. Tamaño de `bot_audit_log`/`audit_logs`/`bot_conversaciones` (retención).
+7. Funciones nuevas con `SET search_path`.
+
+---
+
+## Anexo — 2da tanda de avances (2026-05-28)
+
+**Aplicado/cerrado adicional:**
+- **P2-6 (telegram-digest tiempo constante):** corregido en fuente (`supabase/functions/telegram-digest/index.ts` ahora usa `timingSafeEqual`). Severidad muy baja (clave de alta entropía); sale con el próximo deploy del pipeline de edge functions (no forcé un redeploy por MCP para no arriesgar la función).
+- **P3-6 (crecimiento sin tope) — parcial:** migración **073** agrega trigger `trg_cap_bot_conversaciones` que auto-recorta `mensajes` a los últimos 50 turnos (backstop; el backend ya mantiene ~12). Forward-only, no tocó datos. Retención de `bot_audit_log`/`audit_logs` NO se hizo: **pg_cron no está instalado** y las tablas son chicas (406 / 38.508 filas) → no urgente; revisar cuando crezcan.
+- **P2-7 (`obtener_resumen_cuenta_cliente_bot` sin filtro de sucursal):** verificado que el **único caller** (`_shared/tools/common/ficha_cliente.ts`) ya pre-valida la sucursal del cliente (`.eq("sucursal_id", ctx.sucursal_id)`) + guardrail de admin + chequeo de asignación del preventista. El RPC sin filtro interno es **defensa-en-profundidad, no un hueco activo** → no requiere cambio.
+
+**NO auto-aplicado (con motivo) — requieren tu decisión / branch con test / deploy:**
+- **P2-1 (auth_rls_initplan, perf):** reescribir ~38 políticas RLS (envolver `auth.uid()` en `(select auth.uid())`). Semánticamente idéntico, pero reescribir tantas políticas en prod sin test funcional por rol es riesgoso y lo despriorizaste. Recomendado: hacerlo en una Supabase branch con verificación.
+- **P2-3 (redondeo IVA) / P2-8 (descuento cliente):** tocan la matemática de plata (frontend). Latentes (0/664 clientes usan descuento; totales reconcilian). Cambiar reglas de redondeo necesita tu spec para no introducir diferencias de centavos.
+- **P2-4 (logout no limpia cola offline) / P2-5 (conflicto de stock):** tocan el core de sync (riesgo de pérdida de datos / decisión de UX).
+- **P1-6 parte 3 (rol por-sucursal en escrituras):** cambia `es_admin()`/`es_preventista()` → afecta TODA la RLS; decisión de diseño.
+- **P3-1/2/3 (tests de plata, componentes gigantes, deuda de tipos):** proyectos de refactor (días/semanas), no fixes puntuales.
+- **P1-7 (leaked password):** toggle manual en el Dashboard (sin API).
+
+**Migraciones de la auditoría aplicadas en prod:** 069, 070, 071, 072, 073 (+ saneo de datos de pagos cancelados). Advisors de seguridad: 221 → 158 lints.

--- a/migrations/069_audit_2026_05_hardening.sql
+++ b/migrations/069_audit_2026_05_hardening.sql
@@ -1,0 +1,115 @@
+-- Migración 069: hardening de seguridad/permisos (Auditoría 2026-05)
+-- Cambios reversibles y SIN tocar datos. Ver docs/AUDIT_REPORT_2026-05.md.
+-- Proyecto: hmuchlzmuqqxcldbzkgc (ManaosApp).
+--
+-- Resumen:
+--   1) P0  Impide auto-escalada de rol/activo en perfiles (RLS perfiles_update_self
+--          permite UPDATE de la propia fila sin restringir columnas).
+--   2) P0  RPCs del bot -> solo service_role (la app web no las llama; el bot usa service_role).
+--   3) P1  Funciones trigger sin EXECUTE directo (los triggers siguen disparándose).
+--   4) P1  Cierra acceso anónimo a RPCs sensibles sin gate interno (se mantiene authenticated).
+--   5) P2  search_path fijo en funciones marcadas mutables por el linter.
+--   6) P3  Elimina índices duplicados (se conservan los _id).
+
+-- ============================================================
+-- 1) P0: anti auto-escalada de rol/activo en perfiles
+-- ============================================================
+CREATE OR REPLACE FUNCTION public.prevenir_autoescalada_perfil()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+BEGIN
+  -- auth.uid() IS NULL => contexto service_role/superuser (migraciones, backend de confianza)
+  IF auth.uid() IS NOT NULL AND NOT es_admin()
+     AND ( NEW.rol IS DISTINCT FROM OLD.rol
+           OR COALESCE(NEW.activo, true) IS DISTINCT FROM COALESCE(OLD.activo, true) ) THEN
+    RAISE EXCEPTION 'No autorizado: solo un administrador puede cambiar rol o estado activo';
+  END IF;
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_prevenir_autoescalada_perfil ON public.perfiles;
+CREATE TRIGGER trg_prevenir_autoescalada_perfil
+  BEFORE UPDATE ON public.perfiles
+  FOR EACH ROW EXECUTE FUNCTION public.prevenir_autoescalada_perfil();
+
+-- ============================================================
+-- 2) P0/P1: RPCs del bot solo ejecutables por service_role
+-- ============================================================
+DO $$ DECLARE r RECORD; BEGIN
+  FOR r IN
+    SELECT p.oid::regprocedure AS sig
+    FROM pg_proc p
+    WHERE p.pronamespace = 'public'::regnamespace
+      AND p.proname IN (
+        'bot_buscar_cliente','bot_compras_periodo','bot_ficha_producto',
+        'bot_historico_pagos_cliente','bot_historico_pedidos_cliente','bot_metricas_admin_dia',
+        'bot_mi_recorrido','bot_mis_clientes','bot_mis_ventas','bot_pendientes_pago',
+        'bot_productos_recurrentes_cliente','bot_ranking_preventistas_por_producto',
+        'bot_recorrido_resumen','bot_sugerir_visitas_rfm','bot_ventas_periodo',
+        'bot_ventas_por_preventista','crear_pedido_completo_bot',
+        'canjear_codigo_vinculacion_bot','obtener_resumen_cuenta_cliente_bot')
+  LOOP
+    EXECUTE format('REVOKE EXECUTE ON FUNCTION %s FROM PUBLIC, anon, authenticated', r.sig);
+    EXECUTE format('GRANT EXECUTE ON FUNCTION %s TO service_role', r.sig);
+  END LOOP;
+END $$;
+
+-- ============================================================
+-- 3) P1: funciones trigger sin EXECUTE directo (los triggers siguen funcionando)
+-- ============================================================
+DO $$ DECLARE r RECORD; BEGIN
+  FOR r IN
+    SELECT p.oid::regprocedure AS sig
+    FROM pg_proc p JOIN pg_type t ON t.oid = p.prorettype
+    WHERE p.pronamespace = 'public'::regnamespace AND t.typname = 'trigger'
+  LOOP
+    EXECUTE format('REVOKE EXECUTE ON FUNCTION %s FROM PUBLIC, anon, authenticated', r.sig);
+  END LOOP;
+END $$;
+
+-- ============================================================
+-- 4) P1: cerrar acceso anónimo a RPCs sensibles sin gate interno
+--    (se mantiene authenticated; el gate de rol/sucursal queda como follow-up; ver informe)
+-- ============================================================
+DO $$ DECLARE r RECORD; BEGIN
+  FOR r IN
+    SELECT p.oid::regprocedure AS sig
+    FROM pg_proc p
+    WHERE p.pronamespace = 'public'::regnamespace
+      AND p.proname IN (
+        'actualizar_orden_entrega_batch','aplicar_uso_promo_acumulador','limpiar_orden_entrega',
+        'obtener_estadisticas_rendiciones','obtener_resumen_compras','pedido_bundle_para_promo',
+        'revertir_bloques_auto_ajuste')
+  LOOP
+    EXECUTE format('REVOKE EXECUTE ON FUNCTION %s FROM PUBLIC, anon', r.sig);
+    EXECUTE format('GRANT EXECUTE ON FUNCTION %s TO authenticated, service_role', r.sig);
+  END LOOP;
+END $$;
+
+-- ============================================================
+-- 5) P2: search_path fijo en funciones mutables
+-- ============================================================
+DO $$ DECLARE r RECORD; BEGIN
+  FOR r IN
+    SELECT p.oid::regprocedure AS sig
+    FROM pg_proc p
+    WHERE p.pronamespace = 'public'::regnamespace
+      AND p.proname IN ('f_unaccent','categorias_set_updated_at','registrar_cambio_stock','haversine_m')
+  LOOP
+    EXECUTE format('ALTER FUNCTION %s SET search_path = public, pg_temp', r.sig);
+  END LOOP;
+END $$;
+
+-- ============================================================
+-- 6) P3: eliminar índices duplicados (mismas columnas; se conservan los _id de la mig 054)
+-- ============================================================
+DROP INDEX IF EXISTS public.idx_compra_items_compra;
+DROP INDEX IF EXISTS public.idx_mermas_producto;
+DROP INDEX IF EXISTS public.idx_pagos_fecha;          -- duplicado de idx_pagos_created_at (ambos sobre created_at)
+DROP INDEX IF EXISTS public.idx_pedido_items_pedido;
+DROP INDEX IF EXISTS public.idx_pedidos_cliente;
+DROP INDEX IF EXISTS public.idx_rendicion_items_rendicion;

--- a/migrations/070_audit_2026_05_rpc_gates.sql
+++ b/migrations/070_audit_2026_05_rpc_gates.sql
@@ -1,0 +1,99 @@
+-- Migración 070: gates de rol/sucursal en RPCs mutadoras/lectura sin protección (Auditoría 2026-05, P1-3/P1-4)
+-- Reversible (recrea funciones). No toca datos.
+-- Contexto: estas funciones SECURITY DEFINER bypassan RLS y no validaban rol ni sucursal.
+--   069 ya cerró el acceso anónimo; 070 agrega el gate de rol + scope de sucursal.
+-- Verificado: ninguna función interna las llama (no rompe cadenas de definer);
+--   actualizar_orden_entrega_batch se usa en la optimización de ruta (usePedidos.ts:470).
+-- Roles permitidos: orden de entrega -> encargado/admin/transportista; resumen compras -> encargado/admin.
+
+-- ============================================================
+-- P1-3: orden de entrega — gate de rol + scope de sucursal
+-- ============================================================
+CREATE OR REPLACE FUNCTION public.actualizar_orden_entrega_batch(ordenes jsonb)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $function$
+DECLARE
+  item JSONB;
+BEGIN
+  IF NOT (es_encargado_o_admin() OR es_transportista()) THEN
+    RAISE EXCEPTION 'No autorizado para reordenar entregas';
+  END IF;
+  FOR item IN SELECT * FROM jsonb_array_elements(ordenes)
+  LOOP
+    UPDATE pedidos
+    SET orden_entrega = (item->>'orden')::INTEGER
+    WHERE id = (item->>'pedido_id')::BIGINT
+      AND sucursal_id = current_sucursal_id();
+  END LOOP;
+END;
+$function$;
+
+CREATE OR REPLACE FUNCTION public.actualizar_orden_entrega_batch(ordenes orden_entrega_item[])
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $function$
+DECLARE
+  item orden_entrega_item;
+BEGIN
+  IF NOT (es_encargado_o_admin() OR es_transportista()) THEN
+    RAISE EXCEPTION 'No autorizado para reordenar entregas';
+  END IF;
+  FOREACH item IN ARRAY ordenes
+  LOOP
+    UPDATE pedidos
+    SET orden_entrega = item.orden
+    WHERE id = item.pedido_id
+      AND sucursal_id = current_sucursal_id();
+  END LOOP;
+END;
+$function$;
+
+CREATE OR REPLACE FUNCTION public.limpiar_orden_entrega(p_transportista_id uuid)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $function$
+BEGIN
+  IF NOT (es_encargado_o_admin() OR es_transportista()) THEN
+    RAISE EXCEPTION 'No autorizado';
+  END IF;
+  UPDATE pedidos
+  SET orden_entrega = NULL
+  WHERE transportista_id = p_transportista_id
+    AND sucursal_id = current_sucursal_id();
+END;
+$function$;
+
+-- ============================================================
+-- P1-4: resumen de compras — filtrar por sucursal + gate de rol
+-- ============================================================
+CREATE OR REPLACE FUNCTION public.obtener_resumen_compras(p_fecha_desde date DEFAULT NULL::date, p_fecha_hasta date DEFAULT NULL::date)
+RETURNS TABLE(total_compras bigint, monto_total numeric, promedio_compra numeric, productos_comprados bigint)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $function$
+BEGIN
+  IF NOT es_encargado_o_admin() THEN
+    RAISE EXCEPTION 'No autorizado';
+  END IF;
+  RETURN QUERY
+  SELECT
+    COUNT(DISTINCT c.id)::BIGINT as total_compras,
+    COALESCE(SUM(c.total), 0)::DECIMAL as monto_total,
+    COALESCE(AVG(c.total), 0)::DECIMAL as promedio_compra,
+    COALESCE(SUM(ci.cantidad), 0)::BIGINT as productos_comprados
+  FROM compras c
+  LEFT JOIN compra_items ci ON c.id = ci.compra_id
+  WHERE c.estado != 'cancelada'
+    AND c.sucursal_id = current_sucursal_id()
+    AND (p_fecha_desde IS NULL OR c.fecha_compra >= p_fecha_desde)
+    AND (p_fecha_hasta IS NULL OR c.fecha_compra <= p_fecha_hasta);
+END;
+$function$;

--- a/migrations/071_audit_2026_05_pedido_idempotente.sql
+++ b/migrations/071_audit_2026_05_pedido_idempotente.sql
@@ -1,0 +1,68 @@
+-- Migración 071: idempotencia de creación de pedidos (Auditoría 2026-05, P1-2)
+-- Evita pedidos duplicados cuando el sync offline reintenta tras perder la respuesta
+-- de un INSERT ya commiteado.
+--
+-- Enfoque SEGURO: no se toca crear_pedido_completo (RPC crítica). Se agrega:
+--   1) columna pedidos.offline_id + índice UNIQUE parcial (aditivo, sin riesgo).
+--   2) wrapper crear_pedido_idempotente que verifica offline_id y delega en
+--      crear_pedido_completo. Llamadas con p_offline_id NULL = comportamiento idéntico.
+-- El frontend pasa el offline_id (ya existente en la cola offline) al sincronizar.
+
+-- 1) Columna + índice único parcial
+ALTER TABLE public.pedidos ADD COLUMN IF NOT EXISTS offline_id text;
+CREATE UNIQUE INDEX IF NOT EXISTS uq_pedidos_offline_id
+  ON public.pedidos (offline_id) WHERE offline_id IS NOT NULL;
+
+-- 2) Wrapper idempotente
+CREATE OR REPLACE FUNCTION public.crear_pedido_idempotente(
+  p_cliente_id bigint,
+  p_total numeric,
+  p_usuario_id uuid,
+  p_items jsonb,
+  p_notas text DEFAULT NULL::text,
+  p_forma_pago text DEFAULT 'efectivo'::text,
+  p_estado_pago text DEFAULT 'pendiente'::text,
+  p_fecha date DEFAULT NULL::date,
+  p_tipo_factura text DEFAULT 'ZZ'::text,
+  p_total_neto numeric DEFAULT NULL::numeric,
+  p_total_iva numeric DEFAULT 0,
+  p_fecha_entrega_programada date DEFAULT NULL::date,
+  p_preventista_id uuid DEFAULT NULL::uuid,
+  p_offline_id text DEFAULT NULL::text
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $function$
+DECLARE
+  v_existing INT;
+  v_result JSONB;
+BEGIN
+  -- Idempotencia: si ya existe un pedido con este offline_id, devolverlo sin recrear.
+  IF p_offline_id IS NOT NULL THEN
+    SELECT id INTO v_existing FROM pedidos WHERE offline_id = p_offline_id;
+    IF v_existing IS NOT NULL THEN
+      RETURN jsonb_build_object('success', true, 'pedido_id', v_existing, 'idempotente', true);
+    END IF;
+  END IF;
+
+  -- Delegar en la RPC existente (sin cambios). auth.uid() se preserva.
+  v_result := public.crear_pedido_completo(
+    p_cliente_id, p_total, p_usuario_id, p_items, p_notas, p_forma_pago,
+    p_estado_pago, p_fecha, p_tipo_factura, p_total_neto, p_total_iva,
+    p_fecha_entrega_programada, p_preventista_id
+  );
+
+  -- Etiquetar el pedido recién creado con su offline_id (backstop: índice UNIQUE).
+  IF COALESCE((v_result->>'success')::boolean, false) AND p_offline_id IS NOT NULL THEN
+    UPDATE pedidos SET offline_id = p_offline_id
+    WHERE id = (v_result->>'pedido_id')::int AND offline_id IS NULL;
+  END IF;
+
+  RETURN v_result;
+END;
+$function$;
+
+REVOKE EXECUTE ON FUNCTION public.crear_pedido_idempotente(bigint,numeric,uuid,jsonb,text,text,text,date,text,numeric,numeric,date,uuid,text) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.crear_pedido_idempotente(bigint,numeric,uuid,jsonb,text,text,text,date,text,numeric,numeric,date,uuid,text) TO authenticated, service_role;

--- a/migrations/072_audit_2026_05_saldo_excluye_cancelados.sql
+++ b/migrations/072_audit_2026_05_saldo_excluye_cancelados.sql
@@ -1,0 +1,54 @@
+-- Migración 072: el trigger de saldo trata pedidos cancelados/anulados como contribución 0 (P1-6, parte 2)
+--
+-- Problema (foot-gun verificado en vivo): actualizar_saldo_pedido mantiene clientes.saldo_cuenta
+-- por DELTAS y NO excluye cancelados. Si un pedido se cancela sin zerolear (o se zerolea/edita
+-- estando cancelado), el saldo driftea. La verdad contable (mig 052) es Σ(total - monto_pagado)
+-- SOLO de no-cancelados.
+--
+-- Fix FORWARD-ONLY: la contribución de un pedido al saldo es 0 si está cancelado/anulado.
+-- IMPORTANTE: esto es CREATE OR REPLACE de la función del trigger → NO re-dispara sobre filas
+-- existentes; NO modifica ningún saldo/stock/ítem actual. Solo cambia el cálculo de cambios futuros.
+-- (Comportamiento idéntico al actual para el flujo normal no-cancelado.)
+
+CREATE OR REPLACE FUNCTION public.actualizar_saldo_pedido()
+RETURNS trigger
+LANGUAGE plpgsql
+SET search_path TO 'public'
+AS $function$
+DECLARE
+  contrib_old NUMERIC;
+  contrib_new NUMERIC;
+BEGIN
+  IF TG_OP = 'INSERT' THEN
+    contrib_new := CASE WHEN NEW.estado IN ('cancelado','anulado') THEN 0
+                        ELSE NEW.total - COALESCE(NEW.monto_pagado, 0) END;
+    IF contrib_new <> 0 THEN
+      UPDATE clientes SET saldo_cuenta = COALESCE(saldo_cuenta, 0) + contrib_new
+      WHERE id = NEW.cliente_id;
+    END IF;
+    RETURN NEW;
+
+  ELSIF TG_OP = 'DELETE' THEN
+    contrib_old := CASE WHEN OLD.estado IN ('cancelado','anulado') THEN 0
+                        ELSE OLD.total - COALESCE(OLD.monto_pagado, 0) END;
+    IF contrib_old <> 0 THEN
+      UPDATE clientes SET saldo_cuenta = COALESCE(saldo_cuenta, 0) - contrib_old
+      WHERE id = OLD.cliente_id;
+    END IF;
+    RETURN OLD;
+
+  ELSIF TG_OP = 'UPDATE' THEN
+    contrib_old := CASE WHEN OLD.estado IN ('cancelado','anulado') THEN 0
+                        ELSE OLD.total - COALESCE(OLD.monto_pagado, 0) END;
+    contrib_new := CASE WHEN NEW.estado IN ('cancelado','anulado') THEN 0
+                        ELSE NEW.total - COALESCE(NEW.monto_pagado, 0) END;
+    IF contrib_old IS DISTINCT FROM contrib_new THEN
+      UPDATE clientes SET saldo_cuenta = COALESCE(saldo_cuenta, 0) - contrib_old + contrib_new
+      WHERE id = NEW.cliente_id;
+    END IF;
+    RETURN NEW;
+  END IF;
+
+  RETURN NEW;
+END;
+$function$;

--- a/migrations/073_audit_2026_05_cap_bot_conversaciones.sql
+++ b/migrations/073_audit_2026_05_cap_bot_conversaciones.sql
@@ -1,0 +1,38 @@
+-- Migración 073: backstop de crecimiento para bot_conversaciones (Auditoría 2026-05, P3-6 parcial)
+--
+-- El backend ya trunca el historial a ~12 turnos antes del UPSERT, pero el TODO de
+-- migrations/014_bot_telegram.sql recomendaba un backstop defensivo por si hay un bug.
+-- En vez de un CHECK (que rechazaría el insert y rompería el bot), usamos un trigger
+-- que AUTO-RECORTA a los últimos 50 turnos. Nunca actúa en uso normal (≤ ~12);
+-- solo es una red de seguridad ante crecimiento descontrolado.
+--
+-- Forward-only y aditivo: CREATE TRIGGER no dispara sobre filas existentes (no toca datos).
+-- No afecta saldos/stock/pedidos.
+
+CREATE OR REPLACE FUNCTION public.cap_bot_conversaciones_mensajes()
+RETURNS trigger
+LANGUAGE plpgsql
+SET search_path TO 'public'
+AS $function$
+BEGIN
+  IF NEW.mensajes IS NOT NULL
+     AND jsonb_typeof(NEW.mensajes) = 'array'
+     AND jsonb_array_length(NEW.mensajes) > 50 THEN
+    NEW.mensajes := (
+      SELECT COALESCE(jsonb_agg(elem ORDER BY ord), '[]'::jsonb)
+      FROM (
+        SELECT elem, ord
+        FROM jsonb_array_elements(NEW.mensajes) WITH ORDINALITY AS t(elem, ord)
+        ORDER BY ord DESC
+        LIMIT 50
+      ) ultimos
+    );
+  END IF;
+  RETURN NEW;
+END;
+$function$;
+
+DROP TRIGGER IF EXISTS trg_cap_bot_conversaciones ON public.bot_conversaciones;
+CREATE TRIGGER trg_cap_bot_conversaciones
+  BEFORE INSERT OR UPDATE ON public.bot_conversaciones
+  FOR EACH ROW EXECUTE FUNCTION public.cap_bot_conversaciones_mensajes();

--- a/src/components/containers/PedidosContainer.tsx
+++ b/src/components/containers/PedidosContainer.tsx
@@ -101,7 +101,7 @@ interface ConfirmConfig {
 
 export default function PedidosContainer(): React.ReactElement {
   const queryClient = useQueryClient()
-  const { user, isAdmin, isPreventista, isTransportista, isEncargado, isOnline, authReady } = useAuthData()
+  const { user, isAdmin, isPreventista, isPreventistaTaco, isTransportista, isEncargado, isOnline, authReady } = useAuthData()
   const notify = useNotification()
 
   // Pagination state
@@ -1132,6 +1132,7 @@ export default function PedidosContainer(): React.ReactElement {
           isPreventista={isPreventista}
           isTransportista={isTransportista}
           isEncargado={isEncargado}
+          isPreventistaTaco={isPreventistaTaco}
           userId={user?.id ?? ''}
           clientes={clientes}
           productos={productos}

--- a/src/components/pedidos/PedidoCard.tsx
+++ b/src/components/pedidos/PedidoCard.tsx
@@ -229,7 +229,9 @@ function PedidoCard({
 
   // Intentar usar contexto si está disponible (migración gradual)
   const pedidoActions = useContext(PedidoActionsCtx);
-  const { user } = useAuthData();
+  const { user, isPreventistaTaco } = useAuthData();
+  // preventista_taco no puede ver montos comerciales (P1-5).
+  const verMontos = !isPreventistaTaco;
 
   // Usar handlers del contexto si están disponibles, de lo contrario usar props
   const handleVerHistorial = onVerHistorial ?? pedidoActions?.handleVerHistorial;
@@ -440,9 +442,9 @@ function PedidoCard({
             className="mt-1 text-2xl text-blue-700 dark:text-blue-300 tabular-nums leading-none"
             style={{ fontWeight: 800, letterSpacing: '-0.03em' }}
           >
-            {formatPrecio(pedido.total)}
+            {verMontos ? formatPrecio(pedido.total) : '—'}
           </p>
-          {pedido.estado_pago === 'parcial' && (
+          {verMontos && pedido.estado_pago === 'parcial' && (
             <p className="mt-1.5 text-[13px] font-medium text-amber-700 dark:text-amber-400 tabular-nums">
               Pagado: {formatPrecio(pedido.monto_pagado || 0)} de {formatPrecio(pedido.total)}
             </p>
@@ -554,7 +556,7 @@ function PedidoCard({
                         </span>
                       )}
                     </p>
-                    {!item.es_bonificacion && <p className="text-xs text-gray-500">{formatPrecio(item.precio_unitario)} c/u</p>}
+                    {verMontos && !item.es_bonificacion && <p className="text-xs text-gray-500">{formatPrecio(item.precio_unitario)} c/u</p>}
                     {salvedadItem && (
                       <p className="text-xs text-amber-600 dark:text-amber-400">
                         Pedido: {cantidadOriginal} → Entregado: {item.cantidad} ({salvedadItem.cantidad_afectada} no entregadas)
@@ -563,19 +565,21 @@ function PedidoCard({
                   </div>
                   <div className="text-right">
                     <p className="font-semibold text-gray-700 dark:text-gray-300">x{item.cantidad}</p>
-                    {!item.es_bonificacion && <p className="text-sm font-bold text-blue-600">{formatPrecio(item.subtotal || item.precio_unitario * item.cantidad)}</p>}
-                    {item.es_bonificacion && <p className="text-sm font-bold text-green-600">$0</p>}
-                    {salvedadItem && (
+                    {verMontos && !item.es_bonificacion && <p className="text-sm font-bold text-blue-600">{formatPrecio(item.subtotal || item.precio_unitario * item.cantidad)}</p>}
+                    {verMontos && item.es_bonificacion && <p className="text-sm font-bold text-green-600">$0</p>}
+                    {verMontos && salvedadItem && (
                       <p className="text-xs text-red-500 dark:text-red-400">-{formatPrecio(salvedadItem.monto_afectado)}</p>
                     )}
                   </div>
                 </div>
                 );
               })}
-              <div className="flex justify-between items-center pt-2 border-t-2 dark:border-gray-600">
-                <p className="font-bold text-gray-900 dark:text-white">Total</p>
-                <p className="text-xl font-bold text-blue-600">{formatPrecio(pedido.total)}</p>
-              </div>
+              {verMontos && (
+                <div className="flex justify-between items-center pt-2 border-t-2 dark:border-gray-600">
+                  <p className="font-bold text-gray-900 dark:text-white">Total</p>
+                  <p className="text-xl font-bold text-blue-600">{formatPrecio(pedido.total)}</p>
+                </div>
+              )}
             </div>
           </div>
 
@@ -607,20 +611,24 @@ function PedidoCard({
                           {salvedad.estado_resolucion === 'pendiente' ? 'Pendiente de resolver' : 'Resuelta'}
                         </span>
                       </div>
-                      <div className="text-right">
-                        <p className="text-sm font-bold text-red-600 dark:text-red-400">
-                          -{formatPrecio(salvedad.monto_afectado)}
-                        </p>
-                      </div>
+                      {verMontos && (
+                        <div className="text-right">
+                          <p className="text-sm font-bold text-red-600 dark:text-red-400">
+                            -{formatPrecio(salvedad.monto_afectado)}
+                          </p>
+                        </div>
+                      )}
                     </div>
                   );
                 })}
-                <div className="flex justify-between items-center pt-2 border-t border-amber-300 dark:border-amber-600">
-                  <p className="text-sm font-medium text-amber-800 dark:text-amber-200">Total afectado:</p>
-                  <p className="text-sm font-bold text-red-600 dark:text-red-400">
-                    -{formatPrecio(pedido.salvedades?.reduce((sum, s) => sum + s.monto_afectado, 0) || 0)}
-                  </p>
-                </div>
+                {verMontos && (
+                  <div className="flex justify-between items-center pt-2 border-t border-amber-300 dark:border-amber-600">
+                    <p className="text-sm font-medium text-amber-800 dark:text-amber-200">Total afectado:</p>
+                    <p className="text-sm font-bold text-red-600 dark:text-red-400">
+                      -{formatPrecio(pedido.salvedades?.reduce((sum, s) => sum + s.monto_afectado, 0) || 0)}
+                    </p>
+                  </div>
+                )}
               </div>
             </div>
           )}
@@ -660,7 +668,7 @@ function PedidoCard({
               {(() => {
                 const pagos = pedido.pagos || [];
                 const formas = Array.from(new Set(pagos.map(p => p.forma_pago).filter(Boolean)));
-                if (formas.length < 2) return null;
+                if (!verMontos || formas.length < 2) return null;
                 const desglose = formas.map(f => ({
                   forma: f,
                   monto: pagos.filter(p => p.forma_pago === f).reduce((s, p) => s + (p.monto || 0), 0),

--- a/src/components/pedidos/PedidoStats.tsx
+++ b/src/components/pedidos/PedidoStats.tsx
@@ -25,6 +25,7 @@ import { mostrarMontosEnStats, type PedidoStatKey } from '../../lib/permisos';
 export interface PedidoStatsProps {
   summary: PedidoStatsSummary;
   isEncargado?: boolean;
+  isPreventistaTaco?: boolean;
 }
 
 interface StatItem {
@@ -49,8 +50,9 @@ interface StatItem {
 // COMPONENT
 // =============================================================================
 
-function PedidoStats({ summary, isEncargado }: PedidoStatsProps): React.ReactElement {
-  const rol = isEncargado ? 'encargado' : 'admin';
+function PedidoStats({ summary, isEncargado, isPreventistaTaco }: PedidoStatsProps): React.ReactElement {
+  // El rol determina qué montos se muestran. preventista_taco no ve ningún monto. (P1-5)
+  const rol = isPreventistaTaco ? 'preventista_taco' : isEncargado ? 'encargado' : 'admin';
   const items: StatItem[] = [
     {
       key: 'pendientes',

--- a/src/components/vistas/VistaPedidos.tsx
+++ b/src/components/vistas/VistaPedidos.tsx
@@ -40,6 +40,7 @@ export interface VistaPedidosProps {
   isPreventista: boolean;
   isTransportista: boolean;
   isEncargado?: boolean;
+  isPreventistaTaco?: boolean;
   userId: string;
   clientes: ClienteDB[];
   productos: ProductoDB[];
@@ -108,6 +109,7 @@ export default function VistaPedidos({
   isPreventista,
   isTransportista,
   isEncargado,
+  isPreventistaTaco,
   userId,
   clientes,
   productos,
@@ -197,7 +199,7 @@ export default function VistaPedidos({
       />
 
       {/* Resumen de estados (totales sobre todos los pedidos filtrados) */}
-      <PedidoStats summary={statsSummary} isEncargado={isEncargado} />
+      <PedidoStats summary={statsSummary} isEncargado={isEncargado} isPreventistaTaco={isPreventistaTaco} />
 
       {/* Lista de pedidos */}
       {loading ? (

--- a/src/hooks/supabase/usePedidos.test.js
+++ b/src/hooks/supabase/usePedidos.test.js
@@ -372,7 +372,7 @@ describe('usePedidos', () => {
       })
 
       expect(createdPedido.id).toBe('nuevo-pedido-1')
-      expect(supabase.rpc).toHaveBeenCalledWith('crear_pedido_completo', expect.objectContaining({
+      expect(supabase.rpc).toHaveBeenCalledWith('crear_pedido_idempotente', expect.objectContaining({
         p_cliente_id: 'cliente-1',
         p_total: 500,
         p_usuario_id: 'user-1'

--- a/src/hooks/supabase/usePedidos.ts
+++ b/src/hooks/supabase/usePedidos.ts
@@ -119,7 +119,8 @@ export interface UsePedidosHookReturn {
     tipoFactura?: 'ZZ' | 'FC',
     totalNeto?: number,
     totalIva?: number,
-    preventistaId?: string | null
+    preventistaId?: string | null,
+    offlineId?: string | null
   ) => Promise<{ id: string }>;
   cambiarEstado: (id: string, nuevoEstado: string) => Promise<void>;
   asignarTransportista: (pedidoId: string, transportistaId: string | null, cambiarEstadoFlag?: boolean) => Promise<void>;
@@ -304,7 +305,8 @@ export function usePedidos(): UsePedidosHookReturn {
     tipoFactura: 'ZZ' | 'FC' = 'ZZ',
     totalNeto?: number,
     totalIva?: number,
-    preventistaId?: string | null
+    preventistaId?: string | null,
+    offlineId?: string | null
   ): Promise<{ id: string }> => {
     const itemsParaRPC = items.map(item => ({
       producto_id: item.productoId || item.producto_id,
@@ -318,7 +320,7 @@ export function usePedidos(): UsePedidosHookReturn {
       ...(item.porcentaje_iva != null ? { porcentaje_iva: item.porcentaje_iva } : {}),
     }))
 
-    const { data, error } = await supabase.rpc('crear_pedido_completo', {
+    const { data, error } = await supabase.rpc('crear_pedido_idempotente', {
       p_cliente_id: clienteId,
       p_total: total,
       p_usuario_id: usuarioId,
@@ -329,7 +331,10 @@ export function usePedidos(): UsePedidosHookReturn {
       p_tipo_factura: tipoFactura || 'ZZ',
       p_total_neto: totalNeto ?? total,
       p_total_iva: totalIva ?? 0,
-      p_preventista_id: preventistaId ?? null
+      p_preventista_id: preventistaId ?? null,
+      // Idempotencia: evita pedidos duplicados si el sync reintenta tras un commit
+      // cuya respuesta se perdió. Para creación online directa es null. (P1-2)
+      p_offline_id: offlineId ?? null
     })
 
     if (error) {

--- a/src/hooks/useOfflineSync.ts
+++ b/src/hooks/useOfflineSync.ts
@@ -99,7 +99,12 @@ export interface CrearPedidoFunction {
     descontarStockFn?: (items: Array<{ productoId?: string; producto_id?: string; cantidad: number }>) => Promise<void>,
     notas?: string,
     formaPago?: string,
-    estadoPago?: string
+    estadoPago?: string,
+    tipoFactura?: string,
+    totalNeto?: number,
+    totalIva?: number,
+    preventistaId?: string | null,
+    offlineId?: string | null
   ): Promise<unknown>;
 }
 
@@ -580,7 +585,13 @@ export function useOfflineSync(): UseOfflineSyncReturn {
             descontarStockFn,
             payload.notas as string | undefined,
             payload.formaPago as string | undefined,
-            payload.estadoPago as string | undefined
+            payload.estadoPago as string | undefined,
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            // Clave de idempotencia estable por operación encolada (P1-2)
+            `op_${op.id}`
           )
           await markAsCompleted(op.id!)
           sincronizados++

--- a/supabase/functions/telegram-digest/index.ts
+++ b/supabase/functions/telegram-digest/index.ts
@@ -28,6 +28,7 @@
 
 import { serve } from "std/http/server.ts";
 import { getServiceRoleClient } from "../_shared/supabase.ts";
+import { timingSafeEqual } from "../_shared/telegram.ts";
 import { runDigestForAdmin } from "./digest.ts";
 
 interface AdminRow {
@@ -46,7 +47,9 @@ serve(async (req: Request) => {
   }
 
   const auth = req.headers.get("Authorization") ?? "";
-  if (auth !== `Bearer ${serviceKey}`) {
+  // Comparación en tiempo constante (consistencia con telegram-webhook; evita
+  // timing attacks al validar el bearer). P2-6 de la auditoría 2026-05.
+  if (!timingSafeEqual(auth, `Bearer ${serviceKey}`)) {
     return new Response("forbidden", { status: 403 });
   }
 


### PR DESCRIPTION
## Resumen
Auditoría integral (código + DB) cubriendo los 6 roles (admin, preventista, preventista_taco, transportista, encargado, deposito). Las migraciones **069-073 ya están aplicadas en producción** (ManaosApp `hmuchlzmuqqxcldbzkgc`); este PR las versiona en el repo junto con los fixes de frontend/edge y el informe.

📄 Informe completo: `docs/AUDIT_REPORT_2026-05.md`

## Cambios

### DB (`migrations/`)
- **069** — P0: anti-escalada de rol en `perfiles` (trigger); RPCs del bot → `service_role`; funciones trigger sin EXECUTE directo; cierre de `anon` en RPCs sin gate; `search_path` fijo; drop de 6 índices duplicados.
- **070** — P1: gates de rol/sucursal en `actualizar_orden_entrega_batch`, `limpiar_orden_entrega`, `obtener_resumen_compras`.
- **071** — P1: idempotencia de pedidos (`crear_pedido_idempotente` + `pedidos.offline_id` UNIQUE).
- **072** — P1: el trigger de saldo trata cancelados/anulados como contribución 0 (forward-only).
- **073** — backstop de crecimiento de `bot_conversaciones` (cap a 50 turnos).

### Frontend (`src/`)
- **P1-5**: `preventista_taco` ya no ve montos (PedidoCard / PedidoStats / VistaPedidos / PedidosContainer).
- **P1-2**: wiring de idempotencia offline (usePedidos → `crear_pedido_idempotente`; `offline_id` por operación en useOfflineSync).

### Edge (`supabase/functions/`)
- **P2-6**: telegram-digest valida el bearer en tiempo constante (`timingSafeEqual`).

## Verificación
- Advisors de seguridad: **221 → 158** lints.
- Reconciliación de saldos: **0 divergencias / $0 drift**.
- `typecheck` + `lint` + **674 tests** OK.
- Saneo de datos: 2 pagos sobre pedidos cancelados descartados, sin alterar saldos correctos (respetando "no tocar saldos ≥ 07/04").

> ⚠️ Las migraciones ya corren en prod — **no re-aplicar** al mergear; este PR es el versionado del cambio.

## Pendiente (fuera de este PR)
- **P1-7**: activar leaked-password protection (toggle manual en Dashboard).
- **P1-6 parte 3**: rol por-sucursal en escrituras (decisión de diseño, toca toda la RLS).
- Backlog P2/P3 (perf `auth_rls_initplan`, redondeo IVA, refactors) — recomendado en branch con tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)