### PR TITLE
fix(pagos): rechazar mercadería no genera saldo a favor, reduce el pago

### DIFF
--- a/migrations/167_baja_de_total_reduce_el_pago.sql
+++ b/migrations/167_baja_de_total_reduce_el_pago.sql
@@ -1,0 +1,104 @@
+-- 167_baja_de_total_reduce_el_pago.sql
+--
+-- CORRIGE LA POLITICA DE LA MIG 165.
+--
+-- La 165 asumia que si una boleta quedaba con monto_pagado > total, el cliente
+-- habia pagado de mas y le quedaba credito a favor. Es falso para esta operacion.
+--
+-- Evidencia (los 8 casos historicos, reconstruidos desde audit_logs):
+--
+--   pedido | pago registrado | total previo a la baja
+--   -------|-----------------|-----------------------
+--    1142  |      46.360     |      46.360
+--    1148  |      23.400     |      23.400
+--    1656  |      60.000     |      60.000
+--    1821  |      31.100     |      31.100
+--    2083  |      21.500     |      21.500
+--    3053  |      16.900     |      16.900
+--    3251  |     628.300     |     628.300
+--    3329  |      21.700     |      21.700
+--
+-- 8 de 8: el pago era EXACTAMENTE el total previo. Eso no es que el cliente
+-- pagara de mas; es que se cobro la boleta por el total del pedido y despues se
+-- bajo el total. Cuando el cliente rechaza mercaderia no la paga, simplemente
+-- entrega menos. El pago quedo inflado por la diferencia.
+--
+-- Politica nueva: bajar el total de una boleta ya cobrada REDUCE el pago, no
+-- genera credito. La plata que si entra de mas sigue generando saldo a favor por
+-- el otro camino (`registrar_pago_cliente_fifo`, cuando sobra despues de cubrir
+-- todas las boletas), que es un saldo a favor genuino y no se toca.
+--
+-- OJO — esto SI mueve la caja del dia, a diferencia de una reimputacion: si el
+-- chofer nunca trajo esa plata, la rendicion de ese dia estaba inflada. Por eso
+-- esta funcion, a diferencia de `aplicar_credito_cliente`, NO usa el escape del
+-- guard de caja cerrada: si el dia ya fue rendido y cerrado, la operacion se
+-- bloquea y hay que reabrir la rendicion. El UPDATE del monto va siempre primero
+-- (aunque deje la fila en cero) justamente para que el guard corra.
+
+CREATE OR REPLACE FUNCTION public.desafectar_sobrepago_pedido(p_pedido_id bigint)
+RETURNS numeric
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $function$
+DECLARE
+  v_pedido     RECORD;
+  v_pago       RECORD;
+  v_excedente  numeric;
+  v_quitar     numeric;
+  v_quitado    numeric := 0;
+BEGIN
+  SELECT id, total, COALESCE(monto_pagado, 0) AS pagado, estado
+    INTO v_pedido
+    FROM pedidos
+   WHERE id = p_pedido_id;
+
+  IF NOT FOUND THEN
+    RETURN 0;
+  END IF;
+
+  IF v_pedido.estado IN ('cancelado', 'anulado') THEN
+    RETURN 0;
+  END IF;
+
+  v_excedente := v_pedido.pagado - v_pedido.total;
+  IF v_excedente <= 0.005 THEN
+    RETURN 0;
+  END IF;
+
+  -- Se recorta desde el pago mas nuevo: el excedente es lo ultimo que se cargo.
+  FOR v_pago IN
+    SELECT id, monto
+      FROM pagos
+     WHERE pedido_id = p_pedido_id
+     ORDER BY fecha DESC, id DESC
+  LOOP
+    EXIT WHEN v_excedente <= 0.005;
+
+    v_quitar := LEAST(v_pago.monto, v_excedente);
+
+    -- Siempre pasa por el UPDATE de monto (aunque quede en cero) para que corra
+    -- `guard_pago_fecha_cerrada`. Un DELETE directo no lo dispara y dejaria
+    -- modificar en silencio una rendicion ya cerrada.
+    UPDATE pagos
+       SET monto = monto - v_quitar,
+           notas = trim(COALESCE(notas, '') ||
+                        ' [ajustado -' || trim(to_char(v_quitar, 'FM999999990.00')) ||
+                        ' por baja de total del pedido ' || p_pedido_id || ']')
+     WHERE id = v_pago.id;
+
+    DELETE FROM pagos WHERE id = v_pago.id AND monto <= 0.005;
+
+    v_excedente := v_excedente - v_quitar;
+    v_quitado   := v_quitado + v_quitar;
+  END LOOP;
+
+  RETURN v_quitado;
+END;
+$function$;
+
+REVOKE ALL ON FUNCTION public.desafectar_sobrepago_pedido(bigint) FROM PUBLIC, anon, authenticated;
+
+-- `aplicar_credito_cliente` NO cambia: consumir saldo a favor genuino contra las
+-- boletas pendientes sigue siendo correcto, y ahi el escape del guard si aplica
+-- porque reimputar preserva fecha, forma de pago y monto total del dia.

--- a/migrations/168_revertir_creditos_falsos_del_backfill.sql
+++ b/migrations/168_revertir_creditos_falsos_del_backfill.sql
@@ -1,0 +1,56 @@
+-- 168_revertir_creditos_falsos_del_backfill.sql
+--
+-- La mig 166 saco el excedente de las 8 boletas sobrepagadas y lo convirtio en saldo
+-- a favor (pagos 4156..4163). Esa segunda mitad estaba mal: ese credito nunca existio
+-- (ver el detalle de la evidencia en la mig 167). Los clientes no tenian plata a favor;
+-- las boletas estaban cobradas de mas.
+--
+-- La primera mitad de la 166 SI era correcta y se conserva: los pagos ya quedaron
+-- reducidos al total real de cada boleta.
+--
+-- Esta migracion borra solamente las 8 filas de credito inventado. Al borrarlas, los
+-- triggers `recalcular_monto_pagado_pedido` y `actualizar_saldo_cliente` recalculan
+-- solos el monto_pagado de las boletas y el saldo de cada cliente.
+--
+-- NO se toca el pago 2306 ($50 de TITA MALDONADO, imputado al pedido 3880): ese es un
+-- saldo a favor genuino, generado por el FIFO el 2026-06-15 cuando sobro plata de un
+-- pago combinado. Ahi el cliente si entrego la plata.
+--
+-- Resultado esperado:
+--   #799 Despensa Dalma        39.410 -> 47.710  (= pendiente de la boleta 4452)
+--   #529 Marina Alfaro         22.350 -> 28.850
+--   #24  Los Redonditos       -10.200 ->      0
+--   #65  Marcos                -7.000 ->      0
+--   #523 Eugenio Mendez       -25.560 ->      0
+--   #424 Comercial TP         -33.300 ->      0
+--   #439 Refugio Comedor         -500 ->      0
+--   #648 Juan Romano           -6.000 ->      0
+
+DO $revert$
+DECLARE
+  v_borradas  integer;
+  v_restantes integer;
+BEGIN
+  DELETE FROM pagos
+   WHERE id BETWEEN 4156 AND 4163
+     AND COALESCE(notas, '') NOT LIKE '%[pago combinado]%';
+
+  GET DIAGNOSTICS v_borradas = ROW_COUNT;
+  RAISE NOTICE 'creditos falsos borrados: %', v_borradas;
+
+  IF v_borradas <> 8 THEN
+    RAISE EXCEPTION 'ABORTA: se esperaban 8 filas a borrar y se borraron %', v_borradas;
+  END IF;
+
+  -- Ningun cliente puede quedar con saldo negativo por esta via: si quedo alguno es
+  -- que habia credito genuino ademas, y hay que mirarlo a mano.
+  SELECT count(*) INTO v_restantes
+    FROM clientes
+   WHERE id IN (539, 545, 77, 664, 455, 36, 440, 815)
+     AND saldo_cuenta < -0.005;
+
+  IF v_restantes > 0 THEN
+    RAISE EXCEPTION 'ABORTA: quedaron % clientes con saldo negativo', v_restantes;
+  END IF;
+END;
+$revert$;

--- a/migrations/MANIFEST.md
+++ b/migrations/MANIFEST.md
@@ -52,6 +52,7 @@ número de archivo repetido en el repo (el orden real lo da `version`).
 | 100 | `100_costo_snapshot_y_creado_por_columnas.sql`, `100_marcar_entrega_y_pago_masivo.sql` | `costo_snapshot` (06-29, ver C) → `marcar_entrega_y_pago_masivo` (06-30) |
 | 139 | `139_movimientos_stock_preventivo.sql`, `139_guarda_precio_venta.sql` | `movimientos_stock_preventivo_*` (07-27 15:40, 5 filas, ver D) → `139_guarda_precio_venta` (07-27 17:22) |
 | 140 | `140_clientes_horario_canonico.sql`, `140_detalle_rendicion_cobrado_por.sql` | `140_clientes_horario_canonico` (07-27 18:27) → `detalle_rendicion_cobrado_por` (07-27 19:48, entre `144` y `145`) |
+| 167 | `167_pagos_idempotencia_client_request_id.sql`, `167_baja_de_total_reduce_el_pago.sql` | `167_pagos_idempotencia_client_request_id` (08-06 02:15) → `167_baja_de_total_reduce_el_pago` (08-06 04:08) — dos ramas en paralelo tomaron el mismo número el mismo día |
 
 ### B. Offset de numeración (repo va +1 respecto del ledger en 098–100)
 


### PR DESCRIPTION
Corrige la política de las migs 165/166 (PR #450). **Yo diagnostiqué al revés y la encargada de Tucumán tenía razón.**

## El error

La 165 asumía que una boleta con `monto_pagado > total` significaba que el cliente había pagado de más y le quedaba crédito. Con esa premisa concluí que el número correcto era el de la ficha ($39.410 en Despensa Dalma) y que la boleta ($47.710) estaba inflada.

Es al revés. Cuando el cliente rechaza mercadería **no la paga**: entrega menos. No queda saldo a favor. El número correcto era el de la **boleta**; la ficha venía descontando un pago fantasma.

## La evidencia

Reconstruida desde `audit_logs`, porque el backfill de la 166 ya había pisado las filas de `pagos`:

| pedido | pago registrado | total previo a la baja |
|---|---:|---:|
| 1142 | 46.360 | 46.360 |
| 1148 | 23.400 | 23.400 |
| 1656 | 60.000 | 60.000 |
| 1821 | 31.100 | 31.100 |
| 2083 | 21.500 | 21.500 |
| 3053 | 16.900 | 16.900 |
| 3251 | 628.300 | 628.300 |
| 3329 | 21.700 | 21.700 |

**8 de 8: el pago era exactamente el total previo.** Eso no es gente pagando de más — es el botón de cobrar usando el total del pedido y alguien bajando el total después. En el #3329 el pago entró **1 segundo** después de marcar entregado, y la salvedad casi 4 minutos más tarde.

## La distinción que queda codificada

- Plata que **entra** de más en un pago → el FIFO la deja como saldo a favor genuino (`pagos` con `pedido_id IS NULL`). Se respeta, no se toca.
- Total que **baja** después de cobrar → el pago estaba mal registrado. Se reduce.

## mig 167 — política

`desafectar_sobrepago_pedido()` pasa a **reducir** los pagos hasta el total real, en vez de convertir el excedente en crédito.

A diferencia de una reimputación, esto **sí mueve la caja del día**: si el chofer nunca trajo esa plata, la rendición estaba inflada. Por eso esta función —a diferencia de `aplicar_credito_cliente()`— **no usa el escape del guard de caja cerrada**: si la rendición está cerrada, bloquea y hay que reabrirla.

El `UPDATE` del monto va siempre antes del `DELETE`, aunque deje la fila en cero, porque un `DELETE` directo no dispara el guard y dejaría tocar en silencio una rendición ya rendida.

`aplicar_credito_cliente()` no cambia: ahí el escape sigue siendo válido porque reimputar preserva fecha, forma de pago y monto total del día.

## mig 168 — datos

Borra los 8 créditos inventados por la 166 (pagos 4156..4163). La primera mitad de la 166 **era correcta y se conserva**: los pagos ya habían quedado reducidos al total real.

No se toca el pago 2306 ($50 de TITA MALDONADO): ese saldo a favor es genuino, lo generó el FIFO el 2026-06-15 cuando sobró plata de un pago combinado.

| Cliente | Antes | Después |
|---|---:|---:|
| #799 Despensa Dalma | 39.410 | **47.710** |
| #529 Marina Alfaro | 22.350 | **28.850** |
| #24 Los Redonditos | −10.200 | **0** |
| #65 Marcos | −7.000 | **0** |
| #523 Eugenio Méndez | −25.560 | **0** |
| #424 Comercial TP | −33.300 | **0** |
| #439 Refugio Comedor | −500 | **0** |
| #648 Juan Romano | −6.000 | **0** |

**Resultado: 0 clientes descuadrados en toda la base.**

## Verificación

En transacción con `ROLLBACK` antes de aplicar:

- **Caja abierta** → reduce el pago; el #3329 queda en los $13.400 que el cliente realmente entregó y Dalma en $47.710, ficha = boleta.
- **Caja cerrada** (Taco Pozo, pago del 01/07 con caja cerrada hasta el 03/08) → bloquea con el mensaje de reabrir la rendición. El primer intento de este test dio un falso OK porque el pago ya estaba corregido por la 166; hubo que reconstruir el sobrepago para probarlo de verdad.

Typecheck limpio · **974 tests** en verde (rebasado sobre el main que ya trae la idempotencia del PR de `client_request_id`).

## Notas

- Ambas ramas tomaron el número **167** el mismo día. Queda anotado en la sección A del MANIFEST; el orden real lo da el `version` del ledger: idempotencia (02:15) → esta (04:08) → 168 (04:09).
- Migraciones ya aplicadas a prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
