### PR TITLE
chore(migrations): reconciliar migrations/ con la realidad productiva

### DIFF
--- a/.github/workflows/integridad.yml
+++ b/.github/workflows/integridad.yml
@@ -33,3 +33,14 @@ jobs:
             exit 0
           fi
           node scripts/check-integridad.mjs
+
+      - name: Drift-check de migraciones (repo vs prod)
+        env:
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+        run: |
+          if [ -z "$SUPABASE_URL" ] || [ -z "$SUPABASE_SERVICE_ROLE_KEY" ]; then
+            echo "::warning::Faltan secrets — drift-check omitido."
+            exit 0
+          fi
+          node scripts/check-migrations.mjs

--- a/migrations/108_metas_gerenciales.sql
+++ b/migrations/108_metas_gerenciales.sql
@@ -1,0 +1,78 @@
+-- ============================================================================
+-- 108 — Metas gerenciales (objetivos mensuales por sucursal / red)
+-- ============================================================================
+-- Soporta el panel BI: objetivos mensuales editables por (sucursal, metrica)
+-- contra los que el reporte gerencial compara la venta / margen real.
+--
+--   - metrica IN ('venta','margen_neto')
+--   - sucursal_id NULL = meta de la RED (toda la distribuidora)
+--   - UNIQUE por (sucursal_id, periodo, metrica) tratando NULL como -1
+--     (no se puede usar UNIQUE directo con NULL, de ahi el indice COALESCE).
+--   - guardar_meta_gerencial(): upsert idempotente, gateado admin + sucursal
+--     asignada; trunca periodo al primer dia del mes.
+--
+-- NOTA: este archivo es el ESPEJO de lo aplicado en prod
+-- (schema_migrations version 20260630154130). La tabla ya existe en prod; se
+-- versiona aca para que migrations/ refleje la realidad. Ver migrations/MANIFEST.md.
+-- ============================================================================
+
+CREATE TABLE IF NOT EXISTS public.metas_gerenciales (
+  id          bigint GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+  sucursal_id bigint REFERENCES sucursales(id),
+  periodo     date NOT NULL,
+  metrica     text NOT NULL CHECK (metrica IN ('venta','margen_neto')),
+  valor       numeric NOT NULL CHECK (valor >= 0),
+  usuario_id  uuid,
+  created_at  timestamptz DEFAULT now(),
+  updated_at  timestamptz DEFAULT now()
+);
+
+COMMENT ON TABLE public.metas_gerenciales IS
+  'Objetivos mensuales por sucursal (NULL=red) y métrica (venta/margen_neto). UNIQUE por (sucursal_id, periodo, metrica) tratando NULL como -1.';
+
+CREATE UNIQUE INDEX IF NOT EXISTS metas_gerenciales_uidx
+  ON public.metas_gerenciales (COALESCE(sucursal_id, -1), periodo, metrica);
+
+ALTER TABLE public.metas_gerenciales ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS metas_gerenciales_admin_select ON public.metas_gerenciales;
+CREATE POLICY metas_gerenciales_admin_select ON public.metas_gerenciales
+  FOR SELECT TO authenticated
+  USING (EXISTS (SELECT 1 FROM perfiles WHERE id = auth.uid() AND rol = 'admin'));
+
+CREATE OR REPLACE FUNCTION public.guardar_meta_gerencial(
+  p_sucursal_id bigint,
+  p_periodo     date,
+  p_metrica     text,
+  p_valor       numeric
+)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $function$
+BEGIN
+  IF auth.uid() IS NOT NULL
+     AND NOT EXISTS (SELECT 1 FROM perfiles WHERE id = auth.uid() AND rol = 'admin') THEN
+    RAISE EXCEPTION 'Acceso denegado: se requiere rol admin';
+  END IF;
+  IF auth.uid() IS NOT NULL AND p_sucursal_id IS NOT NULL
+     AND NOT EXISTS (SELECT 1 FROM usuario_sucursales WHERE usuario_id = auth.uid() AND sucursal_id = p_sucursal_id) THEN
+    RAISE EXCEPTION 'Acceso denegado: la sucursal no está asignada al usuario';
+  END IF;
+  IF p_metrica NOT IN ('venta','margen_neto') THEN
+    RAISE EXCEPTION 'Métrica inválida: %', p_metrica;
+  END IF;
+  IF p_valor IS NULL OR p_valor < 0 THEN
+    RAISE EXCEPTION 'Valor inválido';
+  END IF;
+
+  INSERT INTO metas_gerenciales (sucursal_id, periodo, metrica, valor, usuario_id, updated_at)
+  VALUES (p_sucursal_id, date_trunc('month', p_periodo)::date, p_metrica, p_valor, auth.uid(), now())
+  ON CONFLICT (COALESCE(sucursal_id, -1), periodo, metrica) DO UPDATE
+    SET valor = EXCLUDED.valor, usuario_id = EXCLUDED.usuario_id, updated_at = now();
+END;
+$function$;
+
+REVOKE EXECUTE ON FUNCTION public.guardar_meta_gerencial(bigint, date, text, numeric) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.guardar_meta_gerencial(bigint, date, text, numeric) TO authenticated, service_role;

--- a/migrations/109_migraciones_aplicadas_rpc.sql
+++ b/migrations/109_migraciones_aplicadas_rpc.sql
@@ -1,0 +1,38 @@
+-- ============================================================================
+-- 109 — RPC migraciones_aplicadas() (primitiva de verificación de drift)
+-- ============================================================================
+-- Expone el ledger real de migraciones (supabase_migrations.schema_migrations)
+-- como un RPC en `public`. Razon: ese schema NO esta expuesto por PostgREST, asi
+-- que ni supabase-js ni scripts/check-migrations.mjs pueden leerlo directo.
+--
+-- Con esto un script de CI / un humano puede contrastar lo aplicado en prod
+-- contra los archivos de migrations/ (ver scripts/check-migrations.mjs y
+-- migrations/MANIFEST.md). Un agente con el MCP de Supabase no necesita esto:
+-- usa list_migrations directo.
+--
+-- Gate identico a auditoria_integridad (105): service_role (auth.uid() IS NULL)
+-- o rol admin. Solo lectura, sin secretos (devuelve version + name).
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION public.migraciones_aplicadas()
+RETURNS TABLE (version text, name text)
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $function$
+BEGIN
+  IF auth.uid() IS NOT NULL
+     AND NOT EXISTS (SELECT 1 FROM perfiles WHERE id = auth.uid() AND rol = 'admin') THEN
+    RAISE EXCEPTION 'Acceso denegado: se requiere rol admin';
+  END IF;
+
+  RETURN QUERY
+    SELECT m.version, m.name
+    FROM supabase_migrations.schema_migrations m
+    ORDER BY m.version;
+END;
+$function$;
+
+REVOKE EXECUTE ON FUNCTION public.migraciones_aplicadas() FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.migraciones_aplicadas() TO authenticated, service_role;

--- a/migrations/MANIFEST.md
+++ b/migrations/MANIFEST.md
@@ -1,0 +1,106 @@
+# MANIFEST de migraciones — mapeo repo ↔ producción
+
+> **Fechado: 2026-06-30** · Proyecto prod `hmuchlzmuqqxcldbzkgc` (ManaosApp) · región `sa-east-1`.
+
+## Regla de oro
+
+`migrations/` es una **vista curada y consolidada**, **NO** un espejo 1:1 del historial
+aplicado. La **fuente de verdad es producción** (`supabase_migrations.schema_migrations`,
+"el ledger"). Concretamente:
+
+- `000_baseline.sql` es fiel **al 2026-04-21**. Del `001` en adelante son cambios post-baseline.
+- Los archivos a veces **consolidan** varias filas del ledger en una sola, **renombran**, o
+  **renumeran**. Por eso comparar nombres de archivo contra el ledger da falsos positivos.
+- **Antes de asumir que algo "falta" o "está pendiente", verificá en vivo** (abajo).
+
+**Regla práctica:** todo `NNN_<stem>.sql` que **no** aparezca en la tabla de excepciones de
+abajo mapea **1:1** a una fila del ledger con el mismo `stem` (el ledger a veces no lleva el
+prefijo `NNN_`, es normal: guarda el `name` que se pasó al `apply_migration`).
+
+## Cómo verificar drift (en vivo)
+
+- **Agente con MCP de Supabase:** `list_migrations` y comparar con `ls migrations/`. Es lo más
+  directo; no requiere nada más.
+- **CI / humano:** `node scripts/check-migrations.mjs` (env `SUPABASE_URL` +
+  `SUPABASE_SERVICE_ROLE_KEY`). Lee el ledger vía el RPC `public.migraciones_aplicadas()`
+  (creado en `109`) porque el schema `supabase_migrations` no está expuesto por PostgREST.
+
+## Cómo se aplican las migraciones
+
+Hoy se aplican vía **MCP `apply_migration`** (queda registrada en el ledger con su `name`) o,
+ocasionalmente, por el **SQL editor / `execute_sql`** (NO queda en el ledger → "out-of-band";
+ver excepciones). El `db push` por CLI del README es el método histórico/manual.
+
+---
+
+## Excepciones (lo que NO es 1:1)
+
+Convenciones: **consolidado** = varias filas del ledger (iteraciones `CREATE OR REPLACE` o
+hotfixes) plegadas en 1 archivo con el estado final · **out-of-band** = aplicado sin pasar por
+`apply_migration`; backfilleado al ledger el 2026-06-30 con `version` sintética · **dup-NN** =
+número de archivo repetido en el repo (el orden real lo da `version`).
+
+### A. Números de archivo duplicados (mismo `NN`, dos archivos)
+
+| `NN` | archivos en el repo | orden real (por `version` del ledger) |
+|------|---------------------|----------------------------------------|
+| 030 | `030_bot_tomar_pedido.sql`, `030_fix_fraccion_producto_regalo.sql` | `bot_tomar_pedido` (05-01) → `fix_fraccion_producto_regalo` (05-04) |
+| 040 | `040_perfiles_rol_check_encargado.sql`, `040_pedidos_geolocalizacion.sql` | `perfiles_rol_check_encargado` (05-11 19:35) → `pedidos_geolocalizacion` (05-11 21:51) |
+| 080 | `080_clientes_guard_update_preventista.sql`, `080_clientes_proteger_columnas_preventista.sql` | `clientes_guard_update_preventista` (06-10 15:22) → `proteger_columnas_preventista` (06-10 15:27) |
+| 081 | `081_clientes_horario_entrega.sql`, `081_aplicar_orden_ruta.sql` | `clientes_horario_entrega` (06-12 00:56) → `aplicar_orden_ruta` (06-12 17:50) |
+| 091 | `091_fix_promo_acumuladores_resto_y_clamp.sql`, `091_cambio_motivo_mal_estado.sql` | `fix_promo_acumuladores_resto_y_clamp` (06-23) → `cambio_motivo_mal_estado` (06-24) |
+| 100 | `100_costo_snapshot_y_creado_por_columnas.sql`, `100_marcar_entrega_y_pago_masivo.sql` | `costo_snapshot` (06-29, ver C) → `marcar_entrega_y_pago_masivo` (06-30) |
+
+### B. Offset de numeración (repo va +1 respecto del ledger en 098–100)
+
+El repo gastó `098` en `fix_bonif_fraccion`, así que de ahí los números repo y ledger se
+desfasan y **se realinean en `101`**:
+
+| archivo repo | fila(s) del ledger |
+|--------------|--------------------|
+| `098_reporte_gerencial_fix_bonif_fraccion.sql` | `reporte_gerencial_fix_bonif_fraccion` (sin prefijo) |
+| `099_bot_ventas_entregado.sql` | `098_bot_ventas_entregado` |
+| `100_costo_snapshot_y_creado_por_columnas.sql` | `099_costo_snapshot_y_vendedor_id` **+** `100_creado_por_descarta_vendedor_id` (ver C) |
+| `101_crear_pedido_costo_snapshot_creado_por.sql` | `101_crear_pedido_costo_snapshot_creado_por` ✓ realineado |
+
+### C. Out-of-band (vivos en prod, aplicados por SQL editor; backfilleados al ledger el 2026-06-30)
+
+| archivo repo | `version` sintética en el ledger | objeto vivo confirmado |
+|--------------|----------------------------------|------------------------|
+| `085_registrar_pago_combinado_cliente_fifo.sql` | `20260616000085` | fn `registrar_pago_combinado_cliente_fifo` |
+| `086_saldo_a_favor_reduce_saldo_cuenta.sql` | `20260616000086` | trigger `trigger_actualizar_saldo_pago` (UPDATE) |
+| `097_reporte_gerencial_revoke_public.sql` | `20260629000097` | `anon` sin EXECUTE en `reporte_gerencial` |
+
+> Las `version` sintéticas (`…0000NN`) los ordenan entre sus vecinos del repo. El `name` en el
+> ledger lleva el sufijo `(backfill out-of-band 2026-06-30)`.
+
+### D. Consolidaciones (N filas del ledger → 1 archivo)
+
+| archivo repo | filas del ledger consolidadas |
+|--------------|-------------------------------|
+| `011_promo_descripcion_regalo_y_reversion_bloques.sql` | `011a` … `011e` (5 filas) |
+| `012_categorias_activa_y_promo_bundle_pedidos.sql` | `012a`, `012b`, `012c` |
+| `060_preventista_asignable.sql` | `060_preventista_asignable` (×2) + `060_drop_old_crear_pedido_completo_signature` |
+| `061_sustitucion_regalo_fixes.sql` | `060_sustitucion_regalo_fixes` |
+| `064_registrar_salvedad_total_neto_iva.sql` | `064_…` + `064_registrar_salvedad_idempotente_total_neto_iva` |
+| `076_movimientos_sucursal_y_notificaciones.sql` | `076_…` + `076b_revoke_helpers_internos` |
+| `078_control_stock_planilla.sql` | `control_stock_sesiones_y_rpc_aplicar` + `…_fk_usuario` + `fix_aplicar_control_stock_diferencia_generada` |
+| `095_reporte_gerencial.sql` | `reporte_gerencial` + `reporte_gerencial_fix_base_comision` |
+| `105_auditoria_integridad.sql` | `105_…` + `105_…_ventana_2h` + `105_…_fix_cc_saldo_a_favor` |
+| (bot 014–020) | hotfix `020_bot_fix_pgcrypto_schema` plegado en la tanda, sin archivo propio |
+
+**Cadena `reporte_gerencial`** (reescrita ~8 veces por `CREATE OR REPLACE`): el repo versiona
+los hitos (`095`, `097` grants, `098`, `103`, `106`, `107`). Los intermedios del ledger
+`reporte_gerencial_restringir_por_sucursal_asignada` y `reporte_gerencial_desglose_bonif_mermas`
+**no tienen archivo dedicado**: su lógica (p.ej. el gate `v_asignadas`) **sobrevive en el body
+vivo**, que equivale al último archivo (`107`).
+
+---
+
+## Mantenimiento
+
+- Toda migración nueva: archivo `migrations/NNN_descripcion.sql` **y** aplicar por
+  `apply_migration` con `name = NNN_descripcion` (así repo y ledger quedan alineados, sin
+  excepción que documentar).
+- Si aplicás algo por SQL editor, agregalo a la sección C y backfilleá la fila del ledger.
+- Si volvés a tocar este archivo, **actualizá la fecha** del encabezado.

--- a/migrations/README.md
+++ b/migrations/README.md
@@ -1,27 +1,51 @@
 # Migraciones
 
+## ⚠️ Antes que nada: la fuente de verdad es PRODUCCIÓN
+
+Esta carpeta es una **vista curada y consolidada** del historial, **NO un espejo 1:1** de lo
+que está aplicado. La verdad vive en el ledger de prod
+(`supabase_migrations.schema_migrations`). **`migrations/MANIFEST.md`** mapea repo ↔ prod y
+lista todas las divergencias conocidas (duplicados, consolidaciones, out-of-band, offsets).
+
+**Antes de asumir que algo falta o está pendiente, verificá en vivo:**
+
+- **Agente con MCP de Supabase:** `list_migrations` y comparar con `ls migrations/`.
+- **CI / humano:** `npm run check:migrations` (`scripts/check-migrations.mjs`) — falla si hay
+  drift por encima del snapshot reconciliado. Requiere `SUPABASE_URL` + `SUPABASE_SERVICE_ROLE_KEY`.
+  Corre también a diario en `.github/workflows/integridad.yml`.
+
 ## Estado actual
 
-- **`000_baseline.sql`** — dump fiel del schema `public` de la DB de producción **ManaosApp** (`hmuchlzmuqqxcldbzkgc`), generado con `supabase db dump` el 2026-04-21.
+- **`000_baseline.sql`** — dump fiel del schema `public` de prod **ManaosApp**
+  (`hmuchlzmuqqxcldbzkgc`), generado con `supabase db dump` el **2026-04-21**.
   - 39 tablas + 3 vistas, 73 funciones RPC, 115 políticas RLS, 5 extensiones.
-  - Es la única fuente de verdad para el schema. Todo lo previo está consolidado aquí.
-- **`archive/`** — historial consolidado (001–070 + hotfixes datados). **No aplicar.** Solo queda como registro histórico consultable.
+  - Es el punto de partida del schema **al 2026-04-21**. Todo lo previo está consolidado aquí.
+- **`001…NNN_*.sql`** — cambios post-baseline, numerados correlativos. Ver `MANIFEST.md` para el
+  mapeo exacto contra el ledger (algunos archivos consolidan varias filas, renombran o renumeran).
+- **`archive/`** — historial pre-baseline (001–070 + hotfixes). **No aplicar.** Solo registro.
 
 ## Convención para nuevas migraciones
 
-Los próximos cambios van como `001_descripcion.sql`, `002_…`, numerados correlativos después del baseline. Cada archivo debe ser idempotente cuando sea razonable (ej.: `CREATE TABLE IF NOT EXISTS`, `DROP FUNCTION IF EXISTS` antes de recrear).
+1. Crear `migrations/NNN_descripcion.sql` (idempotente cuando sea razonable:
+   `CREATE TABLE IF NOT EXISTS`, `DROP … IF EXISTS` / `CREATE OR REPLACE`, `ON CONFLICT …`).
+2. **Aplicar a prod** y que quede registrado en el ledger con el **mismo nombre**:
+   - **Recomendado — MCP de Supabase:** `apply_migration(name = "NNN_descripcion", query = …)`.
+     Queda en `schema_migrations` automáticamente. Es como se aplica hoy.
+   - SQL editor del dashboard, o CLI:
+     ```bash
+     npx supabase db push --db-url "postgresql://postgres.hmuchlzmuqqxcldbzkgc:<password>@aws-1-sa-east-1.pooler.supabase.com:5432/postgres"
+     ```
+     > Si aplicás por SQL editor/`execute_sql`, **NO** queda en el ledger ("out-of-band"):
+     > registralo después (`INSERT` en `schema_migrations`) y anotalo en `MANIFEST.md §C`.
 
-**Aplicar manualmente** vía el SQL Editor de Supabase, o vía CLI:
-
-```bash
-npx supabase db push --db-url "postgresql://postgres.hmuchlzmuqqxcldbzkgc:<password>@aws-1-sa-east-1.pooler.supabase.com:5432/postgres"
-```
+Mantener archivo y `name` del ledger **alineados** evita que `check:migrations` marque drift y
+que el MANIFEST tenga que documentar la excepción.
 
 Proyecto: `hmuchlzmuqqxcldbzkgc` (región `sa-east-1`, Postgres 17.6.1).
 
 ## Regenerar el baseline
 
-Si el schema de prod cambia fuera de banda y hay que re-sincronizar:
+Si el schema de prod cambia mucho fuera de banda y conviene re-sincronizar el punto de partida:
 
 ```bash
 npx supabase db dump \
@@ -30,4 +54,5 @@ npx supabase db dump \
   -f migrations/000_baseline.sql
 ```
 
-Preservar el header de `000_baseline.sql` (líneas 1–7) después de regenerar.
+Después: preservar el header de `000_baseline.sql` (líneas 1–7), actualizar la **fecha** acá y
+en `MANIFEST.md`, y mover los `NNN_*.sql` ya consolidados a `archive/`.

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "test:e2e:report": "playwright show-report",
     "prepare": "husky",
     "check-secrets": "./scripts/check-secrets.sh",
+    "check:migrations": "node scripts/check-migrations.mjs",
     "typecheck": "tsc --noEmit",
     "typecheck:watch": "tsc --noEmit --watch",
     "generate:pwa-assets": "node scripts/generate-pwa-assets.js",

--- a/scripts/check-migrations.mjs
+++ b/scripts/check-migrations.mjs
@@ -1,0 +1,94 @@
+#!/usr/bin/env node
+/**
+ * Drift-check de migraciones.
+ * Contrasta los archivos migrations/NNN_*.sql contra el ledger REAL de prod
+ * (supabase_migrations.schema_migrations), leído vía el RPC
+ * public.migraciones_aplicadas() (creado en migrations/109).
+ *
+ * Modelo (ver migrations/MANIFEST.md): el historial <= SNAPSHOT ya está
+ * reconciliado y documentado en el MANIFEST — es curado/consolidado, NO 1:1, y
+ * NO se re-chequea acá (daría falsos positivos). Este script vigila que las
+ * migraciones NUEVAS (por encima del snapshot) mantengan el 1:1 archivo<->ledger,
+ * que es la convención a futuro. Atrapa los dos modos de drift reales:
+ *   - aplicado en prod pero sin archivo en el repo (p.ej. el 108 que faltaba)
+ *   - archivo commiteado pero nunca aplicado a prod
+ *
+ * Requiere env: SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY.
+ * Uso local:  SUPABASE_URL=... SUPABASE_SERVICE_ROLE_KEY=... node scripts/check-migrations.mjs
+ */
+import { readdirSync } from 'node:fs';
+
+// Frontera reconciliada el 2026-06-30 (ver MANIFEST.md). Subir estos dos valores
+// SOLO cuando se re-snapshotee el MANIFEST con un histórico nuevo ya verificado.
+const SNAPSHOT_VERSION = '20260630160533'; // 109_migraciones_aplicadas_rpc
+const SNAPSHOT_MAX_FILE = 109;
+
+const url = process.env.SUPABASE_URL;
+const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+if (!url || !key) {
+  console.error('Faltan SUPABASE_URL / SUPABASE_SERVICE_ROLE_KEY en el entorno.');
+  process.exit(2);
+}
+
+// --- 1. Archivos locales (migrations/NNN_*.sql; archive/ y *.md quedan afuera) ---
+const migDir = new URL('../migrations/', import.meta.url);
+const files = readdirSync(migDir).filter((f) => /^\d+.*\.sql$/.test(f));
+
+const fileNum = (f) => parseInt(f.match(/^(\d+)/)[1], 10);
+const fileStem = (f) => f.replace(/^\d+[a-z]?_/, '').replace(/\.sql$/, '');
+
+// --- 2. Ledger en vivo (mismo patrón que scripts/check-integridad.mjs) ---
+const res = await fetch(`${url.replace(/\/$/, '')}/rest/v1/rpc/migraciones_aplicadas`, {
+  method: 'POST',
+  headers: {
+    apikey: key,
+    Authorization: `Bearer ${key}`,
+    'Content-Type': 'application/json',
+  },
+  body: '{}',
+});
+
+if (!res.ok) {
+  console.error(`El RPC migraciones_aplicadas() falló: HTTP ${res.status}\n${await res.text()}`);
+  console.error('¿Aplicaste migrations/109_migraciones_aplicadas_rpc.sql?');
+  process.exit(2);
+}
+
+const ledger = await res.json(); // [{ version, name }]
+// Normaliza el name del ledger al "stem" comparable: saca el sufijo de backfill y el prefijo NNN_.
+const ledgerStem = (name) => name.replace(/\s*\(backfill.*$/i, '').replace(/^\d+[a-z]?_/, '').trim();
+
+// --- 3. Diff por encima del snapshot ---
+const nuevosArchivos = files.filter((f) => fileNum(f) > SNAPSHOT_MAX_FILE);
+const nuevasFilas = ledger.filter((m) => m.version > SNAPSHOT_VERSION);
+
+const stemsArchivo = new Set(nuevosArchivos.map(fileStem));
+const stemsLedger = new Set(nuevasFilas.map((m) => ledgerStem(m.name)));
+
+const aplicadoSinArchivo = nuevasFilas.filter((m) => !stemsArchivo.has(ledgerStem(m.name)));
+const archivoSinAplicar = nuevosArchivos.filter((f) => !stemsLedger.has(fileStem(f)));
+
+// --- 4. Reporte ---
+console.log(`Drift-check de migraciones @ snapshot ${SNAPSHOT_VERSION} (archivos <= ${SNAPSHOT_MAX_FILE} reconciliados en MANIFEST.md)`);
+console.log(`Ledger en prod: ${ledger.length} filas | archivos repo: ${files.length}`);
+console.log(`Nuevos desde el snapshot — archivos: ${nuevosArchivos.length}, filas de ledger: ${nuevasFilas.length}`);
+
+if (aplicadoSinArchivo.length) {
+  console.log('\n❌ Aplicado en prod pero SIN archivo en migrations/:');
+  for (const m of aplicadoSinArchivo) console.log(`   ${m.version}  ${m.name}`);
+}
+if (archivoSinAplicar.length) {
+  console.log('\n❌ Archivo en migrations/ pero NO aplicado en prod (o con nombre distinto):');
+  for (const f of archivoSinAplicar) console.log(`   ${f}`);
+}
+
+if (aplicadoSinArchivo.length || archivoSinAplicar.length) {
+  console.error(
+    '\n❌ Drift detectado. Reconciliá (agregá el archivo / aplicá la migración / alineá el name) ' +
+    'o, si es legítimo, actualizá migrations/MANIFEST.md y subí el snapshot en este script.',
+  );
+  process.exit(1);
+}
+
+console.log('\n✅ Sin drift por encima del snapshot. migrations/ alineado con prod.');


### PR DESCRIPTION
## Contexto

`migrations/` era una **vista curada/consolidada** que driftó del historial real de prod (`supabase_migrations.schema_migrations`). La propia memoria del proyecto avisaba "los archivos de `migrations/` NO reflejan prod, verificar en vivo". Esto realinea la carpeta con la realidad y deja **tooling** para que un agente futuro no tenga que adivinar.

## Drift encontrado (verificado en vivo)

- `108_metas_gerenciales` aplicado en prod **sin archivo** en el repo.
- `085`, `086` y `097` **vivos en prod pero fuera del ledger** (aplicados por SQL editor / out-of-band).
- 6 números de archivo duplicados; offset de numeración 098-100; varias `reporte_gerencial_*` consolidadas.

## Cambios en el repo

| Archivo | Qué |
|---|---|
| `migrations/108_metas_gerenciales.sql` *(nuevo)* | Backfill del archivo faltante — espejo exacto de los objetos vivos (columnas + firma verificadas). |
| `migrations/MANIFEST.md` *(nuevo)* | Mapeo **fechado** repo↔ledger + todas las divergencias (duplicados, offset, consolidaciones, out-of-band). Durable: lista excepciones; lo no listado mapea 1:1. |
| `migrations/109_migraciones_aplicadas_rpc.sql` *(nuevo)* | RPC `migraciones_aplicadas()` (gate admin/servicio) para leer el ledger (PostgREST no expone `supabase_migrations`). |
| `scripts/check-migrations.mjs` *(nuevo)* | Drift-check repo vs prod. Congela el histórico ≤ snapshot y vigila el 1:1 de migraciones nuevas. |
| `migrations/README.md` | Reescrito: prod = fuente de verdad, apply vía MCP, baseline fiel **al 2026-04-21**, punteros a MANIFEST + drift-check. |
| `package.json` · `.github/workflows/integridad.yml` | `npm run check:migrations` + step diario en CI. |

## Reconciliación de prod (ya aplicada vía MCP, fuera de este diff)

- Aplicada la mig **109** (RPC, viva y verificada).
- Backfilleadas al ledger las filas out-of-band **085/086/097** (objetos vivos confirmados, ordenadas entre sus vecinos).

## Verificación

- ✅ 5 filas confirmadas en el ledger vivo (085/086/097/108/109).
- ✅ `108` == objetos vivos (columnas y firma exactas).
- ✅ Lógica del drift-check probada en 3 casos (limpio / aplicado-sin-archivo / archivo-sin-aplicar) + guard de env.
- ✅ `npm run test:run` → **741 tests passed** (corrió en el pre-commit). eslint y `package.json` OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)