### PR TITLE
fix(rutas): mapa vector gris (CSP) + layout de nav + mapa admin más grande

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,7 +10,12 @@
 
     <!-- Content Security Policy - Fortalecido -->
     <!-- NOTE: 'unsafe-inline' in style-src is required by Vite/TailwindCSS injected styles -->
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' https://maps.googleapis.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https://maps.gstatic.com https://maps.googleapis.com https://*.tile.openstreetmap.org https://*.basemaps.cartocdn.com; connect-src 'self' https://*.supabase.co https://*.supabase.in wss://*.supabase.co https://maps.googleapis.com https://*.sentry.io; frame-ancestors 'none'; base-uri 'self'; form-action 'self';">
+    <!-- NOTE: el VECTOR map de Google (WebGL) necesita worker-src/script-src blob:,
+         connect-src + img-src + font-src de *.googleapis.com / *.gstatic.com (el raster
+         no, por eso antes andaba). Ver doc "Content Security Policy" de Maps JS. -->
+    <!-- IMPORTANTE: mantener `connect-src 'self'` como prefijo: el plugin
+         inject-csp-connect-src (vite.config.js) le appendea dominios n8n ahí. -->
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' https://maps.googleapis.com blob:; worker-src 'self' blob:; style-src 'self' 'unsafe-inline'; font-src 'self' https://fonts.gstatic.com data:; img-src 'self' data: blob: https://*.googleapis.com https://*.gstatic.com https://*.google.com https://*.googleusercontent.com https://*.tile.openstreetmap.org https://*.basemaps.cartocdn.com; connect-src 'self' https://*.supabase.co https://*.supabase.in wss://*.supabase.co https://*.googleapis.com https://*.gstatic.com https://*.sentry.io; frame-ancestors 'none'; base-uri 'self'; form-action 'self';">
 
     <!-- PWA Meta Tags -->
     <meta name="theme-color" content="#2563eb" />

--- a/src/components/rutaActiva/BannerManiobra.tsx
+++ b/src/components/rutaActiva/BannerManiobra.tsx
@@ -78,24 +78,26 @@ export default function BannerManiobra({
   const IconoSiguiente = instruccionSiguiente ? (ICONOS[maniobraSiguiente ?? ''] ?? Navigation) : null;
 
   return (
-    <div className="rounded-2xl bg-gray-900/95 px-4 py-3 text-white shadow-xl">
-      <div className="flex items-center gap-3">
-        <div className="flex h-14 w-14 flex-shrink-0 items-center justify-center rounded-xl bg-blue-600">
-          <Icono className="h-8 w-8" strokeWidth={2.5} />
+    <div className="rounded-2xl bg-gray-900/95 px-4 py-3.5 text-white shadow-xl ring-1 ring-white/10 backdrop-blur">
+      <div className="flex items-center gap-3.5">
+        <div className="flex h-16 w-16 flex-shrink-0 items-center justify-center rounded-2xl bg-blue-600">
+          <Icono className="h-9 w-9" strokeWidth={2.5} />
         </div>
         <div className="min-w-0 flex-1">
           {distanciaMetros != null && (
-            <p className="text-2xl font-extrabold leading-tight">
+            <p className="text-3xl font-extrabold leading-none tabular-nums">
               {formatDistancia(distanciaMetros)}
             </p>
           )}
-          <p className="truncate text-base font-medium text-gray-100">{instruccion}</p>
+          <p className="mt-1 line-clamp-2 text-base font-medium leading-snug text-gray-100">
+            {instruccion}
+          </p>
         </div>
       </div>
       {IconoSiguiente && instruccionSiguiente && (
-        <div className="mt-2 flex items-center gap-2 border-t border-white/10 pt-2 text-sm text-gray-300">
-          <span className="flex-shrink-0 text-xs font-semibold uppercase text-gray-400">Luego</span>
-          <IconoSiguiente className="h-4 w-4 flex-shrink-0" />
+        <div className="mt-2.5 flex items-center gap-2 border-t border-white/10 pt-2 text-sm text-gray-300">
+          <span className="flex-shrink-0 text-[11px] font-semibold uppercase tracking-wide text-gray-400">Luego</span>
+          <IconoSiguiente className="h-4 w-4 flex-shrink-0 text-gray-300" />
           <span className="truncate">{instruccionSiguiente}</span>
         </div>
       )}

--- a/src/components/rutaActiva/MapaRutaGoogle.tsx
+++ b/src/components/rutaActiva/MapaRutaGoogle.tsx
@@ -95,7 +95,9 @@ export default function MapaRutaGoogle({
       center: deposito ?? FALLBACK_CENTER,
       zoom: 13,
       // Vector map (si hay Map ID) para poder tiltar/rotar la cámara en guía.
-      ...(USAR_VECTOR ? { mapId: MAP_ID, renderingType: g.RenderingType?.VECTOR } : {}),
+      // El Map ID ya está configurado como vector en la consola; con pasar mapId
+      // alcanza (no forzamos renderingType para evitar conflictos).
+      ...(USAR_VECTOR ? { mapId: MAP_ID } : {}),
       mapTypeControl: false,
       streetViewControl: false,
       fullscreenControl: false,

--- a/src/components/rutaActiva/SheetParada.tsx
+++ b/src/components/rutaActiva/SheetParada.tsx
@@ -117,6 +117,13 @@ export default function SheetParada({
     if (llegaste) setSnap(s => (s === SNAP_COLAPSADO ? SNAP_MEDIO : s));
   }, [llegaste]);
 
+  // Al arrancar la guía, colapsar a la píldora → más mapa para manejar. El chofer
+  // puede subirlo con un toque (no se re-colapsa solo: depende de que cambie
+  // guiando/llegaste, no de cada render).
+  useEffect(() => {
+    if (guiando && !llegaste) setSnap(SNAP_COLAPSADO);
+  }, [guiando, llegaste]);
+
   return (
     <Drawer.Root
       open
@@ -156,15 +163,25 @@ export default function SheetParada({
                       <p className="truncate text-xs text-gray-500 dark:text-gray-400">
                         {llegaste
                           ? '📍 Llegaste — confirmá la entrega'
-                          : distanciaMetros != null
-                            ? `A ${formatDistancia(distanciaMetros)} · ${pendientes.length} pendientes`
-                            : `${pendientes.length} entregas pendientes`}
+                          : guiando
+                            ? `Próxima parada · ${pendientes.length} pendientes`
+                            : distanciaMetros != null
+                              ? `A ${formatDistancia(distanciaMetros)} · ${pendientes.length} pendientes`
+                              : `${pendientes.length} entregas pendientes`}
                       </p>
                     </div>
                   </div>
-                  <span className="flex-shrink-0 text-lg font-bold text-gray-900 dark:text-white">
-                    {formatPrecio(paradaActiva.total)}
-                  </span>
+                  {/* Guiando: la distancia es lo glanceable (grande, tabular para que
+                      no titile al bajar). Si no, el monto a cobrar. */}
+                  {guiando && !llegaste && distanciaMetros != null ? (
+                    <span className="flex-shrink-0 text-xl font-extrabold tabular-nums text-blue-600 dark:text-blue-400">
+                      {formatDistancia(distanciaMetros)}
+                    </span>
+                  ) : (
+                    <span className="flex-shrink-0 text-lg font-bold text-gray-900 dark:text-white">
+                      {formatPrecio(paradaActiva.total)}
+                    </span>
+                  )}
                 </div>
 
                 {/* Tarjeta de la parada activa (visible desde snap medio) */}

--- a/src/components/vistas/VistaRecorridos.tsx
+++ b/src/components/vistas/VistaRecorridos.tsx
@@ -323,7 +323,7 @@ function RecorridoCard({ recorrido, defaultExpanded = false }: RecorridoCardProp
                   .filter((p): p is NonNullable<typeof p> => p !== null)}
                 deposito={deposito}
                 rutaReal={(() => { const r = decodePolylines(recorrido.polylines); return r.length > 1 ? r : null; })()}
-                altura={240}
+                altura={440}
               />
             </div>
           </Suspense>


### PR DESCRIPTION
## Resumen

Fixes tras probar las fases A–D (#373, ya en `main`) en el celu:

1. **Mapa gris (vector) → CSP.** El bug más importante: el mapa base **vector (WebGL) estaba bloqueado por la Content-Security-Policy**. El raster andaba porque usa `<img>` (permitido en `img-src`); el vector necesita **Web Workers desde `blob:`** + fetch de tiles/fonts de `*.googleapis.com` / `*.gstatic.com`, que la CSP no habilitaba. Por eso se veían la flecha y la línea (capas DOM) pero el fondo quedaba gris (en overview y navegando, sin rellenarse al pan/zoom).
   - `index.html`: agrega `worker-src 'self' blob:`, `blob:` en `script-src`, `font-src https://fonts.gstatic.com`, y amplía `img-src`/`connect-src` a los dominios de Google (manteniendo el prefijo `connect-src 'self'` que usa el plugin `inject-csp-connect-src` de `vite.config.js`). Directivas según la doc oficial de Maps JS.
   - `MapaRutaGoogle`: pasa solo `mapId` (sin forzar `renderingType`).

2. **Layout de navegación más cómodo (manejando).** Al guiar, el bottom sheet del pedido se **colapsa solo a la píldora** → más mapa; la píldora muestra la **distancia grande** (tabular, no titila). Se puede subir con un toque para ver detalle; al llegar sube solo (Entregar). El `BannerManiobra` quedó con más jerarquía/contraste: distancia como héroe (3xl), instrucción a 2 líneas, chip de maniobra más grande.

3. **Mapa del admin de Recorridos más grande** (`VistaRecorridos`, altura 240 → 440).

## Sobre la flecha (consulta del usuario)
Confirmado y sin cambios de código: la flecha y la cámara siguen el GPS. Parado, el GPS no se mueve y `heading` viene `null` → la flecha se queda quieta y la cámara no rota. Andando, la flecha se mueve con el chofer y la cámara rota al rumbo.

## Verificación
- ✅ `tsc --noEmit` limpio · ESLint limpio · **701/701 vitest** (verde en pre-commit). El e2e `security.spec.js` solo valida que el meta CSP exista (sigue OK).
- ✅ El prefijo `connect-src 'self'` se mantiene → el plugin de vite que appendea dominios n8n sigue funcionando.

### A revalidar en device (requiere rebuild con `VITE_GOOGLE_MAP_ID`)
- El **mapa base debe renderizar sin gris** (overview y navegando); en DevTools remoto, **0 violaciones CSP**.
- Al tocar Navegar el panel se colapsa (más mapa); banner legible de un vistazo; al llegar sube para Entregar.
- Admin Recorridos con el mapa más grande.

> Si el gris persistiera después del rebuild (improbable): revisar que el Map ID tenga un *map style* válido, o que el GPU del celu no sea el límite (el fallback raster sigue disponible sacando la env).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
