### PR TITLE
feat(fiscal): Fase A — costo real canónico + fix compras ZZ que pisaban el IVA del producto

### DIFF
--- a/migrations/111_costo_real_y_fix_zz_no_pisa_fiscal.sql
+++ b/migrations/111_costo_real_y_fix_zz_no_pisa_fiscal.sql
@@ -1,0 +1,470 @@
+-- ============================================================================
+-- 111 · Costo real canónico + las compras ZZ dejan de pisar el IVA del producto
+-- ============================================================================
+-- Problema (auditoría fiscal 2026-07-13):
+--   1) registrar_compra_completa / actualizar_compra_items pisaban
+--      productos.porcentaje_iva = 0 en compras ZZ (hack para neutralizar
+--      calcularNetoCosto, hoy código muerto en el front) → 42 productos con
+--      IVA 0% en prod; una venta FC de esos productos calcularía desglose 0.
+--   2) productos.impuestos_internos era numeric(12,2): no puede almacenar la
+--      tasa efectiva 8,6956 (colas) → se amplía a numeric(12,4).
+--   3) "Costo real" (neto post-bonif + imp. internos; IVA y percepciones son
+--      créditos fiscales, NO costo) se derivaba con fórmulas distintas en
+--      reporte/rentabilidad/export. Se materializa en productos.costo_real
+--      con funciones canónicas únicas.
+--
+-- Reglas nuevas:
+--   · Los atributos fiscales del producto (porcentaje_iva, impuestos_internos)
+--     NUNCA se auto-actualizan desde una compra (ni FC ni ZZ): se corrigen
+--     explícitamente editando el producto. La compra los usa solo para
+--     calcular costos.
+--   · costo_real:      FC → neto×(1+II/100) ; ZZ → neto (lo pagado, sin add-on)
+--   · costo_con_iva:   FC → neto×(1+IVA/100+II/100) ; ZZ → neto  (financiero)
+--   · ultimo_tipo_compra deja rastro de qué tipo fijó el costo.
+--   · Guard: líneas con bonificación ≥100% o costo 0 (regalos/promos) suman
+--     stock pero NO tocan el costo del producto.
+--   · Se dropea el overload legacy de 12 args de registrar_compra_completa
+--     (body viejo con el zeroing; el front llama al de 13 args y un caller de
+--     12 args resuelve al de 13 por el DEFAULT).
+-- ============================================================================
+
+-- ─── 1. Columnas ────────────────────────────────────────────────────────────
+
+ALTER TABLE public.productos
+  ALTER COLUMN impuestos_internos TYPE numeric(12,4);
+
+ALTER TABLE public.productos
+  ADD COLUMN IF NOT EXISTS costo_real numeric(12,4),
+  ADD COLUMN IF NOT EXISTS ultimo_tipo_compra varchar(2);
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'productos_ultimo_tipo_compra_check'
+  ) THEN
+    ALTER TABLE public.productos
+      ADD CONSTRAINT productos_ultimo_tipo_compra_check
+      CHECK (ultimo_tipo_compra IN ('ZZ','FC'));
+  END IF;
+END $$;
+
+COMMENT ON COLUMN public.productos.costo_real IS
+  'Costo REAL unitario canónico: FC = costo_sin_iva*(1+impuestos_internos/100); ZZ = costo_sin_iva (precio pagado, sin add-on). IVA y percepciones NO son costo (créditos fiscales). Mantenido por registrar_compra_completa / actualizar_compra_items / edición manual del producto.';
+COMMENT ON COLUMN public.productos.ultimo_tipo_compra IS
+  'Tipo de la última compra que fijó el costo (FC/ZZ). NULL = costo cargado a mano o sin compra registrada (se asume semántica FC).';
+COMMENT ON COLUMN public.productos.costo_con_iva IS
+  'Costo FINANCIERO pagado por unidad: FC = neto*(1+iva/100+ii/100); ZZ = neto. NO usar para margen real; usar costo_real.';
+COMMENT ON COLUMN public.productos.impuestos_internos IS
+  'Tasa EFECTIVA de impuestos internos en % sobre el neto (ej: 8.6956 colas, 4.1667 aguas/saborizadas). Atributo fiscal del producto: no lo pisa ninguna compra.';
+
+-- ─── 2. Funciones canónicas ─────────────────────────────────────────────────
+
+CREATE OR REPLACE FUNCTION public.costo_real_unitario(
+  p_costo_neto numeric,
+  p_pct_ii numeric,
+  p_tipo_factura text
+) RETURNS numeric
+LANGUAGE sql IMMUTABLE
+AS $$
+  SELECT CASE
+    WHEN p_tipo_factura = 'ZZ' THEN p_costo_neto
+    ELSE round(p_costo_neto * (1 + COALESCE(p_pct_ii, 0) / 100), 4)
+  END;
+$$;
+
+COMMENT ON FUNCTION public.costo_real_unitario(numeric, numeric, text) IS
+  'Costo real por unidad: FC = neto post-bonif + imp. internos (IVA es crédito, no costo); ZZ = lo pagado (nada recuperable, el precio informal ya incluye todo).';
+
+CREATE OR REPLACE FUNCTION public.costo_financiero_unitario(
+  p_costo_neto numeric,
+  p_pct_iva numeric,
+  p_pct_ii numeric,
+  p_tipo_factura text
+) RETURNS numeric
+LANGUAGE sql IMMUTABLE
+AS $$
+  SELECT CASE
+    WHEN p_tipo_factura = 'ZZ' THEN p_costo_neto
+    ELSE round(p_costo_neto * (1 + COALESCE(p_pct_iva, 0) / 100 + COALESCE(p_pct_ii, 0) / 100), 4)
+  END;
+$$;
+
+COMMENT ON FUNCTION public.costo_financiero_unitario(numeric, numeric, numeric, text) IS
+  'Costo financiero (desembolso) por unidad, sin percepciones: FC = neto*(1+iva+ii); ZZ = neto. Alimenta productos.costo_con_iva.';
+
+-- ─── 3. Drop del overload legacy (12 args, body viejo con zeroing) ─────────
+
+DROP FUNCTION IF EXISTS public.registrar_compra_completa(
+  bigint, character varying, character varying, date,
+  numeric, numeric, numeric, numeric,
+  character varying, text, uuid, jsonb
+);
+
+-- ─── 4. registrar_compra_completa (13 args, misma firma ⇒ OR REPLACE) ──────
+
+CREATE OR REPLACE FUNCTION public.registrar_compra_completa(
+  p_proveedor_id bigint, p_proveedor_nombre character varying,
+  p_numero_factura character varying, p_fecha_compra date,
+  p_subtotal numeric, p_iva numeric, p_otros_impuestos numeric, p_total numeric,
+  p_forma_pago character varying, p_notas text, p_usuario_id uuid,
+  p_items jsonb, p_tipo_factura character varying DEFAULT 'FC'
+) RETURNS jsonb
+LANGUAGE plpgsql SECURITY DEFINER
+SET search_path TO 'public'
+AS $$
+DECLARE
+  v_sucursal            BIGINT := current_sucursal_id();
+  v_compra_id           BIGINT;
+  v_item                JSONB;
+  v_producto            RECORD;
+  v_stock_anterior      INTEGER;
+  v_stock_nuevo         INTEGER;
+  v_cantidad            INTEGER;
+  v_bonificacion        NUMERIC;
+  v_porcentaje_iva      NUMERIC;
+  v_impuestos_internos  NUMERIC;
+  v_costo_unitario      NUMERIC;
+  v_costo_neto          NUMERIC;
+  v_costo_con_iva       NUMERIC;
+  v_costo_real          NUMERIC;
+  v_actualiza_costo     BOOLEAN;
+  v_tipo_factura        TEXT;
+  v_items_procesados    JSONB := '[]'::JSONB;
+  v_user_role           TEXT;
+BEGIN
+  IF v_sucursal IS NULL THEN
+    RETURN jsonb_build_object('success', false, 'error', 'No se pudo determinar la sucursal activa');
+  END IF;
+
+  IF p_usuario_id IS DISTINCT FROM auth.uid() THEN
+    RETURN jsonb_build_object('success', false, 'error', 'ID de usuario no coincide con la sesion autenticada');
+  END IF;
+
+  SELECT rol INTO v_user_role FROM perfiles WHERE id = p_usuario_id;
+  IF v_user_role IS NULL OR v_user_role NOT IN ('admin', 'encargado') THEN
+    RETURN jsonb_build_object('success', false, 'error', 'No autorizado: solo admin o encargado pueden registrar compras');
+  END IF;
+
+  v_tipo_factura := COALESCE(p_tipo_factura, 'FC');
+
+  INSERT INTO compras (
+    proveedor_id, proveedor_nombre, numero_factura, fecha_compra,
+    subtotal, iva, otros_impuestos, total, forma_pago, notas,
+    usuario_id, estado, tipo_factura, sucursal_id
+  ) VALUES (
+    p_proveedor_id, p_proveedor_nombre, p_numero_factura, p_fecha_compra,
+    p_subtotal,
+    CASE WHEN v_tipo_factura = 'ZZ' THEN 0 ELSE p_iva END,
+    p_otros_impuestos, p_total, p_forma_pago, p_notas,
+    p_usuario_id, 'recibida', v_tipo_factura, v_sucursal
+  )
+  RETURNING id INTO v_compra_id;
+
+  FOR v_item IN SELECT * FROM jsonb_array_elements(p_items) LOOP
+    SELECT id, stock INTO v_producto
+      FROM productos
+     WHERE id = (v_item->>'producto_id')::BIGINT
+       AND sucursal_id = v_sucursal
+     FOR UPDATE;
+
+    IF NOT FOUND THEN
+      RAISE EXCEPTION 'Producto no encontrado: %', v_item->>'producto_id';
+    END IF;
+
+    v_cantidad           := (v_item->>'cantidad')::INTEGER;
+    v_stock_anterior     := COALESCE(v_producto.stock, 0);
+    v_stock_nuevo        := v_stock_anterior + v_cantidad;
+    v_costo_unitario     := COALESCE((v_item->>'costo_unitario')::NUMERIC, 0);
+    v_bonificacion       := COALESCE((v_item->>'bonificacion')::NUMERIC, 0);
+    v_porcentaje_iva     := COALESCE((v_item->>'porcentaje_iva')::NUMERIC, 21);
+    v_impuestos_internos := COALESCE((v_item->>'impuestos_internos')::NUMERIC, 0);
+
+    INSERT INTO compra_items (
+      compra_id, producto_id, cantidad, costo_unitario, subtotal,
+      stock_anterior, stock_nuevo, bonificacion, sucursal_id
+    ) VALUES (
+      v_compra_id,
+      (v_item->>'producto_id')::BIGINT,
+      v_cantidad,
+      v_costo_unitario,
+      COALESCE((v_item->>'subtotal')::NUMERIC, 0),
+      v_stock_anterior,
+      v_stock_nuevo,
+      v_bonificacion,
+      v_sucursal
+    );
+
+    v_costo_neto    := v_costo_unitario * (1 - v_bonificacion / 100);
+    v_costo_con_iva := costo_financiero_unitario(v_costo_neto, v_porcentaje_iva, v_impuestos_internos, v_tipo_factura);
+    v_costo_real    := costo_real_unitario(v_costo_neto, v_impuestos_internos, v_tipo_factura);
+
+    -- Regalos / promos (bonif 100% o costo 0) suman stock pero no fijan costo.
+    v_actualiza_costo := (v_bonificacion < 100 AND v_costo_neto > 0);
+
+    IF v_actualiza_costo THEN
+      UPDATE productos
+         SET stock              = stock + v_cantidad,
+             costo_sin_iva      = v_costo_neto,
+             costo_con_iva      = v_costo_con_iva,
+             costo_real         = v_costo_real,
+             ultimo_tipo_compra = v_tipo_factura,
+             updated_at         = NOW()
+       WHERE id = (v_item->>'producto_id')::BIGINT
+         AND sucursal_id = v_sucursal;
+    ELSE
+      UPDATE productos
+         SET stock      = stock + v_cantidad,
+             updated_at = NOW()
+       WHERE id = (v_item->>'producto_id')::BIGINT
+         AND sucursal_id = v_sucursal;
+    END IF;
+
+    v_items_procesados := v_items_procesados || jsonb_build_object(
+      'producto_id',       (v_item->>'producto_id')::BIGINT,
+      'cantidad',          v_cantidad,
+      'stock_anterior',    v_stock_anterior,
+      'stock_nuevo',       v_stock_nuevo,
+      'costo_sin_iva',     v_costo_neto,
+      'costo_con_iva',     v_costo_con_iva,
+      'costo_real',        v_costo_real,
+      'costo_actualizado', v_actualiza_costo
+    );
+  END LOOP;
+
+  RETURN jsonb_build_object(
+    'success',          true,
+    'compra_id',        v_compra_id,
+    'items_procesados', v_items_procesados
+  );
+EXCEPTION WHEN OTHERS THEN
+  RETURN jsonb_build_object('success', false, 'error', SQLERRM);
+END;
+$$;
+
+-- ─── 5. actualizar_compra_items (misma firma de 104 ⇒ OR REPLACE) ──────────
+
+CREATE OR REPLACE FUNCTION public.actualizar_compra_items(p_compra_id bigint, p_items_nuevos jsonb, p_subtotal numeric, p_iva numeric, p_total numeric, p_usuario_id uuid)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public'
+AS $function$
+DECLARE
+  v_sucursal BIGINT := current_sucursal_id();
+  v_user_role TEXT;
+  v_compra RECORD;
+  v_dias NUMERIC;
+  v_item JSONB;
+  v_producto_id BIGINT;
+  v_cantidad INTEGER;
+  v_costo_unitario NUMERIC;
+  v_bonificacion NUMERIC;
+  v_porcentaje_iva NUMERIC;
+  v_impuestos_internos NUMERIC;
+  v_subtotal_item NUMERIC;
+  v_costo_neto NUMERIC;
+  v_costo_con_iva NUMERIC;
+  v_costo_real NUMERIC;
+  v_actualiza_costo BOOLEAN;
+  v_stock_anterior INTEGER;
+  v_stock_nuevo INTEGER;
+  v_max_fecha DATE;
+  v_es_mas_reciente BOOLEAN;
+  v_iva_efectivo NUMERIC;
+  v_items_procesados JSONB := '[]'::JSONB;
+  v_costo_actualizado JSONB := '[]'::JSONB;
+  v_snapshot_stock JSONB := '{}'::JSONB;
+  v_warnings_stock_negativo JSONB;
+  v_warnings JSONB;
+BEGIN
+  IF v_sucursal IS NULL THEN
+    RETURN jsonb_build_object('success', false, 'error', 'No se pudo determinar la sucursal activa');
+  END IF;
+  IF p_usuario_id IS DISTINCT FROM auth.uid() THEN
+    RETURN jsonb_build_object('success', false, 'error', 'ID de usuario no coincide con la sesion autenticada');
+  END IF;
+
+  SELECT rol INTO v_user_role FROM perfiles WHERE id = p_usuario_id;
+  IF v_user_role IS NULL OR v_user_role <> 'admin' THEN
+    RETURN jsonb_build_object('success', false, 'error', 'No autorizado: solo admin puede editar compras');
+  END IF;
+
+  SELECT id, estado, tipo_factura, created_at, fecha_compra
+    INTO v_compra
+    FROM compras
+   WHERE id = p_compra_id AND sucursal_id = v_sucursal;
+  IF NOT FOUND THEN
+    RETURN jsonb_build_object('success', false, 'error', 'Compra no encontrada');
+  END IF;
+
+  IF v_compra.estado = 'cancelada' THEN
+    RETURN jsonb_build_object('success', false, 'error', 'No se puede editar una compra cancelada');
+  END IF;
+
+  v_dias := EXTRACT(EPOCH FROM (now() - v_compra.created_at)) / 86400;
+  IF v_dias > 7 THEN
+    RETURN jsonb_build_object('success', false, 'error',
+      'No se puede editar una compra creada hace mas de 7 dias');
+  END IF;
+
+  v_iva_efectivo := CASE WHEN v_compra.tipo_factura = 'ZZ' THEN 0 ELSE p_iva END;
+
+  PERFORM set_config('app.stock_origen', 'compra_editada', true);
+  PERFORM set_config('app.stock_ref_tipo', 'compra', true);
+  PERFORM set_config('app.stock_ref_id', p_compra_id::TEXT, true);
+  PERFORM set_config('app.stock_user_id', p_usuario_id::TEXT, true);
+
+  PERFORM 1 FROM productos
+   WHERE sucursal_id = v_sucursal
+     AND id IN (
+       SELECT producto_id FROM compra_items
+        WHERE compra_id = p_compra_id AND sucursal_id = v_sucursal
+       UNION
+       SELECT (item->>'producto_id')::BIGINT
+         FROM jsonb_array_elements(p_items_nuevos) AS item
+     )
+   ORDER BY id
+   FOR UPDATE;
+
+  SELECT jsonb_object_agg(id::text, stock) INTO v_snapshot_stock
+    FROM productos
+   WHERE sucursal_id = v_sucursal
+     AND id IN (
+       SELECT producto_id FROM compra_items
+        WHERE compra_id = p_compra_id AND sucursal_id = v_sucursal
+       UNION
+       SELECT (item->>'producto_id')::BIGINT
+         FROM jsonb_array_elements(p_items_nuevos) AS item
+     );
+
+  WITH viejos AS (
+    SELECT producto_id, SUM(cantidad)::INT AS qty_old
+      FROM compra_items
+     WHERE compra_id = p_compra_id AND sucursal_id = v_sucursal
+     GROUP BY producto_id
+  ),
+  nuevos AS (
+    SELECT (item->>'producto_id')::BIGINT AS producto_id,
+           SUM((item->>'cantidad')::INT)::INT AS qty_new
+      FROM jsonb_array_elements(p_items_nuevos) AS item
+     GROUP BY (item->>'producto_id')::BIGINT
+  ),
+  deltas AS (
+    SELECT COALESCE(v.producto_id, n.producto_id) AS producto_id,
+           COALESCE(n.qty_new, 0) - COALESCE(v.qty_old, 0) AS delta
+      FROM viejos v FULL OUTER JOIN nuevos n USING (producto_id)
+  )
+  UPDATE productos p
+     SET stock = p.stock + d.delta,
+         updated_at = NOW()
+    FROM deltas d
+   WHERE p.id = d.producto_id
+     AND p.sucursal_id = v_sucursal
+     AND d.delta <> 0;
+
+  SELECT jsonb_agg(jsonb_build_object('producto_id', id, 'nombre', nombre, 'stock', stock))
+    INTO v_warnings_stock_negativo
+    FROM productos
+   WHERE sucursal_id = v_sucursal
+     AND stock < 0
+     AND id IN (
+       SELECT producto_id FROM compra_items
+        WHERE compra_id = p_compra_id AND sucursal_id = v_sucursal
+       UNION
+       SELECT (item->>'producto_id')::BIGINT
+         FROM jsonb_array_elements(p_items_nuevos) AS item
+     );
+
+  -- Invariante de no-negatividad: si la edición dejaría stock negativo, RECHAZAR
+  IF v_warnings_stock_negativo IS NOT NULL AND jsonb_array_length(v_warnings_stock_negativo) > 0 THEN
+    RAISE EXCEPTION 'La edición dejaría stock negativo en: %. Ajustá las cantidades o reconciliá el stock primero.',
+      (SELECT string_agg((w->>'nombre') || ' (' || (w->>'stock') || ')', ', ')
+         FROM jsonb_array_elements(v_warnings_stock_negativo) w);
+  END IF;
+
+  DELETE FROM compra_items WHERE compra_id = p_compra_id AND sucursal_id = v_sucursal;
+
+  FOR v_item IN SELECT * FROM jsonb_array_elements(p_items_nuevos) LOOP
+    v_producto_id        := (v_item->>'producto_id')::BIGINT;
+    v_cantidad           := (v_item->>'cantidad')::INTEGER;
+    v_costo_unitario     := COALESCE((v_item->>'costo_unitario')::NUMERIC, 0);
+    v_bonificacion       := COALESCE((v_item->>'bonificacion')::NUMERIC, 0);
+    v_porcentaje_iva     := COALESCE((v_item->>'porcentaje_iva')::NUMERIC, 21);
+    v_impuestos_internos := COALESCE((v_item->>'impuestos_internos')::NUMERIC, 0);
+    v_subtotal_item      := COALESCE((v_item->>'subtotal')::NUMERIC, 0);
+
+    IF v_cantidad IS NULL OR v_cantidad <= 0 THEN
+      RAISE EXCEPTION 'Cantidad invalida para producto %', v_producto_id;
+    END IF;
+
+    v_stock_anterior := COALESCE((v_snapshot_stock->>v_producto_id::TEXT)::INTEGER, 0);
+    v_stock_nuevo := v_stock_anterior + v_cantidad;
+
+    INSERT INTO compra_items (
+      compra_id, producto_id, cantidad, costo_unitario, subtotal,
+      stock_anterior, stock_nuevo, bonificacion, sucursal_id
+    ) VALUES (
+      p_compra_id, v_producto_id, v_cantidad, v_costo_unitario,
+      v_subtotal_item, v_stock_anterior, v_stock_nuevo, v_bonificacion, v_sucursal
+    );
+
+    v_costo_neto    := v_costo_unitario * (1 - v_bonificacion / 100);
+    v_costo_con_iva := costo_financiero_unitario(v_costo_neto, v_porcentaje_iva, v_impuestos_internos, v_compra.tipo_factura);
+    v_costo_real    := costo_real_unitario(v_costo_neto, v_impuestos_internos, v_compra.tipo_factura);
+    v_actualiza_costo := (v_bonificacion < 100 AND v_costo_neto > 0);
+
+    SELECT MAX(c.fecha_compra) INTO v_max_fecha
+      FROM compras c
+      JOIN compra_items ci ON ci.compra_id = c.id AND ci.sucursal_id = c.sucursal_id
+     WHERE ci.producto_id = v_producto_id
+       AND ci.sucursal_id = v_sucursal
+       AND c.estado <> 'cancelada'
+       AND c.id <> p_compra_id;
+
+    v_es_mas_reciente := (v_max_fecha IS NULL) OR (v_compra.fecha_compra >= v_max_fecha);
+
+    IF v_es_mas_reciente AND v_actualiza_costo THEN
+      UPDATE productos
+         SET costo_sin_iva      = v_costo_neto,
+             costo_con_iva      = v_costo_con_iva,
+             costo_real         = v_costo_real,
+             ultimo_tipo_compra = v_compra.tipo_factura,
+             updated_at         = NOW()
+       WHERE id = v_producto_id AND sucursal_id = v_sucursal;
+      v_costo_actualizado := v_costo_actualizado || jsonb_build_object(
+        'producto_id', v_producto_id,
+        'costo_sin_iva', v_costo_neto,
+        'costo_con_iva', v_costo_con_iva,
+        'costo_real', v_costo_real
+      );
+    END IF;
+
+    v_items_procesados := v_items_procesados || jsonb_build_object(
+      'producto_id', v_producto_id,
+      'cantidad', v_cantidad,
+      'stock_anterior', v_stock_anterior,
+      'stock_nuevo', v_stock_nuevo,
+      'costo_actualizado', (v_es_mas_reciente AND v_actualiza_costo)
+    );
+  END LOOP;
+
+  UPDATE compras
+     SET subtotal = p_subtotal,
+         iva = v_iva_efectivo,
+         total = p_total,
+         updated_at = NOW()
+   WHERE id = p_compra_id AND sucursal_id = v_sucursal;
+
+  v_warnings := NULL;
+
+  RETURN jsonb_build_object(
+    'success', true,
+    'compra_id', p_compra_id,
+    'items_procesados', v_items_procesados,
+    'costo_actualizado', v_costo_actualizado,
+    'warnings', v_warnings
+  );
+EXCEPTION WHEN OTHERS THEN
+  RETURN jsonb_build_object('success', false, 'error', SQLERRM);
+END;
+$function$;

--- a/migrations/112_backfill_fiscal_productos.sql
+++ b/migrations/112_backfill_fiscal_productos.sql
@@ -1,0 +1,93 @@
+-- ============================================================================
+-- 112 · Backfill fiscal de productos (revisado y aprobado por el usuario 2026-07-13)
+-- ============================================================================
+-- Tres pasos, con listas de ids congeladas tras revisión en prod:
+--   1) Restaurar porcentaje_iva=21 en los 42 productos envenenados por el bug
+--      de compras ZZ (mig 111 elimina la causa). IMPORTANTE: NO se toca
+--      productos.precio (precio final de venta, es lo que factura el negocio);
+--      solo el atributo fiscal y el derivado informativo precio_sin_iva.
+--   2) Cargar tasas efectivas de impuestos internos según evidencia de la
+--      factura Refres Now A 0005-00455160 (16/06/2026) + analogía aprobada:
+--        8,6956% → cola / granadina / manzana / pomelo (blanco, amarillo,
+--                  rosado) / tónica / Coca Cola
+--        4,1667% → lima limón / limón / naranja / citrus / Placer / aguas
+--        0%      → soda sifón / jugos Pindapoy / vinos
+--      (La tasa es por contenido de jugo, NO por familia cítrica: la factura
+--      muestra pomelo blanco a 8,6956 y naranja a 4,1667.)
+--   3) Inicializar ultimo_tipo_compra desde la última compra no cancelada y
+--      recomputar costo_real / costo_con_iva canónicos para todos.
+-- Nota: NO se backfillea pedido_items.costo_unitario_al_crear (falsearía la
+-- historia; el COALESCE del reporte ya maneja el NULL).
+-- ============================================================================
+
+-- ─── 1. porcentaje_iva = 21 (42 productos, sin tocar precio) ───────────────
+
+UPDATE public.productos
+   SET porcentaje_iva = 21,
+       precio_sin_iva = round(precio / 1.21, 2),
+       updated_at     = NOW()
+ WHERE id IN (
+   -- sucursal 1 (Tucumán)
+   156,157,138,242,246,247,250,131,133,249,104,102,101,129,105,106,248,166,241,251,
+   -- sucursal 2 (Taco Pozo)
+   267,270,254,226,265,233,262,231,261,268,225,244,243,245,224,204,206,207,205,269,266,227
+ )
+   AND (porcentaje_iva = 0 OR porcentaje_iva IS NULL);
+
+-- ─── 2. Tasas de impuestos internos ─────────────────────────────────────────
+
+-- 8,6956% efectiva (colas y sabores sin jugo computable + tónica + Coca Cola)
+UPDATE public.productos
+   SET impuestos_internos = 8.6956, updated_at = NOW()
+ WHERE id IN (
+   -- suc 1: MANAOS COLA 1,5/3L/600, GRANADINA, MANZANA, POMELO BLANCO 1,5/3L/600
+   130,78,84,83,82,133,81,87,
+   -- suc 2: COLA 1500/2250/3000/600, GRANADINA, LATA COLA, MANZANA,
+   --        POMELO BLANCO 1500/2250/3000, POMELO AMARILLO, POMELO ROSADO,
+   --        LATA POMELO BLANCO, LATA TONICA, TONICA, COCA COLA
+   239,177,178,219,198,179,185,236,212,189,188,190,182,253,214,226
+ );
+
+-- 4,1667% efectiva (sabores con jugo: lima limón/limón/naranja/citrus,
+-- Placer, aguas con y sin gas, latas lima/naranja)
+UPDATE public.productos
+   SET impuestos_internos = 4.1667, updated_at = NOW()
+ WHERE id IN (
+   -- suc 1: LIMA LIMON 1,5/3L/600, NARANJA 1,5/3L/600, CITRUS, AGUA BIDON,
+   --        AGUA C/GAS, AGUA S/GAS 2L/600, PLACER (todos)
+   131,79,85,132,80,86,77,128,72,127,126,
+   134,161,94,97,135,162,92,136,95,98,93,96,124,125,
+   -- suc 2: LIMA LIMON 1500/2250/3000/600, LIMON, NARANJA 1500/2250/3000/600,
+   --        CITRUS 2250/3000, LATA LIMA, LATA NARANJA, AGUA BIDON, AGUA C/GAS,
+   --        AGUA S/GAS 2000/600, AGUA EL SANO, PLACER (todos)
+   238,213,183,184,199,237,186,187,220,215,252,180,181,173,174,175,176,172,
+   200,192,222,201,210,216,193,211,194,264,195,221,196,197
+ );
+
+-- 0% explícito (soda sifón / Bichy, jugos Pindapoy, vinos)
+UPDATE public.productos
+   SET impuestos_internos = 0, updated_at = NOW()
+ WHERE id IN (89,158,191,208,217,209,218,227,266);
+
+-- ─── 3. ultimo_tipo_compra + recomputo de costos canónicos ─────────────────
+
+UPDATE public.productos p
+   SET ultimo_tipo_compra = sub.tipo_factura
+  FROM (
+    SELECT DISTINCT ON (ci.producto_id, ci.sucursal_id)
+           ci.producto_id, ci.sucursal_id, c.tipo_factura
+      FROM compra_items ci
+      JOIN compras c ON c.id = ci.compra_id
+     WHERE c.estado <> 'cancelada'
+     ORDER BY ci.producto_id, ci.sucursal_id, c.fecha_compra DESC, c.id DESC
+  ) sub
+ WHERE p.id = sub.producto_id
+   AND p.sucursal_id = sub.sucursal_id;
+
+UPDATE public.productos
+   SET costo_real = costo_real_unitario(
+         costo_sin_iva, impuestos_internos, COALESCE(ultimo_tipo_compra, 'FC')),
+       costo_con_iva = costo_financiero_unitario(
+         costo_sin_iva, porcentaje_iva, impuestos_internos, COALESCE(ultimo_tipo_compra, 'FC')),
+       updated_at = NOW()
+ WHERE costo_sin_iva IS NOT NULL;

--- a/src/components/modals/ModalProducto.tsx
+++ b/src/components/modals/ModalProducto.tsx
@@ -10,6 +10,7 @@ import {
   calcularNetoDesdeTotal,
   calcularMargenPorcentaje,
   calcularPrecioDesdeMargen,
+  calcularCostoReal,
   parsePrecio,
 } from '../../utils/calculations';
 import type { ProductoDB, ProveedorDBExtended } from '../../types';
@@ -33,6 +34,8 @@ export interface ProductoFormData {
   impuestos_internos: number | string;
   precio_sin_iva: number | string;
   precio: number | string;
+  /** Costo real canónico (neto + imp. internos si FC; pagado si ZZ) — calculado al guardar */
+  costo_real?: number | null;
   /** Cuántas unidades de venta hacen 1 fardo/bulto (ej: 2 = vendés medio fardo) */
   unidades_de_venta_por_fardo?: number;
   /** Etiqueta del bulto: FARDO, CAJA, PACK, BULTO... */
@@ -100,7 +103,8 @@ const ModalProducto = memo(function ModalProducto({ producto, categorias, provee
     proveedor_id: producto.proveedor_id || '',
     stock: producto.stock ?? '',
     stock_minimo: producto.stock_minimo ?? 10,
-    porcentaje_iva: 21,
+    // Atributo fiscal del producto: preservar el real (ej: 10.5) en vez de resetear a 21.
+    porcentaje_iva: producto.porcentaje_iva ?? 21,
     costo_sin_iva: producto.costo_sin_iva ?? '',
     costo_con_iva: producto.costo_con_iva ?? '',
     impuestos_internos: producto.impuestos_internos ?? '',
@@ -231,7 +235,19 @@ const ModalProducto = memo(function ModalProducto({ producto, categorias, provee
       const categoriaFinal = mostrarNuevaCategoria && nuevaCategoria.trim()
         ? nuevaCategoria.trim()
         : formNormalizado.categoria;
-      onSave({ ...formNormalizado, categoria: categoriaFinal, id: producto?.id });
+      // Mantener el costo_real canónico alineado con la edición manual del costo.
+      // La semántica FC/ZZ la da la última compra registrada (sin compra → FC).
+      const costoReal = calcularCostoReal(
+        formNormalizado.costo_sin_iva,
+        formNormalizado.impuestos_internos,
+        producto?.ultimo_tipo_compra ?? 'FC',
+      );
+      onSave({
+        ...formNormalizado,
+        categoria: categoriaFinal,
+        id: producto?.id,
+        costo_real: costoReal > 0 ? costoReal : null,
+      });
       return;
     }
     // Validación falló: scrollear al primer mensaje de error inline para que sea visible
@@ -479,7 +495,7 @@ const ModalProducto = memo(function ModalProducto({ producto, categorias, provee
             </div>
           </div>
           <p className="text-xs text-gray-500 mt-2">
-            Costo real = Neto + Imp. Internos (sin IVA) = ${(parsePrecio(String(form.costo_sin_iva)) * (1 + (parseFloat(String(form.impuestos_internos)) || 0) / 100)).toFixed(2)}
+            Costo real{(producto?.ultimo_tipo_compra ?? 'FC') === 'ZZ' ? ' (última compra ZZ: lo pagado, sin add-ons)' : ' = Neto + Imp. Internos (sin IVA)'} = ${calcularCostoReal(form.costo_sin_iva, form.impuestos_internos, producto?.ultimo_tipo_compra ?? 'FC').toFixed(2)}
           </p>
         </div>
 

--- a/src/hooks/queries/useProductosQuery.ts
+++ b/src/hooks/queries/useProductosQuery.ts
@@ -85,6 +85,8 @@ async function createProducto(producto: ProductoFormInput, sucursalId: number | 
       costo_con_iva: producto.costo_con_iva ? parseFloat(String(producto.costo_con_iva)) : null,
       impuestos_internos: producto.impuestos_internos ? parseFloat(String(producto.impuestos_internos)) : null,
       precio_sin_iva: producto.precio_sin_iva ? parseFloat(String(producto.precio_sin_iva)) : null,
+      porcentaje_iva: producto.porcentaje_iva ?? 21,
+      costo_real: producto.costo_real ?? null,
       // Bulto/fardo (migración 031): 0 es válido, sólo usamos null cuando viene undefined
       unidades_de_venta_por_fardo: producto.unidades_de_venta_por_fardo == null ? null : producto.unidades_de_venta_por_fardo,
       etiqueta_bulto: producto.etiqueta_bulto || null,
@@ -110,6 +112,8 @@ async function updateProducto({ id, data: producto }: { id: string; data: Partia
   if (producto.costo_con_iva !== undefined) updateData.costo_con_iva = producto.costo_con_iva ? parseFloat(String(producto.costo_con_iva)) : null
   if (producto.impuestos_internos !== undefined) updateData.impuestos_internos = producto.impuestos_internos ? parseFloat(String(producto.impuestos_internos)) : null
   if (producto.precio_sin_iva !== undefined) updateData.precio_sin_iva = producto.precio_sin_iva ? parseFloat(String(producto.precio_sin_iva)) : null
+  if (producto.porcentaje_iva !== undefined) updateData.porcentaje_iva = producto.porcentaje_iva
+  if (producto.costo_real !== undefined) updateData.costo_real = producto.costo_real
   // Bulto/fardo (migración 031): tratá undefined como "no tocar", null como "limpiar"
   if (producto.unidades_de_venta_por_fardo !== undefined) {
     updateData.unidades_de_venta_por_fardo = producto.unidades_de_venta_por_fardo

--- a/src/types/hooks.ts
+++ b/src/types/hooks.ts
@@ -65,6 +65,10 @@ export interface ProductoDB {
   impuestos_internos?: number | null;
   precio_sin_iva?: number | null;
   porcentaje_iva?: number | null;
+  /** Costo real canónico: FC = neto×(1+II/100); ZZ = pagado (mig 111) */
+  costo_real?: number | null;
+  /** Tipo de la última compra que fijó el costo (mig 111) */
+  ultimo_tipo_compra?: 'ZZ' | 'FC' | null;
   activo?: boolean;
   created_at?: string;
   updated_at?: string;
@@ -277,6 +281,9 @@ export interface ProductoFormInput {
   costo_con_iva?: number | string;
   impuestos_internos?: number | string;
   precio_sin_iva?: number | string;
+  porcentaje_iva?: number;
+  /** Costo real canónico calculado en el modal (mig 111) */
+  costo_real?: number | null;
   unidades_de_venta_por_fardo?: number | null;
   etiqueta_bulto?: string | null;
 }

--- a/src/utils/calculations.fiscal.test.ts
+++ b/src/utils/calculations.fiscal.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from 'vitest'
+import { calcularCostoReal, calcularCostoFinanciero, calcularNetoVenta } from './calculations'
+
+// Fixture: factura A 0005-00455160 de Refres Now (Manaos) → T.P. Export,
+// 16/06/2026. Tasas efectivas de imp. internos sobre el neto:
+//   8,6956% colas/granadina/manzana/pomelo · 4,1667% cítricos/aguas/Placer · 0% soda.
+
+describe('calcularCostoReal (canónico, espejo de costo_real_unitario SQL)', () => {
+  it('FC: neto + impuestos internos (IVA es crédito, no costo)', () => {
+    expect(calcularCostoReal(1000, 8.6956, 'FC')).toBe(1086.956)
+    expect(calcularCostoReal(1000, 4.1667, 'FC')).toBe(1041.667)
+    expect(calcularCostoReal(1000, 0, 'FC')).toBe(1000)
+  })
+
+  it('FC: MANAOS COLA 3000cc de la factura → neto bonif 5364.8665 × 1.086956', () => {
+    // precio pack 5397.25 − bonif 0.60% = 5364.8665
+    const netoBonif = 5397.25 * (1 - 0.006)
+    expect(calcularCostoReal(netoBonif, 8.6956, 'FC')).toBeCloseTo(5831.37, 2)
+  })
+
+  it('ZZ: lo pagado tal cual, sin add-on de II', () => {
+    expect(calcularCostoReal(1000, 8.6956, 'ZZ')).toBe(1000)
+    expect(calcularCostoReal(1500.5, 4.1667, 'ZZ')).toBe(1500.5)
+  })
+
+  it('tolera strings y vacíos', () => {
+    expect(calcularCostoReal('1000', '4.1667', 'FC')).toBe(1041.667)
+    expect(calcularCostoReal('', '', 'FC')).toBe(0)
+  })
+})
+
+describe('calcularCostoFinanciero (desembolso por unidad, sin percepciones)', () => {
+  it('FC: neto × (1 + IVA + II)', () => {
+    expect(calcularCostoFinanciero(1000, 21, 8.6956, 'FC')).toBe(1296.956)
+    expect(calcularCostoFinanciero(1000, 21, 0, 'FC')).toBe(1210)
+  })
+
+  it('ZZ: lo pagado', () => {
+    expect(calcularCostoFinanciero(1000, 21, 8.6956, 'ZZ')).toBe(1000)
+  })
+})
+
+describe('calcularNetoVenta con impuestos internos (estructura de la factura)', () => {
+  it('FC: precio final = neto × (1 + IVA + II); IVA = 21% exacto del neto', () => {
+    // Venta FC de una cola a $10.000 final
+    const d = calcularNetoVenta(10000, 21, 8.6956, 'FC')
+    expect(d.neto).toBeCloseTo(7710.36, 2)
+    expect(d.iva).toBeCloseTo(1619.18, 2)
+    expect(d.impuestosInternos).toBeCloseTo(670.46, 2)
+    // Reconstrucción: neto + iva + ii = precio final
+    expect(d.neto + d.iva + d.impuestosInternos).toBeCloseTo(10000, 2)
+    // Propiedad de la factura real: IVA es exactamente 21% del gravado
+    expect(d.iva).toBeCloseTo(d.neto * 0.21, 2)
+  })
+
+  it('ZZ: todo el precio final es ingreso neto', () => {
+    expect(calcularNetoVenta(10000, 21, 8.6956, 'ZZ')).toEqual({
+      neto: 10000, iva: 0, impuestosInternos: 0,
+    })
+  })
+})

--- a/src/utils/calculations.ts
+++ b/src/utils/calculations.ts
@@ -123,29 +123,46 @@ export function calcularNetoVenta(
 }
 
 /**
- * Calcula el costo neto de una compra según tipo de factura
+ * Costo REAL por unidad (canónico, espejo de la función SQL costo_real_unitario).
  *
- * FC (con factura): costo neto = costo sin IVA (IVA es crédito fiscal)
- * ZZ (sin factura): costo neto = costo total (no hay IVA que descontar)
+ * FC: neto post-bonif + impuestos internos (el IVA y las percepciones son
+ *     créditos fiscales, NO costo).
+ * ZZ: lo pagado tal cual (nada recuperable; el precio informal ya incluye todo,
+ *     no se agrega II encima).
  *
- * @param costoSinIva - Costo neto sin IVA del producto
- * @param porcentajeIva - Porcentaje de IVA
+ * @param costoNeto - Costo unitario post-bonificación (FC: neto de factura; ZZ: pagado)
+ * @param porcentajeImpInternos - Tasa efectiva de imp. internos (ej: 8.6956, 4.1667)
  * @param tipoFactura - 'ZZ' o 'FC'
- * @returns Costo neto real
  */
-export function calcularNetoCosto(
-  costoSinIva: number | string,
-  porcentajeIva: number | string = 21,
+export function calcularCostoReal(
+  costoNeto: number | string,
+  porcentajeImpInternos: number | string = 0,
   tipoFactura: 'ZZ' | 'FC' = 'FC'
 ): number {
-  const costo = parseFloat(String(costoSinIva)) || 0;
-  const iva = parseFloat(String(porcentajeIva)) || 0;
+  const costo = parseFloat(String(costoNeto)) || 0;
+  if (tipoFactura === 'ZZ') return costo;
+  const impInt = parseFloat(String(porcentajeImpInternos)) || 0;
+  return redondear(costo * (1 + impInt / 100), 4);
+}
 
-  if (tipoFactura === 'FC') {
-    return costo; // IVA es crédito fiscal, no es costo
-  }
-  // ZZ: IVA no existe, el costo total es el neto
-  return costo * (1 + iva / 100);
+/**
+ * Costo FINANCIERO por unidad (desembolso, sin percepciones; espejo SQL de
+ * costo_financiero_unitario). Alimenta productos.costo_con_iva.
+ * NO usar para margen real: para eso está calcularCostoReal.
+ *
+ * FC: neto × (1 + IVA% + II%). ZZ: lo pagado.
+ */
+export function calcularCostoFinanciero(
+  costoNeto: number | string,
+  porcentajeIva: number | string = 21,
+  porcentajeImpInternos: number | string = 0,
+  tipoFactura: 'ZZ' | 'FC' = 'FC'
+): number {
+  const costo = parseFloat(String(costoNeto)) || 0;
+  if (tipoFactura === 'ZZ') return costo;
+  const iva = parseFloat(String(porcentajeIva)) || 0;
+  const impInt = parseFloat(String(porcentajeImpInternos)) || 0;
+  return redondear(costo * (1 + iva / 100 + impInt / 100), 4);
 }
 
 // ============================================
@@ -312,7 +329,8 @@ export default {
   calcularNetoDesdeTotal,
   calcularMontoIva,
   calcularNetoVenta,
-  calcularNetoCosto,
+  calcularCostoReal,
+  calcularCostoFinanciero,
   calcularSubtotalItem,
   calcularTotalPedido,
   calcularMargenPorcentaje,


### PR DESCRIPTION
## Fase A del rediseño fiscal de compras/ventas (1 de 4)

Plan completo: costo real = neto post-bonif + impuestos internos (IVA y percepciones son créditos fiscales, no costo). Caso de estudio: factura Refres Now A 0005-00455160 (Manaos).

### Bug raíz corregido
`registrar_compra_completa` pisaba `porcentaje_iva = 0` en el producto cuando la compra era ZZ (hack para neutralizar `calcularNetoCosto`, código muerto en el front) → **42 productos quedaron con IVA 0%** en prod y cualquier venta FC calcularía desglose fiscal en 0.

### Cambios
- **mig 111** (APLICADA): `productos.costo_real` numeric(12,4) + `ultimo_tipo_compra`; `impuestos_internos` → numeric(12,4) (la tasa efectiva 8,6956% de las colas no entraba en (12,2)); funciones canónicas `costo_real_unitario` / `costo_financiero_unitario`; los RPCs de compra dejan de tocar los atributos fiscales del producto y mantienen `costo_real`; guard para líneas bonif ≥100%/costo 0; drop del overload legacy de 12 args.
- **mig 112** (APLICADA, backfill con checkpoints aprobados): IVA 21% restaurado en los 42 (sin tocar el precio final de venta); tasas II por evidencia de factura + analogía (8,6956 colas/granadina/manzana/pomelo/tónica/Coca · 4,1667 cítricos/Placer/aguas · 0 soda/jugos/vinos); `ultimo_tipo_compra` inicializado; `costo_real`/`costo_con_iva` recomputados.
- **calculations.ts**: `calcularCostoReal` / `calcularCostoFinanciero` (espejo TS) + tests con la factura como fixture; eliminado `calcularNetoCosto` (muerto).
- **ModalProducto**: preserva el `porcentaje_iva` real al editar (antes reseteaba a 21), guarda `costo_real`, hint según semántica FC/ZZ.

### Verificación en prod
- 0 productos con IVA 0/null · 81 productos con tasa II · `costo_real` poblado en todos los que tienen costo.
- MANAOS COLA 3LT: costo_sin_iva 5.096,62 → costo_real **5.539,80** (×1,086956 ✓).
- ZZ (FIDEO COTELLA): costo_real = pagado, sin add-on ✓.
- 8 tests nuevos verdes; suite pre-commit completa verde.

⚠️ Los márgenes de reportes van a **bajar al nivel real** de acá en adelante (el CMV ahora incluye impuestos internos): no es un bug. Los snapshots históricos quedan congelados.

Siguen: Fase B (percepciones/no gravado/panel control contra factura), C (ventas FC/ZZ server-side), D (reportes + posición fiscal).

🤖 Generated with [Claude Code](https://claude.com/claude-code)