### PR TITLE
fix(compras): cambio de proveedor en un solo modal + proveedor obligatorio

### DIFF
--- a/migrations/126_compra_proveedor_obligatorio.sql
+++ b/migrations/126_compra_proveedor_obligatorio.sql
@@ -1,0 +1,199 @@
+-- ============================================================================
+-- 126 · Proveedor obligatorio al registrar una compra
+-- ============================================================================
+-- Hasta ahora se podía cargar una compra sin proveedor (proveedor_id NULL y
+-- proveedor_nombre NULL) → filas "Sin proveedor". No debería poder hacerse.
+-- Se agrega una guarda a registrar_compra_completa que rechaza si no viene ni
+-- id ni nombre de proveedor. El resto de la función es idéntico a la mig 114
+-- (misma firma de 17 args). El front (ModalCompra) también valida antes de
+-- enviar. Las compras viejas sin proveedor quedan como están (esto solo afecta
+-- altas nuevas).
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION public.registrar_compra_completa(
+  p_proveedor_id bigint, p_proveedor_nombre character varying,
+  p_numero_factura character varying, p_fecha_compra date,
+  p_subtotal numeric, p_iva numeric, p_otros_impuestos numeric, p_total numeric,
+  p_forma_pago character varying, p_notas text, p_usuario_id uuid,
+  p_items jsonb, p_tipo_factura character varying DEFAULT 'FC',
+  p_impuestos_internos numeric DEFAULT 0,
+  p_percepcion_iva numeric DEFAULT 0,
+  p_percepcion_iibb numeric DEFAULT 0,
+  p_no_gravado numeric DEFAULT 0
+) RETURNS jsonb
+LANGUAGE plpgsql SECURITY DEFINER
+SET search_path TO 'public'
+AS $function$
+DECLARE
+  v_sucursal            BIGINT := current_sucursal_id();
+  v_compra_id           BIGINT;
+  v_item                JSONB;
+  v_producto            RECORD;
+  v_stock_anterior      INTEGER;
+  v_stock_nuevo         INTEGER;
+  v_cantidad            INTEGER;
+  v_bonificacion        NUMERIC;
+  v_porcentaje_iva      NUMERIC;
+  v_impuestos_internos  NUMERIC;
+  v_costo_unitario      NUMERIC;
+  v_costo_neto          NUMERIC;
+  v_costo_con_iva       NUMERIC;
+  v_costo_real          NUMERIC;
+  v_actualiza_costo     BOOLEAN;
+  v_tipo_factura        TEXT;
+  v_es_zz               BOOLEAN;
+  v_iva_hdr             NUMERIC;
+  v_ii_hdr              NUMERIC;
+  v_perc_iva_hdr        NUMERIC;
+  v_perc_iibb_hdr       NUMERIC;
+  v_no_gravado_hdr      NUMERIC;
+  v_total_calc          NUMERIC;
+  v_warning             TEXT := NULL;
+  v_items_procesados    JSONB := '[]'::JSONB;
+  v_user_role           TEXT;
+BEGIN
+  IF v_sucursal IS NULL THEN
+    RETURN jsonb_build_object('success', false, 'error', 'No se pudo determinar la sucursal activa');
+  END IF;
+
+  IF p_usuario_id IS DISTINCT FROM auth.uid() THEN
+    RETURN jsonb_build_object('success', false, 'error', 'ID de usuario no coincide con la sesion autenticada');
+  END IF;
+
+  SELECT rol INTO v_user_role FROM perfiles WHERE id = p_usuario_id;
+  IF v_user_role IS NULL OR v_user_role NOT IN ('admin', 'encargado') THEN
+    RETURN jsonb_build_object('success', false, 'error', 'No autorizado: solo admin o encargado pueden registrar compras');
+  END IF;
+
+  -- Proveedor obligatorio: id existente o nombre denormalizado.
+  IF p_proveedor_id IS NULL AND COALESCE(TRIM(p_proveedor_nombre), '') = '' THEN
+    RETURN jsonb_build_object('success', false, 'error', 'Debe indicar un proveedor para la compra');
+  END IF;
+
+  v_tipo_factura   := COALESCE(p_tipo_factura, 'FC');
+  v_es_zz          := (v_tipo_factura = 'ZZ');
+  v_iva_hdr        := CASE WHEN v_es_zz THEN 0 ELSE COALESCE(p_iva, 0) END;
+  v_ii_hdr         := CASE WHEN v_es_zz THEN 0 ELSE COALESCE(p_impuestos_internos, 0) END;
+  v_perc_iva_hdr   := CASE WHEN v_es_zz THEN 0 ELSE COALESCE(p_percepcion_iva, 0) END;
+  v_perc_iibb_hdr  := CASE WHEN v_es_zz THEN 0 ELSE COALESCE(p_percepcion_iibb, 0) END;
+  v_no_gravado_hdr := CASE WHEN v_es_zz THEN 0 ELSE COALESCE(p_no_gravado, 0) END;
+
+  INSERT INTO compras (
+    proveedor_id, proveedor_nombre, numero_factura, fecha_compra,
+    subtotal, iva, impuestos_internos, percepcion_iva, percepcion_iibb,
+    no_gravado, otros_impuestos, total, forma_pago, notas,
+    usuario_id, estado, tipo_factura, sucursal_id
+  ) VALUES (
+    p_proveedor_id, p_proveedor_nombre, p_numero_factura, p_fecha_compra,
+    p_subtotal, v_iva_hdr, v_ii_hdr, v_perc_iva_hdr, v_perc_iibb_hdr,
+    v_no_gravado_hdr, COALESCE(p_otros_impuestos, 0), p_total, p_forma_pago, p_notas,
+    p_usuario_id, 'recibida', v_tipo_factura, v_sucursal
+  )
+  RETURNING id INTO v_compra_id;
+
+  FOR v_item IN SELECT * FROM jsonb_array_elements(p_items) LOOP
+    SELECT id, stock INTO v_producto
+      FROM productos
+     WHERE id = (v_item->>'producto_id')::BIGINT
+       AND sucursal_id = v_sucursal
+     FOR UPDATE;
+
+    IF NOT FOUND THEN
+      RAISE EXCEPTION 'Producto no encontrado: %', v_item->>'producto_id';
+    END IF;
+
+    v_cantidad           := (v_item->>'cantidad')::INTEGER;
+    v_stock_anterior     := COALESCE(v_producto.stock, 0);
+    v_stock_nuevo        := v_stock_anterior + v_cantidad;
+    v_costo_unitario     := COALESCE((v_item->>'costo_unitario')::NUMERIC, 0);
+    v_bonificacion       := COALESCE((v_item->>'bonificacion')::NUMERIC, 0);
+    v_porcentaje_iva     := CASE WHEN v_es_zz THEN 0 ELSE COALESCE((v_item->>'porcentaje_iva')::NUMERIC, 21) END;
+    v_impuestos_internos := CASE WHEN v_es_zz THEN 0 ELSE COALESCE((v_item->>'impuestos_internos')::NUMERIC, 0) END;
+
+    v_costo_neto    := v_costo_unitario * (1 - v_bonificacion / 100);
+    v_costo_con_iva := costo_financiero_unitario(v_costo_neto, v_porcentaje_iva, v_impuestos_internos, v_tipo_factura);
+    v_costo_real    := costo_real_unitario(v_costo_neto, v_impuestos_internos, v_tipo_factura);
+
+    INSERT INTO compra_items (
+      compra_id, producto_id, cantidad, costo_unitario, subtotal,
+      stock_anterior, stock_nuevo, bonificacion, sucursal_id,
+      porcentaje_iva, impuestos_internos, costo_neto_unitario, costo_real_unitario
+    ) VALUES (
+      v_compra_id,
+      (v_item->>'producto_id')::BIGINT,
+      v_cantidad,
+      v_costo_unitario,
+      COALESCE((v_item->>'subtotal')::NUMERIC, 0),
+      v_stock_anterior,
+      v_stock_nuevo,
+      v_bonificacion,
+      v_sucursal,
+      v_porcentaje_iva,
+      v_impuestos_internos,
+      round(v_costo_neto, 4),
+      v_costo_real
+    );
+
+    v_actualiza_costo := (v_bonificacion < 100 AND v_costo_neto > 0);
+
+    IF v_actualiza_costo THEN
+      UPDATE productos
+         SET stock              = stock + v_cantidad,
+             costo_sin_iva      = v_costo_neto,
+             costo_con_iva      = v_costo_con_iva,
+             costo_real         = v_costo_real,
+             ultimo_tipo_compra = v_tipo_factura,
+             updated_at         = NOW()
+       WHERE id = (v_item->>'producto_id')::BIGINT
+         AND sucursal_id = v_sucursal;
+    ELSE
+      UPDATE productos
+         SET stock      = stock + v_cantidad,
+             updated_at = NOW()
+       WHERE id = (v_item->>'producto_id')::BIGINT
+         AND sucursal_id = v_sucursal;
+    END IF;
+
+    v_items_procesados := v_items_procesados || jsonb_build_object(
+      'producto_id',       (v_item->>'producto_id')::BIGINT,
+      'cantidad',          v_cantidad,
+      'stock_anterior',    v_stock_anterior,
+      'stock_nuevo',       v_stock_nuevo,
+      'costo_sin_iva',     v_costo_neto,
+      'costo_con_iva',     v_costo_con_iva,
+      'costo_real',        v_costo_real,
+      'costo_actualizado', v_actualiza_costo
+    );
+  END LOOP;
+
+  v_total_calc := CASE
+    WHEN v_es_zz THEN COALESCE(p_subtotal, 0)
+    ELSE COALESCE(p_subtotal, 0) + v_iva_hdr + v_ii_hdr + v_perc_iva_hdr
+         + v_perc_iibb_hdr + v_no_gravado_hdr + COALESCE(p_otros_impuestos, 0)
+  END;
+  IF abs(v_total_calc - COALESCE(p_total, 0)) > 1 THEN
+    v_warning := format('Descuadre: total calculado %s vs total informado %s',
+                        round(v_total_calc, 2), round(COALESCE(p_total, 0), 2));
+  END IF;
+
+  RETURN jsonb_build_object(
+    'success',           true,
+    'compra_id',         v_compra_id,
+    'items_procesados',  v_items_procesados,
+    'warning_descuadre', v_warning
+  );
+EXCEPTION WHEN OTHERS THEN
+  RETURN jsonb_build_object('success', false, 'error', SQLERRM);
+END;
+$function$;
+
+GRANT EXECUTE ON FUNCTION public.registrar_compra_completa(
+  bigint, character varying, character varying, date, numeric, numeric, numeric,
+  numeric, character varying, text, uuid, jsonb, character varying,
+  numeric, numeric, numeric, numeric
+) TO authenticated, service_role;
+REVOKE EXECUTE ON FUNCTION public.registrar_compra_completa(
+  bigint, character varying, character varying, date, numeric, numeric, numeric,
+  numeric, character varying, text, uuid, jsonb, character varying,
+  numeric, numeric, numeric, numeric
+) FROM anon, public;

--- a/src/components/containers/ComprasContainer.tsx
+++ b/src/components/containers/ComprasContainer.tsx
@@ -33,6 +33,7 @@ const ModalCompra = lazy(() => import('../modals/ModalCompra'))
 const ModalDetalleCompra = lazy(() => import('../modals/ModalDetalleCompra'))
 const ModalNotaCredito = lazy(() => import('../modals/ModalNotaCredito'))
 const ModalEditarCompra = lazy(() => import('../modals/ModalEditarCompra'))
+const ModalCambiarProveedor = lazy(() => import('../modals/ModalCambiarProveedor'))
 const ModalConfirmacion = lazy(() => import('../modals/ModalConfirmacion'))
 
 function LoadingState() {
@@ -75,11 +76,13 @@ export default function ComprasContainer(): React.ReactElement {
   const [modalDetalleOpen, setModalDetalleOpen] = useState(false)
   const [modalNotaCreditoOpen, setModalNotaCreditoOpen] = useState(false)
   const [modalEditarOpen, setModalEditarOpen] = useState(false)
+  const [modalCambiarProveedorOpen, setModalCambiarProveedorOpen] = useState(false)
 
   // Estado de detalle
   const [compraDetalle, setCompraDetalle] = useState<CompraDBExtended | null>(null)
   const [compraParaNC, setCompraParaNC] = useState<CompraDBExtended | null>(null)
   const [compraParaEditar, setCompraParaEditar] = useState<CompraDBExtended | null>(null)
+  const [compraParaCambiarProveedor, setCompraParaCambiarProveedor] = useState<CompraDBExtended | null>(null)
   const [confirmConfig, setConfirmConfig] = useState<ConfirmConfig>({ visible: false })
 
   // Cerrar modales al cambiar de sucursal: las compras son por sucursal.
@@ -88,9 +91,11 @@ export default function ComprasContainer(): React.ReactElement {
     setModalDetalleOpen(false)
     setModalNotaCreditoOpen(false)
     setModalEditarOpen(false)
+    setModalCambiarProveedorOpen(false)
     setCompraDetalle(null)
     setCompraParaNC(null)
     setCompraParaEditar(null)
+    setCompraParaCambiarProveedor(null)
     setConfirmConfig({ visible: false })
   })
 
@@ -193,27 +198,37 @@ export default function ComprasContainer(): React.ReactElement {
     }
   }, [actualizarCompra, notify])
 
+  // Abrir el cambio de proveedor desde "Editar compra": cierra el modal de
+  // edición y abre el de cambio (un solo modal a la vez).
+  const handleAbrirCambioProveedor = useCallback(() => {
+    if (!compraParaEditar) return
+    setCompraParaCambiarProveedor(compraParaEditar)
+    setModalEditarOpen(false)
+    setCompraParaEditar(null)
+    setModalCambiarProveedorOpen(true)
+  }, [compraParaEditar])
+
   // Cambiar proveedor: anula la compra vieja y crea una nueva idéntica con el
   // proveedor correcto (RPC atómico, no mueve stock/costos). Ver mig 125.
   const handleCambiarProveedorCompra = useCallback(async (payload: CambiarProveedorPayload) => {
-    if (!compraParaEditar) return
+    if (!compraParaCambiarProveedor) return
     try {
       const { nuevaCompraId } = await cambiarProveedorMut.mutateAsync({
-        compraId: compraParaEditar.id,
+        compraId: compraParaCambiarProveedor.id,
         nuevoProveedorId: payload.nuevoProveedorId,
         nuevoProveedorNombre: payload.nuevoProveedorNombre,
         usuarioId: user?.id ?? null,
         motivo: payload.motivo,
       })
       notify.success(`Proveedor cambiado: se creó la compra #${nuevaCompraId} y se anuló la anterior`, { persist: true })
-      setModalEditarOpen(false)
-      setCompraParaEditar(null)
+      setModalCambiarProveedorOpen(false)
+      setCompraParaCambiarProveedor(null)
     } catch (err) {
       const msg = err instanceof Error ? err.message : 'Error al cambiar el proveedor'
       notify.error(msg)
       throw err
     }
-  }, [cambiarProveedorMut, compraParaEditar, notify, user])
+  }, [cambiarProveedorMut, compraParaCambiarProveedor, notify, user])
 
   const handleGuardarNC = useCallback(async (data: NotaCreditoFormInput) => {
     try {
@@ -294,8 +309,23 @@ export default function ComprasContainer(): React.ReactElement {
             }}
             guardando={actualizarCompra.isPending}
             canCambiarProveedor={isAdmin}
+            onCambiarProveedor={handleAbrirCambioProveedor}
+          />
+        </Suspense>
+      )}
+
+      {/* Modal Cambiar Proveedor (admin): anula + recrea la compra con otro proveedor */}
+      {modalCambiarProveedorOpen && compraParaCambiarProveedor && (
+        <Suspense fallback={null}>
+          <ModalCambiarProveedor
+            compra={compraParaCambiarProveedor}
             proveedores={proveedores}
-            onCambiarProveedor={handleCambiarProveedorCompra}
+            onConfirmar={handleCambiarProveedorCompra}
+            onClose={() => {
+              setModalCambiarProveedorOpen(false)
+              setCompraParaCambiarProveedor(null)
+            }}
+            guardando={cambiarProveedorMut.isPending}
             onCrearProveedor={handleCrearProveedorDesdeCompra}
           />
         </Suspense>

--- a/src/components/modals/ModalCambiarProveedor.tsx
+++ b/src/components/modals/ModalCambiarProveedor.tsx
@@ -63,11 +63,15 @@ const ModalCambiarProveedor = memo(function ModalCambiarProveedor({
 
   async function handleConfirmar() {
     if (!puedeConfirmar) return
-    await onConfirmar({
-      nuevoProveedorId: nuevoProveedorId || null,
-      nuevoProveedorNombre: null,
-      motivo: 'Cambio de proveedor',
-    })
+    try {
+      await onConfirmar({
+        nuevoProveedorId: nuevoProveedorId || null,
+        nuevoProveedorNombre: null,
+        motivo: 'Cambio de proveedor',
+      })
+    } catch {
+      // el container ya notificó el error; el modal queda abierto para reintentar
+    }
   }
 
   return (

--- a/src/components/modals/ModalCompra.tsx
+++ b/src/components/modals/ModalCompra.tsx
@@ -649,6 +649,14 @@ export default function ModalCompra({ productos, proveedores, onSave, onClose, o
       dispatch({ type: 'SET_ERROR', payload: 'La fecha de compra es obligatoria' })
       return
     }
+    // Proveedor obligatorio: existente (proveedorId) o nombre nuevo escrito.
+    const tieneProveedor = state.usarProveedorNuevo
+      ? !!(state.proveedorNombre || '').trim()
+      : !!state.proveedorId
+    if (!tieneProveedor) {
+      dispatch({ type: 'SET_ERROR', payload: 'Debe seleccionar un proveedor' })
+      return
+    }
     for (const item of state.items) {
       if (!item.cantidad || item.cantidad <= 0) {
         dispatch({ type: 'SET_ERROR', payload: `"${item.productoNombre}" debe tener cantidad mayor a 0` })
@@ -938,7 +946,7 @@ function ProveedorSection({ state, dispatch, proveedores, onAgregarProveedor }: 
     <div className="bg-gray-50 dark:bg-gray-900 rounded-lg p-3 sm:p-4 space-y-3">
       <div className="flex items-center gap-2 mb-2">
         <Building2 className="w-5 h-5 text-gray-500" />
-        <h3 className="font-medium text-gray-800 dark:text-white">Proveedor</h3>
+        <h3 className="font-medium text-gray-800 dark:text-white">Proveedor <span className="text-red-500">*</span></h3>
       </div>
 
       <div className="flex items-center gap-2">
@@ -947,7 +955,7 @@ function ProveedorSection({ state, dispatch, proveedores, onAgregarProveedor }: 
           onChange={(e: ChangeEvent<HTMLSelectElement>) => dispatch({ type: 'SET_PROVEEDOR_ID', payload: e.target.value })}
           className="flex-1 px-3 sm:px-4 py-2 border dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-green-500 dark:bg-gray-700 dark:text-white text-sm sm:text-base"
         >
-          <option value="">Seleccionar proveedor (opcional)...</option>
+          <option value="">Seleccionar proveedor...</option>
           {proveedores.map(p => (
             <option key={p.id} value={p.id}>{p.nombre} {p.cuit ? `(${p.cuit})` : ''}</option>
           ))}

--- a/src/components/modals/ModalEditarCompra.tsx
+++ b/src/components/modals/ModalEditarCompra.tsx
@@ -16,16 +16,13 @@
  * reciente del producto.
  */
 
-import { useState, memo, useMemo, lazy, Suspense } from 'react'
+import { memo, useMemo, useState } from 'react'
 import { Loader2, Trash2, AlertCircle, Building2 } from 'lucide-react'
 import ModalBase from './ModalBase'
 import NumberInput from '../ui/NumberInput'
 import { formatPrecio } from '../../utils/formatters'
-import type { CompraDBExtended, ProveedorDBExtended, ProveedorFormInputExtended } from '../../types'
+import type { CompraDBExtended } from '../../types'
 import type { ActualizarCompraItemsInput } from '../../hooks/queries'
-import type { CambiarProveedorPayload } from './ModalCambiarProveedor'
-
-const ModalCambiarProveedor = lazy(() => import('./ModalCambiarProveedor'))
 
 /** Item editable dentro del modal. */
 interface ItemEdit {
@@ -45,11 +42,10 @@ export interface ModalEditarCompraProps {
   onGuardar: (input: ActualizarCompraItemsInput) => Promise<void>
   onClose: () => void
   guardando: boolean
-  /** Cambiar proveedor (admin): anula + recrea la compra con otro proveedor. */
+  /** Cambiar proveedor (admin): abre el flujo de anular + recrear con otro proveedor. */
   canCambiarProveedor?: boolean
-  proveedores?: ProveedorDBExtended[]
-  onCambiarProveedor?: (payload: CambiarProveedorPayload) => Promise<void>
-  onCrearProveedor?: (data: ProveedorFormInputExtended) => Promise<ProveedorDBExtended>
+  /** Se dispara al pedir el cambio; el container cierra este modal y abre el de cambio. */
+  onCambiarProveedor?: () => void
 }
 
 const ModalEditarCompra = memo(function ModalEditarCompra({
@@ -59,9 +55,7 @@ const ModalEditarCompra = memo(function ModalEditarCompra({
   onClose,
   guardando,
   canCambiarProveedor = false,
-  proveedores,
   onCambiarProveedor,
-  onCrearProveedor,
 }: ModalEditarCompraProps) {
   const esZZ = compra.tipo_factura === 'ZZ'
   const otrosImpuestos = compra.otros_impuestos ?? 0
@@ -89,10 +83,7 @@ const ModalEditarCompra = memo(function ModalEditarCompra({
   // Items que efectivamente se persisten (los no eliminados).
   const itemsActivos = useMemo(() => items.filter((i) => !i.marcadoParaEliminar), [items])
 
-  // --- Cambiar proveedor (admin): anula + recrea la compra con otro proveedor ---
-  const [mostrarCambioProveedor, setMostrarCambioProveedor] = useState(false)
-  const [cambiandoProveedor, setCambiandoProveedor] = useState(false)
-
+  // --- Cambiar proveedor (admin): el botón abre el flujo; el container maneja el modal ---
   // Snapshot inicial de items para detectar ediciones sin guardar: el cambio de
   // proveedor clona los items DE LA BD, no los del modal, así que si hay cambios
   // sin guardar se bloquea para no recrear con datos inconsistentes.
@@ -128,19 +119,6 @@ const ModalEditarCompra = memo(function ModalEditarCompra({
   const puedeCambiarProveedor = Boolean(
     canCambiarProveedor && onCambiarProveedor && compra.estado !== 'cancelada',
   )
-
-  async function handleConfirmarCambioProveedor(payload: CambiarProveedorPayload) {
-    if (!onCambiarProveedor) return
-    setCambiandoProveedor(true)
-    try {
-      await onCambiarProveedor(payload)
-      setMostrarCambioProveedor(false) // el container cierra el modal de edición al tener éxito
-    } catch {
-      // dejar abierto para reintentar; el container ya notificó el error
-    } finally {
-      setCambiandoProveedor(false)
-    }
-  }
 
   // Totales calculados (incluye imp. internos por línea; percepciones y no
   // gravado de la cabecera se conservan tal cual).
@@ -269,8 +247,8 @@ const ModalEditarCompra = memo(function ModalEditarCompra({
           <div className="flex flex-wrap items-center gap-2">
             <button
               type="button"
-              onClick={() => setMostrarCambioProveedor(true)}
-              disabled={itemsModificados || cambiandoProveedor}
+              onClick={() => onCambiarProveedor?.()}
+              disabled={itemsModificados}
               title={
                 itemsModificados
                   ? 'Guardá o descartá los cambios de items primero'
@@ -450,20 +428,6 @@ const ModalEditarCompra = memo(function ModalEditarCompra({
           </button>
         </div>
       </div>
-
-      {/* Cambiar proveedor (anidado): anula + recrea la compra con otro proveedor */}
-      {mostrarCambioProveedor && puedeCambiarProveedor && (
-        <Suspense fallback={null}>
-          <ModalCambiarProveedor
-            compra={compra}
-            proveedores={proveedores ?? []}
-            onConfirmar={handleConfirmarCambioProveedor}
-            onClose={() => setMostrarCambioProveedor(false)}
-            guardando={cambiandoProveedor}
-            onCrearProveedor={onCrearProveedor}
-          />
-        </Suspense>
-      )}
     </ModalBase>
   )
 })


### PR DESCRIPTION
Sigue a #426 (cambiar proveedor de una compra). Dos cosas:

## 1) Cambio de proveedor como un solo modal (no apilado)

Al abrir "Cambiar proveedor" desde **Editar compra**, el modal de cambio se renderizaba **anidado** sobre el de edición → dos modales apilados, dos "X", el footer del de edición asomando por detrás.

**Fix:** el modal de cambio se sube al `ComprasContainer`. El botón dentro de "Editar compra" ahora **cierra ese modal y abre el de cambio** → un solo modal a la vez. Sin cambios en el RPC.

## 2) Proveedor obligatorio al registrar una compra

Se podía cargar una compra **sin proveedor** (filas "Sin proveedor"). Ahora es obligatorio, en dos capas (como el resto del código):

- **Front (`ModalCompra`):** valida que haya proveedor (existente o nombre nuevo) antes de enviar; el selector ya no dice "(opcional)" y el campo se marca con `*`.
- **RPC (`mig 126`):** `registrar_compra_completa` rechaza si no viene ni id ni nombre de proveedor. Resto de la función idéntico a mig 114. **Aplicada a prod.** Las compras viejas sin proveedor no se tocan (solo afecta altas nuevas).

## Verificación

- **Guarda del RPC probada contra prod** (transaccional con rollback): sin id/nombre → error "Debe indicar un proveedor"; nombre en blanco → error; con proveedor → `success:true`.
- `tsc --noEmit` limpio en los archivos tocados; los 6 tests de los modales de cambio pasan; suite completa OK en el pre-commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)