### PR TITLE
fix(pagos): el saldo a favor deja de quedar atrapado en boletas cobradas

### DIFF
--- a/migrations/165_saldo_a_favor_no_queda_atrapado.sql
+++ b/migrations/165_saldo_a_favor_no_queda_atrapado.sql
@@ -1,0 +1,565 @@
+-- 165_saldo_a_favor_no_queda_atrapado.sql
+--
+-- PROBLEMA
+-- Cuando se baja el total de una boleta YA cobrada (por salvedad o por edicion
+-- manual de los items), `pedidos.total` baja pero `pagos` y `pedidos.monto_pagado`
+-- quedan intactos. El pedido queda con monto_pagado > total y ese excedente queda
+-- enterrado en una boleta cerrada.
+--
+-- Efecto visible: la ficha del cliente y la lista de boletas dejan de coincidir.
+--   saldo_cuenta   = SUM(pedidos: total - monto_pagado) - SUM(pagos sin pedido)
+--   lista boletas  = SUM(pedidos: GREATEST(total - monto_pagado, 0))
+-- La ficha netea el negativo, la lista lo clampa a cero. La diferencia es exactamente
+-- el monto de la salvedad. Caso testigo: cliente 815 (#799 "Despensa Dalma"),
+-- pedido 3329, salvedad de $8.300 el 2026-07-08 sobre una boleta ya cobrada.
+--
+-- Ademas `registrar_pago_cliente_fifo` solo recorre pedidos con total > monto_pagado,
+-- asi que nunca consume el credito preexistente: el descuadre no se corrige solo.
+--
+-- SOLUCION
+-- Invariante nuevo: ningun pedido vigente puede tener monto_pagado > total. El
+-- excedente vive siempre como fila de `pagos` con pedido_id IS NULL (saldo a favor),
+-- que es la unica representacion del credito. El saldo_cuenta del cliente NO cambia
+-- al mover el excedente de una forma a la otra: -8300 via (total - monto_pagado)
+-- pasa a ser -8300 via (pago sin pedido). Solo cambia donde vive el credito.
+--
+--   1. desafectar_sobrepago_pedido()  -> saca el excedente de la boleta a saldo a favor
+--   2. aplicar_credito_cliente()      -> imputa el saldo a favor a boletas pendientes (FIFO)
+--   3. trigger AFTER UPDATE OF total  -> corre 1 y 2 ante CUALQUIER cambio de total,
+--                                        no solo salvedades (cubre la edicion manual)
+--   4. las dos RPCs FIFO consumen el credito antes de imputar la plata nueva
+--
+-- Mover un pago ya cobrado entre boletas del mismo cliente preserva fecha, forma de
+-- pago y monto total, asi que ni la caja del dia ni la rendicion cambian: solo cambia
+-- a que boleta se aplica. Por eso el guard de caja cerrada acepta un escape explicito
+-- para estas reimputaciones internas.
+
+-- ---------------------------------------------------------------------------
+-- 1. Escape del guard de caja cerrada para reimputaciones internas
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.guard_pago_fecha_cerrada()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $function$
+DECLARE
+  v_limite date;
+BEGIN
+  IF NEW.sucursal_id IS NULL OR NEW.fecha IS NULL THEN
+    RETURN NEW;
+  END IF;
+
+  -- Reimputacion interna (mig 165): mover plata ya cobrada entre boletas del mismo
+  -- cliente no altera el total del dia ni la rendicion, solo a que boleta se aplica.
+  -- El GUC es transaction-scoped y lo setean unicamente las funciones de abajo.
+  IF current_setting('app.reimputacion_pagos', true) = 'on' THEN
+    RETURN NEW;
+  END IF;
+
+  v_limite := public.ultima_fecha_caja_cerrada(NEW.sucursal_id);
+
+  IF v_limite IS NOT NULL AND NEW.fecha <= v_limite THEN
+    RAISE EXCEPTION 'La caja de la sucursal esta cerrada hasta el % (rendicion controlada). No se puede registrar/editar un pago con fecha %. Reabri la rendicion de ese dia para hacer cambios.',
+      to_char(v_limite, 'DD/MM/YYYY'), to_char(NEW.fecha, 'DD/MM/YYYY')
+      USING ERRCODE = '42501';
+  END IF;
+
+  RETURN NEW;
+END;
+$function$;
+
+-- ---------------------------------------------------------------------------
+-- 2. desafectar_sobrepago_pedido: excedente de la boleta -> saldo a favor
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.desafectar_sobrepago_pedido(p_pedido_id bigint)
+RETURNS numeric
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $function$
+DECLARE
+  v_pedido      RECORD;
+  v_pago        RECORD;
+  v_excedente   numeric;
+  v_mover       numeric;
+  v_desafectado numeric := 0;
+BEGIN
+  SELECT id, total, COALESCE(monto_pagado, 0) AS pagado, estado
+    INTO v_pedido
+    FROM pedidos
+   WHERE id = p_pedido_id;
+
+  IF NOT FOUND THEN
+    RETURN 0;
+  END IF;
+
+  -- En cancelados/anulados el pedido no aporta al saldo; su imputacion se resuelve
+  -- por el flujo de cancelacion, no aca.
+  IF v_pedido.estado IN ('cancelado', 'anulado') THEN
+    RETURN 0;
+  END IF;
+
+  v_excedente := v_pedido.pagado - v_pedido.total;
+  IF v_excedente <= 0.005 THEN
+    RETURN 0;
+  END IF;
+
+  PERFORM set_config('app.reimputacion_pagos', 'on', true);
+
+  -- Se desafecta desde el pago mas nuevo: el excedente es lo ultimo que entro.
+  FOR v_pago IN
+    SELECT id, monto
+      FROM pagos
+     WHERE pedido_id = p_pedido_id
+     ORDER BY fecha DESC, id DESC
+  LOOP
+    EXIT WHEN v_excedente <= 0.005;
+
+    v_mover := LEAST(v_pago.monto, v_excedente);
+
+    IF v_mover >= v_pago.monto - 0.005 THEN
+      -- el pago entero pasa a saldo a favor
+      UPDATE pagos
+         SET pedido_id = NULL,
+             notas = trim(COALESCE(notas, '') || ' [saldo a favor]')
+       WHERE id = v_pago.id;
+    ELSE
+      -- se parte: queda imputado lo que entra en el total, el resto va a saldo a favor
+      UPDATE pagos SET monto = monto - v_mover WHERE id = v_pago.id;
+
+      INSERT INTO pagos (
+        cliente_id, pedido_id, monto, forma_pago, fecha,
+        referencia, notas, usuario_id, sucursal_id
+      )
+      SELECT cliente_id, NULL, v_mover, forma_pago, fecha,
+             referencia, trim(COALESCE(notas, '') || ' [saldo a favor]'),
+             usuario_id, sucursal_id
+        FROM pagos
+       WHERE id = v_pago.id;
+    END IF;
+
+    v_excedente   := v_excedente - v_mover;
+    v_desafectado := v_desafectado + v_mover;
+  END LOOP;
+
+  PERFORM set_config('app.reimputacion_pagos', 'off', true);
+
+  RETURN v_desafectado;
+END;
+$function$;
+
+-- ---------------------------------------------------------------------------
+-- 3. aplicar_credito_cliente: saldo a favor -> boletas pendientes (FIFO)
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.aplicar_credito_cliente(
+  p_cliente_id  bigint,
+  p_sucursal_id bigint
+)
+RETURNS numeric
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $function$
+DECLARE
+  v_credito   RECORD;
+  v_pedido    RECORD;
+  v_restante  numeric;
+  v_aplicar   numeric;
+  v_aplicado  numeric := 0;
+  v_vueltas   integer;
+BEGIN
+  IF p_cliente_id IS NULL OR p_sucursal_id IS NULL THEN
+    RETURN 0;
+  END IF;
+
+  PERFORM set_config('app.reimputacion_pagos', 'on', true);
+
+  FOR v_credito IN
+    SELECT id, monto
+      FROM pagos
+     WHERE cliente_id = p_cliente_id
+       AND sucursal_id = p_sucursal_id
+       AND pedido_id IS NULL
+     ORDER BY fecha ASC, id ASC
+  LOOP
+    v_restante := v_credito.monto;
+    v_vueltas  := 0;
+
+    LOOP
+      EXIT WHEN v_restante <= 0.005;
+
+      -- Se relee en cada vuelta a proposito: el trigger de monto_pagado ya actualizo
+      -- la boleta anterior, asi que esta consulta ve el estado fresco.
+      SELECT id, total - COALESCE(monto_pagado, 0) AS falta
+        INTO v_pedido
+        FROM pedidos
+       WHERE cliente_id = p_cliente_id
+         AND sucursal_id = p_sucursal_id
+         AND estado NOT IN ('cancelado', 'anulado')
+         AND total > COALESCE(monto_pagado, 0)
+       ORDER BY fecha ASC, id ASC
+       LIMIT 1;
+
+      EXIT WHEN NOT FOUND;
+
+      v_vueltas := v_vueltas + 1;
+      EXIT WHEN v_vueltas > 500;  -- backstop, no deberia alcanzarse nunca
+
+      v_aplicar := LEAST(v_restante, v_pedido.falta);
+
+      IF v_aplicar >= v_restante - 0.005 THEN
+        -- el credito entra entero en esta boleta
+        UPDATE pagos
+           SET pedido_id = v_pedido.id,
+               notas = NULLIF(trim(replace(COALESCE(notas, ''), '[saldo a favor]', '')), '')
+         WHERE id = v_credito.id;
+
+        v_aplicado := v_aplicado + v_restante;
+        v_restante := 0;
+      ELSE
+        -- alcanza para cerrar esta boleta y sobra: se parte
+        UPDATE pagos SET monto = monto - v_aplicar WHERE id = v_credito.id;
+
+        INSERT INTO pagos (
+          cliente_id, pedido_id, monto, forma_pago, fecha,
+          referencia, notas, usuario_id, sucursal_id
+        )
+        SELECT cliente_id, v_pedido.id, v_aplicar, forma_pago, fecha, referencia,
+               NULLIF(trim(replace(COALESCE(notas, ''), '[saldo a favor]', '')), ''),
+               usuario_id, sucursal_id
+          FROM pagos
+         WHERE id = v_credito.id;
+
+        v_aplicado := v_aplicado + v_aplicar;
+        v_restante := v_restante - v_aplicar;
+      END IF;
+    END LOOP;
+  END LOOP;
+
+  PERFORM set_config('app.reimputacion_pagos', 'off', true);
+
+  RETURN v_aplicado;
+END;
+$function$;
+
+-- ---------------------------------------------------------------------------
+-- 4. Trigger: cualquier cambio de total reconcilia la imputacion de los pagos
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.pedidos_reconciliar_pagos()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $function$
+BEGIN
+  -- Defensa contra reentrada. En la practica no se alcanza (las cascadas internas
+  -- actualizan monto_pagado, no total), pero el trigger toca pagos y no conviene
+  -- depender de eso.
+  IF current_setting('app.reimputacion_pagos', true) = 'on' THEN
+    RETURN NULL;
+  END IF;
+
+  -- Bajo el total: el excedente cobrado sale de la boleta.
+  PERFORM public.desafectar_sobrepago_pedido(NEW.id);
+  -- Subio el total (o quedo credito suelto): se consume contra lo que el cliente debe.
+  PERFORM public.aplicar_credito_cliente(NEW.cliente_id, NEW.sucursal_id);
+
+  RETURN NULL;
+END;
+$function$;
+
+-- El nombre arranca con zzz_ a proposito: los triggers AFTER corren en orden
+-- alfabetico y este tiene que ser el ultimo, cuando trigger_actualizar_saldo_pedido
+-- ya contabilizo el cambio de total.
+DROP TRIGGER IF EXISTS zzz_pedidos_reconciliar_pagos ON public.pedidos;
+CREATE TRIGGER zzz_pedidos_reconciliar_pagos
+AFTER UPDATE OF total ON public.pedidos
+FOR EACH ROW
+WHEN (NEW.total IS DISTINCT FROM OLD.total
+      AND NEW.estado NOT IN ('cancelado', 'anulado'))
+EXECUTE FUNCTION public.pedidos_reconciliar_pagos();
+
+-- ---------------------------------------------------------------------------
+-- 5. Las RPCs FIFO consumen el credito antes de imputar la plata nueva
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.registrar_pago_cliente_fifo(
+  p_cliente_id bigint,
+  p_monto numeric,
+  p_forma_pago text,
+  p_fecha date DEFAULT CURRENT_DATE,
+  p_referencia text DEFAULT NULL::text,
+  p_notas text DEFAULT NULL::text
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $function$
+DECLARE
+  v_sucursal_id bigint := current_sucursal_id();
+  v_acting_user uuid := auth.uid();
+  v_rol text;
+  v_restante numeric := p_monto;
+  v_aplicar numeric;
+  v_pedido record;
+  v_pago_id bigint;
+  v_pago_ids jsonb := '[]'::jsonb;
+  v_aplicaciones jsonb := '[]'::jsonb;
+  v_credito_aplicado numeric := 0;
+BEGIN
+  IF v_sucursal_id IS NULL THEN
+    RAISE EXCEPTION 'No hay sucursal activa' USING ERRCODE = '42501';
+  END IF;
+
+  IF p_monto IS NULL OR p_monto <= 0 THEN
+    RAISE EXCEPTION 'Monto debe ser mayor a 0' USING ERRCODE = '22023';
+  END IF;
+
+  IF p_forma_pago IS NULL OR length(trim(p_forma_pago)) = 0 THEN
+    RAISE EXCEPTION 'Forma de pago obligatoria' USING ERRCODE = '22023';
+  END IF;
+
+  SELECT rol INTO v_rol FROM perfiles WHERE id = v_acting_user;
+  IF v_rol IS NULL OR v_rol NOT IN ('admin', 'encargado') THEN
+    RAISE EXCEPTION 'No autorizado: solo admin o encargado pueden registrar pagos desde ficha de cliente'
+      USING ERRCODE = '42501';
+  END IF;
+
+  IF v_rol = 'encargado' THEN
+    IF p_fecha <> CURRENT_DATE THEN
+      RAISE EXCEPTION 'Encargado solo puede registrar pagos con fecha de hoy'
+        USING ERRCODE = '42501';
+    END IF;
+    IF public.rendicion_dia_cerrada(p_fecha, v_sucursal_id) THEN
+      RAISE EXCEPTION 'Rendicion ya cerrada para esta fecha. Pedi a un admin.'
+        USING ERRCODE = '42501';
+    END IF;
+  END IF;
+
+  -- Primero se gasta el saldo a favor que el cliente ya tenia (mig 165), recien
+  -- despues se imputa la plata nueva. Sin esto el credito no se consume nunca.
+  v_credito_aplicado := public.aplicar_credito_cliente(p_cliente_id, v_sucursal_id);
+
+  FOR v_pedido IN
+    SELECT id, total, COALESCE(monto_pagado, 0) AS pagado, fecha
+    FROM pedidos
+    WHERE cliente_id = p_cliente_id
+      AND sucursal_id = v_sucursal_id
+      AND estado <> 'cancelado'
+      AND COALESCE(estado_pago, 'pendiente') <> 'pagado'
+      AND total > COALESCE(monto_pagado, 0)
+    ORDER BY fecha ASC, id ASC
+  LOOP
+    EXIT WHEN v_restante <= 0;
+    v_aplicar := LEAST(v_restante, v_pedido.total - v_pedido.pagado);
+
+    INSERT INTO pagos (
+      cliente_id, pedido_id, monto, forma_pago, fecha,
+      referencia, notas, usuario_id, sucursal_id
+    )
+    VALUES (
+      p_cliente_id, v_pedido.id, v_aplicar, p_forma_pago, p_fecha,
+      p_referencia, p_notas, v_acting_user, v_sucursal_id
+    )
+    RETURNING id INTO v_pago_id;
+
+    v_pago_ids := v_pago_ids || to_jsonb(v_pago_id);
+    v_aplicaciones := v_aplicaciones || jsonb_build_object(
+      'pago_id', v_pago_id,
+      'pedido_id', v_pedido.id,
+      'pedido_fecha', v_pedido.fecha,
+      'monto', v_aplicar
+    );
+
+    v_restante := v_restante - v_aplicar;
+  END LOOP;
+
+  IF v_restante > 0 THEN
+    INSERT INTO pagos (
+      cliente_id, pedido_id, monto, forma_pago, fecha,
+      referencia, notas, usuario_id, sucursal_id
+    )
+    VALUES (
+      p_cliente_id, NULL, v_restante, p_forma_pago, p_fecha,
+      p_referencia,
+      COALESCE(NULLIF(p_notas, '') || ' ', '') || '[saldo a favor]',
+      v_acting_user, v_sucursal_id
+    )
+    RETURNING id INTO v_pago_id;
+
+    v_pago_ids := v_pago_ids || to_jsonb(v_pago_id);
+    v_aplicaciones := v_aplicaciones || jsonb_build_object(
+      'pago_id', v_pago_id,
+      'pedido_id', NULL,
+      'monto', v_restante,
+      'saldo_a_favor', true
+    );
+  END IF;
+
+  RETURN jsonb_build_object(
+    'success', true,
+    'monto_total', p_monto,
+    'sobrante', v_restante,
+    'credito_aplicado', v_credito_aplicado,
+    'pago_ids', v_pago_ids,
+    'aplicaciones', v_aplicaciones
+  );
+END;
+$function$;
+
+CREATE OR REPLACE FUNCTION public.registrar_pago_combinado_cliente_fifo(
+  p_cliente_id bigint,
+  p_metodos jsonb,
+  p_fecha date DEFAULT CURRENT_DATE,
+  p_referencia text DEFAULT NULL::text,
+  p_notas text DEFAULT NULL::text
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $function$
+DECLARE
+  v_sucursal_id bigint := current_sucursal_id();
+  v_acting_user uuid := auth.uid();
+  v_rol text;
+  v_metodo jsonb;
+  v_forma text;
+  v_monto numeric;
+  v_restante numeric;
+  v_aplicar numeric;
+  v_pedido record;
+  v_pago_id bigint;
+  v_pago_ids jsonb := '[]'::jsonb;
+  v_aplicaciones jsonb := '[]'::jsonb;
+  v_monto_total numeric := 0;
+  v_sobrante_total numeric := 0;
+  v_notas_imputado text;
+  v_credito_aplicado numeric := 0;
+BEGIN
+  IF v_sucursal_id IS NULL THEN
+    RAISE EXCEPTION 'No hay sucursal activa' USING ERRCODE = '42501';
+  END IF;
+
+  IF p_metodos IS NULL OR jsonb_typeof(p_metodos) <> 'array' OR jsonb_array_length(p_metodos) = 0 THEN
+    RAISE EXCEPTION 'Debe enviar al menos una forma de pago' USING ERRCODE = '22023';
+  END IF;
+
+  SELECT rol INTO v_rol FROM perfiles WHERE id = v_acting_user;
+  IF v_rol IS NULL OR v_rol NOT IN ('admin', 'encargado') THEN
+    RAISE EXCEPTION 'No autorizado: solo admin o encargado pueden registrar pagos desde ficha de cliente'
+      USING ERRCODE = '42501';
+  END IF;
+
+  IF v_rol = 'encargado' THEN
+    IF p_fecha <> CURRENT_DATE THEN
+      RAISE EXCEPTION 'Encargado solo puede registrar pagos con fecha de hoy'
+        USING ERRCODE = '42501';
+    END IF;
+    IF public.rendicion_dia_cerrada(p_fecha, v_sucursal_id) THEN
+      RAISE EXCEPTION 'Rendicion ya cerrada para esta fecha. Pedi a un admin.'
+        USING ERRCODE = '42501';
+    END IF;
+  END IF;
+
+  FOR v_metodo IN SELECT * FROM jsonb_array_elements(p_metodos) LOOP
+    v_monto := NULLIF(v_metodo->>'monto', '')::numeric;
+    v_forma := v_metodo->>'forma_pago';
+    IF v_monto IS NULL OR v_monto <= 0 THEN
+      RAISE EXCEPTION 'Cada forma de pago debe tener un monto mayor a 0' USING ERRCODE = '22023';
+    END IF;
+    IF v_forma IS NULL OR length(trim(v_forma)) = 0 THEN
+      RAISE EXCEPTION 'Forma de pago obligatoria' USING ERRCODE = '22023';
+    END IF;
+    v_monto_total := v_monto_total + v_monto;
+  END LOOP;
+
+  v_notas_imputado := NULLIF(trim(COALESCE(p_notas, '') || ' [pago combinado]'), '');
+
+  -- Igual que en el FIFO simple: primero se gasta el credito preexistente (mig 165).
+  v_credito_aplicado := public.aplicar_credito_cliente(p_cliente_id, v_sucursal_id);
+
+  FOR v_metodo IN SELECT * FROM jsonb_array_elements(p_metodos) LOOP
+    v_monto := (v_metodo->>'monto')::numeric;
+    v_forma := trim(v_metodo->>'forma_pago');
+    v_restante := v_monto;
+
+    FOR v_pedido IN
+      SELECT id, total, COALESCE(monto_pagado, 0) AS pagado, fecha
+      FROM pedidos
+      WHERE cliente_id = p_cliente_id
+        AND sucursal_id = v_sucursal_id
+        AND estado <> 'cancelado'
+        AND COALESCE(estado_pago, 'pendiente') <> 'pagado'
+        AND total > COALESCE(monto_pagado, 0)
+      ORDER BY fecha ASC, id ASC
+    LOOP
+      EXIT WHEN v_restante <= 0;
+      v_aplicar := LEAST(v_restante, v_pedido.total - v_pedido.pagado);
+
+      INSERT INTO pagos (
+        cliente_id, pedido_id, monto, forma_pago, fecha,
+        referencia, notas, usuario_id, sucursal_id
+      )
+      VALUES (
+        p_cliente_id, v_pedido.id, v_aplicar, v_forma, p_fecha,
+        p_referencia, v_notas_imputado, v_acting_user, v_sucursal_id
+      )
+      RETURNING id INTO v_pago_id;
+
+      v_pago_ids := v_pago_ids || to_jsonb(v_pago_id);
+      v_aplicaciones := v_aplicaciones || jsonb_build_object(
+        'pago_id', v_pago_id,
+        'pedido_id', v_pedido.id,
+        'pedido_fecha', v_pedido.fecha,
+        'forma_pago', v_forma,
+        'monto', v_aplicar
+      );
+
+      v_restante := v_restante - v_aplicar;
+    END LOOP;
+
+    IF v_restante > 0 THEN
+      INSERT INTO pagos (
+        cliente_id, pedido_id, monto, forma_pago, fecha,
+        referencia, notas, usuario_id, sucursal_id
+      )
+      VALUES (
+        p_cliente_id, NULL, v_restante, v_forma, p_fecha,
+        p_referencia,
+        trim(COALESCE(p_notas, '') || ' [pago combinado] [saldo a favor]'),
+        v_acting_user, v_sucursal_id
+      )
+      RETURNING id INTO v_pago_id;
+
+      v_pago_ids := v_pago_ids || to_jsonb(v_pago_id);
+      v_aplicaciones := v_aplicaciones || jsonb_build_object(
+        'pago_id', v_pago_id,
+        'pedido_id', NULL,
+        'forma_pago', v_forma,
+        'monto', v_restante,
+        'saldo_a_favor', true
+      );
+
+      v_sobrante_total := v_sobrante_total + v_restante;
+    END IF;
+  END LOOP;
+
+  RETURN jsonb_build_object(
+    'success', true,
+    'monto_total', v_monto_total,
+    'sobrante', v_sobrante_total,
+    'credito_aplicado', v_credito_aplicado,
+    'pago_ids', v_pago_ids,
+    'aplicaciones', v_aplicaciones
+  );
+END;
+$function$;
+
+-- ---------------------------------------------------------------------------
+-- 6. Helpers internos: solo se llaman desde triggers y RPCs SECURITY DEFINER
+-- ---------------------------------------------------------------------------
+REVOKE ALL ON FUNCTION public.desafectar_sobrepago_pedido(bigint) FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.aplicar_credito_cliente(bigint, bigint) FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.pedidos_reconciliar_pagos() FROM PUBLIC, anon, authenticated;

--- a/migrations/166_backfill_sobrepagos_atrapados.sql
+++ b/migrations/166_backfill_sobrepagos_atrapados.sql
@@ -1,0 +1,88 @@
+-- 166_backfill_sobrepagos_atrapados.sql
+--
+-- Corrige los sobrepagos historicos que quedaron enterrados en boletas cerradas
+-- antes de la mig 165 (ver ahi el detalle del problema y del invariante).
+--
+-- Al 2026-08-05 habia 9 pedidos con monto_pagado > total, por $319.920. En todos
+-- el patron es el mismo: se cobro la boleta completa y DESPUES se bajo el total,
+-- por salvedad (1142, 1148, 1656, 3053, 3329) o por edicion manual (1821, 2083, 3251).
+--
+-- Que hace: saca el excedente de cada boleta a saldo a favor y lo imputa a las
+-- boletas que el cliente todavia debe (FIFO). No mueve `saldo_cuenta` de nadie
+-- ni crea o destruye plata: el credito ya estaba contabilizado en la ficha via
+-- (total - monto_pagado) negativo, solo cambia donde vive.
+--
+-- EXCLUSION: el pedido 3602 (cliente 303 "MARCOS CHOFER", $222.560) NO entra. Ahi
+-- no hubo salvedad: tiene el MISMO pago de $111.280 insertado 3 veces con 7 y 10
+-- segundos de diferencia (pagos 3280/3281/3282, 2026-07-13) — un doble/triple clic
+-- en el boton de cobrar, no un credito real del cliente. Convertirlo en saldo a
+-- favor propagaria el error a boletas futuras. Requiere decision humana: si se
+-- confirma que fue un error de carga, se borran los pagos 3281 y 3282.
+
+DO $backfill$
+DECLARE
+  v_pedido            RECORD;
+  v_cliente           RECORD;
+  v_saldo_antes       numeric;
+  v_saldo_despues     numeric;
+  v_plata_antes       numeric;
+  v_plata_despues     numeric;
+  v_desafectado       numeric := 0;
+  v_aplicado          numeric := 0;
+  v_restantes         integer;
+BEGIN
+  SELECT COALESCE(SUM(saldo_cuenta), 0) INTO v_saldo_antes FROM clientes;
+  SELECT COALESCE(SUM(monto), 0)        INTO v_plata_antes FROM pagos;
+
+  -- 1. Sacar el excedente de cada boleta sobrepagada
+  FOR v_pedido IN
+    SELECT id, cliente_id, sucursal_id, (monto_pagado - total) AS excedente
+      FROM pedidos
+     WHERE estado NOT IN ('cancelado', 'anulado')
+       AND monto_pagado > total + 0.005
+       AND id <> 3602            -- ver EXCLUSION arriba
+     ORDER BY id
+  LOOP
+    v_desafectado := v_desafectado + public.desafectar_sobrepago_pedido(v_pedido.id);
+    RAISE NOTICE 'pedido % (cliente %): desafectados %',
+      v_pedido.id, v_pedido.cliente_id, v_pedido.excedente;
+  END LOOP;
+
+  -- 2. Imputar el credito liberado a lo que cada cliente todavia debe
+  FOR v_cliente IN
+    SELECT DISTINCT cliente_id, sucursal_id
+      FROM pagos
+     WHERE pedido_id IS NULL
+     ORDER BY cliente_id
+  LOOP
+    v_aplicado := v_aplicado + public.aplicar_credito_cliente(v_cliente.cliente_id, v_cliente.sucursal_id);
+  END LOOP;
+
+  SELECT COALESCE(SUM(saldo_cuenta), 0) INTO v_saldo_despues FROM clientes;
+  SELECT COALESCE(SUM(monto), 0)        INTO v_plata_despues FROM pagos;
+
+  SELECT count(*) INTO v_restantes
+    FROM pedidos
+   WHERE estado NOT IN ('cancelado', 'anulado')
+     AND monto_pagado > total + 0.005
+     AND id <> 3602;
+
+  RAISE NOTICE 'desafectado=% aplicado=% saldo %->% plata %->%',
+    v_desafectado, v_aplicado, v_saldo_antes, v_saldo_despues, v_plata_antes, v_plata_despues;
+
+  -- Guardas: si alguna no se cumple, la migracion aborta y no queda aplicada a medias.
+  IF abs(v_saldo_despues - v_saldo_antes) > 0.005 THEN
+    RAISE EXCEPTION 'ABORTA: el saldo total de clientes cambio (% -> %). El backfill solo debe mover donde vive el credito, no cuanto es.',
+      v_saldo_antes, v_saldo_despues;
+  END IF;
+
+  IF abs(v_plata_despues - v_plata_antes) > 0.005 THEN
+    RAISE EXCEPTION 'ABORTA: el total de pagos cambio (% -> %). No se debe crear ni destruir plata.',
+      v_plata_antes, v_plata_despues;
+  END IF;
+
+  IF v_restantes > 0 THEN
+    RAISE EXCEPTION 'ABORTA: quedaron % pedidos con monto_pagado > total', v_restantes;
+  END IF;
+END;
+$backfill$;

--- a/migrations/MANIFEST.md
+++ b/migrations/MANIFEST.md
@@ -91,6 +91,7 @@ desfasan y **se realinean en `101`**:
 | `105_auditoria_integridad.sql` | `105_…` + `105_…_ventana_2h` + `105_…_fix_cc_saldo_a_favor` |
 | `123_terna_ingresos_pedidos.sql` | `123_…` (DDL+backfill+función) + `123_…_rpcs` (crear/bot) + `123_…_rpcs2` (editar/salvedades/cambiar tipo) — aplicado en 3 tandas por tamaño |
 | `139_movimientos_stock_preventivo.sql` | `movimientos_stock_preventivo_ddl` + `_crear` + `_aceptar` + `_denegar_cancelar` + `_editar` (5 filas, sin prefijo) |
+| `165_saldo_a_favor_no_queda_atrapado.sql` | `165_…` (guard + helpers + trigger) + `165_…_rpcs_fifo` (las 2 RPCs FIFO) — aplicado en 2 tandas por tamaño |
 | (bot 014–020) | hotfix `020_bot_fix_pgcrypto_schema` plegado en la tanda, sin archivo propio |
 
 **Cadena `reporte_gerencial`** (reescrita ~9 veces por `CREATE OR REPLACE`): el repo versiona

--- a/src/components/modals/ModalRegistrarPago.tsx
+++ b/src/components/modals/ModalRegistrarPago.tsx
@@ -295,6 +295,11 @@ export default function ModalRegistrarPago({
             <p className="text-gray-600 dark:text-gray-400 mb-4">
               Total imputado: <span className="font-bold text-green-600">{formatCurrency(resultadoFIFO.montoTotal)}</span> para {cliente.nombre_fantasia}
             </p>
+            {resultadoFIFO.creditoAplicado > 0 && (
+              <p className="text-sm text-emerald-700 dark:text-emerald-300 mb-4 px-3 py-2 bg-emerald-50 dark:bg-emerald-900/20 rounded-lg">
+                Además se usó {formatCurrency(resultadoFIFO.creditoAplicado)} de saldo a favor que el cliente ya tenía.
+              </p>
+            )}
           </div>
           <div className="mt-2 space-y-2">
             <p className="text-sm font-medium text-gray-700 dark:text-gray-300">Desglose:</p>

--- a/src/hooks/supabase/usePagos.ts
+++ b/src/hooks/supabase/usePagos.ts
@@ -160,6 +160,7 @@ export function usePagos(): UsePagosReturnExtended {
         sobrante?: number
         monto_total?: number
         aplicaciones?: PagoFifoAplicacion[]
+        credito_aplicado?: number
       }
 
       return {
@@ -167,6 +168,7 @@ export function usePagos(): UsePagosReturnExtended {
         sobrante: Number(raw.sobrante ?? 0),
         montoTotal: Number(raw.monto_total ?? input.monto),
         aplicaciones: raw.aplicaciones ?? [],
+        creditoAplicado: Number(raw.credito_aplicado ?? 0),
       }
     } catch (error) {
       notifyError('Error al registrar pago: ' + (error as Error).message)
@@ -203,6 +205,7 @@ export function usePagos(): UsePagosReturnExtended {
         sobrante?: number
         monto_total?: number
         aplicaciones?: PagoFifoAplicacion[]
+        credito_aplicado?: number
       }
 
       return {
@@ -210,6 +213,7 @@ export function usePagos(): UsePagosReturnExtended {
         sobrante: Number(raw.sobrante ?? 0),
         montoTotal: Number(raw.monto_total ?? 0),
         aplicaciones: raw.aplicaciones ?? [],
+        creditoAplicado: Number(raw.credito_aplicado ?? 0),
       }
     } catch (error) {
       notifyError('Error al registrar pago: ' + (error as Error).message)

--- a/src/types/hooks.ts
+++ b/src/types/hooks.ts
@@ -805,6 +805,12 @@ export interface RegistrarPagoFifoResult {
   sobrante: number;
   montoTotal: number;
   aplicaciones: PagoFifoAplicacion[];
+  /**
+   * Saldo a favor que el cliente ya tenía y se consumió contra sus boletas antes
+   * de imputar esta plata (mig 165). No sale de este pago: explica por qué se
+   * cancelaron más boletas de las que cubre `montoTotal`.
+   */
+  creditoAplicado: number;
 }
 
 /**


### PR DESCRIPTION
## El caso

Reportado desde Tucumán: en la ficha de **Despensa Dalma** (#799) el saldo decía **$39.410** pero la única boleta impaga (#4452) mostraba **$47.710** pendiente. Diferencia: **$8.300**.

## Qué pasaba

El **2026-07-08** se cobró el pedido **#3329** completo ($21.700) y **cuatro minutos después** se cargó una salvedad de $8.300 (`cliente_rechaza`), que bajó el total a $13.400. El pago quedó intacto.

`registrar_salvedad` recalcula `pedidos.total` hacia abajo pero **no toca `pagos` ni `monto_pagado`**. La boleta quedó con `monto_pagado (21.700) > total (13.400)` y esos $8.300 quedaron enterrados en una boleta ya cerrada.

Los dos números que el operador comparaba salen de fórmulas distintas:

```
saldo_cuenta  = SUM(pedidos: total - monto_pagado) - SUM(pagos sin pedido)   <- netea el negativo
lista boletas = SUM(pedidos: GREATEST(total - monto_pagado, 0))              <- lo clampa a cero
```

La ficha absorbía el crédito, la lista no. La diferencia era exactamente el monto de la salvedad.

Y no se corregía solo: `registrar_pago_cliente_fifo` sólo recorre pedidos con `total > monto_pagado`, así que **nunca consume el crédito preexistente**.

## El arreglo — mig 165 (causa)

**Invariante nuevo:** ningún pedido vigente puede tener `monto_pagado > total`. El excedente vive siempre como fila de `pagos` con `pedido_id IS NULL`, que pasa a ser la única representación del crédito.

- `desafectar_sobrepago_pedido()` — excedente → saldo a favor (parte el pago si hace falta).
- `aplicar_credito_cliente()` — saldo a favor → boletas pendientes por FIFO.
- Trigger **`zzz_pedidos_reconciliar_pagos`** `AFTER UPDATE OF total`.
- Las 2 RPCs FIFO consumen el crédito **antes** de imputar la plata nueva y devuelven `credito_aplicado`.
- `guard_pago_fecha_cerrada` acepta un escape para reimputaciones internas.

### Dos decisiones de diseño

**Por qué el trigger va colgado del cambio de `total` y no dentro de `registrar_salvedad`:** de los 8 casos históricos, **3 no fueron salvedades sino ediciones manuales del total** (#1821, #2083, #3251). Parchear la RPC habría dejado esa vía abierta. Colgarlo del cambio de `total` cubre salvedad, edición manual y cualquier vía futura.

**Por qué el prefijo `zzz_`:** los triggers AFTER corren en orden alfabético y este tiene que ejecutarse **después** de `trigger_actualizar_saldo_pedido`, cuando el cambio de total ya fue contabilizado.

**Sobre el escape del guard de caja cerrada:** mover plata ya cobrada entre boletas del mismo cliente preserva fecha, forma de pago y monto total — la caja del día y la rendición no cambian, sólo cambia a qué boleta se aplica. Verificado que el guard **sigue bloqueando** pagos normales en caja cerrada y que el escape no queda pegado.

## Los datos — mig 166 (backfill)

8 boletas históricas, **$97.360**. Lleva guardas que abortan la migración si cambia el saldo total de clientes o el total de pagos: no crea ni destruye plata, sólo mueve dónde vive el crédito.

Los 3 casos que confundían al operador (deuda **y** crédito a la vez):

| Cliente | Pendiente antes | Después | Saldo ficha |
|---|---|---|---|
| #799 Despensa Dalma | $47.710 | **$39.410** | $39.410 ✓ |
| #529 Marina Alfaro | $28.850 | **$22.350** | $22.350 ✓ |
| #396 Tita Maldonado | $78.350 | **$78.300** | $78.300 ✓ |

Los otros 6 pasaron de tener el crédito enterrado a tenerlo visible como saldo a favor (Los Redonditos $10.200, Eugenio Méndez $25.560, Comercial TP $33.300, Juan Romano $6.000, Marcos $7.000, Refugio Comedor $500).

## ⚠️ Caso excluido a propósito

El pedido **#3602** (cliente 303 "MARCOS CHOFER", **−$222.560**) — el más grande — **no entra en el backfill**. Ahí no hubo salvedad: tiene el **mismo pago de $111.280 insertado 3 veces** con 7 y 10 segundos de diferencia (pagos 3280/3281/3282, 2026-07-13). Es un triple clic en el botón de cobrar, no un crédito real del cliente; convertirlo en saldo a favor lo propagaría a boletas futuras.

**Requiere decisión:** si se confirma que fue error de carga, se borran los pagos 3281 y 3282. Aparte, el botón de cobrar no tiene guarda de idempotencia — queda abierto como issue separado.

## Verificación

Todo probado en transacción con `ROLLBACK` **antes** de aplicar a producción:

- Escenario real del 2026-07-08 rebobinado y reejecutado → `saldo` intacto, `plata total` intacta, `pendiente == saldo`, 0 sobrepagos restantes.
- Caso de **caja cerrada** en Taco Pozo (Comercial TP, pago del 01/07 con caja cerrada hasta el 03/08) → el escape funciona.
- **Anulación** de salvedad → revierte sola, la deuda reaparece y la ficha sigue cuadrando.
- **4 casos del guard** → pago normal en caja cerrada bloqueado, reimputación interna permitida, y bloqueo restablecido al apagar el flag.
- Typecheck limpio · **962 tests** en verde.

Migraciones ya aplicadas a prod (3 filas en el ledger: `165`, `165_..._rpcs_fifo`, `166`). MANIFEST actualizado con la consolidación.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
