### PR TITLE
fix(promociones): acumuladores modo Fracción (barra 24/12 y -10/12) + descuadre de stock

### DIFF
--- a/migrations/091_fix_promo_acumuladores_resto_y_clamp.sql
+++ b/migrations/091_fix_promo_acumuladores_resto_y_clamp.sql
@@ -1,0 +1,222 @@
+-- 091_fix_promo_acumuladores_resto_y_clamp.sql
+--
+-- PARA REVISAR ANTES DE APLICAR. No toca stock fisico (eso va en una migracion
+-- aparte, con conteo confirmado). Solo: (a) endurece el helper de acumuladores y
+-- (b) recomputa promo_acumuladores.usos_pendientes al RESTO correcto.
+--
+-- ============================================================================
+-- CONTEXTO (auditoria 2026-06-23)
+-- ============================================================================
+-- Sintoma: la barra de consumo en modo Fraccion mostraba valores imposibles
+--   ("24/12", "-10/12", "-4/6"). Reproducido en prod (sucursal 1):
+--     promo 12 regalo 86 (Naranja)  usos_pendientes = 24   (tope 12)
+--     promo 12 regalo 87 (Pomelo)   usos_pendientes = -10
+--     promo 13 regalo 82 (Manzana)  usos_pendientes = -4
+--     promo 13 regalo 78 (Cola)     usos_pendientes = 6    (tope 6, debio ser 0)
+--
+-- Causa raiz (verificada contra el codigo REAL de prod, no el repo):
+--   public.aplicar_uso_promo_acumulador hacia
+--       v_usos_nuevo := v_acc.usos_pendientes + p_delta;   -- SIN clamp
+--       v_old_blocks := FLOOR(v_acc.usos_pendientes / N);  -- SIN GREATEST
+--   => guardaba valores negativos o > tope, y FLOOR sobre negativos producia
+--      delta_blocks negativo => "stock = stock - (-1)" = stock fantasma sumado
+--      al contenedor. (El repo si tenia GREATEST; prod habia quedado atras.)
+--   sustituir_regalo_pedido amplificaba: sincronizaba el acumulador default al
+--   contador-resto global y luego le restaba la CANTIDAD COMPLETA del item ->
+--   underflow.
+--
+-- Fix de fondo: alinear el acumulador a la MISMA semantica que el contador
+-- global (promociones.usos_pendientes) y que revertir_bloques_auto_ajuste:
+-- usos_pendientes es un RESTO que SIEMPRE vive en [0, N). Al cruzar bloques se
+-- descuenta/devuelve stock del contenedor y se deja el resto. Con esto, la
+-- sustitucion (que llama a este helper con -cantidad / +cantidad) queda
+-- coherente sin reescribir sustituir_regalo_pedido: el -cantidad revierte
+-- bloques (devuelve fardos del sabor original) y el +cantidad completa bloques
+-- (descuenta fardos del sabor nuevo).
+
+-- ============================================================================
+-- PARTE A — Helper endurecido: semantica de resto + clamp
+-- ============================================================================
+CREATE OR REPLACE FUNCTION public.aplicar_uso_promo_acumulador(
+  p_promocion_id bigint,
+  p_producto_regalo_id bigint,
+  p_delta numeric,
+  p_ajuste_producto_id_def bigint,
+  p_sucursal_id bigint,
+  p_usuario_id uuid,
+  p_motivo text
+) RETURNS jsonb
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public'
+AS $function$
+DECLARE
+  v_promo          RECORD;
+  v_acc            RECORD;
+  v_usos_raw       NUMERIC;
+  v_blocks         INT;          -- magnitud de bloques cruzados (>= 0)
+  v_usos_final     NUMERIC;      -- resto resultante, SIEMPRE en [0, N)
+  v_stock_delta    INT;          -- + devuelve / - descuenta (unidades de contenedor)
+  v_usos_ajustados INT;          -- para auditoria (+ descuento / - reversion)
+  v_stock_anterior INT;
+  v_stock_nuevo    INT;
+  v_merma_id       BIGINT;
+BEGIN
+  SELECT id, unidades_por_bloque, stock_por_bloque, ajuste_automatico,
+         ajuste_producto_id, regalo_mueve_stock
+    INTO v_promo
+    FROM promociones
+   WHERE id = p_promocion_id AND sucursal_id = p_sucursal_id
+   FOR UPDATE;
+  IF NOT FOUND THEN
+    RETURN jsonb_build_object('aplicado', false, 'razon', 'promo no encontrada');
+  END IF;
+  IF NOT COALESCE(v_promo.ajuste_automatico, FALSE) THEN
+    RETURN jsonb_build_object('aplicado', false, 'razon', 'promo no es modo B');
+  END IF;
+  IF COALESCE(v_promo.unidades_por_bloque, 0) <= 0
+     OR COALESCE(v_promo.stock_por_bloque, 0) <= 0 THEN
+    RETURN jsonb_build_object('aplicado', false, 'razon', 'config bloque invalida');
+  END IF;
+
+  SELECT id, ajuste_producto_id, unidades_por_bloque, stock_por_bloque, usos_pendientes
+    INTO v_acc
+    FROM promo_acumuladores
+   WHERE promocion_id = p_promocion_id
+     AND producto_regalo_id = p_producto_regalo_id
+     AND sucursal_id = p_sucursal_id
+   FOR UPDATE;
+  IF NOT FOUND THEN
+    INSERT INTO promo_acumuladores (
+      promocion_id, producto_regalo_id, ajuste_producto_id,
+      unidades_por_bloque, stock_por_bloque, usos_pendientes, sucursal_id
+    ) VALUES (
+      p_promocion_id, p_producto_regalo_id, p_ajuste_producto_id_def,
+      v_promo.unidades_por_bloque, v_promo.stock_por_bloque, 0, p_sucursal_id
+    )
+    ON CONFLICT (promocion_id, producto_regalo_id, sucursal_id) DO NOTHING;
+    SELECT id, ajuste_producto_id, unidades_por_bloque, stock_por_bloque, usos_pendientes
+      INTO v_acc
+      FROM promo_acumuladores
+     WHERE promocion_id = p_promocion_id
+       AND producto_regalo_id = p_producto_regalo_id
+       AND sucursal_id = p_sucursal_id
+     FOR UPDATE;
+  END IF;
+
+  -- Semantica de RESTO con clamp: usos_pendientes SIEMPRE queda en [0, N).
+  v_usos_raw := COALESCE(v_acc.usos_pendientes, 0) + p_delta;
+  IF v_usos_raw >= 0 THEN
+    v_blocks      := FLOOR(v_usos_raw / v_acc.unidades_por_bloque)::INT;   -- bloques completados
+    v_usos_final  := v_usos_raw - (v_blocks * v_acc.unidades_por_bloque);
+    v_stock_delta := -(v_blocks * v_acc.stock_por_bloque);                 -- descuenta contenedor
+    v_usos_ajustados := v_blocks * v_acc.unidades_por_bloque;
+  ELSE
+    v_blocks      := CEIL(ABS(v_usos_raw) / v_acc.unidades_por_bloque)::INT; -- bloques a revertir
+    v_usos_final  := v_usos_raw + (v_blocks * v_acc.unidades_por_bloque);
+    v_stock_delta := (v_blocks * v_acc.stock_por_bloque);                  -- devuelve contenedor
+    v_usos_ajustados := -(v_blocks * v_acc.unidades_por_bloque);
+  END IF;
+
+  UPDATE promo_acumuladores
+     SET usos_pendientes = v_usos_final, updated_at = NOW()
+   WHERE id = v_acc.id;
+
+  IF v_stock_delta <> 0 AND v_acc.ajuste_producto_id IS NOT NULL THEN
+    PERFORM set_config('app.stock_origen', 'auto_ajuste_promo', true);
+    PERFORM set_config('app.stock_ref_tipo', 'promocion', true);
+    PERFORM set_config('app.stock_ref_id', p_promocion_id::TEXT, true);
+    PERFORM set_config('app.stock_user_id', p_usuario_id::TEXT, true);
+
+    SELECT stock INTO v_stock_anterior
+      FROM productos
+     WHERE id = v_acc.ajuste_producto_id AND sucursal_id = p_sucursal_id
+     FOR UPDATE;
+    v_stock_nuevo := COALESCE(v_stock_anterior, 0) + v_stock_delta;
+
+    UPDATE productos SET stock = v_stock_nuevo, updated_at = NOW()
+     WHERE id = v_acc.ajuste_producto_id AND sucursal_id = p_sucursal_id;
+
+    INSERT INTO mermas_stock (
+      producto_id, cantidad, motivo, observaciones,
+      stock_anterior, stock_nuevo, usuario_id, sucursal_id
+    ) VALUES (
+      v_acc.ajuste_producto_id,
+      -v_stock_delta,   -- convencion: + = descuento, - = devolucion (igual que el resto del codigo)
+      CASE WHEN v_stock_delta < 0 THEN 'promociones' ELSE 'promociones_reversion' END,
+      p_motivo, COALESCE(v_stock_anterior, 0), v_stock_nuevo, p_usuario_id, p_sucursal_id
+    ) RETURNING id INTO v_merma_id;
+
+    INSERT INTO promo_ajustes (
+      promocion_id, usos_ajustados, unidades_ajustadas,
+      producto_id, merma_id, usuario_id, observaciones, sucursal_id
+    ) VALUES (
+      p_promocion_id, v_usos_ajustados, -v_stock_delta,
+      v_acc.ajuste_producto_id, v_merma_id, p_usuario_id, p_motivo, p_sucursal_id
+    );
+  END IF;
+
+  RETURN jsonb_build_object(
+    'aplicado', true,
+    'acumulador_id', v_acc.id,
+    'usos_pendientes', v_usos_final,
+    'bloques_delta', CASE WHEN v_stock_delta < 0 THEN v_blocks ELSE -v_blocks END
+  );
+END;
+$function$;
+
+-- ============================================================================
+-- PARTE B — Recompute de acumuladores existentes al RESTO correcto
+-- ============================================================================
+-- usos_pendientes correcto por sabor = (total regalado NO cancelado) mod N.
+-- Es solo el contador de display; promo_acumuladores no tiene trigger de stock,
+-- asi que este UPDATE NO mueve stock. El ajuste de stock fisico (descuadres de
+-- contenedor) va en migracion aparte, con conteo confirmado.
+--
+-- OJO: esto NO arregla el descuadre de stock fisico de los contenedores
+-- (ver auditoria: 87 +4, 81 +4, 82 +3, 80 +1, 86 -1, 85 -1 vs lo esperado),
+-- que ademas se entrelaza con las correcciones manuales 067/068.
+
+WITH entregado AS (
+  SELECT pi.promocion_id,
+         pi.producto_id,
+         pi.sucursal_id,
+         (SUM(pi.cantidad) % p.unidades_por_bloque) AS resto
+    FROM pedido_items pi
+    JOIN pedidos pe   ON pe.id = pi.pedido_id
+    JOIN promociones p ON p.id = pi.promocion_id AND p.sucursal_id = pi.sucursal_id
+   WHERE pi.es_bonificacion = true
+     AND pe.estado <> 'cancelado'
+     AND COALESCE(p.ajuste_automatico, false) = true
+     AND COALESCE(p.unidades_por_bloque, 0) > 0
+   GROUP BY pi.promocion_id, pi.producto_id, pi.sucursal_id, p.unidades_por_bloque
+)
+UPDATE promo_acumuladores a
+   SET usos_pendientes = e.resto, updated_at = NOW()
+  FROM entregado e
+ WHERE a.promocion_id = e.promocion_id
+   AND a.producto_regalo_id = e.producto_id
+   AND a.sucursal_id = e.sucursal_id
+   AND a.usos_pendientes IS DISTINCT FROM e.resto;
+
+-- Acumuladores sin entregas reales (huerfanos de sustituciones revertidas) -> 0.
+UPDATE promo_acumuladores a
+   SET usos_pendientes = 0, updated_at = NOW()
+ WHERE a.usos_pendientes <> 0
+   AND NOT EXISTS (
+     SELECT 1
+       FROM pedido_items pi
+       JOIN pedidos pe ON pe.id = pi.pedido_id
+      WHERE pi.promocion_id = a.promocion_id
+        AND pi.producto_id  = a.producto_regalo_id
+        AND pi.sucursal_id  = a.sucursal_id
+        AND pi.es_bonificacion = true
+        AND pe.estado <> 'cancelado'
+   );
+
+-- ============================================================================
+-- VERIFICACION (correr despues de aplicar; debe devolver 0 filas)
+-- ============================================================================
+-- SELECT * FROM promo_acumuladores
+--  WHERE usos_pendientes < 0
+--     OR usos_pendientes >= COALESCE(unidades_por_bloque, 1);

--- a/migrations/092_fix_stock_contenedores_promo_acumuladores.sql
+++ b/migrations/092_fix_stock_contenedores_promo_acumuladores.sql
@@ -1,0 +1,110 @@
+-- 092_fix_stock_contenedores_promo_acumuladores.sql
+--
+-- PARA REVISAR ANTES DE APLICAR. Toca STOCK FISICO (sucursal 1). Aplicarla
+-- DESPUES de 091. Idempotente via marcador en observaciones (estilo mig 067).
+--
+-- ============================================================================
+-- CONTEXTO (auditoria 2026-06-23)
+-- ============================================================================
+-- La auditoria comparo, por sabor, los bloques que DEBIERON descontarse
+--   ( FLOOR(total_regalado_no_cancelado / unidades_por_bloque) )
+-- contra lo realmente movido en promo_ajustes. Descuadre detectado (fardos):
+--
+--   contenedor 87 Pomelo 600   esperado 37  real 41  -> +4 de mas  => DEVOLVER 4
+--   contenedor 81 Pomelo 3L    esperado 29  real 33  -> +4 de mas  => DEVOLVER 4
+--   contenedor 82 Manzana 3L   esperado 49  real 52  -> +3 de mas  => DEVOLVER 3
+--   contenedor 80 Naranja 3L   esperado 30  real 31  -> +1 de mas  => DEVOLVER 1
+--   contenedor 85 Lima Limon600 esperado 43 real 42  -> -1 de menos => DESCONTAR 1
+--   contenedor 86 Naranja 600  esperado 12  real 11  -> -1 de menos => DESCONTAR 1
+--
+-- DECISION DEL USUARIO: aplicar la estimacion (asumir que el modelo por-sabor es
+-- la verdad). ADVERTENCIA registrada: parte del descuadre puede ser carryover
+-- legitimo del modelo global al cambiar de sabor, o ruido de los parches
+-- manuales 067/068. La estimacion los corrige igual.
+--
+-- SALVAGUARDA: el stock NUNCA queda negativo. El producto 86 (Naranja 600) hoy
+-- esta en 0; "descontar 1" lo dejaria en -1 => se OMITE (con NOTICE). Eso
+-- confirma que ese -1 era ruido. Los otros 5 se aplican (87,81,82,80 devuelven;
+-- 85 descuenta 55->54).
+--
+-- Convencion de signos (igual que mig 067 y el resto del codigo):
+--   devolver stock  -> productos.stock += ; mermas.cantidad NEGATIVO ; motivo 'promociones_reversion'
+--   descontar stock -> productos.stock -= ; mermas.cantidad POSITIVO ; motivo 'promociones'
+
+DO $$
+DECLARE
+  v_suc    bigint := 1;
+  v_marker text   := 'Correccion stock contenedor promo (mig 092, auditoria 2026-06-23)';
+  r        RECORD;
+  v_old    int;
+  v_new    int;
+  v_merma  bigint;
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM mermas_stock
+     WHERE observaciones LIKE v_marker || '%' AND sucursal_id = v_suc
+  ) THEN
+    RAISE NOTICE 'mig 092 ya aplicada; se omite.';
+    RETURN;
+  END IF;
+
+  PERFORM set_config('app.stock_origen', 'correccion_mig_092', true);
+
+  FOR r IN
+    SELECT * FROM (VALUES
+      -- producto_id, promocion_id, delta_stock (+ devuelve / - descuenta), N (unidades_por_bloque)
+      (87, 12,  4, 12),
+      (81, 13,  4,  6),
+      (82, 13,  3,  6),
+      (80, 13,  1,  6),
+      (85, 12, -1, 12),
+      (86, 10, -1, 12)
+    ) AS t(producto_id, promocion_id, delta_stock, n)
+  LOOP
+    SELECT stock INTO v_old FROM productos
+      WHERE id = r.producto_id AND sucursal_id = v_suc FOR UPDATE;
+
+    IF v_old IS NULL THEN
+      RAISE NOTICE 'mig 092: producto % no existe en sucursal %, se omite', r.producto_id, v_suc;
+      CONTINUE;
+    END IF;
+
+    v_new := v_old + r.delta_stock;
+    IF v_new < 0 THEN
+      RAISE NOTICE 'mig 092: producto % quedaria negativo (% %+ = %), se OMITE (descuadre probablemente ruido/carryover)',
+        r.producto_id, v_old, r.delta_stock, v_new;
+      CONTINUE;
+    END IF;
+
+    UPDATE productos SET stock = v_new, updated_at = NOW()
+      WHERE id = r.producto_id AND sucursal_id = v_suc;
+
+    INSERT INTO mermas_stock (
+      producto_id, cantidad, motivo, observaciones,
+      stock_anterior, stock_nuevo, sucursal_id
+    ) VALUES (
+      r.producto_id,
+      -r.delta_stock,
+      CASE WHEN r.delta_stock < 0 THEN 'promociones' ELSE 'promociones_reversion' END,
+      v_marker || ' (delta ' || r.delta_stock || ' fardos, prod ' || r.producto_id || ')',
+      v_old, v_new, v_suc
+    ) RETURNING id INTO v_merma;
+
+    INSERT INTO promo_ajustes (
+      promocion_id, usos_ajustados, unidades_ajustadas,
+      producto_id, merma_id, observaciones, sucursal_id
+    ) VALUES (
+      r.promocion_id, (-r.delta_stock) * r.n, -r.delta_stock,
+      r.producto_id, v_merma, v_marker, v_suc
+    );
+
+    RAISE NOTICE 'mig 092: producto % stock % -> % (delta % fardos)',
+      r.producto_id, v_old, v_new, r.delta_stock;
+  END LOOP;
+END $$;
+
+-- ============================================================================
+-- VERIFICACION (post-aplicar): no debe haber stock negativo en los contenedores
+-- ============================================================================
+-- SELECT id, nombre, stock FROM productos
+--  WHERE id IN (80,81,82,85,86,87) AND sucursal_id = 1 ORDER BY id;

--- a/src/components/modals/ModalSustituirRegalo.tsx
+++ b/src/components/modals/ModalSustituirRegalo.tsx
@@ -116,6 +116,13 @@ const ModalSustituirRegalo = memo(function ModalSustituirRegalo({
   const usosSustAntes = Number(acumuladorSustituto?.usos_pendientes ?? 0)
   const usosSustDespues = usosSustAntes + cantidadNum
   const bloque = unidadesPorBloque ?? acumuladorOriginal?.unidades_por_bloque ?? 1
+  // Defensa display: los acumuladores pueden venir fuera de rango (bug backend de bloques).
+  // Clampeamos los valores que se muestran al usuario a [0, bloque].
+  const clampBloque = (n: number) => Math.max(0, Math.min(n, bloque))
+  const dispOrigAntes = clampBloque(usosOrigAntes)
+  const dispOrigDespues = clampBloque(usosOrigDespues)
+  const dispSustAntes = clampBloque(usosSustAntes)
+  const dispSustDespues = clampBloque(usosSustDespues)
   const cruzaAbajo = Math.floor(usosOrigDespues / bloque) < Math.floor(usosOrigAntes / bloque)
   const cruzaArriba = Math.floor(usosSustDespues / bloque) > Math.floor(usosSustAntes / bloque)
 
@@ -234,7 +241,7 @@ const ModalSustituirRegalo = memo(function ModalSustituirRegalo({
                 <>
                   <p>
                     ✓ El contador de <b>{productoOriginal.nombre}</b> baja
-                    de <b>{usosOrigAntes}/{bloque}</b> a <b>{usosOrigDespues}/{bloque}</b>.
+                    de <b>{dispOrigAntes}/{bloque}</b> a <b>{dispOrigDespues}/{bloque}</b>.
                   </p>
                   {cruzaAbajo && (
                     <p className="text-emerald-700 dark:text-emerald-300 ml-3">
@@ -243,7 +250,7 @@ const ModalSustituirRegalo = memo(function ModalSustituirRegalo({
                   )}
                   <p>
                     ✓ El contador de <b>{productoNuevo.nombre}</b> sube
-                    de <b>{usosSustAntes}/{bloque}</b> a <b>{usosSustDespues}/{bloque}</b>.
+                    de <b>{dispSustAntes}/{bloque}</b> a <b>{dispSustDespues}/{bloque}</b>.
                   </p>
                   {cruzaArriba ? (
                     <p className="text-orange-700 dark:text-orange-300 ml-3">

--- a/src/components/vistas/VistaPromociones.tsx
+++ b/src/components/vistas/VistaPromociones.tsx
@@ -295,7 +295,10 @@ export default function VistaPromociones({
                       <div className="mb-3 space-y-2">
                         {visibles.map(acc => {
                           const porBloque = acc.unidades_por_bloque ?? promo.unidades_por_bloque ?? 1
-                          const pendientes = acc.usos_pendientes
+                          // Defensa: el acumulador puede venir fuera de rango desde la BD
+                          // (bug historico del subsistema de bloques: negativos o > tope).
+                          // Clampeamos a [0, porBloque] para no mostrar "24/12" o "-10/12".
+                          const pendientes = Math.max(0, Math.min(acc.usos_pendientes, porBloque))
                           const falta = Math.max(porBloque - pendientes, 0)
                           const progreso = porBloque > 0 ? Math.min((pendientes / porBloque) * 100, 100) : 0
                           const esDefault = defaultProductoId !== null

--- a/supabase/functions/_shared/pricing/index.ts
+++ b/supabase/functions/_shared/pricing/index.ts
@@ -58,6 +58,9 @@ interface PromocionRow {
   prioridad: number | null;
   regalo_mueve_stock: boolean | null;
   modo_exclusion: string | null;
+  ajuste_producto_id: number | null;
+  unidades_por_bloque: number | null;
+  descripcion_regalo: string | null;
 }
 interface PromocionProductoRow {
   promocion_id: number;
@@ -236,7 +239,7 @@ async function loadPromoMap(
   const { data: promos, error: errPromos } = await supabase
     .from("promociones")
     .select(
-      "id, nombre, tipo, activo, fecha_inicio, fecha_fin, sucursal_id, producto_regalo_id, prioridad, regalo_mueve_stock, modo_exclusion",
+      "id, nombre, tipo, activo, fecha_inicio, fecha_fin, sucursal_id, producto_regalo_id, prioridad, regalo_mueve_stock, modo_exclusion, ajuste_producto_id, unidades_por_bloque, descripcion_regalo",
     )
     .eq("sucursal_id", sucursalId)
     .eq("activo", true)
@@ -290,6 +293,9 @@ async function loadPromoMap(
       prioridad: promo.prioridad ?? 0,
       regaloMueveStock: promo.regalo_mueve_stock ?? false,
       modoExclusion: (promo.modo_exclusion ?? "acumulable") as PromocionActiva["modoExclusion"],
+      ajusteProductoId: promo.ajuste_producto_id ? String(promo.ajuste_producto_id) : undefined,
+      unidadesPorBloque: promo.unidades_por_bloque ?? undefined,
+      descripcionRegalo: promo.descripcion_regalo ?? undefined,
     };
 
     for (const productoId of productosDePromo) {


### PR DESCRIPTION
## Contexto

Auditoría del módulo de **promociones** (foco: aplicación de reglas y ajuste de stock en modo Fracción). Síntoma reportado: la barra de consumo mostraba valores imposibles como **`24/12`** o **`-10/12`**. **Reproducido y verificado contra producción** (sucursal 1).

## Causa raíz

Dos contadores paralelos con semánticas incompatibles que nunca se reconcilian:

| | `promociones.usos_pendientes` | `promo_acumuladores.usos_pendientes` |
|---|---|---|
| Granularidad | 1 por promo | 1 por **sabor** de regalo |
| Semántica | **resto** [0,N) con clamp | **total corrido sin clamp** |
| Escribe | crear/editar/cancelar/salvedad/bot | **solo** sustitución |
| Lee | auto-ajuste de stock | **la barra del front** |

En **prod**, `aplicar_uso_promo_acumulador` no tenía el clamp/`GREATEST` que sí estaba en el repo, y el `FLOOR` sobre valores negativos **sumaba stock fantasma** al contenedor. `sustituir_regalo_pedido` restaba la cantidad completa del item a un contador-resto → underflow.

> Las **reglas** se resuelven bien (resolver testeado y espejado al bot; acumulación entre sabores, excluyentes/prioridad y multi-sucursal correctos). El problema estaba en el **subsistema de bloques/acumuladores de stock**.

## Cambios

**Código**
- Clamp defensivo de la barra: `VistaPromociones.tsx`, `ModalSustituirRegalo.tsx`.
- Bot `pricing/index.ts`: ahora trae `ajuste_producto_id`, `unidades_por_bloque`, `descripcion_regalo` (faltaba la descripción del regalo en la preview del bot).

**Migraciones**
- `091_fix_promo_acumuladores_resto_y_clamp.sql`: endurece `aplicar_uso_promo_acumulador` a semántica de **resto + clamp** (arregla la sustitución transitivamente) y **recomputa los acumuladores al resto correcto**. No toca stock.
- `092_fix_stock_contenedores_promo_acumuladores.sql`: corrige el **stock físico** de contenedores con descuadre (87 +4, 81 +4, 82 +3, 80 +1, 85 −1; omite 86 que está en 0). Idempotente, con guarda anti-negativo y asiento en `mermas_stock`/`promo_ajustes`.

## Verificación
- `npm run typecheck` limpio; `deno check` del bot OK; **732 tests** verdes (pre-commit).
- Post-migración (a correr en prod): `SELECT * FROM promo_acumuladores WHERE usos_pendientes < 0 OR usos_pendientes >= unidades_por_bloque;` → 0 filas.

## Pendiente (fuera de esta PR)
- **Fase 2** (estructural): cablear los acumuladores en crear/editar/cancelar/salvedad para promos multi-sabor; mientras tanto el bar del regalo *default* queda estático (en rango) hasta una sustitución.
- Validaciones de form (`limite_usos`/`prioridad` ≥ 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)