### PR TITLE
fix(rutas): armar ruta no muestra transportistas ni pedidos (embed ambiguo, regresión de #440)

### DIFF
--- a/src/hooks/queries/useUsuariosQuery.ts
+++ b/src/hooks/queries/useUsuariosQuery.ts
@@ -88,9 +88,13 @@ async function fetchUsuariosByRol(sucursalId: number | null, rol: string): Promi
 // menos de 15 por sucursal) y resolvemos el rol efectivo en memoria.
 async function fetchTransportistas(sucursalId: number | null): Promise<PerfilDB[]> {
   if (!sucursalId) return []
+  // El embed de perfil_roles va desambiguado con el nombre de la FK: la tabla
+  // apunta a `perfiles` DOS veces (usuario_id y created_by), y sin el hint
+  // PostgREST rechaza la consulta entera con PGRST201 -- el picker quedaria
+  // vacio, no incompleto. Mismo patron que pedidos!transportista_id_fkey.
   const { data, error } = await supabase
     .from('perfiles')
-    .select('*, usuario_sucursales!inner(sucursal_id), perfil_roles(rol, sucursal_id)')
+    .select('*, usuario_sucursales!inner(sucursal_id), perfil_roles!perfil_roles_usuario_id_fkey(rol, sucursal_id)')
     .eq('activo', true)
     .eq('usuario_sucursales.sucursal_id', sucursalId)
     .order('nombre')


### PR DESCRIPTION
**Hotfix de una regresión que introduje en #440.** Armar la ruta del día no muestra ni transportistas ni pedidos, para cualquier usuario y en las dos sucursales.

## Causa

`fetchTransportistas` embebe `perfil_roles` para incluir a quien tiene la capacidad extra. Esa tabla apunta a `perfiles` **dos veces** (`usuario_id` y `created_by`), así que sin el hint de la FK PostgREST no sabe cuál usar y **rechaza la consulta entera**.

Verificado contra la API real:

```
A) desplegado:    select=*,usuario_sucursales!inner(...),perfil_roles(rol,sucursal_id)
   → PGRST201 / HTTP 300
     "Could not embed because more than one relationship was found
      for 'perfiles' and 'perfil_roles'"

B) con el fix:    ...,perfil_roles!perfil_roles_usuario_id_fkey(rol,sucursal_id)
   → HTTP 200
```

## Por qué faltaban también los pedidos

El picker quedaba **vacío, no incompleto**, y eso encadena el segundo síntoma: `ModalGestionRutas` hace `if (!transportistaSeleccionado) return []` al armar `pedidosVisibles` (línea 341) y solo renderiza esa sección con un transportista elegido (línea 936). Sin transportistas no se puede elegir ninguno, así que la lista de pedidos ni se dibuja. **Una sola causa, dos síntomas.**

No era un problema de permisos: la RLS devuelve correctamente 34 pedidos y 3 transportistas para un admin en Tucumán, y 1 y 1 en Taco Pozo. Lo verifiqué simulando la sesión con `SET LOCAL ROLE authenticated`.

## El fix

El hint de FK, mismo patrón que ya usa el repo en `pedidoService` (`perfiles!pedidos_transportista_id_fkey`), `useSalvedades` (`perfiles!reportado_por`) y `useMovimientosQuery`.

Revisé los demás accesos a `perfil_roles`: son `.from()` directos, sin embed, así que no tienen la ambigüedad. Este era el único.

## Por qué no lo agarraron las validaciones

El `select` de PostgREST es un string: no lo mira `tsc` ni eslint, y ninguna prueba cubre esa query. En #440 corrí build, typecheck, lint y los 935 tests —todo en verde— pero **la app nunca se abrió contra la base real** porque el worktree no tiene `.env`. Lo señalé como limitación en ese PR y este es exactamente el agujero que dejó.

Vale la pena considerar un smoke test que ejecute las queries con embed contra la API real; hoy no hay nada que las cubra.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
