### PR TITLE
fix(rutas): el pedido con fecha editada aparece al armar la ruta del día

### DIFF
--- a/src/components/containers/PedidosContainer.tsx
+++ b/src/components/containers/PedidosContainer.tsx
@@ -721,6 +721,25 @@ export default function PedidosContainer(): React.ReactElement {
       if (data.fechaEntregaProgramada) updateData.fecha_entrega_programada = data.fechaEntregaProgramada
       const { error } = await supabase.from('pedidos').update(updateData).eq('id', pedidoEditando.id)
       if (error) throw error
+
+      // Si el pedido estaba "en camino" (asignado a una ruta activa) y se le
+      // cambió alguna fecha, vuelve a pendiente y sale de la ruta: al moverlo de
+      // día ya no pertenece a esa ruta y debe poder re-rutearse. Mismo patrón que
+      // "Volver a pendiente" (handleVolverAPendiente). data.fecha llega siempre que
+      // el usuario puede editar fechas, así que se compara contra el valor original.
+      const fechaCambio =
+        (data.fecha !== undefined && data.fecha !== pedidoEditando.fecha) ||
+        (data.fechaEntregaProgramada !== undefined &&
+          data.fechaEntregaProgramada !== (pedidoEditando.fecha_entrega_programada || ''))
+      const revertido = fechaCambio && pedidoEditando.estado === 'asignado'
+      if (revertido) {
+        if (pedidoEditando.transportista_id) {
+          await asignarTransportistaMut.mutateAsync({ pedidoId: pedidoEditando.id, transportistaId: null })
+        }
+        await cambiarEstado.mutateAsync({ pedidoId: pedidoEditando.id, nuevoEstado: 'pendiente' })
+        await quitarDeRecorridosMut.mutateAsync({ pedidoId: pedidoEditando.id })
+      }
+
       // Invalidar cache para que los cambios se reflejen en la UI. Incluye la
       // familia recorridos* para que la hoja de ruta/comanda re-descargada desde
       // Exportaciones refleje cambios de fecha/notas (sino sirve datos cacheados).
@@ -731,10 +750,14 @@ export default function PedidosContainer(): React.ReactElement {
       queryClient.invalidateQueries({ queryKey: ['recorrido-existente'] })
       setModalEditarOpen(false)
       setPedidoEditando(null)
-      notify.success('Pedido actualizado')
+      if (revertido) {
+        notify.warning('Pedido actualizado. Estaba en camino: volvió a pendiente y se quitó de la ruta activa.')
+      } else {
+        notify.success('Pedido actualizado')
+      }
     } catch (e) { notify.error((e as Error).message) }
     setGuardando(false)
-  }, [pedidoEditando, notify, queryClient])
+  }, [pedidoEditando, notify, queryClient, asignarTransportistaMut, cambiarEstado, quitarDeRecorridosMut])
 
   // ModalEditarPedido: onSaveItems - guardar cambios de items via RPC.
   // Reenvía el desglose fiscal para que el RPC actualice correctamente

--- a/src/components/modals/ModalEditarPedido.tsx
+++ b/src/components/modals/ModalEditarPedido.tsx
@@ -3,7 +3,7 @@ import { Loader2, AlertCircle, Package, Plus, Minus, Trash2, Search, X, Shopping
 import ModalBase from './ModalBase';
 import ModalConfirmacion, { type ModalConfirmacionConfig } from './ModalConfirmacion';
 import NumberInput from '../ui/NumberInput';
-import { formatPrecio } from '../../utils/formatters';
+import { formatPrecio, parseDateSafe, fechaHaceDias } from '../../utils/formatters';
 import { useZodValidation } from '../../hooks/useZodValidation';
 import { modalEditarPedidoSchema } from '../../lib/schemas';
 import { usePromocionPedido } from '../../hooks/usePromocionPedido';
@@ -1045,7 +1045,29 @@ const ModalEditarPedido = memo(function ModalEditarPedido({
             <input
               type="date"
               value={fecha}
-              onChange={e => setFecha(e.target.value)}
+              onChange={e => {
+                const nueva = e.target.value;
+                // Cascade: la fecha de entrega programada acompaña a la de pedido,
+                // preservando el desfase (día siguiente por defecto, como en el alta).
+                // No aplica a pedidos ya entregados (ese input no se muestra).
+                if (nueva && !pedidoEntregado) {
+                  if (fecha) {
+                    const delta = Math.round(
+                      (parseDateSafe(nueva).getTime() - parseDateSafe(fecha).getTime()) / 86400000
+                    );
+                    if (delta !== 0) {
+                      setFechaEntregaProgramada(
+                        fechaEntregaProgramada
+                          ? fechaHaceDias(-delta, parseDateSafe(fechaEntregaProgramada))
+                          : fechaHaceDias(-1, parseDateSafe(nueva))
+                      );
+                    }
+                  } else if (!fechaEntregaProgramada) {
+                    setFechaEntregaProgramada(fechaHaceDias(-1, parseDateSafe(nueva)));
+                  }
+                }
+                setFecha(nueva);
+              }}
               className="w-full px-3 py-2 border rounded-lg dark:bg-gray-700 dark:border-gray-600 dark:text-white"
             />
           </div>

--- a/src/components/modals/ModalGestionRutas.tsx
+++ b/src/components/modals/ModalGestionRutas.tsx
@@ -249,10 +249,15 @@ const ModalGestionRutas = memo(function ModalGestionRutas({
   // Hora a la que arranca el recorrido (sale del depósito). Ancla las ventanas
   // horarias en la optimización para priorizar los horarios de entrega.
   const [horaInicio, setHoraInicio] = useState<string>('08:00');
-  // Filtro de fecha (por fecha de pedido) para acotar el pool de disponibles:
-  // suelen acumularse pendientes/en preparación de varios días.
+  // Filtro de fecha para acotar el pool de disponibles (suelen acumularse
+  // pendientes/en preparación de varios días). Se puede filtrar por fecha de
+  // pedido o por fecha de entrega programada (ver filtroTipoFecha).
   const [filtroDesde, setFiltroDesde] = useState<string>('');
   const [filtroHasta, setFiltroHasta] = useState<string>('');
+  // Columna por la que filtra el pool: 'pedido' (fecha) o 'entrega'
+  // (fecha_entrega_programada, con fallback a fecha). Default 'entrega' porque la
+  // ruta del día se identifica por su fecha de reparto.
+  const [filtroTipoFecha, setFiltroTipoFecha] = useState<'pedido' | 'entrega'>('entrega');
   const [mostrarConfigDeposito, setMostrarConfigDeposito] = useState<boolean>(false);
   const [depositoLat, setDepositoLat] = useState<string>('');
   const [depositoLng, setDepositoLng] = useState<string>('');
@@ -308,17 +313,21 @@ const ModalGestionRutas = memo(function ModalGestionRutas({
   const idsExistentes = useMemo(() => new Set(paradasExistentes.map(p => p.id)), [paradasExistentes]);
 
   // Disponibles para sumar a la ruta: pendiente/en_preparacion (vienen del
-  // container) filtrados por fecha de pedido.
+  // container) filtrados por fecha de pedido o de entrega (según filtroTipoFecha).
   const disponiblesFiltrados = useMemo((): PedidoDB[] => {
     return pedidos.filter(p => {
       if (!filtroActivo) return true;
-      const f = p.fecha || null;
+      // Columna según el modo: 'entrega' usa fecha_entrega_programada con fallback
+      // a la fecha de pedido; 'pedido' usa fecha.
+      const f = filtroTipoFecha === 'entrega'
+        ? (p.fecha_entrega_programada || p.fecha || null)
+        : (p.fecha || null);
       if (!f) return true; // sin fecha conocida: incluir antes que ocultar
       if (filtroDesde && f < filtroDesde) return false;
       if (filtroHasta && f > filtroHasta) return false;
       return true;
     });
-  }, [pedidos, filtroActivo, filtroDesde, filtroHasta]);
+  }, [pedidos, filtroActivo, filtroDesde, filtroHasta, filtroTipoFecha]);
 
   // Lista visible. En modo dividir: todo el pool (no hay edición in-place). En
   // modo 1 chofer: paradas de su ruta (si existe) + disponibles, sin duplicar
@@ -740,13 +749,30 @@ const ModalGestionRutas = memo(function ModalGestionRutas({
                 )}
               </div>
 
-              {/* Filtro por fecha de pedido: acota el pool de pendientes/en
-                  preparación cuando se acumulan de varios días */}
+              {/* Filtro por fecha (pedido o entrega): acota el pool de
+                  pendientes/en preparación cuando se acumulan de varios días */}
               <div className="bg-white border rounded-lg p-4">
                 <label className="block text-sm font-medium mb-2 flex items-center gap-1.5">
                   <CalendarDays className="w-4 h-4 text-gray-500" />
-                  Filtrar disponibles por fecha de pedido
+                  Filtrar disponibles por {filtroTipoFecha === 'entrega' ? 'fecha de entrega' : 'fecha de pedido'}
                 </label>
+                {/* Selector de columna: por fecha de pedido o de entrega programada */}
+                <div className="inline-flex rounded-lg border border-gray-200 p-0.5 mb-3">
+                  <button
+                    type="button"
+                    onClick={() => setFiltroTipoFecha('pedido')}
+                    className={`px-3 py-1.5 text-xs font-medium rounded-md ${filtroTipoFecha === 'pedido' ? 'bg-blue-600 text-white' : 'text-gray-600 hover:bg-gray-100'}`}
+                  >
+                    Fecha de pedido
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => setFiltroTipoFecha('entrega')}
+                    className={`px-3 py-1.5 text-xs font-medium rounded-md ${filtroTipoFecha === 'entrega' ? 'bg-blue-600 text-white' : 'text-gray-600 hover:bg-gray-100'}`}
+                  >
+                    Fecha de entrega
+                  </button>
+                </div>
                 <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
                   <div>
                     <label className="block text-xs text-gray-500 mb-1">Desde</label>
@@ -771,10 +797,8 @@ const ModalGestionRutas = memo(function ModalGestionRutas({
                   <button
                     type="button"
                     onClick={() => {
-                      const hoy = new Date();
-                      const f = `${hoy.getFullYear()}-${String(hoy.getMonth() + 1).padStart(2, '0')}-${String(hoy.getDate()).padStart(2, '0')}`;
-                      setFiltroDesde(f);
-                      setFiltroHasta(f);
+                      setFiltroDesde(hoyISO);
+                      setFiltroHasta(hoyISO);
                     }}
                     className="px-3 py-1.5 text-xs font-medium rounded-full border border-blue-200 bg-blue-50 text-blue-700 hover:bg-blue-100"
                   >
@@ -1030,7 +1054,7 @@ const ModalGestionRutas = memo(function ModalGestionRutas({
                                   )}
                                 </p>
                                 <p className="text-sm text-gray-500 truncate">{pedido.cliente?.direccion}</p>
-                                <p className="text-xs text-gray-400">Pedido: {pedido.fecha || '—'}</p>
+                                <p className="text-xs text-gray-400">Pedido: {pedido.fecha || '—'} · Entrega: {pedido.fecha_entrega_programada || '—'}</p>
                               </div>
                               <div className="text-right ml-2">
                                 <p className="font-medium text-gray-900">${pedido.total?.toLocaleString('es-AR')}</p>


### PR DESCRIPTION
## Problema

Una usuaria editaba la fecha de un pedido y, al armar/rearmar la ruta de ese día, el pedido no figuraba en el filtro de fecha. Tres causas combinadas:

1. **No había cascade**: editar "Fecha del Pedido" (`fecha`) no movía la "Fecha programada de entrega" (`fecha_entrega_programada`), que quedaba desfasada.
2. **El filtro del pool miraba una sola columna** (`fecha`), así que según qué día usara para filtrar, el pedido quedaba afuera.
3. **Un pedido ya ruteado no volvía al pool**: al entrar a una ruta pasa a `asignado` ("en camino") y el pool de armar-ruta solo trae `pendiente`/`en_preparacion`.

## Cambios

- **`ModalEditarPedido`** — al editar "Fecha del Pedido", la fecha de entrega programada la acompaña preservando el desfase (día siguiente por defecto, como en el alta), visible en el input.
- **`ModalGestionRutas`** — selector *Fecha de pedido / Fecha de entrega* para filtrar el pool (default **entrega**, con fallback a `fecha` si no hay programada); botón "Hoy" en TZ Argentina y ambas fechas visibles en cada card.
- **`PedidosContainer`** — si el pedido está "en camino" (`asignado`) y se le cambia alguna fecha, vuelve a `pendiente` y sale de la ruta activa (mismo patrón que "Volver a pendiente"). Editar solo notas no lo toca.

Sin migraciones: reutiliza RPCs existentes (`quitar_pedido_de_recorridos_activos`, mig 093).

## Verificación

- ✅ `tsc --noEmit` y ESLint limpios en los 3 archivos.
- ✅ Aritmética del cascade verificada (9 casos: desfase, rollovers de mes/año, delta negativo, fallback).
- ✅ Suite completa: 749/749 tests.
- ✅ Datos en vivo: 92 pedidos `asignado`, todos con `entrega = pedido + 1` (valida las 3 partes).

## Notas
- Default del filtro en `entrega` (la ruta del día se identifica por su fecha de reparto); el toggle permite volver a `pedido`.
- El auto-revert dispara con cualquier cambio de fecha (pedido o entrega).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
