### PR TITLE
fix: autocompletado de dirección borraba la altura de la calle

### DIFF
--- a/src/components/AddressAutocomplete.tsx
+++ b/src/components/AddressAutocomplete.tsx
@@ -2,6 +2,7 @@
 import React, { useEffect, useRef, useState, useCallback, ChangeEvent } from 'react';
 import { MapPin, Loader2, X, AlertCircle } from 'lucide-react';
 import { useGoogleMaps } from '../hooks/useGoogleMaps';
+import { preservarAlturaEnDireccion } from '../utils/direccion';
 
 // =============================================================================
 // TYPES
@@ -184,17 +185,12 @@ export const AddressAutocomplete = ({
           const components = (place.address_components as AddressComponent[]) || [];
           let direccion = place.formatted_address || prediction.description;
 
-          // Si Google no devolvió número de calle, intentar extraerlo del input original
+          // Si Google geocodificó a nivel calle (sin street_number), preservar la
+          // altura que tipeó el usuario. NO lo hacemos si Google ya trajo un
+          // número (podría diferir del tipeado y no queremos pisarlo).
           const tieneStreetNumber = components.some(c => c.types.includes('street_number'));
           if (!tieneStreetNumber) {
-            const route = components.find(c => c.types.includes('route'))?.long_name;
-            // Extraer número del input original del usuario (ej: "eudoro araos 2135" → "2135")
-            const numberMatch = originalInput.match(/\b(\d{1,5})\b/);
-            if (route && numberMatch) {
-              const streetNumber = numberMatch[1];
-              // Insertar el número después del nombre de la calle
-              direccion = direccion.replace(route, `${route} ${streetNumber}`);
-            }
+            direccion = preservarAlturaEnDireccion(direccion, originalInput);
           }
 
           const result: AddressSelectResult = {
@@ -211,9 +207,12 @@ export const AddressAutocomplete = ({
           // Crear nuevo session token para la próxima búsqueda
           sessionTokenRef.current = new window.google.maps.places.AutocompleteSessionToken();
         } else {
-          // Si falla obtener detalles, al menos guardamos la dirección
+          // Si falla obtener detalles, al menos guardamos la dirección,
+          // preservando la altura tipeada por el usuario.
+          const direccionFallback = preservarAlturaEnDireccion(prediction.description, originalInput);
+          onChange(direccionFallback);
           onSelect({
-            direccion: prediction.description,
+            direccion: direccionFallback,
             latitud: null,
             longitud: null,
             componentes: []

--- a/src/utils/direccion.test.ts
+++ b/src/utils/direccion.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest';
+import { preservarAlturaEnDireccion } from './direccion';
+
+// Regresión del bug reportado: al elegir una sugerencia de Google en "Editar
+// Cliente", la altura de la calle que tipeó el usuario se perdía y quedaba solo
+// el nombre de la calle (Google geocodifica pasajes a nivel calle y abrevia el
+// tipo de vía, por lo que el reemplazo por `route` no matcheaba).
+describe('preservarAlturaEnDireccion', () => {
+  it('preserva la altura cuando Google la pierde (geocodificó a nivel calle)', () => {
+    expect(
+      preservarAlturaEnDireccion(
+        'Pje. Juan Padros, T4000 San Miguel de Tucumán, Tucumán, Argentina',
+        'Pje. Juan Padros 1234',
+      ),
+    ).toBe('Pje. Juan Padros 1234, T4000 San Miguel de Tucumán, Tucumán, Argentina');
+  });
+
+  it('es robusto frente a la abreviatura del tipo de vía (Pje. vs Pasaje)', () => {
+    expect(
+      preservarAlturaEnDireccion(
+        'Pje. Juan Padros, San Miguel de Tucumán',
+        'Pasaje Juan Padros 950',
+      ),
+    ).toBe('Pje. Juan Padros 950, San Miguel de Tucumán');
+  });
+
+  it('funciona cuando la dirección no tiene comas', () => {
+    expect(preservarAlturaEnDireccion('Eudoro Aráoz', 'eudoro araos 2135')).toBe(
+      'Eudoro Aráoz 2135',
+    );
+  });
+
+  it('no duplica la altura si la línea de la calle ya la tiene', () => {
+    const dir = 'Pje. Juan Padros 1234, San Miguel de Tucumán';
+    expect(preservarAlturaEnDireccion(dir, 'Pje. Juan Padros 1234')).toBe(dir);
+  });
+
+  it('no toca la dirección si el usuario no tipeó altura', () => {
+    const dir = 'Av. Mitre, San Miguel de Tucumán';
+    expect(preservarAlturaEnDireccion(dir, 'Av. Mitre')).toBe(dir);
+  });
+
+  it('toma la altura real y no el código postal (T4000)', () => {
+    expect(
+      preservarAlturaEnDireccion('Av. Aconquija, Yerba Buena', 'Av. Aconquija 1234 T4000'),
+    ).toBe('Av. Aconquija 1234, Yerba Buena');
+  });
+
+  it('no rompe con dirección vacía', () => {
+    expect(preservarAlturaEnDireccion('', 'Calle 123')).toBe('');
+  });
+});

--- a/src/utils/direccion.ts
+++ b/src/utils/direccion.ts
@@ -1,0 +1,29 @@
+/**
+ * Utilidades de direcciones.
+ */
+
+/**
+ * Preserva la altura (número de calle) que tipeó el usuario cuando Google la
+ * pierde: con frecuencia geocodifica a nivel calle (sin número) para pasajes y
+ * calles poco frecuentes, devolviendo solo el nombre. Inserta el número en la
+ * línea de la calle (primer segmento, antes de la primera coma) en vez de
+ * reemplazar el `route`, porque Google abrevia el tipo de vía en el
+ * `formatted_address` ("Pje. Juan Padros") mientras el route es "Pasaje Juan
+ * Padros", y el reemplazo directo nunca matcheaba → la altura se perdía.
+ *
+ * Idempotente: no agrega el número si la línea de la calle ya lo contiene.
+ *
+ * @param direccion    dirección devuelta por Google (formatted_address o description)
+ * @param inputOriginal lo que tipeó el usuario (de donde se extrae la altura)
+ */
+export function preservarAlturaEnDireccion(direccion: string, inputOriginal: string): string {
+  const numberMatch = inputOriginal.match(/\b(\d{1,5})\b/);
+  if (!numberMatch) return direccion;
+  const altura = numberMatch[1];
+  const partes = direccion.split(',');
+  if (!partes[0]) return direccion;
+  // Si la línea de la calle ya incluye esa altura, no duplicar.
+  if (new RegExp(`\\b${altura}\\b`).test(partes[0])) return direccion;
+  partes[0] = `${partes[0].trim()} ${altura}`;
+  return partes.join(',');
+}


### PR DESCRIPTION
## Problema
Reportado por una usuaria: al **editar un cliente**, si tipea calle + altura (ej. `Pje. Juan Padros 1234`) y elige una sugerencia del autocompletado de Google, **la altura se borra** y queda solo el nombre de la calle.

## Causa
`AddressAutocomplete` ya intentaba preservar la altura, pero lo hacía con `formatted_address.replace(route.long_name, …)`. Google **abrevia el tipo de vía** en `formatted_address` (`"Pje. Juan Padros"`) mientras el `route` es `"Pasaje Juan Padros"`, por lo que el reemplazo **nunca matcheaba** y el número no se insertaba. Pasa sobre todo en **pasajes y calles poco frecuentes**, que Google geocodifica a nivel calle (sin `street_number`).

## Fix
- Nueva función pura **`preservarAlturaEnDireccion`** (`src/utils/direccion.ts`): inserta la altura tipeada en la **línea de la calle** (primer segmento antes de la coma), robusta frente a las abreviaturas y sin depender del `route`. Idempotente (no duplica) y toma la altura real, no el código postal (`T4000`).
- Aplicada en `AddressAutocomplete` en **ambos caminos**: cuando Google no trae `street_number` y en el fallback de `getDetails`.
- Aplica a **todos los modales** con autocompletado (Cliente, Proveedor, Pedido).

**Ejemplo:** `Pje. Juan Padros 1234` → antes guardaba `Pje. Juan Padros`; ahora `Pje. Juan Padros 1234, T4000 San Miguel de Tucumán…`.

## Verificación
- `src/utils/direccion.test.ts`: **7 tests** de regresión (incluye el caso abreviatura Pje./Pasaje, sin coma, código postal, idempotencia).
- `typecheck` + `lint` OK; suite completa de tests en verde (pre-commit hook).

## Archivos
- `src/utils/direccion.ts` (nuevo)
- `src/utils/direccion.test.ts` (nuevo)
- `src/components/AddressAutocomplete.tsx` (usa el helper)

🤖 Generated with [Claude Code](https://claude.com/claude-code)