### PR TITLE
feat(rutas): optimización respeta ventanas horarias + hora de inicio

### DIFF
--- a/src/components/containers/PedidosContainer.tsx
+++ b/src/components/containers/PedidosContainer.tsx
@@ -151,7 +151,8 @@ export default function PedidosContainer(): React.ReactElement {
   // sucursal en la optimización, así el lado que optimiza y el mapa usan la
   // MISMA ubicación. destino null = la ruta termina en el depósito.
   const optimizarRutaConDeposito = useCallback(
-    (transportistaId: string, pedidosData?: PedidoDB[]) => optimizarRuta(transportistaId, pedidosData, deposito, destinoRuta),
+    (transportistaId: string, pedidosData?: PedidoDB[], fecha?: string, horaInicio?: string) =>
+      optimizarRuta(transportistaId, pedidosData, deposito, destinoRuta, { fecha, horaInicio }),
     [optimizarRuta, deposito, destinoRuta],
   )
 
@@ -1011,9 +1012,9 @@ export default function PedidosContainer(): React.ReactElement {
   // solo paso (sin botón "optimizar" separado). Las polylines del resultado se
   // pasan explícitamente a aplicar (no se leen del estado, que aún no se
   // actualizó en este tick).
-  const handleArmarRutaDelDia = useCallback(async (transportistaId: string, pedidosSeleccionados: PedidoDB[], fecha: string) => {
+  const handleArmarRutaDelDia = useCallback(async (transportistaId: string, pedidosSeleccionados: PedidoDB[], fecha: string, horaInicio: string) => {
     if (!transportistaId || pedidosSeleccionados.length === 0) return
-    const ruta = await optimizarRutaConDeposito(transportistaId, pedidosSeleccionados)
+    const ruta = await optimizarRutaConDeposito(transportistaId, pedidosSeleccionados, fecha, horaInicio)
     if (!ruta?.orden_optimizado?.length) {
       // optimizarRuta ya seteó errorOptimizacion / mostró el mensaje
       return

--- a/src/components/modals/ModalGestionRutas.tsx
+++ b/src/components/modals/ModalGestionRutas.tsx
@@ -61,7 +61,7 @@ export interface ModalGestionRutasProps {
    * Arma la ruta del día: optimiza los pedidos seleccionados y la guarda en
    * un solo paso (el container encadena optimizar + aplicar_orden_ruta).
    */
-  onArmarRuta: (transportistaId: string, pedidos: PedidoDB[], fecha: string) => void;
+  onArmarRuta: (transportistaId: string, pedidos: PedidoDB[], fecha: string, horaInicio: string) => void;
   onExportarPDF: (transportista: PerfilDB | undefined, pedidos: PedidoOrdenado[]) => void;
   onClose: () => void;
   /** true mientras se optimiza/guarda la ruta del día */
@@ -188,6 +188,9 @@ const ModalGestionRutas = memo(function ModalGestionRutas({
   // el default es mañana; se puede elegir de hoy en adelante.
   const hoyISO = fechaLocalISO();
   const [fechaEntrega, setFechaEntrega] = useState<string>(fechaHaceDias(-1));
+  // Hora a la que arranca el recorrido (sale del depósito). Ancla las ventanas
+  // horarias en la optimización para priorizar los horarios de entrega.
+  const [horaInicio, setHoraInicio] = useState<string>('08:00');
   // Filtro de fecha (por fecha de pedido) para acotar el pool de disponibles:
   // suelen acumularse pendientes/en preparación de varios días.
   const [filtroDesde, setFiltroDesde] = useState<string>('');
@@ -359,7 +362,7 @@ const ModalGestionRutas = memo(function ModalGestionRutas({
   const handleArmar = (): void => {
     if (transportistaSeleccionado && pedidosSeleccionados.length > 0) {
       // Optimiza + guarda en un paso, solo con los pedidos seleccionados.
-      onArmarRuta(transportistaSeleccionado, pedidosSeleccionados, fechaEntrega);
+      onArmarRuta(transportistaSeleccionado, pedidosSeleccionados, fechaEntrega, horaInicio);
     }
   };
 
@@ -473,6 +476,21 @@ const ModalGestionRutas = memo(function ModalGestionRutas({
                   </div>
                   <span className="text-xs text-blue-700">
                     El transportista la verá el {formatFecha(fechaEntrega)}.
+                  </span>
+                </div>
+                <div className="mt-3 flex flex-wrap items-center gap-3">
+                  <label className="text-sm font-medium flex items-center gap-1.5 text-blue-900">
+                    <Clock className="w-4 h-4" />
+                    Hora de inicio del recorrido
+                  </label>
+                  <input
+                    type="time"
+                    value={horaInicio}
+                    onChange={(e: ChangeEvent<HTMLInputElement>) => setHoraInicio(e.target.value)}
+                    className="px-3 py-2 border rounded-lg text-sm"
+                  />
+                  <span className="text-xs text-blue-700">
+                    Hora a la que sale del depósito. Prioriza los horarios de entrega de los clientes.
                   </span>
                 </div>
               </div>

--- a/src/hooks/useOptimizarRuta.ts
+++ b/src/hooks/useOptimizarRuta.ts
@@ -1,5 +1,6 @@
 import { useState, useCallback } from 'react';
 import { supabase } from './supabase/base';
+import { parsearFranjas } from '../utils/horariosCliente';
 import type { PedidoDB, ClienteDB } from '../types';
 
 // ============================================================================
@@ -45,6 +46,13 @@ export interface RutaOptimizadaResponse {
   error?: string;
 }
 
+/** Ventana horaria de entrega de un pedido, derivada de cliente.horario_entrega. */
+export interface VentanaPedido {
+  pedido_id: string;
+  inicio: string; // "HH:MM"
+  fin: string;    // "HH:MM" (puede ser "24:00")
+}
+
 export interface OptimizarRutaRequestBody {
   transportista_id: string;
   deposito_lat: number;
@@ -53,6 +61,12 @@ export interface OptimizarRutaRequestBody {
   destino_lat?: number | null;
   destino_lng?: number | null;
   pedidos: PedidoParaOptimizar[];
+  /** Fecha de entrega "YYYY-MM-DD" + hora de inicio "HH:MM": ancla temporal para
+   *  respetar ventanas horarias (solo optimizeTours; el fallback las ignora). */
+  fecha?: string;
+  hora_inicio?: string;
+  /** Ventanas por pedido (de horario_entrega). Solo se respetan con optimizeTours. */
+  ventanas?: VentanaPedido[];
   google_api_key?: string;
 }
 
@@ -60,7 +74,7 @@ export interface UseOptimizarRutaReturn {
   loading: boolean;
   rutaOptimizada: RutaOptimizadaResponse | null;
   error: string | null;
-  optimizarRuta: (transportistaId: string, pedidos?: PedidoDB[], deposito?: DepositoCoords, destino?: DepositoCoords | null) => Promise<RutaOptimizadaResponse | null>;
+  optimizarRuta: (transportistaId: string, pedidos?: PedidoDB[], deposito?: DepositoCoords, destino?: DepositoCoords | null, opts?: { fecha?: string; horaInicio?: string }) => Promise<RutaOptimizadaResponse | null>;
   limpiarRuta: () => void;
 }
 
@@ -144,18 +158,22 @@ export function useOptimizarRuta(): UseOptimizarRutaReturn {
     transportistaId: string,
     pedidos: PedidoDB[] = [],
     deposito?: DepositoCoords,
-    destino?: DepositoCoords | null
+    destino?: DepositoCoords | null,
+    opts?: { fecha?: string; horaInicio?: string }
   ): Promise<RutaOptimizadaResponse | null> => {
     if (!transportistaId) {
       setError('Debes seleccionar un transportista');
       return null;
     }
 
-    // Filtrar pedidos del transportista que tengan coordenadas
+    // El caller (modal de rutas) ya pasa los pedidos curados a rutear (pool
+    // pendiente/en_preparacion + paradas de la ruta a editar). Acá solo se exige
+    // que tengan coordenadas. NOTA: NO filtrar por estado/transportista — con la
+    // unificación (un solo "Armar ruta del día") los pedidos nuevos vienen sin
+    // transportista y en pendiente/en_preparacion; filtrar por 'asignado' los
+    // dejaba a todos afuera.
     const pedidosConCoordenadas: PedidoParaOptimizar[] = pedidos
       .filter((p): p is PedidoDB & { cliente: ClienteDB & { latitud: number; longitud: number } } =>
-        p.transportista_id === transportistaId &&
-        p.estado === 'asignado' &&
         p.cliente?.latitud != null &&
         p.cliente?.longitud != null
       )
@@ -167,6 +185,17 @@ export function useOptimizarRuta(): UseOptimizarRutaReturn {
         latitud: p.cliente.latitud,
         longitud: p.cliente.longitud
       }));
+
+    // Ventanas horarias por pedido desde horario_entrega del cliente (1ª franja
+    // estructurada "HH:MM-HH:MM"). Solo las respeta optimizeTours; sin dato =
+    // pedido flexible (sin restricción).
+    const ventanas: VentanaPedido[] = [];
+    for (const p of pedidos) {
+      const fr = parsearFranjas(p.cliente?.horario_entrega)[0];
+      if (fr?.apertura && fr?.cierre) {
+        ventanas.push({ pedido_id: p.id, inicio: fr.apertura, fin: fr.cierre });
+      }
+    }
 
     if (pedidosConCoordenadas.length === 0) {
       const emptyResult: RutaOptimizadaResponse = {
@@ -192,7 +221,10 @@ export function useOptimizarRuta(): UseOptimizarRutaReturn {
       deposito_lng: dep.lng,
       destino_lat: destino?.lat ?? null,
       destino_lng: destino?.lng ?? null,
-      pedidos: pedidosConCoordenadas
+      pedidos: pedidosConCoordenadas,
+      fecha: opts?.fecha,
+      hora_inicio: opts?.horaInicio,
+      ventanas: ventanas.length > 0 ? ventanas : undefined
     };
 
     try {

--- a/supabase/functions/optimizar-ruta/index.ts
+++ b/supabase/functions/optimizar-ruta/index.ts
@@ -46,6 +46,11 @@ interface RequestBody {
   destino_lat?: number | null;
   destino_lng?: number | null;
   pedidos?: Array<Partial<PedidoRuta> & { latitud?: number | null; longitud?: number | null }>;
+  /** Ancla temporal para respetar ventanas horarias (solo optimizeTours). */
+  fecha?: string; // "YYYY-MM-DD"
+  hora_inicio?: string; // "HH:MM"
+  /** Ventanas de entrega por pedido (derivadas de cliente.horario_entrega). */
+  ventanas?: Array<{ pedido_id: string | number; inicio: string; fin: string }>;
 }
 
 function jsonResponse(body: Record<string, unknown>, status = 200): Response {
@@ -209,14 +214,24 @@ serve(async (req: Request) => {
     });
   }
 
+  // Ventanas horarias: solo las respeta optimizeTours (el fallback computeRoutes
+  // no soporta time windows). ventanas_aplicadas avisa al front si se respetaron.
+  const tieneVentanas = !!(body.fecha && body.hora_inicio && body.ventanas && body.ventanas.length > 0);
+  let ventanasAplicadas = false;
+
   // Motor de optimización: Route Optimization (SA) con fallback a computeRoutes.
   let ruta: RutaUnida;
   let optimizadoPor: string;
   try {
     if (saKey) {
       try {
-        ruta = await optimizeTours(saKey, deposito, conCoords, destino);
+        ruta = await optimizeTours(saKey, deposito, conCoords, destino, {
+          fecha: body.fecha,
+          horaInicio: body.hora_inicio,
+          ventanas: body.ventanas,
+        });
         optimizadoPor = "Google Route Optimization";
+        ventanasAplicadas = tieneVentanas;
       } catch (err) {
         if (!apiKey) throw err;
         console.error("[optimizar-ruta] Route Optimization falló, usando computeRoutes:", err);
@@ -270,5 +285,6 @@ serve(async (req: Request) => {
     distancia_formato: `${distanciaTotalKm} km`,
     orden_optimizado: ordenOptimizado,
     polylines,
+    ventanas_aplicadas: ventanasAplicadas,
   });
 });

--- a/supabase/functions/optimizar-ruta/route-optimization.ts
+++ b/supabase/functions/optimizar-ruta/route-optimization.ts
@@ -57,34 +57,96 @@ export function parseOptimizeTours(data: OptimizeToursResponse, pedidos: PedidoR
   return { ordenOptimizado, distanciaTotalMetros, duracionTotalSegundos, polylines };
 }
 
+// === Ventanas horarias ===
+// Argentina no tiene DST → offset fijo -03:00. El día anterior se arma la ruta,
+// así que NO usamos considerRoadTraffic (sería tráfico de "ahora", no del día).
+const TZ = "-03:00";
+const SERVICE_SECONDS = 480; // ~8 min por parada: timing realista para las ventanas
+const COST_LATE_PER_HOUR = 1000; // penalización ALTA por llegar tarde → prioriza la ventana
+const COST_EARLY_PER_HOUR = 1; // leve: llegar antes implica esperar, no rompe
+
+/** Timestamp RFC3339 en hora de Argentina. "24:00" (cierre a medianoche) → 23:59:59. */
+function isoFecha(fecha: string, hhmm: string): string {
+  const t = hhmm === "24:00" ? "23:59:59" : `${hhmm}:00`;
+  return `${fecha}T${t}${TZ}`;
+}
+
+export interface OptimizeToursOpts {
+  /** "YYYY-MM-DD" de la entrega. */
+  fecha?: string;
+  /** "HH:MM" a la que sale del depósito. */
+  horaInicio?: string;
+  /** Ventanas de entrega por pedido (de cliente.horario_entrega). */
+  ventanas?: Array<{ pedido_id: string | number; inicio: string; fin: string }>;
+}
+
 /**
  * Llama a optimizeTours: 1 shipment por pedido (delivery en la ubicación del
  * cliente, label = pedido_id), 1 vehículo que arranca en el depósito y termina
  * en `destino` (el punto de llegada configurable; por defecto = depósito).
+ *
+ * Si `opts.fecha` + `opts.horaInicio` están presentes, agrega el ancla temporal
+ * (globalStartTime + arranque del vehículo) y, por cada pedido con ventana, una
+ * timeWindow BLANDA con penalización alta por llegar tarde: el optimizador
+ * adelanta esas paradas por sobre el ahorro de distancia, pero nunca las saltea.
  */
 export async function optimizeTours(
   saKeyJson: string,
   deposito: LatLng,
   pedidos: PedidoRuta[],
   destino: LatLng = deposito,
+  opts: OptimizeToursOpts = {},
 ): Promise<RutaUnida> {
   const sa = JSON.parse(saKeyJson) as ServiceAccountKey;
   const token = await getAccessToken(sa);
 
+  const usarTiempos = !!(opts.fecha && opts.horaInicio);
+  const ventanasMap = new Map<string, { inicio: string; fin: string }>();
+  for (const v of opts.ventanas ?? []) {
+    ventanasMap.set(String(v.pedido_id), { inicio: v.inicio, fin: v.fin });
+  }
+
+  const model: Record<string, unknown> = {
+    shipments: pedidos.map((p) => {
+      const delivery: Record<string, unknown> = {
+        arrivalLocation: { latitude: p.latitud, longitude: p.longitud },
+      };
+      if (usarTiempos) {
+        delivery.duration = `${SERVICE_SECONDS}s`;
+        const win = ventanasMap.get(String(p.pedido_id));
+        if (win) {
+          delivery.timeWindows = [{
+            softStartTime: isoFecha(opts.fecha!, win.inicio),
+            softEndTime: isoFecha(opts.fecha!, win.fin),
+            costPerHourBeforeSoftStartTime: COST_EARLY_PER_HOUR,
+            costPerHourAfterSoftEndTime: COST_LATE_PER_HOUR,
+          }];
+        }
+      }
+      return { label: String(p.pedido_id), deliveries: [delivery] };
+    }),
+    vehicles: [{
+      // startLocation plano (NO startWaypoint anidado) y endLocation en el
+      // punto de llegada.
+      startLocation: { latitude: deposito.latitude, longitude: deposito.longitude },
+      endLocation: { latitude: destino.latitude, longitude: destino.longitude },
+      ...(usarTiempos
+        ? {
+          startTimeWindows: [{
+            startTime: isoFecha(opts.fecha!, opts.horaInicio!),
+            endTime: isoFecha(opts.fecha!, opts.horaInicio!),
+          }],
+        }
+        : {}),
+    }],
+  };
+  if (usarTiempos) {
+    model.globalStartTime = isoFecha(opts.fecha!, opts.horaInicio!);
+    model.globalEndTime = `${opts.fecha!}T23:59:59${TZ}`;
+  }
+
   const body = {
-    model: {
-      shipments: pedidos.map((p) => ({
-        label: String(p.pedido_id),
-        deliveries: [{ arrivalLocation: { latitude: p.latitud, longitude: p.longitud } }],
-      })),
-      vehicles: [{
-        // startLocation plano (NO startWaypoint anidado) y endLocation en el
-        // punto de llegada. Sin considerRoadTraffic: exige global_start_time y
-        // la ruta se arma el día anterior, así que el tráfico de ahora no aplica.
-        startLocation: { latitude: deposito.latitude, longitude: deposito.longitude },
-        endLocation: { latitude: destino.latitude, longitude: destino.longitude },
-      }],
-    },
+    model,
     populatePolylines: true,
   };
 


### PR DESCRIPTION
## Contexto
Se quiere que la optimización de ruta **priorice los puntos según su horario de entrega** (ej. escuelas que solo reciben 1 hora a la mañana), indicando además la **hora de inicio** del recorrido al armarlo.

Decisiones (brainstorm): la ventana sale de **`cliente.horario_entrega`** (estructurado, 1 franja; cliente sin dato = flexible); ventana **blanda con penalización alta** (prioriza fuerte pero nunca saltea la parada). Solo `optimizeTours` soporta time windows (en prod corre ese engine).

## Cambios
- **Modal "Armar ruta del día":** nuevo input **"Hora de inicio del recorrido"** (default 08:00).
- **Front (`useOptimizarRuta`):** deriva una ventana por pedido desde `cliente.horario_entrega` (`parsearFranjas`, 1ª franja) y manda `fecha` + `hora_inicio` + `ventanas` a la edge.
- **Edge `optimizeTours`:** agrega `globalStartTime` + arranque del vehículo; por pedido con ventana, una `timeWindow` **blanda** con `costPerHourAfterSoftEndTime` alto → adelanta esas paradas sin saltearlas. Mantiene TRAFFIC_UNAWARE. Devuelve `ventanas_aplicadas`. El fallback `computeRoutes` ignora ventanas (no las soporta).
- **Fix (regresión de #378):** `useOptimizarRuta` filtraba `estado='asignado'` + transportista, pero el pool unificado son pedidos `pendiente`/`en_preparacion` **sin** transportista → al armar una ruta **nueva** los dejaba a todos afuera (no optimizaba nada). Ahora solo exige coordenadas (el modal ya cura la lista). **Esto desbloquea armar rutas nuevas con el flujo unificado.**

## Fuera de alcance (diferido)
Persistir `hora_inicio` en `recorridos` y mostrar "Salida: HH:MM" en el PDF (requiere migración extra al RPC + plumbing del PDF; valor marginal en v1, el chofer ya ve la ventana en "ENTREGAR:").

## Verificación
- ESLint limpio, `tsc` OK (salvo leaflet preexistente), **724 tests** en verde (pre-commit).
- ⚠️ **Requiere desplegar la edge function `optimizar-ruta`** (deploy a prod / branch de Supabase — necesita autorización). Luego, prueba e2e: cargar `horario_entrega` (ej. 08:00-09:00) a un cliente "escuela", armar ruta con inicio 08:00 → debe quedar temprano; `ventanas_aplicadas=true`. Clientes sin `horario_entrega` se optimizan igual que antes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)