### PR TITLE
fix(pedidos): el entregado con salvedad impago aparece en Entrega y Pago Masivos

### DIFF
--- a/src/components/containers/PedidosContainer.tsx
+++ b/src/components/containers/PedidosContainer.tsx
@@ -565,12 +565,18 @@ export default function PedidosContainer(): React.ReactElement {
     setGuardando(false)
   }, [pagosMasivos, notify])
 
-  const handleEntregaYPagoMasivos = useCallback(async (transportistaId: string, formaPago: string, pedidoIds: string[], fecha: string) => {
+  const handleEntregaYPagoMasivos = useCallback(async (
+    transportistaId: string,
+    formaPago: string,
+    ids: { idsEntregar: string[]; idsCobrar: string[] },
+    fecha: string,
+  ) => {
     setGuardando(true)
     try {
-      await entregaYPagoMasivos.mutateAsync({ pedidoIds, transportistaId, formaPago, fecha })
+      await entregaYPagoMasivos.mutateAsync({ ...ids, transportistaId, formaPago, fecha })
       setModalEntregaYPagoMasivosOpen(false)
-      notify.success(`${pedidoIds.length} pedido${pedidoIds.length !== 1 ? 's' : ''} entregado${pedidoIds.length !== 1 ? 's' : ''} y pagado${pedidoIds.length !== 1 ? 's' : ''}`)
+      const total = ids.idsEntregar.length + ids.idsCobrar.length
+      notify.success(`${total} pedido${total !== 1 ? 's' : ''} procesado${total !== 1 ? 's' : ''}`)
     } catch (e) { notify.error('Error en entrega y pago masivos: ' + (e as Error).message) }
     setGuardando(false)
   }, [entregaYPagoMasivos, notify])

--- a/src/components/modals/ModalEntregaYPagoMasivos.tsx
+++ b/src/components/modals/ModalEntregaYPagoMasivos.tsx
@@ -1,7 +1,7 @@
 import { useState, useMemo, memo } from 'react'
 import { Loader2, Search, Calendar, AlertTriangle, Truck } from 'lucide-react'
 import ModalBase from './ModalBase'
-import { usePedidosNoEntregadosQuery, useRendicionCerradaQuery } from '../../hooks/queries'
+import { usePedidosParaEntregaYPagoQuery, useRendicionCerradaQuery } from '../../hooks/queries'
 import {
   getEstadoColor, getEstadoLabel,
   getEstadoPagoColor, getEstadoPagoLabel,
@@ -16,10 +16,16 @@ export interface ModalEntregaYPagoMasivosProps {
    * Callback de confirmación.
    * @param transportistaId - ID del transportista a asignar a la entrega
    * @param formaPago - Forma de pago a registrar
-   * @param pedidoIds - IDs de los pedidos seleccionados
+   * @param ids - IDs partidos por acción: `idsEntregar` (no entregados → entregar+cobrar)
+   *   e `idsCobrar` (ya entregados, p.ej. entrega con salvedad → solo cobrar).
    * @param fecha - Fecha contable de entrega y pago (YYYY-MM-DD)
    */
-  onConfirm: (transportistaId: string, formaPago: string, pedidoIds: string[], fecha: string) => Promise<void>
+  onConfirm: (
+    transportistaId: string,
+    formaPago: string,
+    ids: { idsEntregar: string[]; idsCobrar: string[] },
+    fecha: string,
+  ) => Promise<void>
   onClose: () => void
   guardando: boolean
   /** Si el caller es encargado (no admin): fecha bloqueada a hoy y check de rendicion. */
@@ -45,8 +51,9 @@ const ModalEntregaYPagoMasivos = memo(function ModalEntregaYPagoMasivos({
   const [fechaHasta, setFechaHasta] = useState('')
   const [fecha, setFecha] = useState<string>(hoy)
 
-  // Universo: pedidos NO entregados (la entrega es la acción que habilita el combo).
-  const { data: pedidos = [], isLoading } = usePedidosNoEntregadosQuery(true)
+  // Universo: pedidos que aún requieren acción = NO cancelados y NO (entregado Y pagado).
+  // Incluye entregados-con-salvedad impagos (solo se cobran, sin re-entregar).
+  const { data: pedidos = [], isLoading } = usePedidosParaEntregaYPagoQuery(true)
   const { data: rendicionCerrada = false } = useRendicionCerradaQuery(fecha, fechaBloqueada)
 
   const pedidosFiltrados = useMemo(() => {
@@ -83,8 +90,20 @@ const ModalEntregaYPagoMasivos = memo(function ModalEntregaYPagoMasivos({
 
   const allSelected = pedidosFiltrados.length > 0 && selectedIds.size === pedidosFiltrados.length
   const bloqueadoPorRendicion = fechaBloqueada && rendicionCerrada
+
+  // Los ya entregados (p.ej. entrega con salvedad impaga) solo se cobran; los demás
+  // se entregan + cobran. El transportista solo aplica al segundo grupo.
+  const { idsEntregar, idsCobrar } = useMemo(() => {
+    const sel = pedidos.filter(p => selectedIds.has(p.id))
+    return {
+      idsEntregar: sel.filter(p => p.estado !== 'entregado').map(p => p.id),
+      idsCobrar: sel.filter(p => p.estado === 'entregado').map(p => p.id),
+    }
+  }, [pedidos, selectedIds])
+  const requiereTransportista = idsEntregar.length > 0
+
   const canConfirm =
-    !!selectedTransportista &&
+    (!requiereTransportista || !!selectedTransportista) &&
     !!selectedFormaPago &&
     selectedIds.size > 0 &&
     !guardando &&
@@ -118,6 +137,11 @@ const ModalEntregaYPagoMasivos = memo(function ModalEntregaYPagoMasivos({
                 <option key={t.id} value={t.id}>{t.nombre}</option>
               ))}
             </select>
+            {!requiereTransportista && selectedIds.size > 0 && (
+              <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
+                Solo cobro: los pedidos seleccionados ya están entregados.
+              </p>
+            )}
           </div>
 
           {/* Selector de forma de pago */}
@@ -220,7 +244,7 @@ const ModalEntregaYPagoMasivos = memo(function ModalEntregaYPagoMasivos({
             </div>
           ) : pedidosFiltrados.length === 0 ? (
             <div className="text-center py-8 text-gray-500">
-              No hay pedidos disponibles para entregar
+              No hay pedidos disponibles para entregar o cobrar
             </div>
           ) : (
             pedidosFiltrados.map(pedido => {
@@ -288,7 +312,7 @@ const ModalEntregaYPagoMasivos = memo(function ModalEntregaYPagoMasivos({
             Cancelar
           </button>
           <button
-            onClick={() => canConfirm && onConfirm(selectedTransportista, selectedFormaPago, Array.from(selectedIds), fecha)}
+            onClick={() => canConfirm && onConfirm(selectedTransportista, selectedFormaPago, { idsEntregar, idsCobrar }, fecha)}
             disabled={!canConfirm}
             className="px-4 py-2 bg-indigo-600 text-white rounded-lg hover:bg-indigo-700 disabled:opacity-50 disabled:cursor-not-allowed flex items-center"
           >

--- a/src/hooks/queries/index.ts
+++ b/src/hooks/queries/index.ts
@@ -63,6 +63,7 @@ export {
   useCancelarPedidoMutation,
   useCambiarClientePedidoMutation,
   usePedidosNoPagadosQuery,
+  usePedidosParaEntregaYPagoQuery,
   usePagosMasivosMutation,
   useEntregaYPagoMasivosMutation,
 } from './usePedidosQuery'

--- a/src/hooks/queries/usePedidosQuery.ts
+++ b/src/hooks/queries/usePedidosQuery.ts
@@ -24,6 +24,7 @@ export const pedidosKeys = {
     [...pedidosKeys.all(sucursalId), 'paginated', page, pageSize, filters] as const,
   noEntregados: (sucursalId: number | null) => [...pedidosKeys.all(sucursalId), 'no-entregados'] as const,
   noPagados: (sucursalId: number | null) => [...pedidosKeys.all(sucursalId), 'no-pagados'] as const,
+  paraEntregaYPago: (sucursalId: number | null) => [...pedidosKeys.all(sucursalId), 'para-entrega-y-pago'] as const,
   asignados: (sucursalId: number | null) => [...pedidosKeys.all(sucursalId), 'asignados'] as const,
 }
 
@@ -757,6 +758,68 @@ export function usePedidosNoEntregadosQuery(enabled = false) {
   })
 }
 
+// Universo del modal "Entrega y Pago Masivos": pedidos que todavia requieren
+// alguna accion, es decir NO cancelados y NO (entregado Y pagado). A diferencia
+// de fetchPedidosNoEntregados, este SI incluye los ya entregados que siguen con
+// saldo (p.ej. una "entrega con salvedad" que quedo impaga): en ese caso solo se
+// cobran, sin re-entregar. Preserva los prepagos-no-entregados (siguen necesitando
+// la entrega).
+async function fetchPedidosParaEntregaYPago(sucursalId: number | null): Promise<PedidoDB[]> {
+  let query = supabase
+    .from('pedidos')
+    .select('*, cliente:clientes(id, nombre_fantasia, direccion)')
+    .neq('estado', 'cancelado')
+    .or('estado.neq.entregado,estado_pago.neq.pagado')
+
+  if (sucursalId != null) {
+    query = query.eq('sucursal_id', sucursalId)
+  }
+
+  const { data, error } = await query.order('created_at', { ascending: false })
+
+  if (error) throw error
+
+  // Enrich with transportista names
+  const transportistaIds = new Set<string>()
+  for (const pedido of (data || [])) {
+    if (pedido.transportista_id) transportistaIds.add(pedido.transportista_id as string)
+  }
+
+  let perfilesMap: Record<string, PerfilDB> = {}
+  if (transportistaIds.size > 0) {
+    const { data: perfiles } = await supabase
+      .from('perfiles')
+      .select('id, nombre, email')
+      .in('id', Array.from(transportistaIds))
+
+    if (perfiles) {
+      perfilesMap = Object.fromEntries(
+        (perfiles as PerfilDB[]).map(p => [p.id, p])
+      )
+    }
+  }
+
+  return (data || []).map(pedido => ({
+    ...pedido,
+    transportista: pedido.transportista_id ? perfilesMap[pedido.transportista_id] : null,
+  })) as PedidoDB[]
+}
+
+/**
+ * Hook para el universo del modal "Entrega y Pago Masivos" (sin paginacion).
+ * Incluye no-entregados y entregados-impagos; excluye cancelados y entregado+pagado.
+ * Se habilita solo cuando enabled=true (modal abierto).
+ */
+export function usePedidosParaEntregaYPagoQuery(enabled = false) {
+  const { currentSucursalId } = useSucursal()
+  return useQuery({
+    queryKey: pedidosKeys.paraEntregaYPago(currentSucursalId),
+    queryFn: () => fetchPedidosParaEntregaYPago(currentSucursalId),
+    enabled: enabled && !!currentSucursalId,
+    staleTime: 30 * 1000, // 30 segundos
+  })
+}
+
 async function entregarPedidosMasivo(
   pedidoIds: string[],
   transportistaId: string,
@@ -1042,12 +1105,20 @@ export function useEntregaYPagoMasivosMutation() {
   const { currentSucursalId } = useSucursal()
 
   return useMutation({
-    mutationFn: ({ pedidoIds, transportistaId, formaPago, fecha }: {
-      pedidoIds: string[];
+    mutationFn: async ({ idsEntregar, idsCobrar, transportistaId, formaPago, fecha }: {
+      idsEntregar: string[];
+      idsCobrar: string[];
       transportistaId: string;
       formaPago: string;
       fecha?: string | null
-    }) => marcarEntregaYPagoMasivo(pedidoIds, transportistaId, formaPago, fecha),
+    }) => {
+      // Pedidos YA entregados (p.ej. entrega con salvedad impaga): solo se cobran,
+      // sin re-entregar. marcar_pagos_masivo registra el pago real en `pagos` y no
+      // toca estado / transportista_id / fecha_entrega.
+      if (idsCobrar.length) await marcarPagosMasivo(idsCobrar, formaPago, fecha)
+      // Pedidos NO entregados: entrega + cobro en un solo paso.
+      if (idsEntregar.length) await marcarEntregaYPagoMasivo(idsEntregar, transportistaId, formaPago, fecha)
+    },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: pedidosKeys.all(currentSucursalId) })
       queryClient.invalidateQueries({ queryKey: clientesKeys.all(currentSucursalId) })


### PR DESCRIPTION
## Problema

Una usuaria reportó que al marcar un pedido como **entregado con salvedad**, después no puede aplicarle acciones masivas: "no le aparece en los filtros".

## Causa raíz

"Entregado con salvedad" **no es un estado propio**: el pedido queda `estado='entregado'` + filas en `salvedades_items`. Registrar la salvedad **baja el `total`**.

- El modal **"Entrega y Pago Masivos"** (y "Entregas Masivas") se arma con `fetchPedidosNoEntregados`, que excluye **todo** `estado='entregado'` → un entregado-con-salvedad que **todavía debe plata** desaparecía de esa acción y no se podía cobrar en lote.
- Por separado, el trigger `trigger_actualizar_estado_pago` (`BEFORE UPDATE OF monto_pagado, total`) recalcula `estado_pago` cuando la salvedad baja el total (`monto_pagado >= total → 'pagado'`), así que un pedido ya cobrado queda `pagado` y sale — correctamente — de "Pagos Masivos".

## Solución (sin migración)

Reutiliza dos RPC ya probadas en prod:

- **Nueva query** `fetchPedidosParaEntregaYPago` / `usePedidosParaEntregaYPagoQuery` con universo *"no cancelado Y NO (entregado Y pagado)"*: incluye no-entregados, entregados-impagos y prepagos-no-entregados; excluye `entregado+pagado`.
- **`ModalEntregaYPagoMasivos`** parte la selección por estado: los ya entregados se cobran con `marcar_pagos_masivo` (registra el pago real en `pagos`, **no** toca `estado`/`transportista_id`/`fecha_entrega`); los no entregados van por `marcar_entrega_y_pago_masivo`. El transportista se exige **solo si** hay algo por entregar.
- **Entregas Masivas** y **Pagos Masivos** quedan intactos.

## Verificación

- `tsc --noEmit` y `eslint` limpios en los archivos tocados; vitest del pre-commit en verde.
- Validado contra datos de prod: el nuevo universo del combinado ahora incluye los entregado-impagos (p.ej. #3438) y sigue excluyendo los `entregado+pagado` (#3399, que tenía un pago real).
- Reintentos idempotentes: ambas RPC saltan los ya-`pagado`, sin doble cobro si un grupo falla.

### Prueba manual sugerida
1. Pedido `asignado` impago → "Entrega con salvedad" (afectar 1 ítem) → queda `entregado`+`pendiente`.
2. Abrir "Entrega y Pago Masivos" → aparece con badge "Entregado" y "A cobrar"; seleccionarlo (+ uno normal) y confirmar.
3. En DB: el de salvedad mantiene `estado`/`transportista_id`/`fecha_entrega`, queda `estado_pago='pagado'` y hay una fila nueva en `pagos`.

## Fuera de alcance

El "falso pagado" cuando la salvedad deja el total en $0 (`monto_pagado=0` → trigger lo da por `pagado`); 3 casos existentes en prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)