### PR TITLE
feat(productos): encargado ve stock bajo y descarga control de stock

### DIFF
--- a/src/components/containers/ProductosContainer.tsx
+++ b/src/components/containers/ProductosContainer.tsx
@@ -19,6 +19,7 @@ import { useRegistrarCambioProductoMutation, type RegistrarCambioInput } from '.
 import { useCategoriasQuery } from '../../hooks/queries'
 import { useAuthData } from '../../contexts/AuthDataContext'
 import { useNotification } from '../../contexts/NotificationContext'
+import { puedeControlarStock as puedeControlarStockRol } from '../../lib/permisos'
 import { useResetOnSucursalChange } from '../../hooks/useResetOnSucursalChange'
 import { formatPrecio } from '../../utils/formatters'
 import type { ProductoDB, ProductoFormInput, MermaFormInputExtended } from '../../types'
@@ -51,8 +52,10 @@ interface ConfirmConfig {
 }
 
 export default function ProductosContainer(): React.ReactElement {
-  const { isAdmin } = useAuthData()
+  const { isAdmin, perfil } = useAuthData()
   const puedeCambiarProductos = isAdmin
+  // Stock bajo + control de stock (Excel): admin y encargado.
+  const puedeControlarStock = puedeControlarStockRol(perfil?.rol)
   const notify = useNotification()
 
   // Queries
@@ -256,6 +259,7 @@ export default function ProductosContainer(): React.ReactElement {
           proveedores={proveedores}
           loading={isLoading}
           isAdmin={isAdmin}
+          puedeControlarStock={puedeControlarStock}
           onNuevoProducto={handleNuevoProducto}
           onEditarProducto={handleEditarProducto}
           onEliminarProducto={handleEliminarProducto}
@@ -264,8 +268,8 @@ export default function ProductosContainer(): React.ReactElement {
           onActualizacionMasivaPrecios={handleAbrirActualizacionMasiva}
           onGestionarCategorias={handleGestionarCategorias}
           onCambioProducto={puedeCambiarProductos ? handleAbrirCambioProducto : undefined}
-          onControlStock={handleControlStock}
-          onAbrirStockBajo={handleAbrirStockBajo}
+          onControlStock={puedeControlarStock ? handleControlStock : undefined}
+          onAbrirStockBajo={puedeControlarStock ? handleAbrirStockBajo : undefined}
         />
       </Suspense>
 
@@ -350,7 +354,7 @@ export default function ProductosContainer(): React.ReactElement {
         <Suspense fallback={null}>
           <ModalStockBajo
             productos={productosStockBajo}
-            onEditarProducto={handleEditarDesdeStockBajo}
+            onEditarProducto={isAdmin ? handleEditarDesdeStockBajo : undefined}
             onClose={() => setModalStockBajoOpen(false)}
           />
         </Suspense>

--- a/src/components/modals/ModalStockBajo.tsx
+++ b/src/components/modals/ModalStockBajo.tsx
@@ -22,8 +22,11 @@ import type { ProductoDB } from '../../types';
 export interface ModalStockBajoProps {
   /** Productos con stock bajo, ya filtrados por el container. */
   productos: ProductoDB[];
-  /** Click en "Editar" de una fila: cierra el modal y abre ModalProducto. */
-  onEditarProducto: (producto: ProductoDB) => void;
+  /**
+   * Click en "Editar" de una fila: cierra el modal y abre ModalProducto.
+   * Si no se provee (ej. rol encargado, solo lectura) no se muestra el botón.
+   */
+  onEditarProducto?: (producto: ProductoDB) => void;
   /** Cerrar el modal. */
   onClose: () => void;
 }
@@ -215,15 +218,17 @@ const ModalStockBajo = memo(function ModalStockBajo({
                     </span>
                   </div>
                 </div>
-                <button
-                  type="button"
-                  onClick={() => { onEditarProducto(p); onClose(); }}
-                  className="inline-flex items-center gap-1.5 h-8 px-2.5 rounded-md text-xs font-medium bg-blue-50 dark:bg-blue-900/20 text-blue-700 dark:text-blue-300 border border-blue-200/70 dark:border-blue-800/40 hover:bg-blue-100 dark:hover:bg-blue-900/30 hover:border-blue-300 hover:-translate-y-px active:translate-y-0 transition-[transform,background-color,border-color] flex-shrink-0"
-                  title={`Editar ${p.nombre}`}
-                >
-                  <Edit2 className="w-3.5 h-3.5" aria-hidden="true" />
-                  <span>Editar</span>
-                </button>
+                {onEditarProducto && (
+                  <button
+                    type="button"
+                    onClick={() => { onEditarProducto(p); onClose(); }}
+                    className="inline-flex items-center gap-1.5 h-8 px-2.5 rounded-md text-xs font-medium bg-blue-50 dark:bg-blue-900/20 text-blue-700 dark:text-blue-300 border border-blue-200/70 dark:border-blue-800/40 hover:bg-blue-100 dark:hover:bg-blue-900/30 hover:border-blue-300 hover:-translate-y-px active:translate-y-0 transition-[transform,background-color,border-color] flex-shrink-0"
+                    title={`Editar ${p.nombre}`}
+                  >
+                    <Edit2 className="w-3.5 h-3.5" aria-hidden="true" />
+                    <span>Editar</span>
+                  </button>
+                )}
               </div>
             );
           })

--- a/src/components/productos/ProductoToolbar.tsx
+++ b/src/components/productos/ProductoToolbar.tsx
@@ -24,6 +24,12 @@ import { cn } from '../../lib/utils';
 
 export interface ProductoToolbarProps {
   isAdmin: boolean;
+  /**
+   * Si el usuario puede controlar el stock (admin o encargado): habilita el
+   * botón de stock bajo y la descarga del control de stock (Excel), sin
+   * exponer el resto de acciones de catálogo/edición reservadas a admin.
+   */
+  puedeControlarStock?: boolean;
   productosStockBajoCount: number;
   onGestionarCategorias?: () => void;
   onCambioProducto?: () => void;
@@ -147,6 +153,7 @@ function PrimaryNewButton({ onClick, fullWidth = false }: { onClick: () => void;
 
 export default function ProductoToolbar({
   isAdmin,
+  puedeControlarStock = false,
   productosStockBajoCount,
   onGestionarCategorias,
   onCambioProducto,
@@ -159,8 +166,12 @@ export default function ProductoToolbar({
   const hayCatálogo = isAdmin && (
     Boolean(onGestionarCategorias) || Boolean(onCambioProducto) || Boolean(onActualizacionMasivaPrecios)
   );
-  const hayInventario = isAdmin && (Boolean(onControlStock) || Boolean(onVerHistorialMermas));
-  const hayStockBajo = isAdmin;
+  // Control de stock (Excel) lo ve admin y encargado; el historial de mermas
+  // sigue siendo solo admin.
+  const mostrarControlStock = puedeControlarStock && Boolean(onControlStock);
+  const mostrarHistorialMermas = isAdmin && Boolean(onVerHistorialMermas);
+  const hayInventario = mostrarControlStock || mostrarHistorialMermas;
+  const hayStockBajo = puedeControlarStock;
   const hayNuevo = isAdmin && Boolean(onNuevoProducto);
 
   if (!hayCatálogo && !hayInventario && !hayStockBajo && !hayNuevo) {
@@ -195,7 +206,7 @@ export default function ProductoToolbar({
   const inventarioDropdown = hayInventario && (
     <ToolbarDropdown triggerIcon={Package2} label="Inventario" mobileLabel="Inventario">
       <DropdownMenuLabel>Inventario</DropdownMenuLabel>
-      {onControlStock && (
+      {mostrarControlStock && onControlStock && (
         <DropdownMenuItem onSelect={onControlStock}>
           <ClipboardCheck className="w-4 h-4 text-amber-600" />
           <div className="flex flex-col gap-0.5 min-w-0">
@@ -206,7 +217,7 @@ export default function ProductoToolbar({
           </div>
         </DropdownMenuItem>
       )}
-      {onVerHistorialMermas && (
+      {mostrarHistorialMermas && onVerHistorialMermas && (
         <DropdownMenuItem onSelect={onVerHistorialMermas}>
           <TrendingDown className="w-4 h-4 text-rose-600" />
           <span>Historial de mermas</span>

--- a/src/components/vistas/VistaProductos.tsx
+++ b/src/components/vistas/VistaProductos.tsx
@@ -24,6 +24,8 @@ export interface VistaProductosProps {
   proveedores?: ProveedorDBExtended[];
   loading: boolean;
   isAdmin: boolean;
+  /** admin o encargado: habilita stock bajo + control de stock (Excel). */
+  puedeControlarStock?: boolean;
   onNuevoProducto: () => void;
   onEditarProducto: (producto: ProductoDB) => void;
   onEliminarProducto: (id: string) => void;
@@ -42,6 +44,7 @@ export default function VistaProductos({
   proveedores = [],
   loading,
   isAdmin,
+  puedeControlarStock = false,
   onNuevoProducto,
   onEditarProducto,
   onEliminarProducto,
@@ -116,6 +119,7 @@ export default function VistaProductos({
         actions={
           <ProductoToolbar
             isAdmin={isAdmin}
+            puedeControlarStock={puedeControlarStock}
             productosStockBajoCount={productosStockBajo.length}
             onGestionarCategorias={onGestionarCategorias}
             onCambioProducto={onCambioProducto}

--- a/src/lib/permisos.test.ts
+++ b/src/lib/permisos.test.ts
@@ -11,6 +11,7 @@ import {
   puedeAccederPromociones,
   puedeAccederCondicionesMayoristas,
   puedeAccederTransferencias,
+  puedeControlarStock,
   mostrarMontosEnStats,
 } from './permisos'
 import type { RolUsuario } from '@/types'
@@ -51,6 +52,21 @@ describe('permisos por rol', () => {
       expect(puedeAccederDashboard('transportista')).toBe(false)
       expect(puedeAccederDashboard('deposito')).toBe(false)
       expect(puedeAccederDashboard(null)).toBe(false)
+    })
+  })
+
+  describe('puedeControlarStock', () => {
+    it('permite admin y encargado', () => {
+      expect(puedeControlarStock('admin')).toBe(true)
+      expect(puedeControlarStock('encargado')).toBe(true)
+    })
+
+    it('bloquea preventista, transportista, deposito y sin rol', () => {
+      expect(puedeControlarStock('preventista')).toBe(false)
+      expect(puedeControlarStock('transportista')).toBe(false)
+      expect(puedeControlarStock('deposito')).toBe(false)
+      expect(puedeControlarStock(null)).toBe(false)
+      expect(puedeControlarStock(undefined)).toBe(false)
     })
   })
 

--- a/src/lib/permisos.ts
+++ b/src/lib/permisos.ts
@@ -11,6 +11,15 @@ export function puedeEditarProductos(rol: RolUsuario | null | undefined): boolea
   return rol === 'admin'
 }
 
+/**
+ * Si el rol puede controlar el stock: ver el panel de productos con stock bajo
+ * y descargar la planilla de control de stock (Excel). Operacion de solo
+ * lectura, no implica editar productos. Admin y encargado.
+ */
+export function puedeControlarStock(rol: RolUsuario | null | undefined): boolean {
+  return rol === 'admin' || rol === 'encargado'
+}
+
 export function puedeEditarPreciosPedido(rol: RolUsuario | null | undefined): boolean {
   return rol === 'admin'
 }


### PR DESCRIPTION
## Resumen

Habilita al rol **encargado** a ver los productos con stock bajo y descargar la planilla de **control de stock** (Excel) desde `/productos`, sin exponerle las acciones de edición/catálogo reservadas a admin.

Cambios 100% frontend: el encargado ya tenía acceso de lectura a productos vía RLS y la exportación usa datos ya cargados en el cliente. **No requiere migración.**

## Cambios

- **`src/lib/permisos.ts`** — nueva función `puedeControlarStock(rol)` → `admin | encargado` (operación de solo lectura).
- **`ProductoToolbar.tsx`** — desacopla el botón **Stock bajo** y el item **Control de stock** de `isAdmin` mediante el prop `puedeControlarStock`. El **Historial de mermas** sigue siendo admin-only, así que para el encargado el dropdown *Inventario* muestra sólo la descarga de Excel.
- **`VistaProductos.tsx`** — recibe y reenvía `puedeControlarStock` a la toolbar.
- **`ModalStockBajo.tsx`** — `onEditarProducto` ahora opcional: si no se provee (encargado), no se muestra el botón "Editar" por fila → solo lectura.
- **`ProductosContainer.tsx`** — calcula el permiso desde `perfil.rol`, lo pasa a la vista y gatea `onControlStock`/`onAbrirStockBajo`; el "Editar" desde el modal queda admin-only.
- **`permisos.test.ts`** — cobertura del nuevo permiso.

## Resultado para el encargado

En `/productos` ve: el botón **Stock bajo (N)** que abre el modal de reposición (ordenado por urgencia), el toggle "Ver solo stock bajo" en la tabla, y en **Inventario → Control de stock** la descarga del Excel. No ve editar/borrar, catálogo, nuevo producto ni historial de mermas (siguen admin-only).

## Verificación

- `tsc --noEmit`: sin errores
- `vitest run` (suite completa, vía pre-commit): ✓
- `eslint` sobre los archivos cambiados: limpio

🤖 Generated with [Claude Code](https://claude.com/claude-code)
