### PR TITLE
fix(pedidos): la "X" para quitar promo al crear pedido ya no falla en silencio

### DIFF
--- a/src/components/containers/PedidosContainer.tsx
+++ b/src/components/containers/PedidosContainer.tsx
@@ -308,21 +308,14 @@ export default function PedidosContainer(): React.ReactElement {
     }))
   }, [productos])
 
-  // Quitar una promo del pedido en creación, con alerta de confirmación de por
-  // medio. Disponible para quien pueda crear pedidos (admin/preventista/encargado).
+  // Quitar una promo del pedido en creación. La confirmación se muestra DENTRO
+  // de ModalPedido (Radix Dialog modal); una confirmación disparada desde acá
+  // quedaba detrás del overlay y era inalcanzable, así que la quita fallaba en
+  // silencio. Este callback recibe la orden ya confirmada y solo la aplica.
   const handleEliminarPromoCreacion = useCallback((promoId: string, promoNombre: string) => {
-    setConfirmConfig({
-      visible: true,
-      tipo: 'warning',
-      titulo: 'Quitar promoción',
-      mensaje: `¿Quitar la promoción "${promoNombre}" de este pedido? El cliente no recibirá la bonificación.`,
-      onConfirm: () => {
-        setConfirmConfig({ visible: false })
-        setPromosEliminadas(prev =>
-          prev.some(p => p.promoId === promoId) ? prev : [...prev, { promoId, promoNombre }],
-        )
-      },
-    })
+    setPromosEliminadas(prev =>
+      prev.some(p => p.promoId === promoId) ? prev : [...prev, { promoId, promoNombre }],
+    )
   }, [])
 
   const handleRestaurarPromoCreacion = useCallback((promoId: string) => {

--- a/src/components/modals/ModalPedido.tsx
+++ b/src/components/modals/ModalPedido.tsx
@@ -8,6 +8,7 @@ import { aplicarDescuentoClienteItems, resolverDescuentoPctCliente } from '../..
 import { useGeolocationCapture } from '../../hooks/useGeolocationCapture';
 import { usePreventistasAsignablesQuery } from '../../hooks/queries/useUsuariosQuery';
 import ModalBase from './ModalBase';
+import ModalConfirmacion, { type ModalConfirmacionConfig } from './ModalConfirmacion';
 import GeolocationGate from '../GeolocationGate';
 import NumberInput from '../ui/NumberInput';
 import FranjasHorariasEditor from '../ui/FranjasHorariasEditor';
@@ -300,6 +301,12 @@ const ModalPedido = memo(function ModalPedido({
   };
 
   const calcularTotal = (): number => nuevoPedido.items.reduce((t, i) => t + (i.precioUnitario * i.cantidad), 0);
+
+  // Confirmación de quitar promo: vive DENTRO del modal (no en el container),
+  // porque ModalBase es un Radix Dialog modal y una confirmación renderizada
+  // afuera queda detrás del overlay y es inalcanzable → la quita fallaba en
+  // silencio. Mismo patrón que ModalEditarPedido.
+  const [confirmConfig, setConfirmConfig] = useState<ModalConfirmacionConfig | null>(null);
 
   // Promos quitadas a mano → se excluyen de la resolución (display y submit).
   const promosEliminadasSet = useMemo(
@@ -832,7 +839,16 @@ const ModalPedido = memo(function ModalPedido({
                                 {(isAdmin || isPreventista || isEncargado) && onEliminarPromoCreacion && bonif.promoId && (
                                   <button
                                     type="button"
-                                    onClick={() => onEliminarPromoCreacion(String(bonif.promoId), bonif.promoNombre)}
+                                    onClick={() => setConfirmConfig({
+                                      visible: true,
+                                      tipo: 'warning',
+                                      titulo: 'Quitar promoción',
+                                      mensaje: `¿Quitar la promoción "${bonif.promoNombre}" de este pedido? El cliente no recibirá la bonificación.`,
+                                      onConfirm: () => {
+                                        setConfirmConfig(null);
+                                        onEliminarPromoCreacion(String(bonif.promoId), bonif.promoNombre);
+                                      },
+                                    })}
                                     className="p-1 text-red-500 hover:bg-red-100 dark:hover:bg-red-900/30 rounded"
                                     title="Quitar esta promoción del pedido"
                                     aria-label="Quitar promoción"
@@ -1057,6 +1073,7 @@ const ModalPedido = memo(function ModalPedido({
           </button>
         </div>
       </GeolocationGate>
+      <ModalConfirmacion config={confirmConfig} onClose={() => setConfirmConfig(null)} />
     </ModalBase>
   );
 });


### PR DESCRIPTION
## Problema

Al **crear** un pedido, la "X" para quitar una promoción/bonificación fallaba en silencio: al apretarla no pasaba nada ni salía error, así que la promo no se quitaba.

## Causa raíz

El bug **no** estaba en la lógica de promociones ni en los tipos de id, sino en el **apilamiento de modales**:

- `ModalPedido` es un **Radix `Dialog` modal** (vía `ModalBase`), que se monta en un Portal al final del `<body>` con focus-trap y `pointer-events`/`aria-hidden` sobre todo lo de afuera del `DialogContent`.
- La "X" disparaba la confirmación en el container (`PedidosContainer.handleEliminarPromoCreacion` → `setConfirmConfig`), y ese `<ModalConfirmacion>` se renderizaba como **hermano** de `<ModalPedido>` — un `div` plano `z-50`, no Radix, no portal.
- Como el portal de Radix va al final del `<body>`, con el mismo `z-50` gana el apilamiento: la confirmación quedaba **detrás** del overlay y sus botones eran inalcanzables → el "Confirmar" nunca corría → `promosEliminadas` nunca se actualizaba.

El flujo de **editar** ya funcionaba porque ahí la confirmación vive **dentro** del modal.

## Fix

- **`ModalPedido.tsx`**: la confirmación ahora vive **dentro** del modal (estado local `confirmConfig` + `<ModalConfirmacion>` antes de `</ModalBase>`), igual que `ModalEditarPedido`. La "X" abre esa confirmación local; al confirmar llama a `onEliminarPromoCreacion`.
- **`PedidosContainer.tsx`**: `handleEliminarPromoCreacion` deja de abrir su propia confirmación (la inalcanzable) y pasa a ser un callback "ya confirmado" que solo aplica la quita (`setPromosEliminadas`). No se toca el `<ModalConfirmacion>` del container ni `setConfirmConfig` (siguen usándose en otros flujos del listado).

Sin migraciones. El resto del cableado (`promosEliminadas` → `usePromocionPedido` → `resolverPromociones` → `itemsFinales` sin el regalo → RPC `crear_pedido_completo`) ya era correcto.

## Verificación

- `typecheck` y `eslint` limpios en los archivos tocados.
- Suite de tests del pre-commit en verde; Vite compila y sirve 200.
- Pendiente de confirmación funcional en la app (necesita datos con promos): Nuevo Pedido → agregar productos que disparen una promo → "X" → la confirmación aparece **por encima** y responde → Confirmar quita la bonificación y muestra "Promoción quitada / Restaurar" → Restaurar la devuelve → crear el pedido sin persistir el regalo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)