### PR TITLE
fix(rendiciones): cta cte volvía a caer en Entregas + detalle colgado + drill-down + pantalla Cta cte pendiente

### DIFF
--- a/migrations/136_fix_fecha_entrega_desde_historial.sql
+++ b/migrations/136_fix_fecha_entrega_desde_historial.sql
@@ -1,0 +1,70 @@
+-- ============================================================================
+-- 136 · CORRECCION del backfill de fecha_entrega (mig 133)
+-- ============================================================================
+-- QUE SALIO MAL EN LA 133:
+--   El backfill priorizo `MIN(pagos.fecha)` como fecha de entrega. Eso alinea
+--   por definicion la entrega con el dia del cobro, con lo cual TODA venta vieja
+--   cobrada despues quedaba clasificada como "Entregas (cobro del dia)" (verde)
+--   y desaparecia del cuadro "Ctas Ctes" (azul).
+--
+--   Caso que lo detecto (reportado por Taco Pozo): pedido #3892, vendido el
+--   20/07, entregado realmente el 21/07 y cobrado el 22/07. La 133 le puso
+--   fecha_entrega = 22/07 -> aparecia en verde. Corresponde azul (cta cte).
+--
+--   Alcance medido: 1.380 pedidos / ~$49,2M mal clasificados como verde.
+--
+-- FUENTE CORRECTA: `pedido_historial` guarda el instante real del cambio de
+-- estado a 'entregado' (campo_modificado='estado', valor_nuevo='entregado').
+-- Existe para el 100% de los pedidos entregados (3.527/3.527 verificado).
+--
+-- QUE CORRIGE ESTA MIGRACION (y que NO):
+--   SI  · pedidos cuya fecha_entrega quedo igual al dia del 1er pago (grupo A,
+--         1.380) o igual al dia de creacion (grupo B, 55) Y difiere del
+--         historial. Son inequivocamente los que decidio la heuristica de 133.
+--   NO  · los ~52 restantes que difieren del historial por otra causa: son
+--         entregas masivas donde el encargado eligio una fecha contable
+--         retroactiva a proposito (`marcar_entregas_masivo(p_fecha)`). Ahi la
+--         fecha elegida es la correcta, no la del historial.
+--
+-- Se ancla a MEDIODIA AR a proposito: la RPC de rendiciones hace
+-- `fecha_entrega::date`, que castea con el timezone de la sesion (UTC en
+-- Supabase). Guardar el instante crudo haria que una entrega de las 22:00 AR
+-- caiga al dia siguiente. Mediodia AR nunca cruza de dia.
+-- ============================================================================
+
+-- El trigger trg_pedidos_anular_control BORRA la fila de rendiciones_control
+-- cuando cambia fecha_entrega. Sin deshabilitarlo, este UPDATE destruiria las
+-- ~89 rendiciones ya cerradas y ademas bajaria el techo del guard de caja
+-- (mig 134, ultima_fecha_caja_cerrada). Transaccional: si algo falla, el
+-- rollback deja el trigger habilitado.
+ALTER TABLE public.pedidos DISABLE TRIGGER trg_pedidos_anular_control;
+
+WITH h AS (
+  SELECT pedido_id, MAX(created_at) AS entregado_at
+  FROM public.pedido_historial
+  WHERE campo_modificado = 'estado' AND valor_nuevo = 'entregado'
+  GROUP BY pedido_id
+), pp AS (
+  SELECT pedido_id, MIN(fecha) AS primer_pago
+  FROM public.pagos WHERE pedido_id IS NOT NULL GROUP BY pedido_id
+), objetivo AS (
+  SELECT p.id,
+         (h.entregado_at AT TIME ZONE 'America/Argentina/Buenos_Aires')::date AS fecha_real
+  FROM public.pedidos p
+  JOIN h ON h.pedido_id = p.id
+  LEFT JOIN pp ON pp.pedido_id = p.id
+  WHERE p.estado = 'entregado'
+    AND p.fecha_entrega::date IS DISTINCT FROM (h.entregado_at AT TIME ZONE 'America/Argentina/Buenos_Aires')::date
+    AND (
+      -- grupo A: la 133 lo alineo al dia del primer pago
+      (pp.primer_pago IS NOT NULL AND p.fecha_entrega::date = pp.primer_pago)
+      -- grupo B: la 133 cayo al fallback created_at
+      OR p.fecha_entrega::date = (p.created_at AT TIME ZONE 'America/Argentina/Buenos_Aires')::date
+    )
+)
+UPDATE public.pedidos p
+SET fecha_entrega = (o.fecha_real::text || ' 12:00:00 America/Argentina/Buenos_Aires')::timestamptz
+FROM objetivo o
+WHERE p.id = o.id;
+
+ALTER TABLE public.pedidos ENABLE TRIGGER trg_pedidos_anular_control;

--- a/migrations/137_detalle_rendicion_formas_pago.sql
+++ b/migrations/137_detalle_rendicion_formas_pago.sql
@@ -1,0 +1,90 @@
+-- ============================================================================
+-- 137 · obtener_detalle_rendicion: todas las formas de pago por cliente
+-- ============================================================================
+-- Pedido de Taco Pozo: poder clickear un total del breakdown (p. ej.
+-- "Transferencia $90.850") y ver QUE CLIENTES y QUE MONTOS lo componen. Idem
+-- cheque, tarjeta, vale blanco, etc.
+--
+-- La version 135 solo devolvia efectivo / transferencia / otros, con lo cual el
+-- drill-down de cheque/tarjeta/vale_blanco era imposible. Se agregan las tres
+-- columnas y `otros` pasa a ser el resto real (ni efectivo, ni transferencia,
+-- ni cheque, ni tarjeta, ni vale_blanco, ni cuenta_corriente).
+--
+-- `cuenta_corriente` como forma de pago esta deprecada (mig 074) pero sigue
+-- existiendo en datos historicos: se expone aparte para que la suma de columnas
+-- cierre siempre contra el total.
+-- ============================================================================
+
+DROP FUNCTION IF EXISTS public.obtener_detalle_rendicion(date, uuid);
+
+CREATE OR REPLACE FUNCTION public.obtener_detalle_rendicion(
+  p_fecha date,
+  p_transportista_id uuid
+)
+RETURNS TABLE(
+  cliente_id bigint,
+  cliente_nombre text,
+  total numeric,
+  total_entregas numeric,
+  total_ctascte numeric,
+  efectivo numeric,
+  transferencia numeric,
+  cheque numeric,
+  tarjeta numeric,
+  vale_blanco numeric,
+  cuenta_corriente numeric,
+  otros numeric,
+  cantidad_pagos bigint
+)
+LANGUAGE plpgsql
+STABLE SECURITY DEFINER
+SET search_path TO 'public'
+AS $function$
+DECLARE
+  v_sucursal_id bigint;
+BEGIN
+  v_sucursal_id := current_sucursal_id();
+  IF v_sucursal_id IS NULL THEN
+    RAISE EXCEPTION 'Sucursal no seleccionada';
+  END IF;
+  IF NOT es_encargado_o_admin() THEN
+    RAISE EXCEPTION 'No autorizado';
+  END IF;
+
+  RETURN QUERY
+  SELECT
+    pg.cliente_id AS cliente_id,
+    COALESCE(NULLIF(c.nombre_fantasia, ''), c.razon_social, 'Cliente #' || pg.cliente_id)::text AS cliente_nombre,
+    SUM(pg.monto)::numeric AS total,
+    -- Mismo criterio que obtener_resumen_rendiciones (migs 133/136).
+    SUM(CASE
+      WHEN pg.pedido_id IS NOT NULL
+       AND pd.estado = 'entregado'
+       AND COALESCE(pd.fecha_entrega::date, pg.fecha) = pg.fecha
+      THEN pg.monto ELSE 0 END)::numeric AS total_entregas,
+    SUM(CASE
+      WHEN pg.pedido_id IS NULL
+        OR pd.estado IS DISTINCT FROM 'entregado'
+        OR COALESCE(pd.fecha_entrega::date, pg.fecha) IS DISTINCT FROM pg.fecha
+      THEN pg.monto ELSE 0 END)::numeric AS total_ctascte,
+    SUM(CASE WHEN pg.forma_pago = 'efectivo' THEN pg.monto ELSE 0 END)::numeric AS efectivo,
+    SUM(CASE WHEN pg.forma_pago = 'transferencia' THEN pg.monto ELSE 0 END)::numeric AS transferencia,
+    SUM(CASE WHEN pg.forma_pago = 'cheque' THEN pg.monto ELSE 0 END)::numeric AS cheque,
+    SUM(CASE WHEN pg.forma_pago = 'tarjeta' THEN pg.monto ELSE 0 END)::numeric AS tarjeta,
+    SUM(CASE WHEN pg.forma_pago = 'vale_blanco' THEN pg.monto ELSE 0 END)::numeric AS vale_blanco,
+    SUM(CASE WHEN pg.forma_pago = 'cuenta_corriente' THEN pg.monto ELSE 0 END)::numeric AS cuenta_corriente,
+    SUM(CASE WHEN pg.forma_pago NOT IN ('efectivo','transferencia','cheque','tarjeta','vale_blanco','cuenta_corriente')
+              OR pg.forma_pago IS NULL THEN pg.monto ELSE 0 END)::numeric AS otros,
+    COUNT(*)::bigint AS cantidad_pagos
+  FROM pagos pg
+  LEFT JOIN pedidos pd ON pd.id = pg.pedido_id
+  LEFT JOIN clientes c ON c.id = pg.cliente_id
+  WHERE pg.fecha = p_fecha
+    AND pg.sucursal_id = v_sucursal_id
+    AND COALESCE(pd.transportista_id, pg.usuario_id) = p_transportista_id
+  GROUP BY pg.cliente_id, c.nombre_fantasia, c.razon_social
+  ORDER BY SUM(pg.monto) DESC;
+END;
+$function$;
+
+GRANT EXECUTE ON FUNCTION public.obtener_detalle_rendicion(date, uuid) TO authenticated;

--- a/migrations/138_pedidos_ctacte_pendientes.sql
+++ b/migrations/138_pedidos_ctacte_pendientes.sql
@@ -1,0 +1,84 @@
+-- ============================================================================
+-- 138 · obtener_pedidos_ctacte_pendientes — detalle de deuda por pedido
+-- ============================================================================
+-- Pedido de Taco Pozo: "necesito de que listado o pantalla consulto el detalle y
+-- el total de los pedidos entregados que quedaron en cuenta corriente, o sea
+-- pendiente de pago, y que sea el mismo rango de fechas que estoy tomando en la
+-- rendicion".
+--
+-- Hoy no existia: todo lo que agrega deuda lo hace POR CLIENTE y sin rango de
+-- fechas (`obtener_deudores_mora` mig 075, ReporteCuentasPorCobrar) o da solo el
+-- numero total sin detalle (`reporte_gerencial -> cobranza.pendiente`).
+--
+-- Devuelve una fila POR PEDIDO. El rango filtra por FECHA DE ENTREGA (el dia en
+-- que se genero la deuda, que es la misma dimension que usa el bloque
+-- "Entregado" de la rendicion), no por fecha de pago. Con p_desde/p_hasta NULL
+-- devuelve toda la deuda viva.
+--
+-- Mismo predicado de deuda que mig 075 / 109: entregado + estado_pago
+-- pendiente|parcial + saldo > 0.
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION public.obtener_pedidos_ctacte_pendientes(
+  p_desde date DEFAULT NULL,
+  p_hasta date DEFAULT NULL,
+  p_transportista_id uuid DEFAULT NULL
+)
+RETURNS TABLE(
+  pedido_id bigint,
+  fecha_pedido date,
+  fecha_entrega date,
+  dias integer,
+  cliente_id bigint,
+  cliente_nombre text,
+  transportista_nombre text,
+  total numeric,
+  cobrado numeric,
+  saldo numeric,
+  estado_pago text
+)
+LANGUAGE plpgsql
+STABLE SECURITY DEFINER
+SET search_path TO 'public'
+AS $function$
+DECLARE
+  v_sucursal_id bigint;
+BEGIN
+  v_sucursal_id := current_sucursal_id();
+  IF v_sucursal_id IS NULL THEN
+    RAISE EXCEPTION 'Sucursal no seleccionada';
+  END IF;
+  IF NOT es_encargado_o_admin() THEN
+    RAISE EXCEPTION 'No autorizado';
+  END IF;
+
+  RETURN QUERY
+  SELECT
+    p.id AS pedido_id,
+    p.fecha AS fecha_pedido,
+    (p.fecha_entrega AT TIME ZONE 'America/Argentina/Buenos_Aires')::date AS fecha_entrega,
+    (CURRENT_DATE - (p.fecha_entrega AT TIME ZONE 'America/Argentina/Buenos_Aires')::date)::integer AS dias,
+    c.id AS cliente_id,
+    COALESCE(NULLIF(c.nombre_fantasia, ''), c.razon_social, 'Cliente #' || c.id)::text AS cliente_nombre,
+    COALESCE(tr.nombre, 'Sin asignar')::text AS transportista_nombre,
+    p.total::numeric AS total,
+    COALESCE(p.monto_pagado, 0)::numeric AS cobrado,
+    (p.total - COALESCE(p.monto_pagado, 0))::numeric AS saldo,
+    COALESCE(p.estado_pago, 'pendiente')::text AS estado_pago
+  FROM pedidos p
+  LEFT JOIN clientes c ON c.id = p.cliente_id
+  LEFT JOIN perfiles tr ON tr.id = p.transportista_id
+  WHERE p.sucursal_id = v_sucursal_id
+    AND p.estado = 'entregado'
+    AND COALESCE(p.estado_pago, 'pendiente') IN ('pendiente', 'parcial')
+    AND p.total > COALESCE(p.monto_pagado, 0)
+    AND (p_transportista_id IS NULL OR p.transportista_id = p_transportista_id)
+    AND (p_desde IS NULL
+         OR (p.fecha_entrega AT TIME ZONE 'America/Argentina/Buenos_Aires')::date >= p_desde)
+    AND (p_hasta IS NULL
+         OR (p.fecha_entrega AT TIME ZONE 'America/Argentina/Buenos_Aires')::date <= p_hasta)
+  ORDER BY (p.fecha_entrega AT TIME ZONE 'America/Argentina/Buenos_Aires')::date ASC, p.id ASC;
+END;
+$function$;
+
+GRANT EXECUTE ON FUNCTION public.obtener_pedidos_ctacte_pendientes(date, date, uuid) TO authenticated;

--- a/src/components/modals/ModalCtaCtePendiente.tsx
+++ b/src/components/modals/ModalCtaCtePendiente.tsx
@@ -1,0 +1,250 @@
+/**
+ * ModalCtaCtePendiente — detalle y total de los pedidos ENTREGADOS que quedaron
+ * pendientes de cobro (cuenta corriente).
+ *
+ * Se abre desde la pantalla de Rendiciones y arranca con el MISMO rango de
+ * fechas que se esta mirando ahi, para poder cuadrar "entregue X / cobre Y /
+ * quedo Z en cta cte" sobre el mismo periodo. El rango filtra por FECHA DE
+ * ENTREGA (el dia en que se genero la deuda), no por fecha de pago.
+ *
+ * Datos: RPC `obtener_pedidos_ctacte_pendientes` (mig 138), una fila por pedido.
+ */
+import { memo, useCallback, useEffect, useMemo, useState } from 'react'
+import { Download, Loader2, Users, FileText } from 'lucide-react'
+import ModalBase from './ModalBase'
+import { supabase } from '../../hooks/supabase/base'
+
+export interface CtaCtePendienteRow {
+  pedido_id: number
+  fecha_pedido: string
+  fecha_entrega: string
+  dias: number
+  cliente_id: number
+  cliente_nombre: string
+  transportista_nombre: string
+  total: number
+  cobrado: number
+  saldo: number
+  estado_pago: string
+}
+
+export interface ModalCtaCtePendienteProps {
+  fechaDesde: string
+  fechaHasta: string
+  /** Transportista del filtro de la vista ('' = todos) */
+  transportistaId?: string
+  onClose: () => void
+}
+
+function formatMoney(value: number | undefined | null): string {
+  return new Intl.NumberFormat('es-AR', { style: 'currency', currency: 'ARS' }).format(value || 0)
+}
+
+function formatFechaCorta(fechaISO: string | null): string {
+  if (!fechaISO) return '—'
+  const [y, m, d] = fechaISO.split('-')
+  return `${d}/${m}/${y}`
+}
+
+function ModalCtaCtePendiente({
+  fechaDesde,
+  fechaHasta,
+  transportistaId,
+  onClose
+}: ModalCtaCtePendienteProps) {
+  const [filas, setFilas] = useState<CtaCtePendienteRow[]>([])
+  const [loading, setLoading] = useState(true)
+  const [exportando, setExportando] = useState(false)
+  /** false = solo el rango de la rendicion · true = toda la deuda viva */
+  const [verTodo, setVerTodo] = useState(false)
+
+  useEffect(() => {
+    let cancelado = false
+    setLoading(true)
+    void (async () => {
+      const { data, error } = await supabase.rpc('obtener_pedidos_ctacte_pendientes', {
+        p_desde: verTodo ? null : fechaDesde,
+        p_hasta: verTodo ? null : fechaHasta,
+        p_transportista_id: transportistaId || null
+      })
+      if (cancelado) return
+      if (error) {
+        setFilas([])
+      } else {
+        setFilas((data || []).map((r: Record<string, unknown>) => ({
+          pedido_id: Number(r.pedido_id),
+          fecha_pedido: String(r.fecha_pedido ?? ''),
+          fecha_entrega: String(r.fecha_entrega ?? ''),
+          dias: Number(r.dias) || 0,
+          cliente_id: Number(r.cliente_id),
+          cliente_nombre: String(r.cliente_nombre ?? 'Cliente'),
+          transportista_nombre: String(r.transportista_nombre ?? 'Sin asignar'),
+          total: Number(r.total) || 0,
+          cobrado: Number(r.cobrado) || 0,
+          saldo: Number(r.saldo) || 0,
+          estado_pago: String(r.estado_pago ?? 'pendiente')
+        })))
+      }
+      setLoading(false)
+    })()
+    return () => { cancelado = true }
+  }, [fechaDesde, fechaHasta, transportistaId, verTodo])
+
+  const totales = useMemo(() => ({
+    pedidos: filas.length,
+    clientes: new Set(filas.map(f => f.cliente_id)).size,
+    total: filas.reduce((a, f) => a + f.total, 0),
+    cobrado: filas.reduce((a, f) => a + f.cobrado, 0),
+    saldo: filas.reduce((a, f) => a + f.saldo, 0)
+  }), [filas])
+
+  const handleExportar = useCallback(async () => {
+    if (filas.length === 0) return
+    setExportando(true)
+    try {
+      const data = filas.map(f => ({
+        Cliente: f.cliente_nombre,
+        Pedido: f.pedido_id,
+        'Fecha pedido': formatFechaCorta(f.fecha_pedido),
+        'Fecha entrega': formatFechaCorta(f.fecha_entrega),
+        Días: f.dias,
+        Transportista: f.transportista_nombre,
+        Total: f.total,
+        Cobrado: f.cobrado,
+        Saldo: f.saldo,
+        Estado: f.estado_pago
+      }))
+      const { createMultiSheetExcel } = await import('../../utils/excel')
+      const sufijo = verTodo ? 'todo' : `${fechaDesde}_a_${fechaHasta}`
+      await createMultiSheetExcel(
+        [{ name: 'Cta Cte pendiente', data, columnWidths: [28, 9, 13, 13, 7, 20, 14, 14, 14, 11] }],
+        `ctacte-pendiente-${sufijo}`
+      )
+    } finally {
+      setExportando(false)
+    }
+  }, [filas, verTodo, fechaDesde, fechaHasta])
+
+  return (
+    <ModalBase
+      title="Cuenta corriente pendiente"
+      description="Pedidos entregados que todavía no se cobraron"
+      onClose={onClose}
+      maxWidth="max-w-5xl"
+    >
+      <div className="space-y-4">
+        {/* Contexto del rango + toggle */}
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <p className="text-sm text-gray-600 dark:text-gray-400">
+            {verTodo
+              ? 'Toda la deuda viva (sin filtro de fechas)'
+              : <>Entregas del <strong>{formatFechaCorta(fechaDesde)}</strong> al <strong>{formatFechaCorta(fechaHasta)}</strong></>}
+          </p>
+          <label className="flex items-center gap-2 text-sm text-gray-600 dark:text-gray-300 cursor-pointer">
+            <input
+              type="checkbox"
+              checked={verTodo}
+              onChange={e => setVerTodo(e.target.checked)}
+              className="rounded"
+            />
+            Ver toda la deuda
+          </label>
+        </div>
+
+        {/* Totales */}
+        <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
+          <div className="bg-gray-50 dark:bg-gray-700/50 rounded-lg p-3">
+            <p className="text-xs text-gray-500 flex items-center gap-1"><FileText className="w-3 h-3" />Pedidos</p>
+            <p className="text-xl font-bold text-gray-800 dark:text-white">{totales.pedidos}</p>
+          </div>
+          <div className="bg-gray-50 dark:bg-gray-700/50 rounded-lg p-3">
+            <p className="text-xs text-gray-500 flex items-center gap-1"><Users className="w-3 h-3" />Clientes</p>
+            <p className="text-xl font-bold text-gray-800 dark:text-white">{totales.clientes}</p>
+          </div>
+          <div className="bg-gray-50 dark:bg-gray-700/50 rounded-lg p-3">
+            <p className="text-xs text-gray-500">Entregado</p>
+            <p className="text-lg font-bold text-gray-800 dark:text-white">{formatMoney(totales.total)}</p>
+            <p className="text-xs text-gray-500 mt-0.5">Cobrado: {formatMoney(totales.cobrado)}</p>
+          </div>
+          <div className="bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-800 rounded-lg p-3">
+            <p className="text-xs text-blue-700 dark:text-blue-300">Saldo en cta cte</p>
+            <p className="text-lg font-bold text-blue-700 dark:text-blue-300">{formatMoney(totales.saldo)}</p>
+          </div>
+        </div>
+
+        <div className="flex justify-end">
+          <button
+            onClick={() => { void handleExportar() }}
+            disabled={exportando || loading || filas.length === 0}
+            className="text-sm inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-700 disabled:opacity-50"
+          >
+            <Download className="w-4 h-4" />
+            {exportando ? 'Exportando…' : 'Exportar Excel'}
+          </button>
+        </div>
+
+        {/* Detalle */}
+        {loading ? (
+          <div className="flex items-center justify-center py-10 text-gray-500 gap-2">
+            <Loader2 className="w-5 h-5 animate-spin" />
+            Cargando…
+          </div>
+        ) : filas.length === 0 ? (
+          <p className="text-center py-10 text-gray-500">
+            No hay pedidos entregados pendientes de cobro en este período.
+          </p>
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="text-left text-gray-500 dark:text-gray-400 border-b border-gray-200 dark:border-gray-700">
+                  <th className="py-2 pr-2 font-medium">Cliente</th>
+                  <th className="py-2 px-2 font-medium">Pedido</th>
+                  <th className="py-2 px-2 font-medium">Entrega</th>
+                  <th className="py-2 px-2 font-medium text-right">Días</th>
+                  <th className="py-2 px-2 font-medium text-right">Total</th>
+                  <th className="py-2 px-2 font-medium text-right">Cobrado</th>
+                  <th className="py-2 pl-2 font-medium text-right">Saldo</th>
+                </tr>
+              </thead>
+              <tbody>
+                {filas.map(f => (
+                  <tr key={f.pedido_id} className="border-b border-gray-100 dark:border-gray-700/50">
+                    <td className="py-2 pr-2 text-gray-800 dark:text-gray-200">
+                      {f.cliente_nombre}
+                      {f.estado_pago === 'parcial' && (
+                        <span className="ml-1.5 px-1.5 py-0.5 rounded text-xs bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-300">
+                          parcial
+                        </span>
+                      )}
+                    </td>
+                    <td className="py-2 px-2 text-gray-500">#{f.pedido_id}</td>
+                    <td className="py-2 px-2 text-gray-500">{formatFechaCorta(f.fecha_entrega)}</td>
+                    <td className="py-2 px-2 text-right text-gray-500">{f.dias}</td>
+                    <td className="py-2 px-2 text-right text-gray-700 dark:text-gray-300">{formatMoney(f.total)}</td>
+                    <td className="py-2 px-2 text-right text-emerald-600 dark:text-emerald-400">
+                      {f.cobrado > 0 ? formatMoney(f.cobrado) : '—'}
+                    </td>
+                    <td className="py-2 pl-2 text-right font-semibold text-blue-700 dark:text-blue-300">{formatMoney(f.saldo)}</td>
+                  </tr>
+                ))}
+              </tbody>
+              <tfoot>
+                <tr className="border-t-2 border-gray-300 dark:border-gray-600">
+                  <td colSpan={4} className="py-2 pr-2 font-semibold text-gray-700 dark:text-gray-200">
+                    Total ({totales.pedidos} pedido{totales.pedidos !== 1 ? 's' : ''})
+                  </td>
+                  <td className="py-2 px-2 text-right font-semibold text-gray-700 dark:text-gray-200">{formatMoney(totales.total)}</td>
+                  <td className="py-2 px-2 text-right font-semibold text-emerald-600 dark:text-emerald-400">{formatMoney(totales.cobrado)}</td>
+                  <td className="py-2 pl-2 text-right font-bold text-blue-700 dark:text-blue-300">{formatMoney(totales.saldo)}</td>
+                </tr>
+              </tfoot>
+            </table>
+          </div>
+        )}
+      </div>
+    </ModalBase>
+  )
+}
+
+export default memo(ModalCtaCtePendiente)

--- a/src/components/vistas/VistaRendiciones.tsx
+++ b/src/components/vistas/VistaRendiciones.tsx
@@ -64,7 +64,7 @@ const ESTADO_STYLES: Record<EstadoRendicion, { label: string; badge: string; bor
   }
 }
 
-/** Fila del detalle por cliente de una rendición (RPC obtener_detalle_rendicion, mig 135). */
+/** Fila del detalle por cliente de una rendición (RPC obtener_detalle_rendicion, migs 135/137). */
 interface DetalleRendicionCliente {
   cliente_id: number
   cliente_nombre: string
@@ -73,8 +73,23 @@ interface DetalleRendicionCliente {
   total_ctascte: number
   efectivo: number
   transferencia: number
+  cheque: number
+  tarjeta: number
+  vale_blanco: number
   otros: number
   cantidad_pagos: number
+}
+
+/** Claves de forma de pago que se pueden usar para filtrar el detalle. */
+type FormaKey = 'efectivo' | 'transferencia' | 'cheque' | 'tarjeta' | 'vale_blanco' | 'otros'
+
+const FORMA_LABELS: Record<FormaKey, string> = {
+  efectivo: 'Efectivo',
+  transferencia: 'Transferencia',
+  cheque: 'Cheque',
+  tarjeta: 'Tarjeta',
+  vale_blanco: 'Vale Blanco',
+  otros: 'Otros'
 }
 
 interface ResumenCardProps {
@@ -88,6 +103,9 @@ function ResumenCard({ resumen, onCerrar, onResolver }: ResumenCardProps): React
   const [detalle, setDetalle] = useState<DetalleRendicionCliente[] | null>(null)
   const [loadingDetalle, setLoadingDetalle] = useState(false)
   const [exportando, setExportando] = useState(false)
+  // Drill-down: al clickear una forma de pago del breakdown se filtra el detalle
+  // por cliente para ver quien compone ese total.
+  const [formaFiltro, setFormaFiltro] = useState<FormaKey | null>(null)
   const estadoStyle = ESTADO_STYLES[resumen.estado]
 
   const desgloses = useMemo(() => {
@@ -112,9 +130,12 @@ function ResumenCard({ resumen, onCerrar, onResolver }: ResumenCardProps): React
       ? `+${formatMoney(diferencia)} cobrado sobre entregado`
       : `${formatMoney(diferencia)} cobrado menos que entregado`
 
-  // Detalle por cliente: se carga la primera vez que se expande la tarjeta.
+  // Detalle por cliente: se carga cada vez que se expande la tarjeta.
+  // OJO: las deps NO pueden incluir `detalle`/`loadingDetalle`. Al setear el
+  // loading se re-dispararia el effect, su cleanup cancelaria el fetch en vuelo
+  // y el "Cargando detalle..." quedaba colgado para siempre.
   useEffect(() => {
-    if (!expandido || detalle !== null || loadingDetalle) return
+    if (!expandido) return
     let cancelado = false
     setLoadingDetalle(true)
     void (async () => {
@@ -134,6 +155,9 @@ function ResumenCard({ resumen, onCerrar, onResolver }: ResumenCardProps): React
           total_ctascte: Number(r.total_ctascte) || 0,
           efectivo: Number(r.efectivo) || 0,
           transferencia: Number(r.transferencia) || 0,
+          cheque: Number(r.cheque) || 0,
+          tarjeta: Number(r.tarjeta) || 0,
+          vale_blanco: Number(r.vale_blanco) || 0,
           otros: Number(r.otros) || 0,
           cantidad_pagos: Number(r.cantidad_pagos) || 0
         })))
@@ -141,12 +165,19 @@ function ResumenCard({ resumen, onCerrar, onResolver }: ResumenCardProps): React
       setLoadingDetalle(false)
     })()
     return () => { cancelado = true }
-  }, [expandido, detalle, loadingDetalle, resumen.fecha, resumen.transportista_id])
+  }, [expandido, resumen.fecha, resumen.transportista_id])
 
   const clientesCtasCtes = useMemo(
     () => (detalle ?? []).filter(d => d.total_ctascte > 0),
     [detalle]
   )
+
+  // Filas visibles: con filtro activo, solo los clientes que aportaron a esa forma.
+  const detalleVisible = useMemo(() => {
+    if (!detalle) return []
+    if (!formaFiltro) return detalle
+    return detalle.filter(d => (d[formaFiltro] || 0) > 0)
+  }, [detalle, formaFiltro])
 
   const handleExportarExcel = useCallback(async () => {
     if (!detalle || detalle.length === 0) return
@@ -159,12 +190,15 @@ function ResumenCard({ resumen, onCerrar, onResolver }: ResumenCardProps): React
         'Ctas Ctes': d.total_ctascte,
         Efectivo: d.efectivo,
         Transferencia: d.transferencia,
+        Cheque: d.cheque,
+        Tarjeta: d.tarjeta,
+        'Vale Blanco': d.vale_blanco,
         Otros: d.otros,
         'Nro pagos': d.cantidad_pagos
       }))
       const { createMultiSheetExcel } = await import('../../utils/excel')
       await createMultiSheetExcel(
-        [{ name: 'Detalle', data: filas, columnWidths: [28, 14, 14, 14, 12, 14, 10, 8] }],
+        [{ name: 'Detalle', data: filas, columnWidths: [28, 14, 14, 14, 12, 14, 12, 12, 12, 10, 8] }],
         `rendicion-${resumen.transportista_nombre}-${resumen.fecha}`.replace(/\s+/g, '_')
       )
     } finally {
@@ -331,20 +365,39 @@ function ResumenCard({ resumen, onCerrar, onResolver }: ResumenCardProps): React
         {expandido && (
           <div className="mt-4 pt-3 border-t border-gray-200 dark:border-gray-700 text-sm space-y-3">
             <div>
-              <p className="text-xs text-gray-500 mb-2">Breakdown completo por forma de pago</p>
+              <p className="text-xs text-gray-500 mb-2">
+                Breakdown completo por forma de pago
+                <span className="text-gray-400"> · clickeá una para ver qué clientes la componen</span>
+              </p>
               <div className="grid grid-cols-2 sm:grid-cols-3 gap-2">
-                <div><span className="text-gray-500">Efectivo:</span> <span className="font-medium">{formatMoney(resumen.total_efectivo)}</span></div>
-                <div><span className="text-gray-500">Transferencia:</span> <span className="font-medium">{formatMoney(resumen.total_transferencia)}</span></div>
-                <div><span className="text-gray-500">Cheque:</span> <span className="font-medium">{formatMoney(resumen.total_cheque)}</span></div>
+                {([
+                  ['efectivo', 'Efectivo', resumen.total_efectivo],
+                  ['transferencia', 'Transferencia', resumen.total_transferencia],
+                  ['cheque', 'Cheque', resumen.total_cheque],
+                  ['tarjeta', 'Tarjeta', resumen.total_tarjeta],
+                  ['vale_blanco', 'Vale Blanco', resumen.total_vale_blanco],
+                  ['otros', 'Otros', resumen.total_otros]
+                ] as [FormaKey, string, number][]).map(([key, label, valor]) => (
+                  <button
+                    key={key}
+                    onClick={() => setFormaFiltro(formaFiltro === key ? null : key)}
+                    disabled={valor === 0}
+                    className={`text-left px-1.5 py-1 rounded transition-colors disabled:cursor-default ${
+                      formaFiltro === key
+                        ? 'bg-blue-100 dark:bg-blue-900/30 ring-1 ring-blue-400'
+                        : valor > 0 ? 'hover:bg-gray-100 dark:hover:bg-gray-700' : ''
+                    }`}
+                  >
+                    <span className="text-gray-500">{label}:</span>{' '}
+                    <span className="font-medium">{formatMoney(valor)}</span>
+                  </button>
+                ))}
                 {/* Cuenta corriente como forma de pago está deprecada (ya no se registran pagos así):
                     solo se muestra para datos históricos con monto, evitando un $0 permanente que confunde.
                     La cuenta corriente real (cobro de saldos) se ve arriba en la tarjeta "Ctas Ctes". */}
                 {resumen.total_cuenta_corriente > 0 && (
-                  <div><span className="text-gray-500">Cuenta Cte.:</span> <span className="font-medium">{formatMoney(resumen.total_cuenta_corriente)}</span></div>
+                  <div className="px-1.5 py-1"><span className="text-gray-500">Cuenta Cte.:</span> <span className="font-medium">{formatMoney(resumen.total_cuenta_corriente)}</span></div>
                 )}
-                <div><span className="text-gray-500">Tarjeta:</span> <span className="font-medium">{formatMoney(resumen.total_tarjeta)}</span></div>
-                <div><span className="text-gray-500">Vale Blanco:</span> <span className="font-medium">{formatMoney(resumen.total_vale_blanco)}</span></div>
-                <div><span className="text-gray-500">Otros:</span> <span className="font-medium">{formatMoney(resumen.total_otros)}</span></div>
               </div>
             </div>
 
@@ -354,11 +407,19 @@ function ResumenCard({ resumen, onCerrar, onResolver }: ResumenCardProps): React
                 <p className="text-xs text-gray-500 flex items-center gap-1 flex-wrap">
                   <Users className="w-3 h-3" />
                   Detalle por cliente
-                  {detalle && (
+                  {detalle && !formaFiltro && (
                     <span className="text-gray-400">
                       · {detalle.length} cliente{detalle.length !== 1 ? 's' : ''}
                       {clientesCtasCtes.length > 0 && ` · ${clientesCtasCtes.length} con ctas ctes (${formatMoney(resumen.total_ctascte)})`}
                     </span>
+                  )}
+                  {formaFiltro && (
+                    <button
+                      onClick={() => setFormaFiltro(null)}
+                      className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full bg-blue-100 dark:bg-blue-900/30 text-blue-700 dark:text-blue-300"
+                    >
+                      {FORMA_LABELS[formaFiltro]}: {detalleVisible.length} cliente{detalleVisible.length !== 1 ? 's' : ''} ✕
+                    </button>
                   )}
                 </p>
                 <button
@@ -373,31 +434,48 @@ function ResumenCard({ resumen, onCerrar, onResolver }: ResumenCardProps): React
 
               {loadingDetalle ? (
                 <p className="text-xs text-gray-400 py-2">Cargando detalle…</p>
-              ) : detalle && detalle.length > 0 ? (
+              ) : detalleVisible.length > 0 ? (
                 <div className="overflow-x-auto">
                   <table className="w-full text-xs">
                     <thead>
                       <tr className="text-gray-500 dark:text-gray-400 text-left border-b border-gray-200 dark:border-gray-700">
                         <th className="py-1 pr-2 font-medium">Cliente</th>
+                        {formaFiltro && <th className="py-1 px-2 font-medium text-right">{FORMA_LABELS[formaFiltro]}</th>}
                         <th className="py-1 px-2 font-medium text-right">Total</th>
                         <th className="py-1 px-2 font-medium text-right">Entregas</th>
                         <th className="py-1 pl-2 font-medium text-right">Ctas Ctes</th>
                       </tr>
                     </thead>
                     <tbody>
-                      {detalle.map(d => (
+                      {detalleVisible.map(d => (
                         <tr key={d.cliente_id} className="border-b border-gray-100 dark:border-gray-700/50">
                           <td className="py-1 pr-2 text-gray-700 dark:text-gray-300">{d.cliente_nombre}</td>
+                          {formaFiltro && (
+                            <td className="py-1 px-2 text-right font-semibold text-blue-700 dark:text-blue-300">{formatMoney(d[formaFiltro])}</td>
+                          )}
                           <td className="py-1 px-2 text-right font-medium text-gray-800 dark:text-gray-200">{formatMoney(d.total)}</td>
                           <td className="py-1 px-2 text-right text-emerald-600 dark:text-emerald-400">{d.total_entregas > 0 ? formatMoney(d.total_entregas) : '—'}</td>
                           <td className="py-1 pl-2 text-right text-blue-600 dark:text-blue-400">{d.total_ctascte > 0 ? formatMoney(d.total_ctascte) : '—'}</td>
                         </tr>
                       ))}
                     </tbody>
+                    {formaFiltro && (
+                      <tfoot>
+                        <tr className="border-t border-gray-300 dark:border-gray-600">
+                          <td className="py-1 pr-2 font-medium text-gray-600 dark:text-gray-300">Total {FORMA_LABELS[formaFiltro]}</td>
+                          <td className="py-1 px-2 text-right font-bold text-blue-700 dark:text-blue-300">
+                            {formatMoney(detalleVisible.reduce((acc, d) => acc + (d[formaFiltro] || 0), 0))}
+                          </td>
+                          <td colSpan={3} />
+                        </tr>
+                      </tfoot>
+                    )}
                   </table>
                 </div>
               ) : (
-                <p className="text-xs text-gray-400 py-2">Sin pagos ese día.</p>
+                <p className="text-xs text-gray-400 py-2">
+                  {formaFiltro ? 'Ningún cliente pagó con esa forma ese día.' : 'Sin pagos ese día.'}
+                </p>
               )}
             </div>
 

--- a/src/components/vistas/VistaRendiciones.tsx
+++ b/src/components/vistas/VistaRendiciones.tsx
@@ -19,6 +19,7 @@ import {
   FileText,
   Receipt,
   Download,
+  Wallet,
   Users
 } from 'lucide-react'
 import { fechaLocalISO } from '../../utils/formatters'
@@ -31,6 +32,7 @@ import type { ResumenRendicionDiaria, PerfilDB, EstadoRendicion, RendicionGastoI
 
 const ModalCerrarRendicion = lazy(() => import('../modals/ModalCerrarRendicion'))
 const ModalResolverRendicion = lazy(() => import('../modals/ModalResolverRendicion'))
+const ModalCtaCtePendiente = lazy(() => import('../modals/ModalCtaCtePendiente'))
 
 function formatMoney(value: number | undefined | null): string {
   return new Intl.NumberFormat('es-AR', { style: 'currency', currency: 'ARS' }).format(value || 0)
@@ -525,6 +527,7 @@ export default function VistaRendiciones(): React.ReactElement {
   const [cerrarResumen, setCerrarResumen] = useState<ResumenRendicionDiaria | null>(null)
   const [resolverResumen, setResolverResumen] = useState<ResumenRendicionDiaria | null>(null)
   const [guardando, setGuardando] = useState(false)
+  const [verCtaCte, setVerCtaCte] = useState(false)
 
   const cargar = useCallback(async (): Promise<void> => {
     await fetchResumen(fechaDesde, fechaHasta, transportistaFiltro || null)
@@ -607,14 +610,25 @@ export default function VistaRendiciones(): React.ReactElement {
             Resumen auto-calculado por transportista y día (basado en fecha de pago)
           </p>
         </div>
-        <button
-          onClick={cargar}
-          disabled={loading}
-          className="flex items-center gap-2 px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded-lg transition-colors disabled:opacity-50"
-        >
-          <RefreshCw className={`w-4 h-4 ${loading ? 'animate-spin' : ''}`} />
-          Refrescar
-        </button>
+        <div className="flex items-center gap-2 flex-wrap">
+          {/* Deuda del mismo rango que la rendición, para poder cuadrar
+              entregado vs cobrado vs pendiente en un solo lugar. */}
+          <button
+            onClick={() => setVerCtaCte(true)}
+            className="flex items-center gap-2 px-4 py-2 border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-lg transition-colors"
+          >
+            <Wallet className="w-4 h-4" />
+            Cta cte pendiente
+          </button>
+          <button
+            onClick={cargar}
+            disabled={loading}
+            className="flex items-center gap-2 px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded-lg transition-colors disabled:opacity-50"
+          >
+            <RefreshCw className={`w-4 h-4 ${loading ? 'animate-spin' : ''}`} />
+            Refrescar
+          </button>
+        </div>
       </div>
 
       {/* Stats */}
@@ -751,6 +765,17 @@ export default function VistaRendiciones(): React.ReactElement {
             onResolver={handleResolver}
             onClose={() => setResolverResumen(null)}
             guardando={guardando}
+          />
+        </Suspense>
+      )}
+
+      {verCtaCte && (
+        <Suspense fallback={null}>
+          <ModalCtaCtePendiente
+            fechaDesde={fechaDesde}
+            fechaHasta={fechaHasta}
+            transportistaId={transportistaFiltro}
+            onClose={() => setVerCtaCte(false)}
           />
         </Suspense>
       )}


### PR DESCRIPTION
Cuatro cosas reportadas por Taco Pozo (Pablo + Don Jorge) revisando la pantalla de rendiciones. Migs 136/137/138 **ya aplicadas a prod**.

## 1. Ventas en cuenta corriente volvían a caer en el cuadro verde

**El bug lo introduje yo en la mig 133.** Ese backfill priorizó `MIN(pagos.fecha)` como fecha de entrega, lo que por definición alinea la entrega con el día del cobro → **toda venta vieja cobrada después parecía entrega del mismo día**, y el cuadro azul quedaba en $0.

Caso que lo destapó: pedido **#3892** (DESPENSA SHADAY), vendido el 20/07, **entregado el 21/07**, cobrado el 22/07. La 133 le puso `fecha_entrega = 22/07` → figuraba verde. Corresponde azul.

Alcance medido: **1.380 pedidos / ~$49,2M** mal clasificados.

**Fix (mig 136):** recalcular `fecha_entrega` desde `pedido_historial`, que guarda el instante real del cambio de estado a `entregado` — existe para el **100%** de los entregados (3.527/3.527). Acotado a los pedidos que decidió la heurística de la 133 (alineados al día del pago, o al fallback `created_at`); deja intactos los **52** donde el encargado eligió una fecha contable retroactiva en una entrega masiva (ahí la fecha elegida es la correcta, no la del historial). Deshabilita `trg_pedidos_anular_control` durante el UPDATE para no destruir las rendiciones ya cerradas.

**El total cobrado del día no cambia** — sólo se reclasifica verde → azul:

| Día / Transportista | Verde antes | Verde después | Pasa a azul |
|---|---|---|---|
| 21/07 Jony | $53.500 | $53.500 | — |
| 21/07 Taco Pozo | $473.250 | $473.250 | — |
| 22/07 Jony | $234.500 | $23.000 | **$211.500** |
| 22/07 Taco Pozo | $127.000 | $0 | **$127.000** |

## 2. "Cargando detalle..." colgado (y Exportar Excel que no respondía)

El `useEffect` del detalle tenía `loadingDetalle` en las deps: al prender el loading se re-disparaba el effect, su cleanup marcaba `cancelado = true` y descartaba la respuesta en vuelo, así que el flag nunca se apagaba. El botón Exportar quedaba deshabilitado porque `detalle` seguía en `null` — no era un problema del Excel, el detalle nunca llegaba a cargar. Se saca `detalle`/`loadingDetalle` de las deps.

## 3. Drill-down por forma de pago

Ahora se puede **clickear un total del breakdown** (ej. Transferencia $90.850) y ver qué clientes y montos lo componen, con subtotal y un chip para quitar el filtro.

**Mig 137** amplía `obtener_detalle_rendicion` para devolver todas las formas por cliente. Antes sólo traía efectivo/transferencia/otros, así que cheque, tarjeta y vale blanco eran imposibles de desglosar. El Excel ahora incluye todas las columnas.

## 4. Pantalla "Cta cte pendiente"

Faltaba dónde ver el **detalle y el total** de los pedidos entregados pendientes de cobro, sobre el mismo rango de la rendición. Lo que había agregaba por cliente y sin rango (`obtener_deudores_mora`, `ReporteCuentasPorCobrar`) o daba sólo el número total sin detalle (`reporte_gerencial → cobranza.pendiente`).

**Mig 138** `obtener_pedidos_ctacte_pendientes(desde, hasta, transportista)`: una fila por pedido (cliente, pedido, fechas, días, total, cobrado, saldo, estado). Mismo predicado de deuda que las migs 075/109. El rango filtra por **fecha de entrega** (la dimensión con la que nace la deuda, igual que el bloque "Entregado" de la rendición); con `NULL` devuelve toda la deuda viva.

UI: botón **"Cta cte pendiente"** en el header de Rendiciones → modal lazy que arranca con el rango y transportista ya filtrados, muestra pedidos/clientes/entregado/cobrado/saldo, marca los parciales y exporta a Excel. Checkbox "Ver toda la deuda" para salir del rango. Hoy en Taco Pozo: 13 pedidos, 12 clientes, **$727.999,99**.

## Verificación
- #3892 → clasifica **AZUL (cta cte)** ✓
- Quedan 52 diferencias vs historial = exactamente el grupo que se decidió no tocar ✓
- 0 entregados sin `fecha_entrega` ✓
- **90 rendiciones cerradas intactas**, trigger vuelto a habilitar ✓
- Control cruzado: el saldo de $15.750 de ALICIA CORREA coincide con el "-$15.750 cobrado menos que entregado" de la rendición ✓
- CI completo en verde (Build, E2E, Unit 794 tests, TypeScript, Lint, Security Audit) ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)
