### PR TITLE
feat(reportes): panel BI Fase 1 — alertas + resumen ejecutivo + 1 sola llamada

### DIFF
--- a/migrations/107_reporte_gerencial_alertas_comparativo.sql
+++ b/migrations/107_reporte_gerencial_alertas_comparativo.sql
@@ -1,0 +1,267 @@
+-- ============================================================================
+-- 107 · reporte_gerencial: comparativo plegado + alertas (BI Fase 1)
+-- ============================================================================
+-- Agrega 5º parámetro p_comparar. Cuando true, la función:
+--   * calcula el período anterior (misma duración, justo antes) llamándose a sí
+--     misma con p_comparar=false (DRY: reusa toda la agregación) y expone sus
+--     KPIs en `comparativo`. ⇒ reemplaza la 2ª llamada que hacía el front.
+--   * arma `alertas[]` (qué requiere atención) de data ya agregada + 2 queries
+--     baratas (clientes inactivos, cobranza vencida).
+-- Single function de 5 args (DROP de la de 4) para evitar overloads ambiguos;
+-- los callers de 3/4 args siguen andando por los defaults.
+-- ============================================================================
+
+DROP FUNCTION IF EXISTS public.reporte_gerencial(bigint, date, date, boolean);
+
+CREATE OR REPLACE FUNCTION public.reporte_gerencial(
+  p_sucursal_id bigint,
+  p_desde date,
+  p_hasta date,
+  p_incluir_no_entregados boolean DEFAULT false,
+  p_comparar boolean DEFAULT false
+)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ STABLE SECURITY DEFINER
+ SET search_path TO 'public'
+AS $function$
+DECLARE
+  v_sucursales bigint[]; v_asignadas bigint[]; v_nombre text; v_result jsonb;
+  v_es_servicio boolean := (auth.uid() IS NULL);
+  v_estados text[] := CASE WHEN p_incluir_no_entregados
+                           THEN ARRAY['entregado','asignado','pendiente']
+                           ELSE ARRAY['entregado'] END;
+  v_dias int := (p_hasta - p_desde) + 1;
+  v_prev_hasta date := p_desde - 1;
+  v_prev_desde date := (p_desde - 1) - ((p_hasta - p_desde));
+  v_comparativo jsonb := NULL;
+  v_prev jsonb;
+  v_alertas jsonb := '[]'::jsonb;
+  v_cat_neg int;
+  v_cli_inact int;
+  v_cob_venc numeric;
+  v_cob_venc_cli int;
+  v_venta numeric;
+  v_prev_venta numeric;
+  v_mermas numeric;
+  v_prev_mermas numeric;
+BEGIN
+  IF NOT v_es_servicio THEN
+    IF NOT EXISTS (SELECT 1 FROM perfiles WHERE id = auth.uid() AND rol = 'admin') THEN
+      RAISE EXCEPTION 'Acceso denegado: se requiere rol admin'; END IF;
+    SELECT array_agg(sucursal_id) INTO v_asignadas FROM usuario_sucursales WHERE usuario_id = auth.uid();
+    IF v_asignadas IS NULL THEN RAISE EXCEPTION 'Acceso denegado: el usuario no tiene sucursales asignadas'; END IF;
+  END IF;
+  IF p_sucursal_id IS NULL THEN
+    SELECT array_agg(id) INTO v_sucursales FROM sucursales WHERE activa;
+    IF NOT v_es_servicio THEN
+      SELECT array_agg(s) INTO v_sucursales FROM unnest(v_sucursales) AS s WHERE s = ANY(v_asignadas); END IF;
+    v_nombre := 'Red (consolidado)';
+  ELSE
+    IF NOT v_es_servicio AND NOT (p_sucursal_id = ANY(v_asignadas)) THEN
+      RAISE EXCEPTION 'Acceso denegado: la sucursal % no está asignada al usuario', p_sucursal_id; END IF;
+    v_sucursales := ARRAY[p_sucursal_id];
+    SELECT nombre INTO v_nombre FROM sucursales WHERE id = p_sucursal_id;
+  END IF;
+  IF v_sucursales IS NULL OR array_length(v_sucursales,1) IS NULL THEN
+    RAISE EXCEPTION 'Acceso denegado: sin sucursales disponibles para el usuario'; END IF;
+
+  WITH
+  ped AS (
+    SELECT id, cliente_id, usuario_id, total, fecha, forma_pago, estado_pago
+    FROM pedidos WHERE estado = ANY(v_estados) AND canal='app'
+      AND fecha BETWEEN p_desde AND p_hasta AND sucursal_id = ANY(v_sucursales)
+  ),
+  it AS (
+    SELECT p.id AS pedido_id, p.usuario_id, p.fecha,
+           pi.cantidad, pi.subtotal, pi.es_bonificacion,
+           COALESCE(pi.costo_unitario_al_crear, prod.costo_sin_iva*(1+COALESCE(prod.impuestos_internos,0)/100)) AS costo_unit,
+           prod.nombre AS prod_nombre,
+           COALESCE(NULLIF(prod.categoria,''),'(sin categoría)') AS categoria,
+           (prod.costo_sin_iva IS NULL OR prod.costo_sin_iva = 0) AS sin_costo,
+           CASE WHEN pi.es_bonificacion THEN
+             CASE WHEN pr.regalo_mueve_stock IS FALSE AND pr.unidades_por_bloque > 0
+                  THEN pi.cantidad * COALESCE(pi.costo_unitario_al_crear, prod.costo_sin_iva*(1+COALESCE(prod.impuestos_internos,0)/100)) / pr.unidades_por_bloque
+                  ELSE pi.cantidad * COALESCE(pi.costo_unitario_al_crear, prod.costo_sin_iva*(1+COALESCE(prod.impuestos_internos,0)/100)) END
+           ELSE 0 END AS costo_bonif
+    FROM ped p
+    JOIN pedido_items pi ON pi.pedido_id = p.id
+    JOIN productos prod ON prod.id = pi.producto_id
+    LEFT JOIN promociones pr ON pr.id = pi.promocion_id
+  ),
+  nc AS (
+    SELECT usuario_id, total FROM pedidos
+    WHERE estado<>'cancelado' AND canal='app'
+      AND fecha BETWEEN p_desde AND p_hasta AND sucursal_id = ANY(v_sucursales)
+      AND usuario_id IN (SELECT id FROM perfiles)
+  ),
+  k_ped AS (SELECT COUNT(*) AS pedidos, COALESCE(SUM(total),0) AS venta,
+            COUNT(DISTINCT cliente_id) AS clientes, COALESCE(ROUND(AVG(total)),0) AS ticket FROM ped),
+  k_it AS (
+    SELECT COALESCE(SUM(cantidad*costo_unit) FILTER (WHERE NOT es_bonificacion),0) AS cmv,
+      COALESCE(SUM(costo_bonif),0) AS bonif,
+      COALESCE(SUM(cantidad) FILTER (WHERE NOT es_bonificacion),0) AS unidades,
+      COALESCE(SUM(cantidad) FILTER (WHERE es_bonificacion),0) AS unidades_bonif,
+      COALESCE(SUM(subtotal) FILTER (WHERE sin_costo AND NOT es_bonificacion),0) AS ingreso_sin_costo
+    FROM it
+  ),
+  k_nc AS (SELECT COALESCE(SUM(total),0) AS base_comision FROM nc),
+  k_merma AS (
+    SELECT COALESCE(SUM(m.cantidad*prod.costo_sin_iva*(1+COALESCE(prod.impuestos_internos,0)/100)),0) AS mermas
+    FROM mermas_stock m JOIN productos prod ON prod.id = m.producto_id
+    WHERE m.sucursal_id = ANY(v_sucursales)
+      AND (m.created_at AT TIME ZONE 'America/Argentina/Buenos_Aires')::date BETWEEN p_desde AND p_hasta
+      AND COALESCE(m.motivo,'') NOT IN ('promociones','promociones_reversion')
+  ),
+  k_compra AS (SELECT COALESCE(SUM(total),0) AS compras FROM compras
+    WHERE sucursal_id = ANY(v_sucursales) AND fecha_compra BETWEEN p_desde AND p_hasta),
+  k_nuevos AS (SELECT COUNT(*) AS nuevos FROM (
+      SELECT cliente_id, MIN(fecha) AS pc FROM pedidos
+      WHERE estado='entregado' AND sucursal_id = ANY(v_sucursales) GROUP BY cliente_id
+    ) t WHERE pc BETWEEN p_desde AND p_hasta),
+  m_ped AS (SELECT to_char(fecha,'YYYY-MM') AS mes, COUNT(*) AS pedidos, SUM(total) AS venta,
+            COUNT(DISTINCT cliente_id) AS clientes, ROUND(AVG(total)) AS ticket FROM ped GROUP BY 1),
+  m_it AS (SELECT to_char(fecha,'YYYY-MM') AS mes,
+           COALESCE(SUM(cantidad*costo_unit) FILTER (WHERE NOT es_bonificacion),0) AS cmv,
+           COALESCE(SUM(costo_bonif),0) AS bonif FROM it GROUP BY 1),
+  m_merma AS (SELECT to_char(m.created_at AT TIME ZONE 'America/Argentina/Buenos_Aires','YYYY-MM') AS mes,
+       SUM(m.cantidad*prod.costo_sin_iva*(1+COALESCE(prod.impuestos_internos,0)/100)) AS mermas
+    FROM mermas_stock m JOIN productos prod ON prod.id = m.producto_id
+    WHERE m.sucursal_id = ANY(v_sucursales)
+      AND (m.created_at AT TIME ZONE 'America/Argentina/Buenos_Aires')::date BETWEEN p_desde AND p_hasta
+      AND COALESCE(m.motivo,'') NOT IN ('promociones','promociones_reversion') GROUP BY 1),
+  m_compra AS (SELECT to_char(fecha_compra,'YYYY-MM') AS mes, SUM(total) AS compras
+    FROM compras WHERE sucursal_id = ANY(v_sucursales) AND fecha_compra BETWEEN p_desde AND p_hasta GROUP BY 1),
+  mensual AS (SELECT mp.mes, mp.pedidos, mp.venta, mp.clientes, mp.ticket,
+      COALESCE(mi.cmv,0) AS cmv, COALESCE(mi.bonif,0) AS bonif,
+      COALESCE(mm.mermas,0) AS mermas, COALESCE(mc.compras,0) AS compras
+    FROM m_ped mp LEFT JOIN m_it mi ON mi.mes=mp.mes LEFT JOIN m_merma mm ON mm.mes=mp.mes LEFT JOIN m_compra mc ON mc.mes=mp.mes),
+  v_ent AS (SELECT usuario_id, COUNT(DISTINCT pedido_id) AS pedidos, SUM(subtotal) AS venta,
+      SUM(subtotal) - COALESCE(SUM(cantidad*costo_unit) FILTER (WHERE NOT es_bonificacion),0) AS margen_comercial,
+      COALESCE(SUM(costo_bonif),0) AS bonif FROM it GROUP BY usuario_id),
+  v_nc AS (SELECT usuario_id, SUM(total) AS base_nc FROM nc GROUP BY usuario_id),
+  vendedores AS (SELECT pf.nombre, pf.rol, e.pedidos, e.venta, e.margen_comercial, e.bonif,
+      COALESCE(n.base_nc, e.venta) AS base_nc
+    FROM v_ent e JOIN perfiles pf ON pf.id=e.usuario_id LEFT JOIN v_nc n ON n.usuario_id=e.usuario_id),
+  categorias AS (SELECT categoria, SUM(subtotal) AS venta,
+      SUM(subtotal) - COALESCE(SUM(cantidad*costo_unit) FILTER (WHERE NOT es_bonificacion),0) AS margen_comercial,
+      COALESCE(SUM(costo_bonif),0) AS bonif, bool_or(sin_costo) AS sin_costo
+    FROM it GROUP BY categoria),
+  top_prod AS (SELECT prod_nombre AS nombre,
+      COALESCE(SUM(cantidad) FILTER (WHERE NOT es_bonificacion),0) AS unidades, SUM(subtotal) AS venta,
+      SUM(subtotal) - COALESCE(SUM(cantidad*costo_unit) FILTER (WHERE NOT es_bonificacion),0) AS margen
+    FROM it GROUP BY prod_nombre ORDER BY venta DESC LIMIT 10),
+  top_cli AS (SELECT COALESCE(NULLIF(c.nombre_fantasia,''), c.razon_social) AS cliente,
+      COUNT(DISTINCT p.id) AS pedidos, SUM(p.total) AS venta
+    FROM ped p JOIN clientes c ON c.id=p.cliente_id GROUP BY 1 ORDER BY venta DESC LIMIT 10),
+  bonif_det AS (SELECT prod_nombre AS nombre, SUM(cantidad) AS unidades, SUM(costo_bonif) AS costo
+    FROM it WHERE es_bonificacion GROUP BY prod_nombre HAVING SUM(cantidad) > 0 ORDER BY costo DESC LIMIT 12),
+  mermas_motivo AS (SELECT COALESCE(NULLIF(m.motivo,''),'(sin motivo)') AS motivo,
+      SUM(m.cantidad) AS unidades, SUM(m.cantidad*prod.costo_sin_iva*(1+COALESCE(prod.impuestos_internos,0)/100)) AS costo
+    FROM mermas_stock m JOIN productos prod ON prod.id=m.producto_id
+    WHERE m.sucursal_id = ANY(v_sucursales)
+      AND (m.created_at AT TIME ZONE 'America/Argentina/Buenos_Aires')::date BETWEEN p_desde AND p_hasta
+      AND COALESCE(m.motivo,'') NOT IN ('promociones','promociones_reversion') GROUP BY 1),
+  formas AS (SELECT COALESCE(forma_pago,'(sin dato)') AS forma_pago, SUM(total) AS monto FROM ped GROUP BY 1),
+  cobr AS (SELECT COALESCE(SUM(total) FILTER (WHERE estado_pago='pagado'),0) AS cobrado,
+      COALESCE(SUM(total) FILTER (WHERE estado_pago IN ('pendiente','parcial')),0) AS pendiente FROM ped),
+  serie AS (SELECT to_char(fecha,'DD/MM') AS dia, SUM(total) AS venta FROM ped GROUP BY fecha ORDER BY fecha)
+  SELECT jsonb_build_object(
+    'meta', jsonb_build_object('sucursal_id', p_sucursal_id, 'sucursal_nombre', COALESCE(v_nombre,'?'),
+      'desde', p_desde, 'hasta', p_hasta, 'generado_at', now(),
+      'incluye_no_entregados', p_incluir_no_entregados),
+    'kpis', (SELECT jsonb_build_object('venta', kp.venta, 'pedidos', kp.pedidos, 'clientes', kp.clientes, 'ticket', kp.ticket,
+        'clientes_nuevos', kn.nuevos, 'cmv', ki.cmv, 'bonif', ki.bonif, 'unidades', ki.unidades,
+        'unidades_bonif', ki.unidades_bonif, 'margen_comercial', kp.venta - ki.cmv,
+        'margen_neto', kp.venta - ki.cmv - ki.bonif, 'base_comision', kc.base_comision, 'comision_pct_default', 2,
+        'mermas', km.mermas, 'compras', kcp.compras, 'ingreso_sin_costo', ki.ingreso_sin_costo)
+      FROM k_ped kp, k_it ki, k_nc kc, k_merma km, k_compra kcp, k_nuevos kn),
+    'mensual', (SELECT COALESCE(jsonb_agg(to_jsonb(m) ORDER BY m.mes),'[]') FROM mensual m),
+    'vendedores', (SELECT COALESCE(jsonb_agg(to_jsonb(v) ORDER BY v.venta DESC),'[]') FROM vendedores v),
+    'categorias', (SELECT COALESCE(jsonb_agg(to_jsonb(c) ORDER BY c.venta DESC),'[]') FROM categorias c),
+    'top_productos', (SELECT COALESCE(jsonb_agg(to_jsonb(t)),'[]') FROM top_prod t),
+    'top_clientes', (SELECT COALESCE(jsonb_agg(to_jsonb(t)),'[]') FROM top_cli t),
+    'bonif_detalle', (SELECT COALESCE(jsonb_agg(to_jsonb(b)),'[]') FROM bonif_det b),
+    'mermas_motivo', (SELECT COALESCE(jsonb_agg(to_jsonb(mm) ORDER BY mm.costo DESC),'[]') FROM mermas_motivo mm),
+    'cobranza', jsonb_build_object('formas', (SELECT COALESCE(jsonb_agg(to_jsonb(f) ORDER BY f.monto DESC),'[]') FROM formas f),
+      'cobrado', (SELECT cobrado FROM cobr), 'pendiente', (SELECT pendiente FROM cobr)),
+    'serie_diaria', (SELECT COALESCE(jsonb_agg(jsonb_build_array(s.dia, s.venta)),'[]') FROM serie s),
+    'flags', (SELECT jsonb_build_object('ingreso_sin_costo', ki.ingreso_sin_costo,
+        'pct_sin_costo', CASE WHEN kp.venta > 0 THEN round(100.0*ki.ingreso_sin_costo/kp.venta,1) ELSE 0 END)
+      FROM k_it ki, k_ped kp)
+  ) INTO v_result;
+
+  -- ----- Comparativo: período anterior (recursivo, sin volver a comparar) -----
+  IF p_comparar THEN
+    v_prev := public.reporte_gerencial(p_sucursal_id, v_prev_desde, v_prev_hasta, p_incluir_no_entregados, false);
+    v_comparativo := (v_prev->'kpis') || jsonb_build_object('desde', v_prev_desde, 'hasta', v_prev_hasta);
+  END IF;
+
+  -- ----- Alertas: "qué requiere tu atención" -----
+  v_venta := (v_result->'kpis'->>'venta')::numeric;
+  v_mermas := (v_result->'kpis'->>'mermas')::numeric;
+  v_prev_venta := (v_comparativo->>'venta')::numeric;
+  v_prev_mermas := (v_comparativo->>'mermas')::numeric;
+
+  IF p_comparar AND COALESCE(v_prev_venta,0) > 0 AND v_venta < v_prev_venta * 0.9 THEN
+    v_alertas := v_alertas || jsonb_build_object(
+      'severidad', CASE WHEN v_venta < v_prev_venta*0.8 THEN 'critical' ELSE 'warning' END,
+      'codigo','venta_caida','titulo','Venta en baja',
+      'detalle','Cayó '||round((1 - v_venta/v_prev_venta)*100)::text||'% vs período anterior',
+      'valor', v_venta - v_prev_venta, 'seccion','evolucion');
+  END IF;
+
+  SELECT COALESCE(SUM(total - COALESCE(monto_pagado,0)),0), COUNT(DISTINCT cliente_id)
+    INTO v_cob_venc, v_cob_venc_cli
+  FROM pedidos
+  WHERE estado='entregado' AND canal='app' AND sucursal_id = ANY(v_sucursales)
+    AND COALESCE(estado_pago,'pendiente') IN ('pendiente','parcial')
+    AND fecha < CURRENT_DATE - 30 AND total > COALESCE(monto_pagado,0);
+  IF v_cob_venc > 0 THEN
+    v_alertas := v_alertas || jsonb_build_object('severidad','critical','codigo','cobranza_vencida','titulo','Cobranza vencida',
+      'detalle', v_cob_venc_cli::text||' cliente(s) con saldo impago hace +30 días',
+      'valor', v_cob_venc, 'seccion','cobranza');
+  END IF;
+
+  SELECT COUNT(*) INTO v_cli_inact FROM (
+    SELECT p.cliente_id FROM pedidos p
+    WHERE p.estado='entregado' AND p.canal='app' AND p.sucursal_id = ANY(v_sucursales)
+    GROUP BY p.cliente_id
+    HAVING MAX(p.fecha) < CURRENT_DATE - 30 AND MAX(p.fecha) >= CURRENT_DATE - 90
+  ) t;
+  IF v_cli_inact > 0 THEN
+    v_alertas := v_alertas || jsonb_build_object('severidad','warning','codigo','clientes_inactivos','titulo','Clientes que dejaron de comprar',
+      'detalle', v_cli_inact::text||' cliente(s) sin comprar hace +30 días (compraban hasta hace poco)',
+      'valor', v_cli_inact, 'seccion','clientes');
+  END IF;
+
+  IF p_comparar AND COALESCE(v_prev_mermas,0) > 0 AND v_mermas > v_prev_mermas*1.3 AND v_mermas > 50000 THEN
+    v_alertas := v_alertas || jsonb_build_object('severidad','warning','codigo','mermas_alza','titulo','Mermas en alza',
+      'detalle','Subieron '||round((v_mermas/v_prev_mermas - 1)*100)::text||'% vs período anterior',
+      'valor', v_mermas, 'seccion','mermas');
+  END IF;
+
+  SELECT COUNT(*) INTO v_cat_neg FROM jsonb_array_elements(v_result->'categorias') c WHERE (c->>'margen_comercial')::numeric < 0;
+  IF v_cat_neg > 0 THEN
+    v_alertas := v_alertas || jsonb_build_object('severidad','warning','codigo','margen_categoria_negativo','titulo','Categorías con margen negativo',
+      'detalle', v_cat_neg::text||' categoría(s) con margen comercial negativo',
+      'valor', v_cat_neg, 'seccion','categorias');
+  END IF;
+
+  IF (v_result->'flags'->>'pct_sin_costo')::numeric >= 1 THEN
+    v_alertas := v_alertas || jsonb_build_object('severidad','info','codigo','productos_sin_costo','titulo','Productos sin costo',
+      'detalle', (v_result->'flags'->>'pct_sin_costo')::text||'% de la venta es de productos sin costo (margen sobreestimado)',
+      'valor', (v_result->'flags'->>'ingreso_sin_costo')::numeric, 'seccion','categorias');
+  END IF;
+
+  -- Ordenar por severidad
+  SELECT COALESCE(jsonb_agg(a ORDER BY array_position(ARRAY['critical','warning','info'], a->>'severidad')), '[]'::jsonb)
+    INTO v_alertas FROM jsonb_array_elements(v_alertas) a;
+
+  v_result := v_result || jsonb_build_object('comparativo', COALESCE(v_comparativo,'null'::jsonb), 'alertas', v_alertas);
+  RETURN v_result;
+END;
+$function$;
+
+REVOKE EXECUTE ON FUNCTION public.reporte_gerencial(bigint, date, date, boolean, boolean) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.reporte_gerencial(bigint, date, date, boolean, boolean) TO authenticated, service_role;

--- a/src/components/containers/ReportesGerencialesContainer.tsx
+++ b/src/components/containers/ReportesGerencialesContainer.tsx
@@ -48,17 +48,6 @@ function generarPeriodos(): PeriodoOpt[] {
   return opts
 }
 
-/** Período anterior: misma cantidad de días, inmediatamente antes del rango dado. */
-function periodoAnterior(desde: string, hasta: string): { desde: string; hasta: string } {
-  const d0 = new Date(`${desde}T00:00:00`)
-  const d1 = new Date(`${hasta}T00:00:00`)
-  const dia = 24 * 60 * 60 * 1000
-  const dias = Math.round((d1.getTime() - d0.getTime()) / dia) + 1
-  const prevHasta = new Date(d0.getTime() - dia)
-  const prevDesde = new Date(prevHasta.getTime() - (dias - 1) * dia)
-  return { desde: ymd(prevDesde), hasta: ymd(prevHasta) }
-}
-
 function periodoCustom(desde: string, hasta: string): PeriodoOpt {
   return {
     key: 'custom',
@@ -83,8 +72,6 @@ export default function ReportesGerencialesContainer(): React.ReactElement {
   const [incluirNoEntregados, setIncluirNoEntregados] = useState(false)
   const [comparar, setComparar] = useState(true)
 
-  const periodoPrev = useMemo(() => periodoAnterior(periodoSel.desde, periodoSel.hasta), [periodoSel.desde, periodoSel.hasta])
-
   // Cambia el rango personalizado (date pickers de la vista).
   const onRango = (desde: string, hasta: string) => {
     if (!desde || !hasta || desde > hasta) return
@@ -108,8 +95,7 @@ export default function ReportesGerencialesContainer(): React.ReactElement {
   const ready = sucursalSel !== undefined
   const sucParam = sucursalSel ?? null
 
-  const { data: reporte, isLoading, error } = useReporteGerencialQuery(sucParam, periodoSel.desde, periodoSel.hasta, incluirNoEntregados, ready)
-  const { data: comparativo } = useReporteGerencialQuery(sucParam, periodoPrev.desde, periodoPrev.hasta, incluirNoEntregados, ready && comparar)
+  const { data: reporte, isLoading, error } = useReporteGerencialQuery(sucParam, periodoSel.desde, periodoSel.hasta, incluirNoEntregados, comparar, ready)
   const { data: analisis } = useAnalisisMensualQuery(sucParam, periodoSel.periodoMes, ready && periodoSel.esMes)
 
   return (
@@ -127,7 +113,6 @@ export default function ReportesGerencialesContainer(): React.ReactElement {
         onRango={onRango}
         incluirNoEntregados={incluirNoEntregados}
         onIncluirNoEntregados={setIncluirNoEntregados}
-        comparativo={comparativo}
         comparar={comparar}
         onComparar={setComparar}
         analisis={analisis ?? null}

--- a/src/components/vistas/VistaReportesGerenciales.tsx
+++ b/src/components/vistas/VistaReportesGerenciales.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useMemo, useEffect } from 'react'
 import {
-  Loader2, TrendingUp, Percent, AlertTriangle, FileText, Building2, CalendarRange,
+  Loader2, TrendingUp, Percent, AlertTriangle, FileText, Building2, CalendarRange, ChevronDown,
 } from 'lucide-react'
 import ReactMarkdown from 'react-markdown'
 import NumberInput from '../ui/NumberInput'
@@ -8,6 +8,8 @@ import { money, moneyC, pct, N, rolLabel } from './reportes-gerenciales/formato'
 import {
   EvolucionChart, DiarioChart, VendedoresChart, CategoriasChart, WaterfallChart, CobranzaDonut,
 } from './reportes-gerenciales/charts'
+import Sparkline from './reportes-gerenciales/Sparkline'
+import Alertas from './reportes-gerenciales/Alertas'
 import type { ReporteGerencial, AnalisisMensual } from '../../hooks/queries'
 
 export interface PeriodoOpt {
@@ -38,16 +40,15 @@ export interface VistaReportesGerencialesProps {
   onRango: (desde: string, hasta: string) => void
   incluirNoEntregados: boolean
   onIncluirNoEntregados: (v: boolean) => void
-  comparativo: ReporteGerencial | null | undefined
   comparar: boolean
   onComparar: (v: boolean) => void
   analisis: AnalisisMensual | null
 }
 
 // ---- helpers de UI -------------------------------------------------------
-function Card({ children, className = '' }: { children: React.ReactNode; className?: string }): React.ReactElement {
+function Card({ children, className = '', id }: { children: React.ReactNode; className?: string; id?: string }): React.ReactElement {
   return (
-    <div className={`bg-white dark:bg-gray-800 border dark:border-gray-700 rounded-xl shadow-sm ${className}`}>
+    <div id={id} className={`bg-white dark:bg-gray-800 border dark:border-gray-700 rounded-xl shadow-sm ${className}`}>
       {children}
     </div>
   )
@@ -103,10 +104,16 @@ const ACCENTS = { blue: '#2563eb', emerald: '#059669', amber: '#d97706', violet:
 export default function VistaReportesGerenciales({
   reporte, loading, error, sucursalSel, periodoSel, opcionesSucursal, opcionesPeriodo,
   onSucursal, onPeriodo, onRango, incluirNoEntregados, onIncluirNoEntregados,
-  comparativo, comparar, onComparar, analisis,
+  comparar, onComparar, analisis,
 }: VistaReportesGerencialesProps): React.ReactElement {
   const [comPct, setComPct] = useState(2)
   const [comBase, setComBase] = useState<'nc' | 'ent'>('nc')
+  const [detalleAbierto, setDetalleAbierto] = useState(false)
+
+  const irASeccion = (seccion: string): void => {
+    setDetalleAbierto(true)
+    setTimeout(() => document.getElementById(`sec-${seccion}`)?.scrollIntoView({ behavior: 'smooth', block: 'start' }), 80)
+  }
 
   useEffect(() => {
     if (reporte?.kpis?.comision_pct_default) setComPct(reporte.kpis.comision_pct_default)
@@ -121,9 +128,9 @@ export default function VistaReportesGerenciales({
     return { comision, contrib }
   }, [k, comPct, comBase])
 
-  // Período anterior (misma duración, justo antes) para mostrar variaciones.
-  const kp = comparativo?.kpis ?? null
-  const cmp = comparar && !!kp
+  // Período anterior (lo calcula el RPC y viene en reporte.comparativo).
+  const kp = comparar ? (reporte?.comparativo ?? null) : null
+  const cmp = !!kp
   const derivedPrev = useMemo(() => {
     if (!kp) return null
     const base = comBase === 'nc' ? kp.base_comision : kp.venta
@@ -140,7 +147,7 @@ export default function VistaReportesGerenciales({
           <p className="text-sm text-gray-500 dark:text-gray-400">
             {reporte ? `${reporte.meta.sucursal_nombre} · ${periodoSel.label}` : 'Cargando…'}
             <span className="font-medium"> · {incluirNoEntregados ? 'Todos los pedidos' : 'Ventas entregadas'}</span>
-            {cmp && comparativo && <span className="text-gray-400"> · vs {comparativo.meta.desde} → {comparativo.meta.hasta}</span>}
+            {cmp && reporte?.comparativo && <span className="text-gray-400"> · vs {reporte.comparativo.desde} → {reporte.comparativo.hasta}</span>}
             {periodoSel.parcial && <span className="text-amber-600 dark:text-amber-400 font-medium"> · período en curso (parcial)</span>}
           </p>
         </div>
@@ -229,7 +236,7 @@ export default function VistaReportesGerenciales({
           {/* KPIs */}
           <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
             <KpiCard label={incluirNoEntregados ? 'Venta (todos)' : 'Venta entregada'} value={moneyC(k.venta)} sub={`${N.format(k.pedidos)} pedidos`} accent={ACCENTS.blue}
-              delta={cmp ? <Delta cur={k.venta} prev={kp!.venta} /> : undefined} />
+              delta={<div className="flex items-center justify-between gap-2">{cmp ? <Delta cur={k.venta} prev={kp!.venta} /> : <span />}<Sparkline data={(reporte.serie_diaria ?? []).map((s) => Number(s[1]))} /></div>} />
             <KpiCard label="Margen comercial" value={moneyC(k.margen_comercial)} sub={<><b>{pct(k.margen_comercial / k.venta)}</b> antes de bonif.</>} accent={ACCENTS.cyan}
               delta={cmp ? <Delta cur={k.margen_comercial} prev={kp!.margen_comercial} /> : undefined} />
             <KpiCard label="Bonificaciones" value={moneyC(k.bonif)} sub={<><b>{pct(k.bonif / k.venta)}</b> de la venta</>} accent={ACCENTS.amber}
@@ -257,8 +264,22 @@ export default function VistaReportesGerenciales({
             </div>
           )}
 
+          {/* Qué requiere tu atención */}
+          <Alertas items={reporte.alertas ?? []} onSelect={irASeccion} />
+
+          {/* Detalle completo: colapsable; los gráficos montan recién al abrir (perf) */}
+          <button
+            type="button"
+            onClick={() => setDetalleAbierto((o) => !o)}
+            className="flex items-center gap-1.5 text-sm font-semibold text-blue-600 dark:text-blue-400 hover:underline"
+          >
+            <ChevronDown className={`w-4 h-4 transition-transform ${detalleAbierto ? 'rotate-180' : ''}`} />
+            {detalleAbierto ? 'Ocultar detalle' : 'Ver detalle completo (evolución, vendedores, categorías, cobranza…)'}
+          </button>
+
+          {detalleAbierto && (<>
           {/* Evolución mensual */}
-          <Card className="p-5">
+          <Card id="sec-evolucion" className="p-5">
             <SectionTitle icon={TrendingUp} title="Evolución mensual" hint="Venta, bonificaciones y margen neto por mes." />
             <div className="grid lg:grid-cols-3 gap-5">
               <div className="lg:col-span-2 h-72"><EvolucionChart data={reporte.mensual} /></div>
@@ -359,7 +380,7 @@ export default function VistaReportesGerenciales({
           </Card>
 
           {/* Categorías */}
-          <Card className="p-5">
+          <Card id="sec-categorias" className="p-5">
             <SectionTitle icon={TrendingUp} title="Mezcla por categoría" hint="Venta y margen comercial. △ = margen inflado por productos sin costo." />
             <div className="grid lg:grid-cols-3 gap-5">
               <div className="lg:col-span-2 h-80"><CategoriasChart data={reporte.categorias} /></div>
@@ -401,7 +422,7 @@ export default function VistaReportesGerenciales({
                 </tbody>
               </table>
             </Card>
-            <Card className="p-5">
+            <Card id="sec-clientes" className="p-5">
               <SectionTitle icon={TrendingUp} title="Top 10 clientes" hint="Por facturación entregada." />
               <table className="w-full">
                 <thead><tr className="border-b dark:border-gray-700">
@@ -422,7 +443,7 @@ export default function VistaReportesGerenciales({
 
           {/* Cobranza + costos */}
           <div className="grid lg:grid-cols-2 gap-5">
-            <Card className="p-5">
+            <Card id="sec-cobranza" className="p-5">
               <SectionTitle icon={TrendingUp} title="Cobranza y formas de pago" hint={`${pct(reporte.cobranza.cobrado / (k.venta || 1))} cobrado.`} />
               <div className="grid grid-cols-2 gap-4 items-center">
                 <div className="h-48"><CobranzaDonut cobranza={reporte.cobranza} /></div>
@@ -442,7 +463,7 @@ export default function VistaReportesGerenciales({
                 </table>
               </div>
             </Card>
-            <Card className="p-5">
+            <Card id="sec-mermas" className="p-5">
               <SectionTitle icon={TrendingUp} title="Otros costos del período" hint="Mermas, bonificaciones y reposición." />
               <table className="w-full">
                 <thead><tr className="border-b dark:border-gray-700">
@@ -494,6 +515,7 @@ export default function VistaReportesGerenciales({
               </div>
             )}
           </Card>
+          </>)}
         </>
       )}
     </div>

--- a/src/components/vistas/reportes-gerenciales/Alertas.tsx
+++ b/src/components/vistas/reportes-gerenciales/Alertas.tsx
@@ -1,0 +1,38 @@
+import React from 'react'
+import { AlertCircle, AlertTriangle, Info } from 'lucide-react'
+import type { Alerta } from '../../../hooks/queries'
+
+const STYLE: Record<Alerta['severidad'], { icon: React.ElementType; cls: string }> = {
+  critical: { icon: AlertCircle, cls: 'border-red-200 dark:border-red-900 bg-red-50 dark:bg-red-900/20 text-red-700 dark:text-red-300' },
+  warning: { icon: AlertTriangle, cls: 'border-amber-200 dark:border-amber-800 bg-amber-50 dark:bg-amber-900/20 text-amber-800 dark:text-amber-300' },
+  info: { icon: Info, cls: 'border-blue-200 dark:border-blue-900 bg-blue-50 dark:bg-blue-900/20 text-blue-700 dark:text-blue-300' },
+}
+
+/** Panel "Qué requiere tu atención". Cada alerta es clickeable → drill a su sección. */
+export default function Alertas({ items, onSelect }: { items: Alerta[]; onSelect?: (seccion: string) => void }): React.ReactElement | null {
+  if (!items?.length) return null
+  return (
+    <div className="bg-white dark:bg-gray-800 border dark:border-gray-700 rounded-xl shadow-sm p-4">
+      <div className="text-[11px] font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400 mb-2">
+        Qué requiere tu atención
+      </div>
+      <div className="grid sm:grid-cols-2 gap-2">
+        {items.map((a) => {
+          const s = STYLE[a.severidad] ?? STYLE.info
+          const Icon = s.icon
+          return (
+            <button
+              key={a.codigo}
+              type="button"
+              onClick={() => onSelect?.(a.seccion)}
+              className={`flex items-start gap-2 text-left border rounded-lg px-3 py-2 transition hover:brightness-95 ${s.cls}`}
+            >
+              <Icon className="w-4 h-4 mt-0.5 shrink-0" />
+              <span className="text-sm leading-snug"><b>{a.titulo}.</b> {a.detalle}</span>
+            </button>
+          )
+        })}
+      </div>
+    </div>
+  )
+}

--- a/src/components/vistas/reportes-gerenciales/Sparkline.tsx
+++ b/src/components/vistas/reportes-gerenciales/Sparkline.tsx
@@ -1,0 +1,30 @@
+import React from 'react'
+
+/** Mini-tendencia en SVG inline (sin dependencias). data = serie de valores. */
+export default function Sparkline({
+  data,
+  color = '#2563eb',
+  width = 90,
+  height = 24,
+}: {
+  data: number[]
+  color?: string
+  width?: number
+  height?: number
+}): React.ReactElement | null {
+  const pts = (data ?? []).filter((n) => Number.isFinite(n))
+  if (pts.length < 2) return null
+  const min = Math.min(...pts)
+  const max = Math.max(...pts)
+  const range = max - min || 1
+  const stepX = width / (pts.length - 1)
+  const y = (v: number): number => height - ((v - min) / range) * height
+  const path = pts
+    .map((v, i) => `${i === 0 ? 'M' : 'L'}${(i * stepX).toFixed(1)},${y(v).toFixed(1)}`)
+    .join(' ')
+  return (
+    <svg width={width} height={height} viewBox={`0 0 ${width} ${height}`} aria-hidden="true" className="block">
+      <path d={path} fill="none" stroke={color} strokeWidth={1.5} strokeLinejoin="round" strokeLinecap="round" />
+    </svg>
+  )
+}

--- a/src/hooks/queries/index.ts
+++ b/src/hooks/queries/index.ts
@@ -240,6 +240,7 @@ export type {
   ReporteProducto,
   ReporteCliente,
   ReporteCobranza,
+  Alerta,
   AnalisisMensual,
 } from './useReporteGerencialQuery'
 

--- a/src/hooks/queries/useReporteGerencialQuery.ts
+++ b/src/hooks/queries/useReporteGerencialQuery.ts
@@ -77,6 +77,15 @@ export interface ReporteCobranza {
   pendiente: number
 }
 
+export interface Alerta {
+  severidad: 'critical' | 'warning' | 'info'
+  codigo: string
+  titulo: string
+  detalle: string
+  valor: number
+  seccion: string
+}
+
 export interface ReporteGerencial {
   meta: {
     sucursal_id: number | null
@@ -95,6 +104,9 @@ export interface ReporteGerencial {
   cobranza: ReporteCobranza
   serie_diaria: [string, number][]
   flags: { ingreso_sin_costo: number; pct_sin_costo: number }
+  // KPIs del período anterior (cuando se pide comparar) + alertas, ambos del RPC.
+  comparativo?: (ReporteKpis & { desde: string; hasta: string }) | null
+  alertas?: Alerta[]
 }
 
 export interface AnalisisMensual {
@@ -107,8 +119,8 @@ export interface AnalisisMensual {
 
 export const reporteGerencialKeys = {
   all: ['reporte-gerencial'] as const,
-  range: (suc: number | null, desde: string, hasta: string, incluirNoEntregados: boolean) =>
-    ['reporte-gerencial', suc, desde, hasta, incluirNoEntregados] as const,
+  range: (suc: number | null, desde: string, hasta: string, incluirNoEntregados: boolean, comparar: boolean) =>
+    ['reporte-gerencial', suc, desde, hasta, incluirNoEntregados, comparar] as const,
   analisis: (suc: number | null, periodo: string | null) =>
     ['reporte-gerencial-analisis', suc, periodo] as const,
 }
@@ -119,16 +131,18 @@ export function useReporteGerencialQuery(
   desde: string,
   hasta: string,
   incluirNoEntregados = false,
+  comparar = false,
   enabled = true,
 ) {
   return useQuery({
-    queryKey: reporteGerencialKeys.range(sucursalId, desde, hasta, incluirNoEntregados),
+    queryKey: reporteGerencialKeys.range(sucursalId, desde, hasta, incluirNoEntregados, comparar),
     queryFn: async (): Promise<ReporteGerencial> => {
       const { data, error } = await supabase.rpc('reporte_gerencial', {
         p_sucursal_id: sucursalId,
         p_desde: desde,
         p_hasta: hasta,
         p_incluir_no_entregados: incluirNoEntregados,
+        p_comparar: comparar,
       })
       if (error) throw new Error(error.message)
       return data as ReporteGerencial


### PR DESCRIPTION
## Contexto
Eleva el reporte gerencial a nivel BI para decidir rápido, **sin hacer pesada la app** (restricción: performance). Diseño en `docs/plans` (brainstorming). Fase 1 (sin schema); **Metas** quedan para Fase 2.

## RPC `reporte_gerencial` (mig 107, ya aplicada en prod)
- 5º parámetro `p_comparar`. Cuando true, calcula el **período anterior** llamándose recursivamente (DRY) y lo devuelve en `comparativo` dentro del **mismo payload** → reemplaza la 2ª llamada que hacía el front (**vuelve a ser 1 sola llamada**).
- **`alertas[]`** server-side ("qué requiere tu atención"): venta caída >10% vs anterior, cobranza vencida (+30d impaga), clientes inactivos (+30d sin comprar, compraban hasta hace poco), mermas en alza, categoría con margen negativo, productos sin costo. Ordenadas por severidad.
- `DROP` firma de 4 args → 5 con defaults: compat con callers de 3/4 args y `/reporte-mensual`.
- Verificado en prod: comparativo OK (mayo 2–31 para junio), alertas (cobranza 6 clientes, 132 inactivos), y compat 3-args.

## Front
- **Panel de alertas** arriba, cada una **clickeable → abre el detalle y hace scroll** a la sección (drill-down).
- **Sparkline** en Venta (SVG inline, **0 dependencias**).
- **Detalle completo colapsable**: por defecto cerrado; los **6 gráficos montan recién al abrirlo** → la carga inicial no renderiza ningún chart (más liviano). Resumen ejecutivo (KPIs + alertas) primero.
- Comparación vs período anterior ahora viene del RPC (1 query); se eliminó la 2ª query del container.

## Performance
- Carga inicial = **1 request** (antes 2 con comparación) y **sin charts** hasta abrir el detalle. Sin librerías nuevas.

## Verificación
- typecheck sin errores nuevos (los de `react-markdown` son preexistentes, resuelven en CI); pre-commit (vitest) verde.
- Al mergear: revisar 1 sola request al RPC en Network, alertas clickeables, y que los gráficos aparezcan al abrir "Ver detalle".

## Próximo (Fase 2)
Metas vs objetivo (tabla `metas_gerenciales` + carga + semáforo en los KPIs hero).

🤖 Generated with [Claude Code](https://claude.com/claude-code)