### PR TITLE
feat(pedidos): horarios de atención en el alta rápida de clientes

### DIFF
--- a/src/components/containers/PedidosContainer.tsx
+++ b/src/components/containers/PedidosContainer.tsx
@@ -1518,6 +1518,7 @@ export default function PedidosContainer(): React.ReactElement {
                   zona: (clienteData.zona as string) || undefined,
                   latitud: (clienteData.latitud as number | null) ?? null,
                   longitud: (clienteData.longitud as number | null) ?? null,
+                  horarios_atencion: (clienteData.horariosAtencion as string) || undefined,
                 }
                 const newCliente = await crearClienteMut.mutateAsync(dbData)
                 notify.success(`Cliente "${newCliente.nombre_fantasia}" creado`)

--- a/src/components/modals/ModalCliente.tsx
+++ b/src/components/modals/ModalCliente.tsx
@@ -2,6 +2,7 @@ import { useState, memo, useRef, useMemo } from 'react';
 import { Loader2, MapPin, CreditCard, Clock, Tag, FileText, Users, LocateFixed, AlertCircle, Percent, Plus, Trash2 } from 'lucide-react';
 import ModalBase from './ModalBase';
 import NumberInput from '../ui/NumberInput';
+import FranjasHorariasEditor from '../ui/FranjasHorariasEditor';
 import { AddressAutocomplete } from '../AddressAutocomplete';
 import { useZodValidation } from '../../hooks/useZodValidation';
 import { modalClienteSchema } from '../../lib/schemas';
@@ -311,27 +312,12 @@ const ModalCliente = memo(function ModalCliente({ cliente, onSave, onClose, guar
   const horarioOriginalAtencion = convAtencionInicial.franjas.length === 0
     ? (cliente?.horarios_atencion ?? '')
     : '';
+  // El editor de franjas (FranjasHorariasEditor) emite el array completo; acá se
+  // serializa al string del form y se preserva el texto libre legacy si no hay franjas.
   const sincronizarAtencion = (filas: FranjaHoraria[]): void => {
     setFranjasAtencion(filas);
     setForm(prev => ({ ...prev, horarios_atencion: serializarFranjas(filas) || horarioOriginalAtencion }));
   };
-  const agregarFranjaAtencion = (): void =>
-    sincronizarAtencion([...franjasAtencion, { apertura: '', cierre: '' }]);
-  const quitarFranjaAtencion = (index: number): void =>
-    sincronizarAtencion(franjasAtencion.filter((_, i) => i !== index));
-  const actualizarFranjaAtencion = (index: number, campo: keyof FranjaHoraria, valor: string): void =>
-    sincronizarAtencion(
-      franjasAtencion.map((f, i) => {
-        if (i !== index) return f;
-        const next = { ...f, [campo]: valor };
-        // Al cambiar la apertura, si el cierre quedó vacío o <= apertura, lo limpiamos.
-        if (campo === 'apertura' && next.cierre &&
-            (!valor || horaAMinutos(next.cierre) <= horaAMinutos(valor))) {
-          next.cierre = '';
-        }
-        return next;
-      }),
-    );
 
   // Franja única de entrega; el campo queda vacío ("Sin preferencia") si está incompleta.
   const sincronizarEntrega = (franja: FranjaHoraria): void => {
@@ -756,72 +742,7 @@ const ModalCliente = memo(function ModalCliente({ cliente, onSave, onClose, guar
 
         {/* Horarios de Atención: una o más franjas con apertura/cierre (horario cortado) */}
         <div>
-          <label className="block text-sm font-medium mb-1 dark:text-gray-200 flex items-center gap-1">
-            <Clock className="w-4 h-4" />
-            Horarios de Atención
-          </label>
-          <p className="text-xs text-gray-500 dark:text-gray-400 mb-2">
-            Cargá apertura y cierre. Si el horario es cortado (ej: mañana y tarde), agregá otra franja.
-          </p>
-          {franjasAtencion.length > 0 && (
-            <div className="space-y-2 mb-2">
-              {franjasAtencion.map((f, index) => {
-                const tieneError = Boolean(validacionAtencion.erroresPorFila[index]);
-                const selectClass = `flex-1 px-3 py-2 border rounded-lg dark:bg-gray-700 dark:text-white text-sm ${
-                  tieneError ? 'border-red-500 bg-red-50 dark:bg-red-900/20' : 'dark:border-gray-600'
-                }`;
-                return (
-                  <div key={index}>
-                    <div className="flex items-center gap-2">
-                      <select
-                        value={f.apertura}
-                        onChange={e => actualizarFranjaAtencion(index, 'apertura', e.target.value)}
-                        aria-label="Hora de apertura"
-                        className={selectClass}
-                      >
-                        <option value="">Apertura</option>
-                        {opcionesApertura.map(h => <option key={h} value={h}>{h}</option>)}
-                      </select>
-                      <span className="text-gray-400 text-sm">a</span>
-                      <select
-                        value={f.cierre}
-                        onChange={e => actualizarFranjaAtencion(index, 'cierre', e.target.value)}
-                        aria-label="Hora de cierre"
-                        className={selectClass}
-                      >
-                        <option value="">Cierre</option>
-                        {opcionesCierre
-                          .filter(h => !f.apertura || horaAMinutos(h) > horaAMinutos(f.apertura))
-                          .map(h => <option key={h} value={h}>{h}</option>)}
-                      </select>
-                      <button
-                        type="button"
-                        onClick={() => quitarFranjaAtencion(index)}
-                        className="p-2 text-rose-600 hover:bg-rose-50 dark:hover:bg-rose-900/20 rounded-lg"
-                        aria-label="Quitar franja horaria"
-                      >
-                        <Trash2 className="w-4 h-4" />
-                      </button>
-                    </div>
-                    {tieneError && (
-                      <p className="text-red-500 text-xs mt-1">{validacionAtencion.erroresPorFila[index]}</p>
-                    )}
-                  </div>
-                );
-              })}
-            </div>
-          )}
-          {validacionAtencion.errorSolapamiento && (
-            <p className="text-red-500 text-xs mb-2">{validacionAtencion.errorSolapamiento}</p>
-          )}
-          <button
-            type="button"
-            onClick={agregarFranjaAtencion}
-            className="inline-flex items-center gap-1.5 px-3 py-2 text-sm font-medium text-blue-600 hover:bg-blue-50 dark:hover:bg-blue-900/20 rounded-lg"
-          >
-            <Plus className="w-4 h-4" />
-            Agregar franja
-          </button>
+          <FranjasHorariasEditor franjas={franjasAtencion} onChange={sincronizarAtencion} />
           {convAtencionInicial.huboLegacy && (
             <p className="text-xs text-amber-600 dark:text-amber-400 mt-2">
               Convertimos tus horarios anteriores a rangos. Revisá y guardá para confirmar.

--- a/src/components/modals/ModalPedido.tsx
+++ b/src/components/modals/ModalPedido.tsx
@@ -10,6 +10,9 @@ import { usePreventistasAsignablesQuery } from '../../hooks/queries/useUsuariosQ
 import ModalBase from './ModalBase';
 import GeolocationGate from '../GeolocationGate';
 import NumberInput from '../ui/NumberInput';
+import FranjasHorariasEditor from '../ui/FranjasHorariasEditor';
+import { serializarFranjas, validarFranjas } from '../../utils/horariosCliente';
+import type { FranjaHoraria } from '../../utils/horariosCliente';
 import type { ProductoDB, ClienteDB } from '../../types';
 
 /** Item en el pedido */
@@ -46,6 +49,8 @@ export interface NuevoClienteData {
   razonSocial?: string; // Se usa "nombre" como razonSocial en creación rápida
   latitud?: number | null;
   longitud?: number | null;
+  // Horarios de atención serializados ("HH:MM-HH:MM y …"); vacío si no se cargan.
+  horariosAtencion?: string;
 }
 
 /** Advertencia de stock */
@@ -158,6 +163,8 @@ const ModalPedido = memo(function ModalPedido({
   const [categoriaSeleccionada, setCategoriaSeleccionada] = useState<string>('');
   const [mostrarNuevoCliente, setMostrarNuevoCliente] = useState<boolean>(false);
   const [nuevoCliente, setNuevoCliente] = useState<NuevoClienteData>({ nombre: '', nombreFantasia: '', direccion: '', telefono: '', zona: '', latitud: null, longitud: null });
+  // Horarios de atención del alta rápida (mismo editor de franjas que "Editar cliente").
+  const [franjasAtencion, setFranjasAtencion] = useState<FranjaHoraria[]>([{ apertura: '', cierre: '' }]);
   const [guardandoCliente, setGuardandoCliente] = useState<boolean>(false);
   const [errorCliente, setErrorCliente] = useState<string>('');
   const [carritoAbierto, setCarritoAbierto] = useState<boolean>(false);
@@ -238,6 +245,11 @@ const ModalPedido = memo(function ModalPedido({
       setErrorCliente(`Completá: ${camposFaltantes.join(', ')}`);
       return;
     }
+    // Las franjas son opcionales, pero si hay alguna cargada debe ser válida.
+    if (!validarFranjas(franjasAtencion).valido) {
+      setErrorCliente('Revisá los horarios de atención: la apertura debe ser anterior al cierre y las franjas no pueden superponerse.');
+      return;
+    }
     setErrorCliente('');
 
     setGuardandoCliente(true);
@@ -246,11 +258,13 @@ const ModalPedido = memo(function ModalPedido({
       const clienteData = {
         ...nuevoCliente,
         razonSocial: nombre, // El "Nombre completo" es la razón social
+        horariosAtencion: serializarFranjas(franjasAtencion),
       };
       const cliente = await onCrearCliente(clienteData);
       onClienteChange(cliente.id.toString());
       setMostrarNuevoCliente(false);
       setNuevoCliente({ nombre: '', nombreFantasia: '', direccion: '', telefono: '', zona: '', latitud: null, longitud: null });
+      setFranjasAtencion([{ apertura: '', cierre: '' }]);
       setGpsAccuracy(null);
       setGpsError(null);
     } catch (err) {
@@ -404,6 +418,7 @@ const ModalPedido = memo(function ModalPedido({
                     )}
                   </div>
                 )}
+                <FranjasHorariasEditor franjas={franjasAtencion} onChange={setFranjasAtencion} />
                 {errorCliente && (
                   <p className="text-sm text-red-600 bg-red-50 dark:bg-red-900/20 dark:text-red-400 px-3 py-2 rounded-lg">{errorCliente}</p>
                 )}

--- a/src/components/ui/FranjasHorariasEditor.tsx
+++ b/src/components/ui/FranjasHorariasEditor.tsx
@@ -1,0 +1,127 @@
+import { memo, useMemo } from 'react';
+import { Clock, Plus, Trash2 } from 'lucide-react';
+import {
+  generarOpcionesHora,
+  horaAMinutos,
+  validarFranjas,
+} from '../../utils/horariosCliente';
+import type { FranjaHoraria } from '../../utils/horariosCliente';
+
+export interface FranjasHorariasEditorProps {
+  /** Franjas actuales (fuente de verdad en el padre). */
+  franjas: FranjaHoraria[];
+  /** Se llama con el array completo de franjas tras cada edición. */
+  onChange: (franjas: FranjaHoraria[]) => void;
+}
+
+/**
+ * Editor de horarios de atención como lista de franjas Apertura–Cierre.
+ *
+ * Componente presentacional compartido entre "Editar cliente" (ModalCliente) y la
+ * creación rápida de clientes (ModalPedido). No persiste ni serializa: emite el array
+ * de franjas vía `onChange` y el padre decide cómo guardarlo (serializarFranjas) y si
+ * conserva texto libre legacy. La validación (apertura < cierre, sin solapes) se calcula
+ * acá sólo para pintar los errores; el padre vuelve a validar con `validarFranjas` antes
+ * de guardar.
+ */
+const FranjasHorariasEditor = memo(function FranjasHorariasEditor({
+  franjas,
+  onChange,
+}: FranjasHorariasEditorProps) {
+  const opcionesApertura = useMemo(() => generarOpcionesHora(false), []);
+  const opcionesCierre = useMemo(() => generarOpcionesHora(true), []);
+  const validacion = useMemo(() => validarFranjas(franjas), [franjas]);
+
+  const agregarFranja = (): void =>
+    onChange([...franjas, { apertura: '', cierre: '' }]);
+
+  const quitarFranja = (index: number): void =>
+    onChange(franjas.filter((_, i) => i !== index));
+
+  const actualizarFranja = (index: number, campo: keyof FranjaHoraria, valor: string): void =>
+    onChange(
+      franjas.map((f, i) => {
+        if (i !== index) return f;
+        const next = { ...f, [campo]: valor };
+        // Al cambiar la apertura, si el cierre quedó vacío o <= apertura, lo limpiamos.
+        if (campo === 'apertura' && next.cierre &&
+            (!valor || horaAMinutos(next.cierre) <= horaAMinutos(valor))) {
+          next.cierre = '';
+        }
+        return next;
+      }),
+    );
+
+  return (
+    <div>
+      <label className="block text-sm font-medium mb-1 dark:text-gray-200 flex items-center gap-1">
+        <Clock className="w-4 h-4" />
+        Horarios de Atención
+      </label>
+      <p className="text-xs text-gray-500 dark:text-gray-400 mb-2">
+        Cargá apertura y cierre. Si el horario es cortado (ej: mañana y tarde), agregá otra franja.
+      </p>
+      {franjas.length > 0 && (
+        <div className="space-y-2 mb-2">
+          {franjas.map((f, index) => {
+            const tieneError = Boolean(validacion.erroresPorFila[index]);
+            const selectClass = `flex-1 px-3 py-2 border rounded-lg dark:bg-gray-700 dark:text-white text-sm ${
+              tieneError ? 'border-red-500 bg-red-50 dark:bg-red-900/20' : 'dark:border-gray-600'
+            }`;
+            return (
+              <div key={index}>
+                <div className="flex items-center gap-2">
+                  <select
+                    value={f.apertura}
+                    onChange={e => actualizarFranja(index, 'apertura', e.target.value)}
+                    aria-label="Hora de apertura"
+                    className={selectClass}
+                  >
+                    <option value="">Apertura</option>
+                    {opcionesApertura.map(h => <option key={h} value={h}>{h}</option>)}
+                  </select>
+                  <span className="text-gray-400 text-sm">a</span>
+                  <select
+                    value={f.cierre}
+                    onChange={e => actualizarFranja(index, 'cierre', e.target.value)}
+                    aria-label="Hora de cierre"
+                    className={selectClass}
+                  >
+                    <option value="">Cierre</option>
+                    {opcionesCierre
+                      .filter(h => !f.apertura || horaAMinutos(h) > horaAMinutos(f.apertura))
+                      .map(h => <option key={h} value={h}>{h}</option>)}
+                  </select>
+                  <button
+                    type="button"
+                    onClick={() => quitarFranja(index)}
+                    className="p-2 text-rose-600 hover:bg-rose-50 dark:hover:bg-rose-900/20 rounded-lg"
+                    aria-label="Quitar franja horaria"
+                  >
+                    <Trash2 className="w-4 h-4" />
+                  </button>
+                </div>
+                {tieneError && (
+                  <p className="text-red-500 text-xs mt-1">{validacion.erroresPorFila[index]}</p>
+                )}
+              </div>
+            );
+          })}
+        </div>
+      )}
+      {validacion.errorSolapamiento && (
+        <p className="text-red-500 text-xs mb-2">{validacion.errorSolapamiento}</p>
+      )}
+      <button
+        type="button"
+        onClick={agregarFranja}
+        className="inline-flex items-center gap-1.5 px-3 py-2 text-sm font-medium text-blue-600 hover:bg-blue-50 dark:hover:bg-blue-900/20 rounded-lg"
+      >
+        <Plus className="w-4 h-4" />
+        Agregar franja
+      </button>
+    </div>
+  );
+});
+
+export default FranjasHorariasEditor;


### PR DESCRIPTION
## Qué

El alta rápida de clientes dentro del modal **"Crear pedido"** ahora ofrece el mismo selector de **horarios de atención** (lista de franjas Apertura–Cierre) que tiene el formulario de **"Editar cliente"**. Así el horario queda cargado desde el alta y se imprime en hoja de ruta / orden de preparación / ficha.

## Por qué

Hasta ahora el form rápido solo capturaba nombre, dirección y GPS; los horarios solo podían cargarse después editando el cliente. Esto cierra ese gap.

## Cambios

- **Nuevo componente compartido** `src/components/ui/FranjasHorariasEditor.tsx`: encapsula la lista de franjas (selects apertura/cierre, agregar/quitar, validación por fila y de solapamiento). Lo usan **ambos** `ModalCliente` y `ModalPedido` para que las dos copias no diverjan.
- **`ModalCliente`**: reemplaza el editor inline por el componente compartido. Sin cambios de comportamiento — conserva `sincronizarAtencion` (serializa + preserva texto libre legacy), la validación que bloquea el guardado y el aviso de conversión legacy.
- **`ModalPedido`**: el form rápido valida las franjas (apertura < cierre, sin solapes; opcionales) y serializa `horarios_atencion` en el payload del cliente.
- **`PedidosContainer`**: el handler `onCrearCliente` reenvía `horarios_atencion` a la mutation.

Solo **horarios de atención** (no "horario de entrega"). **Sin migración**: la columna `clientes.horarios_atencion` ya existe y `createCliente` ya la insertaba.

## Verificación

- ✅ `eslint` limpio en los archivos tocados (también vía pre-commit lint-staged).
- ✅ `vitest run` completo: **741/741** tests verdes (incluye los 23 de `horariosCliente`; los helpers no se tocaron).
- ⏳ Manual pendiente: en la UI, confirmar que el alta rápida persiste el horario con formato `"HH:MM-HH:MM y …"` y que "Editar cliente" sigue igual (el código es una extracción fiel del editor existente).

🤖 Generated with [Claude Code](https://claude.com/claude-code)