### PR TITLE
fix(reportes): restringir el dashboard a las sucursales asignadas del usuario

### DIFF
--- a/migrations/095_reporte_gerencial.sql
+++ b/migrations/095_reporte_gerencial.sql
@@ -29,24 +29,48 @@ SECURITY DEFINER
 SET search_path = public
 AS $$
 DECLARE
-  v_sucursales bigint[];
-  v_nombre     text;
-  v_result     jsonb;
+  v_sucursales  bigint[];
+  v_asignadas   bigint[];
+  v_nombre      text;
+  v_result      jsonb;
+  v_es_servicio boolean := (auth.uid() IS NULL);
 BEGIN
-  -- Auth: si hay usuario (JWT desde la app), debe ser admin. Si auth.uid() es
-  -- NULL (service_role / Claude Code vía MCP), se permite (contexto privilegiado).
-  IF auth.uid() IS NOT NULL
-     AND NOT EXISTS (SELECT 1 FROM perfiles WHERE id = auth.uid() AND rol = 'admin') THEN
-    RAISE EXCEPTION 'Acceso denegado: se requiere rol admin';
+  -- Auth: desde la app (con JWT) el usuario debe ser admin Y sólo puede ver las
+  -- sucursales que tiene asignadas (usuario_sucursales). Si auth.uid() es NULL
+  -- (service_role / Claude Code vía MCP) es contexto privilegiado: acceso total
+  -- (lo usa el comando /reporte-mensual para generar todas las sucursales + red).
+  IF NOT v_es_servicio THEN
+    IF NOT EXISTS (SELECT 1 FROM perfiles WHERE id = auth.uid() AND rol = 'admin') THEN
+      RAISE EXCEPTION 'Acceso denegado: se requiere rol admin';
+    END IF;
+    SELECT array_agg(sucursal_id) INTO v_asignadas
+    FROM usuario_sucursales WHERE usuario_id = auth.uid();
+    IF v_asignadas IS NULL THEN
+      RAISE EXCEPTION 'Acceso denegado: el usuario no tiene sucursales asignadas';
+    END IF;
   END IF;
 
-  -- Sucursales objetivo. NULL = todas las activas (consolidado de red).
+  -- Sucursales objetivo.
   IF p_sucursal_id IS NULL THEN
+    -- Consolidado: sucursales activas; para un usuario, sólo las que tiene
+    -- asignadas (un admin de una sola sucursal NO ve datos de otras).
     SELECT array_agg(id) INTO v_sucursales FROM sucursales WHERE activa;
+    IF NOT v_es_servicio THEN
+      SELECT array_agg(s) INTO v_sucursales
+      FROM unnest(v_sucursales) AS s WHERE s = ANY(v_asignadas);
+    END IF;
     v_nombre := 'Red (consolidado)';
   ELSE
+    -- Sucursal puntual: el usuario debe tenerla asignada.
+    IF NOT v_es_servicio AND NOT (p_sucursal_id = ANY(v_asignadas)) THEN
+      RAISE EXCEPTION 'Acceso denegado: la sucursal % no está asignada al usuario', p_sucursal_id;
+    END IF;
     v_sucursales := ARRAY[p_sucursal_id];
     SELECT nombre INTO v_nombre FROM sucursales WHERE id = p_sucursal_id;
+  END IF;
+
+  IF v_sucursales IS NULL OR array_length(v_sucursales, 1) IS NULL THEN
+    RAISE EXCEPTION 'Acceso denegado: sin sucursales disponibles para el usuario';
   END IF;
 
   WITH

--- a/src/components/containers/ReportesGerencialesContainer.tsx
+++ b/src/components/containers/ReportesGerencialesContainer.tsx
@@ -1,8 +1,7 @@
-import React, { lazy, Suspense, useMemo, useState } from 'react'
+import React, { lazy, Suspense, useEffect, useMemo, useState } from 'react'
 import { Loader2 } from 'lucide-react'
-import { useQuery } from '@tanstack/react-query'
-import { supabase } from '../../lib/supabase'
 import { useReporteGerencialQuery, useAnalisisMensualQuery } from '../../hooks/queries'
+import { useSucursal } from '../../contexts/SucursalContext'
 import type { PeriodoOpt, SucursalOpt } from '../vistas/VistaReportesGerenciales'
 
 const VistaReportesGerenciales = lazy(() => import('../vistas/VistaReportesGerenciales'))
@@ -18,7 +17,6 @@ function generarPeriodos(): PeriodoOpt[] {
   const hoy = new Date()
   const opts: PeriodoOpt[] = []
 
-  // Trimestre en curso
   const qStart = Math.floor(hoy.getMonth() / 3) * 3
   const qDesde = new Date(hoy.getFullYear(), qStart, 1)
   const qFin = new Date(hoy.getFullYear(), qStart + 3, 0)
@@ -33,7 +31,6 @@ function generarPeriodos(): PeriodoOpt[] {
     parcial: qParcial,
   })
 
-  // Últimos 6 meses
   for (let i = 0; i < 6; i++) {
     const d = new Date(hoy.getFullYear(), hoy.getMonth() - i, 1)
     const y = d.getFullYear()
@@ -57,33 +54,39 @@ function generarPeriodos(): PeriodoOpt[] {
 export default function ReportesGerencialesContainer(): React.ReactElement {
   const periodos = useMemo(() => generarPeriodos(), [])
   const [periodoSel, setPeriodoSel] = useState<PeriodoOpt>(() => periodos[0])
-  const [sucursalSel, setSucursalSel] = useState<number | null>(null) // null = red consolidada
 
-  const { data: sucursalesDb } = useQuery({
-    queryKey: ['sucursales-activas-reporte'],
-    queryFn: async () => {
-      const { data, error } = await supabase.from('sucursales').select('id, nombre').eq('activa', true).order('id')
-      if (error) throw new Error(error.message)
-      return data as { id: number; nombre: string }[]
-    },
-    staleTime: 60 * 60 * 1000,
-  })
+  // Sólo las sucursales que el usuario tiene asignadas (SucursalContext).
+  // El backend (RPC) refuerza esto: un admin de una sola sucursal no puede ver
+  // datos de otra ni el consolidado de la red.
+  const { sucursales, hasMultipleSucursales, loading: sucLoading } = useSucursal()
 
   const opcionesSucursal: SucursalOpt[] = useMemo(() => {
-    const list = (sucursalesDb ?? []).map(s => ({ id: s.id as number | null, nombre: s.nombre }))
-    return [{ id: null, nombre: 'Red (consolidado)' }, ...list]
-  }, [sucursalesDb])
+    const list: SucursalOpt[] = sucursales.map(s => ({ id: s.id as number | null, nombre: s.nombre }))
+    // El consolidado de red sólo se ofrece a quien tiene 2+ sucursales asignadas.
+    return hasMultipleSucursales ? [{ id: null, nombre: 'Red (consolidado)' }, ...list] : list
+  }, [sucursales, hasMultipleSucursales])
 
-  const { data: reporte, isLoading, error } = useReporteGerencialQuery(sucursalSel, periodoSel.desde, periodoSel.hasta)
-  const { data: analisis } = useAnalisisMensualQuery(sucursalSel, periodoSel.periodoMes, periodoSel.esMes)
+  // Default: red si tiene varias; su única sucursal si tiene una.
+  const [sucursalSel, setSucursalSel] = useState<number | null | undefined>(undefined)
+  useEffect(() => {
+    if (sucursalSel === undefined && sucursales.length > 0) {
+      setSucursalSel(hasMultipleSucursales ? null : sucursales[0].id)
+    }
+  }, [sucursales, hasMultipleSucursales, sucursalSel])
+
+  const ready = sucursalSel !== undefined
+  const sucParam = sucursalSel ?? null
+
+  const { data: reporte, isLoading, error } = useReporteGerencialQuery(sucParam, periodoSel.desde, periodoSel.hasta, ready)
+  const { data: analisis } = useAnalisisMensualQuery(sucParam, periodoSel.periodoMes, ready && periodoSel.esMes)
 
   return (
     <Suspense fallback={<div className="flex items-center justify-center py-20"><Loader2 className="w-8 h-8 animate-spin text-blue-600" /></div>}>
       <VistaReportesGerenciales
         reporte={reporte}
-        loading={isLoading}
+        loading={isLoading || !ready || sucLoading}
         error={error ? (error as Error).message : null}
-        sucursalSel={sucursalSel}
+        sucursalSel={sucParam}
         periodoSel={periodoSel}
         opcionesSucursal={opcionesSucursal}
         opcionesPeriodo={periodos}


### PR DESCRIPTION
## Contexto

Sigue a #399 (que ya está en `main`). El dashboard de Reportes Gerenciales dejaba que **cualquier admin viera cualquier sucursal y el consolidado de toda la red**, sin chequear cuáles tiene asignadas. Este cambio lo restringe: un admin de una sola sucursal **no debe ver datos de la otra**.

## Cambios

**Backend — `reporte_gerencial` (la capa que de verdad protege)**
- Si el llamado viene de un usuario (JWT), valida contra `usuario_sucursales`:
  - Sucursal puntual no asignada → `RAISE EXCEPTION` (acceso denegado).
  - Consolidado (`sucursal NULL`) → se reduce a las sucursales asignadas del usuario. Un admin de una sucursal ve "su" combinado = su propia sucursal, nunca la red completa.
- `service_role` (auth.uid NULL, p. ej. el comando `/reporte-mensual`) mantiene acceso total, para poder generar todas las sucursales + red.

**Frontend — `ReportesGerencialesContainer`**
- El selector ofrece solo las sucursales del `SucursalContext` (las asignadas).
- La opción **"Red (consolidado)"** aparece únicamente para quien tiene **2+ sucursales**.
- Default: red si tiene varias; su única sucursal si tiene una.

## Verificación (en vivo, simulando cada usuario)

| Caso | Resultado |
|---|---|
| Julio (solo Taco Pozo) → Taco Pozo | ✅ OK |
| Julio → "combinado" | ✅ ve solo Taco Pozo ($32,6M), no la red ($77,7M) |
| Julio → Tucumán (ajena) | ✅ **denegado** (excepción) |
| Agustín (ambas) → combinado | ✅ red completa ($77,7M) |
| Claude Code (service role) | ✅ acceso total |

Type-check 0 errores · ESLint limpio · 741 tests pasan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)