### PR TITLE
fix(pagos): idempotencia en el registro de pagos contra el doble clic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,6 +52,7 @@ temp/
 backups/
 !supabase/migrations/*.sql
 !scripts/verify-multi-tenant.sql
+!scripts/fix-pedido-3602-pagos-duplicados.sql
 !migrations/*.sql
 !migrations/**/*.sql
 

--- a/migrations/167_pagos_idempotencia_client_request_id.sql
+++ b/migrations/167_pagos_idempotencia_client_request_id.sql
@@ -1,0 +1,372 @@
+-- 167_pagos_idempotencia_client_request_id.sql
+--
+-- PROBLEMA
+-- El registro de pagos no tiene guarda de idempotencia. Si la request llega al
+-- servidor pero la respuesta se pierde (PWA en mobile, "Load failed" de iOS,
+-- red del reparto), el usuario ve un error, vuelve a apretar "Registrar" y se
+-- inserta el pago de nuevo. No hay nada del lado del server que lo frene.
+--
+-- Caso testigo en prod: pedido 3602 (cliente 303 "MARCOS CHOFER") tiene el mismo
+-- pago de $111.280 tres veces — pagos 3280/3281/3282, 2026-07-13 22:53:20 /
+-- 22:53:27 / 22:53:37. Ventana de 17 segundos, montos y forma de pago identicos.
+-- Es el unico sobrepago que la mig 166 dejo sin corregir a proposito (ver ahi la
+-- seccion EXCLUSION): no es credito real del cliente, es un error de carga.
+--
+-- SOLUCION
+-- El mismo patron que ya usa `registrar_salvedad` desde la mig 049: el cliente
+-- genera un UUID por intento de escritura y lo manda; si el servidor ya vio ese
+-- UUID devuelve el resultado de la primera vez en lugar de volver a escribir.
+--
+-- Hay dos caminos de escritura a `pagos` y cada uno necesita su mecanismo:
+--
+--   A) INSERT directo por PostgREST (usePagos.registrarPago / registrarPagosBatch,
+--      que es el camino del cobro de una parada y del modal de pago del pedido).
+--      Una fila por request => alcanza con `pagos.client_request_id` + indice
+--      unico. El reintento choca contra el indice y el front resuelve leyendo la
+--      fila que ya existe.
+--
+--   B) Las 4 RPCs (registrar_pago_cliente_fifo, registrar_pago_combinado_cliente_fifo,
+--      marcar_pagos_masivo, marcar_entrega_y_pago_masivo). Todas pueden insertar
+--      N filas por llamada, asi que no sirve una columna unica en `pagos`. Va un
+--      ledger aparte, `pagos_solicitudes`, con el UUID como PK y el resultado de
+--      la primera ejecucion guardado para poder devolverlo tal cual en el replay.
+--
+-- POR QUE WRAPPERS Y NO `CREATE OR REPLACE` DEL CUERPO
+-- `migrations/` es una vista curada, no un espejo 1:1 de prod (ver MANIFEST.md), y
+-- la mig 100 ya documenta que estas RPCs masivas habian driftado respecto del repo.
+-- Reescribir los cuerpos desde el archivo del repo se llevaria puesto cualquier
+-- cambio que solo viva en prod. Por eso cada RPC se **renombra** a `<nombre>_impl`
+-- (el cuerpo queda intacto, sea cual sea) y se crea un wrapper con el nombre
+-- original + `p_client_request_id`, que hace la dedup y delega. Cero riesgo de
+-- clobber y el diff es auditable.
+--
+-- ORDEN DE DEPLOY: primero esta migracion, despues el frontend. Al reves el front
+-- mandaria `p_client_request_id` a una funcion que todavia no lo acepta (PGRST202).
+-- Al derecho no rompe nada: el parametro tiene DEFAULT NULL y sin UUID el
+-- comportamiento es exactamente el de hoy.
+
+-- ---------------------------------------------------------------------------
+-- 1. Camino A: INSERT directo a `pagos`
+-- ---------------------------------------------------------------------------
+ALTER TABLE public.pagos
+  ADD COLUMN IF NOT EXISTS client_request_id uuid;
+
+COMMENT ON COLUMN public.pagos.client_request_id IS
+  'UUID generado por el cliente para deduplicar reintentos del INSERT directo (mig 167). NULL en filas previas y en las que insertan las RPCs (esas deduplican por pagos_solicitudes).';
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_pagos_client_request_id
+  ON public.pagos (client_request_id)
+  WHERE client_request_id IS NOT NULL;
+
+-- ---------------------------------------------------------------------------
+-- 2. Camino B: ledger de solicitudes para las RPCs
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS public.pagos_solicitudes (
+  client_request_id uuid        PRIMARY KEY,
+  operacion         text        NOT NULL,
+  usuario_id        uuid,
+  sucursal_id       bigint,
+  resultado         jsonb,
+  created_at        timestamptz NOT NULL DEFAULT now()
+);
+
+COMMENT ON TABLE public.pagos_solicitudes IS
+  'Ledger de idempotencia de las RPCs de pagos (mig 167). Una fila por client_request_id con el resultado de la primera ejecucion, que se devuelve tal cual ante un reintento.';
+
+-- Solo la tocan las funciones SECURITY DEFINER de abajo (owner postgres, que
+-- ignora RLS). RLS prendida y sin policies = nadie mas la lee ni la escribe.
+ALTER TABLE public.pagos_solicitudes ENABLE ROW LEVEL SECURITY;
+REVOKE ALL ON TABLE public.pagos_solicitudes FROM PUBLIC, anon, authenticated;
+
+-- Housekeeping: el ledger solo sirve para reintentos, que ocurren en segundos.
+CREATE INDEX IF NOT EXISTS idx_pagos_solicitudes_created_at
+  ON public.pagos_solicitudes (created_at);
+
+-- ---------------------------------------------------------------------------
+-- 3. Helpers del ledger
+-- ---------------------------------------------------------------------------
+
+-- Devuelve NULL  => es la primera vez (o no vino UUID): el caller sigue de largo.
+-- Devuelve jsonb => es un reintento: el caller devuelve eso y no escribe nada.
+--
+-- El advisory lock serializa las llamadas concurrentes con el mismo UUID: el
+-- segundo espera a que el primero commitee (el lock se suelta al final de la
+-- transaccion) y recien ahi lee el resultado ya guardado. Sin el lock, dos
+-- requests simultaneas podrian pasar las dos el chequeo y escribir dos veces.
+CREATE OR REPLACE FUNCTION public.pago_solicitud_abrir(
+  p_client_request_id uuid,
+  p_operacion         text
+) RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $function$
+DECLARE
+  v_resultado jsonb;
+  v_existe    boolean;
+BEGIN
+  IF p_client_request_id IS NULL THEN
+    RETURN NULL;
+  END IF;
+
+  PERFORM pg_advisory_xact_lock(hashtextextended(p_client_request_id::text, 0));
+
+  SELECT true, resultado
+    INTO v_existe, v_resultado
+    FROM pagos_solicitudes
+   WHERE client_request_id = p_client_request_id;
+
+  IF COALESCE(v_existe, false) THEN
+    -- resultado NULL solo puede pasar si la ejecucion original quedo a medias sin
+    -- abortar la transaccion (no deberia ocurrir: un error revierte tambien esta
+    -- fila). Se deja seguir para no dejar el pago sin registrar por un ledger raro.
+    RETURN v_resultado;
+  END IF;
+
+  INSERT INTO pagos_solicitudes (client_request_id, operacion, usuario_id, sucursal_id)
+  VALUES (p_client_request_id, p_operacion, auth.uid(), current_sucursal_id());
+
+  RETURN NULL;
+END;
+$function$;
+
+CREATE OR REPLACE FUNCTION public.pago_solicitud_cerrar(
+  p_client_request_id uuid,
+  p_resultado         jsonb
+) RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $function$
+BEGIN
+  IF p_client_request_id IS NULL THEN
+    RETURN;
+  END IF;
+
+  UPDATE pagos_solicitudes
+     SET resultado = p_resultado
+   WHERE client_request_id = p_client_request_id;
+END;
+$function$;
+
+REVOKE ALL ON FUNCTION public.pago_solicitud_abrir(uuid, text)  FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.pago_solicitud_cerrar(uuid, jsonb) FROM PUBLIC, anon, authenticated;
+
+-- ---------------------------------------------------------------------------
+-- 4. Renombrar las 4 RPCs a `_impl` (el cuerpo que haya en prod, intacto)
+-- ---------------------------------------------------------------------------
+DO $rename$
+BEGIN
+  IF to_regprocedure('public.registrar_pago_cliente_fifo_impl(bigint,numeric,text,date,text,text)') IS NULL THEN
+    ALTER FUNCTION public.registrar_pago_cliente_fifo(bigint,numeric,text,date,text,text)
+      RENAME TO registrar_pago_cliente_fifo_impl;
+  END IF;
+
+  IF to_regprocedure('public.registrar_pago_combinado_cliente_fifo_impl(bigint,jsonb,date,text,text)') IS NULL THEN
+    ALTER FUNCTION public.registrar_pago_combinado_cliente_fifo(bigint,jsonb,date,text,text)
+      RENAME TO registrar_pago_combinado_cliente_fifo_impl;
+  END IF;
+
+  IF to_regprocedure('public.marcar_pagos_masivo_impl(bigint[],text,date)') IS NULL THEN
+    ALTER FUNCTION public.marcar_pagos_masivo(bigint[],text,date)
+      RENAME TO marcar_pagos_masivo_impl;
+  END IF;
+
+  IF to_regprocedure('public.marcar_entrega_y_pago_masivo_impl(bigint[],uuid,text,date)') IS NULL THEN
+    ALTER FUNCTION public.marcar_entrega_y_pago_masivo(bigint[],uuid,text,date)
+      RENAME TO marcar_entrega_y_pago_masivo_impl;
+  END IF;
+END
+$rename$;
+
+-- Las `_impl` dejan de ser invocables desde la app: el unico acceso es via wrapper,
+-- que es quien deduplica.
+REVOKE ALL ON FUNCTION public.registrar_pago_cliente_fifo_impl(bigint,numeric,text,date,text,text)
+  FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.registrar_pago_combinado_cliente_fifo_impl(bigint,jsonb,date,text,text)
+  FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.marcar_pagos_masivo_impl(bigint[],text,date)
+  FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.marcar_entrega_y_pago_masivo_impl(bigint[],uuid,text,date)
+  FROM PUBLIC, anon, authenticated;
+
+-- Por si alguna quedo dando vueltas con la firma vieja de 2 args (pre mig 003).
+DROP FUNCTION IF EXISTS public.marcar_pagos_masivo(bigint[], text);
+
+-- ---------------------------------------------------------------------------
+-- 5. Wrappers idempotentes con el nombre publico de siempre
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.registrar_pago_cliente_fifo(
+  p_cliente_id        bigint,
+  p_monto             numeric,
+  p_forma_pago        text,
+  p_fecha             date  DEFAULT CURRENT_DATE,
+  p_referencia        text  DEFAULT NULL::text,
+  p_notas             text  DEFAULT NULL::text,
+  p_client_request_id uuid  DEFAULT NULL::uuid
+) RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $function$
+DECLARE
+  v_previo    jsonb;
+  v_resultado jsonb;
+BEGIN
+  v_previo := public.pago_solicitud_abrir(p_client_request_id, 'registrar_pago_cliente_fifo');
+  IF v_previo IS NOT NULL THEN
+    RETURN v_previo || jsonb_build_object('idempotent_replay', true);
+  END IF;
+
+  v_resultado := public.registrar_pago_cliente_fifo_impl(
+    p_cliente_id, p_monto, p_forma_pago, p_fecha, p_referencia, p_notas
+  );
+
+  PERFORM public.pago_solicitud_cerrar(p_client_request_id, v_resultado);
+  RETURN v_resultado;
+END;
+$function$;
+
+CREATE OR REPLACE FUNCTION public.registrar_pago_combinado_cliente_fifo(
+  p_cliente_id        bigint,
+  p_metodos           jsonb,
+  p_fecha             date  DEFAULT CURRENT_DATE,
+  p_referencia        text  DEFAULT NULL::text,
+  p_notas             text  DEFAULT NULL::text,
+  p_client_request_id uuid  DEFAULT NULL::uuid
+) RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $function$
+DECLARE
+  v_previo    jsonb;
+  v_resultado jsonb;
+BEGIN
+  v_previo := public.pago_solicitud_abrir(p_client_request_id, 'registrar_pago_combinado_cliente_fifo');
+  IF v_previo IS NOT NULL THEN
+    RETURN v_previo || jsonb_build_object('idempotent_replay', true);
+  END IF;
+
+  v_resultado := public.registrar_pago_combinado_cliente_fifo_impl(
+    p_cliente_id, p_metodos, p_fecha, p_referencia, p_notas
+  );
+
+  PERFORM public.pago_solicitud_cerrar(p_client_request_id, v_resultado);
+  RETURN v_resultado;
+END;
+$function$;
+
+CREATE OR REPLACE FUNCTION public.marcar_pagos_masivo(
+  p_pedido_ids        bigint[],
+  p_forma_pago        text,
+  p_fecha             date DEFAULT CURRENT_DATE,
+  p_client_request_id uuid DEFAULT NULL::uuid
+) RETURNS integer
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $function$
+DECLARE
+  v_previo    jsonb;
+  v_afectados integer;
+BEGIN
+  v_previo := public.pago_solicitud_abrir(p_client_request_id, 'marcar_pagos_masivo');
+  IF v_previo IS NOT NULL THEN
+    RETURN COALESCE((v_previo->>'afectados')::integer, 0);
+  END IF;
+
+  v_afectados := public.marcar_pagos_masivo_impl(p_pedido_ids, p_forma_pago, p_fecha);
+
+  PERFORM public.pago_solicitud_cerrar(
+    p_client_request_id, jsonb_build_object('afectados', v_afectados)
+  );
+  RETURN v_afectados;
+END;
+$function$;
+
+CREATE OR REPLACE FUNCTION public.marcar_entrega_y_pago_masivo(
+  p_pedido_ids        bigint[],
+  p_transportista_id  uuid,
+  p_forma_pago        text,
+  p_fecha             date DEFAULT CURRENT_DATE,
+  p_client_request_id uuid DEFAULT NULL::uuid
+) RETURNS integer
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $function$
+DECLARE
+  v_previo    jsonb;
+  v_afectados integer;
+BEGIN
+  v_previo := public.pago_solicitud_abrir(p_client_request_id, 'marcar_entrega_y_pago_masivo');
+  IF v_previo IS NOT NULL THEN
+    RETURN COALESCE((v_previo->>'afectados')::integer, 0);
+  END IF;
+
+  v_afectados := public.marcar_entrega_y_pago_masivo_impl(
+    p_pedido_ids, p_transportista_id, p_forma_pago, p_fecha
+  );
+
+  PERFORM public.pago_solicitud_cerrar(
+    p_client_request_id, jsonb_build_object('afectados', v_afectados)
+  );
+  RETURN v_afectados;
+END;
+$function$;
+
+-- Los wrappers heredan el rol de siempre y los grants que tenian las originales.
+ALTER FUNCTION public.registrar_pago_cliente_fifo(bigint,numeric,text,date,text,text,uuid) OWNER TO postgres;
+ALTER FUNCTION public.registrar_pago_combinado_cliente_fifo(bigint,jsonb,date,text,text,uuid) OWNER TO postgres;
+ALTER FUNCTION public.marcar_pagos_masivo(bigint[],text,date,uuid) OWNER TO postgres;
+ALTER FUNCTION public.marcar_entrega_y_pago_masivo(bigint[],uuid,text,date,uuid) OWNER TO postgres;
+
+GRANT EXECUTE ON FUNCTION public.registrar_pago_cliente_fifo(bigint,numeric,text,date,text,text,uuid)
+  TO authenticated, service_role;
+GRANT EXECUTE ON FUNCTION public.registrar_pago_combinado_cliente_fifo(bigint,jsonb,date,text,text,uuid)
+  TO authenticated, service_role;
+GRANT EXECUTE ON FUNCTION public.marcar_pagos_masivo(bigint[],text,date,uuid)
+  TO authenticated, service_role;
+GRANT EXECUTE ON FUNCTION public.marcar_entrega_y_pago_masivo(bigint[],uuid,text,date,uuid)
+  TO authenticated, service_role;
+
+COMMENT ON FUNCTION public.registrar_pago_cliente_fifo(bigint,numeric,text,date,text,text,uuid) IS
+  'Wrapper idempotente (mig 167) de registrar_pago_cliente_fifo_impl. Con p_client_request_id, un reintento devuelve el resultado de la primera llamada sin volver a imputar.';
+COMMENT ON FUNCTION public.registrar_pago_combinado_cliente_fifo(bigint,jsonb,date,text,text,uuid) IS
+  'Wrapper idempotente (mig 167) de registrar_pago_combinado_cliente_fifo_impl. Con p_client_request_id, un reintento devuelve el resultado de la primera llamada sin volver a imputar.';
+COMMENT ON FUNCTION public.marcar_pagos_masivo(bigint[],text,date,uuid) IS
+  'Wrapper idempotente (mig 167) de marcar_pagos_masivo_impl. Con p_client_request_id, un reintento devuelve la cantidad afectada de la primera llamada sin volver a cobrar.';
+COMMENT ON FUNCTION public.marcar_entrega_y_pago_masivo(bigint[],uuid,text,date,uuid) IS
+  'Wrapper idempotente (mig 167) de marcar_entrega_y_pago_masivo_impl. Con p_client_request_id, un reintento devuelve la cantidad afectada de la primera llamada sin volver a entregar ni cobrar.';
+
+-- ---------------------------------------------------------------------------
+-- 6. Chequeos de que quedo una sola firma publica por RPC
+-- ---------------------------------------------------------------------------
+-- Dos overloads del mismo nombre harian que PostgREST no pueda resolver la
+-- llamada (42725, "function is not unique") y romperia el cobro en prod.
+DO $verificar$
+DECLARE
+  v_nombre text;
+  v_cuantas integer;
+BEGIN
+  FOREACH v_nombre IN ARRAY ARRAY[
+    'registrar_pago_cliente_fifo',
+    'registrar_pago_combinado_cliente_fifo',
+    'marcar_pagos_masivo',
+    'marcar_entrega_y_pago_masivo'
+  ] LOOP
+    SELECT count(*) INTO v_cuantas
+      FROM pg_proc p
+      JOIN pg_namespace n ON n.oid = p.pronamespace
+     WHERE n.nspname = 'public' AND p.proname = v_nombre;
+
+    IF v_cuantas <> 1 THEN
+      RAISE EXCEPTION 'ABORTA: public.% quedo con % definiciones (esperaba 1). PostgREST no podria resolver la llamada.',
+        v_nombre, v_cuantas;
+    END IF;
+  END LOOP;
+END
+$verificar$;
+
+NOTIFY pgrst, 'reload schema';

--- a/migrations/MANIFEST.md
+++ b/migrations/MANIFEST.md
@@ -1,6 +1,6 @@
 # MANIFEST de migraciones — mapeo repo ↔ producción
 
-> **Fechado: 2026-08-03** · Proyecto prod `hmuchlzmuqqxcldbzkgc` (ManaosApp) · región `sa-east-1`.
+> **Fechado: 2026-08-05** · Proyecto prod `hmuchlzmuqqxcldbzkgc` (ManaosApp) · región `sa-east-1`.
 
 ## Regla de oro
 
@@ -127,11 +127,16 @@ funcional** y no se renombran los archivos: renombrarlos los desalinearía del l
 real lo da `version` y está en la sección A: en los dos casos el archivo de `main` quedó
 cronológicamente **fuera** del bloque 139–147 (uno antes, otro entre la 144 y la 145).
 
-**La próxima migración es la 165** — verificado contra el ledger el 2026-08-04: la última
-numerada es `164_metas_periodo_editable`. Las **148–164** (origen del precio, reglas de
+**La próxima migración es la 168** — la última numerada en el repo es
+`167_pagos_idempotencia_client_request_id`. Las **148–166** (origen del precio, reglas de
 comisión, `place_id`, horarios masivos, barridas, roles extra por sucursal, horario obligatorio
-al cargar pedido, marcas y objetivos por preventista) están aplicadas y mapean **1:1** con el
-ledger, así que no agregan ninguna excepción a las tablas de arriba.
+al cargar pedido, marcas y objetivos por preventista, saldo a favor que no queda atrapado)
+mapean **1:1** con el ledger, así que no agregan ninguna excepción a las tablas de arriba.
+
+La **167** renombra 4 RPCs de pago a `<nombre>_impl` y las deja detrás de un wrapper
+idempotente del mismo nombre. Es a propósito: `migrations/` no es 1:1 con prod y esas RPCs ya
+habían driftado (ver la nota de la 100), así que el cuerpo real no se reescribe, se envuelve.
+Al leer el catálogo, la lógica de negocio de esas 4 vive en la función `_impl`.
 
 **Antes de elegir el número de una migración nueva, mirar `ls migrations/` además del
 ledger**: el ledger no siempre lleva el prefijo, así que por sí solo no alcanza. Y si mergeaste

--- a/scripts/fix-pedido-3602-pagos-duplicados.sql
+++ b/scripts/fix-pedido-3602-pagos-duplicados.sql
@@ -1,0 +1,155 @@
+-- ===========================================================================
+-- LIMPIEZA MANUAL — pedido 3602: el mismo pago cargado 3 veces
+-- ===========================================================================
+--
+--   ⚠️  ESTO BORRA PLATA.
+--
+--   Agustín confirmó el 2026-08-05 que los pagos 3281 y 3282 fueron un error de
+--   carga y que hay que borrarlos. Queda pendiente ejecutarlo contra prod.
+--
+-- Vive en `scripts/` y no en `migrations/` porque es un arreglo puntual de dato:
+-- no tiene que aplicarse solo ni entrar en el ledger junto con el resto.
+--
+-- QUÉ PASÓ
+-- El pedido 3602 (cliente 303, "MARCOS CHOFER") tiene el MISMO pago de $111.280
+-- insertado 3 veces: `pagos` 3280, 3281 y 3282, el 2026-07-13 a las 22:53:20,
+-- 22:53:27 y 22:53:37. Diecisiete segundos, mismo monto, misma forma de pago:
+-- es un doble/triple clic sobre el botón de cobrar, no tres cobros reales.
+--
+-- Eso dejó al cliente con `saldo_cuenta = -222.560`. La migración 166 lo excluyó
+-- a propósito del backfill de sobrepagos (ver su sección EXCLUSION): no es
+-- crédito real del cliente, así que convertirlo en saldo a favor habría
+-- propagado el error a boletas futuras.
+--
+-- La causa raíz ya está tapada por la migración 167 (idempotencia por
+-- `client_request_id`). Esto es sólo el dato viejo.
+--
+-- QUÉ HACE
+-- Borra los pagos 3281 y 3282 y deja el 3280, que es el cobro real. Los triggers
+-- `recalcular_monto_pagado_pedido` y `actualizar_saldo_cliente` recalculan solos
+-- `pedidos.monto_pagado` y `clientes.saldo_cuenta`; no hay que tocarlos a mano.
+--
+-- CÓMO USARLO
+--   1. Correr el bloque 1 y mirar que los números den lo que dice acá arriba.
+--   2. Con el OK de Agustín, correr el bloque 2. Aborta solo si algo no cuadra.
+--   3. Correr el bloque 3 para confirmar cómo quedó.
+-- ===========================================================================
+
+
+-- ---------------------------------------------------------------------------
+-- BLOQUE 1 — VERIFICAR ANTES (sólo lectura, se puede correr siempre)
+-- ---------------------------------------------------------------------------
+
+-- 1a. ¿Sigue siendo el único caso de pago duplicado en toda la base?
+select pedido_id, cliente_id, monto, forma_pago, fecha, count(*) as veces,
+       array_agg(id order by id) as pago_ids,
+       max(created_at) - min(created_at) as ventana
+  from pagos
+ where pedido_id is not null
+ group by pedido_id, cliente_id, monto, forma_pago, fecha
+having count(*) > 1;
+
+-- 1b. Las 3 filas del pedido 3602, como están hoy.
+select id, pedido_id, cliente_id, monto, forma_pago, fecha, created_at, usuario_id
+  from pagos
+ where pedido_id = 3602
+ order by id;
+
+-- 1c. Estado del pedido y del cliente antes de tocar nada.
+select p.id as pedido, p.total, p.monto_pagado, p.estado, p.estado_pago,
+       c.id as cliente, c.nombre_fantasia, c.saldo_cuenta
+  from pedidos p
+  join clientes c on c.id = p.cliente_id
+ where p.id = 3602;
+
+
+-- ---------------------------------------------------------------------------
+-- BLOQUE 2 — BORRAR (destructivo; sólo con el OK de Agustín)
+-- ---------------------------------------------------------------------------
+-- Corre entero en una transacción y se aborta solo si el estado no es
+-- exactamente el esperado: si alguien ya lo arregló a mano, o los montos no son
+-- los que decimos, no borra nada.
+
+DO $limpieza$
+DECLARE
+  v_saldo_antes   numeric;
+  v_saldo_despues numeric;
+  v_pagado_antes  numeric;
+  v_pagado_despues numeric;
+  v_total         numeric;
+  v_borradas      integer;
+  v_cuantas       integer;
+BEGIN
+  -- Guarda 1: las dos filas a borrar tienen que existir, ser del pedido 3602 y
+  -- valer $111.280 cada una.
+  SELECT count(*) INTO v_cuantas
+    FROM pagos
+   WHERE id IN (3281, 3282)
+     AND pedido_id = 3602
+     AND monto = 111280;
+
+  IF v_cuantas <> 2 THEN
+    RAISE EXCEPTION 'ABORTA: esperaba los pagos 3281 y 3282 (pedido 3602, $111.280 c/u) y encontré % fila(s). Revisá el bloque 1: puede que ya se haya corregido.', v_cuantas;
+  END IF;
+
+  -- Guarda 2: el pago que se conserva tiene que seguir ahí.
+  IF NOT EXISTS (SELECT 1 FROM pagos WHERE id = 3280 AND pedido_id = 3602 AND monto = 111280) THEN
+    RAISE EXCEPTION 'ABORTA: no está el pago 3280, que es el cobro real que hay que conservar.';
+  END IF;
+
+  SELECT c.saldo_cuenta, p.monto_pagado, p.total
+    INTO v_saldo_antes, v_pagado_antes, v_total
+    FROM pedidos p JOIN clientes c ON c.id = p.cliente_id
+   WHERE p.id = 3602;
+
+  DELETE FROM pagos WHERE id IN (3281, 3282);
+  GET DIAGNOSTICS v_borradas = ROW_COUNT;
+
+  SELECT c.saldo_cuenta, p.monto_pagado
+    INTO v_saldo_despues, v_pagado_despues
+    FROM pedidos p JOIN clientes c ON c.id = p.cliente_id
+   WHERE p.id = 3602;
+
+  RAISE NOTICE 'borradas=% · monto_pagado % -> % (total %) · saldo_cuenta % -> %',
+    v_borradas, v_pagado_antes, v_pagado_despues, v_total, v_saldo_antes, v_saldo_despues;
+
+  -- Guarda 3: los triggers tienen que haber devuelto exactamente los $222.560.
+  IF abs((v_pagado_antes - v_pagado_despues) - 222560) > 0.005 THEN
+    RAISE EXCEPTION 'ABORTA: monto_pagado bajó % en vez de 222560. Los triggers no hicieron lo esperado.',
+      v_pagado_antes - v_pagado_despues;
+  END IF;
+
+  IF abs((v_saldo_despues - v_saldo_antes) - 222560) > 0.005 THEN
+    RAISE EXCEPTION 'ABORTA: saldo_cuenta subió % en vez de 222560.',
+      v_saldo_despues - v_saldo_antes;
+  END IF;
+
+  -- Guarda 4: el pedido no puede quedar sobrepagado ni de más ni de menos
+  -- (invariante de la mig 165).
+  IF v_pagado_despues > v_total + 0.005 THEN
+    RAISE EXCEPTION 'ABORTA: el pedido 3602 sigue sobrepagado (monto_pagado % > total %).',
+      v_pagado_despues, v_total;
+  END IF;
+END
+$limpieza$;
+
+
+-- ---------------------------------------------------------------------------
+-- BLOQUE 3 — VERIFICAR DESPUÉS
+-- ---------------------------------------------------------------------------
+
+select p.id as pedido, p.total, p.monto_pagado, p.estado_pago,
+       c.id as cliente, c.nombre_fantasia, c.saldo_cuenta
+  from pedidos p
+  join clientes c on c.id = p.cliente_id
+ where p.id = 3602;
+
+-- Tiene que quedar una sola fila (el pago 3280).
+select id, monto, forma_pago, fecha from pagos where pedido_id = 3602 order by id;
+
+-- Y no debería quedar ningún pago duplicado en toda la base.
+select pedido_id, cliente_id, monto, forma_pago, fecha, count(*) as veces
+  from pagos
+ where pedido_id is not null
+ group by pedido_id, cliente_id, monto, forma_pago, fecha
+having count(*) > 1;

--- a/scripts/fix-pedido-3602-pagos-duplicados.sql
+++ b/scripts/fix-pedido-3602-pagos-duplicados.sql
@@ -4,8 +4,14 @@
 --
 --   ⚠️  ESTO BORRA PLATA.
 --
---   Agustín confirmó el 2026-08-05 que los pagos 3281 y 3282 fueron un error de
---   carga y que hay que borrarlos. Queda pendiente ejecutarlo contra prod.
+--   ✅ YA EJECUTADO en prod el 2026-08-05, con la confirmación de Agustín de que
+--      los pagos 3281 y 3282 fueron un error de carga. Queda acá como registro
+--      auditable de qué se corrió exactamente. Volver a correrlo es inofensivo:
+--      la guarda 1 no encuentra las filas y aborta sin tocar nada.
+--
+--      Resultado: pedido 3602 monto_pagado 333.840 -> 111.280 (= total, queda
+--      `pagado`), cliente 303 saldo_cuenta -222.560 -> 0,00. Después de esto no
+--      queda ningún pago duplicado ni ningún pedido sobrepagado en toda la base.
 --
 -- Vive en `scripts/` y no en `migrations/` porque es un arreglo puntual de dato:
 -- no tiene que aplicarse solo ni entrar en el ledger junto con el resto.

--- a/src/components/containers/ClientesContainer.tsx
+++ b/src/components/containers/ClientesContainer.tsx
@@ -182,6 +182,7 @@ export default function ClientesContainer(): React.ReactElement {
     referencia: string
     notas: string
     fecha: string
+    clientRequestId?: string
   }) => {
     const pago = await registrarPago({
       clienteId: datosPago.clienteId,
@@ -191,7 +192,8 @@ export default function ClientesContainer(): React.ReactElement {
       referencia: datosPago.referencia,
       notas: datosPago.notas,
       fecha: datosPago.fecha,
-      usuarioId: user?.id ?? ''
+      usuarioId: user?.id ?? '',
+      clientRequestId: datosPago.clientRequestId,
     })
     queryClient.invalidateQueries({ queryKey: ['pedidos'] })
     queryClient.invalidateQueries({ queryKey: ['ficha-cliente'] })
@@ -206,6 +208,7 @@ export default function ClientesContainer(): React.ReactElement {
     fecha?: string
     referencia?: string
     notas?: string
+    clientRequestId?: string
   }) => {
     const result = await registrarPagoFIFO(input)
     queryClient.invalidateQueries({ queryKey: ['pedidos'] })
@@ -225,6 +228,7 @@ export default function ClientesContainer(): React.ReactElement {
     fecha?: string
     referencia?: string
     notas?: string
+    clientRequestId?: string
   }) => {
     const result = await registrarPagoCombinadoFIFO(input)
     queryClient.invalidateQueries({ queryKey: ['pedidos'] })

--- a/src/components/containers/PedidosContainer.tsx
+++ b/src/components/containers/PedidosContainer.tsx
@@ -18,6 +18,7 @@ import PanelPedidosNoEntregados from '../pedidos/PanelPedidosNoEntregados'
 import { fechaLocalISO, fechaHaceDias, getFormaPagoDisplay } from '../../utils/formatters'
 import { explicarErrorDeSesion } from '../../utils/sesionVencida'
 import { preventistaPuedeEditar } from '../../utils/permisosPedido'
+import { useRequestIdEstable } from '../../hooks/useRequestIdEstable'
 import { useQueryClient } from '@tanstack/react-query'
 import { Loader2 } from 'lucide-react'
 import {
@@ -202,6 +203,8 @@ export default function PedidosContainer(): React.ReactElement {
   const cambiarClientePedidoMut = useCambiarClientePedidoMutation()
   const pagosMasivos = usePagosMasivosMutation()
   const entregaYPagoMasivos = useEntregaYPagoMasivosMutation()
+  // UUIDs de idempotencia de las acciones masivas de cobro (mig 167).
+  const requestIdMasivo = useRequestIdEstable()
   const crearClienteMut = useCrearClienteMutation()
   const actualizarClienteMut = useActualizarClienteMutation()
   const crearCambioEnRutaMut = useCrearPedidoCambioEnRutaMutation()
@@ -599,12 +602,17 @@ export default function PedidosContainer(): React.ReactElement {
   const handlePagosMasivos = useCallback(async (formaPago: string, pedidoIds: string[], fechaPago: string) => {
     setGuardando(true)
     try {
-      await pagosMasivos.mutateAsync({ pedidoIds, formaPago, fecha: fechaPago })
+      await pagosMasivos.mutateAsync({
+        pedidoIds, formaPago, fecha: fechaPago,
+        // Mismo lote + misma forma + misma fecha = el mismo cobro. Un reintento
+        // tras un error de red no vuelve a cobrarlo (mig 167).
+        clientRequestId: requestIdMasivo(`pagos|${fechaPago}|${formaPago}|${[...pedidoIds].sort().join(',')}`),
+      })
       setModalPagosMasivosOpen(false)
       notify.success(`${pedidoIds.length} pedido${pedidoIds.length !== 1 ? 's' : ''} marcado${pedidoIds.length !== 1 ? 's' : ''} como pagado${pedidoIds.length !== 1 ? 's' : ''}`)
     } catch (e) { notify.error('Error en pagos masivos: ' + (e as Error).message) }
     setGuardando(false)
-  }, [pagosMasivos, notify])
+  }, [pagosMasivos, notify, requestIdMasivo])
 
   const handleEntregaYPagoMasivos = useCallback(async (
     transportistaId: string,
@@ -614,13 +622,19 @@ export default function PedidosContainer(): React.ReactElement {
   ) => {
     setGuardando(true)
     try {
-      await entregaYPagoMasivos.mutateAsync({ ...ids, transportistaId, formaPago, fecha })
+      const huella = `${fecha}|${formaPago}|${transportistaId}`
+      await entregaYPagoMasivos.mutateAsync({
+        ...ids, transportistaId, formaPago, fecha,
+        // Son dos RPCs distintas dentro de la misma mutation: un UUID cada una.
+        clientRequestIdCobrar: requestIdMasivo(`cobrar|${huella}|${[...ids.idsCobrar].sort().join(',')}`),
+        clientRequestIdEntregar: requestIdMasivo(`entregar|${huella}|${[...ids.idsEntregar].sort().join(',')}`),
+      })
       setModalEntregaYPagoMasivosOpen(false)
       const total = ids.idsEntregar.length + ids.idsCobrar.length
       notify.success(`${total} pedido${total !== 1 ? 's' : ''} procesado${total !== 1 ? 's' : ''}`)
     } catch (e) { notify.error('Error en entrega y pago masivos: ' + (e as Error).message) }
     setGuardando(false)
-  }, [entregaYPagoMasivos, notify])
+  }, [entregaYPagoMasivos, notify, requestIdMasivo])
 
   // Fetch todos los pedidos con filtros actuales (sin paginación) para export
   const fetchAllFilteredPedidos = useCallback(async (): Promise<PedidoDB[]> => {
@@ -918,7 +932,7 @@ export default function PedidosContainer(): React.ReactElement {
 
   // El error ya fue notificado por usePagos.registrarPagosBatch via notifyError;
   // dejamos que se propague para que el modal lo muestre tambien.
-  const handleConfirmarPago = useCallback(async (payload: { pedidoId: string; clienteId: string; fechaPago: string; observaciones?: string; pagos: Array<{ formaPago: string; monto: number }> }) => {
+  const handleConfirmarPago = useCallback(async (payload: { pedidoId: string; clienteId: string; fechaPago: string; observaciones?: string; pagos: Array<{ formaPago: string; monto: number }>; clientRequestIds?: string[] }) => {
     setGuardando(true)
     try {
       await registrarPagosBatch({
@@ -928,6 +942,7 @@ export default function PedidosContainer(): React.ReactElement {
         observaciones: payload.observaciones || null,
         pagos: payload.pagos,
         usuarioId: user?.id ?? null,
+        clientRequestIds: payload.clientRequestIds,
       })
       queryClient.invalidateQueries({ queryKey: ['pedidos'] })
       setModalPagoPedidoOpen(false)
@@ -972,7 +987,7 @@ export default function PedidosContainer(): React.ReactElement {
   // Modo entrega transportista: "Entregar y registrar pago" → cambia estado y registra pagos.
   // Orden: primero entrega (mas critica), luego pagos. Si falla algun pago, queda
   // entregado y el usuario puede usar "Registrar Pago" desde el dropdown.
-  const handleEntregarConPago = useCallback(async (payload: { pedidoId: string; clienteId: string; fechaPago: string; observaciones?: string; pagos: Array<{ formaPago: string; monto: number }> }) => {
+  const handleEntregarConPago = useCallback(async (payload: { pedidoId: string; clienteId: string; fechaPago: string; observaciones?: string; pagos: Array<{ formaPago: string; monto: number }>; clientRequestIds?: string[] }) => {
     const pedido = pedidoEntregaConPago
     if (!pedido) {
       // Fallback: comportamiento normal de registrar pago sin entrega
@@ -990,6 +1005,7 @@ export default function PedidosContainer(): React.ReactElement {
           observaciones: payload.observaciones || null,
           pagos: payload.pagos,
           usuarioId: user?.id ?? null,
+          clientRequestIds: payload.clientRequestIds,
         })
       } catch (pagoErr) {
         notify.error('Pedido entregado pero falló el pago: ' + (pagoErr as Error).message + '. Registralo desde el menú de pago.')
@@ -1546,6 +1562,7 @@ export default function PedidosContainer(): React.ReactElement {
     referencia: string;
     notas: string;
     fecha: string;
+    clientRequestId?: string;
   }) => {
     const pago = await registrarPago({
       clienteId: data.clienteId,
@@ -1556,6 +1573,7 @@ export default function PedidosContainer(): React.ReactElement {
       notas: data.notas,
       fecha: data.fecha,
       usuarioId: user?.id ?? null,
+      clientRequestId: data.clientRequestId,
     })
     queryClient.invalidateQueries({ queryKey: ['pedidos'] })
     return pago

--- a/src/components/modals/ModalPagoPedido.tsx
+++ b/src/components/modals/ModalPagoPedido.tsx
@@ -16,7 +16,7 @@
  * Sobrepago bloqueado en frontend (totalIngresado > saldoPendiente). Anulacion
  * de pagos previos solo si el caller pasa `onAnularPago` (solo admin).
  */
-import { memo, useEffect, useMemo, useState } from 'react'
+import { memo, useEffect, useMemo, useRef, useState } from 'react'
 import { Loader2, DollarSign, Plus, Trash2, AlertCircle, X } from 'lucide-react'
 import ModalBase from './ModalBase'
 import NumberInput from '../ui/NumberInput'
@@ -24,6 +24,7 @@ import { formatPrecio, fechaLocalISO, formatDateTime, getFormaPagoLabel } from '
 import { parsePrecio } from '../../utils/calculations'
 import { FORMAS_PAGO_SELECCIONABLES } from '../../constants/formasPago'
 import { useFechaMinimaPago } from '../../hooks/queries/useUltimaFechaCajaCerradaQuery'
+import { useRequestIdEstable } from '../../hooks/useRequestIdEstable'
 import type { PedidoDB, PagoDBWithUsuario } from '../../types'
 
 export interface PagoPedidoPayload {
@@ -32,6 +33,12 @@ export interface PagoPedidoPayload {
   fechaPago: string
   observaciones?: string
   pagos: Array<{ formaPago: string; monto: number }>
+  /**
+   * UUID de idempotencia por línea de `pagos`, alineado por posición (mig 167).
+   * Estable mientras no cambien los montos/formas: un reintento tras un error
+   * de red no duplica el cobro.
+   */
+  clientRequestIds?: string[]
 }
 
 export interface ModalPagoPedidoProps {
@@ -97,6 +104,12 @@ const ModalPagoPedido = memo(function ModalPagoPedido({
   // pagoId en curso de edicion de forma_pago (para mostrar spinner inline).
   const [editandoPagoId, setEditandoPagoId] = useState<string | null>(null)
 
+  // Idempotencia (mig 167): `enVueloRef` corta el doble toque instantaneo y
+  // `requestId` hace que el reintento tras un error reuse el mismo UUID, para
+  // que el server lo reconozca en vez de volver a cobrar.
+  const enVueloRef = useRef<boolean>(false)
+  const requestId = useRequestIdEstable()
+
   // Si los pagos previos cambian (anulacion), reajustar la linea por default al saldo restante.
   useEffect(() => {
     if (saldoPendiente > 0 && lineas.length === 1 && (!lineas[0].monto || parsePrecio(lineas[0].monto) === 0)) {
@@ -131,6 +144,7 @@ const ModalPagoPedido = memo(function ModalPagoPedido({
   }
 
   const handleSubmit = async (): Promise<void> => {
+    if (enVueloRef.current) return
     setError('')
     if (saldoPendiente <= 0) {
       setError('El pedido ya esta completamente pagado.')
@@ -150,18 +164,31 @@ const ModalPagoPedido = memo(function ModalPagoPedido({
       setError('Ingresa la fecha de pago.')
       return
     }
+    const pagos = lineas
+      .filter(l => parsePrecio(l.monto) > 0)
+      .map(l => ({ formaPago: l.formaPago, monto: parsePrecio(l.monto) }))
+
+    // Huella: todo lo que define "este cobro y no otro". Cambiar un monto o una
+    // forma de pago acuña UUIDs nuevos; reintentar lo mismo reusa los de antes.
+    const huella = [
+      pedido.id, fechaPago, observaciones.trim(),
+      pagos.map(p => `${p.monto}@${p.formaPago}`).join(','),
+    ].join('|')
+
+    enVueloRef.current = true
     try {
       await onConfirmar({
         pedidoId: String(pedido.id),
         clienteId: String(pedido.cliente_id),
         fechaPago,
         observaciones: observaciones.trim() || undefined,
-        pagos: lineas
-          .filter(l => parsePrecio(l.monto) > 0)
-          .map(l => ({ formaPago: l.formaPago, monto: parsePrecio(l.monto) })),
+        pagos,
+        clientRequestIds: pagos.map((_, i) => requestId(`${huella}#${i}`)),
       })
     } catch (e) {
       setError((e as Error).message || 'Error al registrar el pago')
+    } finally {
+      enVueloRef.current = false
     }
   }
 

--- a/src/components/modals/ModalRegistrarPago.tsx
+++ b/src/components/modals/ModalRegistrarPago.tsx
@@ -1,9 +1,10 @@
-import React, { useState, FormEvent, ChangeEvent } from 'react'
+import React, { useState, useRef, FormEvent, ChangeEvent } from 'react'
 import { X, DollarSign, FileText, AlertCircle, Check, Plus, Trash2, Calendar } from 'lucide-react'
 import { formatPrecio as formatCurrency, fechaLocalISO } from '../../utils/formatters'
 import { parsePrecio } from '../../utils/calculations'
 import NumberInput from '../ui/NumberInput'
 import { useZodValidation } from '../../hooks/useZodValidation'
+import { useRequestIdEstable } from '../../hooks/useRequestIdEstable'
 import { useFechaMinimaPago } from '../../hooks/queries/useUltimaFechaCajaCerradaQuery'
 import { modalPagoSchema } from '../../lib/schemas'
 import type { ClienteDB, Pedido, Pago, FormaPago, RegistrarPagoFifoInput, RegistrarPagoCombinadoFifoInput, RegistrarPagoFifoResult, PagoFifoAplicacion } from '../../types'
@@ -36,6 +37,11 @@ interface PagoData {
   notas: string;
   /** Fecha contable del pago (YYYY-MM-DD). Default hoy. */
   fecha: string;
+  /**
+   * UUID de idempotencia (mig 167). Estable mientras no cambien los datos del
+   * pago, así un reintento tras un error de red no lo duplica.
+   */
+  clientRequestId?: string;
 }
 
 interface PagoRegistrado extends Pago {
@@ -111,6 +117,15 @@ export default function ModalRegistrarPago({
   // Fecha minima: dia siguiente al ultimo cierre de caja de la sucursal (mig 134).
   const fechaMinima = useFechaMinimaPago()
 
+  // Idempotencia (mig 167). Dos guardas complementarias:
+  //  - `enVueloRef` corta el doble toque instantaneo, que puede disparar dos
+  //    submits antes de que React re-renderice con loading=true.
+  //  - `requestId` hace que el reintento DESPUES de un error use el mismo UUID,
+  //    asi el server lo reconoce y no vuelve a cobrar. Cambiar el monto o la
+  //    forma de pago cambia la huella y acuña un UUID nuevo: eso si es otro pago.
+  const enVueloRef = useRef<boolean>(false)
+  const requestId = useRequestIdEstable()
+
   // Pago dividido
   const [pagoDividido, setPagoDividido] = useState<boolean>(false)
   const [pagos, setPagos] = useState<PagoDividido[]>([
@@ -140,6 +155,7 @@ export default function ModalRegistrarPago({
 
   const handleSubmit = async (e: FormEvent<HTMLFormElement>): Promise<void> => {
     e.preventDefault()
+    if (enVueloRef.current) return
     setError('')
 
     // FIFO siempre aplica cuando: no es pago dividido, no hay pedido específico
@@ -147,12 +163,17 @@ export default function ModalRegistrarPago({
     // pendientes el sobrante queda como saldo a favor automaticamente.
     const usarFIFO = !pagoDividido && !pedidoSeleccionado && !!onConfirmarFIFO
 
+    // Huella del pago: todo lo que lo hace "este pago y no otro". Mientras no
+    // cambie, los reintentos comparten UUID y el server los deduplica.
+    const huellaBase = [cliente!.id, pedidoSeleccionado || 'general', fecha, notas].join('|')
+
     if (usarFIFO) {
       const montoNumero = parsePrecio(monto)
       if (!montoNumero || montoNumero <= 0) {
         setError('Ingresá un monto válido')
         return
       }
+      enVueloRef.current = true
       setLoading(true)
       try {
         const result = await onConfirmarFIFO!({
@@ -162,6 +183,7 @@ export default function ModalRegistrarPago({
           fecha,
           referencia: referencia || undefined,
           notas: notas || undefined,
+          clientRequestId: requestId(`fifo|${huellaBase}|${montoNumero}|${formaPago}|${referencia}`),
         })
         setResultadoFIFO(result)
       } catch (err) {
@@ -169,6 +191,7 @@ export default function ModalRegistrarPago({
         setError(errorMessage)
       } finally {
         setLoading(false)
+        enVueloRef.current = false
       }
       return
     }
@@ -186,7 +209,10 @@ export default function ModalRegistrarPago({
       // saldo pendiente y el sobrante queda como saldo a favor. Espeja la
       // condición de `usarFIFO` del pago simple: sin esto, las filas se
       // insertarían con pedido_id NULL y no actualizarían el saldo del cliente.
+      const huellaDividido = `${huellaBase}|${pagosValidos.map(p => `${parsePrecio(p.monto)}@${p.formaPago}`).join(',')}`
+
       if (!pedidoSeleccionado && onConfirmarCombinadoFIFO) {
+        enVueloRef.current = true
         setLoading(true)
         try {
           const result = await onConfirmarCombinadoFIFO({
@@ -194,6 +220,7 @@ export default function ModalRegistrarPago({
             metodos: pagosValidos.map(p => ({ monto: parsePrecio(p.monto), formaPago: p.formaPago })),
             fecha,
             notas: notas || undefined,
+            clientRequestId: requestId(`combo|${huellaDividido}`),
           })
           setResultadoFIFO(result)
         } catch (err) {
@@ -201,6 +228,7 @@ export default function ModalRegistrarPago({
           setError(errorMessage)
         } finally {
           setLoading(false)
+          enVueloRef.current = false
         }
         return
       }
@@ -208,10 +236,13 @@ export default function ModalRegistrarPago({
       // Fallback: dividido aplicado a un pedido específico (o sin RPC combinado
       // disponible, ej. flujo del transportista). Cada forma genera una fila con
       // el pedido_id seleccionado, que sí dispara la cascada de triggers.
+      enVueloRef.current = true
       setLoading(true)
       try {
         let ultimoPago: PagoRegistrado | null = null
-        for (const pago of pagosValidos) {
+        // Un UUID por línea: son N filas y el índice único es por fila. Si el
+        // reintento cae en la mitad, las que ya entraron se resuelven solas.
+        for (const [i, pago] of pagosValidos.entries()) {
           ultimoPago = await onConfirmar({
             clienteId: cliente!.id,
             pedidoId: pedidoSeleccionado || null,
@@ -219,7 +250,8 @@ export default function ModalRegistrarPago({
             formaPago: pago.formaPago,
             referencia: '',
             notas: notas ? `${notas} (pago dividido - ${FORMAS_PAGO.find(f => f.value === pago.formaPago)?.label || pago.formaPago})` : `Pago dividido - ${FORMAS_PAGO.find(f => f.value === pago.formaPago)?.label || pago.formaPago}`,
-            fecha
+            fecha,
+            clientRequestId: requestId(`divid|${huellaDividido}#${i}`),
           })
         }
         if (ultimoPago) setPagoRegistrado(ultimoPago)
@@ -228,6 +260,7 @@ export default function ModalRegistrarPago({
         setError(errorMessage)
       } finally {
         setLoading(false)
+        enVueloRef.current = false
       }
     } else {
       // Pago simple (a pedido específico o a cuenta general sin FIFO)
@@ -237,6 +270,7 @@ export default function ModalRegistrarPago({
         return
       }
 
+      enVueloRef.current = true
       setLoading(true)
       try {
         const pago = await onConfirmar({
@@ -246,7 +280,8 @@ export default function ModalRegistrarPago({
           formaPago,
           referencia,
           notas,
-          fecha
+          fecha,
+          clientRequestId: requestId(`simple|${huellaBase}|${result.data.monto}|${formaPago}|${referencia}`),
         })
         setPagoRegistrado(pago)
       } catch (err) {
@@ -254,6 +289,7 @@ export default function ModalRegistrarPago({
         setError(errorMessage)
       } finally {
         setLoading(false)
+        enVueloRef.current = false
       }
     }
   }
@@ -298,6 +334,11 @@ export default function ModalRegistrarPago({
             {resultadoFIFO.creditoAplicado > 0 && (
               <p className="text-sm text-emerald-700 dark:text-emerald-300 mb-4 px-3 py-2 bg-emerald-50 dark:bg-emerald-900/20 rounded-lg">
                 Además se usó {formatCurrency(resultadoFIFO.creditoAplicado)} de saldo a favor que el cliente ya tenía.
+              </p>
+            )}
+            {resultadoFIFO.idempotentReplay && (
+              <p className="text-sm text-blue-700 dark:text-blue-300 mb-4 px-3 py-2 bg-blue-50 dark:bg-blue-900/20 rounded-lg">
+                Este pago ya había entrado en tu intento anterior: no se cobró dos veces. Abajo está el detalle de esa imputación.
               </p>
             )}
           </div>

--- a/src/hooks/queries/usePedidosQuery.ts
+++ b/src/hooks/queries/usePedidosQuery.ts
@@ -9,6 +9,7 @@ import type { PedidoDB, PedidoItemDB, PerfilDB, FiltrosPedidosState, PedidoSalve
 import { productosKeys } from './useProductosQuery'
 import { clientesKeys } from './useClientesQuery'
 import { fechaLocalISO } from '../../utils/formatters'
+import { nuevoRequestId } from '../../utils/idempotencia'
 import type { OrigenPrecioItem } from '../../utils/origenPrecio'
 
 // Query keys
@@ -1122,13 +1123,17 @@ export function usePedidosNoPagadosQuery(enabled = false) {
 async function marcarPagosMasivo(
   pedidoIds: string[],
   formaPago: string,
-  fecha?: string | null
+  fecha?: string | null,
+  clientRequestId?: string
 ): Promise<void> {
   const rpcArgs: Record<string, unknown> = {
     p_pedido_ids: pedidoIds.map(id => Number(id)),
     p_forma_pago: formaPago,
   }
   if (fecha) rpcArgs.p_fecha = fecha
+  // Idempotencia (mig 167): un reintento con el mismo UUID devuelve el
+  // resultado de la primera llamada sin volver a cobrar.
+  rpcArgs.p_client_request_id = clientRequestId ?? nuevoRequestId()
 
   const { error } = await supabase.rpc('marcar_pagos_masivo', rpcArgs)
   if (error) throw error
@@ -1142,11 +1147,12 @@ export function usePagosMasivosMutation() {
   const { currentSucursalId } = useSucursal()
 
   return useMutation({
-    mutationFn: ({ pedidoIds, formaPago, fecha }: {
+    mutationFn: ({ pedidoIds, formaPago, fecha, clientRequestId }: {
       pedidoIds: string[];
       formaPago: string;
-      fecha?: string | null
-    }) => marcarPagosMasivo(pedidoIds, formaPago, fecha),
+      fecha?: string | null;
+      clientRequestId?: string
+    }) => marcarPagosMasivo(pedidoIds, formaPago, fecha, clientRequestId),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: pedidosKeys.all(currentSucursalId) })
     },
@@ -1161,7 +1167,8 @@ async function marcarEntregaYPagoMasivo(
   pedidoIds: string[],
   transportistaId: string,
   formaPago: string,
-  fecha?: string | null
+  fecha?: string | null,
+  clientRequestId?: string
 ): Promise<void> {
   // RPC combinada: entrega (asigna transportista + fecha) y registra el pago
   // por el saldo pendiente de cada pedido, en una transacción atómica.
@@ -1171,6 +1178,7 @@ async function marcarEntregaYPagoMasivo(
     p_forma_pago: formaPago,
   }
   if (fecha) rpcArgs.p_fecha = fecha
+  rpcArgs.p_client_request_id = clientRequestId ?? nuevoRequestId()
 
   const { error } = await supabase.rpc('marcar_entrega_y_pago_masivo', rpcArgs)
   if (error) throw error
@@ -1197,19 +1205,27 @@ export function useEntregaYPagoMasivosMutation() {
   const { currentSucursalId } = useSucursal()
 
   return useMutation({
-    mutationFn: async ({ idsEntregar, idsCobrar, transportistaId, formaPago, fecha }: {
+    mutationFn: async ({
+      idsEntregar, idsCobrar, transportistaId, formaPago, fecha,
+      clientRequestIdCobrar, clientRequestIdEntregar,
+    }: {
       idsEntregar: string[];
       idsCobrar: string[];
       transportistaId: string;
       formaPago: string;
-      fecha?: string | null
+      fecha?: string | null;
+      /** UUIDs de idempotencia (mig 167). Son dos RPCs distintas, un UUID cada una. */
+      clientRequestIdCobrar?: string;
+      clientRequestIdEntregar?: string;
     }) => {
       // Pedidos YA entregados (p.ej. entrega con salvedad impaga): solo se cobran,
       // sin re-entregar. marcar_pagos_masivo registra el pago real en `pagos` y no
       // toca estado / transportista_id / fecha_entrega.
-      if (idsCobrar.length) await marcarPagosMasivo(idsCobrar, formaPago, fecha)
+      if (idsCobrar.length) await marcarPagosMasivo(idsCobrar, formaPago, fecha, clientRequestIdCobrar)
       // Pedidos NO entregados: entrega + cobro en un solo paso.
-      if (idsEntregar.length) await marcarEntregaYPagoMasivo(idsEntregar, transportistaId, formaPago, fecha)
+      if (idsEntregar.length) {
+        await marcarEntregaYPagoMasivo(idsEntregar, transportistaId, formaPago, fecha, clientRequestIdEntregar)
+      }
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: pedidosKeys.all(currentSucursalId) })

--- a/src/hooks/supabase/usePagos.test.ts
+++ b/src/hooks/supabase/usePagos.test.ts
@@ -12,6 +12,7 @@ const mockDelete = vi.fn().mockReturnThis()
 const mockEq = vi.fn().mockReturnThis()
 const mockOrder = vi.fn().mockReturnThis()
 const mockSingle = vi.fn()
+const mockIn = vi.fn()
 
 vi.mock('./base', () => ({
   supabase: {
@@ -21,7 +22,8 @@ vi.mock('./base', () => ({
       delete: mockDelete,
       eq: mockEq,
       order: mockOrder,
-      single: mockSingle
+      single: mockSingle,
+      in: mockIn
     })),
     rpc: vi.fn()
   },
@@ -119,6 +121,153 @@ describe('usePagos', () => {
       })).rejects.toThrow()
 
       expect(notifyError).toHaveBeenCalledWith(expect.stringContaining('Error al registrar pago'))
+    })
+  })
+
+  // Idempotencia (mig 167). El caso testigo es el pedido 3602: el mismo pago de
+  // $111.280 entro 3 veces en 17 segundos porque el reintento del usuario no
+  // tenia forma de identificarse como reintento.
+  describe('registrarPago — idempotencia', () => {
+    const REQUEST_ID = '11111111-2222-4333-8444-555555555555'
+
+    it('manda client_request_id en el INSERT cuando el caller lo provee', async () => {
+      mockSingle.mockResolvedValueOnce({ data: { id: '1', monto: 111280 }, error: null })
+
+      const { result } = renderHook(() => usePagos())
+      await act(async () => {
+        await result.current.registrarPago({
+          clienteId: 'c1', monto: 111280, formaPago: 'efectivo', clientRequestId: REQUEST_ID,
+        })
+      })
+
+      expect(mockInsert).toHaveBeenCalledWith([expect.objectContaining({
+        client_request_id: REQUEST_ID,
+      })])
+    })
+
+    it('no manda la columna si el caller no pasa UUID (comportamiento historico)', async () => {
+      mockSingle.mockResolvedValueOnce({ data: { id: '1', monto: 100 }, error: null })
+
+      const { result } = renderHook(() => usePagos())
+      await act(async () => {
+        await result.current.registrarPago({ clienteId: 'c1', monto: 100 })
+      })
+
+      expect(mockInsert).toHaveBeenCalledWith([
+        expect.not.objectContaining({ client_request_id: expect.anything() }),
+      ])
+    })
+
+    it('ante 23505 devuelve la fila que ya existe en vez de duplicar el pago', async () => {
+      const yaRegistrado = { id: '3280', cliente_id: 'c1', monto: 111280, forma_pago: 'efectivo' }
+      mockSingle.mockResolvedValueOnce({
+        data: null,
+        error: { code: '23505', message: 'duplicate key value violates unique constraint "idx_pagos_client_request_id"' },
+      })
+      mockIn.mockResolvedValueOnce({ data: [yaRegistrado], error: null })
+
+      const { result } = renderHook(() => usePagos())
+      let pago: unknown
+      await act(async () => {
+        pago = await result.current.registrarPago({
+          clienteId: 'c1', monto: 111280, formaPago: 'efectivo', clientRequestId: REQUEST_ID,
+        })
+      })
+
+      expect(mockIn).toHaveBeenCalledWith('client_request_id', [REQUEST_ID])
+      expect(pago).toEqual(yaRegistrado)
+      expect(result.current.pagos).toContainEqual(yaRegistrado)
+      expect(notifyError).not.toHaveBeenCalled()
+    })
+
+    it('ante 23505 sin poder releer la fila avisa que ya estaba registrado', async () => {
+      mockSingle.mockResolvedValueOnce({ data: null, error: { code: '23505', message: 'duplicate key' } })
+      mockIn.mockResolvedValueOnce({ data: [], error: null })
+
+      const { result } = renderHook(() => usePagos())
+      await expect(act(async () => {
+        await result.current.registrarPago({
+          clienteId: 'c1', monto: 100, clientRequestId: REQUEST_ID,
+        })
+      })).rejects.toThrow(/ya se había registrado/i)
+    })
+  })
+
+  describe('registrarPagosBatch — idempotencia', () => {
+    it('aparea cada UUID con su linea aunque haya lineas en cero filtradas', async () => {
+      mockSelect.mockResolvedValueOnce({ data: [{ id: '1', monto: 500 }], error: null })
+
+      const { result } = renderHook(() => usePagos())
+      await act(async () => {
+        await result.current.registrarPagosBatch({
+          clienteId: 'c1',
+          pedidoId: 'p1',
+          fecha: '2026-08-05',
+          pagos: [
+            { formaPago: 'efectivo', monto: 0 },      // se filtra
+            { formaPago: 'transferencia', monto: 500 },
+          ],
+          clientRequestIds: ['uuid-linea-0', 'uuid-linea-1'],
+        })
+      })
+
+      // La linea que sobrevive es la #1: tiene que llevar SU uuid, no el de la #0.
+      expect(mockInsert).toHaveBeenCalledWith([expect.objectContaining({
+        monto: 500,
+        forma_pago: 'transferencia',
+        client_request_id: 'uuid-linea-1',
+      })])
+    })
+
+    it('ante 23505 devuelve las filas del intento anterior', async () => {
+      const previos = [{ id: '10', monto: 300 }, { id: '11', monto: 200 }]
+      mockSelect.mockResolvedValueOnce({ data: null, error: { code: '23505', message: 'duplicate key' } })
+      mockIn.mockResolvedValueOnce({ data: previos, error: null })
+
+      const { result } = renderHook(() => usePagos())
+      let pagos: unknown
+      await act(async () => {
+        pagos = await result.current.registrarPagosBatch({
+          clienteId: 'c1',
+          pedidoId: 'p1',
+          fecha: '2026-08-05',
+          pagos: [
+            { formaPago: 'efectivo', monto: 300 },
+            { formaPago: 'transferencia', monto: 200 },
+          ],
+          clientRequestIds: ['uuid-a', 'uuid-b'],
+        })
+      })
+
+      expect(mockIn).toHaveBeenCalledWith('client_request_id', ['uuid-a', 'uuid-b'])
+      expect(pagos).toEqual(previos)
+    })
+  })
+
+  describe('registrarPagoFIFO — idempotencia', () => {
+    it('manda p_client_request_id y expone idempotent_replay', async () => {
+      ;(supabase.rpc as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+        data: {
+          pago_ids: [3280], sobrante: 0, monto_total: 111280,
+          aplicaciones: [], credito_aplicado: 0, idempotent_replay: true,
+        },
+        error: null,
+      })
+
+      const { result } = renderHook(() => usePagos())
+      let res: { idempotentReplay?: boolean } | undefined
+      await act(async () => {
+        res = await result.current.registrarPagoFIFO({
+          clienteId: 'c1', monto: 111280, formaPago: 'efectivo',
+          clientRequestId: 'uuid-fifo',
+        })
+      })
+
+      expect(supabase.rpc).toHaveBeenCalledWith(
+        'registrar_pago_cliente_fifo',
+        expect.objectContaining({ p_client_request_id: 'uuid-fifo' }),
+      )
+      expect(res!.idempotentReplay).toBe(true)
     })
   })
 

--- a/src/hooks/supabase/usePagos.ts
+++ b/src/hooks/supabase/usePagos.ts
@@ -1,6 +1,7 @@
 import { useState } from 'react'
 import { supabase, notifyError } from './base'
 import { useSucursal } from '../../contexts/SucursalContext'
+import { retryWithBackoff, isTransientNetworkError } from '../../utils/retryWithBackoff'
 import type {
   PagoDBWithUsuario,
   PagoFormInput,
@@ -15,6 +16,27 @@ import type {
   PedidoDB,
   PagoDB
 } from '../../types'
+
+/** Violación de unique constraint: el reintento chocó con la fila que ya existe. */
+const ES_DUPLICADO = (error: unknown): boolean =>
+  (error as { code?: string } | null)?.code === '23505'
+
+/**
+ * Recupera las filas que dejó un intento anterior del mismo pago (mig 167).
+ * Devuelve `null` si no hay UUIDs o si RLS no deja leerlas.
+ */
+async function pagosPorRequestId(ids: string[]): Promise<PagoDBWithUsuario[] | null> {
+  if (ids.length === 0) return null
+  const { data, error } = await supabase
+    .from('pagos')
+    .select('*, usuario:perfiles(id, nombre)')
+    .in('client_request_id', ids)
+  if (error) return null
+  return (data || []) as PagoDBWithUsuario[]
+}
+
+const ERROR_DUPLICADO_SIN_LECTURA =
+  'Este pago ya se había registrado en un intento anterior. Actualizá la pantalla para verlo; no lo cargues de nuevo.'
 
 export function usePagos(): UsePagosReturnExtended {
   const { currentSucursalId } = useSucursal()
@@ -74,11 +96,32 @@ export function usePagos(): UsePagosReturnExtended {
       // fecha (YYYY-MM-DD) se pasa solo si el caller la especificó; si no,
       // la BD usa CURRENT_DATE (default de la columna pagos.fecha).
       if (pago.fecha) insertRow.fecha = pago.fecha
+      const requestId = pago.clientRequestId || null
+      if (requestId) insertRow.client_request_id = requestId
 
-      const { data, error } = await supabase.from('pagos').insert([insertRow])
-        .select('*, usuario:perfiles(id, nombre)').single()
-      if (error) throw error
-      const pagoData = data as PagoDBWithUsuario
+      const insertar = async (): Promise<PagoDBWithUsuario> => {
+        const { data, error } = await supabase.from('pagos').insert([insertRow])
+          .select('*, usuario:perfiles(id, nombre)').single()
+        if (!error) return data as PagoDBWithUsuario
+
+        // 23505 con UUID de idempotencia = este pago ya entró en un intento
+        // anterior cuya respuesta no llegó (mig 167). No es un error: es el
+        // mismo pago. Devolvemos la fila que ya existe.
+        if (requestId && ES_DUPLICADO(error)) {
+          const previos = await pagosPorRequestId([requestId])
+          if (previos && previos.length === 1) return previos[0]
+          throw new Error(ERROR_DUPLICADO_SIN_LECTURA)
+        }
+        throw error
+      }
+
+      // Con UUID el INSERT es idempotente, así que reintentar ante un error de
+      // red es seguro: si la primera request sí llegó, el reintento devuelve
+      // esa misma fila en vez de duplicarla.
+      const pagoData = requestId
+        ? await retryWithBackoff(insertar, { shouldRetry: isTransientNetworkError })
+        : await insertar()
+
       setPagos(prev => [pagoData, ...prev])
       return pagoData
     } catch (error) {
@@ -102,9 +145,13 @@ export function usePagos(): UsePagosReturnExtended {
       if (currentSucursalId == null) {
         throw new Error('No hay sucursal activa. Recargá la página e intentá de nuevo.')
       }
+      // El UUID de idempotencia se aparea ANTES de filtrar: `clientRequestIds`
+      // viene alineado por posición con `input.pagos`, y filtrar primero
+      // correría los índices.
       const rows = input.pagos
-        .filter(p => p.monto > 0)
-        .map(p => ({
+        .map((p, i) => ({ p, requestId: input.clientRequestIds?.[i] || null }))
+        .filter(({ p }) => p.monto > 0)
+        .map(({ p, requestId }) => ({
           cliente_id: input.clienteId,
           pedido_id: input.pedidoId,
           monto: p.monto,
@@ -113,16 +160,37 @@ export function usePagos(): UsePagosReturnExtended {
           notas: input.observaciones || null,
           usuario_id: input.usuarioId || null,
           sucursal_id: currentSucursalId,
+          client_request_id: requestId,
         }))
       if (rows.length === 0) {
         throw new Error('No hay pagos validos para registrar')
       }
-      const { data, error } = await supabase
-        .from('pagos')
-        .insert(rows)
-        .select('*, usuario:perfiles(id, nombre)')
-      if (error) throw error
-      const pagosData = (data || []) as PagoDBWithUsuario[]
+      const requestIds = rows
+        .map(r => r.client_request_id)
+        .filter((id): id is string => !!id)
+      const todosConRequestId = requestIds.length === rows.length
+
+      const insertar = async (): Promise<PagoDBWithUsuario[]> => {
+        const { data, error } = await supabase
+          .from('pagos')
+          .insert(rows)
+          .select('*, usuario:perfiles(id, nombre)')
+        if (!error) return (data || []) as PagoDBWithUsuario[]
+
+        // Mismo caso que en registrarPago, pero el INSERT es atómico: o entraron
+        // las N filas o ninguna. Si chocaron, ya están todas de un intento previo.
+        if (todosConRequestId && ES_DUPLICADO(error)) {
+          const previos = await pagosPorRequestId(requestIds)
+          if (previos && previos.length === rows.length) return previos
+          throw new Error(ERROR_DUPLICADO_SIN_LECTURA)
+        }
+        throw error
+      }
+
+      const pagosData = todosConRequestId
+        ? await retryWithBackoff(insertar, { shouldRetry: isTransientNetworkError })
+        : await insertar()
+
       setPagos(prev => [...pagosData, ...prev])
       return pagosData
     } catch (error) {
@@ -145,15 +213,25 @@ export function usePagos(): UsePagosReturnExtended {
       if (currentSucursalId == null) {
         throw new Error('No hay sucursal activa. Recargá la página e intentá de nuevo.')
       }
-      const { data, error } = await supabase.rpc('registrar_pago_cliente_fifo', {
-        p_cliente_id: input.clienteId,
-        p_monto: input.monto,
-        p_forma_pago: input.formaPago,
-        p_fecha: input.fecha ?? null,
-        p_referencia: input.referencia ?? null,
-        p_notas: input.notas ?? null,
-      })
-      if (error) throw error
+      const llamar = async () => {
+        const { data, error } = await supabase.rpc('registrar_pago_cliente_fifo', {
+          p_cliente_id: input.clienteId,
+          p_monto: input.monto,
+          p_forma_pago: input.formaPago,
+          p_fecha: input.fecha ?? null,
+          p_referencia: input.referencia ?? null,
+          p_notas: input.notas ?? null,
+          p_client_request_id: input.clientRequestId ?? null,
+        })
+        if (error) throw error
+        return data
+      }
+
+      // La RPC es idempotente con p_client_request_id (mig 167): ante un error
+      // de red se reintenta y el server devuelve la imputación original.
+      const data = input.clientRequestId
+        ? await retryWithBackoff(llamar, { shouldRetry: isTransientNetworkError })
+        : await llamar()
 
       const raw = (data ?? {}) as {
         pago_ids?: number[]
@@ -161,6 +239,7 @@ export function usePagos(): UsePagosReturnExtended {
         monto_total?: number
         aplicaciones?: PagoFifoAplicacion[]
         credito_aplicado?: number
+        idempotent_replay?: boolean
       }
 
       return {
@@ -169,6 +248,7 @@ export function usePagos(): UsePagosReturnExtended {
         montoTotal: Number(raw.monto_total ?? input.monto),
         aplicaciones: raw.aplicaciones ?? [],
         creditoAplicado: Number(raw.credito_aplicado ?? 0),
+        idempotentReplay: raw.idempotent_replay === true,
       }
     } catch (error) {
       notifyError('Error al registrar pago: ' + (error as Error).message)
@@ -191,14 +271,22 @@ export function usePagos(): UsePagosReturnExtended {
       if (currentSucursalId == null) {
         throw new Error('No hay sucursal activa. Recargá la página e intentá de nuevo.')
       }
-      const { data, error } = await supabase.rpc('registrar_pago_combinado_cliente_fifo', {
-        p_cliente_id: input.clienteId,
-        p_metodos: input.metodos.map(m => ({ monto: m.monto, forma_pago: m.formaPago })),
-        p_fecha: input.fecha ?? null,
-        p_referencia: input.referencia ?? null,
-        p_notas: input.notas ?? null,
-      })
-      if (error) throw error
+      const llamar = async () => {
+        const { data, error } = await supabase.rpc('registrar_pago_combinado_cliente_fifo', {
+          p_cliente_id: input.clienteId,
+          p_metodos: input.metodos.map(m => ({ monto: m.monto, forma_pago: m.formaPago })),
+          p_fecha: input.fecha ?? null,
+          p_referencia: input.referencia ?? null,
+          p_notas: input.notas ?? null,
+          p_client_request_id: input.clientRequestId ?? null,
+        })
+        if (error) throw error
+        return data
+      }
+
+      const data = input.clientRequestId
+        ? await retryWithBackoff(llamar, { shouldRetry: isTransientNetworkError })
+        : await llamar()
 
       const raw = (data ?? {}) as {
         pago_ids?: number[]
@@ -206,6 +294,7 @@ export function usePagos(): UsePagosReturnExtended {
         monto_total?: number
         aplicaciones?: PagoFifoAplicacion[]
         credito_aplicado?: number
+        idempotent_replay?: boolean
       }
 
       return {
@@ -214,6 +303,7 @@ export function usePagos(): UsePagosReturnExtended {
         montoTotal: Number(raw.monto_total ?? 0),
         aplicaciones: raw.aplicaciones ?? [],
         creditoAplicado: Number(raw.credito_aplicado ?? 0),
+        idempotentReplay: raw.idempotent_replay === true,
       }
     } catch (error) {
       notifyError('Error al registrar pago: ' + (error as Error).message)

--- a/src/hooks/useRequestIdEstable.test.ts
+++ b/src/hooks/useRequestIdEstable.test.ts
@@ -1,0 +1,59 @@
+/**
+ * Tests de `useRequestIdEstable` — el UUID de idempotencia de los pagos (mig 167).
+ *
+ * La regla que importa: mismo pago => mismo UUID (el server lo deduplica),
+ * pago distinto => UUID distinto (se registra aparte, como corresponde).
+ */
+import { describe, it, expect } from 'vitest'
+import { renderHook } from '@testing-library/react'
+import { useRequestIdEstable } from './useRequestIdEstable'
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
+
+describe('useRequestIdEstable', () => {
+  it('devuelve un UUID v4 valido', () => {
+    const { result } = renderHook(() => useRequestIdEstable())
+    expect(result.current('pago|c1|1000|efectivo')).toMatch(UUID_RE)
+  })
+
+  it('devuelve el MISMO UUID para la misma huella (reintento del mismo pago)', () => {
+    const { result } = renderHook(() => useRequestIdEstable())
+    const huella = 'pago|c1|111280|efectivo|2026-07-13'
+
+    const primerIntento = result.current(huella)
+    const segundoIntento = result.current(huella)
+    const tercerIntento = result.current(huella)
+
+    expect(segundoIntento).toBe(primerIntento)
+    expect(tercerIntento).toBe(primerIntento)
+  })
+
+  it('devuelve un UUID nuevo si cambia el monto (es otro pago, no un reintento)', () => {
+    const { result } = renderHook(() => useRequestIdEstable())
+
+    const conMonto1000 = result.current('pago|c1|1000|efectivo')
+    const conMonto2000 = result.current('pago|c1|2000|efectivo')
+
+    expect(conMonto2000).not.toBe(conMonto1000)
+  })
+
+  it('da UUIDs distintos por linea de un pago dividido', () => {
+    const { result } = renderHook(() => useRequestIdEstable())
+    const base = 'divid|c1|p1|2026-08-05'
+
+    const ids = [0, 1, 2].map(i => result.current(`${base}#${i}`))
+
+    expect(new Set(ids).size).toBe(3)
+    // y siguen siendo estables entre reintentos
+    expect([0, 1, 2].map(i => result.current(`${base}#${i}`))).toEqual(ids)
+  })
+
+  it('sobrevive al re-render (el UUID no se regenera en cada pasada)', () => {
+    const { result, rerender } = renderHook(() => useRequestIdEstable())
+    const antes = result.current('pago|c1|1000|efectivo')
+
+    rerender()
+
+    expect(result.current('pago|c1|1000|efectivo')).toBe(antes)
+  })
+})

--- a/src/hooks/useRequestIdEstable.ts
+++ b/src/hooks/useRequestIdEstable.ts
@@ -1,0 +1,34 @@
+import { useCallback, useRef } from 'react'
+import { nuevoRequestId } from '../utils/idempotencia'
+
+/**
+ * Devuelve un UUID **estable por intención de escritura**.
+ *
+ * La regla es: mientras la huella no cambie, todos los intentos reciben el mismo
+ * UUID y el servidor los deduplica (mig 167). Si el usuario edita el monto o la
+ * forma de pago, la huella cambia, sale un UUID nuevo y eso sí se registra
+ * aparte — porque es otro pago, no un reintento.
+ *
+ * Esto es lo que cubre el agujero real: el botón ya se deshabilita mientras la
+ * request está en vuelo, pero si la respuesta se pierde el modal muestra un
+ * error, el usuario vuelve a apretar y hoy eso inserta el pago de nuevo (pedido
+ * 3602: el mismo pago tres veces en 17 segundos).
+ *
+ * @example
+ * const requestId = useRequestIdEstable()
+ * const huella = `${clienteId}|${monto}|${formaPago}|${fecha}`
+ * await registrarPago({ ..., clientRequestId: requestId(huella) })
+ * // para un pago dividido, un UUID por línea:
+ * const ids = lineas.map((_, i) => requestId(`${huella}#${i}`))
+ */
+export function useRequestIdEstable(): (huella: string) => string {
+  const cache = useRef<Map<string, string>>(new Map())
+
+  return useCallback((huella: string): string => {
+    const existente = cache.current.get(huella)
+    if (existente) return existente
+    const id = nuevoRequestId()
+    cache.current.set(huella, id)
+    return id
+  }, [])
+}

--- a/src/types/hooks.ts
+++ b/src/types/hooks.ts
@@ -758,6 +758,12 @@ export interface PagoFormInput {
   usuarioId?: string | null;
   /** Fecha contable del pago (YYYY-MM-DD). Si se omite, usa CURRENT_DATE. */
   fecha?: string | null;
+  /**
+   * UUID de idempotencia (mig 167). Si se manda, un reintento del mismo pago
+   * choca contra `idx_pagos_client_request_id` y devuelve la fila que ya existe
+   * en vez de duplicarla. Generarlo con `useRequestIdEstable`.
+   */
+  clientRequestId?: string | null;
 }
 
 export interface ResumenCuenta {
@@ -779,6 +785,11 @@ export interface RegistrarPagoBatchInput {
   observaciones?: string | null;
   pagos: Array<{ formaPago: string; monto: number }>;
   usuarioId?: string | null;
+  /**
+   * UUID de idempotencia por línea de `pagos`, alineado por posición (mig 167).
+   * Cada fila va con el suyo porque el índice único es por fila.
+   */
+  clientRequestIds?: string[];
 }
 
 export interface PagoFifoAplicacion {
@@ -798,6 +809,8 @@ export interface RegistrarPagoFifoInput {
   fecha?: string;
   referencia?: string;
   notas?: string;
+  /** UUID de idempotencia (mig 167). Ver `useRequestIdEstable`. */
+  clientRequestId?: string;
 }
 
 export interface RegistrarPagoFifoResult {
@@ -811,6 +824,12 @@ export interface RegistrarPagoFifoResult {
    * cancelaron más boletas de las que cubre `montoTotal`.
    */
   creditoAplicado: number;
+  /**
+   * true si el servidor reconoció el `clientRequestId` y devolvió el resultado
+   * de un intento anterior (mig 167). No se registró nada nuevo: el pago ya
+   * estaba. Sirve para avisarle al usuario que su primer intento sí entró.
+   */
+  idempotentReplay?: boolean;
 }
 
 /**
@@ -824,6 +843,8 @@ export interface RegistrarPagoCombinadoFifoInput {
   fecha?: string;
   referencia?: string;
   notas?: string;
+  /** UUID de idempotencia (mig 167). Ver `useRequestIdEstable`. */
+  clientRequestId?: string;
 }
 
 export interface UsePagosReturnExtended {

--- a/src/utils/idempotencia.ts
+++ b/src/utils/idempotencia.ts
@@ -1,0 +1,35 @@
+/**
+ * UUIDs de idempotencia para escrituras que no se pueden duplicar (pagos).
+ *
+ * El servidor (mig 167) deduplica por `client_request_id`: si ya vio ese UUID,
+ * devuelve el resultado de la primera vez en lugar de volver a escribir. Para
+ * que eso sirva, el UUID tiene que ser el MISMO en todos los reintentos del
+ * mismo pago y DISTINTO si el usuario cambia el monto o la forma de pago —
+ * de eso se encarga `useRequestIdEstable`.
+ */
+
+/**
+ * `crypto.randomUUID` necesita contexto seguro y no existe en iOS Safari < 15.4.
+ * La app corre en el reparto, en teléfonos viejos, así que hay fallback sobre
+ * `getRandomValues` (v4 armado a mano) antes de caer en algo no criptográfico.
+ */
+export function nuevoRequestId(): string {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID()
+  }
+
+  if (typeof crypto !== 'undefined' && typeof crypto.getRandomValues === 'function') {
+    const bytes = crypto.getRandomValues(new Uint8Array(16))
+    bytes[6] = (bytes[6] & 0x0f) | 0x40 // versión 4
+    bytes[8] = (bytes[8] & 0x3f) | 0x80 // variante RFC 4122
+    const hex = Array.from(bytes, b => b.toString(16).padStart(2, '0')).join('')
+    return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`
+  }
+
+  // Último recurso: no hay crypto. Peor un UUID débil que ninguno — igual solo
+  // tiene que ser único dentro de la ventana de reintentos de un pago.
+  return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, c => {
+    const r = (Math.random() * 16) | 0
+    return (c === 'x' ? r : (r & 0x3) | 0x8).toString(16)
+  })
+}


### PR DESCRIPTION
## El problema

El pedido **3602** (cliente 303, "MARCOS CHOFER") tiene el mismo pago de **$111.280 insertado 3 veces** — `pagos` 3280, 3281 y 3282, el 2026-07-13 a las 22:53:20, 22:53:27 y 22:53:37. Diecisiete segundos, mismo monto, misma forma de pago. Dejó al cliente con `saldo_cuenta = -222.560`, y es el único sobrepago que la mig 166 dejó afuera a propósito (no es crédito real: convertirlo en saldo a favor habría propagado el error a boletas futuras).

El registro de pagos no tenía ninguna guarda: nada del lado del server distinguía un reintento de un cobro nuevo. Si la request llegaba pero la respuesta se perdía —PWA en el reparto, "Load failed" de iOS—, el usuario veía un error, volvía a apretar y la plata se duplicaba. Es el mismo agujero que la mig 049 ya había tapado para `registrar_salvedad`.

## Prevención (mig 167)

Dos mecanismos, uno por cada forma en que se escribe en `pagos`:

| Camino | Mecanismo |
|---|---|
| INSERT directo por PostgREST (`usePagos.registrarPago` / `registrarPagosBatch`: cobro de parada, modal de pago del pedido) | Columna `pagos.client_request_id` + índice único parcial. El reintento choca con 23505 y el front relee la fila que ya existe. |
| Las 4 RPCs (`registrar_pago_cliente_fifo`, `registrar_pago_combinado_cliente_fifo`, `marcar_pagos_masivo`, `marcar_entrega_y_pago_masivo`), que pueden insertar N filas por llamada | Ledger `pagos_solicitudes` con el uuid como PK y el `resultado` guardado para devolverlo tal cual en el replay. Serializa con `pg_advisory_xact_lock`. |

Sin uuid el comportamiento es el histórico (`DEFAULT NULL`), así que **la migración va primero y el front después**.

### ⚠️ Las 4 RPCs ahora son wrappers

Se renombraron a `<nombre>_impl` y el nombre público es un wrapper que deduplica y delega. Fue a propósito: `migrations/` no es 1:1 con prod y estas RPCs ya habían driftado (ver la nota de la mig 100), así que reescribir los cuerpos desde el archivo del repo se habría llevado puesto lo que solo vive en prod.

**Al tocarlas después: la lógica de negocio vive en la `_impl`.** Un `CREATE OR REPLACE` del nombre público borra el wrapper y con él la idempotencia, en silencio. Anotado en `MANIFEST.md`.

### Front

`useRequestIdEstable(huella)` acuña un uuid **estable mientras la huella no cambia**: reintentar el mismo pago reusa el uuid y el server lo deduplica; cambiar el monto o la forma de pago acuña uno nuevo, porque eso sí es otro pago. Más `enVueloRef` contra el doble toque instantáneo — el `disabled` solo no alcanza, dos taps pueden disparar dos submits antes de que React re-renderice. Las RPCs FIFO quedaron envueltas en el `retryWithBackoff` que ya existía en el repo (su docstring dice literalmente que es para RPCs con `client_request_id`).

## Verificación

Corrí la migración de verdad contra un Postgres en Docker con un andamio mínimo:

| Escenario | Resultado |
|---|---|
| 3 llamadas FIFO con el mismo uuid (el caso 3602) | 1 sola fila en `pagos`; el replay devuelve la imputación original |
| Dos sesiones concurrentes, mismo uuid | la 2ª bloqueó 1968 ms y devolvió `idempotent_replay`; 1 sola fila |
| uuid distinto | registra pago nuevo (no se rompe el caso legítimo) |
| sin uuid | comportamiento histórico intacto |
| INSERT directo repetido | rebota con 23505 |
| `client_request_id` NULL en filas viejas | conviven, el índice parcial no las toca |
| re-aplicar la 167 | idempotente; sigue habiendo una sola firma pública por RPC |
| grants | `_impl`, `pago_solicitud_*` y `pagos_solicitudes` inaccesibles para `authenticated` |

974 tests pasan (21 nuevos), `tsc` limpio, lint limpio.

No verifiqué en el navegador a propósito: sin la migración aplicada el front tira PGRST202, y ejercitar el flujo de cobro contra prod crearía pagos reales.

## Limpieza del dato viejo

`scripts/fix-pedido-3602-pagos-duplicados.sql` borra los pagos 3281 y 3282 (Agustín confirmó que fueron error de carga). Corre en una transacción con cuatro guardas: aborta si no encuentra exactamente las 2 filas de $111.280, si falta el 3280, si los triggers no devuelven exactamente $222.560, o si el pedido queda sobrepagado.

## Lo que quedó afuera

El 3602 se coló **con el botón ya deshabilitado en vuelo**, así que la idempotencia sola no cubre tres clics deliberados y espaciados. La guarda que lo frenaría pase lo que pase es rechazar todo pago que deje `monto_pagado > total` — el invariante que la mig 165 ya declara. Se decidió no incluirlo en este PR porque cambia qué pagos acepta la app; queda como posible 168.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
