### PR TITLE
fix(reportes): integridad del reporte comercial (bot, costo histórico, creado_por, mermas)

### DIFF
--- a/migrations/099_bot_ventas_entregado.sql
+++ b/migrations/099_bot_ventas_entregado.sql
@@ -1,0 +1,153 @@
+-- ============================================================================
+-- 098 · Bot: "venta" = venta ENTREGADA (alinear con reporte_gerencial)
+-- ============================================================================
+-- Bug detectado en auditoría 2026-06-29: los RPC de venta del bot contaban
+-- como "venta" cualquier pedido NOT IN ('cancelado','anulado') y sin filtrar
+-- canal → sumaban asignado+pendiente (mercadería NO entregada). Junio Tucumán:
+-- bot $21,27M vs reporte $18,27M; gap $3,01M = exactamente asignado+pendiente.
+--
+-- Definición canónica de venta entregada (igual que reporte_gerencial):
+--   estado='entregado' AND canal='app'.
+--
+-- bot_ventas_periodo además expone los pedidos en curso (asignado+pendiente)
+-- como cifra SEPARADA (en_curso_*), nunca mezclada con "ventas".
+--
+-- NOTA: CREATE OR REPLACE preserva owner y permisos (no reintroduce el grant
+-- a PUBLIC). Defs basadas en la versión EN VIVO de prod (no en el repo).
+-- ============================================================================
+
+-- ----------------------------------------------------------------------------
+-- bot_ventas_periodo
+-- ----------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.bot_ventas_periodo(p_desde date, p_hasta date, p_sucursal_id bigint, p_limit integer DEFAULT 10)
+ RETURNS json
+ LANGUAGE plpgsql
+ STABLE SECURITY DEFINER
+ SET search_path TO 'public'
+AS $function$
+DECLARE resultado JSON;
+BEGIN
+  WITH ventas_filtradas AS (
+    SELECT id, cliente_id, total, fecha
+    FROM pedidos
+    WHERE sucursal_id = p_sucursal_id
+      AND fecha BETWEEN p_desde AND p_hasta
+      AND estado = 'entregado' AND canal = 'app'
+  ),
+  en_curso AS (
+    SELECT COALESCE(SUM(total), 0) AS monto, COUNT(*) AS pedidos
+    FROM pedidos
+    WHERE sucursal_id = p_sucursal_id
+      AND fecha BETWEEN p_desde AND p_hasta
+      AND canal = 'app'
+      AND COALESCE(estado, '') IN ('asignado', 'pendiente')
+  ),
+  top_clientes AS (
+    SELECT c.id, c.codigo, c.nombre_fantasia, c.razon_social,
+      SUM(v.total) AS total_comprado, COUNT(*) AS pedidos
+    FROM ventas_filtradas v JOIN clientes c ON c.id = v.cliente_id
+    GROUP BY c.id, c.codigo, c.nombre_fantasia, c.razon_social
+    ORDER BY SUM(v.total) DESC LIMIT p_limit
+  ),
+  top_productos AS (
+    SELECT p.id, p.codigo, p.nombre, SUM(pi.cantidad) AS unidades, SUM(pi.subtotal) AS facturado
+    FROM ventas_filtradas v
+    JOIN pedido_items pi ON pi.pedido_id = v.id
+    JOIN productos p ON p.id = pi.producto_id
+    GROUP BY p.id, p.codigo, p.nombre
+    ORDER BY SUM(pi.subtotal) DESC LIMIT p_limit
+  )
+  SELECT json_build_object(
+    'desde', p_desde, 'hasta', p_hasta,
+    'total_ventas', (SELECT COALESCE(SUM(total), 0) FROM ventas_filtradas),
+    'pedidos_count', (SELECT COUNT(*) FROM ventas_filtradas),
+    'ticket_promedio', (SELECT CASE WHEN COUNT(*) > 0 THEN ROUND(AVG(total), 2) ELSE 0 END FROM ventas_filtradas),
+    'en_curso_monto', (SELECT monto FROM en_curso),
+    'en_curso_pedidos', (SELECT pedidos FROM en_curso),
+    'top_clientes', COALESCE((SELECT json_agg(row_to_json(tc.*)) FROM top_clientes tc), '[]'::JSON),
+    'top_productos', COALESCE((SELECT json_agg(row_to_json(tp.*)) FROM top_productos tp), '[]'::JSON)
+  ) INTO resultado;
+  RETURN resultado;
+END;
+$function$;
+
+-- ----------------------------------------------------------------------------
+-- bot_mis_ventas
+-- ----------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.bot_mis_ventas(p_preventista_id uuid, p_desde date, p_hasta date, p_sucursal_id bigint, p_limit integer DEFAULT 10)
+ RETURNS json
+ LANGUAGE plpgsql
+ STABLE SECURITY DEFINER
+ SET search_path TO 'public'
+AS $function$
+DECLARE resultado JSON;
+BEGIN
+  WITH ventas_filtradas AS (
+    SELECT p.id, p.cliente_id, p.total
+    FROM pedidos p
+    WHERE p.sucursal_id = p_sucursal_id
+      AND p.usuario_id  = p_preventista_id
+      AND p.fecha BETWEEN p_desde AND p_hasta
+      AND p.estado = 'entregado' AND p.canal = 'app'
+  ),
+  top_clientes AS (
+    SELECT c.id AS cliente_id, c.codigo AS cliente_codigo,
+      c.nombre_fantasia, c.razon_social,
+      SUM(v.total) AS total_comprado, COUNT(*) AS pedidos
+    FROM ventas_filtradas v JOIN clientes c ON c.id = v.cliente_id
+    GROUP BY c.id, c.codigo, c.nombre_fantasia, c.razon_social
+    ORDER BY SUM(v.total) DESC LIMIT p_limit
+  )
+  SELECT json_build_object(
+    'desde', p_desde, 'hasta', p_hasta,
+    'preventista_id', p_preventista_id,
+    'total_ventas', (SELECT COALESCE(SUM(total), 0) FROM ventas_filtradas),
+    'pedidos_count', (SELECT COUNT(*) FROM ventas_filtradas),
+    'ticket_promedio', (SELECT CASE WHEN COUNT(*) > 0 THEN ROUND(AVG(total), 2) ELSE 0 END FROM ventas_filtradas),
+    'clientes_distintos', (SELECT COUNT(DISTINCT cliente_id) FROM ventas_filtradas),
+    'top_clientes', COALESCE((SELECT json_agg(row_to_json(tc.*)) FROM top_clientes tc), '[]'::JSON)
+  ) INTO resultado;
+  RETURN resultado;
+END;
+$function$;
+
+-- ----------------------------------------------------------------------------
+-- bot_ventas_por_preventista  (sigue agrupando por usuario_id; pasará a
+-- vendedor_id en la migración de la Fase 3)
+-- ----------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.bot_ventas_por_preventista(p_desde date, p_hasta date, p_sucursal_id bigint, p_solo_preventistas boolean DEFAULT true, p_limit integer DEFAULT 25)
+ RETURNS json
+ LANGUAGE plpgsql
+ STABLE SECURITY DEFINER
+ SET search_path TO 'public'
+AS $function$
+DECLARE resultado JSON;
+BEGIN
+  WITH ventas_filtradas AS (
+    SELECT p.id, p.usuario_id, p.total
+    FROM pedidos p
+    LEFT JOIN perfiles pf ON pf.id = p.usuario_id
+    WHERE p.sucursal_id = p_sucursal_id
+      AND p.fecha BETWEEN p_desde AND p_hasta
+      AND p.estado = 'entregado' AND p.canal = 'app'
+      AND (NOT p_solo_preventistas OR pf.rol = 'preventista')
+  ),
+  por_usuario AS (
+    SELECT v.usuario_id, pf.nombre, pf.rol,
+           COUNT(*) AS pedidos, SUM(v.total) AS total_vendido,
+           ROUND(AVG(v.total), 2) AS ticket_promedio
+    FROM ventas_filtradas v LEFT JOIN perfiles pf ON pf.id = v.usuario_id
+    GROUP BY v.usuario_id, pf.nombre, pf.rol
+    ORDER BY SUM(v.total) DESC LIMIT p_limit
+  )
+  SELECT json_build_object(
+    'desde', p_desde, 'hasta', p_hasta,
+    'solo_preventistas', p_solo_preventistas,
+    'total_ventas', (SELECT COALESCE(SUM(total), 0) FROM ventas_filtradas),
+    'pedidos_count', (SELECT COUNT(*) FROM ventas_filtradas),
+    'preventistas_count', (SELECT COUNT(*) FROM por_usuario),
+    'preventistas', COALESCE((SELECT json_agg(row_to_json(pu.*)) FROM por_usuario pu), '[]'::JSON)
+  ) INTO resultado;
+  RETURN resultado;
+END;
+$function$;

--- a/migrations/100_costo_snapshot_y_creado_por_columnas.sql
+++ b/migrations/100_costo_snapshot_y_creado_por_columnas.sql
@@ -1,0 +1,25 @@
+-- ============================================================================
+-- 100 · Columnas: costo histórico por línea + creador del pedido
+-- ============================================================================
+-- Aditivas, sin cambio de comportamiento (se pueblan/usan en migs 101-103).
+--
+-- (1) pedido_items.costo_unitario_al_crear: costo REAL por unidad congelado al
+--     alta = costo_sin_iva*(1+impuestos_internos/100). Resuelve que el reporte
+--     valúe a costo VIVO del maestro (raíz del margen no reproducible y del
+--     artefacto SALES). Patrón = pedido_items.stock_al_crear.
+-- (2) pedidos.creado_por: quién CARGÓ el pedido (auditoría). usuario_id SIGUE
+--     siendo el vendedor acreditado (cuando el admin elige preventista, queda el
+--     preventista). Se eligió creado_por en vez de vendedor_id para NO tocar la
+--     RLS de pedidos (da visibilidad al preventista por usuario_id=auth.uid()).
+--     Histórico: solo fix forward (creado_por NULL en lo viejo).
+-- ============================================================================
+
+ALTER TABLE public.pedido_items
+  ADD COLUMN IF NOT EXISTS costo_unitario_al_crear numeric NULL;
+COMMENT ON COLUMN public.pedido_items.costo_unitario_al_crear IS
+  'Costo real por unidad (costo_sin_iva*(1+imp_internos/100)) congelado al alta del pedido. NULL = línea vieja: el reporte cae al costo vivo del maestro.';
+
+ALTER TABLE public.pedidos
+  ADD COLUMN IF NOT EXISTS creado_por uuid NULL;
+COMMENT ON COLUMN public.pedidos.creado_por IS
+  'Quién cargó el pedido (auth.uid del caller). usuario_id sigue siendo el vendedor acreditado. NULL = legacy (fix forward).';

--- a/migrations/101_crear_pedido_costo_snapshot_creado_por.sql
+++ b/migrations/101_crear_pedido_costo_snapshot_creado_por.sql
@@ -1,0 +1,235 @@
+-- ============================================================================
+-- 101 · crear_pedido_completo: snapshot de costo histórico + creado_por
+-- ============================================================================
+-- Cambios ADITIVOS sobre la def EN VIVO (no altera lógica existente):
+--  (1) Captura costo REAL por unidad al alta = costo_sin_iva*(1+imp_int/100)
+--      en v_costo_snapshot (Loop 2) y lo persiste en pedido_items.costo_unitario_al_crear.
+--  (2) usuario_id SIGUE siendo el vendedor acreditado (v_preventista_final);
+--      se agrega creado_por = p_usuario_id (quién cargó). NO toca RLS/reporte/comisiones.
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION public.crear_pedido_completo(p_cliente_id bigint, p_total numeric, p_usuario_id uuid, p_items jsonb, p_notas text DEFAULT NULL::text, p_forma_pago text DEFAULT 'efectivo'::text, p_estado_pago text DEFAULT 'pendiente'::text, p_fecha date DEFAULT NULL::date, p_tipo_factura text DEFAULT 'ZZ'::text, p_total_neto numeric DEFAULT NULL::numeric, p_total_iva numeric DEFAULT 0, p_fecha_entrega_programada date DEFAULT NULL::date, p_preventista_id uuid DEFAULT NULL::uuid)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public'
+AS $function$
+DECLARE
+  v_sucursal BIGINT := current_sucursal_id();
+  v_pedido_id INT; item JSONB; v_producto_id INT; v_cantidad INT;
+  v_precio_unitario DECIMAL; v_es_bonificacion BOOLEAN; v_promocion_id BIGINT;
+  v_neto_unitario DECIMAL; v_iva_unitario DECIMAL; v_imp_internos_unitario DECIMAL;
+  v_porcentaje_iva DECIMAL; v_stock_actual INT; v_producto_nombre TEXT;
+  errores TEXT[] := '{}'; v_user_role TEXT;
+  v_cantidades_totales JSONB := '{}'::JSONB; v_cant_acumulada INT;
+  v_stock_snapshot JSONB := '{}'::JSONB;
+  v_stock_al_crear INT;
+  v_costo_actual NUMERIC; v_imp_int_actual NUMERIC;
+  v_costo_snapshot JSONB := '{}'::JSONB; v_costo_al_crear NUMERIC;
+  v_es_regalo_no_mueve_stock JSONB := '{}'::JSONB;
+  v_regalo_mueve_stock BOOLEAN;
+  v_descripcion_regalo TEXT;
+  v_regalo_default_id BIGINT;
+  v_container_id INT;
+  v_fecha_pedido DATE := COALESCE(p_fecha, (now() AT TIME ZONE 'America/Argentina/Buenos_Aires')::date);
+  v_fecha_entrega DATE := COALESCE(p_fecha_entrega_programada, (v_fecha_pedido + INTERVAL '1 day')::date);
+  v_promo RECORD;
+  v_usos_pendientes_actual INT;
+  v_bloques_completos INT;
+  v_ajustar_usos INT;
+  v_ajustar_stock INT;
+  v_stock_ajuste_anterior INT;
+  v_stock_ajuste_nuevo INT;
+  v_ajuste_producto_nombre TEXT;
+  v_merma_id BIGINT;
+  v_pedidos_bundle TEXT;
+  v_observacion TEXT;
+  v_preventista_role TEXT;
+  v_preventista_final UUID;
+BEGIN
+  IF v_sucursal IS NULL THEN RETURN jsonb_build_object('success', false, 'errores', jsonb_build_array('No se pudo determinar la sucursal activa')); END IF;
+  IF p_usuario_id IS DISTINCT FROM auth.uid() THEN RETURN jsonb_build_object('success', false, 'errores', jsonb_build_array('ID de usuario no coincide con la sesion autenticada')); END IF;
+  SELECT rol INTO v_user_role FROM perfiles WHERE id = p_usuario_id;
+  IF v_user_role IS NULL OR v_user_role NOT IN ('admin', 'preventista', 'preventista_taco', 'encargado') THEN RETURN jsonb_build_object('success', false, 'errores', jsonb_build_array('No tiene permisos para crear pedidos')); END IF;
+
+  IF p_preventista_id IS NULL OR p_preventista_id = p_usuario_id THEN
+    v_preventista_final := p_usuario_id;
+  ELSE
+    IF v_user_role <> 'admin' THEN
+      RETURN jsonb_build_object('success', false, 'errores', jsonb_build_array('Solo admin puede asignar otro preventista al pedido'));
+    END IF;
+    SELECT p.rol INTO v_preventista_role
+    FROM perfiles p
+    WHERE p.id = p_preventista_id
+      AND p.activo = true
+      AND EXISTS (
+        SELECT 1 FROM usuario_sucursales us
+        WHERE us.usuario_id = p.id AND us.sucursal_id = v_sucursal
+      );
+    IF v_preventista_role IS NULL OR v_preventista_role NOT IN ('admin', 'preventista', 'preventista_taco') THEN
+      RETURN jsonb_build_object('success', false, 'errores', jsonb_build_array('El usuario asignado no es admin ni preventista (o no pertenece a la sucursal)'));
+    END IF;
+    v_preventista_final := p_preventista_id;
+  END IF;
+
+  FOR item IN SELECT * FROM jsonb_array_elements(p_items) LOOP
+    v_producto_id := (item->>'producto_id')::INT; v_cantidad := (item->>'cantidad')::INT;
+    v_es_bonificacion := COALESCE((item->>'es_bonificacion')::BOOLEAN, false);
+    IF v_cantidad IS NULL OR v_cantidad <= 0 THEN errores := array_append(errores, 'Cantidad invalida para producto ID ' || v_producto_id); CONTINUE; END IF;
+
+    v_cant_acumulada := COALESCE((v_cantidades_totales->>v_producto_id::TEXT)::INT, 0) + v_cantidad;
+    v_cantidades_totales := v_cantidades_totales || jsonb_build_object(v_producto_id::TEXT, v_cant_acumulada);
+
+    IF v_es_bonificacion THEN
+      v_promocion_id := (item->>'promocion_id')::BIGINT;
+      IF v_promocion_id IS NOT NULL THEN
+        SELECT regalo_mueve_stock INTO v_regalo_mueve_stock FROM promociones WHERE id = v_promocion_id AND sucursal_id = v_sucursal;
+        IF NOT COALESCE(v_regalo_mueve_stock, FALSE) THEN
+          v_es_regalo_no_mueve_stock := v_es_regalo_no_mueve_stock || jsonb_build_object(v_producto_id::TEXT, true);
+        END IF;
+      ELSE
+        v_es_regalo_no_mueve_stock := v_es_regalo_no_mueve_stock || jsonb_build_object(v_producto_id::TEXT, true);
+      END IF;
+    END IF;
+  END LOOP;
+
+  FOR v_producto_id IN SELECT (key)::INT FROM jsonb_each_text(v_cantidades_totales) LOOP
+    v_cantidad := (v_cantidades_totales->>v_producto_id::TEXT)::INT;
+    SELECT stock, nombre, costo_sin_iva, COALESCE(impuestos_internos, 0)
+      INTO v_stock_actual, v_producto_nombre, v_costo_actual, v_imp_int_actual
+      FROM productos WHERE id = v_producto_id AND sucursal_id = v_sucursal FOR UPDATE;
+    IF v_stock_actual IS NULL THEN
+      errores := array_append(errores, 'Producto ID ' || v_producto_id || ' no encontrado');
+    ELSIF v_stock_actual < v_cantidad THEN
+      IF COALESCE((v_es_regalo_no_mueve_stock->>v_producto_id::TEXT)::BOOLEAN, FALSE) THEN
+        errores := array_append(errores, v_producto_nombre || ': stock insuficiente para regalo (disponible: ' || v_stock_actual || ', solicitado: ' || v_cantidad || ')');
+      ELSE
+        errores := array_append(errores, v_producto_nombre || ': stock insuficiente (disponible: ' || v_stock_actual || ', solicitado: ' || v_cantidad || ')');
+      END IF;
+    END IF;
+    IF v_stock_actual IS NOT NULL THEN
+      v_stock_snapshot := v_stock_snapshot || jsonb_build_object(v_producto_id::TEXT, v_stock_actual);
+      v_costo_snapshot := v_costo_snapshot || jsonb_build_object(v_producto_id::TEXT,
+        CASE WHEN v_costo_actual IS NULL THEN NULL
+             ELSE round(v_costo_actual * (1 + COALESCE(v_imp_int_actual, 0) / 100), 4) END);
+    END IF;
+  END LOOP;
+
+  IF array_length(errores, 1) > 0 THEN RETURN jsonb_build_object('success', false, 'errores', to_jsonb(errores)); END IF;
+
+  INSERT INTO pedidos (cliente_id, fecha, total, total_neto, total_iva, tipo_factura, estado, usuario_id, creado_por, stock_descontado, notas, forma_pago, estado_pago, fecha_entrega_programada, sucursal_id)
+  VALUES (p_cliente_id, v_fecha_pedido, p_total, COALESCE(p_total_neto, p_total), COALESCE(p_total_iva, 0), COALESCE(p_tipo_factura, 'ZZ'), 'pendiente', v_preventista_final, p_usuario_id, true, p_notas, p_forma_pago, p_estado_pago, v_fecha_entrega, v_sucursal)
+  RETURNING id INTO v_pedido_id;
+
+  PERFORM set_config('app.stock_origen', 'pedido_creado', true);
+  PERFORM set_config('app.stock_ref_tipo', 'pedido', true);
+  PERFORM set_config('app.stock_ref_id', v_pedido_id::TEXT, true);
+  PERFORM set_config('app.stock_user_id', p_usuario_id::TEXT, true);
+
+  IF v_preventista_final IS DISTINCT FROM p_usuario_id THEN
+    INSERT INTO pedido_historial (pedido_id, usuario_id, campo_modificado, valor_anterior, valor_nuevo, sucursal_id)
+    VALUES (v_pedido_id, p_usuario_id, 'usuario_id', NULL, v_preventista_final::TEXT, v_sucursal);
+  END IF;
+
+  FOR item IN SELECT * FROM jsonb_array_elements(p_items) LOOP
+    v_producto_id := (item->>'producto_id')::INT; v_cantidad := (item->>'cantidad')::INT;
+    v_precio_unitario := (item->>'precio_unitario')::DECIMAL;
+    v_es_bonificacion := COALESCE((item->>'es_bonificacion')::BOOLEAN, false);
+    v_promocion_id := (item->>'promocion_id')::BIGINT;
+    v_neto_unitario := (item->>'neto_unitario')::DECIMAL;
+    v_iva_unitario := COALESCE((item->>'iva_unitario')::DECIMAL, 0);
+    v_imp_internos_unitario := COALESCE((item->>'impuestos_internos_unitario')::DECIMAL, 0);
+    v_porcentaje_iva := COALESCE((item->>'porcentaje_iva')::DECIMAL, 0);
+    v_stock_al_crear := (v_stock_snapshot->>v_producto_id::TEXT)::INT;
+    v_costo_al_crear := (v_costo_snapshot->>v_producto_id::TEXT)::NUMERIC;
+
+    v_descripcion_regalo := NULL;
+    v_regalo_default_id := NULL;
+    IF v_es_bonificacion AND v_promocion_id IS NOT NULL THEN
+      SELECT descripcion_regalo, producto_regalo_id
+        INTO v_descripcion_regalo, v_regalo_default_id
+        FROM promociones WHERE id = v_promocion_id AND sucursal_id = v_sucursal;
+      IF v_regalo_default_id IS DISTINCT FROM v_producto_id THEN
+        v_descripcion_regalo := NULL;
+      END IF;
+    END IF;
+
+    INSERT INTO pedido_items (
+      pedido_id, producto_id, cantidad, precio_unitario, subtotal,
+      es_bonificacion, promocion_id,
+      neto_unitario, iva_unitario, impuestos_internos_unitario, porcentaje_iva,
+      sucursal_id, descripcion_regalo, stock_al_crear, costo_unitario_al_crear
+    ) VALUES (
+      v_pedido_id, v_producto_id, v_cantidad, v_precio_unitario, v_cantidad * v_precio_unitario,
+      v_es_bonificacion, v_promocion_id,
+      v_neto_unitario, v_iva_unitario, v_imp_internos_unitario, v_porcentaje_iva,
+      v_sucursal, v_descripcion_regalo, v_stock_al_crear, v_costo_al_crear
+    );
+
+    IF NOT v_es_bonificacion THEN
+      UPDATE productos SET stock = stock - v_cantidad WHERE id = v_producto_id AND sucursal_id = v_sucursal;
+    ELSIF v_promocion_id IS NOT NULL THEN
+      SELECT regalo_mueve_stock INTO v_regalo_mueve_stock FROM promociones WHERE id = v_promocion_id AND sucursal_id = v_sucursal;
+      IF COALESCE(v_regalo_mueve_stock, FALSE) THEN
+        UPDATE productos SET stock = stock - v_cantidad WHERE id = v_producto_id AND sucursal_id = v_sucursal;
+      END IF;
+    END IF;
+
+    IF v_es_bonificacion AND v_promocion_id IS NOT NULL THEN
+      UPDATE promociones SET usos_pendientes = usos_pendientes + v_cantidad WHERE id = v_promocion_id AND sucursal_id = v_sucursal;
+
+      SELECT id, nombre, ajuste_automatico, ajuste_producto_id, unidades_por_bloque,
+             stock_por_bloque, usos_pendientes, producto_regalo_id
+      INTO v_promo
+      FROM promociones WHERE id = v_promocion_id AND sucursal_id = v_sucursal FOR UPDATE;
+
+      v_container_id := CASE WHEN v_promo.producto_regalo_id IS DISTINCT FROM v_producto_id
+                             THEN v_producto_id ELSE v_promo.ajuste_producto_id END;
+
+      IF v_promo.ajuste_automatico AND v_container_id IS NOT NULL
+         AND COALESCE(v_promo.unidades_por_bloque, 0) > 0 AND COALESCE(v_promo.stock_por_bloque, 0) > 0 THEN
+        v_usos_pendientes_actual := v_promo.usos_pendientes;
+        v_bloques_completos := v_usos_pendientes_actual / v_promo.unidades_por_bloque;
+        IF v_bloques_completos > 0 THEN
+          v_ajustar_usos := v_bloques_completos * v_promo.unidades_por_bloque;
+          v_ajustar_stock := v_bloques_completos * v_promo.stock_por_bloque;
+
+          SELECT stock, nombre INTO v_stock_ajuste_anterior, v_ajuste_producto_nombre
+          FROM productos WHERE id = v_container_id AND sucursal_id = v_sucursal FOR UPDATE;
+
+          IF v_stock_ajuste_anterior IS NULL THEN
+            RAISE EXCEPTION 'Auto-ajuste: producto destino no encontrado (promo %)', v_promocion_id;
+          END IF;
+          IF v_stock_ajuste_anterior < v_ajustar_stock THEN
+            RAISE EXCEPTION 'Auto-ajuste: stock insuficiente en % (disponible: %, requerido: %)',
+              v_ajuste_producto_nombre, v_stock_ajuste_anterior, v_ajustar_stock;
+          END IF;
+
+          v_stock_ajuste_nuevo := v_stock_ajuste_anterior - v_ajustar_stock;
+
+          v_pedidos_bundle := public.pedido_bundle_para_promo(v_promocion_id, v_sucursal, 20);
+          v_observacion := 'Auto-ajuste (Promo: ' || v_promo.nombre
+                           || ', Pedidos: ' || COALESCE(v_pedidos_bundle, '#' || v_pedido_id) || ')';
+
+          INSERT INTO mermas_stock (producto_id, cantidad, motivo, observaciones, stock_anterior, stock_nuevo, usuario_id, sucursal_id)
+          VALUES (v_container_id, v_ajustar_stock, 'promociones', v_observacion,
+            v_stock_ajuste_anterior, v_stock_ajuste_nuevo, p_usuario_id, v_sucursal)
+          RETURNING id INTO v_merma_id;
+
+          UPDATE productos SET stock = v_stock_ajuste_nuevo, updated_at = NOW()
+          WHERE id = v_container_id AND sucursal_id = v_sucursal;
+
+          INSERT INTO promo_ajustes (promocion_id, usos_ajustados, unidades_ajustadas, producto_id, merma_id, usuario_id, observaciones, sucursal_id)
+          VALUES (v_promocion_id, v_ajustar_usos, v_ajustar_stock, v_container_id,
+            v_merma_id, p_usuario_id, v_observacion, v_sucursal);
+
+          UPDATE promociones SET usos_pendientes = GREATEST(usos_pendientes - v_ajustar_usos, 0)
+          WHERE id = v_promocion_id AND sucursal_id = v_sucursal;
+        END IF;
+      END IF;
+    END IF;
+  END LOOP;
+
+  RETURN jsonb_build_object('success', true, 'pedido_id', v_pedido_id);
+END;
+$function$;

--- a/migrations/102_bot_y_editar_costo_snapshot.sql
+++ b/migrations/102_bot_y_editar_costo_snapshot.sql
@@ -1,0 +1,514 @@
+-- ============================================================================
+-- 102 · crear_pedido_completo_bot + actualizar_pedido_items: costo snapshot
+-- ============================================================================
+-- Mismo patrón aditivo que la 101:
+--  * bot: captura costo real por unidad + creado_por = p_perfil_id.
+--  * editar: al borrar+reinsertar items, vuelve a capturar el costo vigente.
+-- usuario_id NO cambia (sigue siendo el vendedor acreditado).
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION public.crear_pedido_completo_bot(p_perfil_id uuid, p_confirmacion_id uuid)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public'
+AS $function$
+DECLARE
+  v_pendiente RECORD;
+  v_user_role TEXT;
+  v_pedido_id INT;
+  v_fecha_pedido DATE := (now() AT TIME ZONE 'America/Argentina/Buenos_Aires')::date;
+  v_fecha_entrega DATE := (v_fecha_pedido + INTERVAL '1 day')::date;
+  v_cantidades_totales JSONB := '{}'::JSONB;
+  v_cant_acumulada INT;
+  v_stock_snapshot JSONB := '{}'::JSONB;
+  v_stock_al_crear INT;
+  v_costo_actual NUMERIC; v_imp_int_actual NUMERIC;
+  v_costo_snapshot JSONB := '{}'::JSONB; v_costo_al_crear NUMERIC;
+  v_es_regalo_no_mueve_stock JSONB := '{}'::JSONB;
+  v_regalo_mueve_stock BOOLEAN;
+  v_stock_actual INT;
+  v_producto_nombre TEXT;
+  errores TEXT[] := '{}';
+  item JSONB;
+  v_producto_id INT;
+  v_cantidad INT;
+  v_precio_unitario DECIMAL;
+  v_es_bonificacion BOOLEAN;
+  v_promocion_id BIGINT;
+  v_neto_unitario DECIMAL;
+  v_iva_unitario DECIMAL;
+  v_imp_internos_unitario DECIMAL;
+  v_porcentaje_iva DECIMAL;
+  v_promo RECORD;
+  v_usos_pendientes_actual INT;
+  v_bloques_completos INT;
+  v_ajustar_usos INT;
+  v_ajustar_stock INT;
+  v_stock_ajuste_anterior INT;
+  v_stock_ajuste_nuevo INT;
+  v_ajuste_producto_nombre TEXT;
+  v_merma_id BIGINT;
+BEGIN
+  SELECT * INTO v_pendiente FROM bot_pedidos_pendientes WHERE id = p_confirmacion_id FOR UPDATE;
+  IF NOT FOUND THEN RETURN jsonb_build_object('success', false, 'error', 'Confirmación inválida'); END IF;
+  IF v_pendiente.consumido THEN RETURN jsonb_build_object('success', false, 'error', 'Pedido ya creado, revisalo en la app'); END IF;
+  IF v_pendiente.expires_at < now() THEN RETURN jsonb_build_object('success', false, 'error', 'La confirmación expiró, hacé el pedido de nuevo'); END IF;
+  IF v_pendiente.perfil_id <> p_perfil_id THEN RETURN jsonb_build_object('success', false, 'error', 'Confirmación no pertenece al usuario'); END IF;
+
+  SELECT rol INTO v_user_role FROM perfiles WHERE id = p_perfil_id;
+  IF v_user_role IS NULL OR v_user_role NOT IN ('admin', 'encargado', 'preventista') THEN
+    RETURN jsonb_build_object('success', false, 'error', 'No tiene permisos para crear pedidos');
+  END IF;
+
+  FOR item IN SELECT * FROM jsonb_array_elements(v_pendiente.items) LOOP
+    v_producto_id := (item->>'producto_id')::INT;
+    v_cantidad := (item->>'cantidad')::INT;
+    v_es_bonificacion := COALESCE((item->>'es_bonificacion')::BOOLEAN, false);
+    IF v_cantidad IS NULL OR v_cantidad <= 0 THEN
+      errores := array_append(errores, 'Cantidad inválida para producto ID ' || v_producto_id);
+      CONTINUE;
+    END IF;
+
+    v_cant_acumulada := COALESCE((v_cantidades_totales->>v_producto_id::TEXT)::INT, 0) + v_cantidad;
+    v_cantidades_totales := v_cantidades_totales || jsonb_build_object(v_producto_id::TEXT, v_cant_acumulada);
+
+    IF v_es_bonificacion THEN
+      v_promocion_id := (item->>'promocion_id')::BIGINT;
+      IF v_promocion_id IS NOT NULL THEN
+        SELECT regalo_mueve_stock INTO v_regalo_mueve_stock FROM promociones WHERE id = v_promocion_id AND sucursal_id = v_pendiente.sucursal_id;
+        IF NOT COALESCE(v_regalo_mueve_stock, FALSE) THEN
+          v_es_regalo_no_mueve_stock := v_es_regalo_no_mueve_stock || jsonb_build_object(v_producto_id::TEXT, true);
+        END IF;
+      ELSE
+        v_es_regalo_no_mueve_stock := v_es_regalo_no_mueve_stock || jsonb_build_object(v_producto_id::TEXT, true);
+      END IF;
+    END IF;
+  END LOOP;
+
+  FOR v_producto_id IN SELECT (key)::INT FROM jsonb_each_text(v_cantidades_totales) LOOP
+    v_cantidad := (v_cantidades_totales->>v_producto_id::TEXT)::INT;
+    SELECT stock, nombre, costo_sin_iva, COALESCE(impuestos_internos, 0)
+      INTO v_stock_actual, v_producto_nombre, v_costo_actual, v_imp_int_actual
+      FROM productos WHERE id = v_producto_id AND sucursal_id = v_pendiente.sucursal_id FOR UPDATE;
+    IF v_stock_actual IS NULL THEN
+      errores := array_append(errores, 'Producto ID ' || v_producto_id || ' no encontrado');
+    ELSIF v_stock_actual < v_cantidad THEN
+      IF COALESCE((v_es_regalo_no_mueve_stock->>v_producto_id::TEXT)::BOOLEAN, FALSE) THEN
+        errores := array_append(errores, v_producto_nombre || ': stock insuficiente para regalo (disponible: ' || v_stock_actual || ', solicitado: ' || v_cantidad || ')');
+      ELSE
+        errores := array_append(errores, v_producto_nombre || ': stock insuficiente (disponible: ' || v_stock_actual || ', solicitado: ' || v_cantidad || ')');
+      END IF;
+    END IF;
+    IF v_stock_actual IS NOT NULL THEN
+      v_stock_snapshot := v_stock_snapshot || jsonb_build_object(v_producto_id::TEXT, v_stock_actual);
+      v_costo_snapshot := v_costo_snapshot || jsonb_build_object(v_producto_id::TEXT,
+        CASE WHEN v_costo_actual IS NULL THEN NULL
+             ELSE round(v_costo_actual * (1 + COALESCE(v_imp_int_actual, 0) / 100), 4) END);
+    END IF;
+  END LOOP;
+
+  IF array_length(errores, 1) > 0 THEN RETURN jsonb_build_object('success', false, 'errores', to_jsonb(errores)); END IF;
+
+  INSERT INTO pedidos (
+    cliente_id, fecha, total, total_neto, total_iva, tipo_factura,
+    estado, usuario_id, creado_por, stock_descontado, notas, forma_pago,
+    estado_pago, fecha_entrega_programada, sucursal_id, canal
+  )
+  VALUES (
+    v_pendiente.cliente_id, v_fecha_pedido, v_pendiente.total,
+    COALESCE(v_pendiente.total_neto, v_pendiente.total),
+    COALESCE(v_pendiente.total_iva, 0), 'ZZ',
+    'pendiente', p_perfil_id, p_perfil_id, true, v_pendiente.notas, v_pendiente.forma_pago,
+    'pendiente', v_fecha_entrega, v_pendiente.sucursal_id, 'bot'
+  )
+  RETURNING id INTO v_pedido_id;
+
+  PERFORM set_config('app.stock_origen', 'pedido_creado_bot', true);
+  PERFORM set_config('app.stock_ref_tipo', 'pedido', true);
+  PERFORM set_config('app.stock_ref_id', v_pedido_id::TEXT, true);
+  PERFORM set_config('app.stock_user_id', p_perfil_id::TEXT, true);
+
+  FOR item IN SELECT * FROM jsonb_array_elements(v_pendiente.items) LOOP
+    v_producto_id := (item->>'producto_id')::INT;
+    v_cantidad := (item->>'cantidad')::INT;
+    v_precio_unitario := (item->>'precio_unitario')::DECIMAL;
+    v_es_bonificacion := COALESCE((item->>'es_bonificacion')::BOOLEAN, false);
+    v_promocion_id := (item->>'promocion_id')::BIGINT;
+    v_neto_unitario := (item->>'neto_unitario')::DECIMAL;
+    v_iva_unitario := COALESCE((item->>'iva_unitario')::DECIMAL, 0);
+    v_imp_internos_unitario := COALESCE((item->>'impuestos_internos_unitario')::DECIMAL, 0);
+    v_porcentaje_iva := COALESCE((item->>'porcentaje_iva')::DECIMAL, 0);
+    v_stock_al_crear := (v_stock_snapshot->>v_producto_id::TEXT)::INT;
+    v_costo_al_crear := (v_costo_snapshot->>v_producto_id::TEXT)::NUMERIC;
+
+    INSERT INTO pedido_items (
+      pedido_id, producto_id, cantidad, precio_unitario, subtotal,
+      es_bonificacion, promocion_id, neto_unitario, iva_unitario,
+      impuestos_internos_unitario, porcentaje_iva, sucursal_id, stock_al_crear, costo_unitario_al_crear
+    ) VALUES (
+      v_pedido_id, v_producto_id, v_cantidad, v_precio_unitario,
+      v_cantidad * v_precio_unitario,
+      v_es_bonificacion, v_promocion_id, v_neto_unitario, v_iva_unitario,
+      v_imp_internos_unitario, v_porcentaje_iva, v_pendiente.sucursal_id, v_stock_al_crear, v_costo_al_crear
+    );
+
+    IF NOT v_es_bonificacion THEN
+      UPDATE productos SET stock = stock - v_cantidad WHERE id = v_producto_id AND sucursal_id = v_pendiente.sucursal_id;
+    ELSIF v_promocion_id IS NOT NULL THEN
+      SELECT regalo_mueve_stock INTO v_regalo_mueve_stock FROM promociones WHERE id = v_promocion_id AND sucursal_id = v_pendiente.sucursal_id;
+      IF COALESCE(v_regalo_mueve_stock, FALSE) THEN
+        UPDATE productos SET stock = stock - v_cantidad WHERE id = v_producto_id AND sucursal_id = v_pendiente.sucursal_id;
+      END IF;
+    END IF;
+
+    IF v_es_bonificacion AND v_promocion_id IS NOT NULL THEN
+      UPDATE promociones SET usos_pendientes = usos_pendientes + v_cantidad WHERE id = v_promocion_id AND sucursal_id = v_pendiente.sucursal_id;
+
+      SELECT id, nombre, ajuste_automatico, ajuste_producto_id, unidades_por_bloque,
+             stock_por_bloque, usos_pendientes
+        INTO v_promo
+        FROM promociones WHERE id = v_promocion_id AND sucursal_id = v_pendiente.sucursal_id FOR UPDATE;
+
+      IF v_promo.ajuste_automatico AND v_promo.ajuste_producto_id IS NOT NULL
+         AND COALESCE(v_promo.unidades_por_bloque, 0) > 0 AND COALESCE(v_promo.stock_por_bloque, 0) > 0 THEN
+        v_usos_pendientes_actual := v_promo.usos_pendientes;
+        v_bloques_completos := v_usos_pendientes_actual / v_promo.unidades_por_bloque;
+        IF v_bloques_completos > 0 THEN
+          v_ajustar_usos := v_bloques_completos * v_promo.unidades_por_bloque;
+          v_ajustar_stock := v_bloques_completos * v_promo.stock_por_bloque;
+
+          SELECT stock, nombre INTO v_stock_ajuste_anterior, v_ajuste_producto_nombre
+            FROM productos WHERE id = v_promo.ajuste_producto_id AND sucursal_id = v_pendiente.sucursal_id FOR UPDATE;
+
+          IF v_stock_ajuste_anterior IS NULL THEN
+            RAISE EXCEPTION 'Auto-ajuste: producto destino no encontrado (promo %)', v_promocion_id;
+          END IF;
+          IF v_stock_ajuste_anterior < v_ajustar_stock THEN
+            RAISE EXCEPTION 'Auto-ajuste: stock insuficiente en % (disponible: %, requerido: %)',
+              v_ajuste_producto_nombre, v_stock_ajuste_anterior, v_ajustar_stock;
+          END IF;
+
+          v_stock_ajuste_nuevo := v_stock_ajuste_anterior - v_ajustar_stock;
+
+          INSERT INTO mermas_stock (
+            producto_id, cantidad, motivo, observaciones,
+            stock_anterior, stock_nuevo, usuario_id, sucursal_id
+          ) VALUES (
+            v_promo.ajuste_producto_id, v_ajustar_stock, 'promociones',
+            'Auto-ajuste (Promo: ' || v_promo.nombre || ', Pedido #' || v_pedido_id || ' via bot)',
+            v_stock_ajuste_anterior, v_stock_ajuste_nuevo, p_perfil_id, v_pendiente.sucursal_id
+          ) RETURNING id INTO v_merma_id;
+
+          UPDATE productos SET stock = v_stock_ajuste_nuevo, updated_at = NOW()
+            WHERE id = v_promo.ajuste_producto_id AND sucursal_id = v_pendiente.sucursal_id;
+
+          INSERT INTO promo_ajustes (
+            promocion_id, usos_ajustados, unidades_ajustadas, producto_id,
+            merma_id, usuario_id, observaciones, sucursal_id
+          ) VALUES (
+            v_promocion_id, v_ajustar_usos, v_ajustar_stock, v_promo.ajuste_producto_id,
+            v_merma_id, p_perfil_id,
+            'Auto-ajuste por pedido #' || v_pedido_id || ' via bot', v_pendiente.sucursal_id
+          );
+
+          UPDATE promociones SET usos_pendientes = GREATEST(usos_pendientes - v_ajustar_usos, 0)
+            WHERE id = v_promocion_id AND sucursal_id = v_pendiente.sucursal_id;
+        END IF;
+      END IF;
+    END IF;
+  END LOOP;
+
+  UPDATE bot_pedidos_pendientes SET consumido = TRUE WHERE id = p_confirmacion_id;
+
+  RETURN jsonb_build_object('success', true, 'pedido_id', v_pedido_id, 'total', v_pendiente.total);
+END;
+$function$;
+
+-- ----------------------------------------------------------------------------
+-- actualizar_pedido_items: capturar costo al reinsertar items editados
+-- ----------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.actualizar_pedido_items(p_pedido_id bigint, p_items_nuevos jsonb, p_usuario_id uuid)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public'
+AS $function$
+DECLARE
+  v_sucursal BIGINT := current_sucursal_id();
+  v_item_nuevo JSONB;
+  v_producto_id INT;
+  v_cantidad_original INT;
+  v_cantidad_nueva INT;
+  v_diferencia INT;
+  v_es_bonificacion BOOLEAN;
+  v_stock_actual INT;
+  v_producto_nombre TEXT;
+  v_total_nuevo DECIMAL := 0;
+  v_total_neto_nuevo DECIMAL := 0;
+  v_total_iva_nuevo DECIMAL := 0;
+  v_total_anterior DECIMAL;
+  v_errores TEXT[] := '{}';
+  v_items_originales JSONB;
+  v_user_role TEXT;
+  v_neto_unitario DECIMAL;
+  v_iva_unitario DECIMAL;
+  v_imp_internos_unitario DECIMAL;
+  v_porcentaje_iva DECIMAL;
+  v_precio_unitario DECIMAL;
+  v_promocion_id BIGINT;
+  v_regalo_mueve_stock BOOLEAN;
+  v_descripcion_regalo TEXT;
+  v_bonif RECORD;
+  v_promo RECORD;
+  v_usos_pendientes_actual INT;
+  v_bloques_completos INT;
+  v_ajustar_usos INT;
+  v_ajustar_stock INT;
+  v_stock_ajuste_anterior INT;
+  v_stock_ajuste_nuevo INT;
+  v_ajuste_producto_nombre TEXT;
+  v_merma_id BIGINT;
+  v_pedido_creator UUID;
+  v_pedido_created_at TIMESTAMPTZ;
+  v_hora_corte CONSTANT TIME := TIME '15:30';
+  v_precio_actual DECIMAL;
+  v_costo_actual DECIMAL; v_imp_int_actual DECIMAL; v_costo_al_crear DECIMAL;
+BEGIN
+  IF v_sucursal IS NULL THEN
+    RETURN jsonb_build_object('success', false, 'errores', ARRAY['No se pudo determinar la sucursal activa']);
+  END IF;
+  IF p_usuario_id IS DISTINCT FROM auth.uid() THEN
+    RETURN jsonb_build_object('success', false, 'errores', ARRAY['ID de usuario no coincide con la sesion autenticada']);
+  END IF;
+  SELECT rol INTO v_user_role FROM perfiles WHERE id = p_usuario_id;
+  IF v_user_role IS NULL OR v_user_role NOT IN ('admin', 'encargado', 'preventista', 'preventista_taco') THEN
+    RETURN jsonb_build_object('success', false, 'errores', ARRAY['No autorizado']);
+  END IF;
+
+  SELECT total, usuario_id, created_at
+    INTO v_total_anterior, v_pedido_creator, v_pedido_created_at
+    FROM pedidos
+   WHERE id = p_pedido_id AND sucursal_id = v_sucursal;
+  IF NOT FOUND THEN
+    RETURN jsonb_build_object('success', false, 'errores', ARRAY['Pedido no encontrado']);
+  END IF;
+
+  IF EXISTS (SELECT 1 FROM pedidos WHERE id = p_pedido_id AND sucursal_id = v_sucursal AND estado = 'entregado') THEN
+    RETURN jsonb_build_object('success', false, 'errores', ARRAY['No se puede editar un pedido ya entregado']);
+  END IF;
+
+  IF v_user_role IN ('preventista', 'preventista_taco') THEN
+    IF v_pedido_creator IS DISTINCT FROM p_usuario_id THEN
+      RETURN jsonb_build_object('success', false, 'errores',
+        ARRAY['Solo el preventista que creo el pedido puede editarlo']);
+    END IF;
+
+    IF (v_pedido_created_at AT TIME ZONE 'America/Argentina/Buenos_Aires')::date
+         IS DISTINCT FROM (now() AT TIME ZONE 'America/Argentina/Buenos_Aires')::date
+       OR (now() AT TIME ZONE 'America/Argentina/Buenos_Aires')::time >= v_hora_corte
+    THEN
+      RETURN jsonb_build_object('success', false, 'errores',
+        ARRAY['Como preventista solo puede editar pedidos del dia actual antes de las 15:30 (ARG)']);
+    END IF;
+
+    FOR v_item_nuevo IN SELECT * FROM jsonb_array_elements(p_items_nuevos) LOOP
+      IF COALESCE((v_item_nuevo->>'es_bonificacion')::BOOLEAN, false) = true THEN
+        CONTINUE;
+      END IF;
+      v_producto_id := (v_item_nuevo->>'producto_id')::INT;
+      v_precio_unitario := (v_item_nuevo->>'precio_unitario')::DECIMAL;
+      SELECT precio INTO v_precio_actual
+        FROM productos WHERE id = v_producto_id AND sucursal_id = v_sucursal;
+      IF v_precio_actual IS NULL THEN
+        RETURN jsonb_build_object('success', false, 'errores',
+          ARRAY['Producto ID ' || v_producto_id || ' no encontrado']);
+      END IF;
+      IF v_precio_unitario IS NULL OR v_precio_unitario > v_precio_actual THEN
+        RETURN jsonb_build_object('success', false, 'errores',
+          ARRAY['Como preventista no puede aumentar precios (producto ID ' || v_producto_id || ')']);
+      END IF;
+    END LOOP;
+  END IF;
+
+  SELECT jsonb_agg(jsonb_build_object(
+    'producto_id', producto_id, 'cantidad', cantidad,
+    'precio_unitario', precio_unitario, 'es_bonificacion', COALESCE(es_bonificacion, false)))
+  INTO v_items_originales FROM pedido_items WHERE pedido_id = p_pedido_id AND sucursal_id = v_sucursal;
+
+  FOR v_item_nuevo IN SELECT * FROM jsonb_array_elements(p_items_nuevos) LOOP
+    v_producto_id := (v_item_nuevo->>'producto_id')::INT;
+    v_cantidad_nueva := (v_item_nuevo->>'cantidad')::INT;
+    v_es_bonificacion := COALESCE((v_item_nuevo->>'es_bonificacion')::BOOLEAN, false);
+    v_promocion_id := (v_item_nuevo->>'promocion_id')::BIGINT;
+
+    IF v_es_bonificacion THEN
+      IF v_promocion_id IS NULL THEN CONTINUE; END IF;
+      SELECT regalo_mueve_stock INTO v_regalo_mueve_stock FROM promociones WHERE id = v_promocion_id AND sucursal_id = v_sucursal;
+      IF NOT COALESCE(v_regalo_mueve_stock, FALSE) THEN CONTINUE; END IF;
+    END IF;
+
+    SELECT COALESCE(cantidad, 0) INTO v_cantidad_original
+    FROM pedido_items
+    WHERE pedido_id = p_pedido_id AND producto_id = v_producto_id
+      AND COALESCE(es_bonificacion, false) = v_es_bonificacion
+      AND sucursal_id = v_sucursal;
+
+    v_diferencia := v_cantidad_nueva - COALESCE(v_cantidad_original, 0);
+
+    IF v_diferencia > 0 THEN
+      SELECT stock, nombre INTO v_stock_actual, v_producto_nombre
+      FROM productos WHERE id = v_producto_id AND sucursal_id = v_sucursal FOR UPDATE;
+
+      IF v_stock_actual IS NULL THEN
+        v_errores := array_append(v_errores, 'Producto ID ' || v_producto_id || ' no encontrado');
+      ELSIF v_stock_actual < v_diferencia THEN
+        v_errores := array_append(v_errores, COALESCE(v_producto_nombre, 'Producto ' || v_producto_id)
+          || ': stock insuficiente (disponible: ' || v_stock_actual || ', adicional: ' || v_diferencia || ')');
+      END IF;
+    END IF;
+  END LOOP;
+
+  IF array_length(v_errores, 1) > 0 THEN
+    RETURN jsonb_build_object('success', false, 'errores', to_jsonb(v_errores));
+  END IF;
+
+  UPDATE productos p
+  SET stock = p.stock + pi.cantidad
+  FROM pedido_items pi
+  WHERE pi.pedido_id = p_pedido_id AND pi.sucursal_id = v_sucursal
+    AND COALESCE(pi.es_bonificacion, false) = false
+    AND p.id = pi.producto_id AND p.sucursal_id = v_sucursal;
+
+  UPDATE productos p
+  SET stock = p.stock + pi.cantidad
+  FROM pedido_items pi
+  JOIN promociones pr ON pr.id = pi.promocion_id AND pr.sucursal_id = pi.sucursal_id
+  WHERE pi.pedido_id = p_pedido_id AND pi.sucursal_id = v_sucursal
+    AND COALESCE(pi.es_bonificacion, false) = true
+    AND pi.promocion_id IS NOT NULL
+    AND COALESCE(pr.regalo_mueve_stock, FALSE) = TRUE
+    AND p.id = pi.producto_id AND p.sucursal_id = v_sucursal;
+
+  FOR v_bonif IN
+    SELECT promocion_id, SUM(cantidad)::INT AS total_cantidad
+      FROM pedido_items
+     WHERE pedido_id = p_pedido_id AND sucursal_id = v_sucursal
+       AND COALESCE(es_bonificacion, false) = true AND promocion_id IS NOT NULL
+     GROUP BY promocion_id
+  LOOP
+    PERFORM public.revertir_bloques_auto_ajuste(
+      v_bonif.promocion_id, v_bonif.total_cantidad, v_sucursal,
+      p_usuario_id, 'Edicion pedido #' || p_pedido_id
+    );
+  END LOOP;
+
+  DELETE FROM pedido_items WHERE pedido_id = p_pedido_id AND sucursal_id = v_sucursal;
+
+  FOR v_item_nuevo IN SELECT * FROM jsonb_array_elements(p_items_nuevos) LOOP
+    v_producto_id := (v_item_nuevo->>'producto_id')::INT;
+    v_cantidad_nueva := (v_item_nuevo->>'cantidad')::INT;
+    v_precio_unitario := (v_item_nuevo->>'precio_unitario')::DECIMAL;
+    v_es_bonificacion := COALESCE((v_item_nuevo->>'es_bonificacion')::BOOLEAN, false);
+    v_promocion_id := (v_item_nuevo->>'promocion_id')::BIGINT;
+    v_neto_unitario := (v_item_nuevo->>'neto_unitario')::DECIMAL;
+    v_iva_unitario := COALESCE((v_item_nuevo->>'iva_unitario')::DECIMAL, 0);
+    v_imp_internos_unitario := COALESCE((v_item_nuevo->>'impuestos_internos_unitario')::DECIMAL, 0);
+    v_porcentaje_iva := COALESCE((v_item_nuevo->>'porcentaje_iva')::DECIMAL, 0);
+
+    SELECT costo_sin_iva, COALESCE(impuestos_internos, 0)
+      INTO v_costo_actual, v_imp_int_actual
+      FROM productos WHERE id = v_producto_id AND sucursal_id = v_sucursal;
+    v_costo_al_crear := CASE WHEN v_costo_actual IS NULL THEN NULL
+                             ELSE round(v_costo_actual * (1 + COALESCE(v_imp_int_actual, 0) / 100), 4) END;
+
+    v_descripcion_regalo := NULL;
+    IF v_es_bonificacion AND v_promocion_id IS NOT NULL THEN
+      SELECT descripcion_regalo INTO v_descripcion_regalo FROM promociones WHERE id = v_promocion_id AND sucursal_id = v_sucursal;
+    END IF;
+
+    INSERT INTO pedido_items (
+      pedido_id, producto_id, cantidad, precio_unitario, subtotal,
+      es_bonificacion, promocion_id,
+      neto_unitario, iva_unitario, impuestos_internos_unitario, porcentaje_iva,
+      sucursal_id, descripcion_regalo, costo_unitario_al_crear
+    ) VALUES (
+      p_pedido_id, v_producto_id, v_cantidad_nueva, v_precio_unitario,
+      v_cantidad_nueva * v_precio_unitario,
+      v_es_bonificacion, v_promocion_id,
+      v_neto_unitario, v_iva_unitario, v_imp_internos_unitario, v_porcentaje_iva,
+      v_sucursal, v_descripcion_regalo, v_costo_al_crear
+    );
+
+    IF NOT v_es_bonificacion THEN
+      UPDATE productos SET stock = stock - v_cantidad_nueva WHERE id = v_producto_id AND sucursal_id = v_sucursal;
+      v_total_nuevo := v_total_nuevo + (v_cantidad_nueva * v_precio_unitario);
+      v_total_neto_nuevo := v_total_neto_nuevo + (v_cantidad_nueva * COALESCE(v_neto_unitario, v_precio_unitario));
+      v_total_iva_nuevo := v_total_iva_nuevo + (v_cantidad_nueva * v_iva_unitario);
+    ELSIF v_promocion_id IS NOT NULL THEN
+      SELECT regalo_mueve_stock INTO v_regalo_mueve_stock FROM promociones WHERE id = v_promocion_id AND sucursal_id = v_sucursal;
+      IF COALESCE(v_regalo_mueve_stock, FALSE) THEN
+        UPDATE productos SET stock = stock - v_cantidad_nueva WHERE id = v_producto_id AND sucursal_id = v_sucursal;
+      END IF;
+      UPDATE promociones SET usos_pendientes = usos_pendientes + v_cantidad_nueva WHERE id = v_promocion_id AND sucursal_id = v_sucursal;
+
+      SELECT id, nombre, ajuste_automatico, ajuste_producto_id, unidades_por_bloque,
+             stock_por_bloque, usos_pendientes
+      INTO v_promo
+      FROM promociones WHERE id = v_promocion_id AND sucursal_id = v_sucursal FOR UPDATE;
+
+      IF v_promo.ajuste_automatico AND v_promo.ajuste_producto_id IS NOT NULL
+         AND COALESCE(v_promo.unidades_por_bloque, 0) > 0 AND COALESCE(v_promo.stock_por_bloque, 0) > 0 THEN
+        v_usos_pendientes_actual := v_promo.usos_pendientes;
+        v_bloques_completos := v_usos_pendientes_actual / v_promo.unidades_por_bloque;
+        IF v_bloques_completos > 0 THEN
+          v_ajustar_usos := v_bloques_completos * v_promo.unidades_por_bloque;
+          v_ajustar_stock := v_bloques_completos * v_promo.stock_por_bloque;
+
+          SELECT stock, nombre INTO v_stock_ajuste_anterior, v_ajuste_producto_nombre
+          FROM productos WHERE id = v_promo.ajuste_producto_id AND sucursal_id = v_sucursal FOR UPDATE;
+
+          IF v_stock_ajuste_anterior IS NULL THEN
+            RAISE EXCEPTION 'Auto-ajuste: producto destino no encontrado (promo %)', v_promocion_id;
+          END IF;
+          IF v_stock_ajuste_anterior < v_ajustar_stock THEN
+            RAISE EXCEPTION 'Auto-ajuste: stock insuficiente en % (disponible: %, requerido: %)',
+              v_ajuste_producto_nombre, v_stock_ajuste_anterior, v_ajustar_stock;
+          END IF;
+
+          v_stock_ajuste_nuevo := v_stock_ajuste_anterior - v_ajustar_stock;
+
+          INSERT INTO mermas_stock (producto_id, cantidad, motivo, observaciones, stock_anterior, stock_nuevo, usuario_id, sucursal_id)
+          VALUES (v_promo.ajuste_producto_id, v_ajustar_stock, 'promociones',
+            'Auto-ajuste (Promo: ' || v_promo.nombre || ', Pedido #' || p_pedido_id || ', edicion)',
+            v_stock_ajuste_anterior, v_stock_ajuste_nuevo, p_usuario_id, v_sucursal)
+          RETURNING id INTO v_merma_id;
+
+          UPDATE productos SET stock = v_stock_ajuste_nuevo, updated_at = NOW()
+          WHERE id = v_promo.ajuste_producto_id AND sucursal_id = v_sucursal;
+
+          INSERT INTO promo_ajustes (promocion_id, usos_ajustados, unidades_ajustadas, producto_id, merma_id, usuario_id, observaciones, sucursal_id)
+          VALUES (v_promocion_id, v_ajustar_usos, v_ajustar_stock, v_promo.ajuste_producto_id,
+            v_merma_id, p_usuario_id, 'Auto-ajuste por edicion pedido #' || p_pedido_id, v_sucursal);
+
+          UPDATE promociones SET usos_pendientes = GREATEST(usos_pendientes - v_ajustar_usos, 0)
+          WHERE id = v_promocion_id AND sucursal_id = v_sucursal;
+        END IF;
+      END IF;
+    END IF;
+  END LOOP;
+
+  UPDATE pedidos SET total = v_total_nuevo, total_neto = v_total_neto_nuevo, total_iva = v_total_iva_nuevo, updated_at = NOW()
+  WHERE id = p_pedido_id AND sucursal_id = v_sucursal;
+
+  INSERT INTO pedido_historial (pedido_id, usuario_id, campo_modificado, valor_anterior, valor_nuevo, sucursal_id)
+  VALUES (p_pedido_id, p_usuario_id, 'items', COALESCE(v_items_originales::TEXT, '[]'), p_items_nuevos::TEXT, v_sucursal);
+
+  IF v_total_anterior IS DISTINCT FROM v_total_nuevo THEN
+    INSERT INTO pedido_historial (pedido_id, usuario_id, campo_modificado, valor_anterior, valor_nuevo, sucursal_id)
+    VALUES (p_pedido_id, p_usuario_id, 'total', v_total_anterior::TEXT, v_total_nuevo::TEXT, v_sucursal);
+  END IF;
+
+  RETURN jsonb_build_object('success', true, 'total_nuevo', v_total_nuevo);
+END;
+$function$;

--- a/migrations/103_reporte_gerencial_costo_historico_tz.sql
+++ b/migrations/103_reporte_gerencial_costo_historico_tz.sql
@@ -1,0 +1,171 @@
+-- ============================================================================
+-- 103 · reporte_gerencial: costo histórico (snapshot) + imp. internos + huso AR
+-- ============================================================================
+-- Sobre la versión viva (que ya excluía mermas de promo y valorizaba bonif de
+-- fracción ÷ unidades_por_bloque):
+--  * CMV/bonif usan COALESCE(pi.costo_unitario_al_crear, costo_vivo*(1+imp_int/100)):
+--    líneas nuevas = costo congelado; viejas (NULL) = costo vivo (fix forward).
+--  * Incluye impuestos_internos en CMV, bonif y mermas ("costo real").
+--  * Mermas: fecha en horario AR (antes UTC), alineado con pedidos.fecha.
+-- Vendedores siguen agrupados por usuario_id (= vendedor acreditado; ver mig 100).
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION public.reporte_gerencial(p_sucursal_id bigint, p_desde date, p_hasta date)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ STABLE SECURITY DEFINER
+ SET search_path TO 'public'
+AS $function$
+DECLARE
+  v_sucursales bigint[]; v_asignadas bigint[]; v_nombre text; v_result jsonb;
+  v_es_servicio boolean := (auth.uid() IS NULL);
+BEGIN
+  IF NOT v_es_servicio THEN
+    IF NOT EXISTS (SELECT 1 FROM perfiles WHERE id = auth.uid() AND rol = 'admin') THEN
+      RAISE EXCEPTION 'Acceso denegado: se requiere rol admin'; END IF;
+    SELECT array_agg(sucursal_id) INTO v_asignadas FROM usuario_sucursales WHERE usuario_id = auth.uid();
+    IF v_asignadas IS NULL THEN RAISE EXCEPTION 'Acceso denegado: el usuario no tiene sucursales asignadas'; END IF;
+  END IF;
+  IF p_sucursal_id IS NULL THEN
+    SELECT array_agg(id) INTO v_sucursales FROM sucursales WHERE activa;
+    IF NOT v_es_servicio THEN
+      SELECT array_agg(s) INTO v_sucursales FROM unnest(v_sucursales) AS s WHERE s = ANY(v_asignadas); END IF;
+    v_nombre := 'Red (consolidado)';
+  ELSE
+    IF NOT v_es_servicio AND NOT (p_sucursal_id = ANY(v_asignadas)) THEN
+      RAISE EXCEPTION 'Acceso denegado: la sucursal % no está asignada al usuario', p_sucursal_id; END IF;
+    v_sucursales := ARRAY[p_sucursal_id];
+    SELECT nombre INTO v_nombre FROM sucursales WHERE id = p_sucursal_id;
+  END IF;
+  IF v_sucursales IS NULL OR array_length(v_sucursales,1) IS NULL THEN
+    RAISE EXCEPTION 'Acceso denegado: sin sucursales disponibles para el usuario'; END IF;
+
+  WITH
+  ped AS (
+    SELECT id, cliente_id, usuario_id, total, fecha, forma_pago, estado_pago
+    FROM pedidos WHERE estado='entregado' AND canal='app'
+      AND fecha BETWEEN p_desde AND p_hasta AND sucursal_id = ANY(v_sucursales)
+  ),
+  it AS (
+    SELECT p.id AS pedido_id, p.usuario_id, p.fecha,
+           pi.cantidad, pi.subtotal, pi.es_bonificacion,
+           COALESCE(pi.costo_unitario_al_crear, prod.costo_sin_iva*(1+COALESCE(prod.impuestos_internos,0)/100)) AS costo_unit,
+           prod.nombre AS prod_nombre,
+           COALESCE(NULLIF(prod.categoria,''),'(sin categoría)') AS categoria,
+           (prod.costo_sin_iva IS NULL OR prod.costo_sin_iva = 0) AS sin_costo,
+           CASE WHEN pi.es_bonificacion THEN
+             CASE WHEN pr.regalo_mueve_stock IS FALSE AND pr.unidades_por_bloque > 0
+                  THEN pi.cantidad * COALESCE(pi.costo_unitario_al_crear, prod.costo_sin_iva*(1+COALESCE(prod.impuestos_internos,0)/100)) / pr.unidades_por_bloque
+                  ELSE pi.cantidad * COALESCE(pi.costo_unitario_al_crear, prod.costo_sin_iva*(1+COALESCE(prod.impuestos_internos,0)/100)) END
+           ELSE 0 END AS costo_bonif
+    FROM ped p
+    JOIN pedido_items pi ON pi.pedido_id = p.id
+    JOIN productos prod ON prod.id = pi.producto_id
+    LEFT JOIN promociones pr ON pr.id = pi.promocion_id
+  ),
+  nc AS (
+    SELECT usuario_id, total FROM pedidos
+    WHERE estado<>'cancelado' AND canal='app'
+      AND fecha BETWEEN p_desde AND p_hasta AND sucursal_id = ANY(v_sucursales)
+      AND usuario_id IN (SELECT id FROM perfiles)
+  ),
+  k_ped AS (SELECT COUNT(*) AS pedidos, COALESCE(SUM(total),0) AS venta,
+            COUNT(DISTINCT cliente_id) AS clientes, COALESCE(ROUND(AVG(total)),0) AS ticket FROM ped),
+  k_it AS (
+    SELECT COALESCE(SUM(cantidad*costo_unit) FILTER (WHERE NOT es_bonificacion),0) AS cmv,
+      COALESCE(SUM(costo_bonif),0) AS bonif,
+      COALESCE(SUM(cantidad) FILTER (WHERE NOT es_bonificacion),0) AS unidades,
+      COALESCE(SUM(cantidad) FILTER (WHERE es_bonificacion),0) AS unidades_bonif,
+      COALESCE(SUM(subtotal) FILTER (WHERE sin_costo AND NOT es_bonificacion),0) AS ingreso_sin_costo
+    FROM it
+  ),
+  k_nc AS (SELECT COALESCE(SUM(total),0) AS base_comision FROM nc),
+  k_merma AS (
+    SELECT COALESCE(SUM(m.cantidad*prod.costo_sin_iva*(1+COALESCE(prod.impuestos_internos,0)/100)),0) AS mermas
+    FROM mermas_stock m JOIN productos prod ON prod.id = m.producto_id
+    WHERE m.sucursal_id = ANY(v_sucursales)
+      AND (m.created_at AT TIME ZONE 'America/Argentina/Buenos_Aires')::date BETWEEN p_desde AND p_hasta
+      AND COALESCE(m.motivo,'') NOT IN ('promociones','promociones_reversion')
+  ),
+  k_compra AS (SELECT COALESCE(SUM(total),0) AS compras FROM compras
+    WHERE sucursal_id = ANY(v_sucursales) AND fecha_compra BETWEEN p_desde AND p_hasta),
+  k_nuevos AS (SELECT COUNT(*) AS nuevos FROM (
+      SELECT cliente_id, MIN(fecha) AS pc FROM pedidos
+      WHERE estado='entregado' AND sucursal_id = ANY(v_sucursales) GROUP BY cliente_id
+    ) t WHERE pc BETWEEN p_desde AND p_hasta),
+  m_ped AS (SELECT to_char(fecha,'YYYY-MM') AS mes, COUNT(*) AS pedidos, SUM(total) AS venta,
+            COUNT(DISTINCT cliente_id) AS clientes, ROUND(AVG(total)) AS ticket FROM ped GROUP BY 1),
+  m_it AS (SELECT to_char(fecha,'YYYY-MM') AS mes,
+           COALESCE(SUM(cantidad*costo_unit) FILTER (WHERE NOT es_bonificacion),0) AS cmv,
+           COALESCE(SUM(costo_bonif),0) AS bonif FROM it GROUP BY 1),
+  m_merma AS (SELECT to_char(m.created_at AT TIME ZONE 'America/Argentina/Buenos_Aires','YYYY-MM') AS mes,
+       SUM(m.cantidad*prod.costo_sin_iva*(1+COALESCE(prod.impuestos_internos,0)/100)) AS mermas
+    FROM mermas_stock m JOIN productos prod ON prod.id = m.producto_id
+    WHERE m.sucursal_id = ANY(v_sucursales)
+      AND (m.created_at AT TIME ZONE 'America/Argentina/Buenos_Aires')::date BETWEEN p_desde AND p_hasta
+      AND COALESCE(m.motivo,'') NOT IN ('promociones','promociones_reversion') GROUP BY 1),
+  m_compra AS (SELECT to_char(fecha_compra,'YYYY-MM') AS mes, SUM(total) AS compras
+    FROM compras WHERE sucursal_id = ANY(v_sucursales) AND fecha_compra BETWEEN p_desde AND p_hasta GROUP BY 1),
+  mensual AS (SELECT mp.mes, mp.pedidos, mp.venta, mp.clientes, mp.ticket,
+      COALESCE(mi.cmv,0) AS cmv, COALESCE(mi.bonif,0) AS bonif,
+      COALESCE(mm.mermas,0) AS mermas, COALESCE(mc.compras,0) AS compras
+    FROM m_ped mp LEFT JOIN m_it mi ON mi.mes=mp.mes LEFT JOIN m_merma mm ON mm.mes=mp.mes LEFT JOIN m_compra mc ON mc.mes=mp.mes),
+  v_ent AS (SELECT usuario_id, COUNT(DISTINCT pedido_id) AS pedidos, SUM(subtotal) AS venta,
+      SUM(subtotal) - COALESCE(SUM(cantidad*costo_unit) FILTER (WHERE NOT es_bonificacion),0) AS margen_comercial,
+      COALESCE(SUM(costo_bonif),0) AS bonif FROM it GROUP BY usuario_id),
+  v_nc AS (SELECT usuario_id, SUM(total) AS base_nc FROM nc GROUP BY usuario_id),
+  vendedores AS (SELECT pf.nombre, pf.rol, e.pedidos, e.venta, e.margen_comercial, e.bonif,
+      COALESCE(n.base_nc, e.venta) AS base_nc
+    FROM v_ent e JOIN perfiles pf ON pf.id=e.usuario_id LEFT JOIN v_nc n ON n.usuario_id=e.usuario_id),
+  categorias AS (SELECT categoria, SUM(subtotal) AS venta,
+      SUM(subtotal) - COALESCE(SUM(cantidad*costo_unit) FILTER (WHERE NOT es_bonificacion),0) AS margen_comercial,
+      COALESCE(SUM(costo_bonif),0) AS bonif, bool_or(sin_costo) AS sin_costo
+    FROM it GROUP BY categoria),
+  top_prod AS (SELECT prod_nombre AS nombre,
+      COALESCE(SUM(cantidad) FILTER (WHERE NOT es_bonificacion),0) AS unidades, SUM(subtotal) AS venta,
+      SUM(subtotal) - COALESCE(SUM(cantidad*costo_unit) FILTER (WHERE NOT es_bonificacion),0) AS margen
+    FROM it GROUP BY prod_nombre ORDER BY venta DESC LIMIT 10),
+  top_cli AS (SELECT COALESCE(NULLIF(c.nombre_fantasia,''), c.razon_social) AS cliente,
+      COUNT(DISTINCT p.id) AS pedidos, SUM(p.total) AS venta
+    FROM ped p JOIN clientes c ON c.id=p.cliente_id GROUP BY 1 ORDER BY venta DESC LIMIT 10),
+  bonif_det AS (SELECT prod_nombre AS nombre, SUM(cantidad) AS unidades, SUM(costo_bonif) AS costo
+    FROM it WHERE es_bonificacion GROUP BY prod_nombre HAVING SUM(cantidad) > 0 ORDER BY costo DESC LIMIT 12),
+  mermas_motivo AS (SELECT COALESCE(NULLIF(m.motivo,''),'(sin motivo)') AS motivo,
+      SUM(m.cantidad) AS unidades, SUM(m.cantidad*prod.costo_sin_iva*(1+COALESCE(prod.impuestos_internos,0)/100)) AS costo
+    FROM mermas_stock m JOIN productos prod ON prod.id=m.producto_id
+    WHERE m.sucursal_id = ANY(v_sucursales)
+      AND (m.created_at AT TIME ZONE 'America/Argentina/Buenos_Aires')::date BETWEEN p_desde AND p_hasta
+      AND COALESCE(m.motivo,'') NOT IN ('promociones','promociones_reversion') GROUP BY 1),
+  formas AS (SELECT COALESCE(forma_pago,'(sin dato)') AS forma_pago, SUM(total) AS monto FROM ped GROUP BY 1),
+  cobr AS (SELECT COALESCE(SUM(total) FILTER (WHERE estado_pago='pagado'),0) AS cobrado,
+      COALESCE(SUM(total) FILTER (WHERE estado_pago IN ('pendiente','parcial')),0) AS pendiente FROM ped),
+  serie AS (SELECT to_char(fecha,'DD/MM') AS dia, SUM(total) AS venta FROM ped GROUP BY fecha ORDER BY fecha)
+  SELECT jsonb_build_object(
+    'meta', jsonb_build_object('sucursal_id', p_sucursal_id, 'sucursal_nombre', COALESCE(v_nombre,'?'),
+      'desde', p_desde, 'hasta', p_hasta, 'generado_at', now()),
+    'kpis', (SELECT jsonb_build_object('venta', kp.venta, 'pedidos', kp.pedidos, 'clientes', kp.clientes, 'ticket', kp.ticket,
+        'clientes_nuevos', kn.nuevos, 'cmv', ki.cmv, 'bonif', ki.bonif, 'unidades', ki.unidades,
+        'unidades_bonif', ki.unidades_bonif, 'margen_comercial', kp.venta - ki.cmv,
+        'margen_neto', kp.venta - ki.cmv - ki.bonif, 'base_comision', kc.base_comision, 'comision_pct_default', 2,
+        'mermas', km.mermas, 'compras', kcp.compras, 'ingreso_sin_costo', ki.ingreso_sin_costo)
+      FROM k_ped kp, k_it ki, k_nc kc, k_merma km, k_compra kcp, k_nuevos kn),
+    'mensual', (SELECT COALESCE(jsonb_agg(to_jsonb(m) ORDER BY m.mes),'[]') FROM mensual m),
+    'vendedores', (SELECT COALESCE(jsonb_agg(to_jsonb(v) ORDER BY v.venta DESC),'[]') FROM vendedores v),
+    'categorias', (SELECT COALESCE(jsonb_agg(to_jsonb(c) ORDER BY c.venta DESC),'[]') FROM categorias c),
+    'top_productos', (SELECT COALESCE(jsonb_agg(to_jsonb(t)),'[]') FROM top_prod t),
+    'top_clientes', (SELECT COALESCE(jsonb_agg(to_jsonb(t)),'[]') FROM top_cli t),
+    'bonif_detalle', (SELECT COALESCE(jsonb_agg(to_jsonb(b)),'[]') FROM bonif_det b),
+    'mermas_motivo', (SELECT COALESCE(jsonb_agg(to_jsonb(mm) ORDER BY mm.costo DESC),'[]') FROM mermas_motivo mm),
+    'cobranza', jsonb_build_object('formas', (SELECT COALESCE(jsonb_agg(to_jsonb(f) ORDER BY f.monto DESC),'[]') FROM formas f),
+      'cobrado', (SELECT cobrado FROM cobr), 'pendiente', (SELECT pendiente FROM cobr)),
+    'serie_diaria', (SELECT COALESCE(jsonb_agg(jsonb_build_array(s.dia, s.venta)),'[]') FROM serie s),
+    'flags', (SELECT jsonb_build_object('ingreso_sin_costo', ki.ingreso_sin_costo,
+        'pct_sin_costo', CASE WHEN kp.venta > 0 THEN round(100.0*ki.ingreso_sin_costo/kp.venta,1) ELSE 0 END)
+      FROM k_it ki, k_ped kp)
+  ) INTO v_result;
+  RETURN v_result;
+END;
+$function$;
+
+REVOKE EXECUTE ON FUNCTION public.reporte_gerencial(bigint, date, date) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.reporte_gerencial(bigint, date, date) TO authenticated, service_role;

--- a/migrations/104_actualizar_compra_items_bloquea_stock_negativo.sql
+++ b/migrations/104_actualizar_compra_items_bloquea_stock_negativo.sql
@@ -1,0 +1,234 @@
+-- ============================================================================
+-- 104 · actualizar_compra_items: rechazar si la edición deja stock negativo
+-- ============================================================================
+-- Antes: solo AVISABA (warning) y dejaba el stock negativo (ej. MOÑO MEDIANO −12).
+-- Ahora: RAISE → el EXCEPTION WHEN OTHERS revierte toda la edición y devuelve el
+-- error (mismo invariante que descontar_stock_atomico).
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION public.actualizar_compra_items(p_compra_id bigint, p_items_nuevos jsonb, p_subtotal numeric, p_iva numeric, p_total numeric, p_usuario_id uuid)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public'
+AS $function$
+DECLARE
+  v_sucursal BIGINT := current_sucursal_id();
+  v_user_role TEXT;
+  v_compra RECORD;
+  v_dias NUMERIC;
+  v_item JSONB;
+  v_producto_id BIGINT;
+  v_cantidad INTEGER;
+  v_costo_unitario NUMERIC;
+  v_bonificacion NUMERIC;
+  v_porcentaje_iva NUMERIC;
+  v_impuestos_internos NUMERIC;
+  v_subtotal_item NUMERIC;
+  v_costo_neto NUMERIC;
+  v_costo_con_iva NUMERIC;
+  v_stock_anterior INTEGER;
+  v_stock_nuevo INTEGER;
+  v_max_fecha DATE;
+  v_es_mas_reciente BOOLEAN;
+  v_iva_efectivo NUMERIC;
+  v_items_procesados JSONB := '[]'::JSONB;
+  v_costo_actualizado JSONB := '[]'::JSONB;
+  v_snapshot_stock JSONB := '{}'::JSONB;
+  v_warnings_stock_negativo JSONB;
+  v_warnings JSONB;
+BEGIN
+  IF v_sucursal IS NULL THEN
+    RETURN jsonb_build_object('success', false, 'error', 'No se pudo determinar la sucursal activa');
+  END IF;
+  IF p_usuario_id IS DISTINCT FROM auth.uid() THEN
+    RETURN jsonb_build_object('success', false, 'error', 'ID de usuario no coincide con la sesion autenticada');
+  END IF;
+
+  SELECT rol INTO v_user_role FROM perfiles WHERE id = p_usuario_id;
+  IF v_user_role IS NULL OR v_user_role <> 'admin' THEN
+    RETURN jsonb_build_object('success', false, 'error', 'No autorizado: solo admin puede editar compras');
+  END IF;
+
+  SELECT id, estado, tipo_factura, created_at, fecha_compra
+    INTO v_compra
+    FROM compras
+   WHERE id = p_compra_id AND sucursal_id = v_sucursal;
+  IF NOT FOUND THEN
+    RETURN jsonb_build_object('success', false, 'error', 'Compra no encontrada');
+  END IF;
+
+  IF v_compra.estado = 'cancelada' THEN
+    RETURN jsonb_build_object('success', false, 'error', 'No se puede editar una compra cancelada');
+  END IF;
+
+  v_dias := EXTRACT(EPOCH FROM (now() - v_compra.created_at)) / 86400;
+  IF v_dias > 7 THEN
+    RETURN jsonb_build_object('success', false, 'error',
+      'No se puede editar una compra creada hace mas de 7 dias');
+  END IF;
+
+  v_iva_efectivo := CASE WHEN v_compra.tipo_factura = 'ZZ' THEN 0 ELSE p_iva END;
+
+  PERFORM set_config('app.stock_origen', 'compra_editada', true);
+  PERFORM set_config('app.stock_ref_tipo', 'compra', true);
+  PERFORM set_config('app.stock_ref_id', p_compra_id::TEXT, true);
+  PERFORM set_config('app.stock_user_id', p_usuario_id::TEXT, true);
+
+  PERFORM 1 FROM productos
+   WHERE sucursal_id = v_sucursal
+     AND id IN (
+       SELECT producto_id FROM compra_items
+        WHERE compra_id = p_compra_id AND sucursal_id = v_sucursal
+       UNION
+       SELECT (item->>'producto_id')::BIGINT
+         FROM jsonb_array_elements(p_items_nuevos) AS item
+     )
+   ORDER BY id
+   FOR UPDATE;
+
+  SELECT jsonb_object_agg(id::text, stock) INTO v_snapshot_stock
+    FROM productos
+   WHERE sucursal_id = v_sucursal
+     AND id IN (
+       SELECT producto_id FROM compra_items
+        WHERE compra_id = p_compra_id AND sucursal_id = v_sucursal
+       UNION
+       SELECT (item->>'producto_id')::BIGINT
+         FROM jsonb_array_elements(p_items_nuevos) AS item
+     );
+
+  WITH viejos AS (
+    SELECT producto_id, SUM(cantidad)::INT AS qty_old
+      FROM compra_items
+     WHERE compra_id = p_compra_id AND sucursal_id = v_sucursal
+     GROUP BY producto_id
+  ),
+  nuevos AS (
+    SELECT (item->>'producto_id')::BIGINT AS producto_id,
+           SUM((item->>'cantidad')::INT)::INT AS qty_new
+      FROM jsonb_array_elements(p_items_nuevos) AS item
+     GROUP BY (item->>'producto_id')::BIGINT
+  ),
+  deltas AS (
+    SELECT COALESCE(v.producto_id, n.producto_id) AS producto_id,
+           COALESCE(n.qty_new, 0) - COALESCE(v.qty_old, 0) AS delta
+      FROM viejos v FULL OUTER JOIN nuevos n USING (producto_id)
+  )
+  UPDATE productos p
+     SET stock = p.stock + d.delta,
+         updated_at = NOW()
+    FROM deltas d
+   WHERE p.id = d.producto_id
+     AND p.sucursal_id = v_sucursal
+     AND d.delta <> 0;
+
+  SELECT jsonb_agg(jsonb_build_object('producto_id', id, 'nombre', nombre, 'stock', stock))
+    INTO v_warnings_stock_negativo
+    FROM productos
+   WHERE sucursal_id = v_sucursal
+     AND stock < 0
+     AND id IN (
+       SELECT producto_id FROM compra_items
+        WHERE compra_id = p_compra_id AND sucursal_id = v_sucursal
+       UNION
+       SELECT (item->>'producto_id')::BIGINT
+         FROM jsonb_array_elements(p_items_nuevos) AS item
+     );
+
+  -- Invariante de no-negatividad: si la edición dejaría stock negativo, RECHAZAR
+  -- (el EXCEPTION WHEN OTHERS revierte todo). Antes solo avisaba y dejaba el negativo.
+  IF v_warnings_stock_negativo IS NOT NULL AND jsonb_array_length(v_warnings_stock_negativo) > 0 THEN
+    RAISE EXCEPTION 'La edición dejaría stock negativo en: %. Ajustá las cantidades o reconciliá el stock primero.',
+      (SELECT string_agg((w->>'nombre') || ' (' || (w->>'stock') || ')', ', ')
+         FROM jsonb_array_elements(v_warnings_stock_negativo) w);
+  END IF;
+
+  DELETE FROM compra_items WHERE compra_id = p_compra_id AND sucursal_id = v_sucursal;
+
+  FOR v_item IN SELECT * FROM jsonb_array_elements(p_items_nuevos) LOOP
+    v_producto_id        := (v_item->>'producto_id')::BIGINT;
+    v_cantidad           := (v_item->>'cantidad')::INTEGER;
+    v_costo_unitario     := COALESCE((v_item->>'costo_unitario')::NUMERIC, 0);
+    v_bonificacion       := COALESCE((v_item->>'bonificacion')::NUMERIC, 0);
+    v_porcentaje_iva     := COALESCE((v_item->>'porcentaje_iva')::NUMERIC, 21);
+    v_impuestos_internos := COALESCE((v_item->>'impuestos_internos')::NUMERIC, 0);
+    v_subtotal_item      := COALESCE((v_item->>'subtotal')::NUMERIC, 0);
+
+    IF v_cantidad IS NULL OR v_cantidad <= 0 THEN
+      RAISE EXCEPTION 'Cantidad invalida para producto %', v_producto_id;
+    END IF;
+
+    v_stock_anterior := COALESCE((v_snapshot_stock->>v_producto_id::TEXT)::INTEGER, 0);
+    v_stock_nuevo := v_stock_anterior + v_cantidad;
+
+    INSERT INTO compra_items (
+      compra_id, producto_id, cantidad, costo_unitario, subtotal,
+      stock_anterior, stock_nuevo, bonificacion, sucursal_id
+    ) VALUES (
+      p_compra_id, v_producto_id, v_cantidad, v_costo_unitario,
+      v_subtotal_item, v_stock_anterior, v_stock_nuevo, v_bonificacion, v_sucursal
+    );
+
+    v_costo_neto := v_costo_unitario * (1 - v_bonificacion / 100);
+    IF v_compra.tipo_factura = 'ZZ' THEN
+      v_costo_con_iva  := v_costo_neto;
+      v_porcentaje_iva := 0;
+    ELSE
+      v_costo_con_iva := v_costo_neto * (1 + v_porcentaje_iva / 100);
+    END IF;
+
+    SELECT MAX(c.fecha_compra) INTO v_max_fecha
+      FROM compras c
+      JOIN compra_items ci ON ci.compra_id = c.id AND ci.sucursal_id = c.sucursal_id
+     WHERE ci.producto_id = v_producto_id
+       AND ci.sucursal_id = v_sucursal
+       AND c.estado <> 'cancelada'
+       AND c.id <> p_compra_id;
+
+    v_es_mas_reciente := (v_max_fecha IS NULL) OR (v_compra.fecha_compra >= v_max_fecha);
+
+    IF v_es_mas_reciente THEN
+      UPDATE productos
+         SET costo_sin_iva      = v_costo_neto,
+             costo_con_iva      = v_costo_con_iva,
+             impuestos_internos = v_impuestos_internos,
+             porcentaje_iva     = v_porcentaje_iva,
+             updated_at         = NOW()
+       WHERE id = v_producto_id AND sucursal_id = v_sucursal;
+      v_costo_actualizado := v_costo_actualizado || jsonb_build_object(
+        'producto_id', v_producto_id,
+        'costo_sin_iva', v_costo_neto,
+        'costo_con_iva', v_costo_con_iva
+      );
+    END IF;
+
+    v_items_procesados := v_items_procesados || jsonb_build_object(
+      'producto_id', v_producto_id,
+      'cantidad', v_cantidad,
+      'stock_anterior', v_stock_anterior,
+      'stock_nuevo', v_stock_nuevo,
+      'costo_actualizado', v_es_mas_reciente
+    );
+  END LOOP;
+
+  UPDATE compras
+     SET subtotal = p_subtotal,
+         iva = v_iva_efectivo,
+         total = p_total,
+         updated_at = NOW()
+   WHERE id = p_compra_id AND sucursal_id = v_sucursal;
+
+  v_warnings := NULL;
+
+  RETURN jsonb_build_object(
+    'success', true,
+    'compra_id', p_compra_id,
+    'items_procesados', v_items_procesados,
+    'costo_actualizado', v_costo_actualizado,
+    'warnings', v_warnings
+  );
+EXCEPTION WHEN OTHERS THEN
+  RETURN jsonb_build_object('success', false, 'error', SQLERRM);
+END;
+$function$;

--- a/src/components/modals/ModalPedido.tsx
+++ b/src/components/modals/ModalPedido.tsx
@@ -153,7 +153,12 @@ const ModalPedido = memo(function ModalPedido({
   // Solo admin puede reasignar preventista al pedido. La query se habilita
   // condicionalmente para no traer perfiles para preventistas/encargados.
   const { data: preventistasAsignables = [] } = usePreventistasAsignablesQuery();
-  const preventistaSeleccionado = nuevoPedido.preventistaId ?? currentUserId ?? '';
+  // Atribución explícita: el admin DEBE elegir quién vende (sin default silencioso
+  // a su propio nombre, que cargaba ventas de preventistas al admin). El usuario_id
+  // del pedido = el vendedor elegido; creado_por (quién carga) se setea server-side.
+  const preventistaSeleccionado = nuevoPedido.preventistaId ?? '';
+  const debeElegirPreventista =
+    isAdmin && preventistasAsignables.length > 0 && !preventistaSeleccionado;
 
   const [busquedaProducto, setBusquedaProducto] = useState<string>('');
   const [busquedaCliente, setBusquedaCliente] = useState<string>('');
@@ -885,19 +890,25 @@ const ModalPedido = memo(function ModalPedido({
                     <div>
                       <label className="block text-sm font-medium mb-1 dark:text-gray-200 flex items-center gap-1">
                         <UserCheck className="w-4 h-4 text-blue-600" />
-                        Preventista asignado
+                        Preventista asignado *
                       </label>
                       <select
                         value={preventistaSeleccionado}
                         onChange={e => onPreventistaChange?.(e.target.value)}
-                        className="w-full px-3 py-2 border rounded-lg bg-white dark:bg-gray-700 dark:border-gray-600 dark:text-white text-sm"
+                        className={`w-full px-3 py-2 border rounded-lg bg-white dark:bg-gray-700 dark:text-white text-sm ${debeElegirPreventista ? 'border-amber-500 ring-1 ring-amber-500' : 'dark:border-gray-600'}`}
                       >
+                        <option value="">— Elegí quién vende —</option>
                         {preventistasAsignables.map(p => (
                           <option key={p.id} value={p.id}>
                             {p.nombre}{p.id === currentUserId ? ' (vos)' : ''}
                           </option>
                         ))}
                       </select>
+                      {debeElegirPreventista && (
+                        <p className="text-xs text-amber-600 dark:text-amber-400 mt-1">
+                          Elegí a quién se le acredita la venta (a vos o al preventista que la hizo).
+                        </p>
+                      )}
                     </div>
                   )}
 
@@ -995,7 +1006,7 @@ const ModalPedido = memo(function ModalPedido({
           <button
             type="button"
             onClick={onGuardar}
-            disabled={guardando || violacionesMOQ.length > 0 || !hayItems}
+            disabled={guardando || violacionesMOQ.length > 0 || !hayItems || debeElegirPreventista}
             className="px-5 bg-green-600 text-white font-semibold hover:bg-green-700 disabled:bg-gray-400 disabled:cursor-not-allowed flex items-center justify-center gap-1.5 text-sm"
           >
             {guardando && <Loader2 className="w-4 h-4 animate-spin" />}

--- a/supabase/functions/_shared/tools/admin/ventas_periodo.ts
+++ b/supabase/functions/_shared/tools/admin/ventas_periodo.ts
@@ -155,6 +155,8 @@ export const ventasPeriodoTool: Tool<VentasPeriodoParams, VentasPeriodoResult> =
       total_ventas: Number(r.total_ventas ?? 0),
       pedidos_count: Number(r.pedidos_count ?? 0),
       ticket_promedio: Number(r.ticket_promedio ?? 0),
+      en_curso_monto: Number(r.en_curso_monto ?? 0),
+      en_curso_pedidos: Number(r.en_curso_pedidos ?? 0),
       consulta_realizada_at: consultaRealizadaAt,
       top_clientes: (r.top_clientes ?? []).map((c) => ({
         id: Number(c.id),

--- a/supabase/functions/_shared/tools/admin/ventas_periodo.ts
+++ b/supabase/functions/_shared/tools/admin/ventas_periodo.ts
@@ -24,6 +24,10 @@ export interface VentasPeriodoResult {
   total_ventas: number;
   pedidos_count: number;
   ticket_promedio: number;
+  // Pedidos cargados pero AÚN NO entregados (asignado/pendiente) en el período.
+  // NO son venta: van aparte para que el usuario no los confunda con lo vendido.
+  en_curso_monto: number;
+  en_curso_pedidos: number;
   // Momento en que se ejecutó el RPC (zona ART). El LLM debe mostrarlo al
   // final de la respuesta para que el usuario pueda contrastar contra el
   // panel sabiendo que el panel puede haberse refrescado en otro instante.
@@ -54,8 +58,11 @@ export const ventasPeriodoTool: Tool<VentasPeriodoParams, VentasPeriodoResult> =
     "top productos y el timestamp ART en que se ejecutó la consulta " +
     "(consulta_realizada_at) para que el usuario pueda contrastar contra el " +
     "panel sabiendo cuándo se tomó el dato. Las fechas son inclusive en " +
-    "formato YYYY-MM-DD. Filtra por sucursal del bot user. Excluye pedidos " +
-    "cancelados/anulados.",
+    "formato YYYY-MM-DD. Filtra por sucursal del bot user. total_ventas cuenta " +
+    "SOLO ventas ENTREGADAS (estado='entregado', canal='app') — coincide con el " +
+    "reporte gerencial. Los pedidos cargados pero todavía no entregados " +
+    "(asignado/pendiente) se devuelven aparte en en_curso_monto/en_curso_pedidos " +
+    "y NO deben sumarse a la venta.",
   parameters: {
     type: "object",
     properties: {
@@ -126,6 +133,8 @@ export const ventasPeriodoTool: Tool<VentasPeriodoParams, VentasPeriodoResult> =
       total_ventas: number | string;
       pedidos_count: number;
       ticket_promedio: number | string;
+      en_curso_monto: number | string;
+      en_curso_pedidos: number;
       top_clientes: RpcCliente[];
       top_productos: RpcProducto[];
     };


### PR DESCRIPTION
## Contexto
Auditoría de integridad del reporte comercial (pilar de la app). Las migraciones SQL **ya están aplicadas en prod vía MCP**; este PR versiona los archivos + los cambios de front. El front se activa al mergear (push a main → Coolify).

## Cambios

### Venta confiable
- **Bot Telegram** (`099`): `bot_ventas_periodo`/`bot_mis_ventas`/`bot_ventas_por_preventista` ahora cuentan venta = `estado='entregado' AND canal='app'`. Antes sumaban asignado+pendiente → inflaban junio Tucumán ~16% ($21,3M vs $18,3M reales). `bot_ventas_periodo` expone `en_curso_monto/pedidos` por separado. Verificado: bot = reporte, al peso.

### Margen reproducible (costo histórico)
- **Columna** `pedido_items.costo_unitario_al_crear` (`100`): costo real congelado al alta = `costo_sin_iva*(1+imp_int/100)`.
- **Captura** en `crear_pedido_completo` / `_bot` / `actualizar_pedido_items` (`101`/`102`), patrón de `stock_al_crear`.
- **Reporte** (`103`): CMV/bonif usan `COALESCE(snapshot, costo_vivo*(1+imp_int/100))` → líneas nuevas a costo congelado, viejas (NULL) a costo vivo (fix forward). Resuelve el margen negativo ficticio (SALES) y la no-reproducibilidad. Incluye impuestos internos y fecha las mermas en huso AR.

### Atribución por vendedor
- **`pedidos.creado_por`** (`100`): registra quién CARGA el pedido. `usuario_id` sigue siendo el vendedor acreditado → **no se tocó RLS/reporte/comisiones** (se descartó `vendedor_id` por la RLS de visibilidad).
- **`ModalPedido.tsx`**: el admin debe elegir explícitamente el preventista (sin default silencioso a su nombre). Cierra los ~$8,87M históricos mal atribuidos a admins.

### Robustez
- **`actualizar_compra_items`** (`104`): rechaza la edición si dejaría stock negativo (antes solo avisaba → dejó un producto en −12).

## Review de costos
El modelo es correcto (`costo_sin_iva` = base económica ZZ/FC); 0 productos venden bajo costo (la alarma previa usaba costo con IVA). Único gap real: imp. internos ignorado → ya incluido.

## Nota
El audit inicial marcó "KPI mermas contaminado" y "bonif absurda" como bugs, pero eran contra `migrations/095` (repo desactualizado); en prod ya estaban resueltos (mig 098 de #404). Confirmado en vivo.

## Verificación
- typecheck OK en archivos tocados; 69 tests del área de pedidos verdes (pre-commit corrió la suite).
- Reporte junio Red post-cambios: venta $30,73M / margen neto $11,42M (≈ idéntico).
- **Manual sugerida**: crear un pedido de prueba y confirmar que el admin no puede guardar sin elegir vendedor y que `costo_unitario_al_crear` + `creado_por` quedan poblados.

## Pendientes opcionales (baja prioridad, $0 impacto hoy)
Snapshot de costo en `mermas_stock`; limpiar subtotal residual de cancelados; trazabilidad del ledger; trigger invariante `total = SUM(subtotal)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)