### PR TITLE
feat: horario obligatorio al cargar pedido + objetivos por preventista y marcas

### DIFF
--- a/migrations/157_clientes_sin_horario_fijo.sql
+++ b/migrations/157_clientes_sin_horario_fijo.sql
@@ -1,0 +1,98 @@
+-- Migración 157: `clientes.sin_horario_fijo` — escape del horario obligatorio
+--
+-- CONTEXTO
+-- Los preventistas no cargan el horario de atención porque hoy hay que salir
+-- del pedido, entrar a la ficha del cliente, cargarlo y volver. Con el cliente
+-- apurado, no lo hacen. El resultado es que 283/621 clientes quedaron sin
+-- horario y el ruteo los manda a la barrida "flexible" (ver mig 140).
+--
+-- La solución es pedir el horario DENTRO del modal de pedido y no dejar
+-- confirmar hasta resolverlo. Pero hay clientes que genuinamente no tienen
+-- horario fijo (kioscos que abren "cuando pueden", puestos de feria). Para
+-- esos, un flag explícito: el preventista declara "no atiende con horario
+-- fijo" una vez y la app deja de pedírselo.
+--
+-- El flag NO es lo mismo que `horarios_atencion IS NULL`: la ausencia de dato
+-- es "todavía no lo cargamos", el flag es "ya preguntamos, no aplica". Sin esa
+-- distinción, el aviso reaparece en cada pedido y los preventistas aprenden a
+-- ignorarlo.
+--
+-- CRÍTICO — el trigger allow-list:
+-- `clientes_proteger_columnas_preventista` (mig 080, extendido en 140) es
+-- fail-closed: una columna nueva queda bloqueada para el rol `preventista`
+-- hasta que se la agregue explícitamente. Sin el punto 2 de esta migración, el
+-- preventista que use el escape recibe 42501 y el flujo queda trabado — que es
+-- exactamente el problema que esta feature viene a resolver.
+--
+-- El segundo guard de clientes (`clientes_guard_update_preventista`) es
+-- deny-list, así que no hace falta tocarlo: la columna nueva ya está permitida.
+
+BEGIN;
+
+-- -------------------------------------------------------------------------
+-- 1. Columna
+-- -------------------------------------------------------------------------
+ALTER TABLE public.clientes
+  ADD COLUMN IF NOT EXISTS sin_horario_fijo boolean NOT NULL DEFAULT false;
+
+COMMENT ON COLUMN public.clientes.sin_horario_fijo IS
+  'true = el cliente declaró que no atiende con horario fijo. Distinto de horarios_atencion vacío ("todavía no se cargó"): este flag suprime el pedido de horario al cargar un pedido. El ruteo lo trata igual que un cliente sin franjas (barrida flexible). Mig 157.';
+
+-- -------------------------------------------------------------------------
+-- 2. Allow-list del trigger.
+--
+--    Se replica la función tal cual está en prod (verificada contra
+--    pg_get_functiondef el 2026-08-03), agregando solo la columna nueva.
+--    NO simplificar el cuerpo: las exenciones de current_user y
+--    pg_trigger_depth sostienen las RPCs SECURITY DEFINER y las cascadas de
+--    saldo_cuenta.
+-- -------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.clientes_proteger_columnas_preventista()
+RETURNS trigger
+LANGUAGE plpgsql
+SET search_path TO 'public'
+AS $fn$
+DECLARE
+  v_rol text;
+  v_bloqueadas text;
+BEGIN
+  -- RPCs SECURITY DEFINER, service_role, conexiones directas: exentas.
+  IF current_user <> 'authenticated' THEN
+    RETURN NEW;
+  END IF;
+
+  -- Cascadas desde otros triggers (saldo_cuenta desde pedidos): exentas.
+  IF pg_trigger_depth() > 1 THEN
+    RETURN NEW;
+  END IF;
+
+  SELECT rol INTO v_rol FROM perfiles WHERE id = auth.uid();
+
+  IF v_rol IS NULL OR v_rol NOT IN ('preventista') THEN
+    RETURN NEW;  -- admin y encargado sin restricción
+  END IF;
+
+  SELECT string_agg(o.key, ', ' ORDER BY o.key) INTO v_bloqueadas
+  FROM jsonb_each(to_jsonb(OLD)) o
+  JOIN jsonb_each(to_jsonb(NEW)) n ON n.key = o.key
+  WHERE o.value IS DISTINCT FROM n.value
+    AND o.key NOT IN (
+      'razon_social', 'direccion', 'aclaracion_direccion', 'latitud',
+      'longitud', 'telefono', 'contacto', 'horarios_atencion', 'rubro', 'notas',
+      -- Mig 140: el horario canónico se carga junto con los días.
+      'dias_atencion', 'horarios_atencion_original',
+      -- Mig 157: escape del horario obligatorio al cargar un pedido.
+      'sin_horario_fijo'
+    );
+
+  IF v_bloqueadas IS NOT NULL THEN
+    RAISE EXCEPTION 'El rol % no puede modificar estas columnas de clientes: %',
+      v_rol, v_bloqueadas
+      USING ERRCODE = '42501';
+  END IF;
+
+  RETURN NEW;
+END;
+$fn$;
+
+COMMIT;

--- a/migrations/158_marcas.sql
+++ b/migrations/158_marcas.sql
@@ -1,0 +1,199 @@
+-- =========================================================================
+-- 158_marcas.sql
+--
+-- "Quiero ver cuánto facturó cada preventista en La Virginia, en Manaos, y
+--  cuántas Placer y cuántas gaseosas vendió."
+--
+-- Hoy eso no se puede: no existe el concepto de marca. Las marcas están
+-- metidas como filas de `categorias`, y cada sucursal lo hace distinto:
+--
+--   sucursal 1 (Tucumán): las categorías son MARCAS — ALICANTE (32 productos),
+--     LA VIRGINIA (20), MANAOS (16), PLACER (14), MOLINO (12),
+--     VILLAMANAOS//BICHY (6), PINDAPOY (2) — mezcladas con categorías reales
+--     (FIDEOS, PAPAS FRITAS, NACHOS, PAPEL HIGIENICO, ALFAJORES, ...).
+--   sucursal 2 (Taco Pozo): las categorías son CATEGORÍAS de verdad —
+--     GASEOSAS, AGUAS, AGUAS SABORIZADAS, SNACKS, JUGOS, LATAS, VINOS — y la
+--     marca vive dentro del nombre del producto ("PLACER NARANJA 1500CC X 6").
+--
+-- Con una sola dimensión no se puede pedir "Manaos gaseosas": marca y
+-- categoría son ortogonales y necesitan columnas distintas.
+--
+-- BACKFILL: solo el determinístico — las categorías de la sucursal 1 que son
+-- marcas, listadas por id explícito (precedente mig 145 §3: por id, nunca por
+-- patrón de nombre). La sucursal 2 queda sin marcas asignadas y se completa
+-- desde la UI con la asignación masiva de abajo, filtrando por nombre.
+--
+-- NO se desactivan las categorías que pasan a ser marcas: dejar productos con
+-- categoria_id NULL rompería calcular_comisiones (mig 150) y el breakdown por
+-- categoría de reporte_gerencial (mig 130). Esa reclasificación la hace el
+-- dueño desde la UI, después y a mano.
+-- =========================================================================
+
+-- -------------------------------------------------------------------------
+-- 1. Tabla. Espejo deliberado de `categorias` (mig 009): mismo tipo de id,
+--    mismo UNIQUE por sucursal, mismas policies. Permite clonar los hooks y
+--    la UI en vez de inventar una forma nueva.
+-- -------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS public.marcas (
+  id           uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  nombre       text NOT NULL CHECK (length(btrim(nombre)) > 0),
+  sucursal_id  bigint NOT NULL REFERENCES public.sucursales(id) ON DELETE CASCADE,
+  activa       boolean NOT NULL DEFAULT true,
+  created_at   timestamptz NOT NULL DEFAULT now(),
+  updated_at   timestamptz NOT NULL DEFAULT now(),
+  UNIQUE (sucursal_id, nombre)
+);
+
+CREATE INDEX IF NOT EXISTS idx_marcas_sucursal ON public.marcas (sucursal_id);
+
+COMMENT ON TABLE public.marcas IS
+  'Marcas comerciales por sucursal (Manaos, La Virginia, Placer...). Ortogonal a categorias: un producto tiene una marca Y una categoría. Mig 158.';
+
+ALTER TABLE public.productos
+  ADD COLUMN IF NOT EXISTS marca_id uuid REFERENCES public.marcas(id) ON DELETE SET NULL;
+
+CREATE INDEX IF NOT EXISTS idx_productos_marca_id ON public.productos (marca_id);
+
+COMMENT ON COLUMN public.productos.marca_id IS
+  'FK a marcas. NULL = sin marca asignada (los reportes por marca lo informan como cobertura incompleta). Mig 158.';
+
+-- -------------------------------------------------------------------------
+-- 2. updated_at + RLS (patrón mt_categorias_*)
+-- -------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.marcas_set_updated_at()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $fn$
+BEGIN
+  NEW.updated_at = now();
+  RETURN NEW;
+END;
+$fn$;
+
+DROP TRIGGER IF EXISTS trg_marcas_updated_at ON public.marcas;
+CREATE TRIGGER trg_marcas_updated_at
+  BEFORE UPDATE ON public.marcas
+  FOR EACH ROW
+  EXECUTE FUNCTION public.marcas_set_updated_at();
+
+ALTER TABLE public.marcas ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS mt_marcas_select ON public.marcas;
+CREATE POLICY mt_marcas_select
+  ON public.marcas FOR SELECT TO authenticated
+  USING (sucursal_id = public.current_sucursal_id());
+
+DROP POLICY IF EXISTS mt_marcas_insert ON public.marcas;
+CREATE POLICY mt_marcas_insert
+  ON public.marcas FOR INSERT TO authenticated
+  WITH CHECK (public.es_admin() AND sucursal_id = public.current_sucursal_id());
+
+DROP POLICY IF EXISTS mt_marcas_update ON public.marcas;
+CREATE POLICY mt_marcas_update
+  ON public.marcas FOR UPDATE TO authenticated
+  USING (public.es_admin() AND sucursal_id = public.current_sucursal_id())
+  WITH CHECK (public.es_admin() AND sucursal_id = public.current_sucursal_id());
+
+DROP POLICY IF EXISTS mt_marcas_delete ON public.marcas;
+CREATE POLICY mt_marcas_delete
+  ON public.marcas FOR DELETE TO authenticated
+  USING (public.es_admin() AND sucursal_id = public.current_sucursal_id());
+
+-- -------------------------------------------------------------------------
+-- 3. Backfill determinístico: categorías de la sucursal 1 que son marcas.
+--    Por id explícito. Idempotente.
+-- -------------------------------------------------------------------------
+INSERT INTO public.marcas (nombre, sucursal_id)
+SELECT c.nombre, c.sucursal_id
+FROM public.categorias c
+WHERE c.id IN (
+  '334430bf-62d8-4c15-a940-3e6204e0c8f9',  -- ALICANTE
+  '26c9d4f3-00bb-42d0-b0e5-8623ad568918',  -- LA VIRGINIA
+  'e7ab6a04-ac9e-44af-bcb4-010b0342643a',  -- MANAOS
+  'e0669c9e-73dc-4aa1-aa83-a8c86cad99bc',  -- PLACER
+  '8af81b1b-d5f9-4f00-9f0e-06ea6de368d4',  -- MOLINO
+  '739fd3b8-37e2-494f-9c74-c0e6379d2c21',  -- VILLAMANAOS//BICHY
+  '5acbef81-2ce8-42f7-aa1c-13f530d1f6ba'   -- PINDAPOY
+)
+ON CONFLICT (sucursal_id, nombre) DO NOTHING;
+
+-- Los productos que cuelgan de esas categorías heredan la marca homónima.
+-- Solo se pisa marca_id si está NULL: re-aplicar no deshace correcciones
+-- manuales hechas desde la UI.
+UPDATE public.productos p
+SET marca_id = m.id
+FROM public.categorias c
+JOIN public.marcas m
+  ON m.sucursal_id = c.sucursal_id
+ AND lower(btrim(m.nombre)) = lower(btrim(c.nombre))
+WHERE p.categoria_id = c.id
+  AND p.sucursal_id = c.sucursal_id
+  AND p.marca_id IS NULL
+  AND c.id IN (
+    '334430bf-62d8-4c15-a940-3e6204e0c8f9',
+    '26c9d4f3-00bb-42d0-b0e5-8623ad568918',
+    'e7ab6a04-ac9e-44af-bcb4-010b0342643a',
+    'e0669c9e-73dc-4aa1-aa83-a8c86cad99bc',
+    '8af81b1b-d5f9-4f00-9f0e-06ea6de368d4',
+    '739fd3b8-37e2-494f-9c74-c0e6379d2c21',
+    '5acbef81-2ce8-42f7-aa1c-13f530d1f6ba'
+  );
+
+-- -------------------------------------------------------------------------
+-- 4. Asignación masiva. Clon de actualizar_minimo_venta_masivo (mig 147) con
+--    dos modos, porque el trabajo real es mixto: "toda esta categoría es
+--    Manaos" (sucursal 1) y "estos 14 productos que filtré por nombre son
+--    Placer" (sucursal 2).
+--
+--    p_marca_id NULL quita la marca (permite deshacer una asignación errada).
+-- -------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.asignar_marca_masiva(
+  p_marca_id     uuid,
+  p_categoria_id uuid    DEFAULT NULL,
+  p_producto_ids bigint[] DEFAULT NULL
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $fn$
+DECLARE
+  v_actualizados integer := 0;
+BEGIN
+  IF NOT es_encargado_o_admin() THEN
+    RAISE EXCEPTION 'Solo un admin o encargado puede asignar marcas'
+      USING ERRCODE = '42501';
+  END IF;
+
+  IF p_categoria_id IS NULL AND (p_producto_ids IS NULL OR cardinality(p_producto_ids) = 0) THEN
+    RAISE EXCEPTION 'Indicá una categoría o una lista de productos';
+  END IF;
+
+  -- La marca tiene que ser de la sucursal activa: sin este chequeo se podría
+  -- pegar un producto de una sucursal a una marca de la otra.
+  IF p_marca_id IS NOT NULL AND NOT EXISTS (
+    SELECT 1 FROM marcas
+    WHERE id = p_marca_id AND sucursal_id = current_sucursal_id()
+  ) THEN
+    RAISE EXCEPTION 'La marca no existe en esta sucursal';
+  END IF;
+
+  UPDATE productos
+  SET marca_id = p_marca_id
+  WHERE sucursal_id = current_sucursal_id()
+    AND (
+      (p_categoria_id IS NOT NULL AND categoria_id = p_categoria_id)
+      OR (p_producto_ids IS NOT NULL AND id = ANY (p_producto_ids))
+    );
+  GET DIAGNOSTICS v_actualizados = ROW_COUNT;
+
+  RETURN jsonb_build_object('success', true, 'actualizados', v_actualizados);
+END;
+$fn$;
+
+ALTER FUNCTION public.asignar_marca_masiva(uuid, uuid, bigint[]) OWNER TO postgres;
+REVOKE ALL ON FUNCTION public.asignar_marca_masiva(uuid, uuid, bigint[]) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.asignar_marca_masiva(uuid, uuid, bigint[]) TO authenticated;
+
+COMMENT ON FUNCTION public.asignar_marca_masiva(uuid, uuid, bigint[]) IS
+  'Asigna una marca a todos los productos de una categoría o a una lista de productos, en la sucursal activa. p_marca_id NULL la quita. Mig 158.';

--- a/migrations/159_metas_preventista.sql
+++ b/migrations/159_metas_preventista.sql
@@ -1,0 +1,239 @@
+-- =========================================================================
+-- 159_metas_preventista.sql
+--
+-- "Quiero ponerles objetivo a los preventistas y que los vean en la app en
+--  tiempo real: 2 millones de Manaos al mes, y de esos 2 millones, 100
+--  gaseosas de 3 litros. Después les pago un básico, la comisión y un monto
+--  por objetivo cumplido."
+--
+-- `metas_gerenciales` (mig 108) no sirve para esto: sus dimensiones son
+-- (sucursal, periodo, metrica ∈ {venta, margen_neto}). No tiene preventista ni
+-- alcance por marca/categoría/producto.
+--
+-- Se sigue el precedente de `comision_reglas` (mig 150): lectura por RLS,
+-- escritura sólo por RPC SECURITY DEFINER, baja lógica en vez de DELETE.
+--
+-- DIFERENCIA DELIBERADA con metas_gerenciales/comision_reglas: acá
+-- `sucursal_id` es NOT NULL. Una meta "de toda la red" para una persona no
+-- significa nada —un preventista trabaja en una sucursal— y con NULL el índice
+-- único y el filtro del avance se complican al pedo.
+--
+-- DECISIÓN: no hay columna `unidad` ($ vs unidades). Se deduce de `tipo_meta`.
+-- Una columna redundante con tipo_meta es una fuente garantizada de filas
+-- inconsistentes.
+-- =========================================================================
+
+CREATE TABLE IF NOT EXISTS public.metas_preventista (
+  id             bigint GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+  sucursal_id    bigint NOT NULL REFERENCES sucursales(id),
+  preventista_id uuid   NOT NULL REFERENCES perfiles(id),
+  periodo        date   NOT NULL,          -- primer día del mes
+  tipo_meta      text   NOT NULL,
+  -- Alcance: como mucho UNO no nulo. Todos NULL = la meta es global.
+  marca_id       uuid   REFERENCES marcas(id) ON DELETE CASCADE,
+  categoria_id   uuid   REFERENCES categorias(id) ON DELETE CASCADE,
+  producto_id    bigint REFERENCES productos(id) ON DELETE CASCADE,
+  valor_objetivo numeric NOT NULL CHECK (valor_objetivo > 0),
+  activo         boolean NOT NULL DEFAULT true,
+  usuario_id     uuid,                     -- quién la cargó
+  created_at     timestamptz NOT NULL DEFAULT now(),
+  updated_at     timestamptz NOT NULL DEFAULT now(),
+
+  CONSTRAINT metas_preventista_tipo_check CHECK (
+    tipo_meta IN ('facturacion', 'unidades', 'cobertura', 'clientes_nuevos')
+  ),
+  -- Un solo eje de alcance: "Manaos gaseosas" se pide con dos metas, no con
+  -- una fila ambigua cuya intersección nadie sabe leer.
+  CONSTRAINT metas_preventista_alcance_unico CHECK (
+    (marca_id IS NOT NULL)::int
+    + (categoria_id IS NOT NULL)::int
+    + (producto_id IS NOT NULL)::int <= 1
+  ),
+  -- Cobertura y clientes nuevos se cuentan sobre clientes, no sobre productos.
+  CONSTRAINT metas_preventista_alcance_valido CHECK (
+    tipo_meta IN ('facturacion', 'unidades')
+    OR (marca_id IS NULL AND categoria_id IS NULL AND producto_id IS NULL)
+  ),
+  -- "100 unidades" sin decir de qué no es una meta.
+  CONSTRAINT metas_preventista_unidades_check CHECK (
+    tipo_meta <> 'unidades'
+    OR marca_id IS NOT NULL OR categoria_id IS NOT NULL OR producto_id IS NOT NULL
+  )
+);
+
+COMMENT ON TABLE public.metas_preventista IS
+  'Objetivos mensuales por preventista. tipo_meta define la unidad ($ para facturacion, unidades para unidades, clientes para cobertura/clientes_nuevos). marca_id/categoria_id/producto_id: como mucho uno, NULL = meta global. Mig 159.';
+
+-- COALESCE en el índice único (patrón de metas_gerenciales_uidx): sin esto, dos
+-- metas globales del mismo tipo y mes se duplicarían, porque NULL <> NULL.
+CREATE UNIQUE INDEX IF NOT EXISTS metas_preventista_uidx
+  ON public.metas_preventista (
+    preventista_id, periodo, tipo_meta,
+    COALESCE(marca_id, '00000000-0000-0000-0000-000000000000'::uuid),
+    COALESCE(categoria_id, '00000000-0000-0000-0000-000000000000'::uuid),
+    COALESCE(producto_id, -1)
+  );
+
+CREATE INDEX IF NOT EXISTS metas_preventista_periodo_idx
+  ON public.metas_preventista (sucursal_id, periodo, activo);
+
+-- El avance se calcula filtrando pedidos por (usuario_id, fecha, estado). El
+-- gerencial indexa por sucursal_id, que no sirve para esta consulta.
+CREATE INDEX IF NOT EXISTS pedidos_usuario_fecha_idx
+  ON public.pedidos (usuario_id, fecha, estado);
+
+CREATE OR REPLACE FUNCTION public.metas_preventista_set_updated_at()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $fn$
+BEGIN
+  NEW.updated_at = now();
+  RETURN NEW;
+END;
+$fn$;
+
+DROP TRIGGER IF EXISTS trg_metas_preventista_updated_at ON public.metas_preventista;
+CREATE TRIGGER trg_metas_preventista_updated_at
+  BEFORE UPDATE ON public.metas_preventista
+  FOR EACH ROW
+  EXECUTE FUNCTION public.metas_preventista_set_updated_at();
+
+-- -------------------------------------------------------------------------
+-- RLS. Dos policies de SELECT: se combinan con OR, así que el admin ve todo y
+-- el preventista exclusivamente sus filas. Sin policies de INSERT/UPDATE: la
+-- escritura va sólo por los RPCs de abajo (igual que comision_reglas).
+-- -------------------------------------------------------------------------
+ALTER TABLE public.metas_preventista ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS metas_preventista_admin_select ON public.metas_preventista;
+CREATE POLICY metas_preventista_admin_select ON public.metas_preventista
+  FOR SELECT TO authenticated
+  USING (EXISTS (
+    SELECT 1 FROM perfiles WHERE id = auth.uid() AND rol IN ('admin', 'encargado')
+  ));
+
+DROP POLICY IF EXISTS metas_preventista_propio_select ON public.metas_preventista;
+CREATE POLICY metas_preventista_propio_select ON public.metas_preventista
+  FOR SELECT TO authenticated
+  USING (preventista_id = auth.uid());
+
+-- -------------------------------------------------------------------------
+-- Alta / edición (admin-only)
+-- -------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.guardar_meta_preventista(
+  p_id             bigint,
+  p_sucursal_id    bigint,
+  p_preventista_id uuid,
+  p_periodo        date,
+  p_tipo_meta      text,
+  p_valor_objetivo numeric,
+  p_marca_id       uuid   DEFAULT NULL,
+  p_categoria_id   uuid   DEFAULT NULL,
+  p_producto_id    bigint DEFAULT NULL
+)
+RETURNS bigint
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $fn$
+DECLARE
+  v_id      bigint;
+  v_periodo date := date_trunc('month', COALESCE(p_periodo, current_date))::date;
+BEGIN
+  IF NOT es_admin() THEN
+    RAISE EXCEPTION 'Solo un admin puede definir objetivos' USING ERRCODE = '42501';
+  END IF;
+
+  IF p_valor_objetivo IS NULL OR p_valor_objetivo <= 0 THEN
+    RAISE EXCEPTION 'El objetivo debe ser mayor a 0';
+  END IF;
+
+  IF p_sucursal_id IS NULL THEN
+    RAISE EXCEPTION 'Indicá la sucursal del objetivo';
+  END IF;
+
+  -- El admin sólo carga metas en sucursales que tiene asignadas.
+  IF NOT EXISTS (
+    SELECT 1 FROM usuario_sucursales
+    WHERE usuario_id = auth.uid() AND sucursal_id = p_sucursal_id
+  ) THEN
+    RAISE EXCEPTION 'No tenés acceso a esa sucursal' USING ERRCODE = '42501';
+  END IF;
+
+  -- Sin este chequeo se cargan metas contra usuarios que nunca van a aparecer
+  -- en el reporte, y el gerente ve un objetivo que jamás avanza.
+  IF NOT EXISTS (
+    SELECT 1 FROM usuario_sucursales us
+    WHERE us.usuario_id = p_preventista_id AND us.sucursal_id = p_sucursal_id
+  ) THEN
+    RAISE EXCEPTION 'Ese usuario no trabaja en la sucursal elegida';
+  END IF;
+
+  IF p_id IS NULL THEN
+    INSERT INTO metas_preventista (
+      sucursal_id, preventista_id, periodo, tipo_meta,
+      marca_id, categoria_id, producto_id, valor_objetivo, usuario_id
+    ) VALUES (
+      p_sucursal_id, p_preventista_id, v_periodo, p_tipo_meta,
+      p_marca_id, p_categoria_id, p_producto_id, p_valor_objetivo, auth.uid()
+    )
+    -- Re-cargar la misma meta del mismo mes actualiza el valor en vez de
+    -- explotar con un unique violation críptico.
+    ON CONFLICT (
+      preventista_id, periodo, tipo_meta,
+      COALESCE(marca_id, '00000000-0000-0000-0000-000000000000'::uuid),
+      COALESCE(categoria_id, '00000000-0000-0000-0000-000000000000'::uuid),
+      COALESCE(producto_id, -1)
+    ) DO UPDATE SET
+      valor_objetivo = EXCLUDED.valor_objetivo,
+      activo         = true,
+      usuario_id     = EXCLUDED.usuario_id
+    RETURNING id INTO v_id;
+  ELSE
+    UPDATE metas_preventista SET
+      preventista_id = p_preventista_id,
+      periodo        = v_periodo,
+      tipo_meta      = p_tipo_meta,
+      marca_id       = p_marca_id,
+      categoria_id   = p_categoria_id,
+      producto_id    = p_producto_id,
+      valor_objetivo = p_valor_objetivo
+    WHERE id = p_id
+    RETURNING id INTO v_id;
+
+    IF v_id IS NULL THEN
+      RAISE EXCEPTION 'El objetivo % no existe', p_id USING ERRCODE = 'no_data_found';
+    END IF;
+  END IF;
+
+  RETURN v_id;
+END;
+$fn$;
+
+ALTER FUNCTION public.guardar_meta_preventista(bigint, bigint, uuid, date, text, numeric, uuid, uuid, bigint) OWNER TO postgres;
+REVOKE ALL ON FUNCTION public.guardar_meta_preventista(bigint, bigint, uuid, date, text, numeric, uuid, uuid, bigint) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.guardar_meta_preventista(bigint, bigint, uuid, date, text, numeric, uuid, uuid, bigint) TO authenticated;
+
+-- -------------------------------------------------------------------------
+-- Baja lógica: el pasado no se reescribe. Si en octubre se borra la meta de
+-- agosto, el histórico de agosto tiene que seguir mostrando contra qué se
+-- midió.
+-- -------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.desactivar_meta_preventista(p_id bigint)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $fn$
+BEGIN
+  IF NOT es_admin() THEN
+    RAISE EXCEPTION 'Solo un admin puede dar de baja objetivos' USING ERRCODE = '42501';
+  END IF;
+
+  UPDATE metas_preventista SET activo = false WHERE id = p_id;
+END;
+$fn$;
+
+ALTER FUNCTION public.desactivar_meta_preventista(bigint) OWNER TO postgres;
+REVOKE ALL ON FUNCTION public.desactivar_meta_preventista(bigint) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.desactivar_meta_preventista(bigint) TO authenticated;

--- a/migrations/160_avance_metas_preventista.sql
+++ b/migrations/160_avance_metas_preventista.sql
@@ -1,0 +1,229 @@
+-- =========================================================================
+-- 160_avance_metas_preventista.sql
+--
+-- Avance en vivo de los objetivos de un preventista. Lo consume el dashboard
+-- del propio preventista (sin argumentos) y el admin mirando a cualquiera.
+--
+-- BASE DE CÁLCULO — una sola, fijada acá y no se negocia:
+--   venta = pedidos con estado='entregado' y canal='app'
+--   ítems con es_bonificacion = false
+-- Es la misma de reporte_gerencial (mig 130), así que el % de avance cierra
+-- peso a peso contra la columna "venta" del reporte gerencial.
+-- OJO: calcular_comisiones (mig 150) usa estado <> 'cancelado' A PROPÓSITO
+-- (la comisión se devenga al vender, no al entregar). No mezclar las dos.
+--
+-- SEGURIDAD: la función es SECURITY DEFINER, o sea que BYPASEA la RLS de
+-- metas_preventista y de pedidos, y `p_preventista_id` viene del cliente. El
+-- IF de las primeras líneas es lo único que separa a un preventista de las
+-- ventas y los objetivos de sus compañeros.
+--
+-- El prorrateo se calcula ACÁ, no en el front: metas_gerenciales lo hace en el
+-- front y por eso su semáforo puede discrepar del de esta pantalla.
+-- =========================================================================
+
+CREATE OR REPLACE FUNCTION public.avance_metas_preventista(
+  p_preventista_id uuid DEFAULT NULL,
+  p_periodo        date DEFAULT NULL
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $fn$
+DECLARE
+  v_target      uuid;
+  v_periodo     date;
+  v_hasta       date;
+  v_dias_total  integer;
+  v_dias_trans  integer;
+  v_nombre      text;
+  v_sucursales  bigint[];
+  v_result      jsonb;
+  v_sin_marca   integer := 0;
+  v_hay_marca   boolean := false;
+BEGIN
+  v_target  := COALESCE(p_preventista_id, auth.uid());
+  v_periodo := date_trunc('month', COALESCE(p_periodo, current_date))::date;
+  v_hasta   := (v_periodo + interval '1 month' - interval '1 day')::date;
+
+  IF v_target IS NULL THEN
+    RAISE EXCEPTION 'Sin usuario' USING ERRCODE = '42501';
+  END IF;
+
+  -- El muro. Un preventista sólo puede pedir lo suyo.
+  -- auth.uid() NULL = service_role / SQL editor: exento, igual que reporte_gerencial.
+  IF auth.uid() IS NOT NULL AND v_target <> auth.uid() AND NOT es_admin() THEN
+    RAISE EXCEPTION 'Acceso denegado' USING ERRCODE = '42501';
+  END IF;
+
+  SELECT nombre INTO v_nombre FROM perfiles WHERE id = v_target;
+
+  v_dias_total := EXTRACT(DAY FROM v_hasta)::integer;
+  -- Mes en curso: días ya transcurridos. Mes cerrado: el mes completo.
+  v_dias_trans := CASE
+    WHEN current_date > v_hasta  THEN v_dias_total
+    WHEN current_date < v_periodo THEN 0
+    ELSE EXTRACT(DAY FROM current_date)::integer
+  END;
+
+  -- Las sucursales relevantes son las de las metas cargadas, no todas las del
+  -- usuario: si tiene metas sólo en Tucumán, lo vendido en Taco Pozo no cuenta.
+  SELECT array_agg(DISTINCT sucursal_id) INTO v_sucursales
+  FROM metas_preventista
+  WHERE preventista_id = v_target AND periodo = v_periodo AND activo;
+
+  IF v_sucursales IS NULL THEN
+    RETURN jsonb_build_object(
+      'preventista_id', v_target,
+      'nombre', v_nombre,
+      'periodo', v_periodo,
+      'dias_transcurridos', v_dias_trans,
+      'dias_periodo', v_dias_total,
+      'metas', '[]'::jsonb,
+      'resumen', jsonb_build_object('total', 0, 'cumplidas', 0, 'en_riesgo', 0),
+      'productos_sin_marca', 0
+    );
+  END IF;
+
+  WITH
+  metas AS (
+    SELECT * FROM metas_preventista
+    WHERE preventista_id = v_target AND periodo = v_periodo AND activo
+  ),
+  -- Pedidos entregados del preventista en el mes. MATERIALIZED para que no se
+  -- re-evalúe una vez por meta.
+  ped AS MATERIALIZED (
+    SELECT id, cliente_id, sucursal_id
+    FROM pedidos
+    WHERE usuario_id = v_target
+      AND estado = 'entregado'
+      AND canal = 'app'
+      AND fecha BETWEEN v_periodo AND v_hasta
+      AND sucursal_id = ANY(v_sucursales)
+  ),
+  it AS MATERIALIZED (
+    SELECT p.sucursal_id, pi.cantidad, pi.subtotal, pi.es_bonificacion,
+           pi.producto_id, prod.categoria_id, prod.marca_id
+    FROM ped p
+    JOIN pedido_items pi ON pi.pedido_id = p.id
+    JOIN productos prod  ON prod.id = pi.producto_id
+    WHERE pi.es_bonificacion IS NOT TRUE
+  ),
+  -- Cliente nuevo = su PRIMER pedido entregado de la sucursal cae en el mes.
+  -- El usuario_id se toma de ese primer pedido, no del filtro del MIN: si no,
+  -- dos preventistas se atribuyen el mismo cliente.
+  primer_pedido AS (
+    SELECT DISTINCT ON (p.cliente_id, p.sucursal_id)
+           p.cliente_id, p.sucursal_id, p.usuario_id, p.fecha
+    FROM pedidos p
+    WHERE p.estado = 'entregado' AND p.canal = 'app'
+      AND p.sucursal_id = ANY(v_sucursales)
+    ORDER BY p.cliente_id, p.sucursal_id, p.fecha, p.id
+  ),
+  logrado AS (
+    SELECT m.*,
+      CASE m.tipo_meta
+        WHEN 'facturacion' THEN (
+          SELECT COALESCE(SUM(i.subtotal), 0) FROM it i
+          WHERE i.sucursal_id = m.sucursal_id
+            AND (m.marca_id     IS NULL OR i.marca_id     = m.marca_id)
+            AND (m.categoria_id IS NULL OR i.categoria_id = m.categoria_id)
+            AND (m.producto_id  IS NULL OR i.producto_id  = m.producto_id)
+        )
+        WHEN 'unidades' THEN (
+          SELECT COALESCE(SUM(i.cantidad), 0) FROM it i
+          WHERE i.sucursal_id = m.sucursal_id
+            AND (m.marca_id     IS NULL OR i.marca_id     = m.marca_id)
+            AND (m.categoria_id IS NULL OR i.categoria_id = m.categoria_id)
+            AND (m.producto_id  IS NULL OR i.producto_id  = m.producto_id)
+        )
+        WHEN 'cobertura' THEN (
+          SELECT COUNT(DISTINCT p.cliente_id) FROM ped p
+          WHERE p.sucursal_id = m.sucursal_id
+        )
+        WHEN 'clientes_nuevos' THEN (
+          SELECT COUNT(*) FROM primer_pedido pp
+          WHERE pp.sucursal_id = m.sucursal_id
+            AND pp.usuario_id = v_target
+            AND pp.fecha BETWEEN v_periodo AND v_hasta
+        )
+      END AS logrado
+    FROM metas m
+  ),
+  calc AS (
+    SELECT l.*,
+      ROUND(l.valor_objetivo * v_dias_trans / NULLIF(v_dias_total, 0), 2) AS objetivo_prorrateado,
+      ROUND(100 * l.logrado / NULLIF(l.valor_objetivo, 0), 1) AS pct
+    FROM logrado l
+  )
+  SELECT jsonb_build_object(
+    'preventista_id', v_target,
+    'nombre', v_nombre,
+    'periodo', v_periodo,
+    'dias_transcurridos', v_dias_trans,
+    'dias_periodo', v_dias_total,
+    'metas', COALESCE(jsonb_agg(jsonb_build_object(
+        'id', c.id,
+        'tipo_meta', c.tipo_meta,
+        'unidad', CASE c.tipo_meta
+                    WHEN 'facturacion' THEN '$'
+                    WHEN 'unidades'    THEN 'u'
+                    ELSE 'clientes' END,
+        'alcance', CASE
+          WHEN c.marca_id IS NOT NULL THEN jsonb_build_object(
+            'tipo', 'marca', 'id', c.marca_id,
+            'nombre', (SELECT nombre FROM marcas WHERE id = c.marca_id))
+          WHEN c.categoria_id IS NOT NULL THEN jsonb_build_object(
+            'tipo', 'categoria', 'id', c.categoria_id,
+            'nombre', (SELECT nombre FROM categorias WHERE id = c.categoria_id))
+          WHEN c.producto_id IS NOT NULL THEN jsonb_build_object(
+            'tipo', 'producto', 'id', c.producto_id,
+            'nombre', (SELECT nombre FROM productos WHERE id = c.producto_id))
+          ELSE jsonb_build_object('tipo', 'global', 'id', NULL, 'nombre', NULL)
+        END,
+        'objetivo', c.valor_objetivo,
+        'logrado', c.logrado,
+        'pct', COALESCE(c.pct, 0),
+        'objetivo_prorrateado', COALESCE(c.objetivo_prorrateado, 0),
+        'estado', CASE
+          WHEN c.logrado >= c.valor_objetivo THEN 'cumplida'
+          WHEN c.logrado >= COALESCE(c.objetivo_prorrateado, 0) THEN 'adelantado'
+          WHEN c.logrado >= 0.8 * COALESCE(c.objetivo_prorrateado, 0) THEN 'en_curso'
+          ELSE 'en_riesgo'
+        END
+      ) ORDER BY c.tipo_meta, c.id), '[]'::jsonb),
+    'resumen', jsonb_build_object(
+      'total', COUNT(*),
+      'cumplidas', COUNT(*) FILTER (WHERE c.logrado >= c.valor_objetivo),
+      'en_riesgo', COUNT(*) FILTER (
+        WHERE c.logrado < 0.8 * COALESCE(c.objetivo_prorrateado, 0)
+          AND c.logrado < c.valor_objetivo)
+    )
+  ) INTO v_result
+  FROM calc c;
+
+  -- Cobertura del dato: una meta por marca sobre un catálogo a medio marcar
+  -- mide de menos y el error es invisible. Mismo criterio que el banner
+  -- items_sin_desglose de VistaComisiones.
+  SELECT EXISTS (
+    SELECT 1 FROM metas_preventista
+    WHERE preventista_id = v_target AND periodo = v_periodo AND activo
+      AND marca_id IS NOT NULL
+  ) INTO v_hay_marca;
+
+  IF v_hay_marca THEN
+    SELECT COUNT(*) INTO v_sin_marca
+    FROM productos WHERE marca_id IS NULL AND sucursal_id = ANY(v_sucursales);
+  END IF;
+
+  RETURN v_result || jsonb_build_object('productos_sin_marca', v_sin_marca);
+END;
+$fn$;
+
+ALTER FUNCTION public.avance_metas_preventista(uuid, date) OWNER TO postgres;
+REVOKE ALL ON FUNCTION public.avance_metas_preventista(uuid, date) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.avance_metas_preventista(uuid, date) TO authenticated;
+
+COMMENT ON FUNCTION public.avance_metas_preventista(uuid, date) IS
+  'Avance de los objetivos mensuales de un preventista. Sin argumentos devuelve los del usuario logueado; con p_preventista_id requiere admin. Base: pedidos entregados canal app, sin bonificaciones. Mig 160.';

--- a/migrations/161_rendimiento_preventistas.sql
+++ b/migrations/161_rendimiento_preventistas.sql
@@ -1,0 +1,174 @@
+-- =========================================================================
+-- 161_rendimiento_preventistas.sql
+--
+-- "Quiero una sección donde analizar el rendimiento de cada preventista:
+--  ventas totales, facturación, facturación por categoría de venta."
+--
+-- POR QUÉ UN RPC NUEVO Y NO EXTENDER reporte_gerencial:
+--  1. Agregarle un parámetro cambia la firma → obliga a DROP FUNCTION y a
+--     reescribir sus ~200 líneas y 20 CTEs, que es exactamente lo que las
+--     migs 124/130 lograron evitar.
+--  2. El breakdown marca × preventista multiplica el costo del RPC más pesado
+--     de la app, y lo pagarían todas las pantallas que lo consumen aunque no
+--     miren metas.
+--  3. El gerencial es de rango libre; las metas son estrictamente mensuales.
+--     Un % de cumplimiento sobre un rango de 3 días no significa nada.
+--
+-- Misma base que avance_metas_preventista (mig 160): entregado + canal app,
+-- sin bonificaciones. La cascada de costo se copia LITERAL de la mig 130 para
+-- que el margen coincida con el del reporte gerencial.
+-- =========================================================================
+
+CREATE OR REPLACE FUNCTION public.rendimiento_preventistas(
+  p_sucursal_id bigint DEFAULT NULL,
+  p_periodo     date   DEFAULT NULL
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $fn$
+DECLARE
+  v_periodo    date := date_trunc('month', COALESCE(p_periodo, current_date))::date;
+  v_hasta      date;
+  v_sucursales bigint[];
+  v_asignadas  bigint[];
+  v_es_servicio boolean := auth.uid() IS NULL;
+  v_result     jsonb;
+BEGIN
+  v_hasta := (v_periodo + interval '1 month' - interval '1 day')::date;
+
+  IF NOT v_es_servicio AND NOT es_admin() THEN
+    RAISE EXCEPTION 'Solo un admin puede ver el rendimiento del equipo' USING ERRCODE = '42501';
+  END IF;
+
+  -- Resolución de sucursales: mismo criterio que reporte_gerencial.
+  -- p_sucursal_id NULL = red consolidada, acotada a las asignadas.
+  IF v_es_servicio THEN
+    SELECT array_agg(id) INTO v_asignadas FROM sucursales;
+  ELSE
+    SELECT array_agg(sucursal_id) INTO v_asignadas
+    FROM usuario_sucursales WHERE usuario_id = auth.uid();
+  END IF;
+
+  IF p_sucursal_id IS NULL THEN
+    v_sucursales := v_asignadas;
+  ELSE
+    IF NOT v_es_servicio AND NOT (p_sucursal_id = ANY(v_asignadas)) THEN
+      RAISE EXCEPTION 'Acceso denegado: la sucursal % no está asignada al usuario', p_sucursal_id
+        USING ERRCODE = '42501';
+    END IF;
+    v_sucursales := ARRAY[p_sucursal_id];
+  END IF;
+
+  IF v_sucursales IS NULL OR array_length(v_sucursales, 1) IS NULL THEN
+    RAISE EXCEPTION 'Acceso denegado: sin sucursales disponibles' USING ERRCODE = '42501';
+  END IF;
+
+  WITH
+  ped AS MATERIALIZED (
+    SELECT id, cliente_id, usuario_id, sucursal_id, total
+    FROM pedidos
+    WHERE estado = 'entregado' AND canal = 'app'
+      AND fecha BETWEEN v_periodo AND v_hasta
+      AND sucursal_id = ANY(v_sucursales)
+  ),
+  it AS MATERIALIZED (
+    SELECT p.usuario_id, pi.cantidad, pi.subtotal,
+           -- Cascada de costo de la mig 130, literal.
+           pi.cantidad * COALESCE(pi.costo_unitario_al_crear, prod.costo_promedio, prod.costo_real,
+             prod.costo_sin_iva * (1 + COALESCE(prod.impuestos_internos, 0) / 100)) AS costo,
+           COALESCE(mar.nombre, '(sin marca)')          AS marca,
+           COALESCE(NULLIF(prod.categoria, ''), '(sin categoría)') AS categoria
+    FROM ped p
+    JOIN pedido_items pi ON pi.pedido_id = p.id
+    JOIN productos prod  ON prod.id = pi.producto_id
+    LEFT JOIN marcas mar ON mar.id = prod.marca_id
+    WHERE pi.es_bonificacion IS NOT TRUE
+  ),
+  primer_pedido AS (
+    SELECT DISTINCT ON (p.cliente_id, p.sucursal_id)
+           p.cliente_id, p.sucursal_id, p.usuario_id, p.fecha
+    FROM pedidos p
+    WHERE p.estado = 'entregado' AND p.canal = 'app'
+      AND p.sucursal_id = ANY(v_sucursales)
+    ORDER BY p.cliente_id, p.sucursal_id, p.fecha, p.id
+  ),
+  base AS (
+    SELECT p.usuario_id,
+           COUNT(*)                        AS pedidos,
+           COUNT(DISTINCT p.cliente_id)    AS cobertura,
+           COALESCE(SUM(p.total), 0)       AS venta_pedidos
+    FROM ped p GROUP BY p.usuario_id
+  ),
+  items AS (
+    SELECT i.usuario_id,
+           COALESCE(SUM(i.subtotal), 0) AS venta,
+           COALESCE(SUM(i.cantidad), 0) AS unidades,
+           COALESCE(SUM(i.subtotal - i.costo), 0) AS margen_comercial
+    FROM it i GROUP BY i.usuario_id
+  ),
+  nuevos AS (
+    SELECT pp.usuario_id, COUNT(*) AS clientes_nuevos
+    FROM primer_pedido pp
+    WHERE pp.fecha BETWEEN v_periodo AND v_hasta
+    GROUP BY pp.usuario_id
+  ),
+  por_marca AS (
+    SELECT t.usuario_id, jsonb_agg(jsonb_build_object(
+             'marca', t.marca, 'venta', t.venta, 'unidades', t.unidades
+           ) ORDER BY t.venta DESC) AS detalle
+    FROM (SELECT usuario_id, marca, SUM(subtotal) AS venta, SUM(cantidad) AS unidades
+          FROM it GROUP BY usuario_id, marca) t
+    GROUP BY t.usuario_id
+  ),
+  por_categoria AS (
+    SELECT t.usuario_id, jsonb_agg(jsonb_build_object(
+             'categoria', t.categoria, 'venta', t.venta, 'unidades', t.unidades
+           ) ORDER BY t.venta DESC) AS detalle
+    FROM (SELECT usuario_id, categoria, SUM(subtotal) AS venta, SUM(cantidad) AS unidades
+          FROM it GROUP BY usuario_id, categoria) t
+    GROUP BY t.usuario_id
+  ),
+  metas AS (
+    SELECT preventista_id, COUNT(*) AS total FROM metas_preventista
+    WHERE periodo = v_periodo AND activo AND sucursal_id = ANY(v_sucursales)
+    GROUP BY preventista_id
+  )
+  SELECT jsonb_build_object(
+    'periodo', v_periodo,
+    'preventistas', COALESCE(jsonb_agg(jsonb_build_object(
+      'preventista_id', b.usuario_id,
+      'nombre', COALESCE(pf.nombre, '(sin perfil)'),
+      'rol', pf.rol,
+      'pedidos', b.pedidos,
+      'venta', COALESCE(i.venta, 0),
+      'unidades', COALESCE(i.unidades, 0),
+      'margen_comercial', COALESCE(i.margen_comercial, 0),
+      'cobertura', b.cobertura,
+      'clientes_nuevos', COALESCE(n.clientes_nuevos, 0),
+      'ticket', ROUND(COALESCE(i.venta, 0) / NULLIF(b.pedidos, 0), 2),
+      'metas_cargadas', COALESCE(mt.total, 0),
+      'por_marca', COALESCE(pm.detalle, '[]'::jsonb),
+      'por_categoria', COALESCE(pc.detalle, '[]'::jsonb)
+    ) ORDER BY COALESCE(i.venta, 0) DESC), '[]'::jsonb)
+  ) INTO v_result
+  FROM base b
+  LEFT JOIN perfiles pf     ON pf.id = b.usuario_id
+  LEFT JOIN items i         ON i.usuario_id = b.usuario_id
+  LEFT JOIN nuevos n        ON n.usuario_id = b.usuario_id
+  LEFT JOIN por_marca pm    ON pm.usuario_id = b.usuario_id
+  LEFT JOIN por_categoria pc ON pc.usuario_id = b.usuario_id
+  LEFT JOIN metas mt        ON mt.preventista_id = b.usuario_id;
+
+  RETURN v_result;
+END;
+$fn$;
+
+ALTER FUNCTION public.rendimiento_preventistas(bigint, date) OWNER TO postgres;
+REVOKE ALL ON FUNCTION public.rendimiento_preventistas(bigint, date) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.rendimiento_preventistas(bigint, date) TO authenticated;
+
+COMMENT ON FUNCTION public.rendimiento_preventistas(bigint, date) IS
+  'Rendimiento mensual del equipo comercial: venta, unidades, margen, cobertura, clientes nuevos y breakdown por marca y categoría, por preventista. Admin-only. Misma base que avance_metas_preventista. Mig 161.';

--- a/migrations/MANIFEST.md
+++ b/migrations/MANIFEST.md
@@ -1,6 +1,6 @@
 # MANIFEST de migraciones — mapeo repo ↔ producción
 
-> **Fechado: 2026-07-28** · Proyecto prod `hmuchlzmuqqxcldbzkgc` (ManaosApp) · región `sa-east-1`.
+> **Fechado: 2026-08-03** · Proyecto prod `hmuchlzmuqqxcldbzkgc` (ManaosApp) · región `sa-east-1`.
 
 ## Regla de oro
 
@@ -126,10 +126,11 @@ funcional** y no se renombran los archivos: renombrarlos los desalinearía del l
 real lo da `version` y está en la sección A: en los dos casos el archivo de `main` quedó
 cronológicamente **fuera** del bloque 139–147 (uno antes, otro entre la 144 y la 145).
 
-**La próxima migración es la 156** — verificado contra el ledger el 2026-07-30: la última
-numerada es `155_perfil_roles`. Las **148–155** (origen del precio, reglas de comisión,
-`place_id`, horarios masivos, barridas y roles extra por sucursal) están aplicadas y mapean
-**1:1** con el ledger, así que no agregan ninguna excepción a las tablas de arriba.
+**La próxima migración es la 162** — verificado contra el ledger el 2026-08-03: la última
+numerada es `161_rendimiento_preventistas`. Las **148–161** (origen del precio, reglas de
+comisión, `place_id`, horarios masivos, barridas, roles extra por sucursal, horario obligatorio
+al cargar pedido, marcas y objetivos por preventista) están aplicadas y mapean **1:1** con el
+ledger, así que no agregan ninguna excepción a las tablas de arriba.
 
 **Antes de elegir el número de una migración nueva, mirar `ls migrations/` además del
 ledger**: el ledger no siempre lleva el prefijo, así que por sí solo no alcanza. Y si mergeaste

--- a/package-lock.json
+++ b/package-lock.json
@@ -6009,9 +6009,9 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
@@ -7609,9 +7609,9 @@
       }
     },
     "node_modules/fast-uri": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
-      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "dev": true,
       "funding": [
         {
@@ -10440,9 +10440,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.17",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
+      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
       "dev": true,
       "funding": [
         {
@@ -10900,9 +10900,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.14",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
-      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
+      "version": "8.5.25",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.25.tgz",
+      "integrity": "sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==",
       "dev": true,
       "funding": [
         {
@@ -10921,7 +10921,7 @@
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -45,6 +45,7 @@ const VistaGeolocalizacion = lazyWithReload(() => import('./components/vistas/Vi
 const AnalyticsContainer = lazyWithReload(() => import('./components/containers/AnalyticsContainer'))
 const ReportesContainer = lazyWithReload(() => import('./components/containers/ReportesContainer'))
 const ComisionesContainer = lazyWithReload(() => import('./components/containers/ComisionesContainer'))
+const MetasContainer = lazyWithReload(() => import('./components/containers/MetasContainer'))
 const ReportesGerencialesContainer = lazyWithReload(() => import('./components/containers/ReportesGerencialesContainer'))
 const RecorridosContainer = lazyWithReload(() => import('./components/containers/RecorridosContainer'))
 const RecorridoPreventistaContainer = lazyWithReload(() => import('./components/containers/RecorridoPreventistaContainer'))
@@ -339,6 +340,11 @@ function MainAppInner({ user, perfil, logout, authReady }: {
                 <Route
                   path="/comisiones"
                   element={isAdmin ? <ComisionesContainer /> : <Navigate to="/pedidos" replace />}
+                />
+
+                <Route
+                  path="/metas"
+                  element={isAdmin ? <MetasContainer /> : <Navigate to="/pedidos" replace />}
                 />
 
                 <Route

--- a/src/components/containers/ClientesContainer.tsx
+++ b/src/components/containers/ClientesContainer.tsx
@@ -303,6 +303,10 @@ export default function ClientesContainer(): React.ReactElement {
         telefono: data.telefono || undefined,
         contacto: data.contacto || undefined,
         horarios_atencion: data.horarios_atencion || undefined,
+        // dias_atencion faltaba en el patch: el selector de días de ModalCliente
+        // se editaba pero nunca se persistía (el bitmask lo usa el ruteo).
+        dias_atencion: data.dias_atencion ?? null,
+        sin_horario_fijo: data.sin_horario_fijo,
         horario_entrega: data.horario_entrega || undefined,
         rubro: data.rubro || undefined,
         notas: data.notas || undefined,
@@ -341,6 +345,8 @@ export default function ClientesContainer(): React.ReactElement {
       descuento_porcentaje: data.descuentoPorcentaje,
       contacto: data.contacto || undefined,
       horarios_atencion: data.horarios_atencion || undefined,
+      dias_atencion: data.dias_atencion ?? null,
+      sin_horario_fijo: data.sin_horario_fijo,
       horario_entrega: data.horario_entrega || undefined,
       rubro: data.rubro || undefined,
       notas: data.notas || undefined,

--- a/src/components/containers/DashboardContainer.tsx
+++ b/src/components/containers/DashboardContainer.tsx
@@ -6,7 +6,7 @@
  */
 import React, { lazy, Suspense } from 'react'
 import { Loader2 } from 'lucide-react'
-import { useMetricasQuery, useClientesQuery } from '../../hooks/queries'
+import { useMetricasQuery, useClientesQuery, useAvanceMetasQuery, periodoMensual } from '../../hooks/queries'
 import { useAuthData } from '../../contexts/AuthDataContext'
 import { useBackup } from '../../hooks/supabase'
 
@@ -41,6 +41,15 @@ export default function DashboardContainer(): React.ReactElement {
 
   // Cargar clientes solo para el contador
   const { data: clientes = [] } = useClientesQuery()
+
+  // Objetivos del mes (migs 159-161). Siempre del mes corriente: las metas son
+  // mensuales y NO siguen al chip de período del dashboard. Se pide sin id, así
+  // el RPC devuelve los del usuario logueado.
+  const { data: avanceMetas } = useAvanceMetasQuery(
+    undefined,
+    periodoMensual(),
+    authReady && (isPreventista || isAdmin),
+  )
 
   // Backup
   const { exportando, descargarJSON } = useBackup()
@@ -80,6 +89,7 @@ export default function DashboardContainer(): React.ReactElement {
         isPreventista={isPreventista}
         isEncargado={isEncargado}
         totalClientes={clientes.length}
+        avanceMetas={avanceMetas}
       />
     </Suspense>
   )

--- a/src/components/containers/MetasContainer.tsx
+++ b/src/components/containers/MetasContainer.tsx
@@ -1,0 +1,54 @@
+import React, { lazy, Suspense, useEffect, useState } from 'react'
+import { Loader2 } from 'lucide-react'
+import { useRendimientoPreventistasQuery, periodoMensual } from '../../hooks/queries'
+import { useAuthData } from '../../contexts/AuthDataContext'
+import { useNotification } from '../../contexts/NotificationContext'
+import { useResetOnSucursalChange } from '../../hooks/useResetOnSucursalChange'
+
+const VistaMetasPreventistas = lazy(() => import('../vistas/VistaMetasPreventistas'))
+const ModalMetasPreventista = lazy(() => import('../modals/ModalMetasPreventista'))
+
+function LoadingState(): React.ReactElement {
+  return (
+    <div className="flex items-center justify-center py-20">
+      <Loader2 className="w-8 h-8 animate-spin text-blue-600" />
+    </div>
+  )
+}
+
+export default function MetasContainer(): React.ReactElement {
+  const notify = useNotification()
+  const { isAdmin } = useAuthData()
+  const [periodo, setPeriodo] = useState(periodoMensual)
+  const [modalOpen, setModalOpen] = useState(false)
+
+  const { data: resultado, isLoading, error } = useRendimientoPreventistasQuery(periodo, isAdmin)
+
+  useResetOnSucursalChange(() => {
+    setModalOpen(false)
+  })
+
+  useEffect(() => {
+    if (error) notify.error((error as Error).message || 'Error al cargar el rendimiento')
+  }, [error, notify])
+
+  return (
+    <>
+      <Suspense fallback={<LoadingState />}>
+        <VistaMetasPreventistas
+          resultado={resultado}
+          loading={isLoading}
+          periodo={periodo}
+          onCambiarPeriodo={setPeriodo}
+          onAbrirObjetivos={() => setModalOpen(true)}
+        />
+      </Suspense>
+
+      {modalOpen && (
+        <Suspense fallback={null}>
+          <ModalMetasPreventista periodo={periodo} onClose={() => setModalOpen(false)} />
+        </Suspense>
+      )}
+    </>
+  )
+}

--- a/src/components/containers/PedidosContainer.tsx
+++ b/src/components/containers/PedidosContainer.tsx
@@ -38,6 +38,7 @@ import {
   useTransportistasQuery,
   useUsuariosQuery,
   useCrearClienteMutation,
+  useActualizarClienteMutation,
   useDepositoCoords,
   useDestinoCoords,
   useCrearPedidoCambioEnRutaMutation,
@@ -201,6 +202,7 @@ export default function PedidosContainer(): React.ReactElement {
   const pagosMasivos = usePagosMasivosMutation()
   const entregaYPagoMasivos = useEntregaYPagoMasivosMutation()
   const crearClienteMut = useCrearClienteMutation()
+  const actualizarClienteMut = useActualizarClienteMutation()
   const crearCambioEnRutaMut = useCrearPedidoCambioEnRutaMutation()
   const aplicarCambioParadaMut = useAplicarCambioParadaMutation()
 
@@ -1709,6 +1711,17 @@ export default function PedidosContainer(): React.ReactElement {
                 return { id: newCliente.id }
               } catch (e) {
                 notify.error((e as Error).message || 'Error al crear cliente')
+                throw e
+              }
+            }}
+            onGuardarHorarioCliente={async (clienteId, patch) => {
+              // Mutación aparte y previa a la creación del pedido: si falla, el
+              // pedido armado no se pierde y el error se muestra en el bloque.
+              try {
+                await actualizarClienteMut.mutateAsync({ id: clienteId, data: patch })
+              } catch (e) {
+                const msg = (e as Error).message || 'No se pudo guardar el horario'
+                notify.error(msg)
                 throw e
               }
             }}

--- a/src/components/containers/ProductosContainer.tsx
+++ b/src/components/containers/ProductosContainer.tsx
@@ -36,6 +36,7 @@ const ModalMinimoVentaMasivo = lazy(() => import('../modals/ModalMinimoVentaMasi
 const ModalGrupoPrecio = lazy(() => import('../modals/ModalGrupoPrecio'))
 const ModalConfirmacion = lazy(() => import('../modals/ModalConfirmacion'))
 const ModalCategorias = lazy(() => import('../modals/ModalCategorias'))
+const ModalMarcas = lazy(() => import('../modals/ModalMarcas'))
 const ModalCambioProducto = lazy(() => import('../modals/ModalCambioProducto'))
 const ModalStockBajo = lazy(() => import('../modals/ModalStockBajo'))
 const ModalControlStock = lazy(() => import('../modals/ModalControlStock'))
@@ -91,6 +92,7 @@ export default function ProductosContainer(): React.ReactElement {
   // Producto para el que se está creando una condición mayorista desde su ficha.
   const [condicionParaProducto, setCondicionParaProducto] = useState<ProductoDB | null>(null)
   const [modalCategoriasOpen, setModalCategoriasOpen] = useState(false)
+  const [modalMarcasOpen, setModalMarcasOpen] = useState(false)
   const [modalCambioOpen, setModalCambioOpen] = useState(false)
   const [modalStockBajoOpen, setModalStockBajoOpen] = useState(false)
   const [modalControlStockOpen, setModalControlStockOpen] = useState(false)
@@ -113,6 +115,7 @@ export default function ProductosContainer(): React.ReactElement {
     setModalMinimoVentaOpen(false)
     setCondicionParaProducto(null)
     setModalCategoriasOpen(false)
+    setModalMarcasOpen(false)
     setModalCambioOpen(false)
     setModalStockBajoOpen(false)
     setModalControlStockOpen(false)
@@ -185,6 +188,10 @@ export default function ProductosContainer(): React.ReactElement {
 
   const handleGestionarCategorias = useCallback(() => {
     setModalCategoriasOpen(true)
+  }, [])
+
+  const handleGestionarMarcas = useCallback(() => {
+    setModalMarcasOpen(true)
   }, [])
 
   const handleAbrirCambioProducto = useCallback(() => {
@@ -332,6 +339,7 @@ export default function ProductosContainer(): React.ReactElement {
           onActualizacionMasivaPrecios={handleAbrirActualizacionMasiva}
           onMinimoVentaMasivo={isAdmin ? handleAbrirMinimoVentaMasivo : undefined}
           onGestionarCategorias={handleGestionarCategorias}
+          onGestionarMarcas={handleGestionarMarcas}
           onCambioProducto={puedeCambiarProductos ? handleAbrirCambioProducto : undefined}
           onControlStock={puedeControlarStock ? handleControlStock : undefined}
           onVerAjustesStock={puedeControlarStock ? handleVerAjustesStock : undefined}
@@ -425,6 +433,16 @@ export default function ProductosContainer(): React.ReactElement {
           <ModalCategorias
             productos={productos}
             onClose={() => setModalCategoriasOpen(false)}
+          />
+        </Suspense>
+      )}
+
+      {/* Modal Marcas (mig 158) */}
+      {modalMarcasOpen && (
+        <Suspense fallback={null}>
+          <ModalMarcas
+            productos={productos}
+            onClose={() => setModalMarcasOpen(false)}
           />
         </Suspense>
       )}

--- a/src/components/dashboard/PanelMisMetas.tsx
+++ b/src/components/dashboard/PanelMisMetas.tsx
@@ -1,0 +1,71 @@
+import { memo } from 'react';
+import { Target } from 'lucide-react';
+import BarraProgresoMeta from '../metas/BarraProgresoMeta';
+import type { AvanceMetasResultado } from '../../hooks/queries';
+
+export interface PanelMisMetasProps {
+  avance: AvanceMetasResultado;
+}
+
+const MESES = [
+  'enero', 'febrero', 'marzo', 'abril', 'mayo', 'junio',
+  'julio', 'agosto', 'septiembre', 'octubre', 'noviembre', 'diciembre',
+];
+
+/** "2026-08-01" → "agosto". Se parsea a mano: `new Date('2026-08-01')` es UTC
+ *  y en Argentina devuelve julio. */
+function nombreMes(periodo: string): string {
+  const mes = Number(periodo.slice(5, 7));
+  return MESES[mes - 1] ?? '';
+}
+
+/**
+ * Objetivos del mes del preventista, en su dashboard.
+ *
+ * OJO con dos cosas que confunden si no se dicen:
+ *  - Las metas son SIEMPRE mensuales. El panel no reacciona a los chips de
+ *    período del dashboard (hoy/semana/año), por eso lleva el mes escrito: si
+ *    no, con el filtro en "Hoy" se lee "35%" y se entiende "35% de hoy".
+ *  - La base es "pedidos entregados", distinta de la de "Mis métricas" (que
+ *    cuenta todo lo no cancelado). Los números no coinciden y hay que decirlo,
+ *    o el preventista desconfía de los dos.
+ */
+const PanelMisMetas = memo(function PanelMisMetas({ avance }: PanelMisMetasProps) {
+  if (!avance?.metas?.length) return null;
+
+  const { resumen, metas, dias_transcurridos, dias_periodo } = avance;
+
+  return (
+    <section className="rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-4">
+      <div className="flex flex-wrap items-baseline justify-between gap-2 mb-1">
+        <h2 className="font-semibold dark:text-white flex items-center gap-1.5">
+          <Target className="w-4 h-4 text-blue-600" />
+          Mis objetivos de {nombreMes(avance.periodo)}
+        </h2>
+        <span className="text-sm text-gray-600 dark:text-gray-400">
+          {resumen.cumplidas} de {resumen.total} cumplid{resumen.total === 1 ? 'o' : 'os'}
+          {' · '}día {dias_transcurridos} de {dias_periodo}
+        </span>
+      </div>
+
+      <p className="text-xs text-gray-500 dark:text-gray-400 mb-3">
+        Se cuentan los pedidos entregados del mes, sin bonificaciones.
+      </p>
+
+      <div className="divide-y dark:divide-gray-700">
+        {metas.map(meta => (
+          <BarraProgresoMeta key={meta.id} meta={meta} />
+        ))}
+      </div>
+
+      {avance.productos_sin_marca > 0 && (
+        <p className="mt-3 text-xs px-3 py-2 rounded-lg bg-amber-50 dark:bg-amber-900/20 text-amber-800 dark:text-amber-300">
+          Hay {avance.productos_sin_marca} productos sin marca cargada: los objetivos por
+          marca todavía no los cuentan.
+        </p>
+      )}
+    </section>
+  );
+});
+
+export default PanelMisMetas;

--- a/src/components/layout/TopNavigation.tsx
+++ b/src/components/layout/TopNavigation.tsx
@@ -4,7 +4,7 @@ import type { LucideIcon } from 'lucide-react';
 import {
   Truck, Menu, X, LogOut, Moon, Sun, ChevronDown,
   BarChart3, ShoppingCart, Users, Package, TrendingUp,
-  UserCog, Route, ShoppingBag, Building2, Banknote, AlertTriangle, Database, Tag, Percent, ArrowRightLeft, Gift, Send, MapPin, Clock
+  UserCog, Route, ShoppingBag, Building2, Banknote, AlertTriangle, Database, Tag, Percent, ArrowRightLeft, Gift, Send, MapPin, Clock, Target
 } from 'lucide-react';
 import { getRolColor, getRolLabel } from '../../utils/formatters';
 import { useTheme } from '../../contexts/ThemeContext';
@@ -64,6 +64,7 @@ const menuGroups: MenuGroup[] = [
       { id: 'reportes-gerenciales', icon: BarChart3, label: 'Reportes Gerenciales', roles: ['admin'] },
       { id: 'analytics', icon: Database, label: 'Centro de Analisis', roles: ['admin'], hidden: true },
       { id: 'comisiones', icon: Percent, label: 'Comisiones', roles: ['admin'] },
+      { id: 'metas', icon: Target, label: 'Objetivos', roles: ['admin'] },
     ]
   },
   {

--- a/src/components/metas/BarraProgresoMeta.tsx
+++ b/src/components/metas/BarraProgresoMeta.tsx
@@ -1,0 +1,100 @@
+import { memo } from 'react';
+import { formatPrecio } from '../../utils/formatters';
+import type { AvanceMeta } from '../../hooks/queries';
+
+export interface BarraProgresoMetaProps {
+  meta: AvanceMeta;
+  /** Compacta la fila (para las tablas del admin). */
+  densa?: boolean;
+}
+
+/** Etiqueta legible del objetivo: "Facturación MANAOS", "Clientes nuevos". */
+function etiquetaMeta(meta: AvanceMeta): string {
+  const base =
+    meta.tipo_meta === 'facturacion' ? 'Facturación' :
+    meta.tipo_meta === 'unidades' ? 'Unidades' :
+    meta.tipo_meta === 'cobertura' ? 'Clientes visitados' :
+    'Clientes nuevos';
+  return meta.alcance.nombre ? `${base} ${meta.alcance.nombre}` : base;
+}
+
+/** Formatea un valor según la unidad de la meta. */
+function formatValorMeta(valor: number, unidad: string): string {
+  if (unidad === '$') return formatPrecio(valor);
+  const n = Math.round(valor * 100) / 100;
+  return unidad === 'u' ? `${n} u` : `${n}`;
+}
+
+const COLOR_BARRA: Record<string, string> = {
+  cumplida: 'bg-green-600',
+  adelantado: 'bg-blue-600',
+  en_curso: 'bg-amber-500',
+  en_riesgo: 'bg-rose-500',
+};
+
+const COLOR_TEXTO: Record<string, string> = {
+  cumplida: 'text-green-700 dark:text-green-400',
+  adelantado: 'text-blue-700 dark:text-blue-400',
+  en_curso: 'text-amber-700 dark:text-amber-400',
+  en_riesgo: 'text-rose-700 dark:text-rose-400',
+};
+
+const LABEL_ESTADO: Record<string, string> = {
+  cumplida: 'Cumplida',
+  adelantado: 'Adelantado',
+  en_curso: 'En curso',
+  en_riesgo: 'Atrasado',
+};
+
+/**
+ * Barra de avance de un objetivo, con el marcador del ritmo esperado.
+ *
+ * La marca gris es `objetivo_prorrateado`: lo que habría que llevar a esta
+ * altura del mes. Sin ella un 40% al día 10 y un 40% al día 28 se ven igual, y
+ * son cosas opuestas. El valor lo calcula el RPC, no este componente: si lo
+ * recalculara acá, el semáforo del preventista y el del gerente podrían
+ * discrepar por un redondeo.
+ */
+const BarraProgresoMeta = memo(function BarraProgresoMeta({ meta, densa = false }: BarraProgresoMetaProps) {
+  const pctBarra = Math.min(100, Math.max(0, meta.pct));
+  const pctRitmo = meta.objetivo > 0
+    ? Math.min(100, Math.max(0, (meta.objetivo_prorrateado / meta.objetivo) * 100))
+    : 0;
+
+  return (
+    <div className={densa ? 'py-1' : 'py-2'}>
+      <div className="flex items-baseline justify-between gap-2 mb-1">
+        <span className={`font-medium truncate dark:text-white ${densa ? 'text-sm' : ''}`}>
+          {etiquetaMeta(meta)}
+        </span>
+        <span className={`shrink-0 text-sm font-semibold tabular-nums ${COLOR_TEXTO[meta.estado]}`}>
+          {Math.round(meta.pct)}%
+        </span>
+      </div>
+
+      <div className="relative h-2.5 rounded-full bg-gray-200 dark:bg-gray-700 overflow-hidden">
+        <div
+          className={`h-full rounded-full transition-all ${COLOR_BARRA[meta.estado]}`}
+          style={{ width: `${pctBarra}%` }}
+        />
+        {/* Ritmo esperado a esta altura del mes. */}
+        {pctRitmo > 0 && pctRitmo < 100 && (
+          <div
+            className="absolute top-0 h-full w-0.5 bg-gray-500 dark:bg-gray-300"
+            style={{ left: `${pctRitmo}%` }}
+            title="Ritmo esperado a esta altura del mes"
+          />
+        )}
+      </div>
+
+      <div className="flex items-baseline justify-between gap-2 mt-1 text-xs text-gray-600 dark:text-gray-400">
+        <span className="tabular-nums">
+          {formatValorMeta(meta.logrado, meta.unidad)} de {formatValorMeta(meta.objetivo, meta.unidad)}
+        </span>
+        <span className={COLOR_TEXTO[meta.estado]}>{LABEL_ESTADO[meta.estado]}</span>
+      </div>
+    </div>
+  );
+});
+
+export default BarraProgresoMeta;

--- a/src/components/modals/ModalCliente.tsx
+++ b/src/components/modals/ModalCliente.tsx
@@ -53,6 +53,8 @@ export interface ClienteFormData {
   dias_atencion: string | null;
   /** @deprecated (mig 140) ya no se edita; el horario canónico es horarios_atencion. */
   horario_entrega: string;
+  /** "No atiende con horario fijo" (mig 157): silencia el pedido de horario al cargar pedidos. */
+  sin_horario_fijo: boolean;
   rubro: string;
   notas: string;
   limiteCredito: number;
@@ -174,6 +176,7 @@ const ModalCliente = memo(function ModalCliente({ cliente, onSave, onClose, guar
       : (cliente.horarios_atencion || ''),
     dias_atencion: cliente.dias_atencion ?? null,
     horario_entrega: cliente.horario_entrega || '',
+    sin_horario_fijo: cliente.sin_horario_fijo ?? false,
     rubro: cliente.rubro || '',
     notas: cliente.notas || '',
     limiteCredito: cliente.limite_credito || 0,
@@ -203,6 +206,7 @@ const ModalCliente = memo(function ModalCliente({ cliente, onSave, onClose, guar
     horarios_atencion: '',
     dias_atencion: null,
     horario_entrega: '',
+    sin_horario_fijo: false,
     rubro: '',
     notas: '',
     limiteCredito: 0,
@@ -797,6 +801,23 @@ const ModalCliente = memo(function ModalCliente({ cliente, onSave, onClose, guar
           </div>
 
           <DiasAtencionSelector valor={diasAtencion} onChange={sincronizarDias} />
+
+          {/* Mig 157: distingue "todavía no lo cargamos" de "no tiene horario
+              fijo". Con el flag puesto, el modal de pedido deja de pedirlo. */}
+          <label className="flex items-start gap-2 cursor-pointer">
+            <input
+              type="checkbox"
+              checked={form.sin_horario_fijo}
+              onChange={e => setForm(prev => ({ ...prev, sin_horario_fijo: e.target.checked }))}
+              className="mt-0.5 w-4 h-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500"
+            />
+            <span className="text-sm dark:text-gray-200">
+              No atiende con horario fijo
+              <span className="block text-xs text-gray-500 dark:text-gray-400">
+                Deja de pedir el horario al cargar un pedido a este cliente.
+              </span>
+            </span>
+          </label>
 
           <p className="text-xs text-gray-500 dark:text-gray-400">
             El reparto usa este horario: los locales que cierran al mediodía se visitan primero.

--- a/src/components/modals/ModalMarcas.tsx
+++ b/src/components/modals/ModalMarcas.tsx
@@ -1,0 +1,516 @@
+/**
+ * Modal para gestionar marcas y asignarlas a productos (mig 158).
+ *
+ * Dos vistas en el mismo modal:
+ *  - "lista": ABM de marcas con el conteo de productos de cada una.
+ *  - "asignar": selector masivo de productos para una marca.
+ *
+ * La vista de asignación es la que hace el trabajo real: la mig 158 solo pudo
+ * backfillear las marcas de la sucursal 1 (donde había categorías que en
+ * realidad eran marcas). En Taco Pozo la marca vive dentro del nombre del
+ * producto ("PLACER NARANJA 1500CC X 6"), así que el filtro por nombre +
+ * "seleccionar todo lo filtrado" es lo que convierte un trabajo de horas en
+ * uno de minutos. Deliberadamente no se adivina la marca por patrón de
+ * nombre: "AGUA VILLA MANAOS" y "MANAOS SODA" son marcas distintas y un
+ * heurístico las mezcla en silencio.
+ */
+import { memo, useMemo, useState } from 'react';
+import { Loader2, Plus, Pencil, Trash2, Check, X, Award, AlertCircle, ToggleLeft, ToggleRight, Search, ChevronLeft } from 'lucide-react';
+import ModalBase from './ModalBase';
+import {
+  useMarcasQuery,
+  useCrearMarcaMutation,
+  useRenombrarMarcaMutation,
+  useEliminarMarcaMutation,
+  useToggleMarcaActivaMutation,
+  useAsignarMarcaMasivaMutation,
+} from '../../hooks/queries';
+import type { MarcaDB } from '../../hooks/queries';
+import type { ProductoDB } from '../../types';
+
+export interface ModalMarcasProps {
+  /** Productos de la sucursal activa (para contar y para el selector masivo). */
+  productos: ProductoDB[];
+  onClose: () => void;
+}
+
+const ModalMarcas = memo(function ModalMarcas({ productos, onClose }: ModalMarcasProps) {
+  const { data: marcas = [], isLoading } = useMarcasQuery();
+  const crearMut = useCrearMarcaMutation();
+  const renameMut = useRenombrarMarcaMutation();
+  const deleteMut = useEliminarMarcaMutation();
+  const toggleMut = useToggleMarcaActivaMutation();
+  const asignarMut = useAsignarMarcaMasivaMutation();
+
+  const [nuevoNombre, setNuevoNombre] = useState('');
+  const [error, setError] = useState('');
+  const [editandoId, setEditandoId] = useState<string | null>(null);
+  const [editNombre, setEditNombre] = useState('');
+  const [confirmDelete, setConfirmDelete] = useState<MarcaDB | null>(null);
+
+  // Vista de asignación: null = lista de marcas.
+  const [asignando, setAsignando] = useState<MarcaDB | null>(null);
+  const [busqueda, setBusqueda] = useState('');
+  const [soloSinMarca, setSoloSinMarca] = useState(true);
+  const [seleccion, setSeleccion] = useState<Set<string>>(new Set());
+  const [okMsg, setOkMsg] = useState('');
+
+  const conteoPorMarca = useMemo(() => {
+    const counts = new Map<string, number>();
+    productos.forEach(p => {
+      if (p.marca_id) counts.set(p.marca_id, (counts.get(p.marca_id) || 0) + 1);
+    });
+    return counts;
+  }, [productos]);
+
+  const sinMarca = useMemo(() => productos.filter(p => !p.marca_id).length, [productos]);
+
+  const working = crearMut.isPending || renameMut.isPending || deleteMut.isPending || toggleMut.isPending;
+
+  // ---------------------------------------------------------------- ABM
+
+  const handleCrear = async (): Promise<void> => {
+    const nombre = nuevoNombre.trim();
+    if (!nombre) {
+      setError('Ingresá un nombre');
+      return;
+    }
+    if (marcas.some(m => m.nombre.toLowerCase() === nombre.toLowerCase())) {
+      setError(`Ya existe una marca "${nombre}"`);
+      return;
+    }
+    setError('');
+    try {
+      await crearMut.mutateAsync(nombre);
+      setNuevoNombre('');
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Error al crear marca');
+    }
+  };
+
+  const handleConfirmarRename = async (marca: MarcaDB): Promise<void> => {
+    const nuevo = editNombre.trim();
+    if (!nuevo) {
+      setError('El nombre no puede estar vacío');
+      return;
+    }
+    if (nuevo === marca.nombre) {
+      setEditandoId(null);
+      return;
+    }
+    setError('');
+    try {
+      await renameMut.mutateAsync({ id: marca.id, nombreNuevo: nuevo });
+      setEditandoId(null);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Error al renombrar marca');
+    }
+  };
+
+  const handleEliminar = async (marca: MarcaDB): Promise<void> => {
+    setError('');
+    try {
+      await deleteMut.mutateAsync(marca.id);
+      setConfirmDelete(null);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Error al eliminar marca');
+    }
+  };
+
+  // ---------------------------------------------------------- Asignación
+
+  const abrirAsignar = (marca: MarcaDB): void => {
+    setAsignando(marca);
+    setBusqueda('');
+    setSoloSinMarca(true);
+    setSeleccion(new Set());
+    setError('');
+    setOkMsg('');
+  };
+
+  const productosFiltrados = useMemo(() => {
+    if (!asignando) return [];
+    const q = busqueda.trim().toLowerCase();
+    return productos
+      .filter(p => {
+        if (soloSinMarca && p.marca_id && p.marca_id !== asignando.id) return false;
+        if (!q) return true;
+        return p.nombre.toLowerCase().includes(q) || (p.categoria || '').toLowerCase().includes(q);
+      })
+      .sort((a, b) => a.nombre.localeCompare(b.nombre));
+  }, [productos, asignando, busqueda, soloSinMarca]);
+
+  const todosFiltradosSeleccionados =
+    productosFiltrados.length > 0 && productosFiltrados.every(p => seleccion.has(p.id));
+
+  const toggleTodosFiltrados = (): void => {
+    setSeleccion(prev => {
+      const next = new Set(prev);
+      if (todosFiltradosSeleccionados) {
+        productosFiltrados.forEach(p => next.delete(p.id));
+      } else {
+        productosFiltrados.forEach(p => next.add(p.id));
+      }
+      return next;
+    });
+  };
+
+  const handleAsignar = async (quitar = false): Promise<void> => {
+    if (!asignando || seleccion.size === 0) return;
+    setError('');
+    setOkMsg('');
+    try {
+      const n = await asignarMut.mutateAsync({
+        marcaId: quitar ? null : asignando.id,
+        productoIds: [...seleccion],
+      });
+      setOkMsg(
+        quitar
+          ? `${n} ${n === 1 ? 'producto quedó' : 'productos quedaron'} sin marca.`
+          : `${n} ${n === 1 ? 'producto asignado' : 'productos asignados'} a ${asignando.nombre}.`,
+      );
+      setSeleccion(new Set());
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Error al asignar la marca');
+    }
+  };
+
+  // ------------------------------------------------------------- Render
+
+  if (asignando) {
+    return (
+      <ModalBase title={`Productos de ${asignando.nombre}`} onClose={onClose} maxWidth="max-w-2xl">
+        <div className="p-4 space-y-3">
+          <button
+            type="button"
+            onClick={() => setAsignando(null)}
+            className="inline-flex items-center gap-1 text-sm text-blue-600 hover:underline"
+          >
+            <ChevronLeft className="w-4 h-4" />
+            Volver a las marcas
+          </button>
+
+          <div className="relative">
+            <Search className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400 w-5 h-5 pointer-events-none" />
+            <input
+              type="text"
+              value={busqueda}
+              onChange={e => setBusqueda(e.target.value)}
+              placeholder="Filtrar por nombre o categoría…"
+              className="w-full pl-10 pr-3 py-2 border rounded-lg bg-white dark:bg-gray-700 dark:border-gray-600 dark:text-white focus:ring-2 focus:ring-blue-500 focus:outline-none"
+            />
+          </div>
+
+          <label className="flex items-center gap-2 text-sm dark:text-gray-200 cursor-pointer">
+            <input
+              type="checkbox"
+              checked={soloSinMarca}
+              onChange={e => setSoloSinMarca(e.target.checked)}
+              className="w-4 h-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500"
+            />
+            Ocultar los que ya tienen otra marca
+          </label>
+
+          <div className="flex items-center justify-between gap-2">
+            <button
+              type="button"
+              onClick={toggleTodosFiltrados}
+              disabled={productosFiltrados.length === 0}
+              className="text-sm font-medium text-blue-600 hover:underline disabled:opacity-50 disabled:no-underline"
+            >
+              {todosFiltradosSeleccionados ? 'Deseleccionar' : 'Seleccionar'} los {productosFiltrados.length} de la lista
+            </button>
+            <span className="text-sm text-gray-500 dark:text-gray-400">
+              {seleccion.size} seleccionado{seleccion.size === 1 ? '' : 's'}
+            </span>
+          </div>
+
+          {error && (
+            <div role="alert" className="flex items-start gap-2 p-3 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg text-sm text-red-700 dark:text-red-300">
+              <AlertCircle className="w-4 h-4 flex-shrink-0 mt-0.5" />
+              <span>{error}</span>
+            </div>
+          )}
+          {okMsg && (
+            <p className="p-3 bg-green-50 dark:bg-green-900/20 border border-green-200 dark:border-green-800 rounded-lg text-sm text-green-700 dark:text-green-300">
+              {okMsg}
+            </p>
+          )}
+
+          <ul className="border dark:border-gray-600 rounded-lg divide-y dark:divide-gray-700 max-h-[45vh] overflow-y-auto">
+            {productosFiltrados.length === 0 ? (
+              <li className="px-3 py-6 text-center text-sm text-gray-500 dark:text-gray-400">
+                No hay productos que coincidan.
+              </li>
+            ) : productosFiltrados.map(p => (
+              <li key={p.id}>
+                <label className="flex items-center gap-3 px-3 py-2.5 cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-700/50">
+                  <input
+                    type="checkbox"
+                    checked={seleccion.has(p.id)}
+                    onChange={e => setSeleccion(prev => {
+                      const next = new Set(prev);
+                      if (e.target.checked) next.add(p.id); else next.delete(p.id);
+                      return next;
+                    })}
+                    className="w-4 h-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500 shrink-0"
+                  />
+                  <span className="flex-1 min-w-0">
+                    <span className="block text-sm dark:text-white truncate">{p.nombre}</span>
+                    <span className="block text-xs text-gray-500 dark:text-gray-400">
+                      {p.categoria || 'sin categoría'}
+                      {p.marca_id === asignando.id && ' · ya es de esta marca'}
+                    </span>
+                  </span>
+                </label>
+              </li>
+            ))}
+          </ul>
+        </div>
+
+        <div className="p-4 border-t dark:border-gray-600 flex flex-wrap justify-end gap-2">
+          <button
+            type="button"
+            onClick={() => handleAsignar(true)}
+            disabled={asignarMut.isPending || seleccion.size === 0}
+            className="px-3 py-2 text-sm font-medium text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-lg disabled:opacity-50"
+          >
+            Quitar marca
+          </button>
+          <button
+            type="button"
+            onClick={() => handleAsignar(false)}
+            disabled={asignarMut.isPending || seleccion.size === 0}
+            className="px-4 py-2 bg-blue-600 text-white font-medium rounded-lg hover:bg-blue-700 disabled:bg-gray-400 disabled:cursor-not-allowed flex items-center gap-1.5"
+          >
+            {asignarMut.isPending && <Loader2 className="w-4 h-4 animate-spin" />}
+            Asignar a {asignando.nombre}
+          </button>
+        </div>
+      </ModalBase>
+    );
+  }
+
+  return (
+    <ModalBase title="Gestionar marcas" onClose={onClose} maxWidth="max-w-2xl">
+      <div className="p-4 space-y-4">
+        <p className="text-sm text-gray-600 dark:text-gray-400">
+          La marca es independiente de la categoría: un producto es <em>Manaos</em> (marca) y{' '}
+          <em>gaseosas</em> (categoría). Sirve para poner objetivos y medir ventas por marca.
+        </p>
+
+        <div>
+          <label htmlFor="nueva-marca" className="block text-sm font-medium mb-1 dark:text-gray-200">
+            Nueva marca
+          </label>
+          <div className="flex gap-2">
+            <input
+              id="nueva-marca"
+              type="text"
+              value={nuevoNombre}
+              onChange={e => setNuevoNombre(e.target.value)}
+              onKeyDown={e => {
+                if (e.key === 'Enter') {
+                  e.preventDefault();
+                  void handleCrear();
+                }
+              }}
+              placeholder="Ej.: COTELLA"
+              className="flex-1 px-3 py-2 border rounded-lg bg-white dark:bg-gray-700 dark:border-gray-600 dark:text-white focus:ring-2 focus:ring-blue-500 focus:outline-none"
+              disabled={crearMut.isPending}
+            />
+            <button
+              type="button"
+              onClick={handleCrear}
+              disabled={crearMut.isPending || !nuevoNombre.trim()}
+              className="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 disabled:bg-gray-400 disabled:cursor-not-allowed flex items-center gap-1.5 font-medium"
+            >
+              {crearMut.isPending ? <Loader2 className="w-4 h-4 animate-spin" /> : <Plus className="w-4 h-4" />}
+              Agregar
+            </button>
+          </div>
+        </div>
+
+        {error && (
+          <div role="alert" className="flex items-start gap-2 p-3 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg text-sm text-red-700 dark:text-red-300">
+            <AlertCircle className="w-4 h-4 flex-shrink-0 mt-0.5" />
+            <span>{error}</span>
+          </div>
+        )}
+
+        {/* Cobertura: sin esto, una meta por marca mide sobre datos incompletos
+            y el error es invisible. */}
+        {sinMarca > 0 && (
+          <p className="text-sm px-3 py-2 rounded-lg bg-amber-50 dark:bg-amber-900/20 text-amber-800 dark:text-amber-300">
+            {sinMarca} {sinMarca === 1 ? 'producto no tiene' : 'productos no tienen'} marca asignada. Los
+            objetivos por marca no los van a contar.
+          </p>
+        )}
+
+        <div>
+          <h3 className="text-sm font-medium mb-2 dark:text-gray-200 flex items-center gap-1.5">
+            <Award className="w-4 h-4" />
+            Marcas ({marcas.length})
+          </h3>
+
+          {isLoading ? (
+            <div className="flex items-center justify-center py-8">
+              <Loader2 className="w-6 h-6 animate-spin text-blue-600" />
+            </div>
+          ) : marcas.length === 0 ? (
+            <p className="text-center text-sm text-gray-500 dark:text-gray-400 py-6">
+              Todavía no hay marcas. Agregá la primera arriba.
+            </p>
+          ) : (
+            <ul className="border dark:border-gray-600 rounded-lg divide-y dark:divide-gray-700 max-h-[50vh] overflow-y-auto">
+              {marcas.map(marca => {
+                const editing = editandoId === marca.id;
+                const count = conteoPorMarca.get(marca.id) || 0;
+                return (
+                  <li key={marca.id} className="flex items-center gap-2 px-3 py-2.5">
+                    {editing ? (
+                      <input
+                        type="text"
+                        value={editNombre}
+                        onChange={e => setEditNombre(e.target.value)}
+                        onKeyDown={e => {
+                          if (e.key === 'Enter') {
+                            e.preventDefault();
+                            void handleConfirmarRename(marca);
+                          } else if (e.key === 'Escape') {
+                            setEditandoId(null);
+                          }
+                        }}
+                        className="flex-1 px-2 py-1 border rounded bg-white dark:bg-gray-700 dark:border-gray-600 dark:text-white focus:ring-2 focus:ring-blue-500 focus:outline-none text-sm"
+                        autoFocus
+                        disabled={renameMut.isPending}
+                      />
+                    ) : (
+                      <div className={`flex-1 min-w-0 flex items-center gap-2 flex-wrap ${!marca.activa ? 'opacity-60' : ''}`}>
+                        <span className="font-medium dark:text-white truncate">{marca.nombre}</span>
+                        <span className="text-xs px-2 py-0.5 bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-300 rounded-full">
+                          {count} {count === 1 ? 'producto' : 'productos'}
+                        </span>
+                        {!marca.activa && (
+                          <span className="text-xs px-2 py-0.5 bg-gray-200 dark:bg-gray-600 text-gray-600 dark:text-gray-300 rounded-full font-medium">
+                            inactiva
+                          </span>
+                        )}
+                      </div>
+                    )}
+
+                    {editing ? (
+                      <div className="flex gap-1 shrink-0">
+                        <button
+                          type="button"
+                          onClick={() => handleConfirmarRename(marca)}
+                          disabled={renameMut.isPending}
+                          className="p-1.5 text-green-600 hover:bg-green-50 dark:hover:bg-green-900/20 rounded disabled:opacity-50"
+                          aria-label="Guardar"
+                        >
+                          {renameMut.isPending ? <Loader2 className="w-4 h-4 animate-spin" /> : <Check className="w-4 h-4" />}
+                        </button>
+                        <button
+                          type="button"
+                          onClick={() => setEditandoId(null)}
+                          disabled={renameMut.isPending}
+                          className="p-1.5 text-gray-500 hover:bg-gray-50 dark:hover:bg-gray-700 rounded disabled:opacity-50"
+                          aria-label="Cancelar"
+                        >
+                          <X className="w-4 h-4" />
+                        </button>
+                      </div>
+                    ) : (
+                      <div className="flex gap-1 shrink-0">
+                        <button
+                          type="button"
+                          onClick={() => abrirAsignar(marca)}
+                          disabled={working}
+                          className="px-2 py-1 text-xs font-medium text-blue-600 hover:bg-blue-50 dark:hover:bg-blue-900/20 rounded disabled:opacity-50"
+                        >
+                          Productos
+                        </button>
+                        <button
+                          type="button"
+                          onClick={() => { setEditandoId(marca.id); setEditNombre(marca.nombre); setError(''); }}
+                          disabled={working}
+                          className="p-1.5 text-blue-600 hover:bg-blue-50 dark:hover:bg-blue-900/20 rounded disabled:opacity-50"
+                          aria-label={`Renombrar ${marca.nombre}`}
+                        >
+                          <Pencil className="w-4 h-4" />
+                        </button>
+                        <button
+                          type="button"
+                          onClick={() => toggleMut.mutateAsync({ id: marca.id, activa: !marca.activa })}
+                          disabled={working}
+                          className="p-1.5 hover:bg-gray-100 dark:hover:bg-gray-700 rounded disabled:opacity-50"
+                          aria-label={marca.activa ? `Desactivar ${marca.nombre}` : `Activar ${marca.nombre}`}
+                        >
+                          {marca.activa
+                            ? <ToggleRight className="w-5 h-5 text-green-600" />
+                            : <ToggleLeft className="w-5 h-5 text-gray-400" />}
+                        </button>
+                        <button
+                          type="button"
+                          onClick={() => setConfirmDelete(marca)}
+                          disabled={working}
+                          className="p-1.5 text-red-500 hover:bg-red-50 dark:hover:bg-red-900/20 rounded disabled:opacity-50"
+                          aria-label={`Eliminar ${marca.nombre}`}
+                        >
+                          <Trash2 className="w-4 h-4" />
+                        </button>
+                      </div>
+                    )}
+                  </li>
+                );
+              })}
+            </ul>
+          )}
+        </div>
+      </div>
+
+      {confirmDelete && (
+        <div className="p-4 border-t dark:border-gray-600 bg-amber-50 dark:bg-amber-900/20">
+          <p className="text-sm text-amber-900 dark:text-amber-200 mb-3">
+            <strong>¿Eliminar "{confirmDelete.nombre}"?</strong>{' '}
+            {(conteoPorMarca.get(confirmDelete.id) || 0) > 0
+              ? `${conteoPorMarca.get(confirmDelete.id)} producto(s) quedarán sin marca. No se borran productos.`
+              : 'No hay productos asociados.'}
+            {' '}Los objetivos que apunten a esta marca se van a quedar sin nada que medir.
+          </p>
+          <div className="flex justify-end gap-2">
+            <button
+              type="button"
+              onClick={() => setConfirmDelete(null)}
+              disabled={deleteMut.isPending}
+              className="px-3 py-1.5 text-sm font-medium text-gray-700 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-700 rounded-lg"
+            >
+              Cancelar
+            </button>
+            <button
+              type="button"
+              onClick={() => handleEliminar(confirmDelete)}
+              disabled={deleteMut.isPending}
+              className="px-3 py-1.5 text-sm bg-red-600 text-white font-medium rounded-lg hover:bg-red-700 disabled:bg-gray-400 flex items-center gap-1.5"
+            >
+              {deleteMut.isPending && <Loader2 className="w-4 h-4 animate-spin" />}
+              Eliminar
+            </button>
+          </div>
+        </div>
+      )}
+
+      <div className="p-4 border-t dark:border-gray-600 flex justify-end">
+        <button
+          type="button"
+          onClick={onClose}
+          className="px-4 py-2 text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-lg"
+        >
+          Cerrar
+        </button>
+      </div>
+    </ModalBase>
+  );
+});
+
+export default ModalMarcas;

--- a/src/components/modals/ModalMetasPreventista.tsx
+++ b/src/components/modals/ModalMetasPreventista.tsx
@@ -1,0 +1,306 @@
+/**
+ * Alta y baja de objetivos mensuales por preventista (mig 159).
+ *
+ * Arriba las metas ya cargadas del período, abajo el formulario. El tipo de
+ * meta manda sobre el resto: "cobertura" y "clientes nuevos" no admiten
+ * alcance (se cuentan sobre clientes, no sobre productos) y "unidades" lo
+ * exige (100 unidades sin decir de qué no es una meta). Los CHECK de la base
+ * dicen lo mismo; acá se refleja para no ofrecer combinaciones que van a
+ * fallar del otro lado.
+ */
+import { memo, useMemo, useState } from 'react';
+import { Loader2, Plus, Trash2, AlertCircle, Target } from 'lucide-react';
+import ModalBase from './ModalBase';
+import NumberInput from '../ui/NumberInput';
+import { formatPrecio } from '../../utils/formatters';
+import {
+  useMetasPreventistaQuery,
+  useGuardarMetaPreventistaMutation,
+  useDesactivarMetaPreventistaMutation,
+  useMarcasQuery,
+  useCategoriasQuery,
+  usePreventistasAsignablesQuery,
+} from '../../hooks/queries';
+import type { TipoMeta, MetaPreventista } from '../../hooks/queries';
+import { useSucursal } from '../../contexts/SucursalContext';
+
+export interface ModalMetasPreventistaProps {
+  /** Período 'YYYY-MM-01' sobre el que se cargan las metas. */
+  periodo: string;
+  onClose: () => void;
+}
+
+const TIPOS: Array<{ valor: TipoMeta; label: string; ayuda: string }> = [
+  { valor: 'facturacion', label: 'Facturación ($)', ayuda: 'Pesos vendidos en el mes.' },
+  { valor: 'unidades', label: 'Unidades vendidas', ayuda: 'Cantidad de unidades. Elegí de qué.' },
+  { valor: 'cobertura', label: 'Clientes visitados', ayuda: 'Clientes distintos con pedido entregado.' },
+  { valor: 'clientes_nuevos', label: 'Clientes nuevos', ayuda: 'Clientes que compran por primera vez.' },
+];
+
+/** Tipos que aceptan acotar el alcance a una marca/categoría/producto. */
+const ADMITE_ALCANCE: TipoMeta[] = ['facturacion', 'unidades'];
+/** Tipos donde el alcance es obligatorio. */
+const EXIGE_ALCANCE: TipoMeta[] = ['unidades'];
+
+const ModalMetasPreventista = memo(function ModalMetasPreventista({
+  periodo,
+  onClose,
+}: ModalMetasPreventistaProps) {
+  const { currentSucursalId } = useSucursal();
+  const { data: metas = [], isLoading } = useMetasPreventistaQuery(periodo);
+  const { data: preventistas = [] } = usePreventistasAsignablesQuery();
+  const { data: marcas = [] } = useMarcasQuery();
+  const { data: categorias = [] } = useCategoriasQuery();
+  const guardarMut = useGuardarMetaPreventistaMutation();
+  const bajaMut = useDesactivarMetaPreventistaMutation();
+
+  const [preventistaId, setPreventistaId] = useState('');
+  const [tipoMeta, setTipoMeta] = useState<TipoMeta>('facturacion');
+  // 'marca:<uuid>' | 'categoria:<uuid>' | '' (global)
+  const [alcance, setAlcance] = useState('');
+  const [valor, setValor] = useState<number>(0);
+  const [error, setError] = useState('');
+
+  const admiteAlcance = ADMITE_ALCANCE.includes(tipoMeta);
+  const exigeAlcance = EXIGE_ALCANCE.includes(tipoMeta);
+
+  const nombrePorId = useMemo(() => {
+    const m = new Map<string, string>();
+    preventistas.forEach(p => m.set(p.id, p.nombre || p.email || p.id));
+    marcas.forEach(x => m.set(x.id, x.nombre));
+    categorias.forEach(x => m.set(x.id, x.nombre));
+    return m;
+  }, [preventistas, marcas, categorias]);
+
+  const describirMeta = (meta: MetaPreventista): string => {
+    const tipo = TIPOS.find(t => t.valor === meta.tipo_meta)?.label ?? meta.tipo_meta;
+    const alc = meta.marca_id ? nombrePorId.get(meta.marca_id)
+      : meta.categoria_id ? nombrePorId.get(meta.categoria_id)
+      : null;
+    return alc ? `${tipo} — ${alc}` : tipo;
+  };
+
+  const formatObjetivo = (meta: MetaPreventista): string =>
+    meta.tipo_meta === 'facturacion'
+      ? formatPrecio(meta.valor_objetivo)
+      : `${meta.valor_objetivo}${meta.tipo_meta === 'unidades' ? ' u' : ''}`;
+
+  const handleTipoChange = (t: TipoMeta): void => {
+    setTipoMeta(t);
+    // Cambiar a un tipo sin alcance deja basura seleccionada que la base rechaza.
+    if (!ADMITE_ALCANCE.includes(t)) setAlcance('');
+    setError('');
+  };
+
+  const handleGuardar = async (): Promise<void> => {
+    if (!preventistaId) {
+      setError('Elegí el preventista');
+      return;
+    }
+    if (currentSucursalId == null) {
+      setError('No hay sucursal activa. Recargá la página.');
+      return;
+    }
+    const objetivo = Number(valor);
+    if (!objetivo || objetivo <= 0) {
+      setError('El objetivo tiene que ser mayor a 0');
+      return;
+    }
+    if (exigeAlcance && !alcance) {
+      setError('Elegí de qué marca o categoría son las unidades');
+      return;
+    }
+
+    const [tipoAlc, idAlc] = alcance ? alcance.split(':') : [null, null];
+    setError('');
+    try {
+      await guardarMut.mutateAsync({
+        sucursalId: currentSucursalId,
+        preventistaId,
+        periodo,
+        tipoMeta,
+        valorObjetivo: objetivo,
+        marcaId: tipoAlc === 'marca' ? idAlc : null,
+        categoriaId: tipoAlc === 'categoria' ? idAlc : null,
+      });
+      setValor(0);
+      setAlcance('');
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'No se pudo guardar el objetivo');
+    }
+  };
+
+  // Agrupadas por preventista para que se lea "qué le pedí a cada uno".
+  const porPreventista = useMemo(() => {
+    const grupos = new Map<string, MetaPreventista[]>();
+    metas.forEach(m => {
+      const arr = grupos.get(m.preventista_id) ?? [];
+      arr.push(m);
+      grupos.set(m.preventista_id, arr);
+    });
+    return [...grupos.entries()].sort(
+      (a, b) => (nombrePorId.get(a[0]) ?? '').localeCompare(nombrePorId.get(b[0]) ?? ''),
+    );
+  }, [metas, nombrePorId]);
+
+  return (
+    <ModalBase title="Objetivos del mes" onClose={onClose} maxWidth="max-w-2xl">
+      <div className="p-4 space-y-4">
+        {/* Cargadas */}
+        <div>
+          <h3 className="text-sm font-medium mb-2 dark:text-gray-200 flex items-center gap-1.5">
+            <Target className="w-4 h-4" />
+            Objetivos cargados ({metas.length})
+          </h3>
+          {isLoading ? (
+            <div className="flex justify-center py-6"><Loader2 className="w-5 h-5 animate-spin text-blue-600" /></div>
+          ) : metas.length === 0 ? (
+            <p className="text-sm text-gray-500 dark:text-gray-400 py-3">
+              Todavía no hay objetivos para este mes.
+            </p>
+          ) : (
+            <div className="border dark:border-gray-600 rounded-lg divide-y dark:divide-gray-700 max-h-56 overflow-y-auto">
+              {porPreventista.map(([pid, lista]) => (
+                <div key={pid} className="px-3 py-2">
+                  <p className="text-sm font-semibold dark:text-white mb-1">
+                    {nombrePorId.get(pid) ?? pid}
+                  </p>
+                  <ul className="space-y-1">
+                    {lista.map(meta => (
+                      <li key={meta.id} className="flex items-center justify-between gap-2 text-sm">
+                        <span className="text-gray-700 dark:text-gray-300 truncate">
+                          {describirMeta(meta)}
+                        </span>
+                        <span className="flex items-center gap-2 shrink-0">
+                          <span className="font-medium tabular-nums dark:text-white">
+                            {formatObjetivo(meta)}
+                          </span>
+                          <button
+                            type="button"
+                            onClick={() => bajaMut.mutateAsync(meta.id)}
+                            disabled={bajaMut.isPending}
+                            className="p-1 text-red-500 hover:bg-red-50 dark:hover:bg-red-900/20 rounded disabled:opacity-50"
+                            aria-label="Quitar objetivo"
+                          >
+                            <Trash2 className="w-4 h-4" />
+                          </button>
+                        </span>
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+
+        {/* Alta */}
+        <div className="border-t dark:border-gray-600 pt-4 space-y-3">
+          <h3 className="text-sm font-medium dark:text-gray-200">Nuevo objetivo</h3>
+
+          <div>
+            <label className="block text-sm font-medium mb-1 dark:text-gray-200">Preventista</label>
+            <select
+              value={preventistaId}
+              onChange={e => setPreventistaId(e.target.value)}
+              className="w-full px-3 py-2 border rounded-lg bg-white dark:bg-gray-700 dark:border-gray-600 dark:text-white"
+            >
+              <option value="">Elegí…</option>
+              {preventistas.map(p => (
+                <option key={p.id} value={p.id}>{p.nombre || p.email}</option>
+              ))}
+            </select>
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium mb-1 dark:text-gray-200">Tipo de objetivo</label>
+            <select
+              value={tipoMeta}
+              onChange={e => handleTipoChange(e.target.value as TipoMeta)}
+              className="w-full px-3 py-2 border rounded-lg bg-white dark:bg-gray-700 dark:border-gray-600 dark:text-white"
+            >
+              {TIPOS.map(t => <option key={t.valor} value={t.valor}>{t.label}</option>)}
+            </select>
+            <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
+              {TIPOS.find(t => t.valor === tipoMeta)?.ayuda}
+            </p>
+          </div>
+
+          {admiteAlcance && (
+            <div>
+              <label className="block text-sm font-medium mb-1 dark:text-gray-200">
+                {exigeAlcance ? 'De qué (obligatorio)' : 'Acotar a (opcional)'}
+              </label>
+              <select
+                value={alcance}
+                onChange={e => setAlcance(e.target.value)}
+                className="w-full px-3 py-2 border rounded-lg bg-white dark:bg-gray-700 dark:border-gray-600 dark:text-white"
+              >
+                <option value="">{exigeAlcance ? 'Elegí…' : 'Todo (sin acotar)'}</option>
+                {marcas.filter(m => m.activa).length > 0 && (
+                  <optgroup label="Marcas">
+                    {marcas.filter(m => m.activa).map(m => (
+                      <option key={m.id} value={`marca:${m.id}`}>{m.nombre}</option>
+                    ))}
+                  </optgroup>
+                )}
+                {categorias.filter(c => c.activa !== false).length > 0 && (
+                  <optgroup label="Categorías">
+                    {categorias.filter(c => c.activa !== false).map(c => (
+                      <option key={c.id} value={`categoria:${c.id}`}>{c.nombre}</option>
+                    ))}
+                  </optgroup>
+                )}
+              </select>
+              <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
+                Para "2 millones de Manaos y de esos, 100 gaseosas" cargá dos objetivos.
+              </p>
+            </div>
+          )}
+
+          <div>
+            <label className="block text-sm font-medium mb-1 dark:text-gray-200">
+              Objetivo del mes {tipoMeta === 'facturacion' ? '($)' : tipoMeta === 'unidades' ? '(unidades)' : '(clientes)'}
+            </label>
+            <NumberInput
+              value={valor}
+              onChange={setValor}
+              min={0}
+              integer={tipoMeta !== 'facturacion'}
+              className="w-full px-3 py-2 border rounded-lg bg-white dark:bg-gray-700 dark:border-gray-600 dark:text-white"
+            />
+          </div>
+
+          {error && (
+            <div role="alert" className="flex items-start gap-2 p-3 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg text-sm text-red-700 dark:text-red-300">
+              <AlertCircle className="w-4 h-4 flex-shrink-0 mt-0.5" />
+              <span>{error}</span>
+            </div>
+          )}
+
+          <button
+            type="button"
+            onClick={handleGuardar}
+            disabled={guardarMut.isPending}
+            className="w-full py-2 bg-blue-600 text-white font-medium rounded-lg hover:bg-blue-700 disabled:bg-gray-400 disabled:cursor-not-allowed flex items-center justify-center gap-1.5"
+          >
+            {guardarMut.isPending ? <Loader2 className="w-4 h-4 animate-spin" /> : <Plus className="w-4 h-4" />}
+            Agregar objetivo
+          </button>
+        </div>
+      </div>
+
+      <div className="p-4 border-t dark:border-gray-600 flex justify-end">
+        <button
+          type="button"
+          onClick={onClose}
+          className="px-4 py-2 text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-lg"
+        >
+          Cerrar
+        </button>
+      </div>
+    </ModalBase>
+  );
+});
+
+export default ModalMetasPreventista;

--- a/src/components/modals/ModalPedido.tsx
+++ b/src/components/modals/ModalPedido.tsx
@@ -13,7 +13,8 @@ import GeolocationGate from '../GeolocationGate';
 import NumberInput from '../ui/NumberInput';
 import FranjasHorariasEditor from '../ui/FranjasHorariasEditor';
 import DiasAtencionSelector from '../ui/DiasAtencionSelector';
-import { serializarFranjas, validarFranjas } from '../../utils/horariosCliente';
+import BloqueHorarioRequerido, { type PatchHorarioCliente } from '../ui/BloqueHorarioRequerido';
+import { serializarFranjas, validarFranjas, clienteSinHorario } from '../../utils/horariosCliente';
 import type { FranjaHoraria } from '../../utils/horariosCliente';
 import type { ProductoDB, ClienteDB } from '../../types';
 
@@ -129,6 +130,12 @@ export interface ModalPedidoProps {
   onEliminarPromoCreacion?: (promoId: string, promoNombre: string) => void;
   /** Callback al restaurar una promo previamente quitada. */
   onRestaurarPromoCreacion?: (promoId: string) => void;
+  /**
+   * Persiste el horario del cliente seleccionado sin salir del modal (mig 157).
+   * Si no se provee, el pedido de horario no bloquea (útil para tests y para
+   * cualquier consumidor que no pueda escribir clientes).
+   */
+  onGuardarHorarioCliente?: (clienteId: string, patch: PatchHorarioCliente) => Promise<void>;
 }
  
 
@@ -161,7 +168,8 @@ const ModalPedido = memo(function ModalPedido({
   onCambiarRegaloCreacion,
   promosEliminadas,
   onEliminarPromoCreacion,
-  onRestaurarPromoCreacion
+  onRestaurarPromoCreacion,
+  onGuardarHorarioCliente
 }: ModalPedidoProps) {
   // Solo admin puede reasignar preventista al pedido. La query se habilita
   // condicionalmente para no traer perfiles para preventistas/encargados.
@@ -232,6 +240,13 @@ const ModalPedido = memo(function ModalPedido({
     // clienteId is a string, compare directly with string id
     return clientes.find(c => String(c.id) === String(nuevoPedido.clienteId)) || null;
   }, [clientes, nuevoPedido.clienteId]);
+
+  // Horario obligatorio (mig 157): si el cliente elegido no tiene un horario
+  // utilizable, se pide acá mismo y no se puede confirmar el pedido hasta
+  // resolverlo. Antes había que salir del pedido, editar el cliente y volver —
+  // con el cliente esperando, nadie lo hacía y el ruteo quedaba sin ventanas.
+  const faltaHorarioCliente =
+    !!onGuardarHorarioCliente && clienteSinHorario(clienteSeleccionado);
 
   const handleCapturarGps = async (): Promise<void> => {
     setGpsCapturando(true);
@@ -492,6 +507,23 @@ const ModalPedido = memo(function ModalPedido({
                     ))}
                   </div>
                 )}
+              </div>
+            )}
+
+            {/* Horario faltante del cliente ya seleccionado. Va DENTRO del
+                ModalBase (no como modal hermano): un Radix Dialog deja
+                cualquier overlay hermano detrás y sería inalcanzable.
+                `key` por cliente: al cambiar de cliente el editor se reinicia
+                solo, sin efecto de sincronización. */}
+            {faltaHorarioCliente && clienteSeleccionado && (
+              <div className="mt-3">
+                <BloqueHorarioRequerido
+                  key={clienteSeleccionado.id}
+                  nombreCliente={clienteSeleccionado.nombre_fantasia || clienteSeleccionado.razon_social || 'este cliente'}
+                  horarioActual={clienteSeleccionado.horarios_atencion}
+                  diasActuales={clienteSeleccionado.dias_atencion}
+                  onGuardar={patch => onGuardarHorarioCliente!(String(clienteSeleccionado.id), patch)}
+                />
               </div>
             )}
           </div>
@@ -1054,6 +1086,15 @@ const ModalPedido = memo(function ModalPedido({
           </div>
         </div>
 
+        {/* Aviso del horario faltante en la barra inferior: el bloque para
+            cargarlo está arriba y puede quedar fuera de la vista con el
+            carrito lleno. */}
+        {faltaHorarioCliente && (
+          <div role="alert" className="flex-shrink-0 px-4 py-1.5 bg-amber-100 dark:bg-amber-900/40 border-t border-amber-300 dark:border-amber-700 text-xs text-amber-900 dark:text-amber-200">
+            Falta cargar el horario del cliente — subí para completarlo.
+          </div>
+        )}
+
         {/* Aviso compacto de violaciones (siempre visible cuando aplican) */}
         {violacionesMOQ.length > 0 && (
           <div role="alert" className="flex-shrink-0 px-4 py-1.5 bg-amber-100 dark:bg-amber-900/40 border-t border-amber-300 dark:border-amber-700 text-xs text-amber-900 dark:text-amber-200">
@@ -1091,7 +1132,7 @@ const ModalPedido = memo(function ModalPedido({
           <button
             type="button"
             onClick={onGuardar}
-            disabled={guardando || violacionesMOQ.length > 0 || !hayItems || debeElegirPreventista}
+            disabled={guardando || violacionesMOQ.length > 0 || !hayItems || debeElegirPreventista || faltaHorarioCliente}
             className="px-5 bg-green-600 text-white font-semibold hover:bg-green-700 disabled:bg-gray-400 disabled:cursor-not-allowed flex items-center justify-center gap-1.5 text-sm"
           >
             {guardando && <Loader2 className="w-4 h-4 animate-spin" />}

--- a/src/components/modals/ModalProducto.tsx
+++ b/src/components/modals/ModalProducto.tsx
@@ -4,6 +4,7 @@ import { Loader2 } from 'lucide-react';
 import ModalBase from './ModalBase';
 import NumberInput from '../ui/NumberInput';
 import { useZodValidation } from '../../hooks/useZodValidation';
+import { useMarcasQuery } from '../../hooks/queries';
 import { modalProductoSchema } from '../../lib/schemas';
 import {
   calcularCostoFinanciero,
@@ -28,6 +29,8 @@ export interface ProductoFormData {
   nombre: string;
   codigo: string;
   categoria: string;
+  /** FK a `marcas` (mig 158). '' = sin marca. Ortogonal a la categoría. */
+  marca_id?: string | null;
   proveedor_id: string;
   stock: number | string;
   stock_minimo: number;
@@ -118,11 +121,14 @@ const ModalProducto = memo(function ModalProducto({ producto, categorias, provee
   // en ZZ lo pagado es el costo final (ya incluye IVA e II, nada se suma encima).
   const tipoCompra: 'ZZ' | 'FC' = producto?.ultimo_tipo_compra ?? 'FC';
 
+  const { data: marcas = [] } = useMarcasQuery();
+
   const [form, setForm] = useState<ProductoFormData>(producto ? {
     id: producto.id,
     nombre: producto.nombre || '',
     codigo: producto.codigo || '',
     categoria: producto.categoria || '',
+    marca_id: producto.marca_id || '',
     proveedor_id: producto.proveedor_id || '',
     stock: producto.stock ?? '',
     stock_minimo: producto.stock_minimo ?? 10,
@@ -141,6 +147,7 @@ const ModalProducto = memo(function ModalProducto({ producto, categorias, provee
     nombre: '',
     codigo: '',
     categoria: '',
+    marca_id: '',
     proveedor_id: '',
     stock: '',
     stock_minimo: 10,
@@ -300,6 +307,9 @@ const ModalProducto = memo(function ModalProducto({ producto, categorias, provee
       onSave({
         ...formNormalizado,
         categoria: categoriaFinal,
+        // '' es la opción "sin marca" del select; la columna es una FK y no
+        // acepta string vacío.
+        marca_id: formNormalizado.marca_id || null,
         // 0 / vacío significan "sin mínimo": la columna es NULL, no 0 (el CHECK
         // de la mig 147 exige > 0).
         cantidad_minima_venta: Number(formNormalizado.cantidad_minima_venta) > 0
@@ -433,6 +443,29 @@ const ModalProducto = memo(function ModalProducto({ producto, categorias, provee
                 <option key={getCategoryKey(cat)} value={getCategoryName(cat)}>{getCategoryName(cat)}</option>
               ))}
             </select>
+          )}
+        </div>
+
+        {/* Marca (mig 158). Independiente de la categoría: un producto es
+            Manaos (marca) y gaseosas (categoría). La usan los objetivos por
+            marca, así que un producto nuevo sin marca queda fuera de esa
+            medición. */}
+        <div>
+          <label className="block text-sm font-medium mb-1">Marca</label>
+          <select
+            value={form.marca_id || ''}
+            onChange={(e: ChangeEvent<HTMLSelectElement>) => setForm({ ...form, marca_id: e.target.value })}
+            className="w-full px-3 py-2 border rounded-lg"
+          >
+            <option value="">Sin marca</option>
+            {marcas.filter(m => m.activa).map(m => (
+              <option key={m.id} value={m.id}>{m.nombre}</option>
+            ))}
+          </select>
+          {marcas.length === 0 && (
+            <p className="text-xs text-gray-500 mt-1">
+              Todavía no hay marcas cargadas. Se crean desde Catálogo → Marcas.
+            </p>
           )}
         </div>
 

--- a/src/components/productos/ProductoToolbar.tsx
+++ b/src/components/productos/ProductoToolbar.tsx
@@ -13,7 +13,7 @@
 import React from 'react';
 import {
   Plus, ChevronDown, Tag, Package2, AlertTriangle,
-  ArrowLeftRight, Percent, ClipboardCheck, TrendingDown, History, PackageMinus,
+  ArrowLeftRight, Percent, ClipboardCheck, TrendingDown, History, PackageMinus, Award,
   type LucideIcon,
 } from 'lucide-react';
 import {
@@ -32,6 +32,8 @@ export interface ProductoToolbarProps {
   puedeControlarStock?: boolean;
   productosStockBajoCount: number;
   onGestionarCategorias?: () => void;
+  /** Abre el ABM de marcas + asignación masiva a productos (mig 158). */
+  onGestionarMarcas?: () => void;
   onCambioProducto?: () => void;
   onActualizacionMasivaPrecios?: () => void;
   /** Carga masiva del mínimo de venta por categoría (mig 147). */
@@ -159,6 +161,7 @@ export default function ProductoToolbar({
   puedeControlarStock = false,
   productosStockBajoCount,
   onGestionarCategorias,
+  onGestionarMarcas,
   onCambioProducto,
   onActualizacionMasivaPrecios,
   onMinimoVentaMasivo,
@@ -169,7 +172,7 @@ export default function ProductoToolbar({
   onNuevoProducto,
 }: ProductoToolbarProps): React.ReactElement | null {
   const hayCatálogo = isAdmin && (
-    Boolean(onGestionarCategorias) || Boolean(onCambioProducto) ||
+    Boolean(onGestionarCategorias) || Boolean(onGestionarMarcas) || Boolean(onCambioProducto) ||
     Boolean(onActualizacionMasivaPrecios) || Boolean(onMinimoVentaMasivo)
   );
   // Control de stock (Excel) lo ve admin y encargado; el historial de mermas
@@ -193,6 +196,12 @@ export default function ProductoToolbar({
         <DropdownMenuItem onSelect={onGestionarCategorias}>
           <Tag className="w-4 h-4 text-purple-600" />
           <span>Categorías</span>
+        </DropdownMenuItem>
+      )}
+      {onGestionarMarcas && (
+        <DropdownMenuItem onSelect={onGestionarMarcas}>
+          <Award className="w-4 h-4 text-amber-600" />
+          <span>Marcas</span>
         </DropdownMenuItem>
       )}
       {onCambioProducto && (

--- a/src/components/ui/BloqueHorarioRequerido.tsx
+++ b/src/components/ui/BloqueHorarioRequerido.tsx
@@ -1,0 +1,136 @@
+import { useState, memo } from 'react';
+import { AlertCircle, Loader2 } from 'lucide-react';
+import FranjasHorariasEditor from './FranjasHorariasEditor';
+import DiasAtencionSelector from './DiasAtencionSelector';
+import {
+  convertirHorarioInicial,
+  serializarFranjas,
+  validarFranjas,
+} from '../../utils/horariosCliente';
+import type { FranjaHoraria } from '../../utils/horariosCliente';
+
+/** Patch que se persiste sobre el cliente. */
+export interface PatchHorarioCliente {
+  horarios_atencion?: string;
+  dias_atencion?: string | null;
+  sin_horario_fijo?: boolean;
+}
+
+export interface BloqueHorarioRequeridoProps {
+  /** Nombre a mostrar (solo para el copy). */
+  nombreCliente: string;
+  /** Texto ya cargado en `horarios_atencion`, si lo hay (puede ser legacy no parseable). */
+  horarioActual?: string | null;
+  /** Días ya cargados (bitmask), para no perderlos al guardar. */
+  diasActuales?: string | null;
+  /** Persiste el patch. Debe rechazar si falla para que se muestre el error. */
+  onGuardar: (patch: PatchHorarioCliente) => Promise<void>;
+}
+
+/**
+ * Bloque que pide el horario de atención de un cliente que no lo tiene, para
+ * cargarlo sin salir del modal de pedido.
+ *
+ * Va montado con `key={cliente.id}` para que el estado del editor se reinicie
+ * al cambiar de cliente sin necesidad de un efecto de sincronización.
+ *
+ * El escape ("no atiende con horario fijo") no es una concesión: hay clientes
+ * que genuinamente no tienen horario (puestos de feria, kioscos que abren
+ * cuando pueden). Sin él, el aviso reaparecería en cada pedido de ese cliente
+ * y los preventistas aprenderían a ignorarlo.
+ */
+const BloqueHorarioRequerido = memo(function BloqueHorarioRequerido({
+  nombreCliente,
+  horarioActual,
+  diasActuales,
+  onGuardar,
+}: BloqueHorarioRequeridoProps) {
+  // Si había texto libre legacy lo mostramos como ayuda para que el preventista
+  // lo traduzca a franjas en vez de tipearlo de cero.
+  const legacy = convertirHorarioInicial(horarioActual).sinReconocer;
+
+  const [franjas, setFranjas] = useState<FranjaHoraria[]>([{ apertura: '', cierre: '' }]);
+  const [dias, setDias] = useState<string | null>(diasActuales ?? null);
+  const [guardando, setGuardando] = useState<boolean>(false);
+  const [error, setError] = useState<string>('');
+
+  const persistir = async (patch: PatchHorarioCliente): Promise<void> => {
+    setGuardando(true);
+    try {
+      await onGuardar(patch);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'No se pudo guardar el horario.');
+    }
+    setGuardando(false);
+  };
+
+  const handleGuardar = async (): Promise<void> => {
+    const serializado = serializarFranjas(franjas);
+    if (!serializado) {
+      setError('Cargá al menos una franja completa (apertura y cierre).');
+      return;
+    }
+    if (!validarFranjas(franjas).valido) {
+      setError('Revisá los horarios: la apertura debe ser anterior al cierre y las franjas no pueden superponerse.');
+      return;
+    }
+    setError('');
+    await persistir({ horarios_atencion: serializado, dias_atencion: dias });
+  };
+
+  return (
+    <div
+      role="alert"
+      className="border border-amber-300 dark:border-amber-700 rounded-lg p-3 space-y-3 bg-amber-50 dark:bg-amber-900/20"
+    >
+      <div className="flex items-start gap-2">
+        <AlertCircle className="w-5 h-5 text-amber-600 dark:text-amber-400 shrink-0 mt-0.5" />
+        <div>
+          <p className="font-medium text-sm text-amber-900 dark:text-amber-200">
+            Falta el horario de {nombreCliente}
+          </p>
+          <p className="text-xs text-amber-800 dark:text-amber-300 mt-0.5">
+            Cargalo acá para poder confirmar el pedido. Se usa para armar la ruta y no
+            mandar al repartidor cuando el local está cerrado.
+          </p>
+          {legacy.length > 0 && (
+            <p className="text-xs text-amber-800 dark:text-amber-300 mt-1">
+              Está anotado como texto libre: «{legacy.join(' y ')}». Pasalo a franjas.
+            </p>
+          )}
+        </div>
+      </div>
+
+      <FranjasHorariasEditor franjas={franjas} onChange={setFranjas} />
+      <DiasAtencionSelector valor={dias} onChange={setDias} />
+
+      {error && (
+        <p className="text-sm text-red-600 bg-red-50 dark:bg-red-900/20 dark:text-red-400 px-3 py-2 rounded-lg">
+          {error}
+        </p>
+      )}
+
+      <div className="flex flex-col sm:flex-row gap-2">
+        <button
+          type="button"
+          onClick={handleGuardar}
+          disabled={guardando}
+          className="flex-1 py-2 bg-amber-600 text-white font-medium rounded-lg hover:bg-amber-700 disabled:bg-amber-400 disabled:cursor-not-allowed flex items-center justify-center gap-2"
+        >
+          {guardando && <Loader2 className="w-4 h-4 animate-spin" />}
+          Guardar horario
+        </button>
+        <button
+          type="button"
+          onClick={() => persistir({ sin_horario_fijo: true })}
+          disabled={guardando}
+          className="px-3 py-2 text-sm font-medium text-amber-800 dark:text-amber-300 hover:bg-amber-100 dark:hover:bg-amber-900/40 rounded-lg disabled:opacity-60 disabled:cursor-not-allowed"
+        >
+          No atiende con horario fijo
+        </button>
+      </div>
+    </div>
+  );
+});
+
+export default BloqueHorarioRequerido;

--- a/src/components/vistas/VistaDashboard.tsx
+++ b/src/components/vistas/VistaDashboard.tsx
@@ -7,6 +7,8 @@ import {
 import { formatPrecio } from '../../utils/formatters';
 import LoadingSpinner from '../layout/LoadingSpinner';
 import DashboardViewHeader from '../dashboard/DashboardViewHeader';
+import PanelMisMetas from '../dashboard/PanelMisMetas';
+import type { AvanceMetasResultado } from '../../hooks/queries';
 import DashboardToolbar from '../dashboard/DashboardToolbar';
 import { cn } from '../../lib/utils';
 import type {
@@ -79,6 +81,11 @@ export interface VistaDashboardProps {
   exportando: boolean;
   productosStockBajo?: ProductoDB[];
   totalClientes?: number;
+  /**
+   * Avance de los objetivos del mes (migs 159-161). Si no hay metas cargadas,
+   * el dashboard queda exactamente como antes.
+   */
+  avanceMetas?: AvanceMetasResultado;
   isAdmin?: boolean;
   isPreventista?: boolean;
   isEncargado?: boolean;
@@ -307,6 +314,7 @@ export default function VistaDashboard({
   exportando,
   productosStockBajo = [],
   totalClientes = 0,
+  avanceMetas,
   isAdmin = false,
   isPreventista = false,
   isEncargado = false,
@@ -378,6 +386,12 @@ export default function VistaDashboard({
           />
         }
       />
+
+      {/* Objetivos del mes. Va arriba de todo porque es lo que el preventista
+          tiene que mirar primero; si no hay metas cargadas no se renderiza. */}
+      {avanceMetas && avanceMetas.metas.length > 0 && (
+        <PanelMisMetas avance={avanceMetas} />
+      )}
 
       {/* Alerta de stock bajo: chip compacto (no banner) */}
       {productosStockBajo.length > 0 && (

--- a/src/components/vistas/VistaMetasPreventistas.tsx
+++ b/src/components/vistas/VistaMetasPreventistas.tsx
@@ -1,0 +1,247 @@
+/**
+ * Rendimiento del equipo comercial + avance de objetivos (migs 159-161).
+ *
+ * Una fila por preventista con sus números del mes; al expandir, el desglose
+ * por marca y por categoría y el avance de cada objetivo.
+ *
+ * La base es "pedidos entregados del mes, sin bonificaciones" — la misma de
+ * `reporte_gerencial`, así que la columna Venta cierra peso a peso con la
+ * sección "Equipo comercial" del reporte gerencial. Está escrito en pantalla
+ * porque `/comisiones` usa otra base (todo lo no cancelado) y ver dos números
+ * distintos sin explicación destruye la confianza en los dos.
+ */
+import { memo, useState } from 'react';
+import { Loader2, ChevronRight, Target, Users, UserPlus, TrendingUp } from 'lucide-react';
+import { formatPrecio } from '../../utils/formatters';
+import BarraProgresoMeta from '../metas/BarraProgresoMeta';
+import { useAvanceMetasQuery } from '../../hooks/queries';
+import type { RendimientoPreventista, RendimientoResultado } from '../../hooks/queries';
+
+export interface VistaMetasPreventistasProps {
+  resultado?: RendimientoResultado;
+  loading: boolean;
+  periodo: string;
+  onCambiarPeriodo: (periodo: string) => void;
+  onAbrirObjetivos: () => void;
+}
+
+/** Avance de un preventista, cargado sólo al expandir su fila. */
+const DetalleAvance = memo(function DetalleAvance({
+  preventistaId,
+  periodo,
+}: { preventistaId: string; periodo: string }) {
+  const { data: avance, isLoading } = useAvanceMetasQuery(preventistaId, periodo);
+
+  if (isLoading) {
+    return <div className="py-3 flex justify-center"><Loader2 className="w-4 h-4 animate-spin text-blue-600" /></div>;
+  }
+  if (!avance?.metas?.length) {
+    return <p className="text-sm text-gray-500 dark:text-gray-400 py-2">Sin objetivos cargados este mes.</p>;
+  }
+  return (
+    <div className="divide-y dark:divide-gray-700">
+      {avance.metas.map(m => <BarraProgresoMeta key={m.id} meta={m} densa />)}
+    </div>
+  );
+});
+
+const FilaPreventista = memo(function FilaPreventista({
+  p,
+  periodo,
+}: { p: RendimientoPreventista; periodo: string }) {
+  const [abierta, setAbierta] = useState(false);
+
+  return (
+    <>
+      <tr
+        className="border-b dark:border-gray-700 hover:bg-gray-50 dark:hover:bg-gray-700/40 cursor-pointer"
+        onClick={() => setAbierta(v => !v)}
+      >
+        <td className="px-3 py-2.5">
+          <span className="flex items-center gap-1.5 font-medium dark:text-white">
+            <ChevronRight className={`w-4 h-4 text-gray-400 transition-transform ${abierta ? 'rotate-90' : ''}`} />
+            {p.nombre}
+            {p.rol && p.rol !== 'preventista' && (
+              <span className="text-xs px-1.5 py-0.5 rounded-full bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-300">
+                {p.rol}
+              </span>
+            )}
+          </span>
+        </td>
+        <td className="px-3 py-2.5 text-right tabular-nums font-medium dark:text-white">{formatPrecio(p.venta)}</td>
+        <td className="px-3 py-2.5 text-right tabular-nums dark:text-gray-300 hidden sm:table-cell">{p.pedidos}</td>
+        <td className="px-3 py-2.5 text-right tabular-nums dark:text-gray-300 hidden md:table-cell">
+          {p.ticket != null ? formatPrecio(p.ticket) : '—'}
+        </td>
+        <td className="px-3 py-2.5 text-right tabular-nums dark:text-gray-300">{p.cobertura}</td>
+        <td className="px-3 py-2.5 text-right tabular-nums dark:text-gray-300 hidden sm:table-cell">{p.clientes_nuevos}</td>
+        <td className="px-3 py-2.5 text-right tabular-nums">
+          {p.metas_cargadas > 0 ? (
+            <span className="dark:text-gray-300">{p.metas_cargadas}</span>
+          ) : (
+            <span className="text-gray-400 text-xs">sin metas</span>
+          )}
+        </td>
+      </tr>
+
+      {abierta && (
+        <tr className="bg-gray-50/60 dark:bg-gray-800/60">
+          <td colSpan={7} className="px-3 py-3">
+            <div className="grid gap-4 md:grid-cols-2">
+              <div>
+                <h4 className="text-sm font-semibold mb-2 dark:text-white flex items-center gap-1.5">
+                  <Target className="w-4 h-4 text-blue-600" />
+                  Objetivos
+                </h4>
+                <DetalleAvance preventistaId={p.preventista_id} periodo={periodo} />
+              </div>
+
+              <div className="space-y-3">
+                <div>
+                  <h4 className="text-sm font-semibold mb-1 dark:text-white">Por marca</h4>
+                  <ul className="text-sm space-y-0.5">
+                    {p.por_marca.slice(0, 6).map(m => (
+                      <li key={m.marca} className="flex justify-between gap-2">
+                        <span className="text-gray-600 dark:text-gray-400 truncate">{m.marca}</span>
+                        <span className="tabular-nums dark:text-gray-300 shrink-0">
+                          {formatPrecio(m.venta)} · {m.unidades} u
+                        </span>
+                      </li>
+                    ))}
+                    {p.por_marca.length === 0 && (
+                      <li className="text-gray-400">Sin datos</li>
+                    )}
+                  </ul>
+                </div>
+                <div>
+                  <h4 className="text-sm font-semibold mb-1 dark:text-white">Por categoría</h4>
+                  <ul className="text-sm space-y-0.5">
+                    {p.por_categoria.slice(0, 6).map(c => (
+                      <li key={c.categoria} className="flex justify-between gap-2">
+                        <span className="text-gray-600 dark:text-gray-400 truncate">{c.categoria}</span>
+                        <span className="tabular-nums dark:text-gray-300 shrink-0">
+                          {formatPrecio(c.venta)} · {c.unidades} u
+                        </span>
+                      </li>
+                    ))}
+                    {p.por_categoria.length === 0 && (
+                      <li className="text-gray-400">Sin datos</li>
+                    )}
+                  </ul>
+                </div>
+                <p className="text-xs text-gray-500 dark:text-gray-400">
+                  Margen comercial del mes: {formatPrecio(p.margen_comercial)}
+                </p>
+              </div>
+            </div>
+          </td>
+        </tr>
+      )}
+    </>
+  );
+});
+
+/** Últimos 12 meses como opciones de período. */
+function opcionesPeriodo(): Array<{ valor: string; label: string }> {
+  const meses = ['enero', 'febrero', 'marzo', 'abril', 'mayo', 'junio',
+    'julio', 'agosto', 'septiembre', 'octubre', 'noviembre', 'diciembre'];
+  const hoy = new Date();
+  const out: Array<{ valor: string; label: string }> = [];
+  for (let i = 0; i < 12; i++) {
+    const d = new Date(hoy.getFullYear(), hoy.getMonth() - i, 1);
+    const valor = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-01`;
+    out.push({ valor, label: `${meses[d.getMonth()]} ${d.getFullYear()}` });
+  }
+  return out;
+}
+
+const VistaMetasPreventistas = memo(function VistaMetasPreventistas({
+  resultado,
+  loading,
+  periodo,
+  onCambiarPeriodo,
+  onAbrirObjetivos,
+}: VistaMetasPreventistasProps) {
+  const preventistas = resultado?.preventistas ?? [];
+  const totalVenta = preventistas.reduce((t, p) => t + p.venta, 0);
+  const totalNuevos = preventistas.reduce((t, p) => t + p.clientes_nuevos, 0);
+  const totalCobertura = preventistas.reduce((t, p) => t + p.cobertura, 0);
+
+  return (
+    <div className="space-y-4">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <h1 className="text-xl font-semibold dark:text-white">Objetivos y rendimiento</h1>
+          <p className="text-sm text-gray-500 dark:text-gray-400">
+            Sobre pedidos entregados del mes, sin bonificaciones.
+          </p>
+        </div>
+        <div className="flex items-center gap-2">
+          <select
+            value={periodo}
+            onChange={e => onCambiarPeriodo(e.target.value)}
+            className="px-3 py-2 border rounded-lg bg-white dark:bg-gray-700 dark:border-gray-600 dark:text-white text-sm"
+            aria-label="Mes"
+          >
+            {opcionesPeriodo().map(o => <option key={o.valor} value={o.valor}>{o.label}</option>)}
+          </select>
+          <button
+            type="button"
+            onClick={onAbrirObjetivos}
+            className="px-4 py-2 bg-blue-600 text-white text-sm font-medium rounded-lg hover:bg-blue-700 flex items-center gap-1.5"
+          >
+            <Target className="w-4 h-4" />
+            Cargar objetivos
+          </button>
+        </div>
+      </div>
+
+      <div className="grid grid-cols-3 gap-3">
+        {[
+          { icon: TrendingUp, label: 'Venta del mes', valor: formatPrecio(totalVenta) },
+          { icon: Users, label: 'Clientes atendidos', valor: String(totalCobertura) },
+          { icon: UserPlus, label: 'Clientes nuevos', valor: String(totalNuevos) },
+        ].map(k => (
+          <div key={k.label} className="rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-3">
+            <p className="text-xs text-gray-500 dark:text-gray-400 flex items-center gap-1">
+              <k.icon className="w-3.5 h-3.5" />
+              {k.label}
+            </p>
+            <p className="text-lg font-semibold dark:text-white tabular-nums mt-0.5">{k.valor}</p>
+          </div>
+        ))}
+      </div>
+
+      <div className="rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 overflow-x-auto">
+        {loading ? (
+          <div className="flex justify-center py-16"><Loader2 className="w-6 h-6 animate-spin text-blue-600" /></div>
+        ) : preventistas.length === 0 ? (
+          <p className="text-center text-sm text-gray-500 dark:text-gray-400 py-12">
+            No hay ventas entregadas en este mes.
+          </p>
+        ) : (
+          <table className="w-full text-sm">
+            <thead className="text-xs uppercase text-gray-500 dark:text-gray-400 border-b dark:border-gray-700">
+              <tr>
+                <th className="px-3 py-2 text-left font-medium">Preventista</th>
+                <th className="px-3 py-2 text-right font-medium">Venta</th>
+                <th className="px-3 py-2 text-right font-medium hidden sm:table-cell">Pedidos</th>
+                <th className="px-3 py-2 text-right font-medium hidden md:table-cell">Ticket</th>
+                <th className="px-3 py-2 text-right font-medium">Clientes</th>
+                <th className="px-3 py-2 text-right font-medium hidden sm:table-cell">Nuevos</th>
+                <th className="px-3 py-2 text-right font-medium">Objetivos</th>
+              </tr>
+            </thead>
+            <tbody>
+              {preventistas.map(p => (
+                <FilaPreventista key={p.preventista_id} p={p} periodo={periodo} />
+              ))}
+            </tbody>
+          </table>
+        )}
+      </div>
+    </div>
+  );
+});
+
+export default VistaMetasPreventistas;

--- a/src/components/vistas/VistaProductos.tsx
+++ b/src/components/vistas/VistaProductos.tsx
@@ -34,6 +34,7 @@ export interface VistaProductosProps {
   onActualizacionMasivaPrecios?: () => void;
   onMinimoVentaMasivo?: () => void;
   onGestionarCategorias?: () => void;
+  onGestionarMarcas?: () => void;
   onCambioProducto?: () => void;
   onControlStock?: () => void;
   onVerAjustesStock?: () => void;
@@ -55,6 +56,7 @@ export default function VistaProductos({
   onActualizacionMasivaPrecios,
   onMinimoVentaMasivo,
   onGestionarCategorias,
+  onGestionarMarcas,
   onCambioProducto,
   onControlStock,
   onVerAjustesStock,
@@ -139,6 +141,7 @@ export default function VistaProductos({
             puedeControlarStock={puedeControlarStock}
             productosStockBajoCount={productosStockBajo.length}
             onGestionarCategorias={onGestionarCategorias}
+            onGestionarMarcas={onGestionarMarcas}
             onCambioProducto={onCambioProducto}
             onActualizacionMasivaPrecios={onActualizacionMasivaPrecios}
             onMinimoVentaMasivo={onMinimoVentaMasivo}

--- a/src/hooks/queries/index.ts
+++ b/src/hooks/queries/index.ts
@@ -38,6 +38,45 @@ export {
 } from './useCategoriasQuery'
 export type { CategoriaDB } from './useCategoriasQuery'
 
+// Marcas (mig 158)
+export {
+  marcasKeys,
+  useMarcasQuery,
+  useCrearMarcaMutation,
+  useRenombrarMarcaMutation,
+  useEliminarMarcaMutation,
+  useToggleMarcaActivaMutation,
+  useAsignarMarcaMasivaMutation,
+} from './useMarcasQuery'
+export type { MarcaDB, AsignarMarcaMasivaArgs } from './useMarcasQuery'
+
+// Metas por preventista (migs 159-161)
+export {
+  metasKeys,
+  periodoMensual,
+  useAvanceMetasQuery,
+  useMetasPreventistaQuery,
+  useRendimientoPreventistasQuery,
+  // Ojo: `useGuardarMetaMutation` (sin sufijo) ya existe y es el de
+  // metas_gerenciales (mig 108). Son cosas distintas.
+  useGuardarMetaPreventistaMutation,
+  useDesactivarMetaPreventistaMutation,
+} from './useMetasPreventistaQuery'
+export type {
+  TipoMeta,
+  EstadoMeta,
+  TipoAlcance,
+  AlcanceMeta,
+  AvanceMeta,
+  AvanceMetasResultado,
+  MetaPreventista,
+  GuardarMetaInput,
+  RendimientoPreventista,
+  RendimientoResultado,
+  RendimientoPorMarca,
+  RendimientoPorCategoria,
+} from './useMetasPreventistaQuery'
+
 // Clientes
 export {
   clientesKeys,

--- a/src/hooks/queries/useClientesQuery.ts
+++ b/src/hooks/queries/useClientesQuery.ts
@@ -162,6 +162,8 @@ interface ClienteCreateInput {
   /** Días que abre, bitmask Lunes→Domingo (mig 140). null = abre todos. */
   dias_atencion?: string | null
   horario_entrega?: string
+  /** "No atiende con horario fijo": suprime el pedido de horario al cargar un pedido (mig 157). */
+  sin_horario_fijo?: boolean
   rubro?: string
   notas?: string
   preventista_id?: string | null

--- a/src/hooks/queries/useMarcasQuery.ts
+++ b/src/hooks/queries/useMarcasQuery.ts
@@ -1,0 +1,203 @@
+/**
+ * TanStack Query hooks para Marcas (mig 158).
+ *
+ * La marca es ortogonal a la categoría: un producto tiene una marca (Manaos,
+ * La Virginia) Y una categoría (gaseosas, fideos). Hasta la mig 158 ambas
+ * cosas convivían mezcladas en `categorias`, lo que hacía imposible pedir
+ * "cuánto vendió de gaseosas Manaos".
+ *
+ * A diferencia de `categorias`, acá no hay columna de texto espejo que
+ * mantener: `productos.marca_id` es la única fuente. Renombrar una marca no
+ * requiere tocar productos.
+ */
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import { supabase } from '../supabase/base'
+import { useSucursal } from '../../contexts/SucursalContext'
+import { productosKeys } from './useProductosQuery'
+
+// =============================================================================
+// TYPES
+// =============================================================================
+
+export interface MarcaDB {
+  id: string
+  nombre: string
+  sucursal_id: number
+  activa: boolean
+  created_at: string
+  updated_at: string
+}
+
+/** Args de la asignación masiva: por categoría entera o por lista de productos. */
+export interface AsignarMarcaMasivaArgs {
+  /** null quita la marca de los productos seleccionados. */
+  marcaId: string | null
+  categoriaId?: string | null
+  productoIds?: string[]
+}
+
+// =============================================================================
+// QUERY KEYS
+// =============================================================================
+
+export const marcasKeys = {
+  all: (sucursalId: number | null) => ['marcas', sucursalId] as const,
+  lists: (sucursalId: number | null) => [...marcasKeys.all(sucursalId), 'list'] as const,
+}
+
+// =============================================================================
+// FETCH
+// =============================================================================
+
+async function fetchMarcas(): Promise<MarcaDB[]> {
+  const { data, error } = await supabase
+    .from('marcas')
+    .select('*')
+    .order('nombre')
+
+  if (error) throw error
+  return (data as MarcaDB[]) || []
+}
+
+// =============================================================================
+// MUTATIONS
+// =============================================================================
+
+async function createMarca(nombre: string, sucursalId: number | null): Promise<MarcaDB> {
+  if (sucursalId == null) {
+    throw new Error('No hay sucursal activa. Recargá la página e intentá de nuevo.')
+  }
+
+  const nombreLimpio = nombre.trim()
+  if (!nombreLimpio) throw new Error('El nombre de la marca no puede estar vacío')
+
+  const { data, error } = await supabase
+    .from('marcas')
+    .insert([{ nombre: nombreLimpio, sucursal_id: sucursalId }])
+    .select()
+    .single()
+
+  if (error) {
+    if (error.code === '23505') {
+      throw new Error(`Ya existe una marca llamada "${nombreLimpio}"`)
+    }
+    throw error
+  }
+  return data as MarcaDB
+}
+
+async function renameMarca({ id, nombreNuevo }: { id: string; nombreNuevo: string }): Promise<void> {
+  const nuevoLimpio = nombreNuevo.trim()
+  if (!nuevoLimpio) throw new Error('El nombre nuevo no puede estar vacío')
+
+  const { error } = await supabase.from('marcas').update({ nombre: nuevoLimpio }).eq('id', id)
+  if (error) {
+    if (error.code === '23505') {
+      throw new Error(`Ya existe una marca llamada "${nuevoLimpio}"`)
+    }
+    throw error
+  }
+}
+
+/**
+ * Borra la marca. `productos.marca_id` tiene ON DELETE SET NULL, así que los
+ * productos quedan sin marca pero no se pierden.
+ */
+async function deleteMarca(id: string): Promise<void> {
+  const { error } = await supabase.from('marcas').delete().eq('id', id)
+  if (error) throw error
+}
+
+async function toggleMarcaActiva({ id, activa }: { id: string; activa: boolean }): Promise<void> {
+  const { error } = await supabase.from('marcas').update({ activa }).eq('id', id)
+  if (error) throw error
+}
+
+async function asignarMarcaMasiva(args: AsignarMarcaMasivaArgs): Promise<number> {
+  const { data, error } = await supabase.rpc('asignar_marca_masiva', {
+    p_marca_id: args.marcaId,
+    p_categoria_id: args.categoriaId ?? null,
+    // Los ids de productos son bigint en la base y string en el front.
+    p_producto_ids: args.productoIds?.length ? args.productoIds.map(Number) : null,
+  })
+  if (error) throw error
+  return (data as { actualizados?: number } | null)?.actualizados ?? 0
+}
+
+// =============================================================================
+// HOOKS
+// =============================================================================
+
+export function useMarcasQuery() {
+  const { currentSucursalId } = useSucursal()
+  return useQuery({
+    queryKey: marcasKeys.lists(currentSucursalId),
+    queryFn: fetchMarcas,
+    staleTime: 10 * 60 * 1000,
+  })
+}
+
+export function useCrearMarcaMutation() {
+  const queryClient = useQueryClient()
+  const { currentSucursalId } = useSucursal()
+
+  return useMutation({
+    mutationFn: (nombre: string) => createMarca(nombre, currentSucursalId),
+    onSuccess: (nueva) => {
+      queryClient.setQueryData<MarcaDB[]>(marcasKeys.lists(currentSucursalId), (old) => {
+        if (!old) return [nueva]
+        return [...old, nueva].sort((a, b) => a.nombre.localeCompare(b.nombre))
+      })
+    },
+  })
+}
+
+export function useRenombrarMarcaMutation() {
+  const queryClient = useQueryClient()
+  const { currentSucursalId } = useSucursal()
+
+  return useMutation({
+    mutationFn: renameMarca,
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: marcasKeys.lists(currentSucursalId) })
+    },
+  })
+}
+
+export function useEliminarMarcaMutation() {
+  const queryClient = useQueryClient()
+  const { currentSucursalId } = useSucursal()
+
+  return useMutation({
+    mutationFn: deleteMarca,
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: marcasKeys.lists(currentSucursalId) })
+      queryClient.invalidateQueries({ queryKey: productosKeys.lists(currentSucursalId) })
+    },
+  })
+}
+
+export function useToggleMarcaActivaMutation() {
+  const queryClient = useQueryClient()
+  const { currentSucursalId } = useSucursal()
+
+  return useMutation({
+    mutationFn: toggleMarcaActiva,
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: marcasKeys.lists(currentSucursalId) })
+    },
+  })
+}
+
+export function useAsignarMarcaMasivaMutation() {
+  const queryClient = useQueryClient()
+  const { currentSucursalId } = useSucursal()
+
+  return useMutation({
+    mutationFn: asignarMarcaMasiva,
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: productosKeys.lists(currentSucursalId) })
+      queryClient.invalidateQueries({ queryKey: marcasKeys.lists(currentSucursalId) })
+    },
+  })
+}

--- a/src/hooks/queries/useMetasPreventistaQuery.ts
+++ b/src/hooks/queries/useMetasPreventistaQuery.ts
@@ -1,0 +1,252 @@
+/**
+ * Objetivos por preventista (migs 159-161).
+ *
+ * El avance sale del RPC `avance_metas_preventista`, no de un cálculo en el
+ * front: el prorrateo y el semáforo se resuelven en SQL para que el número que
+ * ve el preventista en su dashboard y el que ve el gerente en /metas sean
+ * literalmente el mismo. `metas_gerenciales` prorratea en el front y por eso
+ * sus semáforos pueden discrepar.
+ *
+ * BASE: pedidos entregados, canal app, sin bonificaciones — la misma de
+ * `reporte_gerencial`. NO coincide con "Mis métricas" del dashboard
+ * (`useMetricasQuery`, que cuenta todo lo no cancelado), por eso el panel se
+ * rotula explícitamente.
+ */
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import { supabase } from '../supabase/base'
+import { useSucursal } from '../../contexts/SucursalContext'
+
+// =============================================================================
+// TYPES
+// =============================================================================
+
+export type TipoMeta = 'facturacion' | 'unidades' | 'cobertura' | 'clientes_nuevos'
+export type EstadoMeta = 'cumplida' | 'adelantado' | 'en_curso' | 'en_riesgo'
+export type TipoAlcance = 'marca' | 'categoria' | 'producto' | 'global'
+
+export interface AlcanceMeta {
+  tipo: TipoAlcance
+  id: string | number | null
+  nombre: string | null
+}
+
+export interface AvanceMeta {
+  id: number
+  tipo_meta: TipoMeta
+  /** '$' | 'u' | 'clientes' — derivada de tipo_meta en el RPC. */
+  unidad: string
+  alcance: AlcanceMeta
+  objetivo: number
+  logrado: number
+  pct: number
+  /** objetivo × días transcurridos / días del mes. Calculado en SQL. */
+  objetivo_prorrateado: number
+  estado: EstadoMeta
+}
+
+export interface AvanceMetasResultado {
+  preventista_id: string
+  nombre: string | null
+  periodo: string
+  dias_transcurridos: number
+  dias_periodo: number
+  metas: AvanceMeta[]
+  resumen: { total: number; cumplidas: number; en_riesgo: number }
+  /** Productos sin marca en la sucursal. Solo > 0 si hay metas por marca. */
+  productos_sin_marca: number
+}
+
+export interface MetaPreventista {
+  id: number
+  sucursal_id: number
+  preventista_id: string
+  periodo: string
+  tipo_meta: TipoMeta
+  marca_id: string | null
+  categoria_id: string | null
+  producto_id: number | null
+  valor_objetivo: number
+  activo: boolean
+  created_at: string
+}
+
+export interface GuardarMetaInput {
+  id?: number | null
+  sucursalId: number
+  preventistaId: string
+  /** 'YYYY-MM-01'. El RPC lo normaliza al primer día del mes igual. */
+  periodo: string
+  tipoMeta: TipoMeta
+  valorObjetivo: number
+  marcaId?: string | null
+  categoriaId?: string | null
+  productoId?: number | null
+}
+
+export interface RendimientoPorMarca {
+  marca: string
+  venta: number
+  unidades: number
+}
+
+export interface RendimientoPorCategoria {
+  categoria: string
+  venta: number
+  unidades: number
+}
+
+export interface RendimientoPreventista {
+  preventista_id: string
+  nombre: string
+  rol: string | null
+  pedidos: number
+  venta: number
+  unidades: number
+  margen_comercial: number
+  cobertura: number
+  clientes_nuevos: number
+  ticket: number | null
+  metas_cargadas: number
+  por_marca: RendimientoPorMarca[]
+  por_categoria: RendimientoPorCategoria[]
+}
+
+export interface RendimientoResultado {
+  periodo: string
+  preventistas: RendimientoPreventista[]
+}
+
+// =============================================================================
+// QUERY KEYS
+// =============================================================================
+
+export const metasKeys = {
+  all: (sucursalId: number | null) => ['metas-preventista', sucursalId] as const,
+  avance: (sucursalId: number | null, preventistaId: string | null, periodo: string) =>
+    [...metasKeys.all(sucursalId), 'avance', preventistaId ?? 'yo', periodo] as const,
+  lista: (sucursalId: number | null, periodo: string) =>
+    [...metasKeys.all(sucursalId), 'lista', periodo] as const,
+  rendimiento: (sucursalId: number | null, periodo: string) =>
+    [...metasKeys.all(sucursalId), 'rendimiento', periodo] as const,
+}
+
+/** Primer día del mes de una fecha, en formato ISO corto. */
+export function periodoMensual(fecha: Date = new Date()): string {
+  const y = fecha.getFullYear()
+  const m = String(fecha.getMonth() + 1).padStart(2, '0')
+  return `${y}-${m}-01`
+}
+
+// =============================================================================
+// HOOKS
+// =============================================================================
+
+/**
+ * Avance de un preventista. Sin `preventistaId` devuelve el del usuario
+ * logueado (es lo que usa el dashboard). Pasar otro id requiere ser admin: el
+ * RPC responde 42501 en caso contrario.
+ */
+export function useAvanceMetasQuery(
+  preventistaId?: string | null,
+  periodo: string = periodoMensual(),
+  enabled = true,
+) {
+  const { currentSucursalId } = useSucursal()
+  return useQuery({
+    queryKey: metasKeys.avance(currentSucursalId, preventistaId ?? null, periodo),
+    queryFn: async (): Promise<AvanceMetasResultado> => {
+      const { data, error } = await supabase.rpc('avance_metas_preventista', {
+        p_preventista_id: preventistaId ?? null,
+        p_periodo: periodo,
+      })
+      if (error) throw error
+      return data as AvanceMetasResultado
+    },
+    enabled,
+    // Alineado con useMetricasQuery, que es lo que se ve al lado en el dashboard.
+    staleTime: 2 * 60 * 1000,
+  })
+}
+
+/** Metas cargadas del período (la RLS ya filtra: el preventista ve las suyas). */
+export function useMetasPreventistaQuery(periodo: string = periodoMensual(), enabled = true) {
+  const { currentSucursalId } = useSucursal()
+  return useQuery({
+    queryKey: metasKeys.lista(currentSucursalId, periodo),
+    queryFn: async (): Promise<MetaPreventista[]> => {
+      const { data, error } = await supabase
+        .from('metas_preventista')
+        .select('*')
+        .eq('periodo', periodo)
+        .eq('activo', true)
+        .order('tipo_meta')
+        .order('id')
+      if (error) throw error
+      return (data as MetaPreventista[]) || []
+    },
+    enabled,
+    staleTime: 5 * 60 * 1000,
+  })
+}
+
+/** Rendimiento comparado del equipo. Admin-only (el RPC tira 42501 al resto). */
+export function useRendimientoPreventistasQuery(
+  periodo: string = periodoMensual(),
+  enabled = true,
+) {
+  const { currentSucursalId } = useSucursal()
+  return useQuery({
+    queryKey: metasKeys.rendimiento(currentSucursalId, periodo),
+    queryFn: async (): Promise<RendimientoResultado> => {
+      const { data, error } = await supabase.rpc('rendimiento_preventistas', {
+        p_sucursal_id: currentSucursalId,
+        p_periodo: periodo,
+      })
+      if (error) throw error
+      return data as RendimientoResultado
+    },
+    enabled,
+    staleTime: 5 * 60 * 1000,
+  })
+}
+
+export function useGuardarMetaPreventistaMutation() {
+  const queryClient = useQueryClient()
+  const { currentSucursalId } = useSucursal()
+
+  return useMutation({
+    mutationFn: async (input: GuardarMetaInput): Promise<number> => {
+      const { data, error } = await supabase.rpc('guardar_meta_preventista', {
+        p_id: input.id ?? null,
+        p_sucursal_id: input.sucursalId,
+        p_preventista_id: input.preventistaId,
+        p_periodo: input.periodo,
+        p_tipo_meta: input.tipoMeta,
+        p_valor_objetivo: input.valorObjetivo,
+        p_marca_id: input.marcaId ?? null,
+        p_categoria_id: input.categoriaId ?? null,
+        p_producto_id: input.productoId ?? null,
+      })
+      if (error) throw error
+      return data as number
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: metasKeys.all(currentSucursalId) })
+    },
+  })
+}
+
+export function useDesactivarMetaPreventistaMutation() {
+  const queryClient = useQueryClient()
+  const { currentSucursalId } = useSucursal()
+
+  return useMutation({
+    mutationFn: async (id: number): Promise<void> => {
+      const { error } = await supabase.rpc('desactivar_meta_preventista', { p_id: id })
+      if (error) throw error
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: metasKeys.all(currentSucursalId) })
+    },
+  })
+}

--- a/src/hooks/queries/useProductosQuery.ts
+++ b/src/hooks/queries/useProductosQuery.ts
@@ -105,6 +105,8 @@ async function createProducto(producto: ProductoFormInput, sucursalId: number | 
       // Mínimo de venta (mig 147): distinto de stock_minimo. null = sin mínimo.
       cantidad_minima_venta: producto.cantidad_minima_venta ?? null,
       categoria: producto.categoria || null,
+      // Marca (mig 158): FK, '' no es válido.
+      marca_id: producto.marca_id || null,
       proveedor_id: producto.proveedor_id || null,
       costo_sin_iva: producto.costo_sin_iva ? parseFloat(String(producto.costo_sin_iva)) : null,
       costo_con_iva: producto.costo_con_iva ? parseFloat(String(producto.costo_con_iva)) : null,
@@ -136,6 +138,7 @@ async function updateProducto({ id, data: producto }: { id: string; data: Partia
   if (producto.stock_minimo !== undefined) updateData.stock_minimo = producto.stock_minimo
   if (producto.cantidad_minima_venta !== undefined) updateData.cantidad_minima_venta = producto.cantidad_minima_venta
   if (producto.categoria !== undefined) updateData.categoria = producto.categoria || null
+  if (producto.marca_id !== undefined) updateData.marca_id = producto.marca_id || null
   if (producto.proveedor_id !== undefined) updateData.proveedor_id = producto.proveedor_id || null
   if (producto.costo_sin_iva !== undefined) updateData.costo_sin_iva = producto.costo_sin_iva ? parseFloat(String(producto.costo_sin_iva)) : null
   if (producto.costo_con_iva !== undefined) updateData.costo_con_iva = producto.costo_con_iva ? parseFloat(String(producto.costo_con_iva)) : null

--- a/src/types/hooks.ts
+++ b/src/types/hooks.ts
@@ -38,6 +38,12 @@ export interface ClienteDB {
    * Se conserva porque la imprimen los PDFs y porque tiene precedencia si está cargada.
    */
   horario_entrega?: string | null;
+  /**
+   * true = el cliente declaró que no atiende con horario fijo (mig 157).
+   * Distinto de `horarios_atencion` vacío ("todavía no se cargó"): suprime el
+   * pedido de horario al cargar un pedido.
+   */
+  sin_horario_fijo?: boolean | null;
   rubro?: string | null;
   notas?: string | null;
   limite_credito?: number;
@@ -74,6 +80,11 @@ export interface ProductoDB {
   categoria?: string | null;
   /** FK a `categorias`; la sincroniza un trigger desde el texto `categoria` (mig 146) */
   categoria_id?: string | null;
+  /**
+   * FK a `marcas` (mig 158). Ortogonal a la categoría: Manaos (marca) +
+   * gaseosas (categoría). NULL = sin marca asignada.
+   */
+  marca_id?: string | null;
   /**
    * Mínimo de unidades por pedido para este producto (mig 147). NULL = sin
    * mínimo. Ojo: NO es `stock_minimo`, que es el umbral de alerta de reposición.
@@ -308,6 +319,8 @@ export interface ProductoFormInput {
   stock: number;
   stock_minimo?: number;
   categoria?: string;
+  /** FK a `marcas` (mig 158). null / '' = sin marca. */
+  marca_id?: string | null;
   /** Mínimo de venta del producto (mig 147). null lo quita. */
   cantidad_minima_venta?: number | null;
   proveedor_id?: string | null;

--- a/src/utils/horariosCliente.test.ts
+++ b/src/utils/horariosCliente.test.ts
@@ -6,6 +6,7 @@ import {
   serializarFranjas,
   validarFranjas,
   convertirHorarioInicial,
+  clienteSinHorario,
 } from './horariosCliente';
 
 describe('generarOpcionesHora', () => {
@@ -178,5 +179,38 @@ describe('convertirHorarioInicial', () => {
     expect(convertirHorarioInicial(null)).toEqual({ franjas: [], huboLegacy: false, sinReconocer: [] });
     expect(convertirHorarioInicial(undefined)).toEqual({ franjas: [], huboLegacy: false, sinReconocer: [] });
     expect(convertirHorarioInicial('')).toEqual({ franjas: [], huboLegacy: false, sinReconocer: [] });
+  });
+});
+
+describe('clienteSinHorario', () => {
+  it('es true cuando no hay ningún horario cargado', () => {
+    expect(clienteSinHorario({})).toBe(true);
+    expect(clienteSinHorario({ horarios_atencion: null, horario_entrega: null })).toBe(true);
+    expect(clienteSinHorario({ horarios_atencion: '' })).toBe(true);
+  });
+
+  it('es false cuando hay franjas utilizables en horarios_atencion', () => {
+    expect(clienteSinHorario({ horarios_atencion: '08:00-12:00' })).toBe(false);
+    expect(clienteSinHorario({ horarios_atencion: '08:00-12:00 y 16:00-20:00' })).toBe(false);
+  });
+
+  it('es false cuando el horario utilizable está en la columna legacy horario_entrega', () => {
+    // horario_entrega está deprecada pero tiene precedencia si trae valor (mig 140).
+    expect(clienteSinHorario({ horarios_atencion: '', horario_entrega: '09:00-13:00' })).toBe(false);
+  });
+
+  it('es true con texto libre legacy no parseable: el ruteo tampoco lo puede usar', () => {
+    expect(clienteSinHorario({ horarios_atencion: '24 HS' })).toBe(true);
+    expect(clienteSinHorario({ horarios_atencion: 'Lunes a sábado de 9 a 14' })).toBe(true);
+  });
+
+  it('es false si el cliente declaró que no atiende con horario fijo', () => {
+    expect(clienteSinHorario({ sin_horario_fijo: true })).toBe(false);
+    expect(clienteSinHorario({ horarios_atencion: '24 HS', sin_horario_fijo: true })).toBe(false);
+  });
+
+  it('es false sin cliente (nada que pedir)', () => {
+    expect(clienteSinHorario(null)).toBe(false);
+    expect(clienteSinHorario(undefined)).toBe(false);
   });
 });

--- a/src/utils/horariosCliente.ts
+++ b/src/utils/horariosCliente.ts
@@ -177,3 +177,29 @@ export function convertirHorarioInicial(valor?: string | null): ConversionInicia
 
   return { franjas, huboLegacy, sinReconocer };
 }
+
+/** Lo mínimo que hace falta de un cliente para saber si tiene horario. */
+export interface ClienteConHorario {
+  horarios_atencion?: string | null;
+  horario_entrega?: string | null;
+  sin_horario_fijo?: boolean | null;
+}
+
+/**
+ * true si el cliente no tiene un horario *utilizable* y tampoco declaró que no
+ * atiende con horario fijo. Es la condición que dispara el pedido de horario al
+ * cargar un pedido.
+ *
+ * "Utilizable" = parseable a franjas. Un texto libre legacy ("24 HS", "9 A 14")
+ * cuenta como sin horario a propósito: el ruteo tampoco lo puede usar
+ * (`horarioParaRutear` en useOptimizarRuta aplica el mismo criterio), así que
+ * pedir que se lo traduzca a franjas es exactamente lo que queremos.
+ */
+export function clienteSinHorario(cliente?: ClienteConHorario | null): boolean {
+  if (!cliente) return false;
+  if (cliente.sin_horario_fijo) return false;
+  return (
+    parsearFranjas(cliente.horarios_atencion).length === 0 &&
+    parsearFranjas(cliente.horario_entrega).length === 0
+  );
+}


### PR DESCRIPTION
Los dos pedidos del gerente. Van en un solo PR con **dos commits separados** (`bd3bffc` horarios, `08b8922` metas), por si querés mergear el urgente primero.

## 1. Horario obligatorio al cargar pedido (lo urgente)

Los preventistas no cargaban el horario porque había que salir del pedido, entrar a la ficha del cliente, cargarlo y volver. Con el cliente esperando, no lo hacían: **386 de 685 clientes activos** están sin horario y el ruteo los manda a la barrida flexible.

Ahora el modal de pedido lo pide ahí mismo y no deja confirmar hasta resolverlo. Escape: *"No atiende con horario fijo"* → `clientes.sin_horario_fijo`, que distingue "todavía no lo cargamos" de "no aplica". Sin esa distinción el aviso reaparece en cada pedido del mismo cliente y se aprende a ignorarlo.

- **mig 157** agrega la columna **y la suma a la allow-list de `clientes_proteger_columnas_preventista`**, que es fail-closed. Sin eso el preventista recibe 42501 justo al usar el escape. Verifiqué el cuerpo vivo contra el catálogo de prod: hay dos guards en `clientes` y sólo el allow-list bloqueaba.
- Un texto libre legacy ("24 HS") cuenta como *sin horario* a propósito — el ruteo tampoco lo puede usar.
- El bloque va **dentro** del `ModalBase`: un overlay hermano queda detrás del Radix Dialog.

**Bug preexistente arreglado de paso:** `ClientesContainer` nunca mandaba `dias_atencion` en el patch, así que el selector de días de la ficha del cliente se editaba pero no persistía nada.

## 2. Objetivos por preventista + marcas

**Marcas (mig 158).** No existía el concepto: "LA VIRGINIA", "MANAOS", "PLACER" eran filas de `categorias` mezcladas con categorías reales, así que no había forma de pedir "gaseosas Manaos". Cada sucursal además lo hacía distinto — en Tucumán las categorías son marcas, en Taco Pozo son categorías de verdad y la marca vive en el nombre del producto. El backfill es sólo el determinístico (por id explícito, nunca por patrón de nombre); el resto se asigna desde Productos → Catálogo → Marcas, con filtro por nombre y "seleccionar todo lo filtrado".

**Objetivos (migs 159-161).** Facturación / unidades / cobertura / clientes nuevos, con alcance opcional por marca, categoría o producto. Pantalla admin `/metas` con el rendimiento comparado del equipo, y panel de avance en el dashboard del preventista.

Dos decisiones que conviene revisar:

- **RPC nuevo (`rendimiento_preventistas`) en vez de extender `reporte_gerencial`.** Cambiarle la firma obliga a `DROP` y reescribir sus ~20 CTEs, que es exactamente lo que las migs 124/130 vinieron evitando; y el gerencial es de rango libre mientras las metas son estrictamente mensuales.
- **`avance_metas_preventista` es `SECURITY DEFINER` y `p_preventista_id` viene del cliente.** El `IF auth.uid() IS NOT NULL AND v_target <> auth.uid() AND NOT es_admin()` es lo único que impide que un preventista lea las ventas y los objetivos de sus compañeros. Es el punto a mirar con lupa en la review.

**Base de venta:** entregado + canal app + sin bonificaciones — la misma de `reporte_gerencial`, para que el % de avance cierre contra la sección "Equipo comercial". Verificado con junio 2026: la facturación de un preventista da 10.789.430,10 y la suma de su desglose por marca da exactamente lo mismo. El panel lo rotula porque "Mis métricas" del dashboard usa otra base (todo lo no cancelado) y los números no coinciden.

El prorrateo se calcula en SQL a propósito: `metas_gerenciales` lo hace en el front y por eso sus semáforos pueden discrepar.

## Migraciones

**Las 5 ya están aplicadas en producción** y el ledger quedó alineado 1:1 con los archivos del repo.

| # | Qué hace |
|---|---|
| 157 | `clientes.sin_horario_fijo` + allow-list del trigger |
| 158 | tabla `marcas`, `productos.marca_id`, backfill, `asignar_marca_masiva` |
| 159 | `metas_preventista` + `guardar_meta_preventista` / `desactivar_meta_preventista` |
| 160 | `avance_metas_preventista` |
| 161 | `rendimiento_preventistas` |

## Verificación

Typecheck, lint, **946 tests** y build en verde. La capa SQL la probé end-to-end contra datos reales de producción (metas de prueba cargadas y borradas después).

**No pude verificar la parte visual:** el panel del navegador no compone frames en este entorno, así que no hay capturas. Conviene una pasada manual por el modal de pedido y por `/metas`.

## Queda pendiente (manual, del lado del negocio)

- **Asignar marca a los 137 productos que quedaron sin marca** — 92 de Taco Pozo y 45 de Tucumán. Es criterio comercial, no lo puedo inventar. Hasta que esté, los objetivos por marca miden de menos (la app lo avisa).
- **Decidir qué pasa con las categorías que en realidad son marcas.** Deliberadamente no las toqué: desactivarlas ahora dejaría productos con `categoria_id` NULL y rompería `calcular_comisiones` y el desglose por categoría del reporte gerencial.

🤖 Generated with [Claude Code](https://claude.com/claude-code)