### PR TITLE
feat(pedidos): entregar e imprimir comanda por tarjeta + recorridos multi-día

### DIFF
--- a/src/components/pedidos/PedidoActions.tsx
+++ b/src/components/pedidos/PedidoActions.tsx
@@ -9,7 +9,7 @@
  * - Focus visible en items
  */
 import React, { memo, useMemo } from 'react';
-import { MoreVertical, History, Edit2, Package, Check, AlertTriangle, RotateCcw, AlertCircle, XCircle, DollarSign, LucideIcon } from 'lucide-react';
+import { MoreVertical, History, Edit2, Package, Check, AlertTriangle, RotateCcw, AlertCircle, XCircle, DollarSign, Printer, LucideIcon } from 'lucide-react';
 import {
   DropdownMenu,
   DropdownMenuTrigger,
@@ -41,6 +41,7 @@ export interface AccionesDropdownProps {
   onRevertir?: (pedido: PedidoDB) => void;
   onCancelarPedido?: (pedido: PedidoDB) => void;
   onRegistrarPago?: (pedido: PedidoDB) => void;
+  onImprimirComanda?: (pedido: PedidoDB) => void;
 }
 
 interface AccionItem {
@@ -72,6 +73,7 @@ function AccionesDropdown({
   onRevertir,
   onCancelarPedido,
   onRegistrarPago,
+  onImprimirComanda,
 }: AccionesDropdownProps): React.ReactElement {
   // Memoizar acciones para evitar recalculos innecesarios
   const acciones = useMemo((): AccionItem[] => {
@@ -84,6 +86,17 @@ function AccionesDropdown({
         icon: History,
         onClick: () => onHistorial(pedido),
         className: 'text-gray-700 dark:text-gray-300'
+      });
+    }
+
+    // Imprimir comanda (ticket 75mm) de un pedido individual. Admin o encargado,
+    // en cualquier estado y estado de pago.
+    if ((isAdmin || isEncargado) && onImprimirComanda) {
+      items.push({
+        label: 'Imprimir Comanda',
+        icon: Printer,
+        onClick: () => onImprimirComanda(pedido),
+        className: 'text-purple-700 dark:text-purple-400'
       });
     }
 
@@ -152,8 +165,14 @@ function AccionesDropdown({
       });
     }
 
-    // Transportista, admin o encargado pueden marcar entregado
-    if ((isTransportista || isAdmin || isEncargado) && pedido.estado === 'asignado' && onEntregado) {
+    // Marcar entregado:
+    // - Transportista: solo pedidos ruteados (estado 'asignado').
+    // - Admin/encargado: cualquier estado activo (no entregado/cancelado), para
+    //   poder cerrar entregas sueltas sin tener que armar una ruta.
+    const puedeEntregarStaff = (isAdmin || isEncargado)
+      && pedido.estado !== 'entregado' && pedido.estado !== 'cancelado';
+    const puedeEntregarTransportista = isTransportista && pedido.estado === 'asignado';
+    if ((puedeEntregarStaff || puedeEntregarTransportista) && onEntregado) {
       items.push({
         label: 'Marcar Entregado',
         icon: Check,
@@ -195,7 +214,7 @@ function AccionesDropdown({
     }
 
     return items;
-  }, [pedido, isAdmin, isPreventista, isTransportista, isEncargado, currentUserId, onHistorial, onEditar, onEditarNotas, onPreparar, onVolverAPendiente, onEntregado, onEntregadoConSalvedad, onRevertir, onCancelarPedido, onRegistrarPago]);
+  }, [pedido, isAdmin, isPreventista, isTransportista, isEncargado, currentUserId, onHistorial, onEditar, onEditarNotas, onPreparar, onVolverAPendiente, onEntregado, onEntregadoConSalvedad, onRevertir, onCancelarPedido, onRegistrarPago, onImprimirComanda]);
 
   return (
     <DropdownMenu>

--- a/src/components/pedidos/PedidoCard.tsx
+++ b/src/components/pedidos/PedidoCard.tsx
@@ -239,6 +239,11 @@ function PedidoCard({
   const handleMarcarEntregado = onMarcarEntregado ?? pedidoActions?.handleMarcarEntregado;
   const handleDesmarcarEntregado = onDesmarcarEntregado ?? pedidoActions?.handleDesmarcarEntregado;
   const handleRegistrarPago = onRegistrarPago ?? pedidoActions?.handleRegistrarPago;
+  // Impresión de comanda individual (ticket 75mm). Autocontenido: reusa la misma
+  // utilidad que el ReciboDropdown del footer; solo necesita el pedido y su cliente.
+  const handleImprimirComanda = React.useCallback(async (p: PedidoDB): Promise<void> => {
+    if (p.cliente) await generarReciboPedido(p, p.cliente, { formato: 'comanda' });
+  }, []);
   const diasAntiguedad = calcularDiasAntiguedad(pedido.fecha || pedido.created_at);
   const fechaCreacionLabel = formatFecha(pedido.fecha || pedido.created_at);
   const horaCreacion = pedido.created_at ? formatHora(pedido.created_at) : null;
@@ -331,6 +336,7 @@ function PedidoCard({
             onRevertir={handleDesmarcarEntregado}
             onCancelarPedido={onCancelarPedido}
             onRegistrarPago={handleRegistrarPago}
+            onImprimirComanda={handleImprimirComanda}
           />
         </div>
 
@@ -355,6 +361,7 @@ function PedidoCard({
             onRevertir={handleDesmarcarEntregado}
             onCancelarPedido={onCancelarPedido}
             onRegistrarPago={handleRegistrarPago}
+            onImprimirComanda={handleImprimirComanda}
           />
         </div>
       </div>

--- a/src/components/vistas/VistaRecorridos.tsx
+++ b/src/components/vistas/VistaRecorridos.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useMemo, lazy, Suspense, ChangeEvent } from 'react';
-import { Route, Truck, Calendar, Check, MapPin, Phone, ChevronDown, ChevronUp, Navigation, RefreshCw, BarChart3, X } from 'lucide-react';
-import { formatPrecio, formatFecha, fechaLocalISO } from '../../utils/formatters';
+import { Route, Truck, Calendar, Check, MapPin, Phone, ChevronDown, ChevronUp, ChevronLeft, ChevronRight, Navigation, RefreshCw, BarChart3, X } from 'lucide-react';
+import { formatPrecio, formatFecha, fechaLocalISO, fechaHaceDias, parseDateSafe } from '../../utils/formatters';
 import LoadingSpinner from '../layout/LoadingSpinner';
 import { useDepositoCoords } from '../../hooks/queries';
 import { decodePolylines } from '../../utils/polyline';
@@ -393,6 +393,7 @@ export default function VistaRecorridos({
 
   const hoy = fechaLocalISO();
   const esHoy = fechaSeleccionada === hoy;
+  const esFuturo = fechaSeleccionada > hoy;
 
   const handleFechaChange = (e: ChangeEvent<HTMLInputElement>): void => {
     onFechaChange(e.target.value);
@@ -416,7 +417,7 @@ export default function VistaRecorridos({
             Recorridos
           </h1>
           <p className="text-gray-500 dark:text-gray-400 mt-1">
-            {esHoy ? 'Recorridos de hoy' : `Recorridos del ${formatFecha(fechaSeleccionada)}`}
+            {esHoy ? 'Recorridos de hoy' : `Recorridos del ${formatFecha(fechaSeleccionada)}${esFuturo ? ' (futuro)' : ''}`}
           </p>
         </div>
         <div className="flex flex-wrap gap-2">
@@ -449,13 +450,28 @@ export default function VistaRecorridos({
             <Calendar className="w-5 h-5 text-gray-500" />
             <span className="text-gray-700 dark:text-gray-300">Fecha:</span>
           </div>
+          <button
+            onClick={() => onFechaChange(fechaHaceDias(1, parseDateSafe(fechaSeleccionada)))}
+            className="p-2 text-gray-600 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-lg transition-colors"
+            aria-label="Día anterior"
+            title="Día anterior"
+          >
+            <ChevronLeft className="w-5 h-5" />
+          </button>
           <input
             type="date"
             value={fechaSeleccionada}
             onChange={handleFechaChange}
-            max={hoy}
             className="px-3 py-2 border dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-blue-500 dark:bg-gray-700 dark:text-white"
           />
+          <button
+            onClick={() => onFechaChange(fechaHaceDias(-1, parseDateSafe(fechaSeleccionada)))}
+            className="p-2 text-gray-600 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-lg transition-colors"
+            aria-label="Día siguiente"
+            title="Día siguiente"
+          >
+            <ChevronRight className="w-5 h-5" />
+          </button>
           {!esHoy && (
             <button
               onClick={() => onFechaChange(hoy)}


### PR DESCRIPTION
## Contexto

El commit `f9712fc` (unificar asignación en "Armar ruta del día") quitó "Asignar Transportista" del menú por-pedido. Efecto colateral: "Marcar Entregado" en la tarjeta quedó condicionado a `estado === 'asignado'`, y como el único camino a `asignado` pasó a ser armar una ruta, **admin/encargado ya no podían marcar entregado un pedido suelto**. Este PR lo restaura, suma impresión de comanda por pedido y habilita ver recorridos de cualquier día.

## Cambios

**1. "Marcar Entregado" individual** — `PedidoActions.tsx`
- Transportista: sigue limitado a pedidos ruteados (`asignado`).
- Admin/encargado: cualquier estado activo (pendiente / en preparación / asignado; no entregado/cancelado). Sin necesidad de armar ruta. El cableado ya existía hasta `cambiarEstado` (que setea `fecha_entrega`); "Revertir Entrega" sigue funcionando.

**2. "Imprimir Comanda" por pedido** — `PedidoActions.tsx` + `PedidoCard.tsx`
- Nuevo ítem en el menú ⋮, **solo admin/encargado**, en cualquier estado y estado de pago.
- Reusa `generarReciboPedido(..., { formato: 'comanda' })` (ticket 75mm), la misma utilidad del botón "Recibo" del footer (que queda igual). Autocontenido en la tarjeta, sin tocar containers.

**3. Recorridos de cualquier día** — `VistaRecorridos.tsx`
- Se quita el límite `max={hoy}` y se agregan flechas ◀/▶ para navegar día a día → admin/encargado pueden ver recorridos futuros ya armados.
- El header marca "(futuro)"; "Ir a hoy" sigue disponible. La ruta del día del transportista (`useRecorridoActivoQuery`) no se toca.

**Sin cambios de base de datos / migraciones.** `cambiarEstado` es un UPDATE a `pedidos` gobernado por RLS (admin/encargado ya lo usaban) y `fetchRecorridosPorFecha` nunca limitó fechas.

## Verificación
- `tsc --noEmit`: limpio en los archivos tocados (los errores de `leaflet`/`react-leaflet` en `MapaRuta.tsx` son pre-existentes por dependencia no instalada en el worktree).
- `eslint`: limpio.
- `vitest run`: **724/724** ✓ (también corrió en el pre-commit hook).

### Test manual sugerido
1. Como admin/encargado, abrir el ⋮ de un pedido `pendiente` y uno `en_preparacion` → debe aparecer "Marcar Entregado" + "Imprimir Comanda".
2. Como transportista, "Marcar Entregado" solo debe verse en pedidos `asignado`.
3. Operaciones → Recorridos: elegir una fecha futura ya armada; navegar con ◀/▶; "Ir a hoy".

## Nota de auditoría (fuera de alcance, seguimiento)
**P1 — desincronización al entregar un pedido ruteado:** marcar entregado por tarjeta (`cambiarEstado`) no actualiza `recorrido_pedidos.estado_entrega` ni los contadores del `recorrido`. Es **pre-existente** (el camino `asignado`-desde-tarjeta ya lo tenía) y este PR **no lo empeora** (los estados nuevos habilitados no están en ningún recorrido). Recomendación: centralizar en un RPC `marcar_entregado(pedido_id)` o trigger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)