### PR TITLE
feat(costos): costo promedio ponderado (CPP) para valuacion y CMV

### DIFF
--- a/migrations/127_costo_promedio_columna_backfill.sql
+++ b/migrations/127_costo_promedio_columna_backfill.sql
@@ -1,0 +1,37 @@
+-- ============================================================================
+-- 127 · productos.costo_promedio: costo promedio ponderado (CPP) por sucursal
+-- ============================================================================
+-- Problema: el modelo "último costo gana" revalúa TODO el stock existente al
+-- costo de la última compra. Si compro 100u en ZZ a 121 (total = costo) y a la
+-- semana compro en FC a 100 neto, las 80u viejas pasan a costearse a 100:
+-- CMV subvaluado, margen inflado (y viceversa cuando el costo sube).
+--
+-- Solución: doble rol del costo.
+--   · costo_real       → costo de REPOSICIÓN (última compra FC/ZZ). Base para
+--                        pricing. Se sigue actualizando igual que hoy.
+--   · costo_promedio   → costo promedio ponderado, base de VALUACIÓN y CMV.
+--                        Al comprar: (stock_ant × cpp + cant × costo_real_nuevo)
+--                                    / (stock_ant + cant)
+--                        Se recalcula en registrar_compra_completa (mig 128).
+--
+-- Política forward-only: ediciones y anulaciones de compras NO retro-ajustan
+-- el promedio (es dependiente del camino). El admin puede corregirlo a mano
+-- desde la ficha del producto.
+--
+-- productos es por sucursal (sucursal_id en la fila) ⇒ el CPP es por sucursal.
+-- ============================================================================
+
+ALTER TABLE public.productos
+  ADD COLUMN IF NOT EXISTS costo_promedio numeric(12,4);
+
+COMMENT ON COLUMN public.productos.costo_promedio IS
+  'Costo promedio ponderado (valuación de stock y CMV). Se recalcula en registrar_compra_completa; forward-only: ediciones/anulaciones de compras no lo retro-ajustan (corregible a mano por admin). costo_real sigue siendo el costo de reposición (última compra).';
+
+-- Backfill: arranca igual al costo real vigente (misma cascada de fallback que
+-- ya usa reporte_gerencial para filas sin costo_real).
+UPDATE public.productos
+   SET costo_promedio = COALESCE(
+         costo_real,
+         round(costo_sin_iva * (1 + COALESCE(impuestos_internos, 0) / 100), 4)
+       )
+ WHERE costo_promedio IS NULL;

--- a/migrations/128_compras_costo_promedio.sql
+++ b/migrations/128_compras_costo_promedio.sql
@@ -1,0 +1,534 @@
+-- ============================================================================
+-- 128 · registrar_compra_completa / actualizar_compra_items con costo promedio
+-- ============================================================================
+-- Base: texto vigente de mig 114 (mismas firmas ⇒ CREATE OR REPLACE).
+-- Cambios:
+-- · registrar_compra_completa: cuando la línea actualiza costo (bonif < 100 y
+--   costo > 0), además de pisar costo_real (reposición) recalcula
+--   productos.costo_promedio:
+--     stock_ant ≤ 0 o CPP nulo/≤0  → CPP = costo_real de la compra (reset)
+--     si no                        → CPP = (stock_ant×CPP + cant×costo_real)
+--                                          / (stock_ant + cant)
+--   Varias líneas del mismo producto: el SELECT ... FOR UPDATE por línea ve el
+--   stock y CPP ya actualizados por la línea anterior ⇒ promedian bien en
+--   cualquier orden. Los regalos (bonif 100% / costo 0) suman stock sin tocar
+--   CPP (quedan valuados implícitamente al CPP vigente).
+-- · actualizar_compra_items (política forward-only, mig 127):
+--   - Si la compra editada es la más reciente del producto: re-deriva el CPP
+--     de forma APROXIMADA, tratando la línea editada como si recién entrara
+--     sobre el stock previo (stock actual sin las unidades de esta compra).
+--     Es una aproximación honesta para el caso común "cargué mal el costo y lo
+--     corrijo enseguida" (la ventana de edición ya es de 7 días).
+--   - Si NO es la más reciente y el costo real de la línea cambió > 1% contra
+--     el snapshot viejo: NO toca el CPP y devuelve warning_costo_promedio con
+--     los productos cuyo promedio puede haber quedado distorsionado (el admin
+--     puede corregirlo desde la ficha).
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION public.registrar_compra_completa(
+  p_proveedor_id bigint, p_proveedor_nombre character varying,
+  p_numero_factura character varying, p_fecha_compra date,
+  p_subtotal numeric, p_iva numeric, p_otros_impuestos numeric, p_total numeric,
+  p_forma_pago character varying, p_notas text, p_usuario_id uuid,
+  p_items jsonb, p_tipo_factura character varying DEFAULT 'FC',
+  p_impuestos_internos numeric DEFAULT 0,
+  p_percepcion_iva numeric DEFAULT 0,
+  p_percepcion_iibb numeric DEFAULT 0,
+  p_no_gravado numeric DEFAULT 0
+) RETURNS jsonb
+LANGUAGE plpgsql SECURITY DEFINER
+SET search_path TO 'public'
+AS $$
+DECLARE
+  v_sucursal            BIGINT := current_sucursal_id();
+  v_compra_id           BIGINT;
+  v_item                JSONB;
+  v_producto            RECORD;
+  v_stock_anterior      INTEGER;
+  v_stock_nuevo         INTEGER;
+  v_cantidad            INTEGER;
+  v_bonificacion        NUMERIC;
+  v_porcentaje_iva      NUMERIC;
+  v_impuestos_internos  NUMERIC;
+  v_costo_unitario      NUMERIC;
+  v_costo_neto          NUMERIC;
+  v_costo_con_iva       NUMERIC;
+  v_costo_real          NUMERIC;
+  v_costo_promedio      NUMERIC;
+  v_actualiza_costo     BOOLEAN;
+  v_tipo_factura        TEXT;
+  v_es_zz               BOOLEAN;
+  v_iva_hdr             NUMERIC;
+  v_ii_hdr              NUMERIC;
+  v_perc_iva_hdr        NUMERIC;
+  v_perc_iibb_hdr       NUMERIC;
+  v_no_gravado_hdr      NUMERIC;
+  v_total_calc          NUMERIC;
+  v_warning             TEXT := NULL;
+  v_items_procesados    JSONB := '[]'::JSONB;
+  v_user_role           TEXT;
+BEGIN
+  IF v_sucursal IS NULL THEN
+    RETURN jsonb_build_object('success', false, 'error', 'No se pudo determinar la sucursal activa');
+  END IF;
+
+  IF p_usuario_id IS DISTINCT FROM auth.uid() THEN
+    RETURN jsonb_build_object('success', false, 'error', 'ID de usuario no coincide con la sesion autenticada');
+  END IF;
+
+  SELECT rol INTO v_user_role FROM perfiles WHERE id = p_usuario_id;
+  IF v_user_role IS NULL OR v_user_role NOT IN ('admin', 'encargado') THEN
+    RETURN jsonb_build_object('success', false, 'error', 'No autorizado: solo admin o encargado pueden registrar compras');
+  END IF;
+
+  v_tipo_factura   := COALESCE(p_tipo_factura, 'FC');
+  v_es_zz          := (v_tipo_factura = 'ZZ');
+  v_iva_hdr        := CASE WHEN v_es_zz THEN 0 ELSE COALESCE(p_iva, 0) END;
+  v_ii_hdr         := CASE WHEN v_es_zz THEN 0 ELSE COALESCE(p_impuestos_internos, 0) END;
+  v_perc_iva_hdr   := CASE WHEN v_es_zz THEN 0 ELSE COALESCE(p_percepcion_iva, 0) END;
+  v_perc_iibb_hdr  := CASE WHEN v_es_zz THEN 0 ELSE COALESCE(p_percepcion_iibb, 0) END;
+  v_no_gravado_hdr := CASE WHEN v_es_zz THEN 0 ELSE COALESCE(p_no_gravado, 0) END;
+
+  INSERT INTO compras (
+    proveedor_id, proveedor_nombre, numero_factura, fecha_compra,
+    subtotal, iva, impuestos_internos, percepcion_iva, percepcion_iibb,
+    no_gravado, otros_impuestos, total, forma_pago, notas,
+    usuario_id, estado, tipo_factura, sucursal_id
+  ) VALUES (
+    p_proveedor_id, p_proveedor_nombre, p_numero_factura, p_fecha_compra,
+    p_subtotal, v_iva_hdr, v_ii_hdr, v_perc_iva_hdr, v_perc_iibb_hdr,
+    v_no_gravado_hdr, COALESCE(p_otros_impuestos, 0), p_total, p_forma_pago, p_notas,
+    p_usuario_id, 'recibida', v_tipo_factura, v_sucursal
+  )
+  RETURNING id INTO v_compra_id;
+
+  FOR v_item IN SELECT * FROM jsonb_array_elements(p_items) LOOP
+    SELECT id, stock, costo_promedio INTO v_producto
+      FROM productos
+     WHERE id = (v_item->>'producto_id')::BIGINT
+       AND sucursal_id = v_sucursal
+     FOR UPDATE;
+
+    IF NOT FOUND THEN
+      RAISE EXCEPTION 'Producto no encontrado: %', v_item->>'producto_id';
+    END IF;
+
+    v_cantidad           := (v_item->>'cantidad')::INTEGER;
+    v_stock_anterior     := COALESCE(v_producto.stock, 0);
+    v_stock_nuevo        := v_stock_anterior + v_cantidad;
+    v_costo_unitario     := COALESCE((v_item->>'costo_unitario')::NUMERIC, 0);
+    v_bonificacion       := COALESCE((v_item->>'bonificacion')::NUMERIC, 0);
+    v_porcentaje_iva     := CASE WHEN v_es_zz THEN 0 ELSE COALESCE((v_item->>'porcentaje_iva')::NUMERIC, 21) END;
+    v_impuestos_internos := CASE WHEN v_es_zz THEN 0 ELSE COALESCE((v_item->>'impuestos_internos')::NUMERIC, 0) END;
+
+    v_costo_neto    := v_costo_unitario * (1 - v_bonificacion / 100);
+    v_costo_con_iva := costo_financiero_unitario(v_costo_neto, v_porcentaje_iva, v_impuestos_internos, v_tipo_factura);
+    v_costo_real    := costo_real_unitario(v_costo_neto, v_impuestos_internos, v_tipo_factura);
+
+    INSERT INTO compra_items (
+      compra_id, producto_id, cantidad, costo_unitario, subtotal,
+      stock_anterior, stock_nuevo, bonificacion, sucursal_id,
+      porcentaje_iva, impuestos_internos, costo_neto_unitario, costo_real_unitario
+    ) VALUES (
+      v_compra_id,
+      (v_item->>'producto_id')::BIGINT,
+      v_cantidad,
+      v_costo_unitario,
+      COALESCE((v_item->>'subtotal')::NUMERIC, 0),
+      v_stock_anterior,
+      v_stock_nuevo,
+      v_bonificacion,
+      v_sucursal,
+      v_porcentaje_iva,
+      v_impuestos_internos,
+      round(v_costo_neto, 4),
+      v_costo_real
+    );
+
+    -- Regalos / promos (bonif 100% o costo 0) suman stock pero no fijan costo.
+    v_actualiza_costo := (v_bonificacion < 100 AND v_costo_neto > 0);
+
+    IF v_actualiza_costo THEN
+      IF v_stock_anterior <= 0 OR v_producto.costo_promedio IS NULL OR v_producto.costo_promedio <= 0 THEN
+        v_costo_promedio := v_costo_real;
+      ELSE
+        v_costo_promedio := round(
+          (v_stock_anterior::NUMERIC * v_producto.costo_promedio + v_cantidad * v_costo_real)
+          / (v_stock_anterior + v_cantidad), 4);
+      END IF;
+
+      UPDATE productos
+         SET stock              = stock + v_cantidad,
+             costo_sin_iva      = v_costo_neto,
+             costo_con_iva      = v_costo_con_iva,
+             costo_real         = v_costo_real,
+             costo_promedio     = v_costo_promedio,
+             ultimo_tipo_compra = v_tipo_factura,
+             updated_at         = NOW()
+       WHERE id = (v_item->>'producto_id')::BIGINT
+         AND sucursal_id = v_sucursal;
+    ELSE
+      v_costo_promedio := v_producto.costo_promedio;
+      UPDATE productos
+         SET stock      = stock + v_cantidad,
+             updated_at = NOW()
+       WHERE id = (v_item->>'producto_id')::BIGINT
+         AND sucursal_id = v_sucursal;
+    END IF;
+
+    v_items_procesados := v_items_procesados || jsonb_build_object(
+      'producto_id',       (v_item->>'producto_id')::BIGINT,
+      'cantidad',          v_cantidad,
+      'stock_anterior',    v_stock_anterior,
+      'stock_nuevo',       v_stock_nuevo,
+      'costo_sin_iva',     v_costo_neto,
+      'costo_con_iva',     v_costo_con_iva,
+      'costo_real',        v_costo_real,
+      'costo_promedio',    v_costo_promedio,
+      'costo_actualizado', v_actualiza_costo
+    );
+  END LOOP;
+
+  -- Control blando de cuadre contra el total informado
+  v_total_calc := CASE
+    WHEN v_es_zz THEN COALESCE(p_subtotal, 0)
+    ELSE COALESCE(p_subtotal, 0) + v_iva_hdr + v_ii_hdr + v_perc_iva_hdr
+         + v_perc_iibb_hdr + v_no_gravado_hdr + COALESCE(p_otros_impuestos, 0)
+  END;
+  IF abs(v_total_calc - COALESCE(p_total, 0)) > 1 THEN
+    v_warning := format('Descuadre: total calculado %s vs total informado %s',
+                        round(v_total_calc, 2), round(COALESCE(p_total, 0), 2));
+  END IF;
+
+  RETURN jsonb_build_object(
+    'success',           true,
+    'compra_id',         v_compra_id,
+    'items_procesados',  v_items_procesados,
+    'warning_descuadre', v_warning
+  );
+EXCEPTION WHEN OTHERS THEN
+  RETURN jsonb_build_object('success', false, 'error', SQLERRM);
+END;
+$$;
+
+-- ────────────────────────────────────────────────────────────────────────────
+-- actualizar_compra_items: re-derivación aproximada del CPP (solo compra más
+-- reciente) + warning_costo_promedio para el resto (forward-only)
+-- ────────────────────────────────────────────────────────────────────────────
+
+CREATE OR REPLACE FUNCTION public.actualizar_compra_items(
+  p_compra_id bigint, p_items_nuevos jsonb,
+  p_subtotal numeric, p_iva numeric, p_total numeric, p_usuario_id uuid,
+  p_impuestos_internos numeric DEFAULT NULL,
+  p_percepcion_iva numeric DEFAULT NULL,
+  p_percepcion_iibb numeric DEFAULT NULL,
+  p_no_gravado numeric DEFAULT NULL,
+  p_otros_impuestos numeric DEFAULT NULL
+) RETURNS jsonb
+LANGUAGE plpgsql SECURITY DEFINER
+SET search_path TO 'public'
+AS $function$
+DECLARE
+  v_sucursal BIGINT := current_sucursal_id();
+  v_user_role TEXT;
+  v_compra RECORD;
+  v_dias NUMERIC;
+  v_item JSONB;
+  v_producto_id BIGINT;
+  v_cantidad INTEGER;
+  v_costo_unitario NUMERIC;
+  v_bonificacion NUMERIC;
+  v_porcentaje_iva NUMERIC;
+  v_impuestos_internos NUMERIC;
+  v_subtotal_item NUMERIC;
+  v_costo_neto NUMERIC;
+  v_costo_con_iva NUMERIC;
+  v_costo_real NUMERIC;
+  v_actualiza_costo BOOLEAN;
+  v_es_zz BOOLEAN;
+  v_stock_anterior INTEGER;
+  v_stock_nuevo INTEGER;
+  v_max_fecha DATE;
+  v_es_mas_reciente BOOLEAN;
+  v_iva_efectivo NUMERIC;
+  v_items_procesados JSONB := '[]'::JSONB;
+  v_costo_actualizado JSONB := '[]'::JSONB;
+  v_snapshot_stock JSONB := '{}'::JSONB;
+  v_warnings_stock_negativo JSONB;
+  -- CPP (mig 128)
+  v_cpp_map JSONB := '{}'::JSONB;          -- cpp corriente por producto (se actualiza línea a línea)
+  v_stock_previo_map JSONB := '{}'::JSONB; -- stock "sin esta compra" por producto (base del re-promedio)
+  v_costo_old_map JSONB := '{}'::JSONB;    -- costo_real_unitario viejo (prom. ponderado) por producto
+  v_stock_previo NUMERIC;
+  v_cpp_actual NUMERIC;
+  v_costo_promedio NUMERIC;
+  v_costo_old NUMERIC;
+  v_warning_cpp JSONB := '[]'::JSONB;
+BEGIN
+  IF v_sucursal IS NULL THEN
+    RETURN jsonb_build_object('success', false, 'error', 'No se pudo determinar la sucursal activa');
+  END IF;
+  IF p_usuario_id IS DISTINCT FROM auth.uid() THEN
+    RETURN jsonb_build_object('success', false, 'error', 'ID de usuario no coincide con la sesion autenticada');
+  END IF;
+
+  SELECT rol INTO v_user_role FROM perfiles WHERE id = p_usuario_id;
+  IF v_user_role IS NULL OR v_user_role <> 'admin' THEN
+    RETURN jsonb_build_object('success', false, 'error', 'No autorizado: solo admin puede editar compras');
+  END IF;
+
+  SELECT id, estado, tipo_factura, created_at, fecha_compra
+    INTO v_compra
+    FROM compras
+   WHERE id = p_compra_id AND sucursal_id = v_sucursal;
+  IF NOT FOUND THEN
+    RETURN jsonb_build_object('success', false, 'error', 'Compra no encontrada');
+  END IF;
+
+  IF v_compra.estado = 'cancelada' THEN
+    RETURN jsonb_build_object('success', false, 'error', 'No se puede editar una compra cancelada');
+  END IF;
+
+  v_dias := EXTRACT(EPOCH FROM (now() - v_compra.created_at)) / 86400;
+  IF v_dias > 7 THEN
+    RETURN jsonb_build_object('success', false, 'error',
+      'No se puede editar una compra creada hace mas de 7 dias');
+  END IF;
+
+  v_es_zz := (v_compra.tipo_factura = 'ZZ');
+  v_iva_efectivo := CASE WHEN v_es_zz THEN 0 ELSE p_iva END;
+
+  PERFORM set_config('app.stock_origen', 'compra_editada', true);
+  PERFORM set_config('app.stock_ref_tipo', 'compra', true);
+  PERFORM set_config('app.stock_ref_id', p_compra_id::TEXT, true);
+  PERFORM set_config('app.stock_user_id', p_usuario_id::TEXT, true);
+
+  PERFORM 1 FROM productos
+   WHERE sucursal_id = v_sucursal
+     AND id IN (
+       SELECT producto_id FROM compra_items
+        WHERE compra_id = p_compra_id AND sucursal_id = v_sucursal
+       UNION
+       SELECT (item->>'producto_id')::BIGINT
+         FROM jsonb_array_elements(p_items_nuevos) AS item
+     )
+   ORDER BY id
+   FOR UPDATE;
+
+  SELECT jsonb_object_agg(id::text, stock),
+         jsonb_object_agg(id::text, COALESCE(costo_promedio, 0))
+    INTO v_snapshot_stock, v_cpp_map
+    FROM productos
+   WHERE sucursal_id = v_sucursal
+     AND id IN (
+       SELECT producto_id FROM compra_items
+        WHERE compra_id = p_compra_id AND sucursal_id = v_sucursal
+       UNION
+       SELECT (item->>'producto_id')::BIGINT
+         FROM jsonb_array_elements(p_items_nuevos) AS item
+     );
+
+  -- Snapshots pre-DELETE para el CPP: costo real viejo (ponderado) por
+  -- producto y stock "sin esta compra" (stock actual menos las unidades que
+  -- esta compra había aportado) como base del re-promedio aproximado.
+  SELECT COALESCE(jsonb_object_agg(producto_id::text, costo_old), '{}'::JSONB)
+    INTO v_costo_old_map
+    FROM (
+      SELECT producto_id,
+             round(SUM(cantidad * costo_real_unitario) / NULLIF(SUM(cantidad), 0), 4) AS costo_old
+        FROM compra_items
+       WHERE compra_id = p_compra_id AND sucursal_id = v_sucursal
+         AND COALESCE(costo_real_unitario, 0) > 0
+         AND COALESCE(bonificacion, 0) < 100
+       GROUP BY producto_id
+    ) t;
+
+  SELECT COALESCE(jsonb_object_agg(p.id::text, p.stock - COALESCE(v.qty_old, 0)), '{}'::JSONB)
+    INTO v_stock_previo_map
+    FROM productos p
+    LEFT JOIN (
+      SELECT producto_id, SUM(cantidad)::INT AS qty_old
+        FROM compra_items
+       WHERE compra_id = p_compra_id AND sucursal_id = v_sucursal
+       GROUP BY producto_id
+    ) v ON v.producto_id = p.id
+   WHERE p.sucursal_id = v_sucursal
+     AND p.id IN (
+       SELECT producto_id FROM compra_items
+        WHERE compra_id = p_compra_id AND sucursal_id = v_sucursal
+       UNION
+       SELECT (item->>'producto_id')::BIGINT
+         FROM jsonb_array_elements(p_items_nuevos) AS item
+     );
+
+  WITH viejos AS (
+    SELECT producto_id, SUM(cantidad)::INT AS qty_old
+      FROM compra_items
+     WHERE compra_id = p_compra_id AND sucursal_id = v_sucursal
+     GROUP BY producto_id
+  ),
+  nuevos AS (
+    SELECT (item->>'producto_id')::BIGINT AS producto_id,
+           SUM((item->>'cantidad')::INT)::INT AS qty_new
+      FROM jsonb_array_elements(p_items_nuevos) AS item
+     GROUP BY (item->>'producto_id')::BIGINT
+  ),
+  deltas AS (
+    SELECT COALESCE(v.producto_id, n.producto_id) AS producto_id,
+           COALESCE(n.qty_new, 0) - COALESCE(v.qty_old, 0) AS delta
+      FROM viejos v FULL OUTER JOIN nuevos n USING (producto_id)
+  )
+  UPDATE productos p
+     SET stock = p.stock + d.delta,
+         updated_at = NOW()
+    FROM deltas d
+   WHERE p.id = d.producto_id
+     AND p.sucursal_id = v_sucursal
+     AND d.delta <> 0;
+
+  SELECT jsonb_agg(jsonb_build_object('producto_id', id, 'nombre', nombre, 'stock', stock))
+    INTO v_warnings_stock_negativo
+    FROM productos
+   WHERE sucursal_id = v_sucursal
+     AND stock < 0
+     AND id IN (
+       SELECT producto_id FROM compra_items
+        WHERE compra_id = p_compra_id AND sucursal_id = v_sucursal
+       UNION
+       SELECT (item->>'producto_id')::BIGINT
+         FROM jsonb_array_elements(p_items_nuevos) AS item
+     );
+
+  IF v_warnings_stock_negativo IS NOT NULL AND jsonb_array_length(v_warnings_stock_negativo) > 0 THEN
+    RAISE EXCEPTION 'La edición dejaría stock negativo en: %. Ajustá las cantidades o reconciliá el stock primero.',
+      (SELECT string_agg((w->>'nombre') || ' (' || (w->>'stock') || ')', ', ')
+         FROM jsonb_array_elements(v_warnings_stock_negativo) w);
+  END IF;
+
+  DELETE FROM compra_items WHERE compra_id = p_compra_id AND sucursal_id = v_sucursal;
+
+  FOR v_item IN SELECT * FROM jsonb_array_elements(p_items_nuevos) LOOP
+    v_producto_id        := (v_item->>'producto_id')::BIGINT;
+    v_cantidad           := (v_item->>'cantidad')::INTEGER;
+    v_costo_unitario     := COALESCE((v_item->>'costo_unitario')::NUMERIC, 0);
+    v_bonificacion       := COALESCE((v_item->>'bonificacion')::NUMERIC, 0);
+    v_porcentaje_iva     := CASE WHEN v_es_zz THEN 0 ELSE COALESCE((v_item->>'porcentaje_iva')::NUMERIC, 21) END;
+    v_impuestos_internos := CASE WHEN v_es_zz THEN 0 ELSE COALESCE((v_item->>'impuestos_internos')::NUMERIC, 0) END;
+    v_subtotal_item      := COALESCE((v_item->>'subtotal')::NUMERIC, 0);
+
+    IF v_cantidad IS NULL OR v_cantidad <= 0 THEN
+      RAISE EXCEPTION 'Cantidad invalida para producto %', v_producto_id;
+    END IF;
+
+    v_stock_anterior := COALESCE((v_snapshot_stock->>v_producto_id::TEXT)::INTEGER, 0);
+    v_stock_nuevo := v_stock_anterior + v_cantidad;
+
+    v_costo_neto    := v_costo_unitario * (1 - v_bonificacion / 100);
+    v_costo_con_iva := costo_financiero_unitario(v_costo_neto, v_porcentaje_iva, v_impuestos_internos, v_compra.tipo_factura);
+    v_costo_real    := costo_real_unitario(v_costo_neto, v_impuestos_internos, v_compra.tipo_factura);
+    v_actualiza_costo := (v_bonificacion < 100 AND v_costo_neto > 0);
+
+    INSERT INTO compra_items (
+      compra_id, producto_id, cantidad, costo_unitario, subtotal,
+      stock_anterior, stock_nuevo, bonificacion, sucursal_id,
+      porcentaje_iva, impuestos_internos, costo_neto_unitario, costo_real_unitario
+    ) VALUES (
+      p_compra_id, v_producto_id, v_cantidad, v_costo_unitario,
+      v_subtotal_item, v_stock_anterior, v_stock_nuevo, v_bonificacion, v_sucursal,
+      v_porcentaje_iva, v_impuestos_internos, round(v_costo_neto, 4), v_costo_real
+    );
+
+    SELECT MAX(c.fecha_compra) INTO v_max_fecha
+      FROM compras c
+      JOIN compra_items ci ON ci.compra_id = c.id AND ci.sucursal_id = c.sucursal_id
+     WHERE ci.producto_id = v_producto_id
+       AND ci.sucursal_id = v_sucursal
+       AND c.estado <> 'cancelada'
+       AND c.id <> p_compra_id;
+
+    v_es_mas_reciente := (v_max_fecha IS NULL) OR (v_compra.fecha_compra >= v_max_fecha);
+
+    IF v_es_mas_reciente AND v_actualiza_costo THEN
+      -- Re-derivación aproximada del CPP (ver header): la línea editada se
+      -- trata como si recién entrara sobre el stock previo a esta compra.
+      v_stock_previo := COALESCE((v_stock_previo_map->>v_producto_id::TEXT)::NUMERIC, 0);
+      v_cpp_actual   := NULLIF((v_cpp_map->>v_producto_id::TEXT)::NUMERIC, 0);
+
+      IF v_stock_previo <= 0 OR v_cpp_actual IS NULL OR v_cpp_actual <= 0 THEN
+        v_costo_promedio := v_costo_real;
+      ELSE
+        v_costo_promedio := round(
+          (v_stock_previo * v_cpp_actual + v_cantidad * v_costo_real)
+          / (v_stock_previo + v_cantidad), 4);
+      END IF;
+
+      -- Varias líneas del mismo producto: la siguiente parte del CPP y stock
+      -- que dejó esta línea.
+      v_cpp_map := jsonb_set(v_cpp_map, ARRAY[v_producto_id::TEXT], to_jsonb(v_costo_promedio));
+      v_stock_previo_map := jsonb_set(v_stock_previo_map, ARRAY[v_producto_id::TEXT],
+                                      to_jsonb(v_stock_previo + v_cantidad));
+
+      UPDATE productos
+         SET costo_sin_iva      = v_costo_neto,
+             costo_con_iva      = v_costo_con_iva,
+             costo_real         = v_costo_real,
+             costo_promedio     = v_costo_promedio,
+             ultimo_tipo_compra = v_compra.tipo_factura,
+             updated_at         = NOW()
+       WHERE id = v_producto_id AND sucursal_id = v_sucursal;
+      v_costo_actualizado := v_costo_actualizado || jsonb_build_object(
+        'producto_id', v_producto_id,
+        'costo_sin_iva', v_costo_neto,
+        'costo_con_iva', v_costo_con_iva,
+        'costo_real', v_costo_real,
+        'costo_promedio', v_costo_promedio
+      );
+    ELSIF v_actualiza_costo THEN
+      -- Compra vieja: forward-only, el CPP no se retro-ajusta. Si el costo
+      -- cambió materialmente (> 1%), avisar que el promedio puede haber
+      -- quedado distorsionado.
+      v_costo_old := NULLIF((v_costo_old_map->>v_producto_id::TEXT)::NUMERIC, 0);
+      IF v_costo_old IS NOT NULL
+         AND abs(v_costo_real - v_costo_old) / v_costo_old > 0.01 THEN
+        v_warning_cpp := v_warning_cpp || jsonb_build_object(
+          'producto_id', v_producto_id,
+          'costo_real_anterior', v_costo_old,
+          'costo_real_nuevo', v_costo_real
+        );
+      END IF;
+    END IF;
+
+    v_items_procesados := v_items_procesados || jsonb_build_object(
+      'producto_id', v_producto_id,
+      'cantidad', v_cantidad,
+      'stock_anterior', v_stock_anterior,
+      'stock_nuevo', v_stock_nuevo,
+      'costo_actualizado', (v_es_mas_reciente AND v_actualiza_costo)
+    );
+  END LOOP;
+
+  UPDATE compras
+     SET subtotal = p_subtotal,
+         iva = v_iva_efectivo,
+         impuestos_internos = CASE WHEN v_es_zz THEN 0 ELSE COALESCE(p_impuestos_internos, impuestos_internos) END,
+         percepcion_iva     = CASE WHEN v_es_zz THEN 0 ELSE COALESCE(p_percepcion_iva, percepcion_iva) END,
+         percepcion_iibb    = CASE WHEN v_es_zz THEN 0 ELSE COALESCE(p_percepcion_iibb, percepcion_iibb) END,
+         no_gravado         = CASE WHEN v_es_zz THEN 0 ELSE COALESCE(p_no_gravado, no_gravado) END,
+         otros_impuestos    = COALESCE(p_otros_impuestos, otros_impuestos),
+         total = p_total,
+         updated_at = NOW()
+   WHERE id = p_compra_id AND sucursal_id = v_sucursal;
+
+  RETURN jsonb_build_object(
+    'success', true,
+    'compra_id', p_compra_id,
+    'items_procesados', v_items_procesados,
+    'costo_actualizado', v_costo_actualizado,
+    'warning_costo_promedio', CASE WHEN jsonb_array_length(v_warning_cpp) > 0
+                                   THEN v_warning_cpp ELSE NULL END,
+    'warnings', NULL
+  );
+EXCEPTION WHEN OTHERS THEN
+  RETURN jsonb_build_object('success', false, 'error', SQLERRM);
+END;
+$function$;

--- a/migrations/129_snapshots_costo_promedio.sql
+++ b/migrations/129_snapshots_costo_promedio.sql
@@ -1,0 +1,934 @@
+-- ============================================================================
+-- 129 · Snapshots de costo congelan el COSTO PROMEDIO (CPP, mig 127)
+-- ============================================================================
+-- Los congeladores de costo (pedido_items.costo_unitario_al_crear y
+-- mermas_stock.costo_unitario) pasan de costo_real (reposición) a la cascada
+--   COALESCE(costo_promedio, costo_real, round(costo_sin_iva*(1+II/100),4))
+-- para que CMV y márgenes se calculen sobre lo que realmente costó el stock
+-- que se está vendiendo/mermando, no sobre el costo de la última compra.
+--
+-- Funciones tocadas (OR REPLACE, mismas firmas; texto base = mig 123 para los
+-- RPCs de pedidos, mig 119 para el trigger de mermas; diff = SOLO la cascada
+-- del snapshot y su SELECT):
+--   · crear_pedido_completo
+--   · crear_pedido_completo_bot
+--   · actualizar_pedido_items
+--   · anular_salvedad          (reinserta el item con costo snapshot)
+--   · mermas_stock_snapshot_costo()
+-- Las filas históricas no cambian (snapshot ya congelado). reporte_gerencial
+-- adopta la misma cascada para filas sin snapshot en mig 130.
+-- ============================================================================
+
+-- ─── 1. crear_pedido_completo ───────────────────────────────────────────────
+
+CREATE OR REPLACE FUNCTION public.crear_pedido_completo(p_cliente_id bigint, p_total numeric, p_usuario_id uuid, p_items jsonb, p_notas text DEFAULT NULL::text, p_forma_pago text DEFAULT 'efectivo'::text, p_estado_pago text DEFAULT 'pendiente'::text, p_fecha date DEFAULT NULL::date, p_tipo_factura text DEFAULT 'ZZ'::text, p_total_neto numeric DEFAULT NULL::numeric, p_total_iva numeric DEFAULT 0, p_fecha_entrega_programada date DEFAULT NULL::date, p_preventista_id uuid DEFAULT NULL::uuid)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public'
+AS $function$
+DECLARE
+  v_sucursal BIGINT := current_sucursal_id();
+  v_pedido_id INT; item JSONB; v_producto_id INT; v_cantidad INT;
+  v_precio_unitario DECIMAL; v_es_bonificacion BOOLEAN; v_promocion_id BIGINT;
+  v_neto_unitario DECIMAL; v_iva_unitario DECIMAL; v_ingreso_real DECIMAL;
+  v_porcentaje_iva DECIMAL; v_stock_actual INT; v_producto_nombre TEXT;
+  errores TEXT[] := '{}'; v_user_role TEXT;
+  v_cantidades_totales JSONB := '{}'::JSONB; v_cant_acumulada INT;
+  v_stock_snapshot JSONB := '{}'::JSONB;
+  v_stock_al_crear INT;
+  v_costo_actual NUMERIC; v_imp_int_actual NUMERIC; v_pct_iva_actual NUMERIC; v_costo_real_actual NUMERIC;
+  v_costo_promedio_actual NUMERIC;
+  v_costo_snapshot JSONB := '{}'::JSONB; v_costo_al_crear NUMERIC;
+  v_pct_iva_snapshot JSONB := '{}'::JSONB;
+  v_pct_ii_snapshot JSONB := '{}'::JSONB;
+  v_tipo_factura TEXT := COALESCE(p_tipo_factura, 'ZZ');
+  v_total_neto_calc NUMERIC := 0;
+  v_total_iva_calc NUMERIC := 0;
+  v_total_real_calc NUMERIC := 0;
+  v_es_regalo_no_mueve_stock JSONB := '{}'::JSONB;
+  v_regalo_mueve_stock BOOLEAN;
+  v_descripcion_regalo TEXT;
+  v_regalo_default_id BIGINT;
+  v_container_id INT;
+  v_fecha_pedido DATE := COALESCE(p_fecha, (now() AT TIME ZONE 'America/Argentina/Buenos_Aires')::date);
+  v_fecha_entrega DATE := COALESCE(p_fecha_entrega_programada, (v_fecha_pedido + INTERVAL '1 day')::date);
+  v_promo RECORD;
+  v_usos_pendientes_actual INT;
+  v_bloques_completos INT;
+  v_ajustar_usos INT;
+  v_ajustar_stock INT;
+  v_stock_ajuste_anterior INT;
+  v_stock_ajuste_nuevo INT;
+  v_ajuste_producto_nombre TEXT;
+  v_merma_id BIGINT;
+  v_pedidos_bundle TEXT;
+  v_observacion TEXT;
+  v_preventista_role TEXT;
+  v_preventista_final UUID;
+BEGIN
+  IF v_sucursal IS NULL THEN RETURN jsonb_build_object('success', false, 'errores', jsonb_build_array('No se pudo determinar la sucursal activa')); END IF;
+  IF p_usuario_id IS DISTINCT FROM auth.uid() THEN RETURN jsonb_build_object('success', false, 'errores', jsonb_build_array('ID de usuario no coincide con la sesion autenticada')); END IF;
+  SELECT rol INTO v_user_role FROM perfiles WHERE id = p_usuario_id;
+  IF v_user_role IS NULL OR v_user_role NOT IN ('admin', 'preventista', 'preventista_taco', 'encargado') THEN RETURN jsonb_build_object('success', false, 'errores', jsonb_build_array('No tiene permisos para crear pedidos')); END IF;
+
+  IF p_preventista_id IS NULL OR p_preventista_id = p_usuario_id THEN
+    v_preventista_final := p_usuario_id;
+  ELSE
+    IF v_user_role <> 'admin' THEN
+      RETURN jsonb_build_object('success', false, 'errores', jsonb_build_array('Solo admin puede asignar otro preventista al pedido'));
+    END IF;
+    SELECT p.rol INTO v_preventista_role
+    FROM perfiles p
+    WHERE p.id = p_preventista_id
+      AND p.activo = true
+      AND EXISTS (
+        SELECT 1 FROM usuario_sucursales us
+        WHERE us.usuario_id = p.id AND us.sucursal_id = v_sucursal
+      );
+    IF v_preventista_role IS NULL OR v_preventista_role NOT IN ('admin', 'preventista', 'preventista_taco') THEN
+      RETURN jsonb_build_object('success', false, 'errores', jsonb_build_array('El usuario asignado no es admin ni preventista (o no pertenece a la sucursal)'));
+    END IF;
+    v_preventista_final := p_preventista_id;
+  END IF;
+
+  FOR item IN SELECT * FROM jsonb_array_elements(p_items) LOOP
+    v_producto_id := (item->>'producto_id')::INT; v_cantidad := (item->>'cantidad')::INT;
+    v_es_bonificacion := COALESCE((item->>'es_bonificacion')::BOOLEAN, false);
+    IF v_cantidad IS NULL OR v_cantidad <= 0 THEN errores := array_append(errores, 'Cantidad invalida para producto ID ' || v_producto_id); CONTINUE; END IF;
+
+    v_cant_acumulada := COALESCE((v_cantidades_totales->>v_producto_id::TEXT)::INT, 0) + v_cantidad;
+    v_cantidades_totales := v_cantidades_totales || jsonb_build_object(v_producto_id::TEXT, v_cant_acumulada);
+
+    IF v_es_bonificacion THEN
+      v_promocion_id := (item->>'promocion_id')::BIGINT;
+      IF v_promocion_id IS NOT NULL THEN
+        SELECT regalo_mueve_stock INTO v_regalo_mueve_stock FROM promociones WHERE id = v_promocion_id AND sucursal_id = v_sucursal;
+        IF NOT COALESCE(v_regalo_mueve_stock, FALSE) THEN
+          v_es_regalo_no_mueve_stock := v_es_regalo_no_mueve_stock || jsonb_build_object(v_producto_id::TEXT, true);
+        END IF;
+      ELSE
+        v_es_regalo_no_mueve_stock := v_es_regalo_no_mueve_stock || jsonb_build_object(v_producto_id::TEXT, true);
+      END IF;
+    END IF;
+  END LOOP;
+
+  FOR v_producto_id IN SELECT (key)::INT FROM jsonb_each_text(v_cantidades_totales) LOOP
+    v_cantidad := (v_cantidades_totales->>v_producto_id::TEXT)::INT;
+    SELECT stock, nombre, costo_promedio, costo_real, costo_sin_iva, COALESCE(impuestos_internos, 0), COALESCE(porcentaje_iva, 21)
+      INTO v_stock_actual, v_producto_nombre, v_costo_promedio_actual, v_costo_real_actual, v_costo_actual, v_imp_int_actual, v_pct_iva_actual
+      FROM productos WHERE id = v_producto_id AND sucursal_id = v_sucursal FOR UPDATE;
+    IF v_stock_actual IS NULL THEN
+      errores := array_append(errores, 'Producto ID ' || v_producto_id || ' no encontrado');
+    ELSIF v_stock_actual < v_cantidad THEN
+      IF COALESCE((v_es_regalo_no_mueve_stock->>v_producto_id::TEXT)::BOOLEAN, FALSE) THEN
+        errores := array_append(errores, v_producto_nombre || ': stock insuficiente para regalo (disponible: ' || v_stock_actual || ', solicitado: ' || v_cantidad || ')');
+      ELSE
+        errores := array_append(errores, v_producto_nombre || ': stock insuficiente (disponible: ' || v_stock_actual || ', solicitado: ' || v_cantidad || ')');
+      END IF;
+    END IF;
+    IF v_stock_actual IS NOT NULL THEN
+      v_stock_snapshot := v_stock_snapshot || jsonb_build_object(v_producto_id::TEXT, v_stock_actual);
+      -- CPP primero (mig 129): valuación del stock que se vende; fallback reposición
+      v_costo_snapshot := v_costo_snapshot || jsonb_build_object(v_producto_id::TEXT,
+        COALESCE(v_costo_promedio_actual, v_costo_real_actual,
+          CASE WHEN v_costo_actual IS NULL THEN NULL
+               ELSE round(v_costo_actual * (1 + COALESCE(v_imp_int_actual, 0) / 100), 4) END));
+      v_pct_iva_snapshot := v_pct_iva_snapshot || jsonb_build_object(v_producto_id::TEXT, v_pct_iva_actual);
+      v_pct_ii_snapshot := v_pct_ii_snapshot || jsonb_build_object(v_producto_id::TEXT, v_imp_int_actual);
+    END IF;
+  END LOOP;
+
+  IF array_length(errores, 1) > 0 THEN RETURN jsonb_build_object('success', false, 'errores', to_jsonb(errores)); END IF;
+
+  INSERT INTO pedidos (cliente_id, fecha, total, total_neto, total_iva, total_real, tipo_factura, estado, usuario_id, creado_por, stock_descontado, notas, forma_pago, estado_pago, fecha_entrega_programada, sucursal_id)
+  VALUES (p_cliente_id, v_fecha_pedido, p_total, COALESCE(p_total_neto, p_total), COALESCE(p_total_iva, 0), p_total, v_tipo_factura, 'pendiente', v_preventista_final, p_usuario_id, true, p_notas, p_forma_pago, p_estado_pago, v_fecha_entrega, v_sucursal)
+  RETURNING id INTO v_pedido_id;
+
+  PERFORM set_config('app.stock_origen', 'pedido_creado', true);
+  PERFORM set_config('app.stock_ref_tipo', 'pedido', true);
+  PERFORM set_config('app.stock_ref_id', v_pedido_id::TEXT, true);
+  PERFORM set_config('app.stock_user_id', p_usuario_id::TEXT, true);
+
+  IF v_preventista_final IS DISTINCT FROM p_usuario_id THEN
+    INSERT INTO pedido_historial (pedido_id, usuario_id, campo_modificado, valor_anterior, valor_nuevo, sucursal_id)
+    VALUES (v_pedido_id, p_usuario_id, 'usuario_id', NULL, v_preventista_final::TEXT, v_sucursal);
+  END IF;
+
+  FOR item IN SELECT * FROM jsonb_array_elements(p_items) LOOP
+    v_producto_id := (item->>'producto_id')::INT; v_cantidad := (item->>'cantidad')::INT;
+    v_precio_unitario := (item->>'precio_unitario')::DECIMAL;
+    v_es_bonificacion := COALESCE((item->>'es_bonificacion')::BOOLEAN, false);
+    v_promocion_id := (item->>'promocion_id')::BIGINT;
+    v_stock_al_crear := (v_stock_snapshot->>v_producto_id::TEXT)::INT;
+    v_costo_al_crear := (v_costo_snapshot->>v_producto_id::TEXT)::NUMERIC;
+
+    -- Terna de ingresos SERVER-SIDE (mig 123)
+    IF v_es_bonificacion THEN
+      v_neto_unitario := 0; v_iva_unitario := 0; v_ingreso_real := 0; v_porcentaje_iva := 0;
+    ELSE
+      SELECT d.neto, d.iva, d.ingreso_real
+        INTO v_neto_unitario, v_iva_unitario, v_ingreso_real
+        FROM calcular_desglose_venta(
+          v_precio_unitario,
+          (v_pct_iva_snapshot->>v_producto_id::TEXT)::NUMERIC,
+          (v_pct_ii_snapshot->>v_producto_id::TEXT)::NUMERIC,
+          v_tipo_factura) d;
+      v_porcentaje_iva := (v_pct_iva_snapshot->>v_producto_id::TEXT)::NUMERIC;
+      v_total_neto_calc := v_total_neto_calc + (v_cantidad * v_neto_unitario);
+      v_total_iva_calc  := v_total_iva_calc  + (v_cantidad * v_iva_unitario);
+      v_total_real_calc := v_total_real_calc + (v_cantidad * v_ingreso_real);
+    END IF;
+
+    v_descripcion_regalo := NULL;
+    v_regalo_default_id := NULL;
+    IF v_es_bonificacion AND v_promocion_id IS NOT NULL THEN
+      SELECT descripcion_regalo, producto_regalo_id
+        INTO v_descripcion_regalo, v_regalo_default_id
+        FROM promociones WHERE id = v_promocion_id AND sucursal_id = v_sucursal;
+      IF v_regalo_default_id IS DISTINCT FROM v_producto_id THEN
+        v_descripcion_regalo := NULL;
+      END IF;
+    END IF;
+
+    INSERT INTO pedido_items (
+      pedido_id, producto_id, cantidad, precio_unitario, subtotal,
+      es_bonificacion, promocion_id,
+      neto_unitario, iva_unitario, impuestos_internos_unitario, porcentaje_iva,
+      ingreso_real_unitario,
+      sucursal_id, descripcion_regalo, stock_al_crear, costo_unitario_al_crear
+    ) VALUES (
+      v_pedido_id, v_producto_id, v_cantidad, v_precio_unitario, v_cantidad * v_precio_unitario,
+      v_es_bonificacion, v_promocion_id,
+      v_neto_unitario, v_iva_unitario, 0, v_porcentaje_iva,
+      v_ingreso_real,
+      v_sucursal, v_descripcion_regalo, v_stock_al_crear, v_costo_al_crear
+    );
+
+    IF NOT v_es_bonificacion THEN
+      UPDATE productos SET stock = stock - v_cantidad WHERE id = v_producto_id AND sucursal_id = v_sucursal;
+    ELSIF v_promocion_id IS NOT NULL THEN
+      SELECT regalo_mueve_stock INTO v_regalo_mueve_stock FROM promociones WHERE id = v_promocion_id AND sucursal_id = v_sucursal;
+      IF COALESCE(v_regalo_mueve_stock, FALSE) THEN
+        UPDATE productos SET stock = stock - v_cantidad WHERE id = v_producto_id AND sucursal_id = v_sucursal;
+      END IF;
+    END IF;
+
+    IF v_es_bonificacion AND v_promocion_id IS NOT NULL THEN
+      UPDATE promociones SET usos_pendientes = usos_pendientes + v_cantidad WHERE id = v_promocion_id AND sucursal_id = v_sucursal;
+
+      SELECT id, nombre, ajuste_automatico, ajuste_producto_id, unidades_por_bloque,
+             stock_por_bloque, usos_pendientes, producto_regalo_id
+      INTO v_promo
+      FROM promociones WHERE id = v_promocion_id AND sucursal_id = v_sucursal FOR UPDATE;
+
+      v_container_id := CASE WHEN v_promo.producto_regalo_id IS DISTINCT FROM v_producto_id
+                             THEN v_producto_id ELSE v_promo.ajuste_producto_id END;
+
+      IF v_promo.ajuste_automatico AND v_container_id IS NOT NULL
+         AND COALESCE(v_promo.unidades_por_bloque, 0) > 0 AND COALESCE(v_promo.stock_por_bloque, 0) > 0 THEN
+        v_usos_pendientes_actual := v_promo.usos_pendientes;
+        v_bloques_completos := v_usos_pendientes_actual / v_promo.unidades_por_bloque;
+        IF v_bloques_completos > 0 THEN
+          v_ajustar_usos := v_bloques_completos * v_promo.unidades_por_bloque;
+          v_ajustar_stock := v_bloques_completos * v_promo.stock_por_bloque;
+
+          SELECT stock, nombre INTO v_stock_ajuste_anterior, v_ajuste_producto_nombre
+          FROM productos WHERE id = v_container_id AND sucursal_id = v_sucursal FOR UPDATE;
+
+          IF v_stock_ajuste_anterior IS NULL THEN
+            RAISE EXCEPTION 'Auto-ajuste: producto destino no encontrado (promo %)', v_promocion_id;
+          END IF;
+          IF v_stock_ajuste_anterior < v_ajustar_stock THEN
+            RAISE EXCEPTION 'Auto-ajuste: stock insuficiente en % (disponible: %, requerido: %)',
+              v_ajuste_producto_nombre, v_stock_ajuste_anterior, v_ajustar_stock;
+          END IF;
+
+          v_stock_ajuste_nuevo := v_stock_ajuste_anterior - v_ajustar_stock;
+
+          v_pedidos_bundle := public.pedido_bundle_para_promo(v_promocion_id, v_sucursal, 20);
+          v_observacion := 'Auto-ajuste (Promo: ' || v_promo.nombre
+                           || ', Pedidos: ' || COALESCE(v_pedidos_bundle, '#' || v_pedido_id) || ')';
+
+          INSERT INTO mermas_stock (producto_id, cantidad, motivo, observaciones, stock_anterior, stock_nuevo, usuario_id, sucursal_id)
+          VALUES (v_container_id, v_ajustar_stock, 'promociones', v_observacion,
+            v_stock_ajuste_anterior, v_stock_ajuste_nuevo, p_usuario_id, v_sucursal)
+          RETURNING id INTO v_merma_id;
+
+          UPDATE productos SET stock = v_stock_ajuste_nuevo, updated_at = NOW()
+          WHERE id = v_container_id AND sucursal_id = v_sucursal;
+
+          INSERT INTO promo_ajustes (promocion_id, usos_ajustados, unidades_ajustadas, producto_id, merma_id, usuario_id, observaciones, sucursal_id)
+          VALUES (v_promocion_id, v_ajustar_usos, v_ajustar_stock, v_container_id,
+            v_merma_id, p_usuario_id, v_observacion, v_sucursal);
+
+          UPDATE promociones SET usos_pendientes = GREATEST(usos_pendientes - v_ajustar_usos, 0)
+          WHERE id = v_promocion_id AND sucursal_id = v_sucursal;
+        END IF;
+      END IF;
+    END IF;
+  END LOOP;
+
+  -- Terna autoritativa server-side
+  UPDATE pedidos
+     SET total_neto = round(v_total_neto_calc, 2),
+         total_iva  = round(v_total_iva_calc, 2),
+         total_real = round(v_total_real_calc, 2)
+   WHERE id = v_pedido_id AND sucursal_id = v_sucursal;
+
+  RETURN jsonb_build_object('success', true, 'pedido_id', v_pedido_id);
+END;
+$function$;
+
+-- ─── 2. crear_pedido_completo_bot ───────────────────────────────────────────
+
+CREATE OR REPLACE FUNCTION public.crear_pedido_completo_bot(p_perfil_id uuid, p_confirmacion_id uuid)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public'
+AS $function$
+DECLARE
+  v_pendiente RECORD;
+  v_user_role TEXT;
+  v_pedido_id INT;
+  v_fecha_pedido DATE := (now() AT TIME ZONE 'America/Argentina/Buenos_Aires')::date;
+  v_fecha_entrega DATE := (v_fecha_pedido + INTERVAL '1 day')::date;
+  v_cantidades_totales JSONB := '{}'::JSONB;
+  v_cant_acumulada INT;
+  v_stock_snapshot JSONB := '{}'::JSONB;
+  v_stock_al_crear INT;
+  v_costo_actual NUMERIC; v_imp_int_actual NUMERIC; v_costo_real_actual NUMERIC; v_pct_iva_actual NUMERIC;
+  v_costo_promedio_actual NUMERIC;
+  v_costo_snapshot JSONB := '{}'::JSONB; v_costo_al_crear NUMERIC;
+  v_pct_iva_snapshot JSONB := '{}'::JSONB;
+  v_es_regalo_no_mueve_stock JSONB := '{}'::JSONB;
+  v_regalo_mueve_stock BOOLEAN;
+  v_stock_actual INT;
+  v_producto_nombre TEXT;
+  errores TEXT[] := '{}';
+  item JSONB;
+  v_producto_id INT;
+  v_cantidad INT;
+  v_precio_unitario DECIMAL;
+  v_es_bonificacion BOOLEAN;
+  v_promocion_id BIGINT;
+  v_neto_unitario DECIMAL;
+  v_ingreso_real DECIMAL;
+  v_total_neto_calc NUMERIC := 0;
+  v_total_real_calc NUMERIC := 0;
+  v_promo RECORD;
+  v_usos_pendientes_actual INT;
+  v_bloques_completos INT;
+  v_ajustar_usos INT;
+  v_ajustar_stock INT;
+  v_stock_ajuste_anterior INT;
+  v_stock_ajuste_nuevo INT;
+  v_ajuste_producto_nombre TEXT;
+  v_merma_id BIGINT;
+BEGIN
+  SELECT * INTO v_pendiente FROM bot_pedidos_pendientes WHERE id = p_confirmacion_id FOR UPDATE;
+  IF NOT FOUND THEN RETURN jsonb_build_object('success', false, 'error', 'Confirmación inválida'); END IF;
+  IF v_pendiente.consumido THEN RETURN jsonb_build_object('success', false, 'error', 'Pedido ya creado, revisalo en la app'); END IF;
+  IF v_pendiente.expires_at < now() THEN RETURN jsonb_build_object('success', false, 'error', 'La confirmación expiró, hacé el pedido de nuevo'); END IF;
+  IF v_pendiente.perfil_id <> p_perfil_id THEN RETURN jsonb_build_object('success', false, 'error', 'Confirmación no pertenece al usuario'); END IF;
+
+  SELECT rol INTO v_user_role FROM perfiles WHERE id = p_perfil_id;
+  IF v_user_role IS NULL OR v_user_role NOT IN ('admin', 'encargado', 'preventista') THEN
+    RETURN jsonb_build_object('success', false, 'error', 'No tiene permisos para crear pedidos');
+  END IF;
+
+  FOR item IN SELECT * FROM jsonb_array_elements(v_pendiente.items) LOOP
+    v_producto_id := (item->>'producto_id')::INT;
+    v_cantidad := (item->>'cantidad')::INT;
+    v_es_bonificacion := COALESCE((item->>'es_bonificacion')::BOOLEAN, false);
+    IF v_cantidad IS NULL OR v_cantidad <= 0 THEN
+      errores := array_append(errores, 'Cantidad inválida para producto ID ' || v_producto_id);
+      CONTINUE;
+    END IF;
+
+    v_cant_acumulada := COALESCE((v_cantidades_totales->>v_producto_id::TEXT)::INT, 0) + v_cantidad;
+    v_cantidades_totales := v_cantidades_totales || jsonb_build_object(v_producto_id::TEXT, v_cant_acumulada);
+
+    IF v_es_bonificacion THEN
+      v_promocion_id := (item->>'promocion_id')::BIGINT;
+      IF v_promocion_id IS NOT NULL THEN
+        SELECT regalo_mueve_stock INTO v_regalo_mueve_stock FROM promociones WHERE id = v_promocion_id AND sucursal_id = v_pendiente.sucursal_id;
+        IF NOT COALESCE(v_regalo_mueve_stock, FALSE) THEN
+          v_es_regalo_no_mueve_stock := v_es_regalo_no_mueve_stock || jsonb_build_object(v_producto_id::TEXT, true);
+        END IF;
+      ELSE
+        v_es_regalo_no_mueve_stock := v_es_regalo_no_mueve_stock || jsonb_build_object(v_producto_id::TEXT, true);
+      END IF;
+    END IF;
+  END LOOP;
+
+  FOR v_producto_id IN SELECT (key)::INT FROM jsonb_each_text(v_cantidades_totales) LOOP
+    v_cantidad := (v_cantidades_totales->>v_producto_id::TEXT)::INT;
+    SELECT stock, nombre, costo_promedio, costo_real, costo_sin_iva, COALESCE(impuestos_internos, 0), COALESCE(porcentaje_iva, 21)
+      INTO v_stock_actual, v_producto_nombre, v_costo_promedio_actual, v_costo_real_actual, v_costo_actual, v_imp_int_actual, v_pct_iva_actual
+      FROM productos WHERE id = v_producto_id AND sucursal_id = v_pendiente.sucursal_id FOR UPDATE;
+    IF v_stock_actual IS NULL THEN
+      errores := array_append(errores, 'Producto ID ' || v_producto_id || ' no encontrado');
+    ELSIF v_stock_actual < v_cantidad THEN
+      IF COALESCE((v_es_regalo_no_mueve_stock->>v_producto_id::TEXT)::BOOLEAN, FALSE) THEN
+        errores := array_append(errores, v_producto_nombre || ': stock insuficiente para regalo (disponible: ' || v_stock_actual || ', solicitado: ' || v_cantidad || ')');
+      ELSE
+        errores := array_append(errores, v_producto_nombre || ': stock insuficiente (disponible: ' || v_stock_actual || ', solicitado: ' || v_cantidad || ')');
+      END IF;
+    END IF;
+    IF v_stock_actual IS NOT NULL THEN
+      v_stock_snapshot := v_stock_snapshot || jsonb_build_object(v_producto_id::TEXT, v_stock_actual);
+      -- CPP primero (mig 129)
+      v_costo_snapshot := v_costo_snapshot || jsonb_build_object(v_producto_id::TEXT,
+        COALESCE(v_costo_promedio_actual, v_costo_real_actual,
+          CASE WHEN v_costo_actual IS NULL THEN NULL
+               ELSE round(v_costo_actual * (1 + COALESCE(v_imp_int_actual, 0) / 100), 4) END));
+      v_pct_iva_snapshot := v_pct_iva_snapshot || jsonb_build_object(v_producto_id::TEXT, v_pct_iva_actual);
+    END IF;
+  END LOOP;
+
+  IF array_length(errores, 1) > 0 THEN RETURN jsonb_build_object('success', false, 'errores', to_jsonb(errores)); END IF;
+
+  INSERT INTO pedidos (
+    cliente_id, fecha, total, total_neto, total_iva, total_real, tipo_factura,
+    estado, usuario_id, creado_por, stock_descontado, notas, forma_pago,
+    estado_pago, fecha_entrega_programada, sucursal_id, canal
+  )
+  VALUES (
+    v_pendiente.cliente_id, v_fecha_pedido, v_pendiente.total,
+    v_pendiente.total,
+    0,
+    v_pendiente.total,   -- ZZ: real = final
+    'ZZ',
+    'pendiente', p_perfil_id, p_perfil_id, true, v_pendiente.notas, v_pendiente.forma_pago,
+    'pendiente', v_fecha_entrega, v_pendiente.sucursal_id, 'bot'
+  )
+  RETURNING id INTO v_pedido_id;
+
+  PERFORM set_config('app.stock_origen', 'pedido_creado_bot', true);
+  PERFORM set_config('app.stock_ref_tipo', 'pedido', true);
+  PERFORM set_config('app.stock_ref_id', v_pedido_id::TEXT, true);
+  PERFORM set_config('app.stock_user_id', p_perfil_id::TEXT, true);
+
+  FOR item IN SELECT * FROM jsonb_array_elements(v_pendiente.items) LOOP
+    v_producto_id := (item->>'producto_id')::INT;
+    v_cantidad := (item->>'cantidad')::INT;
+    v_precio_unitario := (item->>'precio_unitario')::DECIMAL;
+    v_es_bonificacion := COALESCE((item->>'es_bonificacion')::BOOLEAN, false);
+    v_promocion_id := (item->>'promocion_id')::BIGINT;
+    v_stock_al_crear := (v_stock_snapshot->>v_producto_id::TEXT)::INT;
+    v_costo_al_crear := (v_costo_snapshot->>v_producto_id::TEXT)::NUMERIC;
+
+    -- ZZ: real = precio final; neto = teórico sin IVA (tasa del producto)
+    IF v_es_bonificacion THEN
+      v_neto_unitario := 0; v_ingreso_real := 0;
+    ELSE
+      v_neto_unitario := round(COALESCE(v_precio_unitario, 0) /
+        (1 + COALESCE((v_pct_iva_snapshot->>v_producto_id::TEXT)::NUMERIC, 21) / 100), 2);
+      v_ingreso_real := round(COALESCE(v_precio_unitario, 0), 2);
+      v_total_neto_calc := v_total_neto_calc + (v_cantidad * v_neto_unitario);
+      v_total_real_calc := v_total_real_calc + (v_cantidad * v_ingreso_real);
+    END IF;
+
+    INSERT INTO pedido_items (
+      pedido_id, producto_id, cantidad, precio_unitario, subtotal,
+      es_bonificacion, promocion_id, neto_unitario, iva_unitario,
+      impuestos_internos_unitario, porcentaje_iva, ingreso_real_unitario,
+      sucursal_id, stock_al_crear, costo_unitario_al_crear
+    ) VALUES (
+      v_pedido_id, v_producto_id, v_cantidad, v_precio_unitario,
+      v_cantidad * v_precio_unitario,
+      v_es_bonificacion, v_promocion_id, v_neto_unitario, 0,
+      0, CASE WHEN v_es_bonificacion THEN 0 ELSE COALESCE((v_pct_iva_snapshot->>v_producto_id::TEXT)::NUMERIC, 21) END,
+      v_ingreso_real,
+      v_pendiente.sucursal_id, v_stock_al_crear, v_costo_al_crear
+    );
+
+    IF NOT v_es_bonificacion THEN
+      UPDATE productos SET stock = stock - v_cantidad WHERE id = v_producto_id AND sucursal_id = v_pendiente.sucursal_id;
+    ELSIF v_promocion_id IS NOT NULL THEN
+      SELECT regalo_mueve_stock INTO v_regalo_mueve_stock FROM promociones WHERE id = v_promocion_id AND sucursal_id = v_pendiente.sucursal_id;
+      IF COALESCE(v_regalo_mueve_stock, FALSE) THEN
+        UPDATE productos SET stock = stock - v_cantidad WHERE id = v_producto_id AND sucursal_id = v_pendiente.sucursal_id;
+      END IF;
+    END IF;
+
+    IF v_es_bonificacion AND v_promocion_id IS NOT NULL THEN
+      UPDATE promociones SET usos_pendientes = usos_pendientes + v_cantidad WHERE id = v_promocion_id AND sucursal_id = v_pendiente.sucursal_id;
+
+      SELECT id, nombre, ajuste_automatico, ajuste_producto_id, unidades_por_bloque,
+             stock_por_bloque, usos_pendientes
+        INTO v_promo
+        FROM promociones WHERE id = v_promocion_id AND sucursal_id = v_pendiente.sucursal_id FOR UPDATE;
+
+      IF v_promo.ajuste_automatico AND v_promo.ajuste_producto_id IS NOT NULL
+         AND COALESCE(v_promo.unidades_por_bloque, 0) > 0 AND COALESCE(v_promo.stock_por_bloque, 0) > 0 THEN
+        v_usos_pendientes_actual := v_promo.usos_pendientes;
+        v_bloques_completos := v_usos_pendientes_actual / v_promo.unidades_por_bloque;
+        IF v_bloques_completos > 0 THEN
+          v_ajustar_usos := v_bloques_completos * v_promo.unidades_por_bloque;
+          v_ajustar_stock := v_bloques_completos * v_promo.stock_por_bloque;
+
+          SELECT stock, nombre INTO v_stock_ajuste_anterior, v_ajuste_producto_nombre
+            FROM productos WHERE id = v_promo.ajuste_producto_id AND sucursal_id = v_pendiente.sucursal_id FOR UPDATE;
+
+          IF v_stock_ajuste_anterior IS NULL THEN
+            RAISE EXCEPTION 'Auto-ajuste: producto destino no encontrado (promo %)', v_promocion_id;
+          END IF;
+          IF v_stock_ajuste_anterior < v_ajustar_stock THEN
+            RAISE EXCEPTION 'Auto-ajuste: stock insuficiente en % (disponible: %, requerido: %)',
+              v_ajuste_producto_nombre, v_stock_ajuste_anterior, v_ajustar_stock;
+          END IF;
+
+          v_stock_ajuste_nuevo := v_stock_ajuste_anterior - v_ajustar_stock;
+
+          INSERT INTO mermas_stock (
+            producto_id, cantidad, motivo, observaciones,
+            stock_anterior, stock_nuevo, usuario_id, sucursal_id
+          ) VALUES (
+            v_promo.ajuste_producto_id, v_ajustar_stock, 'promociones',
+            'Auto-ajuste (Promo: ' || v_promo.nombre || ', Pedido #' || v_pedido_id || ' via bot)',
+            v_stock_ajuste_anterior, v_stock_ajuste_nuevo, p_perfil_id, v_pendiente.sucursal_id
+          ) RETURNING id INTO v_merma_id;
+
+          UPDATE productos SET stock = v_stock_ajuste_nuevo, updated_at = NOW()
+            WHERE id = v_promo.ajuste_producto_id AND sucursal_id = v_pendiente.sucursal_id;
+
+          INSERT INTO promo_ajustes (
+            promocion_id, usos_ajustados, unidades_ajustadas, producto_id,
+            merma_id, usuario_id, observaciones, sucursal_id
+          ) VALUES (
+            v_promocion_id, v_ajustar_usos, v_ajustar_stock, v_promo.ajuste_producto_id,
+            v_merma_id, p_perfil_id,
+            'Auto-ajuste por pedido #' || v_pedido_id || ' via bot', v_pendiente.sucursal_id
+          );
+
+          UPDATE promociones SET usos_pendientes = GREATEST(usos_pendientes - v_ajustar_usos, 0)
+            WHERE id = v_promocion_id AND sucursal_id = v_pendiente.sucursal_id;
+        END IF;
+      END IF;
+    END IF;
+  END LOOP;
+
+  UPDATE pedidos
+     SET total_neto = round(v_total_neto_calc, 2),
+         total_real = round(v_total_real_calc, 2)
+   WHERE id = v_pedido_id AND sucursal_id = v_pendiente.sucursal_id;
+
+  UPDATE bot_pedidos_pendientes SET consumido = TRUE WHERE id = p_confirmacion_id;
+
+  RETURN jsonb_build_object('success', true, 'pedido_id', v_pedido_id, 'total', v_pendiente.total);
+END;
+$function$;
+
+-- ─── 3. actualizar_pedido_items ─────────────────────────────────────────────
+
+CREATE OR REPLACE FUNCTION public.actualizar_pedido_items(p_pedido_id bigint, p_items_nuevos jsonb, p_usuario_id uuid)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public'
+AS $function$
+DECLARE
+  v_sucursal BIGINT := current_sucursal_id();
+  v_item_nuevo JSONB;
+  v_producto_id INT;
+  v_cantidad_original INT;
+  v_cantidad_nueva INT;
+  v_diferencia INT;
+  v_es_bonificacion BOOLEAN;
+  v_stock_actual INT;
+  v_producto_nombre TEXT;
+  v_total_nuevo DECIMAL := 0;
+  v_total_neto_nuevo DECIMAL := 0;
+  v_total_iva_nuevo DECIMAL := 0;
+  v_total_real_nuevo DECIMAL := 0;
+  v_total_anterior DECIMAL;
+  v_errores TEXT[] := '{}';
+  v_items_originales JSONB;
+  v_user_role TEXT;
+  v_neto_unitario DECIMAL;
+  v_iva_unitario DECIMAL;
+  v_ingreso_real DECIMAL;
+  v_porcentaje_iva DECIMAL;
+  v_precio_unitario DECIMAL;
+  v_promocion_id BIGINT;
+  v_regalo_mueve_stock BOOLEAN;
+  v_descripcion_regalo TEXT;
+  v_bonif RECORD;
+  v_promo RECORD;
+  v_usos_pendientes_actual INT;
+  v_bloques_completos INT;
+  v_ajustar_usos INT;
+  v_ajustar_stock INT;
+  v_stock_ajuste_anterior INT;
+  v_stock_ajuste_nuevo INT;
+  v_ajuste_producto_nombre TEXT;
+  v_merma_id BIGINT;
+  v_pedido_creator UUID;
+  v_pedido_created_at TIMESTAMPTZ;
+  v_tipo_factura TEXT;
+  v_hora_corte CONSTANT TIME := TIME '15:30';
+  v_precio_actual DECIMAL;
+  v_costo_actual DECIMAL; v_imp_int_actual DECIMAL; v_costo_al_crear DECIMAL;
+  v_costo_real_actual DECIMAL; v_pct_iva_actual DECIMAL;
+  v_costo_promedio_actual DECIMAL;
+BEGIN
+  IF v_sucursal IS NULL THEN
+    RETURN jsonb_build_object('success', false, 'errores', ARRAY['No se pudo determinar la sucursal activa']);
+  END IF;
+  IF p_usuario_id IS DISTINCT FROM auth.uid() THEN
+    RETURN jsonb_build_object('success', false, 'errores', ARRAY['ID de usuario no coincide con la sesion autenticada']);
+  END IF;
+  SELECT rol INTO v_user_role FROM perfiles WHERE id = p_usuario_id;
+  IF v_user_role IS NULL OR v_user_role NOT IN ('admin', 'encargado', 'preventista', 'preventista_taco') THEN
+    RETURN jsonb_build_object('success', false, 'errores', ARRAY['No autorizado']);
+  END IF;
+
+  SELECT total, usuario_id, created_at, COALESCE(tipo_factura, 'ZZ')
+    INTO v_total_anterior, v_pedido_creator, v_pedido_created_at, v_tipo_factura
+    FROM pedidos
+   WHERE id = p_pedido_id AND sucursal_id = v_sucursal;
+  IF NOT FOUND THEN
+    RETURN jsonb_build_object('success', false, 'errores', ARRAY['Pedido no encontrado']);
+  END IF;
+
+  IF EXISTS (SELECT 1 FROM pedidos WHERE id = p_pedido_id AND sucursal_id = v_sucursal AND estado = 'entregado') THEN
+    RETURN jsonb_build_object('success', false, 'errores', ARRAY['No se puede editar un pedido ya entregado']);
+  END IF;
+
+  IF v_user_role IN ('preventista', 'preventista_taco') THEN
+    IF v_pedido_creator IS DISTINCT FROM p_usuario_id THEN
+      RETURN jsonb_build_object('success', false, 'errores',
+        ARRAY['Solo el preventista que creo el pedido puede editarlo']);
+    END IF;
+
+    IF (v_pedido_created_at AT TIME ZONE 'America/Argentina/Buenos_Aires')::date
+         IS DISTINCT FROM (now() AT TIME ZONE 'America/Argentina/Buenos_Aires')::date
+       OR (now() AT TIME ZONE 'America/Argentina/Buenos_Aires')::time >= v_hora_corte
+    THEN
+      RETURN jsonb_build_object('success', false, 'errores',
+        ARRAY['Como preventista solo puede editar pedidos del dia actual antes de las 15:30 (ARG)']);
+    END IF;
+
+    FOR v_item_nuevo IN SELECT * FROM jsonb_array_elements(p_items_nuevos) LOOP
+      IF COALESCE((v_item_nuevo->>'es_bonificacion')::BOOLEAN, false) = true THEN
+        CONTINUE;
+      END IF;
+      v_producto_id := (v_item_nuevo->>'producto_id')::INT;
+      v_precio_unitario := (v_item_nuevo->>'precio_unitario')::DECIMAL;
+      SELECT precio INTO v_precio_actual
+        FROM productos WHERE id = v_producto_id AND sucursal_id = v_sucursal;
+      IF v_precio_actual IS NULL THEN
+        RETURN jsonb_build_object('success', false, 'errores',
+          ARRAY['Producto ID ' || v_producto_id || ' no encontrado']);
+      END IF;
+      IF v_precio_unitario IS NULL OR v_precio_unitario > v_precio_actual THEN
+        RETURN jsonb_build_object('success', false, 'errores',
+          ARRAY['Como preventista no puede aumentar precios (producto ID ' || v_producto_id || ')']);
+      END IF;
+    END LOOP;
+  END IF;
+
+  SELECT jsonb_agg(jsonb_build_object(
+    'producto_id', producto_id, 'cantidad', cantidad,
+    'precio_unitario', precio_unitario, 'es_bonificacion', COALESCE(es_bonificacion, false)))
+  INTO v_items_originales FROM pedido_items WHERE pedido_id = p_pedido_id AND sucursal_id = v_sucursal;
+
+  FOR v_item_nuevo IN SELECT * FROM jsonb_array_elements(p_items_nuevos) LOOP
+    v_producto_id := (v_item_nuevo->>'producto_id')::INT;
+    v_cantidad_nueva := (v_item_nuevo->>'cantidad')::INT;
+    v_es_bonificacion := COALESCE((v_item_nuevo->>'es_bonificacion')::BOOLEAN, false);
+    v_promocion_id := (v_item_nuevo->>'promocion_id')::BIGINT;
+
+    IF v_es_bonificacion THEN
+      IF v_promocion_id IS NULL THEN CONTINUE; END IF;
+      SELECT regalo_mueve_stock INTO v_regalo_mueve_stock FROM promociones WHERE id = v_promocion_id AND sucursal_id = v_sucursal;
+      IF NOT COALESCE(v_regalo_mueve_stock, FALSE) THEN CONTINUE; END IF;
+    END IF;
+
+    SELECT COALESCE(cantidad, 0) INTO v_cantidad_original
+    FROM pedido_items
+    WHERE pedido_id = p_pedido_id AND producto_id = v_producto_id
+      AND COALESCE(es_bonificacion, false) = v_es_bonificacion
+      AND sucursal_id = v_sucursal;
+
+    v_diferencia := v_cantidad_nueva - COALESCE(v_cantidad_original, 0);
+
+    IF v_diferencia > 0 THEN
+      SELECT stock, nombre INTO v_stock_actual, v_producto_nombre
+      FROM productos WHERE id = v_producto_id AND sucursal_id = v_sucursal FOR UPDATE;
+
+      IF v_stock_actual IS NULL THEN
+        v_errores := array_append(v_errores, 'Producto ID ' || v_producto_id || ' no encontrado');
+      ELSIF v_stock_actual < v_diferencia THEN
+        v_errores := array_append(v_errores, COALESCE(v_producto_nombre, 'Producto ' || v_producto_id)
+          || ': stock insuficiente (disponible: ' || v_stock_actual || ', adicional: ' || v_diferencia || ')');
+      END IF;
+    END IF;
+  END LOOP;
+
+  IF array_length(v_errores, 1) > 0 THEN
+    RETURN jsonb_build_object('success', false, 'errores', to_jsonb(v_errores));
+  END IF;
+
+  UPDATE productos p
+  SET stock = p.stock + pi.cantidad
+  FROM pedido_items pi
+  WHERE pi.pedido_id = p_pedido_id AND pi.sucursal_id = v_sucursal
+    AND COALESCE(pi.es_bonificacion, false) = false
+    AND p.id = pi.producto_id AND p.sucursal_id = v_sucursal;
+
+  UPDATE productos p
+  SET stock = p.stock + pi.cantidad
+  FROM pedido_items pi
+  JOIN promociones pr ON pr.id = pi.promocion_id AND pr.sucursal_id = pi.sucursal_id
+  WHERE pi.pedido_id = p_pedido_id AND pi.sucursal_id = v_sucursal
+    AND COALESCE(pi.es_bonificacion, false) = true
+    AND pi.promocion_id IS NOT NULL
+    AND COALESCE(pr.regalo_mueve_stock, FALSE) = TRUE
+    AND p.id = pi.producto_id AND p.sucursal_id = v_sucursal;
+
+  FOR v_bonif IN
+    SELECT promocion_id, SUM(cantidad)::INT AS total_cantidad
+      FROM pedido_items
+     WHERE pedido_id = p_pedido_id AND sucursal_id = v_sucursal
+       AND COALESCE(es_bonificacion, false) = true AND promocion_id IS NOT NULL
+     GROUP BY promocion_id
+  LOOP
+    PERFORM public.revertir_bloques_auto_ajuste(
+      v_bonif.promocion_id, v_bonif.total_cantidad, v_sucursal,
+      p_usuario_id, 'Edicion pedido #' || p_pedido_id
+    );
+  END LOOP;
+
+  DELETE FROM pedido_items WHERE pedido_id = p_pedido_id AND sucursal_id = v_sucursal;
+
+  FOR v_item_nuevo IN SELECT * FROM jsonb_array_elements(p_items_nuevos) LOOP
+    v_producto_id := (v_item_nuevo->>'producto_id')::INT;
+    v_cantidad_nueva := (v_item_nuevo->>'cantidad')::INT;
+    v_precio_unitario := (v_item_nuevo->>'precio_unitario')::DECIMAL;
+    v_es_bonificacion := COALESCE((v_item_nuevo->>'es_bonificacion')::BOOLEAN, false);
+    v_promocion_id := (v_item_nuevo->>'promocion_id')::BIGINT;
+
+    SELECT costo_promedio, costo_real, costo_sin_iva, COALESCE(impuestos_internos, 0), COALESCE(porcentaje_iva, 21)
+      INTO v_costo_promedio_actual, v_costo_real_actual, v_costo_actual, v_imp_int_actual, v_pct_iva_actual
+      FROM productos WHERE id = v_producto_id AND sucursal_id = v_sucursal;
+    -- CPP primero (mig 129)
+    v_costo_al_crear := COALESCE(v_costo_promedio_actual, v_costo_real_actual,
+      CASE WHEN v_costo_actual IS NULL THEN NULL
+           ELSE round(v_costo_actual * (1 + COALESCE(v_imp_int_actual, 0) / 100), 4) END);
+
+    -- Terna de ingresos SERVER-SIDE
+    IF v_es_bonificacion THEN
+      v_neto_unitario := 0; v_iva_unitario := 0; v_ingreso_real := 0; v_porcentaje_iva := 0;
+    ELSE
+      SELECT d.neto, d.iva, d.ingreso_real
+        INTO v_neto_unitario, v_iva_unitario, v_ingreso_real
+        FROM calcular_desglose_venta(v_precio_unitario, v_pct_iva_actual, v_imp_int_actual, v_tipo_factura) d;
+      v_porcentaje_iva := v_pct_iva_actual;
+    END IF;
+
+    v_descripcion_regalo := NULL;
+    IF v_es_bonificacion AND v_promocion_id IS NOT NULL THEN
+      SELECT descripcion_regalo INTO v_descripcion_regalo FROM promociones WHERE id = v_promocion_id AND sucursal_id = v_sucursal;
+    END IF;
+
+    INSERT INTO pedido_items (
+      pedido_id, producto_id, cantidad, precio_unitario, subtotal,
+      es_bonificacion, promocion_id,
+      neto_unitario, iva_unitario, impuestos_internos_unitario, porcentaje_iva,
+      ingreso_real_unitario,
+      sucursal_id, descripcion_regalo, costo_unitario_al_crear
+    ) VALUES (
+      p_pedido_id, v_producto_id, v_cantidad_nueva, v_precio_unitario,
+      v_cantidad_nueva * v_precio_unitario,
+      v_es_bonificacion, v_promocion_id,
+      v_neto_unitario, v_iva_unitario, 0, v_porcentaje_iva,
+      v_ingreso_real,
+      v_sucursal, v_descripcion_regalo, v_costo_al_crear
+    );
+
+    IF NOT v_es_bonificacion THEN
+      UPDATE productos SET stock = stock - v_cantidad_nueva WHERE id = v_producto_id AND sucursal_id = v_sucursal;
+      v_total_nuevo := v_total_nuevo + (v_cantidad_nueva * v_precio_unitario);
+      v_total_neto_nuevo := v_total_neto_nuevo + (v_cantidad_nueva * v_neto_unitario);
+      v_total_iva_nuevo := v_total_iva_nuevo + (v_cantidad_nueva * v_iva_unitario);
+      v_total_real_nuevo := v_total_real_nuevo + (v_cantidad_nueva * v_ingreso_real);
+    ELSIF v_promocion_id IS NOT NULL THEN
+      SELECT regalo_mueve_stock INTO v_regalo_mueve_stock FROM promociones WHERE id = v_promocion_id AND sucursal_id = v_sucursal;
+      IF COALESCE(v_regalo_mueve_stock, FALSE) THEN
+        UPDATE productos SET stock = stock - v_cantidad_nueva WHERE id = v_producto_id AND sucursal_id = v_sucursal;
+      END IF;
+      UPDATE promociones SET usos_pendientes = usos_pendientes + v_cantidad_nueva WHERE id = v_promocion_id AND sucursal_id = v_sucursal;
+
+      SELECT id, nombre, ajuste_automatico, ajuste_producto_id, unidades_por_bloque,
+             stock_por_bloque, usos_pendientes
+      INTO v_promo
+      FROM promociones WHERE id = v_promocion_id AND sucursal_id = v_sucursal FOR UPDATE;
+
+      IF v_promo.ajuste_automatico AND v_promo.ajuste_producto_id IS NOT NULL
+         AND COALESCE(v_promo.unidades_por_bloque, 0) > 0 AND COALESCE(v_promo.stock_por_bloque, 0) > 0 THEN
+        v_usos_pendientes_actual := v_promo.usos_pendientes;
+        v_bloques_completos := v_usos_pendientes_actual / v_promo.unidades_por_bloque;
+        IF v_bloques_completos > 0 THEN
+          v_ajustar_usos := v_bloques_completos * v_promo.unidades_por_bloque;
+          v_ajustar_stock := v_bloques_completos * v_promo.stock_por_bloque;
+
+          SELECT stock, nombre INTO v_stock_ajuste_anterior, v_ajuste_producto_nombre
+          FROM productos WHERE id = v_promo.ajuste_producto_id AND sucursal_id = v_sucursal FOR UPDATE;
+
+          IF v_stock_ajuste_anterior IS NULL THEN
+            RAISE EXCEPTION 'Auto-ajuste: producto destino no encontrado (promo %)', v_promocion_id;
+          END IF;
+          IF v_stock_ajuste_anterior < v_ajustar_stock THEN
+            RAISE EXCEPTION 'Auto-ajuste: stock insuficiente en % (disponible: %, requerido: %)',
+              v_ajuste_producto_nombre, v_stock_ajuste_anterior, v_ajustar_stock;
+          END IF;
+
+          v_stock_ajuste_nuevo := v_stock_ajuste_anterior - v_ajustar_stock;
+
+          INSERT INTO mermas_stock (producto_id, cantidad, motivo, observaciones, stock_anterior, stock_nuevo, usuario_id, sucursal_id)
+          VALUES (v_promo.ajuste_producto_id, v_ajustar_stock, 'promociones',
+            'Auto-ajuste (Promo: ' || v_promo.nombre || ', Pedido #' || p_pedido_id || ', edicion)',
+            v_stock_ajuste_anterior, v_stock_ajuste_nuevo, p_usuario_id, v_sucursal)
+          RETURNING id INTO v_merma_id;
+
+          UPDATE productos SET stock = v_stock_ajuste_nuevo, updated_at = NOW()
+          WHERE id = v_promo.ajuste_producto_id AND sucursal_id = v_sucursal;
+
+          INSERT INTO promo_ajustes (promocion_id, usos_ajustados, unidades_ajustadas, producto_id, merma_id, usuario_id, observaciones, sucursal_id)
+          VALUES (v_promocion_id, v_ajustar_usos, v_ajustar_stock, v_promo.ajuste_producto_id,
+            v_merma_id, p_usuario_id, 'Auto-ajuste por edicion pedido #' || p_pedido_id, v_sucursal);
+
+          UPDATE promociones SET usos_pendientes = GREATEST(usos_pendientes - v_ajustar_usos, 0)
+          WHERE id = v_promocion_id AND sucursal_id = v_sucursal;
+        END IF;
+      END IF;
+    END IF;
+  END LOOP;
+
+  UPDATE pedidos SET total = v_total_nuevo, total_neto = round(v_total_neto_nuevo, 2), total_iva = round(v_total_iva_nuevo, 2), total_real = round(v_total_real_nuevo, 2), updated_at = NOW()
+  WHERE id = p_pedido_id AND sucursal_id = v_sucursal;
+
+  INSERT INTO pedido_historial (pedido_id, usuario_id, campo_modificado, valor_anterior, valor_nuevo, sucursal_id)
+  VALUES (p_pedido_id, p_usuario_id, 'items', COALESCE(v_items_originales::TEXT, '[]'), p_items_nuevos::TEXT, v_sucursal);
+
+  IF v_total_anterior IS DISTINCT FROM v_total_nuevo THEN
+    INSERT INTO pedido_historial (pedido_id, usuario_id, campo_modificado, valor_anterior, valor_nuevo, sucursal_id)
+    VALUES (p_pedido_id, p_usuario_id, 'total', v_total_anterior::TEXT, v_total_nuevo::TEXT, v_sucursal);
+  END IF;
+
+  RETURN jsonb_build_object('success', true, 'total_nuevo', v_total_nuevo);
+END;
+$function$;
+
+-- ─── 4. anular_salvedad (reinserta el item con snapshot CPP) ────────────────
+
+CREATE OR REPLACE FUNCTION public.anular_salvedad(p_salvedad_id bigint, p_notas text DEFAULT NULL::text)
+RETURNS jsonb
+LANGUAGE plpgsql SECURITY DEFINER
+SET search_path TO 'public'
+AS $$
+DECLARE
+  v_sucursal BIGINT := current_sucursal_id();
+  v_salvedad RECORD;
+  v_usuario_id UUID := auth.uid();
+  v_tipo_factura TEXT;
+  v_pct_iva NUMERIC; v_pct_ii NUMERIC; v_costo_real NUMERIC; v_costo_sin NUMERIC;
+  v_costo_prom NUMERIC;
+  v_neto NUMERIC; v_iva NUMERIC; v_real NUMERIC;
+BEGIN
+  IF v_sucursal IS NULL THEN
+    RETURN jsonb_build_object('success', false, 'error', 'No se pudo determinar la sucursal activa');
+  END IF;
+  IF NOT es_admin_salvedades() THEN
+    RETURN jsonb_build_object('success', false, 'error', 'Solo admin');
+  END IF;
+  SELECT * INTO v_salvedad FROM salvedades_items WHERE id = p_salvedad_id AND sucursal_id = v_sucursal;
+  IF NOT FOUND THEN RETURN jsonb_build_object('success', false, 'error', 'No encontrada'); END IF;
+  IF v_salvedad.estado_resolucion = 'anulada' THEN
+    RETURN jsonb_build_object('success', false, 'error', 'Ya anulada');
+  END IF;
+  SELECT COALESCE(tipo_factura, 'ZZ') INTO v_tipo_factura
+    FROM pedidos WHERE id = v_salvedad.pedido_id AND sucursal_id = v_sucursal;
+  IF EXISTS (SELECT 1 FROM pedido_items WHERE id = v_salvedad.pedido_item_id AND sucursal_id = v_sucursal) THEN
+    UPDATE pedido_items SET
+      cantidad = v_salvedad.cantidad_original,
+      subtotal = v_salvedad.cantidad_original * v_salvedad.precio_unitario
+    WHERE id = v_salvedad.pedido_item_id AND sucursal_id = v_sucursal;
+  ELSE
+    -- Reinsertar con la terna de ingresos y costo snapshot (CPP primero, mig 129)
+    SELECT COALESCE(porcentaje_iva, 21), COALESCE(impuestos_internos, 0), costo_promedio, costo_real, costo_sin_iva
+      INTO v_pct_iva, v_pct_ii, v_costo_prom, v_costo_real, v_costo_sin
+      FROM productos WHERE id = v_salvedad.producto_id AND sucursal_id = v_sucursal;
+    SELECT d.neto, d.iva, d.ingreso_real INTO v_neto, v_iva, v_real
+      FROM calcular_desglose_venta(v_salvedad.precio_unitario, v_pct_iva, v_pct_ii, v_tipo_factura) d;
+
+    INSERT INTO pedido_items (
+      pedido_id, producto_id, cantidad, precio_unitario, subtotal, sucursal_id,
+      neto_unitario, iva_unitario, impuestos_internos_unitario, porcentaje_iva,
+      ingreso_real_unitario, costo_unitario_al_crear
+    )
+    VALUES (
+      v_salvedad.pedido_id, v_salvedad.producto_id, v_salvedad.cantidad_original,
+      v_salvedad.precio_unitario, v_salvedad.cantidad_original * v_salvedad.precio_unitario, v_sucursal,
+      v_neto, v_iva, 0, v_pct_iva,
+      v_real,
+      COALESCE(v_costo_prom, v_costo_real,
+        CASE WHEN v_costo_sin IS NULL THEN NULL ELSE round(v_costo_sin * (1 + v_pct_ii / 100), 4) END)
+    );
+  END IF;
+  UPDATE pedidos SET
+    total = (SELECT COALESCE(SUM(subtotal), 0) FROM pedido_items WHERE pedido_id = v_salvedad.pedido_id AND sucursal_id = v_sucursal),
+    total_neto = (SELECT COALESCE(SUM(CASE WHEN NOT COALESCE(es_bonificacion, false) THEN cantidad * COALESCE(neto_unitario, precio_unitario) ELSE 0 END), 0)
+                    FROM pedido_items WHERE pedido_id = v_salvedad.pedido_id AND sucursal_id = v_sucursal),
+    total_iva = (SELECT COALESCE(SUM(CASE WHEN NOT COALESCE(es_bonificacion, false) THEN cantidad * COALESCE(iva_unitario, 0) ELSE 0 END), 0)
+                   FROM pedido_items WHERE pedido_id = v_salvedad.pedido_id AND sucursal_id = v_sucursal),
+    total_real = (SELECT COALESCE(SUM(CASE WHEN NOT COALESCE(es_bonificacion, false)
+                          THEN cantidad * COALESCE(ingreso_real_unitario,
+                               CASE WHEN v_tipo_factura = 'FC' THEN COALESCE(neto_unitario, precio_unitario) ELSE precio_unitario END)
+                          ELSE 0 END), 0)
+                    FROM pedido_items WHERE pedido_id = v_salvedad.pedido_id AND sucursal_id = v_sucursal),
+    updated_at = NOW()
+  WHERE id = v_salvedad.pedido_id AND sucursal_id = v_sucursal;
+  IF v_salvedad.stock_devuelto THEN
+    UPDATE productos SET stock = stock - v_salvedad.cantidad_afectada
+     WHERE id = v_salvedad.producto_id AND sucursal_id = v_sucursal;
+  END IF;
+  UPDATE salvedades_items SET
+    estado_resolucion = 'anulada',
+    resolucion_notas = p_notas,
+    resolucion_fecha = NOW(),
+    resuelto_por = v_usuario_id,
+    updated_at = NOW()
+  WHERE id = p_salvedad_id AND sucursal_id = v_sucursal;
+  INSERT INTO salvedad_historial (salvedad_id, accion, estado_anterior, estado_nuevo, notas, usuario_id, sucursal_id)
+  VALUES (p_salvedad_id, 'anulacion', v_salvedad.estado_resolucion, 'anulada', p_notas, v_usuario_id, v_sucursal);
+  RETURN jsonb_build_object('success', true);
+END;
+$$;
+
+-- ─── 5. mermas_stock_snapshot_costo (trigger BEFORE INSERT) ─────────────────
+
+CREATE OR REPLACE FUNCTION public.mermas_stock_snapshot_costo()
+RETURNS trigger
+LANGUAGE plpgsql
+SET search_path TO 'public'
+AS $$
+BEGIN
+  IF NEW.costo_unitario IS NULL THEN
+    -- CPP primero (mig 129): la merma se valúa a lo que costó el stock
+    SELECT COALESCE(costo_promedio, costo_real,
+                    round(costo_sin_iva * (1 + COALESCE(impuestos_internos, 0) / 100), 4))
+      INTO NEW.costo_unitario
+      FROM productos
+     WHERE id = NEW.producto_id AND sucursal_id = NEW.sucursal_id;
+  END IF;
+  RETURN NEW;
+END;
+$$;
+
+COMMENT ON COLUMN public.mermas_stock.costo_unitario IS
+  'Costo por unidad congelado al registrar la merma: COALESCE(costo_promedio, costo_real, fallback) desde mig 129 (antes costo_real). NULL = fila previa a mig 119 → el reporte cae al costo vivo.';

--- a/migrations/130_reporte_gerencial_cpp.sql
+++ b/migrations/130_reporte_gerencial_cpp.sql
@@ -1,0 +1,324 @@
+-- ============================================================================
+-- 130 · reporte_gerencial: fallback de costo con COSTO PROMEDIO (CPP, mig 127)
+-- ============================================================================
+-- Texto base = mig 124 (misma firma de 5 args ⇒ CREATE OR REPLACE). Diff = SOLO
+-- las 6 cascadas de valuación de costo:
+--   · pedidos: COALESCE(pi.costo_unitario_al_crear, prod.costo_promedio,
+--              prod.costo_real, fallback)   (antes sin costo_promedio)
+--   · mermas:  COALESCE(m.costo_unitario, prod.costo_promedio, prod.costo_real,
+--              fallback)
+-- Los pedidos/mermas post-mig-129 ya traen el snapshot congelado desde el CPP;
+-- esta cascada solo afecta filas históricas SIN snapshot (pre migs 100/119).
+-- El CMV de meses cerrados con snapshot NO cambia.
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION public.reporte_gerencial(
+  p_sucursal_id bigint,
+  p_desde date,
+  p_hasta date,
+  p_incluir_no_entregados boolean DEFAULT false,
+  p_comparar boolean DEFAULT false
+)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ STABLE SECURITY DEFINER
+ SET search_path TO 'public'
+AS $function$
+DECLARE
+  v_sucursales bigint[]; v_asignadas bigint[]; v_nombre text; v_result jsonb;
+  v_es_servicio boolean := (auth.uid() IS NULL);
+  v_estados text[] := CASE WHEN p_incluir_no_entregados
+                           THEN ARRAY['entregado','asignado','pendiente','en_preparacion']
+                           ELSE ARRAY['entregado'] END;
+  v_dias int := (p_hasta - p_desde) + 1;
+  v_prev_hasta date := p_desde - 1;
+  v_prev_desde date := (p_desde - 1) - ((p_hasta - p_desde));
+  v_comparativo jsonb := NULL;
+  v_prev jsonb;
+  v_alertas jsonb := '[]'::jsonb;
+  v_cat_neg int;
+  v_cli_inact int;
+  v_cob_venc numeric;
+  v_cob_venc_cli int;
+  v_venta numeric;
+  v_prev_venta numeric;
+  v_mermas numeric;
+  v_prev_mermas numeric;
+BEGIN
+  IF NOT v_es_servicio THEN
+    IF NOT EXISTS (SELECT 1 FROM perfiles WHERE id = auth.uid() AND rol = 'admin') THEN
+      RAISE EXCEPTION 'Acceso denegado: se requiere rol admin'; END IF;
+    SELECT array_agg(sucursal_id) INTO v_asignadas FROM usuario_sucursales WHERE usuario_id = auth.uid();
+    IF v_asignadas IS NULL THEN RAISE EXCEPTION 'Acceso denegado: el usuario no tiene sucursales asignadas'; END IF;
+  END IF;
+  IF p_sucursal_id IS NULL THEN
+    SELECT array_agg(id) INTO v_sucursales FROM sucursales WHERE activa;
+    IF NOT v_es_servicio THEN
+      SELECT array_agg(s) INTO v_sucursales FROM unnest(v_sucursales) AS s WHERE s = ANY(v_asignadas); END IF;
+    v_nombre := 'Red (consolidado)';
+  ELSE
+    IF NOT v_es_servicio AND NOT (p_sucursal_id = ANY(v_asignadas)) THEN
+      RAISE EXCEPTION 'Acceso denegado: la sucursal % no está asignada al usuario', p_sucursal_id; END IF;
+    v_sucursales := ARRAY[p_sucursal_id];
+    SELECT nombre INTO v_nombre FROM sucursales WHERE id = p_sucursal_id;
+  END IF;
+  IF v_sucursales IS NULL OR array_length(v_sucursales,1) IS NULL THEN
+    RAISE EXCEPTION 'Acceso denegado: sin sucursales disponibles para el usuario'; END IF;
+
+  WITH
+  ped AS (
+    SELECT id, cliente_id, usuario_id, total, monto_pagado, fecha, forma_pago, estado_pago,
+           COALESCE(total_neto, total) AS total_neto, COALESCE(total_iva, 0) AS total_iva,
+           COALESCE(tipo_factura, 'ZZ') AS tipo_factura,
+           COALESCE(total_real,
+             CASE WHEN COALESCE(tipo_factura, 'ZZ') = 'FC' THEN COALESCE(total_neto, total) ELSE total END
+           ) AS total_real
+    FROM pedidos WHERE estado = ANY(v_estados) AND canal='app'
+      AND fecha BETWEEN p_desde AND p_hasta AND sucursal_id = ANY(v_sucursales)
+  ),
+  it AS (
+    SELECT p.id AS pedido_id, p.usuario_id, p.fecha,
+           pi.cantidad, pi.subtotal, pi.es_bonificacion,
+           COALESCE(pi.costo_unitario_al_crear, prod.costo_promedio, prod.costo_real, prod.costo_sin_iva*(1+COALESCE(prod.impuestos_internos,0)/100)) AS costo_unit,
+           pi.cantidad * COALESCE(pi.ingreso_real_unitario,
+             CASE WHEN p.tipo_factura = 'FC' THEN COALESCE(pi.neto_unitario, pi.precio_unitario)
+                  ELSE pi.precio_unitario END) AS ingreso_real,
+           prod.nombre AS prod_nombre,
+           COALESCE(NULLIF(prod.categoria,''),'(sin categoría)') AS categoria,
+           (prod.costo_sin_iva IS NULL OR prod.costo_sin_iva = 0) AS sin_costo,
+           pr.nombre AS promo_nombre,
+           (pr.regalo_mueve_stock IS FALSE AND COALESCE(pr.unidades_por_bloque,0) > 0) AS es_fraccion,
+           pr.unidades_por_bloque,
+           COALESCE(prod.precio,0) AS precio_lista,
+           CASE WHEN pi.es_bonificacion THEN
+             CASE WHEN pr.regalo_mueve_stock IS FALSE AND pr.unidades_por_bloque > 0
+                  THEN pi.cantidad * COALESCE(pi.costo_unitario_al_crear, prod.costo_promedio, prod.costo_real, prod.costo_sin_iva*(1+COALESCE(prod.impuestos_internos,0)/100)) / pr.unidades_por_bloque
+                  ELSE pi.cantidad * COALESCE(pi.costo_unitario_al_crear, prod.costo_promedio, prod.costo_real, prod.costo_sin_iva*(1+COALESCE(prod.impuestos_internos,0)/100)) END
+           ELSE 0 END AS costo_bonif
+    FROM ped p
+    JOIN pedido_items pi ON pi.pedido_id = p.id
+    JOIN productos prod ON prod.id = pi.producto_id
+    LEFT JOIN promociones pr ON pr.id = pi.promocion_id
+  ),
+  nc AS (
+    SELECT usuario_id, total FROM pedidos
+    WHERE estado<>'cancelado' AND canal='app'
+      AND fecha BETWEEN p_desde AND p_hasta AND sucursal_id = ANY(v_sucursales)
+      AND usuario_id IN (SELECT id FROM perfiles)
+  ),
+  k_ped AS (SELECT COUNT(*) AS pedidos, COALESCE(SUM(total),0) AS venta,
+            COUNT(DISTINCT cliente_id) AS clientes, COALESCE(ROUND(AVG(total)),0) AS ticket,
+            COALESCE(SUM(total_neto),0) AS venta_neta,
+            COALESCE(SUM(total_iva),0) AS iva_debito,
+            COALESCE(SUM(total_real),0) AS venta_real,
+            COALESCE(SUM(total) FILTER (WHERE tipo_factura='FC'),0) AS fc_venta,
+            COUNT(*) FILTER (WHERE tipo_factura='FC') AS fc_pedidos,
+            COALESCE(SUM(total) FILTER (WHERE tipo_factura='ZZ'),0) AS zz_venta,
+            COUNT(*) FILTER (WHERE tipo_factura='ZZ') AS zz_pedidos
+            FROM ped),
+  k_it AS (
+    SELECT COALESCE(SUM(cantidad*costo_unit) FILTER (WHERE NOT es_bonificacion),0) AS cmv,
+      COALESCE(SUM(costo_bonif),0) AS bonif,
+      COALESCE(SUM(cantidad) FILTER (WHERE NOT es_bonificacion),0) AS unidades,
+      COALESCE(SUM(cantidad) FILTER (WHERE es_bonificacion),0) AS unidades_bonif,
+      COALESCE(SUM(subtotal) FILTER (WHERE sin_costo AND NOT es_bonificacion),0) AS ingreso_sin_costo
+    FROM it
+  ),
+  k_nc AS (SELECT COALESCE(SUM(total),0) AS base_comision FROM nc),
+  k_merma AS (
+    SELECT COALESCE(SUM(costo),0) AS mermas,
+      COALESCE(SUM(costo) FILTER (WHERE clasif = 'perdida'),0) AS mermas_perdida,
+      COALESCE(SUM(costo) FILTER (WHERE clasif = 'ajuste'),0) AS mermas_ajuste,
+      COALESCE(SUM(costo) FILTER (WHERE clasif = 'muestra'),0) AS mermas_muestra
+    FROM (
+      SELECT m.cantidad*COALESCE(m.costo_unitario, prod.costo_promedio, prod.costo_real, prod.costo_sin_iva*(1+COALESCE(prod.impuestos_internos,0)/100)) AS costo,
+             CASE WHEN m.motivo IN ('vencimiento','rotura','robo','decomiso','devolucion') THEN 'perdida'
+                  WHEN m.motivo = 'muestra' THEN 'muestra'
+                  ELSE 'ajuste' END AS clasif
+      FROM mermas_stock m JOIN productos prod ON prod.id = m.producto_id
+      WHERE m.sucursal_id = ANY(v_sucursales)
+        AND (m.created_at AT TIME ZONE 'America/Argentina/Buenos_Aires')::date BETWEEN p_desde AND p_hasta
+        AND COALESCE(m.motivo,'') NOT IN ('promociones','promociones_reversion')
+    ) t
+  ),
+  k_compra AS (SELECT COALESCE(SUM(total),0) AS compras FROM compras
+    WHERE sucursal_id = ANY(v_sucursales) AND fecha_compra BETWEEN p_desde AND p_hasta
+      AND COALESCE(estado,'') <> 'cancelada'),
+  k_nuevos AS (SELECT COUNT(*) AS nuevos FROM (
+      SELECT cliente_id, MIN(fecha) AS pc FROM pedidos
+      WHERE estado='entregado' AND sucursal_id = ANY(v_sucursales) GROUP BY cliente_id
+    ) t WHERE pc BETWEEN p_desde AND p_hasta),
+  m_ped AS (SELECT to_char(fecha,'YYYY-MM') AS mes, COUNT(*) AS pedidos, SUM(total) AS venta,
+            SUM(total_real) AS venta_real,
+            COUNT(DISTINCT cliente_id) AS clientes, ROUND(AVG(total)) AS ticket FROM ped GROUP BY 1),
+  m_it AS (SELECT to_char(fecha,'YYYY-MM') AS mes,
+           COALESCE(SUM(cantidad*costo_unit) FILTER (WHERE NOT es_bonificacion),0) AS cmv,
+           COALESCE(SUM(costo_bonif),0) AS bonif FROM it GROUP BY 1),
+  m_merma AS (SELECT to_char(m.created_at AT TIME ZONE 'America/Argentina/Buenos_Aires','YYYY-MM') AS mes,
+       SUM(m.cantidad*COALESCE(m.costo_unitario, prod.costo_promedio, prod.costo_real, prod.costo_sin_iva*(1+COALESCE(prod.impuestos_internos,0)/100))) AS mermas
+    FROM mermas_stock m JOIN productos prod ON prod.id = m.producto_id
+    WHERE m.sucursal_id = ANY(v_sucursales)
+      AND (m.created_at AT TIME ZONE 'America/Argentina/Buenos_Aires')::date BETWEEN p_desde AND p_hasta
+      AND COALESCE(m.motivo,'') NOT IN ('promociones','promociones_reversion') GROUP BY 1),
+  m_compra AS (SELECT to_char(fecha_compra,'YYYY-MM') AS mes, SUM(total) AS compras
+    FROM compras WHERE sucursal_id = ANY(v_sucursales) AND fecha_compra BETWEEN p_desde AND p_hasta
+      AND COALESCE(estado,'') <> 'cancelada' GROUP BY 1),
+  mensual AS (SELECT mp.mes, mp.pedidos, mp.venta, mp.venta_real, mp.clientes, mp.ticket,
+      COALESCE(mi.cmv,0) AS cmv, COALESCE(mi.bonif,0) AS bonif,
+      (mp.venta_real - COALESCE(mi.cmv,0)) AS margen_real,
+      COALESCE(mm.mermas,0) AS mermas, COALESCE(mc.compras,0) AS compras
+    FROM m_ped mp LEFT JOIN m_it mi ON mi.mes=mp.mes LEFT JOIN m_merma mm ON mm.mes=mp.mes LEFT JOIN m_compra mc ON mc.mes=mp.mes),
+  v_ent AS (SELECT usuario_id, COUNT(DISTINCT pedido_id) AS pedidos, SUM(subtotal) AS venta,
+      SUM(ingreso_real) AS venta_real,
+      SUM(subtotal) - COALESCE(SUM(cantidad*costo_unit) FILTER (WHERE NOT es_bonificacion),0) AS margen_comercial,
+      SUM(ingreso_real) - COALESCE(SUM(cantidad*costo_unit) FILTER (WHERE NOT es_bonificacion),0) AS margen_real,
+      COALESCE(SUM(costo_bonif),0) AS bonif FROM it GROUP BY usuario_id),
+  v_nc AS (SELECT usuario_id, SUM(total) AS base_nc FROM nc GROUP BY usuario_id),
+  vendedores AS (SELECT pf.nombre, pf.rol, e.pedidos, e.venta, e.venta_real, e.margen_comercial, e.margen_real, e.bonif,
+      COALESCE(n.base_nc, e.venta) AS base_nc
+    FROM v_ent e JOIN perfiles pf ON pf.id=e.usuario_id LEFT JOIN v_nc n ON n.usuario_id=e.usuario_id),
+  categorias AS (SELECT categoria, SUM(subtotal) AS venta,
+      SUM(ingreso_real) AS venta_real,
+      SUM(subtotal) - COALESCE(SUM(cantidad*costo_unit) FILTER (WHERE NOT es_bonificacion),0) AS margen_comercial,
+      SUM(ingreso_real) - COALESCE(SUM(cantidad*costo_unit) FILTER (WHERE NOT es_bonificacion),0) AS margen_real,
+      COALESCE(SUM(costo_bonif),0) AS bonif, bool_or(sin_costo) AS sin_costo
+    FROM it GROUP BY categoria),
+  top_prod AS (SELECT prod_nombre AS nombre,
+      COALESCE(SUM(cantidad) FILTER (WHERE NOT es_bonificacion),0) AS unidades, SUM(subtotal) AS venta,
+      SUM(ingreso_real) AS venta_real,
+      SUM(subtotal) - COALESCE(SUM(cantidad*costo_unit) FILTER (WHERE NOT es_bonificacion),0) AS margen,
+      SUM(ingreso_real) - COALESCE(SUM(cantidad*costo_unit) FILTER (WHERE NOT es_bonificacion),0) AS margen_real
+    FROM it GROUP BY prod_nombre ORDER BY venta DESC LIMIT 10),
+  top_cli AS (SELECT COALESCE(NULLIF(c.nombre_fantasia,''), c.razon_social) AS cliente,
+      COUNT(DISTINCT p.id) AS pedidos, SUM(p.total) AS venta
+    FROM ped p JOIN clientes c ON c.id=p.cliente_id GROUP BY 1 ORDER BY venta DESC LIMIT 10),
+  bonif_promos AS (SELECT COALESCE(promo_nombre,'(sin promoción)') AS promocion, prod_nombre AS producto,
+      SUM(cantidad) AS unidades, bool_or(es_fraccion) AS es_fraccion,
+      SUM(costo_bonif) AS costo,
+      SUM(CASE WHEN es_fraccion THEN cantidad * precio_lista / unidades_por_bloque
+               ELSE cantidad * precio_lista END) AS valor_venta
+    FROM it WHERE es_bonificacion GROUP BY 1, 2 HAVING SUM(cantidad) > 0),
+  mermas_motivo AS (SELECT COALESCE(NULLIF(m.motivo,''),'(sin motivo)') AS motivo,
+      CASE WHEN m.motivo IN ('vencimiento','rotura','robo','decomiso','devolucion') THEN 'perdida'
+           WHEN m.motivo = 'muestra' THEN 'muestra'
+           ELSE 'ajuste' END AS clasificacion,
+      SUM(m.cantidad) AS unidades,
+      SUM(m.cantidad*COALESCE(m.costo_unitario, prod.costo_promedio, prod.costo_real, prod.costo_sin_iva*(1+COALESCE(prod.impuestos_internos,0)/100))) AS costo
+    FROM mermas_stock m JOIN productos prod ON prod.id=m.producto_id
+    WHERE m.sucursal_id = ANY(v_sucursales)
+      AND (m.created_at AT TIME ZONE 'America/Argentina/Buenos_Aires')::date BETWEEN p_desde AND p_hasta
+      AND COALESCE(m.motivo,'') NOT IN ('promociones','promociones_reversion') GROUP BY 1, 2),
+  cobr AS (SELECT COALESCE(SUM(LEAST(COALESCE(monto_pagado,0), total)),0) AS cobrado,
+      COALESCE(SUM(GREATEST(total - COALESCE(monto_pagado,0), 0)),0) AS pendiente FROM ped),
+  pagos_ped AS (SELECT COALESCE(NULLIF(pg.forma_pago,''),'(sin dato)') AS forma_pago, SUM(pg.monto) AS monto
+    FROM pagos pg JOIN ped ON ped.id = pg.pedido_id GROUP BY 1),
+  formas AS (SELECT forma_pago, monto FROM pagos_ped
+    UNION ALL
+    SELECT '(sin registro de pago)', c.cobrado - COALESCE((SELECT SUM(monto) FROM pagos_ped),0)
+    FROM cobr c
+    WHERE c.cobrado - COALESCE((SELECT SUM(monto) FROM pagos_ped),0) > 0.01),
+  serie AS (SELECT to_char(fecha,'DD/MM') AS dia, SUM(total) AS venta FROM ped GROUP BY fecha ORDER BY fecha)
+  SELECT jsonb_build_object(
+    'meta', jsonb_build_object('sucursal_id', p_sucursal_id, 'sucursal_nombre', COALESCE(v_nombre,'?'),
+      'desde', p_desde, 'hasta', p_hasta, 'generado_at', now(),
+      'incluye_no_entregados', p_incluir_no_entregados),
+    'kpis', (SELECT jsonb_build_object('venta', kp.venta, 'pedidos', kp.pedidos, 'clientes', kp.clientes, 'ticket', kp.ticket,
+        'clientes_nuevos', kn.nuevos, 'cmv', ki.cmv, 'bonif', ki.bonif, 'unidades', ki.unidades,
+        'unidades_bonif', ki.unidades_bonif, 'margen_comercial', kp.venta - ki.cmv,
+        'margen_neto', kp.venta - ki.cmv - ki.bonif, 'base_comision', kc.base_comision, 'comision_pct_default', 2,
+        'mermas', km.mermas, 'mermas_perdida', km.mermas_perdida, 'mermas_ajuste', km.mermas_ajuste,
+        'mermas_muestra', km.mermas_muestra, 'compras', kcp.compras, 'ingreso_sin_costo', ki.ingreso_sin_costo,
+        'venta_neta', kp.venta_neta, 'iva_debito', kp.iva_debito,
+        'margen_comercial_neto', kp.venta_neta - ki.cmv,
+        'venta_real', kp.venta_real,
+        'margen_real', kp.venta_real - ki.cmv,
+        'margen_real_neto', kp.venta_real - ki.cmv - ki.bonif,
+        'fc_venta', kp.fc_venta, 'fc_pedidos', kp.fc_pedidos,
+        'zz_venta', kp.zz_venta, 'zz_pedidos', kp.zz_pedidos)
+      FROM k_ped kp, k_it ki, k_nc kc, k_merma km, k_compra kcp, k_nuevos kn),
+    'mensual', (SELECT COALESCE(jsonb_agg(to_jsonb(m) ORDER BY m.mes),'[]') FROM mensual m),
+    'vendedores', (SELECT COALESCE(jsonb_agg(to_jsonb(v) ORDER BY v.venta DESC),'[]') FROM vendedores v),
+    'categorias', (SELECT COALESCE(jsonb_agg(to_jsonb(c) ORDER BY c.venta DESC),'[]') FROM categorias c),
+    'top_productos', (SELECT COALESCE(jsonb_agg(to_jsonb(t)),'[]') FROM top_prod t),
+    'top_clientes', (SELECT COALESCE(jsonb_agg(to_jsonb(t)),'[]') FROM top_cli t),
+    'bonif_promos', (SELECT COALESCE(jsonb_agg(to_jsonb(b) ORDER BY b.valor_venta DESC),'[]') FROM bonif_promos b),
+    'mermas_motivo', (SELECT COALESCE(jsonb_agg(to_jsonb(mm) ORDER BY mm.costo DESC),'[]') FROM mermas_motivo mm),
+    'cobranza', jsonb_build_object('formas', (SELECT COALESCE(jsonb_agg(to_jsonb(f) ORDER BY f.monto DESC),'[]') FROM formas f),
+      'cobrado', (SELECT cobrado FROM cobr), 'pendiente', (SELECT pendiente FROM cobr)),
+    'serie_diaria', (SELECT COALESCE(jsonb_agg(jsonb_build_array(s.dia, s.venta)),'[]') FROM serie s),
+    'flags', (SELECT jsonb_build_object('ingreso_sin_costo', ki.ingreso_sin_costo,
+        'pct_sin_costo', CASE WHEN kp.venta > 0 THEN round(100.0*ki.ingreso_sin_costo/kp.venta,1) ELSE 0 END)
+      FROM k_it ki, k_ped kp)
+  ) INTO v_result;
+
+  IF p_comparar THEN
+    v_prev := public.reporte_gerencial(p_sucursal_id, v_prev_desde, v_prev_hasta, p_incluir_no_entregados, false);
+    v_comparativo := (v_prev->'kpis') || jsonb_build_object('desde', v_prev_desde, 'hasta', v_prev_hasta);
+  END IF;
+
+  v_venta := (v_result->'kpis'->>'venta')::numeric;
+  v_mermas := (v_result->'kpis'->>'mermas')::numeric;
+  v_prev_venta := (v_comparativo->>'venta')::numeric;
+  v_prev_mermas := (v_comparativo->>'mermas')::numeric;
+
+  IF p_comparar AND COALESCE(v_prev_venta,0) > 0 AND v_venta < v_prev_venta * 0.9 THEN
+    v_alertas := v_alertas || jsonb_build_object(
+      'severidad', CASE WHEN v_venta < v_prev_venta*0.8 THEN 'critical' ELSE 'warning' END,
+      'codigo','venta_caida','titulo','Venta en baja',
+      'detalle','Cayó '||round((1 - v_venta/v_prev_venta)*100)::text||'% vs período anterior',
+      'valor', v_venta - v_prev_venta, 'seccion','evolucion');
+  END IF;
+
+  SELECT COALESCE(SUM(total - COALESCE(monto_pagado,0)),0), COUNT(DISTINCT cliente_id)
+    INTO v_cob_venc, v_cob_venc_cli
+  FROM pedidos
+  WHERE estado='entregado' AND canal='app' AND sucursal_id = ANY(v_sucursales)
+    AND COALESCE(estado_pago,'pendiente') IN ('pendiente','parcial')
+    AND fecha < CURRENT_DATE - 30 AND total > COALESCE(monto_pagado,0);
+  IF v_cob_venc > 0 THEN
+    v_alertas := v_alertas || jsonb_build_object('severidad','critical','codigo','cobranza_vencida','titulo','Cobranza vencida',
+      'detalle', v_cob_venc_cli::text||' cliente(s) con saldo impago hace +30 días',
+      'valor', v_cob_venc, 'seccion','cobranza');
+  END IF;
+
+  SELECT COUNT(*) INTO v_cli_inact FROM (
+    SELECT p.cliente_id FROM pedidos p
+    WHERE p.estado='entregado' AND p.canal='app' AND p.sucursal_id = ANY(v_sucursales)
+    GROUP BY p.cliente_id
+    HAVING MAX(p.fecha) < CURRENT_DATE - 30 AND MAX(p.fecha) >= CURRENT_DATE - 90
+  ) t;
+  IF v_cli_inact > 0 THEN
+    v_alertas := v_alertas || jsonb_build_object('severidad','warning','codigo','clientes_inactivos','titulo','Clientes que dejaron de comprar',
+      'detalle', v_cli_inact::text||' cliente(s) sin comprar hace +30 días (compraban hasta hace poco)',
+      'valor', v_cli_inact, 'seccion','clientes');
+  END IF;
+
+  IF p_comparar AND COALESCE(v_prev_mermas,0) > 0 AND v_mermas > v_prev_mermas*1.3 AND v_mermas > 50000 THEN
+    v_alertas := v_alertas || jsonb_build_object('severidad','warning','codigo','mermas_alza','titulo','Mermas en alza',
+      'detalle','Subieron '||round((v_mermas/v_prev_mermas - 1)*100)::text||'% vs período anterior',
+      'valor', v_mermas, 'seccion','mermas');
+  END IF;
+
+  SELECT COUNT(*) INTO v_cat_neg FROM jsonb_array_elements(v_result->'categorias') c WHERE (c->>'margen_comercial')::numeric < 0;
+  IF v_cat_neg > 0 THEN
+    v_alertas := v_alertas || jsonb_build_object('severidad','warning','codigo','margen_categoria_negativo','titulo','Categorías con margen negativo',
+      'detalle', v_cat_neg::text||' categoría(s) con margen comercial negativo',
+      'valor', v_cat_neg, 'seccion','categorias');
+  END IF;
+
+  IF (v_result->'flags'->>'pct_sin_costo')::numeric >= 1 THEN
+    v_alertas := v_alertas || jsonb_build_object('severidad','info','codigo','productos_sin_costo','titulo','Productos sin costo',
+      'detalle', (v_result->'flags'->>'pct_sin_costo')::text||'% de la venta es de productos sin costo (margen sobreestimado)',
+      'valor', (v_result->'flags'->>'ingreso_sin_costo')::numeric, 'seccion','categorias');
+  END IF;
+
+  SELECT COALESCE(jsonb_agg(a ORDER BY array_position(ARRAY['critical','warning','info'], a->>'severidad')), '[]'::jsonb)
+    INTO v_alertas FROM jsonb_array_elements(v_alertas) a;
+
+  v_result := v_result || jsonb_build_object('comparativo', COALESCE(v_comparativo,'null'::jsonb), 'alertas', v_alertas);
+  RETURN v_result;
+END;
+$function$;
+
+REVOKE EXECUTE ON FUNCTION public.reporte_gerencial(bigint, date, date, boolean, boolean) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.reporte_gerencial(bigint, date, date, boolean, boolean) TO authenticated, service_role;

--- a/migrations/131_reporte_valuacion_inventario.sql
+++ b/migrations/131_reporte_valuacion_inventario.sql
@@ -1,0 +1,138 @@
+-- ============================================================================
+-- 131 · reporte_valuacion_inventario: stock valuado a costo promedio (CPP)
+-- ============================================================================
+-- Nuevo RPC. Devuelve el inventario valuado a costo promedio (mig 127) con
+-- columna comparativa a costo de reposición (costo_real):
+--   · productos: stock, cpp, reposición, valuacion_promedio, valuacion_reposicion
+--   · agregados por categoría y por sucursal + totales generales
+--   · calidad de datos: productos con stock negativo y con costo nulo
+-- Permisos: admin y encargado, limitados a sus sucursales asignadas (mismo
+-- patrón que reporte_gerencial; service_role sin restricción).
+-- p_sucursal_id NULL ⇒ consolidado de las sucursales activas visibles.
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION public.reporte_valuacion_inventario(
+  p_sucursal_id bigint DEFAULT NULL
+)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ STABLE SECURITY DEFINER
+ SET search_path TO 'public'
+AS $function$
+DECLARE
+  v_sucursales bigint[]; v_asignadas bigint[]; v_nombre text; v_result jsonb;
+  v_es_servicio boolean := (auth.uid() IS NULL);
+  v_rol text;
+BEGIN
+  IF NOT v_es_servicio THEN
+    SELECT rol INTO v_rol FROM perfiles WHERE id = auth.uid();
+    IF v_rol IS NULL OR v_rol NOT IN ('admin', 'encargado') THEN
+      RAISE EXCEPTION 'Acceso denegado: se requiere rol admin o encargado'; END IF;
+    SELECT array_agg(sucursal_id) INTO v_asignadas FROM usuario_sucursales WHERE usuario_id = auth.uid();
+    IF v_asignadas IS NULL THEN RAISE EXCEPTION 'Acceso denegado: el usuario no tiene sucursales asignadas'; END IF;
+  END IF;
+  IF p_sucursal_id IS NULL THEN
+    SELECT array_agg(id) INTO v_sucursales FROM sucursales WHERE activa;
+    IF NOT v_es_servicio THEN
+      SELECT array_agg(s) INTO v_sucursales FROM unnest(v_sucursales) AS s WHERE s = ANY(v_asignadas); END IF;
+    v_nombre := 'Red (consolidado)';
+  ELSE
+    IF NOT v_es_servicio AND NOT (p_sucursal_id = ANY(v_asignadas)) THEN
+      RAISE EXCEPTION 'Acceso denegado: la sucursal % no está asignada al usuario', p_sucursal_id; END IF;
+    v_sucursales := ARRAY[p_sucursal_id];
+    SELECT nombre INTO v_nombre FROM sucursales WHERE id = p_sucursal_id;
+  END IF;
+  IF v_sucursales IS NULL OR array_length(v_sucursales,1) IS NULL THEN
+    RAISE EXCEPTION 'Acceso denegado: sin sucursales disponibles para el usuario'; END IF;
+
+  WITH
+  base AS (
+    SELECT p.id, p.nombre, p.stock, p.sucursal_id, s.nombre AS sucursal_nombre,
+           COALESCE(NULLIF(p.categoria,''),'(sin categoría)') AS categoria,
+           -- CPP con la misma cascada de fallback que los snapshots (mig 129)
+           COALESCE(p.costo_promedio, p.costo_real,
+                    round(p.costo_sin_iva*(1+COALESCE(p.impuestos_internos,0)/100), 4)) AS cpp,
+           COALESCE(p.costo_real,
+                    round(p.costo_sin_iva*(1+COALESCE(p.impuestos_internos,0)/100), 4)) AS reposicion,
+           p.ultimo_tipo_compra
+    FROM productos p
+    JOIN sucursales s ON s.id = p.sucursal_id
+    WHERE p.sucursal_id = ANY(v_sucursales)
+  ),
+  val AS (
+    SELECT b.*,
+           round(GREATEST(b.stock,0) * COALESCE(b.cpp,0), 2)        AS valuacion_promedio,
+           round(GREATEST(b.stock,0) * COALESCE(b.reposicion,0), 2) AS valuacion_reposicion
+    FROM base b
+  ),
+  con_stock AS (SELECT * FROM val WHERE stock <> 0),
+  productos_j AS (
+    SELECT jsonb_agg(jsonb_build_object(
+        'producto_id', id, 'nombre', nombre, 'categoria', categoria,
+        'sucursal_id', sucursal_id, 'sucursal_nombre', sucursal_nombre,
+        'stock', stock,
+        'costo_promedio', cpp, 'costo_reposicion', reposicion,
+        'ultimo_tipo_compra', ultimo_tipo_compra,
+        'valuacion_promedio', valuacion_promedio,
+        'valuacion_reposicion', valuacion_reposicion,
+        'diferencia', valuacion_reposicion - valuacion_promedio
+      ) ORDER BY valuacion_promedio DESC, nombre) AS arr
+    FROM con_stock
+  ),
+  categorias_j AS (
+    SELECT jsonb_agg(to_jsonb(c) ORDER BY c.valuacion_promedio DESC) AS arr FROM (
+      SELECT categoria,
+             COUNT(*) AS productos,
+             SUM(GREATEST(stock,0)) AS unidades,
+             SUM(valuacion_promedio) AS valuacion_promedio,
+             SUM(valuacion_reposicion) AS valuacion_reposicion,
+             SUM(valuacion_reposicion) - SUM(valuacion_promedio) AS diferencia
+      FROM con_stock GROUP BY categoria
+    ) c
+  ),
+  sucursales_j AS (
+    SELECT jsonb_agg(to_jsonb(s) ORDER BY s.valuacion_promedio DESC) AS arr FROM (
+      SELECT sucursal_id, sucursal_nombre,
+             COUNT(*) AS productos,
+             SUM(GREATEST(stock,0)) AS unidades,
+             SUM(valuacion_promedio) AS valuacion_promedio,
+             SUM(valuacion_reposicion) AS valuacion_reposicion
+      FROM con_stock GROUP BY sucursal_id, sucursal_nombre
+    ) s
+  ),
+  tot AS (
+    SELECT COUNT(*) AS productos,
+           COALESCE(SUM(GREATEST(stock,0)),0) AS unidades,
+           COALESCE(SUM(valuacion_promedio),0) AS valuacion_promedio,
+           COALESCE(SUM(valuacion_reposicion),0) AS valuacion_reposicion
+    FROM con_stock
+  ),
+  calidad AS (
+    SELECT COUNT(*) FILTER (WHERE stock < 0) AS stock_negativo,
+           COUNT(*) FILTER (WHERE cpp IS NULL OR cpp = 0) AS sin_costo,
+           COALESCE(jsonb_agg(jsonb_build_object('producto_id', id, 'nombre', nombre, 'stock', stock))
+             FILTER (WHERE stock < 0), '[]'::jsonb) AS detalle_stock_negativo
+    FROM val
+  )
+  SELECT jsonb_build_object(
+    'meta', jsonb_build_object('sucursal_id', p_sucursal_id, 'sucursal_nombre', COALESCE(v_nombre,'?'),
+      'generado_at', now(), 'criterio', 'costo promedio ponderado (fallback: costo reposición)'),
+    'totales', (SELECT jsonb_build_object(
+        'productos', t.productos, 'unidades', t.unidades,
+        'valuacion_promedio', t.valuacion_promedio,
+        'valuacion_reposicion', t.valuacion_reposicion,
+        'diferencia', t.valuacion_reposicion - t.valuacion_promedio) FROM tot t),
+    'sucursales', (SELECT COALESCE(arr,'[]'::jsonb) FROM sucursales_j),
+    'categorias', (SELECT COALESCE(arr,'[]'::jsonb) FROM categorias_j),
+    'productos', (SELECT COALESCE(arr,'[]'::jsonb) FROM productos_j),
+    'calidad_datos', (SELECT jsonb_build_object(
+        'stock_negativo', c.stock_negativo, 'sin_costo', c.sin_costo,
+        'detalle_stock_negativo', c.detalle_stock_negativo) FROM calidad c)
+  ) INTO v_result;
+
+  RETURN v_result;
+END;
+$function$;
+
+REVOKE EXECUTE ON FUNCTION public.reporte_valuacion_inventario(bigint) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.reporte_valuacion_inventario(bigint) TO authenticated, service_role;

--- a/src/components/containers/ComprasContainer.tsx
+++ b/src/components/containers/ComprasContainer.tsx
@@ -187,8 +187,19 @@ export default function ComprasContainer(): React.ReactElement {
 
   const handleGuardarEdicionCompra = useCallback(async (input: ActualizarCompraItemsInput) => {
     try {
-      await actualizarCompra.mutateAsync(input)
+      const res = await actualizarCompra.mutateAsync(input)
       notify.success('Compra actualizada')
+      // CPP forward-only (mig 128): editar una compra que NO es la última del
+      // producto no re-promedia el costo — avisar para corregirlo en la ficha.
+      if (res.warningCostoPromedio.length > 0) {
+        const nombres = res.warningCostoPromedio
+          .map(w => productos.find(p => String(p.id) === String(w.producto_id))?.nombre ?? `#${w.producto_id}`)
+          .join(', ')
+        notify.warning(
+          `El costo promedio de ${nombres} no se recalculó (la compra editada no es la última). ` +
+          'Si el cambio de costo es relevante, corregilo desde la ficha del producto.'
+        )
+      }
       setModalEditarOpen(false)
       setCompraParaEditar(null)
     } catch (err) {
@@ -196,7 +207,7 @@ export default function ComprasContainer(): React.ReactElement {
       notify.error(msg)
       throw err
     }
-  }, [actualizarCompra, notify])
+  }, [actualizarCompra, notify, productos])
 
   // Abrir el cambio de proveedor desde "Editar compra": cierra el modal de
   // edición y abre el de cambio (un solo modal a la vez).

--- a/src/components/containers/ProductosContainer.tsx
+++ b/src/components/containers/ProductosContainer.tsx
@@ -313,6 +313,7 @@ export default function ProductosContainer(): React.ReactElement {
               setProductoEditando(null)
             }}
             guardando={crearProducto.isPending || actualizarProducto.isPending}
+            esAdmin={isAdmin}
           />
         </Suspense>
       )}

--- a/src/components/modals/ModalProducto.tsx
+++ b/src/components/modals/ModalProducto.tsx
@@ -36,6 +36,8 @@ export interface ProductoFormData {
   precio: number | string;
   /** Costo real canónico (neto + imp. internos si FC; pagado si ZZ) — calculado al guardar */
   costo_real?: number | null;
+  /** Costo promedio ponderado (valuación/CMV, mig 127) — solo se envía si el admin lo corrige */
+  costo_promedio?: number | null;
   /** Cuántas unidades de venta hacen 1 fardo/bulto (ej: 2 = vendés medio fardo) */
   unidades_de_venta_por_fardo?: number;
   /** Etiqueta del bulto: FARDO, CAJA, PACK, BULTO... */
@@ -71,6 +73,8 @@ export interface ModalProductoProps {
   onClose: () => void;
   /** Indica si está guardando */
   guardando: boolean;
+  /** Habilita corregir a mano el costo promedio (solo admin) */
+  esAdmin?: boolean;
 }
 
 // Opciones de IVA disponibles
@@ -90,7 +94,7 @@ const getCategoryKey = (cat: string | CategoriaOption): string => {
   return typeof cat === 'string' ? cat : (cat.id || cat.nombre);
 };
 
-const ModalProducto = memo(function ModalProducto({ producto, categorias, proveedores = [], onSave, onClose, guardando }: ModalProductoProps) {
+const ModalProducto = memo(function ModalProducto({ producto, categorias, proveedores = [], onSave, onClose, guardando, esAdmin = false }: ModalProductoProps) {
   // Zod validation hook
   const { errors, validate, clearFieldError, hasAttemptedSubmit: intentoGuardar } = useZodValidation(modalProductoSchema);
   const errores = errors as ValidationErrors;
@@ -131,6 +135,16 @@ const ModalProducto = memo(function ModalProducto({ producto, categorias, provee
   });
   const [nuevaCategoria, setNuevaCategoria] = useState<string>('');
   const [mostrarNuevaCategoria, setMostrarNuevaCategoria] = useState<boolean>(false);
+
+  // ── Costo promedio (valuación, mig 127) ───────────────────────────────────
+  // Solo lectura por defecto: lo recalcula cada compra (forward-only). El admin
+  // puede corregirlo a mano para sanear distorsiones (ediciones/anulaciones de
+  // compras no lo retro-ajustan). Solo se persiste si se corrigió.
+  const [corrigiendoCpp, setCorrigiendoCpp] = useState<boolean>(false);
+  const [cppValor, setCppValor] = useState<string>(
+    producto?.costo_promedio != null ? String(producto.costo_promedio) : ''
+  );
+  const [cppEditado, setCppEditado] = useState<boolean>(false);
 
   // ── Márgenes (solo UI, bidireccionales con el precio final) ───────────────
   // Lógica del negocio (mig 123):
@@ -251,11 +265,16 @@ const ModalProducto = memo(function ModalProducto({ producto, categorias, provee
         formNormalizado.impuestos_internos,
         producto?.ultimo_tipo_compra ?? 'FC',
       );
+      // CPP: solo se persiste si el admin lo corrigió a mano (undefined = no tocar).
+      const cppCorregido = cppEditado && corrigiendoCpp
+        ? (parsePrecio(cppValor) > 0 ? parsePrecio(cppValor) : null)
+        : undefined;
       onSave({
         ...formNormalizado,
         categoria: categoriaFinal,
         id: producto?.id,
         costo_real: costoReal > 0 ? costoReal : null,
+        ...(cppCorregido !== undefined ? { costo_promedio: cppCorregido } : {}),
       });
       return;
     }
@@ -500,13 +519,15 @@ const ModalProducto = memo(function ModalProducto({ producto, categorias, provee
               />
             </div>
             <div>
-              <label className="block text-xs font-medium mb-1 text-gray-600">Costo final (Neto + II)</label>
+              <label className="block text-xs font-medium mb-1 text-gray-600">
+                Costo reposición{producto?.ultimo_tipo_compra ? ` (últ. ${producto.ultimo_tipo_compra})` : ''}
+              </label>
               <input
                 type="text"
                 value={calcularCostoReal(form.costo_sin_iva, form.impuestos_internos, producto?.ultimo_tipo_compra ?? 'FC').toFixed(2)}
                 readOnly
                 className="w-full px-3 py-2 border-2 border-blue-300 rounded-lg text-sm bg-blue-50 font-semibold"
-                title="Costo REAL: el que se aplica en márgenes, mermas y bonificaciones"
+                title="Costo de REPOSICIÓN (última compra, neto + II si FC): la base para fijar precios"
               />
             </div>
             <div>
@@ -524,9 +545,54 @@ const ModalProducto = memo(function ModalProducto({ producto, categorias, provee
           </div>
           <p className="text-xs text-gray-500 mt-2">
             {(producto?.ultimo_tipo_compra ?? 'FC') === 'ZZ'
-              ? 'Última compra ZZ: el costo final es lo pagado (sin add-on de II).'
-              : 'El costo final (neto + imp. internos) es el costo REAL: el IVA de la compra es crédito fiscal, no costo.'}
+              ? 'Última compra ZZ: el costo de reposición es lo pagado (sin add-on de II).'
+              : 'El costo de reposición (neto + imp. internos) refleja la última compra: el IVA es crédito fiscal, no costo.'}
           </p>
+
+          {/* Costo promedio ponderado (valuación/CMV, mig 127). Solo en edición:
+              un producto nuevo arranca con CPP = costo real. */}
+          {producto && (
+            <div className="mt-3 p-3 bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800 rounded-lg">
+              <div className="flex items-end gap-3">
+                <div className="flex-1">
+                  <label className="block text-xs font-medium mb-1 text-amber-800 dark:text-amber-200">
+                    Costo promedio (valuación)
+                  </label>
+                  <NumberInput
+                    min={0}
+                    emptyValue={0}
+                    value={parsePrecio(cppValor)}
+                    onChange={(n) => { setCppValor(String(n)); setCppEditado(true); }}
+                    commitOnChange
+                    disabled={!corrigiendoCpp}
+                    className="w-full px-3 py-2 border rounded-lg text-sm font-semibold disabled:bg-amber-100/60 dark:disabled:bg-amber-900/30 disabled:cursor-not-allowed"
+                    placeholder="—"
+                  />
+                </div>
+                {esAdmin && (
+                  <button
+                    type="button"
+                    onClick={() => {
+                      if (corrigiendoCpp) {
+                        // Cancelar: volver al valor original sin persistir
+                        setCppValor(producto?.costo_promedio != null ? String(producto.costo_promedio) : '');
+                        setCppEditado(false);
+                      }
+                      setCorrigiendoCpp(!corrigiendoCpp);
+                    }}
+                    className="px-3 py-2 text-xs font-medium border rounded-lg text-amber-800 dark:text-amber-200 hover:bg-amber-100 dark:hover:bg-amber-900/40"
+                  >
+                    {corrigiendoCpp ? 'Cancelar' : 'Corregir'}
+                  </button>
+                )}
+              </div>
+              <p className="text-xs text-amber-700 dark:text-amber-300 mt-1">
+                {corrigiendoCpp
+                  ? '⚠ Esto reescribe la valuación de TODO el stock actual y el CMV de las próximas ventas. Usalo solo para corregir distorsiones.'
+                  : 'Promedio ponderado de las compras: valúa el stock y el CMV de reportes. Lo recalcula cada compra; editar o anular compras viejas NO lo ajusta.'}
+              </p>
+            </div>
+          )}
         </div>
 
         {/* Seccion de Precios de Venta */}
@@ -618,6 +684,20 @@ const ModalProducto = memo(function ModalProducto({ producto, categorias, provee
               </p>
             </div>
           </div>
+
+          {/* Informativo: margen sobre el costo promedio (valuación). Los márgenes
+              editables de arriba siguen sobre reposición: esa es la base de pricing. */}
+          {(() => {
+            const cpp = parsePrecio(cppValor);
+            const precioNeto = parsePrecio(String(form.precio_sin_iva));
+            if (!(producto && cpp > 0 && precioNeto > 0)) return null;
+            return (
+              <p className="text-xs text-amber-700 dark:text-amber-300 mt-2">
+                Margen s/ costo promedio: {calcularMargenPorcentaje(precioNeto, cpp).toFixed(1)}%
+                (${(precioNeto - cpp).toFixed(2)} por unidad — el que verás en reportes hasta agotar el stock valuado).
+              </p>
+            );
+          })()}
 
           <p className="text-xs text-gray-500 mt-2">
             * El precio final incluye IVA ({form.porcentaje_iva || 21}%). El neto se calcula hacia atrás.

--- a/src/components/vistas/VistaReportes.tsx
+++ b/src/components/vistas/VistaReportes.tsx
@@ -13,7 +13,7 @@
  */
 import React, { useState, useEffect, ChangeEvent } from 'react';
 import type { LucideIcon } from 'lucide-react';
-import { TrendingUp, BarChart3, X, Loader2, Users, DollarSign, MapPin } from 'lucide-react';
+import { TrendingUp, BarChart3, X, Loader2, Users, DollarSign, MapPin, Boxes } from 'lucide-react';
 import { formatPrecio } from '../../utils/formatters';
 import { useReportesFinancieros } from '../../hooks/supabase';
 import type {
@@ -32,7 +32,8 @@ import {
   ReporteCuentasPorCobrar,
   ReporteRentabilidadSection,
   ReporteVentasClientes,
-  ReporteVentasZonas
+  ReporteVentasZonas,
+  ReporteValuacionInventario
 } from './reportes';
 
 // =============================================================================
@@ -53,7 +54,7 @@ interface TabConfig {
   icon: LucideIcon;
 }
 
-type ReportTabId = 'preventistas' | 'cuentas' | 'rentabilidad' | 'clientes' | 'zonas';
+type ReportTabId = 'preventistas' | 'cuentas' | 'rentabilidad' | 'clientes' | 'zonas' | 'valuacion';
 
 // =============================================================================
 // COMPONENT
@@ -95,7 +96,8 @@ export default function VistaReportes({
     { id: 'cuentas', label: 'Cuentas por Cobrar', icon: DollarSign },
     { id: 'rentabilidad', label: 'Rentabilidad', icon: TrendingUp },
     { id: 'clientes', label: 'Por Cliente', icon: Users },
-    { id: 'zonas', label: 'Por Zona', icon: MapPin }
+    { id: 'zonas', label: 'Por Zona', icon: MapPin },
+    { id: 'valuacion', label: 'Valuación de Stock', icon: Boxes }
   ];
 
   // Cargar reporte automáticamente solo la primera vez
@@ -207,7 +209,8 @@ export default function VistaReportes({
         ))}
       </div>
 
-      {/* Filtros */}
+      {/* Filtros de fecha (la valuación es una foto del stock actual: no aplican) */}
+      {activeTab !== 'valuacion' && (
       <div className="bg-white dark:bg-gray-800 border dark:border-gray-700 rounded-lg shadow-sm p-4">
         <h2 className="font-semibold mb-3 text-gray-700 dark:text-gray-200">Filtrar por Fecha</h2>
         <div className="grid grid-cols-1 md:grid-cols-3 gap-4 items-end">
@@ -266,6 +269,7 @@ export default function VistaReportes({
           </div>
         </div>
       </div>
+      )}
 
       {/* Contenido según tab */}
       {activeTab === 'preventistas' && (
@@ -308,6 +312,10 @@ export default function VistaReportes({
           loading={loadingFinanciero}
           formatPrecio={formatPrecio}
         />
+      )}
+
+      {activeTab === 'valuacion' && (
+        <ReporteValuacionInventario formatPrecio={formatPrecio} />
       )}
     </div>
   );

--- a/src/components/vistas/reportes/ReporteValuacionInventario.tsx
+++ b/src/components/vistas/reportes/ReporteValuacionInventario.tsx
@@ -1,0 +1,236 @@
+/**
+ * Reporte de valuación de inventario (mig 131).
+ *
+ * Stock valuado a COSTO PROMEDIO PONDERADO (mig 127) con comparativa a costo
+ * de reposición (última compra). Autocontenido: trae los datos con su propio
+ * hook (RPC reporte_valuacion_inventario, consolidado de las sucursales del
+ * usuario) y filtra por sucursal/categoría del lado del cliente.
+ */
+import React, { useMemo, useState } from 'react';
+import { Package, AlertTriangle } from 'lucide-react';
+import LoadingSpinner from '../../layout/LoadingSpinner';
+import {
+  useValuacionInventarioQuery,
+  type ValuacionProducto,
+} from '../../../hooks/queries/useValuacionInventarioQuery';
+
+export interface ReporteValuacionInventarioProps {
+  formatPrecio: (precio: number) => string;
+}
+
+export function ReporteValuacionInventario({
+  formatPrecio,
+}: ReporteValuacionInventarioProps): React.ReactElement {
+  const { data, isLoading, error } = useValuacionInventarioQuery(null);
+  const [sucursalFiltro, setSucursalFiltro] = useState<number | 'todas'>('todas');
+  const [categoriaFiltro, setCategoriaFiltro] = useState<string>('todas');
+
+  const productosFiltrados = useMemo<ValuacionProducto[]>(() => {
+    let rows = data?.productos ?? [];
+    if (sucursalFiltro !== 'todas') rows = rows.filter((p) => p.sucursal_id === sucursalFiltro);
+    if (categoriaFiltro !== 'todas') rows = rows.filter((p) => p.categoria === categoriaFiltro);
+    return rows;
+  }, [data, sucursalFiltro, categoriaFiltro]);
+
+  // Totales del filtro activo (los del RPC son globales)
+  const totalesFiltro = useMemo(() => {
+    return productosFiltrados.reduce(
+      (acc, p) => ({
+        unidades: acc.unidades + Math.max(p.stock, 0),
+        promedio: acc.promedio + (p.valuacion_promedio || 0),
+        reposicion: acc.reposicion + (p.valuacion_reposicion || 0),
+      }),
+      { unidades: 0, promedio: 0, reposicion: 0 }
+    );
+  }, [productosFiltrados]);
+
+  if (isLoading) return <LoadingSpinner />;
+  if (error) {
+    return (
+      <div className="bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg p-4 text-red-700 dark:text-red-300 text-sm">
+        No se pudo cargar la valuación: {(error as Error).message}
+      </div>
+    );
+  }
+  if (!data) return <LoadingSpinner />;
+
+  const categorias = Array.from(new Set((data.productos ?? []).map((p) => p.categoria))).sort();
+  const diferencia = totalesFiltro.reposicion - totalesFiltro.promedio;
+
+  return (
+    <div className="space-y-4">
+      {/* KPIs */}
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+        <div className="bg-blue-50 dark:bg-blue-900/20 p-4 rounded-lg">
+          <p className="text-sm text-blue-600 dark:text-blue-400">Stock valuado (promedio)</p>
+          <p className="text-xl font-bold text-blue-700 dark:text-blue-300">
+            {formatPrecio(totalesFiltro.promedio)}
+          </p>
+          <p className="text-xs text-blue-600/70 dark:text-blue-400/70 mt-1">
+            Lo que costó la mercadería en stock (CPP)
+          </p>
+        </div>
+        <div className="bg-indigo-50 dark:bg-indigo-900/20 p-4 rounded-lg">
+          <p className="text-sm text-indigo-600 dark:text-indigo-400">A costo de reposición</p>
+          <p className="text-xl font-bold text-indigo-700 dark:text-indigo-300">
+            {formatPrecio(totalesFiltro.reposicion)}
+          </p>
+          <p className="text-xs text-indigo-600/70 dark:text-indigo-400/70 mt-1">
+            Cuánto saldría reponer todo hoy
+          </p>
+        </div>
+        <div className={`p-4 rounded-lg ${diferencia >= 0 ? 'bg-green-50 dark:bg-green-900/20' : 'bg-red-50 dark:bg-red-900/20'}`}>
+          <p className={`text-sm ${diferencia >= 0 ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400'}`}>Diferencia</p>
+          <p className={`text-xl font-bold ${diferencia >= 0 ? 'text-green-700 dark:text-green-300' : 'text-red-700 dark:text-red-300'}`}>
+            {formatPrecio(diferencia)}
+          </p>
+          <p className="text-xs text-gray-500 mt-1">
+            {diferencia >= 0 ? 'Reponer cuesta más que lo pagado' : 'El stock está valuado por encima de reposición'}
+          </p>
+        </div>
+        <div className="bg-gray-50 dark:bg-gray-800 p-4 rounded-lg border dark:border-gray-700">
+          <p className="text-sm text-gray-600 dark:text-gray-400">Productos / Unidades</p>
+          <p className="text-xl font-bold text-gray-700 dark:text-gray-200">
+            {productosFiltrados.length} / {totalesFiltro.unidades}
+          </p>
+        </div>
+      </div>
+
+      {/* Calidad de datos */}
+      {(data.calidad_datos.stock_negativo > 0 || data.calidad_datos.sin_costo > 0) && (
+        <div className="flex items-start gap-2 bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800 rounded-lg p-3 text-sm text-amber-800 dark:text-amber-200">
+          <AlertTriangle className="w-4 h-4 mt-0.5 shrink-0" />
+          <div>
+            {data.calidad_datos.stock_negativo > 0 && (
+              <p>
+                {data.calidad_datos.stock_negativo} producto(s) con stock negativo (excluidos de la
+                valuación):{' '}
+                {data.calidad_datos.detalle_stock_negativo
+                  .map((p) => `${p.nombre} (${p.stock})`)
+                  .join(', ')}
+              </p>
+            )}
+            {data.calidad_datos.sin_costo > 0 && (
+              <p>{data.calidad_datos.sin_costo} producto(s) sin costo cargado (valuados en $0).</p>
+            )}
+          </div>
+        </div>
+      )}
+
+      {/* Filtros */}
+      <div className="flex flex-wrap gap-3">
+        {data.sucursales.length > 1 && (
+          <select
+            value={sucursalFiltro}
+            onChange={(e) => setSucursalFiltro(e.target.value === 'todas' ? 'todas' : Number(e.target.value))}
+            className="px-3 py-2 border dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 text-sm text-gray-900 dark:text-white"
+          >
+            <option value="todas">Todas las sucursales</option>
+            {data.sucursales.map((s) => (
+              <option key={s.sucursal_id} value={s.sucursal_id}>{s.sucursal_nombre}</option>
+            ))}
+          </select>
+        )}
+        <select
+          value={categoriaFiltro}
+          onChange={(e) => setCategoriaFiltro(e.target.value)}
+          className="px-3 py-2 border dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 text-sm text-gray-900 dark:text-white"
+        >
+          <option value="todas">Todas las categorías</option>
+          {categorias.map((c) => (
+            <option key={c} value={c}>{c}</option>
+          ))}
+        </select>
+      </div>
+
+      {/* Por categoría (solo sin filtro de categoría) */}
+      {categoriaFiltro === 'todas' && sucursalFiltro === 'todas' && data.categorias.length > 0 && (
+        <div className="bg-white dark:bg-gray-800 border dark:border-gray-700 rounded-lg shadow-sm overflow-hidden">
+          <h3 className="font-semibold text-gray-700 dark:text-gray-200 px-4 pt-4">Por categoría</h3>
+          <div className="overflow-x-auto p-4">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="text-left text-gray-500 dark:text-gray-400 border-b dark:border-gray-700">
+                  <th className="py-2 pr-4">Categoría</th>
+                  <th className="py-2 pr-4 text-right">Productos</th>
+                  <th className="py-2 pr-4 text-right">Unidades</th>
+                  <th className="py-2 pr-4 text-right">Valuación (CPP)</th>
+                  <th className="py-2 pr-4 text-right">A reposición</th>
+                  <th className="py-2 text-right">Dif.</th>
+                </tr>
+              </thead>
+              <tbody>
+                {data.categorias.map((c) => (
+                  <tr key={c.categoria} className="border-b dark:border-gray-700/50 last:border-0">
+                    <td className="py-2 pr-4 text-gray-800 dark:text-gray-100">{c.categoria}</td>
+                    <td className="py-2 pr-4 text-right">{c.productos}</td>
+                    <td className="py-2 pr-4 text-right">{c.unidades}</td>
+                    <td className="py-2 pr-4 text-right font-semibold">{formatPrecio(c.valuacion_promedio)}</td>
+                    <td className="py-2 pr-4 text-right">{formatPrecio(c.valuacion_reposicion)}</td>
+                    <td className={`py-2 text-right ${c.diferencia >= 0 ? 'text-green-600' : 'text-red-600'}`}>
+                      {formatPrecio(c.diferencia)}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      )}
+
+      {/* Detalle por producto */}
+      <div className="bg-white dark:bg-gray-800 border dark:border-gray-700 rounded-lg shadow-sm overflow-hidden">
+        <h3 className="font-semibold text-gray-700 dark:text-gray-200 px-4 pt-4 flex items-center gap-2">
+          <Package className="w-4 h-4" /> Detalle por producto
+        </h3>
+        <div className="overflow-x-auto p-4">
+          {productosFiltrados.length === 0 ? (
+            <p className="text-sm text-gray-500 py-4">Sin productos con stock para el filtro elegido.</p>
+          ) : (
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="text-left text-gray-500 dark:text-gray-400 border-b dark:border-gray-700">
+                  <th className="py-2 pr-4">Producto</th>
+                  <th className="py-2 pr-4 text-right">Stock</th>
+                  <th className="py-2 pr-4 text-right">Costo prom.</th>
+                  <th className="py-2 pr-4 text-right">Reposición</th>
+                  <th className="py-2 pr-4 text-right">Valuación (CPP)</th>
+                  <th className="py-2 text-right">Dif.</th>
+                </tr>
+              </thead>
+              <tbody>
+                {productosFiltrados.map((p) => (
+                  <tr key={`${p.sucursal_id}-${p.producto_id}`} className="border-b dark:border-gray-700/50 last:border-0">
+                    <td className="py-2 pr-4 text-gray-800 dark:text-gray-100">
+                      {p.nombre}
+                      {p.ultimo_tipo_compra && (
+                        <span className="ml-2 text-[10px] font-semibold px-1.5 py-0.5 rounded bg-gray-100 dark:bg-gray-700 text-gray-500 dark:text-gray-300">
+                          {p.ultimo_tipo_compra}
+                        </span>
+                      )}
+                      {sucursalFiltro === 'todas' && data.sucursales.length > 1 && (
+                        <span className="ml-2 text-xs text-gray-400">{p.sucursal_nombre}</span>
+                      )}
+                    </td>
+                    <td className="py-2 pr-4 text-right">{p.stock}</td>
+                    <td className="py-2 pr-4 text-right">{p.costo_promedio != null ? formatPrecio(p.costo_promedio) : '—'}</td>
+                    <td className="py-2 pr-4 text-right">{p.costo_reposicion != null ? formatPrecio(p.costo_reposicion) : '—'}</td>
+                    <td className="py-2 pr-4 text-right font-semibold">{formatPrecio(p.valuacion_promedio)}</td>
+                    <td className={`py-2 text-right ${p.diferencia >= 0 ? 'text-green-600' : 'text-red-600'}`}>
+                      {formatPrecio(p.diferencia)}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          )}
+        </div>
+      </div>
+
+      <p className="text-xs text-gray-500">
+        Valuación al costo promedio ponderado de las compras (criterio de gestión). La columna
+        "reposición" usa el costo de la última compra (FC: neto + imp. internos · ZZ: total pagado).
+      </p>
+    </div>
+  );
+}

--- a/src/components/vistas/reportes/index.ts
+++ b/src/components/vistas/reportes/index.ts
@@ -16,3 +16,6 @@ export type { ReporteVentasClientesProps } from './ReporteVentasClientes';
 
 export { ReporteVentasZonas } from './ReporteVentasZonas';
 export type { ReporteVentasZonasProps } from './ReporteVentasZonas';
+
+export { ReporteValuacionInventario } from './ReporteValuacionInventario';
+export type { ReporteValuacionInventarioProps } from './ReporteValuacionInventario';

--- a/src/hooks/queries/useComprasQuery.ts
+++ b/src/hooks/queries/useComprasQuery.ts
@@ -235,7 +235,16 @@ export interface ActualizarCompraItemsInput {
   }>
 }
 
-async function actualizarCompraItems(input: ActualizarCompraItemsInput): Promise<{ compraId: string }> {
+/** Producto cuyo CPP puede haber quedado distorsionado al editar una compra vieja (mig 128). */
+export interface WarningCostoPromedio {
+  producto_id: number
+  costo_real_anterior: number
+  costo_real_nuevo: number
+}
+
+async function actualizarCompraItems(
+  input: ActualizarCompraItemsInput
+): Promise<{ compraId: string; warningCostoPromedio: WarningCostoPromedio[] }> {
   const itemsParaRPC: CompraItemRPC[] = input.items.map(item => ({
     producto_id: item.productoId,
     cantidad: item.cantidad,
@@ -260,11 +269,16 @@ async function actualizarCompraItems(input: ActualizarCompraItemsInput): Promise
   })
 
   if (error) throw error
-  const result = data as { success: boolean; compra_id: string; error?: string }
+  const result = data as {
+    success: boolean
+    compra_id: string
+    error?: string
+    warning_costo_promedio?: WarningCostoPromedio[] | null
+  }
   if (!result.success) {
     throw new Error(result.error || 'Error al actualizar compra')
   }
-  return { compraId: result.compra_id }
+  return { compraId: result.compra_id, warningCostoPromedio: result.warning_costo_promedio ?? [] }
 }
 
 /**

--- a/src/hooks/queries/useProductosQuery.ts
+++ b/src/hooks/queries/useProductosQuery.ts
@@ -87,6 +87,9 @@ async function createProducto(producto: ProductoFormInput, sucursalId: number | 
       precio_sin_iva: producto.precio_sin_iva ? parseFloat(String(producto.precio_sin_iva)) : null,
       porcentaje_iva: producto.porcentaje_iva ?? 21,
       costo_real: producto.costo_real ?? null,
+      // CPP (mig 127): un producto creado a mano arranca con CPP = costo real;
+      // las compras posteriores lo van ponderando.
+      costo_promedio: producto.costo_promedio ?? producto.costo_real ?? null,
       // Bulto/fardo (migración 031): 0 es válido, sólo usamos null cuando viene undefined
       unidades_de_venta_por_fardo: producto.unidades_de_venta_por_fardo == null ? null : producto.unidades_de_venta_por_fardo,
       etiqueta_bulto: producto.etiqueta_bulto || null,
@@ -114,6 +117,8 @@ async function updateProducto({ id, data: producto }: { id: string; data: Partia
   if (producto.precio_sin_iva !== undefined) updateData.precio_sin_iva = producto.precio_sin_iva ? parseFloat(String(producto.precio_sin_iva)) : null
   if (producto.porcentaje_iva !== undefined) updateData.porcentaje_iva = producto.porcentaje_iva
   if (producto.costo_real !== undefined) updateData.costo_real = producto.costo_real
+  // CPP (mig 127): solo llega definido cuando el admin lo corrige a mano en la ficha
+  if (producto.costo_promedio !== undefined) updateData.costo_promedio = producto.costo_promedio
   // Bulto/fardo (migración 031): tratá undefined como "no tocar", null como "limpiar"
   if (producto.unidades_de_venta_por_fardo !== undefined) {
     updateData.unidades_de_venta_por_fardo = producto.unidades_de_venta_por_fardo

--- a/src/hooks/queries/useValuacionInventarioQuery.ts
+++ b/src/hooks/queries/useValuacionInventarioQuery.ts
@@ -1,0 +1,82 @@
+/**
+ * TanStack Query hook para el reporte de valuación de inventario (mig 131).
+ *
+ * RPC `reporte_valuacion_inventario(p_sucursal_id)`: stock valuado a costo
+ * promedio ponderado (mig 127) con comparativa a costo de reposición.
+ * p_sucursal_id NULL = consolidado de las sucursales asignadas al usuario
+ * (admin/encargado); el desglose por sucursal viene en la respuesta.
+ */
+import { useQuery } from '@tanstack/react-query'
+import { supabase } from '../../lib/supabase'
+
+export interface ValuacionProducto {
+  producto_id: number
+  nombre: string
+  categoria: string
+  sucursal_id: number
+  sucursal_nombre: string
+  stock: number
+  costo_promedio: number | null
+  costo_reposicion: number | null
+  ultimo_tipo_compra: 'FC' | 'ZZ' | null
+  valuacion_promedio: number
+  valuacion_reposicion: number
+  diferencia: number
+}
+
+export interface ValuacionCategoria {
+  categoria: string
+  productos: number
+  unidades: number
+  valuacion_promedio: number
+  valuacion_reposicion: number
+  diferencia: number
+}
+
+export interface ValuacionSucursal {
+  sucursal_id: number
+  sucursal_nombre: string
+  productos: number
+  unidades: number
+  valuacion_promedio: number
+  valuacion_reposicion: number
+}
+
+export interface ValuacionInventario {
+  meta: {
+    sucursal_id: number | null
+    sucursal_nombre: string
+    generado_at: string
+    criterio: string
+  }
+  totales: {
+    productos: number
+    unidades: number
+    valuacion_promedio: number
+    valuacion_reposicion: number
+    diferencia: number
+  }
+  sucursales: ValuacionSucursal[]
+  categorias: ValuacionCategoria[]
+  productos: ValuacionProducto[]
+  calidad_datos: {
+    stock_negativo: number
+    sin_costo: number
+    detalle_stock_negativo: { producto_id: number; nombre: string; stock: number }[]
+  }
+}
+
+export function useValuacionInventarioQuery(sucursalId: number | null = null, enabled = true) {
+  return useQuery({
+    queryKey: ['valuacion-inventario', sucursalId] as const,
+    queryFn: async (): Promise<ValuacionInventario> => {
+      const { data, error } = await supabase.rpc('reporte_valuacion_inventario', {
+        p_sucursal_id: sucursalId,
+      })
+      if (error) throw new Error(error.message)
+      return data as ValuacionInventario
+    },
+    enabled,
+    staleTime: 5 * 60 * 1000,
+  })
+}

--- a/src/types/hooks.ts
+++ b/src/types/hooks.ts
@@ -69,6 +69,8 @@ export interface ProductoDB {
   porcentaje_iva?: number | null;
   /** Costo real canónico: FC = neto×(1+II/100); ZZ = pagado (mig 111) */
   costo_real?: number | null;
+  /** Costo promedio ponderado: valuación de stock y CMV (mig 127) */
+  costo_promedio?: number | null;
   /** Tipo de la última compra que fijó el costo (mig 111) */
   ultimo_tipo_compra?: 'ZZ' | 'FC' | null;
   activo?: boolean;
@@ -293,6 +295,8 @@ export interface ProductoFormInput {
   porcentaje_iva?: number;
   /** Costo real canónico calculado en el modal (mig 111) */
   costo_real?: number | null;
+  /** Costo promedio ponderado; solo se envía si el admin lo corrige a mano (mig 127) */
+  costo_promedio?: number | null;
   unidades_de_venta_por_fardo?: number | null;
   etiqueta_bulto?: string | null;
 }

--- a/src/utils/calculations.cpp.test.ts
+++ b/src/utils/calculations.cpp.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest'
+import { calcularCostoPromedioPonderado, calcularCostoReal } from './calculations'
+
+// Espejo TS de la fórmula CPP de registrar_compra_completa (mig 128).
+// Caso guía del negocio: compra ZZ de 100u a $121 (total = costo), se venden
+// 20, quedan 80; luego compra FC a $100 neto. Con "último costo" las 80u
+// viejas se revaluaban a 100 (margen inflado); con CPP quedan a 109,33.
+
+describe('calcularCostoPromedioPonderado (espejo SQL mig 128)', () => {
+  it('caso 121/100 del negocio: 80u a 121 + 100u a 100 → 109,3333', () => {
+    const costoZZ = calcularCostoReal(121, 0, 'ZZ') // 121: total pagado = costo
+    expect(costoZZ).toBe(121)
+    const cpp = calcularCostoPromedioPonderado(80, costoZZ, 100, 100)
+    expect(cpp).toBeCloseTo(109.3333, 4)
+  })
+
+  it('caso E2E del plan: stock 100 a CPP 100 + compra 100u a 121 → 110,5', () => {
+    expect(calcularCostoPromedioPonderado(100, 100, 100, 121)).toBe(110.5)
+  })
+
+  it('stock 0 o negativo: el promedio se resetea al costo de la compra', () => {
+    expect(calcularCostoPromedioPonderado(0, 121, 50, 100)).toBe(100)
+    expect(calcularCostoPromedioPonderado(-30, 121, 50, 100)).toBe(100)
+  })
+
+  it('CPP nulo o 0 (producto sin historial): toma el costo de la compra', () => {
+    expect(calcularCostoPromedioPonderado(80, null, 100, 100)).toBe(100)
+    expect(calcularCostoPromedioPonderado(80, undefined, 100, 100)).toBe(100)
+    expect(calcularCostoPromedioPonderado(80, 0, 100, 100)).toBe(100)
+  })
+
+  it('dos líneas del mismo producto en una compra promedian igual en cualquier orden', () => {
+    // stock 100 @ 100, líneas de 50 @ 120 y 50 @ 124 → (100×100+50×120+50×124)/200 = 111
+    const ordenA = calcularCostoPromedioPonderado(
+      150, calcularCostoPromedioPonderado(100, 100, 50, 120), 50, 124)
+    const ordenB = calcularCostoPromedioPonderado(
+      150, calcularCostoPromedioPonderado(100, 100, 50, 124), 50, 120)
+    expect(ordenA).toBeCloseTo(111, 4)
+    expect(ordenB).toBeCloseTo(111, 4)
+  })
+
+  it('cantidad 0 (regalo / línea sin costo): el CPP no cambia', () => {
+    expect(calcularCostoPromedioPonderado(80, 121, 0, 0)).toBe(121)
+  })
+
+  it('el costo que sube también promedia (simetría, sin sesgo)', () => {
+    // stock 100 @ 100, compra 100 @ 140 → 120
+    expect(calcularCostoPromedioPonderado(100, 100, 100, 140)).toBe(120)
+  })
+
+  it('redondea a 4 decimales como el SQL', () => {
+    // (3×10 + 1×11)/4 = 10.25; (1×10.3333 + 2×11)/3 = 10.7778
+    expect(calcularCostoPromedioPonderado(3, 10, 1, 11)).toBe(10.25)
+    expect(calcularCostoPromedioPonderado(1, 10.3333, 2, 11)).toBe(10.7778)
+  })
+})

--- a/src/utils/calculations.ts
+++ b/src/utils/calculations.ts
@@ -173,6 +173,34 @@ export function calcularCostoFinanciero(
   return redondear(costo * (1 + iva / 100 + impInt / 100), 4);
 }
 
+/**
+ * Costo PROMEDIO PONDERADO tras una compra (espejo de la fórmula SQL en
+ * registrar_compra_completa, mig 128). Base de valuación de stock y CMV;
+ * el costo de reposición (calcularCostoReal) sigue siendo la base de pricing.
+ *
+ * Guardas (mig 128): stock anterior ≤ 0 o CPP nulo/≤ 0 ⇒ el promedio se
+ * resetea al costo real de la compra.
+ *
+ * @param stockAnterior - Stock antes de ingresar la compra
+ * @param costoPromedioActual - CPP vigente del producto (null si nunca se calculó)
+ * @param cantidad - Unidades que ingresan
+ * @param costoRealNuevo - Costo real unitario de la compra (calcularCostoReal)
+ */
+export function calcularCostoPromedioPonderado(
+  stockAnterior: number,
+  costoPromedioActual: number | null | undefined,
+  cantidad: number,
+  costoRealNuevo: number
+): number {
+  const stock = Number(stockAnterior) || 0;
+  const cant = Number(cantidad) || 0;
+  const costoNuevo = Number(costoRealNuevo) || 0;
+  const cppActual = Number(costoPromedioActual) || 0;
+  if (cant <= 0) return redondear(cppActual > 0 ? cppActual : costoNuevo, 4);
+  if (stock <= 0 || cppActual <= 0) return redondear(costoNuevo, 4);
+  return redondear((stock * cppActual + cant * costoNuevo) / (stock + cant), 4);
+}
+
 // ============================================
 // CÁLCULOS DE COMPRAS (desglose fiscal completo)
 // ============================================


### PR DESCRIPTION
## Problema

El modelo de costos era **"último costo gana"**: cada compra pisaba `productos.costo_real` y revaluaba TODO el stock existente. Caso real: comprar en negro (ZZ) a $121 total y a la semana en blanco (FC) a $100 neto dejaba las 80 unidades viejas costeadas a $100 → CMV subvaluado y margen inflado (y a la inversa cuando el costo sube).

## Solución: doble rol del costo (Costo Promedio Ponderado)

| Costo | Rol | Cómo se mueve |
|---|---|---|
| `costo_real` (existente) | **Reposición** — base de pricing | Última compra FC/ZZ, igual que hoy |
| `costo_promedio` (nuevo, por sucursal) | **Valuación y CMV** | `(stock_ant × CPP + cant × costo_real) / total` en cada compra |

En el ejemplo: (80×121 + 100×100)/180 = **109,33** en vez de 100.

## Migraciones (127-131, **ya aplicadas a producción** y verificadas)

- **127**: columna `productos.costo_promedio` + backfill desde `costo_real`.
- **128**: `registrar_compra_completa` pondera el CPP (regalos no lo tocan; stock ≤ 0 o CPP nulo → reset al costo de la compra; múltiples líneas del mismo producto promedian bien en cualquier orden). `actualizar_compra_items`: si la compra editada es la **más reciente** re-deriva aproximado; si es vieja NO retro-ajusta (forward-only) y devuelve `warning_costo_promedio`.
- **129**: los 5 congeladores de costo (`crear_pedido_completo`, `_bot`, `actualizar_pedido_items`, `anular_salvedad`, trigger de mermas) pasan a la cascada `COALESCE(costo_promedio, costo_real, fallback)`.
- **130**: `reporte_gerencial` usa la misma cascada (solo afecta filas históricas sin snapshot; los meses cerrados no cambian).
- **131**: RPC nuevo `reporte_valuacion_inventario` (admin/encargado, por sucursal asignada).

## Frontend

- **Ficha del producto**: "Costo reposición" (badge FC/ZZ) + "Costo promedio (valuación)" solo lectura con botón **Corregir** (solo admin, con advertencia) y margen informativo sobre el promedio. Los márgenes editables siguen sobre reposición (pricing).
- **Reportes → tab "Valuación de Stock"**: stock valuado a CPP vs reposición, KPIs, desglose por categoría/sucursal, alertas de calidad de datos (stock negativo / sin costo).
- **Compras**: toast de advertencia cuando la edición de una compra vieja deja el CPP posiblemente distorsionado.
- Espejo TS `calcularCostoPromedioPonderado` + `calculations.cpp.test.ts`.

## Verificación

- 794/794 tests (incluye los nuevos del CPP con el caso 121/100).
- E2E en producción con transacción revertida (impersonando admin vía `request.jwt.claims`): compra FC 100u@121 sobre stock 100@100 → CPP 110,5 ✓ · regalo no altera ✓ · 2 líneas ZZ mismo producto → 114,2097 ✓ · pedido y merma congelan el CPP ✓ · editar compra vieja → CPP intacto + warning ✓ · editar la más reciente → re-promedia ✓ · `reporte_valuacion_inventario` cuadra ✓.
- Ledger verificado: 127-131 mapean 1:1 (sin excepciones nuevas para el MANIFEST).

Fuera de alcance (documentado): `registrar_ingreso_sucursal` suma stock sin ponderar el CPP (las unidades transferidas entran al CPP local vigente) — fase 2 opcional.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
