### PR TITLE
feat(cambios): motivo + mismo producto · fix movimientos entre sucursales

### DIFF
--- a/migrations/090_cambio_motivo_y_mismo_producto.sql
+++ b/migrations/090_cambio_motivo_y_mismo_producto.sql
@@ -1,0 +1,348 @@
+-- Migración 090 — Cambio/devolución: motivo (stock tipo salvedad) + mismo producto
+--
+-- Dos cambios sobre el feature de cambio (mig 024 + 089):
+-- 1) MISMO PRODUCTO: se permite que el producto devuelto == el entregado (caso
+--    vencimiento: el cliente devuelve el vencido y recibe el mismo producto
+--    fresco). Se dropean los CHECK de "distintos" y los IF que lo rechazaban.
+-- 2) MOTIVO + STOCK condicional (análogo a entrega con salvedad): el cambio
+--    lleva un `motivo`. Si es 'vencimiento' o 'rotura', el producto devuelto NO
+--    reingresa al stock (se da de baja y se registra en mermas_stock); el
+--    entregado SIEMPRE sale del stock. Si es 'erroneo'/'otro' (buen estado), el
+--    devuelto reingresa (canje, comportamiento histórico).
+--
+-- Las tablas cambios_productos y recorrido_cambios están vacías en prod, así que
+-- agregar `motivo NOT NULL DEFAULT 'erroneo'` es seguro.
+--
+-- NO aplicada en prod todavía (pendiente de apply_migration vía MCP).
+
+-- ============================================================================
+-- 1. Permitir mismo producto: dropear CHECK de distintos
+-- ============================================================================
+ALTER TABLE public.cambios_productos DROP CONSTRAINT IF EXISTS cambios_productos_distintos;
+ALTER TABLE public.recorrido_cambios DROP CONSTRAINT IF EXISTS recorrido_cambios_distintos;
+
+-- ============================================================================
+-- 2. Columna motivo en ambas tablas (+ CHECK de valores válidos)
+-- ============================================================================
+ALTER TABLE public.cambios_productos
+  ADD COLUMN IF NOT EXISTS motivo TEXT NOT NULL DEFAULT 'erroneo';
+ALTER TABLE public.recorrido_cambios
+  ADD COLUMN IF NOT EXISTS motivo TEXT NOT NULL DEFAULT 'erroneo';
+
+ALTER TABLE public.cambios_productos DROP CONSTRAINT IF EXISTS cambios_productos_motivo_check;
+ALTER TABLE public.cambios_productos
+  ADD CONSTRAINT cambios_productos_motivo_check
+  CHECK (motivo IN ('vencimiento','rotura','erroneo','otro'));
+ALTER TABLE public.recorrido_cambios DROP CONSTRAINT IF EXISTS recorrido_cambios_motivo_check;
+ALTER TABLE public.recorrido_cambios
+  ADD CONSTRAINT recorrido_cambios_motivo_check
+  CHECK (motivo IN ('vencimiento','rotura','erroneo','otro'));
+
+-- ============================================================================
+-- 3. _aplicar_cambio_producto: nueva firma con p_motivo (deriva reingreso del
+--    devuelto + merma condicional). Se DROPea la firma vieja (8 args).
+-- ============================================================================
+DROP FUNCTION IF EXISTS public._aplicar_cambio_producto(
+  INTEGER, BIGINT, INTEGER, BIGINT, INTEGER, TEXT, BIGINT, UUID
+);
+
+CREATE OR REPLACE FUNCTION public._aplicar_cambio_producto(
+  p_cliente_id INTEGER,
+  p_producto_devuelto_id BIGINT,
+  p_cantidad_devuelta INTEGER,
+  p_producto_entregado_id BIGINT,
+  p_cantidad_entregada INTEGER,
+  p_observaciones TEXT,
+  p_sucursal_id BIGINT,
+  p_usuario_id UUID,
+  p_motivo TEXT
+) RETURNS BIGINT
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = public
+AS $$
+DECLARE
+  v_precio_devuelto NUMERIC(12,2);
+  v_precio_entregado NUMERIC(12,2);
+  v_stock_entregado INT;
+  v_stock_dev_now INT;
+  v_diferencia NUMERIC(12,2);
+  v_cambio_id BIGINT;
+  v_first BIGINT;
+  v_second BIGINT;
+  -- Reingresa el devuelto salvo que sea baja por vencimiento/rotura.
+  v_reingresa BOOLEAN := (COALESCE(p_motivo,'erroneo') NOT IN ('vencimiento','rotura'));
+BEGIN
+  IF p_cantidad_devuelta <= 0 OR p_cantidad_entregada <= 0 THEN
+    RAISE EXCEPTION 'Las cantidades deben ser mayores a 0';
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM clientes WHERE id = p_cliente_id AND sucursal_id = p_sucursal_id
+  ) THEN
+    RAISE EXCEPTION 'Cliente no encontrado en la sucursal';
+  END IF;
+
+  -- Lock en orden estable para evitar deadlocks (tolera ids iguales: re-lock).
+  IF p_producto_devuelto_id <= p_producto_entregado_id THEN
+    v_first := p_producto_devuelto_id;
+    v_second := p_producto_entregado_id;
+  ELSE
+    v_first := p_producto_entregado_id;
+    v_second := p_producto_devuelto_id;
+  END IF;
+
+  PERFORM 1 FROM productos
+   WHERE id = v_first AND sucursal_id = p_sucursal_id FOR UPDATE;
+  PERFORM 1 FROM productos
+   WHERE id = v_second AND sucursal_id = p_sucursal_id FOR UPDATE;
+
+  SELECT precio, stock INTO v_precio_entregado, v_stock_entregado
+    FROM productos
+   WHERE id = p_producto_entregado_id AND sucursal_id = p_sucursal_id;
+  IF v_precio_entregado IS NULL THEN
+    RAISE EXCEPTION 'Producto a entregar no encontrado';
+  END IF;
+  IF v_stock_entregado < p_cantidad_entregada THEN
+    RAISE EXCEPTION 'Stock insuficiente del producto a entregar (% disponibles)', v_stock_entregado;
+  END IF;
+
+  SELECT precio INTO v_precio_devuelto
+    FROM productos
+   WHERE id = p_producto_devuelto_id AND sucursal_id = p_sucursal_id;
+  IF v_precio_devuelto IS NULL THEN
+    RAISE EXCEPTION 'Producto a devolver no encontrado';
+  END IF;
+
+  -- El devuelto reingresa solo si está en buen estado (no vencimiento/rotura).
+  IF v_reingresa THEN
+    UPDATE productos SET stock = stock + p_cantidad_devuelta
+     WHERE id = p_producto_devuelto_id;
+  END IF;
+  -- El entregado SIEMPRE sale del stock.
+  UPDATE productos SET stock = stock - p_cantidad_entregada
+   WHERE id = p_producto_entregado_id;
+
+  -- Baja por vencimiento/rotura: registrar la merma del devuelto (auditoría;
+  -- sin decremento extra — el outflow ya lo refleja el entregado).
+  IF NOT v_reingresa THEN
+    SELECT stock INTO v_stock_dev_now
+      FROM productos WHERE id = p_producto_devuelto_id AND sucursal_id = p_sucursal_id;
+    INSERT INTO mermas_stock (
+      producto_id, cantidad, motivo, observaciones,
+      stock_anterior, stock_nuevo, usuario_id, sucursal_id
+    ) VALUES (
+      p_producto_devuelto_id, p_cantidad_devuelta, p_motivo,
+      'Cambio: producto devuelto no reingresado al stock (' || p_motivo || ')',
+      v_stock_dev_now, v_stock_dev_now, p_usuario_id, p_sucursal_id
+    );
+  END IF;
+
+  v_diferencia := (v_precio_entregado * p_cantidad_entregada)
+                - (v_precio_devuelto * p_cantidad_devuelta);
+
+  UPDATE clientes
+     SET saldo_cuenta = COALESCE(saldo_cuenta, 0) + v_diferencia
+   WHERE id = p_cliente_id;
+
+  INSERT INTO cambios_productos (
+    cliente_id, producto_devuelto_id, cantidad_devuelta, precio_devuelto,
+    producto_entregado_id, cantidad_entregada, precio_entregado,
+    diferencia_monto, observaciones, usuario_id, sucursal_id, motivo
+  ) VALUES (
+    p_cliente_id, p_producto_devuelto_id, p_cantidad_devuelta, v_precio_devuelto,
+    p_producto_entregado_id, p_cantidad_entregada, v_precio_entregado,
+    v_diferencia, p_observaciones, p_usuario_id, p_sucursal_id, COALESCE(p_motivo,'erroneo')
+  ) RETURNING id INTO v_cambio_id;
+
+  RETURN v_cambio_id;
+END;
+$$;
+
+ALTER FUNCTION public._aplicar_cambio_producto(
+  INTEGER, BIGINT, INTEGER, BIGINT, INTEGER, TEXT, BIGINT, UUID, TEXT
+) OWNER TO postgres;
+REVOKE ALL ON FUNCTION public._aplicar_cambio_producto(
+  INTEGER, BIGINT, INTEGER, BIGINT, INTEGER, TEXT, BIGINT, UUID, TEXT
+) FROM PUBLIC;
+
+-- ============================================================================
+-- 4. registrar_cambio_producto (standalone): suma p_motivo, sin check distintos.
+--    Se DROPea la firma vieja (6 args) y se crea la nueva (7 args, motivo default).
+-- ============================================================================
+DROP FUNCTION IF EXISTS public.registrar_cambio_producto(
+  INTEGER, BIGINT, INTEGER, BIGINT, INTEGER, TEXT
+);
+
+CREATE OR REPLACE FUNCTION public.registrar_cambio_producto(
+  p_cliente_id INTEGER,
+  p_producto_devuelto_id BIGINT,
+  p_cantidad_devuelta INTEGER,
+  p_producto_entregado_id BIGINT,
+  p_cantidad_entregada INTEGER,
+  p_observaciones TEXT DEFAULT NULL,
+  p_motivo TEXT DEFAULT 'erroneo'
+) RETURNS BIGINT
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = public
+AS $$
+DECLARE
+  v_sucursal BIGINT := public.current_sucursal_id();
+  v_user UUID := auth.uid();
+BEGIN
+  IF v_sucursal IS NULL THEN
+    RAISE EXCEPTION 'Sin sucursal activa';
+  END IF;
+  IF NOT public.es_encargado_o_admin() THEN
+    RAISE EXCEPTION 'No autorizado';
+  END IF;
+
+  RETURN public._aplicar_cambio_producto(
+    p_cliente_id, p_producto_devuelto_id, p_cantidad_devuelta,
+    p_producto_entregado_id, p_cantidad_entregada, p_observaciones,
+    v_sucursal, v_user, COALESCE(p_motivo,'erroneo')
+  );
+END;
+$$;
+
+ALTER FUNCTION public.registrar_cambio_producto(
+  INTEGER, BIGINT, INTEGER, BIGINT, INTEGER, TEXT, TEXT
+) OWNER TO postgres;
+GRANT EXECUTE ON FUNCTION public.registrar_cambio_producto(
+  INTEGER, BIGINT, INTEGER, BIGINT, INTEGER, TEXT, TEXT
+) TO authenticated;
+
+-- ============================================================================
+-- 5. crear_pedido_cambio_en_ruta: suma p_motivo, lo guarda en recorrido_cambios,
+--    sin check distintos. Se DROPea la firma vieja (6 args).
+-- ============================================================================
+DROP FUNCTION IF EXISTS public.crear_pedido_cambio_en_ruta(
+  INTEGER, BIGINT, INTEGER, BIGINT, INTEGER, TEXT
+);
+
+CREATE OR REPLACE FUNCTION public.crear_pedido_cambio_en_ruta(
+  p_cliente_id INTEGER,
+  p_producto_devuelto_id BIGINT,
+  p_cantidad_devuelta INTEGER,
+  p_producto_entregado_id BIGINT,
+  p_cantidad_entregada INTEGER,
+  p_observaciones TEXT DEFAULT NULL,
+  p_motivo TEXT DEFAULT 'erroneo'
+) RETURNS BIGINT
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = public
+AS $$
+DECLARE
+  v_sucursal BIGINT := public.current_sucursal_id();
+  v_user UUID := auth.uid();
+  v_nombre_devuelto TEXT;
+  v_nombre_entregado TEXT;
+  v_pedido_id BIGINT;
+BEGIN
+  IF v_sucursal IS NULL THEN
+    RAISE EXCEPTION 'Sin sucursal activa';
+  END IF;
+  IF NOT public.es_encargado_o_admin() THEN
+    RAISE EXCEPTION 'No autorizado';
+  END IF;
+  IF p_cantidad_devuelta <= 0 OR p_cantidad_entregada <= 0 THEN
+    RAISE EXCEPTION 'Las cantidades deben ser mayores a 0';
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM clientes WHERE id = p_cliente_id AND sucursal_id = v_sucursal
+  ) THEN
+    RAISE EXCEPTION 'Cliente no encontrado en la sucursal';
+  END IF;
+
+  SELECT nombre INTO v_nombre_devuelto FROM productos
+   WHERE id = p_producto_devuelto_id AND sucursal_id = v_sucursal;
+  IF v_nombre_devuelto IS NULL THEN
+    RAISE EXCEPTION 'Producto a devolver no encontrado';
+  END IF;
+  SELECT nombre INTO v_nombre_entregado FROM productos
+   WHERE id = p_producto_entregado_id AND sucursal_id = v_sucursal;
+  IF v_nombre_entregado IS NULL THEN
+    RAISE EXCEPTION 'Producto a entregar no encontrado';
+  END IF;
+
+  INSERT INTO pedidos (
+    cliente_id, fecha, estado, total, monto_pagado, estado_pago,
+    canal, usuario_id, sucursal_id
+  ) VALUES (
+    p_cliente_id, CURRENT_DATE, 'pendiente', 0, 0, 'pagado',
+    'cambio', v_user, v_sucursal
+  ) RETURNING id INTO v_pedido_id;
+
+  INSERT INTO recorrido_cambios (
+    pedido_id, cliente_id,
+    producto_devuelto_id, producto_devuelto_nombre, cantidad_devuelta,
+    producto_entregado_id, producto_entregado_nombre, cantidad_entregada,
+    observaciones, sucursal_id, motivo
+  ) VALUES (
+    v_pedido_id, p_cliente_id,
+    p_producto_devuelto_id, v_nombre_devuelto, p_cantidad_devuelta,
+    p_producto_entregado_id, v_nombre_entregado, p_cantidad_entregada,
+    p_observaciones, v_sucursal, COALESCE(p_motivo,'erroneo')
+  );
+
+  RETURN v_pedido_id;
+END;
+$$;
+
+ALTER FUNCTION public.crear_pedido_cambio_en_ruta(
+  INTEGER, BIGINT, INTEGER, BIGINT, INTEGER, TEXT, TEXT
+) OWNER TO postgres;
+GRANT EXECUTE ON FUNCTION public.crear_pedido_cambio_en_ruta(
+  INTEGER, BIGINT, INTEGER, BIGINT, INTEGER, TEXT, TEXT
+) TO authenticated;
+
+-- ============================================================================
+-- 6. aplicar_cambio_de_parada: pasa el motivo guardado a _aplicar_cambio_producto.
+--    Misma firma pública (p_pedido_id) → CREATE OR REPLACE.
+-- ============================================================================
+CREATE OR REPLACE FUNCTION public.aplicar_cambio_de_parada(
+  p_pedido_id BIGINT
+) RETURNS BIGINT
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = public
+AS $$
+DECLARE
+  v_rc RECORD;
+  v_user UUID := auth.uid();
+  v_cambio_id BIGINT;
+  v_autorizado BOOLEAN;
+BEGIN
+  SELECT * INTO v_rc FROM recorrido_cambios WHERE pedido_id = p_pedido_id;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'No hay detalle de cambio para el pedido %', p_pedido_id;
+  END IF;
+
+  IF v_rc.aplicado_at IS NOT NULL THEN
+    RETURN v_rc.cambio_producto_id;
+  END IF;
+
+  v_autorizado := public.es_encargado_o_admin()
+    OR EXISTS (
+      SELECT 1
+      FROM recorrido_pedidos rp
+      JOIN recorridos r ON r.id = rp.recorrido_id
+      WHERE rp.pedido_id = p_pedido_id
+        AND r.transportista_id = v_user
+    );
+  IF NOT v_autorizado THEN
+    RAISE EXCEPTION 'No autorizado para aplicar el cambio';
+  END IF;
+
+  v_cambio_id := public._aplicar_cambio_producto(
+    v_rc.cliente_id,
+    v_rc.producto_devuelto_id, v_rc.cantidad_devuelta,
+    v_rc.producto_entregado_id, v_rc.cantidad_entregada,
+    v_rc.observaciones, v_rc.sucursal_id, v_user, COALESCE(v_rc.motivo,'erroneo')
+  );
+
+  UPDATE recorrido_cambios
+     SET aplicado_at = NOW(), cambio_producto_id = v_cambio_id
+   WHERE pedido_id = p_pedido_id;
+
+  RETURN v_cambio_id;
+END;
+$$;
+
+ALTER FUNCTION public.aplicar_cambio_de_parada(BIGINT) OWNER TO postgres;
+GRANT EXECUTE ON FUNCTION public.aplicar_cambio_de_parada(BIGINT) TO authenticated;

--- a/src/components/modals/ModalCambioProducto.tsx
+++ b/src/components/modals/ModalCambioProducto.tsx
@@ -6,6 +6,8 @@ import { formatPrecio } from '../../utils/formatters'
 import NumberInput from '../ui/NumberInput'
 import type { ClienteDB, ProductoDB } from '../../types'
 
+export type MotivoCambio = 'vencimiento' | 'rotura' | 'erroneo' | 'otro'
+
 export interface CambioProductoSaveData {
   clienteId: string
   productoDevueltoId: string
@@ -13,7 +15,17 @@ export interface CambioProductoSaveData {
   productoEntregadoId: string
   cantidadEntregada: number
   observaciones: string
+  motivo: MotivoCambio
 }
+
+/** Motivos del cambio y si el producto devuelto reingresa al stock (igual que
+ *  la entrega con salvedad: vencimiento/rotura se dan de baja). */
+const MOTIVOS_CAMBIO: Array<{ value: MotivoCambio; label: string; reingresa: boolean }> = [
+  { value: 'erroneo', label: 'Cambio común (producto en buen estado)', reingresa: true },
+  { value: 'vencimiento', label: 'Producto vencido', reingresa: false },
+  { value: 'rotura', label: 'Producto roto / dañado', reingresa: false },
+  { value: 'otro', label: 'Otro', reingresa: true },
+]
 
 export interface ModalCambioProductoProps {
   clientes: ClienteDB[]
@@ -60,8 +72,11 @@ export default function ModalCambioProducto({
   const [cantidadEntregada, setCantidadEntregada] = useState<number | string>(1)
 
   const [observaciones, setObservaciones] = useState<string>('')
+  const [motivo, setMotivo] = useState<MotivoCambio>('erroneo')
   const [guardando, setGuardando] = useState<boolean>(false)
   const [error, setError] = useState<string>('')
+
+  const motivoSeleccionado = MOTIVOS_CAMBIO.find(m => m.value === motivo) ?? MOTIVOS_CAMBIO[0]
 
   const clienteSeleccionado = useMemo(
     () => clientes.find(c => c.id === clienteId) || null,
@@ -91,11 +106,12 @@ export default function ModalCambioProducto({
     ).slice(0, 8)
   }, [clientes, busquedaCliente])
 
-  const filtrarProductos = (busqueda: string, excluirId: string): ProductoDB[] => {
+  // Se permite el MISMO producto en ambos lados (caso vencimiento: el cliente
+  // devuelve el vencido y recibe el mismo producto fresco), así que no se excluye.
+  const filtrarProductos = (busqueda: string): ProductoDB[] => {
     const termino = normalizar(busqueda)
     if (!termino) return []
     return productos
-      .filter(p => p.id !== excluirId)
       .filter(p =>
         normalizar(p.nombre).includes(termino) ||
         normalizar(p.codigo).includes(termino),
@@ -104,15 +120,15 @@ export default function ModalCambioProducto({
   }
 
   const productosDevueltoFiltrados = useMemo(
-    () => filtrarProductos(busquedaDevuelto, productoEntregadoId),
+    () => filtrarProductos(busquedaDevuelto),
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [productos, busquedaDevuelto, productoEntregadoId],
+    [productos, busquedaDevuelto],
   )
 
   const productosEntregadoFiltrados = useMemo(
-    () => filtrarProductos(busquedaEntregado, productoDevueltoId),
+    () => filtrarProductos(busquedaEntregado),
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [productos, busquedaEntregado, productoDevueltoId],
+    [productos, busquedaEntregado],
   )
 
   const cantDevNum = typeof cantidadDevuelta === 'string' ? parseInt(cantidadDevuelta) || 0 : cantidadDevuelta
@@ -153,6 +169,7 @@ export default function ModalCambioProducto({
       productoEntregadoId,
       cantidadEntregada: cantEntNum,
       observaciones,
+      motivo,
     })
     if (!result.success) {
       setError(getFirstError() || 'Error de validación')
@@ -173,6 +190,7 @@ export default function ModalCambioProducto({
         productoEntregadoId: result.data.productoEntregadoId,
         cantidadEntregada: result.data.cantidadEntregada,
         observaciones: result.data.observaciones || '',
+        motivo: result.data.motivo,
       })
       onClose()
     } catch (err) {
@@ -417,11 +435,39 @@ export default function ModalCambioProducto({
             </div>
           )}
 
+          {/* Motivo del cambio: define si el producto devuelto reingresa al stock */}
+          <div>
+            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+              Motivo del cambio
+            </label>
+            <select
+              value={motivo}
+              onChange={(e: ChangeEvent<HTMLSelectElement>) => setMotivo(e.target.value as MotivoCambio)}
+              className="w-full px-3 py-2 border dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-indigo-500 dark:bg-gray-700 dark:text-white"
+            >
+              {MOTIVOS_CAMBIO.map(m => (
+                <option key={m.value} value={m.value}>{m.label}</option>
+              ))}
+            </select>
+            <div className={`mt-2 p-2 rounded-lg flex items-start gap-2 text-sm border ${
+              motivoSeleccionado.reingresa
+                ? 'bg-green-50 dark:bg-green-900/20 border-green-200 dark:border-green-800'
+                : 'bg-red-50 dark:bg-red-900/20 border-red-200 dark:border-red-800'
+            }`}>
+              <AlertTriangle className={`w-4 h-4 mt-0.5 flex-shrink-0 ${motivoSeleccionado.reingresa ? 'text-green-600' : 'text-red-600'}`} />
+              <span className={motivoSeleccionado.reingresa ? 'text-green-700 dark:text-green-400' : 'text-red-700 dark:text-red-400'}>
+                {motivoSeleccionado.reingresa
+                  ? 'El producto devuelto reingresa al stock (canje); el entregado sale del stock.'
+                  : 'El producto devuelto NO reingresa al stock (se da de baja como merma); el entregado sale del stock.'}
+              </span>
+            </div>
+          </div>
+
           {/* Observaciones */}
           <div>
             <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
               <FileText className="w-4 h-4 inline mr-1" />
-              Observaciones (motivo del cambio)
+              Observaciones
             </label>
             <textarea
               value={observaciones}

--- a/src/components/pedidos/PedidoToolbar.tsx
+++ b/src/components/pedidos/PedidoToolbar.tsx
@@ -277,17 +277,6 @@ export default function PedidoToolbar({
             >
               Armar ruta del día
             </ToolbarButton>
-            {onCambioEnRuta && (
-              <ToolbarButton
-                icon={ArrowLeftRight}
-                iconClassName="text-indigo-600"
-                mobileLabel="Cambio"
-                onClick={onCambioEnRuta}
-                title="Agregar un cambio/devolución como parada del recorrido"
-              >
-                Cambio/devolución
-              </ToolbarButton>
-            )}
           </div>
         )}
 
@@ -318,7 +307,24 @@ export default function PedidoToolbar({
           </div>
         )}
 
-        {canCreate && <PrimaryNewButton onClick={onNuevoPedido} fullWidth />}
+        {canCreate && (
+          onCambioEnRuta ? (
+            <div className="grid grid-cols-2 gap-2 [&>*]:w-full [&>*]:justify-center [&>*]:px-2">
+              <ToolbarButton
+                icon={ArrowLeftRight}
+                iconClassName="text-indigo-600"
+                mobileLabel="Cambio"
+                onClick={onCambioEnRuta}
+                title="Agregar un cambio/devolución como parada del recorrido"
+              >
+                Cambio/devolución
+              </ToolbarButton>
+              <PrimaryNewButton onClick={onNuevoPedido} fullWidth />
+            </div>
+          ) : (
+            <PrimaryNewButton onClick={onNuevoPedido} fullWidth />
+          )
+        )}
       </div>
 
       {/* ╔══ DESKTOP (sm+): layout original — fila a la derecha ══╗ */}
@@ -335,17 +341,6 @@ export default function PedidoToolbar({
             >
               Armar ruta del día
             </ToolbarButton>
-            {onCambioEnRuta && (
-              <ToolbarButton
-                icon={ArrowLeftRight}
-                iconClassName="text-indigo-600"
-                mobileLabel="Cambio"
-                onClick={onCambioEnRuta}
-                title="Agregar un cambio/devolución como parada del recorrido"
-              >
-                Cambio/devolución
-              </ToolbarButton>
-            )}
           </>
         )}
 
@@ -376,6 +371,18 @@ export default function PedidoToolbar({
           </>
         )}
 
+        {/* Cambio/devolución: en la línea de "Nuevo pedido" (a su izquierda). */}
+        {onCambioEnRuta && (
+          <ToolbarButton
+            icon={ArrowLeftRight}
+            iconClassName="text-indigo-600"
+            mobileLabel="Cambio"
+            onClick={onCambioEnRuta}
+            title="Agregar un cambio/devolución como parada del recorrido"
+          >
+            Cambio/devolución
+          </ToolbarButton>
+        )}
         {canCreate && <PrimaryNewButton onClick={onNuevoPedido} />}
       </div>
     </>

--- a/src/hooks/queries/useCambiosProductosQuery.ts
+++ b/src/hooks/queries/useCambiosProductosQuery.ts
@@ -25,6 +25,8 @@ export interface RegistrarCambioInput {
   productoEntregadoId: string
   cantidadEntregada: number
   observaciones?: string
+  /** Motivo del cambio (vencimiento/rotura → no reingresa el devuelto). */
+  motivo?: 'vencimiento' | 'rotura' | 'erroneo' | 'otro'
 }
 
 async function registrarCambio(input: RegistrarCambioInput): Promise<number> {
@@ -35,6 +37,7 @@ async function registrarCambio(input: RegistrarCambioInput): Promise<number> {
     p_producto_entregado_id: Number(input.productoEntregadoId),
     p_cantidad_entregada: input.cantidadEntregada,
     p_observaciones: input.observaciones || null,
+    p_motivo: input.motivo || 'erroneo',
   })
 
   if (error) throw error
@@ -78,6 +81,7 @@ async function crearPedidoCambioEnRuta(input: RegistrarCambioInput): Promise<num
     p_producto_entregado_id: Number(input.productoEntregadoId),
     p_cantidad_entregada: input.cantidadEntregada,
     p_observaciones: input.observaciones || null,
+    p_motivo: input.motivo || 'erroneo',
   })
 
   if (error) throw error

--- a/src/hooks/queries/useTransferenciasQuery.ts
+++ b/src/hooks/queries/useTransferenciasQuery.ts
@@ -19,16 +19,16 @@ export const sucursalesKeys = {
 }
 
 async function fetchSucursales(): Promise<SucursalDB[]> {
-  // Multi-tenant (C3): filter out tenant rows (ManaosApp/TP Export, tipo
-  // 'principal' / 'secundaria') from the transfer-destination dropdown.
-  // Only sub-sucursales (tipo='distribuidora') are valid transfer targets;
-  // otherwise the UI would let a user move stock into the tenant row itself,
-  // which has no warehouse semantics.
+  // Todas las sucursales ACTIVAS son destinos válidos de movimiento. NO se
+  // filtra por `tipo`: en este deployment las sucursales operativas reales se
+  // etiquetaron 'principal'/'secundaria' (id 1 Tucumán, id 2 Taco Pozo) y la
+  // única 'distribuidora' era una sucursal fantasma vacía; filtrar por
+  // tipo='distribuidora' dejaba el selector mostrando solo el fantasma y rompía
+  // los envíos entre sucursales reales. El container excluye la sucursal actual.
   const { data, error } = await supabase
     .from('sucursales')
     .select('*')
     .eq('activa', true)
-    .eq('tipo', 'distribuidora')
     .order('nombre', { ascending: true })
 
   if (error) {

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -705,10 +705,11 @@ export const modalCambioProductoSchema = z.object({
     .number({ error: 'La cantidad debe ser un número' })
     .int({ message: 'La cantidad debe ser un número entero' })
     .positive({ message: 'La cantidad debe ser mayor a 0' }),
-  observaciones: z.string().optional()
-}).refine(d => d.productoDevueltoId !== d.productoEntregadoId, {
-  message: 'Los productos deben ser distintos',
-  path: ['productoEntregadoId']
+  observaciones: z.string().optional(),
+  // Motivo del cambio: define si el producto devuelto reingresa al stock
+  // (vencimiento/rotura → se da de baja; erroneo/otro → reingresa). Se permite
+  // el mismo producto (caso vencimiento: se cambia por el mismo fresco).
+  motivo: z.enum(['vencimiento', 'rotura', 'erroneo', 'otro']).default('erroneo')
 })
 
 /** Inferred type for ModalCambioProducto schema */


### PR DESCRIPTION
PR nuevo (post-merge de #389) con dos cosas independientes pedidas por el usuario.

## 1. Refinamientos del cambio/devolución

- **Stock por motivo (como entrega con salvedad)**: el cambio lleva un motivo (Vencimiento / Rotura / Cambio común / Otro). Vencimiento y Rotura → el producto **devuelto NO reingresa** al stock (se da de baja y queda registrado en `mermas_stock`); el **entregado siempre sale**. Cambio común / Otro → el devuelto reingresa (canje, comportamiento histórico). El selector muestra el efecto (verde reingresa / rojo se da de baja), igual que `ModalSalvedadItem`.
- **Permitir el MISMO producto**: caso producto vencido que se cambia por el mismo producto fresco. Se quitan los `CHECK` de "productos distintos", los `IF` en las RPCs, el `.refine` del schema Zod y el filtro de exclusión del modal.
- Aplica tanto al cambio **en ruta** como al **standalone** de Productos (comparten modal + `_aplicar_cambio_producto`).
- **Botón "Cambio/devolución"** reubicado a la línea de **"Nuevo pedido"** en `PedidoToolbar` (mobile + desktop).
- **Migración 090** (`migrations/090_cambio_motivo_y_mismo_producto.sql`) — **ya aplicada en prod**. Las RPCs llevan `p_motivo DEFAULT 'erroneo'`, así que son back-compat con el front actual (no hay hazard de orden de deploy).

## 2. Fix: movimientos entre sucursales

**Bug**: la sucursal Tucumán mandó un envío a Taco Pozo que quedaba pendiente, pero en Taco Pozo no aparecía nada; y desde Taco Pozo el selector de destino solo dejaba elegir "Taco Pozo".

**Causa raíz**: `fetchSucursales` filtraba `tipo='distribuidora'`. En el modelo multi-tenant (mig 057) `'principal'`/`'secundaria'` eran tenant-rows y `'distribuidora'` las sucursales reales; pero en la práctica repurpusaron id 1→Tucumán (`principal`) e id 2→Taco Pozo (`secundaria`) como las dos sucursales operativas reales, y la única `'distribuidora'` quedó como una sucursal **fantasma vacía (id 4)**. Por eso el selector solo ofrecía el fantasma → el envío fue a parar a id 4 → ningún usuario real (todos en id 2) lo veía (la RLS es bidireccional pero ninguna sucursal del user matcheaba).

**Fix de código**: `fetchSucursales` lista todas las sucursales **activas** (sin filtrar por `tipo`; es el único lugar que usaba `tipo`). El container ya excluye la sucursal actual.

**Fix de datos en prod (ya aplicado)**: sucursal fantasma id 4 → `activa=false`; envío huérfano id 5 → destino redirigido a Taco Pozo real (id 2) + re-notificado a sus 5 admin/encargado.

## Verificación

- **Cambio (BD, transaccional con ROLLBACK contra prod)**: mismo producto + `erroneo` → stock neto 0; mismo producto + `vencimiento` → −entregado + fila en `mermas_stock`; saldo sin cambio; idempotencia OK.
- **Movimientos (BD)**: simulando sesión de admin de Taco Pozo (`current_sucursal_id=2`), el envío id 5 es **visible** vía RLS; 5 notificaciones insertadas; fantasma desactivado.
- `tsc --noEmit` y `eslint` limpios; `vitest run` 732/732 (corrió en el pre-commit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
