### PR TITLE
fix(compras): el selector de proveedor recortaba el botón "Nuevo"

### DIFF
--- a/src/components/modals/ModalCambiarProveedor.tsx
+++ b/src/components/modals/ModalCambiarProveedor.tsx
@@ -99,7 +99,7 @@ const ModalCambiarProveedor = memo(function ModalCambiarProveedor({
             <select
               value={nuevoProveedorId}
               onChange={(e) => setNuevoProveedorId(e.target.value)}
-              className="flex-1 px-3 py-2 border dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-green-500 dark:bg-gray-700 dark:text-white text-sm"
+              className="flex-1 min-w-0 px-3 py-2 border dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-green-500 dark:bg-gray-700 dark:text-white text-sm"
             >
               <option value="">Seleccionar proveedor...</option>
               {proveedores.map((p) => (
@@ -113,7 +113,7 @@ const ModalCambiarProveedor = memo(function ModalCambiarProveedor({
               <button
                 type="button"
                 onClick={() => setModalProveedorOpen(true)}
-                className="flex items-center gap-1 px-3 py-2 bg-green-600 text-white rounded-lg hover:bg-green-700 transition-colors whitespace-nowrap text-sm"
+                className="flex items-center gap-1 shrink-0 px-3 py-2 bg-green-600 text-white rounded-lg hover:bg-green-700 transition-colors whitespace-nowrap text-sm"
                 title="Crear proveedor nuevo"
               >
                 <Plus className="w-4 h-4" />


### PR DESCRIPTION
Sigue a #427 (ya mergeada). Fix visual del modal **Cambiar proveedor**.

## Problema

En el modal (angosto, `max-w-lg`), el `<select>` de proveedores tomaba su ancho intrínseco del **nombre más largo** de la lista (ej. "MOLINOS JOSE LOPEZ//MOLINOS CONFIABLES SRL"). Al ser `flex-1` **sin** `min-width:0`, no podía encogerse y empujaba el botón **"Nuevo"** fuera del modal, quedando recortado.

## Fix

- `min-w-0` en el select → ahora se encoge y trunca el texto (el desplegable sigue mostrando los nombres completos).
- `shrink-0` en el botón "Nuevo" → nunca se comprime, queda siempre entero.

Cambio de 2 líneas, solo presentación. `tsc` limpio, tests OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)