### PR TITLE
feat(compras): cambiar proveedor de una compra (anula + clona)

### DIFF
--- a/migrations/125_cambiar_proveedor_compra.sql
+++ b/migrations/125_cambiar_proveedor_compra.sql
@@ -1,0 +1,150 @@
+-- ============================================================================
+-- 125 · cambiar_proveedor_compra: corrige el proveedor de una compra cargada
+--       al proveedor equivocado, sin reescribir la fila.
+-- ============================================================================
+-- Analogo a cambiar_cliente_pedido (mig 094) pero para compras: en vez de un
+-- UPDATE proveedor_id, ANULA la compra vieja y CLONA una nueva identica (mismos
+-- items, importes, fecha, factura, tipo, forma de pago) cambiando solo el
+-- proveedor en la cabecera. Conserva trazabilidad/auditoria (queda la vieja
+-- cancelada + la nueva como rastro de la correccion) en lugar de pisar
+-- silenciosamente el proveedor de una factura ya registrada.
+--
+-- POR QUE NO anular_compra_atomica + registrar_compra_completa:
+--   anular RESTA stock y RECHAZA si quedaria negativo (apenas vendiste parte de
+--   lo comprado, ya falla), y registrar lo volveria a SUMAR -> dos movimientos
+--   de stock_historico y riesgo de fallar en el caso comun. Aca la mercaderia
+--   llego fisicamente y sigue en deposito: solo reasignamos la contraparte de la
+--   factura. Por eso el clon NO toca stock ni costos (productos.stock, costo_real,
+--   etc.): el neto de stock es cero por construccion, sin guardas ni churn. Los
+--   reportes ya excluyen las compras 'cancelada', asi que la vieja sale de los
+--   totales y la nueva entra con valores identicos.
+--
+-- Solo admin. La cabecera nueva copia todo menos el proveedor (y no arrastra
+-- tp_import_id). La auditoria la cubre el trigger audit_compras (INSERT de la
+-- nueva + UPDATE de la vieja). Atomico: cualquier error revierte toda la
+-- transaccion via EXCEPTION WHEN OTHERS.
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION public.cambiar_proveedor_compra(
+  p_compra_id bigint,
+  p_usuario_id uuid,
+  p_nuevo_proveedor_id bigint DEFAULT NULL,
+  p_nuevo_proveedor_nombre character varying DEFAULT NULL,
+  p_motivo text DEFAULT 'Cambio de proveedor'
+) RETURNS jsonb
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public'
+AS $function$
+DECLARE
+  v_sucursal   BIGINT := current_sucursal_id();
+  v_acting     UUID := auth.uid();
+  v_role       TEXT;
+  v_compra     RECORD;
+  v_nc_count   INTEGER;
+  v_nueva_id   BIGINT;
+BEGIN
+  -- ---- Validaciones ----
+  IF v_sucursal IS NULL THEN
+    RETURN jsonb_build_object('success', false, 'error', 'No hay sucursal activa');
+  END IF;
+
+  IF p_usuario_id IS DISTINCT FROM v_acting THEN
+    RETURN jsonb_build_object('success', false, 'error', 'ID de usuario no coincide con la sesion autenticada');
+  END IF;
+
+  SELECT rol INTO v_role FROM perfiles WHERE id = v_acting;
+  IF v_role IS NULL OR v_role <> 'admin' THEN
+    RETURN jsonb_build_object('success', false, 'error', 'No autorizado: solo admin puede cambiar el proveedor de una compra');
+  END IF;
+
+  IF p_nuevo_proveedor_id IS NULL AND COALESCE(TRIM(p_nuevo_proveedor_nombre), '') = '' THEN
+    RETURN jsonb_build_object('success', false, 'error', 'Debe indicar el proveedor nuevo');
+  END IF;
+
+  -- Lock de la compra vieja
+  SELECT * INTO v_compra FROM compras WHERE id = p_compra_id AND sucursal_id = v_sucursal FOR UPDATE;
+  IF NOT FOUND THEN
+    RETURN jsonb_build_object('success', false, 'error', 'Compra no encontrada');
+  END IF;
+
+  IF v_compra.estado = 'cancelada' THEN
+    RETURN jsonb_build_object('success', false, 'error', 'La compra ya esta cancelada');
+  END IF;
+
+  -- Debe ser realmente otro proveedor
+  IF p_nuevo_proveedor_id IS NOT NULL AND p_nuevo_proveedor_id IS NOT DISTINCT FROM v_compra.proveedor_id THEN
+    RETURN jsonb_build_object('success', false, 'error', 'El proveedor nuevo es el mismo que el actual');
+  END IF;
+  IF p_nuevo_proveedor_id IS NULL AND v_compra.proveedor_id IS NULL
+     AND lower(COALESCE(TRIM(p_nuevo_proveedor_nombre), '')) = lower(COALESCE(TRIM(v_compra.proveedor_nombre), '')) THEN
+    RETURN jsonb_build_object('success', false, 'error', 'El proveedor nuevo es el mismo que el actual');
+  END IF;
+
+  -- El proveedor nuevo (si es por id) debe existir en la sucursal
+  IF p_nuevo_proveedor_id IS NOT NULL THEN
+    PERFORM 1 FROM proveedores WHERE id = p_nuevo_proveedor_id AND sucursal_id = v_sucursal;
+    IF NOT FOUND THEN
+      RETURN jsonb_build_object('success', false, 'error', 'El proveedor nuevo no existe en esta sucursal');
+    END IF;
+  END IF;
+
+  -- Bloquear si la compra tiene notas de credito: referencian la compra vieja y
+  -- ya revirtieron stock; el clon las dejaria huerfanas / doble-contadas.
+  SELECT count(*) INTO v_nc_count FROM notas_credito
+   WHERE compra_id = p_compra_id AND sucursal_id = v_sucursal;
+  IF v_nc_count > 0 THEN
+    RETURN jsonb_build_object('success', false, 'error',
+      'La compra tiene notas de credito asociadas; gestionalas antes de cambiar el proveedor');
+  END IF;
+
+  -- ---- 1) Clonar la cabecera con el proveedor nuevo (todo lo demas identico) ----
+  INSERT INTO compras (
+    proveedor_id, proveedor_nombre, numero_factura, fecha_compra, fecha_recepcion,
+    subtotal, iva, impuestos_internos, percepcion_iva, percepcion_iibb, no_gravado,
+    otros_impuestos, total, forma_pago, notas, usuario_id, estado, tipo_factura, sucursal_id
+  )
+  SELECT
+    p_nuevo_proveedor_id,
+    CASE WHEN p_nuevo_proveedor_id IS NULL THEN p_nuevo_proveedor_nombre ELSE NULL END,
+    c.numero_factura, c.fecha_compra, c.fecha_recepcion,
+    c.subtotal, c.iva, c.impuestos_internos, c.percepcion_iva, c.percepcion_iibb, c.no_gravado,
+    c.otros_impuestos, c.total, c.forma_pago,
+    COALESCE(c.notas, '') || ' (cambio de proveedor desde compra #' || p_compra_id || ')',
+    c.usuario_id, 'recibida', c.tipo_factura, c.sucursal_id
+  FROM compras c
+  WHERE c.id = p_compra_id AND c.sucursal_id = v_sucursal
+  RETURNING id INTO v_nueva_id;
+
+  -- ---- 2) Clonar los items verbatim (incluye snapshots fiscales), SIN mover stock ----
+  INSERT INTO compra_items (
+    compra_id, producto_id, cantidad, costo_unitario, subtotal,
+    stock_anterior, stock_nuevo, bonificacion, sucursal_id,
+    porcentaje_iva, impuestos_internos, costo_neto_unitario, costo_real_unitario
+  )
+  SELECT
+    v_nueva_id, ci.producto_id, ci.cantidad, ci.costo_unitario, ci.subtotal,
+    ci.stock_anterior, ci.stock_nuevo, ci.bonificacion, ci.sucursal_id,
+    ci.porcentaje_iva, ci.impuestos_internos, ci.costo_neto_unitario, ci.costo_real_unitario
+  FROM compra_items ci
+  WHERE ci.compra_id = p_compra_id AND ci.sucursal_id = v_sucursal;
+
+  -- ---- 3) Anular la compra vieja (NO revierte stock: la mercaderia queda) ----
+  UPDATE compras
+     SET estado = 'cancelada',
+         notas  = COALESCE(notas, '') || ' -> reemplazada por compra #' || v_nueva_id || ' (' || p_motivo || ')',
+         updated_at = NOW()
+   WHERE id = p_compra_id AND sucursal_id = v_sucursal;
+
+  RETURN jsonb_build_object(
+    'success', true,
+    'nueva_compra_id', v_nueva_id,
+    'compra_anulada_id', p_compra_id
+  );
+EXCEPTION WHEN OTHERS THEN
+  RETURN jsonb_build_object('success', false, 'error', SQLERRM);
+END;
+$function$;
+
+GRANT EXECUTE ON FUNCTION public.cambiar_proveedor_compra(bigint, uuid, bigint, character varying, text) TO authenticated;
+REVOKE EXECUTE ON FUNCTION public.cambiar_proveedor_compra(bigint, uuid, bigint, character varying, text) FROM anon, public;

--- a/src/components/containers/ComprasContainer.tsx
+++ b/src/components/containers/ComprasContainer.tsx
@@ -11,6 +11,7 @@ import {
   useRegistrarCompraMutation,
   useActualizarCompraMutation,
   useAnularCompraMutation,
+  useCambiarProveedorCompraMutation,
   useProductosQuery,
   useCrearProductoMutation,
   useCrearProveedorMutation,
@@ -20,6 +21,7 @@ import {
   useActualizarProductoMutation,
 } from '../../hooks/queries'
 import type { ActualizarCompraItemsInput } from '../../hooks/queries'
+import type { CambiarProveedorPayload } from '../modals/ModalCambiarProveedor'
 import { useAuthData } from '../../contexts/AuthDataContext'
 import { useNotification } from '../../contexts/NotificationContext'
 import { useResetOnSucursalChange } from '../../hooks/useResetOnSucursalChange'
@@ -66,6 +68,7 @@ export default function ComprasContainer(): React.ReactElement {
   const actualizarProducto = useActualizarProductoMutation()
   const crearProveedor = useCrearProveedorMutation()
   const registrarNC = useRegistrarNotaCreditoMutation()
+  const cambiarProveedorMut = useCambiarProveedorCompraMutation()
 
   // Estado de modales
   const [modalCompraOpen, setModalCompraOpen] = useState(false)
@@ -190,6 +193,28 @@ export default function ComprasContainer(): React.ReactElement {
     }
   }, [actualizarCompra, notify])
 
+  // Cambiar proveedor: anula la compra vieja y crea una nueva idéntica con el
+  // proveedor correcto (RPC atómico, no mueve stock/costos). Ver mig 125.
+  const handleCambiarProveedorCompra = useCallback(async (payload: CambiarProveedorPayload) => {
+    if (!compraParaEditar) return
+    try {
+      const { nuevaCompraId } = await cambiarProveedorMut.mutateAsync({
+        compraId: compraParaEditar.id,
+        nuevoProveedorId: payload.nuevoProveedorId,
+        nuevoProveedorNombre: payload.nuevoProveedorNombre,
+        usuarioId: user?.id ?? null,
+        motivo: payload.motivo,
+      })
+      notify.success(`Proveedor cambiado: se creó la compra #${nuevaCompraId} y se anuló la anterior`, { persist: true })
+      setModalEditarOpen(false)
+      setCompraParaEditar(null)
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : 'Error al cambiar el proveedor'
+      notify.error(msg)
+      throw err
+    }
+  }, [cambiarProveedorMut, compraParaEditar, notify, user])
+
   const handleGuardarNC = useCallback(async (data: NotaCreditoFormInput) => {
     try {
       await registrarNC.mutateAsync(data)
@@ -268,6 +293,10 @@ export default function ComprasContainer(): React.ReactElement {
               setCompraParaEditar(null)
             }}
             guardando={actualizarCompra.isPending}
+            canCambiarProveedor={isAdmin}
+            proveedores={proveedores}
+            onCambiarProveedor={handleCambiarProveedorCompra}
+            onCrearProveedor={handleCrearProveedorDesdeCompra}
           />
         </Suspense>
       )}

--- a/src/components/modals/ModalCambiarProveedor.test.jsx
+++ b/src/components/modals/ModalCambiarProveedor.test.jsx
@@ -1,0 +1,67 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+vi.mock('../../utils/formatters', () => ({
+  formatPrecio: (value) => `$${Number(value).toFixed(2)}`,
+}))
+
+import ModalCambiarProveedor from './ModalCambiarProveedor'
+
+describe('ModalCambiarProveedor', () => {
+  // Compra cargada al proveedor equivocado (id 6). Al cambiarlo, se anula y se
+  // recrea idéntica; el modal solo elige el proveedor nuevo, no toca importes.
+  const compra = {
+    id: 133,
+    proveedor_id: 6,
+    proveedor_nombre: null,
+    proveedor: { id: 6, nombre: 'Proveedor Viejo' },
+    numero_factura: '0001-00025144',
+    fecha_compra: '2026-07-12',
+    tipo_factura: 'FC',
+    total: 3273780.84,
+    items: [
+      { producto_id: 1, cantidad: 2 },
+      { producto_id: 2, cantidad: 3 },
+    ],
+  }
+
+  const proveedores = [
+    { id: 6, nombre: 'Proveedor Viejo' },
+    { id: 20, nombre: 'Proveedor Nuevo' },
+    { id: 21, nombre: 'Otro Proveedor' },
+  ]
+
+  const baseProps = { compra, proveedores, guardando: false }
+
+  it('muestra el proveedor actual y deshabilita confirmar sin proveedor nuevo', () => {
+    render(<ModalCambiarProveedor {...baseProps} onConfirmar={vi.fn()} onClose={vi.fn()} />)
+    expect(screen.getByText('Proveedor Viejo')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /Cambiar proveedor/i })).toBeDisabled()
+  })
+
+  it('deja el proveedor actual como opción deshabilitada (no se puede elegir el mismo)', () => {
+    render(<ModalCambiarProveedor {...baseProps} onConfirmar={vi.fn()} onClose={vi.fn()} />)
+    const opcionActual = screen.getByRole('option', { name: /Proveedor Viejo — actual/i })
+    expect(opcionActual).toBeDisabled()
+  })
+
+  it('al elegir un proveedor nuevo, confirma con el id correcto y sin tocar importes', async () => {
+    const user = userEvent.setup()
+    const onConfirmar = vi.fn()
+    render(<ModalCambiarProveedor {...baseProps} onConfirmar={onConfirmar} onClose={vi.fn()} />)
+
+    await user.selectOptions(screen.getByRole('combobox'), '20')
+
+    const confirmar = screen.getByRole('button', { name: /Cambiar proveedor/i })
+    expect(confirmar).toBeEnabled()
+    await user.click(confirmar)
+
+    expect(onConfirmar).toHaveBeenCalledTimes(1)
+    expect(onConfirmar.mock.calls[0][0]).toEqual({
+      nuevoProveedorId: '20',
+      nuevoProveedorNombre: null,
+      motivo: 'Cambio de proveedor',
+    })
+  })
+})

--- a/src/components/modals/ModalCambiarProveedor.tsx
+++ b/src/components/modals/ModalCambiarProveedor.tsx
@@ -1,0 +1,205 @@
+/**
+ * ModalCambiarProveedor
+ *
+ * Corrige el proveedor de una compra cargada al proveedor equivocado. En vez de
+ * reescribir la fila, dispara el RPC cambiar_proveedor_compra (mig 125) que
+ * ANULA la compra vieja y crea una NUEVA idéntica (mismos items, importes,
+ * fecha, factura, tipo, forma de pago) con el proveedor nuevo. El stock y los
+ * costos NO se modifican.
+ *
+ * Análogo a ModalCambiarCliente (pedidos) pero mucho más simple: en compras los
+ * costos vienen de la factura, no de un motor de precios, así que no hay
+ * recálculo de promos/mayorista/descuento.
+ */
+import { useState, memo, lazy, Suspense } from 'react'
+import { Loader2, Building2, Plus, AlertTriangle, ArrowRight } from 'lucide-react'
+import ModalBase from './ModalBase'
+import { formatPrecio } from '../../utils/formatters'
+import type {
+  CompraDBExtended,
+  ProveedorDBExtended,
+  ProveedorFormInputExtended,
+  CompraItemDBExtended,
+} from '../../types'
+
+const ModalProveedor = lazy(() => import('./ModalProveedor'))
+
+export type CambiarProveedorPayload = {
+  nuevoProveedorId: string | null
+  nuevoProveedorNombre: string | null
+  motivo?: string
+}
+
+export interface ModalCambiarProveedorProps {
+  compra: CompraDBExtended
+  proveedores: ProveedorDBExtended[]
+  onConfirmar: (payload: CambiarProveedorPayload) => Promise<void>
+  onClose: () => void
+  guardando: boolean
+  onCrearProveedor?: (data: ProveedorFormInputExtended) => Promise<ProveedorDBExtended>
+}
+
+const ModalCambiarProveedor = memo(function ModalCambiarProveedor({
+  compra,
+  proveedores,
+  onConfirmar,
+  onClose,
+  guardando,
+  onCrearProveedor,
+}: ModalCambiarProveedorProps) {
+  const [nuevoProveedorId, setNuevoProveedorId] = useState<string>('')
+  const [modalProveedorOpen, setModalProveedorOpen] = useState(false)
+
+  const proveedorActualId = compra.proveedor_id != null ? String(compra.proveedor_id) : ''
+  const proveedorActualNombre = compra.proveedor?.nombre ?? compra.proveedor_nombre ?? 'Sin proveedor'
+  const proveedorNuevo = proveedores.find((p) => String(p.id) === nuevoProveedorId)
+
+  const totalItems = (compra.items ?? []).reduce((s: number, i: CompraItemDBExtended) => s + (i.cantidad ?? 0), 0)
+  const nItems = (compra.items ?? []).length
+
+  // El nuevo no puede ser el mismo que el actual.
+  const mismoProveedor = nuevoProveedorId !== '' && nuevoProveedorId === proveedorActualId
+  const puedeConfirmar = nuevoProveedorId !== '' && !mismoProveedor && !guardando
+
+  async function handleConfirmar() {
+    if (!puedeConfirmar) return
+    await onConfirmar({
+      nuevoProveedorId: nuevoProveedorId || null,
+      nuevoProveedorNombre: null,
+      motivo: 'Cambio de proveedor',
+    })
+  }
+
+  return (
+    <ModalBase title={`Cambiar proveedor · Compra #${compra.id}`} onClose={onClose} maxWidth="max-w-lg">
+      <div className="p-4 space-y-4">
+        {/* Proveedor actual -> nuevo */}
+        <div className="flex items-center gap-3">
+          <div className="flex-1 min-w-0">
+            <p className="text-xs text-gray-500 dark:text-gray-400">Proveedor actual</p>
+            <p className="font-medium dark:text-gray-200 truncate">{proveedorActualNombre}</p>
+          </div>
+          <ArrowRight className="w-5 h-5 text-gray-400 shrink-0" />
+          <div className="flex-1 min-w-0">
+            <p className="text-xs text-gray-500 dark:text-gray-400">Proveedor nuevo</p>
+            <p className="font-medium text-green-700 dark:text-green-400 truncate">{proveedorNuevo?.nombre ?? '—'}</p>
+          </div>
+        </div>
+
+        {/* Selector de proveedor */}
+        <div>
+          <label className="text-sm font-medium text-gray-700 dark:text-gray-300 mb-1 flex items-center gap-2">
+            <Building2 className="w-4 h-4 text-gray-500" /> Elegí el proveedor correcto
+          </label>
+          <div className="flex items-center gap-2">
+            <select
+              value={nuevoProveedorId}
+              onChange={(e) => setNuevoProveedorId(e.target.value)}
+              className="flex-1 px-3 py-2 border dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-green-500 dark:bg-gray-700 dark:text-white text-sm"
+            >
+              <option value="">Seleccionar proveedor...</option>
+              {proveedores.map((p) => (
+                <option key={p.id} value={p.id} disabled={String(p.id) === proveedorActualId}>
+                  {p.nombre} {p.cuit ? `(${p.cuit})` : ''}
+                  {String(p.id) === proveedorActualId ? ' — actual' : ''}
+                </option>
+              ))}
+            </select>
+            {onCrearProveedor && (
+              <button
+                type="button"
+                onClick={() => setModalProveedorOpen(true)}
+                className="flex items-center gap-1 px-3 py-2 bg-green-600 text-white rounded-lg hover:bg-green-700 transition-colors whitespace-nowrap text-sm"
+                title="Crear proveedor nuevo"
+              >
+                <Plus className="w-4 h-4" />
+                <span className="hidden sm:inline">Nuevo</span>
+              </button>
+            )}
+          </div>
+          {mismoProveedor && (
+            <p className="text-xs text-amber-600 dark:text-amber-400 mt-1">Es el mismo proveedor actual.</p>
+          )}
+        </div>
+
+        {/* Resumen read-only de la compra (no cambia) */}
+        <div className="bg-gray-50 dark:bg-gray-900 rounded-lg p-3 text-sm">
+          <p className="text-xs text-gray-500 dark:text-gray-400 mb-2">Estos datos NO cambian:</p>
+          <div className="grid grid-cols-2 gap-x-4 gap-y-1">
+            <span className="text-gray-500 dark:text-gray-400">Factura</span>
+            <span className="text-right dark:text-gray-200">
+              {compra.numero_factura ?? '—'} ({compra.tipo_factura ?? 'FC'})
+            </span>
+            <span className="text-gray-500 dark:text-gray-400">Fecha</span>
+            <span className="text-right dark:text-gray-200">{compra.fecha_compra ?? '—'}</span>
+            <span className="text-gray-500 dark:text-gray-400">Items</span>
+            <span className="text-right dark:text-gray-200">
+              {nItems} ({totalItems} u.)
+            </span>
+            <span className="text-gray-500 dark:text-gray-400">Total</span>
+            <span className="text-right font-semibold text-green-600 dark:text-green-400">
+              {formatPrecio(compra.total)}
+            </span>
+          </div>
+        </div>
+
+        {/* Advertencia */}
+        <div className="bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800 rounded-lg p-3 text-xs text-amber-800 dark:text-amber-300 flex items-start gap-2">
+          <AlertTriangle className="w-4 h-4 mt-0.5 shrink-0" />
+          <span>
+            Se anulará la compra #{compra.id} y se creará una nueva idéntica con el proveedor nuevo. El stock y los
+            costos no se modifican.
+          </span>
+        </div>
+
+        {/* Acciones */}
+        <div className="flex justify-end gap-2 pt-2 border-t dark:border-gray-700">
+          <button
+            type="button"
+            onClick={onClose}
+            disabled={guardando}
+            className="px-4 py-2 text-sm rounded-lg border dark:border-gray-600 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-700 disabled:opacity-50"
+          >
+            Cancelar
+          </button>
+          <button
+            type="button"
+            onClick={handleConfirmar}
+            disabled={!puedeConfirmar}
+            className="px-4 py-2 text-sm rounded-lg bg-green-600 text-white hover:bg-green-700 disabled:bg-green-400 disabled:cursor-not-allowed inline-flex items-center gap-2"
+          >
+            {guardando ? <Loader2 className="w-4 h-4 animate-spin" /> : null}
+            Cambiar proveedor
+          </button>
+        </div>
+      </div>
+
+      {/* Modal Proveedor anidado (crear uno nuevo y auto-seleccionarlo) */}
+      {modalProveedorOpen && onCrearProveedor && (
+        <Suspense fallback={null}>
+          <ModalProveedor
+            onSave={async (data) => {
+              const nuevoProveedor = await onCrearProveedor({
+                nombre: data.nombre,
+                cuit: data.cuit || null,
+                direccion: data.direccion || null,
+                latitud: data.latitud || null,
+                longitud: data.longitud || null,
+                telefono: data.telefono || null,
+                email: data.email || null,
+                contacto: data.contacto || null,
+                notas: data.notas || null,
+                activo: true,
+              })
+              setNuevoProveedorId(String(nuevoProveedor.id))
+              setModalProveedorOpen(false)
+            }}
+            onClose={() => setModalProveedorOpen(false)}
+          />
+        </Suspense>
+      )}
+    </ModalBase>
+  )
+})
+
+export default ModalCambiarProveedor

--- a/src/components/modals/ModalEditarCompra.cambiarProveedor.test.jsx
+++ b/src/components/modals/ModalEditarCompra.cambiarProveedor.test.jsx
@@ -1,0 +1,62 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+vi.mock('../../utils/formatters', () => ({
+  formatPrecio: (value) => `$${Number(value).toFixed(2)}`,
+}))
+
+import ModalEditarCompra from './ModalEditarCompra'
+
+describe('ModalEditarCompra · botón "Cambiar proveedor"', () => {
+  const compra = {
+    id: 133,
+    estado: 'recibida',
+    tipo_factura: 'FC',
+    proveedor_id: 6,
+    proveedor: { id: 6, nombre: 'Proveedor Viejo' },
+    numero_factura: '0001-1',
+    fecha_compra: '2026-07-12',
+    total: 1000,
+    otros_impuestos: 0,
+    percepcion_iva: 0,
+    percepcion_iibb: 0,
+    no_gravado: 0,
+    items: [
+      {
+        producto_id: 1,
+        cantidad: 2,
+        costo_unitario: 100,
+        bonificacion: 0,
+        porcentaje_iva: 21,
+        impuestos_internos: 0,
+        producto: { nombre: 'Prod 1' },
+      },
+    ],
+  }
+  const proveedores = [
+    { id: 6, nombre: 'Proveedor Viejo' },
+    { id: 20, nombre: 'Proveedor Nuevo' },
+  ]
+  const baseProps = { compra, usuarioId: 'u1', onGuardar: vi.fn(), onClose: vi.fn(), guardando: false }
+  const adminProps = { ...baseProps, canCambiarProveedor: true, onCambiarProveedor: vi.fn(), proveedores }
+
+  it('no muestra el botón si no es admin', () => {
+    render(<ModalEditarCompra {...baseProps} />)
+    expect(screen.queryByRole('button', { name: /Cambiar proveedor/i })).not.toBeInTheDocument()
+  })
+
+  it('muestra el botón habilitado para admin sin cambios de items', () => {
+    render(<ModalEditarCompra {...adminProps} />)
+    expect(screen.getByRole('button', { name: /Cambiar proveedor/i })).toBeEnabled()
+  })
+
+  it('deshabilita el botón si hay cambios de items sin guardar', async () => {
+    const user = userEvent.setup()
+    render(<ModalEditarCompra {...adminProps} />)
+    expect(screen.getByRole('button', { name: /Cambiar proveedor/i })).toBeEnabled()
+    // marcar el item para eliminar => hay cambios sin guardar
+    await user.click(screen.getByTitle('Eliminar item'))
+    expect(screen.getByRole('button', { name: /Cambiar proveedor/i })).toBeDisabled()
+  })
+})

--- a/src/components/modals/ModalEditarCompra.tsx
+++ b/src/components/modals/ModalEditarCompra.tsx
@@ -16,13 +16,16 @@
  * reciente del producto.
  */
 
-import { useState, memo, useMemo } from 'react'
-import { Loader2, Trash2, AlertCircle } from 'lucide-react'
+import { useState, memo, useMemo, lazy, Suspense } from 'react'
+import { Loader2, Trash2, AlertCircle, Building2 } from 'lucide-react'
 import ModalBase from './ModalBase'
 import NumberInput from '../ui/NumberInput'
 import { formatPrecio } from '../../utils/formatters'
-import type { CompraDBExtended } from '../../types'
+import type { CompraDBExtended, ProveedorDBExtended, ProveedorFormInputExtended } from '../../types'
 import type { ActualizarCompraItemsInput } from '../../hooks/queries'
+import type { CambiarProveedorPayload } from './ModalCambiarProveedor'
+
+const ModalCambiarProveedor = lazy(() => import('./ModalCambiarProveedor'))
 
 /** Item editable dentro del modal. */
 interface ItemEdit {
@@ -42,6 +45,11 @@ export interface ModalEditarCompraProps {
   onGuardar: (input: ActualizarCompraItemsInput) => Promise<void>
   onClose: () => void
   guardando: boolean
+  /** Cambiar proveedor (admin): anula + recrea la compra con otro proveedor. */
+  canCambiarProveedor?: boolean
+  proveedores?: ProveedorDBExtended[]
+  onCambiarProveedor?: (payload: CambiarProveedorPayload) => Promise<void>
+  onCrearProveedor?: (data: ProveedorFormInputExtended) => Promise<ProveedorDBExtended>
 }
 
 const ModalEditarCompra = memo(function ModalEditarCompra({
@@ -50,6 +58,10 @@ const ModalEditarCompra = memo(function ModalEditarCompra({
   onGuardar,
   onClose,
   guardando,
+  canCambiarProveedor = false,
+  proveedores,
+  onCambiarProveedor,
+  onCrearProveedor,
 }: ModalEditarCompraProps) {
   const esZZ = compra.tipo_factura === 'ZZ'
   const otrosImpuestos = compra.otros_impuestos ?? 0
@@ -76,6 +88,59 @@ const ModalEditarCompra = memo(function ModalEditarCompra({
 
   // Items que efectivamente se persisten (los no eliminados).
   const itemsActivos = useMemo(() => items.filter((i) => !i.marcadoParaEliminar), [items])
+
+  // --- Cambiar proveedor (admin): anula + recrea la compra con otro proveedor ---
+  const [mostrarCambioProveedor, setMostrarCambioProveedor] = useState(false)
+  const [cambiandoProveedor, setCambiandoProveedor] = useState(false)
+
+  // Snapshot inicial de items para detectar ediciones sin guardar: el cambio de
+  // proveedor clona los items DE LA BD, no los del modal, así que si hay cambios
+  // sin guardar se bloquea para no recrear con datos inconsistentes.
+  const itemsIniciales = useMemo(
+    () =>
+      (compra.items ?? []).map((it) => ({
+        productoId: it.producto_id,
+        cantidad: it.cantidad ?? 0,
+        costoUnitario: it.costo_unitario ?? 0,
+        bonificacion: it.bonificacion ?? 0,
+        porcentajeIva: esZZ ? 0 : (it.porcentaje_iva ?? it.producto?.porcentaje_iva ?? 21),
+        impuestosInternos: esZZ ? 0 : (it.impuestos_internos ?? it.producto?.impuestos_internos ?? 0),
+      })),
+    [compra.items, esZZ],
+  )
+
+  const itemsModificados = useMemo(() => {
+    if (items.some((i) => i.marcadoParaEliminar)) return true
+    if (items.length !== itemsIniciales.length) return true
+    return items.some((it) => {
+      const orig = itemsIniciales.find((o) => o.productoId === it.productoId)
+      if (!orig) return true
+      return (
+        orig.cantidad !== it.cantidad ||
+        orig.costoUnitario !== it.costoUnitario ||
+        orig.bonificacion !== it.bonificacion ||
+        orig.porcentajeIva !== it.porcentajeIva ||
+        orig.impuestosInternos !== it.impuestosInternos
+      )
+    })
+  }, [items, itemsIniciales])
+
+  const puedeCambiarProveedor = Boolean(
+    canCambiarProveedor && onCambiarProveedor && compra.estado !== 'cancelada',
+  )
+
+  async function handleConfirmarCambioProveedor(payload: CambiarProveedorPayload) {
+    if (!onCambiarProveedor) return
+    setCambiandoProveedor(true)
+    try {
+      await onCambiarProveedor(payload)
+      setMostrarCambioProveedor(false) // el container cierra el modal de edición al tener éxito
+    } catch {
+      // dejar abierto para reintentar; el container ya notificó el error
+    } finally {
+      setCambiandoProveedor(false)
+    }
+  }
 
   // Totales calculados (incluye imp. internos por línea; percepciones y no
   // gravado de la cabecera se conservan tal cual).
@@ -194,11 +259,35 @@ const ModalEditarCompra = memo(function ModalEditarCompra({
         <div className="bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800 rounded-lg p-3 text-xs text-amber-800 dark:text-amber-300 flex items-start gap-2">
           <AlertCircle className="w-4 h-4 mt-0.5 shrink-0" />
           <span>
-            Solo se editan items. La cabecera (proveedor, fecha, factura, tipo) queda inmutable.
-            Si necesitás cambiar la cabecera, anulá la compra y volvé a cargarla. No se pueden
-            agregar items nuevos: anulá y rehacé si falta cargar uno.
+            Solo se editan items. La cabecera (fecha, factura, tipo) queda inmutable. Para corregir
+            el <strong>proveedor</strong> usá el botón de abajo; para el resto, anulá la compra y
+            volvé a cargarla. No se pueden agregar items nuevos: anulá y rehacé si falta cargar uno.
           </span>
         </div>
+
+        {puedeCambiarProveedor && (
+          <div className="flex flex-wrap items-center gap-2">
+            <button
+              type="button"
+              onClick={() => setMostrarCambioProveedor(true)}
+              disabled={itemsModificados || cambiandoProveedor}
+              title={
+                itemsModificados
+                  ? 'Guardá o descartá los cambios de items primero'
+                  : 'Anular y recrear la compra con otro proveedor'
+              }
+              className="inline-flex items-center gap-2 px-3 py-2 text-sm rounded-lg border border-amber-300 dark:border-amber-700 text-amber-800 dark:text-amber-300 hover:bg-amber-50 dark:hover:bg-amber-900/30 disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              <Building2 className="w-4 h-4" />
+              Cambiar proveedor
+            </button>
+            {itemsModificados && (
+              <span className="text-xs text-gray-500 dark:text-gray-400">
+                Guardá los cambios de items primero.
+              </span>
+            )}
+          </div>
+        )}
 
         {/* Tabla de items */}
         <div className="overflow-x-auto">
@@ -361,6 +450,20 @@ const ModalEditarCompra = memo(function ModalEditarCompra({
           </button>
         </div>
       </div>
+
+      {/* Cambiar proveedor (anidado): anula + recrea la compra con otro proveedor */}
+      {mostrarCambioProveedor && puedeCambiarProveedor && (
+        <Suspense fallback={null}>
+          <ModalCambiarProveedor
+            compra={compra}
+            proveedores={proveedores ?? []}
+            onConfirmar={handleConfirmarCambioProveedor}
+            onClose={() => setMostrarCambioProveedor(false)}
+            guardando={cambiandoProveedor}
+            onCrearProveedor={onCrearProveedor}
+          />
+        </Suspense>
+      )}
     </ModalBase>
   )
 })

--- a/src/hooks/queries/index.ts
+++ b/src/hooks/queries/index.ts
@@ -93,8 +93,9 @@ export {
   useRegistrarCompraMutation,
   useActualizarCompraMutation,
   useAnularCompraMutation,
+  useCambiarProveedorCompraMutation,
 } from './useComprasQuery'
-export type { ActualizarCompraItemsInput } from './useComprasQuery'
+export type { ActualizarCompraItemsInput, CambiarProveedorCompraInput } from './useComprasQuery'
 
 // Proveedores
 export {

--- a/src/hooks/queries/useComprasQuery.ts
+++ b/src/hooks/queries/useComprasQuery.ts
@@ -323,3 +323,54 @@ export function useAnularCompraMutation() {
     },
   })
 }
+
+/**
+ * Input para cambiar el proveedor de una compra (admin only).
+ * En vez de reescribir la fila, el RPC anula la compra vieja y crea una nueva
+ * idéntica (mismos items, importes, fecha, factura) con el proveedor nuevo, sin
+ * tocar stock ni costos. Analogo a cambiar_cliente_pedido. Ver mig 125.
+ */
+export interface CambiarProveedorCompraInput {
+  compraId: string
+  /** id del proveedor existente elegido; null si se usa un nombre nuevo. */
+  nuevoProveedorId: string | null
+  /** nombre denormalizado si no hay id (fallback). */
+  nuevoProveedorNombre: string | null
+  usuarioId: string | null
+  motivo?: string
+}
+
+async function cambiarProveedorCompra(input: CambiarProveedorCompraInput): Promise<{ nuevaCompraId: string }> {
+  const { data, error } = await supabase.rpc('cambiar_proveedor_compra', {
+    p_compra_id: input.compraId,
+    p_usuario_id: input.usuarioId,
+    // ids son bigint: mandar numero, no string (ver cambio "Invalid input")
+    p_nuevo_proveedor_id: input.nuevoProveedorId ? Number(input.nuevoProveedorId) : null,
+    p_nuevo_proveedor_nombre: input.nuevoProveedorNombre || null,
+    ...(input.motivo ? { p_motivo: input.motivo } : {}),
+  })
+
+  if (error) throw error
+  const result = data as { success: boolean; nueva_compra_id?: string | number; error?: string }
+  if (!result.success) {
+    throw new Error(result.error || 'Error al cambiar el proveedor')
+  }
+  return { nuevaCompraId: String(result.nueva_compra_id) }
+}
+
+/**
+ * Hook para cambiar el proveedor de una compra: anula la vieja y crea una nueva
+ * idéntica con el proveedor correcto, vía RPC atómico. No mueve stock/costos.
+ */
+export function useCambiarProveedorCompraMutation() {
+  const queryClient = useQueryClient()
+  const { currentSucursalId } = useSucursal()
+
+  return useMutation({
+    mutationFn: cambiarProveedorCompra,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: comprasKeys.lists(currentSucursalId) })
+      queryClient.invalidateQueries({ queryKey: ['productos'] })
+    },
+  })
+}


### PR DESCRIPTION
## Qué

Feature hermana de **"Cambiar cliente de pedido"** (mig 094) pero para compras. Cuando se carga una compra con el proveedor equivocado, en vez de reescribir la fila se **anula la compra vieja y se crea una nueva idéntica** (mismos items, importes, fecha, factura, tipo, forma de pago) cambiando **solo el proveedor**. Preserva trazabilidad/auditoría en lugar de pisar el proveedor de una factura ya registrada.

- Botón **"Cambiar proveedor"** dentro de **Editar compra** (solo admin, hereda la ventana de 7 días del modal).
- Modal `ModalCambiarProveedor`: elegís un proveedor existente o **creás uno nuevo** al toque.
- Se deshabilita si hay ediciones de items sin guardar (el clon usa los items de la BD).

## Diferencia clave con pedidos (stock)

En pedidos, cancelar **restaura** stock (nunca falla). En compras, `anular_compra_atomica` **resta** stock y **rechaza si quedaría negativo** — lo que pasa apenas vendiste parte de lo comprado. Por eso el RPC **NO encadena** anular + registrar: **clona** la fila con el proveedor nuevo y marca la vieja como `cancelada` **sin tocar stock ni costos**. La mercadería llegó y queda; solo reasignamos la contraparte de la factura → el neto de stock es cero por construcción, sin riesgo de guardas ni churn de `stock_historico`.

Guardas del RPC: solo admin; rechaza si la compra ya está cancelada, si es el mismo proveedor, si el proveedor no existe en la sucursal, o si la compra tiene **notas de crédito**.

## Cambios

- **`migrations/125_cambiar_proveedor_compra.sql`** (nuevo) — RPC atómico. **Ya aplicada a prod** vía MCP (aditiva y reversible).
- `useComprasQuery.ts` + `queries/index.ts` — hook `useCambiarProveedorCompraMutation`.
- `ModalCambiarProveedor.tsx` (nuevo) + `ModalEditarCompra.tsx` (botón/guarda/modal anidado) + `ComprasContainer.tsx` (wiring).
- Tests: `ModalCambiarProveedor.test.jsx`, `ModalEditarCompra.cambiarProveedor.test.jsx`.

## Verificación

- **RPC probado contra datos reales de prod** (transacción con `RAISE`-rollback, cero persistencia): compra vieja→`cancelada`, nueva idéntica + proveedor nuevo, **stock y costos intactos**, snapshots fiscales clonados, `usuario_id` original conservado. Las 6 guardas (mismo proveedor / inexistente / sin proveedor / ya cancelada / con NC / no-admin) devuelven el error correcto.
- **786 tests pasan** (6 nuevos, sin regresiones); `tsc --noEmit` limpio en los archivos tocados.

🤖 Generated with [Claude Code](https://claude.com/claude-code)