### PR TITLE
feat(ui): cantidad editable en pedidos y arreglo del "0 adelante" en modales

### DIFF
--- a/src/components/modals/ModalCambioProducto.tsx
+++ b/src/components/modals/ModalCambioProducto.tsx
@@ -3,6 +3,7 @@ import { X, ArrowLeftRight, ArrowDown, ArrowUp, FileText, Search, Package, Alert
 import { useZodValidation } from '../../hooks/useZodValidation'
 import { modalCambioProductoSchema } from '../../lib/schemas'
 import { formatPrecio } from '../../utils/formatters'
+import NumberInput from '../ui/NumberInput'
 import type { ClienteDB, ProductoDB } from '../../types'
 
 export interface CambioProductoSaveData {
@@ -283,13 +284,13 @@ export default function ModalCambioProducto({
                     Precio: {formatPrecio(productoDevuelto.precio)} · Stock actual: {productoDevuelto.stock}
                   </p>
                 </div>
-                <input
-                  type="number"
-                  inputMode="numeric"
-                  min="1"
-                  step="1"
-                  value={cantidadDevuelta}
-                  onChange={(e: ChangeEvent<HTMLInputElement>) => setCantidadDevuelta(e.target.value)}
+                <NumberInput
+                  integer
+                  min={1}
+                  emptyValue={1}
+                  commitOnChange
+                  value={Number(cantidadDevuelta) || 0}
+                  onChange={(n) => setCantidadDevuelta(n)}
                   className="w-20 px-2 py-1 border dark:border-gray-600 rounded text-right dark:bg-gray-700 dark:text-white"
                   aria-label="Cantidad devuelta"
                 />
@@ -343,14 +344,14 @@ export default function ModalCambioProducto({
                     Precio: {formatPrecio(productoEntregado.precio)} · Stock actual: {productoEntregado.stock}
                   </p>
                 </div>
-                <input
-                  type="number"
-                  inputMode="numeric"
-                  min="1"
-                  step="1"
+                <NumberInput
+                  integer
+                  min={1}
                   max={productoEntregado.stock}
-                  value={cantidadEntregada}
-                  onChange={(e: ChangeEvent<HTMLInputElement>) => setCantidadEntregada(e.target.value)}
+                  emptyValue={1}
+                  commitOnChange
+                  value={Number(cantidadEntregada) || 0}
+                  onChange={(n) => setCantidadEntregada(n)}
                   className="w-20 px-2 py-1 border dark:border-gray-600 rounded text-right dark:bg-gray-700 dark:text-white"
                   aria-label="Cantidad entregada"
                 />

--- a/src/components/modals/ModalCerrarRendicion.tsx
+++ b/src/components/modals/ModalCerrarRendicion.tsx
@@ -12,6 +12,7 @@
 import { useState, memo, useMemo } from 'react'
 import { Loader2, Plus, Trash2, CheckCircle2, AlertTriangle, FileText } from 'lucide-react'
 import ModalBase from './ModalBase'
+import NumberInput from '../ui/NumberInput'
 import { formatPrecio } from '../../utils/formatters'
 import type { RendicionGastoInput } from '../../types'
 
@@ -233,13 +234,12 @@ const ModalCerrarRendicion = memo(function ModalCerrarRendicion({
                     placeholder="Descripción (ej: combustible)"
                     className="flex-1 px-3 py-2 text-sm border rounded-lg dark:bg-gray-700 dark:border-gray-600 dark:text-white"
                   />
-                  <input
-                    type="number"
-                    inputMode="decimal"
-                    step="0.01"
-                    min="0"
-                    value={g.monto}
-                    onChange={e => updateGasto(idx, 'monto', e.target.value)}
+                  <NumberInput
+                    min={0}
+                    emptyValue={0}
+                    commitOnChange
+                    value={Number(g.monto) || 0}
+                    onChange={(n) => updateGasto(idx, 'monto', String(n))}
                     placeholder="0.00"
                     className="w-28 px-3 py-2 text-sm border rounded-lg dark:bg-gray-700 dark:border-gray-600 dark:text-white"
                   />

--- a/src/components/modals/ModalCliente.tsx
+++ b/src/components/modals/ModalCliente.tsx
@@ -1,6 +1,7 @@
 import { useState, memo, useRef, useMemo } from 'react';
 import { Loader2, MapPin, CreditCard, Clock, Tag, FileText, Users, LocateFixed, AlertCircle, Percent, Plus, Trash2 } from 'lucide-react';
 import ModalBase from './ModalBase';
+import NumberInput from '../ui/NumberInput';
 import { AddressAutocomplete } from '../AddressAutocomplete';
 import { useZodValidation } from '../../hooks/useZodValidation';
 import { modalClienteSchema } from '../../lib/schemas';
@@ -904,13 +905,12 @@ const ModalCliente = memo(function ModalCliente({ cliente, onSave, onClose, guar
             <div className="grid grid-cols-2 gap-4">
               <div>
                 <label className="block text-sm font-medium mb-1 dark:text-gray-200">Límite de Crédito ($)</label>
-                <input
-                  type="number"
-                  inputMode="decimal"
-                  min="0"
-                  step="100"
-                  value={form.limiteCredito}
-                  onChange={e => handleFieldChange('limiteCredito', e.target.value)}
+                <NumberInput
+                  min={0}
+                  emptyValue={0}
+                  commitOnChange
+                  value={Number(form.limiteCredito) || 0}
+                  onChange={(n) => handleFieldChange('limiteCredito', n)}
                   className="w-full px-3 py-2 border rounded-lg dark:bg-gray-700 dark:border-gray-600 dark:text-white"
                   placeholder="0"
                 />
@@ -918,14 +918,14 @@ const ModalCliente = memo(function ModalCliente({ cliente, onSave, onClose, guar
               </div>
               <div>
                 <label className="block text-sm font-medium mb-1 dark:text-gray-200">Días de Crédito</label>
-                <input
-                  type="number"
-                  inputMode="numeric"
-                  step="1"
-                  min="0"
-                  max="365"
-                  value={form.diasCredito}
-                  onChange={e => handleFieldChange('diasCredito', e.target.value)}
+                <NumberInput
+                  integer
+                  min={0}
+                  max={365}
+                  emptyValue={0}
+                  commitOnChange
+                  value={Number(form.diasCredito) || 0}
+                  onChange={(n) => handleFieldChange('diasCredito', n)}
                   className="w-full px-3 py-2 border rounded-lg dark:bg-gray-700 dark:border-gray-600 dark:text-white"
                   placeholder="30"
                 />
@@ -933,14 +933,13 @@ const ModalCliente = memo(function ModalCliente({ cliente, onSave, onClose, guar
               </div>
               <div>
                 <label className="block text-sm font-medium mb-1 dark:text-gray-200">Descuento (%)</label>
-                <input
-                  type="number"
-                  inputMode="decimal"
-                  step="0.5"
-                  min="0"
-                  max="100"
-                  value={form.descuentoPorcentaje}
-                  onChange={e => handleFieldChange('descuentoPorcentaje', e.target.value)}
+                <NumberInput
+                  min={0}
+                  max={100}
+                  emptyValue={0}
+                  commitOnChange
+                  value={Number(form.descuentoPorcentaje) || 0}
+                  onChange={(n) => handleFieldChange('descuentoPorcentaje', n)}
                   className="w-full px-3 py-2 border rounded-lg dark:bg-gray-700 dark:border-gray-600 dark:text-white"
                   placeholder="0"
                 />
@@ -975,14 +974,14 @@ const ModalCliente = memo(function ModalCliente({ cliente, onSave, onClose, guar
                         className="flex-1 px-3 py-2 border rounded-lg dark:bg-gray-700 dark:border-gray-600 dark:text-white text-sm"
                       />
                       <div className="relative w-24">
-                        <input
-                          type="number"
-                          inputMode="numeric"
-                          min="0"
-                          max="100"
-                          step="1"
-                          value={row.porcentaje}
-                          onChange={e => actualizarDescuentoCategoria(index, 'porcentaje', e.target.value)}
+                        <NumberInput
+                          integer
+                          min={0}
+                          max={100}
+                          emptyValue={0}
+                          commitOnChange
+                          value={Number(row.porcentaje) || 0}
+                          onChange={(n) => actualizarDescuentoCategoria(index, 'porcentaje', String(n))}
                           className="w-full px-3 py-2 pr-7 border rounded-lg dark:bg-gray-700 dark:border-gray-600 dark:text-white text-sm"
                         />
                         <span className="absolute right-2 top-1/2 -translate-y-1/2 text-xs text-gray-400">%</span>

--- a/src/components/modals/ModalCompra.tsx
+++ b/src/components/modals/ModalCompra.tsx
@@ -8,7 +8,7 @@ import React, { useReducer, useMemo, useCallback, useState, useEffect, useRef, l
 import type { ChangeEvent, FormEvent } from 'react'
 import { X, ShoppingCart, Plus, Trash2, Package, Building2, FileText, Calculator, Search, Loader2, Camera, CheckCircle, AlertTriangle } from 'lucide-react'
 import { formatPrecio, fechaLocalISO } from '../../utils/formatters'
-import { parsePrecio } from '../../utils/calculations'
+import NumberInput from '../ui/NumberInput'
 import { supabase } from '../../lib/supabase'
 import { CompactErrorBoundary } from '../ErrorBoundary'
 import type { ProductoDB, ProveedorDBExtended, CompraFormInputExtended, ProveedorFormInputExtended } from '../../types'
@@ -1178,13 +1178,12 @@ function ProductosSection({ state, dispatch, productosFiltrados, onAgregarItem, 
             </div>
             <div>
               <label className="block text-xs text-gray-500 mb-1">Costo neto</label>
-              <input
-                type="number"
-                inputMode="decimal"
-                min="0"
-                step="0.01"
-                value={itemRapido.costo || ''}
-                onChange={(e: ChangeEvent<HTMLInputElement>) => setItemRapido(prev => ({ ...prev, costo: parsePrecio(e.target.value) }))}
+              <NumberInput
+                min={0}
+                emptyValue={0}
+                value={itemRapido.costo || 0}
+                onChange={(n) => setItemRapido(prev => ({ ...prev, costo: n }))}
+                commitOnChange
                 placeholder="0.00"
                 className="w-full px-3 py-1.5 text-sm border dark:border-gray-600 rounded focus:ring-2 focus:ring-blue-500 dark:bg-gray-700 dark:text-white"
               />
@@ -1266,38 +1265,36 @@ function ItemRow({ item, index, onActualizarItem, onEliminarItem }: ItemRowProps
         <div className="grid grid-cols-4 gap-2">
           <div>
             <label className="block text-xs text-gray-500 mb-1">Cant.</label>
-            <input
-              type="number"
-              inputMode="numeric"
-              step="1"
-              min="1"
+            <NumberInput
+              integer
+              min={1}
+              emptyValue={1}
               value={item.cantidad}
-              onChange={(e: ChangeEvent<HTMLInputElement>) => onActualizarItem(index, 'cantidad', parseInt(e.target.value) || 0)}
+              onChange={(n) => onActualizarItem(index, 'cantidad', n)}
+              commitOnChange
               className="w-full px-2 py-1 text-center border dark:border-gray-600 rounded focus:ring-2 focus:ring-green-500 dark:bg-gray-700 dark:text-white text-sm"
             />
           </div>
           <div>
             <label className="block text-xs text-gray-500 mb-1">Bonif.%</label>
-            <input
-              type="number"
-              inputMode="decimal"
-              min="0"
-              max="100"
-              step="0.01"
+            <NumberInput
+              min={0}
+              max={100}
+              emptyValue={0}
               value={item.bonificacion}
-              onChange={(e: ChangeEvent<HTMLInputElement>) => onActualizarItem(index, 'bonificacion', parseFloat(e.target.value) || 0)}
+              onChange={(n) => onActualizarItem(index, 'bonificacion', n)}
+              commitOnChange
               className="w-full px-2 py-1 text-center border dark:border-gray-600 rounded focus:ring-2 focus:ring-green-500 dark:bg-gray-700 dark:text-white text-sm"
             />
           </div>
           <div>
             <label className="block text-xs text-gray-500 mb-1">Neto</label>
-            <input
-              type="number"
-              inputMode="decimal"
-              min="0"
-              step="0.01"
+            <NumberInput
+              min={0}
+              emptyValue={0}
               value={item.costoUnitario}
-              onChange={(e: ChangeEvent<HTMLInputElement>) => onActualizarItem(index, 'costoUnitario', parsePrecio(e.target.value))}
+              onChange={(n) => onActualizarItem(index, 'costoUnitario', n)}
+              commitOnChange
               className="w-full px-2 py-1 text-center border dark:border-gray-600 rounded focus:ring-2 focus:ring-green-500 dark:bg-gray-700 dark:text-white text-sm"
             />
           </div>
@@ -1327,36 +1324,34 @@ function ItemRow({ item, index, onActualizarItem, onEliminarItem }: ItemRowProps
           <p className="text-xs text-gray-500">Stock: {item.stockActual} | IVA: {item.porcentajeIva}%</p>
         </div>
         <div className="col-span-2">
-          <input
-            type="number"
-            inputMode="numeric"
-            step="1"
-            min="1"
+          <NumberInput
+            integer
+            min={1}
+            emptyValue={1}
             value={item.cantidad}
-            onChange={(e: ChangeEvent<HTMLInputElement>) => onActualizarItem(index, 'cantidad', parseInt(e.target.value) || 0)}
+            onChange={(n) => onActualizarItem(index, 'cantidad', n)}
+            commitOnChange
             className="w-full px-2 py-1 text-center border dark:border-gray-600 rounded focus:ring-2 focus:ring-green-500 dark:bg-gray-700 dark:text-white text-sm"
           />
         </div>
         <div className="col-span-1">
-          <input
-            type="number"
-            inputMode="decimal"
-            min="0"
-            max="100"
-            step="0.01"
+          <NumberInput
+            min={0}
+            max={100}
+            emptyValue={0}
             value={item.bonificacion}
-            onChange={(e: ChangeEvent<HTMLInputElement>) => onActualizarItem(index, 'bonificacion', parseFloat(e.target.value) || 0)}
+            onChange={(n) => onActualizarItem(index, 'bonificacion', n)}
+            commitOnChange
             className="w-full px-2 py-1 text-center border dark:border-gray-600 rounded focus:ring-2 focus:ring-green-500 dark:bg-gray-700 dark:text-white text-sm"
           />
         </div>
         <div className="col-span-2">
-          <input
-            type="number"
-            inputMode="decimal"
-            min="0"
-            step="0.01"
+          <NumberInput
+            min={0}
+            emptyValue={0}
             value={item.costoUnitario}
-            onChange={(e: ChangeEvent<HTMLInputElement>) => onActualizarItem(index, 'costoUnitario', parsePrecio(e.target.value))}
+            onChange={(n) => onActualizarItem(index, 'costoUnitario', n)}
+            commitOnChange
             className="w-full px-2 py-1 text-center border dark:border-gray-600 rounded focus:ring-2 focus:ring-green-500 dark:bg-gray-700 dark:text-white text-sm"
           />
         </div>
@@ -1721,13 +1716,12 @@ function ItemPendienteRow({
           </div>
           <div>
             <label className="block text-xs text-gray-500 mb-0.5">Costo sin IVA</label>
-            <input
-              type="number"
-              inputMode="decimal"
-              step="0.01"
-              min="0"
+            <NumberInput
+              min={0}
+              emptyValue={0}
               value={costoNuevo}
-              onChange={(e) => setCostoNuevo(parsePrecio(e.target.value))}
+              onChange={(n) => setCostoNuevo(n)}
+              commitOnChange
               className="w-full px-2 py-1.5 text-sm border dark:border-gray-600 rounded focus:ring-2 focus:ring-green-500 dark:bg-gray-700 dark:text-white"
             />
           </div>

--- a/src/components/modals/ModalCrearMovimiento.tsx
+++ b/src/components/modals/ModalCrearMovimiento.tsx
@@ -5,6 +5,7 @@
 import { memo, useMemo, useState } from 'react'
 import { Loader2, Search, Plus, Trash2, Building2 } from 'lucide-react'
 import ModalBase from './ModalBase'
+import NumberInput from '../ui/NumberInput'
 import type { ProductoDB, SucursalDB } from '../../types'
 
 interface LineaItem {
@@ -117,9 +118,13 @@ const ModalCrearMovimiento = memo(function ModalCrearMovimiento({
                   <p className="text-sm font-medium dark:text-white truncate">{l.nombre}</p>
                   <p className="text-xs text-gray-400">stock disponible: {l.stock}</p>
                 </div>
-                <input
-                  type="number" min="1" inputMode="numeric" value={l.cantidad}
-                  onChange={e => setCantidad(l.productoId, Math.max(0, parseInt(e.target.value) || 0))}
+                <NumberInput
+                  integer
+                  min={0}
+                  emptyValue={0}
+                  commitOnChange
+                  value={l.cantidad}
+                  onChange={(n) => setCantidad(l.productoId, n)}
                   className="w-20 px-2 py-1 text-sm border rounded dark:bg-gray-700 dark:border-gray-600 dark:text-white"
                 />
                 <button type="button" onClick={() => quitar(l.productoId)} className="p-1 text-red-500 hover:bg-red-50 dark:hover:bg-red-900/20 rounded">

--- a/src/components/modals/ModalEditarCompra.tsx
+++ b/src/components/modals/ModalEditarCompra.tsx
@@ -19,6 +19,7 @@
 import { useState, memo, useMemo } from 'react'
 import { Loader2, Trash2, AlertCircle } from 'lucide-react'
 import ModalBase from './ModalBase'
+import NumberInput from '../ui/NumberInput'
 import { formatPrecio } from '../../utils/formatters'
 import type { CompraDBExtended } from '../../types'
 import type { ActualizarCompraItemsInput } from '../../hooks/queries'
@@ -41,11 +42,6 @@ export interface ModalEditarCompraProps {
   onGuardar: (input: ActualizarCompraItemsInput) => Promise<void>
   onClose: () => void
   guardando: boolean
-}
-
-function toNumber(raw: string, fallback = 0): number {
-  const n = parseFloat(raw.replace(',', '.'))
-  return Number.isFinite(n) ? n : fallback
 }
 
 const ModalEditarCompra = memo(function ModalEditarCompra({
@@ -223,48 +219,49 @@ const ModalEditarCompra = memo(function ModalEditarCompra({
                   <tr key={it.productoId} className={`border-b dark:border-gray-700 ${rowClass}`}>
                     <td className="py-2 pr-2 dark:text-gray-200">{it.nombre}</td>
                     <td className="py-2 px-2">
-                      <input
-                        type="number"
+                      <NumberInput
+                        integer
                         min={1}
-                        step={1}
+                        emptyValue={1}
                         value={it.cantidad}
-                        onChange={(e) => updateItem(it.productoId, 'cantidad', toNumber(e.target.value))}
+                        onChange={(n) => updateItem(it.productoId, 'cantidad', n)}
+                        commitOnChange
                         disabled={it.marcadoParaEliminar}
                         className="w-full px-2 py-1 text-right border rounded dark:bg-gray-700 dark:border-gray-600 dark:text-white disabled:opacity-50"
                       />
                     </td>
                     <td className="py-2 px-2">
-                      <input
-                        type="number"
+                      <NumberInput
                         min={0}
-                        step={0.01}
+                        emptyValue={0}
                         value={it.costoUnitario}
-                        onChange={(e) => updateItem(it.productoId, 'costoUnitario', toNumber(e.target.value))}
+                        onChange={(n) => updateItem(it.productoId, 'costoUnitario', n)}
+                        commitOnChange
                         disabled={it.marcadoParaEliminar}
                         className="w-full px-2 py-1 text-right border rounded dark:bg-gray-700 dark:border-gray-600 dark:text-white disabled:opacity-50"
                       />
                     </td>
                     <td className="py-2 px-2">
-                      <input
-                        type="number"
+                      <NumberInput
                         min={0}
                         max={99.99}
-                        step={0.01}
+                        emptyValue={0}
                         value={it.bonificacion}
-                        onChange={(e) => updateItem(it.productoId, 'bonificacion', toNumber(e.target.value))}
+                        onChange={(n) => updateItem(it.productoId, 'bonificacion', n)}
+                        commitOnChange
                         disabled={it.marcadoParaEliminar}
                         className="w-full px-2 py-1 text-right border rounded dark:bg-gray-700 dark:border-gray-600 dark:text-white disabled:opacity-50"
                       />
                     </td>
                     {!esZZ && (
                       <td className="py-2 px-2">
-                        <input
-                          type="number"
+                        <NumberInput
                           min={0}
                           max={100}
-                          step={0.01}
+                          emptyValue={0}
                           value={it.porcentajeIva}
-                          onChange={(e) => updateItem(it.productoId, 'porcentajeIva', toNumber(e.target.value))}
+                          onChange={(n) => updateItem(it.productoId, 'porcentajeIva', n)}
+                          commitOnChange
                           disabled={it.marcadoParaEliminar}
                           className="w-full px-2 py-1 text-right border rounded dark:bg-gray-700 dark:border-gray-600 dark:text-white disabled:opacity-50"
                         />

--- a/src/components/modals/ModalEditarPedido.tsx
+++ b/src/components/modals/ModalEditarPedido.tsx
@@ -2,6 +2,7 @@ import { lazy, Suspense, useState, memo, useEffect, useMemo } from 'react';
 import { Loader2, AlertCircle, Package, Plus, Minus, Trash2, Search, X, ShoppingCart, Pencil, Gift, RefreshCw, UserCheck, Check } from 'lucide-react';
 import ModalBase from './ModalBase';
 import ModalConfirmacion, { type ModalConfirmacionConfig } from './ModalConfirmacion';
+import NumberInput from '../ui/NumberInput';
 import { formatPrecio } from '../../utils/formatters';
 import { useZodValidation } from '../../hooks/useZodValidation';
 import { modalEditarPedidoSchema } from '../../lib/schemas';
@@ -349,6 +350,27 @@ const ModalEditarPedido = memo(function ModalEditarPedido({
         return { ...item, cantidad: nuevaCantidad };
       }
       return item;
+    }));
+  };
+
+  // Setea la cantidad a un valor absoluto (para el input editable), con la
+  // misma validación de MOQ/stock que handleCantidadChange pero clampeando al
+  // máximo disponible en vez de rechazar.
+  const handleCantidadSet = (productoId: string, value: number): void => {
+    setErrorStock(null);
+    setItems(prev => prev.map(item => {
+      if (item.productoId !== productoId) return item;
+      const moq = moqMap.get(String(productoId));
+      const minCantidad = moq && moq > 1 ? moq : 1;
+      const producto = productos.find(p => p.id === productoId);
+      const cantidadOriginal = itemsOriginales.find(o => o.productoId === productoId)?.cantidad || 0;
+      const stockDisponible = (producto?.stock || 0) + cantidadOriginal;
+      let nueva = Math.max(minCantidad, Math.round(value));
+      if (nueva > stockDisponible) {
+        setErrorStock(`Stock insuficiente para "${item.nombre}". Disponible: ${stockDisponible}`);
+        nueva = stockDisponible;
+      }
+      return { ...item, cantidad: nueva };
     }));
   };
 
@@ -719,9 +741,16 @@ const ModalEditarPedido = memo(function ModalEditarPedido({
                           >
                             <Minus className="w-4 h-4" />
                           </button>
-                          <span className="px-3 py-1 min-w-[40px] text-center font-medium dark:text-white">
-                            {item.cantidad}
-                          </span>
+                          <NumberInput
+                            integer
+                            min={moqMap.get(String(item.productoId)) || 1}
+                            max={stockDisponible}
+                            emptyValue={moqMap.get(String(item.productoId)) || 1}
+                            value={item.cantidad}
+                            onChange={(n) => handleCantidadSet(item.productoId, n)}
+                            aria-label="Cantidad"
+                            className="w-12 px-1 py-1 text-center font-medium dark:text-white bg-transparent focus:outline-none"
+                          />
                           <button
                             onClick={() => handleCantidadChange(item.productoId, 1)}
                             disabled={item.cantidad >= stockDisponible}

--- a/src/components/modals/ModalEntregaConSalvedad.tsx
+++ b/src/components/modals/ModalEntregaConSalvedad.tsx
@@ -6,6 +6,7 @@
 import React, { useState, useCallback } from 'react'
 import { X, AlertTriangle, Package, Check, ChevronDown, ChevronUp, Truck, Gift } from 'lucide-react'
 import { MOTIVOS_SALVEDAD_LABELS } from '../../lib/schemas'
+import NumberInput from '../ui/NumberInput'
 import type { PedidoDB, PedidoItemDB, MotivoSalvedad, RegistrarSalvedadInput, RegistrarSalvedadResult } from '../../types'
 
 interface MotivoOption {
@@ -267,14 +268,14 @@ export default function ModalEntregaConSalvedad({
                             <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
                               Cantidad con problema
                             </label>
-                            <input
-                              type="number"
-                              inputMode="numeric"
-                              step="1"
-                              min="1"
+                            <NumberInput
+                              integer
+                              min={1}
                               max={itemSalv.item.cantidad}
+                              emptyValue={1}
+                              commitOnChange
                               value={itemSalv.cantidadAfectada}
-                              onChange={(e) => updateItemSalvedad(itemSalv.item.id, { cantidadAfectada: parseInt(e.target.value) || 0 })}
+                              onChange={(n) => updateItemSalvedad(itemSalv.item.id, { cantidadAfectada: n })}
                               onClick={(e) => e.stopPropagation()}
                               className="w-full px-3 py-2 border dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-amber-500 dark:bg-gray-700 dark:text-white"
                             />

--- a/src/components/modals/ModalMermaStock.tsx
+++ b/src/components/modals/ModalMermaStock.tsx
@@ -2,6 +2,7 @@ import React, { useState, FormEvent, ChangeEvent } from 'react'
 import { X, AlertTriangle, Package, Minus, FileText } from 'lucide-react'
 import { useZodValidation } from '../../hooks/useZodValidation'
 import { modalMermaSchema } from '../../lib/schemas'
+import NumberInput from '../ui/NumberInput'
 import type { Producto } from '../../types'
 
 type MotivoMermaValue = 'rotura' | 'vencimiento' | 'robo' | 'decomiso' | 'devolucion' | 'error_inventario' | 'muestra' | 'promociones' | 'otro';
@@ -154,14 +155,14 @@ export default function ModalMermaStock({
             <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
               Cantidad a dar de baja *
             </label>
-            <input
-              type="number"
-              inputMode="numeric"
-              step="1"
-              min="1"
+            <NumberInput
+              integer
+              min={1}
               max={producto.stock}
-              value={cantidad}
-              onChange={(e: ChangeEvent<HTMLInputElement>) => setCantidad(e.target.value)}
+              emptyValue={1}
+              commitOnChange
+              value={Number(cantidad) || 0}
+              onChange={(n) => setCantidad(n)}
               className="w-full px-4 py-2 border dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-red-500 dark:bg-gray-700 dark:text-white"
               required
             />

--- a/src/components/modals/ModalNotaCredito.tsx
+++ b/src/components/modals/ModalNotaCredito.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useMemo } from 'react'
 import { X, FileText, AlertTriangle } from 'lucide-react'
+import NumberInput from '../ui/NumberInput'
 import { formatPrecio } from '../../utils/formatters'
 import type { NotaCreditoDB, NotaCreditoFormInput } from '../../types'
 
@@ -203,14 +204,14 @@ export default function ModalNotaCredito({
                         </span>
                       </td>
                       <td className="px-4 py-3 text-center">
-                        <input
-                          type="number"
-                          inputMode="numeric"
-                          step="1"
+                        <NumberInput
+                          integer
                           min={0}
                           max={max}
+                          emptyValue={0}
+                          commitOnChange
                           value={cant}
-                          onChange={(e) => handleCantidadChange(item.producto_id, e.target.value)}
+                          onChange={(n) => handleCantidadChange(item.producto_id, String(n))}
                           disabled={max <= 0}
                           className="w-20 px-2 py-1 text-center border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 text-gray-800 dark:text-white disabled:opacity-50 disabled:cursor-not-allowed focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
                         />

--- a/src/components/modals/ModalPagoPedido.tsx
+++ b/src/components/modals/ModalPagoPedido.tsx
@@ -19,6 +19,7 @@
 import { memo, useEffect, useMemo, useState } from 'react'
 import { Loader2, DollarSign, Plus, Trash2, AlertCircle, X } from 'lucide-react'
 import ModalBase from './ModalBase'
+import NumberInput from '../ui/NumberInput'
 import { formatPrecio, fechaLocalISO, formatDateTime, getFormaPagoLabel } from '../../utils/formatters'
 import { parsePrecio } from '../../utils/calculations'
 import { FORMAS_PAGO_SELECCIONABLES } from '../../constants/formasPago'
@@ -322,13 +323,12 @@ const ModalPagoPedido = memo(function ModalPagoPedido({
                     </select>
                     <div className="relative flex-1">
                       <span className="absolute left-2 top-1/2 -translate-y-1/2 text-gray-400 text-sm">$</span>
-                      <input
-                        type="number"
-                        inputMode="decimal"
-                        step="0.01"
-                        min="0"
-                        value={linea.monto}
-                        onChange={e => handleLineaChange(index, { monto: e.target.value })}
+                      <NumberInput
+                        min={0}
+                        emptyValue={0}
+                        commitOnChange
+                        value={Number(linea.monto) || 0}
+                        onChange={(n) => handleLineaChange(index, { monto: String(n) })}
                         placeholder="0.00"
                         className="w-full pl-6 pr-2 py-2 text-sm border rounded-lg dark:bg-gray-700 dark:border-gray-600 dark:text-white font-semibold"
                       />

--- a/src/components/modals/ModalPedido.tsx
+++ b/src/components/modals/ModalPedido.tsx
@@ -9,6 +9,7 @@ import { useGeolocationCapture } from '../../hooks/useGeolocationCapture';
 import { usePreventistasAsignablesQuery } from '../../hooks/queries/useUsuariosQuery';
 import ModalBase from './ModalBase';
 import GeolocationGate from '../GeolocationGate';
+import NumberInput from '../ui/NumberInput';
 import type { ProductoDB, ClienteDB } from '../../types';
 
 /** Item en el pedido */
@@ -725,7 +726,16 @@ const ModalPedido = memo(function ModalPedido({
                               <div className="flex items-center gap-2 shrink-0 self-end sm:self-auto">
                                 <button onClick={(e) => { e.stopPropagation(); onActualizarCantidad(item.productoId, 0); }} className="p-1 text-red-500 hover:bg-red-50 dark:hover:bg-red-900/20 rounded" title="Eliminar producto"><Trash2 className="w-4 h-4" /></button>
                                 <button onClick={(e) => { e.stopPropagation(); onActualizarCantidad(item.productoId, Math.max(item.cantidad - 1, minCantidad)); }} className={`w-7 h-7 rounded-full text-sm ${item.cantidad <= minCantidad ? 'bg-gray-100 text-gray-400 dark:bg-gray-700' : 'bg-gray-200 hover:bg-gray-300 dark:bg-gray-600 dark:hover:bg-gray-500'}`} disabled={item.cantidad <= minCantidad}>-</button>
-                                <span className="w-6 text-center font-medium text-sm dark:text-white">{item.cantidad}</span>
+                                <NumberInput
+                                  integer
+                                  min={minCantidad}
+                                  emptyValue={minCantidad}
+                                  value={item.cantidad}
+                                  onChange={(n) => onActualizarCantidad(item.productoId, Math.max(n, minCantidad))}
+                                  onClick={(e) => e.stopPropagation()}
+                                  aria-label="Cantidad"
+                                  className="w-12 text-center font-medium text-sm border dark:border-gray-600 rounded px-1 py-0.5 dark:bg-gray-700 dark:text-white focus:outline-none focus:ring-1 focus:ring-blue-500"
+                                />
                                 <button onClick={(e) => { e.stopPropagation(); onActualizarCantidad(item.productoId, item.cantidad + 1); }} className="w-7 h-7 rounded-full text-sm bg-gray-200 hover:bg-gray-300 dark:bg-gray-600 dark:hover:bg-gray-500">+</button>
                                 <p className="w-20 text-right font-semibold text-sm dark:text-white">{formatPrecio(subtotal)}</p>
                               </div>

--- a/src/components/modals/ModalProducto.tsx
+++ b/src/components/modals/ModalProducto.tsx
@@ -2,6 +2,7 @@ import { useState, memo } from 'react';
 import type { ChangeEvent } from 'react';
 import { Loader2 } from 'lucide-react';
 import ModalBase from './ModalBase';
+import NumberInput from '../ui/NumberInput';
 import { useZodValidation } from '../../hooks/useZodValidation';
 import { modalProductoSchema } from '../../lib/schemas';
 import {
@@ -260,18 +261,14 @@ const ModalProducto = memo(function ModalProducto({ producto, categorias, provee
           </div>
           <div className="col-span-2 sm:col-span-1">
             <label className="block text-sm font-medium mb-1">Stock *</label>
-            <input
-              type="number"
-              inputMode="numeric"
-              step="1"
-              value={form.stock}
-              onChange={(e: ChangeEvent<HTMLInputElement>) => {
-                const val = e.target.value;
-                // Permitir campo vacío temporalmente mientras escribe, pero validar como número
-                handleFieldChange('stock', val === '' ? '' : (parseInt(val, 10) || 0));
-              }}
+            <NumberInput
+              integer
+              min={0}
+              emptyValue={0}
+              value={Number(form.stock) || 0}
+              onChange={(n) => handleFieldChange('stock', n)}
+              commitOnChange
               className={inputClass('stock')}
-              min="0"
             />
             {errores.stock && <p className="text-red-500 text-xs mt-1">{errores.stock}</p>}
           </div>
@@ -279,12 +276,13 @@ const ModalProducto = memo(function ModalProducto({ producto, categorias, provee
 
         <div>
           <label className="block text-sm font-medium mb-1">Stock Minimo de Seguridad</label>
-          <input
-            type="number"
-            inputMode="numeric"
-            step="1"
+          <NumberInput
+            integer
+            min={0}
+            emptyValue={0}
             value={form.stock_minimo !== undefined ? form.stock_minimo : 10}
-            onChange={(e: ChangeEvent<HTMLInputElement>) => handleFieldChange('stock_minimo', parseInt(e.target.value) || 0)}
+            onChange={(n) => handleFieldChange('stock_minimo', n)}
+            commitOnChange
             className={inputClass('stock_minimo')}
             placeholder="10"
           />
@@ -436,14 +434,13 @@ const ModalProducto = memo(function ModalProducto({ producto, categorias, provee
             </div>
             <div>
               <label className="block text-xs font-medium mb-1 text-gray-600">Imp. Internos (%)</label>
-              <input
-                type="number"
-                inputMode="decimal"
-                step="0.01"
-                min="0"
-                max="100"
-                value={form.impuestos_internos || ''}
-                onChange={(e: ChangeEvent<HTMLInputElement>) => handleImpuestosInternosChange(e.target.value)}
+              <NumberInput
+                min={0}
+                max={100}
+                emptyValue={0}
+                value={parsePrecio(form.impuestos_internos)}
+                onChange={(n) => handleImpuestosInternosChange(String(n))}
+                commitOnChange
                 className="w-full px-3 py-2 border rounded-lg text-sm"
                 placeholder="0"
               />
@@ -458,12 +455,12 @@ const ModalProducto = memo(function ModalProducto({ producto, categorias, provee
           <div className="grid grid-cols-2 gap-3">
             <div>
               <label className="block text-xs font-medium mb-1 text-gray-600">Costo Neto</label>
-              <input
-                type="number"
-                inputMode="decimal"
-                step="0.01"
-                value={form.costo_sin_iva || ''}
-                onChange={(e: ChangeEvent<HTMLInputElement>) => handleCostoSinIvaChange(e.target.value)}
+              <NumberInput
+                min={0}
+                emptyValue={0}
+                value={parsePrecio(form.costo_sin_iva)}
+                onChange={(n) => handleCostoSinIvaChange(String(n))}
+                commitOnChange
                 className="w-full px-3 py-2 border rounded-lg text-sm"
                 placeholder="0.00"
               />
@@ -492,12 +489,12 @@ const ModalProducto = memo(function ModalProducto({ producto, categorias, provee
           <div className="grid grid-cols-2 gap-4">
             <div>
               <label className="block text-xs font-medium mb-1 text-gray-600">Precio Final (con IVA + Imp.Int.) *</label>
-              <input
-                type="number"
-                inputMode="decimal"
-                step="0.01"
-                value={form.precio}
-                onChange={(e: ChangeEvent<HTMLInputElement>) => handlePrecioChange(e.target.value)}
+              <NumberInput
+                min={0}
+                emptyValue={0}
+                value={parsePrecio(form.precio)}
+                onChange={(n) => handlePrecioChange(String(n))}
+                commitOnChange
                 className={`w-full px-3 py-2 border rounded-lg font-semibold ${errores.precio ? 'border-red-500 bg-red-50' : ''}`}
                 placeholder="0.00"
               />
@@ -522,12 +519,11 @@ const ModalProducto = memo(function ModalProducto({ producto, categorias, provee
             <div>
               <label className="block text-xs font-medium mb-1 text-gray-600">Margen (%)</label>
               <div className="relative">
-                <input
-                  type="number"
-                  inputMode="decimal"
-                  step="0.1"
-                  value={margen}
-                  onChange={(e: ChangeEvent<HTMLInputElement>) => handleMargenChange(e.target.value)}
+                <NumberInput
+                  value={parsePrecio(margen)}
+                  emptyValue={0}
+                  onChange={(n) => handleMargenChange(String(n))}
+                  commitOnChange
                   disabled={parsePrecio(String(form.costo_con_iva)) <= 0}
                   className="w-full px-3 py-2 pr-7 border rounded-lg disabled:bg-gray-100 disabled:cursor-not-allowed"
                   placeholder="0.0"

--- a/src/components/modals/ModalRegistrarPago.tsx
+++ b/src/components/modals/ModalRegistrarPago.tsx
@@ -2,6 +2,7 @@ import React, { useState, FormEvent, ChangeEvent } from 'react'
 import { X, DollarSign, FileText, AlertCircle, Check, Plus, Trash2, Calendar } from 'lucide-react'
 import { formatPrecio as formatCurrency, fechaLocalISO } from '../../utils/formatters'
 import { parsePrecio } from '../../utils/calculations'
+import NumberInput from '../ui/NumberInput'
 import { useZodValidation } from '../../hooks/useZodValidation'
 import { modalPagoSchema } from '../../lib/schemas'
 import type { ClienteDB, Pedido, Pago, FormaPago, RegistrarPagoFifoInput, RegistrarPagoCombinadoFifoInput, RegistrarPagoFifoResult, PagoFifoAplicacion } from '../../types'
@@ -459,13 +460,12 @@ export default function ModalRegistrarPago({
                     <div className="flex-1">
                       <div className="relative">
                         <DollarSign className="absolute left-2 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400" />
-                        <input
-                          type="number"
-                          inputMode="decimal"
-                          step="0.01"
-                          min="0"
-                          value={pago.monto}
-                          onChange={e => handlePagoChange(index, 'monto', e.target.value)}
+                        <NumberInput
+                          min={0}
+                          emptyValue={0}
+                          commitOnChange
+                          value={Number(pago.monto) || 0}
+                          onChange={(n) => handlePagoChange(index, 'monto', String(n))}
                           placeholder="0.00"
                           className="w-full pl-7 pr-2 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 text-gray-900 dark:text-white text-sm font-semibold"
                         />
@@ -522,13 +522,12 @@ export default function ModalRegistrarPago({
                 </label>
                 <div className="relative">
                   <DollarSign className="absolute left-3 top-1/2 -translate-y-1/2 w-5 h-5 text-gray-400" />
-                  <input
-                    type="number"
-                    inputMode="decimal"
-                    step="0.01"
-                    min="0"
-                    value={monto}
-                    onChange={(e: ChangeEvent<HTMLInputElement>) => setMonto(e.target.value)}
+                  <NumberInput
+                    min={0}
+                    emptyValue={0}
+                    commitOnChange
+                    value={Number(monto) || 0}
+                    onChange={(n) => setMonto(String(n))}
                     placeholder="0.00"
                     className="w-full pl-10 pr-4 py-3 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 text-gray-900 dark:text-white text-lg font-semibold"
                     required

--- a/src/components/modals/ModalSalvedadItem.tsx
+++ b/src/components/modals/ModalSalvedadItem.tsx
@@ -6,6 +6,7 @@ import React, { useState, FormEvent, ChangeEvent } from 'react'
 import { X, AlertTriangle, Package, FileText, AlertCircle, Gift, Minus, Plus } from 'lucide-react'
 import { MOTIVOS_SALVEDAD_LABELS } from '../../lib/schemas'
 import { useSimularSalvedadPromoImpactoQuery } from '../../hooks/queries'
+import NumberInput from '../ui/NumberInput'
 import type { PedidoItemDB, MotivoSalvedad, RegistrarSalvedadResult } from '../../types'
 
 interface MotivoOption {
@@ -213,14 +214,14 @@ export default function ModalSalvedadItem({
               >
                 <Minus className="w-6 h-6" />
               </button>
-              <input
-                type="number"
-                inputMode="numeric"
-                step="1"
-                min="1"
+              <NumberInput
+                integer
+                min={1}
                 max={item.cantidad}
-                value={cantidad}
-                onChange={(e: ChangeEvent<HTMLInputElement>) => setCantidad(e.target.value)}
+                emptyValue={1}
+                commitOnChange
+                value={Number(cantidad) || 0}
+                onChange={(n) => setCantidad(n)}
                 className="flex-1 h-14 text-center text-2xl font-bold border-2 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-amber-500 dark:bg-gray-700 dark:text-white"
                 required
               />

--- a/src/components/modals/ModalSustituirRegalo.tsx
+++ b/src/components/modals/ModalSustituirRegalo.tsx
@@ -21,6 +21,7 @@
 import { useMemo, useState, memo } from 'react'
 import { Loader2, Gift, AlertTriangle, ChevronDown, ChevronUp, Info } from 'lucide-react'
 import ModalBase from './ModalBase'
+import NumberInput from '../ui/NumberInput'
 import { useProductosQuery, usePromoAcumuladorQuery } from '../../hooks/queries'
 import { useSustituirRegaloMutation } from '../../hooks/queries/useSustituirRegaloMutation'
 import { useNotification } from '../../contexts/NotificationContext'
@@ -188,13 +189,12 @@ const ModalSustituirRegalo = memo(function ModalSustituirRegalo({
           <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
             Cantidad *
           </label>
-          <input
-            type="number"
-            inputMode="decimal"
-            step="0.01"
-            min="0"
-            value={cantidadNueva}
-            onChange={e => setCantidadNueva(e.target.value)}
+          <NumberInput
+            min={0}
+            emptyValue={0}
+            commitOnChange
+            value={Number(cantidadNueva) || 0}
+            onChange={(n) => setCantidadNueva(String(n))}
             className="w-full px-3 py-2 border rounded-lg dark:bg-gray-700 dark:border-gray-600 dark:text-white"
           />
           {productoNuevo && regaloMueveStock && !stockSuficiente && (

--- a/src/components/ui/NumberInput.test.tsx
+++ b/src/components/ui/NumberInput.test.tsx
@@ -1,0 +1,114 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import '@testing-library/jest-dom/vitest'
+import { NumberInput } from './NumberInput'
+
+describe('NumberInput', () => {
+  it('permite vaciar el campo y no fuerza 0 mientras se edita', async () => {
+    const user = userEvent.setup()
+    const onChange = vi.fn()
+    render(<NumberInput aria-label="num" integer value={5} onChange={onChange} />)
+    const input = screen.getByLabelText('num')
+
+    await user.clear(input)
+
+    expect(input).toHaveValue('')
+    // Por defecto recién confirma en blur: vaciar no dispara onChange todavía.
+    expect(onChange).not.toHaveBeenCalled()
+  })
+
+  it('no deja el cero adelante al escribir junto a un 0', async () => {
+    const user = userEvent.setup()
+    render(
+      <NumberInput aria-label="num" integer value={0} selectOnFocus={false} onChange={vi.fn()} />
+    )
+    const input = screen.getByLabelText('num')
+
+    await user.type(input, '5') // el DOM ve "05", se sanitiza a "5"
+
+    expect(input).toHaveValue('5')
+  })
+
+  it('ignora caracteres no numéricos en modo entero', async () => {
+    const user = userEvent.setup()
+    render(
+      <NumberInput aria-label="num" integer value={0} selectOnFocus={false} onChange={vi.fn()} />
+    )
+    const input = screen.getByLabelText('num')
+
+    await user.type(input, '1a2')
+
+    expect(input).toHaveValue('12')
+  })
+
+  it('confirma el mínimo (emptyValue) cuando queda vacío al salir', async () => {
+    const user = userEvent.setup()
+    const onChange = vi.fn()
+    render(<NumberInput aria-label="num" integer min={1} value={3} onChange={onChange} />)
+    const input = screen.getByLabelText('num')
+
+    await user.clear(input)
+    await user.tab() // blur
+
+    expect(onChange).toHaveBeenLastCalledWith(1)
+  })
+
+  it('clampa al máximo al confirmar', async () => {
+    const user = userEvent.setup()
+    const onChange = vi.fn()
+    render(<NumberInput aria-label="num" integer max={10} value={5} onChange={onChange} />)
+    const input = screen.getByLabelText('num')
+
+    await user.clear(input)
+    await user.type(input, '50')
+    await user.tab()
+
+    expect(onChange).toHaveBeenLastCalledWith(10)
+  })
+
+  it('parsea decimales con coma', async () => {
+    const user = userEvent.setup()
+    const onChange = vi.fn()
+    render(<NumberInput aria-label="num" value={0} onChange={onChange} />)
+    const input = screen.getByLabelText('num')
+
+    await user.clear(input)
+    await user.type(input, '12,5')
+    await user.tab()
+
+    expect(onChange).toHaveBeenLastCalledWith(12.5)
+  })
+
+  it('confirma con Enter', async () => {
+    const user = userEvent.setup()
+    const onChange = vi.fn()
+    render(<NumberInput aria-label="num" integer value={2} onChange={onChange} />)
+    const input = screen.getByLabelText('num')
+
+    await user.clear(input)
+    await user.type(input, '9{Enter}')
+
+    expect(onChange).toHaveBeenLastCalledWith(9)
+  })
+
+  it('con commitOnChange confirma en vivo', async () => {
+    const user = userEvent.setup()
+    const onChange = vi.fn()
+    render(
+      <NumberInput
+        aria-label="num"
+        integer
+        commitOnChange
+        value={0}
+        selectOnFocus={false}
+        onChange={onChange}
+      />
+    )
+    const input = screen.getByLabelText('num')
+
+    await user.type(input, '7')
+
+    expect(onChange).toHaveBeenCalledWith(7)
+  })
+})

--- a/src/components/ui/NumberInput.tsx
+++ b/src/components/ui/NumberInput.tsx
@@ -1,0 +1,162 @@
+/**
+ * NumberInput - Campo numérico controlado con mejor UX de edición.
+ *
+ * Reemplaza al patrón habitual `<input type="number"
+ * onChange={e => setX(parseInt(e.target.value) || 0)} />`, que tiene dos
+ * molestias:
+ *  - El campo NUNCA puede quedar vacío: al borrar el `0` vuelve a `0` al
+ *    instante, así que para reemplazarlo terminás tipeando delante/detrás y
+ *    queda "010", "0500", etc. (el "0 adelante").
+ *  - No se puede escribir un número de una; invita a usar los spinners.
+ *
+ * Mantiene un borrador (string) interno mientras el input está enfocado, de
+ * modo que el campo puede quedar vacío o parcial ("12,") mientras se edita.
+ * Al confirmar (blur / Enter) parsea, clampa a [min, max] y normaliza.
+ *
+ * Usa `type="text"` + `inputMode` a propósito: el `type="number"` es lo que
+ * impide controlar el string vacío y los ceros a la izquierda. Con `text`
+ * controlamos el valor y igual sale el teclado numérico en mobile.
+ */
+import {
+  useState,
+  useRef,
+  InputHTMLAttributes,
+  ChangeEvent,
+  FocusEvent,
+  KeyboardEvent,
+  ReactElement,
+} from 'react'
+import { parsePrecio } from '../../utils/calculations'
+
+type InheritedInputProps = Omit<
+  InputHTMLAttributes<HTMLInputElement>,
+  'value' | 'onChange' | 'type' | 'inputMode' | 'min' | 'max'
+>
+
+export interface NumberInputProps extends InheritedInputProps {
+  /** Valor numérico confirmado (lo que vive en el state del padre). */
+  value: number;
+  /** Se llama con el número confirmado (blur/Enter, o en vivo si commitOnChange). */
+  onChange: (value: number) => void;
+  /** Solo enteros (sin separador decimal). */
+  integer?: boolean;
+  /** Mínimo; se clampa al confirmar. */
+  min?: number;
+  /** Máximo; se clampa al confirmar. */
+  max?: number;
+  /** Qué número confirmar si el campo queda vacío. Default: `min ?? 0`. */
+  emptyValue?: number;
+  /** Si true, además confirma en vivo por cada tecla con un número válido. */
+  commitOnChange?: boolean;
+  /** Selecciona el contenido al enfocar (tipear reemplaza). Default true. */
+  selectOnFocus?: boolean;
+}
+
+export function NumberInput({
+  value,
+  onChange,
+  integer = false,
+  min,
+  max,
+  emptyValue,
+  commitOnChange = false,
+  selectOnFocus = true,
+  onFocus,
+  onBlur,
+  onKeyDown,
+  ...rest
+}: NumberInputProps): ReactElement {
+  // draft === null  -> mostrar el valor canónico del padre.
+  // draft === '...' -> el usuario está editando (puede ser '' o parcial).
+  const [draft, setDraft] = useState<string | null>(null)
+  const inputRef = useRef<HTMLInputElement>(null)
+
+  /** Limpia el string a un numérico tipeable (sin forzar a número todavía). */
+  const sanitize = (raw: string): string => {
+    if (integer) {
+      // Solo dígitos. Quitar ceros a la izquierda: "007" -> "7", "0" -> "0".
+      return raw.replace(/[^\d]/g, '').replace(/^0+(?=\d)/, '')
+    }
+    // Decimal: dígitos + un único separador ("," o ".").
+    let s = raw.replace(/[^\d.,]/g, '')
+    const sep = s.search(/[.,]/)
+    if (sep !== -1) {
+      s = s.slice(0, sep + 1) + s.slice(sep + 1).replace(/[.,]/g, '')
+    }
+    // Quitar ceros a la izquierda salvo el que precede al separador ("0,5").
+    return s.replace(/^0+(?=\d)/, '')
+  }
+
+  /** Parsea el borrador a número, o null si está vacío/inválido. */
+  const toNumber = (raw: string): number | null => {
+    const t = raw.trim()
+    if (t === '') return null
+    const n = integer ? parseInt(t, 10) : parsePrecio(t)
+    return Number.isFinite(n) ? n : null
+  }
+
+  const clamp = (n: number): number => {
+    let v = n
+    if (typeof min === 'number') v = Math.max(min, v)
+    if (typeof max === 'number') v = Math.min(max, v)
+    return integer ? Math.round(v) : v
+  }
+
+  const handleChange = (e: ChangeEvent<HTMLInputElement>): void => {
+    const next = sanitize(e.target.value)
+    setDraft(next)
+    if (commitOnChange) {
+      // En vivo mandamos el número crudo (como hacía el parseInt anterior);
+      // el clamp/normalización quedan para el blur. El vacío NO empuja 0:
+      // se mantiene el último valor y el campo se ve vacío.
+      const n = toNumber(next)
+      if (n !== null) onChange(n)
+    }
+  }
+
+  const commit = (): void => {
+    if (draft === null) return
+    const parsed = toNumber(draft)
+    const final = clamp(parsed ?? emptyValue ?? min ?? 0)
+    setDraft(null)
+    onChange(final)
+  }
+
+  const handleBlur = (e: FocusEvent<HTMLInputElement>): void => {
+    commit()
+    onBlur?.(e)
+  }
+
+  const handleFocus = (e: FocusEvent<HTMLInputElement>): void => {
+    if (selectOnFocus) e.target.select()
+    onFocus?.(e)
+  }
+
+  const handleKeyDown = (e: KeyboardEvent<HTMLInputElement>): void => {
+    if (e.key === 'Enter') {
+      commit()
+      inputRef.current?.blur()
+    }
+    onKeyDown?.(e)
+  }
+
+  const display = draft !== null
+    ? draft
+    : (Number.isFinite(value) ? String(value) : '')
+
+  return (
+    <input
+      {...rest}
+      ref={inputRef}
+      type="text"
+      inputMode={integer ? 'numeric' : 'decimal'}
+      value={display}
+      onChange={handleChange}
+      onFocus={handleFocus}
+      onBlur={handleBlur}
+      onKeyDown={handleKeyDown}
+    />
+  )
+}
+
+export default NumberInput

--- a/src/components/vistas/VistaComisiones.tsx
+++ b/src/components/vistas/VistaComisiones.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useMemo } from 'react';
 import { Percent, TrendingUp, Calendar } from 'lucide-react';
 import LoadingSpinner from '../layout/LoadingSpinner';
+import NumberInput from '../ui/NumberInput';
 import { formatPrecio, fechaLocalISO } from '../../utils/formatters';
 import type { ReportePreventista } from '../../types';
 
@@ -64,13 +65,13 @@ export default function VistaComisiones({
         <div className="flex items-center gap-2 bg-white dark:bg-gray-800 border dark:border-gray-700 rounded-lg px-3 py-2 shadow-sm">
           <Percent className="w-4 h-4 text-gray-500" />
           <label className="text-sm font-medium dark:text-gray-300">Comision:</label>
-          <input
-            type="number"
-            min="0"
-            max="100"
-            step="0.5"
+          <NumberInput
+            min={0}
+            max={100}
             value={porcentaje}
-            onChange={e => setPorcentaje(parseFloat(e.target.value) || 0)}
+            onChange={(n) => setPorcentaje(n)}
+            commitOnChange
+            emptyValue={0}
             className="w-16 px-2 py-1 border rounded text-center text-sm font-semibold dark:bg-gray-700 dark:border-gray-600 dark:text-white"
           />
           <span className="text-sm font-medium dark:text-gray-300">%</span>


### PR DESCRIPTION
## Qué resuelve

Dos molestias de UI con los campos numéricos:

1. **Cantidad de un pedido no editable.** Había que tocar `+` N veces. Ahora se puede **escribir el número directo**, manteniendo los `+`/`−`.
2. **El "0 adelante" en los modales.** Los `<input type="number">` con `parseInt(...) || 0` no dejaban borrar el `0` (volvía solo) y arrastraban ceros a la izquierda (`0123`).

Ambos son el mismo problema de fondo → se resuelven con un único componente reutilizable.

## Componente nuevo
`src/components/ui/NumberInput.tsx` (+ test con 8 casos): input controlado que mientras editás mantiene un **borrador de texto**, así el campo **puede quedar vacío** y **no arrastra el cero**. Al salir o con **Enter** confirma, clampa a `min`/`max` y normaliza. Soporta enteros y decimales (coma o punto, reusa `parsePrecio`). Usa `type="text"` + `inputMode` a propósito (el `type="number"` es justo lo que impedía controlar el string vacío).

## Cambios
- **Pedidos** (crear/editar): cantidad editable entera, con los `+`/`−` intactos. Respeta MOQ y stock disponible; vaciar no borra el ítem.
- **~50 campos** migrados a `NumberInput` en: Producto, Compra, Editar Compra, Cliente, Registrar Pago, Pago Pedido, Cerrar Rendición, Nota de Crédito, Merma Stock, Crear Movimiento, Entrega con Salvedad, Salvedad Item, Cambio Producto, Sustituir Regalo y Comisiones.

## Dejados nativos a propósito (no tienen el bug y se romperían)
- **Promociones** y **Grupos de Precio**: la cadena vacía es un *sentinel* con significado ("sin límite", "usar precio base"; un `0` borra la fila).
- **Gestión de Rutas / Optimizar Ruta (x2)**: coordenadas GPS **negativas** (`-26.8241`) — el componente saca el `-`.
- En el modal de pedido: el editor de precio inline (cancela con Escape) y "monto pagado" (ya muestra vacío en 0 y normaliza solo).

## Verificación
- `tsc --noEmit`: **0 errores** en lo modificado.
- `vitest`: **732/732** (incluye 8 nuevos de `NumberInput` y los 19 de Editar Pedido).
- ESLint: limpio.
- ⚠️ `npm run build` falla sólo al resolver `react-leaflet`/`leaflet` (deps faltantes en `node_modules` de este worktree, preexistente, nada de mapas tocado). Con `npm install` cierra.

🤖 Generated with [Claude Code](https://claude.com/claude-code)