### PR TITLE
fix(reporte): cobranza real, split de mermas y sección de bonificaciones por promo

### DIFF
--- a/migrations/110_reporte_gerencial_pagos_mermas_split_bonif_promos.sql
+++ b/migrations/110_reporte_gerencial_pagos_mermas_split_bonif_promos.sql
@@ -1,0 +1,321 @@
+-- ============================================================================
+-- 110 · reporte_gerencial: cobranza real, split de mermas y detalle de promos
+-- ============================================================================
+-- Fixes de la auditoría de integridad 2026-07-10 + sección nueva de
+-- bonificaciones. Misma firma de 5 args ⇒ CREATE OR REPLACE (sin DROP).
+--
+--   1) cobranza.formas sale de la tabla `pagos` (cobros REALES de los pedidos
+--      del período, criterio devengado), no de pedidos.forma_pago (intención
+--      declarada al crear: junio-2026 s1 mostraba transferencia $415K cuando
+--      los pagos reales fueron $3,36M). Si hay monto_pagado sin fila en
+--      `pagos` se agrega la línea residual "(sin registro de pago)".
+--   2) cobranza.cobrado/pendiente por MONTO (LEAST/GREATEST sobre
+--      monto_pagado): un pago parcial ya no cuenta 100% como pendiente.
+--   3) kpis.compras y mensual.compras excluyen compras canceladas.
+--   4) kpis.mermas se mantiene TOTAL operativo (compat: contribución del
+--      front y /reporte-mensual lo usan como escalar) y se agregan
+--      mermas_perdida (vencimiento/rotura/robo/decomiso/devolucion),
+--      mermas_ajuste (error_inventario/otro/desconocido) y mermas_muestra
+--      (muestra). mermas_motivo[] expone ahora `clasificacion`.
+--   5) bonif_detalle → bonif_promos: lo regalado agrupado por promoción ×
+--      producto, valuado a costo (convención del KPI bonif) Y a precio de
+--      lista actual (valor_venta; ÷ unidades_por_bloque si la promo es
+--      fraccionada, porque ahí `cantidad` está en botellas). bonif_detalle
+--      no tenía consumidores en el front.
+--   6) El modo "Todos" (p_incluir_no_entregados) suma 'en_preparacion' al
+--      set de estados: hoy no hay filas en prod pero el flujo puede setearlo
+--      y quedaba fuera del toggle (y del dashboard no; alineación).
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION public.reporte_gerencial(
+  p_sucursal_id bigint,
+  p_desde date,
+  p_hasta date,
+  p_incluir_no_entregados boolean DEFAULT false,
+  p_comparar boolean DEFAULT false
+)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ STABLE SECURITY DEFINER
+ SET search_path TO 'public'
+AS $function$
+DECLARE
+  v_sucursales bigint[]; v_asignadas bigint[]; v_nombre text; v_result jsonb;
+  v_es_servicio boolean := (auth.uid() IS NULL);
+  v_estados text[] := CASE WHEN p_incluir_no_entregados
+                           THEN ARRAY['entregado','asignado','pendiente','en_preparacion']
+                           ELSE ARRAY['entregado'] END;
+  v_dias int := (p_hasta - p_desde) + 1;
+  v_prev_hasta date := p_desde - 1;
+  v_prev_desde date := (p_desde - 1) - ((p_hasta - p_desde));
+  v_comparativo jsonb := NULL;
+  v_prev jsonb;
+  v_alertas jsonb := '[]'::jsonb;
+  v_cat_neg int;
+  v_cli_inact int;
+  v_cob_venc numeric;
+  v_cob_venc_cli int;
+  v_venta numeric;
+  v_prev_venta numeric;
+  v_mermas numeric;
+  v_prev_mermas numeric;
+BEGIN
+  IF NOT v_es_servicio THEN
+    IF NOT EXISTS (SELECT 1 FROM perfiles WHERE id = auth.uid() AND rol = 'admin') THEN
+      RAISE EXCEPTION 'Acceso denegado: se requiere rol admin'; END IF;
+    SELECT array_agg(sucursal_id) INTO v_asignadas FROM usuario_sucursales WHERE usuario_id = auth.uid();
+    IF v_asignadas IS NULL THEN RAISE EXCEPTION 'Acceso denegado: el usuario no tiene sucursales asignadas'; END IF;
+  END IF;
+  IF p_sucursal_id IS NULL THEN
+    SELECT array_agg(id) INTO v_sucursales FROM sucursales WHERE activa;
+    IF NOT v_es_servicio THEN
+      SELECT array_agg(s) INTO v_sucursales FROM unnest(v_sucursales) AS s WHERE s = ANY(v_asignadas); END IF;
+    v_nombre := 'Red (consolidado)';
+  ELSE
+    IF NOT v_es_servicio AND NOT (p_sucursal_id = ANY(v_asignadas)) THEN
+      RAISE EXCEPTION 'Acceso denegado: la sucursal % no está asignada al usuario', p_sucursal_id; END IF;
+    v_sucursales := ARRAY[p_sucursal_id];
+    SELECT nombre INTO v_nombre FROM sucursales WHERE id = p_sucursal_id;
+  END IF;
+  IF v_sucursales IS NULL OR array_length(v_sucursales,1) IS NULL THEN
+    RAISE EXCEPTION 'Acceso denegado: sin sucursales disponibles para el usuario'; END IF;
+
+  WITH
+  ped AS (
+    SELECT id, cliente_id, usuario_id, total, monto_pagado, fecha, forma_pago, estado_pago
+    FROM pedidos WHERE estado = ANY(v_estados) AND canal='app'
+      AND fecha BETWEEN p_desde AND p_hasta AND sucursal_id = ANY(v_sucursales)
+  ),
+  it AS (
+    SELECT p.id AS pedido_id, p.usuario_id, p.fecha,
+           pi.cantidad, pi.subtotal, pi.es_bonificacion,
+           COALESCE(pi.costo_unitario_al_crear, prod.costo_sin_iva*(1+COALESCE(prod.impuestos_internos,0)/100)) AS costo_unit,
+           prod.nombre AS prod_nombre,
+           COALESCE(NULLIF(prod.categoria,''),'(sin categoría)') AS categoria,
+           (prod.costo_sin_iva IS NULL OR prod.costo_sin_iva = 0) AS sin_costo,
+           pr.nombre AS promo_nombre,
+           (pr.regalo_mueve_stock IS FALSE AND COALESCE(pr.unidades_por_bloque,0) > 0) AS es_fraccion,
+           pr.unidades_por_bloque,
+           COALESCE(prod.precio,0) AS precio_lista,
+           CASE WHEN pi.es_bonificacion THEN
+             CASE WHEN pr.regalo_mueve_stock IS FALSE AND pr.unidades_por_bloque > 0
+                  THEN pi.cantidad * COALESCE(pi.costo_unitario_al_crear, prod.costo_sin_iva*(1+COALESCE(prod.impuestos_internos,0)/100)) / pr.unidades_por_bloque
+                  ELSE pi.cantidad * COALESCE(pi.costo_unitario_al_crear, prod.costo_sin_iva*(1+COALESCE(prod.impuestos_internos,0)/100)) END
+           ELSE 0 END AS costo_bonif
+    FROM ped p
+    JOIN pedido_items pi ON pi.pedido_id = p.id
+    JOIN productos prod ON prod.id = pi.producto_id
+    LEFT JOIN promociones pr ON pr.id = pi.promocion_id
+  ),
+  nc AS (
+    SELECT usuario_id, total FROM pedidos
+    WHERE estado<>'cancelado' AND canal='app'
+      AND fecha BETWEEN p_desde AND p_hasta AND sucursal_id = ANY(v_sucursales)
+      AND usuario_id IN (SELECT id FROM perfiles)
+  ),
+  k_ped AS (SELECT COUNT(*) AS pedidos, COALESCE(SUM(total),0) AS venta,
+            COUNT(DISTINCT cliente_id) AS clientes, COALESCE(ROUND(AVG(total)),0) AS ticket FROM ped),
+  k_it AS (
+    SELECT COALESCE(SUM(cantidad*costo_unit) FILTER (WHERE NOT es_bonificacion),0) AS cmv,
+      COALESCE(SUM(costo_bonif),0) AS bonif,
+      COALESCE(SUM(cantidad) FILTER (WHERE NOT es_bonificacion),0) AS unidades,
+      COALESCE(SUM(cantidad) FILTER (WHERE es_bonificacion),0) AS unidades_bonif,
+      COALESCE(SUM(subtotal) FILTER (WHERE sin_costo AND NOT es_bonificacion),0) AS ingreso_sin_costo
+    FROM it
+  ),
+  k_nc AS (SELECT COALESCE(SUM(total),0) AS base_comision FROM nc),
+  -- Mermas operativas valuadas a costo, con clasificación de negocio:
+  -- perdida = producto que se perdió físicamente; ajuste = corrección de
+  -- inventario (puede ser error de carga, no pérdida); muestra = costo
+  -- comercial. El total (mermas) = perdida + ajuste + muestra, siempre.
+  k_merma AS (
+    SELECT COALESCE(SUM(costo),0) AS mermas,
+      COALESCE(SUM(costo) FILTER (WHERE clasif = 'perdida'),0) AS mermas_perdida,
+      COALESCE(SUM(costo) FILTER (WHERE clasif = 'ajuste'),0) AS mermas_ajuste,
+      COALESCE(SUM(costo) FILTER (WHERE clasif = 'muestra'),0) AS mermas_muestra
+    FROM (
+      SELECT m.cantidad*prod.costo_sin_iva*(1+COALESCE(prod.impuestos_internos,0)/100) AS costo,
+             CASE WHEN m.motivo IN ('vencimiento','rotura','robo','decomiso','devolucion') THEN 'perdida'
+                  WHEN m.motivo = 'muestra' THEN 'muestra'
+                  ELSE 'ajuste' END AS clasif
+      FROM mermas_stock m JOIN productos prod ON prod.id = m.producto_id
+      WHERE m.sucursal_id = ANY(v_sucursales)
+        AND (m.created_at AT TIME ZONE 'America/Argentina/Buenos_Aires')::date BETWEEN p_desde AND p_hasta
+        AND COALESCE(m.motivo,'') NOT IN ('promociones','promociones_reversion')
+    ) t
+  ),
+  k_compra AS (SELECT COALESCE(SUM(total),0) AS compras FROM compras
+    WHERE sucursal_id = ANY(v_sucursales) AND fecha_compra BETWEEN p_desde AND p_hasta
+      AND COALESCE(estado,'') <> 'cancelada'),
+  k_nuevos AS (SELECT COUNT(*) AS nuevos FROM (
+      SELECT cliente_id, MIN(fecha) AS pc FROM pedidos
+      WHERE estado='entregado' AND sucursal_id = ANY(v_sucursales) GROUP BY cliente_id
+    ) t WHERE pc BETWEEN p_desde AND p_hasta),
+  m_ped AS (SELECT to_char(fecha,'YYYY-MM') AS mes, COUNT(*) AS pedidos, SUM(total) AS venta,
+            COUNT(DISTINCT cliente_id) AS clientes, ROUND(AVG(total)) AS ticket FROM ped GROUP BY 1),
+  m_it AS (SELECT to_char(fecha,'YYYY-MM') AS mes,
+           COALESCE(SUM(cantidad*costo_unit) FILTER (WHERE NOT es_bonificacion),0) AS cmv,
+           COALESCE(SUM(costo_bonif),0) AS bonif FROM it GROUP BY 1),
+  m_merma AS (SELECT to_char(m.created_at AT TIME ZONE 'America/Argentina/Buenos_Aires','YYYY-MM') AS mes,
+       SUM(m.cantidad*prod.costo_sin_iva*(1+COALESCE(prod.impuestos_internos,0)/100)) AS mermas
+    FROM mermas_stock m JOIN productos prod ON prod.id = m.producto_id
+    WHERE m.sucursal_id = ANY(v_sucursales)
+      AND (m.created_at AT TIME ZONE 'America/Argentina/Buenos_Aires')::date BETWEEN p_desde AND p_hasta
+      AND COALESCE(m.motivo,'') NOT IN ('promociones','promociones_reversion') GROUP BY 1),
+  m_compra AS (SELECT to_char(fecha_compra,'YYYY-MM') AS mes, SUM(total) AS compras
+    FROM compras WHERE sucursal_id = ANY(v_sucursales) AND fecha_compra BETWEEN p_desde AND p_hasta
+      AND COALESCE(estado,'') <> 'cancelada' GROUP BY 1),
+  mensual AS (SELECT mp.mes, mp.pedidos, mp.venta, mp.clientes, mp.ticket,
+      COALESCE(mi.cmv,0) AS cmv, COALESCE(mi.bonif,0) AS bonif,
+      COALESCE(mm.mermas,0) AS mermas, COALESCE(mc.compras,0) AS compras
+    FROM m_ped mp LEFT JOIN m_it mi ON mi.mes=mp.mes LEFT JOIN m_merma mm ON mm.mes=mp.mes LEFT JOIN m_compra mc ON mc.mes=mp.mes),
+  v_ent AS (SELECT usuario_id, COUNT(DISTINCT pedido_id) AS pedidos, SUM(subtotal) AS venta,
+      SUM(subtotal) - COALESCE(SUM(cantidad*costo_unit) FILTER (WHERE NOT es_bonificacion),0) AS margen_comercial,
+      COALESCE(SUM(costo_bonif),0) AS bonif FROM it GROUP BY usuario_id),
+  v_nc AS (SELECT usuario_id, SUM(total) AS base_nc FROM nc GROUP BY usuario_id),
+  vendedores AS (SELECT pf.nombre, pf.rol, e.pedidos, e.venta, e.margen_comercial, e.bonif,
+      COALESCE(n.base_nc, e.venta) AS base_nc
+    FROM v_ent e JOIN perfiles pf ON pf.id=e.usuario_id LEFT JOIN v_nc n ON n.usuario_id=e.usuario_id),
+  categorias AS (SELECT categoria, SUM(subtotal) AS venta,
+      SUM(subtotal) - COALESCE(SUM(cantidad*costo_unit) FILTER (WHERE NOT es_bonificacion),0) AS margen_comercial,
+      COALESCE(SUM(costo_bonif),0) AS bonif, bool_or(sin_costo) AS sin_costo
+    FROM it GROUP BY categoria),
+  top_prod AS (SELECT prod_nombre AS nombre,
+      COALESCE(SUM(cantidad) FILTER (WHERE NOT es_bonificacion),0) AS unidades, SUM(subtotal) AS venta,
+      SUM(subtotal) - COALESCE(SUM(cantidad*costo_unit) FILTER (WHERE NOT es_bonificacion),0) AS margen
+    FROM it GROUP BY prod_nombre ORDER BY venta DESC LIMIT 10),
+  top_cli AS (SELECT COALESCE(NULLIF(c.nombre_fantasia,''), c.razon_social) AS cliente,
+      COUNT(DISTINCT p.id) AS pedidos, SUM(p.total) AS venta
+    FROM ped p JOIN clientes c ON c.id=p.cliente_id GROUP BY 1 ORDER BY venta DESC LIMIT 10),
+  -- Lo regalado por promoción × producto, valuado a costo real y a precio de
+  -- lista actual. En promos fraccionadas `cantidad` está en botellas y tanto
+  -- costo como precio del maestro son por fardo ⇒ ÷ unidades_por_bloque.
+  bonif_promos AS (SELECT COALESCE(promo_nombre,'(sin promoción)') AS promocion, prod_nombre AS producto,
+      SUM(cantidad) AS unidades, bool_or(es_fraccion) AS es_fraccion,
+      SUM(costo_bonif) AS costo,
+      SUM(CASE WHEN es_fraccion THEN cantidad * precio_lista / unidades_por_bloque
+               ELSE cantidad * precio_lista END) AS valor_venta
+    FROM it WHERE es_bonificacion GROUP BY 1, 2 HAVING SUM(cantidad) > 0),
+  mermas_motivo AS (SELECT COALESCE(NULLIF(m.motivo,''),'(sin motivo)') AS motivo,
+      CASE WHEN m.motivo IN ('vencimiento','rotura','robo','decomiso','devolucion') THEN 'perdida'
+           WHEN m.motivo = 'muestra' THEN 'muestra'
+           ELSE 'ajuste' END AS clasificacion,
+      SUM(m.cantidad) AS unidades, SUM(m.cantidad*prod.costo_sin_iva*(1+COALESCE(prod.impuestos_internos,0)/100)) AS costo
+    FROM mermas_stock m JOIN productos prod ON prod.id=m.producto_id
+    WHERE m.sucursal_id = ANY(v_sucursales)
+      AND (m.created_at AT TIME ZONE 'America/Argentina/Buenos_Aires')::date BETWEEN p_desde AND p_hasta
+      AND COALESCE(m.motivo,'') NOT IN ('promociones','promociones_reversion') GROUP BY 1, 2),
+  -- Cobranza por monto: parcial cuenta lo efectivamente pagado (LEAST capea
+  -- sobrepagos). Definido ANTES de `formas`, que necesita `cobrado`.
+  cobr AS (SELECT COALESCE(SUM(LEAST(COALESCE(monto_pagado,0), total)),0) AS cobrado,
+      COALESCE(SUM(GREATEST(total - COALESCE(monto_pagado,0), 0)),0) AS pendiente FROM ped),
+  -- Formas de pago REALES: pagos registrados de los pedidos del período
+  -- (devengado). La fila residual cubre monto_pagado legacy sin fila en pagos.
+  pagos_ped AS (SELECT COALESCE(NULLIF(pg.forma_pago,''),'(sin dato)') AS forma_pago, SUM(pg.monto) AS monto
+    FROM pagos pg JOIN ped ON ped.id = pg.pedido_id GROUP BY 1),
+  formas AS (SELECT forma_pago, monto FROM pagos_ped
+    UNION ALL
+    SELECT '(sin registro de pago)', c.cobrado - COALESCE((SELECT SUM(monto) FROM pagos_ped),0)
+    FROM cobr c
+    WHERE c.cobrado - COALESCE((SELECT SUM(monto) FROM pagos_ped),0) > 0.01),
+  serie AS (SELECT to_char(fecha,'DD/MM') AS dia, SUM(total) AS venta FROM ped GROUP BY fecha ORDER BY fecha)
+  SELECT jsonb_build_object(
+    'meta', jsonb_build_object('sucursal_id', p_sucursal_id, 'sucursal_nombre', COALESCE(v_nombre,'?'),
+      'desde', p_desde, 'hasta', p_hasta, 'generado_at', now(),
+      'incluye_no_entregados', p_incluir_no_entregados),
+    'kpis', (SELECT jsonb_build_object('venta', kp.venta, 'pedidos', kp.pedidos, 'clientes', kp.clientes, 'ticket', kp.ticket,
+        'clientes_nuevos', kn.nuevos, 'cmv', ki.cmv, 'bonif', ki.bonif, 'unidades', ki.unidades,
+        'unidades_bonif', ki.unidades_bonif, 'margen_comercial', kp.venta - ki.cmv,
+        'margen_neto', kp.venta - ki.cmv - ki.bonif, 'base_comision', kc.base_comision, 'comision_pct_default', 2,
+        'mermas', km.mermas, 'mermas_perdida', km.mermas_perdida, 'mermas_ajuste', km.mermas_ajuste,
+        'mermas_muestra', km.mermas_muestra, 'compras', kcp.compras, 'ingreso_sin_costo', ki.ingreso_sin_costo)
+      FROM k_ped kp, k_it ki, k_nc kc, k_merma km, k_compra kcp, k_nuevos kn),
+    'mensual', (SELECT COALESCE(jsonb_agg(to_jsonb(m) ORDER BY m.mes),'[]') FROM mensual m),
+    'vendedores', (SELECT COALESCE(jsonb_agg(to_jsonb(v) ORDER BY v.venta DESC),'[]') FROM vendedores v),
+    'categorias', (SELECT COALESCE(jsonb_agg(to_jsonb(c) ORDER BY c.venta DESC),'[]') FROM categorias c),
+    'top_productos', (SELECT COALESCE(jsonb_agg(to_jsonb(t)),'[]') FROM top_prod t),
+    'top_clientes', (SELECT COALESCE(jsonb_agg(to_jsonb(t)),'[]') FROM top_cli t),
+    'bonif_promos', (SELECT COALESCE(jsonb_agg(to_jsonb(b) ORDER BY b.valor_venta DESC),'[]') FROM bonif_promos b),
+    'mermas_motivo', (SELECT COALESCE(jsonb_agg(to_jsonb(mm) ORDER BY mm.costo DESC),'[]') FROM mermas_motivo mm),
+    'cobranza', jsonb_build_object('formas', (SELECT COALESCE(jsonb_agg(to_jsonb(f) ORDER BY f.monto DESC),'[]') FROM formas f),
+      'cobrado', (SELECT cobrado FROM cobr), 'pendiente', (SELECT pendiente FROM cobr)),
+    'serie_diaria', (SELECT COALESCE(jsonb_agg(jsonb_build_array(s.dia, s.venta)),'[]') FROM serie s),
+    'flags', (SELECT jsonb_build_object('ingreso_sin_costo', ki.ingreso_sin_costo,
+        'pct_sin_costo', CASE WHEN kp.venta > 0 THEN round(100.0*ki.ingreso_sin_costo/kp.venta,1) ELSE 0 END)
+      FROM k_it ki, k_ped kp)
+  ) INTO v_result;
+
+  -- ----- Comparativo: período anterior (recursivo, sin volver a comparar) -----
+  IF p_comparar THEN
+    v_prev := public.reporte_gerencial(p_sucursal_id, v_prev_desde, v_prev_hasta, p_incluir_no_entregados, false);
+    v_comparativo := (v_prev->'kpis') || jsonb_build_object('desde', v_prev_desde, 'hasta', v_prev_hasta);
+  END IF;
+
+  -- ----- Alertas: "qué requiere tu atención" -----
+  v_venta := (v_result->'kpis'->>'venta')::numeric;
+  v_mermas := (v_result->'kpis'->>'mermas')::numeric;
+  v_prev_venta := (v_comparativo->>'venta')::numeric;
+  v_prev_mermas := (v_comparativo->>'mermas')::numeric;
+
+  IF p_comparar AND COALESCE(v_prev_venta,0) > 0 AND v_venta < v_prev_venta * 0.9 THEN
+    v_alertas := v_alertas || jsonb_build_object(
+      'severidad', CASE WHEN v_venta < v_prev_venta*0.8 THEN 'critical' ELSE 'warning' END,
+      'codigo','venta_caida','titulo','Venta en baja',
+      'detalle','Cayó '||round((1 - v_venta/v_prev_venta)*100)::text||'% vs período anterior',
+      'valor', v_venta - v_prev_venta, 'seccion','evolucion');
+  END IF;
+
+  SELECT COALESCE(SUM(total - COALESCE(monto_pagado,0)),0), COUNT(DISTINCT cliente_id)
+    INTO v_cob_venc, v_cob_venc_cli
+  FROM pedidos
+  WHERE estado='entregado' AND canal='app' AND sucursal_id = ANY(v_sucursales)
+    AND COALESCE(estado_pago,'pendiente') IN ('pendiente','parcial')
+    AND fecha < CURRENT_DATE - 30 AND total > COALESCE(monto_pagado,0);
+  IF v_cob_venc > 0 THEN
+    v_alertas := v_alertas || jsonb_build_object('severidad','critical','codigo','cobranza_vencida','titulo','Cobranza vencida',
+      'detalle', v_cob_venc_cli::text||' cliente(s) con saldo impago hace +30 días',
+      'valor', v_cob_venc, 'seccion','cobranza');
+  END IF;
+
+  SELECT COUNT(*) INTO v_cli_inact FROM (
+    SELECT p.cliente_id FROM pedidos p
+    WHERE p.estado='entregado' AND p.canal='app' AND p.sucursal_id = ANY(v_sucursales)
+    GROUP BY p.cliente_id
+    HAVING MAX(p.fecha) < CURRENT_DATE - 30 AND MAX(p.fecha) >= CURRENT_DATE - 90
+  ) t;
+  IF v_cli_inact > 0 THEN
+    v_alertas := v_alertas || jsonb_build_object('severidad','warning','codigo','clientes_inactivos','titulo','Clientes que dejaron de comprar',
+      'detalle', v_cli_inact::text||' cliente(s) sin comprar hace +30 días (compraban hasta hace poco)',
+      'valor', v_cli_inact, 'seccion','clientes');
+  END IF;
+
+  IF p_comparar AND COALESCE(v_prev_mermas,0) > 0 AND v_mermas > v_prev_mermas*1.3 AND v_mermas > 50000 THEN
+    v_alertas := v_alertas || jsonb_build_object('severidad','warning','codigo','mermas_alza','titulo','Mermas en alza',
+      'detalle','Subieron '||round((v_mermas/v_prev_mermas - 1)*100)::text||'% vs período anterior',
+      'valor', v_mermas, 'seccion','mermas');
+  END IF;
+
+  SELECT COUNT(*) INTO v_cat_neg FROM jsonb_array_elements(v_result->'categorias') c WHERE (c->>'margen_comercial')::numeric < 0;
+  IF v_cat_neg > 0 THEN
+    v_alertas := v_alertas || jsonb_build_object('severidad','warning','codigo','margen_categoria_negativo','titulo','Categorías con margen negativo',
+      'detalle', v_cat_neg::text||' categoría(s) con margen comercial negativo',
+      'valor', v_cat_neg, 'seccion','categorias');
+  END IF;
+
+  IF (v_result->'flags'->>'pct_sin_costo')::numeric >= 1 THEN
+    v_alertas := v_alertas || jsonb_build_object('severidad','info','codigo','productos_sin_costo','titulo','Productos sin costo',
+      'detalle', (v_result->'flags'->>'pct_sin_costo')::text||'% de la venta es de productos sin costo (margen sobreestimado)',
+      'valor', (v_result->'flags'->>'ingreso_sin_costo')::numeric, 'seccion','categorias');
+  END IF;
+
+  -- Ordenar por severidad
+  SELECT COALESCE(jsonb_agg(a ORDER BY array_position(ARRAY['critical','warning','info'], a->>'severidad')), '[]'::jsonb)
+    INTO v_alertas FROM jsonb_array_elements(v_alertas) a;
+
+  v_result := v_result || jsonb_build_object('comparativo', COALESCE(v_comparativo,'null'::jsonb), 'alertas', v_alertas);
+  RETURN v_result;
+END;
+$function$;
+
+REVOKE EXECUTE ON FUNCTION public.reporte_gerencial(bigint, date, date, boolean, boolean) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.reporte_gerencial(bigint, date, date, boolean, boolean) TO authenticated, service_role;

--- a/migrations/MANIFEST.md
+++ b/migrations/MANIFEST.md
@@ -1,6 +1,6 @@
 # MANIFEST de migraciones — mapeo repo ↔ producción
 
-> **Fechado: 2026-06-30** · Proyecto prod `hmuchlzmuqqxcldbzkgc` (ManaosApp) · región `sa-east-1`.
+> **Fechado: 2026-07-10** · Proyecto prod `hmuchlzmuqqxcldbzkgc` (ManaosApp) · región `sa-east-1`.
 
 ## Regla de oro
 
@@ -89,11 +89,12 @@ desfasan y **se realinean en `101`**:
 | `105_auditoria_integridad.sql` | `105_…` + `105_…_ventana_2h` + `105_…_fix_cc_saldo_a_favor` |
 | (bot 014–020) | hotfix `020_bot_fix_pgcrypto_schema` plegado en la tanda, sin archivo propio |
 
-**Cadena `reporte_gerencial`** (reescrita ~8 veces por `CREATE OR REPLACE`): el repo versiona
-los hitos (`095`, `097` grants, `098`, `103`, `106`, `107`). Los intermedios del ledger
+**Cadena `reporte_gerencial`** (reescrita ~9 veces por `CREATE OR REPLACE`): el repo versiona
+los hitos (`095`, `097` grants, `098`, `103`, `106`, `107`, `110`). Los intermedios del ledger
 `reporte_gerencial_restringir_por_sucursal_asignada` y `reporte_gerencial_desglose_bonif_mermas`
 **no tienen archivo dedicado**: su lógica (p.ej. el gate `v_asignadas`) **sobrevive en el body
-vivo**, que equivale al último archivo (`107`).
+vivo**, que equivale al último archivo (`110`: cobranza desde `pagos`, parciales por monto,
+compras sin canceladas, split de mermas, `bonif_promos`).
 
 ---
 

--- a/src/components/vistas/VistaReportesGerenciales.tsx
+++ b/src/components/vistas/VistaReportesGerenciales.tsx
@@ -6,13 +6,13 @@ import ReactMarkdown from 'react-markdown'
 import NumberInput from '../ui/NumberInput'
 import { money, moneyC, pct, N, rolLabel } from './reportes-gerenciales/formato'
 import {
-  EvolucionChart, DiarioChart, VendedoresChart, CategoriasChart, WaterfallChart, CobranzaDonut,
+  EvolucionChart, DiarioChart, VendedoresChart, CategoriasChart, WaterfallChart, CobranzaDonut, BonifPromosChart,
 } from './reportes-gerenciales/charts'
 import Sparkline from './reportes-gerenciales/Sparkline'
 import Alertas from './reportes-gerenciales/Alertas'
 import ModalMetas from './reportes-gerenciales/ModalMetas'
 import ModalAlertaDetalle from './reportes-gerenciales/ModalAlertaDetalle'
-import type { ReporteGerencial, AnalisisMensual, MetasGerenciales, Alerta } from '../../hooks/queries'
+import type { ReporteGerencial, AnalisisMensual, MetasGerenciales, Alerta, BonifPromo } from '../../hooks/queries'
 
 // Alertas cuyo detalle es una LISTA (modal). El resto hace scroll a su sección.
 const ALERTA_CON_LISTA = new Set(['cobranza_vencida', 'clientes_inactivos', 'productos_sin_costo'])
@@ -183,6 +183,29 @@ export default function VistaReportesGerenciales({
     return { comision, contrib: kp.margen_neto - kp.mermas - comision }
   }, [kp, comPct, comBase])
 
+  // Bonificaciones agrupadas por promoción (subtotales + filas por producto).
+  const bonifAgrupado = useMemo(() => {
+    const grupos = new Map<string, { promocion: string; costo: number; valor_venta: number; items: BonifPromo[] }>()
+    for (const b of reporte?.bonif_promos ?? []) {
+      const g = grupos.get(b.promocion) ?? { promocion: b.promocion, costo: 0, valor_venta: 0, items: [] }
+      g.costo += b.costo
+      g.valor_venta += b.valor_venta
+      g.items.push(b)
+      grupos.set(b.promocion, g)
+    }
+    return [...grupos.values()]
+      .map(g => ({ ...g, items: [...g.items].sort((a, b) => b.valor_venta - a.valor_venta) }))
+      .sort((a, b) => b.valor_venta - a.valor_venta)
+  }, [reporte?.bonif_promos])
+
+  const totBonif = useMemo(
+    () => bonifAgrupado.reduce(
+      (acc, g) => ({ costo: acc.costo + g.costo, valor_venta: acc.valor_venta + g.valor_venta }),
+      { costo: 0, valor_venta: 0 },
+    ),
+    [bonifAgrupado],
+  )
+
   return (
     <div className="space-y-5">
       {/* Header + selectores */}
@@ -306,7 +329,11 @@ export default function VistaReportesGerenciales({
               </div>} />
             <KpiCard label={`Comisión ${String(comPct).replace('.', ',')}%`} value={moneyC(derived.comision)} sub={`base ${comBase === 'nc' ? 'no cancelado' : 'entregado'}`} accent={ACCENTS.slate}
               delta={cmp && derivedPrev ? <Delta cur={derived.comision} prev={derivedPrev.comision} invert /> : undefined} />
-            <KpiCard label="Mermas" value={moneyC(k.mermas)} sub="producto perdido" accent={ACCENTS.red}
+            <KpiCard label="Mermas" value={moneyC(k.mermas)}
+              sub={k.mermas_perdida != null
+                ? <>Pérdida <b>{moneyC(k.mermas_perdida)}</b> · Ajustes {moneyC(k.mermas_ajuste ?? 0)} · Muestras {moneyC(k.mermas_muestra ?? 0)}</>
+                : 'producto perdido'}
+              accent={ACCENTS.red}
               delta={cmp ? <Delta cur={k.mermas} prev={kp!.mermas} invert /> : undefined} />
             <KpiCard label="Contribución est." value={moneyC(derived.contrib)} sub={<><b>{pct(derived.contrib / k.venta)}</b> antes de gastos fijos</>} accent={ACCENTS.emerald}
               delta={cmp && derivedPrev ? <Delta cur={derived.contrib} prev={derivedPrev.contrib} /> : undefined} />
@@ -505,7 +532,7 @@ export default function VistaReportesGerenciales({
           {/* Cobranza + costos */}
           <div className="grid lg:grid-cols-2 gap-5">
             <Card id="sec-cobranza" className="p-5">
-              <SectionTitle icon={TrendingUp} title="Cobranza y formas de pago" hint={`${pct(reporte.cobranza.cobrado / (k.venta || 1))} cobrado.`} />
+              <SectionTitle icon={TrendingUp} title="Cobranza y formas de pago" hint={`Pagos registrados de las ventas del período. ${pct(reporte.cobranza.cobrado / (k.venta || 1))} cobrado.`} />
               <div className="grid grid-cols-2 gap-4 items-center">
                 <div className="h-48"><CobranzaDonut cobranza={reporte.cobranza} /></div>
                 <table className="w-full">
@@ -519,6 +546,10 @@ export default function VistaReportesGerenciales({
                     <tr className="font-semibold">
                       <td className={`${td} text-emerald-600 dark:text-emerald-400`}>Cobrado</td>
                       <td className={`${td} text-right tabular-nums text-emerald-600 dark:text-emerald-400`}>{moneyC(reporte.cobranza.cobrado)}</td>
+                    </tr>
+                    <tr className="font-semibold">
+                      <td className={`${td} text-rose-600 dark:text-rose-400`}>Pendiente</td>
+                      <td className={`${td} text-right tabular-nums text-rose-600 dark:text-rose-400`}>{moneyC(reporte.cobranza.pendiente)}</td>
                     </tr>
                   </tbody>
                 </table>
@@ -543,6 +574,58 @@ export default function VistaReportesGerenciales({
               </table>
             </Card>
           </div>
+
+          {/* Bonificaciones y promociones: qué se regaló y cuánto vale */}
+          {bonifAgrupado.length > 0 && (
+            <Card id="sec-bonif" className="p-5">
+              <SectionTitle
+                icon={TrendingUp} title="Bonificaciones y promociones"
+                hint="Qué se regaló, de qué promoción salió y cuánto vale: costo real vs precio de lista. Unidades en botellas (bot.) cuando la promo es fraccionada."
+              />
+              <div className="grid lg:grid-cols-3 gap-5">
+                <div className="lg:col-span-2 h-72"><BonifPromosChart data={reporte.bonif_promos ?? []} /></div>
+                <div className="overflow-x-auto">
+                  <table className="w-full">
+                    <thead><tr className="border-b dark:border-gray-700">
+                      <th className={`${th} text-left`}>Producto</th><th className={`${th} text-right`}>Unid.</th>
+                      <th className={`${th} text-right`}>Costo</th><th className={`${th} text-right`}>Valor venta</th>
+                    </tr></thead>
+                    {bonifAgrupado.map(g => (
+                      <tbody key={g.promocion} className="divide-y dark:divide-gray-700/60">
+                        <tr className="bg-gray-50 dark:bg-gray-700/40">
+                          <td colSpan={2} className={`${td} font-semibold text-gray-900 dark:text-white`}>
+                            {g.promocion}
+                            <span className="ml-2 text-[10px] font-medium text-gray-400">{pct(g.valor_venta / (k.venta || 1))} de la venta</span>
+                          </td>
+                          <td className={`${td} text-right tabular-nums font-semibold`}>{moneyC(g.costo)}</td>
+                          <td className={`${td} text-right tabular-nums font-semibold`}>{moneyC(g.valor_venta)}</td>
+                        </tr>
+                        {g.items.map(b => (
+                          <tr key={g.promocion + b.producto}>
+                            <td className={`${td} pl-5`}>
+                              {b.producto}
+                              {b.es_fraccion && <span className="ml-1.5 text-[10px] font-semibold uppercase px-1 py-0.5 rounded border border-amber-300 dark:border-amber-700 text-amber-600 dark:text-amber-400">bot.</span>}
+                            </td>
+                            <td className={`${td} text-right tabular-nums`}>{N.format(b.unidades)}</td>
+                            <td className={`${td} text-right tabular-nums`}>{moneyC(b.costo)}</td>
+                            <td className={`${td} text-right tabular-nums`}>{moneyC(b.valor_venta)}</td>
+                          </tr>
+                        ))}
+                      </tbody>
+                    ))}
+                    <tfoot>
+                      <tr className="border-t-2 dark:border-gray-600 font-bold">
+                        <td className={`${td} text-gray-900 dark:text-white`}>Total</td>
+                        <td className={td}></td>
+                        <td className={`${td} text-right tabular-nums`}>{moneyC(totBonif.costo)}</td>
+                        <td className={`${td} text-right tabular-nums`}>{moneyC(totBonif.valor_venta)}</td>
+                      </tr>
+                    </tfoot>
+                  </table>
+                </div>
+              </div>
+            </Card>
+          )}
 
           {/* Análisis mensual (Claude Code) */}
           <Card className="p-5">

--- a/src/components/vistas/reportes-gerenciales/charts.tsx
+++ b/src/components/vistas/reportes-gerenciales/charts.tsx
@@ -16,7 +16,7 @@ import {
 import { Bar, Line, Doughnut } from 'react-chartjs-2'
 import { useTheme } from '../../../contexts/ThemeContext'
 import { money } from './formato'
-import type { ReporteMes, ReporteVendedor, ReporteCategoria, ReporteCobranza } from '../../../hooks/queries'
+import type { ReporteMes, ReporteVendedor, ReporteCategoria, ReporteCobranza, BonifPromo } from '../../../hooks/queries'
 
 ChartJS.register(
   CategoryScale, LinearScale, BarElement, LineElement, PointElement,
@@ -202,6 +202,44 @@ export function WaterfallChart({
         scales: {
           y: { ticks: { callback: fmtM, color: t.tick }, grid: { color: t.grid }, border: { display: false } },
           x: { ticks: { color: t.tick, font: { size: 10 } }, grid: { display: false }, border: { color: t.border } },
+        },
+      }}
+    />
+  )
+}
+
+// --- Bonificaciones: costo vs valor de venta por promoción (barras horiz.) ---
+export function BonifPromosChart({ data }: { data: BonifPromo[] }): React.ReactElement {
+  const t = useChartTheme()
+  // Agrupar por promoción y quedarse con las 10 de mayor valor de venta.
+  const porPromo = new Map<string, { costo: number; valor_venta: number }>()
+  for (const b of data) {
+    const acc = porPromo.get(b.promocion) ?? { costo: 0, valor_venta: 0 }
+    acc.costo += b.costo
+    acc.valor_venta += b.valor_venta
+    porPromo.set(b.promocion, acc)
+  }
+  const top = [...porPromo.entries()]
+    .sort((a, b) => b[1].valor_venta - a[1].valor_venta)
+    .slice(0, 10)
+  return (
+    <Bar
+      data={{
+        labels: top.map(([promo]) => promo),
+        datasets: [
+          { label: 'Valor de venta', data: top.map(([, v]) => v.valor_venta), backgroundColor: PALETTE.blue, borderRadius: 4 },
+          { label: 'Costo real', data: top.map(([, v]) => v.costo), backgroundColor: PALETTE.amber, borderRadius: 4 },
+        ],
+      }}
+      options={{
+        maintainAspectRatio: false, indexAxis: 'y',
+        plugins: {
+          legend: { position: 'bottom', labels: { usePointStyle: true, boxWidth: 8, padding: 12, color: t.tick } },
+          tooltip: { ...baseTooltip(t.tooltipBg), callbacks: { label: (c) => ` ${c.dataset.label}: ${money(Number(c.raw))}` } },
+        },
+        scales: {
+          x: { ticks: { callback: fmtM, color: t.tick }, grid: { color: t.grid }, border: { display: false } },
+          y: { ticks: { color: t.tick, font: { size: 11 } }, grid: { display: false }, border: { color: t.border } },
         },
       }}
     />

--- a/src/hooks/queries/index.ts
+++ b/src/hooks/queries/index.ts
@@ -245,6 +245,8 @@ export type {
   ReporteProducto,
   ReporteCliente,
   ReporteCobranza,
+  MermaMotivo,
+  BonifPromo,
   Alerta,
   MetasGerenciales,
   AlertaDetalleItem,

--- a/src/hooks/queries/useReporteGerencialQuery.ts
+++ b/src/hooks/queries/useReporteGerencialQuery.ts
@@ -1,10 +1,11 @@
 /**
  * TanStack Query hooks para los Reportes Gerenciales.
  *
- * Los datos salen del RPC `reporte_gerencial(sucursal, desde, hasta)` (mig 095),
- * que devuelve TODO el dashboard en un JSONB. p_sucursal_id NULL = consolidado
- * de red. El análisis narrativo mensual vive en la tabla `reportes_mensuales`
- * (lo escribe Claude Code vía el comando /reporte-mensual).
+ * Los datos salen del RPC `reporte_gerencial(sucursal, desde, hasta, ...)`
+ * (mig 095, última reescritura 110: cobranza real desde `pagos`, split de
+ * mermas y `bonif_promos`), que devuelve TODO el dashboard en un JSONB.
+ * p_sucursal_id NULL = consolidado de red. El análisis narrativo mensual vive
+ * en la tabla `reportes_mensuales` (lo escribe Claude Code vía /reporte-mensual).
  */
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { supabase } from '../../lib/supabase'
@@ -23,9 +24,36 @@ export interface ReporteKpis {
   margen_neto: number
   base_comision: number
   comision_pct_default: number
+  /** Total operativo (la contribución resta este número). */
   mermas: number
+  /** Split del total (mig 110): perdida+ajuste+muestra = mermas.
+   *  Opcionales por compat con respuestas cacheadas pre-110. */
+  mermas_perdida?: number
+  mermas_ajuste?: number
+  mermas_muestra?: number
   compras: number
   ingreso_sin_costo: number
+}
+
+/** Fila de mermas por motivo, con clasificación de negocio (mig 110). */
+export interface MermaMotivo {
+  motivo: string
+  unidades: number
+  costo: number
+  clasificacion: 'perdida' | 'ajuste' | 'muestra'
+}
+
+/** Lo regalado por promoción × producto (mig 110). */
+export interface BonifPromo {
+  promocion: string
+  producto: string
+  /** BOTELLAS si es_fraccion, fardos si no. */
+  unidades: number
+  es_fraccion: boolean
+  /** Costo real (misma convención que kpis.bonif). */
+  costo: number
+  /** Valuado a precio de lista actual (÷ unidades_por_bloque si fracción). */
+  valor_venta: number
 }
 
 export interface ReporteMes {
@@ -72,8 +100,11 @@ export interface ReporteCliente {
 }
 
 export interface ReporteCobranza {
+  /** Cobros REALES (tabla pagos) de los pedidos del período, por forma (mig 110). */
   formas: { forma_pago: string; monto: number }[]
+  /** Σ LEAST(monto_pagado, total): un pago parcial cuenta lo pagado. */
   cobrado: number
+  /** Σ GREATEST(total − monto_pagado, 0). */
   pendiente: number
 }
 
@@ -104,6 +135,10 @@ export interface ReporteGerencial {
   cobranza: ReporteCobranza
   serie_diaria: [string, number][]
   flags: { ingreso_sin_costo: number; pct_sin_costo: number }
+  // Detalle de mermas y de bonificaciones por promo (mig 110; opcionales por
+  // compat con respuestas cacheadas del RPC anterior).
+  mermas_motivo?: MermaMotivo[]
+  bonif_promos?: BonifPromo[]
   // KPIs del período anterior (cuando se pide comparar) + alertas, ambos del RPC.
   comparativo?: (ReporteKpis & { desde: string; hasta: string }) | null
   alertas?: Alerta[]


### PR DESCRIPTION
## Resumen

Fixes de la auditoría de integridad 2026-07-10 sobre `reporte_gerencial` + la sección nueva de análisis de bonificaciones/promociones. **La mig 110 ya está APLICADA en prod** (vía MCP `apply_migration`, nombre alineado al archivo para `check:migrations`) y validada con regresión: los KPIs de junio (venta/cmv/bonif) quedaron **idénticos al decimal**.

## Cambios (mig 110 · misma firma de 5 args, `CREATE OR REPLACE`)

1. **Formas de pago reales**: `cobranza.formas` sale de la tabla `pagos` (cobros de las ventas del período, criterio devengado), no de `pedidos.forma_pago` (la intención declarada al crear). Junio Tucumán: el donut mostraba transferencia **$414.780** cuando los cobros reales fueron **$3.709.510** (9x). Fila residual `(sin registro de pago)` si hubiera `monto_pagado` sin fila en `pagos`.
2. **Pagos parciales cuentan lo cobrado**: `cobrado = Σ LEAST(monto_pagado, total)`, `pendiente = Σ GREATEST(total − monto_pagado, 0)`. Junio Tucumán: cobrado $22,45M (antes $22,37M), pendiente $687K (antes $766K) — la diferencia se movió de una columna a la otra al peso. Fila "Pendiente" agregada a la tabla.
3. **Compras sin canceladas** en `k_compra` y `m_compra` (junio s1 baja $3.487; histórico había $3,5M en 6 canceladas esperando distorsionar un mes).
4. **Split del KPI mermas** (decisión de negocio confirmada): `mermas` sigue siendo el **total** (compat con la contribución del front y `/reporte-mensual`) + `mermas_perdida` (vencimiento/rotura/robo/decomiso/devolución), `mermas_ajuste` (error_inventario/otro), `mermas_muestra`. Junio Tucumán: $440,6K = **$111,7K pérdida física + $320,1K ajustes + $8,8K muestras** — el 73% del KPI era ajuste de conteo, no producto perdido. La card lo muestra; `mermas_motivo[]` expone `clasificacion`.
5. **`bonif_detalle` → `bonif_promos`** (el viejo no tenía consumidores): lo regalado por **promoción × producto**, con unidades (botellas si la promo es fraccionada, badge `bot.`), **costo real** (misma convención que el KPI) y **valor a precio de lista** (÷ `unidades_por_bloque` en fracción). Sección nueva "Bonificaciones y promociones" en el detalle: chart costo vs valor de venta por promo + tabla agrupada con subtotales y % de la venta.
6. Modo "Todos" ahora incluye `en_preparacion` (hoy 0 filas en prod, pero el flujo puede setearlo y quedaba fuera del toggle).

## Validación (contra prod, junio 2026 Tucumán)

| Check | Resultado |
|---|---|
| Regresión venta/cmv/bonif | idénticos al snapshot pre-migración ✅ |
| `mermas = perdida + ajuste + muestra` | 440.619,83 = 111.688,53 + 320.112,28 + 8.819,02 ✅ |
| `formas` vs join directo a `pagos` | match fila por fila (efectivo $18,75M / transf $3,71M) ✅ |
| `Σ bonif_promos.costo` vs `kpis.bonif` | $817.016 = $817.016 ✅ (valor de venta: $1,58M) |
| `comparativo` hereda el split | `mermas_perdida` de mayo presente ✅ |
| Ledger | `110_...` registrada, nombre = stem del archivo ✅ |
| `npm run typecheck` + `npm run test:run` | ✅ 749/749 |

**Deploy**: la mig ya está viva; el front viejo tolera el payload nuevo (superset) y este front tolera respuestas cacheadas pre-110 (campos opcionales con guard). MANIFEST actualizado (cadena `reporte_gerencial`: …107, 110).

🤖 Generated with [Claude Code](https://claude.com/claude-code)