### PR TITLE
feat(compras): Fase B — percepciones, no gravado, II propio y control contra factura

### DIFF
--- a/migrations/113_compras_desglose_fiscal_columnas.sql
+++ b/migrations/113_compras_desglose_fiscal_columnas.sql
@@ -1,0 +1,58 @@
+-- ============================================================================
+-- 113 · Compras: columnas de desglose fiscal completo (percepciones, no
+--       gravado, imp. internos propio) + snapshots fiscales por línea
+-- ============================================================================
+-- Contexto (Fase B del rediseño fiscal):
+--   · El monto de impuestos internos calculado por el modal se guardaba en
+--     compras.otros_impuestos (concepto equivocado). Ahora tiene columna
+--     propia y otros_impuestos vuelve a ser un catch-all. Backfill: en prod
+--     hay 4 filas con otros_impuestos > 0, todas eran II del modal.
+--   · Percepción IVA (ej: RG 5329 3% sobre gravado) y percepción IIBB son
+--     CRÉDITOS fiscales: se registran para seguimiento (posición fiscal),
+--     NO integran el costo del producto.
+--   · no_gravado: conceptos de factura fuera del IVA (ej: pallets/separadores
+--     valorizados). No integran costo unitario; hacen cuadrar el total.
+--   · compra_items snapshotea la tasa de IVA/II aplicada y el costo neto y
+--     real por unidad → historial de costos confiable por línea.
+-- Sin CHECK duro de consistencia de total: las 43 compras ZZ legacy y los
+-- redondeos de factura lo violarían; el control es blando (warning del RPC +
+-- panel "Control contra factura" en el modal).
+-- ============================================================================
+
+ALTER TABLE public.compras
+  ADD COLUMN IF NOT EXISTS impuestos_internos numeric(12,2) NOT NULL DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS percepcion_iva     numeric(12,2) NOT NULL DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS percepcion_iibb    numeric(12,2) NOT NULL DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS no_gravado         numeric(12,2) NOT NULL DEFAULT 0;
+
+COMMENT ON COLUMN public.compras.impuestos_internos IS
+  'Monto total de impuestos internos de la factura (antes se guardaba en otros_impuestos). Integra el costo real de los productos.';
+COMMENT ON COLUMN public.compras.percepcion_iva IS
+  'Percepción de IVA de la factura (ej: RG 5329 3% sobre gravado). Crédito fiscal, NO costo.';
+COMMENT ON COLUMN public.compras.percepcion_iibb IS
+  'Percepción de IIBB de la factura. Crédito fiscal, NO costo.';
+COMMENT ON COLUMN public.compras.no_gravado IS
+  'Conceptos no gravados de la factura (ej: pallets/separadores valorizados). No integran costo unitario; cuadran el total.';
+COMMENT ON COLUMN public.compras.otros_impuestos IS
+  'Catch-all para otros conceptos impositivos. Hasta mig 113 guardaba (mal) el monto de imp. internos.';
+
+-- Backfill: el II del modal vivía en otros_impuestos (4 filas en prod)
+UPDATE public.compras
+   SET impuestos_internos = otros_impuestos,
+       otros_impuestos    = 0
+ WHERE otros_impuestos > 0;
+
+ALTER TABLE public.compra_items
+  ADD COLUMN IF NOT EXISTS porcentaje_iva      numeric(5,2),
+  ADD COLUMN IF NOT EXISTS impuestos_internos  numeric(8,4),
+  ADD COLUMN IF NOT EXISTS costo_neto_unitario numeric(12,4),
+  ADD COLUMN IF NOT EXISTS costo_real_unitario numeric(12,4);
+
+COMMENT ON COLUMN public.compra_items.porcentaje_iva IS
+  'Tasa de IVA aplicada en esta línea (snapshot al registrar; NULL = línea previa a mig 113).';
+COMMENT ON COLUMN public.compra_items.impuestos_internos IS
+  'Tasa EFECTIVA de imp. internos aplicada en esta línea, en % sobre el neto (snapshot).';
+COMMENT ON COLUMN public.compra_items.costo_neto_unitario IS
+  'Costo unitario post-bonificación (snapshot). costo_unitario es el bruto pre-bonif.';
+COMMENT ON COLUMN public.compra_items.costo_real_unitario IS
+  'Costo real por unidad (canónico mig 111): FC = neto×(1+II/100); ZZ = pagado. Historial de costos confiable.';

--- a/migrations/114_registrar_compra_percepciones.sql
+++ b/migrations/114_registrar_compra_percepciones.sql
@@ -1,0 +1,457 @@
+-- ============================================================================
+-- 114 · registrar_compra_completa y actualizar_compra_items con desglose
+--       fiscal completo (percepciones, no gravado, II propio, snapshots)
+-- ============================================================================
+-- · Se consolida registrar_compra_completa en UNA sola función: se dropea el
+--   overload de 13 args (el de 12 ya cayó en mig 111). Los 4 params nuevos
+--   tienen DEFAULT ⇒ un cliente PWA viejo que llama con los 13 args con nombre
+--   sigue resolviendo sin ambigüedad (PGRST203 imposible con función única).
+-- · actualizar_compra_items: se dropea la firma de 6 args y se recrea con 5
+--   params opcionales DEFAULT NULL (NULL = conservar el valor actual de la
+--   cabecera, así un cliente viejo no pisa datos).
+-- · Control blando de cuadre: si |total calculado − p_total| > 1 se devuelve
+--   warning_descuadre en el JSONB (no bloquea: redondeos de factura reales).
+-- · ZZ fuerza iva / II / percepciones / no_gravado = 0 en cabecera y no aplica
+--   II por línea (lo pagado ya es todo).
+-- ============================================================================
+
+DROP FUNCTION IF EXISTS public.registrar_compra_completa(
+  bigint, character varying, character varying, date,
+  numeric, numeric, numeric, numeric,
+  character varying, text, uuid, jsonb, character varying
+);
+
+CREATE FUNCTION public.registrar_compra_completa(
+  p_proveedor_id bigint, p_proveedor_nombre character varying,
+  p_numero_factura character varying, p_fecha_compra date,
+  p_subtotal numeric, p_iva numeric, p_otros_impuestos numeric, p_total numeric,
+  p_forma_pago character varying, p_notas text, p_usuario_id uuid,
+  p_items jsonb, p_tipo_factura character varying DEFAULT 'FC',
+  p_impuestos_internos numeric DEFAULT 0,
+  p_percepcion_iva numeric DEFAULT 0,
+  p_percepcion_iibb numeric DEFAULT 0,
+  p_no_gravado numeric DEFAULT 0
+) RETURNS jsonb
+LANGUAGE plpgsql SECURITY DEFINER
+SET search_path TO 'public'
+AS $$
+DECLARE
+  v_sucursal            BIGINT := current_sucursal_id();
+  v_compra_id           BIGINT;
+  v_item                JSONB;
+  v_producto            RECORD;
+  v_stock_anterior      INTEGER;
+  v_stock_nuevo         INTEGER;
+  v_cantidad            INTEGER;
+  v_bonificacion        NUMERIC;
+  v_porcentaje_iva      NUMERIC;
+  v_impuestos_internos  NUMERIC;
+  v_costo_unitario      NUMERIC;
+  v_costo_neto          NUMERIC;
+  v_costo_con_iva       NUMERIC;
+  v_costo_real          NUMERIC;
+  v_actualiza_costo     BOOLEAN;
+  v_tipo_factura        TEXT;
+  v_es_zz               BOOLEAN;
+  v_iva_hdr             NUMERIC;
+  v_ii_hdr              NUMERIC;
+  v_perc_iva_hdr        NUMERIC;
+  v_perc_iibb_hdr       NUMERIC;
+  v_no_gravado_hdr      NUMERIC;
+  v_total_calc          NUMERIC;
+  v_warning             TEXT := NULL;
+  v_items_procesados    JSONB := '[]'::JSONB;
+  v_user_role           TEXT;
+BEGIN
+  IF v_sucursal IS NULL THEN
+    RETURN jsonb_build_object('success', false, 'error', 'No se pudo determinar la sucursal activa');
+  END IF;
+
+  IF p_usuario_id IS DISTINCT FROM auth.uid() THEN
+    RETURN jsonb_build_object('success', false, 'error', 'ID de usuario no coincide con la sesion autenticada');
+  END IF;
+
+  SELECT rol INTO v_user_role FROM perfiles WHERE id = p_usuario_id;
+  IF v_user_role IS NULL OR v_user_role NOT IN ('admin', 'encargado') THEN
+    RETURN jsonb_build_object('success', false, 'error', 'No autorizado: solo admin o encargado pueden registrar compras');
+  END IF;
+
+  v_tipo_factura   := COALESCE(p_tipo_factura, 'FC');
+  v_es_zz          := (v_tipo_factura = 'ZZ');
+  v_iva_hdr        := CASE WHEN v_es_zz THEN 0 ELSE COALESCE(p_iva, 0) END;
+  v_ii_hdr         := CASE WHEN v_es_zz THEN 0 ELSE COALESCE(p_impuestos_internos, 0) END;
+  v_perc_iva_hdr   := CASE WHEN v_es_zz THEN 0 ELSE COALESCE(p_percepcion_iva, 0) END;
+  v_perc_iibb_hdr  := CASE WHEN v_es_zz THEN 0 ELSE COALESCE(p_percepcion_iibb, 0) END;
+  v_no_gravado_hdr := CASE WHEN v_es_zz THEN 0 ELSE COALESCE(p_no_gravado, 0) END;
+
+  INSERT INTO compras (
+    proveedor_id, proveedor_nombre, numero_factura, fecha_compra,
+    subtotal, iva, impuestos_internos, percepcion_iva, percepcion_iibb,
+    no_gravado, otros_impuestos, total, forma_pago, notas,
+    usuario_id, estado, tipo_factura, sucursal_id
+  ) VALUES (
+    p_proveedor_id, p_proveedor_nombre, p_numero_factura, p_fecha_compra,
+    p_subtotal, v_iva_hdr, v_ii_hdr, v_perc_iva_hdr, v_perc_iibb_hdr,
+    v_no_gravado_hdr, COALESCE(p_otros_impuestos, 0), p_total, p_forma_pago, p_notas,
+    p_usuario_id, 'recibida', v_tipo_factura, v_sucursal
+  )
+  RETURNING id INTO v_compra_id;
+
+  FOR v_item IN SELECT * FROM jsonb_array_elements(p_items) LOOP
+    SELECT id, stock INTO v_producto
+      FROM productos
+     WHERE id = (v_item->>'producto_id')::BIGINT
+       AND sucursal_id = v_sucursal
+     FOR UPDATE;
+
+    IF NOT FOUND THEN
+      RAISE EXCEPTION 'Producto no encontrado: %', v_item->>'producto_id';
+    END IF;
+
+    v_cantidad           := (v_item->>'cantidad')::INTEGER;
+    v_stock_anterior     := COALESCE(v_producto.stock, 0);
+    v_stock_nuevo        := v_stock_anterior + v_cantidad;
+    v_costo_unitario     := COALESCE((v_item->>'costo_unitario')::NUMERIC, 0);
+    v_bonificacion       := COALESCE((v_item->>'bonificacion')::NUMERIC, 0);
+    v_porcentaje_iva     := CASE WHEN v_es_zz THEN 0 ELSE COALESCE((v_item->>'porcentaje_iva')::NUMERIC, 21) END;
+    v_impuestos_internos := CASE WHEN v_es_zz THEN 0 ELSE COALESCE((v_item->>'impuestos_internos')::NUMERIC, 0) END;
+
+    v_costo_neto    := v_costo_unitario * (1 - v_bonificacion / 100);
+    v_costo_con_iva := costo_financiero_unitario(v_costo_neto, v_porcentaje_iva, v_impuestos_internos, v_tipo_factura);
+    v_costo_real    := costo_real_unitario(v_costo_neto, v_impuestos_internos, v_tipo_factura);
+
+    INSERT INTO compra_items (
+      compra_id, producto_id, cantidad, costo_unitario, subtotal,
+      stock_anterior, stock_nuevo, bonificacion, sucursal_id,
+      porcentaje_iva, impuestos_internos, costo_neto_unitario, costo_real_unitario
+    ) VALUES (
+      v_compra_id,
+      (v_item->>'producto_id')::BIGINT,
+      v_cantidad,
+      v_costo_unitario,
+      COALESCE((v_item->>'subtotal')::NUMERIC, 0),
+      v_stock_anterior,
+      v_stock_nuevo,
+      v_bonificacion,
+      v_sucursal,
+      v_porcentaje_iva,
+      v_impuestos_internos,
+      round(v_costo_neto, 4),
+      v_costo_real
+    );
+
+    -- Regalos / promos (bonif 100% o costo 0) suman stock pero no fijan costo.
+    v_actualiza_costo := (v_bonificacion < 100 AND v_costo_neto > 0);
+
+    IF v_actualiza_costo THEN
+      UPDATE productos
+         SET stock              = stock + v_cantidad,
+             costo_sin_iva      = v_costo_neto,
+             costo_con_iva      = v_costo_con_iva,
+             costo_real         = v_costo_real,
+             ultimo_tipo_compra = v_tipo_factura,
+             updated_at         = NOW()
+       WHERE id = (v_item->>'producto_id')::BIGINT
+         AND sucursal_id = v_sucursal;
+    ELSE
+      UPDATE productos
+         SET stock      = stock + v_cantidad,
+             updated_at = NOW()
+       WHERE id = (v_item->>'producto_id')::BIGINT
+         AND sucursal_id = v_sucursal;
+    END IF;
+
+    v_items_procesados := v_items_procesados || jsonb_build_object(
+      'producto_id',       (v_item->>'producto_id')::BIGINT,
+      'cantidad',          v_cantidad,
+      'stock_anterior',    v_stock_anterior,
+      'stock_nuevo',       v_stock_nuevo,
+      'costo_sin_iva',     v_costo_neto,
+      'costo_con_iva',     v_costo_con_iva,
+      'costo_real',        v_costo_real,
+      'costo_actualizado', v_actualiza_costo
+    );
+  END LOOP;
+
+  -- Control blando de cuadre contra el total informado
+  v_total_calc := CASE
+    WHEN v_es_zz THEN COALESCE(p_subtotal, 0)
+    ELSE COALESCE(p_subtotal, 0) + v_iva_hdr + v_ii_hdr + v_perc_iva_hdr
+         + v_perc_iibb_hdr + v_no_gravado_hdr + COALESCE(p_otros_impuestos, 0)
+  END;
+  IF abs(v_total_calc - COALESCE(p_total, 0)) > 1 THEN
+    v_warning := format('Descuadre: total calculado %s vs total informado %s',
+                        round(v_total_calc, 2), round(COALESCE(p_total, 0), 2));
+  END IF;
+
+  RETURN jsonb_build_object(
+    'success',           true,
+    'compra_id',         v_compra_id,
+    'items_procesados',  v_items_procesados,
+    'warning_descuadre', v_warning
+  );
+EXCEPTION WHEN OTHERS THEN
+  RETURN jsonb_build_object('success', false, 'error', SQLERRM);
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.registrar_compra_completa(
+  bigint, character varying, character varying, date, numeric, numeric, numeric,
+  numeric, character varying, text, uuid, jsonb, character varying,
+  numeric, numeric, numeric, numeric
+) TO authenticated, service_role;
+REVOKE EXECUTE ON FUNCTION public.registrar_compra_completa(
+  bigint, character varying, character varying, date, numeric, numeric, numeric,
+  numeric, character varying, text, uuid, jsonb, character varying,
+  numeric, numeric, numeric, numeric
+) FROM anon, public;
+
+-- ────────────────────────────────────────────────────────────────────────────
+-- actualizar_compra_items con cabecera fiscal opcional (NULL = conservar)
+-- ────────────────────────────────────────────────────────────────────────────
+
+DROP FUNCTION IF EXISTS public.actualizar_compra_items(bigint, jsonb, numeric, numeric, numeric, uuid);
+
+CREATE FUNCTION public.actualizar_compra_items(
+  p_compra_id bigint, p_items_nuevos jsonb,
+  p_subtotal numeric, p_iva numeric, p_total numeric, p_usuario_id uuid,
+  p_impuestos_internos numeric DEFAULT NULL,
+  p_percepcion_iva numeric DEFAULT NULL,
+  p_percepcion_iibb numeric DEFAULT NULL,
+  p_no_gravado numeric DEFAULT NULL,
+  p_otros_impuestos numeric DEFAULT NULL
+) RETURNS jsonb
+LANGUAGE plpgsql SECURITY DEFINER
+SET search_path TO 'public'
+AS $function$
+DECLARE
+  v_sucursal BIGINT := current_sucursal_id();
+  v_user_role TEXT;
+  v_compra RECORD;
+  v_dias NUMERIC;
+  v_item JSONB;
+  v_producto_id BIGINT;
+  v_cantidad INTEGER;
+  v_costo_unitario NUMERIC;
+  v_bonificacion NUMERIC;
+  v_porcentaje_iva NUMERIC;
+  v_impuestos_internos NUMERIC;
+  v_subtotal_item NUMERIC;
+  v_costo_neto NUMERIC;
+  v_costo_con_iva NUMERIC;
+  v_costo_real NUMERIC;
+  v_actualiza_costo BOOLEAN;
+  v_es_zz BOOLEAN;
+  v_stock_anterior INTEGER;
+  v_stock_nuevo INTEGER;
+  v_max_fecha DATE;
+  v_es_mas_reciente BOOLEAN;
+  v_iva_efectivo NUMERIC;
+  v_items_procesados JSONB := '[]'::JSONB;
+  v_costo_actualizado JSONB := '[]'::JSONB;
+  v_snapshot_stock JSONB := '{}'::JSONB;
+  v_warnings_stock_negativo JSONB;
+BEGIN
+  IF v_sucursal IS NULL THEN
+    RETURN jsonb_build_object('success', false, 'error', 'No se pudo determinar la sucursal activa');
+  END IF;
+  IF p_usuario_id IS DISTINCT FROM auth.uid() THEN
+    RETURN jsonb_build_object('success', false, 'error', 'ID de usuario no coincide con la sesion autenticada');
+  END IF;
+
+  SELECT rol INTO v_user_role FROM perfiles WHERE id = p_usuario_id;
+  IF v_user_role IS NULL OR v_user_role <> 'admin' THEN
+    RETURN jsonb_build_object('success', false, 'error', 'No autorizado: solo admin puede editar compras');
+  END IF;
+
+  SELECT id, estado, tipo_factura, created_at, fecha_compra
+    INTO v_compra
+    FROM compras
+   WHERE id = p_compra_id AND sucursal_id = v_sucursal;
+  IF NOT FOUND THEN
+    RETURN jsonb_build_object('success', false, 'error', 'Compra no encontrada');
+  END IF;
+
+  IF v_compra.estado = 'cancelada' THEN
+    RETURN jsonb_build_object('success', false, 'error', 'No se puede editar una compra cancelada');
+  END IF;
+
+  v_dias := EXTRACT(EPOCH FROM (now() - v_compra.created_at)) / 86400;
+  IF v_dias > 7 THEN
+    RETURN jsonb_build_object('success', false, 'error',
+      'No se puede editar una compra creada hace mas de 7 dias');
+  END IF;
+
+  v_es_zz := (v_compra.tipo_factura = 'ZZ');
+  v_iva_efectivo := CASE WHEN v_es_zz THEN 0 ELSE p_iva END;
+
+  PERFORM set_config('app.stock_origen', 'compra_editada', true);
+  PERFORM set_config('app.stock_ref_tipo', 'compra', true);
+  PERFORM set_config('app.stock_ref_id', p_compra_id::TEXT, true);
+  PERFORM set_config('app.stock_user_id', p_usuario_id::TEXT, true);
+
+  PERFORM 1 FROM productos
+   WHERE sucursal_id = v_sucursal
+     AND id IN (
+       SELECT producto_id FROM compra_items
+        WHERE compra_id = p_compra_id AND sucursal_id = v_sucursal
+       UNION
+       SELECT (item->>'producto_id')::BIGINT
+         FROM jsonb_array_elements(p_items_nuevos) AS item
+     )
+   ORDER BY id
+   FOR UPDATE;
+
+  SELECT jsonb_object_agg(id::text, stock) INTO v_snapshot_stock
+    FROM productos
+   WHERE sucursal_id = v_sucursal
+     AND id IN (
+       SELECT producto_id FROM compra_items
+        WHERE compra_id = p_compra_id AND sucursal_id = v_sucursal
+       UNION
+       SELECT (item->>'producto_id')::BIGINT
+         FROM jsonb_array_elements(p_items_nuevos) AS item
+     );
+
+  WITH viejos AS (
+    SELECT producto_id, SUM(cantidad)::INT AS qty_old
+      FROM compra_items
+     WHERE compra_id = p_compra_id AND sucursal_id = v_sucursal
+     GROUP BY producto_id
+  ),
+  nuevos AS (
+    SELECT (item->>'producto_id')::BIGINT AS producto_id,
+           SUM((item->>'cantidad')::INT)::INT AS qty_new
+      FROM jsonb_array_elements(p_items_nuevos) AS item
+     GROUP BY (item->>'producto_id')::BIGINT
+  ),
+  deltas AS (
+    SELECT COALESCE(v.producto_id, n.producto_id) AS producto_id,
+           COALESCE(n.qty_new, 0) - COALESCE(v.qty_old, 0) AS delta
+      FROM viejos v FULL OUTER JOIN nuevos n USING (producto_id)
+  )
+  UPDATE productos p
+     SET stock = p.stock + d.delta,
+         updated_at = NOW()
+    FROM deltas d
+   WHERE p.id = d.producto_id
+     AND p.sucursal_id = v_sucursal
+     AND d.delta <> 0;
+
+  SELECT jsonb_agg(jsonb_build_object('producto_id', id, 'nombre', nombre, 'stock', stock))
+    INTO v_warnings_stock_negativo
+    FROM productos
+   WHERE sucursal_id = v_sucursal
+     AND stock < 0
+     AND id IN (
+       SELECT producto_id FROM compra_items
+        WHERE compra_id = p_compra_id AND sucursal_id = v_sucursal
+       UNION
+       SELECT (item->>'producto_id')::BIGINT
+         FROM jsonb_array_elements(p_items_nuevos) AS item
+     );
+
+  IF v_warnings_stock_negativo IS NOT NULL AND jsonb_array_length(v_warnings_stock_negativo) > 0 THEN
+    RAISE EXCEPTION 'La edición dejaría stock negativo en: %. Ajustá las cantidades o reconciliá el stock primero.',
+      (SELECT string_agg((w->>'nombre') || ' (' || (w->>'stock') || ')', ', ')
+         FROM jsonb_array_elements(v_warnings_stock_negativo) w);
+  END IF;
+
+  DELETE FROM compra_items WHERE compra_id = p_compra_id AND sucursal_id = v_sucursal;
+
+  FOR v_item IN SELECT * FROM jsonb_array_elements(p_items_nuevos) LOOP
+    v_producto_id        := (v_item->>'producto_id')::BIGINT;
+    v_cantidad           := (v_item->>'cantidad')::INTEGER;
+    v_costo_unitario     := COALESCE((v_item->>'costo_unitario')::NUMERIC, 0);
+    v_bonificacion       := COALESCE((v_item->>'bonificacion')::NUMERIC, 0);
+    v_porcentaje_iva     := CASE WHEN v_es_zz THEN 0 ELSE COALESCE((v_item->>'porcentaje_iva')::NUMERIC, 21) END;
+    v_impuestos_internos := CASE WHEN v_es_zz THEN 0 ELSE COALESCE((v_item->>'impuestos_internos')::NUMERIC, 0) END;
+    v_subtotal_item      := COALESCE((v_item->>'subtotal')::NUMERIC, 0);
+
+    IF v_cantidad IS NULL OR v_cantidad <= 0 THEN
+      RAISE EXCEPTION 'Cantidad invalida para producto %', v_producto_id;
+    END IF;
+
+    v_stock_anterior := COALESCE((v_snapshot_stock->>v_producto_id::TEXT)::INTEGER, 0);
+    v_stock_nuevo := v_stock_anterior + v_cantidad;
+
+    v_costo_neto    := v_costo_unitario * (1 - v_bonificacion / 100);
+    v_costo_con_iva := costo_financiero_unitario(v_costo_neto, v_porcentaje_iva, v_impuestos_internos, v_compra.tipo_factura);
+    v_costo_real    := costo_real_unitario(v_costo_neto, v_impuestos_internos, v_compra.tipo_factura);
+    v_actualiza_costo := (v_bonificacion < 100 AND v_costo_neto > 0);
+
+    INSERT INTO compra_items (
+      compra_id, producto_id, cantidad, costo_unitario, subtotal,
+      stock_anterior, stock_nuevo, bonificacion, sucursal_id,
+      porcentaje_iva, impuestos_internos, costo_neto_unitario, costo_real_unitario
+    ) VALUES (
+      p_compra_id, v_producto_id, v_cantidad, v_costo_unitario,
+      v_subtotal_item, v_stock_anterior, v_stock_nuevo, v_bonificacion, v_sucursal,
+      v_porcentaje_iva, v_impuestos_internos, round(v_costo_neto, 4), v_costo_real
+    );
+
+    SELECT MAX(c.fecha_compra) INTO v_max_fecha
+      FROM compras c
+      JOIN compra_items ci ON ci.compra_id = c.id AND ci.sucursal_id = c.sucursal_id
+     WHERE ci.producto_id = v_producto_id
+       AND ci.sucursal_id = v_sucursal
+       AND c.estado <> 'cancelada'
+       AND c.id <> p_compra_id;
+
+    v_es_mas_reciente := (v_max_fecha IS NULL) OR (v_compra.fecha_compra >= v_max_fecha);
+
+    IF v_es_mas_reciente AND v_actualiza_costo THEN
+      UPDATE productos
+         SET costo_sin_iva      = v_costo_neto,
+             costo_con_iva      = v_costo_con_iva,
+             costo_real         = v_costo_real,
+             ultimo_tipo_compra = v_compra.tipo_factura,
+             updated_at         = NOW()
+       WHERE id = v_producto_id AND sucursal_id = v_sucursal;
+      v_costo_actualizado := v_costo_actualizado || jsonb_build_object(
+        'producto_id', v_producto_id,
+        'costo_sin_iva', v_costo_neto,
+        'costo_con_iva', v_costo_con_iva,
+        'costo_real', v_costo_real
+      );
+    END IF;
+
+    v_items_procesados := v_items_procesados || jsonb_build_object(
+      'producto_id', v_producto_id,
+      'cantidad', v_cantidad,
+      'stock_anterior', v_stock_anterior,
+      'stock_nuevo', v_stock_nuevo,
+      'costo_actualizado', (v_es_mas_reciente AND v_actualiza_costo)
+    );
+  END LOOP;
+
+  UPDATE compras
+     SET subtotal = p_subtotal,
+         iva = v_iva_efectivo,
+         impuestos_internos = CASE WHEN v_es_zz THEN 0 ELSE COALESCE(p_impuestos_internos, impuestos_internos) END,
+         percepcion_iva     = CASE WHEN v_es_zz THEN 0 ELSE COALESCE(p_percepcion_iva, percepcion_iva) END,
+         percepcion_iibb    = CASE WHEN v_es_zz THEN 0 ELSE COALESCE(p_percepcion_iibb, percepcion_iibb) END,
+         no_gravado         = CASE WHEN v_es_zz THEN 0 ELSE COALESCE(p_no_gravado, no_gravado) END,
+         otros_impuestos    = COALESCE(p_otros_impuestos, otros_impuestos),
+         total = p_total,
+         updated_at = NOW()
+   WHERE id = p_compra_id AND sucursal_id = v_sucursal;
+
+  RETURN jsonb_build_object(
+    'success', true,
+    'compra_id', p_compra_id,
+    'items_procesados', v_items_procesados,
+    'costo_actualizado', v_costo_actualizado,
+    'warnings', NULL
+  );
+EXCEPTION WHEN OTHERS THEN
+  RETURN jsonb_build_object('success', false, 'error', SQLERRM);
+END;
+$function$;
+
+GRANT EXECUTE ON FUNCTION public.actualizar_compra_items(
+  bigint, jsonb, numeric, numeric, numeric, uuid, numeric, numeric, numeric, numeric, numeric
+) TO authenticated, service_role;
+REVOKE EXECUTE ON FUNCTION public.actualizar_compra_items(
+  bigint, jsonb, numeric, numeric, numeric, uuid, numeric, numeric, numeric, numeric, numeric
+) FROM anon, public;

--- a/migrations/115_anular_compra_atomica_v2.sql
+++ b/migrations/115_anular_compra_atomica_v2.sql
@@ -1,0 +1,158 @@
+-- ============================================================================
+-- 115 · anular_compra_atomica v2: multi-tenant, atómica y con restauración
+--       de costo desde la última compra restante
+-- ============================================================================
+-- La versión del baseline era pre-multitenant y el front ni la usaba: anulaba
+-- CLIENT-SIDE (loop de updates de stock no atómico, clampeado en 0 que pierde
+-- reversa, sin restaurar costo). Esta versión:
+--   · admin/encargado, scoping por current_sucursal_id()
+--   · rechaza si la reversa dejaría stock negativo (misma invariante que 104)
+--   · si la compra anulada era la que fijó el costo del producto, lo restaura
+--     desde la línea de compra restante más reciente (usando su tipo_factura y
+--     los atributos fiscales actuales del producto); si no hay, deja el costo
+--     y lo reporta en warnings
+--   · tagea stock_historico vía GUCs (origen 'compra_anulada')
+-- ============================================================================
+
+DROP FUNCTION IF EXISTS public.anular_compra_atomica(bigint, uuid);
+
+CREATE FUNCTION public.anular_compra_atomica(p_compra_id bigint, p_usuario_id uuid)
+RETURNS jsonb
+LANGUAGE plpgsql SECURITY DEFINER
+SET search_path TO 'public'
+AS $$
+DECLARE
+  v_sucursal   BIGINT := current_sucursal_id();
+  v_user_role  TEXT;
+  v_compra     RECORD;
+  v_row        RECORD;
+  v_ult        RECORD;
+  v_neto       NUMERIC;
+  v_warnings   JSONB := '[]'::JSONB;
+  v_negativos  JSONB;
+BEGIN
+  IF v_sucursal IS NULL THEN
+    RETURN jsonb_build_object('success', false, 'error', 'No se pudo determinar la sucursal activa');
+  END IF;
+  IF p_usuario_id IS DISTINCT FROM auth.uid() THEN
+    RETURN jsonb_build_object('success', false, 'error', 'ID de usuario no coincide con la sesion autenticada');
+  END IF;
+
+  SELECT rol INTO v_user_role FROM perfiles WHERE id = p_usuario_id;
+  IF v_user_role IS NULL OR v_user_role NOT IN ('admin', 'encargado') THEN
+    RETURN jsonb_build_object('success', false, 'error', 'No autorizado: solo admin o encargado pueden anular compras');
+  END IF;
+
+  SELECT id, estado, tipo_factura, fecha_compra
+    INTO v_compra
+    FROM compras
+   WHERE id = p_compra_id AND sucursal_id = v_sucursal
+   FOR UPDATE;
+  IF NOT FOUND THEN
+    RETURN jsonb_build_object('success', false, 'error', 'Compra no encontrada');
+  END IF;
+  IF v_compra.estado = 'cancelada' THEN
+    RETURN jsonb_build_object('success', false, 'error', 'La compra ya está cancelada');
+  END IF;
+
+  PERFORM set_config('app.stock_origen', 'compra_anulada', true);
+  PERFORM set_config('app.stock_ref_tipo', 'compra', true);
+  PERFORM set_config('app.stock_ref_id', p_compra_id::TEXT, true);
+  PERFORM set_config('app.stock_user_id', p_usuario_id::TEXT, true);
+
+  -- Lock determinista de los productos afectados
+  PERFORM 1 FROM productos
+   WHERE sucursal_id = v_sucursal
+     AND id IN (SELECT producto_id FROM compra_items
+                 WHERE compra_id = p_compra_id AND sucursal_id = v_sucursal)
+   ORDER BY id
+   FOR UPDATE;
+
+  -- Chequeo de no-negatividad ANTES de tocar nada
+  SELECT jsonb_agg(jsonb_build_object('producto_id', p.id, 'nombre', p.nombre,
+                                      'stock', p.stock, 'reversa', q.qty))
+    INTO v_negativos
+    FROM (SELECT producto_id, SUM(cantidad)::INT AS qty
+            FROM compra_items
+           WHERE compra_id = p_compra_id AND sucursal_id = v_sucursal
+           GROUP BY producto_id) q
+    JOIN productos p ON p.id = q.producto_id AND p.sucursal_id = v_sucursal
+   WHERE p.stock - q.qty < 0;
+
+  IF v_negativos IS NOT NULL AND jsonb_array_length(v_negativos) > 0 THEN
+    RETURN jsonb_build_object('success', false, 'error',
+      'La anulación dejaría stock negativo en: ' ||
+      (SELECT string_agg((w->>'nombre') || ' (' || (w->>'stock') || ' − ' || (w->>'reversa') || ')', ', ')
+         FROM jsonb_array_elements(v_negativos) w));
+  END IF;
+
+  -- Reversa de stock
+  UPDATE productos p
+     SET stock = p.stock - q.qty,
+         updated_at = NOW()
+    FROM (SELECT producto_id, SUM(cantidad)::INT AS qty
+            FROM compra_items
+           WHERE compra_id = p_compra_id AND sucursal_id = v_sucursal
+           GROUP BY producto_id) q
+   WHERE p.id = q.producto_id AND p.sucursal_id = v_sucursal;
+
+  UPDATE compras
+     SET estado = 'cancelada', updated_at = NOW()
+   WHERE id = p_compra_id AND sucursal_id = v_sucursal;
+
+  -- Restauración de costo: solo para productos cuya ÚLTIMA compra válida era esta
+  FOR v_row IN
+    SELECT DISTINCT ci.producto_id
+      FROM compra_items ci
+     WHERE ci.compra_id = p_compra_id AND ci.sucursal_id = v_sucursal
+  LOOP
+    -- ¿Queda una compra más reciente o igual que ya gobierna el costo? Entonces nada.
+    SELECT c.tipo_factura, ci.costo_unitario, ci.bonificacion,
+           ci.impuestos_internos AS ii_linea, ci.porcentaje_iva AS iva_linea,
+           ci.costo_neto_unitario, ci.costo_real_unitario
+      INTO v_ult
+      FROM compra_items ci
+      JOIN compras c ON c.id = ci.compra_id
+     WHERE ci.producto_id = v_row.producto_id
+       AND ci.sucursal_id = v_sucursal
+       AND c.estado <> 'cancelada'
+       AND c.id <> p_compra_id
+       AND COALESCE(ci.bonificacion, 0) < 100
+       AND ci.costo_unitario > 0
+     ORDER BY c.fecha_compra DESC, c.id DESC
+     LIMIT 1;
+
+    IF FOUND THEN
+      v_neto := COALESCE(v_ult.costo_neto_unitario,
+                         v_ult.costo_unitario * (1 - COALESCE(v_ult.bonificacion, 0) / 100));
+      UPDATE productos p
+         SET costo_sin_iva      = v_neto,
+             costo_real         = COALESCE(v_ult.costo_real_unitario,
+                                    costo_real_unitario(v_neto, COALESCE(v_ult.ii_linea, p.impuestos_internos), v_ult.tipo_factura)),
+             costo_con_iva      = costo_financiero_unitario(
+                                    v_neto,
+                                    COALESCE(v_ult.iva_linea, p.porcentaje_iva),
+                                    COALESCE(v_ult.ii_linea, p.impuestos_internos),
+                                    v_ult.tipo_factura),
+             ultimo_tipo_compra = v_ult.tipo_factura,
+             updated_at         = NOW()
+       WHERE p.id = v_row.producto_id AND p.sucursal_id = v_sucursal;
+    ELSE
+      v_warnings := v_warnings || jsonb_build_object(
+        'producto_id', v_row.producto_id,
+        'warning', 'costo_no_restaurado: sin otra compra válida de referencia');
+    END IF;
+  END LOOP;
+
+  RETURN jsonb_build_object(
+    'success', true,
+    'compra_id', p_compra_id,
+    'warnings', CASE WHEN jsonb_array_length(v_warnings) > 0 THEN v_warnings ELSE NULL END
+  );
+EXCEPTION WHEN OTHERS THEN
+  RETURN jsonb_build_object('success', false, 'error', SQLERRM);
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.anular_compra_atomica(bigint, uuid) TO authenticated, service_role;
+REVOKE EXECUTE ON FUNCTION public.anular_compra_atomica(bigint, uuid) FROM anon, public;

--- a/src/components/modals/ModalCompra.tsx
+++ b/src/components/modals/ModalCompra.tsx
@@ -8,6 +8,8 @@ import React, { useReducer, useMemo, useCallback, useState, useEffect, useRef, l
 import type { ChangeEvent, FormEvent } from 'react'
 import { X, ShoppingCart, Plus, Trash2, Package, Building2, FileText, Calculator, Search, Loader2, Camera, CheckCircle, AlertTriangle } from 'lucide-react'
 import { formatPrecio, fechaLocalISO } from '../../utils/formatters'
+import { calcularTotalesCompra } from '../../utils/calculations'
+import type { TotalesCompra } from '../../utils/calculations'
 import NumberInput from '../ui/NumberInput'
 import { supabase } from '../../lib/supabase'
 import { CompactErrorBoundary } from '../ErrorBoundary'
@@ -105,8 +107,24 @@ function construirCompraItemDesdeScan(
   }
 }
 
+/** Totales impresos en la factura física, para el panel "Control contra factura" (0 = no cargado) */
+export interface ControlFactura {
+  gravado: number;
+  iva: number;
+  impuestosInternos: number;
+  percepciones: number;
+  total: number;
+}
+
 /** Estado del reducer de compra */
 export interface CompraState {
+  /** Percepción de IVA de la factura (crédito fiscal, no costo) — solo FC */
+  percepcionIva: number;
+  /** Percepción de IIBB de la factura (crédito fiscal, no costo) — solo FC */
+  percepcionIibb: number;
+  /** Conceptos no gravados (ej: pallets valorizados) — solo FC */
+  noGravado: number;
+  controlFactura: ControlFactura;
   proveedorId: string;
   proveedorNombre: string;
   usarProveedorNuevo: boolean;
@@ -157,7 +175,10 @@ type CompraActionType =
   | { type: 'RESOLVER_PENDIENTE_VINCULAR'; payload: { index: number; producto: ProductoDB } }
   | { type: 'RESOLVER_PENDIENTE_CREAR'; payload: { index: number; producto: ProductoDB } }
   | { type: 'RESOLVER_PENDIENTE_OMITIR'; payload: { index: number } }
-  | { type: 'LIMPIAR_PENDIENTES_SCAN' };
+  | { type: 'LIMPIAR_PENDIENTES_SCAN' }
+  | { type: 'SET_EXTRAS'; payload: Partial<Pick<CompraState, 'percepcionIva' | 'percepcionIibb' | 'noGravado'>> }
+  | { type: 'SET_CONTROL'; payload: Partial<ControlFactura> }
+  | { type: 'APLICAR_BONIF_GLOBAL'; payload: number };
 
 /** Props del componente principal */
 export interface ModalCompraProps {
@@ -212,22 +233,9 @@ interface ItemRowProps {
 
 /** Props de ResumenSection */
 interface ResumenSectionProps {
-  subtotalBruto: number;
-  bonificacionTotal: number;
-  subtotal: number;
-  iva: number;
-  impuestosInternos: number;
-  total: number;
-}
-
-/** Return type del hook de cálculos */
-interface CalculosImpuestos {
-  subtotalBruto: number;
-  bonificacionTotal: number;
-  subtotal: number;
-  iva: number;
-  impuestosInternos: number;
-  total: number;
+  totales: TotalesCompra;
+  state: CompraState;
+  dispatch: React.Dispatch<CompraActionType>;
 }
 
 // Constantes
@@ -243,6 +251,11 @@ const FORMAS_PAGO = [
 
 // Estado inicial
 const initialState: CompraState = {
+  // Desglose fiscal extra (solo FC)
+  percepcionIva: 0,
+  percepcionIibb: 0,
+  noGravado: 0,
+  controlFactura: { gravado: 0, iva: 0, impuestosInternos: 0, percepciones: 0, total: 0 },
   // Proveedor
   proveedorId: '',
   proveedorNombre: '',
@@ -439,36 +452,37 @@ function compraReducer(state: CompraState, action: CompraActionType): CompraStat
     case 'LIMPIAR_PENDIENTES_SCAN':
       return { ...state, itemsPendientesScan: [] }
 
+    case 'SET_EXTRAS':
+      return { ...state, ...action.payload }
+
+    case 'SET_CONTROL':
+      return { ...state, controlFactura: { ...state.controlFactura, ...action.payload } }
+
+    case 'APLICAR_BONIF_GLOBAL':
+      return {
+        ...state,
+        items: state.items.map(item => ({ ...item, bonificacion: action.payload }))
+      }
+
     default:
       return state
   }
 }
 
-// Hook para cálculos de impuestos (bonificacion e imp. internos como porcentaje)
-function useCalculosImpuestos(items: CompraItemForm[], tipoFactura: 'ZZ' | 'FC' = 'FC'): CalculosImpuestos {
-  return useMemo(() => {
-    let subtotalBruto = 0
-    let bonificacionTotal = 0
-    let iva = 0
-    let impuestosInternos = 0
-
-    for (const item of items) {
-      const bruto = item.cantidad * item.costoUnitario
-      const bonif = bruto * (item.bonificacion || 0) / 100
-      const neto = bruto - bonif
-      subtotalBruto += bruto
-      bonificacionTotal += bonif
-      // ZZ: no hay IVA discriminado
-      if (tipoFactura === 'FC') {
-        iva += neto * ((item.porcentajeIva ?? 21) / 100)
-      }
-      impuestosInternos += neto * ((item.impuestosInternos || 0) / 100)
-    }
-
-    const subtotal = subtotalBruto - bonificacionTotal
-    const total = subtotal + iva + impuestosInternos
-    return { subtotalBruto, bonificacionTotal, subtotal, iva, impuestosInternos, total }
-  }, [items, tipoFactura])
+// Hook para cálculos de impuestos: delega en calcularTotalesCompra (fuente
+// única, testeada con la factura Manaos). ZZ: lo pagado es todo (sin IVA, II
+// ni percepciones).
+function useCalculosImpuestos(
+  items: CompraItemForm[],
+  tipoFactura: 'ZZ' | 'FC',
+  percepcionIva: number,
+  percepcionIibb: number,
+  noGravado: number
+): TotalesCompra {
+  return useMemo(
+    () => calcularTotalesCompra(items, tipoFactura, { percepcionIva, percepcionIibb, noGravado }),
+    [items, tipoFactura, percepcionIva, percepcionIibb, noGravado]
+  )
 }
 
 const N8N_FACTURA_WEBHOOK_URL: string = import.meta.env.VITE_N8N_FACTURA_WEBHOOK_URL || ''
@@ -478,7 +492,8 @@ export default function ModalCompra({ productos, proveedores, onSave, onClose, o
   const [state, dispatch] = useReducer(compraReducer, initialState)
   const [modalProveedorOpen, setModalProveedorOpen] = useState(false)
   const [modalImportarOpen, setModalImportarOpen] = useState(false)
-  const { subtotalBruto, bonificacionTotal, subtotal, iva, impuestosInternos, total } = useCalculosImpuestos(state.items, state.tipoFactura)
+  const totales = useCalculosImpuestos(state.items, state.tipoFactura, state.percepcionIva, state.percepcionIibb, state.noGravado)
+  const { subtotal, iva, impuestosInternos, total } = totales
   const fileInputRef = useRef<HTMLInputElement>(null)
 
   // Productos filtrados
@@ -638,7 +653,11 @@ export default function ModalCompra({ productos, proveedores, onSave, onClose, o
         fechaCompra: state.fechaCompra,
         subtotal,
         iva,
-        otrosImpuestos: impuestosInternos,
+        impuestosInternos,
+        percepcionIva: state.tipoFactura === 'FC' ? state.percepcionIva : 0,
+        percepcionIibb: state.tipoFactura === 'FC' ? state.percepcionIibb : 0,
+        noGravado: state.tipoFactura === 'FC' ? state.noGravado : 0,
+        otrosImpuestos: 0,
         total,
         formaPago: state.formaPago,
         notas: state.notas,
@@ -786,14 +805,7 @@ export default function ModalCompra({ productos, proveedores, onSave, onClose, o
 
             {/* Totales */}
             {state.items.length > 0 && (
-              <ResumenSection
-                subtotalBruto={subtotalBruto}
-                bonificacionTotal={bonificacionTotal}
-                subtotal={subtotal}
-                iva={iva}
-                impuestosInternos={impuestosInternos}
-                total={total}
-              />
+              <ResumenSection totales={totales} state={state} dispatch={dispatch} />
             )}
 
             {/* Notas */}
@@ -1750,13 +1762,124 @@ function ItemPendienteRow({
   )
 }
 
-function ResumenSection({ subtotalBruto, bonificacionTotal, subtotal, iva, impuestosInternos, total }: ResumenSectionProps) {
+/** Fila del panel de control: calculado vs impreso en la factura */
+function ControlRow({ label, calculado, impreso, onChange }: {
+  label: string;
+  calculado: number;
+  impreso: number;
+  onChange: (n: number) => void;
+}) {
+  const cargado = impreso > 0
+  const diff = impreso - calculado
+  const ok = Math.abs(diff) <= 1
   return (
-    <div className="bg-green-50 dark:bg-green-900/20 rounded-lg p-4">
-      <div className="flex items-center gap-2 mb-3">
-        <Calculator className="w-5 h-5 text-green-600" />
-        <h3 className="font-medium text-gray-800 dark:text-white">Resumen</h3>
+    <div className="grid grid-cols-12 gap-2 items-center text-sm">
+      <span className="col-span-4 text-gray-600 dark:text-gray-400">{label}</span>
+      <span className="col-span-3 text-right text-gray-800 dark:text-white">{formatPrecio(calculado)}</span>
+      <div className="col-span-3">
+        <NumberInput
+          min={0}
+          emptyValue={0}
+          value={impreso}
+          onChange={onChange}
+          commitOnChange
+          className="w-full px-2 py-1 text-right border dark:border-gray-600 rounded dark:bg-gray-700 dark:text-white text-sm"
+          placeholder="factura"
+        />
       </div>
+      <span className={`col-span-2 text-right text-xs font-medium ${!cargado ? 'text-gray-400' : ok ? 'text-green-600' : 'text-red-600'}`}>
+        {!cargado ? '—' : ok ? '✓' : formatPrecio(diff)}
+      </span>
+    </div>
+  )
+}
+
+function ResumenSection({ totales, state, dispatch }: ResumenSectionProps) {
+  const { subtotalBruto, bonificacionTotal, subtotal, iva, impuestosInternos, percepcionIva, percepcionIibb, noGravado, total } = totales
+  const esFC = state.tipoFactura === 'FC'
+  const [bonifGlobal, setBonifGlobal] = useState(0)
+  const [mostrarControl, setMostrarControl] = useState(false)
+  const ctrl = state.controlFactura
+  const percepcionesCalc = percepcionIva + percepcionIibb
+
+  return (
+    <div className="bg-green-50 dark:bg-green-900/20 rounded-lg p-4 space-y-4">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <Calculator className="w-5 h-5 text-green-600" />
+          <h3 className="font-medium text-gray-800 dark:text-white">Resumen</h3>
+        </div>
+        {/* Bonificación global (ej: 0,60% de Refres Now) aplicada a todas las líneas */}
+        <div className="flex items-center gap-1.5">
+          <span className="text-xs text-gray-500">Bonif. global %</span>
+          <NumberInput
+            min={0}
+            max={100}
+            emptyValue={0}
+            value={bonifGlobal}
+            onChange={setBonifGlobal}
+            commitOnChange
+            className="w-16 px-2 py-1 text-center border dark:border-gray-600 rounded dark:bg-gray-700 dark:text-white text-sm"
+          />
+          <button
+            type="button"
+            onClick={() => dispatch({ type: 'APLICAR_BONIF_GLOBAL', payload: bonifGlobal })}
+            className="px-2 py-1 text-xs bg-green-600 text-white rounded hover:bg-green-700"
+          >
+            Aplicar
+          </button>
+        </div>
+      </div>
+
+      {esFC && (
+        <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
+          <div>
+            <label className="block text-xs text-gray-500 mb-1">
+              Percepción IVA
+              <button
+                type="button"
+                onClick={() => dispatch({ type: 'SET_EXTRAS', payload: { percepcionIva: Math.round(subtotal * 3) / 100 } })}
+                className="ml-2 text-blue-600 hover:underline"
+                title="RG 5329: 3% sobre el gravado"
+              >
+                3% del gravado
+              </button>
+            </label>
+            <NumberInput
+              min={0}
+              emptyValue={0}
+              value={state.percepcionIva}
+              onChange={(n) => dispatch({ type: 'SET_EXTRAS', payload: { percepcionIva: n } })}
+              commitOnChange
+              className="w-full px-2 py-1.5 border dark:border-gray-600 rounded dark:bg-gray-700 dark:text-white text-sm"
+            />
+          </div>
+          <div>
+            <label className="block text-xs text-gray-500 mb-1">Percepción IIBB</label>
+            <NumberInput
+              min={0}
+              emptyValue={0}
+              value={state.percepcionIibb}
+              onChange={(n) => dispatch({ type: 'SET_EXTRAS', payload: { percepcionIibb: n } })}
+              commitOnChange
+              className="w-full px-2 py-1.5 border dark:border-gray-600 rounded dark:bg-gray-700 dark:text-white text-sm"
+            />
+          </div>
+          <div>
+            <label className="block text-xs text-gray-500 mb-1" title="Conceptos fuera del IVA (ej: pallets/separadores valorizados)">
+              No gravado
+            </label>
+            <NumberInput
+              min={0}
+              emptyValue={0}
+              value={state.noGravado}
+              onChange={(n) => dispatch({ type: 'SET_EXTRAS', payload: { noGravado: n } })}
+              commitOnChange
+              className="w-full px-2 py-1.5 border dark:border-gray-600 rounded dark:bg-gray-700 dark:text-white text-sm"
+            />
+          </div>
+        </div>
+      )}
 
       <div className="space-y-2">
         {bonificacionTotal > 0 && (
@@ -1772,17 +1895,31 @@ function ResumenSection({ subtotalBruto, bonificacionTotal, subtotal, iva, impue
           </>
         )}
         <div className="flex justify-between text-sm">
-          <span className="text-gray-600 dark:text-gray-400">Subtotal Neto:</span>
+          <span className="text-gray-600 dark:text-gray-400">{esFC ? 'Gravado (neto):' : 'Subtotal Neto:'}</span>
           <span className="font-medium text-gray-800 dark:text-white">{formatPrecio(subtotal)}</span>
         </div>
-        <div className="flex justify-between text-sm">
-          <span className="text-gray-600 dark:text-gray-400">IVA (sobre neto):</span>
-          <span className="font-medium text-gray-800 dark:text-white">{formatPrecio(iva)}</span>
-        </div>
+        {esFC && (
+          <div className="flex justify-between text-sm">
+            <span className="text-gray-600 dark:text-gray-400">IVA (sobre neto):</span>
+            <span className="font-medium text-gray-800 dark:text-white">{formatPrecio(iva)}</span>
+          </div>
+        )}
         {impuestosInternos > 0 && (
           <div className="flex justify-between text-sm">
             <span className="text-gray-600 dark:text-gray-400">Impuestos Internos:</span>
             <span className="font-medium text-gray-800 dark:text-white">{formatPrecio(impuestosInternos)}</span>
+          </div>
+        )}
+        {percepcionesCalc > 0 && (
+          <div className="flex justify-between text-sm">
+            <span className="text-gray-600 dark:text-gray-400">Percepciones (IVA + IIBB):</span>
+            <span className="font-medium text-gray-800 dark:text-white">{formatPrecio(percepcionesCalc)}</span>
+          </div>
+        )}
+        {noGravado > 0 && (
+          <div className="flex justify-between text-sm">
+            <span className="text-gray-600 dark:text-gray-400">No gravado:</span>
+            <span className="font-medium text-gray-800 dark:text-white">{formatPrecio(noGravado)}</span>
           </div>
         )}
         <div className="flex justify-between text-lg font-bold pt-2 border-t dark:border-gray-600">
@@ -1790,6 +1927,43 @@ function ResumenSection({ subtotalBruto, bonificacionTotal, subtotal, iva, impue
           <span className="text-green-600">{formatPrecio(total)}</span>
         </div>
       </div>
+
+      {/* Control contra factura: reemplaza las columnas "control" del Excel */}
+      {esFC && (
+        <div className="pt-2 border-t dark:border-gray-700">
+          <button
+            type="button"
+            onClick={() => setMostrarControl(v => !v)}
+            className="text-sm text-blue-600 hover:underline"
+          >
+            {mostrarControl ? 'Ocultar control contra factura' : 'Control contra factura ▸'}
+          </button>
+          {mostrarControl && (
+            <div className="mt-2 space-y-1.5">
+              <div className="grid grid-cols-12 gap-2 text-xs text-gray-500">
+                <span className="col-span-4">Concepto</span>
+                <span className="col-span-3 text-right">Calculado</span>
+                <span className="col-span-3 text-right">Factura dice</span>
+                <span className="col-span-2 text-right">Dif.</span>
+              </div>
+              <ControlRow label="Gravado" calculado={subtotal} impreso={ctrl.gravado}
+                onChange={(n) => dispatch({ type: 'SET_CONTROL', payload: { gravado: n } })} />
+              <ControlRow label="IVA" calculado={iva} impreso={ctrl.iva}
+                onChange={(n) => dispatch({ type: 'SET_CONTROL', payload: { iva: n } })} />
+              <ControlRow label="Imp. internos" calculado={impuestosInternos} impreso={ctrl.impuestosInternos}
+                onChange={(n) => dispatch({ type: 'SET_CONTROL', payload: { impuestosInternos: n } })} />
+              <ControlRow label="Percepciones" calculado={percepcionesCalc} impreso={ctrl.percepciones}
+                onChange={(n) => dispatch({ type: 'SET_CONTROL', payload: { percepciones: n } })} />
+              <ControlRow label="TOTAL" calculado={total} impreso={ctrl.total}
+                onChange={(n) => dispatch({ type: 'SET_CONTROL', payload: { total: n } })} />
+              <p className="text-xs text-gray-500 pt-1">
+                Tipeá los totales impresos en la factura: si una diferencia no da ✓ (± $1), revisá
+                bonificaciones, tasas de II del producto o el no gravado antes de registrar.
+              </p>
+            </div>
+          )}
+        </div>
+      )}
     </div>
   )
 }

--- a/src/components/modals/ModalDetalleCompra.tsx
+++ b/src/components/modals/ModalDetalleCompra.tsx
@@ -49,6 +49,10 @@ interface CompraDetalle {
   forma_pago: FormaPagoCompra;
   subtotal: number;
   iva: number;
+  impuestos_internos?: number;
+  percepcion_iva?: number;
+  percepcion_iibb?: number;
+  no_gravado?: number;
   otros_impuestos?: number;
   total: number;
   notas?: string;
@@ -247,6 +251,30 @@ export default function ModalDetalleCompra({
                 <span className="text-gray-600 dark:text-gray-400">IVA:</span>
                 <span className="font-medium text-gray-800 dark:text-white">{formatPrecio(compra.iva)}</span>
               </div>
+              {(compra.impuestos_internos ?? 0) > 0 && (
+                <div className="flex justify-between text-sm">
+                  <span className="text-gray-600 dark:text-gray-400">Impuestos internos:</span>
+                  <span className="font-medium text-gray-800 dark:text-white">{formatPrecio(compra.impuestos_internos!)}</span>
+                </div>
+              )}
+              {(compra.percepcion_iva ?? 0) > 0 && (
+                <div className="flex justify-between text-sm">
+                  <span className="text-gray-600 dark:text-gray-400">Percepción IVA:</span>
+                  <span className="font-medium text-gray-800 dark:text-white">{formatPrecio(compra.percepcion_iva!)}</span>
+                </div>
+              )}
+              {(compra.percepcion_iibb ?? 0) > 0 && (
+                <div className="flex justify-between text-sm">
+                  <span className="text-gray-600 dark:text-gray-400">Percepción IIBB:</span>
+                  <span className="font-medium text-gray-800 dark:text-white">{formatPrecio(compra.percepcion_iibb!)}</span>
+                </div>
+              )}
+              {(compra.no_gravado ?? 0) > 0 && (
+                <div className="flex justify-between text-sm">
+                  <span className="text-gray-600 dark:text-gray-400">No gravado:</span>
+                  <span className="font-medium text-gray-800 dark:text-white">{formatPrecio(compra.no_gravado!)}</span>
+                </div>
+              )}
               {compra.otros_impuestos && compra.otros_impuestos > 0 && (
                 <div className="flex justify-between text-sm">
                   <span className="text-gray-600 dark:text-gray-400">Otros impuestos:</span>

--- a/src/components/modals/ModalEditarCompra.tsx
+++ b/src/components/modals/ModalEditarCompra.tsx
@@ -53,6 +53,9 @@ const ModalEditarCompra = memo(function ModalEditarCompra({
 }: ModalEditarCompraProps) {
   const esZZ = compra.tipo_factura === 'ZZ'
   const otrosImpuestos = compra.otros_impuestos ?? 0
+  // Percepciones y no gravado (cabecera) no se editan acá: se conservan.
+  const percepciones = (compra.percepcion_iva ?? 0) + (compra.percepcion_iibb ?? 0)
+  const noGravado = compra.no_gravado ?? 0
 
   const [items, setItems] = useState<ItemEdit[]>(() =>
     (compra.items ?? []).map((it) => ({
@@ -61,11 +64,10 @@ const ModalEditarCompra = memo(function ModalEditarCompra({
       cantidad: it.cantidad ?? 0,
       costoUnitario: it.costo_unitario ?? 0,
       bonificacion: it.bonificacion ?? 0,
-      // CompraItemDBExtended no expone porcentaje_iva/impuestos_internos por
-      // ahora — usamos defaults razonables al editar. Si en el futuro el
-      // select trae esos campos, se pueden leer del producto/compra.
-      porcentajeIva: esZZ ? 0 : 21,
-      impuestosInternos: 0,
+      // Snapshot de la línea (mig 113); líneas viejas caen a los atributos
+      // fiscales actuales del producto y por último a defaults.
+      porcentajeIva: esZZ ? 0 : (it.porcentaje_iva ?? it.producto?.porcentaje_iva ?? 21),
+      impuestosInternos: esZZ ? 0 : (it.impuestos_internos ?? it.producto?.impuestos_internos ?? 0),
       marcadoParaEliminar: false,
     })),
   )
@@ -75,21 +77,24 @@ const ModalEditarCompra = memo(function ModalEditarCompra({
   // Items que efectivamente se persisten (los no eliminados).
   const itemsActivos = useMemo(() => items.filter((i) => !i.marcadoParaEliminar), [items])
 
-  // Totales calculados.
+  // Totales calculados (incluye imp. internos por línea; percepciones y no
+  // gravado de la cabecera se conservan tal cual).
   const totales = useMemo(() => {
     let subtotal = 0
     let iva = 0
+    let impuestosInternos = 0
     for (const it of itemsActivos) {
       const netoUnitario = it.costoUnitario * (1 - it.bonificacion / 100)
       const subtotalItem = it.cantidad * netoUnitario
       subtotal += subtotalItem
       if (!esZZ) {
         iva += subtotalItem * (it.porcentajeIva / 100)
+        impuestosInternos += subtotalItem * ((it.impuestosInternos || 0) / 100)
       }
     }
-    const total = subtotal + iva + otrosImpuestos
-    return { subtotal, iva, total }
-  }, [itemsActivos, esZZ, otrosImpuestos])
+    const total = subtotal + iva + impuestosInternos + percepciones + noGravado + otrosImpuestos
+    return { subtotal, iva, impuestosInternos, total }
+  }, [itemsActivos, esZZ, otrosImpuestos, percepciones, noGravado])
 
   function updateItem<K extends keyof ItemEdit>(productoId: string, field: K, value: ItemEdit[K]) {
     setItems((prev) =>
@@ -154,6 +159,7 @@ const ModalEditarCompra = memo(function ModalEditarCompra({
       subtotal: totales.subtotal,
       iva: totales.iva,
       total: totales.total,
+      impuestosInternos: totales.impuestosInternos,
       items: itemsPayload,
     })
   }
@@ -297,6 +303,24 @@ const ModalEditarCompra = memo(function ModalEditarCompra({
             <span>IVA{esZZ ? ' (ZZ → 0)' : ''}</span>
             <span className="tabular-nums">{formatPrecio(totales.iva)}</span>
           </div>
+          {totales.impuestosInternos > 0 && (
+            <div className="flex justify-between dark:text-gray-300">
+              <span>Impuestos internos</span>
+              <span className="tabular-nums">{formatPrecio(totales.impuestosInternos)}</span>
+            </div>
+          )}
+          {percepciones > 0 && (
+            <div className="flex justify-between dark:text-gray-300">
+              <span>Percepciones (sin cambio)</span>
+              <span className="tabular-nums">{formatPrecio(percepciones)}</span>
+            </div>
+          )}
+          {noGravado > 0 && (
+            <div className="flex justify-between dark:text-gray-300">
+              <span>No gravado (sin cambio)</span>
+              <span className="tabular-nums">{formatPrecio(noGravado)}</span>
+            </div>
+          )}
           {otrosImpuestos > 0 && (
             <div className="flex justify-between dark:text-gray-300">
               <span>Otros impuestos (sin cambio)</span>

--- a/src/hooks/queries/useComprasQuery.ts
+++ b/src/hooks/queries/useComprasQuery.ts
@@ -114,7 +114,11 @@ async function registrarCompra(compraData: CompraFormInputExtended): Promise<Reg
     p_notas: compraData.notas || null,
     p_usuario_id: compraData.usuarioId || null,
     p_items: itemsParaRPC,
-    p_tipo_factura: compraData.tipoFactura || 'FC'
+    p_tipo_factura: compraData.tipoFactura || 'FC',
+    p_impuestos_internos: compraData.impuestosInternos || 0,
+    p_percepcion_iva: compraData.percepcionIva || 0,
+    p_percepcion_iibb: compraData.percepcionIibb || 0,
+    p_no_gravado: compraData.noGravado || 0
   })
 
   if (error) throw error
@@ -127,40 +131,25 @@ async function registrarCompra(compraData: CompraFormInputExtended): Promise<Reg
   return { success: true, compraId: result.compra_id }
 }
 
-async function anularCompra(compraId: string, compras: CompraDBExtended[]): Promise<void> {
-  const compra = compras.find(c => c.id === compraId)
-  if (!compra) throw new Error('Compra no encontrada')
+/**
+ * Anula una compra via RPC atómico (mig 115): reversa de stock con invariante
+ * de no-negatividad + restauración del costo del producto desde la última
+ * compra restante. Reemplaza el loop client-side no atómico que clampeaba el
+ * stock en 0 (perdía reversa) y no restauraba costos.
+ */
+async function anularCompra(compraId: string): Promise<void> {
+  const { data: { user } } = await supabase.auth.getUser()
 
-  // Obtener stock ACTUAL de todos los productos afectados
-  const productIds = (compra.items || []).map(i => i.producto_id).filter(Boolean)
-  if (productIds.length > 0) {
-    const { data: productosActuales } = await supabase
-      .from('productos')
-      .select('id, stock')
-      .in('id', productIds)
-
-    const stockMap: Record<string, number> = Object.fromEntries(
-      ((productosActuales || []) as Array<{ id: string; stock: number }>).map(p => [p.id, p.stock || 0])
-    )
-
-    // Revertir stock de cada item (restar del stock ACTUAL)
-    for (const item of (compra.items || [])) {
-      const stockActual = stockMap[item.producto_id] || 0
-      const nuevoStock = stockActual - item.cantidad
-      await supabase
-        .from('productos')
-        .update({ stock: Math.max(0, nuevoStock) })
-        .eq('id', item.producto_id)
-    }
-  }
-
-  // Marcar compra como cancelada
-  const { error } = await supabase
-    .from('compras')
-    .update({ estado: 'cancelada' })
-    .eq('id', compraId)
+  const { data, error } = await supabase.rpc('anular_compra_atomica', {
+    p_compra_id: compraId,
+    p_usuario_id: user?.id ?? null,
+  })
 
   if (error) throw error
+  const result = data as { success: boolean; error?: string }
+  if (!result.success) {
+    throw new Error(result.error || 'Error al anular la compra')
+  }
 }
 
 // Hooks
@@ -230,6 +219,11 @@ export interface ActualizarCompraItemsInput {
   subtotal: number
   iva: number
   total: number
+  /** Cabecera fiscal (mig 114). undefined = conservar el valor actual. */
+  impuestosInternos?: number
+  percepcionIva?: number
+  percepcionIibb?: number
+  noGravado?: number
   items: Array<{
     productoId: string
     cantidad: number
@@ -259,6 +253,10 @@ async function actualizarCompraItems(input: ActualizarCompraItemsInput): Promise
     p_iva: input.iva,
     p_total: input.total,
     p_usuario_id: input.usuarioId,
+    p_impuestos_internos: input.impuestosInternos ?? null,
+    p_percepcion_iva: input.percepcionIva ?? null,
+    p_percepcion_iibb: input.percepcionIibb ?? null,
+    p_no_gravado: input.noGravado ?? null,
   })
 
   if (error) throw error
@@ -295,8 +293,7 @@ export function useAnularCompraMutation() {
 
   return useMutation({
     mutationFn: async (compraId: string) => {
-      const compras = queryClient.getQueryData<CompraDBExtended[]>(comprasKeys.lists(currentSucursalId)) || []
-      await anularCompra(compraId, compras)
+      await anularCompra(compraId)
       return compraId
     },
     // Optimistic update

--- a/src/types/hooks.ts
+++ b/src/types/hooks.ts
@@ -865,6 +865,11 @@ export interface CompraItemDBExtended {
   costo_unitario: number;
   subtotal?: number;
   bonificacion?: number;
+  /** Snapshots fiscales por línea (mig 113); NULL en líneas previas */
+  porcentaje_iva?: number | null;
+  impuestos_internos?: number | null;
+  costo_neto_unitario?: number | null;
+  costo_real_unitario?: number | null;
 }
 
 export interface CompraDBExtended {
@@ -878,6 +883,11 @@ export interface CompraDBExtended {
   fecha_compra?: string;
   subtotal?: number;
   iva?: number;
+  /** Desglose fiscal de cabecera (mig 113) */
+  impuestos_internos?: number;
+  percepcion_iva?: number;
+  percepcion_iibb?: number;
+  no_gravado?: number;
   otros_impuestos?: number;
   total: number;
   forma_pago?: string;
@@ -895,6 +905,11 @@ export interface CompraFormInputExtended {
   fechaCompra?: string;
   subtotal?: number;
   iva?: number;
+  /** Desglose fiscal de cabecera (mig 113/114). Percepciones y no gravado NO integran costo. */
+  impuestosInternos?: number;
+  percepcionIva?: number;
+  percepcionIibb?: number;
+  noGravado?: number;
   otrosImpuestos?: number;
   total?: number;
   formaPago?: string;

--- a/src/utils/calculations.fiscal.test.ts
+++ b/src/utils/calculations.fiscal.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { calcularCostoReal, calcularCostoFinanciero, calcularNetoVenta } from './calculations'
+import { calcularCostoReal, calcularCostoFinanciero, calcularNetoVenta, calcularTotalesCompra } from './calculations'
 
 // Fixture: factura A 0005-00455160 de Refres Now (Manaos) → T.P. Export,
 // 16/06/2026. Tasas efectivas de imp. internos sobre el neto:
@@ -57,5 +57,35 @@ describe('calcularNetoVenta con impuestos internos (estructura de la factura)', 
     expect(calcularNetoVenta(10000, 21, 8.6956, 'ZZ')).toEqual({
       neto: 10000, iva: 0, impuestosInternos: 0,
     })
+  })
+})
+
+describe('calcularTotalesCompra (estructura de la factura A)', () => {
+  const items = [
+    // MANAOS COLA 3000cc: 240 packs, bonif 0,60%, II 8,6956%
+    { cantidad: 240, costoUnitario: 5397.25, bonificacion: 0.6, porcentajeIva: 21, impuestosInternos: 8.6956 },
+    // AGUA S/G 600: 120 packs, bonif 0,60%, II 4,1667%
+    { cantidad: 120, costoUnitario: 2796.27, bonificacion: 0.6, porcentajeIva: 21, impuestosInternos: 4.1667 },
+    // SODA SIFON: sin II
+    { cantidad: 150, costoUnitario: 5123.97, bonificacion: 0.6, porcentajeIva: 21, impuestosInternos: 0 },
+  ]
+
+  it('FC: total = gravado + IVA + II + percepciones + no gravado', () => {
+    const t = calcularTotalesCompra(items, 'FC', { percepcionIva: 1000, percepcionIibb: 500, noGravado: 2000 })
+    const gravadoEsperado = 240 * 5397.25 * 0.994 + 120 * 2796.27 * 0.994 + 150 * 5123.97 * 0.994
+    expect(t.subtotal).toBeCloseTo(gravadoEsperado, 2)
+    expect(t.iva).toBeCloseTo(gravadoEsperado * 0.21, 0)
+    expect(t.impuestosInternos).toBeCloseTo(
+      240 * 5397.25 * 0.994 * 0.086956 + 120 * 2796.27 * 0.994 * 0.041667, 2)
+    expect(t.total).toBeCloseTo(t.subtotal + t.iva + t.impuestosInternos + 1000 + 500 + 2000, 2)
+  })
+
+  it('ZZ: lo pagado es todo — sin IVA, II ni extras aunque vengan cargados', () => {
+    const t = calcularTotalesCompra(items, 'ZZ', { percepcionIva: 1000, noGravado: 2000 })
+    expect(t.iva).toBe(0)
+    expect(t.impuestosInternos).toBe(0)
+    expect(t.percepcionIva).toBe(0)
+    expect(t.noGravado).toBe(0)
+    expect(t.total).toBeCloseTo(t.subtotal, 2)
   })
 })

--- a/src/utils/calculations.ts
+++ b/src/utils/calculations.ts
@@ -166,6 +166,84 @@ export function calcularCostoFinanciero(
 }
 
 // ============================================
+// CÁLCULOS DE COMPRAS (desglose fiscal completo)
+// ============================================
+
+export interface CompraItemCalculo {
+  cantidad: number;
+  costoUnitario: number;
+  bonificacion?: number;
+  porcentajeIva?: number;
+  /** Tasa efectiva de imp. internos (%) */
+  impuestosInternos?: number;
+}
+
+export interface CompraExtras {
+  percepcionIva?: number;
+  percepcionIibb?: number;
+  noGravado?: number;
+  otrosImpuestos?: number;
+}
+
+export interface TotalesCompra {
+  subtotalBruto: number;
+  bonificacionTotal: number;
+  /** Neto gravado (bruto − bonif) */
+  subtotal: number;
+  iva: number;
+  impuestosInternos: number;
+  percepcionIva: number;
+  percepcionIibb: number;
+  noGravado: number;
+  otrosImpuestos: number;
+  total: number;
+}
+
+/**
+ * Totales de una compra según tipo de comprobante (fuente única del modal de
+ * compras; estructura = factura A real: total = gravado + IVA + II +
+ * percepciones + no gravado + otros).
+ *
+ * ZZ (sin factura): lo pagado es todo — sin IVA, sin II, sin percepciones ni
+ * no gravado. total = subtotal.
+ */
+export function calcularTotalesCompra(
+  items: CompraItemCalculo[],
+  tipoFactura: 'ZZ' | 'FC' = 'FC',
+  extras: CompraExtras = {}
+): TotalesCompra {
+  let subtotalBruto = 0;
+  let bonificacionTotal = 0;
+  let iva = 0;
+  let impuestosInternos = 0;
+
+  for (const item of items) {
+    const bruto = (item.cantidad || 0) * (item.costoUnitario || 0);
+    const bonif = bruto * (item.bonificacion || 0) / 100;
+    const neto = bruto - bonif;
+    subtotalBruto += bruto;
+    bonificacionTotal += bonif;
+    if (tipoFactura === 'FC') {
+      iva += neto * ((item.porcentajeIva ?? 21) / 100);
+      impuestosInternos += neto * ((item.impuestosInternos || 0) / 100);
+    }
+  }
+
+  const subtotal = subtotalBruto - bonificacionTotal;
+  const esFC = tipoFactura === 'FC';
+  const percepcionIva = esFC ? (extras.percepcionIva || 0) : 0;
+  const percepcionIibb = esFC ? (extras.percepcionIibb || 0) : 0;
+  const noGravado = esFC ? (extras.noGravado || 0) : 0;
+  const otrosImpuestos = esFC ? (extras.otrosImpuestos || 0) : 0;
+  const total = subtotal + iva + impuestosInternos + percepcionIva + percepcionIibb + noGravado + otrosImpuestos;
+
+  return {
+    subtotalBruto, bonificacionTotal, subtotal, iva, impuestosInternos,
+    percepcionIva, percepcionIibb, noGravado, otrosImpuestos, total,
+  };
+}
+
+// ============================================
 // CÁLCULOS DE PEDIDOS
 // ============================================
 
@@ -331,6 +409,7 @@ export default {
   calcularNetoVenta,
   calcularCostoReal,
   calcularCostoFinanciero,
+  calcularTotalesCompra,
   calcularSubtotalItem,
   calcularTotalPedido,
   calcularMargenPorcentaje,


### PR DESCRIPTION
## Fase B del rediseño fiscal (2 de 4) — apilado sobre #420

### Cambios
- **mig 113** (APLICADA): `compras.{impuestos_internos, percepcion_iva, percepcion_iibb, no_gravado}` (backfill: el II que vivía en `otros_impuestos` se movió a su columna); `compra_items` snapshotea tasa IVA/II y `costo_neto/real_unitario` por línea → historial de costos confiable.
- **mig 114** (APLICADA): `registrar_compra_completa` consolidado en UNA función de 17 args (4 nuevos con DEFAULT → PWA viejas siguen andando) + `warning_descuadre` (±$1) + persiste el desglose por línea; `actualizar_compra_items` con cabecera fiscal opcional (NULL = conservar). ZZ fuerza IVA/II/percepciones/no gravado a 0.
- **mig 115** (APLICADA): `anular_compra_atomica` v2 — atómico, multi-tenant, rechaza stock negativo y **restaura el costo del producto** desde la última compra restante (el anular anterior era un loop client-side que clampeaba stock en 0 y dejaba el costo de la compra anulada).
- **ModalCompra**: percepción IVA con atajo "3% del gravado" (RG 5329), percepción IIBB, no gravado (solo FC); **panel "Control contra factura"** — tipeás los totales impresos y ves la diferencia por concepto (reemplaza las columnas de control del Excel); **bonif. global %** para el 0,60% de Refres Now; fix: en ZZ no se suma II.
- `calcularTotalesCompra` como fuente única (2 tests nuevos, 10 en total); ModalEditarCompra usa snapshots de línea + II en totales; ModalDetalleCompra muestra el desglose.

### Cómo cargar la factura Manaos de punta a punta
Items con precio de lista + bonif global 0,60% → II se calcula solo desde las tasas del producto (Fase A) → percepción con el atajo 3% → no gravado 179.600 (pallets) → el panel de control debe dar ✓ contra Gravado 8.600.831,72 / IVA 1.806.174,66 / II 540.353,02 / Percepción 258.024,95 / Total 11.384.984,35. La bonificación promo (−51 packs) se carga subiendo la bonif % de las líneas 3000cc (como hace el Excel), no como línea con cantidad negativa.

🤖 Generated with [Claude Code](https://claude.com/claude-code)