### PR TITLE
feat(rutas): botón centrar + cámara más suave + sheet a barra fija con menú full-screen

### DIFF
--- a/src/components/MapaRuta.tsx
+++ b/src/components/MapaRuta.tsx
@@ -61,6 +61,16 @@ export interface MapaRutaProps {
    */
   modoGuia?: boolean;
   /**
+   * En modo guía, ¿la cámara sigue automáticamente? Se pone false cuando el
+   * chofer mueve el mapa a mano (deja de pelearle el giro, estilo Maps). El
+   * botón "centrar" lo vuelve a true (+ bump de recenterNonce). Default true.
+   */
+  camaraActiva?: boolean;
+  /** Bump para forzar re-centrar la cámara en la posición/rumbo actuales. */
+  recenterNonce?: number;
+  /** El chofer movió el mapa a mano (pan/rotación/zoom) → pausar el seguimiento. */
+  onArrastreUsuario?: () => void;
+  /**
    * Ruta real sobre las calles (polyline decodificada de Google). Si viene con
    * >1 punto se dibuja la línea sólida real; si no, fallback a la línea recta
    * punteada entre paradas (recorridos viejos / sin polyline).

--- a/src/components/rutaActiva/MapaRutaGoogle.tsx
+++ b/src/components/rutaActiva/MapaRutaGoogle.tsx
@@ -63,6 +63,9 @@ export default function MapaRutaGoogle({
   rutaReal = null,
   rutaTramo = null,
   modoGuia = false,
+  camaraActiva = true,
+  recenterNonce = 0,
+  onArrastreUsuario,
 }: MapaRutaProps): React.ReactElement {
   const { isLoaded, isLoading, error } = useGoogleMaps();
   const containerRef = useRef<HTMLDivElement | null>(null);
@@ -84,6 +87,7 @@ export default function MapaRutaGoogle({
   const headingRef = useRef<number>(0);
   const prevPosRef = useRef<{ lat: number; lng: number } | null>(null);
   const animarRef = useRef<() => void>(() => {});
+  const recenterAplicadoRef = useRef<number>(-1);
   const [mapReady, setMapReady] = useState(false);
 
   // 1) Inicializar el mapa una sola vez.
@@ -236,6 +240,8 @@ export default function MapaRutaGoogle({
     if (!mapReady || !mapRef.current) return;
     // En modo guía vector, la cámara la maneja el rAF heading-up (efecto 4b).
     if (USAR_VECTOR && modoGuia) return;
+    // En guía (raster), si el chofer movió el mapa a mano, no re-centramos.
+    if (modoGuia && !camaraActiva) return;
     const map = mapRef.current;
     if (seguirPosicion && posicion) {
       map.panTo({ lat: posicion.lat, lng: posicion.lng });
@@ -251,7 +257,7 @@ export default function MapaRutaGoogle({
       const activa = paradas.find(p => p.orden === paradaActivaOrden);
       if (activa) map.panTo({ lat: activa.lat, lng: activa.lng });
     }
-  }, [mapReady, seguirPosicion, zoomSeguir, posicion, paradaActivaOrden, paradas, modoGuia]);
+  }, [mapReady, seguirPosicion, zoomSeguir, posicion, paradaActivaOrden, paradas, modoGuia, camaraActiva]);
 
   // 4a) Loop de animación de la cámara: interpola la cámara actual hacia el
   //     target en cada frame (rumbo por el camino más corto, sin spin en 0/360).
@@ -262,14 +268,16 @@ export default function MapaRutaGoogle({
       const tgt = camTargetRef.current;
       const map = mapRef.current;
       if (!cam || !tgt || !map) { rafRef.current = null; return; }
-      const k = 0.2;
+      // Easing por propiedad: el rumbo MÁS lento (rotación suave, no brusca);
+      // el centro un poco más ágil. Interpola por el camino más corto del ángulo.
+      const kH = 0.1, kC = 0.18, kT = 0.12;
       const dh = ((tgt.heading - cam.heading + 540) % 360) - 180;
-      cam.heading = (cam.heading + dh * k + 360) % 360;
-      cam.lat += (tgt.lat - cam.lat) * k;
-      cam.lng += (tgt.lng - cam.lng) * k;
-      cam.tilt += (tgt.tilt - cam.tilt) * k;
+      cam.heading = (cam.heading + dh * kH + 360) % 360;
+      cam.lat += (tgt.lat - cam.lat) * kC;
+      cam.lng += (tgt.lng - cam.lng) * kC;
+      cam.tilt += (tgt.tilt - cam.tilt) * kT;
       map.moveCamera({ center: { lat: cam.lat, lng: cam.lng }, heading: cam.heading, tilt: cam.tilt });
-      const convergio = Math.abs(dh) < 0.5
+      const convergio = Math.abs(dh) < 1
         && Math.abs(tgt.lat - cam.lat) < 1e-6
         && Math.abs(tgt.lng - cam.lng) < 1e-6
         && Math.abs(tgt.tilt - cam.tilt) < 0.5;
@@ -284,8 +292,8 @@ export default function MapaRutaGoogle({
     if (!mapReady || !mapRef.current) return;
     const map = mapRef.current;
 
-    if (!(USAR_VECTOR && modoGuia && posicion)) {
-      // Salir del modo cámara: frenar el loop y volver a norte-up plano.
+    // Guía terminada → frenar el loop y volver a norte-up plano.
+    if (!(USAR_VECTOR && modoGuia)) {
       if (rafRef.current != null) { cancelAnimationFrame(rafRef.current); rafRef.current = null; }
       if (camRef.current) {
         camRef.current = null;
@@ -293,6 +301,14 @@ export default function MapaRutaGoogle({
         prevPosRef.current = null;
         map.moveCamera({ heading: 0, tilt: 0 });
       }
+      return;
+    }
+
+    // En guía pero el chofer movió el mapa a mano (camaraActiva=false) → no
+    // forzamos nada: lo dejamos donde lo puso (sin pelearle el giro). El botón
+    // "centrar" reactiva con un bump de recenterNonce.
+    if (!camaraActiva || !posicion) {
+      if (rafRef.current != null) { cancelAnimationFrame(rafRef.current); rafRef.current = null; }
       return;
     }
 
@@ -307,15 +323,33 @@ export default function MapaRutaGoogle({
     headingRef.current = heading;
     prevPosRef.current = pos;
 
-    if (!camRef.current) {
-      // Recién entramos en guía: ubicar la cámara de una y fijar el zoom cercano.
+    // (Re)centrar de una al entrar en guía o al tocar "centrar" (recenterNonce).
+    const necesitaSnap = !camRef.current || recenterAplicadoRef.current !== recenterNonce;
+    if (necesitaSnap) {
+      recenterAplicadoRef.current = recenterNonce;
       camRef.current = { lat: pos.lat, lng: pos.lng, heading, tilt: TILT_GUIA };
       map.setZoom(zoomSeguir ?? 17);
       map.moveCamera({ center: pos, heading, tilt: TILT_GUIA });
     }
     camTargetRef.current = { lat: pos.lat, lng: pos.lng, heading, tilt: TILT_GUIA };
     if (rafRef.current == null) rafRef.current = requestAnimationFrame(animarRef.current);
-  }, [mapReady, modoGuia, posicion, zoomSeguir]);
+  }, [mapReady, modoGuia, camaraActiva, posicion, zoomSeguir, recenterNonce]);
+
+  // 4c) Detectar cuando el chofer mueve el mapa a mano (pan o gesto de 2 dedos
+  //     para rotar/zoomear) → avisar al contenedor para pausar el seguimiento.
+  useEffect(() => {
+    if (!mapReady || !mapRef.current || !onArrastreUsuario) return;
+    const map = mapRef.current;
+    const cont = containerRef.current;
+    const avisar = (): void => onArrastreUsuario();
+    const lisDrag = map.addListener('dragstart', avisar);
+    const onTouch = (e: TouchEvent): void => { if (e.touches.length >= 2) onArrastreUsuario(); };
+    cont?.addEventListener('touchstart', onTouch, { passive: true });
+    return () => {
+      lisDrag.remove();
+      cont?.removeEventListener('touchstart', onTouch);
+    };
+  }, [mapReady, onArrastreUsuario]);
 
   // 5) Tramo de navegación activo: polyline resaltada (cyan, gruesa) por encima
   //    de la ruta del día. Solo en modo guía (cuando viene rutaTramo).

--- a/src/components/rutaActiva/RutaActivaTransportista.tsx
+++ b/src/components/rutaActiva/RutaActivaTransportista.tsx
@@ -12,7 +12,7 @@
  * (useEntregaParada). Diseño: docs/plans/2026-06-12-ruta-activa-design.md
  */
 import React, { useState, useMemo, useEffect, useCallback, lazy, Suspense } from 'react';
-import { Crosshair, WifiOff, Truck, Volume2, VolumeX } from 'lucide-react';
+import { Crosshair, WifiOff, Truck, Volume2, VolumeX, LocateFixed } from 'lucide-react';
 import { formatPrecio } from '../../utils/formatters';
 import { haversineMeters } from '../../utils/geo';
 import { useAuthData } from '../../contexts/AuthDataContext';
@@ -60,6 +60,10 @@ export default function RutaActivaTransportista({
   // Guía giro-a-giro in-app: convive con el mapa y el sheet (no es overlay).
   const [guiando, setGuiando] = useState(false);
   const [vozOn, setVozOn] = useState(true);
+  // Cámara de guía: se pausa cuando el chofer mueve el mapa a mano (estilo Maps);
+  // el botón "centrar" la reactiva (+ bump del nonce para re-centrar).
+  const [camaraSeguir, setCamaraSeguir] = useState(true);
+  const [recenterNonce, setRecenterNonce] = useState(0);
   const voz = useNavegacionVoz();
   const wakeLock = useWakeLock();
   // Guiando: GPS más frecuente para seguir suave; si no, ahorro de batería.
@@ -202,6 +206,7 @@ export default function RutaActivaTransportista({
     }
     wakeLock.solicitar();
     setSeguirPosicion(true);
+    setCamaraSeguir(true);
     setGuiando(true);
   }, [voz, wakeLock]);
 
@@ -210,6 +215,14 @@ export default function RutaActivaTransportista({
     voz.callar();
     setGuiando(false);
   }, [wakeLock, voz]);
+
+  // El chofer movió el mapa a mano → pausar el seguimiento de la cámara.
+  const handleArrastreMapa = useCallback((): void => setCamaraSeguir(false), []);
+  // Botón "centrar": volver a seguir y re-centrar en la posición/rumbo actuales.
+  const recentrarMapa = useCallback((): void => {
+    setCamaraSeguir(true);
+    setRecenterNonce(n => n + 1);
+  }, []);
 
   const toggleGuia = useCallback((): void => {
     if (guiando) pararGuia(); else iniciarGuia();
@@ -263,6 +276,10 @@ export default function RutaActivaTransportista({
           modoGuia={guiando}
           // Tramo activo resaltado sobre la ruta del día (modo guía).
           rutaTramo={guiando && guia.rutaTramo.length > 1 ? guia.rutaTramo : null}
+          // Pausa/recentrado de la cámara estilo Maps.
+          camaraActiva={camaraSeguir}
+          recenterNonce={recenterNonce}
+          onArrastreUsuario={handleArrastreMapa}
         />
       </Suspense>
 
@@ -321,6 +338,18 @@ export default function RutaActivaTransportista({
           <WifiOff className="h-4 w-4 flex-shrink-0" aria-hidden />
           <p className="text-sm font-medium">Sin conexión — las entregas no se están guardando</p>
         </div>
+      )}
+
+      {/* Botón "centrar" estilo Maps: aparece al guiar cuando el chofer movió el
+          mapa a mano; lo vuelve a centrar y reactiva el seguimiento. */}
+      {guiando && !camaraSeguir && (
+        <button
+          onClick={recentrarMapa}
+          className="fixed right-4 bottom-[calc(7rem+env(safe-area-inset-bottom))] z-30 flex h-12 w-12 items-center justify-center rounded-full bg-white text-blue-600 shadow-lg ring-1 ring-black/10 active:bg-gray-100 dark:bg-gray-800 dark:text-blue-400"
+          aria-label="Centrar el mapa en mi posición"
+        >
+          <LocateFixed className="h-6 w-6" />
+        </button>
       )}
 
       {/* Bottom sheet con la parada activa */}

--- a/src/components/rutaActiva/SheetParada.tsx
+++ b/src/components/rutaActiva/SheetParada.tsx
@@ -1,30 +1,21 @@
 /**
- * SheetParada — bottom sheet de la pantalla Ruta Activa (estilo Uber/Rappi).
+ * SheetParada — barra inferior + menú a pantalla completa de la Ruta Activa.
  *
- * Tres posiciones (vaul snap points):
- *  - Colapsado: píldora con la próxima entrega y distancia.
- *  - Medio (default): tarjeta de la parada activa con acciones grandes
- *    (Navegar / Waze / Entregar). Si el GPS detecta llegada (<100m), la
- *    tarjeta entra en modo "Llegaste" y Entregar pasa a CTA primario.
- *  - Expandido: productos de la parada activa (con salvedad por item) +
- *    lista completa de paradas (tap selecciona) + links de ruta completa.
- *
- * No-modal: el mapa de fondo sigue interactivo.
+ * En vez de un sheet que se arrastra (vaul, incómodo en iOS), es una BARRA FIJA
+ * abajo (resumen de la parada activa + acción primaria contextual) que, al
+ * tocarla, despliega un PANEL a pantalla completa con el detalle, los productos,
+ * todas las paradas y los links. Volver a tocar (o la flecha) lo oculta. Sin
+ * arrastre → más mapa para manejar y cero jank de gestos.
  */
 import { useState, useEffect } from 'react';
-import { Drawer } from 'vaul';
 import {
-  Navigation, Square, Check, MapPin, Phone, AlertTriangle, Gift, ChevronRight, Map as MapIcon,
+  Navigation, Square, Check, MapPin, Phone, AlertTriangle, Gift, ChevronRight, ChevronUp, ChevronDown, Map as MapIcon,
 } from 'lucide-react';
 import { formatPrecio, getFormaPagoLabel } from '../../utils/formatters';
 import { formatDistancia } from '../../utils/geo';
 import { googleMapsNavUrl, googleMapsSearchUrl } from '../../utils/navegacion';
 import type { PedidoItemDB, ProductoDB } from '../../types';
 import type { PedidoConCliente } from './useEntregaParada';
-
-const SNAP_COLAPSADO = '120px';
-const SNAP_MEDIO = 0.52;
-const SNAP_EXPANDIDO = 0.94;
 
 export interface LinkRutaMaps {
   url: string;
@@ -55,7 +46,7 @@ function navUrl(p: PedidoConCliente): string {
     : googleMapsSearchUrl(p.cliente?.direccion || '');
 }
 
-/** Fila compacta de una parada. Reusada en "Próximas paradas" y "Todas las paradas". */
+/** Fila compacta de una parada (lista "Todas las paradas"). */
 function FilaParada({ parada, numero, activa, onSelect }: {
   parada: PedidoConCliente;
   numero: number;
@@ -103,296 +94,269 @@ export default function SheetParada({
   onToggleGuia,
   guiando = false,
 }: SheetParadaProps) {
-  const [snap, setSnap] = useState<number | string | null>(SNAP_MEDIO);
-  const expandido = snap === SNAP_EXPANDIDO;
-
+  const [abierto, setAbierto] = useState(false);
   const pendientes = paradas.filter(p => p.estado === 'asignado');
-  // Próximas (hasta 3) pendientes después de la activa: visibles sin expandir.
-  const idxActiva = paradaActiva ? pendientes.findIndex(p => p.id === paradaActiva.id) : -1;
-  const proximas = (idxActiva >= 0 ? pendientes.slice(idxActiva + 1) : pendientes).slice(0, 3);
+  const tieneCoords = paradaActiva?.cliente?.latitud != null && paradaActiva?.cliente?.longitud != null;
 
-  // Al detectar llegada, subir el sheet a la posición media si está colapsado
-  // para que el botón Entregar quede a la vista (flujo guiado).
+  // Al arrancar la guía, cerrar el panel → más mapa para manejar.
   useEffect(() => {
-    if (llegaste) setSnap(s => (s === SNAP_COLAPSADO ? SNAP_MEDIO : s));
-  }, [llegaste]);
+    if (guiando) setAbierto(false);
+  }, [guiando]);
 
-  // Al arrancar la guía, colapsar a la píldora → más mapa para manejar. El chofer
-  // puede subirlo con un toque (no se re-colapsa solo: depende de que cambie
-  // guiando/llegaste, no de cada render).
-  useEffect(() => {
-    if (guiando && !llegaste) setSnap(SNAP_COLAPSADO);
-  }, [guiando, llegaste]);
+  // Acciones que abren un modal (entregar/cobro/salvedad) cierran el panel
+  // primero, así el modal queda sobre el mapa sin pelear z-index con el panel.
+  const entregar = (p: PedidoConCliente): void => { setAbierto(false); onEntregar(p); };
+  const salvedad = (item: PedidoItemDB & { producto?: ProductoDB }): void => {
+    if (!paradaActiva || !onSalvedad) return;
+    setAbierto(false);
+    onSalvedad(paradaActiva.id, item);
+  };
 
   return (
-    <Drawer.Root
-      open
-      modal={false}
-      dismissible={false}
-      snapPoints={[SNAP_COLAPSADO, SNAP_MEDIO, SNAP_EXPANDIDO]}
-      activeSnapPoint={snap}
-      setActiveSnapPoint={setSnap}
-    >
-      <Drawer.Portal>
-        <Drawer.Content
-          aria-describedby={undefined}
-          className="fixed bottom-0 left-0 right-0 z-40 flex h-full max-h-[94%] flex-col rounded-t-2xl border-t border-gray-200 bg-white shadow-[0_-8px_30px_rgba(0,0,0,0.18)] outline-none dark:border-gray-700 dark:bg-gray-800"
+    <>
+      {/* PANEL pantalla completa (se desliza desde abajo al tocar la barra) */}
+      <div
+        className={`fixed inset-0 z-50 flex flex-col bg-white transition-transform duration-300 ease-out dark:bg-gray-900 ${abierto ? 'translate-y-0' : 'pointer-events-none translate-y-full'}`}
+        aria-hidden={!abierto}
+      >
+        <button
+          onClick={() => setAbierto(false)}
+          className="flex w-full flex-shrink-0 items-center justify-between gap-2 border-b border-gray-200 px-4 pb-3 pt-[max(env(safe-area-inset-top),12px)] text-left dark:border-gray-700"
         >
-          <Drawer.Title className="sr-only">Parada actual de la ruta</Drawer.Title>
+          <div className="min-w-0">
+            <p className="truncate text-lg font-bold text-gray-900 dark:text-white">
+              {paradaActiva?.cliente?.nombre_fantasia || 'Paradas de la ruta'}
+            </p>
+            <p className="text-xs text-gray-500 dark:text-gray-400">{pendientes.length} entregas pendientes</p>
+          </div>
+          <span className="flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-full bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-300">
+            <ChevronDown className="h-5 w-5" />
+          </span>
+        </button>
 
-          {/* Handle de arrastre. Drawer.Handle trae el hit-area táctil de 44px
-              nativo de vaul (fácil de agarrar) y al tocarlo cicla los snaps. */}
-          <Drawer.Handle className="mx-auto mt-2 mb-1 h-1.5 w-12 flex-shrink-0 rounded-full bg-gray-300 dark:bg-gray-600" />
-
-          {/* Bloque fijo superior: encabezado + tarjeta + acciones. Las acciones
-              van ACÁ (arriba), NO en un footer: vaul revela el contenido
-              top-down, así que el peek/medio muestra el tope del panel. */}
-          <div className="flex-shrink-0 px-4 pb-1">
-            {paradaActiva ? (
-              <>
-                {/* Encabezado (visible incluso colapsado) */}
-                <div className="flex items-center justify-between gap-2 pt-2">
-                  <div className="flex items-center gap-2.5 min-w-0">
-                    <div className={`flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-full text-sm font-bold text-white ${llegaste ? 'bg-green-600' : 'bg-blue-600'}`}>
-                      {paradaActiva.orden_entrega || '•'}
-                    </div>
-                    <div className="min-w-0">
-                      <p className="truncate font-semibold text-gray-900 dark:text-white">
-                        {paradaActiva.cliente?.nombre_fantasia || 'Cliente'}
+        <div className="min-h-0 flex-1 overflow-y-auto overscroll-contain px-4 py-3 pb-[max(env(safe-area-inset-bottom),16px)]">
+          {paradaActiva && (
+            <div className="space-y-4">
+              <div className="space-y-3">
+                <div className="flex items-start gap-2 text-sm text-gray-700 dark:text-gray-300">
+                  <MapPin className="mt-0.5 h-4 w-4 flex-shrink-0 text-gray-400" />
+                  <div className="min-w-0">
+                    <p>{paradaActiva.cliente?.direccion || 'Sin dirección'}</p>
+                    {paradaActiva.cliente?.aclaracion_direccion && (
+                      <p className="italic text-gray-500 dark:text-gray-400">
+                        {paradaActiva.cliente.aclaracion_direccion}
                       </p>
-                      <p className="truncate text-xs text-gray-500 dark:text-gray-400">
-                        {llegaste
-                          ? '📍 Llegaste — confirmá la entrega'
-                          : guiando
-                            ? `Próxima parada · ${pendientes.length} pendientes`
-                            : distanciaMetros != null
-                              ? `A ${formatDistancia(distanciaMetros)} · ${pendientes.length} pendientes`
-                              : `${pendientes.length} entregas pendientes`}
-                      </p>
-                    </div>
-                  </div>
-                  {/* Guiando: la distancia es lo glanceable (grande, tabular para que
-                      no titile al bajar). Si no, el monto a cobrar. */}
-                  {guiando && !llegaste && distanciaMetros != null ? (
-                    <span className="flex-shrink-0 text-xl font-extrabold tabular-nums text-blue-600 dark:text-blue-400">
-                      {formatDistancia(distanciaMetros)}
-                    </span>
-                  ) : (
-                    <span className="flex-shrink-0 text-lg font-bold text-gray-900 dark:text-white">
-                      {formatPrecio(paradaActiva.total)}
-                    </span>
-                  )}
-                </div>
-
-                {/* Tarjeta de la parada activa (visible desde snap medio) */}
-                <div className="mt-3 space-y-3">
-                  <div className="flex items-start gap-2 text-sm text-gray-700 dark:text-gray-300">
-                    <MapPin className="mt-0.5 h-4 w-4 flex-shrink-0 text-gray-400" />
-                    <div className="min-w-0">
-                      <p>{paradaActiva.cliente?.direccion || 'Sin dirección'}</p>
-                      {paradaActiva.cliente?.aclaracion_direccion && (
-                        <p className="italic text-gray-500 dark:text-gray-400">
-                          {paradaActiva.cliente.aclaracion_direccion}
-                        </p>
-                      )}
-                    </div>
-                  </div>
-
-                  <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-sm">
-                    <span className={`rounded-full px-2 py-0.5 text-xs font-semibold ${
-                      paradaActiva.estado_pago === 'pagado'
-                        ? 'bg-green-100 text-green-700 dark:bg-green-900/40 dark:text-green-300'
-                        : paradaActiva.estado_pago === 'parcial'
-                          ? 'bg-yellow-100 text-yellow-700 dark:bg-yellow-900/40 dark:text-yellow-300'
-                          : 'bg-red-100 text-red-700 dark:bg-red-900/40 dark:text-red-300'
-                    }`}>
-                      {paradaActiva.estado_pago === 'pagado' ? 'PAGADO' : paradaActiva.estado_pago === 'parcial' ? 'PARCIAL' : 'A COBRAR'}
-                    </span>
-                    <span className="text-gray-500 dark:text-gray-400">
-                      {getFormaPagoLabel(paradaActiva.forma_pago || '')}
-                    </span>
-                    <span className="text-gray-500 dark:text-gray-400">
-                      {paradaActiva.items?.length || 0} items
-                    </span>
-                    {paradaActiva.cliente?.telefono && (
-                      <a href={`tel:${paradaActiva.cliente.telefono}`} className="inline-flex items-center gap-1 text-blue-600 dark:text-blue-400">
-                        <Phone className="h-3.5 w-3.5" />
-                        {paradaActiva.cliente.telefono}
-                      </a>
                     )}
                   </div>
+                </div>
 
-                  {paradaActiva.notas && (
-                    <p className="rounded-lg border border-yellow-200 bg-yellow-50 p-2 text-xs text-yellow-800 dark:border-yellow-800 dark:bg-yellow-900/20 dark:text-yellow-300">
-                      <strong>Nota:</strong> {paradaActiva.notas}
-                    </p>
-                  )}
-
-                  {/* Guía in-app (toggle Navegar/Parar). El handoff a Maps queda
-                      como fallback abajo. Se muestra si se está guiando (para
-                      poder parar) o si todavía no llegaste. */}
-                  {onToggleGuia
-                    && (guiando || !llegaste)
-                    && paradaActiva.cliente?.latitud != null
-                    && paradaActiva.cliente?.longitud != null && (
-                    <button
-                      onClick={() => onToggleGuia(paradaActiva)}
-                      className={`flex min-h-[52px] w-full items-center justify-center gap-2 rounded-xl text-sm font-semibold transition-colors ${
-                        guiando
-                          ? 'bg-gray-200 text-gray-700 active:bg-gray-300 dark:bg-gray-700 dark:text-gray-200'
-                          : 'bg-blue-600 text-white active:bg-blue-800'
-                      }`}
-                    >
-                      {guiando
-                        ? <><Square className="h-5 w-5" /> Parar guía</>
-                        : <><Navigation className="h-5 w-5" /> Navegar</>}
-                    </button>
-                  )}
-
-                  {/* Acciones principales: Maps (handoff, fallback) + Entregar */}
-                  <div className="grid grid-cols-2 gap-2">
-                    <a
-                      href={navUrl(paradaActiva)}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="flex min-h-[52px] items-center justify-center gap-1.5 rounded-xl bg-blue-50 text-sm font-semibold text-blue-700 transition-colors active:bg-blue-100 dark:bg-blue-900/30 dark:text-blue-300"
-                    >
-                      <MapIcon className="h-4 w-4" />
-                      Maps
+                <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-sm">
+                  <span className={`rounded-full px-2 py-0.5 text-xs font-semibold ${
+                    paradaActiva.estado_pago === 'pagado'
+                      ? 'bg-green-100 text-green-700 dark:bg-green-900/40 dark:text-green-300'
+                      : paradaActiva.estado_pago === 'parcial'
+                        ? 'bg-yellow-100 text-yellow-700 dark:bg-yellow-900/40 dark:text-yellow-300'
+                        : 'bg-red-100 text-red-700 dark:bg-red-900/40 dark:text-red-300'
+                  }`}>
+                    {paradaActiva.estado_pago === 'pagado' ? 'PAGADO' : paradaActiva.estado_pago === 'parcial' ? 'PARCIAL' : 'A COBRAR'}
+                  </span>
+                  <span className="text-gray-500 dark:text-gray-400">
+                    {getFormaPagoLabel(paradaActiva.forma_pago || '')}
+                  </span>
+                  <span className="font-semibold text-gray-900 dark:text-white">{formatPrecio(paradaActiva.total)}</span>
+                  {paradaActiva.cliente?.telefono && (
+                    <a href={`tel:${paradaActiva.cliente.telefono}`} className="inline-flex items-center gap-1 text-blue-600 dark:text-blue-400">
+                      <Phone className="h-3.5 w-3.5" />
+                      {paradaActiva.cliente.telefono}
                     </a>
-                    <button
-                      onClick={() => onEntregar(paradaActiva)}
-                      className={`flex min-h-[52px] items-center justify-center gap-1.5 rounded-xl text-sm font-semibold transition-colors ${
-                        llegaste
-                          ? 'bg-green-600 text-white active:bg-green-800'
-                          : 'bg-green-50 text-green-700 active:bg-green-100 dark:bg-green-900/30 dark:text-green-300'
-                      }`}
-                    >
-                      <Check className="h-5 w-5" />
-                      Entregar
-                    </button>
-                  </div>
+                  )}
                 </div>
-              </>
-            ) : (
-              <div className="flex items-center justify-between pt-2">
-                <p className="font-semibold text-gray-900 dark:text-white">🎉 Ruta completada</p>
-                <p className="text-sm text-gray-500 dark:text-gray-400">No quedan entregas pendientes</p>
-              </div>
-            )}
-          </div>
 
-          {/* Bloque scrollable: próximas paradas (siempre) + detalle al expandir.
-              overscroll-contain corta el encadenamiento del scroll al documento
-              (defensa extra contra el pull-to-refresh); el pb respeta el home
-              indicator en snap expandido. min-h-0 para que flex-1 pueda scrollear. */}
-          <div className="mt-2 min-h-0 flex-1 overflow-y-auto overscroll-contain px-4 pb-[max(env(safe-area-inset-bottom),12px)]">
-            {/* Próximas paradas: visibles/scrolleables desde el snap medio, sin
-                tener que expandir del todo. Al expandir se ve la lista completa. */}
-            {!expandido && proximas.length > 0 && (
-              <div>
-                <p className="mb-2 text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">
-                  Próximas paradas
-                </p>
-                <div className="space-y-1.5">
-                  {proximas.map((p, i) => (
-                    <FilaParada
-                      key={p.id}
-                      parada={p}
-                      numero={p.orden_entrega || i + 1}
-                      activa={false}
-                      onSelect={() => { onSeleccionarParada(p.id); setSnap(SNAP_MEDIO); }}
-                    />
-                  ))}
-                </div>
-              </div>
-            )}
-
-            {/* Contenido expandido: productos de la parada + lista de paradas */}
-            {expandido && (
-              <div className="space-y-5">
-                {paradaActiva && (paradaActiva.items?.length || 0) > 0 && (
-                  <div>
-                    <p className="mb-2 text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">
-                      Productos de esta entrega
-                    </p>
-                    <div className="space-y-1.5">
-                      {paradaActiva.items.map(item => (
-                        <div
-                          key={item.id}
-                          className={`flex items-center justify-between gap-2 rounded-lg p-2 text-sm ${
-                            item.es_bonificacion
-                              ? 'border border-green-200 bg-green-50 dark:border-green-800 dark:bg-green-900/30'
-                              : 'bg-gray-50 dark:bg-gray-700'
-                          }`}
-                        >
-                          <span className="flex flex-1 items-center gap-1.5 text-gray-700 dark:text-gray-300">
-                            {item.es_bonificacion && <Gift className="h-3.5 w-3.5 flex-shrink-0 text-green-600" />}
-                            {item.cantidad}x {item.es_bonificacion && item.descripcion_regalo
-                              ? item.descripcion_regalo
-                              : (item.producto?.nombre || 'Producto')}
-                          </span>
-                          {!item.es_bonificacion && (
-                            <span className="text-gray-500">{formatPrecio(item.subtotal || item.precio_unitario * item.cantidad)}</span>
-                          )}
-                          {paradaActiva.estado === 'asignado' && onSalvedad && (
-                            <button
-                              onClick={() => onSalvedad(paradaActiva.id, item)}
-                              className="flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-lg bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-300"
-                              aria-label="Reportar problema con este item"
-                            >
-                              <AlertTriangle className="h-4 w-4" />
-                            </button>
-                          )}
-                        </div>
-                      ))}
-                    </div>
-                  </div>
+                {paradaActiva.notas && (
+                  <p className="rounded-lg border border-yellow-200 bg-yellow-50 p-2 text-xs text-yellow-800 dark:border-yellow-800 dark:bg-yellow-900/20 dark:text-yellow-300">
+                    <strong>Nota:</strong> {paradaActiva.notas}
+                  </p>
                 )}
 
+                {/* Acciones completas dentro del panel */}
+                {onToggleGuia && (guiando || !llegaste) && tieneCoords && (
+                  <button
+                    onClick={() => onToggleGuia(paradaActiva)}
+                    className={`flex min-h-[52px] w-full items-center justify-center gap-2 rounded-xl text-sm font-semibold transition-colors ${
+                      guiando
+                        ? 'bg-gray-200 text-gray-700 active:bg-gray-300 dark:bg-gray-700 dark:text-gray-200'
+                        : 'bg-blue-600 text-white active:bg-blue-800'
+                    }`}
+                  >
+                    {guiando ? <><Square className="h-5 w-5" /> Parar guía</> : <><Navigation className="h-5 w-5" /> Navegar</>}
+                  </button>
+                )}
+                <div className="grid grid-cols-2 gap-2">
+                  <a
+                    href={navUrl(paradaActiva)}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="flex min-h-[52px] items-center justify-center gap-1.5 rounded-xl bg-blue-50 text-sm font-semibold text-blue-700 transition-colors active:bg-blue-100 dark:bg-blue-900/30 dark:text-blue-300"
+                  >
+                    <MapIcon className="h-4 w-4" />
+                    Maps
+                  </a>
+                  <button
+                    onClick={() => entregar(paradaActiva)}
+                    className={`flex min-h-[52px] items-center justify-center gap-1.5 rounded-xl text-sm font-semibold transition-colors ${
+                      llegaste
+                        ? 'bg-green-600 text-white active:bg-green-800'
+                        : 'bg-green-50 text-green-700 active:bg-green-100 dark:bg-green-900/30 dark:text-green-300'
+                    }`}
+                  >
+                    <Check className="h-5 w-5" />
+                    Entregar
+                  </button>
+                </div>
+              </div>
+
+              {(paradaActiva.items?.length || 0) > 0 && (
                 <div>
                   <p className="mb-2 text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">
-                    Todas las paradas
+                    Productos de esta entrega
                   </p>
                   <div className="space-y-1.5">
-                    {paradas.map((p, i) => (
-                      <FilaParada
-                        key={p.id}
-                        parada={p}
-                        numero={p.orden_entrega || i + 1}
-                        activa={paradaActiva?.id === p.id}
-                        onSelect={() => { onSeleccionarParada(p.id); setSnap(SNAP_MEDIO); }}
-                      />
+                    {paradaActiva.items.map(item => (
+                      <div
+                        key={item.id}
+                        className={`flex items-center justify-between gap-2 rounded-lg p-2 text-sm ${
+                          item.es_bonificacion
+                            ? 'border border-green-200 bg-green-50 dark:border-green-800 dark:bg-green-900/30'
+                            : 'bg-gray-50 dark:bg-gray-800'
+                        }`}
+                      >
+                        <span className="flex flex-1 items-center gap-1.5 text-gray-700 dark:text-gray-300">
+                          {item.es_bonificacion && <Gift className="h-3.5 w-3.5 flex-shrink-0 text-green-600" />}
+                          {item.cantidad}x {item.es_bonificacion && item.descripcion_regalo
+                            ? item.descripcion_regalo
+                            : (item.producto?.nombre || 'Producto')}
+                        </span>
+                        {!item.es_bonificacion && (
+                          <span className="text-gray-500">{formatPrecio(item.subtotal || item.precio_unitario * item.cantidad)}</span>
+                        )}
+                        {paradaActiva.estado === 'asignado' && onSalvedad && (
+                          <button
+                            onClick={() => salvedad(item)}
+                            className="flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-lg bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-300"
+                            aria-label="Reportar problema con este item"
+                          >
+                            <AlertTriangle className="h-4 w-4" />
+                          </button>
+                        )}
+                      </div>
                     ))}
                   </div>
                 </div>
+              )}
+            </div>
+          )}
 
-                {linksRutaMaps.length > 0 && (
-                  <div>
-                    <p className="mb-2 text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">
-                      Ruta completa en Google Maps
-                    </p>
-                    <div className="flex flex-wrap gap-2">
-                      {linksRutaMaps.map((link, i) => (
-                        <a
-                          key={link.url}
-                          href={link.url}
-                          target="_blank"
-                          rel="noopener noreferrer"
-                          className="inline-flex min-h-[44px] items-center gap-2 rounded-lg bg-gray-100 px-4 py-2 text-sm font-medium text-gray-700 dark:bg-gray-700 dark:text-gray-200"
-                        >
-                          <MapIcon className="h-4 w-4" />
-                          {linksRutaMaps.length === 1 ? 'Abrir ruta completa' : `Tramo ${i + 1} (${link.desde}-${link.hasta})`}
-                        </a>
-                      ))}
-                    </div>
-                  </div>
-                )}
-              </div>
-            )}
+          <div className="mt-5">
+            <p className="mb-2 text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">
+              Todas las paradas
+            </p>
+            <div className="space-y-1.5">
+              {paradas.map((p, i) => (
+                <FilaParada
+                  key={p.id}
+                  parada={p}
+                  numero={p.orden_entrega || i + 1}
+                  activa={paradaActiva?.id === p.id}
+                  onSelect={() => { onSeleccionarParada(p.id); setAbierto(false); }}
+                />
+              ))}
+            </div>
           </div>
-        </Drawer.Content>
-      </Drawer.Portal>
-    </Drawer.Root>
+
+          {linksRutaMaps.length > 0 && (
+            <div className="mt-5">
+              <p className="mb-2 text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">
+                Ruta completa en Google Maps
+              </p>
+              <div className="flex flex-wrap gap-2">
+                {linksRutaMaps.map((link, i) => (
+                  <a
+                    key={link.url}
+                    href={link.url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="inline-flex min-h-[44px] items-center gap-2 rounded-lg bg-gray-100 px-4 py-2 text-sm font-medium text-gray-700 dark:bg-gray-800 dark:text-gray-200"
+                  >
+                    <MapIcon className="h-4 w-4" />
+                    {linksRutaMaps.length === 1 ? 'Abrir ruta completa' : `Tramo ${i + 1} (${link.desde}-${link.hasta})`}
+                  </a>
+                ))}
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* BARRA fija inferior (siempre visible; tocar el resumen abre el panel) */}
+      <div className="fixed inset-x-0 bottom-0 z-40 border-t border-gray-200 bg-white shadow-[0_-8px_30px_rgba(0,0,0,0.18)] dark:border-gray-700 dark:bg-gray-800">
+        <div className="flex items-center gap-2.5 px-4 pt-2.5 pb-[max(env(safe-area-inset-bottom),10px)]">
+          {paradaActiva ? (
+            <>
+              <button
+                onClick={() => setAbierto(o => !o)}
+                className="flex min-w-0 flex-1 items-center gap-2.5 text-left"
+                aria-label="Abrir el detalle de la parada"
+              >
+                <span className={`flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-full text-sm font-bold text-white ${llegaste ? 'bg-green-600' : 'bg-blue-600'}`}>
+                  {paradaActiva.orden_entrega || '•'}
+                </span>
+                <span className="min-w-0 flex-1">
+                  <span className="block truncate font-semibold text-gray-900 dark:text-white">
+                    {paradaActiva.cliente?.nombre_fantasia || 'Cliente'}
+                  </span>
+                  <span className="block truncate text-xs text-gray-500 dark:text-gray-400">
+                    {llegaste
+                      ? '📍 Llegaste — confirmá la entrega'
+                      : distanciaMetros != null
+                        ? `A ${formatDistancia(distanciaMetros)} · ${pendientes.length} pendientes`
+                        : `${pendientes.length} entregas pendientes`}
+                  </span>
+                </span>
+                <ChevronUp className={`h-5 w-5 flex-shrink-0 text-gray-400 transition-transform ${abierto ? 'rotate-180' : ''}`} />
+              </button>
+
+              {/* Acción primaria contextual (compacta → barra fina, más mapa) */}
+              {llegaste ? (
+                <button
+                  onClick={() => entregar(paradaActiva)}
+                  className="flex h-12 flex-shrink-0 items-center gap-1.5 rounded-xl bg-green-600 px-4 text-sm font-semibold text-white active:bg-green-800"
+                >
+                  <Check className="h-5 w-5" /> Entregar
+                </button>
+              ) : guiando && onToggleGuia ? (
+                <button
+                  onClick={() => onToggleGuia(paradaActiva)}
+                  className="flex h-12 flex-shrink-0 items-center gap-1.5 rounded-xl bg-gray-200 px-4 text-sm font-semibold text-gray-700 active:bg-gray-300 dark:bg-gray-700 dark:text-gray-200"
+                >
+                  <Square className="h-5 w-5" /> Parar
+                </button>
+              ) : onToggleGuia && tieneCoords ? (
+                <button
+                  onClick={() => onToggleGuia(paradaActiva)}
+                  className="flex h-12 flex-shrink-0 items-center gap-1.5 rounded-xl bg-blue-600 px-4 text-sm font-semibold text-white active:bg-blue-800"
+                >
+                  <Navigation className="h-5 w-5" /> Navegar
+                </button>
+              ) : null}
+            </>
+          ) : (
+            <div className="flex min-h-[44px] w-full items-center justify-between">
+              <p className="font-semibold text-gray-900 dark:text-white">🎉 Ruta completada</p>
+              <p className="text-sm text-gray-500 dark:text-gray-400">Sin entregas pendientes</p>
+            </div>
+          )}
+        </div>
+      </div>
+    </>
   );
 }

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -37,6 +37,7 @@ declare namespace google.maps {
     getZoom(): number;
     /** Mueve la cámara (center/zoom/heading/tilt) en un paso; solo vector maps tiltan/rotan. */
     moveCamera(cameraOptions: CameraOptions): void;
+    addListener(event: string, handler: (...args: unknown[]) => void): MapsEventListener;
   }
 
   interface CameraOptions {


### PR DESCRIPTION
## Resumen

Pulido de la navegación tras probar en device (3 detalles):

1. **Botón "centrar" estilo Maps + cámara que no pelea.** Cuando el chofer mueve el mapa a mano durante la guía, el seguimiento se **pausa** (la cámara deja de re-centrar/rotar) y aparece un **FAB de "centrar"** que vuelve a la posición/rumbo y reactiva el seguimiento. Detección por `dragstart` (pan) + `touchstart` de 2 dedos (rotar/zoom). Esto saca lo "brusco" de que la cámara te peleara el giro.

2. **Rotación de cámara más suave.** Easing por propiedad con el **rumbo más lento** → la rotación heading-up es gradual, no a tirones.

3. **El sheet de pedidos pasa a barra fija + menú a pantalla completa.** En vez de un sheet que se arrastra (vaul, incómodo en iOS), ahora es una **barra fija inferior** (resumen de la parada + acción primaria contextual: Navegar / Parar / Entregar) que con **un toque despliega un menú a pantalla completa** (detalle, productos con salvedad, todas las paradas, links) y se **oculta con la flecha**. Sin arrastre → **más mapa** y cero jank de gestos.

`vaul` queda sin uso (se puede sacar del package.json en un cleanup aparte).

## Verificación
- ✅ `tsc --noEmit` limpio · ESLint limpio · **701/701 vitest** (verde en pre-commit).
- Solo frontend; sin migración ni edge.

### A probar en device
- Mover el mapa con el dedo durante la guía → el seguimiento se pausa y aparece el botón centrar; tocarlo vuelve a seguir.
- Que la rotación del mapa al doblar se sienta suave.
- Tocar la barra de abajo abre el menú a pantalla completa; la flecha lo cierra; al guiar queda como barra fina (más mapa).

🤖 Generated with [Claude Code](https://claude.com/claude-code)