### PR TITLE
fix(pagos): pago combinado imputa por FIFO + saldo a favor neto

### DIFF
--- a/migrations/085_registrar_pago_combinado_cliente_fifo.sql
+++ b/migrations/085_registrar_pago_combinado_cliente_fifo.sql
@@ -1,0 +1,191 @@
+-- ============================================================================
+-- 085 — RPC registrar_pago_combinado_cliente_fifo
+-- ============================================================================
+-- Variante combinada (pago dividido / multiples formas de pago) de
+-- registrar_pago_cliente_fifo (migracion 051).
+--
+-- Problema que resuelve: el "pago dividido" desde la ficha de cliente se
+-- registraba con un loop en el frontend que insertaba filas en pagos con
+-- pedido_id = NULL (cuenta general). El trigger recalcular_monto_pagado_pedido
+-- (035) ignora filas con pedido_id NULL, asi que el pago no se imputaba a
+-- ningun pedido y el saldo_cuenta del cliente nunca bajaba.
+--
+-- Esta RPC recibe varias formas de pago y, en UNA sola transaccion (atomico),
+-- imputa cada una por FIFO sobre los pedidos pendientes mas antiguos. El
+-- sobrante de cada metodo queda como saldo a favor (fila con pedido_id NULL).
+-- Como cada INSERT dispara el trigger que recalcula pedidos.monto_pagado, el
+-- metodo siguiente ya ve el saldo pendiente actualizado.
+--
+-- RBAC y gating identicos a registrar_pago_cliente_fifo:
+--   - solo admin o encargado
+--   - encargado: p_fecha = hoy y sin rendicion cerrada para (fecha, sucursal)
+--
+-- Reusa la misma cascada de triggers (035 en pagos, estado_pago/saldo en
+-- pedidos), por eso solo hace inserts.
+--
+-- p_metodos: jsonb array, p.ej.
+--   [{"monto": 98600, "forma_pago": "efectivo"},
+--    {"monto": 25000, "forma_pago": "transferencia"}]
+-- ============================================================================
+
+BEGIN;
+
+CREATE OR REPLACE FUNCTION public.registrar_pago_combinado_cliente_fifo(
+  p_cliente_id bigint,
+  p_metodos jsonb,
+  p_fecha date DEFAULT CURRENT_DATE,
+  p_referencia text DEFAULT NULL,
+  p_notas text DEFAULT NULL
+) RETURNS jsonb
+LANGUAGE plpgsql SECURITY DEFINER SET search_path TO 'public'
+AS $$
+DECLARE
+  v_sucursal_id bigint := current_sucursal_id();
+  v_acting_user uuid := auth.uid();
+  v_rol text;
+  v_metodo jsonb;
+  v_forma text;
+  v_monto numeric;
+  v_restante numeric;
+  v_aplicar numeric;
+  v_pedido record;
+  v_pago_id bigint;
+  v_pago_ids jsonb := '[]'::jsonb;
+  v_aplicaciones jsonb := '[]'::jsonb;
+  v_monto_total numeric := 0;
+  v_sobrante_total numeric := 0;
+  v_notas_imputado text;
+BEGIN
+  IF v_sucursal_id IS NULL THEN
+    RAISE EXCEPTION 'No hay sucursal activa' USING ERRCODE = '42501';
+  END IF;
+
+  -- p_metodos debe ser un array no vacio
+  IF p_metodos IS NULL OR jsonb_typeof(p_metodos) <> 'array' OR jsonb_array_length(p_metodos) = 0 THEN
+    RAISE EXCEPTION 'Debe enviar al menos una forma de pago' USING ERRCODE = '22023';
+  END IF;
+
+  -- RBAC: solo admin o encargado
+  SELECT rol INTO v_rol FROM perfiles WHERE id = v_acting_user;
+  IF v_rol IS NULL OR v_rol NOT IN ('admin', 'encargado') THEN
+    RAISE EXCEPTION 'No autorizado: solo admin o encargado pueden registrar pagos desde ficha de cliente'
+      USING ERRCODE = '42501';
+  END IF;
+
+  IF v_rol = 'encargado' THEN
+    IF p_fecha <> CURRENT_DATE THEN
+      RAISE EXCEPTION 'Encargado solo puede registrar pagos con fecha de hoy'
+        USING ERRCODE = '42501';
+    END IF;
+    IF public.rendicion_dia_cerrada(p_fecha, v_sucursal_id) THEN
+      RAISE EXCEPTION 'Rendicion ya cerrada para esta fecha. Pedi a un admin.'
+        USING ERRCODE = '42501';
+    END IF;
+  END IF;
+
+  -- Validar cada metodo y acumular el total
+  FOR v_metodo IN SELECT * FROM jsonb_array_elements(p_metodos) LOOP
+    v_monto := NULLIF(v_metodo->>'monto', '')::numeric;
+    v_forma := v_metodo->>'forma_pago';
+    IF v_monto IS NULL OR v_monto <= 0 THEN
+      RAISE EXCEPTION 'Cada forma de pago debe tener un monto mayor a 0' USING ERRCODE = '22023';
+    END IF;
+    IF v_forma IS NULL OR length(trim(v_forma)) = 0 THEN
+      RAISE EXCEPTION 'Forma de pago obligatoria' USING ERRCODE = '22023';
+    END IF;
+    v_monto_total := v_monto_total + v_monto;
+  END LOOP;
+
+  -- Nota base para filas imputadas: marca el pago como combinado (reportes/rendicion)
+  v_notas_imputado := NULLIF(trim(COALESCE(p_notas, '') || ' [pago combinado]'), '');
+
+  -- Imputacion FIFO por metodo, secuencial dentro de la misma transaccion.
+  FOR v_metodo IN SELECT * FROM jsonb_array_elements(p_metodos) LOOP
+    v_monto := (v_metodo->>'monto')::numeric;
+    v_forma := trim(v_metodo->>'forma_pago');
+    v_restante := v_monto;
+
+    -- FIFO: pedidos con saldo pendiente, mas antiguos primero.
+    -- Se re-consulta por metodo para ver el monto_pagado actualizado por el
+    -- metodo anterior (trigger 035).
+    FOR v_pedido IN
+      SELECT id, total, COALESCE(monto_pagado, 0) AS pagado, fecha
+      FROM pedidos
+      WHERE cliente_id = p_cliente_id
+        AND sucursal_id = v_sucursal_id
+        AND estado <> 'cancelado'
+        AND COALESCE(estado_pago, 'pendiente') <> 'pagado'
+        AND total > COALESCE(monto_pagado, 0)
+      ORDER BY fecha ASC, id ASC
+    LOOP
+      EXIT WHEN v_restante <= 0;
+      v_aplicar := LEAST(v_restante, v_pedido.total - v_pedido.pagado);
+
+      INSERT INTO pagos (
+        cliente_id, pedido_id, monto, forma_pago, fecha,
+        referencia, notas, usuario_id, sucursal_id
+      )
+      VALUES (
+        p_cliente_id, v_pedido.id, v_aplicar, v_forma, p_fecha,
+        p_referencia, v_notas_imputado, v_acting_user, v_sucursal_id
+      )
+      RETURNING id INTO v_pago_id;
+
+      v_pago_ids := v_pago_ids || to_jsonb(v_pago_id);
+      v_aplicaciones := v_aplicaciones || jsonb_build_object(
+        'pago_id', v_pago_id,
+        'pedido_id', v_pedido.id,
+        'pedido_fecha', v_pedido.fecha,
+        'forma_pago', v_forma,
+        'monto', v_aplicar
+      );
+
+      v_restante := v_restante - v_aplicar;
+    END LOOP;
+
+    -- Sobrante de este metodo: queda como saldo a favor (pedido_id NULL)
+    IF v_restante > 0 THEN
+      INSERT INTO pagos (
+        cliente_id, pedido_id, monto, forma_pago, fecha,
+        referencia, notas, usuario_id, sucursal_id
+      )
+      VALUES (
+        p_cliente_id, NULL, v_restante, v_forma, p_fecha,
+        p_referencia,
+        trim(COALESCE(p_notas, '') || ' [pago combinado] [saldo a favor]'),
+        v_acting_user, v_sucursal_id
+      )
+      RETURNING id INTO v_pago_id;
+
+      v_pago_ids := v_pago_ids || to_jsonb(v_pago_id);
+      v_aplicaciones := v_aplicaciones || jsonb_build_object(
+        'pago_id', v_pago_id,
+        'pedido_id', NULL,
+        'forma_pago', v_forma,
+        'monto', v_restante,
+        'saldo_a_favor', true
+      );
+
+      v_sobrante_total := v_sobrante_total + v_restante;
+    END IF;
+  END LOOP;
+
+  RETURN jsonb_build_object(
+    'success', true,
+    'monto_total', v_monto_total,
+    'sobrante', v_sobrante_total,
+    'pago_ids', v_pago_ids,
+    'aplicaciones', v_aplicaciones
+  );
+END;
+$$;
+
+ALTER FUNCTION public.registrar_pago_combinado_cliente_fifo(bigint, jsonb, date, text, text) OWNER TO postgres;
+
+COMMENT ON FUNCTION public.registrar_pago_combinado_cliente_fifo(bigint, jsonb, date, text, text) IS
+  'Pago combinado (varias formas de pago) desde ficha de cliente. Imputa cada forma por FIFO sobre los pedidos mas antiguos con saldo pendiente, en una sola transaccion. Sobrante por metodo queda como saldo a favor (pedido_id NULL). Mismo RBAC que registrar_pago_cliente_fifo.';
+
+GRANT EXECUTE ON FUNCTION public.registrar_pago_combinado_cliente_fifo(bigint, jsonb, date, text, text)
+  TO authenticated, service_role;
+
+COMMIT;

--- a/migrations/086_saldo_a_favor_reduce_saldo_cuenta.sql
+++ b/migrations/086_saldo_a_favor_reduce_saldo_cuenta.sql
@@ -1,0 +1,104 @@
+-- ============================================================================
+-- 086 — Saldo a favor reduce clientes.saldo_cuenta (modelo de saldo neto)
+-- ============================================================================
+-- Hasta ahora, un pago sin pedido (pedido_id NULL) — el "saldo a favor" que
+-- deja FIFO al sobrar — NO afectaba `clientes.saldo_cuenta` (el trigger
+-- `actualizar_saldo_cliente` estaba neutralizado). El crédito quedaba invisible:
+-- el cliente había pagado de más pero el saldo seguía mostrando lo que "debía".
+--
+-- Este cambio reactiva ese trigger para que los pagos SIN pedido resten el
+-- saldo (quedan como saldo negativo = crédito a favor). Así el crédito se netea
+-- solo contra próximos pedidos: al crear un pedido, `actualizar_saldo_pedido`
+-- sube el saldo, y el crédito ya está restado.
+--
+-- Invariante resultante:
+--   saldo_cuenta = Σ(pedidos no cancelados: total - monto_pagado)   [trigger pedidos]
+--                - Σ(pagos con pedido_id NULL: monto)                [este trigger]
+--   ≡ compras_no_canceladas - pagos_totales
+--
+-- Sin doble conteo: los pagos CON pedido los maneja la cascada de pedidos
+-- (recalcular_monto_pagado_pedido → actualizar_saldo_pedido); este trigger solo
+-- toca los pagos SIN pedido. Las transiciones (imputar un crédito a un pedido =
+-- UPDATE pedido_id NULL→valor) se compensan exactamente entre ambos triggers.
+-- ============================================================================
+
+BEGIN;
+
+CREATE OR REPLACE FUNCTION public.actualizar_saldo_cliente()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $function$
+DECLARE
+  -- Contribución de un pago al saldo: solo los pagos SIN pedido (créditos a
+  -- favor) afectan saldo_cuenta acá, y lo RESTAN (contrib negativa). Los pagos
+  -- CON pedido contribuyen 0 (los maneja la cascada de pedidos).
+  contrib_old numeric;
+  contrib_new numeric;
+BEGIN
+  IF TG_OP = 'INSERT' THEN
+    IF NEW.pedido_id IS NULL THEN
+      UPDATE clientes SET saldo_cuenta = COALESCE(saldo_cuenta, 0) - NEW.monto
+       WHERE id = NEW.cliente_id;
+    END IF;
+    RETURN NEW;
+
+  ELSIF TG_OP = 'DELETE' THEN
+    IF OLD.pedido_id IS NULL THEN
+      UPDATE clientes SET saldo_cuenta = COALESCE(saldo_cuenta, 0) + OLD.monto
+       WHERE id = OLD.cliente_id;
+    END IF;
+    RETURN OLD;
+
+  ELSIF TG_OP = 'UPDATE' THEN
+    contrib_old := CASE WHEN OLD.pedido_id IS NULL THEN -OLD.monto ELSE 0 END;
+    contrib_new := CASE WHEN NEW.pedido_id IS NULL THEN -NEW.monto ELSE 0 END;
+
+    IF OLD.cliente_id IS DISTINCT FROM NEW.cliente_id THEN
+      -- Cambió de cliente: revertir en el viejo, aplicar en el nuevo
+      IF contrib_old <> 0 THEN
+        UPDATE clientes SET saldo_cuenta = COALESCE(saldo_cuenta, 0) - contrib_old
+         WHERE id = OLD.cliente_id;
+      END IF;
+      IF contrib_new <> 0 THEN
+        UPDATE clientes SET saldo_cuenta = COALESCE(saldo_cuenta, 0) + contrib_new
+         WHERE id = NEW.cliente_id;
+      END IF;
+    ELSIF contrib_new <> contrib_old THEN
+      UPDATE clientes SET saldo_cuenta = COALESCE(saldo_cuenta, 0) + (contrib_new - contrib_old)
+       WHERE id = NEW.cliente_id;
+    END IF;
+    RETURN NEW;
+  END IF;
+
+  RETURN NULL;
+END;
+$function$;
+
+-- Recrear el trigger incluyendo UPDATE (antes era solo INSERT/DELETE) para
+-- captar transiciones de pedido_id/monto/cliente_id (p.ej. imputar un crédito).
+-- UPDATE OF acotado a esas columnas: un cambio de forma_pago no dispara nada.
+DROP TRIGGER IF EXISTS trigger_actualizar_saldo_pago ON public.pagos;
+CREATE TRIGGER trigger_actualizar_saldo_pago
+  AFTER INSERT OR DELETE OR UPDATE OF monto, pedido_id, cliente_id
+  ON public.pagos
+  FOR EACH ROW
+  EXECUTE FUNCTION public.actualizar_saldo_cliente();
+
+-- Recalc one-time (idempotente): reflejar en saldo_cuenta los créditos (pagos
+-- sin pedido) ya existentes. Se recomputa desde cero con la misma invariante,
+-- acotado a los clientes que tienen pagos sin pedido para no tocar otros saldos.
+UPDATE clientes c
+SET saldo_cuenta =
+      COALESCE((SELECT SUM(pe.total - COALESCE(pe.monto_pagado, 0))
+                  FROM pedidos pe
+                 WHERE pe.cliente_id = c.id
+                   AND pe.estado NOT IN ('cancelado', 'anulado')), 0)
+    - COALESCE((SELECT SUM(pa.monto)
+                  FROM pagos pa
+                 WHERE pa.cliente_id = c.id
+                   AND pa.pedido_id IS NULL), 0)
+WHERE c.id IN (SELECT DISTINCT cliente_id FROM pagos WHERE pedido_id IS NULL);
+
+COMMIT;

--- a/src/components/containers/ClientesContainer.tsx
+++ b/src/components/containers/ClientesContainer.tsx
@@ -52,7 +52,7 @@ export default function ClientesContainer(): React.ReactElement {
   const { user, perfil, isAdmin, isPreventista, isEncargado } = useAuthData()
   const notify = useNotification()
   const queryClient = useQueryClient()
-  const { registrarPago, registrarPagoFIFO, obtenerResumenCuenta } = usePagos()
+  const { registrarPago, registrarPagoFIFO, registrarPagoCombinadoFIFO, obtenerResumenCuenta } = usePagos()
   const rol = perfil?.rol
   const puedePago = puedeRegistrarPagoCliente(rol)
   // Preventista editando un cliente existente: solo puede tocar datos de
@@ -197,6 +197,25 @@ export default function ClientesContainer(): React.ReactElement {
     }
     return result
   }, [registrarPagoFIFO, queryClient, notify])
+
+  const handleConfirmarPagoCombinadoFIFO = useCallback(async (input: {
+    clienteId: string
+    metodos: { monto: number; formaPago: string }[]
+    fecha?: string
+    referencia?: string
+    notas?: string
+  }) => {
+    const result = await registrarPagoCombinadoFIFO(input)
+    queryClient.invalidateQueries({ queryKey: ['pedidos'] })
+    queryClient.invalidateQueries({ queryKey: ['ficha-cliente'] })
+    queryClient.invalidateQueries({ queryKey: ['clientes'] })
+    if (result.sobrante > 0) {
+      notify.success(`Pago registrado. $${result.sobrante.toLocaleString('es-AR')} quedó como saldo a favor.`)
+    } else {
+      notify.success('Pago registrado y aplicado a pedidos pendientes')
+    }
+    return result
+  }, [registrarPagoCombinadoFIFO, queryClient, notify])
 
   const handleGestionarZonas = useCallback(() => {
     setModalZonasOpen(true)
@@ -379,6 +398,7 @@ export default function ClientesContainer(): React.ReactElement {
             onClose={() => setClientePago(null)}
             onConfirmar={handleConfirmarPagoSimple as any}
             onConfirmarFIFO={handleConfirmarPagoFIFO}
+            onConfirmarCombinadoFIFO={handleConfirmarPagoCombinadoFIFO}
           />
         </Suspense>
       )}

--- a/src/components/modals/ModalFichaCliente.tsx
+++ b/src/components/modals/ModalFichaCliente.tsx
@@ -149,10 +149,11 @@ export default function ModalFichaCliente({ cliente, onClose, onRegistrarPago, o
               <div>
                 <p className="text-sm text-gray-600 dark:text-gray-400">Saldo Cuenta Corriente</p>
                 <p className={`text-3xl font-bold ${saldoActual > 0 ? 'text-red-600 dark:text-red-400' : 'text-green-600 dark:text-green-400'}`}>
-                  {formatCurrency(saldoActual)}
+                  {formatCurrency(Math.abs(saldoActual))}
                 </p>
                 {saldoActual > 0 && <p className="text-sm text-gray-500">Debe</p>}
-                {saldoActual < 0 && <p className="text-sm text-gray-500">A favor</p>}
+                {saldoActual < 0 && <p className="text-sm text-green-600 dark:text-green-400 font-medium">A favor</p>}
+                {saldoActual === 0 && <p className="text-sm text-gray-500">Sin deuda</p>}
               </div>
               <div className="text-right">
                 <p className="text-sm text-gray-600 dark:text-gray-400">Límite de Crédito</p>
@@ -182,7 +183,7 @@ export default function ModalFichaCliente({ cliente, onClose, onRegistrarPago, o
                     style={{ width: `${Math.min(100, porcentajeUsado)}%` }}
                   />
                 </div>
-                <p className="text-xs text-gray-500 mt-1">{porcentajeUsado.toFixed(0)}% del crédito utilizado</p>
+                <p className="text-xs text-gray-500 mt-1">{Math.max(0, porcentajeUsado).toFixed(0)}% del crédito utilizado</p>
               </div>
             )}
             {excedido && (

--- a/src/components/modals/ModalRegistrarPago.tsx
+++ b/src/components/modals/ModalRegistrarPago.tsx
@@ -386,6 +386,16 @@ export default function ModalRegistrarPago({
               </div>
             </div>
           )}
+          {saldoPendiente < 0 && (
+            <div className="mt-4 p-3 bg-green-50 dark:bg-green-900/20 rounded-lg">
+              <div className="flex justify-between items-center">
+                <span className="text-green-700 dark:text-green-400">Saldo a favor:</span>
+                <span className="text-xl font-bold text-green-700 dark:text-green-400">
+                  {formatCurrency(Math.abs(saldoPendiente))}
+                </span>
+              </div>
+            </div>
+          )}
         </div>
 
         {/* Form */}

--- a/src/components/modals/ModalRegistrarPago.tsx
+++ b/src/components/modals/ModalRegistrarPago.tsx
@@ -4,7 +4,7 @@ import { formatPrecio as formatCurrency, fechaLocalISO } from '../../utils/forma
 import { parsePrecio } from '../../utils/calculations'
 import { useZodValidation } from '../../hooks/useZodValidation'
 import { modalPagoSchema } from '../../lib/schemas'
-import type { ClienteDB, Pedido, Pago, FormaPago, RegistrarPagoFifoInput, RegistrarPagoFifoResult, PagoFifoAplicacion } from '../../types'
+import type { ClienteDB, Pedido, Pago, FormaPago, RegistrarPagoFifoInput, RegistrarPagoCombinadoFifoInput, RegistrarPagoFifoResult, PagoFifoAplicacion } from '../../types'
 
 // Alias for the Cliente type used in this component
 type Cliente = ClienteDB;
@@ -57,6 +57,12 @@ export interface ModalRegistrarPagoProps {
    * mas antiguos (FIFO). Sobrante queda como saldo a favor.
    */
   onConfirmarFIFO?: (input: RegistrarPagoFifoInput) => Promise<RegistrarPagoFifoResult>;
+  /**
+   * Si se provee, un pago dividido sin pedido específico se imputa por FIFO de
+   * forma atómica (una transacción server-side) en lugar de insertar filas a
+   * cuenta general. Sin esto, el dividido a cuenta general quedaría sin imputar.
+   */
+  onConfirmarCombinadoFIFO?: (input: RegistrarPagoCombinadoFifoInput) => Promise<RegistrarPagoFifoResult>;
   onGenerarRecibo?: (pago: PagoRegistrado, cliente: Cliente) => void;
   /**
    * Si se provee, muestra el botón "Entregar a cuenta corriente (sin cobrar)"
@@ -73,6 +79,7 @@ export default function ModalRegistrarPago({
   onClose,
   onConfirmar,
   onConfirmarFIFO,
+  onConfirmarCombinadoFIFO,
   onGenerarRecibo,
   onEntregarSinCobrar
 }: ModalRegistrarPagoProps): React.ReactElement | null {
@@ -160,9 +167,33 @@ export default function ModalRegistrarPago({
         return
       }
 
-      // El exceso ya no bloquea: queda como saldo a favor (ver flujo FIFO).
-      // Pero si NO se eligio pedido y NO se va a usar FIFO, advertimos.
+      // Pago dividido a cuenta general (sin pedido específico): imputación FIFO
+      // atómica server-side. Cada forma se aplica a los pedidos más antiguos con
+      // saldo pendiente y el sobrante queda como saldo a favor. Espeja la
+      // condición de `usarFIFO` del pago simple: sin esto, las filas se
+      // insertarían con pedido_id NULL y no actualizarían el saldo del cliente.
+      if (!pedidoSeleccionado && onConfirmarCombinadoFIFO) {
+        setLoading(true)
+        try {
+          const result = await onConfirmarCombinadoFIFO({
+            clienteId: cliente!.id,
+            metodos: pagosValidos.map(p => ({ monto: parsePrecio(p.monto), formaPago: p.formaPago })),
+            fecha,
+            notas: notas || undefined,
+          })
+          setResultadoFIFO(result)
+        } catch (err) {
+          const errorMessage = err instanceof Error ? err.message : 'Error al registrar el pago'
+          setError(errorMessage)
+        } finally {
+          setLoading(false)
+        }
+        return
+      }
 
+      // Fallback: dividido aplicado a un pedido específico (o sin RPC combinado
+      // disponible, ej. flujo del transportista). Cada forma genera una fila con
+      // el pedido_id seleccionado, que sí dispara la cascada de triggers.
       setLoading(true)
       try {
         let ultimoPago: PagoRegistrado | null = null

--- a/src/hooks/supabase/usePagos.ts
+++ b/src/hooks/supabase/usePagos.ts
@@ -6,6 +6,7 @@ import type {
   PagoFormInput,
   RegistrarPagoBatchInput,
   RegistrarPagoFifoInput,
+  RegistrarPagoCombinadoFifoInput,
   RegistrarPagoFifoResult,
   PagoFifoAplicacion,
   ResumenCuenta,
@@ -173,6 +174,49 @@ export function usePagos(): UsePagosReturnExtended {
     }
   }
 
+  /**
+   * Registra un pago combinado (varias formas de pago) e imputa el total por
+   * FIFO sobre los pedidos más antiguos con saldo pendiente, en una sola
+   * transacción server-side (RPC `registrar_pago_combinado_cliente_fifo`).
+   * Sobrante por forma queda como saldo a favor (fila con pedido_id NULL).
+   *
+   * Solo admin o encargado (validado server-side en la RPC).
+   */
+  const registrarPagoCombinadoFIFO = async (
+    input: RegistrarPagoCombinadoFifoInput
+  ): Promise<RegistrarPagoFifoResult> => {
+    try {
+      if (currentSucursalId == null) {
+        throw new Error('No hay sucursal activa. Recargá la página e intentá de nuevo.')
+      }
+      const { data, error } = await supabase.rpc('registrar_pago_combinado_cliente_fifo', {
+        p_cliente_id: input.clienteId,
+        p_metodos: input.metodos.map(m => ({ monto: m.monto, forma_pago: m.formaPago })),
+        p_fecha: input.fecha ?? null,
+        p_referencia: input.referencia ?? null,
+        p_notas: input.notas ?? null,
+      })
+      if (error) throw error
+
+      const raw = (data ?? {}) as {
+        pago_ids?: number[]
+        sobrante?: number
+        monto_total?: number
+        aplicaciones?: PagoFifoAplicacion[]
+      }
+
+      return {
+        pagoIds: raw.pago_ids ?? [],
+        sobrante: Number(raw.sobrante ?? 0),
+        montoTotal: Number(raw.monto_total ?? 0),
+        aplicaciones: raw.aplicaciones ?? [],
+      }
+    } catch (error) {
+      notifyError('Error al registrar pago: ' + (error as Error).message)
+      throw error
+    }
+  }
+
   const eliminarPago = async (pagoId: string): Promise<void> => {
     try {
       const { error } = await supabase.from('pagos').delete().eq('id', pagoId)
@@ -260,6 +304,7 @@ export function usePagos(): UsePagosReturnExtended {
     registrarPago,
     registrarPagosBatch,
     registrarPagoFIFO,
+    registrarPagoCombinadoFIFO,
     eliminarPago,
     actualizarFormaPagoDePago,
     obtenerResumenCuenta,

--- a/src/types/hooks.ts
+++ b/src/types/hooks.ts
@@ -703,6 +703,8 @@ export interface PagoFifoAplicacion {
   pago_id: number;
   pedido_id: number | null;
   pedido_fecha?: string;
+  /** Forma de pago de esta aplicación (presente en pagos combinados). */
+  forma_pago?: string;
   monto: number;
   saldo_a_favor?: boolean;
 }
@@ -723,6 +725,19 @@ export interface RegistrarPagoFifoResult {
   aplicaciones: PagoFifoAplicacion[];
 }
 
+/**
+ * Pago combinado (varias formas de pago) imputado por FIFO en una sola
+ * transacción server-side. Cada forma se aplica a los pedidos más antiguos
+ * con saldo pendiente; el sobrante por forma queda como saldo a favor.
+ */
+export interface RegistrarPagoCombinadoFifoInput {
+  clienteId: string;
+  metodos: Array<{ formaPago: string; monto: number }>;
+  fecha?: string;
+  referencia?: string;
+  notas?: string;
+}
+
 export interface UsePagosReturnExtended {
   pagos: PagoDBWithUsuario[];
   loading: boolean;
@@ -731,6 +746,7 @@ export interface UsePagosReturnExtended {
   registrarPago: (pago: PagoFormInput) => Promise<PagoDBWithUsuario>;
   registrarPagosBatch: (input: RegistrarPagoBatchInput) => Promise<PagoDBWithUsuario[]>;
   registrarPagoFIFO: (input: RegistrarPagoFifoInput) => Promise<RegistrarPagoFifoResult>;
+  registrarPagoCombinadoFIFO: (input: RegistrarPagoCombinadoFifoInput) => Promise<RegistrarPagoFifoResult>;
   eliminarPago: (pagoId: string) => Promise<void>;
   actualizarFormaPagoDePago: (pagoId: string, nuevaFormaPago: string) => Promise<void>;
   obtenerResumenCuenta: (clienteId: string) => Promise<ResumenCuenta | null>;


### PR DESCRIPTION
Dos cambios relacionados sobre pagos/saldo de clientes. RPCs y datos **ya aplicados a producción**; falta desplegar el frontend.

## Parte A — Bug: pago combinado a cuenta general no imputaba ni movía saldo

El **pago dividido** (varias formas de pago) desde la ficha a cuenta general insertaba filas en `pagos` con `pedido_id NULL` y excluía FIFO. Como `recalcular_monto_pagado_pedido` solo actúa con `pedido_id` no nulo y `actualizar_saldo_cliente` estaba neutralizado, el dinero quedaba huérfano, el pedido seguía pendiente y `saldo_cuenta` no bajaba. (Reportado en TITA MALDONADO, Taco Pozo, 15/06.)

- **RPC** `registrar_pago_combinado_cliente_fifo` (mig 085): imputa cada forma por FIFO en una transacción; sobrante por método queda como saldo a favor. Mismos guards RBAC que `registrar_pago_cliente_fifo`.
- `usePagos.registrarPagoCombinadoFIFO` + tipos; `ModalRegistrarPago` rutea el dividido al RPC cuando no hay pedido específico (fallback al loop para pedido puntual / transportista); `ClientesContainer` cableado.
- Datos reparados (one-off): TITA \$123.550 → pedido #2446 (+\$50 a favor); DESPENSA SAY SOF \$72.000 → pedido #2450. Ambos saldo neteado.

## Parte B — Saldo a favor reduce el saldo y se netea solo

Un pago sin pedido (el saldo a favor de FIFO) **no** afectaba `saldo_cuenta`: el crédito quedaba invisible y no se aplicaba a futuros pedidos.

- **mig 086**: reescribe/reactiva el trigger `actualizar_saldo_cliente` (lógica delta INSERT/UPDATE/DELETE, sin doble conteo con la cascada de pedidos) → los pagos sin pedido restan el saldo (queda negativo = a favor) y se netean solos contra próximos pedidos. Recalc idempotente acotado a los clientes con créditos existentes.
- Modelo elegido: **saldo neto** (crédito = saldo negativo). El sistema ya toleraba saldos negativos. Reportes de mora/CxC son order-driven → sin impacto.
- UI: `ModalFichaCliente` y `ModalRegistrarPago` muestran el negativo como "Saldo a favor".
- Datos: 3 clientes con crédito reflejados → TITA −\$80.050, ELINA ROJAS −\$60.100, SHOWMATCH \$81.100→\$36.700 (neto).

## Verificación

- Tests e2e (transacciones revertidas): RPC combinado FIFO por método OK; trigger de saldo a favor (insert/imputar/borrar) OK, sin doble conteo.
- `tsc --noEmit` limpio, `vite build` OK, **692/692** tests, ESLint OK.

## Deploy

RPCs y migraciones (085, 086) ya en prod. Falta **desplegar el frontend** para que los nuevos pagos divididos usen el RPC. Hasta entonces, un pago dividido nuevo a cuenta general puede volver a quedar huérfano.

🤖 Generated with [Claude Code](https://claude.com/claude-code)