### PR TITLE
fix(rutas): mostrar hoja de ruta/comandas tras armar aunque haya paradas sin coordenadas

### DIFF
--- a/src/components/containers/PedidosContainer.tsx
+++ b/src/components/containers/PedidosContainer.tsx
@@ -144,7 +144,7 @@ export default function PedidosContainer(): React.ReactElement {
   const crearClienteMut = useCrearClienteMutation()
 
   // Route optimization
-  const { loading: loadingOptimizacion, rutaOptimizada, error: errorOptimizacion, optimizarRuta, limpiarRuta } = useOptimizarRuta()
+  const { loading: loadingOptimizacion, rutaOptimizada, error: errorOptimizacion, optimizarRuta, setRutaOptimizada, limpiarRuta } = useOptimizarRuta()
   const deposito = useDepositoCoords()
   const destinoRuta = useDestinoCoords()
   // Inyecta el depósito (origen) y el punto de llegada opcional (destino) de la
@@ -989,8 +989,9 @@ export default function PedidosContainer(): React.ReactElement {
   // distancia/duración. Un recorrido vigente por transportista por día.
   // Las polylines se pasan por argumento (no se leen de rutaOptimizada del
   // closure) para evitar usar un valor viejo cuando se encadena optimizar→aplicar.
-  const aplicarOrden = useCallback(async (data: { ordenOptimizado: Array<{ pedido_id: string; orden: number }>; transportistaId: string; distancia: number | null; duracion: number | null; polylines: string[] | null; fecha: string }) => {
+  const aplicarOrden = useCallback(async (data: { ordenOptimizado: Array<{ pedido_id: string; orden: number }>; transportistaId: string; distancia: number | null; duracion: number | null; polylines: string[] | null; fecha: string }): Promise<boolean> => {
     setGuardando(true)
+    let ok = false
     try {
       const { error } = await supabase.rpc('aplicar_orden_ruta', {
         p_transportista_id: data.transportistaId,
@@ -1016,16 +1017,18 @@ export default function PedidosContainer(): React.ReactElement {
       // No cerramos el modal: queda en la vista de resultado (confirmación +
       // export PDF). El admin cierra con "Cerrar" (que limpia la ruta).
       notify.success('Ruta del día armada y guardada')
+      ok = true
     } catch (e) { notify.error('Error al guardar la ruta: ' + (e as Error).message) }
     setGuardando(false)
+    return ok
   }, [notify, queryClient])
 
-  const handleAplicarOrden = useCallback(async (data: { ordenOptimizado: Array<{ pedido_id: string; orden: number }>; transportistaId: string; distancia: number | null; duracion: number | null; polylines: string[] | null; fecha: string }) => {
-    if (!data.ordenOptimizado?.length || !data.transportistaId) return
+  const handleAplicarOrden = useCallback(async (data: { ordenOptimizado: Array<{ pedido_id: string; orden: number }>; transportistaId: string; distancia: number | null; duracion: number | null; polylines: string[] | null; fecha: string }): Promise<boolean> => {
+    if (!data.ordenOptimizado?.length || !data.transportistaId) return false
     // Sin confirm de reemplazo: si ya hay una ruta para ese transportista+fecha,
     // el modal la cargó pre-tildada y el RPC (mig 088) la edita in-place (no
     // duplica). Armar = guardar las modificaciones sobre esa misma ruta.
-    await aplicarOrden(data)
+    return await aplicarOrden(data)
   }, [aplicarOrden])
 
   // Armar ruta del día: optimiza los pedidos seleccionados y los guarda en un
@@ -1053,7 +1056,7 @@ export default function PedidosContainer(): React.ReactElement {
     const ordenFinal = [...optimizados, ...sinCoordenadas]
     if (ordenFinal.length === 0) return
 
-    await handleAplicarOrden({
+    const armado = await handleAplicarOrden({
       ordenOptimizado: ordenFinal,
       transportistaId,
       distancia: ruta.distancia_total ?? null,
@@ -1061,7 +1064,21 @@ export default function PedidosContainer(): React.ReactElement {
       polylines: ruta.polylines ?? null,
       fecha,
     })
-  }, [optimizarRutaConDeposito, handleAplicarOrden])
+
+    // Reflejar en el resultado la ruta REALMENTE armada (optimizadas + sin
+    // coordenadas). El optimizador no devuelve las paradas sin coordenadas, así
+    // que sin esto el modal no cambiaba a la vista de resultado (ni mostraba los
+    // botones de hoja de ruta / comandas) cuando la ruta tenía pocas o ninguna
+    // parada geolocalizada.
+    if (armado) {
+      setRutaOptimizada(prev => ({
+        ...(prev ?? {}),
+        success: true,
+        total_pedidos: ordenFinal.length,
+        orden_optimizado: ordenFinal.map(o => ({ pedido_id: o.pedido_id, orden: o.orden })),
+      }))
+    }
+  }, [optimizarRutaConDeposito, handleAplicarOrden, setRutaOptimizada])
 
   const handleExportarHojaRutaOptimizada = useCallback(async (transportista: PerfilDB | undefined, pedidosOrdenados: PedidoDB[]) => {
     try {

--- a/src/hooks/useOptimizarRuta.ts
+++ b/src/hooks/useOptimizarRuta.ts
@@ -1,4 +1,5 @@
 import { useState, useCallback } from 'react';
+import type { Dispatch, SetStateAction } from 'react';
 import { supabase } from './supabase/base';
 import { parsearFranjas } from '../utils/horariosCliente';
 import type { PedidoDB, ClienteDB } from '../types';
@@ -75,6 +76,10 @@ export interface UseOptimizarRutaReturn {
   rutaOptimizada: RutaOptimizadaResponse | null;
   error: string | null;
   optimizarRuta: (transportistaId: string, pedidos?: PedidoDB[], deposito?: DepositoCoords, destino?: DepositoCoords | null, opts?: { fecha?: string; horaInicio?: string }) => Promise<RutaOptimizadaResponse | null>;
+  /** Permite al caller reflejar la ruta realmente armada (p.ej. agregando las
+   *  paradas sin coordenadas que el optimizador no devuelve) para que el modal
+   *  muestre el resultado y los botones de hoja de ruta / comandas. */
+  setRutaOptimizada: Dispatch<SetStateAction<RutaOptimizadaResponse | null>>;
   limpiarRuta: () => void;
 }
 
@@ -326,6 +331,7 @@ export function useOptimizarRuta(): UseOptimizarRutaReturn {
     rutaOptimizada,
     error,
     optimizarRuta,
+    setRutaOptimizada,
     limpiarRuta
   };
 }


### PR DESCRIPTION
## Problema

Al armar una ruta del día desde el modal, los botones **Hoja de ruta** y **Comandas** no aparecían directamente (el modal no pasaba a la vista "Ruta guardada"). Después, desde el modal de Exportaciones, sí se podían generar.

## Causa

Tras incluir los pedidos sin coordenadas en la ruta ([#385](https://github.com/AgustinReiden/distribuidora-app/pull/385)), una ruta puede quedar armada con pocas o ninguna parada geolocalizada. El cambio del modal a la vista de resultado dependía de `rutaOptimizada.orden_optimizado`, que el optimizador **solo** devuelve para paradas con coordenadas. Si no había paradas geolocalizadas (o muy pocas), el modal no cambiaba de pestaña y no mostraba los botones, aunque la ruta sí se hubiera guardado.

## Solución

Tras armar con éxito, se refleja en `rutaOptimizada` la ruta **realmente armada** (optimizadas + sin coordenadas), de modo que el modal cambie a la vista de resultado y muestre los botones de hoja de ruta y comandas, con el conteo correcto de paradas.

- `useOptimizarRuta`: se expone `setRutaOptimizada`.
- `aplicarOrden` / `handleAplicarOrden`: devuelven si la operación tuvo éxito.
- `handleArmarRutaDelDia`: tras un armado exitoso, setea `orden_optimizado` con todas las paradas armadas (preservando distancia/duración/polylines del tramo optimizado).

## Verificación
- `tsc --noEmit` y `eslint` limpios en los archivos tocados.
- `vitest run`: **724/724** ✓.

### Test manual
1. Armar una ruta con pedidos donde varios (o todos) los clientes no tengan coordenadas.
2. Al armar, el modal debe pasar a "Ruta guardada" mostrando **Hoja de ruta** y **Comandas** directamente, con el total de paradas correcto.

🤖 Generated with [Claude Code](https://claude.com/claude-code)