### PR TITLE
feat(movimientos): movimientos entre sucursales con aprobación + stock real + notificaciones

### DIFF
--- a/migrations/076_movimientos_sucursal_y_notificaciones.sql
+++ b/migrations/076_movimientos_sucursal_y_notificaciones.sql
@@ -1,0 +1,364 @@
+-- Migración 076: Movimientos entre sucursales con aprobación + notificaciones (DB)
+--
+-- Reemplaza el flujo viejo de transferencias (un solo lado, inmediato) por un
+-- traslado A→B con estado: la sucursal ORIGEN crea un movimiento "pendiente"
+-- (NO mueve stock), y la sucursal DESTINO lo ACEPTA o DENIEGA. Al aceptar se
+-- mueve el stock atómicamente (baja A, sube B), con matching de productos y
+-- regla de costo = max(origen, destino). Precios no se tocan (salvo al crear un
+-- producto nuevo en destino, que copia el de origen).
+--
+-- Notificaciones: tabla DB con fan-out por usuario (admins/encargados de la
+-- sucursal destinataria). La campanita las lee por polling.
+--
+-- Las tablas viejas transferencias_stock / transferencia_items NO se tocan
+-- (quedan como histórico). Forward-only.
+
+BEGIN;
+
+-- =========================================================================
+-- TABLAS
+-- =========================================================================
+
+CREATE TABLE IF NOT EXISTS public.movimientos_sucursal (
+  id BIGSERIAL PRIMARY KEY,
+  sucursal_origen_id BIGINT NOT NULL REFERENCES public.sucursales(id),
+  sucursal_destino_id BIGINT NOT NULL REFERENCES public.sucursales(id),
+  estado VARCHAR(20) NOT NULL DEFAULT 'pendiente'
+    CHECK (estado IN ('pendiente', 'aceptada', 'denegada')),
+  total_costo NUMERIC NOT NULL DEFAULT 0,
+  notas TEXT,
+  motivo_rechazo TEXT,
+  creado_por UUID NOT NULL REFERENCES public.perfiles(id),
+  resuelto_por UUID REFERENCES public.perfiles(id),
+  created_at TIMESTAMPTZ DEFAULT now(),
+  resuelto_at TIMESTAMPTZ,
+  CONSTRAINT mov_suc_distintas CHECK (sucursal_origen_id <> sucursal_destino_id)
+);
+
+CREATE TABLE IF NOT EXISTS public.movimiento_sucursal_items (
+  id BIGSERIAL PRIMARY KEY,
+  movimiento_id BIGINT NOT NULL REFERENCES public.movimientos_sucursal(id) ON DELETE CASCADE,
+  producto_origen_id BIGINT NOT NULL REFERENCES public.productos(id),
+  cantidad INTEGER NOT NULL CHECK (cantidad > 0),
+  -- Snapshot del producto origen al crear (inmutable: sobrevive si origen edita/borra,
+  -- y permite a destino verlo aunque la RLS de productos oculte las filas de origen).
+  origen_nombre TEXT NOT NULL,
+  origen_codigo VARCHAR(50),
+  origen_tp_import_id BIGINT,
+  origen_categoria TEXT,
+  origen_precio NUMERIC,
+  origen_precio_sin_iva NUMERIC,
+  origen_costo_sin_iva NUMERIC,
+  origen_costo_con_iva NUMERIC,
+  origen_impuestos_internos NUMERIC,
+  origen_porcentaje_iva NUMERIC,
+  origen_stock_minimo INTEGER,
+  origen_unidades_por_fardo NUMERIC,
+  origen_etiqueta_bulto TEXT,
+  -- Resolución al aceptar
+  producto_destino_id BIGINT REFERENCES public.productos(id),
+  resolucion VARCHAR(20) CHECK (resolucion IN ('match_existente', 'creado_nuevo')),
+  costo_aplicado_destino NUMERIC,
+  stock_origen_anterior INTEGER,
+  stock_origen_nuevo INTEGER,
+  stock_destino_anterior INTEGER,
+  stock_destino_nuevo INTEGER,
+  created_at TIMESTAMPTZ DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS public.notificaciones (
+  id BIGSERIAL PRIMARY KEY,
+  usuario_id UUID NOT NULL REFERENCES public.perfiles(id),
+  sucursal_id BIGINT REFERENCES public.sucursales(id),
+  tipo VARCHAR(40) NOT NULL,
+  titulo TEXT NOT NULL,
+  mensaje TEXT,
+  entidad_tipo VARCHAR(40),
+  entidad_id BIGINT,
+  payload JSONB DEFAULT '{}'::jsonb,
+  leida BOOLEAN NOT NULL DEFAULT false,
+  created_at TIMESTAMPTZ DEFAULT now(),
+  leida_at TIMESTAMPTZ
+);
+
+CREATE INDEX IF NOT EXISTS idx_mov_suc_origen ON public.movimientos_sucursal (sucursal_origen_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_mov_suc_destino ON public.movimientos_sucursal (sucursal_destino_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_mov_suc_estado ON public.movimientos_sucursal (estado);
+CREATE INDEX IF NOT EXISTS idx_mov_items_mov ON public.movimiento_sucursal_items (movimiento_id);
+CREATE INDEX IF NOT EXISTS idx_notif_usuario_unread ON public.notificaciones (usuario_id, leida, created_at DESC);
+
+-- =========================================================================
+-- RLS
+-- =========================================================================
+
+ALTER TABLE public.movimientos_sucursal ENABLE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS mov_suc_select ON public.movimientos_sucursal;
+CREATE POLICY mov_suc_select ON public.movimientos_sucursal FOR SELECT TO authenticated
+  USING (sucursal_origen_id = current_sucursal_id() OR sucursal_destino_id = current_sucursal_id());
+
+ALTER TABLE public.movimiento_sucursal_items ENABLE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS mov_items_select ON public.movimiento_sucursal_items;
+CREATE POLICY mov_items_select ON public.movimiento_sucursal_items FOR SELECT TO authenticated
+  USING (EXISTS (
+    SELECT 1 FROM public.movimientos_sucursal m
+    WHERE m.id = movimiento_sucursal_items.movimiento_id
+      AND (m.sucursal_origen_id = current_sucursal_id() OR m.sucursal_destino_id = current_sucursal_id())
+  ));
+
+ALTER TABLE public.notificaciones ENABLE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS notif_select ON public.notificaciones;
+CREATE POLICY notif_select ON public.notificaciones FOR SELECT TO authenticated
+  USING (usuario_id = auth.uid());
+DROP POLICY IF EXISTS notif_update ON public.notificaciones;
+CREATE POLICY notif_update ON public.notificaciones FOR UPDATE TO authenticated
+  USING (usuario_id = auth.uid()) WITH CHECK (usuario_id = auth.uid());
+
+GRANT SELECT ON public.movimientos_sucursal TO authenticated;
+GRANT SELECT ON public.movimiento_sucursal_items TO authenticated;
+GRANT SELECT ON public.notificaciones TO authenticated;
+GRANT UPDATE (leida, leida_at) ON public.notificaciones TO authenticated;
+
+-- =========================================================================
+-- HELPERS
+-- =========================================================================
+
+-- Rol efectivo del usuario en una sucursal (resuelve 'mismo' → rol global).
+CREATE OR REPLACE FUNCTION public._rol_en_sucursal(p_uid uuid, p_suc bigint)
+RETURNS text LANGUAGE sql STABLE SECURITY DEFINER SET search_path TO 'public' AS $$
+  SELECT CASE WHEN us.rol = 'mismo' THEN p.rol ELSE us.rol END
+  FROM usuario_sucursales us
+  JOIN perfiles p ON p.id = us.usuario_id
+  WHERE us.usuario_id = p_uid AND us.sucursal_id = p_suc
+  LIMIT 1;
+$$;
+ALTER FUNCTION public._rol_en_sucursal(uuid, bigint) OWNER TO postgres;
+
+-- Fan-out de una notificación a todos los admin/encargado de una sucursal,
+-- excluyendo al actor. Dedup por usuario.
+CREATE OR REPLACE FUNCTION public._notificar_sucursal_roles(
+  p_sucursal_id bigint, p_excluir_uid uuid, p_tipo varchar, p_titulo text,
+  p_mensaje text, p_entidad_tipo varchar, p_entidad_id bigint, p_payload jsonb
+) RETURNS void LANGUAGE sql SECURITY DEFINER SET search_path TO 'public' AS $$
+  INSERT INTO notificaciones (usuario_id, sucursal_id, tipo, titulo, mensaje, entidad_tipo, entidad_id, payload)
+  SELECT DISTINCT us.usuario_id, p_sucursal_id, p_tipo, p_titulo, p_mensaje, p_entidad_tipo, p_entidad_id, p_payload
+  FROM usuario_sucursales us
+  JOIN perfiles p ON p.id = us.usuario_id
+  WHERE us.sucursal_id = p_sucursal_id
+    AND (CASE WHEN us.rol = 'mismo' THEN p.rol ELSE us.rol END) IN ('admin', 'encargado')
+    AND p.activo IS NOT FALSE
+    AND us.usuario_id <> COALESCE(p_excluir_uid, '00000000-0000-0000-0000-000000000000'::uuid);
+$$;
+ALTER FUNCTION public._notificar_sucursal_roles(bigint, uuid, varchar, text, text, varchar, bigint, jsonb) OWNER TO postgres;
+
+CREATE OR REPLACE FUNCTION public.marcar_notificacion_leida(p_id bigint)
+RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER SET search_path TO 'public' AS $$
+BEGIN
+  UPDATE notificaciones SET leida = true, leida_at = now()
+  WHERE id = p_id AND usuario_id = auth.uid();
+  RETURN jsonb_build_object('success', true);
+END; $$;
+ALTER FUNCTION public.marcar_notificacion_leida(bigint) OWNER TO postgres;
+
+CREATE OR REPLACE FUNCTION public.marcar_todas_notificaciones_leidas()
+RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER SET search_path TO 'public' AS $$
+BEGIN
+  UPDATE notificaciones SET leida = true, leida_at = now()
+  WHERE usuario_id = auth.uid() AND leida = false;
+  RETURN jsonb_build_object('success', true);
+END; $$;
+ALTER FUNCTION public.marcar_todas_notificaciones_leidas() OWNER TO postgres;
+
+-- =========================================================================
+-- RPC: crear movimiento (origen). NO mueve stock.
+-- =========================================================================
+CREATE OR REPLACE FUNCTION public.crear_movimiento_sucursal(
+  p_sucursal_destino_id bigint, p_notas text DEFAULT NULL, p_items jsonb DEFAULT '[]'::jsonb
+) RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER SET search_path TO 'public' AS $$
+DECLARE
+  v_origen bigint; v_mov_id bigint; v_item jsonb; v_prod productos%ROWTYPE;
+  v_cant integer; v_total numeric := 0; v_count integer := 0;
+BEGIN
+  v_origen := current_sucursal_id();
+  IF v_origen IS NULL THEN RETURN jsonb_build_object('success', false, 'error', 'Sucursal no seleccionada'); END IF;
+  IF p_sucursal_destino_id = v_origen THEN RETURN jsonb_build_object('success', false, 'error', 'El destino debe ser distinto al origen'); END IF;
+  IF public._rol_en_sucursal(auth.uid(), v_origen) NOT IN ('admin', 'encargado') THEN
+    RETURN jsonb_build_object('success', false, 'error', 'No autorizado'); END IF;
+  IF NOT EXISTS (SELECT 1 FROM sucursales WHERE id = p_sucursal_destino_id AND activa IS NOT FALSE) THEN
+    RETURN jsonb_build_object('success', false, 'error', 'Sucursal destino inválida'); END IF;
+
+  INSERT INTO movimientos_sucursal (sucursal_origen_id, sucursal_destino_id, estado, notas, creado_por)
+  VALUES (v_origen, p_sucursal_destino_id, 'pendiente', p_notas, auth.uid())
+  RETURNING id INTO v_mov_id;
+
+  FOR v_item IN SELECT * FROM jsonb_array_elements(p_items) LOOP
+    v_cant := COALESCE((v_item->>'cantidad')::int, 0);
+    IF v_cant <= 0 THEN CONTINUE; END IF;
+    SELECT * INTO v_prod FROM productos WHERE id = (v_item->>'producto_id')::bigint AND sucursal_id = v_origen;
+    IF NOT FOUND THEN RAISE EXCEPTION 'Producto % no encontrado en la sucursal origen', (v_item->>'producto_id'); END IF;
+
+    INSERT INTO movimiento_sucursal_items (
+      movimiento_id, producto_origen_id, cantidad,
+      origen_nombre, origen_codigo, origen_tp_import_id, origen_categoria,
+      origen_precio, origen_precio_sin_iva, origen_costo_sin_iva, origen_costo_con_iva,
+      origen_impuestos_internos, origen_porcentaje_iva, origen_stock_minimo,
+      origen_unidades_por_fardo, origen_etiqueta_bulto
+    ) VALUES (
+      v_mov_id, v_prod.id, v_cant,
+      v_prod.nombre, v_prod.codigo, v_prod.tp_import_id, v_prod.categoria,
+      v_prod.precio, v_prod.precio_sin_iva, v_prod.costo_sin_iva, v_prod.costo_con_iva,
+      v_prod.impuestos_internos, v_prod.porcentaje_iva, v_prod.stock_minimo,
+      v_prod.unidades_de_venta_por_fardo, v_prod.etiqueta_bulto
+    );
+    v_total := v_total + COALESCE(v_prod.costo_con_iva, v_prod.costo_sin_iva, 0) * v_cant;
+    v_count := v_count + 1;
+  END LOOP;
+
+  IF v_count = 0 THEN RAISE EXCEPTION 'El movimiento no tiene items válidos'; END IF;
+
+  UPDATE movimientos_sucursal SET total_costo = v_total WHERE id = v_mov_id;
+
+  PERFORM public._notificar_sucursal_roles(
+    p_sucursal_destino_id, auth.uid(), 'movimiento_pendiente',
+    'Nuevo movimiento de stock para aceptar',
+    COALESCE((SELECT nombre FROM sucursales WHERE id = v_origen), 'Otra sucursal') || ' envió ' || v_count || ' producto(s).',
+    'movimiento_sucursal', v_mov_id,
+    jsonb_build_object('origen_id', v_origen, 'items', v_count)
+  );
+
+  RETURN jsonb_build_object('success', true, 'movimiento_id', v_mov_id);
+EXCEPTION WHEN OTHERS THEN
+  RETURN jsonb_build_object('success', false, 'error', SQLERRM);
+END; $$;
+ALTER FUNCTION public.crear_movimiento_sucursal(bigint, text, jsonb) OWNER TO postgres;
+
+-- =========================================================================
+-- RPC: aceptar movimiento (destino). Mueve stock atómicamente.
+--   p_resoluciones: [{item_id, accion: 'match_existente'|'crear_nuevo', producto_destino_id?}]
+-- =========================================================================
+CREATE OR REPLACE FUNCTION public.aceptar_movimiento_sucursal(
+  p_movimiento_id bigint, p_resoluciones jsonb
+) RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER SET search_path TO 'public' AS $$
+DECLARE
+  v_mov movimientos_sucursal%ROWTYPE;
+  v_destino bigint; v_item movimiento_sucursal_items%ROWTYPE;
+  v_res jsonb; v_accion text; v_dest_id bigint;
+  v_stock_o integer; v_stock_d integer;
+  v_costo_dest numeric; v_costo_dest_neto numeric;
+BEGIN
+  SELECT * INTO v_mov FROM movimientos_sucursal WHERE id = p_movimiento_id FOR UPDATE;
+  IF NOT FOUND THEN RETURN jsonb_build_object('success', false, 'error', 'Movimiento no encontrado'); END IF;
+  IF v_mov.estado <> 'pendiente' THEN RETURN jsonb_build_object('success', false, 'error', 'El movimiento ya fue resuelto'); END IF;
+  v_destino := v_mov.sucursal_destino_id;
+  IF current_sucursal_id() <> v_destino THEN
+    RETURN jsonb_build_object('success', false, 'error', 'Tenés que estar en la sucursal destino para aceptar'); END IF;
+  IF public._rol_en_sucursal(auth.uid(), v_destino) NOT IN ('admin', 'encargado') THEN
+    RETURN jsonb_build_object('success', false, 'error', 'No autorizado'); END IF;
+
+  FOR v_item IN SELECT * FROM movimiento_sucursal_items WHERE movimiento_id = p_movimiento_id ORDER BY producto_origen_id LOOP
+    SELECT r INTO v_res FROM jsonb_array_elements(p_resoluciones) r WHERE (r->>'item_id')::bigint = v_item.id LIMIT 1;
+    IF v_res IS NULL THEN RAISE EXCEPTION 'Falta resolver el producto "%"', v_item.origen_nombre; END IF;
+    v_accion := v_res->>'accion';
+
+    SELECT stock INTO v_stock_o FROM productos
+      WHERE id = v_item.producto_origen_id AND sucursal_id = v_mov.sucursal_origen_id FOR UPDATE;
+    IF NOT FOUND THEN RAISE EXCEPTION 'El producto "%" ya no existe en la sucursal origen', v_item.origen_nombre; END IF;
+    IF v_stock_o < v_item.cantidad THEN
+      RAISE EXCEPTION 'Stock insuficiente en origen para "%": disponible %, solicitado %', v_item.origen_nombre, v_stock_o, v_item.cantidad;
+    END IF;
+
+    IF v_accion = 'crear_nuevo' THEN
+      INSERT INTO productos (
+        nombre, codigo, categoria, precio, precio_sin_iva, costo_sin_iva, costo_con_iva,
+        impuestos_internos, porcentaje_iva, stock, stock_minimo, proveedor_id,
+        unidades_de_venta_por_fardo, etiqueta_bulto, tp_import_id, sucursal_id
+      ) VALUES (
+        v_item.origen_nombre, v_item.origen_codigo, v_item.origen_categoria,
+        COALESCE(v_item.origen_precio, 0), v_item.origen_precio_sin_iva, v_item.origen_costo_sin_iva, v_item.origen_costo_con_iva,
+        v_item.origen_impuestos_internos, v_item.origen_porcentaje_iva, 0, v_item.origen_stock_minimo, NULL,
+        v_item.origen_unidades_por_fardo, v_item.origen_etiqueta_bulto, v_item.origen_tp_import_id, v_destino
+      ) RETURNING id, stock INTO v_dest_id, v_stock_d;
+      v_costo_dest := v_item.origen_costo_con_iva;
+      v_costo_dest_neto := v_item.origen_costo_sin_iva;
+    ELSE
+      v_dest_id := (v_res->>'producto_destino_id')::bigint;
+      SELECT stock, costo_con_iva, costo_sin_iva INTO v_stock_d, v_costo_dest, v_costo_dest_neto
+        FROM productos WHERE id = v_dest_id AND sucursal_id = v_destino FOR UPDATE;
+      IF NOT FOUND THEN RAISE EXCEPTION 'El producto destino elegido no existe en la sucursal'; END IF;
+      -- Regla de costo: queda el mayor entre origen y destino.
+      v_costo_dest := GREATEST(COALESCE(v_costo_dest, 0), COALESCE(v_item.origen_costo_con_iva, 0));
+      v_costo_dest_neto := GREATEST(COALESCE(v_costo_dest_neto, 0), COALESCE(v_item.origen_costo_sin_iva, 0));
+    END IF;
+
+    UPDATE productos SET stock = stock - v_item.cantidad, updated_at = now()
+      WHERE id = v_item.producto_origen_id AND sucursal_id = v_mov.sucursal_origen_id;
+    UPDATE productos SET stock = stock + v_item.cantidad,
+        costo_con_iva = v_costo_dest, costo_sin_iva = v_costo_dest_neto, updated_at = now()
+      WHERE id = v_dest_id AND sucursal_id = v_destino;
+
+    UPDATE movimiento_sucursal_items SET
+      producto_destino_id = v_dest_id,
+      resolucion = CASE WHEN v_accion = 'crear_nuevo' THEN 'creado_nuevo' ELSE 'match_existente' END,
+      costo_aplicado_destino = v_costo_dest,
+      stock_origen_anterior = v_stock_o, stock_origen_nuevo = v_stock_o - v_item.cantidad,
+      stock_destino_anterior = v_stock_d, stock_destino_nuevo = v_stock_d + v_item.cantidad
+    WHERE id = v_item.id;
+  END LOOP;
+
+  UPDATE movimientos_sucursal SET estado = 'aceptada', resuelto_por = auth.uid(), resuelto_at = now()
+    WHERE id = p_movimiento_id;
+
+  PERFORM public._notificar_sucursal_roles(
+    v_mov.sucursal_origen_id, auth.uid(), 'movimiento_aceptado',
+    'Movimiento aceptado',
+    COALESCE((SELECT nombre FROM sucursales WHERE id = v_destino), 'La sucursal destino') || ' aceptó tu movimiento #' || p_movimiento_id || '.',
+    'movimiento_sucursal', p_movimiento_id, jsonb_build_object('destino_id', v_destino)
+  );
+
+  RETURN jsonb_build_object('success', true, 'movimiento_id', p_movimiento_id);
+EXCEPTION WHEN OTHERS THEN
+  RETURN jsonb_build_object('success', false, 'error', SQLERRM);
+END; $$;
+ALTER FUNCTION public.aceptar_movimiento_sucursal(bigint, jsonb) OWNER TO postgres;
+
+-- =========================================================================
+-- RPC: denegar movimiento (destino). No mueve stock.
+-- =========================================================================
+CREATE OR REPLACE FUNCTION public.denegar_movimiento_sucursal(
+  p_movimiento_id bigint, p_motivo text DEFAULT NULL
+) RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER SET search_path TO 'public' AS $$
+DECLARE v_mov movimientos_sucursal%ROWTYPE; v_destino bigint;
+BEGIN
+  SELECT * INTO v_mov FROM movimientos_sucursal WHERE id = p_movimiento_id FOR UPDATE;
+  IF NOT FOUND THEN RETURN jsonb_build_object('success', false, 'error', 'Movimiento no encontrado'); END IF;
+  IF v_mov.estado <> 'pendiente' THEN RETURN jsonb_build_object('success', false, 'error', 'El movimiento ya fue resuelto'); END IF;
+  v_destino := v_mov.sucursal_destino_id;
+  IF current_sucursal_id() <> v_destino THEN
+    RETURN jsonb_build_object('success', false, 'error', 'Tenés que estar en la sucursal destino'); END IF;
+  IF public._rol_en_sucursal(auth.uid(), v_destino) NOT IN ('admin', 'encargado') THEN
+    RETURN jsonb_build_object('success', false, 'error', 'No autorizado'); END IF;
+
+  UPDATE movimientos_sucursal SET estado = 'denegada', motivo_rechazo = p_motivo,
+      resuelto_por = auth.uid(), resuelto_at = now()
+    WHERE id = p_movimiento_id;
+
+  PERFORM public._notificar_sucursal_roles(
+    v_mov.sucursal_origen_id, auth.uid(), 'movimiento_denegado',
+    'Movimiento denegado',
+    COALESCE((SELECT nombre FROM sucursales WHERE id = v_destino), 'La sucursal destino') || ' denegó tu movimiento #' || p_movimiento_id || COALESCE('. Motivo: ' || p_motivo, ''),
+    'movimiento_sucursal', p_movimiento_id, jsonb_build_object('destino_id', v_destino, 'motivo', p_motivo)
+  );
+
+  RETURN jsonb_build_object('success', true, 'movimiento_id', p_movimiento_id);
+EXCEPTION WHEN OTHERS THEN
+  RETURN jsonb_build_object('success', false, 'error', SQLERRM);
+END; $$;
+ALTER FUNCTION public.denegar_movimiento_sucursal(bigint, text) OWNER TO postgres;
+
+-- Grants de ejecución (RPCs de cara al cliente).
+GRANT EXECUTE ON FUNCTION public.crear_movimiento_sucursal(bigint, text, jsonb) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.aceptar_movimiento_sucursal(bigint, jsonb) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.denegar_movimiento_sucursal(bigint, text) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.marcar_notificacion_leida(bigint) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.marcar_todas_notificaciones_leidas() TO authenticated;
+
+COMMIT;

--- a/migrations/076_movimientos_sucursal_y_notificaciones.sql
+++ b/migrations/076_movimientos_sucursal_y_notificaciones.sql
@@ -354,6 +354,17 @@ EXCEPTION WHEN OTHERS THEN
 END; $$;
 ALTER FUNCTION public.denegar_movimiento_sucursal(bigint, text) OWNER TO postgres;
 
+-- Helpers internos: NO deben ser invocables directamente por el cliente (las
+-- RPCs definer los llaman internamente como owner). Revocar de PUBLIC/anon/auth
+-- evita, p.ej., que un anon llame a _notificar_sucursal_roles (sin gate) para
+-- spamear notificaciones.
+REVOKE EXECUTE ON FUNCTION public._rol_en_sucursal(uuid, bigint) FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION public._rol_en_sucursal(uuid, bigint) FROM anon;
+REVOKE EXECUTE ON FUNCTION public._rol_en_sucursal(uuid, bigint) FROM authenticated;
+REVOKE EXECUTE ON FUNCTION public._notificar_sucursal_roles(bigint, uuid, varchar, text, text, varchar, bigint, jsonb) FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION public._notificar_sucursal_roles(bigint, uuid, varchar, text, text, varchar, bigint, jsonb) FROM anon;
+REVOKE EXECUTE ON FUNCTION public._notificar_sucursal_roles(bigint, uuid, varchar, text, text, varchar, bigint, jsonb) FROM authenticated;
+
 -- Grants de ejecución (RPCs de cara al cliente).
 GRANT EXECUTE ON FUNCTION public.crear_movimiento_sucursal(bigint, text, jsonb) TO authenticated;
 GRANT EXECUTE ON FUNCTION public.aceptar_movimiento_sucursal(bigint, jsonb) TO authenticated;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -43,7 +43,7 @@ const ReportesContainer = lazy(() => import('./components/containers/ReportesCon
 const ComisionesContainer = lazy(() => import('./components/containers/ComisionesContainer'))
 const RecorridosContainer = lazy(() => import('./components/containers/RecorridosContainer'))
 const RecorridoPreventistaContainer = lazy(() => import('./components/containers/RecorridoPreventistaContainer'))
-const TransferenciasContainer = lazy(() => import('./components/containers/TransferenciasContainer'))
+const MovimientosContainer = lazy(() => import('./components/containers/MovimientosContainer'))
 const PromocionesContainer = lazy(() => import('./components/containers/PromocionesContainer'))
 const VistaBotTelegramContainer = lazy(() => import('./components/containers/VistaBotTelegramContainer'))
 
@@ -299,7 +299,7 @@ function MainAppInner({ user, perfil, logout, authReady }: {
 
                 <Route
                   path="/transferencias"
-                  element={isAdmin ? <TransferenciasContainer /> : <Navigate to="/pedidos" replace />}
+                  element={isAdminOrEncargado ? <MovimientosContainer /> : <Navigate to="/pedidos" replace />}
                 />
 
                 <Route

--- a/src/components/containers/MovimientosContainer.tsx
+++ b/src/components/containers/MovimientosContainer.tsx
@@ -1,0 +1,126 @@
+/**
+ * MovimientosContainer — panel de movimientos entre sucursales (con aprobación).
+ * Reemplaza el flujo viejo de transferencias (un solo lado, inmediato).
+ */
+import React, { lazy, Suspense, useState, useCallback } from 'react'
+import { Loader2 } from 'lucide-react'
+import {
+  useMovimientosQuery,
+  useMovimientoItemsQuery,
+  useSucursalesQuery,
+  useProductosQuery,
+  useCrearMovimientoMutation,
+  useAceptarMovimientoMutation,
+  useDenegarMovimientoMutation,
+} from '../../hooks/queries'
+import type { MovimientoSucursalDB, EstadoMovimiento, ResolucionItem } from '../../hooks/queries'
+import { useAuthData } from '../../contexts/AuthDataContext'
+import { useSucursal } from '../../contexts/SucursalContext'
+import { useNotification } from '../../contexts/NotificationContext'
+import { useResetOnSucursalChange } from '../../hooks/useResetOnSucursalChange'
+
+const VistaMovimientos = lazy(() => import('../vistas/VistaMovimientos'))
+const ModalCrearMovimiento = lazy(() => import('../modals/ModalCrearMovimiento'))
+const ModalAceptarMovimiento = lazy(() => import('../modals/ModalAceptarMovimiento'))
+
+type TabEstado = EstadoMovimiento | 'todos'
+
+function LoadingState() {
+  return <div className="flex items-center justify-center py-20"><Loader2 className="w-8 h-8 animate-spin text-blue-600" /></div>
+}
+
+export default function MovimientosContainer(): React.ReactElement {
+  const { isAdminOrEncargado } = useAuthData()
+  const { currentSucursalId } = useSucursal()
+  const notify = useNotification()
+
+  const [estado, setEstado] = useState<TabEstado>('pendiente')
+  const [crearOpen, setCrearOpen] = useState(false)
+  const [aceptarMov, setAceptarMov] = useState<MovimientoSucursalDB | null>(null)
+
+  const { data: movimientos = [], isLoading } = useMovimientosQuery({ estado })
+  const { data: sucursales = [] } = useSucursalesQuery()
+  const { data: productos = [] } = useProductosQuery()
+  const { data: itemsAceptar = [], isLoading: loadingItems } = useMovimientoItemsQuery(aceptarMov ? String(aceptarMov.id) : null)
+
+  const crear = useCrearMovimientoMutation()
+  const aceptar = useAceptarMovimientoMutation()
+  const denegar = useDenegarMovimientoMutation()
+  const guardando = crear.isPending || aceptar.isPending || denegar.isPending
+
+  useResetOnSucursalChange(() => {
+    setCrearOpen(false)
+    setAceptarMov(null)
+    setEstado('pendiente')
+  })
+
+  // Sucursales destino: las activas distintas de la actual.
+  const sucursalesDestino = sucursales.filter(s => Number(s.id) !== currentSucursalId)
+
+  const handleCrear = useCallback(async (payload: {
+    sucursalDestinoId: number; notas?: string; items: Array<{ producto_id: number; cantidad: number }>
+  }) => {
+    await crear.mutateAsync(payload)
+    setCrearOpen(false)
+    notify.success('Salida creada. Queda pendiente de aprobación.')
+  }, [crear, notify])
+
+  const handleAceptar = useCallback(async (resoluciones: ResolucionItem[]) => {
+    if (!aceptarMov) return
+    await aceptar.mutateAsync({ movimientoId: aceptarMov.id, resoluciones })
+    setAceptarMov(null)
+    notify.success('Movimiento aceptado. Stock actualizado.')
+  }, [aceptar, aceptarMov, notify])
+
+  const handleDenegar = useCallback(async (motivo: string) => {
+    if (!aceptarMov) return
+    await denegar.mutateAsync({ movimientoId: aceptarMov.id, motivo })
+    setAceptarMov(null)
+    notify.warning('Movimiento denegado.')
+  }, [denegar, aceptarMov, notify])
+
+  return (
+    <>
+      <Suspense fallback={<LoadingState />}>
+        <VistaMovimientos
+          movimientos={movimientos}
+          loading={isLoading}
+          currentSucursalId={currentSucursalId}
+          canResolver={isAdminOrEncargado}
+          estado={estado}
+          onEstadoChange={setEstado}
+          onNuevaSalida={() => setCrearOpen(true)}
+          onAceptar={setAceptarMov}
+          onDenegar={setAceptarMov}
+        />
+      </Suspense>
+
+      {crearOpen && (
+        <Suspense fallback={null}>
+          <ModalCrearMovimiento
+            sucursales={sucursalesDestino}
+            productos={productos}
+            guardando={guardando}
+            onClose={() => setCrearOpen(false)}
+            onConfirmar={handleCrear}
+          />
+        </Suspense>
+      )}
+
+      {aceptarMov && (
+        <Suspense fallback={null}>
+          <ModalAceptarMovimiento
+            movimiento={aceptarMov}
+            items={itemsAceptar}
+            loadingItems={loadingItems}
+            productosDestino={productos}
+            guardando={guardando}
+            onConfirmar={handleAceptar}
+            onDenegar={handleDenegar}
+            onClose={() => setAceptarMov(null)}
+          />
+        </Suspense>
+      )}
+    </>
+  )
+}

--- a/src/components/layout/DbNotificationBell.tsx
+++ b/src/components/layout/DbNotificationBell.tsx
@@ -1,0 +1,107 @@
+/**
+ * Campanita de notificaciones persistentes (DB), por polling.
+ *
+ * Reemplaza la campanita local (localStorage) en la barra superior: estas
+ * notificaciones cruzan usuarios y dispositivos (ej: a la sucursal destino le
+ * llega un movimiento pendiente). Los toasts transitorios siguen funcionando
+ * aparte (NotificationProvider).
+ */
+import { memo, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { Bell, Check, Loader2, CheckCheck } from 'lucide-react'
+import { formatDateTime } from '../../utils/formatters'
+import {
+  useNotificacionesQuery,
+  useMarcarNotificacionLeidaMutation,
+  useMarcarTodasNotificacionesLeidasMutation,
+  type NotificacionDB,
+} from '../../hooks/queries'
+
+function rutaDeNotificacion(n: NotificacionDB): string | null {
+  if (n.entidad_tipo === 'movimiento_sucursal') return '/transferencias'
+  return null
+}
+
+const DbNotificationBell = memo(function DbNotificationBell() {
+  const navigate = useNavigate()
+  const [open, setOpen] = useState(false)
+  const { data: notificaciones = [], isLoading } = useNotificacionesQuery()
+  const marcarLeida = useMarcarNotificacionLeidaMutation()
+  const marcarTodas = useMarcarTodasNotificacionesLeidasMutation()
+
+  const noLeidas = notificaciones.filter(n => !n.leida).length
+
+  const handleClick = (n: NotificacionDB) => {
+    if (!n.leida) marcarLeida.mutate(n.id)
+    const ruta = rutaDeNotificacion(n)
+    setOpen(false)
+    if (ruta) navigate(ruta)
+  }
+
+  return (
+    <div className="relative">
+      <button
+        onClick={() => setOpen(o => !o)}
+        className="relative p-2 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-700 text-gray-600 dark:text-gray-300"
+        aria-label="Notificaciones"
+        title="Notificaciones"
+      >
+        <Bell className="w-5 h-5" />
+        {noLeidas > 0 && (
+          <span className="absolute -top-0.5 -right-0.5 min-w-[18px] h-[18px] px-1 rounded-full bg-red-500 text-white text-[11px] font-bold flex items-center justify-center">
+            {noLeidas > 9 ? '9+' : noLeidas}
+          </span>
+        )}
+      </button>
+
+      {open && (
+        <>
+          <div className="fixed inset-0 z-40" onClick={() => setOpen(false)} aria-hidden />
+          <div className="absolute right-0 mt-2 w-80 max-w-[90vw] bg-white dark:bg-gray-800 rounded-xl shadow-lg border dark:border-gray-700 z-50 overflow-hidden">
+            <div className="flex items-center justify-between px-4 py-2 border-b dark:border-gray-700">
+              <span className="font-semibold text-gray-900 dark:text-white">Notificaciones</span>
+              {noLeidas > 0 && (
+                <button
+                  onClick={() => marcarTodas.mutate()}
+                  className="text-xs text-blue-600 hover:underline flex items-center gap-1"
+                >
+                  <CheckCheck className="w-3.5 h-3.5" /> Marcar todas
+                </button>
+              )}
+            </div>
+            <div className="max-h-96 overflow-y-auto divide-y dark:divide-gray-700">
+              {isLoading ? (
+                <div className="flex items-center justify-center py-6 text-gray-500">
+                  <Loader2 className="w-5 h-5 animate-spin" />
+                </div>
+              ) : notificaciones.length === 0 ? (
+                <div className="text-center py-8 text-sm text-gray-500">Sin notificaciones</div>
+              ) : (
+                notificaciones.map(n => (
+                  <button
+                    key={n.id}
+                    onClick={() => handleClick(n)}
+                    className={`w-full text-left px-4 py-3 hover:bg-gray-50 dark:hover:bg-gray-700/50 transition-colors ${
+                      n.leida ? '' : 'bg-blue-50/50 dark:bg-blue-900/10'
+                    }`}
+                  >
+                    <div className="flex items-start gap-2">
+                      {!n.leida && <span className="w-2 h-2 rounded-full bg-blue-500 mt-1.5 flex-shrink-0" />}
+                      <div className={`min-w-0 ${n.leida ? 'pl-4' : ''}`}>
+                        <p className="text-sm font-medium text-gray-900 dark:text-white">{n.titulo}</p>
+                        {n.mensaje && <p className="text-xs text-gray-500 dark:text-gray-400 mt-0.5">{n.mensaje}</p>}
+                        <p className="text-[11px] text-gray-400 mt-0.5">{n.created_at && formatDateTime(n.created_at)}</p>
+                      </div>
+                    </div>
+                  </button>
+                ))
+              )}
+            </div>
+          </div>
+        </>
+      )}
+    </div>
+  )
+})
+
+export default DbNotificationBell

--- a/src/components/layout/TopNavigation.tsx
+++ b/src/components/layout/TopNavigation.tsx
@@ -8,7 +8,7 @@ import {
 } from 'lucide-react';
 import { getRolColor, getRolLabel } from '../../utils/formatters';
 import { useTheme } from '../../contexts/ThemeContext';
-import { NotificationCenter } from '../../contexts/NotificationContext';
+import DbNotificationBell from './DbNotificationBell';
 import SucursalSelector from './SucursalSelector';
 import VincularTelegramButton from '../perfil/VincularTelegramButton';
 import type { PerfilDB, RolUsuario } from '../../types';
@@ -75,7 +75,7 @@ const menuGroups: MenuGroup[] = [
       { id: 'proveedores', icon: Building2, label: 'Proveedores', roles: ['admin'] },
       { id: 'condiciones-mayoristas', icon: Tag, label: 'Condiciones Mayoristas', roles: ['admin'] },
       { id: 'promociones', icon: Gift, label: 'Promociones', roles: ['admin'] },
-      { id: 'transferencias', icon: ArrowRightLeft, label: 'Mov. Sucursales', roles: ['admin'] },
+      { id: 'transferencias', icon: ArrowRightLeft, label: 'Mov. Sucursales', roles: ['admin', 'encargado'] },
     ]
   },
   {
@@ -295,8 +295,8 @@ export default function TopNavigation({
               {darkMode ? <Sun className="w-5 h-5" /> : <Moon className="w-5 h-5" />}
             </button>
 
-            {/* Notificaciones */}
-            <NotificationCenter />
+            {/* Notificaciones (persistentes, DB) */}
+            <DbNotificationBell />
 
             {/* Sucursal */}
             <SucursalSelector />

--- a/src/components/modals/ModalAceptarMovimiento.tsx
+++ b/src/components/modals/ModalAceptarMovimiento.tsx
@@ -1,0 +1,184 @@
+/**
+ * ModalAceptarMovimiento — la sucursal destino acepta (o deniega) un movimiento.
+ *
+ * Por cada item sugiere el match con un producto del destino (código/nombre
+ * exacto). Quien acepta confirma el match, elige otro producto, o crea uno nuevo
+ * (copiando el de origen). Al aceptar, el backend mueve el stock atómicamente.
+ */
+import { memo, useEffect, useMemo, useState } from 'react'
+import { Loader2, Check, X, AlertTriangle } from 'lucide-react'
+import ModalBase from './ModalBase'
+import { formatPrecio } from '../../utils/formatters'
+import { sugerirMatchProducto } from '../../utils/matchProducto'
+import type { ProductoDB } from '../../types'
+import type { MovimientoSucursalDB, MovimientoItemDB, ResolucionItem } from '../../hooks/queries'
+
+const NUEVO = '__nuevo__'
+
+export interface ModalAceptarMovimientoProps {
+  movimiento: MovimientoSucursalDB
+  items: MovimientoItemDB[]
+  loadingItems: boolean
+  productosDestino: ProductoDB[]
+  guardando: boolean
+  onConfirmar: (resoluciones: ResolucionItem[]) => Promise<void>
+  onDenegar: (motivo: string) => Promise<void>
+  onClose: () => void
+}
+
+const ModalAceptarMovimiento = memo(function ModalAceptarMovimiento({
+  movimiento, items, loadingItems, productosDestino, guardando, onConfirmar, onDenegar, onClose,
+}: ModalAceptarMovimientoProps) {
+  // item_id -> producto_destino_id (string) | NUEVO
+  const [sel, setSel] = useState<Record<number, string>>({})
+  const [modoDenegar, setModoDenegar] = useState(false)
+  const [motivo, setMotivo] = useState('')
+  const [error, setError] = useState('')
+
+  // Inicializar selección con la sugerencia automática por item.
+  useEffect(() => {
+    if (items.length === 0) return
+    setSel(prev => {
+      const next = { ...prev }
+      for (const it of items) {
+        if (next[it.id] != null) continue
+        const sug = sugerirMatchProducto({ codigo: it.origen_codigo, nombre: it.origen_nombre }, productosDestino)
+        next[it.id] = sug ? String(sug.id) : NUEVO
+      }
+      return next
+    })
+  }, [items, productosDestino])
+
+  const productosPorId = useMemo(() => {
+    const m = new Map<string, ProductoDB>()
+    for (const p of productosDestino) m.set(String(p.id), p)
+    return m
+  }, [productosDestino])
+
+  const handleAceptar = async () => {
+    setError('')
+    const resoluciones: ResolucionItem[] = items.map(it => {
+      const v = sel[it.id] ?? NUEVO
+      return v === NUEVO
+        ? { item_id: it.id, accion: 'crear_nuevo' }
+        : { item_id: it.id, accion: 'match_existente', producto_destino_id: Number(v) }
+    })
+    try {
+      await onConfirmar(resoluciones)
+    } catch (e) {
+      setError((e as Error).message || 'Error al aceptar el movimiento')
+    }
+  }
+
+  const handleDenegar = async () => {
+    setError('')
+    try {
+      await onDenegar(motivo.trim())
+    } catch (e) {
+      setError((e as Error).message || 'Error al denegar el movimiento')
+    }
+  }
+
+  return (
+    <ModalBase
+      title={`Aceptar movimiento #${movimiento.id}`}
+      description={`Entrante de ${movimiento.origen?.nombre || 'otra sucursal'}. Confirmá el producto de destino para cada item.`}
+      onClose={onClose}
+      maxWidth="max-w-2xl"
+    >
+      <div className="p-4 space-y-3 max-h-[65vh] overflow-y-auto">
+        {loadingItems ? (
+          <div className="flex items-center justify-center py-8 text-gray-500">
+            <Loader2 className="w-5 h-5 animate-spin text-blue-600" /><span className="ml-2">Cargando items...</span>
+          </div>
+        ) : (
+          items.map(it => {
+            const v = sel[it.id] ?? NUEVO
+            const destProd = v !== NUEVO ? productosPorId.get(v) : undefined
+            const costoOrigen = it.origen_costo_con_iva ?? 0
+            const costoDest = destProd?.costo_con_iva ?? 0
+            const costoResultante = v === NUEVO ? costoOrigen : Math.max(costoOrigen, costoDest)
+            return (
+              <div key={it.id} className="border dark:border-gray-600 rounded-lg p-3">
+                <div className="flex items-center justify-between gap-2">
+                  <div className="min-w-0">
+                    <p className="font-medium dark:text-white truncate">{it.origen_nombre}</p>
+                    <p className="text-xs text-gray-500">
+                      {it.cantidad} u · {it.origen_codigo ? `cód ${it.origen_codigo} · ` : ''}costo origen {formatPrecio(costoOrigen)}
+                    </p>
+                  </div>
+                </div>
+                <div className="mt-2">
+                  <label className="block text-xs font-medium mb-1 text-gray-600 dark:text-gray-400">Producto en esta sucursal</label>
+                  <select
+                    value={v}
+                    onChange={e => setSel(prev => ({ ...prev, [it.id]: e.target.value }))}
+                    className="w-full px-2 py-2 text-sm border rounded-lg dark:bg-gray-700 dark:border-gray-600 dark:text-white"
+                  >
+                    <option value={NUEVO}>➕ Crear nuevo (copia de origen)</option>
+                    {productosDestino.map(p => (
+                      <option key={p.id} value={p.id}>{p.nombre}{p.codigo ? ` (${p.codigo})` : ''}</option>
+                    ))}
+                  </select>
+                  <p className="text-xs text-gray-500 mt-1">
+                    {v === NUEVO
+                      ? `Se creará el producto copiando precio y costo de origen.`
+                      : `Costo destino quedará en ${formatPrecio(costoResultante)} (el mayor). Precio sin cambios.`}
+                  </p>
+                </div>
+              </div>
+            )
+          })
+        )}
+
+        {modoDenegar && (
+          <div className="border border-red-200 dark:border-red-800 rounded-lg p-3 bg-red-50 dark:bg-red-900/20">
+            <label className="block text-sm font-medium mb-1 text-red-700 dark:text-red-300">Motivo del rechazo (opcional)</label>
+            <textarea
+              value={motivo} onChange={e => setMotivo(e.target.value)} rows={2}
+              className="w-full px-3 py-2 border rounded-lg dark:bg-gray-700 dark:border-gray-600 dark:text-white"
+              placeholder="Ej: no esperábamos este envío"
+            />
+          </div>
+        )}
+
+        {error && (
+          <div className="p-3 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg flex items-start gap-2 text-sm text-red-600 dark:text-red-400">
+            <AlertTriangle className="w-4 h-4 flex-shrink-0 mt-0.5" /><span>{error}</span>
+          </div>
+        )}
+      </div>
+
+      <div className="flex justify-between gap-2 p-4 border-t bg-gray-50 dark:bg-gray-800 dark:border-gray-700">
+        {!modoDenegar ? (
+          <>
+            <button onClick={() => setModoDenegar(true)} disabled={guardando}
+              className="px-4 py-2 text-red-600 hover:bg-red-50 dark:hover:bg-red-900/20 rounded-lg disabled:opacity-50">
+              Denegar
+            </button>
+            <div className="flex gap-2">
+              <button onClick={onClose} className="px-4 py-2 text-gray-700 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-700 rounded-lg">Cancelar</button>
+              <button onClick={() => { void handleAceptar() }} disabled={guardando || loadingItems || items.length === 0}
+                className="px-4 py-2 bg-green-600 text-white rounded-lg hover:bg-green-700 flex items-center disabled:opacity-50">
+                {guardando && <Loader2 className="w-4 h-4 mr-2 animate-spin" />}<Check className="w-4 h-4 mr-1" /> Aceptar y mover stock
+              </button>
+            </div>
+          </>
+        ) : (
+          <>
+            <button onClick={() => setModoDenegar(false)} disabled={guardando}
+              className="px-4 py-2 text-gray-700 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-700 rounded-lg disabled:opacity-50">
+              Volver
+            </button>
+            <button onClick={() => { void handleDenegar() }} disabled={guardando}
+              className="px-4 py-2 bg-red-600 text-white rounded-lg hover:bg-red-700 flex items-center disabled:opacity-50">
+              {guardando && <Loader2 className="w-4 h-4 mr-2 animate-spin" />}<X className="w-4 h-4 mr-1" /> Confirmar rechazo
+            </button>
+          </>
+        )}
+      </div>
+    </ModalBase>
+  )
+})
+
+export default ModalAceptarMovimiento

--- a/src/components/modals/ModalCrearMovimiento.tsx
+++ b/src/components/modals/ModalCrearMovimiento.tsx
@@ -1,0 +1,166 @@
+/**
+ * ModalCrearMovimiento — la sucursal origen crea una "salida" hacia otra
+ * sucursal. Queda pendiente de aprobación; NO mueve stock todavía.
+ */
+import { memo, useMemo, useState } from 'react'
+import { Loader2, Search, Plus, Trash2, Building2 } from 'lucide-react'
+import ModalBase from './ModalBase'
+import type { ProductoDB, SucursalDB } from '../../types'
+
+interface LineaItem {
+  productoId: string
+  nombre: string
+  cantidad: number
+  stock: number
+}
+
+export interface ModalCrearMovimientoProps {
+  sucursales: SucursalDB[]
+  productos: ProductoDB[]
+  guardando: boolean
+  onClose: () => void
+  onConfirmar: (payload: {
+    sucursalDestinoId: number
+    notas?: string
+    items: Array<{ producto_id: number; cantidad: number }>
+  }) => Promise<void>
+}
+
+const ModalCrearMovimiento = memo(function ModalCrearMovimiento({
+  sucursales, productos, guardando, onClose, onConfirmar,
+}: ModalCrearMovimientoProps) {
+  const [destino, setDestino] = useState<string>('')
+  const [notas, setNotas] = useState<string>('')
+  const [busqueda, setBusqueda] = useState<string>('')
+  const [lineas, setLineas] = useState<LineaItem[]>([])
+  const [error, setError] = useState<string>('')
+
+  const resultados = useMemo(() => {
+    const term = busqueda.trim().toLowerCase()
+    if (!term) return []
+    return productos
+      .filter(p => p.nombre.toLowerCase().includes(term) || (p.codigo || '').toLowerCase().includes(term))
+      .slice(0, 20)
+  }, [productos, busqueda])
+
+  const agregar = (p: ProductoDB) => {
+    setLineas(prev => prev.some(l => l.productoId === p.id)
+      ? prev
+      : [...prev, { productoId: p.id, nombre: p.nombre, cantidad: 1, stock: p.stock || 0 }])
+    setBusqueda('')
+  }
+
+  const setCantidad = (id: string, cant: number) =>
+    setLineas(prev => prev.map(l => l.productoId === id ? { ...l, cantidad: cant } : l))
+
+  const quitar = (id: string) => setLineas(prev => prev.filter(l => l.productoId !== id))
+
+  const handleSubmit = async () => {
+    setError('')
+    if (!destino) { setError('Elegí la sucursal destino.'); return }
+    const items = lineas.filter(l => l.cantidad > 0).map(l => ({ producto_id: Number(l.productoId), cantidad: l.cantidad }))
+    if (items.length === 0) { setError('Agregá al menos un producto con cantidad.'); return }
+    try {
+      await onConfirmar({ sucursalDestinoId: Number(destino), notas: notas.trim() || undefined, items })
+    } catch (e) {
+      setError((e as Error).message || 'Error al crear el movimiento')
+    }
+  }
+
+  return (
+    <ModalBase title="Nueva salida de stock" description="Enviá productos a otra sucursal. Queda pendiente hasta que la sucursal destino lo acepte." onClose={onClose} maxWidth="max-w-xl">
+      <div className="p-4 space-y-4 max-h-[70vh] overflow-y-auto">
+        <div>
+          <label className="block text-sm font-medium mb-1 dark:text-gray-200 flex items-center gap-1">
+            <Building2 className="w-4 h-4" /> Sucursal destino
+          </label>
+          <select
+            value={destino}
+            onChange={e => setDestino(e.target.value)}
+            className="w-full px-3 py-2 border rounded-lg dark:bg-gray-700 dark:border-gray-600 dark:text-white"
+          >
+            <option value="">Seleccionar sucursal...</option>
+            {sucursales.map(s => <option key={s.id} value={s.id}>{s.nombre}</option>)}
+          </select>
+        </div>
+
+        <div>
+          <label className="block text-sm font-medium mb-1 dark:text-gray-200">Agregar productos</label>
+          <div className="relative">
+            <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400" />
+            <input
+              type="text" value={busqueda} onChange={e => setBusqueda(e.target.value)}
+              placeholder="Buscar por nombre o código..."
+              className="w-full pl-9 pr-3 py-2 border rounded-lg dark:bg-gray-700 dark:border-gray-600 dark:text-white"
+            />
+          </div>
+          {resultados.length > 0 && (
+            <div className="mt-1 border rounded-lg divide-y dark:border-gray-600 dark:divide-gray-600 max-h-48 overflow-y-auto">
+              {resultados.map(p => (
+                <button
+                  key={p.id} type="button" onClick={() => agregar(p)}
+                  className="w-full flex items-center justify-between px-3 py-2 text-left text-sm hover:bg-gray-50 dark:hover:bg-gray-700/50"
+                >
+                  <span className="truncate dark:text-white">{p.nombre}</span>
+                  <span className="text-xs text-gray-400 flex-shrink-0 ml-2">stock {p.stock ?? 0}</span>
+                </button>
+              ))}
+            </div>
+          )}
+        </div>
+
+        {lineas.length > 0 && (
+          <div className="border rounded-lg divide-y dark:border-gray-600 dark:divide-gray-600">
+            {lineas.map(l => (
+              <div key={l.productoId} className="flex items-center gap-2 px-3 py-2">
+                <div className="flex-1 min-w-0">
+                  <p className="text-sm font-medium dark:text-white truncate">{l.nombre}</p>
+                  <p className="text-xs text-gray-400">stock disponible: {l.stock}</p>
+                </div>
+                <input
+                  type="number" min="1" inputMode="numeric" value={l.cantidad}
+                  onChange={e => setCantidad(l.productoId, Math.max(0, parseInt(e.target.value) || 0))}
+                  className="w-20 px-2 py-1 text-sm border rounded dark:bg-gray-700 dark:border-gray-600 dark:text-white"
+                />
+                <button type="button" onClick={() => quitar(l.productoId)} className="p-1 text-red-500 hover:bg-red-50 dark:hover:bg-red-900/20 rounded">
+                  <Trash2 className="w-4 h-4" />
+                </button>
+              </div>
+            ))}
+          </div>
+        )}
+
+        <div>
+          <label className="block text-sm font-medium mb-1 dark:text-gray-200">Notas (opcional)</label>
+          <textarea
+            value={notas} onChange={e => setNotas(e.target.value)} rows={2}
+            className="w-full px-3 py-2 border rounded-lg dark:bg-gray-700 dark:border-gray-600 dark:text-white"
+            placeholder="Observaciones del envío..."
+          />
+        </div>
+
+        {error && (
+          <div className="p-3 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg text-sm text-red-600 dark:text-red-400">
+            {error}
+          </div>
+        )}
+      </div>
+
+      <div className="flex justify-end gap-2 p-4 border-t bg-gray-50 dark:bg-gray-800 dark:border-gray-700">
+        <button onClick={onClose} className="px-4 py-2 text-gray-700 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-700 rounded-lg">
+          Cancelar
+        </button>
+        <button
+          onClick={() => { void handleSubmit() }}
+          disabled={guardando}
+          className="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 flex items-center disabled:opacity-50"
+        >
+          {guardando && <Loader2 className="w-4 h-4 mr-2 animate-spin" />}
+          Crear salida
+        </button>
+      </div>
+    </ModalBase>
+  )
+})
+
+export default ModalCrearMovimiento

--- a/src/components/vistas/VistaMovimientos.tsx
+++ b/src/components/vistas/VistaMovimientos.tsx
@@ -1,0 +1,155 @@
+/**
+ * Panel de Movimientos entre Sucursales (con aprobación).
+ *
+ * Muestra movimientos entrantes (destino = sucursal activa) y salientes
+ * (origen = activa). Los pendientes ENTRANTES se pueden Aceptar/Denegar
+ * (admin/encargado). Los salientes son solo lectura (esperan aprobación).
+ */
+import { memo } from 'react'
+import { Loader2, ArrowDownLeft, ArrowUpRight, Plus, Check, X, PackageX } from 'lucide-react'
+import { formatPrecio, formatDateTime } from '../../utils/formatters'
+import type { MovimientoSucursalDB, EstadoMovimiento } from '../../hooks/queries'
+
+type TabEstado = EstadoMovimiento | 'todos'
+
+export interface VistaMovimientosProps {
+  movimientos: MovimientoSucursalDB[]
+  loading: boolean
+  currentSucursalId: number | null
+  canResolver: boolean
+  estado: TabEstado
+  onEstadoChange: (e: TabEstado) => void
+  onNuevaSalida: () => void
+  onAceptar: (mov: MovimientoSucursalDB) => void
+  onDenegar: (mov: MovimientoSucursalDB) => void
+}
+
+const TABS: Array<{ value: TabEstado; label: string }> = [
+  { value: 'pendiente', label: 'Pendientes' },
+  { value: 'aceptada', label: 'Aceptadas' },
+  { value: 'denegada', label: 'Denegadas' },
+  { value: 'todos', label: 'Todas' },
+]
+
+const ESTADO_BADGE: Record<EstadoMovimiento, string> = {
+  pendiente: 'bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-400',
+  aceptada: 'bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400',
+  denegada: 'bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400',
+}
+
+const VistaMovimientos = memo(function VistaMovimientos({
+  movimientos, loading, currentSucursalId, canResolver, estado, onEstadoChange,
+  onNuevaSalida, onAceptar, onDenegar,
+}: VistaMovimientosProps) {
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between flex-wrap gap-2">
+        <h2 className="text-xl font-bold text-gray-900 dark:text-white">Movimientos entre sucursales</h2>
+        <button
+          onClick={onNuevaSalida}
+          className="inline-flex items-center gap-2 px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded-lg font-medium"
+        >
+          <Plus className="w-4 h-4" /> Nueva salida
+        </button>
+      </div>
+
+      {/* Tabs */}
+      <div className="flex gap-1 border-b dark:border-gray-700">
+        {TABS.map(t => (
+          <button
+            key={t.value}
+            onClick={() => onEstadoChange(t.value)}
+            className={`px-4 py-2 text-sm font-medium border-b-2 -mb-px transition-colors ${
+              estado === t.value
+                ? 'border-blue-600 text-blue-600 dark:text-blue-400'
+                : 'border-transparent text-gray-500 hover:text-gray-700 dark:hover:text-gray-300'
+            }`}
+          >
+            {t.label}
+          </button>
+        ))}
+      </div>
+
+      {loading ? (
+        <div className="flex items-center justify-center py-12 text-gray-500">
+          <Loader2 className="w-6 h-6 animate-spin text-blue-600" /><span className="ml-2">Cargando...</span>
+        </div>
+      ) : movimientos.length === 0 ? (
+        <div className="text-center py-12">
+          <PackageX className="w-12 h-12 mx-auto text-gray-300 dark:text-gray-600 mb-3" />
+          <p className="text-gray-500">No hay movimientos para mostrar</p>
+        </div>
+      ) : (
+        <div className="space-y-3">
+          {movimientos.map(mov => {
+            const entrante = mov.sucursal_destino_id === currentSucursalId
+            const contraparte = entrante ? mov.origen?.nombre : mov.destino?.nombre
+            const puedeResolver = entrante && mov.estado === 'pendiente' && canResolver
+            return (
+              <div key={mov.id} className="bg-white dark:bg-gray-800 rounded-xl border dark:border-gray-700 p-4">
+                <div className="flex items-start justify-between gap-3 flex-wrap">
+                  <div className="flex items-start gap-3 min-w-0">
+                    <div className={`w-9 h-9 rounded-full flex items-center justify-center flex-shrink-0 ${
+                      entrante ? 'bg-green-100 dark:bg-green-900/30' : 'bg-blue-100 dark:bg-blue-900/30'
+                    }`}>
+                      {entrante
+                        ? <ArrowDownLeft className="w-5 h-5 text-green-600 dark:text-green-400" />
+                        : <ArrowUpRight className="w-5 h-5 text-blue-600 dark:text-blue-400" />}
+                    </div>
+                    <div className="min-w-0">
+                      <div className="flex items-center gap-2 flex-wrap">
+                        <span className="font-semibold text-gray-900 dark:text-white">
+                          {entrante ? 'Entrante de' : 'Saliente a'} {contraparte || 'otra sucursal'}
+                        </span>
+                        <span className={`px-2 py-0.5 rounded-full text-xs font-medium ${ESTADO_BADGE[mov.estado]}`}>
+                          {mov.estado}
+                        </span>
+                        <span className="text-xs text-gray-400">#{mov.id}</span>
+                      </div>
+                      <p className="text-xs text-gray-500 mt-0.5">
+                        {mov.created_at && formatDateTime(mov.created_at)}
+                        {mov.creador?.nombre ? ` · ${mov.creador.nombre}` : ''}
+                      </p>
+                      {mov.notas && <p className="text-xs text-gray-500 italic mt-1">{mov.notas}</p>}
+                      {mov.estado === 'denegada' && mov.motivo_rechazo && (
+                        <p className="text-xs text-red-500 mt-1">Motivo: {mov.motivo_rechazo}</p>
+                      )}
+                    </div>
+                  </div>
+                  <div className="text-right flex-shrink-0">
+                    <p className="font-bold text-gray-900 dark:text-white">{formatPrecio(mov.total_costo || 0)}</p>
+                    <p className="text-xs text-gray-400">costo total</p>
+                  </div>
+                </div>
+
+                {puedeResolver && (
+                  <div className="flex justify-end gap-2 mt-3 pt-3 border-t dark:border-gray-700">
+                    <button
+                      onClick={() => onDenegar(mov)}
+                      className="inline-flex items-center gap-1.5 px-3 py-2 text-sm rounded-lg bg-red-50 text-red-600 hover:bg-red-100 dark:bg-red-900/20 dark:text-red-400"
+                    >
+                      <X className="w-4 h-4" /> Denegar
+                    </button>
+                    <button
+                      onClick={() => onAceptar(mov)}
+                      className="inline-flex items-center gap-1.5 px-3 py-2 text-sm rounded-lg bg-green-600 text-white hover:bg-green-700"
+                    >
+                      <Check className="w-4 h-4" /> Aceptar
+                    </button>
+                  </div>
+                )}
+                {!entrante && mov.estado === 'pendiente' && (
+                  <p className="text-xs text-amber-600 dark:text-amber-400 mt-2 pt-2 border-t dark:border-gray-700">
+                    Esperando aprobación de {mov.destino?.nombre || 'la sucursal destino'}.
+                  </p>
+                )}
+              </div>
+            )
+          })}
+        </div>
+      )}
+    </div>
+  )
+})
+
+export default VistaMovimientos

--- a/src/hooks/queries/index.ts
+++ b/src/hooks/queries/index.ts
@@ -158,6 +158,32 @@ export {
 } from './useTransferenciasQuery'
 export type { TransferenciasFiltros } from './useTransferenciasQuery'
 
+// Movimientos entre sucursales (con aprobación, mig 076)
+export {
+  movimientosKeys,
+  MOVIMIENTOS_PAGE_SIZE,
+  useMovimientosQuery,
+  useMovimientoItemsQuery,
+  useCrearMovimientoMutation,
+  useAceptarMovimientoMutation,
+  useDenegarMovimientoMutation,
+} from './useMovimientosQuery'
+export type {
+  EstadoMovimiento,
+  MovimientoSucursalDB,
+  MovimientoItemDB,
+  MovimientosFiltros,
+  ResolucionItem,
+} from './useMovimientosQuery'
+
+// Notificaciones (campanita DB-backed, mig 076)
+export {
+  useNotificacionesQuery,
+  useMarcarNotificacionLeidaMutation,
+  useMarcarTodasNotificacionesLeidasMutation,
+} from './useNotificacionesQuery'
+export type { NotificacionDB } from './useNotificacionesQuery'
+
 // Sustitucion de regalos en promociones (mig 058)
 export { useSustituirRegaloMutation } from './useSustituirRegaloMutation'
 

--- a/src/hooks/queries/useMovimientosQuery.ts
+++ b/src/hooks/queries/useMovimientosQuery.ts
@@ -1,0 +1,210 @@
+/**
+ * TanStack Query hooks para Movimientos entre Sucursales (con aprobación).
+ *
+ * Flujo A→B: la sucursal origen crea un movimiento "pendiente" (no mueve stock);
+ * la sucursal destino lo acepta (mueve stock atómico, con matching de productos)
+ * o lo deniega. RLS bidireccional: el listado trae tanto entrantes (destino =
+ * activa) como salientes (origen = activa).
+ *
+ * Doble FK a `sucursales` (origen/destino) → hints PostgREST explícitos.
+ */
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import { supabase } from '../supabase/base'
+import { fechaLocalISO, fechaHaceDias } from '../../utils/formatters'
+import { useSucursal } from '../../contexts/SucursalContext'
+
+export const MOVIMIENTOS_PAGE_SIZE = 50
+
+export type EstadoMovimiento = 'pendiente' | 'aceptada' | 'denegada'
+
+export interface MovimientoSucursalDB {
+  id: number
+  sucursal_origen_id: number
+  sucursal_destino_id: number
+  estado: EstadoMovimiento
+  total_costo: number
+  notas: string | null
+  motivo_rechazo: string | null
+  creado_por: string
+  resuelto_por: string | null
+  created_at: string
+  resuelto_at: string | null
+  origen?: { id: number; nombre: string } | null
+  destino?: { id: number; nombre: string } | null
+  creador?: { id: string; nombre: string } | null
+}
+
+export interface MovimientoItemDB {
+  id: number
+  movimiento_id: number
+  producto_origen_id: number
+  cantidad: number
+  origen_nombre: string
+  origen_codigo: string | null
+  origen_tp_import_id: number | null
+  origen_categoria: string | null
+  origen_precio: number | null
+  origen_precio_sin_iva: number | null
+  origen_costo_sin_iva: number | null
+  origen_costo_con_iva: number | null
+  origen_impuestos_internos: number | null
+  origen_porcentaje_iva: number | null
+  producto_destino_id: number | null
+  resolucion: 'match_existente' | 'creado_nuevo' | null
+  costo_aplicado_destino: number | null
+}
+
+export interface MovimientosFiltros {
+  desde?: string
+  hasta?: string
+  pagina?: number
+  estado?: EstadoMovimiento | 'todos'
+}
+
+/** Resolución de un item al aceptar. */
+export interface ResolucionItem {
+  item_id: number
+  accion: 'match_existente' | 'crear_nuevo'
+  producto_destino_id?: number
+}
+
+export const movimientosKeys = {
+  all: (s: number | null) => ['movimientos', s] as const,
+  lists: (s: number | null) => [...movimientosKeys.all(s), 'list'] as const,
+  list: (s: number | null, f: Record<string, unknown>) => [...movimientosKeys.lists(s), f] as const,
+  items: (s: number | null, id: string) => [...movimientosKeys.all(s), 'items', id] as const,
+}
+
+interface FetchOpts {
+  desde: string
+  hasta: string
+  estado?: EstadoMovimiento | 'todos'
+  limit: number
+  offset: number
+}
+
+async function fetchMovimientos(opts: FetchOpts): Promise<MovimientoSucursalDB[]> {
+  let q = supabase
+    .from('movimientos_sucursal')
+    .select(`
+      *,
+      origen:sucursales!sucursal_origen_id(id, nombre),
+      destino:sucursales!sucursal_destino_id(id, nombre),
+      creador:perfiles!creado_por(id, nombre)
+    `)
+    .gte('created_at', `${opts.desde}T00:00:00`)
+    .lte('created_at', `${opts.hasta}T23:59:59`)
+    .order('created_at', { ascending: false })
+    .range(opts.offset, opts.offset + opts.limit - 1)
+
+  if (opts.estado && opts.estado !== 'todos') {
+    q = q.eq('estado', opts.estado)
+  }
+
+  const { data, error } = await q
+  if (error) {
+    if (error.message.includes('does not exist')) return []
+    throw error
+  }
+  return (data || []) as MovimientoSucursalDB[]
+}
+
+async function fetchMovimientoItems(movimientoId: string): Promise<MovimientoItemDB[]> {
+  const { data, error } = await supabase
+    .from('movimiento_sucursal_items')
+    .select('*')
+    .eq('movimiento_id', movimientoId)
+    .order('id', { ascending: true })
+  if (error) throw error
+  return (data || []) as MovimientoItemDB[]
+}
+
+interface RPCResult { success: boolean; movimiento_id?: number; error?: string }
+
+async function crearMovimiento(input: {
+  sucursalDestinoId: number
+  notas?: string | null
+  items: Array<{ producto_id: number; cantidad: number }>
+}): Promise<number> {
+  const { data, error } = await supabase.rpc('crear_movimiento_sucursal', {
+    p_sucursal_destino_id: input.sucursalDestinoId,
+    p_notas: input.notas ?? null,
+    p_items: input.items,
+  })
+  if (error) throw error
+  const r = data as RPCResult
+  if (!r.success) throw new Error(r.error || 'Error al crear el movimiento')
+  return r.movimiento_id!
+}
+
+async function aceptarMovimiento(input: { movimientoId: number; resoluciones: ResolucionItem[] }): Promise<void> {
+  const { data, error } = await supabase.rpc('aceptar_movimiento_sucursal', {
+    p_movimiento_id: input.movimientoId,
+    p_resoluciones: input.resoluciones,
+  })
+  if (error) throw error
+  const r = data as RPCResult
+  if (!r.success) throw new Error(r.error || 'Error al aceptar el movimiento')
+}
+
+async function denegarMovimiento(input: { movimientoId: number; motivo?: string | null }): Promise<void> {
+  const { data, error } = await supabase.rpc('denegar_movimiento_sucursal', {
+    p_movimiento_id: input.movimientoId,
+    p_motivo: input.motivo ?? null,
+  })
+  if (error) throw error
+  const r = data as RPCResult
+  if (!r.success) throw new Error(r.error || 'Error al denegar el movimiento')
+}
+
+export function useMovimientosQuery(filtros: MovimientosFiltros = {}) {
+  const { currentSucursalId } = useSucursal()
+  const desde = filtros.desde ?? fechaHaceDias(60)
+  const hasta = filtros.hasta ?? fechaLocalISO()
+  const pagina = filtros.pagina ?? 1
+  const estado = filtros.estado ?? 'todos'
+  return useQuery({
+    queryKey: movimientosKeys.list(currentSucursalId, { desde, hasta, pagina, estado }),
+    queryFn: () => fetchMovimientos({
+      desde, hasta, estado,
+      limit: MOVIMIENTOS_PAGE_SIZE,
+      offset: (pagina - 1) * MOVIMIENTOS_PAGE_SIZE,
+    }),
+    staleTime: 60 * 1000,
+  })
+}
+
+export function useMovimientoItemsQuery(movimientoId: string | null | undefined) {
+  const { currentSucursalId } = useSucursal()
+  return useQuery({
+    queryKey: movimientosKeys.items(currentSucursalId, movimientoId ?? ''),
+    queryFn: () => fetchMovimientoItems(movimientoId!),
+    enabled: !!movimientoId,
+    staleTime: 30 * 1000,
+  })
+}
+
+function useInvalidarMovimientos() {
+  const queryClient = useQueryClient()
+  const { currentSucursalId } = useSucursal()
+  return () => {
+    queryClient.invalidateQueries({ queryKey: movimientosKeys.lists(currentSucursalId) })
+    queryClient.invalidateQueries({ queryKey: ['productos'] })
+    queryClient.invalidateQueries({ queryKey: ['notificaciones'] })
+  }
+}
+
+export function useCrearMovimientoMutation() {
+  const invalidar = useInvalidarMovimientos()
+  return useMutation({ mutationFn: crearMovimiento, onSuccess: invalidar })
+}
+
+export function useAceptarMovimientoMutation() {
+  const invalidar = useInvalidarMovimientos()
+  return useMutation({ mutationFn: aceptarMovimiento, onSuccess: invalidar })
+}
+
+export function useDenegarMovimientoMutation() {
+  const invalidar = useInvalidarMovimientos()
+  return useMutation({ mutationFn: denegarMovimiento, onSuccess: invalidar })
+}

--- a/src/hooks/queries/useNotificacionesQuery.ts
+++ b/src/hooks/queries/useNotificacionesQuery.ts
@@ -1,0 +1,72 @@
+/**
+ * Notificaciones persistentes (DB) para la campanita.
+ *
+ * Se leen por POLLING (no realtime): el header de sucursal no viaja por
+ * websocket y la publicación realtime está vacía, así que polling con TanStack
+ * Query es lo robusto. RLS filtra por usuario (auth.uid()).
+ */
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import { supabase } from '../supabase/base'
+import { useAuthData } from '../../contexts/AuthDataContext'
+
+export interface NotificacionDB {
+  id: number
+  usuario_id: string
+  sucursal_id: number | null
+  tipo: string
+  titulo: string
+  mensaje: string | null
+  entidad_tipo: string | null
+  entidad_id: number | null
+  payload: Record<string, unknown> | null
+  leida: boolean
+  created_at: string
+  leida_at: string | null
+}
+
+async function fetchNotificaciones(): Promise<NotificacionDB[]> {
+  const { data, error } = await supabase
+    .from('notificaciones')
+    .select('*')
+    .order('created_at', { ascending: false })
+    .limit(30)
+  if (error) {
+    if (error.message.includes('does not exist')) return []
+    throw error
+  }
+  return (data || []) as NotificacionDB[]
+}
+
+export function useNotificacionesQuery() {
+  const { perfil, isOnline } = useAuthData()
+  return useQuery({
+    queryKey: ['notificaciones'],
+    queryFn: fetchNotificaciones,
+    enabled: !!perfil && isOnline !== false,
+    refetchInterval: 60_000,
+    refetchOnWindowFocus: true,
+    staleTime: 30_000,
+  })
+}
+
+export function useMarcarNotificacionLeidaMutation() {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: async (id: number) => {
+      const { error } = await supabase.rpc('marcar_notificacion_leida', { p_id: id })
+      if (error) throw error
+    },
+    onSuccess: () => qc.invalidateQueries({ queryKey: ['notificaciones'] }),
+  })
+}
+
+export function useMarcarTodasNotificacionesLeidasMutation() {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: async () => {
+      const { error } = await supabase.rpc('marcar_todas_notificaciones_leidas')
+      if (error) throw error
+    },
+    onSuccess: () => qc.invalidateQueries({ queryKey: ['notificaciones'] }),
+  })
+}

--- a/src/utils/matchProducto.ts
+++ b/src/utils/matchProducto.ts
@@ -1,0 +1,29 @@
+/**
+ * Matching de productos entre sucursales (al aceptar un movimiento).
+ *
+ * Mismo criterio estricto que el escaneo de facturas (ModalCompra): match solo
+ * por código exacto o nombre exacto (normalizado). Cualquier coincidencia
+ * parcial queda fuera para que el usuario decida.
+ */
+import type { ProductoDB } from '../types'
+
+export function normalizarTexto(s: string | null | undefined): string {
+  return (s ?? '').trim().toLowerCase().replace(/\s+/g, ' ')
+}
+
+export function sugerirMatchProducto(
+  ref: { codigo?: string | null; nombre?: string | null },
+  productos: ProductoDB[],
+): ProductoDB | null {
+  const cod = normalizarTexto(ref.codigo)
+  if (cod) {
+    const porCodigo = productos.find(p => normalizarTexto(p.codigo) === cod)
+    if (porCodigo) return porCodigo
+  }
+  const nom = normalizarTexto(ref.nombre)
+  if (nom) {
+    const porNombre = productos.find(p => normalizarTexto(p.nombre) === nom)
+    if (porNombre) return porNombre
+  }
+  return null
+}


### PR DESCRIPTION
## Contexto
Los "movimientos entre sucursales" eran operaciones de un solo lado e inmediatas. Ahora que hay una sola DB multi-sucursal, se implementa un traslado **A→B con aprobación** que **mueve stock real**, con notificación a la sucursal destino, matching de productos y reglas de costo.

## Flujo (Feature 2 del plan)
1. Sucursal **A** crea una **salida** con productos → estado **pendiente** (NO mueve stock).
2. Admin/encargado de **B** recibe **notificación en la campanita** y ve el movimiento entrante en el panel; puede **Aceptar** o **Denegar**.
3. **Aceptar** → mueve stock atómicamente (−A, +B). **Denegar** → sin cambios, queda visible para ambas como denegada.
4. **Costo destino** = `max(costo origen, costo destino)`. **Precios no se tocan.**
5. Si el producto **no existe** en B → se crea copiando el de A. Si existe con **otro nombre**, al aceptar la app **sugiere** el match y quien acepta lo confirma, elige otro de la lista, o crea uno nuevo (copia).

## Implementación
- **Migración 076** (aplicada a prod): tablas `movimientos_sucursal`, `movimiento_sucursal_items` (con **snapshot** del producto origen), `notificaciones`; RLS bidireccional; RPCs `crear/aceptar/denegar_movimiento_sucursal` (SECURITY DEFINER, transaccionales, gate por rol+sucursal, `FOR UPDATE` anti doble-aceptación, validación de stock, regla de costo, copia de producto) + helpers de notificación (fan-out por usuario, helpers internos con EXECUTE revocado).
- **Frontend:** hooks `useMovimientosQuery` / `useNotificacionesQuery`; `VistaMovimientos` (tabs por estado, entrante/saliente); `ModalCrearMovimiento`; `ModalAceptarMovimiento` (matching por item); `MovimientosContainer`; `DbNotificationBell` (campanita DB por **polling**, reemplaza la local — los toasts transitorios siguen igual); util `matchProducto`.
- **Permisos/ruteo:** `/transferencias` → admin+encargado → `MovimientosContainer`; menú "Mov. Sucursales" habilitado a encargado.
- El flujo viejo (`transferencias_stock`) queda como histórico en DB; su UI ya no se enlaza.

## Notas
- **Campanita por polling** (no realtime): el header de sucursal no viaja por websocket y la publicación realtime está vacía. Realtime de `notificaciones` queda como mejora futura (su RLS es por `auth.uid()`).
- La **migración 076 ya está aplicada a producción** (verificada: RLS on, 7 funciones, smoke test de RPCs OK).

## Verificación
- `npm run typecheck` ✅ · `npm run lint` ✅ · `npm run test:run` ✅ (688) · `npm run build` ✅ · `get_advisors(security)` sin issues nuevos (solo el WARN estándar de SECURITY DEFINER, igual que el resto del proyecto).
- **Pendiente (manual, 2 sucursales):** crear salida en A → notificación + entrante en B → aceptar resolviendo matches → stock baja en A / sube en B, producto nuevo creado con precio copiado, costo = max; probar stock insuficiente (rollback), doble aceptación, denegar, permisos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)