### PR TITLE
feat(envíos): descontar stock al cargar el envío + editar/cancelar + trazabilidad de usuarios

### DIFF
--- a/migrations/139_movimientos_stock_preventivo.sql
+++ b/migrations/139_movimientos_stock_preventivo.sql
@@ -1,0 +1,545 @@
+-- ============================================================================
+-- 139 · Envios entre sucursales: descuento preventivo de stock + editar/cancelar
+-- ============================================================================
+-- PROBLEMA (reportado por Agustin, caso real en prod):
+--   La sucursal origen carga un envio, la mercaderia SALE fisicamente, pero el
+--   stock recien se descontaba cuando el destino ACEPTABA. En el medio el origen
+--   seguia mostrando (y vendiendo) stock que ya no tenia.
+--   Movimiento #6: 39,3 horas pendiente con 160 unidades fantasma en Tucuman.
+--   Ademas, al no existir forma de editar ni cancelar un envio pendiente, lo
+--   denegaron y lo recrearon (#7) un minuto despues.
+--
+-- SOLUCION:
+--   1) crear_  -> valida y DESCUENTA el stock del origen en el acto.
+--   2) aceptar_-> NO vuelve a descontar del origen (solo ingresa al destino).
+--   3) denegar_-> RESTITUYE el stock al origen.
+--   4) cancelar_ (NUEVA) -> el origen se retracta y recupera el stock.
+--   5) editar_   (NUEVA) -> el origen corrige el envio ajustando el stock por delta.
+--
+-- IDEMPOTENCIA / LEGADO — columna `stock_descontado`:
+--   Significa "el origen tiene estas unidades descontadas AHORA" (estado vivo,
+--   no historico). Es lo que evita el doble descuento: aceptar solo descuenta
+--   del origen si el flag esta en false (movimiento creado con la logica vieja).
+--   Los pendientes que existan al momento del deploy quedan en false -> aceptar
+--   usa el camino viejo y denegar no restituye. El deploy es seguro aun con
+--   envios en vuelo, sin downtime.
+--
+--   Invariantes auditables:
+--     estado='aceptada'                  => stock_descontado = true
+--     estado IN ('denegada','cancelada') => stock_descontado = false
+--
+-- TRAZABILIDAD: la 076 nunca seteaba `app.stock_*`, asi que estos movimientos
+-- caian en stock_historico como origen='auto' sin referencia (pendiente P1
+-- STK-D de la mig 105). Ahora cada UPDATE de stock setea el contexto y el
+-- trigger trg_stock_historico lo registra. NO se inserta a mano en
+-- stock_historico (eso duplicaria filas).
+-- ============================================================================
+
+BEGIN;
+
+-- ----------------------------------------------------------------------------
+-- 1) DDL + backfill
+-- ----------------------------------------------------------------------------
+ALTER TABLE public.movimientos_sucursal
+  ADD COLUMN IF NOT EXISTS stock_descontado BOOLEAN NOT NULL DEFAULT false,
+  ADD COLUMN IF NOT EXISTS total_unidades   INTEGER NOT NULL DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS editado_por      UUID REFERENCES public.perfiles(id),
+  ADD COLUMN IF NOT EXISTS editado_at       TIMESTAMPTZ;
+
+COMMENT ON COLUMN public.movimientos_sucursal.stock_descontado IS
+  'true = el origen tiene estas unidades descontadas AHORA. Evita el doble descuento al aceptar.';
+COMMENT ON COLUMN public.movimientos_sucursal.motivo_rechazo IS
+  'Motivo del rechazo (denegada) o de la retractacion (cancelada).';
+
+ALTER TABLE public.movimientos_sucursal DROP CONSTRAINT IF EXISTS movimientos_sucursal_estado_check;
+ALTER TABLE public.movimientos_sucursal ADD CONSTRAINT movimientos_sucursal_estado_check
+  CHECK (estado IN ('pendiente', 'aceptada', 'denegada', 'cancelada'));
+
+-- Historicos: las aceptadas ya movieron el stock (respeta el invariante).
+UPDATE public.movimientos_sucursal SET stock_descontado = true WHERE estado = 'aceptada';
+UPDATE public.movimientos_sucursal m SET total_unidades = COALESCE(
+  (SELECT SUM(i.cantidad) FROM public.movimiento_sucursal_items i WHERE i.movimiento_id = m.id), 0);
+
+-- ----------------------------------------------------------------------------
+-- 2) crear_movimiento_sucursal — misma firma, ahora valida y descuenta
+-- ----------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.crear_movimiento_sucursal(
+  p_sucursal_destino_id bigint, p_notas text DEFAULT NULL, p_items jsonb DEFAULT '[]'::jsonb
+) RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER SET search_path TO 'public' AS $$
+DECLARE
+  v_origen bigint; v_mov_id bigint; v_agg record; v_prod productos%ROWTYPE;
+  v_total numeric := 0; v_count integer := 0; v_unidades integer := 0;
+  v_errores text[] := ARRAY[]::text[]; v_stock_prev integer;
+BEGIN
+  v_origen := current_sucursal_id();
+  IF v_origen IS NULL THEN RETURN jsonb_build_object('success', false, 'error', 'Sucursal no seleccionada'); END IF;
+  IF p_sucursal_destino_id = v_origen THEN RETURN jsonb_build_object('success', false, 'error', 'El destino debe ser distinto al origen'); END IF;
+  IF public._rol_en_sucursal(auth.uid(), v_origen) NOT IN ('admin', 'encargado') THEN
+    RETURN jsonb_build_object('success', false, 'error', 'No autorizado'); END IF;
+  IF NOT EXISTS (SELECT 1 FROM sucursales WHERE id = p_sucursal_destino_id AND activa IS NOT FALSE) THEN
+    RETURN jsonb_build_object('success', false, 'error', 'Sucursal destino inválida'); END IF;
+
+  -- Pasada 1: validar TODO antes de tocar nada. Agrega por producto (dos lineas
+  -- del mismo producto se validarian por separado contra el mismo stock) y
+  -- bloquea en orden de id para no cruzarse con otro envio simultaneo.
+  FOR v_agg IN
+    SELECT (e->>'producto_id')::bigint AS pid, SUM(COALESCE((e->>'cantidad')::int, 0))::int AS cant
+    FROM jsonb_array_elements(p_items) e
+    WHERE COALESCE((e->>'cantidad')::int, 0) > 0
+    GROUP BY 1 ORDER BY 1
+  LOOP
+    SELECT * INTO v_prod FROM productos WHERE id = v_agg.pid AND sucursal_id = v_origen FOR UPDATE;
+    IF NOT FOUND THEN
+      v_errores := array_append(v_errores, 'Producto ' || v_agg.pid || ' no existe en la sucursal origen');
+    ELSIF v_prod.stock < v_agg.cant THEN
+      v_errores := array_append(v_errores,
+        v_prod.nombre || ': stock insuficiente (disponible ' || v_prod.stock || ', solicitado ' || v_agg.cant || ')');
+    ELSE
+      v_count := v_count + 1;
+      v_unidades := v_unidades + v_agg.cant;
+    END IF;
+  END LOOP;
+
+  IF array_length(v_errores, 1) > 0 THEN
+    RETURN jsonb_build_object('success', false, 'error', array_to_string(v_errores, ' · '), 'errores', to_jsonb(v_errores));
+  END IF;
+  IF v_count = 0 THEN
+    RETURN jsonb_build_object('success', false, 'error', 'El movimiento no tiene items válidos');
+  END IF;
+
+  INSERT INTO movimientos_sucursal (sucursal_origen_id, sucursal_destino_id, estado, notas, creado_por, stock_descontado)
+  VALUES (v_origen, p_sucursal_destino_id, 'pendiente', p_notas, auth.uid(), true)
+  RETURNING id INTO v_mov_id;
+
+  PERFORM set_config('app.stock_origen', 'movimiento_salida', true);
+  PERFORM set_config('app.stock_ref_tipo', 'movimiento_sucursal', true);
+  PERFORM set_config('app.stock_ref_id', v_mov_id::text, true);
+  PERFORM set_config('app.stock_user_id', COALESCE(auth.uid()::text, ''), true);
+
+  -- Pasada 2: descontar y snapshotear. Las filas siguen bloqueadas por la pasada 1.
+  FOR v_agg IN
+    SELECT (e->>'producto_id')::bigint AS pid, SUM(COALESCE((e->>'cantidad')::int, 0))::int AS cant
+    FROM jsonb_array_elements(p_items) e
+    WHERE COALESCE((e->>'cantidad')::int, 0) > 0
+    GROUP BY 1 ORDER BY 1
+  LOOP
+    SELECT * INTO v_prod FROM productos WHERE id = v_agg.pid AND sucursal_id = v_origen;
+    v_stock_prev := v_prod.stock;
+
+    UPDATE productos SET stock = stock - v_agg.cant, updated_at = now()
+      WHERE id = v_agg.pid AND sucursal_id = v_origen;
+
+    INSERT INTO movimiento_sucursal_items (
+      movimiento_id, producto_origen_id, cantidad,
+      origen_nombre, origen_codigo, origen_tp_import_id, origen_categoria,
+      origen_precio, origen_precio_sin_iva, origen_costo_sin_iva, origen_costo_con_iva,
+      origen_impuestos_internos, origen_porcentaje_iva, origen_stock_minimo,
+      origen_unidades_por_fardo, origen_etiqueta_bulto,
+      stock_origen_anterior, stock_origen_nuevo
+    ) VALUES (
+      v_mov_id, v_prod.id, v_agg.cant,
+      v_prod.nombre, v_prod.codigo, v_prod.tp_import_id, v_prod.categoria,
+      v_prod.precio, v_prod.precio_sin_iva, v_prod.costo_sin_iva, v_prod.costo_con_iva,
+      v_prod.impuestos_internos, v_prod.porcentaje_iva, v_prod.stock_minimo,
+      v_prod.unidades_de_venta_por_fardo, v_prod.etiqueta_bulto,
+      v_stock_prev, v_stock_prev - v_agg.cant
+    );
+    v_total := v_total + COALESCE(v_prod.costo_con_iva, v_prod.costo_sin_iva, 0) * v_agg.cant;
+  END LOOP;
+
+  UPDATE movimientos_sucursal SET total_costo = v_total, total_unidades = v_unidades WHERE id = v_mov_id;
+
+  PERFORM public._notificar_sucursal_roles(
+    p_sucursal_destino_id, auth.uid(), 'movimiento_pendiente',
+    'Nuevo movimiento de stock para aceptar',
+    COALESCE((SELECT nombre FROM sucursales WHERE id = v_origen), 'Otra sucursal')
+      || ' envió ' || v_count || ' producto(s), ' || v_unidades || ' unidades. Ya salió del depósito.',
+    'movimiento_sucursal', v_mov_id,
+    jsonb_build_object('origen_id', v_origen, 'items', v_count, 'unidades', v_unidades)
+  );
+
+  RETURN jsonb_build_object('success', true, 'movimiento_id', v_mov_id);
+EXCEPTION WHEN OTHERS THEN
+  RETURN jsonb_build_object('success', false, 'error', SQLERRM);
+END; $$;
+ALTER FUNCTION public.crear_movimiento_sucursal(bigint, text, jsonb) OWNER TO postgres;
+
+-- ----------------------------------------------------------------------------
+-- 3) aceptar_movimiento_sucursal — no vuelve a descontar del origen
+-- ----------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.aceptar_movimiento_sucursal(
+  p_movimiento_id bigint, p_resoluciones jsonb
+) RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER SET search_path TO 'public' AS $$
+DECLARE
+  v_mov movimientos_sucursal%ROWTYPE;
+  v_destino bigint; v_item movimiento_sucursal_items%ROWTYPE;
+  v_res jsonb; v_accion text; v_dest_id bigint;
+  v_stock_o integer; v_stock_d integer;
+  v_costo_dest numeric; v_costo_dest_neto numeric;
+  v_items_count integer;
+BEGIN
+  SELECT * INTO v_mov FROM movimientos_sucursal WHERE id = p_movimiento_id FOR UPDATE;
+  IF NOT FOUND THEN RETURN jsonb_build_object('success', false, 'error', 'Movimiento no encontrado'); END IF;
+  IF v_mov.estado <> 'pendiente' THEN RETURN jsonb_build_object('success', false, 'error', 'El movimiento ya fue resuelto'); END IF;
+  v_destino := v_mov.sucursal_destino_id;
+  IF current_sucursal_id() <> v_destino THEN
+    RETURN jsonb_build_object('success', false, 'error', 'Tenés que estar en la sucursal destino para aceptar'); END IF;
+  IF public._rol_en_sucursal(auth.uid(), v_destino) NOT IN ('admin', 'encargado') THEN
+    RETURN jsonb_build_object('success', false, 'error', 'No autorizado'); END IF;
+
+  -- El origen pudo haber editado el envio despues de que el destino abrio el
+  -- modal: los item_id de p_resoluciones serian viejos.
+  SELECT COUNT(*) INTO v_items_count FROM movimiento_sucursal_items WHERE movimiento_id = p_movimiento_id;
+  IF v_items_count <> jsonb_array_length(COALESCE(p_resoluciones, '[]'::jsonb)) THEN
+    RETURN jsonb_build_object('success', false,
+      'error', 'El envío fue modificado por la sucursal origen. Cerrá y volvé a abrirlo.');
+  END IF;
+
+  FOR v_item IN SELECT * FROM movimiento_sucursal_items WHERE movimiento_id = p_movimiento_id ORDER BY producto_origen_id LOOP
+    SELECT r INTO v_res FROM jsonb_array_elements(p_resoluciones) r WHERE (r->>'item_id')::bigint = v_item.id LIMIT 1;
+    IF v_res IS NULL THEN
+      RAISE EXCEPTION 'Falta resolver el producto "%". Si el envío fue modificado, cerrá y volvé a abrirlo.', v_item.origen_nombre;
+    END IF;
+    v_accion := v_res->>'accion';
+
+    -- Camino LEGADO (movimientos creados antes de la 139): el stock del origen
+    -- todavia no se descontó, hay que hacerlo aca como antes.
+    IF NOT v_mov.stock_descontado THEN
+      SELECT stock INTO v_stock_o FROM productos
+        WHERE id = v_item.producto_origen_id AND sucursal_id = v_mov.sucursal_origen_id FOR UPDATE;
+      IF NOT FOUND THEN RAISE EXCEPTION 'El producto "%" ya no existe en la sucursal origen', v_item.origen_nombre; END IF;
+      IF v_stock_o < v_item.cantidad THEN
+        RAISE EXCEPTION 'Stock insuficiente en origen para "%": disponible %, solicitado %', v_item.origen_nombre, v_stock_o, v_item.cantidad;
+      END IF;
+    END IF;
+
+    IF v_accion = 'crear_nuevo' THEN
+      INSERT INTO productos (
+        nombre, codigo, categoria, precio, precio_sin_iva, costo_sin_iva, costo_con_iva,
+        impuestos_internos, porcentaje_iva, stock, stock_minimo, proveedor_id,
+        unidades_de_venta_por_fardo, etiqueta_bulto, tp_import_id, sucursal_id
+      ) VALUES (
+        v_item.origen_nombre, v_item.origen_codigo, v_item.origen_categoria,
+        COALESCE(v_item.origen_precio, 0), v_item.origen_precio_sin_iva, v_item.origen_costo_sin_iva, v_item.origen_costo_con_iva,
+        v_item.origen_impuestos_internos, v_item.origen_porcentaje_iva, 0, v_item.origen_stock_minimo, NULL,
+        v_item.origen_unidades_por_fardo, v_item.origen_etiqueta_bulto, v_item.origen_tp_import_id, v_destino
+      ) RETURNING id, stock INTO v_dest_id, v_stock_d;
+      v_costo_dest := v_item.origen_costo_con_iva;
+      v_costo_dest_neto := v_item.origen_costo_sin_iva;
+    ELSE
+      v_dest_id := (v_res->>'producto_destino_id')::bigint;
+      SELECT stock, costo_con_iva, costo_sin_iva INTO v_stock_d, v_costo_dest, v_costo_dest_neto
+        FROM productos WHERE id = v_dest_id AND sucursal_id = v_destino FOR UPDATE;
+      IF NOT FOUND THEN RAISE EXCEPTION 'El producto destino elegido no existe en la sucursal'; END IF;
+      -- Regla de costo: queda el mayor entre origen y destino.
+      v_costo_dest := GREATEST(COALESCE(v_costo_dest, 0), COALESCE(v_item.origen_costo_con_iva, 0));
+      v_costo_dest_neto := GREATEST(COALESCE(v_costo_dest_neto, 0), COALESCE(v_item.origen_costo_sin_iva, 0));
+    END IF;
+
+    IF NOT v_mov.stock_descontado THEN
+      PERFORM set_config('app.stock_origen', 'movimiento_salida', true);
+      PERFORM set_config('app.stock_ref_tipo', 'movimiento_sucursal', true);
+      PERFORM set_config('app.stock_ref_id', p_movimiento_id::text, true);
+      PERFORM set_config('app.stock_user_id', COALESCE(auth.uid()::text, ''), true);
+      UPDATE productos SET stock = stock - v_item.cantidad, updated_at = now()
+        WHERE id = v_item.producto_origen_id AND sucursal_id = v_mov.sucursal_origen_id;
+    END IF;
+
+    -- set_config es transaction-local: re-setear porque el camino legado de
+    -- arriba deja 'movimiento_salida' y este UPDATE es un ingreso.
+    PERFORM set_config('app.stock_origen', 'movimiento_ingreso', true);
+    PERFORM set_config('app.stock_ref_tipo', 'movimiento_sucursal', true);
+    PERFORM set_config('app.stock_ref_id', p_movimiento_id::text, true);
+    PERFORM set_config('app.stock_user_id', COALESCE(auth.uid()::text, ''), true);
+
+    UPDATE productos SET stock = stock + v_item.cantidad,
+        costo_con_iva = v_costo_dest, costo_sin_iva = v_costo_dest_neto, updated_at = now()
+      WHERE id = v_dest_id AND sucursal_id = v_destino;
+
+    -- stock_origen_anterior/nuevo ya los escribio crear_/editar_ cuando el flag
+    -- esta en true: NO se pisan.
+    UPDATE movimiento_sucursal_items SET
+      producto_destino_id = v_dest_id,
+      resolucion = CASE WHEN v_accion = 'crear_nuevo' THEN 'creado_nuevo' ELSE 'match_existente' END,
+      costo_aplicado_destino = v_costo_dest,
+      stock_origen_anterior = CASE WHEN v_mov.stock_descontado THEN stock_origen_anterior ELSE v_stock_o END,
+      stock_origen_nuevo    = CASE WHEN v_mov.stock_descontado THEN stock_origen_nuevo ELSE v_stock_o - v_item.cantidad END,
+      stock_destino_anterior = v_stock_d, stock_destino_nuevo = v_stock_d + v_item.cantidad
+    WHERE id = v_item.id;
+  END LOOP;
+
+  UPDATE movimientos_sucursal
+    SET estado = 'aceptada', stock_descontado = true, resuelto_por = auth.uid(), resuelto_at = now()
+    WHERE id = p_movimiento_id;
+
+  PERFORM public._notificar_sucursal_roles(
+    v_mov.sucursal_origen_id, auth.uid(), 'movimiento_aceptado',
+    'Movimiento aceptado',
+    COALESCE((SELECT nombre FROM sucursales WHERE id = v_destino), 'La sucursal destino') || ' aceptó tu movimiento #' || p_movimiento_id || '.',
+    'movimiento_sucursal', p_movimiento_id, jsonb_build_object('destino_id', v_destino)
+  );
+
+  RETURN jsonb_build_object('success', true, 'movimiento_id', p_movimiento_id);
+EXCEPTION WHEN OTHERS THEN
+  RETURN jsonb_build_object('success', false, 'error', SQLERRM);
+END; $$;
+ALTER FUNCTION public.aceptar_movimiento_sucursal(bigint, jsonb) OWNER TO postgres;
+
+-- ----------------------------------------------------------------------------
+-- 4) denegar_movimiento_sucursal — restituye el stock al origen
+-- ----------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.denegar_movimiento_sucursal(
+  p_movimiento_id bigint, p_motivo text DEFAULT NULL
+) RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER SET search_path TO 'public' AS $$
+DECLARE
+  v_mov movimientos_sucursal%ROWTYPE; v_destino bigint;
+  v_item movimiento_sucursal_items%ROWTYPE; v_rows integer;
+BEGIN
+  SELECT * INTO v_mov FROM movimientos_sucursal WHERE id = p_movimiento_id FOR UPDATE;
+  IF NOT FOUND THEN RETURN jsonb_build_object('success', false, 'error', 'Movimiento no encontrado'); END IF;
+  IF v_mov.estado <> 'pendiente' THEN RETURN jsonb_build_object('success', false, 'error', 'El movimiento ya fue resuelto'); END IF;
+  v_destino := v_mov.sucursal_destino_id;
+  IF current_sucursal_id() <> v_destino THEN
+    RETURN jsonb_build_object('success', false, 'error', 'Tenés que estar en la sucursal destino'); END IF;
+  IF public._rol_en_sucursal(auth.uid(), v_destino) NOT IN ('admin', 'encargado') THEN
+    RETURN jsonb_build_object('success', false, 'error', 'No autorizado'); END IF;
+
+  IF v_mov.stock_descontado THEN
+    PERFORM set_config('app.stock_origen', 'movimiento_denegado', true);
+    PERFORM set_config('app.stock_ref_tipo', 'movimiento_sucursal', true);
+    PERFORM set_config('app.stock_ref_id', p_movimiento_id::text, true);
+    PERFORM set_config('app.stock_user_id', COALESCE(auth.uid()::text, ''), true);
+
+    FOR v_item IN SELECT * FROM movimiento_sucursal_items WHERE movimiento_id = p_movimiento_id ORDER BY producto_origen_id LOOP
+      UPDATE productos SET stock = stock + v_item.cantidad, updated_at = now()
+        WHERE id = v_item.producto_origen_id AND sucursal_id = v_mov.sucursal_origen_id;
+      GET DIAGNOSTICS v_rows = ROW_COUNT;
+      IF v_rows = 0 THEN
+        RAISE EXCEPTION 'No se puede devolver "%" al origen: el producto ya no existe ahí', v_item.origen_nombre;
+      END IF;
+    END LOOP;
+  END IF;
+
+  UPDATE movimientos_sucursal SET estado = 'denegada', stock_descontado = false, motivo_rechazo = p_motivo,
+      resuelto_por = auth.uid(), resuelto_at = now()
+    WHERE id = p_movimiento_id;
+
+  PERFORM public._notificar_sucursal_roles(
+    v_mov.sucursal_origen_id, auth.uid(), 'movimiento_denegado',
+    'Movimiento denegado',
+    COALESCE((SELECT nombre FROM sucursales WHERE id = v_destino), 'La sucursal destino') || ' denegó tu movimiento #' || p_movimiento_id
+      || CASE WHEN v_mov.stock_descontado THEN '. Se devolvió el stock.' ELSE '' END
+      || COALESCE(' Motivo: ' || p_motivo, ''),
+    'movimiento_sucursal', p_movimiento_id, jsonb_build_object('destino_id', v_destino, 'motivo', p_motivo)
+  );
+
+  RETURN jsonb_build_object('success', true, 'movimiento_id', p_movimiento_id);
+EXCEPTION WHEN OTHERS THEN
+  RETURN jsonb_build_object('success', false, 'error', SQLERRM);
+END; $$;
+ALTER FUNCTION public.denegar_movimiento_sucursal(bigint, text) OWNER TO postgres;
+
+-- ----------------------------------------------------------------------------
+-- 5) cancelar_movimiento_sucursal (NUEVA) — el origen se retracta
+-- ----------------------------------------------------------------------------
+-- Sin esto, con el descuento preventivo un envio cargado por error dejaria el
+-- stock descontado indefinidamente: el origen no tenia NINGUNA accion posible.
+CREATE OR REPLACE FUNCTION public.cancelar_movimiento_sucursal(
+  p_movimiento_id bigint, p_motivo text DEFAULT NULL
+) RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER SET search_path TO 'public' AS $$
+DECLARE
+  v_mov movimientos_sucursal%ROWTYPE; v_origen bigint;
+  v_item movimiento_sucursal_items%ROWTYPE; v_rows integer;
+BEGIN
+  SELECT * INTO v_mov FROM movimientos_sucursal WHERE id = p_movimiento_id FOR UPDATE;
+  IF NOT FOUND THEN RETURN jsonb_build_object('success', false, 'error', 'Movimiento no encontrado'); END IF;
+  IF v_mov.estado <> 'pendiente' THEN RETURN jsonb_build_object('success', false, 'error', 'El movimiento ya fue resuelto'); END IF;
+  v_origen := v_mov.sucursal_origen_id;
+  IF current_sucursal_id() <> v_origen THEN
+    RETURN jsonb_build_object('success', false, 'error', 'Solo la sucursal que creó el envío puede cancelarlo'); END IF;
+  IF public._rol_en_sucursal(auth.uid(), v_origen) <> 'admin' THEN
+    RETURN jsonb_build_object('success', false, 'error', 'Solo un admin puede cancelar un envío'); END IF;
+
+  IF v_mov.stock_descontado THEN
+    PERFORM set_config('app.stock_origen', 'movimiento_cancelado', true);
+    PERFORM set_config('app.stock_ref_tipo', 'movimiento_sucursal', true);
+    PERFORM set_config('app.stock_ref_id', p_movimiento_id::text, true);
+    PERFORM set_config('app.stock_user_id', COALESCE(auth.uid()::text, ''), true);
+
+    FOR v_item IN SELECT * FROM movimiento_sucursal_items WHERE movimiento_id = p_movimiento_id ORDER BY producto_origen_id LOOP
+      UPDATE productos SET stock = stock + v_item.cantidad, updated_at = now()
+        WHERE id = v_item.producto_origen_id AND sucursal_id = v_origen;
+      GET DIAGNOSTICS v_rows = ROW_COUNT;
+      IF v_rows = 0 THEN
+        RAISE EXCEPTION 'No se puede devolver "%" al stock: el producto ya no existe', v_item.origen_nombre;
+      END IF;
+    END LOOP;
+  END IF;
+
+  UPDATE movimientos_sucursal SET estado = 'cancelada', stock_descontado = false, motivo_rechazo = p_motivo,
+      resuelto_por = auth.uid(), resuelto_at = now()
+    WHERE id = p_movimiento_id;
+
+  PERFORM public._notificar_sucursal_roles(
+    v_mov.sucursal_destino_id, auth.uid(), 'movimiento_cancelado',
+    'Movimiento cancelado por el origen',
+    COALESCE((SELECT nombre FROM sucursales WHERE id = v_origen), 'La sucursal origen')
+      || ' canceló el movimiento #' || p_movimiento_id || COALESCE('. Motivo: ' || p_motivo, ''),
+    'movimiento_sucursal', p_movimiento_id, jsonb_build_object('origen_id', v_origen, 'motivo', p_motivo)
+  );
+
+  RETURN jsonb_build_object('success', true, 'movimiento_id', p_movimiento_id);
+EXCEPTION WHEN OTHERS THEN
+  RETURN jsonb_build_object('success', false, 'error', SQLERRM);
+END; $$;
+ALTER FUNCTION public.cancelar_movimiento_sucursal(bigint, text) OWNER TO postgres;
+
+-- ----------------------------------------------------------------------------
+-- 6) editar_movimiento_sucursal (NUEVA) — corregir un envio pendiente
+-- ----------------------------------------------------------------------------
+-- Ajusta el stock por DELTA por producto (no restituye-todo-y-reaplica): un
+-- producto cuya cantidad no cambia no genera UPDATE ni fila en stock_historico.
+-- El destino NO es editable: cambiarlo es semanticamente otro envio (cancelar +
+-- crear) y obligaria a "des-notificar" al destino original.
+CREATE OR REPLACE FUNCTION public.editar_movimiento_sucursal(
+  p_movimiento_id bigint, p_notas text DEFAULT NULL, p_items jsonb DEFAULT '[]'::jsonb
+) RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER SET search_path TO 'public' AS $$
+DECLARE
+  v_mov movimientos_sucursal%ROWTYPE; v_origen bigint; v_agg record; v_prod productos%ROWTYPE;
+  v_errores text[] := ARRAY[]::text[]; v_rows integer;
+  v_total numeric := 0; v_count integer := 0; v_unidades integer := 0;
+BEGIN
+  SELECT * INTO v_mov FROM movimientos_sucursal WHERE id = p_movimiento_id FOR UPDATE;
+  IF NOT FOUND THEN RETURN jsonb_build_object('success', false, 'error', 'Movimiento no encontrado'); END IF;
+  IF v_mov.estado <> 'pendiente' THEN RETURN jsonb_build_object('success', false, 'error', 'Solo se puede editar un envío pendiente'); END IF;
+  v_origen := v_mov.sucursal_origen_id;
+  IF current_sucursal_id() <> v_origen THEN
+    RETURN jsonb_build_object('success', false, 'error', 'Solo la sucursal que creó el envío puede editarlo'); END IF;
+  IF public._rol_en_sucursal(auth.uid(), v_origen) <> 'admin' THEN
+    RETURN jsonb_build_object('success', false, 'error', 'Solo un admin puede editar un envío'); END IF;
+  IF NOT v_mov.stock_descontado THEN
+    RETURN jsonb_build_object('success', false,
+      'error', 'Este envío es anterior al descuento preventivo. Cancelalo y creá uno nuevo.'); END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM jsonb_array_elements(COALESCE(p_items, '[]'::jsonb)) e
+    WHERE COALESCE((e->>'cantidad')::int, 0) > 0
+  ) THEN
+    RETURN jsonb_build_object('success', false, 'error', 'El envío no puede quedar sin productos. Usá Cancelar.');
+  END IF;
+
+  -- Pasada 1: validar los deltas positivos (lo que sale de mas).
+  FOR v_agg IN
+    WITH nuevas AS (
+      SELECT (e->>'producto_id')::bigint AS pid, SUM(COALESCE((e->>'cantidad')::int, 0))::int AS cant
+      FROM jsonb_array_elements(p_items) e WHERE COALESCE((e->>'cantidad')::int, 0) > 0 GROUP BY 1
+    ), viejas AS (
+      SELECT producto_origen_id AS pid, SUM(cantidad)::int AS cant
+      FROM movimiento_sucursal_items WHERE movimiento_id = p_movimiento_id GROUP BY 1
+    )
+    SELECT COALESCE(n.pid, v.pid) AS pid,
+           COALESCE(n.cant, 0) - COALESCE(v.cant, 0) AS delta
+    FROM nuevas n FULL OUTER JOIN viejas v ON v.pid = n.pid
+    ORDER BY 1
+  LOOP
+    CONTINUE WHEN v_agg.delta = 0;
+    SELECT * INTO v_prod FROM productos WHERE id = v_agg.pid AND sucursal_id = v_origen FOR UPDATE;
+    IF NOT FOUND THEN
+      v_errores := array_append(v_errores, 'Producto ' || v_agg.pid || ' no existe en la sucursal origen');
+    ELSIF v_agg.delta > 0 AND v_prod.stock < v_agg.delta THEN
+      v_errores := array_append(v_errores,
+        v_prod.nombre || ': stock insuficiente para agregar ' || v_agg.delta || ' (disponible ' || v_prod.stock || ')');
+    END IF;
+  END LOOP;
+
+  IF array_length(v_errores, 1) > 0 THEN
+    RETURN jsonb_build_object('success', false, 'error', array_to_string(v_errores, ' · '), 'errores', to_jsonb(v_errores));
+  END IF;
+
+  PERFORM set_config('app.stock_origen', 'movimiento_editado', true);
+  PERFORM set_config('app.stock_ref_tipo', 'movimiento_sucursal', true);
+  PERFORM set_config('app.stock_ref_id', p_movimiento_id::text, true);
+  PERFORM set_config('app.stock_user_id', COALESCE(auth.uid()::text, ''), true);
+
+  -- Pasada 2: aplicar solo los deltas != 0.
+  FOR v_agg IN
+    WITH nuevas AS (
+      SELECT (e->>'producto_id')::bigint AS pid, SUM(COALESCE((e->>'cantidad')::int, 0))::int AS cant
+      FROM jsonb_array_elements(p_items) e WHERE COALESCE((e->>'cantidad')::int, 0) > 0 GROUP BY 1
+    ), viejas AS (
+      SELECT producto_origen_id AS pid, SUM(cantidad)::int AS cant
+      FROM movimiento_sucursal_items WHERE movimiento_id = p_movimiento_id GROUP BY 1
+    )
+    SELECT COALESCE(n.pid, v.pid) AS pid,
+           COALESCE(n.cant, 0) - COALESCE(v.cant, 0) AS delta
+    FROM nuevas n FULL OUTER JOIN viejas v ON v.pid = n.pid
+    ORDER BY 1
+  LOOP
+    CONTINUE WHEN v_agg.delta = 0;
+    -- delta > 0: salen mas unidades (resta). delta < 0: vuelven al stock (suma).
+    UPDATE productos SET stock = stock - v_agg.delta, updated_at = now()
+      WHERE id = v_agg.pid AND sucursal_id = v_origen;
+    GET DIAGNOSTICS v_rows = ROW_COUNT;
+    IF v_rows = 0 THEN
+      RAISE EXCEPTION 'El producto % ya no existe en la sucursal origen', v_agg.pid;
+    END IF;
+  END LOOP;
+
+  -- Reemplazar los items: mientras esta pendiente no hay resoluciones que
+  -- preservar (producto_destino_id es NULL).
+  DELETE FROM movimiento_sucursal_items WHERE movimiento_id = p_movimiento_id;
+
+  FOR v_agg IN
+    SELECT (e->>'producto_id')::bigint AS pid, SUM(COALESCE((e->>'cantidad')::int, 0))::int AS cant
+    FROM jsonb_array_elements(p_items) e
+    WHERE COALESCE((e->>'cantidad')::int, 0) > 0
+    GROUP BY 1 ORDER BY 1
+  LOOP
+    SELECT * INTO v_prod FROM productos WHERE id = v_agg.pid AND sucursal_id = v_origen;
+    IF NOT FOUND THEN RAISE EXCEPTION 'El producto % ya no existe en la sucursal origen', v_agg.pid; END IF;
+
+    INSERT INTO movimiento_sucursal_items (
+      movimiento_id, producto_origen_id, cantidad,
+      origen_nombre, origen_codigo, origen_tp_import_id, origen_categoria,
+      origen_precio, origen_precio_sin_iva, origen_costo_sin_iva, origen_costo_con_iva,
+      origen_impuestos_internos, origen_porcentaje_iva, origen_stock_minimo,
+      origen_unidades_por_fardo, origen_etiqueta_bulto,
+      stock_origen_anterior, stock_origen_nuevo
+    ) VALUES (
+      p_movimiento_id, v_prod.id, v_agg.cant,
+      v_prod.nombre, v_prod.codigo, v_prod.tp_import_id, v_prod.categoria,
+      v_prod.precio, v_prod.precio_sin_iva, v_prod.costo_sin_iva, v_prod.costo_con_iva,
+      v_prod.impuestos_internos, v_prod.porcentaje_iva, v_prod.stock_minimo,
+      v_prod.unidades_de_venta_por_fardo, v_prod.etiqueta_bulto,
+      -- el stock ya quedo descontado arriba: "anterior" es el de antes de este envio
+      v_prod.stock + v_agg.cant, v_prod.stock
+    );
+    v_total := v_total + COALESCE(v_prod.costo_con_iva, v_prod.costo_sin_iva, 0) * v_agg.cant;
+    v_count := v_count + 1;
+    v_unidades := v_unidades + v_agg.cant;
+  END LOOP;
+
+  UPDATE movimientos_sucursal
+    SET notas = p_notas, total_costo = v_total, total_unidades = v_unidades,
+        editado_por = auth.uid(), editado_at = now()
+    WHERE id = p_movimiento_id;
+
+  PERFORM public._notificar_sucursal_roles(
+    v_mov.sucursal_destino_id, auth.uid(), 'movimiento_editado',
+    'Movimiento modificado por el origen',
+    COALESCE((SELECT nombre FROM sucursales WHERE id = v_origen), 'La sucursal origen')
+      || ' modificó el movimiento #' || p_movimiento_id || ': ahora son ' || v_count || ' producto(s), ' || v_unidades || ' unidades.',
+    'movimiento_sucursal', p_movimiento_id,
+    jsonb_build_object('origen_id', v_origen, 'items', v_count, 'unidades', v_unidades)
+  );
+
+  RETURN jsonb_build_object('success', true, 'movimiento_id', p_movimiento_id);
+EXCEPTION WHEN OTHERS THEN
+  RETURN jsonb_build_object('success', false, 'error', SQLERRM);
+END; $$;
+ALTER FUNCTION public.editar_movimiento_sucursal(bigint, text, jsonb) OWNER TO postgres;
+
+GRANT EXECUTE ON FUNCTION public.cancelar_movimiento_sucursal(bigint, text) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.editar_movimiento_sucursal(bigint, text, jsonb) TO authenticated;
+
+COMMIT;

--- a/src/components/containers/MovimientosContainer.tsx
+++ b/src/components/containers/MovimientosContainer.tsx
@@ -12,6 +12,8 @@ import {
   useCrearMovimientoMutation,
   useAceptarMovimientoMutation,
   useDenegarMovimientoMutation,
+  useCancelarMovimientoMutation,
+  useEditarMovimientoMutation,
 } from '../../hooks/queries'
 import type { MovimientoSucursalDB, EstadoMovimiento, ResolucionItem } from '../../hooks/queries'
 import { useAuthData } from '../../contexts/AuthDataContext'
@@ -23,6 +25,7 @@ const VistaMovimientos = lazy(() => import('../vistas/VistaMovimientos'))
 const ModalCrearMovimiento = lazy(() => import('../modals/ModalCrearMovimiento'))
 const ModalAceptarMovimiento = lazy(() => import('../modals/ModalAceptarMovimiento'))
 const ModalDetalleMovimiento = lazy(() => import('../modals/ModalDetalleMovimiento'))
+const ModalCancelarMovimiento = lazy(() => import('../modals/ModalCancelarMovimiento'))
 
 type TabEstado = EstadoMovimiento | 'todos'
 
@@ -32,29 +35,39 @@ function LoadingState() {
 
 export default function MovimientosContainer(): React.ReactElement {
   const { isAdminOrEncargado } = useAuthData()
-  const { currentSucursalId } = useSucursal()
+  // El rol POR SUCURSAL, no el global: un admin global puede ser encargado acá.
+  const { currentSucursalId, currentSucursalRol } = useSucursal()
   const notify = useNotification()
 
   const [estado, setEstado] = useState<TabEstado>('pendiente')
   const [crearOpen, setCrearOpen] = useState(false)
   const [aceptarMov, setAceptarMov] = useState<MovimientoSucursalDB | null>(null)
+  const [aceptarModo, setAceptarModo] = useState<'aceptar' | 'denegar'>('aceptar')
   const [detalleMov, setDetalleMov] = useState<MovimientoSucursalDB | null>(null)
+  const [editarMov, setEditarMov] = useState<MovimientoSucursalDB | null>(null)
+  const [cancelarMov, setCancelarMov] = useState<MovimientoSucursalDB | null>(null)
 
   const { data: movimientos = [], isLoading } = useMovimientosQuery({ estado })
   const { data: sucursales = [] } = useSucursalesQuery()
   const { data: productos = [] } = useProductosQuery()
   const { data: itemsAceptar = [], isLoading: loadingItems } = useMovimientoItemsQuery(aceptarMov ? String(aceptarMov.id) : null)
   const { data: itemsDetalle = [], isLoading: loadingItemsDetalle } = useMovimientoItemsQuery(detalleMov ? String(detalleMov.id) : null)
+  const { data: itemsEditar = [], isLoading: loadingItemsEditar } = useMovimientoItemsQuery(editarMov ? String(editarMov.id) : null)
 
   const crear = useCrearMovimientoMutation()
   const aceptar = useAceptarMovimientoMutation()
   const denegar = useDenegarMovimientoMutation()
+  const cancelar = useCancelarMovimientoMutation()
+  const editar = useEditarMovimientoMutation()
   const guardando = crear.isPending || aceptar.isPending || denegar.isPending
+    || cancelar.isPending || editar.isPending
 
   useResetOnSucursalChange(() => {
     setCrearOpen(false)
     setAceptarMov(null)
     setDetalleMov(null)
+    setEditarMov(null)
+    setCancelarMov(null)
     setEstado('pendiente')
   })
 
@@ -66,22 +79,38 @@ export default function MovimientosContainer(): React.ReactElement {
   }) => {
     await crear.mutateAsync(payload)
     setCrearOpen(false)
-    notify.success('Salida creada. Queda pendiente de aprobación.')
+    notify.success('Salida creada. El stock ya se descontó de esta sucursal.')
   }, [crear, notify])
 
   const handleAceptar = useCallback(async (resoluciones: ResolucionItem[]) => {
     if (!aceptarMov) return
     await aceptar.mutateAsync({ movimientoId: aceptarMov.id, resoluciones })
     setAceptarMov(null)
-    notify.success('Movimiento aceptado. Stock actualizado.')
+    notify.success('Movimiento aceptado. Stock ingresado en esta sucursal.')
   }, [aceptar, aceptarMov, notify])
 
   const handleDenegar = useCallback(async (motivo: string) => {
     if (!aceptarMov) return
     await denegar.mutateAsync({ movimientoId: aceptarMov.id, motivo })
     setAceptarMov(null)
-    notify.warning('Movimiento denegado.')
+    notify.warning('Movimiento denegado. Se le devolvió el stock al origen.')
   }, [denegar, aceptarMov, notify])
+
+  const handleEditar = useCallback(async (payload: {
+    notas?: string; items: Array<{ producto_id: number; cantidad: number }>
+  }) => {
+    if (!editarMov) return
+    await editar.mutateAsync({ movimientoId: editarMov.id, notas: payload.notas, items: payload.items })
+    setEditarMov(null)
+    notify.success('Envío actualizado. Se ajustó el stock de esta sucursal.')
+  }, [editar, editarMov, notify])
+
+  const handleCancelar = useCallback(async (motivo: string) => {
+    if (!cancelarMov) return
+    await cancelar.mutateAsync({ movimientoId: cancelarMov.id, motivo })
+    setCancelarMov(null)
+    notify.warning('Envío cancelado. El stock volvió a esta sucursal.')
+  }, [cancelar, cancelarMov, notify])
 
   return (
     <>
@@ -91,12 +120,15 @@ export default function MovimientosContainer(): React.ReactElement {
           loading={isLoading}
           currentSucursalId={currentSucursalId}
           canResolver={isAdminOrEncargado}
+          canEditar={currentSucursalRol === 'admin'}
           estado={estado}
           onEstadoChange={setEstado}
           onNuevaSalida={() => setCrearOpen(true)}
-          onAceptar={setAceptarMov}
-          onDenegar={setAceptarMov}
+          onAceptar={(m) => { setAceptarModo('aceptar'); setAceptarMov(m) }}
+          onDenegar={(m) => { setAceptarModo('denegar'); setAceptarMov(m) }}
           onVerDetalle={setDetalleMov}
+          onEditar={setEditarMov}
+          onCancelar={setCancelarMov}
         />
       </Suspense>
 
@@ -112,6 +144,33 @@ export default function MovimientosContainer(): React.ReactElement {
         </Suspense>
       )}
 
+      {editarMov && (
+        <Suspense fallback={null}>
+          <ModalCrearMovimiento
+            modo="editar"
+            movimiento={editarMov}
+            itemsIniciales={itemsEditar}
+            loadingItems={loadingItemsEditar}
+            sucursales={sucursales}
+            productos={productos}
+            guardando={guardando}
+            onClose={() => setEditarMov(null)}
+            onGuardarEdicion={handleEditar}
+          />
+        </Suspense>
+      )}
+
+      {cancelarMov && (
+        <Suspense fallback={null}>
+          <ModalCancelarMovimiento
+            movimiento={cancelarMov}
+            guardando={guardando}
+            onConfirmar={handleCancelar}
+            onClose={() => setCancelarMov(null)}
+          />
+        </Suspense>
+      )}
+
       {aceptarMov && (
         <Suspense fallback={null}>
           <ModalAceptarMovimiento
@@ -120,6 +179,7 @@ export default function MovimientosContainer(): React.ReactElement {
             loadingItems={loadingItems}
             productosDestino={productos}
             guardando={guardando}
+            modoDenegarInicial={aceptarModo === 'denegar'}
             onConfirmar={handleAceptar}
             onDenegar={handleDenegar}
             onClose={() => setAceptarMov(null)}

--- a/src/components/modals/ModalAceptarMovimiento.tsx
+++ b/src/components/modals/ModalAceptarMovimiento.tsx
@@ -111,17 +111,20 @@ export interface ModalAceptarMovimientoProps {
   loadingItems: boolean
   productosDestino: ProductoDB[]
   guardando: boolean
+  /** Abre directo en el paso de denegar (botón "Denegar" de la lista). */
+  modoDenegarInicial?: boolean
   onConfirmar: (resoluciones: ResolucionItem[]) => Promise<void>
   onDenegar: (motivo: string) => Promise<void>
   onClose: () => void
 }
 
 const ModalAceptarMovimiento = memo(function ModalAceptarMovimiento({
-  movimiento, items, loadingItems, productosDestino, guardando, onConfirmar, onDenegar, onClose,
+  movimiento, items, loadingItems, productosDestino, guardando,
+  modoDenegarInicial = false, onConfirmar, onDenegar, onClose,
 }: ModalAceptarMovimientoProps) {
   // item_id -> producto_destino_id (string) | NUEVO
   const [sel, setSel] = useState<Record<number, string>>({})
-  const [modoDenegar, setModoDenegar] = useState(false)
+  const [modoDenegar, setModoDenegar] = useState(modoDenegarInicial)
   const [motivo, setMotivo] = useState('')
   const [error, setError] = useState('')
 
@@ -172,7 +175,7 @@ const ModalAceptarMovimiento = memo(function ModalAceptarMovimiento({
   return (
     <ModalBase
       title={`Aceptar movimiento #${movimiento.id}`}
-      description={`Entrante de ${movimiento.origen?.nombre || 'otra sucursal'}. Confirmá el producto de destino para cada item.`}
+      description={`Entrante de ${movimiento.origen?.nombre || 'otra sucursal'}. La mercadería ya salió de ahí: al aceptar ingresa al stock de esta sucursal. Confirmá el producto de destino para cada item.`}
       onClose={onClose}
       maxWidth="max-w-2xl"
     >
@@ -224,6 +227,9 @@ const ModalAceptarMovimiento = memo(function ModalAceptarMovimiento({
               className="w-full px-3 py-2 border rounded-lg dark:bg-gray-700 dark:border-gray-600 dark:text-white"
               placeholder="Ej: no esperábamos este envío"
             />
+            <p className="text-xs text-red-600 dark:text-red-400 mt-1.5">
+              Al denegar, las {movimiento.total_unidades} unidades vuelven al stock de {movimiento.origen?.nombre || 'la sucursal origen'}.
+            </p>
           </div>
         )}
 
@@ -245,7 +251,7 @@ const ModalAceptarMovimiento = memo(function ModalAceptarMovimiento({
               <button onClick={onClose} className="px-4 py-2 text-gray-700 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-700 rounded-lg">Cancelar</button>
               <button onClick={() => { void handleAceptar() }} disabled={guardando || loadingItems || items.length === 0}
                 className="px-4 py-2 bg-green-600 text-white rounded-lg hover:bg-green-700 flex items-center disabled:opacity-50">
-                {guardando && <Loader2 className="w-4 h-4 mr-2 animate-spin" />}<Check className="w-4 h-4 mr-1" /> Aceptar y mover stock
+                {guardando && <Loader2 className="w-4 h-4 mr-2 animate-spin" />}<Check className="w-4 h-4 mr-1" /> Aceptar e ingresar stock
               </button>
             </div>
           </>

--- a/src/components/modals/ModalCancelarMovimiento.tsx
+++ b/src/components/modals/ModalCancelarMovimiento.tsx
@@ -1,0 +1,72 @@
+/**
+ * ModalCancelarMovimiento — el origen se retracta de un envío pendiente.
+ *
+ * Cancelar devuelve el stock a la sucursal origen (mig 139). Solo admin y solo
+ * mientras el envío siga pendiente; el motivo viaja en la notificación al destino.
+ */
+import { memo, useState } from 'react'
+import { AlertTriangle } from 'lucide-react'
+import ModalBase from './ModalBase'
+import type { MovimientoSucursalDB } from '../../hooks/queries'
+
+export interface ModalCancelarMovimientoProps {
+  movimiento: MovimientoSucursalDB
+  guardando?: boolean
+  onConfirmar: (motivo: string) => void | Promise<void>
+  onClose: () => void
+}
+
+function ModalCancelarMovimiento({ movimiento, guardando, onConfirmar, onClose }: ModalCancelarMovimientoProps) {
+  const [motivo, setMotivo] = useState('')
+
+  return (
+    <ModalBase
+      title={`Cancelar envío #${movimiento.id}`}
+      description="El stock vuelve a esta sucursal"
+      onClose={onClose}
+      maxWidth="max-w-md"
+    >
+      <div className="space-y-4">
+        <div className="flex gap-2 p-3 rounded-lg bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800">
+          <AlertTriangle className="w-5 h-5 text-amber-600 dark:text-amber-400 shrink-0 mt-0.5" />
+          <p className="text-sm text-amber-800 dark:text-amber-200">
+            Se van a devolver <strong>{movimiento.total_unidades} unidades</strong> al stock de esta sucursal
+            y se le va a avisar a {movimiento.destino?.nombre || 'la sucursal destino'}.
+          </p>
+        </div>
+
+        <div>
+          <label className="block text-sm font-medium mb-1 dark:text-gray-200">
+            Motivo <span className="text-gray-400 font-normal">(opcional)</span>
+          </label>
+          <textarea
+            value={motivo}
+            onChange={e => setMotivo(e.target.value)}
+            rows={3}
+            placeholder="Ej: se cargó por error, la mercadería no salió…"
+            className="w-full px-3 py-2 border rounded-lg dark:bg-gray-700 dark:border-gray-600 dark:text-white"
+          />
+        </div>
+
+        <div className="flex justify-end gap-2">
+          <button
+            onClick={onClose}
+            disabled={guardando}
+            className="px-4 py-2 rounded-lg border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-700 disabled:opacity-50"
+          >
+            Volver
+          </button>
+          <button
+            onClick={() => { void onConfirmar(motivo.trim()) }}
+            disabled={guardando}
+            className="px-4 py-2 rounded-lg bg-red-600 hover:bg-red-700 text-white disabled:opacity-50"
+          >
+            {guardando ? 'Cancelando…' : 'Cancelar envío'}
+          </button>
+        </div>
+      </div>
+    </ModalBase>
+  )
+}
+
+export default memo(ModalCancelarMovimiento)

--- a/src/components/modals/ModalCrearMovimiento.tsx
+++ b/src/components/modals/ModalCrearMovimiento.tsx
@@ -1,17 +1,23 @@
 /**
  * ModalCrearMovimiento — la sucursal origen crea una "salida" hacia otra
- * sucursal. Queda pendiente de aprobación; NO mueve stock todavía.
+ * sucursal, o edita una pendiente (`modo="editar"`, solo admin).
+ *
+ * Desde la mig 139 crear DESCUENTA el stock del origen en el acto (la
+ * mercadería ya salió del depósito), y editar lo ajusta por diferencia.
  */
-import { memo, useMemo, useState } from 'react'
-import { Loader2, Search, Plus, Trash2, Building2 } from 'lucide-react'
+import { memo, useEffect, useMemo, useState } from 'react'
+import { Loader2, Search, Plus, Trash2, Building2, PackageMinus } from 'lucide-react'
 import ModalBase from './ModalBase'
 import NumberInput from '../ui/NumberInput'
+import { stockDisponibleParaEnvio } from '../../utils/movimientos'
+import type { MovimientoSucursalDB, MovimientoItemDB } from '../../hooks/queries'
 import type { ProductoDB, SucursalDB } from '../../types'
 
 interface LineaItem {
   productoId: string
   nombre: string
   cantidad: number
+  /** Tope editable: stock en góndola + lo que este envío ya tenía reservado. */
   stock: number
 }
 
@@ -20,8 +26,17 @@ export interface ModalCrearMovimientoProps {
   productos: ProductoDB[]
   guardando: boolean
   onClose: () => void
-  onConfirmar: (payload: {
+  onConfirmar?: (payload: {
     sucursalDestinoId: number
+    notas?: string
+    items: Array<{ producto_id: number; cantidad: number }>
+  }) => Promise<void>
+  /** Modo edición de un envío pendiente. */
+  modo?: 'crear' | 'editar'
+  movimiento?: MovimientoSucursalDB
+  itemsIniciales?: MovimientoItemDB[]
+  loadingItems?: boolean
+  onGuardarEdicion?: (payload: {
     notas?: string
     items: Array<{ producto_id: number; cantidad: number }>
   }) => Promise<void>
@@ -29,12 +44,44 @@ export interface ModalCrearMovimientoProps {
 
 const ModalCrearMovimiento = memo(function ModalCrearMovimiento({
   sucursales, productos, guardando, onClose, onConfirmar,
+  modo = 'crear', movimiento, itemsIniciales, loadingItems, onGuardarEdicion,
 }: ModalCrearMovimientoProps) {
-  const [destino, setDestino] = useState<string>('')
-  const [notas, setNotas] = useState<string>('')
+  const esEditar = modo === 'editar'
+  const [destino, setDestino] = useState<string>(esEditar ? String(movimiento?.sucursal_destino_id ?? '') : '')
+  const [notas, setNotas] = useState<string>(esEditar ? (movimiento?.notas ?? '') : '')
   const [busqueda, setBusqueda] = useState<string>('')
   const [lineas, setLineas] = useState<LineaItem[]>([])
   const [error, setError] = useState<string>('')
+
+  // Cantidades que este envío ya tiene reservadas, por producto: en edición el
+  // stock de `productos` viene descontado por este mismo envío.
+  const reservadoPorProducto = useMemo(() => {
+    const m = new Map<string, number>()
+    if (!esEditar) return m
+    for (const it of itemsIniciales ?? []) {
+      const k = String(it.producto_origen_id)
+      m.set(k, (m.get(k) ?? 0) + it.cantidad)
+    }
+    return m
+  }, [esEditar, itemsIniciales])
+
+  const stockDe = (productoId: string, stockActual: number) =>
+    stockDisponibleParaEnvio(stockActual, reservadoPorProducto.get(productoId) ?? 0)
+
+  // Prellenar las líneas cuando llegan los items del envío que se edita.
+  useEffect(() => {
+    if (!esEditar || !itemsIniciales?.length) return
+    setLineas(itemsIniciales.map(it => {
+      const pid = String(it.producto_origen_id)
+      const prod = productos.find(p => String(p.id) === pid)
+      return {
+        productoId: pid,
+        nombre: prod?.nombre ?? it.origen_nombre,
+        cantidad: it.cantidad,
+        stock: stockDisponibleParaEnvio(prod?.stock ?? 0, it.cantidad),
+      }
+    }))
+  }, [esEditar, itemsIniciales, productos])
 
   const resultados = useMemo(() => {
     const term = busqueda.trim().toLowerCase()
@@ -47,7 +94,7 @@ const ModalCrearMovimiento = memo(function ModalCrearMovimiento({
   const agregar = (p: ProductoDB) => {
     setLineas(prev => prev.some(l => l.productoId === p.id)
       ? prev
-      : [...prev, { productoId: p.id, nombre: p.nombre, cantidad: 1, stock: p.stock || 0 }])
+      : [...prev, { productoId: p.id, nombre: p.nombre, cantidad: 1, stock: stockDe(p.id, p.stock || 0) }])
     setBusqueda('')
   }
 
@@ -58,19 +105,46 @@ const ModalCrearMovimiento = memo(function ModalCrearMovimiento({
 
   const handleSubmit = async () => {
     setError('')
-    if (!destino) { setError('Elegí la sucursal destino.'); return }
+    if (!esEditar && !destino) { setError('Elegí la sucursal destino.'); return }
     const items = lineas.filter(l => l.cantidad > 0).map(l => ({ producto_id: Number(l.productoId), cantidad: l.cantidad }))
-    if (items.length === 0) { setError('Agregá al menos un producto con cantidad.'); return }
+    if (items.length === 0) {
+      setError(esEditar
+        ? 'Un envío no puede quedar sin productos. Si querés darlo de baja, usá Cancelar.'
+        : 'Agregá al menos un producto con cantidad.')
+      return
+    }
+    const excedido = lineas.find(l => l.cantidad > l.stock)
+    if (excedido) { setError(`${excedido.nombre}: no hay stock para ${excedido.cantidad} (disponible ${excedido.stock}).`); return }
     try {
-      await onConfirmar({ sucursalDestinoId: Number(destino), notas: notas.trim() || undefined, items })
+      if (esEditar) {
+        await onGuardarEdicion?.({ notas: notas.trim() || undefined, items })
+      } else {
+        await onConfirmar?.({ sucursalDestinoId: Number(destino), notas: notas.trim() || undefined, items })
+      }
     } catch (e) {
-      setError((e as Error).message || 'Error al crear el movimiento')
+      setError((e as Error).message || `Error al ${esEditar ? 'editar' : 'crear'} el movimiento`)
     }
   }
 
   return (
-    <ModalBase title="Nueva salida de stock" description="Enviá productos a otra sucursal. Queda pendiente hasta que la sucursal destino lo acepte." onClose={onClose} maxWidth="max-w-xl">
+    <ModalBase
+      title={esEditar ? `Editar envío #${movimiento?.id}` : 'Nueva salida de stock'}
+      description={esEditar
+        ? 'El stock de esta sucursal se ajusta según los cambios que hagas.'
+        : 'El stock sale de esta sucursal al confirmar. La otra sucursal lo ingresa cuando lo recibe.'}
+      onClose={onClose}
+      maxWidth="max-w-xl"
+    >
       <div className="p-4 space-y-4 max-h-[70vh] overflow-y-auto">
+        <div className="flex gap-2 p-3 rounded-lg bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800">
+          <PackageMinus className="w-5 h-5 text-amber-600 dark:text-amber-400 shrink-0 mt-0.5" />
+          <p className="text-sm text-amber-800 dark:text-amber-200">
+            {esEditar
+              ? 'Este envío ya descontó su stock. Si subís una cantidad se descuenta la diferencia; si la bajás o quitás un producto, vuelve al stock.'
+              : 'Al crear la salida el stock se descuenta de esta sucursal, porque la mercadería ya salió del depósito.'}
+          </p>
+        </div>
+
         <div>
           <label className="block text-sm font-medium mb-1 dark:text-gray-200 flex items-center gap-1">
             <Building2 className="w-4 h-4" /> Sucursal destino
@@ -78,11 +152,17 @@ const ModalCrearMovimiento = memo(function ModalCrearMovimiento({
           <select
             value={destino}
             onChange={e => setDestino(e.target.value)}
-            className="w-full px-3 py-2 border rounded-lg dark:bg-gray-700 dark:border-gray-600 dark:text-white"
+            disabled={esEditar}
+            className="w-full px-3 py-2 border rounded-lg dark:bg-gray-700 dark:border-gray-600 dark:text-white disabled:opacity-60 disabled:cursor-not-allowed"
           >
             <option value="">Seleccionar sucursal...</option>
             {sucursales.map(s => <option key={s.id} value={s.id}>{s.nombre}</option>)}
           </select>
+          {esEditar && (
+            <p className="text-xs text-gray-500 mt-1">
+              El destino no se puede cambiar. Para eso, cancelá el envío y creá uno nuevo.
+            </p>
+          )}
         </div>
 
         <div>
@@ -103,12 +183,18 @@ const ModalCrearMovimiento = memo(function ModalCrearMovimiento({
                   className="w-full flex items-center justify-between px-3 py-2 text-left text-sm hover:bg-gray-50 dark:hover:bg-gray-700/50"
                 >
                   <span className="truncate dark:text-white">{p.nombre}</span>
-                  <span className="text-xs text-gray-400 flex-shrink-0 ml-2">stock {p.stock ?? 0}</span>
+                  <span className="text-xs text-gray-400 flex-shrink-0 ml-2">stock {stockDe(p.id, p.stock ?? 0)}</span>
                 </button>
               ))}
             </div>
           )}
         </div>
+
+        {esEditar && loadingItems && (
+          <p className="text-sm text-gray-500 flex items-center gap-2">
+            <Loader2 className="w-4 h-4 animate-spin" /> Cargando el envío…
+          </p>
+        )}
 
         {lineas.length > 0 && (
           <div className="border rounded-lg divide-y dark:border-gray-600 dark:divide-gray-600">
@@ -116,11 +202,14 @@ const ModalCrearMovimiento = memo(function ModalCrearMovimiento({
               <div key={l.productoId} className="flex items-center gap-2 px-3 py-2">
                 <div className="flex-1 min-w-0">
                   <p className="text-sm font-medium dark:text-white truncate">{l.nombre}</p>
-                  <p className="text-xs text-gray-400">stock disponible: {l.stock}</p>
+                  <p className={`text-xs ${l.cantidad > l.stock ? 'text-red-500' : 'text-gray-400'}`}>
+                    stock disponible: {l.stock}
+                  </p>
                 </div>
                 <NumberInput
                   integer
                   min={0}
+                  max={l.stock}
                   emptyValue={0}
                   commitOnChange
                   value={l.cantidad}
@@ -161,7 +250,7 @@ const ModalCrearMovimiento = memo(function ModalCrearMovimiento({
           className="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 flex items-center disabled:opacity-50"
         >
           {guardando && <Loader2 className="w-4 h-4 mr-2 animate-spin" />}
-          Crear salida
+          {esEditar ? 'Guardar cambios' : 'Crear salida'}
         </button>
       </div>
     </ModalBase>

--- a/src/components/modals/ModalDetalleMovimiento.tsx
+++ b/src/components/modals/ModalDetalleMovimiento.tsx
@@ -8,17 +8,12 @@
  * (matcheado a un producto del destino o creado nuevo).
  */
 import { memo, useMemo } from 'react'
-import { Loader2, ArrowRight, Check, PlusCircle } from 'lucide-react'
+import { Loader2, ArrowRight, Check, PlusCircle, PackageMinus } from 'lucide-react'
 import ModalBase from './ModalBase'
 import { formatPrecio, formatDateTime } from '../../utils/formatters'
+import { ESTADO_MOVIMIENTO_BADGE, VERBO_RESOLUCION } from '../../constants/movimientos'
 import type { ProductoDB } from '../../types'
-import type { MovimientoSucursalDB, MovimientoItemDB, EstadoMovimiento } from '../../hooks/queries'
-
-const ESTADO_BADGE: Record<EstadoMovimiento, string> = {
-  pendiente: 'bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-400',
-  aceptada: 'bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400',
-  denegada: 'bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400',
-}
+import type { MovimientoSucursalDB, MovimientoItemDB } from '../../hooks/queries'
 
 export interface ModalDetalleMovimientoProps {
   movimiento: MovimientoSucursalDB
@@ -54,17 +49,39 @@ const ModalDetalleMovimiento = memo(function ModalDetalleMovimiento({
             <ArrowRight className="w-4 h-4 text-gray-400" />
             <span>{movimiento.destino?.nombre || 'Destino'}</span>
           </div>
-          <span className={`px-2 py-0.5 rounded-full text-xs font-medium ${ESTADO_BADGE[movimiento.estado]}`}>
+          <span className={`px-2 py-0.5 rounded-full text-xs font-medium ${ESTADO_MOVIMIENTO_BADGE[movimiento.estado]}`}>
             {movimiento.estado}
           </span>
         </div>
 
+        {movimiento.estado === 'pendiente' && movimiento.stock_descontado && (
+          <div className="flex gap-2 p-3 rounded-lg bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800">
+            <PackageMinus className="w-5 h-5 text-amber-600 dark:text-amber-400 shrink-0 mt-0.5" />
+            <p className="text-sm text-amber-800 dark:text-amber-200">
+              El stock ya salió de {movimiento.origen?.nombre || 'la sucursal origen'}.
+              {' '}{movimiento.destino?.nombre || 'La sucursal destino'} todavía no lo ingresó.
+            </p>
+          </div>
+        )}
+
         <div className="text-xs text-gray-500 space-y-0.5">
-          {movimiento.created_at && <p>Creado: {formatDateTime(movimiento.created_at)}{movimiento.creador?.nombre ? ` · ${movimiento.creador.nombre}` : ''}</p>}
-          {movimiento.resuelto_at && <p>Resuelto: {formatDateTime(movimiento.resuelto_at)}</p>}
+          {movimiento.created_at && (
+            <p>Creado: {formatDateTime(movimiento.created_at)}{movimiento.creador?.nombre ? ` · por ${movimiento.creador.nombre}` : ''}</p>
+          )}
+          {movimiento.resuelto_at && (
+            <p>
+              {VERBO_RESOLUCION[movimiento.estado]}: {formatDateTime(movimiento.resuelto_at)}
+              {movimiento.resuelto?.nombre ? ` · por ${movimiento.resuelto.nombre}` : ''}
+            </p>
+          )}
+          {movimiento.editado_at && (
+            <p>Editado: {formatDateTime(movimiento.editado_at)}{movimiento.editor?.nombre ? ` · por ${movimiento.editor.nombre}` : ''}</p>
+          )}
           {movimiento.notas && <p className="italic text-gray-600 dark:text-gray-400">Nota: {movimiento.notas}</p>}
-          {movimiento.estado === 'denegada' && movimiento.motivo_rechazo && (
-            <p className="text-red-500">Motivo del rechazo: {movimiento.motivo_rechazo}</p>
+          {(movimiento.estado === 'denegada' || movimiento.estado === 'cancelada') && movimiento.motivo_rechazo && (
+            <p className="text-red-500">
+              Motivo de la {movimiento.estado === 'cancelada' ? 'cancelación' : 'denegación'}: {movimiento.motivo_rechazo}
+            </p>
           )}
         </div>
 
@@ -116,6 +133,20 @@ const ModalDetalleMovimiento = memo(function ModalDetalleMovimiento({
                       <p className="mt-1.5 text-xs flex items-center gap-1 text-blue-700 dark:text-blue-400">
                         <PlusCircle className="w-3.5 h-3.5" />
                         Producto creado en el destino
+                      </p>
+                    )}
+
+                    {/* Asiento de stock. El del origen se escribe al crear el
+                        envío (mig 139), así que también se ve en los pendientes. */}
+                    {(it.stock_origen_anterior != null || it.stock_destino_anterior != null) && (
+                      <p className="mt-1 text-xs text-gray-400">
+                        {it.stock_origen_anterior != null && (
+                          <span>origen {it.stock_origen_anterior} → {it.stock_origen_nuevo}</span>
+                        )}
+                        {it.stock_origen_anterior != null && it.stock_destino_anterior != null && ' · '}
+                        {it.stock_destino_anterior != null && (
+                          <span>destino {it.stock_destino_anterior} → {it.stock_destino_nuevo}</span>
+                        )}
                       </p>
                     )}
                   </div>

--- a/src/components/vistas/VistaMovimientos.tsx
+++ b/src/components/vistas/VistaMovimientos.tsx
@@ -6,8 +6,9 @@
  * (admin/encargado). Los salientes son solo lectura (esperan aprobación).
  */
 import { memo } from 'react'
-import { Loader2, ArrowDownLeft, ArrowUpRight, Plus, Check, X, PackageX, Eye } from 'lucide-react'
+import { Loader2, ArrowDownLeft, ArrowUpRight, Plus, Check, X, PackageX, Eye, Pencil, Ban, PackageMinus, Clock } from 'lucide-react'
 import { formatPrecio, formatDateTime } from '../../utils/formatters'
+import { ESTADO_MOVIMIENTO_BADGE, VERBO_RESOLUCION, horasDesde } from '../../constants/movimientos'
 import type { MovimientoSucursalDB, EstadoMovimiento } from '../../hooks/queries'
 
 type TabEstado = EstadoMovimiento | 'todos'
@@ -17,30 +18,32 @@ export interface VistaMovimientosProps {
   loading: boolean
   currentSucursalId: number | null
   canResolver: boolean
+  /** Editar/cancelar un envío propio pendiente: solo admin de la sucursal origen. */
+  canEditar: boolean
   estado: TabEstado
   onEstadoChange: (e: TabEstado) => void
   onNuevaSalida: () => void
   onAceptar: (mov: MovimientoSucursalDB) => void
   onDenegar: (mov: MovimientoSucursalDB) => void
   onVerDetalle: (mov: MovimientoSucursalDB) => void
+  onEditar: (mov: MovimientoSucursalDB) => void
+  onCancelar: (mov: MovimientoSucursalDB) => void
 }
 
 const TABS: Array<{ value: TabEstado; label: string }> = [
   { value: 'pendiente', label: 'Pendientes' },
   { value: 'aceptada', label: 'Aceptadas' },
   { value: 'denegada', label: 'Denegadas' },
+  { value: 'cancelada', label: 'Canceladas' },
   { value: 'todos', label: 'Todas' },
 ]
 
-const ESTADO_BADGE: Record<EstadoMovimiento, string> = {
-  pendiente: 'bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-400',
-  aceptada: 'bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400',
-  denegada: 'bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400',
-}
+/** Un envío pendiente hace más de esto se resalta: el incidente real fueron 39 h. */
+const HORAS_ALERTA = 24
 
 const VistaMovimientos = memo(function VistaMovimientos({
-  movimientos, loading, currentSucursalId, canResolver, estado, onEstadoChange,
-  onNuevaSalida, onAceptar, onDenegar, onVerDetalle,
+  movimientos, loading, currentSucursalId, canResolver, canEditar, estado, onEstadoChange,
+  onNuevaSalida, onAceptar, onDenegar, onVerDetalle, onEditar, onCancelar,
 }: VistaMovimientosProps) {
   return (
     <div className="space-y-4">
@@ -86,8 +89,17 @@ const VistaMovimientos = memo(function VistaMovimientos({
             const entrante = mov.sucursal_destino_id === currentSucursalId
             const contraparte = entrante ? mov.origen?.nombre : mov.destino?.nombre
             const puedeResolver = entrante && mov.estado === 'pendiente' && canResolver
+            const salientePendiente = !entrante && mov.estado === 'pendiente'
+            const enTransito = mov.estado === 'pendiente' && mov.stock_descontado
+            const horas = mov.estado === 'pendiente' ? horasDesde(mov.created_at) : 0
+            const demorado = horas >= HORAS_ALERTA
             return (
-              <div key={mov.id} className="bg-white dark:bg-gray-800 rounded-xl border dark:border-gray-700 p-4">
+              <div
+                key={mov.id}
+                className={`bg-white dark:bg-gray-800 rounded-xl border p-4 ${
+                  demorado ? 'border-red-300 dark:border-red-700' : 'dark:border-gray-700'
+                }`}
+              >
                 <div className="flex items-start justify-between gap-3 flex-wrap">
                   <div className="flex items-start gap-3 min-w-0">
                     <div className={`w-9 h-9 rounded-full flex items-center justify-center flex-shrink-0 ${
@@ -102,18 +114,51 @@ const VistaMovimientos = memo(function VistaMovimientos({
                         <span className="font-semibold text-gray-900 dark:text-white">
                           {entrante ? 'Entrante de' : 'Saliente a'} {contraparte || 'otra sucursal'}
                         </span>
-                        <span className={`px-2 py-0.5 rounded-full text-xs font-medium ${ESTADO_BADGE[mov.estado]}`}>
+                        <span className={`px-2 py-0.5 rounded-full text-xs font-medium ${ESTADO_MOVIMIENTO_BADGE[mov.estado]}`}>
                           {mov.estado}
                         </span>
                         <span className="text-xs text-gray-400">#{mov.id}</span>
                       </div>
+
+                      {/* Auditoría: quién cargó y quién resolvió, visible para ambas sucursales */}
                       <p className="text-xs text-gray-500 mt-0.5">
-                        {mov.created_at && formatDateTime(mov.created_at)}
-                        {mov.creador?.nombre ? ` · ${mov.creador.nombre}` : ''}
+                        Creado {mov.created_at && formatDateTime(mov.created_at)}
+                        {mov.creador?.nombre ? ` por ${mov.creador.nombre}` : ''}
                       </p>
+                      {mov.resuelto_at && (
+                        <p className="text-xs text-gray-500">
+                          {VERBO_RESOLUCION[mov.estado]} {formatDateTime(mov.resuelto_at)}
+                          {mov.resuelto?.nombre ? ` por ${mov.resuelto.nombre}` : ''}
+                        </p>
+                      )}
+                      {mov.editado_at && (
+                        <p className="text-xs text-gray-500">
+                          Editado {formatDateTime(mov.editado_at)}
+                          {mov.editor?.nombre ? ` por ${mov.editor.nombre}` : ''}
+                        </p>
+                      )}
+
+                      {/* El stock ya salió del origen: lo más importante de la tarjeta */}
+                      {enTransito && (
+                        <span className="inline-flex items-center gap-1 mt-1.5 px-2 py-0.5 rounded text-xs bg-amber-50 text-amber-700 dark:bg-amber-900/20 dark:text-amber-300">
+                          <PackageMinus className="w-3 h-3" />
+                          {entrante
+                            ? `Ya salió del origen · ${mov.total_unidades} u. pendientes de ingresar`
+                            : `Stock ya descontado · ${mov.total_unidades} u. en tránsito`}
+                        </span>
+                      )}
+                      {demorado && (
+                        <span className="inline-flex items-center gap-1 mt-1.5 ml-1.5 px-2 py-0.5 rounded text-xs bg-red-50 text-red-700 dark:bg-red-900/20 dark:text-red-300">
+                          <Clock className="w-3 h-3" />
+                          Sin resolver hace {horas} h
+                        </span>
+                      )}
+
                       {mov.notas && <p className="text-xs text-gray-500 italic mt-1">{mov.notas}</p>}
-                      {mov.estado === 'denegada' && mov.motivo_rechazo && (
-                        <p className="text-xs text-red-500 mt-1">Motivo: {mov.motivo_rechazo}</p>
+                      {(mov.estado === 'denegada' || mov.estado === 'cancelada') && mov.motivo_rechazo && (
+                        <p className="text-xs text-red-500 mt-1">
+                          Motivo de la {mov.estado === 'cancelada' ? 'cancelación' : 'denegación'}: {mov.motivo_rechazo}
+                        </p>
                       )}
                     </div>
                   </div>
@@ -145,10 +190,28 @@ const VistaMovimientos = memo(function VistaMovimientos({
                         <Check className="w-4 h-4" /> Aceptar
                       </button>
                     </div>
-                  ) : (!entrante && mov.estado === 'pendiente') ? (
-                    <span className="text-xs text-amber-600 dark:text-amber-400">
-                      Esperando aprobación de {mov.destino?.nombre || 'la sucursal destino'}.
-                    </span>
+                  ) : salientePendiente ? (
+                    <div className="flex items-center gap-2 flex-wrap justify-end">
+                      <span className="text-xs text-amber-600 dark:text-amber-400">
+                        Esperando aprobación de {mov.destino?.nombre || 'la sucursal destino'}.
+                      </span>
+                      {canEditar && (
+                        <>
+                          <button
+                            onClick={() => onEditar(mov)}
+                            className="inline-flex items-center gap-1.5 px-3 py-2 text-sm rounded-lg text-gray-600 hover:bg-gray-100 dark:text-gray-300 dark:hover:bg-gray-700"
+                          >
+                            <Pencil className="w-4 h-4" /> Editar
+                          </button>
+                          <button
+                            onClick={() => onCancelar(mov)}
+                            className="inline-flex items-center gap-1.5 px-3 py-2 text-sm rounded-lg bg-red-50 text-red-600 hover:bg-red-100 dark:bg-red-900/20 dark:text-red-400"
+                          >
+                            <Ban className="w-4 h-4" /> Cancelar
+                          </button>
+                        </>
+                      )}
+                    </div>
                   ) : null}
                 </div>
               </div>

--- a/src/constants/movimientos.ts
+++ b/src/constants/movimientos.ts
@@ -1,0 +1,29 @@
+/**
+ * Constantes compartidas de movimientos entre sucursales.
+ *
+ * El mapa de badges estaba duplicado literalmente en VistaMovimientos y
+ * ModalDetalleMovimiento; vive acá para que agregar un estado sea un solo cambio.
+ */
+import type { EstadoMovimiento } from '../hooks/queries'
+
+export const ESTADO_MOVIMIENTO_BADGE: Record<EstadoMovimiento, string> = {
+  pendiente: 'bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-400',
+  aceptada: 'bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400',
+  denegada: 'bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400',
+  cancelada: 'bg-gray-100 text-gray-600 dark:bg-gray-700 dark:text-gray-300',
+}
+
+/** Cómo se lee la resolución en la línea de auditoría ("Aceptado el … por …"). */
+export const VERBO_RESOLUCION: Record<EstadoMovimiento, string> = {
+  pendiente: 'Resuelto',
+  aceptada: 'Aceptado',
+  denegada: 'Denegado',
+  cancelada: 'Cancelado',
+}
+
+/** Horas transcurridas desde una fecha ISO (para marcar envíos demorados). */
+export function horasDesde(iso: string | null | undefined): number {
+  if (!iso) return 0
+  const ms = Date.now() - new Date(iso).getTime()
+  return ms > 0 ? Math.floor(ms / 3_600_000) : 0
+}

--- a/src/hooks/queries/index.ts
+++ b/src/hooks/queries/index.ts
@@ -191,7 +191,8 @@ export {
   useSucursalesQuery,
 } from './useTransferenciasQuery'
 
-// Movimientos entre sucursales (con aprobación, mig 076)
+// Movimientos entre sucursales (con aprobación, mig 076;
+// descuento preventivo de stock + editar/cancelar, mig 139)
 export {
   movimientosKeys,
   MOVIMIENTOS_PAGE_SIZE,
@@ -200,6 +201,8 @@ export {
   useCrearMovimientoMutation,
   useAceptarMovimientoMutation,
   useDenegarMovimientoMutation,
+  useCancelarMovimientoMutation,
+  useEditarMovimientoMutation,
 } from './useMovimientosQuery'
 export type {
   EstadoMovimiento,

--- a/src/hooks/queries/useMovimientosQuery.ts
+++ b/src/hooks/queries/useMovimientosQuery.ts
@@ -15,7 +15,7 @@ import { useSucursal } from '../../contexts/SucursalContext'
 
 export const MOVIMIENTOS_PAGE_SIZE = 50
 
-export type EstadoMovimiento = 'pendiente' | 'aceptada' | 'denegada'
+export type EstadoMovimiento = 'pendiente' | 'aceptada' | 'denegada' | 'cancelada'
 
 export interface MovimientoSucursalDB {
   id: number
@@ -23,15 +23,24 @@ export interface MovimientoSucursalDB {
   sucursal_destino_id: number
   estado: EstadoMovimiento
   total_costo: number
+  /** Unidades totales del envío (mig 139): la lista no trae los items. */
+  total_unidades: number
+  /** true = el origen tiene estas unidades descontadas AHORA (mig 139). */
+  stock_descontado: boolean
   notas: string | null
   motivo_rechazo: string | null
   creado_por: string
   resuelto_por: string | null
+  editado_por: string | null
   created_at: string
   resuelto_at: string | null
+  editado_at: string | null
   origen?: { id: number; nombre: string } | null
   destino?: { id: number; nombre: string } | null
   creador?: { id: string; nombre: string } | null
+  /** Quien aceptó, denegó o canceló. */
+  resuelto?: { id: string; nombre: string } | null
+  editor?: { id: string; nombre: string } | null
 }
 
 export interface MovimientoItemDB {
@@ -52,6 +61,11 @@ export interface MovimientoItemDB {
   producto_destino_id: number | null
   resolucion: 'match_existente' | 'creado_nuevo' | null
   costo_aplicado_destino: number | null
+  /** Asiento de stock. El origen se llena al crear/editar (mig 139); el destino al aceptar. */
+  stock_origen_anterior: number | null
+  stock_origen_nuevo: number | null
+  stock_destino_anterior: number | null
+  stock_destino_nuevo: number | null
 }
 
 export interface MovimientosFiltros {
@@ -90,7 +104,9 @@ async function fetchMovimientos(opts: FetchOpts): Promise<MovimientoSucursalDB[]
       *,
       origen:sucursales!sucursal_origen_id(id, nombre),
       destino:sucursales!sucursal_destino_id(id, nombre),
-      creador:perfiles!creado_por(id, nombre)
+      creador:perfiles!creado_por(id, nombre),
+      resuelto:perfiles!resuelto_por(id, nombre),
+      editor:perfiles!editado_por(id, nombre)
     `)
     .gte('created_at', `${opts.desde}T00:00:00`)
     .lte('created_at', `${opts.hasta}T23:59:59`)
@@ -157,6 +173,33 @@ async function denegarMovimiento(input: { movimientoId: number; motivo?: string 
   if (!r.success) throw new Error(r.error || 'Error al denegar el movimiento')
 }
 
+/** Cancela un envío pendiente desde el origen y le devuelve el stock (mig 139). */
+async function cancelarMovimiento(input: { movimientoId: number; motivo?: string | null }): Promise<void> {
+  const { data, error } = await supabase.rpc('cancelar_movimiento_sucursal', {
+    p_movimiento_id: input.movimientoId,
+    p_motivo: input.motivo ?? null,
+  })
+  if (error) throw error
+  const r = data as RPCResult
+  if (!r.success) throw new Error(r.error || 'Error al cancelar el movimiento')
+}
+
+/** Edita un envío pendiente desde el origen ajustando el stock por delta (mig 139). */
+async function editarMovimiento(input: {
+  movimientoId: number
+  notas?: string | null
+  items: Array<{ producto_id: number; cantidad: number }>
+}): Promise<void> {
+  const { data, error } = await supabase.rpc('editar_movimiento_sucursal', {
+    p_movimiento_id: input.movimientoId,
+    p_notas: input.notas ?? null,
+    p_items: input.items,
+  })
+  if (error) throw error
+  const r = data as RPCResult
+  if (!r.success) throw new Error(r.error || 'Error al editar el movimiento')
+}
+
 export function useMovimientosQuery(filtros: MovimientosFiltros = {}) {
   const { currentSucursalId } = useSucursal()
   const desde = filtros.desde ?? fechaHaceDias(60)
@@ -188,7 +231,9 @@ function useInvalidarMovimientos() {
   const queryClient = useQueryClient()
   const { currentSucursalId } = useSucursal()
   return () => {
-    queryClient.invalidateQueries({ queryKey: movimientosKeys.lists(currentSucursalId) })
+    // `all` y no `lists`: la edición cambia los items, así que el detalle
+    // cacheado (movimientosKeys.items) también tiene que invalidarse.
+    queryClient.invalidateQueries({ queryKey: movimientosKeys.all(currentSucursalId) })
     queryClient.invalidateQueries({ queryKey: ['productos'] })
     queryClient.invalidateQueries({ queryKey: ['notificaciones'] })
   }
@@ -207,4 +252,14 @@ export function useAceptarMovimientoMutation() {
 export function useDenegarMovimientoMutation() {
   const invalidar = useInvalidarMovimientos()
   return useMutation({ mutationFn: denegarMovimiento, onSuccess: invalidar })
+}
+
+export function useCancelarMovimientoMutation() {
+  const invalidar = useInvalidarMovimientos()
+  return useMutation({ mutationFn: cancelarMovimiento, onSuccess: invalidar })
+}
+
+export function useEditarMovimientoMutation() {
+  const invalidar = useInvalidarMovimientos()
+  return useMutation({ mutationFn: editarMovimiento, onSuccess: invalidar })
 }

--- a/src/utils/movimientos.test.ts
+++ b/src/utils/movimientos.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest'
+import { stockDisponibleParaEnvio } from './movimientos'
+
+describe('stockDisponibleParaEnvio', () => {
+  it('al crear (sin reserva previa) el tope es el stock actual', () => {
+    expect(stockDisponibleParaEnvio(50)).toBe(50)
+    expect(stockDisponibleParaEnvio(50, 0)).toBe(50)
+  })
+
+  it('al editar suma lo que este envío ya se llevó', () => {
+    // El envío tiene 10 u. reservadas y en góndola quedan 40 -> se puede llegar a 50.
+    expect(stockDisponibleParaEnvio(40, 10)).toBe(50)
+  })
+
+  it('permite bajar la cantidad aunque el producto haya quedado en 0', () => {
+    // Caso real: el envío se llevó todo. Sin sumar la reserva el tope sería 0
+    // y no se podría ni corregir el envío hacia abajo.
+    expect(stockDisponibleParaEnvio(0, 100)).toBe(100)
+  })
+
+  it('nunca devuelve negativo', () => {
+    expect(stockDisponibleParaEnvio(-5)).toBe(0)
+    expect(stockDisponibleParaEnvio(-10, 3)).toBe(0)
+  })
+
+  it('tolera valores no numéricos', () => {
+    expect(stockDisponibleParaEnvio(NaN)).toBe(0)
+    expect(stockDisponibleParaEnvio(10, NaN)).toBe(10)
+  })
+})

--- a/src/utils/movimientos.ts
+++ b/src/utils/movimientos.ts
@@ -1,0 +1,23 @@
+/**
+ * Helpers de movimientos entre sucursales.
+ */
+
+/**
+ * Stock que la sucursal origen puede poner en un envío para un producto.
+ *
+ * Al CREAR es simplemente el stock actual. Al EDITAR hay una trampa: desde la
+ * mig 139 el envío YA descontó su cantidad del stock, así que `producto.stock`
+ * viene deflactado por este mismo envío. El tope real es lo que queda en
+ * góndola MÁS lo que este envío ya se llevó — si no, editar un envío de 100 u.
+ * sobre un producto que quedó en 0 mostraría tope 0 y no se podría ni bajar la
+ * cantidad.
+ *
+ * @param stockActual        `productos.stock` tal como viene de la base
+ * @param cantidadEnEsteEnvio unidades que este envío ya tiene reservadas del
+ *                            producto (0 al crear, o para una línea nueva)
+ */
+export function stockDisponibleParaEnvio(stockActual: number, cantidadEnEsteEnvio = 0): number {
+  const stock = Number.isFinite(stockActual) ? stockActual : 0
+  const reservado = Number.isFinite(cantidadEnEsteEnvio) ? cantidadEnEsteEnvio : 0
+  return Math.max(0, stock + reservado)
+}


### PR DESCRIPTION
La sucursal origen cargaba un envío, **la mercadería salía físicamente**, pero el stock recién se descontaba cuando el destino **aceptaba**. En el medio el origen seguía mostrando —y vendiendo— stock que ya no tenía.

Caso real en prod: el movimiento **#6 estuvo 39,3 horas** pendiente con **160 unidades** fantasma en Tucumán. Y como no había forma de editar ni cancelar un envío pendiente, lo **denegaron y lo recrearon** (#7) un minuto después.

## Migración 139 (ya aplicada a prod)

| RPC | Antes | Ahora |
|---|---|---|
| `crear_` | no tocaba **ni validaba** stock | **valida y descuenta** del origen en el acto |
| `aceptar_` | descontaba origen + sumaba destino | **solo ingresa al destino** |
| `denegar_` | no tocaba stock | **restituye** al origen |
| `cancelar_` | ❌ no existía | **nueva**: el origen se retracta y recupera el stock |
| `editar_` | ❌ no existía | **nueva**: corrige el envío ajustando el stock por delta |

`cancelar_` no es un extra: sin ella, con descuento preventivo un envío cargado por error dejaba el stock descontado **para siempre** — el origen no tenía ninguna acción disponible. Ambas nuevas son **admin + sucursal origen + estado pendiente**.

**Editar usa delta por producto** (no restituir-todo-y-reaplicar): un producto cuya cantidad no cambia no genera `UPDATE` ni fila de ledger. El destino no es editable — para eso, cancelar + crear.

### Cómo se evita el doble descuento
La columna `stock_descontado` significa *"el origen tiene estas unidades descontadas AHORA"*. `aceptar_` solo descuenta del origen si está en `false`, o sea los movimientos creados con la lógica vieja. Los pendientes que existan al desplegar quedan en `false` y siguen el camino viejo, **así que el deploy es seguro aun con envíos en vuelo**, sin downtime.

Invariantes auditables: `aceptada ⟹ true` · `denegada|cancelada ⟹ false`.

### Trazabilidad
La mig 076 nunca seteaba `app.stock_*`, así que estos movimientos caían en `stock_historico` como `origen='auto'` sin referencia (pendiente P1 `STK-D` de la mig 105). Ahora cada `UPDATE` de stock setea `origen` / `ref_tipo` / `ref_id` / `user_id`.

## Frontend

- **Auditoría (lo que pediste):** línea en la tarjeta y en el detalle, visible para **ambas sucursales**: quién creó, quién aceptó/denegó/canceló y quién editó. El join a `perfiles!resuelto_por` **faltaba** — el dato estaba en la base pero no se pedía ni se mostraba.
- **Chip "stock ya descontado · N u. en tránsito"** y **resalte en rojo** de los pendientes de más de 24 h (el incidente fueron 39).
- Botones **Editar** y **Cancelar** para el admin del origen; antes ese caso sólo mostraba el texto "Esperando aprobación".
- `ModalCrearMovimiento` soporta modo edición. **El detalle más fácil de arruinar:** ahí `productos.stock` ya viene descontado por el propio envío, así que el tope es `stock + lo que el envío ya se llevó` (`stockDisponibleParaEnvio`, con 5 tests). Se agrega el `max` al `NumberInput`, que no tenía ninguno.
- Estado `cancelada` (badge + tab) y el mapa de badges movido a `constants/` — estaba duplicado literalmente entre la vista y el modal de detalle.

**Dos bugs preexistentes que aparecieron en el camino:**
- `useInvalidarMovimientos` invalidaba `lists` pero no `items`, así que el detalle quedaba cacheado. La edición lo volvía visible.
- `onAceptar` y `onDenegar` apuntaban ambos al mismo handler: "Denegar" abría el modal en modo aceptar.

## Verificación en prod

Ciclo completo probado con transacciones revertidas (**no quedó nada**: 3 movimientos, stocks intactos, 0 filas de test):

| Caso | Resultado |
|---|---|
| Crear (con línea duplicada del mismo producto) | stock 124→114, **colapsó a 1 item**, 4 filas de ledger correctas |
| Editar (subir uno, quitar otro) | 114→99 y el quitado **devuelto** 209→214 |
| Cancelar | restitución exacta a 124, `estado=cancelada`, flag en `false` |
| **Aceptar** | **origen quedó en 114 — no volvió a descontar** ✅, destino +10, snapshot `124→114` preservado |
| Denegar | stock devuelto, ledger `movimiento_denegado` |
| Stock insuficiente | rechaza nombrando el producto y las cantidades |
| Gates | encargado no puede editar/cancelar · el destino tampoco · no se puede vaciar el envío |

`typecheck` y `eslint` limpios · **799 tests** en verde (5 nuevos).

## Nota
Mientras un envío está pendiente, esas unidades no figuran en ninguna sucursal (salieron de origen, no entraron en destino) — decidimos aceptarlo, así que no aparecen en el reporte de Valuación de Stock durante ese lapso.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
