### PR TITLE
refactor(roles): eliminar preventista_taco, que dejaba el menú vacío

### DIFF
--- a/migrations/156_eliminar_rol_preventista_taco.sql
+++ b/migrations/156_eliminar_rol_preventista_taco.sql
@@ -1,0 +1,304 @@
+-- =========================================================================
+-- 156_eliminar_rol_preventista_taco.sql
+--
+-- Elimina el rol `preventista_taco` (agregado por la mig 050, propagado por
+-- la 055). Tiene 0 usuarios en produccion y arrastraba un bug: `menuGroups`
+-- en TopNavigation.tsx nunca lo listo en ningun `roles[]`, asi que un usuario
+-- con ese rol veia el menu COMPLETAMENTE VACIO -- ni siquiera Pedidos.
+--
+-- El rol era "preventista que no ve plata": su unica diferencia funcional con
+-- `preventista` era ocultar montos, saldos e historial de compras. Ese caso de
+-- uso, si vuelve a hacer falta, hoy se modela como capacidad en `perfil_roles`
+-- (mig 155) y no como un rol compuesto nuevo -- que es justamente el motivo por
+-- el que se creo esa tabla.
+--
+-- QUE HACE
+--   1. Guarda: aborta si algun perfil todavia tiene el rol.
+--   2. Achica el CHECK `perfiles_rol_check`.
+--   3. Barre el literal de TODA funcion de `public` que lo mencione.
+--   4. Barre el literal de TODA policy de `public` que lo mencione.
+--   5. Verifica que no quede ni un rastro; si queda, aborta.
+--
+-- POR QUE ES DINAMICA (no hardcodea cuerpos)
+--   `migrations/` es una vista curada y NO es 1:1 con produccion (ver
+--   MANIFEST.md). Los cuerpos de `crear_pedido_completo`,
+--   `actualizar_pedido_items`, `registrar_visita_cliente` y
+--   `obtener_geolocalizacion_preventistas` que estan en la mig 055 fueron
+--   superados despues por las migs 096, 101, 102, 117, 123, 129, 132 y 140;
+--   y `es_preventista()` fue redefinida out-of-band por la mig 155
+--   (`perfil_roles`), que NO esta versionada en este repo.
+--
+--   Copiar cualquiera de esos cuerpos desde los archivos del repo REVERTIRIA
+--   logica viva -- incluido el multi-rol por sucursal. Por eso esta migracion
+--   lee la definicion viva de cada objeto desde el catalogo
+--   (`pg_get_functiondef` / `pg_get_expr`), le saca unicamente el literal
+--   `'preventista_taco'` y la vuelve a crear. El resto del cuerpo se preserva
+--   caracter por caracter, sea cual sea.
+--
+--   Corolario: `perfil_roles` y `es_transportista()` no se tocan. La unica
+--   forma en que esta migracion toca `es_preventista()` es borrandole el
+--   literal muerto; si hoy consulta `perfil_roles`, lo sigue haciendo igual.
+--
+-- SEGURIDAD DEL BARRIDO
+--   Los reemplazos solo contemplan el literal como elemento de una lista
+--   (`IN (...)` / `= ANY (ARRAY[...])`), que es la unica forma en que aparece.
+--   Si en produccion existiera bajo otra forma (por ejemplo
+--   `rol = 'preventista_taco'`), el paso 5 aborta la transaccion en vez de
+--   dejar el objeto a medio limpiar.
+--
+-- NOTA sobre el bot de Telegram: `bot_usuarios_rol_check` (mig 014) y el tipo
+-- `BotRol` nunca incluyeron este rol, por lo que un preventista_taco jamas
+-- pudo vincular Telegram. Al eliminar el rol esa inconsistencia desaparece
+-- sola y no hay nada que migrar ahi.
+-- =========================================================================
+
+BEGIN;
+
+-- -------------------------------------------------------------------------
+-- 1. Guarda: el rol no puede estar en uso
+-- -------------------------------------------------------------------------
+
+DO $guard$
+DECLARE
+  v_n integer;
+BEGIN
+  SELECT count(*) INTO v_n FROM public.perfiles WHERE rol = 'preventista_taco';
+  IF v_n > 0 THEN
+    RAISE EXCEPTION
+      'Hay % perfil(es) con rol preventista_taco. Reasignalos a preventista antes de correr esta migracion.', v_n;
+  END IF;
+END
+$guard$;
+
+-- -------------------------------------------------------------------------
+-- 2. CHECK perfiles_rol_check: se reconstruye desde la definicion viva
+-- -------------------------------------------------------------------------
+
+DO $chk$
+DECLARE
+  v_def text;
+  v_new text;
+BEGIN
+  SELECT pg_get_constraintdef(c.oid) INTO v_def
+    FROM pg_constraint c
+    JOIN pg_class t ON t.oid = c.conrelid
+    JOIN pg_namespace n ON n.oid = t.relnamespace
+   WHERE n.nspname = 'public' AND t.relname = 'perfiles' AND c.conname = 'perfiles_rol_check';
+
+  IF v_def IS NULL THEN
+    RAISE NOTICE 'perfiles_rol_check no existe; nada que achicar';
+    RETURN;
+  END IF;
+
+  IF position('preventista_taco' in v_def) = 0 THEN
+    RAISE NOTICE 'perfiles_rol_check ya estaba limpio';
+    RETURN;
+  END IF;
+
+  v_new := regexp_replace(v_def, '\s*,\s*''preventista_taco''(::text)?', '', 'g');
+  v_new := regexp_replace(v_new, '''preventista_taco''(::text)?\s*,\s*', '', 'g');
+
+  IF position('preventista_taco' in v_new) > 0 THEN
+    RAISE EXCEPTION 'No se pudo limpiar el literal de perfiles_rol_check: %', v_new;
+  END IF;
+
+  EXECUTE 'ALTER TABLE public.perfiles DROP CONSTRAINT perfiles_rol_check';
+  EXECUTE 'ALTER TABLE public.perfiles ADD CONSTRAINT perfiles_rol_check ' || v_new;
+  RAISE NOTICE 'perfiles_rol_check achicado: %', v_new;
+END
+$chk$;
+
+-- -------------------------------------------------------------------------
+-- 3. Funciones: se recrean con su cuerpo vivo menos el literal
+--
+--    Alcanza (entre otras) a es_preventista(), crear_pedido_completo(),
+--    crear_pedido_completo_bot(), actualizar_pedido_items(),
+--    registrar_visita_cliente() y obtener_geolocalizacion_preventistas(),
+--    sea cual sea la version que hoy este viva en produccion.
+-- -------------------------------------------------------------------------
+
+DO $fns$
+DECLARE
+  v_oids oid[];
+  v_oid  oid;
+  v_def  text;
+  v_new  text;
+  v_n    integer := 0;
+BEGIN
+  -- Se materializa la lista ANTES de tocar nada: el loop modifica pg_proc.
+  SELECT array_agg(p.oid ORDER BY p.proname) INTO v_oids
+    FROM pg_proc p
+    JOIN pg_namespace n ON n.oid = p.pronamespace
+   WHERE n.nspname = 'public'
+     AND p.prokind IN ('f', 'p')
+     AND p.prosrc LIKE '%preventista_taco%';
+
+  IF v_oids IS NULL THEN
+    RAISE NOTICE 'No hay funciones que mencionen el rol';
+    RETURN;
+  END IF;
+
+  FOREACH v_oid IN ARRAY v_oids LOOP
+    v_def := pg_get_functiondef(v_oid);
+
+    v_new := regexp_replace(v_def, '\s*,\s*''preventista_taco''(::text)?', '', 'g');
+    v_new := regexp_replace(v_new, '''preventista_taco''(::text)?\s*,\s*', '', 'g');
+
+    IF position('preventista_taco' in v_new) > 0 THEN
+      RAISE EXCEPTION
+        'No se pudo limpiar el literal de %: aparece fuera de una lista. Revisala a mano.',
+        v_oid::regprocedure;
+    END IF;
+
+    EXECUTE v_new;
+    v_n := v_n + 1;
+    RAISE NOTICE 'Funcion limpiada: %', v_oid::regprocedure;
+  END LOOP;
+
+  RAISE NOTICE 'Funciones limpiadas: %', v_n;
+END
+$fns$;
+
+-- -------------------------------------------------------------------------
+-- 4. Policies: se recrean con su expresion viva menos el literal
+--
+--    En el repo la unica afectada es `mt_clientes_select` sobre `clientes`
+--    (mig 055), pero el barrido es generico por si produccion derivo.
+-- -------------------------------------------------------------------------
+
+DO $pols$
+DECLARE
+  v_oids   oid[];
+  v_oid    oid;
+  r        record;
+  v_qual   text;
+  v_check  text;
+  v_roles  text;
+  v_cmd    text;
+  v_sql    text;
+  v_n      integer := 0;
+BEGIN
+  -- Se materializa la lista ANTES de tocar nada: el loop modifica pg_policy.
+  SELECT array_agg(pol.oid ORDER BY pol.polname) INTO v_oids
+    FROM pg_policy pol
+    JOIN pg_class c     ON c.oid = pol.polrelid
+    JOIN pg_namespace n ON n.oid = c.relnamespace
+   WHERE n.nspname = 'public'
+     AND (COALESCE(pg_get_expr(pol.polqual, pol.polrelid), '')      LIKE '%preventista_taco%'
+       OR COALESCE(pg_get_expr(pol.polwithcheck, pol.polrelid), '') LIKE '%preventista_taco%');
+
+  IF v_oids IS NULL THEN
+    RAISE NOTICE 'No hay policies que mencionen el rol';
+    RETURN;
+  END IF;
+
+  FOREACH v_oid IN ARRAY v_oids LOOP
+    SELECT pol.polname,
+           pol.polcmd,
+           pol.polpermissive,
+           pol.polroles,
+           n.nspname,
+           c.relname,
+           pg_get_expr(pol.polqual, pol.polrelid)      AS qual,
+           pg_get_expr(pol.polwithcheck, pol.polrelid) AS withcheck
+      INTO r
+      FROM pg_policy pol
+      JOIN pg_class c     ON c.oid = pol.polrelid
+      JOIN pg_namespace n ON n.oid = c.relnamespace
+     WHERE pol.oid = v_oid;
+
+    v_qual  := r.qual;
+    v_check := r.withcheck;
+
+    v_qual := regexp_replace(v_qual, '\s*,\s*''preventista_taco''(::text)?', '', 'g');
+    v_qual := regexp_replace(v_qual, '''preventista_taco''(::text)?\s*,\s*', '', 'g');
+    v_check := regexp_replace(v_check, '\s*,\s*''preventista_taco''(::text)?', '', 'g');
+    v_check := regexp_replace(v_check, '''preventista_taco''(::text)?\s*,\s*', '', 'g');
+
+    IF position('preventista_taco' in COALESCE(v_qual, '')) > 0
+       OR position('preventista_taco' in COALESCE(v_check, '')) > 0 THEN
+      RAISE EXCEPTION
+        'No se pudo limpiar el literal de la policy % sobre %.%. Revisala a mano.',
+        r.polname, r.nspname, r.relname;
+    END IF;
+
+    v_cmd := CASE r.polcmd
+               WHEN 'r' THEN 'SELECT'
+               WHEN 'a' THEN 'INSERT'
+               WHEN 'w' THEN 'UPDATE'
+               WHEN 'd' THEN 'DELETE'
+               ELSE 'ALL'
+             END;
+
+    -- polroles = {0} significa PUBLIC
+    IF r.polroles = '{0}'::oid[] THEN
+      v_roles := 'PUBLIC';
+    ELSE
+      SELECT string_agg(quote_ident(rolname), ', ')
+        INTO v_roles
+        FROM pg_roles
+       WHERE oid = ANY (r.polroles);
+    END IF;
+
+    v_sql := format('CREATE POLICY %I ON %I.%I AS %s FOR %s TO %s',
+                    r.polname, r.nspname, r.relname,
+                    CASE WHEN r.polpermissive THEN 'PERMISSIVE' ELSE 'RESTRICTIVE' END,
+                    v_cmd, COALESCE(v_roles, 'PUBLIC'));
+
+    IF v_qual IS NOT NULL THEN
+      v_sql := v_sql || format(' USING (%s)', v_qual);
+    END IF;
+    IF v_check IS NOT NULL THEN
+      v_sql := v_sql || format(' WITH CHECK (%s)', v_check);
+    END IF;
+
+    EXECUTE format('DROP POLICY %I ON %I.%I', r.polname, r.nspname, r.relname);
+    EXECUTE v_sql;
+    v_n := v_n + 1;
+    RAISE NOTICE 'Policy limpiada: % sobre %.%', r.polname, r.nspname, r.relname;
+  END LOOP;
+
+  RAISE NOTICE 'Policies limpiadas: %', v_n;
+END
+$pols$;
+
+-- -------------------------------------------------------------------------
+-- 5. Verificacion final: no debe quedar ni un rastro
+-- -------------------------------------------------------------------------
+
+DO $verify$
+DECLARE
+  v_fns   integer;
+  v_pols  integer;
+  v_chk   integer;
+  v_rows  integer;
+BEGIN
+  SELECT count(*) INTO v_fns
+    FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace
+   WHERE n.nspname = 'public' AND p.prosrc LIKE '%preventista_taco%';
+
+  SELECT count(*) INTO v_pols
+    FROM pg_policy pol JOIN pg_class c ON c.oid = pol.polrelid
+    JOIN pg_namespace n ON n.oid = c.relnamespace
+   WHERE n.nspname = 'public'
+     AND (COALESCE(pg_get_expr(pol.polqual, pol.polrelid), '')      LIKE '%preventista_taco%'
+       OR COALESCE(pg_get_expr(pol.polwithcheck, pol.polrelid), '') LIKE '%preventista_taco%');
+
+  SELECT count(*) INTO v_chk
+    FROM pg_constraint c JOIN pg_class t ON t.oid = c.conrelid
+    JOIN pg_namespace n ON n.oid = t.relnamespace
+   WHERE n.nspname = 'public' AND pg_get_constraintdef(c.oid) LIKE '%preventista_taco%';
+
+  SELECT count(*) INTO v_rows FROM public.perfiles WHERE rol = 'preventista_taco';
+
+  IF v_fns > 0 OR v_pols > 0 OR v_chk > 0 OR v_rows > 0 THEN
+    RAISE EXCEPTION
+      'Quedaron rastros de preventista_taco: % funcion(es), % policy(s), % constraint(s), % fila(s)',
+      v_fns, v_pols, v_chk, v_rows;
+  END IF;
+
+  RAISE NOTICE 'OK: el rol preventista_taco fue eliminado por completo';
+END
+$verify$;
+
+COMMIT;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -204,8 +204,6 @@ function MainAppInner({ user, perfil, logout, authReady }: {
   const effectiveRol = currentSucursalRol ?? perfil?.rol
   const isAdmin = effectiveRol === 'admin'
   const isPreventista = effectiveRol === 'preventista'
-  const isPreventistaTaco = effectiveRol === 'preventista_taco'
-  const isAnyPreventista = isPreventista || isPreventistaTaco
   const isTransportista = effectiveRol === 'transportista'
   const isEncargado = effectiveRol === 'encargado'
   const isAdminOrEncargado = isAdmin || isEncargado
@@ -218,8 +216,6 @@ function MainAppInner({ user, perfil, logout, authReady }: {
     authReady,
     isAdmin,
     isPreventista,
-    isPreventistaTaco,
-    isAnyPreventista,
     isTransportista,
     isEncargado,
     isAdminOrEncargado,
@@ -227,7 +223,7 @@ function MainAppInner({ user, perfil, logout, authReady }: {
     logout: handleLogout,
     currentSucursalId,
     currentSucursalNombre,
-  }), [user, perfil, authReady, isAdmin, isPreventista, isPreventistaTaco, isAnyPreventista, isTransportista, isEncargado, isAdminOrEncargado, isOnline, handleLogout, currentSucursalId, currentSucursalNombre])
+  }), [user, perfil, authReady, isAdmin, isPreventista, isTransportista, isEncargado, isAdminOrEncargado, isOnline, handleLogout, currentSucursalId, currentSucursalNombre])
 
   const handleRetrySync = useCallback(async () => {
     await refreshPendingOperations()
@@ -255,7 +251,7 @@ function MainAppInner({ user, perfil, logout, authReady }: {
 
                 <Route
                   path="/dashboard"
-                  element={(isAdmin || isAnyPreventista) ? <DashboardContainer /> : <Navigate to="/pedidos" replace />}
+                  element={(isAdmin || isPreventista) ? <DashboardContainer /> : <Navigate to="/pedidos" replace />}
                 />
 
                 <Route path="/pedidos" element={<PedidosContainer />} />

--- a/src/components/clientes/ClienteStats.tsx
+++ b/src/components/clientes/ClienteStats.tsx
@@ -3,16 +3,10 @@
  *
  * Cálculos in-memory sobre el array completo de clientes (no paginado), que
  * ya está cargado en RAM. Diseño editorial cálido — gemelo a PedidoStats.
- *
- * Gating:
- *  - Si el rol no puede ver saldos (preventista_taco), se ocultan las tarjetas
- *    "Con deuda", "Al día" y "Saldo adeudado".
  */
 import React, { memo, useMemo } from 'react';
 import { Users, AlertTriangle, Check, DollarSign, MapPin, Tag, type LucideIcon } from 'lucide-react';
 import { formatPrecio } from '../../utils/formatters';
-import { puedeVerSaldoCliente } from '../../lib/permisos';
-import { useAuthData } from '../../contexts/AuthDataContext';
 import type { ClienteDB } from '../../types';
 
 export interface ClienteStatsProps {
@@ -30,14 +24,9 @@ interface StatItem {
   badgeBg: string;
   badgeIcon: string;
   gradientFrom: string;
-  /** Si true y el rol no ve saldos, se oculta la card. */
-  requiereSaldo?: boolean;
 }
 
 function ClienteStats({ clientes }: ClienteStatsProps): React.ReactElement {
-  const { perfil } = useAuthData();
-  const verSaldo = puedeVerSaldoCliente(perfil?.rol);
-
   const summary = useMemo(() => {
     let conDeuda = 0;
     let alDia = 0;
@@ -89,7 +78,6 @@ function ClienteStats({ clientes }: ClienteStatsProps): React.ReactElement {
       badgeBg: 'bg-rose-100 dark:bg-rose-500/15',
       badgeIcon: 'text-rose-600 dark:text-rose-400',
       gradientFrom: 'before:from-rose-500/[0.07]',
-      requiereSaldo: true,
     },
     {
       key: 'alDia',
@@ -101,7 +89,6 @@ function ClienteStats({ clientes }: ClienteStatsProps): React.ReactElement {
       badgeBg: 'bg-emerald-100 dark:bg-emerald-500/15',
       badgeIcon: 'text-emerald-600 dark:text-emerald-400',
       gradientFrom: 'before:from-emerald-500/[0.07]',
-      requiereSaldo: true,
     },
     {
       key: 'saldoAdeudado',
@@ -114,7 +101,6 @@ function ClienteStats({ clientes }: ClienteStatsProps): React.ReactElement {
       badgeBg: 'bg-amber-100 dark:bg-amber-500/15',
       badgeIcon: 'text-amber-600 dark:text-amber-400',
       gradientFrom: 'before:from-amber-500/[0.07]',
-      requiereSaldo: true,
     },
     {
       key: 'geo',
@@ -140,11 +126,9 @@ function ClienteStats({ clientes }: ClienteStatsProps): React.ReactElement {
     },
   ];
 
-  const visibleItems = items.filter(i => verSaldo || !i.requiereSaldo);
-
   return (
     <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-6 gap-3">
-      {visibleItems.map((item, idx) => {
+      {items.map((item, idx) => {
         const IconComponent = item.icon;
         // Para la card "Saldo adeudado" mostramos el monto como número grande
         // (con peso 800) y el count de clientes como detail.

--- a/src/components/containers/DashboardContainer.tsx
+++ b/src/components/containers/DashboardContainer.tsx
@@ -21,11 +21,11 @@ function LoadingState() {
 }
 
 export default function DashboardContainer(): React.ReactElement {
-  const { user, isAdmin, isPreventista, isPreventistaTaco, isAnyPreventista, isEncargado, authReady } = useAuthData()
+  const { user, isAdmin, isPreventista, isEncargado, authReady } = useAuthData()
 
-  // Determinar si debe filtrar por usuario (preventista y preventista_taco
-  // solo ven sus propios datos)
-  const usuarioFiltro = isAnyPreventista && !isAdmin ? user?.id : null
+  // Determinar si debe filtrar por usuario (el preventista solo ve sus
+  // propios datos)
+  const usuarioFiltro = isPreventista && !isAdmin ? user?.id : null
 
   // Estado local para el filtro de periodo y fechas personalizadas
   const [filtroPeriodo, setFiltroPeriodo] = React.useState('mes')
@@ -78,7 +78,6 @@ export default function DashboardContainer(): React.ReactElement {
         exportando={exportando}
         isAdmin={isAdmin}
         isPreventista={isPreventista}
-        isPreventistaTaco={isPreventistaTaco}
         isEncargado={isEncargado}
         totalClientes={clientes.length}
       />

--- a/src/components/containers/PedidosContainer.tsx
+++ b/src/components/containers/PedidosContainer.tsx
@@ -121,7 +121,7 @@ interface ConfirmConfig {
 
 export default function PedidosContainer(): React.ReactElement {
   const queryClient = useQueryClient()
-  const { user, isAdmin, isPreventista, isPreventistaTaco, isTransportista, isEncargado, isOnline, authReady } = useAuthData()
+  const { user, isAdmin, isPreventista, isTransportista, isEncargado, isOnline, authReady } = useAuthData()
   const notify = useNotification()
 
   // Pagination state
@@ -1557,7 +1557,6 @@ export default function PedidosContainer(): React.ReactElement {
           isPreventista={isPreventista}
           isTransportista={isTransportista}
           isEncargado={isEncargado}
-          isPreventistaTaco={isPreventistaTaco}
           userId={user?.id ?? ''}
           clientes={clientes}
           productos={productos}

--- a/src/components/containers/UsuariosContainer.tsx
+++ b/src/components/containers/UsuariosContainer.tsx
@@ -54,7 +54,7 @@ export default function UsuariosContainer(): React.ReactElement {
           nombre: usuario.nombre,
           rol: usuario.rol,
           activo: usuario.activo,
-          zona: (usuario.rol === 'preventista' || usuario.rol === 'preventista_taco') ? usuario.zona || null : null
+          zona: usuario.rol === 'preventista' ? usuario.zona || null : null
         }
       })
       notify.success('Usuario actualizado')

--- a/src/components/modals/ModalFichaCliente.tsx
+++ b/src/components/modals/ModalFichaCliente.tsx
@@ -6,7 +6,7 @@ import ModalBase from './ModalBase'
 import { useFichaCliente, usePagos } from '../../hooks/supabase'
 import { useAuthData } from '../../contexts/AuthDataContext'
 import { useNotification } from '../../contexts/NotificationContext'
-import { puedeVerSaldoCliente, puedeVerHistorialVentasCliente, puedeRegistrarPagoCliente, puedeAnularPago } from '../../lib/permisos'
+import { puedeRegistrarPagoCliente, puedeAnularPago } from '../../lib/permisos'
 import { formatPrecio as formatCurrency, formatFecha as formatDate, getEstadoColor, getEstadoPagoColor } from '../../utils/formatters'
 import { logger } from '../../utils/logger'
 import type { ClienteDB, PedidoDB, PagoDBWithUsuario, ResumenCuenta, EstadisticasCliente, PedidoClienteWithItems } from '../../types'
@@ -53,8 +53,6 @@ export default function ModalFichaCliente({ cliente, onClose, onRegistrarPago, o
   const notify = useNotification()
   const queryClient = useQueryClient()
   const rol = perfil?.rol
-  const verSaldo = puedeVerSaldoCliente(rol)
-  const verHistorialVentas = puedeVerHistorialVentasCliente(rol)
   const puedeRegistrarPago = puedeRegistrarPagoCliente(rol)
   const puedeAnular = puedeAnularPago(rol)
   const [resumenCuenta, setResumenCuenta] = useState<ResumenCuenta | null>(null)
@@ -174,7 +172,6 @@ export default function ModalFichaCliente({ cliente, onClose, onRegistrarPago, o
           </div>
 
           {/* Account Balance Card */}
-          {verSaldo && (
           <div className={`mt-4 p-4 rounded-xl ${excedido ? 'bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800' : 'bg-blue-50 dark:bg-blue-900/20'}`}>
             <div className="flex items-center justify-between">
               <div>
@@ -234,15 +231,14 @@ export default function ModalFichaCliente({ cliente, onClose, onRegistrarPago, o
               </div>
             )}
           </div>
-          )}
         </div>
 
-        {/* Tabs (taco no ve la pestaña Pagos) */}
+        {/* Tabs */}
         <div className="flex border-b border-gray-200 dark:border-gray-700 px-5">
           {(([
             { id: 'resumen', label: 'Resumen', icon: TrendingUp },
             { id: 'pedidos', label: 'Pedidos', icon: ShoppingBag },
-            ...(verSaldo ? [{ id: 'pagos' as ActiveTab, label: 'Pagos', icon: DollarSign }] : [])
+            { id: 'pagos', label: 'Pagos', icon: DollarSign }
           ]) as TabItem[]).map(tab => (
             <button
               key={tab.id}
@@ -275,22 +271,18 @@ export default function ModalFichaCliente({ cliente, onClose, onRegistrarPago, o
                   value={estadisticas?.totalPedidos || 0}
                   color="blue"
                 />
-                {verHistorialVentas && (
-                  <>
-                    <StatCard
-                      icon={DollarSign}
-                      label="Total Compras"
-                      value={formatCurrency(estadisticas?.totalCompras || 0)}
-                      color="green"
-                    />
-                    <StatCard
-                      icon={TrendingUp}
-                      label="Ticket Promedio"
-                      value={formatCurrency(estadisticas?.ticketPromedio || 0)}
-                      color="purple"
-                    />
-                  </>
-                )}
+                <StatCard
+                  icon={DollarSign}
+                  label="Total Compras"
+                  value={formatCurrency(estadisticas?.totalCompras || 0)}
+                  color="green"
+                />
+                <StatCard
+                  icon={TrendingUp}
+                  label="Ticket Promedio"
+                  value={formatCurrency(estadisticas?.ticketPromedio || 0)}
+                  color="purple"
+                />
                 <StatCard
                   icon={Clock}
                   label="Días sin Comprar"
@@ -299,8 +291,7 @@ export default function ModalFichaCliente({ cliente, onClose, onRegistrarPago, o
                 />
               </div>
 
-              {/* Payment Status (oculto para preventista_taco) */}
-              {verSaldo && (
+              {/* Payment Status */}
               <div className="grid grid-cols-2 gap-4">
                 <div className="p-4 bg-green-50 dark:bg-green-900/20 rounded-xl">
                   <div className="flex items-center gap-2 text-green-600 dark:text-green-400 mb-2">
@@ -323,7 +314,6 @@ export default function ModalFichaCliente({ cliente, onClose, onRegistrarPago, o
                   <p className="text-sm text-yellow-600">{estadisticas?.pedidosPendientes || 0} pedidos</p>
                 </div>
               </div>
-              )}
 
               {/* Favorite Products */}
               {(estadisticas?.productosFavoritos?.length ?? 0) > 0 && estadisticas && (
@@ -346,8 +336,7 @@ export default function ModalFichaCliente({ cliente, onClose, onRegistrarPago, o
                 </div>
               )}
 
-              {/* Credit Info (oculto para preventista_taco) */}
-              {verSaldo && (
+              {/* Credit Info */}
               <div className="p-4 bg-gray-50 dark:bg-gray-700/50 rounded-xl">
                 <h3 className="font-semibold text-gray-900 dark:text-white mb-2 flex items-center gap-2">
                   <CreditCard className="w-5 h-5" />
@@ -374,7 +363,6 @@ export default function ModalFichaCliente({ cliente, onClose, onRegistrarPago, o
                   </div>
                 </div>
               </div>
-              )}
 
               {/* Notas del cliente */}
               {cliente.notas && (
@@ -419,11 +407,9 @@ export default function ModalFichaCliente({ cliente, onClose, onRegistrarPago, o
                         </div>
                       </div>
                       <div className="flex items-center gap-4">
-                        {verHistorialVentas && (
-                          <p className="text-xl font-bold text-gray-900 dark:text-white">
-                            {formatCurrency(pedido.total)}
-                          </p>
-                        )}
+                        <p className="text-xl font-bold text-gray-900 dark:text-white">
+                          {formatCurrency(pedido.total)}
+                        </p>
                         {expandedPedido === pedido.id ? <ChevronUp className="w-5 h-5" /> : <ChevronDown className="w-5 h-5" />}
                       </div>
                     </div>
@@ -434,8 +420,8 @@ export default function ModalFichaCliente({ cliente, onClose, onRegistrarPago, o
                             <tr className="text-gray-500 text-left">
                               <th className="pb-2">Producto</th>
                               <th className="pb-2 text-right">Cant.</th>
-                              {verHistorialVentas && <th className="pb-2 text-right">Precio</th>}
-                              {verHistorialVentas && <th className="pb-2 text-right">Subtotal</th>}
+                              <th className="pb-2 text-right">Precio</th>
+                              <th className="pb-2 text-right">Subtotal</th>
                             </tr>
                           </thead>
                           <tbody>
@@ -443,8 +429,8 @@ export default function ModalFichaCliente({ cliente, onClose, onRegistrarPago, o
                               <tr key={item.id} className="border-t border-gray-100 dark:border-gray-700">
                                 <td className="py-2">{item.producto?.nombre || 'Producto'}</td>
                                 <td className="py-2 text-right">{item.cantidad}</td>
-                                {verHistorialVentas && <td className="py-2 text-right">{formatCurrency(item.precio_unitario)}</td>}
-                                {verHistorialVentas && <td className="py-2 text-right font-medium">{formatCurrency(item.subtotal)}</td>}
+                                <td className="py-2 text-right">{formatCurrency(item.precio_unitario)}</td>
+                                <td className="py-2 text-right font-medium">{formatCurrency(item.subtotal)}</td>
                               </tr>
                             ))}
                           </tbody>

--- a/src/components/modals/ModalUsuario.tsx
+++ b/src/components/modals/ModalUsuario.tsx
@@ -7,7 +7,7 @@ import { useZonasEstandarizadasQuery, usePreventistaZonasQuery, useAsignarZonasP
 import type { PerfilDB } from '../../types';
 
 /** Roles disponibles para usuarios */
-export type RolUsuario = 'admin' | 'preventista' | 'preventista_taco' | 'transportista' | 'deposito' | 'encargado';
+export type RolUsuario = 'admin' | 'preventista' | 'transportista' | 'deposito' | 'encargado';
 
 /** Datos del formulario de usuario */
 export interface UsuarioFormData {
@@ -63,8 +63,8 @@ const ModalUsuario = memo(function ModalUsuario({ usuario, onSave, onClose, guar
     }
   }, [prevZonaIds]);
 
-  // Mostrar campo de zona para preventistas (regular y taco)
-  const mostrarZona = form.rol === 'preventista' || form.rol === 'preventista_taco';
+  // Mostrar campo de zona solo para preventistas
+  const mostrarZona = form.rol === 'preventista';
 
   const handleFieldChange = (field: keyof UsuarioFormData, value: string | boolean): void => {
     setForm({ ...form, [field]: value });
@@ -102,7 +102,7 @@ const ModalUsuario = memo(function ModalUsuario({ usuario, onSave, onClose, guar
     await onSave({ ...form, id: usuario?.id });
 
     // Guardar zonas del preventista en tabla pivot
-    if (usuario?.id && (form.rol === 'preventista' || form.rol === 'preventista_taco')) {
+    if (usuario?.id && form.rol === 'preventista') {
       try {
         await asignarZonasMut.mutateAsync({ perfilId: usuario.id, zonaIds });
       } catch {
@@ -145,7 +145,7 @@ const ModalUsuario = memo(function ModalUsuario({ usuario, onSave, onClose, guar
             value={form.rol}
             onChange={e => {
               const newRol = e.target.value as RolUsuario;
-              const esPreventista = newRol === 'preventista' || newRol === 'preventista_taco';
+              const esPreventista = newRol === 'preventista';
               setForm({ ...form, rol: newRol, zona: esPreventista ? form.zona : '' });
               if (hasAttemptedSubmit && errors.rol) clearFieldError('rol');
             }}
@@ -153,7 +153,6 @@ const ModalUsuario = memo(function ModalUsuario({ usuario, onSave, onClose, guar
             {...getAriaProps('rol', true)}
           >
             <option value="preventista">Preventista</option>
-            <option value="preventista_taco">Preventista Taco</option>
             <option value="transportista">Transportista</option>
             <option value="deposito">Deposito</option>
             <option value="encargado">Encargado</option>

--- a/src/components/pedidos/PedidoCard.tsx
+++ b/src/components/pedidos/PedidoCard.tsx
@@ -288,9 +288,7 @@ function PedidoCard({
 
   // Intentar usar contexto si está disponible (migración gradual)
   const pedidoActions = useContext(PedidoActionsCtx);
-  const { user, isPreventistaTaco } = useAuthData();
-  // preventista_taco no puede ver montos comerciales (P1-5).
-  const verMontos = !isPreventistaTaco;
+  const { user } = useAuthData();
 
   // Usar handlers del contexto si están disponibles, de lo contrario usar props
   const handleVerHistorial = onVerHistorial ?? pedidoActions?.handleVerHistorial;
@@ -498,9 +496,9 @@ function PedidoCard({
             className="mt-1 text-2xl text-blue-700 dark:text-blue-300 tabular-nums leading-none"
             style={{ fontWeight: 800, letterSpacing: '-0.03em' }}
           >
-            {verMontos ? formatPrecio(pedido.total) : '—'}
+            {formatPrecio(pedido.total)}
           </p>
-          {verMontos && pedido.estado_pago === 'parcial' && (
+          {pedido.estado_pago === 'parcial' && (
             <p className="mt-1.5 text-[13px] font-medium text-amber-700 dark:text-amber-400 tabular-nums">
               Pagado: {formatPrecio(pedido.monto_pagado || 0)} de {formatPrecio(pedido.total)}
             </p>
@@ -612,7 +610,7 @@ function PedidoCard({
                         </span>
                       )}
                     </p>
-                    {verMontos && !item.es_bonificacion && <p className="text-xs text-gray-500">{formatPrecio(item.precio_unitario)} c/u</p>}
+                    {!item.es_bonificacion && <p className="text-xs text-gray-500">{formatPrecio(item.precio_unitario)} c/u</p>}
                     {salvedadItem && (
                       <p className="text-xs text-amber-600 dark:text-amber-400">
                         Pedido: {cantidadOriginal} → Entregado: {item.cantidad} ({salvedadItem.cantidad_afectada} no entregadas)
@@ -621,21 +619,19 @@ function PedidoCard({
                   </div>
                   <div className="text-right">
                     <p className="font-semibold text-gray-700 dark:text-gray-300">x{item.cantidad}</p>
-                    {verMontos && !item.es_bonificacion && <p className="text-sm font-bold text-blue-600">{formatPrecio(item.subtotal || item.precio_unitario * item.cantidad)}</p>}
-                    {verMontos && item.es_bonificacion && <p className="text-sm font-bold text-green-600">$0</p>}
-                    {verMontos && salvedadItem && (
+                    {!item.es_bonificacion && <p className="text-sm font-bold text-blue-600">{formatPrecio(item.subtotal || item.precio_unitario * item.cantidad)}</p>}
+                    {item.es_bonificacion && <p className="text-sm font-bold text-green-600">$0</p>}
+                    {salvedadItem && (
                       <p className="text-xs text-red-500 dark:text-red-400">-{formatPrecio(salvedadItem.monto_afectado)}</p>
                     )}
                   </div>
                 </div>
                 );
               })}
-              {verMontos && (
-                <div className="flex justify-between items-center pt-2 border-t-2 dark:border-gray-600">
-                  <p className="font-bold text-gray-900 dark:text-white">Total</p>
-                  <p className="text-xl font-bold text-blue-600">{formatPrecio(pedido.total)}</p>
-                </div>
-              )}
+              <div className="flex justify-between items-center pt-2 border-t-2 dark:border-gray-600">
+                <p className="font-bold text-gray-900 dark:text-white">Total</p>
+                <p className="text-xl font-bold text-blue-600">{formatPrecio(pedido.total)}</p>
+              </div>
             </div>
           </div>
 
@@ -667,24 +663,20 @@ function PedidoCard({
                           {salvedad.estado_resolucion === 'pendiente' ? 'Pendiente de resolver' : 'Resuelta'}
                         </span>
                       </div>
-                      {verMontos && (
-                        <div className="text-right">
-                          <p className="text-sm font-bold text-red-600 dark:text-red-400">
-                            -{formatPrecio(salvedad.monto_afectado)}
-                          </p>
-                        </div>
-                      )}
+                      <div className="text-right">
+                        <p className="text-sm font-bold text-red-600 dark:text-red-400">
+                          -{formatPrecio(salvedad.monto_afectado)}
+                        </p>
+                      </div>
                     </div>
                   );
                 })}
-                {verMontos && (
-                  <div className="flex justify-between items-center pt-2 border-t border-amber-300 dark:border-amber-600">
-                    <p className="text-sm font-medium text-amber-800 dark:text-amber-200">Total afectado:</p>
-                    <p className="text-sm font-bold text-red-600 dark:text-red-400">
-                      -{formatPrecio(pedido.salvedades?.reduce((sum, s) => sum + s.monto_afectado, 0) || 0)}
-                    </p>
-                  </div>
-                )}
+                <div className="flex justify-between items-center pt-2 border-t border-amber-300 dark:border-amber-600">
+                  <p className="text-sm font-medium text-amber-800 dark:text-amber-200">Total afectado:</p>
+                  <p className="text-sm font-bold text-red-600 dark:text-red-400">
+                    -{formatPrecio(pedido.salvedades?.reduce((sum, s) => sum + s.monto_afectado, 0) || 0)}
+                  </p>
+                </div>
               </div>
             </div>
           )}
@@ -724,7 +716,7 @@ function PedidoCard({
               {(() => {
                 const pagos = pedido.pagos || [];
                 const formas = Array.from(new Set(pagos.map(p => p.forma_pago).filter(Boolean)));
-                if (!verMontos || formas.length < 2) return null;
+                if (formas.length < 2) return null;
                 const desglose = formas.map(f => ({
                   forma: f,
                   monto: pagos.filter(p => p.forma_pago === f).reduce((s, p) => s + (p.monto || 0), 0),

--- a/src/components/pedidos/PedidoStats.tsx
+++ b/src/components/pedidos/PedidoStats.tsx
@@ -25,7 +25,6 @@ import { mostrarMontosEnStats, type PedidoStatKey } from '../../lib/permisos';
 export interface PedidoStatsProps {
   summary: PedidoStatsSummary;
   isEncargado?: boolean;
-  isPreventistaTaco?: boolean;
 }
 
 interface StatItem {
@@ -50,9 +49,9 @@ interface StatItem {
 // COMPONENT
 // =============================================================================
 
-function PedidoStats({ summary, isEncargado, isPreventistaTaco }: PedidoStatsProps): React.ReactElement {
-  // El rol determina qué montos se muestran. preventista_taco no ve ningún monto. (P1-5)
-  const rol = isPreventistaTaco ? 'preventista_taco' : isEncargado ? 'encargado' : 'admin';
+function PedidoStats({ summary, isEncargado }: PedidoStatsProps): React.ReactElement {
+  // El rol determina qué montos se muestran: el encargado solo ve los impagos.
+  const rol = isEncargado ? 'encargado' : 'admin';
   const items: StatItem[] = [
     {
       key: 'pendientes',

--- a/src/components/vistas/VistaClientes.tsx
+++ b/src/components/vistas/VistaClientes.tsx
@@ -6,8 +6,6 @@ import Paginacion from '../layout/Paginacion';
 import ClientesViewHeader from '../clientes/ClientesViewHeader';
 import ClienteStats from '../clientes/ClienteStats';
 import { useZonasEstandarizadasQuery } from '../../hooks/queries';
-import { puedeVerSaldoCliente } from '../../lib/permisos';
-import { useAuthData } from '../../contexts/AuthDataContext';
 import { formatPrecio } from '../../utils/formatters';
 import { cn } from '../../lib/utils';
 import type { ClienteDB } from '../../types';
@@ -55,9 +53,6 @@ export default function VistaClientes({
   onGestionarZonas,
   onVerDeudores
 }: VistaClientesProps) {
-  const { perfil } = useAuthData();
-  const verSaldo = puedeVerSaldoCliente(perfil?.rol);
-
   const [busqueda, setBusqueda] = useState<string>('');
   const [paginaActual, setPaginaActual] = useState(1);
 
@@ -287,7 +282,6 @@ export default function VistaClientes({
               idx={idx}
               isAdmin={isAdmin}
               canEditar={isAdmin || isEncargado || isPreventista}
-              verSaldo={verSaldo}
               onEditar={() => onEditarCliente(cliente)}
               onEliminar={() => onEliminarCliente(cliente.id)}
               onVerFicha={onVerFichaCliente ? () => onVerFichaCliente(cliente) : undefined}
@@ -316,13 +310,12 @@ interface ClienteCardProps {
   idx: number;
   isAdmin: boolean;
   canEditar: boolean;
-  verSaldo: boolean;
   onEditar: () => void;
   onEliminar: () => void;
   onVerFicha?: () => void;
 }
 
-function ClienteCard({ cliente, idx, isAdmin, canEditar, verSaldo, onEditar, onEliminar, onVerFicha }: ClienteCardProps) {
+function ClienteCard({ cliente, idx, isAdmin, canEditar, onEditar, onEliminar, onVerFicha }: ClienteCardProps) {
   const saldo = cliente.saldo_cuenta ?? 0;
   const saldoColor =
     saldo > 0 ? 'text-rose-700 dark:text-rose-300'
@@ -431,22 +424,18 @@ function ClienteCard({ cliente, idx, isAdmin, canEditar, verSaldo, onEditar, onE
 
       {/* Footer con gradient + saldo + botón Ver Ficha */}
       <div className="mt-3 px-4 py-3 bg-gradient-to-br from-stone-50/70 via-stone-50/40 to-blue-50/30 dark:from-gray-900/50 dark:via-gray-900/30 dark:to-blue-900/10 border-t border-stone-200/70 dark:border-gray-700/60 flex items-end justify-between gap-2">
-        {verSaldo ? (
-          <div className="min-w-0">
-            <p className="text-[10px] font-semibold uppercase tracking-[0.14em] text-stone-500 dark:text-stone-400 leading-none">
-              Saldo
-            </p>
-            <p
-              className={`mt-1 text-base tabular-nums leading-none truncate ${saldoColor}`}
-              style={{ fontWeight: 800, letterSpacing: '-0.025em' }}
-              title={saldo > 0 ? 'Cliente con deuda' : saldo < 0 ? 'Saldo a favor del cliente' : 'Sin saldo pendiente'}
-            >
-              {formatPrecio(saldo)}
-            </p>
-          </div>
-        ) : (
-          <div className="flex-1" />
-        )}
+        <div className="min-w-0">
+          <p className="text-[10px] font-semibold uppercase tracking-[0.14em] text-stone-500 dark:text-stone-400 leading-none">
+            Saldo
+          </p>
+          <p
+            className={`mt-1 text-base tabular-nums leading-none truncate ${saldoColor}`}
+            style={{ fontWeight: 800, letterSpacing: '-0.025em' }}
+            title={saldo > 0 ? 'Cliente con deuda' : saldo < 0 ? 'Saldo a favor del cliente' : 'Sin saldo pendiente'}
+          >
+            {formatPrecio(saldo)}
+          </p>
+        </div>
         {onVerFicha && (
           <button
             onClick={onVerFicha}

--- a/src/components/vistas/VistaDashboard.tsx
+++ b/src/components/vistas/VistaDashboard.tsx
@@ -81,7 +81,6 @@ export interface VistaDashboardProps {
   totalClientes?: number;
   isAdmin?: boolean;
   isPreventista?: boolean;
-  isPreventistaTaco?: boolean;
   isEncargado?: boolean;
 }
 
@@ -310,16 +309,13 @@ export default function VistaDashboard({
   totalClientes = 0,
   isAdmin = false,
   isPreventista = false,
-  isPreventistaTaco = false,
   isEncargado = false,
 }: VistaDashboardProps) {
   // Visibilidad por rol:
   //  - admin: ve todo
   //  - encargado: solo "Ventas ultimos 7 dias" + estados de pedido (sin facturacion total ni agregados)
-  //  - preventista_taco: solo items (Top 5 productos) + estados; sin ningun monto
-  //  - preventista regular: ve montos pero filtrados a sus propias ventas
-  const verMontosAgregados = isAdmin || (isPreventista && !isPreventistaTaco)
-  const verVentasSemanales = !isPreventistaTaco // taco no ve ningun monto
+  //  - preventista: ve montos pero filtrados a sus propias ventas
+  const verMontosAgregados = isAdmin || isPreventista
   const verTopProductos = !isEncargado || isAdmin // encargado no ve agregados de productos
   const verEstadoPedidos = true
   const [fechaDesdeLocal, setFechaDesdeLocal] = useState<string>('');
@@ -360,7 +356,7 @@ export default function VistaDashboard({
 
   if (loading) return <LoadingSpinner />;
 
-  const verbo = (isPreventista && !isAdmin && !isPreventistaTaco) ? 'Mis métricas' : 'Resumen';
+  const verbo = (isPreventista && !isAdmin) ? 'Mis métricas' : 'Resumen';
 
   return (
     <div className="space-y-5">
@@ -508,7 +504,6 @@ export default function VistaDashboard({
       {/* Gráficos */}
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-5">
         {/* Ventas últimos 7 días */}
-        {verVentasSemanales && (
         <div className="bg-white dark:bg-gray-800 border border-stone-200 dark:border-gray-700 rounded-xl shadow-warm p-5">
           <div className="flex items-center justify-between mb-4">
             <h3 className="text-base font-semibold text-stone-900 dark:text-white">Ventas últimos 7 días</h3>
@@ -533,7 +528,6 @@ export default function VistaDashboard({
             })}
           </div>
         </div>
-        )}
 
         {/* Top 5 productos */}
         {verTopProductos && (

--- a/src/components/vistas/VistaPedidos.tsx
+++ b/src/components/vistas/VistaPedidos.tsx
@@ -41,7 +41,6 @@ export interface VistaPedidosProps {
   isPreventista: boolean;
   isTransportista: boolean;
   isEncargado?: boolean;
-  isPreventistaTaco?: boolean;
   userId: string;
   clientes: ClienteDB[];
   productos: ProductoDB[];
@@ -115,7 +114,6 @@ export default function VistaPedidos({
   isPreventista,
   isTransportista,
   isEncargado,
-  isPreventistaTaco,
   userId,
   transportistas = [],
   usuarios = [],
@@ -204,7 +202,7 @@ export default function VistaPedidos({
       />
 
       {/* Resumen de estados (totales sobre todos los pedidos filtrados) */}
-      <PedidoStats summary={statsSummary} isEncargado={isEncargado} isPreventistaTaco={isPreventistaTaco} />
+      <PedidoStats summary={statsSummary} isEncargado={isEncargado} />
 
       {/* Lista de pedidos */}
       {loading ? (

--- a/src/components/vistas/reportes-gerenciales/formato.ts
+++ b/src/components/vistas/reportes-gerenciales/formato.ts
@@ -27,7 +27,6 @@ export function moneyC(x: number): string {
 export function rolLabel(rol: string): string {
   switch (rol) {
     case 'preventista':
-    case 'preventista_taco':
       return 'Prev'
     case 'encargado':
       return 'Encarg'

--- a/src/contexts/AuthDataContext.tsx
+++ b/src/contexts/AuthDataContext.tsx
@@ -17,8 +17,6 @@ export interface AuthDataContextValue {
   authReady: boolean
   isAdmin: boolean
   isPreventista: boolean
-  isPreventistaTaco: boolean
-  isAnyPreventista: boolean
   isTransportista: boolean
   isEncargado: boolean
   isAdminOrEncargado: boolean
@@ -72,8 +70,8 @@ export function useAuthData(): AuthDataContextValue {
  */
 // eslint-disable-next-line react-refresh/only-export-components
 export function useUserPermissions() {
-  const { user, perfil, isAdmin, isPreventista, isPreventistaTaco, isAnyPreventista, isTransportista, isEncargado, isAdminOrEncargado } = useAuthData()
-  return { user, perfil, isAdmin, isPreventista, isPreventistaTaco, isAnyPreventista, isTransportista, isEncargado, isAdminOrEncargado }
+  const { user, perfil, isAdmin, isPreventista, isTransportista, isEncargado, isAdminOrEncargado } = useAuthData()
+  return { user, perfil, isAdmin, isPreventista, isTransportista, isEncargado, isAdminOrEncargado }
 }
 
 export default AuthDataContext

--- a/src/hooks/queries/useUsuariosQuery.ts
+++ b/src/hooks/queries/useUsuariosQuery.ts
@@ -108,14 +108,14 @@ async function fetchPreventistas(sucursalId: number | null): Promise<PerfilDB[]>
 }
 
 // Lista de usuarios que pueden ser asignados como preventista de un pedido:
-// admin + preventista + preventista_taco. Usada por admin para asignar quien
-// "tomo" el pedido (etiquetas, estadisticas, comisiones).
+// admin + preventista. Usada por admin para asignar quien "tomo" el pedido
+// (etiquetas, estadisticas, comisiones).
 async function fetchPreventistasAsignables(sucursalId: number | null): Promise<PerfilDB[]> {
   if (!sucursalId) return []
   const { data, error } = await supabase
     .from('perfiles')
     .select('*, usuario_sucursales!inner(sucursal_id)')
-    .in('rol', ['admin', 'preventista', 'preventista_taco'])
+    .in('rol', ['admin', 'preventista'])
     .eq('activo', true)
     .eq('usuario_sucursales.sucursal_id', sucursalId)
     .order('nombre')
@@ -217,7 +217,7 @@ export function usePreventistasQuery() {
 
 /**
  * Hook para obtener todos los usuarios que pueden ser asignados como
- * preventista de un pedido (admin + preventista + preventista_taco activos).
+ * preventista de un pedido (admin + preventista activos).
  */
 export function usePreventistasAsignablesQuery() {
   const { currentSucursalId } = useSucursal()

--- a/src/hooks/supabase/useAuth.tsx
+++ b/src/hooks/supabase/useAuth.tsx
@@ -51,8 +51,6 @@ export interface AuthContextValue {
   logout: () => Promise<void>;
   isAdmin: boolean;
   isPreventista: boolean;
-  isPreventistaTaco: boolean;
-  isAnyPreventista: boolean;
   isTransportista: boolean;
   isEncargado: boolean;
   isAdminOrEncargado: boolean;
@@ -479,8 +477,6 @@ export function AuthProvider({ children }: AuthProviderProps) {
     logout,
     isAdmin: perfil?.rol === 'admin',
     isPreventista: perfil?.rol === 'preventista',
-    isPreventistaTaco: perfil?.rol === 'preventista_taco',
-    isAnyPreventista: perfil?.rol === 'preventista' || perfil?.rol === 'preventista_taco',
     isTransportista: perfil?.rol === 'transportista',
     isEncargado: perfil?.rol === 'encargado',
     isAdminOrEncargado: perfil?.rol === 'admin' || perfil?.rol === 'encargado',

--- a/src/hooks/supabase/useUsuarios.ts
+++ b/src/hooks/supabase/useUsuarios.ts
@@ -47,7 +47,7 @@ export function useUsuarios(): UseUsuariosReturn {
       nombre: datos.nombre,
       rol: datos.rol,
       activo: datos.activo,
-      zona: (datos.rol === 'preventista' || datos.rol === 'preventista_taco') ? (datos.zona || null) : null
+      zona: datos.rol === 'preventista' ? (datos.zona || null) : null
     }
     const { data, error } = await supabase.from('perfiles').update(updateData).eq('id', id).select().single()
     if (error) throw error

--- a/src/lib/permisos.ts
+++ b/src/lib/permisos.ts
@@ -43,7 +43,7 @@ export function puedeAnularPago(rol: RolUsuario | null | undefined): boolean {
 }
 
 export function puedeAccederDashboard(rol: RolUsuario | null | undefined): boolean {
-  return rol === 'admin' || rol === 'preventista' || rol === 'preventista_taco'
+  return rol === 'admin' || rol === 'preventista'
 }
 
 export function puedeAccederReportes(rol: RolUsuario | null | undefined): boolean {
@@ -75,29 +75,11 @@ export function puedeAccederGeolocalizacion(rol: RolUsuario | null | undefined):
 }
 
 export function puedeCrearCliente(rol: RolUsuario | null | undefined): boolean {
-  return rol === 'admin' || rol === 'preventista' || rol === 'preventista_taco' || rol === 'encargado'
+  return rol === 'admin' || rol === 'preventista' || rol === 'encargado'
 }
 
 export function puedeCrearPedido(rol: RolUsuario | null | undefined): boolean {
-  return rol === 'admin' || rol === 'preventista' || rol === 'preventista_taco' || rol === 'encargado'
-}
-
-/**
- * Si el rol puede ver montos comerciales (ventas, totales, ticket promedio, saldos
- * de cuenta corriente, historicos de compra). Falso para preventista_taco.
- */
-export function puedeVerMontosYVentas(rol: RolUsuario | null | undefined): boolean {
-  return rol !== 'preventista_taco'
-}
-
-/** Si el rol puede ver el saldo de cuenta corriente en la ficha de cliente. */
-export function puedeVerSaldoCliente(rol: RolUsuario | null | undefined): boolean {
-  return rol !== 'preventista_taco'
-}
-
-/** Si el rol puede ver el historial de ventas/compras de un cliente. */
-export function puedeVerHistorialVentasCliente(rol: RolUsuario | null | undefined): boolean {
-  return rol !== 'preventista_taco'
+  return rol === 'admin' || rol === 'preventista' || rol === 'encargado'
 }
 
 /** Si el rol puede ver la facturacion total en el dashboard. Solo admin. */
@@ -132,7 +114,6 @@ export function mostrarMontosEnStats(
   rol: RolUsuario | null | undefined,
   key: PedidoStatKey,
 ): boolean {
-  if (rol === 'preventista_taco') return false
   if (rol === 'encargado') return key === 'impagos'
   return true
 }

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -379,7 +379,7 @@ export const usuarioSchema = z.object({
     .email({ message: 'Email inválido' })
     .min(1, { message: 'El email es obligatorio' }),
 
-  rol: z.enum(['admin', 'preventista', 'preventista_taco', 'transportista', 'deposito', 'encargado'], {
+  rol: z.enum(['admin', 'preventista', 'transportista', 'deposito', 'encargado'], {
     error: 'Rol invalido'
   }),
 
@@ -392,7 +392,7 @@ export const usuarioSchema = z.object({
 export type UsuarioFormData = z.infer<typeof usuarioSchema>
 
 /** Valid user roles */
-export type RolUsuario = 'admin' | 'preventista' | 'preventista_taco' | 'transportista' | 'deposito' | 'encargado'
+export type RolUsuario = 'admin' | 'preventista' | 'transportista' | 'deposito' | 'encargado'
 
 // ============================================
 // SCHEMAS DE PROVEEDOR

--- a/src/types/hooks.ts
+++ b/src/types/hooks.ts
@@ -127,7 +127,7 @@ export interface PerfilDB {
   id: string;
   nombre: string;
   email: string;
-  rol?: 'admin' | 'preventista' | 'preventista_taco' | 'transportista' | 'deposito' | 'encargado';
+  rol?: 'admin' | 'preventista' | 'transportista' | 'deposito' | 'encargado';
   zona?: string;
   activo?: boolean;
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -164,7 +164,7 @@ export interface PedidoInput {
 // USUARIO
 // =============================================================================
 
-export type RolUsuario = 'admin' | 'preventista' | 'preventista_taco' | 'transportista' | 'deposito' | 'encargado';
+export type RolUsuario = 'admin' | 'preventista' | 'transportista' | 'deposito' | 'encargado';
 
 export interface Usuario extends BaseEntity {
   email: string;

--- a/src/utils/formatters.ts
+++ b/src/utils/formatters.ts
@@ -352,7 +352,6 @@ export const getRolColor = (r: RolUsuario | string | null | undefined): string =
   r === 'deposito' ? 'bg-emerald-100 text-emerald-700' :
   r === 'transportista' ? 'bg-orange-100 text-orange-700' :
   r === 'preventista' ? 'bg-blue-100 text-blue-700' :
-  r === 'preventista_taco' ? 'bg-cyan-100 text-cyan-700' :
   'bg-gray-100 text-gray-700';
 
 export const getRolLabel = (r: RolUsuario | string | null | undefined): string =>
@@ -361,7 +360,6 @@ export const getRolLabel = (r: RolUsuario | string | null | undefined): string =
   r === 'deposito' ? 'Deposito' :
   r === 'transportista' ? 'Transportista' :
   r === 'preventista' ? 'Preventista' :
-  r === 'preventista_taco' ? 'Preventista Taco' :
   'Sin rol';
 
 export const getEstadoPagoColor = (estado: EstadoPago | string | null | undefined): string =>


### PR DESCRIPTION
## Qué

Elimina el rol `preventista_taco` por completo — código + CHECK. Tenía **0 usuarios en producción** y arrastraba un bug real.

## El bug

`menuGroups` en `TopNavigation.tsx` nunca incluyó `'preventista_taco'` en ningún array `roles[]`. Como `getMenuFiltrado()` filtra por rol, un usuario con ese rol veía el menú **completamente vacío** — ni siquiera Pedidos. Solo llegaba a las pantallas escribiendo la URL a mano.

## Por qué eliminarlo y no arreglarlo

Su única diferencia funcional con `preventista` era ocultar montos, saldos e historial de compras. Ese caso de uso, si vuelve a hacer falta, hoy se modela como **capacidad en `perfil_roles`** (mig 155) y no como un rol compuesto nuevo — que es justamente el motivo por el que se creó esa tabla.

## Código (22 archivos, −188/+95)

- Sale el tipo de los 4 lugares donde vivía, el `<option>` del select, y el color/label en `formatters.ts`.
- `isPreventistaTaco` desaparece; `isAnyPreventista` colapsa en `isPreventista` (era su única razón de existir), en toda la cadena `useAuth → App → AuthDataContext → containers`.
- Se **borran** de `permisos.ts` tres funciones que existían solo para gatear este rol, así que sin él eran tautologías:
  - `puedeVerMontosYVentas` — ya era código muerto, **0 llamadas**
  - `puedeVerSaldoCliente`
  - `puedeVerHistorialVentasCliente`
- Eso obligó a desarmar ~25 sitios de gating en `PedidoCard`, `ModalFichaCliente`, `VistaClientes`, `ClienteStats` y `VistaDashboard`. **El render no cambia**: todas esas condiciones ya eran `true` para los roles restantes.

## Migración 156 — ya APLICADA a prod

No hardcodea ningún cuerpo, y eso es deliberado. `migrations/` no es 1:1 con prod (ver `MANIFEST.md`) y la **mig 155 redefinió `es_preventista()`**; copiar el cuerpo de la mig 055, que es lo habitual, habría **revertido el multi-rol por sucursal en silencio**.

En su lugar lee la definición viva del catálogo (`pg_get_functiondef` / `pg_get_expr` / `pg_get_constraintdef`), le saca únicamente el literal y la recrea. El resto del cuerpo se preserva carácter por carácter. Todo en `BEGIN/COMMIT` con guardas que abortan si algún perfil todavía tuviera el rol o si el literal apareciera fuera de una lista.

Eso además hizo que el barrido encontrara solo **4 objetos que nadie tenía mapeados**: `actualizar_preventista_pedido`, `cambiar_cliente_pedido`, `clientes_guard_update_preventista` y `clientes_proteger_columnas_preventista`.

**Alcance real: 9 funciones + 1 policy + 1 CHECK.**

## Verificación

Dry-run read-only antes de aplicar, y post-check en vivo después:

| | |
|---|---|
| Rastros de `preventista_taco` en prod | **0** funciones / **0** policies / **0** checks |
| `es_preventista()` conserva `tiene_rol_extra` | ✅ **multi-rol intacto** |
| `es_transportista()` conserva `tiene_rol_extra` | ✅ (no se tocó) |
| Las 9 funciones + la policy siguen existiendo | ✅ |
| `perfiles_rol_check` | `ARRAY['admin','preventista','transportista','deposito','encargado']` |
| `npm run typecheck` / `lint` / `build` | limpios |
| `npm test` | **933 tests, 67 archivos** |

`perfil_roles` y `es_transportista()` no se tocaron.

## ⚠️ Coordinación con #440

#440 (multi-rol) toca los mismos helpers. Al mergear ambos va a haber **conflicto en `permisos.test.ts` y en el `EXISTS` de la mig 155**, que mencionan `preventista_taco`. Resolver quitándolo. Después del merge conviene reconfirmar:

```sql
SELECT proname, pg_get_functiondef(oid) ILIKE '%tiene_rol_extra%'
  FROM pg_proc WHERE proname IN ('es_preventista','es_transportista');
```

## Nota

`docs/AUDIT_REPORT_2026-05.md` menciona el rol y un "Fix (pendiente)" que quedó sin objeto, pero es un informe fechado y preferí no reescribir un registro histórico.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
