### PR TITLE
feat(pedidos): cambiar cliente de un pedido (cancela y recrea)

### DIFF
--- a/migrations/094_cambiar_cliente_pedido.sql
+++ b/migrations/094_cambiar_cliente_pedido.sql
@@ -1,0 +1,172 @@
+-- 094_cambiar_cliente_pedido.sql
+--
+-- "Cambiar cliente" de un pedido cargado al cliente equivocado.
+--
+-- Caso: el usuario carga un pedido y elige mal el cliente. Hoy hay que recrearlo
+-- a mano y borrar el viejo. Esta RPC lo hace en una sola operacion atomica:
+-- cancela el pedido viejo (restaura stock + ajusta saldo del cliente viejo via
+-- los triggers de cancelacion), lo saca de la ruta en curso si estaba asignado,
+-- crea un pedido nuevo IDENTICO para el cliente correcto (con precios ya
+-- recalculados en el front para ESE cliente) y transfiere los pagos del viejo al
+-- nuevo.
+--
+-- Por que cancelar+recrear y no UPDATE cliente_id: el trigger
+-- actualizar_saldo_pedido en su rama UPDATE solo ajusta el saldo de
+-- NEW.cliente_id; un cambio directo de cliente_id dejaria la deuda pegada al
+-- cliente viejo. Cancelar (baja la contribucion del viejo) + crear (suma la del
+-- nuevo) dispara las ramas correctas y mueve el saldo solo.
+--
+-- Transferencia de pagos: un pago con pedido_id NO afecta saldo directo (lo hace
+-- via monto_pagado del pedido, trigger recalcular_monto_pagado_pedido). Por eso
+-- mover el pago es un simple UPDATE pagos SET pedido_id/cliente_id y los triggers
+-- reajustan monto_pagado del nuevo y el saldo de ambos clientes.
+--
+-- Atomicidad: si crear_pedido_completo falla (ej. stock), se hace RAISE para
+-- revertir TODA la transaccion, incluida la cancelacion -> el pedido viejo queda
+-- intacto.
+--
+-- Solo admin. No aplica a pedidos entregados ni cancelados.
+
+CREATE OR REPLACE FUNCTION public.cambiar_cliente_pedido(
+  p_pedido_id bigint,
+  p_nuevo_cliente_id bigint,
+  p_usuario_id uuid,
+  p_items jsonb,
+  p_total numeric,
+  p_total_neto numeric DEFAULT NULL,
+  p_total_iva numeric DEFAULT 0,
+  p_motivo text DEFAULT 'Cambio de cliente'
+) RETURNS jsonb
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public'
+AS $function$
+DECLARE
+  v_sucursal     BIGINT := current_sucursal_id();
+  v_acting       UUID := auth.uid();
+  v_role         TEXT;
+  v_pedido       RECORD;
+  v_prev_role    TEXT;
+  v_preventista  UUID := NULL;            -- preventista del pedido nuevo (NULL = actor)
+  v_preventista_fallback BOOLEAN := false;
+  v_cancel       JSONB;
+  v_crear        JSONB;
+  v_nuevo_id     BIGINT;
+BEGIN
+  -- ---- Validaciones ----
+  IF v_sucursal IS NULL THEN
+    RETURN jsonb_build_object('success', false, 'error', 'No hay sucursal activa');
+  END IF;
+
+  IF p_usuario_id IS DISTINCT FROM v_acting THEN
+    RETURN jsonb_build_object('success', false, 'error', 'ID de usuario no coincide con la sesion autenticada');
+  END IF;
+
+  SELECT rol INTO v_role FROM perfiles WHERE id = v_acting;
+  IF v_role IS NULL OR v_role <> 'admin' THEN
+    RETURN jsonb_build_object('success', false, 'error', 'No autorizado: solo admin puede cambiar el cliente de un pedido');
+  END IF;
+
+  IF p_items IS NULL OR jsonb_typeof(p_items) <> 'array' OR jsonb_array_length(p_items) = 0 THEN
+    RETURN jsonb_build_object('success', false, 'error', 'El pedido nuevo no tiene items');
+  END IF;
+
+  SELECT * INTO v_pedido FROM pedidos WHERE id = p_pedido_id AND sucursal_id = v_sucursal FOR UPDATE;
+  IF NOT FOUND THEN
+    RETURN jsonb_build_object('success', false, 'error', 'Pedido no encontrado');
+  END IF;
+
+  IF v_pedido.estado IN ('entregado', 'cancelado') THEN
+    RETURN jsonb_build_object('success', false, 'error', 'No se puede cambiar el cliente de un pedido ' || v_pedido.estado);
+  END IF;
+
+  IF p_nuevo_cliente_id = v_pedido.cliente_id THEN
+    RETURN jsonb_build_object('success', false, 'error', 'El cliente nuevo es el mismo que el actual');
+  END IF;
+
+  PERFORM 1 FROM clientes WHERE id = p_nuevo_cliente_id AND sucursal_id = v_sucursal;
+  IF NOT FOUND THEN
+    RETURN jsonb_build_object('success', false, 'error', 'El cliente nuevo no existe en esta sucursal');
+  END IF;
+
+  -- ---- Resolver preventista del pedido nuevo (conservar el del viejo) ----
+  -- Si el preventista original sigue siendo asignable, se conserva (comisiones);
+  -- si no (inactivo o fuera de la sucursal), el nuevo queda a nombre del actor.
+  IF v_pedido.usuario_id IS DISTINCT FROM p_usuario_id THEN
+    SELECT p.rol INTO v_prev_role
+    FROM perfiles p
+    WHERE p.id = v_pedido.usuario_id
+      AND p.activo = true
+      AND EXISTS (SELECT 1 FROM usuario_sucursales us WHERE us.usuario_id = p.id AND us.sucursal_id = v_sucursal);
+    IF v_prev_role IN ('admin', 'preventista', 'preventista_taco') THEN
+      v_preventista := v_pedido.usuario_id;
+    ELSE
+      v_preventista_fallback := true;     -- no asignable -> queda al actor
+    END IF;
+  END IF;
+
+  -- ---- 1) Cancelar el pedido viejo (restaura stock, baja usos promo, ajusta saldo cliente viejo) ----
+  v_cancel := cancelar_pedido_con_stock(p_pedido_id, p_motivo, p_usuario_id);
+  IF NOT COALESCE((v_cancel->>'success')::boolean, false) THEN
+    RETURN v_cancel;   -- propaga el error (nada irreversible hecho aun)
+  END IF;
+
+  -- ---- 2) Sacar el pedido viejo de la ruta en curso (si estaba asignado) ----
+  PERFORM quitar_pedido_de_recorridos_activos(p_pedido_id);
+
+  -- ---- 3) Crear el pedido nuevo para el cliente correcto ----
+  -- Preserva notas/forma_pago/fecha/tipo_factura/fecha_entrega_programada del viejo.
+  v_crear := crear_pedido_completo(
+    p_nuevo_cliente_id,
+    p_total,
+    p_usuario_id,
+    p_items,
+    v_pedido.notas,
+    v_pedido.forma_pago,
+    'pendiente',                          -- estado_pago se deriva al transferir pagos
+    v_pedido.fecha,
+    v_pedido.tipo_factura,
+    p_total_neto,
+    COALESCE(p_total_iva, 0),
+    v_pedido.fecha_entrega_programada,
+    v_preventista
+  );
+  IF NOT COALESCE((v_crear->>'success')::boolean, false) THEN
+    -- Revertir TODA la transaccion (incluida la cancelacion del viejo).
+    RAISE EXCEPTION 'No se pudo crear el pedido nuevo: %',
+      COALESCE(v_crear->>'errores', v_crear->>'error', 'error desconocido');
+  END IF;
+  v_nuevo_id := (v_crear->>'pedido_id')::bigint;
+
+  -- ---- 4) Transferir pagos del viejo al nuevo (triggers reajustan monto_pagado y saldos) ----
+  UPDATE pagos
+     SET pedido_id = v_nuevo_id,
+         cliente_id = p_nuevo_cliente_id
+   WHERE pedido_id = p_pedido_id
+     AND sucursal_id = v_sucursal;
+
+  -- ---- 5) Trazabilidad: referencia cruzada en el viejo y en el historial del nuevo ----
+  UPDATE pedidos
+     SET motivo_cancelacion = COALESCE(motivo_cancelacion, p_motivo) || ' -> pedido #' || v_nuevo_id
+   WHERE id = p_pedido_id AND sucursal_id = v_sucursal;
+
+  INSERT INTO pedido_historial (pedido_id, usuario_id, campo_modificado, valor_anterior, valor_nuevo, sucursal_id)
+  VALUES (
+    v_nuevo_id,
+    v_acting,
+    'cliente_id',
+    v_pedido.cliente_id::text,
+    p_nuevo_cliente_id::text || ' (cambio de cliente desde pedido #' || p_pedido_id || ')',
+    v_sucursal
+  );
+
+  RETURN jsonb_build_object(
+    'success', true,
+    'nuevo_pedido_id', v_nuevo_id,
+    'pedido_cancelado_id', p_pedido_id,
+    'preventista_fallback', v_preventista_fallback
+  );
+END;
+$function$;
+
+GRANT EXECUTE ON FUNCTION public.cambiar_cliente_pedido(bigint, bigint, uuid, jsonb, numeric, numeric, numeric, text) TO authenticated;

--- a/src/components/containers/PedidosContainer.tsx
+++ b/src/components/containers/PedidosContainer.tsx
@@ -22,6 +22,7 @@ import {
   useQuitarPedidoDeRecorridosMutation,
   useEntregasMasivasMutation,
   useCancelarPedidoMutation,
+  useCambiarClientePedidoMutation,
   usePagosMasivosMutation,
   usePedidosAsignadosQuery,
   useClientesQuery,
@@ -50,6 +51,7 @@ import { retryWithBackoff, isTransientNetworkError } from '../../utils/retryWith
 import { importConRecarga } from '../../utils/lazyWithReload'
 import type { PedidoDB, FiltrosPedidosState, PerfilDB, RegistrarSalvedadInput, RegistrarSalvedadResult, PagoDBWithUsuario } from '../../types'
 import type { PedidoEditItem } from '../modals/ModalEditarPedido'
+import type { CambiarClientePayload } from '../modals/ModalCambiarCliente'
 import type { RutaMultiResultadoUI } from '../modals/ModalGestionRutas'
 
 // Lazy load de componentes
@@ -151,6 +153,7 @@ export default function PedidosContainer(): React.ReactElement {
   const quitarDeRecorridosMut = useQuitarPedidoDeRecorridosMutation()
   const entregasMasivas = useEntregasMasivasMutation()
   const cancelarPedidoMut = useCancelarPedidoMutation()
+  const cambiarClientePedidoMut = useCambiarClientePedidoMutation()
   const pagosMasivos = usePagosMasivosMutation()
   const crearClienteMut = useCrearClienteMutation()
   const crearCambioEnRutaMut = useCrearPedidoCambioEnRutaMutation()
@@ -737,6 +740,31 @@ export default function PedidosContainer(): React.ReactElement {
       throw e
     }
   }, [pedidoEditando, queryClient, notify])
+
+  // Cambiar el cliente de un pedido cargado al cliente equivocado: cancela el
+  // viejo y crea uno nuevo idéntico (precios recalculados en el modal) para el
+  // cliente correcto, transfiriendo los pagos. Atómico (RPC). Solo admin.
+  const handleCambiarClientePedido = useCallback(async (payload: CambiarClientePayload) => {
+    if (!pedidoEditando) return
+    try {
+      const { nuevoPedidoId } = await cambiarClientePedidoMut.mutateAsync({
+        pedidoId: String(pedidoEditando.id),
+        nuevoClienteId: payload.nuevoClienteId,
+        usuarioId: user?.id ?? null,
+        items: payload.items,
+        total: payload.total,
+        totalNeto: payload.totalNeto,
+        totalIva: payload.totalIva,
+        motivo: payload.motivo,
+      })
+      setModalEditarOpen(false)
+      setPedidoEditando(null)
+      notify.success(`Cliente cambiado: se creó el pedido #${nuevoPedidoId} y se canceló el anterior`, { persist: true })
+    } catch (e) {
+      notify.error((e as Error).message || 'Error al cambiar el cliente del pedido')
+      throw e
+    }
+  }, [pedidoEditando, cambiarClientePedidoMut, user, notify])
 
   // ===========================================================================
   // ModalPagoPedido handlers (registrar/anular pagos sobre un pedido)
@@ -1532,9 +1560,12 @@ export default function PedidosContainer(): React.ReactElement {
             }
             canSustituirRegalo={isAdmin || isEncargado}
             canEditPreventista={isAdmin}
+            canCambiarCliente={isAdmin}
+            clientes={clientes}
             onSave={handleGuardarEdicion}
             onSaveItems={handleGuardarItemsEdicion}
             onCambiarPreventista={handleCambiarPreventistaPedido}
+            onCambiarCliente={handleCambiarClientePedido}
             onClose={() => { setModalEditarOpen(false); setPedidoEditando(null) }}
             guardando={guardando}
           />

--- a/src/components/modals/ModalCambiarCliente.test.jsx
+++ b/src/components/modals/ModalCambiarCliente.test.jsx
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+// usePromocionPedido depende de estos dos hooks de query. Maps vacíos => sin
+// mayorista ni promos, así el recálculo parte del precio de lista del producto.
+vi.mock('../../hooks/queries/useGruposPrecioQuery', () => ({
+  usePricingMapQuery: () => ({ data: new Map(), isLoading: false }),
+}))
+vi.mock('../../hooks/queries/usePromocionesQuery', () => ({
+  usePromoMapQuery: () => ({ data: new Map(), isLoading: false }),
+}))
+
+vi.mock('../../utils/formatters', () => ({
+  formatPrecio: (value) => `$${Number(value).toFixed(2)}`,
+}))
+
+import ModalCambiarCliente from './ModalCambiarCliente'
+
+describe('ModalCambiarCliente', () => {
+  // Pedido del cliente equivocado (id 10). El precio_unitario viejo (250) NO
+  // debe usarse: el recálculo parte del precio de LISTA del producto (300).
+  const pedido = {
+    id: 123,
+    cliente_id: 10,
+    total: 1000,
+    estado: 'pendiente',
+    tipo_factura: 'ZZ',
+    items: [
+      { producto_id: 1, cantidad: 2, precio_unitario: 250 },
+      { producto_id: 2, cantidad: 1, precio_unitario: 500 },
+    ],
+  }
+
+  const productos = [
+    { id: 1, nombre: 'Producto 1', precio: 300, stock: 10, categoria: 'BEBIDAS' },
+    { id: 2, nombre: 'Producto 2', precio: 500, stock: 5, categoria: 'BEBIDAS' },
+  ]
+
+  const clientes = [
+    { id: 10, nombre_fantasia: 'Cliente Actual', direccion: 'Calle Vieja 1' },
+    { id: 20, nombre_fantasia: 'Cliente Nuevo', direccion: 'Calle Nueva 2' },
+    { id: 30, nombre_fantasia: 'Cliente Descuento', direccion: 'Calle Desc 3', descuento_porcentaje: 10 },
+  ]
+
+  const baseProps = { pedido, productos, clientes, guardando: false }
+
+  it('muestra el cliente actual y deshabilita el botón sin cliente nuevo', () => {
+    render(<ModalCambiarCliente {...baseProps} onConfirmar={vi.fn()} onClose={vi.fn()} />)
+    expect(screen.getByText('Cliente Actual')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /Confirmar cambio/i })).toBeDisabled()
+  })
+
+  it('recalcula con el precio de lista (no el precio viejo) al elegir cliente nuevo', async () => {
+    const user = userEvent.setup()
+    const onConfirmar = vi.fn()
+    render(<ModalCambiarCliente {...baseProps} onConfirmar={onConfirmar} onClose={vi.fn()} />)
+
+    await user.type(screen.getByPlaceholderText(/Buscar por nombre/i), 'Nuevo')
+    await user.click(await screen.findByText('Cliente Nuevo'))
+
+    const confirmar = screen.getByRole('button', { name: /Confirmar cambio/i })
+    expect(confirmar).toBeEnabled()
+    await user.click(confirmar)
+
+    expect(onConfirmar).toHaveBeenCalledTimes(1)
+    const payload = onConfirmar.mock.calls[0][0]
+    expect(payload.nuevoClienteId).toBe('20')
+    // 2×300 + 1×500 = 1100 (precio de lista, NO 2×250+500=1000)
+    expect(payload.total).toBe(1100)
+    expect(payload.items).toHaveLength(2)
+    expect(payload.items[0]).toMatchObject({ productoId: '1', cantidad: 2, precioUnitario: 300 })
+  })
+
+  it('aplica el descuento del cliente nuevo al total recalculado', async () => {
+    const user = userEvent.setup()
+    const onConfirmar = vi.fn()
+    render(<ModalCambiarCliente {...baseProps} onConfirmar={onConfirmar} onClose={vi.fn()} />)
+
+    await user.type(screen.getByPlaceholderText(/Buscar por nombre/i), 'Descuento')
+    await user.click(await screen.findByText('Cliente Descuento'))
+
+    await user.click(screen.getByRole('button', { name: /Confirmar cambio/i }))
+
+    const payload = onConfirmar.mock.calls[0][0]
+    // 1100 con 10% de descuento general => 990 (270×2 + 450)
+    expect(payload.total).toBe(990)
+    expect(payload.items[0].precioUnitario).toBe(270)
+    expect(payload.items[1].precioUnitario).toBe(450)
+  })
+})

--- a/src/components/modals/ModalCambiarCliente.tsx
+++ b/src/components/modals/ModalCambiarCliente.tsx
@@ -1,0 +1,336 @@
+import { useMemo, useState, memo } from 'react';
+import { Search, X, Loader2, ArrowRight, AlertCircle, Gift, RefreshCw } from 'lucide-react';
+import ModalBase from './ModalBase';
+import { formatPrecio } from '../../utils/formatters';
+import { calcularNetoVenta } from '../../utils/calculations';
+import { usePromocionPedido } from '../../hooks/usePromocionPedido';
+import { aplicarDescuentoClienteItems } from '../../utils/descuentoCliente';
+import type { ItemPedido } from '../../utils/precioMayorista';
+import type { PedidoDB, ProductoDB, ClienteDB } from '../../types';
+
+/** Item recalculado que se envía a la RPC cambiar_cliente_pedido. */
+export interface CambiarClienteItem {
+  productoId: string;
+  cantidad: number;
+  precioUnitario: number;
+  esBonificacion?: boolean;
+  promocionId?: string;
+  neto_unitario?: number;
+  iva_unitario?: number;
+  impuestos_internos_unitario?: number;
+  porcentaje_iva?: number;
+}
+
+/** Payload con todo lo que necesita el container para invocar la mutación. */
+export interface CambiarClientePayload {
+  nuevoClienteId: string;
+  items: CambiarClienteItem[];
+  total: number;
+  totalNeto: number;
+  totalIva: number;
+  motivo?: string;
+}
+
+export interface ModalCambiarClienteProps {
+  pedido: PedidoDB;
+  productos: ProductoDB[];
+  clientes: ClienteDB[];
+  onConfirmar: (payload: CambiarClientePayload) => void | Promise<void>;
+  onClose: () => void;
+  guardando: boolean;
+}
+
+/**
+ * Cambia el cliente de un pedido cargado al cliente equivocado. Recalcula
+ * precios/promos/descuentos para el cliente nuevo (no copia los del viejo),
+ * muestra una comparación total anterior vs nuevo, y al confirmar delega en el
+ * container que cancela el pedido viejo y crea uno nuevo idéntico (RPC atómica).
+ */
+const ModalCambiarCliente = memo(function ModalCambiarCliente({
+  pedido,
+  productos,
+  clientes,
+  onConfirmar,
+  onClose,
+  guardando,
+}: ModalCambiarClienteProps) {
+  const [busquedaCliente, setBusquedaCliente] = useState<string>('');
+  const [nuevoClienteId, setNuevoClienteId] = useState<string>('');
+
+  const tipoFactura = pedido.tipo_factura ?? 'ZZ';
+
+  // Cliente actual (para mostrarlo de referencia).
+  const clienteActual = useMemo(
+    () => clientes.find(c => String(c.id) === String(pedido.cliente_id)) ?? pedido.cliente ?? null,
+    [clientes, pedido.cliente_id, pedido.cliente],
+  );
+
+  const clienteNuevo = useMemo(
+    () => (nuevoClienteId ? clientes.find(c => String(c.id) === String(nuevoClienteId)) ?? null : null),
+    [clientes, nuevoClienteId],
+  );
+
+  // Buscador de cliente (réplica del de ModalPedido), excluyendo el cliente actual.
+  const clientesFiltrados = useMemo(() => {
+    if (busquedaCliente.length < 2) return [];
+    const busquedaNorm = busquedaCliente.replace(/\s+/g, ' ').trim().toLowerCase();
+    if (!busquedaNorm) return [];
+    const norm = (s: string | null | undefined) => s?.replace(/\s+/g, ' ').trim().toLowerCase() ?? '';
+    return clientes
+      .filter(c => String(c.id) !== String(pedido.cliente_id))
+      .filter(c =>
+        norm(c.nombre_fantasia).includes(busquedaNorm) ||
+        norm(c.razon_social).includes(busquedaNorm) ||
+        norm(c.direccion).includes(busquedaNorm) ||
+        c.cuit?.includes(busquedaCliente.replace(/[-\s]/g, '')) ||
+        (c.codigo != null && String(c.codigo).includes(busquedaCliente.trim())),
+      )
+      .slice(0, 8);
+  }, [clientes, busquedaCliente, pedido.cliente_id]);
+
+  // Items de venta del pedido viejo -> base para recalcular. Se descartan las
+  // bonificaciones (se regeneran para el cliente nuevo) y se parte del precio
+  // de LISTA del producto, no del precio_unitario viejo (que ya traía
+  // mayorista/descuento del cliente equivocado embebido).
+  const itemsVenta = useMemo<ItemPedido[]>(() => {
+    return (pedido.items ?? [])
+      .filter(i => !i.es_bonificacion)
+      .map(i => {
+        const prod = productos.find(p => String(p.id) === String(i.producto_id));
+        return {
+          productoId: String(i.producto_id),
+          cantidad: i.cantidad,
+          precioUnitario: prod?.precio ?? i.precio_unitario,
+        };
+      });
+  }, [pedido.items, productos]);
+
+  // Mayorista + promos para el cliente nuevo (vigencia a la fecha del pedido).
+  const { itemsFinales, isLoading } = usePromocionPedido(itemsVenta, pedido.fecha);
+
+  // Descuento del cliente nuevo (general + categoría) sobre los items resueltos.
+  const descuento = useMemo(
+    () => aplicarDescuentoClienteItems(itemsFinales, productos, clienteNuevo),
+    [itemsFinales, productos, clienteNuevo],
+  );
+
+  const totalNuevo = descuento.total;
+  const totalViejo = pedido.total ?? 0;
+  const delta = totalNuevo - totalViejo;
+
+  const tienePago = (pedido.monto_pagado ?? 0) > 0;
+
+  const handleConfirmar = (): void => {
+    if (!clienteNuevo || isLoading || guardando) return;
+
+    let total = 0;
+    let totalNeto = 0;
+    let totalIva = 0;
+
+    const items: CambiarClienteItem[] = descuento.items.map(item => {
+      const productoId = String(item.productoId);
+      if (item.esBonificacion) {
+        return {
+          productoId,
+          cantidad: item.cantidad,
+          precioUnitario: 0,
+          esBonificacion: true,
+          promocionId: item.promoId,
+          neto_unitario: 0,
+          iva_unitario: 0,
+          impuestos_internos_unitario: 0,
+          porcentaje_iva: 0,
+        };
+      }
+      const prod = productos.find(p => String(p.id) === productoId);
+      const pctIva = prod?.porcentaje_iva ?? 21;
+      const pctImpInt = prod?.impuestos_internos ?? 0;
+      const desglose = calcularNetoVenta(item.precioUnitario, pctIva, pctImpInt, tipoFactura);
+      total += item.precioUnitario * item.cantidad;
+      totalNeto += desglose.neto * item.cantidad;
+      totalIva += desglose.iva * item.cantidad;
+      return {
+        productoId,
+        cantidad: item.cantidad,
+        precioUnitario: item.precioUnitario,
+        neto_unitario: desglose.neto,
+        iva_unitario: desglose.iva,
+        impuestos_internos_unitario: desglose.impuestosInternos,
+        porcentaje_iva: pctIva,
+      };
+    });
+
+    void onConfirmar({
+      nuevoClienteId: String(clienteNuevo.id),
+      items,
+      total,
+      totalNeto,
+      totalIva,
+      motivo: 'Cambio de cliente',
+    });
+  };
+
+  const nombreProducto = (productoId: string): string =>
+    productos.find(p => String(p.id) === String(productoId))?.nombre ?? `Producto #${productoId}`;
+
+  return (
+    <ModalBase title="Cambiar cliente" onClose={onClose} maxWidth="max-w-lg">
+      <div className="max-h-[70vh] overflow-y-auto overscroll-contain p-4 space-y-4">
+        {/* Cliente actual */}
+        <div>
+          <p className="text-xs font-medium text-gray-500 dark:text-gray-400 mb-1">Cliente actual</p>
+          <div className="p-3 bg-gray-50 dark:bg-gray-800 border dark:border-gray-700 rounded-lg">
+            <p className="font-medium dark:text-white">{clienteActual?.nombre_fantasia ?? '—'}</p>
+            {clienteActual?.direccion && (
+              <p className="text-sm text-gray-500 dark:text-gray-400">{clienteActual.direccion}</p>
+            )}
+          </div>
+        </div>
+
+        {/* Nuevo cliente: buscador o seleccionado */}
+        <div>
+          <p className="text-xs font-medium text-gray-500 dark:text-gray-400 mb-1">Nuevo cliente</p>
+          {clienteNuevo ? (
+            <div className="p-3 bg-blue-50 dark:bg-blue-900/30 border border-blue-200 dark:border-blue-800 rounded-lg flex justify-between items-center">
+              <div className="min-w-0">
+                <p className="font-medium dark:text-white truncate">{clienteNuevo.nombre_fantasia}</p>
+                {clienteNuevo.direccion && (
+                  <p className="text-sm text-gray-500 dark:text-gray-400 truncate">{clienteNuevo.direccion}</p>
+                )}
+              </div>
+              <button
+                type="button"
+                onClick={() => { setNuevoClienteId(''); setBusquedaCliente(''); }}
+                className="text-red-500 p-1 flex-shrink-0"
+                aria-label="Quitar cliente seleccionado"
+              >
+                <X className="w-5 h-5" />
+              </button>
+            </div>
+          ) : (
+            <div>
+              <div className="relative w-full">
+                <Search className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400 w-5 h-5 pointer-events-none" />
+                <input
+                  type="text"
+                  value={busquedaCliente}
+                  onChange={e => setBusquedaCliente(e.target.value)}
+                  autoComplete="off"
+                  className="block w-full pl-10 pr-3 py-3 min-h-11 text-base border rounded-lg dark:bg-gray-700 dark:border-gray-600 dark:text-white focus:ring-2 focus:ring-blue-500 focus:outline-none"
+                  placeholder="Buscar por nombre, razón social o CUIT..."
+                />
+              </div>
+              {clientesFiltrados.length > 0 && (
+                <div role="listbox" aria-label="Resultados de clientes" className="border dark:border-gray-600 rounded-lg max-h-40 overflow-y-auto mt-2">
+                  {clientesFiltrados.map(c => (
+                    <button
+                      type="button"
+                      role="option"
+                      aria-selected={false}
+                      key={c.id}
+                      className="w-full text-left p-3 hover:bg-blue-50 dark:hover:bg-blue-900/30 border-b dark:border-gray-600 focus:outline-none focus:bg-blue-100 dark:focus:bg-blue-900/50"
+                      onClick={() => { setNuevoClienteId(c.id.toString()); setBusquedaCliente(''); }}
+                    >
+                      <p className="font-medium dark:text-white">{c.nombre_fantasia}</p>
+                      {c.razon_social && c.razon_social !== c.nombre_fantasia && (
+                        <p className="text-xs text-gray-400">{c.razon_social}</p>
+                      )}
+                      <p className="text-sm text-gray-500 dark:text-gray-400">{c.direccion}</p>
+                    </button>
+                  ))}
+                </div>
+              )}
+            </div>
+          )}
+        </div>
+
+        {/* Comparación de precios (solo con cliente nuevo elegido) */}
+        {clienteNuevo && (
+          <div className="space-y-3">
+            {isLoading ? (
+              <div className="flex items-center justify-center gap-2 py-6 text-gray-500 dark:text-gray-400">
+                <Loader2 className="w-5 h-5 animate-spin" />
+                <span className="text-sm">Recalculando precios…</span>
+              </div>
+            ) : (
+              <>
+                {/* Detalle de items recalculados */}
+                <div className="border dark:border-gray-700 rounded-lg divide-y dark:divide-gray-700">
+                  {descuento.items.map((item, idx) => (
+                    <div key={`${item.productoId}-${idx}`} className="flex items-center justify-between gap-2 p-2.5 text-sm">
+                      <div className="min-w-0 flex items-center gap-1.5">
+                        {item.esBonificacion && <Gift className="w-4 h-4 text-green-600 flex-shrink-0" />}
+                        <span className="truncate dark:text-gray-200">{nombreProducto(String(item.productoId))}</span>
+                      </div>
+                      <div className="flex-shrink-0 text-right">
+                        {item.esBonificacion ? (
+                          <span className="text-green-600 font-medium">{item.cantidad} × Regalo</span>
+                        ) : (
+                          <span className="dark:text-gray-200">{item.cantidad} × {formatPrecio(item.precioUnitario)}</span>
+                        )}
+                      </div>
+                    </div>
+                  ))}
+                </div>
+
+                {/* Comparativo de totales */}
+                <div className="p-3 bg-gray-50 dark:bg-gray-800 rounded-lg space-y-1.5">
+                  <div className="flex items-center justify-between text-sm">
+                    <span className="text-gray-500 dark:text-gray-400">Total anterior</span>
+                    <span className="text-gray-500 dark:text-gray-400 line-through">{formatPrecio(totalViejo)}</span>
+                  </div>
+                  <div className="flex items-center justify-between">
+                    <span className="font-medium dark:text-white flex items-center gap-1.5">
+                      <ArrowRight className="w-4 h-4 text-blue-500" /> Total nuevo
+                    </span>
+                    <span className="text-lg font-bold dark:text-white">{formatPrecio(totalNuevo)}</span>
+                  </div>
+                  {Math.abs(delta) >= 0.01 && (
+                    <div className={`text-xs text-right font-medium ${delta > 0 ? 'text-red-600' : 'text-green-600'}`}>
+                      {delta > 0 ? '+' : ''}{formatPrecio(delta)} respecto al anterior
+                    </div>
+                  )}
+                </div>
+              </>
+            )}
+          </div>
+        )}
+
+        {/* Avisos */}
+        <div className="flex items-start gap-2 p-3 bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800 rounded-lg text-xs text-amber-800 dark:text-amber-200">
+          <AlertCircle className="w-4 h-4 flex-shrink-0 mt-0.5" />
+          <div className="space-y-0.5">
+            <p>El pedido actual se <strong>cancelará</strong> y se creará uno nuevo para el cliente elegido. Si estaba asignado a una ruta, saldrá de la ruta.</p>
+            {tienePago && <p>El pago registrado se <strong>transferirá</strong> al pedido nuevo.</p>}
+          </div>
+        </div>
+      </div>
+
+      {/* Acciones */}
+      <div className="flex gap-2 p-4 border-t dark:border-gray-700">
+        <button
+          type="button"
+          onClick={onClose}
+          disabled={guardando}
+          className="flex-1 py-2.5 border dark:border-gray-600 rounded-lg font-medium text-gray-700 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-700 disabled:opacity-50"
+        >
+          Cancelar
+        </button>
+        <button
+          type="button"
+          onClick={handleConfirmar}
+          disabled={!clienteNuevo || isLoading || guardando}
+          className="flex-1 py-2.5 bg-blue-600 text-white rounded-lg font-medium hover:bg-blue-700 disabled:bg-blue-400 disabled:cursor-not-allowed flex items-center justify-center gap-2"
+        >
+          {guardando ? (
+            <><Loader2 className="w-4 h-4 animate-spin" /> Cambiando…</>
+          ) : (
+            <><RefreshCw className="w-4 h-4" /> Confirmar cambio</>
+          )}
+        </button>
+      </div>
+    </ModalBase>
+  );
+});
+
+export default ModalCambiarCliente;

--- a/src/components/modals/ModalEditarPedido.tsx
+++ b/src/components/modals/ModalEditarPedido.tsx
@@ -11,9 +11,11 @@ import { useRendiciones } from '../../hooks/supabase/useRendiciones';
 import { usePromocionesListQuery, usePedidoSustitucionesQuery } from '../../hooks/queries/usePromocionesQuery';
 import { usePreventistasAsignablesQuery } from '../../hooks/queries/useUsuariosQuery';
 import { calcularNetoVenta, parsePrecio } from '../../utils/calculations';
-import type { PedidoDB, ProductoDB, PedidoItemDB } from '../../types';
+import type { PedidoDB, ProductoDB, PedidoItemDB, ClienteDB } from '../../types';
+import type { CambiarClientePayload } from './ModalCambiarCliente';
 
 const ModalSustituirRegalo = lazy(() => import('./ModalSustituirRegalo'));
+const ModalCambiarCliente = lazy(() => import('./ModalCambiarCliente'));
 
 /** Item del pedido para edición. Incluye fiscales opcionales que se pueblan al guardar. */
 export interface PedidoEditItem {
@@ -56,6 +58,12 @@ export interface ModalEditarPedidoProps {
   canSustituirRegalo?: boolean;
   /** Permite reasignar el preventista del pedido. Default: false. Solo admin. */
   canEditPreventista?: boolean;
+  /** Permite cambiar el cliente del pedido (cancela el viejo + crea uno nuevo). Default: false. Solo admin. */
+  canCambiarCliente?: boolean;
+  /** Lista de clientes para el buscador del cambio de cliente. */
+  clientes?: ClienteDB[];
+  /** Callback al confirmar el cambio de cliente. Resuelve cuando la RPC terminó. */
+  onCambiarCliente?: (payload: CambiarClientePayload) => Promise<void>;
   /** @deprecated usar canEditItems/canEditPrices/canEditFechaEntrega. Mantiene compat. */
   isAdmin?: boolean;
   /** Callback al guardar datos */
@@ -78,10 +86,13 @@ const ModalEditarPedido = memo(function ModalEditarPedido({
   canEditFechaEntrega,
   canSustituirRegalo = false,
   canEditPreventista = false,
+  canCambiarCliente = false,
+  clientes = [],
   isAdmin = false,
   onSave,
   onSaveItems,
   onCambiarPreventista,
+  onCambiarCliente,
   onClose,
   guardando
 }: ModalEditarPedidoProps) {
@@ -120,8 +131,33 @@ const ModalEditarPedido = memo(function ModalEditarPedido({
   // Sustitucion de regalos: el row persistido a editar (id real de pedido_items).
   const [sustItemTarget, setSustItemTarget] = useState<PedidoItemDB | null>(null);
 
+  // Cambio de cliente: abre el sub-modal y trackea el loading de la RPC.
+  const [mostrarCambioCliente, setMostrarCambioCliente] = useState<boolean>(false);
+  const [cambiandoCliente, setCambiandoCliente] = useState<boolean>(false);
+
   // Verificar si el pedido está entregado (no editable)
   const pedidoEntregado = pedido?.estado === 'entregado';
+
+  // Cambiar cliente: solo admin, pedido no entregado/cancelado y que no sea un
+  // pedido de cambio/devolución (canal='cambio', total=0). Se exige no tener
+  // cambios de items sin guardar para no recrear con datos inconsistentes.
+  const puedeCambiarCliente = Boolean(
+    canCambiarCliente && onCambiarCliente && pedido &&
+    pedido.estado !== 'entregado' && pedido.estado !== 'cancelado' && pedido.canal !== 'cambio',
+  );
+
+  const handleConfirmarCambioCliente = async (payload: CambiarClientePayload): Promise<void> => {
+    if (!onCambiarCliente) return;
+    setCambiandoCliente(true);
+    try {
+      await onCambiarCliente(payload);
+      setMostrarCambioCliente(false); // el container suele cerrar todo el modal en éxito
+    } catch {
+      // El caller notifica el error; dejamos el sub-modal abierto para reintentar.
+    } finally {
+      setCambiandoCliente(false);
+    }
+  };
 
   // Regalos persistidos en DB (items con es_bonificacion=true). A diferencia
   // de las bonificacionesCalculadas que se recalculan localmente, estas son
@@ -861,6 +897,28 @@ const ModalEditarPedido = memo(function ModalEditarPedido({
           </div>
         </div>
 
+        {/* Cambiar cliente (solo admin). Recrea el pedido para otro cliente
+            cuando se eligió mal el cliente al cargarlo. */}
+        {puedeCambiarCliente && (
+          <div>
+            <button
+              type="button"
+              onClick={() => setMostrarCambioCliente(true)}
+              disabled={guardando || cambiandoCliente || itemsModificados}
+              title={itemsModificados ? 'Guardá los cambios de items antes de cambiar el cliente' : undefined}
+              className="w-full flex items-center justify-center gap-2 px-4 py-2.5 text-sm font-medium text-blue-700 dark:text-blue-300 hover:bg-blue-50 dark:hover:bg-blue-900/30 border border-blue-300 dark:border-blue-700 rounded-lg disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              <UserCheck className="w-4 h-4" />
+              Cambiar cliente
+            </button>
+            {itemsModificados && (
+              <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
+                Guardá primero los cambios de items para poder cambiar el cliente.
+              </p>
+            )}
+          </div>
+        )}
+
         {/* Fecha del pedido (solo admin/encargado) */}
         {puedeEditarFechas && (
           <div>
@@ -1000,6 +1058,20 @@ const ModalEditarPedido = memo(function ModalEditarPedido({
               />
             );
           })()}
+        </Suspense>
+      )}
+
+      {/* Modal de cambio de cliente (lazy) */}
+      {mostrarCambioCliente && pedido && (
+        <Suspense fallback={null}>
+          <ModalCambiarCliente
+            pedido={pedido}
+            productos={productos}
+            clientes={clientes}
+            onConfirmar={handleConfirmarCambioCliente}
+            onClose={() => setMostrarCambioCliente(false)}
+            guardando={cambiandoCliente}
+          />
         </Suspense>
       )}
     </ModalBase>

--- a/src/hooks/queries/index.ts
+++ b/src/hooks/queries/index.ts
@@ -61,6 +61,7 @@ export {
   usePedidosAsignadosQuery,
   useEntregasMasivasMutation,
   useCancelarPedidoMutation,
+  useCambiarClientePedidoMutation,
   usePedidosNoPagadosQuery,
   usePagosMasivosMutation,
 } from './usePedidosQuery'

--- a/src/hooks/queries/usePedidosQuery.ts
+++ b/src/hooks/queries/usePedidosQuery.ts
@@ -7,6 +7,7 @@ import { supabase } from '../supabase/base'
 import { useSucursal } from '../../contexts/SucursalContext'
 import type { PedidoDB, PedidoItemDB, PerfilDB, FiltrosPedidosState, PedidoSalvedadResumen } from '../../types'
 import { productosKeys } from './useProductosQuery'
+import { clientesKeys } from './useClientesQuery'
 
 // Query keys
 export const pedidosKeys = {
@@ -59,6 +60,19 @@ interface CrearPedidoInput {
   // el RPC usa auth.uid() (comportamiento histórico). Si difiere, el RPC
   // exige que el actor sea admin (mig 060).
   preventistaId?: string | null
+}
+
+interface CambiarClienteInput {
+  pedidoId: string
+  nuevoClienteId: string
+  usuarioId: string | null
+  // Items YA recalculados para el cliente nuevo (mayorista/promo/descuento +
+  // desglose fiscal). Mismo shape que CrearPedidoInput.items.
+  items: PedidoItemInput[]
+  total: number
+  totalNeto?: number
+  totalIva?: number
+  motivo?: string
 }
 
 interface ActualizarEstadoInput {
@@ -822,6 +836,71 @@ export function useCancelarPedidoMutation() {
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: pedidosKeys.all(currentSucursalId) })
       queryClient.invalidateQueries({ queryKey: productosKeys.all(currentSucursalId) })
+    },
+  })
+}
+
+// =========================================================================
+// Cambiar cliente del pedido (cancela el viejo + crea uno nuevo)
+// =========================================================================
+
+/**
+ * Cambia el cliente de un pedido cargado al cliente equivocado. La RPC cancela
+ * el pedido actual y crea uno nuevo idéntico para el cliente correcto, con los
+ * precios ya recalculados en el front y transfiriendo los pagos. Atómico.
+ */
+async function cambiarClientePedido(input: CambiarClienteInput): Promise<{ nuevoPedidoId: string }> {
+  const itemsParaRPC = input.items.map(item => ({
+    producto_id: item.productoId || item.producto_id,
+    cantidad: item.cantidad,
+    precio_unitario: item.precioUnitario ?? item.precio_unitario ?? 0,
+    ...(item.esBonificacion ? { es_bonificacion: true } : {}),
+    ...(item.promocionId ? { promocion_id: item.promocionId } : {}),
+    ...(item.neto_unitario != null ? { neto_unitario: item.neto_unitario } : {}),
+    ...(item.iva_unitario != null ? { iva_unitario: item.iva_unitario } : {}),
+    ...(item.impuestos_internos_unitario != null ? { impuestos_internos_unitario: item.impuestos_internos_unitario } : {}),
+    ...(item.porcentaje_iva != null ? { porcentaje_iva: item.porcentaje_iva } : {}),
+  }))
+
+  const { data, error } = await supabase.rpc('cambiar_cliente_pedido', {
+    p_pedido_id: input.pedidoId,
+    p_nuevo_cliente_id: input.nuevoClienteId,
+    p_usuario_id: input.usuarioId,
+    p_items: itemsParaRPC,
+    p_total: input.total,
+    p_total_neto: input.totalNeto ?? input.total,
+    p_total_iva: input.totalIva ?? 0,
+    ...(input.motivo ? { p_motivo: input.motivo } : {}),
+  })
+
+  if (error) throw error
+
+  const result = data as { success: boolean; nuevo_pedido_id?: string; error?: string; errores?: string[] }
+  if (!result.success) {
+    throw new Error(result.error || result.errores?.join(', ') || 'Error al cambiar el cliente del pedido')
+  }
+
+  return { nuevoPedidoId: String(result.nuevo_pedido_id) }
+}
+
+/**
+ * Hook para cambiar el cliente de un pedido. Invalida pedidos, productos (stock),
+ * recorridos (pudo salir de una ruta) y clientes (saldo de ambos clientes).
+ */
+export function useCambiarClientePedidoMutation() {
+  const queryClient = useQueryClient()
+  const { currentSucursalId } = useSucursal()
+
+  return useMutation({
+    mutationFn: cambiarClientePedido,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: pedidosKeys.all(currentSucursalId) })
+      queryClient.invalidateQueries({ queryKey: productosKeys.all(currentSucursalId) })
+      queryClient.invalidateQueries({ queryKey: clientesKeys.all(currentSucursalId) })
+      queryClient.invalidateQueries({ queryKey: ['recorridos'] })
+      queryClient.invalidateQueries({ queryKey: ['recorrido-activo'] })
+      queryClient.invalidateQueries({ queryKey: ['recorrido-existente'] })
+      queryClient.invalidateQueries({ queryKey: ['recorridos-hoja-ruta'] })
     },
   })
 }


### PR DESCRIPTION
## Problema

Los usuarios a veces cargan un pedido al **cliente equivocado**. Hoy la única forma de corregirlo es que el admin recree el pedido a mano y borre el viejo — tedioso y propenso a errores.

## Solución

Botón **"Cambiar cliente"** en el modal de edición de pedidos (solo admin) que, en una operación atómica, cancela el pedido actual y crea uno nuevo idéntico para el cliente correcto:
- **Recalcula** precios/promos/condición mayorista/descuentos para el cliente nuevo (no copia los del viejo) y muestra una **comparación total anterior vs nuevo**.
- **Transfiere los pagos** ya registrados al pedido nuevo.
- Si el pedido estaba en una ruta, lo **saca de la ruta** (el nuevo vuelve al pool de "Armar ruta").
- **Conserva el preventista** original (comisiones).

## Backend (migración 094, ya aplicada a prod)

`cambiar_cliente_pedido` (SECURITY DEFINER) orquesta y reutiliza RPCs existentes:
1. Valida (solo admin, no entregado/cancelado, cliente distinto).
2. `cancelar_pedido_con_stock` — restaura stock + ajusta saldo del cliente viejo.
3. `quitar_pedido_de_recorridos_activos` — lo saca de la ruta en curso.
4. `crear_pedido_completo` — descuenta stock + ajusta saldo del cliente nuevo, conservando notas/forma_pago/fecha/factura/preventista.
5. Transferencia de pagos con `UPDATE pagos SET pedido_id/cliente_id` — los triggers reajustan `monto_pagado` y el saldo de **ambos** clientes.

**Atómico:** si `crear_pedido_completo` falla (ej. stock), un `RAISE` revierte toda la transacción (incluida la cancelación) y el pedido viejo queda intacto.

## Frontend

- `ModalCambiarCliente.tsx` (nuevo): buscador de cliente + recálculo vía `usePromocionPedido` + `aplicarDescuentoClienteItems` + comparativo de totales.
- `useCambiarClientePedidoMutation` en `usePedidosQuery.ts` (invalida pedidos/productos/recorridos/saldo).
- Botón en `ModalEditarPedido.tsx` + wiring en `PedidosContainer.tsx`.

## Verificación

- **Estática:** lint ✅, typecheck ✅, build ✅, **741 tests** (3 nuevos en `ModalCambiarCliente`).
- **En vivo** (prueba transaccional con rollback, sin tocar datos reales): saldo del cliente viejo vuelve a 0, el nuevo = `total − pago`, stock neto cero, pago transferido al cliente/pedido nuevo, pedido viejo `cancelado` con referencia cruzada, preventista conservado.

🤖 Generated with [Claude Code](https://claude.com/claude-code)