### PR TITLE
feat(pagos): cuenta corriente deja de ser forma de pago (salvo transportista)

### DIFF
--- a/migrations/074_pagos_forma_pago_no_cuenta_corriente.sql
+++ b/migrations/074_pagos_forma_pago_no_cuenta_corriente.sql
@@ -1,0 +1,22 @@
+-- Migración 074: cuenta_corriente deja de ser una forma de pago válida en `pagos`
+--
+-- Cta Cte no es una forma de pago: es una venta no cobrada. Registrar un pago con
+-- forma_pago='cuenta_corriente' marcaba el pedido como PAGADO (vía el trigger
+-- actualizar_estado_pago_pedido) aunque el cliente no pagó, e inflaba las
+-- rendiciones. La UI ya no ofrece esa opción; este CHECK lo impide a nivel DB
+-- para cualquier origen (UI, bot de Telegram, scripts).
+--
+-- Si el cliente no paga, el flujo correcto es "entregar a cuenta corriente (sin
+-- cobrar)": el pedido queda entregado y el saldo pendiente, SIN registrar un pago.
+--
+-- NOT VALID: no valida las filas existentes (se conserva el pago histórico que ya
+-- tiene 'cuenta_corriente' y el valor legacy 'combinado'); solo aplica a
+-- INSERT/UPDATE nuevos. `IS DISTINCT FROM` tolera forma_pago NULL.
+-- Forward-only y aditivo: no toca datos, saldos, stock ni pedidos.
+
+ALTER TABLE public.pagos
+  DROP CONSTRAINT IF EXISTS pagos_forma_pago_no_cuenta_corriente;
+
+ALTER TABLE public.pagos
+  ADD CONSTRAINT pagos_forma_pago_no_cuenta_corriente
+  CHECK (forma_pago IS DISTINCT FROM 'cuenta_corriente') NOT VALID;

--- a/package-lock.json
+++ b/package-lock.json
@@ -189,6 +189,7 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -1811,6 +1812,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -1854,6 +1856,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -4646,6 +4649,7 @@
       "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.90.20.tgz",
       "integrity": "sha512-vXBxa+qeyveVO7OA0jX1z+DeyCA4JKnThKv411jd5SORpBKgkcVnYKCiBgECvADvniBX7tobwBmg01qq9JmMJw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@tanstack/query-core": "5.90.20"
       },
@@ -4769,8 +4773,7 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -4893,6 +4896,7 @@
       "integrity": "sha512-MWtvHrGZLFttgeEj28VXHxpmwYbor/ATPYbBfSFZEIRK0ecCFLl2Qo55z52Hss+UV9CRN7trSeq1zbgx7YDWWg==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -4903,6 +4907,7 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -4995,6 +5000,7 @@
       "integrity": "sha512-nm3cvFN9SqZGXjmw5bZ6cGmvJSyJPn0wU9gHAZZHDnZl2wF9PhHv78Xf06E0MaNk4zLVHL8hb2/c32XvyJOLQg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.53.1",
         "@typescript-eslint/types": "8.53.1",
@@ -5215,29 +5221,30 @@
       }
     },
     "node_modules/@vitest/coverage-v8": {
-      "version": "4.0.17",
-      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.0.17.tgz",
-      "integrity": "sha512-/6zU2FLGg0jsd+ePZcwHRy3+WpNTBBhDY56P4JTRqUN/Dp6CvOEa9HrikcQ4KfV2b2kAHUFB4dl1SuocWXSFEw==",
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.8.tgz",
+      "integrity": "sha512-lt3kovsyHwYe00wq4D1ti0Z974fWj4NLp6siqiyEufUpyFwK9Yhi7rBhac9JL5aA0zoMrJqc4vYPZRUnI7l7nw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@bcoe/v8-coverage": "^1.0.2",
-        "@vitest/utils": "4.0.17",
-        "ast-v8-to-istanbul": "^0.3.10",
+        "@vitest/utils": "4.1.8",
+        "ast-v8-to-istanbul": "^1.0.0",
         "istanbul-lib-coverage": "^3.2.2",
         "istanbul-lib-report": "^3.0.1",
         "istanbul-reports": "^3.2.0",
-        "magicast": "^0.5.1",
+        "magicast": "^0.5.2",
         "obug": "^2.1.1",
-        "std-env": "^3.10.0",
-        "tinyrainbow": "^3.0.3"
+        "std-env": "^4.0.0-rc.1",
+        "tinyrainbow": "^3.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       },
       "peerDependencies": {
-        "@vitest/browser": "4.0.17",
-        "vitest": "4.0.17"
+        "@vitest/browser": "4.1.8",
+        "vitest": "4.1.8"
       },
       "peerDependenciesMeta": {
         "@vitest/browser": {
@@ -5246,31 +5253,31 @@
       }
     },
     "node_modules/@vitest/expect": {
-      "version": "4.0.17",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.0.17.tgz",
-      "integrity": "sha512-mEoqP3RqhKlbmUmntNDDCJeTDavDR+fVYkSOw8qRwJFaW/0/5zA9zFeTrHqNtcmwh6j26yMmwx2PqUDPzt5ZAQ==",
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.8.tgz",
+      "integrity": "sha512-h3nDO677RDLEGlBxyQ5CW8RlMThSKSRLUePLOx09gNIWRL40edgA1GCZSZgf1W55MFAG6/Sw14KeaAnqv0NKdQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@standard-schema/spec": "^1.0.0",
+        "@standard-schema/spec": "^1.1.0",
         "@types/chai": "^5.2.2",
-        "@vitest/spy": "4.0.17",
-        "@vitest/utils": "4.0.17",
-        "chai": "^6.2.1",
-        "tinyrainbow": "^3.0.3"
+        "@vitest/spy": "4.1.8",
+        "@vitest/utils": "4.1.8",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vitest/mocker": {
-      "version": "4.0.17",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.0.17.tgz",
-      "integrity": "sha512-+ZtQhLA3lDh1tI2wxe3yMsGzbp7uuJSWBM1iTIKCbppWTSBN09PUC+L+fyNlQApQoR+Ps8twt2pbSSXg2fQVEQ==",
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.8.tgz",
+      "integrity": "sha512-LEiN/xe4OSIbKe9HQIp5OC24agGD9J5CnmMgsLohVVoOPWL9a2sBoR6VBx43jQZb7Kr1l4RCuyCJzcAa0+dojw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "4.0.17",
+        "@vitest/spy": "4.1.8",
         "estree-walker": "^3.0.3",
         "magic-string": "^0.30.21"
       },
@@ -5279,7 +5286,7 @@
       },
       "peerDependencies": {
         "msw": "^2.4.9",
-        "vite": "^6.0.0 || ^7.0.0-0"
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
       },
       "peerDependenciesMeta": {
         "msw": {
@@ -5291,26 +5298,26 @@
       }
     },
     "node_modules/@vitest/pretty-format": {
-      "version": "4.0.17",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.0.17.tgz",
-      "integrity": "sha512-Ah3VAYmjcEdHg6+MwFE17qyLqBHZ+ni2ScKCiW2XrlSBV4H3Z7vYfPfz7CWQ33gyu76oc0Ai36+kgLU3rfF4nw==",
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.8.tgz",
+      "integrity": "sha512-9GasEBxpZ1VYIpqHf/0+YGg121uSNwCKOJqIrTwWP/TB7DmFCiaBpNl3aPZzoLWfWkuqhbH8vJIVobZkvdo2cA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "tinyrainbow": "^3.0.3"
+        "tinyrainbow": "^3.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "4.0.17",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.0.17.tgz",
-      "integrity": "sha512-JmuQyf8aMWoo/LmNFppdpkfRVHJcsgzkbCA+/Bk7VfNH7RE6Ut2qxegeyx2j3ojtJtKIbIGy3h+KxGfYfk28YQ==",
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.8.tgz",
+      "integrity": "sha512-EmVxeBAfMJvycdjd6Hm+RbFBbA9fKvo0Kx37hNpBYoYeavH3RNsBXWDooR1mgD52dCrxIIuP7UotpfiwOikvcg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "4.0.17",
+        "@vitest/utils": "4.1.8",
         "pathe": "^2.0.3"
       },
       "funding": {
@@ -5318,13 +5325,14 @@
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "4.0.17",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.0.17.tgz",
-      "integrity": "sha512-npPelD7oyL+YQM2gbIYvlavlMVWUfNNGZPcu0aEUQXt7FXTuqhmgiYupPnAanhKvyP6Srs2pIbWo30K0RbDtRQ==",
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.8.tgz",
+      "integrity": "sha512-acfZboRmAIf05DEKcBQy33VXojFJjtUdLyo7oOmV9kebb2xdU01UknNiPuPZoJZQyO7DF0gZdTGTpeAzET9QPQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.0.17",
+        "@vitest/pretty-format": "4.1.8",
+        "@vitest/utils": "4.1.8",
         "magic-string": "^0.30.21",
         "pathe": "^2.0.3"
       },
@@ -5333,9 +5341,9 @@
       }
     },
     "node_modules/@vitest/spy": {
-      "version": "4.0.17",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.0.17.tgz",
-      "integrity": "sha512-I1bQo8QaP6tZlTomQNWKJE6ym4SHf3oLS7ceNjozxxgzavRAgZDc06T7kD8gb9bXKEgcLNt00Z+kZO6KaJ62Ew==",
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.8.tgz",
+      "integrity": "sha512-6EevtBp6OZOPF7bmz36HrGMeP3txgVSrgebWxHOafDXGkhIzfXK14f8KF6MuFfgXXUeHxmpD3BQxkV00/3s5mA==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -5343,14 +5351,15 @@
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "4.0.17",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.0.17.tgz",
-      "integrity": "sha512-RG6iy+IzQpa9SB8HAFHJ9Y+pTzI+h8553MrciN9eC6TFBErqrQaTas4vG+MVj8S4uKk8uTT2p0vgZPnTdxd96w==",
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.8.tgz",
+      "integrity": "sha512-uOJamYALNhfJ6iolExyQM40yIQwDqYnkKtQ5VCiSe17E33H0aQ/u+1GlRuz4LZBk6Mm3sg90G9hEbmEt37C1Zg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.0.17",
-        "tinyrainbow": "^3.0.3"
+        "@vitest/pretty-format": "4.1.8",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
@@ -5362,6 +5371,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -5395,6 +5405,7 @@
       "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -5637,21 +5648,21 @@
       }
     },
     "node_modules/ast-v8-to-istanbul": {
-      "version": "0.3.10",
-      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-0.3.10.tgz",
-      "integrity": "sha512-p4K7vMz2ZSk3wN8l5o3y2bJAoZXT3VuJI5OLTATY/01CYWumWvwkUw0SqDBnNq6IiTO3qDa1eSQDibAV8g7XOQ==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.3.tgz",
+      "integrity": "sha512-jCMQ6ZylLPudp0CDfBmQBZUsrh1/8psbmu9ibeVWKuHWD0YrH9YABwlKu5kVEFoT0GCQQW9Z/SxfuEbbkGQCRg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/trace-mapping": "^0.3.31",
         "estree-walker": "^3.0.3",
-        "js-tokens": "^9.0.1"
+        "js-tokens": "^10.0.0"
       }
     },
     "node_modules/ast-v8-to-istanbul/node_modules/js-tokens": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
-      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
       "dev": true,
       "license": "MIT"
     },
@@ -5941,6 +5952,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -6685,8 +6697,7 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/dompurify": {
       "version": "3.4.2",
@@ -6913,9 +6924,9 @@
       }
     },
     "node_modules/es-module-lexer": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
-      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+      "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -7037,6 +7048,7 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -8720,6 +8732,7 @@
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -8749,6 +8762,7 @@
       "integrity": "sha512-mjzqwWRD9Y1J1KUi7W97Gja1bwOOM5Ug0EZ6UDK3xS7j7mndrkwozHtSblfomlzyB4NepioNt+B2sOSzczVgtQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@acemir/cssom": "^0.9.28",
         "@asamuzakjp/dom-selector": "^6.7.6",
@@ -9269,7 +9283,6 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -9285,14 +9298,14 @@
       }
     },
     "node_modules/magicast": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.1.tgz",
-      "integrity": "sha512-xrHS24IxaLrvuo613F719wvOIv9xPHFWQHuvGUBmPnCA/3MQxKI3b+r7n1jAoDHmsbC5bRhTZYR77invLAxVnw==",
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.3.tgz",
+      "integrity": "sha512-pVKE4UdSQ7DvHzivsCIFx2BJn1mHG6KsyrFcaxFx6tONdneEuThrDx0Cj3AMg58KyN4pzYT+LHOotxDQDjNvkw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.28.5",
-        "@babel/types": "^7.28.5",
+        "@babel/parser": "^7.29.3",
+        "@babel/types": "^7.29.0",
         "source-map-js": "^1.2.1"
       }
     },
@@ -9935,6 +9948,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -10107,7 +10121,6 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -10123,7 +10136,6 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -10200,6 +10212,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.3.tgz",
       "integrity": "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -10209,6 +10222,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -10221,8 +10235,7 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/react-refresh": {
       "version": "0.18.0",
@@ -10648,6 +10661,7 @@
       "integrity": "sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -11208,9 +11222,9 @@
       }
     },
     "node_modules/std-env": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
-      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -11744,9 +11758,9 @@
       }
     },
     "node_modules/tinyrainbow": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.0.3.tgz",
-      "integrity": "sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -11966,6 +11980,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -12240,6 +12255,7 @@
       "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -12341,31 +12357,32 @@
       }
     },
     "node_modules/vitest": {
-      "version": "4.0.17",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.0.17.tgz",
-      "integrity": "sha512-FQMeF0DJdWY0iOnbv466n/0BudNdKj1l5jYgl5JVTwjSsZSlqyXFt/9+1sEyhR6CLowbZpV7O1sCHrzBhucKKg==",
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.8.tgz",
+      "integrity": "sha512-flY6ScbCIt9HThs+C5HS7jvGOB560DJtk/Z15IQROTA6zEy49Nh8T/dofWTQL+n3vswqn87sbJNiuqw1SDp5Ig==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
-        "@vitest/expect": "4.0.17",
-        "@vitest/mocker": "4.0.17",
-        "@vitest/pretty-format": "4.0.17",
-        "@vitest/runner": "4.0.17",
-        "@vitest/snapshot": "4.0.17",
-        "@vitest/spy": "4.0.17",
-        "@vitest/utils": "4.0.17",
-        "es-module-lexer": "^1.7.0",
-        "expect-type": "^1.2.2",
+        "@vitest/expect": "4.1.8",
+        "@vitest/mocker": "4.1.8",
+        "@vitest/pretty-format": "4.1.8",
+        "@vitest/runner": "4.1.8",
+        "@vitest/snapshot": "4.1.8",
+        "@vitest/spy": "4.1.8",
+        "@vitest/utils": "4.1.8",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
         "magic-string": "^0.30.21",
         "obug": "^2.1.1",
         "pathe": "^2.0.3",
         "picomatch": "^4.0.3",
-        "std-env": "^3.10.0",
+        "std-env": "^4.0.0-rc.1",
         "tinybench": "^2.9.0",
         "tinyexec": "^1.0.2",
         "tinyglobby": "^0.2.15",
-        "tinyrainbow": "^3.0.3",
-        "vite": "^6.0.0 || ^7.0.0",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
         "why-is-node-running": "^2.3.0"
       },
       "bin": {
@@ -12381,12 +12398,15 @@
         "@edge-runtime/vm": "*",
         "@opentelemetry/api": "^1.9.0",
         "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
-        "@vitest/browser-playwright": "4.0.17",
-        "@vitest/browser-preview": "4.0.17",
-        "@vitest/browser-webdriverio": "4.0.17",
-        "@vitest/ui": "4.0.17",
+        "@vitest/browser-playwright": "4.1.8",
+        "@vitest/browser-preview": "4.1.8",
+        "@vitest/browser-webdriverio": "4.1.8",
+        "@vitest/coverage-istanbul": "4.1.8",
+        "@vitest/coverage-v8": "4.1.8",
+        "@vitest/ui": "4.1.8",
         "happy-dom": "*",
-        "jsdom": "*"
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
       },
       "peerDependenciesMeta": {
         "@edge-runtime/vm": {
@@ -12407,6 +12427,12 @@
         "@vitest/browser-webdriverio": {
           "optional": true
         },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
         "@vitest/ui": {
           "optional": true
         },
@@ -12415,6 +12441,9 @@
         },
         "jsdom": {
           "optional": true
+        },
+        "vite": {
+          "optional": false
         }
       }
     },
@@ -12834,6 +12863,7 @@
       "integrity": "sha512-cIFJOD1DESzpjOBl763Kp1AH7UE/0fcdHe6rZXUdQ9c50uvgigvW97u3IcSeBwOkgqL/PXPBktBCh0KEu5L8XQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "rollup": "dist/bin/rollup"
       },
@@ -13213,6 +13243,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.5.tgz",
       "integrity": "sha512-k7Nwx6vuWx1IJ9Bjuf4Zt1PEllcwe7cls3VNzm4CQ1/hgtFUK2bRNG3rvnpPUhFjmqJKAKtjV576KnUkHocg/g==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/components/containers/PedidosContainer.tsx
+++ b/src/components/containers/PedidosContainer.tsx
@@ -733,6 +733,21 @@ export default function PedidosContainer(): React.ReactElement {
     setGuardando(false)
   }, [pedidoEntregaConPago, cambiarEstado, queryClient, notify])
 
+  // Flujo transportista: "Entregar a cuenta corriente (sin cobrar)" desde el
+  // modal de cobranza. Marca entregado sin registrar pago (el saldo queda
+  // pendiente = deuda del cliente). Repropaga el error para que el modal del
+  // transportista quede abierto y permita reintentar (importante sin red).
+  const handleEntregarSinCobrar = useCallback(async (pedido: PedidoDB) => {
+    try {
+      await cambiarEstado.mutateAsync({ pedidoId: pedido.id, nuevoEstado: 'entregado' })
+      queryClient.invalidateQueries({ queryKey: ['pedidos'] })
+      notify.success('Entregado a cuenta corriente (sin cobrar)')
+    } catch (e) {
+      notify.error((e as Error).message)
+      throw e
+    }
+  }, [cambiarEstado, queryClient, notify])
+
   // Modo entrega transportista: "Entregar y registrar pago" → cambia estado y registra pagos.
   // Orden: primero entrega (mas critica), luego pagos. Si falla algun pago, queda
   // entregado y el usuario puede usar "Registrar Pago" desde el dropdown.
@@ -1166,6 +1181,7 @@ export default function PedidosContainer(): React.ReactElement {
           onRegistrarSalvedad={handleRegistrarSalvedadSingle}
           onRegistrarPago={handleRegistrarPagoTransportista}
           onAbrirPagoPedido={handleAbrirRegistrarPago}
+          onEntregarSinCobrar={handleEntregarSinCobrar}
         />
       </Suspense>
 

--- a/src/components/modals/ModalCompra.tsx
+++ b/src/components/modals/ModalCompra.tsx
@@ -231,11 +231,13 @@ interface CalculosImpuestos {
 }
 
 // Constantes
+// Nota: `cuenta_corriente` ya no se ofrece como forma de pago (no es una forma
+// de pago real). Las compras históricas con ese valor se siguen mostrando bien
+// en ModalDetalleCompra; el mapeo del escaneo de factura lo conserva.
 const FORMAS_PAGO = [
   { value: 'efectivo', label: 'Efectivo' },
   { value: 'transferencia', label: 'Transferencia' },
   { value: 'cheque', label: 'Cheque' },
-  { value: 'cuenta_corriente', label: 'Cuenta Corriente' },
   { value: 'tarjeta', label: 'Tarjeta' }
 ]
 

--- a/src/components/modals/ModalPagoPedido.tsx
+++ b/src/components/modals/ModalPagoPedido.tsx
@@ -21,6 +21,7 @@ import { Loader2, DollarSign, Plus, Trash2, AlertCircle, X } from 'lucide-react'
 import ModalBase from './ModalBase'
 import { formatPrecio, fechaLocalISO, formatDateTime, getFormaPagoLabel } from '../../utils/formatters'
 import { parsePrecio } from '../../utils/calculations'
+import { FORMAS_PAGO_SELECCIONABLES } from '../../constants/formasPago'
 import type { PedidoDB, PagoDBWithUsuario } from '../../types'
 
 export interface PagoPedidoPayload {
@@ -57,14 +58,12 @@ interface LineaPago {
   monto: string
 }
 
-const FORMAS_PAGO_OPCIONES: Array<{ value: string; label: string }> = [
-  { value: 'efectivo', label: 'Efectivo' },
-  { value: 'transferencia', label: 'Transferencia' },
-  { value: 'cheque', label: 'Cheque' },
-  { value: 'cuenta_corriente', label: 'Cuenta Corriente' },
-  { value: 'tarjeta', label: 'Tarjeta' },
-  { value: 'vale_blanco', label: 'Vale Blanco' },
-]
+// Opciones de forma de pago seleccionables. `cuenta_corriente` ya no se ofrece:
+// registrar un "pago" en cuenta corriente marcaba el pedido como pagado sin que
+// el cliente pagara. Si el cliente no paga, se usa "Entregar a cuenta corriente
+// (sin cobrar)" (no crea pago, deja saldo pendiente).
+const FORMAS_PAGO_OPCIONES: Array<{ value: string; label: string }> =
+  FORMAS_PAGO_SELECCIONABLES.map(m => ({ value: m.value, label: m.label }))
 
 const ModalPagoPedido = memo(function ModalPagoPedido({
   pedido,
@@ -243,6 +242,11 @@ const ModalPagoPedido = memo(function ModalPagoPedido({
                               aria-label="Editar forma de pago"
                               title="Editar forma de pago"
                             >
+                              {/* Pago histórico con forma ya no seleccionable (ej: cuenta_corriente):
+                                  se muestra deshabilitada para no cambiarla en silencio. */}
+                              {p.forma_pago && !FORMAS_PAGO_OPCIONES.some(o => o.value === p.forma_pago) && (
+                                <option value={p.forma_pago} disabled>{getFormaPagoLabel(p.forma_pago)}</option>
+                              )}
                               {FORMAS_PAGO_OPCIONES.map(o => (
                                 <option key={o.value} value={o.value}>{o.label}</option>
                               ))}
@@ -395,7 +399,7 @@ const ModalPagoPedido = memo(function ModalPagoPedido({
             className="px-4 py-2 bg-amber-600 text-white rounded-lg hover:bg-amber-700 flex items-center disabled:opacity-50"
           >
             {guardando && <Loader2 className="w-4 h-4 mr-2 animate-spin" />}
-            Entregar sin pago
+            Entregar a cuenta corriente (sin cobrar)
           </button>
         )}
         {saldoPendiente > 0 && (

--- a/src/components/modals/ModalPagosMasivos.tsx
+++ b/src/components/modals/ModalPagosMasivos.tsx
@@ -3,7 +3,7 @@ import { Loader2, Search, Calendar, AlertTriangle } from 'lucide-react'
 import ModalBase from './ModalBase'
 import { usePedidosNoPagadosQuery, useRendicionCerradaQuery } from '../../hooks/queries'
 import { getEstadoPagoColor, getEstadoPagoLabel, formatPrecio, fechaLocalISO } from '../../utils/formatters'
-import { FORMAS_PAGO } from '../../constants/formasPago'
+import { FORMAS_PAGO_SELECCIONABLES } from '../../constants/formasPago'
 
 export interface ModalPagosMasivosProps {
   /**
@@ -102,7 +102,7 @@ const ModalPagosMasivos = memo(function ModalPagosMasivos({
               className="w-full px-3 py-2 border rounded-lg dark:bg-gray-700 dark:border-gray-600 dark:text-white"
             >
               <option value="">Seleccionar forma de pago...</option>
-              {FORMAS_PAGO.filter(fp => fp.value !== 'otros').map(fp => (
+              {FORMAS_PAGO_SELECCIONABLES.map(fp => (
                 <option key={fp.value} value={fp.value}>{fp.label}</option>
               ))}
             </select>

--- a/src/components/modals/ModalPedido.tsx
+++ b/src/components/modals/ModalPedido.tsx
@@ -782,7 +782,6 @@ const ModalPedido = memo(function ModalPedido({
                         <option value="efectivo">Efectivo</option>
                         <option value="transferencia">Transferencia</option>
                         <option value="cheque">Cheque</option>
-                        <option value="cuenta_corriente">Cuenta Corriente</option>
                         <option value="tarjeta">Tarjeta</option>
                       </select>
                     </div>

--- a/src/components/modals/ModalRegistrarPago.tsx
+++ b/src/components/modals/ModalRegistrarPago.tsx
@@ -58,6 +58,12 @@ export interface ModalRegistrarPagoProps {
    */
   onConfirmarFIFO?: (input: RegistrarPagoFifoInput) => Promise<RegistrarPagoFifoResult>;
   onGenerarRecibo?: (pago: PagoRegistrado, cliente: Cliente) => void;
+  /**
+   * Si se provee, muestra el botón "Entregar a cuenta corriente (sin cobrar)"
+   * (flujo del transportista al entregar): entrega sin registrar pago. Debe
+   * rechazar (throw) si falla para mantener el modal abierto.
+   */
+  onEntregarSinCobrar?: () => void | Promise<void>;
 }
 
 export default function ModalRegistrarPago({
@@ -67,7 +73,8 @@ export default function ModalRegistrarPago({
   onClose,
   onConfirmar,
   onConfirmarFIFO,
-  onGenerarRecibo
+  onGenerarRecibo,
+  onEntregarSinCobrar
 }: ModalRegistrarPagoProps): React.ReactElement | null {
   // Zod validation hook
   const { validate, getFirstError } = useZodValidation(modalPagoSchema)
@@ -209,6 +216,20 @@ export default function ModalRegistrarPago({
   const handleMontoPreset = (porcentaje: number): void => {
     if (saldoPendiente) {
       setMonto((saldoPendiente * porcentaje / 100).toFixed(2))
+    }
+  }
+
+  const handleEntregarSinCobrar = async (): Promise<void> => {
+    if (!onEntregarSinCobrar) return
+    setError('')
+    setLoading(true)
+    try {
+      await onEntregarSinCobrar()
+    } catch (err) {
+      // El padre ya notifica el error; mantenemos el modal abierto para reintentar.
+      setError(err instanceof Error ? err.message : 'Error al entregar')
+    } finally {
+      setLoading(false)
     }
   }
 
@@ -585,28 +606,42 @@ export default function ModalRegistrarPago({
           </div>
 
           {/* Actions */}
-          <div className="flex-shrink-0 flex gap-3 p-4 sm:p-6 pt-4 border-t border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 rounded-b-2xl pb-[max(1rem,env(safe-area-inset-bottom))]">
-            <button
-              type="button"
-              onClick={onClose}
-              className="flex-1 px-4 py-3 bg-gray-100 hover:bg-gray-200 dark:bg-gray-700 dark:hover:bg-gray-600 text-gray-900 dark:text-white rounded-lg font-medium"
-            >
-              Cancelar
-            </button>
-            <button
-              type="submit"
-              disabled={loading || (pagoDividido ? totalDividido <= 0 : !monto)}
-              className="flex-1 px-4 py-3 bg-green-600 hover:bg-green-700 disabled:opacity-50 text-white rounded-lg font-medium flex items-center justify-center gap-2"
-            >
-              {loading ? (
-                <div className="animate-spin rounded-full h-5 w-5 border-b-2 border-white" />
-              ) : (
-                <>
-                  <Check className="w-5 h-5" />
-                  Registrar
-                </>
-              )}
-            </button>
+          <div className="flex-shrink-0 flex flex-col gap-3 p-4 sm:p-6 pt-4 border-t border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 rounded-b-2xl pb-[max(1rem,env(safe-area-inset-bottom))]">
+            {/* Flujo transportista: entregar dejando el saldo a cuenta corriente,
+                sin registrar pago. Solo aparece si el caller provee el handler. */}
+            {onEntregarSinCobrar && (
+              <button
+                type="button"
+                onClick={() => { void handleEntregarSinCobrar() }}
+                disabled={loading}
+                className="w-full px-4 py-3 bg-amber-100 hover:bg-amber-200 dark:bg-amber-900/30 dark:hover:bg-amber-900/50 text-amber-800 dark:text-amber-300 rounded-lg font-medium disabled:opacity-50"
+              >
+                Entregar a cuenta corriente (sin cobrar)
+              </button>
+            )}
+            <div className="flex gap-3">
+              <button
+                type="button"
+                onClick={onClose}
+                className="flex-1 px-4 py-3 bg-gray-100 hover:bg-gray-200 dark:bg-gray-700 dark:hover:bg-gray-600 text-gray-900 dark:text-white rounded-lg font-medium"
+              >
+                Cancelar
+              </button>
+              <button
+                type="submit"
+                disabled={loading || (pagoDividido ? totalDividido <= 0 : !monto)}
+                className="flex-1 px-4 py-3 bg-green-600 hover:bg-green-700 disabled:opacity-50 text-white rounded-lg font-medium flex items-center justify-center gap-2"
+              >
+                {loading ? (
+                  <div className="animate-spin rounded-full h-5 w-5 border-b-2 border-white" />
+                ) : (
+                  <>
+                    <Check className="w-5 h-5" />
+                    Registrar
+                  </>
+                )}
+              </button>
+            </div>
           </div>
         </form>
       </div>

--- a/src/components/pedidos/VistaRutaTransportista.tsx
+++ b/src/components/pedidos/VistaRutaTransportista.tsx
@@ -43,6 +43,12 @@ export interface VistaRutaTransportistaProps {
     notas: string;
     fecha: string;
   }) => Promise<unknown>;
+  /**
+   * Entregar a cuenta corriente (sin cobrar): marca el pedido como entregado
+   * sin registrar pago, dejando el saldo pendiente. Debe rechazar (throw) si
+   * falla para que el modal quede abierto y permita reintentar.
+   */
+  onEntregarSinCobrar?: (pedido: PedidoDB) => void | Promise<void>;
 }
 
 interface PedidoEnriquecido extends PedidoDB {
@@ -261,7 +267,8 @@ function VistaRutaTransportista({
   clientes,
   productos,
   onRegistrarSalvedad,
-  onRegistrarPago
+  onRegistrarPago,
+  onEntregarSinCobrar
 }: VistaRutaTransportistaProps): React.ReactElement {
   // Estado para modal de salvedad
   const [salvedadModal, setSalvedadModal] = useState<{
@@ -369,6 +376,17 @@ function VistaRutaTransportista({
       onMarcarEntregado(pedido as PedidoDB);
     }
     pagoExitosoRef.current = false;
+  };
+
+  // Entregar a cuenta corriente (sin cobrar): entrega el pedido sin registrar
+  // pago. El saldo queda pendiente (deuda del cliente). Si falla, propaga el
+  // error para que el modal siga abierto y se pueda reintentar.
+  const handleEntregarSinCobrar = async (): Promise<void> => {
+    const pedido = pedidoParaCobrar;
+    if (!pedido || !onEntregarSinCobrar) return;
+    pagoExitosoRef.current = false;
+    await onEntregarSinCobrar(pedido as PedidoDB);
+    setPedidoParaCobrar(null);
   };
 
   const handleReportarSalvedad = (pedidoId: string, item: PedidoItemDB & { producto?: ProductoDB }): void => {
@@ -511,6 +529,7 @@ function VistaRutaTransportista({
           pedidos={[pedidoParaCobrar as unknown as import('../../types').Pedido]}
           onClose={handleCerrarModalPago}
           onConfirmar={handleConfirmarPago}
+          onEntregarSinCobrar={onEntregarSinCobrar ? handleEntregarSinCobrar : undefined}
         />
       )}
 

--- a/src/components/vistas/VistaPedidos.tsx
+++ b/src/components/vistas/VistaPedidos.tsx
@@ -95,6 +95,11 @@ export interface VistaPedidosProps {
   }) => Promise<unknown>;
   /** Handler para abrir ModalPagoPedido desde el dropdown del PedidoCard. */
   onAbrirPagoPedido?: (pedido: PedidoDB) => void;
+  /**
+   * Handler para que el transportista entregue a cuenta corriente (sin cobrar):
+   * marca el pedido como entregado sin registrar pago, dejando el saldo pendiente.
+   */
+  onEntregarSinCobrar?: (pedido: PedidoDB) => void | Promise<void>;
 }
 
 export default function VistaPedidos({
@@ -143,6 +148,7 @@ export default function VistaPedidos({
   onRegistrarSalvedad,
   onRegistrarPago,
   onAbrirPagoPedido,
+  onEntregarSinCobrar,
 }: VistaPedidosProps) {
   // Si es transportista, mostrar vista especial de ruta
   if (isTransportista && !isAdmin && !isPreventista) {
@@ -155,6 +161,7 @@ export default function VistaPedidos({
         productos={productos}
         onRegistrarSalvedad={onRegistrarSalvedad}
         onRegistrarPago={onRegistrarPago}
+        onEntregarSinCobrar={onEntregarSinCobrar}
       />
     );
   }

--- a/src/constants/formasPago.test.ts
+++ b/src/constants/formasPago.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest'
+import {
+  FORMAS_PAGO,
+  FORMAS_PAGO_SELECCIONABLES,
+  formaPagoLabel,
+  formaPagoMeta,
+} from './formasPago'
+
+describe('formas de pago seleccionables', () => {
+  it('excluye cuenta_corriente y otros del set seleccionable', () => {
+    const values = FORMAS_PAGO_SELECCIONABLES.map((m) => m.value)
+    expect(values).not.toContain('cuenta_corriente')
+    expect(values).not.toContain('otros')
+  })
+
+  it('incluye las formas de pago reales', () => {
+    const values = FORMAS_PAGO_SELECCIONABLES.map((m) => m.value)
+    expect(values).toEqual(
+      expect.arrayContaining(['efectivo', 'transferencia', 'cheque', 'tarjeta', 'vale_blanco']),
+    )
+  })
+
+  it('toda forma seleccionable tiene seleccionable=true', () => {
+    expect(FORMAS_PAGO_SELECCIONABLES.every((m) => m.seleccionable)).toBe(true)
+  })
+})
+
+describe('cuenta_corriente se conserva para etiquetas/reportes históricos', () => {
+  it('sigue teniendo etiqueta legible aunque no sea seleccionable', () => {
+    expect(formaPagoLabel('cuenta_corriente')).toBe('Cuenta corriente')
+    expect(formaPagoMeta('cuenta_corriente').seleccionable).toBe(false)
+  })
+
+  it('cuenta_corriente sigue presente en el catálogo completo FORMAS_PAGO', () => {
+    const values = FORMAS_PAGO.map((m) => m.value)
+    expect(values).toContain('cuenta_corriente')
+  })
+})

--- a/src/constants/formasPago.ts
+++ b/src/constants/formasPago.ts
@@ -18,16 +18,23 @@ export interface FormaPagoMeta {
   color: string
   /** Etiqueta corta para tarjetas con poco espacio */
   short: string
+  /**
+   * Si se puede ELEGIR como forma de pago en los selectores de cobranza/compra.
+   * `cuenta_corriente` no es una forma de pago real (es una venta no cobrada): se
+   * conserva en este set solo para etiquetas y reportes históricos, pero no debe
+   * ofrecerse como opción. `otros` tampoco es seleccionable (bucket de fallback).
+   */
+  seleccionable: boolean
 }
 
 export const FORMAS_PAGO: readonly FormaPagoMeta[] = [
-  { value: 'efectivo', label: 'Efectivo', short: 'Ef.', color: 'emerald' },
-  { value: 'transferencia', label: 'Transferencia', short: 'Transf.', color: 'sky' },
-  { value: 'cheque', label: 'Cheque', short: 'Ch.', color: 'purple' },
-  { value: 'cuenta_corriente', label: 'Cuenta corriente', short: 'Cta. Cte.', color: 'amber' },
-  { value: 'tarjeta', label: 'Tarjeta', short: 'Tj.', color: 'indigo' },
-  { value: 'vale_blanco', label: 'Vale Blanco', short: 'V.B.', color: 'rose' },
-  { value: 'otros', label: 'Otros', short: 'Otros', color: 'slate' }
+  { value: 'efectivo', label: 'Efectivo', short: 'Ef.', color: 'emerald', seleccionable: true },
+  { value: 'transferencia', label: 'Transferencia', short: 'Transf.', color: 'sky', seleccionable: true },
+  { value: 'cheque', label: 'Cheque', short: 'Ch.', color: 'purple', seleccionable: true },
+  { value: 'cuenta_corriente', label: 'Cuenta corriente', short: 'Cta. Cte.', color: 'amber', seleccionable: false },
+  { value: 'tarjeta', label: 'Tarjeta', short: 'Tj.', color: 'indigo', seleccionable: true },
+  { value: 'vale_blanco', label: 'Vale Blanco', short: 'V.B.', color: 'rose', seleccionable: true },
+  { value: 'otros', label: 'Otros', short: 'Otros', color: 'slate', seleccionable: false }
 ] as const
 
 const FORMAS_PAGO_MAP: Record<FormaPago, FormaPagoMeta> = FORMAS_PAGO.reduce(
@@ -50,3 +57,13 @@ export function formaPagoLabel(value: FormaPago | string | null | undefined): st
 }
 
 export const FORMA_PAGO_VALUES: readonly FormaPago[] = FORMAS_PAGO.map((m) => m.value)
+
+/**
+ * Formas de pago que SÍ se pueden elegir en los selectores (cobranza, pedido,
+ * compra). Excluye `cuenta_corriente` (no es una forma de pago: es una venta no
+ * cobrada) y `otros` (bucket de fallback). Usar esto para poblar `<select>`/
+ * botones; usar `FORMAS_PAGO`/`formaPagoLabel` para mostrar valores históricos.
+ */
+export const FORMAS_PAGO_SELECCIONABLES: readonly FormaPagoMeta[] = FORMAS_PAGO.filter(
+  (m) => m.seleccionable,
+)

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -224,6 +224,9 @@ export const pedidoSchema = z.object({
     .array(itemPedidoSchema)
     .min(1, { message: 'Debe agregar al menos un producto' }),
 
+  // `cuenta_corriente` es legacy: ya no se ofrece en la UI (no es una forma de
+  // pago real). Se mantiene en el enum solo para no rechazar la validación al
+  // editar pedidos históricos que ya tienen ese valor.
   forma_pago: z.enum(['efectivo', 'transferencia', 'cheque', 'cuenta_corriente', 'tarjeta', 'vale_blanco'], {
     error: 'Forma de pago inválida'
   }),
@@ -313,6 +316,9 @@ export const compraSchema = z.object({
 
   fecha_compra: z.string().min(1, { message: 'La fecha es obligatoria' }),
 
+  // `cuenta_corriente` es legacy: ya no se ofrece en la UI de compras. Se
+  // mantiene en el enum solo para no rechazar la validación al editar compras
+  // históricas (o valores provenientes del escaneo de factura) que ya lo tengan.
   forma_pago: z.enum(['efectivo', 'transferencia', 'cheque', 'cuenta_corriente', 'tarjeta'], {
     error: 'Forma de pago inválida'
   }),


### PR DESCRIPTION
## Contexto

"Cuenta corriente" (Cta Cte) aparecía como **forma de pago** en varios selectores, lo que confunde a los usuarios: **no es una forma de pago**, es una venta no cobrada. Peor: registrar un "pago" con forma `cuenta_corriente` marcaba el pedido como **PAGADO** aunque el cliente no pagó, e inflaba los totales de rendición.

## Cambios

**Se quita "Cuenta corriente" de los selectores de forma de pago:**
- Crear/editar pedido (`ModalPedido`)
- Registrar pago de pedido (`ModalPagoPedido`)
- Pagos masivos (`ModalPagosMasivos`)
- Compras a proveedor (`ModalCompra`)

**Transportista — nueva capacidad "entregar sin cobrar":** al marcar entregado un pedido impago, aparece el botón **"Entregar a cuenta corriente (sin cobrar)"** que marca el pedido como entregado **sin** registrar pago (el saldo queda pendiente = deuda real del cliente). Antes el transportista ni siquiera podía entregar sin cobrar. Para admin/encargado se renombró el botón equivalente por consistencia.

**Una sola fuente de verdad:** `FORMAS_PAGO_SELECCIONABLES` en `src/constants/formasPago.ts` (campo `seleccionable`). La etiqueta "Cuenta corriente" se conserva para mostrar registros históricos y para el bucket de rendiciones (`total_cuenta_corriente`).

**Retrocompatibilidad:** schemas (`pedidoSchema`/`compraSchema`) y constraints de DB quedan permisivos para no romper la edición de registros históricos. En `ModalPagoPedido`, un pago histórico en cuenta corriente se muestra como opción **deshabilitada** (no se pisa al editar).

## Consecuencias documentadas
- **Compras:** la tabla no tiene `estado_pago`/`saldo`, así que `cuenta_corriente` era el único marcador de "compra a crédito". Las compras nuevas ya no pueden marcarse a crédito (ningún reporte se rompe hoy). Comentado en el código.
- **Rendiciones:** la celda "Cuenta Cte." mostrará \$0 para datos nuevos (históricos intactos). Queda como mejora de seguimiento ocultarla o reemplazarla por `total_ctascte`.

## Verificación
- `npm run typecheck` ✅
- `npm run lint` ✅
- `npm run test:run` ✅ (683 tests previos + 5 nuevos)

🤖 Generated with [Claude Code](https://claude.com/claude-code)