### PR TITLE
feat(roles): multi-rol por sucursal — el preventista que también reparte

### DIFF
--- a/migrations/155_perfil_roles.sql
+++ b/migrations/155_perfil_roles.sql
@@ -1,0 +1,254 @@
+-- =========================================================================
+-- 155_perfil_roles.sql
+--
+-- Un usuario puede tener capacidades de mas de un rol en una sucursal.
+--
+-- El caso: en Taco Pozo, Juan (preventista) acompaña al camion. Vende, entrega
+-- y cobra en la misma parada. `perfiles.rol` es escalar, asi que hoy o es
+-- preventista o es transportista, nunca los dos: puede cargar el pedido pero
+-- no ve la ruta, no marca entregado ni cobrado.
+--
+-- El intento anterior fue un rol a medida (`preventista_taco`, mig 050/055) y
+-- salio caro: quedo con 6 funciones de permisos, gating repartido por la app,
+-- el menu vacio y CERO usuarios. Cada combinacion futura seria un rol nuevo con
+-- su propia deuda. Aca "tambien reparte" pasa a ser un dato que el admin asigna
+-- desde la UI, por sucursal.
+--
+-- MODELO
+-- ------
+-- `perfiles.rol` sigue siendo la IDENTIDAD / PUESTO. Esta tabla son CAPACIDADES
+-- OPERATIVAS que se SUMAN, y afecta EXCLUSIVAMENTE a dos helpers:
+-- es_preventista() y es_transportista(). En ambos el cambio es ADITIVO
+-- (`... OR tiene_rol_extra(...)`), nunca sustractivo.
+--
+-- Por eso NO cambia de comportamiento nada de lo que lee `perfiles.rol` crudo:
+--   · registrar_pago_cliente_fifo / registrar_pago_combinado_cliente_fifo
+--     (SELECT rol INTO v_rol FROM perfiles; IF v_rol NOT IN ('admin','encargado'))
+--     => el pago a cuenta corriente desde la ficha sigue vedado a los
+--        transportistas Y a Juan, sin escribir una linea para lograrlo.
+--   · es_admin(), es_encargado_o_admin(), es_admin_rendiciones(),
+--     es_admin_salvedades(), es_transportista_rendiciones(), get_mi_rol()
+--   · crear_pedido_completo, actualizar_pedido_items, registrar_visita_cliente,
+--     obtener_geolocalizacion_preventistas (mig 055)
+--   · clientes_proteger_columnas_preventista (mig 080)
+--   · mt_clientes_select (rama preventista, mig 055)
+--   · las policies de `deposito` (rol leido inline)
+--
+-- Se aplica VACIA a proposito: cero cambio de comportamiento hasta que un admin
+-- asigne una fila. El interruptor es un INSERT; el rollback, un DELETE.
+--
+-- La unica excepcion, y es deliberada: la rama nueva de `pagos` (seccion 5),
+-- que habilita al transportista a cobrar los pedidos de SU ruta. Es aditiva:
+-- solo puede otorgar, nunca revocar.
+-- =========================================================================
+
+BEGIN;
+
+-- -------------------------------------------------------------------------
+-- 1. Tabla
+-- -------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS public.perfil_roles (
+  id          bigint GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+  usuario_id  uuid        NOT NULL REFERENCES public.perfiles(id)   ON DELETE CASCADE,
+  sucursal_id bigint      NOT NULL REFERENCES public.sucursales(id) ON DELETE CASCADE,
+  rol         text        NOT NULL,
+  created_at  timestamptz NOT NULL DEFAULT now(),
+  created_by  uuid        REFERENCES public.perfiles(id) ON DELETE SET NULL,
+
+  -- Solo 'transportista' a proposito. La escalabilidad esta en la ESTRUCTURA
+  -- (N:M por sucursal), no en habilitar valores sin caso de uso:
+  --   · 'admin'/'encargado' quedan afuera para que esto nunca sea un vector de
+  --     escalada de privilegios.
+  --   · 'deposito' seria letra muerta: no existe es_deposito(), esas policies
+  --     preguntan `perfiles.rol = 'deposito'` inline. Darlo aca daria falsa
+  --     sensacion de permiso otorgado.
+  --   · 'preventista' abriria clientes I/U, pedidos I, pedido_items I/U y
+  --     `pagos` SELECT de TODA la sucursal. Sin caso real, no se habilita.
+  -- Ampliar es un ALTER de una linea el dia que haga falta.
+  CONSTRAINT perfil_roles_rol_check CHECK (rol IN ('transportista')),
+  CONSTRAINT perfil_roles_uq UNIQUE (usuario_id, sucursal_id, rol)
+);
+
+CREATE INDEX IF NOT EXISTS idx_perfil_roles_lookup
+  ON public.perfil_roles (usuario_id, sucursal_id, rol);
+CREATE INDEX IF NOT EXISTS idx_perfil_roles_por_sucursal
+  ON public.perfil_roles (sucursal_id, rol);
+
+COMMENT ON TABLE public.perfil_roles IS
+  'Capacidades operativas EXTRA por sucursal, que se SUMAN a perfiles.rol. '
+  'perfiles.rol sigue siendo identidad/puesto y es lo que leen los gates '
+  'sensibles (FIFO, es_admin, es_encargado_o_admin, mt_clientes_select). '
+  'Esta tabla SOLO afecta a es_preventista() y es_transportista().';
+
+-- -------------------------------------------------------------------------
+-- 2. RLS
+-- -------------------------------------------------------------------------
+ALTER TABLE public.perfil_roles ENABLE ROW LEVEL SECURITY;
+
+-- Sin filtro de sucursal a proposito: el frontend lee sus propios roles al
+-- iniciar sesion, ANTES de setear el header X-Sucursal-ID.
+DROP POLICY IF EXISTS perfil_roles_select_propio ON public.perfil_roles;
+CREATE POLICY perfil_roles_select_propio
+  ON public.perfil_roles FOR SELECT TO authenticated
+  USING (usuario_id = auth.uid());
+
+-- El ENCARGADO es imprescindible: en Taco Pozo la ruta la arma Jony (encargado)
+-- y aplicar_orden_ruta gatea con es_encargado_o_admin(). Sin este SELECT, Juan
+-- no apareceria en el picker de transportistas.
+-- Espeja usuario_sucursales_select_sucursal_activa (mig 007).
+DROP POLICY IF EXISTS perfil_roles_select_sucursal_activa ON public.perfil_roles;
+CREATE POLICY perfil_roles_select_sucursal_activa
+  ON public.perfil_roles FOR SELECT TO authenticated
+  USING (
+    sucursal_id = public.current_sucursal_id()
+    AND EXISTS (
+      SELECT 1 FROM public.perfiles p
+      WHERE p.id = auth.uid() AND p.rol IN ('admin', 'encargado')
+    )
+  );
+
+DROP POLICY IF EXISTS perfil_roles_write_admin ON public.perfil_roles;
+CREATE POLICY perfil_roles_write_admin
+  ON public.perfil_roles FOR ALL TO authenticated
+  USING      (public.es_admin() AND sucursal_id = public.current_sucursal_id())
+  WITH CHECK (public.es_admin() AND sucursal_id = public.current_sucursal_id());
+
+GRANT SELECT, INSERT, UPDATE, DELETE ON public.perfil_roles TO authenticated;
+
+-- -------------------------------------------------------------------------
+-- 3. Primitiva: SOLO los roles extra (no mira perfiles.rol)
+-- -------------------------------------------------------------------------
+-- SECURITY DEFINER para leer perfil_roles saltandose su propia RLS.
+-- current_sucursal_id() devuelve NULL si el header falta o no esta autorizado
+-- => EXISTS falso => fail-closed, igual que el resto del sistema.
+CREATE OR REPLACE FUNCTION public.tiene_rol_extra(p_rol text)
+RETURNS boolean
+LANGUAGE sql STABLE SECURITY DEFINER
+SET search_path TO 'public'
+AS $fn$
+  SELECT EXISTS (
+    SELECT 1
+    FROM public.perfil_roles pr
+    WHERE pr.usuario_id  = auth.uid()
+      AND pr.rol         = p_rol
+      AND pr.sucursal_id = public.current_sucursal_id()
+  );
+$fn$;
+
+REVOKE ALL ON FUNCTION public.tiene_rol_extra(text) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.tiene_rol_extra(text) TO authenticated, service_role;
+
+COMMENT ON FUNCTION public.tiene_rol_extra(text) IS
+  'true si el usuario actual tiene ese rol EXTRA en la sucursal activa. '
+  'No mira perfiles.rol: es la primitiva que usan es_preventista()/es_transportista().';
+
+-- -------------------------------------------------------------------------
+-- 4. Helpers reescritos: ADITIVO y con corto-circuito
+-- -------------------------------------------------------------------------
+-- El EXISTS de cada uno es IDENTICO al de la mig 055 / baseline: se agrega
+-- unicamente un segundo RETURN. El IF/RETURN (en vez de `RETURN a OR b`)
+-- garantiza que admin, preventista, preventista_taco y encargado NO paguen el
+-- lookup extra: en el 99% del trafico el costo es exactamente el de hoy.
+-- Ademas pasan de VOLATILE (default, sin marca) a STABLE, que es lo correcto
+-- para funciones que solo leen y se evaluan dentro de policies.
+
+CREATE OR REPLACE FUNCTION public.es_preventista()
+RETURNS boolean
+LANGUAGE plpgsql STABLE SECURITY DEFINER
+SET search_path TO 'public'
+AS $fn$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM perfiles
+    WHERE id = auth.uid()
+      AND rol IN ('admin', 'preventista', 'preventista_taco', 'encargado')
+  ) THEN
+    RETURN true;
+  END IF;
+  RETURN public.tiene_rol_extra('preventista');
+END;
+$fn$;
+
+CREATE OR REPLACE FUNCTION public.es_transportista()
+RETURNS boolean
+LANGUAGE plpgsql STABLE SECURITY DEFINER
+SET search_path TO 'public'
+AS $fn$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM perfiles
+    WHERE id = auth.uid()
+      AND rol IN ('admin', 'transportista')
+  ) THEN
+    RETURN true;
+  END IF;
+  RETURN public.tiene_rol_extra('transportista');
+END;
+$fn$;
+
+-- NO se tocan, a proposito: es_admin(), es_encargado_o_admin(),
+-- es_admin_rendiciones(), es_admin_salvedades(), es_transportista_rendiciones(),
+-- is_admin(), is_preventista(), is_transportista(), get_mi_rol().
+
+-- -------------------------------------------------------------------------
+-- 5. pagos: el transportista cobra los pedidos de SU ruta
+-- -------------------------------------------------------------------------
+-- Hasta hoy `mt_pagos_insert` exigia es_preventista(), que no incluye a
+-- transportista: el chofer nunca pudo cobrar (0 pagos registrados por un
+-- transportista en toda la historia de la base). La cobranza se cargaba en la
+-- oficina al volver.
+--
+-- La rama nueva es por PERTENENCIA, igual que mt_pedidos_update,
+-- registrar_salvedad y marcar_no_entregado. `pedido_id IS NOT NULL` es lo que
+-- separa el cobro de la parada del pago a cuenta corriente: sin pedido no hay
+-- pertenencia que verificar. El pago a cuenta va por los RPC FIFO, que leen
+-- perfiles.rol crudo y exigen admin|encargado.
+DROP POLICY IF EXISTS "mt_pagos_insert" ON public.pagos;
+CREATE POLICY "mt_pagos_insert" ON public.pagos
+  FOR INSERT TO authenticated
+  WITH CHECK (
+    pagos.sucursal_id = public.current_sucursal_id()
+    AND (
+      public.es_preventista()
+      OR (
+        public.es_transportista()
+        AND pagos.pedido_id IS NOT NULL
+        AND EXISTS (
+          SELECT 1 FROM public.pedidos pd
+          WHERE pd.id               = pagos.pedido_id
+            AND pd.transportista_id = auth.uid()
+            AND pd.sucursal_id      = public.current_sucursal_id()
+        )
+      )
+    )
+  );
+
+-- El SELECT es imprescindible ademas del INSERT: usePagos.registrarPago hace
+-- `.insert(...).select('*, usuario:perfiles(id,nombre)').single()` y PostgREST
+-- necesita poder LEER la fila recien insertada para devolverla.
+DROP POLICY IF EXISTS "mt_pagos_select" ON public.pagos;
+CREATE POLICY "mt_pagos_select" ON public.pagos
+  FOR SELECT TO authenticated
+  USING (
+    pagos.sucursal_id = public.current_sucursal_id()
+    AND (
+      public.es_preventista()
+      OR (
+        public.es_transportista()
+        AND pagos.pedido_id IS NOT NULL
+        AND EXISTS (
+          SELECT 1 FROM public.pedidos pd
+          WHERE pd.id               = pagos.pedido_id
+            AND pd.transportista_id = auth.uid()
+            AND pd.sucursal_id      = public.current_sucursal_id()
+        )
+      )
+    )
+  );
+
+-- mt_pagos_update y mt_pagos_delete quedan admin-only, sin cambios.
+
+-- SIN SEEDS: la fila de Juan la crea el admin desde la UI, asi created_by queda
+-- poblado y el rollback operativo es un DELETE de una fila, sin deploy.
+
+COMMIT;

--- a/migrations/MANIFEST.md
+++ b/migrations/MANIFEST.md
@@ -126,10 +126,10 @@ funcional** y no se renombran los archivos: renombrarlos los desalinearía del l
 real lo da `version` y está en la sección A: en los dos casos el archivo de `main` quedó
 cronológicamente **fuera** del bloque 139–147 (uno antes, otro entre la 144 y la 145).
 
-**La próxima migración es la 153** — verificado contra el ledger el 2026-07-28: la última
-numerada es `152_guardar_horario_cliente_masivo`. Las **148–152** (origen del precio, reglas
-de comisión, `place_id` y horarios masivos) están aplicadas y mapean **1:1** con el ledger,
-así que no agregan ninguna excepción a las tablas de arriba.
+**La próxima migración es la 156** — verificado contra el ledger el 2026-07-30: la última
+numerada es `155_perfil_roles`. Las **148–155** (origen del precio, reglas de comisión,
+`place_id`, horarios masivos, barridas y roles extra por sucursal) están aplicadas y mapean
+**1:1** con el ledger, así que no agregan ninguna excepción a las tablas de arriba.
 
 **Antes de elegir el número de una migración nueva, mirar `ls migrations/` además del
 ledger**: el ledger no siempre lleva el prefijo, así que por sí solo no alcanza. Y si mergeaste

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -155,6 +155,7 @@ function MainAppInner({ user, perfil, logout, authReady }: {
     currentSucursalId,
     currentSucursalNombre,
     currentSucursalRol,
+    currentSucursalRolesExtra,
     sucursales,
     loading: sucursalLoading,
   } = useSucursal()
@@ -206,9 +207,18 @@ function MainAppInner({ user, perfil, logout, authReady }: {
   const isPreventista = effectiveRol === 'preventista'
   const isPreventistaTaco = effectiveRol === 'preventista_taco'
   const isAnyPreventista = isPreventista || isPreventistaTaco
+  // Los roles extra (mig 155) SUMAN capacidades al rol primario, no lo
+  // reemplazan: el preventista de Taco Pozo acompaña al camión, así que es
+  // preventista Y transportista a la vez. El rol primario sigue siendo el que
+  // mandan los permisos sensibles (ver src/lib/permisos.ts).
   const isTransportista = effectiveRol === 'transportista'
+    || currentSucursalRolesExtra.includes('transportista')
   const isEncargado = effectiveRol === 'encargado'
   const isAdminOrEncargado = isAdmin || isEncargado
+  const rolesEfectivos = useMemo(
+    () => (effectiveRol ? [effectiveRol, ...currentSucursalRolesExtra] : [...currentSucursalRolesExtra]),
+    [effectiveRol, currentSucursalRolesExtra],
+  )
 
   const defaultRoute = '/pedidos'
 
@@ -223,11 +233,12 @@ function MainAppInner({ user, perfil, logout, authReady }: {
     isTransportista,
     isEncargado,
     isAdminOrEncargado,
+    rolesEfectivos,
     isOnline,
     logout: handleLogout,
     currentSucursalId,
     currentSucursalNombre,
-  }), [user, perfil, authReady, isAdmin, isPreventista, isPreventistaTaco, isAnyPreventista, isTransportista, isEncargado, isAdminOrEncargado, isOnline, handleLogout, currentSucursalId, currentSucursalNombre])
+  }), [user, perfil, authReady, isAdmin, isPreventista, isPreventistaTaco, isAnyPreventista, isTransportista, isEncargado, isAdminOrEncargado, rolesEfectivos, isOnline, handleLogout, currentSucursalId, currentSucursalNombre])
 
   const handleRetrySync = useCallback(async () => {
     await refreshPendingOperations()

--- a/src/components/containers/PedidosContainer.tsx
+++ b/src/components/containers/PedidosContainer.tsx
@@ -6,6 +6,7 @@
  * Reemplaza el flujo legacy de App.tsx → VistaPedidos con prop drilling.
  */
 import React, { lazy, Suspense, useState, useCallback, useMemo, useRef } from 'react'
+import { useSearchParams } from 'react-router-dom'
 import { calcularNetoVenta } from '../../utils/calculations'
 import {
   aplicarDescuentoClienteItems,
@@ -44,6 +45,7 @@ import {
   useZonasEstandarizadasQuery,
   type RegistrarCambioInput,
 } from '../../hooks/queries'
+import { useRecorridoActivoQuery } from '../../hooks/queries/useRecorridoActivoQuery'
 import { useAuthData } from '../../contexts/AuthDataContext'
 import { useNotification } from '../../contexts/NotificationContext'
 import { useOptimizarRuta, type RepartidorParam } from '../../hooks/useOptimizarRuta'
@@ -123,6 +125,40 @@ export default function PedidosContainer(): React.ReactElement {
   const queryClient = useQueryClient()
   const { user, isAdmin, isPreventista, isPreventistaTaco, isTransportista, isEncargado, isOnline, authReady } = useAuthData()
   const notify = useNotification()
+
+  // Multi-rol (mig 155): quien vende Y reparte alterna entre la lista y el
+  // mapa de la ruta. El estado va en la URL (?vista=ruta) y no en useState
+  // porque esto es una PWA que se usa arriba del camión: sobrevive al reload y
+  // el botón "atrás" de Android vuelve a la lista en vez de salir de la app.
+  const [searchParams, setSearchParams] = useSearchParams()
+  const puedeAlternarRuta = isTransportista && !isAdmin && (isPreventista || isEncargado)
+  const modoRuta = puedeAlternarRuta && searchParams.get('vista') === 'ruta'
+
+  const verMiRuta = useCallback(() => {
+    setSearchParams(prev => {
+      const next = new URLSearchParams(prev)
+      next.set('vista', 'ruta')
+      return next
+    })
+  }, [setSearchParams])
+
+  const salirDeRuta = useCallback(() => {
+    setSearchParams(prev => {
+      const next = new URLSearchParams(prev)
+      next.delete('vista')
+      return next
+    })
+  }, [setSearchParams])
+
+  // Badge del botón "Mi ruta". Comparte cache con RutaActivaTransportista
+  // (misma query key), así que no agrega un request.
+  const { data: recorridoParaBadge } = useRecorridoActivoQuery(
+    puedeAlternarRuta ? user?.id : null,
+  )
+  const paradasPendientes = useMemo(
+    () => (recorridoParaBadge?.paradas ?? []).filter(p => p.estado !== 'entregado').length,
+    [recorridoParaBadge],
+  )
 
   // Pagination state
   const [paginaActual, setPaginaActual] = useState(1)
@@ -1558,6 +1594,10 @@ export default function PedidosContainer(): React.ReactElement {
           isTransportista={isTransportista}
           isEncargado={isEncargado}
           isPreventistaTaco={isPreventistaTaco}
+          modoRuta={modoRuta}
+          onVerMiRuta={puedeAlternarRuta ? verMiRuta : undefined}
+          onSalirDeRuta={salirDeRuta}
+          paradasPendientes={paradasPendientes}
           userId={user?.id ?? ''}
           clientes={clientes}
           productos={productos}

--- a/src/components/layout/TopNavigation.tsx
+++ b/src/components/layout/TopNavigation.tsx
@@ -8,6 +8,7 @@ import {
 } from 'lucide-react';
 import { getRolColor, getRolLabel } from '../../utils/formatters';
 import { useTheme } from '../../contexts/ThemeContext';
+import { useAuthData } from '../../contexts/AuthDataContext';
 import DbNotificationBell from './DbNotificationBell';
 import SucursalSelector from './SucursalSelector';
 import VincularTelegramButton from '../perfil/VincularTelegramButton';
@@ -107,6 +108,7 @@ export default function TopNavigation({
   const navigate = useNavigate();
   const location = useLocation();
   const { darkMode, toggleDarkMode } = useTheme();
+  const { rolesEfectivos } = useAuthData();
   const [menuAbierto, setMenuAbierto] = useState<boolean>(false);
   const [userMenuAbierto, setUserMenuAbierto] = useState<boolean>(false);
   const [dropdownAbierto, setDropdownAbierto] = useState<string | null>(null);
@@ -117,18 +119,23 @@ export default function TopNavigation({
   // Obtener la vista actual desde la ruta
   const vista = location.pathname.replace('/', '') || 'dashboard';
 
-  // Filtrar grupos y items por rol
+  // Filtrar grupos y items por rol.
+  //
+  // Usa los roles EFECTIVOS (rol de la sucursal activa + capacidades extra de
+  // la mig 155), no `perfil.rol`. Dos motivos: el rol global ignoraba el rol
+  // por sucursal (el menu podia mostrar items que el router despues redirigia),
+  // y el multi-rol necesita la union — el preventista que tambien reparte ve
+  // los items de ambos.
   const getMenuFiltrado = (): MenuGroup[] => {
-    const userRol = perfil?.rol;
-    if (!userRol) return [];
+    if (rolesEfectivos.length === 0) return [];
 
     return menuGroups.map(group => ({
       ...group,
-      items: group.items.filter(item => item.roles.includes(userRol) && !item.hidden)
+      items: group.items.filter(item => item.roles.some(r => rolesEfectivos.includes(r)) && !item.hidden)
     })).filter(group => {
       // Filtrar grupos vacios o sin permiso
       if (group.items.length === 0) return false;
-      if (group.roles && !group.roles.some(r => r === userRol)) return false;
+      if (group.roles && !group.roles.some(r => rolesEfectivos.includes(r))) return false;
       return true;
     });
   };

--- a/src/components/modals/ModalRegistrarPago.tsx
+++ b/src/components/modals/ModalRegistrarPago.tsx
@@ -72,6 +72,15 @@ export interface ModalRegistrarPagoProps {
    * rechazar (throw) si falla para mantener el modal abierto.
    */
   onEntregarSinCobrar?: () => void | Promise<void>;
+  /**
+   * Cobro de UNA parada concreta (ruta activa): imputa el pago a ese pedido y
+   * oculta el selector "Aplicar a Pedido". Sin esto el selector arranca en
+   * "Pago a cuenta general" y el pago sale con pedido_id NULL, dejando el
+   * pedido entregado e impago (el trigger de monto_pagado necesita el pedido).
+   * Además, la RLS solo deja cobrar al transportista si el pago apunta a un
+   * pedido suyo, así que a cuenta general el INSERT le sería rechazado.
+   */
+  pedidoIdFijo?: string;
 }
 
 export default function ModalRegistrarPago({
@@ -83,7 +92,8 @@ export default function ModalRegistrarPago({
   onConfirmarFIFO,
   onConfirmarCombinadoFIFO,
   onGenerarRecibo,
-  onEntregarSinCobrar
+  onEntregarSinCobrar,
+  pedidoIdFijo
 }: ModalRegistrarPagoProps): React.ReactElement | null {
   // Zod validation hook
   const { validate, getFirstError } = useZodValidation(modalPagoSchema)
@@ -92,7 +102,7 @@ export default function ModalRegistrarPago({
   const [formaPago, setFormaPago] = useState<string>('efectivo')
   const [referencia, setReferencia] = useState<string>('')
   const [notas, setNotas] = useState<string>('')
-  const [pedidoSeleccionado, setPedidoSeleccionado] = useState<string>('')
+  const [pedidoSeleccionado, setPedidoSeleccionado] = useState<string>(pedidoIdFijo ?? '')
   const [loading, setLoading] = useState<boolean>(false)
   const [pagoRegistrado, setPagoRegistrado] = useState<PagoRegistrado | null>(null)
   const [resultadoFIFO, setResultadoFIFO] = useState<RegistrarPagoFifoResult | null>(null)
@@ -614,8 +624,9 @@ export default function ModalRegistrarPago({
             </>
           )}
 
-          {/* Aplicar a pedido especifico */}
-          {pedidosPendientes.length > 0 && (
+          {/* Aplicar a pedido especifico. Se oculta cuando el cobro es de una
+              parada concreta (pedidoIdFijo): ahi el pedido no es opcional. */}
+          {!pedidoIdFijo && pedidosPendientes.length > 0 && (
             <div>
               <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
                 Aplicar a Pedido (opcional)

--- a/src/components/modals/ModalUsuario.tsx
+++ b/src/components/modals/ModalUsuario.tsx
@@ -1,9 +1,16 @@
 import { useState, useEffect, memo, useRef } from 'react';
-import { Loader2, MapPin } from 'lucide-react';
+import { Loader2, MapPin, Truck } from 'lucide-react';
 import ModalBase from './ModalBase';
 import { useZodValidation } from '../../hooks/useZodValidation';
 import { usuarioSchema } from '../../lib/schemas';
-import { useZonasEstandarizadasQuery, usePreventistaZonasQuery, useAsignarZonasPrevMutation } from '../../hooks/queries';
+import {
+  useZonasEstandarizadasQuery,
+  usePreventistaZonasQuery,
+  useAsignarZonasPrevMutation,
+  usePerfilRolesQuery,
+  useAsignarPerfilRolesMutation,
+} from '../../hooks/queries';
+import { useSucursal } from '../../contexts/SucursalContext';
 import type { PerfilDB } from '../../types';
 
 /** Roles disponibles para usuarios */
@@ -44,6 +51,11 @@ const ModalUsuario = memo(function ModalUsuario({ usuario, onSave, onClose, guar
   const { data: prevZonaIds } = usePreventistaZonasQuery(usuario?.id);
   const asignarZonasMut = useAsignarZonasPrevMutation();
 
+  // Capacidades extra en la sucursal activa (mig 155)
+  const { currentSucursalNombre } = useSucursal();
+  const { data: rolesExtraGuardados } = usePerfilRolesQuery(usuario?.id);
+  const asignarRolesMut = useAsignarPerfilRolesMutation();
+
   const [form, setForm] = useState<UsuarioFormData>(usuario ? {
     id: usuario.id,
     nombre: usuario.nombre || '',
@@ -63,8 +75,23 @@ const ModalUsuario = memo(function ModalUsuario({ usuario, onSave, onClose, guar
     }
   }, [prevZonaIds]);
 
+  // Estado local para las capacidades extra (tabla perfil_roles, mig 155)
+  const [puedeLlevarRuta, setPuedeLlevarRuta] = useState<boolean>(false);
+
+  useEffect(() => {
+    if (rolesExtraGuardados) {
+      setPuedeLlevarRuta(rolesExtraGuardados.includes('transportista'));
+    }
+  }, [rolesExtraGuardados]);
+
   // Mostrar campo de zona para preventistas (regular y taco)
   const mostrarZona = form.rol === 'preventista' || form.rol === 'preventista_taco';
+
+  // El bloque de capacidades extra no aplica a quien ya las tiene por su rol:
+  // el transportista lleva la ruta por definicion y el admin puede todo.
+  const mostrarCapacidadesExtra = !!usuario?.id
+    && form.rol !== 'transportista'
+    && form.rol !== 'admin';
 
   const handleFieldChange = (field: keyof UsuarioFormData, value: string | boolean): void => {
     setForm({ ...form, [field]: value });
@@ -107,6 +134,18 @@ const ModalUsuario = memo(function ModalUsuario({ usuario, onSave, onClose, guar
         await asignarZonasMut.mutateAsync({ perfilId: usuario.id, zonaIds });
       } catch {
         // Si falla la asignación de zonas, el perfil ya se guardó
+      }
+    }
+
+    // Guardar capacidades extra de la sucursal activa. Si el rol paso a ser
+    // transportista o admin, se limpian: ya las tiene por rol y dejarlas seria
+    // ruido en la tabla.
+    if (usuario?.id) {
+      const roles = mostrarCapacidadesExtra && puedeLlevarRuta ? ['transportista'] : [];
+      try {
+        await asignarRolesMut.mutateAsync({ usuarioId: usuario.id, roles });
+      } catch {
+        // Si falla, el perfil ya se guardó
       }
     }
   };
@@ -197,6 +236,39 @@ const ModalUsuario = memo(function ModalUsuario({ usuario, onSave, onClose, guar
           </div>
         )}
 
+        {/* Capacidades extra en la sucursal activa (mig 155). Se SUMAN al rol,
+            no lo reemplazan: el preventista que acompaña al camion sigue
+            vendiendo y ademas reparte. */}
+        {mostrarCapacidadesExtra && (
+          <div>
+            <label className="block text-sm font-medium mb-1 dark:text-gray-200 flex items-center gap-1">
+              <Truck className="w-4 h-4" />
+              Capacidades extra{currentSucursalNombre ? ` en ${currentSucursalNombre}` : ''}
+            </label>
+            <div className="border dark:border-gray-600 rounded-lg p-3 bg-white dark:bg-gray-700">
+              <label className="flex items-start gap-2 text-sm dark:text-gray-200 cursor-pointer">
+                <input
+                  type="checkbox"
+                  checked={puedeLlevarRuta}
+                  onChange={e => setPuedeLlevarRuta(e.target.checked)}
+                  className="w-4 h-4 rounded mt-0.5"
+                />
+                <span>
+                  Puede llevar la ruta (transportista)
+                  <span className="block text-xs text-gray-500 dark:text-gray-400 mt-0.5">
+                    Le permite recibir la ruta del dia, marcar entregado y cobrar los pedidos
+                    de esa ruta. NO le da acceso a cobrar cuenta corriente desde la ficha
+                    del cliente.
+                  </span>
+                </span>
+              </label>
+            </div>
+            <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
+              Solo aplica a esta sucursal. Debe volver a entrar a la app para que tome efecto.
+            </p>
+          </div>
+        )}
+
         <div className="flex items-center space-x-2">
           <input
             type="checkbox"
@@ -217,10 +289,10 @@ const ModalUsuario = memo(function ModalUsuario({ usuario, onSave, onClose, guar
         </button>
         <button
           onClick={handleSubmit}
-          disabled={guardando || asignarZonasMut.isPending}
+          disabled={guardando || asignarZonasMut.isPending || asignarRolesMut.isPending}
           className="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 flex items-center disabled:opacity-50"
         >
-          {(guardando || asignarZonasMut.isPending) && <Loader2 className="w-4 h-4 mr-2 animate-spin" />}
+          {(guardando || asignarZonasMut.isPending || asignarRolesMut.isPending) && <Loader2 className="w-4 h-4 mr-2 animate-spin" />}
           Guardar
         </button>
       </div>

--- a/src/components/pedidos/PedidoActions.tsx
+++ b/src/components/pedidos/PedidoActions.tsx
@@ -169,9 +169,17 @@ function AccionesDropdown({
     // - Transportista: solo pedidos ruteados (estado 'asignado').
     // - Admin/encargado: cualquier estado activo (no entregado/cancelado), para
     //   poder cerrar entregas sueltas sin tener que armar una ruta.
+    //
+    // El transportista solo puede cerrar SUS paradas. Antes alcanzaba con el
+    // rol, y con el multi-rol (mig 155) eso se volvía peligroso: el preventista
+    // que también reparte ve en la lista todos los pedidos que cargó él, así
+    // que le habrían aparecido botones de entrega sobre pedidos que lleva otro
+    // chofer. Además, "Entrega con Salvedad" habría fallado del lado del
+    // servidor (registrar_salvedad valida la pertenencia) con un error confuso.
+    const esSuParada = !!currentUserId && pedido.transportista_id === currentUserId;
     const puedeEntregarStaff = (isAdmin || isEncargado)
       && pedido.estado !== 'entregado' && pedido.estado !== 'cancelado';
-    const puedeEntregarTransportista = isTransportista && pedido.estado === 'asignado';
+    const puedeEntregarTransportista = isTransportista && esSuParada && pedido.estado === 'asignado';
     if ((puedeEntregarStaff || puedeEntregarTransportista) && onEntregado) {
       items.push({
         label: 'Marcar Entregado',
@@ -181,8 +189,8 @@ function AccionesDropdown({
       });
     }
 
-    // Transportista, admin o encargado pueden marcar entregado con salvedad
-    if ((isTransportista || isAdmin || isEncargado) && pedido.estado === 'asignado' && onEntregadoConSalvedad && pedido.items && pedido.items.length > 0) {
+    // Admin/encargado sobre cualquier parada; el transportista solo sobre la suya.
+    if ((isAdmin || isEncargado || (isTransportista && esSuParada)) && pedido.estado === 'asignado' && onEntregadoConSalvedad && pedido.items && pedido.items.length > 0) {
       items.push({
         label: 'Entrega con Salvedad',
         icon: AlertCircle,

--- a/src/components/pedidos/PedidoToolbar.tsx
+++ b/src/components/pedidos/PedidoToolbar.tsx
@@ -23,7 +23,8 @@
 import React from 'react';
 import {
   Plus, Route, FileDown, PackageCheck, Banknote, ChevronDown,
-  MapPin, History, Boxes, Download, ArrowLeftRight, HandCoins, type LucideIcon,
+  MapPin, History, Boxes, Download, ArrowLeftRight, HandCoins, Navigation,
+  type LucideIcon,
 } from 'lucide-react';
 import {
   DropdownMenu, DropdownMenuTrigger, DropdownMenuContent,
@@ -52,6 +53,13 @@ export interface PedidoToolbarProps {
   onEntregaYPagoMasivos?: () => void;
   onMarcarVisita?: () => void;
   onVerVisitasHoy?: () => void;
+  /**
+   * Multi-rol (mig 155): abre el mapa de la ruta del día. Solo se pasa a quien
+   * vende Y reparte — el transportista puro ya entra directo al mapa.
+   */
+  onVerMiRuta?: () => void;
+  /** Paradas sin entregar, para el badge del botón "Mi ruta". */
+  paradasPendientes?: number;
 }
 
 // =============================================================================
@@ -189,10 +197,35 @@ export default function PedidoToolbar({
   onEntregaYPagoMasivos,
   onMarcarVisita,
   onVerVisitasHoy,
+  onVerMiRuta,
+  paradasPendientes,
 }: PedidoToolbarProps): React.ReactElement {
   const canCreate = isAdmin || isEncargado || isPreventista;
   const showOpsGroups = isAdmin || isEncargado;
   const showPreventistaActions = isPreventista && !isAdmin && !isEncargado;
+
+  // "Mi ruta" — multi-rol. Se usa arriba del camión, así que en mobile va
+  // full-width y primero: cuando está repartiendo es LA acción del día.
+  const miRutaButton = onVerMiRuta && (
+    <button
+      onClick={onVerMiRuta}
+      title="Ver el mapa de la ruta del día para entregar y cobrar"
+      className={cn(
+        BUTTON_BASE,
+        'border-blue-200/80 dark:border-blue-800 bg-blue-50 dark:bg-blue-900/30',
+        'text-blue-800 dark:text-blue-200',
+        'hover:bg-blue-100 dark:hover:bg-blue-900/50 hover:border-blue-300 dark:hover:border-blue-700',
+      )}
+    >
+      <Navigation className={cn('text-blue-600 dark:text-blue-300', TOOLBAR_ICON_SIZE)} aria-hidden="true" />
+      <span>Mi ruta</span>
+      {paradasPendientes != null && paradasPendientes > 0 && (
+        <span className="ml-0.5 inline-flex items-center justify-center min-w-[1.375rem] h-[1.375rem] px-1.5 rounded-full bg-blue-600 text-white text-xs font-semibold">
+          {paradasPendientes}
+        </span>
+      )}
+    </button>
+  );
 
   // ¿Hay al menos una acción masiva habilitada? (para mostrar el dropdown)
   const hasMasivas = Boolean(
@@ -273,6 +306,10 @@ export default function PedidoToolbar({
     <>
       {/* ╔══ MOBILE (<sm): grid 3-col arriba + primary full-width abajo ══╗ */}
       <div className="flex flex-col gap-2 sm:hidden">
+        {miRutaButton && (
+          <div className="[&>*]:w-full [&>*]:justify-center">{miRutaButton}</div>
+        )}
+
         {showOpsGroups && (
           <div className="grid grid-cols-3 gap-1.5 [&>*]:w-full [&>*]:justify-center [&>*]:px-2">
             {masivasDropdown}
@@ -337,6 +374,8 @@ export default function PedidoToolbar({
 
       {/* ╔══ DESKTOP (sm+): layout original — fila a la derecha ══╗ */}
       <div className="hidden sm:flex items-center gap-2 justify-end flex-wrap">
+        {miRutaButton}
+
         {showOpsGroups && (
           <>
             {masivasDropdown}

--- a/src/components/rutaActiva/RutaActivaTransportista.tsx
+++ b/src/components/rutaActiva/RutaActivaTransportista.tsx
@@ -12,7 +12,7 @@
  * (useEntregaParada). Diseño: docs/plans/2026-06-12-ruta-activa-design.md
  */
 import React, { useState, useMemo, useEffect, useCallback, lazy, Suspense } from 'react';
-import { Crosshair, WifiOff, Truck, Volume2, VolumeX, LocateFixed } from 'lucide-react';
+import { Crosshair, WifiOff, Truck, Volume2, VolumeX, LocateFixed, ArrowLeft } from 'lucide-react';
 import { formatPrecio } from '../../utils/formatters';
 import { haversineMeters } from '../../utils/geo';
 import { useAuthData } from '../../contexts/AuthDataContext';
@@ -50,6 +50,12 @@ export interface RutaActivaTransportistaProps {
   onRegistrarSalvedad?: (data: DatosSalvedad) => Promise<RegistrarSalvedadResult>;
   onRegistrarPago?: (data: DatosPago) => Promise<unknown>;
   onEntregarSinCobrar?: (pedido: PedidoDB) => void | Promise<void>;
+  /**
+   * Multi-rol (mig 155): vuelve a la lista de pedidos. Solo se pasa a quien
+   * tiene las dos pantallas; para el transportista puro el mapa es la única,
+   * así que ahí no hay a dónde volver.
+   */
+  onVolver?: () => void;
 }
 
 export default function RutaActivaTransportista({
@@ -58,6 +64,7 @@ export default function RutaActivaTransportista({
   onRegistrarSalvedad,
   onRegistrarPago,
   onEntregarSinCobrar,
+  onVolver,
 }: RutaActivaTransportistaProps): React.ReactElement {
   const { isOnline } = useAuthData();
   const deposito = useDepositoCoords();
@@ -327,13 +334,25 @@ export default function RutaActivaTransportista({
             />
           </div>
         ) : (
-          <div className="pointer-events-auto rounded-2xl bg-white/95 px-4 py-2.5 shadow-lg backdrop-blur dark:bg-gray-800/95">
-            <p className="text-sm font-bold text-gray-900 dark:text-white">
-              {completadas}/{pedidosOrdenados.length} entregas
-            </p>
-            <p className="text-xs text-gray-500 dark:text-gray-400">
-              {formatPrecio(porCobrar)} por cobrar
-            </p>
+          <div className="pointer-events-auto flex min-w-0 flex-col items-start gap-2">
+            {/* Solo multi-rol: el que ademas vende vuelve a su lista de pedidos. */}
+            {onVolver && (
+              <button
+                onClick={onVolver}
+                className="inline-flex items-center gap-1.5 rounded-full bg-white/95 px-3 py-1.5 text-sm font-medium text-gray-700 shadow-lg backdrop-blur transition-colors hover:bg-white dark:bg-gray-800/95 dark:text-gray-200 dark:hover:bg-gray-800"
+              >
+                <ArrowLeft className="h-4 w-4" aria-hidden="true" />
+                Lista
+              </button>
+            )}
+            <div className="rounded-2xl bg-white/95 px-4 py-2.5 shadow-lg backdrop-blur dark:bg-gray-800/95">
+              <p className="text-sm font-bold text-gray-900 dark:text-white">
+                {completadas}/{pedidosOrdenados.length} entregas
+              </p>
+              <p className="text-xs text-gray-500 dark:text-gray-400">
+                {formatPrecio(porCobrar)} por cobrar
+              </p>
+            </div>
           </div>
         )}
         {guiando ? (

--- a/src/components/rutaActiva/RutaActivaTransportista.tsx
+++ b/src/components/rutaActiva/RutaActivaTransportista.tsx
@@ -420,6 +420,7 @@ export default function RutaActivaTransportista({
           cliente={entrega.pedidoParaCobrar.cliente}
           saldoPendiente={(entrega.pedidoParaCobrar.total || 0) - (entrega.pedidoParaCobrar.monto_pagado || 0)}
           pedidos={[entrega.pedidoParaCobrar as unknown as import('../../types').Pedido]}
+          pedidoIdFijo={String(entrega.pedidoParaCobrar.id)}
           onClose={entrega.cerrarModalPago}
           onConfirmar={entrega.confirmarPago}
           onEntregarSinCobrar={onEntregarSinCobrar ? entrega.entregarSinCobrar : undefined}

--- a/src/components/vistas/VistaPedidos.tsx
+++ b/src/components/vistas/VistaPedidos.tsx
@@ -42,6 +42,16 @@ export interface VistaPedidosProps {
   isTransportista: boolean;
   isEncargado?: boolean;
   isPreventistaTaco?: boolean;
+  /**
+   * Multi-rol (mig 155): el usuario tiene la lista Y el mapa de la ruta, y
+   * alterna con el botón "Mi ruta". El transportista puro no lo usa: para él
+   * el mapa sigue siendo la pantalla única.
+   */
+  modoRuta?: boolean;
+  onVerMiRuta?: () => void;
+  onSalirDeRuta?: () => void;
+  /** Paradas sin entregar de hoy, para el badge del botón "Mi ruta". */
+  paradasPendientes?: number;
   userId: string;
   clientes: ClienteDB[];
   productos: ProductoDB[];
@@ -148,10 +158,23 @@ export default function VistaPedidos({
   onRegistrarPago,
   onAbrirPagoPedido,
   onEntregarSinCobrar,
+  modoRuta,
+  onVerMiRuta,
+  onSalirDeRuta,
+  paradasPendientes,
 }: VistaPedidosProps) {
+  // Transportista puro: el mapa es su pantalla unica, sin toolbar ni lista.
+  // Se mantiene tal cual estaba. El `!isEncargado` es no-op hoy (un encargado
+  // no puede tener el rol extra), pero evita que si algun dia lo tuviera
+  // perdiera toda la pantalla de Pedidos.
+  const esTransportistaPuro = isTransportista && !isAdmin && !isPreventista && !isEncargado;
+
+  // Multi-rol (mig 155): tiene las dos pantallas y alterna con "Mi ruta".
+  const puedeAlternarRuta = isTransportista && !esTransportistaPuro && !!onVerMiRuta;
+
   // Si es transportista, mostrar la pantalla map-first "Ruta Activa"
   // (reemplaza a VistaRutaTransportista; el flujo de entrega es el mismo).
-  if (isTransportista && !isAdmin && !isPreventista) {
+  if (esTransportistaPuro || (puedeAlternarRuta && modoRuta)) {
     return (
       <RutaActivaTransportista
         onMarcarEntregado={onMarcarEntregado}
@@ -159,6 +182,7 @@ export default function VistaPedidos({
         onRegistrarSalvedad={onRegistrarSalvedad}
         onRegistrarPago={onRegistrarPago}
         onEntregarSinCobrar={onEntregarSinCobrar}
+        onVolver={esTransportistaPuro ? undefined : onSalirDeRuta}
       />
     );
   }
@@ -187,6 +211,8 @@ export default function VistaPedidos({
             onEntregaYPagoMasivos={onEntregaYPagoMasivos}
             onMarcarVisita={onMarcarVisita}
             onVerVisitasHoy={onVerVisitasHoy}
+            onVerMiRuta={puedeAlternarRuta ? onVerMiRuta : undefined}
+            paradasPendientes={paradasPendientes}
           />
         }
       />

--- a/src/contexts/AuthDataContext.tsx
+++ b/src/contexts/AuthDataContext.tsx
@@ -5,7 +5,7 @@
  * Reemplaza AppDataContext para evitar cargar todos los datos globalmente.
  */
 import React, { createContext, useContext, ReactNode } from 'react'
-import type { PerfilDB } from '../types'
+import type { PerfilDB, RolUsuario } from '../types'
 
 // =============================================================================
 // TYPES
@@ -22,6 +22,12 @@ export interface AuthDataContextValue {
   isTransportista: boolean
   isEncargado: boolean
   isAdminOrEncargado: boolean
+  /**
+   * Rol primario en la sucursal activa + capacidades extra (mig 155).
+   * Para gating de NAVEGACIÓN (qué pantallas ve). Los permisos sensibles se
+   * siguen evaluando contra `perfil.rol` vía src/lib/permisos.ts.
+   */
+  rolesEfectivos: RolUsuario[]
   isOnline: boolean
   logout: () => Promise<void>
   currentSucursalId: number | null
@@ -72,8 +78,8 @@ export function useAuthData(): AuthDataContextValue {
  */
 // eslint-disable-next-line react-refresh/only-export-components
 export function useUserPermissions() {
-  const { user, perfil, isAdmin, isPreventista, isPreventistaTaco, isAnyPreventista, isTransportista, isEncargado, isAdminOrEncargado } = useAuthData()
-  return { user, perfil, isAdmin, isPreventista, isPreventistaTaco, isAnyPreventista, isTransportista, isEncargado, isAdminOrEncargado }
+  const { user, perfil, isAdmin, isPreventista, isPreventistaTaco, isAnyPreventista, isTransportista, isEncargado, isAdminOrEncargado, rolesEfectivos } = useAuthData()
+  return { user, perfil, isAdmin, isPreventista, isPreventistaTaco, isAnyPreventista, isTransportista, isEncargado, isAdminOrEncargado, rolesEfectivos }
 }
 
 export default AuthDataContext

--- a/src/contexts/SucursalContext.tsx
+++ b/src/contexts/SucursalContext.tsx
@@ -10,17 +10,27 @@ export interface SucursalInfo {
   id: number
   nombre: string
   rol: RolUsuario // resolved role for this sucursal
+  /**
+   * Capacidades operativas EXTRA en esta sucursal (tabla perfil_roles, mig 155).
+   * Se SUMAN a `rol`; no lo reemplazan. Caso de uso: el preventista de Taco Pozo
+   * que acompaña al camión y también reparte.
+   */
+  rolesExtra: RolUsuario[]
 }
 
 export interface SucursalContextValue {
   currentSucursalId: number | null
   currentSucursalNombre: string | null
   currentSucursalRol: RolUsuario | null
+  /** Roles extra en la sucursal activa. Ver SucursalInfo.rolesExtra. */
+  currentSucursalRolesExtra: RolUsuario[]
   sucursales: SucursalInfo[]
   loading: boolean
   hasMultipleSucursales: boolean
   switchSucursal: (sucursalId: number) => Promise<void>
 }
+
+const SIN_ROLES_EXTRA: RolUsuario[] = []
 
 const SucursalContext = createContext<SucursalContextValue | null>(null)
 
@@ -51,10 +61,32 @@ export function SucursalProvider({ children, userId, globalRol }: SucursalProvid
     const loadSucursales = async () => {
       setLoading(true)
       try {
-        const { data, error } = await supabase
-          .from('usuario_sucursales')
-          .select('id, usuario_id, sucursal_id, rol, es_default, sucursal:sucursales(id, nombre)')
-          .eq('usuario_id', userId)
+        // Los roles extra se piden SIN filtrar por sucursal: la policy
+        // perfil_roles_select_propio no depende del header X-Sucursal-ID, que
+        // en este punto todavia no esta seteado (se setea mas abajo).
+        const [{ data, error }, rolesExtraRes] = await Promise.all([
+          supabase
+            .from('usuario_sucursales')
+            .select('id, usuario_id, sucursal_id, rol, es_default, sucursal:sucursales(id, nombre)')
+            .eq('usuario_id', userId),
+          supabase
+            .from('perfil_roles')
+            .select('sucursal_id, rol')
+            .eq('usuario_id', userId),
+        ])
+
+        // Tolerante a fallo a proposito: este contexto bloquea el arranque de
+        // la app. Sin roles extra el usuario entra con su rol primario, que es
+        // exactamente el comportamiento previo a la mig 155.
+        if (rolesExtraRes.error) {
+          logger.warn('[SucursalContext] No se pudieron cargar los roles extra:', rolesExtraRes.error)
+        }
+        const rolesExtraPorSucursal = new Map<number, RolUsuario[]>()
+        for (const fila of (rolesExtraRes.data ?? []) as Array<{ sucursal_id: number; rol: string }>) {
+          const acumulado = rolesExtraPorSucursal.get(fila.sucursal_id) ?? []
+          acumulado.push(fila.rol as RolUsuario)
+          rolesExtraPorSucursal.set(fila.sucursal_id, acumulado)
+        }
 
         if (error) {
           logger.error('[SucursalContext] Error loading sucursales:', error)
@@ -82,6 +114,7 @@ export function SucursalProvider({ children, userId, globalRol }: SucursalProvid
             id: us.sucursal_id,
             nombre: sucNombre,
             rol: resolvedRol,
+            rolesExtra: rolesExtraPorSucursal.get(us.sucursal_id) ?? SIN_ROLES_EXTRA,
           }
         })
 
@@ -147,6 +180,7 @@ export function SucursalProvider({ children, userId, globalRol }: SucursalProvid
       currentSucursalId,
       currentSucursalNombre: currentSucursal?.nombre ?? null,
       currentSucursalRol: currentSucursal?.rol ?? globalRol,
+      currentSucursalRolesExtra: currentSucursal?.rolesExtra ?? SIN_ROLES_EXTRA,
       sucursales,
       loading,
       hasMultipleSucursales: sucursales.length > 1,

--- a/src/hooks/queries/index.ts
+++ b/src/hooks/queries/index.ts
@@ -87,6 +87,8 @@ export {
   useTransportistasQuery,
   usePreventistasQuery,
   usePreventistasAsignablesQuery,
+  usePerfilRolesQuery,
+  useAsignarPerfilRolesMutation,
   useActualizarUsuarioMutation,
   useToggleUsuarioActivoMutation,
 } from './useUsuariosQuery'

--- a/src/hooks/queries/useUsuariosQuery.ts
+++ b/src/hooks/queries/useUsuariosQuery.ts
@@ -25,6 +25,8 @@ export const usuariosKeys = {
   transportistas: (sucursalId: number | null) => [...usuariosKeys.all(sucursalId), 'transportistas'] as const,
   preventistas: (sucursalId: number | null) => [...usuariosKeys.all(sucursalId), 'preventistas'] as const,
   preventistasAsignables: (sucursalId: number | null) => [...usuariosKeys.all(sucursalId), 'preventistasAsignables'] as const,
+  rolesExtra: (sucursalId: number | null, id: string) =>
+    [...usuariosKeys.all(sucursalId), 'rolesExtra', id] as const,
 }
 
 // Types
@@ -79,18 +81,63 @@ async function fetchUsuariosByRol(sucursalId: number | null, rol: string): Promi
   return (data as PerfilDB[]) || []
 }
 
+// Quien puede recibir la ruta del dia: el rol primario `transportista` MAS
+// quien tenga esa capacidad extra en la sucursal (perfil_roles, mig 155) — el
+// preventista que acompaña al camion. Por eso no se puede filtrar con
+// .eq('rol', 'transportista'): traemos los activos de la sucursal (son pocos,
+// menos de 15 por sucursal) y resolvemos el rol efectivo en memoria.
 async function fetchTransportistas(sucursalId: number | null): Promise<PerfilDB[]> {
   if (!sucursalId) return []
   const { data, error } = await supabase
     .from('perfiles')
-    .select('*, usuario_sucursales!inner(sucursal_id)')
-    .eq('rol', 'transportista')
+    .select('*, usuario_sucursales!inner(sucursal_id), perfil_roles(rol, sucursal_id)')
     .eq('activo', true)
     .eq('usuario_sucursales.sucursal_id', sucursalId)
     .order('nombre')
 
   if (error) throw error
-  return (data as PerfilDB[]) || []
+
+  type ConRolesExtra = PerfilDB & { perfil_roles?: Array<{ rol: string; sucursal_id: number }> }
+  return ((data ?? []) as ConRolesExtra[]).filter(p =>
+    p.rol === 'transportista'
+    || (p.perfil_roles ?? []).some(r => r.rol === 'transportista' && r.sucursal_id === sucursalId)
+  )
+}
+
+// Roles extra de un usuario en la sucursal activa (mig 155).
+async function fetchPerfilRoles(usuarioId: string, sucursalId: number): Promise<string[]> {
+  const { data, error } = await supabase
+    .from('perfil_roles')
+    .select('rol')
+    .eq('usuario_id', usuarioId)
+    .eq('sucursal_id', sucursalId)
+
+  if (error) throw error
+  return ((data ?? []) as Array<{ rol: string }>).map(r => r.rol)
+}
+
+// Reemplaza el set completo de roles extra del usuario EN ESA SUCURSAL.
+// Delete + insert como en asignarZonasPreventista: son 0..1 filas por usuario,
+// no vale la pena diferenciar altas de bajas.
+async function asignarPerfilRoles(
+  usuarioId: string,
+  sucursalId: number,
+  roles: string[],
+): Promise<void> {
+  const { error: errorDelete } = await supabase
+    .from('perfil_roles')
+    .delete()
+    .eq('usuario_id', usuarioId)
+    .eq('sucursal_id', sucursalId)
+
+  if (errorDelete) throw errorDelete
+  if (roles.length === 0) return
+
+  const { error } = await supabase
+    .from('perfil_roles')
+    .insert(roles.map(rol => ({ usuario_id: usuarioId, sucursal_id: sucursalId, rol })))
+
+  if (error) throw error
 }
 
 async function fetchPreventistas(sucursalId: number | null): Promise<PerfilDB[]> {
@@ -199,6 +246,48 @@ export function useTransportistasQuery() {
     queryFn: () => fetchTransportistas(currentSucursalId),
     enabled: !!currentSucursalId,
     staleTime: 10 * 60 * 1000,
+  })
+}
+
+/**
+ * Roles extra del usuario en la sucursal activa (mig 155). Solo admin/encargado
+ * ven los de otros; cualquiera ve los propios.
+ */
+export function usePerfilRolesQuery(usuarioId: string | undefined) {
+  const { currentSucursalId } = useSucursal()
+  return useQuery({
+    queryKey: usuariosKeys.rolesExtra(currentSucursalId, usuarioId || ''),
+    queryFn: () => fetchPerfilRoles(usuarioId!, currentSucursalId!),
+    enabled: !!usuarioId && !!currentSucursalId,
+    staleTime: 5 * 60 * 1000,
+  })
+}
+
+/**
+ * Reemplaza los roles extra del usuario en la sucursal activa. Solo admin
+ * (lo hace cumplir la policy perfil_roles_write_admin).
+ */
+export function useAsignarPerfilRolesMutation() {
+  const queryClient = useQueryClient()
+  const { currentSucursalId } = useSucursal()
+
+  return useMutation({
+    mutationFn: ({ usuarioId, roles }: { usuarioId: string; roles: string[] }) => {
+      if (!currentSucursalId) {
+        return Promise.reject(new Error('No hay sucursal activa'))
+      }
+      return asignarPerfilRoles(usuarioId, currentSucursalId, roles)
+    },
+    onSuccess: (_data, variables) => {
+      queryClient.invalidateQueries({
+        queryKey: usuariosKeys.rolesExtra(currentSucursalId, variables.usuarioId),
+      })
+      // El picker de "quien lleva la ruta" tiene staleTime de 10 min: sin esta
+      // invalidacion, quien arma la ruta no veria al usuario recien habilitado.
+      queryClient.invalidateQueries({
+        queryKey: usuariosKeys.transportistas(currentSucursalId),
+      })
+    },
   })
 }
 

--- a/src/hooks/useRealtimeInvalidation.test.tsx
+++ b/src/hooks/useRealtimeInvalidation.test.tsx
@@ -49,6 +49,7 @@ vi.mock('../contexts/SucursalContext', () => ({
     currentSucursalId: 1,
     currentSucursalNombre: 'Test',
     currentSucursalRol: 'admin',
+    currentSucursalRolesExtra: [],
     sucursales: [],
     loading: false,
     hasMultipleSucursales: false,

--- a/src/lib/permisos.test.ts
+++ b/src/lib/permisos.test.ts
@@ -12,6 +12,7 @@ import {
   puedeAccederCondicionesMayoristas,
   puedeAccederTransferencias,
   puedeControlarStock,
+  puedeRegistrarPagoCliente,
   mostrarMontosEnStats,
 } from './permisos'
 import type { RolUsuario } from '@/types'
@@ -90,6 +91,29 @@ describe('permisos por rol', () => {
     it('otros roles ven monto en todas (sin restriccion)', () => {
       expect(mostrarMontosEnStats('preventista', 'pendientes')).toBe(true)
       expect(mostrarMontosEnStats('transportista', 'entregados')).toBe(true)
+    })
+  })
+
+  // Fija el invariante de la mig 155: el multi-rol (roles extra por sucursal)
+  // habilita llevar la ruta, entregar y cobrar LA PARADA, pero NO el pago a
+  // cuenta corriente desde la ficha del cliente. Este gate es el espejo en la
+  // UI de los RPC registrar_pago_cliente_fifo / ..._combinado_..., que leen
+  // perfiles.rol crudo y exigen admin|encargado. Si alguien "arregla" esta
+  // funcion para aceptar roles efectivos, la UI mostraria un boton que el
+  // servidor rechaza.
+  describe('puedeRegistrarPagoCliente (pago a cuenta corriente por ficha)', () => {
+    it('permite solo admin y encargado', () => {
+      expect(puedeRegistrarPagoCliente('admin')).toBe(true)
+      expect(puedeRegistrarPagoCliente('encargado')).toBe(true)
+    })
+
+    it('bloquea al preventista que tambien reparte y al transportista', () => {
+      expect(puedeRegistrarPagoCliente('preventista')).toBe(false)
+      expect(puedeRegistrarPagoCliente('preventista_taco')).toBe(false)
+      expect(puedeRegistrarPagoCliente('transportista')).toBe(false)
+      expect(puedeRegistrarPagoCliente('deposito')).toBe(false)
+      expect(puedeRegistrarPagoCliente(null)).toBe(false)
+      expect(puedeRegistrarPagoCliente(undefined)).toBe(false)
     })
   })
 })

--- a/src/lib/permisos.ts
+++ b/src/lib/permisos.ts
@@ -3,6 +3,16 @@
  *
  * Reglas de negocio puras: dado un rol devuelve si la accion esta permitida.
  * No usar hooks ni contexto: se consumen desde containers que ya tienen el rol.
+ *
+ * INVARIANTE (mig 155): estas funciones se evaluan SIEMPRE contra el rol
+ * PRIMARIO (`perfil.rol`), nunca contra los roles efectivos/extra de
+ * `useAuthData().rolesEfectivos`. Los roles extra son capacidades operativas
+ * (llevar la ruta, entregar, cobrar la parada) y solo gatean NAVEGACION.
+ *
+ * El caso que lo obliga: `puedeRegistrarPagoCliente` es el espejo en la UI del
+ * gate de los RPC `registrar_pago_cliente_fifo` / `..._combinado_...`, que leen
+ * `perfiles.rol` crudo y exigen admin|encargado. Si a estas funciones se les
+ * pasara un rol efectivo, la UI mostraria un boton que el servidor rechaza.
  */
 
 import type { RolUsuario } from '@/types'


### PR DESCRIPTION
En Taco Pozo el preventista (Juan) acompaña al camión: vende, entrega y cobra en la misma parada. Como `perfiles.rol` es escalar, o es preventista o es transportista — hoy carga el pedido pero no ve la ruta, no marca entregado ni cobrado.

## Por qué no un rol nuevo

Era la alternativa obvia y es la que ya falló: `preventista_taco` quedó con 6 funciones en `permisos.ts`, gating disperso por dashboard/stats/cards, el menú vacío en `TopNavigation` y **0 usuarios en prod**. Cada combinación futura sería otro rol con su propia deuda.

Tampoco un selector de perfil ("hoy soy transportista"): el preventista hace las dos cosas **en la misma parada** — toma el pedido nuevo y entrega el de la semana pasada — así que estaría cambiando de perfil todo el día. El permiso es la unión; lo que se alterna es la pantalla.

## El modelo

> `perfiles.rol` sigue siendo **identidad/puesto**. La tabla nueva `perfil_roles` son **capacidades operativas** que se suman, y afecta **exclusivamente** a `es_preventista()` y `es_transportista()`.

De ahí sale la propiedad que hace que esto no rompa nada: todo lo que lee `perfiles.rol` **crudo** no cambia de comportamiento sin escribir una línea — los RPC FIFO, `es_admin()`, `es_encargado_o_admin()`, `mt_clientes_select`, las policies de `deposito`. Por eso **el pago a cuenta corriente desde la ficha sigue vedado al multi-rol**, y eso se comprueba con una query en vez de confiar en la revisión.

En ambos helpers el cambio es aditivo: el `EXISTS` original queda intacto y se agrega un segundo `RETURN`. El `IF/RETURN` (en vez de `RETURN a OR b`) garantiza el corto-circuito, así que admin, preventista y encargado no pagan el lookup extra.

El CHECK acepta **solo `'transportista'`** a propósito: `'deposito'` sería letra muerta (no existe `es_deposito()`) y `'preventista'` abriría `pagos` SELECT de toda la sucursal. `'admin'`/`'encargado'` quedan afuera para que esto nunca sea escalada de privilegios.

## Hallazgo: el cobro del chofer era una regresión, no una feature

Marcos registró **215 pagos entre el 14/01 y el 21/04**, todos correctamente imputados. La migración `058_multi_tenant_rls` se aplicó el **20/04** y trajo `mt_pagos_insert` con `es_preventista()`, que no incluye `transportista` — último pago de Marcos el 21/04, nunca más. Desde el 02/05 la oficina absorbió el trabajo (1740 pagos de Virginia) sin que se reportara como bug.

Al desplegar esto, **Marcos y nachovir recuperan el cobro en la calle**, sin necesidad de tocar ningún checkbox.

## Un bug preexistente que había que arreglar sí o sí

`ModalRegistrarPago` mandaba `pedido_id: null` al cobrar desde la ruta (el combo arranca en "Pago a cuenta general"), dejando el pedido **entregado e impago**. Sin ese fix, rehabilitar el cobro habría dejado la rendición 100% en cuenta corriente: el 20/04 fueron **$1.806.480 en entregas contra $31.700 en cta.cte** — se habrían visto $0 y $1.838.180.

Va en su propio commit y **se puede mergear solo**.

## Verificación

La migración **ya está aplicada en prod** (`20260730151235 · perfil_roles`) y se aplicó **vacía**: cero cambio de comportamiento hasta que un admin tilde el checkbox.

| Qué | Resultado |
|---|---|
| Transportista cobra su parada / a cuenta / pedido de otro chofer (RLS real, `SET LOCAL ROLE authenticated`) | **PERMITIDO / RECHAZADO / RECHAZADO** |
| Multi-rol **con** la capacidad puesta intenta pago FIFO por ficha | `RECHAZADO: solo admin o encargado` |
| `es_transportista()` antes → después → en otra sucursal | `false → true → false` (fail-closed) |
| Funciones que leen `perfil_roles` | exactamente 3 |
| Policies afectadas por los helpers | 11, todas enumeradas |
| Suite / typecheck / lint / build | 935 tests, 0 errores, limpio, build OK |

Todas las pruebas corrieron en transacción con `ROLLBACK`: la tabla quedó en 0 filas y no se creó ningún pago.

## Después del merge

1. Pararse en **Taco Pozo** con el selector de sucursal (el checkbox aplica a la sucursal activa).
2. Usuarios → Juan → tildar **"Puede llevar la ruta (transportista)"**.
3. Juan **cierra y abre la app** (`perfil_roles` no está en `useRealtimeInvalidation`).
4. Armar la ruta a nombre de Juan.

Para revertir: destildar. Es borrar una fila, sin deploy ni migración.

**Aviso operativo:** la rendición de Taco Pozo va a pasar a nombre de Juan; lo histórico queda bajo "Transporte Taco Pozo". Conviene avisarle a Pablo y a Jony. La estructura del reporte no cambia — verifiqué que hoy ya agrupa por el transportista del pedido, no por quien carga el pago; lo único que cambia es la columna `cobrado_por` del detalle, que gana precisión.

## Coordinación con la migración 156

Hay una rama paralela que elimina `preventista_taco` y hace `CREATE OR REPLACE` de `es_preventista()`. Verifiqué que **hoy los helpers en prod conservan `tiene_rol_extra`**, pero si esa migración se aplica copiando el cuerpo de la mig 055 en vez de leer la definición viva, **revierte este multi-rol en silencio**. Al mergear ambas, chequear que `es_preventista()` siga mencionando `tiene_rol_extra`. También habrá conflicto en `permisos.test.ts` y en el `EXISTS` de la mig 155, que referencian `preventista_taco`.

## Fuera de alcance

- `preventista_taco` con el menú vacío — se está tratando en la rama paralela.
- El guard de caja protege los *pagos* de una fecha cerrada pero no los *pedidos*: revertir una entrega de un día confirmado recalcula el split entregas/cta.cte sin dejar rastro. Preexistente.
- `actualizar_orden_entrega_batch` / `limpiar_orden_entrega` gatean por rol sin filtrar por dueño. Ya pasa hoy con Marcos, no es regresión de este cambio.

## Lo que no pude verificar

La prueba visual en el navegador: el worktree no tiene `.env`, y pasar del login requiere credenciales reales. La tabla de pruebas funcionales de arriba queda para hacer en el ambiente real.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
