### PR TITLE
fix(rutas): avisar cuando la ruta ya existe en otra fecha

### DIFF
--- a/src/components/modals/ModalGestionRutas.tsx
+++ b/src/components/modals/ModalGestionRutas.tsx
@@ -8,7 +8,7 @@ import {
 } from 'lucide-react';
 import ModalBase from './ModalBase';
 import ModalCambioProducto, { type CambioProductoSaveData } from './ModalCambioProducto';
-import { useDepositoCoords, useSetDepositoMutation, useDestinoCoords, useSetDestinoMutation, useRecorridoExistenteQuery } from '../../hooks/queries';
+import { useDepositoCoords, useSetDepositoMutation, useDestinoCoords, useSetDestinoMutation, useRecorridoExistenteQuery, useRutasEnCursoQuery } from '../../hooks/queries';
 import type { RegistrarCambioInput } from '../../hooks/queries';
 import type { RepartidorParam } from '../../hooks/useOptimizarRuta';
 import { horarioParaRutear } from '../../hooks/useOptimizarRuta';
@@ -312,6 +312,18 @@ const ModalGestionRutas = memo(function ModalGestionRutas({
   );
   const paradasExistentes = useMemo((): PedidoDB[] => rutaExistente?.paradas ?? [], [rutaExistente]);
   const editando = paradasExistentes.length > 0;
+
+  // Rutas ya armadas de este transportista en OTRAS fechas. Sin esto, abrir el
+  // modal al día siguiente (default: mañana) no muestra la ruta de hoy ni sus
+  // paradas —ya están en estado `asignado`, fuera del pool— y parece que armar
+  // de nuevo estuviera bloqueado.
+  const { data: rutasEnCurso = [] } = useRutasEnCursoQuery(
+    modoDividir ? null : transportistaSeleccionado || null,
+  );
+  const rutasOtraFecha = useMemo(
+    () => rutasEnCurso.filter(r => r.fecha !== fechaEntrega && r.paradas > 0),
+    [rutasEnCurso, fechaEntrega],
+  );
   const idsExistentes = useMemo(() => new Set(paradasExistentes.map(p => p.id)), [paradasExistentes]);
 
   // Disponibles para sumar a la ruta: pendiente/en_preparacion (vienen del
@@ -943,6 +955,33 @@ const ModalGestionRutas = memo(function ModalGestionRutas({
                         Ya hay una ruta armada para <strong>{transportistaInfo?.nombre}</strong> el {formatFecha(fechaEntrega)}.
                         Se editará esa misma ruta (agregá o quitá paradas y se reoptimiza al armar).
                       </p>
+                    </div>
+                  )}
+
+                  {/* La ruta existe, pero en otra fecha. Es el caso de volver al
+                      día siguiente a agregarle un pedido: sin este aviso la
+                      pantalla se ve vacía y parece que no dejara rearmarla. */}
+                  {!modoDividir && !editando && rutasOtraFecha.length > 0 && (
+                    <div className="bg-blue-50 border border-blue-200 rounded-lg p-3 flex items-start gap-2">
+                      <CalendarDays className="w-5 h-5 text-blue-600 mt-0.5 flex-shrink-0" />
+                      <div className="text-sm text-blue-900">
+                        <p>
+                          <strong>{transportistaInfo?.nombre}</strong> ya tiene una ruta armada en otra fecha.
+                          Estás por crear una <strong>nueva</strong> para el {formatFecha(fechaEntrega)}.
+                        </p>
+                        <div className="mt-2 flex flex-wrap gap-2">
+                          {rutasOtraFecha.map(r => (
+                            <button
+                              key={r.recorridoId}
+                              type="button"
+                              onClick={() => setFechaEntrega(r.fecha)}
+                              className="px-3 py-1.5 text-xs font-medium rounded-lg bg-white border border-blue-300 text-blue-800 hover:bg-blue-100"
+                            >
+                              Editar la del {formatFecha(r.fecha)} ({r.paradas} parada{r.paradas === 1 ? '' : 's'})
+                            </button>
+                          ))}
+                        </div>
+                      </div>
                     </div>
                   )}
 

--- a/src/hooks/queries/index.ts
+++ b/src/hooks/queries/index.ts
@@ -211,6 +211,10 @@ export {
 } from './useRecorridoExistenteQuery'
 export type { RecorridoExistente } from './useRecorridoExistenteQuery'
 
+// Rutas en curso del transportista (para avisar que ya hay una en otra fecha)
+export { rutasEnCursoKeys, useRutasEnCursoQuery } from './useRutasEnCursoQuery'
+export type { RutaEnCurso } from './useRutasEnCursoQuery'
+
 // Recorridos de una fecha con paradas completas (para re-descargar la hoja de ruta)
 export {
   recorridosHojaRutaKeys,

--- a/src/hooks/queries/useRutasEnCursoQuery.ts
+++ b/src/hooks/queries/useRutasEnCursoQuery.ts
@@ -1,0 +1,73 @@
+/**
+ * Rutas ya armadas (en_curso) de un transportista, de hoy en adelante.
+ *
+ * `useRecorridoExistenteQuery` responde "¿hay ruta para ESTA fecha?" y con eso
+ * el modal precarga las paradas. El problema es la respuesta negativa: si la
+ * ruta existe en OTRA fecha, la pantalla no dice nada y parece que armar de
+ * nuevo no estuviera permitido.
+ *
+ * Caso real (2026-08-02): la ruta se armó el 01/08 para el 02/08. Al día
+ * siguiente el modal abre con la fecha de entrega en su default —mañana, 03/08—,
+ * no encuentra ruta para esa fecha, y como los pedidos de la ruta del 02/08 ya
+ * están en estado `asignado` (fuera del pool de disponibles), la pantalla queda
+ * con un solo pedido nuevo y sin ninguna señal de que la ruta del 02/08 existe.
+ *
+ * Esta query es la que permite decirlo.
+ */
+import { useQuery } from '@tanstack/react-query'
+import { supabase } from '../supabase/base'
+import { useSucursal } from '../../contexts/SucursalContext'
+import { fechaLocalISO } from '../../utils/formatters'
+
+export interface RutaEnCurso {
+  recorridoId: string
+  fecha: string
+  paradas: number
+}
+
+export const rutasEnCursoKeys = {
+  all: (sucursalId: number | null, transportistaId: string | null) =>
+    ['rutas-en-curso', sucursalId, transportistaId] as const,
+}
+
+interface RutaEnCursoRaw {
+  id: number | string
+  fecha: string
+  // `recorrido_pedidos` tiene una sola FK a `recorridos`, así que el embed no es
+  // ambiguo (PGRST201). Verificado contra el catálogo antes de escribirlo.
+  recorrido_pedidos?: Array<{ count: number }>
+}
+
+async function fetchRutasEnCurso(
+  sucursalId: number | null,
+  transportistaId: string,
+): Promise<RutaEnCurso[]> {
+  let query = supabase
+    .from('recorridos')
+    .select('id, fecha, recorrido_pedidos(count)')
+    .eq('transportista_id', transportistaId)
+    .eq('estado', 'en_curso')
+    .gte('fecha', fechaLocalISO())
+    .order('fecha', { ascending: true })
+
+  if (sucursalId != null) query = query.eq('sucursal_id', sucursalId)
+
+  const { data, error } = await query
+  if (error) throw error
+
+  return ((data as unknown as RutaEnCursoRaw[]) || []).map(r => ({
+    recorridoId: String(r.id),
+    fecha: r.fecha,
+    paradas: r.recorrido_pedidos?.[0]?.count ?? 0,
+  }))
+}
+
+export function useRutasEnCursoQuery(transportistaId: string | null | undefined) {
+  const { currentSucursalId } = useSucursal()
+  return useQuery({
+    queryKey: rutasEnCursoKeys.all(currentSucursalId, transportistaId ?? null),
+    queryFn: () => fetchRutasEnCurso(currentSucursalId, transportistaId as string),
+    enabled: !!transportistaId,
+    staleTime: 30 * 1000,
+  })
+}


### PR DESCRIPTION
## El reclamo

> Ayer hice la hoja de ruta y hoy se agregó un pedido. Quiero volver a hacerla teniendo en cuenta los pedidos de ayer y de hoy, y no me deja. Antes, cuando ya habías hecho una hoja de ruta y querías volverla a hacer, te decía "ya existe una hoja…" y le decías que sí. Ahora no me da esa opción: me toma solo el pedido que cargaron hoy.

## Qué pasa realmente

Reproducido con los datos de producción de hoy (02/08). El recorrido **74** se armó el **01/08 para el 02/08**, con 28 paradas. Al abrir "Armar ruta" al día siguiente:

1. La fecha de entrega arranca en su default, **mañana (03/08)** — correcto para el flujo normal, que es armar la ruta el día anterior.
2. `useRecorridoExistenteQuery` busca ruta para el **03/08** y no encuentra ninguna: no precarga paradas ni muestra el cartel de "ya hay una ruta armada".
3. Los 28 pedidos de la ruta del 02/08 están en estado `asignado`, o sea **fuera del pool de disponibles**.
4. Resultado: la pantalla muestra solo el pedido nuevo, sin una sola señal de que la ruta del 02/08 existe.

Cada pieza es correcta por separado; juntas dan la sensación de "no me deja rearmarla". Lo que faltaba era la **respuesta negativa**: hay ruta, pero en otra fecha.

De paso, el diálogo "ya existe una hoja, ¿reemplazar?" que ella recuerda se sacó a propósito hace varias versiones: ahora el modal carga la ruta existente pre-tildada y el RPC la edita in-place en vez de duplicarla. Con la fecha correcta seleccionada, ese flujo funciona.

## El cambio

- `useRutasEnCursoQuery`: rutas `en_curso` del transportista, de hoy en adelante, con su cantidad de paradas.
- Aviso en el modal cuando la fecha elegida no tiene ruta pero el transportista sí tiene una en otra fecha, con un botón por ruta que salta a esa fecha. De ahí en adelante el flujo de edición que ya existe hace el resto.

**No se toca el default de la fecha de entrega**: mañana sigue siendo lo correcto para el caso común. Cambiarlo arreglaría este caso y rompería el otro.

## Verificación

- El embed `recorrido_pedidos(count)` se probó contra PostgREST con la anon key **antes** de commitear: HTTP 200, sin `PGRST201`. `recorrido_pedidos` tiene una sola FK a `recorridos`. Es la misma clase de bug que rompió "Armar ruta" en #440 y que ni `tsc` ni los tests detectan, porque el `select` es un string.
- 940 tests en verde, typecheck, lint y `npm run build` limpios.

### Para probar

Con Marcos seleccionado y la fecha en 03/08, tiene que aparecer el aviso azul con "Editar la del 02/08 (28 paradas)". Al tocarlo, las 28 paradas quedan pre-tildadas y se le puede sumar el pedido nuevo.

## Aparte, no es bug

El otro síntoma —"pongo los pedidos cargados ayer y hoy y no me los toma"— es el filtro del pool, que por defecto filtra por **fecha de entrega**, no por fecha de carga. El pedido nuevo (4380) se cargó hoy pero quedó programado para el 03/08, así que un filtro de 01/08–02/08 lo esconde. El selector "Fecha de pedido / Fecha de entrega" está arriba de los dos campos de fecha. Sin filtro, el pool muestra todo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)