### PR TITLE
feat(reportes): Fase D — venta neta, posición fiscal FC/ZZ y costo canónico

### DIFF
--- a/migrations/119_mermas_costo_snapshot.sql
+++ b/migrations/119_mermas_costo_snapshot.sql
@@ -1,0 +1,38 @@
+-- ============================================================================
+-- 119 · mermas_stock.costo_unitario: snapshot de costo al registrar la merma
+-- ============================================================================
+-- Riesgo documentado (docs/plan-auditoria-integridad.md ítem 8): las mermas se
+-- valuaban SIEMPRE a costo vivo → el KPI de un mes cerrado cambiaba si después
+-- se actualizaba el costo del producto. El trigger BEFORE INSERT congela el
+-- costo_real canónico (mig 111) en el alta, cubriendo TODOS los caminos de
+-- inserción (useMermas, auto-ajuste de promos en crear/editar pedido, control
+-- de stock) sin tocar cada uno. Filas históricas quedan NULL (fallback a costo
+-- vivo en lectura, mig 120).
+-- ============================================================================
+
+ALTER TABLE public.mermas_stock
+  ADD COLUMN IF NOT EXISTS costo_unitario numeric(12,4);
+
+COMMENT ON COLUMN public.mermas_stock.costo_unitario IS
+  'Costo real por unidad congelado al registrar la merma (productos.costo_real, mig 111). NULL = fila previa a mig 119 → el reporte cae al costo vivo.';
+
+CREATE OR REPLACE FUNCTION public.mermas_stock_snapshot_costo()
+RETURNS trigger
+LANGUAGE plpgsql
+SET search_path TO 'public'
+AS $$
+BEGIN
+  IF NEW.costo_unitario IS NULL THEN
+    SELECT COALESCE(costo_real, round(costo_sin_iva * (1 + COALESCE(impuestos_internos, 0) / 100), 4))
+      INTO NEW.costo_unitario
+      FROM productos
+     WHERE id = NEW.producto_id AND sucursal_id = NEW.sucursal_id;
+  END IF;
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_mermas_snapshot_costo ON public.mermas_stock;
+CREATE TRIGGER trg_mermas_snapshot_costo
+  BEFORE INSERT ON public.mermas_stock
+  FOR EACH ROW EXECUTE FUNCTION public.mermas_stock_snapshot_costo();

--- a/migrations/120_reporte_gerencial_neto_fc_zz.sql
+++ b/migrations/120_reporte_gerencial_neto_fc_zz.sql
@@ -1,0 +1,314 @@
+-- ============================================================================
+-- 120 · reporte_gerencial: venta neta / IVA débito / mix FC-ZZ + costo_real
+-- ============================================================================
+-- Fase D del rediseño fiscal. Misma firma de 5 args ⇒ CREATE OR REPLACE.
+-- Cambios ADITIVOS (las claves existentes no cambian: front y /reporte-mensual
+-- siguen funcionando; la venta bruta se mantiene por comparabilidad histórica):
+--
+--   1) kpis nuevos: venta_neta (Σ total_neto: para ZZ = total, para FC = sin
+--      IVA/II → margen comparable entre canales), iva_debito (Σ total_iva de
+--      ventas FC), margen_comercial_neto (venta_neta − cmv), y el mix
+--      fc_venta / fc_pedidos / zz_venta / zz_pedidos.
+--   2) El fallback de costo de items y bonificaciones pasa a
+--      COALESCE(costo_unitario_al_crear, productos.costo_real, fórmula vieja).
+--   3) Mermas valuadas al snapshot mermas_stock.costo_unitario (mig 119) con
+--      fallback a costo_real vivo → el KPI de un mes cerrado ya no cambia si
+--      después se actualiza el costo del producto.
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION public.reporte_gerencial(
+  p_sucursal_id bigint,
+  p_desde date,
+  p_hasta date,
+  p_incluir_no_entregados boolean DEFAULT false,
+  p_comparar boolean DEFAULT false
+)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ STABLE SECURITY DEFINER
+ SET search_path TO 'public'
+AS $function$
+DECLARE
+  v_sucursales bigint[]; v_asignadas bigint[]; v_nombre text; v_result jsonb;
+  v_es_servicio boolean := (auth.uid() IS NULL);
+  v_estados text[] := CASE WHEN p_incluir_no_entregados
+                           THEN ARRAY['entregado','asignado','pendiente','en_preparacion']
+                           ELSE ARRAY['entregado'] END;
+  v_dias int := (p_hasta - p_desde) + 1;
+  v_prev_hasta date := p_desde - 1;
+  v_prev_desde date := (p_desde - 1) - ((p_hasta - p_desde));
+  v_comparativo jsonb := NULL;
+  v_prev jsonb;
+  v_alertas jsonb := '[]'::jsonb;
+  v_cat_neg int;
+  v_cli_inact int;
+  v_cob_venc numeric;
+  v_cob_venc_cli int;
+  v_venta numeric;
+  v_prev_venta numeric;
+  v_mermas numeric;
+  v_prev_mermas numeric;
+BEGIN
+  IF NOT v_es_servicio THEN
+    IF NOT EXISTS (SELECT 1 FROM perfiles WHERE id = auth.uid() AND rol = 'admin') THEN
+      RAISE EXCEPTION 'Acceso denegado: se requiere rol admin'; END IF;
+    SELECT array_agg(sucursal_id) INTO v_asignadas FROM usuario_sucursales WHERE usuario_id = auth.uid();
+    IF v_asignadas IS NULL THEN RAISE EXCEPTION 'Acceso denegado: el usuario no tiene sucursales asignadas'; END IF;
+  END IF;
+  IF p_sucursal_id IS NULL THEN
+    SELECT array_agg(id) INTO v_sucursales FROM sucursales WHERE activa;
+    IF NOT v_es_servicio THEN
+      SELECT array_agg(s) INTO v_sucursales FROM unnest(v_sucursales) AS s WHERE s = ANY(v_asignadas); END IF;
+    v_nombre := 'Red (consolidado)';
+  ELSE
+    IF NOT v_es_servicio AND NOT (p_sucursal_id = ANY(v_asignadas)) THEN
+      RAISE EXCEPTION 'Acceso denegado: la sucursal % no está asignada al usuario', p_sucursal_id; END IF;
+    v_sucursales := ARRAY[p_sucursal_id];
+    SELECT nombre INTO v_nombre FROM sucursales WHERE id = p_sucursal_id;
+  END IF;
+  IF v_sucursales IS NULL OR array_length(v_sucursales,1) IS NULL THEN
+    RAISE EXCEPTION 'Acceso denegado: sin sucursales disponibles para el usuario'; END IF;
+
+  WITH
+  ped AS (
+    SELECT id, cliente_id, usuario_id, total, monto_pagado, fecha, forma_pago, estado_pago,
+           COALESCE(total_neto, total) AS total_neto, COALESCE(total_iva, 0) AS total_iva,
+           COALESCE(tipo_factura, 'ZZ') AS tipo_factura
+    FROM pedidos WHERE estado = ANY(v_estados) AND canal='app'
+      AND fecha BETWEEN p_desde AND p_hasta AND sucursal_id = ANY(v_sucursales)
+  ),
+  it AS (
+    SELECT p.id AS pedido_id, p.usuario_id, p.fecha,
+           pi.cantidad, pi.subtotal, pi.es_bonificacion,
+           COALESCE(pi.costo_unitario_al_crear, prod.costo_real, prod.costo_sin_iva*(1+COALESCE(prod.impuestos_internos,0)/100)) AS costo_unit,
+           prod.nombre AS prod_nombre,
+           COALESCE(NULLIF(prod.categoria,''),'(sin categoría)') AS categoria,
+           (prod.costo_sin_iva IS NULL OR prod.costo_sin_iva = 0) AS sin_costo,
+           pr.nombre AS promo_nombre,
+           (pr.regalo_mueve_stock IS FALSE AND COALESCE(pr.unidades_por_bloque,0) > 0) AS es_fraccion,
+           pr.unidades_por_bloque,
+           COALESCE(prod.precio,0) AS precio_lista,
+           CASE WHEN pi.es_bonificacion THEN
+             CASE WHEN pr.regalo_mueve_stock IS FALSE AND pr.unidades_por_bloque > 0
+                  THEN pi.cantidad * COALESCE(pi.costo_unitario_al_crear, prod.costo_real, prod.costo_sin_iva*(1+COALESCE(prod.impuestos_internos,0)/100)) / pr.unidades_por_bloque
+                  ELSE pi.cantidad * COALESCE(pi.costo_unitario_al_crear, prod.costo_real, prod.costo_sin_iva*(1+COALESCE(prod.impuestos_internos,0)/100)) END
+           ELSE 0 END AS costo_bonif
+    FROM ped p
+    JOIN pedido_items pi ON pi.pedido_id = p.id
+    JOIN productos prod ON prod.id = pi.producto_id
+    LEFT JOIN promociones pr ON pr.id = pi.promocion_id
+  ),
+  nc AS (
+    SELECT usuario_id, total FROM pedidos
+    WHERE estado<>'cancelado' AND canal='app'
+      AND fecha BETWEEN p_desde AND p_hasta AND sucursal_id = ANY(v_sucursales)
+      AND usuario_id IN (SELECT id FROM perfiles)
+  ),
+  k_ped AS (SELECT COUNT(*) AS pedidos, COALESCE(SUM(total),0) AS venta,
+            COUNT(DISTINCT cliente_id) AS clientes, COALESCE(ROUND(AVG(total)),0) AS ticket,
+            COALESCE(SUM(total_neto),0) AS venta_neta,
+            COALESCE(SUM(total_iva),0) AS iva_debito,
+            COALESCE(SUM(total) FILTER (WHERE tipo_factura='FC'),0) AS fc_venta,
+            COUNT(*) FILTER (WHERE tipo_factura='FC') AS fc_pedidos,
+            COALESCE(SUM(total) FILTER (WHERE tipo_factura='ZZ'),0) AS zz_venta,
+            COUNT(*) FILTER (WHERE tipo_factura='ZZ') AS zz_pedidos
+            FROM ped),
+  k_it AS (
+    SELECT COALESCE(SUM(cantidad*costo_unit) FILTER (WHERE NOT es_bonificacion),0) AS cmv,
+      COALESCE(SUM(costo_bonif),0) AS bonif,
+      COALESCE(SUM(cantidad) FILTER (WHERE NOT es_bonificacion),0) AS unidades,
+      COALESCE(SUM(cantidad) FILTER (WHERE es_bonificacion),0) AS unidades_bonif,
+      COALESCE(SUM(subtotal) FILTER (WHERE sin_costo AND NOT es_bonificacion),0) AS ingreso_sin_costo
+    FROM it
+  ),
+  k_nc AS (SELECT COALESCE(SUM(total),0) AS base_comision FROM nc),
+  -- Mermas valuadas al snapshot (mig 119); histórico sin snapshot → costo vivo.
+  k_merma AS (
+    SELECT COALESCE(SUM(costo),0) AS mermas,
+      COALESCE(SUM(costo) FILTER (WHERE clasif = 'perdida'),0) AS mermas_perdida,
+      COALESCE(SUM(costo) FILTER (WHERE clasif = 'ajuste'),0) AS mermas_ajuste,
+      COALESCE(SUM(costo) FILTER (WHERE clasif = 'muestra'),0) AS mermas_muestra
+    FROM (
+      SELECT m.cantidad*COALESCE(m.costo_unitario, prod.costo_real, prod.costo_sin_iva*(1+COALESCE(prod.impuestos_internos,0)/100)) AS costo,
+             CASE WHEN m.motivo IN ('vencimiento','rotura','robo','decomiso','devolucion') THEN 'perdida'
+                  WHEN m.motivo = 'muestra' THEN 'muestra'
+                  ELSE 'ajuste' END AS clasif
+      FROM mermas_stock m JOIN productos prod ON prod.id = m.producto_id
+      WHERE m.sucursal_id = ANY(v_sucursales)
+        AND (m.created_at AT TIME ZONE 'America/Argentina/Buenos_Aires')::date BETWEEN p_desde AND p_hasta
+        AND COALESCE(m.motivo,'') NOT IN ('promociones','promociones_reversion')
+    ) t
+  ),
+  k_compra AS (SELECT COALESCE(SUM(total),0) AS compras FROM compras
+    WHERE sucursal_id = ANY(v_sucursales) AND fecha_compra BETWEEN p_desde AND p_hasta
+      AND COALESCE(estado,'') <> 'cancelada'),
+  k_nuevos AS (SELECT COUNT(*) AS nuevos FROM (
+      SELECT cliente_id, MIN(fecha) AS pc FROM pedidos
+      WHERE estado='entregado' AND sucursal_id = ANY(v_sucursales) GROUP BY cliente_id
+    ) t WHERE pc BETWEEN p_desde AND p_hasta),
+  m_ped AS (SELECT to_char(fecha,'YYYY-MM') AS mes, COUNT(*) AS pedidos, SUM(total) AS venta,
+            COUNT(DISTINCT cliente_id) AS clientes, ROUND(AVG(total)) AS ticket FROM ped GROUP BY 1),
+  m_it AS (SELECT to_char(fecha,'YYYY-MM') AS mes,
+           COALESCE(SUM(cantidad*costo_unit) FILTER (WHERE NOT es_bonificacion),0) AS cmv,
+           COALESCE(SUM(costo_bonif),0) AS bonif FROM it GROUP BY 1),
+  m_merma AS (SELECT to_char(m.created_at AT TIME ZONE 'America/Argentina/Buenos_Aires','YYYY-MM') AS mes,
+       SUM(m.cantidad*COALESCE(m.costo_unitario, prod.costo_real, prod.costo_sin_iva*(1+COALESCE(prod.impuestos_internos,0)/100))) AS mermas
+    FROM mermas_stock m JOIN productos prod ON prod.id = m.producto_id
+    WHERE m.sucursal_id = ANY(v_sucursales)
+      AND (m.created_at AT TIME ZONE 'America/Argentina/Buenos_Aires')::date BETWEEN p_desde AND p_hasta
+      AND COALESCE(m.motivo,'') NOT IN ('promociones','promociones_reversion') GROUP BY 1),
+  m_compra AS (SELECT to_char(fecha_compra,'YYYY-MM') AS mes, SUM(total) AS compras
+    FROM compras WHERE sucursal_id = ANY(v_sucursales) AND fecha_compra BETWEEN p_desde AND p_hasta
+      AND COALESCE(estado,'') <> 'cancelada' GROUP BY 1),
+  mensual AS (SELECT mp.mes, mp.pedidos, mp.venta, mp.clientes, mp.ticket,
+      COALESCE(mi.cmv,0) AS cmv, COALESCE(mi.bonif,0) AS bonif,
+      COALESCE(mm.mermas,0) AS mermas, COALESCE(mc.compras,0) AS compras
+    FROM m_ped mp LEFT JOIN m_it mi ON mi.mes=mp.mes LEFT JOIN m_merma mm ON mm.mes=mp.mes LEFT JOIN m_compra mc ON mc.mes=mp.mes),
+  v_ent AS (SELECT usuario_id, COUNT(DISTINCT pedido_id) AS pedidos, SUM(subtotal) AS venta,
+      SUM(subtotal) - COALESCE(SUM(cantidad*costo_unit) FILTER (WHERE NOT es_bonificacion),0) AS margen_comercial,
+      COALESCE(SUM(costo_bonif),0) AS bonif FROM it GROUP BY usuario_id),
+  v_nc AS (SELECT usuario_id, SUM(total) AS base_nc FROM nc GROUP BY usuario_id),
+  vendedores AS (SELECT pf.nombre, pf.rol, e.pedidos, e.venta, e.margen_comercial, e.bonif,
+      COALESCE(n.base_nc, e.venta) AS base_nc
+    FROM v_ent e JOIN perfiles pf ON pf.id=e.usuario_id LEFT JOIN v_nc n ON n.usuario_id=e.usuario_id),
+  categorias AS (SELECT categoria, SUM(subtotal) AS venta,
+      SUM(subtotal) - COALESCE(SUM(cantidad*costo_unit) FILTER (WHERE NOT es_bonificacion),0) AS margen_comercial,
+      COALESCE(SUM(costo_bonif),0) AS bonif, bool_or(sin_costo) AS sin_costo
+    FROM it GROUP BY categoria),
+  top_prod AS (SELECT prod_nombre AS nombre,
+      COALESCE(SUM(cantidad) FILTER (WHERE NOT es_bonificacion),0) AS unidades, SUM(subtotal) AS venta,
+      SUM(subtotal) - COALESCE(SUM(cantidad*costo_unit) FILTER (WHERE NOT es_bonificacion),0) AS margen
+    FROM it GROUP BY prod_nombre ORDER BY venta DESC LIMIT 10),
+  top_cli AS (SELECT COALESCE(NULLIF(c.nombre_fantasia,''), c.razon_social) AS cliente,
+      COUNT(DISTINCT p.id) AS pedidos, SUM(p.total) AS venta
+    FROM ped p JOIN clientes c ON c.id=p.cliente_id GROUP BY 1 ORDER BY venta DESC LIMIT 10),
+  bonif_promos AS (SELECT COALESCE(promo_nombre,'(sin promoción)') AS promocion, prod_nombre AS producto,
+      SUM(cantidad) AS unidades, bool_or(es_fraccion) AS es_fraccion,
+      SUM(costo_bonif) AS costo,
+      SUM(CASE WHEN es_fraccion THEN cantidad * precio_lista / unidades_por_bloque
+               ELSE cantidad * precio_lista END) AS valor_venta
+    FROM it WHERE es_bonificacion GROUP BY 1, 2 HAVING SUM(cantidad) > 0),
+  mermas_motivo AS (SELECT COALESCE(NULLIF(m.motivo,''),'(sin motivo)') AS motivo,
+      CASE WHEN m.motivo IN ('vencimiento','rotura','robo','decomiso','devolucion') THEN 'perdida'
+           WHEN m.motivo = 'muestra' THEN 'muestra'
+           ELSE 'ajuste' END AS clasificacion,
+      SUM(m.cantidad) AS unidades,
+      SUM(m.cantidad*COALESCE(m.costo_unitario, prod.costo_real, prod.costo_sin_iva*(1+COALESCE(prod.impuestos_internos,0)/100))) AS costo
+    FROM mermas_stock m JOIN productos prod ON prod.id=m.producto_id
+    WHERE m.sucursal_id = ANY(v_sucursales)
+      AND (m.created_at AT TIME ZONE 'America/Argentina/Buenos_Aires')::date BETWEEN p_desde AND p_hasta
+      AND COALESCE(m.motivo,'') NOT IN ('promociones','promociones_reversion') GROUP BY 1, 2),
+  cobr AS (SELECT COALESCE(SUM(LEAST(COALESCE(monto_pagado,0), total)),0) AS cobrado,
+      COALESCE(SUM(GREATEST(total - COALESCE(monto_pagado,0), 0)),0) AS pendiente FROM ped),
+  pagos_ped AS (SELECT COALESCE(NULLIF(pg.forma_pago,''),'(sin dato)') AS forma_pago, SUM(pg.monto) AS monto
+    FROM pagos pg JOIN ped ON ped.id = pg.pedido_id GROUP BY 1),
+  formas AS (SELECT forma_pago, monto FROM pagos_ped
+    UNION ALL
+    SELECT '(sin registro de pago)', c.cobrado - COALESCE((SELECT SUM(monto) FROM pagos_ped),0)
+    FROM cobr c
+    WHERE c.cobrado - COALESCE((SELECT SUM(monto) FROM pagos_ped),0) > 0.01),
+  serie AS (SELECT to_char(fecha,'DD/MM') AS dia, SUM(total) AS venta FROM ped GROUP BY fecha ORDER BY fecha)
+  SELECT jsonb_build_object(
+    'meta', jsonb_build_object('sucursal_id', p_sucursal_id, 'sucursal_nombre', COALESCE(v_nombre,'?'),
+      'desde', p_desde, 'hasta', p_hasta, 'generado_at', now(),
+      'incluye_no_entregados', p_incluir_no_entregados),
+    'kpis', (SELECT jsonb_build_object('venta', kp.venta, 'pedidos', kp.pedidos, 'clientes', kp.clientes, 'ticket', kp.ticket,
+        'clientes_nuevos', kn.nuevos, 'cmv', ki.cmv, 'bonif', ki.bonif, 'unidades', ki.unidades,
+        'unidades_bonif', ki.unidades_bonif, 'margen_comercial', kp.venta - ki.cmv,
+        'margen_neto', kp.venta - ki.cmv - ki.bonif, 'base_comision', kc.base_comision, 'comision_pct_default', 2,
+        'mermas', km.mermas, 'mermas_perdida', km.mermas_perdida, 'mermas_ajuste', km.mermas_ajuste,
+        'mermas_muestra', km.mermas_muestra, 'compras', kcp.compras, 'ingreso_sin_costo', ki.ingreso_sin_costo,
+        'venta_neta', kp.venta_neta, 'iva_debito', kp.iva_debito,
+        'margen_comercial_neto', kp.venta_neta - ki.cmv,
+        'fc_venta', kp.fc_venta, 'fc_pedidos', kp.fc_pedidos,
+        'zz_venta', kp.zz_venta, 'zz_pedidos', kp.zz_pedidos)
+      FROM k_ped kp, k_it ki, k_nc kc, k_merma km, k_compra kcp, k_nuevos kn),
+    'mensual', (SELECT COALESCE(jsonb_agg(to_jsonb(m) ORDER BY m.mes),'[]') FROM mensual m),
+    'vendedores', (SELECT COALESCE(jsonb_agg(to_jsonb(v) ORDER BY v.venta DESC),'[]') FROM vendedores v),
+    'categorias', (SELECT COALESCE(jsonb_agg(to_jsonb(c) ORDER BY c.venta DESC),'[]') FROM categorias c),
+    'top_productos', (SELECT COALESCE(jsonb_agg(to_jsonb(t)),'[]') FROM top_prod t),
+    'top_clientes', (SELECT COALESCE(jsonb_agg(to_jsonb(t)),'[]') FROM top_cli t),
+    'bonif_promos', (SELECT COALESCE(jsonb_agg(to_jsonb(b) ORDER BY b.valor_venta DESC),'[]') FROM bonif_promos b),
+    'mermas_motivo', (SELECT COALESCE(jsonb_agg(to_jsonb(mm) ORDER BY mm.costo DESC),'[]') FROM mermas_motivo mm),
+    'cobranza', jsonb_build_object('formas', (SELECT COALESCE(jsonb_agg(to_jsonb(f) ORDER BY f.monto DESC),'[]') FROM formas f),
+      'cobrado', (SELECT cobrado FROM cobr), 'pendiente', (SELECT pendiente FROM cobr)),
+    'serie_diaria', (SELECT COALESCE(jsonb_agg(jsonb_build_array(s.dia, s.venta)),'[]') FROM serie s),
+    'flags', (SELECT jsonb_build_object('ingreso_sin_costo', ki.ingreso_sin_costo,
+        'pct_sin_costo', CASE WHEN kp.venta > 0 THEN round(100.0*ki.ingreso_sin_costo/kp.venta,1) ELSE 0 END)
+      FROM k_it ki, k_ped kp)
+  ) INTO v_result;
+
+  -- ----- Comparativo: período anterior (recursivo, sin volver a comparar) -----
+  IF p_comparar THEN
+    v_prev := public.reporte_gerencial(p_sucursal_id, v_prev_desde, v_prev_hasta, p_incluir_no_entregados, false);
+    v_comparativo := (v_prev->'kpis') || jsonb_build_object('desde', v_prev_desde, 'hasta', v_prev_hasta);
+  END IF;
+
+  -- ----- Alertas: "qué requiere tu atención" -----
+  v_venta := (v_result->'kpis'->>'venta')::numeric;
+  v_mermas := (v_result->'kpis'->>'mermas')::numeric;
+  v_prev_venta := (v_comparativo->>'venta')::numeric;
+  v_prev_mermas := (v_comparativo->>'mermas')::numeric;
+
+  IF p_comparar AND COALESCE(v_prev_venta,0) > 0 AND v_venta < v_prev_venta * 0.9 THEN
+    v_alertas := v_alertas || jsonb_build_object(
+      'severidad', CASE WHEN v_venta < v_prev_venta*0.8 THEN 'critical' ELSE 'warning' END,
+      'codigo','venta_caida','titulo','Venta en baja',
+      'detalle','Cayó '||round((1 - v_venta/v_prev_venta)*100)::text||'% vs período anterior',
+      'valor', v_venta - v_prev_venta, 'seccion','evolucion');
+  END IF;
+
+  SELECT COALESCE(SUM(total - COALESCE(monto_pagado,0)),0), COUNT(DISTINCT cliente_id)
+    INTO v_cob_venc, v_cob_venc_cli
+  FROM pedidos
+  WHERE estado='entregado' AND canal='app' AND sucursal_id = ANY(v_sucursales)
+    AND COALESCE(estado_pago,'pendiente') IN ('pendiente','parcial')
+    AND fecha < CURRENT_DATE - 30 AND total > COALESCE(monto_pagado,0);
+  IF v_cob_venc > 0 THEN
+    v_alertas := v_alertas || jsonb_build_object('severidad','critical','codigo','cobranza_vencida','titulo','Cobranza vencida',
+      'detalle', v_cob_venc_cli::text||' cliente(s) con saldo impago hace +30 días',
+      'valor', v_cob_venc, 'seccion','cobranza');
+  END IF;
+
+  SELECT COUNT(*) INTO v_cli_inact FROM (
+    SELECT p.cliente_id FROM pedidos p
+    WHERE p.estado='entregado' AND p.canal='app' AND p.sucursal_id = ANY(v_sucursales)
+    GROUP BY p.cliente_id
+    HAVING MAX(p.fecha) < CURRENT_DATE - 30 AND MAX(p.fecha) >= CURRENT_DATE - 90
+  ) t;
+  IF v_cli_inact > 0 THEN
+    v_alertas := v_alertas || jsonb_build_object('severidad','warning','codigo','clientes_inactivos','titulo','Clientes que dejaron de comprar',
+      'detalle', v_cli_inact::text||' cliente(s) sin comprar hace +30 días (compraban hasta hace poco)',
+      'valor', v_cli_inact, 'seccion','clientes');
+  END IF;
+
+  IF p_comparar AND COALESCE(v_prev_mermas,0) > 0 AND v_mermas > v_prev_mermas*1.3 AND v_mermas > 50000 THEN
+    v_alertas := v_alertas || jsonb_build_object('severidad','warning','codigo','mermas_alza','titulo','Mermas en alza',
+      'detalle','Subieron '||round((v_mermas/v_prev_mermas - 1)*100)::text||'% vs período anterior',
+      'valor', v_mermas, 'seccion','mermas');
+  END IF;
+
+  SELECT COUNT(*) INTO v_cat_neg FROM jsonb_array_elements(v_result->'categorias') c WHERE (c->>'margen_comercial')::numeric < 0;
+  IF v_cat_neg > 0 THEN
+    v_alertas := v_alertas || jsonb_build_object('severidad','warning','codigo','margen_categoria_negativo','titulo','Categorías con margen negativo',
+      'detalle', v_cat_neg::text||' categoría(s) con margen comercial negativo',
+      'valor', v_cat_neg, 'seccion','categorias');
+  END IF;
+
+  IF (v_result->'flags'->>'pct_sin_costo')::numeric >= 1 THEN
+    v_alertas := v_alertas || jsonb_build_object('severidad','info','codigo','productos_sin_costo','titulo','Productos sin costo',
+      'detalle', (v_result->'flags'->>'pct_sin_costo')::text||'% de la venta es de productos sin costo (margen sobreestimado)',
+      'valor', (v_result->'flags'->>'ingreso_sin_costo')::numeric, 'seccion','categorias');
+  END IF;
+
+  -- Ordenar por severidad
+  SELECT COALESCE(jsonb_agg(a ORDER BY array_position(ARRAY['critical','warning','info'], a->>'severidad')), '[]'::jsonb)
+    INTO v_alertas FROM jsonb_array_elements(v_alertas) a;
+
+  v_result := v_result || jsonb_build_object('comparativo', COALESCE(v_comparativo,'null'::jsonb), 'alertas', v_alertas);
+  RETURN v_result;
+END;
+$function$;
+
+REVOKE EXECUTE ON FUNCTION public.reporte_gerencial(bigint, date, date, boolean, boolean) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.reporte_gerencial(bigint, date, date, boolean, boolean) TO authenticated, service_role;

--- a/migrations/121_posicion_fiscal.sql
+++ b/migrations/121_posicion_fiscal.sql
@@ -1,0 +1,123 @@
+-- ============================================================================
+-- 121 · posicion_fiscal: IVA débito/crédito, percepciones e imp. internos
+-- ============================================================================
+-- Reporte de gestión del período (NO reemplaza la liquidación del contador):
+--   · Ventas: mix FC/ZZ (montos y counts), IVA débito (Σ total_iva de FC),
+--     II contenido en ventas FC (Σ impuestos_internos_unitario × cantidad).
+--   · Compras: mix FC/ZZ, IVA crédito (Σ compras.iva), II soportado,
+--     percepciones IVA/IIBB acumuladas (créditos fiscales, mig 113).
+--   · saldo_tecnico = iva_debito − iva_credito − percepcion_iva (positivo =
+--     IVA a pagar estimado; negativo = crédito a favor).
+-- Mismo gate/scoping que reporte_gerencial (admin + usuario_sucursales;
+-- service role sin restricción). Ventas = entregadas, canal 'app'.
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION public.posicion_fiscal(
+  p_sucursal_id bigint,
+  p_desde date,
+  p_hasta date
+) RETURNS jsonb
+LANGUAGE plpgsql STABLE SECURITY DEFINER
+SET search_path TO 'public'
+AS $$
+DECLARE
+  v_sucursales bigint[]; v_asignadas bigint[]; v_nombre text; v_result jsonb;
+  v_es_servicio boolean := (auth.uid() IS NULL);
+BEGIN
+  IF NOT v_es_servicio THEN
+    IF NOT EXISTS (SELECT 1 FROM perfiles WHERE id = auth.uid() AND rol = 'admin') THEN
+      RAISE EXCEPTION 'Acceso denegado: se requiere rol admin'; END IF;
+    SELECT array_agg(sucursal_id) INTO v_asignadas FROM usuario_sucursales WHERE usuario_id = auth.uid();
+    IF v_asignadas IS NULL THEN RAISE EXCEPTION 'Acceso denegado: el usuario no tiene sucursales asignadas'; END IF;
+  END IF;
+  IF p_sucursal_id IS NULL THEN
+    SELECT array_agg(id) INTO v_sucursales FROM sucursales WHERE activa;
+    IF NOT v_es_servicio THEN
+      SELECT array_agg(s) INTO v_sucursales FROM unnest(v_sucursales) AS s WHERE s = ANY(v_asignadas); END IF;
+    v_nombre := 'Red (consolidado)';
+  ELSE
+    IF NOT v_es_servicio AND NOT (p_sucursal_id = ANY(v_asignadas)) THEN
+      RAISE EXCEPTION 'Acceso denegado: la sucursal % no está asignada al usuario', p_sucursal_id; END IF;
+    v_sucursales := ARRAY[p_sucursal_id];
+    SELECT nombre INTO v_nombre FROM sucursales WHERE id = p_sucursal_id;
+  END IF;
+  IF v_sucursales IS NULL OR array_length(v_sucursales,1) IS NULL THEN
+    RAISE EXCEPTION 'Acceso denegado: sin sucursales disponibles para el usuario'; END IF;
+
+  WITH
+  ped AS (
+    SELECT id, total, COALESCE(total_neto, total) AS total_neto,
+           COALESCE(total_iva, 0) AS total_iva, COALESCE(tipo_factura, 'ZZ') AS tipo_factura
+    FROM pedidos
+    WHERE estado = 'entregado' AND canal = 'app'
+      AND fecha BETWEEN p_desde AND p_hasta AND sucursal_id = ANY(v_sucursales)
+  ),
+  v_fc AS (
+    SELECT COALESCE(SUM(pi.cantidad * COALESCE(pi.impuestos_internos_unitario, 0)), 0) AS ii_ventas
+    FROM ped p JOIN pedido_items pi ON pi.pedido_id = p.id
+    WHERE p.tipo_factura = 'FC' AND NOT COALESCE(pi.es_bonificacion, false)
+  ),
+  ventas AS (
+    SELECT COUNT(*) FILTER (WHERE tipo_factura='FC') AS fc_pedidos,
+           COALESCE(SUM(total) FILTER (WHERE tipo_factura='FC'), 0) AS fc_venta,
+           COALESCE(SUM(total_neto) FILTER (WHERE tipo_factura='FC'), 0) AS fc_neto,
+           COALESCE(SUM(total_iva) FILTER (WHERE tipo_factura='FC'), 0) AS iva_debito,
+           COUNT(*) FILTER (WHERE tipo_factura='ZZ') AS zz_pedidos,
+           COALESCE(SUM(total) FILTER (WHERE tipo_factura='ZZ'), 0) AS zz_venta
+    FROM ped
+  ),
+  compras_p AS (
+    SELECT COALESCE(tipo_factura, 'FC') AS tipo_factura, subtotal, iva,
+           COALESCE(impuestos_internos, 0) AS impuestos_internos,
+           COALESCE(percepcion_iva, 0) AS percepcion_iva,
+           COALESCE(percepcion_iibb, 0) AS percepcion_iibb, total
+    FROM compras
+    WHERE sucursal_id = ANY(v_sucursales)
+      AND fecha_compra BETWEEN p_desde AND p_hasta
+      AND COALESCE(estado, '') <> 'cancelada'
+  ),
+  compras_k AS (
+    SELECT COUNT(*) FILTER (WHERE tipo_factura='FC') AS fc_compras,
+           COALESCE(SUM(total) FILTER (WHERE tipo_factura='FC'), 0) AS fc_total,
+           COALESCE(SUM(subtotal) FILTER (WHERE tipo_factura='FC'), 0) AS fc_neto,
+           COALESCE(SUM(iva), 0) AS iva_credito,
+           COALESCE(SUM(impuestos_internos), 0) AS ii_compras,
+           COALESCE(SUM(percepcion_iva), 0) AS percepcion_iva,
+           COALESCE(SUM(percepcion_iibb), 0) AS percepcion_iibb,
+           COUNT(*) FILTER (WHERE tipo_factura='ZZ') AS zz_compras,
+           COALESCE(SUM(total) FILTER (WHERE tipo_factura='ZZ'), 0) AS zz_total
+    FROM compras_p
+  )
+  SELECT jsonb_build_object(
+    'meta', jsonb_build_object('sucursal_id', p_sucursal_id, 'sucursal_nombre', COALESCE(v_nombre, '?'),
+      'desde', p_desde, 'hasta', p_hasta, 'generado_at', now(),
+      'nota', 'Estimación de gestión; no reemplaza la liquidación del contador. II es costo; percepciones son créditos.'),
+    'ventas', (SELECT jsonb_build_object(
+        'fc_pedidos', v.fc_pedidos, 'fc_venta', v.fc_venta, 'fc_neto', v.fc_neto,
+        'iva_debito', v.iva_debito, 'ii_ventas_fc', f.ii_ventas,
+        'zz_pedidos', v.zz_pedidos, 'zz_venta', v.zz_venta,
+        'pct_fc', CASE WHEN v.fc_venta + v.zz_venta > 0
+                       THEN round(100.0 * v.fc_venta / (v.fc_venta + v.zz_venta), 1) ELSE 0 END)
+      FROM ventas v, v_fc f),
+    'compras', (SELECT jsonb_build_object(
+        'fc_compras', c.fc_compras, 'fc_total', c.fc_total, 'fc_neto', c.fc_neto,
+        'iva_credito', c.iva_credito, 'ii_compras', c.ii_compras,
+        'percepcion_iva', c.percepcion_iva, 'percepcion_iibb', c.percepcion_iibb,
+        'zz_compras', c.zz_compras, 'zz_total', c.zz_total,
+        'pct_fc', CASE WHEN c.fc_total + c.zz_total > 0
+                       THEN round(100.0 * c.fc_total / (c.fc_total + c.zz_total), 1) ELSE 0 END)
+      FROM compras_k c),
+    'posicion', (SELECT jsonb_build_object(
+        'saldo_tecnico', v.iva_debito - c.iva_credito - c.percepcion_iva,
+        'iva_debito', v.iva_debito,
+        'iva_credito', c.iva_credito,
+        'percepciones_a_favor', c.percepcion_iva + c.percepcion_iibb)
+      FROM ventas v, compras_k c)
+  ) INTO v_result;
+
+  RETURN v_result;
+END;
+$$;
+
+REVOKE EXECUTE ON FUNCTION public.posicion_fiscal(bigint, date, date) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.posicion_fiscal(bigint, date, date) TO authenticated, service_role;

--- a/src/components/vistas/VistaReportesGerenciales.tsx
+++ b/src/components/vistas/VistaReportesGerenciales.tsx
@@ -13,6 +13,7 @@ import Alertas from './reportes-gerenciales/Alertas'
 import ModalMetas from './reportes-gerenciales/ModalMetas'
 import ModalAlertaDetalle from './reportes-gerenciales/ModalAlertaDetalle'
 import type { ReporteGerencial, AnalisisMensual, MetasGerenciales, Alerta, BonifPromo } from '../../hooks/queries'
+import { usePosicionFiscalQuery } from '../../hooks/queries/useReporteGerencialQuery'
 
 // Alertas cuyo detalle es una LISTA (modal). El resto hace scroll a su sección.
 const ALERTA_CON_LISTA = new Set(['cobranza_vencida', 'clientes_inactivos', 'productos_sin_costo'])
@@ -133,6 +134,11 @@ export default function VistaReportesGerenciales({
   const [comBase, setComBase] = useState<'nc' | 'ent'>('nc')
   const [detalleAbierto, setDetalleAbierto] = useState(false)
   const [showMetas, setShowMetas] = useState(false)
+
+  // Posición fiscal (mig 121): se pide recién al abrir el detalle (perf).
+  const { data: posFiscal } = usePosicionFiscalQuery(
+    sucursalSel, periodoSel.desde, periodoSel.hasta, detalleAbierto,
+  )
 
   // Prorrateo de la meta: en un mes en curso compara contra la parte transcurrida.
   const metaFactor = useMemo(() => {
@@ -341,6 +347,16 @@ export default function VistaReportesGerenciales({
               delta={cmp ? <Delta cur={k.ticket} prev={kp!.ticket} /> : undefined} />
           </div>
 
+          {/* Fiscal (mig 120): solo si hay ventas FC en el período (todo-ZZ ⇒ venta neta = venta) */}
+          {(k.fc_pedidos ?? 0) > 0 && k.venta_neta != null && (
+            <div className="flex flex-wrap items-center gap-x-5 gap-y-1 bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-800 rounded-lg px-4 py-2.5 text-sm text-blue-900 dark:text-blue-200">
+              <span><b>Venta neta</b> (sin IVA/II de FC): <b>{moneyC(k.venta_neta)}</b></span>
+              <span>Margen comercial s/neta: <b>{moneyC(k.margen_comercial_neto ?? (k.venta_neta - k.cmv))}</b></span>
+              <span>IVA débito: <b>{moneyC(k.iva_debito ?? 0)}</b></span>
+              <span>Mix: FC {moneyC(k.fc_venta ?? 0)} ({N.format(k.fc_pedidos ?? 0)}) · ZZ {moneyC(k.zz_venta ?? 0)} ({N.format(k.zz_pedidos ?? 0)})</span>
+            </div>
+          )}
+
           {/* Flag: productos sin costo */}
           {reporte.flags.pct_sin_costo >= 1 && (
             <div className="flex items-start gap-2.5 bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800 rounded-lg px-4 py-3">
@@ -366,6 +382,47 @@ export default function VistaReportesGerenciales({
           </button>
 
           {detalleAbierto && (<>
+          {/* Posición fiscal del período (mig 121) — estimación de gestión */}
+          {posFiscal && (
+            <Card id="sec-fiscal" className="p-5">
+              <SectionTitle icon={FileText} title="Posición fiscal (FC/ZZ)" hint="Estimación de gestión — no reemplaza la liquidación del contador. II es costo; percepciones son créditos." />
+              <div className="grid md:grid-cols-3 gap-5 text-sm">
+                <div>
+                  <p className="text-xs font-semibold uppercase tracking-wide text-gray-500 mb-2">Ventas</p>
+                  <div className="space-y-1 text-gray-700 dark:text-gray-300">
+                    <p>FC: <b>{moneyC(posFiscal.ventas.fc_venta)}</b> ({N.format(posFiscal.ventas.fc_pedidos)} pedidos · {posFiscal.ventas.pct_fc}%)</p>
+                    <p>ZZ: <b>{moneyC(posFiscal.ventas.zz_venta)}</b> ({N.format(posFiscal.ventas.zz_pedidos)} pedidos)</p>
+                    <p>IVA débito: <b>{moneyC(posFiscal.ventas.iva_debito)}</b></p>
+                    <p>II contenido en FC: {moneyC(posFiscal.ventas.ii_ventas_fc)}</p>
+                  </div>
+                </div>
+                <div>
+                  <p className="text-xs font-semibold uppercase tracking-wide text-gray-500 mb-2">Compras</p>
+                  <div className="space-y-1 text-gray-700 dark:text-gray-300">
+                    <p>FC: <b>{moneyC(posFiscal.compras.fc_total)}</b> ({N.format(posFiscal.compras.fc_compras)} · {posFiscal.compras.pct_fc}%)</p>
+                    <p>ZZ: <b>{moneyC(posFiscal.compras.zz_total)}</b> ({N.format(posFiscal.compras.zz_compras)})</p>
+                    <p>IVA crédito: <b>{moneyC(posFiscal.compras.iva_credito)}</b></p>
+                    <p>Imp. internos soportados: {moneyC(posFiscal.compras.ii_compras)}</p>
+                    <p>Percepciones: IVA {moneyC(posFiscal.compras.percepcion_iva)} · IIBB {moneyC(posFiscal.compras.percepcion_iibb)}</p>
+                  </div>
+                </div>
+                <div>
+                  <p className="text-xs font-semibold uppercase tracking-wide text-gray-500 mb-2">Posición IVA</p>
+                  <div className="space-y-1 text-gray-700 dark:text-gray-300">
+                    <p>Débito − crédito − percepción IVA:</p>
+                    <p className={`text-xl font-bold ${posFiscal.posicion.saldo_tecnico >= 0 ? 'text-red-600' : 'text-emerald-600'}`}>
+                      {moneyC(posFiscal.posicion.saldo_tecnico)}
+                    </p>
+                    <p className="text-xs text-gray-500">
+                      {posFiscal.posicion.saldo_tecnico >= 0 ? 'IVA a pagar estimado del período' : 'Crédito fiscal a favor del período'}
+                    </p>
+                    <p className="text-xs text-gray-500">Percepciones a favor acumuladas: {moneyC(posFiscal.posicion.percepciones_a_favor)}</p>
+                  </div>
+                </div>
+              </div>
+            </Card>
+          )}
+
           {/* Evolución mensual */}
           <Card id="sec-evolucion" className="p-5">
             <SectionTitle icon={TrendingUp} title="Evolución mensual" hint="Venta, bonificaciones y margen neto por mes." />

--- a/src/hooks/queries/useReporteGerencialQuery.ts
+++ b/src/hooks/queries/useReporteGerencialQuery.ts
@@ -33,6 +33,57 @@ export interface ReporteKpis {
   mermas_muestra?: number
   compras: number
   ingreso_sin_costo: number
+  /** Fiscal (mig 120, opcionales por compat con respuestas cacheadas):
+   *  venta_neta = Σ total_neto (ZZ: total; FC: sin IVA/II) — margen comparable
+   *  entre canales; iva_debito = Σ total_iva de ventas FC. */
+  venta_neta?: number
+  iva_debito?: number
+  margen_comercial_neto?: number
+  fc_venta?: number
+  fc_pedidos?: number
+  zz_venta?: number
+  zz_pedidos?: number
+}
+
+/** Resultado del RPC posicion_fiscal (mig 121). Estimación de gestión. */
+export interface PosicionFiscal {
+  meta: {
+    sucursal_id: number | null
+    sucursal_nombre: string
+    desde: string
+    hasta: string
+    generado_at: string
+    nota: string
+  }
+  ventas: {
+    fc_pedidos: number
+    fc_venta: number
+    fc_neto: number
+    iva_debito: number
+    ii_ventas_fc: number
+    zz_pedidos: number
+    zz_venta: number
+    pct_fc: number
+  }
+  compras: {
+    fc_compras: number
+    fc_total: number
+    fc_neto: number
+    iva_credito: number
+    ii_compras: number
+    percepcion_iva: number
+    percepcion_iibb: number
+    zz_compras: number
+    zz_total: number
+    pct_fc: number
+  }
+  posicion: {
+    /** iva_debito − iva_credito − percepcion_iva. Positivo = IVA a pagar estimado. */
+    saldo_tecnico: number
+    iva_debito: number
+    iva_credito: number
+    percepciones_a_favor: number
+  }
 }
 
 /** Fila de mermas por motivo, con clasificación de negocio (mig 110). */
@@ -181,6 +232,29 @@ export function useReporteGerencialQuery(
       })
       if (error) throw new Error(error.message)
       return data as ReporteGerencial
+    },
+    enabled,
+    staleTime: 5 * 60 * 1000,
+  })
+}
+
+/** Posición fiscal del período (mig 121). sucursalId null = red. */
+export function usePosicionFiscalQuery(
+  sucursalId: number | null,
+  desde: string,
+  hasta: string,
+  enabled = true,
+) {
+  return useQuery({
+    queryKey: ['posicion-fiscal', sucursalId, desde, hasta] as const,
+    queryFn: async (): Promise<PosicionFiscal> => {
+      const { data, error } = await supabase.rpc('posicion_fiscal', {
+        p_sucursal_id: sucursalId,
+        p_desde: desde,
+        p_hasta: hasta,
+      })
+      if (error) throw new Error(error.message)
+      return data as PosicionFiscal
     },
     enabled,
     staleTime: 5 * 60 * 1000,

--- a/src/hooks/supabase/useReportesFinancieros.ts
+++ b/src/hooks/supabase/useReportesFinancieros.ts
@@ -204,8 +204,13 @@ export function useReportesFinancieros(): UseReportesFinancierosReturn {
             ventasNetas += subtotalItem
           }
 
-          const costoUnitario = prod.costo_sin_iva || 0
-          productoStats[id].costos += costoUnitario * item.cantidad
+          // Costo canónico (mig 120): snapshot congelado al crear el pedido;
+          // fallback a productos.costo_real (mig 111) y por último a la
+          // fórmula vieja. Antes usaba costo_sin_iva vivo SIN imp. internos.
+          const costoUnitario = ((item as Record<string, unknown>).costo_unitario_al_crear as number | null)
+            ?? prod.costo_real
+            ?? ((prod.costo_sin_iva || 0) * (1 + (prod.impuestos_internos || 0) / 100))
+          productoStats[id].costos += (costoUnitario || 0) * item.cantidad
         })
       })
 

--- a/src/services/analyticsExport.ts
+++ b/src/services/analyticsExport.ts
@@ -52,7 +52,8 @@ export async function fetchVentasDetallado(
         cantidad,
         precio_unitario,
         subtotal,
-        producto:productos(id, nombre, codigo, categoria, costo_con_iva)
+        costo_unitario_al_crear,
+        producto:productos(id, nombre, codigo, categoria, costo_con_iva, costo_real)
       )
     `)
     .gte('created_at', `${desde}T00:00:00`)
@@ -87,7 +88,11 @@ export async function fetchVentasDetallado(
 
     for (const item of items) {
       const producto = item.producto as Record<string, unknown> | null
-      const costoUnitario = Number(producto?.costo_con_iva || 0)
+      // Costo canónico (mig 120): snapshot al crear → costo_real vivo → legacy
+      // costo_con_iva (que incluía IVA y sobreestimaba el costo).
+      const costoUnitario = Number(
+        item.costo_unitario_al_crear ?? producto?.costo_real ?? producto?.costo_con_iva ?? 0
+      )
       const precioUnitario = Number(item.precio_unitario || 0)
       const cantidad = Number(item.cantidad || 0)
       const subtotal = Number(item.subtotal || precioUnitario * cantidad)
@@ -236,7 +241,8 @@ export async function fetchProductosDimension(
 
   return (productosRes.data || []).map(p => {
     const ventas = ventasPorProducto.get(p.id) || { cantidad: 0, ingresos: 0, dias: new Set() }
-    const costoUnitario = Number(p.costo_con_iva || 0)
+    // Costo real canónico (mig 111); fallback legacy a costo_con_iva.
+    const costoUnitario = Number(p.costo_real ?? p.costo_con_iva ?? 0)
     const costoTotal = costoUnitario * ventas.cantidad
     const margenTotal = ventas.ingresos - costoTotal
 
@@ -254,6 +260,7 @@ export async function fetchProductosDimension(
       stock_minimo: p.stock_minimo ?? 0,
       costo_sin_iva: p.costo_sin_iva ?? 0,
       costo_con_iva: p.costo_con_iva ?? 0,
+      costo_real: p.costo_real ?? 0,
       activo: p.activo !== false ? 'Si' : 'No',
       total_vendido: ventas.cantidad,
       total_ingresos: Number(ventas.ingresos.toFixed(2)),
@@ -282,11 +289,21 @@ export async function fetchComprasFact(
       created_at,
       total,
       estado,
+      tipo_factura,
+      subtotal,
+      iva,
+      impuestos_internos,
+      percepcion_iva,
+      percepcion_iibb,
+      no_gravado,
       proveedor:proveedores(nombre, cuit),
       items:compra_items(
         cantidad,
         costo_unitario,
+        bonificacion,
         subtotal,
+        costo_neto_unitario,
+        costo_real_unitario,
         producto:productos(nombre, codigo, categoria)
       )
     `)
@@ -314,8 +331,18 @@ export async function fetchComprasFact(
         producto_categoria: safe(producto?.categoria),
         cantidad: item.cantidad,
         costo_unitario: item.costo_unitario,
+        bonificacion: item.bonificacion ?? 0,
+        costo_neto_unitario: item.costo_neto_unitario ?? '',
+        costo_real_unitario: item.costo_real_unitario ?? '',
         subtotal: item.subtotal,
         estado: safe(compra.estado),
+        tipo_factura: safe(compra.tipo_factura),
+        compra_subtotal: compra.subtotal ?? 0,
+        compra_iva: compra.iva ?? 0,
+        compra_impuestos_internos: compra.impuestos_internos ?? 0,
+        compra_percepcion_iva: compra.percepcion_iva ?? 0,
+        compra_percepcion_iibb: compra.percepcion_iibb ?? 0,
+        compra_no_gravado: compra.no_gravado ?? 0,
       })
     }
   }


### PR DESCRIPTION
## Fase D del rediseño fiscal (4 de 4) — apilado sobre #422

- **mig 119** (APLICADA): `mermas_stock.costo_unitario` + trigger BEFORE INSERT → mermas valuadas al costo congelado del día (cierra el riesgo documentado en docs/plan-auditoria-integridad.md ítem 8; el KPI de un mes cerrado ya no cambia al reprecificar).
- **mig 120** (APLICADA): `reporte_gerencial` con claves **aditivas** — `venta_neta` (ZZ: total; FC: sin IVA/II → margen comparable entre canales), `iva_debito`, `margen_comercial_neto`, mix `fc_*`/`zz_*`; costos de items/bonif/mermas → `COALESCE(snapshot, costo_real, fórmula vieja)`. Las claves brutas no cambian: front actual y /reporte-mensual siguen intactos.
- **mig 121** (APLICADA): RPC `posicion_fiscal(sucursal, desde, hasta)` — IVA débito vs crédito (saldo técnico), II soportado, percepciones IVA/IIBB a favor, mix FC/ZZ de ventas y compras. Con nota explícita: estimación de gestión, no reemplaza la liquidación del contador.
- **Front**: banda fiscal bajo los KPIs (aparece solo si hay ventas FC en el período) + sección "Posición fiscal (FC/ZZ)" en el detalle (lazy). **Se unifican las 3 definiciones de costo** que convivían: Rentabilidad dejaba fuera los imp. internos y el export Power BI usaba `costo_con_iva` (sobreestimaba); ambos pasan a snapshot → `costo_real`. El export de compras suma el desglose fiscal por fila.

### Verificación en prod
Corrí `reporte_gerencial` y `posicion_fiscal` sobre el período en curso: al ser un mes todo-ZZ, `venta_neta = venta` e `iva_debito = 0` como corresponde, y la posición fiscal refleja el crédito IVA de las compras FC del período.

Cierra el plan de 4 fases (A #420, B #421, C #422).

🤖 Generated with [Claude Code](https://claude.com/claude-code)