### PR TITLE
feat(metas): objetivos sobre varios productos y carga para varios preventistas

### DIFF
--- a/migrations/162_metas_multi_producto.sql
+++ b/migrations/162_metas_multi_producto.sql
@@ -1,0 +1,401 @@
+-- =========================================================================
+-- 162_metas_multi_producto.sql
+--
+-- "Estaría bueno poder crear un objetivo por producto y múltiples productos,
+--  seleccionando los que se incluyen."
+--
+-- La mig 159 dejó `producto_id bigint` (un solo producto). En la práctica los
+-- objetivos son sobre un conjunto: "las gaseosas de 3 litros" son varios
+-- SKUs (sabores) y no siempre coinciden con una categoría entera.
+--
+-- `producto_id` se reemplaza por `producto_ids bigint[]`. La alternativa era
+-- una tabla hija, pero rompe dos cosas que hoy funcionan: el índice único con
+-- COALESCE (que es lo que habilita el upsert de guardar_meta_preventista) y
+-- los CHECK de alcance único, que pasarían a depender de otra tabla. Con el
+-- array, "sin productos" sigue siendo un valor comparable y el upsert vive.
+--
+-- Se pierde la FK: si alguien borra un producto, su id queda colgado en el
+-- array. Es aceptable — un producto borrado simplemente deja de matchear y el
+-- objetivo mide de menos; la UI muestra los que existen. A cambio, el RPC
+-- valida al guardar que los productos sean de la sucursal de la meta.
+--
+-- El array se guarda ORDENADO y sin duplicados: sin eso {12,7} y {7,12} son
+-- claves distintas para el índice único y se duplicaría el mismo objetivo.
+--
+-- La tabla está vacía en prod (0 filas), así que el cambio de columna no
+-- migra datos.
+--
+-- NOTA sobre bonificaciones: no hace falta tocar nada. avance_metas_preventista
+-- y rendimiento_preventistas ya filtran `es_bonificacion IS NOT TRUE`, así que
+-- los regalos de promoción (2.775 unidades y $0 desde junio) nunca sumaron ni
+-- en pesos ni en unidades.
+-- =========================================================================
+
+-- -------------------------------------------------------------------------
+-- 1. Columna nueva y baja de la vieja
+-- -------------------------------------------------------------------------
+ALTER TABLE public.metas_preventista
+  ADD COLUMN IF NOT EXISTS producto_ids bigint[];
+
+-- Los CHECK y el índice viejos referencian producto_id: hay que soltarlos
+-- antes de dropear la columna.
+ALTER TABLE public.metas_preventista
+  DROP CONSTRAINT IF EXISTS metas_preventista_alcance_unico,
+  DROP CONSTRAINT IF EXISTS metas_preventista_alcance_valido,
+  DROP CONSTRAINT IF EXISTS metas_preventista_unidades_check;
+
+DROP INDEX IF EXISTS public.metas_preventista_uidx;
+
+ALTER TABLE public.metas_preventista DROP COLUMN IF EXISTS producto_id;
+
+COMMENT ON COLUMN public.metas_preventista.producto_ids IS
+  'Productos incluidos en el objetivo. NULL = no acota por producto. Siempre ordenado y sin duplicados (lo normaliza guardar_meta_preventista) para que el índice único no vea {7,12} y {12,7} como distintos. Sin FK a propósito: ver mig 162.';
+
+-- -------------------------------------------------------------------------
+-- 2. CHECKs equivalentes, con el array en lugar de la columna
+-- -------------------------------------------------------------------------
+ALTER TABLE public.metas_preventista
+  ADD CONSTRAINT metas_preventista_alcance_unico CHECK (
+    (marca_id IS NOT NULL)::int
+    + (categoria_id IS NOT NULL)::int
+    + (producto_ids IS NOT NULL)::int <= 1
+  ),
+  -- Un array vacío es "acota por producto pero por ninguno": mide siempre 0.
+  ADD CONSTRAINT metas_preventista_productos_no_vacio CHECK (
+    producto_ids IS NULL OR cardinality(producto_ids) > 0
+  ),
+  ADD CONSTRAINT metas_preventista_alcance_valido CHECK (
+    tipo_meta IN ('facturacion', 'unidades')
+    OR (marca_id IS NULL AND categoria_id IS NULL AND producto_ids IS NULL)
+  ),
+  ADD CONSTRAINT metas_preventista_unidades_check CHECK (
+    tipo_meta <> 'unidades'
+    OR marca_id IS NOT NULL OR categoria_id IS NOT NULL OR producto_ids IS NOT NULL
+  );
+
+CREATE UNIQUE INDEX IF NOT EXISTS metas_preventista_uidx
+  ON public.metas_preventista (
+    preventista_id, periodo, tipo_meta,
+    COALESCE(marca_id, '00000000-0000-0000-0000-000000000000'::uuid),
+    COALESCE(categoria_id, '00000000-0000-0000-0000-000000000000'::uuid),
+    COALESCE(producto_ids, '{}'::bigint[])
+  );
+
+-- -------------------------------------------------------------------------
+-- 3. guardar_meta_preventista: p_producto_ids en lugar de p_producto_id.
+--    Cambia la firma, así que hay que dropear la vieja.
+-- -------------------------------------------------------------------------
+DROP FUNCTION IF EXISTS public.guardar_meta_preventista(bigint, bigint, uuid, date, text, numeric, uuid, uuid, bigint);
+
+CREATE OR REPLACE FUNCTION public.guardar_meta_preventista(
+  p_id             bigint,
+  p_sucursal_id    bigint,
+  p_preventista_id uuid,
+  p_periodo        date,
+  p_tipo_meta      text,
+  p_valor_objetivo numeric,
+  p_marca_id       uuid     DEFAULT NULL,
+  p_categoria_id   uuid     DEFAULT NULL,
+  p_producto_ids   bigint[] DEFAULT NULL
+)
+RETURNS bigint
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $fn$
+DECLARE
+  v_id        bigint;
+  v_periodo   date := date_trunc('month', COALESCE(p_periodo, current_date))::date;
+  v_productos bigint[];
+  v_ajenos    integer;
+BEGIN
+  IF NOT es_admin() THEN
+    RAISE EXCEPTION 'Solo un admin puede definir objetivos' USING ERRCODE = '42501';
+  END IF;
+
+  IF p_valor_objetivo IS NULL OR p_valor_objetivo <= 0 THEN
+    RAISE EXCEPTION 'El objetivo debe ser mayor a 0';
+  END IF;
+
+  IF p_sucursal_id IS NULL THEN
+    RAISE EXCEPTION 'Indicá la sucursal del objetivo';
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM usuario_sucursales
+    WHERE usuario_id = auth.uid() AND sucursal_id = p_sucursal_id
+  ) THEN
+    RAISE EXCEPTION 'No tenés acceso a esa sucursal' USING ERRCODE = '42501';
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM usuario_sucursales us
+    WHERE us.usuario_id = p_preventista_id AND us.sucursal_id = p_sucursal_id
+  ) THEN
+    RAISE EXCEPTION 'Ese usuario no trabaja en la sucursal elegida';
+  END IF;
+
+  -- Normalizar: ordenado, sin duplicados, NULL si viene vacío.
+  IF p_producto_ids IS NOT NULL AND cardinality(p_producto_ids) > 0 THEN
+    SELECT array_agg(DISTINCT x ORDER BY x) INTO v_productos
+    FROM unnest(p_producto_ids) AS x;
+
+    -- Un producto de otra sucursal no vende nunca acá: la meta mediría 0 y
+    -- nadie entendería por qué.
+    SELECT COUNT(*) INTO v_ajenos
+    FROM unnest(v_productos) AS x
+    WHERE NOT EXISTS (
+      SELECT 1 FROM productos p WHERE p.id = x AND p.sucursal_id = p_sucursal_id
+    );
+    IF v_ajenos > 0 THEN
+      RAISE EXCEPTION '% producto(s) no pertenecen a la sucursal elegida', v_ajenos;
+    END IF;
+  ELSE
+    v_productos := NULL;
+  END IF;
+
+  IF p_id IS NULL THEN
+    INSERT INTO metas_preventista (
+      sucursal_id, preventista_id, periodo, tipo_meta,
+      marca_id, categoria_id, producto_ids, valor_objetivo, usuario_id
+    ) VALUES (
+      p_sucursal_id, p_preventista_id, v_periodo, p_tipo_meta,
+      p_marca_id, p_categoria_id, v_productos, p_valor_objetivo, auth.uid()
+    )
+    ON CONFLICT (
+      preventista_id, periodo, tipo_meta,
+      COALESCE(marca_id, '00000000-0000-0000-0000-000000000000'::uuid),
+      COALESCE(categoria_id, '00000000-0000-0000-0000-000000000000'::uuid),
+      COALESCE(producto_ids, '{}'::bigint[])
+    ) DO UPDATE SET
+      valor_objetivo = EXCLUDED.valor_objetivo,
+      activo         = true,
+      usuario_id     = EXCLUDED.usuario_id
+    RETURNING id INTO v_id;
+  ELSE
+    UPDATE metas_preventista SET
+      preventista_id = p_preventista_id,
+      periodo        = v_periodo,
+      tipo_meta      = p_tipo_meta,
+      marca_id       = p_marca_id,
+      categoria_id   = p_categoria_id,
+      producto_ids   = v_productos,
+      valor_objetivo = p_valor_objetivo
+    WHERE id = p_id
+    RETURNING id INTO v_id;
+
+    IF v_id IS NULL THEN
+      RAISE EXCEPTION 'El objetivo % no existe', p_id USING ERRCODE = 'no_data_found';
+    END IF;
+  END IF;
+
+  RETURN v_id;
+END;
+$fn$;
+
+ALTER FUNCTION public.guardar_meta_preventista(bigint, bigint, uuid, date, text, numeric, uuid, uuid, bigint[]) OWNER TO postgres;
+REVOKE ALL ON FUNCTION public.guardar_meta_preventista(bigint, bigint, uuid, date, text, numeric, uuid, uuid, bigint[]) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.guardar_meta_preventista(bigint, bigint, uuid, date, text, numeric, uuid, uuid, bigint[]) TO authenticated;
+
+-- -------------------------------------------------------------------------
+-- 4. avance_metas_preventista: matchear contra el array.
+--    Sólo cambian el filtro de alcance y la etiqueta; el resto es la mig 160.
+-- -------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.avance_metas_preventista(
+  p_preventista_id uuid DEFAULT NULL,
+  p_periodo        date DEFAULT NULL
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $fn$
+DECLARE
+  v_target      uuid;
+  v_periodo     date;
+  v_hasta       date;
+  v_dias_total  integer;
+  v_dias_trans  integer;
+  v_nombre      text;
+  v_sucursales  bigint[];
+  v_result      jsonb;
+  v_sin_marca   integer := 0;
+  v_hay_marca   boolean := false;
+BEGIN
+  v_target  := COALESCE(p_preventista_id, auth.uid());
+  v_periodo := date_trunc('month', COALESCE(p_periodo, current_date))::date;
+  v_hasta   := (v_periodo + interval '1 month' - interval '1 day')::date;
+
+  IF v_target IS NULL THEN
+    RAISE EXCEPTION 'Sin usuario' USING ERRCODE = '42501';
+  END IF;
+
+  -- El muro: un preventista sólo puede pedir lo suyo.
+  IF auth.uid() IS NOT NULL AND v_target <> auth.uid() AND NOT es_admin() THEN
+    RAISE EXCEPTION 'Acceso denegado' USING ERRCODE = '42501';
+  END IF;
+
+  SELECT nombre INTO v_nombre FROM perfiles WHERE id = v_target;
+
+  v_dias_total := EXTRACT(DAY FROM v_hasta)::integer;
+  v_dias_trans := CASE
+    WHEN current_date > v_hasta   THEN v_dias_total
+    WHEN current_date < v_periodo THEN 0
+    ELSE EXTRACT(DAY FROM current_date)::integer
+  END;
+
+  SELECT array_agg(DISTINCT sucursal_id) INTO v_sucursales
+  FROM metas_preventista
+  WHERE preventista_id = v_target AND periodo = v_periodo AND activo;
+
+  IF v_sucursales IS NULL THEN
+    RETURN jsonb_build_object(
+      'preventista_id', v_target,
+      'nombre', v_nombre,
+      'periodo', v_periodo,
+      'dias_transcurridos', v_dias_trans,
+      'dias_periodo', v_dias_total,
+      'metas', '[]'::jsonb,
+      'resumen', jsonb_build_object('total', 0, 'cumplidas', 0, 'en_riesgo', 0),
+      'productos_sin_marca', 0
+    );
+  END IF;
+
+  WITH
+  metas AS (
+    SELECT * FROM metas_preventista
+    WHERE preventista_id = v_target AND periodo = v_periodo AND activo
+  ),
+  ped AS MATERIALIZED (
+    SELECT id, cliente_id, sucursal_id
+    FROM pedidos
+    WHERE usuario_id = v_target
+      AND estado = 'entregado'
+      AND canal = 'app'
+      AND fecha BETWEEN v_periodo AND v_hasta
+      AND sucursal_id = ANY(v_sucursales)
+  ),
+  -- Los regalos de promoción quedan afuera acá: no suman ni unidades ni pesos.
+  it AS MATERIALIZED (
+    SELECT p.sucursal_id, pi.cantidad, pi.subtotal,
+           pi.producto_id, prod.categoria_id, prod.marca_id
+    FROM ped p
+    JOIN pedido_items pi ON pi.pedido_id = p.id
+    JOIN productos prod  ON prod.id = pi.producto_id
+    WHERE pi.es_bonificacion IS NOT TRUE
+  ),
+  primer_pedido AS (
+    SELECT DISTINCT ON (p.cliente_id, p.sucursal_id)
+           p.cliente_id, p.sucursal_id, p.usuario_id, p.fecha
+    FROM pedidos p
+    WHERE p.estado = 'entregado' AND p.canal = 'app'
+      AND p.sucursal_id = ANY(v_sucursales)
+    ORDER BY p.cliente_id, p.sucursal_id, p.fecha, p.id
+  ),
+  logrado AS (
+    SELECT m.*,
+      CASE m.tipo_meta
+        WHEN 'facturacion' THEN (
+          SELECT COALESCE(SUM(i.subtotal), 0) FROM it i
+          WHERE i.sucursal_id = m.sucursal_id
+            AND (m.marca_id     IS NULL OR i.marca_id     = m.marca_id)
+            AND (m.categoria_id IS NULL OR i.categoria_id = m.categoria_id)
+            AND (m.producto_ids IS NULL OR i.producto_id  = ANY(m.producto_ids))
+        )
+        WHEN 'unidades' THEN (
+          SELECT COALESCE(SUM(i.cantidad), 0) FROM it i
+          WHERE i.sucursal_id = m.sucursal_id
+            AND (m.marca_id     IS NULL OR i.marca_id     = m.marca_id)
+            AND (m.categoria_id IS NULL OR i.categoria_id = m.categoria_id)
+            AND (m.producto_ids IS NULL OR i.producto_id  = ANY(m.producto_ids))
+        )
+        WHEN 'cobertura' THEN (
+          SELECT COUNT(DISTINCT p.cliente_id) FROM ped p
+          WHERE p.sucursal_id = m.sucursal_id
+        )
+        WHEN 'clientes_nuevos' THEN (
+          SELECT COUNT(*) FROM primer_pedido pp
+          WHERE pp.sucursal_id = m.sucursal_id
+            AND pp.usuario_id = v_target
+            AND pp.fecha BETWEEN v_periodo AND v_hasta
+        )
+      END AS logrado
+    FROM metas m
+  ),
+  calc AS (
+    SELECT l.*,
+      ROUND(l.valor_objetivo * v_dias_trans / NULLIF(v_dias_total, 0), 2) AS objetivo_prorrateado,
+      ROUND(100 * l.logrado / NULLIF(l.valor_objetivo, 0), 1) AS pct
+    FROM logrado l
+  )
+  SELECT jsonb_build_object(
+    'preventista_id', v_target,
+    'nombre', v_nombre,
+    'periodo', v_periodo,
+    'dias_transcurridos', v_dias_trans,
+    'dias_periodo', v_dias_total,
+    'metas', COALESCE(jsonb_agg(jsonb_build_object(
+        'id', c.id,
+        'tipo_meta', c.tipo_meta,
+        'unidad', CASE c.tipo_meta
+                    WHEN 'facturacion' THEN '$'
+                    WHEN 'unidades'    THEN 'u'
+                    ELSE 'clientes' END,
+        'alcance', CASE
+          WHEN c.marca_id IS NOT NULL THEN jsonb_build_object(
+            'tipo', 'marca', 'id', c.marca_id,
+            'nombre', (SELECT nombre FROM marcas WHERE id = c.marca_id))
+          WHEN c.categoria_id IS NOT NULL THEN jsonb_build_object(
+            'tipo', 'categoria', 'id', c.categoria_id,
+            'nombre', (SELECT nombre FROM categorias WHERE id = c.categoria_id))
+          WHEN c.producto_ids IS NOT NULL THEN jsonb_build_object(
+            'tipo', 'productos', 'id', NULL,
+            -- Un solo producto: su nombre. Varios: el conteo, porque la lista
+            -- entera no entra en una barra de progreso.
+            'nombre', CASE WHEN cardinality(c.producto_ids) = 1
+              THEN (SELECT nombre FROM productos WHERE id = c.producto_ids[1])
+              ELSE cardinality(c.producto_ids) || ' productos' END,
+            'productos', (SELECT COALESCE(jsonb_agg(jsonb_build_object('id', p.id, 'nombre', p.nombre) ORDER BY p.nombre), '[]'::jsonb)
+                          FROM productos p WHERE p.id = ANY(c.producto_ids)))
+          ELSE jsonb_build_object('tipo', 'global', 'id', NULL, 'nombre', NULL)
+        END,
+        'objetivo', c.valor_objetivo,
+        'logrado', c.logrado,
+        'pct', COALESCE(c.pct, 0),
+        'objetivo_prorrateado', COALESCE(c.objetivo_prorrateado, 0),
+        'estado', CASE
+          WHEN c.logrado >= c.valor_objetivo THEN 'cumplida'
+          WHEN c.logrado >= COALESCE(c.objetivo_prorrateado, 0) THEN 'adelantado'
+          WHEN c.logrado >= 0.8 * COALESCE(c.objetivo_prorrateado, 0) THEN 'en_curso'
+          ELSE 'en_riesgo'
+        END
+      ) ORDER BY c.tipo_meta, c.id), '[]'::jsonb),
+    'resumen', jsonb_build_object(
+      'total', COUNT(*),
+      'cumplidas', COUNT(*) FILTER (WHERE c.logrado >= c.valor_objetivo),
+      'en_riesgo', COUNT(*) FILTER (
+        WHERE c.logrado < 0.8 * COALESCE(c.objetivo_prorrateado, 0)
+          AND c.logrado < c.valor_objetivo)
+    )
+  ) INTO v_result
+  FROM calc c;
+
+  SELECT EXISTS (
+    SELECT 1 FROM metas_preventista
+    WHERE preventista_id = v_target AND periodo = v_periodo AND activo
+      AND marca_id IS NOT NULL
+  ) INTO v_hay_marca;
+
+  IF v_hay_marca THEN
+    SELECT COUNT(*) INTO v_sin_marca
+    FROM productos WHERE marca_id IS NULL AND sucursal_id = ANY(v_sucursales);
+  END IF;
+
+  RETURN v_result || jsonb_build_object('productos_sin_marca', v_sin_marca);
+END;
+$fn$;
+
+ALTER FUNCTION public.avance_metas_preventista(uuid, date) OWNER TO postgres;
+REVOKE ALL ON FUNCTION public.avance_metas_preventista(uuid, date) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.avance_metas_preventista(uuid, date) TO authenticated;

--- a/migrations/MANIFEST.md
+++ b/migrations/MANIFEST.md
@@ -126,8 +126,8 @@ funcional** y no se renombran los archivos: renombrarlos los desalinearía del l
 real lo da `version` y está en la sección A: en los dos casos el archivo de `main` quedó
 cronológicamente **fuera** del bloque 139–147 (uno antes, otro entre la 144 y la 145).
 
-**La próxima migración es la 162** — verificado contra el ledger el 2026-08-03: la última
-numerada es `161_rendimiento_preventistas`. Las **148–161** (origen del precio, reglas de
+**La próxima migración es la 163** — verificado contra el ledger el 2026-08-03: la última
+numerada es `162_metas_multi_producto`. Las **148–162** (origen del precio, reglas de
 comisión, `place_id`, horarios masivos, barridas, roles extra por sucursal, horario obligatorio
 al cargar pedido, marcas y objetivos por preventista) están aplicadas y mapean **1:1** con el
 ledger, así que no agregan ninguna excepción a las tablas de arriba.

--- a/src/components/metas/BarraProgresoMeta.tsx
+++ b/src/components/metas/BarraProgresoMeta.tsx
@@ -64,7 +64,14 @@ const BarraProgresoMeta = memo(function BarraProgresoMeta({ meta, densa = false 
   return (
     <div className={densa ? 'py-1' : 'py-2'}>
       <div className="flex items-baseline justify-between gap-2 mb-1">
-        <span className={`font-medium truncate dark:text-white ${densa ? 'text-sm' : ''}`}>
+        <span
+          className={`font-medium truncate dark:text-white ${densa ? 'text-sm' : ''}`}
+          // Con varios productos la etiqueta dice "N productos"; el detalle va
+          // en el tooltip, porque la lista entera no entra en una barra.
+          title={meta.alcance.productos?.length
+            ? meta.alcance.productos.map(p => p.nombre).join('\n')
+            : undefined}
+        >
           {etiquetaMeta(meta)}
         </span>
         <span className={`shrink-0 text-sm font-semibold tabular-nums ${COLOR_TEXTO[meta.estado]}`}>

--- a/src/components/modals/ModalMetasPreventista.tsx
+++ b/src/components/modals/ModalMetasPreventista.tsx
@@ -1,5 +1,5 @@
 /**
- * Alta y baja de objetivos mensuales por preventista (mig 159).
+ * Alta y baja de objetivos mensuales por preventista (migs 159 y 162).
  *
  * Arriba las metas ya cargadas del período, abajo el formulario. El tipo de
  * meta manda sobre el resto: "cobertura" y "clientes nuevos" no admiten
@@ -7,9 +7,16 @@
  * exige (100 unidades sin decir de qué no es una meta). Los CHECK de la base
  * dicen lo mismo; acá se refleja para no ofrecer combinaciones que van a
  * fallar del otro lado.
+ *
+ * Dos multiselecciones, por pedido explícito:
+ *  - Preventistas: el mismo objetivo suele ir para todo el equipo. En la base
+ *    igual se guarda UNA fila por persona (el avance es individual); el modal
+ *    sólo evita cargarlo cinco veces a mano.
+ *  - Productos: "las gaseosas de 3 litros" son varios SKUs y no siempre
+ *    coinciden con una categoría entera (mig 162).
  */
 import { memo, useMemo, useState } from 'react';
-import { Loader2, Plus, Trash2, AlertCircle, Target } from 'lucide-react';
+import { Loader2, Plus, Trash2, AlertCircle, Target, Search } from 'lucide-react';
 import ModalBase from './ModalBase';
 import NumberInput from '../ui/NumberInput';
 import { formatPrecio } from '../../utils/formatters';
@@ -19,6 +26,7 @@ import {
   useDesactivarMetaPreventistaMutation,
   useMarcasQuery,
   useCategoriasQuery,
+  useProductosQuery,
   usePreventistasAsignablesQuery,
 } from '../../hooks/queries';
 import type { TipoMeta, MetaPreventista } from '../../hooks/queries';
@@ -51,15 +59,19 @@ const ModalMetasPreventista = memo(function ModalMetasPreventista({
   const { data: preventistas = [] } = usePreventistasAsignablesQuery();
   const { data: marcas = [] } = useMarcasQuery();
   const { data: categorias = [] } = useCategoriasQuery();
+  const { data: productos = [] } = useProductosQuery();
   const guardarMut = useGuardarMetaPreventistaMutation();
   const bajaMut = useDesactivarMetaPreventistaMutation();
 
-  const [preventistaId, setPreventistaId] = useState('');
+  const [seleccionados, setSeleccionados] = useState<Set<string>>(new Set());
   const [tipoMeta, setTipoMeta] = useState<TipoMeta>('facturacion');
-  // 'marca:<uuid>' | 'categoria:<uuid>' | '' (global)
+  // 'marca:<uuid>' | 'categoria:<uuid>' | 'productos' | '' (global)
   const [alcance, setAlcance] = useState('');
+  const [productosSel, setProductosSel] = useState<Set<string>>(new Set());
+  const [busquedaProd, setBusquedaProd] = useState('');
   const [valor, setValor] = useState<number>(0);
   const [error, setError] = useState('');
+  const [okMsg, setOkMsg] = useState('');
 
   const admiteAlcance = ADMITE_ALCANCE.includes(tipoMeta);
   const exigeAlcance = EXIGE_ALCANCE.includes(tipoMeta);
@@ -74,8 +86,12 @@ const ModalMetasPreventista = memo(function ModalMetasPreventista({
 
   const describirMeta = (meta: MetaPreventista): string => {
     const tipo = TIPOS.find(t => t.valor === meta.tipo_meta)?.label ?? meta.tipo_meta;
+    const n = meta.producto_ids?.length ?? 0;
     const alc = meta.marca_id ? nombrePorId.get(meta.marca_id)
       : meta.categoria_id ? nombrePorId.get(meta.categoria_id)
+      // Con un solo producto vale la pena el nombre; con varios no entra.
+      : n === 1 ? (productos.find(p => String(p.id) === String(meta.producto_ids![0]))?.nombre ?? '1 producto')
+      : n > 1 ? `${n} productos`
       : null;
     return alc ? `${tipo} — ${alc}` : tipo;
   };
@@ -88,13 +104,26 @@ const ModalMetasPreventista = memo(function ModalMetasPreventista({
   const handleTipoChange = (t: TipoMeta): void => {
     setTipoMeta(t);
     // Cambiar a un tipo sin alcance deja basura seleccionada que la base rechaza.
-    if (!ADMITE_ALCANCE.includes(t)) setAlcance('');
+    if (!ADMITE_ALCANCE.includes(t)) {
+      setAlcance('');
+      setProductosSel(new Set());
+    }
     setError('');
   };
 
+  const productosFiltrados = useMemo(() => {
+    const q = busquedaProd.trim().toLowerCase();
+    return productos
+      .filter(p => !q || p.nombre.toLowerCase().includes(q) || (p.categoria || '').toLowerCase().includes(q))
+      .sort((a, b) => a.nombre.localeCompare(b.nombre));
+  }, [productos, busquedaProd]);
+
+  const todosFiltradosSel =
+    productosFiltrados.length > 0 && productosFiltrados.every(p => productosSel.has(p.id));
+
   const handleGuardar = async (): Promise<void> => {
-    if (!preventistaId) {
-      setError('Elegí el preventista');
+    if (seleccionados.size === 0) {
+      setError('Elegí al menos un preventista');
       return;
     }
     if (currentSucursalId == null) {
@@ -107,26 +136,47 @@ const ModalMetasPreventista = memo(function ModalMetasPreventista({
       return;
     }
     if (exigeAlcance && !alcance) {
-      setError('Elegí de qué marca o categoría son las unidades');
+      setError('Elegí de qué son las unidades (marca, categoría o productos)');
+      return;
+    }
+    if (alcance === 'productos' && productosSel.size === 0) {
+      setError('Elegí al menos un producto');
       return;
     }
 
-    const [tipoAlc, idAlc] = alcance ? alcance.split(':') : [null, null];
+    const [tipoAlc, idAlc] = alcance.includes(':') ? alcance.split(':') : [alcance, null];
     setError('');
-    try {
-      await guardarMut.mutateAsync({
-        sucursalId: currentSucursalId,
-        preventistaId,
-        periodo,
-        tipoMeta,
-        valorObjetivo: objetivo,
-        marcaId: tipoAlc === 'marca' ? idAlc : null,
-        categoriaId: tipoAlc === 'categoria' ? idAlc : null,
-      });
+    setOkMsg('');
+
+    // Una fila por preventista: el avance es individual. El modal sólo evita
+    // cargar el mismo objetivo cinco veces a mano.
+    const fallos: string[] = [];
+    for (const pid of seleccionados) {
+      try {
+        await guardarMut.mutateAsync({
+          sucursalId: currentSucursalId,
+          preventistaId: pid,
+          periodo,
+          tipoMeta,
+          valorObjetivo: objetivo,
+          marcaId: tipoAlc === 'marca' ? idAlc : null,
+          categoriaId: tipoAlc === 'categoria' ? idAlc : null,
+          productoIds: tipoAlc === 'productos' ? [...productosSel].map(Number) : null,
+        });
+      } catch (e) {
+        // Se sigue con el resto: que uno falle (ej. no pertenece a la sucursal)
+        // no tiene por qué tirar abajo la carga de los demás.
+        fallos.push(`${nombrePorId.get(pid) ?? pid}: ${e instanceof Error ? e.message : 'error'}`);
+      }
+    }
+
+    const ok = seleccionados.size - fallos.length;
+    if (fallos.length > 0) setError(fallos.join(' · '));
+    if (ok > 0) {
+      setOkMsg(`Objetivo cargado para ${ok} preventista${ok === 1 ? '' : 's'}.`);
       setValor(0);
       setAlcance('');
-    } catch (e) {
-      setError(e instanceof Error ? e.message : 'No se pudo guardar el objetivo');
+      setProductosSel(new Set());
     }
   };
 
@@ -199,17 +249,45 @@ const ModalMetasPreventista = memo(function ModalMetasPreventista({
           <h3 className="text-sm font-medium dark:text-gray-200">Nuevo objetivo</h3>
 
           <div>
-            <label className="block text-sm font-medium mb-1 dark:text-gray-200">Preventista</label>
-            <select
-              value={preventistaId}
-              onChange={e => setPreventistaId(e.target.value)}
-              className="w-full px-3 py-2 border rounded-lg bg-white dark:bg-gray-700 dark:border-gray-600 dark:text-white"
-            >
-              <option value="">Elegí…</option>
+            <div className="flex items-baseline justify-between gap-2 mb-1">
+              <label className="block text-sm font-medium dark:text-gray-200">
+                Preventistas ({seleccionados.size})
+              </label>
+              <button
+                type="button"
+                onClick={() => setSeleccionados(
+                  seleccionados.size === preventistas.length
+                    ? new Set()
+                    : new Set(preventistas.map(p => p.id)),
+                )}
+                className="text-sm font-medium text-blue-600 hover:underline"
+              >
+                {seleccionados.size === preventistas.length ? 'Ninguno' : 'Todos'}
+              </button>
+            </div>
+            <div className="border dark:border-gray-600 rounded-lg divide-y dark:divide-gray-700 max-h-36 overflow-y-auto">
               {preventistas.map(p => (
-                <option key={p.id} value={p.id}>{p.nombre || p.email}</option>
+                <label
+                  key={p.id}
+                  className="flex items-center gap-2 px-3 py-2 text-sm cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-700/50"
+                >
+                  <input
+                    type="checkbox"
+                    checked={seleccionados.has(p.id)}
+                    onChange={e => setSeleccionados(prev => {
+                      const next = new Set(prev);
+                      if (e.target.checked) next.add(p.id); else next.delete(p.id);
+                      return next;
+                    })}
+                    className="w-4 h-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500"
+                  />
+                  <span className="dark:text-white truncate">{p.nombre || p.email}</span>
+                </label>
               ))}
-            </select>
+            </div>
+            <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
+              Se carga el mismo objetivo para cada uno; el avance se mide por separado.
+            </p>
           </div>
 
           <div>
@@ -237,6 +315,7 @@ const ModalMetasPreventista = memo(function ModalMetasPreventista({
                 className="w-full px-3 py-2 border rounded-lg bg-white dark:bg-gray-700 dark:border-gray-600 dark:text-white"
               >
                 <option value="">{exigeAlcance ? 'Elegí…' : 'Todo (sin acotar)'}</option>
+                <option value="productos">Productos específicos…</option>
                 {marcas.filter(m => m.activa).length > 0 && (
                   <optgroup label="Marcas">
                     {marcas.filter(m => m.activa).map(m => (
@@ -255,6 +334,72 @@ const ModalMetasPreventista = memo(function ModalMetasPreventista({
               <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
                 Para "2 millones de Manaos y de esos, 100 gaseosas" cargá dos objetivos.
               </p>
+            </div>
+          )}
+
+          {/* Selector de productos: "las gaseosas de 3 litros" son varios SKUs
+              y no siempre coinciden con una categoría entera. */}
+          {admiteAlcance && alcance === 'productos' && (
+            <div>
+              <div className="flex items-baseline justify-between gap-2 mb-1">
+                <label className="block text-sm font-medium dark:text-gray-200">
+                  Productos incluidos ({productosSel.size})
+                </label>
+                <button
+                  type="button"
+                  onClick={() => setProductosSel(prev => {
+                    const next = new Set(prev);
+                    if (todosFiltradosSel) productosFiltrados.forEach(p => next.delete(p.id));
+                    else productosFiltrados.forEach(p => next.add(p.id));
+                    return next;
+                  })}
+                  disabled={productosFiltrados.length === 0}
+                  className="text-sm font-medium text-blue-600 hover:underline disabled:opacity-50 disabled:no-underline"
+                >
+                  {todosFiltradosSel ? 'Quitar' : 'Agregar'} los {productosFiltrados.length} de la lista
+                </button>
+              </div>
+
+              <div className="relative mb-2">
+                <Search className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400 w-4 h-4 pointer-events-none" />
+                <input
+                  type="text"
+                  value={busquedaProd}
+                  onChange={e => setBusquedaProd(e.target.value)}
+                  placeholder="Filtrar por nombre o categoría… (ej: 3LT)"
+                  className="w-full pl-9 pr-3 py-2 border rounded-lg bg-white dark:bg-gray-700 dark:border-gray-600 dark:text-white text-sm"
+                />
+              </div>
+
+              <div className="border dark:border-gray-600 rounded-lg divide-y dark:divide-gray-700 max-h-44 overflow-y-auto">
+                {productosFiltrados.length === 0 ? (
+                  <p className="px-3 py-4 text-center text-sm text-gray-500 dark:text-gray-400">
+                    No hay productos que coincidan.
+                  </p>
+                ) : productosFiltrados.map(p => (
+                  <label
+                    key={p.id}
+                    className="flex items-center gap-2 px-3 py-2 text-sm cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-700/50"
+                  >
+                    <input
+                      type="checkbox"
+                      checked={productosSel.has(p.id)}
+                      onChange={e => setProductosSel(prev => {
+                        const next = new Set(prev);
+                        if (e.target.checked) next.add(p.id); else next.delete(p.id);
+                        return next;
+                      })}
+                      className="w-4 h-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500 shrink-0"
+                    />
+                    <span className="flex-1 min-w-0">
+                      <span className="block dark:text-white truncate">{p.nombre}</span>
+                      <span className="block text-xs text-gray-500 dark:text-gray-400">
+                        {p.categoria || 'sin categoría'}
+                      </span>
+                    </span>
+                  </label>
+                ))}
+              </div>
             </div>
           )}
 
@@ -277,6 +422,11 @@ const ModalMetasPreventista = memo(function ModalMetasPreventista({
               <span>{error}</span>
             </div>
           )}
+          {okMsg && (
+            <p className="p-3 bg-green-50 dark:bg-green-900/20 border border-green-200 dark:border-green-800 rounded-lg text-sm text-green-700 dark:text-green-300">
+              {okMsg}
+            </p>
+          )}
 
           <button
             type="button"
@@ -285,7 +435,9 @@ const ModalMetasPreventista = memo(function ModalMetasPreventista({
             className="w-full py-2 bg-blue-600 text-white font-medium rounded-lg hover:bg-blue-700 disabled:bg-gray-400 disabled:cursor-not-allowed flex items-center justify-center gap-1.5"
           >
             {guardarMut.isPending ? <Loader2 className="w-4 h-4 animate-spin" /> : <Plus className="w-4 h-4" />}
-            Agregar objetivo
+            {seleccionados.size > 1
+              ? `Agregar objetivo a ${seleccionados.size} preventistas`
+              : 'Agregar objetivo'}
           </button>
         </div>
       </div>

--- a/src/hooks/queries/useMetasPreventistaQuery.ts
+++ b/src/hooks/queries/useMetasPreventistaQuery.ts
@@ -22,12 +22,15 @@ import { useSucursal } from '../../contexts/SucursalContext'
 
 export type TipoMeta = 'facturacion' | 'unidades' | 'cobertura' | 'clientes_nuevos'
 export type EstadoMeta = 'cumplida' | 'adelantado' | 'en_curso' | 'en_riesgo'
-export type TipoAlcance = 'marca' | 'categoria' | 'producto' | 'global'
+export type TipoAlcance = 'marca' | 'categoria' | 'productos' | 'global'
 
 export interface AlcanceMeta {
   tipo: TipoAlcance
   id: string | number | null
+  /** Nombre del alcance. Para varios productos: "N productos". */
   nombre: string | null
+  /** Sólo cuando tipo === 'productos': el detalle de cuáles. */
+  productos?: Array<{ id: number; nombre: string }>
 }
 
 export interface AvanceMeta {
@@ -64,7 +67,8 @@ export interface MetaPreventista {
   tipo_meta: TipoMeta
   marca_id: string | null
   categoria_id: string | null
-  producto_id: number | null
+  /** Productos incluidos. null = no acota por producto (mig 162). */
+  producto_ids: number[] | null
   valor_objetivo: number
   activo: boolean
   created_at: string
@@ -80,7 +84,7 @@ export interface GuardarMetaInput {
   valorObjetivo: number
   marcaId?: string | null
   categoriaId?: string | null
-  productoId?: number | null
+  productoIds?: number[] | null
 }
 
 export interface RendimientoPorMarca {
@@ -225,7 +229,7 @@ export function useGuardarMetaPreventistaMutation() {
         p_valor_objetivo: input.valorObjetivo,
         p_marca_id: input.marcaId ?? null,
         p_categoria_id: input.categoriaId ?? null,
-        p_producto_id: input.productoId ?? null,
+        p_producto_ids: input.productoIds?.length ? input.productoIds : null,
       })
       if (error) throw error
       return data as number


### PR DESCRIPTION
Sigue a #445 (ya mergeado). Dos ajustes pedidos sobre esa primera versión, más una verificación.

## 1. Objetivos sobre varios productos

Antes el alcance por producto era **uno solo** — y encima el selector del modal ni lo ofrecía, así que en la práctica sólo se podía por marca o categoría. Pero "las gaseosas de 3 litros" son varios SKUs (un sabor por producto) y no siempre coinciden con una categoría entera.

Ahora el objetivo puede enumerar los productos que incluye: en el modal aparece **"Productos específicos…"** con buscador y checkboxes, más un "agregar los N de la lista". Filtrás por `3LT`, seleccionás todos, listo.

**Decisión de schema** (mig 162): `producto_id bigint` → `producto_ids bigint[]`. La alternativa era una tabla hija, pero rompe dos cosas que hoy funcionan: el índice único con `COALESCE` (que es lo que habilita el upsert de `guardar_meta_preventista`) y los CHECK de alcance único, que pasarían a depender de otra tabla.

Dos consecuencias que vale la pena mirar en la review:
- El array se guarda **ordenado y sin duplicados**. Sin eso `{7,12}` y `{12,7}` son claves distintas para el índice único y se duplicaría el mismo objetivo.
- **Se pierde la FK.** Un producto borrado deja su id colgado en el array y simplemente deja de matchear (el objetivo mide de menos, no rompe). A cambio, el RPC valida al guardar que los productos sean de la sucursal de la meta — uno de otra sucursal mediría 0 y nadie entendería por qué.

La tabla estaba vacía en producción, así que el cambio de columna no migra datos.

## 2. Carga para varios preventistas de una

El mismo objetivo suele ir para todo el equipo. El selector de preventista pasó a ser una lista de checkboxes con "Todos".

En la base **se sigue guardando una fila por persona** — el avance es individual y tiene que serlo. El modal sólo evita cargar el mismo objetivo cinco veces a mano. Si uno falla se sigue con el resto y se informa cuáles: que un preventista no pertenezca a la sucursal no tiene por qué tirar abajo la carga de los demás.

## 3. Regalos de promoción — ya estaba bien

Se pidió controlar que los regalos no cuenten como venta. **No hizo falta cambiar nada:** `avance_metas_preventista` y `rendimiento_preventistas` ya filtran `es_bonificacion IS NOT TRUE` desde #445.

Verificado en producción sobre un objetivo real de 3 productos:

| | unidades |
|---|---|
| Vendidas (`es_bonificacion = false`) | 102 |
| Regaladas por promo (`es_bonificacion = true`) | 64 |
| **Lo que cuenta el objetivo** | **102** |

A nivel global desde junio son 2.775 unidades de regalo con subtotal $0 que nunca entraron ni en pesos ni en unidades.

## Migración

**La 162 ya está aplicada en producción** y el ledger quedó alineado con el repo.

## Verificación

Typecheck, lint, 946 tests y build en verde. El RPC lo probé contra datos reales (objetivo multi-producto cargado, avance verificado contra el conteo crudo, y borrado después).

Sigue pendiente la verificación visual: el panel del navegador no compone frames en este entorno.

🤖 Generated with [Claude Code](https://claude.com/claude-code)