### PR TITLE
fix(pedidos): editar precio en mobile, precio en exportaciones y destildar pedidos a imprimir

### DIFF
--- a/src/components/containers/PedidosContainer.tsx
+++ b/src/components/containers/PedidosContainer.tsx
@@ -614,8 +614,14 @@ export default function PedidosContainer(): React.ReactElement {
       if (data.fechaEntregaProgramada) updateData.fecha_entrega_programada = data.fechaEntregaProgramada
       const { error } = await supabase.from('pedidos').update(updateData).eq('id', pedidoEditando.id)
       if (error) throw error
-      // Invalidar cache para que los cambios se reflejen en la UI
+      // Invalidar cache para que los cambios se reflejen en la UI. Incluye la
+      // familia recorridos* para que la hoja de ruta/comanda re-descargada desde
+      // Exportaciones refleje cambios de fecha/notas (sino sirve datos cacheados).
       queryClient.invalidateQueries({ queryKey: ['pedidos'] })
+      queryClient.invalidateQueries({ queryKey: ['recorridos'] })
+      queryClient.invalidateQueries({ queryKey: ['recorridos-hoja-ruta'] })
+      queryClient.invalidateQueries({ queryKey: ['recorrido-activo'] })
+      queryClient.invalidateQueries({ queryKey: ['recorrido-existente'] })
       setModalEditarOpen(false)
       setPedidoEditando(null)
       notify.success('Pedido actualizado')
@@ -650,8 +656,15 @@ export default function PedidosContainer(): React.ReactElement {
     if (!response.success) {
       throw new Error(response.errores?.join(', ') || 'Error al actualizar items')
     }
-    // Invalidar cache de pedidos para refrescar datos
+    // Invalidar cache de pedidos para refrescar datos. Tambien la familia
+    // recorridos* para que la hoja de ruta y las comandas (que se descargan
+    // desde la ruta armada via useRecorridosHojaRutaQuery) reflejen el precio
+    // editado y no sirvan paradas cacheadas con el valor viejo.
     queryClient.invalidateQueries({ queryKey: ['pedidos'] })
+    queryClient.invalidateQueries({ queryKey: ['recorridos'] })
+    queryClient.invalidateQueries({ queryKey: ['recorridos-hoja-ruta'] })
+    queryClient.invalidateQueries({ queryKey: ['recorrido-activo'] })
+    queryClient.invalidateQueries({ queryKey: ['recorrido-existente'] })
   }, [pedidoEditando, user, queryClient])
 
   // Reasignar el preventista del pedido en edicion. Solo admin (la UI ya

--- a/src/components/modals/ModalEditarPedido.tsx
+++ b/src/components/modals/ModalEditarPedido.tsx
@@ -1,5 +1,5 @@
 import { lazy, Suspense, useState, memo, useEffect, useMemo } from 'react';
-import { Loader2, AlertCircle, Package, Plus, Minus, Trash2, Search, X, ShoppingCart, Pencil, Gift, RefreshCw, UserCheck } from 'lucide-react';
+import { Loader2, AlertCircle, Package, Plus, Minus, Trash2, Search, X, ShoppingCart, Pencil, Gift, RefreshCw, UserCheck, Check } from 'lucide-react';
 import ModalBase from './ModalBase';
 import ModalConfirmacion, { type ModalConfirmacionConfig } from './ModalConfirmacion';
 import { formatPrecio } from '../../utils/formatters';
@@ -365,6 +365,16 @@ const ModalEditarPedido = memo(function ModalEditarPedido({
     ));
   };
 
+  // Confirma el precio en edicion. Se invoca desde Enter, blur y el boton ✓.
+  // El boton es clave en mobile: el `onBlur` en touch no siempre dispara de
+  // forma confiable, asi que damos una via explicita para commitear el valor.
+  const commitEditingPrice = (): void => {
+    if (editingPriceId == null) return;
+    const newPrice = parsePrecio(editingPriceValue);
+    if (newPrice > 0) handlePrecioChange(editingPriceId, newPrice);
+    setEditingPriceId(null);
+  };
+
   const handleAgregarProducto = (producto: ProductoDB): void => {
     const moq = moqMap.get(String(producto.id));
     const cantidadInicial = moq && moq > 1 ? moq : 1;
@@ -645,30 +655,31 @@ const ModalEditarPedido = memo(function ModalEditarPedido({
                             <div className="flex items-center gap-1">
                               <span className="text-orange-600">$</span>
                               <input
-                                type="number"
+                                type="text"
                                 inputMode="decimal"
-                                step="0.01"
-                                min="0.01"
                                 aria-label="Editar precio unitario"
                                 value={editingPriceValue}
                                 onChange={e => setEditingPriceValue(e.target.value)}
                                 onKeyDown={e => {
                                   if (e.key === 'Enter') {
-                                    const newPrice = parsePrecio(editingPriceValue);
-                                    if (newPrice > 0) handlePrecioChange(item.productoId, newPrice);
-                                    setEditingPriceId(null);
+                                    commitEditingPrice();
                                   } else if (e.key === 'Escape') {
                                     setEditingPriceId(null);
                                   }
                                 }}
-                                onBlur={() => {
-                                  const newPrice = parsePrecio(editingPriceValue);
-                                  if (newPrice > 0) handlePrecioChange(item.productoId, newPrice);
-                                  setEditingPriceId(null);
-                                }}
-                                className="w-28 px-2 py-1 text-sm border border-orange-300 rounded bg-orange-50 dark:bg-orange-900/20 dark:border-orange-600 dark:text-white focus:ring-2 focus:ring-orange-500 focus:outline-none"
+                                onBlur={commitEditingPrice}
+                                className="w-24 px-2 py-1 text-sm border border-orange-300 rounded bg-orange-50 dark:bg-orange-900/20 dark:border-orange-600 dark:text-white focus:ring-2 focus:ring-orange-500 focus:outline-none"
                                 autoFocus
                               />
+                              <button
+                                type="button"
+                                aria-label="Confirmar precio"
+                                onPointerDown={e => e.preventDefault()}
+                                onClick={commitEditingPrice}
+                                className="p-1 text-white bg-orange-500 hover:bg-orange-600 rounded shrink-0"
+                              >
+                                <Check className="w-3.5 h-3.5" />
+                              </button>
                               <span className="text-orange-600">c/u</span>
                             </div>
                           ) : (

--- a/src/components/modals/ModalExportarPDF.tsx
+++ b/src/components/modals/ModalExportarPDF.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo, useCallback, memo } from 'react';
+import { useState, useMemo, useCallback, useEffect, useRef, memo } from 'react';
 import type { ChangeEvent } from 'react';
 import { FileDown, Package, Truck, Printer, Loader2, CalendarDays } from 'lucide-react';
 import ModalBase from './ModalBase';
@@ -48,7 +48,7 @@ const ModalExportarPDF = memo(function ModalExportarPDF({
   // transportista (persistida en recorridos), no desde pedidos filtrados a mano.
   const [fechaRuta, setFechaRuta] = useState<string>(fechaLocalISO());
   const usaRecorrido = tipoExport === 'ruta' || tipoExport === 'comanda';
-  const { data: recorridosDia = [], isLoading: cargandoRecorridos } = useRecorridosHojaRutaQuery(
+  const { data: recorridosDia = [], isLoading: cargandoRecorridos, isFetching: recargandoRecorridos } = useRecorridosHojaRutaQuery(
     usaRecorrido ? fechaRuta : null,
   );
   const recorridoSeleccionado = useMemo(
@@ -100,11 +100,36 @@ const ModalExportarPDF = memo(function ModalExportarPDF({
     }
   }, [todosLosPedidos, fetchAllFilteredPedidos]);
 
+  // Lista sobre la que opera la seleccion: para Hoja de Ruta y Comandas son las
+  // paradas de la ruta armada; para Orden de Preparacion, los pedidos filtrados.
+  const listaSeleccionable = usaRecorrido
+    ? (recorridoSeleccionado?.paradas ?? [])
+    : pedidosFiltrados;
+
+  // Hoja de Ruta y Comandas arrancan con TODAS las paradas tildadas (imprime
+  // todo por defecto, como antes); el usuario destilda las que quiera excluir.
+  // Solo reseteamos cuando CAMBIA el recorrido elegido (día/transportista), no
+  // en cada refetch en segundo plano: sino pisaríamos los destildados del user.
+  const recorridoAplicadoRef = useRef<string | null>(null);
+  useEffect(() => {
+    if (!usaRecorrido) { recorridoAplicadoRef.current = null; return; }
+    const id = recorridoSeleccionado?.recorridoId ?? null;
+    if (id === recorridoAplicadoRef.current) return;
+    recorridoAplicadoRef.current = id;
+    if (recorridoSeleccionado) {
+      setPedidosSeleccionados(recorridoSeleccionado.paradas.map(p => p.id));
+      setSeleccionarTodos(true);
+    } else {
+      setPedidosSeleccionados([]);
+      setSeleccionarTodos(false);
+    }
+  }, [recorridoSeleccionado, usaRecorrido]);
+
   // Manejar seleccion de todos
   const handleSeleccionarTodos = (checked: boolean): void => {
     setSeleccionarTodos(checked);
     if (checked) {
-      setPedidosSeleccionados(pedidosFiltrados.map(p => p.id));
+      setPedidosSeleccionados(listaSeleccionable.map(p => p.id));
     } else {
       setPedidosSeleccionados([]);
     }
@@ -119,7 +144,7 @@ const ModalExportarPDF = memo(function ModalExportarPDF({
         return nuevo;
       } else {
         const nuevo = [...prev, pedidoId];
-        if (nuevo.length === pedidosFiltrados.length) {
+        if (nuevo.length === listaSeleccionable.length) {
           setSeleccionarTodos(true);
         }
         return nuevo;
@@ -144,15 +169,18 @@ const ModalExportarPDF = memo(function ModalExportarPDF({
 
   // Exportar
   const handleExportar = (): void => {
-    // Hoja de ruta y Comandas: usan las paradas de la ruta ya armada
-    // (persistida), en su orden de entrega; sin selección manual de pedidos.
+    // Hoja de ruta y Comandas: parten de las paradas de la ruta ya armada
+    // (persistida), en su orden de entrega, excluyendo las que el usuario haya
+    // destildado.
     if (usaRecorrido) {
-      if (!recorridoSeleccionado || recorridoSeleccionado.paradas.length === 0) return;
+      if (!recorridoSeleccionado) return;
+      const paradas = recorridoSeleccionado.paradas.filter(p => pedidosSeleccionados.includes(p.id));
+      if (paradas.length === 0) return;
       const transportista = transportistas.find(t => t.id === transportistaSeleccionado);
       if (tipoExport === 'ruta') {
-        onExportarHojaRuta(transportista, recorridoSeleccionado.paradas);
+        onExportarHojaRuta(transportista, paradas);
       } else {
-        onImprimirComandas?.(recorridoSeleccionado.paradas);
+        onImprimirComandas?.(paradas);
       }
       onClose();
       return;
@@ -310,6 +338,58 @@ const ModalExportarPDF = memo(function ModalExportarPDF({
                 <p className="text-sm text-gray-500">Elegí un transportista para continuar.</p>
               )}
             </div>
+
+            {/* Lista de paradas para destildar las que NO se quieran imprimir.
+                Arranca todo tildado (imprime todo, como antes). Aplica igual a
+                Hoja de Ruta y a Comandas. */}
+            {recorridoSeleccionado && recorridoSeleccionado.paradas.length > 0 && (
+              <div>
+                <div className="flex justify-between items-center mb-1">
+                  <label className="block text-sm font-medium">
+                    Pedidos a imprimir ({pedidosSeleccionados.length} de {recorridoSeleccionado.paradas.length})
+                  </label>
+                  <label className="flex items-center space-x-2 text-sm cursor-pointer">
+                    <input
+                      type="checkbox"
+                      checked={seleccionarTodos}
+                      onChange={(e: ChangeEvent<HTMLInputElement>) => handleSeleccionarTodos(e.target.checked)}
+                      className="w-4 h-4 rounded"
+                    />
+                    <span>Seleccionar todos</span>
+                  </label>
+                </div>
+                <p className="text-xs text-gray-500 dark:text-gray-400 mb-2">
+                  Destildá los pedidos que no quieras incluir en la impresión.
+                </p>
+                <div className="border rounded-lg max-h-56 overflow-y-auto dark:border-gray-600">
+                  {recorridoSeleccionado.paradas.map((pedido, idx) => (
+                    <div
+                      key={pedido.id}
+                      onClick={() => handleTogglePedido(pedido.id)}
+                      className={`flex items-center p-3 border-b last:border-b-0 cursor-pointer transition-colors dark:border-gray-700 ${
+                        pedidosSeleccionados.includes(pedido.id)
+                          ? 'bg-blue-50 dark:bg-blue-900/20'
+                          : 'hover:bg-gray-50 dark:hover:bg-gray-700/40'
+                      }`}
+                    >
+                      <input
+                        type="checkbox"
+                        checked={pedidosSeleccionados.includes(pedido.id)}
+                        onChange={() => {}}
+                        className="w-4 h-4 mr-3"
+                      />
+                      <div className="flex-1 min-w-0">
+                        <p className="font-medium truncate dark:text-white">
+                          {idx + 1}. #{pedido.id} - {pedido.cliente?.nombre_fantasia}
+                        </p>
+                        <p className="text-sm text-gray-500 dark:text-gray-400 truncate">{pedido.cliente?.direccion}</p>
+                        <p className="text-sm font-medium text-blue-600">{formatPrecio(pedido.total)}</p>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            )}
           </>
         )}
 
@@ -384,8 +464,8 @@ const ModalExportarPDF = memo(function ModalExportarPDF({
       <div className="flex justify-between items-center p-4 border-t bg-gray-50 dark:bg-gray-800 sticky bottom-0">
         <p className="text-sm text-gray-600">
           {usaRecorrido
-            ? (recorridoSeleccionado && (
-                <>Total: {formatPrecio(recorridoSeleccionado.paradas.reduce((sum, p) => sum + (p.total || 0), 0))}</>
+            ? (recorridoSeleccionado && pedidosSeleccionados.length > 0 && (
+                <>Total: {formatPrecio(recorridoSeleccionado.paradas.filter(p => pedidosSeleccionados.includes(p.id)).reduce((sum, p) => sum + (p.total || 0), 0))}</>
               ))
             : (pedidosSeleccionados.length > 0 && (
                 <>
@@ -404,7 +484,7 @@ const ModalExportarPDF = memo(function ModalExportarPDF({
           <button
             onClick={handleExportar}
             disabled={usaRecorrido
-              ? !recorridoSeleccionado || recorridoSeleccionado.paradas.length === 0
+              ? !recorridoSeleccionado || pedidosSeleccionados.length === 0 || recargandoRecorridos
               : pedidosSeleccionados.length === 0}
             className={`flex items-center space-x-2 px-4 py-2 text-white rounded-lg disabled:opacity-50 disabled:cursor-not-allowed ${
               tipoExport === 'comanda'

--- a/src/hooks/queries/useRecorridosHojaRutaQuery.ts
+++ b/src/hooks/queries/useRecorridosHojaRutaQuery.ts
@@ -91,6 +91,10 @@ export function useRecorridosHojaRutaQuery(fecha: string | null | undefined) {
     queryKey: recorridosHojaRutaKeys.all(currentSucursalId, fecha ?? null),
     queryFn: () => fetchRecorridosHojaRuta(currentSucursalId, fecha as string),
     enabled: !!fecha,
-    staleTime: 30 * 1000,
+    // La exportacion debe reflejar SIEMPRE el ultimo precio/estado del pedido:
+    // sin ventana de frescura y con refetch al abrir el modal, ademas de la
+    // invalidacion de ['recorridos-hoja-ruta'] al editar items del pedido.
+    staleTime: 0,
+    refetchOnMount: 'always',
   })
 }

--- a/src/utils/calculations.parsePrecio.test.ts
+++ b/src/utils/calculations.parsePrecio.test.ts
@@ -26,6 +26,10 @@ describe('parsePrecio', () => {
   it('acepta comas como separador decimal (es-AR)', () => {
     expect(parsePrecio('10,5')).toBe(10.5)
     expect(parsePrecio('1.234,56')).toBe(1234.56)
+    // Caso del bug de edición de precio en mobile: el teclado es-AR tipea coma
+    // ("0,1" para un regalo). Con type="text"+inputMode="decimal" el valor llega
+    // a parsePrecio y se convierte (antes el type="number" lo descartaba).
+    expect(parsePrecio('0,1')).toBe(0.1)
   })
 
   it('trimea whitespace en strings', () => {


### PR DESCRIPTION
Tres correcciones reportadas sobre el flujo de pedidos / reparto.

## 1. Editar el precio de un pedido no funcionaba en el celular
**Causa:** el input de precio en `ModalEditarPedido` era el único de la app con `type="number"`. En el teclado del celular en es-AR el separador decimal es **coma**, y `<input type="number">` la descarta (el valor queda vacío), así que el precio nunca se cambiaba. En la compu funcionaba porque se tipea con punto.
**Fix:** se pasa a `type="text"` + `inputMode="decimal"` (como el resto de los inputs monetarios; `parsePrecio` ya normaliza la coma) y se agrega un botón **✓** para confirmar sin depender del `onBlur` (poco confiable en touch).

## 2. El cambio de precio no se reflejaba en hoja de ruta / comanda
**Verificado en producción:** el pedido **#2817 (Florida 608)** ya tenía `precio_unitario = 0.10` y `total = 8400.10` bien persistidos — no se perdía el dato. Era un problema de **caché**: al editar items solo se invalidaba `['pedidos']`, pero la hoja de ruta y las comandas se descargan desde `['recorridos-hoja-ruta']` (otra caché, join en vivo), así que re-descargabas las paradas con el precio viejo.
**Fix:** al guardar la edición se invalida toda la familia `recorridos*` (como ya hacía "armar ruta"), y la query de exportación queda con `staleTime: 0` + `refetchOnMount: 'always'`. El botón de exportar se deshabilita mientras refresca para no generar un PDF con datos en vuelo.

## 3. Poder destildar pedidos en el modal de exportaciones
Para **Hoja de Ruta** y **Comandas** se agrega, debajo de día + transportista, la lista de paradas con checkboxes (todo tildado por defecto, igual que antes). Destildar un pedido lo excluye del PDF y del total. Reusa el patrón de selección que ya tenía "Orden de Preparación".

## Archivos
- `src/components/modals/ModalEditarPedido.tsx` — input de precio mobile + botón ✓
- `src/components/containers/PedidosContainer.tsx` — invalidación de `recorridos*` al editar
- `src/hooks/queries/useRecorridosHojaRutaQuery.ts` — frescura de la exportación
- `src/components/modals/ModalExportarPDF.tsx` — checkboxes para excluir paradas
- `src/utils/calculations.parsePrecio.test.ts` — caso del bug (`parsePrecio('0,1') === 0.1`)

## Verificación
- `typecheck` y `eslint` limpios en los archivos tocados; **33/33** tests verdes (más el pre-commit que corre `vitest run` completo).
- Pendiente prueba manual end-to-end: editar precio con coma en celular y re-descargar hoja de ruta + comanda de una ruta armada.

🤖 Generated with [Claude Code](https://claude.com/claude-code)