### PR TITLE
fix(deploy): forzar provider node en nixpacks - Coolify detectaba el repo como Deno

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,10 @@
 # Dependencies
 node_modules/
 
+# deno.lock en la raiz (generado al correr deno desde la raiz) hace que
+# nixpacks detecte el repo como Deno y rompa el build de Coolify
+/deno.lock
+
 # Environment variables (NUNCA commitear con valores reales)
 .env
 .env.local

--- a/nixpacks.toml
+++ b/nixpacks.toml
@@ -1,0 +1,7 @@
+# Fuerza el provider Node en Nixpacks (Coolify).
+#
+# El repo contiene edge functions de Deno (supabase/functions/deno.json,
+# deno.lock y archivos .ts con imports de deno.land). Sin esto, nixpacks
+# autodetecta el proyecto como Deno, no instala Node y el build de Coolify
+# falla con "npm: command not found".
+providers = ["node"]

--- a/supabase/functions/tests/optimizar_ruta.test.ts
+++ b/supabase/functions/tests/optimizar_ruta.test.ts
@@ -1,5 +1,8 @@
 // Tests de la lógica pura de tramos de optimizar-ruta (sin red).
-import { assertEquals } from "https://deno.land/std@0.224.0/assert/mod.ts";
+// Import vía el alias std/ del deno.json (NO usar la URL literal de
+// deno.land: nixpacks la detecta y clasifica el repo entero como Deno,
+// rompiendo el build de Coolify).
+import { assertEquals } from "std/assert/mod.ts";
 import {
   type GoogleRoute,
   MAX_INTERMEDIOS,


### PR DESCRIPTION
## Resumen

El deploy de Coolify falla desde el merge de #363 con `npm: command not found`. Causa: al agregar la edge function `optimizar-ruta` entraron al repo `supabase/functions/deno.lock` y un test con un import literal de `https://deno.land/...`, y **nixpacks autodetectó el proyecto como Deno** (instala solo deno, sin Node — se ve en el log de Coolify: `NIXPACKS_METADATA: deno`).

- `nixpacks.toml` con `providers = ["node"]` → fix definitivo, la detección ya no depende del contenido del repo.
- El test de Deno importa vía el alias `std/` del deno.json en vez de la URL literal.
- `/deno.lock` raíz agregado a .gitignore (se genera al correr deno localmente).

## Test plan
- [x] Tests de Deno pasan con el import por alias (4/4)
- [x] Suite frontend completa (688) en el pre-commit
- [ ] Tras el merge: verificar que el deployment de Coolify termine en verde y que la app muestre el filtro de fecha en Gestión de Rutas

🤖 Generated with [Claude Code](https://claude.com/claude-code)
