### PR TITLE
Ruta Activa rediseño: deposito en DB, ruta real sobre calles y mapa profesional

### DIFF
--- a/docs/plans/2026-06-13-ruta-activa-rediseno-design.md
+++ b/docs/plans/2026-06-13-ruta-activa-rediseno-design.md
@@ -1,0 +1,98 @@
+# Plan: Rediseño "Ruta Activa" — depósito correcto, ruta real sobre calles, look profesional
+
+## Contexto
+
+La pantalla map-first del transportista (PR #367) salió funcional pero con problemas reales, vistos en producción:
+
+1. **Depósito mal ubicado (bug)**: `getDepositoCoords()` ([useOptimizarRuta.ts](src/hooks/useOptimizarRuta.ts)) lee de **localStorage (por dispositivo)**. El admin lo configura en su PC; el celular del transportista tiene localStorage vacío → cae al default (centro de Tucumán = la "D" del screenshot). La ruta se optimizó con un depósito y el mapa muestra otro. `sucursales` no tiene columnas de coordenadas.
+2. **"808.4 km" de distancia**: el GPS lee la ubicación del escritorio al testear (accuracy pésima). En celular real andaría, pero el dato basura no debe mostrarse.
+3. **Telaraña de líneas rectas**: `MapaRuta` dibuja una Polyline recta depósito→paradas→depósito. Google ya calcula la ruta real sobre las calles al optimizar (la pagamos), pero el FieldMask no la pide y se descarta.
+4. **Markers amontonados + tiles crudos**: sin jerarquía visual; tiles OSM crudos se ven artesanales.
+
+**Decisiones tomadas con el usuario (brainstorming):**
+- Mapa: **seguir con Leaflet** (costo $0) pero con tiles **CARTO Voyager** (limpios, retina) + ruta real sobre calles.
+- Navegación: **ruta real dentro de la app + handoff a Google Maps/Waze** para el manejo con voz (lo que hacen las apps de delivery; turn-by-turn propio se descarta por no ser realista en PWA).
+- Depósito: **a la base de datos por sucursal**, configurado desde el modal de optimización donde ya está.
+- Alcance: **solo experiencia del transportista** este PR (el camión en vivo para el admin es otro PR). El mapa del admin en Recorridos igual se beneficia de la ruta real y el depósito correcto.
+
+Stack ya presente: Leaflet + react-leaflet + vaul, edge function `optimizar-ruta` (parte en tramos ≤23 con `optimizeWaypointOrder`), RPC `aplicar_orden_ruta` (mig 081), tabla `recorridos`/`recorrido_pedidos`, TanStack Query. Gate `es_encargado_o_admin()` y `current_sucursal_id()` confirmados en prod.
+
+---
+
+## Implementación
+
+### A. Depósito en DB por sucursal (cierra bug #1)
+
+**Migración `082_sucursales_deposito_coords.sql`** (aplicar a prod vía MCP + versionar, patrón mig 081):
+- `ALTER TABLE sucursales ADD COLUMN deposito_lat double precision, ADD COLUMN deposito_lng double precision;`
+- Seed solo Tucumán (id=1, el default coincide geográficamente): `UPDATE ... WHERE id=1 AND deposito_lat IS NULL`. Las otras quedan NULL → fallback al default hasta configurarlas.
+- RPC `get_deposito_sucursal()` (lee de `current_sucursal_id()`, SECURITY DEFINER, GRANT authenticated — el transportista necesita leer).
+- RPC `set_deposito_sucursal(p_lat, p_lng)` con gate `es_encargado_o_admin()` (42501), escribe en la sucursal actual.
+
+**`src/hooks/queries/useDepositoQuery.ts`** (nuevo): `useDepositoCoords()` (useQuery sobre `get_deposito_sucursal`, `placeholderData: DEPOSITO_DEFAULT` → **siempre devuelve `{lat,lng}` usable**, sin async en el render) + `useSetDepositoMutation()`. queryKey incluye `currentSucursalId`.
+
+**Migrar los call sites de `getDepositoCoords()`** a `useDepositoCoords()`: [RutaActivaTransportista.tsx](src/components/rutaActiva/RutaActivaTransportista.tsx), [VistaRecorridos.tsx](src/components/vistas/VistaRecorridos.tsx) (dentro de `RecorridoCard`), [ModalGestionRutas.tsx](src/components/modals/ModalGestionRutas.tsx) (carga + guardar con la mutation), `ModalOptimizarRuta.tsx`, `ModalOptimizarRutaPreventista.tsx`. `getDepositoCoords`/`DEPOSITO_DEFAULT` quedan como fallback puro `@deprecated` (sin escribir localStorage).
+
+**`optimizarRuta` deja de leer el depósito internamente**: pasa a recibirlo por parámetro; el caller ([PedidosContainer.tsx](src/components/containers/PedidosContainer.tsx)) lo lee de `useDepositoCoords()` y lo pasa. Así el lado que optimiza y el que dibuja usan la **misma** fuente (DB) — raíz del bug eliminada.
+
+### B. Ruta real sobre las calles (cierra #3)
+
+**Edge function** [optimizar-ruta](supabase/functions/optimizar-ruta/index.ts):
+- FieldMask: agregar `routes.polyline.encodedPolyline`; body explícito `polylineEncoding: "ENCODED_POLYLINE"`.
+- `tramos.ts`: agregar `polyline?.encodedPolyline` a `GoogleRoute`; `unirTramos` recolecta `polylines: string[]` (una por tramo, en orden).
+- Respuesta JSON suma `polylines: [...]`.
+
+**Migración `083_recorridos_polyline.sql`**: `ALTER TABLE recorridos ADD COLUMN polylines jsonb;` + **DROP** de la firma vieja de `aplicar_orden_ruta(uuid,jsonb,numeric,integer)` y CREATE con `p_polylines jsonb DEFAULT NULL` (evita overload ambiguo en PostgREST); el INSERT guarda las polylines.
+
+**Front**:
+- `src/utils/polyline.ts` (nuevo): `decodePolyline` (algoritmo Google precisión 1e5, ~30 líneas, sin dependencia) + `decodePolylines(string[])` que decodifica y concatena tramos. Devuelve `[lat,lng][]` (formato directo de Leaflet). Test unitario contra un encoded conocido.
+- [useOptimizarRuta.ts](src/hooks/useOptimizarRuta.ts): `polylines?: string[]` en `RutaOptimizadaResponse` (el campo `polyline?` viejo sin uso se reemplaza).
+- [PedidosContainer.tsx](src/components/containers/PedidosContainer.tsx) `aplicarOrden`: pasa `p_polylines: rutaOptimizada.polylines ?? null`.
+- `src/hooks/queries/useRecorridoActivoQuery.ts` (nuevo): recorrido `en_curso` de hoy del transportista (`.maybeSingle()`), trae `polylines`.
+- [MapaRuta.tsx](src/components/MapaRuta.tsx): prop `rutaReal?: [number,number][]`; si viene, Polyline **sólida** sobre calles; si no, fallback a la recta punteada actual (degradado elegante para recorridos viejos / sin polyline).
+- [RutaActivaTransportista.tsx](src/components/rutaActiva/RutaActivaTransportista.tsx): consume `useRecorridoActivoQuery` → decode → `rutaReal`.
+- [useRecorridos.ts](src/hooks/supabase/useRecorridos.ts) + [VistaRecorridos.tsx](src/components/vistas/VistaRecorridos.tsx): `polylines` en el select y `rutaReal` al mapa del admin. `RecorridoDBExtended` suma `polylines`.
+
+Las paradas y el flujo de entrega siguen leyendo `pedidos.orden_entrega`; el recorrido se usa **solo** para la polyline → si la query falla, el flujo no se rompe.
+
+### C. Tiles CARTO + jerarquía de markers (cierra #4 visual)
+
+- [MapaRuta.tsx](src/components/MapaRuta.tsx) TileLayer → CARTO Voyager (`https://{s}.basemaps.cartocdn.com/rastertiles/voyager/{z}/{x}/{y}{r}.png`, `subdomains="abcd"`, atribución "© OpenStreetMap contributors © CARTO", `{r}` retina).
+- **CSP (bloqueante)**: [index.html](index.html) `img-src` suma `https://*.basemaps.cartocdn.com` (sin esto el mapa queda gris, sin error visible).
+- Jerarquía de markers (sin clustering — en una ruta querés ver todas las paradas): activa 40px destacada con anillo pulsante; pendientes 28px; **completadas 20px verdes atenuadas (opacity ~0.6)** para ceder protagonismo. La ruta real guía el ojo entre paradas céntricas juntas.
+
+### D. Gating de GPS + pulido del sheet (cierra #2 y experiencia)
+
+- [RutaActivaTransportista.tsx](src/components/rutaActiva/RutaActivaTransportista.tsx): `gpsConfiable = accuracy <= 1000m`; `distanciaMetros = null` si no confiable o si la distancia a la parada > 50km (fuera de zona). `llegaste` solo con GPS confiable. `posicion` al mapa solo si confiable (no plantar el punto azul en medio del país). Reusa `haversineMeters`/`formatDistancia` ([geo.ts](src/utils/geo.ts)) y `useWatchPosition`.
+- [SheetParada.tsx](src/components/rutaActiva/SheetParada.tsx): con GPS impreciso, microcopy honesto ("Ubicación imprecisa") en vez de distancia falsa; Entregar disponible pero secundario (Navegar es el CTA dominante). Al entrar en "Llegaste" auto-subir el sheet a snap medio. Skeleton de la parada activa mientras carga. No tocar `useEntregaParada` (lógica de entrega/cobro/salvedad intacta).
+
+---
+
+## Secuencia de build (cada paso compila y se verifica aislado)
+
+1. Migración 082 + RPCs → verificar en vivo: `get_deposito_sucursal()` devuelve coords (admin), `set_deposito_sucursal` bloquea transportista (42501).
+2. `useDepositoQuery` + migrar los 5 call sites → la "D" coincide en admin y transportista; el modal persiste a DB. **Bug #1 cerrado.**
+3. `utils/polyline.ts` + test de decode.
+4. Edge function FieldMask + `polylines` → deploy; la respuesta trae `polylines`.
+5. Migración 083 + `aplicar_orden_ruta` con `p_polylines` + wire en `aplicarOrden` → aplicar orden guarda polylines.
+6. MapaRuta `rutaReal` + tiles CARTO + jerarquía markers + **CSP (paso bloqueante junto a este)**.
+7. `useRecorridoActivoQuery` + wire en RutaActivaTransportista → transportista ve ruta real; sin recorrido, fallback recto.
+8. VistaRecorridos: polylines en select + rutaReal en mapa admin.
+9. Gating GPS + pulido SheetParada.
+
+## Riesgos / gotchas
+
+- **CSP**: agregar `*.basemaps.cartocdn.com` a `img-src` o el mapa queda gris sin error.
+- **Overload de `aplicar_orden_ruta`**: DROP de la firma de 4 args antes del CREATE de 5; el front siempre manda los 5 (con `null`).
+- **Tipo polylines = jsonb** (no `text[]`): serialización transparente con supabase-js.
+- **Costo Google**: pedir `routes.polyline` no sube el SKU (ya estamos en TRAFFIC_AWARE); verificar en Cloud console post-deploy.
+- **Recorridos viejos / sin polyline**: `polylines=NULL` → fallback recto; `.maybeSingle()` y manejar null.
+- **Cache depósito**: la mutation invalida `depositoKeys`; el switch de sucursal ya invalida global.
+
+## Verificación end-to-end
+
+1. `npm run typecheck`, lint, suite completa (pre-commit), build, deno test de la edge function.
+2. RPCs probadas en vivo con transacción+rollback (patrón mig 080/081).
+3. Manual: admin configura depósito → optimiza → aplica orden (guarda polylines) → la "D" y la ruta real coinciden en el mapa del transportista y en Recorridos; en desktop no aparece "808 km" (estado neutro); en móvil/simulación el geofence anda.
+4. Guardar el diseño en `docs/plans/2026-06-13-ruta-activa-rediseno-design.md` (primer commit del PR).
+5. PR a main con los pasos manuales en el body (configurar depósitos de las sucursales 2 y 4, que quedan NULL).

--- a/index.html
+++ b/index.html
@@ -10,7 +10,7 @@
 
     <!-- Content Security Policy - Fortalecido -->
     <!-- NOTE: 'unsafe-inline' in style-src is required by Vite/TailwindCSS injected styles -->
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' https://maps.googleapis.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https://maps.gstatic.com https://maps.googleapis.com https://*.tile.openstreetmap.org; connect-src 'self' https://*.supabase.co https://*.supabase.in wss://*.supabase.co https://maps.googleapis.com https://*.sentry.io; frame-ancestors 'none'; base-uri 'self'; form-action 'self';">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' https://maps.googleapis.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https://maps.gstatic.com https://maps.googleapis.com https://*.tile.openstreetmap.org https://*.basemaps.cartocdn.com; connect-src 'self' https://*.supabase.co https://*.supabase.in wss://*.supabase.co https://maps.googleapis.com https://*.sentry.io; frame-ancestors 'none'; base-uri 'self'; form-action 'self';">
 
     <!-- PWA Meta Tags -->
     <meta name="theme-color" content="#2563eb" />

--- a/migrations/082_sucursales_deposito_coords.sql
+++ b/migrations/082_sucursales_deposito_coords.sql
@@ -1,0 +1,60 @@
+-- Migración 082: ubicación del depósito por sucursal
+--
+-- Hasta ahora el depósito de optimización de rutas vivía en localStorage
+-- (por dispositivo): el admin lo configuraba en su PC y el celular del
+-- transportista, con localStorage vacío, caía al default → el mapa mostraba
+-- la "D" en otro lado que el usado al optimizar. Esto lo persiste por sucursal.
+--
+-- Aplicada en prod el 2026-06-13 vía MCP (apply_migration:
+-- sucursales_deposito_coords) y verificada en vivo con rollback: admin lee y
+-- escribe, transportista lee pero no escribe (42501).
+
+ALTER TABLE public.sucursales
+  ADD COLUMN IF NOT EXISTS deposito_lat numeric,
+  ADD COLUMN IF NOT EXISTS deposito_lng numeric;
+
+-- Seed solo Tucumán (id=1): el default -26.8241,-65.2226 es San Miguel de
+-- Tucumán, geográficamente válido solo para esa sucursal. Las otras quedan
+-- NULL → el front cae al default hasta que el admin las configure.
+UPDATE public.sucursales
+SET deposito_lat = -26.8241, deposito_lng = -65.2226
+WHERE id = 1 AND deposito_lat IS NULL;
+
+-- Lectura: cualquier usuario autenticado de la sucursal (el transportista la
+-- necesita para dibujar el mapa).
+CREATE OR REPLACE FUNCTION public.get_deposito_sucursal()
+RETURNS TABLE(lat numeric, lng numeric)
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $$
+  SELECT deposito_lat, deposito_lng
+  FROM sucursales
+  WHERE id = current_sucursal_id();
+$$;
+
+-- Escritura: solo encargado/admin, sobre la sucursal actual.
+CREATE OR REPLACE FUNCTION public.set_deposito_sucursal(p_lat numeric, p_lng numeric)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $$
+DECLARE
+  v_sucursal BIGINT := current_sucursal_id();
+BEGIN
+  IF NOT es_encargado_o_admin() THEN
+    RAISE EXCEPTION 'No autorizado para configurar el depósito' USING ERRCODE = '42501';
+  END IF;
+  IF v_sucursal IS NULL THEN
+    RAISE EXCEPTION 'Sucursal no resuelta para el usuario actual';
+  END IF;
+  UPDATE sucursales SET deposito_lat = p_lat, deposito_lng = p_lng WHERE id = v_sucursal;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.get_deposito_sucursal() FROM anon;
+GRANT EXECUTE ON FUNCTION public.get_deposito_sucursal() TO authenticated;
+REVOKE ALL ON FUNCTION public.set_deposito_sucursal(numeric, numeric) FROM anon;
+GRANT EXECUTE ON FUNCTION public.set_deposito_sucursal(numeric, numeric) TO authenticated;

--- a/migrations/083_recorridos_polylines.sql
+++ b/migrations/083_recorridos_polylines.sql
@@ -1,0 +1,89 @@
+-- Migración 083: guardar la ruta real (polylines de Google) en el recorrido
+--
+-- La edge function optimizar-ruta ahora devuelve `polylines` (encoded, una por
+-- tramo) con la geometría real sobre las calles. Se persisten en el recorrido
+-- al aplicar el orden, para que el mapa del transportista y del admin dibujen
+-- la ruta real en vez de líneas rectas.
+--
+-- Aplicada en prod el 2026-06-13 vía MCP (apply_migration: recorridos_polylines)
+-- y verificada en vivo con rollback: guarda las polylines y sigue andando sin
+-- ellas (compat).
+
+ALTER TABLE public.recorridos ADD COLUMN IF NOT EXISTS polylines jsonb;
+
+-- Reemplaza aplicar_orden_ruta (mig 081) agregando p_polylines. Se DROPea la
+-- firma de 4 args para no dejar dos overloads (PostgREST ambiguaría).
+DROP FUNCTION IF EXISTS public.aplicar_orden_ruta(uuid, jsonb, numeric, integer);
+
+CREATE OR REPLACE FUNCTION public.aplicar_orden_ruta(
+  p_transportista_id uuid,
+  p_pedidos jsonb,            -- [{ "pedido_id": 123, "orden_entrega": 1 }, ...]
+  p_distancia numeric DEFAULT NULL,
+  p_duracion integer DEFAULT NULL,
+  p_polylines jsonb DEFAULT NULL  -- array de encoded polylines (una por tramo)
+) RETURNS bigint
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $$
+DECLARE
+  v_sucursal BIGINT := current_sucursal_id();
+  v_item jsonb;
+  v_recorrido_id BIGINT;
+  v_total_facturado DECIMAL := 0;
+BEGIN
+  IF NOT es_encargado_o_admin() THEN
+    RAISE EXCEPTION 'No autorizado para aplicar orden de ruta' USING ERRCODE = '42501';
+  END IF;
+
+  IF v_sucursal IS NULL THEN
+    RAISE EXCEPTION 'Sucursal no resuelta para el usuario actual';
+  END IF;
+
+  IF p_pedidos IS NULL OR jsonb_array_length(p_pedidos) = 0 THEN
+    RAISE EXCEPTION 'No hay pedidos para aplicar orden';
+  END IF;
+
+  -- 1. Actualizar orden de entrega en pedidos
+  FOR v_item IN SELECT * FROM jsonb_array_elements(p_pedidos) LOOP
+    UPDATE pedidos
+    SET orden_entrega = (v_item->>'orden_entrega')::INTEGER
+    WHERE id = (v_item->>'pedido_id')::BIGINT
+      AND sucursal_id = v_sucursal;
+  END LOOP;
+
+  -- 2. Cancelar el recorrido vigente del día (si lo hay)
+  UPDATE recorridos
+  SET estado = 'cancelado'
+  WHERE transportista_id = p_transportista_id
+    AND fecha = CURRENT_DATE
+    AND estado = 'en_curso'
+    AND sucursal_id = v_sucursal;
+
+  -- 3. Crear el recorrido nuevo
+  SELECT COALESCE(SUM(total), 0) INTO v_total_facturado
+  FROM pedidos
+  WHERE id IN (SELECT (value->>'pedido_id')::BIGINT FROM jsonb_array_elements(p_pedidos))
+    AND sucursal_id = v_sucursal;
+
+  INSERT INTO recorridos
+    (transportista_id, fecha, distancia_total, duracion_total, total_pedidos,
+     total_facturado, estado, sucursal_id, polylines)
+  VALUES
+    (p_transportista_id, CURRENT_DATE, p_distancia, p_duracion,
+     jsonb_array_length(p_pedidos), v_total_facturado, 'en_curso', v_sucursal, p_polylines)
+  RETURNING id INTO v_recorrido_id;
+
+  INSERT INTO recorrido_pedidos (recorrido_id, pedido_id, orden_entrega, sucursal_id)
+  SELECT v_recorrido_id,
+         (value->>'pedido_id')::BIGINT,
+         (value->>'orden_entrega')::INTEGER,
+         v_sucursal
+  FROM jsonb_array_elements(p_pedidos);
+
+  RETURN v_recorrido_id;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.aplicar_orden_ruta(uuid, jsonb, numeric, integer, jsonb) FROM anon;
+GRANT EXECUTE ON FUNCTION public.aplicar_orden_ruta(uuid, jsonb, numeric, integer, jsonb) TO authenticated;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { useEffect, lazy, Suspense, ReactElement, useCallback, useMemo } from 'react'
+import { useEffect, Suspense, ReactElement, useCallback, useMemo } from 'react'
 import { BrowserRouter, useLocation, Navigate, Route, Routes } from 'react-router-dom'
 import { Loader2 } from 'lucide-react'
 import {
@@ -10,6 +10,7 @@ import {
   useProductos
 } from './hooks/supabase'
 import { useInvalidateMetricas } from './hooks/queries'
+import { lazyWithReload } from './utils/lazyWithReload'
 import { ThemeProvider } from './contexts/ThemeContext'
 import { NotificationProvider, useNotification } from './contexts/NotificationContext'
 import { AuthDataProvider, type AuthDataContextValue } from './contexts/AuthDataContext'
@@ -35,17 +36,19 @@ import ProductosContainer from './components/containers/ProductosContainer'
 import ProveedoresContainer from './components/containers/ProveedoresContainer'
 import UsuariosContainer from './components/containers/UsuariosContainer'
 
-const VistaRendiciones = lazy(() => import('./components/vistas/VistaRendiciones'))
-const VistaSalvedades = lazy(() => import('./components/vistas/VistaSalvedades'))
-const VistaGeolocalizacion = lazy(() => import('./components/vistas/VistaGeolocalizacion'))
-const AnalyticsContainer = lazy(() => import('./components/containers/AnalyticsContainer'))
-const ReportesContainer = lazy(() => import('./components/containers/ReportesContainer'))
-const ComisionesContainer = lazy(() => import('./components/containers/ComisionesContainer'))
-const RecorridosContainer = lazy(() => import('./components/containers/RecorridosContainer'))
-const RecorridoPreventistaContainer = lazy(() => import('./components/containers/RecorridoPreventistaContainer'))
-const MovimientosContainer = lazy(() => import('./components/containers/MovimientosContainer'))
-const PromocionesContainer = lazy(() => import('./components/containers/PromocionesContainer'))
-const VistaBotTelegramContainer = lazy(() => import('./components/containers/VistaBotTelegramContainer'))
+// lazyWithReload: si un chunk quedó obsoleto tras un deploy (PWA con SW que
+// tomó control a mitad de sesión), recarga una vez en vez de colgar el Suspense.
+const VistaRendiciones = lazyWithReload(() => import('./components/vistas/VistaRendiciones'))
+const VistaSalvedades = lazyWithReload(() => import('./components/vistas/VistaSalvedades'))
+const VistaGeolocalizacion = lazyWithReload(() => import('./components/vistas/VistaGeolocalizacion'))
+const AnalyticsContainer = lazyWithReload(() => import('./components/containers/AnalyticsContainer'))
+const ReportesContainer = lazyWithReload(() => import('./components/containers/ReportesContainer'))
+const ComisionesContainer = lazyWithReload(() => import('./components/containers/ComisionesContainer'))
+const RecorridosContainer = lazyWithReload(() => import('./components/containers/RecorridosContainer'))
+const RecorridoPreventistaContainer = lazyWithReload(() => import('./components/containers/RecorridoPreventistaContainer'))
+const MovimientosContainer = lazyWithReload(() => import('./components/containers/MovimientosContainer'))
+const PromocionesContainer = lazyWithReload(() => import('./components/containers/PromocionesContainer'))
+const VistaBotTelegramContainer = lazyWithReload(() => import('./components/containers/VistaBotTelegramContainer'))
 
 function LoadingVista(): ReactElement {
   return (

--- a/src/components/MapaRuta.tsx
+++ b/src/components/MapaRuta.tsx
@@ -48,22 +48,36 @@ export interface MapaRutaProps {
   onParadaTap?: (orden: number) => void;
   /** Si true, el mapa sigue la posición propia en vez de la parada activa. */
   seguirPosicion?: boolean;
+  /**
+   * Ruta real sobre las calles (polyline decodificada de Google). Si viene con
+   * >1 punto se dibuja la línea sólida real; si no, fallback a la línea recta
+   * punteada entre paradas (recorridos viejos / sin polyline).
+   */
+  rutaReal?: [number, number][] | null;
 }
 
-const markerParada = (orden: number, entregado: boolean, activa: boolean) =>
-  divIcon({
+// Jerarquía visual: la parada activa domina (40px, anillo pulsante); las
+// pendientes son medianas (28px); las completadas se "apagan" (20px, verde
+// atenuado) para ceder protagonismo y desamontonar el centro.
+const markerParada = (orden: number, entregado: boolean, activa: boolean) => {
+  const size = activa ? 40 : entregado ? 20 : 28;
+  const bg = entregado ? '#16a34a' : activa ? '#1d4ed8' : '#2563eb';
+  const fontSize = activa ? 15 : entregado ? 10 : 12;
+  const border = activa ? 3 : 2;
+  return divIcon({
     className: '', // sin clase default de leaflet (evita el sprite roto)
     html: `<div class="${activa ? 'mapa-marker-activo' : ''}" style="
-      width:${activa ? 36 : 28}px;height:${activa ? 36 : 28}px;border-radius:9999px;
-      background:${entregado ? '#22c55e' : activa ? '#1d4ed8' : '#2563eb'};
-      color:#fff;font-weight:700;font-size:${activa ? 14 : 12}px;
+      width:${size}px;height:${size}px;border-radius:9999px;
+      background:${bg};opacity:${entregado && !activa ? 0.65 : 1};
+      color:#fff;font-weight:700;font-size:${fontSize}px;
       display:flex;align-items:center;justify-content:center;
-      border:${activa ? 3 : 2}px solid #fff;box-shadow:0 1px 6px rgba(0,0,0,.45);
+      border:${border}px solid #fff;box-shadow:0 1px 6px rgba(0,0,0,.45);
     ">${entregado ? '✓' : orden}</div>`,
-    iconSize: activa ? [36, 36] : [28, 28],
-    iconAnchor: activa ? [18, 18] : [14, 14],
-    popupAnchor: [0, activa ? -18 : -14],
+    iconSize: [size, size],
+    iconAnchor: [size / 2, size / 2],
+    popupAnchor: [0, -size / 2],
   });
+};
 
 const markerDeposito = divIcon({
   className: '',
@@ -108,6 +122,7 @@ export default function MapaRuta({
   paradaActivaOrden = null,
   onParadaTap,
   seguirPosicion = false,
+  rutaReal = null,
 }: MapaRutaProps) {
   const paradasOrdenadas = useMemo(
     () => [...paradas].sort((a, b) => a.orden - b.orden),
@@ -121,16 +136,17 @@ export default function MapaRuta({
     return latLngBounds(puntos as [number, number][]).pad(0.15);
   }, [paradasOrdenadas, deposito]);
 
-  // Trazado simple (líneas punteadas entre paradas en orden). El trazado real
-  // sobre calles requeriría guardar la polyline de Google en recorridos —
-  // fase 3 del plan de Ruta Activa.
-  const linea = useMemo((): LatLngExpression[] => {
+  // Fallback: líneas rectas punteadas entre paradas en orden. Solo se usa
+  // cuando no hay ruta real (recorridos viejos / sin polyline guardada).
+  const lineaFallback = useMemo((): LatLngExpression[] => {
     const pts: LatLngExpression[] = paradasOrdenadas.map(p => [p.lat, p.lng]);
     if (deposito && pts.length > 0) {
       return [[deposito.lat, deposito.lng], ...pts, [deposito.lat, deposito.lng]];
     }
     return pts;
   }, [paradasOrdenadas, deposito]);
+
+  const hayRutaReal = (rutaReal?.length ?? 0) > 1;
 
   const objetivo = useMemo((): LatLngExpression | null => {
     if (seguirPosicion && posicion) return [posicion.lat, posicion.lng];
@@ -157,13 +173,21 @@ export default function MapaRuta({
         zoomControl={!esFull}
         attributionControl={true}
       >
+        {/* CARTO Voyager: base limpia y profesional (gratis). {r} sirve tiles
+            @2x en pantallas retina (celulares). Atribución CARTO + OSM. */}
         <TileLayer
-          attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a>'
-          url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
+          attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors &copy; <a href="https://carto.com/attributions">CARTO</a>'
+          url="https://{s}.basemaps.cartocdn.com/rastertiles/voyager/{z}/{x}/{y}{r}.png"
+          subdomains="abcd"
+          maxZoom={20}
         />
         <VistaControlada objetivo={objetivo} />
-        {linea.length > 1 && (
-          <Polyline positions={linea} pathOptions={{ color: '#2563eb', weight: 3, dashArray: '6 8', opacity: 0.7 }} />
+        {hayRutaReal ? (
+          // Ruta real sobre las calles: línea sólida.
+          <Polyline positions={rutaReal as LatLngExpression[]} pathOptions={{ color: '#2563eb', weight: 5, opacity: 0.85 }} />
+        ) : lineaFallback.length > 1 && (
+          // Fallback recto punteado (sin polyline guardada).
+          <Polyline positions={lineaFallback} pathOptions={{ color: '#2563eb', weight: 3, dashArray: '6 8', opacity: 0.6 }} />
         )}
         {deposito && (
           <Marker position={[deposito.lat, deposito.lng]} icon={markerDeposito}>

--- a/src/components/containers/PedidosContainer.tsx
+++ b/src/components/containers/PedidosContainer.tsx
@@ -28,6 +28,7 @@ import {
   useTransportistasQuery,
   useUsuariosQuery,
   useCrearClienteMutation,
+  useDepositoCoords,
 } from '../../hooks/queries'
 import { useAuthData } from '../../contexts/AuthDataContext'
 import { useNotification } from '../../contexts/NotificationContext'
@@ -145,6 +146,13 @@ export default function PedidosContainer(): React.ReactElement {
 
   // Route optimization
   const { loading: loadingOptimizacion, rutaOptimizada, error: errorOptimizacion, optimizarRuta, limpiarRuta } = useOptimizarRuta()
+  const deposito = useDepositoCoords()
+  // Inyecta el depósito de la sucursal (DB) en la optimización, así el lado
+  // que optimiza y el mapa del transportista usan la MISMA ubicación.
+  const optimizarRutaConDeposito = useCallback(
+    (transportistaId: string, pedidosData?: PedidoDB[]) => optimizarRuta(transportistaId, pedidosData, deposito),
+    [optimizarRuta, deposito],
+  )
 
   // Export
   const [exportando, setExportando] = useState(false)
@@ -1006,18 +1014,23 @@ export default function PedidosContainer(): React.ReactElement {
         p_transportista_id: data.transportistaId,
         p_pedidos: data.ordenOptimizado.map(p => ({ pedido_id: p.pedido_id, orden_entrega: p.orden })),
         p_distancia: data.distancia,
-        p_duracion: data.duracion != null ? Math.round(data.duracion) : null
+        p_duracion: data.duracion != null ? Math.round(data.duracion) : null,
+        // Ruta real sobre las calles (encoded polylines de Google) para
+        // dibujarla en el mapa del transportista y del admin.
+        p_polylines: rutaOptimizada?.polylines ?? null
       })
       if (error) throw error
 
-      // Refresca lista paginada y query de asignados: ambos cachean orden_entrega
+      // Refresca lista paginada, query de asignados y recorridos (cachean
+      // orden_entrega y la ruta real)
       queryClient.invalidateQueries({ queryKey: ['pedidos'] })
+      queryClient.invalidateQueries({ queryKey: ['recorridos'] })
       setModalOptimizarRutaOpen(false)
       limpiarRuta()
       notify.success('Ruta aplicada: orden de entrega y recorrido del día guardados')
     } catch (e) { notify.error('Error al aplicar la ruta: ' + (e as Error).message) }
     setGuardando(false)
-  }, [limpiarRuta, notify, queryClient])
+  }, [limpiarRuta, notify, queryClient, rutaOptimizada])
 
   const handleAplicarOrden = useCallback(async (data: { ordenOptimizado: Array<{ pedido_id: string; orden: number }>; transportistaId: string; distancia: number | null; duracion: number | null }) => {
     if (!data.ordenOptimizado?.length || !data.transportistaId) return
@@ -1432,7 +1445,7 @@ export default function PedidosContainer(): React.ReactElement {
           <ModalGestionRutas
             transportistas={transportistas}
             pedidos={pedidosParaRuta}
-            onOptimizar={optimizarRuta as Parameters<typeof ModalGestionRutas>[0]['onOptimizar']}
+            onOptimizar={optimizarRutaConDeposito as Parameters<typeof ModalGestionRutas>[0]['onOptimizar']}
             onAplicarOrden={handleAplicarOrden as Parameters<typeof ModalGestionRutas>[0]['onAplicarOrden']}
             onExportarPDF={handleExportarHojaRutaOptimizada as Parameters<typeof ModalGestionRutas>[0]['onExportarPDF']}
             onClose={() => { setModalOptimizarRutaOpen(false); limpiarRuta() }}

--- a/src/components/modals/ModalGestionRutas.tsx
+++ b/src/components/modals/ModalGestionRutas.tsx
@@ -6,7 +6,7 @@ import {
   DollarSign, Package, CheckCircle, Circle, Printer, ArrowRight, CalendarDays
 } from 'lucide-react';
 import ModalBase from './ModalBase';
-import { getDepositoCoords, setDepositoCoords } from '../../hooks/useOptimizarRuta';
+import { useDepositoCoords, useSetDepositoMutation } from '../../hooks/queries';
 import type { PedidoDB, PerfilDB } from '../../types';
 
 // =============================================================================
@@ -192,12 +192,15 @@ const ModalGestionRutas = memo(function ModalGestionRutas({
   const [depositoGuardado, setDepositoGuardado] = useState<boolean>(false);
   const [vistaActiva, setVistaActiva] = useState<'optimizar' | 'resultado'>('optimizar');
 
-  // Cargar coordenadas del deposito al montar
+  // Depósito de la sucursal (DB, mig 082) — compartido con el mapa del transportista
+  const deposito = useDepositoCoords();
+  const setDepositoMut = useSetDepositoMutation();
+
+  // Cargar coordenadas del deposito en los inputs
   useEffect(() => {
-    const coords = getDepositoCoords();
-    setDepositoLat(coords.lat.toString());
-    setDepositoLng(coords.lng.toString());
-  }, []);
+    setDepositoLat(deposito.lat.toString());
+    setDepositoLng(deposito.lng.toString());
+  }, [deposito.lat, deposito.lng]);
 
   // Cambiar a vista resultado cuando hay ruta optimizada
   useEffect(() => {
@@ -276,10 +279,9 @@ const ModalGestionRutas = memo(function ModalGestionRutas({
       .map(p => `${p.cliente!.latitud},${p.cliente!.longitud}`);
     if (coords.length === 0) return [];
 
-    const dep = getDepositoCoords();
     const PARADAS_POR_LINK = 10; // 9 waypoints + destino
     const links: Array<{ url: string; desde: number; hasta: number }> = [];
-    let origen = `${dep.lat},${dep.lng}`;
+    let origen = `${deposito.lat},${deposito.lng}`;
 
     for (let i = 0; i < coords.length; i += PARADAS_POR_LINK) {
       const grupo = coords.slice(i, i + PARADAS_POR_LINK);
@@ -292,7 +294,7 @@ const ModalGestionRutas = memo(function ModalGestionRutas({
       origen = destino;
     }
     return links;
-  }, [pedidosOrdenados]);
+  }, [pedidosOrdenados, deposito.lat, deposito.lng]);
 
   // Calcular totales
   const totales = useMemo((): Totales => {
@@ -317,9 +319,12 @@ const ModalGestionRutas = memo(function ModalGestionRutas({
     const lat = parseFloat(depositoLat);
     const lng = parseFloat(depositoLng);
     if (!isNaN(lat) && !isNaN(lng)) {
-      setDepositoCoords(lat, lng);
-      setDepositoGuardado(true);
-      setTimeout(() => setDepositoGuardado(false), 2000);
+      setDepositoMut.mutate({ lat, lng }, {
+        onSuccess: () => {
+          setDepositoGuardado(true);
+          setTimeout(() => setDepositoGuardado(false), 2000);
+        },
+      });
     }
   };
 

--- a/src/components/rutaActiva/RutaActivaTransportista.tsx
+++ b/src/components/rutaActiva/RutaActivaTransportista.tsx
@@ -17,7 +17,8 @@ import { formatPrecio } from '../../utils/formatters';
 import { haversineMeters } from '../../utils/geo';
 import { useAuthData } from '../../contexts/AuthDataContext';
 import { useWatchPosition } from '../../hooks/useWatchPosition';
-import { getDepositoCoords } from '../../hooks/useOptimizarRuta';
+import { useDepositoCoords, useRecorridoActivoQuery } from '../../hooks/queries';
+import { decodePolylines } from '../../utils/polyline';
 import { useEntregaParada, type PedidoConCliente, type DatosPago, type DatosSalvedad } from './useEntregaParada';
 import SheetParada, { type LinkRutaMaps } from './SheetParada';
 import ModalSalvedadItem from '../modals/ModalSalvedadItem';
@@ -28,6 +29,10 @@ const MapaRuta = lazy(() => import('../MapaRuta'));
 
 /** Radio del geofence de llegada, en metros */
 const RADIO_LLEGADA_M = 100;
+/** Accuracy máxima para confiar en el GPS (peor = IP-geoloc de desktop) */
+const ACCURACY_MAX_M = 1000;
+/** Más lejos que esto de la parada activa = el chofer no está en zona */
+const DISTANCIA_ABSURDA_M = 50_000;
 
 export interface RutaActivaTransportistaProps {
   pedidos: PedidoDB[] | null;
@@ -51,7 +56,14 @@ export default function RutaActivaTransportista({
   onEntregarSinCobrar,
 }: RutaActivaTransportistaProps): React.ReactElement {
   const { isOnline } = useAuthData();
+  const deposito = useDepositoCoords();
   const { posicion } = useWatchPosition(true);
+  // Ruta real sobre las calles (polylines guardadas al aplicar el orden)
+  const { data: recorridoActivo } = useRecorridoActivoQuery(userId);
+  const rutaReal = useMemo(
+    () => decodePolylines(recorridoActivo?.polylines),
+    [recorridoActivo?.polylines],
+  );
   const [seguirPosicion, setSeguirPosicion] = useState(false);
   // Parada seleccionada manualmente (tap en mapa o en la lista). null = automática.
   const [paradaSeleccionadaId, setParadaSeleccionadaId] = useState<string | null>(null);
@@ -106,15 +118,21 @@ export default function RutaActivaTransportista({
     if (!sel || sel.estado !== 'asignado') setParadaSeleccionadaId(null);
   }, [paradaSeleccionadaId, pedidosOrdenados]);
 
-  // Geofence: distancia a la parada activa
+  // GPS confiable: descarta la geolocalización por IP del navegador en
+  // desktop (accuracy enorme) que producía el falso "808 km".
+  const gpsConfiable = posicion != null && posicion.accuracy != null && posicion.accuracy <= ACCURACY_MAX_M;
+
+  // Geofence: distancia a la parada activa. null si el GPS no es confiable o si
+  // la distancia es absurda (chofer fuera de zona) → no mostrar dato falso.
   const distanciaMetros = useMemo((): number | null => {
-    if (!posicion || !paradaActiva?.cliente?.latitud || !paradaActiva?.cliente?.longitud) return null;
-    return haversineMeters(
+    if (!gpsConfiable || !posicion || !paradaActiva?.cliente?.latitud || !paradaActiva?.cliente?.longitud) return null;
+    const d = haversineMeters(
       { lat: posicion.lat, lng: posicion.lng },
       { lat: Number(paradaActiva.cliente.latitud), lng: Number(paradaActiva.cliente.longitud) },
     );
-  }, [posicion, paradaActiva]);
-  const llegaste = distanciaMetros != null && distanciaMetros <= RADIO_LLEGADA_M;
+    return d > DISTANCIA_ABSURDA_M ? null : d;
+  }, [gpsConfiable, posicion, paradaActiva]);
+  const llegaste = gpsConfiable && distanciaMetros != null && distanciaMetros <= RADIO_LLEGADA_M;
 
   // Paradas para el mapa
   const paradasMapa = useMemo(
@@ -179,12 +197,15 @@ export default function RutaActivaTransportista({
       <Suspense fallback={<div className="flex h-full items-center justify-center text-gray-400">Cargando mapa…</div>}>
         <MapaRuta
           paradas={paradasMapa}
-          deposito={getDepositoCoords()}
+          deposito={deposito}
           altura="full"
-          posicion={posicion ? { lat: posicion.lat, lng: posicion.lng, accuracy: posicion.accuracy } : null}
+          rutaReal={rutaReal.length > 1 ? rutaReal : null}
+          // Solo mostramos el punto azul con GPS confiable (no plantarlo en
+          // medio del país con la geolocalización por IP del desktop).
+          posicion={gpsConfiable && posicion ? { lat: posicion.lat, lng: posicion.lng, accuracy: posicion.accuracy } : null}
           paradaActivaOrden={paradaActiva?.orden_entrega ?? null}
           onParadaTap={handleParadaTapMapa}
-          seguirPosicion={seguirPosicion}
+          seguirPosicion={seguirPosicion && gpsConfiable}
         />
       </Suspense>
 

--- a/src/components/rutaActiva/SheetParada.tsx
+++ b/src/components/rutaActiva/SheetParada.tsx
@@ -11,7 +11,7 @@
  *
  * No-modal: el mapa de fondo sigue interactivo.
  */
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { Drawer } from 'vaul';
 import {
   Navigation, Check, MapPin, Phone, AlertTriangle, Gift, ChevronRight, Map as MapIcon,
@@ -65,6 +65,12 @@ export default function SheetParada({
   const expandido = snap === SNAP_EXPANDIDO;
 
   const pendientes = paradas.filter(p => p.estado === 'asignado');
+
+  // Al detectar llegada, subir el sheet a la posición media si está colapsado
+  // para que el botón Entregar quede a la vista (flujo guiado).
+  useEffect(() => {
+    if (llegaste) setSnap(s => (s === SNAP_COLAPSADO ? SNAP_MEDIO : s));
+  }, [llegaste]);
 
   return (
     <Drawer.Root

--- a/src/components/vistas/VistaRecorridos.tsx
+++ b/src/components/vistas/VistaRecorridos.tsx
@@ -2,7 +2,8 @@ import React, { useState, useMemo, lazy, Suspense, ChangeEvent } from 'react';
 import { Route, Truck, Calendar, Check, MapPin, Phone, ChevronDown, ChevronUp, Navigation, RefreshCw, BarChart3, X } from 'lucide-react';
 import { formatPrecio, formatFecha, fechaLocalISO } from '../../utils/formatters';
 import LoadingSpinner from '../layout/LoadingSpinner';
-import { getDepositoCoords } from '../../hooks/useOptimizarRuta';
+import { useDepositoCoords } from '../../hooks/queries';
+import { decodePolylines } from '../../utils/polyline';
 
 // Lazy: leaflet solo se carga al expandir un recorrido
 const MapaRuta = lazy(() => import('../MapaRuta'));
@@ -211,6 +212,7 @@ function PedidoRecorridoCard({ pedido, orden }: PedidoRecorridoCardProps): React
 
 function RecorridoCard({ recorrido, defaultExpanded = false }: RecorridoCardProps): React.ReactElement {
   const [expandido, setExpandido] = useState<boolean>(defaultExpanded);
+  const deposito = useDepositoCoords();
 
   const pedidosOrdenados = useMemo<PedidoRecorrido[]>(() => {
     if (!recorrido.pedidos) return [];
@@ -319,7 +321,8 @@ function RecorridoCard({ recorrido, defaultExpanded = false }: RecorridoCardProp
                     };
                   })
                   .filter((p): p is NonNullable<typeof p> => p !== null)}
-                deposito={getDepositoCoords()}
+                deposito={deposito}
+                rutaReal={(() => { const r = decodePolylines(recorrido.polylines); return r.length > 1 ? r : null; })()}
                 altura={240}
               />
             </div>

--- a/src/hooks/queries/index.ts
+++ b/src/hooks/queries/index.ts
@@ -145,6 +145,22 @@ export {
 } from './useZonasQuery'
 export type { ZonaDB } from './useZonasQuery'
 
+// Depósito de la sucursal (origen/cierre de rutas)
+export {
+  depositoKeys,
+  DEPOSITO_DEFAULT,
+  useDepositoCoords,
+  useSetDepositoMutation,
+} from './useDepositoQuery'
+export type { DepositoCoords } from './useDepositoQuery'
+
+// Recorrido activo del transportista (para la ruta real)
+export {
+  recorridoActivoKeys,
+  useRecorridoActivoQuery,
+} from './useRecorridoActivoQuery'
+export type { RecorridoActivo } from './useRecorridoActivoQuery'
+
 // Sucursales (el flujo viejo de transferencias fue reemplazado por movimientos)
 export {
   sucursalesKeys,

--- a/src/hooks/queries/useDepositoQuery.ts
+++ b/src/hooks/queries/useDepositoQuery.ts
@@ -1,0 +1,65 @@
+/**
+ * Depósito de la sucursal (origen/cierre de las rutas de entrega).
+ *
+ * Reemplaza el viejo getDepositoCoords() basado en localStorage (por
+ * dispositivo), que causaba que el admin y el transportista vieran depósitos
+ * distintos. Ahora vive en sucursales.deposito_lat/lng (mig 082), así el
+ * lado que optimiza y el que dibuja el mapa usan la MISMA fuente.
+ */
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import { supabase } from '../supabase/base'
+import { useSucursal } from '../../contexts/SucursalContext'
+
+export interface DepositoCoords {
+  lat: number
+  lng: number
+}
+
+// Centro de San Miguel de Tucumán. Fallback cuando la sucursal aún no tiene
+// depósito configurado (mismo valor histórico del default de localStorage).
+export const DEPOSITO_DEFAULT: DepositoCoords = { lat: -26.8241, lng: -65.2226 }
+
+export const depositoKeys = {
+  all: (sucursalId: number | null) => ['deposito', sucursalId] as const,
+}
+
+async function fetchDeposito(): Promise<DepositoCoords> {
+  const { data, error } = await supabase.rpc('get_deposito_sucursal')
+  if (error) throw error
+  const row = Array.isArray(data) ? data[0] : data
+  if (row?.lat != null && row?.lng != null) {
+    return { lat: Number(row.lat), lng: Number(row.lng) }
+  }
+  return DEPOSITO_DEFAULT
+}
+
+/**
+ * Coordenadas del depósito de la sucursal actual. SIEMPRE devuelve un objeto
+ * usable: el default mientras la query resuelve (placeholderData) y luego el
+ * valor real. Pensado para reemplazar el viejo getDepositoCoords() síncrono.
+ */
+export function useDepositoCoords(): DepositoCoords {
+  const { currentSucursalId } = useSucursal()
+  const { data } = useQuery({
+    queryKey: depositoKeys.all(currentSucursalId),
+    queryFn: fetchDeposito,
+    enabled: currentSucursalId != null,
+    staleTime: 30 * 60 * 1000, // el depósito casi nunca cambia
+    placeholderData: DEPOSITO_DEFAULT,
+  })
+  return data ?? DEPOSITO_DEFAULT
+}
+
+export function useSetDepositoMutation() {
+  const queryClient = useQueryClient()
+  const { currentSucursalId } = useSucursal()
+  return useMutation({
+    mutationFn: async ({ lat, lng }: DepositoCoords) => {
+      const { error } = await supabase.rpc('set_deposito_sucursal', { p_lat: lat, p_lng: lng })
+      if (error) throw error
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: depositoKeys.all(currentSucursalId) })
+    },
+  })
+}

--- a/src/hooks/queries/useRecorridoActivoQuery.ts
+++ b/src/hooks/queries/useRecorridoActivoQuery.ts
@@ -1,0 +1,49 @@
+/**
+ * Recorrido vigente (en_curso) de hoy del transportista logueado.
+ *
+ * Lo usa la pantalla Ruta Activa SOLO para obtener las `polylines` (la ruta
+ * real sobre las calles que guardó el admin al aplicar el orden) y dibujarla.
+ * Las paradas y el flujo de entrega NO dependen de esto: se arman desde
+ * `pedidos.orden_entrega`. Si no hay recorrido (o es viejo sin polyline), el
+ * mapa cae al trazado recto — degradado seguro.
+ */
+import { useQuery } from '@tanstack/react-query'
+import { supabase } from '../supabase/base'
+import { useSucursal } from '../../contexts/SucursalContext'
+import { fechaLocalISO } from '../../utils/formatters'
+
+export interface RecorridoActivo {
+  id: string
+  polylines: string[] | null
+}
+
+export const recorridoActivoKeys = {
+  all: (sucursalId: number | null, transportistaId: string | null) =>
+    ['recorrido-activo', sucursalId, transportistaId] as const,
+}
+
+async function fetchRecorridoActivo(transportistaId: string): Promise<RecorridoActivo | null> {
+  const { data, error } = await supabase
+    .from('recorridos')
+    .select('id, polylines')
+    .eq('transportista_id', transportistaId)
+    .eq('fecha', fechaLocalISO())
+    .eq('estado', 'en_curso')
+    .order('created_at', { ascending: false })
+    .limit(1)
+    .maybeSingle()
+
+  if (error) throw error
+  if (!data) return null
+  return { id: String(data.id), polylines: (data.polylines as string[] | null) ?? null }
+}
+
+export function useRecorridoActivoQuery(transportistaId: string | null | undefined) {
+  const { currentSucursalId } = useSucursal()
+  return useQuery({
+    queryKey: recorridoActivoKeys.all(currentSucursalId, transportistaId ?? null),
+    queryFn: () => fetchRecorridoActivo(transportistaId as string),
+    enabled: !!transportistaId,
+    staleTime: 2 * 60 * 1000,
+  })
+}

--- a/src/hooks/supabase/useRecorridos.ts
+++ b/src/hooks/supabase/useRecorridos.ts
@@ -29,6 +29,7 @@ interface RecorridoRaw {
   duracion_total?: number;
   completed_at?: string | null;
   created_at?: string;
+  polylines?: string[] | null;
   transportista?: TransportistaBasic | null;
   recorrido_pedidos?: Array<{
     id: string;

--- a/src/hooks/supabase/useRecorridos.ts
+++ b/src/hooks/supabase/useRecorridos.ts
@@ -127,7 +127,7 @@ export function useRecorridos(): UseRecorridosReturnExtended {
   }, [fetchRecorridosDeFecha])
 
   // Crear un nuevo recorrido cuando se aplica una ruta optimizada
-  const crearRecorrido = async (
+  const crearRecorrido = useCallback(async (
     transportistaId: string,
     pedidosOrdenados: PedidoOrdenado[],
     distancia: number | null = null,
@@ -151,10 +151,10 @@ export function useRecorridos(): UseRecorridosReturnExtended {
     setRecorridoActual({ id: recorridoId })
     await fetchRecorridosHoy()
     return recorridoId
-  }
+  }, [fetchRecorridosHoy])
 
   // Completar un recorrido
-  const completarRecorrido = async (recorridoId: string): Promise<void> => {
+  const completarRecorrido = useCallback(async (recorridoId: string): Promise<void> => {
     const { error } = await supabase
       .from('recorridos')
       .update({ estado: 'completado', completed_at: new Date().toISOString() })
@@ -162,10 +162,13 @@ export function useRecorridos(): UseRecorridosReturnExtended {
 
     if (error) throw error
     await fetchRecorridosHoy()
-  }
+  }, [fetchRecorridosHoy])
 
-  // Obtener resumen de recorridos para estadisticas
-  const getEstadisticasRecorridos = async (
+  // Obtener resumen de recorridos para estadisticas.
+  // useCallback: si no, su referencia cambia en cada render y dispara un loop
+  // infinito de fetches en RecorridosContainer (la tenía en las deps de un
+  // useEffect vía cargarRecorridos) → ERR_INSUFFICIENT_RESOURCES.
+  const getEstadisticasRecorridos = useCallback(async (
     fechaDesde: string,
     fechaHasta: string
   ): Promise<EstadisticasRecorridos> => {
@@ -214,7 +217,7 @@ export function useRecorridos(): UseRecorridosReturnExtended {
     } catch {
       return { total: 0, porTransportista: [] }
     }
-  }
+  }, [])
 
   return {
     recorridos,

--- a/src/hooks/useOptimizarRuta.ts
+++ b/src/hooks/useOptimizarRuta.ts
@@ -35,7 +35,12 @@ export interface RutaOptimizadaResponse {
   orden_optimizado?: OrdenOptimizadoItem[];
   distancia_total?: number;
   duracion_total?: number;
-  polyline?: string;
+  /**
+   * Polylines codificadas (Google encoded polyline, una por tramo) de la ruta
+   * real sobre las calles. El front las decodifica y dibuja. Se persisten en
+   * recorridos.polylines al aplicar el orden.
+   */
+  polylines?: string[];
   mensaje?: string;
   error?: string;
 }
@@ -52,7 +57,7 @@ export interface UseOptimizarRutaReturn {
   loading: boolean;
   rutaOptimizada: RutaOptimizadaResponse | null;
   error: string | null;
-  optimizarRuta: (transportistaId: string, pedidos?: PedidoDB[]) => Promise<RutaOptimizadaResponse | null>;
+  optimizarRuta: (transportistaId: string, pedidos?: PedidoDB[], deposito?: DepositoCoords) => Promise<RutaOptimizadaResponse | null>;
   limpiarRuta: () => void;
 }
 
@@ -83,7 +88,9 @@ const DEPOSITO_STORAGE_KEY = 'distribuidora_deposito_coords';
 // ============================================================================
 
 /**
- * Obtiene las coordenadas del depósito desde localStorage o usa las por defecto
+ * Obtiene las coordenadas del depósito desde localStorage o usa las por defecto.
+ * @deprecated El depósito vive en la DB por sucursal (mig 082). Usar
+ * `useDepositoCoords()` de hooks/queries. Esto queda solo como fallback puro.
  */
 export const getDepositoCoords = (): DepositoCoords => {
   try {
@@ -132,7 +139,8 @@ export function useOptimizarRuta(): UseOptimizarRutaReturn {
    */
   const optimizarRuta = useCallback(async (
     transportistaId: string,
-    pedidos: PedidoDB[] = []
+    pedidos: PedidoDB[] = [],
+    deposito?: DepositoCoords
   ): Promise<RutaOptimizadaResponse | null> => {
     if (!transportistaId) {
       setError('Debes seleccionar un transportista');
@@ -169,13 +177,15 @@ export function useOptimizarRuta(): UseOptimizarRutaReturn {
     setLoading(true);
     setError(null);
 
-    // Obtener coordenadas del depósito (configurables)
-    const deposito = getDepositoCoords();
+    // Depósito: lo provee el caller desde la DB (useDepositoCoords). Fallback
+    // al default si no se pasó (compat) — pero el caller debe pasarlo para que
+    // optimización y mapa usen la MISMA fuente.
+    const dep = deposito ?? getDepositoCoords();
 
     const requestBody: OptimizarRutaRequestBody = {
       transportista_id: transportistaId,
-      deposito_lat: deposito.lat,
-      deposito_lng: deposito.lng,
+      deposito_lat: dep.lat,
+      deposito_lng: dep.lng,
       pedidos: pedidosConCoordenadas
     };
 

--- a/src/types/hooks.ts
+++ b/src/types/hooks.ts
@@ -1106,6 +1106,8 @@ export interface RecorridoDBExtended {
   fecha: string;
   /** Paradas del recorrido, mapeadas desde recorrido_pedidos por useRecorridos */
   pedidos?: RecorridoParada[];
+  /** Encoded polylines (ruta real sobre calles) guardadas al aplicar el orden */
+  polylines?: string[] | null;
   pedidos_json?: Array<{ pedido_id: string; orden_entrega: number }>;
   estado?: string;
   total_pedidos?: number;

--- a/src/utils/lazyWithReload.ts
+++ b/src/utils/lazyWithReload.ts
@@ -1,0 +1,44 @@
+/**
+ * lazyWithReload — React.lazy resiliente a chunks obsoletos tras un deploy.
+ *
+ * Problema: el SW de la PWA usa skipWaiting + clientsClaim, así que una versión
+ * nueva toma control a mitad de sesión. La app vieja en memoria sigue pidiendo
+ * chunks con el hash viejo (`Container-<hashViejo>.js`) que ya no existen en el
+ * server → el import() dinámico falla → el <Suspense> queda colgado para
+ * siempre (síntoma: "se queda cargando y no pasa nada" al navegar a una
+ * pantalla lazy).
+ *
+ * Solución: ante un fallo de carga de chunk, recargar UNA vez para traer el
+ * index.html + chunks frescos. El guard por sessionStorage evita loops de
+ * recarga (si tras recargar sigue fallando, propaga el error real).
+ */
+import { lazy, type ComponentType, type LazyExoticComponent } from 'react'
+
+const RELOAD_KEY = 'chunk-reload-at'
+const RELOAD_COOLDOWN_MS = 15000
+
+function esErrorDeChunk(err: unknown): boolean {
+  const msg = err instanceof Error ? err.message : String(err)
+  return /Failed to fetch dynamically imported module|error loading dynamically imported module|Importing a module script failed|ChunkLoadError/i.test(msg)
+}
+
+export function lazyWithReload<T extends ComponentType<unknown>>(
+  factory: () => Promise<{ default: T }>,
+): LazyExoticComponent<T> {
+  return lazy(async () => {
+    try {
+      return await factory()
+    } catch (err) {
+      if (esErrorDeChunk(err)) {
+        const last = Number(sessionStorage.getItem(RELOAD_KEY) || 0)
+        if (Date.now() - last > RELOAD_COOLDOWN_MS) {
+          sessionStorage.setItem(RELOAD_KEY, String(Date.now()))
+          window.location.reload()
+          // Promesa que nunca resuelve: mantiene el fallback hasta que recarga.
+          return new Promise<{ default: T }>(() => {})
+        }
+      }
+      throw err
+    }
+  })
+}

--- a/src/utils/polyline.test.ts
+++ b/src/utils/polyline.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest';
+import { decodePolyline, decodePolylines } from './polyline';
+
+describe('decodePolyline', () => {
+  // Ejemplo canónico de la documentación de Google:
+  // "_p~iF~ps|U_ulLnnqC_mqNvxq`@" → 3 puntos conocidos.
+  it('decodifica el ejemplo canónico de Google', () => {
+    const pts = decodePolyline('_p~iF~ps|U_ulLnnqC_mqNvxq`@');
+    expect(pts).toHaveLength(3);
+    expect(pts[0][0]).toBeCloseTo(38.5, 5);
+    expect(pts[0][1]).toBeCloseTo(-120.2, 5);
+    expect(pts[1][0]).toBeCloseTo(40.7, 5);
+    expect(pts[1][1]).toBeCloseTo(-120.95, 5);
+    expect(pts[2][0]).toBeCloseTo(43.252, 5);
+    expect(pts[2][1]).toBeCloseTo(-126.453, 5);
+  });
+
+  it('string vacío → array vacío', () => {
+    expect(decodePolyline('')).toEqual([]);
+  });
+});
+
+describe('decodePolylines', () => {
+  it('concatena varios tramos en orden', () => {
+    const tramo = '_p~iF~ps|U_ulLnnqC_mqNvxq`@';
+    const result = decodePolylines([tramo, tramo]);
+    expect(result).toHaveLength(6);
+  });
+
+  it('null/undefined/vacío → array vacío', () => {
+    expect(decodePolylines(null)).toEqual([]);
+    expect(decodePolylines(undefined)).toEqual([]);
+    expect(decodePolylines([])).toEqual([]);
+  });
+});

--- a/src/utils/polyline.ts
+++ b/src/utils/polyline.ts
@@ -1,0 +1,61 @@
+/**
+ * Decodificador de Google Encoded Polyline Algorithm Format (precisión 5).
+ *
+ * Google Routes API devuelve la geometría de la ruta como un string codificado
+ * (`encodedPolyline`). Lo decodificamos a [lat, lng][] — el formato que Leaflet
+ * <Polyline positions> espera directamente, sin transformación.
+ *
+ * Sin dependencia npm: el algoritmo son ~25 líneas. Referencia:
+ * https://developers.google.com/maps/documentation/utilities/polylinealgorithm
+ */
+
+export type LatLngTuple = [number, number];
+
+/**
+ * Decodifica un único string encoded a un array de coordenadas [lat, lng].
+ * Precisión 5 (factor 1e5), el default de Google `ENCODED_POLYLINE`.
+ */
+export function decodePolyline(encoded: string): LatLngTuple[] {
+  if (!encoded) return [];
+  const points: LatLngTuple[] = [];
+  let index = 0;
+  let lat = 0;
+  let lng = 0;
+  const len = encoded.length;
+
+  while (index < len) {
+    let result = 0;
+    let shift = 0;
+    let byte: number;
+    do {
+      byte = encoded.charCodeAt(index++) - 63;
+      result |= (byte & 0x1f) << shift;
+      shift += 5;
+    } while (byte >= 0x20);
+    const dlat = result & 1 ? ~(result >> 1) : result >> 1;
+    lat += dlat;
+
+    result = 0;
+    shift = 0;
+    do {
+      byte = encoded.charCodeAt(index++) - 63;
+      result |= (byte & 0x1f) << shift;
+      shift += 5;
+    } while (byte >= 0x20);
+    const dlng = result & 1 ? ~(result >> 1) : result >> 1;
+    lng += dlng;
+
+    points.push([lat / 1e5, lng / 1e5]);
+  }
+  return points;
+}
+
+/**
+ * Decodifica y concatena varias polylines (una por tramo de la optimización).
+ * El último punto de un tramo coincide con el primero del siguiente (parada
+ * "puente"); el solapamiento de 1 punto es visualmente nulo.
+ */
+export function decodePolylines(encoded: string[] | null | undefined): LatLngTuple[] {
+  if (!encoded || encoded.length === 0) return [];
+  return encoded.flatMap(decodePolyline);
+}

--- a/supabase/functions/optimizar-ruta/index.ts
+++ b/supabase/functions/optimizar-ruta/index.ts
@@ -60,8 +60,10 @@ async function llamarGoogle(
     headers: {
       "Content-Type": "application/json",
       "X-Goog-Api-Key": apiKey,
+      // routes.polyline: geometría real sobre las calles para dibujarla en la
+      // app (la pagamos igual al optimizar; es campo base, no sube el SKU).
       "X-Goog-FieldMask":
-        "routes.duration,routes.distanceMeters,routes.optimizedIntermediateWaypointIndex,routes.legs",
+        "routes.duration,routes.distanceMeters,routes.optimizedIntermediateWaypointIndex,routes.legs,routes.polyline.encodedPolyline",
     },
     body: JSON.stringify({
       origin: { location: { latLng: origen } },
@@ -72,6 +74,7 @@ async function llamarGoogle(
       travelMode: "DRIVE",
       optimizeWaypointOrder: intermedios.length > 1,
       routingPreference: "TRAFFIC_AWARE",
+      polylineEncoding: "ENCODED_POLYLINE",
       languageCode: "es-419",
       units: "METRIC",
     }),
@@ -164,7 +167,7 @@ serve(async (req: Request) => {
     });
   }
 
-  const { ordenOptimizado, distanciaTotalMetros, duracionTotalSegundos } = unirTramos(
+  const { ordenOptimizado, distanciaTotalMetros, duracionTotalSegundos, polylines } = unirTramos(
     tramos,
     rutas,
   );
@@ -200,5 +203,6 @@ serve(async (req: Request) => {
     duracion_formato: horas > 0 ? `${horas}h ${minutos}m` : `${minutos} minutos`,
     distancia_formato: `${distanciaTotalKm} km`,
     orden_optimizado: ordenOptimizado,
+    polylines,
   });
 });

--- a/supabase/functions/optimizar-ruta/tramos.ts
+++ b/supabase/functions/optimizar-ruta/tramos.ts
@@ -38,6 +38,8 @@ export interface GoogleRoute {
   duration?: string;
   optimizedIntermediateWaypointIndex?: number[];
   legs?: Array<{ distanceMeters?: number; duration?: string }>;
+  /** Geometría de la ruta sobre las calles (encoded polyline, precisión 5). */
+  polyline?: { encodedPolyline?: string };
 }
 
 export interface OrdenOptimizadoItem {
@@ -55,6 +57,8 @@ export interface RutaUnida {
   ordenOptimizado: OrdenOptimizadoItem[];
   distanciaTotalMetros: number;
   duracionTotalSegundos: number;
+  /** Encoded polylines, una por tramo en orden (la ruta real sobre calles). */
+  polylines: string[];
 }
 
 /** Máximo de intermedios por request (25 de Google, con margen). */
@@ -109,6 +113,7 @@ const parseDuracion = (s: string | undefined): number =>
  */
 export function unirTramos(tramos: Tramo[], rutas: GoogleRoute[]): RutaUnida {
   const ordenOptimizado: OrdenOptimizadoItem[] = [];
+  const polylines: string[] = [];
   let distanciaTotalMetros = 0;
   let duracionTotalSegundos = 0;
 
@@ -116,6 +121,9 @@ export function unirTramos(tramos: Tramo[], rutas: GoogleRoute[]): RutaUnida {
     const ruta = rutas[i] ?? {};
     const legs = ruta.legs ?? [];
     const optimizedOrder = ruta.optimizedIntermediateWaypointIndex ?? [];
+
+    const encoded = ruta.polyline?.encodedPolyline;
+    if (encoded) polylines.push(encoded);
 
     // Orden de visita del tramo: intermedios (reordenados por Google si hubo
     // optimización) y el puente al final si existe.
@@ -150,5 +158,5 @@ export function unirTramos(tramos: Tramo[], rutas: GoogleRoute[]): RutaUnida {
     }
   });
 
-  return { ordenOptimizado, distanciaTotalMetros, duracionTotalSegundos };
+  return { ordenOptimizado, distanciaTotalMetros, duracionTotalSegundos, polylines };
 }

--- a/supabase/functions/tests/optimizar_ruta.test.ts
+++ b/supabase/functions/tests/optimizar_ruta.test.ts
@@ -74,6 +74,7 @@ Deno.test("unirTramos respeta el orden optimizado de Google y suma totales", () 
   // (índices sobre tramos[0].intermedios). 4 legs: 3 llegadas + vuelta al depósito.
   const ruta: GoogleRoute = {
     optimizedIntermediateWaypointIndex: [2, 0, 1],
+    polyline: { encodedPolyline: "_p~iF~ps|U" },
     legs: [
       { distanceMeters: 1000, duration: "60s" },
       { distanceMeters: 2000, duration: "120s" },
@@ -84,6 +85,8 @@ Deno.test("unirTramos respeta el orden optimizado de Google y suma totales", () 
 
   const unida = unirTramos(tramos, [ruta]);
   assertEquals(unida.ordenOptimizado.length, 3);
+  // La polyline del tramo se recolecta en orden
+  assertEquals(unida.polylines, ["_p~iF~ps|U"]);
   assertEquals(unida.ordenOptimizado.map((o) => o.orden), [1, 2, 3]);
   assertEquals(
     unida.ordenOptimizado.map((o) => o.pedido_id),


### PR DESCRIPTION
## Resumen

Rediseño de la pantalla **Ruta Activa** del transportista (sobre el PR #367) tras tu feedback: el depósito mal ubicado, la "telaraña" de líneas rectas, el "808 km" y el look artesanal. Diseño consensuado en [docs/plans/2026-06-13-ruta-activa-rediseno-design.md](docs/plans/2026-06-13-ruta-activa-rediseno-design.md).

### 1. Depósito correcto (bug de fondo)
Vivía en **localStorage (por dispositivo)**: el admin lo configuraba en su PC y el celular del transportista caía al default (la "D" del centro de Tucumán que no coincidía con la ruta optimizada).
- **Migración 082** (✅ aplicada en prod, verificada con rollback): `sucursales.deposito_lat/lng` + RPCs `get_deposito_sucursal` (cualquier autenticado de la sucursal) y `set_deposito_sucursal` (gate encargado/admin).
- `useDepositoCoords()` / `useSetDepositoMutation()` reemplazan el localStorage; `optimizarRuta` recibe el depósito por parámetro → **optimización y mapa usan la misma fuente (DB)**.

### 2. Ruta real sobre las calles (adiós telaraña)
Google ya calculaba la geometría al optimizar; la descartábamos.
- **Edge function** (✅ desplegada v4, verificada): el FieldMask pide `routes.polyline` y devuelve `polylines` (una por tramo).
- **Migración 083** (✅ aplicada, verificada): `recorridos.polylines` + `aplicar_orden_ruta` las guarda.
- `utils/polyline.ts`: decoder propio (sin dependencia npm, +test contra el ejemplo canónico de Google). El mapa dibuja la **línea real sólida**; fallback recto punteado para recorridos viejos.
- La ven el transportista (`useRecorridoActivoQuery`) y el admin en Recorridos.

### 3. Look profesional
- Tiles **CARTO Voyager** (retina) en vez de OSM crudo (CSP actualizado).
- Jerarquía de markers: **activa 40px** con anillo pulsante, pendientes 28px, **completadas 20px verdes atenuadas**. La ruta real desamontona el centro.

### 4. GPS honesto
Gating de accuracy (>1000m = geolocalización por IP en desktop) y distancia absurda (>50km): **ya no aparece el falso "808 km"** ni se activa "Llegaste"; el punto azul solo con GPS confiable. El sheet se sube solo al detectar llegada.

### Navegación integrada
Confirmado el modelo de las apps de delivery: el mapa muestra la **ruta real + posición en vivo** dentro de la app, y "Navegar" hace handoff a Google Maps/Waze para el manejo con voz (turn-by-turn propio no es viable en PWA). El seguimiento del camión en vivo para el admin queda para el próximo PR.

## Test plan
- [x] Migraciones 082/083 y edge function v4 probadas en vivo (rollback): depósito set/get + gate, polylines guardadas, RPC sin polylines (compat)
- [x] Edge function devuelve `polylines` (verificado con request real)
- [x] Decoder testeado contra el ejemplo canónico de Google
- [x] typecheck, lint, build y suite completa (692 tests) en verde
- [ ] **Acción manual**: configurar el depósito de las sucursales **Taco Pozo (id 2 y 4)** desde el panel de optimización (quedaron NULL → usan el default hasta configurarlas)
- [ ] Manual post-deploy: optimizar → aplicar → el transportista y Recorridos ven la **ruta real** sobre las calles y la "D" correcta; en desktop no aparece "808 km"; tiles CARTO cargan (revisar consola por CSP)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
