### PR TITLE
fix(cambios): arreglar el cambio/devolución roto + feat: quitar promoción al crear/editar pedido

### DIFF
--- a/src/components/containers/PedidosContainer.tsx
+++ b/src/components/containers/PedidosContainer.tsx
@@ -279,6 +279,11 @@ export default function PedidosContainer(): React.ReactElement {
   // Override del producto del regalo al crear (solo admin). promoId -> producto elegido.
   const [regalosOverride, setRegalosOverride] = useState<Record<string, RegaloOverride>>({})
 
+  // Promos quitadas a mano al crear el pedido (admin/preventista/encargado).
+  // Guarda {id, nombre} para mostrar la fila "quitada" y restaurar sin re-resolver.
+  const [promosEliminadas, setPromosEliminadas] = useState<Array<{ promoId: string; promoNombre: string }>>([])
+  const promosEliminadasSet = useMemo(() => new Set(promosEliminadas.map(p => p.promoId)), [promosEliminadas])
+
   const resetNuevoPedido = useCallback(() => {
     setNuevoPedido({
       clienteId: '', items: [], notas: '',
@@ -289,6 +294,7 @@ export default function PedidosContainer(): React.ReactElement {
       preventistaId: undefined,
     })
     setRegalosOverride({})
+    setPromosEliminadas([])
   }, [])
 
   // Admin elige/cambia el producto del regalo de una promo al crear el pedido.
@@ -302,8 +308,30 @@ export default function PedidosContainer(): React.ReactElement {
     }))
   }, [productos])
 
-  // Resolve wholesale prices + promos (con override del regalo elegido por admin)
-  const { itemsFinales } = usePromocionPedido(nuevoPedido.items, undefined, regalosOverride)
+  // Quitar una promo del pedido en creación, con alerta de confirmación de por
+  // medio. Disponible para quien pueda crear pedidos (admin/preventista/encargado).
+  const handleEliminarPromoCreacion = useCallback((promoId: string, promoNombre: string) => {
+    setConfirmConfig({
+      visible: true,
+      tipo: 'warning',
+      titulo: 'Quitar promoción',
+      mensaje: `¿Quitar la promoción "${promoNombre}" de este pedido? El cliente no recibirá la bonificación.`,
+      onConfirm: () => {
+        setConfirmConfig({ visible: false })
+        setPromosEliminadas(prev =>
+          prev.some(p => p.promoId === promoId) ? prev : [...prev, { promoId, promoNombre }],
+        )
+      },
+    })
+  }, [])
+
+  const handleRestaurarPromoCreacion = useCallback((promoId: string) => {
+    setPromosEliminadas(prev => prev.filter(p => p.promoId !== promoId))
+  }, [])
+
+  // Resolve wholesale prices + promos (con override del regalo elegido por admin
+  // y las promos que el usuario haya quitado a mano)
+  const { itemsFinales } = usePromocionPedido(nuevoPedido.items, undefined, regalosOverride, promosEliminadasSet)
 
   // =========================================================================
   // VistaPedidos handlers
@@ -1495,6 +1523,9 @@ export default function PedidosContainer(): React.ReactElement {
             nuevoPedido={nuevoPedido}
             regalosOverride={regalosOverride}
             onCambiarRegaloCreacion={handleCambiarRegaloCreacion}
+            promosEliminadas={promosEliminadas}
+            onEliminarPromoCreacion={handleEliminarPromoCreacion}
+            onRestaurarPromoCreacion={handleRestaurarPromoCreacion}
             onClose={() => { setModalPedidoOpen(false); resetNuevoPedido() }}
             onClienteChange={(id: string) => setNuevoPedido(prev => ({ ...prev, clienteId: id }))}
             onAgregarItem={(productoId: string) => {
@@ -1593,6 +1624,7 @@ export default function PedidosContainer(): React.ReactElement {
               (isPreventista && preventistaPuedeEditar(pedidoEditando, user?.id))
             }
             canSustituirRegalo={isAdmin || isEncargado}
+            canEliminarPromo={isAdmin || isPreventista || isEncargado}
             canEditPreventista={isAdmin}
             canCambiarCliente={isAdmin}
             clientes={clientes}

--- a/src/components/modals/ModalCambioProducto.test.ts
+++ b/src/components/modals/ModalCambioProducto.test.ts
@@ -1,0 +1,64 @@
+/**
+ * Tests del schema de validación del cambio/devolución.
+ *
+ * Regresión: clientes.id y productos.id son bigint → PostgREST los devuelve como
+ * NUMBER en runtime. Con z.string() el número fallaba el chequeo de tipo base y
+ * devolvía "Invalid input", por lo que el cambio NUNCA se pudo cargar. El schema
+ * ahora usa z.coerce.string() para tolerar ids numéricos.
+ */
+import { describe, it, expect } from 'vitest'
+import { modalCambioProductoSchema } from './ModalCambioProducto'
+
+const baseNumerico = {
+  clienteId: 123,
+  productoDevueltoId: 45,
+  cantidadDevuelta: 2,
+  productoEntregadoId: 45,
+  cantidadEntregada: 2,
+  observaciones: '',
+  motivo: 'vencimiento' as const,
+}
+
+describe('modalCambioProductoSchema', () => {
+  it('acepta ids NUMÉRICOS (el caso real de runtime: bigint → number)', () => {
+    const result = modalCambioProductoSchema.safeParse(baseNumerico)
+    expect(result.success).toBe(true)
+    if (result.success) {
+      // coerce normaliza a string para el RPC (que hace Number(...))
+      expect(result.data.clienteId).toBe('123')
+      expect(result.data.productoDevueltoId).toBe('45')
+      expect(result.data.productoEntregadoId).toBe('45')
+    }
+  })
+
+  it('acepta ids string (por si algún path los stringifica)', () => {
+    const result = modalCambioProductoSchema.safeParse({
+      ...baseNumerico,
+      clienteId: '123',
+      productoDevueltoId: '45',
+      productoEntregadoId: '45',
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('rechaza cliente sin seleccionar (string vacío) con el mensaje en español', () => {
+    const result = modalCambioProductoSchema.safeParse({ ...baseNumerico, clienteId: '' })
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      const msg = result.error.issues.find(i => i.path[0] === 'clienteId')?.message
+      expect(msg).toBe('Debe seleccionar un cliente')
+    }
+  })
+
+  it('rechaza cantidad no positiva', () => {
+    const result = modalCambioProductoSchema.safeParse({ ...baseNumerico, cantidadDevuelta: 0 })
+    expect(result.success).toBe(false)
+  })
+
+  it('aplica el default de motivo cuando falta', () => {
+    const { motivo: _omit, ...sinMotivo } = baseNumerico
+    const result = modalCambioProductoSchema.safeParse(sinMotivo)
+    expect(result.success).toBe(true)
+    if (result.success) expect(result.data.motivo).toBe('erroneo')
+  })
+})

--- a/src/components/modals/ModalCambioProducto.tsx
+++ b/src/components/modals/ModalCambioProducto.tsx
@@ -14,14 +14,25 @@ export type MotivoCambio = 'vencimiento' | 'rotura' | 'mal_estado' | 'erroneo' |
 // 'mal_estado' daba "Invalid input" validado contra un enum viejo. Acá la
 // validación viaja SIEMPRE en el mismo chunk que la UI: no pueden desfasarse.
 // Las opciones del enum deben coincidir con MOTIVOS_CAMBIO / MotivoCambio.
-const modalCambioProductoSchema = z.object({
-  clienteId: z.string().min(1, { message: 'Debe seleccionar un cliente' }),
-  productoDevueltoId: z.string().min(1, { message: 'Debe seleccionar el producto a devolver' }),
+//
+// Los ids se validan con z.coerce.string(): clientes.id y productos.id son
+// bigint en Postgres y PostgREST los devuelve como NUMBER en runtime (los hooks
+// useClientesQuery/useProductosQuery no los stringifican, a diferencia de
+// pedidos/promos). Con z.string() el número fallaba el chequeo de tipo base y
+// devolvía "Invalid input" — por eso el cambio nunca se pudo cargar. coerce
+// normaliza number→string; '' (sin selección) sigue fallando el .min(1).
+//
+// Se exporta SÓLO para el test unitario de regresión; debe seguir co-locado acá
+// (mover el schema reintroduce el riesgo de chunk desincronizado del PWA).
+// eslint-disable-next-line react-refresh/only-export-components
+export const modalCambioProductoSchema = z.object({
+  clienteId: z.coerce.string().min(1, { message: 'Debe seleccionar un cliente' }),
+  productoDevueltoId: z.coerce.string().min(1, { message: 'Debe seleccionar el producto a devolver' }),
   cantidadDevuelta: z.coerce
     .number({ error: 'La cantidad debe ser un número' })
     .int({ message: 'La cantidad debe ser un número entero' })
     .positive({ message: 'La cantidad debe ser mayor a 0' }),
-  productoEntregadoId: z.string().min(1, { message: 'Debe seleccionar el producto a entregar' }),
+  productoEntregadoId: z.coerce.string().min(1, { message: 'Debe seleccionar el producto a entregar' }),
   cantidadEntregada: z.coerce
     .number({ error: 'La cantidad debe ser un número' })
     .int({ message: 'La cantidad debe ser un número entero' })

--- a/src/components/modals/ModalEditarPedido.tsx
+++ b/src/components/modals/ModalEditarPedido.tsx
@@ -56,6 +56,8 @@ export interface ModalEditarPedidoProps {
   canEditFechaEntrega?: boolean;
   /** Permite sustituir el producto de un regalo de promo. Default: false. Solo admin/encargado. */
   canSustituirRegalo?: boolean;
+  /** Permite quitar una promoción del pedido (con confirmación). Default: false. Admin/preventista/encargado. */
+  canEliminarPromo?: boolean;
   /** Permite reasignar el preventista del pedido. Default: false. Solo admin. */
   canEditPreventista?: boolean;
   /** Permite cambiar el cliente del pedido (cancela el viejo + crea uno nuevo). Default: false. Solo admin. */
@@ -85,6 +87,7 @@ const ModalEditarPedido = memo(function ModalEditarPedido({
   canEditPrices,
   canEditFechaEntrega,
   canSustituirRegalo = false,
+  canEliminarPromo = false,
   canEditPreventista = false,
   canCambiarCliente = false,
   clientes = [],
@@ -111,6 +114,11 @@ const ModalEditarPedido = memo(function ModalEditarPedido({
   const [fechaEntregaProgramada, setFechaEntregaProgramada] = useState<string>(fechaEntregaProgramadaOriginal);
   const [errorValidacion, setErrorValidacion] = useState<string>('');
   const [confirmConfig, setConfirmConfig] = useState<ModalConfirmacionConfig | null>(null);
+
+  // Promos que el usuario quitó a mano en esta edición. Guarda {id, nombre} para
+  // mostrar la fila "quitada" + restaurar sin re-resolver. Al guardar, la promo
+  // excluida no viaja en itemsBonif y actualizar_pedido_items borra su regalo.
+  const [promosEliminadas, setPromosEliminadas] = useState<Array<{ promoId: string; promoNombre: string }>>([]);
 
   // Zod validation (solo notas; el pago se maneja en ModalRegistrarPago)
   const { validate } = useZodValidation(modalEditarPedidoSchema);
@@ -265,12 +273,39 @@ const ModalEditarPedido = memo(function ModalEditarPedido({
   // Así promos vigentes al momento de la creación siguen aplicando; y promos
   // creadas DESPUÉS del pedido no se aplican retroactivamente.
   const fechaReferenciaPromo = pedido?.fecha || undefined;
+  const promosEliminadasSet = useMemo(
+    () => new Set(promosEliminadas.map(p => p.promoId)),
+    [promosEliminadas],
+  );
   const {
     itemsFinales,
     totalFinal,
     moqMap,
     isLoading: promosLoading,
-  } = usePromocionPedido(itemsConPrecioBase, fechaReferenciaPromo);
+  } = usePromocionPedido(itemsConPrecioBase, fechaReferenciaPromo, undefined, promosEliminadasSet);
+
+  const hayPromosQuitadas = promosEliminadas.length > 0;
+
+  // Quitar una promo del pedido (con alerta). Se aplica al guardar: la promo
+  // excluida no genera bonificación y el RPC borra su regalo + restaura stock.
+  const handleQuitarPromo = (promoId: string, promoNombre: string): void => {
+    setConfirmConfig({
+      visible: true,
+      tipo: 'warning',
+      titulo: 'Quitar promoción',
+      mensaje: `¿Quitar la promoción "${promoNombre}" de este pedido? Al guardar se elimina la bonificación y se restaura el stock si corresponde.`,
+      onConfirm: () => {
+        setConfirmConfig(null);
+        setPromosEliminadas(prev =>
+          prev.some(p => p.promoId === promoId) ? prev : [...prev, { promoId, promoNombre }],
+        );
+      },
+    });
+  };
+
+  const handleRestaurarPromo = (promoId: string): void => {
+    setPromosEliminadas(prev => prev.filter(p => p.promoId !== promoId));
+  };
 
   // Mapa de precios resueltos para mostrar en cada item no-bonif
   const preciosResueltosMap = useMemo(() => {
@@ -502,9 +537,12 @@ const ModalEditarPedido = memo(function ModalEditarPedido({
     fechaEntregaCambio: boolean,
   ): Promise<void> => {
     try {
-      // Si hay cambios en items y el usuario puede editarlos, guardar items con
-      // precios mayoristas resueltos, desglose fiscal y bonificaciones recalculadas.
-      if (itemsModificados && puedeEditarItems && onSaveItems) {
+      // Si hay cambios en items (con permiso de edición) O se quitó alguna promo
+      // a mano, guardar items con precios resueltos, desglose fiscal y las
+      // bonificaciones recalculadas (que ya excluyen las promos quitadas). Quitar
+      // una promo no requiere permiso de edición de ítems: el RPC
+      // actualizar_pedido_items autoriza admin/encargado/preventista.
+      if (((itemsModificados && puedeEditarItems) || hayPromosQuitadas) && onSaveItems) {
         const tipoFactura = pedido?.tipo_factura || 'ZZ';
 
         // Items no-bonif del estado → con precio resuelto + desglose fiscal
@@ -597,7 +635,9 @@ const ModalEditarPedido = memo(function ModalEditarPedido({
               <span className="text-xs text-gray-500">(solo lectura)</span>
             </div>
             <div className="divide-y dark:divide-gray-600">
-              {pedido.items?.map(item => (
+              {/* Se oculta el regalo de una promo quitada (aún sin guardar): su
+                  gestión vive en "Promociones aplicadas". El resto se muestra igual. */}
+              {pedido.items?.filter(item => !(item.es_bonificacion && item.promocion_id != null && promosEliminadasSet.has(String(item.promocion_id)))).map(item => (
                 <div key={item.producto_id} className="p-3 flex items-center justify-between">
                   <div className="flex-1">
                     <p className="font-medium text-sm dark:text-white">{item.producto?.nombre || 'Producto'}</p>
@@ -830,7 +870,86 @@ const ModalEditarPedido = memo(function ModalEditarPedido({
                       </p>
                     </div>
                   </div>
-                  <span className="text-sm font-bold text-green-600">$0</span>
+                  <div className="flex items-center gap-2 shrink-0">
+                    <span className="text-sm font-bold text-green-600">$0</span>
+                    {canEliminarPromo && bonif.promocionId && (
+                      <button
+                        type="button"
+                        onClick={() => handleQuitarPromo(String(bonif.promocionId), bonif.promoNombre ?? bonif.nombre)}
+                        className="p-1 text-red-500 hover:bg-red-100 dark:hover:bg-red-900/30 rounded"
+                        title="Quitar esta promoción del pedido"
+                        aria-label="Quitar promoción"
+                      >
+                        <X className="w-4 h-4" />
+                      </button>
+                    )}
+                  </div>
+                </div>
+              ))}
+              {/* Promos quitadas a mano — restaurables antes de guardar */}
+              {promosEliminadas.map(p => (
+                <div key={`promo-quitada-${p.promoId}`} className="p-3 flex items-center justify-between bg-gray-50 dark:bg-gray-800/40">
+                  <p className="text-xs text-gray-500 dark:text-gray-400 min-w-0 truncate">
+                    Promoción quitada: <span className="font-medium">{p.promoNombre}</span>
+                  </p>
+                  <button
+                    type="button"
+                    onClick={() => handleRestaurarPromo(p.promoId)}
+                    className="text-xs font-medium text-indigo-600 dark:text-indigo-400 hover:underline shrink-0"
+                  >
+                    Restaurar
+                  </button>
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {/* Promociones aplicadas — visible cuando NO se editan ítems (encargado/
+            preventista ven la vista de solo lectura), para poder quitar/restaurar
+            una promo. Los admins la manejan en la lista editable de arriba. */}
+        {canEliminarPromo && !puedeEditarItems && !pedidoEntregado && (bonificacionesCalculadas.length > 0 || hayPromosQuitadas) && (
+          <div className="border dark:border-gray-600 rounded-lg overflow-hidden">
+            <div className="bg-gray-50 dark:bg-gray-700 px-4 py-3 flex items-center gap-2">
+              <Gift className="w-5 h-5 text-green-600" />
+              <span className="font-medium dark:text-white">Promociones aplicadas</span>
+            </div>
+            <div className="divide-y dark:divide-gray-600">
+              {bonificacionesCalculadas.map(bonif => (
+                <div key={`promo-ro-${bonif.productoId}-${bonif.promocionId ?? 'anon'}`} className="p-3 flex items-center justify-between bg-green-50 dark:bg-green-900/20">
+                  <div className="flex items-center gap-2 flex-1 min-w-0">
+                    <Gift className="w-4 h-4 text-green-600 flex-shrink-0" />
+                    <div className="min-w-0">
+                      <p className="font-medium text-sm dark:text-white truncate">{bonif.nombre}</p>
+                      <p className="text-xs text-green-600 font-medium">
+                        REGALO x{bonif.cantidad}{bonif.promoNombre ? ` · ${bonif.promoNombre}` : ''}
+                      </p>
+                    </div>
+                  </div>
+                  {bonif.promocionId && (
+                    <button
+                      type="button"
+                      onClick={() => handleQuitarPromo(String(bonif.promocionId), bonif.promoNombre ?? bonif.nombre)}
+                      className="flex items-center gap-1 px-3 py-1.5 text-xs font-medium text-red-600 dark:text-red-400 hover:bg-red-100 dark:hover:bg-red-900/30 border border-red-300 dark:border-red-700 rounded-lg shrink-0"
+                    >
+                      <Trash2 className="w-3.5 h-3.5" />
+                      Quitar
+                    </button>
+                  )}
+                </div>
+              ))}
+              {promosEliminadas.map(p => (
+                <div key={`promo-ro-quitada-${p.promoId}`} className="p-3 flex items-center justify-between bg-gray-50 dark:bg-gray-800/40">
+                  <p className="text-xs text-gray-500 dark:text-gray-400 min-w-0 truncate">
+                    Promoción quitada: <span className="font-medium">{p.promoNombre}</span>
+                  </p>
+                  <button
+                    type="button"
+                    onClick={() => handleRestaurarPromo(p.promoId)}
+                    className="text-xs font-medium text-indigo-600 dark:text-indigo-400 hover:underline shrink-0"
+                  >
+                    Restaurar
+                  </button>
                 </div>
               ))}
             </div>

--- a/src/components/modals/ModalPedido.tsx
+++ b/src/components/modals/ModalPedido.tsx
@@ -119,6 +119,12 @@ export interface ModalPedidoProps {
   regalosOverride?: Record<string, RegaloOverride>;
   /** Callback cuando el admin cambia el producto del regalo de una promo al crear. */
   onCambiarRegaloCreacion?: (promoId: string, productoId: string) => void;
+  /** Promos quitadas a mano del pedido (para mostrar la fila "quitada" + restaurar). */
+  promosEliminadas?: Array<{ promoId: string; promoNombre: string }>;
+  /** Callback al quitar una promo del pedido (abre la confirmación en el container). */
+  onEliminarPromoCreacion?: (promoId: string, promoNombre: string) => void;
+  /** Callback al restaurar una promo previamente quitada. */
+  onRestaurarPromoCreacion?: (promoId: string) => void;
 }
  
 
@@ -148,7 +154,10 @@ const ModalPedido = memo(function ModalPedido({
   onPreventistaChange,
   currentUserId,
   regalosOverride,
-  onCambiarRegaloCreacion
+  onCambiarRegaloCreacion,
+  promosEliminadas,
+  onEliminarPromoCreacion,
+  onRestaurarPromoCreacion
 }: ModalPedidoProps) {
   // Solo admin puede reasignar preventista al pedido. La query se habilita
   // condicionalmente para no traer perfiles para preventistas/encargados.
@@ -292,8 +301,14 @@ const ModalPedido = memo(function ModalPedido({
 
   const calcularTotal = (): number => nuevoPedido.items.reduce((t, i) => t + (i.precioUnitario * i.cantidad), 0);
 
+  // Promos quitadas a mano → se excluyen de la resolución (display y submit).
+  const promosEliminadasSet = useMemo(
+    () => new Set((promosEliminadas ?? []).map(p => p.promoId)),
+    [promosEliminadas],
+  );
+
   // Precios mayoristas, promociones y cantidades mínimas
-  const { preciosResueltos, faltantes, faltantesBonificacion, promoResolucion, itemsFinales, totalOriginal, hayDescuento, moqMap, violacionesMOQ } = usePromocionPedido(nuevoPedido.items, undefined, regalosOverride);
+  const { preciosResueltos, faltantes, faltantesBonificacion, promoResolucion, itemsFinales, totalOriginal, hayDescuento, moqMap, violacionesMOQ } = usePromocionPedido(nuevoPedido.items, undefined, regalosOverride, promosEliminadasSet);
 
   // Descuento del cliente (general + por categoría) aplicado en vivo sobre los
   // items ya resueltos (mayorista/promo). La categoría prevalece sobre el general.
@@ -814,11 +829,39 @@ const ModalPedido = memo(function ModalPedido({
                               <div className="flex items-center gap-2 shrink-0">
                                 <span className="w-6 text-center font-medium text-sm text-green-700 dark:text-green-400">{bonif.cantidadBonificacion}</span>
                                 <p className="w-20 text-right font-semibold text-sm text-green-600">GRATIS</p>
+                                {(isAdmin || isPreventista || isEncargado) && onEliminarPromoCreacion && bonif.promoId && (
+                                  <button
+                                    type="button"
+                                    onClick={() => onEliminarPromoCreacion(String(bonif.promoId), bonif.promoNombre)}
+                                    className="p-1 text-red-500 hover:bg-red-100 dark:hover:bg-red-900/30 rounded"
+                                    title="Quitar esta promoción del pedido"
+                                    aria-label="Quitar promoción"
+                                  >
+                                    <X className="w-4 h-4" />
+                                  </button>
+                                )}
                               </div>
                             </div>
                           </div>
                         );
                       })}
+                      {/* Promos quitadas a mano — se pueden restaurar */}
+                      {(promosEliminadas ?? []).map(p => (
+                        <div key={`promo-quitada-${p.promoId}`} className="px-3 py-2 bg-gray-50 dark:bg-gray-800/40 flex items-center justify-between gap-2">
+                          <p className="text-xs text-gray-500 dark:text-gray-400 min-w-0 truncate">
+                            Promoción quitada: <span className="font-medium">{p.promoNombre}</span>
+                          </p>
+                          {onRestaurarPromoCreacion && (
+                            <button
+                              type="button"
+                              onClick={() => onRestaurarPromoCreacion(p.promoId)}
+                              className="text-xs font-medium text-indigo-600 dark:text-indigo-400 hover:underline shrink-0"
+                            >
+                              Restaurar
+                            </button>
+                          )}
+                        </div>
+                      ))}
                     </div>
 
                     {/* Nudges para alcanzar siguiente tier */}

--- a/src/hooks/usePromocionPedido.ts
+++ b/src/hooks/usePromocionPedido.ts
@@ -75,6 +75,9 @@ export function usePromocionPedido(
    *  producto para la bonificación al crear el pedido (paridad con "Cambiar
    *  regalo" de la edición). */
   overridesRegalo?: Record<string, RegaloOverride>,
+  /** Ids de promos que el usuario quitó a mano (crear/editar). Se excluyen de la
+   *  resolución: sin regalo y con los disparadores liberados para mayorista. */
+  promosEliminadas?: ReadonlySet<string>,
 ): UsePromocionPedidoReturn {
   const { data: pricingMap, isLoading: loadingPricing } = usePricingMapQuery()
   const { data: promoMap, isLoading: loadingPromos } = usePromoMapQuery(fechaReferencia)
@@ -84,8 +87,8 @@ export function usePromocionPedido(
     if (!promoMap || promoMap.size === 0 || items.length === 0) {
       return { bonificaciones: [], productosConPromo: new Set() }
     }
-    return resolverPromociones(items, promoMap)
-  }, [items, promoMap])
+    return resolverPromociones(items, promoMap, promosEliminadas)
+  }, [items, promoMap, promosEliminadas])
 
   // 1b. Aplicar override del regalo: solo cambia el producto/descripción de la
   //     bonificación; los disparadores (productosConPromo) y reglas no se tocan.

--- a/src/utils/promociones.test.ts
+++ b/src/utils/promociones.test.ts
@@ -1,0 +1,52 @@
+/**
+ * Tests de resolverPromociones — foco en `promosEliminadas` (quitar promo a mano
+ * al crear/editar un pedido).
+ */
+import { describe, it, expect } from 'vitest'
+import { resolverPromociones, type PromocionActiva, type PromoMap } from './promociones'
+import type { ItemPedido } from './precioMayorista'
+
+function promoMapDe(promos: PromocionActiva[]): PromoMap {
+  const map: PromoMap = new Map()
+  for (const promo of promos) {
+    for (const pid of promo.productoIds) {
+      const arr = map.get(pid) ?? []
+      arr.push(promo)
+      map.set(pid, arr)
+    }
+  }
+  return map
+}
+
+const promo2x1: PromocionActiva = {
+  id: '77',
+  nombre: 'Promo 2+1',
+  tipo: 'bonificacion',
+  productoIds: ['10'],
+  reglas: { cantidad_compra: 2, cantidad_bonificacion: 1 },
+  productoRegaloId: '10',
+}
+
+const items: ItemPedido[] = [{ productoId: '10', cantidad: 4, precioUnitario: 100 }]
+
+describe('resolverPromociones · promosEliminadas', () => {
+  it('sin eliminar: la promo dispara (bonificación + producto reclamado)', () => {
+    const r = resolverPromociones(items, promoMapDe([promo2x1]))
+    expect(r.bonificaciones).toHaveLength(1)
+    expect(r.bonificaciones[0].promoId).toBe('77')
+    expect(r.bonificaciones[0].cantidadBonificacion).toBe(2) // floor(4/2) * 1
+    expect(r.productosConPromo.has('10')).toBe(true)
+  })
+
+  it('con la promo en promosEliminadas: desaparece por completo', () => {
+    const r = resolverPromociones(items, promoMapDe([promo2x1]), new Set(['77']))
+    expect(r.bonificaciones).toHaveLength(0)
+    expect(r.productosConPromo.has('10')).toBe(false)
+  })
+
+  it('un set vacío o con otros ids no afecta la resolución', () => {
+    const r = resolverPromociones(items, promoMapDe([promo2x1]), new Set(['999']))
+    expect(r.bonificaciones).toHaveLength(1)
+    expect(r.productosConPromo.has('10')).toBe(true)
+  })
+})

--- a/src/utils/promociones.ts
+++ b/src/utils/promociones.ts
@@ -67,7 +67,11 @@ export interface PromoResolucion {
  */
 export function resolverPromociones(
   items: ItemPedido[],
-  promoMap: PromoMap
+  promoMap: PromoMap,
+  /** Ids de promos que el usuario quitó manualmente (al crear o editar el pedido).
+   *  Se excluyen de la resolución: no generan bonificación y sus disparadores
+   *  vuelven a poder tomar precio mayorista. */
+  promosEliminadas?: ReadonlySet<string>,
 ): PromoResolucion {
   const bonificaciones: BonificacionResult[] = []
   const productosConPromo = new Set<string>()
@@ -77,6 +81,12 @@ export function resolverPromociones(
   //    su promo (el precio manual cambia el precio, no la elegibilidad). Ej: regalar
   //    un producto bajándole el precio no debe anular la botella de regalo de la promo.
   const promosVistas = acumularPromos(items, promoMap, { skipOverride: false })
+
+  // 1a. Sacar las promos quitadas a mano ANTES de derivar productosConPromo y
+  //     bonificaciones, así desaparecen por completo (regalo + reclamo de precio).
+  if (promosEliminadas && promosEliminadas.size > 0) {
+    for (const id of promosEliminadas) promosVistas.delete(id)
+  }
 
   for (const entry of promosVistas.values()) {
     for (const pid of entry.productoIdsEnPedido) productosConPromo.add(pid)


### PR DESCRIPTION
## Contexto

Dos cosas en una: (1) el cambio/devolución en la hoja de ruta estaba roto con "Invalid input", y (2) nueva feature para quitar una promoción de un pedido.

## Parte 1 — Fix del cambio/devolución ("Invalid input"), NO era cache

**Causa raíz:** `clientes.id` y `productos.id` son `bigint` → PostgREST los devuelve como `number` en runtime, y `useClientesQuery`/`useProductosQuery` **no** los stringifican (a diferencia de pedidos/promos, que hacen `id: String(...)`). El schema co-locado del modal validaba los ids con `z.string()`, que falla el chequeo de tipo base ante un `number` → Zod v4 devuelve **"Invalid input"** en `validate()`, antes del RPC.

**Prueba:** en prod había **0** cambios de cualquier tipo (`recorrido_cambios`, `cambios_productos`, `pedidos canal='cambio'`, todos en cero). La función **nunca funcionó** — por eso limpiar cache jamás ayudó.

**Fix:** `z.coerce.string()` en los 3 campos de id del schema (normaliza `number→string`; sin selección `''` sigue fallando el `.min(1)`). Arregla también el cambio standalone de depósito (mismo modal). Test de regresión con ids numéricos.

## Parte 2 — Quitar una promoción (crear y editar), con alerta y restaurar

Para **admin, preventista y encargado**, al **crear** y al **editar** un pedido:

- `resolverPromociones`/`usePromocionPedido` aceptan un set `promosEliminadas` que excluye la promo por completo (sin regalo; los disparadores vuelven a poder tomar mayorista).
- **Crear** (`ModalPedido` + `PedidosContainer`): botón quitar en cada bonificación → confirmación → baja el total; fila "Promoción quitada · Restaurar".
- **Editar** (`ModalEditarPedido`): mismo mecanismo. Al guardar, la promo excluida no viaja en `itemsBonif` y `actualizar_pedido_items` borra el regalo + restaura stock. Se desacopla el guardado de la quita del permiso de edición de ítems (el RPC ya autoriza a los 3 roles); sección "Promociones aplicadas" para la vista de solo lectura; el regalo de una promo quitada se oculta del listado de solo lectura hasta guardar.

## Migraciones

Ninguna. La Parte 2 reusa el RPC existente `actualizar_pedido_items` (ya autoriza a admin/encargado/preventista).

## Verificación

- ✅ **749 tests** pasan (53 archivos), incluidos 2 nuevos (`ModalCambioProducto.test.ts`, `promociones.test.ts`).
- ✅ Typecheck y lint limpios en los archivos tocados.
- ⚠️ No se corrió E2E en vivo (requiere login + datos); el test de regresión cubre el mecanismo exacto que fallaba.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
