### PR TITLE
fix(reportes): las alertas abren la lista que referencian

### DIFF
--- a/migrations/109_reporte_alerta_detalle.sql
+++ b/migrations/109_reporte_alerta_detalle.sql
@@ -1,0 +1,87 @@
+-- ============================================================================
+-- 109 · reporte_alerta_detalle: lista on-demand detrás de cada alerta (BI)
+-- ============================================================================
+-- Al hacer click en una alerta, el front trae acá la LISTA concreta que la
+-- alerta referencia (clientes que deben, clientes inactivos, productos sin
+-- costo). Lazy: solo se llama al click. Admin-only + scope de sucursal, igual
+-- que reporte_gerencial. p_sucursal_id NULL = red.
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION public.reporte_alerta_detalle(
+  p_sucursal_id bigint,
+  p_codigo text
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+STABLE SECURITY DEFINER
+SET search_path = public
+AS $function$
+DECLARE
+  v_sucursales bigint[];
+  v_asignadas bigint[];
+  v_es_servicio boolean := (auth.uid() IS NULL);
+  v_result jsonb;
+BEGIN
+  IF NOT v_es_servicio THEN
+    IF NOT EXISTS (SELECT 1 FROM perfiles WHERE id = auth.uid() AND rol = 'admin') THEN
+      RAISE EXCEPTION 'Acceso denegado: se requiere rol admin'; END IF;
+    SELECT array_agg(sucursal_id) INTO v_asignadas FROM usuario_sucursales WHERE usuario_id = auth.uid();
+    IF v_asignadas IS NULL THEN RAISE EXCEPTION 'Acceso denegado: el usuario no tiene sucursales asignadas'; END IF;
+  END IF;
+  IF p_sucursal_id IS NULL THEN
+    SELECT array_agg(id) INTO v_sucursales FROM sucursales WHERE activa;
+    IF NOT v_es_servicio THEN
+      SELECT array_agg(s) INTO v_sucursales FROM unnest(v_sucursales) AS s WHERE s = ANY(v_asignadas); END IF;
+  ELSE
+    IF NOT v_es_servicio AND NOT (p_sucursal_id = ANY(v_asignadas)) THEN
+      RAISE EXCEPTION 'Acceso denegado: la sucursal % no está asignada al usuario', p_sucursal_id; END IF;
+    v_sucursales := ARRAY[p_sucursal_id];
+  END IF;
+  IF v_sucursales IS NULL OR array_length(v_sucursales,1) IS NULL THEN
+    RETURN '[]'::jsonb; END IF;
+
+  IF p_codigo = 'cobranza_vencida' THEN
+    SELECT COALESCE(jsonb_agg(jsonb_build_object('nombre', nombre, 'valor', valor, 'detalle', detalle) ORDER BY valor DESC), '[]')
+      INTO v_result FROM (
+      SELECT COALESCE(NULLIF(c.nombre_fantasia,''), c.razon_social) AS nombre,
+             SUM(p.total - COALESCE(p.monto_pagado,0)) AS valor,
+             'hace ' || MAX(CURRENT_DATE - p.fecha) || ' días' AS detalle
+      FROM pedidos p JOIN clientes c ON c.id = p.cliente_id
+      WHERE p.estado='entregado' AND p.canal='app' AND p.sucursal_id = ANY(v_sucursales)
+        AND COALESCE(p.estado_pago,'pendiente') IN ('pendiente','parcial')
+        AND p.fecha < CURRENT_DATE - 30 AND p.total > COALESCE(p.monto_pagado,0)
+      GROUP BY c.id, c.nombre_fantasia, c.razon_social
+      LIMIT 100
+    ) t;
+  ELSIF p_codigo = 'clientes_inactivos' THEN
+    SELECT COALESCE(jsonb_agg(jsonb_build_object('nombre', nombre, 'valor', valor, 'detalle', detalle) ORDER BY valor DESC NULLS LAST), '[]')
+      INTO v_result FROM (
+      SELECT COALESCE(NULLIF(c.nombre_fantasia,''), c.razon_social) AS nombre,
+             COALESCE(SUM(p.total) FILTER (WHERE p.fecha >= CURRENT_DATE - 90), 0) AS valor,
+             'sin comprar hace ' || (CURRENT_DATE - MAX(p.fecha)) || ' días' AS detalle
+      FROM pedidos p JOIN clientes c ON c.id = p.cliente_id
+      WHERE p.estado='entregado' AND p.canal='app' AND p.sucursal_id = ANY(v_sucursales)
+      GROUP BY c.id, c.nombre_fantasia, c.razon_social
+      HAVING MAX(p.fecha) < CURRENT_DATE - 30 AND MAX(p.fecha) >= CURRENT_DATE - 90
+      LIMIT 200
+    ) t;
+  ELSIF p_codigo = 'productos_sin_costo' THEN
+    SELECT COALESCE(jsonb_agg(jsonb_build_object('nombre', nombre, 'valor', valor, 'detalle', detalle) ORDER BY valor DESC), '[]')
+      INTO v_result FROM (
+      SELECT prod.nombre AS nombre, SUM(pi.subtotal) AS valor, 'sin costo cargado' AS detalle
+      FROM pedido_items pi JOIN pedidos p ON p.id = pi.pedido_id JOIN productos prod ON prod.id = pi.producto_id
+      WHERE p.estado='entregado' AND p.canal='app' AND p.sucursal_id = ANY(v_sucursales)
+        AND NOT pi.es_bonificacion AND (prod.costo_sin_iva IS NULL OR prod.costo_sin_iva = 0)
+      GROUP BY prod.id, prod.nombre
+      LIMIT 100
+    ) t;
+  ELSE
+    v_result := '[]'::jsonb;
+  END IF;
+
+  RETURN COALESCE(v_result, '[]'::jsonb);
+END;
+$function$;
+
+REVOKE EXECUTE ON FUNCTION public.reporte_alerta_detalle(bigint, text) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.reporte_alerta_detalle(bigint, text) TO authenticated, service_role;

--- a/src/components/vistas/VistaReportesGerenciales.tsx
+++ b/src/components/vistas/VistaReportesGerenciales.tsx
@@ -11,7 +11,11 @@ import {
 import Sparkline from './reportes-gerenciales/Sparkline'
 import Alertas from './reportes-gerenciales/Alertas'
 import ModalMetas from './reportes-gerenciales/ModalMetas'
-import type { ReporteGerencial, AnalisisMensual, MetasGerenciales } from '../../hooks/queries'
+import ModalAlertaDetalle from './reportes-gerenciales/ModalAlertaDetalle'
+import type { ReporteGerencial, AnalisisMensual, MetasGerenciales, Alerta } from '../../hooks/queries'
+
+// Alertas cuyo detalle es una LISTA (modal). El resto hace scroll a su sección.
+const ALERTA_CON_LISTA = new Set(['cobranza_vencida', 'clientes_inactivos', 'productos_sin_costo'])
 
 export interface PeriodoOpt {
   key: string
@@ -142,9 +146,18 @@ export default function VistaReportesGerenciales({
 
   const metasOn = periodoSel.esMes && !!metas && (metas.venta != null || metas.margen_neto != null)
 
+  const [alertaDetalle, setAlertaDetalle] = useState<Alerta | null>(null)
+
   const irASeccion = (seccion: string): void => {
     setDetalleAbierto(true)
     setTimeout(() => document.getElementById(`sec-${seccion}`)?.scrollIntoView({ behavior: 'smooth', block: 'start' }), 80)
+  }
+
+  // Click en una alerta: si tiene lista (clientes que deben, inactivos…) abre un
+  // modal con esa lista; si no, baja a la sección relacionada.
+  const onAlerta = (a: Alerta): void => {
+    if (ALERTA_CON_LISTA.has(a.codigo)) setAlertaDetalle(a)
+    else irASeccion(a.seccion)
   }
 
   useEffect(() => {
@@ -313,7 +326,7 @@ export default function VistaReportesGerenciales({
           )}
 
           {/* Qué requiere tu atención */}
-          <Alertas items={reporte.alertas ?? []} onSelect={irASeccion} />
+          <Alertas items={reporte.alertas ?? []} onSelect={onAlerta} />
 
           {/* Detalle completo: colapsable; los gráficos montan recién al abrir (perf) */}
           <button
@@ -575,6 +588,15 @@ export default function VistaReportesGerenciales({
           guardando={guardandoMeta}
           onGuardar={(v, m) => { onGuardarMeta(v, m); setShowMetas(false) }}
           onClose={() => setShowMetas(false)}
+        />
+      )}
+
+      {alertaDetalle && (
+        <ModalAlertaDetalle
+          titulo={alertaDetalle.titulo}
+          codigo={alertaDetalle.codigo}
+          sucursalId={sucursalSel}
+          onClose={() => setAlertaDetalle(null)}
         />
       )}
     </div>

--- a/src/components/vistas/reportes-gerenciales/Alertas.tsx
+++ b/src/components/vistas/reportes-gerenciales/Alertas.tsx
@@ -9,7 +9,7 @@ const STYLE: Record<Alerta['severidad'], { icon: React.ElementType; cls: string 
 }
 
 /** Panel "Qué requiere tu atención". Cada alerta es clickeable → drill a su sección. */
-export default function Alertas({ items, onSelect }: { items: Alerta[]; onSelect?: (seccion: string) => void }): React.ReactElement | null {
+export default function Alertas({ items, onSelect }: { items: Alerta[]; onSelect?: (alerta: Alerta) => void }): React.ReactElement | null {
   if (!items?.length) return null
   return (
     <div className="bg-white dark:bg-gray-800 border dark:border-gray-700 rounded-xl shadow-sm p-4">
@@ -24,7 +24,7 @@ export default function Alertas({ items, onSelect }: { items: Alerta[]; onSelect
             <button
               key={a.codigo}
               type="button"
-              onClick={() => onSelect?.(a.seccion)}
+              onClick={() => onSelect?.(a)}
               className={`flex items-start gap-2 text-left border rounded-lg px-3 py-2 transition hover:brightness-95 ${s.cls}`}
             >
               <Icon className="w-4 h-4 mt-0.5 shrink-0" />

--- a/src/components/vistas/reportes-gerenciales/ModalAlertaDetalle.tsx
+++ b/src/components/vistas/reportes-gerenciales/ModalAlertaDetalle.tsx
@@ -1,0 +1,54 @@
+import React from 'react'
+import { X, Loader2 } from 'lucide-react'
+import { moneyC } from './formato'
+import { useAlertaDetalleQuery } from '../../../hooks/queries'
+
+/** Muestra la lista concreta detrás de una alerta (clientes que deben, inactivos, etc.). */
+export default function ModalAlertaDetalle({
+  titulo,
+  codigo,
+  sucursalId,
+  onClose,
+}: {
+  titulo: string
+  codigo: string
+  sucursalId: number | null
+  onClose: () => void
+}): React.ReactElement {
+  const { data, isLoading, error } = useAlertaDetalleQuery(sucursalId, codigo)
+  const items = data ?? []
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4" onClick={onClose}>
+      <div className="bg-white dark:bg-gray-800 rounded-xl shadow-xl w-full max-w-md max-h-[80vh] flex flex-col" onClick={(e) => e.stopPropagation()}>
+        <div className="flex items-center justify-between p-4 border-b dark:border-gray-700">
+          <h3 className="text-base font-bold text-gray-900 dark:text-white">
+            {titulo}{!isLoading && <span className="ml-2 text-sm font-normal text-gray-400">{items.length}</span>}
+          </h3>
+          <button onClick={onClose} className="text-gray-400 hover:text-gray-600" aria-label="Cerrar"><X className="w-5 h-5" /></button>
+        </div>
+        <div className="overflow-y-auto p-2">
+          {isLoading ? (
+            <div className="flex items-center justify-center py-10"><Loader2 className="w-6 h-6 animate-spin text-blue-600" /></div>
+          ) : error ? (
+            <p className="p-4 text-sm text-red-600 dark:text-red-400">{(error as Error).message}</p>
+          ) : items.length === 0 ? (
+            <p className="p-4 text-sm text-gray-500 dark:text-gray-400">Sin datos para mostrar.</p>
+          ) : (
+            <ul className="divide-y dark:divide-gray-700/60">
+              {items.map((it, i) => (
+                <li key={it.nombre + i} className="flex items-center justify-between gap-3 px-3 py-2">
+                  <div className="min-w-0">
+                    <div className="text-sm font-medium text-gray-800 dark:text-gray-100 truncate">{it.nombre}</div>
+                    <div className="text-xs text-gray-500 dark:text-gray-400">{it.detalle}</div>
+                  </div>
+                  <div className="text-sm font-semibold tabular-nums text-gray-900 dark:text-white shrink-0">{moneyC(it.valor)}</div>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/hooks/queries/index.ts
+++ b/src/hooks/queries/index.ts
@@ -232,6 +232,7 @@ export {
   useAnalisisMensualQuery,
   useMetasGerencialQuery,
   useGuardarMetaMutation,
+  useAlertaDetalleQuery,
 } from './useReporteGerencialQuery'
 export type {
   ReporteGerencial,
@@ -244,6 +245,7 @@ export type {
   ReporteCobranza,
   Alerta,
   MetasGerenciales,
+  AlertaDetalleItem,
   AnalisisMensual,
 } from './useReporteGerencialQuery'
 

--- a/src/hooks/queries/useReporteGerencialQuery.ts
+++ b/src/hooks/queries/useReporteGerencialQuery.ts
@@ -157,6 +157,33 @@ export interface MetasGerenciales {
   margen_neto: number | null
 }
 
+export interface AlertaDetalleItem {
+  nombre: string
+  valor: number
+  detalle: string
+}
+
+/** Lista detrás de una alerta (lazy: solo al hacer click). codigo = alerta.codigo. */
+export function useAlertaDetalleQuery(
+  sucursalId: number | null,
+  codigo: string | null,
+  enabled = true,
+) {
+  return useQuery({
+    queryKey: ['alerta-detalle', sucursalId, codigo] as const,
+    queryFn: async (): Promise<AlertaDetalleItem[]> => {
+      const { data, error } = await supabase.rpc('reporte_alerta_detalle', {
+        p_sucursal_id: sucursalId,
+        p_codigo: codigo,
+      })
+      if (error) throw new Error(error.message)
+      return (data as AlertaDetalleItem[] | null) ?? []
+    },
+    enabled: enabled && !!codigo,
+    staleTime: 5 * 60 * 1000,
+  })
+}
+
 /** Metas (objetivos) del mes para una sucursal (null = red). Sólo aplica a meses. */
 export function useMetasGerencialQuery(
   sucursalId: number | null,


### PR DESCRIPTION
## Problema
Al hacer click en una alerta del panel, la pantalla bajaba a una sección que **no mostraba lo que la alerta menciona** (no hay sección con "los 6 clientes que deben" ni "los 131 que dejaron de comprar").

## Fix
- **mig 109** (aplicada en prod): RPC `reporte_alerta_detalle(p_sucursal_id, p_codigo)` devuelve **on-demand** (lazy, sólo al click) la lista detrás de la alerta:
  - `cobranza_vencida` → clientes con saldo impago + monto + días de atraso.
  - `clientes_inactivos` → clientes + días sin comprar + venta de los últimos 90d.
  - `productos_sin_costo` → productos sin costo + facturación.
  Admin-only + scope de sucursal, igual que `reporte_gerencial`.
- **Front**: click en esas alertas abre un **modal con la lista** (`ModalAlertaDetalle`). Las demás (venta caída, mermas, categorías) siguen haciendo scroll a su sección (que sí muestra el dato).

## Verificación
- RPC probado en prod: cobranza 6 clientes (top $119.870, 31 días), inactivos 130 (top $514.180). typecheck sin errores nuevos; pre-commit verde.
- Al mergear: click en "Cobranza vencida"/"Clientes que dejaron de comprar" → modal con la lista concreta.

🤖 Generated with [Claude Code](https://claude.com/claude-code)