### PR TITLE
fix(dashboard): venta entregada vs en curso, tendencia real y fechas correctas

### DIFF
--- a/src/components/containers/DashboardContainer.tsx
+++ b/src/components/containers/DashboardContainer.tsx
@@ -61,10 +61,13 @@ export default function DashboardContainer(): React.ReactElement {
       <VistaDashboard
         metricas={metricas || {
           ventasPeriodo: 0,
+          ventasEnCurso: 0,
           pedidosPeriodo: 0,
+          pedidosEntregados: 0,
+          pedidosEnCurso: 0,
           productosMasVendidos: [],
           clientesMasActivos: [],
-          pedidosPorEstado: { pendiente: 0, en_preparacion: 0, asignado: 0, entregado: 0 },
+          pedidosPorEstado: { pendiente: 0, asignado: 0, entregado: 0 },
           ventasPorDia: []
         }}
         loading={loadingMetricas}

--- a/src/components/vistas/VistaDashboard.tsx
+++ b/src/components/vistas/VistaDashboard.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useMemo, memo } from 'react';
 import type { LucideIcon } from 'lucide-react';
 import {
-  DollarSign, ShoppingCart, Clock, Package, Truck, Check,
+  DollarSign, ShoppingCart, Clock, Truck, Check,
   TrendingUp, TrendingDown, Minus, Target, Users, AlertTriangle,
 } from 'lucide-react';
 import { formatPrecio } from '../../utils/formatters';
@@ -273,18 +273,12 @@ const METRICAS_SEMANTICA: Record<'ventas' | 'pedidos' | 'ticket' | 'clientes', M
   },
 };
 
-const ESTADOS_SEMANTICA: Record<'pendiente' | 'preparacion' | 'camino' | 'entregado', EstadoSemantica> = {
+const ESTADOS_SEMANTICA: Record<'pendiente' | 'camino' | 'entregado', EstadoSemantica> = {
   pendiente: {
     accentBorder: 'border-l-amber-500',
     accentText: 'text-amber-700 dark:text-amber-300',
     badgeBg: 'bg-amber-100 dark:bg-amber-500/15',
     badgeIcon: 'text-amber-600 dark:text-amber-400',
-  },
-  preparacion: {
-    accentBorder: 'border-l-orange-500',
-    accentText: 'text-orange-700 dark:text-orange-300',
-    badgeBg: 'bg-orange-100 dark:bg-orange-500/15',
-    badgeIcon: 'text-orange-600 dark:text-orange-400',
   },
   camino: {
     accentBorder: 'border-l-blue-500',
@@ -335,14 +329,13 @@ export default function VistaDashboard({
   const metricasCalculadas = useMemo((): MetricasCalculadas | null => {
     if (!metricas) return null;
 
-    const ticketPromedio = metricas.pedidosPeriodo > 0
-      ? metricas.ventasPeriodo / metricas.pedidosPeriodo
+    const ticketPromedio = metricas.pedidosEntregados > 0
+      ? metricas.ventasPeriodo / metricas.pedidosEntregados
       : 0;
 
     const tasaEntrega = metricas.pedidosPorEstado
       ? (metricas.pedidosPorEstado.entregado /
          (metricas.pedidosPorEstado.pendiente +
-          metricas.pedidosPorEstado.en_preparacion +
           metricas.pedidosPorEstado.asignado +
           metricas.pedidosPorEstado.entregado || 1)) * 100
       : 0;
@@ -465,9 +458,11 @@ export default function VistaDashboard({
         {verMontosAgregados && (
           <MetricaCard
             icono={DollarSign}
-            titulo="Ventas"
+            titulo="Venta entregada"
             valor={formatPrecio(metricas.ventasPeriodo)}
-            subtitulo={periodoLabels[filtroPeriodo]}
+            subtitulo={metricas.ventasEnCurso > 0
+              ? `+${formatPrecio(metricas.ventasEnCurso)} en curso (${metricas.pedidosEnCurso})`
+              : periodoLabels[filtroPeriodo]}
             semantica={METRICAS_SEMANTICA.ventas}
             tendencia={<TendenciaIndicator valor={metricas.ventasPeriodo} comparacion={metricas.ventasPeriodoAnterior} />}
           />
@@ -485,7 +480,7 @@ export default function VistaDashboard({
             icono={Target}
             titulo="Ticket promedio"
             valor={formatPrecio(metricasCalculadas?.ticketPromedio || 0)}
-            subtitulo="Por pedido"
+            subtitulo="Por pedido entregado"
             semantica={METRICAS_SEMANTICA.ticket}
           />
         )}
@@ -503,9 +498,8 @@ export default function VistaDashboard({
         <h3 className="text-[11px] font-semibold uppercase tracking-[0.14em] text-stone-500 dark:text-stone-400 mb-2.5">
           Estado de pedidos
         </h3>
-        <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
+        <div className="grid grid-cols-2 md:grid-cols-3 gap-3">
           <EstadoCard icono={Clock} titulo="Pendientes" valor={metricas.pedidosPorEstado.pendiente} semantica={ESTADOS_SEMANTICA.pendiente} />
-          <EstadoCard icono={Package} titulo="En preparación" valor={metricas.pedidosPorEstado.en_preparacion || 0} semantica={ESTADOS_SEMANTICA.preparacion} />
           <EstadoCard icono={Truck} titulo="En camino" valor={metricas.pedidosPorEstado.asignado} semantica={ESTADOS_SEMANTICA.camino} />
           <EstadoCard icono={Check} titulo="Entregados" valor={metricas.pedidosPorEstado.entregado} semantica={ESTADOS_SEMANTICA.entregado} />
         </div>

--- a/src/hooks/queries/useMetricasQuery.ts
+++ b/src/hooks/queries/useMetricasQuery.ts
@@ -6,13 +6,17 @@ import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { supabase } from '../supabase/base'
 import { useSucursal } from '../../contexts/SucursalContext'
 import { fechaLocalISO } from '../../utils/formatters'
+import {
+  addDiasISO,
+  agregarMetricasPeriodo,
+  serieVentas7Dias,
+  ventanaAnterior,
+  ventanaPeriodoDashboard,
+  type PedidoMetricaRow,
+} from '../../utils/metricasDashboard'
 import type {
   DashboardMetricasExtended,
   ReportePreventista,
-  ProductoVendido,
-  ClienteActivo,
-  VentaPorDia,
-  PedidosPorEstado,
   PedidoDB
 } from '../../types'
 
@@ -31,24 +35,6 @@ export const metricasKeys = {
     [...metricasKeys.all(sucursalId), 'reporte-preventistas', fechaDesde, fechaHasta] as const,
 }
 
-interface PedidoWithRelations {
-  id: string
-  cliente_id: string
-  cliente?: { nombre_fantasia?: string } | null
-  usuario_id?: string
-  estado: string
-  estado_pago?: string
-  total: number
-  monto_pagado?: number
-  fecha?: string
-  created_at?: string
-  items?: Array<{
-    producto_id: string
-    cantidad: number
-    producto?: { nombre?: string } | null
-  }>
-}
-
 type FiltroPeriodo = 'hoy' | 'semana' | 'mes' | 'anio' | 'historico' | 'personalizado'
 
 interface MetricasParams {
@@ -62,146 +48,74 @@ interface MetricasParams {
 async function calcularMetricas(params: MetricasParams): Promise<DashboardMetricasExtended> {
   const { periodo, fechaDesde, fechaHasta, usuarioId } = params
 
-  // Calcular ventana de fecha ANTES de la query para poder filtrar server-side.
-  // Con 10k+ pedidos, traer todo y filtrar en JS es KB/MB innecesarios.
-  const hoy = new Date()
-  const hoyStr = fechaLocalISO(hoy)
-  let fechaInicioStr: string | null = null
+  const hoyISO = fechaLocalISO()
+  // Ventana [desde, hasta] sobre `pedidos.fecha` (fecha de entrega, editable):
+  // filtrar por fecha server-side incluye los pedidos re-fechados (patrón del
+  // fix de rutas PR #414) y elimina el viejo hack de +1 día sobre created_at
+  // que perdía el último día del rango personalizado.
+  const ventana = ventanaPeriodoDashboard(periodo, hoyISO, fechaDesde, fechaHasta)
 
-  switch (periodo) {
-    case 'hoy':
-      fechaInicioStr = hoyStr
-      break
-    case 'semana': {
-      const hace7Dias = new Date()
-      hace7Dias.setDate(hace7Dias.getDate() - 7)
-      fechaInicioStr = fechaLocalISO(hace7Dias)
-      break
-    }
-    case 'mes': {
-      const inicioMes = new Date(hoy.getFullYear(), hoy.getMonth(), 1)
-      fechaInicioStr = fechaLocalISO(inicioMes)
-      break
-    }
-    case 'anio': {
-      const inicioAnio = new Date(hoy.getFullYear(), 0, 1)
-      fechaInicioStr = fechaLocalISO(inicioAnio)
-      break
-    }
-    case 'personalizado':
-      fechaInicioStr = fechaDesde || null
-      break
-    case 'historico':
-    default:
-      fechaInicioStr = null
-      break
-  }
+  // -- Query principal del período (para 'historico' baja todo: intencional) --
+  const principalPromise = (async () => {
+    let query = supabase
+      .from('pedidos')
+      .select(`*, cliente:clientes(*), items:pedido_items(*, producto:productos(*))`)
+      .neq('estado', 'cancelado')
+    if (usuarioId) query = query.eq('usuario_id', usuarioId)
+    if (ventana.desde) query = query.gte('fecha', ventana.desde)
+    if (ventana.hasta) query = query.lte('fecha', ventana.hasta)
+    const { data, error } = await query.order('created_at', { ascending: false })
+    if (error) throw error
+    return (data as PedidoMetricaRow[]) || []
+  })()
 
-  let query = supabase
-    .from('pedidos')
-    .select(`*, cliente:clientes(*), items:pedido_items(*, producto:productos(*))`)
+  // -- Período anterior de igual duración terminando el día antes (misma
+  //    convención que el comparativo del RPC reporte_gerencial). Sin `desde`
+  //    (historico) no hay comparación posible.
+  const prev = ventana.desde ? ventanaAnterior(ventana.desde, ventana.hasta ?? hoyISO) : null
+  const anteriorPromise = (async () => {
+    if (!prev) return null
+    let query = supabase
+      .from('pedidos')
+      .select('total, estado')
+      .neq('estado', 'cancelado')
+      .gte('fecha', prev.desde)
+      .lte('fecha', prev.hasta)
+    if (usuarioId) query = query.eq('usuario_id', usuarioId)
+    const { data, error } = await query
+    if (error) throw error
+    return (data as Array<{ total: number | null; estado: string }>) || []
+  })()
 
-  if (usuarioId) {
-    query = query.eq('usuario_id', usuarioId)
-  }
+  // -- Últimos 7 días para el gráfico, SIEMPRE (ventana propia, independiente
+  //    del período elegido). Mantiene "no cancelados": con entregado-only los
+  //    días recientes se verían vacíos hasta cerrar el reparto.
+  const seriePromise = (async () => {
+    let query = supabase
+      .from('pedidos')
+      .select('total, fecha')
+      .neq('estado', 'cancelado')
+      .gte('fecha', addDiasISO(hoyISO, -6))
+      .lte('fecha', hoyISO)
+    if (usuarioId) query = query.eq('usuario_id', usuarioId)
+    const { data, error } = await query
+    if (error) throw error
+    return (data as Array<{ total: number | null; fecha: string | null }>) || []
+  })()
 
-  // Filtro server-side: evita descargar histórico completo.
-  // Para 'historico' (sin fechaInicioStr) se respeta el comportamiento actual
-  // de descargar todo (export ilimitado intencional).
-  if (fechaInicioStr) {
-    query = query.gte('created_at', fechaInicioStr)
-  }
-  if (periodo === 'personalizado' && fechaHasta) {
-    // Sumar un día para incluir pedidos de fechaHasta (timestamptz vs date).
-    const hastaDate = new Date(fechaHasta)
-    hastaDate.setDate(hastaDate.getDate() + 1)
-    query = query.lt('created_at', fechaLocalISO(hastaDate))
-  }
-
-  const { data: todosPedidos, error } = await query.order('created_at', { ascending: false })
-
-  if (error) throw error
-  if (!todosPedidos) {
-    return {
-      ventasPeriodo: 0,
-      pedidosPeriodo: 0,
-      productosMasVendidos: [],
-      clientesMasActivos: [],
-      pedidosPorEstado: { pendiente: 0, en_preparacion: 0, asignado: 0, entregado: 0 },
-      ventasPorDia: []
-    }
-  }
-
-  const pedidosTyped = (todosPedidos as PedidoWithRelations[]).filter(p => p.estado !== 'cancelado')
-
-  // Redundant client-side filter preservado: la columna `fecha` puede diferir
-  // de `created_at` (ej. pedidos reprogramados) y algunos cálculos de UI
-  // (ventasPorDia) usan `fecha` cuando existe.
-  let pedidosFiltrados = pedidosTyped
-  if (fechaInicioStr) {
-    pedidosFiltrados = pedidosTyped.filter(p => (p.fecha ?? p.created_at?.split('T')[0] ?? '') >= fechaInicioStr!)
-  }
-  if (periodo === 'personalizado' && fechaHasta) {
-    pedidosFiltrados = pedidosFiltrados.filter(p => (p.fecha ?? p.created_at?.split('T')[0] ?? '') <= fechaHasta)
-  }
-
-  // Productos más vendidos
-  const productosVendidos: Record<string, ProductoVendido> = {}
-  pedidosFiltrados.forEach(p => p.items?.forEach(i => {
-    const id = i.producto_id
-    if (!productosVendidos[id]) productosVendidos[id] = { id, nombre: i.producto?.nombre || 'N/A', cantidad: 0 }
-    productosVendidos[id].cantidad += i.cantidad
-  }))
-  const topProductos: ProductoVendido[] = Object.values(productosVendidos)
-    .sort((a, b) => b.cantidad - a.cantidad)
-    .slice(0, 5)
-
-  // Clientes más activos
-  const clientesActivos: Record<string, ClienteActivo> = {}
-  pedidosFiltrados.forEach(p => {
-    const id = p.cliente_id
-    if (!clientesActivos[id]) clientesActivos[id] = {
-      id,
-      nombre: (p.cliente as { nombre_fantasia?: string })?.nombre_fantasia || 'N/A',
-      total: 0,
-      pedidos: 0
-    }
-    clientesActivos[id].total += p.total || 0
-    clientesActivos[id].pedidos += 1
-  })
-  const topClientes: ClienteActivo[] = Object.values(clientesActivos)
-    .sort((a, b) => b.total - a.total)
-    .slice(0, 5)
-
-  // Ventas por día (últimos 7 días)
-  const ventasPorDia: VentaPorDia[] = []
-  for (let i = 6; i >= 0; i--) {
-    const fecha = new Date()
-    fecha.setDate(fecha.getDate() - i)
-    const fechaStr = fechaLocalISO(fecha)
-    const pedidosDia = pedidosTyped.filter(p => (p.fecha ?? p.created_at?.split('T')[0]) === fechaStr)
-    ventasPorDia.push({
-      dia: fecha.toLocaleDateString('es-AR', { weekday: 'short' }),
-      ventas: pedidosDia.reduce((s, p) => s + (p.total || 0), 0),
-      pedidos: pedidosDia.length
-    })
-  }
-
-  // Pedidos por estado
-  const pedidosPorEstado: PedidosPorEstado = {
-    pendiente: pedidosTyped.filter(p => p.estado === 'pendiente').length,
-    en_preparacion: pedidosTyped.filter(p => p.estado === 'en_preparacion').length,
-    asignado: pedidosTyped.filter(p => p.estado === 'asignado').length,
-    entregado: pedidosTyped.filter(p => p.estado === 'entregado').length
-  }
+  const [pedidos, pedidosAnterior, filasSerie] = await Promise.all([
+    principalPromise,
+    anteriorPromise,
+    seriePromise,
+  ])
 
   return {
-    ventasPeriodo: pedidosFiltrados.reduce((s, p) => s + (p.total || 0), 0),
-    pedidosPeriodo: pedidosFiltrados.length,
-    productosMasVendidos: topProductos,
-    clientesMasActivos: topClientes,
-    pedidosPorEstado,
-    ventasPorDia
+    ...agregarMetricasPeriodo(pedidos),
+    ventasPeriodoAnterior: pedidosAnterior
+      ? pedidosAnterior.filter(p => p.estado === 'entregado').reduce((s, p) => s + (p.total || 0), 0)
+      : null,
+    pedidosPeriodoAnterior: pedidosAnterior ? pedidosAnterior.length : null,
+    ventasPorDia: serieVentas7Dias(filasSerie, hoyISO),
   }
 }
 

--- a/src/types/hooks.ts
+++ b/src/types/hooks.ts
@@ -592,21 +592,31 @@ export interface VentaPorDia {
   pedidos: number;
 }
 
+// Buckets de estado del dashboard. 'en_preparacion' (hoy sin uso en la BD)
+// se agrupa dentro de `pendiente` (pre-reparto).
 export interface PedidosPorEstado {
   pendiente: number;
-  en_preparacion: number;
   asignado: number;
   entregado: number;
 }
 
 export interface DashboardMetricasExtended {
+  /** $ de pedidos ENTREGADOS del período (convención: venta = entregado). */
   ventasPeriodo: number;
+  /** $ de pedidos pendiente+asignado del período (aún no entregados). */
+  ventasEnCurso: number;
+  /** Pedidos no cancelados del período (actividad total). */
   pedidosPeriodo: number;
+  /** Base del ticket promedio. */
+  pedidosEntregados: number;
+  pedidosEnCurso: number;
+  /** Ventana anterior de igual duración; null si historico o rango sin desde. */
   ventasPeriodoAnterior?: number | null;
   pedidosPeriodoAnterior?: number | null;
   productosMasVendidos: ProductoVendido[];
   clientesMasActivos: ClienteActivo[];
   pedidosPorEstado: PedidosPorEstado;
+  /** Siempre los últimos 7 días calendario, independiente del período. */
   ventasPorDia: VentaPorDia[];
 }
 

--- a/src/utils/metricasDashboard.test.ts
+++ b/src/utils/metricasDashboard.test.ts
@@ -1,0 +1,183 @@
+import { describe, it, expect } from 'vitest'
+import {
+  addDiasISO,
+  diffDiasISO,
+  ventanaPeriodoDashboard,
+  ventanaAnterior,
+  agregarMetricasPeriodo,
+  serieVentas7Dias,
+  type PedidoMetricaRow,
+} from './metricasDashboard'
+
+describe('addDiasISO', () => {
+  it('suma un día sin perderse por el parseo UTC (bug del último día)', () => {
+    // new Date('2026-07-10') parsea a medianoche UTC y en AR (UTC-3) el +1 se
+    // anulaba; la aritmética por partes no depende del huso.
+    expect(addDiasISO('2026-07-10', 1)).toBe('2026-07-11')
+  })
+
+  it('cruza el mes', () => {
+    expect(addDiasISO('2026-06-30', 1)).toBe('2026-07-01')
+  })
+
+  it('resta días cruzando el mes', () => {
+    expect(addDiasISO('2026-03-01', -1)).toBe('2026-02-28')
+  })
+
+  it('respeta años bisiestos', () => {
+    expect(addDiasISO('2024-02-28', 1)).toBe('2024-02-29')
+    expect(addDiasISO('2024-03-01', -1)).toBe('2024-02-29')
+  })
+})
+
+describe('diffDiasISO', () => {
+  it('cuenta los días entre dos fechas', () => {
+    expect(diffDiasISO('2026-07-01', '2026-07-10')).toBe(9)
+    expect(diffDiasISO('2026-07-10', '2026-07-10')).toBe(0)
+  })
+})
+
+describe('ventanaPeriodoDashboard', () => {
+  const HOY = '2026-07-10'
+
+  it('hoy: un solo día, acotado arriba', () => {
+    expect(ventanaPeriodoDashboard('hoy', HOY)).toEqual({ desde: HOY, hasta: HOY })
+  })
+
+  it('semana: desde hace 7 días, sin tope', () => {
+    expect(ventanaPeriodoDashboard('semana', HOY)).toEqual({ desde: '2026-07-03', hasta: null })
+  })
+
+  it('mes: desde el 1° del mes, sin tope', () => {
+    expect(ventanaPeriodoDashboard('mes', HOY)).toEqual({ desde: '2026-07-01', hasta: null })
+  })
+
+  it('anio: desde el 1° de enero, sin tope', () => {
+    expect(ventanaPeriodoDashboard('anio', HOY)).toEqual({ desde: '2026-01-01', hasta: null })
+  })
+
+  it('historico: sin ventana', () => {
+    expect(ventanaPeriodoDashboard('historico', HOY)).toEqual({ desde: null, hasta: null })
+  })
+
+  it('personalizado: usa las fechas provistas, incluido el último día', () => {
+    expect(ventanaPeriodoDashboard('personalizado', HOY, '2026-07-01', '2026-07-09'))
+      .toEqual({ desde: '2026-07-01', hasta: '2026-07-09' })
+  })
+
+  it('personalizado con una sola fecha', () => {
+    expect(ventanaPeriodoDashboard('personalizado', HOY, '2026-07-01', null))
+      .toEqual({ desde: '2026-07-01', hasta: null })
+    expect(ventanaPeriodoDashboard('personalizado', HOY, null, '2026-07-09'))
+      .toEqual({ desde: null, hasta: '2026-07-09' })
+  })
+
+  it('personalizado del mismo día', () => {
+    expect(ventanaPeriodoDashboard('personalizado', HOY, '2026-07-05', '2026-07-05'))
+      .toEqual({ desde: '2026-07-05', hasta: '2026-07-05' })
+  })
+})
+
+describe('ventanaAnterior', () => {
+  it('misma duración terminando el día antes (convención del RPC)', () => {
+    expect(ventanaAnterior('2026-07-01', '2026-07-10'))
+      .toEqual({ desde: '2026-06-21', hasta: '2026-06-30' })
+  })
+
+  it('un solo día → el día anterior', () => {
+    expect(ventanaAnterior('2026-07-10', '2026-07-10'))
+      .toEqual({ desde: '2026-07-09', hasta: '2026-07-09' })
+  })
+})
+
+describe('agregarMetricasPeriodo', () => {
+  const pedido = (over: Partial<PedidoMetricaRow>): PedidoMetricaRow => ({
+    cliente_id: 'c1',
+    estado: 'entregado',
+    total: 100,
+    ...over,
+  })
+
+  it('separa venta entregada de lo en curso y excluye cancelados', () => {
+    const r = agregarMetricasPeriodo([
+      pedido({ estado: 'entregado', total: 1000 }),
+      pedido({ estado: 'entregado', total: 500, cliente_id: 'c2' }),
+      pedido({ estado: 'pendiente', total: 200 }),
+      pedido({ estado: 'asignado', total: 300 }),
+      pedido({ estado: 'cancelado', total: 9999 }),
+    ])
+    expect(r.ventasPeriodo).toBe(1500)
+    expect(r.ventasEnCurso).toBe(500)
+    expect(r.pedidosPeriodo).toBe(4)
+    expect(r.pedidosEntregados).toBe(2)
+    expect(r.pedidosEnCurso).toBe(2)
+    expect(r.pedidosPorEstado).toEqual({ pendiente: 1, asignado: 1, entregado: 2 })
+  })
+
+  it('en_preparacion cuenta como en curso y se agrupa con pendientes', () => {
+    const r = agregarMetricasPeriodo([
+      pedido({ estado: 'en_preparacion', total: 400 }),
+      pedido({ estado: 'entregado', total: 100 }),
+    ])
+    expect(r.ventasPeriodo).toBe(100)
+    expect(r.ventasEnCurso).toBe(400)
+    expect(r.pedidosEnCurso).toBe(1)
+    expect(r.pedidosPorEstado).toEqual({ pendiente: 1, asignado: 0, entregado: 1 })
+  })
+
+  it('arma top de productos y clientes sobre la actividad no cancelada', () => {
+    const r = agregarMetricasPeriodo([
+      pedido({
+        total: 100,
+        cliente: { nombre_fantasia: 'Kiosco A' },
+        items: [
+          { producto_id: 'p1', cantidad: 5, producto: { nombre: 'Manaos Cola' } },
+          { producto_id: 'p2', cantidad: 2, producto: { nombre: 'Placer Manzana' } },
+        ],
+      }),
+      pedido({
+        estado: 'pendiente',
+        total: 50,
+        cliente: { nombre_fantasia: 'Kiosco A' },
+        items: [{ producto_id: 'p1', cantidad: 3, producto: { nombre: 'Manaos Cola' } }],
+      }),
+    ])
+    expect(r.productosMasVendidos).toEqual([
+      { id: 'p1', nombre: 'Manaos Cola', cantidad: 8 },
+      { id: 'p2', nombre: 'Placer Manzana', cantidad: 2 },
+    ])
+    expect(r.clientesMasActivos).toEqual([
+      { id: 'c1', nombre: 'Kiosco A', total: 150, pedidos: 2 },
+    ])
+  })
+
+  it('devuelve ceros con dataset vacío', () => {
+    const r = agregarMetricasPeriodo([])
+    expect(r.ventasPeriodo).toBe(0)
+    expect(r.pedidosPeriodo).toBe(0)
+    expect(r.pedidosPorEstado).toEqual({ pendiente: 0, asignado: 0, entregado: 0 })
+    expect(r.productosMasVendidos).toEqual([])
+  })
+})
+
+describe('serieVentas7Dias', () => {
+  it('devuelve 7 buckets terminando hoy y rellena con 0 los días sin filas', () => {
+    const serie = serieVentas7Dias(
+      [
+        { fecha: '2026-07-10', total: 100 },
+        { fecha: '2026-07-10', total: 50 },
+        { fecha: '2026-07-08', total: 30 },
+        { fecha: '2026-07-01', total: 999 }, // fuera de la ventana de 7 días
+      ],
+      '2026-07-10',
+    )
+    expect(serie).toHaveLength(7)
+    expect(serie.map(s => s.ventas)).toEqual([0, 0, 0, 0, 30, 0, 150])
+    expect(serie.map(s => s.pedidos)).toEqual([0, 0, 0, 0, 1, 0, 2])
+  })
+
+  it('ignora filas sin fecha', () => {
+    const serie = serieVentas7Dias([{ fecha: null, total: 100 }], '2026-07-10')
+    expect(serie.every(s => s.ventas === 0)).toBe(true)
+  })
+})

--- a/src/utils/metricasDashboard.ts
+++ b/src/utils/metricasDashboard.ts
@@ -1,0 +1,196 @@
+/**
+ * Helpers puros para las métricas del Dashboard.
+ *
+ * Separados de useMetricasQuery para poder testearlos sin TanStack Query.
+ * Todas las fechas son strings 'YYYY-MM-DD' en huso Argentina (fechaLocalISO).
+ * OJO: nunca construir `new Date('YYYY-MM-DD')` — parsea a medianoche UTC y
+ * en UTC-3 cae en el día anterior (así se perdía el último día del rango
+ * personalizado). Acá las fechas se arman siempre por partes.
+ */
+import type {
+  ClienteActivo,
+  PedidosPorEstado,
+  ProductoVendido,
+  VentaPorDia,
+} from '../types'
+
+export interface VentanaPeriodo {
+  desde: string | null
+  hasta: string | null
+}
+
+/** Suma (o resta) días a una fecha 'YYYY-MM-DD' con aritmética de calendario. */
+export function addDiasISO(fechaISO: string, dias: number): string {
+  const [y, m, d] = fechaISO.split('-').map(Number)
+  const fecha = new Date(y, m - 1, d + dias)
+  const mm = String(fecha.getMonth() + 1).padStart(2, '0')
+  const dd = String(fecha.getDate()).padStart(2, '0')
+  return `${fecha.getFullYear()}-${mm}-${dd}`
+}
+
+/** Días entre dos fechas ISO (hasta − desde), sin efectos de huso/DST. */
+export function diffDiasISO(desdeISO: string, hastaISO: string): number {
+  const [y1, m1, d1] = desdeISO.split('-').map(Number)
+  const [y2, m2, d2] = hastaISO.split('-').map(Number)
+  return Math.round((Date.UTC(y2, m2 - 1, d2) - Date.UTC(y1, m1 - 1, d1)) / 86400000)
+}
+
+/**
+ * Ventana [desde, hasta] inclusive del período elegido, para filtrar por
+ * `pedidos.fecha` en el server. hasta=null ⇒ sin tope superior (los períodos
+ * relativos llegan hasta hoy e incluyen pedidos re-fechados a futuro dentro
+ * del mes/año, como siempre). Solo 'hoy' y 'personalizado' acotan arriba.
+ */
+export function ventanaPeriodoDashboard(
+  periodo: string,
+  hoyISO: string,
+  fechaDesde?: string | null,
+  fechaHasta?: string | null,
+): VentanaPeriodo {
+  switch (periodo) {
+    case 'hoy':
+      return { desde: hoyISO, hasta: hoyISO }
+    case 'semana':
+      return { desde: addDiasISO(hoyISO, -7), hasta: null }
+    case 'mes':
+      return { desde: `${hoyISO.slice(0, 7)}-01`, hasta: null }
+    case 'anio':
+      return { desde: `${hoyISO.slice(0, 4)}-01-01`, hasta: null }
+    case 'personalizado':
+      return { desde: fechaDesde || null, hasta: fechaHasta || null }
+    case 'historico':
+    default:
+      return { desde: null, hasta: null }
+  }
+}
+
+/**
+ * Ventana anterior de igual duración que termina el día antes de `desde`
+ * (misma convención que el comparativo del RPC reporte_gerencial).
+ */
+export function ventanaAnterior(desde: string, hasta: string): { desde: string; hasta: string } {
+  const prevHasta = addDiasISO(desde, -1)
+  const duracion = diffDiasISO(desde, hasta)
+  return { desde: addDiasISO(prevHasta, -duracion), hasta: prevHasta }
+}
+
+export interface PedidoMetricaRow {
+  cliente_id: string
+  estado: string
+  total: number | null
+  cliente?: { nombre_fantasia?: string } | null
+  items?: Array<{ producto_id: string; cantidad: number; producto?: { nombre?: string } | null }>
+}
+
+export interface MetricasPeriodo {
+  ventasPeriodo: number
+  ventasEnCurso: number
+  pedidosPeriodo: number
+  pedidosEntregados: number
+  pedidosEnCurso: number
+  pedidosPorEstado: PedidosPorEstado
+  productosMasVendidos: ProductoVendido[]
+  clientesMasActivos: ClienteActivo[]
+}
+
+/**
+ * Agregación del dataset del período. Venta = SOLO entregados (convención de
+ * negocio: igual que reporte_gerencial y el bot); pendiente+asignado se expone
+ * aparte como "en curso". Top productos/clientes siguen contando toda la
+ * actividad no cancelada del período.
+ */
+export function agregarMetricasPeriodo(pedidos: PedidoMetricaRow[]): MetricasPeriodo {
+  // La query ya excluye cancelados server-side; el filtro queda como defensa.
+  const activos = pedidos.filter(p => p.estado !== 'cancelado')
+
+  let ventasPeriodo = 0
+  let ventasEnCurso = 0
+  let pedidosEntregados = 0
+  let pedidosEnCurso = 0
+  const pedidosPorEstado: PedidosPorEstado = { pendiente: 0, asignado: 0, entregado: 0 }
+  const productosVendidos: Record<string, ProductoVendido> = {}
+  const clientesActivos: Record<string, ClienteActivo> = {}
+
+  for (const p of activos) {
+    const total = p.total || 0
+    if (p.estado === 'entregado') {
+      ventasPeriodo += total
+      pedidosEntregados += 1
+      pedidosPorEstado.entregado += 1
+    } else {
+      // Todo lo no entregado (ni cancelado) es venta en curso: pendiente,
+      // asignado y también en_preparacion (raro pero el flujo puede setearlo);
+      // en las cards, en_preparacion se agrupa con pendientes (pre-reparto).
+      ventasEnCurso += total
+      pedidosEnCurso += 1
+      if (p.estado === 'asignado') pedidosPorEstado.asignado += 1
+      else pedidosPorEstado.pendiente += 1
+    }
+
+    p.items?.forEach(i => {
+      const id = i.producto_id
+      if (!productosVendidos[id]) {
+        productosVendidos[id] = { id, nombre: i.producto?.nombre || 'N/A', cantidad: 0 }
+      }
+      productosVendidos[id].cantidad += i.cantidad
+    })
+
+    const clienteId = p.cliente_id
+    if (!clientesActivos[clienteId]) {
+      clientesActivos[clienteId] = {
+        id: clienteId,
+        nombre: p.cliente?.nombre_fantasia || 'N/A',
+        total: 0,
+        pedidos: 0,
+      }
+    }
+    clientesActivos[clienteId].total += total
+    clientesActivos[clienteId].pedidos += 1
+  }
+
+  return {
+    ventasPeriodo,
+    ventasEnCurso,
+    pedidosPeriodo: activos.length,
+    pedidosEntregados,
+    pedidosEnCurso,
+    pedidosPorEstado,
+    productosMasVendidos: Object.values(productosVendidos)
+      .sort((a, b) => b.cantidad - a.cantidad)
+      .slice(0, 5),
+    clientesMasActivos: Object.values(clientesActivos)
+      .sort((a, b) => b.total - a.total)
+      .slice(0, 5),
+  }
+}
+
+/**
+ * Serie fija de los últimos 7 días calendario terminando en hoyISO, con los
+ * días sin ventas en 0. Independiente del período elegido en el filtro.
+ */
+export function serieVentas7Dias(
+  rows: Array<{ fecha?: string | null; total: number | null }>,
+  hoyISO: string,
+): VentaPorDia[] {
+  const porFecha = new Map<string, { ventas: number; pedidos: number }>()
+  for (const r of rows) {
+    if (!r.fecha) continue
+    const acc = porFecha.get(r.fecha) ?? { ventas: 0, pedidos: 0 }
+    acc.ventas += r.total || 0
+    acc.pedidos += 1
+    porFecha.set(r.fecha, acc)
+  }
+
+  const serie: VentaPorDia[] = []
+  for (let i = 6; i >= 0; i--) {
+    const fechaISO = addDiasISO(hoyISO, -i)
+    const [y, m, d] = fechaISO.split('-').map(Number)
+    const acc = porFecha.get(fechaISO)
+    serie.push({
+      dia: new Date(y, m - 1, d).toLocaleDateString('es-AR', { weekday: 'short' }),
+      ventas: acc?.ventas ?? 0,
+      pedidos: acc?.pedidos ?? 0,
+    })
+  }
+  return serie
+}


### PR DESCRIPTION
## Resumen

Auditoría 2026-07-10 (verificada contra prod): el dashboard contaba pedidos **no entregados** como "Ventas" — julio MTD Tucumán mostraba **$6.901.530** cuando lo entregado era **$5.178.150** (+33%). Este PR alinea el dashboard con la convención de negocio (venta = `estado='entregado'`, la misma del RPC `reporte_gerencial` y del bot desde mig 098) y arregla 3 bugs de fechas/UI.

## Cambios

- **Venta entregada vs en curso**: la card principal pasa a "Venta entregada"; pendiente+asignado (+en_preparacion si apareciera) se muestran como subtítulo `+$X en curso (N)`. El ticket promedio usa la base entregada.
- **Tendencia vs período anterior**: el hook ahora calcula la ventana anterior de igual duración (misma convención que el comparativo del RPC) con una query liviana. Antes `ventasPeriodoAnterior` nunca se devolvía y el indicador decía siempre "Sin datos previos".
- **Filtro por `pedidos.fecha` server-side** (gte/lte) en vez de `created_at`:
  - arregla que el rango personalizado **perdía el último día** (`new Date('YYYY-MM-DD')` parsea a medianoche UTC y el hack de +1 día se anulaba en huso AR);
  - incluye pedidos **re-fechados** a un período posterior a su creación (mismo patrón del fix de rutas #414; desde mayo hay 80/2101 pedidos con fecha editada).
- **Gráfico "Ventas últimos 7 días"** con ventana propia fija: antes usaba el dataset del período elegido, y con "Hoy" mostraba 6 días en cero.
- **Card "En preparación" eliminada** (0 pedidos en prod; grid de estados queda en 3). Si el estado apareciera, cuenta como "en curso" y se agrupa en "Pendientes" — la matemática no se rompe.
- Lógica pura extraída a `src/utils/metricasDashboard.ts` (ventanas de fecha, agregación, serie 7 días) con **15 tests nuevos**, incluido el caso exacto del bug de UTC.

## Verificación

- `npm run typecheck` ✅ · `npm run test:run` **770/770** ✅ (corre también en pre-commit)
- Números de referencia (prod, julio 1–10, Tucumán): entregado **$5.178.150** + en curso **$1.723.380** = $6.901.530 (el total que antes se mostraba como "Ventas" — cierra al peso).
- La ventana anterior para ese rango es 21–30/06 (`ventanaAnterior` testeada con ese caso).

🤖 Generated with [Claude Code](https://claude.com/claude-code)