### PR TITLE
fix(test): acotar maxWorkers de vitest para evitar timeouts en maquinas con muchos cores

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -2,9 +2,13 @@ import { defineConfig, loadEnv } from 'vite'
 import react from '@vitejs/plugin-react'
 import { VitePWA } from 'vite-plugin-pwa'
 import path from 'path'
+import os from 'os'
+import process from 'node:process'
 import { fileURLToPath } from 'url'
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
+
+const cpuCount = os.availableParallelism?.() ?? os.cpus().length
 
 function cspConnectSrcPlugin() {
   let resolvedEnv = {}
@@ -269,6 +273,10 @@ export default defineConfig({
     // cuando la máquina está cargada (p. ej. la suite completa en el hook
     // de pre-commit): fallaba un test distinto en cada corrida.
     testTimeout: 15000,
+    // Sin tope, vitest levanta un fork jsdom por core lógico; en máquinas
+    // con muchos cores (20+) se autosaturan y vuelven los timeouts.
+    maxWorkers: Number(process.env.VITEST_MAX_WORKERS)
+      || Math.min(6, Math.max(2, Math.floor(cpuCount / 2))),
     coverage: {
       provider: 'v8',
       reporter: ['text', 'json', 'html', 'lcov'],


### PR DESCRIPTION
## Qué cambia

Agrega `maxWorkers` acotado a la sección `test` de `vite.config.js`:

```js
maxWorkers: Number(process.env.VITEST_MAX_WORKERS)
  || Math.min(6, Math.max(2, Math.floor(cpuCount / 2)))
```

con `cpuCount = os.availableParallelism()`. `VITEST_MAX_WORKERS` sigue funcionando como override explícito.

## Por qué

Sin tope, vitest 4 levanta un fork jsdom por core lógico. En máquinas con muchos cores (22 lógicos) los ~22 forks se autosaturan y fallan 6-10 tests al azar con `Test timed out in 5000ms`; la suite tardaba ~100-115 s y rompía el hook de pre-commit (`npm run test:run`). Acotado a 6 workers, la misma suite pasa completa en ~14-18 s.

En máquinas más chicas la fórmula escala a la mitad de los cores con piso de 2 (8 cores → 4, 4 cores → 2), así que no penaliza hardware modesto.

## Verificación

- 3 corridas consecutivas de `npm run test:run`: 45 archivos / 688 tests verdes en 16.0 s, 17.1 s y 17.7 s (antes: ~100-115 s con fallos aleatorios).
- 1 corrida con `VITEST_MAX_WORKERS=4` para confirmar que el override por entorno sigue vigente: verde en 19.3 s.
- El propio hook de pre-commit corrió la suite completa al commitear este cambio: verde en 14.1 s sin setear ninguna variable.

## Notas para review

- El `import process from 'node:process'` es porque el ESLint del repo no define globals de Node en `vite.config.js` (`no-undef` sobre `process`).
- `testTimeout: 15000` ya estaba en la rama; este PR solo suma el tope de workers (la causa raíz de los timeouts era la oversuscripción, el timeout más alto es red de seguridad).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
