### PR TITLE
feat(rendiciones): mostrar quién cobró cada pago en el detalle

### DIFF
--- a/migrations/140_detalle_rendicion_cobrado_por.sql
+++ b/migrations/140_detalle_rendicion_cobrado_por.sql
@@ -1,0 +1,102 @@
+-- ============================================================================
+-- 140 · Detalle de rendición: quién cobró cada pago
+-- ============================================================================
+-- PEDIDO (Pablo y Don Jorge): "los pagos que se registren mediante la ficha de
+-- cliente también tienen que salir en la rendición, porque es plata que se
+-- rinde igual".
+--
+-- Esa plata YA sale (cae en el cuadro azul "Ctas Ctes"). Lo que faltaba es
+-- poder ver DE QUIÉN es: la rendición agrupa por el transportista que repartió
+-- el pedido, así que un saldo viejo cobrado en el mostrador por Pablo figura
+-- bajo el transportista del pedido, no bajo Pablo. Medido en prod (30 días):
+-- $9.054.000 registrados por Jony y $1.544.660 por Pablo aparecen bajo
+-- "Transporte Taco Pozo".
+--
+-- Como en la práctica se mezclan las dos cosas (cobro de mostrador y carga de
+-- lo que trajo el chofer), NO se cambia la agrupación: mover esa plata de
+-- rendición rompería el control contra el chofer. Solo se expone el dato.
+--
+-- Cambio: el detalle pasa a agrupar por (cliente, usuario que registró el pago)
+-- y devuelve `cobrado_por`. En el caso normal —un cliente pagó todo con el
+-- mismo cobrador— sigue siendo una fila por cliente; solo se abre en dos
+-- cuando efectivamente cobraron dos personas distintas ese día.
+-- ============================================================================
+
+DROP FUNCTION IF EXISTS public.obtener_detalle_rendicion(date, uuid);
+
+CREATE OR REPLACE FUNCTION public.obtener_detalle_rendicion(
+  p_fecha date,
+  p_transportista_id uuid
+)
+RETURNS TABLE(
+  cliente_id bigint,
+  cliente_nombre text,
+  cobrado_por_id uuid,
+  cobrado_por text,
+  total numeric,
+  total_entregas numeric,
+  total_ctascte numeric,
+  efectivo numeric,
+  transferencia numeric,
+  cheque numeric,
+  tarjeta numeric,
+  vale_blanco numeric,
+  cuenta_corriente numeric,
+  otros numeric,
+  cantidad_pagos bigint
+)
+LANGUAGE plpgsql
+STABLE SECURITY DEFINER
+SET search_path TO 'public'
+AS $function$
+DECLARE
+  v_sucursal_id bigint;
+BEGIN
+  v_sucursal_id := current_sucursal_id();
+  IF v_sucursal_id IS NULL THEN
+    RAISE EXCEPTION 'Sucursal no seleccionada';
+  END IF;
+  IF NOT es_encargado_o_admin() THEN
+    RAISE EXCEPTION 'No autorizado';
+  END IF;
+
+  RETURN QUERY
+  SELECT
+    pg.cliente_id AS cliente_id,
+    COALESCE(NULLIF(c.nombre_fantasia, ''), c.razon_social, 'Cliente #' || pg.cliente_id)::text AS cliente_nombre,
+    pg.usuario_id AS cobrado_por_id,
+    COALESCE(u.nombre, 'Sin usuario')::text AS cobrado_por,
+    SUM(pg.monto)::numeric AS total,
+    -- Mismo criterio que obtener_resumen_rendiciones (migs 133/136).
+    SUM(CASE
+      WHEN pg.pedido_id IS NOT NULL
+       AND pd.estado = 'entregado'
+       AND COALESCE(pd.fecha_entrega::date, pg.fecha) = pg.fecha
+      THEN pg.monto ELSE 0 END)::numeric AS total_entregas,
+    SUM(CASE
+      WHEN pg.pedido_id IS NULL
+        OR pd.estado IS DISTINCT FROM 'entregado'
+        OR COALESCE(pd.fecha_entrega::date, pg.fecha) IS DISTINCT FROM pg.fecha
+      THEN pg.monto ELSE 0 END)::numeric AS total_ctascte,
+    SUM(CASE WHEN pg.forma_pago = 'efectivo' THEN pg.monto ELSE 0 END)::numeric AS efectivo,
+    SUM(CASE WHEN pg.forma_pago = 'transferencia' THEN pg.monto ELSE 0 END)::numeric AS transferencia,
+    SUM(CASE WHEN pg.forma_pago = 'cheque' THEN pg.monto ELSE 0 END)::numeric AS cheque,
+    SUM(CASE WHEN pg.forma_pago = 'tarjeta' THEN pg.monto ELSE 0 END)::numeric AS tarjeta,
+    SUM(CASE WHEN pg.forma_pago = 'vale_blanco' THEN pg.monto ELSE 0 END)::numeric AS vale_blanco,
+    SUM(CASE WHEN pg.forma_pago = 'cuenta_corriente' THEN pg.monto ELSE 0 END)::numeric AS cuenta_corriente,
+    SUM(CASE WHEN pg.forma_pago NOT IN ('efectivo','transferencia','cheque','tarjeta','vale_blanco','cuenta_corriente')
+              OR pg.forma_pago IS NULL THEN pg.monto ELSE 0 END)::numeric AS otros,
+    COUNT(*)::bigint AS cantidad_pagos
+  FROM pagos pg
+  LEFT JOIN pedidos pd ON pd.id = pg.pedido_id
+  LEFT JOIN clientes c ON c.id = pg.cliente_id
+  LEFT JOIN perfiles u ON u.id = pg.usuario_id
+  WHERE pg.fecha = p_fecha
+    AND pg.sucursal_id = v_sucursal_id
+    AND COALESCE(pd.transportista_id, pg.usuario_id) = p_transportista_id
+  GROUP BY pg.cliente_id, c.nombre_fantasia, c.razon_social, pg.usuario_id, u.nombre
+  ORDER BY SUM(pg.monto) DESC;
+END;
+$function$;
+
+GRANT EXECUTE ON FUNCTION public.obtener_detalle_rendicion(date, uuid) TO authenticated;

--- a/src/components/vistas/VistaRendiciones.tsx
+++ b/src/components/vistas/VistaRendiciones.tsx
@@ -66,10 +66,15 @@ const ESTADO_STYLES: Record<EstadoRendicion, { label: string; badge: string; bor
   }
 }
 
-/** Fila del detalle por cliente de una rendición (RPC obtener_detalle_rendicion, migs 135/137). */
+/** Fila del detalle de una rendición: cliente + quién cobró (RPC obtener_detalle_rendicion, migs 135/137/140). */
 interface DetalleRendicionCliente {
   cliente_id: number
   cliente_nombre: string
+  /** Usuario que registró el pago. Ojo: puede no ser el transportista de la
+   *  rendición — un saldo viejo cobrado en el mostrador figura bajo el
+   *  transportista que repartió ese pedido. */
+  cobrado_por_id: string | null
+  cobrado_por: string
   total: number
   total_entregas: number
   total_ctascte: number
@@ -152,6 +157,8 @@ function ResumenCard({ resumen, onCerrar, onResolver }: ResumenCardProps): React
         setDetalle((data || []).map((r: Record<string, unknown>) => ({
           cliente_id: Number(r.cliente_id),
           cliente_nombre: String(r.cliente_nombre ?? 'Cliente'),
+          cobrado_por_id: (r.cobrado_por_id as string | null) ?? null,
+          cobrado_por: String(r.cobrado_por ?? 'Sin usuario'),
           total: Number(r.total) || 0,
           total_entregas: Number(r.total_entregas) || 0,
           total_ctascte: Number(r.total_ctascte) || 0,
@@ -174,6 +181,15 @@ function ResumenCard({ resumen, onCerrar, onResolver }: ResumenCardProps): React
     [detalle]
   )
 
+  // Cuánto cobró cada persona dentro de esta rendición. Sirve para el control
+  // de caja: la rendición agrupa por transportista, pero la plata la puede
+  // haber cobrado otro (p. ej. un saldo viejo cobrado en el mostrador).
+  const porCobrador = useMemo(() => {
+    const m = new Map<string, number>()
+    for (const d of detalle ?? []) m.set(d.cobrado_por, (m.get(d.cobrado_por) ?? 0) + d.total)
+    return [...m.entries()].sort((a, b) => b[1] - a[1])
+  }, [detalle])
+
   // Filas visibles: con filtro activo, solo los clientes que aportaron a esa forma.
   const detalleVisible = useMemo(() => {
     if (!detalle) return []
@@ -187,6 +203,7 @@ function ResumenCard({ resumen, onCerrar, onResolver }: ResumenCardProps): React
     try {
       const filas = detalle.map(d => ({
         Cliente: d.cliente_nombre,
+        Cobró: d.cobrado_por,
         Total: d.total,
         'Entregas (dia)': d.total_entregas,
         'Ctas Ctes': d.total_ctascte,
@@ -200,7 +217,7 @@ function ResumenCard({ resumen, onCerrar, onResolver }: ResumenCardProps): React
       }))
       const { createMultiSheetExcel } = await import('../../utils/excel')
       await createMultiSheetExcel(
-        [{ name: 'Detalle', data: filas, columnWidths: [28, 14, 14, 14, 12, 14, 12, 12, 12, 10, 8] }],
+        [{ name: 'Detalle', data: filas, columnWidths: [28, 16, 14, 14, 14, 12, 14, 12, 12, 12, 10, 8] }],
         `rendicion-${resumen.transportista_nombre}-${resumen.fecha}`.replace(/\s+/g, '_')
       )
     } finally {
@@ -434,6 +451,22 @@ function ResumenCard({ resumen, onCerrar, onResolver }: ResumenCardProps): React
                 </button>
               </div>
 
+              {/* Quién cobró: la rendición agrupa por transportista, pero la
+                  plata la puede haber cobrado otro (típico: un saldo viejo
+                  cobrado en el mostrador desde la ficha del cliente). */}
+              {!loadingDetalle && porCobrador.length > 0 && (
+                <div className="flex flex-wrap gap-2 mb-2">
+                  {porCobrador.map(([nombre, monto]) => (
+                    <span
+                      key={nombre}
+                      className="inline-flex items-center gap-1 px-2 py-0.5 rounded text-xs bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-300"
+                    >
+                      Cobró {nombre}: <strong>{formatMoney(monto)}</strong>
+                    </span>
+                  ))}
+                </div>
+              )}
+
               {loadingDetalle ? (
                 <p className="text-xs text-gray-400 py-2">Cargando detalle…</p>
               ) : detalleVisible.length > 0 ? (
@@ -442,6 +475,7 @@ function ResumenCard({ resumen, onCerrar, onResolver }: ResumenCardProps): React
                     <thead>
                       <tr className="text-gray-500 dark:text-gray-400 text-left border-b border-gray-200 dark:border-gray-700">
                         <th className="py-1 pr-2 font-medium">Cliente</th>
+                        <th className="py-1 px-2 font-medium">Cobró</th>
                         {formaFiltro && <th className="py-1 px-2 font-medium text-right">{FORMA_LABELS[formaFiltro]}</th>}
                         <th className="py-1 px-2 font-medium text-right">Total</th>
                         <th className="py-1 px-2 font-medium text-right">Entregas</th>
@@ -450,8 +484,9 @@ function ResumenCard({ resumen, onCerrar, onResolver }: ResumenCardProps): React
                     </thead>
                     <tbody>
                       {detalleVisible.map(d => (
-                        <tr key={d.cliente_id} className="border-b border-gray-100 dark:border-gray-700/50">
+                        <tr key={`${d.cliente_id}-${d.cobrado_por_id ?? 'x'}`} className="border-b border-gray-100 dark:border-gray-700/50">
                           <td className="py-1 pr-2 text-gray-700 dark:text-gray-300">{d.cliente_nombre}</td>
+                          <td className="py-1 px-2 text-gray-500">{d.cobrado_por}</td>
                           {formaFiltro && (
                             <td className="py-1 px-2 text-right font-semibold text-blue-700 dark:text-blue-300">{formatMoney(d[formaFiltro])}</td>
                           )}
@@ -464,7 +499,7 @@ function ResumenCard({ resumen, onCerrar, onResolver }: ResumenCardProps): React
                     {formaFiltro && (
                       <tfoot>
                         <tr className="border-t border-gray-300 dark:border-gray-600">
-                          <td className="py-1 pr-2 font-medium text-gray-600 dark:text-gray-300">Total {FORMA_LABELS[formaFiltro]}</td>
+                          <td className="py-1 pr-2 font-medium text-gray-600 dark:text-gray-300" colSpan={2}>Total {FORMA_LABELS[formaFiltro]}</td>
                           <td className="py-1 px-2 text-right font-bold text-blue-700 dark:text-blue-300">
                             {formatMoney(detalleVisible.reduce((acc, d) => acc + (d[formaFiltro] || 0), 0))}
                           </td>


### PR DESCRIPTION
Pablo y Don Jorge pedían que **los pagos registrados desde la ficha del cliente también salgan en la rendición**, porque es plata que se rinde igual.

## Esa plata ya salía — lo que faltaba era ver de quién es

Los cobros de ficha caen en el cuadro azul **"Ctas Ctes (cobro de saldos)"**. Verificado en prod: **ningún pago queda afuera** (0 de 1.079 en Taco Pozo). Últimos días:

| Fecha | Cobranza de saldos | Venta del día |
|---|---|---|
| 24/07 | **$302.500** (todo) | — |
| 22/07 | $338.500 | $23.000 |
| 20/07 | $203.620 | $656.700 |

**El problema real es otro:** la rendición agrupa por el transportista que repartió el pedido, no por quién cobró. Un saldo viejo cobrado en el mostrador figura bajo ese transportista.

En 30 días: **$9.054.000 registrados por Jony** y **$1.544.660 por Pablo** aparecen bajo "Transporte Taco Pozo". Caso concreto del 24/07 — los $302.500 los cobró **Pablo**:

| Cliente | Cobró | Monto |
|---|---|---|
| MARIO SALVATIERRA | Pablo | $214.800 |
| SHOWMATCH | Pablo | $65.700 |
| DESPENSA SAY SOF | Pablo | $22.000 |

## Por qué NO cambio la agrupación

Porque en la práctica se mezclan dos cosas y el sistema no las distingue: a veces cobran en el mostrador (la plata la tienen ellos) y a veces cargan lo que trajo el chofer (la plata es del reparto). Mover esa plata de rendición rompería el control contra el chofer. Se expone el dato y se decide mirando.

## Cambios

**Mig 140** (ya aplicada): `obtener_detalle_rendicion` agrupa también por el usuario que registró el pago y devuelve `cobrado_por`. En el caso normal —un cliente pagó todo con el mismo cobrador— sigue siendo una fila por cliente; solo se abre en dos cuando cobraron dos personas distintas ese día.

**UI:** columna **"Cobró"** en la tabla del detalle, **chips con el total por cobrador** (ej. *"Cobró Pablo: $302.500"*) y la columna en el Excel. El `key` de las filas pasa a ser cliente+cobrador, que ya no es único por cliente.

No cambia ningún total ni mueve plata entre rendiciones.

`typecheck` y `eslint` limpios · **799 tests** en verde.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
