### PR TITLE
Bonificaciones separadas en hoja de ruta, franjas de horario, horario de entrega y links a Google Maps

### DIFF
--- a/migrations/081_clientes_horario_entrega.sql
+++ b/migrations/081_clientes_horario_entrega.sql
@@ -1,0 +1,10 @@
+-- Migración 081: horario de entrega preferido del cliente
+--
+-- Franja horaria en la que el cliente pide recibir el pedido. La completan
+-- preventistas/admin en la ficha del cliente y se imprime en la hoja de ruta.
+-- Editable por preventistas: NO se agrega al blacklist del trigger
+-- clientes_guard_update_preventista (mig 080).
+--
+-- Aplicada en prod el 2026-06-11 vía MCP (apply_migration: clientes_horario_entrega).
+
+ALTER TABLE public.clientes ADD COLUMN IF NOT EXISTS horario_entrega text;

--- a/src/components/containers/ClientesContainer.tsx
+++ b/src/components/containers/ClientesContainer.tsx
@@ -243,6 +243,7 @@ export default function ClientesContainer(): React.ReactElement {
         telefono: data.telefono || undefined,
         contacto: data.contacto || undefined,
         horarios_atencion: data.horarios_atencion || undefined,
+        horario_entrega: data.horario_entrega || undefined,
         rubro: data.rubro || undefined,
         notas: data.notas || undefined,
       }
@@ -279,6 +280,7 @@ export default function ClientesContainer(): React.ReactElement {
       descuento_porcentaje: data.descuentoPorcentaje,
       contacto: data.contacto || undefined,
       horarios_atencion: data.horarios_atencion || undefined,
+      horario_entrega: data.horario_entrega || undefined,
       rubro: data.rubro || undefined,
       notas: data.notas || undefined,
       ...(ids !== undefined ? { preventista_id: ids[0] ?? null, preventista_ids: ids } : {}),

--- a/src/components/modals/ModalCliente.tsx
+++ b/src/components/modals/ModalCliente.tsx
@@ -36,6 +36,8 @@ export interface ClienteFormData {
   /** FK a tabla zonas. Cadena vacía representa "sin zona". */
   zona_id: string;
   horarios_atencion: string;
+  /** Franja en la que el cliente pide recibir el pedido (hoja de ruta) */
+  horario_entrega: string;
   rubro: string;
   notas: string;
   limiteCredito: number;
@@ -82,6 +84,25 @@ export interface ModalClienteProps {
 }
 
 // Las zonas ahora vienen de la tabla `zonas` via useZonasEstandarizadasQuery
+
+// Franjas horarias seleccionables para "Horarios de Atención" (multi-select:
+// hay clientes que abren fraccionado mañana y tarde). Se persisten unidas
+// con " y " en el campo de texto existente (clientes.horarios_atencion).
+const FRANJAS_ATENCION = [
+  'Mañana (08 a 13)',
+  'Mediodía (12 a 16)',
+  'Tarde (16 a 20)',
+  'Noche (20 a 00)',
+];
+const SEPARADOR_FRANJAS = ' y ';
+
+// Opciones para "Horario de entrega" (franja en la que el cliente pide
+// recibir el pedido; se imprime en la hoja de ruta del transportista).
+const FRANJAS_ENTREGA = [
+  'Mañana (08 a 13)',
+  'Mediodía (12 a 16)',
+  'Tarde (16 a 20)',
+];
 
 // Opciones predefinidas de rubros
 const RUBROS_OPCIONES = [
@@ -136,6 +157,7 @@ const ModalCliente = memo(function ModalCliente({ cliente, onSave, onClose, guar
     zona: cliente.zona || '',
     zona_id: cliente.zona_id ? String(cliente.zona_id) : '',
     horarios_atencion: cliente.horarios_atencion || '',
+    horario_entrega: cliente.horario_entrega || '',
     rubro: cliente.rubro || '',
     notas: cliente.notas || '',
     limiteCredito: cliente.limite_credito || 0,
@@ -161,6 +183,7 @@ const ModalCliente = memo(function ModalCliente({ cliente, onSave, onClose, guar
     zona: '',
     zona_id: '',
     horarios_atencion: '',
+    horario_entrega: '',
     rubro: '',
     notas: '',
     limiteCredito: 0,
@@ -660,19 +683,79 @@ const ModalCliente = memo(function ModalCliente({ cliente, onSave, onClose, guar
           </div>
         )}
 
-        {/* Horarios de Atención */}
+        {/* Horarios de Atención: franjas seleccionables (multi) */}
         <div>
           <label className="block text-sm font-medium mb-1 dark:text-gray-200 flex items-center gap-1">
             <Clock className="w-4 h-4" />
             Horarios de Atención
           </label>
-          <input
-            type="text"
-            value={form.horarios_atencion}
-            onChange={e => handleFieldChange('horarios_atencion', e.target.value)}
+          <p className="text-xs text-gray-500 dark:text-gray-400 mb-2">
+            Podés marcar más de una franja (ej: abre a la mañana y a la tarde).
+          </p>
+          <div className="flex flex-wrap gap-2">
+            {FRANJAS_ATENCION.map(franja => {
+              const seleccionadas = form.horarios_atencion
+                ? form.horarios_atencion.split(SEPARADOR_FRANJAS)
+                : [];
+              const activa = seleccionadas.includes(franja);
+              return (
+                <button
+                  key={franja}
+                  type="button"
+                  onClick={() => {
+                    const nuevas = activa
+                      ? seleccionadas.filter(f => f !== franja)
+                      : [...seleccionadas.filter(f => FRANJAS_ATENCION.includes(f)), franja];
+                    // Mantener el orden canónico de las franjas
+                    const ordenadas = FRANJAS_ATENCION.filter(f => nuevas.includes(f));
+                    handleFieldChange('horarios_atencion', ordenadas.join(SEPARADOR_FRANJAS));
+                  }}
+                  className={`px-3 py-2 text-sm rounded-lg border transition-colors ${
+                    activa
+                      ? 'bg-blue-600 text-white border-blue-600'
+                      : 'bg-white dark:bg-gray-700 text-gray-700 dark:text-gray-200 border-gray-300 dark:border-gray-600 hover:bg-blue-50 dark:hover:bg-gray-600'
+                  }`}
+                >
+                  {franja}
+                </button>
+              );
+            })}
+          </div>
+          {/* Valor legacy de texto libre: si lo guardado no coincide con las
+              franjas, se muestra para que no se pierda al editar. */}
+          {form.horarios_atencion &&
+            form.horarios_atencion.split(SEPARADOR_FRANJAS).some(f => !FRANJAS_ATENCION.includes(f)) && (
+            <p className="text-xs text-amber-600 dark:text-amber-400 mt-2">
+              Valor actual: "{form.horarios_atencion}" — al elegir franjas se reemplaza.
+            </p>
+          )}
+        </div>
+
+        {/* Horario de entrega (franja en la que el cliente pide recibir el pedido) */}
+        <div>
+          <label className="block text-sm font-medium mb-1 dark:text-gray-200 flex items-center gap-1">
+            <Clock className="w-4 h-4" />
+            Horario de entrega
+            <span
+              className="inline-flex items-center justify-center w-4 h-4 rounded-full bg-gray-200 dark:bg-gray-600 text-gray-600 dark:text-gray-300 text-[10px] font-bold cursor-help"
+              title="Franja horaria en la que el cliente pide que se le entregue el pedido. El transportista la ve en la hoja de ruta."
+            >
+              ?
+            </span>
+          </label>
+          <select
+            value={form.horario_entrega}
+            onChange={e => handleFieldChange('horario_entrega', e.target.value)}
             className="w-full px-3 py-2 border rounded-lg dark:bg-gray-700 dark:border-gray-600 dark:text-white"
-            placeholder="Ej: Lunes a Viernes 9:00 a 18:00"
-          />
+          >
+            <option value="">Sin preferencia</option>
+            {FRANJAS_ENTREGA.map(franja => (
+              <option key={franja} value={franja}>{franja}</option>
+            ))}
+          </select>
+          <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
+            Franja en la que el cliente pide que se le entregue. Se imprime en la hoja de ruta.
+          </p>
         </div>
 
         {/* Notas */}

--- a/src/components/modals/ModalGestionRutas.tsx
+++ b/src/components/modals/ModalGestionRutas.tsx
@@ -266,6 +266,34 @@ const ModalGestionRutas = memo(function ModalGestionRutas({
     return pedidosTransportista.filter(p => !p.cliente?.latitud || !p.cliente?.longitud);
   }, [pedidosTransportista]);
 
+  // Links a Google Maps con la ruta armada. Maps acepta máximo 9 waypoints
+  // por link (+ origen + destino = 10 paradas nuevas por link), así que rutas
+  // largas se parten en varios links encadenados: el destino de un link es el
+  // origen del siguiente.
+  const linksGoogleMaps = useMemo((): Array<{ url: string; desde: number; hasta: number }> => {
+    const coords = pedidosOrdenados
+      .filter(p => p.cliente?.latitud != null && p.cliente?.longitud != null)
+      .map(p => `${p.cliente!.latitud},${p.cliente!.longitud}`);
+    if (coords.length === 0) return [];
+
+    const dep = getDepositoCoords();
+    const PARADAS_POR_LINK = 10; // 9 waypoints + destino
+    const links: Array<{ url: string; desde: number; hasta: number }> = [];
+    let origen = `${dep.lat},${dep.lng}`;
+
+    for (let i = 0; i < coords.length; i += PARADAS_POR_LINK) {
+      const grupo = coords.slice(i, i + PARADAS_POR_LINK);
+      const destino = grupo[grupo.length - 1];
+      const waypoints = grupo.slice(0, -1).join('|');
+      const url = `https://www.google.com/maps/dir/?api=1&origin=${encodeURIComponent(origen)}&destination=${encodeURIComponent(destino)}${
+        waypoints ? `&waypoints=${encodeURIComponent(waypoints)}` : ''
+      }&travelmode=driving`;
+      links.push({ url, desde: i + 1, hasta: i + grupo.length });
+      origen = destino;
+    }
+    return links;
+  }, [pedidosOrdenados]);
+
   // Calcular totales
   const totales = useMemo((): Totales => {
     const lista = vistaActiva === 'resultado' ? pedidosOrdenados : pedidosTransportista;
@@ -655,6 +683,39 @@ const ModalGestionRutas = memo(function ModalGestionRutas({
                   </div>
                 </div>
               </div>
+
+              {/* Navegación en Google Maps con las paradas ya cargadas */}
+              {linksGoogleMaps.length > 0 && (
+                <div className="bg-white border rounded-lg p-4">
+                  <h3 className="font-medium text-gray-700 mb-1 flex items-center gap-2">
+                    <Navigation className="w-5 h-5 text-blue-600" />
+                    Abrir ruta en Google Maps
+                  </h3>
+                  <p className="text-xs text-gray-500 mb-3">
+                    Sale del depósito con las paradas en el orden optimizado. Google Maps
+                    admite hasta 10 paradas por link
+                    {linksGoogleMaps.length > 1
+                      ? ': al terminar un tramo, abrí el siguiente (continúa desde la última parada).'
+                      : '.'}
+                  </p>
+                  <div className="flex flex-wrap gap-2">
+                    {linksGoogleMaps.map((link, i) => (
+                      <a
+                        key={link.url}
+                        href={link.url}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="inline-flex items-center gap-2 px-4 py-2 bg-blue-600 text-white text-sm rounded-lg hover:bg-blue-700"
+                      >
+                        <MapPin className="w-4 h-4" />
+                        {linksGoogleMaps.length === 1
+                          ? 'Abrir ruta completa'
+                          : `Tramo ${i + 1} (paradas ${link.desde}-${link.hasta})`}
+                      </a>
+                    ))}
+                  </div>
+                </div>
+              )}
 
               {/* Lista de entregas ordenadas */}
               <div>

--- a/src/components/pedidos/VistaRutaTransportista.tsx
+++ b/src/components/pedidos/VistaRutaTransportista.tsx
@@ -338,6 +338,35 @@ function VistaRutaTransportista({
     return pedidosOrdenados.find(p => p.estado === 'asignado') || null;
   }, [pedidosOrdenados]);
 
+  // Links a Google Maps con las entregas pendientes ya cargadas en orden.
+  // El primer tramo sale desde la ubicación actual del chofer (sin origin,
+  // Maps usa "Tu ubicación"). Maps acepta máximo 9 waypoints por link, así
+  // que rutas largas se parten en tramos encadenados de 10 paradas.
+  const linksRutaMaps = useMemo((): Array<{ url: string; desde: number; hasta: number }> => {
+    const coords = pedidosOrdenados
+      .filter(p => p.estado === 'asignado' && p.cliente?.latitud != null && p.cliente?.longitud != null)
+      .map(p => `${p.cliente!.latitud},${p.cliente!.longitud}`);
+    if (coords.length === 0) return [];
+
+    const PARADAS_POR_LINK = 10; // 9 waypoints + destino
+    const links: Array<{ url: string; desde: number; hasta: number }> = [];
+    let origen: string | null = null; // primer tramo: ubicación actual
+
+    for (let i = 0; i < coords.length; i += PARADAS_POR_LINK) {
+      const grupo = coords.slice(i, i + PARADAS_POR_LINK);
+      const destino = grupo[grupo.length - 1];
+      const waypoints = grupo.slice(0, -1).join('|');
+      const url = `https://www.google.com/maps/dir/?api=1${
+        origen ? `&origin=${encodeURIComponent(origen)}` : ''
+      }&destination=${encodeURIComponent(destino)}${
+        waypoints ? `&waypoints=${encodeURIComponent(waypoints)}` : ''
+      }&travelmode=driving`;
+      links.push({ url, desde: i + 1, hasta: i + grupo.length });
+      origen = destino;
+    }
+    return links;
+  }, [pedidosOrdenados]);
+
   const entregasPendientes = pedidosOrdenados.filter(p => p.estado === 'asignado').length;
   const entregasCompletadas = pedidosOrdenados.filter(p => p.estado === 'entregado').length;
   const totalACobrar = pedidosOrdenados.filter(p => p.estado === 'asignado').reduce((sum, p) => sum + (p.total || 0), 0);
@@ -491,6 +520,36 @@ function VistaRutaTransportista({
           />
         </div>
       </div>
+
+      {/* Ruta completa en Google Maps (paradas pendientes en orden) */}
+      {linksRutaMaps.length > 0 && (
+        <div className="bg-white dark:bg-gray-800 rounded-xl p-4 border dark:border-gray-700">
+          <h3 className="font-semibold text-gray-800 dark:text-white mb-1 flex items-center gap-2">
+            <MapPin className="w-5 h-5 text-blue-600" />
+            Ruta completa en Google Maps
+          </h3>
+          <p className="text-xs text-gray-500 dark:text-gray-400 mb-3">
+            Abre Maps con tus entregas pendientes ya cargadas en orden, saliendo desde donde estás.
+            {linksRutaMaps.length > 1 && ' Al terminar un tramo, abrí el siguiente.'}
+          </p>
+          <div className="flex flex-wrap gap-2">
+            {linksRutaMaps.map((link, i) => (
+              <a
+                key={link.url}
+                href={link.url}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex items-center gap-2 px-4 py-3 bg-blue-600 text-white text-sm font-medium rounded-lg hover:bg-blue-700 active:bg-blue-800 min-h-[44px]"
+              >
+                <Navigation className="w-4 h-4" />
+                {linksRutaMaps.length === 1
+                  ? 'Abrir ruta completa'
+                  : `Tramo ${i + 1} (paradas ${link.desde}-${link.hasta})`}
+              </a>
+            ))}
+          </div>
+        </div>
+      )}
 
       {/* Lista de entregas */}
       <div>

--- a/src/hooks/queries/useClientesQuery.ts
+++ b/src/hooks/queries/useClientesQuery.ts
@@ -159,6 +159,7 @@ interface ClienteCreateInput {
   descuento_porcentaje?: number
   contacto?: string
   horarios_atencion?: string
+  horario_entrega?: string
   rubro?: string
   notas?: string
   preventista_id?: string | null

--- a/src/hooks/queries/usePedidosQuery.ts
+++ b/src/hooks/queries/usePedidosQuery.ts
@@ -77,7 +77,7 @@ interface ActualizarPagoInput {
 // inferencia de PostgREST: un string sin literal-type degradaria el resultado
 // a GenericStringError. Mantener sincronizado con el tipo PedidoDB.
 const PEDIDO_PRODUCT_COLS = 'id, nombre, codigo, categoria, unidades_de_venta_por_fardo, etiqueta_bulto' as const
-const PEDIDO_CLIENT_COLS = 'id, nombre_fantasia, razon_social, cuit, direccion, aclaracion_direccion, telefono, contacto, latitud, longitud, horarios_atencion, zona' as const
+const PEDIDO_CLIENT_COLS = 'id, nombre_fantasia, razon_social, cuit, direccion, aclaracion_direccion, telefono, contacto, latitud, longitud, horarios_atencion, horario_entrega, zona' as const
 // pagos(forma_pago, monto): permite a la card derivar la forma de pago real
 // (incluido "Combinado") sin queries extra. Los pagos combinados se guardan
 // como N filas en `pagos` (una por forma_pago); pedidos.forma_pago es el

--- a/src/lib/pdf/hojaRutaOptimizada.js
+++ b/src/lib/pdf/hojaRutaOptimizada.js
@@ -153,6 +153,19 @@ function buildCardOps(doc, pedido, orderNumber) {
     })
   }
 
+  // Horario de entrega pedido por el cliente (destacado para el chofer)
+  if (pedido.cliente?.horario_entrega) {
+    doc.setFont('helvetica', 'bold')
+    doc.setFontSize(9)
+    const entLines = doc.splitTextToSize(
+      `ENTREGAR: ${pedido.cliente.horario_entrega}`,
+      CARD_CONTENT_WIDTH
+    )
+    entLines.slice(0, 2).forEach((line) => {
+      ops.push({ kind: 'text', text: line, fontSize: 9, bold: true, advance: 4 })
+    })
+  }
+
   // Total + estado
   ops.push({
     kind: 'text',
@@ -162,19 +175,18 @@ function buildCardOps(doc, pedido, orderNumber) {
     advance: 5
   })
 
-  // Productos
+  // Productos: las bonificaciones van en una lista aparte abajo de los items
+  // comprados, con la unidad bien aclarada (botellas/paquetes sueltos vs
+  // fardos) para que el chofer no mezcle unidades al cargar/descargar.
   doc.setFont('helvetica', 'normal')
   doc.setFontSize(9)
   const priceColWidth = 24
   const productWrapWidth = CARD_CONTENT_WIDTH - priceColWidth
-  ;(pedido.items || []).forEach((item) => {
-    // Para regalos de tipo Fracción, descripcion_regalo es el texto manual
-    // que el admin cargó (ej: "1 botella Manaos Naranja 600cc"). Cae al
-    // nombre del producto cuando no hay snapshot (regalos antiguos / unidad
-    // entera).
-    const nombre = (item.es_bonificacion && item.descripcion_regalo?.trim())
-      ? item.descripcion_regalo.trim()
-      : (item.producto?.nombre || 'Producto')
+  const itemsComprados = (pedido.items || []).filter((i) => !i.es_bonificacion)
+  const itemsBonificados = (pedido.items || []).filter((i) => i.es_bonificacion)
+
+  itemsComprados.forEach((item) => {
+    const nombre = item.producto?.nombre || 'Producto'
     const subtotal = (item.precio_unitario || 0) * item.cantidad
     const aclaracion = formatAclaracionBulto(
       item.cantidad,
@@ -195,6 +207,50 @@ function buildCardOps(doc, pedido, orderNumber) {
       })
     })
   })
+
+  if (itemsBonificados.length > 0) {
+    ops.push({ kind: 'spacer', advance: 0.5 })
+    ops.push({
+      kind: 'text',
+      text: 'PRODUCTOS BONIFICADOS:',
+      fontSize: 8.5,
+      bold: true,
+      advance: 4
+    })
+    itemsBonificados.forEach((item) => {
+      // Regalo de tipo Fracción: cantidad en subunidades (botellas/paquetes)
+      // y descripcion_regalo describe la subunidad (ej: "botella Manaos 600cc").
+      // Regalo de unidad entera: cantidad en unidades de venta del producto,
+      // con la aclaración de fardos si aplica.
+      const esFraccion = !!(item.promocion?.unidades_por_bloque
+        && item.promocion.unidades_por_bloque > 1
+        && item.descripcion_regalo?.trim())
+      let linea
+      if (esFraccion) {
+        linea = `${item.cantidad}x ${item.descripcion_regalo.trim()} (SUELTAS, NO FARDO)`
+      } else {
+        const nombre = item.descripcion_regalo?.trim() || item.producto?.nombre || 'Producto'
+        const aclaracion = formatAclaracionBulto(
+          item.cantidad,
+          item.producto?.unidades_de_venta_por_fardo,
+          item.producto?.etiqueta_bulto,
+        )
+        linea = aclaracion
+          ? `${item.cantidad}x ${nombre} ${aclaracion}`
+          : `${item.cantidad}x ${nombre}`
+      }
+      const itemLines = doc.splitTextToSize(linea, productWrapWidth)
+      itemLines.forEach((line, idx) => {
+        ops.push({
+          kind: 'product',
+          text: line,
+          subtotal: idx === 0 ? 'BONIF' : null,
+          fontSize: 9,
+          advance: 4
+        })
+      })
+    })
+  }
 
   // Total pedido
   ops.push({ kind: 'spacer', advance: 1 })
@@ -316,8 +372,15 @@ function buildCierreOps(pedidos) {
  * para que el chofer sepa que carga 1 fardo + N botellas individuales.
  */
 function buildManifiestoOps(pedidos) {
-  const totalesFardos = {} // por producto_id (fardos enteros)
-  const totalesBotellas = {} // por descripcion_regalo (botellas sueltas)
+  const totalesCompras = {} // por producto_id (items vendidos)
+  const totalesBonifFardos = {} // por producto_id (bonifs en unidades de venta / fardos)
+  const totalesBonifSueltas = {} // por descripcion_regalo (botellas/paquetes sueltos)
+
+  const acumular = (mapa, key, nombre, cantidad) => {
+    if (!mapa[key]) mapa[key] = { nombre, cantidad: 0 }
+    mapa[key].cantidad += cantidad
+    return mapa[key]
+  }
 
   pedidos.forEach((pedido) => {
     ;(pedido.items || []).forEach((item) => {
@@ -329,49 +392,65 @@ function buildManifiestoOps(pedidos) {
       const upb = item.promocion?.unidades_por_bloque
       const desc = item.descripcion_regalo?.trim()
 
-      // Caso A: regalo Fracción → split en fardos + botellas sueltas.
-      if (item.es_bonificacion && upb && upb > 1 && desc) {
-        const fardos = Math.floor(cantidad / upb)
-        const sueltas = cantidad % upb
-        if (fardos > 0) {
-          if (!totalesFardos[key]) totalesFardos[key] = { nombre: nombreProducto, cantidad: 0 }
-          totalesFardos[key].cantidad += fardos
-          // La cantidad acumulada para esta key ya no está en unidades de venta
-          // (mezcla fardos enteros pre-convertidos), así que no aplicar la
-          // aclaración (N FARDO) sobre el total consolidado para esta key.
-          totalesFardos[key].mixedFardo = true
+      // Compras → lista principal, con aclaración (N FARDOS) si aplica.
+      if (!item.es_bonificacion) {
+        const fila = acumular(totalesCompras, key, nombreProducto, cantidad)
+        if (fila.unidades_de_venta_por_fardo == null) {
+          fila.unidades_de_venta_por_fardo = item.producto?.unidades_de_venta_por_fardo ?? null
         }
-        if (sueltas > 0) {
-          const sueltasKey = `bonif:${desc}`
-          if (!totalesBotellas[sueltasKey]) totalesBotellas[sueltasKey] = { nombre: desc, cantidad: 0 }
-          totalesBotellas[sueltasKey].cantidad += sueltas
+        if (fila.etiqueta_bulto == null) {
+          fila.etiqueta_bulto = item.producto?.etiqueta_bulto ?? null
         }
         return
       }
 
-      // Caso B: items normales (compras o regalos de unidad entera) → suma directa.
-      if (!totalesFardos[key]) totalesFardos[key] = { nombre: nombreProducto, cantidad: 0 }
-      totalesFardos[key].cantidad += cantidad
-      // Capturar campos de fardo del producto para mostrar la aclaración
-      // (N FARDO) sobre la cantidad consolidada. Solo aplican a Caso B; si la
-      // entrada también recibió Caso A, mixedFardo bloquea la aclaración.
-      if (totalesFardos[key].unidades_de_venta_por_fardo == null) {
-        totalesFardos[key].unidades_de_venta_por_fardo =
-          item.producto?.unidades_de_venta_por_fardo ?? null
+      // Bonificación de tipo Fracción: cantidad en subunidades → split en
+      // fardos completos + botellas/paquetes sueltos.
+      if (upb && upb > 1 && desc) {
+        const fardos = Math.floor(cantidad / upb)
+        const sueltas = cantidad % upb
+        if (fardos > 0) {
+          // Pre-convertido a fardos: marcar para no re-aplicar la aclaración.
+          const fila = acumular(totalesBonifFardos, key, nombreProducto, fardos)
+          fila.preConvertidoAFardos = true
+        }
+        if (sueltas > 0) {
+          acumular(totalesBonifSueltas, `bonif:${desc}`, desc, sueltas)
+        }
+        return
       }
-      if (totalesFardos[key].etiqueta_bulto == null) {
-        totalesFardos[key].etiqueta_bulto = item.producto?.etiqueta_bulto ?? null
+
+      // Bonificación de unidad entera: en unidades de venta del producto.
+      const fila = acumular(totalesBonifFardos, key, nombreProducto, cantidad)
+      if (fila.unidades_de_venta_por_fardo == null) {
+        fila.unidades_de_venta_por_fardo = item.producto?.unidades_de_venta_por_fardo ?? null
+      }
+      if (fila.etiqueta_bulto == null) {
+        fila.etiqueta_bulto = item.producto?.etiqueta_bulto ?? null
       }
     })
   })
 
-  const filasFardos = Object.values(totalesFardos)
+  const ordenar = (mapa) => Object.values(mapa)
     .filter((t) => t.cantidad > 0)
     .sort((a, b) => a.nombre.localeCompare(b.nombre, 'es'))
 
-  const filasBotellas = Object.values(totalesBotellas)
-    .filter((t) => t.cantidad > 0)
-    .sort((a, b) => a.nombre.localeCompare(b.nombre, 'es'))
+  const filasCompras = ordenar(totalesCompras)
+  const filasBonifFardos = ordenar(totalesBonifFardos)
+  const filasBonifSueltas = ordenar(totalesBonifSueltas)
+
+  const lineaConAclaracion = (f) => {
+    // preConvertidoAFardos: la cantidad ya está en fardos, la etiqueta va directa.
+    if (f.preConvertidoAFardos) {
+      return `${f.nombre} (${f.cantidad === 1 ? 'FARDO COMPLETO' : 'FARDOS COMPLETOS'})`
+    }
+    const aclaracion = formatAclaracionBulto(
+      f.cantidad,
+      f.unidades_de_venta_por_fardo,
+      f.etiqueta_bulto,
+    )
+    return aclaracion ? `${f.nombre} ${aclaracion}` : f.nombre
+  }
 
   const ops = []
   ops.push({ kind: 'manifiesto-title', text: 'MANIFIESTO DE CARGA', advance: 5.5 })
@@ -380,33 +459,34 @@ function buildManifiestoOps(pedidos) {
     text: 'Total de productos a cargar en el vehiculo',
     advance: 5
   })
-  filasFardos.forEach((f) => {
-    const aclaracion = f.mixedFardo
-      ? null
-      : formatAclaracionBulto(
-          f.cantidad,
-          f.unidades_de_venta_por_fardo,
-          f.etiqueta_bulto,
-        )
+  filasCompras.forEach((f) => {
     ops.push({
       kind: 'manifiesto-line',
       cantidad: `${f.cantidad}x`,
-      nombre: aclaracion ? `${f.nombre} ${aclaracion}` : f.nombre,
+      nombre: lineaConAclaracion(f),
       advance: 4.5
     })
   })
-  if (filasBotellas.length > 0) {
+  if (filasBonifFardos.length > 0 || filasBonifSueltas.length > 0) {
     ops.push({ kind: 'spacer', advance: 1.5 })
     ops.push({
       kind: 'manifiesto-subtitle',
-      text: 'Bonificaciones sueltas (de fardo abierto)',
+      text: 'PRODUCTOS BONIFICADOS (cargar aparte)',
       advance: 4.5
     })
-    filasBotellas.forEach((f) => {
+    filasBonifFardos.forEach((f) => {
       ops.push({
         kind: 'manifiesto-line',
         cantidad: `${f.cantidad}x`,
-        nombre: f.nombre,
+        nombre: lineaConAclaracion(f),
+        advance: 4.5
+      })
+    })
+    filasBonifSueltas.forEach((f) => {
+      ops.push({
+        kind: 'manifiesto-line',
+        cantidad: `${f.cantidad}x`,
+        nombre: `${f.nombre} (SUELTAS, NO FARDO)`,
         advance: 4.5
       })
     })

--- a/src/types/hooks.ts
+++ b/src/types/hooks.ts
@@ -25,6 +25,8 @@ export interface ClienteDB {
   zona?: string | null;
   zona_id?: string | null;
   horarios_atencion?: string | null;
+  // Franja en la que el cliente pide recibir el pedido (se imprime en hoja de ruta)
+  horario_entrega?: string | null;
   rubro?: string | null;
   notas?: string | null;
   limite_credito?: number;
@@ -237,6 +239,7 @@ export interface ClienteFormInput {
   zona?: string;
   zona_id?: string | null;
   horarios_atencion?: string;
+  horario_entrega?: string;
   rubro?: string;
   notas?: string;
   limiteCredito?: string | number;


### PR DESCRIPTION
## Resumen

### 1. Bonificaciones separadas en la hoja de ruta y el manifiesto de carga
Reclamo del transportista: se mezclaban unidades (botellas vs fardos) en el manifiesto.

- **En cada pedido de la hoja de ruta**: los items bonificados ahora van en una lista aparte **"PRODUCTOS BONIFICADOS:"** abajo de los comprados, con la unidad bien aclarada:
  - Regalo fracción (botellas/paquetes sueltos): `6x botella Manaos 600cc (SUELTAS, NO FARDO)` — columna de precio dice `BONIF`.
  - Regalo de unidad entera: nombre + aclaración `(N FARDOS)` si aplica.
- **En el manifiesto de carga**: sección **"PRODUCTOS BONIFICADOS (cargar aparte)"** que separa todo lo bonificado del total vendido, distinguiendo fardos completos de sueltas.

### 2. Horarios de atención por franjas seleccionables
En la ficha del cliente, el texto libre se reemplaza por botones de franja **multi-select** (Mañana / Mediodía / Tarde / Noche) para clientes que abren fraccionado. Se persiste en el mismo campo `horarios_atencion` unido con " y " — los valores legacy de texto libre se muestran y se preservan hasta que se elijan franjas.

### 3. Nuevo campo "Horario de entrega"
- Desplegable (Mañana / Mediodía / Tarde) con tooltip: *"Franja horaria en la que el cliente pide que se le entregue el pedido"*.
- Migración **081** (`clientes.horario_entrega`, **ya aplicada en prod**). Editable por preventistas (no está en el blacklist del trigger 080).
- Se imprime **destacado en negrita** en la hoja de ruta: `ENTREGAR: Mañana (08 a 13)`.

### 4. Link a Google Maps con la ruta armada
En la vista de ruta optimizada del modal: botones que abren Google Maps **con todas las paradas ya cargadas** en el orden optimizado, saliendo del depósito. Google Maps admite máximo 9 waypoints por link, así que rutas largas se parten en tramos encadenados de 10 paradas (el destino de un tramo es el origen del siguiente).

## Test plan
- [x] `npm run typecheck` y `eslint` sin errores
- [x] Suite completa (688 tests) en el pre-commit hook
- [ ] Manual: exportar hoja de ruta de un pedido con bonificaciones mixtas (fracción + unidad entera) y verificar las dos secciones
- [ ] Manual: editar horarios de un cliente con franjas múltiples y verificar que se imprima bien en la hoja de ruta
- [ ] Manual: abrir un tramo de Google Maps desde la ruta optimizada en el celular

🤖 Generated with [Claude Code](https://claude.com/claude-code)
