### PR TITLE
fix(rutas): incluir pedidos sin coordenadas al armar la ruta del día

### DIFF
--- a/src/components/containers/PedidosContainer.tsx
+++ b/src/components/containers/PedidosContainer.tsx
@@ -1035,12 +1035,26 @@ export default function PedidosContainer(): React.ReactElement {
   const handleArmarRutaDelDia = useCallback(async (transportistaId: string, pedidosSeleccionados: PedidoDB[], fecha: string, horaInicio: string) => {
     if (!transportistaId || pedidosSeleccionados.length === 0) return
     const ruta = await optimizarRutaConDeposito(transportistaId, pedidosSeleccionados, fecha, horaInicio)
-    if (!ruta?.orden_optimizado?.length) {
-      // optimizarRuta ya seteó errorOptimizacion / mostró el mensaje
-      return
-    }
+    // ruta es null solo si la optimización falló de verdad (error de red/servicio):
+    // optimizarRuta ya mostró el mensaje y no armamos nada.
+    if (!ruta) return
+
+    const optimizados = (ruta.orden_optimizado ?? []) as Array<{ pedido_id: string; orden: number }>
+    // Los pedidos sin coordenadas NO los devuelve el optimizador, pero igual deben
+    // formar parte de la ruta (son entregables). Se anexan al final, después de las
+    // paradas optimizadas, con orden_entrega secuencial. Antes se perdían y la ruta
+    // quedaba solo con los pedidos geolocalizados.
+    const idsOptimizados = new Set(optimizados.map(o => String(o.pedido_id)))
+    const maxOrden = optimizados.reduce((m, o) => Math.max(m, o.orden), 0)
+    const sinCoordenadas = pedidosSeleccionados
+      .filter(p => !idsOptimizados.has(String(p.id)))
+      .map((p, i) => ({ pedido_id: p.id, orden: maxOrden + 1 + i }))
+
+    const ordenFinal = [...optimizados, ...sinCoordenadas]
+    if (ordenFinal.length === 0) return
+
     await handleAplicarOrden({
-      ordenOptimizado: ruta.orden_optimizado as Array<{ pedido_id: string; orden: number }>,
+      ordenOptimizado: ordenFinal,
       transportistaId,
       distancia: ruta.distancia_total ?? null,
       duracion: ruta.duracion_total ?? null,

--- a/src/components/modals/ModalGestionRutas.tsx
+++ b/src/components/modals/ModalGestionRutas.tsx
@@ -312,12 +312,20 @@ const ModalGestionRutas = memo(function ModalGestionRutas({
     for (const p of paradasExistentes) map.set(p.id, p);
     for (const p of pedidos) map.set(p.id, p);
     const result: PedidoOrdenado[] = [];
+    const incluidos = new Set<string>();
     for (const item of rutaOptimizada.orden_optimizado) {
       const pedido = map.get(item.pedido_id);
-      if (pedido) result.push({ ...pedido, orden_optimizado: item.orden });
+      if (pedido) { result.push({ ...pedido, orden_optimizado: item.orden }); incluidos.add(pedido.id); }
+    }
+    // Pedidos seleccionados sin coordenadas: el optimizador no los ordena, pero
+    // forman parte de la ruta armada. Se muestran al final, sin orden geográfico,
+    // para que el conteo, la hoja de ruta y las comandas coincidan con lo seleccionado.
+    let orden = result.length;
+    for (const p of pedidosSeleccionados) {
+      if (!incluidos.has(p.id)) { result.push({ ...p, orden_optimizado: ++orden }); incluidos.add(p.id); }
     }
     return result;
-  }, [rutaOptimizada, paradasExistentes, pedidos]);
+  }, [rutaOptimizada, paradasExistentes, pedidos, pedidosSeleccionados]);
 
   // Verificar si hay pedidos seleccionados sin coordenadas
   const pedidosSinCoordenadas = useMemo((): PedidoDB[] => {


### PR DESCRIPTION
## Problema

Al armar la ruta del día seleccionando varios pedidos, si algunos clientes no tienen coordenadas, la ruta guardada terminaba con **un solo pedido** (el único geolocalizado). Reportado en la ruta de Taco Pozo: 7 paradas seleccionadas, 6 sin coordenadas → la ruta guardaba solo 1.

## Causa

El optimizador (Google Routes) solo devuelve los pedidos con coordenadas en `orden_optimizado`. `handleArmarRutaDelDia` pasaba **únicamente** esos al RPC `aplicar_orden_ruta`, así que los pedidos sin coordenadas nunca entraban al recorrido. Lo mismo en el modal: la vista de resultado, los totales, la hoja de ruta y las comandas se derivaban solo de `orden_optimizado`.

## Solución

Los pedidos seleccionados **sin coordenadas se anexan al final** de la ruta — son entregables, solo que sin orden geográfico (van después de las paradas optimizadas, con `orden_entrega` secuencial):

- `PedidosContainer.handleArmarRutaDelDia`: agrega los sin-coordenadas al payload del RPC (`orden_entrega` continuando después del máximo optimizado). También arma la ruta aunque el optimizador devuelva 0 (todos sin coords).
- `ModalGestionRutas.pedidosOrdenados`: los muestra al final, para que el conteo, "Total/Pendiente de cobro", la hoja de ruta y las comandas coincidan con lo seleccionado. El link de Google Maps sigue usando solo los geolocalizados.

La advertencia "Pedidos sin coordenadas… no serán incluidos en la optimización" sigue mostrándose (correcto: no se optimizan, pero ahora **sí** se incluyen en la ruta).

## Verificación
- `tsc --noEmit` y `eslint` limpios en los archivos tocados.
- `vitest run`: **724/724** ✓.

### Test manual
1. Armar ruta del día con pedidos seleccionados donde algunos clientes no tengan coordenadas.
2. La ruta guardada debe contener **todos** los seleccionados; los geolocalizados primero (orden optimizado) y los sin coordenadas al final.
3. Verificar que la hoja de ruta y las comandas incluyan a todos.

> Nota: el `feat` previo (PR #384) ya está mergeado en `main`; esta rama sale de `main` actualizado y contiene solo este fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)