### PR TITLE
feat(clientes): horarios de atención/entrega manuales por rango

### DIFF
--- a/src/components/modals/ModalCliente.tsx
+++ b/src/components/modals/ModalCliente.tsx
@@ -294,6 +294,12 @@ const ModalCliente = memo(function ModalCliente({ cliente, onSave, onClose, guar
   // `franjasAtencion` es la fuente de verdad del editor; se inicializa de la
   // conversión calculada arriba y se espeja al string del form al editar.
   const [franjasAtencion, setFranjasAtencion] = useState<FranjaHoraria[]>(convAtencionInicial.franjas);
+  // Texto libre de atención: para horarios que no entran en franjas (24 hs, por
+  // día de semana, cierres pasada la medianoche). Se prellena con el valor viejo
+  // que no se pudo convertir, para no perderlo y dejarlo editable.
+  const [notaLibreAtencion, setNotaLibreAtencion] = useState<string>(
+    convAtencionInicial.franjas.length === 0 ? (cliente?.horarios_atencion ?? '') : '',
+  );
   const [franjaEntrega, setFranjaEntrega] = useState<FranjaHoraria>(
     convEntregaInicial.franjas[0] ?? { apertura: '', cierre: '' },
   );
@@ -301,10 +307,20 @@ const ModalCliente = memo(function ModalCliente({ cliente, onSave, onClose, guar
   const opcionesCierre = useMemo(() => generarOpcionesHora(true), []);
   const validacionAtencion = useMemo(() => validarFranjas(franjasAtencion), [franjasAtencion]);
 
-  // Sincroniza las filas de atención con el string persistido (clientes.horarios_atencion).
+  // El horario de atención se guarda como franjas estructuradas si hay alguna
+  // completa; si no, como el texto libre. Las franjas tienen prioridad.
+  const combinarHorariosAtencion = (filas: FranjaHoraria[], nota: string): string =>
+    serializarFranjas(filas) || nota.trim();
+  // Si hay al menos una franja completa, el texto libre se ignora (las franjas
+  // tienen prioridad) y se deshabilita su input.
+  const usandoFranjasAtencion = serializarFranjas(franjasAtencion) !== '';
   const sincronizarAtencion = (filas: FranjaHoraria[]): void => {
     setFranjasAtencion(filas);
-    setForm(prev => ({ ...prev, horarios_atencion: serializarFranjas(filas) }));
+    setForm(prev => ({ ...prev, horarios_atencion: combinarHorariosAtencion(filas, notaLibreAtencion) }));
+  };
+  const cambiarNotaLibreAtencion = (nota: string): void => {
+    setNotaLibreAtencion(nota);
+    setForm(prev => ({ ...prev, horarios_atencion: combinarHorariosAtencion(franjasAtencion, nota) }));
   };
   const agregarFranjaAtencion = (): void =>
     sincronizarAtencion([...franjasAtencion, { apertura: '', cierre: '' }]);
@@ -818,11 +834,30 @@ const ModalCliente = memo(function ModalCliente({ cliente, onSave, onClose, guar
               Convertimos tus horarios anteriores a rangos. Revisá y guardá para confirmar.
             </p>
           )}
-          {convAtencionInicial.sinReconocer.length > 0 && (
-            <p className="text-xs text-amber-600 dark:text-amber-400 mt-2">
-              Valor anterior no reconocido: "{cliente?.horarios_atencion}". Cargá las franjas manualmente.
-            </p>
-          )}
+
+          {/* Texto libre: para horarios que no entran en franjas (24 hs, por día
+              de semana, cierres pasada la medianoche). Se prellena con el valor
+              viejo no convertible para no perderlo y dejarlo editable. Si hay
+              franjas completas, esas tienen prioridad y este campo se deshabilita. */}
+          <div className="mt-3">
+            <label className="block text-xs font-medium text-gray-500 dark:text-gray-400 mb-1">
+              ¿No entra en franjas? Describilo en texto libre (ej: "24 hs", "Lun a Sáb de 9 a 14 y 17 a 21")
+            </label>
+            <input
+              type="text"
+              value={notaLibreAtencion}
+              onChange={e => cambiarNotaLibreAtencion(e.target.value)}
+              disabled={usandoFranjasAtencion}
+              placeholder="Horario en texto libre (opcional)"
+              aria-label="Horario de atención en texto libre"
+              className="w-full px-3 py-2 border rounded-lg dark:bg-gray-700 dark:border-gray-600 dark:text-white text-sm disabled:opacity-50 disabled:cursor-not-allowed"
+            />
+            {usandoFranjasAtencion && (
+              <p className="text-xs text-gray-400 mt-1">
+                Se usan las franjas de arriba. Quitalas si querés volver al texto libre.
+              </p>
+            )}
+          </div>
         </div>
 
         {/* Horario de entrega (franja en la que el cliente pide recibir el pedido) */}

--- a/src/components/modals/ModalCliente.tsx
+++ b/src/components/modals/ModalCliente.tsx
@@ -14,6 +14,14 @@ import {
   extractDniFromStorage,
   detectDocumentType
 } from '../../utils/formatters';
+import {
+  generarOpcionesHora,
+  horaAMinutos,
+  serializarFranjas,
+  validarFranjas,
+  convertirHorarioInicial,
+} from '../../utils/horariosCliente';
+import type { FranjaHoraria } from '../../utils/horariosCliente';
 import type { ClienteDB } from '../../types';
 
 /** Tipo de documento del cliente */
@@ -85,25 +93,6 @@ export interface ModalClienteProps {
 
 // Las zonas ahora vienen de la tabla `zonas` via useZonasEstandarizadasQuery
 
-// Franjas horarias seleccionables para "Horarios de Atención" (multi-select:
-// hay clientes que abren fraccionado mañana y tarde). Se persisten unidas
-// con " y " en el campo de texto existente (clientes.horarios_atencion).
-const FRANJAS_ATENCION = [
-  'Mañana (08 a 13)',
-  'Mediodía (12 a 16)',
-  'Tarde (16 a 20)',
-  'Noche (20 a 00)',
-];
-const SEPARADOR_FRANJAS = ' y ';
-
-// Opciones para "Horario de entrega" (franja en la que el cliente pide
-// recibir el pedido; se imprime en la hoja de ruta del transportista).
-const FRANJAS_ENTREGA = [
-  'Mañana (08 a 13)',
-  'Mediodía (12 a 16)',
-  'Tarde (16 a 20)',
-];
-
 // Opciones predefinidas de rubros
 const RUBROS_OPCIONES = [
   'Gimnasio',
@@ -143,6 +132,12 @@ const ModalCliente = memo(function ModalCliente({ cliente, onSave, onClose, guar
   const tipoDocInicial = cliente ? (cliente.tipo_documento || detectDocumentType(cliente.cuit)) : 'CUIT';
   const numeroDocInicial = cliente ? (tipoDocInicial === 'DNI' ? extractDniFromStorage(cliente.cuit) : cliente.cuit) : '';
 
+  // Conversión inicial de los horarios guardados (string) a franjas para el
+  // editor. Auto-convierte las etiquetas viejas a rangos (decisión del usuario).
+  // Se computa una vez (el modal se remonta en cada apertura).
+  const convAtencionInicial = convertirHorarioInicial(cliente?.horarios_atencion);
+  const convEntregaInicial = convertirHorarioInicial(cliente?.horario_entrega);
+
   const [form, setForm] = useState<ClienteFormData>(cliente ? {
     tipo_documento: tipoDocInicial,
     numero_documento: numeroDocInicial || '',
@@ -156,8 +151,15 @@ const ModalCliente = memo(function ModalCliente({ cliente, onSave, onClose, guar
     contacto: cliente.contacto || '',
     zona: cliente.zona || '',
     zona_id: cliente.zona_id ? String(cliente.zona_id) : '',
-    horarios_atencion: cliente.horarios_atencion || '',
-    horario_entrega: cliente.horario_entrega || '',
+    // Si reconocimos franjas (formato nuevo o etiquetas viejas) guardamos el
+    // string ya convertido, para que "Guardar" persista los rangos. Si no
+    // reconocimos nada, preservamos el valor original para no perderlo.
+    horarios_atencion: convAtencionInicial.franjas.length > 0
+      ? serializarFranjas(convAtencionInicial.franjas)
+      : (cliente.horarios_atencion || ''),
+    horario_entrega: convEntregaInicial.franjas.length > 0
+      ? serializarFranjas(convEntregaInicial.franjas)
+      : (cliente.horario_entrega || ''),
     rubro: cliente.rubro || '',
     notas: cliente.notas || '',
     limiteCredito: cliente.limite_credito || 0,
@@ -288,6 +290,55 @@ const ModalCliente = memo(function ModalCliente({ cliente, onSave, onClose, guar
     }));
   };
 
+  // --- Horarios de atención y entrega (filas con rangos HH:MM) ---
+  // `franjasAtencion` es la fuente de verdad del editor; se inicializa de la
+  // conversión calculada arriba y se espeja al string del form al editar.
+  const [franjasAtencion, setFranjasAtencion] = useState<FranjaHoraria[]>(convAtencionInicial.franjas);
+  const [franjaEntrega, setFranjaEntrega] = useState<FranjaHoraria>(
+    convEntregaInicial.franjas[0] ?? { apertura: '', cierre: '' },
+  );
+  const opcionesApertura = useMemo(() => generarOpcionesHora(false), []);
+  const opcionesCierre = useMemo(() => generarOpcionesHora(true), []);
+  const validacionAtencion = useMemo(() => validarFranjas(franjasAtencion), [franjasAtencion]);
+
+  // Sincroniza las filas de atención con el string persistido (clientes.horarios_atencion).
+  const sincronizarAtencion = (filas: FranjaHoraria[]): void => {
+    setFranjasAtencion(filas);
+    setForm(prev => ({ ...prev, horarios_atencion: serializarFranjas(filas) }));
+  };
+  const agregarFranjaAtencion = (): void =>
+    sincronizarAtencion([...franjasAtencion, { apertura: '', cierre: '' }]);
+  const quitarFranjaAtencion = (index: number): void =>
+    sincronizarAtencion(franjasAtencion.filter((_, i) => i !== index));
+  const actualizarFranjaAtencion = (index: number, campo: keyof FranjaHoraria, valor: string): void =>
+    sincronizarAtencion(
+      franjasAtencion.map((f, i) => {
+        if (i !== index) return f;
+        const next = { ...f, [campo]: valor };
+        // Al cambiar la apertura, si el cierre quedó vacío o <= apertura, lo limpiamos.
+        if (campo === 'apertura' && next.cierre &&
+            (!valor || horaAMinutos(next.cierre) <= horaAMinutos(valor))) {
+          next.cierre = '';
+        }
+        return next;
+      }),
+    );
+
+  // Franja única de entrega; el campo queda vacío ("Sin preferencia") si está incompleta.
+  const sincronizarEntrega = (franja: FranjaHoraria): void => {
+    const next = { ...franja };
+    if (!next.apertura) {
+      next.cierre = '';
+    } else if (next.cierre && horaAMinutos(next.cierre) <= horaAMinutos(next.apertura)) {
+      next.cierre = '';
+    }
+    setFranjaEntrega(next);
+    setForm(prev => ({
+      ...prev,
+      horario_entrega: next.apertura && next.cierre ? serializarFranjas([next]) : '',
+    }));
+  };
+
   const handleAddressSelect = (result: AddressSelectResult): void => {
     setForm(prev => ({
       ...prev,
@@ -337,6 +388,17 @@ const ModalCliente = memo(function ModalCliente({ cliente, onSave, onClose, guar
         if (primerError) {
           primerError.scrollIntoView({ behavior: 'smooth', block: 'center' });
         }
+      }, 100);
+      return;
+    }
+
+    // Las franjas de atención no pueden solaparse ni tener apertura >= cierre.
+    // Es validación cross-field (no la cubre Zod): bloquea el guardado y hace
+    // scroll al primer select marcado en rojo.
+    if (!validacionAtencion.valido) {
+      setTimeout(() => {
+        const primerError = formRef.current?.querySelector('.border-red-500');
+        if (primerError) primerError.scrollIntoView({ behavior: 'smooth', block: 'center' });
       }, 100);
       return;
     }
@@ -683,50 +745,82 @@ const ModalCliente = memo(function ModalCliente({ cliente, onSave, onClose, guar
           </div>
         )}
 
-        {/* Horarios de Atención: franjas seleccionables (multi) */}
+        {/* Horarios de Atención: una o más franjas con apertura/cierre (horario cortado) */}
         <div>
           <label className="block text-sm font-medium mb-1 dark:text-gray-200 flex items-center gap-1">
             <Clock className="w-4 h-4" />
             Horarios de Atención
           </label>
           <p className="text-xs text-gray-500 dark:text-gray-400 mb-2">
-            Podés marcar más de una franja (ej: abre a la mañana y a la tarde).
+            Cargá apertura y cierre. Si el horario es cortado (ej: mañana y tarde), agregá otra franja.
           </p>
-          <div className="flex flex-wrap gap-2">
-            {FRANJAS_ATENCION.map(franja => {
-              const seleccionadas = form.horarios_atencion
-                ? form.horarios_atencion.split(SEPARADOR_FRANJAS)
-                : [];
-              const activa = seleccionadas.includes(franja);
-              return (
-                <button
-                  key={franja}
-                  type="button"
-                  onClick={() => {
-                    const nuevas = activa
-                      ? seleccionadas.filter(f => f !== franja)
-                      : [...seleccionadas.filter(f => FRANJAS_ATENCION.includes(f)), franja];
-                    // Mantener el orden canónico de las franjas
-                    const ordenadas = FRANJAS_ATENCION.filter(f => nuevas.includes(f));
-                    handleFieldChange('horarios_atencion', ordenadas.join(SEPARADOR_FRANJAS));
-                  }}
-                  className={`px-3 py-2 text-sm rounded-lg border transition-colors ${
-                    activa
-                      ? 'bg-blue-600 text-white border-blue-600'
-                      : 'bg-white dark:bg-gray-700 text-gray-700 dark:text-gray-200 border-gray-300 dark:border-gray-600 hover:bg-blue-50 dark:hover:bg-gray-600'
-                  }`}
-                >
-                  {franja}
-                </button>
-              );
-            })}
-          </div>
-          {/* Valor legacy de texto libre: si lo guardado no coincide con las
-              franjas, se muestra para que no se pierda al editar. */}
-          {form.horarios_atencion &&
-            form.horarios_atencion.split(SEPARADOR_FRANJAS).some(f => !FRANJAS_ATENCION.includes(f)) && (
+          {franjasAtencion.length > 0 && (
+            <div className="space-y-2 mb-2">
+              {franjasAtencion.map((f, index) => {
+                const tieneError = Boolean(validacionAtencion.erroresPorFila[index]);
+                const selectClass = `flex-1 px-3 py-2 border rounded-lg dark:bg-gray-700 dark:text-white text-sm ${
+                  tieneError ? 'border-red-500 bg-red-50 dark:bg-red-900/20' : 'dark:border-gray-600'
+                }`;
+                return (
+                  <div key={index}>
+                    <div className="flex items-center gap-2">
+                      <select
+                        value={f.apertura}
+                        onChange={e => actualizarFranjaAtencion(index, 'apertura', e.target.value)}
+                        aria-label="Hora de apertura"
+                        className={selectClass}
+                      >
+                        <option value="">Apertura</option>
+                        {opcionesApertura.map(h => <option key={h} value={h}>{h}</option>)}
+                      </select>
+                      <span className="text-gray-400 text-sm">a</span>
+                      <select
+                        value={f.cierre}
+                        onChange={e => actualizarFranjaAtencion(index, 'cierre', e.target.value)}
+                        aria-label="Hora de cierre"
+                        className={selectClass}
+                      >
+                        <option value="">Cierre</option>
+                        {opcionesCierre
+                          .filter(h => !f.apertura || horaAMinutos(h) > horaAMinutos(f.apertura))
+                          .map(h => <option key={h} value={h}>{h}</option>)}
+                      </select>
+                      <button
+                        type="button"
+                        onClick={() => quitarFranjaAtencion(index)}
+                        className="p-2 text-rose-600 hover:bg-rose-50 dark:hover:bg-rose-900/20 rounded-lg"
+                        aria-label="Quitar franja horaria"
+                      >
+                        <Trash2 className="w-4 h-4" />
+                      </button>
+                    </div>
+                    {tieneError && (
+                      <p className="text-red-500 text-xs mt-1">{validacionAtencion.erroresPorFila[index]}</p>
+                    )}
+                  </div>
+                );
+              })}
+            </div>
+          )}
+          {validacionAtencion.errorSolapamiento && (
+            <p className="text-red-500 text-xs mb-2">{validacionAtencion.errorSolapamiento}</p>
+          )}
+          <button
+            type="button"
+            onClick={agregarFranjaAtencion}
+            className="inline-flex items-center gap-1.5 px-3 py-2 text-sm font-medium text-blue-600 hover:bg-blue-50 dark:hover:bg-blue-900/20 rounded-lg"
+          >
+            <Plus className="w-4 h-4" />
+            Agregar franja
+          </button>
+          {convAtencionInicial.huboLegacy && (
             <p className="text-xs text-amber-600 dark:text-amber-400 mt-2">
-              Valor actual: "{form.horarios_atencion}" — al elegir franjas se reemplaza.
+              Convertimos tus horarios anteriores a rangos. Revisá y guardá para confirmar.
+            </p>
+          )}
+          {convAtencionInicial.sinReconocer.length > 0 && (
+            <p className="text-xs text-amber-600 dark:text-amber-400 mt-2">
+              Valor anterior no reconocido: "{cliente?.horarios_atencion}". Cargá las franjas manualmente.
             </p>
           )}
         </div>
@@ -743,19 +837,43 @@ const ModalCliente = memo(function ModalCliente({ cliente, onSave, onClose, guar
               ?
             </span>
           </label>
-          <select
-            value={form.horario_entrega}
-            onChange={e => handleFieldChange('horario_entrega', e.target.value)}
-            className="w-full px-3 py-2 border rounded-lg dark:bg-gray-700 dark:border-gray-600 dark:text-white"
-          >
-            <option value="">Sin preferencia</option>
-            {FRANJAS_ENTREGA.map(franja => (
-              <option key={franja} value={franja}>{franja}</option>
-            ))}
-          </select>
+          <div className="flex items-center gap-2">
+            <select
+              value={franjaEntrega.apertura}
+              onChange={e => sincronizarEntrega({ ...franjaEntrega, apertura: e.target.value })}
+              aria-label="Entregar desde"
+              className="flex-1 px-3 py-2 border rounded-lg dark:bg-gray-700 dark:border-gray-600 dark:text-white"
+            >
+              <option value="">Sin preferencia</option>
+              {opcionesApertura.map(h => <option key={h} value={h}>{h}</option>)}
+            </select>
+            <span className="text-gray-400 text-sm">a</span>
+            <select
+              value={franjaEntrega.cierre}
+              onChange={e => sincronizarEntrega({ ...franjaEntrega, cierre: e.target.value })}
+              disabled={!franjaEntrega.apertura}
+              aria-label="Entregar hasta"
+              className="flex-1 px-3 py-2 border rounded-lg dark:bg-gray-700 dark:border-gray-600 dark:text-white disabled:opacity-60 disabled:cursor-not-allowed"
+            >
+              <option value="">--</option>
+              {opcionesCierre
+                .filter(h => !franjaEntrega.apertura || horaAMinutos(h) > horaAMinutos(franjaEntrega.apertura))
+                .map(h => <option key={h} value={h}>{h}</option>)}
+            </select>
+          </div>
           <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
             Franja en la que el cliente pide que se le entregue. Se imprime en la hoja de ruta.
           </p>
+          {convEntregaInicial.huboLegacy && (
+            <p className="text-xs text-amber-600 dark:text-amber-400 mt-1">
+              Convertimos la franja anterior a un rango. Revisá y guardá para confirmar.
+            </p>
+          )}
+          {convEntregaInicial.sinReconocer.length > 0 && (
+            <p className="text-xs text-amber-600 dark:text-amber-400 mt-1">
+              Valor anterior no reconocido: "{cliente?.horario_entrega}". Elegí el rango manualmente.
+            </p>
+          )}
         </div>
 
         {/* Notas */}

--- a/src/hooks/queries/useClientesQuery.ts
+++ b/src/hooks/queries/useClientesQuery.ts
@@ -217,6 +217,7 @@ async function createCliente(cliente: ClienteCreateInput, sucursalId: number | n
       descuento_porcentaje: clienteFields.descuento_porcentaje ?? 0,
       contacto: clienteFields.contacto || null,
       horarios_atencion: clienteFields.horarios_atencion || null,
+      horario_entrega: clienteFields.horario_entrega || null,
       rubro: clienteFields.rubro || null,
       notas: clienteFields.notas || null,
       sucursal_id: sucursalId,

--- a/src/utils/horariosCliente.test.ts
+++ b/src/utils/horariosCliente.test.ts
@@ -1,0 +1,182 @@
+import { describe, it, expect } from 'vitest';
+import {
+  generarOpcionesHora,
+  horaAMinutos,
+  parsearFranjas,
+  serializarFranjas,
+  validarFranjas,
+  convertirHorarioInicial,
+} from './horariosCliente';
+
+describe('generarOpcionesHora', () => {
+  it('genera 48 opciones de 00:00 a 23:30 en pasos de 30 min', () => {
+    const ops = generarOpcionesHora();
+    expect(ops).toHaveLength(48);
+    expect(ops[0]).toBe('00:00');
+    expect(ops[1]).toBe('00:30');
+    expect(ops[ops.length - 1]).toBe('23:30');
+  });
+
+  it('agrega "24:00" al final cuando se pide la medianoche', () => {
+    const ops = generarOpcionesHora(true);
+    expect(ops).toHaveLength(49);
+    expect(ops[ops.length - 1]).toBe('24:00');
+  });
+});
+
+describe('horaAMinutos', () => {
+  it('convierte horas válidas a minutos', () => {
+    expect(horaAMinutos('00:00')).toBe(0);
+    expect(horaAMinutos('08:30')).toBe(510);
+    expect(horaAMinutos('23:30')).toBe(1410);
+  });
+
+  it('trata "24:00" como medianoche (1440)', () => {
+    expect(horaAMinutos('24:00')).toBe(1440);
+  });
+
+  it('devuelve NaN para formatos inválidos', () => {
+    expect(horaAMinutos('24:30')).toBeNaN();
+    expect(horaAMinutos('25:00')).toBeNaN();
+    expect(horaAMinutos('08:15')).toBeNaN();
+    expect(horaAMinutos('8:00')).toBeNaN();
+    expect(horaAMinutos('')).toBeNaN();
+  });
+});
+
+describe('parsearFranjas / serializarFranjas', () => {
+  it('hace ida y vuelta de un horario cortado', () => {
+    const valor = '08:00-12:00 y 16:00-20:00';
+    const franjas = parsearFranjas(valor);
+    expect(franjas).toEqual([
+      { apertura: '08:00', cierre: '12:00' },
+      { apertura: '16:00', cierre: '20:00' },
+    ]);
+    expect(serializarFranjas(franjas)).toBe(valor);
+  });
+
+  it('parsea una franja con cierre a medianoche', () => {
+    expect(parsearFranjas('20:00-24:00')).toEqual([{ apertura: '20:00', cierre: '24:00' }]);
+  });
+
+  it('devuelve [] para etiquetas viejas, null y vacío', () => {
+    expect(parsearFranjas('Mañana (08 a 13)')).toEqual([]);
+    expect(parsearFranjas(null)).toEqual([]);
+    expect(parsearFranjas(undefined)).toEqual([]);
+    expect(parsearFranjas('')).toEqual([]);
+  });
+
+  it('descarta filas incompletas al serializar', () => {
+    expect(
+      serializarFranjas([
+        { apertura: '08:00', cierre: '12:00' },
+        { apertura: '16:00', cierre: '' },
+        { apertura: '', cierre: '20:00' },
+      ]),
+    ).toBe('08:00-12:00');
+  });
+});
+
+describe('validarFranjas', () => {
+  it('acepta una franja simple válida', () => {
+    expect(validarFranjas([{ apertura: '08:00', cierre: '20:00' }]).valido).toBe(true);
+  });
+
+  it('acepta un horario cortado sin solape', () => {
+    const r = validarFranjas([
+      { apertura: '08:00', cierre: '12:00' },
+      { apertura: '16:00', cierre: '20:00' },
+    ]);
+    expect(r.valido).toBe(true);
+  });
+
+  it('acepta franjas adyacentes (el borde no es solape)', () => {
+    const r = validarFranjas([
+      { apertura: '08:00', cierre: '12:00' },
+      { apertura: '12:00', cierre: '16:00' },
+    ]);
+    expect(r.valido).toBe(true);
+    expect(r.errorSolapamiento).toBeNull();
+  });
+
+  it('acepta la franja nocturna 20:00-24:00', () => {
+    expect(validarFranjas([{ apertura: '20:00', cierre: '24:00' }]).valido).toBe(true);
+  });
+
+  it('rechaza franjas que se solapan', () => {
+    const r = validarFranjas([
+      { apertura: '08:00', cierre: '12:00' },
+      { apertura: '11:00', cierre: '14:00' },
+    ]);
+    expect(r.valido).toBe(false);
+    expect(r.errorSolapamiento).not.toBeNull();
+  });
+
+  it('detecta el solape sin importar el orden de las filas', () => {
+    const r = validarFranjas([
+      { apertura: '16:00', cierre: '20:00' },
+      { apertura: '08:00', cierre: '18:00' },
+    ]);
+    expect(r.valido).toBe(false);
+    expect(r.errorSolapamiento).not.toBeNull();
+  });
+
+  it('rechaza apertura >= cierre y lo marca en la fila', () => {
+    const r = validarFranjas([{ apertura: '14:00', cierre: '10:00' }]);
+    expect(r.valido).toBe(false);
+    expect(r.erroresPorFila[0]).toBeTruthy();
+  });
+
+  it('ignora filas incompletas', () => {
+    const r = validarFranjas([
+      { apertura: '08:00', cierre: '12:00' },
+      { apertura: '16:00', cierre: '' },
+    ]);
+    expect(r.valido).toBe(true);
+  });
+});
+
+describe('convertirHorarioInicial', () => {
+  it('convierte una etiqueta vieja simple a rango', () => {
+    const r = convertirHorarioInicial('Mañana (08 a 13)');
+    expect(r.franjas).toEqual([{ apertura: '08:00', cierre: '13:00' }]);
+    expect(r.huboLegacy).toBe(true);
+    expect(r.sinReconocer).toEqual([]);
+  });
+
+  it('convierte un horario cortado legacy a dos franjas', () => {
+    const r = convertirHorarioInicial('Mañana (08 a 13) y Tarde (16 a 20)');
+    expect(r.franjas).toEqual([
+      { apertura: '08:00', cierre: '13:00' },
+      { apertura: '16:00', cierre: '20:00' },
+    ]);
+    expect(r.huboLegacy).toBe(true);
+  });
+
+  it('mapea "Noche (20 a 00)" a cierre 24:00', () => {
+    const r = convertirHorarioInicial('Noche (20 a 00)');
+    expect(r.franjas).toEqual([{ apertura: '20:00', cierre: '24:00' }]);
+  });
+
+  it('reconoce el formato nuevo sin marcar legacy', () => {
+    const r = convertirHorarioInicial('08:00-12:00 y 16:00-20:00');
+    expect(r.franjas).toEqual([
+      { apertura: '08:00', cierre: '12:00' },
+      { apertura: '16:00', cierre: '20:00' },
+    ]);
+    expect(r.huboLegacy).toBe(false);
+    expect(r.sinReconocer).toEqual([]);
+  });
+
+  it('reporta el texto libre desconocido en sinReconocer', () => {
+    const r = convertirHorarioInicial('Lun a Vie cualquier hora');
+    expect(r.franjas).toEqual([]);
+    expect(r.sinReconocer).toEqual(['Lun a Vie cualquier hora']);
+  });
+
+  it('devuelve vacío para null/undefined/""', () => {
+    expect(convertirHorarioInicial(null)).toEqual({ franjas: [], huboLegacy: false, sinReconocer: [] });
+    expect(convertirHorarioInicial(undefined)).toEqual({ franjas: [], huboLegacy: false, sinReconocer: [] });
+    expect(convertirHorarioInicial('')).toEqual({ franjas: [], huboLegacy: false, sinReconocer: [] });
+  });
+});

--- a/src/utils/horariosCliente.ts
+++ b/src/utils/horariosCliente.ts
@@ -1,0 +1,179 @@
+/**
+ * Utilidades para los horarios de atención y entrega del cliente.
+ *
+ * Los horarios se persisten como texto legible en columnas `text`
+ * (`clientes.horarios_atencion`, `clientes.horario_entrega`) para que se
+ * impriman tal cual en la hoja de ruta, la orden de preparación, el recibo y
+ * la ficha del cliente. El formato es una o más franjas `HH:MM-HH:MM` unidas
+ * por " y " (ej: "08:00-12:00 y 16:00-20:00").
+ *
+ * Reglas:
+ * - Las horas se comparan SIEMPRE en minutos (nunca lexicográficamente).
+ * - El cierre puede llegar a "24:00" (medianoche); la apertura va 00:00..23:30.
+ * - Dos franjas adyacentes (08:00-12:00 y 12:00-16:00) NO se consideran solapadas.
+ */
+
+export interface FranjaHoraria {
+  /** Hora de apertura "HH:MM" (00:00..23:30). */
+  apertura: string;
+  /** Hora de cierre "HH:MM" (00:30..24:00; "24:00" = medianoche). */
+  cierre: string;
+}
+
+/** Separador entre franjas en el string persistido. */
+const SEPARADOR_FRANJAS = ' y ';
+
+/** Regex de una franja "HH:MM-HH:MM" (el cierre admite 24:00). */
+const RE_FRANJA = /^([01]\d|2[0-3]):(00|30)-([01]\d|2[0-3]|24):(00|30)$/;
+
+/**
+ * Etiquetas prefijadas que usaba la versión anterior del formulario. Se mapean
+ * a rangos para no perder los datos ya cargados al abrir el editor.
+ */
+const MAPA_LEGACY: Record<string, FranjaHoraria> = {
+  'Mañana (08 a 13)': { apertura: '08:00', cierre: '13:00' },
+  'Mediodía (12 a 16)': { apertura: '12:00', cierre: '16:00' },
+  'Tarde (16 a 20)': { apertura: '16:00', cierre: '20:00' },
+  'Noche (20 a 00)': { apertura: '20:00', cierre: '24:00' },
+};
+
+/**
+ * Genera las opciones de hora seleccionables, en pasos de 30 min.
+ * @param incluirMedianoche si es true agrega "24:00" al final (solo para cierres).
+ * @returns ["00:00", "00:30", ..., "23:30"] (+ "24:00" opcional).
+ */
+export function generarOpcionesHora(incluirMedianoche = false): string[] {
+  const opciones: string[] = [];
+  for (let h = 0; h < 24; h++) {
+    const hh = String(h).padStart(2, '0');
+    opciones.push(`${hh}:00`, `${hh}:30`);
+  }
+  if (incluirMedianoche) opciones.push('24:00');
+  return opciones;
+}
+
+/**
+ * Convierte "HH:MM" a minutos desde medianoche. "24:00" → 1440.
+ * @returns minutos, o NaN si el formato es inválido.
+ */
+export function horaAMinutos(hora: string): number {
+  if (!/^([01]\d|2[0-4]):(00|30)$/.test(hora)) return NaN;
+  const [h, m] = hora.split(':').map(Number);
+  if (h === 24 && m !== 0) return NaN;
+  return h * 60 + m;
+}
+
+/**
+ * Parsea el string persistido a franjas. Tolerante: ignora los trozos que no
+ * sean exactamente "HH:MM-HH:MM" (ej. etiquetas viejas o texto libre).
+ */
+export function parsearFranjas(valor?: string | null): FranjaHoraria[] {
+  if (!valor) return [];
+  return valor
+    .split(SEPARADOR_FRANJAS)
+    .map(t => t.trim())
+    .filter(t => RE_FRANJA.test(t))
+    .map(t => {
+      const [apertura, cierre] = t.split('-');
+      return { apertura, cierre };
+    });
+}
+
+/**
+ * Serializa franjas al string persistido, descartando filas incompletas
+ * (sin apertura o sin cierre).
+ */
+export function serializarFranjas(franjas: FranjaHoraria[]): string {
+  return franjas
+    .filter(f => f.apertura && f.cierre)
+    .map(f => `${f.apertura}-${f.cierre}`)
+    .join(SEPARADOR_FRANJAS);
+}
+
+export interface ResultadoValidacionFranjas {
+  valido: boolean;
+  /** Mensaje de error por índice de fila (apertura ≥ cierre). */
+  erroresPorFila: Record<number, string>;
+  /** Mensaje si dos franjas se solapan (null si no hay solape). */
+  errorSolapamiento: string | null;
+}
+
+/**
+ * Valida que cada franja tenga apertura < cierre y que ninguna se solape.
+ * Las filas incompletas (sin ambas horas) se ignoran. Dos franjas adyacentes
+ * (una termina donde empieza la otra) NO se consideran solapadas.
+ */
+export function validarFranjas(franjas: FranjaHoraria[]): ResultadoValidacionFranjas {
+  const erroresPorFila: Record<number, string> = {};
+
+  // 1. apertura < cierre, por fila (solo filas completas).
+  franjas.forEach((f, i) => {
+    if (!f.apertura || !f.cierre) return;
+    if (horaAMinutos(f.apertura) >= horaAMinutos(f.cierre)) {
+      erroresPorFila[i] = 'La apertura debe ser anterior al cierre.';
+    }
+  });
+
+  // 2. solapamiento entre filas completas y sin error propio.
+  let errorSolapamiento: string | null = null;
+  const completas = franjas
+    .map((f, i) => ({ f, i }))
+    .filter(({ f, i }) => f.apertura && f.cierre && !erroresPorFila[i]);
+  for (let a = 0; a < completas.length && !errorSolapamiento; a++) {
+    for (let b = a + 1; b < completas.length; b++) {
+      const ia = horaAMinutos(completas[a].f.apertura);
+      const fa = horaAMinutos(completas[a].f.cierre);
+      const ib = horaAMinutos(completas[b].f.apertura);
+      const fb = horaAMinutos(completas[b].f.cierre);
+      // Sin solape ⟺ una termina antes o justo cuando empieza la otra.
+      const sinSolape = ib >= fa || ia >= fb;
+      if (!sinSolape) {
+        errorSolapamiento = 'Las franjas de atención no pueden superponerse.';
+        break;
+      }
+    }
+  }
+
+  return {
+    valido: Object.keys(erroresPorFila).length === 0 && !errorSolapamiento,
+    erroresPorFila,
+    errorSolapamiento,
+  };
+}
+
+export interface ConversionInicial {
+  franjas: FranjaHoraria[];
+  /** true si alguna etiqueta prefijada vieja fue convertida a rango. */
+  huboLegacy: boolean;
+  /** Trozos que no eran ni "HH:MM-HH:MM" ni etiqueta conocida. */
+  sinReconocer: string[];
+}
+
+/**
+ * Convierte el valor persistido (string) a franjas para inicializar el editor.
+ * Reconoce tanto el formato nuevo "HH:MM-HH:MM" como las etiquetas viejas
+ * (MAPA_LEGACY). Lo que no reconoce se devuelve en `sinReconocer` para poder
+ * avisarlo sin perderlo.
+ */
+export function convertirHorarioInicial(valor?: string | null): ConversionInicial {
+  const franjas: FranjaHoraria[] = [];
+  const sinReconocer: string[] = [];
+  let huboLegacy = false;
+
+  if (!valor) return { franjas, huboLegacy, sinReconocer };
+
+  for (const trozo of valor.split(SEPARADOR_FRANJAS).map(t => t.trim())) {
+    if (!trozo) continue;
+    if (RE_FRANJA.test(trozo)) {
+      const [apertura, cierre] = trozo.split('-');
+      franjas.push({ apertura, cierre });
+    } else if (MAPA_LEGACY[trozo]) {
+      franjas.push({ ...MAPA_LEGACY[trozo] });
+      huboLegacy = true;
+    } else {
+      sinReconocer.push(trozo);
+    }
+  }
+
+  return { franjas, huboLegacy, sinReconocer };
+}


### PR DESCRIPTION
## Qué cambia

Al editar un cliente, los horarios de **atención** y **entrega** dejaban elegir solo etiquetas prefijadas (`Mañana (08 a 13)`, `Mediodía (12 a 16)`, …). Ahora son **carga manual por rango**:

- **Horario de atención**: una o más franjas `Apertura`–`Cierre`. Botón **Agregar franja** / quitar por fila para horario cortado (mañana + tarde). Valida que las franjas **no se solapen** y que apertura < cierre — bloquea el guardado y hace scroll al error (mismo patrón que el resto del form).
- **Horario de entrega**: rango `De`–`A`.
- Horas en pasos de **30 min** (`00:00`–`23:30`); el **cierre** llega hasta **`24:00`** (medianoche), para locales que cierran a la noche.

## Datos / persistencia

- **Sin cambios de schema.** Se sigue guardando un string legible en las columnas `text` existentes (`clientes.horarios_atencion`, `clientes.horario_entrega`), ahora con formato `"08:00-12:00 y 16:00-20:00"`. La hoja de ruta, la orden de preparación, el recibo y la ficha lo imprimen tal cual, sin tocarse.
- **Auto-conversión de datos viejos**: al abrir el editor, las etiquetas conocidas se convierten a rangos (`Mañana (08 a 13)` → `08:00-13:00`, `Noche (20 a 00)` → `20:00-24:00`) y el form se inicializa con el valor ya convertido, así Guardar lo persiste. El texto libre no reconocido se preserva (no se pierde) y se avisa.

## Fix incluido

`createCliente` ahora persiste `horario_entrega` en el INSERT — antes solo se guardaba al editar, no al crear un cliente nuevo.

## Archivos

- `src/utils/horariosCliente.ts` (nuevo) — generación de opciones, parse/serialize, validación de solapamiento y conversión de legacy.
- `src/utils/horariosCliente.test.ts` (nuevo) — 23 tests.
- `src/components/modals/ModalCliente.tsx` — nueva UI de filas + bloqueo de guardado por validación.
- `src/hooks/queries/useClientesQuery.ts` — fix del INSERT.

## Test plan

- [x] `npm run typecheck` (limpio en los archivos tocados)
- [x] `npx eslint` sobre los 4 archivos (sin warnings)
- [x] `npx vitest run` → 724/724
- [ ] Smoke manual en el modal: editar legacy simple/cortado, solape bloqueado, nocturna `24:00`, entrega `De/A`, crear cliente nuevo con entrega

🤖 Generated with [Claude Code](https://claude.com/claude-code)