### PR TITLE
fix(cambios+rutas): validación co-locada del cambio, cambio en el manifiesto y buscador de pedidos

### DIFF
--- a/src/components/modals/ModalCambioProducto.tsx
+++ b/src/components/modals/ModalCambioProducto.tsx
@@ -1,12 +1,36 @@
 import React, { useState, useMemo, FormEvent, ChangeEvent } from 'react'
+import { z } from 'zod'
 import { X, ArrowLeftRight, ArrowDown, ArrowUp, FileText, Search, Package, AlertTriangle, User as UserIcon } from 'lucide-react'
 import { useZodValidation } from '../../hooks/useZodValidation'
-import { modalCambioProductoSchema } from '../../lib/schemas'
 import { formatPrecio } from '../../utils/formatters'
 import NumberInput from '../ui/NumberInput'
 import type { ClienteDB, ProductoDB } from '../../types'
 
 export type MotivoCambio = 'vencimiento' | 'rotura' | 'mal_estado' | 'erroneo' | 'otro'
+
+// Schema CO-LOCADO a propósito (no en lib/schemas.ts): si viviera en ese chunk
+// compartido, un deploy podía dejar el schema viejo cacheado en el PWA y
+// desincronizarlo de las opciones que muestra este modal — el motivo nuevo
+// 'mal_estado' daba "Invalid input" validado contra un enum viejo. Acá la
+// validación viaja SIEMPRE en el mismo chunk que la UI: no pueden desfasarse.
+// Las opciones del enum deben coincidir con MOTIVOS_CAMBIO / MotivoCambio.
+const modalCambioProductoSchema = z.object({
+  clienteId: z.string().min(1, { message: 'Debe seleccionar un cliente' }),
+  productoDevueltoId: z.string().min(1, { message: 'Debe seleccionar el producto a devolver' }),
+  cantidadDevuelta: z.coerce
+    .number({ error: 'La cantidad debe ser un número' })
+    .int({ message: 'La cantidad debe ser un número entero' })
+    .positive({ message: 'La cantidad debe ser mayor a 0' }),
+  productoEntregadoId: z.string().min(1, { message: 'Debe seleccionar el producto a entregar' }),
+  cantidadEntregada: z.coerce
+    .number({ error: 'La cantidad debe ser un número' })
+    .int({ message: 'La cantidad debe ser un número entero' })
+    .positive({ message: 'La cantidad debe ser mayor a 0' }),
+  observaciones: z.string().optional(),
+  // vencimiento/rotura/mal_estado → el devuelto se da de baja; erroneo/otro →
+  // reingresa. Se permite el mismo producto (caso vencimiento: mismo fresco).
+  motivo: z.enum(['vencimiento', 'rotura', 'mal_estado', 'erroneo', 'otro']).default('erroneo'),
+})
 
 export interface CambioProductoSaveData {
   clienteId: string

--- a/src/components/modals/ModalExportarPDF.tsx
+++ b/src/components/modals/ModalExportarPDF.tsx
@@ -1,10 +1,14 @@
 import { useState, useMemo, useCallback, useEffect, useRef, memo } from 'react';
 import type { ChangeEvent } from 'react';
-import { FileDown, Package, Truck, Printer, Loader2, CalendarDays } from 'lucide-react';
+import { FileDown, Package, Truck, Printer, Loader2, CalendarDays, Search } from 'lucide-react';
 import ModalBase from './ModalBase';
 import { formatPrecio, fechaLocalISO, formatFecha } from '../../utils/formatters';
 import { useRecorridosHojaRutaQuery } from '../../hooks/queries';
 import type { PedidoDB, PerfilDB } from '../../types';
+
+// Normaliza para búsquedas: saca acentos y pasa a minúsculas.
+const normTexto = (s?: string | null): string =>
+  (s || '').normalize('NFD').replace(/\p{Diacritic}/gu, '').toLowerCase();
 
 // =============================================================================
 // TIPOS
@@ -42,6 +46,7 @@ const ModalExportarPDF = memo(function ModalExportarPDF({
   const [transportistaSeleccionado, setTransportistaSeleccionado] = useState<string>('');
   const [pedidosSeleccionados, setPedidosSeleccionados] = useState<string[]>([]);
   const [seleccionarTodos, setSeleccionarTodos] = useState<boolean>(false);
+  const [busquedaPedido, setBusquedaPedido] = useState<string>('');
   const [todosLosPedidos, setTodosLosPedidos] = useState<PedidoDB[] | null>(null);
   const [cargandoTodos, setCargandoTodos] = useState(false);
   // Hoja de ruta Y comandas: se descargan desde la ruta YA armada de un día +
@@ -78,6 +83,16 @@ const ModalExportarPDF = memo(function ModalExportarPDF({
       );
     }
   }, [pedidosBase, tipoExport, transportistaSeleccionado]);
+
+  // Filtro de búsqueda para encontrar/destildar pedidos rápido en listas largas.
+  const coincideBusqueda = (p: PedidoDB): boolean => {
+    const q = normTexto(busquedaPedido);
+    if (!q) return true;
+    return String(p.id).includes(q)
+      || normTexto(p.cliente?.nombre_fantasia).includes(q)
+      || normTexto(p.cliente?.razon_social).includes(q)
+      || normTexto(p.cliente?.direccion).includes(q);
+  };
 
   // Cargar todos los pedidos cuando se selecciona "todos"
   const handleAlcanceChange = useCallback(async (nuevoAlcance: AlcanceExport) => {
@@ -159,6 +174,7 @@ const ModalExportarPDF = memo(function ModalExportarPDF({
     setPedidosSeleccionados([]);
     setSeleccionarTodos(false);
     setTransportistaSeleccionado('');
+    setBusquedaPedido('');
   };
 
   const handleTransportistaChange = (id: string): void => {
@@ -361,8 +377,21 @@ const ModalExportarPDF = memo(function ModalExportarPDF({
                 <p className="text-xs text-gray-500 dark:text-gray-400 mb-2">
                   Destildá los pedidos que no quieras incluir en la impresión.
                 </p>
+                <div className="relative mb-2">
+                  <Search className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400 w-4 h-4" aria-hidden="true" />
+                  <input
+                    type="text"
+                    value={busquedaPedido}
+                    onChange={(e: ChangeEvent<HTMLInputElement>) => setBusquedaPedido(e.target.value)}
+                    placeholder="Buscar por cliente, dirección o N° de pedido…"
+                    className="w-full pl-9 pr-3 py-2 text-sm border rounded-lg dark:bg-gray-700 dark:border-gray-600 dark:text-white"
+                  />
+                </div>
                 <div className="border rounded-lg max-h-56 overflow-y-auto dark:border-gray-600">
-                  {recorridoSeleccionado.paradas.map((pedido, idx) => (
+                  {recorridoSeleccionado.paradas
+                    .map((pedido, idx) => ({ pedido, idx }))
+                    .filter(({ pedido }) => coincideBusqueda(pedido))
+                    .map(({ pedido, idx }) => (
                     <div
                       key={pedido.id}
                       onClick={() => handleTogglePedido(pedido.id)}
@@ -387,6 +416,9 @@ const ModalExportarPDF = memo(function ModalExportarPDF({
                       </div>
                     </div>
                   ))}
+                  {recorridoSeleccionado.paradas.filter(coincideBusqueda).length === 0 && (
+                    <p className="p-3 text-sm text-gray-500 text-center">Sin pedidos que coincidan con la búsqueda.</p>
+                  )}
                 </div>
               </div>
             )}
@@ -414,6 +446,19 @@ const ModalExportarPDF = memo(function ModalExportarPDF({
               )}
             </div>
 
+            {pedidosFiltrados.length > 0 && (
+              <div className="relative mb-2">
+                <Search className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400 w-4 h-4" aria-hidden="true" />
+                <input
+                  type="text"
+                  value={busquedaPedido}
+                  onChange={(e: ChangeEvent<HTMLInputElement>) => setBusquedaPedido(e.target.value)}
+                  placeholder="Buscar por cliente, dirección o N° de pedido…"
+                  className="w-full pl-9 pr-3 py-2 text-sm border rounded-lg dark:bg-gray-700 dark:border-gray-600 dark:text-white"
+                />
+              </div>
+            )}
+
             {cargandoTodos ? (
               <div className="flex items-center justify-center py-8 bg-gray-50 dark:bg-gray-900 rounded-lg">
                 <Loader2 className="w-6 h-6 animate-spin text-blue-600 mr-2" />
@@ -427,7 +472,7 @@ const ModalExportarPDF = memo(function ModalExportarPDF({
               </div>
             ) : (
               <div className="border rounded-lg max-h-64 overflow-y-auto">
-                {pedidosFiltrados.map(pedido => (
+                {pedidosFiltrados.filter(coincideBusqueda).map(pedido => (
                   <div
                     key={pedido.id}
                     onClick={() => handleTogglePedido(pedido.id)}
@@ -455,6 +500,9 @@ const ModalExportarPDF = memo(function ModalExportarPDF({
                     </div>
                   </div>
                 ))}
+                {pedidosFiltrados.filter(coincideBusqueda).length === 0 && (
+                  <p className="p-3 text-sm text-gray-500 text-center">Sin pedidos que coincidan con la búsqueda.</p>
+                )}
               </div>
             )}
           </div>

--- a/src/components/modals/ModalGestionRutas.tsx
+++ b/src/components/modals/ModalGestionRutas.tsx
@@ -4,7 +4,7 @@ import {
   Loader2, AlertTriangle, Check, Truck, MapPin, Route, Clock, Navigation,
   Settings, Save, FileText, ChevronDown, ChevronUp, Phone,
   DollarSign, Package, CheckCircle, Circle, Printer, ArrowRight, CalendarDays, Pencil,
-  ArrowLeftRight
+  ArrowLeftRight, Search
 } from 'lucide-react';
 import ModalBase from './ModalBase';
 import ModalCambioProducto, { type CambioProductoSaveData } from './ModalCambioProducto';
@@ -13,6 +13,10 @@ import type { RegistrarCambioInput } from '../../hooks/queries';
 import type { RepartidorParam } from '../../hooks/useOptimizarRuta';
 import { fechaLocalISO, fechaHaceDias, formatFecha } from '../../utils/formatters';
 import type { PedidoDB, PerfilDB, ClienteDB, ProductoDB } from '../../types';
+
+// Normaliza para búsquedas: saca acentos y pasa a minúsculas.
+const normTexto = (s?: string | null): string =>
+  (s || '').normalize('NFD').replace(/\p{Diacritic}/gu, '').toLowerCase();
 
 // =============================================================================
 // TIPOS
@@ -237,6 +241,7 @@ const ModalGestionRutas = memo(function ModalGestionRutas({
   const [repartidoresSel, setRepartidoresSel] = useState<Set<string>>(new Set());
   const [paramsPorChofer, setParamsPorChofer] = useState<Record<string, { maxParadas: string; zonas: string[] }>>({});
   const [transportistaSeleccionado, setTransportistaSeleccionado] = useState<string>('');
+  const [busquedaPedido, setBusquedaPedido] = useState<string>('');
   // Fecha de entrega de la ruta. Generalmente se arma el día anterior, así que
   // el default es mañana; se puede elegir de hoy en adelante.
   const hoyISO = fechaLocalISO();
@@ -329,6 +334,19 @@ const ModalGestionRutas = memo(function ModalGestionRutas({
     return Array.from(map.values())
       .sort((a, b) => (a.orden_entrega || 999) - (b.orden_entrega || 999));
   }, [modoDividir, transportistaSeleccionado, paradasExistentes, disponiblesFiltrados]);
+
+  // Filtro de búsqueda SOLO para la vista de la lista (no afecta selección ni
+  // contadores): encontrar/destildar un pedido rápido en listas largas.
+  const pedidosVisiblesFiltrados = useMemo((): PedidoDB[] => {
+    const q = normTexto(busquedaPedido);
+    if (!q) return pedidosVisibles;
+    return pedidosVisibles.filter(p =>
+      String(p.id).includes(q)
+      || normTexto(p.cliente?.nombre_fantasia).includes(q)
+      || normTexto(p.cliente?.razon_social).includes(q)
+      || normTexto(p.cliente?.direccion).includes(q)
+    );
+  }, [pedidosVisibles, busquedaPedido]);
 
   // Selección de paradas. En modo dividir se siembra con TODO el pool (el caso
   // común es rutear todo y dividir). En modo 1 chofer se siembra una vez por
@@ -973,8 +991,22 @@ const ModalGestionRutas = memo(function ModalGestionRutas({
                           Seleccionar todos
                         </label>
                       </div>
+                      <div className="p-2 border-b">
+                        <div className="relative">
+                          <Search className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400 w-4 h-4" aria-hidden="true" />
+                          <input
+                            type="text"
+                            value={busquedaPedido}
+                            onChange={(e: ChangeEvent<HTMLInputElement>) => setBusquedaPedido(e.target.value)}
+                            placeholder="Buscar por cliente, dirección o N° de pedido…"
+                            className="w-full pl-9 pr-3 py-2 text-sm border rounded-lg"
+                          />
+                        </div>
+                      </div>
                       <div className="max-h-60 overflow-y-auto divide-y">
-                        {pedidosVisibles.map((pedido) => {
+                        {pedidosVisiblesFiltrados.length === 0 ? (
+                          <p className="p-3 text-sm text-gray-500 text-center">Sin pedidos que coincidan con la búsqueda.</p>
+                        ) : pedidosVisiblesFiltrados.map((pedido) => {
                           const checked = seleccionados.has(pedido.id);
                           const enRuta = idsExistentes.has(pedido.id);
                           return (

--- a/src/hooks/queries/useRecorridosHojaRutaQuery.ts
+++ b/src/hooks/queries/useRecorridosHojaRutaQuery.ts
@@ -27,11 +27,15 @@ export const recorridosHojaRutaKeys = {
     ['recorridos-hoja-ruta', sucursalId, fecha] as const,
 }
 
+// Se agrega `cambio:recorrido_cambios(...)` SOLO acá (no en el PEDIDO_SELECT
+// global, para no inflar la lista de pedidos): la hoja de ruta necesita el
+// detalle del cambio para mostrar qué retirar/entregar en la parada y para
+// sumar el producto entregado al manifiesto de carga del camión.
 const SELECT = `id,
   transportista:perfiles!transportista_id(id, nombre),
   recorrido_pedidos(
     orden_entrega,
-    pedido:pedidos(${PEDIDO_SELECT})
+    pedido:pedidos(${PEDIDO_SELECT}, cambio:recorrido_cambios(producto_devuelto_nombre, cantidad_devuelta, producto_entregado_id, producto_entregado_nombre, cantidad_entregada, observaciones, motivo))
   )`
 
 interface RecorridoHojaRutaRaw {

--- a/src/lib/pdf/hojaRutaOptimizada.js
+++ b/src/lib/pdf/hojaRutaOptimizada.js
@@ -446,6 +446,20 @@ function buildManifiestoOps(doc, pedidos) {
     })
   })
 
+  // Paradas de cambio/devolución (canal='cambio'): el producto que se ENTREGA al
+  // cliente también se carga en el camión, así que suma al manifiesto. El detalle
+  // vive en recorrido_cambios (cargado como pedido.cambio en la hoja de ruta).
+  // Si el entregado coincide con un producto comprado, se acumulan en la misma fila.
+  pedidos.forEach((pedido) => {
+    if (pedido.canal !== 'cambio') return
+    const c = Array.isArray(pedido.cambio) ? pedido.cambio[0] : pedido.cambio
+    if (!c) return
+    const cantidad = Number(c.cantidad_entregada) || 0
+    if (cantidad <= 0) return
+    const key = c.producto_entregado_id ?? c.producto_entregado_nombre ?? 'cambio-sin-id'
+    acumular(totalesCompras, key, c.producto_entregado_nombre || 'Producto', cantidad)
+  })
+
   // Partir las fracciones consolidadas UNA vez por producto: fardos completos +
   // el resto como sueltas (a lo sumo upb-1 sueltas por producto en toda la ruta).
   Object.values(totalesBonifFraccion).forEach((f) => {

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -690,30 +690,12 @@ export const modalMermaSchema = z.object({
 /** Inferred type for ModalMerma schema */
 export type ModalMermaFormData = z.infer<typeof modalMermaSchema>
 
-/**
- * Schema para ModalCambioProducto
- */
-export const modalCambioProductoSchema = z.object({
-  clienteId: z.string().min(1, { message: 'Debe seleccionar un cliente' }),
-  productoDevueltoId: z.string().min(1, { message: 'Debe seleccionar el producto a devolver' }),
-  cantidadDevuelta: z.coerce
-    .number({ error: 'La cantidad debe ser un número' })
-    .int({ message: 'La cantidad debe ser un número entero' })
-    .positive({ message: 'La cantidad debe ser mayor a 0' }),
-  productoEntregadoId: z.string().min(1, { message: 'Debe seleccionar el producto a entregar' }),
-  cantidadEntregada: z.coerce
-    .number({ error: 'La cantidad debe ser un número' })
-    .int({ message: 'La cantidad debe ser un número entero' })
-    .positive({ message: 'La cantidad debe ser mayor a 0' }),
-  observaciones: z.string().optional(),
-  // Motivo del cambio: define si el producto devuelto reingresa al stock
-  // (vencimiento/rotura → se da de baja; erroneo/otro → reingresa). Se permite
-  // el mismo producto (caso vencimiento: se cambia por el mismo fresco).
-  motivo: z.enum(['vencimiento', 'rotura', 'mal_estado', 'erroneo', 'otro']).default('erroneo')
-})
-
-/** Inferred type for ModalCambioProducto schema */
-export type ModalCambioProductoFormData = z.infer<typeof modalCambioProductoSchema>
+// NOTA: el schema de ModalCambioProducto se movió DENTRO del propio modal
+// (src/components/modals/ModalCambioProducto.tsx). Vivía acá, en este chunk
+// compartido, y un deploy podía dejar la versión vieja cacheada en el PWA y
+// desincronizarla de las opciones que muestra el modal (p. ej. el motivo nuevo
+// 'mal_estado' fallaba con "Invalid input" contra el schema viejo). Co-locado,
+// la validación viaja siempre en el mismo chunk que la UI.
 
 /**
  * Schema para ModalProveedor


### PR DESCRIPTION
Tres pedidos de la usuaria (feedback de Vir), todo **frontend, sin migración**:

### 1. 🐛 El cambio/devolución no se podía crear ("Invalid input")
La pantalla mostraba el motivo nuevo *"Producto en mal estado"* pero al guardar fallaba con **"Invalid input"**. Reproduje el schema actual: el payload **pasa** la validación. La causa real es un **chunk viejo del PWA**: el schema vivía en `lib/schemas.ts` (chunk compartido), y tras un deploy el navegador podía servir la versión vieja cacheada — desincronizada del modal nuevo — así que validaba `'mal_estado'` contra un enum sin esa opción.

**Fix:** el schema se mueve **dentro de `ModalCambioProducto.tsx`**. Ahora la validación y la UI viajan siempre en el mismo chunk: no pueden desfasarse nunca más (esto cubre también futuros motivos/campos).

> Igual conviene un hard-refresh para bajar el build nuevo la primera vez.

### 2. 📦 El cambio ahora entra en el manifiesto de carga
La query de la hoja de ruta no cargaba `recorrido_cambios`, así que el producto entregado del cambio no llegaba al manifiesto (y la parada salía sin detalle). Ahora se carga `cambio:recorrido_cambios(...)` **solo en esa query** (no en el `PEDIDO_SELECT` global, para no inflar la lista de pedidos):
- El **producto que se entrega** suma al *Manifiesto de carga* del camión (si coincide con un producto comprado, se acumulan en la misma fila).
- La parada de cambio ahora muestra **qué retirar / qué entregar** en la hoja de ruta (antes salía en blanco).

### 3. 🔎 Buscador de pedidos
Barra de búsqueda (por cliente, dirección o N° de pedido) en:
- **Exportar PDF** → Hoja de Ruta y Orden de Preparación.
- **Armar ruta del día**.

Es un filtro **solo de vista**: no toca la selección ni los contadores (encontrás/destildás rápido en listas largas).

---
**Verificación:** `tsc --noEmit` ✅ · `eslint` ✅ · `vitest run` (741) ✅
🤖 Generated with [Claude Code](https://claude.com/claude-code)