### PR TITLE
fix(reportes): no contar los regalos de promo como venta ni mezclar unidades

### DIFF
--- a/src/components/pedidos/PedidoCard.tsx
+++ b/src/components/pedidos/PedidoCard.tsx
@@ -21,6 +21,7 @@ import { useCambiarTipoFacturaMutation } from '../../hooks/queries/usePedidosQue
 import { PedidoActionsCtx } from '../../contexts/HandlersContext';
 import { useAuthData } from '../../contexts/AuthDataContext';
 import { haversineMeters, formatDistancia, clasificarDistancia, SEMAFORO_COLORS } from '../../utils/geo';
+import { formatCantidadItem, equivalenteEnUnidades } from '../../utils/unidadesRegalo';
 import type { PedidoDB, MotivoSalvedad } from '../../types';
 
 // =============================================================================
@@ -618,7 +619,12 @@ function PedidoCard({
                     )}
                   </div>
                   <div className="text-right">
-                    <p className="font-semibold text-gray-700 dark:text-gray-300">x{item.cantidad}</p>
+                    {/* El regalo de una promo Fracción viene en botellas, no en
+                        fardos: sin la etiqueta, "x392" se lee como 392 fardos. */}
+                    <p className="font-semibold text-gray-700 dark:text-gray-300">{formatCantidadItem(item)}</p>
+                    {equivalenteEnUnidades(item) && (
+                      <p className="text-xs text-gray-500 dark:text-gray-400">{equivalenteEnUnidades(item)}</p>
+                    )}
                     {!item.es_bonificacion && <p className="text-sm font-bold text-blue-600">{formatPrecio(item.subtotal || item.precio_unitario * item.cantidad)}</p>}
                     {item.es_bonificacion && <p className="text-sm font-bold text-green-600">$0</p>}
                     {salvedadItem && (

--- a/src/utils/metricasDashboard.test.ts
+++ b/src/utils/metricasDashboard.test.ts
@@ -151,6 +151,34 @@ describe('agregarMetricasPeriodo', () => {
     ])
   })
 
+  it('excluye los regalos de promoción del top de productos', () => {
+    // Caso real (Lima Limón, agosto 2026): 3 fardos vendidos y 96 botellas
+    // regaladas figuraban como "99 vendidas". Son dos errores a la vez: contar
+    // el regalo como venta y sumar botellas con fardos.
+    const r = agregarMetricasPeriodo([
+      pedido({
+        total: 11100,
+        items: [
+          { producto_id: 'p1', cantidad: 3, producto: { nombre: 'Manaos Lima Limón 3LT x 6' } },
+          { producto_id: 'p1', cantidad: 96, es_bonificacion: true, producto: { nombre: 'Manaos Lima Limón 3LT x 6' } },
+        ],
+      }),
+    ])
+    expect(r.productosMasVendidos).toEqual([
+      { id: 'p1', nombre: 'Manaos Lima Limón 3LT x 6', cantidad: 3 },
+    ])
+  })
+
+  it('no lista un producto que sólo se entregó como regalo', () => {
+    const r = agregarMetricasPeriodo([
+      pedido({
+        total: 0,
+        items: [{ producto_id: 'p9', cantidad: 24, es_bonificacion: true, producto: { nombre: 'Regalo' } }],
+      }),
+    ])
+    expect(r.productosMasVendidos).toEqual([])
+  })
+
   it('devuelve ceros con dataset vacío', () => {
     const r = agregarMetricasPeriodo([])
     expect(r.ventasPeriodo).toBe(0)

--- a/src/utils/metricasDashboard.ts
+++ b/src/utils/metricasDashboard.ts
@@ -79,7 +79,12 @@ export interface PedidoMetricaRow {
   estado: string
   total: number | null
   cliente?: { nombre_fantasia?: string } | null
-  items?: Array<{ producto_id: string; cantidad: number; producto?: { nombre?: string } | null }>
+  items?: Array<{
+    producto_id: string
+    cantidad: number
+    es_bonificacion?: boolean | null
+    producto?: { nombre?: string } | null
+  }>
 }
 
 export interface MetricasPeriodo {
@@ -128,6 +133,12 @@ export function agregarMetricasPeriodo(pedidos: PedidoMetricaRow[]): MetricasPer
     }
 
     p.items?.forEach(i => {
+      // Los regalos de promoción NO son venta, y además vienen en otra unidad:
+      // las líneas de venta cuentan fardos y las de regalo de una promo
+      // Fracción cuentan botellas. Sumarlas daba números sin sentido — un
+      // Lima Limón con 3 fardos vendidos figuraba con "99 vendidas" porque se
+      // le sumaban 96 botellas regaladas.
+      if (i.es_bonificacion) return
       const id = i.producto_id
       if (!productosVendidos[id]) {
         productosVendidos[id] = { id, nombre: i.producto?.nombre || 'N/A', cantidad: 0 }

--- a/src/utils/unidadesRegalo.test.ts
+++ b/src/utils/unidadesRegalo.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from 'vitest';
+import {
+  esCantidadEnSubunidades,
+  formatCantidadItem,
+  equivalenteEnUnidades,
+} from './unidadesRegalo';
+
+describe('esCantidadEnSubunidades', () => {
+  it('es true para el regalo de una promo fraccionada', () => {
+    expect(esCantidadEnSubunidades({
+      cantidad: 392, es_bonificacion: true, promocion: { unidades_por_bloque: 6 },
+    })).toBe(true);
+  });
+
+  it('es false para una línea de venta, aunque tenga promo', () => {
+    expect(esCantidadEnSubunidades({
+      cantidad: 30, es_bonificacion: false, promocion: { unidades_por_bloque: 6 },
+    })).toBe(false);
+  });
+
+  it('es false para un regalo NO fraccionado (bloque 1 o sin promo)', () => {
+    expect(esCantidadEnSubunidades({
+      cantidad: 2, es_bonificacion: true, promocion: { unidades_por_bloque: 1 },
+    })).toBe(false);
+    expect(esCantidadEnSubunidades({ cantidad: 2, es_bonificacion: true })).toBe(false);
+    expect(esCantidadEnSubunidades({
+      cantidad: 2, es_bonificacion: true, promocion: { unidades_por_bloque: null },
+    })).toBe(false);
+  });
+});
+
+describe('formatCantidadItem', () => {
+  it('aclara la unidad sólo en el regalo fraccionado', () => {
+    expect(formatCantidadItem({
+      cantidad: 392, es_bonificacion: true, promocion: { unidades_por_bloque: 6 },
+    })).toBe('x392 botellas');
+    expect(formatCantidadItem({ cantidad: 30 })).toBe('x30');
+  });
+});
+
+describe('equivalenteEnUnidades', () => {
+  it('convierte a fardos el regalo fraccionado', () => {
+    // El caso que disparó todo: 392 botellas = 65,3 fardos, no 392 fardos.
+    expect(equivalenteEnUnidades({
+      cantidad: 392, es_bonificacion: true, promocion: { unidades_por_bloque: 6 },
+    })).toBe('≈ 65,3 fardos');
+  });
+
+  it('no muestra decimales cuando el bloque cierra justo', () => {
+    expect(equivalenteEnUnidades({
+      cantidad: 24, es_bonificacion: true, promocion: { unidades_por_bloque: 6 },
+    })).toBe('≈ 4 fardos');
+    expect(equivalenteEnUnidades({
+      cantidad: 6, es_bonificacion: true, promocion: { unidades_por_bloque: 6 },
+    })).toBe('≈ 1 fardo');
+  });
+
+  it('devuelve null cuando la cantidad ya está en fardos', () => {
+    expect(equivalenteEnUnidades({ cantidad: 30 })).toBeNull();
+    expect(equivalenteEnUnidades({ cantidad: 2, es_bonificacion: true })).toBeNull();
+  });
+});

--- a/src/utils/unidadesRegalo.ts
+++ b/src/utils/unidadesRegalo.ts
@@ -1,0 +1,54 @@
+/**
+ * Unidades de las líneas de un pedido.
+ *
+ * `pedido_items.cantidad` NO está siempre en la misma unidad:
+ *  - línea de venta            → unidades de venta (para estos productos, fardos)
+ *  - regalo de promo Fracción  → subunidades sueltas (botellas)
+ *
+ * Una promo "6 + 2" sobre 196 fardos deja una línea de regalo con cantidad
+ * 392: son 392 BOTELLAS (65 fardos), no 392 fardos. Leído sin contexto parece
+ * un regalo 6 veces más grande de lo que es, y fue exactamente lo que hizo
+ * dudar del stock de Lima Limón.
+ *
+ * El stock lo descuenta bien el auto-ajuste por bloques (mig 132); acá sólo se
+ * resuelve cómo MOSTRAR la cantidad para que no se lea en la unidad equivocada.
+ */
+
+/** Lo mínimo que hace falta de un ítem para saber en qué unidad está. */
+export interface ItemConUnidad {
+  cantidad: number;
+  es_bonificacion?: boolean | null;
+  promocion?: { unidades_por_bloque?: number | null } | null;
+}
+
+/**
+ * true si la cantidad de este ítem está en subunidades sueltas (botellas) en
+ * vez de en unidades de venta (fardos): pasa sólo en los regalos de promos
+ * fraccionadas, donde el bloque agrupa más de una subunidad.
+ */
+export function esCantidadEnSubunidades(item: ItemConUnidad): boolean {
+  return Boolean(item.es_bonificacion) && (item.promocion?.unidades_por_bloque ?? 0) > 1;
+}
+
+/**
+ * Etiqueta de la cantidad, lista para mostrar.
+ * - Venta o regalo no fraccionado → "x24"
+ * - Regalo fraccionado           → "x392 botellas" (+ equivalente en fardos)
+ */
+export function formatCantidadItem(item: ItemConUnidad): string {
+  if (!esCantidadEnSubunidades(item)) return `x${item.cantidad}`;
+  return `x${item.cantidad} botellas`;
+}
+
+/**
+ * Equivalente en unidades de venta de un regalo fraccionado, para aclarar al
+ * lado: "= 65,3 fardos". null cuando la cantidad ya está en fardos.
+ */
+export function equivalenteEnUnidades(item: ItemConUnidad): string | null {
+  if (!esCantidadEnSubunidades(item)) return null;
+  const porBloque = item.promocion?.unidades_por_bloque ?? 1;
+  const fardos = item.cantidad / porBloque;
+  // Un decimal alcanza: 392/6 = 65,3. Sin decimales "65" sugiere exactitud que no hay.
+  const txt = Number.isInteger(fardos) ? String(fardos) : fardos.toFixed(1).replace('.', ',');
+  return `≈ ${txt} ${fardos === 1 ? 'fardo' : 'fardos'}`;
+}


### PR DESCRIPTION
Sale de la revisión del stock de Manaos Lima Limón que pidió el gerente.

## El síntoma

"Lima Limón 3L figura con **99 vendidas** este mes". Eran **3**. Las otras 96 son botellas regaladas por la promo "6+2".

## Dos errores sumados en el mismo número

**1. Los regalos contaban como venta.** El top de "Productos más vendidos" del dashboard sumaba `pedido_items.cantidad` sin filtrar `es_bonificacion`.

**2. Esa columna no está siempre en la misma unidad.** Las líneas de venta cuentan **fardos**; las de regalo de una promo Fracción cuentan **botellas sueltas**. Mismo producto, misma columna, dos unidades. Un regalo de 392 (botellas = 65 fardos) se leía como 392 fardos.

## Qué cambia

- `agregarMetricasPeriodo` saltea las bonificaciones. Un producto que sólo se entregó como regalo ya no aparece en el top.
- El (2) no se puede arreglar sin migrar datos, así que **se etiqueta**: en la tarjeta del pedido, un regalo fraccionado ahora muestra `x392 botellas` con `≈ 65,3 fardos` debajo, en vez de `x392` a secas. La lógica vive en `src/utils/unidadesRegalo.ts`, aislada y testeada.

Audité el resto de los reportes: las demás sumas sobre ítems son de *pedidos*, no de cantidades de producto. Este era el único lugar afectado.

## Lo que NO estaba mal

**El stock.** Reconstruí el movimiento completo contra producción desde la compra del 20/07:

```
+180  compra
 -42  fardos vendidos
-106  consumidos por la promo (auto-ajuste por bloques)
────
 +32  neto  →  coincide al peso con stock_historico
```

El auto-ajuste de la mig 132 convierte bien botellas→fardos. El descuadre físico que reportó el depósito tiene otra causa (un pedido puntual), que se trata aparte.

Las metas y el rendimiento por preventista tampoco estaban afectados: filtran `es_bonificacion` desde el arranque.

## Verificación

Typecheck, lint, build y **955 tests** en verde (9 nuevos: 4 sobre el filtro de bonificaciones en el top de productos, 5 sobre el etiquetado de unidades, incluido el caso real de 392 botellas → 65,3 fardos).

🤖 Generated with [Claude Code](https://claude.com/claude-code)