### PR TITLE
feat(fiscal): terna ingreso neto/final/real + margen real + compra con II editable

### DIFF
--- a/migrations/123_terna_ingresos_pedidos.sql
+++ b/migrations/123_terna_ingresos_pedidos.sql
@@ -1,0 +1,1588 @@
+-- ============================================================================
+-- 123 · Terna de ingresos en pedidos: NETO / FINAL / REAL
+-- ============================================================================
+-- Lógica definitiva del negocio (2026-07-14):
+--   · ingreso FINAL  = precio cobrado (pedidos.total / pedido_items.precio_unitario)
+--   · ingreso NETO   = precio / (1 + IVA%)  — SIEMPRE, también en ZZ (teórico)
+--   · ingreso REAL   = neto si FC (el IVA se remite) · final si ZZ
+--   · La métrica reina es margen real = Σ ingresos reales − Σ costos reales
+--     (costo real = neto compra + imp. internos, ya canónico desde mig 111).
+--
+-- CAMBIO DE SEMÁNTICA (decisión del usuario): hasta ahora total_neto /
+-- neto_unitario guardaban el "real" (FC: sin IVA; ZZ: final). Pasan a ser el
+-- NETO SIEMPRE-SIN-IVA y se agregan pedido_items.ingreso_real_unitario y
+-- pedidos.total_real con la semántica vieja. iva_unitario / total_iva NO
+-- cambian: siguen siendo el IVA DISCRIMINADO (débito real, 0 en ZZ) — así
+-- iva_debito y posicion_fiscal quedan intactos.
+--
+-- Backfill (¡orden importa!):
+--   1) real := semántica vieja (COALESCE(neto, precio))
+--   2) neto := recomputado sin-IVA-siempre (ZZ usa la tasa del producto)
+--
+-- RPCs actualizados (OR REPLACE, mismas firmas): crear_pedido_completo,
+-- crear_pedido_completo_bot, actualizar_pedido_items, anular_salvedad,
+-- cambiar_tipo_factura_pedido, registrar_salvedad (2 overloads).
+-- calcular_desglose_venta cambia el tipo de retorno (DROP + CREATE):
+-- (neto, iva, ingreso_real).
+-- Nota: al cambiar FC↔ZZ el neto ya NO cambia (es teórico); solo se
+-- redistribuyen iva e ingreso_real. total invariante.
+-- ============================================================================
+
+-- ─── 1. Columnas ────────────────────────────────────────────────────────────
+
+ALTER TABLE public.pedido_items
+  ADD COLUMN IF NOT EXISTS ingreso_real_unitario numeric(12,2);
+
+ALTER TABLE public.pedidos
+  ADD COLUMN IF NOT EXISTS total_real numeric(12,2);
+
+COMMENT ON COLUMN public.pedido_items.ingreso_real_unitario IS
+  'Ingreso REAL por unidad: FC = neto (el IVA se remite); ZZ = precio final. Bonificaciones = 0. LA base del margen real.';
+COMMENT ON COLUMN public.pedido_items.neto_unitario IS
+  'Precio sin IVA por unidad, SIEMPRE (también en ZZ, donde es teórico). Hasta mig 123 guardaba el ingreso real.';
+COMMENT ON COLUMN public.pedido_items.iva_unitario IS
+  'IVA DISCRIMINADO por unidad: solo ventas FC (débito real); 0 en ZZ.';
+COMMENT ON COLUMN public.pedidos.total_real IS
+  'Σ ingreso_real_unitario × cantidad (no bonif). FC = total_neto; ZZ = total.';
+COMMENT ON COLUMN public.pedidos.total_neto IS
+  'Σ neto (sin IVA, SIEMPRE) × cantidad. Hasta mig 123 guardaba el ingreso real.';
+
+-- ─── 2. Backfill ────────────────────────────────────────────────────────────
+
+-- 2a) real := semántica vieja de neto (FC: sin IVA ✓ · ZZ: final ✓)
+UPDATE public.pedido_items
+   SET ingreso_real_unitario = CASE WHEN COALESCE(es_bonificacion, false) THEN 0
+                                    ELSE COALESCE(neto_unitario, precio_unitario) END
+ WHERE ingreso_real_unitario IS NULL;
+
+UPDATE public.pedidos
+   SET total_real = COALESCE(total_neto, total)
+ WHERE total_real IS NULL;
+
+-- 2b) neto := sin-IVA-siempre. FC ya lo es; ZZ se recomputa con la tasa del
+--     ítem (si la guardó) o la del producto (post-backfill 112 es confiable).
+UPDATE public.pedido_items pi
+   SET neto_unitario = CASE
+         WHEN COALESCE(pi.es_bonificacion, false) THEN 0
+         ELSE round(pi.precio_unitario /
+              (1 + COALESCE(NULLIF(pi.porcentaje_iva, 0), prod.porcentaje_iva, 21) / 100), 2)
+       END
+  FROM pedidos p, productos prod
+ WHERE p.id = pi.pedido_id
+   AND prod.id = pi.producto_id AND prod.sucursal_id = pi.sucursal_id
+   AND COALESCE(p.tipo_factura, 'ZZ') = 'ZZ';
+
+UPDATE public.pedidos p
+   SET total_neto = sub.neto
+  FROM (
+    SELECT pedido_id,
+           COALESCE(SUM(CASE WHEN NOT COALESCE(es_bonificacion, false)
+                             THEN cantidad * COALESCE(neto_unitario, 0) ELSE 0 END), 0) AS neto
+      FROM pedido_items GROUP BY pedido_id
+  ) sub
+ WHERE sub.pedido_id = p.id
+   AND COALESCE(p.tipo_factura, 'ZZ') = 'ZZ';
+
+-- ─── 3. calcular_desglose_venta v3: (neto, iva, ingreso_real) ───────────────
+
+DROP FUNCTION IF EXISTS public.calcular_desglose_venta(numeric, numeric, numeric, text);
+
+CREATE FUNCTION public.calcular_desglose_venta(
+  p_precio numeric,
+  p_pct_iva numeric,
+  p_pct_ii numeric,
+  p_tipo_factura text
+) RETURNS TABLE(neto numeric, iva numeric, ingreso_real numeric)
+LANGUAGE sql IMMUTABLE
+AS $$
+  SELECT
+    -- neto: SIEMPRE sin IVA (teórico en ZZ). La venta no discrimina II (mig 122).
+    round(COALESCE(p_precio, 0) / (1 + COALESCE(p_pct_iva, 0)/100), 2),
+    -- iva: discriminado solo en FC (débito real)
+    CASE WHEN p_tipo_factura = 'FC'
+         THEN round(COALESCE(p_precio, 0) / (1 + COALESCE(p_pct_iva, 0)/100) * COALESCE(p_pct_iva, 0)/100, 2)
+         ELSE 0::numeric END,
+    -- ingreso real: FC = neto · ZZ = precio final
+    CASE WHEN p_tipo_factura = 'FC'
+         THEN round(COALESCE(p_precio, 0) / (1 + COALESCE(p_pct_iva, 0)/100), 2)
+         ELSE round(COALESCE(p_precio, 0), 2) END;
+$$;
+
+COMMENT ON FUNCTION public.calcular_desglose_venta(numeric, numeric, numeric, text) IS
+  'Terna de ingresos por unidad de venta (mig 123): neto = precio/(1+iva%) SIEMPRE; iva discriminado solo FC; ingreso_real = neto si FC, precio final si ZZ. p_pct_ii se ignora (la venta no discrimina II, mig 122).';
+
+-- ─── 4. crear_pedido_completo ───────────────────────────────────────────────
+
+CREATE OR REPLACE FUNCTION public.crear_pedido_completo(p_cliente_id bigint, p_total numeric, p_usuario_id uuid, p_items jsonb, p_notas text DEFAULT NULL::text, p_forma_pago text DEFAULT 'efectivo'::text, p_estado_pago text DEFAULT 'pendiente'::text, p_fecha date DEFAULT NULL::date, p_tipo_factura text DEFAULT 'ZZ'::text, p_total_neto numeric DEFAULT NULL::numeric, p_total_iva numeric DEFAULT 0, p_fecha_entrega_programada date DEFAULT NULL::date, p_preventista_id uuid DEFAULT NULL::uuid)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public'
+AS $function$
+DECLARE
+  v_sucursal BIGINT := current_sucursal_id();
+  v_pedido_id INT; item JSONB; v_producto_id INT; v_cantidad INT;
+  v_precio_unitario DECIMAL; v_es_bonificacion BOOLEAN; v_promocion_id BIGINT;
+  v_neto_unitario DECIMAL; v_iva_unitario DECIMAL; v_ingreso_real DECIMAL;
+  v_porcentaje_iva DECIMAL; v_stock_actual INT; v_producto_nombre TEXT;
+  errores TEXT[] := '{}'; v_user_role TEXT;
+  v_cantidades_totales JSONB := '{}'::JSONB; v_cant_acumulada INT;
+  v_stock_snapshot JSONB := '{}'::JSONB;
+  v_stock_al_crear INT;
+  v_costo_actual NUMERIC; v_imp_int_actual NUMERIC; v_pct_iva_actual NUMERIC; v_costo_real_actual NUMERIC;
+  v_costo_snapshot JSONB := '{}'::JSONB; v_costo_al_crear NUMERIC;
+  v_pct_iva_snapshot JSONB := '{}'::JSONB;
+  v_pct_ii_snapshot JSONB := '{}'::JSONB;
+  v_tipo_factura TEXT := COALESCE(p_tipo_factura, 'ZZ');
+  v_total_neto_calc NUMERIC := 0;
+  v_total_iva_calc NUMERIC := 0;
+  v_total_real_calc NUMERIC := 0;
+  v_es_regalo_no_mueve_stock JSONB := '{}'::JSONB;
+  v_regalo_mueve_stock BOOLEAN;
+  v_descripcion_regalo TEXT;
+  v_regalo_default_id BIGINT;
+  v_container_id INT;
+  v_fecha_pedido DATE := COALESCE(p_fecha, (now() AT TIME ZONE 'America/Argentina/Buenos_Aires')::date);
+  v_fecha_entrega DATE := COALESCE(p_fecha_entrega_programada, (v_fecha_pedido + INTERVAL '1 day')::date);
+  v_promo RECORD;
+  v_usos_pendientes_actual INT;
+  v_bloques_completos INT;
+  v_ajustar_usos INT;
+  v_ajustar_stock INT;
+  v_stock_ajuste_anterior INT;
+  v_stock_ajuste_nuevo INT;
+  v_ajuste_producto_nombre TEXT;
+  v_merma_id BIGINT;
+  v_pedidos_bundle TEXT;
+  v_observacion TEXT;
+  v_preventista_role TEXT;
+  v_preventista_final UUID;
+BEGIN
+  IF v_sucursal IS NULL THEN RETURN jsonb_build_object('success', false, 'errores', jsonb_build_array('No se pudo determinar la sucursal activa')); END IF;
+  IF p_usuario_id IS DISTINCT FROM auth.uid() THEN RETURN jsonb_build_object('success', false, 'errores', jsonb_build_array('ID de usuario no coincide con la sesion autenticada')); END IF;
+  SELECT rol INTO v_user_role FROM perfiles WHERE id = p_usuario_id;
+  IF v_user_role IS NULL OR v_user_role NOT IN ('admin', 'preventista', 'preventista_taco', 'encargado') THEN RETURN jsonb_build_object('success', false, 'errores', jsonb_build_array('No tiene permisos para crear pedidos')); END IF;
+
+  IF p_preventista_id IS NULL OR p_preventista_id = p_usuario_id THEN
+    v_preventista_final := p_usuario_id;
+  ELSE
+    IF v_user_role <> 'admin' THEN
+      RETURN jsonb_build_object('success', false, 'errores', jsonb_build_array('Solo admin puede asignar otro preventista al pedido'));
+    END IF;
+    SELECT p.rol INTO v_preventista_role
+    FROM perfiles p
+    WHERE p.id = p_preventista_id
+      AND p.activo = true
+      AND EXISTS (
+        SELECT 1 FROM usuario_sucursales us
+        WHERE us.usuario_id = p.id AND us.sucursal_id = v_sucursal
+      );
+    IF v_preventista_role IS NULL OR v_preventista_role NOT IN ('admin', 'preventista', 'preventista_taco') THEN
+      RETURN jsonb_build_object('success', false, 'errores', jsonb_build_array('El usuario asignado no es admin ni preventista (o no pertenece a la sucursal)'));
+    END IF;
+    v_preventista_final := p_preventista_id;
+  END IF;
+
+  FOR item IN SELECT * FROM jsonb_array_elements(p_items) LOOP
+    v_producto_id := (item->>'producto_id')::INT; v_cantidad := (item->>'cantidad')::INT;
+    v_es_bonificacion := COALESCE((item->>'es_bonificacion')::BOOLEAN, false);
+    IF v_cantidad IS NULL OR v_cantidad <= 0 THEN errores := array_append(errores, 'Cantidad invalida para producto ID ' || v_producto_id); CONTINUE; END IF;
+
+    v_cant_acumulada := COALESCE((v_cantidades_totales->>v_producto_id::TEXT)::INT, 0) + v_cantidad;
+    v_cantidades_totales := v_cantidades_totales || jsonb_build_object(v_producto_id::TEXT, v_cant_acumulada);
+
+    IF v_es_bonificacion THEN
+      v_promocion_id := (item->>'promocion_id')::BIGINT;
+      IF v_promocion_id IS NOT NULL THEN
+        SELECT regalo_mueve_stock INTO v_regalo_mueve_stock FROM promociones WHERE id = v_promocion_id AND sucursal_id = v_sucursal;
+        IF NOT COALESCE(v_regalo_mueve_stock, FALSE) THEN
+          v_es_regalo_no_mueve_stock := v_es_regalo_no_mueve_stock || jsonb_build_object(v_producto_id::TEXT, true);
+        END IF;
+      ELSE
+        v_es_regalo_no_mueve_stock := v_es_regalo_no_mueve_stock || jsonb_build_object(v_producto_id::TEXT, true);
+      END IF;
+    END IF;
+  END LOOP;
+
+  FOR v_producto_id IN SELECT (key)::INT FROM jsonb_each_text(v_cantidades_totales) LOOP
+    v_cantidad := (v_cantidades_totales->>v_producto_id::TEXT)::INT;
+    SELECT stock, nombre, costo_real, costo_sin_iva, COALESCE(impuestos_internos, 0), COALESCE(porcentaje_iva, 21)
+      INTO v_stock_actual, v_producto_nombre, v_costo_real_actual, v_costo_actual, v_imp_int_actual, v_pct_iva_actual
+      FROM productos WHERE id = v_producto_id AND sucursal_id = v_sucursal FOR UPDATE;
+    IF v_stock_actual IS NULL THEN
+      errores := array_append(errores, 'Producto ID ' || v_producto_id || ' no encontrado');
+    ELSIF v_stock_actual < v_cantidad THEN
+      IF COALESCE((v_es_regalo_no_mueve_stock->>v_producto_id::TEXT)::BOOLEAN, FALSE) THEN
+        errores := array_append(errores, v_producto_nombre || ': stock insuficiente para regalo (disponible: ' || v_stock_actual || ', solicitado: ' || v_cantidad || ')');
+      ELSE
+        errores := array_append(errores, v_producto_nombre || ': stock insuficiente (disponible: ' || v_stock_actual || ', solicitado: ' || v_cantidad || ')');
+      END IF;
+    END IF;
+    IF v_stock_actual IS NOT NULL THEN
+      v_stock_snapshot := v_stock_snapshot || jsonb_build_object(v_producto_id::TEXT, v_stock_actual);
+      v_costo_snapshot := v_costo_snapshot || jsonb_build_object(v_producto_id::TEXT,
+        COALESCE(v_costo_real_actual,
+          CASE WHEN v_costo_actual IS NULL THEN NULL
+               ELSE round(v_costo_actual * (1 + COALESCE(v_imp_int_actual, 0) / 100), 4) END));
+      v_pct_iva_snapshot := v_pct_iva_snapshot || jsonb_build_object(v_producto_id::TEXT, v_pct_iva_actual);
+      v_pct_ii_snapshot := v_pct_ii_snapshot || jsonb_build_object(v_producto_id::TEXT, v_imp_int_actual);
+    END IF;
+  END LOOP;
+
+  IF array_length(errores, 1) > 0 THEN RETURN jsonb_build_object('success', false, 'errores', to_jsonb(errores)); END IF;
+
+  INSERT INTO pedidos (cliente_id, fecha, total, total_neto, total_iva, total_real, tipo_factura, estado, usuario_id, creado_por, stock_descontado, notas, forma_pago, estado_pago, fecha_entrega_programada, sucursal_id)
+  VALUES (p_cliente_id, v_fecha_pedido, p_total, COALESCE(p_total_neto, p_total), COALESCE(p_total_iva, 0), p_total, v_tipo_factura, 'pendiente', v_preventista_final, p_usuario_id, true, p_notas, p_forma_pago, p_estado_pago, v_fecha_entrega, v_sucursal)
+  RETURNING id INTO v_pedido_id;
+
+  PERFORM set_config('app.stock_origen', 'pedido_creado', true);
+  PERFORM set_config('app.stock_ref_tipo', 'pedido', true);
+  PERFORM set_config('app.stock_ref_id', v_pedido_id::TEXT, true);
+  PERFORM set_config('app.stock_user_id', p_usuario_id::TEXT, true);
+
+  IF v_preventista_final IS DISTINCT FROM p_usuario_id THEN
+    INSERT INTO pedido_historial (pedido_id, usuario_id, campo_modificado, valor_anterior, valor_nuevo, sucursal_id)
+    VALUES (v_pedido_id, p_usuario_id, 'usuario_id', NULL, v_preventista_final::TEXT, v_sucursal);
+  END IF;
+
+  FOR item IN SELECT * FROM jsonb_array_elements(p_items) LOOP
+    v_producto_id := (item->>'producto_id')::INT; v_cantidad := (item->>'cantidad')::INT;
+    v_precio_unitario := (item->>'precio_unitario')::DECIMAL;
+    v_es_bonificacion := COALESCE((item->>'es_bonificacion')::BOOLEAN, false);
+    v_promocion_id := (item->>'promocion_id')::BIGINT;
+    v_stock_al_crear := (v_stock_snapshot->>v_producto_id::TEXT)::INT;
+    v_costo_al_crear := (v_costo_snapshot->>v_producto_id::TEXT)::NUMERIC;
+
+    -- Terna de ingresos SERVER-SIDE (mig 123)
+    IF v_es_bonificacion THEN
+      v_neto_unitario := 0; v_iva_unitario := 0; v_ingreso_real := 0; v_porcentaje_iva := 0;
+    ELSE
+      SELECT d.neto, d.iva, d.ingreso_real
+        INTO v_neto_unitario, v_iva_unitario, v_ingreso_real
+        FROM calcular_desglose_venta(
+          v_precio_unitario,
+          (v_pct_iva_snapshot->>v_producto_id::TEXT)::NUMERIC,
+          (v_pct_ii_snapshot->>v_producto_id::TEXT)::NUMERIC,
+          v_tipo_factura) d;
+      v_porcentaje_iva := (v_pct_iva_snapshot->>v_producto_id::TEXT)::NUMERIC;
+      v_total_neto_calc := v_total_neto_calc + (v_cantidad * v_neto_unitario);
+      v_total_iva_calc  := v_total_iva_calc  + (v_cantidad * v_iva_unitario);
+      v_total_real_calc := v_total_real_calc + (v_cantidad * v_ingreso_real);
+    END IF;
+
+    v_descripcion_regalo := NULL;
+    v_regalo_default_id := NULL;
+    IF v_es_bonificacion AND v_promocion_id IS NOT NULL THEN
+      SELECT descripcion_regalo, producto_regalo_id
+        INTO v_descripcion_regalo, v_regalo_default_id
+        FROM promociones WHERE id = v_promocion_id AND sucursal_id = v_sucursal;
+      IF v_regalo_default_id IS DISTINCT FROM v_producto_id THEN
+        v_descripcion_regalo := NULL;
+      END IF;
+    END IF;
+
+    INSERT INTO pedido_items (
+      pedido_id, producto_id, cantidad, precio_unitario, subtotal,
+      es_bonificacion, promocion_id,
+      neto_unitario, iva_unitario, impuestos_internos_unitario, porcentaje_iva,
+      ingreso_real_unitario,
+      sucursal_id, descripcion_regalo, stock_al_crear, costo_unitario_al_crear
+    ) VALUES (
+      v_pedido_id, v_producto_id, v_cantidad, v_precio_unitario, v_cantidad * v_precio_unitario,
+      v_es_bonificacion, v_promocion_id,
+      v_neto_unitario, v_iva_unitario, 0, v_porcentaje_iva,
+      v_ingreso_real,
+      v_sucursal, v_descripcion_regalo, v_stock_al_crear, v_costo_al_crear
+    );
+
+    IF NOT v_es_bonificacion THEN
+      UPDATE productos SET stock = stock - v_cantidad WHERE id = v_producto_id AND sucursal_id = v_sucursal;
+    ELSIF v_promocion_id IS NOT NULL THEN
+      SELECT regalo_mueve_stock INTO v_regalo_mueve_stock FROM promociones WHERE id = v_promocion_id AND sucursal_id = v_sucursal;
+      IF COALESCE(v_regalo_mueve_stock, FALSE) THEN
+        UPDATE productos SET stock = stock - v_cantidad WHERE id = v_producto_id AND sucursal_id = v_sucursal;
+      END IF;
+    END IF;
+
+    IF v_es_bonificacion AND v_promocion_id IS NOT NULL THEN
+      UPDATE promociones SET usos_pendientes = usos_pendientes + v_cantidad WHERE id = v_promocion_id AND sucursal_id = v_sucursal;
+
+      SELECT id, nombre, ajuste_automatico, ajuste_producto_id, unidades_por_bloque,
+             stock_por_bloque, usos_pendientes, producto_regalo_id
+      INTO v_promo
+      FROM promociones WHERE id = v_promocion_id AND sucursal_id = v_sucursal FOR UPDATE;
+
+      v_container_id := CASE WHEN v_promo.producto_regalo_id IS DISTINCT FROM v_producto_id
+                             THEN v_producto_id ELSE v_promo.ajuste_producto_id END;
+
+      IF v_promo.ajuste_automatico AND v_container_id IS NOT NULL
+         AND COALESCE(v_promo.unidades_por_bloque, 0) > 0 AND COALESCE(v_promo.stock_por_bloque, 0) > 0 THEN
+        v_usos_pendientes_actual := v_promo.usos_pendientes;
+        v_bloques_completos := v_usos_pendientes_actual / v_promo.unidades_por_bloque;
+        IF v_bloques_completos > 0 THEN
+          v_ajustar_usos := v_bloques_completos * v_promo.unidades_por_bloque;
+          v_ajustar_stock := v_bloques_completos * v_promo.stock_por_bloque;
+
+          SELECT stock, nombre INTO v_stock_ajuste_anterior, v_ajuste_producto_nombre
+          FROM productos WHERE id = v_container_id AND sucursal_id = v_sucursal FOR UPDATE;
+
+          IF v_stock_ajuste_anterior IS NULL THEN
+            RAISE EXCEPTION 'Auto-ajuste: producto destino no encontrado (promo %)', v_promocion_id;
+          END IF;
+          IF v_stock_ajuste_anterior < v_ajustar_stock THEN
+            RAISE EXCEPTION 'Auto-ajuste: stock insuficiente en % (disponible: %, requerido: %)',
+              v_ajuste_producto_nombre, v_stock_ajuste_anterior, v_ajustar_stock;
+          END IF;
+
+          v_stock_ajuste_nuevo := v_stock_ajuste_anterior - v_ajustar_stock;
+
+          v_pedidos_bundle := public.pedido_bundle_para_promo(v_promocion_id, v_sucursal, 20);
+          v_observacion := 'Auto-ajuste (Promo: ' || v_promo.nombre
+                           || ', Pedidos: ' || COALESCE(v_pedidos_bundle, '#' || v_pedido_id) || ')';
+
+          INSERT INTO mermas_stock (producto_id, cantidad, motivo, observaciones, stock_anterior, stock_nuevo, usuario_id, sucursal_id)
+          VALUES (v_container_id, v_ajustar_stock, 'promociones', v_observacion,
+            v_stock_ajuste_anterior, v_stock_ajuste_nuevo, p_usuario_id, v_sucursal)
+          RETURNING id INTO v_merma_id;
+
+          UPDATE productos SET stock = v_stock_ajuste_nuevo, updated_at = NOW()
+          WHERE id = v_container_id AND sucursal_id = v_sucursal;
+
+          INSERT INTO promo_ajustes (promocion_id, usos_ajustados, unidades_ajustadas, producto_id, merma_id, usuario_id, observaciones, sucursal_id)
+          VALUES (v_promocion_id, v_ajustar_usos, v_ajustar_stock, v_container_id,
+            v_merma_id, p_usuario_id, v_observacion, v_sucursal);
+
+          UPDATE promociones SET usos_pendientes = GREATEST(usos_pendientes - v_ajustar_usos, 0)
+          WHERE id = v_promocion_id AND sucursal_id = v_sucursal;
+        END IF;
+      END IF;
+    END IF;
+  END LOOP;
+
+  -- Terna autoritativa server-side
+  UPDATE pedidos
+     SET total_neto = round(v_total_neto_calc, 2),
+         total_iva  = round(v_total_iva_calc, 2),
+         total_real = round(v_total_real_calc, 2)
+   WHERE id = v_pedido_id AND sucursal_id = v_sucursal;
+
+  RETURN jsonb_build_object('success', true, 'pedido_id', v_pedido_id);
+END;
+$function$;
+
+-- ─── 5. crear_pedido_completo_bot (siempre ZZ: real = final; neto teórico) ──
+
+CREATE OR REPLACE FUNCTION public.crear_pedido_completo_bot(p_perfil_id uuid, p_confirmacion_id uuid)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public'
+AS $function$
+DECLARE
+  v_pendiente RECORD;
+  v_user_role TEXT;
+  v_pedido_id INT;
+  v_fecha_pedido DATE := (now() AT TIME ZONE 'America/Argentina/Buenos_Aires')::date;
+  v_fecha_entrega DATE := (v_fecha_pedido + INTERVAL '1 day')::date;
+  v_cantidades_totales JSONB := '{}'::JSONB;
+  v_cant_acumulada INT;
+  v_stock_snapshot JSONB := '{}'::JSONB;
+  v_stock_al_crear INT;
+  v_costo_actual NUMERIC; v_imp_int_actual NUMERIC; v_costo_real_actual NUMERIC; v_pct_iva_actual NUMERIC;
+  v_costo_snapshot JSONB := '{}'::JSONB; v_costo_al_crear NUMERIC;
+  v_pct_iva_snapshot JSONB := '{}'::JSONB;
+  v_es_regalo_no_mueve_stock JSONB := '{}'::JSONB;
+  v_regalo_mueve_stock BOOLEAN;
+  v_stock_actual INT;
+  v_producto_nombre TEXT;
+  errores TEXT[] := '{}';
+  item JSONB;
+  v_producto_id INT;
+  v_cantidad INT;
+  v_precio_unitario DECIMAL;
+  v_es_bonificacion BOOLEAN;
+  v_promocion_id BIGINT;
+  v_neto_unitario DECIMAL;
+  v_ingreso_real DECIMAL;
+  v_total_neto_calc NUMERIC := 0;
+  v_total_real_calc NUMERIC := 0;
+  v_promo RECORD;
+  v_usos_pendientes_actual INT;
+  v_bloques_completos INT;
+  v_ajustar_usos INT;
+  v_ajustar_stock INT;
+  v_stock_ajuste_anterior INT;
+  v_stock_ajuste_nuevo INT;
+  v_ajuste_producto_nombre TEXT;
+  v_merma_id BIGINT;
+BEGIN
+  SELECT * INTO v_pendiente FROM bot_pedidos_pendientes WHERE id = p_confirmacion_id FOR UPDATE;
+  IF NOT FOUND THEN RETURN jsonb_build_object('success', false, 'error', 'Confirmación inválida'); END IF;
+  IF v_pendiente.consumido THEN RETURN jsonb_build_object('success', false, 'error', 'Pedido ya creado, revisalo en la app'); END IF;
+  IF v_pendiente.expires_at < now() THEN RETURN jsonb_build_object('success', false, 'error', 'La confirmación expiró, hacé el pedido de nuevo'); END IF;
+  IF v_pendiente.perfil_id <> p_perfil_id THEN RETURN jsonb_build_object('success', false, 'error', 'Confirmación no pertenece al usuario'); END IF;
+
+  SELECT rol INTO v_user_role FROM perfiles WHERE id = p_perfil_id;
+  IF v_user_role IS NULL OR v_user_role NOT IN ('admin', 'encargado', 'preventista') THEN
+    RETURN jsonb_build_object('success', false, 'error', 'No tiene permisos para crear pedidos');
+  END IF;
+
+  FOR item IN SELECT * FROM jsonb_array_elements(v_pendiente.items) LOOP
+    v_producto_id := (item->>'producto_id')::INT;
+    v_cantidad := (item->>'cantidad')::INT;
+    v_es_bonificacion := COALESCE((item->>'es_bonificacion')::BOOLEAN, false);
+    IF v_cantidad IS NULL OR v_cantidad <= 0 THEN
+      errores := array_append(errores, 'Cantidad inválida para producto ID ' || v_producto_id);
+      CONTINUE;
+    END IF;
+
+    v_cant_acumulada := COALESCE((v_cantidades_totales->>v_producto_id::TEXT)::INT, 0) + v_cantidad;
+    v_cantidades_totales := v_cantidades_totales || jsonb_build_object(v_producto_id::TEXT, v_cant_acumulada);
+
+    IF v_es_bonificacion THEN
+      v_promocion_id := (item->>'promocion_id')::BIGINT;
+      IF v_promocion_id IS NOT NULL THEN
+        SELECT regalo_mueve_stock INTO v_regalo_mueve_stock FROM promociones WHERE id = v_promocion_id AND sucursal_id = v_pendiente.sucursal_id;
+        IF NOT COALESCE(v_regalo_mueve_stock, FALSE) THEN
+          v_es_regalo_no_mueve_stock := v_es_regalo_no_mueve_stock || jsonb_build_object(v_producto_id::TEXT, true);
+        END IF;
+      ELSE
+        v_es_regalo_no_mueve_stock := v_es_regalo_no_mueve_stock || jsonb_build_object(v_producto_id::TEXT, true);
+      END IF;
+    END IF;
+  END LOOP;
+
+  FOR v_producto_id IN SELECT (key)::INT FROM jsonb_each_text(v_cantidades_totales) LOOP
+    v_cantidad := (v_cantidades_totales->>v_producto_id::TEXT)::INT;
+    SELECT stock, nombre, costo_real, costo_sin_iva, COALESCE(impuestos_internos, 0), COALESCE(porcentaje_iva, 21)
+      INTO v_stock_actual, v_producto_nombre, v_costo_real_actual, v_costo_actual, v_imp_int_actual, v_pct_iva_actual
+      FROM productos WHERE id = v_producto_id AND sucursal_id = v_pendiente.sucursal_id FOR UPDATE;
+    IF v_stock_actual IS NULL THEN
+      errores := array_append(errores, 'Producto ID ' || v_producto_id || ' no encontrado');
+    ELSIF v_stock_actual < v_cantidad THEN
+      IF COALESCE((v_es_regalo_no_mueve_stock->>v_producto_id::TEXT)::BOOLEAN, FALSE) THEN
+        errores := array_append(errores, v_producto_nombre || ': stock insuficiente para regalo (disponible: ' || v_stock_actual || ', solicitado: ' || v_cantidad || ')');
+      ELSE
+        errores := array_append(errores, v_producto_nombre || ': stock insuficiente (disponible: ' || v_stock_actual || ', solicitado: ' || v_cantidad || ')');
+      END IF;
+    END IF;
+    IF v_stock_actual IS NOT NULL THEN
+      v_stock_snapshot := v_stock_snapshot || jsonb_build_object(v_producto_id::TEXT, v_stock_actual);
+      v_costo_snapshot := v_costo_snapshot || jsonb_build_object(v_producto_id::TEXT,
+        COALESCE(v_costo_real_actual,
+          CASE WHEN v_costo_actual IS NULL THEN NULL
+               ELSE round(v_costo_actual * (1 + COALESCE(v_imp_int_actual, 0) / 100), 4) END));
+      v_pct_iva_snapshot := v_pct_iva_snapshot || jsonb_build_object(v_producto_id::TEXT, v_pct_iva_actual);
+    END IF;
+  END LOOP;
+
+  IF array_length(errores, 1) > 0 THEN RETURN jsonb_build_object('success', false, 'errores', to_jsonb(errores)); END IF;
+
+  INSERT INTO pedidos (
+    cliente_id, fecha, total, total_neto, total_iva, total_real, tipo_factura,
+    estado, usuario_id, creado_por, stock_descontado, notas, forma_pago,
+    estado_pago, fecha_entrega_programada, sucursal_id, canal
+  )
+  VALUES (
+    v_pendiente.cliente_id, v_fecha_pedido, v_pendiente.total,
+    v_pendiente.total,
+    0,
+    v_pendiente.total,   -- ZZ: real = final
+    'ZZ',
+    'pendiente', p_perfil_id, p_perfil_id, true, v_pendiente.notas, v_pendiente.forma_pago,
+    'pendiente', v_fecha_entrega, v_pendiente.sucursal_id, 'bot'
+  )
+  RETURNING id INTO v_pedido_id;
+
+  PERFORM set_config('app.stock_origen', 'pedido_creado_bot', true);
+  PERFORM set_config('app.stock_ref_tipo', 'pedido', true);
+  PERFORM set_config('app.stock_ref_id', v_pedido_id::TEXT, true);
+  PERFORM set_config('app.stock_user_id', p_perfil_id::TEXT, true);
+
+  FOR item IN SELECT * FROM jsonb_array_elements(v_pendiente.items) LOOP
+    v_producto_id := (item->>'producto_id')::INT;
+    v_cantidad := (item->>'cantidad')::INT;
+    v_precio_unitario := (item->>'precio_unitario')::DECIMAL;
+    v_es_bonificacion := COALESCE((item->>'es_bonificacion')::BOOLEAN, false);
+    v_promocion_id := (item->>'promocion_id')::BIGINT;
+    v_stock_al_crear := (v_stock_snapshot->>v_producto_id::TEXT)::INT;
+    v_costo_al_crear := (v_costo_snapshot->>v_producto_id::TEXT)::NUMERIC;
+
+    -- ZZ: real = precio final; neto = teórico sin IVA (tasa del producto)
+    IF v_es_bonificacion THEN
+      v_neto_unitario := 0; v_ingreso_real := 0;
+    ELSE
+      v_neto_unitario := round(COALESCE(v_precio_unitario, 0) /
+        (1 + COALESCE((v_pct_iva_snapshot->>v_producto_id::TEXT)::NUMERIC, 21) / 100), 2);
+      v_ingreso_real := round(COALESCE(v_precio_unitario, 0), 2);
+      v_total_neto_calc := v_total_neto_calc + (v_cantidad * v_neto_unitario);
+      v_total_real_calc := v_total_real_calc + (v_cantidad * v_ingreso_real);
+    END IF;
+
+    INSERT INTO pedido_items (
+      pedido_id, producto_id, cantidad, precio_unitario, subtotal,
+      es_bonificacion, promocion_id, neto_unitario, iva_unitario,
+      impuestos_internos_unitario, porcentaje_iva, ingreso_real_unitario,
+      sucursal_id, stock_al_crear, costo_unitario_al_crear
+    ) VALUES (
+      v_pedido_id, v_producto_id, v_cantidad, v_precio_unitario,
+      v_cantidad * v_precio_unitario,
+      v_es_bonificacion, v_promocion_id, v_neto_unitario, 0,
+      0, CASE WHEN v_es_bonificacion THEN 0 ELSE COALESCE((v_pct_iva_snapshot->>v_producto_id::TEXT)::NUMERIC, 21) END,
+      v_ingreso_real,
+      v_pendiente.sucursal_id, v_stock_al_crear, v_costo_al_crear
+    );
+
+    IF NOT v_es_bonificacion THEN
+      UPDATE productos SET stock = stock - v_cantidad WHERE id = v_producto_id AND sucursal_id = v_pendiente.sucursal_id;
+    ELSIF v_promocion_id IS NOT NULL THEN
+      SELECT regalo_mueve_stock INTO v_regalo_mueve_stock FROM promociones WHERE id = v_promocion_id AND sucursal_id = v_pendiente.sucursal_id;
+      IF COALESCE(v_regalo_mueve_stock, FALSE) THEN
+        UPDATE productos SET stock = stock - v_cantidad WHERE id = v_producto_id AND sucursal_id = v_pendiente.sucursal_id;
+      END IF;
+    END IF;
+
+    IF v_es_bonificacion AND v_promocion_id IS NOT NULL THEN
+      UPDATE promociones SET usos_pendientes = usos_pendientes + v_cantidad WHERE id = v_promocion_id AND sucursal_id = v_pendiente.sucursal_id;
+
+      SELECT id, nombre, ajuste_automatico, ajuste_producto_id, unidades_por_bloque,
+             stock_por_bloque, usos_pendientes
+        INTO v_promo
+        FROM promociones WHERE id = v_promocion_id AND sucursal_id = v_pendiente.sucursal_id FOR UPDATE;
+
+      IF v_promo.ajuste_automatico AND v_promo.ajuste_producto_id IS NOT NULL
+         AND COALESCE(v_promo.unidades_por_bloque, 0) > 0 AND COALESCE(v_promo.stock_por_bloque, 0) > 0 THEN
+        v_usos_pendientes_actual := v_promo.usos_pendientes;
+        v_bloques_completos := v_usos_pendientes_actual / v_promo.unidades_por_bloque;
+        IF v_bloques_completos > 0 THEN
+          v_ajustar_usos := v_bloques_completos * v_promo.unidades_por_bloque;
+          v_ajustar_stock := v_bloques_completos * v_promo.stock_por_bloque;
+
+          SELECT stock, nombre INTO v_stock_ajuste_anterior, v_ajuste_producto_nombre
+            FROM productos WHERE id = v_promo.ajuste_producto_id AND sucursal_id = v_pendiente.sucursal_id FOR UPDATE;
+
+          IF v_stock_ajuste_anterior IS NULL THEN
+            RAISE EXCEPTION 'Auto-ajuste: producto destino no encontrado (promo %)', v_promocion_id;
+          END IF;
+          IF v_stock_ajuste_anterior < v_ajustar_stock THEN
+            RAISE EXCEPTION 'Auto-ajuste: stock insuficiente en % (disponible: %, requerido: %)',
+              v_ajuste_producto_nombre, v_stock_ajuste_anterior, v_ajustar_stock;
+          END IF;
+
+          v_stock_ajuste_nuevo := v_stock_ajuste_anterior - v_ajustar_stock;
+
+          INSERT INTO mermas_stock (
+            producto_id, cantidad, motivo, observaciones,
+            stock_anterior, stock_nuevo, usuario_id, sucursal_id
+          ) VALUES (
+            v_promo.ajuste_producto_id, v_ajustar_stock, 'promociones',
+            'Auto-ajuste (Promo: ' || v_promo.nombre || ', Pedido #' || v_pedido_id || ' via bot)',
+            v_stock_ajuste_anterior, v_stock_ajuste_nuevo, p_perfil_id, v_pendiente.sucursal_id
+          ) RETURNING id INTO v_merma_id;
+
+          UPDATE productos SET stock = v_stock_ajuste_nuevo, updated_at = NOW()
+            WHERE id = v_promo.ajuste_producto_id AND sucursal_id = v_pendiente.sucursal_id;
+
+          INSERT INTO promo_ajustes (
+            promocion_id, usos_ajustados, unidades_ajustadas, producto_id,
+            merma_id, usuario_id, observaciones, sucursal_id
+          ) VALUES (
+            v_promocion_id, v_ajustar_usos, v_ajustar_stock, v_promo.ajuste_producto_id,
+            v_merma_id, p_perfil_id,
+            'Auto-ajuste por pedido #' || v_pedido_id || ' via bot', v_pendiente.sucursal_id
+          );
+
+          UPDATE promociones SET usos_pendientes = GREATEST(usos_pendientes - v_ajustar_usos, 0)
+            WHERE id = v_promocion_id AND sucursal_id = v_pendiente.sucursal_id;
+        END IF;
+      END IF;
+    END IF;
+  END LOOP;
+
+  UPDATE pedidos
+     SET total_neto = round(v_total_neto_calc, 2),
+         total_real = round(v_total_real_calc, 2)
+   WHERE id = v_pedido_id AND sucursal_id = v_pendiente.sucursal_id;
+
+  UPDATE bot_pedidos_pendientes SET consumido = TRUE WHERE id = p_confirmacion_id;
+
+  RETURN jsonb_build_object('success', true, 'pedido_id', v_pedido_id, 'total', v_pendiente.total);
+END;
+$function$;
+
+-- ─── 6. actualizar_pedido_items ─────────────────────────────────────────────
+
+CREATE OR REPLACE FUNCTION public.actualizar_pedido_items(p_pedido_id bigint, p_items_nuevos jsonb, p_usuario_id uuid)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public'
+AS $function$
+DECLARE
+  v_sucursal BIGINT := current_sucursal_id();
+  v_item_nuevo JSONB;
+  v_producto_id INT;
+  v_cantidad_original INT;
+  v_cantidad_nueva INT;
+  v_diferencia INT;
+  v_es_bonificacion BOOLEAN;
+  v_stock_actual INT;
+  v_producto_nombre TEXT;
+  v_total_nuevo DECIMAL := 0;
+  v_total_neto_nuevo DECIMAL := 0;
+  v_total_iva_nuevo DECIMAL := 0;
+  v_total_real_nuevo DECIMAL := 0;
+  v_total_anterior DECIMAL;
+  v_errores TEXT[] := '{}';
+  v_items_originales JSONB;
+  v_user_role TEXT;
+  v_neto_unitario DECIMAL;
+  v_iva_unitario DECIMAL;
+  v_ingreso_real DECIMAL;
+  v_porcentaje_iva DECIMAL;
+  v_precio_unitario DECIMAL;
+  v_promocion_id BIGINT;
+  v_regalo_mueve_stock BOOLEAN;
+  v_descripcion_regalo TEXT;
+  v_bonif RECORD;
+  v_promo RECORD;
+  v_usos_pendientes_actual INT;
+  v_bloques_completos INT;
+  v_ajustar_usos INT;
+  v_ajustar_stock INT;
+  v_stock_ajuste_anterior INT;
+  v_stock_ajuste_nuevo INT;
+  v_ajuste_producto_nombre TEXT;
+  v_merma_id BIGINT;
+  v_pedido_creator UUID;
+  v_pedido_created_at TIMESTAMPTZ;
+  v_tipo_factura TEXT;
+  v_hora_corte CONSTANT TIME := TIME '15:30';
+  v_precio_actual DECIMAL;
+  v_costo_actual DECIMAL; v_imp_int_actual DECIMAL; v_costo_al_crear DECIMAL;
+  v_costo_real_actual DECIMAL; v_pct_iva_actual DECIMAL;
+BEGIN
+  IF v_sucursal IS NULL THEN
+    RETURN jsonb_build_object('success', false, 'errores', ARRAY['No se pudo determinar la sucursal activa']);
+  END IF;
+  IF p_usuario_id IS DISTINCT FROM auth.uid() THEN
+    RETURN jsonb_build_object('success', false, 'errores', ARRAY['ID de usuario no coincide con la sesion autenticada']);
+  END IF;
+  SELECT rol INTO v_user_role FROM perfiles WHERE id = p_usuario_id;
+  IF v_user_role IS NULL OR v_user_role NOT IN ('admin', 'encargado', 'preventista', 'preventista_taco') THEN
+    RETURN jsonb_build_object('success', false, 'errores', ARRAY['No autorizado']);
+  END IF;
+
+  SELECT total, usuario_id, created_at, COALESCE(tipo_factura, 'ZZ')
+    INTO v_total_anterior, v_pedido_creator, v_pedido_created_at, v_tipo_factura
+    FROM pedidos
+   WHERE id = p_pedido_id AND sucursal_id = v_sucursal;
+  IF NOT FOUND THEN
+    RETURN jsonb_build_object('success', false, 'errores', ARRAY['Pedido no encontrado']);
+  END IF;
+
+  IF EXISTS (SELECT 1 FROM pedidos WHERE id = p_pedido_id AND sucursal_id = v_sucursal AND estado = 'entregado') THEN
+    RETURN jsonb_build_object('success', false, 'errores', ARRAY['No se puede editar un pedido ya entregado']);
+  END IF;
+
+  IF v_user_role IN ('preventista', 'preventista_taco') THEN
+    IF v_pedido_creator IS DISTINCT FROM p_usuario_id THEN
+      RETURN jsonb_build_object('success', false, 'errores',
+        ARRAY['Solo el preventista que creo el pedido puede editarlo']);
+    END IF;
+
+    IF (v_pedido_created_at AT TIME ZONE 'America/Argentina/Buenos_Aires')::date
+         IS DISTINCT FROM (now() AT TIME ZONE 'America/Argentina/Buenos_Aires')::date
+       OR (now() AT TIME ZONE 'America/Argentina/Buenos_Aires')::time >= v_hora_corte
+    THEN
+      RETURN jsonb_build_object('success', false, 'errores',
+        ARRAY['Como preventista solo puede editar pedidos del dia actual antes de las 15:30 (ARG)']);
+    END IF;
+
+    FOR v_item_nuevo IN SELECT * FROM jsonb_array_elements(p_items_nuevos) LOOP
+      IF COALESCE((v_item_nuevo->>'es_bonificacion')::BOOLEAN, false) = true THEN
+        CONTINUE;
+      END IF;
+      v_producto_id := (v_item_nuevo->>'producto_id')::INT;
+      v_precio_unitario := (v_item_nuevo->>'precio_unitario')::DECIMAL;
+      SELECT precio INTO v_precio_actual
+        FROM productos WHERE id = v_producto_id AND sucursal_id = v_sucursal;
+      IF v_precio_actual IS NULL THEN
+        RETURN jsonb_build_object('success', false, 'errores',
+          ARRAY['Producto ID ' || v_producto_id || ' no encontrado']);
+      END IF;
+      IF v_precio_unitario IS NULL OR v_precio_unitario > v_precio_actual THEN
+        RETURN jsonb_build_object('success', false, 'errores',
+          ARRAY['Como preventista no puede aumentar precios (producto ID ' || v_producto_id || ')']);
+      END IF;
+    END LOOP;
+  END IF;
+
+  SELECT jsonb_agg(jsonb_build_object(
+    'producto_id', producto_id, 'cantidad', cantidad,
+    'precio_unitario', precio_unitario, 'es_bonificacion', COALESCE(es_bonificacion, false)))
+  INTO v_items_originales FROM pedido_items WHERE pedido_id = p_pedido_id AND sucursal_id = v_sucursal;
+
+  FOR v_item_nuevo IN SELECT * FROM jsonb_array_elements(p_items_nuevos) LOOP
+    v_producto_id := (v_item_nuevo->>'producto_id')::INT;
+    v_cantidad_nueva := (v_item_nuevo->>'cantidad')::INT;
+    v_es_bonificacion := COALESCE((v_item_nuevo->>'es_bonificacion')::BOOLEAN, false);
+    v_promocion_id := (v_item_nuevo->>'promocion_id')::BIGINT;
+
+    IF v_es_bonificacion THEN
+      IF v_promocion_id IS NULL THEN CONTINUE; END IF;
+      SELECT regalo_mueve_stock INTO v_regalo_mueve_stock FROM promociones WHERE id = v_promocion_id AND sucursal_id = v_sucursal;
+      IF NOT COALESCE(v_regalo_mueve_stock, FALSE) THEN CONTINUE; END IF;
+    END IF;
+
+    SELECT COALESCE(cantidad, 0) INTO v_cantidad_original
+    FROM pedido_items
+    WHERE pedido_id = p_pedido_id AND producto_id = v_producto_id
+      AND COALESCE(es_bonificacion, false) = v_es_bonificacion
+      AND sucursal_id = v_sucursal;
+
+    v_diferencia := v_cantidad_nueva - COALESCE(v_cantidad_original, 0);
+
+    IF v_diferencia > 0 THEN
+      SELECT stock, nombre INTO v_stock_actual, v_producto_nombre
+      FROM productos WHERE id = v_producto_id AND sucursal_id = v_sucursal FOR UPDATE;
+
+      IF v_stock_actual IS NULL THEN
+        v_errores := array_append(v_errores, 'Producto ID ' || v_producto_id || ' no encontrado');
+      ELSIF v_stock_actual < v_diferencia THEN
+        v_errores := array_append(v_errores, COALESCE(v_producto_nombre, 'Producto ' || v_producto_id)
+          || ': stock insuficiente (disponible: ' || v_stock_actual || ', adicional: ' || v_diferencia || ')');
+      END IF;
+    END IF;
+  END LOOP;
+
+  IF array_length(v_errores, 1) > 0 THEN
+    RETURN jsonb_build_object('success', false, 'errores', to_jsonb(v_errores));
+  END IF;
+
+  UPDATE productos p
+  SET stock = p.stock + pi.cantidad
+  FROM pedido_items pi
+  WHERE pi.pedido_id = p_pedido_id AND pi.sucursal_id = v_sucursal
+    AND COALESCE(pi.es_bonificacion, false) = false
+    AND p.id = pi.producto_id AND p.sucursal_id = v_sucursal;
+
+  UPDATE productos p
+  SET stock = p.stock + pi.cantidad
+  FROM pedido_items pi
+  JOIN promociones pr ON pr.id = pi.promocion_id AND pr.sucursal_id = pi.sucursal_id
+  WHERE pi.pedido_id = p_pedido_id AND pi.sucursal_id = v_sucursal
+    AND COALESCE(pi.es_bonificacion, false) = true
+    AND pi.promocion_id IS NOT NULL
+    AND COALESCE(pr.regalo_mueve_stock, FALSE) = TRUE
+    AND p.id = pi.producto_id AND p.sucursal_id = v_sucursal;
+
+  FOR v_bonif IN
+    SELECT promocion_id, SUM(cantidad)::INT AS total_cantidad
+      FROM pedido_items
+     WHERE pedido_id = p_pedido_id AND sucursal_id = v_sucursal
+       AND COALESCE(es_bonificacion, false) = true AND promocion_id IS NOT NULL
+     GROUP BY promocion_id
+  LOOP
+    PERFORM public.revertir_bloques_auto_ajuste(
+      v_bonif.promocion_id, v_bonif.total_cantidad, v_sucursal,
+      p_usuario_id, 'Edicion pedido #' || p_pedido_id
+    );
+  END LOOP;
+
+  DELETE FROM pedido_items WHERE pedido_id = p_pedido_id AND sucursal_id = v_sucursal;
+
+  FOR v_item_nuevo IN SELECT * FROM jsonb_array_elements(p_items_nuevos) LOOP
+    v_producto_id := (v_item_nuevo->>'producto_id')::INT;
+    v_cantidad_nueva := (v_item_nuevo->>'cantidad')::INT;
+    v_precio_unitario := (v_item_nuevo->>'precio_unitario')::DECIMAL;
+    v_es_bonificacion := COALESCE((v_item_nuevo->>'es_bonificacion')::BOOLEAN, false);
+    v_promocion_id := (v_item_nuevo->>'promocion_id')::BIGINT;
+
+    SELECT costo_real, costo_sin_iva, COALESCE(impuestos_internos, 0), COALESCE(porcentaje_iva, 21)
+      INTO v_costo_real_actual, v_costo_actual, v_imp_int_actual, v_pct_iva_actual
+      FROM productos WHERE id = v_producto_id AND sucursal_id = v_sucursal;
+    v_costo_al_crear := COALESCE(v_costo_real_actual,
+      CASE WHEN v_costo_actual IS NULL THEN NULL
+           ELSE round(v_costo_actual * (1 + COALESCE(v_imp_int_actual, 0) / 100), 4) END);
+
+    -- Terna de ingresos SERVER-SIDE
+    IF v_es_bonificacion THEN
+      v_neto_unitario := 0; v_iva_unitario := 0; v_ingreso_real := 0; v_porcentaje_iva := 0;
+    ELSE
+      SELECT d.neto, d.iva, d.ingreso_real
+        INTO v_neto_unitario, v_iva_unitario, v_ingreso_real
+        FROM calcular_desglose_venta(v_precio_unitario, v_pct_iva_actual, v_imp_int_actual, v_tipo_factura) d;
+      v_porcentaje_iva := v_pct_iva_actual;
+    END IF;
+
+    v_descripcion_regalo := NULL;
+    IF v_es_bonificacion AND v_promocion_id IS NOT NULL THEN
+      SELECT descripcion_regalo INTO v_descripcion_regalo FROM promociones WHERE id = v_promocion_id AND sucursal_id = v_sucursal;
+    END IF;
+
+    INSERT INTO pedido_items (
+      pedido_id, producto_id, cantidad, precio_unitario, subtotal,
+      es_bonificacion, promocion_id,
+      neto_unitario, iva_unitario, impuestos_internos_unitario, porcentaje_iva,
+      ingreso_real_unitario,
+      sucursal_id, descripcion_regalo, costo_unitario_al_crear
+    ) VALUES (
+      p_pedido_id, v_producto_id, v_cantidad_nueva, v_precio_unitario,
+      v_cantidad_nueva * v_precio_unitario,
+      v_es_bonificacion, v_promocion_id,
+      v_neto_unitario, v_iva_unitario, 0, v_porcentaje_iva,
+      v_ingreso_real,
+      v_sucursal, v_descripcion_regalo, v_costo_al_crear
+    );
+
+    IF NOT v_es_bonificacion THEN
+      UPDATE productos SET stock = stock - v_cantidad_nueva WHERE id = v_producto_id AND sucursal_id = v_sucursal;
+      v_total_nuevo := v_total_nuevo + (v_cantidad_nueva * v_precio_unitario);
+      v_total_neto_nuevo := v_total_neto_nuevo + (v_cantidad_nueva * v_neto_unitario);
+      v_total_iva_nuevo := v_total_iva_nuevo + (v_cantidad_nueva * v_iva_unitario);
+      v_total_real_nuevo := v_total_real_nuevo + (v_cantidad_nueva * v_ingreso_real);
+    ELSIF v_promocion_id IS NOT NULL THEN
+      SELECT regalo_mueve_stock INTO v_regalo_mueve_stock FROM promociones WHERE id = v_promocion_id AND sucursal_id = v_sucursal;
+      IF COALESCE(v_regalo_mueve_stock, FALSE) THEN
+        UPDATE productos SET stock = stock - v_cantidad_nueva WHERE id = v_producto_id AND sucursal_id = v_sucursal;
+      END IF;
+      UPDATE promociones SET usos_pendientes = usos_pendientes + v_cantidad_nueva WHERE id = v_promocion_id AND sucursal_id = v_sucursal;
+
+      SELECT id, nombre, ajuste_automatico, ajuste_producto_id, unidades_por_bloque,
+             stock_por_bloque, usos_pendientes
+      INTO v_promo
+      FROM promociones WHERE id = v_promocion_id AND sucursal_id = v_sucursal FOR UPDATE;
+
+      IF v_promo.ajuste_automatico AND v_promo.ajuste_producto_id IS NOT NULL
+         AND COALESCE(v_promo.unidades_por_bloque, 0) > 0 AND COALESCE(v_promo.stock_por_bloque, 0) > 0 THEN
+        v_usos_pendientes_actual := v_promo.usos_pendientes;
+        v_bloques_completos := v_usos_pendientes_actual / v_promo.unidades_por_bloque;
+        IF v_bloques_completos > 0 THEN
+          v_ajustar_usos := v_bloques_completos * v_promo.unidades_por_bloque;
+          v_ajustar_stock := v_bloques_completos * v_promo.stock_por_bloque;
+
+          SELECT stock, nombre INTO v_stock_ajuste_anterior, v_ajuste_producto_nombre
+          FROM productos WHERE id = v_promo.ajuste_producto_id AND sucursal_id = v_sucursal FOR UPDATE;
+
+          IF v_stock_ajuste_anterior IS NULL THEN
+            RAISE EXCEPTION 'Auto-ajuste: producto destino no encontrado (promo %)', v_promocion_id;
+          END IF;
+          IF v_stock_ajuste_anterior < v_ajustar_stock THEN
+            RAISE EXCEPTION 'Auto-ajuste: stock insuficiente en % (disponible: %, requerido: %)',
+              v_ajuste_producto_nombre, v_stock_ajuste_anterior, v_ajustar_stock;
+          END IF;
+
+          v_stock_ajuste_nuevo := v_stock_ajuste_anterior - v_ajustar_stock;
+
+          INSERT INTO mermas_stock (producto_id, cantidad, motivo, observaciones, stock_anterior, stock_nuevo, usuario_id, sucursal_id)
+          VALUES (v_promo.ajuste_producto_id, v_ajustar_stock, 'promociones',
+            'Auto-ajuste (Promo: ' || v_promo.nombre || ', Pedido #' || p_pedido_id || ', edicion)',
+            v_stock_ajuste_anterior, v_stock_ajuste_nuevo, p_usuario_id, v_sucursal)
+          RETURNING id INTO v_merma_id;
+
+          UPDATE productos SET stock = v_stock_ajuste_nuevo, updated_at = NOW()
+          WHERE id = v_promo.ajuste_producto_id AND sucursal_id = v_sucursal;
+
+          INSERT INTO promo_ajustes (promocion_id, usos_ajustados, unidades_ajustadas, producto_id, merma_id, usuario_id, observaciones, sucursal_id)
+          VALUES (v_promocion_id, v_ajustar_usos, v_ajustar_stock, v_promo.ajuste_producto_id,
+            v_merma_id, p_usuario_id, 'Auto-ajuste por edicion pedido #' || p_pedido_id, v_sucursal);
+
+          UPDATE promociones SET usos_pendientes = GREATEST(usos_pendientes - v_ajustar_usos, 0)
+          WHERE id = v_promocion_id AND sucursal_id = v_sucursal;
+        END IF;
+      END IF;
+    END IF;
+  END LOOP;
+
+  UPDATE pedidos SET total = v_total_nuevo, total_neto = round(v_total_neto_nuevo, 2), total_iva = round(v_total_iva_nuevo, 2), total_real = round(v_total_real_nuevo, 2), updated_at = NOW()
+  WHERE id = p_pedido_id AND sucursal_id = v_sucursal;
+
+  INSERT INTO pedido_historial (pedido_id, usuario_id, campo_modificado, valor_anterior, valor_nuevo, sucursal_id)
+  VALUES (p_pedido_id, p_usuario_id, 'items', COALESCE(v_items_originales::TEXT, '[]'), p_items_nuevos::TEXT, v_sucursal);
+
+  IF v_total_anterior IS DISTINCT FROM v_total_nuevo THEN
+    INSERT INTO pedido_historial (pedido_id, usuario_id, campo_modificado, valor_anterior, valor_nuevo, sucursal_id)
+    VALUES (p_pedido_id, p_usuario_id, 'total', v_total_anterior::TEXT, v_total_nuevo::TEXT, v_sucursal);
+  END IF;
+
+  RETURN jsonb_build_object('success', true, 'total_nuevo', v_total_nuevo);
+END;
+$function$;
+
+-- ─── 7. anular_salvedad ─────────────────────────────────────────────────────
+
+CREATE OR REPLACE FUNCTION public.anular_salvedad(p_salvedad_id bigint, p_notas text DEFAULT NULL::text)
+RETURNS jsonb
+LANGUAGE plpgsql SECURITY DEFINER
+SET search_path TO 'public'
+AS $$
+DECLARE
+  v_sucursal BIGINT := current_sucursal_id();
+  v_salvedad RECORD;
+  v_usuario_id UUID := auth.uid();
+  v_tipo_factura TEXT;
+  v_pct_iva NUMERIC; v_pct_ii NUMERIC; v_costo_real NUMERIC; v_costo_sin NUMERIC;
+  v_neto NUMERIC; v_iva NUMERIC; v_real NUMERIC;
+BEGIN
+  IF v_sucursal IS NULL THEN
+    RETURN jsonb_build_object('success', false, 'error', 'No se pudo determinar la sucursal activa');
+  END IF;
+  IF NOT es_admin_salvedades() THEN
+    RETURN jsonb_build_object('success', false, 'error', 'Solo admin');
+  END IF;
+  SELECT * INTO v_salvedad FROM salvedades_items WHERE id = p_salvedad_id AND sucursal_id = v_sucursal;
+  IF NOT FOUND THEN RETURN jsonb_build_object('success', false, 'error', 'No encontrada'); END IF;
+  IF v_salvedad.estado_resolucion = 'anulada' THEN
+    RETURN jsonb_build_object('success', false, 'error', 'Ya anulada');
+  END IF;
+  SELECT COALESCE(tipo_factura, 'ZZ') INTO v_tipo_factura
+    FROM pedidos WHERE id = v_salvedad.pedido_id AND sucursal_id = v_sucursal;
+  IF EXISTS (SELECT 1 FROM pedido_items WHERE id = v_salvedad.pedido_item_id AND sucursal_id = v_sucursal) THEN
+    UPDATE pedido_items SET
+      cantidad = v_salvedad.cantidad_original,
+      subtotal = v_salvedad.cantidad_original * v_salvedad.precio_unitario
+    WHERE id = v_salvedad.pedido_item_id AND sucursal_id = v_sucursal;
+  ELSE
+    -- Reinsertar con la terna de ingresos y costo snapshot (mig 123)
+    SELECT COALESCE(porcentaje_iva, 21), COALESCE(impuestos_internos, 0), costo_real, costo_sin_iva
+      INTO v_pct_iva, v_pct_ii, v_costo_real, v_costo_sin
+      FROM productos WHERE id = v_salvedad.producto_id AND sucursal_id = v_sucursal;
+    SELECT d.neto, d.iva, d.ingreso_real INTO v_neto, v_iva, v_real
+      FROM calcular_desglose_venta(v_salvedad.precio_unitario, v_pct_iva, v_pct_ii, v_tipo_factura) d;
+
+    INSERT INTO pedido_items (
+      pedido_id, producto_id, cantidad, precio_unitario, subtotal, sucursal_id,
+      neto_unitario, iva_unitario, impuestos_internos_unitario, porcentaje_iva,
+      ingreso_real_unitario, costo_unitario_al_crear
+    )
+    VALUES (
+      v_salvedad.pedido_id, v_salvedad.producto_id, v_salvedad.cantidad_original,
+      v_salvedad.precio_unitario, v_salvedad.cantidad_original * v_salvedad.precio_unitario, v_sucursal,
+      v_neto, v_iva, 0, v_pct_iva,
+      v_real,
+      COALESCE(v_costo_real,
+        CASE WHEN v_costo_sin IS NULL THEN NULL ELSE round(v_costo_sin * (1 + v_pct_ii / 100), 4) END)
+    );
+  END IF;
+  UPDATE pedidos SET
+    total = (SELECT COALESCE(SUM(subtotal), 0) FROM pedido_items WHERE pedido_id = v_salvedad.pedido_id AND sucursal_id = v_sucursal),
+    total_neto = (SELECT COALESCE(SUM(CASE WHEN NOT COALESCE(es_bonificacion, false) THEN cantidad * COALESCE(neto_unitario, precio_unitario) ELSE 0 END), 0)
+                    FROM pedido_items WHERE pedido_id = v_salvedad.pedido_id AND sucursal_id = v_sucursal),
+    total_iva = (SELECT COALESCE(SUM(CASE WHEN NOT COALESCE(es_bonificacion, false) THEN cantidad * COALESCE(iva_unitario, 0) ELSE 0 END), 0)
+                   FROM pedido_items WHERE pedido_id = v_salvedad.pedido_id AND sucursal_id = v_sucursal),
+    total_real = (SELECT COALESCE(SUM(CASE WHEN NOT COALESCE(es_bonificacion, false)
+                          THEN cantidad * COALESCE(ingreso_real_unitario,
+                               CASE WHEN v_tipo_factura = 'FC' THEN COALESCE(neto_unitario, precio_unitario) ELSE precio_unitario END)
+                          ELSE 0 END), 0)
+                    FROM pedido_items WHERE pedido_id = v_salvedad.pedido_id AND sucursal_id = v_sucursal),
+    updated_at = NOW()
+  WHERE id = v_salvedad.pedido_id AND sucursal_id = v_sucursal;
+  IF v_salvedad.stock_devuelto THEN
+    UPDATE productos SET stock = stock - v_salvedad.cantidad_afectada
+     WHERE id = v_salvedad.producto_id AND sucursal_id = v_sucursal;
+  END IF;
+  UPDATE salvedades_items SET
+    estado_resolucion = 'anulada',
+    resolucion_notas = p_notas,
+    resolucion_fecha = NOW(),
+    resuelto_por = v_usuario_id,
+    updated_at = NOW()
+  WHERE id = p_salvedad_id AND sucursal_id = v_sucursal;
+  INSERT INTO salvedad_historial (salvedad_id, accion, estado_anterior, estado_nuevo, notas, usuario_id, sucursal_id)
+  VALUES (p_salvedad_id, 'anulacion', v_salvedad.estado_resolucion, 'anulada', p_notas, v_usuario_id, v_sucursal);
+  RETURN jsonb_build_object('success', true);
+END;
+$$;
+
+-- ─── 8. cambiar_tipo_factura_pedido ─────────────────────────────────────────
+-- Con la nueva semántica el NETO no cambia al flipear: solo se redistribuyen
+-- iva (discriminado) e ingreso_real. total invariante.
+
+CREATE OR REPLACE FUNCTION public.cambiar_tipo_factura_pedido(
+  p_pedido_id bigint,
+  p_tipo varchar,
+  p_usuario_id uuid
+) RETURNS jsonb
+LANGUAGE plpgsql SECURITY DEFINER
+SET search_path TO 'public'
+AS $$
+DECLARE
+  v_sucursal BIGINT := current_sucursal_id();
+  v_user_role TEXT;
+  v_pedido RECORD;
+  v_item RECORD;
+  v_neto NUMERIC; v_iva NUMERIC; v_real NUMERIC;
+  v_total_neto NUMERIC := 0;
+  v_total_iva NUMERIC := 0;
+  v_total_real NUMERIC := 0;
+BEGIN
+  IF v_sucursal IS NULL THEN
+    RETURN jsonb_build_object('success', false, 'error', 'No se pudo determinar la sucursal activa');
+  END IF;
+  IF p_usuario_id IS DISTINCT FROM auth.uid() THEN
+    RETURN jsonb_build_object('success', false, 'error', 'ID de usuario no coincide con la sesion autenticada');
+  END IF;
+  IF p_tipo NOT IN ('ZZ', 'FC') THEN
+    RETURN jsonb_build_object('success', false, 'error', 'Tipo de factura inválido (ZZ o FC)');
+  END IF;
+
+  SELECT rol INTO v_user_role FROM perfiles WHERE id = p_usuario_id;
+  IF v_user_role IS NULL OR v_user_role NOT IN ('admin', 'encargado') THEN
+    RETURN jsonb_build_object('success', false, 'error', 'No autorizado: solo admin o encargado');
+  END IF;
+
+  SELECT id, estado, tipo_factura INTO v_pedido
+    FROM pedidos WHERE id = p_pedido_id AND sucursal_id = v_sucursal
+    FOR UPDATE;
+  IF NOT FOUND THEN
+    RETURN jsonb_build_object('success', false, 'error', 'Pedido no encontrado');
+  END IF;
+  IF v_pedido.estado = 'cancelado' THEN
+    RETURN jsonb_build_object('success', false, 'error', 'No se puede cambiar el tipo de un pedido cancelado');
+  END IF;
+  IF v_user_role = 'encargado' AND v_pedido.estado = 'entregado' THEN
+    RETURN jsonb_build_object('success', false, 'error', 'Solo admin puede cambiar el tipo de un pedido entregado');
+  END IF;
+  IF COALESCE(v_pedido.tipo_factura, 'ZZ') = p_tipo THEN
+    RETURN jsonb_build_object('success', true, 'sin_cambio', true);
+  END IF;
+
+  FOR v_item IN
+    SELECT pi.id, pi.cantidad, pi.precio_unitario, COALESCE(pi.es_bonificacion, false) AS es_bonif,
+           COALESCE(pr.porcentaje_iva, 21) AS pct_iva, COALESCE(pr.impuestos_internos, 0) AS pct_ii
+      FROM pedido_items pi
+      JOIN productos pr ON pr.id = pi.producto_id AND pr.sucursal_id = pi.sucursal_id
+     WHERE pi.pedido_id = p_pedido_id AND pi.sucursal_id = v_sucursal
+  LOOP
+    IF v_item.es_bonif THEN
+      UPDATE pedido_items
+         SET neto_unitario = 0, iva_unitario = 0, impuestos_internos_unitario = 0,
+             porcentaje_iva = 0, ingreso_real_unitario = 0
+       WHERE id = v_item.id;
+    ELSE
+      SELECT d.neto, d.iva, d.ingreso_real INTO v_neto, v_iva, v_real
+        FROM calcular_desglose_venta(v_item.precio_unitario, v_item.pct_iva, v_item.pct_ii, p_tipo) d;
+      UPDATE pedido_items
+         SET neto_unitario = v_neto,
+             iva_unitario = v_iva,
+             impuestos_internos_unitario = 0,
+             porcentaje_iva = v_item.pct_iva,
+             ingreso_real_unitario = v_real
+       WHERE id = v_item.id;
+      v_total_neto := v_total_neto + v_item.cantidad * v_neto;
+      v_total_iva  := v_total_iva  + v_item.cantidad * v_iva;
+      v_total_real := v_total_real + v_item.cantidad * v_real;
+    END IF;
+  END LOOP;
+
+  UPDATE pedidos
+     SET tipo_factura = p_tipo,
+         total_neto = round(v_total_neto, 2),
+         total_iva  = round(v_total_iva, 2),
+         total_real = round(v_total_real, 2),
+         updated_at = NOW()
+   WHERE id = p_pedido_id AND sucursal_id = v_sucursal;
+
+  INSERT INTO pedido_historial (pedido_id, usuario_id, campo_modificado, valor_anterior, valor_nuevo, sucursal_id)
+  VALUES (p_pedido_id, p_usuario_id, 'tipo_factura', COALESCE(v_pedido.tipo_factura, 'ZZ'), p_tipo, v_sucursal);
+
+  RETURN jsonb_build_object('success', true, 'pedido_id', p_pedido_id,
+    'tipo_factura', p_tipo, 'total_neto', round(v_total_neto, 2),
+    'total_iva', round(v_total_iva, 2), 'total_real', round(v_total_real, 2));
+EXCEPTION WHEN OTHERS THEN
+  RETURN jsonb_build_object('success', false, 'error', SQLERRM);
+END;
+$$;
+
+-- ─── 9. registrar_salvedad (2 overloads): recompute con total_real ──────────
+-- Patch quirúrgico sobre los bodies vivos (obtenidos con pg_get_functiondef):
+-- se agrega v_tipo_factura y el UPDATE de totales suma total_real. La nueva
+-- semántica de neto ya la cubre el COALESCE existente (items intactos).
+
+CREATE OR REPLACE FUNCTION public.registrar_salvedad(p_pedido_id bigint, p_pedido_item_id bigint, p_cantidad_afectada integer, p_motivo character varying, p_descripcion text DEFAULT NULL::text, p_foto_url text DEFAULT NULL::text, p_devolver_stock boolean DEFAULT true)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public'
+AS $function$
+DECLARE
+  v_sucursal              BIGINT := current_sucursal_id();
+  v_salvedad_id           BIGINT;
+  v_item                  RECORD;
+  v_cantidad_entregada    INTEGER;
+  v_monto_afectado        DECIMAL;
+  v_usuario_id            UUID;
+  v_es_admin_o_encargado  BOOLEAN;
+  v_subtotal_nuevo        DECIMAL;
+  v_stock_devuelto        BOOLEAN := FALSE;
+  v_merma_registrada      BOOLEAN := FALSE;
+  v_stock_actual          INTEGER;
+  v_bonif                 RECORD;
+  v_cant_compra           INT;
+  v_cant_bonif            INT;
+  v_total_qty             INT;
+  v_bloques               INT;
+  v_expected_bonif        INT;
+  v_diff                  INT;
+  v_regalo_mueve_stock    BOOLEAN;
+  v_tipo_factura          TEXT;
+BEGIN
+  IF v_sucursal IS NULL THEN
+    RETURN jsonb_build_object('success', false, 'error', 'No se pudo determinar la sucursal activa');
+  END IF;
+
+  v_usuario_id := auth.uid();
+  IF v_usuario_id IS NULL THEN
+    RETURN jsonb_build_object('success', false, 'error', 'Usuario no autenticado');
+  END IF;
+
+  SELECT EXISTS (
+    SELECT 1 FROM perfiles
+     WHERE id = v_usuario_id AND rol IN ('admin', 'encargado')
+  ) INTO v_es_admin_o_encargado;
+  IF NOT v_es_admin_o_encargado THEN
+    IF NOT EXISTS (
+      SELECT 1 FROM pedidos
+       WHERE id = p_pedido_id AND transportista_id = v_usuario_id AND sucursal_id = v_sucursal
+    ) THEN
+      RETURN jsonb_build_object('success', false, 'error', 'No autorizado para este pedido');
+    END IF;
+  END IF;
+
+  SELECT pi.id, pi.producto_id, pi.cantidad, pi.precio_unitario, pi.subtotal
+    INTO v_item
+    FROM pedido_items pi
+   WHERE pi.id = p_pedido_item_id
+     AND pi.pedido_id = p_pedido_id
+     AND pi.sucursal_id = v_sucursal;
+
+  IF v_item IS NULL THEN
+    RETURN jsonb_build_object('success', false, 'error', 'Item de pedido no encontrado');
+  END IF;
+
+  IF p_cantidad_afectada > v_item.cantidad THEN
+    RETURN jsonb_build_object('success', false, 'error', 'Cantidad afectada mayor a cantidad del item');
+  END IF;
+  IF p_cantidad_afectada <= 0 THEN
+    RETURN jsonb_build_object('success', false, 'error', 'Cantidad debe ser mayor a 0');
+  END IF;
+
+  v_cantidad_entregada := v_item.cantidad - p_cantidad_afectada;
+  v_monto_afectado     := p_cantidad_afectada * v_item.precio_unitario;
+  v_subtotal_nuevo     := v_cantidad_entregada * v_item.precio_unitario;
+
+  IF p_motivo IN ('cliente_rechaza', 'error_pedido', 'diferencia_precio') THEN
+    v_stock_devuelto := TRUE;
+  END IF;
+
+  INSERT INTO salvedades_items (
+    pedido_id, pedido_item_id, producto_id, cantidad_original, cantidad_afectada,
+    cantidad_entregada, motivo, descripcion, foto_url, monto_afectado, precio_unitario,
+    reportado_por, stock_devuelto, stock_devuelto_at, estado_resolucion, sucursal_id
+  ) VALUES (
+    p_pedido_id, p_pedido_item_id, v_item.producto_id, v_item.cantidad, p_cantidad_afectada,
+    v_cantidad_entregada, p_motivo, p_descripcion, p_foto_url, v_monto_afectado, v_item.precio_unitario,
+    v_usuario_id, v_stock_devuelto, CASE WHEN v_stock_devuelto THEN NOW() ELSE NULL END, 'pendiente', v_sucursal
+  ) RETURNING id INTO v_salvedad_id;
+
+  IF v_salvedad_id IS NULL THEN
+    RAISE EXCEPTION 'No se pudo crear la salvedad';
+  END IF;
+
+  IF v_cantidad_entregada > 0 THEN
+    UPDATE pedido_items SET cantidad = v_cantidad_entregada, subtotal = v_subtotal_nuevo
+     WHERE id = p_pedido_item_id AND sucursal_id = v_sucursal;
+  ELSE
+    DELETE FROM pedido_items WHERE id = p_pedido_item_id AND sucursal_id = v_sucursal;
+  END IF;
+
+  FOR v_bonif IN
+    SELECT pi.id, pi.producto_id, pi.cantidad, pi.promocion_id
+      FROM pedido_items pi
+     WHERE pi.pedido_id = p_pedido_id AND pi.sucursal_id = v_sucursal
+       AND COALESCE(pi.es_bonificacion, FALSE) = TRUE
+       AND pi.promocion_id IS NOT NULL
+  LOOP
+    SELECT
+      MAX(CASE WHEN pr.clave = 'cantidad_compra'       THEN pr.valor END)::INT,
+      MAX(CASE WHEN pr.clave = 'cantidad_bonificacion' THEN pr.valor END)::INT,
+      MAX(p.regalo_mueve_stock::INT)::BOOLEAN
+    INTO v_cant_compra, v_cant_bonif, v_regalo_mueve_stock
+    FROM promociones p
+    LEFT JOIN promocion_reglas pr ON pr.promocion_id = p.id
+    WHERE p.id = v_bonif.promocion_id AND p.sucursal_id = v_sucursal
+    GROUP BY p.id;
+
+    IF v_cant_compra IS NULL OR v_cant_compra <= 0
+       OR v_cant_bonif IS NULL OR v_cant_bonif <= 0 THEN
+      CONTINUE;
+    END IF;
+
+    SELECT COALESCE(SUM(pi.cantidad), 0)::INT
+      INTO v_total_qty
+      FROM pedido_items pi
+      JOIN promocion_productos pp ON pp.producto_id = pi.producto_id AND pp.promocion_id = v_bonif.promocion_id
+     WHERE pi.pedido_id = p_pedido_id AND pi.sucursal_id = v_sucursal
+       AND COALESCE(pi.es_bonificacion, FALSE) = FALSE;
+
+    v_bloques        := v_total_qty / v_cant_compra;
+    v_expected_bonif := v_bloques * v_cant_bonif;
+
+    IF v_expected_bonif < v_bonif.cantidad THEN
+      v_diff := v_bonif.cantidad - v_expected_bonif;
+
+      IF COALESCE(v_regalo_mueve_stock, FALSE) THEN
+        UPDATE productos SET stock = stock + v_diff
+         WHERE id = v_bonif.producto_id AND sucursal_id = v_sucursal;
+      END IF;
+
+      PERFORM public.revertir_bloques_auto_ajuste(
+        v_bonif.promocion_id, v_diff, v_sucursal,
+        v_usuario_id, 'Salvedad pedido #' || p_pedido_id
+      );
+
+      IF v_expected_bonif = 0 THEN
+        DELETE FROM pedido_items WHERE id = v_bonif.id;
+      ELSE
+        UPDATE pedido_items
+           SET cantidad = v_expected_bonif, subtotal = v_expected_bonif * COALESCE(precio_unitario, 0)
+         WHERE id = v_bonif.id;
+      END IF;
+    END IF;
+  END LOOP;
+
+  SELECT COALESCE(tipo_factura, 'ZZ') INTO v_tipo_factura
+    FROM pedidos WHERE id = p_pedido_id AND sucursal_id = v_sucursal;
+
+  UPDATE pedidos
+     SET total = sub.total_recalc,
+         total_neto = sub.neto_recalc,
+         total_iva = sub.iva_recalc,
+         total_real = sub.real_recalc,
+         updated_at = NOW()
+    FROM (
+      SELECT
+        COALESCE(SUM(subtotal), 0) AS total_recalc,
+        COALESCE(SUM(CASE WHEN COALESCE(es_bonificacion, FALSE) = FALSE
+                          THEN cantidad * COALESCE(neto_unitario, precio_unitario)
+                          ELSE 0 END), 0) AS neto_recalc,
+        COALESCE(SUM(CASE WHEN COALESCE(es_bonificacion, FALSE) = FALSE
+                          THEN cantidad * COALESCE(iva_unitario, 0)
+                          ELSE 0 END), 0) AS iva_recalc,
+        COALESCE(SUM(CASE WHEN COALESCE(es_bonificacion, FALSE) = FALSE
+                          THEN cantidad * COALESCE(ingreso_real_unitario,
+                               CASE WHEN v_tipo_factura = 'FC'
+                                    THEN COALESCE(neto_unitario, precio_unitario)
+                                    ELSE precio_unitario END)
+                          ELSE 0 END), 0) AS real_recalc
+        FROM pedido_items
+       WHERE pedido_id = p_pedido_id AND sucursal_id = v_sucursal
+    ) sub
+   WHERE id = p_pedido_id AND sucursal_id = v_sucursal;
+
+  IF v_stock_devuelto THEN
+    UPDATE productos SET stock = stock + p_cantidad_afectada
+     WHERE id = v_item.producto_id AND sucursal_id = v_sucursal;
+  END IF;
+
+  IF p_motivo IN ('producto_danado', 'producto_vencido') THEN
+    SELECT stock INTO v_stock_actual
+      FROM productos WHERE id = v_item.producto_id AND sucursal_id = v_sucursal FOR UPDATE;
+
+    INSERT INTO mermas_stock (producto_id, cantidad, motivo, observaciones, stock_anterior, stock_nuevo, usuario_id, sucursal_id)
+    VALUES (v_item.producto_id, p_cantidad_afectada,
+      CASE p_motivo WHEN 'producto_danado' THEN 'rotura' WHEN 'producto_vencido' THEN 'vencimiento' END,
+      COALESCE(p_descripcion, 'Salvedad pedido #' || p_pedido_id || ': ' || p_motivo),
+      v_stock_actual, GREATEST(v_stock_actual - p_cantidad_afectada, 0), v_usuario_id, v_sucursal);
+
+    UPDATE productos SET stock = GREATEST(stock - p_cantidad_afectada, 0)
+     WHERE id = v_item.producto_id AND sucursal_id = v_sucursal;
+    v_merma_registrada := TRUE;
+  END IF;
+
+  INSERT INTO salvedad_historial (salvedad_id, accion, estado_nuevo, notas, usuario_id, sucursal_id)
+  VALUES (v_salvedad_id, 'creacion', 'pendiente', p_descripcion, v_usuario_id, v_sucursal);
+
+  RETURN jsonb_build_object(
+    'success', true, 'salvedad_id', v_salvedad_id,
+    'monto_afectado', v_monto_afectado, 'cantidad_entregada', v_cantidad_entregada,
+    'stock_devuelto', v_stock_devuelto, 'merma_registrada', v_merma_registrada,
+    'nuevo_total_pedido', (SELECT total FROM pedidos WHERE id = p_pedido_id AND sucursal_id = v_sucursal)
+  );
+EXCEPTION WHEN OTHERS THEN
+  RETURN jsonb_build_object('success', false, 'error', SQLERRM);
+END;
+$function$;
+
+CREATE OR REPLACE FUNCTION public.registrar_salvedad(p_pedido_id bigint, p_pedido_item_id bigint, p_cantidad_afectada integer, p_motivo character varying, p_descripcion text DEFAULT NULL::text, p_foto_url text DEFAULT NULL::text, p_devolver_stock boolean DEFAULT true, p_client_request_id uuid DEFAULT NULL::uuid)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public'
+AS $function$
+DECLARE
+  v_sucursal              BIGINT := current_sucursal_id();
+  v_salvedad_id           BIGINT;
+  v_item                  RECORD;
+  v_existing              RECORD;
+  v_cantidad_entregada    INTEGER;
+  v_monto_afectado        DECIMAL;
+  v_usuario_id            UUID;
+  v_es_admin_o_encargado  BOOLEAN;
+  v_subtotal_nuevo        DECIMAL;
+  v_stock_devuelto        BOOLEAN := FALSE;
+  v_merma_registrada      BOOLEAN := FALSE;
+  v_stock_actual          INTEGER;
+  v_bonif                 RECORD;
+  v_cant_compra           INT;
+  v_cant_bonif            INT;
+  v_total_qty             INT;
+  v_bloques               INT;
+  v_expected_bonif        INT;
+  v_diff                  INT;
+  v_regalo_mueve_stock    BOOLEAN;
+  v_tipo_factura          TEXT;
+BEGIN
+  IF p_client_request_id IS NOT NULL THEN
+    SELECT id, motivo, monto_afectado, cantidad_entregada, stock_devuelto, pedido_id
+      INTO v_existing
+      FROM salvedades_items
+     WHERE client_request_id = p_client_request_id;
+
+    IF FOUND THEN
+      RETURN jsonb_build_object(
+        'success', true,
+        'salvedad_id', v_existing.id,
+        'monto_afectado', v_existing.monto_afectado,
+        'cantidad_entregada', v_existing.cantidad_entregada,
+        'stock_devuelto', v_existing.stock_devuelto,
+        'merma_registrada', v_existing.motivo IN ('producto_danado', 'producto_vencido'),
+        'nuevo_total_pedido', (
+          SELECT total FROM pedidos
+           WHERE id = v_existing.pedido_id AND sucursal_id = v_sucursal
+        ),
+        'idempotent_replay', true
+      );
+    END IF;
+  END IF;
+
+  IF v_sucursal IS NULL THEN
+    RETURN jsonb_build_object('success', false, 'error', 'No se pudo determinar la sucursal activa');
+  END IF;
+
+  v_usuario_id := auth.uid();
+  IF v_usuario_id IS NULL THEN
+    RETURN jsonb_build_object('success', false, 'error', 'Usuario no autenticado');
+  END IF;
+
+  SELECT EXISTS (
+    SELECT 1 FROM perfiles
+     WHERE id = v_usuario_id AND rol IN ('admin', 'encargado')
+  ) INTO v_es_admin_o_encargado;
+  IF NOT v_es_admin_o_encargado THEN
+    IF NOT EXISTS (
+      SELECT 1 FROM pedidos
+       WHERE id = p_pedido_id AND transportista_id = v_usuario_id AND sucursal_id = v_sucursal
+    ) THEN
+      RETURN jsonb_build_object('success', false, 'error', 'No autorizado para este pedido');
+    END IF;
+  END IF;
+
+  SELECT pi.id, pi.producto_id, pi.cantidad, pi.precio_unitario, pi.subtotal
+    INTO v_item
+    FROM pedido_items pi
+   WHERE pi.id = p_pedido_item_id
+     AND pi.pedido_id = p_pedido_id
+     AND pi.sucursal_id = v_sucursal;
+
+  IF NOT FOUND THEN
+    RETURN jsonb_build_object('success', false, 'error', 'Item de pedido no encontrado');
+  END IF;
+
+  IF p_cantidad_afectada > v_item.cantidad THEN
+    RETURN jsonb_build_object('success', false, 'error', 'Cantidad afectada mayor a cantidad del item');
+  END IF;
+  IF p_cantidad_afectada <= 0 THEN
+    RETURN jsonb_build_object('success', false, 'error', 'Cantidad debe ser mayor a 0');
+  END IF;
+
+  v_cantidad_entregada := v_item.cantidad - p_cantidad_afectada;
+  v_monto_afectado     := p_cantidad_afectada * v_item.precio_unitario;
+  v_subtotal_nuevo     := v_cantidad_entregada * v_item.precio_unitario;
+
+  IF p_motivo IN ('cliente_rechaza', 'error_pedido', 'diferencia_precio') THEN
+    v_stock_devuelto := TRUE;
+  END IF;
+
+  PERFORM set_config('app.stock_origen', 'salvedad', true);
+  PERFORM set_config('app.stock_ref_tipo', 'pedido', true);
+  PERFORM set_config('app.stock_ref_id', p_pedido_id::TEXT, true);
+  PERFORM set_config('app.stock_user_id', v_usuario_id::TEXT, true);
+
+  INSERT INTO salvedades_items (
+    pedido_id, pedido_item_id, producto_id, cantidad_original, cantidad_afectada,
+    cantidad_entregada, motivo, descripcion, foto_url, monto_afectado, precio_unitario,
+    reportado_por, stock_devuelto, stock_devuelto_at, estado_resolucion, sucursal_id,
+    client_request_id
+  ) VALUES (
+    p_pedido_id, p_pedido_item_id, v_item.producto_id, v_item.cantidad, p_cantidad_afectada,
+    v_cantidad_entregada, p_motivo, p_descripcion, p_foto_url, v_monto_afectado, v_item.precio_unitario,
+    v_usuario_id, v_stock_devuelto, CASE WHEN v_stock_devuelto THEN NOW() ELSE NULL END, 'pendiente', v_sucursal,
+    p_client_request_id
+  ) RETURNING id INTO v_salvedad_id;
+
+  IF v_salvedad_id IS NULL THEN
+    RAISE EXCEPTION 'No se pudo crear la salvedad';
+  END IF;
+
+  IF v_cantidad_entregada > 0 THEN
+    UPDATE pedido_items
+       SET cantidad = v_cantidad_entregada,
+           subtotal = v_subtotal_nuevo
+     WHERE id = p_pedido_item_id AND sucursal_id = v_sucursal;
+  ELSE
+    DELETE FROM pedido_items
+     WHERE id = p_pedido_item_id AND sucursal_id = v_sucursal;
+  END IF;
+
+  FOR v_bonif IN
+    SELECT pi.id, pi.producto_id, pi.cantidad, pi.promocion_id
+      FROM pedido_items pi
+     WHERE pi.pedido_id = p_pedido_id
+       AND pi.sucursal_id = v_sucursal
+       AND COALESCE(pi.es_bonificacion, FALSE) = TRUE
+       AND pi.promocion_id IS NOT NULL
+  LOOP
+    SELECT
+      MAX(CASE WHEN pr.clave = 'cantidad_compra'       THEN pr.valor END)::INT,
+      MAX(CASE WHEN pr.clave = 'cantidad_bonificacion' THEN pr.valor END)::INT,
+      MAX(p.regalo_mueve_stock::INT)::BOOLEAN
+    INTO v_cant_compra, v_cant_bonif, v_regalo_mueve_stock
+    FROM promociones p
+    LEFT JOIN promocion_reglas pr
+      ON pr.promocion_id = p.id
+    WHERE p.id = v_bonif.promocion_id
+      AND p.sucursal_id = v_sucursal
+    GROUP BY p.id;
+
+    IF v_cant_compra IS NULL OR v_cant_compra <= 0
+       OR v_cant_bonif IS NULL OR v_cant_bonif <= 0 THEN
+      CONTINUE;
+    END IF;
+
+    SELECT COALESCE(SUM(pi.cantidad), 0)::INT
+      INTO v_total_qty
+      FROM pedido_items pi
+      JOIN promocion_productos pp
+        ON pp.producto_id = pi.producto_id
+       AND pp.promocion_id = v_bonif.promocion_id
+     WHERE pi.pedido_id = p_pedido_id
+       AND pi.sucursal_id = v_sucursal
+       AND COALESCE(pi.es_bonificacion, FALSE) = FALSE;
+
+    v_bloques        := v_total_qty / v_cant_compra;
+    v_expected_bonif := v_bloques * v_cant_bonif;
+
+    IF v_expected_bonif < v_bonif.cantidad THEN
+      v_diff := v_bonif.cantidad - v_expected_bonif;
+
+      IF COALESCE(v_regalo_mueve_stock, FALSE) THEN
+        UPDATE productos
+           SET stock = stock + v_diff
+         WHERE id = v_bonif.producto_id
+           AND sucursal_id = v_sucursal;
+      END IF;
+
+      UPDATE promociones
+         SET usos_pendientes = GREATEST(COALESCE(usos_pendientes, 0) - v_diff, 0)
+       WHERE id = v_bonif.promocion_id
+         AND sucursal_id = v_sucursal;
+
+      IF v_expected_bonif = 0 THEN
+        DELETE FROM pedido_items WHERE id = v_bonif.id;
+      ELSE
+        UPDATE pedido_items
+           SET cantidad = v_expected_bonif,
+               subtotal = v_expected_bonif * COALESCE(precio_unitario, 0)
+         WHERE id = v_bonif.id;
+      END IF;
+    END IF;
+  END LOOP;
+
+  SELECT COALESCE(tipo_factura, 'ZZ') INTO v_tipo_factura
+    FROM pedidos WHERE id = p_pedido_id AND sucursal_id = v_sucursal;
+
+  UPDATE pedidos
+     SET total = sub.total_recalc,
+         total_neto = sub.neto_recalc,
+         total_iva = sub.iva_recalc,
+         total_real = sub.real_recalc,
+         updated_at = NOW()
+    FROM (
+      SELECT
+        COALESCE(SUM(subtotal), 0) AS total_recalc,
+        COALESCE(SUM(CASE WHEN COALESCE(es_bonificacion, FALSE) = FALSE
+                          THEN cantidad * COALESCE(neto_unitario, precio_unitario)
+                          ELSE 0 END), 0) AS neto_recalc,
+        COALESCE(SUM(CASE WHEN COALESCE(es_bonificacion, FALSE) = FALSE
+                          THEN cantidad * COALESCE(iva_unitario, 0)
+                          ELSE 0 END), 0) AS iva_recalc,
+        COALESCE(SUM(CASE WHEN COALESCE(es_bonificacion, FALSE) = FALSE
+                          THEN cantidad * COALESCE(ingreso_real_unitario,
+                               CASE WHEN v_tipo_factura = 'FC'
+                                    THEN COALESCE(neto_unitario, precio_unitario)
+                                    ELSE precio_unitario END)
+                          ELSE 0 END), 0) AS real_recalc
+        FROM pedido_items
+       WHERE pedido_id = p_pedido_id AND sucursal_id = v_sucursal
+    ) sub
+   WHERE id = p_pedido_id AND sucursal_id = v_sucursal;
+
+  IF v_stock_devuelto THEN
+    UPDATE productos
+       SET stock = stock + p_cantidad_afectada
+     WHERE id = v_item.producto_id AND sucursal_id = v_sucursal;
+  END IF;
+
+  IF p_motivo IN ('producto_danado', 'producto_vencido') THEN
+    SELECT stock INTO v_stock_actual
+      FROM productos
+     WHERE id = v_item.producto_id AND sucursal_id = v_sucursal
+     FOR UPDATE;
+
+    INSERT INTO mermas_stock (
+      producto_id, cantidad, motivo, observaciones,
+      stock_anterior, stock_nuevo, usuario_id, sucursal_id
+    ) VALUES (
+      v_item.producto_id, p_cantidad_afectada,
+      CASE p_motivo WHEN 'producto_danado' THEN 'rotura' WHEN 'producto_vencido' THEN 'vencimiento' END,
+      COALESCE(p_descripcion, 'Salvedad pedido #' || p_pedido_id || ': ' || p_motivo),
+      v_stock_actual, GREATEST(v_stock_actual - p_cantidad_afectada, 0), v_usuario_id, v_sucursal
+    );
+
+    UPDATE productos
+       SET stock = GREATEST(stock - p_cantidad_afectada, 0)
+     WHERE id = v_item.producto_id AND sucursal_id = v_sucursal;
+
+    v_merma_registrada := TRUE;
+  END IF;
+
+  INSERT INTO salvedad_historial (salvedad_id, accion, estado_nuevo, notas, usuario_id, sucursal_id)
+  VALUES (v_salvedad_id, 'creacion', 'pendiente', p_descripcion, v_usuario_id, v_sucursal);
+
+  RETURN jsonb_build_object(
+    'success', true,
+    'salvedad_id', v_salvedad_id,
+    'monto_afectado', v_monto_afectado,
+    'cantidad_entregada', v_cantidad_entregada,
+    'stock_devuelto', v_stock_devuelto,
+    'merma_registrada', v_merma_registrada,
+    'nuevo_total_pedido', (
+      SELECT total FROM pedidos WHERE id = p_pedido_id AND sucursal_id = v_sucursal
+    )
+  );
+EXCEPTION WHEN OTHERS THEN
+  RETURN jsonb_build_object('success', false, 'error', SQLERRM);
+END;
+$function$;

--- a/migrations/124_reporte_gerencial_margen_real.sql
+++ b/migrations/124_reporte_gerencial_margen_real.sql
@@ -1,0 +1,325 @@
+-- ============================================================================
+-- 124 · reporte_gerencial: MARGEN REAL (Σ ingresos reales − Σ costos reales)
+-- ============================================================================
+-- Misma firma de 5 args ⇒ CREATE OR REPLACE. Claves ADITIVAS.
+-- Con la terna de mig 123:
+--   · venta        = Σ total (ingreso FINAL, compat)
+--   · venta_neta   = Σ total_neto — CAMBIA DE SIGNIFICADO: ahora es el neto
+--                    sin-IVA-SIEMPRE (teórico en ZZ), ya no el "real".
+--   · venta_real   = Σ total_real (FC: neto · ZZ: final) — LA base del margen.
+--   · margen_real  = venta_real − cmv       ← métrica reina
+--   · margen_real_neto = margen_real − bonif
+--   · vendedores/categorías/top_productos suman venta_real y margen_real.
+-- Fallbacks para filas pre-123 (no debería haber tras el backfill).
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION public.reporte_gerencial(
+  p_sucursal_id bigint,
+  p_desde date,
+  p_hasta date,
+  p_incluir_no_entregados boolean DEFAULT false,
+  p_comparar boolean DEFAULT false
+)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ STABLE SECURITY DEFINER
+ SET search_path TO 'public'
+AS $function$
+DECLARE
+  v_sucursales bigint[]; v_asignadas bigint[]; v_nombre text; v_result jsonb;
+  v_es_servicio boolean := (auth.uid() IS NULL);
+  v_estados text[] := CASE WHEN p_incluir_no_entregados
+                           THEN ARRAY['entregado','asignado','pendiente','en_preparacion']
+                           ELSE ARRAY['entregado'] END;
+  v_dias int := (p_hasta - p_desde) + 1;
+  v_prev_hasta date := p_desde - 1;
+  v_prev_desde date := (p_desde - 1) - ((p_hasta - p_desde));
+  v_comparativo jsonb := NULL;
+  v_prev jsonb;
+  v_alertas jsonb := '[]'::jsonb;
+  v_cat_neg int;
+  v_cli_inact int;
+  v_cob_venc numeric;
+  v_cob_venc_cli int;
+  v_venta numeric;
+  v_prev_venta numeric;
+  v_mermas numeric;
+  v_prev_mermas numeric;
+BEGIN
+  IF NOT v_es_servicio THEN
+    IF NOT EXISTS (SELECT 1 FROM perfiles WHERE id = auth.uid() AND rol = 'admin') THEN
+      RAISE EXCEPTION 'Acceso denegado: se requiere rol admin'; END IF;
+    SELECT array_agg(sucursal_id) INTO v_asignadas FROM usuario_sucursales WHERE usuario_id = auth.uid();
+    IF v_asignadas IS NULL THEN RAISE EXCEPTION 'Acceso denegado: el usuario no tiene sucursales asignadas'; END IF;
+  END IF;
+  IF p_sucursal_id IS NULL THEN
+    SELECT array_agg(id) INTO v_sucursales FROM sucursales WHERE activa;
+    IF NOT v_es_servicio THEN
+      SELECT array_agg(s) INTO v_sucursales FROM unnest(v_sucursales) AS s WHERE s = ANY(v_asignadas); END IF;
+    v_nombre := 'Red (consolidado)';
+  ELSE
+    IF NOT v_es_servicio AND NOT (p_sucursal_id = ANY(v_asignadas)) THEN
+      RAISE EXCEPTION 'Acceso denegado: la sucursal % no está asignada al usuario', p_sucursal_id; END IF;
+    v_sucursales := ARRAY[p_sucursal_id];
+    SELECT nombre INTO v_nombre FROM sucursales WHERE id = p_sucursal_id;
+  END IF;
+  IF v_sucursales IS NULL OR array_length(v_sucursales,1) IS NULL THEN
+    RAISE EXCEPTION 'Acceso denegado: sin sucursales disponibles para el usuario'; END IF;
+
+  WITH
+  ped AS (
+    SELECT id, cliente_id, usuario_id, total, monto_pagado, fecha, forma_pago, estado_pago,
+           COALESCE(total_neto, total) AS total_neto, COALESCE(total_iva, 0) AS total_iva,
+           COALESCE(tipo_factura, 'ZZ') AS tipo_factura,
+           COALESCE(total_real,
+             CASE WHEN COALESCE(tipo_factura, 'ZZ') = 'FC' THEN COALESCE(total_neto, total) ELSE total END
+           ) AS total_real
+    FROM pedidos WHERE estado = ANY(v_estados) AND canal='app'
+      AND fecha BETWEEN p_desde AND p_hasta AND sucursal_id = ANY(v_sucursales)
+  ),
+  it AS (
+    SELECT p.id AS pedido_id, p.usuario_id, p.fecha,
+           pi.cantidad, pi.subtotal, pi.es_bonificacion,
+           COALESCE(pi.costo_unitario_al_crear, prod.costo_real, prod.costo_sin_iva*(1+COALESCE(prod.impuestos_internos,0)/100)) AS costo_unit,
+           pi.cantidad * COALESCE(pi.ingreso_real_unitario,
+             CASE WHEN p.tipo_factura = 'FC' THEN COALESCE(pi.neto_unitario, pi.precio_unitario)
+                  ELSE pi.precio_unitario END) AS ingreso_real,
+           prod.nombre AS prod_nombre,
+           COALESCE(NULLIF(prod.categoria,''),'(sin categoría)') AS categoria,
+           (prod.costo_sin_iva IS NULL OR prod.costo_sin_iva = 0) AS sin_costo,
+           pr.nombre AS promo_nombre,
+           (pr.regalo_mueve_stock IS FALSE AND COALESCE(pr.unidades_por_bloque,0) > 0) AS es_fraccion,
+           pr.unidades_por_bloque,
+           COALESCE(prod.precio,0) AS precio_lista,
+           CASE WHEN pi.es_bonificacion THEN
+             CASE WHEN pr.regalo_mueve_stock IS FALSE AND pr.unidades_por_bloque > 0
+                  THEN pi.cantidad * COALESCE(pi.costo_unitario_al_crear, prod.costo_real, prod.costo_sin_iva*(1+COALESCE(prod.impuestos_internos,0)/100)) / pr.unidades_por_bloque
+                  ELSE pi.cantidad * COALESCE(pi.costo_unitario_al_crear, prod.costo_real, prod.costo_sin_iva*(1+COALESCE(prod.impuestos_internos,0)/100)) END
+           ELSE 0 END AS costo_bonif
+    FROM ped p
+    JOIN pedido_items pi ON pi.pedido_id = p.id
+    JOIN productos prod ON prod.id = pi.producto_id
+    LEFT JOIN promociones pr ON pr.id = pi.promocion_id
+  ),
+  nc AS (
+    SELECT usuario_id, total FROM pedidos
+    WHERE estado<>'cancelado' AND canal='app'
+      AND fecha BETWEEN p_desde AND p_hasta AND sucursal_id = ANY(v_sucursales)
+      AND usuario_id IN (SELECT id FROM perfiles)
+  ),
+  k_ped AS (SELECT COUNT(*) AS pedidos, COALESCE(SUM(total),0) AS venta,
+            COUNT(DISTINCT cliente_id) AS clientes, COALESCE(ROUND(AVG(total)),0) AS ticket,
+            COALESCE(SUM(total_neto),0) AS venta_neta,
+            COALESCE(SUM(total_iva),0) AS iva_debito,
+            COALESCE(SUM(total_real),0) AS venta_real,
+            COALESCE(SUM(total) FILTER (WHERE tipo_factura='FC'),0) AS fc_venta,
+            COUNT(*) FILTER (WHERE tipo_factura='FC') AS fc_pedidos,
+            COALESCE(SUM(total) FILTER (WHERE tipo_factura='ZZ'),0) AS zz_venta,
+            COUNT(*) FILTER (WHERE tipo_factura='ZZ') AS zz_pedidos
+            FROM ped),
+  k_it AS (
+    SELECT COALESCE(SUM(cantidad*costo_unit) FILTER (WHERE NOT es_bonificacion),0) AS cmv,
+      COALESCE(SUM(costo_bonif),0) AS bonif,
+      COALESCE(SUM(cantidad) FILTER (WHERE NOT es_bonificacion),0) AS unidades,
+      COALESCE(SUM(cantidad) FILTER (WHERE es_bonificacion),0) AS unidades_bonif,
+      COALESCE(SUM(subtotal) FILTER (WHERE sin_costo AND NOT es_bonificacion),0) AS ingreso_sin_costo
+    FROM it
+  ),
+  k_nc AS (SELECT COALESCE(SUM(total),0) AS base_comision FROM nc),
+  k_merma AS (
+    SELECT COALESCE(SUM(costo),0) AS mermas,
+      COALESCE(SUM(costo) FILTER (WHERE clasif = 'perdida'),0) AS mermas_perdida,
+      COALESCE(SUM(costo) FILTER (WHERE clasif = 'ajuste'),0) AS mermas_ajuste,
+      COALESCE(SUM(costo) FILTER (WHERE clasif = 'muestra'),0) AS mermas_muestra
+    FROM (
+      SELECT m.cantidad*COALESCE(m.costo_unitario, prod.costo_real, prod.costo_sin_iva*(1+COALESCE(prod.impuestos_internos,0)/100)) AS costo,
+             CASE WHEN m.motivo IN ('vencimiento','rotura','robo','decomiso','devolucion') THEN 'perdida'
+                  WHEN m.motivo = 'muestra' THEN 'muestra'
+                  ELSE 'ajuste' END AS clasif
+      FROM mermas_stock m JOIN productos prod ON prod.id = m.producto_id
+      WHERE m.sucursal_id = ANY(v_sucursales)
+        AND (m.created_at AT TIME ZONE 'America/Argentina/Buenos_Aires')::date BETWEEN p_desde AND p_hasta
+        AND COALESCE(m.motivo,'') NOT IN ('promociones','promociones_reversion')
+    ) t
+  ),
+  k_compra AS (SELECT COALESCE(SUM(total),0) AS compras FROM compras
+    WHERE sucursal_id = ANY(v_sucursales) AND fecha_compra BETWEEN p_desde AND p_hasta
+      AND COALESCE(estado,'') <> 'cancelada'),
+  k_nuevos AS (SELECT COUNT(*) AS nuevos FROM (
+      SELECT cliente_id, MIN(fecha) AS pc FROM pedidos
+      WHERE estado='entregado' AND sucursal_id = ANY(v_sucursales) GROUP BY cliente_id
+    ) t WHERE pc BETWEEN p_desde AND p_hasta),
+  m_ped AS (SELECT to_char(fecha,'YYYY-MM') AS mes, COUNT(*) AS pedidos, SUM(total) AS venta,
+            SUM(total_real) AS venta_real,
+            COUNT(DISTINCT cliente_id) AS clientes, ROUND(AVG(total)) AS ticket FROM ped GROUP BY 1),
+  m_it AS (SELECT to_char(fecha,'YYYY-MM') AS mes,
+           COALESCE(SUM(cantidad*costo_unit) FILTER (WHERE NOT es_bonificacion),0) AS cmv,
+           COALESCE(SUM(costo_bonif),0) AS bonif FROM it GROUP BY 1),
+  m_merma AS (SELECT to_char(m.created_at AT TIME ZONE 'America/Argentina/Buenos_Aires','YYYY-MM') AS mes,
+       SUM(m.cantidad*COALESCE(m.costo_unitario, prod.costo_real, prod.costo_sin_iva*(1+COALESCE(prod.impuestos_internos,0)/100))) AS mermas
+    FROM mermas_stock m JOIN productos prod ON prod.id = m.producto_id
+    WHERE m.sucursal_id = ANY(v_sucursales)
+      AND (m.created_at AT TIME ZONE 'America/Argentina/Buenos_Aires')::date BETWEEN p_desde AND p_hasta
+      AND COALESCE(m.motivo,'') NOT IN ('promociones','promociones_reversion') GROUP BY 1),
+  m_compra AS (SELECT to_char(fecha_compra,'YYYY-MM') AS mes, SUM(total) AS compras
+    FROM compras WHERE sucursal_id = ANY(v_sucursales) AND fecha_compra BETWEEN p_desde AND p_hasta
+      AND COALESCE(estado,'') <> 'cancelada' GROUP BY 1),
+  mensual AS (SELECT mp.mes, mp.pedidos, mp.venta, mp.venta_real, mp.clientes, mp.ticket,
+      COALESCE(mi.cmv,0) AS cmv, COALESCE(mi.bonif,0) AS bonif,
+      (mp.venta_real - COALESCE(mi.cmv,0)) AS margen_real,
+      COALESCE(mm.mermas,0) AS mermas, COALESCE(mc.compras,0) AS compras
+    FROM m_ped mp LEFT JOIN m_it mi ON mi.mes=mp.mes LEFT JOIN m_merma mm ON mm.mes=mp.mes LEFT JOIN m_compra mc ON mc.mes=mp.mes),
+  v_ent AS (SELECT usuario_id, COUNT(DISTINCT pedido_id) AS pedidos, SUM(subtotal) AS venta,
+      SUM(ingreso_real) AS venta_real,
+      SUM(subtotal) - COALESCE(SUM(cantidad*costo_unit) FILTER (WHERE NOT es_bonificacion),0) AS margen_comercial,
+      SUM(ingreso_real) - COALESCE(SUM(cantidad*costo_unit) FILTER (WHERE NOT es_bonificacion),0) AS margen_real,
+      COALESCE(SUM(costo_bonif),0) AS bonif FROM it GROUP BY usuario_id),
+  v_nc AS (SELECT usuario_id, SUM(total) AS base_nc FROM nc GROUP BY usuario_id),
+  vendedores AS (SELECT pf.nombre, pf.rol, e.pedidos, e.venta, e.venta_real, e.margen_comercial, e.margen_real, e.bonif,
+      COALESCE(n.base_nc, e.venta) AS base_nc
+    FROM v_ent e JOIN perfiles pf ON pf.id=e.usuario_id LEFT JOIN v_nc n ON n.usuario_id=e.usuario_id),
+  categorias AS (SELECT categoria, SUM(subtotal) AS venta,
+      SUM(ingreso_real) AS venta_real,
+      SUM(subtotal) - COALESCE(SUM(cantidad*costo_unit) FILTER (WHERE NOT es_bonificacion),0) AS margen_comercial,
+      SUM(ingreso_real) - COALESCE(SUM(cantidad*costo_unit) FILTER (WHERE NOT es_bonificacion),0) AS margen_real,
+      COALESCE(SUM(costo_bonif),0) AS bonif, bool_or(sin_costo) AS sin_costo
+    FROM it GROUP BY categoria),
+  top_prod AS (SELECT prod_nombre AS nombre,
+      COALESCE(SUM(cantidad) FILTER (WHERE NOT es_bonificacion),0) AS unidades, SUM(subtotal) AS venta,
+      SUM(ingreso_real) AS venta_real,
+      SUM(subtotal) - COALESCE(SUM(cantidad*costo_unit) FILTER (WHERE NOT es_bonificacion),0) AS margen,
+      SUM(ingreso_real) - COALESCE(SUM(cantidad*costo_unit) FILTER (WHERE NOT es_bonificacion),0) AS margen_real
+    FROM it GROUP BY prod_nombre ORDER BY venta DESC LIMIT 10),
+  top_cli AS (SELECT COALESCE(NULLIF(c.nombre_fantasia,''), c.razon_social) AS cliente,
+      COUNT(DISTINCT p.id) AS pedidos, SUM(p.total) AS venta
+    FROM ped p JOIN clientes c ON c.id=p.cliente_id GROUP BY 1 ORDER BY venta DESC LIMIT 10),
+  bonif_promos AS (SELECT COALESCE(promo_nombre,'(sin promoción)') AS promocion, prod_nombre AS producto,
+      SUM(cantidad) AS unidades, bool_or(es_fraccion) AS es_fraccion,
+      SUM(costo_bonif) AS costo,
+      SUM(CASE WHEN es_fraccion THEN cantidad * precio_lista / unidades_por_bloque
+               ELSE cantidad * precio_lista END) AS valor_venta
+    FROM it WHERE es_bonificacion GROUP BY 1, 2 HAVING SUM(cantidad) > 0),
+  mermas_motivo AS (SELECT COALESCE(NULLIF(m.motivo,''),'(sin motivo)') AS motivo,
+      CASE WHEN m.motivo IN ('vencimiento','rotura','robo','decomiso','devolucion') THEN 'perdida'
+           WHEN m.motivo = 'muestra' THEN 'muestra'
+           ELSE 'ajuste' END AS clasificacion,
+      SUM(m.cantidad) AS unidades,
+      SUM(m.cantidad*COALESCE(m.costo_unitario, prod.costo_real, prod.costo_sin_iva*(1+COALESCE(prod.impuestos_internos,0)/100))) AS costo
+    FROM mermas_stock m JOIN productos prod ON prod.id=m.producto_id
+    WHERE m.sucursal_id = ANY(v_sucursales)
+      AND (m.created_at AT TIME ZONE 'America/Argentina/Buenos_Aires')::date BETWEEN p_desde AND p_hasta
+      AND COALESCE(m.motivo,'') NOT IN ('promociones','promociones_reversion') GROUP BY 1, 2),
+  cobr AS (SELECT COALESCE(SUM(LEAST(COALESCE(monto_pagado,0), total)),0) AS cobrado,
+      COALESCE(SUM(GREATEST(total - COALESCE(monto_pagado,0), 0)),0) AS pendiente FROM ped),
+  pagos_ped AS (SELECT COALESCE(NULLIF(pg.forma_pago,''),'(sin dato)') AS forma_pago, SUM(pg.monto) AS monto
+    FROM pagos pg JOIN ped ON ped.id = pg.pedido_id GROUP BY 1),
+  formas AS (SELECT forma_pago, monto FROM pagos_ped
+    UNION ALL
+    SELECT '(sin registro de pago)', c.cobrado - COALESCE((SELECT SUM(monto) FROM pagos_ped),0)
+    FROM cobr c
+    WHERE c.cobrado - COALESCE((SELECT SUM(monto) FROM pagos_ped),0) > 0.01),
+  serie AS (SELECT to_char(fecha,'DD/MM') AS dia, SUM(total) AS venta FROM ped GROUP BY fecha ORDER BY fecha)
+  SELECT jsonb_build_object(
+    'meta', jsonb_build_object('sucursal_id', p_sucursal_id, 'sucursal_nombre', COALESCE(v_nombre,'?'),
+      'desde', p_desde, 'hasta', p_hasta, 'generado_at', now(),
+      'incluye_no_entregados', p_incluir_no_entregados),
+    'kpis', (SELECT jsonb_build_object('venta', kp.venta, 'pedidos', kp.pedidos, 'clientes', kp.clientes, 'ticket', kp.ticket,
+        'clientes_nuevos', kn.nuevos, 'cmv', ki.cmv, 'bonif', ki.bonif, 'unidades', ki.unidades,
+        'unidades_bonif', ki.unidades_bonif, 'margen_comercial', kp.venta - ki.cmv,
+        'margen_neto', kp.venta - ki.cmv - ki.bonif, 'base_comision', kc.base_comision, 'comision_pct_default', 2,
+        'mermas', km.mermas, 'mermas_perdida', km.mermas_perdida, 'mermas_ajuste', km.mermas_ajuste,
+        'mermas_muestra', km.mermas_muestra, 'compras', kcp.compras, 'ingreso_sin_costo', ki.ingreso_sin_costo,
+        'venta_neta', kp.venta_neta, 'iva_debito', kp.iva_debito,
+        'margen_comercial_neto', kp.venta_neta - ki.cmv,
+        'venta_real', kp.venta_real,
+        'margen_real', kp.venta_real - ki.cmv,
+        'margen_real_neto', kp.venta_real - ki.cmv - ki.bonif,
+        'fc_venta', kp.fc_venta, 'fc_pedidos', kp.fc_pedidos,
+        'zz_venta', kp.zz_venta, 'zz_pedidos', kp.zz_pedidos)
+      FROM k_ped kp, k_it ki, k_nc kc, k_merma km, k_compra kcp, k_nuevos kn),
+    'mensual', (SELECT COALESCE(jsonb_agg(to_jsonb(m) ORDER BY m.mes),'[]') FROM mensual m),
+    'vendedores', (SELECT COALESCE(jsonb_agg(to_jsonb(v) ORDER BY v.venta DESC),'[]') FROM vendedores v),
+    'categorias', (SELECT COALESCE(jsonb_agg(to_jsonb(c) ORDER BY c.venta DESC),'[]') FROM categorias c),
+    'top_productos', (SELECT COALESCE(jsonb_agg(to_jsonb(t)),'[]') FROM top_prod t),
+    'top_clientes', (SELECT COALESCE(jsonb_agg(to_jsonb(t)),'[]') FROM top_cli t),
+    'bonif_promos', (SELECT COALESCE(jsonb_agg(to_jsonb(b) ORDER BY b.valor_venta DESC),'[]') FROM bonif_promos b),
+    'mermas_motivo', (SELECT COALESCE(jsonb_agg(to_jsonb(mm) ORDER BY mm.costo DESC),'[]') FROM mermas_motivo mm),
+    'cobranza', jsonb_build_object('formas', (SELECT COALESCE(jsonb_agg(to_jsonb(f) ORDER BY f.monto DESC),'[]') FROM formas f),
+      'cobrado', (SELECT cobrado FROM cobr), 'pendiente', (SELECT pendiente FROM cobr)),
+    'serie_diaria', (SELECT COALESCE(jsonb_agg(jsonb_build_array(s.dia, s.venta)),'[]') FROM serie s),
+    'flags', (SELECT jsonb_build_object('ingreso_sin_costo', ki.ingreso_sin_costo,
+        'pct_sin_costo', CASE WHEN kp.venta > 0 THEN round(100.0*ki.ingreso_sin_costo/kp.venta,1) ELSE 0 END)
+      FROM k_it ki, k_ped kp)
+  ) INTO v_result;
+
+  IF p_comparar THEN
+    v_prev := public.reporte_gerencial(p_sucursal_id, v_prev_desde, v_prev_hasta, p_incluir_no_entregados, false);
+    v_comparativo := (v_prev->'kpis') || jsonb_build_object('desde', v_prev_desde, 'hasta', v_prev_hasta);
+  END IF;
+
+  v_venta := (v_result->'kpis'->>'venta')::numeric;
+  v_mermas := (v_result->'kpis'->>'mermas')::numeric;
+  v_prev_venta := (v_comparativo->>'venta')::numeric;
+  v_prev_mermas := (v_comparativo->>'mermas')::numeric;
+
+  IF p_comparar AND COALESCE(v_prev_venta,0) > 0 AND v_venta < v_prev_venta * 0.9 THEN
+    v_alertas := v_alertas || jsonb_build_object(
+      'severidad', CASE WHEN v_venta < v_prev_venta*0.8 THEN 'critical' ELSE 'warning' END,
+      'codigo','venta_caida','titulo','Venta en baja',
+      'detalle','Cayó '||round((1 - v_venta/v_prev_venta)*100)::text||'% vs período anterior',
+      'valor', v_venta - v_prev_venta, 'seccion','evolucion');
+  END IF;
+
+  SELECT COALESCE(SUM(total - COALESCE(monto_pagado,0)),0), COUNT(DISTINCT cliente_id)
+    INTO v_cob_venc, v_cob_venc_cli
+  FROM pedidos
+  WHERE estado='entregado' AND canal='app' AND sucursal_id = ANY(v_sucursales)
+    AND COALESCE(estado_pago,'pendiente') IN ('pendiente','parcial')
+    AND fecha < CURRENT_DATE - 30 AND total > COALESCE(monto_pagado,0);
+  IF v_cob_venc > 0 THEN
+    v_alertas := v_alertas || jsonb_build_object('severidad','critical','codigo','cobranza_vencida','titulo','Cobranza vencida',
+      'detalle', v_cob_venc_cli::text||' cliente(s) con saldo impago hace +30 días',
+      'valor', v_cob_venc, 'seccion','cobranza');
+  END IF;
+
+  SELECT COUNT(*) INTO v_cli_inact FROM (
+    SELECT p.cliente_id FROM pedidos p
+    WHERE p.estado='entregado' AND p.canal='app' AND p.sucursal_id = ANY(v_sucursales)
+    GROUP BY p.cliente_id
+    HAVING MAX(p.fecha) < CURRENT_DATE - 30 AND MAX(p.fecha) >= CURRENT_DATE - 90
+  ) t;
+  IF v_cli_inact > 0 THEN
+    v_alertas := v_alertas || jsonb_build_object('severidad','warning','codigo','clientes_inactivos','titulo','Clientes que dejaron de comprar',
+      'detalle', v_cli_inact::text||' cliente(s) sin comprar hace +30 días (compraban hasta hace poco)',
+      'valor', v_cli_inact, 'seccion','clientes');
+  END IF;
+
+  IF p_comparar AND COALESCE(v_prev_mermas,0) > 0 AND v_mermas > v_prev_mermas*1.3 AND v_mermas > 50000 THEN
+    v_alertas := v_alertas || jsonb_build_object('severidad','warning','codigo','mermas_alza','titulo','Mermas en alza',
+      'detalle','Subieron '||round((v_mermas/v_prev_mermas - 1)*100)::text||'% vs período anterior',
+      'valor', v_mermas, 'seccion','mermas');
+  END IF;
+
+  SELECT COUNT(*) INTO v_cat_neg FROM jsonb_array_elements(v_result->'categorias') c WHERE (c->>'margen_comercial')::numeric < 0;
+  IF v_cat_neg > 0 THEN
+    v_alertas := v_alertas || jsonb_build_object('severidad','warning','codigo','margen_categoria_negativo','titulo','Categorías con margen negativo',
+      'detalle', v_cat_neg::text||' categoría(s) con margen comercial negativo',
+      'valor', v_cat_neg, 'seccion','categorias');
+  END IF;
+
+  IF (v_result->'flags'->>'pct_sin_costo')::numeric >= 1 THEN
+    v_alertas := v_alertas || jsonb_build_object('severidad','info','codigo','productos_sin_costo','titulo','Productos sin costo',
+      'detalle', (v_result->'flags'->>'pct_sin_costo')::text||'% de la venta es de productos sin costo (margen sobreestimado)',
+      'valor', (v_result->'flags'->>'ingreso_sin_costo')::numeric, 'seccion','categorias');
+  END IF;
+
+  SELECT COALESCE(jsonb_agg(a ORDER BY array_position(ARRAY['critical','warning','info'], a->>'severidad')), '[]'::jsonb)
+    INTO v_alertas FROM jsonb_array_elements(v_alertas) a;
+
+  v_result := v_result || jsonb_build_object('comparativo', COALESCE(v_comparativo,'null'::jsonb), 'alertas', v_alertas);
+  RETURN v_result;
+END;
+$function$;
+
+REVOKE EXECUTE ON FUNCTION public.reporte_gerencial(bigint, date, date, boolean, boolean) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.reporte_gerencial(bigint, date, date, boolean, boolean) TO authenticated, service_role;

--- a/migrations/MANIFEST.md
+++ b/migrations/MANIFEST.md
@@ -87,6 +87,7 @@ desfasan y **se realinean en `101`**:
 | `078_control_stock_planilla.sql` | `control_stock_sesiones_y_rpc_aplicar` + `…_fk_usuario` + `fix_aplicar_control_stock_diferencia_generada` |
 | `095_reporte_gerencial.sql` | `reporte_gerencial` + `reporte_gerencial_fix_base_comision` |
 | `105_auditoria_integridad.sql` | `105_…` + `105_…_ventana_2h` + `105_…_fix_cc_saldo_a_favor` |
+| `123_terna_ingresos_pedidos.sql` | `123_…` (DDL+backfill+función) + `123_…_rpcs` (crear/bot) + `123_…_rpcs2` (editar/salvedades/cambiar tipo) — aplicado en 3 tandas por tamaño |
 | (bot 014–020) | hotfix `020_bot_fix_pgcrypto_schema` plegado en la tanda, sin archivo propio |
 
 **Cadena `reporte_gerencial`** (reescrita ~9 veces por `CREATE OR REPLACE`): el repo versiona

--- a/src/components/containers/ComprasContainer.tsx
+++ b/src/components/containers/ComprasContainer.tsx
@@ -17,6 +17,7 @@ import {
   useNotasCreditoByCompraQuery,
   useNotasCreditoResumenQuery,
   useRegistrarNotaCreditoMutation,
+  useActualizarProductoMutation,
 } from '../../hooks/queries'
 import type { ActualizarCompraItemsInput } from '../../hooks/queries'
 import { useAuthData } from '../../contexts/AuthDataContext'
@@ -62,6 +63,7 @@ export default function ComprasContainer(): React.ReactElement {
   const actualizarCompra = useActualizarCompraMutation()
   const anularCompra = useAnularCompraMutation()
   const crearProducto = useCrearProductoMutation()
+  const actualizarProducto = useActualizarProductoMutation()
   const crearProveedor = useCrearProveedorMutation()
   const registrarNC = useRegistrarNotaCreditoMutation()
 
@@ -131,7 +133,27 @@ export default function ComprasContainer(): React.ReactElement {
       notify.error(msg)
       throw err
     }
-  }, [registrarCompra, notify, user])
+
+    // Propagar alícuotas de II editadas en la factura al maestro de productos
+    // (la alícuota pudo cambiar; el costo de ESTA compra ya usó la de la línea).
+    const cambios = data.cambiosImpuestosInternos ?? []
+    if (cambios.length > 0) {
+      const fallidos: string[] = []
+      for (const c of cambios) {
+        try {
+          await actualizarProducto.mutateAsync({
+            id: c.productoId,
+            data: { impuestos_internos: c.impuestosInternos },
+          })
+        } catch {
+          fallidos.push(c.nombre)
+        }
+      }
+      const ok = cambios.length - fallidos.length
+      if (ok > 0) notify.success(`Alícuota de imp. internos actualizada en ${ok} producto${ok === 1 ? '' : 's'}`)
+      if (fallidos.length > 0) notify.error(`No se pudo actualizar la alícuota de: ${fallidos.join(', ')}`)
+    }
+  }, [registrarCompra, actualizarProducto, notify, user])
 
   const handleCrearProductoRapido = useCallback(async (data: { nombre: string; codigo: string; costoSinIva: number }) => {
     const producto = await crearProducto.mutateAsync({

--- a/src/components/modals/ModalCompra.tsx
+++ b/src/components/modals/ModalCompra.tsx
@@ -209,6 +209,7 @@ interface ProductosSectionProps {
   state: CompraState;
   dispatch: React.Dispatch<CompraActionType>;
   productosFiltrados: ProductoDB[];
+  iiMaster: Record<string, number>;
   onAgregarItem: (producto: ProductoDB) => void;
   onActualizarItem: (index: number, campo: keyof CompraItemForm, valor: number | string) => void;
   onEliminarItem: (index: number) => void;
@@ -221,6 +222,8 @@ interface ItemsListProps {
   items: CompraItemForm[];
   onActualizarItem: (index: number, campo: keyof CompraItemForm, valor: number | string) => void;
   onEliminarItem: (index: number) => void;
+  /** Tasa de II vigente del producto (para avisar si la línea difiere) */
+  iiMaster: Record<string, number>;
 }
 
 /** Props de ItemRow */
@@ -229,6 +232,8 @@ interface ItemRowProps {
   index: number;
   onActualizarItem: (index: number, campo: keyof CompraItemForm, valor: number | string) => void;
   onEliminarItem: (index: number) => void;
+  /** Tasa de II vigente en el maestro del producto (undefined = desconocida) */
+  iiDelProducto?: number;
 }
 
 /** Props de ResumenSection */
@@ -494,6 +499,13 @@ export default function ModalCompra({ productos, proveedores, onSave, onClose, o
   const [modalImportarOpen, setModalImportarOpen] = useState(false)
   const totales = useCalculosImpuestos(state.items, state.tipoFactura, state.percepcionIva, state.percepcionIibb, state.noGravado)
   const { subtotal, iva, impuestosInternos, total } = totales
+
+  // Tasa de II vigente por producto: para autocompletar y detectar líneas que
+  // difieren (alícuota cambiada en la factura → se propaga al producto al guardar).
+  const iiMaster = useMemo<Record<string, number>>(
+    () => Object.fromEntries(productos.map(p => [String(p.id), Number(p.impuestos_internos ?? 0)])),
+    [productos]
+  )
   const fileInputRef = useRef<HTMLInputElement>(null)
 
   // Productos filtrados
@@ -659,6 +671,17 @@ export default function ModalCompra({ productos, proveedores, onSave, onClose, o
         noGravado: state.tipoFactura === 'FC' ? state.noGravado : 0,
         otrosImpuestos: 0,
         total,
+        // Líneas FC cuya tasa de II fue editada a mano: la alícuota nueva se
+        // propaga al producto tras registrar la compra (con toast resumen).
+        cambiosImpuestosInternos: state.tipoFactura === 'FC'
+          ? state.items
+              .filter(it => difiereII(it, iiMaster[String(it.productoId)]))
+              .map(it => ({
+                productoId: it.productoId,
+                nombre: it.productoNombre,
+                impuestosInternos: it.impuestosInternos || 0,
+              }))
+          : [],
         formaPago: state.formaPago,
         notas: state.notas,
         tipoFactura: state.tipoFactura,
@@ -686,7 +709,7 @@ export default function ModalCompra({ productos, proveedores, onSave, onClose, o
 
   return (
     <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-2 sm:p-4">
-      <div className="bg-white dark:bg-gray-800 rounded-xl shadow-xl w-full max-w-4xl max-h-[90vh] overflow-hidden flex flex-col">
+      <div className="bg-white dark:bg-gray-800 rounded-xl shadow-xl w-full max-w-6xl max-h-[90vh] overflow-hidden flex flex-col">
         {/* Header */}
         <div className="flex items-center justify-between p-3 sm:p-4 border-b dark:border-gray-700 shrink-0">
           <div className="flex items-center gap-2 min-w-0">
@@ -796,6 +819,7 @@ export default function ModalCompra({ productos, proveedores, onSave, onClose, o
               state={state}
               dispatch={dispatch}
               productosFiltrados={productosFiltrados}
+              iiMaster={iiMaster}
               onAgregarItem={handleAgregarItem}
               onActualizarItem={handleActualizarItem}
               onEliminarItem={handleEliminarItem}
@@ -1022,7 +1046,7 @@ function DatosCompraSection({ state, dispatch }: DatosCompraSectionProps) {
   )
 }
 
-function ProductosSection({ state, dispatch, productosFiltrados, onAgregarItem, onActualizarItem, onEliminarItem, onCrearProductoRapido, onImportarExcel }: ProductosSectionProps) {
+function ProductosSection({ state, dispatch, productosFiltrados, iiMaster, onAgregarItem, onActualizarItem, onEliminarItem, onCrearProductoRapido, onImportarExcel }: ProductosSectionProps) {
   const [itemRapido, setItemRapido] = useState({ nombre: '', codigo: '', costo: 0 })
   const [creandoItem, setCreandoItem] = useState(false)
   const buscadorRef = useRef<HTMLDivElement>(null)
@@ -1218,7 +1242,7 @@ function ProductosSection({ state, dispatch, productosFiltrados, onAgregarItem, 
 
       {/* Lista de items */}
       {state.items.length > 0 ? (
-        <ItemsList items={state.items} onActualizarItem={onActualizarItem} onEliminarItem={onEliminarItem} />
+        <ItemsList items={state.items} onActualizarItem={onActualizarItem} onEliminarItem={onEliminarItem} iiMaster={iiMaster} />
       ) : (
         <div className="text-center py-8 text-gray-500">
           <Package className="w-12 h-12 mx-auto mb-2 opacity-50" />
@@ -1230,7 +1254,7 @@ function ProductosSection({ state, dispatch, productosFiltrados, onAgregarItem, 
   )
 }
 
-function ItemsList({ items, onActualizarItem, onEliminarItem }: ItemsListProps) {
+function ItemsList({ items, onActualizarItem, onEliminarItem, iiMaster }: ItemsListProps) {
   return (
     <div className="space-y-2">
       {/* Header solo en desktop */}
@@ -1250,15 +1274,23 @@ function ItemsList({ items, onActualizarItem, onEliminarItem }: ItemsListProps) 
           index={index}
           onActualizarItem={onActualizarItem}
           onEliminarItem={onEliminarItem}
+          iiDelProducto={iiMaster[String(item.productoId)]}
         />
       ))}
     </div>
   )
 }
 
-function ItemRow({ item, index, onActualizarItem, onEliminarItem }: ItemRowProps) {
+/** ¿La tasa de II de la línea difiere de la vigente en el producto? */
+function difiereII(item: CompraItemForm, iiDelProducto?: number): boolean {
+  if (iiDelProducto === undefined) return false
+  return Math.abs((item.impuestosInternos || 0) - iiDelProducto) > 0.0001
+}
+
+function ItemRow({ item, index, onActualizarItem, onEliminarItem, iiDelProducto }: ItemRowProps) {
+  const iiDifiere = difiereII(item, iiDelProducto)
   return (
-    <div className="bg-white dark:bg-gray-800 p-3 rounded-lg border dark:border-gray-600">
+    <div className={`bg-white dark:bg-gray-800 p-3 rounded-lg border ${iiDifiere ? 'border-amber-400 dark:border-amber-600' : 'dark:border-gray-600'}`}>
       {/* Mobile: Layout en cards */}
       <div className="md:hidden space-y-3">
         <div className="flex justify-between items-start">
@@ -1312,17 +1344,23 @@ function ItemRow({ item, index, onActualizarItem, onEliminarItem }: ItemRowProps
           </div>
           <div>
             <label className="block text-xs text-gray-500 mb-1">II%</label>
-            <input
-              type="number"
-              inputMode="decimal"
-              min="0"
-              step="0.01"
+            <NumberInput
+              min={0}
+              emptyValue={0}
               value={item.impuestosInternos || 0}
-              readOnly
-              className="w-full px-2 py-1 text-center border dark:border-gray-600 rounded bg-gray-100 dark:bg-gray-600 dark:text-gray-300 text-sm cursor-not-allowed"
+              onChange={(n) => onActualizarItem(index, 'impuestosInternos', n)}
+              commitOnChange
+              className={`w-full px-2 py-1 text-center border rounded text-sm dark:bg-gray-700 dark:text-white ${
+                iiDifiere ? 'border-amber-400 bg-amber-50 dark:bg-amber-900/20' : 'dark:border-gray-600'
+              }`}
             />
           </div>
         </div>
+        {iiDifiere && (
+          <p className="text-xs text-amber-700 dark:text-amber-300">
+            ⚠ II difiere del producto ({iiDelProducto}% → {item.impuestosInternos}%): al registrar se actualiza la alícuota del producto.
+          </p>
+        )}
         <div className="flex justify-between items-center pt-2 border-t dark:border-gray-600">
           <span className="text-sm text-gray-500">Subtotal:</span>
           <span className="font-semibold text-gray-800 dark:text-white">{formatPrecio(item.cantidad * item.costoUnitario * (1 - (item.bonificacion || 0) / 100))}</span>
@@ -1368,14 +1406,16 @@ function ItemRow({ item, index, onActualizarItem, onEliminarItem }: ItemRowProps
           />
         </div>
         <div className="col-span-2">
-          <input
-            type="number"
-            inputMode="decimal"
-            min="0"
-            step="0.01"
+          <NumberInput
+            min={0}
+            emptyValue={0}
             value={item.impuestosInternos || 0}
-            readOnly
-            className="w-full px-2 py-1 text-center border dark:border-gray-600 rounded bg-gray-100 dark:bg-gray-600 dark:text-gray-300 text-sm cursor-not-allowed"
+            onChange={(n) => onActualizarItem(index, 'impuestosInternos', n)}
+            commitOnChange
+            title={iiDifiere ? `Difiere del producto (${iiDelProducto}%): al registrar se actualiza la alícuota` : 'Tasa efectiva de imp. internos (autocompletada del producto)'}
+            className={`w-full px-2 py-1 text-center border rounded text-sm dark:bg-gray-700 dark:text-white ${
+              iiDifiere ? 'border-amber-400 bg-amber-50 dark:bg-amber-900/20' : 'dark:border-gray-600'
+            }`}
           />
         </div>
         <div className="col-span-1 text-right font-medium text-gray-800 dark:text-white text-sm">
@@ -1391,6 +1431,11 @@ function ItemRow({ item, index, onActualizarItem, onEliminarItem }: ItemRowProps
           </button>
         </div>
       </div>
+      {iiDifiere && (
+        <p className="hidden md:block text-xs text-amber-700 dark:text-amber-300 mt-1">
+          ⚠ II difiere del producto ({iiDelProducto}% → {item.impuestosInternos}%): al registrar se actualiza la alícuota del producto.
+        </p>
+      )}
     </div>
   )
 }

--- a/src/components/modals/ModalProducto.tsx
+++ b/src/components/modals/ModalProducto.tsx
@@ -132,28 +132,41 @@ const ModalProducto = memo(function ModalProducto({ producto, categorias, provee
   const [nuevaCategoria, setNuevaCategoria] = useState<string>('');
   const [mostrarNuevaCategoria, setMostrarNuevaCategoria] = useState<boolean>(false);
 
-  // Margen (markup sobre el costo FINAL) — solo UI, bidireccional con el precio
-  // final. Si edito el margen se recalcula el precio final; si edito el precio
-  // final se recalcula el margen.
-  const [margen, setMargen] = useState<string>(() => {
-    const costoFinal = calcularTotalConIva(
-      producto?.costo_sin_iva ?? '',
-      producto?.porcentaje_iva ?? 21,
-      producto?.impuestos_internos ?? '',
-    );
-    const precioFinal = parsePrecio(String(producto?.precio ?? ''));
-    if (costoFinal > 0 && precioFinal > 0) {
-      return calcularMargenPorcentaje(precioFinal, costoFinal).toFixed(1);
-    }
-    return '';
+  // ── Márgenes (solo UI, bidireccionales con el precio final) ───────────────
+  // Lógica del negocio (mig 123):
+  //   · MARGEN BRUTO = precio final − costo total (neto + IVA + II): la plata
+  //     desembolsada vs la cobrada. % = markup sobre el costo total.
+  //   · MARGEN NETO  = precio neto (precio/1+IVA%) − costo final (neto + II =
+  //     costo real). Es el margen fiscal FC. % = markup sobre el costo real.
+  // Editar cualquiera de los dos % recalcula el precio final (y el otro %).
+
+  /** Costo total con IVA (desembolso) y costo real (neto+II) desde el form. */
+  const costosDesdeForm = (f: ProductoFormData) => ({
+    costoTotal: calcularTotalConIva(f.costo_sin_iva, f.porcentaje_iva, f.impuestos_internos),
+    costoReal: calcularCostoReal(f.costo_sin_iva, f.impuestos_internos, producto?.ultimo_tipo_compra ?? 'FC'),
   });
 
+  const margenesDesdeForm = (f: ProductoFormData): { bruto: string; neto: string } => {
+    const { costoTotal, costoReal } = costosDesdeForm(f);
+    const precioFinal = parsePrecio(String(f.precio));
+    const precioNeto = calcularNetoDesdeTotal(f.precio, f.porcentaje_iva, 0);
+    return {
+      bruto: costoTotal > 0 && precioFinal > 0
+        ? calcularMargenPorcentaje(precioFinal, costoTotal).toFixed(1) : '',
+      neto: costoReal > 0 && precioNeto > 0
+        ? calcularMargenPorcentaje(precioNeto, costoReal).toFixed(1) : '',
+    };
+  };
+
+  // Inicialización lazy desde el producto (el modal se remonta al abrir).
+  const [margenBruto, setMargenBruto] = useState<string>(() => margenesDesdeForm(form).bruto);
+  const [margenNeto, setMargenNeto] = useState<string>(() => margenesDesdeForm(form).neto);
+
   // Recalcula los campos derivados a partir del form:
-  //  - costo_con_iva (costo final) desde el costo neto + IVA + imp. internos
-  //  - precio_sin_iva (precio neto) HACIA ATRÁS desde el precio final (el usuario
-  //    edita el precio final; en venta ZZ el ingreso es el final, en FC el neto).
-  //    OJO: la VENTA no discrimina imp. internos (no somos agente, mig 122):
-  //    el precio neto es precio / (1 + IVA%), sin II. El II solo afecta el costo.
+  //  - costo_con_iva (costo total) desde el costo neto + IVA + imp. internos
+  //  - precio_sin_iva (precio neto) HACIA ATRÁS desde el precio final. OJO: la
+  //    VENTA no discrimina imp. internos (no somos agente, mig 122): el precio
+  //    neto es precio / (1 + IVA%), sin II. El II solo afecta el costo.
   const recalcularTotales = (nuevoForm: ProductoFormData): ProductoFormData => {
     const costoTotal = calcularTotalConIva(nuevoForm.costo_sin_iva, nuevoForm.porcentaje_iva, nuevoForm.impuestos_internos);
     const precioNeto = calcularNetoDesdeTotal(nuevoForm.precio, nuevoForm.porcentaje_iva, 0);
@@ -164,57 +177,51 @@ const ModalProducto = memo(function ModalProducto({ producto, categorias, provee
     };
   };
 
-  // Margen derivado del precio final vs costo final (markup sobre costo).
-  const margenDesdeForm = (f: ProductoFormData): string => {
-    const costoFinal = calcularTotalConIva(f.costo_sin_iva, f.porcentaje_iva, f.impuestos_internos);
-    const precioFinal = parsePrecio(String(f.precio));
-    if (costoFinal > 0 && precioFinal > 0) {
-      return calcularMargenPorcentaje(precioFinal, costoFinal).toFixed(1);
-    }
-    return '';
+  const aplicarForm = (nuevoForm: ProductoFormData): void => {
+    const conTotales = recalcularTotales(nuevoForm);
+    setForm(conTotales);
+    const margenes = margenesDesdeForm(conTotales);
+    setMargenBruto(margenes.bruto);
+    setMargenNeto(margenes.neto);
   };
 
-  // Manejar cambio de costo neto: el precio final se mantiene, se recalcula el margen.
-  const handleCostoSinIvaChange = (valor: string): void => {
-    const nuevoForm = recalcularTotales({ ...form, costo_sin_iva: valor });
-    setForm(nuevoForm);
-    setMargen(margenDesdeForm(nuevoForm));
-  };
+  // Cambios de costo/atributos fiscales: el precio final se mantiene, se
+  // recalculan derivados y ambos márgenes.
+  const handleCostoSinIvaChange = (valor: string): void => aplicarForm({ ...form, costo_sin_iva: valor });
+  const handleImpuestosInternosChange = (valor: string): void => aplicarForm({ ...form, impuestos_internos: valor });
+  const handlePorcentajeIvaChange = (valor: string): void => aplicarForm({ ...form, porcentaje_iva: parseFloat(valor) });
 
-  // Imp. internos: solo cambian el costo final (la venta no los discrimina); recalcular margen.
-  const handleImpuestosInternosChange = (valor: string): void => {
-    const nuevoForm = recalcularTotales({ ...form, impuestos_internos: valor });
-    setForm(nuevoForm);
-    setMargen(margenDesdeForm(nuevoForm));
-  };
-
-  // % IVA: ídem imp. internos.
-  const handlePorcentajeIvaChange = (valor: string): void => {
-    const nuevoForm = recalcularTotales({ ...form, porcentaje_iva: parseFloat(valor) });
-    setForm(nuevoForm);
-    setMargen(margenDesdeForm(nuevoForm));
-  };
-
-  // Manejar cambio de PRECIO FINAL (lo edita el usuario) → recalcula neto + margen.
+  // Cambio de PRECIO FINAL (lo edita el usuario) → recalcula neto + márgenes.
   const handlePrecioChange = (valor: string): void => {
-    const nuevoForm = recalcularTotales({ ...form, precio: valor });
-    setForm(nuevoForm);
-    setMargen(margenDesdeForm(nuevoForm));
+    aplicarForm({ ...form, precio: valor });
     if (intentoGuardar && errores.precio) {
       clearFieldError('precio');
     }
   };
 
-  // Manejar cambio de MARGEN → recalcula el precio final (y el neto).
-  const handleMargenChange = (valor: string): void => {
-    setMargen(valor);
-    const costoFinal = calcularTotalConIva(form.costo_sin_iva, form.porcentaje_iva, form.impuestos_internos);
-    if (costoFinal > 0 && valor.trim() !== '' && !Number.isNaN(parseFloat(valor))) {
-      const precioFinal = calcularPrecioDesdeMargen(costoFinal, valor);
-      setForm(recalcularTotales({ ...form, precio: precioFinal.toFixed(2) }));
-      if (intentoGuardar && errores.precio) {
-        clearFieldError('precio');
-      }
+  // Margen BRUTO editado → precio final = costo total × (1 + %).
+  const handleMargenBrutoChange = (valor: string): void => {
+    setMargenBruto(valor);
+    const { costoTotal } = costosDesdeForm(form);
+    if (costoTotal > 0 && valor.trim() !== '' && !Number.isNaN(parseFloat(valor))) {
+      const precioFinal = calcularPrecioDesdeMargen(costoTotal, valor);
+      aplicarForm({ ...form, precio: precioFinal.toFixed(2) });
+      setMargenBruto(valor); // preservar lo tipeado (aplicarForm lo pisa con el derivado)
+      if (intentoGuardar && errores.precio) clearFieldError('precio');
+    }
+  };
+
+  // Margen NETO editado → precio neto = costo real × (1 + %) → precio final = neto × (1 + IVA%).
+  const handleMargenNetoChange = (valor: string): void => {
+    setMargenNeto(valor);
+    const { costoReal } = costosDesdeForm(form);
+    if (costoReal > 0 && valor.trim() !== '' && !Number.isNaN(parseFloat(valor))) {
+      const precioNeto = calcularPrecioDesdeMargen(costoReal, valor);
+      const iva = parseFloat(String(form.porcentaje_iva)) || 0;
+      const precioFinal = precioNeto * (1 + iva / 100);
+      aplicarForm({ ...form, precio: precioFinal.toFixed(2) });
+      setMargenNeto(valor); // preservar lo tipeado
+      if (intentoGuardar && errores.precio) clearFieldError('precio');
     }
   };
 
@@ -470,7 +477,7 @@ const ModalProducto = memo(function ModalProducto({ producto, categorias, provee
         {/* Seccion de Costos */}
         <div className="border-t pt-4">
           <h3 className="text-sm font-semibold text-gray-700 mb-3">Costos (compra)</h3>
-          <div className="grid grid-cols-2 gap-3">
+          <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
             <div>
               <label className="block text-xs font-medium mb-1 text-gray-600">Costo Neto</label>
               <NumberInput
@@ -484,20 +491,41 @@ const ModalProducto = memo(function ModalProducto({ producto, categorias, provee
               />
             </div>
             <div>
-              <label className="block text-xs font-medium mb-1 text-gray-600">Costo Total (Neto + IVA + Imp.Int.)</label>
+              <label className="block text-xs font-medium mb-1 text-gray-600">Imp. Internos ($)</label>
+              <input
+                type="text"
+                value={(parsePrecio(form.costo_sin_iva) * ((parseFloat(String(form.impuestos_internos)) || 0) / 100)).toFixed(2)}
+                readOnly
+                className="w-full px-3 py-2 border rounded-lg text-sm bg-gray-100"
+              />
+            </div>
+            <div>
+              <label className="block text-xs font-medium mb-1 text-gray-600">Costo final (Neto + II)</label>
+              <input
+                type="text"
+                value={calcularCostoReal(form.costo_sin_iva, form.impuestos_internos, producto?.ultimo_tipo_compra ?? 'FC').toFixed(2)}
+                readOnly
+                className="w-full px-3 py-2 border-2 border-blue-300 rounded-lg text-sm bg-blue-50 font-semibold"
+                title="Costo REAL: el que se aplica en márgenes, mermas y bonificaciones"
+              />
+            </div>
+            <div>
+              <label className="block text-xs font-medium mb-1 text-gray-600">Costo total (con IVA)</label>
               <input
                 type="number"
                 inputMode="decimal"
                 step="0.01"
                 value={form.costo_con_iva || ''}
                 readOnly
-                className="w-full px-3 py-2 border rounded-lg text-sm bg-gray-100 font-semibold"
+                className="w-full px-3 py-2 border rounded-lg text-sm bg-gray-100"
                 placeholder="0.00"
               />
             </div>
           </div>
           <p className="text-xs text-gray-500 mt-2">
-            Costo real{(producto?.ultimo_tipo_compra ?? 'FC') === 'ZZ' ? ' (última compra ZZ: lo pagado, sin add-ons)' : ' = Neto + Imp. Internos (sin IVA)'} = ${calcularCostoReal(form.costo_sin_iva, form.impuestos_internos, producto?.ultimo_tipo_compra ?? 'FC').toFixed(2)}
+            {(producto?.ultimo_tipo_compra ?? 'FC') === 'ZZ'
+              ? 'Última compra ZZ: el costo final es lo pagado (sin add-on de II).'
+              : 'El costo final (neto + imp. internos) es el costo REAL: el IVA de la compra es crédito fiscal, no costo.'}
           </p>
         </div>
 
@@ -532,15 +560,23 @@ const ModalProducto = memo(function ModalProducto({ producto, categorias, provee
             </div>
           </div>
 
-          {/* Margen: markup sobre el costo final, bidireccional con el precio final */}
-          <div className="grid grid-cols-2 gap-4 mt-3">
-            <div>
-              <label className="block text-xs font-medium mb-1 text-gray-600">Margen (%)</label>
+          {/* Márgenes bruto y neto: markup sobre costo, bidireccionales con el precio final */}
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mt-3">
+            {/* MARGEN BRUTO: precio final − costo total (con IVA + II) */}
+            <div className="p-3 bg-gray-50 dark:bg-gray-900 border rounded-lg">
+              <p className="text-xs font-semibold text-gray-700 dark:text-gray-200 mb-2">
+                Margen BRUTO
+                {(parsePrecio(String(form.costo_con_iva)) > 0 && parsePrecio(String(form.precio)) > 0) && (
+                  <span className="ml-2 text-blue-700 dark:text-blue-300">
+                    ${(parsePrecio(String(form.precio)) - parsePrecio(String(form.costo_con_iva))).toFixed(2)}
+                  </span>
+                )}
+              </p>
               <div className="relative">
                 <NumberInput
-                  value={parsePrecio(margen)}
+                  value={parsePrecio(margenBruto)}
                   emptyValue={0}
-                  onChange={(n) => handleMargenChange(String(n))}
+                  onChange={(n) => handleMargenBrutoChange(String(n))}
                   commitOnChange
                   disabled={parsePrecio(String(form.costo_con_iva)) <= 0}
                   className="w-full px-3 py-2 pr-7 border rounded-lg disabled:bg-gray-100 disabled:cursor-not-allowed"
@@ -549,26 +585,44 @@ const ModalProducto = memo(function ModalProducto({ producto, categorias, provee
                 <span className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-400 text-sm">%</span>
               </div>
               <p className="text-xs text-gray-500 mt-1">
-                {parsePrecio(String(form.costo_con_iva)) > 0
-                  ? 'Markup sobre el costo final. Editá margen o precio final indistintamente.'
-                  : 'Cargá el costo para usar el margen.'}
+                Precio final − costo total (con IVA + II). Markup s/ costo total.
               </p>
             </div>
-            {(parsePrecio(String(form.costo_con_iva)) > 0 && parsePrecio(String(form.precio)) > 0) && (
-              <div className="flex items-center">
-                <div className="p-3 bg-blue-50 rounded-lg w-full">
-                  <p className="text-xs font-medium text-blue-800">
-                    Ganancia final: ${(parsePrecio(String(form.precio)) - parsePrecio(String(form.costo_con_iva))).toFixed(2)}
-                  </p>
-                  <p className="text-xs text-blue-600 mt-1">Precio final − costo final (con IVA e imp. internos)</p>
-                </div>
+
+            {/* MARGEN NETO: precio neto − costo final (neto + II = costo real) */}
+            <div className="p-3 bg-emerald-50 dark:bg-emerald-900/20 border border-emerald-200 dark:border-emerald-800 rounded-lg">
+              <p className="text-xs font-semibold text-emerald-800 dark:text-emerald-200 mb-2">
+                Margen NETO
+                {(() => {
+                  const costoReal = calcularCostoReal(form.costo_sin_iva, form.impuestos_internos, producto?.ultimo_tipo_compra ?? 'FC');
+                  const precioNeto = parsePrecio(String(form.precio_sin_iva));
+                  return costoReal > 0 && precioNeto > 0 ? (
+                    <span className="ml-2">${(precioNeto - costoReal).toFixed(2)}</span>
+                  ) : null;
+                })()}
+              </p>
+              <div className="relative">
+                <NumberInput
+                  value={parsePrecio(margenNeto)}
+                  emptyValue={0}
+                  onChange={(n) => handleMargenNetoChange(String(n))}
+                  commitOnChange
+                  disabled={calcularCostoReal(form.costo_sin_iva, form.impuestos_internos, producto?.ultimo_tipo_compra ?? 'FC') <= 0}
+                  className="w-full px-3 py-2 pr-7 border rounded-lg disabled:bg-gray-100 disabled:cursor-not-allowed"
+                  placeholder="0.0"
+                />
+                <span className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-400 text-sm">%</span>
               </div>
-            )}
+              <p className="text-xs text-emerald-700 dark:text-emerald-300 mt-1">
+                Precio neto − costo final (neto + II). Markup s/ costo real. Es el margen real si vendés FC.
+              </p>
+            </div>
           </div>
 
           <p className="text-xs text-gray-500 mt-2">
             * El precio final incluye IVA ({form.porcentaje_iva || 21}%). El neto se calcula hacia atrás.
             La venta no discrimina imp. internos (no somos agente): el II solo integra el costo.
+            Editá cualquiera de los dos márgenes o el precio final indistintamente.
           </p>
         </div>
       </div>

--- a/src/components/vistas/VistaReportesGerenciales.tsx
+++ b/src/components/vistas/VistaReportesGerenciales.tsx
@@ -324,7 +324,11 @@ export default function VistaReportesGerenciales({
                 <div className="flex items-center justify-between gap-2">{cmp ? <Delta cur={k.venta} prev={kp!.venta} /> : <span />}<Sparkline data={(reporte.serie_diaria ?? []).map((s) => Number(s[1]))} /></div>
                 {metasOn && metas?.venta != null && <Semaforo cur={k.venta} meta={metas.venta} factor={metaFactor} />}
               </div>} />
-            <KpiCard label="Margen comercial" value={moneyC(k.margen_comercial)} sub={<><b>{pct(k.margen_comercial / k.venta)}</b> antes de bonif.</>} accent={ACCENTS.cyan}
+            <KpiCard label="Margen real" value={moneyC(k.margen_real ?? k.margen_comercial)}
+              sub={<><b>{pct((k.margen_real ?? k.margen_comercial) / (k.venta_real ?? k.venta))}</b> s/ venta real (Σ ingresos reales − costos reales)</>}
+              accent={ACCENTS.emerald}
+              delta={cmp && kp!.margen_real != null ? <Delta cur={k.margen_real ?? 0} prev={kp!.margen_real} /> : undefined} />
+            <KpiCard label="Margen comercial" value={moneyC(k.margen_comercial)} sub={<><b>{pct(k.margen_comercial / k.venta)}</b> s/ venta final, antes de bonif.</>} accent={ACCENTS.cyan}
               delta={cmp ? <Delta cur={k.margen_comercial} prev={kp!.margen_comercial} /> : undefined} />
             <KpiCard label="Bonificaciones" value={moneyC(k.bonif)} sub={<><b>{pct(k.bonif / k.venta)}</b> de la venta</>} accent={ACCENTS.amber}
               delta={cmp ? <Delta cur={k.bonif} prev={kp!.bonif} invert /> : undefined} />
@@ -347,11 +351,12 @@ export default function VistaReportesGerenciales({
               delta={cmp ? <Delta cur={k.ticket} prev={kp!.ticket} /> : undefined} />
           </div>
 
-          {/* Fiscal (mig 120): solo si hay ventas FC en el período (todo-ZZ ⇒ venta neta = venta) */}
-          {(k.fc_pedidos ?? 0) > 0 && k.venta_neta != null && (
+          {/* Terna fiscal (mig 124): solo si hay ventas FC en el período (todo-ZZ ⇒ real = final) */}
+          {(k.fc_pedidos ?? 0) > 0 && k.venta_real != null && (
             <div className="flex flex-wrap items-center gap-x-5 gap-y-1 bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-800 rounded-lg px-4 py-2.5 text-sm text-blue-900 dark:text-blue-200">
-              <span><b>Venta neta</b> (sin IVA de FC): <b>{moneyC(k.venta_neta)}</b></span>
-              <span>Margen comercial s/neta: <b>{moneyC(k.margen_comercial_neto ?? (k.venta_neta - k.cmv))}</b></span>
+              <span>Venta <b>final</b>: {moneyC(k.venta)}</span>
+              <span>Venta <b>neta</b> (sin IVA): {moneyC(k.venta_neta ?? 0)}</span>
+              <span>Venta <b>real</b> (FC neto · ZZ final): <b>{moneyC(k.venta_real)}</b></span>
               <span>IVA débito: <b>{moneyC(k.iva_debito ?? 0)}</b></span>
               <span>Mix: FC {moneyC(k.fc_venta ?? 0)} ({N.format(k.fc_pedidos ?? 0)}) · ZZ {moneyC(k.zz_venta ?? 0)} ({N.format(k.zz_pedidos ?? 0)})</span>
             </div>

--- a/src/hooks/queries/useReporteGerencialQuery.ts
+++ b/src/hooks/queries/useReporteGerencialQuery.ts
@@ -39,6 +39,11 @@ export interface ReporteKpis {
   venta_neta?: number
   iva_debito?: number
   margen_comercial_neto?: number
+  /** Terna real (mig 124): venta_real = Σ total_real (FC: neto · ZZ: final).
+   *  margen_real = venta_real − cmv es LA métrica del negocio. */
+  venta_real?: number
+  margen_real?: number
+  margen_real_neto?: number
   fc_venta?: number
   fc_pedidos?: number
   zz_venta?: number

--- a/src/hooks/supabase/useReportesFinancieros.ts
+++ b/src/hooks/supabase/useReportesFinancieros.ts
@@ -189,17 +189,23 @@ export function useReportesFinancieros(): UseReportesFinancierosReturn {
           productoStats[id].cantidadVendida += item.cantidad
           ventasBrutas += subtotalItem
 
-          // Usar neto_unitario si existe (pedidos nuevos), sino calcular
-          if (tipoFactura === 'FC' && (item as Record<string, unknown>).neto_unitario != null) {
-            const netoItem = ((item as Record<string, unknown>).neto_unitario as number) * item.cantidad
-            const ivaItem = ((item as Record<string, unknown>).iva_unitario as number || 0) * item.cantidad
-            const impIntItem = ((item as Record<string, unknown>).impuestos_internos_unitario as number || 0) * item.cantidad
+          // Ingreso REAL por item (mig 123): FC = neto (el IVA se remite), ZZ =
+          // precio final. Snapshot en ingreso_real_unitario; fallback por tipo
+          // para filas legacy.
+          const itemRec = item as Record<string, unknown>
+          const realUnit = itemRec.ingreso_real_unitario as number | null | undefined
+          if (realUnit != null) {
+            productoStats[id].ingresos += realUnit * item.cantidad
+            ivaDiscriminado += ((itemRec.iva_unitario as number) || 0) * item.cantidad
+            impuestosInternosTotales += ((itemRec.impuestos_internos_unitario as number) || 0) * item.cantidad
+            ventasNetas += ((itemRec.neto_unitario as number) ?? realUnit) * item.cantidad
+          } else if (tipoFactura === 'FC' && itemRec.neto_unitario != null) {
+            const netoItem = (itemRec.neto_unitario as number) * item.cantidad
             productoStats[id].ingresos += netoItem
-            ivaDiscriminado += ivaItem
-            impuestosInternosTotales += impIntItem
+            ivaDiscriminado += ((itemRec.iva_unitario as number) || 0) * item.cantidad
             ventasNetas += netoItem
           } else {
-            // Pedidos ZZ o legacy sin desglose: neto = total
+            // ZZ o legacy sin desglose: real = final
             productoStats[id].ingresos += subtotalItem
             ventasNetas += subtotalItem
           }

--- a/src/types/hooks.ts
+++ b/src/types/hooks.ts
@@ -93,10 +93,14 @@ export interface PedidoItemDB {
   promocion?: {
     unidades_por_bloque?: number | null;
   } | null;
+  /** Precio sin IVA por unidad, SIEMPRE (teórico en ZZ; mig 123) */
   neto_unitario?: number;
+  /** IVA discriminado: solo FC (débito real); 0 en ZZ */
   iva_unitario?: number;
   impuestos_internos_unitario?: number;
   porcentaje_iva?: number;
+  /** Ingreso REAL por unidad: FC = neto · ZZ = precio final (mig 123) */
+  ingreso_real_unitario?: number;
 }
 
 export interface PerfilDB {
@@ -129,8 +133,11 @@ export interface PedidoDB {
   estado_pago?: 'pendiente' | 'parcial' | 'pagado';
   forma_pago?: string;
   total: number;
+  /** Σ neto (sin IVA, SIEMPRE — teórico en ZZ; mig 123) */
   total_neto?: number;
   total_iva?: number;
+  /** Σ ingreso real (FC: neto · ZZ: final; mig 123) — base del margen real */
+  total_real?: number;
   tipo_factura?: 'ZZ' | 'FC';
   monto_pagado?: number;
   notas?: string | null;
@@ -927,6 +934,8 @@ export interface CompraFormInputExtended {
     porcentajeIva?: number;
     impuestosInternos?: number;
   }>;
+  /** Líneas cuya tasa de II fue editada a mano: se propaga al producto tras registrar (mig 123 UI). */
+  cambiosImpuestosInternos?: Array<{ productoId: string; nombre: string; impuestosInternos: number }>;
 }
 
 export interface ProveedorFormInputExtended {

--- a/src/utils/calculations.fiscal.test.ts
+++ b/src/utils/calculations.fiscal.test.ts
@@ -40,24 +40,27 @@ describe('calcularCostoFinanciero (desembolso por unidad, sin percepciones)', ()
   })
 })
 
-describe('calcularNetoVenta (mig 122: la venta NO discrimina imp. internos)', () => {
-  it('FC: neto = precio/(1+IVA%); el II del producto se ignora (no somos agente)', () => {
+describe('calcularNetoVenta (mig 123: terna neto / iva / ingreso real)', () => {
+  it('FC: neto = precio/(1+IVA%); ingreso real = neto; el II se ignora (no somos agente)', () => {
     // Venta FC de una cola a $10.000 final: aunque el producto tenga II 8,6956%,
     // la factura de venta discrimina solo neto + IVA.
     const d = calcularNetoVenta(10000, 21, 8.6956, 'FC')
     expect(d.neto).toBeCloseTo(8264.46, 2)
     expect(d.iva).toBeCloseTo(1735.54, 2)
     expect(d.impuestosInternos).toBe(0)
+    expect(d.ingresoReal).toBeCloseTo(8264.46, 2)
     // Reconstrucción: neto + iva = precio final
     expect(d.neto + d.iva).toBeCloseTo(10000, 2)
     // IVA es exactamente 21% del gravado
     expect(d.iva).toBeCloseTo(d.neto * 0.21, 2)
   })
 
-  it('ZZ: todo el precio final es ingreso neto', () => {
-    expect(calcularNetoVenta(10000, 21, 8.6956, 'ZZ')).toEqual({
-      neto: 10000, iva: 0, impuestosInternos: 0,
-    })
+  it('ZZ: ingreso real = precio final; neto teórico sin IVA; IVA discriminado 0', () => {
+    const d = calcularNetoVenta(10000, 21, 8.6956, 'ZZ')
+    expect(d.ingresoReal).toBe(10000)
+    expect(d.neto).toBeCloseTo(8264.46, 2)
+    expect(d.iva).toBe(0)
+    expect(d.impuestosInternos).toBe(0)
   })
 })
 

--- a/src/utils/calculations.ts
+++ b/src/utils/calculations.ts
@@ -85,28 +85,33 @@ export function calcularMontoIva(
 // ============================================
 
 export interface DesgloseNetoVenta {
+  /** Precio sin IVA, SIEMPRE (teórico en ZZ) */
   neto: number;
+  /** IVA discriminado: solo FC (débito real); 0 en ZZ */
   iva: number;
+  /** Siempre 0: la venta no discrimina imp. internos (mig 122) */
   impuestosInternos: number;
+  /** Ingreso REAL: FC = neto (el IVA se remite) · ZZ = precio final */
+  ingresoReal: number;
 }
 
 /**
- * Calcula el ingreso neto de una venta según tipo de factura (espejo del SQL
- * calcular_desglose_venta, mig 122).
+ * Terna de ingresos por unidad de venta (espejo del SQL calcular_desglose_venta,
+ * mig 123):
  *
- * ZZ (sin factura): todo el precio final es ingreso neto.
- * FC (con factura): neto = precio / (1 + IVA%); el IVA se remite a AFIP.
+ *   · neto        = precio / (1 + IVA%) — SIEMPRE, también en ZZ (teórico)
+ *   · iva         = IVA discriminado, solo FC (débito real); 0 en ZZ
+ *   · ingresoReal = neto si FC (el IVA se remite) · precio final si ZZ
  *
  * La venta NUNCA discrimina impuestos internos: la distribuidora no es agente
  * de II — el II existe solo en el COSTO de compra (calcularCostoReal). El
  * parámetro porcentajeImpInternos se conserva por compatibilidad pero se
- * ignora (mig 122; antes dividía por 1+iva+II y subestimaba el neto).
+ * ignora (mig 122).
  *
  * @param precioFinal - Precio final al consumidor (incluye IVA)
  * @param porcentajeIva - Porcentaje de IVA del producto (ej: 21, 10.5, 0)
  * @param _porcentajeImpInternos - IGNORADO (compat de firma)
  * @param tipoFactura - 'ZZ' o 'FC'
- * @returns Desglose con neto, iva e impuestos internos (siempre 0)
  */
 export function calcularNetoVenta(
   precioFinal: number | string,
@@ -115,16 +120,14 @@ export function calcularNetoVenta(
   tipoFactura: 'ZZ' | 'FC' = 'ZZ'
 ): DesgloseNetoVenta {
   const precio = parseFloat(String(precioFinal)) || 0;
+  const neto = calcularNetoDesdeTotal(precio, porcentajeIva, 0);
 
   if (tipoFactura === 'ZZ') {
-    return { neto: precio, iva: 0, impuestosInternos: 0 };
+    return { neto, iva: 0, impuestosInternos: 0, ingresoReal: precio };
   }
 
-  // FC: back-calculate neto from final price (solo IVA; sin II)
-  const neto = calcularNetoDesdeTotal(precio, porcentajeIva, 0);
   const iva = calcularMontoIva(neto, porcentajeIva);
-
-  return { neto, iva, impuestosInternos: 0 };
+  return { neto, iva, impuestosInternos: 0, ingresoReal: neto };
 }
 
 /**


### PR DESCRIPTION
## Lógica definitiva de ingresos y costos

**Regla:** costo real = neto compra + imp. internos (aplica a TODO: CMV, mermas, bonif). Ingreso **final** = precio cobrado · **neto** = precio/(1+IVA%) siempre (teórico en ZZ) · **real** = neto si FC, final si ZZ. **Margen real = Σ ingresos reales − Σ costos reales** es la métrica reina. Bonif/mermas valuadas a precio de venta usan el precio FINAL (ya era así).

### Cambios
- **mig 123** (APLICADA en 3 tandas por tamaño, documentado en MANIFEST): `pedido_items.ingreso_real_unitario` + `pedidos.total_real`; **redefine** `total_neto`/`neto_unitario` como sin-IVA-siempre (backfill completo; `total_iva` invariante = débito real). `calcular_desglose_venta` → (neto, iva, ingreso_real). Los 7 RPCs de pedidos persisten la terna; el flip FC↔ZZ ya no toca el neto (solo iva y real). También cierra que `registrar_salvedad`/`anular_salvedad` no recalculaban `total_real`.
- **mig 124** (APLICADA): `reporte_gerencial` suma `venta_real`, `margen_real`, `margen_real_neto` (kpis + mensual + vendedores + categorías + top productos), claves viejas intactas — sin mezclar bruto con neto.
- **ModalProducto**: Costos = Neto (input) · **II en $** · **Costo final (neto+II)** destacado · Costo total con IVA. Márgenes: **BRUTO** (precio final − costo total) y **NETO** (precio neto − costo real), $ y % markup s/costo, ambos editables ↔ precio final.
- **ModalCompra** ampliado (max-w-6xl): **II por línea editable** (autocompletado del producto); si difiere → warning ámbar en la línea y al registrar **se actualiza la alícuota del producto** con toast resumen (la alícuota puede cambiar por ley).
- Dashboard: KpiCard **"Margen real"** + banda con la terna; Rentabilidad y `calcularNetoVenta` (TS) alineados.

### Verificación en prod
- 0 filas sin `total_real`/`ingreso_real_unitario`; Σ `total_iva` invariante pre/post (débito real intacto); ZZ: `total_real = total` y `total_neto ≈ total/1,21`.
- Reporte de julio (todo ZZ): `venta_real = venta` y `margen_real = margen_comercial`, como corresponde; `venta_neta` pasó a ser el neto teórico sin IVA.
- 76 tests verdes + typecheck limpio.

⚠️ Cambio de semántica: `venta_neta` del reporte ahora significa "sin IVA siempre" (antes era el real). El real vive en `venta_real`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)