### PR TITLE
fix(pedidos): historial con usuario, precio editado y comandas al armar ruta

### DIFF
--- a/src/components/containers/PedidosContainer.tsx
+++ b/src/components/containers/PedidosContainer.tsx
@@ -375,7 +375,27 @@ export default function PedidosContainer(): React.ReactElement {
         .from('pedido_historial').select('*')
         .eq('pedido_id', pedido.id)
         .order('created_at', { ascending: false })
-      setHistorialCambios(data || [])
+      const filas = (data || []) as Array<Record<string, unknown>>
+      // Resolver usuario_id → nombre: la tabla guarda solo el id y el modal
+      // muestra `cambio.usuario?.nombre` (si no, "Sistema"). Mismo patrón que
+      // fetchAllFilteredPedidos. Sin esto, todo el historial salía como "Sistema".
+      const usuarioIds = Array.from(
+        new Set(filas.map(f => f.usuario_id).filter(Boolean)),
+      ) as string[]
+      let perfilesMap: Record<string, { nombre: string }> = {}
+      if (usuarioIds.length > 0) {
+        const { data: perfiles } = await supabase
+          .from('perfiles').select('id, nombre').in('id', usuarioIds)
+        if (perfiles) {
+          perfilesMap = Object.fromEntries(
+            (perfiles as Array<{ id: string; nombre: string }>).map(p => [p.id, { nombre: p.nombre }]),
+          )
+        }
+      }
+      setHistorialCambios(filas.map(f => ({
+        ...f,
+        usuario: f.usuario_id ? (perfilesMap[f.usuario_id as string] ?? null) : null,
+      })))
     } catch (e) {
       notify.error('Error al cargar historial: ' + (e as Error).message)
       setHistorialCambios([])
@@ -1400,6 +1420,7 @@ export default function PedidosContainer(): React.ReactElement {
             pedidos={pedidosParaRuta}
             onArmarRuta={handleArmarRutaDelDia as Parameters<typeof ModalGestionRutas>[0]['onArmarRuta']}
             onExportarPDF={handleExportarHojaRutaOptimizada as Parameters<typeof ModalGestionRutas>[0]['onExportarPDF']}
+            onImprimirComandas={handleImprimirComandas as Parameters<typeof ModalGestionRutas>[0]['onImprimirComandas']}
             onClose={() => { setModalOptimizarRutaOpen(false); limpiarRuta() }}
             loading={loadingOptimizacion || loadingPedidosRuta}
             guardando={guardando}

--- a/src/components/modals/ModalEditarPedido.tsx
+++ b/src/components/modals/ModalEditarPedido.tsx
@@ -180,17 +180,27 @@ const ModalEditarPedido = memo(function ModalEditarPedido({
     if (pedido?.items) {
       const itemsFormateados = pedido.items
         .filter(item => !item.es_bonificacion)
-        .map(item => ({
-          productoId: item.producto_id,
-          nombre: item.producto?.nombre || 'Producto desconocido',
-          cantidad: item.cantidad,
-          precioUnitario: item.precio_unitario,
-          cantidadOriginal: item.cantidad,
-        }));
+        .map(item => {
+          // Marcar precioOverride cuando el precio guardado difiere del de lista
+          // (precio negociado o regalo manual). Sin esto, al reabrir el modal el
+          // precio se recalculaba a lista/mayorista y se "perdía" el manual.
+          const producto = productos.find(p => p.id === item.producto_id);
+          const base = producto?.precio;
+          const override = base != null
+            && Math.abs(Number(item.precio_unitario) - Number(base)) > 0.001;
+          return {
+            productoId: item.producto_id,
+            nombre: item.producto?.nombre || 'Producto desconocido',
+            cantidad: item.cantidad,
+            precioUnitario: item.precio_unitario,
+            cantidadOriginal: item.cantidad,
+            ...(override ? { precioOverride: true } : {}),
+          };
+        });
       setItems(itemsFormateados);
       setItemsOriginales(JSON.parse(JSON.stringify(itemsFormateados)));
     }
-  }, [pedido]);
+  }, [pedido, productos]);
 
   // Armar input con precios base para la resolución. Para items con override
   // manual usamos ese precio; para los demás, el precio base del producto
@@ -294,7 +304,9 @@ const ModalEditarPedido = memo(function ModalEditarPedido({
         const original = itemsOriginales.find(o => o.productoId === item.productoId);
         if (!original) return true; // item nuevo
         if (original.cantidad !== item.cantidad) return true;
-        if (item.precioOverride) return true;
+        // El override puede venir precargado (precio negociado/regalo) sin ser un
+        // cambio del usuario: solo cuenta si difiere del estado original.
+        if (Boolean(item.precioOverride) !== Boolean(original.precioOverride)) return true;
         if (Math.abs((original.precioUnitario ?? 0) - (item.precioUnitario ?? 0)) > 0.001) return true;
         return false;
       }) ||

--- a/src/components/modals/ModalExportarPDF.tsx
+++ b/src/components/modals/ModalExportarPDF.tsx
@@ -44,11 +44,12 @@ const ModalExportarPDF = memo(function ModalExportarPDF({
   const [seleccionarTodos, setSeleccionarTodos] = useState<boolean>(false);
   const [todosLosPedidos, setTodosLosPedidos] = useState<PedidoDB[] | null>(null);
   const [cargandoTodos, setCargandoTodos] = useState(false);
-  // Hoja de ruta: se descarga la ruta YA armada de un día + transportista
-  // (persistida en recorridos), no se regenera al vuelo desde pedidos filtrados.
+  // Hoja de ruta Y comandas: se descargan desde la ruta YA armada de un día +
+  // transportista (persistida en recorridos), no desde pedidos filtrados a mano.
   const [fechaRuta, setFechaRuta] = useState<string>(fechaLocalISO());
+  const usaRecorrido = tipoExport === 'ruta' || tipoExport === 'comanda';
   const { data: recorridosDia = [], isLoading: cargandoRecorridos } = useRecorridosHojaRutaQuery(
-    tipoExport === 'ruta' ? fechaRuta : null,
+    usaRecorrido ? fechaRuta : null,
   );
   const recorridoSeleccionado = useMemo(
     () => recorridosDia.find(r => r.transportistaId === transportistaSeleccionado) ?? null,
@@ -126,26 +127,13 @@ const ModalExportarPDF = memo(function ModalExportarPDF({
     });
   };
 
-  // Resetear seleccion cuando cambia el tipo o transportista
+  // Resetear seleccion cuando cambia el tipo. Hoja de ruta y comandas eligen
+  // día + transportista de la ruta armada (sin selección manual).
   const handleTipoChange = (tipo: TipoExport): void => {
     setTipoExport(tipo);
     setPedidosSeleccionados([]);
     setSeleccionarTodos(false);
-    // El transportista se elige distinto según el tipo (ruta: con ruta armada;
-    // comanda: filtro opcional), así que se resetea al cambiar de tipo.
     setTransportistaSeleccionado('');
-    // Comandas siempre cargan todos
-    if (tipo === 'comanda' && !todosLosPedidos && fetchAllFilteredPedidos) {
-      setAlcance('todos');
-      setCargandoTodos(true);
-      fetchAllFilteredPedidos().then(todos => {
-        setTodosLosPedidos(todos);
-      }).catch(() => {
-        setTodosLosPedidos(null);
-      }).finally(() => {
-        setCargandoTodos(false);
-      });
-    }
   };
 
   const handleTransportistaChange = (id: string): void => {
@@ -156,25 +144,25 @@ const ModalExportarPDF = memo(function ModalExportarPDF({
 
   // Exportar
   const handleExportar = (): void => {
-    // Hoja de ruta: usa las paradas de la ruta ya armada (persistida), en su
-    // orden de entrega; no depende de la selección de pedidos.
-    if (tipoExport === 'ruta') {
+    // Hoja de ruta y Comandas: usan las paradas de la ruta ya armada
+    // (persistida), en su orden de entrega; sin selección manual de pedidos.
+    if (usaRecorrido) {
       if (!recorridoSeleccionado || recorridoSeleccionado.paradas.length === 0) return;
       const transportista = transportistas.find(t => t.id === transportistaSeleccionado);
-      onExportarHojaRuta(transportista, recorridoSeleccionado.paradas);
+      if (tipoExport === 'ruta') {
+        onExportarHojaRuta(transportista, recorridoSeleccionado.paradas);
+      } else {
+        onImprimirComandas?.(recorridoSeleccionado.paradas);
+      }
       onClose();
       return;
     }
 
+    // Orden de preparación: selección manual de pedidos.
     const fuente = alcance === 'todos' && todosLosPedidos ? todosLosPedidos : pedidos;
     const pedidosAExportar = fuente.filter(p => pedidosSeleccionados.includes(p.id));
     if (pedidosAExportar.length === 0) return;
-
-    if (tipoExport === 'preparacion') {
-      onExportarOrdenPreparacion(pedidosAExportar);
-    } else if (tipoExport === 'comanda') {
-      onImprimirComandas?.(pedidosAExportar);
-    }
+    onExportarOrdenPreparacion(pedidosAExportar);
     onClose();
   };
 
@@ -270,9 +258,9 @@ const ModalExportarPDF = memo(function ModalExportarPDF({
           </div>
         )}
 
-        {/* Hoja de Ruta: se elige un día + un transportista con ruta armada y se
-            descarga la hoja de ruta YA generada (persistida en recorridos). */}
-        {tipoExport === 'ruta' && (
+        {/* Hoja de Ruta y Comandas: se elige día + transportista con ruta armada
+            y se genera desde el recorrido persistido (sin selección manual). */}
+        {usaRecorrido && (
           <>
             <div>
               <label className="block text-sm font-medium mb-1 flex items-center gap-1.5">
@@ -314,45 +302,20 @@ const ModalExportarPDF = memo(function ModalExportarPDF({
                 </div>
               ) : recorridoSeleccionado ? (
                 <p className="text-sm text-gray-700 dark:text-gray-300">
-                  Se descargará la hoja de ruta de <strong>{recorridoSeleccionado.transportistaNombre}</strong> con <strong>{recorridoSeleccionado.paradas.length}</strong> paradas.
+                  {tipoExport === 'ruta'
+                    ? <>Se descargará la hoja de ruta de <strong>{recorridoSeleccionado.transportistaNombre}</strong> con <strong>{recorridoSeleccionado.paradas.length}</strong> paradas.</>
+                    : <>Se imprimirán las comandas (duplicado por pedido) de <strong>{recorridoSeleccionado.transportistaNombre}</strong>: <strong>{recorridoSeleccionado.paradas.length}</strong> pedidos.</>}
                 </p>
               ) : (
-                <p className="text-sm text-gray-500">Elegí un transportista para descargar su hoja de ruta.</p>
+                <p className="text-sm text-gray-500">Elegí un transportista para continuar.</p>
               )}
             </div>
           </>
         )}
 
-        {/* Selector de transportista (filtro opcional para comandas) */}
-        {tipoExport === 'comanda' && (
-          <div>
-            <label className="block text-sm font-medium mb-1">
-              Filtrar por transportista (opcional)
-            </label>
-            <select
-              value={transportistaSeleccionado}
-              onChange={(e: ChangeEvent<HTMLSelectElement>) => handleTransportistaChange(e.target.value)}
-              className="w-full px-3 py-2 border rounded-lg dark:bg-gray-700 dark:border-gray-600 dark:text-white"
-            >
-              <option value="">Todos los transportistas</option>
-              {transportistas.map(t => {
-                const fuente = alcance === 'todos' && todosLosPedidos ? todosLosPedidos : pedidos;
-                const pedidosTransportista = fuente.filter(p =>
-                  p.transportista_id === t.id &&
-                  p.estado !== 'entregado' && p.estado !== 'cancelado'
-                ).length;
-                return (
-                  <option key={t.id} value={t.id}>
-                    {t.nombre} ({pedidosTransportista} pedidos)
-                  </option>
-                );
-              })}
-            </select>
-          </div>
-        )}
-
-        {/* Lista de pedidos (preparación y comandas) */}
-        {tipoExport !== 'ruta' && (
+        {/* Lista de pedidos: solo Orden de Preparación usa selección manual.
+            Hoja de Ruta y Comandas salen del recorrido armado (arriba). */}
+        {tipoExport === 'preparacion' && (
           <div>
             <div className="flex justify-between items-center mb-2">
               <label className="block text-sm font-medium">
@@ -380,12 +343,7 @@ const ModalExportarPDF = memo(function ModalExportarPDF({
               <div className="text-center py-8 text-gray-500 bg-gray-50 rounded-lg">
                 <Package className="w-10 h-10 mx-auto mb-2 opacity-50" />
                 <p>No hay pedidos disponibles para exportar</p>
-                <p className="text-xs mt-1">
-                  {tipoExport === 'preparacion'
-                    ? 'Solo se muestran pedidos pendientes o en preparacion'
-                    : 'No hay pedidos para imprimir comandas'
-                  }
-                </p>
+                <p className="text-xs mt-1">Solo se muestran pedidos pendientes o en preparacion</p>
               </div>
             ) : (
               <div className="border rounded-lg max-h-64 overflow-y-auto">
@@ -425,7 +383,7 @@ const ModalExportarPDF = memo(function ModalExportarPDF({
 
       <div className="flex justify-between items-center p-4 border-t bg-gray-50 dark:bg-gray-800 sticky bottom-0">
         <p className="text-sm text-gray-600">
-          {tipoExport === 'ruta'
+          {usaRecorrido
             ? (recorridoSeleccionado && (
                 <>Total: {formatPrecio(recorridoSeleccionado.paradas.reduce((sum, p) => sum + (p.total || 0), 0))}</>
               ))
@@ -445,7 +403,7 @@ const ModalExportarPDF = memo(function ModalExportarPDF({
           </button>
           <button
             onClick={handleExportar}
-            disabled={tipoExport === 'ruta'
+            disabled={usaRecorrido
               ? !recorridoSeleccionado || recorridoSeleccionado.paradas.length === 0
               : pedidosSeleccionados.length === 0}
             className={`flex items-center space-x-2 px-4 py-2 text-white rounded-lg disabled:opacity-50 disabled:cursor-not-allowed ${

--- a/src/components/modals/ModalGestionRutas.tsx
+++ b/src/components/modals/ModalGestionRutas.tsx
@@ -63,6 +63,8 @@ export interface ModalGestionRutasProps {
    */
   onArmarRuta: (transportistaId: string, pedidos: PedidoDB[], fecha: string, horaInicio: string) => void;
   onExportarPDF: (transportista: PerfilDB | undefined, pedidos: PedidoOrdenado[]) => void;
+  /** Imprime las comandas (duplicado por pedido) de la ruta recién armada. */
+  onImprimirComandas?: (pedidos: PedidoOrdenado[]) => void;
   onClose: () => void;
   /** true mientras se optimiza/guarda la ruta del día */
   loading: boolean;
@@ -177,6 +179,7 @@ const ModalGestionRutas = memo(function ModalGestionRutas({
   pedidos,
   onArmarRuta,
   onExportarPDF,
+  onImprimirComandas,
   onClose,
   loading,
   guardando,
@@ -397,6 +400,10 @@ const ModalGestionRutas = memo(function ModalGestionRutas({
   const handleExportarPDF = (): void => {
     const transportista = transportistas.find(t => t.id === transportistaSeleccionado);
     onExportarPDF(transportista, pedidosOrdenados);
+  };
+
+  const handleImprimirComandas = (): void => {
+    onImprimirComandas?.(pedidosOrdenados);
   };
 
   const handleVolverOptimizar = (): void => {
@@ -920,13 +927,24 @@ const ModalGestionRutas = memo(function ModalGestionRutas({
                 </span>
               </button>
             ) : (
-              <button
-                onClick={handleExportarPDF}
-                className="flex items-center space-x-2 px-4 py-2.5 bg-gray-600 text-white rounded-lg hover:bg-gray-700 transition-colors"
-              >
-                <Printer className="w-5 h-5" />
-                <span>Exportar PDF</span>
-              </button>
+              <>
+                <button
+                  onClick={handleExportarPDF}
+                  className="flex items-center space-x-2 px-4 py-2.5 bg-gray-600 text-white rounded-lg hover:bg-gray-700 transition-colors"
+                >
+                  <Printer className="w-5 h-5" />
+                  <span>Hoja de ruta</span>
+                </button>
+                {onImprimirComandas && (
+                  <button
+                    onClick={handleImprimirComandas}
+                    className="flex items-center space-x-2 px-4 py-2.5 bg-purple-600 text-white rounded-lg hover:bg-purple-700 transition-colors"
+                  >
+                    <FileText className="w-5 h-5" />
+                    <span>Comandas</span>
+                  </button>
+                )}
+              </>
             )}
           </div>
         </div>

--- a/src/utils/promociones.ts
+++ b/src/utils/promociones.ts
@@ -72,8 +72,11 @@ export function resolverPromociones(
   const bonificaciones: BonificacionResult[] = []
   const productosConPromo = new Set<string>()
 
-  // 1. Recolectar promos vistas en el pedido
-  const promosVistas = acumularPromos(items, promoMap, { skipOverride: true })
+  // 1. Recolectar promos vistas en el pedido.
+  //    skipOverride:false → un ítem con precio editado a mano SIGUE contando para
+  //    su promo (el precio manual cambia el precio, no la elegibilidad). Ej: regalar
+  //    un producto bajándole el precio no debe anular la botella de regalo de la promo.
+  const promosVistas = acumularPromos(items, promoMap, { skipOverride: false })
 
   for (const entry of promosVistas.values()) {
     for (const pid of entry.productoIdsEnPedido) productosConPromo.add(pid)


### PR DESCRIPTION
Resultado de la investigación de 4 problemas reportados + 1 feature. Todo frontend (sin migraciones ni deploy de edge).

## Fixes
1. **Historial mostraba "Sistema" en todo.** La base sí guarda `usuario_id`; faltaba resolverlo a nombre. `handleVerHistorial` ahora trae `perfiles` por `usuario_id` y arma `cambio.usuario.{nombre}` (mismo patrón que `fetchAllFilteredPedidos`). *(Esto también aclara el caso del pedido #2725: el cambio "En camino → En preparación" lo hizo Virginia H al re-armar la ruta de Marcos sin ese pedido — el RPC mig 088 revierte las paradas quitadas.)*
2. **Precio editado a mano que "volvía" al reabrir el pedido.** La base estaba bien; el modal recalculaba a precio de lista porque no marcaba `precioOverride` al cargar. Ahora lo marca cuando `precio_unitario != producto.precio` (y ese override precargado no cuenta como "modificado" salvo que difiera del original). Evita además que se corrompa al guardar.
3. **Regalo de promo no generado al editar el precio del disparador (5 vs 6 en la hoja de ruta).** `resolverPromociones` saltaba los ítems con precio editado. Ahora **no** los saltea (`skipOverride:false`): un ítem con precio manual igual dispara su promo y genera el regalo. *(El pedido #2753 ya quedó sin la botella; re-guardarlo la genera.)*

## Feature — Comandas al armar la ruta (igual que Hoja de Ruta)
- Botón **"Comandas"** en la vista resultado de "Armar ruta del día" (usa los pedidos de la ruta, sin seleccionar nada).
- La pestaña **"Comandas"** de Exportar PDF pasa a **día + transportista** desde el recorrido armado (`useRecorridosHojaRutaQuery`), sin selección manual — espejo de Hoja de Ruta.

## Verificación
- `tsc` OK (salvo leaflet preexistente), ESLint limpio, suite de tests en verde (pre-commit).
- Manual: historial con nombres reales; editar precio → se mantiene al reabrir; producto con promo + precio editado → genera el regalo; armar ruta → botón Comandas baja las comandas; Export PDF › Comandas → día+transportista baja las mismas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)