### PR TITLE
feat(reportes): metas vs objetivo con semáforo (BI Fase 2)

### DIFF
--- a/migrations/108_metas_gerenciales.sql
+++ b/migrations/108_metas_gerenciales.sql
@@ -1,0 +1,73 @@
+-- ============================================================================
+-- 108 · Metas gerenciales (objetivos mensuales) — BI Fase 2
+-- ============================================================================
+-- Tabla de metas por sucursal y mes (sucursal_id NULL = red consolidada) para
+-- venta y margen_neto. El semáforo (cumplimiento) se calcula en el front contra
+-- estas metas (prorrateadas por días si el mes está en curso). Escritura por RPC
+-- admin-only; lectura por RLS admin. NO toca reporte_gerencial.
+-- ============================================================================
+
+CREATE TABLE IF NOT EXISTS public.metas_gerenciales (
+  id          bigint GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+  sucursal_id bigint REFERENCES sucursales(id),         -- NULL = red consolidada
+  periodo     date NOT NULL,                            -- primer día del mes
+  metrica     text NOT NULL CHECK (metrica IN ('venta','margen_neto')),
+  valor       numeric NOT NULL CHECK (valor >= 0),
+  usuario_id  uuid,
+  created_at  timestamptz DEFAULT now(),
+  updated_at  timestamptz DEFAULT now()
+);
+
+COMMENT ON TABLE public.metas_gerenciales IS
+  'Objetivos mensuales por sucursal (NULL=red) y métrica (venta/margen_neto). UNIQUE por (sucursal_id, periodo, metrica) tratando NULL como -1.';
+
+CREATE UNIQUE INDEX IF NOT EXISTS metas_gerenciales_uidx
+  ON public.metas_gerenciales (COALESCE(sucursal_id, -1), periodo, metrica);
+
+ALTER TABLE public.metas_gerenciales ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS metas_gerenciales_admin_select ON public.metas_gerenciales;
+CREATE POLICY metas_gerenciales_admin_select ON public.metas_gerenciales
+  FOR SELECT TO authenticated
+  USING (EXISTS (SELECT 1 FROM perfiles WHERE id = auth.uid() AND rol = 'admin'));
+-- Escritura: sólo vía guardar_meta_gerencial (SECURITY DEFINER) o service_role.
+
+-- ----------------------------------------------------------------------------
+-- RPC upsert de meta (admin-only; valida sucursal asignada)
+-- ----------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.guardar_meta_gerencial(
+  p_sucursal_id bigint,
+  p_periodo     date,
+  p_metrica     text,
+  p_valor       numeric
+)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $function$
+BEGIN
+  IF auth.uid() IS NOT NULL
+     AND NOT EXISTS (SELECT 1 FROM perfiles WHERE id = auth.uid() AND rol = 'admin') THEN
+    RAISE EXCEPTION 'Acceso denegado: se requiere rol admin';
+  END IF;
+  IF auth.uid() IS NOT NULL AND p_sucursal_id IS NOT NULL
+     AND NOT EXISTS (SELECT 1 FROM usuario_sucursales WHERE usuario_id = auth.uid() AND sucursal_id = p_sucursal_id) THEN
+    RAISE EXCEPTION 'Acceso denegado: la sucursal no está asignada al usuario';
+  END IF;
+  IF p_metrica NOT IN ('venta','margen_neto') THEN
+    RAISE EXCEPTION 'Métrica inválida: %', p_metrica;
+  END IF;
+  IF p_valor IS NULL OR p_valor < 0 THEN
+    RAISE EXCEPTION 'Valor inválido';
+  END IF;
+
+  INSERT INTO metas_gerenciales (sucursal_id, periodo, metrica, valor, usuario_id, updated_at)
+  VALUES (p_sucursal_id, date_trunc('month', p_periodo)::date, p_metrica, p_valor, auth.uid(), now())
+  ON CONFLICT (COALESCE(sucursal_id, -1), periodo, metrica) DO UPDATE
+    SET valor = EXCLUDED.valor, usuario_id = EXCLUDED.usuario_id, updated_at = now();
+END;
+$function$;
+
+REVOKE EXECUTE ON FUNCTION public.guardar_meta_gerencial(bigint, date, text, numeric) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.guardar_meta_gerencial(bigint, date, text, numeric) TO authenticated, service_role;

--- a/src/components/containers/ReportesGerencialesContainer.tsx
+++ b/src/components/containers/ReportesGerencialesContainer.tsx
@@ -1,6 +1,6 @@
 import React, { lazy, Suspense, useEffect, useMemo, useState } from 'react'
 import { Loader2 } from 'lucide-react'
-import { useReporteGerencialQuery, useAnalisisMensualQuery } from '../../hooks/queries'
+import { useReporteGerencialQuery, useAnalisisMensualQuery, useMetasGerencialQuery, useGuardarMetaMutation } from '../../hooks/queries'
 import { useSucursal } from '../../contexts/SucursalContext'
 import type { PeriodoOpt, SucursalOpt } from '../vistas/VistaReportesGerenciales'
 
@@ -97,6 +97,14 @@ export default function ReportesGerencialesContainer(): React.ReactElement {
 
   const { data: reporte, isLoading, error } = useReporteGerencialQuery(sucParam, periodoSel.desde, periodoSel.hasta, incluirNoEntregados, comparar, ready)
   const { data: analisis } = useAnalisisMensualQuery(sucParam, periodoSel.periodoMes, ready && periodoSel.esMes)
+  const { data: metas } = useMetasGerencialQuery(sucParam, periodoSel.periodoMes, ready && periodoSel.esMes)
+  const guardarMeta = useGuardarMetaMutation()
+
+  const onGuardarMeta = (venta: number | null, margenNeto: number | null): void => {
+    if (!periodoSel.periodoMes) return
+    if (venta != null) guardarMeta.mutate({ sucursalId: sucParam, periodo: periodoSel.periodoMes, metrica: 'venta', valor: venta })
+    if (margenNeto != null) guardarMeta.mutate({ sucursalId: sucParam, periodo: periodoSel.periodoMes, metrica: 'margen_neto', valor: margenNeto })
+  }
 
   return (
     <Suspense fallback={<div className="flex items-center justify-center py-20"><Loader2 className="w-8 h-8 animate-spin text-blue-600" /></div>}>
@@ -115,6 +123,10 @@ export default function ReportesGerencialesContainer(): React.ReactElement {
         onIncluirNoEntregados={setIncluirNoEntregados}
         comparar={comparar}
         onComparar={setComparar}
+        metas={metas ?? null}
+        metasEditable={periodoSel.esMes}
+        onGuardarMeta={onGuardarMeta}
+        guardandoMeta={guardarMeta.isPending}
         analisis={analisis ?? null}
       />
     </Suspense>

--- a/src/components/vistas/VistaReportesGerenciales.tsx
+++ b/src/components/vistas/VistaReportesGerenciales.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useMemo, useEffect } from 'react'
 import {
-  Loader2, TrendingUp, Percent, AlertTriangle, FileText, Building2, CalendarRange, ChevronDown,
+  Loader2, TrendingUp, Percent, AlertTriangle, FileText, Building2, CalendarRange, ChevronDown, Target,
 } from 'lucide-react'
 import ReactMarkdown from 'react-markdown'
 import NumberInput from '../ui/NumberInput'
@@ -10,7 +10,8 @@ import {
 } from './reportes-gerenciales/charts'
 import Sparkline from './reportes-gerenciales/Sparkline'
 import Alertas from './reportes-gerenciales/Alertas'
-import type { ReporteGerencial, AnalisisMensual } from '../../hooks/queries'
+import ModalMetas from './reportes-gerenciales/ModalMetas'
+import type { ReporteGerencial, AnalisisMensual, MetasGerenciales } from '../../hooks/queries'
 
 export interface PeriodoOpt {
   key: string
@@ -42,6 +43,10 @@ export interface VistaReportesGerencialesProps {
   onIncluirNoEntregados: (v: boolean) => void
   comparar: boolean
   onComparar: (v: boolean) => void
+  metas: MetasGerenciales | null
+  metasEditable: boolean
+  onGuardarMeta: (venta: number | null, margenNeto: number | null) => void
+  guardandoMeta: boolean
   analisis: AnalisisMensual | null
 }
 
@@ -82,6 +87,20 @@ function Delta({ cur, prev, invert = false }: { cur: number; prev: number | null
   )
 }
 
+/** Semáforo de cumplimiento vs meta. factor prorratea la meta por días del mes en curso. */
+function Semaforo({ cur, meta, factor }: { cur: number; meta: number | null | undefined; factor: number }): React.ReactElement | null {
+  if (meta == null || meta <= 0) return null
+  const objetivo = meta * factor
+  const cumpl = objetivo > 0 ? cur / objetivo : 0
+  const color = cumpl >= 1 ? 'text-emerald-600 dark:text-emerald-400' : cumpl >= 0.85 ? 'text-amber-600 dark:text-amber-400' : 'text-red-600 dark:text-red-400'
+  const dot = cumpl >= 1 ? 'bg-emerald-500' : cumpl >= 0.85 ? 'bg-amber-500' : 'bg-red-500'
+  return (
+    <span className={`inline-flex items-center gap-1 text-[11px] font-semibold ${color}`} title={factor < 1 ? 'Meta prorrateada por días transcurridos' : 'Meta del mes'}>
+      <span className={`w-2 h-2 rounded-full ${dot}`} />{pct(cumpl)} de la meta
+    </span>
+  )
+}
+
 function SectionTitle({ icon: Icon, title, hint, right }: { icon: React.ElementType; title: string; hint?: string; right?: React.ReactNode }): React.ReactElement {
   return (
     <div className="flex items-start justify-between gap-3 mb-4">
@@ -104,11 +123,24 @@ const ACCENTS = { blue: '#2563eb', emerald: '#059669', amber: '#d97706', violet:
 export default function VistaReportesGerenciales({
   reporte, loading, error, sucursalSel, periodoSel, opcionesSucursal, opcionesPeriodo,
   onSucursal, onPeriodo, onRango, incluirNoEntregados, onIncluirNoEntregados,
-  comparar, onComparar, analisis,
+  comparar, onComparar, metas, metasEditable, onGuardarMeta, guardandoMeta, analisis,
 }: VistaReportesGerencialesProps): React.ReactElement {
   const [comPct, setComPct] = useState(2)
   const [comBase, setComBase] = useState<'nc' | 'ent'>('nc')
   const [detalleAbierto, setDetalleAbierto] = useState(false)
+  const [showMetas, setShowMetas] = useState(false)
+
+  // Prorrateo de la meta: en un mes en curso compara contra la parte transcurrida.
+  const metaFactor = useMemo(() => {
+    if (!periodoSel.esMes || !periodoSel.periodoMes) return 1
+    const [yy, mm] = periodoSel.periodoMes.split('-').map(Number)
+    const diasMes = new Date(yy, mm, 0).getDate()
+    if (!periodoSel.parcial) return 1
+    const diaHasta = Number(periodoSel.hasta.split('-')[2])
+    return Math.min(Math.max(diaHasta, 1) / diasMes, 1)
+  }, [periodoSel.esMes, periodoSel.periodoMes, periodoSel.parcial, periodoSel.hasta])
+
+  const metasOn = periodoSel.esMes && !!metas && (metas.venta != null || metas.margen_neto != null)
 
   const irASeccion = (seccion: string): void => {
     setDetalleAbierto(true)
@@ -174,6 +206,16 @@ export default function VistaReportesGerenciales({
           >
             Comparar
           </button>
+          {metasEditable && (
+            <button
+              type="button"
+              onClick={() => setShowMetas(true)}
+              title="Cargar las metas (objetivos) del mes"
+              className="flex items-center gap-1 px-2.5 py-1.5 text-xs font-semibold rounded-lg border shadow-sm bg-white dark:bg-gray-800 text-gray-600 dark:text-gray-300 border-gray-200 dark:border-gray-700 hover:bg-gray-100 dark:hover:bg-gray-700"
+            >
+              <Target className="w-3.5 h-3.5" /> Metas
+            </button>
+          )}
           <div className="flex items-center gap-1.5 bg-white dark:bg-gray-800 border dark:border-gray-700 rounded-lg px-2.5 py-1.5 shadow-sm">
             <Building2 className="w-4 h-4 text-gray-400" />
             <select
@@ -236,13 +278,19 @@ export default function VistaReportesGerenciales({
           {/* KPIs */}
           <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
             <KpiCard label={incluirNoEntregados ? 'Venta (todos)' : 'Venta entregada'} value={moneyC(k.venta)} sub={`${N.format(k.pedidos)} pedidos`} accent={ACCENTS.blue}
-              delta={<div className="flex items-center justify-between gap-2">{cmp ? <Delta cur={k.venta} prev={kp!.venta} /> : <span />}<Sparkline data={(reporte.serie_diaria ?? []).map((s) => Number(s[1]))} /></div>} />
+              delta={<div className="space-y-1">
+                <div className="flex items-center justify-between gap-2">{cmp ? <Delta cur={k.venta} prev={kp!.venta} /> : <span />}<Sparkline data={(reporte.serie_diaria ?? []).map((s) => Number(s[1]))} /></div>
+                {metasOn && metas?.venta != null && <Semaforo cur={k.venta} meta={metas.venta} factor={metaFactor} />}
+              </div>} />
             <KpiCard label="Margen comercial" value={moneyC(k.margen_comercial)} sub={<><b>{pct(k.margen_comercial / k.venta)}</b> antes de bonif.</>} accent={ACCENTS.cyan}
               delta={cmp ? <Delta cur={k.margen_comercial} prev={kp!.margen_comercial} /> : undefined} />
             <KpiCard label="Bonificaciones" value={moneyC(k.bonif)} sub={<><b>{pct(k.bonif / k.venta)}</b> de la venta</>} accent={ACCENTS.amber}
               delta={cmp ? <Delta cur={k.bonif} prev={kp!.bonif} invert /> : undefined} />
             <KpiCard label="Margen neto" value={moneyC(k.margen_neto)} sub={<><b>{pct(k.margen_neto / k.venta)}</b> post bonif.</>} accent={ACCENTS.violet}
-              delta={cmp ? <Delta cur={k.margen_neto} prev={kp!.margen_neto} /> : undefined} />
+              delta={<div className="space-y-1">
+                {cmp && <Delta cur={k.margen_neto} prev={kp!.margen_neto} />}
+                {metasOn && metas?.margen_neto != null && <Semaforo cur={k.margen_neto} meta={metas.margen_neto} factor={metaFactor} />}
+              </div>} />
             <KpiCard label={`Comisión ${String(comPct).replace('.', ',')}%`} value={moneyC(derived.comision)} sub={`base ${comBase === 'nc' ? 'no cancelado' : 'entregado'}`} accent={ACCENTS.slate}
               delta={cmp && derivedPrev ? <Delta cur={derived.comision} prev={derivedPrev.comision} invert /> : undefined} />
             <KpiCard label="Mermas" value={moneyC(k.mermas)} sub="producto perdido" accent={ACCENTS.red}
@@ -517,6 +565,17 @@ export default function VistaReportesGerenciales({
           </Card>
           </>)}
         </>
+      )}
+
+      {showMetas && (
+        <ModalMetas
+          metas={metas}
+          periodoLabel={periodoSel.label}
+          sucursalNombre={reporte?.meta.sucursal_nombre ?? ''}
+          guardando={guardandoMeta}
+          onGuardar={(v, m) => { onGuardarMeta(v, m); setShowMetas(false) }}
+          onClose={() => setShowMetas(false)}
+        />
       )}
     </div>
   )

--- a/src/components/vistas/reportes-gerenciales/ModalMetas.tsx
+++ b/src/components/vistas/reportes-gerenciales/ModalMetas.tsx
@@ -1,0 +1,70 @@
+import React, { useState } from 'react'
+import { X, Target } from 'lucide-react'
+import type { MetasGerenciales } from '../../../hooks/queries'
+
+/** Modal para cargar las metas (objetivos) del mes: venta y margen neto. */
+export default function ModalMetas({
+  metas,
+  periodoLabel,
+  sucursalNombre,
+  onGuardar,
+  onClose,
+  guardando = false,
+}: {
+  metas: MetasGerenciales | null
+  periodoLabel: string
+  sucursalNombre: string
+  onGuardar: (venta: number | null, margenNeto: number | null) => void
+  onClose: () => void
+  guardando?: boolean
+}): React.ReactElement {
+  const [venta, setVenta] = useState<string>(metas?.venta != null ? String(metas.venta) : '')
+  const [margen, setMargen] = useState<string>(metas?.margen_neto != null ? String(metas.margen_neto) : '')
+
+  const parse = (s: string): number | null => {
+    const n = Number(s.replace(/[^\d.-]/g, ''))
+    return s.trim() === '' || !Number.isFinite(n) ? null : n
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4" onClick={onClose}>
+      <div className="bg-white dark:bg-gray-800 rounded-xl shadow-xl w-full max-w-sm p-5" onClick={(e) => e.stopPropagation()}>
+        <div className="flex items-center justify-between mb-1">
+          <h3 className="text-lg font-bold text-gray-900 dark:text-white flex items-center gap-2">
+            <Target className="w-5 h-5 text-blue-600" /> Metas del mes
+          </h3>
+          <button onClick={onClose} className="text-gray-400 hover:text-gray-600" aria-label="Cerrar"><X className="w-5 h-5" /></button>
+        </div>
+        <p className="text-xs text-gray-500 dark:text-gray-400 mb-4">{sucursalNombre} · {periodoLabel}</p>
+
+        <label className="block text-sm font-medium mb-1 dark:text-gray-200">Venta objetivo ($)</label>
+        <input
+          inputMode="numeric"
+          value={venta}
+          onChange={(e) => setVenta(e.target.value)}
+          placeholder="Ej: 20000000"
+          className="w-full px-3 py-2 border rounded-lg bg-white dark:bg-gray-700 dark:border-gray-600 dark:text-white text-sm mb-3"
+        />
+        <label className="block text-sm font-medium mb-1 dark:text-gray-200">Margen neto objetivo ($)</label>
+        <input
+          inputMode="numeric"
+          value={margen}
+          onChange={(e) => setMargen(e.target.value)}
+          placeholder="Ej: 6000000"
+          className="w-full px-3 py-2 border rounded-lg bg-white dark:bg-gray-700 dark:border-gray-600 dark:text-white text-sm mb-4"
+        />
+
+        <div className="flex justify-end gap-2">
+          <button onClick={onClose} className="px-4 py-2 text-sm text-gray-600 dark:text-gray-300">Cancelar</button>
+          <button
+            onClick={() => onGuardar(parse(venta), parse(margen))}
+            disabled={guardando}
+            className="px-4 py-2 text-sm font-semibold bg-blue-600 text-white rounded-lg hover:bg-blue-700 disabled:bg-blue-400"
+          >
+            Guardar
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/hooks/queries/index.ts
+++ b/src/hooks/queries/index.ts
@@ -230,6 +230,8 @@ export {
   reporteGerencialKeys,
   useReporteGerencialQuery,
   useAnalisisMensualQuery,
+  useMetasGerencialQuery,
+  useGuardarMetaMutation,
 } from './useReporteGerencialQuery'
 export type {
   ReporteGerencial,
@@ -241,6 +243,7 @@ export type {
   ReporteCliente,
   ReporteCobranza,
   Alerta,
+  MetasGerenciales,
   AnalisisMensual,
 } from './useReporteGerencialQuery'
 

--- a/src/hooks/queries/useReporteGerencialQuery.ts
+++ b/src/hooks/queries/useReporteGerencialQuery.ts
@@ -6,7 +6,7 @@
  * de red. El análisis narrativo mensual vive en la tabla `reportes_mensuales`
  * (lo escribe Claude Code vía el comando /reporte-mensual).
  */
-import { useQuery } from '@tanstack/react-query'
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { supabase } from '../../lib/supabase'
 
 export interface ReporteKpis {
@@ -149,6 +149,54 @@ export function useReporteGerencialQuery(
     },
     enabled,
     staleTime: 5 * 60 * 1000,
+  })
+}
+
+export interface MetasGerenciales {
+  venta: number | null
+  margen_neto: number | null
+}
+
+/** Metas (objetivos) del mes para una sucursal (null = red). Sólo aplica a meses. */
+export function useMetasGerencialQuery(
+  sucursalId: number | null,
+  periodoMes: string | null,
+  enabled = true,
+) {
+  return useQuery({
+    queryKey: ['metas-gerenciales', sucursalId, periodoMes] as const,
+    queryFn: async (): Promise<MetasGerenciales> => {
+      let q = supabase.from('metas_gerenciales').select('metrica, valor').eq('periodo', periodoMes as string)
+      q = sucursalId == null ? q.is('sucursal_id', null) : q.eq('sucursal_id', sucursalId)
+      const { data, error } = await q
+      if (error) throw new Error(error.message)
+      const rows = (data as { metrica: string; valor: number }[] | null) ?? []
+      return {
+        venta: rows.find((r) => r.metrica === 'venta')?.valor ?? null,
+        margen_neto: rows.find((r) => r.metrica === 'margen_neto')?.valor ?? null,
+      }
+    },
+    enabled: enabled && !!periodoMes,
+    staleTime: 5 * 60 * 1000,
+  })
+}
+
+/** Upsert de una meta mensual (admin). Invalida metas tras guardar. */
+export function useGuardarMetaMutation() {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: async (vars: { sucursalId: number | null; periodo: string; metrica: 'venta' | 'margen_neto'; valor: number }) => {
+      const { error } = await supabase.rpc('guardar_meta_gerencial', {
+        p_sucursal_id: vars.sucursalId,
+        p_periodo: vars.periodo,
+        p_metrica: vars.metrica,
+        p_valor: vars.valor,
+      })
+      if (error) throw new Error(error.message)
+    },
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['metas-gerenciales'] })
+    },
   })
 }
 


### PR DESCRIPTION
## Contexto
Cierra el panel BI: ahora los KPIs se miden contra un **objetivo mensual** que carga el gerente, con semáforo de cumplimiento. Continúa el #409 (alertas + resumen ejecutivo).

## Backend (mig 108, aplicada en prod)
- Tabla **`metas_gerenciales`** (sucursal/mes, métricas `venta` y `margen_neto`; `sucursal_id` NULL = red). UNIQUE por (sucursal, mes, métrica). RLS admin select.
- RPC **`guardar_meta_gerencial`** (upsert admin-only; valida sucursal asignada; service_role libre). Verificado: upsert por mes + unique + cleanup OK.
- **No toca `reporte_gerencial`** (evita reescribir la función grande): las metas se leen con una consulta mínima (1 fila) sólo cuando se mira un mes.

## Front
- Botón **"🎯 Metas"** (visible en vistas por mes) → modal para cargar Venta objetivo y Margen neto objetivo del mes/sucursal.
- **Semáforo** de cumplimiento (🟢 ≥100% · 🟡 ≥85% · 🔴 <85%) en los KPIs de **Venta** y **Margen neto**, mostrando "% de la meta".
- **Prorrateo**: si el mes está en curso, compara contra la meta proporcional a los días transcurridos (¿voy en ritmo?), no contra el objetivo full.
- Al guardar, invalida la query → el semáforo se actualiza solo.

## Performance
- 1 consulta extra mínima (single-row) y **sólo en vistas por mes**. Sin librerías nuevas.

## Verificación
- RPC probado en prod (upsert/lectura/unique). typecheck sin errores nuevos; pre-commit (vitest) verde.
- Al mergear: en un mes, cargar metas → ver semáforo en Venta/Margen neto; en mes en curso, semáforo prorrateado.

🤖 Generated with [Claude Code](https://claude.com/claude-code)