### PR TITLE
fix(pedidos): traducir el falso "No se pudo determinar la sucursal activa"

### DIFF
--- a/src/components/containers/PedidosContainer.tsx
+++ b/src/components/containers/PedidosContainer.tsx
@@ -16,6 +16,7 @@ import {
 import { construirOrigenPrecioItems, type OrigenPrecioItem } from '../../utils/origenPrecio'
 import PanelPedidosNoEntregados from '../pedidos/PanelPedidosNoEntregados'
 import { fechaLocalISO, fechaHaceDias, getFormaPagoDisplay } from '../../utils/formatters'
+import { explicarErrorDeSesion } from '../../utils/sesionVencida'
 import { preventistaPuedeEditar } from '../../utils/permisosPedido'
 import { useQueryClient } from '@tanstack/react-query'
 import { Loader2 } from 'lucide-react'
@@ -1154,7 +1155,12 @@ export default function PedidosContainer(): React.ReactElement {
       setModalPedidoOpen(false)
       notify.success('Pedido creado correctamente')
     } catch (e) {
-      notify.error('Error al crear pedido: ' + (e as Error).message)
+      // "No se pudo determinar la sucursal activa" casi siempre es el token, no
+      // la sucursal: se traduce y se renueva la sesión para que el reintento
+      // funcione. Ver src/utils/sesionVencida.ts.
+      const crudo = (e as Error).message
+      const mensaje = await explicarErrorDeSesion(crudo)
+      notify.error(mensaje === crudo ? 'Error al crear pedido: ' + crudo : mensaje)
     }
     setGuardando(false)
   }, [nuevoPedido, itemsFinales, preciosResueltos, crearPedido, user, resetNuevoPedido, notify, productos, clientes, registrarGpsPedido])

--- a/src/utils/sesionVencida.test.ts
+++ b/src/utils/sesionVencida.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const refreshSession = vi.fn();
+vi.mock('../lib/supabase', () => ({
+  supabase: { auth: { refreshSession: () => refreshSession() } },
+}));
+
+const {
+  pareceSesionVencida,
+  explicarErrorDeSesion,
+  MENSAJE_SESION_RENOVADA,
+  MENSAJE_SESION_CAIDA,
+} = await import('./sesionVencida');
+
+describe('pareceSesionVencida', () => {
+  it('reconoce el error de sucursal, que es el síntoma habitual', () => {
+    expect(pareceSesionVencida('No se pudo determinar la sucursal activa')).toBe(true);
+    // Tal cual llega desde el RPC, con prefijo.
+    expect(pareceSesionVencida('Error al crear pedido: No se pudo determinar la sucursal activa')).toBe(true);
+  });
+
+  it('reconoce los errores de JWT explícitos', () => {
+    expect(pareceSesionVencida('JWT expired')).toBe(true);
+    expect(pareceSesionVencida('token is expired')).toBe(true);
+    expect(pareceSesionVencida('invalid claim: missing sub')).toBe(true);
+  });
+
+  it('no se come errores de negocio', () => {
+    expect(pareceSesionVencida('Stock insuficiente en MANAOS COLA 3LT')).toBe(false);
+    expect(pareceSesionVencida('La compra mínima de "FIDEO" es 3 unidades')).toBe(false);
+    expect(pareceSesionVencida('')).toBe(false);
+    expect(pareceSesionVencida(null)).toBe(false);
+    expect(pareceSesionVencida(undefined)).toBe(false);
+  });
+});
+
+describe('explicarErrorDeSesion', () => {
+  beforeEach(() => refreshSession.mockReset());
+
+  it('deja pasar sin tocar los errores que no son de sesión', async () => {
+    const msg = 'Stock insuficiente en MANAOS COLA 3LT';
+    expect(await explicarErrorDeSesion(msg)).toBe(msg);
+    expect(refreshSession).not.toHaveBeenCalled();
+  });
+
+  it('si la sesión se renueva, avisa que hay que reintentar', async () => {
+    refreshSession.mockResolvedValue({ data: { session: { access_token: 'x' } }, error: null });
+    expect(await explicarErrorDeSesion('No se pudo determinar la sucursal activa'))
+      .toBe(MENSAJE_SESION_RENOVADA);
+  });
+
+  it('si no se puede renovar, manda a iniciar sesión de nuevo', async () => {
+    refreshSession.mockResolvedValue({ data: { session: null }, error: { message: 'no refresh token' } });
+    expect(await explicarErrorDeSesion('No se pudo determinar la sucursal activa'))
+      .toBe(MENSAJE_SESION_CAIDA);
+  });
+
+  it('sin red, manda a iniciar sesión de nuevo', async () => {
+    // supabase-js devuelve el error, no lo tira: así se ve un refresh sin red.
+    refreshSession.mockResolvedValue({
+      data: { session: null },
+      error: { message: 'Failed to fetch' },
+    });
+    expect(await explicarErrorDeSesion('JWT expired')).toBe(MENSAJE_SESION_CAIDA);
+  });
+});

--- a/src/utils/sesionVencida.ts
+++ b/src/utils/sesionVencida.ts
@@ -1,0 +1,62 @@
+/**
+ * Diagnóstico del error "No se pudo determinar la sucursal activa".
+ *
+ * Ese mensaje sale de los RPCs cuando `current_sucursal_id()` devuelve NULL, y
+ * confunde: culpa a la sucursal cuando casi siempre el problema es el token.
+ *
+ * `current_sucursal_id()` (mig 061) resuelve así:
+ *   1. lee el header X-Sucursal-ID;
+ *   2. si está, verifica contra `usuario_sucursales` USANDO auth.uid();
+ *   3. si esa verificación falla → devuelve NULL.
+ *
+ * El front nunca manda una sucursal ajena: SucursalContext sólo activa una de
+ * las que el usuario tiene asignadas. Así que para alguien con su sucursal
+ * cargada, el paso 2 sólo falla si `auth.uid()` es NULL — o sea, el JWT no era
+ * válido en ese instante (venció, o el servicio de auth se reinició y hubo una
+ * ventana sin refresh). El header sigue puesto porque vive en memoria del tab.
+ *
+ * Se ve como algo intermitente: el mismo preventista carga pedidos bien antes y
+ * después, y en el medio uno falla hablando de sucursales.
+ */
+import { supabase } from '../lib/supabase';
+
+/** El pedido NO se creó: el RPC valida la sucursal antes de escribir nada. */
+export const MENSAJE_SESION_RENOVADA =
+  'Tu sesión se había vencido y la renovamos. Tocá Confirmar de nuevo — el pedido no se guardó.';
+
+export const MENSAJE_SESION_CAIDA =
+  'Tu sesión venció. Cerrá sesión y volvé a entrar para seguir cargando pedidos.';
+
+/**
+ * true si el mensaje de error apunta a un problema de sesión disfrazado.
+ * Se acepta el de sucursal porque, con el front validando el header, es el
+ * síntoma habitual de un token inválido.
+ */
+export function pareceSesionVencida(mensaje?: string | null): boolean {
+  const m = (mensaje ?? '').toLowerCase();
+  if (!m) return false;
+  return (
+    m.includes('no se pudo determinar la sucursal activa') ||
+    m.includes('jwt expired') ||
+    m.includes('token is expired') ||
+    m.includes('invalid claim')
+  );
+}
+
+/**
+ * Traduce el error a algo accionable e intenta renovar la sesión en el acto,
+ * para que el reintento del usuario funcione. Si el mensaje no es de sesión lo
+ * devuelve tal cual.
+ *
+ * NO reintenta el pedido solo: la creación online no lleva clave de
+ * idempotencia, así que un reintento automático podría duplicarlo.
+ */
+export async function explicarErrorDeSesion(mensaje: string): Promise<string> {
+  if (!pareceSesionVencida(mensaje)) return mensaje;
+  try {
+    const { data, error } = await supabase.auth.refreshSession();
+    return error || !data.session ? MENSAJE_SESION_CAIDA : MENSAJE_SESION_RENOVADA;
+  } catch {
+    return MENSAJE_SESION_CAIDA;
+  }
+}


### PR DESCRIPTION
Un preventista de Tucumán vio ese cartel al confirmar un pedido. **La sucursal no tenía nada que ver.**

## Qué pasa realmente

`current_sucursal_id()` (mig 061) lee el header `X-Sucursal-ID` y lo verifica contra `usuario_sucursales` **usando `auth.uid()`**. Si esa verificación falla, devuelve NULL y los RPCs cortan con ese mensaje.

El front nunca manda una sucursal ajena — `SucursalContext` sólo activa una de las asignadas al usuario. Así que para alguien con su sucursal cargada, el único camino a NULL es que **`auth.uid()` sea NULL**: el JWT no era válido en ese instante. El header sigue puesto porque vive en memoria del tab, y por eso el error termina hablando de sucursales.

## Por qué no fue un cambio nuestro

- El preventista **creó pedidos antes y después**, el mismo día y en la misma sucursal (4444, 4445, 4446).
- En la ventana de logs, **todos** los `crear_pedido_completo` devolvieron **200**.
- Los logs de auth muestran el **servicio reiniciándose** (`GoTrue API started`, `http server closed`, `apiworker: … exited`) con 38 logins y 37 refresh de token alrededor.
- Su fila en `usuario_sucursales` está sana: sucursal 1, `es_default`, activo.
- Nada de lo desplegado toca auth, el header, `current_sucursal_id()` ni `crear_pedido_completo`.

## El fix

Legibilidad y recuperación, no un parche al síntoma:

1. Se detecta el caso (`src/utils/sesionVencida.ts`).
2. Se **renueva la sesión en el acto**, para que el reintento del usuario funcione.
3. Se avisa qué pasó de verdad: *"Tu sesión se había vencido y la renovamos. Tocá Confirmar de nuevo — el pedido no se guardó."* Y si no se puede renovar: *"Tu sesión venció. Cerrá sesión y volvé a entrar."*

**No se reintenta el pedido solo.** La creación online no lleva clave de idempotencia (la de la cola offline sí), así que un reintento automático podría duplicarlo. Y sí se puede afirmar que el pedido no se guardó: el RPC valida la sucursal antes de escribir nada.

Los errores de negocio (stock insuficiente, mínimos de venta) siguen mostrándose tal cual — hay test para eso.

## Verificación

Typecheck, lint, build y **962 tests** (7 nuevos: reconocimiento del mensaje, los tres desenlaces del refresh, y que no se coma errores de negocio).

Nota: un caso de test usa el error devuelto por `supabase-js` en vez de un throw, porque `mockRejectedValue` crea la promesa rechazada al configurar el mock y el runner la marca como no manejada antes de que el código la consuma. El `try/catch` de la función queda igual como red de seguridad.

🤖 Generated with [Claude Code](https://claude.com/claude-code)