### PR TITLE
feat(reportes): filtro entregadas/todos + filtros de fecha BI

### DIFF
--- a/migrations/106_reporte_gerencial_filtro_estado.sql
+++ b/migrations/106_reporte_gerencial_filtro_estado.sql
@@ -1,0 +1,186 @@
+-- ============================================================================
+-- 106 · reporte_gerencial: filtro de estado (entregadas vs todos los pedidos)
+-- ============================================================================
+-- Agrega p_incluir_no_entregados:
+--   false (default) → solo estado='entregado' (venta entregada, comportamiento previo)
+--   true            → estado IN ('entregado','asignado','pendiente') (todos los
+--                     pedidos vigentes: incluye pendientes y en camino; excluye
+--                     cancelados/anulados).
+-- Afecta la CTE 'ped' (venta/CMV/márgenes/categorías/vendedores/etc.). La base de
+-- comisión ('nc') NO cambia: siempre es sobre no-cancelados.
+-- meta.incluye_no_entregados expone el modo para el front.
+--
+-- Se DROPea la firma de 3 args y se crea la de 4 (con default) para evitar
+-- overloads ambiguos en PostgREST; los callers de 3 args siguen funcionando.
+-- ============================================================================
+
+DROP FUNCTION IF EXISTS public.reporte_gerencial(bigint, date, date);
+
+CREATE OR REPLACE FUNCTION public.reporte_gerencial(
+  p_sucursal_id bigint,
+  p_desde date,
+  p_hasta date,
+  p_incluir_no_entregados boolean DEFAULT false
+)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ STABLE SECURITY DEFINER
+ SET search_path TO 'public'
+AS $function$
+DECLARE
+  v_sucursales bigint[]; v_asignadas bigint[]; v_nombre text; v_result jsonb;
+  v_es_servicio boolean := (auth.uid() IS NULL);
+  v_estados text[] := CASE WHEN p_incluir_no_entregados
+                           THEN ARRAY['entregado','asignado','pendiente']
+                           ELSE ARRAY['entregado'] END;
+BEGIN
+  IF NOT v_es_servicio THEN
+    IF NOT EXISTS (SELECT 1 FROM perfiles WHERE id = auth.uid() AND rol = 'admin') THEN
+      RAISE EXCEPTION 'Acceso denegado: se requiere rol admin'; END IF;
+    SELECT array_agg(sucursal_id) INTO v_asignadas FROM usuario_sucursales WHERE usuario_id = auth.uid();
+    IF v_asignadas IS NULL THEN RAISE EXCEPTION 'Acceso denegado: el usuario no tiene sucursales asignadas'; END IF;
+  END IF;
+  IF p_sucursal_id IS NULL THEN
+    SELECT array_agg(id) INTO v_sucursales FROM sucursales WHERE activa;
+    IF NOT v_es_servicio THEN
+      SELECT array_agg(s) INTO v_sucursales FROM unnest(v_sucursales) AS s WHERE s = ANY(v_asignadas); END IF;
+    v_nombre := 'Red (consolidado)';
+  ELSE
+    IF NOT v_es_servicio AND NOT (p_sucursal_id = ANY(v_asignadas)) THEN
+      RAISE EXCEPTION 'Acceso denegado: la sucursal % no está asignada al usuario', p_sucursal_id; END IF;
+    v_sucursales := ARRAY[p_sucursal_id];
+    SELECT nombre INTO v_nombre FROM sucursales WHERE id = p_sucursal_id;
+  END IF;
+  IF v_sucursales IS NULL OR array_length(v_sucursales,1) IS NULL THEN
+    RAISE EXCEPTION 'Acceso denegado: sin sucursales disponibles para el usuario'; END IF;
+
+  WITH
+  ped AS (
+    SELECT id, cliente_id, usuario_id, total, fecha, forma_pago, estado_pago
+    FROM pedidos WHERE estado = ANY(v_estados) AND canal='app'
+      AND fecha BETWEEN p_desde AND p_hasta AND sucursal_id = ANY(v_sucursales)
+  ),
+  it AS (
+    SELECT p.id AS pedido_id, p.usuario_id, p.fecha,
+           pi.cantidad, pi.subtotal, pi.es_bonificacion,
+           COALESCE(pi.costo_unitario_al_crear, prod.costo_sin_iva*(1+COALESCE(prod.impuestos_internos,0)/100)) AS costo_unit,
+           prod.nombre AS prod_nombre,
+           COALESCE(NULLIF(prod.categoria,''),'(sin categoría)') AS categoria,
+           (prod.costo_sin_iva IS NULL OR prod.costo_sin_iva = 0) AS sin_costo,
+           CASE WHEN pi.es_bonificacion THEN
+             CASE WHEN pr.regalo_mueve_stock IS FALSE AND pr.unidades_por_bloque > 0
+                  THEN pi.cantidad * COALESCE(pi.costo_unitario_al_crear, prod.costo_sin_iva*(1+COALESCE(prod.impuestos_internos,0)/100)) / pr.unidades_por_bloque
+                  ELSE pi.cantidad * COALESCE(pi.costo_unitario_al_crear, prod.costo_sin_iva*(1+COALESCE(prod.impuestos_internos,0)/100)) END
+           ELSE 0 END AS costo_bonif
+    FROM ped p
+    JOIN pedido_items pi ON pi.pedido_id = p.id
+    JOIN productos prod ON prod.id = pi.producto_id
+    LEFT JOIN promociones pr ON pr.id = pi.promocion_id
+  ),
+  nc AS (
+    SELECT usuario_id, total FROM pedidos
+    WHERE estado<>'cancelado' AND canal='app'
+      AND fecha BETWEEN p_desde AND p_hasta AND sucursal_id = ANY(v_sucursales)
+      AND usuario_id IN (SELECT id FROM perfiles)
+  ),
+  k_ped AS (SELECT COUNT(*) AS pedidos, COALESCE(SUM(total),0) AS venta,
+            COUNT(DISTINCT cliente_id) AS clientes, COALESCE(ROUND(AVG(total)),0) AS ticket FROM ped),
+  k_it AS (
+    SELECT COALESCE(SUM(cantidad*costo_unit) FILTER (WHERE NOT es_bonificacion),0) AS cmv,
+      COALESCE(SUM(costo_bonif),0) AS bonif,
+      COALESCE(SUM(cantidad) FILTER (WHERE NOT es_bonificacion),0) AS unidades,
+      COALESCE(SUM(cantidad) FILTER (WHERE es_bonificacion),0) AS unidades_bonif,
+      COALESCE(SUM(subtotal) FILTER (WHERE sin_costo AND NOT es_bonificacion),0) AS ingreso_sin_costo
+    FROM it
+  ),
+  k_nc AS (SELECT COALESCE(SUM(total),0) AS base_comision FROM nc),
+  k_merma AS (
+    SELECT COALESCE(SUM(m.cantidad*prod.costo_sin_iva*(1+COALESCE(prod.impuestos_internos,0)/100)),0) AS mermas
+    FROM mermas_stock m JOIN productos prod ON prod.id = m.producto_id
+    WHERE m.sucursal_id = ANY(v_sucursales)
+      AND (m.created_at AT TIME ZONE 'America/Argentina/Buenos_Aires')::date BETWEEN p_desde AND p_hasta
+      AND COALESCE(m.motivo,'') NOT IN ('promociones','promociones_reversion')
+  ),
+  k_compra AS (SELECT COALESCE(SUM(total),0) AS compras FROM compras
+    WHERE sucursal_id = ANY(v_sucursales) AND fecha_compra BETWEEN p_desde AND p_hasta),
+  k_nuevos AS (SELECT COUNT(*) AS nuevos FROM (
+      SELECT cliente_id, MIN(fecha) AS pc FROM pedidos
+      WHERE estado='entregado' AND sucursal_id = ANY(v_sucursales) GROUP BY cliente_id
+    ) t WHERE pc BETWEEN p_desde AND p_hasta),
+  m_ped AS (SELECT to_char(fecha,'YYYY-MM') AS mes, COUNT(*) AS pedidos, SUM(total) AS venta,
+            COUNT(DISTINCT cliente_id) AS clientes, ROUND(AVG(total)) AS ticket FROM ped GROUP BY 1),
+  m_it AS (SELECT to_char(fecha,'YYYY-MM') AS mes,
+           COALESCE(SUM(cantidad*costo_unit) FILTER (WHERE NOT es_bonificacion),0) AS cmv,
+           COALESCE(SUM(costo_bonif),0) AS bonif FROM it GROUP BY 1),
+  m_merma AS (SELECT to_char(m.created_at AT TIME ZONE 'America/Argentina/Buenos_Aires','YYYY-MM') AS mes,
+       SUM(m.cantidad*prod.costo_sin_iva*(1+COALESCE(prod.impuestos_internos,0)/100)) AS mermas
+    FROM mermas_stock m JOIN productos prod ON prod.id = m.producto_id
+    WHERE m.sucursal_id = ANY(v_sucursales)
+      AND (m.created_at AT TIME ZONE 'America/Argentina/Buenos_Aires')::date BETWEEN p_desde AND p_hasta
+      AND COALESCE(m.motivo,'') NOT IN ('promociones','promociones_reversion') GROUP BY 1),
+  m_compra AS (SELECT to_char(fecha_compra,'YYYY-MM') AS mes, SUM(total) AS compras
+    FROM compras WHERE sucursal_id = ANY(v_sucursales) AND fecha_compra BETWEEN p_desde AND p_hasta GROUP BY 1),
+  mensual AS (SELECT mp.mes, mp.pedidos, mp.venta, mp.clientes, mp.ticket,
+      COALESCE(mi.cmv,0) AS cmv, COALESCE(mi.bonif,0) AS bonif,
+      COALESCE(mm.mermas,0) AS mermas, COALESCE(mc.compras,0) AS compras
+    FROM m_ped mp LEFT JOIN m_it mi ON mi.mes=mp.mes LEFT JOIN m_merma mm ON mm.mes=mp.mes LEFT JOIN m_compra mc ON mc.mes=mp.mes),
+  v_ent AS (SELECT usuario_id, COUNT(DISTINCT pedido_id) AS pedidos, SUM(subtotal) AS venta,
+      SUM(subtotal) - COALESCE(SUM(cantidad*costo_unit) FILTER (WHERE NOT es_bonificacion),0) AS margen_comercial,
+      COALESCE(SUM(costo_bonif),0) AS bonif FROM it GROUP BY usuario_id),
+  v_nc AS (SELECT usuario_id, SUM(total) AS base_nc FROM nc GROUP BY usuario_id),
+  vendedores AS (SELECT pf.nombre, pf.rol, e.pedidos, e.venta, e.margen_comercial, e.bonif,
+      COALESCE(n.base_nc, e.venta) AS base_nc
+    FROM v_ent e JOIN perfiles pf ON pf.id=e.usuario_id LEFT JOIN v_nc n ON n.usuario_id=e.usuario_id),
+  categorias AS (SELECT categoria, SUM(subtotal) AS venta,
+      SUM(subtotal) - COALESCE(SUM(cantidad*costo_unit) FILTER (WHERE NOT es_bonificacion),0) AS margen_comercial,
+      COALESCE(SUM(costo_bonif),0) AS bonif, bool_or(sin_costo) AS sin_costo
+    FROM it GROUP BY categoria),
+  top_prod AS (SELECT prod_nombre AS nombre,
+      COALESCE(SUM(cantidad) FILTER (WHERE NOT es_bonificacion),0) AS unidades, SUM(subtotal) AS venta,
+      SUM(subtotal) - COALESCE(SUM(cantidad*costo_unit) FILTER (WHERE NOT es_bonificacion),0) AS margen
+    FROM it GROUP BY prod_nombre ORDER BY venta DESC LIMIT 10),
+  top_cli AS (SELECT COALESCE(NULLIF(c.nombre_fantasia,''), c.razon_social) AS cliente,
+      COUNT(DISTINCT p.id) AS pedidos, SUM(p.total) AS venta
+    FROM ped p JOIN clientes c ON c.id=p.cliente_id GROUP BY 1 ORDER BY venta DESC LIMIT 10),
+  bonif_det AS (SELECT prod_nombre AS nombre, SUM(cantidad) AS unidades, SUM(costo_bonif) AS costo
+    FROM it WHERE es_bonificacion GROUP BY prod_nombre HAVING SUM(cantidad) > 0 ORDER BY costo DESC LIMIT 12),
+  mermas_motivo AS (SELECT COALESCE(NULLIF(m.motivo,''),'(sin motivo)') AS motivo,
+      SUM(m.cantidad) AS unidades, SUM(m.cantidad*prod.costo_sin_iva*(1+COALESCE(prod.impuestos_internos,0)/100)) AS costo
+    FROM mermas_stock m JOIN productos prod ON prod.id=m.producto_id
+    WHERE m.sucursal_id = ANY(v_sucursales)
+      AND (m.created_at AT TIME ZONE 'America/Argentina/Buenos_Aires')::date BETWEEN p_desde AND p_hasta
+      AND COALESCE(m.motivo,'') NOT IN ('promociones','promociones_reversion') GROUP BY 1),
+  formas AS (SELECT COALESCE(forma_pago,'(sin dato)') AS forma_pago, SUM(total) AS monto FROM ped GROUP BY 1),
+  cobr AS (SELECT COALESCE(SUM(total) FILTER (WHERE estado_pago='pagado'),0) AS cobrado,
+      COALESCE(SUM(total) FILTER (WHERE estado_pago IN ('pendiente','parcial')),0) AS pendiente FROM ped),
+  serie AS (SELECT to_char(fecha,'DD/MM') AS dia, SUM(total) AS venta FROM ped GROUP BY fecha ORDER BY fecha)
+  SELECT jsonb_build_object(
+    'meta', jsonb_build_object('sucursal_id', p_sucursal_id, 'sucursal_nombre', COALESCE(v_nombre,'?'),
+      'desde', p_desde, 'hasta', p_hasta, 'generado_at', now(),
+      'incluye_no_entregados', p_incluir_no_entregados),
+    'kpis', (SELECT jsonb_build_object('venta', kp.venta, 'pedidos', kp.pedidos, 'clientes', kp.clientes, 'ticket', kp.ticket,
+        'clientes_nuevos', kn.nuevos, 'cmv', ki.cmv, 'bonif', ki.bonif, 'unidades', ki.unidades,
+        'unidades_bonif', ki.unidades_bonif, 'margen_comercial', kp.venta - ki.cmv,
+        'margen_neto', kp.venta - ki.cmv - ki.bonif, 'base_comision', kc.base_comision, 'comision_pct_default', 2,
+        'mermas', km.mermas, 'compras', kcp.compras, 'ingreso_sin_costo', ki.ingreso_sin_costo)
+      FROM k_ped kp, k_it ki, k_nc kc, k_merma km, k_compra kcp, k_nuevos kn),
+    'mensual', (SELECT COALESCE(jsonb_agg(to_jsonb(m) ORDER BY m.mes),'[]') FROM mensual m),
+    'vendedores', (SELECT COALESCE(jsonb_agg(to_jsonb(v) ORDER BY v.venta DESC),'[]') FROM vendedores v),
+    'categorias', (SELECT COALESCE(jsonb_agg(to_jsonb(c) ORDER BY c.venta DESC),'[]') FROM categorias c),
+    'top_productos', (SELECT COALESCE(jsonb_agg(to_jsonb(t)),'[]') FROM top_prod t),
+    'top_clientes', (SELECT COALESCE(jsonb_agg(to_jsonb(t)),'[]') FROM top_cli t),
+    'bonif_detalle', (SELECT COALESCE(jsonb_agg(to_jsonb(b)),'[]') FROM bonif_det b),
+    'mermas_motivo', (SELECT COALESCE(jsonb_agg(to_jsonb(mm) ORDER BY mm.costo DESC),'[]') FROM mermas_motivo mm),
+    'cobranza', jsonb_build_object('formas', (SELECT COALESCE(jsonb_agg(to_jsonb(f) ORDER BY f.monto DESC),'[]') FROM formas f),
+      'cobrado', (SELECT cobrado FROM cobr), 'pendiente', (SELECT pendiente FROM cobr)),
+    'serie_diaria', (SELECT COALESCE(jsonb_agg(jsonb_build_array(s.dia, s.venta)),'[]') FROM serie s),
+    'flags', (SELECT jsonb_build_object('ingreso_sin_costo', ki.ingreso_sin_costo,
+        'pct_sin_costo', CASE WHEN kp.venta > 0 THEN round(100.0*ki.ingreso_sin_costo/kp.venta,1) ELSE 0 END)
+      FROM k_it ki, k_ped kp)
+  ) INTO v_result;
+  RETURN v_result;
+END;
+$function$;
+
+REVOKE EXECUTE ON FUNCTION public.reporte_gerencial(bigint, date, date, boolean) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.reporte_gerencial(bigint, date, date, boolean) TO authenticated, service_role;

--- a/src/components/containers/ReportesGerencialesContainer.tsx
+++ b/src/components/containers/ReportesGerencialesContainer.tsx
@@ -12,61 +12,78 @@ function ymd(d: Date): string {
   return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`
 }
 
-/** Opciones de período: trimestre en curso + últimos 6 meses (el mes actual es parcial). */
+/**
+ * Presets de fecha tipo BI. El primero (Este mes) es el default — NO hay un
+ * trimestre hardcodeado. Además del listado, el usuario puede elegir un rango
+ * personalizado (manejado vía onRango en la vista).
+ */
 function generarPeriodos(): PeriodoOpt[] {
   const hoy = new Date()
+  const y = hoy.getFullYear()
+  const m = hoy.getMonth()
+  const hoyYmd = ymd(hoy)
   const opts: PeriodoOpt[] = []
-
-  const qStart = Math.floor(hoy.getMonth() / 3) * 3
-  const qDesde = new Date(hoy.getFullYear(), qStart, 1)
-  const qFin = new Date(hoy.getFullYear(), qStart + 3, 0)
-  const qParcial = hoy < qFin
-  opts.push({
-    key: 'trimestre',
-    label: `Trimestre ${MESES_ES[qStart].slice(0, 3)}–${MESES_ES[qStart + 2].slice(0, 3)} ${hoy.getFullYear()}`,
-    desde: ymd(qDesde),
-    hasta: ymd(qParcial ? hoy : qFin),
-    esMes: false,
-    periodoMes: null,
-    parcial: qParcial,
-  })
-
-  for (let i = 0; i < 6; i++) {
-    const d = new Date(hoy.getFullYear(), hoy.getMonth() - i, 1)
-    const y = d.getFullYear()
-    const m = d.getMonth()
-    const ultimo = new Date(y, m + 1, 0)
-    const esActual = i === 0
+  const add = (key: string, label: string, desde: Date, hasta: Date, esMes = false, periodoMes: Date | null = null) => {
     opts.push({
-      key: `${y}-${String(m + 1).padStart(2, '0')}`,
-      label: `${MESES_ES[m]} ${y}`,
-      desde: ymd(new Date(y, m, 1)),
-      hasta: ymd(esActual ? hoy : ultimo),
-      esMes: true,
-      periodoMes: ymd(new Date(y, m, 1)),
-      parcial: esActual,
+      key, label,
+      desde: ymd(desde), hasta: ymd(hasta > hoy ? hoy : hasta),
+      esMes, periodoMes: periodoMes ? ymd(periodoMes) : null,
+      parcial: ymd(hasta) >= hoyYmd, // el período llega hasta hoy ⇒ todavía abierto
     })
   }
 
+  add('mes-actual', 'Este mes', new Date(y, m, 1), hoy, true, new Date(y, m, 1))
+  const pm = new Date(y, m - 1, 1)
+  add('mes-pasado', 'Mes pasado', pm, new Date(y, m, 0), true, pm)
+  const qStart = Math.floor(m / 3) * 3
+  add('trimestre', 'Trimestre en curso', new Date(y, qStart, 1), hoy)
+  add('anio', 'Año en curso', new Date(y, 0, 1), hoy)
+  // Meses anteriores (para el análisis narrativo guardado por mes).
+  for (let i = 2; i < 12; i++) {
+    const d = new Date(y, m - i, 1)
+    const yy = d.getFullYear()
+    const mm = d.getMonth()
+    add(`${yy}-${String(mm + 1).padStart(2, '0')}`, `${MESES_ES[mm]} ${yy}`, new Date(yy, mm, 1), new Date(yy, mm + 1, 0), true, new Date(yy, mm, 1))
+  }
   return opts
+}
+
+function periodoCustom(desde: string, hasta: string): PeriodoOpt {
+  return {
+    key: 'custom',
+    label: desde && hasta ? `${desde} → ${hasta}` : 'Personalizado',
+    desde, hasta,
+    esMes: false, periodoMes: null,
+    parcial: hasta >= ymd(new Date()),
+  }
 }
 
 export default function ReportesGerencialesContainer(): React.ReactElement {
   const periodos = useMemo(() => generarPeriodos(), [])
-  const [periodoSel, setPeriodoSel] = useState<PeriodoOpt>(() => periodos[0])
+  // Opción "Personalizado" al final del selector (rango default: últimos 30 días).
+  const customDefault = useMemo(() => {
+    const hoy = new Date()
+    const hace30 = new Date(hoy.getTime() - 29 * 24 * 60 * 60 * 1000)
+    return periodoCustom(ymd(hace30), ymd(hoy))
+  }, [])
+  const opcionesPeriodo = useMemo<PeriodoOpt[]>(() => [...periodos, customDefault], [periodos, customDefault])
 
-  // Sólo las sucursales que el usuario tiene asignadas (SucursalContext).
-  // El backend (RPC) refuerza esto: un admin de una sola sucursal no puede ver
-  // datos de otra ni el consolidado de la red.
+  const [periodoSel, setPeriodoSel] = useState<PeriodoOpt>(() => periodos[0]) // default: Este mes
+  const [incluirNoEntregados, setIncluirNoEntregados] = useState(false)
+
+  // Cambia el rango personalizado (date pickers de la vista).
+  const onRango = (desde: string, hasta: string) => {
+    if (!desde || !hasta || desde > hasta) return
+    setPeriodoSel(periodoCustom(desde, hasta))
+  }
+
   const { sucursales, hasMultipleSucursales, loading: sucLoading } = useSucursal()
 
   const opcionesSucursal: SucursalOpt[] = useMemo(() => {
     const list: SucursalOpt[] = sucursales.map(s => ({ id: s.id as number | null, nombre: s.nombre }))
-    // El consolidado de red sólo se ofrece a quien tiene 2+ sucursales asignadas.
     return hasMultipleSucursales ? [{ id: null, nombre: 'Red (consolidado)' }, ...list] : list
   }, [sucursales, hasMultipleSucursales])
 
-  // Default: red si tiene varias; su única sucursal si tiene una.
   const [sucursalSel, setSucursalSel] = useState<number | null | undefined>(undefined)
   useEffect(() => {
     if (sucursalSel === undefined && sucursales.length > 0) {
@@ -77,7 +94,7 @@ export default function ReportesGerencialesContainer(): React.ReactElement {
   const ready = sucursalSel !== undefined
   const sucParam = sucursalSel ?? null
 
-  const { data: reporte, isLoading, error } = useReporteGerencialQuery(sucParam, periodoSel.desde, periodoSel.hasta, ready)
+  const { data: reporte, isLoading, error } = useReporteGerencialQuery(sucParam, periodoSel.desde, periodoSel.hasta, incluirNoEntregados, ready)
   const { data: analisis } = useAnalisisMensualQuery(sucParam, periodoSel.periodoMes, ready && periodoSel.esMes)
 
   return (
@@ -89,9 +106,12 @@ export default function ReportesGerencialesContainer(): React.ReactElement {
         sucursalSel={sucParam}
         periodoSel={periodoSel}
         opcionesSucursal={opcionesSucursal}
-        opcionesPeriodo={periodos}
+        opcionesPeriodo={opcionesPeriodo}
         onSucursal={setSucursalSel}
         onPeriodo={setPeriodoSel}
+        onRango={onRango}
+        incluirNoEntregados={incluirNoEntregados}
+        onIncluirNoEntregados={setIncluirNoEntregados}
         analisis={analisis ?? null}
       />
     </Suspense>

--- a/src/components/containers/ReportesGerencialesContainer.tsx
+++ b/src/components/containers/ReportesGerencialesContainer.tsx
@@ -48,6 +48,17 @@ function generarPeriodos(): PeriodoOpt[] {
   return opts
 }
 
+/** Período anterior: misma cantidad de días, inmediatamente antes del rango dado. */
+function periodoAnterior(desde: string, hasta: string): { desde: string; hasta: string } {
+  const d0 = new Date(`${desde}T00:00:00`)
+  const d1 = new Date(`${hasta}T00:00:00`)
+  const dia = 24 * 60 * 60 * 1000
+  const dias = Math.round((d1.getTime() - d0.getTime()) / dia) + 1
+  const prevHasta = new Date(d0.getTime() - dia)
+  const prevDesde = new Date(prevHasta.getTime() - (dias - 1) * dia)
+  return { desde: ymd(prevDesde), hasta: ymd(prevHasta) }
+}
+
 function periodoCustom(desde: string, hasta: string): PeriodoOpt {
   return {
     key: 'custom',
@@ -70,6 +81,9 @@ export default function ReportesGerencialesContainer(): React.ReactElement {
 
   const [periodoSel, setPeriodoSel] = useState<PeriodoOpt>(() => periodos[0]) // default: Este mes
   const [incluirNoEntregados, setIncluirNoEntregados] = useState(false)
+  const [comparar, setComparar] = useState(true)
+
+  const periodoPrev = useMemo(() => periodoAnterior(periodoSel.desde, periodoSel.hasta), [periodoSel.desde, periodoSel.hasta])
 
   // Cambia el rango personalizado (date pickers de la vista).
   const onRango = (desde: string, hasta: string) => {
@@ -95,6 +109,7 @@ export default function ReportesGerencialesContainer(): React.ReactElement {
   const sucParam = sucursalSel ?? null
 
   const { data: reporte, isLoading, error } = useReporteGerencialQuery(sucParam, periodoSel.desde, periodoSel.hasta, incluirNoEntregados, ready)
+  const { data: comparativo } = useReporteGerencialQuery(sucParam, periodoPrev.desde, periodoPrev.hasta, incluirNoEntregados, ready && comparar)
   const { data: analisis } = useAnalisisMensualQuery(sucParam, periodoSel.periodoMes, ready && periodoSel.esMes)
 
   return (
@@ -112,6 +127,9 @@ export default function ReportesGerencialesContainer(): React.ReactElement {
         onRango={onRango}
         incluirNoEntregados={incluirNoEntregados}
         onIncluirNoEntregados={setIncluirNoEntregados}
+        comparativo={comparativo}
+        comparar={comparar}
+        onComparar={setComparar}
         analisis={analisis ?? null}
       />
     </Suspense>

--- a/src/components/vistas/VistaReportesGerenciales.tsx
+++ b/src/components/vistas/VistaReportesGerenciales.tsx
@@ -35,6 +35,9 @@ export interface VistaReportesGerencialesProps {
   opcionesPeriodo: PeriodoOpt[]
   onSucursal: (id: number | null) => void
   onPeriodo: (p: PeriodoOpt) => void
+  onRango: (desde: string, hasta: string) => void
+  incluirNoEntregados: boolean
+  onIncluirNoEntregados: (v: boolean) => void
   analisis: AnalisisMensual | null
 }
 
@@ -79,7 +82,7 @@ const ACCENTS = { blue: '#2563eb', emerald: '#059669', amber: '#d97706', violet:
 
 export default function VistaReportesGerenciales({
   reporte, loading, error, sucursalSel, periodoSel, opcionesSucursal, opcionesPeriodo,
-  onSucursal, onPeriodo, analisis,
+  onSucursal, onPeriodo, onRango, incluirNoEntregados, onIncluirNoEntregados, analisis,
 }: VistaReportesGerencialesProps): React.ReactElement {
   const [comPct, setComPct] = useState(2)
   const [comBase, setComBase] = useState<'nc' | 'ent'>('nc')
@@ -105,10 +108,25 @@ export default function VistaReportesGerenciales({
           <h1 className="text-2xl font-bold text-gray-900 dark:text-white">Reportes Gerenciales</h1>
           <p className="text-sm text-gray-500 dark:text-gray-400">
             {reporte ? `${reporte.meta.sucursal_nombre} · ${periodoSel.label}` : 'Cargando…'}
+            <span className="font-medium"> · {incluirNoEntregados ? 'Todos los pedidos' : 'Ventas entregadas'}</span>
             {periodoSel.parcial && <span className="text-amber-600 dark:text-amber-400 font-medium"> · período en curso (parcial)</span>}
           </p>
         </div>
         <div className="flex flex-wrap items-center gap-2">
+          {/* Toggle: ventas entregadas vs todos los pedidos (pendientes/en camino/entregados) */}
+          <div className="flex items-center bg-white dark:bg-gray-800 border dark:border-gray-700 rounded-lg p-0.5 shadow-sm">
+            {([['Entregadas', false], ['Todos', true]] as const).map(([lbl, val]) => (
+              <button
+                key={lbl}
+                type="button"
+                onClick={() => onIncluirNoEntregados(val)}
+                title={val ? 'Incluye pendientes, en camino (asignados) y entregados' : 'Solo ventas efectivamente entregadas'}
+                className={`px-2.5 py-1 text-xs font-semibold rounded-md transition-colors ${incluirNoEntregados === val ? 'bg-blue-600 text-white' : 'text-gray-600 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700'}`}
+              >
+                {lbl}
+              </button>
+            ))}
+          </div>
           <div className="flex items-center gap-1.5 bg-white dark:bg-gray-800 border dark:border-gray-700 rounded-lg px-2.5 py-1.5 shadow-sm">
             <Building2 className="w-4 h-4 text-gray-400" />
             <select
@@ -128,9 +146,31 @@ export default function VistaReportesGerenciales({
               onChange={(e) => { const p = opcionesPeriodo.find(o => o.key === e.target.value); if (p) onPeriodo(p) }}
               className="bg-transparent text-sm font-medium text-gray-800 dark:text-gray-100 focus:outline-none"
             >
-              {opcionesPeriodo.map(p => <option key={p.key} value={p.key}>{p.label}</option>)}
+              {opcionesPeriodo.map(p => <option key={p.key} value={p.key}>{p.key === 'custom' ? 'Personalizado…' : p.label}</option>)}
             </select>
           </div>
+          {/* Rango personalizado: date pickers desde/hasta */}
+          {periodoSel.key === 'custom' && (
+            <div className="flex items-center gap-1.5 bg-white dark:bg-gray-800 border dark:border-gray-700 rounded-lg px-2.5 py-1.5 shadow-sm">
+              <input
+                type="date"
+                value={periodoSel.desde}
+                max={periodoSel.hasta || undefined}
+                onChange={(e) => onRango(e.target.value, periodoSel.hasta)}
+                className="bg-transparent text-sm text-gray-800 dark:text-gray-100 focus:outline-none"
+                aria-label="Desde"
+              />
+              <span className="text-gray-400 text-xs">→</span>
+              <input
+                type="date"
+                value={periodoSel.hasta}
+                min={periodoSel.desde || undefined}
+                onChange={(e) => onRango(periodoSel.desde, e.target.value)}
+                className="bg-transparent text-sm text-gray-800 dark:text-gray-100 focus:outline-none"
+                aria-label="Hasta"
+              />
+            </div>
+          )}
         </div>
       </div>
 

--- a/src/components/vistas/VistaReportesGerenciales.tsx
+++ b/src/components/vistas/VistaReportesGerenciales.tsx
@@ -38,6 +38,9 @@ export interface VistaReportesGerencialesProps {
   onRango: (desde: string, hasta: string) => void
   incluirNoEntregados: boolean
   onIncluirNoEntregados: (v: boolean) => void
+  comparativo: ReporteGerencial | null | undefined
+  comparar: boolean
+  onComparar: (v: boolean) => void
   analisis: AnalisisMensual | null
 }
 
@@ -50,14 +53,31 @@ function Card({ children, className = '' }: { children: React.ReactNode; classNa
   )
 }
 
-function KpiCard({ label, value, sub, accent }: { label: string; value: string; sub?: React.ReactNode; accent: string }): React.ReactElement {
+function KpiCard({ label, value, sub, accent, delta }: { label: string; value: string; sub?: React.ReactNode; accent: string; delta?: React.ReactNode }): React.ReactElement {
   return (
     <div className="bg-white dark:bg-gray-800 border dark:border-gray-700 rounded-xl shadow-sm p-4 relative overflow-hidden">
       <div className="absolute left-0 top-0 bottom-0 w-1" style={{ background: accent }} />
       <div className="text-[11px] font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400 pl-1">{label}</div>
       <div className="text-2xl font-bold text-gray-900 dark:text-white mt-1.5 pl-1">{value}</div>
+      {delta && <div className="mt-0.5 pl-1">{delta}</div>}
       {sub && <div className="text-xs text-gray-500 dark:text-gray-400 mt-0.5 pl-1">{sub}</div>}
     </div>
+  )
+}
+
+/** Variación vs período anterior. invert=true ⇒ subir es malo (costos, mermas). */
+function Delta({ cur, prev, invert = false }: { cur: number; prev: number | null | undefined; invert?: boolean }): React.ReactElement | null {
+  if (prev == null || !isFinite(prev) || prev === 0) return null
+  const d = cur - prev
+  const ratio = d / Math.abs(prev)
+  const flat = Math.abs(ratio) < 0.0005
+  const good = invert ? d < 0 : d > 0
+  const color = flat ? 'text-gray-400' : good ? 'text-emerald-600 dark:text-emerald-400' : 'text-red-600 dark:text-red-400'
+  const arrow = flat ? '→' : d > 0 ? '▲' : '▼'
+  return (
+    <span className={`text-[11px] font-semibold ${color}`}>
+      {arrow} {pct(Math.abs(ratio))} <span className="font-normal text-gray-400">vs ant.</span>
+    </span>
   )
 }
 
@@ -82,7 +102,8 @@ const ACCENTS = { blue: '#2563eb', emerald: '#059669', amber: '#d97706', violet:
 
 export default function VistaReportesGerenciales({
   reporte, loading, error, sucursalSel, periodoSel, opcionesSucursal, opcionesPeriodo,
-  onSucursal, onPeriodo, onRango, incluirNoEntregados, onIncluirNoEntregados, analisis,
+  onSucursal, onPeriodo, onRango, incluirNoEntregados, onIncluirNoEntregados,
+  comparativo, comparar, onComparar, analisis,
 }: VistaReportesGerencialesProps): React.ReactElement {
   const [comPct, setComPct] = useState(2)
   const [comBase, setComBase] = useState<'nc' | 'ent'>('nc')
@@ -100,6 +121,16 @@ export default function VistaReportesGerenciales({
     return { comision, contrib }
   }, [k, comPct, comBase])
 
+  // Período anterior (misma duración, justo antes) para mostrar variaciones.
+  const kp = comparativo?.kpis ?? null
+  const cmp = comparar && !!kp
+  const derivedPrev = useMemo(() => {
+    if (!kp) return null
+    const base = comBase === 'nc' ? kp.base_comision : kp.venta
+    const comision = base * comPct / 100
+    return { comision, contrib: kp.margen_neto - kp.mermas - comision }
+  }, [kp, comPct, comBase])
+
   return (
     <div className="space-y-5">
       {/* Header + selectores */}
@@ -109,6 +140,7 @@ export default function VistaReportesGerenciales({
           <p className="text-sm text-gray-500 dark:text-gray-400">
             {reporte ? `${reporte.meta.sucursal_nombre} · ${periodoSel.label}` : 'Cargando…'}
             <span className="font-medium"> · {incluirNoEntregados ? 'Todos los pedidos' : 'Ventas entregadas'}</span>
+            {cmp && comparativo && <span className="text-gray-400"> · vs {comparativo.meta.desde} → {comparativo.meta.hasta}</span>}
             {periodoSel.parcial && <span className="text-amber-600 dark:text-amber-400 font-medium"> · período en curso (parcial)</span>}
           </p>
         </div>
@@ -127,6 +159,14 @@ export default function VistaReportesGerenciales({
               </button>
             ))}
           </div>
+          <button
+            type="button"
+            onClick={() => onComparar(!comparar)}
+            title="Comparar contra el período anterior de igual duración"
+            className={`px-2.5 py-1.5 text-xs font-semibold rounded-lg border shadow-sm transition-colors ${comparar ? 'bg-blue-600 text-white border-blue-600' : 'bg-white dark:bg-gray-800 text-gray-600 dark:text-gray-300 border-gray-200 dark:border-gray-700 hover:bg-gray-100 dark:hover:bg-gray-700'}`}
+          >
+            Comparar
+          </button>
           <div className="flex items-center gap-1.5 bg-white dark:bg-gray-800 border dark:border-gray-700 rounded-lg px-2.5 py-1.5 shadow-sm">
             <Building2 className="w-4 h-4 text-gray-400" />
             <select
@@ -188,14 +228,22 @@ export default function VistaReportesGerenciales({
         <>
           {/* KPIs */}
           <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
-            <KpiCard label="Venta entregada" value={moneyC(k.venta)} sub={`${N.format(k.pedidos)} pedidos`} accent={ACCENTS.blue} />
-            <KpiCard label="Margen comercial" value={moneyC(k.margen_comercial)} sub={<><b>{pct(k.margen_comercial / k.venta)}</b> antes de bonif.</>} accent={ACCENTS.cyan} />
-            <KpiCard label="Bonificaciones" value={moneyC(k.bonif)} sub={<><b>{pct(k.bonif / k.venta)}</b> de la venta</>} accent={ACCENTS.amber} />
-            <KpiCard label="Margen neto" value={moneyC(k.margen_neto)} sub={<><b>{pct(k.margen_neto / k.venta)}</b> post bonif.</>} accent={ACCENTS.violet} />
-            <KpiCard label={`Comisión ${String(comPct).replace('.', ',')}%`} value={moneyC(derived.comision)} sub={`base ${comBase === 'nc' ? 'no cancelado' : 'entregado'}`} accent={ACCENTS.slate} />
-            <KpiCard label="Mermas" value={moneyC(k.mermas)} sub="producto perdido" accent={ACCENTS.red} />
-            <KpiCard label="Contribución est." value={moneyC(derived.contrib)} sub={<><b>{pct(derived.contrib / k.venta)}</b> antes de gastos fijos</>} accent={ACCENTS.emerald} />
-            <KpiCard label="Ticket promedio" value={moneyC(k.ticket)} sub={`${N.format(k.clientes)} clientes · ${N.format(k.clientes_nuevos)} nuevos`} accent={ACCENTS.blue} />
+            <KpiCard label={incluirNoEntregados ? 'Venta (todos)' : 'Venta entregada'} value={moneyC(k.venta)} sub={`${N.format(k.pedidos)} pedidos`} accent={ACCENTS.blue}
+              delta={cmp ? <Delta cur={k.venta} prev={kp!.venta} /> : undefined} />
+            <KpiCard label="Margen comercial" value={moneyC(k.margen_comercial)} sub={<><b>{pct(k.margen_comercial / k.venta)}</b> antes de bonif.</>} accent={ACCENTS.cyan}
+              delta={cmp ? <Delta cur={k.margen_comercial} prev={kp!.margen_comercial} /> : undefined} />
+            <KpiCard label="Bonificaciones" value={moneyC(k.bonif)} sub={<><b>{pct(k.bonif / k.venta)}</b> de la venta</>} accent={ACCENTS.amber}
+              delta={cmp ? <Delta cur={k.bonif} prev={kp!.bonif} invert /> : undefined} />
+            <KpiCard label="Margen neto" value={moneyC(k.margen_neto)} sub={<><b>{pct(k.margen_neto / k.venta)}</b> post bonif.</>} accent={ACCENTS.violet}
+              delta={cmp ? <Delta cur={k.margen_neto} prev={kp!.margen_neto} /> : undefined} />
+            <KpiCard label={`Comisión ${String(comPct).replace('.', ',')}%`} value={moneyC(derived.comision)} sub={`base ${comBase === 'nc' ? 'no cancelado' : 'entregado'}`} accent={ACCENTS.slate}
+              delta={cmp && derivedPrev ? <Delta cur={derived.comision} prev={derivedPrev.comision} invert /> : undefined} />
+            <KpiCard label="Mermas" value={moneyC(k.mermas)} sub="producto perdido" accent={ACCENTS.red}
+              delta={cmp ? <Delta cur={k.mermas} prev={kp!.mermas} invert /> : undefined} />
+            <KpiCard label="Contribución est." value={moneyC(derived.contrib)} sub={<><b>{pct(derived.contrib / k.venta)}</b> antes de gastos fijos</>} accent={ACCENTS.emerald}
+              delta={cmp && derivedPrev ? <Delta cur={derived.contrib} prev={derivedPrev.contrib} /> : undefined} />
+            <KpiCard label="Ticket promedio" value={moneyC(k.ticket)} sub={`${N.format(k.clientes)} clientes · ${N.format(k.clientes_nuevos)} nuevos`} accent={ACCENTS.blue}
+              delta={cmp ? <Delta cur={k.ticket} prev={kp!.ticket} /> : undefined} />
           </div>
 
           {/* Flag: productos sin costo */}

--- a/src/hooks/queries/useReporteGerencialQuery.ts
+++ b/src/hooks/queries/useReporteGerencialQuery.ts
@@ -84,6 +84,7 @@ export interface ReporteGerencial {
     desde: string
     hasta: string
     generado_at: string
+    incluye_no_entregados?: boolean
   }
   kpis: ReporteKpis
   mensual: ReporteMes[]
@@ -106,8 +107,8 @@ export interface AnalisisMensual {
 
 export const reporteGerencialKeys = {
   all: ['reporte-gerencial'] as const,
-  range: (suc: number | null, desde: string, hasta: string) =>
-    ['reporte-gerencial', suc, desde, hasta] as const,
+  range: (suc: number | null, desde: string, hasta: string, incluirNoEntregados: boolean) =>
+    ['reporte-gerencial', suc, desde, hasta, incluirNoEntregados] as const,
   analisis: (suc: number | null, periodo: string | null) =>
     ['reporte-gerencial-analisis', suc, periodo] as const,
 }
@@ -117,15 +118,17 @@ export function useReporteGerencialQuery(
   sucursalId: number | null,
   desde: string,
   hasta: string,
+  incluirNoEntregados = false,
   enabled = true,
 ) {
   return useQuery({
-    queryKey: reporteGerencialKeys.range(sucursalId, desde, hasta),
+    queryKey: reporteGerencialKeys.range(sucursalId, desde, hasta, incluirNoEntregados),
     queryFn: async (): Promise<ReporteGerencial> => {
       const { data, error } = await supabase.rpc('reporte_gerencial', {
         p_sucursal_id: sucursalId,
         p_desde: desde,
         p_hasta: hasta,
+        p_incluir_no_entregados: incluirNoEntregados,
       })
       if (error) throw new Error(error.message)
       return data as ReporteGerencial


### PR DESCRIPTION
## Qué cambia
Mejora el Reporte Gerencial para un uso más profesional tipo BI.

### Filtro de estado (entregadas vs todos)
- RPC `reporte_gerencial`: nuevo parámetro `p_incluir_no_entregados`.
  - `false` (default) → **ventas entregadas** (estado='entregado', como antes).
  - `true` → **todos los pedidos vigentes** (entregado + asignado/en camino + pendiente; excluye cancelados/anulados).
- Se DROPeó la firma de 3 args y se creó la de 4 con default → los callers de 3 args (ej. `/reporte-mensual`) siguen funcionando. `meta.incluye_no_entregados` expone el modo.
- Verificado en prod (Tucumán junio): entregadas $19,39M/570 vs todos $22,49M/637.

### Filtros de fecha tipo BI
- **Se sacó el trimestre hardcodeado como default**. Default ahora: **Este mes**.
- Presets: Este mes · Mes pasado · Trimestre en curso · Año en curso · meses anteriores · **Personalizado** (date pickers desde/hasta).
- Toggle **Entregadas / Todos** en la barra de filtros; el subtítulo muestra el modo activo y si el período está en curso (parcial).

## Archivos
- `migrations/106_…` (RPC, ya aplicada en prod vía MCP)
- `useReporteGerencialQuery.ts` (param + queryKey)
- `ReportesGerencialesContainer.tsx` (presets + rango custom + estado)
- `VistaReportesGerenciales.tsx` (toggle + date pickers + subtítulo)

## Verificación
- RPC probado en prod (3 modos, incl. compat 3-args).
- typecheck: sin errores nuevos en los archivos tocados (los de `react-markdown` son preexistentes y resuelven en CI). Pre-commit (vitest) verde.

🤖 Generated with [Claude Code](https://claude.com/claude-code)