### PR TITLE
Optimizar ruta con todos los pedidos asignados + edicion de cliente para preventistas

### DIFF
--- a/src/components/containers/ClientesContainer.tsx
+++ b/src/components/containers/ClientesContainer.tsx
@@ -55,6 +55,10 @@ export default function ClientesContainer(): React.ReactElement {
   const { registrarPago, registrarPagoFIFO, obtenerResumenCuenta } = usePagos()
   const rol = perfil?.rol
   const puedePago = puedeRegistrarPagoCliente(rol)
+  // Preventista editando un cliente existente: solo puede tocar datos de
+  // contacto/atención (razón social, dirección, teléfono, contacto, rubro,
+  // horarios, notas). El resto lo gestiona admin/encargado.
+  const edicionRestringida = isPreventista && !isAdmin && !isEncargado
 
   // Queries
   const { data: clientes = [], isLoading } = useClientesQuery()
@@ -226,6 +230,34 @@ export default function ClientesContainer(): React.ReactElement {
       ? zonas.find(z => String(z.id) === String(data.zona_id))
       : null
 
+    // Preventista editando: patch acotado a los campos que puede tocar.
+    // CUIT, nombre fantasía, zona, crédito, descuentos y asignaciones quedan
+    // fuera para que no se sobrescriban desde esta UI.
+    if (!isCreating && edicionRestringida) {
+      const patchRestringido = {
+        razon_social: data.razonSocial || data.nombreFantasia,
+        direccion: data.direccion,
+        aclaracion_direccion: data.aclaracionDireccion?.trim() || null,
+        latitud: data.latitud,
+        longitud: data.longitud,
+        telefono: data.telefono || undefined,
+        contacto: data.contacto || undefined,
+        horarios_atencion: data.horarios_atencion || undefined,
+        rubro: data.rubro || undefined,
+        notas: data.notas || undefined,
+      }
+      try {
+        await actualizarCliente.mutateAsync({ id: clienteEditando!.id, data: patchRestringido })
+        notify.success('Cliente actualizado')
+        setModalClienteOpen(false)
+        setClienteEditando(null)
+      } catch (error) {
+        notify.error((error as Error).message || 'Error al guardar cliente')
+        throw error
+      }
+      return
+    }
+
     const dbData = {
       razon_social: data.razonSocial || data.nombreFantasia,
       nombre_fantasia: data.nombreFantasia,
@@ -274,7 +306,7 @@ export default function ClientesContainer(): React.ReactElement {
       notify.error((error as Error).message || 'Error al guardar cliente')
       throw error
     }
-  }, [clienteEditando, actualizarCliente, crearCliente, notify, isAdmin, isPreventista, user, zonas])
+  }, [clienteEditando, actualizarCliente, crearCliente, notify, isAdmin, isPreventista, edicionRestringida, user, zonas])
 
   return (
     <>
@@ -306,6 +338,7 @@ export default function ClientesContainer(): React.ReactElement {
             }}
             guardando={crearCliente.isPending || actualizarCliente.isPending}
             isAdmin={isAdmin}
+            edicionRestringida={edicionRestringida && !!clienteEditando}
           />
         </Suspense>
       )}

--- a/src/components/containers/PedidosContainer.tsx
+++ b/src/components/containers/PedidosContainer.tsx
@@ -22,6 +22,7 @@ import {
   useEntregasMasivasMutation,
   useCancelarPedidoMutation,
   usePagosMasivosMutation,
+  usePedidosAsignadosQuery,
   useClientesQuery,
   useProductosQuery,
   useTransportistasQuery,
@@ -172,6 +173,11 @@ export default function PedidosContainer(): React.ReactElement {
   const [modalVisitasHoyOpen, setModalVisitasHoyOpen] = useState(false)
   const [pedidoPago, setPedidoPago] = useState<PedidoDB | null>(null)
   const [pagosPreviosPedido, setPagosPreviosPedido] = useState<PagoDBWithUsuario[]>([])
+
+  // Pedidos para el modal de gestión de rutas: TODOS los 'asignado' de la
+  // sucursal, sin paginar. La lista paginada de la vista (15 por página)
+  // dejaba afuera pedidos del transportista al optimizar la ruta.
+  const { data: pedidosParaRuta = [], isLoading: loadingPedidosRuta } = usePedidosAsignadosQuery(modalOptimizarRutaOpen)
   const [loadingPagosPrevios, setLoadingPagosPrevios] = useState(false)
   const [confirmConfig, setConfirmConfig] = useState<ConfirmConfig>({ visible: false })
 
@@ -997,12 +1003,14 @@ export default function PedidosContainer(): React.ReactElement {
           p_pedidos: data.ordenOptimizado.map(p => ({ id: p.pedido_id, orden_entrega: p.orden }))
         })
       }
+      // Refresca lista paginada y query de asignados: ambos cachean orden_entrega
+      queryClient.invalidateQueries({ queryKey: ['pedidos'] })
       setModalOptimizarRutaOpen(false)
       limpiarRuta()
       notify.success('Orden de entrega actualizado')
     } catch (e) { notify.error((e as Error).message) }
     setGuardando(false)
-  }, [limpiarRuta, notify])
+  }, [limpiarRuta, notify, queryClient])
 
   const handleExportarHojaRutaOptimizada = useCallback(async (transportista: PerfilDB | undefined, pedidosOrdenados: PedidoDB[]) => {
     try {
@@ -1386,12 +1394,12 @@ export default function PedidosContainer(): React.ReactElement {
         <Suspense fallback={null}>
           <ModalGestionRutas
             transportistas={transportistas}
-            pedidos={pedidos}
+            pedidos={pedidosParaRuta}
             onOptimizar={optimizarRuta as Parameters<typeof ModalGestionRutas>[0]['onOptimizar']}
             onAplicarOrden={handleAplicarOrden as Parameters<typeof ModalGestionRutas>[0]['onAplicarOrden']}
             onExportarPDF={handleExportarHojaRutaOptimizada as Parameters<typeof ModalGestionRutas>[0]['onExportarPDF']}
             onClose={() => { setModalOptimizarRutaOpen(false); limpiarRuta() }}
-            loading={loadingOptimizacion}
+            loading={loadingOptimizacion || loadingPedidosRuta}
             guardando={guardando}
             rutaOptimizada={rutaOptimizada as Parameters<typeof ModalGestionRutas>[0]['rutaOptimizada']}
             error={errorOptimizacion}

--- a/src/components/modals/ModalCliente.tsx
+++ b/src/components/modals/ModalCliente.tsx
@@ -72,6 +72,13 @@ export interface ModalClienteProps {
   guardando: boolean;
   /** Si el usuario es admin (puede editar crédito) */
   isAdmin?: boolean;
+  /**
+   * Edición restringida (preventista editando un cliente existente): solo
+   * permite tocar razón social, dirección, teléfono, contacto, rubro,
+   * horarios de atención y notas. El resto se muestra deshabilitado.
+   * El container debe enviar únicamente esos campos en el patch.
+   */
+  edicionRestringida?: boolean;
 }
 
 // Las zonas ahora vienen de la tabla `zonas` via useZonasEstandarizadasQuery
@@ -91,7 +98,7 @@ const RUBROS_OPCIONES = [
   'Otro'
 ];
 
-const ModalCliente = memo(function ModalCliente({ cliente, onSave, onClose, guardando, isAdmin = false }: ModalClienteProps) {
+const ModalCliente = memo(function ModalCliente({ cliente, onSave, onClose, guardando, isAdmin = false, edicionRestringida = false }: ModalClienteProps) {
   // Ref para scroll a errores
   const formRef = useRef<HTMLDivElement>(null);
   const { data: preventistas = [] } = usePreventistasQuery();
@@ -361,6 +368,15 @@ const ModalCliente = memo(function ModalCliente({ cliente, onSave, onClose, guar
   return (
     <ModalBase title={cliente ? 'Editar Cliente' : 'Nuevo Cliente'} onClose={onClose}>
       <div ref={formRef} className="p-4 space-y-4 max-h-[70vh] overflow-y-auto">
+        {edicionRestringida && (
+          <div className="flex items-start gap-2 px-3 py-2 rounded-lg bg-blue-50 dark:bg-blue-900/20 text-blue-700 dark:text-blue-300 text-xs">
+            <AlertCircle className="w-4 h-4 mt-0.5 shrink-0" />
+            <span>
+              Podés editar razón social, dirección, teléfono, contacto, rubro, horarios y notas.
+              El resto de los datos los gestiona un administrador.
+            </span>
+          </div>
+        )}
         {/* Tipo Documento, Numero y Razón Social */}
         <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
           <div>
@@ -368,7 +384,8 @@ const ModalCliente = memo(function ModalCliente({ cliente, onSave, onClose, guar
             <select
               value={form.tipo_documento}
               onChange={e => handleTipoDocumentoChange(e.target.value)}
-              className="w-full px-3 py-2 border rounded-lg dark:bg-gray-700 dark:border-gray-600 dark:text-white"
+              disabled={edicionRestringida}
+              className="w-full px-3 py-2 border rounded-lg dark:bg-gray-700 dark:border-gray-600 dark:text-white disabled:opacity-60 disabled:cursor-not-allowed"
             >
               <option value="CUIT">CUIT</option>
               <option value="DNI">DNI</option>
@@ -383,7 +400,8 @@ const ModalCliente = memo(function ModalCliente({ cliente, onSave, onClose, guar
               type="text"
               value={form.numero_documento}
               onChange={e => handleFieldChange('numero_documento', e.target.value)}
-              className={inputClass('numero_documento')}
+              disabled={edicionRestringida}
+              className={`${inputClass('numero_documento')} disabled:opacity-60 disabled:cursor-not-allowed`}
               placeholder={form.tipo_documento === 'CUIT' ? 'XX-XXXXXXXX-X' : '12345678'}
               maxLength={form.tipo_documento === 'CUIT' ? 13 : 8}
               {...getAriaProps('numero_documento', true)}
@@ -413,7 +431,8 @@ const ModalCliente = memo(function ModalCliente({ cliente, onSave, onClose, guar
             type="text"
             value={form.nombreFantasia}
             onChange={e => handleFieldChange('nombreFantasia', e.target.value)}
-            className={inputClass('nombreFantasia')}
+            disabled={edicionRestringida}
+            className={`${inputClass('nombreFantasia')} disabled:opacity-60 disabled:cursor-not-allowed`}
             placeholder="Nombre comercial"
             {...getAriaProps('nombreFantasia', true)}
           />
@@ -578,7 +597,8 @@ const ModalCliente = memo(function ModalCliente({ cliente, onSave, onClose, guar
             <select
               value={form.zona_id}
               onChange={e => handleFieldChange('zona_id', e.target.value)}
-              className="w-full px-3 py-2 border rounded-lg dark:bg-gray-700 dark:border-gray-600 dark:text-white"
+              disabled={edicionRestringida}
+              className="w-full px-3 py-2 border rounded-lg dark:bg-gray-700 dark:border-gray-600 dark:text-white disabled:opacity-60 disabled:cursor-not-allowed"
             >
               <option value="">(Sin zona)</option>
               {zonas.map(z => (

--- a/src/components/vistas/VistaClientes.tsx
+++ b/src/components/vistas/VistaClientes.tsx
@@ -286,7 +286,7 @@ export default function VistaClientes({
               cliente={cliente}
               idx={idx}
               isAdmin={isAdmin}
-              canEditar={isAdmin || isEncargado}
+              canEditar={isAdmin || isEncargado || isPreventista}
               verSaldo={verSaldo}
               onEditar={() => onEditarCliente(cliente)}
               onEliminar={() => onEliminarCliente(cliente.id)}

--- a/src/hooks/queries/index.ts
+++ b/src/hooks/queries/index.ts
@@ -57,6 +57,7 @@ export {
   useAsignarTransportistaMutation,
   useEliminarPedidoMutation,
   usePedidosNoEntregadosQuery,
+  usePedidosAsignadosQuery,
   useEntregasMasivasMutation,
   useCancelarPedidoMutation,
   usePedidosNoPagadosQuery,

--- a/src/hooks/queries/usePedidosQuery.ts
+++ b/src/hooks/queries/usePedidosQuery.ts
@@ -23,6 +23,7 @@ export const pedidosKeys = {
     [...pedidosKeys.all(sucursalId), 'paginated', page, pageSize, filters] as const,
   noEntregados: (sucursalId: number | null) => [...pedidosKeys.all(sucursalId), 'no-entregados'] as const,
   noPagados: (sucursalId: number | null) => [...pedidosKeys.all(sucursalId), 'no-pagados'] as const,
+  asignados: (sucursalId: number | null) => [...pedidosKeys.all(sucursalId), 'asignados'] as const,
 }
 
 // Types
@@ -190,6 +191,26 @@ async function fetchPedidosByCliente(clienteId: string): Promise<PedidoDB[]> {
     .eq('cliente_id', clienteId)
     .order('created_at', { ascending: false })
     .limit(50)
+
+  if (error) throw error
+  return (data || []) as PedidoDB[]
+}
+
+// Pedidos asignados (sin paginar) para el modal de gestión de rutas: la
+// optimización necesita TODOS los pedidos en estado 'asignado' de la sucursal,
+// no la página visible de /pedidos (15 items), que dejaba afuera pedidos del
+// transportista al optimizar.
+async function fetchPedidosAsignados(sucursalId: number | null): Promise<PedidoDB[]> {
+  let query = supabase
+    .from('pedidos')
+    .select(PEDIDO_SELECT)
+    .eq('estado', 'asignado')
+
+  if (sucursalId != null) {
+    query = query.eq('sucursal_id', sucursalId)
+  }
+
+  const { data, error } = await query.order('orden_entrega', { ascending: true, nullsFirst: false })
 
   if (error) throw error
   return (data || []) as PedidoDB[]
@@ -470,6 +491,20 @@ export function usePedidosPaginatedQuery(
     staleTime: 2 * 60 * 1000,
     placeholderData: keepPreviousData,
     enabled,
+  })
+}
+
+/**
+ * Hook para obtener todos los pedidos asignados (sin paginación).
+ * Se habilita solo cuando enabled=true (modal de gestión de rutas abierto).
+ */
+export function usePedidosAsignadosQuery(enabled = false) {
+  const { currentSucursalId } = useSucursal()
+  return useQuery({
+    queryKey: pedidosKeys.asignados(currentSucursalId),
+    queryFn: () => fetchPedidosAsignados(currentSucursalId),
+    enabled: enabled && !!currentSucursalId,
+    staleTime: 30 * 1000, // 30 segundos
   })
 }
 


### PR DESCRIPTION
## Resumen

### 1. Optimización de ruta: ahora toma TODOS los pedidos asignados
Un usuario reportó que la optimización de ruta solo tomaba los pedidos de "una hoja". La causa: el modal de gestión de rutas recibía la lista paginada de `/pedidos` (15 por página), así que cualquier pedido del transportista fuera de la página visible quedaba afuera de la optimización.

- Nueva query `usePedidosAsignadosQuery` que carga todos los pedidos en estado `asignado` de la sucursal, sin paginar. Se habilita solo cuando el modal de rutas está abierto (mismo patrón que `usePedidosNoEntregadosQuery`).
- El modal de gestión de rutas ahora usa esa lista completa: el contador por transportista, la advertencia de pedidos sin coordenadas, la optimización, el "Aplicar Orden" y la hoja de ruta PDF ven todos los pedidos asignados.
- Al aplicar el orden optimizado se invalida el cache de pedidos para que `orden_entrega` se refresque en la lista y en el modal.

### 2. Preventistas pueden editar clientes (campos limitados)
Los preventistas ahora ven el botón de editar en las tarjetas de clientes, pero solo pueden modificar:

- Razón social
- Dirección (incluye coordenadas GPS y aclaración para repartidores)
- Horario de atención
- Observaciones (notas)
- Teléfono
- Contacto
- Rubro

En el modal, CUIT/DNI, nombre fantasía y zona aparecen deshabilitados con un aviso; crédito, descuentos y preventistas asignados ya eran solo-admin. Además el container envía un patch acotado a esos campos, así nada fuera de la lista se sobrescribe desde esta UI.

**Nota**: la política RLS `mt_clientes_update` en prod ya permitía UPDATE a preventistas sobre cualquier columna (vía `es_preventista()`); la restricción por campo es a nivel app. Si se quiere blindar por columna a nivel DB haría falta un trigger o una RPC dedicada (no incluido en este PR).

## Test plan
- [x] `npm run typecheck` sin errores
- [x] `eslint` sin errores en los archivos tocados
- [x] Suite de unit tests completa (688 tests) pasó en el pre-commit hook
- [ ] Manual: abrir Gestión de Rutas con un transportista con >15 pedidos asignados y verificar que el contador y la optimización incluyan todos
- [ ] Manual: como preventista, editar un cliente y verificar que solo se puedan tocar los campos permitidos y que zona/CUIT/crédito no cambien

🤖 Generated with [Claude Code](https://claude.com/claude-code)
