### PR TITLE
feat(cuenta-corriente): mora desde fecha de entrega + panel de deudores

### DIFF
--- a/migrations/075_obtener_deudores_mora.sql
+++ b/migrations/075_obtener_deudores_mora.sql
@@ -1,0 +1,74 @@
+-- Migración 075: RPC obtener_deudores_mora
+--
+-- Lista los clientes en mora de la sucursal activa. La mora se cuenta desde la
+-- FECHA DE ENTREGA (no desde la creación del pedido): días vencido =
+-- hoy - (fecha_entrega + dias_credito del cliente). Solo cuentan pedidos
+-- ENTREGADOS e impagos; los no entregados todavía no generan mora.
+-- Para pedidos entregados sin fecha_entrega (datos viejos) se usa pedidos.fecha.
+--
+-- Devuelve, por cliente con al menos un pedido vencido >= p_dias_min días:
+--   saldo (saldo_cuenta total), saldo_vencido (suma de pedidos entregados
+--   impagos en mora), dias_mora_max (atraso del más viejo) y la fecha base de
+--   ese pedido. Orden: más atrasado primero.
+--
+-- Gate: es_encargado_o_admin() + current_sucursal_id(). SECURITY DEFINER.
+
+CREATE OR REPLACE FUNCTION public.obtener_deudores_mora(p_dias_min integer DEFAULT 1)
+RETURNS TABLE(
+  cliente_id bigint,
+  nombre text,
+  saldo numeric,
+  saldo_vencido numeric,
+  dias_mora_max integer,
+  pedido_mas_viejo date
+)
+LANGUAGE plpgsql
+STABLE SECURITY DEFINER
+SET search_path TO 'public'
+AS $function$
+DECLARE
+  v_sucursal_id bigint;
+BEGIN
+  v_sucursal_id := current_sucursal_id();
+  IF v_sucursal_id IS NULL THEN
+    RAISE EXCEPTION 'Sucursal no seleccionada';
+  END IF;
+  IF NOT es_encargado_o_admin() THEN
+    RAISE EXCEPTION 'No autorizado';
+  END IF;
+
+  RETURN QUERY
+  WITH pedidos_vencidos AS (
+    SELECT
+      p.cliente_id AS cli_id,
+      (p.total - COALESCE(p.monto_pagado, 0)) AS saldo_pedido,
+      COALESCE(p.fecha_entrega::date, p.fecha) AS base_date,
+      (CURRENT_DATE
+        - (COALESCE(p.fecha_entrega::date, p.fecha) + COALESCE(c.dias_credito, 30)))::int AS dias_mora
+    FROM pedidos p
+    JOIN clientes c ON c.id = p.cliente_id
+    WHERE p.sucursal_id = v_sucursal_id
+      AND p.estado = 'entregado'
+      AND COALESCE(p.estado_pago, 'pendiente') <> 'pagado'
+      AND (p.total - COALESCE(p.monto_pagado, 0)) > 0
+  )
+  SELECT
+    c.id AS cliente_id,
+    c.nombre_fantasia AS nombre,
+    COALESCE(c.saldo_cuenta, 0)::numeric AS saldo,
+    COALESCE(SUM(pv.saldo_pedido) FILTER (WHERE pv.dias_mora >= p_dias_min), 0)::numeric AS saldo_vencido,
+    MAX(pv.dias_mora)::int AS dias_mora_max,
+    MIN(pv.base_date) AS pedido_mas_viejo
+  FROM pedidos_vencidos pv
+  JOIN clientes c ON c.id = pv.cli_id
+  GROUP BY c.id, c.nombre_fantasia, c.saldo_cuenta
+  HAVING MAX(pv.dias_mora) >= p_dias_min
+  ORDER BY MAX(pv.dias_mora) DESC, COALESCE(c.saldo_cuenta, 0) DESC;
+END;
+$function$;
+
+ALTER FUNCTION public.obtener_deudores_mora(integer) OWNER TO postgres;
+
+GRANT ALL ON FUNCTION public.obtener_deudores_mora(integer) TO anon;
+GRANT ALL ON FUNCTION public.obtener_deudores_mora(integer) TO authenticated;
+GRANT ALL ON FUNCTION public.obtener_deudores_mora(integer) TO service_role;

--- a/src/components/containers/ClientesContainer.tsx
+++ b/src/components/containers/ClientesContainer.tsx
@@ -30,6 +30,7 @@ const ModalFichaCliente = lazy(() => import('../modals/ModalFichaCliente'))
 const ModalConfirmacion = lazy(() => import('../modals/ModalConfirmacion'))
 const ModalZonas = lazy(() => import('../modals/ModalZonas'))
 const ModalRegistrarPago = lazy(() => import('../modals/ModalRegistrarPago'))
+const ModalDeudoresMora = lazy(() => import('../modals/ModalDeudoresMora'))
 
 function LoadingState() {
   return (
@@ -71,6 +72,7 @@ export default function ClientesContainer(): React.ReactElement {
   const [modalClienteOpen, setModalClienteOpen] = useState(false)
   const [modalFichaOpen, setModalFichaOpen] = useState(false)
   const [modalZonasOpen, setModalZonasOpen] = useState(false)
+  const [modalDeudoresOpen, setModalDeudoresOpen] = useState(false)
   const [clienteFichaId, setClienteFichaId] = useState<string | null>(null)
   const [clientePago, setClientePago] = useState<ClienteDB | null>(null)
   const [saldoPendientePago, setSaldoPendientePago] = useState<number>(0)
@@ -91,6 +93,7 @@ export default function ClientesContainer(): React.ReactElement {
     setModalClienteOpen(false)
     setModalFichaOpen(false)
     setModalZonasOpen(false)
+    setModalDeudoresOpen(false)
     setClienteFichaId(null)
     setClientePago(null)
     setClienteEditando(null)
@@ -128,6 +131,13 @@ export default function ClientesContainer(): React.ReactElement {
 
   const handleVerFichaCliente = useCallback((cliente: ClienteDB) => {
     setClienteFichaId(cliente.id)
+    setModalFichaOpen(true)
+  }, [])
+
+  // Abre la ficha desde el panel de deudores (la RPC devuelve cliente_id numérico).
+  const handleVerFichaDesdeDeudores = useCallback((clienteId: number) => {
+    setModalDeudoresOpen(false)
+    setClienteFichaId(String(clienteId))
     setModalFichaOpen(true)
   }, [])
 
@@ -272,6 +282,7 @@ export default function ClientesContainer(): React.ReactElement {
           onEliminarCliente={handleEliminarCliente}
           onVerFichaCliente={handleVerFichaCliente}
           onGestionarZonas={isAdmin ? handleGestionarZonas : undefined}
+          onVerDeudores={(isAdmin || isEncargado) ? () => setModalDeudoresOpen(true) : undefined}
         />
       </Suspense>
 
@@ -287,6 +298,16 @@ export default function ClientesContainer(): React.ReactElement {
             }}
             guardando={crearCliente.isPending || actualizarCliente.isPending}
             isAdmin={isAdmin}
+          />
+        </Suspense>
+      )}
+
+      {/* Modal Deudores en mora */}
+      {modalDeudoresOpen && (
+        <Suspense fallback={null}>
+          <ModalDeudoresMora
+            onClose={() => setModalDeudoresOpen(false)}
+            onVerFicha={handleVerFichaDesdeDeudores}
           />
         </Suspense>
       )}

--- a/src/components/modals/ModalDeudoresMora.tsx
+++ b/src/components/modals/ModalDeudoresMora.tsx
@@ -1,0 +1,133 @@
+/**
+ * ModalDeudoresMora — lista de clientes en mora (cuenta corriente).
+ *
+ * La antigüedad se cuenta desde la FECHA DE ENTREGA (+ dias_credito del cliente),
+ * vía la RPC `obtener_deudores_mora`. Solo cuenta pedidos entregados impagos.
+ */
+import { memo, useMemo, useState } from 'react'
+import { Loader2, Search, AlertTriangle, User, ChevronRight } from 'lucide-react'
+import ModalBase from './ModalBase'
+import { formatPrecio } from '../../utils/formatters'
+import { useDeudoresMoraQuery } from '../../hooks/queries'
+
+export interface ModalDeudoresMoraProps {
+  onClose: () => void
+  /** Abre la ficha del cliente (resuelto en el container desde la lista de clientes). */
+  onVerFicha: (clienteId: number) => void
+}
+
+function badgeMora(dias: number): string {
+  if (dias > 60) return 'bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400'
+  if (dias > 30) return 'bg-orange-100 text-orange-700 dark:bg-orange-900/30 dark:text-orange-400'
+  return 'bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-400'
+}
+
+const ModalDeudoresMora = memo(function ModalDeudoresMora({ onClose, onVerFicha }: ModalDeudoresMoraProps) {
+  const { data: deudores = [], isLoading, isError, error } = useDeudoresMoraQuery(1, true)
+  const [busqueda, setBusqueda] = useState('')
+
+  const filtrados = useMemo(() => {
+    const term = busqueda.trim().toLowerCase()
+    if (!term) return deudores
+    return deudores.filter(d => d.nombre?.toLowerCase().includes(term))
+  }, [deudores, busqueda])
+
+  const totalVencido = useMemo(
+    () => filtrados.reduce((s, d) => s + (d.saldo_vencido || 0), 0),
+    [filtrados],
+  )
+
+  return (
+    <ModalBase
+      title="Deudores con mora"
+      description="Clientes con pedidos entregados e impagos vencidos. La antigüedad se cuenta desde la fecha de entrega."
+      onClose={onClose}
+      maxWidth="max-w-2xl"
+    >
+      <div className="p-4 space-y-3">
+        {/* Resumen */}
+        <div className="grid grid-cols-2 gap-3">
+          <div className="bg-gray-50 dark:bg-gray-700/50 rounded-lg p-3">
+            <p className="text-xs text-gray-500 dark:text-gray-400">Deudores en mora</p>
+            <p className="text-xl font-bold text-gray-900 dark:text-white">{filtrados.length}</p>
+          </div>
+          <div className="bg-red-50 dark:bg-red-900/20 rounded-lg p-3">
+            <p className="text-xs text-gray-500 dark:text-gray-400">Saldo vencido total</p>
+            <p className="text-xl font-bold text-red-600 dark:text-red-400">{formatPrecio(totalVencido)}</p>
+          </div>
+        </div>
+
+        {/* Búsqueda */}
+        <div className="relative">
+          <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400" />
+          <input
+            type="text"
+            placeholder="Buscar cliente..."
+            value={busqueda}
+            onChange={e => setBusqueda(e.target.value)}
+            className="w-full pl-9 pr-3 py-2 border rounded-lg dark:bg-gray-700 dark:border-gray-600 dark:text-white"
+          />
+        </div>
+
+        {/* Lista */}
+        <div className="max-h-[55vh] overflow-y-auto border rounded-lg dark:border-gray-600">
+          {isLoading ? (
+            <div className="flex items-center justify-center py-10 text-gray-500">
+              <Loader2 className="w-6 h-6 animate-spin text-blue-600" />
+              <span className="ml-2">Cargando deudores...</span>
+            </div>
+          ) : isError ? (
+            <div className="flex items-start gap-2 p-4 text-sm text-red-600 dark:text-red-400">
+              <AlertTriangle className="w-5 h-5 flex-shrink-0 mt-0.5" />
+              <span>{(error as Error)?.message || 'Error al cargar deudores'}</span>
+            </div>
+          ) : filtrados.length === 0 ? (
+            <div className="text-center py-10 text-gray-500">
+              {busqueda ? 'Sin resultados para la búsqueda' : 'No hay clientes en mora 🎉'}
+            </div>
+          ) : (
+            <ul className="divide-y dark:divide-gray-600">
+              {filtrados.map(d => (
+                <li key={d.cliente_id}>
+                  <button
+                    type="button"
+                    onClick={() => onVerFicha(d.cliente_id)}
+                    className="w-full flex items-center gap-3 px-3 py-2.5 text-left hover:bg-gray-50 dark:hover:bg-gray-700/50 transition-colors"
+                  >
+                    <div className="w-8 h-8 rounded-full bg-gray-100 dark:bg-gray-700 flex items-center justify-center flex-shrink-0">
+                      <User className="w-4 h-4 text-gray-500" />
+                    </div>
+                    <div className="flex-1 min-w-0">
+                      <p className="font-medium text-gray-900 dark:text-white truncate">{d.nombre || 'Sin nombre'}</p>
+                      <div className="flex items-center gap-2 mt-0.5">
+                        <span className={`px-1.5 py-0.5 rounded-full text-xs font-medium ${badgeMora(d.dias_mora_max)}`}>
+                          {d.dias_mora_max} {d.dias_mora_max === 1 ? 'día' : 'días'} de mora
+                        </span>
+                      </div>
+                    </div>
+                    <div className="text-right flex-shrink-0">
+                      <p className="font-bold text-red-600 dark:text-red-400">{formatPrecio(d.saldo_vencido)}</p>
+                      <p className="text-xs text-gray-400">Saldo total: {formatPrecio(d.saldo)}</p>
+                    </div>
+                    <ChevronRight className="w-4 h-4 text-gray-400 flex-shrink-0" />
+                  </button>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      </div>
+
+      <div className="flex justify-end gap-2 p-4 border-t bg-gray-50 dark:bg-gray-800 dark:border-gray-700">
+        <button
+          onClick={onClose}
+          className="px-4 py-2 text-gray-700 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-700 rounded-lg"
+        >
+          Cerrar
+        </button>
+      </div>
+    </ModalBase>
+  )
+})
+
+export default ModalDeudoresMora

--- a/src/components/vistas/VistaClientes.tsx
+++ b/src/components/vistas/VistaClientes.tsx
@@ -1,6 +1,6 @@
 import { useState, useMemo } from 'react';
 import type { ChangeEvent } from 'react';
-import { Users, Plus, Edit2, Trash2, Search, MapPin, Phone, FileText, Tag, Building2 } from 'lucide-react';
+import { Users, Plus, Edit2, Trash2, Search, MapPin, Phone, FileText, Tag, Building2, AlertTriangle } from 'lucide-react';
 import LoadingSpinner from '../layout/LoadingSpinner';
 import Paginacion from '../layout/Paginacion';
 import ClientesViewHeader from '../clientes/ClientesViewHeader';
@@ -34,6 +34,8 @@ export interface VistaClientesProps {
   onVerFichaCliente?: (cliente: ClienteDB) => void;
   /** Solo se pasa cuando el usuario es admin (gating en el container). */
   onGestionarZonas?: () => void;
+  /** Abre el panel de deudores en mora. Solo se pasa a admin/encargado. */
+  onVerDeudores?: () => void;
 }
 
 // =============================================================================
@@ -50,7 +52,8 @@ export default function VistaClientes({
   onEditarCliente,
   onEliminarCliente,
   onVerFichaCliente,
-  onGestionarZonas
+  onGestionarZonas,
+  onVerDeudores
 }: VistaClientesProps) {
   const { perfil } = useAuthData();
   const verSaldo = puedeVerSaldoCliente(perfil?.rol);
@@ -138,6 +141,23 @@ export default function VistaClientes({
         filtroDescriptivo={filtroDescriptivo}
         actions={
           <div className="flex flex-wrap items-center gap-2 justify-end">
+            {onVerDeudores && (
+              <button
+                onClick={onVerDeudores}
+                className={cn(
+                  'inline-flex items-center gap-2.5 h-11 px-5 rounded-lg text-[14px] font-medium',
+                  'bg-white dark:bg-gray-800 text-stone-700 dark:text-gray-200',
+                  'border border-stone-200/80 dark:border-gray-700',
+                  'shadow-warm',
+                  'hover:bg-stone-50 dark:hover:bg-gray-700/50 hover:border-stone-300 dark:hover:border-gray-600 hover:-translate-y-px hover:shadow-warm-md',
+                  'active:translate-y-0 active:shadow-warm',
+                  'transition-[transform,box-shadow,background-color,border-color] duration-150',
+                )}
+              >
+                <AlertTriangle className="w-[18px] h-[18px] text-amber-600" aria-hidden="true" />
+                <span>Deudores</span>
+              </button>
+            )}
             {isAdmin && onGestionarZonas && (
               <button
                 onClick={onGestionarZonas}

--- a/src/hooks/queries/index.ts
+++ b/src/hooks/queries/index.ts
@@ -253,3 +253,7 @@ export type {
   BotToggleUsuarioInput,
   BotToggleUsuarioResult,
 } from './useBotAdmin'
+
+// Deudores en mora (cuenta corriente)
+export { useDeudoresMoraQuery } from './useDeudoresMoraQuery'
+export type { DeudorMora } from './useDeudoresMoraQuery'

--- a/src/hooks/queries/useDeudoresMoraQuery.ts
+++ b/src/hooks/queries/useDeudoresMoraQuery.ts
@@ -1,0 +1,39 @@
+/**
+ * TanStack Query hook para la lista de deudores en mora.
+ *
+ * Consume la RPC `obtener_deudores_mora(p_dias_min)`: clientes de la sucursal
+ * activa con pedidos ENTREGADOS impagos cuya antigüedad (desde la fecha de
+ * entrega + dias_credito) supera `p_dias_min` días. Orden: más atrasado primero.
+ */
+import { useQuery } from '@tanstack/react-query'
+import { supabase } from '../supabase/base'
+import { useSucursal } from '../../contexts/SucursalContext'
+
+export interface DeudorMora {
+  cliente_id: number
+  nombre: string
+  /** Saldo total de cuenta corriente del cliente (clientes.saldo_cuenta). */
+  saldo: number
+  /** Suma de saldos de pedidos entregados impagos ya vencidos (en mora). */
+  saldo_vencido: number
+  /** Días de atraso del pedido vencido más viejo. */
+  dias_mora_max: number
+  /** Fecha base (entrega o, si falta, fecha del pedido) del más viejo. */
+  pedido_mas_viejo: string | null
+}
+
+async function fetchDeudoresMora(diasMin: number): Promise<DeudorMora[]> {
+  const { data, error } = await supabase.rpc('obtener_deudores_mora', { p_dias_min: diasMin })
+  if (error) throw error
+  return (data as DeudorMora[]) || []
+}
+
+export function useDeudoresMoraQuery(diasMin = 1, enabled = true) {
+  const { currentSucursalId } = useSucursal()
+  return useQuery({
+    queryKey: ['deudores-mora', currentSucursalId, diasMin],
+    queryFn: () => fetchDeudoresMora(diasMin),
+    enabled,
+    staleTime: 60 * 1000,
+  })
+}

--- a/src/hooks/supabase/useReportesFinancieros.ts
+++ b/src/hooks/supabase/useReportesFinancieros.ts
@@ -95,14 +95,25 @@ export function useReportesFinancieros(): UseReportesFinancierosReturn {
 
         let corriente = 0, vencido30 = 0, vencido60 = 0, vencido90 = 0
         pedidosCliente.forEach(p => {
-          const fechaPedido = new Date(p.created_at || 0)
-          const diasCredito = cliente.dias_credito || 30
-          const fechaVencimiento = new Date(fechaPedido)
-          fechaVencimiento.setDate(fechaVencimiento.getDate() + diasCredito)
-          const diasVencido = Math.floor((hoy.getTime() - fechaVencimiento.getTime()) / (1000 * 60 * 60 * 24))
           // Use outstanding balance per order, not full total (BUG-9 fix)
           const saldoPedido = (p.total || 0) - (p.monto_pagado || 0)
           if (saldoPedido <= 0) return // Skip fully paid orders
+
+          // La mora se cuenta desde la ENTREGA, no desde la creación del pedido.
+          // Un pedido con saldo pero aún NO entregado todavía no genera mora: va
+          // a "corriente" (el cliente todavía no recibió la mercadería).
+          if (p.estado !== 'entregado') {
+            corriente += saldoPedido
+            return
+          }
+          // Base de antigüedad: fecha de entrega real. Para pedidos entregados sin
+          // fecha_entrega (datos viejos) se usa la fecha del pedido como fallback.
+          const baseStr = p.fecha_entrega || p.fecha || p.created_at || 0
+          const fechaBase = new Date(baseStr)
+          const diasCredito = cliente.dias_credito || 30
+          const fechaVencimiento = new Date(fechaBase)
+          fechaVencimiento.setDate(fechaVencimiento.getDate() + diasCredito)
+          const diasVencido = Math.floor((hoy.getTime() - fechaVencimiento.getTime()) / (1000 * 60 * 60 * 24))
 
           if (diasVencido <= 0) corriente += saldoPedido
           else if (diasVencido <= 30) vencido30 += saldoPedido


### PR DESCRIPTION
## Contexto
Al revisar la lógica de cuenta corriente: la antigüedad/mora se calculaba desde la **fecha de creación** del pedido. Debe contarse desde la **fecha de entrega** (el cliente recién debe cuando recibió la mercadería). Además faltaba una forma rápida de ver los deudores en mora desde Clientes.

## Cambios (Feature 1 del plan)
- **Mora desde la entrega:** `useReportesFinancieros` (reporte Cuentas por Cobrar) calcula el aging con `COALESCE(fecha_entrega, fecha)` y **solo** para pedidos `entregado`. Pedidos con saldo pero no entregados figuran "corriente". Entregados sin `fecha_entrega` (datos viejos) usan la fecha del pedido.
- **Nueva RPC `obtener_deudores_mora(p_dias_min)`** (migración `075`): clientes de la sucursal activa con pedidos entregados impagos vencidos; devuelve saldo, saldo vencido y días de atraso. Gate `es_encargado_o_admin()` + `current_sucursal_id()`.
- **Botón "Deudores"** en la vista de Clientes (admin/encargado) → `ModalDeudoresMora` (hook `useDeudoresMoraQuery`): lista ordenada por atraso, con búsqueda y acceso directo a la ficha del cliente.

## ⚠️ Migración pendiente de aplicar a prod
`migrations/075_obtener_deudores_mora.sql` **todavía no se aplicó a producción** (requiere autorización). El panel de deudores no funcionará hasta aplicarla.

## Verificación
- `npm run typecheck` ✅ · `npm run lint` ✅ · `npm run test:run` ✅ (688) · `npm run build` ✅
- Funcional (tras aplicar la migración): pedido entregado impago viejo aparece en el panel con los días correctos; pedido impago NO entregado figura corriente; botón visible solo para admin/encargado.

🤖 Generated with [Claude Code](https://claude.com/claude-code)