### PR TITLE
fix(metas): panel completo de objetivos, período editable y semáforo

### DIFF
--- a/migrations/163_backfill_marcas_por_nombre.sql
+++ b/migrations/163_backfill_marcas_por_nombre.sql
@@ -1,0 +1,80 @@
+-- =========================================================================
+-- 163_backfill_marcas_por_nombre.sql
+--
+-- La mig 158 sólo pudo backfillear las marcas de la sucursal 1 que estaban
+-- cargadas como categorías. Quedaron 137 productos sin marca — 92 en Taco
+-- Pozo, donde la marca vive dentro del nombre del producto.
+--
+-- Este backfill asigna SÓLO los casos donde la marca es inequívoca en el
+-- nombre. Se dejan a propósito sin marca los que requieren criterio comercial:
+--   · "PAPAS FRITAS 200GRS", "CHIZITOS", "PUFLITO", "NACHO LIBRE"  → sin marca en el nombre
+--   · "AZUCAR CALIDAD", "AZUCAR INDEPENDENCIA"                     → ¿marca o descriptor?
+--   · "VINO TORO TETRA", "VINO VIÑA DE BALBO"                      → hay marca, pero no sé si
+--                                                                     se quieren separadas
+--   · "AGUA EL SANO CORAZON ARGENTINO"                             → ¿"EL SANO"? ambiguo
+--   · "SAL FINA", "FERNET 750ML", "CEPILLO DE DIENTES NIÑO"        → sin marca
+-- Esos 40 y pico se asignan a mano desde Productos → Catálogo → Marcas.
+--
+-- ORDEN IMPORTANTE: VILLAMANAOS se resuelve ANTES que MANAOS. "AGUA VILLA
+-- MANAOS CON GAS" contiene "MANAOS" pero es otra marca; al revés quedaría mal
+-- clasificada y el error sería invisible.
+--
+-- Sólo se tocan productos con marca_id NULL: re-aplicar no pisa correcciones
+-- hechas a mano desde la UI.
+-- =========================================================================
+
+DO $$
+DECLARE
+  r          RECORD;
+  v_marca_id uuid;
+  v_n        integer;
+  -- patron: regex sobre upper(nombre). El orden de esta lista ES la precedencia.
+  v_reglas CONSTANT jsonb := '[
+    {"marca": "VILLAMANAOS",  "patron": "VILLA ?MANAOS"},
+    {"marca": "MANAOS",       "patron": "^MANAOS\\M"},
+    {"marca": "PLACER",       "patron": "^PLACER\\M"},
+    {"marca": "PINDAPOY",     "patron": "\\mPINDAPOY\\M"},
+    {"marca": "COTELLA",      "patron": "\\mCOTELLA\\M"},
+    {"marca": "RICATTO",      "patron": "\\mRICATTO\\M"},
+    {"marca": "RIVOLLI",      "patron": "\\mRIVOLLI\\M"},
+    {"marca": "MONDEO",       "patron": "\\mMONDEO\\M"},
+    {"marca": "NESS",         "patron": "\\mNESS\\M"},
+    {"marca": "NATUREZA",     "patron": "\\mNATUREZA\\M"},
+    {"marca": "ALFATUC",      "patron": "\\mALFATUC\\M"},
+    {"marca": "COCA COLA",    "patron": "\\mCOCA COLA\\M"},
+    {"marca": "PANINI",       "patron": "\\mPANINI\\M"}
+  ]'::jsonb;
+  v_suc bigint;
+BEGIN
+  FOREACH v_suc IN ARRAY ARRAY[1::bigint, 2::bigint]
+  LOOP
+    FOR r IN SELECT * FROM jsonb_to_recordset(v_reglas) AS x(marca text, patron text)
+    LOOP
+      -- ¿Hay algún producto sin marca que matchee en esta sucursal? Si no, no
+      -- se crea la marca: mejor no ensuciar el ABM con marcas vacías.
+      SELECT count(*) INTO v_n
+      FROM productos p
+      WHERE p.sucursal_id = v_suc AND p.marca_id IS NULL
+        AND upper(p.nombre) ~ r.patron;
+
+      IF v_n = 0 THEN
+        CONTINUE;
+      END IF;
+
+      INSERT INTO marcas (nombre, sucursal_id)
+      VALUES (r.marca, v_suc)
+      ON CONFLICT (sucursal_id, nombre) DO NOTHING;
+
+      SELECT id INTO v_marca_id FROM marcas
+      WHERE sucursal_id = v_suc AND nombre = r.marca;
+
+      UPDATE productos p
+      SET marca_id = v_marca_id
+      WHERE p.sucursal_id = v_suc
+        AND p.marca_id IS NULL          -- la precedencia de la lista se sostiene acá
+        AND upper(p.nombre) ~ r.patron;
+
+      RAISE NOTICE 'Sucursal %: % productos → %', v_suc, v_n, r.marca;
+    END LOOP;
+  END LOOP;
+END $$;

--- a/migrations/164_metas_periodo_editable.sql
+++ b/migrations/164_metas_periodo_editable.sql
@@ -1,0 +1,593 @@
+-- =========================================================================
+-- 164_metas_periodo_editable.sql
+--
+-- Tres cosas que salieron de probar los objetivos en producción:
+--
+-- 1. PERÍODO EDITABLE. Las metas eran mensuales y punto (`periodo` = primer
+--    día del mes). El mes sigue siendo el default, pero ahora se puede cargar
+--    un objetivo para una quincena, una semana de acción o una campaña que
+--    cruza meses. Se agrega `periodo_fin`; `periodo` pasa a ser el "desde".
+--
+-- 2. SEMÁFORO. Al día 4 de 31, con $0 sobre un objetivo de $1.000, el panel
+--    decía "Atrasado". Es matemáticamente cierto contra el prorrateo (debía
+--    llevar $129) pero es una lectura inútil: quedan 27 días y al principio
+--    del período el prorrateo es ruido, no señal. Ahora sólo se marca en
+--    riesgo cuando transcurrió al menos el 25% del período. Antes de eso, lo
+--    peor que puede decir es "En progreso".
+--
+-- 3. El objetivo cuenta las ventas de TODO el período, no desde que se cargó.
+--    Ya era así (el cálculo nunca miró `created_at`), pero queda dicho acá
+--    porque fue una duda concreta: cargar hoy una meta del mes toma lo que ya
+--    se vendió del 1 al día de hoy.
+-- =========================================================================
+
+-- -------------------------------------------------------------------------
+-- 1. Columna de fin de período
+-- -------------------------------------------------------------------------
+ALTER TABLE public.metas_preventista
+  ADD COLUMN IF NOT EXISTS periodo_fin date;
+
+-- Las metas que ya existían son mensuales: fin = último día de su mes.
+UPDATE public.metas_preventista
+SET periodo_fin = (date_trunc('month', periodo) + interval '1 month - 1 day')::date
+WHERE periodo_fin IS NULL;
+
+ALTER TABLE public.metas_preventista
+  ALTER COLUMN periodo_fin SET NOT NULL;
+
+ALTER TABLE public.metas_preventista
+  DROP CONSTRAINT IF EXISTS metas_preventista_periodo_check;
+ALTER TABLE public.metas_preventista
+  ADD CONSTRAINT metas_preventista_periodo_check CHECK (periodo_fin >= periodo);
+
+COMMENT ON COLUMN public.metas_preventista.periodo IS
+  'Inicio del período del objetivo. Por defecto el primer día del mes. Mig 164.';
+COMMENT ON COLUMN public.metas_preventista.periodo_fin IS
+  'Fin del período (inclusive). Por defecto el último día del mes de `periodo`. Mig 164.';
+
+-- El índice único tiene que incluir el fin: "agosto" y "primera quincena de
+-- agosto" son dos objetivos distintos y ambos arrancan el 01/08.
+DROP INDEX IF EXISTS public.metas_preventista_uidx;
+CREATE UNIQUE INDEX metas_preventista_uidx
+  ON public.metas_preventista (
+    preventista_id, periodo, periodo_fin, tipo_meta,
+    COALESCE(marca_id, '00000000-0000-0000-0000-000000000000'::uuid),
+    COALESCE(categoria_id, '00000000-0000-0000-0000-000000000000'::uuid),
+    COALESCE(producto_ids, '{}'::bigint[])
+  );
+
+-- -------------------------------------------------------------------------
+-- 2. guardar_meta_preventista: p_periodo_hasta opcional.
+--    NULL = mensual (comportamiento anterior, sigue siendo el default).
+-- -------------------------------------------------------------------------
+DROP FUNCTION IF EXISTS public.guardar_meta_preventista(bigint, bigint, uuid, date, text, numeric, uuid, uuid, bigint[]);
+
+CREATE OR REPLACE FUNCTION public.guardar_meta_preventista(
+  p_id             bigint,
+  p_sucursal_id    bigint,
+  p_preventista_id uuid,
+  p_periodo        date,
+  p_tipo_meta      text,
+  p_valor_objetivo numeric,
+  p_marca_id       uuid     DEFAULT NULL,
+  p_categoria_id   uuid     DEFAULT NULL,
+  p_producto_ids   bigint[] DEFAULT NULL,
+  p_periodo_hasta  date     DEFAULT NULL
+)
+RETURNS bigint
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $fn$
+DECLARE
+  v_id        bigint;
+  v_desde     date;
+  v_hasta     date;
+  v_productos bigint[];
+  v_ajenos    integer;
+BEGIN
+  IF NOT es_admin() THEN
+    RAISE EXCEPTION 'Solo un admin puede definir objetivos' USING ERRCODE = '42501';
+  END IF;
+
+  -- Sin fecha de fin explícita el objetivo es del mes de p_periodo, que es el
+  -- caso normal. Con fecha de fin, las dos fechas se respetan tal cual.
+  IF p_periodo_hasta IS NULL THEN
+    v_desde := date_trunc('month', COALESCE(p_periodo, current_date))::date;
+    v_hasta := (v_desde + interval '1 month - 1 day')::date;
+  ELSE
+    v_desde := COALESCE(p_periodo, current_date);
+    v_hasta := p_periodo_hasta;
+  END IF;
+
+  IF v_hasta < v_desde THEN
+    RAISE EXCEPTION 'El fin del período no puede ser anterior al inicio';
+  END IF;
+
+  IF p_valor_objetivo IS NULL OR p_valor_objetivo <= 0 THEN
+    RAISE EXCEPTION 'El objetivo debe ser mayor a 0';
+  END IF;
+
+  IF p_sucursal_id IS NULL THEN
+    RAISE EXCEPTION 'Indicá la sucursal del objetivo';
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM usuario_sucursales
+    WHERE usuario_id = auth.uid() AND sucursal_id = p_sucursal_id
+  ) THEN
+    RAISE EXCEPTION 'No tenés acceso a esa sucursal' USING ERRCODE = '42501';
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM usuario_sucursales us
+    WHERE us.usuario_id = p_preventista_id AND us.sucursal_id = p_sucursal_id
+  ) THEN
+    RAISE EXCEPTION 'Ese usuario no trabaja en la sucursal elegida';
+  END IF;
+
+  IF p_producto_ids IS NOT NULL AND cardinality(p_producto_ids) > 0 THEN
+    SELECT array_agg(DISTINCT x ORDER BY x) INTO v_productos
+    FROM unnest(p_producto_ids) AS x;
+
+    SELECT COUNT(*) INTO v_ajenos
+    FROM unnest(v_productos) AS x
+    WHERE NOT EXISTS (
+      SELECT 1 FROM productos p WHERE p.id = x AND p.sucursal_id = p_sucursal_id
+    );
+    IF v_ajenos > 0 THEN
+      RAISE EXCEPTION '% producto(s) no pertenecen a la sucursal elegida', v_ajenos;
+    END IF;
+  ELSE
+    v_productos := NULL;
+  END IF;
+
+  IF p_id IS NULL THEN
+    INSERT INTO metas_preventista (
+      sucursal_id, preventista_id, periodo, periodo_fin, tipo_meta,
+      marca_id, categoria_id, producto_ids, valor_objetivo, usuario_id
+    ) VALUES (
+      p_sucursal_id, p_preventista_id, v_desde, v_hasta, p_tipo_meta,
+      p_marca_id, p_categoria_id, v_productos, p_valor_objetivo, auth.uid()
+    )
+    ON CONFLICT (
+      preventista_id, periodo, periodo_fin, tipo_meta,
+      COALESCE(marca_id, '00000000-0000-0000-0000-000000000000'::uuid),
+      COALESCE(categoria_id, '00000000-0000-0000-0000-000000000000'::uuid),
+      COALESCE(producto_ids, '{}'::bigint[])
+    ) DO UPDATE SET
+      valor_objetivo = EXCLUDED.valor_objetivo,
+      activo         = true,
+      usuario_id     = EXCLUDED.usuario_id
+    RETURNING id INTO v_id;
+  ELSE
+    UPDATE metas_preventista SET
+      preventista_id = p_preventista_id,
+      periodo        = v_desde,
+      periodo_fin    = v_hasta,
+      tipo_meta      = p_tipo_meta,
+      marca_id       = p_marca_id,
+      categoria_id   = p_categoria_id,
+      producto_ids   = v_productos,
+      valor_objetivo = p_valor_objetivo
+    WHERE id = p_id
+    RETURNING id INTO v_id;
+
+    IF v_id IS NULL THEN
+      RAISE EXCEPTION 'El objetivo % no existe', p_id USING ERRCODE = 'no_data_found';
+    END IF;
+  END IF;
+
+  RETURN v_id;
+END;
+$fn$;
+
+ALTER FUNCTION public.guardar_meta_preventista(bigint, bigint, uuid, date, text, numeric, uuid, uuid, bigint[], date) OWNER TO postgres;
+REVOKE ALL ON FUNCTION public.guardar_meta_preventista(bigint, bigint, uuid, date, text, numeric, uuid, uuid, bigint[], date) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.guardar_meta_preventista(bigint, bigint, uuid, date, text, numeric, uuid, uuid, bigint[], date) TO authenticated;
+
+-- -------------------------------------------------------------------------
+-- 3. avance_metas_preventista: cada meta se mide contra SU período.
+--
+--    Se devuelven las metas cuyo período se solapa con el mes consultado, así
+--    el dashboard sigue mostrando "los objetivos de agosto" aunque alguno sea
+--    quincenal o cruce de mes.
+-- -------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.avance_metas_preventista(
+  p_preventista_id uuid DEFAULT NULL,
+  p_periodo        date DEFAULT NULL
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $fn$
+DECLARE
+  v_target      uuid;
+  v_mes_desde   date;
+  v_mes_hasta   date;
+  v_min         date;
+  v_max         date;
+  v_nombre      text;
+  v_sucursales  bigint[];
+  v_result      jsonb;
+  v_sin_marca   integer := 0;
+  v_hay_marca   boolean := false;
+BEGIN
+  v_target    := COALESCE(p_preventista_id, auth.uid());
+  v_mes_desde := date_trunc('month', COALESCE(p_periodo, current_date))::date;
+  v_mes_hasta := (v_mes_desde + interval '1 month - 1 day')::date;
+
+  IF v_target IS NULL THEN
+    RAISE EXCEPTION 'Sin usuario' USING ERRCODE = '42501';
+  END IF;
+
+  -- El muro: un preventista sólo puede pedir lo suyo.
+  IF auth.uid() IS NOT NULL AND v_target <> auth.uid() AND NOT es_admin() THEN
+    RAISE EXCEPTION 'Acceso denegado' USING ERRCODE = '42501';
+  END IF;
+
+  SELECT nombre INTO v_nombre FROM perfiles WHERE id = v_target;
+
+  SELECT array_agg(DISTINCT sucursal_id), min(periodo), max(periodo_fin)
+    INTO v_sucursales, v_min, v_max
+  FROM metas_preventista
+  WHERE preventista_id = v_target AND activo
+    AND periodo <= v_mes_hasta AND periodo_fin >= v_mes_desde;
+
+  IF v_sucursales IS NULL THEN
+    RETURN jsonb_build_object(
+      'preventista_id', v_target,
+      'nombre', v_nombre,
+      'periodo', v_mes_desde,
+      'dias_transcurridos', LEAST(EXTRACT(DAY FROM current_date)::int, EXTRACT(DAY FROM v_mes_hasta)::int),
+      'dias_periodo', EXTRACT(DAY FROM v_mes_hasta)::int,
+      'metas', '[]'::jsonb,
+      'resumen', jsonb_build_object('total', 0, 'cumplidas', 0, 'en_riesgo', 0),
+      'productos_sin_marca', 0
+    );
+  END IF;
+
+  WITH
+  metas AS (
+    SELECT * FROM metas_preventista
+    WHERE preventista_id = v_target AND activo
+      AND periodo <= v_mes_hasta AND periodo_fin >= v_mes_desde
+  ),
+  -- Cubre la unión de los períodos; cada meta filtra después por el suyo.
+  ped AS MATERIALIZED (
+    SELECT id, cliente_id, sucursal_id, fecha
+    FROM pedidos
+    WHERE usuario_id = v_target
+      AND estado = 'entregado'
+      AND canal = 'app'
+      AND fecha BETWEEN v_min AND v_max
+      AND sucursal_id = ANY(v_sucursales)
+  ),
+  it AS MATERIALIZED (
+    SELECT p.sucursal_id, p.fecha, pi.cantidad, pi.subtotal,
+           pi.producto_id, prod.categoria_id, prod.marca_id
+    FROM ped p
+    JOIN pedido_items pi ON pi.pedido_id = p.id
+    JOIN productos prod  ON prod.id = pi.producto_id
+    WHERE pi.es_bonificacion IS NOT TRUE
+  ),
+  primer_pedido AS (
+    SELECT DISTINCT ON (p.cliente_id, p.sucursal_id)
+           p.cliente_id, p.sucursal_id, p.usuario_id, p.fecha
+    FROM pedidos p
+    WHERE p.estado = 'entregado' AND p.canal = 'app'
+      AND p.sucursal_id = ANY(v_sucursales)
+    ORDER BY p.cliente_id, p.sucursal_id, p.fecha, p.id
+  ),
+  logrado AS (
+    SELECT m.*,
+      (m.periodo_fin - m.periodo + 1) AS dias_periodo,
+      GREATEST(0, LEAST(current_date - m.periodo + 1, m.periodo_fin - m.periodo + 1)) AS dias_trans,
+      CASE m.tipo_meta
+        WHEN 'facturacion' THEN (
+          SELECT COALESCE(SUM(i.subtotal), 0) FROM it i
+          WHERE i.sucursal_id = m.sucursal_id
+            AND i.fecha BETWEEN m.periodo AND m.periodo_fin
+            AND (m.marca_id     IS NULL OR i.marca_id     = m.marca_id)
+            AND (m.categoria_id IS NULL OR i.categoria_id = m.categoria_id)
+            AND (m.producto_ids IS NULL OR i.producto_id  = ANY(m.producto_ids))
+        )
+        WHEN 'unidades' THEN (
+          SELECT COALESCE(SUM(i.cantidad), 0) FROM it i
+          WHERE i.sucursal_id = m.sucursal_id
+            AND i.fecha BETWEEN m.periodo AND m.periodo_fin
+            AND (m.marca_id     IS NULL OR i.marca_id     = m.marca_id)
+            AND (m.categoria_id IS NULL OR i.categoria_id = m.categoria_id)
+            AND (m.producto_ids IS NULL OR i.producto_id  = ANY(m.producto_ids))
+        )
+        WHEN 'cobertura' THEN (
+          SELECT COUNT(DISTINCT p.cliente_id) FROM ped p
+          WHERE p.sucursal_id = m.sucursal_id
+            AND p.fecha BETWEEN m.periodo AND m.periodo_fin
+        )
+        WHEN 'clientes_nuevos' THEN (
+          SELECT COUNT(*) FROM primer_pedido pp
+          WHERE pp.sucursal_id = m.sucursal_id
+            AND pp.usuario_id = v_target
+            AND pp.fecha BETWEEN m.periodo AND m.periodo_fin
+        )
+      END AS logrado
+    FROM metas m
+  ),
+  calc AS (
+    SELECT l.*,
+      ROUND(l.valor_objetivo * l.dias_trans / NULLIF(l.dias_periodo, 0), 2) AS objetivo_prorrateado,
+      ROUND(100 * l.logrado / NULLIF(l.valor_objetivo, 0), 1) AS pct,
+      -- Cuánto del período ya pasó. Debajo del 25% el prorrateo es ruido: con
+      -- 27 de 31 días por delante, "atrasado" no informa nada.
+      (l.dias_trans::numeric / NULLIF(l.dias_periodo, 0)) AS avance_periodo
+    FROM logrado l
+  ),
+  estados AS (
+    SELECT c.*,
+      CASE
+        WHEN c.logrado >= c.valor_objetivo THEN 'cumplida'
+        WHEN c.logrado >= COALESCE(c.objetivo_prorrateado, 0) THEN 'adelantado'
+        WHEN c.avance_periodo < 0.25 THEN 'en_curso'
+        WHEN c.logrado >= 0.8 * COALESCE(c.objetivo_prorrateado, 0) THEN 'en_curso'
+        ELSE 'en_riesgo'
+      END AS estado
+    FROM calc c
+  )
+  SELECT jsonb_build_object(
+    'preventista_id', v_target,
+    'nombre', v_nombre,
+    'periodo', v_mes_desde,
+    'dias_transcurridos', LEAST(EXTRACT(DAY FROM current_date)::int, EXTRACT(DAY FROM v_mes_hasta)::int),
+    'dias_periodo', EXTRACT(DAY FROM v_mes_hasta)::int,
+    'metas', COALESCE(jsonb_agg(jsonb_build_object(
+        'id', c.id,
+        'tipo_meta', c.tipo_meta,
+        'unidad', CASE c.tipo_meta
+                    WHEN 'facturacion' THEN '$'
+                    WHEN 'unidades'    THEN 'u'
+                    ELSE 'clientes' END,
+        'alcance', CASE
+          WHEN c.marca_id IS NOT NULL THEN jsonb_build_object(
+            'tipo', 'marca', 'id', c.marca_id,
+            'nombre', (SELECT nombre FROM marcas WHERE id = c.marca_id))
+          WHEN c.categoria_id IS NOT NULL THEN jsonb_build_object(
+            'tipo', 'categoria', 'id', c.categoria_id,
+            'nombre', (SELECT nombre FROM categorias WHERE id = c.categoria_id))
+          WHEN c.producto_ids IS NOT NULL THEN jsonb_build_object(
+            'tipo', 'productos', 'id', NULL,
+            'nombre', CASE WHEN cardinality(c.producto_ids) = 1
+              THEN (SELECT nombre FROM productos WHERE id = c.producto_ids[1])
+              ELSE cardinality(c.producto_ids) || ' productos' END,
+            'productos', (SELECT COALESCE(jsonb_agg(jsonb_build_object('id', p.id, 'nombre', p.nombre) ORDER BY p.nombre), '[]'::jsonb)
+                          FROM productos p WHERE p.id = ANY(c.producto_ids)))
+          ELSE jsonb_build_object('tipo', 'global', 'id', NULL, 'nombre', NULL)
+        END,
+        'desde', c.periodo,
+        'hasta', c.periodo_fin,
+        'dias_periodo', c.dias_periodo,
+        'dias_transcurridos', c.dias_trans,
+        -- true = el período no es un mes calendario completo; la UI lo aclara.
+        'periodo_personalizado', (c.periodo <> date_trunc('month', c.periodo)::date
+                                  OR c.periodo_fin <> (date_trunc('month', c.periodo) + interval '1 month - 1 day')::date),
+        'objetivo', c.valor_objetivo,
+        'logrado', c.logrado,
+        'pct', COALESCE(c.pct, 0),
+        'objetivo_prorrateado', COALESCE(c.objetivo_prorrateado, 0),
+        'estado', c.estado
+      ) ORDER BY c.tipo_meta, c.id), '[]'::jsonb),
+    'resumen', jsonb_build_object(
+      'total', COUNT(*),
+      'cumplidas', COUNT(*) FILTER (WHERE c.estado = 'cumplida'),
+      'en_riesgo', COUNT(*) FILTER (WHERE c.estado = 'en_riesgo')
+    )
+  ) INTO v_result
+  FROM estados c;
+
+  SELECT EXISTS (
+    SELECT 1 FROM metas_preventista
+    WHERE preventista_id = v_target AND activo
+      AND periodo <= v_mes_hasta AND periodo_fin >= v_mes_desde
+      AND marca_id IS NOT NULL
+  ) INTO v_hay_marca;
+
+  IF v_hay_marca THEN
+    SELECT COUNT(*) INTO v_sin_marca
+    FROM productos WHERE marca_id IS NULL AND sucursal_id = ANY(v_sucursales);
+  END IF;
+
+  RETURN v_result || jsonb_build_object('productos_sin_marca', v_sin_marca);
+END;
+$fn$;
+
+ALTER FUNCTION public.avance_metas_preventista(uuid, date) OWNER TO postgres;
+REVOKE ALL ON FUNCTION public.avance_metas_preventista(uuid, date) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.avance_metas_preventista(uuid, date) TO authenticated;
+
+-- -------------------------------------------------------------------------
+-- 4. rendimiento_preventistas: incluir a quien tiene objetivos aunque no haya
+--    vendido nada.
+--
+--    Antes la lista salía de los pedidos entregados, así que un preventista
+--    sin ventas en el mes no aparecía — y con él desaparecían sus objetivos.
+--    Fue justo lo que pasó al cargar el primer objetivo de prueba: estaba en
+--    la base y en el dashboard, pero la pantalla de /metas no lo mostraba.
+-- -------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.rendimiento_preventistas(
+  p_sucursal_id bigint DEFAULT NULL,
+  p_periodo     date   DEFAULT NULL
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $fn$
+DECLARE
+  v_periodo    date := date_trunc('month', COALESCE(p_periodo, current_date))::date;
+  v_hasta      date;
+  v_sucursales bigint[];
+  v_asignadas  bigint[];
+  v_es_servicio boolean := auth.uid() IS NULL;
+  v_result     jsonb;
+BEGIN
+  v_hasta := (v_periodo + interval '1 month - 1 day')::date;
+
+  IF NOT v_es_servicio AND NOT es_admin() THEN
+    RAISE EXCEPTION 'Solo un admin puede ver el rendimiento del equipo' USING ERRCODE = '42501';
+  END IF;
+
+  IF v_es_servicio THEN
+    SELECT array_agg(id) INTO v_asignadas FROM sucursales;
+  ELSE
+    SELECT array_agg(sucursal_id) INTO v_asignadas
+    FROM usuario_sucursales WHERE usuario_id = auth.uid();
+  END IF;
+
+  IF p_sucursal_id IS NULL THEN
+    v_sucursales := v_asignadas;
+  ELSE
+    IF NOT v_es_servicio AND NOT (p_sucursal_id = ANY(v_asignadas)) THEN
+      RAISE EXCEPTION 'Acceso denegado: la sucursal % no está asignada al usuario', p_sucursal_id
+        USING ERRCODE = '42501';
+    END IF;
+    v_sucursales := ARRAY[p_sucursal_id];
+  END IF;
+
+  IF v_sucursales IS NULL OR array_length(v_sucursales, 1) IS NULL THEN
+    RAISE EXCEPTION 'Acceso denegado: sin sucursales disponibles' USING ERRCODE = '42501';
+  END IF;
+
+  WITH
+  ped AS MATERIALIZED (
+    SELECT id, cliente_id, usuario_id, sucursal_id, total
+    FROM pedidos
+    WHERE estado = 'entregado' AND canal = 'app'
+      AND fecha BETWEEN v_periodo AND v_hasta
+      AND sucursal_id = ANY(v_sucursales)
+  ),
+  it AS MATERIALIZED (
+    SELECT p.usuario_id, pi.cantidad, pi.subtotal,
+           pi.cantidad * COALESCE(pi.costo_unitario_al_crear, prod.costo_promedio, prod.costo_real,
+             prod.costo_sin_iva * (1 + COALESCE(prod.impuestos_internos, 0) / 100)) AS costo,
+           COALESCE(mar.nombre, '(sin marca)')          AS marca,
+           COALESCE(NULLIF(prod.categoria, ''), '(sin categoría)') AS categoria
+    FROM ped p
+    JOIN pedido_items pi ON pi.pedido_id = p.id
+    JOIN productos prod  ON prod.id = pi.producto_id
+    LEFT JOIN marcas mar ON mar.id = prod.marca_id
+    WHERE pi.es_bonificacion IS NOT TRUE
+  ),
+  primer_pedido AS (
+    SELECT DISTINCT ON (p.cliente_id, p.sucursal_id)
+           p.cliente_id, p.sucursal_id, p.usuario_id, p.fecha
+    FROM pedidos p
+    WHERE p.estado = 'entregado' AND p.canal = 'app'
+      AND p.sucursal_id = ANY(v_sucursales)
+    ORDER BY p.cliente_id, p.sucursal_id, p.fecha, p.id
+  ),
+  metas AS (
+    SELECT preventista_id, COUNT(*) AS total FROM metas_preventista
+    WHERE activo AND sucursal_id = ANY(v_sucursales)
+      AND periodo <= v_hasta AND periodo_fin >= v_periodo
+    GROUP BY preventista_id
+  ),
+  -- La lista es la UNIÓN de: quien vendió, quien tiene objetivos cargados, y
+  -- TODOS los preventistas de la sucursal. El panel es de seguimiento del
+  -- equipo: un preventista que no vendió nada en el mes es exactamente el que
+  -- hay que ver, no el que hay que esconder.
+  gente AS (
+    SELECT usuario_id FROM ped WHERE usuario_id IS NOT NULL
+    UNION
+    SELECT preventista_id FROM metas
+    UNION
+    SELECT us.usuario_id
+    FROM usuario_sucursales us
+    JOIN perfiles pf ON pf.id = us.usuario_id
+    WHERE us.sucursal_id = ANY(v_sucursales)
+      AND pf.rol = 'preventista'
+      AND COALESCE(pf.activo, true)
+  ),
+  base AS (
+    SELECT g.usuario_id,
+           COUNT(p.id)                     AS pedidos,
+           COUNT(DISTINCT p.cliente_id)    AS cobertura
+    FROM gente g LEFT JOIN ped p ON p.usuario_id = g.usuario_id
+    GROUP BY g.usuario_id
+  ),
+  items AS (
+    SELECT i.usuario_id,
+           COALESCE(SUM(i.subtotal), 0) AS venta,
+           COALESCE(SUM(i.cantidad), 0) AS unidades,
+           COALESCE(SUM(i.subtotal - i.costo), 0) AS margen_comercial
+    FROM it i GROUP BY i.usuario_id
+  ),
+  nuevos AS (
+    SELECT pp.usuario_id, COUNT(*) AS clientes_nuevos
+    FROM primer_pedido pp
+    WHERE pp.fecha BETWEEN v_periodo AND v_hasta
+    GROUP BY pp.usuario_id
+  ),
+  por_marca AS (
+    SELECT t.usuario_id, jsonb_agg(jsonb_build_object(
+             'marca', t.marca, 'venta', t.venta, 'unidades', t.unidades
+           ) ORDER BY t.venta DESC) AS detalle
+    FROM (SELECT usuario_id, marca, SUM(subtotal) AS venta, SUM(cantidad) AS unidades
+          FROM it GROUP BY usuario_id, marca) t
+    GROUP BY t.usuario_id
+  ),
+  por_categoria AS (
+    SELECT t.usuario_id, jsonb_agg(jsonb_build_object(
+             'categoria', t.categoria, 'venta', t.venta, 'unidades', t.unidades
+           ) ORDER BY t.venta DESC) AS detalle
+    FROM (SELECT usuario_id, categoria, SUM(subtotal) AS venta, SUM(cantidad) AS unidades
+          FROM it GROUP BY usuario_id, categoria) t
+    GROUP BY t.usuario_id
+  )
+  SELECT jsonb_build_object(
+    'periodo', v_periodo,
+    'preventistas', COALESCE(jsonb_agg(jsonb_build_object(
+      'preventista_id', b.usuario_id,
+      'nombre', COALESCE(pf.nombre, '(sin perfil)'),
+      'rol', pf.rol,
+      'pedidos', b.pedidos,
+      'venta', COALESCE(i.venta, 0),
+      'unidades', COALESCE(i.unidades, 0),
+      'margen_comercial', COALESCE(i.margen_comercial, 0),
+      'cobertura', b.cobertura,
+      'clientes_nuevos', COALESCE(n.clientes_nuevos, 0),
+      'ticket', ROUND(COALESCE(i.venta, 0) / NULLIF(b.pedidos, 0), 2),
+      'metas_cargadas', COALESCE(mt.total, 0),
+      -- El avance completo viene embebido: el panel muestra objetivo, a quién
+      -- está asignado y progreso sin tener que expandir ni pedir otra query
+      -- por preventista. Sale del MISMO RPC que ve el preventista en su
+      -- dashboard, así que los números no pueden discrepar.
+      'metas', COALESCE(av.detalle -> 'metas', '[]'::jsonb),
+      'resumen_metas', COALESCE(av.detalle -> 'resumen',
+                                jsonb_build_object('total', 0, 'cumplidas', 0, 'en_riesgo', 0)),
+      'por_marca', COALESCE(pm.detalle, '[]'::jsonb),
+      'por_categoria', COALESCE(pc.detalle, '[]'::jsonb)
+    ) ORDER BY COALESCE(i.venta, 0) DESC), '[]'::jsonb)
+  ) INTO v_result
+  FROM base b
+  LEFT JOIN perfiles pf     ON pf.id = b.usuario_id
+  LEFT JOIN items i         ON i.usuario_id = b.usuario_id
+  LEFT JOIN nuevos n        ON n.usuario_id = b.usuario_id
+  LEFT JOIN por_marca pm    ON pm.usuario_id = b.usuario_id
+  LEFT JOIN por_categoria pc ON pc.usuario_id = b.usuario_id
+  LEFT JOIN metas mt        ON mt.preventista_id = b.usuario_id
+  -- Sólo para quien tiene objetivos: evita N llamadas inútiles.
+  LEFT JOIN LATERAL (
+    SELECT avance_metas_preventista(b.usuario_id, v_periodo) AS detalle
+    WHERE mt.total > 0
+  ) av ON true;
+
+  RETURN v_result;
+END;
+$fn$;
+
+ALTER FUNCTION public.rendimiento_preventistas(bigint, date) OWNER TO postgres;
+REVOKE ALL ON FUNCTION public.rendimiento_preventistas(bigint, date) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.rendimiento_preventistas(bigint, date) TO authenticated;

--- a/migrations/MANIFEST.md
+++ b/migrations/MANIFEST.md
@@ -126,8 +126,8 @@ funcional** y no se renombran los archivos: renombrarlos los desalinearía del l
 real lo da `version` y está en la sección A: en los dos casos el archivo de `main` quedó
 cronológicamente **fuera** del bloque 139–147 (uno antes, otro entre la 144 y la 145).
 
-**La próxima migración es la 163** — verificado contra el ledger el 2026-08-03: la última
-numerada es `162_metas_multi_producto`. Las **148–162** (origen del precio, reglas de
+**La próxima migración es la 165** — verificado contra el ledger el 2026-08-04: la última
+numerada es `164_metas_periodo_editable`. Las **148–164** (origen del precio, reglas de
 comisión, `place_id`, horarios masivos, barridas, roles extra por sucursal, horario obligatorio
 al cargar pedido, marcas y objetivos por preventista) están aplicadas y mapean **1:1** con el
 ledger, así que no agregan ninguna excepción a las tablas de arriba.

--- a/src/components/containers/MetasContainer.tsx
+++ b/src/components/containers/MetasContainer.tsx
@@ -1,6 +1,11 @@
 import React, { lazy, Suspense, useEffect, useState } from 'react'
 import { Loader2 } from 'lucide-react'
-import { useRendimientoPreventistasQuery, periodoMensual } from '../../hooks/queries'
+import {
+  useRendimientoPreventistasQuery,
+  useDesactivarMetaPreventistaMutation,
+  periodoMensual,
+} from '../../hooks/queries'
+import type { AvanceMeta } from '../../hooks/queries'
 import { useAuthData } from '../../contexts/AuthDataContext'
 import { useNotification } from '../../contexts/NotificationContext'
 import { useResetOnSucursalChange } from '../../hooks/useResetOnSucursalChange'
@@ -16,21 +21,49 @@ function LoadingState(): React.ReactElement {
   )
 }
 
+/** Meta que se está editando: el avance + a quién pertenece. */
+export interface MetaEnEdicion {
+  meta: AvanceMeta
+  preventistaId: string
+}
+
 export default function MetasContainer(): React.ReactElement {
   const notify = useNotification()
   const { isAdmin } = useAuthData()
   const [periodo, setPeriodo] = useState(periodoMensual)
   const [modalOpen, setModalOpen] = useState(false)
+  const [enEdicion, setEnEdicion] = useState<MetaEnEdicion | null>(null)
 
   const { data: resultado, isLoading, error } = useRendimientoPreventistasQuery(periodo, isAdmin)
+  const bajaMut = useDesactivarMetaPreventistaMutation()
 
   useResetOnSucursalChange(() => {
     setModalOpen(false)
+    setEnEdicion(null)
   })
 
   useEffect(() => {
     if (error) notify.error((error as Error).message || 'Error al cargar el rendimiento')
   }, [error, notify])
+
+  const handleEditar = (meta: AvanceMeta, preventistaId: string): void => {
+    setEnEdicion({ meta, preventistaId })
+    setModalOpen(true)
+  }
+
+  const handleEliminar = async (meta: AvanceMeta): Promise<void> => {
+    try {
+      await bajaMut.mutateAsync(meta.id)
+      notify.success('Objetivo eliminado')
+    } catch (e) {
+      notify.error((e as Error).message || 'No se pudo eliminar el objetivo')
+    }
+  }
+
+  const cerrarModal = (): void => {
+    setModalOpen(false)
+    setEnEdicion(null)
+  }
 
   return (
     <>
@@ -40,13 +73,20 @@ export default function MetasContainer(): React.ReactElement {
           loading={isLoading}
           periodo={periodo}
           onCambiarPeriodo={setPeriodo}
-          onAbrirObjetivos={() => setModalOpen(true)}
+          onAbrirObjetivos={() => { setEnEdicion(null); setModalOpen(true) }}
+          onEditarMeta={handleEditar}
+          onEliminarMeta={handleEliminar}
+          eliminando={bajaMut.isPending}
         />
       </Suspense>
 
       {modalOpen && (
         <Suspense fallback={null}>
-          <ModalMetasPreventista periodo={periodo} onClose={() => setModalOpen(false)} />
+          <ModalMetasPreventista
+            periodo={periodo}
+            edicion={enEdicion}
+            onClose={cerrarModal}
+          />
         </Suspense>
       )}
     </>

--- a/src/components/metas/BarraProgresoMeta.tsx
+++ b/src/components/metas/BarraProgresoMeta.tsx
@@ -42,9 +42,18 @@ const COLOR_TEXTO: Record<string, string> = {
 const LABEL_ESTADO: Record<string, string> = {
   cumplida: 'Cumplida',
   adelantado: 'Adelantado',
-  en_curso: 'En curso',
+  // "En progreso" y no "Atrasado": arrancando el período el prorrateo es ruido.
+  // El RPC ya sólo marca en_riesgo pasado el 25% del período (mig 164).
+  en_curso: 'En progreso',
   en_riesgo: 'Atrasado',
 };
+
+/** "01/08 al 15/08" para los períodos que no son un mes completo. */
+function rangoCorto(desde?: string, hasta?: string): string | null {
+  if (!desde || !hasta) return null;
+  const dm = (iso: string) => `${iso.slice(8, 10)}/${iso.slice(5, 7)}`;
+  return `${dm(desde)} al ${dm(hasta)}`;
+}
 
 /**
  * Barra de avance de un objetivo, con el marcador del ritmo esperado.
@@ -73,6 +82,12 @@ const BarraProgresoMeta = memo(function BarraProgresoMeta({ meta, densa = false 
             : undefined}
         >
           {etiquetaMeta(meta)}
+          {/* Sólo cuando NO es el mes completo: si no, es ruido en todas las filas. */}
+          {meta.periodo_personalizado && (
+            <span className="ml-1.5 text-xs font-normal px-1.5 py-0.5 rounded-full bg-violet-100 dark:bg-violet-900/40 text-violet-700 dark:text-violet-300">
+              {rangoCorto(meta.desde, meta.hasta)}
+            </span>
+          )}
         </span>
         <span className={`shrink-0 text-sm font-semibold tabular-nums ${COLOR_TEXTO[meta.estado]}`}>
           {Math.round(meta.pct)}%

--- a/src/components/modals/ModalMetasPreventista.tsx
+++ b/src/components/modals/ModalMetasPreventista.tsx
@@ -1,115 +1,106 @@
 /**
- * Alta y baja de objetivos mensuales por preventista (migs 159 y 162).
+ * Alta, edición y baja de objetivos (migs 159-164).
  *
- * Arriba las metas ya cargadas del período, abajo el formulario. El tipo de
- * meta manda sobre el resto: "cobertura" y "clientes nuevos" no admiten
- * alcance (se cuentan sobre clientes, no sobre productos) y "unidades" lo
- * exige (100 unidades sin decir de qué no es una meta). Los CHECK de la base
- * dicen lo mismo; acá se refleja para no ofrecer combinaciones que van a
- * fallar del otro lado.
+ * Dos modos:
+ *  - alta: multiselección de preventistas, para cargarle el mismo objetivo a
+ *    todo el equipo de una. En la base igual queda UNA fila por persona (el
+ *    avance es individual); el modal sólo evita cargarlo cinco veces a mano.
+ *  - edición: se abre desde el panel con un objetivo ya cargado. Ahí el
+ *    preventista es uno solo y no se cambia — mover un objetivo de persona
+ *    sería borrar el avance de una y estrenar el de otra sin dejar rastro.
  *
- * Dos multiselecciones, por pedido explícito:
- *  - Preventistas: el mismo objetivo suele ir para todo el equipo. En la base
- *    igual se guarda UNA fila por persona (el avance es individual); el modal
- *    sólo evita cargarlo cinco veces a mano.
- *  - Productos: "las gaseosas de 3 litros" son varios SKUs y no siempre
- *    coinciden con una categoría entera (mig 162).
+ * El período es mensual por defecto y editable: una quincena, una semana de
+ * acción o una campaña que cruza meses.
+ *
+ * El tipo de meta manda sobre el alcance: "cobertura" y "clientes nuevos" no
+ * lo admiten (se cuentan sobre clientes, no sobre productos) y "unidades" lo
+ * exige. Los CHECK de la base dicen lo mismo; acá se refleja para no ofrecer
+ * combinaciones que van a fallar del otro lado.
  */
 import { memo, useMemo, useState } from 'react';
-import { Loader2, Plus, Trash2, AlertCircle, Target, Search } from 'lucide-react';
+import { Loader2, Plus, AlertCircle, Target, Search, Check } from 'lucide-react';
 import ModalBase from './ModalBase';
 import NumberInput from '../ui/NumberInput';
-import { formatPrecio } from '../../utils/formatters';
 import {
-  useMetasPreventistaQuery,
   useGuardarMetaPreventistaMutation,
-  useDesactivarMetaPreventistaMutation,
   useMarcasQuery,
   useCategoriasQuery,
   useProductosQuery,
   usePreventistasAsignablesQuery,
 } from '../../hooks/queries';
-import type { TipoMeta, MetaPreventista } from '../../hooks/queries';
+import type { TipoMeta, AvanceMeta } from '../../hooks/queries';
 import { useSucursal } from '../../contexts/SucursalContext';
 
 export interface ModalMetasPreventistaProps {
-  /** Período 'YYYY-MM-01' sobre el que se cargan las metas. */
+  /** Período 'YYYY-MM-01' del panel; da el mes por defecto del formulario. */
   periodo: string;
+  /** Si viene, el modal abre en modo edición de ese objetivo. */
+  edicion?: { meta: AvanceMeta; preventistaId: string } | null;
   onClose: () => void;
 }
 
 const TIPOS: Array<{ valor: TipoMeta; label: string; ayuda: string }> = [
-  { valor: 'facturacion', label: 'Facturación ($)', ayuda: 'Pesos vendidos en el mes.' },
+  { valor: 'facturacion', label: 'Facturación ($)', ayuda: 'Pesos vendidos en el período.' },
   { valor: 'unidades', label: 'Unidades vendidas', ayuda: 'Cantidad de unidades. Elegí de qué.' },
   { valor: 'cobertura', label: 'Clientes visitados', ayuda: 'Clientes distintos con pedido entregado.' },
   { valor: 'clientes_nuevos', label: 'Clientes nuevos', ayuda: 'Clientes que compran por primera vez.' },
 ];
 
-/** Tipos que aceptan acotar el alcance a una marca/categoría/producto. */
 const ADMITE_ALCANCE: TipoMeta[] = ['facturacion', 'unidades'];
-/** Tipos donde el alcance es obligatorio. */
 const EXIGE_ALCANCE: TipoMeta[] = ['unidades'];
+
+/** Último día del mes de una fecha ISO 'YYYY-MM-DD'. */
+function finDeMes(iso: string): string {
+  const [y, m] = iso.split('-').map(Number);
+  return new Date(y, m, 0).toISOString().slice(0, 10);
+}
 
 const ModalMetasPreventista = memo(function ModalMetasPreventista({
   periodo,
+  edicion,
   onClose,
 }: ModalMetasPreventistaProps) {
   const { currentSucursalId } = useSucursal();
-  const { data: metas = [], isLoading } = useMetasPreventistaQuery(periodo);
   const { data: preventistas = [] } = usePreventistasAsignablesQuery();
   const { data: marcas = [] } = useMarcasQuery();
   const { data: categorias = [] } = useCategoriasQuery();
   const { data: productos = [] } = useProductosQuery();
   const guardarMut = useGuardarMetaPreventistaMutation();
-  const bajaMut = useDesactivarMetaPreventistaMutation();
 
-  const [seleccionados, setSeleccionados] = useState<Set<string>>(new Set());
-  const [tipoMeta, setTipoMeta] = useState<TipoMeta>('facturacion');
-  // 'marca:<uuid>' | 'categoria:<uuid>' | 'productos' | '' (global)
-  const [alcance, setAlcance] = useState('');
-  const [productosSel, setProductosSel] = useState<Set<string>>(new Set());
+  const esEdicion = Boolean(edicion);
+  const m = edicion?.meta;
+
+  const [seleccionados, setSeleccionados] = useState<Set<string>>(
+    () => new Set(edicion ? [edicion.preventistaId] : []),
+  );
+  const [tipoMeta, setTipoMeta] = useState<TipoMeta>(m?.tipo_meta ?? 'facturacion');
+  const [alcance, setAlcance] = useState(() => {
+    if (!m) return '';
+    if (m.marca_id) return `marca:${m.marca_id}`;
+    if (m.categoria_id) return `categoria:${m.categoria_id}`;
+    if (m.producto_ids?.length) return 'productos';
+    return '';
+  });
+  const [productosSel, setProductosSel] = useState<Set<string>>(
+    () => new Set((m?.producto_ids ?? []).map(String)),
+  );
   const [busquedaProd, setBusquedaProd] = useState('');
-  const [valor, setValor] = useState<number>(0);
+  const [valor, setValor] = useState<number>(Number(m?.objetivo ?? 0));
+  const [desde, setDesde] = useState(m?.desde ?? periodo);
+  const [hasta, setHasta] = useState(m?.hasta ?? finDeMes(periodo));
   const [error, setError] = useState('');
   const [okMsg, setOkMsg] = useState('');
 
   const admiteAlcance = ADMITE_ALCANCE.includes(tipoMeta);
   const exigeAlcance = EXIGE_ALCANCE.includes(tipoMeta);
+  // Mes completo = el caso normal; se avisa cuando deja de serlo.
+  const esMesCompleto = desde === `${desde.slice(0, 7)}-01` && hasta === finDeMes(desde);
 
   const nombrePorId = useMemo(() => {
-    const m = new Map<string, string>();
-    preventistas.forEach(p => m.set(p.id, p.nombre || p.email || p.id));
-    marcas.forEach(x => m.set(x.id, x.nombre));
-    categorias.forEach(x => m.set(x.id, x.nombre));
-    return m;
-  }, [preventistas, marcas, categorias]);
-
-  const describirMeta = (meta: MetaPreventista): string => {
-    const tipo = TIPOS.find(t => t.valor === meta.tipo_meta)?.label ?? meta.tipo_meta;
-    const n = meta.producto_ids?.length ?? 0;
-    const alc = meta.marca_id ? nombrePorId.get(meta.marca_id)
-      : meta.categoria_id ? nombrePorId.get(meta.categoria_id)
-      // Con un solo producto vale la pena el nombre; con varios no entra.
-      : n === 1 ? (productos.find(p => String(p.id) === String(meta.producto_ids![0]))?.nombre ?? '1 producto')
-      : n > 1 ? `${n} productos`
-      : null;
-    return alc ? `${tipo} — ${alc}` : tipo;
-  };
-
-  const formatObjetivo = (meta: MetaPreventista): string =>
-    meta.tipo_meta === 'facturacion'
-      ? formatPrecio(meta.valor_objetivo)
-      : `${meta.valor_objetivo}${meta.tipo_meta === 'unidades' ? ' u' : ''}`;
-
-  const handleTipoChange = (t: TipoMeta): void => {
-    setTipoMeta(t);
-    // Cambiar a un tipo sin alcance deja basura seleccionada que la base rechaza.
-    if (!ADMITE_ALCANCE.includes(t)) {
-      setAlcance('');
-      setProductosSel(new Set());
-    }
-    setError('');
-  };
+    const map = new Map<string, string>();
+    preventistas.forEach(p => map.set(p.id, p.nombre || p.email || p.id));
+    return map;
+  }, [preventistas]);
 
   const productosFiltrados = useMemo(() => {
     const q = busquedaProd.trim().toLowerCase();
@@ -120,6 +111,15 @@ const ModalMetasPreventista = memo(function ModalMetasPreventista({
 
   const todosFiltradosSel =
     productosFiltrados.length > 0 && productosFiltrados.every(p => productosSel.has(p.id));
+
+  const handleTipoChange = (t: TipoMeta): void => {
+    setTipoMeta(t);
+    if (!ADMITE_ALCANCE.includes(t)) {
+      setAlcance('');
+      setProductosSel(new Set());
+    }
+    setError('');
+  };
 
   const handleGuardar = async (): Promise<void> => {
     if (seleccionados.size === 0) {
@@ -143,33 +143,49 @@ const ModalMetasPreventista = memo(function ModalMetasPreventista({
       setError('Elegí al menos un producto');
       return;
     }
+    if (hasta < desde) {
+      setError('El fin del período no puede ser anterior al inicio');
+      return;
+    }
 
     const [tipoAlc, idAlc] = alcance.includes(':') ? alcance.split(':') : [alcance, null];
     setError('');
     setOkMsg('');
 
-    // Una fila por preventista: el avance es individual. El modal sólo evita
-    // cargar el mismo objetivo cinco veces a mano.
+    const comun = {
+      sucursalId: currentSucursalId,
+      periodo: desde,
+      // Sólo se manda el fin si NO es el mes completo: así el RPC conserva su
+      // comportamiento mensual por defecto y no se guardan rangos "custom"
+      // que en realidad son un mes.
+      periodoHasta: esMesCompleto ? null : hasta,
+      tipoMeta,
+      valorObjetivo: objetivo,
+      marcaId: tipoAlc === 'marca' ? idAlc : null,
+      categoriaId: tipoAlc === 'categoria' ? idAlc : null,
+      productoIds: tipoAlc === 'productos' ? [...productosSel].map(Number) : null,
+    };
+
+    if (esEdicion && m) {
+      try {
+        await guardarMut.mutateAsync({ ...comun, id: m.id, preventistaId: edicion!.preventistaId });
+        onClose();
+      } catch (e) {
+        setError(e instanceof Error ? e.message : 'No se pudo guardar el objetivo');
+      }
+      return;
+    }
+
+    // Alta: una fila por preventista. Si uno falla se sigue con el resto —
+    // que a uno le falte la sucursal no tiene por qué tirar abajo la carga.
     const fallos: string[] = [];
     for (const pid of seleccionados) {
       try {
-        await guardarMut.mutateAsync({
-          sucursalId: currentSucursalId,
-          preventistaId: pid,
-          periodo,
-          tipoMeta,
-          valorObjetivo: objetivo,
-          marcaId: tipoAlc === 'marca' ? idAlc : null,
-          categoriaId: tipoAlc === 'categoria' ? idAlc : null,
-          productoIds: tipoAlc === 'productos' ? [...productosSel].map(Number) : null,
-        });
+        await guardarMut.mutateAsync({ ...comun, preventistaId: pid });
       } catch (e) {
-        // Se sigue con el resto: que uno falle (ej. no pertenece a la sucursal)
-        // no tiene por qué tirar abajo la carga de los demás.
         fallos.push(`${nombrePorId.get(pid) ?? pid}: ${e instanceof Error ? e.message : 'error'}`);
       }
     }
-
     const ok = seleccionados.size - fallos.length;
     if (fallos.length > 0) setError(fallos.join(' · '));
     if (ok > 0) {
@@ -180,74 +196,19 @@ const ModalMetasPreventista = memo(function ModalMetasPreventista({
     }
   };
 
-  // Agrupadas por preventista para que se lea "qué le pedí a cada uno".
-  const porPreventista = useMemo(() => {
-    const grupos = new Map<string, MetaPreventista[]>();
-    metas.forEach(m => {
-      const arr = grupos.get(m.preventista_id) ?? [];
-      arr.push(m);
-      grupos.set(m.preventista_id, arr);
-    });
-    return [...grupos.entries()].sort(
-      (a, b) => (nombrePorId.get(a[0]) ?? '').localeCompare(nombrePorId.get(b[0]) ?? ''),
-    );
-  }, [metas, nombrePorId]);
-
   return (
-    <ModalBase title="Objetivos del mes" onClose={onClose} maxWidth="max-w-2xl">
-      <div className="p-4 space-y-4">
-        {/* Cargadas */}
-        <div>
-          <h3 className="text-sm font-medium mb-2 dark:text-gray-200 flex items-center gap-1.5">
-            <Target className="w-4 h-4" />
-            Objetivos cargados ({metas.length})
-          </h3>
-          {isLoading ? (
-            <div className="flex justify-center py-6"><Loader2 className="w-5 h-5 animate-spin text-blue-600" /></div>
-          ) : metas.length === 0 ? (
-            <p className="text-sm text-gray-500 dark:text-gray-400 py-3">
-              Todavía no hay objetivos para este mes.
-            </p>
-          ) : (
-            <div className="border dark:border-gray-600 rounded-lg divide-y dark:divide-gray-700 max-h-56 overflow-y-auto">
-              {porPreventista.map(([pid, lista]) => (
-                <div key={pid} className="px-3 py-2">
-                  <p className="text-sm font-semibold dark:text-white mb-1">
-                    {nombrePorId.get(pid) ?? pid}
-                  </p>
-                  <ul className="space-y-1">
-                    {lista.map(meta => (
-                      <li key={meta.id} className="flex items-center justify-between gap-2 text-sm">
-                        <span className="text-gray-700 dark:text-gray-300 truncate">
-                          {describirMeta(meta)}
-                        </span>
-                        <span className="flex items-center gap-2 shrink-0">
-                          <span className="font-medium tabular-nums dark:text-white">
-                            {formatObjetivo(meta)}
-                          </span>
-                          <button
-                            type="button"
-                            onClick={() => bajaMut.mutateAsync(meta.id)}
-                            disabled={bajaMut.isPending}
-                            className="p-1 text-red-500 hover:bg-red-50 dark:hover:bg-red-900/20 rounded disabled:opacity-50"
-                            aria-label="Quitar objetivo"
-                          >
-                            <Trash2 className="w-4 h-4" />
-                          </button>
-                        </span>
-                      </li>
-                    ))}
-                  </ul>
-                </div>
-              ))}
-            </div>
-          )}
-        </div>
-
-        {/* Alta */}
-        <div className="border-t dark:border-gray-600 pt-4 space-y-3">
-          <h3 className="text-sm font-medium dark:text-gray-200">Nuevo objetivo</h3>
-
+    <ModalBase
+      title={esEdicion ? 'Editar objetivo' : 'Cargar objetivos'}
+      onClose={onClose}
+      maxWidth="max-w-2xl"
+    >
+      <div className="p-4 space-y-3">
+        {esEdicion ? (
+          <p className="text-sm px-3 py-2 rounded-lg bg-blue-50 dark:bg-blue-900/20 text-blue-800 dark:text-blue-300">
+            Editando el objetivo de <strong>{nombrePorId.get(edicion!.preventistaId) ?? ''}</strong>.
+            Para asignárselo a otra persona, cargá uno nuevo y eliminá este.
+          </p>
+        ) : (
           <div>
             <div className="flex items-baseline justify-between gap-2 mb-1">
               <label className="block text-sm font-medium dark:text-gray-200">
@@ -289,160 +250,201 @@ const ModalMetasPreventista = memo(function ModalMetasPreventista({
               Se carga el mismo objetivo para cada uno; el avance se mide por separado.
             </p>
           </div>
+        )}
 
+        {/* Período: mensual por defecto, editable. */}
+        <div className="grid grid-cols-2 gap-2">
           <div>
-            <label className="block text-sm font-medium mb-1 dark:text-gray-200">Tipo de objetivo</label>
-            <select
-              value={tipoMeta}
-              onChange={e => handleTipoChange(e.target.value as TipoMeta)}
-              className="w-full px-3 py-2 border rounded-lg bg-white dark:bg-gray-700 dark:border-gray-600 dark:text-white"
-            >
-              {TIPOS.map(t => <option key={t.valor} value={t.valor}>{t.label}</option>)}
-            </select>
-            <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
-              {TIPOS.find(t => t.valor === tipoMeta)?.ayuda}
-            </p>
-          </div>
-
-          {admiteAlcance && (
-            <div>
-              <label className="block text-sm font-medium mb-1 dark:text-gray-200">
-                {exigeAlcance ? 'De qué (obligatorio)' : 'Acotar a (opcional)'}
-              </label>
-              <select
-                value={alcance}
-                onChange={e => setAlcance(e.target.value)}
-                className="w-full px-3 py-2 border rounded-lg bg-white dark:bg-gray-700 dark:border-gray-600 dark:text-white"
-              >
-                <option value="">{exigeAlcance ? 'Elegí…' : 'Todo (sin acotar)'}</option>
-                <option value="productos">Productos específicos…</option>
-                {marcas.filter(m => m.activa).length > 0 && (
-                  <optgroup label="Marcas">
-                    {marcas.filter(m => m.activa).map(m => (
-                      <option key={m.id} value={`marca:${m.id}`}>{m.nombre}</option>
-                    ))}
-                  </optgroup>
-                )}
-                {categorias.filter(c => c.activa !== false).length > 0 && (
-                  <optgroup label="Categorías">
-                    {categorias.filter(c => c.activa !== false).map(c => (
-                      <option key={c.id} value={`categoria:${c.id}`}>{c.nombre}</option>
-                    ))}
-                  </optgroup>
-                )}
-              </select>
-              <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
-                Para "2 millones de Manaos y de esos, 100 gaseosas" cargá dos objetivos.
-              </p>
-            </div>
-          )}
-
-          {/* Selector de productos: "las gaseosas de 3 litros" son varios SKUs
-              y no siempre coinciden con una categoría entera. */}
-          {admiteAlcance && alcance === 'productos' && (
-            <div>
-              <div className="flex items-baseline justify-between gap-2 mb-1">
-                <label className="block text-sm font-medium dark:text-gray-200">
-                  Productos incluidos ({productosSel.size})
-                </label>
-                <button
-                  type="button"
-                  onClick={() => setProductosSel(prev => {
-                    const next = new Set(prev);
-                    if (todosFiltradosSel) productosFiltrados.forEach(p => next.delete(p.id));
-                    else productosFiltrados.forEach(p => next.add(p.id));
-                    return next;
-                  })}
-                  disabled={productosFiltrados.length === 0}
-                  className="text-sm font-medium text-blue-600 hover:underline disabled:opacity-50 disabled:no-underline"
-                >
-                  {todosFiltradosSel ? 'Quitar' : 'Agregar'} los {productosFiltrados.length} de la lista
-                </button>
-              </div>
-
-              <div className="relative mb-2">
-                <Search className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400 w-4 h-4 pointer-events-none" />
-                <input
-                  type="text"
-                  value={busquedaProd}
-                  onChange={e => setBusquedaProd(e.target.value)}
-                  placeholder="Filtrar por nombre o categoría… (ej: 3LT)"
-                  className="w-full pl-9 pr-3 py-2 border rounded-lg bg-white dark:bg-gray-700 dark:border-gray-600 dark:text-white text-sm"
-                />
-              </div>
-
-              <div className="border dark:border-gray-600 rounded-lg divide-y dark:divide-gray-700 max-h-44 overflow-y-auto">
-                {productosFiltrados.length === 0 ? (
-                  <p className="px-3 py-4 text-center text-sm text-gray-500 dark:text-gray-400">
-                    No hay productos que coincidan.
-                  </p>
-                ) : productosFiltrados.map(p => (
-                  <label
-                    key={p.id}
-                    className="flex items-center gap-2 px-3 py-2 text-sm cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-700/50"
-                  >
-                    <input
-                      type="checkbox"
-                      checked={productosSel.has(p.id)}
-                      onChange={e => setProductosSel(prev => {
-                        const next = new Set(prev);
-                        if (e.target.checked) next.add(p.id); else next.delete(p.id);
-                        return next;
-                      })}
-                      className="w-4 h-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500 shrink-0"
-                    />
-                    <span className="flex-1 min-w-0">
-                      <span className="block dark:text-white truncate">{p.nombre}</span>
-                      <span className="block text-xs text-gray-500 dark:text-gray-400">
-                        {p.categoria || 'sin categoría'}
-                      </span>
-                    </span>
-                  </label>
-                ))}
-              </div>
-            </div>
-          )}
-
-          <div>
-            <label className="block text-sm font-medium mb-1 dark:text-gray-200">
-              Objetivo del mes {tipoMeta === 'facturacion' ? '($)' : tipoMeta === 'unidades' ? '(unidades)' : '(clientes)'}
-            </label>
-            <NumberInput
-              value={valor}
-              onChange={setValor}
-              min={0}
-              integer={tipoMeta !== 'facturacion'}
-              className="w-full px-3 py-2 border rounded-lg bg-white dark:bg-gray-700 dark:border-gray-600 dark:text-white"
+            <label className="block text-sm font-medium mb-1 dark:text-gray-200">Desde</label>
+            <input
+              type="date"
+              value={desde}
+              onChange={e => setDesde(e.target.value)}
+              className="w-full px-3 py-2 border rounded-lg bg-white dark:bg-gray-700 dark:border-gray-600 dark:text-white text-sm"
             />
           </div>
-
-          {error && (
-            <div role="alert" className="flex items-start gap-2 p-3 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg text-sm text-red-700 dark:text-red-300">
-              <AlertCircle className="w-4 h-4 flex-shrink-0 mt-0.5" />
-              <span>{error}</span>
-            </div>
-          )}
-          {okMsg && (
-            <p className="p-3 bg-green-50 dark:bg-green-900/20 border border-green-200 dark:border-green-800 rounded-lg text-sm text-green-700 dark:text-green-300">
-              {okMsg}
-            </p>
-          )}
-
+          <div>
+            <label className="block text-sm font-medium mb-1 dark:text-gray-200">Hasta</label>
+            <input
+              type="date"
+              value={hasta}
+              onChange={e => setHasta(e.target.value)}
+              min={desde}
+              className="w-full px-3 py-2 border rounded-lg bg-white dark:bg-gray-700 dark:border-gray-600 dark:text-white text-sm"
+            />
+          </div>
+        </div>
+        <div className="flex items-center gap-2 -mt-1">
           <button
             type="button"
-            onClick={handleGuardar}
-            disabled={guardarMut.isPending}
-            className="w-full py-2 bg-blue-600 text-white font-medium rounded-lg hover:bg-blue-700 disabled:bg-gray-400 disabled:cursor-not-allowed flex items-center justify-center gap-1.5"
+            onClick={() => { const d = `${desde.slice(0, 7)}-01`; setDesde(d); setHasta(finDeMes(d)); }}
+            className="text-xs font-medium text-blue-600 hover:underline"
           >
-            {guardarMut.isPending ? <Loader2 className="w-4 h-4 animate-spin" /> : <Plus className="w-4 h-4" />}
-            {seleccionados.size > 1
+            Usar el mes completo
+          </button>
+          <span className="text-xs text-gray-500 dark:text-gray-400">
+            {esMesCompleto ? 'Mes completo (lo habitual)' : 'Período personalizado'}
+          </span>
+        </div>
+
+        <div>
+          <label className="block text-sm font-medium mb-1 dark:text-gray-200">Tipo de objetivo</label>
+          <select
+            value={tipoMeta}
+            onChange={e => handleTipoChange(e.target.value as TipoMeta)}
+            className="w-full px-3 py-2 border rounded-lg bg-white dark:bg-gray-700 dark:border-gray-600 dark:text-white"
+          >
+            {TIPOS.map(t => <option key={t.valor} value={t.valor}>{t.label}</option>)}
+          </select>
+          <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
+            {TIPOS.find(t => t.valor === tipoMeta)?.ayuda}
+          </p>
+        </div>
+
+        {admiteAlcance && (
+          <div>
+            <label className="block text-sm font-medium mb-1 dark:text-gray-200">
+              {exigeAlcance ? 'De qué (obligatorio)' : 'Acotar a (opcional)'}
+            </label>
+            <select
+              value={alcance}
+              onChange={e => setAlcance(e.target.value)}
+              className="w-full px-3 py-2 border rounded-lg bg-white dark:bg-gray-700 dark:border-gray-600 dark:text-white"
+            >
+              <option value="">{exigeAlcance ? 'Elegí…' : 'Todo (sin acotar)'}</option>
+              <option value="productos">Productos específicos…</option>
+              {marcas.filter(x => x.activa).length > 0 && (
+                <optgroup label="Marcas">
+                  {marcas.filter(x => x.activa).map(x => (
+                    <option key={x.id} value={`marca:${x.id}`}>{x.nombre}</option>
+                  ))}
+                </optgroup>
+              )}
+              {categorias.filter(c => c.activa !== false).length > 0 && (
+                <optgroup label="Categorías">
+                  {categorias.filter(c => c.activa !== false).map(c => (
+                    <option key={c.id} value={`categoria:${c.id}`}>{c.nombre}</option>
+                  ))}
+                </optgroup>
+              )}
+            </select>
+            <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
+              Para "2 millones de Manaos y de esos, 100 gaseosas" cargá dos objetivos.
+            </p>
+          </div>
+        )}
+
+        {admiteAlcance && alcance === 'productos' && (
+          <div>
+            <div className="flex items-baseline justify-between gap-2 mb-1">
+              <label className="block text-sm font-medium dark:text-gray-200">
+                Productos incluidos ({productosSel.size})
+              </label>
+              <button
+                type="button"
+                onClick={() => setProductosSel(prev => {
+                  const next = new Set(prev);
+                  if (todosFiltradosSel) productosFiltrados.forEach(p => next.delete(p.id));
+                  else productosFiltrados.forEach(p => next.add(p.id));
+                  return next;
+                })}
+                disabled={productosFiltrados.length === 0}
+                className="text-sm font-medium text-blue-600 hover:underline disabled:opacity-50 disabled:no-underline"
+              >
+                {todosFiltradosSel ? 'Quitar' : 'Agregar'} los {productosFiltrados.length} de la lista
+              </button>
+            </div>
+
+            <div className="relative mb-2">
+              <Search className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400 w-4 h-4 pointer-events-none" />
+              <input
+                type="text"
+                value={busquedaProd}
+                onChange={e => setBusquedaProd(e.target.value)}
+                placeholder="Filtrar por nombre o categoría… (ej: 3LT)"
+                className="w-full pl-9 pr-3 py-2 border rounded-lg bg-white dark:bg-gray-700 dark:border-gray-600 dark:text-white text-sm"
+              />
+            </div>
+
+            <div className="border dark:border-gray-600 rounded-lg divide-y dark:divide-gray-700 max-h-44 overflow-y-auto">
+              {productosFiltrados.length === 0 ? (
+                <p className="px-3 py-4 text-center text-sm text-gray-500 dark:text-gray-400">
+                  No hay productos que coincidan.
+                </p>
+              ) : productosFiltrados.map(p => (
+                <label
+                  key={p.id}
+                  className="flex items-center gap-2 px-3 py-2 text-sm cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-700/50"
+                >
+                  <input
+                    type="checkbox"
+                    checked={productosSel.has(p.id)}
+                    onChange={e => setProductosSel(prev => {
+                      const next = new Set(prev);
+                      if (e.target.checked) next.add(p.id); else next.delete(p.id);
+                      return next;
+                    })}
+                    className="w-4 h-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500 shrink-0"
+                  />
+                  <span className="flex-1 min-w-0">
+                    <span className="block dark:text-white truncate">{p.nombre}</span>
+                    <span className="block text-xs text-gray-500 dark:text-gray-400">
+                      {p.categoria || 'sin categoría'}
+                    </span>
+                  </span>
+                </label>
+              ))}
+            </div>
+          </div>
+        )}
+
+        <div>
+          <label className="block text-sm font-medium mb-1 dark:text-gray-200">
+            Objetivo del período {tipoMeta === 'facturacion' ? '($)' : tipoMeta === 'unidades' ? '(unidades)' : '(clientes)'}
+          </label>
+          <NumberInput
+            value={valor}
+            onChange={setValor}
+            min={0}
+            integer={tipoMeta !== 'facturacion'}
+            className="w-full px-3 py-2 border rounded-lg bg-white dark:bg-gray-700 dark:border-gray-600 dark:text-white"
+          />
+        </div>
+
+        {error && (
+          <div role="alert" className="flex items-start gap-2 p-3 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg text-sm text-red-700 dark:text-red-300">
+            <AlertCircle className="w-4 h-4 flex-shrink-0 mt-0.5" />
+            <span>{error}</span>
+          </div>
+        )}
+        {okMsg && (
+          <p className="p-3 bg-green-50 dark:bg-green-900/20 border border-green-200 dark:border-green-800 rounded-lg text-sm text-green-700 dark:text-green-300">
+            {okMsg}
+          </p>
+        )}
+
+        <button
+          type="button"
+          onClick={handleGuardar}
+          disabled={guardarMut.isPending}
+          className="w-full py-2 bg-blue-600 text-white font-medium rounded-lg hover:bg-blue-700 disabled:bg-gray-400 disabled:cursor-not-allowed flex items-center justify-center gap-1.5"
+        >
+          {guardarMut.isPending
+            ? <Loader2 className="w-4 h-4 animate-spin" />
+            : esEdicion ? <Check className="w-4 h-4" /> : <Plus className="w-4 h-4" />}
+          {esEdicion
+            ? 'Guardar cambios'
+            : seleccionados.size > 1
               ? `Agregar objetivo a ${seleccionados.size} preventistas`
               : 'Agregar objetivo'}
-          </button>
-        </div>
+        </button>
       </div>
 
-      <div className="p-4 border-t dark:border-gray-600 flex justify-end">
+      <div className="p-4 border-t dark:border-gray-600 flex items-center justify-between gap-2">
+        <span className="text-xs text-gray-500 dark:text-gray-400 flex items-center gap-1.5">
+          <Target className="w-3.5 h-3.5" />
+          Los objetivos y su avance se ven en el panel.
+        </span>
         <button
           type="button"
           onClick={onClose}

--- a/src/components/vistas/VistaMetasPreventistas.tsx
+++ b/src/components/vistas/VistaMetasPreventistas.tsx
@@ -1,21 +1,22 @@
 /**
- * Rendimiento del equipo comercial + avance de objetivos (migs 159-161).
+ * Objetivos y rendimiento del equipo comercial (migs 159-164).
  *
- * Una fila por preventista con sus números del mes; al expandir, el desglose
- * por marca y por categoría y el avance de cada objetivo.
+ * El panel muestra a TODOS los preventistas de la sucursal —vendieran o no—
+ * con sus objetivos, a quién están asignados y el progreso, sin tener que
+ * expandir nada. Un preventista que no vendió en el mes es justamente el que
+ * hay que ver: esconderlo (que era lo que pasaba al armar la lista desde los
+ * pedidos entregados) dejaba objetivos invisibles.
  *
- * La base es "pedidos entregados del mes, sin bonificaciones" — la misma de
- * `reporte_gerencial`, así que la columna Venta cierra peso a peso con la
- * sección "Equipo comercial" del reporte gerencial. Está escrito en pantalla
- * porque `/comisiones` usa otra base (todo lo no cancelado) y ver dos números
- * distintos sin explicación destruye la confianza en los dos.
+ * El avance viene embebido en el mismo RPC, y sale del mismo cálculo que ve el
+ * preventista en su dashboard, así que los números no pueden discrepar.
+ *
+ * Expandir la fila agrega el desglose por marca y por categoría.
  */
 import { memo, useState } from 'react';
-import { Loader2, ChevronRight, Target, Users, UserPlus, TrendingUp } from 'lucide-react';
+import { Loader2, ChevronRight, Target, Users, UserPlus, TrendingUp, Pencil, Trash2 } from 'lucide-react';
 import { formatPrecio } from '../../utils/formatters';
 import BarraProgresoMeta from '../metas/BarraProgresoMeta';
-import { useAvanceMetasQuery } from '../../hooks/queries';
-import type { RendimientoPreventista, RendimientoResultado } from '../../hooks/queries';
+import type { AvanceMeta, RendimientoPreventista, RendimientoResultado } from '../../hooks/queries';
 
 export interface VistaMetasPreventistasProps {
   resultado?: RendimientoResultado;
@@ -23,33 +24,25 @@ export interface VistaMetasPreventistasProps {
   periodo: string;
   onCambiarPeriodo: (periodo: string) => void;
   onAbrirObjetivos: () => void;
+  onEditarMeta: (meta: AvanceMeta, preventistaId: string) => void;
+  onEliminarMeta: (meta: AvanceMeta) => void;
+  eliminando?: boolean;
 }
-
-/** Avance de un preventista, cargado sólo al expandir su fila. */
-const DetalleAvance = memo(function DetalleAvance({
-  preventistaId,
-  periodo,
-}: { preventistaId: string; periodo: string }) {
-  const { data: avance, isLoading } = useAvanceMetasQuery(preventistaId, periodo);
-
-  if (isLoading) {
-    return <div className="py-3 flex justify-center"><Loader2 className="w-4 h-4 animate-spin text-blue-600" /></div>;
-  }
-  if (!avance?.metas?.length) {
-    return <p className="text-sm text-gray-500 dark:text-gray-400 py-2">Sin objetivos cargados este mes.</p>;
-  }
-  return (
-    <div className="divide-y dark:divide-gray-700">
-      {avance.metas.map(m => <BarraProgresoMeta key={m.id} meta={m} densa />)}
-    </div>
-  );
-});
 
 const FilaPreventista = memo(function FilaPreventista({
   p,
-  periodo,
-}: { p: RendimientoPreventista; periodo: string }) {
+  onEditarMeta,
+  onEliminarMeta,
+  eliminando,
+}: {
+  p: RendimientoPreventista;
+  onEditarMeta: VistaMetasPreventistasProps['onEditarMeta'];
+  onEliminarMeta: VistaMetasPreventistasProps['onEliminarMeta'];
+  eliminando?: boolean;
+}) {
   const [abierta, setAbierta] = useState(false);
+  const metas = p.metas ?? [];
+  const resumen = p.resumen_metas ?? { total: 0, cumplidas: 0, en_riesgo: 0 };
 
   return (
     <>
@@ -76,61 +69,92 @@ const FilaPreventista = memo(function FilaPreventista({
         <td className="px-3 py-2.5 text-right tabular-nums dark:text-gray-300">{p.cobertura}</td>
         <td className="px-3 py-2.5 text-right tabular-nums dark:text-gray-300 hidden sm:table-cell">{p.clientes_nuevos}</td>
         <td className="px-3 py-2.5 text-right tabular-nums">
-          {p.metas_cargadas > 0 ? (
-            <span className="dark:text-gray-300">{p.metas_cargadas}</span>
+          {resumen.total > 0 ? (
+            <span className="dark:text-gray-300">
+              {resumen.cumplidas} de {resumen.total}
+              {resumen.en_riesgo > 0 && (
+                <span className="ml-1.5 text-xs text-rose-600 dark:text-rose-400">
+                  · {resumen.en_riesgo} atrasado{resumen.en_riesgo === 1 ? '' : 's'}
+                </span>
+              )}
+            </span>
           ) : (
-            <span className="text-gray-400 text-xs">sin metas</span>
+            <span className="text-gray-400 text-xs">sin objetivos</span>
           )}
         </td>
       </tr>
 
+      {/* Objetivos SIEMPRE visibles: son el motivo de esta pantalla. */}
+      {metas.length > 0 && (
+        <tr className="border-b dark:border-gray-700">
+          <td colSpan={7} className="px-3 pt-1 pb-3 bg-gray-50/60 dark:bg-gray-800/40">
+            <div className="space-y-1 max-w-3xl">
+              {metas.map(m => (
+                <div key={m.id} className="flex items-start gap-2">
+                  <div className="flex-1 min-w-0">
+                    <BarraProgresoMeta meta={m} densa />
+                  </div>
+                  <div className="flex gap-0.5 shrink-0 pt-1.5">
+                    <button
+                      type="button"
+                      onClick={() => onEditarMeta(m, p.preventista_id)}
+                      className="p-1.5 text-blue-600 hover:bg-blue-50 dark:hover:bg-blue-900/20 rounded"
+                      aria-label={`Editar objetivo de ${p.nombre}`}
+                      title="Editar objetivo"
+                    >
+                      <Pencil className="w-4 h-4" />
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => onEliminarMeta(m)}
+                      disabled={eliminando}
+                      className="p-1.5 text-red-500 hover:bg-red-50 dark:hover:bg-red-900/20 rounded disabled:opacity-50"
+                      aria-label={`Eliminar objetivo de ${p.nombre}`}
+                      title="Eliminar objetivo"
+                    >
+                      <Trash2 className="w-4 h-4" />
+                    </button>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </td>
+        </tr>
+      )}
+
       {abierta && (
-        <tr className="bg-gray-50/60 dark:bg-gray-800/60">
+        <tr className="bg-gray-50/60 dark:bg-gray-800/60 border-b dark:border-gray-700">
           <td colSpan={7} className="px-3 py-3">
             <div className="grid gap-4 md:grid-cols-2">
               <div>
-                <h4 className="text-sm font-semibold mb-2 dark:text-white flex items-center gap-1.5">
-                  <Target className="w-4 h-4 text-blue-600" />
-                  Objetivos
-                </h4>
-                <DetalleAvance preventistaId={p.preventista_id} periodo={periodo} />
+                <h4 className="text-sm font-semibold mb-1 dark:text-white">Por marca</h4>
+                <ul className="text-sm space-y-0.5">
+                  {p.por_marca.slice(0, 6).map(m => (
+                    <li key={m.marca} className="flex justify-between gap-2">
+                      <span className="text-gray-600 dark:text-gray-400 truncate">{m.marca}</span>
+                      <span className="tabular-nums dark:text-gray-300 shrink-0">
+                        {formatPrecio(m.venta)} · {m.unidades} u
+                      </span>
+                    </li>
+                  ))}
+                  {p.por_marca.length === 0 && <li className="text-gray-400">Sin ventas en el período</li>}
+                </ul>
               </div>
-
-              <div className="space-y-3">
-                <div>
-                  <h4 className="text-sm font-semibold mb-1 dark:text-white">Por marca</h4>
-                  <ul className="text-sm space-y-0.5">
-                    {p.por_marca.slice(0, 6).map(m => (
-                      <li key={m.marca} className="flex justify-between gap-2">
-                        <span className="text-gray-600 dark:text-gray-400 truncate">{m.marca}</span>
-                        <span className="tabular-nums dark:text-gray-300 shrink-0">
-                          {formatPrecio(m.venta)} · {m.unidades} u
-                        </span>
-                      </li>
-                    ))}
-                    {p.por_marca.length === 0 && (
-                      <li className="text-gray-400">Sin datos</li>
-                    )}
-                  </ul>
-                </div>
-                <div>
-                  <h4 className="text-sm font-semibold mb-1 dark:text-white">Por categoría</h4>
-                  <ul className="text-sm space-y-0.5">
-                    {p.por_categoria.slice(0, 6).map(c => (
-                      <li key={c.categoria} className="flex justify-between gap-2">
-                        <span className="text-gray-600 dark:text-gray-400 truncate">{c.categoria}</span>
-                        <span className="tabular-nums dark:text-gray-300 shrink-0">
-                          {formatPrecio(c.venta)} · {c.unidades} u
-                        </span>
-                      </li>
-                    ))}
-                    {p.por_categoria.length === 0 && (
-                      <li className="text-gray-400">Sin datos</li>
-                    )}
-                  </ul>
-                </div>
-                <p className="text-xs text-gray-500 dark:text-gray-400">
-                  Margen comercial del mes: {formatPrecio(p.margen_comercial)}
+              <div>
+                <h4 className="text-sm font-semibold mb-1 dark:text-white">Por categoría</h4>
+                <ul className="text-sm space-y-0.5">
+                  {p.por_categoria.slice(0, 6).map(c => (
+                    <li key={c.categoria} className="flex justify-between gap-2">
+                      <span className="text-gray-600 dark:text-gray-400 truncate">{c.categoria}</span>
+                      <span className="tabular-nums dark:text-gray-300 shrink-0">
+                        {formatPrecio(c.venta)} · {c.unidades} u
+                      </span>
+                    </li>
+                  ))}
+                  {p.por_categoria.length === 0 && <li className="text-gray-400">Sin ventas en el período</li>}
+                </ul>
+                <p className="text-xs text-gray-500 dark:text-gray-400 mt-2">
+                  Margen comercial del período: {formatPrecio(p.margen_comercial)}
                 </p>
               </div>
             </div>
@@ -161,11 +185,15 @@ const VistaMetasPreventistas = memo(function VistaMetasPreventistas({
   periodo,
   onCambiarPeriodo,
   onAbrirObjetivos,
+  onEditarMeta,
+  onEliminarMeta,
+  eliminando,
 }: VistaMetasPreventistasProps) {
   const preventistas = resultado?.preventistas ?? [];
   const totalVenta = preventistas.reduce((t, p) => t + p.venta, 0);
   const totalNuevos = preventistas.reduce((t, p) => t + p.clientes_nuevos, 0);
   const totalCobertura = preventistas.reduce((t, p) => t + p.cobertura, 0);
+  const totalObjetivos = preventistas.reduce((t, p) => t + (p.resumen_metas?.total ?? 0), 0);
 
   return (
     <div className="space-y-4">
@@ -196,11 +224,12 @@ const VistaMetasPreventistas = memo(function VistaMetasPreventistas({
         </div>
       </div>
 
-      <div className="grid grid-cols-3 gap-3">
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
         {[
           { icon: TrendingUp, label: 'Venta del mes', valor: formatPrecio(totalVenta) },
           { icon: Users, label: 'Clientes atendidos', valor: String(totalCobertura) },
           { icon: UserPlus, label: 'Clientes nuevos', valor: String(totalNuevos) },
+          { icon: Target, label: 'Objetivos cargados', valor: String(totalObjetivos) },
         ].map(k => (
           <div key={k.label} className="rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-3">
             <p className="text-xs text-gray-500 dark:text-gray-400 flex items-center gap-1">
@@ -217,7 +246,7 @@ const VistaMetasPreventistas = memo(function VistaMetasPreventistas({
           <div className="flex justify-center py-16"><Loader2 className="w-6 h-6 animate-spin text-blue-600" /></div>
         ) : preventistas.length === 0 ? (
           <p className="text-center text-sm text-gray-500 dark:text-gray-400 py-12">
-            No hay ventas entregadas en este mes.
+            No hay preventistas ni objetivos en esta sucursal.
           </p>
         ) : (
           <table className="w-full text-sm">
@@ -234,7 +263,13 @@ const VistaMetasPreventistas = memo(function VistaMetasPreventistas({
             </thead>
             <tbody>
               {preventistas.map(p => (
-                <FilaPreventista key={p.preventista_id} p={p} periodo={periodo} />
+                <FilaPreventista
+                  key={p.preventista_id}
+                  p={p}
+                  onEditarMeta={onEditarMeta}
+                  onEliminarMeta={onEliminarMeta}
+                  eliminando={eliminando}
+                />
               ))}
             </tbody>
           </table>

--- a/src/hooks/queries/useMetasPreventistaQuery.ts
+++ b/src/hooks/queries/useMetasPreventistaQuery.ts
@@ -39,12 +39,24 @@ export interface AvanceMeta {
   /** '$' | 'u' | 'clientes' — derivada de tipo_meta en el RPC. */
   unidad: string
   alcance: AlcanceMeta
+  /** Inicio del período de ESTA meta (puede no ser un mes; mig 164). */
+  desde: string
+  /** Fin del período de esta meta, inclusive. */
+  hasta: string
+  dias_periodo: number
+  dias_transcurridos: number
+  /** true si el período no es un mes calendario completo. */
+  periodo_personalizado: boolean
   objetivo: number
   logrado: number
   pct: number
-  /** objetivo × días transcurridos / días del mes. Calculado en SQL. */
+  /** objetivo × días transcurridos / días del período. Calculado en SQL. */
   objetivo_prorrateado: number
   estado: EstadoMeta
+  // Alcance en crudo, para poder cargar la meta en el formulario y editarla.
+  marca_id: string | null
+  categoria_id: string | null
+  producto_ids: number[] | null
 }
 
 export interface AvanceMetasResultado {
@@ -63,7 +75,10 @@ export interface MetaPreventista {
   id: number
   sucursal_id: number
   preventista_id: string
+  /** Inicio del período. */
   periodo: string
+  /** Fin del período, inclusive (mig 164). */
+  periodo_fin: string
   tipo_meta: TipoMeta
   marca_id: string | null
   categoria_id: string | null
@@ -78,8 +93,13 @@ export interface GuardarMetaInput {
   id?: number | null
   sucursalId: number
   preventistaId: string
-  /** 'YYYY-MM-01'. El RPC lo normaliza al primer día del mes igual. */
+  /** Inicio del período. Si no se manda `periodoHasta`, el RPC lo lleva al mes entero. */
   periodo: string
+  /**
+   * Fin del período. Omitirlo = objetivo mensual (el caso normal). Mandarlo
+   * respeta las dos fechas tal cual, para quincenas o campañas (mig 164).
+   */
+  periodoHasta?: string | null
   tipoMeta: TipoMeta
   valorObjetivo: number
   marcaId?: string | null
@@ -111,6 +131,12 @@ export interface RendimientoPreventista {
   clientes_nuevos: number
   ticket: number | null
   metas_cargadas: number
+  /**
+   * Avance de cada objetivo, embebido por el RPC (mig 164). Sale del MISMO
+   * cálculo que ve el preventista en su dashboard, así que no puede discrepar.
+   */
+  metas: AvanceMeta[]
+  resumen_metas: { total: number; cumplidas: number; en_riesgo: number }
   por_marca: RendimientoPorMarca[]
   por_categoria: RendimientoPorCategoria[]
 }
@@ -230,6 +256,7 @@ export function useGuardarMetaPreventistaMutation() {
         p_marca_id: input.marcaId ?? null,
         p_categoria_id: input.categoriaId ?? null,
         p_producto_ids: input.productoIds?.length ? input.productoIds : null,
+        p_periodo_hasta: input.periodoHasta ?? null,
       })
       if (error) throw error
       return data as number


### PR DESCRIPTION
Cuatro cosas que salieron de probar los objetivos en producción, más el backfill de marcas.

## 1. El objetivo no se veía en `/metas`

La tabla se armaba desde los **pedidos entregados**, así que un preventista sin ventas en el mes no aparecía — y con él desaparecía su objetivo. Pasó con el primer objetivo de prueba: estaba en la base y se veía en el dashboard, pero la pantalla de objetivos lo ignoraba.

Ahora la lista es la unión de: quien vendió + quien tiene objetivos + **todos los preventistas de la sucursal**. El que no vendió nada es justamente el que hay que mirar.

## 2. Ahora se ve todo en el mismo panel

El avance estaba detrás de un "expandir" y se pedía con una query por preventista. `rendimiento_preventistas` ahora lo trae **embebido** (LATERAL sobre `avance_metas_preventista`, sólo para quien tiene objetivos cargados), y el panel muestra el objetivo, a quién está asignado y el progreso sin expandir nada.

Sale del **mismo cálculo** que ve el preventista en su dashboard, así que los números no pueden discrepar.

## 3. Se pueden editar

El RPC ya soportaba UPDATE por id, pero la UI nunca lo usaba: se cargaba un objetivo y no había forma de tocarlo. Ahora hay botón de editar por objetivo, y el de eliminar pasó al panel.

Al editar **no se cambia de preventista** a propósito: mover un objetivo de persona sería borrar el avance de una y estrenar el de otra sin dejar rastro. Para eso, cargar uno nuevo y eliminar el viejo.

## 4. Período editable (mig 164)

Las metas eran mensuales y punto. El mes sigue siendo el default —y si el rango elegido *es* el mes completo no se guarda como personalizado, así el RPC conserva su comportamiento habitual—, pero ahora entra una quincena o una campaña que cruza meses.

Cada meta se mide contra **su** período: días, prorrateo y semáforo. Verificado en prod con una meta del 01 al 15: prorrateo sobre 15 días ($133.333 de $500.000 al día 4), no sobre 31.

## Y el semáforo

Al día 4 de 31, con $0 sobre un objetivo de $1.000, decía **"Atrasado"**. Es cierto contra el prorrateo (debía llevar $129) pero es una lectura inútil con 27 días por delante: al principio del período el prorrateo es ruido, no señal.

Ahora sólo se marca en riesgo **pasado el 25% del período**. Antes de eso, lo peor que puede decir es **"En progreso"** (ámbar).

## Backfill de marcas (mig 163)

Sólo los casos donde la marca es **inequívoca en el nombre**: VILLAMANAOS (resuelto *antes* que MANAOS, si no "AGUA VILLA MANAOS" quedaba mal clasificada y el error sería invisible), MANAOS, PLACER, PINDAPOY, COTELLA, RICATTO, RIVOLLI, MONDEO, NESS, NATUREZA, ALFATUC, COCA COLA, PANINI.

**137 productos sin marca → 34.** Simulé la asignación antes de aplicarla y revisé producto por producto que no hubiera falsos positivos.

Quedan sin marca a propósito los que necesitan criterio comercial: "PAPAS FRITAS 200GRS", "CHIZITOS", "PUFLITO" (sin marca en el nombre), "AZUCAR CALIDAD"/"INDEPENDENCIA" (¿marca o descriptor?), "VINO TORO"/"VIÑA DE BALBO" (hay marca, pero no sé si se quieren separadas) y "AGUA EL SANO CORAZON ARGENTINO".

## De paso, verificado

El objetivo **toma las ventas ya hechas del período**, no desde que se carga. Una meta creada hoy contabilizó los $262.950 vendidos del 1 al 4.

## Migraciones

163 y 164 **ya aplicadas en producción**, ledger alineado 1:1 con el repo.

## Verificación

Typecheck, lint, 955 tests y build en verde. Los RPCs probados contra datos reales (meta de quincena, meta de preventista sin ventas, semáforo al día 4).

Sigue pendiente la verificación visual: el panel del navegador no compone frames en este entorno.

🤖 Generated with [Claude Code](https://claude.com/claude-code)