### PR TITLE
fix(rutas+pwa): re-rutear pedidos no entregados + comanda resiliente a deploy

### DIFF
--- a/migrations/093_quitar_pedido_de_recorridos_activos.sql
+++ b/migrations/093_quitar_pedido_de_recorridos_activos.sql
@@ -1,0 +1,45 @@
+-- 093_quitar_pedido_de_recorridos_activos.sql
+--
+-- Soporte para re-rutear pedidos no entregados. Cuando un pedido 'asignado' se
+-- vuelve a 'pendiente' (boton "Volver a pendiente"), debe salir de la ruta
+-- (recorrido) en curso a la que pertenece; si no, queda como parada fantasma en
+-- la ruta de hoy aunque ya no se entregue ese dia.
+--
+-- recorrido_pedidos NO tiene policy de DELETE (solo INSERT/SELECT/UPDATE), asi
+-- que el cliente no puede borrar la parada. Esta RPC SECURITY DEFINER lo hace,
+-- con chequeo de rol (admin/encargado) y scope por sucursal. Solo toca
+-- recorridos en_curso (no altera el historico de rutas finalizadas).
+
+CREATE OR REPLACE FUNCTION public.quitar_pedido_de_recorridos_activos(p_pedido_id bigint)
+RETURNS jsonb
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public'
+AS $function$
+DECLARE
+  v_sucursal BIGINT := current_sucursal_id();
+  v_role     TEXT;
+  v_borradas INT;
+BEGIN
+  IF v_sucursal IS NULL THEN
+    RETURN jsonb_build_object('success', false, 'error', 'No hay sucursal activa');
+  END IF;
+
+  SELECT rol INTO v_role FROM perfiles WHERE id = auth.uid();
+  IF v_role IS NULL OR v_role NOT IN ('admin', 'encargado') THEN
+    RETURN jsonb_build_object('success', false, 'error', 'No autorizado');
+  END IF;
+
+  DELETE FROM recorrido_pedidos rp
+   USING recorridos r
+   WHERE rp.recorrido_id = r.id
+     AND rp.pedido_id = p_pedido_id
+     AND rp.sucursal_id = v_sucursal
+     AND r.estado = 'en_curso';
+  GET DIAGNOSTICS v_borradas = ROW_COUNT;
+
+  RETURN jsonb_build_object('success', true, 'paradas_eliminadas', v_borradas);
+END;
+$function$;
+
+GRANT EXECUTE ON FUNCTION public.quitar_pedido_de_recorridos_activos(bigint) TO authenticated;

--- a/src/components/containers/PedidosContainer.tsx
+++ b/src/components/containers/PedidosContainer.tsx
@@ -19,6 +19,7 @@ import {
   useCrearPedidoMutation,
   useCambiarEstadoMutation,
   useAsignarTransportistaMutation,
+  useQuitarPedidoDeRecorridosMutation,
   useEntregasMasivasMutation,
   useCancelarPedidoMutation,
   usePagosMasivosMutation,
@@ -46,6 +47,7 @@ import type { GpsResult, GpsStatus } from '../../hooks/useGeolocationCapture'
 import { supabase } from '../../hooks/supabase/base'
 import { usePagos } from '../../hooks/supabase/usePagos'
 import { retryWithBackoff, isTransientNetworkError } from '../../utils/retryWithBackoff'
+import { importConRecarga } from '../../utils/lazyWithReload'
 import type { PedidoDB, FiltrosPedidosState, PerfilDB, RegistrarSalvedadInput, RegistrarSalvedadResult, PagoDBWithUsuario } from '../../types'
 import type { PedidoEditItem } from '../modals/ModalEditarPedido'
 import type { RutaMultiResultadoUI } from '../modals/ModalGestionRutas'
@@ -146,6 +148,7 @@ export default function PedidosContainer(): React.ReactElement {
   const { capturarGps, registrarGpsPedido } = useRegistrarGeolocalizacionPedido()
   const cambiarEstado = useCambiarEstadoMutation()
   const asignarTransportistaMut = useAsignarTransportistaMutation()
+  const quitarDeRecorridosMut = useQuitarPedidoDeRecorridosMutation()
   const entregasMasivas = useEntregasMasivasMutation()
   const cancelarPedidoMut = useCancelarPedidoMutation()
   const pagosMasivos = usePagosMasivosMutation()
@@ -392,19 +395,22 @@ export default function PedidosContainer(): React.ReactElement {
   const handleVolverAPendiente = useCallback((pedido: PedidoDB) => {
     setConfirmConfig({
       visible: true, titulo: 'Volver a pendiente',
-      mensaje: `¿Volver el pedido #${pedido.id} a estado "Pendiente"?`, tipo: 'warning',
+      mensaje: `¿Volver el pedido #${pedido.id} a estado "Pendiente"? Si está en una ruta activa, se quitará de ella.`, tipo: 'warning',
       onConfirm: async () => {
         try {
           if (pedido.transportista_id) {
             await asignarTransportistaMut.mutateAsync({ pedidoId: pedido.id, transportistaId: null })
           }
           await cambiarEstado.mutateAsync({ pedidoId: pedido.id, nuevoEstado: 'pendiente' })
+          // Sacarlo de la(s) ruta(s) en curso para que no quede como parada
+          // fantasma; así reaparece limpio en el pool de "Armar ruta".
+          await quitarDeRecorridosMut.mutateAsync({ pedidoId: pedido.id })
           notify.warning('Pedido vuelto a pendiente')
         } catch (e) { notify.error((e as Error).message) }
         setConfirmConfig({ visible: false })
       },
     })
-  }, [cambiarEstado, asignarTransportistaMut, notify])
+  }, [cambiarEstado, asignarTransportistaMut, quitarDeRecorridosMut, notify])
 
   const handleVerHistorial = useCallback(async (pedido: PedidoDB) => {
     setPedidoHistorial(pedido)
@@ -1015,7 +1021,7 @@ export default function PedidosContainer(): React.ReactElement {
   // ModalExportarPDF handlers (lazy PDF generation)
   const handleExportarOrdenPreparacion = useCallback(async (pedidosExport: PedidoDB[]) => {
     try {
-      const { generarOrdenPreparacion } = await import('../../lib/pdfExport')
+      const { generarOrdenPreparacion } = await importConRecarga(() => import('../../lib/pdfExport'))
       generarOrdenPreparacion(pedidosExport)
     } catch (e) { notify.error((e as Error).message) }
   }, [notify])
@@ -1023,14 +1029,14 @@ export default function PedidosContainer(): React.ReactElement {
   const handleExportarHojaRuta = useCallback(async (transportista: PerfilDB | undefined, pedidosExport: PedidoDB[]) => {
     if (!transportista) return
     try {
-      const { generarHojaRutaOptimizada } = await import('../../lib/pdfExport')
+      const { generarHojaRutaOptimizada } = await importConRecarga(() => import('../../lib/pdfExport'))
       generarHojaRutaOptimizada(transportista, pedidosExport)
     } catch (e) { notify.error((e as Error).message) }
   }, [notify])
 
   const handleImprimirComandas = useCallback(async (pedidosExport: PedidoDB[]) => {
     try {
-      const { generarComandasMultiples } = await import('../../lib/pdfExport')
+      const { generarComandasMultiples } = await importConRecarga(() => import('../../lib/pdfExport'))
       generarComandasMultiples(pedidosExport)
     } catch (e) { notify.error((e as Error).message) }
   }, [notify])
@@ -1236,7 +1242,7 @@ export default function PedidosContainer(): React.ReactElement {
 
   const handleExportarHojaRutaOptimizada = useCallback(async (transportista: PerfilDB | undefined, pedidosOrdenados: PedidoDB[]) => {
     try {
-      const { generarHojaRutaOptimizada } = await import('../../lib/pdfExport')
+      const { generarHojaRutaOptimizada } = await importConRecarga(() => import('../../lib/pdfExport'))
       if (transportista) generarHojaRutaOptimizada(transportista, pedidosOrdenados)
     } catch (e) { notify.error((e as Error).message) }
   }, [notify])

--- a/src/components/pedidos/PedidoCard.tsx
+++ b/src/components/pedidos/PedidoCard.tsx
@@ -9,8 +9,9 @@
  */
 import React, { useState, memo, useContext } from 'react';
 import { Clock, Package, Truck, Check, Eye, ChevronDown, ChevronUp, CreditCard, User, MapPin, Phone, FileText, Building2, Timer, FileDown, LucideIcon, AlertTriangle, Gift, RefreshCw } from 'lucide-react';
+import { importConRecarga } from '../../utils/lazyWithReload';
 const generarReciboPedido = async (pedido: any, _empresa: any = {}, options: { formato?: 'a4' | 'comanda' } = {}) => {
-  const mod = await import('../../lib/pdfExport') as any
+  const mod = await importConRecarga(() => import('../../lib/pdfExport')) as any
   return mod.generarReciboPedido(pedido, _empresa, options)
 };
 import { formatPrecio, formatFecha, formatHora, getEstadoColor, getEstadoPagoColor, getEstadoPagoLabel, getFormaPagoLabel, getFormaPagoDisplay } from '../../utils/formatters';

--- a/src/hooks/handlers/useClienteHandlers.ts
+++ b/src/hooks/handlers/useClienteHandlers.ts
@@ -2,8 +2,9 @@
  * Handlers para operaciones con clientes
  */
 import { useCallback } from 'react'
+import { importConRecarga } from '../../utils/lazyWithReload'
 const generarReciboPago = async (...args: Parameters<typeof import('../../lib/pdfExport').generarReciboPago>) => {
-  const mod = await import('../../lib/pdfExport')
+  const mod = await importConRecarga(() => import('../../lib/pdfExport'))
   return mod.generarReciboPago(...args)
 }
 import type { User } from '@supabase/supabase-js'

--- a/src/hooks/handlers/usePedidoHandlers.ts
+++ b/src/hooks/handlers/usePedidoHandlers.ts
@@ -11,6 +11,7 @@ import { resolverPreciosMayorista, aplicarPreciosMayorista, validarMOQPedido } f
 import { resolverPromociones } from '../../utils/promociones'
 import { calcularNetoVenta } from '../../utils/calculations'
 import { aplicarDescuentoClienteItems } from '../../utils/descuentoCliente'
+import { importConRecarga } from '../../utils/lazyWithReload'
 import type { User } from '@supabase/supabase-js'
 import type {
   ProductoDB,
@@ -762,7 +763,7 @@ export function usePedidoHandlers({
 
   const handleExportarHojaRutaOptimizada = useCallback(async (transportista: PerfilDB, pedidosOrdenados: PedidoDB[]): Promise<void> => {
     try {
-      const { generarHojaRutaOptimizada } = await import('../../lib/pdfExport')
+      const { generarHojaRutaOptimizada } = await importConRecarga(() => import('../../lib/pdfExport'))
       const rutaOptimizada = rutaOptimizadaRef.current
       generarHojaRutaOptimizada(transportista, pedidosOrdenados, (rutaOptimizada as { distanciaTotal?: number })?.distanciaTotal, (rutaOptimizada as { duracionTotal?: number })?.duracionTotal)
       notify.success('PDF generado correctamente')
@@ -808,11 +809,11 @@ export function usePedidoHandlers({
     handleCerrarModalOptimizar,
     // PDF exports (lazy loaded)
     generarOrdenPreparacion: async (...args: unknown[]) => {
-      const mod = await import('../../lib/pdfExport')
+      const mod = await importConRecarga(() => import('../../lib/pdfExport'))
       return mod.generarOrdenPreparacion(...args as Parameters<typeof mod.generarOrdenPreparacion>)
     },
     generarHojaRuta: async (...args: unknown[]) => {
-      const mod = await import('../../lib/pdfExport')
+      const mod = await importConRecarga(() => import('../../lib/pdfExport'))
       return mod.generarHojaRuta(...args as Parameters<typeof mod.generarHojaRuta>)
     }
   }

--- a/src/hooks/queries/index.ts
+++ b/src/hooks/queries/index.ts
@@ -55,6 +55,7 @@ export {
   useCambiarEstadoMutation,
   useActualizarPagoMutation,
   useAsignarTransportistaMutation,
+  useQuitarPedidoDeRecorridosMutation,
   useEliminarPedidoMutation,
   usePedidosNoEntregadosQuery,
   usePedidosAsignadosQuery,

--- a/src/hooks/queries/usePedidosQuery.ts
+++ b/src/hooks/queries/usePedidosQuery.ts
@@ -630,6 +630,36 @@ export function useAsignarTransportistaMutation() {
 }
 
 /**
+ * Quita un pedido de las rutas (recorridos) en curso a las que pertenece.
+ * Se usa al "Volver a pendiente" un pedido ya asignado para que no quede como
+ * parada fantasma en la ruta activa. Va por RPC SECURITY DEFINER (mig 093)
+ * porque recorrido_pedidos no tiene policy de DELETE para el cliente.
+ */
+async function quitarPedidoDeRecorridos(pedidoId: string): Promise<void> {
+  const { data, error } = await supabase.rpc('quitar_pedido_de_recorridos_activos', {
+    p_pedido_id: Number(pedidoId),
+  })
+  if (error) throw error
+  if (data && typeof data === 'object' && 'success' in data && !(data as { success: boolean }).success) {
+    throw new Error((data as { error?: string }).error || 'No se pudo quitar el pedido de la ruta')
+  }
+}
+
+export function useQuitarPedidoDeRecorridosMutation() {
+  const queryClient = useQueryClient()
+  const { currentSucursalId } = useSucursal()
+
+  return useMutation({
+    mutationFn: ({ pedidoId }: { pedidoId: string }) => quitarPedidoDeRecorridos(pedidoId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: pedidosKeys.all(currentSucursalId) })
+      // La ruta activa perdió una parada: refrescar recorridos.
+      queryClient.invalidateQueries({ queryKey: ['recorrido-existente'] })
+    },
+  })
+}
+
+/**
  * Hook para eliminar un pedido
  */
 export function useEliminarPedidoMutation() {

--- a/src/utils/lazyWithReload.test.ts
+++ b/src/utils/lazyWithReload.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { esErrorDeChunk, importConRecarga } from './lazyWithReload'
+
+describe('esErrorDeChunk', () => {
+  it('detecta mensajes de chunk obsoleto tras deploy', () => {
+    expect(esErrorDeChunk(new Error('Failed to fetch dynamically imported module: https://x/assets/pdfExport-Dd1O76j0.js'))).toBe(true)
+    expect(esErrorDeChunk(new Error('error loading dynamically imported module'))).toBe(true)
+    expect(esErrorDeChunk(new Error('Importing a module script failed'))).toBe(true)
+    expect(esErrorDeChunk(new Error('ChunkLoadError: Loading chunk 5 failed'))).toBe(true)
+  })
+
+  it('ignora errores que no son de chunk', () => {
+    expect(esErrorDeChunk(new Error('Network request failed'))).toBe(false)
+    expect(esErrorDeChunk('algo')).toBe(false)
+    expect(esErrorDeChunk(null)).toBe(false)
+  })
+})
+
+describe('importConRecarga', () => {
+  const originalLocation = window.location
+  let reloadMock: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    reloadMock = vi.fn()
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: { ...originalLocation, reload: reloadMock },
+    })
+    sessionStorage.clear()
+  })
+
+  afterEach(() => {
+    Object.defineProperty(window, 'location', { configurable: true, value: originalLocation })
+    sessionStorage.clear()
+    vi.restoreAllMocks()
+  })
+
+  it('devuelve el módulo cuando el import resuelve', async () => {
+    const mod = { generar: vi.fn() }
+    await expect(importConRecarga(() => Promise.resolve(mod))).resolves.toBe(mod)
+    expect(reloadMock).not.toHaveBeenCalled()
+  })
+
+  it('ante chunk obsoleto recarga una vez y lanza error amistoso', async () => {
+    const factory = () => Promise.reject(new Error('Failed to fetch dynamically imported module: /assets/pdfExport-x.js'))
+    await expect(importConRecarga(factory)).rejects.toThrow(/versión nueva/i)
+    expect(reloadMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('no recarga de nuevo dentro del cooldown', async () => {
+    const factory = () => Promise.reject(new Error('Failed to fetch dynamically imported module: /assets/pdfExport-x.js'))
+    await expect(importConRecarga(factory)).rejects.toThrow(/versión nueva/i)     // 1ra: dispara recarga
+    await expect(importConRecarga(factory)).rejects.toThrow(/Recargá la página/i) // 2da: en cooldown
+    expect(reloadMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('propaga errores que no son de chunk sin recargar', async () => {
+    const err = new Error('boom de negocio')
+    await expect(importConRecarga(() => Promise.reject(err))).rejects.toThrow('boom de negocio')
+    expect(reloadMock).not.toHaveBeenCalled()
+  })
+})

--- a/src/utils/lazyWithReload.ts
+++ b/src/utils/lazyWithReload.ts
@@ -1,12 +1,12 @@
 /**
- * lazyWithReload — React.lazy resiliente a chunks obsoletos tras un deploy.
+ * lazyWithReload / importConRecarga — resiliencia ante chunks obsoletos tras un deploy.
  *
  * Problema: el SW de la PWA usa skipWaiting + clientsClaim, así que una versión
  * nueva toma control a mitad de sesión. La app vieja en memoria sigue pidiendo
- * chunks con el hash viejo (`Container-<hashViejo>.js`) que ya no existen en el
- * server → el import() dinámico falla → el <Suspense> queda colgado para
- * siempre (síntoma: "se queda cargando y no pasa nada" al navegar a una
- * pantalla lazy).
+ * chunks con el hash viejo (`Container-<hashViejo>.js` / `pdfExport-<hashViejo>.js`)
+ * que ya no existen en el server → el import() dinámico falla con "Failed to fetch
+ * dynamically imported module". En React.lazy el <Suspense> queda colgado; en un
+ * handler (ej. descargar comanda) el catch solo muestra el error y no se puede usar.
  *
  * Solución: ante un fallo de carga de chunk, recargar UNA vez para traer el
  * index.html + chunks frescos. El guard por sessionStorage evita loops de
@@ -17,9 +17,24 @@ import { lazy, type ComponentType, type LazyExoticComponent } from 'react'
 const RELOAD_KEY = 'chunk-reload-at'
 const RELOAD_COOLDOWN_MS = 15000
 
-function esErrorDeChunk(err: unknown): boolean {
+export function esErrorDeChunk(err: unknown): boolean {
   const msg = err instanceof Error ? err.message : String(err)
   return /Failed to fetch dynamically imported module|error loading dynamically imported module|Importing a module script failed|ChunkLoadError/i.test(msg)
+}
+
+/**
+ * Recarga la página UNA vez (con cooldown por sessionStorage) para traer
+ * index.html + chunks frescos. Devuelve true si disparó la recarga; false si
+ * está en cooldown (ya recargó hace poco y sigue fallando → no insistir).
+ */
+function recargarUnaVezPorChunk(): boolean {
+  const last = Number(sessionStorage.getItem(RELOAD_KEY) || 0)
+  if (Date.now() - last > RELOAD_COOLDOWN_MS) {
+    sessionStorage.setItem(RELOAD_KEY, String(Date.now()))
+    window.location.reload()
+    return true
+  }
+  return false
 }
 
 export function lazyWithReload<T extends ComponentType<unknown>>(
@@ -29,16 +44,36 @@ export function lazyWithReload<T extends ComponentType<unknown>>(
     try {
       return await factory()
     } catch (err) {
-      if (esErrorDeChunk(err)) {
-        const last = Number(sessionStorage.getItem(RELOAD_KEY) || 0)
-        if (Date.now() - last > RELOAD_COOLDOWN_MS) {
-          sessionStorage.setItem(RELOAD_KEY, String(Date.now()))
-          window.location.reload()
-          // Promesa que nunca resuelve: mantiene el fallback hasta que recarga.
-          return new Promise<{ default: T }>(() => {})
-        }
+      if (esErrorDeChunk(err) && recargarUnaVezPorChunk()) {
+        // Promesa que nunca resuelve: mantiene el fallback hasta que recarga.
+        return new Promise<{ default: T }>(() => {})
       }
       throw err
     }
   })
+}
+
+/**
+ * importConRecarga — misma resiliencia que lazyWithReload pero para import()
+ * dinámicos usados FUERA de React.lazy (handlers de eventos que cargan un módulo
+ * bajo demanda, ej. el módulo de PDF/comandas). Si el chunk quedó obsoleto tras
+ * un deploy, recarga la app una vez; al reintentar la acción el import resuelve.
+ * Lanza un error amistoso para que el catch del handler muestre algo razonable.
+ *
+ * Uso: `const { generarComandas } = await importConRecarga(() => import('../../lib/pdfExport'))`
+ */
+export async function importConRecarga<T>(factory: () => Promise<T>): Promise<T> {
+  try {
+    return await factory()
+  } catch (err) {
+    if (esErrorDeChunk(err)) {
+      const recargo = recargarUnaVezPorChunk()
+      throw new Error(
+        recargo
+          ? 'Hay una versión nueva de la app. Recargando…'
+          : 'No se pudo cargar el módulo. Recargá la página e intentá de nuevo.',
+      )
+    }
+    throw err
+  }
 }


### PR DESCRIPTION
## Contexto

Dos bugs reportados (con screenshot):

1. **Pedidos no entregados no aparecen al "Armar ruta nueva".** Ej. 2889/2907: quedaron
   `estado='asignado'` como paradas de un recorrido `en_curso`. El pool de "Armar ruta" solo lista
   `pendiente`/`en_preparación`, así que un pedido ya asignado a una ruta no reaparece. El botón
   **"Volver a pendiente"** (admin) los devolvía al pool pero **no los sacaba del recorrido** →
   quedaban como parada fantasma. `recorrido_pedidos` no tiene policy de DELETE → hace falta una RPC.

2. **No descarga la comanda:** `Failed to fetch dynamically imported module .../pdfExport-*.js`.
   Chunk viejo tras redeploy (el PWA cambia el SW a mitad de sesión). `lazyWithReload` ya recargaba
   ante esto, pero solo para `React.lazy`, no para los `import()` de los handlers (comandas, PDFs).

## Cambios

**Re-ruteo (Parte B)**
- **mig 093:** RPC `quitar_pedido_de_recorridos_activos(p_pedido_id)` `SECURITY DEFINER` (admin/encargado,
  scope sucursal) que borra las filas de `recorrido_pedidos` del pedido en recorridos `en_curso` (no
  toca rutas finalizadas).
- Nuevo hook `useQuitarPedidoDeRecorridosMutation` ([usePedidosQuery.ts](src/hooks/queries/usePedidosQuery.ts))
  + cableado en `handleVolverAPendiente` ([PedidosContainer.tsx](src/components/containers/PedidosContainer.tsx)):
  ahora, tras volver a pendiente, lo saca de la ruta activa y refresca el pool.

**Comanda / PWA (Parte C)**
- [lazyWithReload.ts](src/utils/lazyWithReload.ts): exporta `esErrorDeChunk` + `importConRecarga()`
  (reusa la recarga-única-con-cooldown). Ante chunk viejo, recarga la app una vez; al reintentar
  toma la versión nueva. Cubre comandas, hoja de ruta, orden de preparación y recibo de pago
  (PedidosContainer, usePedidoHandlers, useClienteHandlers, PedidoCard). Test nuevo `lazyWithReload.test.ts`.

## Aplicado aparte de esta PR (datos prod, ya hecho)
- Pedidos **2889/2907**: sacados del recorrido 18 (ruta de hoy) y vueltos a `pendiente` para poder
  rutearlos mañana (mantienen `fecha=23/06`, `entrega=24/06`). Verificado: quedan `pendiente`.

## Pendiente
- **Aplicar mig 093 a prod** antes/junto con el deploy (el front llama la RPC). No se aplicó directo;
  va en esta PR para revisión.

## Verificación
- `npm run typecheck` limpio (solo errores preexistentes de `leaflet` en `MapaRuta.tsx`).
- **738 tests** verdes (incluye `lazyWithReload.test.ts`, 6 casos).
- Manual: con un pedido 'asignado' en ruta activa, "Volver a pendiente" lo saca de la ruta y aparece
  en "Armar ruta"; la comanda, ante un deploy intermedio, recarga y luego descarga.

🤖 Generated with [Claude Code](https://claude.com/claude-code)