### PR TITLE
fix(bot): sanea el history conversacional envenenado (Gemini 400) + sync promos

### DIFF
--- a/supabase/functions/_shared/gemini/memory.ts
+++ b/supabase/functions/_shared/gemini/memory.ts
@@ -44,13 +44,22 @@ export async function loadConversation(
   if (!Array.isArray(arr)) return [];
 
   // Validar shape mínima de cada turn antes de usarlo en el loop.
-  return arr.filter((t): t is GeminiContent => {
+  const cleaned = arr.filter((t): t is GeminiContent => {
     if (typeof t !== "object" || t === null) return false;
     const turn = t as { role?: unknown; parts?: unknown };
     if (turn.role !== "user" && turn.role !== "model") return false;
     if (!Array.isArray(turn.parts)) return false;
     return true;
   });
+
+  // Sanear el arranque: si una escritura previa dejó el history empezando con
+  // un `functionResponse` huérfano (ej: se truncó una conversación con muchas
+  // tool calls y quedaron los responses sin sus calls), Gemini rechaza TODO el
+  // turno con 400 "function response turn comes immediately after a function
+  // call turn". Y como ese turno crashea ANTES de re-guardar un history sano,
+  // la fila queda atascada y el bot deja de responderle a ese usuario para
+  // siempre. Descartar el arranque inválido en la carga auto-cura ese estado.
+  return dropToValidStart(cleaned);
 }
 
 /**
@@ -79,42 +88,53 @@ export async function saveConversation(
 }
 
 /**
- * Trunca el history a los últimos N turnos manteniendo emparejamientos
- * coherentes. Si el primer turno del tail empieza con un functionResponse
- * (huérfano sin su functionCall correspondiente), descartamos hasta encontrar
- * el primer turno "user" con texto plano.
+ * Descarta turnos desde el frente hasta que el history empiece en un punto
+ * VÁLIDO para Gemini: un turno `user` cuyas parts son TODAS de texto (el
+ * comienzo natural de un intercambio del usuario).
  *
- * Edge cases:
- *   * `history.length <= maxTurns` → retorna tal cual.
- *   * Si NINGÚN turno del tail es "user con texto plano", retornamos el
- *     tail original — preferimos un history un poco roto a uno vacío que
- *     pierda el contexto.
+ * Esto garantiza la invariante que Gemini exige —un `functionResponse` (que va
+ * en un turno con role "user") SIEMPRE debe venir inmediatamente después de un
+ * `functionCall` (turno "model")— evitando el error 400 "function response
+ * turn comes immediately after a function call turn" cuando el history quedó
+ * con un `functionResponse` huérfano al frente.
+ *
+ * Si NINGÚN turno es un "user text turn", devuelve [] — arrancar sin contexto
+ * es infinitamente preferible a mandar un history que rompe TODAS las
+ * respuestas del usuario de forma permanente.
+ */
+export function dropToValidStart(history: GeminiContent[]): GeminiContent[] {
+  for (let i = 0; i < history.length; i++) {
+    const t = history[i];
+    if (
+      t.role === "user" &&
+      t.parts.length > 0 &&
+      t.parts.every((p) => isTextPart(p))
+    ) {
+      return i === 0 ? history : history.slice(i);
+    }
+  }
+  return [];
+}
+
+/**
+ * Trunca el history a los últimos N turnos y garantiza SIEMPRE un arranque
+ * válido para Gemini. Tras cortar al tail, `dropToValidStart` descarta
+ * cualquier `functionResponse` huérfano que haya quedado al frente (o devuelve
+ * [] si el tail entero es tool-call sin un "user text turn" — el caso
+ * patológico que antes se persistía roto y dejaba al usuario atascado).
+ *
+ * El saneo corre aun cuando no hace falta recortar (`length <= maxTurns`): un
+ * history sano queda intacto (`dropToValidStart` devuelve el mismo arranque),
+ * así que es barato y hace que la función nunca persista un arranque inválido.
  */
 export function truncateHistory(
   history: GeminiContent[],
   maxTurns: number,
 ): GeminiContent[] {
-  if (history.length <= maxTurns) return history;
-  const tail = history.slice(history.length - maxTurns);
-
-  // Buscar el primer turno user-only-text. Si existe, cortamos desde ahí —
-  // sino dejamos el tail tal cual (evita devolver [] y perder TODO el contexto).
-  for (let i = 0; i < tail.length; i++) {
-    const t = tail[i];
-    if (t.role === "user" && t.parts.every((p) => isTextPart(p))) {
-      return i === 0 ? tail : tail.slice(i);
-    }
-  }
-  // Caso raro pero posible: el tail entero está hecho de turns model + user
-  // con functionResponse. Devolverlo tal cual puede dejar a Gemini con un
-  // functionResponse huérfano al frente del próximo prompt → riesgo de error.
-  // No cambiamos el comportamiento (preferimos history roto a vacío) pero
-  // dejamos visibilidad para detectarlo en logs.
-  console.warn(
-    "[memory] truncateHistory: no user-text turn found in tail; returning " +
-      "tail as-is, may have orphan functionResponse at head",
-  );
-  return tail;
+  const tail = history.length <= maxTurns
+    ? history
+    : history.slice(history.length - maxTurns);
+  return dropToValidStart(tail);
 }
 
 /** Para tests: expone el cap. */

--- a/supabase/functions/_shared/utils/promociones.ts
+++ b/supabase/functions/_shared/utils/promociones.ts
@@ -71,7 +71,11 @@ export interface PromoResolucion {
  */
 export function resolverPromociones(
   items: ItemPedido[],
-  promoMap: PromoMap
+  promoMap: PromoMap,
+  /** Ids de promos que el usuario quitó manualmente (al crear o editar el pedido).
+   *  Se excluyen de la resolución: no generan bonificación y sus disparadores
+   *  vuelven a poder tomar precio mayorista. */
+  promosEliminadas?: ReadonlySet<string>,
 ): PromoResolucion {
   const bonificaciones: BonificacionResult[] = []
   const productosConPromo = new Set<string>()
@@ -81,6 +85,12 @@ export function resolverPromociones(
   //    su promo (el precio manual cambia el precio, no la elegibilidad). Ej: regalar
   //    un producto bajándole el precio no debe anular la botella de regalo de la promo.
   const promosVistas = acumularPromos(items, promoMap, { skipOverride: false })
+
+  // 1a. Sacar las promos quitadas a mano ANTES de derivar productosConPromo y
+  //     bonificaciones, así desaparecen por completo (regalo + reclamo de precio).
+  if (promosEliminadas && promosEliminadas.size > 0) {
+    for (const id of promosEliminadas) promosVistas.delete(id)
+  }
 
   for (const entry of promosVistas.values()) {
     for (const pid of entry.productoIdsEnPedido) productosConPromo.add(pid)

--- a/supabase/functions/tests/agent.test.ts
+++ b/supabase/functions/tests/agent.test.ts
@@ -33,7 +33,7 @@ import {
 import type { SupabaseClient } from "@supabase/supabase-js";
 
 import { runAgent } from "../_shared/gemini/agent.ts";
-import { truncateHistory } from "../_shared/gemini/memory.ts";
+import { dropToValidStart, truncateHistory } from "../_shared/gemini/memory.ts";
 import type { GeminiContent } from "../_shared/gemini/types.ts";
 import {
   clearSystemPromptCache,
@@ -697,6 +697,63 @@ Deno.test("truncateHistory no toca history de longitud <= cap", () => {
   ];
   const tr = truncateHistory(h, 12);
   assertEquals(tr, h);
+});
+
+Deno.test("truncateHistory devuelve [] si el tail entero es tool-call sin user-text (regresión: history envenenado)", () => {
+  // Reproduce el estado que atascó al bot en prod (2026-06-29): una conversación
+  // con muchísimas tool calls creció > cap; al truncar a 12 quedaron solo
+  // functionResponse (role user) + el texto final del modelo, SIN ningún
+  // "user text turn". Antes se devolvía tal cual → Gemini 400 "function response
+  // turn comes immediately after a function call turn" en CADA mensaje siguiente,
+  // y como el turno crasheaba antes de re-guardar, la fila quedaba atascada para
+  // siempre. Ahora debe colapsar a [] (arranque limpio).
+  const envenenado: GeminiContent[] = [];
+  // 8 turnos planos al inicio (quedan fuera del tail de 12) para forzar el
+  // recorte real, tal como pasó en prod.
+  for (let i = 0; i < 4; i++) {
+    envenenado.push({ role: "user", parts: [{ text: `vieja q${i}` }] });
+    envenenado.push({ role: "model", parts: [{ text: `vieja a${i}` }] });
+  }
+  // Los últimos 12 turnos: puro functionResponse + el texto final del modelo.
+  for (let i = 0; i < 11; i++) {
+    envenenado.push({
+      role: "user",
+      parts: [{ functionResponse: { name: "ventas_periodo", response: { result: i } } }],
+    });
+  }
+  envenenado.push({ role: "model", parts: [{ text: "acá va el catálogo..." }] });
+  assertEquals(envenenado.length, 20);
+
+  const tr = truncateHistory(envenenado, 12);
+  assertEquals(tr, [], "un tail sin user-text turn debe colapsar a [] en vez de persistir corrupción");
+});
+
+Deno.test("dropToValidStart descarta functionResponse huérfanos del frente y auto-cura el history", () => {
+  // Vacío → vacío.
+  assertEquals(dropToValidStart([]), []);
+
+  // Empieza limpio → intacto (misma referencia lógica).
+  const limpio: GeminiContent[] = [
+    { role: "user", parts: [{ text: "hola" }] },
+    { role: "model", parts: [{ text: "buenas" }] },
+  ];
+  assertEquals(dropToValidStart(limpio), limpio);
+
+  // functionResponse huérfano al frente → se descarta hasta el primer user-text.
+  const conHuerfano: GeminiContent[] = [
+    { role: "user", parts: [{ functionResponse: { name: "x", response: { result: 1 } } }] },
+    { role: "model", parts: [{ text: "resultado" }] },
+    { role: "user", parts: [{ text: "gracias" }] },
+    { role: "model", parts: [{ text: "de nada" }] },
+  ];
+  assertEquals(dropToValidStart(conHuerfano), conHuerfano.slice(2));
+
+  // Sin ningún user-text turn → [].
+  const soloTools: GeminiContent[] = [
+    { role: "user", parts: [{ functionResponse: { name: "x", response: {} } }] },
+    { role: "model", parts: [{ text: "algo" }] },
+  ];
+  assertEquals(dropToValidStart(soloTools), []);
 });
 
 // ============================================================================


### PR DESCRIPTION
## Problema

Reporte: "el bot de Telegram no responde". En realidad estaba caído **solo para el admin** (los otros usuarios funcionaban).

En `bot_audit_log` cada mensaje del admin terminaba en el mismo error:

> `Gemini 400: "Please ensure that function response turn comes immediately after a function call turn."`

## Causa raíz

El bot guarda los últimos 12 turnos de conversación en `bot_conversaciones` como memoria del LLM. El 29/06 hubo una consulta con muchas llamadas a herramientas (reportes de ventas); al **truncar** a 12 turnos quedaron solo `functionResponse` (role `user`) sin su `functionCall` previo. Gemini rechaza ese historial entero con el 400 de arriba.

Y como el turno **crashea antes** de re-persistir (el throw de Gemini se propaga sin pasar por `persistOrAudit`), la fila corrupta nunca se sobrescribía → **cada mensaje nuevo fallaba igual**. Estado atascado y auto-perpetuado desde el 29/06.

## Fix

`dropToValidStart()` en `_shared/gemini/memory.ts`: descarta turnos desde el frente hasta el primer "user text turn" (o `[]` si no hay ninguno). Se aplica en dos lugares:

- **`loadConversation`** — **auto-cura** cualquier fila ya envenenada al leerla (no requiere intervención manual; el próximo mensaje arranca sano y re-guarda un historial válido).
- **`truncateHistory`** — deja de **generar** la corrupción: sanea siempre el arranque, aun cuando no haga falta recortar. Antes devolvía el tail roto con solo un `console.warn`.

Escape hatch de producto ya existente: el comando `/reset` borra la fila.

## Extra (drift preexistente)

`tests/sync_utils.test.ts` fallaba desde antes: la copia de `_shared/utils/promociones.ts` del bot quedó vieja respecto a `src/utils/promociones.ts` (le faltaba el parámetro `promosEliminadas` del #413). Efecto: el bot calculaba las promos "quitadas a mano" distinto que la app. Re-sincronizado.

## Tests

- Regresión en `tests/agent.test.ts` que reproduce el estado real de prod (tail todo-tool-call → `[]`) + cobertura directa de `dropToValidStart`.
- Suite del edge: **180/0**. Frontend (pre-commit): **770/0**. `deno task check`: OK.

## Nota operativa

La fila corrupta del admin ya se limpió en prod (equivalente a `/reset`) para desatascarlo de inmediato. Este PR previene la recurrencia. Requiere deploy de la edge function `telegram-webhook`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
