### PR TITLE
Ruta del día (fase 1): el transportista lee del recorrido + armado con selección

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8774,10 +8774,20 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -11839,9 +11849,9 @@
       "license": "MIT"
     },
     "node_modules/tmp": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.6.tgz",
-      "integrity": "sha512-5sJPdPjfI5Kx+qbrDesxkglRBxW//g7hCsqspEjwkewGvBMGIKMOTKzLt1hFVJzyadba3lDUN20O9qhvbQUSTA==",
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
+      "integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==",
       "license": "MIT",
       "engines": {
         "node": ">=14.14"

--- a/src/components/AppModals.tsx
+++ b/src/components/AppModals.tsx
@@ -503,8 +503,7 @@ export default function AppModals({
             <ModalGestionRutas
               transportistas={transportistas}
               pedidos={pedidos}
-              onOptimizar={(transportistaId, pedidosData) => optimizarRuta(transportistaId, pedidosData)}
-              onAplicarOrden={handlers.handleAplicarOrdenOptimizado as any}
+              onArmarRuta={((transportistaId: string, pedidosData: PedidoDB[]) => optimizarRuta(transportistaId, pedidosData)) as any}
               onExportarPDF={handlers.handleExportarHojaRutaOptimizada as any}
               onClose={handlers.handleCerrarModalOptimizar}
               loading={loadingOptimizacion}

--- a/src/components/containers/PedidosContainer.tsx
+++ b/src/components/containers/PedidosContainer.tsx
@@ -1007,7 +1007,9 @@ export default function PedidosContainer(): React.ReactElement {
   // aplicar_orden_ruta, mig 081): actualiza pedidos.orden_entrega, cancela el
   // recorrido en_curso anterior del transportista y crea el nuevo con
   // distancia/duración. Un recorrido vigente por transportista por día.
-  const aplicarOrden = useCallback(async (data: { ordenOptimizado: Array<{ pedido_id: string; orden: number }>; transportistaId: string; distancia: number | null; duracion: number | null }) => {
+  // Las polylines se pasan por argumento (no se leen de rutaOptimizada del
+  // closure) para evitar usar un valor viejo cuando se encadena optimizar→aplicar.
+  const aplicarOrden = useCallback(async (data: { ordenOptimizado: Array<{ pedido_id: string; orden: number }>; transportistaId: string; distancia: number | null; duracion: number | null; polylines: string[] | null }) => {
     setGuardando(true)
     try {
       const { error } = await supabase.rpc('aplicar_orden_ruta', {
@@ -1017,22 +1019,22 @@ export default function PedidosContainer(): React.ReactElement {
         p_duracion: data.duracion != null ? Math.round(data.duracion) : null,
         // Ruta real sobre las calles (encoded polylines de Google) para
         // dibujarla en el mapa del transportista y del admin.
-        p_polylines: rutaOptimizada?.polylines ?? null
+        p_polylines: data.polylines ?? null
       })
       if (error) throw error
 
-      // Refresca lista paginada, query de asignados y recorridos (cachean
-      // orden_entrega y la ruta real)
+      // Refresca lista paginada, asignados, recorridos y la ruta del transportista
       queryClient.invalidateQueries({ queryKey: ['pedidos'] })
       queryClient.invalidateQueries({ queryKey: ['recorridos'] })
-      setModalOptimizarRutaOpen(false)
-      limpiarRuta()
-      notify.success('Ruta aplicada: orden de entrega y recorrido del día guardados')
-    } catch (e) { notify.error('Error al aplicar la ruta: ' + (e as Error).message) }
+      queryClient.invalidateQueries({ queryKey: ['recorrido-activo'] })
+      // No cerramos el modal: queda en la vista de resultado (confirmación +
+      // export PDF). El admin cierra con "Cerrar" (que limpia la ruta).
+      notify.success('Ruta del día armada y guardada')
+    } catch (e) { notify.error('Error al guardar la ruta: ' + (e as Error).message) }
     setGuardando(false)
-  }, [limpiarRuta, notify, queryClient, rutaOptimizada])
+  }, [notify, queryClient])
 
-  const handleAplicarOrden = useCallback(async (data: { ordenOptimizado: Array<{ pedido_id: string; orden: number }>; transportistaId: string; distancia: number | null; duracion: number | null }) => {
+  const handleAplicarOrden = useCallback(async (data: { ordenOptimizado: Array<{ pedido_id: string; orden: number }>; transportistaId: string; distancia: number | null; duracion: number | null; polylines: string[] | null }) => {
     if (!data.ordenOptimizado?.length || !data.transportistaId) return
     // Si ya hay un recorrido vigente hoy para este transportista, confirmar
     // el reemplazo (el anterior queda como 'cancelado' a modo de historial).
@@ -1061,6 +1063,26 @@ export default function PedidosContainer(): React.ReactElement {
     }
     await aplicarOrden(data)
   }, [aplicarOrden, transportistas])
+
+  // Armar ruta del día: optimiza los pedidos seleccionados y los guarda en un
+  // solo paso (sin botón "optimizar" separado). Las polylines del resultado se
+  // pasan explícitamente a aplicar (no se leen del estado, que aún no se
+  // actualizó en este tick).
+  const handleArmarRutaDelDia = useCallback(async (transportistaId: string, pedidosSeleccionados: PedidoDB[]) => {
+    if (!transportistaId || pedidosSeleccionados.length === 0) return
+    const ruta = await optimizarRutaConDeposito(transportistaId, pedidosSeleccionados)
+    if (!ruta?.orden_optimizado?.length) {
+      // optimizarRuta ya seteó errorOptimizacion / mostró el mensaje
+      return
+    }
+    await handleAplicarOrden({
+      ordenOptimizado: ruta.orden_optimizado as Array<{ pedido_id: string; orden: number }>,
+      transportistaId,
+      distancia: ruta.distancia_total ?? null,
+      duracion: ruta.duracion_total ?? null,
+      polylines: ruta.polylines ?? null,
+    })
+  }, [optimizarRutaConDeposito, handleAplicarOrden])
 
   const handleExportarHojaRutaOptimizada = useCallback(async (transportista: PerfilDB | undefined, pedidosOrdenados: PedidoDB[]) => {
     try {
@@ -1445,8 +1467,7 @@ export default function PedidosContainer(): React.ReactElement {
           <ModalGestionRutas
             transportistas={transportistas}
             pedidos={pedidosParaRuta}
-            onOptimizar={optimizarRutaConDeposito as Parameters<typeof ModalGestionRutas>[0]['onOptimizar']}
-            onAplicarOrden={handleAplicarOrden as Parameters<typeof ModalGestionRutas>[0]['onAplicarOrden']}
+            onArmarRuta={handleArmarRutaDelDia as Parameters<typeof ModalGestionRutas>[0]['onArmarRuta']}
             onExportarPDF={handleExportarHojaRutaOptimizada as Parameters<typeof ModalGestionRutas>[0]['onExportarPDF']}
             onClose={() => { setModalOptimizarRutaOpen(false); limpiarRuta() }}
             loading={loadingOptimizacion || loadingPedidosRuta}

--- a/src/components/modals/ModalGestionRutas.tsx
+++ b/src/components/modals/ModalGestionRutas.tsx
@@ -56,10 +56,14 @@ interface PedidoRutaCardProps {
 export interface ModalGestionRutasProps {
   transportistas: PerfilDB[];
   pedidos: PedidoDB[];
-  onOptimizar: (transportistaId: string, pedidos: PedidoDB[]) => void;
-  onAplicarOrden: (data: AplicarOrdenData) => void;
+  /**
+   * Arma la ruta del día: optimiza los pedidos seleccionados y la guarda en
+   * un solo paso (el container encadena optimizar + aplicar_orden_ruta).
+   */
+  onArmarRuta: (transportistaId: string, pedidos: PedidoDB[]) => void;
   onExportarPDF: (transportista: PerfilDB | undefined, pedidos: PedidoOrdenado[]) => void;
   onClose: () => void;
+  /** true mientras se optimiza/guarda la ruta del día */
   loading: boolean;
   guardando: boolean;
   rutaOptimizada: RutaOptimizadaResult | null;
@@ -170,8 +174,7 @@ const PedidoRutaCard = memo(function PedidoRutaCard({ pedido, orden, isFirst, is
 const ModalGestionRutas = memo(function ModalGestionRutas({
   transportistas,
   pedidos,
-  onOptimizar,
-  onAplicarOrden,
+  onArmarRuta,
   onExportarPDF,
   onClose,
   loading,
@@ -242,6 +245,30 @@ const ModalGestionRutas = memo(function ModalGestionRutas({
       .sort((a, b) => (a.orden_entrega || 999) - (b.orden_entrega || 999));
   }, [pedidosFiltrados, transportistaSeleccionado]);
 
+  // Selección de pedidos para la ruta del día (default: todos). El admin puede
+  // destildar los que no van hoy (ej: entregados-no-marcados de días previos).
+  const [seleccionados, setSeleccionados] = useState<Set<string>>(new Set());
+  useEffect(() => {
+    setSeleccionados(new Set(pedidosTransportista.map(p => p.id)));
+  }, [pedidosTransportista]);
+
+  const pedidosSeleccionados = useMemo(
+    () => pedidosTransportista.filter(p => seleccionados.has(p.id)),
+    [pedidosTransportista, seleccionados],
+  );
+
+  const toggleSeleccion = (id: string): void => {
+    setSeleccionados(prev => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id); else next.add(id);
+      return next;
+    });
+  };
+  const todosSeleccionados = pedidosTransportista.length > 0 && seleccionados.size === pedidosTransportista.length;
+  const toggleTodos = (): void => {
+    setSeleccionados(todosSeleccionados ? new Set() : new Set(pedidosTransportista.map(p => p.id)));
+  };
+
   // Cuántos pedidos del transportista quedaron afuera por el filtro de fecha
   const pedidosExcluidosPorFecha = useMemo((): number => {
     if (!transportistaSeleccionado || !filtroActivo) return 0;
@@ -307,11 +334,10 @@ const ModalGestionRutas = memo(function ModalGestionRutas({
     };
   }, [vistaActiva, pedidosOrdenados, pedidosTransportista]);
 
-  const handleOptimizar = (): void => {
-    if (transportistaSeleccionado) {
-      // Solo los pedidos que pasaron el filtro de fecha: la optimización debe
-      // respetar lo que el admin ve en el panel.
-      onOptimizar(transportistaSeleccionado, pedidosTransportista);
+  const handleArmar = (): void => {
+    if (transportistaSeleccionado && pedidosSeleccionados.length > 0) {
+      // Optimiza + guarda en un paso, solo con los pedidos seleccionados.
+      onArmarRuta(transportistaSeleccionado, pedidosSeleccionados);
     }
   };
 
@@ -328,17 +354,6 @@ const ModalGestionRutas = memo(function ModalGestionRutas({
     }
   };
 
-  const handleAplicar = (): void => {
-    if (rutaOptimizada?.orden_optimizado) {
-      onAplicarOrden({
-        ordenOptimizado: rutaOptimizada.orden_optimizado,
-        transportistaId: transportistaSeleccionado,
-        distancia: rutaOptimizada.distancia_total ?? null,
-        duracion: rutaOptimizada.duracion_total ?? null
-      });
-    }
-  };
-
   const handleExportarPDF = (): void => {
     const transportista = transportistas.find(t => t.id === transportistaSeleccionado);
     onExportarPDF(transportista, pedidosOrdenados);
@@ -351,7 +366,7 @@ const ModalGestionRutas = memo(function ModalGestionRutas({
   const transportistaInfo = transportistas.find(t => t.id === transportistaSeleccionado);
 
   return (
-    <ModalBase title="Gestion de Rutas de Entrega" onClose={onClose} maxWidth="max-w-4xl">
+    <ModalBase title="Armar ruta del día" onClose={onClose} maxWidth="max-w-4xl">
       <div className="flex flex-col h-[75vh]">
         {/* Tabs de navegacion */}
         <div className="flex border-b bg-gray-50 px-4">
@@ -364,7 +379,7 @@ const ModalGestionRutas = memo(function ModalGestionRutas({
             }`}
           >
             <Route className="w-4 h-4 inline mr-2" />
-            Optimizar Ruta
+            Armar ruta
           </button>
           <button
             onClick={() => rutaOptimizada?.orden_optimizado && setVistaActiva('resultado')}
@@ -376,7 +391,7 @@ const ModalGestionRutas = memo(function ModalGestionRutas({
             }`}
           >
             <CheckCircle className="w-4 h-4 inline mr-2" />
-            Ruta Optimizada
+            Ruta guardada
             {rutaOptimizada?.orden_optimizado && (
               <span className="ml-2 px-2 py-0.5 bg-green-100 text-green-700 text-xs rounded-full">
                 {rutaOptimizada.orden_optimizado.length}
@@ -583,42 +598,53 @@ const ModalGestionRutas = memo(function ModalGestionRutas({
                     </div>
                   )}
 
-                  {/* Lista de pedidos actuales */}
+                  {/* Lista de pedidos: el admin elige cuáles entran en la ruta del día */}
                   {pedidosTransportista.length > 0 && (
                     <div className="bg-white border rounded-lg">
-                      <div className="p-3 border-b bg-gray-50">
-                        <h3 className="font-medium text-gray-700">Pedidos asignados (orden actual)</h3>
+                      <div className="p-3 border-b bg-gray-50 flex items-center justify-between">
+                        <h3 className="font-medium text-gray-700">
+                          Pedidos del día ({pedidosSeleccionados.length}/{pedidosTransportista.length})
+                        </h3>
+                        <label className="flex items-center gap-2 text-sm text-gray-600 cursor-pointer select-none">
+                          <input type="checkbox" checked={todosSeleccionados} onChange={toggleTodos} className="rounded" />
+                          Seleccionar todos
+                        </label>
                       </div>
                       <div className="max-h-60 overflow-y-auto divide-y">
-                        {pedidosTransportista.map((pedido) => (
-                          <div key={pedido.id} className="flex items-center p-3 hover:bg-gray-50">
-                            <div className="flex items-center justify-center w-8 h-8 rounded-full bg-gray-100 mr-3">
-                              {pedido.orden_entrega ? (
-                                <span className="text-sm font-bold text-blue-600">{pedido.orden_entrega}</span>
-                              ) : (
-                                <span className="text-xs text-gray-400">-</span>
-                              )}
-                            </div>
-                            <div className="flex-1 min-w-0">
-                              <p className="font-medium text-gray-900 truncate">
-                                #{pedido.id} - {pedido.cliente?.nombre_fantasia}
-                              </p>
-                              <p className="text-sm text-gray-500 truncate">{pedido.cliente?.direccion}</p>
-                              <p className="text-xs text-gray-400">
-                                Pedido: {pedido.fecha || '—'}
-                                {pedido.fecha_asignacion ? ` · Asignado: ${pedido.fecha_asignacion}` : ''}
-                              </p>
-                            </div>
-                            <div className="text-right ml-2">
-                              <p className="font-medium text-gray-900">${pedido.total?.toLocaleString('es-AR')}</p>
-                              {pedido.cliente?.latitud && pedido.cliente?.longitud ? (
-                                <MapPin className="w-4 h-4 text-green-500 inline" />
-                              ) : (
-                                <MapPin className="w-4 h-4 text-gray-300 inline" />
-                              )}
-                            </div>
-                          </div>
-                        ))}
+                        {pedidosTransportista.map((pedido) => {
+                          const checked = seleccionados.has(pedido.id);
+                          return (
+                            <label
+                              key={pedido.id}
+                              className={`flex items-center p-3 cursor-pointer ${checked ? 'hover:bg-gray-50' : 'bg-gray-50/60 opacity-60 hover:opacity-100'}`}
+                            >
+                              <input
+                                type="checkbox"
+                                checked={checked}
+                                onChange={() => toggleSeleccion(pedido.id)}
+                                className="rounded mr-3"
+                              />
+                              <div className="flex-1 min-w-0">
+                                <p className="font-medium text-gray-900 truncate">
+                                  #{pedido.id} - {pedido.cliente?.nombre_fantasia}
+                                </p>
+                                <p className="text-sm text-gray-500 truncate">{pedido.cliente?.direccion}</p>
+                                <p className="text-xs text-gray-400">
+                                  Pedido: {pedido.fecha || '—'}
+                                  {pedido.fecha_asignacion ? ` · Asignado: ${pedido.fecha_asignacion}` : ''}
+                                </p>
+                              </div>
+                              <div className="text-right ml-2">
+                                <p className="font-medium text-gray-900">${pedido.total?.toLocaleString('es-AR')}</p>
+                                {pedido.cliente?.latitud && pedido.cliente?.longitud ? (
+                                  <MapPin className="w-4 h-4 text-green-500 inline" />
+                                ) : (
+                                  <MapPin className="w-4 h-4 text-gray-300 inline" />
+                                )}
+                              </div>
+                            </label>
+                          );
+                        })}
                       </div>
                     </div>
                   )}
@@ -646,7 +672,7 @@ const ModalGestionRutas = memo(function ModalGestionRutas({
                       <Route className="w-6 h-6" />
                     </div>
                     <div>
-                      <h3 className="font-semibold text-lg">Ruta Optimizada</h3>
+                      <h3 className="font-semibold text-lg">Ruta del día guardada</h3>
                       <p className="text-green-100 text-sm">{transportistaInfo?.nombre}</p>
                     </div>
                   </div>
@@ -756,40 +782,27 @@ const ModalGestionRutas = memo(function ModalGestionRutas({
           <div className="flex space-x-3">
             {vistaActiva === 'optimizar' ? (
               <button
-                onClick={handleOptimizar}
-                disabled={!transportistaSeleccionado || loading || pedidosTransportista.length === 0}
+                onClick={handleArmar}
+                disabled={!transportistaSeleccionado || loading || guardando || pedidosSeleccionados.length === 0}
                 className="flex items-center space-x-2 px-5 py-2.5 bg-blue-600 text-white rounded-lg hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
               >
-                {loading ? (
+                {(loading || guardando) ? (
                   <Loader2 className="w-5 h-5 animate-spin" />
                 ) : (
                   <Route className="w-5 h-5" />
                 )}
-                <span>{loading ? 'Calculando ruta...' : 'Optimizar Ruta'}</span>
+                <span>
+                  {loading ? 'Optimizando…' : guardando ? 'Guardando…' : `Armar ruta del día (${pedidosSeleccionados.length})`}
+                </span>
               </button>
             ) : (
-              <>
-                <button
-                  onClick={handleExportarPDF}
-                  disabled={guardando}
-                  className="flex items-center space-x-2 px-4 py-2.5 bg-gray-600 text-white rounded-lg hover:bg-gray-700 disabled:opacity-50 transition-colors"
-                >
-                  <Printer className="w-5 h-5" />
-                  <span>Exportar PDF</span>
-                </button>
-                <button
-                  onClick={handleAplicar}
-                  disabled={guardando}
-                  className="flex items-center space-x-2 px-5 py-2.5 bg-green-600 text-white rounded-lg hover:bg-green-700 disabled:opacity-50 transition-colors"
-                >
-                  {guardando ? (
-                    <Loader2 className="w-5 h-5 animate-spin" />
-                  ) : (
-                    <Check className="w-5 h-5" />
-                  )}
-                  <span>{guardando ? 'Guardando...' : 'Aplicar Orden'}</span>
-                </button>
-              </>
+              <button
+                onClick={handleExportarPDF}
+                className="flex items-center space-x-2 px-4 py-2.5 bg-gray-600 text-white rounded-lg hover:bg-gray-700 transition-colors"
+              >
+                <Printer className="w-5 h-5" />
+                <span>Exportar PDF</span>
+              </button>
             )}
           </div>
         </div>

--- a/src/components/pedidos/PedidoToolbar.tsx
+++ b/src/components/pedidos/PedidoToolbar.tsx
@@ -280,7 +280,7 @@ export default function PedidoToolbar({
               mobileLabel="Ruta"
               onClick={onOptimizarRuta}
             >
-              Optimizar Ruta
+              Armar ruta del día
             </ToolbarButton>
           </div>
         )}
@@ -327,7 +327,7 @@ export default function PedidoToolbar({
               mobileLabel="Ruta"
               onClick={onOptimizarRuta}
             >
-              Optimizar Ruta
+              Armar ruta del día
             </ToolbarButton>
           </>
         )}

--- a/src/components/rutaActiva/RutaActivaTransportista.tsx
+++ b/src/components/rutaActiva/RutaActivaTransportista.tsx
@@ -23,7 +23,7 @@ import { useEntregaParada, type PedidoConCliente, type DatosPago, type DatosSalv
 import SheetParada, { type LinkRutaMaps } from './SheetParada';
 import ModalSalvedadItem from '../modals/ModalSalvedadItem';
 import ModalRegistrarPago from '../modals/ModalRegistrarPago';
-import type { PedidoDB, ClienteDB, ProductoDB, RegistrarSalvedadResult } from '../../types';
+import type { PedidoDB, RegistrarSalvedadResult } from '../../types';
 
 const MapaRuta = lazy(() => import('../MapaRuta'));
 
@@ -35,22 +35,16 @@ const ACCURACY_MAX_M = 1000;
 const DISTANCIA_ABSURDA_M = 50_000;
 
 export interface RutaActivaTransportistaProps {
-  pedidos: PedidoDB[] | null;
   onMarcarEntregado: (pedido: PedidoDB) => void;
   userId: string;
-  clientes: ClienteDB[];
-  productos: ProductoDB[];
   onRegistrarSalvedad?: (data: DatosSalvedad) => Promise<RegistrarSalvedadResult>;
   onRegistrarPago?: (data: DatosPago) => Promise<unknown>;
   onEntregarSinCobrar?: (pedido: PedidoDB) => void | Promise<void>;
 }
 
 export default function RutaActivaTransportista({
-  pedidos,
   onMarcarEntregado,
   userId,
-  clientes,
-  productos,
   onRegistrarSalvedad,
   onRegistrarPago,
   onEntregarSinCobrar,
@@ -58,8 +52,10 @@ export default function RutaActivaTransportista({
   const { isOnline } = useAuthData();
   const deposito = useDepositoCoords();
   const { posicion } = useWatchPosition(true);
-  // Ruta real sobre las calles (polylines guardadas al aplicar el orden)
-  const { data: recorridoActivo } = useRecorridoActivoQuery(userId);
+  // Ruta del día: el transportista lee del recorrido en_curso (las paradas que
+  // armó el admin), NO de "todos sus pedidos asignados". Trae también la ruta
+  // real (polylines) para dibujarla.
+  const { data: recorridoActivo, isLoading: cargandoRuta } = useRecorridoActivoQuery(userId);
   const rutaReal = useMemo(
     () => decodePolylines(recorridoActivo?.polylines),
     [recorridoActivo?.polylines],
@@ -75,23 +71,11 @@ export default function RutaActivaTransportista({
     onRegistrarSalvedad,
   });
 
-  // Enriquecer pedidos con cliente y productos (mismo criterio que la vista anterior)
-  const pedidosOrdenados = useMemo<PedidoConCliente[]>(() => {
-    if (!pedidos) return [];
-    return pedidos
-      .filter(p => (p.estado === 'asignado' || p.estado === 'entregado') && p.transportista_id === userId)
-      .map(pedido => {
-        const cliente = (pedido.cliente_id && clientes.find(c => c.id === pedido.cliente_id))
-          || (pedido.cliente?.nombre_fantasia ? pedido.cliente : undefined);
-        const items = (pedido.items || []).map(item => ({
-          ...item,
-          producto: (item.producto_id && productos.find(pr => pr.id === item.producto_id))
-            || item.producto || undefined,
-        }));
-        return { ...pedido, cliente, items } as PedidoConCliente;
-      })
-      .sort((a, b) => (a.orden_entrega || 999) - (b.orden_entrega || 999));
-  }, [pedidos, clientes, productos, userId]);
+  // Paradas de la ruta del día (ya vienen ordenadas y enriquecidas del recorrido)
+  const pedidosOrdenados = useMemo<PedidoConCliente[]>(
+    () => recorridoActivo?.paradas ?? [],
+    [recorridoActivo?.paradas],
+  );
 
   const pendientes = useMemo(
     () => pedidosOrdenados.filter(p => p.estado === 'asignado'),
@@ -181,11 +165,21 @@ export default function RutaActivaTransportista({
   };
 
   if (pedidosOrdenados.length === 0) {
+    // Distinguir "todavía no hay ruta armada" de "ruta cargando".
+    const sinRuta = !cargandoRuta && recorridoActivo == null;
     return (
       <div className="text-center py-12">
         <Truck className="w-16 h-16 mx-auto text-gray-300 dark:text-gray-600 mb-4" />
-        <h3 className="text-xl font-semibold text-gray-600 dark:text-gray-400 mb-2">Sin entregas asignadas</h3>
-        <p className="text-gray-500 dark:text-gray-500">No tienes entregas pendientes por el momento</p>
+        <h3 className="text-xl font-semibold text-gray-600 dark:text-gray-400 mb-2">
+          {cargandoRuta ? 'Cargando tu ruta…' : sinRuta ? 'Todavía no tenés ruta para hoy' : 'Ruta sin paradas'}
+        </h3>
+        <p className="text-gray-500 dark:text-gray-500">
+          {cargandoRuta
+            ? 'Un momento'
+            : sinRuta
+              ? 'El administrador todavía no armó tu ruta del día. Cuando la arme, va a aparecer acá.'
+              : 'Tu ruta de hoy no tiene paradas cargadas.'}
+        </p>
       </div>
     );
   }

--- a/src/components/vistas/VistaPedidos.tsx
+++ b/src/components/vistas/VistaPedidos.tsx
@@ -117,8 +117,6 @@ export default function VistaPedidos({
   isEncargado,
   isPreventistaTaco,
   userId,
-  clientes,
-  productos,
   transportistas = [],
   usuarios = [],
   loading,
@@ -156,11 +154,8 @@ export default function VistaPedidos({
   if (isTransportista && !isAdmin && !isPreventista) {
     return (
       <RutaActivaTransportista
-        pedidos={pedidos}
         onMarcarEntregado={onMarcarEntregado}
         userId={userId}
-        clientes={clientes}
-        productos={productos}
         onRegistrarSalvedad={onRegistrarSalvedad}
         onRegistrarPago={onRegistrarPago}
         onEntregarSinCobrar={onEntregarSinCobrar}

--- a/src/hooks/queries/usePedidosQuery.ts
+++ b/src/hooks/queries/usePedidosQuery.ts
@@ -586,6 +586,10 @@ export function useCambiarEstadoMutation() {
     },
     onSettled: () => {
       queryClient.invalidateQueries({ queryKey: pedidosKeys.all(currentSucursalId) })
+      // La ruta del día del transportista lee pedido.estado vía el recorrido;
+      // al marcar entregado hay que refrescarla para que avance la parada.
+      queryClient.invalidateQueries({ queryKey: ['recorrido-activo'] })
+      queryClient.invalidateQueries({ queryKey: ['recorridos'] })
     },
   })
 }

--- a/src/hooks/queries/useRecorridoActivoQuery.ts
+++ b/src/hooks/queries/useRecorridoActivoQuery.ts
@@ -1,20 +1,25 @@
 /**
- * Recorrido vigente (en_curso) de hoy del transportista logueado.
+ * Recorrido vigente (en_curso) de hoy del transportista logueado, CON sus
+ * paradas. Es la "ruta del día" que arma el admin: el transportista lee de
+ * acá, NO de "todos sus pedidos asignados" (que colaba entregados-no-marcados
+ * de días previos).
  *
- * Lo usa la pantalla Ruta Activa SOLO para obtener las `polylines` (la ruta
- * real sobre las calles que guardó el admin al aplicar el orden) y dibujarla.
- * Las paradas y el flujo de entrega NO dependen de esto: se arman desde
- * `pedidos.orden_entrega`. Si no hay recorrido (o es viejo sin polyline), el
- * mapa cae al trazado recto — degradado seguro.
+ * El embedding PostgREST funciona con las RLS existentes: el transportista ve
+ * su recorrido (transportista_id = auth.uid()), sus recorrido_pedidos (vía el
+ * recorrido propio), sus pedidos (transportista_id = auth.uid()), los items de
+ * esos pedidos y los clientes/productos de su sucursal. Sin RPC.
  */
 import { useQuery } from '@tanstack/react-query'
 import { supabase } from '../supabase/base'
 import { useSucursal } from '../../contexts/SucursalContext'
 import { fechaLocalISO } from '../../utils/formatters'
+import type { PedidoConCliente } from '../../components/rutaActiva/useEntregaParada'
 
 export interface RecorridoActivo {
   id: string
   polylines: string[] | null
+  /** Paradas de la ruta del día, ordenadas por orden_entrega, enriquecidas. */
+  paradas: PedidoConCliente[]
 }
 
 export const recorridoActivoKeys = {
@@ -22,10 +27,27 @@ export const recorridoActivoKeys = {
     ['recorrido-activo', sucursalId, transportistaId] as const,
 }
 
+// Embedding: recorrido → paradas (recorrido_pedidos) → pedido → cliente/items.
+const RECORRIDO_ACTIVO_SELECT = `id, polylines,
+  recorrido_pedidos(
+    orden_entrega, estado_entrega, hora_entrega,
+    pedido:pedidos(
+      *,
+      cliente:clientes(id, nombre_fantasia, razon_social, direccion, aclaracion_direccion, telefono, contacto, latitud, longitud, horarios_atencion),
+      items:pedido_items(*, producto:productos(id, nombre, codigo, etiqueta_bulto, unidades_de_venta_por_fardo))
+    )
+  )`
+
+interface RecorridoPedidoRaw {
+  orden_entrega: number | null
+  estado_entrega: string | null
+  pedido: (Record<string, unknown> & { orden_entrega?: number | null }) | null
+}
+
 async function fetchRecorridoActivo(transportistaId: string): Promise<RecorridoActivo | null> {
   const { data, error } = await supabase
     .from('recorridos')
-    .select('id, polylines')
+    .select(RECORRIDO_ACTIVO_SELECT)
     .eq('transportista_id', transportistaId)
     .eq('fecha', fechaLocalISO())
     .eq('estado', 'en_curso')
@@ -35,7 +57,22 @@ async function fetchRecorridoActivo(transportistaId: string): Promise<RecorridoA
 
   if (error) throw error
   if (!data) return null
-  return { id: String(data.id), polylines: (data.polylines as string[] | null) ?? null }
+
+  const rps = ((data.recorrido_pedidos as unknown as RecorridoPedidoRaw[]) || [])
+    .filter(rp => rp.pedido != null)
+    // El orden de entrega del recorrido es la fuente de verdad
+    .sort((a, b) => (a.orden_entrega ?? 999) - (b.orden_entrega ?? 999))
+
+  const paradas = rps.map(rp => ({
+    ...(rp.pedido as object),
+    orden_entrega: rp.orden_entrega ?? rp.pedido?.orden_entrega ?? null,
+  })) as unknown as PedidoConCliente[]
+
+  return {
+    id: String(data.id),
+    polylines: (data.polylines as string[] | null) ?? null,
+    paradas,
+  }
 }
 
 export function useRecorridoActivoQuery(transportistaId: string | null | undefined) {
@@ -44,6 +81,6 @@ export function useRecorridoActivoQuery(transportistaId: string | null | undefin
     queryKey: recorridoActivoKeys.all(currentSucursalId, transportistaId ?? null),
     queryFn: () => fetchRecorridoActivo(transportistaId as string),
     enabled: !!transportistaId,
-    staleTime: 2 * 60 * 1000,
+    staleTime: 60 * 1000,
   })
 }


### PR DESCRIPTION
## Resumen — Fase 1 de 3: flujo "Ruta del día"

Rediseño del flujo de rutas tras el feedback (ruta mal optimizada, mala reactividad, flujo confuso). Esta fase resuelve **el flujo** y el bug de raíz de que el transportista veía pedidos que no correspondían.

**Decisiones tomadas (las 3 fases):** Ruta del día con selección · optimización para 40+ con Route Optimization API · UI con Google Maps integrado. Fases 2 y 3 van en PRs siguientes.

### El problema que cierra esta fase
El transportista leía **"todos sus pedidos en estado `asignado`"** → se colaban los entregados-no-marcados de días previos, y la ruta no era la que armó el admin.

### Admin — "Armar ruta del día"
- El modal (antes "Optimizar Ruta") ahora tiene **checkbox por pedido** (default: todos los del transportista de la fecha) + "seleccionar todos": el admin **elige qué pedidos entrega ese día**.
- **Un solo botón "Armar ruta del día"**: optimiza y guarda en un paso (se eliminó el paso manual Optimizar→Aplicar). Si ya hay ruta hoy, pide confirmación de reemplazo. Tras guardar muestra la ruta como confirmación con export PDF.
- Toolbar: el botón pasó a llamarse "Armar ruta del día".

### Transportista — lee del recorrido
- `useRecorridoActivoQuery` ahora trae **las paradas** del recorrido en_curso de hoy (embedding `recorrido_pedidos → pedidos → cliente/items`; las RLS ya permiten al transportista leer lo suyo, sin RPC nueva).
- La pantalla deriva las paradas del recorrido (no de "todos los asignados"). Estados vacíos claros ("todavía no tenés ruta para hoy").
- Al marcar entregado se refresca la ruta (avanza la parada).

Sin migración nueva (reusa `aplicar_orden_ruta` y las RLS existentes). El flujo de entrega/cobro/salvedad no cambia.

### Limitación conocida (se aborda en fase 2)
Los pedidos cuyo cliente **no tiene coordenadas** se excluyen de la ruta (el modal ya lo advierte). Se resuelve al migrar a Route Optimization API.

## Test plan
- [x] typecheck, lint, build y suite completa (692 tests) en verde
- [x] RLS verificadas en prod: el transportista puede leer su recorrido + pedidos + items + clientes
- [ ] Manual: admin arma ruta seleccionando un subconjunto → el transportista ve EXACTAMENTE esas paradas; un pedido viejo asignado no incluido ya no aparece; marcar entregado avanza la parada

🤖 Generated with [Claude Code](https://claude.com/claude-code)
