### PR TITLE
fix(ruteo): priorizar los que abren temprano y no mandar el camion a puerta cerrada

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,11 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "dev",
+      "runtimeExecutable": "npm",
+      "runtimeArgs": ["run", "dev"],
+      "port": 5173
+    }
+  ]
+}

--- a/docs/AUDIT_REPORT_2026-03-20.md
+++ b/docs/AUDIT_REPORT_2026-03-20.md
@@ -1,0 +1,172 @@
+# Auditoría Integral del Código
+
+Fecha: 2026-03-20
+Proyecto: `distribuidora-app`
+Alcance: frontend React/Vite, capa de datos actual y legacy, SQL/RPC/RLS y tooling que impacta la confiabilidad de los checks
+
+## Resumen Ejecutivo
+
+La aplicación tiene buena cobertura base para cambios locales (`tsc` y `vitest` pasan), pero la auditoría encontró varios problemas reales en flujos críticos de pedidos, sincronización offline y dashboard:
+
+- Riesgo inmediato de falso éxito al aplicar ordenes de entrega y al editar pedidos.
+- Riesgo inmediato de duplicación de operaciones offline por una deduplicación que hoy no funciona.
+- Riesgo funcional en dashboard por cache incorrecto de métricas personalizadas.
+- Riesgo estructural de escalabilidad por analytics y exportaciones basadas en cargas completas de tablas.
+- Riesgo de regresión por deriva entre la capa viva y la capa legacy de pedidos.
+
+## Validación Ejecutada
+
+- `npm.cmd run typecheck`
+  Resultado: OK
+- `npm.cmd run test:run`
+  Resultado: OK, 27 archivos y 522 tests en verde
+- `npx.cmd eslint src e2e eslint.config.js`
+  Resultado: OK
+- `npm.cmd run lint`
+  Resultado: no es confiable hoy porque recorre artefactos generados en `.claude/worktrees/*/dist`
+
+## Top Riesgos Inmediatos
+
+1. Aplicar una ruta optimizada puede mostrar éxito sin persistir nada.
+2. La cola offline puede aceptar duplicados y luego sincronizarlos como pedidos/mermas repetidos.
+3. Editar un pedido puede cerrar el modal con mensaje de éxito aunque el backend rechace el cambio.
+
+## Hallazgos
+
+### 1. [Alta] La acción "Aplicar orden" usa una RPC inexistente y además ignora el error de Supabase
+
+- Categoría: funcionalidad / lógica de negocio
+- Evidencia:
+  - `src/components/containers/PedidosContainer.tsx:469-480` llama `supabase.rpc('actualizar_orden_entrega', ...)` y luego siempre ejecuta `notify.success('Orden de entrega actualizado')`.
+  - `migrations/006_add_orden_entrega_rpc.sql:25-66` solo define `actualizar_orden_entrega_batch(...)` y `limpiar_orden_entrega(...)`.
+- Impacto:
+  - El usuario puede creer que persistió la ruta optimizada cuando la base quedó igual.
+  - La operación afecta un flujo operativo central para transportistas.
+- Condición de disparo:
+  - Desde gestión de rutas, al confirmar un orden optimizado.
+- Recomendación:
+  - Cambiar el handler para usar `actualizar_orden_entrega_batch`.
+  - Inspeccionar explícitamente `{ error }` antes de cerrar modal o mostrar éxito.
+
+### 2. [Alta] La deduplicación offline no funciona porque el hash cambia en cada intento
+
+- Categoría: funcionalidad / lógica de negocio
+- Evidencia:
+  - `src/lib/offlineDb.ts:138-147` agrega `Date.now()` al hash usado para detectar duplicados.
+  - `src/lib/offlineDb.ts:159-170` compara hashes exactos para decidir si una operación ya existe.
+  - `src/hooks/useOfflineSync.ts:350-353` agrega el pedido al estado local antes de conocer si el encolado fue aceptado o rechazado.
+  - `e2e/offline-sync.spec.ts:193-233` tiene un test de duplicados, pero solo imprime el resultado y no hace ninguna aserción.
+- Impacto:
+  - Dos clics iguales offline pueden terminar como dos operaciones distintas y sincronizarse duplicadas.
+  - También pueden aparecer pendientes "fantasma" en la UI si el encolado falla o debería descartarse.
+- Condición de disparo:
+  - Reintentos manuales, doble submit, reconexiones o clicks repetidos en modo offline.
+- Recomendación:
+  - Hacer el hash determinístico a partir de `type + payload normalizado`.
+  - No meter timestamps dentro del hash.
+  - Persistir en la UI solo después de confirmar que la operación fue encolada.
+  - Convertir el test e2e de duplicados en una aserción obligatoria.
+
+### 3. [Alta] Editar un pedido puede reportar éxito aunque el backend no haya guardado nada
+
+- Categoría: funcionalidad
+- Evidencia:
+  - `src/components/containers/PedidosContainer.tsx:379-392` hace `await supabase.from('pedidos').update(...).eq(...)`, pero nunca inspecciona el `error` devuelto.
+  - Ese mismo flujo cierra el modal y lanza `notify.success('Pedido actualizado')` sin invalidar cache.
+  - En contraste, `src/components/containers/PedidosContainer.tsx:402-413` sí valida `error` e invalida queries cuando edita items.
+- Impacto:
+  - Notas, estado de pago o monto pagado pueden fallar por RLS/validación/red y aun así presentarse como guardados.
+  - Incluso cuando el update sí persiste, la lista puede seguir mostrando datos viejos hasta un refresh.
+- Condición de disparo:
+  - Editar un pedido desde `ModalEditarPedido`.
+- Recomendación:
+  - Capturar `{ error }` y abortar el camino de éxito si existe.
+  - Invalidar `pedidosKeys.all` o al menos refrescar la query paginada visible.
+
+### 4. [Media] El dashboard reutiliza cache incorrecta para rangos personalizados
+
+- Categoría: funcionalidad
+- Evidencia:
+  - `src/components/containers/DashboardContainer.tsx:30-39` pasa `fechaDesde` y `fechaHasta` a `useMetricasQuery`.
+  - `src/hooks/queries/useMetricasQuery.ts:20-21` construye la key solo con `periodo` y `usuarioId`.
+  - `src/hooks/queries/useMetricasQuery.ts:262-263` usa esa key aunque la query sí depende de `fechaDesde` y `fechaHasta`.
+- Impacto:
+  - Si el usuario cambia un rango personalizado dentro del mismo período, React Query puede devolver la métrica anterior durante el `staleTime`.
+  - El dashboard muestra cifras equivocadas sin indicar que la fecha cambió.
+- Condición de disparo:
+  - Cambiar fechas dentro del modo `personalizado`.
+- Recomendación:
+  - Incluir `fechaDesde` y `fechaHasta` en `metricasKeys.dashboard(...)`.
+
+### 5. [Media] "Limpiar pedidos offline" no limpia realmente la cola persistida
+
+- Categoría: funcionalidad
+- Evidencia:
+  - `src/hooks/useOfflineSync.ts:614-618` promete limpiar todo, pero llama `cleanupOldOperations(0)`.
+  - `src/lib/offlineDb.ts:281-290` solo elimina operaciones con `status = 'completed'`.
+- Impacto:
+  - Operaciones `pending` o `failed` pueden reaparecer después de recargar la app.
+  - El operador no tiene una forma real de descartar una cola corrupta o vieja.
+- Condición de disparo:
+  - Uso de la acción de limpieza esperando resetear la cola offline.
+- Recomendación:
+  - Agregar una operación explícita para borrar pendientes/fallidas, o borrar por tipo/usuario según el caso de uso.
+
+### 6. [Media] El dashboard y los backups cargan tablas completas en el navegador
+
+- Categoría: escalabilidad
+- Evidencia:
+  - `src/hooks/queries/useMetricasQuery.ts:57-65` trae todos los pedidos con cliente e items.
+  - `src/hooks/queries/useMetricasQuery.ts:114-178` calcula filtros, top productos, top clientes y series temporales enteramente en cliente.
+  - `src/hooks/supabase/useBackup.ts:93-103` exporta `clientes`, `productos` y `pedidos` completos desde el frontend.
+- Impacto:
+  - El dashboard se degrada con el crecimiento histórico de pedidos.
+  - Los backups completos dependen de memoria y ancho de banda del navegador del admin.
+- Condición de disparo:
+  - Historial mediano/grande de pedidos o backups operados desde equipos modestos.
+- Recomendación:
+  - Mover agregaciones de métricas a RPC/SQL.
+  - Paginación o generación server-side para exportaciones grandes.
+  - Reducir los `select` a los campos realmente usados.
+
+### 7. [Media] Hay deriva fuerte entre la capa viva y la capa legacy de pedidos
+
+- Categoría: lógica de negocio / mantenibilidad
+- Evidencia:
+  - `src/types/index.ts:86-92` define `EstadoPedido` con `en_reparto`.
+  - `src/types/hooks.ts:90` usa `en_camino` y `asignado`.
+  - `src/services/api/pedidoService.ts:183-210` valida `en_reparto` y asigna ese estado.
+  - `src/hooks/queries/usePedidosQuery.ts:114` filtra `['asignado', 'en_camino']`.
+  - `src/services/api/pedidoService.ts:120-139` trabaja con `fecha_creacion`, `metodo_pago` y un filtro `cliente.zona` marcado como TODO, mientras la capa viva usa otro contrato.
+  - `src/services/api/pedidoService.ts:264-286` escribe/ordena historial con columnas `accion`, `descripcion` y `fecha`, pero la tabla real usa `campo_modificado`, `valor_anterior`, `valor_nuevo` y `created_at` según `migrations/001_add_pedido_improvements.sql:17-25`.
+- Impacto:
+  - La capa legacy ya no representa fielmente el contrato real de la base ni el flujo actual.
+  - Reutilizarla para nuevos features o fixes puede reintroducir bugs difíciles de detectar.
+- Condición de disparo:
+  - Cualquier refactor que mezcle servicios legacy con containers/query hooks actuales.
+- Recomendación:
+  - Consolidar un único contrato de estados y columnas.
+  - Retirar o encapsular la capa legacy para que no compita con la viva.
+
+## Hallazgos Descartados o Reinterpretados
+
+- El posible descalce entre `productoService` y las RPC de stock no quedó como bug inmediato:
+  - `src/services/api/productoService.ts:113-117` llama `descontar_stock_atomico` con `p_items`.
+  - Las firmas JSONB siguen definidas en `migrations/023_security_fixes.sql:69-169`.
+  - `migrations/032_fix_rpc_security_and_add_fecha_pedido.sql` agrega overloads escalares, pero no elimina las firmas JSONB anteriores.
+  - Conclusión: hoy es más bien deuda de contrato y no una rotura confirmada.
+
+- El lint del repo no está “roto” a nivel de código fuente:
+  - `npx.cmd eslint src e2e eslint.config.js` pasa limpio.
+  - El problema de `npm run lint` viene de alcance/ignore, no de errores reales del `src`.
+
+## Riesgos Estructurales Secundarios
+
+- `eslint.config.js:10` solo ignora `dist` y `**/*.d.ts`, por lo que worktrees o builds auxiliares fuera de la raíz contaminan el comando estándar de lint.
+- La suite e2e actual existe, pero varias pruebas de caos validan muy poco el estado final y por eso no protegen bien los invariantes offline más delicados.
+
+## Siguiente Fase Recomendada
+
+1. Corregir los tres hallazgos altos antes de tocar optimizaciones menores.
+2. Unificar el contrato de pedidos y desactivar la capa legacy no usada.
+3. Mover métricas y exportaciones pesadas fuera del navegador para sostener crecimiento.

--- a/migrations/153_barridas_5_grupos.sql
+++ b/migrations/153_barridas_5_grupos.sql
@@ -1,0 +1,34 @@
+-- =========================================================================
+-- 153_barridas_5_grupos.sql
+--
+-- El ruteo pasa de 3 a 5 bloques. El criterio viejo (sólo hora de cierre)
+-- dejaba que, dentro del primer bloque, el optimizador arrancara por un local
+-- que abre 09:00 mientras uno de 07:00 quedaba noveno: el camión sale 08:00 y
+-- la primera parada estaba cerrada.
+--
+-- Orden nuevo:
+--   1 · abren temprano Y cierran al mediodía  (lo único visitable al salir)
+--   2 · cierran hasta las 13
+--   3 · cierran hasta las 14:30
+--   4 · sin horario cargado
+--   5 · corrido o abren tarde
+--
+-- El grupo 1 exige las DOS condiciones: un local 07:00-24:00 abre temprano
+-- pero no urge, y meterlo ahí gasta la mañana —el recurso escaso— en alguien
+-- que se puede visitar a cualquier hora. En una ruta real eso llevaba el primer
+-- bloque de 6 a 14 paradas.
+--
+-- Los valores 1-3 ya persistidos siguen siendo válidos como número, pero su
+-- SIGNIFICADO cambió (el 2 era "sin horario" y ahora es "cierran hasta las 13").
+-- No se migran: son de rutas ya ejecutadas y sólo se usan para mostrar y medir.
+-- =========================================================================
+
+ALTER TABLE public.recorrido_pedidos
+  DROP CONSTRAINT IF EXISTS recorrido_pedidos_barrida_check;
+
+ALTER TABLE public.recorrido_pedidos
+  ADD CONSTRAINT recorrido_pedidos_barrida_check
+  CHECK (barrida IS NULL OR barrida BETWEEN 1 AND 5);
+
+COMMENT ON COLUMN public.recorrido_pedidos.barrida IS
+  'Bloque de reparto (mig 153): 1 = abren temprano y cierran al mediodía, 2 = cierran hasta las 13, 3 = cierran hasta las 14:30, 4 = sin horario, 5 = corrido o abren tarde. NULL = ruta armada sin barridas.';

--- a/migrations/154_actualizar_barridas_1a5.sql
+++ b/migrations/154_actualizar_barridas_1a5.sql
@@ -1,0 +1,57 @@
+-- =========================================================================
+-- 154_actualizar_barridas_1a5.sql
+--
+-- El RPC filtraba `IN (1, 2, 3)` al parsear el jsonb, así que con los 5 grupos
+-- de la mig 153 habría descartado EN SILENCIO las barridas 4 y 5: esas paradas
+-- quedaban con barrida NULL y sin separador en la hoja de ruta, sin ningún
+-- error visible. Se cambia por el rango 1..5.
+-- =========================================================================
+
+CREATE OR REPLACE FUNCTION public.actualizar_barridas_recorrido(p_items jsonb)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $fn$
+DECLARE
+  v_actualizados integer := 0;
+BEGIN
+  IF NOT es_encargado_o_admin() THEN
+    RAISE EXCEPTION 'Solo un admin o encargado puede actualizar las barridas'
+      USING ERRCODE = '42501';
+  END IF;
+
+  IF p_items IS NULL OR jsonb_typeof(p_items) <> 'array' THEN
+    RAISE EXCEPTION 'p_items debe ser un array JSON';
+  END IF;
+
+  WITH datos AS (
+    SELECT (e ->> 'pedido_id')::bigint  AS pedido_id,
+           (e ->> 'barrida')::smallint  AS barrida
+    FROM jsonb_array_elements(p_items) e
+    WHERE e ->> 'pedido_id' IS NOT NULL
+      AND (e ->> 'barrida')::smallint BETWEEN 1 AND 5
+  ),
+  upd AS (
+    UPDATE recorrido_pedidos rp
+    SET barrida = d.barrida
+    FROM datos d
+    WHERE rp.pedido_id = d.pedido_id
+      AND rp.recorrido_id IN (
+        SELECT id FROM recorridos
+        WHERE estado = 'en_curso' AND sucursal_id = current_sucursal_id()
+      )
+    RETURNING 1
+  )
+  SELECT count(*) INTO v_actualizados FROM upd;
+
+  RETURN jsonb_build_object('success', true, 'actualizados', v_actualizados);
+END;
+$fn$;
+
+ALTER FUNCTION public.actualizar_barridas_recorrido(jsonb) OWNER TO postgres;
+REVOKE ALL ON FUNCTION public.actualizar_barridas_recorrido(jsonb) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.actualizar_barridas_recorrido(jsonb) TO authenticated;
+
+COMMENT ON FUNCTION public.actualizar_barridas_recorrido(jsonb) IS
+  'Marca la barrida (1..5) de cada parada del recorrido en curso. Admin/encargado. Mig 154.';

--- a/output/pdf/auditoria-tecnica-distribuidora-app-2026-04-15.pdf
+++ b/output/pdf/auditoria-tecnica-distribuidora-app-2026-04-15.pdf
@@ -1,0 +1,232 @@
+%PDF-1.4
+%“Œ‹ž ReportLab Generated PDF document (opensource)
+1 0 obj
+<<
+/F1 2 0 R /F2 3 0 R /F3 6 0 R
+>>
+endobj
+2 0 obj
+<<
+/BaseFont /Helvetica /Encoding /WinAnsiEncoding /Name /F1 /Subtype /Type1 /Type /Font
+>>
+endobj
+3 0 obj
+<<
+/BaseFont /Helvetica-Bold /Encoding /WinAnsiEncoding /Name /F2 /Subtype /Type1 /Type /Font
+>>
+endobj
+4 0 obj
+<<
+/Contents 17 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 16 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+5 0 obj
+<<
+/Contents 18 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 16 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+6 0 obj
+<<
+/BaseFont /Courier /Encoding /WinAnsiEncoding /Name /F3 /Subtype /Type1 /Type /Font
+>>
+endobj
+7 0 obj
+<<
+/Contents 19 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 16 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+8 0 obj
+<<
+/Contents 20 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 16 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+9 0 obj
+<<
+/Contents 21 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 16 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+10 0 obj
+<<
+/Contents 22 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 16 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+11 0 obj
+<<
+/Contents 23 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 16 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+12 0 obj
+<<
+/Contents 24 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 16 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+13 0 obj
+<<
+/Contents 25 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 16 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+14 0 obj
+<<
+/PageMode /UseNone /Pages 16 0 R /Type /Catalog
+>>
+endobj
+15 0 obj
+<<
+/Author (\(anonymous\)) /CreationDate (D:20260415100412-03'00') /Creator (\(unspecified\)) /Keywords () /ModDate (D:20260415100412-03'00') /Producer (ReportLab PDF Library - \(opensource\)) 
+  /Subject (\(unspecified\)) /Title (\(anonymous\)) /Trapped /False
+>>
+endobj
+16 0 obj
+<<
+/Count 9 /Kids [ 4 0 R 5 0 R 7 0 R 8 0 R 9 0 R 10 0 R 11 0 R 12 0 R 13 0 R ] /Type /Pages
+>>
+endobj
+17 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 2526
+>>
+stream
+Gau0DgNM=0(4GpYS4C&R)$7H`T$iQRX4'b3fP4G/q>ue@$kGc\+R*'4oC:W:8Vs`)9?G]WP"cLSF2^??Llma*k5OLYU*&Rjl5_+hBtbi.H6LPje)gMoo9kqUZ(IiQV*W&+&H>ZM6igTllcb:Nca/MGe733]V%dr'@Tf5KR\DM+r%sFXmn1/T)l0918ERmD$no[]M\>Tt.*R'6?5,jmN\`2tJIS&cV=;tB_DoL%24_MH$Irmd"LU"g<%dBd$IuLQ/NQmF,;)AiiuO%aq;EjloCtD9hpVFL.sQ)\`$4F0a8;ca&1^`e@ZrqsiKET*E)8!?&eDu;\C,]IO5M7-b0PI&:*,>2"@qq8j&9K"]R%VT40S7oqLeT?+G.@VRMSp"k(A(H<NTLD;3!\Cm-emC5-8?,9U4[1)?u/5_#;(EN$WK98BJXde3n?Pp=Z<u;`+0\KH\4GU*#?NaLp',+1m$#l/%`DR`8M(%@XT`TW64/Go#m8eTWd`&QD:VnkM&7=0F"963!_'$6HBm5:m50F<sB4'$KJDqP7;OJ(IsX(8A'pF&?5P,6'<Em%i=]&#6\*V&oC0BTW'dH*?;['g1tKT4^ZH(8m92`(1HLiopVk)Aep8HJt6;XERTTh/rXnbXIf?]ki1%W4s^EiVMPg6Pt=T_X0%*///-;L1_<moCmjT2Tt]0@?`*I5'LsfhKDB8dV.]h<Qo,ZG.5&VAQRt!Rj_i8[8@djp3B,C;9<$:HFYS,-"j%M]4)RdWP!/GWC/N]%6SRiW\^Xd"cbm%EP5s0Rp;1eTh>'.K3blA8j\=VNCVBr45nR?RLoG*0%<e\RW:NlZq[P5k1'&gW6qGG@UpqVoM4Nh:30Vt<9Uu!94T!`&oq4;)F9?XPhtpI6qQmW"o_+P<Y;pUQ$EW3oEjN0m&O%beV1sQEZhRn>`<WG61:BAW.i8<FT>cmb=6GX,J8apGLCf=2L6q_L&9O6*<%&nlWTPZA.+Gj!B92Q![;b+8IM%L_jbCVi$]H47?SN[G?n>pa@#l2K'B#QD9s5KP0WS=\Psa'23QB67WV27r0MEUAVmeO^ai6';9H:sFY9)`N^uW>/WGkC!W?kMPb!"s\\=3g6"\$9&rF/"Q#c+o_o%1G?9`Pap5\+E*#DS&ES#"r[92CFf#$?IHU0TtPd4CnJAcHBrA:NUOg#'5k>1VSR(SCPXqfdV%Gc+s%62C?((^XGoL0T9DTWE-aRm3Fj9jkt81jU/34RCP9oDnZ*t0kX(SV&G91T&/)S=+#N%tq"-WW^>7"l"5J/K,(S\.$5Q,<$%SFMN>Gq]P=mAqg2Z%a2cT2#A=>:a&X(q#Za.WpMW\Ij7q'cf3mX_]OVpIMt`HE?G\!ZhiW.48l"Kb*"E9=0o,B-(R^URGlL7@JlDJBNrDE)2qB4Gh/&^aX]A-Zf4%\u2jg;"?t-UVun*P[t%0d.2ORBn+/\.,qirG180k*cs!VB$S_=+M*bU`-CUjiAiUdBhHN-pGdr4m7LG'%P1@B01nMRa2RNEi]10/];;9?loElWk0EaA!kh*G*-Q^mVDr,3W8VuGVb33GG#O$R8YEu@+h!)b7T<0U&Q@]``4Sk]lksd+LjHtI.t)cgJ&BFP`YOi:>;T`o(/uk$oJd46d%JmLLj@oDA6%be\phRPNp&OjH\8Asb4:q6UD-_UgJ=0"Ei$U-TV?UuK>ctCNBHE"[0!2!3M\Z2#9QX,ck3+0/LN#2XT$R<>l<Bn`h7.%k6C467Nthq"ufi@K!eIT>?=Tc]"1c]e37kbs7Z>mVB&<iY>Mu?4EpFnL-i%hD@,Q8Ke4aHq^VuW>`2'S@V>K?(oYG,e7t3Q!I1.@ZT.YsHu>SD\3nkfpTV'^JW_&-#.np@:+#nPfD]=>ABBCT/C7+h0H?ueAgT;NN>$:cS\Sp/#l/QDUN$?s4.3m_T3s5<ULVj/%X.-B,jb]nk/Y:ts7&qQi/$Eh2Z-p`q*218"^(arM;q$_8,cKWhoD(=-E0g2X`.,XIiGt]AV]CL'[7i;;Wj)6M%2O];.s?Q4cg/\D+9:oh8=h]=gkRtGe_9[TmCd5qAUCd*:^qsd*#X>!dg7@W9]\R0,Au<JS"5-[S7k?7CDFk2`)]"%Ut+]*glnb<QNN'Yf\h6UD6/Z3%D!G\$BpF)SIi-,;QRUI5>^P#;:8XCRf8LbHdHgjXkif-!c^WA$PLGC;6%+4fYTl7@%4&-BT`oB-ATA*V<7^[a3#df6kZZ2"nd7L,E\k&AusF,.$dXHcgbfce#EdrZoDH^L2G9,LJOlW]<>PN!81MfQQN@!t+f[WI%NRi_]!SWn1dmC.Gps#TpMRqX^D,)tElJ&ZjT/3-+AildqcnO)k:[g;TPQZUAc:,D(DmG=Z3$%he>n)>6s,@rf/j5^=[E[[H)q5P*UKIdW9\0q<C=]QDI\/+(E7l+dk];Kj^]-VtQ#6MHarrC4Y1!W2QL\!MR+.e]6kG5.`MDr5@I4hG40C0TTEl$JAtof\mA`&k79L=:uu`s=Ys:2mqLhn4/7?b_B4W*3QCl0L'-"AX=~>endstream
+endobj
+18 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 1157
+>>
+stream
+Gau0A?#Sa]&:F5UfZ1@T),fA'6OWP598b\nRu>[<>%2;/&uecn;s2bV.+sV$UmLBJ#PgaJMVOWQ=\97G--"iB-2Oj=X(t!FU;]9PKI+"8ToY,bh_URb):&\"7@ZhYK)[$Pe!N>t11Marc3u!&'1Gb6PXI&;AQD]%Bp(8YAD-QZ6[,kbQ6IS'=glYmi\D-\:+Su#P"3I=,j!\(Xhk.E7s`Al'eE+c"KPb<ph?\7[n]TeW\V/K1oFOOhWa-pC[:%dFrf^5HGu)KLe$-B[+NabqiLS`pJds(ag:Tps-,$N,Xj(rDB[,1;3:m"#&\_')9<.UM(g$h'Dau'*&W`LCep4+'_=&?kur+[+^f3Qf)^cA@&8[C_id65Inu-R)/WF(=\%"g0Fp>F81E`onDX%7Z69*0T+&liHu<0UJ#Lm5\!u6C2mQ6F3GjPk-mt@mdC$&U:S"ib:jKa>rQ,g@X5EF&I+Cd/BVUZg`A^@XYJ=4:`8W>*`qeZQ)!:#Qr&BZ`?@O#kP5mdF5ig<\0'md%m+:'Rf5o3cA8fAUQR=Y'49ZnTi['B9M2<e*@Ae/W"'a.@l8jM?7otqk'c5KQH.f,Dg!_=&S">(0n?\JSR@=/,,V+aN,Qc3n:BCRh#,3e&?6Xq@is?(\q$88V;!%quMjc9\F<bKKHZa-UTPA>G*#`9VQ!Go<N*#HLilZnq-2j[R\tk$:G@";\F?:n[];3'4PN,+oYkgj?lD0VSn*_34'Ka[rkPYh4oW))Oltr2V>q5"BTTXr:Xn;Grap5ehm2DKH,@^9m9YNks/Cb))%rHE$hbfW%FOaQ5D''rC+coE,Y],NWOM,b^X`_^e9\;a.SJ]X+p'%j!`4)]<@b7SoXf@0"kmRnUVN.gd2'=]G(7;4(VbF3dV<(k/+%S^lkCRj2i/[h7?L_%6hCS-!E^slF-cCSO!<6(e1R8ut?EFDJc7k?eb?haHiD>05Dsf=6lBRQ!#5A5CFPt]ef(aGNg:aS&09$GGRY6m#nQ8UZ#=k1i,p-*&+B5IEp'YW,(>hBG3G4k[+r7P1$p&fQT%sk*C].ecj+*I8MZ=G29b5I0$pEQtGk(.?7PL+oqOs;oO-7)V`h7elIp8)$C=Lm#P$59048D.0LYPDU<-X>q)U"7>UE?(H!($"=$IS3Ii6"?T~>endstream
+endobj
+19 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 2459
+>>
+stream
+GauHM?$"Lb&:F5UR)_jWe*6`T;L&P!,ZIWP-[+@F9'o2sLPW=<X<`Gop$(/[I:3V=3=Jp?B1psHSt>?f&Wi'gJc3&kLn<GLijXGiOD`V``*Q+rYNWsM`IA]\1/Ij[7U?iV@34HE(.Lk`J,OiT-1pUl;4MntQK9"'TpGn-RSuRF]_)+Q:%plQl2"jO-0%@50-/C.U-&jI-$aJCkC,s.&gojaB/Y-)0LiW8--X"M:1N)8d-R*mXEn_56+ngK<=#$l=`qEW<^Tl%,Nb_;nZs?@q!fR#_t42FGtU(\o"bQ,:P&^hqW[P!YJd;9JtdmErWFLYS)Q/uAX[j72?8u#R%F@'+Q_cM;C=+gj!>apS<$H#T<\/C6uWq7SFN!F+mN6Yf]\?u9SL\SLf/Fe!IQq]0L#sh!29H68#(55Kg02D6O5F`""NcOb1dac9du@')F;$hL!sd(<RZi"f-Aq:mRXh8Lq^IN*kgR#"7!8!GQ'NlC'<r\H6lV"Co$>BD=CpXeMa+h1e&G;;(5)YN@l^ZK^d'g.Ksrp/JW`_$3#&rH9>2+Tc8[5Ml+>n2-$['W^Fnqj',ppadRs%&:i)r!1^ed!:C+5:m^-\T\)R7Sh65jVtdUZ$HE0$oE&oi!:\DF=O-.G7pHO@%7VNB`UR0.p]IhPlZHJ6@G1=*N5e)cB/W_-)57H,5W"!5n%S@FY6&peB?ku)_jBshZi!e:nOM898t;akc$gBjC52/'C<t`-BL^=&%5$dab]<f*Ck0KXn<3Ek4FU.[^YKj5!DVXb;+bf:(P]rpTXcV-$ofQs3>1nIIeOaW4sA<RQGn6r@J)*l7ur!Y;M3[N2$;=NTob-<fMl.OkuQ<f9H[a^7]2.';Yuo_]Q?ko^F!?"TkgoC?TUgJ;A?EJ5['#AZQ7Uf_i;8s89>mRa[2?E7WUXM^lUiI+84K__R?Q&pG<"<i'KiJMQAXa/;C%(jTI,tgclkrIn@_8<2D2&I714aPJT;F!"2=(1'.k0a""8E7goj.G8>u2f9UG'WKUp!!0bV`Q)_@-n!JR$P?\$GYaV2O-<9<%4P$6jS"VUUcUH4-frAJ;BNf'm%PB$/7GWkN-n^,Wo[2NYNnW]_Ypd%trqUUWd(_OK_7HBdauhV9q"F("'T9P+/On#L?[7(o1l/G_&20TBTOfdI$#0&;f1'S8g`6&D$!4SBn]1/E`1Q,^!5hYslI"0,%Q'#JNqlRi##U_],l&MK"AdMt_nI:ljqHjJSS+&1V_8=A]*lpDIj+\2#)2>=;b"`7.BpRmMSND+,YIZAjqm4VWFWcAq>Imq:s_QCK$=.F+MY4)5B9"[rnfA;6Noi;63q)>?&*>+;9R8L2V5fH7=H*>dHOi`9&nVMhh0qAM5>;]=:OP]';R%::GU-#qV4T?P9@l#GNWtWbCc`t-u#M9n?o[>5ZtChQNER'HDsO4?C&p0=^`Cb`_hU$,Gh[=Dm=j/l]MM0H9g#i8c'LtlkUB=2tX.%Ui?Y11s0-^A].`qTQm,0L!^5`^$U'`f$R&KlkC.Z/,L<DB=,WbXFe$NKi9ApSu&E<!a/Z@#IBOD=kc-k9VnWOiEhg0`pO4p/KQnjQ?)/ModCC&3fRCrnh!$cNH:!Z(s(XE!n0A+-0b^.VoG]c!a\`q4M6Td_#U58FRPP)jGhajG)N&XUSM/PWIfOD%H;XOqP0pV/#Tg[h8/+%TK9IpC1o9dEp&VAl^9t+/Yb-aHRed&0[-7O^K:20S=#D<L,X'%8DmB1FS,1NHhEei6Nkko:>0%h#M\..`Vh!jh_g-Y[FQ1h_<;4f.epVu5VX[f.>%G.B*pcPeai6X0FFQg=as3d]XkT(:PdM]pQ9oo(II+99UV(B$PfqP"cX:%<OV?PTZO6<UI5/-oFm;A>T.E<FqDQA%RKIO*Aj:E#Z\Ls+-uJ@OS(1Ppn9*Hf1cgTE-[=dB3b88XI$U4/,>#*cflsLQJ*LgSI+Xpl`:`OCrpG\^U)?pn+XM%n;A--a"<hSd-.?C^L<@t%>c_tgP_*2`UG:^XoO(H2Vuq%qi9p>-\7I8"ks[`ZsGXA4*it`r*r5F*l@gQ$NLBQ2cFP=O<.]r=QCm*gs4!E/WI+jZco#0"mf/'P<:H+ncq+o2cs=HIs"Pm/Nh,6U+i',Qja#_Yi#&^jlBWK%)!YkG\uSc\ZLSF-FS(plOCEB`B/P#3$GtHpiu$Lrg_lC4'ml8/,87Q'r`&'CVpYGFQFtE"sak*\ic@X[X9u''V:D%l9?QG#GmmOo*@er`hT$sn&S\[>D;%@dL"BUYjia"o_>5a#>r"Ci%2S`_q/<>@d*Kt6UokK]M,Tm_'DiArf76hM,b$s*Uh:V>R0Qp4FSN"e*jMNFH:)/5nKYTj*UY$p!LABjY4$V7N%f`h61(e+f+N@Y$8e-hS;b*eWET\n?qO6D<\-4+7.2%)Ko\FpqRZTOp>NO$^ssW@:##XJg'/N+IoCfo0U%`+)G4^8,~>endstream
+endobj
+20 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 2529
+>>
+stream
+Gau`U@;jmi')h6*1&"C*=;4>h']l&;;Br^[OC$_\!=lX3_jXgZ9W;<0QW2udm_@YK,t67*SC"O0-Endp9CC*[2fIQS!qPkGE5/_"d8-+9GSX*edcH48aG]9Q"[0O]q/G>qeqq.6a\.t?\;p'IL<Fg5YPrP$`Us%aU+#\d1gR!nKjGb#P;V_UN`MaD-HU5/Ut7!M/1FB#p6';'Dn-@1GXYpQ7r(=7090K`O#("S+m;t\cP!,31.ibG]qa8E-80+N$:2)D<07KU;dS,1'N\"kCEqu9Wc0PG(Oi^sr@n&-0&P.>hg+5/e)MRj3rS.%dkAYJ:kGFh4hgu[rhcVudOJ!S"<.>5Hou^+IStVmi:'u6$RtR*GV;>#!6#<_>CakGV?oSdg%/JqZ<Em28_p8R>A!Lo&-l,k17.V6^P*i5b!J\BZm&dI,I0WdBh9dZ.L"KlnP<c(.fL!V'UIS^>7809A4_btKIJ`p)JLsP#]nQ>BT_hkBI?b(9%&r\h,WEOP'B6p.<j7`Nu7!7!9hlCL!/LBoL`_A-WTTO]aN>RXcZh<PKO;cUrj%_NTK_<KiBo0daT]!MRk3/Nl2WY%LGq]m3oA*f8Zg-^h1o6.EW[gHoa`]J5%W?%Q#n>C6;l1GJE4`W3JCAdD5\6@?oB^^;r`,"YW(YiH7@%2kc0IaT99pe(IYnl;0J;o"7Q*Idk";/F_)2l6W95.jD]sgR;sK:@$g(U9X:^[E<q68o1?oC3p`7_42/\T01qGJBhTDaD/19oUj"7F:A1lb/tl3S@MbtV["JU5N!:\+]>d/)"89Ecqj-Ag>oH4!(?J](;[ekn6$0.H!8XnCu/r*NSNicAN?!q,$0I!?]]rPd\c/;h/#':;[bCLF4>_=bQh#aj8ht18T/5o<,WL<%5Arhd#\$)T(aFB7sno_Dnhcl<tsHq8+b/]4;YE\Z4,Vb`h/\O/a1Hon`sa*s+I3LraBM>aWGU=$uWBNU>:lONP3-oL+6U8JQV;S3.lE9(Zf(0\j&b$8DOeNJOJY][ET3HLH@#]X7,ke/[U^!fG8L/R6a!tH^QbDGNeK*Y>.PkSXtr;nLD4j=,pBTrWtl"Ol(s-&Qu)L]1eQ;bZ9!3X2bW5P_lj@LauDk!@KK)$KB18`lO[Q#9X_"X,SgAX\di4^]iM;pTpN-e/7N&:gB7u9B\-G$<U1'H*HEp-Vh#YkjnIX<gYhGfYD<BM4qU>SAL%mG?_cEnU"R2B=D7P>$EVq+5p3rP&bt3!1M*3SkM=$I+B&]1QW)cG7XPAl\iXI?n,q#(Oc+SHO@H3%^(Gt:mXN19nlpUoYtQ#"kta,MB%"k!K-i2k<9]TcW20)Aqg)^C:hOs3a`c5PlWc,j&qnTkD?t?Zb)KD!c*#>:9%r'E77"jj'8eL'8me'G34),'Fg(!D8.FM,K6++d2]S9N4C6l5Q(7oLW]M/?6CVKZWd<qiODn?`R"J1J^.,oj7t`Eij1D$K\[r@A?E[\"e;(8Ld*3hOi2`8&:s;rK.uA_k"o%+A9DC.;<Gr9S&\[b>g";5.Im2;$Hmd5;7'"-T-)#e-*8\t`)a5B+R;ZI==,MXW7qfJVQSX1Z5/(2@NSQc'frgBkCfSV^B]>M)khc?A*b]%Tt/\HbDTT%X'p"/ZpNt!.ff\/&mTG.;Y.U>mZhr,#)sq>2Q1U!I;&<#0QfJ1RA@*q)/13L['='o!8.$NTYeT>TdAa5>ju6k)\Yij'(8#t01WB9Y6o![e."Gu<%&5/09"tcis$Ae\t8d1L?fo^AW[^m*h;8UaF6K6#G'b]JN?nfEmaWJgdol01Mo_mmi3)>+`h<SiL6nX2IHkm@;n')^0lE8@3JgP!E-H$A^`%Kl<MBSIY_h_/sVTVF[ck:<u:&Fit0q8$D+)LB>hVbdd<FQ+W9G`XkYg:eSrr&i7<o!I@SPB0[(LbFs-/dq#'X?=n[*H'0\Oh+(&cG+J't(<@>[t[6\7mE6Grm(3U@#5e[)Q(ln"8Y\kL3Q-;*&T_=)L+_n1Akc%U>CHekg&7)q2p("LN+V5:hl/?-70!8Q#jdOLa,(CY(F?\pRF&b)F30KQNo2/I#f"VWR^,o[1+C(c7-#3).dVr\h:_d/</Weiff(9<mScDHS&7ZQ(8V6THcf0WWZ6+$"O0aGYGp,W^JSgV.):&Y$KMP)A8F-g-<EJh-RA1):pqD9>DeWPA/SjhXc?BiEBR,Xq2=R%YLUe+hpP1?Y!uktJG9gQDG9"b%Z.fp!#i@&dStV\Efe$L97QQFh@`2&+*7D!"Ju6?ClpZc1_.F/1g;CWD=j"EsVp0L*"X]J.+B[O1G=T#'?-9_mjk$*9I)L*d97u[%L4,TRrWCSR8q,)(\qN<+qp/NIg6'+\l65ODeSn'L"<6<')M#D]ffNWs10tcD]^9=53,a%.rjkD$MW;^9BZf%(!%ptcDW*PMMLiTYSOUqu&bg0LDni&UhKWmMjD#2qCY@M(S^daL#H&sad*FPqikqO?2jiX**RA)=TiHbqkAqa(^@J:H9=@T7-@hD``h<9%cA,0o&#1,LD#~>endstream
+endobj
+21 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 2637
+>>
+stream
+Gau`U?$"Ie&q/*0kXVt5AW=DTn]#,\MH]G2RtP!gX&;BGjfo\b1s1ak#etgaO)1!["qa1f<,>&G8^jU7SC9%mL%l8Z[B,5a32bH7+;*#sRR@c6FT.F=k=:k/_7[k+GtpXHVbrT74ceSZVUO]u5tW5Z)G9QcjEZkd&d>6_Z@Zg`PBd`%=n_Yn7;#-F]B"@',074e#i[$@l(!>N9o:X!+AL8qQa7Vp6#:bV^IsdrEKVV-];E^!I\f,9[A6Q_N@lMOBr,*Jos31"A*$[u/WP[0(+-@9N3Yrqrf5;(`AbMNoi.a>B:.MhqMF"k7T+QmSA,'GrhO):V>34[&?GkrN0ljiLc>qS*"_-poB_B["C?\MD_jJ8.1ZXD6cNZrCcQiXb^2;7SU.\M=1V7Af1d-)mR\S!+r'[n.VV].$:,a-:"a70O>E.F=fSoooN"#c._Mhk_D&Gcpi[3OoO't@31l)(+O_ejH10p.Lh42YS>O^k:>%-h[:q[^!Ki=s+pm]P`LXk:UNi6IJguTd2l/BkrZk-379.H5;L'KY%5570bMuk^P>8UL=I*62,rM.BWdH<59kW!GSli>(\C=-2#X(ob?b-OAgC$E^?Z:9(J<7QE%UXJ;c]04S,\7[A0Z-,:1Fs.^+9R3q5QF*=*9U_\91d=`?1r"ZBr.d$d5o]MVeg,u-K`@opu%]ZF9dIMWJ9!8l7<^B(tWV"(MDoQ1%?t&o.Ym<:_6.D"5J.J*PUK(1p$JtSh;)_(oXN,&)iUtJO8QT3*8U+GpYV\@0(]6n*<ElT/<5t[HXf"aVE(ae,Z:>IDX$SbKdU0Rfj`rDfT)+j*+_H]3Pi=9Z',OXFM:_J"XoX6;D@!)oE!:-dO4e%?,pUXL(u=a'YSKq5kj,e7QTG"NFbAJfqRJ'[WQtdokq6Q*sW:YAC>Op1I`"Im-2W(%og(hU(`LXf=X6^6ir;Ct3$[%IPGoHVN--G1&GiN5-hk%OH,qib(%BU2Ie5o5u*]2g`318Q8<?Fikn5j]YZ!=lEiu$l)oDF'pP)IFUp`Qo:sq`*'rt4u,reca3WB?I:*?Bse+B848MWf=KIh&^h-8oU>>&dYn/T/[G6Uku<qF<mAdfgt,@cD(Bibpg);1*:IS0K>?A[@p'b][Ub*PW',gb)9/Gg0:]XX.I6ocD8=bMSB@FSWeOcOjuU9FRn4J"c?t'GQ6cXTU0An4/?Uf8;spI>qtIc+]>p<kaDA9TDDaD7q[5osfrh%tT;$P)97L>F@jW-S-Z/[F_",';-quAI"$9"@"4OqV1l&r!?A1s-02eth*#ko\2%<0tiFC>.E6,WD2S`t;,7*l#PB\-E@l1:P@r#mNfC77L,;Yml5f6WHW&E3UM9>ClHs<-7/i=hjOl's05#cEGFGUFK<mSo\,A;3X*9/;VLhNASo8r5YeSf$:q7IlZ6diV6J.CBi(^(mHT_C%V7.E>%oWhBfLrLW-h[jDi_7h)oM72;k.59H%=0M_%H(=Y_ra_3i$r+ajP8Ejt>r10+)mcLX%CUsI1Cd_YOO^0b++PJ!Ot-[ufM&AEbnW\NjSsj91/2Y!r4s;4,V9K+ot1'\1PHkar<>I"5TQPbA//,iqMtcLhXC+bKi*4@N"p3qQn"rrmhb/F2pYjEHN%sT#$HBGT>a#c(HTN=2QM6Ic0G-p_DppWhMb;',Wo1fpX^%N*m7/^m:u,_3t3fZ\%[Tu5\!h#Wg!*R.rX7/fq9>c?U(54%<iM_ZF`T:L6.gsIG+n<O*%[H^+6-.&/m0<IA[Mp>\i#?P+LEW%<=Tk:c3>)CF`O3H9YSl^b3VHHXGG(TMtX7>_/_*I6#MDGaCL$T:2@@8OThJja0H0]cj<2HbLFkHC/kY/<ube3%qkjC(K#^#:m2]r-6"-J/qD5.l7sMQE`[_GBVIa#d2+W0g.moVKZXl0=2/XcP(?sGi!VTB$WR+46^#tSmkkg`NeJj69A-CU=1uhC/?E3"/I/b*T[g@CB7oZ;"0IJUGjmR2nXWNrnU=NXL_rSp]L(B@e9)m#MK$3<EIO;q"G=iQqrF'Dn?b@G-,%eFtJX8Hi*W'&S`AF0ZZ"Kh'!;inpJ41?ChTKjs_/3gQ=u$;0+l_j'\En_+d/N]KUbc_pae3#5<(t!2=a`.,<]k`@"\n5n(6:g_hV$,?jC]'fS&ICH`0YdP^IHgdhX5g\"2CJ_faN]spQtr/Fj&YV.'U1!"Mc5#&4t2,rKVWVjj-CY/DX5iQ1Fh4m9.C#;>NY`FgoY/1U+`:_WK$6=R%^LV\WO(i1J*aZg6P#IA7o'Jj&$k@2IQ>hZI(M5lM9MiG(SM1sETqJ0H%9jY&<.;uBnJ0S]q4Z:W1s[FB&(CHAmNeqo!]#n9pBT@^I/,X9E/.Z@'oPp#%\Pb?=q,$8XTq':Jp.5W6a_5Q!"`lJ!-fSsm!5,N=6:9%4$2WYEm&aXcPQejm-ZG""j[p-@,I"bi5R0LU]%1Ilq`(W`q:ST"Ik3\RUE.#=8b36S:+TZao*J`c?s,^q+_'4nc+CfcDO6=CnKeEdZ07->$("(Z;tIW>/WuDV>,#N[tKS2$gu'EKV(3Zn:)+h["RSrJI9[eS-4&PmFqFPH4/UfqP0&i9d]ai\QCS:o=J:E_'6lc0V`7bo&r-\+8ks"CQ-![2')W+F4Q0#~>endstream
+endobj
+22 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 2574
+>>
+stream
+Gau`U?$"c/&q0MXfLI<!;>_d&4sd@QS!eB<9q@\6S\.35,f:o7"sB0\^]'f.ojoM2Bh.D^-BU]I"SQ6tS?l$W55kcSs.UidI8/0L!<jWP0.;XiR',>ojn6`n'/,iOI[61a7nG[unX>51'%-UVS9P?g5%uFj]cbX63Q7\Y"LE2>2'm8)q0AFsY>t5Xa_$j/-^f8EAe$J_KgCla(FSas&'7K(`5go^P&CUa/)AG_k$Ab"1%)4/oMo7u:)bLXP=;5R5nb`5m>RM.WmjL37,-^)OA,Ut)Z!n=K!'%VqB\pbnFRtsYYIErqt)DD</mQgHi=!j]:7g)P-QA+&8V=p)6j2#+C[!3i.)YobgUq/i*Xcn38"01Fp@%"2mK5PGLFp;?BQ_J?<$3JBZS7@8#E99B)b/8hdXM5?5\]ZA4(EP]89cD[->m*5khW`h?oD\=U^P&fZ&%`s(Qfgf7\'Z-VA6T'rJd1V"O.Ds6]U!kTKkC"?D,nI1pKbI2F.hI9X/d>+`E@pZS-qKl3h)Q<(T^CBUTlVb2':_+N$EnC::l$5GLo.6(S4AZ7@u#@jHL,OHAJVU1<TJT%tY,]J[ojj]_[-0nV'/7s_THn0%aNF6uNP+"TYd70dncMZ^roNi:OiKc*hYH`CTad"Pt1HG4RC@(BcWs]<nE+>qKdok\CZ,6RuCmQG;g0Rf1,S]Db@A:2nSNbeZ[*Q'9B3ur)16#OR4GS!]8(C_$NT_<]MNUB*CD>qKOL!d^V%aH*'],sfbEXR5p7@>42h$&ZA$Q*8*TiA1pBL?`h;m-$di5Fh[SoG+PdJorat%!IMX(dX=aQ]&:W%RC-9`R<J>;%U<\(H$<o@3TJ/.<`V*T"fOPfGZ<R'JLNefNLT,$SmJPLU=O)c=uIi]IafQ*/:1R&H;PRCV9<%,.l]OSLs>F/2X7bqt"o6Iq9`#+0JhbC6UPS'o"Da?4[OiC-Td9URl+MrWRUH"W/nVe%6Z>h2%h-/>`Hf0>cT7uS(gF/!:j_?Y^#Q;kf)MRCh3?ZG-h10iG"$+(c2$%%bg%[#q5_]/>*.X*_JE8t6AFg#>?p[p#f+B?\>*r9W62QNWL6Jia@d.?-])\t7AC8dtqKV:7nhNF\Gp"aI+nV.80GHXc<B,s4c5Jm\GT<(rboVa(IO`0?5Za7VC1!1jV(G(=d\eP-#Eu/k+Y!38YM_E&@[Z^@qdhsRj6jI3CL)f4V!8/e_,[(:E"E)ZW>"mGD3O!u]Ruea33*p(Ko.di%Xl7(<30fTi<jKA%5KT47C)J)H3A/mJU.=mT3q\WMBQUQDiHArN+H!.fE)isK@Mn3c`L;N>*N[tIaE+9.YD#jL<10p.r4#'>p6eTY+]#?rMJ0L?\B@`^&Xlol-:gT$]2]#!2d1;?SoKo'e?/WKi*kb@7%Lo7K=7fiUMGF`"i2"(TL>e6!MO7.B%6C0kJ()Tt]K]%S@V$YG@Rg-n4XhaKE$m(8t%;<=CeUNfA_HPe7ei&rliX.kTMt0gMP^o;gjUPWsUd21A%+^TE&'RtTUS?l2SSI)'h#*GW*G)qOq3qXW[)HaGgXPUQJpKG'%R=I;1D]O(UA5D_F:R6hBNg7$+q_/L@iN*q[CiNOaC)IG2=OOjbNX*BX>_4t68_nEZ#=K&5UY(M&kmeJXE@.^+l7sVQAr]$Vn6.EI"gjpYP,.<c[U4@Irp82L,9$%Q4Y^E*.^j%BlWa^15Z2^908*T@@%#ue+Iju]m'AUBS;gN"=ouLZG<1(-DIJE8eQ(f%</,d:/JTpIA9l]3P13<+$42SMZnk2gh7g!t)Yd7%GIg3*rS$[$Z@9e\]drqG;`:,(`OA8$lo\o1')r0rA6Aad,Q)upg.uf3!60"(L4g7:DoDt;+<j@eBau0,$RKr0kFLmdIg'H<h)`aDo!$:4f+F!<?U7R"7"tJUW,Id_Q3"m9)"p_iZTsm1,gbg>%,Va=>Iu>-<GUTK-*hD^+pS-dr[jp,6>,nE<28s2&TR9@fk@QHX4dJ#r*5fub)QJje"M5f[j#fUNX><Sae`Z_S\f0MF(mkgoV<<RHDUZM+pZDuQca/]$oSQF=5.p!()MX3C.PM=/E!B&oP*%9bjMGmbi2lc$L@>6_5#^*9$ds0M'R"LQ#/;F.H8Y]3[g8U$!fuU9JV#m)m.>LN\\Mc$=Lc]]c(^0ZCS]gC'o)6S>i?nG$cA,NJ&a/V:&Vg/k-.mq_C/&"BOb--qo<%%A#Ccsloam[/hi[3?CE(#+7^77(@DAHa(3+B)4))_qkgG?3Y0TCC'>\F00uO(HN;=kT2_iTBNaR[^-uf`?'e9GWc82K;X]!&&4BZg^h7K]7NTHmbQagS*Q;[p8c0,2a)i5DcOX@VW[dfa@>)D2Hj:&W;1en>h:ue^D)-@H((CuNihgYnjt9lT$j[EK5elK.CUf!MCe"9oer4kGb)%*B&%@fp?gt]_dd?#mo[nk5`8E=.@m/F290T`G`nbh9g1f#p3IAhgLICp$cQ7aj\tN9h6b;4j6GnO[=H/"K:dmQU0=dS7+(I>I5,\<r'Jd1>.U$jr)^ghs8:K07llfiuctjB5rQO5Zbk>*C$*2O("V%%#&!4M[Du~>endstream
+endobj
+23 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 1582
+>>
+stream
+Gatm:bAu>s&A7ljk,>(,Lu=cZ;rWeG;X:>nZc^N/LkK:a,f&p.=S_g\!@:sq;pO)L9/Ho^ApScL7T+bDks*@GkiIsC(Qr<"b;ICD`3d1Q=3He'-R((h+Nm@;;%aX!^@O$N,'s"8M+Hk%M5<0J1=(lKi_Uo+8.0/\M),b)BmRNpe%[7l.leOt7(T]JU*>gn7NtUe+p^acE>%3@DSl_?cI4j*@4n96NH)P'fo**jKBnJj6'p/eMWRm+Id#!j1mRCV>dZ07A?lL#72U^B1Ko7#j`<>-E-icBp_fk<Dh"fG`[]+@cMRc8mLI2tQa.kO#Z_"!]KWh@IlZC34e@RiOCZ/C$]0Z?MNEcK5imLe'HtrlSM"3CD5Bkbm$Tg";r\D6kYci^;XIFPNTs)P3o-8E8!PELgU_:LrM%cQLW3>oeigFP=-`)I8X[:n*Nc^f7NCJfWbRKhm68IVC>.BLO4dVoD5jKmG+_lYMA5JaX)`/B=\%dTgHg`&n9c=N-p%Fma3d,i/nX>86(:-0]t,q`[\Zi68(a*cU[>pcPTl`98!Jq2-3A,``XJ;$Xh$Qde/86ic1Po[W/;u<Bg<bIT)-F7>#UYuYj@^8Xn426Be#!ScOCNS\p4f+]DER96%j9rL*IlNK&;ITB*!n<fsTLh&,hp?jZJJGg+(GWFere?6"gt")Y=5F#6m'.NiG:X*pq#If++]]rhM!2#9jFbKU\=#Br67>l9PEh*8>d@]8=nWWrm5'\Z!Hns$=)1W#P+lnQp9':j8^3@QbG\C<!]k1gNb&=7-/!]K%,<onH;ID64%e9_=J:nq-)?^EJ_`)nqIJ.-Xf:,'a?,&u>;RJ-JFn+ZMfo;G42?(G^R>>q0#,7#,SE(C"A.#RNWE<h2Pt3_.e>b8"<CWt$7#-u)PKp?LY=k%CkC=#1qnO>=tqKL?M"kQbc.E>BgR\+hkM[f"(CX(OpF'h(=g,(?VhShjN[97/7fkGgET`,n;g*A@j^BD/9hnSaHW'IA"ml*94pGBB,]e;`-$"DOHQH<h^$D)^_pJ#cmAVi`pY\`5GM6fjGq0Dc_mD?K*TKBeuG6+<jO2i4grK.3@XH`4FlE!u:B*M]KS4at2g;;\m=eDBb#[pF^^>0r1bD`Zu;Xqoit%dn#)WZ-r+^lgg&P]F:nb.)a%1S/N6q>KV()F]g$5K`i_46c(.j];%kdU1P#5E2O_e;i87K[lWK'LLUP`lfFtH8B`9*KAdaN^Z8063&)"#2:5aaIRX\8!X_Plbt^9MA<^5c`2g1U1^b=0p&D%T7r%sc[BBua']V#:P[=NVMuAtDZ_Ze/;0L:+n$b0HLP45eJ/9@Eg@$<fF\A,<#`m=mD'23_HjE\%6/\>(B_erPRcnp8W=Q>[^O,nBU>UW=_,)X4(&`9)P0!M64-ZIj"'a$Nuc>\.)O<!o"I[M6dGJcE:sPn9P*<CL;4l"-"4;6\Mo$<g<hn+T@D7Qa,[^EQO/AYldBI4UX,sHOB4'&<Y(j\-dt-drdUa]rFgq"2SF;%,7!o@ob!m.l'$jBl*s$rh[;HZaEH#b#?%Q;__]WfK\C$0n.+moq%uUJH=Jd+!-IcRnZ7LM~>endstream
+endobj
+24 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 2435
+>>
+stream
+Gau0D?$"a[&q'GWQq-V29_2JQhemN/?<uZu523'jLV,kt`4u`n>_#dSq=W>A;Na9<.SNH09"%0GQpK&?:I>_Jp`K=(AOH+5"'sbO'ZK^KTdU@JH?`6;%qgB`"j9me/di#D,`>_QIM[!e-$8nI=ch$tZ^0#`Ll,YA:`9RA[)uJ":mN_dYfQFr2,3gX;j;ldXFbhW&L=D:b*Ea;=h4rM$F2JrZ(.rlJS<3u&1&r\,gB7Mh9bs^L._-Y.RCa!>?)$ATLucOWqE#7A&X/c3a@TKb:pVg_`7[Q*ZjS)B+FiModn7IB:(njrDqFJ'i[;@k.cH-n5)0B[*5iVRuICo,8On,#Y9ZM&6l%Tb0qZ&I_MG9;N>aB'-fMuqMOf&IkSuoY_$bPV<^YI/G.g):W$h]F8T6_n2-#![YUt"]aC>NJr_5(I.1Ktg<GEj(/H/EW#c;)D5'h1D15^%hCau]+jjl[fOa)lNMAAJ;JB<49de*?:a6sZ[ZQgfGUHcM>*:Jn6jpS_nOi:Cn]L@DBh(,*J3Ffj=JCtlcs$!dY*$E7YH.VfcG^"O@]^+j=2lhj'/ee<E5=TBNGM7pP1aZYC1ZmO,k<->)>;\5)N26Y8_V[-jVd$`k]DOJi2-`EW>U5u'o]()V<Jgqg%H3G#o(Eijmgp_Tkae&Es$B"3b*Na."'a1PsP^tXf8X=XmrAX0flA>6mjeub\M*LmKINYBXnul)ikLP[@-#lo^HP8Zs9-?^.K@ZlWDW9YC\R!;mnYM?.iI3[&D3XULpS!Ph"c6+VW?T8pof;#&gFCrAdFFCj+;0I1uccTtS8P79`'09&Y(r$VTS(g'ZGe26+;HH>$j$TYV)S.^7p:V/n8gQB/$Y'cF)!HF4Ig]a%4/>D=.U"D`"Jl(mjZP8\!/FT1m0T>pMB%4,qS$HS(F=K]]:!\L]df%V(-"(EXYgi$K%R]1"_Z^"'qCt]bP,g2D%nfl"9P!$e003m/7VC?SZjMi"M[#KIO3:k9pC15'rY-\V:fP)S1`H]FR5-EA7mo<S%SaeL<@kBqde[DadRo*KgC;7s=a"9/e>mBpSYlj:p6s9(ViV*6!Rn@L^Dm'L.Q(Nj*&$MOuA][C9%Vo._c)G1eT<+(IQl9.FTU:oc0jHj7GP(G"Dl8c\q%&]FM>n)<'36o&U3r1^Q;9;8HpTt=Q4VX<1Vh]QmDtb'hCZn09A".4<r.*n!-+=\S_$4k>OdA+d'AhY3+ridA8D*d!PRO63Js"@]#55gR!JcJ4u/K%_Q^IQ>ar5R[\E`C`<02LRAAe$2espZ(($[Id54Rme!4"cK4X;8&N3mb:gj_;m)jB(SFk>>R.89hrYqkkY&iHHC_b'oW^[60/<lurXD\Zr7eMqf6`o?PQ0b/$rfccl1c3`Zp0L"nK5OO:N(\BEma'gfr2VVKq)1HXfnVr!ECKoOa1M)k:LcKq@]7[TTS_HS)*=UDag*moUOCD5>AK>32dUPBR\\h*371&irh?QP=5/<1YG1Ur\t:AP[dL9<BFL;UST);f(,`b!GG@2O3-?heHcL>BNQUVORa"DU0(5Ur#mpjTm+laS=Q+\`8s[VZUjL7,QlaR9chTR9MV\Q%#AD&3akgF!JO^4\?l1(P_pQV2WNRutd"g25,dY9V+h_)r&$<I2SoH!X:]0nR,p^eG*4nA*`SCI2(%TJNGZD)g-SF6[RK&X+Ft1X9MWnQcJ;&]bZ5gkYD?_BQh=5/_Vce!#3=L8If7*>@KiIUh1j8'd5';[-oN2aGZ^!^4gF&L/*BUu-XsGou*G9sWA-joL4%I'1>(FiU%d.q;S@oB'G7mSI5/VPO>KD*W7pZX[MDg!nhJrk*"1?"HTg-)m?XmV9$LtcmQq[\/]7V%WYF&tA(\Alf<"PhIN+^G8Z_>.)@QJ!>#lFfa:JVrY]/c;ta)?UZa4?0HSIV^H[6eUL4g=8kWK5qfQn.1l1'n^%`)FML2"h1_^M,';`Fgtj=n`b68cmmObr7AFRnZhV*-C,Xl#&VB?-YYh8#t]]KB5iP)shZRXFEk=%^Q^Xhes:mPj8F4&,9]4CaO4ApX5B,oE4i<[k&!>qmpN)9C\^e5+JL[9YVKEC[!hgo;/m'9-npsqJ2p8cX*>EiB/ZElGCArbUH*\2DC(G*[i#HM)Vd_b!0F_;RC#`n_(U1XW7jD0=eP]#D;1$Dh#8WLQ2m)<%3VR=q86Y(0IE8pu)/b"cVijoO:DWL:%5.B#(Vh;+OIl"8k+pJo(]3iF(b1%_AC+VQ/;XDR)\uYOmDMgtu3ACO(Bu']DF4]jfE"17'$p*%jk)+8m-Gke=F(lX/YeVIIkS37aNop)OW\P'BB;4sA-bbjFf9Da'0,!31j)#cQf'3*ij'<H,9O)(Et5r\tR*UNFhp\](PE^:V+/5fViH"D8Ze(duboYZ2YA[Vq[Rm*-i+SMo?`V@$X;2!pFNrWafW>P8~>endstream
+endobj
+25 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 2220
+>>
+stream
+Gau0D9iKh:&A@ZcqFFL,l[-%b+[rW+\-c:L^f<DU1+W#Mj%()"7Tu;ZqRdl+AKf"Y;?0]J.ucCAY@#'4Sqo`27fI>Z&H-W<Da$Q'`H8M`-k0(c3huFN#CdfuZ[!V;$4;Y9MruNQM`Afk](kq@aQVqU95+u+756GDNIrdNkAtAd94pOmjS@W>RP#,J>mf7q*otck5r+LrCdp^ZV=QC<+A9$PYHoa)+IXk;lk1+#P3+3bDWpS#W,usZ<n)3Dl;H"a<SI+H0*Y]"X,^33iEDJZ$.ChQ)!=-1eJGgn;)[9WHPU1s1X,=&rEQIHX(]6?bjU'mo2%K91s:aVc:3=^&<#HV4:WP9%Z&6Y,(JM]TT8q&*r"%ASd6O\"n#_tFEgJ,/'BGSWNu[[PbX*B(G%Xb>&n4`R6":4*e$2^34kt*\c`pdL$Ql2ijJ4Eptl0PWLAN!N_IJoom2UIe\\?[f!X7,(IS!7p[3i`[A`Ur6Pnp`Ngat^>#@;!gT06R,`dQjcaH+G1Cse!K_#b&&9-'#p^i[OdLd+BPBf^]!m0D>k)5sX9G^("k^lIVE*K;6m9i@"hm4NIcV1E2UBmZUK[\=uX@P6MN!YVl.md,JPN,-?b!!F\?=_Aj7IgR10%cS<c'CO]`uen!\XHX[#59NEJd4%0NlCh#Gl3fFQ`:3Zs+-$?WF27cC,%]p;SJ\@f<6g`?XCS.U";.;[Zr#=l'cClQ1u:2)PlCV*6Fr,E9'u]#];1nfaek,.iS!_\EgPSeYOOg?F=%ckDM,fT2'T8l^#@+Ml7XX?1$ZCP.lYqms(g9%E`A#fpU.<T#iOMhGTH5isPAAaN"Qm227Eui3]T6V,fHYF$d0=6YJr'q#$8WPs^9M3O,l#>FRc\%HfC1WA,T\n"-N34FRa(5;lflNQ@q:<RcqIVcLeFWeg-VYj*N_V^qO1648EFM:CY3jkXq#B!3C?@kG'p7P_j''l$7X@]a3rT1[PdEQr(pkM_JOrd_j2Fj&QZ3B=sZj&.OYXn"CcJ>m=lLM+p`ZVMp#?L%s?E'A=AeA*]4JN]`'OK3]?$qL9*;q#hd=^,W72:Q71"[3eqK#-h?paf!CN:8h5&,16[I$DB@D*mj55D'<8s4F[sb!T]6r>((E2$biL6AGRK3Dgjn.^ZAtL_>"m:]9*h9]u"KWELk;$F(],M8:2o<K4t_^PUq+:nIgGNHU$U94^tZI>Lm0KG955[0Oh&r)ql=fh2ZlCDJ?S$RnMZJPqCIlIJ1Rn2-*D\K!a`%2=5j#gs/CYO_+Y/`Gbg'%\ecW66\QM:KLUP/$[+gF_slNn[.q@bp%cXlOkG)\>o(?@@tH=ep:>o+(SY4sN9Mk%nMbVl7K]!;I<R%ul-X%%&H5J?&^ra<3U=kelcS"45TF)Zfk-$AX[BKke<&#LBHM7O&g]7DTnAbIe5:8Wc-Q4fHe=rl"o6;&W=L2iKfmX"gXnmCF0]?R'Lp[@fqe1`A[LCUT\1Tgc8[O(p1e'jl6+D9Q?s/&`eq$oeL-bcP*)O*+@XnML\]cIW3(A1Or>Likk;A2RjV*bi;";9L`1NM2e-F>R:Z"PW+K[&3LJo&aD`Rh!^*`bWn[)ekfc0ch?_!^jDcijrptPPr,Rs!)_+crnV/=<rKkb55HP@d=sT,;!>:+;SjZrGgeVp;Z_&li-oR0FP=he93mP\lW*MKhUl1eK'a[_S@*$q-&VghUVdn2(34;Ul2!oO<I:SP#m:mMOP:_R:lfHI9dcU*)sV0htbGid-,5eH4Wh8]l-m:?\1W:muQK,8WtubaE5;CJ[p@1<$Cjb*6k_;re4#T-m\eZ!FnJWef(u'/=Sq-c`LQpro)+-U^h"SAoeN&Ln<,K$B$G+';gm2P!FY3<7]2eQ-G3WC,6kJ)5O$1Yk9@"#X*UpG-WAY;eQVG)_YW;=A7K.24GVa;<_bWiLA(/-,].S:8T.Z;CK@'s#A.Q$uppD;)6_6EPD"]_:!AiEs]roqe"Lt#VRjBiB()JHHgRtQWg7?:t4cqE"E5D7jMEi#f@\%2^^i\.bN+)&<4Pc-68Q1@FjIYigU8iq->6GGM5-#!fW(u\;_BP9nc1$!!d0R)H38%2#qM!N^roYd4:fWho,QQe"8Pt2n+tn]4G1YN'*.jSqBPB(-uf@rCPU=cE+rN;(<H!iLR=:>@\S.f*Q%r.7T$l+YZ6_9''oSS?"OH8Utc(JiH4l.\/C\[MAJ6n)uIAq9X=Hp_W;ca\i~>endstream
+endobj
+xref
+0 26
+0000000000 65535 f 
+0000000061 00000 n 
+0000000112 00000 n 
+0000000219 00000 n 
+0000000331 00000 n 
+0000000536 00000 n 
+0000000741 00000 n 
+0000000846 00000 n 
+0000001051 00000 n 
+0000001256 00000 n 
+0000001461 00000 n 
+0000001667 00000 n 
+0000001873 00000 n 
+0000002079 00000 n 
+0000002285 00000 n 
+0000002355 00000 n 
+0000002636 00000 n 
+0000002748 00000 n 
+0000005366 00000 n 
+0000006615 00000 n 
+0000009166 00000 n 
+0000011787 00000 n 
+0000014516 00000 n 
+0000017182 00000 n 
+0000018856 00000 n 
+0000021383 00000 n 
+trailer
+<<
+/ID 
+[<634f2658090bb94ae2d335693723de57><634f2658090bb94ae2d335693723de57>]
+% ReportLab generated PDF document -- digest (opensource)
+
+/Info 15 0 R
+/Root 14 0 R
+/Size 26
+>>
+startxref
+23695
+%%EOF

--- a/output/pdf/distribuidora-app-summary-one-pager.pdf
+++ b/output/pdf/distribuidora-app-summary-one-pager.pdf
@@ -1,0 +1,90 @@
+%PDF-1.4
+%“Œ‹ž ReportLab Generated PDF document (opensource)
+1 0 obj
+<<
+/F1 2 0 R /F2 3 0 R /F3 4 0 R
+>>
+endobj
+2 0 obj
+<<
+/BaseFont /Helvetica /Encoding /WinAnsiEncoding /Name /F1 /Subtype /Type1 /Type /Font
+>>
+endobj
+3 0 obj
+<<
+/BaseFont /Helvetica-Bold /Encoding /WinAnsiEncoding /Name /F2 /Subtype /Type1 /Type /Font
+>>
+endobj
+4 0 obj
+<<
+/BaseFont /Courier /Encoding /WinAnsiEncoding /Name /F3 /Subtype /Type1 /Type /Font
+>>
+endobj
+5 0 obj
+<<
+/Contents 9 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 8 0 R /Resources <<
+/ExtGState <<
+/gRLs0 <<
+/ca .18
+>> /gRLs1 <<
+/CA 0
+>> /gRLs2 <<
+/ca 1
+>> /gRLs3 <<
+/CA 1
+>>
+>> /Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+6 0 obj
+<<
+/PageMode /UseNone /Pages 8 0 R /Type /Catalog
+>>
+endobj
+7 0 obj
+<<
+/Author (OpenAI Codex) /CreationDate (D:20260409155133-03'00') /Creator (anonymous) /Keywords () /ModDate (D:20260409155133-03'00') /Producer (ReportLab PDF Library - \(opensource\)) 
+  /Subject (One-page repository summary) /Title (Distribuidora App Summary) /Trapped /False
+>>
+endobj
+8 0 obj
+<<
+/Count 1 /Kids [ 5 0 R ] /Type /Pages
+>>
+endobj
+9 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 4491
+>>
+stream
+Gatm>>>sRl&q801d+dO'Jn%Bd10(4Z#%j1T=^Zg6Xn+r+CdG_ofNHtfEdmt$a];'>PAFV_9S)lUDY6HSrCIJF0)SQ=4.R%*H:Oj).A;^U4V6m=*kD/?cL3*?)nRp:L]bEI0Hq!n6V?XaN??u(R?S@<+sE^V'ZCZP:OFg;=Qfto.jhtP30^tF_>JiL]4/hRHjek@G=stO=NjX,`Zga0+nl%i_BV#-KkhD78YqS0.OI9$W:)MEEFo?j2,9N6j@H=NW)9b'Q@UsIIRkimahrnU?PD-ThfhX/\G_2(on!#Aha0:N7L3HXLZgG/\;Un*AS_k%ntrP\n&mhol@bZY(B5_*J!.DS12=S?cg!>p]nb&r;8>NFeqk:;K6YY*bipJYI9a0*=LTOcY"E]@80.r6`M+R$E^!:a=&M2CFs]bkXD:\A,Zu[U4AFPB.L0.NL"")3YDl0rRi[/]UED%[EoKa,q0N!9=HPlh(oRE?>YQHh@$IqqVV(Ejcnb[B^l>#(Jg,ufJ/HC7+#oeI_amDu4L:?aj+j=NK64YiVlil!HW6r+<YpI'K5;Y%CM21G9_q@m0!&"iV:Z+N]X=I_`Gi9o5K*3P7O2\@BM<k!^ZV`'!jjO=jb/4O.m\]qKE9/R<oOb&:/"qT/s4cCUuS0M.kX2fYTOr&P`0V0e!mk?OsW/QH]\'Y_C2p(2<5#[NJ:8<+>a3IUTHm*rI_VR/3A*cb=1tbBm,OUF5>@XbpP&u*4?bC(.+QrM&HKR1-94V(a"a1_Ld*c)Tg_135(.e.VV='%NIFsmAS!?YTOK2;&_iUJM:ge)/UDjkT<2%A_BqmH?^k/;F&5fneH"*\)ZYiJZQmgN?ae19`C"gpJm-24AIna'SZ)b5(Y*LKifmO="HLq">n'dL7o9"BZPuq=<b:RWHB;@ir1P7c-m2jNF7MuR-D&8Kj^q,3%PLj4`k]:K_ca3WFpVh9f$m9&6P%\U08[E#:nUG<@YRWYHepq<nX(+5s5*"EN&'4Z(rb<>BSBspQcI0#B>^abb\nW.gMMmi'S_S9W_fk3fJ]rh14J4Z\Lt6oGlbH@&7U0BW[fIndXekqh@2fUVX`)]e"<N/DjQnW_osk(4s]`[Z79l:n/Ye/1L_n8\)s:P2(?$Oi&Ra0a1*C9i!1]XLJ=59];%8dZP"5heZgME`TWc9Qlqkqi7id9'!p*<pEL=mrb0c-*8<9ik$H[jIrSF]e%@>HmB#WWf1IOGA=2T?Ob,?]Qhsf*`NME/*>8>jDLi?cE)>0i9@Cg2B]$`BFm@>;')As@!N)IW(r6JJ"csMe?mb2eBK.>e5`qN>I^]u9Hkl.'1MmGl<MEBP1M]V%p)>j.2D,Kl7[im$V@gL,B*k4I:"j/28n["<'q5'C'\9N$%,:^eJdFoHrNK2R#Yp;+%Lr%'"E<c6P**P"@o>D+9_!P"fc?QjU%r_ncVtD6I74:'0FbV57['!JjZSn+=7JK%s`sg,]I&$L>]<"LMTdScrsGPN,N6U>JAMLDtsTKWGC,VNA[^+>J+-,:jLgHFZ%*mp:oK';F(V?*;s-mgT$(U"35o_]Z`1dS2F;7m;/F61f]q`6R%[=S*)*Y/L7TGK(O^GOq:1WY,[jWf%!4?K!^t"P4B?&8Y)**b%#Z'C.U#8\RrC6O>%2(,-B!]c<OES'X><AOhNT`*^*J!8OQ%>Eq.rO1%UelAe0]#R?&3I0CstcJb`gLi1&S80\B:+B"j>]"KRUJjdu.UaaAd&Wmq14[FJHK;5rbK"877Gfq-hRo-mteHqMGIY;)=<Pafnk@:*_[4q<L"(^r/AXmMtmXj"8&UQ]l?2Z[O)26/n*11.(pKM[m.FONM[A=saNHd;PL4e,M].t@$il3)$t(X1Wuq+'KM1@Ialf8LtJa?S4-X/5*sP"hl9E+i;ReYb-W><C@AA8FD$el<Z>cFf\MD7AKUUm.c6CRKsZ3^qnVb;u2FV%sS=qT@Ra<00VSHdU:R&2::KB!g),(V7XNXZ:DB2\';B2Yemuqc!s]GDARsH$`*1UeF5)BaB_pJ+U[Z/"Jhc+qP$)7'#])8M^WJ<PROg?-Gjf2#1W1TA"$,O1=6<3G@"JFI=%.5[EPU,pS[;$+9Cn++n;/]1:eDfFp;]0mHK>U@*Su<KJsc@E\JCWdq47]PPQ^B!tnQoAA*9[i4s1<C:$f?*F[[7@AuKOe&&+^Qr=8**FW>6Bmn4\LN2c>D(n=L?Ak&Tq.%'1p:IOX[NW[5Ke%H9#98aU@Ffm!ea3XPT[JI!1uW[(<a-H-J)n&6/D,K=I_dlaH^>u=NBW*9U"JDbu;+TVD->)m6Q+0@1e#;g?r,rbm0MuG*Qd)i^mZP-MGF^3:6SqO3Q(c:V1[h*a;//TbG$\(bn.(kAa:u&b-8s74_P^G)r,BP`FL*eA9ure):T81ba`Fl[%-G*%k:<.M/iq(c:AXr)mNC&P>Qoa8XeL27Se"!)FY\kRB5fE<:p7!OHt=k#=cfndT&g"@cL%A,7$.9/jT53nRci]%UJ6""+RgDloA6FG$f[QYjDEVCg6ENR]8'NVJ9&md?B(T4.Y&4\HD3bL^>A@V4fNhJ:?EMdq>dp:&X$?1mQG)qc'C;cR5gcmDQpl`&Y^9]oC["UXlHd.N__1sEQW0:m55VOqaE]684YAGHTss6W-i=/o.>4`%9u`a3'.I*\ACA?k?eoeECLhR9_`s0e/ODG_tX8ICkceW31&Dup0eGi3Hdk$[C!d$0=b1o<&c97Vjjs+m#49_1XO*Sl-j-r7Yp.-nouG,(:W%XhV?m:._p+>>>jasZbEeBLK6Y*kAg;P">[2Yg[pT4XJm0l<RpAfXlBJ^Ka?-hKg1ZMKQTDk_^%MfH4.B0?XZ6)qC7arPX%?Wa_AVbJI]+j1$W76mmV_YF=FZO>u(.bJ$We"eD=L7@L)%4Uii5\biMf(Y`spN"4gU9.IB,L!KYB5cq@]G:&#,P9OSr#P"J'AT5p^o)Kc:=4VS\-dKX4*"a+6Kqhn9Pqpq9[:RL/r6=)U+o>5P4P8IRIu`=1XW=O8Kb@26%7V)%/WBt6Vc^uRVAeT`rq%<J'cfCFn2^]'AhU[%&U`#inGlRa-nDaMt&s_Pe,YeHr&Wg?.cR6'a39V_0Bd,C!;38(0,"2>.UWH*.U(pfOBfBSooA;3Rj$?bcCmuh&tLo6B#)Y"gQo.,Meme&,k#l$u7#l:uC9GA)"uP9.[Ub\ULO.^#qV^X(TLHkWe.l5@$<F0i%ff^5+n5[;:/43e]D]lF1#E-'LO]iBb,+YQ9h@-*8P9[;i>#c=)k6I8aGjRMDgd-=RbP71>#'NTbo`dV/Q$'cn2pLkTY1GpQ6jV7_UdPSZ'4nfh\%X-RXb^`S[ne?uM83hX-!p"3ViU:`V,N<Ra)`%9&h(_Tmknc@j;!eupUZ,4M4!Tc2Q1--7*)dP&AoV?T"Q\,>#[IkGHp;R.c1=ES\,CaR-]\ME5_4.75G87Yk%_oT]DJmainEi)'cF:O^;28D@5lZ]C3*[f#59%JpT2[0g(NVq!T6=nid[tHUiS/#pF8A6OOr3`o/E'A*/6jYPhu:<4Y6sI'DV6:b0Uq_nl/(>IMO0Fn78j+-B;[hY_dIP":']Br;X8%r^=d7A^`=:uU1RGK^O,$,H8tB+hg^C?%X-7KL\A,Ac^sR;;,IkZ?7fL(RQA6H*V#:`ju62'!#Jo;`9>L-^c[bQfQ[@EEHck]qsF7@o]5`DrnG]LnK\n)h#-6TjjiJk0B`@`QTLnGa6VQ\Qg,OGkr[s,0#MQ7\Mj@CXG]c24k6/fMK594ZaO-Z:T$VbFF=?tR:DkDr,5=/`uG`Cg5&*?AoUA[O9s@f)fS>_NYW19e/V@(/08b$`qY'O,%>O_`%2CTQjL<hDBVK8`i+#JA2%r;+joS[^G^.()MX_R%931Ac+3P:UMA'D5(]A2Eq4,Ks$F-UY4R`AmV%[K77U(dI(?ibneJIlqI5O;h*$OoMp?Y<1:k-uj8AQ4X/fS3=h;e?T2.Z,IChLbVhEgrbIa8DhOiV1NZQpOH#1O/_S@LrLfrdQ1%UB<`T3tWK`+%L3Mg>G@k^+aOAd(]dp=<@Jbam$'#VN33M_]:*RH-tD@gULV(pKMU.o<`3UP?tO8\_uE_:c8!['3cbT`s@+iU88U/c5+r<TMC@2:kW1-HbX``K*kj^lrlo!5-RCV5VSNSgLnQYjDE((SEbZ$PK7c/_iQ6[#*_oL:U;0?I[Y_cTN`rGp@3E[Ko`Ck>)&:S9K=l8L/bW*NFUH)R%U+nJTO^`C"uHDeMbm='f@.l)PL-bk!0"`4M3[[!NR]+ednap3k4EkBa^#db,n)mZ^`X;V^5Tf+1_MItA14.JOsi7V)NfB1a@\N)l7qt8a4BC\-(l&Xn&mKqsJDH!I^H'4LhgUqX'PJtBIMZ!@Yd9i#7n%="O5:\hmNbEXF!Rp^s't:AXlI[cU<c6>U)]/AK:`b[3;>PfRROn$o#6ij]ooM;tX`2^gI)mDGN^ITg0^[3PHC^tb-c:Isao;C>Wr4a~>endstream
+endobj
+xref
+0 10
+0000000000 65535 f 
+0000000061 00000 n 
+0000000112 00000 n 
+0000000219 00000 n 
+0000000331 00000 n 
+0000000436 00000 n 
+0000000734 00000 n 
+0000000802 00000 n 
+0000001099 00000 n 
+0000001158 00000 n 
+trailer
+<<
+/ID 
+[<8ba3047cefbea0ed0c362437bfa11288><8ba3047cefbea0ed0c362437bfa11288>]
+% ReportLab generated PDF document -- digest (opensource)
+
+/Info 7 0 R
+/Root 6 0 R
+/Size 10
+>>
+startxref
+5740
+%%EOF

--- a/output/pdf/manual-operativo-admin-preventista-distribuidora.pdf
+++ b/output/pdf/manual-operativo-admin-preventista-distribuidora.pdf
@@ -1,0 +1,226 @@
+%PDF-1.4
+%“Œ‹ž ReportLab Generated PDF document (opensource)
+1 0 obj
+<<
+/F1 2 0 R /F2 3 0 R
+>>
+endobj
+2 0 obj
+<<
+/BaseFont /Helvetica /Encoding /WinAnsiEncoding /Name /F1 /Subtype /Type1 /Type /Font
+>>
+endobj
+3 0 obj
+<<
+/BaseFont /Helvetica-Bold /Encoding /WinAnsiEncoding /Name /F2 /Subtype /Type1 /Type /Font
+>>
+endobj
+4 0 obj
+<<
+/Contents 16 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 15 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+5 0 obj
+<<
+/Contents 17 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 15 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+6 0 obj
+<<
+/Contents 18 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 15 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+7 0 obj
+<<
+/Contents 19 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 15 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+8 0 obj
+<<
+/Contents 20 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 15 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+9 0 obj
+<<
+/Contents 21 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 15 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+10 0 obj
+<<
+/Contents 22 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 15 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+11 0 obj
+<<
+/Contents 23 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 15 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+12 0 obj
+<<
+/Contents 24 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 15 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+13 0 obj
+<<
+/PageMode /UseNone /Pages 15 0 R /Type /Catalog
+>>
+endobj
+14 0 obj
+<<
+/Author (OpenAI Codex) /CreationDate (D:20260409160812-03'00') /Creator (\(unspecified\)) /Keywords () /ModDate (D:20260409160812-03'00') /Producer (ReportLab PDF Library - \(opensource\)) 
+  /Subject (Manual operativo basado en evidencia del repositorio) /Title (Manual operativo admin y preventista) /Trapped /False
+>>
+endobj
+15 0 obj
+<<
+/Count 9 /Kids [ 4 0 R 5 0 R 6 0 R 7 0 R 8 0 R 9 0 R 10 0 R 11 0 R 12 0 R ] /Type /Pages
+>>
+endobj
+16 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 2300
+>>
+stream
+Gb!#\968lH'#*[5oHdLp97d2Ykrn.eA9TQ,[2l+;Z53oUNN$lQ0h?&Sr;-@1HjiN6),%-3g.3NP+FrlL2u;iq,)K[grtcWKmr.F_:Pr+:2n,S,&^eiVo_.G,o7b7bT#cjY(</W]i>H92&CJOj018/,]kAfh7$7ecU,82\9+jZ4MSi-+=ci'ceb&0JD&<SYi\XuES\O\u02Y!%nfgX;N$8Rr7nQ&iQ7Kp1a<b07Xa,sG%lQ5dA0:pkV0'&;bBLP^F\R$pSF3D(9@rfGeTS*!oi5^srg%HikiNVd))[R3pDbP$R7F#1U*u:H:*O<,l4NV9$mD08pR-N7>?tDf%@R*n1egh].SWX_D!aFH-\hso&O_c*4e7YdhH%(Q2nu%O#0F93Y%<'8OA(@m8\.^]]j=d"-FMLt!>^1%4jI!7HAJ&Bl#0T,gSiT%g44V!;,LD!fG9fD_OOJdM_*%-$u1[J7)VA.@1[!bp`>>I8YY#Xqhi?@c?S5/9HoUP@BuZ(;Rti(K7YQA90JF"J_Y+-SnPsd!/opFCja;inq''Q^L'iZnVq8*-c\;glPcX^/e3-N,A666eV3Y,*,^OU0^3Ls0Y>r4Clh[I))SF>r9-b(4PPg#!mV#h6,kae5iaE:=P5XpJc!-gNh!4!$X`A+pBLZ%01?YI&gEj!:kMtu+]JjTO_HWZZ0,!Vh0(l$hd:Va459!&G6W]EW5oPf4AmUS_HbB$poU7@es8p4oGc8$Q3qdOgX=(laL&<s]'-02[Vr*_TI11G\'Ec=28n)u4co'd32+Mie[/e0N]hQ@c4QSrU.UIf,Sr`ZcNj9tlHZUShpCQC:n^P,etd/$n7M)^d<F;Ag[f],@9T2*XL,%tCb#^G/afoaGekS/M?,]6F/Uo3;&mV$1[#)lD`Y3aBV(&;:lc(ZiR*4??p]`%S<;h#JljUt7*#Kq.IEX`6d,RZ,n.SA^2i29^C"+L^qt5rERrAMhWeq]9JiC=MG^X\?s?gf%`Yu2MpN,2Xg-(ak))iJ]Jf;^X%\0E`bh`![!CPD='It/CX?cWZ^HH`j_\"A=E-Q2'O;F".P=_:emJai5RE?V0Xh8IM`lSRXHuHu<89*4!mHsfqZ7\4$T&4?#Y+DsoP<GsM-(UCED`YGKSNPO+"W+YOsM9C#m0*]J,n"=hRQ-@&&m-TJE!;9d.cE./pfK1-b+TiPVWPR#":M0VkX+FHtUX:[RY2<JlkS=_cP=e\ARte_uo("50eX0n_`70c6/GB/K^.A-^i,P]*nt/,'oYichro>nZ1".I'RnjUM`;uXEN\]1`.>U(`;`%#,3-%T4fk0*#F\h^LOdO#LD!`r$!gW6f[>Ek++dl/Tc?YTMeo<O:SS5XYXfK!fIk7OL`;2`Z/1HiqInK!dGgl6I"2Bp"ko=p[+;AKn,?a<@i9!=akn5\1:bUC]\N#\.7@ZYlhO/f2&Kup)BWGE4k-8JrnK(cG4f<AH"jZf'+?^S?cXnS]usTe-L\tH%m&tFE7$R^D5'G9AQlL3>^uN]!0lBZ=7TWEi&6sOC7q'n<A'i7%DRemi<TEd65Op_W7Q=4mD8Dj2"!aQO,F\T$ninRC96/j,mb.eP<-N38A0l=sJ<6qu2;q<s68gI_S5/k;LE1$mA96I-R-^;t5MPB/&45_sE@9/\"%r(9.(cfQL"%I[s:5ARi^BZda*f/(0E[+&I1?[BLSa@3!mhh:MblY')-[Nc(EJTQ12aD$K05'!8>*;>uedOaZ!]Ep&Mrs,"M&PPqQ7pTK=!H*c]p?oYNoptUc6\bB5Z(+tmm+iLAPEXK^0b%Jo@8cN4fp.=gaerQ_#T*R(srHOe'q<h_?O,$;\9%2ZN(3gne":i:V\->&[&#T/t"^i0;VsB^8-HeFsQ['od'YZA;Z7%i0Abj-:QhF?[Xmo%)-_&j0JJ_RanZL)PkIq:0q=\RT<M_m1`qUq3b@Cm><P$fSO(OBQDs1c**(>;?itP,5f)-mhPiaM;eaO>3]WQ$f/lHQ<V[s=N^,1=!+lG#0MT0ieCKmHR5^cp;`c5Y13iX+d\D0G]-.T\3>F$q;:DWMnPV@Dt,Wj^3\>I%,#=-$o,Ms37R_maTqJuoLgb&%FORF3KN<1_[.`NQ0o"L:hSXVhnhc%>?8iP#A@C_*?#IO&Yh]*`KV:,4"X:*&q]!JQeV*91k(S^o.;o::b>L'V?:!7qnf5hm@lkKGYnBm2C12`(N%>T<o2+LhbWa2rf]2DR#jj-9>;<;hs(COGJCHF$,E$&TnBr/Z\mOCQFkR<Oog?T0qf`]aN5"8#p1I6=nGQah_q#St.idXrE"HN~>endstream
+endobj
+17 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 2114
+>>
+stream
+Gau0DbBDVu&Dd46B'JI1/-*DJ<T9fgHeQt@I(JSI+sE@,8Z3c2eG8sdJ.GM;a@N=I+'Toi!goC6HS<Hki@h\?P60[e*W5[G#;4qP$/BSa\GH`lh-Kr"iC#d<=9MC[qBGY&duP^3_5I#D:&nWR9(2p1LdfN2N0t=_!J^`(2fegeK\Li6Hli$)4bn#AoZ)B8HdpZM8,tR$,r%o396+/$EK1F$FbTT>@YS7+XQUPY"ZB$g1#WE#KlC,/jmTKkA.EpfN3'@FL22%'<OKpa9pTN=It5-9\9gNjF;]pKp)#%A-MP)fG[AJh(`]11k"d>u>SgJ^_VN>ka@`<J<!d<'V5d3E$)u(`W3tKQpmWCZlNkgHYoW!@5$hg3*$0P8Jr/ESH.OU=(l3kU@mRUdd&gPaV$&N!js*q)S(U/q;:Sr?$3;>_EPrCo</*(,)gmK<\06)/GG6LGi#48-K&qmuAk-Y.@j/j.4iIE*IQG+VFYg6%ImVdgRZR8#aUC:hJj@1?)H1SnZ`io$;&`Nd=C&HN?Q7t-q"HJ#mDrbk7TF9b_Q+Hn["ctV[W@pTqi,oL43Y`R4`*`@kVFj0OR^")Jp=1=#:>B7"Q[GN+f7D_KlAJTf?E29huW8R06$a-i^)8R@0*7sQ]T:2/Iag/+j4&Sb!;,&QsE]t@@LD.gKLG`KdoX#0e00mgESo^J1\<bXB]L=aFmBZ;b:@K%K8`ei[<RMCW,QH*l5;7g=]E:-g:1)mgsS]+\(ssX(1\A+HDN+2\pC`W,PpXodr^Q0on*9AHi)j$CXRRXXSTWrhZ$a-H!i'+@4^]lqHNLQ#4])WpfRXiURoR1pjoupZ5U^h(Q,ll-$5D)!DSj$EBtT66T\_P3TYs<2pK0`?N2\,?U%/1Q8)=VQ)(E3F+oZ`>?i:b&%O-4b4kJaW@WeYfu[la=C@L<Iu<IfTh8\lD$V\4lTJ29]i[DM"pci\`rhASktALOa]kM)muBqf6,'l,eC(G*4OWW9C?@K]DCG'b@#GG&0L6h7)-Z.@^br%?NK:Mq3tD<CUKnD=0J:H:aq!gUqR`_npq.$o[+-(ZAGSr7<GpjdZ3cVG=1>Aj"_g)jSMusa*^\,0Oee.4G`O:*VWK]h`f0X4u1hUc6%kfA,_;J3)si=2kQ/Q%Bkd>2_L,The@92eC8"[Wb-s4O@lSnW+)mC[NpG%2MX`HloM!`kr>K$Z<9Q4-_-,$qG@cacCL'>bBG9#2ac6:TOa@t>7L%$l7Y*SEd"3HnYrcf\MT6s3`;7j6[QL#R=RX+i3?e0*H(<L^>!bj#?!A]A@AQfa990Y<^!!J7*&+tKKG`\G0oj2=Mi;mT.VoV0uch/:8DH94@`MY6VOueA)0sB%g(OX-cYRKa5.;PcIb2Z`R#QU!9td5Se;'.ai"s/;aV<#("Mppe2tJ^+.J4ZA(n#*1_"\V2D_Kq2)G5RAmB>Qbe.d$7GMn8eTc.CmA9J=#_99@(O0)Z(+P[Q[+$[,]!b,)`rj"DZr`f(X3RG>B0%Hq6]`P&+%--YqHhBBi`pTAGQ9%4rh+&;<T3@s9DG"XH$V#PPN!(ToE*",.>NW"%b.H&A5rTIc2Me!mO\Q"3o;?;9m[r&pKI;9AD$',lKRmBAU*Du+i@U_U^XkT3%r1dod460E5s_m=!u(nG9i$i*&<IJ<2HkO28%3dr-EuT/&:.TDOqMLE@u;2jU!Z:A&M+:J]Ob(4hI7E4.1S27(=3/%.W0;@\##YbrT'5:.]Rp8#[DN@#85!IN&"s%7m</g4YN#OUKmN90-*SfloR"aWrqm^!XA]p838/OCi/]kf(=fW%qgafjLA_bh0C<8Y\hUTNRql:sUZW<Zs8m/V@&U"pW1?CQkb23Vb`A+SQa!3B6U&bTVd=\Q\82!C34iXVQ@Q+HREt$c9lr7e+d*C6t@t).q2U[VDqlVp-R)o:A6rgHj/IK_MpLoF_LR-Gr2fkJXUg*N=TXbFuWsj@W!dgG_j<]<]K8UNMn"k7cRYedcLJ5YWn,k]QC0"PWQkCZLpZ9O"B;i&8KR-QDu`^X6m)XSf;4i3<g`&j:T(iR"VKG812#p*/BldUJ*8.aZW*c,9RHCrH3QC%:aJaW<K<89WTK.G7%H:X3qL+*&b7jo~>endstream
+endobj
+18 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 1979
+>>
+stream
+Gau0Dfll+.&:O:SbbLXPZR!&Y:JI%Mm7H+bC>WG4P*qJd$Ar`WYO<K^eDaS(U=/b?,n_=SpWdda%*6J-@/h#Pd>K<!qdVmBT]M&_aGXa-L0cGbrjqU)+A_oo]I]"1*oSp#1(hq2f,%a[Ip]Ps-XMso4J4P*]du_VC+'QJ0?uts^K8m>_ms4:q*COjLN@\6GcnGF&;I8X^*a,K4?nmY!!]]6.6^2gj"$NT58+I@FrP#,n:Vm[Zu"ss=5!;Q-G<8GDQ>in=7if`[\gY#X&9o4%4sfmnel@%0Ttto3KO`?7fs]-PkoAp?Hda$%lTKc&D$[An`DK8-VI16-$<:SW\#\lV5hY9NBZ4o'+cA[6koI-?0=?lmjd/]*e$l$(Whpa?2=;QL&BHlr?OO4kcJ)kXebIER<S/q-bIDj_Hm`b.<_).!P$*"i<*p4GZg>FFN%<NdH]D=DqAs0fYI'[(WA#.`_A,u^km5GcVO%odb_k]E=^11VI%:9F*Ii)F!2Lob*R%+/l\`?^p-*pZY"f'UImN?#irT&(<"dU;b:p6AoC+G3=JZE-^&K"0?4fJQo3HLS2Z38TnW0G+\?T(N/m=?Ws`Y*\lX+0RtMO=kJ@iFYhZ67_"s^=<>:7"T]oZ1l:SHg7HttjV#@0i0Zjl?13*Kln7Mum,4M)%CG[o[Pk?j>_EXB?;i/=9\5d/aiMB^XD.RCWMHa-m>eGO++?O20OX-(Z&m)T@el;rAjS/^e<:(H"kZ6S:1P+mTPDNt)$+K1.9YBRNNpD\PARB6cko4K<e]eOqauul,H>@aB2[d/rCMbP88ZG&W(Y5Hb.-7*nfD8m?!gU&Yb5=7k:+"9J-9f\6>BC'aQ8[b2=iqa=g.5V:CSTJ/!:W/%4\-alYm2:3\_U;_7(u@S:;V'l-`:r3iCpb`e4G[PXm?h1d\_"1?*<jPPk4ck%0da,>%6'1)u*FRKBlj4;OU/qU?Gi#daL%_7;&:P[6jqI#j,+j&e+`hgG7uM"\D+7qR;RA?.@<!KT#bWUoD_\-j7h;)E<Y9EQ2>+Fuf5=9j,WiGp8'./AYs=jh;ij%+5:'N`jim2*CTfmUWpXpV8)gWa3`$_0#p&&\YTZ?:%mUR`.O7%VJoR=,jj_Y'2c*mKjK]i/'2AAZa2-X^I?_MI*`<[D0)I]+(')Nrf7aIig>V+:(mX"+\_B/UC[Rh/SLFfcJaf3mGCjiCheN1/.uUrm>T_@,f"e7i$FF^_qtG]<=3KF^L3<B+Z?\7!f[l"S_:$?_,T9M6AK"T5W%BZtCK1]!!#QHu8i,_-+:NFpRC$M8X51AXcE<Icn"j9Y?M-fTLC+G=YjNE"m&cP*Ih?j44S5=NqVaQ>&[)[tn7p[Adu#I=G2#%.(;!M$.[ipR=n(^:uDdH2^VE"DhXT.u/(NhM,W]Ynus9jW?Tg<Ho^1S*9f_;`>X?grcY*B3;GV.\>aRanZ7gk<9,@<dIbH<nD2:UK`NoX^l:l4E>'D3_KdJSk.uj3l'EZDH(t#I(*jC6TX01+5$=)Z/_^F2]1V)fHuB*=L`$qr,$Bu`Z1jr6*dQB/ZTtc]=6QGI4fB.?3"El*K4u`NKO8^GHSWW4.s/*I?)r]7MG+J/i'M)IY,mo*rmq'oda!Yn'YMK<K2%bk)ui7mKGpoH_h?Bs%a_>>Rk;(0>C%"pCeY#a)V$Q5"9uVXcF[MNqC`BfkKF5:"H8.8Tq%t\2lu-UNeDnI%tP:GPrIY]hf^4MN"^9O1KD3f+hTW+h">O5fE0j8<fuE9g71P%r2OuTo`bkn0#p-_Hh1X)jPlKH_uc@o$$OjP&%FDdYN-#&[b*\g2UfCTUaj-WW`%Ofhu<rFY2^ND.9Yl44^jgW\o^a!fbPs8Y`gX;4gnX=eiMU\C=.J`mfM\e4JJ4%%f!Zc5m@PZ_4T?q>9RsZ@M/gGKQMUJYRuQRHebl6da+e5NauEU\04GTHDcZ'Ucj:LW_?ORCe;'C?@5<C*m6a#=8^NdJ~>endstream
+endobj
+19 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 1700
+>>
+stream
+Gb!;cgMYe)&:O:SbbH,%<U)35:N^tLMRIJeD;T&ald1_aKp"?\YO<?$/'F81Ct&aE(g0EE7@oo-F(Q8P^gH;TX-Vss9Afa^;Adf)7q!#U[/HPEhO]*S$&Yt26pX*NVbrl?RMJ>Vd+_o'JrDmb(eV+W/#+kq]G*YoAKeIG`^Pt);1:=Pd(Au+3!i!?k373[1<+AuU58<]6P;[A6OH5LKHU=MXrQ&l'Y#H5`SZ?T@EV,oLk8/C3Ght]rBm#N2Ino2jIl752Y<4$#H'4F?!A\kU[9pU?got[7ge+dKVe;&am>!4a[KB2ORh8eS^!?X#!.n(hY^XPZF6P;WP,I"WO/I)2<7_LDf:$LLaWb-,S?k[k:Jmd[5H.J0.@N2[LpVNP[@QajFIkFIX@arH)6LrAG+1d7/Yp0Gq:r?0poh2-q.8E&:q`\BB5%2p`e!4.Dh`+b(;NrE/Jfl:4utknrK]9nF;GQJfV;;:bhD]1Ao>[-IU,N]1s-+YSBip0]t<gOOlV.E,)T#J?VY!\$qoNK;-[kC#tkrAa<moDtng1Pimb`\[SfVYn9bFW>X#s>hg552tL'+mP"0D_)%LG70i9OdGk*0_ikl3A&8o!kpempo[Em"#K'=E&YLdCMLnE*;BMc[RUde:WYE.qL+6ug-RQ6t:7591JuX;C=::AQM.DH'LKe\*amoWYYm7S.5:p,;8TuI$JM!\PDJXVl7T1rZm>u#28@l7TaBDIP\;kVAduf2"BIb>d^,%k4Zus2>gfaJi\D]d@harIXG#ZgC$0Ti8Z6!n"Q"ssGo&^gh:RGC&f3%+Ob(Nq-Z>%fcgrU3SIg#MH&L]3t8(HrP]J_0Ne8Rl%_Z:W)B8unBHhe_OI,(2e!u5E<]m1a]B]r>4UDu:@D)qO.@T;9`l=gK1kutrr%,D<lqGnVSK/kF.)DD5"oai<i7WNOXjL&RTC3-WE<,uf"O*^.20Zc'$4<(9mjf7G+4lh<"\ABrFUQg@4Y[To.VUDge0$a0UjRD3)V!DXP_qK6Xs&JS]oCBD9,tYBTYE5OU*u1mK;&RY,n6eMKH=)-5RptuK`9Ma:R3P]f-++O?A(sW]Ou`=A$JJ^+(<m^?d8e/U4el).^"u'g.U23h9+0c0Vm+Za+EaI5gM`omImYN+T'6VNkg?%A[BkV:Xe,_4F5F7YHBn*57Vo;^bb=EdDE*Y9.\B9P2Bi]H`baI[SEklq.Ur^oi)+@C8/A=2%a\Q`j09Ll-WuGp`I]1F/i5WtH%t">aB]r?mc9Z%%NBdlagSNKr=aY?b+aBbYkW8hifPqnGb@VU]lZ+;`RX0dGG$%"mF#^X$4md.NFu;*Xtg*,"\s6deg&qR=T1N"[Ns.Y$X9.>\%8m@YYmr);B@Hsd$=,nkO@t_RENQjWSHf*[69o%%G=L/U.eoiEJ-uY*]D'[LL,/@&VXq"A2p'p9S(R0BLQnL\sIGWO<<[f"L5uZ*pD2ad^*j9QJLpHD:GWs+Pa+;;4A`KI%nO*`RO^rAFL[1Kgoo6_65X@**OI!=cK9R*7jU!'Q1nW)sd?L3Jj;%b^GkOpTj2Dg'``D"m@#R&p%J#4]RomU6/qOkK[R*(ZNEPG82\OE*3.j262d$UMB(qA>M>)9@P?Eb[$.YeI"0mPAb1e0Y1\2i@#$d5cNfb`DOXI09;oB51)B\cQ)P!SY>!5.^/@6W;Ko_4e/,8lR=p[j<*Ol0OX~>endstream
+endobj
+20 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 2142
+>>
+stream
+Gau0DgNK)F'Rf^WS4>MR9SL!S:JTnm[B"!]Hh%1maC?2T'*3!AYO=Ia0T8/&c`FB]#8"K6F4k16(E!-mc2VJan6lX<rpGB]@<i6`n+a-b)_RF(5>Ia$9gTVJ'70aUI(TZ'b^I"tj2;8_hieD!cj:AW\.Bt1M8R\o&cs_0Js]&t[K<VPI6HIrD@d!3^-`k42*9fJYKW<"_n.K\/Fd!^2amP#nB)E!\"HeZ`pJ9c$cS&dSG<aJ9/ul$W`Bh,el%DQIo((gTCTS@q+[>k8rI%aGn8)BZqP+pQrZuoBt(V0=i9tY(*qf@['ojBESpA,G:_HSr.Cq:VEe0)+7`*+BeCNl"_bGIgC$4J_**SN5"j*^=#dk<<Ab26&"N1ZN;7*;R@&e!%V&qS4jg*.jct@(2!-<7r7U@ta2mQf7LB;e_C,K$8Ko5NBEI2uT1i)?3%k=tG+CTf@Q;71/`HEZ#r?X+/"&Y4`iFImZ[PbfMS""5Ld)Jfr(Z_UeC4nS_EssU7PlK:C!PSak?43S>PKbd^[U]@2R[*/gBLHa6%i#lOD4Ab454L^Rsq+Rc_pS"m)O\aH#I]J#E/';&11U6H)7LqO92sL*_7^"d06*rf9_tRBbJ;$PUbOBdMS]F6Qp9WU_IgJ.bBAjKEE"o#dQ$?<=KELYa-0h:q_Cj;<dfY7AeFk1,hfaZA-EV&Z7VP2IElJXF3,:B8<CV`*s;SYE),=o2.3ie%X5N+A):50fj1X8FBSD%;\SXWpPb"$/AW0GaA?`\8_VlLLpWmX*E3XepAWc:@AfjcbM)!46q3b?KrMEBJ#,9h5atY;tqX'],N&<[X_$:g1g<>2?Wr%g\e!BWKAfWD=_8"b6k"[!EV$V>2r*2;Tf;]6mE(S[c+]GO-2gE6QFB%;':WlRjnl8b'A(kGrp+t<jZ#'F0u,,V,g`g2Tfo[XTdQhgOk_mY7)gZAU/#%^h<291nh@K8nH`nE)AdZWWiLUD;+8Y'XM2b\&8'=V\3/$!'>GPG]U[.J88"Ea@p,ds/g1\<]g91d5nTjme@rdquEpllUBYGXV2S2#al`@7I6M(]:$?^5=t5C;V<[;h^G8<)_mjU/fFF8oYu95:]'aOla((5g/ZmhI]2"d7&L@,H7R1Hr/"DUGqI4Y>`cMOlsiY4NZjAhR*dMRKOEbI5O7X_GuGIJr'ojq9S29<`QZb4k:laoA0+%4%;Liln7JD?JKJ1[*f?<1i3fm4!O#@cLdVqT2^D(6*JYSR:KTE@jr#)5cJ_No(j2Rg?E'Woc8H:Le8j+%,r)]o[78@N224&,N0k^/()L(#a:s']"&q$b:df).VQT'_`<os^.+J'mlA0;K>J3CTqpW?u4a#[.n4P"[&0k2sH7dQ,K@_"bZUp-iAXPIo$^jWAP$C`Mn9;#"*+b,pV&ojK&N\3j77tkZ`V0nNbLH%cm:%G+"rWN3$"PMCRYN`%c'EZTR.R7bToDsGL*(7b2.fZbiIs#oeWs5N15=2iQpV&Jk'WoiW5WZ4Gbu=!>E%g2CsG3SGCqRZnVUeCTe,om.)aR^(#sdC,;pjW)fSD1Ic*16>D\,D!B7#5a%Q1MddQSWL-K-@KjGp9Ei:BAoc)<V>,r>>`9'1A_7,EfV1#1*i+SP$62PS"DeI%*-WTM1at`h7'c8$"=3?;Y';`?g5?Z.B31)A\SAg\g4;siUl03^r*pad%e"uu*]N?]NFTqpS4?b-Dfa?m_SATC_h)eXM?W91\0An`A%)q8S!%;/0A\!0hfNcsK@NZ\N>]qV0^Wh9d(4L,C4W\h9Q*/%5am6OS>L\$Z3#:<`Wj_2_].%P(BPT-X8ij:f;N#W>2He*9P5f0g;sI<SnNn7.Xc\9T;"Kn?8@J<*Pq-EcT:9;m@JM/_Y,'_CB"m+DOq[hQ"b4jgR/ZUHWBV&kY>p;aSt%s"R76T3mAtPcdX'eu*&9q>K`_ZK"blc`@8_hlQW,d+I.ZslFcsO%6mMO]B``3KOZ73hDg:u$O?_!&*((m?iJ:.*0\W?!d@rfARfj\':sc.=%RTCl)H#@!m_KgR99B19XbEpeb3#8+2o8h/0*L)`dGQ$@1L0*B(bF=.pgYg8`o'Ke22DU):HR4M*1G);_$C&\F[o=2dFQ?AH@27rLupqRp?sAo!,$,D"Q8?jc7Cu0~>endstream
+endobj
+21 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 1490
+>>
+stream
+Gb!;cgN)%,'R\M6S4>MJUEBj!nsCb<VpdK:W#l#%YX4[#'Tc:`^[D4HFg37#j7.5#CFi@/#b52e3I;STa!^H8jbi9XS::AQ;']h(:Q]1Nk.f<!q<[F+j\_02S6-g[U6%>]GqLAur]F[>rAA@>8Qf5Q,,20s/5O`N<g:N_96-0^Xu1=15;ngd7nK$5O54,`@spasE6F$TR2A;#]T?!DJ6Z=sNhYGk-+e9F6mJr'69,iUE1,+$72MRq4/dnX>$KP/)ad^!^@$;O08@%n<rG;T#F`DIbD_D@DY4'%a2R/]L6NQO$=\ir4*n9DN+58rZbsc>WD6HJFA$pY=1Tu!7?qc3lErWWp^%3<1Ee%tr&hH5]W4c=IJ>B#0%)7&YBY%r,+^O7e*M%JCUL6J7HrYb2q[XJX/B46?&tZnJ(oAO\94RpQt.8C4>1`dEke]Qq_p>!k6S/6@<'&?@OnKn&_r0f%l6#5i\.(_%QhWm-C9p(\Vo@e,8)Ou2K:N[>[(.lcB,i]IV=)/Qc`Wt=`iA8gf^W1;E)`2[\9[%5]71Kh`QciprH2Va$.RMFHP`E3^Kc:Vcj$]hUoqgj^T^oiWp_<E0XE[['\C!j@cMRQRsJ+8OE`AT9LpI(jWpqE_n=tNIhB527akd[Do@K_p7hgUZ_1jcL;BWI/tDWCAK\:%'?X71jZ!3%Ht377Nt;+W'nqdWFhnU<Oj7[@U6S;`u'n9,9oQZSg>TtcfH?7bse#lAZ-I"h$/(l<oCjQHX[*=6ef?3dW-+>)F#%>4:O3.?OeVZi2HY+cpj.M]GtZJK)KCUq!0Wt)sOLn\HdNCc,t8EfVf#KcLN+>F*U;Oo+36s)'2`\h07@`eA&T8RFPTH"t/f@2s$Z1.Z@BR\PP)T3l4:n,b:9MM"M<f_I=<YW9_:&1D^i@;3L&jNeo<s+;RIM$6-?F](k+RlE+F8qeLH7@^f:$ISbCGlF[Tum??-f_PM6#[VQK#K._pcH1<O%AuLgDFc.d-BXC>VGZC)f^(,GjH82Z=8A\KDqA280/..2C-cFD,L4Rf`4T10;#OGu7NgNL/-5.BZ.*c;Z/EOTK$C86VRATj!H6^Jqh@4pQRI:U?)ffJ`Rn%glMUBG-,2LuJ;4i&LbNn`p(d@uQ201)?+l/j7FnGsua$,r4=J6(jmPPs]++*_3_9`9FDdAoOFQm1C"<=N1eco-fo7BK9;a[gREa(?qJ_+o-PGC"=4QU4#e_]aD676P<I`rCQmTkb2EuF#0o!?mq$t'>BWa)6#f^i_EI<PZW1OhJH3+h#s*;NF6)>n<uiAd(RW/)qa%@Z6_b_,*A(+&SfpB)Z4d^b.NX="c+G2N%s_]-q_.>E0/hT-VHYFFCCK.d&[?[C]"^(].;!<<htSKE$N+E5CCNd"'0@I%bdi)65r*O[$uQ"km5X]ImRR?$"Ws4.r*'l7enO8h%`rQFk[2io$cqsZ?7npF7m[lqR1Ef=r&U$J*&Y+Dfe$JGNLr<%'#E:E~>endstream
+endobj
+22 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 2340
+>>
+stream
+Gb!;e?$Fae&:Mm.fZ06:W;;h()haGC%r_TGIG[S2B2_CfY,%<SfD!SY8sW%b6?">"LH,._O.!O?pWba+5(3S)];QToH,4t./RUlc/f$!o]pN*<AS2fLIiir]0MhY;H$PX-o,+)kSqf&tq"i')ffqt992[F6L\$%-F5P0i1gi16U>/E40O*G8fVduG;=+*EOsSS$a*[H]fhoi[aDAum6FS8eT>s6J%FMmFI"l\aIkn^50nD,s>U]>60D+:`?.A69*H-710sqX_GOe5.'D>&,SX,VU/=#A4Y`!:?nVicR*m&-h3@o<2a3GWDSGC9sGmUSnI'Io97G+0'D(bgN\%G[61ec]G;Da*gX:uDu@\kt!^10PJH!q]iF#2-4$u_tW`kfu(k_JDZ+.r?"/JIrJkPJu%3RKiob(d6=1?JZ_IV8=)ngWi9O@"Jbqh+t3c*K*\i;s[IQsA!G>a2KQ&%k#skNi<f>-PuP,N$^Z]juZUS#D&db_AQ+.sL=S.K3mp*H/gPQ`g$b9XYL3JrJh#".JiV79Re<i@QN.RSL4Geon(gMqt[*eLSo!%AU&Y^Z5@e:;H#snA`OqD'lD:\nOg$qu4TPJ,S6bNP!Ye)#%Ml9Z&"^@5s##hDchQBq,7qjq*e#$7B8UX)Et*IK;@a'H(_2N(rNhe<63_S82,\<ZuW6m'ULgMrl`rpV^\!7;b#g/RM6>=`5Q>E"BD84A=S,&%=*aKM\-ib\:q\+YneC24`luEH^V@@4SK@j&O-49U)i5V)*;:YIQr.e+S#QVCuJ"`P#Q3BDuBM&%<Kq-f'F6V`7\Ak[8b:MS=i4C;r+1(P-E<10lbINN+W<FhHs`/)cOeC/J)oFJ9BUeR/eTi0!F\2(l%nPI4@ASCK$Hg?G7UGcZOlm1-Fcm__=RDijo*V6su<W[Z$j@Nc\i=X@k:$$-/)5gh+6>>!aIn!'Qc'f,bTl+4(>/W<VkgZ]@koLJa'hX2%=koP6C7glt/gk+G1REGU(e7^$e]HJ6"R1iKBR8K5#H+EgZ3"l$r*tdnXAiD4m$tXZlOJI/Z:[jb_ArD6l"_m9K4+7^m4Z<`d2.-Y/ZaZH5Dr%Y<P-__i*lFj.<MpaD6:ZUEp2:O#"Lu:?fXc)@@9_q8$2Km/]JpA,35K5A6s6l_6BoG:oKefSU7q7<p[cc$Hn,dpXR.@/3!cu+&MhXbLiE"m,!p,>9LQuL&ZrDiqk>m'a687`:^b/,#q3p?\qa5XLA9t[[)g#n=bZ1pJ5EXC.+b"@qF^-M[=Or7!?&FNpW>sZ.cjP;j>19Ln&/+<U)sO67L7(aV[Wlf#Y2rS6f.b:!q32@_I*PM6HVa6k1/nDo4W]\K80(H:e]"X(6MUpM,g(nO<bqrb>Au\(86lHOKI5c.8_Z[OYkb-14,33B:i6t',F=Xe=!>XkYK33B5]#V"!i`2^)?M<:a0q,?<XW#EC*4I4HTh>IXhV?pm)lL7=Hp_F9DX+!HnYDl$sU8eH3\D%Z\-[\+#1"-2<gub2rmL+XutM+sd*f,34quFL3]t%=_s+ht5n4.AA2F]r<$$c:nYuSJe&%GFVYP8ICS:(q%Dl-1(@#];6iA2*cH0BA][JZ;%$Sq%$FEj,7+ULO6a8EQ!==>B,<nHshgVL#P)"XU*;Fa@3_!hk+1hXNOs`fr\6mk%)0'1Zb2J[(85t`"H))(c*L&j.MgO7?.!jP=*-X&o"\FZ58f*!=OZ]Y*UiD6#CO__ZIBHf1;&4Ja.)al;F*f\.r85OMDI!W->/`T3FIK)nAWW*a,eOfaHYY<//[pnMLpo/@V/Y,8b&eegi3U'tF<2npj.2plY2XeO(GdiY.R7$b8[h9B@!g%Ld&uX/$tDpd\"til^+EJ?%g-K$sb$L0(5m;[n&()DsG7c.J$&\F+TAU#+]:okF]Ogff3TfpMJVS@jHCC[a/KG=>^$;HA>'s/\,_+^PU`%V.A,,!A>AOHJ[ePBDie$?\T$6Jt=B,gtaOgQCK:-ZjD_$k>OeKOMGrPgE+dMlh=o$&k:.&mRRdP_@p"k-']+%&1\>>ZUH#PQ>XAD=srE759.@k'Xi1mX1+6f-aN#g,;&mo"3;fRH*\2mT6V5.;l8UB4J*b&>Qjs9*jF?mErN%!05!*`:8heW!e'i*W6eO[%QOmm,m`Qq1m,O#02"'^;W4mXul](^4u?3!\K]jZCBXp>IgOVf`W4rK4ZqOTn;1^[0,jDKD\<PO2i>C?#u)Eoaq?;P5B.)^XH<Cf6p;PZ.5lA3=;m*o;Rh_kiGlL.6i^EkklW^+LbQm^QPXO&N]<0"8?@pX"'ieHe;c6/\rn";j<+,Xg-nsK8&=GJTNfa\:r5`F%^04kW`g]4Q$~>endstream
+endobj
+23 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 2412
+>>
+stream
+Gau0Ea`?-,'#!T]nu1sfdF]6W-Gjr<4(c@cj$fQg>`(e/Jd4]K$NN9TYFh/8PqiAs1i7q7![q#Z^0FuVg*%D"Nqo14LgJod0>BO.\9,J/a1$H-InO_JDuR>Q@ODKLR&npJgr.6G&BCqL++Cu06MgSVU`d%]`(_5/'&/;]d%MH`?>KeM)iaS!qD_dHq3LCN;(u9;guGe3,+%f?Lh'_--^&$g^>hI$Q7KhMS(RL.HHYb:SRTK&Z0b_tm7295UYA"$fnb70?><@##=U0>26UbcYF@XQ>5Ue_TBZ>f5,L[mk0juWg)]U*B_[$e#74N6TC"a%h"Np%B1L!t^ClgQ'ZlO!+jX\ek(5?kOHt69I.0'e\=VgY^7CX>52c)`=68rB$Z^)C>hT,!:1cDi,KmO5k]ikH@[i^9ilO:N@I\82O$&o6m_MiS+VL8-J?1#:"!8'k1\_AEM>+Z=r7J:63/M@'$S?)ao8RV\Cf)sJAfIe^K:DOhi`=j*@u'gqd:dIl^W01*jKgK*.Sdp/\dn1Sq_Hpf--QaEKW`iGV5gW).d.7igZ7*YM\I9Tl/$1T0Dp9*o_[;9^!Us]C5].Da]YpkIJ`6:4g(9Upi`/$K0691U"`ehFU)]P1fk4m'6?/BC2Y([f>K^tFfp#Za7IV5&B#S_jB?DT$&k#'BpHh5_;[!A+B,*oU9M4]:h>s!F^tZ&<MDIo9OtFi@B<<WgL7AL'%p7%;)H<Qc`Ju:!H-P.qg<7OOH[Z/8<NE3&Ap<X^*t-QM(f^6p.Ee'V@S7icJfth<$JUs'q(^uMmC3O)G*QVnH,PL3V^.<43ObA7YRRr88C2,VXAb)DH!t*)o-C<BO\NZQLI70T+@P[c^dS0h=UO$H#qVd@\j":YOc'!(#M232<W6l34tFmj%3r08uVVgP9[P<5W9EHg([Ze(c)*EPfME/65+[36K?<X'7*`3`jjP10;DlKK4qH""mt8H*)L+JeQV/u;X6s?"%1"O4U?cXfb(t\?EJ:VLl:_/MMj][Mgo>^=i0:\O?)`BP8CI5*hrc1`*2>MAE+96<0VNC?6k*Sm"#7r$9RN23)`[+j3nUnZ2T=9Z+MUAZK!?B-N:VMZu*?`8Bc+F+H/[8JmiM8Xli(qap>\WgHS[i?C54sIF>iK95c!4JR,hOZs]#?NNCdYi;dW9d[P(E.'$ma(.BCYEhZ3'\=IQ6m]2T"RfL>+=KfB^9&+;`NC1W2:B_OpA(j*M;Fe$99<+:"\re)mdrW1C4!Ig>W<k`Yjg/WD>^2]Mqrb:R)[+PDdJE8nd<b5FBQ8.qdD@oH9XG+^p/BL\A@"LM<M`eCeMt)r_A=UX5#\T:#_/s&@^YIn.3!QJ7nX43S%Vp^9%)uHoWkG<&Fo85RN35h4sBBcFNZuAaSl3^fPZ!=c/1F"WskU$!&9p!j'.E$[1Gn#HU@7\@*EX:F"5^XXX0.#.Sr_[oM'I9HsdPDi0(tB.JaFt/?<BVGfL_Sh[XI2:4Gh#<PC&YYYhOo#NW=ab0^#?q6t;p.d^MH%P;XhGHGoL5>p[7B/SrpUKaW/?U@%XKA>5hAiWd_9$NC5ok!Y]X`KB+]U#k+_bs/sHZ4l$.Mco@hOGHQoGY!1\-:0/d1F>/!d4%16#eippDrj!+6h\)19f#f*,t^9Q5LI`YY=e=Q=YI,$'oT0BU34k:aR`GWs`#6#.lY6?rudZ\ABp/>i0kFDHl1mdp;\rOE3urq/dkES68rH20*!ZS`hI0\OA(V^YEmFrN@"uE7%@R/]kqh7gUY^\@et<0kU8=D0k&BXRh%ec9"&q$c[q(0P)bLp$n_IEJs@W"@%FWg.ec4a'S0APJp48DKr5LKYP<"9%i;Wh4hPUfAR7uW-6X*Fg#`nV!J>M^3X",9e3g&:.b&=4ehi]$P0,cZL)Gl+P9!P:pY5@VE%(O^JXU+h5SX(e8)JH(UEEg9`t6mW#jM^kc?@D\E0a<J@+-'lPeS)O'W>CccZsZ<&qjN%F'].p2bd.MX%(0rjJqfTE<&aXj'gQ"1lV(E\XrNdp7SKhmE@mk,\22ALY/`lhWS?D&i:;K&OYsL/'VENl>5pm]gIuZUKHDC8jjYe$k,Bk^8dBLXhZ+S&ohgc%Ndn+nj$BEsC5c`tTEEcfEegi=+=]cY'f>oo`mhN?!E8p5HLDl#spgb.bBsKRM0?V=X'N^6->2i^Dmpj^O?ph.mbdX'm84N`rC(Gm;*kG]#q?^-l>*Xu$)&i#*/M'0n?,<9&eOLt</]Q?hUrbQjQSp)#$nac:FfLK>e29toYCbH4BUXfc,%+)@/@O4N<s1(o+Cp;f;Y,X+.ebl^q@;uOYabIpr'^REG*O%,KfRkVs(H#@sd62kS%P>(4!Wc3Ee<LJ>RBk4FknKbhVLAoI$M-Mg\CUeauJfGQO,foELCk<)/1&nr%Tpu&a8nMe<~>endstream
+endobj
+24 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 965
+>>
+stream
+Gatm9gN&c;&:O:SlslK@<CmH-m8K4UST`^^P.Da>!SL<WL^J)S?f)S0@OJ-f1/fteZF&&OF7ugDi,jh72m33V=7GdO!$PdY#,.E9eL,UR>5VJV/[C%F?oj0VVW](:/JVO(?a'Z^/o$1UQ=M`aOCk$I,S<j=*,-1(RGQ8Tn9$ZJ;N-MnNH\mq\I^hFP!DYB,gPHRM=F7G6%B$>PjU<e1^(Q"Hc/<g:8GF2P,f9t'c_YA]#PFg@m"pXlX1%^[dC`@mVUoF^4=`cXH#Z:8J)uKB>emaXsQ#j8pQp-MaMCP+M!@R6H@RRjJUX>iP<rN[^Il4D@m4SJiA\D:]-$%N0mS%B>Z`2[(WlMSi=Cca^qd=C<<f3*5kdqH'7S;FFbB8,OFj/Ul%CZSkrjol4H$&(a>GkcXa,_],M&QLL!a[8dhM=VI:AAGm!Bm"Wu#0<>ph9LT8MMAp6g\5mTYciX($2\?C-ri'Xb08>ZK]?l(!>B]1q@I.S`+S\)K)PO_!lE)8WhfsUKQR&;+7rS$Dbe=@ac4"O%2Von*b7'.hi;T+DeaFg8hQbXf--<0ER#h'A/)2^ib5VW7D_M*3E.;T`>43C8/gCARkq,h+9`r(2@ZnuT?oG[ioN+qAngRDu6^0l`#`p**!MWb%B=5(s^3'T\7jqm/#6A$<[)t0rWPJH&92u&/_hUI5g<(m\7TuD%f$7,DMTg\\L!NMaTL9:7gF96RT=<MNDj6aYUNo*]N2N@hL&sgZ>,CD\$!S2Z>n58Z,1CBZ"^^k"'6]:S=&qMi?%F=4Qpr_[CHYP04BX=OKC,_>[A@nu6Sb4:K,]>TndU;K;m7]Q"55;TMaSM=#%lj.(S$>&?->6bs'Bn0lVc#d?%=,9!rCPMD)s>JJWLD7pgk%)S`mN=4iVlC*gBC6j*[5j+\XN!Gh4f[KbLf[lqjnH"Nj"V]A7pJ^:%OpkSWG3/\f<>)qus^Uc!1~>endstream
+endobj
+xref
+0 25
+0000000000 65535 f 
+0000000061 00000 n 
+0000000102 00000 n 
+0000000209 00000 n 
+0000000321 00000 n 
+0000000526 00000 n 
+0000000731 00000 n 
+0000000936 00000 n 
+0000001141 00000 n 
+0000001346 00000 n 
+0000001551 00000 n 
+0000001757 00000 n 
+0000001963 00000 n 
+0000002169 00000 n 
+0000002239 00000 n 
+0000002579 00000 n 
+0000002690 00000 n 
+0000005082 00000 n 
+0000007288 00000 n 
+0000009359 00000 n 
+0000011151 00000 n 
+0000013385 00000 n 
+0000014967 00000 n 
+0000017399 00000 n 
+0000019903 00000 n 
+trailer
+<<
+/ID 
+[<3772eb22c2f3dc974da6fb5567531840><3772eb22c2f3dc974da6fb5567531840>]
+% ReportLab generated PDF document -- digest (opensource)
+
+/Info 14 0 R
+/Root 13 0 R
+/Size 25
+>>
+startxref
+20959
+%%EOF

--- a/src/components/modals/ModalGestionRutas.tsx
+++ b/src/components/modals/ModalGestionRutas.tsx
@@ -396,7 +396,7 @@ const ModalGestionRutas = memo(function ModalGestionRutas({
    * También detecta los clientes que ese día no abren.
    */
   const composicionBarridas = useMemo(() => {
-    const conteo = { 1: 0, 2: 0, 3: 0 };
+    const conteo = { 1: 0, 2: 0, 3: 0, 4: 0, 5: 0 };
     const cerradosEseDia: PedidoDB[] = [];
     for (const p of pedidosSeleccionados) {
       const { barrida } = clasificarBarrida(horarioParaRutear(p.cliente));
@@ -990,8 +990,8 @@ const ModalGestionRutas = memo(function ModalGestionRutas({
                       <p className="font-medium text-stone-800 dark:text-white text-sm mb-2">
                         Orden de reparto
                       </p>
-                      <div className="grid grid-cols-3 gap-2">
-                        {([1, 2, 3] as const).map(b => (
+                      <div className="grid grid-cols-2 sm:grid-cols-5 gap-2">
+                        {([1, 2, 3, 4, 5] as const).map(b => (
                           <div
                             key={b}
                             className={
@@ -1016,7 +1016,7 @@ const ModalGestionRutas = memo(function ModalGestionRutas({
                         Primero los que cierran al mediodía, después los que no tienen horario
                         cargado, y al final los de horario corrido.
                       </p>
-                      {composicionBarridas.conteo[2] > pedidosSeleccionados.length / 2 && (
+                      {composicionBarridas.conteo[4] > pedidosSeleccionados.length / 2 && (
                         <p className="text-xs text-amber-700 dark:text-amber-400 mt-1">
                           Más de la mitad no tiene horario cargado: el reparto va a ser menos preciso
                           hasta que se completen.

--- a/src/utils/barridas.test.ts
+++ b/src/utils/barridas.test.ts
@@ -2,69 +2,119 @@ import { describe, it, expect } from 'vitest';
 import { clasificarBarrida, abreEnDia, UMBRAL_CIERRE_TEMPRANO } from './barridas';
 import { serializarFranjas } from './horariosCliente';
 
-describe('clasificarBarrida — barrida 1 (cierran al mediodía)', () => {
-  it('una sola franja que cierra al mediodía y no reabre: "09:00-14:00"', () => {
-    // El caso más problemático de los datos reales: no es "cortado", pero es
-    // el que más rechaza si se lo deja para el final.
-    expect(clasificarBarrida('09:00-14:00').barrida).toBe(1);
-  });
+/**
+ * El orden de los grupos sale de cómo se aprovecha el día de reparto, no de una
+ * clasificación teórica de horarios. Los casos vienen de una ruta real de 43
+ * paradas donde el camión salía 08:00 y la primera parada abría 09:00.
+ */
 
-  it('horario cortado: "08:00-14:00 y 17:00-23:00"', () => {
-    expect(clasificarBarrida('08:00-14:00 y 17:00-23:00').barrida).toBe(1);
-  });
-
+describe('clasificarBarrida — grupo 1: abren temprano Y cierran al mediodía', () => {
   it.each([
-    '08:30-14:00',
-    '07:30-14:30',
-    '09:00-13:30',
-    '09:30-13:00',
-    '08:30-12:00',
-  ])('cierra temprano: "%s" → barrida 1', (horario) => {
+    ['07:00-11:00'],
+    ['07:30-12:30'],
+    ['08:00-11:00'],
+    ['08:00-14:00'],
+    ['08:30-14:00'],
+  ])('"%s" → grupo 1 (se hace apenas sale el camión)', (horario) => {
     expect(clasificarBarrida(horario).barrida).toBe(1);
   });
 
-  it('el umbral es inclusivo: cerrar exactamente a las 14:30 es barrida 1', () => {
-    expect(clasificarBarrida(`08:00-${UMBRAL_CIERRE_TEMPRANO}`).barrida).toBe(1);
+  it('el horario cortado que abre temprano también entra', () => {
+    expect(clasificarBarrida('08:00-14:00 y 17:00-23:00').barrida).toBe(1);
   });
 
-  it('un minuto después del umbral ya no es barrida 1', () => {
-    expect(clasificarBarrida('08:00-15:00').barrida).toBe(3);
+  it('exige las DOS condiciones: abrir temprano no alcanza si cierra tarde', () => {
+    // Este es el caso que hacía perder la mañana: abre 07:00 pero como cierra
+    // 24:00 se lo puede visitar en cualquier momento, no urge.
+    expect(clasificarBarrida('07:00-24:00').barrida).toBe(5);
+    expect(clasificarBarrida('08:00-17:00').barrida).toBe(5);
+    expect(clasificarBarrida('00:00-24:00').barrida).toBe(5);
   });
 
-  it('devuelve TODAS las franjas como ventanas, no solo la primera', () => {
+  it('exige las DOS condiciones: cerrar temprano no alcanza si abre 09:00', () => {
+    // Abrir 09:00 y cerrar 14:00 es del mediodía, pero no sirve para la primera
+    // hora: a las 08:15 está cerrado.
+    expect(clasificarBarrida('09:00-14:00').barrida).toBe(3);
+  });
+
+  it('el umbral de apertura es estricto: 09:00 en punto NO es madrugador', () => {
+    // Mismo cierre (13:30), sólo cambia la apertura: 08:30 entra al grupo 1 y
+    // 09:00 cae al 3 (13:30 pasa las 13, así que tampoco es del 2).
+    expect(clasificarBarrida('08:30-13:30').barrida).toBe(1);
+    expect(clasificarBarrida('09:00-13:30').barrida).toBe(3);
+  });
+});
+
+describe('clasificarBarrida — grupos 2 y 3: por hora de cierre', () => {
+  it.each([
+    ['09:00-13:00'],
+    ['09:30-13:00'],
+    ['10:00-12:30'],
+  ])('"%s" cierra hasta las 13 → grupo 2', (horario) => {
+    expect(clasificarBarrida(horario).barrida).toBe(2);
+  });
+
+  it.each([
+    ['09:00-14:00'],
+    ['09:00-14:30'],
+    ['10:00-14:00'],
+  ])('"%s" cierra hasta las 14:30 → grupo 3', (horario) => {
+    expect(clasificarBarrida(horario).barrida).toBe(3);
+  });
+
+  it('el corte de las 14:30 es inclusivo', () => {
+    expect(clasificarBarrida(`09:00-${UMBRAL_CIERRE_TEMPRANO}`).barrida).toBe(3);
+  });
+
+  it('un minuto después del corte ya es del último grupo', () => {
+    expect(clasificarBarrida('09:00-15:00').barrida).toBe(5);
+  });
+});
+
+describe('clasificarBarrida — grupo 4: sin horario', () => {
+  it.each([null, undefined, '', '   '])('vacío (%s) → grupo 4 sin ventanas', (v) => {
+    const r = clasificarBarrida(v as string | null | undefined);
+    expect(r.barrida).toBe(4);
+    expect(r.ventanas).toEqual([]);
+  });
+
+  it('texto libre no convertido cae en el grupo 4, no rompe', () => {
+    const r = clasificarBarrida('Lunes a sábado de 9 a 14');
+    expect(r.barrida).toBe(4);
+    expect(r.ventanas).toEqual([]);
+  });
+});
+
+describe('clasificarBarrida — grupo 5: corrido o abren tarde', () => {
+  it.each([
+    ['00:00-24:00'],
+    ['07:00-23:30'],
+    ['08:00-17:00'],
+    ['09:00-20:00'],
+    ['10:00-24:00'],
+    ['11:00-23:30'],
+    ['14:00-24:00'],
+  ])('"%s" → grupo 5', (horario) => {
+    expect(clasificarBarrida(horario).barrida).toBe(5);
+  });
+});
+
+describe('clasificarBarrida — ventanas', () => {
+  it('devuelve TODAS las franjas, no solo la primera', () => {
     const r = clasificarBarrida('08:00-14:00 y 17:00-23:00');
     expect(serializarFranjas(r.ventanas)).toBe('08:00-14:00 y 17:00-23:00');
   });
 });
 
-describe('clasificarBarrida — barrida 2 (sin horario)', () => {
-  it.each([null, undefined, '', '   '])('vacío (%s) → barrida 2 sin ventanas', (v) => {
-    const r = clasificarBarrida(v as string | null | undefined);
-    expect(r.barrida).toBe(2);
-    expect(r.ventanas).toEqual([]);
-  });
-
-  it('texto libre no convertido cae en barrida 2, no rompe', () => {
-    const r = clasificarBarrida('Lunes a sábado de 9 a 14');
-    expect(r.barrida).toBe(2);
-    expect(r.ventanas).toEqual([]);
-  });
-});
-
-describe('clasificarBarrida — barrida 3 (corrido / abren tarde)', () => {
-  it.each([
-    '00:00-24:00',
-    '07:00-23:30',
-    '08:00-17:00',
-    '09:00-20:00',
-    '10:00-24:00',
-    '11:00-23:30',
-  ])('atiende hasta tarde: "%s" → barrida 3', (horario) => {
-    expect(clasificarBarrida(horario).barrida).toBe(3);
-  });
-
-  it('abre tarde: "14:00-24:00" → barrida 3', () => {
-    expect(clasificarBarrida('14:00-24:00').barrida).toBe(3);
+describe('clasificarBarrida — orden relativo de la ruta real', () => {
+  it('los madrugadores van antes que los de las 9 y que los corridos', () => {
+    const g = (h: string) => clasificarBarrida(h).barrida;
+    // Caso exacto del reclamo: el de 09:00 arrancaba la ruta y el de 07:00
+    // quedaba segundo. Ahora el de 07:00 pertenece a un grupo anterior.
+    expect(g('07:00-11:00')).toBeLessThan(g('09:00-14:00'));
+    expect(g('07:30-12:30')).toBeLessThan(g('09:00-14:00'));
+    expect(g('09:00-13:00')).toBeLessThan(g('09:00-14:00'));
+    expect(g('09:00-14:00')).toBeLessThan(g('08:00-17:00'));
   });
 });
 
@@ -107,7 +157,6 @@ describe('abreEnDia', () => {
   });
 
   it('no se corre un día por zona horaria (fecha parseada como local)', () => {
-    // Con new Date('2026-08-02') en UTC-3 daría sábado y no domingo.
     expect(abreEnDia('0000001', DOMINGO)).toBe(true);
     expect(abreEnDia('0000010', DOMINGO)).toBe(false);
   });

--- a/src/utils/barridas.ts
+++ b/src/utils/barridas.ts
@@ -6,26 +6,43 @@
  * mirar a qué hora cierra cada local, así que el local que atiende hasta las 14
  * podía quedar en la parada 35 y se perdía la entrega.
  *
- * El reparto se ordena en tres bloques consecutivos y el orden ENTRE bloques es
- * duro: ninguna parada de la barrida 2 se entrega antes que una de la 1.
+ * El reparto se ordena en bloques consecutivos y el orden ENTRE bloques es
+ * duro: ninguna parada de un bloque se entrega antes que una del anterior.
  * Dentro de cada bloque se optimiza normalmente, respetando además la ventana
  * horaria real de cada cliente.
  *
- *   Barrida 1 — cierran temprano (al mediodía). Son los que más rechazan.
- *   Barrida 2 — sin horario cargado. Se hacen mientras la mayoría está abierta.
- *   Barrida 3 — corrido / abren tarde / cierran tarde. Toleran la visita final.
+ *   1 — abren temprano Y cierran al mediodía. Lo primero al salir del depósito.
+ *   2 — cierran hasta las 13.
+ *   3 — cierran hasta las 14:30.
+ *   4 — sin horario cargado.
+ *   5 — corrido / abren tarde. Toleran la visita al final del día.
  *
  * Nota sobre el criterio: agrupar por "cortado vs corrido" NO alcanza. El caso
  * más problemático de los datos reales es `09:00-14:00`: una sola franja, que
  * cierra al mediodía y no reabre. No es "cortado", pero es exactamente el que
- * hay que visitar primero. Por eso el criterio es la HORA DE CIERRE, no la
- * cantidad de franjas.
+ * hay que visitar temprano. Por eso el criterio son las HORAS, no la cantidad
+ * de franjas.
+ *
+ * El grupo 1 salió de una observación de la operación: entre que sale el camión
+ * y las 9 hay MUY pocos locales abiertos (6 de 43 en una ruta real). Esos son
+ * los únicos visitables en esa franja, así que desaprovecharla cuesta caro.
  */
 
 import type { FranjaHoraria } from './horariosCliente';
 import { horaAMinutos, parsearFranjas } from './horariosCliente';
 
-export type Barrida = 1 | 2 | 3;
+export type Barrida = 1 | 2 | 3 | 4 | 5;
+
+/**
+ * Apertura hasta la cual el local cuenta como "madrugador".
+ *
+ * Entre que sale el camión y esta hora hay pocos locales abiertos, así que los
+ * que SÍ lo están son los únicos visitables en esa franja: hay que aprovecharla.
+ */
+export const UMBRAL_APERTURA_TEMPRANA = '09:00';
+
+/** Primer corte de cierre: los que levantan más temprano. */
+export const UMBRAL_CIERRE_MUY_TEMPRANO = '13:00';
 
 /**
  * Cierre hasta el cual se considera que el local "cierra al mediodía".
@@ -34,13 +51,12 @@ export type Barrida = 1 | 2 | 3;
  */
 export const UMBRAL_CIERRE_TEMPRANO = '14:30';
 
-/** Apertura desde la cual se considera que el local "abre tarde". */
-export const UMBRAL_APERTURA_TARDIA = '11:00';
-
 export const ETIQUETA_BARRIDA: Record<Barrida, string> = {
-  1: 'Cierran al mediodía',
-  2: 'Sin horario cargado',
-  3: 'Corrido o abren tarde',
+  1: 'Abren temprano y cierran al mediodía',
+  2: 'Cierran hasta las 13',
+  3: 'Cierran hasta las 14:30',
+  4: 'Sin horario cargado',
+  5: 'Corrido o abren tarde',
 };
 
 export interface ClasificacionBarrida {
@@ -52,28 +68,49 @@ export interface ClasificacionBarrida {
 /**
  * Determina en qué barrida entra un cliente según su horario canónico.
  *
+ * OJO con el grupo 1: exige las DOS condiciones. Un local que abre 07:00 pero
+ * cierra 24:00 abre temprano, pero no urge —se lo puede visitar a cualquier
+ * hora—, así que va al 5. Meterlo en el 1 gastaría la mañana, que es el recurso
+ * escaso, en un cliente que no la necesita. En una ruta real eso pasaba de 6 a
+ * 14 paradas en el primer bloque, y el camión llegaba a las 11 a los del mediodía.
+ *
  * @param horario valor de `clientes.horarios_atencion` en formato "HH:MM-HH:MM y …".
- *                El texto libre no parseable cae en la barrida 2, igual que el vacío.
+ *                El texto libre no parseable cae en la barrida 4, igual que el vacío.
  */
 export function clasificarBarrida(horario?: string | null): ClasificacionBarrida {
   const franjas = parsearFranjas(horario);
 
   // Sin horario utilizable: no se puede saber cuándo conviene ir.
   if (franjas.length === 0) {
-    return { barrida: 2, ventanas: [] };
+    return { barrida: 4, ventanas: [] };
   }
 
+  const apertura = horaAMinutos(franjas[0].apertura);
   const cierre = horaAMinutos(franjas[0].cierre);
+  const cierraAlMediodia =
+    Number.isFinite(cierre) && cierre <= horaAMinutos(UMBRAL_CIERRE_TEMPRANO);
 
-  // Cierra al mediodía → primero, sí o sí.
-  if (Number.isFinite(cierre) && cierre <= horaAMinutos(UMBRAL_CIERRE_TEMPRANO)) {
+  // 1. Madrugador Y de cierre temprano: lo único que se puede hacer al salir.
+  if (
+    cierraAlMediodia &&
+    Number.isFinite(apertura) &&
+    apertura < horaAMinutos(UMBRAL_APERTURA_TEMPRANA)
+  ) {
     return { barrida: 1, ventanas: franjas };
   }
 
-  // El resto tolera la visita tardía: atiende de corrido, cierra tarde o abre
-  // tarde (apertura >= UMBRAL_APERTURA_TARDIA). Los tres casos van al final y
-  // se ordenan entre sí por su ventana horaria dentro de la barrida.
-  return { barrida: 3, ventanas: franjas };
+  // 2. Los que levantan más temprano.
+  if (Number.isFinite(cierre) && cierre <= horaAMinutos(UMBRAL_CIERRE_MUY_TEMPRANO)) {
+    return { barrida: 2, ventanas: franjas };
+  }
+
+  // 3. El resto de los que cierran al mediodía.
+  if (cierraAlMediodia) {
+    return { barrida: 3, ventanas: franjas };
+  }
+
+  // 5. Corrido, cierra tarde o abre tarde: tolera la visita al final del día.
+  return { barrida: 5, ventanas: franjas };
 }
 
 /**

--- a/supabase/functions/optimizar-ruta/index.ts
+++ b/supabase/functions/optimizar-ruta/index.ts
@@ -161,14 +161,16 @@ async function viaComputeRoutesPorBarridas(
   pedidos: PedidoRutaBarrida[],
   destino: LatLng = deposito,
 ): Promise<ResultadoFallback> {
-  const grupos: Record<Barrida, PedidoRutaBarrida[]> = { 1: [], 2: [], 3: [] };
-  for (const p of pedidos) grupos[p.barrida ?? 2].push(p);
+  const grupos: Record<Barrida, PedidoRutaBarrida[]> = { 1: [], 2: [], 3: [], 4: [], 5: [] };
+  for (const p of pedidos) grupos[p.barrida ?? 4].push(p);
 
   const conPedidos = ORDEN_BARRIDAS.filter((b) => grupos[b].length > 0);
   const composicion: Record<Barrida, number> = {
     1: grupos[1].length,
     2: grupos[2].length,
     3: grupos[3].length,
+    4: grupos[4].length,
+    5: grupos[5].length,
   };
 
   const ordenOptimizado: RutaUnida["ordenOptimizado"] = [];
@@ -312,7 +314,7 @@ serve(async (req: Request) => {
   const usarBarridas = barridaPorPedido.size > 0;
   const conBarrida: PedidoRutaBarrida[] = conCoords.map((p) => ({
     ...p,
-    barrida: barridaPorPedido.get(String(p.pedido_id)) ?? 2,
+    barrida: barridaPorPedido.get(String(p.pedido_id)) ?? 4,
   }));
   let composicion: Record<Barrida, number> | null = null;
 

--- a/supabase/functions/optimizar-ruta/route-optimization.ts
+++ b/supabase/functions/optimizar-ruta/route-optimization.ts
@@ -101,7 +101,7 @@ export function parseOptimizeTours(data: OptimizeToursResponse, pedidos: PedidoR
 const TZ = "-03:00";
 const SERVICE_SECONDS = 480; // ~8 min por parada: timing realista para las ventanas
 const COST_LATE_PER_HOUR = 1000; // penalización ALTA por llegar tarde → prioriza la ventana
-const COST_EARLY_PER_HOUR = 1; // leve: llegar antes implica esperar, no rompe
+const COST_EARLY_PER_HOUR = 500; // llegar antes de que abra = puerta cerrada, no "esperar"
 
 /** Timestamp RFC3339 en hora de Argentina. "24:00" (cierre a medianoche) → 23:59:59. */
 function isoFecha(fecha: string, hhmm: string): string {
@@ -242,7 +242,7 @@ export async function optimizeTours(
 // Barridas: el orden ENTRE bloques es duro.
 // ============================================================================
 
-export type Barrida = 1 | 2 | 3;
+export type Barrida = 1 | 2 | 3 | 4 | 5;
 
 /** Pedido con la barrida que le asignó el cliente (ver src/utils/barridas.ts). */
 export type PedidoRutaBarrida = PedidoRuta & { barrida?: Barrida };
@@ -255,7 +255,7 @@ export interface RutaBarridas extends RutaUnida {
   composicion: Record<Barrida, number>;
 }
 
-export const ORDEN_BARRIDAS: Barrida[] = [1, 2, 3];
+export const ORDEN_BARRIDAS: Barrida[] = [1, 2, 3, 4, 5];
 
 /**
  * Optimiza en 3 barridas consecutivas, encadenadas.
@@ -282,10 +282,10 @@ export async function optimizeToursPorBarridas(
   destino: LatLng | null = deposito,
   opts: OptimizeToursOpts = {},
 ): Promise<RutaBarridas> {
-  const grupos: Record<Barrida, PedidoRutaBarrida[]> = { 1: [], 2: [], 3: [] };
+  const grupos: Record<Barrida, PedidoRutaBarrida[]> = { 1: [], 2: [], 3: [], 4: [], 5: [] };
   for (const p of pedidos) {
     // Sin clasificación explícita se asume "sin horario" (barrida 2).
-    grupos[p.barrida ?? 2].push(p);
+    grupos[p.barrida ?? 4].push(p);
   }
 
   const conPedidos = ORDEN_BARRIDAS.filter((b) => grupos[b].length > 0);
@@ -293,6 +293,8 @@ export async function optimizeToursPorBarridas(
     1: grupos[1].length,
     2: grupos[2].length,
     3: grupos[3].length,
+    4: grupos[4].length,
+    5: grupos[5].length,
   };
 
   const ordenOptimizado: OrdenOptimizadoItemBarrida[] = [];
@@ -575,14 +577,16 @@ export async function optimizeToursMultiPorBarridas(
 ): Promise<RutaMultiResultado & { composicion: Record<Barrida, number> }> {
   if (repartidores.length === 0) throw new Error("No hay repartidores para el split");
 
-  const grupos: Record<Barrida, Array<PedidoRutaZona & { barrida?: Barrida }>> = { 1: [], 2: [], 3: [] };
-  for (const p of pedidos) grupos[p.barrida ?? 2].push(p);
+  const grupos: Record<Barrida, Array<PedidoRutaZona & { barrida?: Barrida }>> = { 1: [], 2: [], 3: [], 4: [], 5: [] };
+  for (const p of pedidos) grupos[p.barrida ?? 4].push(p);
 
   const conPedidos = ORDEN_BARRIDAS.filter((b) => grupos[b].length > 0);
   const composicion: Record<Barrida, number> = {
     1: grupos[1].length,
     2: grupos[2].length,
     3: grupos[3].length,
+    4: grupos[4].length,
+    5: grupos[5].length,
   };
 
   // Estado de cada chofer entre barridas.

--- a/supabase/functions/optimizar-ruta/tramos.ts
+++ b/supabase/functions/optimizar-ruta/tramos.ts
@@ -56,7 +56,7 @@ export interface OrdenOptimizadoItem {
    * 3 = corrido o abre tarde. Se persiste en recorrido_pedidos.barrida para
    * mostrarla en la hoja de ruta y medir rechazos por barrida.
    */
-  barrida?: 1 | 2 | 3;
+  barrida?: 1 | 2 | 3 | 4 | 5;
 }
 
 export interface RutaUnida {


### PR DESCRIPTION
Corrige el reporte del dueño: el camión sale 08:00, la primera parada abre 09:00, y un local de 07:00 quedaba segundo y uno de 07:30, noveno.

## ⚠️ Orden de despliegue

**Hay que deployar la edge function ANTES o JUNTO con el frontend.** El front nuevo manda barridas 4 y 5; la versión actual de `optimizar-ruta` sólo conoce 1-3 y fallaría al agrupar. Las migraciones 153 y 154 ya están aplicadas.

```
npx supabase@latest functions deploy optimizar-ruta --project-ref hmuchlzmuqqxcldbzkgc
```

## Las dos causas

**1. Llegar a puerta cerrada era casi gratis.**

```
COST_LATE_PER_HOUR  = 1000   // llegar tarde
COST_EARLY_PER_HOUR = 1      // llegar antes de que abra
```

El comentario decía *"llegar antes implica esperar, no rompe"*, y esa premisa es falsa: el chofer no espera 50 minutos, encuentra cerrado y sigue. Con ese costo el optimizador priorizaba la cercanía al depósito por sobre la hora de apertura. Pasa a 500.

**2. El criterio agrupaba sólo por hora de cierre**, así que un local de 07:00 y uno de 09:00 caían en el mismo bloque y adentro competían por distancia.

## Los 5 grupos

| | Criterio |
|---|---|
| 1 | Abren temprano **y** cierran al mediodía |
| 2 | Cierran hasta las 13 |
| 3 | Cierran hasta las 14:30 |
| 4 | Sin horario cargado |
| 5 | Corrido o abren tarde |

**El grupo 1 exige las dos condiciones, y eso salió de mirar los datos.** De los 14 que abren antes de las 9 en una ruta real, sólo **6 cierran al mediodía**; los otros 8 son corridos (`07:00-24:00`, `08:00-17:00`) que se pueden visitar a cualquier hora. Agrupar sólo por apertura metía esos 8 en el primer bloque y el camión llegaba a las 11 a los del mediodía. Con las dos condiciones el primer bloque queda en 6 paradas — que es lo que el dueño estimaba a ojo.

## Bug latente encontrado en el camino

El RPC `actualizar_barridas_recorrido` filtraba `IN (1, 2, 3)` al parsear el jsonb. Con 5 grupos habría descartado **en silencio** las barridas 4 y 5: esas paradas quedaban con `barrida` NULL y sin separador en la hoja de ruta, sin ningún error visible. Corregido en la migración 154.

## Nota sobre datos existentes

Las barridas 1-3 ya persistidas no se migran: son de rutas ya ejecutadas y sólo se usan para mostrar y medir. Su número sigue siendo válido pero cambió de significado (el 2 era "sin horario" y ahora es "cierran hasta las 13").

## Verificación

933 tests en verde (incluye los del clasificador reescritos con el criterio nuevo y un test del orden relativo que reproduce el caso reportado), 193 de Deno, typecheck limpio.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
