### PR TITLE
fix(hoja-ruta): consolidar bonificados en fardos + quitar saldo por cliente

### DIFF
--- a/src/lib/pdf/hojaRutaOptimizada.js
+++ b/src/lib/pdf/hojaRutaOptimizada.js
@@ -83,12 +83,6 @@ function drawPageHeader(doc, transportista, pedidos, infoRuta, showSummary) {
  */
 function buildCardOps(doc, pedido, orderNumber) {
   const ops = []
-  const estadoPagoLabel =
-    pedido.estado_pago === 'pagado'
-      ? 'PAGADO'
-      : pedido.estado_pago === 'parcial'
-        ? 'PARCIAL'
-        : 'PEND'
 
   // Nombre cliente + numero
   const headerText = `${orderNumber}. ${pedido.cliente?.nombre_fantasia || 'Sin cliente'}`
@@ -166,14 +160,9 @@ function buildCardOps(doc, pedido, orderNumber) {
     })
   }
 
-  // Total + estado
-  ops.push({
-    kind: 'text',
-    text: `${formatPrecio(pedido.total)} - ${estadoPagoLabel}`,
-    fontSize: 11,
-    bold: true,
-    advance: 5
-  })
+  // (Se quitó la línea "Total + estado de pago" por cliente a pedido del negocio:
+  // la hoja de ruta no debe mostrar saldo/pendiente por ahora. El total del
+  // pedido sigue al pie como "Total pedido".)
 
   // Productos: las bonificaciones van en una lista aparte abajo de los items
   // comprados, con la unidad bien aclarada (botellas/paquetes sueltos vs
@@ -375,6 +364,10 @@ function buildManifiestoOps(pedidos) {
   const totalesCompras = {} // por producto_id (items vendidos)
   const totalesBonifFardos = {} // por producto_id (bonifs en unidades de venta / fardos)
   const totalesBonifSueltas = {} // por descripcion_regalo (botellas/paquetes sueltos)
+  // Bonifs de tipo Fracción: se acumulan en subunidades CRUDAS por producto y se
+  // parten a fardos+sueltas UNA sola vez sobre el total de la ruta (ver abajo),
+  // así no quedan más sueltas que un fardo por sumar restos pedido por pedido.
+  const totalesBonifFraccion = {} // `${id}|${desc}|${upb}` → { key, nombre, desc, upb, subunidades }
 
   const acumular = (mapa, key, nombre, cantidad) => {
     if (!mapa[key]) mapa[key] = { nombre, cantidad: 0 }
@@ -404,19 +397,14 @@ function buildManifiestoOps(pedidos) {
         return
       }
 
-      // Bonificación de tipo Fracción: cantidad en subunidades → split en
-      // fardos completos + botellas/paquetes sueltos.
+      // Bonificación de tipo Fracción: acumular en subunidades crudas. El split
+      // a fardos+sueltas se hace al final sobre el total consolidado de la ruta.
       if (upb && upb > 1 && desc) {
-        const fardos = Math.floor(cantidad / upb)
-        const sueltas = cantidad % upb
-        if (fardos > 0) {
-          // Pre-convertido a fardos: marcar para no re-aplicar la aclaración.
-          const fila = acumular(totalesBonifFardos, key, nombreProducto, fardos)
-          fila.preConvertidoAFardos = true
+        const fkey = `${key}|${desc}|${upb}`
+        if (!totalesBonifFraccion[fkey]) {
+          totalesBonifFraccion[fkey] = { key, nombre: nombreProducto, desc, upb, subunidades: 0 }
         }
-        if (sueltas > 0) {
-          acumular(totalesBonifSueltas, `bonif:${desc}`, desc, sueltas)
-        }
+        totalesBonifFraccion[fkey].subunidades += cantidad
         return
       }
 
@@ -429,6 +417,20 @@ function buildManifiestoOps(pedidos) {
         fila.etiqueta_bulto = item.producto?.etiqueta_bulto ?? null
       }
     })
+  })
+
+  // Partir las fracciones consolidadas UNA vez por producto: fardos completos +
+  // el resto como sueltas (a lo sumo upb-1 sueltas por producto en toda la ruta).
+  Object.values(totalesBonifFraccion).forEach((f) => {
+    const fardos = Math.floor(f.subunidades / f.upb)
+    const sueltas = f.subunidades % f.upb
+    if (fardos > 0) {
+      const fila = acumular(totalesBonifFardos, f.key, f.nombre, fardos)
+      fila.preConvertidoAFardos = true
+    }
+    if (sueltas > 0) {
+      acumular(totalesBonifSueltas, `bonif:${f.desc}`, f.desc, sueltas)
+    }
   })
 
   const ordenar = (mapa) => Object.values(mapa)

--- a/src/lib/pdf/hojaRutaOptimizada.js
+++ b/src/lib/pdf/hojaRutaOptimizada.js
@@ -55,13 +55,12 @@ function drawPageHeader(doc, transportista, pedidos, infoRuta, showSummary) {
   doc.text(metricas.join('  |  '), PAGE_MARGIN, y)
 
   if (showSummary) {
+    // Solo el TOTAL de la ruta. Se quitó "PENDIENTE" (saldo deudor de clientes):
+    // no corresponde a la hoja de ruta.
     const totalGeneral = pedidos.reduce((sum, p) => sum + (p.total || 0), 0)
-    const totalPendiente = pedidos
-      .filter((p) => p.estado_pago !== 'pagado')
-      .reduce((sum, p) => sum + (p.total || 0), 0)
     doc.setFont('helvetica', 'bold')
     doc.text(
-      `TOTAL: ${formatPrecio(totalGeneral)}   PENDIENTE: ${formatPrecio(totalPendiente)}`,
+      `TOTAL: ${formatPrecio(totalGeneral)}`,
       PAGE_WIDTH - PAGE_MARGIN,
       y,
       { align: 'right' }


### PR DESCRIPTION
## Contexto
Dos pedidos del negocio sobre la hoja de ruta (PDF), independientes del #378 (ya mergeado):
1. Los **productos bonificados** figuraban confusos: el mismo producto aparecía partido entre "FARDOS" y "SUELTAS", a veces con más sueltas que un fardo.
2. Cada cliente mostraba un **saldo + estado de pago** ("$X - PEND") que no debe ir en la hoja por ahora.

## Cambios

### Bonificados consolidados (manifiesto de carga)
La bonificación de tipo fracción se acumulaba y partía en fardos/sueltas **pedido por pedido**, y los restos nunca se re-juntaban → quedaban más sueltas que un fardo y el mismo producto aparecía en ambas listas. Ahora se acumulan en subunidades por producto en **toda la ruta** y se parte una sola vez: `floor(total/upb)` fardos + `total % upb` sueltas.

**Verificado** con la ruta vigente de Marcos (16-06): Manaos Manzana 3LT (6+4+2 = 12 bonif., fardo = 6) pasa de **"1 fardo + 6 sueltas"** a **"2 fardos"**. Lima Limón (8, fardo = 12) sigue **"8 sueltas"** (correcto, no llega a un fardo).

### Quitar saldo/estado de pago por cliente
Se elimina la línea "$total - PEND/PARCIAL/PAGADO" de cada tarjeta. El total del pedido sigue al pie como "Total pedido".
> Nota: el header global de la hoja todavía muestra "TOTAL: … PENDIENTE: …" de la ruta. Si también hay que sacarlo, avisar.

## Verificación
- `tsc --noEmit` OK (salvo errores **preexistentes** de `leaflet`/`MapaRuta`), ESLint limpio, **724 tests** en verde (pre-commit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)