### PR TITLE
feat(pedidos): acción masiva combinada "Entrega y Pago"

### DIFF
--- a/migrations/100_marcar_entrega_y_pago_masivo.sql
+++ b/migrations/100_marcar_entrega_y_pago_masivo.sql
@@ -1,0 +1,111 @@
+-- ============================================================================
+-- 100 · Acción masiva combinada: marcar_entrega_y_pago_masivo()
+-- ============================================================================
+-- Equivalente masivo del botón individual "entregar y pagar" (handleEntregarConPago).
+-- Hoy las acciones masivas separan "Entregas Masivas" (marcar_entregas_masivo)
+-- y "Pagos Masivos" (marcar_pagos_masivo). Esta RPC las combina en UN SOLO paso
+-- atómico: entrega + cobro de los pedidos seleccionados, eligiendo transportista
+-- + una forma de pago.
+--
+-- Es la unión literal de las dos funciones probadas en prod, con un único UPDATE
+-- (los triggers de pedidos se disparan una sola vez). NO toca a las dos RPC
+-- existentes.
+--
+-- Semántica:
+--   1) Por cada pedido NO pagado del lote: inserta una fila real en `pagos` por
+--      el saldo pendiente (total - monto_pagado) con la forma de pago elegida.
+--   2) Un solo UPDATE deja estado='entregado', fecha_entrega (mediodía AR),
+--      transportista_id, monto_pagado=total y forma_pago.
+--
+-- Autorización: es_encargado_o_admin(). Para encargado, mismo gate de rendición
+-- que marcar_pagos_masivo (fecha = hoy y rendición no cerrada), porque registra
+-- pagos.
+--
+-- NOTA: defs basadas en la versión EN VIVO de prod (no en el repo).
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION public.marcar_entrega_y_pago_masivo(
+  p_pedido_ids bigint[],
+  p_transportista_id uuid,
+  p_forma_pago text,
+  p_fecha date DEFAULT CURRENT_DATE
+)
+RETURNS integer
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $function$
+DECLARE
+  v_sucursal_id BIGINT;
+  v_affected INTEGER;
+  v_pedido RECORD;
+  v_rol TEXT;
+  v_fecha_ts TIMESTAMPTZ;
+BEGIN
+  v_sucursal_id := current_sucursal_id();
+  IF v_sucursal_id IS NULL THEN
+    RAISE EXCEPTION 'No hay sucursal activa' USING ERRCODE = '42501';
+  END IF;
+
+  IF NOT es_encargado_o_admin() THEN
+    RAISE EXCEPTION 'Solo encargado o admin pueden marcar entrega y pago masivos'
+      USING ERRCODE = '42501';
+  END IF;
+
+  -- Mismo gate de rendición que marcar_pagos_masivo (esta RPC registra pagos)
+  SELECT rol INTO v_rol FROM perfiles WHERE id = auth.uid();
+  IF v_rol = 'encargado' THEN
+    IF p_fecha <> CURRENT_DATE THEN
+      RAISE EXCEPTION 'Encargado solo puede registrar pagos con fecha de hoy'
+        USING ERRCODE = '42501';
+    END IF;
+    IF public.rendicion_dia_cerrada(p_fecha, v_sucursal_id) THEN
+      RAISE EXCEPTION 'Rendicion ya cerrada para esta fecha. Pedi a un admin.'
+        USING ERRCODE = '42501';
+    END IF;
+  END IF;
+
+  IF p_pedido_ids IS NULL OR array_length(p_pedido_ids, 1) IS NULL THEN
+    RETURN 0;
+  END IF;
+
+  v_fecha_ts := (p_fecha::text || ' 12:00:00 America/Argentina/Buenos_Aires')::timestamptz;
+
+  -- 1) Registrar pago por el saldo pendiente (solo pedidos NO pagados)
+  FOR v_pedido IN
+    SELECT id, cliente_id, total, COALESCE(monto_pagado, 0) AS ya_pagado
+    FROM pedidos
+    WHERE id = ANY(p_pedido_ids)
+      AND sucursal_id = v_sucursal_id
+      AND COALESCE(estado_pago, 'pendiente') <> 'pagado'
+      AND total > COALESCE(monto_pagado, 0)
+  LOOP
+    INSERT INTO pagos (cliente_id, pedido_id, monto, forma_pago, fecha, usuario_id, sucursal_id)
+    VALUES (
+      v_pedido.cliente_id,
+      v_pedido.id,
+      v_pedido.total - v_pedido.ya_pagado,
+      p_forma_pago,
+      p_fecha,
+      auth.uid(),
+      v_sucursal_id
+    );
+  END LOOP;
+
+  -- 2) Entregar + saldar en un solo UPDATE (transportista_id SE asigna)
+  UPDATE pedidos
+     SET estado = 'entregado',
+         fecha_entrega = v_fecha_ts,
+         transportista_id = p_transportista_id,
+         monto_pagado = total,
+         forma_pago = p_forma_pago,
+         updated_at = now()
+   WHERE id = ANY(p_pedido_ids)
+     AND sucursal_id = v_sucursal_id;
+
+  GET DIAGNOSTICS v_affected = ROW_COUNT;
+  RETURN v_affected;
+END;
+$function$;
+
+GRANT EXECUTE ON FUNCTION public.marcar_entrega_y_pago_masivo(bigint[], uuid, text, date) TO authenticated;

--- a/src/components/containers/PedidosContainer.tsx
+++ b/src/components/containers/PedidosContainer.tsx
@@ -24,6 +24,7 @@ import {
   useCancelarPedidoMutation,
   useCambiarClientePedidoMutation,
   usePagosMasivosMutation,
+  useEntregaYPagoMasivosMutation,
   usePedidosAsignadosQuery,
   useClientesQuery,
   useProductosQuery,
@@ -70,6 +71,7 @@ const ModalEntregaConSalvedad = lazy(() => import('../modals/ModalEntregaConSalv
 const ModalEntregasMasivas = lazy(() => import('../modals/ModalEntregasMasivas'))
 const ModalCancelarPedido = lazy(() => import('../modals/ModalCancelarPedido'))
 const ModalPagosMasivos = lazy(() => import('../modals/ModalPagosMasivos'))
+const ModalEntregaYPagoMasivos = lazy(() => import('../modals/ModalEntregaYPagoMasivos'))
 const ModalMarcarVisita = lazy(() => import('../modals/ModalMarcarVisita'))
 const ModalVisitasHoy = lazy(() => import('../modals/ModalVisitasHoy'))
 const ModalMotivoSinGps = lazy(() => import('../modals/ModalMotivoSinGps'))
@@ -155,6 +157,7 @@ export default function PedidosContainer(): React.ReactElement {
   const cancelarPedidoMut = useCancelarPedidoMutation()
   const cambiarClientePedidoMut = useCambiarClientePedidoMutation()
   const pagosMasivos = usePagosMasivosMutation()
+  const entregaYPagoMasivos = useEntregaYPagoMasivosMutation()
   const crearClienteMut = useCrearClienteMutation()
   const crearCambioEnRutaMut = useCrearPedidoCambioEnRutaMutation()
   const aplicarCambioParadaMut = useAplicarCambioParadaMutation()
@@ -196,6 +199,7 @@ export default function PedidosContainer(): React.ReactElement {
   const [modalEntregasMasivasOpen, setModalEntregasMasivasOpen] = useState(false)
   const [modalCancelarOpen, setModalCancelarOpen] = useState(false)
   const [modalPagosMasivosOpen, setModalPagosMasivosOpen] = useState(false)
+  const [modalEntregaYPagoMasivosOpen, setModalEntregaYPagoMasivosOpen] = useState(false)
   const [modalNotasOpen, setModalNotasOpen] = useState(false)
   const [modalPagoPedidoOpen, setModalPagoPedidoOpen] = useState(false)
   const [modalMarcarVisitaOpen, setModalMarcarVisitaOpen] = useState(false)
@@ -243,6 +247,7 @@ export default function PedidosContainer(): React.ReactElement {
     setModalEntregasMasivasOpen(false)
     setModalCancelarOpen(false)
     setModalPagosMasivosOpen(false)
+    setModalEntregaYPagoMasivosOpen(false)
     setModalNotasOpen(false)
     setModalPagoPedidoOpen(false)
     setModalMarcarVisitaOpen(false)
@@ -531,6 +536,16 @@ export default function PedidosContainer(): React.ReactElement {
     } catch (e) { notify.error('Error en pagos masivos: ' + (e as Error).message) }
     setGuardando(false)
   }, [pagosMasivos, notify])
+
+  const handleEntregaYPagoMasivos = useCallback(async (transportistaId: string, formaPago: string, pedidoIds: string[], fecha: string) => {
+    setGuardando(true)
+    try {
+      await entregaYPagoMasivos.mutateAsync({ pedidoIds, transportistaId, formaPago, fecha })
+      setModalEntregaYPagoMasivosOpen(false)
+      notify.success(`${pedidoIds.length} pedido${pedidoIds.length !== 1 ? 's' : ''} entregado${pedidoIds.length !== 1 ? 's' : ''} y pagado${pedidoIds.length !== 1 ? 's' : ''}`)
+    } catch (e) { notify.error('Error en entrega y pago masivos: ' + (e as Error).message) }
+    setGuardando(false)
+  }, [entregaYPagoMasivos, notify])
 
   // Fetch todos los pedidos con filtros actuales (sin paginación) para export
   const fetchAllFilteredPedidos = useCallback(async (): Promise<PedidoDB[]> => {
@@ -1450,6 +1465,7 @@ export default function PedidosContainer(): React.ReactElement {
           onCancelarPedido={handleCancelarPedido}
           onEntregasMasivas={() => setModalEntregasMasivasOpen(true)}
           onPagosMasivos={() => setModalPagosMasivosOpen(true)}
+          onEntregaYPagoMasivos={() => setModalEntregaYPagoMasivosOpen(true)}
           onMarcarVisita={() => setModalMarcarVisitaOpen(true)}
           onVerVisitasHoy={() => setModalVisitasHoyOpen(true)}
           onRegistrarSalvedad={handleRegistrarSalvedadSingle}
@@ -1733,6 +1749,20 @@ export default function PedidosContainer(): React.ReactElement {
           <ModalPagosMasivos
             onConfirm={handlePagosMasivos}
             onClose={() => setModalPagosMasivosOpen(false)}
+            guardando={guardando}
+            isEncargado={isEncargado}
+            isAdmin={isAdmin}
+          />
+        </Suspense>
+      )}
+
+      {/* Modal Entrega y Pago Masivos (combinado) */}
+      {modalEntregaYPagoMasivosOpen && (
+        <Suspense fallback={null}>
+          <ModalEntregaYPagoMasivos
+            transportistas={transportistas}
+            onConfirm={handleEntregaYPagoMasivos}
+            onClose={() => setModalEntregaYPagoMasivosOpen(false)}
             guardando={guardando}
             isEncargado={isEncargado}
             isAdmin={isAdmin}

--- a/src/components/modals/ModalEntregaYPagoMasivos.tsx
+++ b/src/components/modals/ModalEntregaYPagoMasivos.tsx
@@ -1,0 +1,304 @@
+import { useState, useMemo, memo } from 'react'
+import { Loader2, Search, Calendar, AlertTriangle, Truck } from 'lucide-react'
+import ModalBase from './ModalBase'
+import { usePedidosNoEntregadosQuery, useRendicionCerradaQuery } from '../../hooks/queries'
+import {
+  getEstadoColor, getEstadoLabel,
+  getEstadoPagoColor, getEstadoPagoLabel,
+  formatPrecio, fechaLocalISO,
+} from '../../utils/formatters'
+import { FORMAS_PAGO_SELECCIONABLES } from '../../constants/formasPago'
+import type { PerfilDB } from '../../types'
+
+export interface ModalEntregaYPagoMasivosProps {
+  transportistas: PerfilDB[]
+  /**
+   * Callback de confirmación.
+   * @param transportistaId - ID del transportista a asignar a la entrega
+   * @param formaPago - Forma de pago a registrar
+   * @param pedidoIds - IDs de los pedidos seleccionados
+   * @param fecha - Fecha contable de entrega y pago (YYYY-MM-DD)
+   */
+  onConfirm: (transportistaId: string, formaPago: string, pedidoIds: string[], fecha: string) => Promise<void>
+  onClose: () => void
+  guardando: boolean
+  /** Si el caller es encargado (no admin): fecha bloqueada a hoy y check de rendicion. */
+  isEncargado?: boolean
+  isAdmin?: boolean
+}
+
+const ModalEntregaYPagoMasivos = memo(function ModalEntregaYPagoMasivos({
+  transportistas,
+  onConfirm,
+  onClose,
+  guardando,
+  isEncargado = false,
+  isAdmin = false,
+}: ModalEntregaYPagoMasivosProps) {
+  const hoy = fechaLocalISO()
+  const fechaBloqueada = isEncargado && !isAdmin
+  const [selectedTransportista, setSelectedTransportista] = useState('')
+  const [selectedFormaPago, setSelectedFormaPago] = useState('')
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set())
+  const [busqueda, setBusqueda] = useState('')
+  const [fechaDesde, setFechaDesde] = useState('')
+  const [fechaHasta, setFechaHasta] = useState('')
+  const [fecha, setFecha] = useState<string>(hoy)
+
+  // Universo: pedidos NO entregados (la entrega es la acción que habilita el combo).
+  const { data: pedidos = [], isLoading } = usePedidosNoEntregadosQuery(true)
+  const { data: rendicionCerrada = false } = useRendicionCerradaQuery(fecha, fechaBloqueada)
+
+  const pedidosFiltrados = useMemo(() => {
+    let resultado = pedidos
+    if (fechaDesde) resultado = resultado.filter(p => (p.fecha || p.created_at?.split('T')[0] || '') >= fechaDesde)
+    if (fechaHasta) resultado = resultado.filter(p => (p.fecha || p.created_at?.split('T')[0] || '') <= fechaHasta)
+    if (busqueda.trim()) {
+      const term = busqueda.toLowerCase()
+      resultado = resultado.filter(p =>
+        p.cliente?.nombre_fantasia?.toLowerCase().includes(term) ||
+        p.cliente?.direccion?.toLowerCase().includes(term) ||
+        String(p.id).includes(term)
+      )
+    }
+    return resultado
+  }, [pedidos, busqueda, fechaDesde, fechaHasta])
+
+  const toggleSelect = (id: string) => {
+    setSelectedIds(prev => {
+      const next = new Set(prev)
+      if (next.has(id)) next.delete(id)
+      else next.add(id)
+      return next
+    })
+  }
+
+  const toggleAll = () => {
+    if (selectedIds.size === pedidosFiltrados.length) {
+      setSelectedIds(new Set())
+    } else {
+      setSelectedIds(new Set(pedidosFiltrados.map(p => p.id)))
+    }
+  }
+
+  const allSelected = pedidosFiltrados.length > 0 && selectedIds.size === pedidosFiltrados.length
+  const bloqueadoPorRendicion = fechaBloqueada && rendicionCerrada
+  const canConfirm =
+    !!selectedTransportista &&
+    !!selectedFormaPago &&
+    selectedIds.size > 0 &&
+    !guardando &&
+    !!fecha &&
+    !bloqueadoPorRendicion
+
+  // Total a cobrar = suma del saldo pendiente de los pedidos seleccionados
+  const totalACobrar = useMemo(() => {
+    return pedidos
+      .filter(p => selectedIds.has(p.id))
+      .reduce((sum, p) => sum + Math.max(0, (p.total || 0) - (p.monto_pagado ?? 0)), 0)
+  }, [pedidos, selectedIds])
+
+  return (
+    <ModalBase title="Entrega y Pago Masivos" onClose={onClose} maxWidth="max-w-3xl">
+      <div className="p-4 space-y-4">
+        <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
+          {/* Selector de transportista */}
+          <div>
+            <label className="block text-sm font-medium mb-1 text-gray-700 dark:text-gray-300 flex items-center gap-1">
+              <Truck className="w-4 h-4" />
+              Transportista
+            </label>
+            <select
+              value={selectedTransportista}
+              onChange={e => setSelectedTransportista(e.target.value)}
+              className="w-full px-3 py-2 border rounded-lg dark:bg-gray-700 dark:border-gray-600 dark:text-white"
+            >
+              <option value="">Seleccionar transportista...</option>
+              {transportistas.map(t => (
+                <option key={t.id} value={t.id}>{t.nombre}</option>
+              ))}
+            </select>
+          </div>
+
+          {/* Selector de forma de pago */}
+          <div>
+            <label className="block text-sm font-medium mb-1 text-gray-700 dark:text-gray-300">
+              Forma de pago
+            </label>
+            <select
+              value={selectedFormaPago}
+              onChange={e => setSelectedFormaPago(e.target.value)}
+              className="w-full px-3 py-2 border rounded-lg dark:bg-gray-700 dark:border-gray-600 dark:text-white"
+            >
+              <option value="">Seleccionar forma de pago...</option>
+              {FORMAS_PAGO_SELECCIONABLES.map(fp => (
+                <option key={fp.value} value={fp.value}>{fp.label}</option>
+              ))}
+            </select>
+          </div>
+
+          {/* Fecha contable de entrega y pago */}
+          <div>
+            <label className="block text-sm font-medium mb-1 text-gray-700 dark:text-gray-300 flex items-center gap-1">
+              <Calendar className="w-4 h-4" />
+              Fecha
+            </label>
+            <input
+              type="date"
+              value={fecha}
+              onChange={e => setFecha(e.target.value)}
+              disabled={fechaBloqueada}
+              min={fechaBloqueada ? hoy : undefined}
+              max={fechaBloqueada ? hoy : undefined}
+              className="w-full px-3 py-2 border rounded-lg dark:bg-gray-700 dark:border-gray-600 dark:text-white disabled:bg-gray-100 dark:disabled:bg-gray-800 disabled:cursor-not-allowed"
+            />
+            <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
+              {fechaBloqueada
+                ? 'Como encargado solo podés registrar con fecha de hoy. Si necesitás otra fecha pedíselo a un admin.'
+                : 'Se aplica a la entrega y al pago. Por defecto hoy.'}
+            </p>
+          </div>
+        </div>
+
+        {bloqueadoPorRendicion && (
+          <div className="flex items-start gap-2 p-3 rounded-lg border border-amber-300 bg-amber-50 dark:bg-amber-900/20 dark:border-amber-700">
+            <AlertTriangle className="w-5 h-5 text-amber-600 dark:text-amber-400 flex-shrink-0 mt-0.5" />
+            <div className="text-sm text-amber-900 dark:text-amber-200">
+              <p className="font-medium">Rendición cerrada</p>
+              <p>La rendición de hoy ya fue confirmada. No podés registrar más pagos a esta fecha. Pedile a un admin si necesitás corregir algo.</p>
+            </div>
+          </div>
+        )}
+
+        {/* Filtro por fechas */}
+        <div className="grid grid-cols-2 gap-3">
+          <div>
+            <label className="block text-xs font-medium text-gray-500 dark:text-gray-400 mb-1">Desde</label>
+            <input type="date" value={fechaDesde} onChange={e => setFechaDesde(e.target.value)}
+              className="w-full px-3 py-2 text-sm border rounded-lg dark:bg-gray-700 dark:border-gray-600 dark:text-white" />
+          </div>
+          <div>
+            <label className="block text-xs font-medium text-gray-500 dark:text-gray-400 mb-1">Hasta</label>
+            <input type="date" value={fechaHasta} onChange={e => setFechaHasta(e.target.value)}
+              className="w-full px-3 py-2 text-sm border rounded-lg dark:bg-gray-700 dark:border-gray-600 dark:text-white" />
+          </div>
+        </div>
+
+        {/* Busqueda */}
+        <div className="relative">
+          <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400" />
+          <input
+            type="text"
+            placeholder="Buscar por cliente, direccion o #pedido..."
+            value={busqueda}
+            onChange={e => setBusqueda(e.target.value)}
+            className="w-full pl-9 pr-3 py-2 border rounded-lg dark:bg-gray-700 dark:border-gray-600 dark:text-white"
+          />
+        </div>
+
+        {/* Seleccionar todos */}
+        {pedidosFiltrados.length > 0 && (
+          <label className="flex items-center space-x-2 cursor-pointer">
+            <input
+              type="checkbox"
+              checked={allSelected}
+              onChange={toggleAll}
+              className="w-4 h-4 rounded border-gray-300"
+            />
+            <span className="text-sm font-medium text-gray-700 dark:text-gray-300">
+              Seleccionar todos ({pedidosFiltrados.length})
+            </span>
+          </label>
+        )}
+
+        {/* Lista de pedidos */}
+        <div className="max-h-96 overflow-y-auto border rounded-lg dark:border-gray-600">
+          {isLoading ? (
+            <div className="flex items-center justify-center py-8">
+              <Loader2 className="w-6 h-6 animate-spin text-blue-600" />
+              <span className="ml-2 text-gray-500">Cargando pedidos...</span>
+            </div>
+          ) : pedidosFiltrados.length === 0 ? (
+            <div className="text-center py-8 text-gray-500">
+              No hay pedidos disponibles para entregar
+            </div>
+          ) : (
+            pedidosFiltrados.map(pedido => {
+              const saldo = Math.max(0, (pedido.total || 0) - (pedido.monto_pagado ?? 0))
+              return (
+                <label
+                  key={pedido.id}
+                  className={`flex items-center p-3 border-b last:border-b-0 dark:border-gray-600 cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-700/50 transition-colors ${
+                    selectedIds.has(pedido.id) ? 'bg-indigo-50 dark:bg-indigo-900/20' : ''
+                  }`}
+                >
+                  <input
+                    type="checkbox"
+                    checked={selectedIds.has(pedido.id)}
+                    onChange={() => toggleSelect(pedido.id)}
+                    className="w-4 h-4 rounded border-gray-300 mr-3 flex-shrink-0"
+                  />
+                  <div className="flex-1 min-w-0">
+                    <div className="flex items-center gap-2 flex-wrap">
+                      <span className="text-xs text-gray-400">#{pedido.id}</span>
+                      <span className={`px-2 py-0.5 rounded-full text-xs font-medium ${getEstadoColor(pedido.estado)}`}>
+                        {getEstadoLabel(pedido.estado)}
+                      </span>
+                      <span className={`px-2 py-0.5 rounded-full text-xs font-medium ${getEstadoPagoColor(pedido.estado_pago)}`}>
+                        {getEstadoPagoLabel(pedido.estado_pago)}
+                      </span>
+                    </div>
+                    <p className="font-medium text-gray-800 dark:text-white truncate">
+                      {pedido.cliente?.nombre_fantasia || 'Sin cliente'}
+                    </p>
+                    <p className="text-xs text-gray-500 truncate">
+                      {pedido.cliente?.direccion}
+                    </p>
+                  </div>
+                  <div className="text-right ml-3 flex-shrink-0">
+                    <p className="font-bold text-blue-600">{formatPrecio(pedido.total)}</p>
+                    {saldo > 0 ? (
+                      <p className="text-xs text-amber-600">A cobrar: {formatPrecio(saldo)}</p>
+                    ) : (
+                      <p className="text-xs text-green-600">Ya pagado</p>
+                    )}
+                  </div>
+                </label>
+              )
+            })
+          )}
+        </div>
+      </div>
+
+      {/* Footer */}
+      <div className="flex items-center justify-between p-4 border-t bg-gray-50 dark:bg-gray-800 dark:border-gray-700">
+        <div className="text-sm text-gray-600 dark:text-gray-400">
+          <span>{selectedIds.size} pedido{selectedIds.size !== 1 ? 's' : ''} seleccionado{selectedIds.size !== 1 ? 's' : ''}</span>
+          {selectedIds.size > 0 && (
+            <span className="ml-2 font-semibold text-green-600">
+              A cobrar: {formatPrecio(totalACobrar)}
+            </span>
+          )}
+        </div>
+        <div className="flex space-x-3">
+          <button
+            onClick={onClose}
+            className="px-4 py-2 text-gray-700 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-600 rounded-lg"
+          >
+            Cancelar
+          </button>
+          <button
+            onClick={() => canConfirm && onConfirm(selectedTransportista, selectedFormaPago, Array.from(selectedIds), fecha)}
+            disabled={!canConfirm}
+            className="px-4 py-2 bg-indigo-600 text-white rounded-lg hover:bg-indigo-700 disabled:opacity-50 disabled:cursor-not-allowed flex items-center"
+          >
+            {guardando && <Loader2 className="w-4 h-4 mr-2 animate-spin" />}
+            Entregar y registrar pago
+          </button>
+        </div>
+      </div>
+    </ModalBase>
+  )
+})
+
+export default ModalEntregaYPagoMasivos

--- a/src/components/pedidos/PedidoToolbar.tsx
+++ b/src/components/pedidos/PedidoToolbar.tsx
@@ -23,7 +23,7 @@
 import React from 'react';
 import {
   Plus, Route, FileDown, PackageCheck, Banknote, ChevronDown,
-  MapPin, History, Boxes, Download, ArrowLeftRight, type LucideIcon,
+  MapPin, History, Boxes, Download, ArrowLeftRight, HandCoins, type LucideIcon,
 } from 'lucide-react';
 import {
   DropdownMenu, DropdownMenuTrigger, DropdownMenuContent,
@@ -49,6 +49,7 @@ export interface PedidoToolbarProps {
   onExportarExcel: (modo: 'pagina' | 'filtro') => void;
   onEntregasMasivas?: () => void;
   onPagosMasivos?: () => void;
+  onEntregaYPagoMasivos?: () => void;
   onMarcarVisita?: () => void;
   onVerVisitasHoy?: () => void;
 }
@@ -185,6 +186,7 @@ export default function PedidoToolbar({
   onExportarExcel,
   onEntregasMasivas,
   onPagosMasivos,
+  onEntregaYPagoMasivos,
   onMarcarVisita,
   onVerVisitasHoy,
 }: PedidoToolbarProps): React.ReactElement {
@@ -194,7 +196,7 @@ export default function PedidoToolbar({
 
   // ¿Hay al menos una acción masiva habilitada? (para mostrar el dropdown)
   const hasMasivas = Boolean(
-    onPagosMasivos || onEntregasMasivas,
+    onPagosMasivos || onEntregasMasivas || onEntregaYPagoMasivos,
   );
 
   // Dropdowns "Acciones masivas" y "Exportaciones" — reusados en ambos layouts.
@@ -215,6 +217,12 @@ export default function PedidoToolbar({
         <DropdownMenuItem onSelect={onEntregasMasivas}>
           <PackageCheck className="w-4 h-4 text-teal-600" />
           <span>Entregas Masivas</span>
+        </DropdownMenuItem>
+      )}
+      {onEntregaYPagoMasivos && (
+        <DropdownMenuItem onSelect={onEntregaYPagoMasivos}>
+          <HandCoins className="w-4 h-4 text-indigo-600" />
+          <span>Entrega y Pago</span>
         </DropdownMenuItem>
       )}
     </ToolbarDropdown>

--- a/src/components/vistas/VistaPedidos.tsx
+++ b/src/components/vistas/VistaPedidos.tsx
@@ -69,6 +69,7 @@ export interface VistaPedidosProps {
   onCancelarPedido?: (pedido: PedidoDB) => void;
   onEntregasMasivas?: () => void;
   onPagosMasivos?: () => void;
+  onEntregaYPagoMasivos?: () => void;
   /** Abre el modal para que el preventista marque una visita a un cliente. */
   onMarcarVisita?: () => void;
   /** Abre el modal con el timeline de visitas del día del preventista logueado. */
@@ -140,6 +141,7 @@ export default function VistaPedidos({
   onCancelarPedido,
   onEntregasMasivas,
   onPagosMasivos,
+  onEntregaYPagoMasivos,
   onMarcarVisita,
   onVerVisitasHoy,
   onRegistrarSalvedad,
@@ -182,6 +184,7 @@ export default function VistaPedidos({
             onExportarExcel={onExportarExcel}
             onEntregasMasivas={onEntregasMasivas}
             onPagosMasivos={onPagosMasivos}
+            onEntregaYPagoMasivos={onEntregaYPagoMasivos}
             onMarcarVisita={onMarcarVisita}
             onVerVisitasHoy={onVerVisitasHoy}
           />

--- a/src/hooks/queries/index.ts
+++ b/src/hooks/queries/index.ts
@@ -64,6 +64,7 @@ export {
   useCambiarClientePedidoMutation,
   usePedidosNoPagadosQuery,
   usePagosMasivosMutation,
+  useEntregaYPagoMasivosMutation,
 } from './usePedidosQuery'
 export type { PaginatedResult } from './usePedidosQuery'
 export { usePedidoStatsQuery, EMPTY_PEDIDO_STATS_SUMMARY } from './usePedidoStatsQuery'

--- a/src/hooks/queries/usePedidosQuery.ts
+++ b/src/hooks/queries/usePedidosQuery.ts
@@ -997,3 +997,62 @@ export function usePagosMasivosMutation() {
     },
   })
 }
+
+// =========================================================================
+// Entrega y Pago Masivos (combinado: entregar + cobrar en un solo paso)
+// =========================================================================
+
+async function marcarEntregaYPagoMasivo(
+  pedidoIds: string[],
+  transportistaId: string,
+  formaPago: string,
+  fecha?: string | null
+): Promise<void> {
+  // RPC combinada: entrega (asigna transportista + fecha) y registra el pago
+  // por el saldo pendiente de cada pedido, en una transacción atómica.
+  const rpcArgs: Record<string, unknown> = {
+    p_pedido_ids: pedidoIds.map(id => Number(id)),
+    p_transportista_id: transportistaId,
+    p_forma_pago: formaPago,
+  }
+  if (fecha) rpcArgs.p_fecha = fecha
+
+  const { error } = await supabase.rpc('marcar_entrega_y_pago_masivo', rpcArgs)
+  if (error) throw error
+
+  // Historial best-effort (no bloquea)
+  const fechaHistorial = fecha ? `${fecha}T12:00:00-03:00` : new Date().toISOString()
+  const historialEntries = pedidoIds.map(pedidoId => ({
+    pedido_id: pedidoId,
+    accion: 'entregado',
+    descripcion: `Entrega+pago masivo - Transportista: ${transportistaId} - Forma: ${formaPago}`,
+    fecha: fechaHistorial,
+  }))
+
+  await supabase.from('pedido_historial').insert(historialEntries).then(() => {})
+}
+
+/**
+ * Hook para entregar + cobrar multiples pedidos en un solo paso (con fecha opcional).
+ * Invalida pedidos, clientes (cambia el saldo) y recorridos (la entrega puede
+ * cerrar paradas de una ruta activa).
+ */
+export function useEntregaYPagoMasivosMutation() {
+  const queryClient = useQueryClient()
+  const { currentSucursalId } = useSucursal()
+
+  return useMutation({
+    mutationFn: ({ pedidoIds, transportistaId, formaPago, fecha }: {
+      pedidoIds: string[];
+      transportistaId: string;
+      formaPago: string;
+      fecha?: string | null
+    }) => marcarEntregaYPagoMasivo(pedidoIds, transportistaId, formaPago, fecha),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: pedidosKeys.all(currentSucursalId) })
+      queryClient.invalidateQueries({ queryKey: clientesKeys.all(currentSucursalId) })
+      queryClient.invalidateQueries({ queryKey: ['recorridos'] })
+      queryClient.invalidateQueries({ queryKey: ['recorridos-hoja-ruta'] })
+    },
+  })
+}


### PR DESCRIPTION
## Qué

Agrega una **tercera acción masiva** en `/pedidos` → "Acciones masivas": **"Entrega y Pago"**, que entrega los pedidos seleccionados (asignando transportista) y registra el cobro con una forma de pago elegida, **en un solo paso**. Es el equivalente masivo del botón individual "entregar y pagar".

No modifica las acciones existentes "Entregas Masivas" ni "Pagos Masivos".

## Cómo funciona

- Modal con selector de **transportista + forma de pago + fecha**; lista todos los pedidos **no entregados** con su saldo a cobrar, checkboxes y "seleccionar todos".
- Al confirmar marca `entregado`, asigna el transportista e **inserta el pago real** por el saldo pendiente de cada pedido (los ya pagados solo se entregan), dejando `monto_pagado = total`.
- Mismo gate de rendición que "Pagos Masivos" para encargados (fecha de hoy + rendición no cerrada).

## Backend

- RPC `marcar_entrega_y_pago_masivo(p_pedido_ids, p_transportista_id, p_forma_pago, p_fecha)` — unión atómica de `marcar_entregas_masivo` + `marcar_pagos_masivo` (un solo `UPDATE`; los triggers de `pedidos` se disparan una sola vez). No toca el `transportista_id` para reasignarlo: lo setea como parte de la entrega.
- **Migración `100_marcar_entrega_y_pago_masivo.sql` ya aplicada a producción.**

## Frontend

- Nuevo `ModalEntregaYPagoMasivos.tsx` (clon de `ModalPagosMasivos` + selector de transportista de `ModalEntregasMasivas`, data de `usePedidosNoEntregadosQuery`).
- `useEntregaYPagoMasivosMutation` (invalida pedidos + clientes + recorridos).
- Wiring en `PedidoToolbar` (item del dropdown con icono HandCoins), `VistaPedidos`, `PedidosContainer`.

## Verificación

- ✅ `tsc --noEmit` y ESLint limpios en los archivos tocados.
- ✅ Suite completa (741 tests) en verde en el pre-commit.
- ✅ RPC probado end-to-end en prod con `BEGIN…ROLLBACK` simulando sesión admin: el pedido quedó `entregado` + `pagado`, `monto_pagado=total`, transportista asignado y se creó la fila en `pagos`; el `ROLLBACK` dejó prod intacto.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
