### PR TITLE
feat(rutas): paradas de cambio/devolución + split de ruta entre repartidores

### DIFF
--- a/migrations/089_parada_cambio.sql
+++ b/migrations/089_parada_cambio.sql
@@ -1,0 +1,385 @@
+-- Migración 089 — Parada de cambio/devolución en el recorrido
+--
+-- El cliente tiene un producto vencido/erróneo y necesita un cambio. Hoy el
+-- recorrido solo rutea pedidos (recorrido_pedidos.pedido_id es NOT NULL y la
+-- vista del chofer filtra pedido != null). Para que un cambio sea una PARADA
+-- sin reescribir el modelo de paradas, se modela como un "pedido especial":
+--   canal = 'cambio', total = 0, estado_pago = 'pagado'.
+-- Con total = 0 el trigger actualizar_saldo_pedido NO mueve saldo_cuenta, y no
+-- hay trigger de stock en la entrega (el stock se descuenta al CREAR un pedido
+-- normal, en JS). Así el pedido de cambio fluye por todo el pipeline
+-- (optimizador, aplicar_orden_ruta, recorrido_pedidos, ruta del chofer, hoja de
+-- ruta, comandas) sin efectos de venta indeseados.
+--
+-- El detalle del cambio (producto devuelto/entregado + cantidades) vive en la
+-- tabla nueva recorrido_cambios (1:1 con el pedido). Cuando el chofer completa
+-- la parada se ejecuta aplicar_cambio_de_parada, que recién ahí ajusta stock +
+-- saldo_cuenta reusando la misma lógica que registrar_cambio_producto (mig 024),
+-- factorizada en _aplicar_cambio_producto.
+--
+-- NO aplicada en prod todavía (pendiente de apply_migration vía MCP).
+
+-- ============================================================================
+-- 1. Tabla recorrido_cambios — detalle 1:1 del cambio asociado a un pedido
+-- ============================================================================
+
+CREATE TABLE IF NOT EXISTS public.recorrido_cambios (
+  id BIGSERIAL PRIMARY KEY,
+  pedido_id BIGINT NOT NULL UNIQUE REFERENCES public.pedidos(id) ON DELETE CASCADE,
+  cliente_id INTEGER NOT NULL REFERENCES public.clientes(id),
+  producto_devuelto_id BIGINT NOT NULL REFERENCES public.productos(id),
+  producto_devuelto_nombre TEXT,
+  cantidad_devuelta INTEGER NOT NULL CHECK (cantidad_devuelta > 0),
+  producto_entregado_id BIGINT NOT NULL REFERENCES public.productos(id),
+  producto_entregado_nombre TEXT,
+  cantidad_entregada INTEGER NOT NULL CHECK (cantidad_entregada > 0),
+  observaciones TEXT,
+  sucursal_id BIGINT NOT NULL REFERENCES public.sucursales(id),
+  -- Auditoría de aplicación: NULL = todavía no se ejecutó el cambio real.
+  aplicado_at TIMESTAMPTZ,
+  cambio_producto_id BIGINT REFERENCES public.cambios_productos(id) ON DELETE SET NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  CONSTRAINT recorrido_cambios_distintos
+    CHECK (producto_devuelto_id <> producto_entregado_id)
+);
+
+ALTER TABLE public.recorrido_cambios OWNER TO postgres;
+
+CREATE INDEX IF NOT EXISTS idx_recorrido_cambios_sucursal
+  ON public.recorrido_cambios (sucursal_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_recorrido_cambios_cliente
+  ON public.recorrido_cambios (cliente_id, created_at DESC);
+
+COMMENT ON TABLE public.recorrido_cambios IS
+  'Detalle 1:1 de una parada de cambio/devolución (pedido con canal=cambio). El producto devuelto/entregado y cantidades; aplicado_at marca cuándo el chofer la completó (stock+saldo ajustados vía aplicar_cambio_de_parada).';
+
+-- ============================================================================
+-- 2. RLS — admin/encargado de la sucursal; el transportista ve el detalle de
+--    las paradas de su recorrido. Las escrituras van por RPC SECURITY DEFINER.
+-- ============================================================================
+
+ALTER TABLE public.recorrido_cambios ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS rc_select ON public.recorrido_cambios;
+CREATE POLICY rc_select ON public.recorrido_cambios
+  FOR SELECT TO authenticated
+  USING (
+    sucursal_id = public.current_sucursal_id()
+    AND (
+      public.es_encargado_o_admin()
+      OR EXISTS (
+        SELECT 1
+        FROM public.recorrido_pedidos rp
+        JOIN public.recorridos r ON r.id = rp.recorrido_id
+        WHERE rp.pedido_id = recorrido_cambios.pedido_id
+          AND r.transportista_id = auth.uid()
+      )
+    )
+  );
+
+-- INSERT/UPDATE/DELETE: solo vía RPC (SECURITY DEFINER, owner postgres). No
+-- abrimos políticas de escritura directa para mantener invariantes.
+GRANT SELECT ON TABLE public.recorrido_cambios TO authenticated;
+GRANT USAGE, SELECT ON SEQUENCE public.recorrido_cambios_id_seq TO authenticated;
+
+-- ============================================================================
+-- 3. _aplicar_cambio_producto — núcleo del cambio (stock + saldo + auditoría)
+--    Factorizado desde registrar_cambio_producto (mig 024). SIN chequeo de
+--    autorización ni resolución de sucursal: el caller (wrapper DEFINER) las
+--    provee. Valida productos, cantidades, cliente y stock.
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION public._aplicar_cambio_producto(
+  p_cliente_id INTEGER,
+  p_producto_devuelto_id BIGINT,
+  p_cantidad_devuelta INTEGER,
+  p_producto_entregado_id BIGINT,
+  p_cantidad_entregada INTEGER,
+  p_observaciones TEXT,
+  p_sucursal_id BIGINT,
+  p_usuario_id UUID
+) RETURNS BIGINT
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = public
+AS $$
+DECLARE
+  v_precio_devuelto NUMERIC(12,2);
+  v_precio_entregado NUMERIC(12,2);
+  v_stock_entregado INT;
+  v_diferencia NUMERIC(12,2);
+  v_cambio_id BIGINT;
+  v_first BIGINT;
+  v_second BIGINT;
+BEGIN
+  IF p_producto_devuelto_id = p_producto_entregado_id THEN
+    RAISE EXCEPTION 'Los productos deben ser distintos';
+  END IF;
+
+  IF p_cantidad_devuelta <= 0 OR p_cantidad_entregada <= 0 THEN
+    RAISE EXCEPTION 'Las cantidades deben ser mayores a 0';
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM clientes WHERE id = p_cliente_id AND sucursal_id = p_sucursal_id
+  ) THEN
+    RAISE EXCEPTION 'Cliente no encontrado en la sucursal';
+  END IF;
+
+  -- Lock en orden estable para evitar deadlocks
+  IF p_producto_devuelto_id < p_producto_entregado_id THEN
+    v_first := p_producto_devuelto_id;
+    v_second := p_producto_entregado_id;
+  ELSE
+    v_first := p_producto_entregado_id;
+    v_second := p_producto_devuelto_id;
+  END IF;
+
+  PERFORM 1 FROM productos
+   WHERE id = v_first AND sucursal_id = p_sucursal_id FOR UPDATE;
+  PERFORM 1 FROM productos
+   WHERE id = v_second AND sucursal_id = p_sucursal_id FOR UPDATE;
+
+  SELECT precio, stock INTO v_precio_entregado, v_stock_entregado
+    FROM productos
+   WHERE id = p_producto_entregado_id AND sucursal_id = p_sucursal_id;
+  IF v_precio_entregado IS NULL THEN
+    RAISE EXCEPTION 'Producto a entregar no encontrado';
+  END IF;
+  IF v_stock_entregado < p_cantidad_entregada THEN
+    RAISE EXCEPTION 'Stock insuficiente del producto a entregar (% disponibles)', v_stock_entregado;
+  END IF;
+
+  SELECT precio INTO v_precio_devuelto
+    FROM productos
+   WHERE id = p_producto_devuelto_id AND sucursal_id = p_sucursal_id;
+  IF v_precio_devuelto IS NULL THEN
+    RAISE EXCEPTION 'Producto a devolver no encontrado';
+  END IF;
+
+  UPDATE productos SET stock = stock + p_cantidad_devuelta
+   WHERE id = p_producto_devuelto_id;
+  UPDATE productos SET stock = stock - p_cantidad_entregada
+   WHERE id = p_producto_entregado_id;
+
+  v_diferencia := (v_precio_entregado * p_cantidad_entregada)
+                - (v_precio_devuelto * p_cantidad_devuelta);
+
+  UPDATE clientes
+     SET saldo_cuenta = COALESCE(saldo_cuenta, 0) + v_diferencia
+   WHERE id = p_cliente_id;
+
+  INSERT INTO cambios_productos (
+    cliente_id, producto_devuelto_id, cantidad_devuelta, precio_devuelto,
+    producto_entregado_id, cantidad_entregada, precio_entregado,
+    diferencia_monto, observaciones, usuario_id, sucursal_id
+  ) VALUES (
+    p_cliente_id, p_producto_devuelto_id, p_cantidad_devuelta, v_precio_devuelto,
+    p_producto_entregado_id, p_cantidad_entregada, v_precio_entregado,
+    v_diferencia, p_observaciones, p_usuario_id, p_sucursal_id
+  ) RETURNING id INTO v_cambio_id;
+
+  RETURN v_cambio_id;
+END;
+$$;
+
+ALTER FUNCTION public._aplicar_cambio_producto(
+  INTEGER, BIGINT, INTEGER, BIGINT, INTEGER, TEXT, BIGINT, UUID
+) OWNER TO postgres;
+
+-- Solo lo llaman los wrappers DEFINER; no se expone a clientes.
+REVOKE ALL ON FUNCTION public._aplicar_cambio_producto(
+  INTEGER, BIGINT, INTEGER, BIGINT, INTEGER, TEXT, BIGINT, UUID
+) FROM PUBLIC;
+
+-- ============================================================================
+-- 4. registrar_cambio_producto (mig 024) → delega en _aplicar_cambio_producto
+--    Misma firma y semántica pública (cambio standalone admin/encargado).
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION public.registrar_cambio_producto(
+  p_cliente_id INTEGER,
+  p_producto_devuelto_id BIGINT,
+  p_cantidad_devuelta INTEGER,
+  p_producto_entregado_id BIGINT,
+  p_cantidad_entregada INTEGER,
+  p_observaciones TEXT DEFAULT NULL
+) RETURNS BIGINT
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = public
+AS $$
+DECLARE
+  v_sucursal BIGINT := public.current_sucursal_id();
+  v_user UUID := auth.uid();
+BEGIN
+  IF v_sucursal IS NULL THEN
+    RAISE EXCEPTION 'Sin sucursal activa';
+  END IF;
+  IF NOT public.es_encargado_o_admin() THEN
+    RAISE EXCEPTION 'No autorizado';
+  END IF;
+
+  RETURN public._aplicar_cambio_producto(
+    p_cliente_id, p_producto_devuelto_id, p_cantidad_devuelta,
+    p_producto_entregado_id, p_cantidad_entregada, p_observaciones,
+    v_sucursal, v_user
+  );
+END;
+$$;
+
+ALTER FUNCTION public.registrar_cambio_producto(
+  INTEGER, BIGINT, INTEGER, BIGINT, INTEGER, TEXT
+) OWNER TO postgres;
+
+GRANT EXECUTE ON FUNCTION public.registrar_cambio_producto(
+  INTEGER, BIGINT, INTEGER, BIGINT, INTEGER, TEXT
+) TO authenticated;
+
+-- ============================================================================
+-- 5. crear_pedido_cambio_en_ruta — crea el pedido especial + el detalle
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION public.crear_pedido_cambio_en_ruta(
+  p_cliente_id INTEGER,
+  p_producto_devuelto_id BIGINT,
+  p_cantidad_devuelta INTEGER,
+  p_producto_entregado_id BIGINT,
+  p_cantidad_entregada INTEGER,
+  p_observaciones TEXT DEFAULT NULL
+) RETURNS BIGINT
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = public
+AS $$
+DECLARE
+  v_sucursal BIGINT := public.current_sucursal_id();
+  v_user UUID := auth.uid();
+  v_nombre_devuelto TEXT;
+  v_nombre_entregado TEXT;
+  v_pedido_id BIGINT;
+BEGIN
+  IF v_sucursal IS NULL THEN
+    RAISE EXCEPTION 'Sin sucursal activa';
+  END IF;
+  IF NOT public.es_encargado_o_admin() THEN
+    RAISE EXCEPTION 'No autorizado';
+  END IF;
+  IF p_producto_devuelto_id = p_producto_entregado_id THEN
+    RAISE EXCEPTION 'Los productos deben ser distintos';
+  END IF;
+  IF p_cantidad_devuelta <= 0 OR p_cantidad_entregada <= 0 THEN
+    RAISE EXCEPTION 'Las cantidades deben ser mayores a 0';
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM clientes WHERE id = p_cliente_id AND sucursal_id = v_sucursal
+  ) THEN
+    RAISE EXCEPTION 'Cliente no encontrado en la sucursal';
+  END IF;
+
+  SELECT nombre INTO v_nombre_devuelto FROM productos
+   WHERE id = p_producto_devuelto_id AND sucursal_id = v_sucursal;
+  IF v_nombre_devuelto IS NULL THEN
+    RAISE EXCEPTION 'Producto a devolver no encontrado';
+  END IF;
+  SELECT nombre INTO v_nombre_entregado FROM productos
+   WHERE id = p_producto_entregado_id AND sucursal_id = v_sucursal;
+  IF v_nombre_entregado IS NULL THEN
+    RAISE EXCEPTION 'Producto a entregar no encontrado';
+  END IF;
+
+  -- Pedido especial de cambio: total 0 (no mueve saldo), estado_pago pagado
+  -- (el chofer no entra al modal de cobro), canal 'cambio' (diferenciador).
+  INSERT INTO pedidos (
+    cliente_id, fecha, estado, total, monto_pagado, estado_pago,
+    canal, usuario_id, sucursal_id
+  ) VALUES (
+    p_cliente_id, CURRENT_DATE, 'pendiente', 0, 0, 'pagado',
+    'cambio', v_user, v_sucursal
+  ) RETURNING id INTO v_pedido_id;
+
+  INSERT INTO recorrido_cambios (
+    pedido_id, cliente_id,
+    producto_devuelto_id, producto_devuelto_nombre, cantidad_devuelta,
+    producto_entregado_id, producto_entregado_nombre, cantidad_entregada,
+    observaciones, sucursal_id
+  ) VALUES (
+    v_pedido_id, p_cliente_id,
+    p_producto_devuelto_id, v_nombre_devuelto, p_cantidad_devuelta,
+    p_producto_entregado_id, v_nombre_entregado, p_cantidad_entregada,
+    p_observaciones, v_sucursal
+  );
+
+  RETURN v_pedido_id;
+END;
+$$;
+
+ALTER FUNCTION public.crear_pedido_cambio_en_ruta(
+  INTEGER, BIGINT, INTEGER, BIGINT, INTEGER, TEXT
+) OWNER TO postgres;
+
+GRANT EXECUTE ON FUNCTION public.crear_pedido_cambio_en_ruta(
+  INTEGER, BIGINT, INTEGER, BIGINT, INTEGER, TEXT
+) TO authenticated;
+
+COMMENT ON FUNCTION public.crear_pedido_cambio_en_ruta(
+  INTEGER, BIGINT, INTEGER, BIGINT, INTEGER, TEXT
+) IS 'Crea un pedido especial canal=cambio (total 0) + su detalle en recorrido_cambios, para agregarlo como parada del recorrido. NO ajusta stock/saldo (eso ocurre al completar la parada vía aplicar_cambio_de_parada).';
+
+-- ============================================================================
+-- 6. aplicar_cambio_de_parada — ejecuta el cambio real al completar la parada
+--    Idempotente (aplicado_at). Autoriza al transportista del recorrido o a
+--    admin/encargado.
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION public.aplicar_cambio_de_parada(
+  p_pedido_id BIGINT
+) RETURNS BIGINT
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = public
+AS $$
+DECLARE
+  v_rc RECORD;
+  v_user UUID := auth.uid();
+  v_cambio_id BIGINT;
+  v_autorizado BOOLEAN;
+BEGIN
+  SELECT * INTO v_rc FROM recorrido_cambios WHERE pedido_id = p_pedido_id;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'No hay detalle de cambio para el pedido %', p_pedido_id;
+  END IF;
+
+  -- Idempotencia: si ya se aplicó, devolver el cambio existente.
+  IF v_rc.aplicado_at IS NOT NULL THEN
+    RETURN v_rc.cambio_producto_id;
+  END IF;
+
+  -- Autorización: admin/encargado de la sucursal, o el transportista a cargo
+  -- del recorrido que contiene esta parada.
+  v_autorizado := public.es_encargado_o_admin()
+    OR EXISTS (
+      SELECT 1
+      FROM recorrido_pedidos rp
+      JOIN recorridos r ON r.id = rp.recorrido_id
+      WHERE rp.pedido_id = p_pedido_id
+        AND r.transportista_id = v_user
+    );
+  IF NOT v_autorizado THEN
+    RAISE EXCEPTION 'No autorizado para aplicar el cambio';
+  END IF;
+
+  v_cambio_id := public._aplicar_cambio_producto(
+    v_rc.cliente_id,
+    v_rc.producto_devuelto_id, v_rc.cantidad_devuelta,
+    v_rc.producto_entregado_id, v_rc.cantidad_entregada,
+    v_rc.observaciones, v_rc.sucursal_id, v_user
+  );
+
+  UPDATE recorrido_cambios
+     SET aplicado_at = NOW(), cambio_producto_id = v_cambio_id
+   WHERE pedido_id = p_pedido_id;
+
+  RETURN v_cambio_id;
+END;
+$$;
+
+ALTER FUNCTION public.aplicar_cambio_de_parada(BIGINT) OWNER TO postgres;
+
+GRANT EXECUTE ON FUNCTION public.aplicar_cambio_de_parada(BIGINT) TO authenticated;
+
+COMMENT ON FUNCTION public.aplicar_cambio_de_parada(BIGINT) IS
+  'Ejecuta el cambio real de una parada (suma stock devuelto, resta entregado, ajusta saldo_cuenta, inserta cambios_productos) y marca aplicado_at. Idempotente. Autoriza al transportista del recorrido o a admin/encargado.';

--- a/src/components/containers/ClientesContainer.tsx
+++ b/src/components/containers/ClientesContainer.tsx
@@ -11,7 +11,10 @@ import {
   useCrearClienteMutation,
   useActualizarClienteMutation,
   useEliminarClienteMutation,
-  useZonasEstandarizadasQuery
+  useZonasEstandarizadasQuery,
+  useProductosQuery,
+  useCrearPedidoCambioEnRutaMutation,
+  type RegistrarCambioInput,
 } from '../../hooks/queries'
 import { useAuthData } from '../../contexts/AuthDataContext'
 import { useNotification } from '../../contexts/NotificationContext'
@@ -31,6 +34,7 @@ const ModalConfirmacion = lazy(() => import('../modals/ModalConfirmacion'))
 const ModalZonas = lazy(() => import('../modals/ModalZonas'))
 const ModalRegistrarPago = lazy(() => import('../modals/ModalRegistrarPago'))
 const ModalDeudoresMora = lazy(() => import('../modals/ModalDeudoresMora'))
+const ModalCambioProducto = lazy(() => import('../modals/ModalCambioProducto'))
 
 function LoadingState() {
   return (
@@ -66,11 +70,14 @@ export default function ClientesContainer(): React.ReactElement {
   // entre ediciones del cliente — el espejo legacy debe seguir resolviendo
   // aunque la zona ya no esté disponible en el selector activo.
   const { data: zonas = [] } = useZonasEstandarizadasQuery({ includeInactive: true })
+  const { data: productos = [] } = useProductosQuery()
+  const puedeCambio = isAdmin || isEncargado
 
   // Mutations
   const crearCliente = useCrearClienteMutation()
   const actualizarCliente = useActualizarClienteMutation()
   const eliminarCliente = useEliminarClienteMutation()
+  const crearCambioEnRutaMut = useCrearPedidoCambioEnRutaMutation()
 
   // Estado de modales
   const [modalClienteOpen, setModalClienteOpen] = useState(false)
@@ -80,6 +87,8 @@ export default function ClientesContainer(): React.ReactElement {
   const [clienteFichaId, setClienteFichaId] = useState<string | null>(null)
   const [clientePago, setClientePago] = useState<ClienteDB | null>(null)
   const [saldoPendientePago, setSaldoPendientePago] = useState<number>(0)
+  // Cambio/devolución como parada, desde la ficha del cliente.
+  const [cambioCliente, setCambioCliente] = useState<ClienteDB | null>(null)
 
   // Ficha cliente hook - ModalFichaCliente lo usa internamente
   useFichaCliente(clienteFichaId)
@@ -98,6 +107,7 @@ export default function ClientesContainer(): React.ReactElement {
     setModalFichaOpen(false)
     setModalZonasOpen(false)
     setModalDeudoresOpen(false)
+    setCambioCliente(null)
     setClienteFichaId(null)
     setClientePago(null)
     setClienteEditando(null)
@@ -132,6 +142,17 @@ export default function ClientesContainer(): React.ReactElement {
       },
     })
   }, [clientes, eliminarCliente, notify])
+
+  const handleGuardarCambioEnRuta = useCallback(async (data: RegistrarCambioInput) => {
+    try {
+      await crearCambioEnRutaMut.mutateAsync(data)
+      notify.success('Cambio/devolución agregado como parada del recorrido')
+      setCambioCliente(null)
+    } catch (err) {
+      notify.error(err instanceof Error ? err.message : 'No se pudo crear la parada de cambio')
+      throw err
+    }
+  }, [crearCambioEnRutaMut, notify])
 
   const handleVerFichaCliente = useCallback((cliente: ClienteDB) => {
     setClienteFichaId(cliente.id)
@@ -403,6 +424,21 @@ export default function ClientesContainer(): React.ReactElement {
               setClienteFichaId(null)
             }}
             onRegistrarPago={puedePago ? handleAbrirRegistrarPago : undefined}
+            onCambioEnRuta={puedeCambio ? (cliente) => setCambioCliente(cliente) : undefined}
+          />
+        </Suspense>
+      )}
+
+      {/* Modal Cambio/Devolución como parada (cliente fijo desde su ficha) */}
+      {cambioCliente && (
+        <Suspense fallback={null}>
+          <ModalCambioProducto
+            clientes={clientes}
+            productos={productos}
+            modo="enRuta"
+            clienteFijo={cambioCliente}
+            onSave={async (data) => { await handleGuardarCambioEnRuta(data as RegistrarCambioInput) }}
+            onClose={() => setCambioCliente(null)}
           />
         </Suspense>
       )}

--- a/src/components/containers/PedidosContainer.tsx
+++ b/src/components/containers/PedidosContainer.tsx
@@ -30,10 +30,14 @@ import {
   useCrearClienteMutation,
   useDepositoCoords,
   useDestinoCoords,
+  useCrearPedidoCambioEnRutaMutation,
+  useAplicarCambioParadaMutation,
+  useZonasEstandarizadasQuery,
+  type RegistrarCambioInput,
 } from '../../hooks/queries'
 import { useAuthData } from '../../contexts/AuthDataContext'
 import { useNotification } from '../../contexts/NotificationContext'
-import { useOptimizarRuta } from '../../hooks/useOptimizarRuta'
+import { useOptimizarRuta, type RepartidorParam } from '../../hooks/useOptimizarRuta'
 import { usePromocionPedido } from '../../hooks/usePromocionPedido'
 import { useDebounce } from '../../hooks/useAsync'
 import { useResetOnSucursalChange } from '../../hooks/useResetOnSucursalChange'
@@ -44,6 +48,7 @@ import { usePagos } from '../../hooks/supabase/usePagos'
 import { retryWithBackoff, isTransientNetworkError } from '../../utils/retryWithBackoff'
 import type { PedidoDB, FiltrosPedidosState, PerfilDB, RegistrarSalvedadInput, RegistrarSalvedadResult, PagoDBWithUsuario } from '../../types'
 import type { PedidoEditItem } from '../modals/ModalEditarPedido'
+import type { RutaMultiResultadoUI } from '../modals/ModalGestionRutas'
 
 // Lazy load de componentes
 const VistaPedidos = lazy(() => import('../vistas/VistaPedidos'))
@@ -56,6 +61,7 @@ const ModalEditarNotas = lazy(() => import('../modals/ModalEditarNotas'))
 const ModalFiltroFecha = lazy(() => import('../modals/ModalFiltroFecha'))
 const ModalExportarPDF = lazy(() => import('../modals/ModalExportarPDF'))
 const ModalGestionRutas = lazy(() => import('../modals/ModalGestionRutas'))
+const ModalCambioProducto = lazy(() => import('../modals/ModalCambioProducto'))
 const ModalEntregaConSalvedad = lazy(() => import('../modals/ModalEntregaConSalvedad'))
 const ModalEntregasMasivas = lazy(() => import('../modals/ModalEntregasMasivas'))
 const ModalCancelarPedido = lazy(() => import('../modals/ModalCancelarPedido'))
@@ -124,6 +130,8 @@ export default function PedidosContainer(): React.ReactElement {
   const { data: clientes = [] } = useClientesQuery()
   const { data: productos = [] } = useProductosQuery()
   const { data: transportistas = [] } = useTransportistasQuery()
+  // Zonas activas (para elegir zonas preferidas por chofer en el split)
+  const { data: zonasRuta = [] } = useZonasEstandarizadasQuery()
   const { data: usuariosTodos = [] } = useUsuariosQuery()
   const usuarios = useMemo(
     () => (isAdmin ? usuariosTodos : []),
@@ -142,9 +150,11 @@ export default function PedidosContainer(): React.ReactElement {
   const cancelarPedidoMut = useCancelarPedidoMutation()
   const pagosMasivos = usePagosMasivosMutation()
   const crearClienteMut = useCrearClienteMutation()
+  const crearCambioEnRutaMut = useCrearPedidoCambioEnRutaMutation()
+  const aplicarCambioParadaMut = useAplicarCambioParadaMutation()
 
   // Route optimization
-  const { loading: loadingOptimizacion, rutaOptimizada, error: errorOptimizacion, optimizarRuta, setRutaOptimizada, limpiarRuta } = useOptimizarRuta()
+  const { loading: loadingOptimizacion, rutaOptimizada, error: errorOptimizacion, optimizarRuta, optimizarRutaMulti, setRutaOptimizada, limpiarRuta } = useOptimizarRuta()
   const deposito = useDepositoCoords()
   const destinoRuta = useDestinoCoords()
   // Inyecta el depósito (origen) y el punto de llegada opcional (destino) de la
@@ -154,6 +164,11 @@ export default function PedidosContainer(): React.ReactElement {
     (transportistaId: string, pedidosData?: PedidoDB[], fecha?: string, horaInicio?: string) =>
       optimizarRuta(transportistaId, pedidosData, deposito, destinoRuta, { fecha, horaInicio }),
     [optimizarRuta, deposito, destinoRuta],
+  )
+  const optimizarRutaMultiConDeposito = useCallback(
+    (repartidores: RepartidorParam[], pedidosData?: PedidoDB[], fecha?: string, horaInicio?: string) =>
+      optimizarRutaMulti(repartidores, pedidosData, deposito, destinoRuta, { fecha, horaInicio }),
+    [optimizarRutaMulti, deposito, destinoRuta],
   )
 
   // Export
@@ -179,6 +194,10 @@ export default function PedidosContainer(): React.ReactElement {
   const [modalPagoPedidoOpen, setModalPagoPedidoOpen] = useState(false)
   const [modalMarcarVisitaOpen, setModalMarcarVisitaOpen] = useState(false)
   const [modalVisitasHoyOpen, setModalVisitasHoyOpen] = useState(false)
+  // Cambio/devolución como parada (desde la pantalla de Pedidos)
+  const [cambioEnRutaOpen, setCambioEnRutaOpen] = useState(false)
+  // Resultado del split multi-repartidor (vista de resultado del modal de rutas)
+  const [rutaMultiResultado, setRutaMultiResultado] = useState<RutaMultiResultadoUI | null>(null)
   const [pedidoPago, setPedidoPago] = useState<PedidoDB | null>(null)
   const [pagosPreviosPedido, setPagosPreviosPedido] = useState<PagoDBWithUsuario[]>([])
 
@@ -212,6 +231,8 @@ export default function PedidosContainer(): React.ReactElement {
     setModalFiltroFechaOpen(false)
     setModalExportarPDFOpen(false)
     setModalOptimizarRutaOpen(false)
+    setCambioEnRutaOpen(false)
+    setRutaMultiResultado(null)
     setModalEntregaSalvedadOpen(false)
     setModalEntregasMasivasOpen(false)
     setModalCancelarOpen(false)
@@ -296,6 +317,25 @@ export default function PedidosContainer(): React.ReactElement {
   }, [fetchPagosPedido])
 
   const handleMarcarEntregado = useCallback(async (pedido: PedidoDB) => {
+    // Parada de cambio/devolución (canal='cambio'): al completarla se ajusta
+    // stock + saldo (aplicar_cambio_de_parada, idempotente) y recién después se
+    // marca el pedido entregado. No hay cobro (total 0).
+    if (pedido.canal === 'cambio') {
+      setConfirmConfig({
+        visible: true, titulo: 'Confirmar cambio/devolución',
+        mensaje: `¿Confirmar el cambio/devolución del pedido #${pedido.id}? Se ajustará el stock y la cuenta del cliente.`,
+        tipo: 'success',
+        onConfirm: async () => {
+          try {
+            await aplicarCambioParadaMut.mutateAsync(String(pedido.id))
+            await cambiarEstado.mutateAsync({ pedidoId: pedido.id, nuevoEstado: 'entregado' })
+            notify.success('Cambio/devolución completado')
+          } catch (e) { notify.error((e as Error).message) }
+          setConfirmConfig({ visible: false })
+        },
+      })
+      return
+    }
     if (pedido.estado_pago === 'pagado') {
       setConfirmConfig({
         visible: true, titulo: 'Confirmar entrega',
@@ -316,7 +356,7 @@ export default function PedidosContainer(): React.ReactElement {
     setPagosPreviosPedido([])
     setModalPagoPedidoOpen(true)
     await refreshPagosPedido(String(pedido.id))
-  }, [cambiarEstado, notify, refreshPagosPedido])
+  }, [cambiarEstado, notify, refreshPagosPedido, aplicarCambioParadaMut])
 
   const handleDesmarcarEntregado = useCallback((pedido: PedidoDB) => {
     setConfirmConfig({
@@ -1093,6 +1133,107 @@ export default function PedidosContainer(): React.ReactElement {
     }
   }, [optimizarRutaConDeposito, handleAplicarOrden, setRutaOptimizada])
 
+  // Split multi-repartidor: optimiza dividiendo los pedidos entre N choferes y
+  // persiste un recorrido por chofer (aplicar_orden_ruta una vez por cada uno).
+  // Los pedidos sin coordenadas (que el optimizador no rutea) se reparten por
+  // zona preferida o round-robin antes de persistir.
+  const handleArmarRutaMulti = useCallback(async (repartidores: RepartidorParam[], pedidosSeleccionados: PedidoDB[], fecha: string, horaInicio: string) => {
+    if (!repartidores.length || pedidosSeleccionados.length === 0) return
+    const resp = await optimizarRutaMultiConDeposito(repartidores, pedidosSeleccionados, fecha, horaInicio)
+    if (!resp) return // error ya notificado por el hook
+
+    const byId = new Map(pedidosSeleccionados.map(p => [String(p.id), p]))
+
+    // Orden por repartidor desde el resultado del optimizador (geocodificados).
+    const ordenPorRep = new Map<string, Array<{ pedido_id: string; orden: number }>>()
+    for (const rep of repartidores) ordenPorRep.set(rep.transportista_id, [])
+    for (const r of resp.recorridos) {
+      ordenPorRep.set(
+        r.transportista_id,
+        (r.orden_optimizado ?? []).map(o => ({ pedido_id: String(o.pedido_id), orden: o.orden })),
+      )
+    }
+
+    // Pedidos sin coordenadas: el optimizador no los devuelve → repartir por
+    // zona preferida (si el cliente tiene zona) o round-robin, y anexar al final.
+    const sinCoordsIds = resp.pedidos_sin_coordenadas_ids
+      ?? pedidosSeleccionados
+        .filter(p => p.cliente?.latitud == null || p.cliente?.longitud == null)
+        .map(p => String(p.id))
+    let rr = 0
+    for (const pid of sinCoordsIds) {
+      const pedido = byId.get(String(pid))
+      const zonaId = pedido?.cliente?.zona_id != null ? Number(pedido.cliente.zona_id) : null
+      let target = zonaId != null
+        ? repartidores.find(r => Array.isArray(r.zonas_preferidas) && r.zonas_preferidas.includes(zonaId))?.transportista_id
+        : undefined
+      if (!target) { target = repartidores[rr % repartidores.length].transportista_id; rr++ }
+      const lista = ordenPorRep.get(target)!
+      const maxOrden = lista.reduce((m, o) => Math.max(m, o.orden), 0)
+      lista.push({ pedido_id: String(pid), orden: maxOrden + 1 })
+    }
+
+    // Métricas (distancia/duración/polylines) por chofer desde el optimizador.
+    const metricsByRep = new Map(resp.recorridos.map(r => [r.transportista_id, r]))
+
+    setGuardando(true)
+    const recorridosUI: RutaMultiResultadoUI['recorridos'] = []
+    try {
+      for (const rep of repartidores) {
+        const lista = ordenPorRep.get(rep.transportista_id) ?? []
+        if (lista.length === 0) continue
+        const m = metricsByRep.get(rep.transportista_id)
+        const { error } = await supabase.rpc('aplicar_orden_ruta', {
+          p_transportista_id: rep.transportista_id,
+          p_pedidos: lista.map(o => ({ pedido_id: o.pedido_id, orden_entrega: o.orden })),
+          p_distancia: m?.distancia_total ?? null,
+          p_duracion: m?.duracion_total != null ? Math.round(m.duracion_total) : null,
+          p_polylines: m?.polylines ?? null,
+          p_fecha: fecha,
+        })
+        if (error) throw error
+        recorridosUI.push({
+          transportista_id: rep.transportista_id,
+          transportista_nombre: transportistas.find(t => t.id === rep.transportista_id)?.nombre || 'Transportista',
+          total_pedidos: lista.length,
+          distancia_formato: m?.distancia_formato,
+          duracion_formato: m?.duracion_formato,
+          pedido_ids: lista.slice().sort((a, b) => a.orden - b.orden).map(o => o.pedido_id),
+        })
+      }
+
+      queryClient.invalidateQueries({ queryKey: ['pedidos'] })
+      queryClient.invalidateQueries({ queryKey: ['recorridos'] })
+      queryClient.invalidateQueries({ queryKey: ['recorrido-activo'] })
+      queryClient.invalidateQueries({ queryKey: ['recorrido-existente'] })
+      queryClient.invalidateQueries({ queryKey: ['recorridos-hoja-ruta'] })
+
+      setRutaMultiResultado({ recorridos: recorridosUI, skipped: resp.skipped ?? [] })
+      const noAsignados = (resp.skipped ?? []).length
+      notify.success(
+        `Ruta dividida en ${recorridosUI.length} recorrido(s)` +
+        (noAsignados > 0 ? ` · ${noAsignados} pedido(s) sin asignar (capacidad)` : ''),
+      )
+    } catch (e) {
+      notify.error('Error al guardar las rutas: ' + (e as Error).message)
+    }
+    setGuardando(false)
+  }, [optimizarRutaMultiConDeposito, transportistas, notify, queryClient])
+
+  // Crea una parada de cambio/devolución (pedido especial canal='cambio'). La
+  // usa tanto el modal de armar ruta (que además la suma a la selección con el
+  // pedido_id que devuelve) como la pantalla de Pedidos. Devuelve el pedido_id.
+  const handleCrearCambioEnRuta = useCallback(async (data: RegistrarCambioInput): Promise<string | null> => {
+    try {
+      const pedidoId = await crearCambioEnRutaMut.mutateAsync(data)
+      notify.success('Cambio/devolución agregado como parada')
+      return pedidoId != null ? String(pedidoId) : null
+    } catch (err) {
+      notify.error(err instanceof Error ? err.message : 'No se pudo crear la parada de cambio')
+      return null
+    }
+  }, [crearCambioEnRutaMut, notify])
+
   const handleExportarHojaRutaOptimizada = useCallback(async (transportista: PerfilDB | undefined, pedidosOrdenados: PedidoDB[]) => {
     try {
       const { generarHojaRutaOptimizada } = await import('../../lib/pdfExport')
@@ -1245,6 +1386,7 @@ export default function PedidosContainer(): React.ReactElement {
           onPageChange={handlePageChange}
           onNuevoPedido={() => setModalPedidoOpen(true)}
           onOptimizarRuta={() => setModalOptimizarRutaOpen(true)}
+          onCambioEnRuta={(isAdmin || isEncargado) ? () => setCambioEnRutaOpen(true) : undefined}
           onExportarPDF={() => setModalExportarPDFOpen(true)}
           onExportarExcel={handleExportarExcel}
           onModalFiltroFecha={() => setModalFiltroFechaOpen(true)}
@@ -1462,14 +1604,33 @@ export default function PedidosContainer(): React.ReactElement {
           <ModalGestionRutas
             transportistas={transportistas}
             pedidos={pedidosParaRuta}
+            clientes={clientes}
+            productos={productos}
+            zonas={zonasRuta}
+            onCrearCambio={handleCrearCambioEnRuta}
             onArmarRuta={handleArmarRutaDelDia as Parameters<typeof ModalGestionRutas>[0]['onArmarRuta']}
+            onArmarRutaMulti={handleArmarRutaMulti as Parameters<typeof ModalGestionRutas>[0]['onArmarRutaMulti']}
             onExportarPDF={handleExportarHojaRutaOptimizada as Parameters<typeof ModalGestionRutas>[0]['onExportarPDF']}
             onImprimirComandas={handleImprimirComandas as Parameters<typeof ModalGestionRutas>[0]['onImprimirComandas']}
-            onClose={() => { setModalOptimizarRutaOpen(false); limpiarRuta() }}
+            onClose={() => { setModalOptimizarRutaOpen(false); limpiarRuta(); setRutaMultiResultado(null) }}
             loading={loadingOptimizacion || loadingPedidosRuta}
             guardando={guardando}
             rutaOptimizada={rutaOptimizada as Parameters<typeof ModalGestionRutas>[0]['rutaOptimizada']}
+            rutaMulti={rutaMultiResultado}
             error={errorOptimizacion}
+          />
+        </Suspense>
+      )}
+
+      {/* Modal Cambio/Devolución como parada (desde la pantalla de Pedidos) */}
+      {cambioEnRutaOpen && (
+        <Suspense fallback={null}>
+          <ModalCambioProducto
+            clientes={clientes}
+            productos={productos}
+            modo="enRuta"
+            onSave={async (data) => { await handleCrearCambioEnRuta(data as RegistrarCambioInput) }}
+            onClose={() => setCambioEnRutaOpen(false)}
           />
         </Suspense>
       )}

--- a/src/components/modals/ModalCambioProducto.tsx
+++ b/src/components/modals/ModalCambioProducto.tsx
@@ -20,6 +20,14 @@ export interface ModalCambioProductoProps {
   productos: ProductoDB[]
   onSave: (data: CambioProductoSaveData) => Promise<void>
   onClose: () => void
+  /**
+   * 'standalone' (default): cambio de dep\u00F3sito, ajusta stock/saldo al registrar.
+   * 'enRuta': crea una parada de cambio en el recorrido; el ajuste ocurre cuando
+   * el chofer la completa. Solo cambia textos/t\u00EDtulo.
+   */
+  modo?: 'standalone' | 'enRuta'
+  /** Si viene, el cliente queda fijo (no se puede buscar/cambiar). */
+  clienteFijo?: ClienteDB | null
 }
 
 function normalizar(s: string | null | undefined): string {
@@ -31,11 +39,17 @@ export default function ModalCambioProducto({
   productos,
   onSave,
   onClose,
+  modo = 'standalone',
+  clienteFijo = null,
 }: ModalCambioProductoProps): React.ReactElement {
   const { validate, getFirstError } = useZodValidation(modalCambioProductoSchema)
 
-  const [clienteId, setClienteId] = useState<string>('')
-  const [busquedaCliente, setBusquedaCliente] = useState<string>('')
+  const enRuta = modo === 'enRuta'
+
+  const [clienteId, setClienteId] = useState<string>(clienteFijo?.id ?? '')
+  const [busquedaCliente, setBusquedaCliente] = useState<string>(
+    clienteFijo ? (clienteFijo.nombre_fantasia || clienteFijo.razon_social || '') : '',
+  )
 
   const [productoDevueltoId, setProductoDevueltoId] = useState<string>('')
   const [busquedaDevuelto, setBusquedaDevuelto] = useState<string>('')
@@ -186,8 +200,14 @@ export default function ModalCambioProducto({
               <ArrowLeftRight className="w-5 h-5 text-indigo-600 dark:text-indigo-400" />
             </div>
             <div>
-              <h2 className="text-lg font-semibold text-gray-800 dark:text-white">Cambio de productos</h2>
-              <p className="text-sm text-gray-500">El cliente devuelve uno y se le entrega otro</p>
+              <h2 className="text-lg font-semibold text-gray-800 dark:text-white">
+                {enRuta ? 'Cambio/devolución en la ruta' : 'Cambio de productos'}
+              </h2>
+              <p className="text-sm text-gray-500">
+                {enRuta
+                  ? 'Se agrega como parada; el stock y el saldo se ajustan al completarla'
+                  : 'El cliente devuelve uno y se le entrega otro'}
+              </p>
             </div>
           </div>
           <button onClick={onClose} className="p-2 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-lg" aria-label="Cerrar">
@@ -211,11 +231,12 @@ export default function ModalCambioProducto({
                   setBusquedaCliente(e.target.value)
                   setClienteId('')
                 }}
+                disabled={!!clienteFijo}
                 placeholder="Buscar por nombre, razón social o CUIT..."
-                className="w-full pl-10 pr-3 py-2 border dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-indigo-500 dark:bg-gray-700 dark:text-white"
+                className="w-full pl-10 pr-3 py-2 border dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-indigo-500 dark:bg-gray-700 dark:text-white disabled:bg-gray-100 dark:disabled:bg-gray-900 disabled:text-gray-500"
               />
             </div>
-            {!clienteId && clientesFiltrados.length > 0 && (
+            {!clienteFijo && !clienteId && clientesFiltrados.length > 0 && (
               <ul className="absolute z-20 mt-1 w-full bg-white dark:bg-gray-800 border dark:border-gray-700 rounded-lg shadow-lg max-h-56 overflow-auto">
                 {clientesFiltrados.map(c => (
                   <li key={c.id}>
@@ -433,11 +454,11 @@ export default function ModalCambioProducto({
               className="flex-1 px-4 py-2 bg-indigo-600 hover:bg-indigo-700 disabled:bg-indigo-300 dark:disabled:bg-indigo-800 text-white rounded-lg transition-colors flex items-center justify-center gap-2"
             >
               {guardando ? (
-                <span className="animate-pulse">Registrando...</span>
+                <span className="animate-pulse">{enRuta ? 'Agregando...' : 'Registrando...'}</span>
               ) : (
                 <>
                   <ArrowLeftRight className="w-4 h-4" />
-                  Registrar cambio
+                  {enRuta ? 'Agregar a la ruta' : 'Registrar cambio'}
                 </>
               )}
             </button>

--- a/src/components/modals/ModalFichaCliente.tsx
+++ b/src/components/modals/ModalFichaCliente.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useMemo } from 'react'
 import type { LucideIcon } from 'lucide-react'
-import { User, MapPin, Phone, CreditCard, ShoppingBag, TrendingUp, DollarSign, Clock, Package, ChevronDown, ChevronUp, FileText, Plus, AlertTriangle, CheckCircle, Tag, Building2, Percent } from 'lucide-react'
+import { User, MapPin, Phone, CreditCard, ShoppingBag, TrendingUp, DollarSign, Clock, Package, ChevronDown, ChevronUp, FileText, Plus, AlertTriangle, CheckCircle, Tag, Building2, Percent, ArrowLeftRight } from 'lucide-react'
 import ModalBase from './ModalBase'
 import { useFichaCliente, usePagos } from '../../hooks/supabase'
 import { useAuthData } from '../../contexts/AuthDataContext'
@@ -22,6 +22,8 @@ export interface ModalFichaClienteProps {
   onClose: () => void;
   onRegistrarPago?: (cliente: ClienteDB) => void;
   onVerPedido?: (pedido: PedidoDB) => void;
+  /** Abre el modal de cambio/devolución como parada con el cliente fijo. */
+  onCambioEnRuta?: (cliente: ClienteDB) => void;
 }
 
 /** Colores de tarjeta estadistica */
@@ -42,7 +44,7 @@ interface TabItem {
   icon: LucideIcon;
 }
 
-export default function ModalFichaCliente({ cliente, onClose, onRegistrarPago, onVerPedido }: ModalFichaClienteProps) {
+export default function ModalFichaCliente({ cliente, onClose, onRegistrarPago, onVerPedido, onCambioEnRuta }: ModalFichaClienteProps) {
   const { pedidosCliente, estadisticas, loading } = useFichaCliente(cliente?.id)
   const { pagos, loading: loadingPagos, fetchPagosCliente, obtenerResumenCuenta } = usePagos()
   const { perfil } = useAuthData()
@@ -172,6 +174,16 @@ export default function ModalFichaCliente({ cliente, onClose, onRegistrarPago, o
                 >
                   <Plus className="w-4 h-4" />
                   Registrar Pago
+                </button>
+              )}
+              {onCambioEnRuta && (
+                <button
+                  onClick={() => onCambioEnRuta(cliente)}
+                  className="ml-2 px-4 py-2 bg-indigo-600 hover:bg-indigo-700 text-white rounded-lg flex items-center gap-2"
+                  title="Agregar un cambio/devolución como parada del recorrido"
+                >
+                  <ArrowLeftRight className="w-4 h-4" />
+                  Cambio/devolución
                 </button>
               )}
             </div>

--- a/src/components/modals/ModalGestionRutas.tsx
+++ b/src/components/modals/ModalGestionRutas.tsx
@@ -3,12 +3,16 @@ import type { ChangeEvent } from 'react';
 import {
   Loader2, AlertTriangle, Check, Truck, MapPin, Route, Clock, Navigation,
   Settings, Save, FileText, ChevronDown, ChevronUp, Phone,
-  DollarSign, Package, CheckCircle, Circle, Printer, ArrowRight, CalendarDays, Pencil
+  DollarSign, Package, CheckCircle, Circle, Printer, ArrowRight, CalendarDays, Pencil,
+  ArrowLeftRight
 } from 'lucide-react';
 import ModalBase from './ModalBase';
+import ModalCambioProducto, { type CambioProductoSaveData } from './ModalCambioProducto';
 import { useDepositoCoords, useSetDepositoMutation, useDestinoCoords, useSetDestinoMutation, useRecorridoExistenteQuery } from '../../hooks/queries';
+import type { RegistrarCambioInput } from '../../hooks/queries';
+import type { RepartidorParam } from '../../hooks/useOptimizarRuta';
 import { fechaLocalISO, fechaHaceDias, formatFecha } from '../../utils/formatters';
-import type { PedidoDB, PerfilDB } from '../../types';
+import type { PedidoDB, PerfilDB, ClienteDB, ProductoDB } from '../../types';
 
 // =============================================================================
 // TIPOS
@@ -40,6 +44,23 @@ export interface AplicarOrdenData {
   duracion: number | null;
 }
 
+/** Resultado del split multi-repartidor: una ruta armada por chofer. */
+export interface RecorridoArmadoUI {
+  transportista_id: string;
+  transportista_nombre: string;
+  total_pedidos: number;
+  distancia_formato?: string;
+  duracion_formato?: string;
+  /** Paradas (pedido_id en orden) para reconstruir la lista en la vista resultado. */
+  pedido_ids: string[];
+}
+
+export interface RutaMultiResultadoUI {
+  recorridos: RecorridoArmadoUI[];
+  /** pedido_id de pedidos que no se pudieron asignar (capacidad). */
+  skipped: string[];
+}
+
 /** Pedido con orden optimizado extendido */
 interface PedidoOrdenado extends PedidoDB {
   orden_optimizado?: number;
@@ -57,11 +78,24 @@ interface PedidoRutaCardProps {
 export interface ModalGestionRutasProps {
   transportistas: PerfilDB[];
   pedidos: PedidoDB[];
+  /** Para el modal de cambio/devolución embebido (agregar parada). */
+  clientes?: ClienteDB[];
+  productos?: ProductoDB[];
+  /**
+   * Crea una parada de cambio (pedido especial canal='cambio') y devuelve su
+   * pedido_id, que se agrega automáticamente a la selección de la ruta.
+   */
+  onCrearCambio?: (data: RegistrarCambioInput) => Promise<string | null>;
   /**
    * Arma la ruta del día: optimiza los pedidos seleccionados y la guarda en
    * un solo paso (el container encadena optimizar + aplicar_orden_ruta).
    */
   onArmarRuta: (transportistaId: string, pedidos: PedidoDB[], fecha: string, horaInicio: string) => void;
+  /**
+   * Divide los pedidos seleccionados entre varios repartidores (N recorridos).
+   * Cada repartidor puede traer máx paradas y zonas preferidas.
+   */
+  onArmarRutaMulti?: (repartidores: RepartidorParam[], pedidos: PedidoDB[], fecha: string, horaInicio: string) => void;
   onExportarPDF: (transportista: PerfilDB | undefined, pedidos: PedidoOrdenado[]) => void;
   /** Imprime las comandas (duplicado por pedido) de la ruta recién armada. */
   onImprimirComandas?: (pedidos: PedidoOrdenado[]) => void;
@@ -70,6 +104,10 @@ export interface ModalGestionRutasProps {
   loading: boolean;
   guardando: boolean;
   rutaOptimizada: RutaOptimizadaResult | null;
+  /** Resultado del split multi-repartidor (vista de resultado). */
+  rutaMulti?: RutaMultiResultadoUI | null;
+  /** Zonas activas (para elegir zonas preferidas por chofer en modo dividir). */
+  zonas?: Array<{ id: string; nombre: string }>;
   error: string | null;
 }
 
@@ -177,15 +215,27 @@ const PedidoRutaCard = memo(function PedidoRutaCard({ pedido, orden, isFirst, is
 const ModalGestionRutas = memo(function ModalGestionRutas({
   transportistas,
   pedidos,
+  clientes = [],
+  productos = [],
+  onCrearCambio,
   onArmarRuta,
+  onArmarRutaMulti,
   onExportarPDF,
   onImprimirComandas,
   onClose,
   loading,
   guardando,
   rutaOptimizada,
+  rutaMulti = null,
+  zonas = [],
   error
 }: ModalGestionRutasProps) {
+  const [cambioOpen, setCambioOpen] = useState<boolean>(false);
+  // Modo de armado: un solo chofer (con edición in-place) o dividir entre varios.
+  const [modoDividir, setModoDividir] = useState<boolean>(false);
+  // Modo dividir: repartidores elegidos + sus parámetros (máx paradas, zonas).
+  const [repartidoresSel, setRepartidoresSel] = useState<Set<string>>(new Set());
+  const [paramsPorChofer, setParamsPorChofer] = useState<Record<string, { maxParadas: string; zonas: string[] }>>({});
   const [transportistaSeleccionado, setTransportistaSeleccionado] = useState<string>('');
   // Fecha de entrega de la ruta. Generalmente se arma el día anterior, así que
   // el default es mañana; se puede elegir de hoy en adelante.
@@ -232,6 +282,13 @@ const ModalGestionRutas = memo(function ModalGestionRutas({
     }
   }, [rutaOptimizada]);
 
+  // Modo dividir: pasar a la vista resultado cuando llega el split armado.
+  useEffect(() => {
+    if ((rutaMulti?.recorridos?.length ?? 0) > 0) {
+      setVistaActiva('resultado');
+    }
+  }, [rutaMulti]);
+
   const filtroActivo = !!(filtroDesde || filtroHasta);
 
   // Ruta ya armada (en_curso) de este transportista+fecha: sus paradas se
@@ -258,25 +315,36 @@ const ModalGestionRutas = memo(function ModalGestionRutas({
     });
   }, [pedidos, filtroActivo, filtroDesde, filtroHasta]);
 
-  // Lista visible al elegir transportista: paradas de su ruta (si existe) +
-  // disponibles, sin duplicar (las paradas existentes ganan y van primero).
+  // Lista visible. En modo dividir: todo el pool (no hay edición in-place). En
+  // modo 1 chofer: paradas de su ruta (si existe) + disponibles, sin duplicar
+  // (las paradas existentes ganan y van primero).
   const pedidosVisibles = useMemo((): PedidoDB[] => {
+    if (modoDividir) {
+      return [...disponiblesFiltrados].sort((a, b) => (a.orden_entrega || 999) - (b.orden_entrega || 999));
+    }
     if (!transportistaSeleccionado) return [];
     const map = new Map<string, PedidoDB>();
     for (const p of paradasExistentes) map.set(p.id, p);
     for (const p of disponiblesFiltrados) if (!map.has(p.id)) map.set(p.id, p);
     return Array.from(map.values())
       .sort((a, b) => (a.orden_entrega || 999) - (b.orden_entrega || 999));
-  }, [transportistaSeleccionado, paradasExistentes, disponiblesFiltrados]);
+  }, [modoDividir, transportistaSeleccionado, paradasExistentes, disponiblesFiltrados]);
 
-  // Selección de paradas. Se siembra una vez por (transportista, fecha): en
-  // edición, con las paradas de la ruta existente; en ruta nueva, vacía (el
-  // admin tilda las que entran). No se re-siembra en refetch para no pisar la
-  // selección en curso.
+  // Selección de paradas. En modo dividir se siembra con TODO el pool (el caso
+  // común es rutear todo y dividir). En modo 1 chofer se siembra una vez por
+  // (transportista, fecha): en edición con las paradas existentes; en ruta
+  // nueva, vacía. No se re-siembra en refetch para no pisar la selección.
   const [seleccionados, setSeleccionados] = useState<Set<string>>(new Set());
-  const rutaKey = `${transportistaSeleccionado}|${fechaEntrega}`;
+  const rutaKey = modoDividir ? `multi|${fechaEntrega}` : `${transportistaSeleccionado}|${fechaEntrega}`;
   const seededKeyRef = useRef<string>('');
   useEffect(() => {
+    if (modoDividir) {
+      if (seededKeyRef.current === rutaKey) return;
+      if (pedidos.length === 0) return; // esperar a que cargue el pool
+      seededKeyRef.current = rutaKey;
+      setSeleccionados(new Set(disponiblesFiltrados.map(p => p.id)));
+      return;
+    }
     if (!transportistaSeleccionado) {
       if (seededKeyRef.current !== '') { setSeleccionados(new Set()); seededKeyRef.current = ''; }
       return;
@@ -285,7 +353,7 @@ const ModalGestionRutas = memo(function ModalGestionRutas({
     if (seededKeyRef.current === rutaKey) return;
     seededKeyRef.current = rutaKey;
     setSeleccionados(new Set(paradasExistentes.map(p => p.id)));
-  }, [transportistaSeleccionado, rutaKey, rutaExistente, paradasExistentes]);
+  }, [modoDividir, transportistaSeleccionado, rutaKey, rutaExistente, paradasExistentes, disponiblesFiltrados, pedidos.length]);
 
   const pedidosSeleccionados = useMemo(
     () => pedidosVisibles.filter(p => seleccionados.has(p.id)),
@@ -377,6 +445,54 @@ const ModalGestionRutas = memo(function ModalGestionRutas({
     }
   };
 
+  // === Modo dividir: repartidores + parámetros ===
+  const toggleRepartidor = (id: string): void => {
+    setRepartidoresSel(prev => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id); else next.add(id);
+      return next;
+    });
+  };
+  const setMaxParadas = (id: string, valor: string): void => {
+    setParamsPorChofer(prev => ({ ...prev, [id]: { maxParadas: valor, zonas: prev[id]?.zonas ?? [] } }));
+  };
+  const toggleZonaChofer = (id: string, zonaId: string): void => {
+    setParamsPorChofer(prev => {
+      const actual = prev[id] ?? { maxParadas: '', zonas: [] };
+      const zonas = actual.zonas.includes(zonaId)
+        ? actual.zonas.filter(z => z !== zonaId)
+        : [...actual.zonas, zonaId];
+      return { ...prev, [id]: { ...actual, zonas } };
+    });
+  };
+
+  const repartidoresParam = useMemo((): RepartidorParam[] => {
+    return Array.from(repartidoresSel).map(id => {
+      const pp = paramsPorChofer[id] ?? { maxParadas: '', zonas: [] };
+      const max = parseInt(pp.maxParadas, 10);
+      return {
+        transportista_id: id,
+        max_paradas: Number.isFinite(max) && max > 0 ? max : null,
+        zonas_preferidas: pp.zonas.length ? pp.zonas.map(z => Number(z)) : null,
+      };
+    });
+  }, [repartidoresSel, paramsPorChofer]);
+
+  const handleDividir = (): void => {
+    if (onArmarRutaMulti && repartidoresParam.length > 0 && pedidosSeleccionados.length > 0) {
+      onArmarRutaMulti(repartidoresParam, pedidosSeleccionados, fechaEntrega, horaInicio);
+    }
+  };
+
+  // Crea la parada de cambio y la agrega (pre-tildada) a la selección de la
+  // ruta. El pool se refresca e incorpora el pedido de cambio recién creado.
+  const handleGuardarCambio = async (data: CambioProductoSaveData): Promise<void> => {
+    if (!onCrearCambio) return;
+    const id = await onCrearCambio(data as RegistrarCambioInput);
+    if (id) setSeleccionados(prev => { const n = new Set(prev); n.add(id); return n; });
+    setCambioOpen(false);
+  };
+
   const handleGuardarDeposito = (): void => {
     const lat = parseFloat(depositoLat);
     const lng = parseFloat(depositoLng);
@@ -421,6 +537,7 @@ const ModalGestionRutas = memo(function ModalGestionRutas({
   const transportistaInfo = transportistas.find(t => t.id === transportistaSeleccionado);
 
   return (
+    <>
     <ModalBase title="Armar ruta del día" onClose={onClose} maxWidth="max-w-4xl">
       <div className="flex flex-col h-[75vh]">
         {/* Tabs de navegacion */}
@@ -437,8 +554,8 @@ const ModalGestionRutas = memo(function ModalGestionRutas({
             Armar ruta
           </button>
           <button
-            onClick={() => rutaOptimizada?.orden_optimizado && setVistaActiva('resultado')}
-            disabled={!rutaOptimizada?.orden_optimizado}
+            onClick={() => (rutaOptimizada?.orden_optimizado || rutaMulti) && setVistaActiva('resultado')}
+            disabled={!rutaOptimizada?.orden_optimizado && !rutaMulti}
             className={`px-4 py-3 text-sm font-medium border-b-2 transition-colors ${
               vistaActiva === 'resultado'
                 ? 'border-green-500 text-green-600'
@@ -446,8 +563,12 @@ const ModalGestionRutas = memo(function ModalGestionRutas({
             }`}
           >
             <CheckCircle className="w-4 h-4 inline mr-2" />
-            Ruta guardada
-            {rutaOptimizada?.orden_optimizado && (
+            {rutaMulti ? 'Rutas guardadas' : 'Ruta guardada'}
+            {rutaMulti ? (
+              <span className="ml-2 px-2 py-0.5 bg-green-100 text-green-700 text-xs rounded-full">
+                {rutaMulti.recorridos.length}
+              </span>
+            ) : rutaOptimizada?.orden_optimizado && (
               <span className="ml-2 px-2 py-0.5 bg-green-100 text-green-700 text-xs rounded-full">
                 {rutaOptimizada.orden_optimizado.length}
               </span>
@@ -653,29 +774,108 @@ const ModalGestionRutas = memo(function ModalGestionRutas({
                 </div>
               </div>
 
-              {/* Selector de transportista */}
-              <div className="bg-white border rounded-lg p-4">
-                <label className="block text-sm font-medium mb-2">Seleccionar Transportista</label>
-                <select
-                  value={transportistaSeleccionado}
-                  onChange={(e: ChangeEvent<HTMLSelectElement>) => setTransportistaSeleccionado(e.target.value)}
-                  className="w-full px-3 py-2 border rounded-lg"
-                  disabled={loading}
-                >
-                  <option value="">Seleccionar transportista...</option>
-                  {transportistas.map(t => (
-                    <option key={t.id} value={t.id}>
-                      {t.nombre}
-                    </option>
-                  ))}
-                </select>
-              </div>
+              {/* Modo: un transportista (con edición) o dividir entre varios */}
+              {onArmarRutaMulti && (
+                <div className="bg-white border rounded-lg p-1.5 flex gap-1.5">
+                  <button
+                    type="button"
+                    onClick={() => setModoDividir(false)}
+                    className={`flex-1 px-3 py-2 text-sm font-medium rounded-lg transition-colors ${!modoDividir ? 'bg-blue-600 text-white' : 'text-gray-600 hover:bg-gray-100'}`}
+                  >
+                    Un transportista
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => setModoDividir(true)}
+                    className={`flex-1 px-3 py-2 text-sm font-medium rounded-lg transition-colors ${modoDividir ? 'bg-blue-600 text-white' : 'text-gray-600 hover:bg-gray-100'}`}
+                  >
+                    Dividir entre varios
+                  </button>
+                </div>
+              )}
 
-              {/* Info del transportista */}
-              {transportistaSeleccionado && (
+              {/* Selector de transportista (modo 1 chofer) */}
+              {!modoDividir ? (
+                <div className="bg-white border rounded-lg p-4">
+                  <label className="block text-sm font-medium mb-2">Seleccionar Transportista</label>
+                  <select
+                    value={transportistaSeleccionado}
+                    onChange={(e: ChangeEvent<HTMLSelectElement>) => setTransportistaSeleccionado(e.target.value)}
+                    className="w-full px-3 py-2 border rounded-lg"
+                    disabled={loading}
+                  >
+                    <option value="">Seleccionar transportista...</option>
+                    {transportistas.map(t => (
+                      <option key={t.id} value={t.id}>
+                        {t.nombre}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+              ) : (
+                /* Repartidores disponibles + parámetros (modo dividir) */
+                <div className="bg-white border rounded-lg p-4 space-y-2">
+                  <label className="block text-sm font-medium">Repartidores disponibles</label>
+                  {transportistas.map(t => {
+                    const checked = repartidoresSel.has(t.id);
+                    const pp = paramsPorChofer[t.id] ?? { maxParadas: '', zonas: [] };
+                    return (
+                      <div key={t.id} className={`border rounded-lg p-2.5 ${checked ? 'border-blue-300 bg-blue-50/40' : 'border-gray-200'}`}>
+                        <label className="flex items-center gap-2 cursor-pointer">
+                          <input type="checkbox" checked={checked} onChange={() => toggleRepartidor(t.id)} className="rounded" />
+                          <span className="font-medium text-gray-800">{t.nombre}</span>
+                        </label>
+                        {checked && (
+                          <div className="mt-2 pl-6 space-y-2">
+                            <div className="flex items-center gap-2">
+                              <label className="text-xs text-gray-500">Máx paradas</label>
+                              <input
+                                type="number"
+                                min="1"
+                                inputMode="numeric"
+                                value={pp.maxParadas}
+                                onChange={(e: ChangeEvent<HTMLInputElement>) => setMaxParadas(t.id, e.target.value)}
+                                placeholder="sin tope"
+                                className="w-28 px-2 py-1 border rounded text-sm"
+                              />
+                            </div>
+                            {zonas.length > 0 && (
+                              <div>
+                                <p className="text-xs text-gray-500 mb-1">Zonas preferidas</p>
+                                <div className="flex flex-wrap gap-1">
+                                  {zonas.map(z => {
+                                    const on = pp.zonas.includes(z.id);
+                                    return (
+                                      <button
+                                        key={z.id}
+                                        type="button"
+                                        onClick={() => toggleZonaChofer(t.id, z.id)}
+                                        className={`px-2 py-0.5 text-xs rounded-full border ${on ? 'bg-blue-600 text-white border-blue-600' : 'bg-white text-gray-600 border-gray-300 hover:bg-gray-50'}`}
+                                      >
+                                        {z.nombre}
+                                      </button>
+                                    );
+                                  })}
+                                </div>
+                              </div>
+                            )}
+                          </div>
+                        )}
+                      </div>
+                    );
+                  })}
+                  <p className="text-xs text-gray-500">
+                    Sin tope = se reparte lo más parejo posible. Las zonas son una preferencia (no estricta).
+                  </p>
+                </div>
+              )}
+
+              {/* Info / lista de pedidos: visible al elegir transportista (single)
+                  o siempre en modo dividir. */}
+              {(modoDividir || transportistaSeleccionado) && (
                 <>
-                  {/* Edición de ruta existente: aviso de que se modificará la armada */}
-                  {editando && (
+                  {/* Edición de ruta existente (solo modo 1 chofer) */}
+                  {!modoDividir && editando && (
                     <div className="bg-amber-50 border border-amber-200 rounded-lg p-3 flex items-start gap-2">
                       <Pencil className="w-5 h-5 text-amber-600 mt-0.5 flex-shrink-0" />
                       <p className="text-sm text-amber-800">
@@ -685,23 +885,43 @@ const ModalGestionRutas = memo(function ModalGestionRutas({
                     </div>
                   )}
 
-                  <div className="bg-gradient-to-r from-blue-500 to-blue-600 rounded-xl p-4 text-white">
-                    <div className="flex items-center justify-between">
-                      <div className="flex items-center space-x-3">
-                        <div className="w-12 h-12 bg-white/20 rounded-full flex items-center justify-center">
-                          <Truck className="w-6 h-6" />
+                  {modoDividir ? (
+                    <div className="bg-gradient-to-r from-indigo-500 to-indigo-600 rounded-xl p-4 text-white">
+                      <div className="flex items-center justify-between">
+                        <div className="flex items-center space-x-3">
+                          <div className="w-12 h-12 bg-white/20 rounded-full flex items-center justify-center">
+                            <Truck className="w-6 h-6" />
+                          </div>
+                          <div>
+                            <h3 className="font-semibold text-lg">{repartidoresSel.size} repartidor(es)</h3>
+                            <p className="text-indigo-100 text-sm">{pedidosSeleccionados.length} paradas a dividir</p>
+                          </div>
                         </div>
-                        <div>
-                          <h3 className="font-semibold text-lg">{transportistaInfo?.nombre}</h3>
-                          <p className="text-blue-100 text-sm">{pedidosSeleccionados.length} paradas seleccionadas</p>
+                        <div className="text-right">
+                          <p className="text-2xl font-bold">${totales.total.toLocaleString('es-AR')}</p>
+                          <p className="text-indigo-100 text-sm">Total a cobrar</p>
                         </div>
-                      </div>
-                      <div className="text-right">
-                        <p className="text-2xl font-bold">${totales.total.toLocaleString('es-AR')}</p>
-                        <p className="text-blue-100 text-sm">Total a cobrar</p>
                       </div>
                     </div>
-                  </div>
+                  ) : (
+                    <div className="bg-gradient-to-r from-blue-500 to-blue-600 rounded-xl p-4 text-white">
+                      <div className="flex items-center justify-between">
+                        <div className="flex items-center space-x-3">
+                          <div className="w-12 h-12 bg-white/20 rounded-full flex items-center justify-center">
+                            <Truck className="w-6 h-6" />
+                          </div>
+                          <div>
+                            <h3 className="font-semibold text-lg">{transportistaInfo?.nombre}</h3>
+                            <p className="text-blue-100 text-sm">{pedidosSeleccionados.length} paradas seleccionadas</p>
+                          </div>
+                        </div>
+                        <div className="text-right">
+                          <p className="text-2xl font-bold">${totales.total.toLocaleString('es-AR')}</p>
+                          <p className="text-blue-100 text-sm">Total a cobrar</p>
+                        </div>
+                      </div>
+                    </div>
+                  )}
 
                   {/* Advertencia de pedidos sin coordenadas */}
                   {pedidosSinCoordenadas.length > 0 && (
@@ -724,6 +944,19 @@ const ModalGestionRutas = memo(function ModalGestionRutas({
                         </div>
                       </div>
                     </div>
+                  )}
+
+                  {/* Agregar una parada de cambio/devolución (no es un pedido):
+                      crea el pedido especial y lo suma pre-tildado a la ruta. */}
+                  {onCrearCambio && (
+                    <button
+                      type="button"
+                      onClick={() => setCambioOpen(true)}
+                      className="w-full flex items-center justify-center gap-2 px-4 py-2.5 border-2 border-dashed border-indigo-300 text-indigo-700 rounded-lg hover:bg-indigo-50 text-sm font-medium transition-colors"
+                    >
+                      <ArrowLeftRight className="w-4 h-4" />
+                      Agregar cambio/devolución
+                    </button>
                   )}
 
                   {/* Lista de pedidos: el admin elige cuáles entran en la ruta del
@@ -799,6 +1032,58 @@ const ModalGestionRutas = memo(function ModalGestionRutas({
                   </div>
                 </div>
               )}
+            </div>
+          ) : rutaMulti ? (
+            /* Vista de resultado: split multi-repartidor */
+            <div className="space-y-4">
+              <div className="bg-gradient-to-r from-green-500 to-green-600 rounded-xl p-4 text-white">
+                <div className="flex items-center gap-3">
+                  <div className="w-12 h-12 bg-white/20 rounded-full flex items-center justify-center">
+                    <Route className="w-6 h-6" />
+                  </div>
+                  <div>
+                    <h3 className="font-semibold text-lg">Ruta dividida y guardada</h3>
+                    <p className="text-green-100 text-sm">{rutaMulti.recorridos.length} recorrido(s) · {formatFecha(fechaEntrega)}</p>
+                  </div>
+                </div>
+              </div>
+
+              {rutaMulti.skipped.length > 0 && (
+                <div className="bg-yellow-50 border border-yellow-200 rounded-lg p-3 flex items-start gap-2">
+                  <AlertTriangle className="w-5 h-5 text-yellow-600 mt-0.5 flex-shrink-0" />
+                  <p className="text-sm text-yellow-800">
+                    {rutaMulti.skipped.length} pedido(s) no se pudieron asignar (capacidad). Subí el máximo de paradas o sumá un repartidor.
+                  </p>
+                </div>
+              )}
+
+              <div className="space-y-2">
+                {rutaMulti.recorridos.map(r => (
+                  <div key={r.transportista_id} className="bg-white border rounded-lg p-4">
+                    <div className="flex items-center justify-between">
+                      <div className="flex items-center gap-2">
+                        <div className="w-9 h-9 bg-blue-100 rounded-full flex items-center justify-center">
+                          <Truck className="w-5 h-5 text-blue-600" />
+                        </div>
+                        <span className="font-semibold text-gray-800">{r.transportista_nombre}</span>
+                      </div>
+                      <span className="px-2 py-0.5 bg-green-100 text-green-700 text-xs font-medium rounded-full">
+                        {r.total_pedidos} paradas
+                      </span>
+                    </div>
+                    {(r.distancia_formato || r.duracion_formato) && (
+                      <div className="mt-2 flex gap-4 text-xs text-gray-500">
+                        {r.duracion_formato && <span className="flex items-center gap-1"><Clock className="w-3.5 h-3.5" />{r.duracion_formato}</span>}
+                        {r.distancia_formato && <span className="flex items-center gap-1"><Navigation className="w-3.5 h-3.5" />{r.distancia_formato}</span>}
+                      </div>
+                    )}
+                  </div>
+                ))}
+              </div>
+
+              <p className="text-xs text-gray-500">
+                Cada repartidor ya tiene su recorrido del día. Las hojas de ruta por chofer se descargan desde la pantalla de Recorridos.
+              </p>
             </div>
           ) : (
             /* Vista de resultado */
@@ -920,21 +1205,34 @@ const ModalGestionRutas = memo(function ModalGestionRutas({
 
           <div className="flex space-x-3">
             {vistaActiva === 'optimizar' ? (
-              <button
-                onClick={handleArmar}
-                disabled={!transportistaSeleccionado || loading || guardando || pedidosSeleccionados.length === 0}
-                className="flex items-center space-x-2 px-5 py-2.5 bg-blue-600 text-white rounded-lg hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
-              >
-                {(loading || guardando) ? (
-                  <Loader2 className="w-5 h-5 animate-spin" />
-                ) : (
-                  <Route className="w-5 h-5" />
-                )}
-                <span>
-                  {loading ? 'Optimizando…' : guardando ? 'Guardando…' : `Armar ruta del día (${pedidosSeleccionados.length})`}
-                </span>
-              </button>
-            ) : (
+              modoDividir ? (
+                <button
+                  onClick={handleDividir}
+                  disabled={repartidoresSel.size === 0 || loading || guardando || pedidosSeleccionados.length === 0}
+                  className="flex items-center space-x-2 px-5 py-2.5 bg-indigo-600 text-white rounded-lg hover:bg-indigo-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+                >
+                  {(loading || guardando) ? <Loader2 className="w-5 h-5 animate-spin" /> : <Route className="w-5 h-5" />}
+                  <span>
+                    {loading ? 'Optimizando…' : guardando ? 'Guardando…' : `Dividir y armar (${repartidoresSel.size} chofer/es)`}
+                  </span>
+                </button>
+              ) : (
+                <button
+                  onClick={handleArmar}
+                  disabled={!transportistaSeleccionado || loading || guardando || pedidosSeleccionados.length === 0}
+                  className="flex items-center space-x-2 px-5 py-2.5 bg-blue-600 text-white rounded-lg hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+                >
+                  {(loading || guardando) ? (
+                    <Loader2 className="w-5 h-5 animate-spin" />
+                  ) : (
+                    <Route className="w-5 h-5" />
+                  )}
+                  <span>
+                    {loading ? 'Optimizando…' : guardando ? 'Guardando…' : `Armar ruta del día (${pedidosSeleccionados.length})`}
+                  </span>
+                </button>
+              )
+            ) : rutaMulti ? null : (
               <>
                 <button
                   onClick={handleExportarPDF}
@@ -958,6 +1256,18 @@ const ModalGestionRutas = memo(function ModalGestionRutas({
         </div>
       </div>
     </ModalBase>
+
+    {/* Cambio/devolución como parada: se renderiza por encima del modal de ruta. */}
+    {cambioOpen && onCrearCambio && (
+      <ModalCambioProducto
+        clientes={clientes}
+        productos={productos}
+        modo="enRuta"
+        onSave={handleGuardarCambio}
+        onClose={() => setCambioOpen(false)}
+      />
+    )}
+    </>
   );
 });
 

--- a/src/components/pedidos/PedidoToolbar.tsx
+++ b/src/components/pedidos/PedidoToolbar.tsx
@@ -23,7 +23,7 @@
 import React from 'react';
 import {
   Plus, Route, FileDown, PackageCheck, Banknote, ChevronDown,
-  MapPin, History, Boxes, Download, type LucideIcon,
+  MapPin, History, Boxes, Download, ArrowLeftRight, type LucideIcon,
 } from 'lucide-react';
 import {
   DropdownMenu, DropdownMenuTrigger, DropdownMenuContent,
@@ -43,6 +43,8 @@ export interface PedidoToolbarProps {
   totalCount: number;
   onNuevoPedido: () => void;
   onOptimizarRuta: () => void;
+  /** Abre el modal de cambio/devolución como parada (admin/encargado). */
+  onCambioEnRuta?: () => void;
   onExportarPDF: () => void;
   onExportarExcel: (modo: 'pagina' | 'filtro') => void;
   onEntregasMasivas?: () => void;
@@ -178,6 +180,7 @@ export default function PedidoToolbar({
   totalCount,
   onNuevoPedido,
   onOptimizarRuta,
+  onCambioEnRuta,
   onExportarPDF,
   onExportarExcel,
   onEntregasMasivas,
@@ -274,6 +277,17 @@ export default function PedidoToolbar({
             >
               Armar ruta del día
             </ToolbarButton>
+            {onCambioEnRuta && (
+              <ToolbarButton
+                icon={ArrowLeftRight}
+                iconClassName="text-indigo-600"
+                mobileLabel="Cambio"
+                onClick={onCambioEnRuta}
+                title="Agregar un cambio/devolución como parada del recorrido"
+              >
+                Cambio/devolución
+              </ToolbarButton>
+            )}
           </div>
         )}
 
@@ -321,6 +335,17 @@ export default function PedidoToolbar({
             >
               Armar ruta del día
             </ToolbarButton>
+            {onCambioEnRuta && (
+              <ToolbarButton
+                icon={ArrowLeftRight}
+                iconClassName="text-indigo-600"
+                mobileLabel="Cambio"
+                onClick={onCambioEnRuta}
+                title="Agregar un cambio/devolución como parada del recorrido"
+              >
+                Cambio/devolución
+              </ToolbarButton>
+            )}
           </>
         )}
 

--- a/src/components/rutaActiva/SheetParada.tsx
+++ b/src/components/rutaActiva/SheetParada.tsx
@@ -9,7 +9,7 @@
  */
 import { useState, useEffect } from 'react';
 import {
-  Navigation, Square, Check, MapPin, Phone, AlertTriangle, Gift, ChevronRight, ChevronUp, ChevronDown, Map as MapIcon,
+  Navigation, Square, Check, MapPin, Phone, AlertTriangle, Gift, ChevronRight, ChevronUp, ChevronDown, Map as MapIcon, ArrowLeftRight,
 } from 'lucide-react';
 import { formatPrecio, getFormaPagoLabel } from '../../utils/formatters';
 import { formatDistancia } from '../../utils/geo';
@@ -46,6 +46,11 @@ function navUrl(p: PedidoConCliente): string {
     : googleMapsSearchUrl(p.cliente?.direccion || '');
 }
 
+/** ¿La parada es un cambio/devolución (pedido especial canal='cambio')? */
+function esCambio(p: PedidoConCliente | null | undefined): boolean {
+  return p?.canal === 'cambio';
+}
+
 /** Fila compacta de una parada (lista "Todas las paradas"). */
 function FilaParada({ parada, numero, activa, onSelect }: {
   parada: PedidoConCliente;
@@ -74,9 +79,15 @@ function FilaParada({ parada, numero, activa, onSelect }: {
           {parada.cliente?.direccion || 'Sin dirección'}
         </span>
       </span>
-      <span className="flex-shrink-0 text-sm font-semibold text-gray-700 dark:text-gray-300">
-        {formatPrecio(parada.total)}
-      </span>
+      {esCambio(parada) ? (
+        <span className="flex flex-shrink-0 items-center gap-1 rounded-full bg-indigo-100 px-2 py-0.5 text-[11px] font-semibold text-indigo-700 dark:bg-indigo-900/40 dark:text-indigo-300">
+          <ArrowLeftRight className="h-3 w-3" /> Cambio
+        </span>
+      ) : (
+        <span className="flex-shrink-0 text-sm font-semibold text-gray-700 dark:text-gray-300">
+          {formatPrecio(parada.total)}
+        </span>
+      )}
       <ChevronRight className="h-4 w-4 flex-shrink-0 text-gray-400" />
     </button>
   );
@@ -150,27 +161,56 @@ export default function SheetParada({
                   </div>
                 </div>
 
-                <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-sm">
-                  <span className={`rounded-full px-2 py-0.5 text-xs font-semibold ${
-                    paradaActiva.estado_pago === 'pagado'
-                      ? 'bg-green-100 text-green-700 dark:bg-green-900/40 dark:text-green-300'
-                      : paradaActiva.estado_pago === 'parcial'
-                        ? 'bg-yellow-100 text-yellow-700 dark:bg-yellow-900/40 dark:text-yellow-300'
-                        : 'bg-red-100 text-red-700 dark:bg-red-900/40 dark:text-red-300'
-                  }`}>
-                    {paradaActiva.estado_pago === 'pagado' ? 'PAGADO' : paradaActiva.estado_pago === 'parcial' ? 'PARCIAL' : 'A COBRAR'}
-                  </span>
-                  <span className="text-gray-500 dark:text-gray-400">
-                    {getFormaPagoLabel(paradaActiva.forma_pago || '')}
-                  </span>
-                  <span className="font-semibold text-gray-900 dark:text-white">{formatPrecio(paradaActiva.total)}</span>
-                  {paradaActiva.cliente?.telefono && (
-                    <a href={`tel:${paradaActiva.cliente.telefono}`} className="inline-flex items-center gap-1 text-blue-600 dark:text-blue-400">
-                      <Phone className="h-3.5 w-3.5" />
-                      {paradaActiva.cliente.telefono}
-                    </a>
-                  )}
-                </div>
+                {esCambio(paradaActiva) ? (
+                  <div className="space-y-2">
+                    <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-sm">
+                      <span className="inline-flex items-center gap-1 rounded-full bg-indigo-100 px-2 py-0.5 text-xs font-semibold text-indigo-700 dark:bg-indigo-900/40 dark:text-indigo-300">
+                        <ArrowLeftRight className="h-3.5 w-3.5" /> CAMBIO/DEVOLUCIÓN
+                      </span>
+                      {paradaActiva.cliente?.telefono && (
+                        <a href={`tel:${paradaActiva.cliente.telefono}`} className="inline-flex items-center gap-1 text-blue-600 dark:text-blue-400">
+                          <Phone className="h-3.5 w-3.5" />
+                          {paradaActiva.cliente.telefono}
+                        </a>
+                      )}
+                    </div>
+                    <div className="space-y-1 rounded-lg border border-indigo-200 bg-indigo-50 p-2.5 text-sm dark:border-indigo-800 dark:bg-indigo-900/20">
+                      <p className="text-gray-700 dark:text-gray-200">
+                        <strong>Retirar del cliente:</strong>{' '}
+                        {(paradaActiva.cambio?.cantidad_devuelta ?? '?')}x {paradaActiva.cambio?.producto_devuelto_nombre || 'producto'}
+                      </p>
+                      <p className="text-gray-700 dark:text-gray-200">
+                        <strong>Entregar al cliente:</strong>{' '}
+                        {(paradaActiva.cambio?.cantidad_entregada ?? '?')}x {paradaActiva.cambio?.producto_entregado_nombre || 'producto'}
+                      </p>
+                      {paradaActiva.cambio?.observaciones && (
+                        <p className="italic text-gray-500 dark:text-gray-400">{paradaActiva.cambio.observaciones}</p>
+                      )}
+                    </div>
+                  </div>
+                ) : (
+                  <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-sm">
+                    <span className={`rounded-full px-2 py-0.5 text-xs font-semibold ${
+                      paradaActiva.estado_pago === 'pagado'
+                        ? 'bg-green-100 text-green-700 dark:bg-green-900/40 dark:text-green-300'
+                        : paradaActiva.estado_pago === 'parcial'
+                          ? 'bg-yellow-100 text-yellow-700 dark:bg-yellow-900/40 dark:text-yellow-300'
+                          : 'bg-red-100 text-red-700 dark:bg-red-900/40 dark:text-red-300'
+                    }`}>
+                      {paradaActiva.estado_pago === 'pagado' ? 'PAGADO' : paradaActiva.estado_pago === 'parcial' ? 'PARCIAL' : 'A COBRAR'}
+                    </span>
+                    <span className="text-gray-500 dark:text-gray-400">
+                      {getFormaPagoLabel(paradaActiva.forma_pago || '')}
+                    </span>
+                    <span className="font-semibold text-gray-900 dark:text-white">{formatPrecio(paradaActiva.total)}</span>
+                    {paradaActiva.cliente?.telefono && (
+                      <a href={`tel:${paradaActiva.cliente.telefono}`} className="inline-flex items-center gap-1 text-blue-600 dark:text-blue-400">
+                        <Phone className="h-3.5 w-3.5" />
+                        {paradaActiva.cliente.telefono}
+                      </a>
+                    )}
+                  </div>
+                )}
 
                 {paradaActiva.notas && (
                   <p className="rounded-lg border border-yellow-200 bg-yellow-50 p-2 text-xs text-yellow-800 dark:border-yellow-800 dark:bg-yellow-900/20 dark:text-yellow-300">
@@ -210,7 +250,7 @@ export default function SheetParada({
                     }`}
                   >
                     <Check className="h-5 w-5" />
-                    Entregar
+                    {esCambio(paradaActiva) ? 'Completar cambio' : 'Entregar'}
                   </button>
                 </div>
               </div>
@@ -331,7 +371,7 @@ export default function SheetParada({
                   onClick={() => entregar(paradaActiva)}
                   className="flex h-12 flex-shrink-0 items-center gap-1.5 rounded-xl bg-green-600 px-4 text-sm font-semibold text-white active:bg-green-800"
                 >
-                  <Check className="h-5 w-5" /> Entregar
+                  <Check className="h-5 w-5" /> {esCambio(paradaActiva) ? 'Completar' : 'Entregar'}
                 </button>
               ) : guiando && onToggleGuia ? (
                 <button

--- a/src/components/vistas/VistaPedidos.tsx
+++ b/src/components/vistas/VistaPedidos.tsx
@@ -54,6 +54,7 @@ export interface VistaPedidosProps {
   onPageChange: (page: number) => void;
   onNuevoPedido: () => void;
   onOptimizarRuta: () => void;
+  onCambioEnRuta?: () => void;
   onExportarPDF: () => void;
   onExportarExcel: (modo: 'pagina' | 'filtro') => void;
   onModalFiltroFecha: () => void;
@@ -124,6 +125,7 @@ export default function VistaPedidos({
   onPageChange,
   onNuevoPedido,
   onOptimizarRuta,
+  onCambioEnRuta,
   onExportarPDF,
   onExportarExcel,
   onModalFiltroFecha,
@@ -175,6 +177,7 @@ export default function VistaPedidos({
             totalCount={totalCount}
             onNuevoPedido={onNuevoPedido}
             onOptimizarRuta={onOptimizarRuta}
+            onCambioEnRuta={onCambioEnRuta}
             onExportarPDF={onExportarPDF}
             onExportarExcel={onExportarExcel}
             onEntregasMasivas={onEntregasMasivas}

--- a/src/hooks/queries/index.ts
+++ b/src/hooks/queries/index.ts
@@ -118,6 +118,8 @@ export {
 export {
   cambiosProductosKeys,
   useRegistrarCambioProductoMutation,
+  useCrearPedidoCambioEnRutaMutation,
+  useAplicarCambioParadaMutation,
 } from './useCambiosProductosQuery'
 export type { RegistrarCambioInput } from './useCambiosProductosQuery'
 

--- a/src/hooks/queries/useCambiosProductosQuery.ts
+++ b/src/hooks/queries/useCambiosProductosQuery.ts
@@ -59,3 +59,77 @@ export function useRegistrarCambioProductoMutation() {
     },
   })
 }
+
+// ============================================================================
+// Cambio como PARADA del recorrido (mig 089)
+// ============================================================================
+
+/**
+ * Crea un pedido especial canal='cambio' (total 0) + su detalle en
+ * recorrido_cambios para sumarlo como parada del recorrido. NO ajusta
+ * stock/saldo todavía (eso ocurre al completar la parada). Devuelve el
+ * pedido_id creado.
+ */
+async function crearPedidoCambioEnRuta(input: RegistrarCambioInput): Promise<number> {
+  const { data, error } = await supabase.rpc('crear_pedido_cambio_en_ruta', {
+    p_cliente_id: Number(input.clienteId),
+    p_producto_devuelto_id: Number(input.productoDevueltoId),
+    p_cantidad_devuelta: input.cantidadDevuelta,
+    p_producto_entregado_id: Number(input.productoEntregadoId),
+    p_cantidad_entregada: input.cantidadEntregada,
+    p_observaciones: input.observaciones || null,
+  })
+
+  if (error) throw error
+  return data as number
+}
+
+/**
+ * Hook para crear una parada de cambio. Solo invalida pedidos (la parada
+ * aparece en el pool rutable); stock/saldo no se tocan hasta completarla.
+ */
+export function useCrearPedidoCambioEnRutaMutation() {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: crearPedidoCambioEnRuta,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['pedidos'] })
+    },
+  })
+}
+
+/**
+ * Aplica el cambio real de una parada al completarla (suma stock devuelto,
+ * resta entregado, ajusta saldo_cuenta, inserta cambios_productos). Idempotente
+ * en el backend. Devuelve el cambio_producto_id.
+ */
+async function aplicarCambioDeParada(pedidoId: string): Promise<number | null> {
+  const { data, error } = await supabase.rpc('aplicar_cambio_de_parada', {
+    p_pedido_id: Number(pedidoId),
+  })
+
+  if (error) throw error
+  return (data as number | null) ?? null
+}
+
+/**
+ * Hook para aplicar el cambio de una parada. Invalida productos (stock),
+ * clientes (saldo), la ruta activa del chofer y pedidos.
+ */
+export function useAplicarCambioParadaMutation() {
+  const queryClient = useQueryClient()
+  const { currentSucursalId } = useSucursal()
+
+  return useMutation({
+    mutationFn: aplicarCambioDeParada,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: productosKeys.lists(currentSucursalId) })
+      queryClient.invalidateQueries({ queryKey: productosKeys.stockBajo(currentSucursalId, 10) })
+      queryClient.invalidateQueries({ queryKey: clientesKeys.lists(currentSucursalId) })
+      queryClient.invalidateQueries({ queryKey: cambiosProductosKeys.lists(currentSucursalId) })
+      queryClient.invalidateQueries({ queryKey: ['recorrido-activo'] })
+      queryClient.invalidateQueries({ queryKey: ['pedidos'] })
+    },
+  })
+}

--- a/src/hooks/queries/usePedidosQuery.ts
+++ b/src/hooks/queries/usePedidosQuery.ts
@@ -77,7 +77,7 @@ interface ActualizarPagoInput {
 // inferencia de PostgREST: un string sin literal-type degradaria el resultado
 // a GenericStringError. Mantener sincronizado con el tipo PedidoDB.
 const PEDIDO_PRODUCT_COLS = 'id, nombre, codigo, categoria, unidades_de_venta_por_fardo, etiqueta_bulto' as const
-const PEDIDO_CLIENT_COLS = 'id, nombre_fantasia, razon_social, cuit, direccion, aclaracion_direccion, telefono, contacto, latitud, longitud, horarios_atencion, horario_entrega, zona' as const
+const PEDIDO_CLIENT_COLS = 'id, nombre_fantasia, razon_social, cuit, direccion, aclaracion_direccion, telefono, contacto, latitud, longitud, horarios_atencion, horario_entrega, zona, zona_id' as const
 // pagos(forma_pago, monto): permite a la card derivar la forma de pago real
 // (incluido "Combinado") sin queries extra. Los pagos combinados se guardan
 // como N filas en `pagos` (una por forma_pago); pedidos.forma_pago es el

--- a/src/hooks/queries/useRecorridoActivoQuery.ts
+++ b/src/hooks/queries/useRecorridoActivoQuery.ts
@@ -34,7 +34,8 @@ const RECORRIDO_ACTIVO_SELECT = `id, polylines,
     pedido:pedidos(
       *,
       cliente:clientes(id, nombre_fantasia, razon_social, direccion, aclaracion_direccion, telefono, contacto, latitud, longitud, horarios_atencion),
-      items:pedido_items(*, producto:productos(id, nombre, codigo, etiqueta_bulto, unidades_de_venta_por_fardo))
+      items:pedido_items(*, producto:productos(id, nombre, codigo, etiqueta_bulto, unidades_de_venta_por_fardo)),
+      cambio:recorrido_cambios(producto_devuelto_nombre, cantidad_devuelta, producto_entregado_nombre, cantidad_entregada, observaciones, aplicado_at)
     )
   )`
 
@@ -63,10 +64,18 @@ async function fetchRecorridoActivo(transportistaId: string): Promise<RecorridoA
     // El orden de entrega del recorrido es la fuente de verdad
     .sort((a, b) => (a.orden_entrega ?? 999) - (b.orden_entrega ?? 999))
 
-  const paradas = rps.map(rp => ({
-    ...(rp.pedido as object),
-    orden_entrega: rp.orden_entrega ?? rp.pedido?.orden_entrega ?? null,
-  })) as unknown as PedidoConCliente[]
+  const paradas = rps.map(rp => {
+    const pedido = rp.pedido as Record<string, unknown> & { orden_entrega?: number | null; cambio?: unknown }
+    // recorrido_cambios viene como objeto (FK única) o array según PostgREST:
+    // lo normalizamos a objeto | null.
+    const cambioRaw = pedido?.cambio
+    const cambio = Array.isArray(cambioRaw) ? (cambioRaw[0] ?? null) : (cambioRaw ?? null)
+    return {
+      ...pedido,
+      cambio,
+      orden_entrega: rp.orden_entrega ?? pedido?.orden_entrega ?? null,
+    }
+  }) as unknown as PedidoConCliente[]
 
   return {
     id: String(data.id),

--- a/src/hooks/useOptimizarRuta.ts
+++ b/src/hooks/useOptimizarRuta.ts
@@ -54,6 +54,39 @@ export interface VentanaPedido {
   fin: string;    // "HH:MM" (puede ser "24:00")
 }
 
+// === Split multi-repartidor ===
+
+/** Repartidor disponible + sus parámetros para el split. */
+export interface RepartidorParam {
+  transportista_id: string;
+  /** Tope de paradas (loadLimit). Vacío = sin tope. */
+  max_paradas?: number | null;
+  /** Zonas que prefiere (zona_id). Sesgo soft hacia este chofer. */
+  zonas_preferidas?: number[] | null;
+}
+
+/** Ruta optimizada de un repartidor (devuelta por el modo multi). */
+export interface RutaPorRepartidor {
+  transportista_id: string;
+  total_pedidos: number;
+  orden_optimizado: OrdenOptimizadoItem[];
+  polylines?: string[];
+  distancia_total?: number;
+  duracion_total?: number;
+  distancia_formato?: string;
+  duracion_formato?: string;
+}
+
+export interface RutaMultiVehiculoResponse {
+  success?: boolean;
+  recorridos: RutaPorRepartidor[];
+  pedidos_sin_coordenadas?: number;
+  pedidos_sin_coordenadas_ids?: string[];
+  skipped?: string[];
+  error?: string;
+  mensaje?: string;
+}
+
 export interface OptimizarRutaRequestBody {
   transportista_id: string;
   deposito_lat: number;
@@ -76,6 +109,8 @@ export interface UseOptimizarRutaReturn {
   rutaOptimizada: RutaOptimizadaResponse | null;
   error: string | null;
   optimizarRuta: (transportistaId: string, pedidos?: PedidoDB[], deposito?: DepositoCoords, destino?: DepositoCoords | null, opts?: { fecha?: string; horaInicio?: string }) => Promise<RutaOptimizadaResponse | null>;
+  /** Split multi-repartidor: divide los pedidos en N recorridos optimizados. */
+  optimizarRutaMulti: (repartidores: RepartidorParam[], pedidos?: PedidoDB[], deposito?: DepositoCoords, destino?: DepositoCoords | null, opts?: { fecha?: string; horaInicio?: string }) => Promise<RutaMultiVehiculoResponse | null>;
   /** Permite al caller reflejar la ruta realmente armada (p.ej. agregando las
    *  paradas sin coordenadas que el optimizador no devuelve) para que el modal
    *  muestre el resultado y los botones de hoja de ruta / comandas. */
@@ -319,6 +354,94 @@ export function useOptimizarRuta(): UseOptimizarRutaReturn {
   }, []);
 
   /**
+   * Optimización multi-repartidor: divide los pedidos seleccionados en N
+   * recorridos (uno por chofer). Devuelve un recorrido por repartidor con su
+   * orden_optimizado y polylines. NO toca `rutaOptimizada` (shape distinto): el
+   * caller maneja el resultado por chofer. Los pedidos sin coordenadas no entran
+   * (el caller los reparte) y se devuelven en pedidos_sin_coordenadas_ids.
+   */
+  const optimizarRutaMulti = useCallback(async (
+    repartidores: RepartidorParam[],
+    pedidos: PedidoDB[] = [],
+    deposito?: DepositoCoords,
+    destino?: DepositoCoords | null,
+    opts?: { fecha?: string; horaInicio?: string }
+  ): Promise<RutaMultiVehiculoResponse | null> => {
+    if (!repartidores.length) {
+      setError('Elegí al menos un repartidor');
+      return null;
+    }
+
+    const pedidosConCoordenadas = pedidos
+      .filter((p): p is PedidoDB & { cliente: ClienteDB & { latitud: number; longitud: number } } =>
+        p.cliente?.latitud != null && p.cliente?.longitud != null
+      )
+      .map(p => ({
+        pedido_id: p.id,
+        cliente_id: p.cliente_id,
+        cliente_nombre: p.cliente?.nombre_fantasia || 'Sin nombre',
+        direccion: p.cliente?.direccion || '',
+        latitud: p.cliente.latitud,
+        longitud: p.cliente.longitud,
+        // zona_id del cliente (para el sesgo por zona). Puede no venir.
+        zona_id: p.cliente?.zona_id != null ? Number(p.cliente.zona_id) : null,
+      }));
+
+    const ventanas: VentanaPedido[] = [];
+    for (const p of pedidos) {
+      const fr = parsearFranjas(p.cliente?.horario_entrega)[0];
+      if (fr?.apertura && fr?.cierre) {
+        ventanas.push({ pedido_id: p.id, inicio: fr.apertura, fin: fr.cierre });
+      }
+    }
+
+    if (pedidosConCoordenadas.length === 0) {
+      return {
+        success: true,
+        recorridos: [],
+        pedidos_sin_coordenadas: pedidos.length,
+        mensaje: 'No hay pedidos con coordenadas para optimizar',
+      };
+    }
+
+    setLoading(true);
+    setError(null);
+
+    const dep = deposito ?? getDepositoCoords();
+    const body = {
+      deposito_lat: dep.lat,
+      deposito_lng: dep.lng,
+      destino_lat: destino?.lat ?? null,
+      destino_lng: destino?.lng ?? null,
+      pedidos: pedidosConCoordenadas,
+      fecha: opts?.fecha,
+      hora_inicio: opts?.horaInicio,
+      ventanas: ventanas.length > 0 ? ventanas : undefined,
+      repartidores,
+    };
+
+    try {
+      const { data: fnData, error: fnError } = await supabase.functions.invoke(
+        'optimizar-ruta',
+        { body }
+      );
+      if (fnError) {
+        throw new Error(fnError.message || 'No se pudo contactar el servicio de optimización');
+      }
+      const data = fnData as RutaMultiVehiculoResponse;
+      if (data?.error) {
+        throw new Error(data.mensaje || data.error);
+      }
+      return data;
+    } catch (err) {
+      setError((err as Error).message || 'Error al dividir la ruta');
+      return null;
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  /**
    * Limpia los datos de la ruta optimizada
    */
   const limpiarRuta = useCallback((): void => {
@@ -331,6 +454,7 @@ export function useOptimizarRuta(): UseOptimizarRutaReturn {
     rutaOptimizada,
     error,
     optimizarRuta,
+    optimizarRutaMulti,
     setRutaOptimizada,
     limpiarRuta
   };

--- a/src/lib/pdf/hojaRutaOptimizada.js
+++ b/src/lib/pdf/hojaRutaOptimizada.js
@@ -92,6 +92,32 @@ function buildCardOps(doc, pedido, orderNumber) {
     ops.push({ kind: 'text', text: line, fontSize: 11, bold: true, advance: 5 })
   })
 
+  // Parada de cambio/devolución (canal='cambio'): cartel prominente + qué
+  // retirar/entregar (si el detalle está disponible en pedido.cambio).
+  const esCambio = pedido.canal === 'cambio'
+  if (esCambio) {
+    ops.push({ kind: 'text', text: '** CAMBIO / DEVOLUCION **', fontSize: 10, bold: true, advance: 5 })
+    // recorrido_cambios puede venir como objeto o array según el origen.
+    const c = Array.isArray(pedido.cambio) ? pedido.cambio[0] : pedido.cambio
+    if (c) {
+      const retirar = `Retirar: ${c.cantidad_devuelta ?? '?'}x ${c.producto_devuelto_nombre || 'producto'}`
+      const entregar = `Entregar: ${c.cantidad_entregada ?? '?'}x ${c.producto_entregado_nombre || 'producto'}`
+      doc.setFont('helvetica', 'normal')
+      doc.setFontSize(9)
+      doc.splitTextToSize(retirar, CARD_CONTENT_WIDTH).forEach((line) => {
+        ops.push({ kind: 'text', text: line, fontSize: 9, bold: false, advance: 4 })
+      })
+      doc.splitTextToSize(entregar, CARD_CONTENT_WIDTH).forEach((line) => {
+        ops.push({ kind: 'text', text: line, fontSize: 9, bold: false, advance: 4 })
+      })
+      if (c.observaciones) {
+        doc.splitTextToSize(`* ${c.observaciones}`, CARD_CONTENT_WIDTH).slice(0, 2).forEach((line) => {
+          ops.push({ kind: 'italic', text: line, fontSize: 8, advance: 3.5 })
+        })
+      }
+    }
+  }
+
   // Razon social en linea aparte si existe y difiere del nombre de fantasia
   if (pedido.cliente?.razon_social && pedido.cliente.razon_social !== pedido.cliente.nombre_fantasia) {
     doc.setFont('helvetica', 'normal')
@@ -240,15 +266,17 @@ function buildCardOps(doc, pedido, orderNumber) {
     })
   }
 
-  // Total pedido
-  ops.push({ kind: 'spacer', advance: 1 })
-  ops.push({
-    kind: 'total',
-    label: 'Total pedido:',
-    value: formatPrecio(pedido.total),
-    fontSize: 10,
-    advance: 4.5
-  })
+  // Total pedido (no aplica a paradas de cambio: total 0, no es una venta)
+  if (!esCambio) {
+    ops.push({ kind: 'spacer', advance: 1 })
+    ops.push({
+      kind: 'total',
+      label: 'Total pedido:',
+      value: formatPrecio(pedido.total),
+      fontSize: 10,
+      advance: 4.5
+    })
+  }
 
   // Notas
   if (pedido.notas) {

--- a/src/lib/pdf/reciboPedido.js
+++ b/src/lib/pdf/reciboPedido.js
@@ -373,6 +373,7 @@ function calcularAlturaComanda(pedido) {
   if (pedido.cliente?.horarios_atencion) height += 8 // horario (hasta 2 lineas)
   height += 10 // divider + header tabla productos
   height += items.length * 12 // productos (nombre puede envolver + detalle precio unit)
+  if (pedido.canal === 'cambio') height += 18 // banner CAMBIO/DEVOLUCION + retirar/entregar
   height += 32 // total + forma pago + estado
   if (pedido.estado_pago === 'parcial') height += 6
   if (pedido.notas) height += 18
@@ -448,6 +449,22 @@ function dibujarComanda(doc, pedido) {
 
   drawDivider(doc, y, margin, ticketWidth - margin, 0.3)
   y += 4
+
+  // === CAMBIO / DEVOLUCIÓN (parada canal='cambio'): banner + qué retirar/entregar ===
+  if (pedido.canal === 'cambio') {
+    setHeaderStyle(doc, 11)
+    doc.text('CAMBIO / DEVOLUCION', ticketWidth / 2, y, { align: 'center' })
+    y += 5
+    const c = Array.isArray(pedido.cambio) ? pedido.cambio[0] : pedido.cambio
+    setNormalStyle(doc, 9)
+    if (c) {
+      doc.splitTextToSize(`Retirar: ${c.cantidad_devuelta ?? '?'}x ${c.producto_devuelto_nombre || 'producto'}`, contentWidth)
+        .forEach(line => { doc.text(line, margin, y); y += 4 })
+      doc.splitTextToSize(`Entregar: ${c.cantidad_entregada ?? '?'}x ${c.producto_entregado_nombre || 'producto'}`, contentWidth)
+        .forEach(line => { doc.text(line, margin, y); y += 4 })
+    }
+    y += 1
+  }
 
   // === PRODUCTOS ===
   // Agrupamos bonificaciones repetidas: 3 filas de 2 unidades de la misma

--- a/src/types/hooks.ts
+++ b/src/types/hooks.ts
@@ -153,6 +153,22 @@ export interface PedidoDB {
   gps_accuracy?: number | null;
   gps_capturado_at?: string | null;
   gps_status?: 'ok' | 'denied' | 'unavailable' | 'timeout' | 'error' | null;
+  // Canal de origen del pedido. 'cambio' marca una parada de cambio/devolución
+  // (pedido especial total=0; mig 089), no una venta.
+  canal?: string;
+  // Detalle del cambio embebido (recorrido_cambios) cuando canal='cambio'.
+  // Lo adjunta la ruta activa del transportista para mostrar qué retirar/entregar.
+  cambio?: ParadaCambioDetalle | null;
+}
+
+/** Detalle de una parada de cambio/devolución (recorrido_cambios, mig 089). */
+export interface ParadaCambioDetalle {
+  producto_devuelto_nombre?: string | null;
+  cantidad_devuelta?: number | null;
+  producto_entregado_nombre?: string | null;
+  cantidad_entregada?: number | null;
+  observaciones?: string | null;
+  aplicado_at?: string | null;
 }
 
 export interface MermaDB {

--- a/supabase/functions/_shared/utils/promociones.ts
+++ b/supabase/functions/_shared/utils/promociones.ts
@@ -76,8 +76,11 @@ export function resolverPromociones(
   const bonificaciones: BonificacionResult[] = []
   const productosConPromo = new Set<string>()
 
-  // 1. Recolectar promos vistas en el pedido
-  const promosVistas = acumularPromos(items, promoMap, { skipOverride: true })
+  // 1. Recolectar promos vistas en el pedido.
+  //    skipOverride:false → un ítem con precio editado a mano SIGUE contando para
+  //    su promo (el precio manual cambia el precio, no la elegibilidad). Ej: regalar
+  //    un producto bajándole el precio no debe anular la botella de regalo de la promo.
+  const promosVistas = acumularPromos(items, promoMap, { skipOverride: false })
 
   for (const entry of promosVistas.values()) {
     for (const pid of entry.productoIdsEnPedido) productosConPromo.add(pid)

--- a/supabase/functions/optimizar-ruta/index.ts
+++ b/supabase/functions/optimizar-ruta/index.ts
@@ -24,7 +24,12 @@ import {
   type RutaUnida,
   unirTramos,
 } from "./tramos.ts";
-import { optimizeTours } from "./route-optimization.ts";
+import {
+  optimizeTours,
+  optimizeToursMulti,
+  type RepartidorVehiculo,
+  type PedidoRutaZona,
+} from "./route-optimization.ts";
 import { navegarTramo } from "./navegar-tramo.ts";
 
 const CORS_HEADERS: Record<string, string> = {
@@ -45,12 +50,14 @@ interface RequestBody {
   /** Punto de llegada para optimizar (opcional; si falta, fin = depósito). */
   destino_lat?: number | null;
   destino_lng?: number | null;
-  pedidos?: Array<Partial<PedidoRuta> & { latitud?: number | null; longitud?: number | null }>;
+  pedidos?: Array<Partial<PedidoRuta> & { latitud?: number | null; longitud?: number | null; zona_id?: number | null }>;
   /** Ancla temporal para respetar ventanas horarias (solo optimizeTours). */
   fecha?: string; // "YYYY-MM-DD"
   hora_inicio?: string; // "HH:MM"
   /** Ventanas de entrega por pedido (derivadas de cliente.horario_entrega). */
   ventanas?: Array<{ pedido_id: string | number; inicio: string; fin: string }>;
+  /** Split multi-repartidor: si viene (≥1), divide la ruta en N recorridos. */
+  repartidores?: Array<{ transportista_id: string; max_paradas?: number | null; zonas_preferidas?: number[] | null }>;
 }
 
 function jsonResponse(body: Record<string, unknown>, status = 200): Response {
@@ -212,6 +219,64 @@ serve(async (req: Request) => {
       mensaje: "Los clientes deben tener latitud y longitud para optimizar la ruta",
       pedidos_sin_coordenadas: sinCoords.length,
     });
+  }
+
+  // --- Split multi-repartidor: N vehículos en una sola optimización ---
+  // Requiere el motor optimizeTours (SA key); el fallback computeRoutes no
+  // soporta múltiples vehículos. Los pedidos sin coordenadas los reparte el
+  // front entre los choferes (no entran al optimizador).
+  const repartidores = body.repartidores ?? [];
+  if (repartidores.length > 0) {
+    if (!saKey) {
+      return jsonResponse({
+        success: false,
+        error: "Split no configurado",
+        mensaje: "Dividir la ruta entre repartidores requiere GOOGLE_SA_KEY (Route Optimization).",
+      });
+    }
+    try {
+      const result = await optimizeToursMulti(
+        saKey,
+        deposito,
+        conCoords as PedidoRutaZona[],
+        destino,
+        { fecha: body.fecha, horaInicio: body.hora_inicio, ventanas: body.ventanas },
+        repartidores as RepartidorVehiculo[],
+      );
+      const recorridos = result.recorridos.map((r) => {
+        const km = Math.round(r.distanciaTotalMetros / 10) / 100;
+        const min = Math.round(r.duracionTotalSegundos / 60);
+        const h = Math.floor(min / 60);
+        const m = min % 60;
+        return {
+          transportista_id: r.transportista_id,
+          total_pedidos: r.ordenOptimizado.length,
+          orden_optimizado: r.ordenOptimizado,
+          polylines: r.polylines,
+          distancia_total: r.distanciaTotalMetros,
+          distancia_total_km: km,
+          duracion_total: r.duracionTotalSegundos,
+          duracion_total_minutos: min,
+          duracion_formato: h > 0 ? `${h}h ${m}m` : `${m} minutos`,
+          distancia_formato: `${km} km`,
+        };
+      });
+      return jsonResponse({
+        success: true,
+        optimizado_por: `Google Route Optimization (${repartidores.length} vehículos)`,
+        recorridos,
+        pedidos_sin_coordenadas: sinCoords.length,
+        pedidos_sin_coordenadas_ids: sinCoords.map((p) => String(p.pedido_id ?? "")),
+        skipped: result.skipped,
+      });
+    } catch (err) {
+      console.error("[optimizar-ruta] split multi error:", err);
+      return jsonResponse({
+        success: false,
+        error: "Error al dividir la ruta",
+        mensaje: err instanceof Error ? err.message : "No se pudo optimizar el split",
+      });
+    }
   }
 
   // Ventanas horarias: solo las respeta optimizeTours (el fallback computeRoutes

--- a/supabase/functions/optimizar-ruta/route-optimization.ts
+++ b/supabase/functions/optimizar-ruta/route-optimization.ts
@@ -14,12 +14,20 @@ interface OptimizeToursVisit {
   isPickup?: boolean;
 }
 interface OptimizeToursRoute {
+  vehicleIndex?: number;
+  vehicleLabel?: string;
   visits?: OptimizeToursVisit[];
   routePolyline?: { points?: string };
   metrics?: { travelDistanceMeters?: number; totalDuration?: string };
 }
+interface OptimizeToursSkipped {
+  index?: number;
+  label?: string;
+  reasons?: Array<{ code?: string; exampleVehicleIndex?: number; exampleExceededCapacityType?: string }>;
+}
 export interface OptimizeToursResponse {
   routes?: OptimizeToursRoute[];
+  skippedShipments?: OptimizeToursSkipped[];
   error?: { message?: string; code?: number; status?: string };
 }
 
@@ -163,4 +171,202 @@ export async function optimizeTours(
     throw new Error(data.error.message ?? `Route Optimization HTTP ${res.status}`);
   }
   return parseOptimizeTours(data, pedidos);
+}
+
+// ============================================================================
+// Multi-vehículo: dividir la ruta entre N repartidores en una sola llamada.
+// ============================================================================
+
+/** Penalización (costo) por asignar un pedido a un chofer que NO prefiere su
+ *  zona. Soft: sesga la asignación sin volver el modelo infeasible (a diferencia
+ *  de allowedVehicleIndices, que es hard). */
+const COST_ZONA_NO_PREFERIDA = 1000;
+/** Costo alto por dejar un pedido sin asignar: solo se "saltea" si es infeasible
+ *  por capacidad (Σ max_paradas < #pedidos), nunca por ahorro de distancia. */
+const PENALTY_NO_ASIGNADO = 1_000_000_000;
+
+/** Pedido con su zona (para el sesgo por zona). */
+export type PedidoRutaZona = PedidoRuta & { zona_id?: number | null };
+
+/** Un repartidor disponible y sus parámetros para el split. */
+export interface RepartidorVehiculo {
+  transportista_id: string;
+  /** Tope de paradas para este chofer (loadLimit). Sin valor = sin tope. */
+  max_paradas?: number | null;
+  /** Zonas que prefiere (soft). Pedidos de esas zonas se sesgan hacia él. */
+  zonas_preferidas?: number[] | null;
+}
+
+/** Ruta optimizada de un repartidor. */
+export interface RutaPorVehiculo extends RutaUnida {
+  transportista_id: string;
+}
+
+export interface RutaMultiResultado {
+  recorridos: RutaPorVehiculo[];
+  /** pedido_id de los pedidos que el optimizador no pudo asignar (capacidad). */
+  skipped: string[];
+}
+
+/** Construye el ordenOptimizado + métricas de una sola ruta (vehículo). */
+function parseRutaVehiculo(route: OptimizeToursRoute, byLabel: Map<string, PedidoRuta>): RutaUnida {
+  const ordenOptimizado: OrdenOptimizadoItem[] = [];
+  for (const v of route.visits ?? []) {
+    if (v.shipmentLabel == null) continue;
+    const p = byLabel.get(String(v.shipmentLabel));
+    if (!p) continue;
+    ordenOptimizado.push({
+      pedido_id: p.pedido_id,
+      orden: ordenOptimizado.length + 1,
+      cliente: p.cliente_nombre ?? p.nombre_fantasia ?? "Sin nombre",
+      direccion: p.direccion ?? "",
+    });
+  }
+  const distanciaTotalMetros = route.metrics?.travelDistanceMeters ?? 0;
+  const duracionTotalSegundos = parseDuracion(route.metrics?.totalDuration);
+  const polylines = route.routePolyline?.points ? [route.routePolyline.points] : [];
+  return { ordenOptimizado, distanciaTotalMetros, duracionTotalSegundos, polylines };
+}
+
+/**
+ * Mapea la respuesta multi-vehículo a una ruta por repartidor. Cada `route`
+ * trae su vehicleLabel (= transportista_id) o vehicleIndex; los `visits` son las
+ * paradas de ese chofer. Devuelve también los pedidos no asignados. Pura/testeable.
+ */
+export function parseOptimizeToursMulti(
+  data: OptimizeToursResponse,
+  pedidos: PedidoRuta[],
+  vehicleLabels: string[],
+): RutaMultiResultado {
+  const byLabel = new Map(pedidos.map((p) => [String(p.pedido_id), p]));
+  const recorridos: RutaPorVehiculo[] = [];
+
+  for (const route of data.routes ?? []) {
+    const label = route.vehicleLabel
+      ?? (route.vehicleIndex != null ? vehicleLabels[route.vehicleIndex] : undefined);
+    if (!label) continue;
+    const ruta = parseRutaVehiculo(route, byLabel);
+    // Saltear vehículos sin paradas (chofer disponible al que no le tocó nada).
+    if (ruta.ordenOptimizado.length === 0) continue;
+    recorridos.push({ transportista_id: label, ...ruta });
+  }
+
+  const skipped = (data.skippedShipments ?? [])
+    .map((s) => s.label != null ? String(s.label) : (s.index != null ? String(pedidos[s.index]?.pedido_id ?? "") : ""))
+    .filter((x) => x !== "");
+
+  return { recorridos, skipped };
+}
+
+/**
+ * Optimización multi-vehículo: 1 shipment por pedido, N vehículos (uno por
+ * repartidor, label = transportista_id). Parámetros:
+ *  - max_paradas por chofer → loadLimits/loadDemands (capacidad "paradas").
+ *  - zonas_preferidas → costsPerVehicle SOFT: penaliza asignar el pedido a un
+ *    chofer que no prefiere su zona (sin volverlo infeasible).
+ * Las ventanas horarias se aplican igual que en el modo 1 vehículo.
+ */
+export async function optimizeToursMulti(
+  saKeyJson: string,
+  deposito: LatLng,
+  pedidos: PedidoRutaZona[],
+  destino: LatLng = deposito,
+  opts: OptimizeToursOpts = {},
+  repartidores: RepartidorVehiculo[] = [],
+): Promise<RutaMultiResultado> {
+  if (repartidores.length === 0) throw new Error("No hay repartidores para el split");
+
+  const sa = JSON.parse(saKeyJson) as ServiceAccountKey;
+  const token = await getAccessToken(sa);
+
+  const usarTiempos = !!(opts.fecha && opts.horaInicio);
+  const ventanasMap = new Map<string, { inicio: string; fin: string }>();
+  for (const v of opts.ventanas ?? []) {
+    ventanasMap.set(String(v.pedido_id), { inicio: v.inicio, fin: v.fin });
+  }
+
+  // Costos por zona: para un pedido cuya zona prefiere AL MENOS un chofer, se
+  // penaliza a los choferes que NO la prefieren. Si nadie la prefiere (o el
+  // pedido no tiene zona), no se sesga.
+  const costosZona = (zonaId: number | null | undefined): { idx: number[]; cost: number[] } | null => {
+    if (zonaId == null) return null;
+    const prefiere = repartidores.map((r) => Array.isArray(r.zonas_preferidas) && r.zonas_preferidas.includes(zonaId));
+    if (!prefiere.some(Boolean)) return null;
+    const idx: number[] = [];
+    const cost: number[] = [];
+    prefiere.forEach((pref, i) => { if (!pref) { idx.push(i); cost.push(COST_ZONA_NO_PREFERIDA); } });
+    return idx.length > 0 ? { idx, cost } : null;
+  };
+
+  const model: Record<string, unknown> = {
+    shipments: pedidos.map((p) => {
+      const delivery: Record<string, unknown> = {
+        arrivalLocation: { latitude: p.latitud, longitude: p.longitud },
+      };
+      if (usarTiempos) {
+        delivery.duration = `${SERVICE_SECONDS}s`;
+        const win = ventanasMap.get(String(p.pedido_id));
+        if (win) {
+          delivery.timeWindows = [{
+            softStartTime: isoFecha(opts.fecha!, win.inicio),
+            softEndTime: isoFecha(opts.fecha!, win.fin),
+            costPerHourBeforeSoftStartTime: COST_EARLY_PER_HOUR,
+            costPerHourAfterSoftEndTime: COST_LATE_PER_HOUR,
+          }];
+        }
+      }
+      const shipment: Record<string, unknown> = {
+        label: String(p.pedido_id),
+        deliveries: [delivery],
+        // 1 unidad de carga "paradas" por pedido (para los loadLimits por chofer).
+        loadDemands: { paradas: { amount: "1" } },
+        // Permite saltear (no asignar) si es infeasible por capacidad, con costo
+        // altísimo para que solo ocurra cuando no hay alternativa.
+        penaltyCost: PENALTY_NO_ASIGNADO,
+      };
+      const cz = costosZona(p.zona_id);
+      if (cz) {
+        shipment.costsPerVehicleIndices = cz.idx;
+        shipment.costsPerVehicle = cz.cost;
+      }
+      return shipment;
+    }),
+    vehicles: repartidores.map((r) => {
+      const vehicle: Record<string, unknown> = {
+        label: r.transportista_id,
+        startLocation: { latitude: deposito.latitude, longitude: deposito.longitude },
+        endLocation: { latitude: destino.latitude, longitude: destino.longitude },
+      };
+      if (r.max_paradas != null && r.max_paradas > 0) {
+        vehicle.loadLimits = { paradas: { maxLoad: String(Math.floor(r.max_paradas)) } };
+      }
+      if (usarTiempos) {
+        vehicle.startTimeWindows = [{
+          startTime: isoFecha(opts.fecha!, opts.horaInicio!),
+          endTime: isoFecha(opts.fecha!, opts.horaInicio!),
+        }];
+      }
+      return vehicle;
+    }),
+  };
+  if (usarTiempos) {
+    model.globalStartTime = isoFecha(opts.fecha!, opts.horaInicio!);
+    model.globalEndTime = `${opts.fecha!}T23:59:59${TZ}`;
+  }
+
+  const body = { model, populatePolylines: true };
+
+  const res = await fetch(
+    `https://routeoptimization.googleapis.com/v1/projects/${sa.project_id}:optimizeTours`,
+    {
+      method: "POST",
+      headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    },
+  );
+  const data = (await res.json()) as OptimizeToursResponse;
+  if (data.error) {
+    throw new Error(data.error.message ?? `Route Optimization HTTP ${res.status}`);
+  }
+  return parseOptimizeToursMulti(data, pedidos, repartidores.map((r) => r.transportista_id));
 }

--- a/supabase/functions/tests/optimizar_ruta.test.ts
+++ b/supabase/functions/tests/optimizar_ruta.test.ts
@@ -10,7 +10,7 @@ import {
   type PedidoRuta,
   unirTramos,
 } from "../optimizar-ruta/tramos.ts";
-import { parseOptimizeTours } from "../optimizar-ruta/route-optimization.ts";
+import { parseOptimizeTours, parseOptimizeToursMulti } from "../optimizar-ruta/route-optimization.ts";
 
 const DEPOSITO = { latitude: -26.8241, longitude: -65.2226 };
 
@@ -197,4 +197,73 @@ Deno.test("parseOptimizeTours ignora visits sin label y rutas sin polyline", () 
   assertEquals(ruta.ordenOptimizado[0].pedido_id, "1");
   assertEquals(ruta.polylines, []);
   assertEquals(ruta.duracionTotalSegundos, 0);
+});
+
+// --- Split multi-vehículo (parseOptimizeToursMulti) ---
+
+Deno.test("parseOptimizeToursMulti reparte las visitas por vehicleLabel (transportista)", () => {
+  const pedidos: PedidoRuta[] = [
+    { pedido_id: "1", cliente_nombre: "A", latitud: -26.80, longitud: -65.20 },
+    { pedido_id: "2", cliente_nombre: "B", latitud: -26.81, longitud: -65.21 },
+    { pedido_id: "3", cliente_nombre: "C", latitud: -26.82, longitud: -65.22 },
+  ];
+  const data = {
+    routes: [
+      {
+        vehicleLabel: "chofer-A",
+        visits: [{ shipmentLabel: "1" }, { shipmentLabel: "3" }],
+        routePolyline: { points: "abc" },
+        metrics: { travelDistanceMeters: 1200, totalDuration: "600s" },
+      },
+      {
+        vehicleLabel: "chofer-B",
+        visits: [{ shipmentLabel: "2" }],
+        routePolyline: { points: "def" },
+        metrics: { travelDistanceMeters: 800, totalDuration: "300s" },
+      },
+    ],
+  };
+
+  const { recorridos, skipped } = parseOptimizeToursMulti(data, pedidos, ["chofer-A", "chofer-B"]);
+  assertEquals(recorridos.length, 2);
+  assertEquals(recorridos[0].transportista_id, "chofer-A");
+  assertEquals(recorridos[0].ordenOptimizado.map((o) => o.pedido_id), ["1", "3"]);
+  assertEquals(recorridos[0].ordenOptimizado.map((o) => o.orden), [1, 2]);
+  assertEquals(recorridos[0].polylines, ["abc"]);
+  assertEquals(recorridos[0].distanciaTotalMetros, 1200);
+  assertEquals(recorridos[0].duracionTotalSegundos, 600);
+  assertEquals(recorridos[1].transportista_id, "chofer-B");
+  assertEquals(recorridos[1].ordenOptimizado.map((o) => o.pedido_id), ["2"]);
+  assertEquals(skipped, []);
+});
+
+Deno.test("parseOptimizeToursMulti usa vehicleIndex cuando falta el label y saltea rutas vacías", () => {
+  const pedidos: PedidoRuta[] = [
+    { pedido_id: "1", latitud: -26.80, longitud: -65.20 },
+    { pedido_id: "2", latitud: -26.81, longitud: -65.21 },
+  ];
+  const data = {
+    routes: [
+      { vehicleIndex: 0, visits: [{ shipmentLabel: "1" }, { shipmentLabel: "2" }] },
+      { vehicleIndex: 1, visits: [] }, // chofer sin paradas → se saltea
+    ],
+  };
+  const { recorridos } = parseOptimizeToursMulti(data, pedidos, ["uuid-A", "uuid-B"]);
+  assertEquals(recorridos.length, 1);
+  assertEquals(recorridos[0].transportista_id, "uuid-A");
+  assertEquals(recorridos[0].ordenOptimizado.length, 2);
+});
+
+Deno.test("parseOptimizeToursMulti devuelve los pedidos no asignados (skippedShipments)", () => {
+  const pedidos: PedidoRuta[] = [
+    { pedido_id: "1", latitud: -26.80, longitud: -65.20 },
+    { pedido_id: "2", latitud: -26.81, longitud: -65.21 },
+  ];
+  const data = {
+    routes: [{ vehicleLabel: "A", visits: [{ shipmentLabel: "1" }] }],
+    skippedShipments: [{ index: 1, label: "2", reasons: [{ code: "DEMAND_EXCEEDS_VEHICLE_CAPACITY" }] }],
+  };
+  const { recorridos, skipped } = parseOptimizeToursMulti(data, pedidos, ["A"]);
+  assertEquals(recorridos.length, 1);
+  assertEquals(skipped, ["2"]);
 });


### PR DESCRIPTION
## Qué resuelve

Dos pedidos sobre la "Ruta del día" de la sucursal de Tucumán:

1. **Cambio/devolución como parada.** Un cliente con producto vencido/erróneo necesita un cambio: ahora se puede **agregar como parada del recorrido aunque no sea un pedido**.
2. **Split multi-repartidor.** Seleccionar qué repartidores están disponibles y que una optimización **divida la ruta en N recorridos**, con máx paradas por chofer, preferencia de zona y balance.

## Feature A — Parada de cambio/devolución

Se modela como un **pedido especial** (`canal='cambio'`, `total=0`, `estado_pago='pagado'`), así reusa todo el pipeline (optimizador, `aplicar_orden_ruta`, `recorrido_pedidos`, vista del chofer, hoja de ruta, comandas) sin tocar el modelo de paradas (`recorrido_pedidos.pedido_id` es NOT NULL). Seguro porque con `total=0` el trigger de saldo no se dispara y no hay trigger de stock en la entrega.

- **DB** (`migrations/089_parada_cambio.sql`, **ya aplicada en prod**): tabla `recorrido_cambios` (detalle 1:1 + RLS), `_aplicar_cambio_producto` (núcleo factorizado de la RPC `registrar_cambio_producto` mig 024, que ahora delega), `crear_pedido_cambio_en_ruta` (crea la parada, no toca stock/saldo) y `aplicar_cambio_de_parada` (ajusta stock+saldo al completar, idempotente).
- **Creación desde 3 lugares**: modal "Armar ruta" (la suma pre-tildada), ficha de cliente, y toolbar de Pedidos — reusando `ModalCambioProducto` con `modo='enRuta'`.
- **Chofer**: badge "Cambio/Devolución" en `SheetParada` (qué retirar/entregar, sin cobro); "Completar" aplica el cambio y marca entregado.
- **PDF**: hoja de ruta y comandas etiquetan el cambio.

## Feature B — Split entre N repartidores

- **Edge function `optimizar-ruta`**: `optimizeToursMulti` (Google Route Optimization, N vehículos) — `loadLimits`/`loadDemands` para máx paradas, `costsPerVehicle` **soft** para preferencia de zona, `penaltyCost` para reportar no-asignados en vez de fallar. Tests Deno para `parseOptimizeToursMulti`.
- **Front**: `optimizarRutaMulti` + `handleArmarRutaMulti` (una optimización → N recorridos vía `aplicar_orden_ruta` por chofer; reparte sin-coords por zona/round-robin).
- **UI** `ModalGestionRutas`: toggle "Un transportista" / "Dividir entre varios", multi-select con máx paradas y zonas por chofer, y resultado por chofer.

## Validación

- `tsc --noEmit` limpio (salvo errores preexistentes de `MapaRuta.tsx` por `react-leaflet`, no instalado en el entorno; no toqué ese archivo).
- `eslint` limpio en los archivos cambiados.
- `vitest run`: **732 tests OK** (corrió en el pre-commit).
- `deno test optimizar_ruta.test.ts`: **11/11 OK** (incluye 3 nuevos de `parseOptimizeToursMulti`).

## ⚠️ Pendiente / orden de deploy

- **Falta deployar la edge function `optimizar-ruta`** (el CLI local falla por `deno.lock` v5 vs el bundler viejo; deployar tras el merge con un CLve/Deno actualizado o `--use-api`). Hasta entonces el split multi NO funciona; el modo 1 chofer sí.
- La migración 089 **debe** estar antes que el front (ya aplicada): `useRecorridoActivoQuery` embebe `recorrido_cambios`. Por eso **no** se tocó `PEDIDO_SELECT` (evita romper la lista de pedidos pre-migración).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
