### PR TITLE
feat(rutas): navegación asistida in-app (fase 1) + fix UX mobile/iOS del sheet

### DIFF
--- a/index.html
+++ b/index.html
@@ -43,8 +43,9 @@
     <link rel="preconnect" href="https://maps.googleapis.com" />
     <link rel="preconnect" href="https://maps.gstatic.com" crossorigin />
 
-    <!-- Viewport -->
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=5.0" />
+    <!-- Viewport. viewport-fit=cover: imprescindible para que env(safe-area-inset-*)
+         resuelva con valores reales en iOS (notch / home indicator). -->
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=5.0, viewport-fit=cover" />
 
     <!-- Color Scheme Support -->
     <meta name="color-scheme" content="light dark" />

--- a/src/components/rutaActiva/BannerManiobra.tsx
+++ b/src/components/rutaActiva/BannerManiobra.tsx
@@ -1,0 +1,89 @@
+/**
+ * BannerManiobra — banner grande de la próxima maniobra en el modo navegación.
+ * Ícono de la maniobra (mapeo del enum de Google) + distancia + instrucción.
+ * Pensado para leerse de un vistazo con el celu montado en el auto.
+ */
+import {
+  ArrowUp, ArrowRight, ArrowLeft, ArrowUpRight, ArrowUpLeft,
+  CornerUpRight, CornerUpLeft, RotateCw, RotateCcw, Navigation, Ship, Flag, Loader2,
+  type LucideIcon,
+} from 'lucide-react';
+import { formatDistancia } from '../../utils/geo';
+
+/** Mapeo del enum `maneuver` de Routes API a íconos. */
+const ICONOS: Record<string, LucideIcon> = {
+  DEPART: Navigation,
+  STRAIGHT: ArrowUp,
+  NAME_CHANGE: ArrowUp,
+  MERGE: ArrowUp,
+  TURN_RIGHT: ArrowRight,
+  TURN_LEFT: ArrowLeft,
+  TURN_SLIGHT_RIGHT: ArrowUpRight,
+  TURN_SLIGHT_LEFT: ArrowUpLeft,
+  TURN_SHARP_RIGHT: CornerUpRight,
+  TURN_SHARP_LEFT: CornerUpLeft,
+  RAMP_RIGHT: ArrowUpRight,
+  RAMP_LEFT: ArrowUpLeft,
+  FORK_RIGHT: ArrowUpRight,
+  FORK_LEFT: ArrowUpLeft,
+  ROUNDABOUT_RIGHT: RotateCw,
+  ROUNDABOUT_LEFT: RotateCcw,
+  UTURN_RIGHT: RotateCw,
+  UTURN_LEFT: RotateCcw,
+  FERRY: Ship,
+  FERRY_TRAIN: Ship,
+  LLEGADA: Flag,
+};
+
+export interface BannerManiobraProps {
+  maniobra: string | null;
+  instruccion: string | null;
+  /** Distancia a la maniobra, en metros. */
+  distanciaMetros: number | null;
+  cargando?: boolean;
+  error?: string | null;
+}
+
+export default function BannerManiobra({
+  maniobra,
+  instruccion,
+  distanciaMetros,
+  cargando = false,
+  error = null,
+}: BannerManiobraProps) {
+  if (error) {
+    return (
+      <div className="rounded-2xl bg-red-600 px-4 py-3 text-white shadow-xl">
+        <p className="text-sm font-semibold">No se pudo trazar la ruta</p>
+        <p className="text-xs opacity-90">{error} — usá “Abrir en Maps”.</p>
+      </div>
+    );
+  }
+
+  if (cargando || !instruccion) {
+    return (
+      <div className="flex items-center gap-3 rounded-2xl bg-gray-900/95 px-4 py-3 text-white shadow-xl">
+        <Loader2 className="h-6 w-6 flex-shrink-0 animate-spin" />
+        <p className="text-base font-medium">Calculando ruta…</p>
+      </div>
+    );
+  }
+
+  const Icono = ICONOS[maniobra ?? ''] ?? Navigation;
+
+  return (
+    <div className="flex items-center gap-3 rounded-2xl bg-gray-900/95 px-4 py-3 text-white shadow-xl">
+      <div className="flex h-14 w-14 flex-shrink-0 items-center justify-center rounded-xl bg-blue-600">
+        <Icono className="h-8 w-8" strokeWidth={2.5} />
+      </div>
+      <div className="min-w-0 flex-1">
+        {distanciaMetros != null && (
+          <p className="text-2xl font-extrabold leading-tight">
+            {formatDistancia(distanciaMetros)}
+          </p>
+        )}
+        <p className="truncate text-base font-medium text-gray-100">{instruccion}</p>
+      </div>
+    </div>
+  );
+}

--- a/src/components/rutaActiva/NavAsistida.tsx
+++ b/src/components/rutaActiva/NavAsistida.tsx
@@ -1,0 +1,224 @@
+/**
+ * NavAsistida — pantalla completa de navegación asistida in-app (Fase 1).
+ *
+ * Guía al chofer de su posición a la próxima parada SIN salir de la app:
+ *  - mapa raster que sigue la posición (reusa MapaRutaGoogle),
+ *  - banner grande de la próxima maniobra (texto Google es-419) + distancia,
+ *  - voz que anuncia la maniobra al acercarse,
+ *  - “Abrir en Maps” como fallback y “Salir” siempre a mano.
+ *
+ * Fase 1 = SIN recálculo ni snap-to-route: una llamada por tramo (useNavTramo),
+ * y el avance de maniobra se calcula contra los puntos absolutos de cada paso.
+ * El handoff a Google Maps queda como red de seguridad. La cámara tilteada
+ * heading-up, el snap y el recálculo en desvío son Fase 2/3.
+ */
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { X, Volume2, VolumeX, Map as MapIcon } from 'lucide-react';
+import MapaRutaGoogle from './MapaRutaGoogle';
+import BannerManiobra from './BannerManiobra';
+import { useNavTramo, type Coord } from '../../hooks/useNavTramo';
+import type { UseNavegacionVozReturn } from '../../hooks/useNavegacionVoz';
+import type { PosicionGps } from '../../hooks/useWatchPosition';
+import type { ParadaMapa } from '../MapaRuta';
+import { haversineMeters, formatDistancia } from '../../utils/geo';
+
+/** Distancia (m) a la maniobra para considerarla pasada y avanzar de paso. */
+const UMBRAL_AVANCE_M = 30;
+/** Distancia (m) para el aviso anticipado de la maniobra. */
+const UMBRAL_AVISO_M = 160;
+
+export interface NavAsistidaProps {
+  destino: Coord;
+  destinoNombre: string;
+  destinoDireccion?: string;
+  posicion: PosicionGps | null;
+  gpsConfiable: boolean;
+  /** El geofence del contenedor detectó llegada → cerrar nav y volver a entregar. */
+  llegaste: boolean;
+  voz: UseNavegacionVozReturn;
+  vozOn: boolean;
+  onToggleVoz: () => void;
+  /** Deep-link a Google Maps/búsqueda como fallback. */
+  navUrlFallback: string;
+  onSalir: () => void;
+}
+
+export default function NavAsistida({
+  destino,
+  destinoNombre,
+  destinoDireccion,
+  posicion,
+  gpsConfiable,
+  llegaste,
+  voz,
+  vozOn,
+  onToggleVoz,
+  navUrlFallback,
+  onSalir,
+}: NavAsistidaProps) {
+  const { decir, callar } = voz;
+
+  // Origen del tramo: la posición al iniciar (capturada una vez por destino).
+  const [origen, setOrigen] = useState<Coord | null>(null);
+  useEffect(() => {
+    setOrigen(null);
+  }, [destino.lat, destino.lng]);
+  useEffect(() => {
+    if (!origen && gpsConfiable && posicion) {
+      setOrigen({ lat: posicion.lat, lng: posicion.lng });
+    }
+  }, [origen, gpsConfiable, posicion]);
+
+  const tramo = useNavTramo(origen, destino, true);
+  const { pasos } = tramo;
+
+  // Paso (maniobra) actual y avisos ya dichos por paso.
+  const [idx, setIdx] = useState(0);
+  const anunciadosRef = useRef<Set<number>>(new Set());
+  useEffect(() => {
+    // Saltear el "DEPART" inicial: arrancar en la primera maniobra real.
+    const start = pasos.length > 1 && pasos[0]?.maniobra === 'DEPART' ? 1 : 0;
+    setIdx(start);
+    anunciadosRef.current = new Set();
+  }, [pasos]);
+
+  const pasoActual = pasos[idx] ?? null;
+
+  const distManiobra = useMemo<number | null>(() => {
+    if (!gpsConfiable || !posicion || !pasoActual) return null;
+    return haversineMeters({ lat: posicion.lat, lng: posicion.lng }, pasoActual.inicio);
+  }, [gpsConfiable, posicion, pasoActual]);
+
+  // Avance de paso + avisos por voz (Fase 1: contra el punto absoluto del paso).
+  useEffect(() => {
+    if (!gpsConfiable || !posicion || pasos.length === 0) return;
+    const paso = pasos[idx];
+    if (!paso) return;
+    const dist = haversineMeters({ lat: posicion.lat, lng: posicion.lng }, paso.inicio);
+    const key150 = idx * 1000 + 150;
+    const key30 = idx * 1000 + 30;
+
+    if (vozOn) {
+      if (dist <= UMBRAL_AVANCE_M && !anunciadosRef.current.has(key30)) {
+        anunciadosRef.current.add(key30);
+        anunciadosRef.current.add(key150);
+        decir(paso.instruccion, { forzar: true });
+      } else if (dist <= UMBRAL_AVISO_M && !anunciadosRef.current.has(key150)) {
+        anunciadosRef.current.add(key150);
+        const redonda = Math.max(10, Math.round(dist / 10) * 10);
+        decir(`En ${redonda} metros, ${paso.instruccion}`);
+      }
+    }
+
+    if (dist <= UMBRAL_AVANCE_M && idx < pasos.length - 1) {
+      setIdx(i => (i < pasos.length - 1 ? i + 1 : i));
+    }
+  }, [posicion, gpsConfiable, pasos, idx, vozOn, decir]);
+
+  // Llegada: anunciar y volver a la pantalla de entrega.
+  const salioRef = useRef(false);
+  useEffect(() => {
+    if (llegaste && !salioRef.current) {
+      salioRef.current = true;
+      if (vozOn) decir('Llegaste a destino', { forzar: true });
+      const t = window.setTimeout(() => onSalir(), 1500);
+      return () => window.clearTimeout(t);
+    }
+  }, [llegaste, vozOn, decir, onSalir]);
+
+  // Cortar la voz al cerrar la navegación.
+  useEffect(() => () => callar(), [callar]);
+
+  const paradasMapa = useMemo<ParadaMapa[]>(
+    () => [{
+      lat: destino.lat,
+      lng: destino.lng,
+      orden: 1,
+      titulo: destinoNombre,
+      subtitulo: destinoDireccion,
+      entregado: false,
+    }],
+    [destino.lat, destino.lng, destinoNombre, destinoDireccion],
+  );
+
+  const etaMin = tramo.duracionSegundos != null
+    ? Math.max(1, Math.round(tramo.duracionSegundos / 60))
+    : null;
+
+  return (
+    <div className="fixed inset-0 z-50 flex flex-col bg-gray-900">
+      {/* Mapa de fondo */}
+      <div className="absolute inset-0">
+        <MapaRutaGoogle
+          paradas={paradasMapa}
+          deposito={null}
+          altura="full"
+          rutaReal={tramo.rutaTramo.length > 1 ? tramo.rutaTramo : null}
+          posicion={gpsConfiable && posicion ? { lat: posicion.lat, lng: posicion.lng, accuracy: posicion.accuracy } : null}
+          paradaActivaOrden={1}
+          seguirPosicion={gpsConfiable && posicion != null}
+        />
+      </div>
+
+      {/* Banner de maniobra (arriba) */}
+      <div className="absolute inset-x-0 top-0 z-10 px-3 pt-[max(env(safe-area-inset-top),12px)]">
+        <BannerManiobra
+          maniobra={pasoActual?.maniobra ?? null}
+          instruccion={pasoActual?.instruccion ?? null}
+          distanciaMetros={distManiobra}
+          cargando={tramo.cargando}
+          error={tramo.error}
+        />
+        {!gpsConfiable && !tramo.error && (
+          <div className="mt-2 rounded-xl bg-amber-500 px-3 py-2 text-sm font-medium text-white shadow-lg">
+            Buscando señal GPS… mantené el celu a la vista.
+          </div>
+        )}
+      </div>
+
+      {/* Barra inferior: destino + ETA + acciones */}
+      <div className="absolute inset-x-0 bottom-0 z-10 px-3 pb-[max(env(safe-area-inset-bottom),12px)] pt-3">
+        <div className="rounded-2xl bg-white/95 p-3 shadow-xl backdrop-blur dark:bg-gray-800/95">
+          <div className="flex items-center justify-between gap-3">
+            <div className="min-w-0">
+              <p className="truncate font-semibold text-gray-900 dark:text-white">{destinoNombre}</p>
+              <p className="text-xs text-gray-500 dark:text-gray-400">
+                {etaMin != null && tramo.distanciaMetros != null
+                  ? `≈ ${etaMin} min · ${formatDistancia(tramo.distanciaMetros)}`
+                  : 'Calculando…'}
+              </p>
+            </div>
+            <button
+              onClick={onToggleVoz}
+              className={`flex h-11 w-11 flex-shrink-0 items-center justify-center rounded-full transition-colors ${
+                vozOn ? 'bg-blue-600 text-white' : 'bg-gray-200 text-gray-500 dark:bg-gray-700 dark:text-gray-300'
+              }`}
+              aria-label={vozOn ? 'Silenciar voz' : 'Activar voz'}
+            >
+              {vozOn ? <Volume2 className="h-5 w-5" /> : <VolumeX className="h-5 w-5" />}
+            </button>
+          </div>
+
+          <div className="mt-3 grid grid-cols-2 gap-2">
+            <a
+              href={navUrlFallback}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="flex min-h-[48px] items-center justify-center gap-2 rounded-xl bg-gray-100 text-sm font-semibold text-gray-700 active:bg-gray-200 dark:bg-gray-700 dark:text-gray-200"
+            >
+              <MapIcon className="h-4 w-4" />
+              Abrir en Maps
+            </a>
+            <button
+              onClick={onSalir}
+              className="flex min-h-[48px] items-center justify-center gap-2 rounded-xl bg-red-50 text-sm font-semibold text-red-700 active:bg-red-100 dark:bg-red-900/30 dark:text-red-300"
+            >
+              <X className="h-4 w-4" />
+              Salir
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/rutaActiva/RutaActivaTransportista.tsx
+++ b/src/components/rutaActiva/RutaActivaTransportista.tsx
@@ -11,14 +11,17 @@
  * transportista en /pedidos. La lógica de entrega/cobro/salvedad es la misma
  * (useEntregaParada). Diseño: docs/plans/2026-06-12-ruta-activa-design.md
  */
-import React, { useState, useMemo, useEffect, lazy, Suspense } from 'react';
+import React, { useState, useMemo, useEffect, useCallback, lazy, Suspense } from 'react';
 import { Crosshair, WifiOff, Truck } from 'lucide-react';
 import { formatPrecio } from '../../utils/formatters';
 import { haversineMeters } from '../../utils/geo';
 import { useAuthData } from '../../contexts/AuthDataContext';
 import { useWatchPosition } from '../../hooks/useWatchPosition';
 import { useDepositoCoords, useRecorridoActivoQuery } from '../../hooks/queries';
+import { useNavegacionVoz } from '../../hooks/useNavegacionVoz';
+import { useWakeLock } from '../../hooks/useWakeLock';
 import { decodePolylines } from '../../utils/polyline';
+import { googleMapsNavUrl, googleMapsSearchUrl } from '../../utils/navegacion';
 import { useEntregaParada, type PedidoConCliente, type DatosPago, type DatosSalvedad } from './useEntregaParada';
 import SheetParada, { type LinkRutaMaps } from './SheetParada';
 import ModalSalvedadItem from '../modals/ModalSalvedadItem';
@@ -27,6 +30,8 @@ import type { PedidoDB, RegistrarSalvedadResult } from '../../types';
 
 // Mapa con Google Maps JS (reemplaza el Leaflet; mejor reactividad y estética).
 const MapaRuta = lazy(() => import('./MapaRutaGoogle'));
+// Navegación asistida in-app (pantalla completa) — pesada, carga bajo demanda.
+const NavAsistida = lazy(() => import('./NavAsistida'));
 
 /** Radio del geofence de llegada, en metros */
 const RADIO_LLEGADA_M = 100;
@@ -52,7 +57,13 @@ export default function RutaActivaTransportista({
 }: RutaActivaTransportistaProps): React.ReactElement {
   const { isOnline } = useAuthData();
   const deposito = useDepositoCoords();
-  const { posicion } = useWatchPosition(true);
+  // Modo navegación asistida in-app (pantalla completa giro-a-giro).
+  const [modoNavegacion, setModoNavegacion] = useState(false);
+  const [vozOn, setVozOn] = useState(true);
+  const voz = useNavegacionVoz();
+  const wakeLock = useWakeLock();
+  // En navegación, GPS más frecuente para seguir suave; si no, ahorro de batería.
+  const { posicion } = useWatchPosition(true, modoNavegacion ? 1000 : 4000);
   // Ruta del día: el transportista lee del recorrido en_curso (las paradas que
   // armó el admin), NO de "todos sus pedidos asignados". Trae también la ruta
   // real (polylines) para dibujarla.
@@ -165,6 +176,37 @@ export default function RutaActivaTransportista({
     }
   };
 
+  // --- Navegación asistida in-app ---
+  // Deep-link a Maps como fallback (botón "Abrir en Maps" dentro de la nav).
+  const navUrlActiva = useMemo((): string => {
+    if (paradaActiva?.cliente?.latitud != null && paradaActiva?.cliente?.longitud != null) {
+      return googleMapsNavUrl(Number(paradaActiva.cliente.latitud), Number(paradaActiva.cliente.longitud));
+    }
+    return googleMapsSearchUrl(paradaActiva?.cliente?.direccion || '');
+  }, [paradaActiva]);
+
+  // Desbloquear voz/haptics/wake-lock DENTRO del gesto (requisito del navegador).
+  const iniciarNavegacion = useCallback((): void => {
+    voz.prime();
+    if (typeof navigator !== 'undefined' && 'vibrate' in navigator) {
+      try { navigator.vibrate(1); } catch { /* sin haptics */ }
+    }
+    wakeLock.solicitar();
+    setSeguirPosicion(false);
+    setModoNavegacion(true);
+  }, [voz, wakeLock]);
+
+  const salirNavegacion = useCallback((): void => {
+    wakeLock.liberar();
+    voz.callar();
+    setModoNavegacion(false);
+  }, [wakeLock, voz]);
+
+  // Si se completó la ruta (o no hay parada activa), salir de la navegación.
+  useEffect(() => {
+    if (modoNavegacion && !paradaActiva) salirNavegacion();
+  }, [modoNavegacion, paradaActiva, salirNavegacion]);
+
   if (pedidosOrdenados.length === 0) {
     // Distinguir "todavía no hay ruta armada" de "ruta cargando".
     const sinRuta = !cargandoRuta && recorridoActivo == null;
@@ -189,20 +231,23 @@ export default function RutaActivaTransportista({
     // Full-bleed: compensa el padding del <main> (px-4 pb-6) para que el mapa
     // ocupe todo el ancho y llegue hasta abajo de la pantalla.
     <div className="relative -mx-4 -mb-6 h-[calc(100dvh-5rem)] overflow-hidden">
-      <Suspense fallback={<div className="flex h-full items-center justify-center text-gray-400">Cargando mapa…</div>}>
-        <MapaRuta
-          paradas={paradasMapa}
-          deposito={deposito}
-          altura="full"
-          rutaReal={rutaReal.length > 1 ? rutaReal : null}
-          // Solo mostramos el punto azul con GPS confiable (no plantarlo en
-          // medio del país con la geolocalización por IP del desktop).
-          posicion={gpsConfiable && posicion ? { lat: posicion.lat, lng: posicion.lng, accuracy: posicion.accuracy } : null}
-          paradaActivaOrden={paradaActiva?.orden_entrega ?? null}
-          onParadaTap={handleParadaTapMapa}
-          seguirPosicion={seguirPosicion && gpsConfiable}
-        />
-      </Suspense>
+      {/* Mapa overview: se desmonta en navegación para no tener dos mapas. */}
+      {!modoNavegacion && (
+        <Suspense fallback={<div className="flex h-full items-center justify-center text-gray-400">Cargando mapa…</div>}>
+          <MapaRuta
+            paradas={paradasMapa}
+            deposito={deposito}
+            altura="full"
+            rutaReal={rutaReal.length > 1 ? rutaReal : null}
+            // Solo mostramos el punto azul con GPS confiable (no plantarlo en
+            // medio del país con la geolocalización por IP del desktop).
+            posicion={gpsConfiable && posicion ? { lat: posicion.lat, lng: posicion.lng, accuracy: posicion.accuracy } : null}
+            paradaActivaOrden={paradaActiva?.orden_entrega ?? null}
+            onParadaTap={handleParadaTapMapa}
+            seguirPosicion={seguirPosicion && gpsConfiable}
+          />
+        </Suspense>
+      )}
 
       {/* Header flotante: progreso del día */}
       <div className="pointer-events-none absolute inset-x-3 top-3 z-20 flex items-start justify-between gap-2">
@@ -245,6 +290,7 @@ export default function RutaActivaTransportista({
         onEntregar={entrega.marcarEntregado}
         onSalvedad={onRegistrarSalvedad ? entrega.abrirSalvedad : undefined}
         linksRutaMaps={linksRutaMaps}
+        onNavegarInApp={iniciarNavegacion}
       />
 
       {/* Modales del flujo de entrega (mismos que la vista anterior) */}
@@ -265,6 +311,27 @@ export default function RutaActivaTransportista({
           onConfirmar={entrega.confirmarPago}
           onEntregarSinCobrar={onEntregarSinCobrar ? entrega.entregarSinCobrar : undefined}
         />
+      )}
+
+      {/* Navegación asistida in-app (pantalla completa, encima de todo) */}
+      {modoNavegacion && paradaActiva
+        && paradaActiva.cliente?.latitud != null
+        && paradaActiva.cliente?.longitud != null && (
+        <Suspense fallback={<div className="fixed inset-0 z-50 flex items-center justify-center bg-gray-900 text-gray-300">Iniciando navegación…</div>}>
+          <NavAsistida
+            destino={{ lat: Number(paradaActiva.cliente.latitud), lng: Number(paradaActiva.cliente.longitud) }}
+            destinoNombre={paradaActiva.cliente?.nombre_fantasia || 'Cliente'}
+            destinoDireccion={paradaActiva.cliente?.direccion || undefined}
+            posicion={posicion}
+            gpsConfiable={gpsConfiable}
+            llegaste={llegaste}
+            voz={voz}
+            vozOn={vozOn}
+            onToggleVoz={() => setVozOn(v => !v)}
+            navUrlFallback={navUrlActiva}
+            onSalir={salirNavegacion}
+          />
+        </Suspense>
       )}
     </div>
   );

--- a/src/components/rutaActiva/SheetParada.tsx
+++ b/src/components/rutaActiva/SheetParada.tsx
@@ -43,12 +43,50 @@ export interface SheetParadaProps {
   onEntregar: (pedido: PedidoConCliente) => void;
   onSalvedad?: (pedidoId: string, item: PedidoItemDB & { producto?: ProductoDB }) => void;
   linksRutaMaps: LinkRutaMaps[];
+  /** Inicia la navegación asistida in-app. Si no se pasa, solo queda el handoff. */
+  onNavegarInApp?: (pedido: PedidoConCliente) => void;
 }
 
 function navUrl(p: PedidoConCliente): string {
   return p.cliente?.latitud != null && p.cliente?.longitud != null
     ? googleMapsNavUrl(Number(p.cliente.latitud), Number(p.cliente.longitud))
     : googleMapsSearchUrl(p.cliente?.direccion || '');
+}
+
+/** Fila compacta de una parada. Reusada en "Próximas paradas" y "Todas las paradas". */
+function FilaParada({ parada, numero, activa, onSelect }: {
+  parada: PedidoConCliente;
+  numero: number;
+  activa: boolean;
+  onSelect: () => void;
+}) {
+  const entregado = parada.estado === 'entregado';
+  return (
+    <button
+      onClick={onSelect}
+      className={`flex w-full items-center gap-3 rounded-xl border p-2.5 text-left transition-colors ${
+        activa
+          ? 'border-blue-400 bg-blue-50 dark:border-blue-600 dark:bg-blue-900/30'
+          : 'border-gray-200 bg-white dark:border-gray-700 dark:bg-gray-800'
+      }`}
+    >
+      <span className={`flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-full text-xs font-bold text-white ${entregado ? 'bg-green-500' : 'bg-blue-500'}`}>
+        {entregado ? <Check className="h-4 w-4" /> : numero}
+      </span>
+      <span className="min-w-0 flex-1">
+        <span className="block truncate text-sm font-medium text-gray-900 dark:text-white">
+          {parada.cliente?.nombre_fantasia || 'Cliente'}
+        </span>
+        <span className="block truncate text-xs text-gray-500 dark:text-gray-400">
+          {parada.cliente?.direccion || 'Sin dirección'}
+        </span>
+      </span>
+      <span className="flex-shrink-0 text-sm font-semibold text-gray-700 dark:text-gray-300">
+        {formatPrecio(parada.total)}
+      </span>
+      <ChevronRight className="h-4 w-4 flex-shrink-0 text-gray-400" />
+    </button>
+  );
 }
 
 export default function SheetParada({
@@ -60,11 +98,15 @@ export default function SheetParada({
   onEntregar,
   onSalvedad,
   linksRutaMaps,
+  onNavegarInApp,
 }: SheetParadaProps) {
   const [snap, setSnap] = useState<number | string | null>(SNAP_MEDIO);
   const expandido = snap === SNAP_EXPANDIDO;
 
   const pendientes = paradas.filter(p => p.estado === 'asignado');
+  // Próximas (hasta 3) pendientes después de la activa: visibles sin expandir.
+  const idxActiva = paradaActiva ? pendientes.findIndex(p => p.id === paradaActiva.id) : -1;
+  const proximas = (idxActiva >= 0 ? pendientes.slice(idxActiva + 1) : pendientes).slice(0, 3);
 
   // Al detectar llegada, subir el sheet a la posición media si está colapsado
   // para que el botón Entregar quede a la vista (flujo guiado).
@@ -88,10 +130,14 @@ export default function SheetParada({
         >
           <Drawer.Title className="sr-only">Parada actual de la ruta</Drawer.Title>
 
-          {/* Handle de arrastre */}
-          <div className="mx-auto mt-2 h-1.5 w-12 flex-shrink-0 rounded-full bg-gray-300 dark:bg-gray-600" />
+          {/* Handle de arrastre. Drawer.Handle trae el hit-area táctil de 44px
+              nativo de vaul (fácil de agarrar) y al tocarlo cicla los snaps. */}
+          <Drawer.Handle className="mx-auto mt-2 mb-1 h-1.5 w-12 flex-shrink-0 rounded-full bg-gray-300 dark:bg-gray-600" />
 
-          <div className={`flex-1 px-4 pb-[max(env(safe-area-inset-bottom),12px)] ${expandido ? 'overflow-y-auto' : 'overflow-hidden'}`}>
+          {/* Bloque fijo superior: encabezado + tarjeta + acciones. Las acciones
+              van ACÁ (arriba), NO en un footer: vaul revela el contenido
+              top-down, así que el peek/medio muestra el tope del panel. */}
+          <div className="flex-shrink-0 px-4 pb-1">
             {paradaActiva ? (
               <>
                 {/* Encabezado (visible incluso colapsado) */}
@@ -162,6 +208,20 @@ export default function SheetParada({
                     </p>
                   )}
 
+                  {/* Navegación asistida in-app (la principal). El handoff a
+                      Maps/Waze queda abajo como fallback. */}
+                  {onNavegarInApp && !llegaste
+                    && paradaActiva.cliente?.latitud != null
+                    && paradaActiva.cliente?.longitud != null && (
+                    <button
+                      onClick={() => onNavegarInApp(paradaActiva)}
+                      className="flex min-h-[52px] w-full items-center justify-center gap-2 rounded-xl bg-blue-600 text-sm font-semibold text-white transition-colors active:bg-blue-800"
+                    >
+                      <Navigation className="h-5 w-5" />
+                      Navegar en la app
+                    </button>
+                  )}
+
                   {/* Acciones principales */}
                   <div className="grid grid-cols-3 gap-2">
                     <a
@@ -175,7 +235,7 @@ export default function SheetParada({
                       }`}
                     >
                       <Navigation className="h-4 w-4" />
-                      Navegar
+                      Maps
                     </a>
                     {paradaActiva.cliente?.latitud != null && paradaActiva.cliente?.longitud != null ? (
                       <a
@@ -208,10 +268,37 @@ export default function SheetParada({
                 <p className="text-sm text-gray-500 dark:text-gray-400">No quedan entregas pendientes</p>
               </div>
             )}
+          </div>
+
+          {/* Bloque scrollable: próximas paradas (siempre) + detalle al expandir.
+              overscroll-contain corta el encadenamiento del scroll al documento
+              (defensa extra contra el pull-to-refresh); el pb respeta el home
+              indicator en snap expandido. min-h-0 para que flex-1 pueda scrollear. */}
+          <div className="mt-2 min-h-0 flex-1 overflow-y-auto overscroll-contain px-4 pb-[max(env(safe-area-inset-bottom),12px)]">
+            {/* Próximas paradas: visibles/scrolleables desde el snap medio, sin
+                tener que expandir del todo. Al expandir se ve la lista completa. */}
+            {!expandido && proximas.length > 0 && (
+              <div>
+                <p className="mb-2 text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">
+                  Próximas paradas
+                </p>
+                <div className="space-y-1.5">
+                  {proximas.map((p, i) => (
+                    <FilaParada
+                      key={p.id}
+                      parada={p}
+                      numero={p.orden_entrega || i + 1}
+                      activa={false}
+                      onSelect={() => { onSeleccionarParada(p.id); setSnap(SNAP_MEDIO); }}
+                    />
+                  ))}
+                </div>
+              </div>
+            )}
 
             {/* Contenido expandido: productos de la parada + lista de paradas */}
             {expandido && (
-              <div className="mt-5 space-y-5">
+              <div className="space-y-5">
                 {paradaActiva && (paradaActiva.items?.length || 0) > 0 && (
                   <div>
                     <p className="mb-2 text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">
@@ -256,37 +343,15 @@ export default function SheetParada({
                     Todas las paradas
                   </p>
                   <div className="space-y-1.5">
-                    {paradas.map((p, i) => {
-                      const entregado = p.estado === 'entregado';
-                      const activa = paradaActiva?.id === p.id;
-                      return (
-                        <button
-                          key={p.id}
-                          onClick={() => { onSeleccionarParada(p.id); setSnap(SNAP_MEDIO); }}
-                          className={`flex w-full items-center gap-3 rounded-xl border p-2.5 text-left transition-colors ${
-                            activa
-                              ? 'border-blue-400 bg-blue-50 dark:border-blue-600 dark:bg-blue-900/30'
-                              : 'border-gray-200 bg-white dark:border-gray-700 dark:bg-gray-800'
-                          }`}
-                        >
-                          <span className={`flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-full text-xs font-bold text-white ${entregado ? 'bg-green-500' : 'bg-blue-500'}`}>
-                            {entregado ? <Check className="h-4 w-4" /> : (p.orden_entrega || i + 1)}
-                          </span>
-                          <span className="min-w-0 flex-1">
-                            <span className="block truncate text-sm font-medium text-gray-900 dark:text-white">
-                              {p.cliente?.nombre_fantasia || 'Cliente'}
-                            </span>
-                            <span className="block truncate text-xs text-gray-500 dark:text-gray-400">
-                              {p.cliente?.direccion || 'Sin dirección'}
-                            </span>
-                          </span>
-                          <span className="flex-shrink-0 text-sm font-semibold text-gray-700 dark:text-gray-300">
-                            {formatPrecio(p.total)}
-                          </span>
-                          <ChevronRight className="h-4 w-4 flex-shrink-0 text-gray-400" />
-                        </button>
-                      );
-                    })}
+                    {paradas.map((p, i) => (
+                      <FilaParada
+                        key={p.id}
+                        parada={p}
+                        numero={p.orden_entrega || i + 1}
+                        activa={paradaActiva?.id === p.id}
+                        onSelect={() => { onSeleccionarParada(p.id); setSnap(SNAP_MEDIO); }}
+                      />
+                    ))}
                   </div>
                 </div>
 

--- a/src/hooks/useNavTramo.ts
+++ b/src/hooks/useNavTramo.ts
@@ -1,0 +1,98 @@
+/**
+ * useNavTramo — pide a la edge function `optimizar-ruta` (modo navegar_tramo)
+ * la guía giro-a-giro de UN tramo: de la posición actual a la próxima parada.
+ *
+ * Fase 1 (navegación asistida): una sola llamada por tramo, SIN recálculo. El
+ * origen se captura una vez (la posición al iniciar el tramo) y no se refetchea
+ * al moverse; el avance de maniobra se calcula client-side contra los puntos
+ * absolutos de cada paso. La query se cachea por destino (`staleTime: Infinity`)
+ * para no gastar llamadas de más. `refetch` queda expuesto para la Fase 2
+ * (recálculo al desviarse).
+ */
+import { useMemo } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { supabase } from './supabase/base';
+import { decodePolyline, type LatLngTuple } from '../utils/polyline';
+
+export interface Coord {
+  lat: number;
+  lng: number;
+}
+
+export interface PasoNav {
+  /** Enum de maniobra de Google (TURN_RIGHT, ROUNDABOUT_LEFT, …) o "". */
+  maniobra: string;
+  /** Texto de la instrucción ya localizado (es-419). */
+  instruccion: string;
+  distancia_metros: number;
+  duracion_segundos: number;
+  polyline: string;
+  /** Punto donde ocurre la maniobra. */
+  inicio: Coord;
+  fin: Coord;
+}
+
+interface TramoNavResponse {
+  success?: boolean;
+  pasos?: PasoNav[];
+  polyline?: string;
+  distancia_metros?: number;
+  duracion_segundos?: number;
+  error?: string;
+  mensaje?: string;
+}
+
+async function fetchTramo(origen: Coord, destino: Coord): Promise<TramoNavResponse> {
+  const { data, error } = await supabase.functions.invoke('optimizar-ruta', {
+    body: { mode: 'navegar_tramo', origen, destino },
+  });
+  if (error) throw new Error(error.message);
+  const r = (data ?? {}) as TramoNavResponse;
+  if (r.error) throw new Error(r.mensaje || r.error);
+  return r;
+}
+
+export interface UseNavTramoReturn {
+  pasos: PasoNav[];
+  /** Geometría del tramo decodificada para dibujar la ruta. */
+  rutaTramo: LatLngTuple[];
+  distanciaMetros: number | null;
+  duracionSegundos: number | null;
+  cargando: boolean;
+  error: string | null;
+  refetch: () => void;
+}
+
+export function useNavTramo(
+  origen: Coord | null,
+  destino: Coord | null,
+  enabled: boolean,
+): UseNavTramoReturn {
+  // La query se keyea SOLO por destino: una sola llamada por tramo. El origen se
+  // captura en el closure del queryFn (la última posición al habilitarse); los
+  // cambios de origen al moverse no re-fetchean porque la key no cambia.
+  const query = useQuery({
+    queryKey: ['nav-tramo', destino?.lat ?? null, destino?.lng ?? null],
+    queryFn: () => fetchTramo(origen as Coord, destino as Coord),
+    enabled: enabled && !!origen && !!destino,
+    staleTime: Infinity,
+    retry: 1,
+    refetchOnWindowFocus: false,
+  });
+
+  const polyline = query.data?.polyline;
+  const rutaTramo = useMemo<LatLngTuple[]>(
+    () => (polyline ? decodePolyline(polyline) : []),
+    [polyline],
+  );
+
+  return {
+    pasos: query.data?.pasos ?? [],
+    rutaTramo,
+    distanciaMetros: query.data?.distancia_metros ?? null,
+    duracionSegundos: query.data?.duracion_segundos ?? null,
+    cargando: query.isFetching,
+    error: query.error instanceof Error ? query.error.message : null,
+    refetch: () => { void query.refetch(); },
+  };
+}

--- a/src/hooks/useNavegacionVoz.ts
+++ b/src/hooks/useNavegacionVoz.ts
@@ -1,0 +1,112 @@
+/**
+ * useNavegacionVoz — voz para la navegación in-app con Web Speech API
+ * (speechSynthesis). Gratis y, en Android, offline una vez bajado el pack de
+ * voz en español (clave para túneles/zonas muertas).
+ *
+ * Gotchas que maneja (validados para Android Chrome PWA):
+ *  - Activación de usuario: `speak()` solo arranca si hubo un gesto. `prime()`
+ *    se llama DENTRO del tap de "Iniciar navegación" para desbloquear la voz
+ *    del resto de la sesión.
+ *  - getVoices() viene vacío al principio: se reintenta en `voiceschanged`.
+ *  - No existe voz es-AR garantizada: se elige por prefijo `es-*` (priorizando
+ *    es-419/es-AR/es-US/es-MX > es-ES) y se prefiere `localService` (offline).
+ *  - Las instrucciones se encolan: `cancel()` antes de cada `speak()`, con un
+ *    pequeño delay para que Chrome no se coma la frase.
+ */
+import { useCallback, useEffect, useRef } from 'react';
+
+function rankVoz(v: SpeechSynthesisVoice): number {
+  const l = (v.lang || '').toLowerCase();
+  let s = 0;
+  if (l.startsWith('es-419') || l.startsWith('es-ar') || l.startsWith('es-us') || l.startsWith('es-mx')) {
+    s += 4;
+  } else if (l.startsWith('es-es')) {
+    s += 1;
+  } else if (l.startsWith('es')) {
+    s += 2;
+  }
+  if (v.localService) s += 2; // preferir offline
+  return s;
+}
+
+function elegirVoz(voces: SpeechSynthesisVoice[]): SpeechSynthesisVoice | null {
+  const es = voces.filter(v => (v.lang || '').toLowerCase().startsWith('es'));
+  if (es.length === 0) return null;
+  return [...es].sort((a, b) => rankVoz(b) - rankVoz(a))[0];
+}
+
+export interface UseNavegacionVozReturn {
+  /** Desbloquea la voz; llamar DENTRO del gesto de inicio. */
+  prime: () => void;
+  /** Dice una frase (no repite la última salvo `forzar`). */
+  decir: (texto: string, opts?: { forzar?: boolean }) => void;
+  /** Corta cualquier locución en curso. */
+  callar: () => void;
+  soportada: boolean;
+}
+
+export function useNavegacionVoz(): UseNavegacionVozReturn {
+  const vozRef = useRef<SpeechSynthesisVoice | null>(null);
+  const ultimoRef = useRef<string>('');
+  const soportada = typeof window !== 'undefined' && 'speechSynthesis' in window;
+
+  useEffect(() => {
+    if (!soportada) return;
+    const cargar = (): void => {
+      const elegida = elegirVoz(window.speechSynthesis.getVoices());
+      if (elegida) vozRef.current = elegida;
+    };
+    cargar();
+    window.speechSynthesis.addEventListener('voiceschanged', cargar);
+    return () => window.speechSynthesis.removeEventListener('voiceschanged', cargar);
+  }, [soportada]);
+
+  const prime = useCallback((): void => {
+    if (!soportada) return;
+    try {
+      const u = new SpeechSynthesisUtterance(' ');
+      u.volume = 0;
+      u.lang = vozRef.current?.lang || 'es-419';
+      window.speechSynthesis.cancel();
+      window.speechSynthesis.speak(u);
+    } catch {
+      // sin voz; la nav funciona igual con el banner visual
+    }
+  }, [soportada]);
+
+  const decir = useCallback((texto: string, opts?: { forzar?: boolean }): void => {
+    if (!soportada || !texto) return;
+    if (!opts?.forzar && texto === ultimoRef.current) return;
+    ultimoRef.current = texto;
+    try {
+      window.speechSynthesis.cancel();
+      const u = new SpeechSynthesisUtterance(texto);
+      u.lang = vozRef.current?.lang || 'es-419';
+      if (vozRef.current) u.voice = vozRef.current;
+      u.rate = 1;
+      u.pitch = 1;
+      // Delay corto: en algunos Chrome, speak() inmediato tras cancel() se pierde.
+      window.setTimeout(() => {
+        try {
+          window.speechSynthesis.speak(u);
+        } catch {
+          // ignore
+        }
+      }, 60);
+    } catch {
+      // ignore
+    }
+  }, [soportada]);
+
+  const callar = useCallback((): void => {
+    if (!soportada) return;
+    try {
+      window.speechSynthesis.cancel();
+    } catch {
+      // ignore
+    }
+    ultimoRef.current = '';
+  }, [soportada]);
+
+  return { prime, decir, callar, soportada };
+}

--- a/src/hooks/useWakeLock.ts
+++ b/src/hooks/useWakeLock.ts
@@ -1,0 +1,100 @@
+/**
+ * useWakeLock — mantiene la pantalla encendida durante la navegación (Screen
+ * Wake Lock API). En una PWA, si la pantalla se apaga el GPS deja de emitir y
+ * la nav muere, así que esto es condición necesaria del modo navegación.
+ *
+ * Gotchas que maneja:
+ *  - Se debe pedir desde un gesto y con el documento visible → `solicitar()` se
+ *    llama dentro del tap de "Iniciar navegación".
+ *  - El lock se suelta solo cada vez que la app pierde visibilidad (llamada,
+ *    cambio de app, pantalla apagada) → se re-adquiere en `visibilitychange`.
+ *  - Bajo ahorro de batería el request puede ser rechazado: se traga el error
+ *    (la nav sigue, pero la pantalla podría apagarse).
+ */
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+interface WakeLockSentinelLike {
+  released: boolean;
+  release: () => Promise<void>;
+  addEventListener: (type: string, listener: () => void) => void;
+}
+interface WakeLockNavigator {
+  wakeLock?: { request: (type: 'screen') => Promise<WakeLockSentinelLike> };
+}
+
+export interface UseWakeLockReturn {
+  /** Pide el lock y activa la re-adquisición. Llamar dentro de un gesto. */
+  solicitar: () => void;
+  /** Libera el lock y desactiva la re-adquisición. */
+  liberar: () => void;
+  soportado: boolean;
+}
+
+export function useWakeLock(): UseWakeLockReturn {
+  const sentinelRef = useRef<WakeLockSentinelLike | null>(null);
+  const activoRef = useRef<boolean>(false);
+  // Ref al último `pedir` para que el listener 'release' lo invoque sin que
+  // `pedir` se referencie a sí mismo (evita el TDZ del callback).
+  const pedirRef = useRef<() => void>(() => {});
+  const [soportado] = useState<boolean>(
+    () => typeof navigator !== 'undefined' && 'wakeLock' in navigator,
+  );
+
+  const pedir = useCallback(async (): Promise<void> => {
+    const nav = navigator as unknown as WakeLockNavigator;
+    if (!nav.wakeLock) return;
+    if (sentinelRef.current && !sentinelRef.current.released) return;
+    if (typeof document !== 'undefined' && document.visibilityState !== 'visible') return;
+    try {
+      const sentinel = await nav.wakeLock.request('screen');
+      sentinelRef.current = sentinel;
+      // Si el sistema lo suelta solo (no por nosotros), intentar recuperarlo.
+      sentinel.addEventListener('release', () => {
+        if (activoRef.current && document.visibilityState === 'visible') {
+          pedirRef.current();
+        }
+      });
+    } catch {
+      // ahorro de batería / no visible: la pantalla podría apagarse
+    }
+  }, []);
+
+  useEffect(() => {
+    pedirRef.current = () => { void pedir(); };
+  }, [pedir]);
+
+  const solicitar = useCallback((): void => {
+    activoRef.current = true;
+    void pedir();
+  }, [pedir]);
+
+  const liberar = useCallback((): void => {
+    activoRef.current = false;
+    const sentinel = sentinelRef.current;
+    sentinelRef.current = null;
+    if (sentinel && !sentinel.released) {
+      void sentinel.release().catch(() => {});
+    }
+  }, []);
+
+  // Re-adquirir al volver a primer plano; liberar al desmontar.
+  useEffect(() => {
+    const onVisibilidad = (): void => {
+      if (activoRef.current && document.visibilityState === 'visible') {
+        void pedir();
+      }
+    };
+    document.addEventListener('visibilitychange', onVisibilidad);
+    return () => {
+      document.removeEventListener('visibilitychange', onVisibilidad);
+      activoRef.current = false;
+      const sentinel = sentinelRef.current;
+      sentinelRef.current = null;
+      if (sentinel && !sentinel.released) {
+        void sentinel.release().catch(() => {});
+      }
+    };
+  }, [pedir]);
+
+  return { solicitar, liberar, soportado };
+}

--- a/src/index.css
+++ b/src/index.css
@@ -11,6 +11,11 @@ body {
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, sans-serif;
   @apply bg-stone-50 dark:bg-gray-900 text-gray-900 dark:text-gray-100;
   letter-spacing: -0.005em;
+  /* Mata el pull-to-refresh / rubber-band de iOS que recargaba el PWA
+     standalone al arrastrar el bottom sheet (vaul en modo no-modal no lockea
+     el body). A nivel documento porque el overscroll nace del fondo, no del
+     contenedor del sheet. */
+  overscroll-behavior: none;
 }
 
 /* Personalidad para titulares: kerning levemente apretado +
@@ -25,6 +30,7 @@ h1, h2, h3 {
 /* Transición suave para el cambio de tema */
 html {
   transition: background-color 0.3s ease, color 0.3s ease;
+  overscroll-behavior: none;
 }
 
 /*

--- a/supabase/functions/deno.json
+++ b/supabase/functions/deno.json
@@ -7,7 +7,7 @@
     "test": "deno test --allow-env --allow-net=api.telegram.org --allow-read",
     "lint": "deno lint",
     "fmt": "deno fmt",
-    "check": "deno check optimizar-ruta/index.ts optimizar-ruta/tramos.ts optimizar-ruta/route-optimization.ts optimizar-ruta/sa-auth.ts telegram-webhook/index.ts telegram-webhook/handlers.ts telegram-webhook/commands/*.ts telegram-webhook/formatters/*.ts telegram-digest/index.ts telegram-digest/digest.ts _shared/*.ts _shared/tools/*.ts _shared/tools/common/*.ts _shared/tools/admin/*.ts _shared/tools/preventista/*.ts _shared/tools/transportista/*.ts _shared/transcribe/*.ts _shared/gemini/agent.ts _shared/gemini/client.ts _shared/gemini/history-mapper.ts _shared/gemini/memory.ts _shared/gemini/schema.ts _shared/gemini/types.ts _shared/gemini/prompts/*.ts tests/*.ts"
+    "check": "deno check optimizar-ruta/index.ts optimizar-ruta/tramos.ts optimizar-ruta/route-optimization.ts optimizar-ruta/sa-auth.ts optimizar-ruta/navegar-tramo.ts telegram-webhook/index.ts telegram-webhook/handlers.ts telegram-webhook/commands/*.ts telegram-webhook/formatters/*.ts telegram-digest/index.ts telegram-digest/digest.ts _shared/*.ts _shared/tools/*.ts _shared/tools/common/*.ts _shared/tools/admin/*.ts _shared/tools/preventista/*.ts _shared/tools/transportista/*.ts _shared/transcribe/*.ts _shared/gemini/agent.ts _shared/gemini/client.ts _shared/gemini/history-mapper.ts _shared/gemini/memory.ts _shared/gemini/schema.ts _shared/gemini/types.ts _shared/gemini/prompts/*.ts tests/*.ts"
   },
   "lint": {
     "rules": {

--- a/supabase/functions/optimizar-ruta/index.ts
+++ b/supabase/functions/optimizar-ruta/index.ts
@@ -25,6 +25,7 @@ import {
   unirTramos,
 } from "./tramos.ts";
 import { optimizeTours } from "./route-optimization.ts";
+import { navegarTramo } from "./navegar-tramo.ts";
 
 const CORS_HEADERS: Record<string, string> = {
   "Access-Control-Allow-Origin": "*",
@@ -34,6 +35,11 @@ const CORS_HEADERS: Record<string, string> = {
 };
 
 interface RequestBody {
+  /** "navegar_tramo" → guía giro-a-giro de un tramo; ausente → optimizar ruta. */
+  mode?: string;
+  /** Modo navegar_tramo: origen (posición actual) y destino (próxima parada). */
+  origen?: { lat?: number | null; lng?: number | null };
+  destino?: { lat?: number | null; lng?: number | null };
   deposito_lat?: number;
   deposito_lng?: number;
   pedidos?: Array<Partial<PedidoRuta> & { latitud?: number | null; longitud?: number | null }>;
@@ -125,6 +131,41 @@ serve(async (req: Request) => {
     body = await req.json();
   } catch {
     return jsonResponse({ success: false, error: "Body inválido", mensaje: "Se esperaba JSON" });
+  }
+
+  // --- Modo navegación asistida: guía giro-a-giro de un solo tramo ---
+  if (body.mode === "navegar_tramo") {
+    if (!apiKey) {
+      return jsonResponse({
+        success: false,
+        error: "Navegación no configurada",
+        mensaje: "Falta GOOGLE_API_KEY (Routes API) para la navegación in-app",
+      });
+    }
+    const o = body.origen;
+    const d = body.destino;
+    if (o?.lat == null || o?.lng == null || d?.lat == null || d?.lng == null) {
+      return jsonResponse({
+        success: false,
+        error: "Faltan coordenadas",
+        mensaje: "Se requieren origen y destino con lat/lng para navegar el tramo",
+      });
+    }
+    try {
+      const tramo = await navegarTramo(
+        apiKey,
+        { latitude: o.lat, longitude: o.lng },
+        { latitude: d.lat, longitude: d.lng },
+      );
+      return jsonResponse({ success: true, ...tramo });
+    } catch (err) {
+      console.error("[optimizar-ruta] navegar_tramo error:", err);
+      return jsonResponse({
+        success: false,
+        error: "No se pudo calcular el tramo de navegación",
+        mensaje: err instanceof Error ? err.message : "Error al calcular la ruta",
+      });
+    }
   }
 
   const pedidos = body.pedidos ?? [];

--- a/supabase/functions/optimizar-ruta/navegar-tramo.ts
+++ b/supabase/functions/optimizar-ruta/navegar-tramo.ts
@@ -1,0 +1,142 @@
+// Navegación asistida de UN tramo (posición actual → próxima parada) para el
+// turn-by-turn in-app del transportista. A diferencia del optimizador (que da
+// el ORDEN global de las paradas), acá pedimos a Routes API computeRoutes los
+// PASOS con maniobras (`navigationInstruction`) y la geometría por paso, para
+// guiar al chofer giro a giro dentro de la app.
+//
+// Costo: un solo origen → un destino, sin intermedios, `TRAFFIC_UNAWARE` →
+// queda en el tier Essentials de Routes API (pedir steps/navigationInstruction
+// NO sube de tier; lo que sube es el tráfico o >10 waypoints). languageCode
+// es-419 para que las instrucciones vengan en castellano.
+//
+// Separado de index.ts para poder testear el parseo sin red.
+
+import type { LatLng } from "./tramos.ts";
+
+export interface PasoNavegacion {
+  /** Enum de maniobra de Google (TURN_RIGHT, ROUNDABOUT_LEFT, …) o "". */
+  maniobra: string;
+  /** Texto de la instrucción ya localizado (es-419). */
+  instruccion: string;
+  distancia_metros: number;
+  duracion_segundos: number;
+  /** Geometría del paso (encoded polyline, precisión 5). */
+  polyline: string;
+  /** Punto donde ocurre la maniobra (startLocation del paso). */
+  inicio: { lat: number; lng: number };
+  /** Fin del paso (endLocation). */
+  fin: { lat: number; lng: number };
+}
+
+export interface TramoNavegacion {
+  pasos: PasoNavegacion[];
+  /** Geometría completa del tramo (encoded polyline) para dibujar la ruta. */
+  polyline: string;
+  distancia_metros: number;
+  duracion_segundos: number;
+}
+
+// --- Subconjunto tipado de la respuesta de computeRoutes que consumimos ---
+interface RoutesLatLng {
+  latLng?: { latitude?: number; longitude?: number };
+}
+interface RoutesStep {
+  navigationInstruction?: { maneuver?: string; instructions?: string };
+  distanceMeters?: number;
+  staticDuration?: string;
+  polyline?: { encodedPolyline?: string };
+  startLocation?: RoutesLatLng;
+  endLocation?: RoutesLatLng;
+}
+interface RoutesLeg {
+  steps?: RoutesStep[];
+}
+interface RoutesRoute {
+  distanceMeters?: number;
+  duration?: string;
+  polyline?: { encodedPolyline?: string };
+  legs?: RoutesLeg[];
+}
+export interface RoutesResponse {
+  routes?: RoutesRoute[];
+  error?: { message?: string };
+}
+
+/** FieldMask: pasos con maniobra + geometría + totales del tramo. */
+const NAV_FIELD_MASK = [
+  "routes.legs.steps.navigationInstruction",
+  "routes.legs.steps.distanceMeters",
+  "routes.legs.steps.staticDuration",
+  "routes.legs.steps.polyline.encodedPolyline",
+  "routes.legs.steps.startLocation",
+  "routes.legs.steps.endLocation",
+  "routes.polyline.encodedPolyline",
+  "routes.duration",
+  "routes.distanceMeters",
+].join(",");
+
+const seg = (s: string | undefined): number =>
+  parseInt(String(s ?? "0s").replace("s", "")) || 0;
+
+const coord = (loc: RoutesLatLng | undefined): { lat: number; lng: number } => ({
+  lat: loc?.latLng?.latitude ?? 0,
+  lng: loc?.latLng?.longitude ?? 0,
+});
+
+/** Transforma la respuesta de computeRoutes en el tramo que consume el front. */
+export function parseNavTramo(data: RoutesResponse): TramoNavegacion {
+  const route = data.routes?.[0];
+  if (!route) {
+    throw new Error("Google Routes no devolvió una ruta para el tramo");
+  }
+  const pasos: PasoNavegacion[] = (route.legs ?? [])
+    .flatMap((leg) => leg.steps ?? [])
+    .map((s) => ({
+      maniobra: s.navigationInstruction?.maneuver ?? "",
+      instruccion: s.navigationInstruction?.instructions ?? "",
+      distancia_metros: s.distanceMeters ?? 0,
+      duracion_segundos: seg(s.staticDuration),
+      polyline: s.polyline?.encodedPolyline ?? "",
+      inicio: coord(s.startLocation),
+      fin: coord(s.endLocation),
+    }));
+
+  return {
+    pasos,
+    polyline: route.polyline?.encodedPolyline ?? "",
+    distancia_metros: route.distanceMeters ?? 0,
+    duracion_segundos: seg(route.duration),
+  };
+}
+
+/** Pide a Routes API el tramo navegable origen → destino (sin intermedios). */
+export async function navegarTramo(
+  apiKey: string,
+  origen: LatLng,
+  destino: LatLng,
+): Promise<TramoNavegacion> {
+  const res = await fetch("https://routes.googleapis.com/directions/v2:computeRoutes", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "X-Goog-Api-Key": apiKey,
+      "X-Goog-FieldMask": NAV_FIELD_MASK,
+    },
+    body: JSON.stringify({
+      origin: { location: { latLng: origen } },
+      destination: { location: { latLng: destino } },
+      travelMode: "DRIVE",
+      // Sin tráfico a propósito: tramos cortos urbanos + queda en Essentials.
+      routingPreference: "TRAFFIC_UNAWARE",
+      polylineEncoding: "ENCODED_POLYLINE",
+      languageCode: "es-419",
+      units: "METRIC",
+    }),
+  });
+
+  const data = (await res.json()) as RoutesResponse;
+  if (data.error) {
+    throw new Error(data.error.message ?? `Google Routes API HTTP ${res.status}`);
+  }
+  return parseNavTramo(data);
+}

--- a/supabase/functions/tests/navegar_tramo.test.ts
+++ b/supabase/functions/tests/navegar_tramo.test.ts
@@ -1,0 +1,68 @@
+// Tests del parseo del tramo de navegación asistida (sin red).
+// Import vía el alias std/ del deno.json (ver nota en optimizar_ruta.test.ts).
+import { assertEquals, assertThrows } from "std/assert/mod.ts";
+import { parseNavTramo, type RoutesResponse } from "../optimizar-ruta/navegar-tramo.ts";
+
+const respuestaOk: RoutesResponse = {
+  routes: [
+    {
+      distanceMeters: 1200,
+      duration: "300s",
+      polyline: { encodedPolyline: "_overview_" },
+      legs: [
+        {
+          steps: [
+            {
+              navigationInstruction: { maneuver: "DEPART", instructions: "Dirígete al norte" },
+              distanceMeters: 100,
+              staticDuration: "30s",
+              polyline: { encodedPolyline: "aa" },
+              startLocation: { latLng: { latitude: -26.80, longitude: -65.20 } },
+              endLocation: { latLng: { latitude: -26.81, longitude: -65.21 } },
+            },
+            {
+              navigationInstruction: { maneuver: "TURN_RIGHT", instructions: "Gira a la derecha" },
+              distanceMeters: 1100,
+              staticDuration: "270s",
+              polyline: { encodedPolyline: "bb" },
+              startLocation: { latLng: { latitude: -26.81, longitude: -65.21 } },
+              endLocation: { latLng: { latitude: -26.82, longitude: -65.22 } },
+            },
+          ],
+        },
+      ],
+    },
+  ],
+};
+
+Deno.test("parseNavTramo extrae pasos, maniobras, geometría y totales", () => {
+  const tramo = parseNavTramo(respuestaOk);
+  assertEquals(tramo.pasos.length, 2);
+  assertEquals(tramo.pasos[0].maniobra, "DEPART");
+  assertEquals(tramo.pasos[0].instruccion, "Dirígete al norte");
+  assertEquals(tramo.pasos[1].maniobra, "TURN_RIGHT");
+  assertEquals(tramo.pasos[1].distancia_metros, 1100);
+  assertEquals(tramo.pasos[1].duracion_segundos, 270);
+  assertEquals(tramo.pasos[1].inicio, { lat: -26.81, lng: -65.21 });
+  assertEquals(tramo.pasos[1].fin, { lat: -26.82, lng: -65.22 });
+  assertEquals(tramo.polyline, "_overview_");
+  assertEquals(tramo.distancia_metros, 1200);
+  assertEquals(tramo.duracion_segundos, 300);
+});
+
+Deno.test("parseNavTramo tolera campos faltantes sin romper", () => {
+  const tramo = parseNavTramo({
+    routes: [{ legs: [{ steps: [{}] }] }],
+  });
+  assertEquals(tramo.pasos.length, 1);
+  assertEquals(tramo.pasos[0].maniobra, "");
+  assertEquals(tramo.pasos[0].instruccion, "");
+  assertEquals(tramo.pasos[0].inicio, { lat: 0, lng: 0 });
+  assertEquals(tramo.polyline, "");
+  assertEquals(tramo.distancia_metros, 0);
+});
+
+Deno.test("parseNavTramo tira error si no hay ruta", () => {
+  assertThrows(() => parseNavTramo({ routes: [] }), Error);
+  assertThrows(() => parseNavTramo({}), Error);
+});


### PR DESCRIPTION
## Resumen

Dos cosas sobre la pantalla **Ruta Activa** del transportista:

1. **`feat(rutas)`: navegación asistida giro-a-giro DENTRO de la app (fase 1).** El chofer navega de su posición a la próxima parada sin salir de la app. El handoff a Google Maps/Waze queda como fallback.
2. **`fix(rutas)`: UX mobile/iOS del bottom sheet.** Se cerraba la app en iOS al expandir el sheet, las acciones quedaban tapadas por el home indicator y costaba ver las próximas paradas.

---

## 1. Navegación asistida in-app (fase 1)

PWA → el Navigation SDK de Google es solo nativo, así que la nav se construye sobre **Routes API (`computeRoutes`) + Maps JS + browser APIs**. Fase 1 = **asistida** (cámara que sigue + banner de maniobra + voz), **sin snap ni recálculo**.

- **Edge `optimizar-ruta`** — nuevo modo `navegar_tramo` (módulo `navegar-tramo.ts`): pide los pasos con maniobras de **un solo tramo** (origen→destino, sin intermedios, `TRAFFIC_UNAWARE` → tier **Essentials**, `languageCode: es-419`). Aditivo: el flujo de optimización queda igual. **Desplegado (v12) y verificado en vivo** contra la API real (devuelve maniobras en castellano + polyline por paso). Incluye test de parseo (deno).
- **Hooks** — `useNavTramo` (1 llamada por tramo, cacheada por destino; `refetch` listo para fase 2), `useNavegacionVoz` (Web Speech, `prime` dentro del gesto, voz por prefijo `es-*`, gratis/offline), `useWakeLock` (pantalla encendida + re-adquirir en `visibilitychange`).
- **UI** — `NavAsistida` (pantalla completa, reusa `MapaRutaGoogle` en modo follow) + `BannerManiobra` (enum de maniobra → ícono). Wiring en `RutaActivaTransportista` (flag `modoNavegacion`, GPS a 1s en nav, `prime`+`vibrate`+`wakelock` dentro del tap de inicio) y botón "Navegar en la app" en `SheetParada`.

**Costo:** 1 chofer ≈ 1–1.7k llamadas/mes → entra en el free tier (10k). Nunca recálculo continuo ni `TRAFFIC_AWARE` (saltaría a Pro). Sin persistir tramos (efímero + ToS).

## 2. Fix UX mobile/iOS del sheet

- `index.html`: **`viewport-fit=cover`** → habilita `env(safe-area-inset-*)` real en iOS (antes daba 0 → acciones bajo el home indicator).
- `index.css`: **`overscroll-behavior: none`** en `html`/`body` → mata el pull-to-refresh/overscroll que recargaba el PWA standalone al arrastrar el sheet.
- `SheetParada`: **`Drawer.Handle`** (hit-area 44px), reestructura en **bloque fijo superior** (encabezado + acciones) + **bloque scrollable** (`overscroll-contain` + `pb` safe-area), y **"Próximas paradas"** visibles/scrolleables desde el snap medio (antes solo al expandir del todo).

---

## Verificación

- ✅ `tsc --noEmit` limpio · ESLint limpio · **692/692 vitest** (verde en pre-commit de ambos commits).
- ✅ Deno: typecheck + tests de parseo del tramo.
- ✅ Edge `navegar_tramo` desplegada (v12) y probada en vivo (tramo real en Tucumán → 8 pasos, maniobras en es-419).

### Falta probar en dispositivo (no se valida en CI)
En **iPhone con la PWA instalada (standalone)** — único entorno donde el safe-area y el reload por overscroll se comportan de verdad:
- El sheet no recarga la app al arrastrar/expandir; acciones por encima del home indicator; próximas paradas visibles desde el snap medio.
- "Navegar en la app": que cante la maniobra dentro del mismo tap, siga la posición, y al llegar (geofence 100m) vuelva a "Entregar".
- `TopNavigation` se dejó sin tocar; si en el celu se ve corte arriba con el notch, agregar `safe-area-top` (cambio acotado, gateado por evidencia).

## Sin migración
Ninguna de las dos partes toca la base (la edge ya estaba desplegada; el fix mobile es puro front).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
