### PR TITLE
fix(fiscal): la venta FC no discrimina impuestos internos

### DIFF
--- a/migrations/122_venta_fc_sin_impuestos_internos.sql
+++ b/migrations/122_venta_fc_sin_impuestos_internos.sql
@@ -1,0 +1,38 @@
+-- ============================================================================
+-- 122 · Venta FC: el desglose NO discrimina impuestos internos
+-- ============================================================================
+-- Regla de negocio (aclarada por el usuario 2026-07-14): la distribuidora NO
+-- es agente de impuestos internos. El II existe solo en la COMPRA (integra el
+-- costo real, mig 111); la factura de VENTA discrimina únicamente neto + IVA.
+--
+--   Antes (mig 117): FC → neto = precio / (1 + iva% + II%)   ← subestimaba el
+--                    neto y "facturaba" un II fantasma.
+--   Ahora:           FC → neto = precio / (1 + iva%); iva = neto × iva%; II = 0.
+--   ZZ: sin cambios (todo el precio es ingreso neto).
+--
+-- Un solo CREATE OR REPLACE de calcular_desglose_venta corrige los 5 RPCs que
+-- la usan (crear_pedido_completo, _bot, actualizar_pedido_items,
+-- anular_salvedad, cambiar_tipo_factura_pedido) sin tocarlos: todos le pasan
+-- la tasa de II del producto, que ahora se ignora en el lado venta.
+-- No hay datos que corregir: el único pedido FC en prod está cancelado con
+-- total 0 y ningún item FC tiene II > 0.
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION public.calcular_desglose_venta(
+  p_precio numeric,
+  p_pct_iva numeric,
+  p_pct_ii numeric,
+  p_tipo_factura text
+) RETURNS TABLE(neto numeric, iva numeric, imp_internos numeric)
+LANGUAGE sql IMMUTABLE
+AS $$
+  SELECT
+    CASE WHEN p_tipo_factura = 'ZZ' THEN round(COALESCE(p_precio, 0), 2)
+         ELSE round(COALESCE(p_precio, 0) / (1 + COALESCE(p_pct_iva, 0)/100), 2) END,
+    CASE WHEN p_tipo_factura = 'ZZ' THEN 0::numeric
+         ELSE round(COALESCE(p_precio, 0) / (1 + COALESCE(p_pct_iva, 0)/100) * COALESCE(p_pct_iva, 0)/100, 2) END,
+    0::numeric;  -- la venta nunca discrimina imp. internos (no somos agente)
+$$;
+
+COMMENT ON FUNCTION public.calcular_desglose_venta(numeric, numeric, numeric, text) IS
+  'Desglose fiscal por unidad de VENTA. ZZ: todo el precio es ingreso neto. FC: neto = precio/(1+iva%); la venta NUNCA discrimina impuestos internos (la distribuidora no es agente; el II vive solo en el costo de compra). p_pct_ii se conserva en la firma por compatibilidad pero se ignora.';

--- a/src/components/modals/ModalProducto.tsx
+++ b/src/components/modals/ModalProducto.tsx
@@ -152,9 +152,11 @@ const ModalProducto = memo(function ModalProducto({ producto, categorias, provee
   //  - costo_con_iva (costo final) desde el costo neto + IVA + imp. internos
   //  - precio_sin_iva (precio neto) HACIA ATRÁS desde el precio final (el usuario
   //    edita el precio final; en venta ZZ el ingreso es el final, en FC el neto).
+  //    OJO: la VENTA no discrimina imp. internos (no somos agente, mig 122):
+  //    el precio neto es precio / (1 + IVA%), sin II. El II solo afecta el costo.
   const recalcularTotales = (nuevoForm: ProductoFormData): ProductoFormData => {
     const costoTotal = calcularTotalConIva(nuevoForm.costo_sin_iva, nuevoForm.porcentaje_iva, nuevoForm.impuestos_internos);
-    const precioNeto = calcularNetoDesdeTotal(nuevoForm.precio, nuevoForm.porcentaje_iva, nuevoForm.impuestos_internos);
+    const precioNeto = calcularNetoDesdeTotal(nuevoForm.precio, nuevoForm.porcentaje_iva, 0);
     return {
       ...nuevoForm,
       costo_con_iva: costoTotal ? costoTotal.toFixed(2) : '',
@@ -179,7 +181,7 @@ const ModalProducto = memo(function ModalProducto({ producto, categorias, provee
     setMargen(margenDesdeForm(nuevoForm));
   };
 
-  // Imp. internos: cambian costo final y precio neto (precio final fijo); recalcular margen.
+  // Imp. internos: solo cambian el costo final (la venta no los discrimina); recalcular margen.
   const handleImpuestosInternosChange = (valor: string): void => {
     const nuevoForm = recalcularTotales({ ...form, impuestos_internos: valor });
     setForm(nuevoForm);
@@ -565,7 +567,8 @@ const ModalProducto = memo(function ModalProducto({ producto, categorias, provee
           </div>
 
           <p className="text-xs text-gray-500 mt-2">
-            * El precio final incluye IVA ({form.porcentaje_iva || 21}%) + Imp. Internos ({form.impuestos_internos || 0}%). El neto se calcula hacia atrás.
+            * El precio final incluye IVA ({form.porcentaje_iva || 21}%). El neto se calcula hacia atrás.
+            La venta no discrimina imp. internos (no somos agente): el II solo integra el costo.
           </p>
         </div>
       </div>

--- a/src/components/vistas/VistaReportesGerenciales.tsx
+++ b/src/components/vistas/VistaReportesGerenciales.tsx
@@ -350,7 +350,7 @@ export default function VistaReportesGerenciales({
           {/* Fiscal (mig 120): solo si hay ventas FC en el período (todo-ZZ ⇒ venta neta = venta) */}
           {(k.fc_pedidos ?? 0) > 0 && k.venta_neta != null && (
             <div className="flex flex-wrap items-center gap-x-5 gap-y-1 bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-800 rounded-lg px-4 py-2.5 text-sm text-blue-900 dark:text-blue-200">
-              <span><b>Venta neta</b> (sin IVA/II de FC): <b>{moneyC(k.venta_neta)}</b></span>
+              <span><b>Venta neta</b> (sin IVA de FC): <b>{moneyC(k.venta_neta)}</b></span>
               <span>Margen comercial s/neta: <b>{moneyC(k.margen_comercial_neto ?? (k.venta_neta - k.cmv))}</b></span>
               <span>IVA débito: <b>{moneyC(k.iva_debito ?? 0)}</b></span>
               <span>Mix: FC {moneyC(k.fc_venta ?? 0)} ({N.format(k.fc_pedidos ?? 0)}) · ZZ {moneyC(k.zz_venta ?? 0)} ({N.format(k.zz_pedidos ?? 0)})</span>

--- a/src/utils/calculations.fiscal.test.ts
+++ b/src/utils/calculations.fiscal.test.ts
@@ -40,16 +40,17 @@ describe('calcularCostoFinanciero (desembolso por unidad, sin percepciones)', ()
   })
 })
 
-describe('calcularNetoVenta con impuestos internos (estructura de la factura)', () => {
-  it('FC: precio final = neto × (1 + IVA + II); IVA = 21% exacto del neto', () => {
-    // Venta FC de una cola a $10.000 final
+describe('calcularNetoVenta (mig 122: la venta NO discrimina imp. internos)', () => {
+  it('FC: neto = precio/(1+IVA%); el II del producto se ignora (no somos agente)', () => {
+    // Venta FC de una cola a $10.000 final: aunque el producto tenga II 8,6956%,
+    // la factura de venta discrimina solo neto + IVA.
     const d = calcularNetoVenta(10000, 21, 8.6956, 'FC')
-    expect(d.neto).toBeCloseTo(7710.36, 2)
-    expect(d.iva).toBeCloseTo(1619.18, 2)
-    expect(d.impuestosInternos).toBeCloseTo(670.46, 2)
-    // Reconstrucción: neto + iva + ii = precio final
-    expect(d.neto + d.iva + d.impuestosInternos).toBeCloseTo(10000, 2)
-    // Propiedad de la factura real: IVA es exactamente 21% del gravado
+    expect(d.neto).toBeCloseTo(8264.46, 2)
+    expect(d.iva).toBeCloseTo(1735.54, 2)
+    expect(d.impuestosInternos).toBe(0)
+    // Reconstrucción: neto + iva = precio final
+    expect(d.neto + d.iva).toBeCloseTo(10000, 2)
+    // IVA es exactamente 21% del gravado
     expect(d.iva).toBeCloseTo(d.neto * 0.21, 2)
   })
 

--- a/src/utils/calculations.ts
+++ b/src/utils/calculations.ts
@@ -91,21 +91,27 @@ export interface DesgloseNetoVenta {
 }
 
 /**
- * Calcula el ingreso neto de una venta según tipo de factura
+ * Calcula el ingreso neto de una venta según tipo de factura (espejo del SQL
+ * calcular_desglose_venta, mig 122).
  *
- * ZZ (sin factura): todo el precio final es ingreso neto
- * FC (con factura): el neto es el precio sin IVA ni impuestos, el IVA se remite a AFIP
+ * ZZ (sin factura): todo el precio final es ingreso neto.
+ * FC (con factura): neto = precio / (1 + IVA%); el IVA se remite a AFIP.
  *
- * @param precioFinal - Precio final al consumidor (incluye IVA + imp internos)
+ * La venta NUNCA discrimina impuestos internos: la distribuidora no es agente
+ * de II — el II existe solo en el COSTO de compra (calcularCostoReal). El
+ * parámetro porcentajeImpInternos se conserva por compatibilidad pero se
+ * ignora (mig 122; antes dividía por 1+iva+II y subestimaba el neto).
+ *
+ * @param precioFinal - Precio final al consumidor (incluye IVA)
  * @param porcentajeIva - Porcentaje de IVA del producto (ej: 21, 10.5, 0)
- * @param porcentajeImpInternos - Porcentaje de impuestos internos (ej: 5, 8)
+ * @param _porcentajeImpInternos - IGNORADO (compat de firma)
  * @param tipoFactura - 'ZZ' o 'FC'
- * @returns Desglose con neto, iva e impuestos internos
+ * @returns Desglose con neto, iva e impuestos internos (siempre 0)
  */
 export function calcularNetoVenta(
   precioFinal: number | string,
   porcentajeIva: number | string = 21,
-  porcentajeImpInternos: number | string = 0,
+  _porcentajeImpInternos: number | string = 0,
   tipoFactura: 'ZZ' | 'FC' = 'ZZ'
 ): DesgloseNetoVenta {
   const precio = parseFloat(String(precioFinal)) || 0;
@@ -114,12 +120,11 @@ export function calcularNetoVenta(
     return { neto: precio, iva: 0, impuestosInternos: 0 };
   }
 
-  // FC: back-calculate neto from final price
-  const neto = calcularNetoDesdeTotal(precio, porcentajeIva, porcentajeImpInternos);
+  // FC: back-calculate neto from final price (solo IVA; sin II)
+  const neto = calcularNetoDesdeTotal(precio, porcentajeIva, 0);
   const iva = calcularMontoIva(neto, porcentajeIva);
-  const impInt = neto * (parseFloat(String(porcentajeImpInternos)) || 0) / 100;
 
-  return { neto, iva, impuestosInternos: impInt };
+  return { neto, iva, impuestosInternos: 0 };
 }
 
 /**


### PR DESCRIPTION
Ajuste de regla de negocio sobre las fases C/D ya mergeadas (#422/#423): **la distribuidora no es agente de impuestos internos** — el II integra solo el costo de compra; la factura de venta discrimina neto + IVA únicamente.

- **mig 122** (APLICADA): `calcular_desglose_venta` FC → `neto = precio/(1+iva%)`, II siempre 0. Un solo `OR REPLACE` corrige los 5 RPCs que la usan (crear/bot/editar/anular salvedad/cambiar tipo). Sin backfill necesario: el único pedido FC existente está cancelado con total 0.
- `calcularNetoVenta` (espejo TS) ídem; ModalProducto deriva `precio_sin_iva` sin II; labels actualizados.
- Verificado en prod: FC $10.000 al 21% → neto 8.264,46 / IVA 1.735,54 / II 0 ✓ (antes daba neto 7.710,36 con II fantasma de 670,46).

🤖 Generated with [Claude Code](https://claude.com/claude-code)