### PR TITLE
Trigger DB: restringir columnas de clientes editables por preventistas

### DIFF
--- a/migrations/080_clientes_guard_update_preventista.sql
+++ b/migrations/080_clientes_guard_update_preventista.sql
@@ -1,0 +1,60 @@
+-- Migración 080: Restringir columnas editables de clientes para preventistas
+--
+-- La política RLS mt_clientes_update permite UPDATE a cualquier rol de
+-- es_preventista() sobre TODAS las columnas. La UI (PR #359) acota el patch
+-- del preventista a datos de contacto/atención, pero por API directa un
+-- preventista podía modificar crédito, descuentos, zona, CUIT, etc.
+--
+-- Este trigger BEFORE UPDATE bloquea, solo para rol preventista /
+-- preventista_taco, los cambios en columnas gestionadas por admin/encargado.
+-- Se usa blacklist (no whitelist) a propósito: saldo_cuenta lo actualizan
+-- RPCs/triggers de pagos (actualizar_saldo_pedido) que corren bajo el
+-- auth.uid() del preventista y no deben romperse.
+--
+-- Aplicada en prod el 2026-06-10 vía MCP (apply_migration:
+-- clientes_guard_update_preventista).
+
+CREATE OR REPLACE FUNCTION public.clientes_guard_update_preventista()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $$
+DECLARE
+  v_rol text;
+  -- Columnas que un preventista NO puede modificar
+  v_bloqueadas text[] := ARRAY[
+    'id','created_at','cuit','tipo_documento','nombre_fantasia','zona','zona_id',
+    'limite_credito','dias_credito','descuento_porcentaje','preventista_id',
+    'activo','codigo','sucursal_id','tp_import_id'
+  ];
+  v_old jsonb := to_jsonb(OLD);
+  v_new jsonb := to_jsonb(NEW);
+  v_cambiadas text[];
+BEGIN
+  SELECT rol INTO v_rol FROM perfiles WHERE id = auth.uid();
+
+  -- Sin perfil (service role, SQL editor) u otros roles: sin restricción
+  IF v_rol IS NULL OR v_rol NOT IN ('preventista', 'preventista_taco') THEN
+    RETURN NEW;
+  END IF;
+
+  SELECT array_agg(col) INTO v_cambiadas
+  FROM unnest(v_bloqueadas) AS col
+  WHERE (v_old -> col) IS DISTINCT FROM (v_new -> col);
+
+  IF v_cambiadas IS NOT NULL THEN
+    RAISE EXCEPTION 'Un preventista no puede modificar estas columnas de clientes: %',
+      array_to_string(v_cambiadas, ', ')
+      USING ERRCODE = '42501';
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS clientes_guard_update_preventista ON public.clientes;
+CREATE TRIGGER clientes_guard_update_preventista
+  BEFORE UPDATE ON public.clientes
+  FOR EACH ROW
+  EXECUTE FUNCTION public.clientes_guard_update_preventista();

--- a/vite.config.js
+++ b/vite.config.js
@@ -265,6 +265,10 @@ export default defineConfig({
     environment: 'jsdom',
     setupFiles: './src/test/setup.js',
     include: ['src/**/*.{test,spec}.{js,jsx,ts,tsx}'],
+    // El default (5s) produce timeouts aleatorios en tests jsdom pesados
+    // cuando la máquina está cargada (p. ej. la suite completa en el hook
+    // de pre-commit): fallaba un test distinto en cada corrida.
+    testTimeout: 15000,
     coverage: {
       provider: 'v8',
       reporter: ['text', 'json', 'html', 'lcov'],


### PR DESCRIPTION
## Resumen

Refuerzo a nivel base de datos de la restricción de campos del PR #359.

La política RLS `mt_clientes_update` permite a cualquier rol de `es_preventista()` hacer UPDATE de **todas** las columnas de `clientes`; la limitación de campos para preventistas era solo de UI. Esta migración agrega un trigger `BEFORE UPDATE` que, solo para los roles `preventista` y `preventista_taco`, rechaza (error 42501) cambios en:

`cuit, tipo_documento, nombre_fantasia, zona, zona_id, limite_credito, dias_credito, descuento_porcentaje, preventista_id, activo, codigo, sucursal_id, tp_import_id` (más `id` y `created_at`).

Se usa blacklist (y no whitelist) a propósito: `saldo_cuenta` lo actualizan RPCs/triggers de pagos (`actualizar_saldo_pedido`) que corren bajo el `auth.uid()` del preventista y no deben romperse. Admin, encargado, transportista y service role quedan sin restricción.

También sube `testTimeout` de vitest a 15s: el default de 5s producía timeouts aleatorios (un test distinto en cada corrida) al ejecutar la suite completa en el hook de pre-commit con la máquina cargada.

## Estado en producción

⚠️ **La migración ya está aplicada en prod** (vía MCP `apply_migration`, 2026-06-10). El archivo en `migrations/` documenta lo aplicado.

Verificación en vivo (transacción con rollback, simulando JWT de cada rol):
- ✅ Preventista puede actualizar `telefono`
- ✅ Preventista bloqueado al actualizar `limite_credito` (42501)
- ✅ Preventista bloqueado al actualizar `descuento_porcentaje` (42501)
- ✅ Admin sin restricción

## Test plan
- [x] Tests en vivo descritos arriba
- [x] Suite completa de unit tests (688) pasó en el pre-commit hook
- [ ] Manual: como preventista, editar un cliente desde la app y guardar (debe funcionar con los campos permitidos)
- [ ] Manual: como preventista, registrar un pago a un cliente (el saldo debe actualizarse sin error)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
