### PR TITLE
fix(reportes): cerrar acceso anónimo a las funciones de reportes (seguridad)

### DIFF
--- a/migrations/097_reporte_gerencial_revoke_public.sql
+++ b/migrations/097_reporte_gerencial_revoke_public.sql
@@ -1,0 +1,21 @@
+-- ============================================================================
+-- 097 · Seguridad: quitar EXECUTE de PUBLIC/anon en las funciones de reportes
+-- ============================================================================
+-- Postgres otorga EXECUTE a PUBLIC por defecto al CREAR una función. Por eso
+-- reporte_gerencial y guardar_analisis_mensual (mig 095) quedaron ejecutables
+-- por el rol `anon` (la anon key es pública, va en el bundle del frontend).
+-- Como el RPC trata `auth.uid() IS NULL` como contexto de servicio (acceso
+-- total a cualquier sucursal/red), cualquiera con la anon key podía leer TODOS
+-- los datos financieros. Este es el cierre del agujero.
+--
+-- Se quita el acceso de PUBLIC y anon; sólo quedan:
+--   * authenticated → usuarios logueados de la app (el RPC valida admin +
+--     sucursales asignadas internamente).
+--   * service_role  → Claude Code vía MCP (comando /reporte-mensual) y crons.
+-- (Aplicado en prod vía MCP el 2026-06-29; este archivo lo deja en el historial.)
+
+REVOKE EXECUTE ON FUNCTION public.reporte_gerencial(bigint, date, date)            FROM PUBLIC, anon;
+REVOKE EXECUTE ON FUNCTION public.guardar_analisis_mensual(bigint, date, text, jsonb) FROM PUBLIC, anon;
+
+GRANT EXECUTE ON FUNCTION public.reporte_gerencial(bigint, date, date)            TO authenticated, service_role;
+GRANT EXECUTE ON FUNCTION public.guardar_analisis_mensual(bigint, date, text, jsonb) TO authenticated, service_role;


### PR DESCRIPTION
## Agujero de seguridad

Al regenerar un reporte descubrí que las funciones del dashboard gerencial (`reporte_gerencial`, `guardar_analisis_mensual`, mig 095) eran **ejecutables por el rol `anon`**. Causa: Postgres otorga `EXECUTE` a **PUBLIC** por defecto al crear una función, y el `GRANT ... TO authenticated` no lo revierte.

Como la **anon key es pública** (va en el bundle JS del frontend) y el RPC trata `auth.uid() IS NULL` como contexto de servicio (**acceso total** a cualquier sucursal y a la red consolidada), **cualquiera con la anon key podía leer todos los datos financieros** sin login.

## Fix (mig 097)

```sql
REVOKE EXECUTE ... FROM PUBLIC, anon;
GRANT  EXECUTE ... TO authenticated, service_role;
```

Quedan con acceso sólo:
- **authenticated** → usuarios logueados (el RPC valida admin + sucursales asignadas internamente).
- **service_role** → Claude Code vía MCP (`/reporte-mensual`) y crons.

## Verificación

Aplicado en prod vía MCP. `has_function_privilege`:

| rol | EXECUTE |
|---|---|
| anon | ❌ false |
| authenticated | ✅ true |
| service_role | ✅ true |

741 tests pasan.

> Nota: conviene auditar si otras funciones `SECURITY DEFINER` del proyecto tienen el mismo patrón (PUBLIC execute + lógica sensible).

🤖 Generated with [Claude Code](https://claude.com/claude-code)