### PR TITLE
feat(pedidos): admin elige el producto del regalo al CREAR el pedido

### DIFF
--- a/migrations/096_crear_pedido_regalo_elegido_contenedor.sql
+++ b/migrations/096_crear_pedido_regalo_elegido_contenedor.sql
@@ -1,0 +1,252 @@
+-- 096_crear_pedido_regalo_elegido_contenedor.sql
+--
+-- PARA REVISAR ANTES DE APLICAR. Modifica crear_pedido_completo (RPC crítica).
+-- Habilita que el admin elija OTRO producto para el regalo al CREAR el pedido
+-- (paridad con "Cambiar regalo" de la edición). El front ya persiste el producto
+-- elegido en la bonificación; esta migración ajusta el stock/descripción cuando
+-- el producto del regalo difiere del regalo default de la promo (override).
+--
+-- Cambios (retrocompatibles — regalo default ⇒ comportamiento IDÉNTICO al previo,
+-- porque en prod ajuste_producto_id == producto_regalo_id):
+--   1. Modo Fracción (auto-ajuste): el contenedor a descontar es el del PRODUCTO
+--      del regalo elegido (su propio fardo) cuando hay override; si es el default,
+--      el `ajuste_producto_id` configurado en la promo.
+--   2. descripcion_regalo: si el producto del regalo difiere del default (override),
+--      NO usar la descripción fija de la promo (ej. "1 botella Pomelo") → NULL, para
+--      que comanda/manifiesto muestren el nombre del producto elegido.
+--
+-- NO toca crear_pedido_completo_bot: el bot nunca overridea (usa el regalo default
+-- del resolver), así que su comportamiento queda igual.
+
+CREATE OR REPLACE FUNCTION public.crear_pedido_completo(
+  p_cliente_id bigint, p_total numeric, p_usuario_id uuid, p_items jsonb,
+  p_notas text DEFAULT NULL::text, p_forma_pago text DEFAULT 'efectivo'::text,
+  p_estado_pago text DEFAULT 'pendiente'::text, p_fecha date DEFAULT NULL::date,
+  p_tipo_factura text DEFAULT 'ZZ'::text, p_total_neto numeric DEFAULT NULL::numeric,
+  p_total_iva numeric DEFAULT 0, p_fecha_entrega_programada date DEFAULT NULL::date,
+  p_preventista_id uuid DEFAULT NULL::uuid)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public'
+AS $function$
+DECLARE
+  v_sucursal BIGINT := current_sucursal_id();
+  v_pedido_id INT; item JSONB; v_producto_id INT; v_cantidad INT;
+  v_precio_unitario DECIMAL; v_es_bonificacion BOOLEAN; v_promocion_id BIGINT;
+  v_neto_unitario DECIMAL; v_iva_unitario DECIMAL; v_imp_internos_unitario DECIMAL;
+  v_porcentaje_iva DECIMAL; v_stock_actual INT; v_producto_nombre TEXT;
+  errores TEXT[] := '{}'; v_user_role TEXT;
+  v_cantidades_totales JSONB := '{}'::JSONB; v_cant_acumulada INT;
+  v_stock_snapshot JSONB := '{}'::JSONB;
+  v_stock_al_crear INT;
+  v_es_regalo_no_mueve_stock JSONB := '{}'::JSONB;
+  v_regalo_mueve_stock BOOLEAN;
+  v_descripcion_regalo TEXT;
+  v_regalo_default_id BIGINT;     -- producto_regalo_id de la promo (para detectar override)
+  v_container_id INT;             -- contenedor a descontar en modo Fracción
+  v_fecha_pedido DATE := COALESCE(p_fecha, (now() AT TIME ZONE 'America/Argentina/Buenos_Aires')::date);
+  v_fecha_entrega DATE := COALESCE(p_fecha_entrega_programada, (v_fecha_pedido + INTERVAL '1 day')::date);
+  v_promo RECORD;
+  v_usos_pendientes_actual INT;
+  v_bloques_completos INT;
+  v_ajustar_usos INT;
+  v_ajustar_stock INT;
+  v_stock_ajuste_anterior INT;
+  v_stock_ajuste_nuevo INT;
+  v_ajuste_producto_nombre TEXT;
+  v_merma_id BIGINT;
+  v_pedidos_bundle TEXT;
+  v_observacion TEXT;
+  v_preventista_role TEXT;
+  v_preventista_final UUID;
+BEGIN
+  IF v_sucursal IS NULL THEN RETURN jsonb_build_object('success', false, 'errores', jsonb_build_array('No se pudo determinar la sucursal activa')); END IF;
+  IF p_usuario_id IS DISTINCT FROM auth.uid() THEN RETURN jsonb_build_object('success', false, 'errores', jsonb_build_array('ID de usuario no coincide con la sesion autenticada')); END IF;
+  SELECT rol INTO v_user_role FROM perfiles WHERE id = p_usuario_id;
+  IF v_user_role IS NULL OR v_user_role NOT IN ('admin', 'preventista', 'preventista_taco', 'encargado') THEN RETURN jsonb_build_object('success', false, 'errores', jsonb_build_array('No tiene permisos para crear pedidos')); END IF;
+
+  -- Resolver el preventista del pedido. Default = actor (p_usuario_id).
+  IF p_preventista_id IS NULL OR p_preventista_id = p_usuario_id THEN
+    v_preventista_final := p_usuario_id;
+  ELSE
+    IF v_user_role <> 'admin' THEN
+      RETURN jsonb_build_object('success', false, 'errores', jsonb_build_array('Solo admin puede asignar otro preventista al pedido'));
+    END IF;
+    SELECT p.rol INTO v_preventista_role
+    FROM perfiles p
+    WHERE p.id = p_preventista_id
+      AND p.activo = true
+      AND EXISTS (
+        SELECT 1 FROM usuario_sucursales us
+        WHERE us.usuario_id = p.id AND us.sucursal_id = v_sucursal
+      );
+    IF v_preventista_role IS NULL OR v_preventista_role NOT IN ('admin', 'preventista', 'preventista_taco') THEN
+      RETURN jsonb_build_object('success', false, 'errores', jsonb_build_array('El usuario asignado no es admin ni preventista (o no pertenece a la sucursal)'));
+    END IF;
+    v_preventista_final := p_preventista_id;
+  END IF;
+
+  -- Loop 1: acumular cantidades por producto (incluye TODOS: ventas y regalos).
+  FOR item IN SELECT * FROM jsonb_array_elements(p_items) LOOP
+    v_producto_id := (item->>'producto_id')::INT; v_cantidad := (item->>'cantidad')::INT;
+    v_es_bonificacion := COALESCE((item->>'es_bonificacion')::BOOLEAN, false);
+    IF v_cantidad IS NULL OR v_cantidad <= 0 THEN errores := array_append(errores, 'Cantidad invalida para producto ID ' || v_producto_id); CONTINUE; END IF;
+
+    v_cant_acumulada := COALESCE((v_cantidades_totales->>v_producto_id::TEXT)::INT, 0) + v_cantidad;
+    v_cantidades_totales := v_cantidades_totales || jsonb_build_object(v_producto_id::TEXT, v_cant_acumulada);
+
+    IF v_es_bonificacion THEN
+      v_promocion_id := (item->>'promocion_id')::BIGINT;
+      IF v_promocion_id IS NOT NULL THEN
+        SELECT regalo_mueve_stock INTO v_regalo_mueve_stock FROM promociones WHERE id = v_promocion_id AND sucursal_id = v_sucursal;
+        IF NOT COALESCE(v_regalo_mueve_stock, FALSE) THEN
+          v_es_regalo_no_mueve_stock := v_es_regalo_no_mueve_stock || jsonb_build_object(v_producto_id::TEXT, true);
+        END IF;
+      ELSE
+        v_es_regalo_no_mueve_stock := v_es_regalo_no_mueve_stock || jsonb_build_object(v_producto_id::TEXT, true);
+      END IF;
+    END IF;
+  END LOOP;
+
+  -- Loop 2: validar stock por producto + capturar snapshot. Lock con FOR UPDATE.
+  FOR v_producto_id IN SELECT (key)::INT FROM jsonb_each_text(v_cantidades_totales) LOOP
+    v_cantidad := (v_cantidades_totales->>v_producto_id::TEXT)::INT;
+    SELECT stock, nombre INTO v_stock_actual, v_producto_nombre FROM productos WHERE id = v_producto_id AND sucursal_id = v_sucursal FOR UPDATE;
+    IF v_stock_actual IS NULL THEN
+      errores := array_append(errores, 'Producto ID ' || v_producto_id || ' no encontrado');
+    ELSIF v_stock_actual < v_cantidad THEN
+      IF COALESCE((v_es_regalo_no_mueve_stock->>v_producto_id::TEXT)::BOOLEAN, FALSE) THEN
+        errores := array_append(errores, v_producto_nombre || ': stock insuficiente para regalo (disponible: ' || v_stock_actual || ', solicitado: ' || v_cantidad || ')');
+      ELSE
+        errores := array_append(errores, v_producto_nombre || ': stock insuficiente (disponible: ' || v_stock_actual || ', solicitado: ' || v_cantidad || ')');
+      END IF;
+    END IF;
+    IF v_stock_actual IS NOT NULL THEN
+      v_stock_snapshot := v_stock_snapshot || jsonb_build_object(v_producto_id::TEXT, v_stock_actual);
+    END IF;
+  END LOOP;
+
+  IF array_length(errores, 1) > 0 THEN RETURN jsonb_build_object('success', false, 'errores', to_jsonb(errores)); END IF;
+
+  INSERT INTO pedidos (cliente_id, fecha, total, total_neto, total_iva, tipo_factura, estado, usuario_id, stock_descontado, notas, forma_pago, estado_pago, fecha_entrega_programada, sucursal_id)
+  VALUES (p_cliente_id, v_fecha_pedido, p_total, COALESCE(p_total_neto, p_total), COALESCE(p_total_iva, 0), COALESCE(p_tipo_factura, 'ZZ'), 'pendiente', v_preventista_final, true, p_notas, p_forma_pago, p_estado_pago, v_fecha_entrega, v_sucursal)
+  RETURNING id INTO v_pedido_id;
+
+  PERFORM set_config('app.stock_origen', 'pedido_creado', true);
+  PERFORM set_config('app.stock_ref_tipo', 'pedido', true);
+  PERFORM set_config('app.stock_ref_id', v_pedido_id::TEXT, true);
+  PERFORM set_config('app.stock_user_id', p_usuario_id::TEXT, true);
+
+  IF v_preventista_final IS DISTINCT FROM p_usuario_id THEN
+    INSERT INTO pedido_historial (pedido_id, usuario_id, campo_modificado, valor_anterior, valor_nuevo, sucursal_id)
+    VALUES (v_pedido_id, p_usuario_id, 'usuario_id', NULL, v_preventista_final::TEXT, v_sucursal);
+  END IF;
+
+  -- Loop 3: INSERT items + UPDATE stock + auto-ajuste promos.
+  FOR item IN SELECT * FROM jsonb_array_elements(p_items) LOOP
+    v_producto_id := (item->>'producto_id')::INT; v_cantidad := (item->>'cantidad')::INT;
+    v_precio_unitario := (item->>'precio_unitario')::DECIMAL;
+    v_es_bonificacion := COALESCE((item->>'es_bonificacion')::BOOLEAN, false);
+    v_promocion_id := (item->>'promocion_id')::BIGINT;
+    v_neto_unitario := (item->>'neto_unitario')::DECIMAL;
+    v_iva_unitario := COALESCE((item->>'iva_unitario')::DECIMAL, 0);
+    v_imp_internos_unitario := COALESCE((item->>'impuestos_internos_unitario')::DECIMAL, 0);
+    v_porcentaje_iva := COALESCE((item->>'porcentaje_iva')::DECIMAL, 0);
+    v_stock_al_crear := (v_stock_snapshot->>v_producto_id::TEXT)::INT;
+
+    v_descripcion_regalo := NULL;
+    v_regalo_default_id := NULL;
+    IF v_es_bonificacion AND v_promocion_id IS NOT NULL THEN
+      SELECT descripcion_regalo, producto_regalo_id
+        INTO v_descripcion_regalo, v_regalo_default_id
+        FROM promociones WHERE id = v_promocion_id AND sucursal_id = v_sucursal;
+      -- Override: admin eligió otro producto de regalo → no forzar la descripción
+      -- fija de la promo; comanda/manifiesto muestran el nombre del producto elegido.
+      IF v_regalo_default_id IS DISTINCT FROM v_producto_id THEN
+        v_descripcion_regalo := NULL;
+      END IF;
+    END IF;
+
+    INSERT INTO pedido_items (
+      pedido_id, producto_id, cantidad, precio_unitario, subtotal,
+      es_bonificacion, promocion_id,
+      neto_unitario, iva_unitario, impuestos_internos_unitario, porcentaje_iva,
+      sucursal_id, descripcion_regalo, stock_al_crear
+    ) VALUES (
+      v_pedido_id, v_producto_id, v_cantidad, v_precio_unitario, v_cantidad * v_precio_unitario,
+      v_es_bonificacion, v_promocion_id,
+      v_neto_unitario, v_iva_unitario, v_imp_internos_unitario, v_porcentaje_iva,
+      v_sucursal, v_descripcion_regalo, v_stock_al_crear
+    );
+
+    IF NOT v_es_bonificacion THEN
+      UPDATE productos SET stock = stock - v_cantidad WHERE id = v_producto_id AND sucursal_id = v_sucursal;
+    ELSIF v_promocion_id IS NOT NULL THEN
+      SELECT regalo_mueve_stock INTO v_regalo_mueve_stock FROM promociones WHERE id = v_promocion_id AND sucursal_id = v_sucursal;
+      IF COALESCE(v_regalo_mueve_stock, FALSE) THEN
+        UPDATE productos SET stock = stock - v_cantidad WHERE id = v_producto_id AND sucursal_id = v_sucursal;
+      END IF;
+    END IF;
+
+    IF v_es_bonificacion AND v_promocion_id IS NOT NULL THEN
+      UPDATE promociones SET usos_pendientes = usos_pendientes + v_cantidad WHERE id = v_promocion_id AND sucursal_id = v_sucursal;
+
+      SELECT id, nombre, ajuste_automatico, ajuste_producto_id, unidades_por_bloque,
+             stock_por_bloque, usos_pendientes, producto_regalo_id
+      INTO v_promo
+      FROM promociones WHERE id = v_promocion_id AND sucursal_id = v_sucursal FOR UPDATE;
+
+      -- Contenedor a descontar: si el admin eligió otro producto de regalo
+      -- (override), descontar el contenedor de ESE producto (su propio fardo);
+      -- si es el default, el ajuste_producto_id de la promo (idéntico al previo).
+      v_container_id := CASE WHEN v_promo.producto_regalo_id IS DISTINCT FROM v_producto_id
+                             THEN v_producto_id ELSE v_promo.ajuste_producto_id END;
+
+      IF v_promo.ajuste_automatico AND v_container_id IS NOT NULL
+         AND COALESCE(v_promo.unidades_por_bloque, 0) > 0 AND COALESCE(v_promo.stock_por_bloque, 0) > 0 THEN
+        v_usos_pendientes_actual := v_promo.usos_pendientes;
+        v_bloques_completos := v_usos_pendientes_actual / v_promo.unidades_por_bloque;
+        IF v_bloques_completos > 0 THEN
+          v_ajustar_usos := v_bloques_completos * v_promo.unidades_por_bloque;
+          v_ajustar_stock := v_bloques_completos * v_promo.stock_por_bloque;
+
+          SELECT stock, nombre INTO v_stock_ajuste_anterior, v_ajuste_producto_nombre
+          FROM productos WHERE id = v_container_id AND sucursal_id = v_sucursal FOR UPDATE;
+
+          IF v_stock_ajuste_anterior IS NULL THEN
+            RAISE EXCEPTION 'Auto-ajuste: producto destino no encontrado (promo %)', v_promocion_id;
+          END IF;
+          IF v_stock_ajuste_anterior < v_ajustar_stock THEN
+            RAISE EXCEPTION 'Auto-ajuste: stock insuficiente en % (disponible: %, requerido: %)',
+              v_ajuste_producto_nombre, v_stock_ajuste_anterior, v_ajustar_stock;
+          END IF;
+
+          v_stock_ajuste_nuevo := v_stock_ajuste_anterior - v_ajustar_stock;
+
+          v_pedidos_bundle := public.pedido_bundle_para_promo(v_promocion_id, v_sucursal, 20);
+          v_observacion := 'Auto-ajuste (Promo: ' || v_promo.nombre
+                           || ', Pedidos: ' || COALESCE(v_pedidos_bundle, '#' || v_pedido_id) || ')';
+
+          INSERT INTO mermas_stock (producto_id, cantidad, motivo, observaciones, stock_anterior, stock_nuevo, usuario_id, sucursal_id)
+          VALUES (v_container_id, v_ajustar_stock, 'promociones', v_observacion,
+            v_stock_ajuste_anterior, v_stock_ajuste_nuevo, p_usuario_id, v_sucursal)
+          RETURNING id INTO v_merma_id;
+
+          UPDATE productos SET stock = v_stock_ajuste_nuevo, updated_at = NOW()
+          WHERE id = v_container_id AND sucursal_id = v_sucursal;
+
+          INSERT INTO promo_ajustes (promocion_id, usos_ajustados, unidades_ajustadas, producto_id, merma_id, usuario_id, observaciones, sucursal_id)
+          VALUES (v_promocion_id, v_ajustar_usos, v_ajustar_stock, v_container_id,
+            v_merma_id, p_usuario_id, v_observacion, v_sucursal);
+
+          UPDATE promociones SET usos_pendientes = GREATEST(usos_pendientes - v_ajustar_usos, 0)
+          WHERE id = v_promocion_id AND sucursal_id = v_sucursal;
+        END IF;
+      END IF;
+    END IF;
+  END LOOP;
+
+  RETURN jsonb_build_object('success', true, 'pedido_id', v_pedido_id);
+END;
+$function$;

--- a/src/components/containers/PedidosContainer.tsx
+++ b/src/components/containers/PedidosContainer.tsx
@@ -40,7 +40,7 @@ import {
 import { useAuthData } from '../../contexts/AuthDataContext'
 import { useNotification } from '../../contexts/NotificationContext'
 import { useOptimizarRuta, type RepartidorParam } from '../../hooks/useOptimizarRuta'
-import { usePromocionPedido } from '../../hooks/usePromocionPedido'
+import { usePromocionPedido, type RegaloOverride } from '../../hooks/usePromocionPedido'
 import { useDebounce } from '../../hooks/useAsync'
 import { useResetOnSucursalChange } from '../../hooks/useResetOnSucursalChange'
 import { useRegistrarGeolocalizacionPedido } from '../../hooks/useRegistrarGeolocalizacionPedido'
@@ -271,6 +271,9 @@ export default function PedidosContainer(): React.ReactElement {
     preventistaId: undefined as string | undefined,
   })
 
+  // Override del producto del regalo al crear (solo admin). promoId -> producto elegido.
+  const [regalosOverride, setRegalosOverride] = useState<Record<string, RegaloOverride>>({})
+
   const resetNuevoPedido = useCallback(() => {
     setNuevoPedido({
       clienteId: '', items: [], notas: '',
@@ -280,10 +283,22 @@ export default function PedidosContainer(): React.ReactElement {
       fechaEntregaProgramada: undefined,
       preventistaId: undefined,
     })
+    setRegalosOverride({})
   }, [])
 
-  // Resolve wholesale prices for current pedido items
-  const { itemsFinales } = usePromocionPedido(nuevoPedido.items)
+  // Admin elige/cambia el producto del regalo de una promo al crear el pedido.
+  // El producto elegido se persiste en la bonificación; el RPC ajusta el stock
+  // (modo A descuenta el producto elegido; modo Fracción su contenedor por sabor).
+  const handleCambiarRegaloCreacion = useCallback((promoId: string, productoId: string) => {
+    const prod = productos.find(p => String(p.id) === String(productoId))
+    setRegalosOverride(prev => ({
+      ...prev,
+      [String(promoId)]: { productoId: String(productoId), descripcionRegalo: prod?.nombre },
+    }))
+  }, [productos])
+
+  // Resolve wholesale prices + promos (con override del regalo elegido por admin)
+  const { itemsFinales } = usePromocionPedido(nuevoPedido.items, undefined, regalosOverride)
 
   // =========================================================================
   // VistaPedidos handlers
@@ -1462,6 +1477,8 @@ export default function PedidosContainer(): React.ReactElement {
             clientes={clientes}
             categorias={[...new Set(productos.map(p => p.categoria).filter(Boolean))] as string[]}
             nuevoPedido={nuevoPedido}
+            regalosOverride={regalosOverride}
+            onCambiarRegaloCreacion={handleCambiarRegaloCreacion}
             onClose={() => { setModalPedidoOpen(false); resetNuevoPedido() }}
             onClienteChange={(id: string) => setNuevoPedido(prev => ({ ...prev, clienteId: id }))}
             onAgregarItem={(productoId: string) => {

--- a/src/components/modals/ModalPedido.tsx
+++ b/src/components/modals/ModalPedido.tsx
@@ -3,7 +3,7 @@ import { X, Loader2, Search, MapPin, Tag, Calendar, Trash2, Pencil, Gift, Truck,
 import { formatPrecio, fechaLocalISO } from '../../utils/formatters';
 import { parsePrecio } from '../../utils/calculations';
 import { AddressAutocomplete } from '../AddressAutocomplete';
-import { usePromocionPedido } from '../../hooks/usePromocionPedido';
+import { usePromocionPedido, type RegaloOverride } from '../../hooks/usePromocionPedido';
 import { aplicarDescuentoClienteItems, resolverDescuentoPctCliente } from '../../utils/descuentoCliente';
 import { useGeolocationCapture } from '../../hooks/useGeolocationCapture';
 import { usePreventistasAsignablesQuery } from '../../hooks/queries/useUsuariosQuery';
@@ -110,6 +110,10 @@ export interface ModalPedidoProps {
   onPreventistaChange?: (preventistaId: string) => void;
   /** ID del usuario actual (default del selector de preventista) */
   currentUserId?: string;
+  /** Override del producto del regalo por promoId (admin lo elige al crear). */
+  regalosOverride?: Record<string, RegaloOverride>;
+  /** Callback cuando el admin cambia el producto del regalo de una promo al crear. */
+  onCambiarRegaloCreacion?: (promoId: string, productoId: string) => void;
 }
  
 
@@ -137,7 +141,9 @@ const ModalPedido = memo(function ModalPedido({
   onFechaEntregaProgramadaChange,
   onActualizarPrecio,
   onPreventistaChange,
-  currentUserId
+  currentUserId,
+  regalosOverride,
+  onCambiarRegaloCreacion
 }: ModalPedidoProps) {
   // Solo admin puede reasignar preventista al pedido. La query se habilita
   // condicionalmente para no traer perfiles para preventistas/encargados.
@@ -172,6 +178,12 @@ const ModalPedido = memo(function ModalPedido({
       return matchNombre && matchCategoria && tieneStock;
     });
   }, [productos, busquedaProducto, categoriaSeleccionada]);
+
+  // Opciones para el selector de regalo (admin): todos los productos, ordenados.
+  const productosRegaloOpciones = useMemo(
+    () => [...productos].sort((a, b) => (a.nombre || '').localeCompare(b.nombre || '')),
+    [productos]
+  );
 
   const clientesFiltrados = useMemo(() => {
     if (busquedaCliente.length < 2) return [];
@@ -262,7 +274,7 @@ const ModalPedido = memo(function ModalPedido({
   const calcularTotal = (): number => nuevoPedido.items.reduce((t, i) => t + (i.precioUnitario * i.cantidad), 0);
 
   // Precios mayoristas, promociones y cantidades mínimas
-  const { preciosResueltos, faltantes, faltantesBonificacion, promoResolucion, itemsFinales, totalOriginal, hayDescuento, moqMap, violacionesMOQ } = usePromocionPedido(nuevoPedido.items);
+  const { preciosResueltos, faltantes, faltantesBonificacion, promoResolucion, itemsFinales, totalOriginal, hayDescuento, moqMap, violacionesMOQ } = usePromocionPedido(nuevoPedido.items, undefined, regalosOverride);
 
   // Descuento del cliente (general + por categoría) aplicado en vivo sobre los
   // items ya resueltos (mayorista/promo). La categoría prevalece sobre el general.
@@ -752,7 +764,7 @@ const ModalPedido = memo(function ModalPedido({
                         // 600cc"). Si no hay, fallback al nombre del producto.
                         const labelRegalo = bonif.descripcionRegalo?.trim() || prod?.nombre;
                         return (
-                          <div key={`bonif-${bonif.productoId}`} className="px-3 py-2.5 bg-green-50 dark:bg-green-900/10">
+                          <div key={`bonif-${bonif.promoId ?? bonif.productoId}`} className="px-3 py-2.5 bg-green-50 dark:bg-green-900/10">
                             <div className="flex justify-between items-center gap-2">
                               <div className="min-w-0 flex-1">
                                 <div className="flex items-center gap-1.5">
@@ -763,6 +775,21 @@ const ModalPedido = memo(function ModalPedido({
                                   </span>
                                 </div>
                                 <p className="text-xs text-green-600 dark:text-green-400">{bonif.promoNombre}</p>
+                                {/* Admin: elegir/cambiar el producto del regalo al crear. */}
+                                {isAdmin && onCambiarRegaloCreacion && bonif.promoId && (
+                                  <select
+                                    value={String(bonif.productoId)}
+                                    onChange={e => onCambiarRegaloCreacion(String(bonif.promoId), e.target.value)}
+                                    className="mt-1 w-full max-w-xs text-xs px-2 py-1 border border-green-300 dark:border-green-700 rounded bg-white dark:bg-gray-700 dark:text-white"
+                                    title="Cambiar el producto del regalo"
+                                  >
+                                    {productosRegaloOpciones.map(p => (
+                                      <option key={p.id} value={String(p.id)}>
+                                        {p.nombre}{(p.stock ?? 0) > 0 ? '' : ' · sin stock'}
+                                      </option>
+                                    ))}
+                                  </select>
+                                )}
                               </div>
                               <div className="flex items-center gap-2 shrink-0">
                                 <span className="w-6 text-center font-medium text-sm text-green-700 dark:text-green-400">{bonif.cantidadBonificacion}</span>

--- a/src/hooks/usePromocionPedido.ts
+++ b/src/hooks/usePromocionPedido.ts
@@ -62,20 +62,42 @@ interface UsePromocionPedidoReturn {
   violacionesMOQ: ViolacionMOQ[]
 }
 
+/** Override del producto del regalo de una promo (admin lo elige al crear el pedido). */
+export interface RegaloOverride {
+  productoId: string
+  descripcionRegalo?: string
+}
+
 export function usePromocionPedido(
   items: ItemPedido[],
   fechaReferencia?: string,
+  /** Override del producto del regalo por promoId. El admin puede elegir otro
+   *  producto para la bonificación al crear el pedido (paridad con "Cambiar
+   *  regalo" de la edición). */
+  overridesRegalo?: Record<string, RegaloOverride>,
 ): UsePromocionPedidoReturn {
   const { data: pricingMap, isLoading: loadingPricing } = usePricingMapQuery()
   const { data: promoMap, isLoading: loadingPromos } = usePromoMapQuery(fechaReferencia)
 
   // 1. Resolver promociones
-  const promoResolucion = useMemo((): PromoResolucion => {
+  const promoResolucionRaw = useMemo((): PromoResolucion => {
     if (!promoMap || promoMap.size === 0 || items.length === 0) {
       return { bonificaciones: [], productosConPromo: new Set() }
     }
     return resolverPromociones(items, promoMap)
   }, [items, promoMap])
+
+  // 1b. Aplicar override del regalo: solo cambia el producto/descripción de la
+  //     bonificación; los disparadores (productosConPromo) y reglas no se tocan.
+  //     Así itemsFinales y el display muestran/persisten el producto elegido.
+  const promoResolucion = useMemo((): PromoResolucion => {
+    if (!overridesRegalo || Object.keys(overridesRegalo).length === 0) return promoResolucionRaw
+    const bonificaciones = promoResolucionRaw.bonificaciones.map(b => {
+      const ov = overridesRegalo[String(b.promoId)]
+      return ov ? { ...b, productoId: ov.productoId, descripcionRegalo: ov.descripcionRegalo } : b
+    })
+    return { bonificaciones, productosConPromo: promoResolucionRaw.productosConPromo }
+  }, [promoResolucionRaw, overridesRegalo])
 
   // 2. Resolver mayorista EXCLUYENDO productos con promo
   const preciosResueltos = useMemo(() => {


### PR DESCRIPTION
## Contexto

El regalo (bonificación) de una promo se fijaba **automático** al crear el pedido (lo resuelve la
promo) y el admin **solo podía cambiarlo al EDITAR** (botón "Cambiar regalo" → `sustituir_regalo_pedido`).
Pedido: poder elegir/cambiar el producto del regalo **también al CREAR**, con el stock ajustándose bien.

## Cambios

**Front**
- [usePromocionPedido.ts](src/hooks/usePromocionPedido.ts): nuevo param `overridesRegalo`
  (`promoId → { productoId, descripcionRegalo }`) que reemplaza el producto/descr. de la bonificación.
  Como `itemsFinales` ya alimenta el payload de creación, el producto elegido **se persiste solo**.
- [ModalPedido.tsx](src/components/modals/ModalPedido.tsx): selector de regalo (**solo admin**) en cada
  bonificación, reusando el patrón del de edición.
- [PedidosContainer.tsx](src/components/containers/PedidosContainer.tsx): estado local `regalosOverride`
  + handler; se pasa al hook (creación) y al modal (display); se resetea al crear/cerrar.

**Back (mig 096, `crear_pedido_completo`)**
- **Modo A** (`regalo_mueve_stock`): ya funcionaba — descuenta el producto elegido. Sin cambios.
- **Modo Fracción**: cuando el regalo elegido difiere del default de la promo (override), el auto-ajuste
  descuenta el contenedor de **ESE** producto (su propio fardo) y **no** fuerza la descripción fija de la
  promo (→ comanda/manifiesto muestran el producto elegido). **Retrocompatible**: regalo default ⇒
  comportamiento idéntico (en prod `ajuste_producto_id == producto_regalo_id`).
- NO toca `crear_pedido_completo_bot` (el bot nunca overridea).

## Verificación
- `npm run typecheck` limpio; **741 tests** verdes (pre-commit).
- Manual modo A (promo Placer 3+1): crear, cambiar el producto del regalo, crear → la bonificación
  queda con el producto elegido y baja SU stock.
- Manual modo Fracción (promo 12/13): cambiar el sabor del regalo → se persiste el sabor elegido; al
  cerrar bloque, el descuento va al contenedor del sabor elegido.

## Pendiente
- **Aplicar mig 096 a prod** (modifica `crear_pedido_completo`, RPC crítica) — va en esta PR para
  revisión; el front sin la mig igual persiste el producto elegido y funciona en modo A (modo Fracción
  necesita la mig para el contenedor/descr. correctos).

🤖 Generated with [Claude Code](https://claude.com/claude-code)