### PR TITLE
fix(promociones): Fase 2 — el bar del regalo default lee el contador global (vivo)

### DIFF
--- a/src/components/vistas/VistaPromociones.tsx
+++ b/src/components/vistas/VistaPromociones.tsx
@@ -257,37 +257,46 @@ export default function VistaPromociones({
                 )}
 
                 {/* Subunidades pendientes para descontar stock — multi-barra (mig 059).
-                    Si hay acumuladores en promo_acumuladores los mostramos uno por uno;
-                    para el regalo default siempre se muestra incluso si esta en 0/N
-                    (con leyenda "Bloque recien cerrado"); los acumuladores
-                    alternativos (sustituciones) solo se muestran si usos_pendientes > 0. */}
+                    El bar del regalo DEFAULT se lee SIEMPRE del contador global vivo
+                    (promociones.usos_pendientes): los pedidos normales actualizan ese
+                    contador, no el acumulador (que solo lo mueve la sustitucion), asi que
+                    leerlo del global mantiene la barra al dia. Los acumuladores
+                    alternativos (sustituciones) se muestran desde su fila, solo si > 0. */}
                 {promo.ajuste_automatico && promo.unidades_por_bloque && promo.unidades_por_bloque > 0 && (
                   (() => {
-                    const acumuladores = (acumuladoresPorPromo?.get(String(promo.id)) ?? []).slice()
+                    const accRows = acumuladoresPorPromo?.get(String(promo.id)) ?? []
                     const defaultProductoId = promo.producto_regalo_id ? String(promo.producto_regalo_id) : null
 
-                    // Si NO hay acumuladores en la tabla, sintetizamos uno default desde promo.usos_pendientes.
-                    if (acumuladores.length === 0 && defaultProductoId) {
-                      acumuladores.push({
-                        id: `legacy-${promo.id}`,
+                    const visibles: PromoAcumuladorDB[] = []
+
+                    // Bar DEFAULT: valor desde el contador global (vivo). Tomamos el
+                    // contenedor/config del acumulador default si existe (nombre correcto),
+                    // si no del propio promo.
+                    if (defaultProductoId) {
+                      const accDefault = accRows.find(
+                        a => String(a.producto_regalo_id) === defaultProductoId
+                      )
+                      visibles.push({
+                        id: `default-${promo.id}`,
                         promocion_id: String(promo.id),
                         producto_regalo_id: defaultProductoId,
-                        ajuste_producto_id: promo.ajuste_producto_id ? String(promo.ajuste_producto_id) : null,
-                        unidades_por_bloque: promo.unidades_por_bloque,
-                        stock_por_bloque: promo.stock_por_bloque,
+                        ajuste_producto_id: accDefault?.ajuste_producto_id
+                          ?? (promo.ajuste_producto_id ? String(promo.ajuste_producto_id) : null),
+                        unidades_por_bloque: accDefault?.unidades_por_bloque ?? promo.unidades_por_bloque,
+                        stock_por_bloque: accDefault?.stock_por_bloque ?? promo.stock_por_bloque,
                         usos_pendientes: promo.usos_pendientes ?? 0,
-                        sucursal_id: 0,
+                        sucursal_id: accDefault?.sucursal_id ?? 0,
                         created_at: '',
                         updated_at: '',
                       } as PromoAcumuladorDB)
                     }
 
-                    // Filtrar: mostrar default siempre, alternativos solo si > 0.
-                    const visibles = acumuladores.filter(acc => {
-                      const esDefault = defaultProductoId !== null
-                        && String(acc.producto_regalo_id) === defaultProductoId
-                      return esDefault || acc.usos_pendientes > 0
-                    })
+                    // Barras de SUSTITUTOS: desde sus acumuladores, distintos del default
+                    // y con usos pendientes > 0.
+                    for (const acc of accRows) {
+                      if (String(acc.producto_regalo_id) === defaultProductoId) continue
+                      if (acc.usos_pendientes > 0) visibles.push(acc)
+                    }
 
                     if (visibles.length === 0) return null
 


### PR DESCRIPTION
## Contexto

Continuación de la auditoría de promociones (tras #391, que arregló los acumuladores y el stock). Quedaba un gap: el bar de consumo del **regalo default** se mostraba **estático** tras pedidos normales.

## Causa

Los pedidos normales (crear/editar/cancelar/bot) actualizan el contador **global** `promociones.usos_pendientes`, **no** el `promo_acumuladores` (que solo lo mueve la sustitución). El front leía el acumulador para el bar default → quedaba congelado. El dato correcto y vivo **ya existía** en el contador global.

## Cambio (front-only, sin tocar backend ni stock)

`VistaPromociones.tsx`: el bar del regalo **default** se sintetiza siempre desde `promociones.usos_pendientes` (contador global, vivo). Los bars de **sustitutos** siguen leyendo sus filas de `promo_acumuladores` (gestionadas por el helper ya endurecido en #391). 

Decisión de alcance acordada: **fix dirigido** en vez de reescribir las 5 RPCs financieras (unificación completa), por relación riesgo/beneficio — los pedidos normales solo entregan el sabor default, así que el conteo per-sabor solo aplica a sustituciones, que ya están cubiertas.

## Verificación
- `npm run typecheck` limpio (solo errores preexistentes de `leaflet` en `MapaRuta.tsx`, ajenos).
- **732 tests** verdes (pre-commit).
- Manual sugerido: con una promo modo Fracción, crear pedidos que sumen al bloque → el bar default avanza y resetea a 0/N al cerrar; sustituir un regalo → aparece su bar aparte, ambos en rango.

## Pendiente (no en esta PR)
- Unificación completa de las RPCs en el modelo per-sabor (opcional, requiere testing en branch de Supabase).
- Validaciones de form (`limite_usos`/`prioridad` ≥ 0).
- Redeploy de la edge function del bot para que `descripcion_regalo` aparezca en la preview (el código ya está en main desde #391).

🤖 Generated with [Claude Code](https://claude.com/claude-code)