### PR TITLE
fix(rendiciones): fecha_entrega en entregas + guard de caja + detalle por cliente

### DIFF
--- a/migrations/133_fix_fecha_entrega_backfill_y_rendiciones.sql
+++ b/migrations/133_fix_fecha_entrega_backfill_y_rendiciones.sql
@@ -1,0 +1,184 @@
+-- ============================================================================
+-- 133 · Fix fecha_entrega en entregas + backfill + endurecer rendiciones
+-- ============================================================================
+-- CONTEXTO / BUG (Taco Pozo, doc "Mejoras app Crecer"):
+--   En "Rendiciones Diarias" las ventas cobradas el mismo dia caian en
+--   "Ctas Ctes (cobro de saldos)" en vez de "Entregas (cobro del dia)".
+--   Causa raiz: la mutacion viva que marca 'entregado' (actualizarEstado en
+--   src/hooks/queries/usePedidosQuery.ts) hacia `.update({ estado })` SIN
+--   estampar `fecha_entrega`. La RPC obtener_resumen_rendiciones (mig 056)
+--   clasifica como "Entrega del dia" solo si `pd.fecha_entrega::date = pg.fecha`,
+--   asi que con fecha_entrega NULL todo caia en "Ctas Ctes".
+--   Alcance: ~1.339 de 3.510 pedidos entregados (38%) quedaron con
+--   fecha_entrega NULL desde ~abril/2026.
+--
+-- Esta migracion:
+--   1) Backfillea `fecha_entrega` para los entregados con fecha NULL, usando la
+--      mejor senal disponible (mediodia AR): 1er pago -> created_at ->
+--      fecha_entrega_programada -> fecha del pedido. La prioridad "1er pago"
+--      alinea la entrega con el dia de cobro (que es la dimension de la
+--      rendicion), dejando la clasificacion correcta.
+--   2) Endurece obtener_resumen_rendiciones para tolerar fecha_entrega NULL de
+--      forma defensiva (COALESCE al dia del pago), por si algun camino futuro
+--      vuelve a dejarla nula.
+--
+-- El fix del frontend (estampar fecha_entrega al marcar entregado) va en el
+-- mismo PR (usePedidosQuery.ts). Aqui solo backend + datos.
+--
+-- NOTA: la funcion se reproduce desde la version EN VIVO de prod (el repo puede
+-- estar stale). Unico cambio: los dos CASE del split usan COALESCE(...).
+-- ============================================================================
+
+-- ----------------------------------------------------------------------------
+-- 1) BACKFILL de fecha_entrega
+-- ----------------------------------------------------------------------------
+-- El trigger trg_pedidos_anular_control BORRA la fila de rendiciones_control
+-- cuando cambia fecha_entrega. Un backfill masivo lo dispararia 1.339 veces y
+-- destruiria las ~89 rendiciones ya cerradas (confirmadas/disconformidad). Lo
+-- deshabilitamos SOLO durante el UPDATE (transaccional: si algo falla, rollback
+-- deja el trigger habilitado).
+ALTER TABLE public.pedidos DISABLE TRIGGER trg_pedidos_anular_control;
+
+UPDATE public.pedidos p
+SET fecha_entrega = COALESCE(
+  (SELECT (MIN(pg.fecha)::text || ' 12:00:00 America/Argentina/Buenos_Aires')::timestamptz
+     FROM public.pagos pg WHERE pg.pedido_id = p.id),
+  p.created_at,
+  CASE WHEN p.fecha_entrega_programada IS NOT NULL
+       THEN (p.fecha_entrega_programada::text || ' 12:00:00 America/Argentina/Buenos_Aires')::timestamptz END,
+  (p.fecha::text || ' 12:00:00 America/Argentina/Buenos_Aires')::timestamptz
+)
+WHERE p.estado = 'entregado' AND p.fecha_entrega IS NULL;
+
+ALTER TABLE public.pedidos ENABLE TRIGGER trg_pedidos_anular_control;
+
+-- ----------------------------------------------------------------------------
+-- 2) obtener_resumen_rendiciones endurecida (COALESCE fecha_entrega -> pg.fecha)
+-- ----------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.obtener_resumen_rendiciones(
+  p_fecha_desde date DEFAULT ((CURRENT_DATE - '30 days'::interval))::date,
+  p_fecha_hasta date DEFAULT CURRENT_DATE,
+  p_transportista_id uuid DEFAULT NULL::uuid)
+ RETURNS TABLE(fecha date, transportista_id uuid, transportista_nombre text, total_efectivo numeric, total_transferencia numeric, total_cheque numeric, total_cuenta_corriente numeric, total_tarjeta numeric, total_vale_blanco numeric, total_otros numeric, total_general numeric, total_entregas numeric, total_ctascte numeric, cantidad_pedidos bigint, total_entregado numeric, total_gastos numeric, cantidad_gastos bigint, estado text, observaciones text, controlada boolean, controlada_at timestamp with time zone, controlada_por_nombre text, resuelta_at timestamp with time zone, resuelta_por_nombre text)
+ LANGUAGE plpgsql
+ STABLE SECURITY DEFINER
+ SET search_path TO 'public'
+AS $function$
+DECLARE
+  v_sucursal_id BIGINT;
+BEGIN
+  v_sucursal_id := current_sucursal_id();
+  IF v_sucursal_id IS NULL THEN
+    RAISE EXCEPTION 'Sucursal no seleccionada';
+  END IF;
+  IF NOT es_encargado_o_admin() THEN
+    RAISE EXCEPTION 'No autorizado';
+  END IF;
+
+  RETURN QUERY
+  WITH pagos_agg AS (
+    SELECT
+      COALESCE(pd.transportista_id, pg.usuario_id) AS t_id,
+      pg.fecha AS f,
+      SUM(CASE WHEN pg.forma_pago = 'efectivo' THEN pg.monto ELSE 0 END)::numeric AS tot_ef,
+      SUM(CASE WHEN pg.forma_pago = 'transferencia' THEN pg.monto ELSE 0 END)::numeric AS tot_tr,
+      SUM(CASE WHEN pg.forma_pago = 'cheque' THEN pg.monto ELSE 0 END)::numeric AS tot_ch,
+      SUM(CASE WHEN pg.forma_pago = 'cuenta_corriente' THEN pg.monto ELSE 0 END)::numeric AS tot_cc,
+      SUM(CASE WHEN pg.forma_pago = 'tarjeta' THEN pg.monto ELSE 0 END)::numeric AS tot_tj,
+      SUM(CASE WHEN pg.forma_pago = 'vale_blanco' THEN pg.monto ELSE 0 END)::numeric AS tot_vb,
+      SUM(CASE WHEN pg.forma_pago NOT IN ('efectivo','transferencia','cheque','cuenta_corriente','tarjeta','vale_blanco')
+                OR pg.forma_pago IS NULL THEN pg.monto ELSE 0 END)::numeric AS tot_ot,
+      SUM(pg.monto)::numeric AS tot_gen,
+      -- Entregas del dia: pago vinculado a un pedido entregado. Si fecha_entrega
+      -- es NULL (dato viejo sin backfillear) se toma el dia del pago (defensivo).
+      SUM(CASE
+        WHEN pg.pedido_id IS NOT NULL
+         AND pd.estado = 'entregado'
+         AND COALESCE(pd.fecha_entrega::date, pg.fecha) = pg.fecha
+        THEN pg.monto ELSE 0 END)::numeric AS tot_entregas,
+      -- Ctas Ctes: complemento exacto del anterior.
+      SUM(CASE
+        WHEN pg.pedido_id IS NULL
+          OR pd.estado IS DISTINCT FROM 'entregado'
+          OR COALESCE(pd.fecha_entrega::date, pg.fecha) IS DISTINCT FROM pg.fecha
+        THEN pg.monto ELSE 0 END)::numeric AS tot_ctascte
+    FROM pagos pg
+    LEFT JOIN pedidos pd ON pd.id = pg.pedido_id
+    WHERE pg.fecha BETWEEN p_fecha_desde AND p_fecha_hasta
+      AND pg.sucursal_id = v_sucursal_id
+      AND COALESCE(pd.transportista_id, pg.usuario_id) IS NOT NULL
+      AND (p_transportista_id IS NULL
+           OR COALESCE(pd.transportista_id, pg.usuario_id) = p_transportista_id)
+    GROUP BY COALESCE(pd.transportista_id, pg.usuario_id), pg.fecha
+  ),
+  entregas_agg AS (
+    SELECT
+      pd.transportista_id AS t_id,
+      pd.fecha_entrega::date AS f,
+      SUM(pd.total)::numeric AS tot_entregado,
+      COUNT(*)::bigint AS cant
+    FROM pedidos pd
+    WHERE pd.estado = 'entregado'
+      AND pd.fecha_entrega IS NOT NULL
+      AND pd.transportista_id IS NOT NULL
+      AND pd.fecha_entrega::date BETWEEN p_fecha_desde AND p_fecha_hasta
+      AND pd.sucursal_id = v_sucursal_id
+      AND (p_transportista_id IS NULL OR pd.transportista_id = p_transportista_id)
+    GROUP BY pd.transportista_id, pd.fecha_entrega::date
+  ),
+  gastos_agg AS (
+    SELECT
+      rg.transportista_id AS t_id,
+      rg.fecha AS f,
+      SUM(rg.monto)::numeric AS tot_g,
+      COUNT(*)::bigint AS cant_g
+    FROM rendicion_gastos rg
+    WHERE rg.fecha BETWEEN p_fecha_desde AND p_fecha_hasta
+      AND rg.sucursal_id = v_sucursal_id
+      AND (p_transportista_id IS NULL OR rg.transportista_id = p_transportista_id)
+    GROUP BY rg.transportista_id, rg.fecha
+  ),
+  fechas_activas AS (
+    SELECT t_id, f FROM pagos_agg
+    UNION
+    SELECT t_id, f FROM entregas_agg
+  )
+  SELECT
+    fa.f::date AS fecha,
+    fa.t_id AS transportista_id,
+    tr.nombre::text AS transportista_nombre,
+    COALESCE(pagos_agg.tot_ef, 0)::numeric AS total_efectivo,
+    COALESCE(pagos_agg.tot_tr, 0)::numeric AS total_transferencia,
+    COALESCE(pagos_agg.tot_ch, 0)::numeric AS total_cheque,
+    COALESCE(pagos_agg.tot_cc, 0)::numeric AS total_cuenta_corriente,
+    COALESCE(pagos_agg.tot_tj, 0)::numeric AS total_tarjeta,
+    COALESCE(pagos_agg.tot_vb, 0)::numeric AS total_vale_blanco,
+    COALESCE(pagos_agg.tot_ot, 0)::numeric AS total_otros,
+    COALESCE(pagos_agg.tot_gen, 0)::numeric AS total_general,
+    COALESCE(pagos_agg.tot_entregas, 0)::numeric AS total_entregas,
+    COALESCE(pagos_agg.tot_ctascte, 0)::numeric AS total_ctascte,
+    COALESCE(entregas_agg.cant, 0)::bigint AS cantidad_pedidos,
+    COALESCE(entregas_agg.tot_entregado, 0)::numeric AS total_entregado,
+    COALESCE(gastos_agg.tot_g, 0)::numeric AS total_gastos,
+    COALESCE(gastos_agg.cant_g, 0)::bigint AS cantidad_gastos,
+    COALESCE(rc.estado, 'pendiente')::text AS estado,
+    rc.observaciones,
+    (rc.id IS NOT NULL AND COALESCE(rc.estado, 'pendiente') IN ('confirmada','resuelta')) AS controlada,
+    rc.controlada_at,
+    cp.nombre::text AS controlada_por_nombre,
+    rc.resuelta_at,
+    rp.nombre::text AS resuelta_por_nombre
+  FROM fechas_activas fa
+  JOIN perfiles tr ON tr.id = fa.t_id
+  LEFT JOIN pagos_agg ON pagos_agg.t_id = fa.t_id AND pagos_agg.f = fa.f
+  LEFT JOIN entregas_agg ON entregas_agg.t_id = fa.t_id AND entregas_agg.f = fa.f
+  LEFT JOIN gastos_agg ON gastos_agg.t_id = fa.t_id AND gastos_agg.f = fa.f
+  LEFT JOIN rendiciones_control rc
+    ON rc.fecha = fa.f
+   AND rc.transportista_id = fa.t_id
+   AND rc.sucursal_id = v_sucursal_id
+  LEFT JOIN perfiles cp ON cp.id = rc.controlada_por
+  LEFT JOIN perfiles rp ON rp.id = rc.resuelta_por
+  ORDER BY fa.f DESC, tr.nombre ASC;
+END;
+$function$;

--- a/migrations/134_guard_pago_fecha_caja_cerrada.sql
+++ b/migrations/134_guard_pago_fecha_caja_cerrada.sql
@@ -1,0 +1,68 @@
+-- ============================================================================
+-- 134 · Guard de "caja cerrada": no registrar pagos con fecha <= ultimo cierre
+-- ============================================================================
+-- CONTEXTO (Taco Pozo, doc "Mejoras app Crecer"):
+--   Se podian registrar cobranzas con fecha anterior a la actual, rompiendo el
+--   control de caja. El primitivo previo `rendicion_dia_cerrada` (mig 039) solo
+--   frenaba al rol 'encargado' y solo en las RPC (los INSERT directos de pagos
+--   lo salteaban); admin quedaba exento.
+--
+-- Decision (usuario): bloquear cualquier pago con fecha <= al ULTIMO cierre de
+-- caja de la sucursal (rendicion confirmada/resuelta), para TODOS los roles.
+--
+-- Implementacion autoritativa: un trigger BEFORE INSERT/UPDATE en `pagos` que
+-- corre para cualquier camino (RPC FIFO/masivas, INSERT directo del front, admin
+-- o encargado). No toca DELETE (para permitir anular/corregir, p.ej. el saldo a
+-- favor erroneo). El trigger solo mira fecha/monto: transferencias de pagos que
+-- cambian pedido_id/cliente_id (cambiar_cliente_pedido) o forma_pago
+-- (actualizar_forma_pago_pago) NO lo disparan.
+-- ============================================================================
+
+-- Fecha del ultimo cierre de caja de una sucursal (NULL si nunca cerro ninguna).
+-- SECURITY DEFINER para ver todas las rendiciones_control sin depender del RLS
+-- del que inserta el pago. Mismo criterio que rendicion_dia_cerrada (039):
+-- 'confirmada'/'resuelta' = cerrada; 'disconformidad' = aun pendiente.
+CREATE OR REPLACE FUNCTION public.ultima_fecha_caja_cerrada(p_sucursal_id bigint)
+RETURNS date
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $$
+  SELECT MAX(fecha)
+  FROM rendiciones_control
+  WHERE sucursal_id = p_sucursal_id
+    AND estado IN ('confirmada','resuelta');
+$$;
+
+GRANT EXECUTE ON FUNCTION public.ultima_fecha_caja_cerrada(bigint) TO authenticated;
+
+CREATE OR REPLACE FUNCTION public.guard_pago_fecha_cerrada()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $$
+DECLARE
+  v_limite date;
+BEGIN
+  IF NEW.sucursal_id IS NULL OR NEW.fecha IS NULL THEN
+    RETURN NEW;
+  END IF;
+
+  v_limite := public.ultima_fecha_caja_cerrada(NEW.sucursal_id);
+
+  IF v_limite IS NOT NULL AND NEW.fecha <= v_limite THEN
+    RAISE EXCEPTION 'La caja de la sucursal esta cerrada hasta el % (rendicion controlada). No se puede registrar/editar un pago con fecha %. Reabri la rendicion de ese dia para hacer cambios.',
+      to_char(v_limite, 'DD/MM/YYYY'), to_char(NEW.fecha, 'DD/MM/YYYY')
+      USING ERRCODE = '42501';
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_pagos_guard_fecha_cerrada ON public.pagos;
+CREATE TRIGGER trg_pagos_guard_fecha_cerrada
+  BEFORE INSERT OR UPDATE OF fecha, monto ON public.pagos
+  FOR EACH ROW EXECUTE FUNCTION public.guard_pago_fecha_cerrada();

--- a/migrations/135_obtener_detalle_rendicion.sql
+++ b/migrations/135_obtener_detalle_rendicion.sql
@@ -1,0 +1,76 @@
+-- ============================================================================
+-- 135 · obtener_detalle_rendicion(fecha, transportista) — detalle por cliente
+-- ============================================================================
+-- CONTEXTO (Taco Pozo, doc "Mejoras app Crecer"):
+--   El "Detalle" de la rendicion solo mostraba el breakdown por forma de pago.
+--   Pedido: ver por cliente cuanto es entrega vs ctas ctes, cuantos clientes y
+--   el monto de ctas ctes del dia, y poder exportar a Excel.
+--
+-- Esta RPC devuelve una fila por cliente para una (fecha, transportista) dada,
+-- con el mismo criterio de clasificacion Entregas/Ctas Ctes que
+-- obtener_resumen_rendiciones (mig 133). El front agrega el conteo de clientes,
+-- el total de ctas ctes del dia y el export a Excel.
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION public.obtener_detalle_rendicion(
+  p_fecha date,
+  p_transportista_id uuid
+)
+RETURNS TABLE(
+  cliente_id bigint,
+  cliente_nombre text,
+  total numeric,
+  total_entregas numeric,
+  total_ctascte numeric,
+  efectivo numeric,
+  transferencia numeric,
+  otros numeric,
+  cantidad_pagos bigint
+)
+LANGUAGE plpgsql
+STABLE SECURITY DEFINER
+SET search_path TO 'public'
+AS $function$
+DECLARE
+  v_sucursal_id bigint;
+BEGIN
+  v_sucursal_id := current_sucursal_id();
+  IF v_sucursal_id IS NULL THEN
+    RAISE EXCEPTION 'Sucursal no seleccionada';
+  END IF;
+  IF NOT es_encargado_o_admin() THEN
+    RAISE EXCEPTION 'No autorizado';
+  END IF;
+
+  RETURN QUERY
+  SELECT
+    pg.cliente_id AS cliente_id,
+    COALESCE(NULLIF(c.nombre_fantasia, ''), c.razon_social, 'Cliente #' || pg.cliente_id)::text AS cliente_nombre,
+    SUM(pg.monto)::numeric AS total,
+    SUM(CASE
+      WHEN pg.pedido_id IS NOT NULL
+       AND pd.estado = 'entregado'
+       AND COALESCE(pd.fecha_entrega::date, pg.fecha) = pg.fecha
+      THEN pg.monto ELSE 0 END)::numeric AS total_entregas,
+    SUM(CASE
+      WHEN pg.pedido_id IS NULL
+        OR pd.estado IS DISTINCT FROM 'entregado'
+        OR COALESCE(pd.fecha_entrega::date, pg.fecha) IS DISTINCT FROM pg.fecha
+      THEN pg.monto ELSE 0 END)::numeric AS total_ctascte,
+    SUM(CASE WHEN pg.forma_pago = 'efectivo' THEN pg.monto ELSE 0 END)::numeric AS efectivo,
+    SUM(CASE WHEN pg.forma_pago = 'transferencia' THEN pg.monto ELSE 0 END)::numeric AS transferencia,
+    SUM(CASE WHEN pg.forma_pago NOT IN ('efectivo','transferencia') OR pg.forma_pago IS NULL
+             THEN pg.monto ELSE 0 END)::numeric AS otros,
+    COUNT(*)::bigint AS cantidad_pagos
+  FROM pagos pg
+  LEFT JOIN pedidos pd ON pd.id = pg.pedido_id
+  LEFT JOIN clientes c ON c.id = pg.cliente_id
+  WHERE pg.fecha = p_fecha
+    AND pg.sucursal_id = v_sucursal_id
+    AND COALESCE(pd.transportista_id, pg.usuario_id) = p_transportista_id
+  GROUP BY pg.cliente_id, c.nombre_fantasia, c.razon_social
+  ORDER BY SUM(pg.monto) DESC;
+END;
+$function$;
+
+GRANT EXECUTE ON FUNCTION public.obtener_detalle_rendicion(date, uuid) TO authenticated;

--- a/package-lock.json
+++ b/package-lock.json
@@ -6009,15 +6009,15 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/braces": {
@@ -6897,9 +6897,9 @@
       "license": "MIT"
     },
     "node_modules/dompurify": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.2.tgz",
-      "integrity": "sha512-lHeS9SA/IKeIFFyYciHBr2n0v1VMPlSj843HdLOwjb2OxNwdq9Xykxqhk+FE42MzAdHvInbAolSE4mhahPpjXA==",
+      "version": "3.4.12",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.12.tgz",
+      "integrity": "sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
@@ -7609,9 +7609,9 @@
       }
     },
     "node_modules/fast-uri": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
       "dev": true,
       "funding": [
         {
@@ -9069,9 +9069,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
       "dev": true,
       "funding": [
         {

--- a/src/components/modals/ModalFichaCliente.tsx
+++ b/src/components/modals/ModalFichaCliente.tsx
@@ -1,10 +1,12 @@
 import { useState, useEffect, useMemo } from 'react'
+import { useQueryClient } from '@tanstack/react-query'
 import type { LucideIcon } from 'lucide-react'
-import { User, MapPin, Phone, CreditCard, ShoppingBag, TrendingUp, DollarSign, Clock, Package, ChevronDown, ChevronUp, FileText, Plus, AlertTriangle, CheckCircle, Tag, Building2, Percent, ArrowLeftRight } from 'lucide-react'
+import { User, MapPin, Phone, CreditCard, ShoppingBag, TrendingUp, DollarSign, Clock, Package, ChevronDown, ChevronUp, FileText, Plus, AlertTriangle, CheckCircle, Tag, Building2, Percent, ArrowLeftRight, Trash2 } from 'lucide-react'
 import ModalBase from './ModalBase'
 import { useFichaCliente, usePagos } from '../../hooks/supabase'
 import { useAuthData } from '../../contexts/AuthDataContext'
-import { puedeVerSaldoCliente, puedeVerHistorialVentasCliente, puedeRegistrarPagoCliente } from '../../lib/permisos'
+import { useNotification } from '../../contexts/NotificationContext'
+import { puedeVerSaldoCliente, puedeVerHistorialVentasCliente, puedeRegistrarPagoCliente, puedeAnularPago } from '../../lib/permisos'
 import { formatPrecio as formatCurrency, formatFecha as formatDate, getEstadoColor, getEstadoPagoColor } from '../../utils/formatters'
 import { logger } from '../../utils/logger'
 import type { ClienteDB, PedidoDB, PagoDBWithUsuario, ResumenCuenta, EstadisticasCliente, PedidoClienteWithItems } from '../../types'
@@ -46,15 +48,21 @@ interface TabItem {
 
 export default function ModalFichaCliente({ cliente, onClose, onRegistrarPago, onVerPedido, onCambioEnRuta }: ModalFichaClienteProps) {
   const { pedidosCliente, estadisticas, loading } = useFichaCliente(cliente?.id)
-  const { pagos, loading: loadingPagos, fetchPagosCliente, obtenerResumenCuenta } = usePagos()
+  const { pagos, loading: loadingPagos, fetchPagosCliente, obtenerResumenCuenta, eliminarPago } = usePagos()
   const { perfil } = useAuthData()
+  const notify = useNotification()
+  const queryClient = useQueryClient()
   const rol = perfil?.rol
   const verSaldo = puedeVerSaldoCliente(rol)
   const verHistorialVentas = puedeVerHistorialVentasCliente(rol)
   const puedeRegistrarPago = puedeRegistrarPagoCliente(rol)
+  const puedeAnular = puedeAnularPago(rol)
   const [resumenCuenta, setResumenCuenta] = useState<ResumenCuenta | null>(null)
   const [activeTab, setActiveTab] = useState<ActiveTab>('resumen')
   const [expandedPedido, setExpandedPedido] = useState<string | null>(null)
+  // Anulacion de pagos (solo admin): confirmacion inline dentro del modal.
+  const [anulandoId, setAnulandoId] = useState<string | null>(null)
+  const [procesandoAnular, setProcesandoAnular] = useState<boolean>(false)
 
 
   useEffect(() => {
@@ -76,6 +84,27 @@ export default function ModalFichaCliente({ cliente, onClose, onRegistrarPago, o
     if (resumenCuenta?.saldo_actual !== undefined) return resumenCuenta.saldo_actual
     return 0
   }, [resumenCuenta])
+
+  // Anular un pago (admin). El borrado dispara los triggers que revierten el
+  // saldo del cliente (mig 086) y recalculan el pedido (mig 035). No lo bloquea
+  // el guard de caja cerrada (ese solo aplica a INSERT/UPDATE, no a DELETE).
+  const handleConfirmarAnular = async (pagoId: string | number): Promise<void> => {
+    if (!cliente?.id) return
+    setProcesandoAnular(true)
+    try {
+      await eliminarPago(String(pagoId))
+      await fetchPagosCliente(cliente.id)
+      const res = await obtenerResumenCuenta(cliente.id)
+      setResumenCuenta(res)
+      queryClient.invalidateQueries({ queryKey: ['clientes'] })
+      notify.success('Pago anulado. Se ajustó el saldo del cliente.')
+      setAnulandoId(null)
+    } catch (err) {
+      notify.error(err instanceof Error ? err.message : 'No se pudo anular el pago')
+    } finally {
+      setProcesandoAnular(false)
+    }
+  }
 
   const limiteCredito: number = cliente?.limite_credito || 0
   const creditoDisponible: number = limiteCredito - saldoActual
@@ -456,21 +485,63 @@ export default function ModalFichaCliente({ cliente, onClose, onRegistrarPago, o
                 </div>
               ) : (
                 pagos.map(pago => (
-                  <div key={pago.id} className="p-4 bg-gray-50 dark:bg-gray-700/50 rounded-xl flex items-center justify-between">
-                    <div>
-                      <p className="font-semibold text-gray-900 dark:text-white">
-                        {formatCurrency(pago.monto)}
-                      </p>
-                      <p className="text-sm text-gray-500">
-                        {formatDate(pago.created_at)} • {pago.forma_pago}
-                        {pago.referencia && ` • Ref: ${pago.referencia}`}
-                      </p>
-                      {pago.notas && <p className="text-sm text-gray-400 mt-1">{pago.notas}</p>}
+                  <div key={pago.id} className="p-4 bg-gray-50 dark:bg-gray-700/50 rounded-xl">
+                    <div className="flex items-center justify-between">
+                      <div>
+                        <p className="font-semibold text-gray-900 dark:text-white">
+                          {formatCurrency(pago.monto)}
+                        </p>
+                        <p className="text-sm text-gray-500">
+                          {formatDate(pago.created_at)} • {pago.forma_pago}
+                          {pago.referencia && ` • Ref: ${pago.referencia}`}
+                        </p>
+                        {pago.notas && <p className="text-sm text-gray-400 mt-1">{pago.notas}</p>}
+                      </div>
+                      <div className="flex items-start gap-3">
+                        <div className="text-right text-sm text-gray-500">
+                          {pago.usuario?.nombre || 'Sistema'}
+                          {pago.pedido_id && <p>Pedido #{pago.pedido_id}</p>}
+                        </div>
+                        {puedeAnular && anulandoId !== String(pago.id) && (
+                          <button
+                            onClick={() => setAnulandoId(String(pago.id))}
+                            className="p-1.5 text-gray-400 hover:text-red-600 hover:bg-red-50 dark:hover:bg-red-900/20 rounded-lg transition-colors"
+                            title="Anular pago"
+                          >
+                            <Trash2 className="w-4 h-4" />
+                          </button>
+                        )}
+                      </div>
                     </div>
-                    <div className="text-right text-sm text-gray-500">
-                      {pago.usuario?.nombre || 'Sistema'}
-                      {pago.pedido_id && <p>Pedido #{pago.pedido_id}</p>}
-                    </div>
+                    {anulandoId === String(pago.id) && (
+                      <div className="mt-3 p-3 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg">
+                        <p className="text-sm text-red-700 dark:text-red-300 mb-2 flex items-start gap-2">
+                          <AlertTriangle className="w-4 h-4 mt-0.5 shrink-0" />
+                          <span>
+                            ¿Anular este pago de <strong>{formatCurrency(pago.monto)}</strong>?{' '}
+                            {pago.pedido_id
+                              ? 'Se revertirá la imputación al pedido y se ajustará el saldo del cliente.'
+                              : 'Es un pago a cuenta / saldo a favor: se ajustará el saldo del cliente.'}
+                          </span>
+                        </p>
+                        <div className="flex gap-2 justify-end">
+                          <button
+                            onClick={() => setAnulandoId(null)}
+                            disabled={procesandoAnular}
+                            className="px-3 py-1.5 text-sm rounded-lg border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-700 disabled:opacity-50"
+                          >
+                            Cancelar
+                          </button>
+                          <button
+                            onClick={() => { void handleConfirmarAnular(pago.id) }}
+                            disabled={procesandoAnular}
+                            className="px-3 py-1.5 text-sm rounded-lg bg-red-600 hover:bg-red-700 text-white disabled:opacity-50"
+                          >
+                            {procesandoAnular ? 'Anulando…' : 'Sí, anular'}
+                          </button>
+                        </div>
+                      </div>
+                    )}
                   </div>
                 ))
               )}

--- a/src/components/modals/ModalPagoPedido.tsx
+++ b/src/components/modals/ModalPagoPedido.tsx
@@ -23,6 +23,7 @@ import NumberInput from '../ui/NumberInput'
 import { formatPrecio, fechaLocalISO, formatDateTime, getFormaPagoLabel } from '../../utils/formatters'
 import { parsePrecio } from '../../utils/calculations'
 import { FORMAS_PAGO_SELECCIONABLES } from '../../constants/formasPago'
+import { useFechaMinimaPago } from '../../hooks/queries/useUltimaFechaCajaCerradaQuery'
 import type { PedidoDB, PagoDBWithUsuario } from '../../types'
 
 export interface PagoPedidoPayload {
@@ -86,6 +87,8 @@ const ModalPagoPedido = memo(function ModalPagoPedido({
   const saldoPendiente = Math.max(0, total - yaPagado)
 
   const [fechaPago, setFechaPago] = useState<string>(fechaLocalISO())
+  // Fecha minima: dia siguiente al ultimo cierre de caja de la sucursal (mig 134).
+  const fechaMinima = useFechaMinimaPago()
   const [observaciones, setObservaciones] = useState<string>('')
   const [lineas, setLineas] = useState<LineaPago[]>([
     { formaPago: 'efectivo', monto: saldoPendiente > 0 ? saldoPendiente.toFixed(2) : '' },
@@ -291,6 +294,7 @@ const ModalPagoPedido = memo(function ModalPagoPedido({
               <input
                 type="date"
                 value={fechaPago}
+                min={fechaMinima}
                 onChange={e => setFechaPago(e.target.value)}
                 className="w-full px-3 py-2 border rounded-lg dark:bg-gray-700 dark:border-gray-600 dark:text-white"
               />

--- a/src/components/modals/ModalRegistrarPago.tsx
+++ b/src/components/modals/ModalRegistrarPago.tsx
@@ -4,6 +4,7 @@ import { formatPrecio as formatCurrency, fechaLocalISO } from '../../utils/forma
 import { parsePrecio } from '../../utils/calculations'
 import NumberInput from '../ui/NumberInput'
 import { useZodValidation } from '../../hooks/useZodValidation'
+import { useFechaMinimaPago } from '../../hooks/queries/useUltimaFechaCajaCerradaQuery'
 import { modalPagoSchema } from '../../lib/schemas'
 import type { ClienteDB, Pedido, Pago, FormaPago, RegistrarPagoFifoInput, RegistrarPagoCombinadoFifoInput, RegistrarPagoFifoResult, PagoFifoAplicacion } from '../../types'
 
@@ -97,6 +98,8 @@ export default function ModalRegistrarPago({
   const [resultadoFIFO, setResultadoFIFO] = useState<RegistrarPagoFifoResult | null>(null)
   const [error, setError] = useState<string>('')
   const [fecha, setFecha] = useState<string>(fechaLocalISO())
+  // Fecha minima: dia siguiente al ultimo cierre de caja de la sucursal (mig 134).
+  const fechaMinima = useFechaMinimaPago()
 
   // Pago dividido
   const [pagoDividido, setPagoDividido] = useState<boolean>(false)
@@ -418,11 +421,13 @@ export default function ModalRegistrarPago({
             <input
               type="date"
               value={fecha}
+              min={fechaMinima}
               onChange={(e: ChangeEvent<HTMLInputElement>) => setFecha(e.target.value)}
               className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 text-gray-900 dark:text-white"
             />
             <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
               Se imputa a la rendición de esa fecha. Por defecto hoy.
+              {fechaMinima && ' No se permiten fechas con la caja ya cerrada.'}
             </p>
           </div>
 

--- a/src/components/vistas/VistaRendiciones.tsx
+++ b/src/components/vistas/VistaRendiciones.tsx
@@ -17,9 +17,12 @@ import {
   ChevronUp,
   AlertTriangle,
   FileText,
-  Receipt
+  Receipt,
+  Download,
+  Users
 } from 'lucide-react'
 import { fechaLocalISO } from '../../utils/formatters'
+import { supabase } from '../../hooks/supabase/base'
 import { useRendiciones } from '../../hooks/supabase'
 import { useTransportistasQuery } from '../../hooks/queries'
 import { useNotification } from '../../contexts/NotificationContext'
@@ -61,6 +64,19 @@ const ESTADO_STYLES: Record<EstadoRendicion, { label: string; badge: string; bor
   }
 }
 
+/** Fila del detalle por cliente de una rendición (RPC obtener_detalle_rendicion, mig 135). */
+interface DetalleRendicionCliente {
+  cliente_id: number
+  cliente_nombre: string
+  total: number
+  total_entregas: number
+  total_ctascte: number
+  efectivo: number
+  transferencia: number
+  otros: number
+  cantidad_pagos: number
+}
+
 interface ResumenCardProps {
   resumen: ResumenRendicionDiaria
   onCerrar: (resumen: ResumenRendicionDiaria) => void
@@ -69,6 +85,9 @@ interface ResumenCardProps {
 
 function ResumenCard({ resumen, onCerrar, onResolver }: ResumenCardProps): React.ReactElement {
   const [expandido, setExpandido] = useState(false)
+  const [detalle, setDetalle] = useState<DetalleRendicionCliente[] | null>(null)
+  const [loadingDetalle, setLoadingDetalle] = useState(false)
+  const [exportando, setExportando] = useState(false)
   const estadoStyle = ESTADO_STYLES[resumen.estado]
 
   const desgloses = useMemo(() => {
@@ -92,6 +111,66 @@ function ResumenCard({ resumen, onCerrar, onResolver }: ResumenCardProps): React
     : diferencia > 0
       ? `+${formatMoney(diferencia)} cobrado sobre entregado`
       : `${formatMoney(diferencia)} cobrado menos que entregado`
+
+  // Detalle por cliente: se carga la primera vez que se expande la tarjeta.
+  useEffect(() => {
+    if (!expandido || detalle !== null || loadingDetalle) return
+    let cancelado = false
+    setLoadingDetalle(true)
+    void (async () => {
+      const { data, error } = await supabase.rpc('obtener_detalle_rendicion', {
+        p_fecha: resumen.fecha,
+        p_transportista_id: resumen.transportista_id
+      })
+      if (cancelado) return
+      if (error) {
+        setDetalle([])
+      } else {
+        setDetalle((data || []).map((r: Record<string, unknown>) => ({
+          cliente_id: Number(r.cliente_id),
+          cliente_nombre: String(r.cliente_nombre ?? 'Cliente'),
+          total: Number(r.total) || 0,
+          total_entregas: Number(r.total_entregas) || 0,
+          total_ctascte: Number(r.total_ctascte) || 0,
+          efectivo: Number(r.efectivo) || 0,
+          transferencia: Number(r.transferencia) || 0,
+          otros: Number(r.otros) || 0,
+          cantidad_pagos: Number(r.cantidad_pagos) || 0
+        })))
+      }
+      setLoadingDetalle(false)
+    })()
+    return () => { cancelado = true }
+  }, [expandido, detalle, loadingDetalle, resumen.fecha, resumen.transportista_id])
+
+  const clientesCtasCtes = useMemo(
+    () => (detalle ?? []).filter(d => d.total_ctascte > 0),
+    [detalle]
+  )
+
+  const handleExportarExcel = useCallback(async () => {
+    if (!detalle || detalle.length === 0) return
+    setExportando(true)
+    try {
+      const filas = detalle.map(d => ({
+        Cliente: d.cliente_nombre,
+        Total: d.total,
+        'Entregas (dia)': d.total_entregas,
+        'Ctas Ctes': d.total_ctascte,
+        Efectivo: d.efectivo,
+        Transferencia: d.transferencia,
+        Otros: d.otros,
+        'Nro pagos': d.cantidad_pagos
+      }))
+      const { createMultiSheetExcel } = await import('../../utils/excel')
+      await createMultiSheetExcel(
+        [{ name: 'Detalle', data: filas, columnWidths: [28, 14, 14, 14, 12, 14, 10, 8] }],
+        `rendicion-${resumen.transportista_nombre}-${resumen.fecha}`.replace(/\s+/g, '_')
+      )
+    } finally {
+      setExportando(false)
+    }
+  }, [detalle, resumen.transportista_nombre, resumen.fecha])
 
   return (
     <div className={`bg-white dark:bg-gray-800 rounded-xl shadow-sm border-l-4 ${estadoStyle.border} overflow-hidden`}>
@@ -267,6 +346,59 @@ function ResumenCard({ resumen, onCerrar, onResolver }: ResumenCardProps): React
                 <div><span className="text-gray-500">Vale Blanco:</span> <span className="font-medium">{formatMoney(resumen.total_vale_blanco)}</span></div>
                 <div><span className="text-gray-500">Otros:</span> <span className="font-medium">{formatMoney(resumen.total_otros)}</span></div>
               </div>
+            </div>
+
+            {/* Detalle por cliente (Ítem 4) + export a Excel */}
+            <div>
+              <div className="flex items-center justify-between mb-2 flex-wrap gap-2">
+                <p className="text-xs text-gray-500 flex items-center gap-1 flex-wrap">
+                  <Users className="w-3 h-3" />
+                  Detalle por cliente
+                  {detalle && (
+                    <span className="text-gray-400">
+                      · {detalle.length} cliente{detalle.length !== 1 ? 's' : ''}
+                      {clientesCtasCtes.length > 0 && ` · ${clientesCtasCtes.length} con ctas ctes (${formatMoney(resumen.total_ctascte)})`}
+                    </span>
+                  )}
+                </p>
+                <button
+                  onClick={() => { void handleExportarExcel() }}
+                  disabled={exportando || !detalle || detalle.length === 0}
+                  className="text-xs inline-flex items-center gap-1 px-2 py-1 rounded border border-gray-300 dark:border-gray-600 text-gray-600 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 disabled:opacity-50"
+                >
+                  <Download className="w-3 h-3" />
+                  {exportando ? 'Exportando…' : 'Exportar Excel'}
+                </button>
+              </div>
+
+              {loadingDetalle ? (
+                <p className="text-xs text-gray-400 py-2">Cargando detalle…</p>
+              ) : detalle && detalle.length > 0 ? (
+                <div className="overflow-x-auto">
+                  <table className="w-full text-xs">
+                    <thead>
+                      <tr className="text-gray-500 dark:text-gray-400 text-left border-b border-gray-200 dark:border-gray-700">
+                        <th className="py-1 pr-2 font-medium">Cliente</th>
+                        <th className="py-1 px-2 font-medium text-right">Total</th>
+                        <th className="py-1 px-2 font-medium text-right">Entregas</th>
+                        <th className="py-1 pl-2 font-medium text-right">Ctas Ctes</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {detalle.map(d => (
+                        <tr key={d.cliente_id} className="border-b border-gray-100 dark:border-gray-700/50">
+                          <td className="py-1 pr-2 text-gray-700 dark:text-gray-300">{d.cliente_nombre}</td>
+                          <td className="py-1 px-2 text-right font-medium text-gray-800 dark:text-gray-200">{formatMoney(d.total)}</td>
+                          <td className="py-1 px-2 text-right text-emerald-600 dark:text-emerald-400">{d.total_entregas > 0 ? formatMoney(d.total_entregas) : '—'}</td>
+                          <td className="py-1 pl-2 text-right text-blue-600 dark:text-blue-400">{d.total_ctascte > 0 ? formatMoney(d.total_ctascte) : '—'}</td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+              ) : (
+                <p className="text-xs text-gray-400 py-2">Sin pagos ese día.</p>
+              )}
             </div>
 
             <div className="flex items-center gap-2 text-xs text-gray-500 dark:text-gray-400">

--- a/src/hooks/queries/usePedidosQuery.ts
+++ b/src/hooks/queries/usePedidosQuery.ts
@@ -8,6 +8,7 @@ import { useSucursal } from '../../contexts/SucursalContext'
 import type { PedidoDB, PedidoItemDB, PerfilDB, FiltrosPedidosState, PedidoSalvedadResumen } from '../../types'
 import { productosKeys } from './useProductosQuery'
 import { clientesKeys } from './useClientesQuery'
+import { fechaLocalISO } from '../../utils/formatters'
 
 // Query keys
 export const pedidosKeys = {
@@ -383,9 +384,21 @@ async function crearPedido(input: CrearPedidoInput): Promise<{ id: string }> {
 }
 
 async function actualizarEstado(input: ActualizarEstadoInput): Promise<PedidoDB> {
+  // Al marcar 'entregado' hay que estampar fecha_entrega (mediodia AR, igual que
+  // las RPC masivas marcar_entregas_masivo / marcar_entrega_y_pago_masivo) para
+  // que las rendiciones clasifiquen el cobro como "Entrega del dia". Sin esto el
+  // pedido queda entregado con fecha_entrega NULL y el cobro cae en "Ctas Ctes"
+  // (bug sistemico: ~38% de las entregas quedaron sin fecha desde abr-2026).
+  // Al pasar a cualquier otro estado (desmarcar/reasignar) se limpia.
+  const updateData: Record<string, unknown> = {
+    estado: input.nuevoEstado,
+    updated_at: new Date().toISOString(),
+    fecha_entrega: input.nuevoEstado === 'entregado' ? `${fechaLocalISO()}T12:00:00-03:00` : null,
+  }
+
   const { data, error } = await supabase
     .from('pedidos')
-    .update({ estado: input.nuevoEstado })
+    .update(updateData)
     .eq('id', input.pedidoId)
     .select()
     .single()

--- a/src/hooks/queries/useUltimaFechaCajaCerradaQuery.ts
+++ b/src/hooks/queries/useUltimaFechaCajaCerradaQuery.ts
@@ -1,0 +1,51 @@
+/**
+ * Hook para consultar la fecha del ultimo cierre de caja de la sucursal actual
+ * (rendicion confirmada/resuelta mas reciente). Se usa para poner el `min` de
+ * los inputs de fecha de pago: no se puede registrar una cobranza con fecha
+ * anterior o igual al ultimo cierre (lo valida el trigger del backend, mig 134).
+ *
+ * El RPC `ultima_fecha_caja_cerrada(p_sucursal_id)` se define en migracion 134.
+ */
+import { useQuery } from '@tanstack/react-query'
+import { supabase } from '../supabase/base'
+import { useSucursal } from '../../contexts/SucursalContext'
+
+export const ultimaFechaCajaCerradaKeys = {
+  all: ['ultima_fecha_caja_cerrada'] as const,
+  forSucursal: (sucursalId: number | null) =>
+    [...ultimaFechaCajaCerradaKeys.all, sucursalId] as const,
+}
+
+async function fetchUltimaFechaCajaCerrada(sucursalId: number | null): Promise<string | null> {
+  if (sucursalId == null) return null
+  const { data, error } = await supabase.rpc('ultima_fecha_caja_cerrada', {
+    p_sucursal_id: sucursalId,
+  })
+  if (error) throw error
+  return (data as string | null) ?? null
+}
+
+/** Fecha (YYYY-MM-DD) del ultimo cierre de caja de la sucursal, o null si no hay. */
+export function useUltimaFechaCajaCerradaQuery(enabled = true) {
+  const { currentSucursalId } = useSucursal()
+  return useQuery({
+    queryKey: ultimaFechaCajaCerradaKeys.forSucursal(currentSucursalId),
+    queryFn: () => fetchUltimaFechaCajaCerrada(currentSucursalId),
+    enabled: enabled && currentSucursalId != null,
+    staleTime: 60 * 1000,
+  })
+}
+
+/**
+ * Fecha minima permitida para registrar un pago (ultimo cierre + 1 dia), en
+ * formato YYYY-MM-DD para el atributo `min` de un <input type="date">. Devuelve
+ * undefined si la sucursal no tiene ninguna caja cerrada (sin restriccion).
+ */
+export function useFechaMinimaPago(enabled = true): string | undefined {
+  const { data } = useUltimaFechaCajaCerradaQuery(enabled)
+  if (!data) return undefined
+  // Anclar a mediodia UTC para que sumar un dia no cruce husos horarios.
+  const d = new Date(`${data}T12:00:00Z`)
+  d.setUTCDate(d.getUTCDate() + 1)
+  return d.toISOString().slice(0, 10)
+}


### PR DESCRIPTION
Batch de mejoras pedidas por Crecer/Taco Pozo (doc de Pablo/Pablito, 4 puntos). Los 4 son válidos; dos eran bugs (uno sistémico) y dos mejoras.

## 1. Cobranzas con fecha anterior / control de caja — gap real
Se podía backdatear: `rendicion_dia_cerrada` (mig 039) sólo frenaba al rol `encargado` y sólo dentro de las RPC — los `INSERT` directos de `pagos` lo salteaban y admin quedaba exento. Evidencia en prod: pagos con `fecha=15/05` cargados el `23/05`.

**Fix (mig 134):** `ultima_fecha_caja_cerrada(sucursal)` + trigger `BEFORE INSERT OR UPDATE OF fecha, monto` en `pagos` que rechaza `fecha <= último cierre` **para todos los roles**. `DELETE` queda exento a propósito, para poder anular/corregir. Frontend: nuevo hook `useFechaMinimaPago` pone el `min` en los dos inputs de fecha.

## 2. Saldo a favor fantasma (TITA MALDONADO) — dato + feature faltante
El pago erróneo era `pagos.id=1670` (22/05, $80.000, `pedido_id=NULL`, `[saldo a favor]`). **Ya corregido en prod**: al borrarlo, el trigger 086 revirtió el saldo de **−$8.450 "a favor" a Debe $71.550** (deuda real que el crédito fantasma tapaba).

**Feature:** botón **Anular** (admin) por fila en el Historial de Pagos de la ficha. Antes no había forma de anular un pago a cuenta (`pedido_id=NULL`): el historial era read-only y `ModalPagoPedido` sólo ve pagos con pedido. Confirmación inline dentro del modal (evita el problema de z-index con Radix).

## 3. Ventas del día en "Ctas Ctes" — BUG SISTÉMICO
**Causa raíz:** `actualizarEstado` en `usePedidosQuery.ts` (la mutación viva) marcaba `entregado` con `.update({estado})` **sin estampar `fecha_entrega`**. El hook legacy `usePedidos.ts` sí la estampaba, pero es código muerto. Resultado: **1.339 de 3.510 entregas (38%)** con `fecha_entrega` NULL desde ~abr-2026, y como la RPC exige `fecha_entrega::date = pg.fecha`, todo el cobro del día caía en "Ctas Ctes".

**Fix:** el código estampa mediodía AR (igual que las RPC masivas) y limpia al desmarcar. **Mig 133** backfillea las 1.339 filas (1er pago → `created_at` → programada → fecha) y endurece `obtener_resumen_rendiciones` con `COALESCE(fecha_entrega, pg.fecha)` como red defensiva. El backfill deshabilita `trg_pedidos_anular_control` durante el UPDATE para no destruir las rendiciones ya cerradas.

## 4. Detalle del cierre diario — mejora
**Mig 135** `obtener_detalle_rendicion(fecha, transportista)` devuelve una fila por cliente con el split entregas/ctas ctes y formas de pago. La vista lo carga al expandir "Detalle" y suma conteo de clientes, total de ctas ctes y **Exportar a Excel** (reusa `createMultiSheetExcel`).

---

## Verificación
- Entregas con `fecha_entrega` NULL: **1.339 → 0**.
- El **$473.250** de Transporte Taco Pozo (21/07) ahora clasifica en **"Entregas (cobro del día)"**.
- Las **89** rendiciones ya cerradas quedaron intactas; `trg_pedidos_anular_control` volvió a quedar habilitado.
- Guard probado: insertar un pago con fecha de un día cerrado es rechazado con mensaje claro (test con rollback, sin dejar datos).
- `typecheck` sin errores nuevos, `eslint` limpio, **794 tests** en verde.

## Notas operativas
- **Migs 133/134/135 ya aplicadas a prod** (registradas en el ledger).
- El guard de caja **ya está activo** y hoy sólo afecta a **Taco Pozo** (única sucursal que cierra rendiciones; último cierre 22/07). Para cargar un pago de un día ya cerrado hay que **reabrir esa rendición**. Tucumán no se ve afectada hasta que empiece a cerrar cajas.
- Los reportes/rendiciones de días pasados ahora incluyen entregas que antes quedaban fuera (es una corrección: algunos números cambian respecto de antes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
