### PR TITLE
feat(movimientos): ver detalle (ambos lados) + buscador en el match de productos

### DIFF
--- a/src/components/containers/MovimientosContainer.tsx
+++ b/src/components/containers/MovimientosContainer.tsx
@@ -22,6 +22,7 @@ import { useResetOnSucursalChange } from '../../hooks/useResetOnSucursalChange'
 const VistaMovimientos = lazy(() => import('../vistas/VistaMovimientos'))
 const ModalCrearMovimiento = lazy(() => import('../modals/ModalCrearMovimiento'))
 const ModalAceptarMovimiento = lazy(() => import('../modals/ModalAceptarMovimiento'))
+const ModalDetalleMovimiento = lazy(() => import('../modals/ModalDetalleMovimiento'))
 
 type TabEstado = EstadoMovimiento | 'todos'
 
@@ -37,11 +38,13 @@ export default function MovimientosContainer(): React.ReactElement {
   const [estado, setEstado] = useState<TabEstado>('pendiente')
   const [crearOpen, setCrearOpen] = useState(false)
   const [aceptarMov, setAceptarMov] = useState<MovimientoSucursalDB | null>(null)
+  const [detalleMov, setDetalleMov] = useState<MovimientoSucursalDB | null>(null)
 
   const { data: movimientos = [], isLoading } = useMovimientosQuery({ estado })
   const { data: sucursales = [] } = useSucursalesQuery()
   const { data: productos = [] } = useProductosQuery()
   const { data: itemsAceptar = [], isLoading: loadingItems } = useMovimientoItemsQuery(aceptarMov ? String(aceptarMov.id) : null)
+  const { data: itemsDetalle = [], isLoading: loadingItemsDetalle } = useMovimientoItemsQuery(detalleMov ? String(detalleMov.id) : null)
 
   const crear = useCrearMovimientoMutation()
   const aceptar = useAceptarMovimientoMutation()
@@ -51,6 +54,7 @@ export default function MovimientosContainer(): React.ReactElement {
   useResetOnSucursalChange(() => {
     setCrearOpen(false)
     setAceptarMov(null)
+    setDetalleMov(null)
     setEstado('pendiente')
   })
 
@@ -92,6 +96,7 @@ export default function MovimientosContainer(): React.ReactElement {
           onNuevaSalida={() => setCrearOpen(true)}
           onAceptar={setAceptarMov}
           onDenegar={setAceptarMov}
+          onVerDetalle={setDetalleMov}
         />
       </Suspense>
 
@@ -118,6 +123,18 @@ export default function MovimientosContainer(): React.ReactElement {
             onConfirmar={handleAceptar}
             onDenegar={handleDenegar}
             onClose={() => setAceptarMov(null)}
+          />
+        </Suspense>
+      )}
+
+      {detalleMov && (
+        <Suspense fallback={null}>
+          <ModalDetalleMovimiento
+            movimiento={detalleMov}
+            items={itemsDetalle}
+            loadingItems={loadingItemsDetalle}
+            productos={productos}
+            onClose={() => setDetalleMov(null)}
           />
         </Suspense>
       )}

--- a/src/components/modals/ModalAceptarMovimiento.tsx
+++ b/src/components/modals/ModalAceptarMovimiento.tsx
@@ -6,7 +6,7 @@
  * (copiando el de origen). Al aceptar, el backend mueve el stock atómicamente.
  */
 import { memo, useEffect, useMemo, useState } from 'react'
-import { Loader2, Check, X, AlertTriangle } from 'lucide-react'
+import { Loader2, Check, X, AlertTriangle, Search, ChevronDown } from 'lucide-react'
 import ModalBase from './ModalBase'
 import { formatPrecio } from '../../utils/formatters'
 import { sugerirMatchProducto } from '../../utils/matchProducto'
@@ -14,6 +14,96 @@ import type { ProductoDB } from '../../types'
 import type { MovimientoSucursalDB, MovimientoItemDB, ResolucionItem } from '../../hooks/queries'
 
 const NUEVO = '__nuevo__'
+
+function normalizar(s: string | null | undefined): string {
+  return (s || '').replace(/\s+/g, ' ').trim().toLowerCase()
+}
+
+/**
+ * Combobox con barra de búsqueda para elegir el producto del destino que matchea
+ * el item de origen. Reemplaza al <select> nativo para encontrar rápido entre
+ * muchos productos.
+ */
+function MatchSelector({ productos, value, onChange }: {
+  productos: ProductoDB[]
+  value: string
+  onChange: (v: string) => void
+}) {
+  const [q, setQ] = useState('')
+  const [open, setOpen] = useState(false)
+
+  const seleccionado = value !== NUEVO ? productos.find(p => String(p.id) === value) : null
+  const label = value === NUEVO
+    ? '➕ Crear nuevo (copia de origen)'
+    : (seleccionado ? `${seleccionado.nombre}${seleccionado.codigo ? ` (${seleccionado.codigo})` : ''}` : 'Seleccionar producto...')
+
+  const filtrados = useMemo(() => {
+    const t = normalizar(q)
+    const base = t
+      ? productos.filter(p => normalizar(p.nombre).includes(t) || normalizar(p.codigo).includes(t))
+      : productos
+    return base.slice(0, 50)
+  }, [productos, q])
+
+  const elegir = (v: string) => { onChange(v); setOpen(false); setQ('') }
+
+  return (
+    <div className="relative">
+      <button
+        type="button"
+        onClick={() => setOpen(o => !o)}
+        className="w-full flex items-center justify-between gap-2 px-2 py-2 text-sm border rounded-lg text-left dark:bg-gray-700 dark:border-gray-600 dark:text-white"
+      >
+        <span className={`truncate ${value === NUEVO ? 'text-blue-600 dark:text-blue-400' : ''}`}>{label}</span>
+        <ChevronDown className="w-4 h-4 flex-shrink-0 text-gray-400" />
+      </button>
+
+      {open && (
+        <>
+          {/* Backdrop para cerrar al tocar afuera */}
+          <button type="button" className="fixed inset-0 z-10 cursor-default" aria-hidden="true" onClick={() => { setOpen(false); setQ('') }} />
+          <div className="absolute z-20 mt-1 w-full bg-white dark:bg-gray-800 border dark:border-gray-700 rounded-lg shadow-lg">
+            <div className="relative p-2 border-b dark:border-gray-700">
+              <Search className="absolute left-4 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400" aria-hidden="true" />
+              <input
+                autoFocus
+                value={q}
+                onChange={e => setQ(e.target.value)}
+                placeholder="Buscar por nombre o código..."
+                className="w-full pl-9 pr-2 py-1.5 text-sm border rounded-lg dark:bg-gray-700 dark:border-gray-600 dark:text-white"
+              />
+            </div>
+            <ul className="max-h-56 overflow-auto py-1">
+              <li>
+                <button
+                  type="button"
+                  onClick={() => elegir(NUEVO)}
+                  className="w-full px-3 py-2 text-left text-sm text-blue-600 dark:text-blue-400 hover:bg-gray-100 dark:hover:bg-gray-700"
+                >
+                  ➕ Crear nuevo (copia de origen)
+                </button>
+              </li>
+              {filtrados.map(p => (
+                <li key={p.id}>
+                  <button
+                    type="button"
+                    onClick={() => elegir(String(p.id))}
+                    className={`w-full px-3 py-2 text-left text-sm hover:bg-gray-100 dark:hover:bg-gray-700 dark:text-white ${String(p.id) === value ? 'bg-gray-50 dark:bg-gray-700/60' : ''}`}
+                  >
+                    {p.nombre}{p.codigo ? <span className="text-gray-400"> ({p.codigo})</span> : ''}
+                  </button>
+                </li>
+              ))}
+              {filtrados.length === 0 && (
+                <li className="px-3 py-2 text-sm text-gray-400">Sin resultados</li>
+              )}
+            </ul>
+          </div>
+        </>
+      )}
+    </div>
+  )
+}
 
 export interface ModalAceptarMovimientoProps {
   movimiento: MovimientoSucursalDB
@@ -110,16 +200,11 @@ const ModalAceptarMovimiento = memo(function ModalAceptarMovimiento({
                 </div>
                 <div className="mt-2">
                   <label className="block text-xs font-medium mb-1 text-gray-600 dark:text-gray-400">Producto en esta sucursal</label>
-                  <select
+                  <MatchSelector
+                    productos={productosDestino}
                     value={v}
-                    onChange={e => setSel(prev => ({ ...prev, [it.id]: e.target.value }))}
-                    className="w-full px-2 py-2 text-sm border rounded-lg dark:bg-gray-700 dark:border-gray-600 dark:text-white"
-                  >
-                    <option value={NUEVO}>➕ Crear nuevo (copia de origen)</option>
-                    {productosDestino.map(p => (
-                      <option key={p.id} value={p.id}>{p.nombre}{p.codigo ? ` (${p.codigo})` : ''}</option>
-                    ))}
-                  </select>
+                    onChange={(nuevo) => setSel(prev => ({ ...prev, [it.id]: nuevo }))}
+                  />
                   <p className="text-xs text-gray-500 mt-1">
                     {v === NUEVO
                       ? `Se creará el producto copiando precio y costo de origen.`

--- a/src/components/modals/ModalDetalleMovimiento.tsx
+++ b/src/components/modals/ModalDetalleMovimiento.tsx
@@ -1,0 +1,143 @@
+/**
+ * ModalDetalleMovimiento — detalle de un movimiento entre sucursales.
+ *
+ * Lo pueden ver AMBOS lados (origen y destino) en cualquier estado
+ * (pendiente/aceptado/denegado). Muestra el encabezado (origen → destino,
+ * estado, fecha, creador, notas, motivo de rechazo) y la lista de productos
+ * con cantidades. En los aceptados indica cómo se resolvió cada item
+ * (matcheado a un producto del destino o creado nuevo).
+ */
+import { memo, useMemo } from 'react'
+import { Loader2, ArrowRight, Check, PlusCircle } from 'lucide-react'
+import ModalBase from './ModalBase'
+import { formatPrecio, formatDateTime } from '../../utils/formatters'
+import type { ProductoDB } from '../../types'
+import type { MovimientoSucursalDB, MovimientoItemDB, EstadoMovimiento } from '../../hooks/queries'
+
+const ESTADO_BADGE: Record<EstadoMovimiento, string> = {
+  pendiente: 'bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-400',
+  aceptada: 'bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400',
+  denegada: 'bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400',
+}
+
+export interface ModalDetalleMovimientoProps {
+  movimiento: MovimientoSucursalDB
+  items: MovimientoItemDB[]
+  loadingItems: boolean
+  /** Productos de la sucursal activa, para resolver el nombre del destino. */
+  productos?: ProductoDB[]
+  onClose: () => void
+}
+
+const ModalDetalleMovimiento = memo(function ModalDetalleMovimiento({
+  movimiento, items, loadingItems, productos = [], onClose,
+}: ModalDetalleMovimientoProps) {
+  const productosPorId = useMemo(() => {
+    const m = new Map<string, ProductoDB>()
+    for (const p of productos) m.set(String(p.id), p)
+    return m
+  }, [productos])
+
+  const totalUnidades = items.reduce((s, it) => s + (it.cantidad || 0), 0)
+
+  return (
+    <ModalBase
+      title={`Movimiento #${movimiento.id}`}
+      onClose={onClose}
+      maxWidth="max-w-2xl"
+    >
+      <div className="p-4 space-y-4 max-h-[70vh] overflow-y-auto">
+        {/* Encabezado: origen → destino + estado */}
+        <div className="flex items-center justify-between gap-3 flex-wrap">
+          <div className="flex items-center gap-2 text-sm font-medium text-gray-900 dark:text-white">
+            <span>{movimiento.origen?.nombre || 'Origen'}</span>
+            <ArrowRight className="w-4 h-4 text-gray-400" />
+            <span>{movimiento.destino?.nombre || 'Destino'}</span>
+          </div>
+          <span className={`px-2 py-0.5 rounded-full text-xs font-medium ${ESTADO_BADGE[movimiento.estado]}`}>
+            {movimiento.estado}
+          </span>
+        </div>
+
+        <div className="text-xs text-gray-500 space-y-0.5">
+          {movimiento.created_at && <p>Creado: {formatDateTime(movimiento.created_at)}{movimiento.creador?.nombre ? ` · ${movimiento.creador.nombre}` : ''}</p>}
+          {movimiento.resuelto_at && <p>Resuelto: {formatDateTime(movimiento.resuelto_at)}</p>}
+          {movimiento.notas && <p className="italic text-gray-600 dark:text-gray-400">Nota: {movimiento.notas}</p>}
+          {movimiento.estado === 'denegada' && movimiento.motivo_rechazo && (
+            <p className="text-red-500">Motivo del rechazo: {movimiento.motivo_rechazo}</p>
+          )}
+        </div>
+
+        {/* Items */}
+        <div>
+          <div className="flex items-center justify-between mb-2">
+            <p className="text-xs font-semibold uppercase tracking-wide text-gray-500">
+              Productos ({items.length})
+            </p>
+            <p className="text-xs text-gray-500">{totalUnidades} unidades</p>
+          </div>
+
+          {loadingItems ? (
+            <div className="flex items-center justify-center py-8 text-gray-500">
+              <Loader2 className="w-5 h-5 animate-spin text-blue-600" /><span className="ml-2">Cargando items...</span>
+            </div>
+          ) : items.length === 0 ? (
+            <p className="text-sm text-gray-500 py-4 text-center">Sin items.</p>
+          ) : (
+            <div className="space-y-2">
+              {items.map(it => {
+                const destProd = it.producto_destino_id != null
+                  ? productosPorId.get(String(it.producto_destino_id))
+                  : undefined
+                return (
+                  <div key={it.id} className="border dark:border-gray-700 rounded-lg p-3">
+                    <div className="flex items-start justify-between gap-2">
+                      <div className="min-w-0">
+                        <p className="font-medium text-gray-900 dark:text-white truncate">{it.origen_nombre}</p>
+                        <p className="text-xs text-gray-500">
+                          {it.cantidad} u
+                          {it.origen_codigo ? ` · cód ${it.origen_codigo}` : ''}
+                          {it.origen_costo_con_iva != null ? ` · costo ${formatPrecio(it.origen_costo_con_iva)}` : ''}
+                        </p>
+                      </div>
+                      <span className="text-sm font-semibold text-gray-700 dark:text-gray-300 flex-shrink-0">
+                        {it.cantidad} u
+                      </span>
+                    </div>
+
+                    {/* Resolución (solo en aceptados) */}
+                    {it.resolucion === 'match_existente' && (
+                      <p className="mt-1.5 text-xs flex items-center gap-1 text-green-700 dark:text-green-400">
+                        <Check className="w-3.5 h-3.5" />
+                        Matcheado{destProd ? ` a "${destProd.nombre}"` : ' a un producto del destino'}
+                      </p>
+                    )}
+                    {it.resolucion === 'creado_nuevo' && (
+                      <p className="mt-1.5 text-xs flex items-center gap-1 text-blue-700 dark:text-blue-400">
+                        <PlusCircle className="w-3.5 h-3.5" />
+                        Producto creado en el destino
+                      </p>
+                    )}
+                  </div>
+                )
+              })}
+            </div>
+          )}
+        </div>
+
+        <div className="flex items-center justify-between pt-2 border-t dark:border-gray-700">
+          <span className="text-sm text-gray-500">Costo total</span>
+          <span className="font-bold text-gray-900 dark:text-white">{formatPrecio(movimiento.total_costo || 0)}</span>
+        </div>
+      </div>
+
+      <div className="flex justify-end gap-2 p-4 border-t bg-gray-50 dark:bg-gray-800 dark:border-gray-700">
+        <button onClick={onClose} className="px-4 py-2 text-gray-700 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-700 rounded-lg">
+          Cerrar
+        </button>
+      </div>
+    </ModalBase>
+  )
+})
+
+export default ModalDetalleMovimiento

--- a/src/components/vistas/VistaMovimientos.tsx
+++ b/src/components/vistas/VistaMovimientos.tsx
@@ -6,7 +6,7 @@
  * (admin/encargado). Los salientes son solo lectura (esperan aprobación).
  */
 import { memo } from 'react'
-import { Loader2, ArrowDownLeft, ArrowUpRight, Plus, Check, X, PackageX } from 'lucide-react'
+import { Loader2, ArrowDownLeft, ArrowUpRight, Plus, Check, X, PackageX, Eye } from 'lucide-react'
 import { formatPrecio, formatDateTime } from '../../utils/formatters'
 import type { MovimientoSucursalDB, EstadoMovimiento } from '../../hooks/queries'
 
@@ -22,6 +22,7 @@ export interface VistaMovimientosProps {
   onNuevaSalida: () => void
   onAceptar: (mov: MovimientoSucursalDB) => void
   onDenegar: (mov: MovimientoSucursalDB) => void
+  onVerDetalle: (mov: MovimientoSucursalDB) => void
 }
 
 const TABS: Array<{ value: TabEstado; label: string }> = [
@@ -39,7 +40,7 @@ const ESTADO_BADGE: Record<EstadoMovimiento, string> = {
 
 const VistaMovimientos = memo(function VistaMovimientos({
   movimientos, loading, currentSucursalId, canResolver, estado, onEstadoChange,
-  onNuevaSalida, onAceptar, onDenegar,
+  onNuevaSalida, onAceptar, onDenegar, onVerDetalle,
 }: VistaMovimientosProps) {
   return (
     <div className="space-y-4">
@@ -122,27 +123,34 @@ const VistaMovimientos = memo(function VistaMovimientos({
                   </div>
                 </div>
 
-                {puedeResolver && (
-                  <div className="flex justify-end gap-2 mt-3 pt-3 border-t dark:border-gray-700">
-                    <button
-                      onClick={() => onDenegar(mov)}
-                      className="inline-flex items-center gap-1.5 px-3 py-2 text-sm rounded-lg bg-red-50 text-red-600 hover:bg-red-100 dark:bg-red-900/20 dark:text-red-400"
-                    >
-                      <X className="w-4 h-4" /> Denegar
-                    </button>
-                    <button
-                      onClick={() => onAceptar(mov)}
-                      className="inline-flex items-center gap-1.5 px-3 py-2 text-sm rounded-lg bg-green-600 text-white hover:bg-green-700"
-                    >
-                      <Check className="w-4 h-4" /> Aceptar
-                    </button>
-                  </div>
-                )}
-                {!entrante && mov.estado === 'pendiente' && (
-                  <p className="text-xs text-amber-600 dark:text-amber-400 mt-2 pt-2 border-t dark:border-gray-700">
-                    Esperando aprobación de {mov.destino?.nombre || 'la sucursal destino'}.
-                  </p>
-                )}
+                <div className="flex items-center justify-between gap-2 mt-3 pt-3 border-t dark:border-gray-700">
+                  <button
+                    onClick={() => onVerDetalle(mov)}
+                    className="inline-flex items-center gap-1.5 px-3 py-2 text-sm rounded-lg text-gray-600 hover:bg-gray-100 dark:text-gray-300 dark:hover:bg-gray-700"
+                  >
+                    <Eye className="w-4 h-4" /> Ver detalle
+                  </button>
+                  {puedeResolver ? (
+                    <div className="flex gap-2">
+                      <button
+                        onClick={() => onDenegar(mov)}
+                        className="inline-flex items-center gap-1.5 px-3 py-2 text-sm rounded-lg bg-red-50 text-red-600 hover:bg-red-100 dark:bg-red-900/20 dark:text-red-400"
+                      >
+                        <X className="w-4 h-4" /> Denegar
+                      </button>
+                      <button
+                        onClick={() => onAceptar(mov)}
+                        className="inline-flex items-center gap-1.5 px-3 py-2 text-sm rounded-lg bg-green-600 text-white hover:bg-green-700"
+                      >
+                        <Check className="w-4 h-4" /> Aceptar
+                      </button>
+                    </div>
+                  ) : (!entrante && mov.estado === 'pendiente') ? (
+                    <span className="text-xs text-amber-600 dark:text-amber-400">
+                      Esperando aprobación de {mov.destino?.nombre || 'la sucursal destino'}.
+                    </span>
+                  ) : null}
+                </div>
               </div>
             )
           })}


### PR DESCRIPTION
Dos mejoras pedidas para movimientos entre sucursales (sobre lo de #390, ya mergeado).

## 1. Ver detalle desde ambos lados, en cualquier estado
Cada movimiento (entrante o saliente) tiene ahora un botón **"Ver detalle"**, disponible esté **pendiente, aceptado o denegado**. Abre un nuevo `ModalDetalleMovimiento` que muestra:
- Encabezado: **origen → destino**, estado, fecha de creación/resolución, creador, notas y motivo de rechazo.
- **Lista de productos con cantidades** (snapshot del origen: nombre, código, costo).
- En los aceptados, cómo se resolvió cada item: **matcheado** a un producto del destino (con su nombre si está disponible) o **creado nuevo**.

La RLS de `movimiento_sucursal_items` ya es bidireccional (`origen OR destino = current_sucursal_id()`), así que el detalle lo ven **ambas sucursales** sin cambios de backend.

## 2. Buscador en el selector de producto a matchear
Al aceptar un movimiento, por cada item había que elegir el producto del destino con un `<select>` nativo (lento con muchos productos). Ahora es un **combobox con barra de búsqueda** (por nombre o código) que filtra al tipear, más la opción "Crear nuevo". Cierra al elegir o al tocar afuera.

## Archivos
- `src/components/modals/ModalDetalleMovimiento.tsx` (nuevo)
- `src/components/vistas/VistaMovimientos.tsx` — botón "Ver detalle" + prop `onVerDetalle`
- `src/components/containers/MovimientosContainer.tsx` — estado + query de items del detalle + render
- `src/components/modals/ModalAceptarMovimiento.tsx` — `MatchSelector` (combobox con búsqueda) en vez del `<select>`

## Verificación
- `tsc --noEmit` y `eslint` limpios; `vitest run` 732/732 (pre-commit). Sin cambios de backend (reusa la query/RLS existentes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
