### PR TITLE
Historial con usuario, control de stock por planilla y descuentos por categoría

### DIFF
--- a/migrations/077_fix_pedido_historial_captura_usuario.sql
+++ b/migrations/077_fix_pedido_historial_captura_usuario.sql
@@ -1,0 +1,104 @@
+-- Migración 077: Historial de pedidos — capturar el usuario real del cambio
+--
+-- Antes: los triggers que registran cambios en pedido_historial leían
+-- current_setting('app.current_user_id'), una variable de sesión que la app
+-- NUNCA setea → usuario_id quedaba NULL y el modal mostraba "Usuario desconocido".
+--
+-- Ahora: si esa GUC no está seteada, caen en auth.uid() (disponible dentro del
+-- request autenticado de PostgREST/RPC). Cambios hechos por service-role (bot,
+-- edge functions sin JWT) quedan con auth.uid()=NULL → el front los muestra como
+-- "Sistema". Forward-only: las filas históricas con usuario NULL no se recuperan.
+
+BEGIN;
+
+CREATE OR REPLACE FUNCTION public.registrar_cambio_pedido()
+ RETURNS trigger
+ LANGUAGE plpgsql
+ SET search_path TO 'public'
+AS $function$
+DECLARE
+  usuario_actual UUID;
+BEGIN
+  BEGIN
+    usuario_actual := COALESCE(
+      NULLIF(current_setting('app.current_user_id', true), '')::uuid,
+      auth.uid()
+    );
+  EXCEPTION WHEN OTHERS THEN
+    usuario_actual := auth.uid();
+  END;
+
+  IF OLD.estado IS DISTINCT FROM NEW.estado THEN
+    INSERT INTO pedido_historial (pedido_id, usuario_id, campo_modificado, valor_anterior, valor_nuevo, sucursal_id)
+    VALUES (NEW.id, usuario_actual, 'estado', OLD.estado, NEW.estado, NEW.sucursal_id);
+  END IF;
+
+  IF OLD.transportista_id IS DISTINCT FROM NEW.transportista_id THEN
+    INSERT INTO pedido_historial (pedido_id, usuario_id, campo_modificado, valor_anterior, valor_nuevo, sucursal_id)
+    VALUES (NEW.id, usuario_actual, 'transportista_id',
+            COALESCE(OLD.transportista_id::TEXT, 'sin asignar'),
+            COALESCE(NEW.transportista_id::TEXT, 'sin asignar'),
+            NEW.sucursal_id);
+  END IF;
+
+  IF OLD.notas IS DISTINCT FROM NEW.notas THEN
+    INSERT INTO pedido_historial (pedido_id, usuario_id, campo_modificado, valor_anterior, valor_nuevo, sucursal_id)
+    VALUES (NEW.id, usuario_actual, 'notas',
+            COALESCE(OLD.notas, '(sin notas)'),
+            COALESCE(NEW.notas, '(sin notas)'),
+            NEW.sucursal_id);
+  END IF;
+
+  IF OLD.forma_pago IS DISTINCT FROM NEW.forma_pago THEN
+    INSERT INTO pedido_historial (pedido_id, usuario_id, campo_modificado, valor_anterior, valor_nuevo, sucursal_id)
+    VALUES (NEW.id, usuario_actual, 'forma_pago',
+            COALESCE(OLD.forma_pago, 'efectivo'),
+            COALESCE(NEW.forma_pago, 'efectivo'),
+            NEW.sucursal_id);
+  END IF;
+
+  IF OLD.estado_pago IS DISTINCT FROM NEW.estado_pago THEN
+    INSERT INTO pedido_historial (pedido_id, usuario_id, campo_modificado, valor_anterior, valor_nuevo, sucursal_id)
+    VALUES (NEW.id, usuario_actual, 'estado_pago',
+            COALESCE(OLD.estado_pago, 'pendiente'),
+            COALESCE(NEW.estado_pago, 'pendiente'),
+            NEW.sucursal_id);
+  END IF;
+
+  IF OLD.total IS DISTINCT FROM NEW.total THEN
+    INSERT INTO pedido_historial (pedido_id, usuario_id, campo_modificado, valor_anterior, valor_nuevo, sucursal_id)
+    VALUES (NEW.id, usuario_actual, 'total',
+            OLD.total::TEXT,
+            NEW.total::TEXT,
+            NEW.sucursal_id);
+  END IF;
+
+  RETURN NEW;
+END;
+$function$;
+
+CREATE OR REPLACE FUNCTION public.registrar_creacion_pedido()
+ RETURNS trigger
+ LANGUAGE plpgsql
+ SET search_path TO 'public'
+AS $function$
+DECLARE
+  usuario_actual UUID;
+BEGIN
+  BEGIN
+    usuario_actual := COALESCE(
+      NULLIF(current_setting('app.current_user_id', true), '')::uuid,
+      auth.uid()
+    );
+  EXCEPTION WHEN OTHERS THEN
+    usuario_actual := NEW.usuario_id;
+  END;
+
+  INSERT INTO pedido_historial (pedido_id, usuario_id, campo_modificado, valor_anterior, valor_nuevo, sucursal_id)
+  VALUES (NEW.id, COALESCE(usuario_actual, NEW.usuario_id), 'creacion', NULL, 'Pedido creado', NEW.sucursal_id);
+
+  RETURN NEW;
+END;
+$function$;
+
+COMMIT;

--- a/migrations/078_control_stock_planilla.sql
+++ b/migrations/078_control_stock_planilla.sql
@@ -1,0 +1,168 @@
+-- Migración 078: Control de stock por planilla (cargar → ajustar → histórico)
+--
+-- Ya existía la DESCARGA de la planilla (exportControlStock). Esto agrega la
+-- CARGA: una RPC que aplica los ajustes, registra cada alta/baja en
+-- stock_historico (origen='control_stock') y agrupa cada carga en una "sesión"
+-- (control_stock_sesiones) para el histórico.
+--
+-- Permisos: solo admin puede aplicar (la RPC revalida es_admin()). Descargar y
+-- ver histórico los puede admin y encargado (SELECT por sucursal vía RLS).
+-- Regla de seguridad (en el front): solo se ajustan ítems con "Stock Real"
+-- cargado; los vacíos se omiten (no se pisa a 0 lo no controlado).
+
+BEGIN;
+
+-- =========================================================================
+-- TABLA CABECERA (una fila por carga de planilla)
+-- =========================================================================
+CREATE TABLE IF NOT EXISTS public.control_stock_sesiones (
+  id            bigint GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+  fecha         timestamptz NOT NULL DEFAULT now(),
+  usuario_id    uuid,
+  sucursal_id   bigint NOT NULL REFERENCES public.sucursales(id) ON DELETE CASCADE,
+  total_items   integer NOT NULL DEFAULT 0,
+  total_altas   integer NOT NULL DEFAULT 0,
+  total_bajas   integer NOT NULL DEFAULT 0,
+  observaciones text
+);
+
+-- FK al perfil del usuario (para embeber el nombre del uploader vía PostgREST).
+DO $$ BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'control_stock_sesiones_usuario_id_fkey'
+  ) THEN
+    ALTER TABLE public.control_stock_sesiones
+      ADD CONSTRAINT control_stock_sesiones_usuario_id_fkey
+      FOREIGN KEY (usuario_id) REFERENCES public.perfiles(id) ON DELETE SET NULL;
+  END IF;
+END $$;
+
+ALTER TABLE public.control_stock_sesiones ENABLE ROW LEVEL SECURITY;
+
+-- SELECT: cualquier usuario de la sucursal (admin y encargado ven el histórico).
+-- INSERT/UPDATE: solo vía RPC SECURITY DEFINER (no se exponen policies de escritura).
+DROP POLICY IF EXISTS mt_control_stock_sesiones_select ON public.control_stock_sesiones;
+CREATE POLICY mt_control_stock_sesiones_select ON public.control_stock_sesiones
+  FOR SELECT TO authenticated
+  USING (sucursal_id = current_sucursal_id());
+
+-- Índice para traer el detalle de cada sesión (stock_historico) rápido.
+CREATE INDEX IF NOT EXISTS idx_stock_historico_control_sesion
+  ON public.stock_historico (referencia_id)
+  WHERE origen = 'control_stock';
+
+-- =========================================================================
+-- RPC: aplicar los ajustes de una planilla completada
+--   p_ajustes = [{ "producto_id": <bigint>, "stock_real": <int> }, ...]
+-- Solo admin. Solo productos de la sucursal activa. Solo escribe si hay
+-- diferencia. NOTA: stock_historico.diferencia es columna GENERADA (no se
+-- inserta; la calcula la DB).
+-- =========================================================================
+CREATE OR REPLACE FUNCTION public.aplicar_control_stock(
+  p_ajustes      jsonb,
+  p_observaciones text DEFAULT NULL
+) RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $function$
+DECLARE
+  v_sucursal_id   bigint;
+  v_usuario_id    uuid;
+  v_sesion_id     bigint;
+  v_total_items   integer := 0;
+  v_total_altas   integer := 0;
+  v_total_bajas   integer := 0;
+  v_ajuste        jsonb;
+  v_producto_id   bigint;
+  v_stock_real    integer;
+  v_stock_actual  integer;
+  v_diferencia    integer;
+  v_aplicados     jsonb := '[]'::jsonb;
+  v_no_encontrados jsonb := '[]'::jsonb;
+BEGIN
+  IF NOT es_admin() THEN
+    RAISE EXCEPTION 'Solo un administrador puede aplicar ajustes de control de stock';
+  END IF;
+
+  v_sucursal_id := current_sucursal_id();
+  IF v_sucursal_id IS NULL THEN
+    RAISE EXCEPTION 'No hay sucursal activa';
+  END IF;
+  v_usuario_id := auth.uid();
+
+  INSERT INTO control_stock_sesiones (usuario_id, sucursal_id, observaciones)
+  VALUES (v_usuario_id, v_sucursal_id, p_observaciones)
+  RETURNING id INTO v_sesion_id;
+
+  FOR v_ajuste IN SELECT * FROM jsonb_array_elements(COALESCE(p_ajustes, '[]'::jsonb))
+  LOOP
+    v_producto_id := (v_ajuste->>'producto_id')::bigint;
+    -- stock_real vacío/null => ítem no contado => se saltea (no se ajusta a 0).
+    IF (v_ajuste->>'stock_real') IS NULL OR btrim(v_ajuste->>'stock_real') = '' THEN
+      CONTINUE;
+    END IF;
+    v_stock_real := round((v_ajuste->>'stock_real')::numeric)::integer;
+    IF v_stock_real < 0 THEN
+      CONTINUE;
+    END IF;
+
+    SELECT stock INTO v_stock_actual
+    FROM productos
+    WHERE id = v_producto_id AND sucursal_id = v_sucursal_id
+    FOR UPDATE;
+
+    IF NOT FOUND THEN
+      v_no_encontrados := v_no_encontrados || jsonb_build_object('producto_id', v_producto_id);
+      CONTINUE;
+    END IF;
+
+    v_diferencia := v_stock_real - v_stock_actual;
+
+    IF v_diferencia <> 0 THEN
+      UPDATE productos SET stock = v_stock_real, updated_at = now()
+      WHERE id = v_producto_id AND sucursal_id = v_sucursal_id;
+
+      INSERT INTO stock_historico (
+        producto_id, stock_anterior, stock_nuevo, origen,
+        referencia_tipo, referencia_id, usuario_id, sucursal_id
+      ) VALUES (
+        v_producto_id, v_stock_actual, v_stock_real, 'control_stock',
+        'control_stock_sesion', v_sesion_id, v_usuario_id, v_sucursal_id
+      );
+
+      v_total_items := v_total_items + 1;
+      IF v_diferencia > 0 THEN
+        v_total_altas := v_total_altas + v_diferencia;
+      ELSE
+        v_total_bajas := v_total_bajas + abs(v_diferencia);
+      END IF;
+
+      v_aplicados := v_aplicados || jsonb_build_object(
+        'producto_id', v_producto_id,
+        'stock_anterior', v_stock_actual,
+        'stock_nuevo', v_stock_real,
+        'diferencia', v_diferencia
+      );
+    END IF;
+  END LOOP;
+
+  UPDATE control_stock_sesiones
+  SET total_items = v_total_items, total_altas = v_total_altas, total_bajas = v_total_bajas
+  WHERE id = v_sesion_id;
+
+  RETURN jsonb_build_object(
+    'sesion_id', v_sesion_id,
+    'total_items', v_total_items,
+    'total_altas', v_total_altas,
+    'total_bajas', v_total_bajas,
+    'aplicados', v_aplicados,
+    'no_encontrados', v_no_encontrados
+  );
+END;
+$function$;
+
+REVOKE ALL ON FUNCTION public.aplicar_control_stock(jsonb, text) FROM public;
+GRANT EXECUTE ON FUNCTION public.aplicar_control_stock(jsonb, text) TO authenticated;
+
+COMMIT;

--- a/migrations/079_cliente_descuentos_categoria.sql
+++ b/migrations/079_cliente_descuentos_categoria.sql
@@ -1,0 +1,49 @@
+-- Migración 079: Descuentos por categoría por cliente
+--
+-- Hasta ahora un cliente tenía un único descuento general
+-- (clientes.descuento_porcentaje). Esto agrega descuentos POR CATEGORÍA por
+-- cliente. Regla de negocio (en el front): si un producto pertenece a una
+-- categoría con descuento configurado para el cliente, ese descuento PREVALECE
+-- sobre el general.
+--
+-- Se guarda `categoria` como texto (no FK uuid) porque el precio se calcula
+-- sobre productos.categoria (texto libre); el match es por nombre normalizado.
+-- Espeja el patrón de cliente_preventistas: junction hijo de cliente, sin
+-- sucursal_id (la sucursal la da el cliente padre vía su RLS), escritura admin.
+
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS public.cliente_descuentos_categoria (
+  id                   bigint GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+  cliente_id           bigint NOT NULL REFERENCES public.clientes(id) ON DELETE CASCADE,
+  categoria            text NOT NULL,
+  descuento_porcentaje numeric(5,2) NOT NULL DEFAULT 0
+                         CHECK (descuento_porcentaje >= 0 AND descuento_porcentaje <= 100),
+  created_at           timestamptz NOT NULL DEFAULT now(),
+  UNIQUE (cliente_id, categoria)
+);
+
+CREATE INDEX IF NOT EXISTS idx_cliente_descuentos_categoria_cliente
+  ON public.cliente_descuentos_categoria (cliente_id);
+
+ALTER TABLE public.cliente_descuentos_categoria ENABLE ROW LEVEL SECURITY;
+
+-- SELECT: cualquier autenticado (el embed bajo clientes ya queda acotado por la
+-- RLS del cliente padre). Escritura: solo admin (editar descuentos es admin-only).
+DROP POLICY IF EXISTS cdc_select ON public.cliente_descuentos_categoria;
+CREATE POLICY cdc_select ON public.cliente_descuentos_categoria
+  FOR SELECT TO authenticated USING (true);
+
+DROP POLICY IF EXISTS cdc_insert ON public.cliente_descuentos_categoria;
+CREATE POLICY cdc_insert ON public.cliente_descuentos_categoria
+  FOR INSERT TO authenticated WITH CHECK (es_admin());
+
+DROP POLICY IF EXISTS cdc_update ON public.cliente_descuentos_categoria;
+CREATE POLICY cdc_update ON public.cliente_descuentos_categoria
+  FOR UPDATE TO authenticated USING (es_admin()) WITH CHECK (es_admin());
+
+DROP POLICY IF EXISTS cdc_delete ON public.cliente_descuentos_categoria;
+CREATE POLICY cdc_delete ON public.cliente_descuentos_categoria
+  FOR DELETE TO authenticated USING (es_admin());
+
+COMMIT;

--- a/src/components/containers/ClientesContainer.tsx
+++ b/src/components/containers/ClientesContainer.tsx
@@ -249,7 +249,15 @@ export default function ClientesContainer(): React.ReactElement {
       horarios_atencion: data.horarios_atencion || undefined,
       rubro: data.rubro || undefined,
       notas: data.notas || undefined,
-      ...(ids !== undefined ? { preventista_id: ids[0] ?? null, preventista_ids: ids } : {})
+      ...(ids !== undefined ? { preventista_id: ids[0] ?? null, preventista_ids: ids } : {}),
+      // Descuentos por categoría: solo admin puede escribirlos (RLS de
+      // cliente_descuentos_categoria exige es_admin()). Para no-admin omitimos
+      // la clave para que replaceCategoriaDiscounts ni se ejecute.
+      ...(isAdmin ? {
+        descuentos_categoria: data.descuentosPorCategoria
+          .filter(d => d.categoria && d.categoria.trim() !== '')
+          .map(d => ({ categoria: d.categoria.trim(), descuento_porcentaje: d.porcentaje })),
+      } : {})
     }
 
     try {

--- a/src/components/containers/PedidosContainer.tsx
+++ b/src/components/containers/PedidosContainer.tsx
@@ -7,6 +7,7 @@
  */
 import React, { lazy, Suspense, useState, useCallback, useMemo, useRef } from 'react'
 import { calcularNetoVenta } from '../../utils/calculations'
+import { aplicarDescuentoClienteItems } from '../../utils/descuentoCliente'
 import { fechaLocalISO, fechaHaceDias, getFormaPagoDisplay } from '../../utils/formatters'
 import { preventistaPuedeEditar } from '../../utils/permisosPedido'
 import { useQueryClient } from '@tanstack/react-query'
@@ -245,7 +246,7 @@ export default function PedidosContainer(): React.ReactElement {
   }, [])
 
   // Resolve wholesale prices for current pedido items
-  const { itemsFinales, totalFinal } = usePromocionPedido(nuevoPedido.items)
+  const { itemsFinales } = usePromocionPedido(nuevoPedido.items)
 
   // =========================================================================
   // VistaPedidos handlers
@@ -840,16 +841,15 @@ export default function PedidosContainer(): React.ReactElement {
     try {
       // Use promo+wholesale-resolved items and total (includes bonificaciones)
       const tipoFactura = nuevoPedido.tipoFactura || 'ZZ'
-      // Descuento porcentual del cliente (admin lo precarga en la ficha).
-      // Se aplica DESPUES de promociones/precio mayorista para que el factor
-      // multiplique el precio final por linea. Items bonificacion no se tocan.
+      // Descuento del cliente: general + por categoría (la categoría prevalece).
+      // Se aplica DESPUES de promociones/precio mayorista. Mismo helper que usa
+      // ModalPedido, para que el total guardado == el total mostrado en vivo.
+      // Items bonificacion / precioOverride / precio<=0 no se tocan.
       const clienteSel = clientes.find(c => String(c.id) === String(nuevoPedido.clienteId))
-      const dtoPct = clienteSel?.descuento_porcentaje ?? 0
-      const factorDto = dtoPct > 0 ? 1 - dtoPct / 100 : 1
+      const { items: itemsConDescuento, total: totalConDescuento } = aplicarDescuentoClienteItems(itemsFinales, productos, clienteSel)
       let totalNeto = 0
       let totalIva = 0
-      let totalConDescuento = 0
-      const itemsParaCrear = itemsFinales.map(item => {
+      const itemsParaCrear = itemsConDescuento.map(item => {
         const esBonif = !!item.esBonificacion
         if (esBonif) {
           return {
@@ -864,17 +864,13 @@ export default function PedidosContainer(): React.ReactElement {
         const producto = productos.find(p => String(p.id) === String(item.productoId))
         const pctIva = producto?.porcentaje_iva ?? 21
         const pctImpInt = producto?.impuestos_internos ?? 0
-        const precioConDto = factorDto < 1
-          ? Math.round(item.precioUnitario * factorDto * 100) / 100
-          : item.precioUnitario
-        const desglose = calcularNetoVenta(precioConDto, pctIva, pctImpInt, tipoFactura)
+        const desglose = calcularNetoVenta(item.precioUnitario, pctIva, pctImpInt, tipoFactura)
         totalNeto += desglose.neto * item.cantidad
         totalIva += desglose.iva * item.cantidad
-        totalConDescuento += precioConDto * item.cantidad
         return {
           productoId: String(item.productoId),
           cantidad: item.cantidad,
-          precioUnitario: precioConDto,
+          precioUnitario: item.precioUnitario,
           ...(item.promoId ? { promocionId: item.promoId } : {}),
           neto_unitario: desglose.neto,
           iva_unitario: desglose.iva,
@@ -885,7 +881,7 @@ export default function PedidosContainer(): React.ReactElement {
       const pedidoCreado = await crearPedido.mutateAsync({
         clienteId: nuevoPedido.clienteId,
         items: itemsParaCrear,
-        total: factorDto < 1 ? totalConDescuento : totalFinal,
+        total: totalConDescuento,
         usuarioId: user?.id ?? null,
         notas: nuevoPedido.notas,
         formaPago: nuevoPedido.formaPago,
@@ -911,7 +907,7 @@ export default function PedidosContainer(): React.ReactElement {
       notify.error('Error al crear pedido: ' + (e as Error).message)
     }
     setGuardando(false)
-  }, [nuevoPedido, itemsFinales, totalFinal, crearPedido, user, resetNuevoPedido, notify, productos, clientes, registrarGpsPedido])
+  }, [nuevoPedido, itemsFinales, crearPedido, user, resetNuevoPedido, notify, productos, clientes, registrarGpsPedido])
 
   // Handler que arranca el flujo: captura GPS si preventista, decide si bloquear,
   // pedir motivo, o crear directo.
@@ -1290,6 +1286,7 @@ export default function PedidosContainer(): React.ReactElement {
             pedido={pedidoHistorial}
             historial={historialCambios as Parameters<typeof ModalHistorialPedido>[0]['historial']}
             loading={cargandoHistorial}
+            transportistas={transportistas}
             onClose={() => { setModalHistorialOpen(false); setPedidoHistorial(null) }}
           />
         </Suspense>

--- a/src/components/containers/ProductosContainer.tsx
+++ b/src/components/containers/ProductosContainer.tsx
@@ -17,9 +17,10 @@ import { useProveedoresActivosQuery } from '../../hooks/queries'
 import { useClientesQuery } from '../../hooks/queries'
 import { useRegistrarCambioProductoMutation, type RegistrarCambioInput } from '../../hooks/queries'
 import { useCategoriasQuery } from '../../hooks/queries'
+import { useAplicarControlStockMutation } from '../../hooks/queries/useControlStockQuery'
 import { useAuthData } from '../../contexts/AuthDataContext'
 import { useNotification } from '../../contexts/NotificationContext'
-import { puedeControlarStock as puedeControlarStockRol } from '../../lib/permisos'
+import { puedeControlarStock as puedeControlarStockRol, puedeCargarControlStock as puedeCargarControlStockRol } from '../../lib/permisos'
 import { useResetOnSucursalChange } from '../../hooks/useResetOnSucursalChange'
 import { formatPrecio } from '../../utils/formatters'
 import type { ProductoDB, ProductoFormInput, MermaFormInputExtended } from '../../types'
@@ -34,6 +35,8 @@ const ModalConfirmacion = lazy(() => import('../modals/ModalConfirmacion'))
 const ModalCategorias = lazy(() => import('../modals/ModalCategorias'))
 const ModalCambioProducto = lazy(() => import('../modals/ModalCambioProducto'))
 const ModalStockBajo = lazy(() => import('../modals/ModalStockBajo'))
+const ModalControlStock = lazy(() => import('../modals/ModalControlStock'))
+const ModalAjustesStockHistorial = lazy(() => import('../modals/ModalAjustesStockHistorial'))
 
 function LoadingState() {
   return (
@@ -54,8 +57,10 @@ interface ConfirmConfig {
 export default function ProductosContainer(): React.ReactElement {
   const { isAdmin, perfil } = useAuthData()
   const puedeCambiarProductos = isAdmin
-  // Stock bajo + control de stock (Excel): admin y encargado.
+  // Stock bajo + descargar planilla + ver histórico de ajustes: admin y encargado.
   const puedeControlarStock = puedeControlarStockRol(perfil?.rol)
+  // Cargar la planilla (aplicar ajustes que modifican stock): solo admin.
+  const puedeCargarControlStock = puedeCargarControlStockRol(perfil?.rol)
   const notify = useNotification()
 
   // Queries
@@ -71,6 +76,7 @@ export default function ProductosContainer(): React.ReactElement {
   const eliminarProducto = useEliminarProductoMutation()
   const registrarMerma = useRegistrarMermaMutation()
   const registrarCambioProducto = useRegistrarCambioProductoMutation()
+  const aplicarControlStock = useAplicarControlStockMutation()
 
   // Estado de modales
   const [modalProductoOpen, setModalProductoOpen] = useState(false)
@@ -80,6 +86,8 @@ export default function ProductosContainer(): React.ReactElement {
   const [modalCategoriasOpen, setModalCategoriasOpen] = useState(false)
   const [modalCambioOpen, setModalCambioOpen] = useState(false)
   const [modalStockBajoOpen, setModalStockBajoOpen] = useState(false)
+  const [modalControlStockOpen, setModalControlStockOpen] = useState(false)
+  const [modalAjustesStockOpen, setModalAjustesStockOpen] = useState(false)
 
   // Estado de edición
   const [productoEditando, setProductoEditando] = useState<ProductoDB | null>(null)
@@ -98,6 +106,8 @@ export default function ProductosContainer(): React.ReactElement {
     setModalCategoriasOpen(false)
     setModalCambioOpen(false)
     setModalStockBajoOpen(false)
+    setModalControlStockOpen(false)
+    setModalAjustesStockOpen(false)
     setProductoEditando(null)
     setProductoMerma(null)
     setConfirmConfig({ visible: false })
@@ -172,17 +182,33 @@ export default function ProductosContainer(): React.ReactElement {
     setModalStockBajoOpen(true)
   }, [])
 
-  // Control de stock: descarga Excel con el inventario actual.
-  // Antes vivía inline en VistaProductos; movido al container para que la
-  // toolbar pueda recibirlo como handler simple.
-  const handleControlStock = useCallback(async () => {
-    try {
-      const { exportControlStock } = await import('../../utils/excel')
-      await exportControlStock(productos)
-    } catch {
-      notify.error('Error al exportar el control de stock')
-    }
-  }, [productos, notify])
+  // Control de stock: abre el modal de descarga/carga de planilla. La descarga
+  // (con filtro por categoría, ambos roles) y la carga (aplicar ajustes, solo
+  // admin) viven dentro del modal.
+  const handleControlStock = useCallback(() => {
+    setModalControlStockOpen(true)
+  }, [])
+
+  // Histórico de ajustes de control de stock (agrupado por carga). Ambos roles.
+  const handleVerAjustesStock = useCallback(() => {
+    setModalAjustesStockOpen(true)
+  }, [])
+
+  // Aplica los ajustes de la planilla via RPC (solo admin; la DB revalida).
+  // Devuelve el resumen de la sesión al modal para mostrar el resultado.
+  const handleAplicarControlStock = useCallback(
+    async (ajustes: Array<{ producto_id: string; stock_real: number }>) => {
+      try {
+        const res = await aplicarControlStock.mutateAsync(ajustes)
+        notify.success(`Stock ajustado: ${res.total_items} producto${res.total_items === 1 ? '' : 's'}`)
+        return res
+      } catch (e) {
+        notify.error((e as Error).message || 'Error al aplicar los ajustes de stock')
+        throw e
+      }
+    },
+    [aplicarControlStock, notify]
+  )
 
   // Productos con stock bajo: una sola fuente de verdad. El toolbar usa
   // el count y el modal usa la lista. La fórmula respeta exactamente la
@@ -269,6 +295,7 @@ export default function ProductosContainer(): React.ReactElement {
           onGestionarCategorias={handleGestionarCategorias}
           onCambioProducto={puedeCambiarProductos ? handleAbrirCambioProducto : undefined}
           onControlStock={puedeControlarStock ? handleControlStock : undefined}
+          onVerAjustesStock={puedeControlarStock ? handleVerAjustesStock : undefined}
           onAbrirStockBajo={puedeControlarStock ? handleAbrirStockBajo : undefined}
         />
       </Suspense>
@@ -356,6 +383,29 @@ export default function ProductosContainer(): React.ReactElement {
             productos={productosStockBajo}
             onEditarProducto={isAdmin ? handleEditarDesdeStockBajo : undefined}
             onClose={() => setModalStockBajoOpen(false)}
+          />
+        </Suspense>
+      )}
+
+      {/* Modal Control de stock (descargar / cargar planilla) */}
+      {modalControlStockOpen && (
+        <Suspense fallback={null}>
+          <ModalControlStock
+            productos={productos}
+            puedeCargar={puedeCargarControlStock}
+            onAplicar={handleAplicarControlStock}
+            aplicando={aplicarControlStock.isPending}
+            onClose={() => setModalControlStockOpen(false)}
+          />
+        </Suspense>
+      )}
+
+      {/* Modal Histórico de ajustes de stock */}
+      {modalAjustesStockOpen && (
+        <Suspense fallback={null}>
+          <ModalAjustesStockHistorial
+            productos={productos}
+            onClose={() => setModalAjustesStockOpen(false)}
           />
         </Suspense>
       )}

--- a/src/components/modals/ModalAjustesStockHistorial.tsx
+++ b/src/components/modals/ModalAjustesStockHistorial.tsx
@@ -1,0 +1,121 @@
+/**
+ * ModalAjustesStockHistorial
+ *
+ * Histórico de ajustes de control de stock, agrupado por carga de planilla
+ * (sesión). Cada sesión muestra fecha, usuario y totales (+altas/-bajas) y se
+ * expande para ver el detalle producto por producto. Lo ven admin y encargado.
+ */
+import { useMemo, useState, memo } from 'react';
+import { Loader2, History, ChevronDown, ChevronRight, TrendingUp, TrendingDown } from 'lucide-react';
+import ModalBase from './ModalBase';
+import { formatFecha } from './utils';
+import { useControlStockSesionesQuery, useControlStockDetalleQuery } from '../../hooks/queries/useControlStockQuery';
+import type { ProductoDB } from '../../types';
+
+export interface ModalAjustesStockHistorialProps {
+  productos: ProductoDB[];
+  onClose: () => void;
+}
+
+function DetalleSesion({ sesionId, productosMap }: { sesionId: number; productosMap: Map<string, string> }) {
+  const { data: detalle = [], isLoading } = useControlStockDetalleQuery(sesionId);
+
+  if (isLoading) {
+    return (
+      <div className="flex justify-center py-3">
+        <Loader2 className="w-5 h-5 animate-spin text-blue-600" />
+      </div>
+    );
+  }
+  if (detalle.length === 0) {
+    return <p className="px-3 py-2 text-sm text-gray-500">Sin detalle.</p>;
+  }
+  return (
+    <div className="divide-y dark:divide-gray-700">
+      {detalle.map(d => {
+        const dif = d.diferencia ?? (d.stock_nuevo - d.stock_anterior);
+        return (
+          <div key={d.id} className="flex items-center justify-between gap-2 px-3 py-1.5 text-sm">
+            <span className="truncate dark:text-gray-200">{productosMap.get(String(d.producto_id)) || `Producto #${d.producto_id}`}</span>
+            <span className="flex items-center gap-2 shrink-0">
+              <span className="text-gray-400">{d.stock_anterior}</span>
+              <span className="text-gray-400">→</span>
+              <span className="font-medium dark:text-gray-100">{d.stock_nuevo}</span>
+              <span className={`w-12 text-right font-semibold ${dif > 0 ? 'text-emerald-600' : 'text-rose-600'}`}>
+                {dif > 0 ? '+' : ''}{dif}
+              </span>
+            </span>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+const ModalAjustesStockHistorial = memo(function ModalAjustesStockHistorial({ productos, onClose }: ModalAjustesStockHistorialProps) {
+  const { data: sesiones = [], isLoading } = useControlStockSesionesQuery();
+  const [expandida, setExpandida] = useState<number | null>(null);
+
+  const productosMap = useMemo(
+    () => new Map(productos.map(p => [String(p.id), p.nombre])),
+    [productos]
+  );
+
+  return (
+    <ModalBase title="Ajustes de stock" onClose={onClose} maxWidth="max-w-2xl">
+      <div className="p-4">
+        {isLoading ? (
+          <div className="flex justify-center py-8">
+            <Loader2 className="w-8 h-8 animate-spin text-blue-600" />
+          </div>
+        ) : sesiones.length === 0 ? (
+          <div className="text-center py-8 text-gray-500">
+            <History className="w-12 h-12 mx-auto mb-3 opacity-50" />
+            <p>Todavía no se cargaron planillas de control de stock.</p>
+          </div>
+        ) : (
+          <div className="space-y-2 max-h-[60vh] overflow-y-auto">
+            {sesiones.map(s => {
+              const abierta = expandida === s.id;
+              return (
+                <div key={s.id} className="border rounded-lg dark:border-gray-700 overflow-hidden">
+                  <button
+                    type="button"
+                    onClick={() => setExpandida(abierta ? null : s.id)}
+                    className="w-full flex items-center justify-between gap-2 px-3 py-2.5 text-left hover:bg-gray-50 dark:hover:bg-gray-700/40"
+                  >
+                    <div className="min-w-0">
+                      <p className="font-medium text-sm text-gray-900 dark:text-gray-100">{formatFecha(s.fecha)}</p>
+                      <p className="text-xs text-gray-500">
+                        {s.usuario?.nombre || 'Sistema'} · {s.total_items} ítem{s.total_items === 1 ? '' : 's'}
+                      </p>
+                    </div>
+                    <div className="flex items-center gap-3 shrink-0">
+                      <span className="inline-flex items-center gap-1 text-xs text-emerald-600 font-medium">
+                        <TrendingUp className="w-3.5 h-3.5" />+{s.total_altas}
+                      </span>
+                      <span className="inline-flex items-center gap-1 text-xs text-rose-600 font-medium">
+                        <TrendingDown className="w-3.5 h-3.5" />-{s.total_bajas}
+                      </span>
+                      {abierta ? <ChevronDown className="w-4 h-4 text-gray-400" /> : <ChevronRight className="w-4 h-4 text-gray-400" />}
+                    </div>
+                  </button>
+                  {abierta && (
+                    <div className="border-t dark:border-gray-700 bg-gray-50/60 dark:bg-gray-800/40">
+                      <DetalleSesion sesionId={s.id} productosMap={productosMap} />
+                    </div>
+                  )}
+                </div>
+              );
+            })}
+          </div>
+        )}
+      </div>
+      <div className="flex justify-end p-4 border-t bg-gray-50 dark:bg-gray-800 dark:border-gray-700">
+        <button onClick={onClose} className="px-4 py-2 bg-gray-600 text-white rounded-lg hover:bg-gray-700">Cerrar</button>
+      </div>
+    </ModalBase>
+  );
+});
+
+export default ModalAjustesStockHistorial;

--- a/src/components/modals/ModalCliente.tsx
+++ b/src/components/modals/ModalCliente.tsx
@@ -1,10 +1,10 @@
-import { useState, memo, useRef } from 'react';
-import { Loader2, MapPin, CreditCard, Clock, Tag, FileText, Users, LocateFixed, AlertCircle } from 'lucide-react';
+import { useState, memo, useRef, useMemo } from 'react';
+import { Loader2, MapPin, CreditCard, Clock, Tag, FileText, Users, LocateFixed, AlertCircle, Percent, Plus, Trash2 } from 'lucide-react';
 import ModalBase from './ModalBase';
 import { AddressAutocomplete } from '../AddressAutocomplete';
 import { useZodValidation } from '../../hooks/useZodValidation';
 import { modalClienteSchema } from '../../lib/schemas';
-import { usePreventistasQuery, useZonasEstandarizadasQuery } from '../../hooks/queries';
+import { usePreventistasQuery, useZonasEstandarizadasQuery, useCategoriasQuery, useProductosQuery } from '../../hooks/queries';
 import { useGeolocationCapture } from '../../hooks/useGeolocationCapture';
 import { useReverseGeocoding } from '../../hooks/useReverseGeocoding';
 import {
@@ -41,6 +41,8 @@ export interface ClienteFormData {
   limiteCredito: number;
   diasCredito: number;
   descuentoPorcentaje: number;
+  /** Descuentos por categoría (override del general). Porcentaje entero. */
+  descuentosPorCategoria: Array<{ categoria: string; porcentaje: number }>;
   preventista_id: string;
   preventista_ids: string[];
 }
@@ -94,6 +96,17 @@ const ModalCliente = memo(function ModalCliente({ cliente, onSave, onClose, guar
   const formRef = useRef<HTMLDivElement>(null);
   const { data: preventistas = [] } = usePreventistasQuery();
   const { data: zonas = [] } = useZonasEstandarizadasQuery({ includeInactive: true });
+  const { data: categoriasTabla = [] } = useCategoriasQuery();
+  const { data: productosParaCategorias = [] } = useProductosQuery();
+  // Opciones de categoría = unión de la tabla `categorias` (gestionada) y las
+  // categorías reales usadas por productos. Así el valor elegido siempre matchea
+  // algún producto al calcular el descuento (productos.categoria es texto libre).
+  const categoriasDisponibles = useMemo(() => {
+    const set = new Set<string>();
+    categoriasTabla.forEach(c => { const n = (c.nombre || '').trim(); if (n) set.add(n); });
+    productosParaCategorias.forEach(p => { const n = (p.categoria || '').trim(); if (n) set.add(n); });
+    return [...set].sort((a, b) => a.localeCompare(b));
+  }, [categoriasTabla, productosParaCategorias]);
 
   // Zod validation hook with accessibility helpers
   const { errors: errores, validate, clearFieldError, hasAttemptedSubmit: intentoGuardar, getAriaProps, getErrorMessageProps } = useZodValidation(modalClienteSchema);
@@ -121,6 +134,10 @@ const ModalCliente = memo(function ModalCliente({ cliente, onSave, onClose, guar
     limiteCredito: cliente.limite_credito || 0,
     diasCredito: cliente.dias_credito || 30,
     descuentoPorcentaje: cliente.descuento_porcentaje || 0,
+    descuentosPorCategoria: (cliente.descuentos_categoria || []).map(d => ({
+      categoria: d.categoria,
+      porcentaje: Number(d.descuento_porcentaje) || 0,
+    })),
     preventista_id: cliente.preventista_id || '',
     preventista_ids: cliente.preventista_ids || []
   } : {
@@ -142,6 +159,7 @@ const ModalCliente = memo(function ModalCliente({ cliente, onSave, onClose, guar
     limiteCredito: 0,
     diasCredito: 30,
     descuentoPorcentaje: 0,
+    descuentosPorCategoria: [],
     preventista_id: '',
     preventista_ids: []
   });
@@ -212,6 +230,33 @@ const ModalCliente = memo(function ModalCliente({ cliente, onSave, onClose, guar
   const preventistasVisibles = preventistas.filter(p =>
     (p.nombre || '').toLowerCase().includes(preventistasFiltro.trim().toLowerCase())
   );
+
+  // --- Descuentos por categoría (filas dinámicas) ---
+  const agregarDescuentoCategoria = (): void => {
+    setForm(prev => ({
+      ...prev,
+      descuentosPorCategoria: [...prev.descuentosPorCategoria, { categoria: '', porcentaje: 0 }],
+    }));
+  };
+  const actualizarDescuentoCategoria = (index: number, field: 'categoria' | 'porcentaje', value: string): void => {
+    setForm(prev => ({
+      ...prev,
+      descuentosPorCategoria: prev.descuentosPorCategoria.map((row, i) => {
+        if (i !== index) return row;
+        if (field === 'porcentaje') {
+          const num = value === '' ? 0 : Math.max(0, Math.min(100, Math.trunc(Number(value)) || 0));
+          return { ...row, porcentaje: num };
+        }
+        return { ...row, categoria: value };
+      }),
+    }));
+  };
+  const eliminarDescuentoCategoria = (index: number): void => {
+    setForm(prev => ({
+      ...prev,
+      descuentosPorCategoria: prev.descuentosPorCategoria.filter((_, i) => i !== index),
+    }));
+  };
 
   const handleAddressSelect = (result: AddressSelectResult): void => {
     setForm(prev => ({
@@ -677,6 +722,68 @@ const ModalCliente = memo(function ModalCliente({ cliente, onSave, onClose, guar
                 />
                 <p className="text-xs text-gray-500 mt-1">Se aplica al precio_unitario al armar pedidos</p>
               </div>
+            </div>
+
+            {/* Descuentos por categoría (prevalecen sobre el descuento general) */}
+            <div className="mt-4 border-t border-dashed pt-3 dark:border-gray-700">
+              <div className="flex items-center gap-2 mb-1">
+                <Percent className="w-4 h-4 text-blue-600" />
+                <span className="text-sm font-medium text-gray-700 dark:text-gray-200">Descuentos por categoría</span>
+              </div>
+              <p className="text-xs text-gray-500 mb-2">
+                Para productos de la categoría elegida se aplica este % en lugar del descuento general.
+              </p>
+
+              <datalist id="cliente-categorias-disponibles">
+                {categoriasDisponibles.map(c => <option key={c} value={c} />)}
+              </datalist>
+
+              {form.descuentosPorCategoria.length > 0 && (
+                <div className="space-y-2 mb-2">
+                  {form.descuentosPorCategoria.map((row, index) => (
+                    <div key={index} className="flex items-center gap-2">
+                      <input
+                        type="text"
+                        list="cliente-categorias-disponibles"
+                        value={row.categoria}
+                        onChange={e => actualizarDescuentoCategoria(index, 'categoria', e.target.value)}
+                        placeholder="Buscar categoría..."
+                        className="flex-1 px-3 py-2 border rounded-lg dark:bg-gray-700 dark:border-gray-600 dark:text-white text-sm"
+                      />
+                      <div className="relative w-24">
+                        <input
+                          type="number"
+                          inputMode="numeric"
+                          min="0"
+                          max="100"
+                          step="1"
+                          value={row.porcentaje}
+                          onChange={e => actualizarDescuentoCategoria(index, 'porcentaje', e.target.value)}
+                          className="w-full px-3 py-2 pr-7 border rounded-lg dark:bg-gray-700 dark:border-gray-600 dark:text-white text-sm"
+                        />
+                        <span className="absolute right-2 top-1/2 -translate-y-1/2 text-xs text-gray-400">%</span>
+                      </div>
+                      <button
+                        type="button"
+                        onClick={() => eliminarDescuentoCategoria(index)}
+                        className="p-2 text-rose-600 hover:bg-rose-50 dark:hover:bg-rose-900/20 rounded-lg"
+                        aria-label="Eliminar descuento de categoría"
+                      >
+                        <Trash2 className="w-4 h-4" />
+                      </button>
+                    </div>
+                  ))}
+                </div>
+              )}
+
+              <button
+                type="button"
+                onClick={agregarDescuentoCategoria}
+                className="inline-flex items-center gap-1.5 px-3 py-2 text-sm font-medium text-blue-600 hover:bg-blue-50 dark:hover:bg-blue-900/20 rounded-lg"
+              >
+                <Plus className="w-4 h-4" />
+                Agregar categoría
+              </button>
             </div>
           </div>
         ) : (

--- a/src/components/modals/ModalControlStock.tsx
+++ b/src/components/modals/ModalControlStock.tsx
@@ -1,0 +1,285 @@
+/**
+ * ModalControlStock
+ *
+ * Control de stock por planilla:
+ *  - Descargar planilla (Excel) filtrando por categoría (admin y encargado).
+ *  - Cargar planilla completada para ajustar stock (solo admin). Parsea, matchea
+ *    productos por código/nombre, muestra preview de diferencias y aplica via RPC.
+ *
+ * Regla clave: solo se ajustan los ítems con "Stock Real" cargado en la planilla.
+ * Las filas vacías se omiten (no se pisa a 0 un ítem no controlado).
+ */
+import { useState, useMemo, memo } from 'react';
+import { Download, Upload, Loader2, AlertTriangle, CheckCircle2, FileSpreadsheet, X } from 'lucide-react';
+import ModalBase from './ModalBase';
+import { exportControlStock, readControlStockPlanilla, type ControlStockRow } from '../../utils/excel';
+import type { ProductoDB } from '../../types';
+import type { AplicarControlStockResult } from '../../hooks/queries/useControlStockQuery';
+
+export interface ModalControlStockProps {
+  productos: ProductoDB[];
+  /** Si el usuario puede cargar la planilla (aplicar ajustes). Solo admin. */
+  puedeCargar: boolean;
+  /** Aplica los ajustes via RPC. Devuelve el resumen de la sesión. */
+  onAplicar: (ajustes: Array<{ producto_id: string; stock_real: number }>) => Promise<AplicarControlStockResult>;
+  aplicando: boolean;
+  onClose: () => void;
+}
+
+const SIN_CATEGORIA = 'Sin categoría';
+const catDe = (p: ProductoDB): string => (p.categoria || '').trim() || SIN_CATEGORIA;
+
+interface PreviewItem {
+  producto: ProductoDB;
+  stockReal: number;
+  diferencia: number;
+}
+
+const ModalControlStock = memo(function ModalControlStock({ productos, puedeCargar, onAplicar, aplicando, onClose }: ModalControlStockProps) {
+  const categoriasDisponibles = useMemo(() => {
+    const set = new Set<string>();
+    productos.forEach(p => set.add(catDe(p)));
+    return [...set].sort((a, b) => a.localeCompare(b));
+  }, [productos]);
+
+  const [categoriasSel, setCategoriasSel] = useState<Set<string>>(() => new Set(categoriasDisponibles));
+  const [descargando, setDescargando] = useState(false);
+
+  const [parseando, setParseando] = useState(false);
+  const [parseError, setParseError] = useState<string | null>(null);
+  const [preview, setPreview] = useState<{ matched: PreviewItem[]; unmatched: ControlStockRow[] } | null>(null);
+  const [resultado, setResultado] = useState<AplicarControlStockResult | null>(null);
+
+  const productosFiltrados = useMemo(
+    () => productos.filter(p => categoriasSel.has(catDe(p))),
+    [productos, categoriasSel]
+  );
+
+  const toggleCategoria = (cat: string): void => {
+    setCategoriasSel(prev => {
+      const next = new Set(prev);
+      if (next.has(cat)) next.delete(cat); else next.add(cat);
+      return next;
+    });
+  };
+  const seleccionarTodas = (): void => setCategoriasSel(new Set(categoriasDisponibles));
+  const seleccionarNinguna = (): void => setCategoriasSel(new Set());
+
+  const handleDescargar = async (): Promise<void> => {
+    if (productosFiltrados.length === 0) return;
+    setDescargando(true);
+    try {
+      await exportControlStock(productosFiltrados);
+    } finally {
+      setDescargando(false);
+    }
+  };
+
+  const matchProducto = (row: ControlStockRow): ProductoDB | undefined => {
+    if (row.codigo) {
+      const porCodigo = productos.find(p => (p.codigo || '').trim() === row.codigo);
+      if (porCodigo) return porCodigo;
+    }
+    if (row.nombre) {
+      const n = row.nombre.trim().toLowerCase();
+      return productos.find(p => (p.nombre || '').trim().toLowerCase() === n);
+    }
+    return undefined;
+  };
+
+  const handleArchivo = async (file: File | undefined): Promise<void> => {
+    if (!file) return;
+    setParseError(null);
+    setPreview(null);
+    setResultado(null);
+    setParseando(true);
+    try {
+      const filas = await readControlStockPlanilla(file);
+      const matched: PreviewItem[] = [];
+      const unmatched: ControlStockRow[] = [];
+      for (const row of filas) {
+        const producto = matchProducto(row);
+        if (!producto) { unmatched.push(row); continue; }
+        matched.push({ producto, stockReal: row.stockReal, diferencia: row.stockReal - producto.stock });
+      }
+      if (matched.length === 0 && unmatched.length === 0) {
+        setParseError('La planilla no tiene ninguna fila con "Stock Real" cargado.');
+        return;
+      }
+      setPreview({ matched, unmatched });
+    } catch (e) {
+      setParseError((e as Error).message || 'No se pudo leer la planilla.');
+    } finally {
+      setParseando(false);
+    }
+  };
+
+  const cambios = preview ? preview.matched.filter(m => m.diferencia !== 0) : [];
+
+  const handleAplicar = async (): Promise<void> => {
+    if (!preview || cambios.length === 0) return;
+    const ajustes = preview.matched.map(m => ({ producto_id: String(m.producto.id), stock_real: m.stockReal }));
+    const res = await onAplicar(ajustes);
+    setResultado(res);
+    setPreview(null);
+  };
+
+  return (
+    <ModalBase title="Control de stock" onClose={onClose} maxWidth="max-w-2xl">
+      <div className="p-4 space-y-5 max-h-[70vh] overflow-y-auto">
+        {/* ── Descargar ── */}
+        <section>
+          <div className="flex items-center gap-2 mb-2">
+            <FileSpreadsheet className="w-5 h-5 text-amber-600" />
+            <h3 className="font-medium text-gray-800 dark:text-gray-100">Descargar planilla</h3>
+          </div>
+          <p className="text-xs text-gray-500 mb-2">
+            Elegí qué categorías controlar. La planilla solo incluye esas categorías; el resto no se toca al cargar.
+          </p>
+
+          <div className="flex items-center gap-3 mb-2 text-xs">
+            <button type="button" onClick={seleccionarTodas} className="text-blue-600 hover:underline">Todas</button>
+            <button type="button" onClick={seleccionarNinguna} className="text-blue-600 hover:underline">Ninguna</button>
+            <span className="text-gray-400">{categoriasSel.size}/{categoriasDisponibles.length} categorías · {productosFiltrados.length} productos</span>
+          </div>
+
+          <div className="max-h-40 overflow-y-auto border rounded-lg dark:border-gray-600 p-2 grid grid-cols-1 sm:grid-cols-2 gap-1">
+            {categoriasDisponibles.map(cat => (
+              <label key={cat} className="flex items-center gap-2 px-2 py-1 rounded hover:bg-gray-50 dark:hover:bg-gray-700 cursor-pointer">
+                <input type="checkbox" checked={categoriasSel.has(cat)} onChange={() => toggleCategoria(cat)} className="rounded" />
+                <span className="text-sm dark:text-gray-200 truncate">{cat}</span>
+              </label>
+            ))}
+          </div>
+
+          <button
+            type="button"
+            onClick={handleDescargar}
+            disabled={descargando || productosFiltrados.length === 0}
+            className="mt-3 inline-flex items-center gap-2 px-4 py-2 bg-amber-600 text-white rounded-lg hover:bg-amber-700 disabled:bg-gray-400 disabled:cursor-not-allowed font-medium"
+          >
+            {descargando ? <Loader2 className="w-4 h-4 animate-spin" /> : <Download className="w-4 h-4" />}
+            Descargar planilla
+          </button>
+        </section>
+
+        {/* ── Cargar (solo admin) ── */}
+        {puedeCargar && (
+          <section className="border-t pt-4 dark:border-gray-700">
+            <div className="flex items-center gap-2 mb-2">
+              <Upload className="w-5 h-5 text-emerald-600" />
+              <h3 className="font-medium text-gray-800 dark:text-gray-100">Cargar planilla completada</h3>
+            </div>
+            <p className="text-xs text-gray-500 mb-2">
+              Solo se ajustan los ítems con "Stock Real" cargado. Las filas vacías se omiten.
+            </p>
+
+            {resultado ? (
+              <div className="rounded-lg border border-emerald-200 bg-emerald-50 dark:bg-emerald-900/20 dark:border-emerald-700 p-3">
+                <div className="flex items-center gap-2 text-emerald-700 dark:text-emerald-300 font-medium mb-1">
+                  <CheckCircle2 className="w-5 h-5" />
+                  Ajustes aplicados
+                </div>
+                <p className="text-sm text-gray-700 dark:text-gray-200">
+                  {resultado.total_items} producto{resultado.total_items === 1 ? '' : 's'} ajustado{resultado.total_items === 1 ? '' : 's'}
+                  {' · '}<span className="text-emerald-600">+{resultado.total_altas}</span>
+                  {' / '}<span className="text-rose-600">-{resultado.total_bajas}</span>
+                </p>
+                {resultado.no_encontrados.length > 0 && (
+                  <p className="text-xs text-amber-600 mt-1">{resultado.no_encontrados.length} fila(s) no se pudieron asociar a un producto.</p>
+                )}
+                <button type="button" onClick={() => setResultado(null)} className="mt-2 text-sm text-blue-600 hover:underline">
+                  Cargar otra planilla
+                </button>
+              </div>
+            ) : preview ? (
+              <div className="space-y-3">
+                <div className="text-sm text-gray-700 dark:text-gray-200">
+                  <span className="font-medium">{cambios.length}</span> de {preview.matched.length} ítems tienen diferencia.
+                  {preview.unmatched.length > 0 && (
+                    <span className="text-amber-600"> {preview.unmatched.length} sin asociar.</span>
+                  )}
+                </div>
+
+                {cambios.length > 0 && (
+                  <div className="max-h-56 overflow-y-auto border rounded-lg dark:border-gray-600 divide-y dark:divide-gray-700">
+                    {cambios.map(m => (
+                      <div key={m.producto.id} className="flex items-center justify-between gap-2 px-3 py-2 text-sm">
+                        <span className="truncate dark:text-gray-200">{m.producto.nombre}</span>
+                        <span className="flex items-center gap-2 shrink-0">
+                          <span className="text-gray-400">{m.producto.stock}</span>
+                          <span className="text-gray-400">→</span>
+                          <span className="font-medium dark:text-gray-100">{m.stockReal}</span>
+                          <span className={`w-12 text-right font-semibold ${m.diferencia > 0 ? 'text-emerald-600' : 'text-rose-600'}`}>
+                            {m.diferencia > 0 ? '+' : ''}{m.diferencia}
+                          </span>
+                        </span>
+                      </div>
+                    ))}
+                  </div>
+                )}
+
+                {preview.unmatched.length > 0 && (
+                  <details className="text-xs text-gray-500">
+                    <summary className="cursor-pointer">Ver {preview.unmatched.length} fila(s) sin asociar</summary>
+                    <ul className="mt-1 pl-4 list-disc">
+                      {preview.unmatched.slice(0, 30).map((u, i) => (
+                        <li key={i}>{u.codigo || '(sin código)'} — {u.nombre || '(sin nombre)'} → {u.stockReal}</li>
+                      ))}
+                    </ul>
+                  </details>
+                )}
+
+                <div className="flex items-center gap-2">
+                  <button
+                    type="button"
+                    onClick={handleAplicar}
+                    disabled={aplicando || cambios.length === 0}
+                    className="inline-flex items-center gap-2 px-4 py-2 bg-emerald-600 text-white rounded-lg hover:bg-emerald-700 disabled:bg-gray-400 disabled:cursor-not-allowed font-medium"
+                  >
+                    {aplicando ? <Loader2 className="w-4 h-4 animate-spin" /> : <CheckCircle2 className="w-4 h-4" />}
+                    Aplicar ajustes
+                  </button>
+                  <button type="button" onClick={() => setPreview(null)} className="inline-flex items-center gap-1 px-3 py-2 text-sm text-gray-600 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-lg">
+                    <X className="w-4 h-4" /> Descartar
+                  </button>
+                </div>
+              </div>
+            ) : (
+              <label className="flex flex-col items-center justify-center gap-2 border-2 border-dashed rounded-lg p-6 cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-700/40 dark:border-gray-600">
+                {parseando ? (
+                  <Loader2 className="w-6 h-6 animate-spin text-gray-400" />
+                ) : (
+                  <Upload className="w-6 h-6 text-gray-400" />
+                )}
+                <span className="text-sm text-gray-600 dark:text-gray-300">
+                  {parseando ? 'Leyendo planilla...' : 'Hacé clic para elegir el archivo .xlsx'}
+                </span>
+                <input
+                  type="file"
+                  accept=".xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+                  className="hidden"
+                  onChange={e => { handleArchivo(e.target.files?.[0]); e.target.value = ''; }}
+                  disabled={parseando}
+                />
+              </label>
+            )}
+
+            {parseError && (
+              <div className="mt-2 flex items-start gap-2 text-sm text-rose-600">
+                <AlertTriangle className="w-4 h-4 mt-0.5 shrink-0" />
+                <span>{parseError}</span>
+              </div>
+            )}
+          </section>
+        )}
+      </div>
+
+      <div className="flex justify-end p-4 border-t bg-gray-50 dark:bg-gray-800 dark:border-gray-700">
+        <button onClick={onClose} className="px-4 py-2 bg-gray-600 text-white rounded-lg hover:bg-gray-700">Cerrar</button>
+      </div>
+    </ModalBase>
+  );
+});
+
+export default ModalControlStock;

--- a/src/components/modals/ModalHistorialPedido.tsx
+++ b/src/components/modals/ModalHistorialPedido.tsx
@@ -28,12 +28,22 @@ export interface ModalHistorialPedidoProps {
   historial: HistorialCambio[];
   onClose: () => void;
   loading: boolean;
+  /** Transportistas activos para resolver el UUID guardado en el historial a un nombre legible. */
+  transportistas?: Array<{ id: string; nombre: string }>;
 }
 
 /** Mapa de campos a etiquetas */
 type CampoMapeo = Record<string, string>;
 
-const ModalHistorialPedido = memo(function ModalHistorialPedido({ pedido, historial, onClose, loading }: ModalHistorialPedidoProps) {
+const ModalHistorialPedido = memo(function ModalHistorialPedido({ pedido, historial, onClose, loading, transportistas = [] }: ModalHistorialPedidoProps) {
+  // Resuelve el UUID del transportista (guardado como texto en el historial) a
+  // su nombre. 'sin asignar' es el literal que escribe el trigger cuando no hay
+  // transportista. Si no se encuentra (transportista dado de baja), cae al UUID.
+  const resolverTransportista = (valor: string): string => {
+    if (!valor || valor === 'sin asignar') return 'Sin asignar';
+    return transportistas.find(t => String(t.id) === String(valor))?.nombre || valor;
+  };
+
   const formatearCampo = (campo: string): string => {
     const mapeo: CampoMapeo = {
       estado: "Estado",
@@ -50,6 +60,7 @@ const ModalHistorialPedido = memo(function ModalHistorialPedido({ pedido, histor
   };
 
   const formatearValor = (campo: string, valor: string): string => {
+    if (campo === "transportista_id") return resolverTransportista(valor);
     if (campo === "total") return formatPrecio(parsePrecio(valor));
     if (campo === "estado") {
       const estados: Record<string, string> = { pendiente: "Pendiente", en_preparacion: "En preparacion", asignado: "En camino", entregado: "Entregado" };
@@ -94,7 +105,7 @@ const ModalHistorialPedido = memo(function ModalHistorialPedido({ pedido, histor
                       {formatearCampo(cambio.campo_modificado)}
                     </p>
                     <p className="text-sm text-gray-600">
-                      {cambio.usuario?.nombre || "Usuario desconocido"}
+                      {cambio.usuario?.nombre || "Sistema"}
                     </p>
                   </div>
                   <p className="text-xs text-gray-500">{cambio.created_at ? formatFecha(cambio.created_at) : '-'}</p>

--- a/src/components/modals/ModalPedido.tsx
+++ b/src/components/modals/ModalPedido.tsx
@@ -1,9 +1,10 @@
 import { useState, useMemo, memo, useRef } from 'react';
-import { X, Loader2, Search, MapPin, Tag, Calendar, Trash2, Pencil, Gift, Truck, ChevronLeft, ChevronRight, ShoppingCart, ChevronUp, LocateFixed, AlertCircle, UserCheck } from 'lucide-react';
+import { X, Loader2, Search, MapPin, Tag, Calendar, Trash2, Pencil, Gift, Truck, ChevronLeft, ChevronRight, ShoppingCart, ChevronUp, LocateFixed, AlertCircle, UserCheck, Percent } from 'lucide-react';
 import { formatPrecio, fechaLocalISO } from '../../utils/formatters';
 import { parsePrecio } from '../../utils/calculations';
 import { AddressAutocomplete } from '../AddressAutocomplete';
 import { usePromocionPedido } from '../../hooks/usePromocionPedido';
+import { aplicarDescuentoClienteItems, resolverDescuentoPctCliente } from '../../utils/descuentoCliente';
 import { useGeolocationCapture } from '../../hooks/useGeolocationCapture';
 import { usePreventistasAsignablesQuery } from '../../hooks/queries/useUsuariosQuery';
 import ModalBase from './ModalBase';
@@ -260,10 +261,19 @@ const ModalPedido = memo(function ModalPedido({
   const calcularTotal = (): number => nuevoPedido.items.reduce((t, i) => t + (i.precioUnitario * i.cantidad), 0);
 
   // Precios mayoristas, promociones y cantidades mínimas
-  const { preciosResueltos, faltantes, faltantesBonificacion, promoResolucion, totalFinal, totalOriginal, ahorro, hayDescuento, moqMap, violacionesMOQ } = usePromocionPedido(nuevoPedido.items);
+  const { preciosResueltos, faltantes, faltantesBonificacion, promoResolucion, itemsFinales, totalOriginal, hayDescuento, moqMap, violacionesMOQ } = usePromocionPedido(nuevoPedido.items);
+
+  // Descuento del cliente (general + por categoría) aplicado en vivo sobre los
+  // items ya resueltos (mayorista/promo). La categoría prevalece sobre el general.
+  const descuentoCliente = useMemo(
+    () => aplicarDescuentoClienteItems(itemsFinales, productos, clienteSeleccionado),
+    [itemsFinales, productos, clienteSeleccionado]
+  );
+  const totalConDescuentoCliente = descuentoCliente.total;
+  const hayDescuentoTotal = hayDescuento || descuentoCliente.hayDescuento;
 
   const totalItemsCarrito = nuevoPedido.items.reduce((t, i) => t + i.cantidad, 0);
-  const totalParaMostrar = hayDescuento ? totalFinal : calcularTotal();
+  const totalParaMostrar = hayDescuentoTotal ? totalConDescuentoCliente : calcularTotal();
   const hayItems = nuevoPedido.items.length > 0;
 
   const tipoFacturaToggle = (
@@ -601,7 +611,12 @@ const ModalPedido = memo(function ModalPedido({
                         const precioInfo = preciosResueltos.get(String(item.productoId));
                         const esOverride = item.precioOverride || false;
                         const esMayorista = !esOverride && (precioInfo?.esMayorista || false);
-                        const precioMostrar = esOverride ? item.precioUnitario : (esMayorista ? precioInfo!.precioResuelto : item.precioUnitario);
+                        const precioBase = esOverride ? item.precioUnitario : (esMayorista ? precioInfo!.precioResuelto : item.precioUnitario);
+                        // Descuento del cliente sobre el precio efectivo (no sobre override).
+                        const pctCliente = esOverride ? 0 : resolverDescuentoPctCliente(clienteSeleccionado, prod?.categoria);
+                        const precioMostrar = pctCliente > 0 && precioBase > 0
+                          ? Math.round(precioBase * (1 - pctCliente / 100) * 100) / 100
+                          : precioBase;
                         const subtotal = precioMostrar * item.cantidad;
                         const itemMoq = moqMap.get(String(item.productoId));
                         const minCantidad = itemMoq && itemMoq > 1 ? itemMoq : 1;
@@ -622,6 +637,12 @@ const ModalPedido = memo(function ModalPedido({
                                     <span className="inline-flex items-center gap-0.5 text-xs px-1.5 py-0.5 bg-green-100 text-green-700 rounded-full font-medium shrink-0">
                                       <Tag className="w-3 h-3" />
                                       {precioInfo?.etiqueta || 'Mayorista'}
+                                    </span>
+                                  )}
+                                  {pctCliente > 0 && (
+                                    <span className="inline-flex items-center gap-0.5 text-xs px-1.5 py-0.5 bg-emerald-100 text-emerald-700 rounded-full font-medium shrink-0">
+                                      <Percent className="w-3 h-3" />
+                                      -{pctCliente}%
                                     </span>
                                   )}
                                 </div>
@@ -690,6 +711,11 @@ const ModalPedido = memo(function ModalPedido({
                                     }}
                                   >
                                     {formatPrecio(item.precioUnitario)} c/u {isAdmin && onActualizarPrecio && <Pencil className="w-3 h-3 inline ml-0.5 text-gray-400" />}
+                                  </p>
+                                )}
+                                {pctCliente > 0 && (
+                                  <p className="text-xs text-emerald-600 font-medium mt-0.5">
+                                    Descuento cliente -{pctCliente}%: {formatPrecio(precioMostrar)} c/u
                                   </p>
                                 )}
                                 {itemMoq && itemMoq > 1 && (
@@ -834,7 +860,7 @@ const ModalPedido = memo(function ModalPedido({
                           inputMode="decimal"
                           min="0"
                           step="0.01"
-                          max={hayDescuento ? totalFinal : calcularTotal()}
+                          max={totalParaMostrar}
                           value={nuevoPedido.montoPagado || ''}
                           onChange={e => onMontoPagadoChange && onMontoPagadoChange(parsePrecio(e.target.value))}
                           className="flex-1 px-3 py-2 border border-yellow-300 rounded-lg focus:ring-2 focus:ring-yellow-500 bg-white dark:bg-gray-800 dark:border-yellow-600 dark:text-white"
@@ -843,7 +869,7 @@ const ModalPedido = memo(function ModalPedido({
                       </div>
                       {(nuevoPedido.montoPagado ?? 0) > 0 && (
                         <p className="text-sm text-yellow-700 dark:text-yellow-300 mt-2">
-                          Resta por pagar: {formatPrecio((hayDescuento ? totalFinal : calcularTotal()) - (nuevoPedido.montoPagado ?? 0))}
+                          Resta por pagar: {formatPrecio(totalParaMostrar - (nuevoPedido.montoPagado ?? 0))}
                         </p>
                       )}
                     </div>
@@ -865,11 +891,11 @@ const ModalPedido = memo(function ModalPedido({
               <div className="border-t dark:border-gray-600 pt-3 flex justify-between items-center">
                 <span className="text-base font-medium dark:text-white">Total</span>
                 <div className="text-right">
-                  {hayDescuento ? (
+                  {hayDescuentoTotal ? (
                     <>
                       <span className="text-xs text-gray-400 line-through mr-2">{formatPrecio(totalOriginal)}</span>
-                      <span className="text-xl font-bold text-green-600">{formatPrecio(totalFinal)}</span>
-                      <p className="text-xs text-green-600 font-medium">Ahorro: {formatPrecio(ahorro)}</p>
+                      <span className="text-xl font-bold text-green-600">{formatPrecio(totalConDescuentoCliente)}</span>
+                      <p className="text-xs text-green-600 font-medium">Ahorro: {formatPrecio(totalOriginal - totalConDescuentoCliente)}</p>
                     </>
                   ) : (
                     <span className="text-xl font-bold text-blue-600">{formatPrecio(calcularTotal())}</span>
@@ -905,7 +931,7 @@ const ModalPedido = memo(function ModalPedido({
                   : 'Sin productos'}
               </span>
               {hayItems && (
-                <span className={`font-bold text-sm truncate ${hayDescuento ? 'text-green-600' : 'text-blue-600 dark:text-blue-400'}`}>
+                <span className={`font-bold text-sm truncate ${hayDescuentoTotal ? 'text-green-600' : 'text-blue-600 dark:text-blue-400'}`}>
                   {formatPrecio(totalParaMostrar)}
                 </span>
               )}

--- a/src/components/productos/ProductoToolbar.tsx
+++ b/src/components/productos/ProductoToolbar.tsx
@@ -13,7 +13,7 @@
 import React from 'react';
 import {
   Plus, ChevronDown, Tag, Package2, AlertTriangle,
-  ArrowLeftRight, Percent, ClipboardCheck, TrendingDown,
+  ArrowLeftRight, Percent, ClipboardCheck, TrendingDown, History,
   type LucideIcon,
 } from 'lucide-react';
 import {
@@ -35,6 +35,7 @@ export interface ProductoToolbarProps {
   onCambioProducto?: () => void;
   onActualizacionMasivaPrecios?: () => void;
   onControlStock?: () => void;
+  onVerAjustesStock?: () => void;
   onVerHistorialMermas?: () => void;
   onAbrirStockBajo?: () => void;
   onNuevoProducto?: () => void;
@@ -159,6 +160,7 @@ export default function ProductoToolbar({
   onCambioProducto,
   onActualizacionMasivaPrecios,
   onControlStock,
+  onVerAjustesStock,
   onVerHistorialMermas,
   onAbrirStockBajo,
   onNuevoProducto,
@@ -169,8 +171,9 @@ export default function ProductoToolbar({
   // Control de stock (Excel) lo ve admin y encargado; el historial de mermas
   // sigue siendo solo admin.
   const mostrarControlStock = puedeControlarStock && Boolean(onControlStock);
+  const mostrarAjustesStock = puedeControlarStock && Boolean(onVerAjustesStock);
   const mostrarHistorialMermas = isAdmin && Boolean(onVerHistorialMermas);
-  const hayInventario = mostrarControlStock || mostrarHistorialMermas;
+  const hayInventario = mostrarControlStock || mostrarAjustesStock || mostrarHistorialMermas;
   const hayStockBajo = puedeControlarStock;
   const hayNuevo = isAdmin && Boolean(onNuevoProducto);
 
@@ -212,7 +215,18 @@ export default function ProductoToolbar({
           <div className="flex flex-col gap-0.5 min-w-0">
             <span className="font-medium">Control de stock</span>
             <span className="text-xs text-stone-500 dark:text-gray-400">
-              Descarga Excel con el inventario actual
+              Descargar o cargar planilla de inventario
+            </span>
+          </div>
+        </DropdownMenuItem>
+      )}
+      {mostrarAjustesStock && onVerAjustesStock && (
+        <DropdownMenuItem onSelect={onVerAjustesStock}>
+          <History className="w-4 h-4 text-indigo-600" />
+          <div className="flex flex-col gap-0.5 min-w-0">
+            <span className="font-medium">Ajustes de stock</span>
+            <span className="text-xs text-stone-500 dark:text-gray-400">
+              Histórico de ajustes por planilla
             </span>
           </div>
         </DropdownMenuItem>

--- a/src/components/vistas/VistaProductos.tsx
+++ b/src/components/vistas/VistaProductos.tsx
@@ -35,6 +35,7 @@ export interface VistaProductosProps {
   onGestionarCategorias?: () => void;
   onCambioProducto?: () => void;
   onControlStock?: () => void;
+  onVerAjustesStock?: () => void;
   onAbrirStockBajo?: () => void;
 }
 
@@ -54,6 +55,7 @@ export default function VistaProductos({
   onGestionarCategorias,
   onCambioProducto,
   onControlStock,
+  onVerAjustesStock,
   onAbrirStockBajo,
 }: VistaProductosProps) {
   const [busqueda, setBusqueda] = useState<string>('');
@@ -125,6 +127,7 @@ export default function VistaProductos({
             onCambioProducto={onCambioProducto}
             onActualizacionMasivaPrecios={onActualizacionMasivaPrecios}
             onControlStock={onControlStock}
+            onVerAjustesStock={onVerAjustesStock}
             onVerHistorialMermas={onVerHistorialMermas}
             onAbrirStockBajo={onAbrirStockBajo}
             onNuevoProducto={onNuevoProducto}

--- a/src/hooks/handlers/usePedidoHandlers.ts
+++ b/src/hooks/handlers/usePedidoHandlers.ts
@@ -10,6 +10,7 @@ import { usePromoMapQuery } from '../queries/usePromocionesQuery'
 import { resolverPreciosMayorista, aplicarPreciosMayorista, validarMOQPedido } from '../../utils/precioMayorista'
 import { resolverPromociones } from '../../utils/promociones'
 import { calcularNetoVenta } from '../../utils/calculations'
+import { aplicarDescuentoClienteItems } from '../../utils/descuentoCliente'
 import type { User } from '@supabase/supabase-js'
 import type {
   ProductoDB,
@@ -426,21 +427,12 @@ export function usePedidoHandlers({
       }
     }
 
-    // Aplicar descuento porcentual del cliente. Se aplica DESPUES de precio
-    // mayorista/promo para que el descuento se calcule sobre el precio final
-    // por linea. No tocamos lineas con precioOverride (admin lo fijo manual)
-    // ni items con precio 0 (bonificaciones se agregan despues).
+    // Aplicar descuento del cliente: general + por categoría (la categoría
+    // prevalece). Se aplica DESPUES de precio mayorista/promo. Mismo helper que
+    // el path online y ModalPedido. No toca precioOverride / bonificaciones /
+    // precio <= 0.
     const clienteSeleccionado = clientesRef.current.find(c => String(c.id) === String(nuevoPedido.clienteId))
-    const dtoPct = clienteSeleccionado?.descuento_porcentaje ?? 0
-    if (dtoPct > 0) {
-      const factor = 1 - dtoPct / 100
-      itemsFinales = itemsFinales.map(item => {
-        if (item.precioOverride) return item
-        if (!item.precioUnitario || item.precioUnitario <= 0) return item
-        const precioConDto = Math.round(item.precioUnitario * factor * 100) / 100
-        return { ...item, precioUnitario: precioConDto }
-      })
-    }
+    itemsFinales = aplicarDescuentoClienteItems(itemsFinales, productosRef.current, clienteSeleccionado).items
 
     // Agregar items de bonificación
     const itemsBonificacion = promoResolucion.bonificaciones.map(b => ({

--- a/src/hooks/queries/useClientesQuery.ts
+++ b/src/hooks/queries/useClientesQuery.ts
@@ -20,36 +20,43 @@ export const clientesKeys = {
 
 type ClienteRow = ClienteDB & {
   cliente_preventistas?: { preventista_id: string }[] | null
+  cliente_descuentos_categoria?: { categoria: string; descuento_porcentaje: number }[] | null
 }
 
-function flattenPreventistaIds(row: ClienteRow): ClienteDB {
-  const { cliente_preventistas, ...rest } = row
+function flattenClienteRow(row: ClienteRow): ClienteDB {
+  const { cliente_preventistas, cliente_descuentos_categoria, ...rest } = row
   return {
     ...rest,
-    preventista_ids: (cliente_preventistas || []).map(cp => cp.preventista_id)
+    preventista_ids: (cliente_preventistas || []).map(cp => cp.preventista_id),
+    descuentos_categoria: (cliente_descuentos_categoria || []).map(d => ({
+      categoria: d.categoria,
+      descuento_porcentaje: Number(d.descuento_porcentaje) || 0,
+    })),
   }
 }
+
+const CLIENTE_SELECT = '*, cliente_preventistas(preventista_id), cliente_descuentos_categoria(categoria, descuento_porcentaje)'
 
 // Fetch functions
 async function fetchClientes(): Promise<ClienteDB[]> {
   const { data, error } = await supabase
     .from('clientes')
-    .select('*, cliente_preventistas(preventista_id)')
+    .select(CLIENTE_SELECT)
     .order('nombre_fantasia')
 
   if (error) throw error
-  return ((data as ClienteRow[]) || []).map(flattenPreventistaIds)
+  return ((data as ClienteRow[]) || []).map(flattenClienteRow)
 }
 
 async function fetchClienteById(id: string): Promise<ClienteDB | null> {
   const { data, error } = await supabase
     .from('clientes')
-    .select('*, cliente_preventistas(preventista_id)')
+    .select(CLIENTE_SELECT)
     .eq('id', id)
     .single()
 
   if (error) throw error
-  return data ? flattenPreventistaIds(data as ClienteRow) : null
+  return data ? flattenClienteRow(data as ClienteRow) : null
 }
 
 /**
@@ -71,6 +78,40 @@ async function replacePreventistaAssignments(
   const rows = preventistaIds.map(pid => ({ cliente_id: clienteId, preventista_id: pid }))
   const { error: insError } = await supabase
     .from('cliente_preventistas')
+    .insert(rows)
+  if (insError) throw insError
+}
+
+/**
+ * Reemplaza los descuentos por categoría de un cliente (delete + insert).
+ * Idempotente. Dedup por categoría normalizada (la última gana) para no chocar
+ * con el UNIQUE (cliente_id, categoria). Filas sin categoría se descartan.
+ */
+async function replaceCategoriaDiscounts(
+  clienteId: string,
+  descuentos: { categoria: string; descuento_porcentaje: number }[]
+): Promise<void> {
+  const { error: delError } = await supabase
+    .from('cliente_descuentos_categoria')
+    .delete()
+    .eq('cliente_id', clienteId)
+  if (delError) throw delError
+
+  const dedup = new Map<string, { cliente_id: string; categoria: string; descuento_porcentaje: number }>()
+  for (const d of descuentos || []) {
+    const categoria = (d.categoria || '').trim()
+    if (!categoria) continue
+    dedup.set(categoria.toUpperCase(), {
+      cliente_id: clienteId,
+      categoria,
+      descuento_porcentaje: d.descuento_porcentaje,
+    })
+  }
+  const rows = [...dedup.values()]
+  if (rows.length === 0) return
+
+  const { error: insError } = await supabase
+    .from('cliente_descuentos_categoria')
     .insert(rows)
   if (insError) throw insError
 }
@@ -122,6 +163,7 @@ interface ClienteCreateInput {
   notas?: string
   preventista_id?: string | null
   preventista_ids?: string[]
+  descuentos_categoria?: { categoria: string; descuento_porcentaje: number }[]
 }
 
 // Mutation functions
@@ -153,7 +195,7 @@ async function createCliente(cliente: ClienteCreateInput, sucursalId: number | n
     }
   }
 
-  const { preventista_ids, ...clienteFields } = cliente
+  const { preventista_ids, descuentos_categoria, ...clienteFields } = cliente
   const { data, error } = await supabase
     .from('clientes')
     .insert([{
@@ -190,11 +232,16 @@ async function createCliente(cliente: ClienteCreateInput, sucursalId: number | n
     newCliente.preventista_ids = preventista_ids
   }
 
+  if (descuentos_categoria !== undefined) {
+    await replaceCategoriaDiscounts(newCliente.id, descuentos_categoria)
+    newCliente.descuentos_categoria = descuentos_categoria
+  }
+
   return newCliente
 }
 
 async function updateCliente({ id, data: cliente }: { id: string; data: Partial<ClienteCreateInput> }): Promise<ClienteDB> {
-  const { preventista_ids, ...clienteFields } = cliente
+  const { preventista_ids, descuentos_categoria, ...clienteFields } = cliente
 
   // Coerce '' → null para zona_id (FK column). PostgREST rechaza '' en columnas FK.
   // Solo aplicamos si el campo viene en el patch (Partial), preservando undefined
@@ -217,6 +264,11 @@ async function updateCliente({ id, data: cliente }: { id: string; data: Partial<
   if (preventista_ids !== undefined) {
     await replacePreventistaAssignments(id, preventista_ids)
     updated.preventista_ids = preventista_ids
+  }
+
+  if (descuentos_categoria !== undefined) {
+    await replaceCategoriaDiscounts(id, descuentos_categoria)
+    updated.descuentos_categoria = descuentos_categoria
   }
 
   return updated

--- a/src/hooks/queries/useControlStockQuery.ts
+++ b/src/hooks/queries/useControlStockQuery.ts
@@ -1,0 +1,107 @@
+/**
+ * TanStack Query hooks para Control de Stock (planilla → ajustes).
+ *
+ * - Sesiones: cabecera de cada carga de planilla (control_stock_sesiones).
+ * - Detalle: filas de stock_historico con origen='control_stock' de una sesión.
+ * - Aplicar: RPC aplicar_control_stock (solo admin; revalida es_admin() en DB).
+ */
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import { supabase } from '../supabase/base'
+import { useSucursal } from '../../contexts/SucursalContext'
+import { productosKeys } from './useProductosQuery'
+
+export interface AplicarControlStockResult {
+  sesion_id: number
+  total_items: number
+  total_altas: number
+  total_bajas: number
+  aplicados: Array<{ producto_id: number; stock_anterior: number; stock_nuevo: number; diferencia: number }>
+  no_encontrados: Array<{ producto_id: number }>
+}
+
+export interface ControlStockSesion {
+  id: number
+  fecha: string
+  usuario_id: string | null
+  total_items: number
+  total_altas: number
+  total_bajas: number
+  observaciones: string | null
+  usuario?: { nombre: string } | null
+}
+
+export interface ControlStockDetalle {
+  id: number
+  producto_id: number
+  stock_anterior: number
+  stock_nuevo: number
+  diferencia: number | null
+  created_at: string
+}
+
+const controlStockKeys = {
+  all: (sucursalId: number | null) => ['control_stock', sucursalId] as const,
+  sesiones: (sucursalId: number | null) => [...controlStockKeys.all(sucursalId), 'sesiones'] as const,
+  detalle: (sucursalId: number | null, sesionId: number) => [...controlStockKeys.all(sucursalId), 'detalle', sesionId] as const,
+}
+
+async function fetchSesiones(): Promise<ControlStockSesion[]> {
+  const { data, error } = await supabase
+    .from('control_stock_sesiones')
+    .select('id, fecha, usuario_id, total_items, total_altas, total_bajas, observaciones, usuario:perfiles(nombre)')
+    .order('fecha', { ascending: false })
+    .limit(100)
+  if (error) throw error
+  return (data as unknown as ControlStockSesion[]) || []
+}
+
+async function fetchDetalle(sesionId: number): Promise<ControlStockDetalle[]> {
+  const { data, error } = await supabase
+    .from('stock_historico')
+    .select('id, producto_id, stock_anterior, stock_nuevo, diferencia, created_at')
+    .eq('origen', 'control_stock')
+    .eq('referencia_id', sesionId)
+    .order('id', { ascending: true })
+  if (error) throw error
+  return (data as ControlStockDetalle[]) || []
+}
+
+export function useControlStockSesionesQuery(enabled = true) {
+  const { currentSucursalId } = useSucursal()
+  return useQuery({
+    queryKey: controlStockKeys.sesiones(currentSucursalId),
+    queryFn: fetchSesiones,
+    enabled: enabled && !!currentSucursalId,
+    staleTime: 60 * 1000,
+  })
+}
+
+export function useControlStockDetalleQuery(sesionId: number | null) {
+  const { currentSucursalId } = useSucursal()
+  return useQuery({
+    queryKey: controlStockKeys.detalle(currentSucursalId, sesionId ?? -1),
+    queryFn: () => fetchDetalle(sesionId as number),
+    enabled: sesionId != null,
+    staleTime: 60 * 1000,
+  })
+}
+
+export function useAplicarControlStockMutation() {
+  const queryClient = useQueryClient()
+  const { currentSucursalId } = useSucursal()
+  return useMutation({
+    mutationFn: async (ajustes: Array<{ producto_id: string; stock_real: number }>): Promise<AplicarControlStockResult> => {
+      const { data, error } = await supabase.rpc('aplicar_control_stock', {
+        p_ajustes: ajustes,
+        p_observaciones: null,
+      })
+      if (error) throw error
+      return data as AplicarControlStockResult
+    },
+    onSuccess: () => {
+      // El stock cambió: refrescar productos y el histórico de sesiones.
+      queryClient.invalidateQueries({ queryKey: productosKeys.all(currentSucursalId) })
+      queryClient.invalidateQueries({ queryKey: controlStockKeys.all(currentSucursalId) })
+    },
+  })
+}

--- a/src/lib/permisos.ts
+++ b/src/lib/permisos.ts
@@ -20,6 +20,16 @@ export function puedeControlarStock(rol: RolUsuario | null | undefined): boolean
   return rol === 'admin' || rol === 'encargado'
 }
 
+/**
+ * Si el rol puede CARGAR la planilla de control de stock (aplicar ajustes que
+ * modifican el stock). Solo admin: si el encargado pudiera cargarla, sería una
+ * vía para editar stock sin permisos. Descargar y ver histórico sí los puede
+ * (ver puedeControlarStock). El RPC aplicar_control_stock revalida es_admin().
+ */
+export function puedeCargarControlStock(rol: RolUsuario | null | undefined): boolean {
+  return rol === 'admin'
+}
+
 export function puedeEditarPreciosPedido(rol: RolUsuario | null | undefined): boolean {
   return rol === 'admin'
 }

--- a/src/types/hooks.ts
+++ b/src/types/hooks.ts
@@ -31,6 +31,12 @@ export interface ClienteDB {
   dias_credito?: number;
   saldo_cuenta?: number;
   descuento_porcentaje?: number;
+  /**
+   * Descuentos por categoría (override del descuento general). N-a-1 via
+   * cliente_descuentos_categoria. Para productos de una categoría con descuento
+   * configurado, este prevalece sobre `descuento_porcentaje`.
+   */
+  descuentos_categoria?: Array<{ categoria: string; descuento_porcentaje: number }>;
   preventista_id?: string | null;
   /**
    * IDs de preventistas asignados (N-a-N via tabla cliente_preventistas).

--- a/src/utils/descuentoCliente.ts
+++ b/src/utils/descuentoCliente.ts
@@ -1,0 +1,105 @@
+/**
+ * Descuentos por cliente: general + por categoría.
+ *
+ * Regla de negocio: si el cliente tiene un descuento por la categoría del
+ * producto, ese prevalece sobre el descuento general (incluso si el de la
+ * categoría es 0%, lo que sirve para excluir una categoría del general).
+ *
+ * El match es por NOMBRE de categoría normalizado (trim + mayúsculas) porque
+ * `productos.categoria` es texto libre (no FK) y es el campo sobre el que se
+ * calcula el precio. Centraliza la lógica para usarla en vivo (armado del
+ * pedido) y al guardar, evitando duplicar la matemática.
+ */
+
+export interface DescuentoCategoriaCliente {
+  categoria: string
+  descuento_porcentaje: number
+}
+
+export interface ClienteConDescuentos {
+  descuento_porcentaje?: number | null
+  descuentos_categoria?: DescuentoCategoriaCliente[] | null
+}
+
+export interface ProductoConCategoria {
+  id: string | number
+  categoria?: string | null
+}
+
+/** Forma mínima de un item de pedido para aplicarle descuento. */
+export interface ItemDescuentable {
+  productoId?: string | number
+  producto_id?: string | number
+  cantidad: number
+  precioUnitario: number
+  precioOverride?: boolean
+  esBonificacion?: boolean
+}
+
+const norm = (s?: string | null): string => (s ?? '').trim().toUpperCase()
+
+/**
+ * Devuelve el % de descuento efectivo para un producto de la categoría dada.
+ * Categoría > general. Si no hay match de categoría, usa el general.
+ */
+export function resolverDescuentoPctCliente(
+  cliente: ClienteConDescuentos | null | undefined,
+  categoria: string | null | undefined,
+): number {
+  if (!cliente) return 0
+  const general = Number(cliente.descuento_porcentaje ?? 0) || 0
+  const cats = cliente.descuentos_categoria
+  if (cats && cats.length > 0 && categoria) {
+    const key = norm(categoria)
+    const match = cats.find(c => norm(c.categoria) === key)
+    // La categoría prevalece aunque sea 0 (exclusión explícita del general).
+    if (match) return Number(match.descuento_porcentaje ?? 0) || 0
+  }
+  return general
+}
+
+/**
+ * Aplica el descuento del cliente a los items ya resueltos (mayorista/promo).
+ * No toca bonificaciones, líneas con precioOverride ni precio ≤ 0.
+ * Devuelve los items con `precioUnitario` ajustado + total e info de ahorro.
+ */
+export function aplicarDescuentoClienteItems<T extends ItemDescuentable>(
+  items: T[],
+  productos: ProductoConCategoria[],
+  cliente: ClienteConDescuentos | null | undefined,
+): { items: T[]; total: number; ahorro: number; hayDescuento: boolean } {
+  const general = Number(cliente?.descuento_porcentaje ?? 0) || 0
+  const cats = cliente?.descuentos_categoria ?? []
+  const sinDescuentos = general <= 0 && (!cats || cats.length === 0)
+
+  let total = 0
+  let totalOriginal = 0
+  let hayDescuento = false
+
+  const out = items.map(item => {
+    const pid = String(item.productoId ?? item.producto_id ?? '')
+    const precio = item.precioUnitario ?? 0
+    const cantidad = item.cantidad ?? 0
+    const esBonif = !!item.esBonificacion
+    if (!esBonif) totalOriginal += precio * cantidad
+
+    if (sinDescuentos || esBonif || item.precioOverride || precio <= 0) {
+      if (!esBonif) total += precio * cantidad
+      return item
+    }
+
+    const prod = productos.find(p => String(p.id) === pid)
+    const pct = resolverDescuentoPctCliente(cliente, prod?.categoria)
+    if (pct <= 0) {
+      total += precio * cantidad
+      return item
+    }
+
+    const nuevoPrecio = Math.round(precio * (1 - pct / 100) * 100) / 100
+    hayDescuento = true
+    total += nuevoPrecio * cantidad
+    return { ...item, precioUnitario: nuevoPrecio }
+  })
+
+  return { items: out, total, ahorro: totalOriginal - total, hayDescuento }
+}

--- a/src/utils/excel.ts
+++ b/src/utils/excel.ts
@@ -408,11 +408,93 @@ export async function exportControlStock(
   downloadBuffer(buffer as ArrayBuffer, `Control_Stock_${fecha}.xlsx`, 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet')
 }
 
+/** Fila parseada de una planilla de control de stock completada. */
+export interface ControlStockRow {
+  codigo: string | null
+  nombre: string | null
+  stockReal: number
+}
+
+/**
+ * Lee una planilla de control de stock COMPLETADA (la que genera
+ * exportControlStock). A diferencia de readExcelFile, esta tolera el layout
+ * real: encabezados en una fila intermedia (busca la que tiene "Stock Real") y
+ * datos debajo.
+ *
+ * REGLA DE SEGURIDAD: solo devuelve filas con "Stock Real" numérico no vacío.
+ * Una celda vacía = ítem no contado = se OMITE (no se ajusta a 0). Así un ítem
+ * que no se controló nunca se pisa.
+ */
+export async function readControlStockPlanilla(file: File | ArrayBuffer): Promise<ControlStockRow[]> {
+  const workbook = new ExcelJS.Workbook()
+  const arrayBuffer = file instanceof File ? await file.arrayBuffer() : file
+  await workbook.xlsx.load(arrayBuffer)
+
+  const ws = workbook.worksheets[0]
+  if (!ws) throw new Error('El archivo no contiene hojas de cálculo')
+
+  const norm = (v: unknown): string => String(v ?? '').trim().toLowerCase()
+  const cellNumber = (v: unknown): unknown => {
+    if (v && typeof v === 'object') {
+      const cv = v as { result?: unknown; text?: string }
+      return cv.result ?? cv.text ?? null
+    }
+    return v
+  }
+
+  // 1. Localizar la fila de encabezados (la que contiene "Stock Real").
+  let headerRowNum = -1
+  const colIndex: { codigo?: number; nombre?: number; stockReal?: number } = {}
+  const maxScan = Math.min(ws.rowCount || 0, 20)
+  for (let r = 1; r <= maxScan; r++) {
+    const row = ws.getRow(r)
+    let tieneStockReal = false
+    row.eachCell((cell) => { if (norm(cell.value).includes('stock real')) tieneStockReal = true })
+    if (!tieneStockReal) continue
+    headerRowNum = r
+    row.eachCell((cell, col) => {
+      const t = norm(cell.value)
+      if (t.includes('stock real') || t === 'real') colIndex.stockReal = col
+      else if (t.includes('cód') || t.includes('cod')) colIndex.codigo = col
+      else if (t.includes('producto') || t === 'nombre') colIndex.nombre = col
+    })
+    break
+  }
+  if (headerRowNum < 0 || colIndex.stockReal == null) {
+    throw new Error('No se encontró la columna "Stock Real". Usá la planilla descargada desde el sistema.')
+  }
+
+  // 2. Leer filas de datos.
+  const out: ControlStockRow[] = []
+  for (let r = headerRowNum + 1; r <= (ws.rowCount || 0); r++) {
+    const row = ws.getRow(r)
+    const realRaw = cellNumber(row.getCell(colIndex.stockReal).value)
+    if (realRaw === null || realRaw === undefined || String(realRaw).trim() === '') continue
+    const num = Number(String(realRaw).replace(',', '.'))
+    if (!Number.isFinite(num)) continue
+
+    const codigoRaw = colIndex.codigo ? cellNumber(row.getCell(colIndex.codigo).value) : null
+    const nombreRaw = colIndex.nombre ? cellNumber(row.getCell(colIndex.nombre).value) : null
+    const codigo = codigoRaw != null ? String(codigoRaw).trim() : null
+    const nombre = nombreRaw != null ? String(nombreRaw).trim() : null
+    // Saltar la fila de TOTALES (sin código ni producto).
+    if (!codigo && !nombre) continue
+
+    out.push({
+      codigo: codigo && codigo !== '-' ? codigo : null,
+      nombre: nombre || null,
+      stockReal: Math.max(0, Math.round(num)),
+    })
+  }
+  return out
+}
+
 export default {
   readExcelFile,
   createAndDownloadExcel,
   createTemplate,
   exportReport,
   createMultiSheetExcel,
-  exportControlStock
+  exportControlStock,
+  readControlStockPlanilla
 }


### PR DESCRIPTION
## Resumen

Tres cambios pedidos por el gerente/usuario, sobre `ManaosApp`.

### 1. 🐞 Corrección — Historial de pedidos
Los eventos mostraban **"Usuario desconocido"** y el transportista como UUID.
- **Causa raíz** (verificada en prod): el trigger `registrar_cambio_pedido` leía `app.current_user_id`, una variable que la app nunca setea → `usuario_id` quedaba NULL.
- **Fix DB**: los triggers ahora caen en `auth.uid()` cuando esa GUC no está seteada.
- **Modal**: resuelve el transportista a **nombre** y muestra **"Sistema"** para cambios automáticos (bot/service-role).
- Solo corrige hacia adelante: filas históricas con usuario NULL no se recuperan.

### 2. ✨ Control de stock por planilla
- **DB**: tabla `control_stock_sesiones` + RPC `aplicar_control_stock` (SECURITY DEFINER, revalida `es_admin()`). El detalle reutiliza `stock_historico` con `origen='control_stock'`.
- **UI**: modal para **descargar** (filtrando por categoría) y **cargar** (solo admin → preview de diferencias → aplicar), y modal de **histórico agrupado por carga** (expandible al detalle).
- **Seguridad**: solo se ajustan ítems con "Stock Real" cargado; los vacíos se **omiten** (no se pisa a 0 lo no controlado).
- **Permisos**: admin descarga+carga+histórico; encargado descarga+histórico, **no** carga (UI oculta + RPC rechaza).

### 3. ✨ Descuentos por categoría por cliente
- **DB**: tabla `cliente_descuentos_categoria` (escritura solo admin).
- **Editar Cliente**: sección "Descuentos por categoría" (categoría con búsqueda + % entero + agregar/quitar filas).
- **Regla**: la categoría **prevalece** sobre el descuento general. Helper compartido aplicado **en vivo** al armar el pedido (badge "−X%", precio y total con descuento) y **al guardar**, así el total mostrado == el guardado.

## Migraciones
`077` (triggers historial) · `078` (control de stock + RPC) · `079` (descuentos por categoría).
Ya **aplicadas en prod** vía MCP durante el desarrollo; los archivos quedan para versionar el schema (consistente con el flujo del repo).

## Verificación
- `tsc --noEmit` ✅ · `eslint` ✅ · **688 tests** ✅ · `vite build` ✅
- RPC `aplicar_control_stock` probada en vivo: rechaza a no-admin; happy-path OK (stock 50→55, `stock_historico` con `diferencia` generada) en transacción con rollback (prod sin cambios).
- Durante la verificación se detectó y corrigió un bug: `stock_historico.diferencia` es columna generada (no se puede insertar).

## Prueba manual sugerida
1. **Historial**: cambiar estado / asignar transportista logueado → el evento muestra tu nombre y el transportista por nombre.
2. **Control de stock**: descargar filtrando categorías, completar algunas filas (dejar otras vacías), cargar (admin) → solo se ajustan las completadas; ver "Ajustes de stock".
3. **Descuentos**: cliente con general 10% + categoría "GASEOSAS" 5% → producto de GASEOSAS aplica 5%, otro aplica 10%, visible en vivo en el carrito.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
