### PR TITLE
feat(rutas): botón Parar en rojo + ocultar la ruta del día al guiar

### DIFF
--- a/src/components/rutaActiva/MapaRutaGoogle.tsx
+++ b/src/components/rutaActiva/MapaRutaGoogle.tsx
@@ -159,9 +159,10 @@ export default function MapaRutaGoogle({
       bounds.extend({ lat: p.lat, lng: p.lng });
     }
 
-    // Ruta real sobre las calles, o fallback recto depósito→paradas→depósito
+    // Ruta del día (real, o fallback recto). En modo guía NO se dibuja: solo se
+    // ve el tramo de navegación (rutaTramo), para no confundir dos líneas.
     const hayRutaReal = (rutaReal?.length ?? 0) > 1;
-    if (hayRutaReal) {
+    if (!modoGuia && hayRutaReal) {
       polylineRef.current = new g.Polyline({
         path: (rutaReal as [number, number][]).map(([lat, lng]) => ({ lat, lng })),
         map,
@@ -170,7 +171,7 @@ export default function MapaRutaGoogle({
         strokeOpacity: 0.85,
         strokeWeight: 5,
       });
-    } else if (ordenadas.length > 0) {
+    } else if (!modoGuia && ordenadas.length > 0) {
       const path: google.maps.LatLngLiteral[] = [];
       if (deposito) path.push({ lat: deposito.lat, lng: deposito.lng });
       for (const p of ordenadas) path.push({ lat: p.lat, lng: p.lng });
@@ -194,7 +195,7 @@ export default function MapaRutaGoogle({
         map.fitBounds(bounds, 64);
       }
     }
-  }, [mapReady, paradas, deposito, rutaReal, paradaActivaOrden, onParadaTap]);
+  }, [mapReady, paradas, deposito, rutaReal, paradaActivaOrden, onParadaTap, modoGuia]);
 
   // 3) Posición propia: efecto AISLADO. Solo mueve el punto azul + el círculo de
   //    precisión, sin tocar los markers de paradas. Esto mata el re-render por GPS.

--- a/src/components/rutaActiva/RutaActivaTransportista.tsx
+++ b/src/components/rutaActiva/RutaActivaTransportista.tsx
@@ -263,7 +263,9 @@ export default function RutaActivaTransportista({
           paradas={paradasMapa}
           deposito={deposito}
           altura="full"
-          rutaReal={rutaReal.length > 1 ? rutaReal : null}
+          // Al guiar se oculta la ruta del día completa para no confundir con el
+          // tramo de navegación (rutaTramo); al parar vuelve la ruta completa.
+          rutaReal={!guiando && rutaReal.length > 1 ? rutaReal : null}
           // Solo mostramos el punto azul con GPS confiable (no plantarlo en
           // medio del país con la geolocalización por IP del desktop).
           posicion={gpsConfiable && posicion ? { lat: posicion.lat, lng: posicion.lng, accuracy: posicion.accuracy, heading: posicion.heading, speed: posicion.speed } : null}

--- a/src/components/rutaActiva/SheetParada.tsx
+++ b/src/components/rutaActiva/SheetParada.tsx
@@ -184,7 +184,7 @@ export default function SheetParada({
                     onClick={() => onToggleGuia(paradaActiva)}
                     className={`flex min-h-[52px] w-full items-center justify-center gap-2 rounded-xl text-sm font-semibold transition-colors ${
                       guiando
-                        ? 'bg-gray-200 text-gray-700 active:bg-gray-300 dark:bg-gray-700 dark:text-gray-200'
+                        ? 'bg-red-600 text-white active:bg-red-800'
                         : 'bg-blue-600 text-white active:bg-blue-800'
                     }`}
                   >
@@ -336,7 +336,7 @@ export default function SheetParada({
               ) : guiando && onToggleGuia ? (
                 <button
                   onClick={() => onToggleGuia(paradaActiva)}
-                  className="flex h-12 flex-shrink-0 items-center gap-1.5 rounded-xl bg-gray-200 px-4 text-sm font-semibold text-gray-700 active:bg-gray-300 dark:bg-gray-700 dark:text-gray-200"
+                  className="flex h-12 flex-shrink-0 items-center gap-1.5 rounded-xl bg-red-600 px-4 text-sm font-semibold text-white active:bg-red-800"
                 >
                   <Square className="h-5 w-5" /> Parar
                 </button>


### PR DESCRIPTION
Últimos detalles de la navegación:

- **Botón "Parar" en rojo** (antes gris), en la barra inferior y en el panel.
- **Al guiar se oculta el recorrido completo del día** (la línea azul `rutaReal` y también su fallback punteado): mientras navegás solo se ve el **tramo hasta el pedido seleccionado** (cyan), así no se confunden dos líneas de colores parecidos. Al tocar **Parar**, vuelve a aparecer la ruta completa de los pedidos que faltan.

## Verificación
- ✅ typecheck + ESLint limpios · **701/701 vitest** (verde en pre-commit). Solo frontend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)