### PR TITLE
Permitir cambiar el transportista de una ruta ya armada

### DIFF
--- a/migrations/172_cambiar_transportista_de_una_ruta.sql
+++ b/migrations/172_cambiar_transportista_de_una_ruta.sql
@@ -1,0 +1,190 @@
+-- =========================================================================
+-- 172_cambiar_transportista_de_una_ruta.sql
+--
+-- Reasignar una ruta YA ARMADA a otro transportista, sin rearmarla.
+--
+-- EL CASO
+-- -------
+-- En Taco Pozo la ruta del dia la arma el admin la tarde anterior. El 08/08
+-- Pablo armo la ruta del 09/08 (18 paradas) a nombre del transportista que
+-- estaba disponible en el picker; media hora despues se le habilito a Juan
+-- —preventista que acompaña al camion— la capacidad `transportista` (mig 155).
+-- La ruta quedo a nombre de quien NO la iba a repartir, y no habia forma de
+-- corregirlo: el unico camino era cancelarla y armarla de nuevo.
+--
+-- POR QUE NO ALCANZABA CON aplicar_orden_ruta
+-- -------------------------------------------
+-- Esa RPC busca el recorrido por (transportista_id, fecha, estado='en_curso',
+-- sucursal_id): el transportista es parte de la IDENTIDAD de la ruta, no un
+-- atributo editable. Elegir otro chofer y volver a armar no mueve la ruta,
+-- crea una SEGUNDA — y la original queda viva, con sus pedidos en `asignado`,
+-- fuera del pool de disponibles.
+--
+-- QUE HACE ESTA RPC
+-- -----------------
+-- Mueve la ruta entera de un chofer al otro en una sola transaccion:
+-- `recorridos.transportista_id` + el `transportista_id` de cada pedido de sus
+-- paradas. No toca el orden de entrega, la optimizacion ni las polylines: la
+-- ruta es la misma, cambia quien la reparte.
+--
+-- GUARDAS
+-- -------
+--   · es_encargado_o_admin(), igual gate que aplicar_orden_ruta.
+--   · La ruta y el destino tienen que ser de la sucursal activa.
+--   · El destino tiene que ser transportista HABILITADO ahi: rol base o
+--     capacidad extra de la mig 155. Es la misma condicion que arma el picker
+--     en el front (fetchTransportistas), replicada server-side para que no
+--     dependa de la UI.
+--   · Ruta en_curso. Una completada ya se rindio; reabrirla no es un cambio de
+--     chofer, es reabrir la caja del dia.
+--   · CERO entregas hechas. Si el chofer ya entrego y cobro una parada, la
+--     plata de ese dia es suya: mover la ruta partiria la rendicion entre dos
+--     personas. Paradas marcadas "no entregado" NO bloquean: no mueven plata y
+--     el caso real (se rompio el camion a media mañana) es justamente ese.
+--   · El destino no puede tener otra ruta en_curso esa fecha — es
+--     `uq_recorrido_vigente`. Se chequea explicito para devolver un mensaje
+--     util en vez de un 23505 crudo.
+--
+-- Idempotente: reasignar al mismo chofer que ya la tiene devuelve el id sin
+-- tocar nada, asi un doble click no es un error en pantalla.
+-- =========================================================================
+
+BEGIN;
+
+CREATE OR REPLACE FUNCTION public.cambiar_transportista_recorrido(
+  p_recorrido_id     bigint,
+  p_transportista_id uuid
+)
+RETURNS bigint
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $fn$
+DECLARE
+  v_sucursal   bigint := current_sucursal_id();
+  v_recorrido  recorridos%ROWTYPE;
+  v_entregadas integer;
+  v_conflicto  bigint;
+  v_nombre     text;
+BEGIN
+  IF NOT es_encargado_o_admin() THEN
+    RAISE EXCEPTION 'No autorizado para cambiar el transportista de una ruta'
+      USING ERRCODE = '42501';
+  END IF;
+
+  IF v_sucursal IS NULL THEN
+    RAISE EXCEPTION 'Sucursal no resuelta para el usuario actual';
+  END IF;
+
+  IF p_transportista_id IS NULL THEN
+    RAISE EXCEPTION 'Hay que elegir un transportista';
+  END IF;
+
+  -- FOR UPDATE: sin el lock, dos admins reasignando en paralelo pueden pasar
+  -- los dos el chequeo de uq_recorrido_vigente y uno se come el 23505.
+  SELECT * INTO v_recorrido
+  FROM recorridos
+  WHERE id = p_recorrido_id
+    AND sucursal_id = v_sucursal
+  FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'La ruta #% no existe en esta sucursal', p_recorrido_id
+      USING ERRCODE = 'P0002';
+  END IF;
+
+  IF v_recorrido.transportista_id = p_transportista_id THEN
+    RETURN p_recorrido_id;  -- ya esta a su nombre: no-op
+  END IF;
+
+  IF v_recorrido.estado <> 'en_curso' THEN
+    RAISE EXCEPTION 'La ruta #% esta %, solo se puede reasignar una ruta en curso',
+      p_recorrido_id, v_recorrido.estado;
+  END IF;
+
+  -- Habilitado como transportista EN ESTA SUCURSAL (rol base o mig 155),
+  -- activo y asignado aca. Espeja fetchTransportistas() del front.
+  SELECT p.nombre INTO v_nombre
+  FROM perfiles p
+  WHERE p.id = p_transportista_id
+    AND p.activo
+    AND EXISTS (
+      SELECT 1 FROM usuario_sucursales us
+      WHERE us.usuario_id = p.id AND us.sucursal_id = v_sucursal
+    )
+    AND (
+      p.rol = 'transportista'
+      OR EXISTS (
+        SELECT 1 FROM perfil_roles pr
+        WHERE pr.usuario_id  = p.id
+          AND pr.sucursal_id = v_sucursal
+          AND pr.rol         = 'transportista'
+      )
+    );
+
+  IF v_nombre IS NULL THEN
+    RAISE EXCEPTION 'El usuario elegido no esta habilitado como transportista en esta sucursal';
+  END IF;
+
+  -- Entregas ya hechas: la rendicion del dia quedaria partida entre dos.
+  SELECT COUNT(*) INTO v_entregadas
+  FROM recorrido_pedidos rp
+  JOIN pedidos p ON p.id = rp.pedido_id
+  WHERE rp.recorrido_id = p_recorrido_id
+    AND (rp.estado_entrega = 'entregado' OR p.estado = 'entregado');
+
+  IF v_entregadas > 0 THEN
+    RAISE EXCEPTION
+      'La ruta #% ya tiene % entrega(s) hecha(s) por %. Sacale esas paradas o armale una ruta nueva al otro chofer.',
+      p_recorrido_id,
+      v_entregadas,
+      COALESCE((SELECT nombre FROM perfiles WHERE id = v_recorrido.transportista_id), 'el chofer actual');
+  END IF;
+
+  -- uq_recorrido_vigente (transportista_id, fecha, sucursal_id) WHERE en_curso
+  SELECT id INTO v_conflicto
+  FROM recorridos
+  WHERE transportista_id = p_transportista_id
+    AND fecha            = v_recorrido.fecha
+    AND sucursal_id      = v_sucursal
+    AND estado           = 'en_curso'
+  LIMIT 1;
+
+  IF v_conflicto IS NOT NULL THEN
+    RAISE EXCEPTION
+      '% ya tiene la ruta #% armada para el %. Pasale las paradas a esa en vez de duplicarla.',
+      v_nombre, v_conflicto, to_char(v_recorrido.fecha, 'DD/MM/YYYY');
+  END IF;
+
+  UPDATE recorridos
+  SET transportista_id = p_transportista_id
+  WHERE id = p_recorrido_id;
+
+  -- Los pedidos tambien: `pedidos.transportista_id` es lo que leen la PWA del
+  -- chofer, las policies de `pagos` (mig 155) y la rendicion. Sin esto la ruta
+  -- cambia de nombre en el listado y el chofer nuevo no la ve.
+  -- `estado <> 'entregado'` es defensivo: arriba ya garantizamos que no hay
+  -- ninguno, pero deja explicito que una entrega hecha nunca cambia de dueño.
+  UPDATE pedidos p
+  SET transportista_id = p_transportista_id
+  FROM recorrido_pedidos rp
+  WHERE rp.recorrido_id = p_recorrido_id
+    AND p.id            = rp.pedido_id
+    AND p.sucursal_id   = v_sucursal
+    AND p.estado <> 'entregado';
+
+  RETURN p_recorrido_id;
+END;
+$fn$;
+
+REVOKE ALL ON FUNCTION public.cambiar_transportista_recorrido(bigint, uuid) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.cambiar_transportista_recorrido(bigint, uuid)
+  TO authenticated, service_role;
+
+COMMENT ON FUNCTION public.cambiar_transportista_recorrido(bigint, uuid) IS
+  'Reasigna una ruta en_curso a otro transportista de la misma sucursal: '
+  'actualiza recorridos.transportista_id y el de los pedidos de sus paradas. '
+  'No cambia el orden ni la optimizacion. Rechaza si la ruta ya tiene entregas '
+  'hechas o si el destino ya tiene ruta armada esa fecha (uq_recorrido_vigente).';
+
+COMMIT;

--- a/migrations/MANIFEST.md
+++ b/migrations/MANIFEST.md
@@ -1,6 +1,6 @@
 # MANIFEST de migraciones — mapeo repo ↔ producción
 
-> **Fechado: 2026-08-06** · Proyecto prod `hmuchlzmuqqxcldbzkgc` (ManaosApp) · región `sa-east-1`.
+> **Fechado: 2026-08-08** · Proyecto prod `hmuchlzmuqqxcldbzkgc` (ManaosApp) · región `sa-east-1`.
 
 ## Regla de oro
 
@@ -128,8 +128,8 @@ funcional** y no se renombran los archivos: renombrarlos los desalinearía del l
 real lo da `version` y está en la sección A: en los dos casos el archivo de `main` quedó
 cronológicamente **fuera** del bloque 139–147 (uno antes, otro entre la 144 y la 145).
 
-**La próxima migración es la 172** — la última numerada en el repo es
-`171_condicion_desde_la_ficha`. Las **148–166** (origen del precio, reglas de
+**La próxima migración es la 173** — la última numerada en el repo es
+`172_cambiar_transportista_de_una_ruta`. Las **148–166** (origen del precio, reglas de
 comisión, `place_id`, horarios masivos, barridas, roles extra por sucursal, horario obligatorio
 al cargar pedido, marcas y objetivos por preventista, saldo a favor que no queda atrapado)
 mapean **1:1** con el ledger, así que no agregan ninguna excepción a las tablas de arriba.
@@ -141,8 +141,15 @@ orden que no se ve en el SQL: `supabase/functions/_shared/pricing/index.ts` sele
 columna por nombre, y PostgREST devuelve 400 si no existe. **Desplegar las edge functions
 antes de aplicarla**, o el bot deja de tomar pedidos.
 
-Las **170** y **171** solo agregan funciones: no modifican ni una fila. Todo su SQL corre
-adentro de la RPC, o sea únicamente cuando el usuario dispara la acción desde la UI.
+Las **170**, **171** y **172** solo agregan funciones: no modifican ni una fila. Todo su SQL
+corre adentro de la RPC, o sea únicamente cuando el usuario dispara la acción desde la UI.
+
+La **172** agrega `cambiar_transportista_recorrido()`, que reasigna una ruta ya armada a otro
+chofer sin rearmarla. Hace falta porque para `aplicar_orden_ruta` el transportista es parte de
+la **identidad** de la ruta (la busca por `transportista_id + fecha + estado + sucursal_id`),
+así que elegir otro chofer y volver a armar no la mueve: crea una segunda y deja la original
+viva con sus pedidos en `asignado`. Rechaza si la ruta ya tiene entregas hechas (partiría la
+rendición entre dos personas) o si el destino ya tiene ruta ese día (`uq_recorrido_vigente`).
 
 La **170** agrega `consolidar_condiciones()`, que fusiona condiciones mayoristas duplicadas.
 Mueve las escalas conservando su `id` y solo repunta `pedido_items.grupo_precio_escala_id`

--- a/src/components/modals/ModalGestionRutas.tsx
+++ b/src/components/modals/ModalGestionRutas.tsx
@@ -4,11 +4,11 @@ import {
   Loader2, AlertTriangle, Check, Truck, MapPin, Route, Clock, Navigation,
   Settings, Save, FileText, ChevronDown, ChevronUp, Phone,
   DollarSign, Package, CheckCircle, Circle, Printer, ArrowRight, CalendarDays, Pencil,
-  ArrowLeftRight, Search
+  ArrowLeftRight, Search, UserCog
 } from 'lucide-react';
 import ModalBase from './ModalBase';
 import ModalCambioProducto, { type CambioProductoSaveData } from './ModalCambioProducto';
-import { useDepositoCoords, useSetDepositoMutation, useDestinoCoords, useSetDestinoMutation, useRecorridoExistenteQuery, useRutasEnCursoQuery } from '../../hooks/queries';
+import { useDepositoCoords, useSetDepositoMutation, useDestinoCoords, useSetDestinoMutation, useRecorridoExistenteQuery, useRutasEnCursoQuery, useCambiarTransportistaRutaMutation } from '../../hooks/queries';
 import type { RegistrarCambioInput } from '../../hooks/queries';
 import type { RepartidorParam } from '../../hooks/useOptimizarRuta';
 import { horarioParaRutear } from '../../hooks/useOptimizarRuta';
@@ -325,6 +325,42 @@ const ModalGestionRutas = memo(function ModalGestionRutas({
     [rutasEnCurso, fechaEntrega],
   );
   const idsExistentes = useMemo(() => new Set(paradasExistentes.map(p => p.id)), [paradasExistentes]);
+
+  // === Reasignar la ruta ya armada a otro chofer (mig 172) ===
+  // El transportista es parte de la identidad de la ruta (aplicar_orden_ruta la
+  // busca por transportista+fecha), así que elegir otro en el selector de arriba
+  // NO la mueve: arma una segunda y deja la original viva. Este panel es el
+  // único camino para corregir una ruta armada a nombre equivocado.
+  const [reasignando, setReasignando] = useState<boolean>(false);
+  const [choferDestino, setChoferDestino] = useState<string>('');
+  const [errorReasignar, setErrorReasignar] = useState<string | null>(null);
+  const cambiarChofer = useCambiarTransportistaRutaMutation();
+
+  // Cerrar el panel al cambiar de ruta: si no, queda abierto con el destino
+  // elegido para OTRA ruta.
+  useEffect(() => {
+    setReasignando(false);
+    setChoferDestino('');
+    setErrorReasignar(null);
+  }, [transportistaSeleccionado, fechaEntrega]);
+
+  const handleReasignar = async (): Promise<void> => {
+    if (!rutaExistente?.recorridoId || !choferDestino) return;
+    setErrorReasignar(null);
+    try {
+      await cambiarChofer.mutateAsync({
+        recorridoId: rutaExistente.recorridoId,
+        transportistaId: choferDestino,
+      });
+      // Seguir parado sobre la MISMA ruta, ahora bajo su nuevo dueño: el
+      // selector de arriba es lo que decide qué ruta se está editando.
+      setTransportistaSeleccionado(choferDestino);
+      setReasignando(false);
+      setChoferDestino('');
+    } catch (e) {
+      setErrorReasignar(e instanceof Error ? e.message : 'No se pudo cambiar el transportista');
+    }
+  };
 
   // Disponibles para sumar a la ruta: pendiente/en_preparacion (vienen del
   // container) filtrados por fecha de pedido o de entrega (según filtroTipoFecha).
@@ -949,12 +985,76 @@ const ModalGestionRutas = memo(function ModalGestionRutas({
                 <>
                   {/* Edición de ruta existente (solo modo 1 chofer) */}
                   {!modoDividir && editando && (
-                    <div className="bg-amber-50 border border-amber-200 rounded-lg p-3 flex items-start gap-2">
-                      <Pencil className="w-5 h-5 text-amber-600 mt-0.5 flex-shrink-0" />
-                      <p className="text-sm text-amber-800">
-                        Ya hay una ruta armada para <strong>{transportistaInfo?.nombre}</strong> el {formatFecha(fechaEntrega)}.
-                        Se editará esa misma ruta (agregá o quitá paradas y se reoptimiza al armar).
-                      </p>
+                    <div className="bg-amber-50 border border-amber-200 rounded-lg p-3">
+                      <div className="flex items-start gap-2">
+                        <Pencil className="w-5 h-5 text-amber-600 mt-0.5 flex-shrink-0" />
+                        <p className="text-sm text-amber-800">
+                          Ya hay una ruta armada para <strong>{transportistaInfo?.nombre}</strong> el {formatFecha(fechaEntrega)}.
+                          Se editará esa misma ruta (agregá o quitá paradas y se reoptimiza al armar).
+                        </p>
+                      </div>
+
+                      {/* Cambiar quién la entrega, sin rearmarla: conserva las
+                          paradas, el orden y la optimización. */}
+                      {!reasignando ? (
+                        <button
+                          type="button"
+                          onClick={() => { setReasignando(true); setChoferDestino(''); }}
+                          className="mt-2 ml-7 inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded-lg bg-white border border-amber-300 text-amber-800 hover:bg-amber-100"
+                        >
+                          <UserCog className="w-3.5 h-3.5" />
+                          Cambiar transportista
+                        </button>
+                      ) : (
+                        <div className="mt-3 ml-7 space-y-2">
+                          <label className="block text-xs font-medium text-amber-900">
+                            Pasar esta ruta a:
+                          </label>
+                          <div className="flex flex-wrap items-center gap-2">
+                            <select
+                              value={choferDestino}
+                              onChange={(e: ChangeEvent<HTMLSelectElement>) => setChoferDestino(e.target.value)}
+                              disabled={cambiarChofer.isPending}
+                              className="px-3 py-2 border border-amber-300 rounded-lg text-sm bg-white min-w-52"
+                            >
+                              <option value="">Elegir transportista...</option>
+                              {transportistas
+                                .filter(t => t.id !== transportistaSeleccionado)
+                                .map(t => (
+                                  <option key={t.id} value={t.id}>{t.nombre}</option>
+                                ))}
+                            </select>
+                            <button
+                              type="button"
+                              onClick={handleReasignar}
+                              disabled={!choferDestino || cambiarChofer.isPending}
+                              className="inline-flex items-center gap-1.5 px-4 py-2 text-sm font-medium rounded-lg bg-amber-600 text-white hover:bg-amber-700 disabled:opacity-50 disabled:cursor-not-allowed"
+                            >
+                              {cambiarChofer.isPending
+                                ? <Loader2 className="w-4 h-4 animate-spin" />
+                                : <Check className="w-4 h-4" />}
+                              {cambiarChofer.isPending ? 'Cambiando…' : 'Confirmar'}
+                            </button>
+                            <button
+                              type="button"
+                              onClick={() => { setReasignando(false); setErrorReasignar(null); }}
+                              disabled={cambiarChofer.isPending}
+                              className="px-3 py-2 text-sm text-amber-800 hover:bg-amber-100 rounded-lg disabled:opacity-50"
+                            >
+                              Cancelar
+                            </button>
+                          </div>
+                          <p className="text-xs text-amber-700">
+                            Se mantienen las {paradasExistentes.length} paradas y su orden. No se puede
+                            si la ruta ya tiene entregas hechas, o si el otro chofer ya tiene ruta armada ese día.
+                          </p>
+                          {errorReasignar && (
+                            <p className="text-xs text-red-700 bg-red-50 border border-red-200 rounded-lg p-2">
+                              {errorReasignar}
+                            </p>
+                          )}
+                        </div>
+                      )}
                     </div>
                   )}
 

--- a/src/hooks/queries/index.ts
+++ b/src/hooks/queries/index.ts
@@ -268,6 +268,10 @@ export type { RecorridoExistente } from './useRecorridoExistenteQuery'
 export { rutasEnCursoKeys, useRutasEnCursoQuery } from './useRutasEnCursoQuery'
 export type { RutaEnCurso } from './useRutasEnCursoQuery'
 
+// Reasignar una ruta ya armada a otro transportista (mig 172)
+export { useCambiarTransportistaRutaMutation } from './useCambiarTransportistaRutaMutation'
+export type { CambiarTransportistaRutaInput } from './useCambiarTransportistaRutaMutation'
+
 // Recorridos de una fecha con paradas completas (para re-descargar la hoja de ruta)
 export {
   recorridosHojaRutaKeys,

--- a/src/hooks/queries/useCambiarTransportistaRutaMutation.test.tsx
+++ b/src/hooks/queries/useCambiarTransportistaRutaMutation.test.tsx
@@ -1,0 +1,111 @@
+/**
+ * Tests de `useCambiarTransportistaRutaMutation` (mig 172).
+ *
+ * Lo que importa acá es el contrato con la RPC, no la lógica de negocio: las
+ * guardas (permisos, sucursal, entregas hechas, ruta duplicada) viven en
+ * `cambiar_transportista_recorrido` y se prueban contra la base.
+ *
+ * De este lado hay dos cosas que se pueden romper en silencio:
+ *   1. Los nombres/tipos de los parámetros. `p_recorrido_id` es bigint: si se
+ *      manda el id como string, PostgREST no resuelve la firma y falla en
+ *      runtime, no en compilación.
+ *   2. Que el mensaje del RAISE EXCEPTION llegue a la UI. Están redactados para
+ *      el usuario ("ya tiene 3 entregas hechas por Marcos"); taparlos con un
+ *      genérico deja al admin sin saber por qué no lo dejó.
+ */
+import React from 'react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+
+const rpc = vi.fn()
+
+vi.mock('../supabase/base', () => ({
+  supabase: {
+    rpc: (...args: unknown[]) => rpc(...args),
+    from: vi.fn(),
+  },
+}))
+
+vi.mock('../../contexts/SucursalContext', () => ({
+  useSucursal: () => ({ currentSucursalId: 2 }),
+}))
+
+import { useCambiarTransportistaRutaMutation } from './useCambiarTransportistaRutaMutation'
+
+const JUAN = '9bba9f79-9563-4654-aa76-c56769fe1ce9'
+
+function makeWrapper(qc: QueryClient) {
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return <QueryClientProvider client={qc}>{children}</QueryClientProvider>
+  }
+}
+
+function setup() {
+  const qc = new QueryClient({ defaultOptions: { mutations: { retry: false } } })
+  const { result } = renderHook(() => useCambiarTransportistaRutaMutation(), {
+    wrapper: makeWrapper(qc),
+  })
+  return { qc, result }
+}
+
+describe('useCambiarTransportistaRutaMutation', () => {
+  beforeEach(() => rpc.mockReset())
+
+  it('llama a la RPC con el id numerico y el uuid del chofer', async () => {
+    rpc.mockResolvedValue({ data: 82, error: null })
+    const { result } = setup()
+
+    result.current.mutate({ recorridoId: '82', transportistaId: JUAN })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(rpc).toHaveBeenCalledWith('cambiar_transportista_recorrido', {
+      p_recorrido_id: 82,
+      p_transportista_id: JUAN,
+    })
+    expect(result.current.data).toBe('82')
+  })
+
+  it('propaga el mensaje de la RPC tal cual para mostrarlo en pantalla', async () => {
+    rpc.mockResolvedValue({
+      data: null,
+      error: { message: 'La ruta #79 ya tiene 17 entrega(s) hecha(s) por pruebataco.' },
+    })
+    const { result } = setup()
+
+    result.current.mutate({ recorridoId: '79', transportistaId: JUAN })
+
+    await waitFor(() => expect(result.current.isError).toBe(true))
+    expect(result.current.error?.message).toBe(
+      'La ruta #79 ya tiene 17 entrega(s) hecha(s) por pruebataco.',
+    )
+  })
+
+  it('cae en un mensaje generico si el error viene sin texto', async () => {
+    rpc.mockResolvedValue({ data: null, error: { message: '' } })
+    const { result } = setup()
+
+    result.current.mutate({ recorridoId: '82', transportistaId: JUAN })
+
+    await waitFor(() => expect(result.current.isError).toBe(true))
+    expect(result.current.error?.message).toBe('No se pudo cambiar el transportista de la ruta')
+  })
+
+  it('invalida las queries de la ruta: la vieja y la nueva se indexan por transportista', async () => {
+    rpc.mockResolvedValue({ data: 82, error: null })
+    const { qc, result } = setup()
+    const invalidate = vi.spyOn(qc, 'invalidateQueries')
+
+    result.current.mutate({ recorridoId: '82', transportistaId: JUAN })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    const keys = invalidate.mock.calls.map(([arg]) => JSON.stringify(arg?.queryKey))
+    // Por prefijo, sin el transportista: hay que refrescar tanto la ruta del
+    // chofer que la pierde como la del que la recibe.
+    expect(keys).toContain(JSON.stringify(['recorrido-existente']))
+    expect(keys).toContain(JSON.stringify(['rutas-en-curso']))
+    expect(keys).toContain(JSON.stringify(['recorrido-activo']))
+    expect(keys).toContain(JSON.stringify(['recorridos-hoja-ruta']))
+    expect(keys).toContain(JSON.stringify(['pedidos', 2]))
+  })
+})

--- a/src/hooks/queries/useCambiarTransportistaRutaMutation.ts
+++ b/src/hooks/queries/useCambiarTransportistaRutaMutation.ts
@@ -1,0 +1,62 @@
+/**
+ * Reasigna una ruta YA ARMADA a otro transportista (mig 172).
+ *
+ * Por qué hace falta un RPC y no un update: para `aplicar_orden_ruta` el
+ * transportista es parte de la IDENTIDAD de la ruta —la busca por
+ * (transportista_id, fecha, estado, sucursal_id)—, así que elegir otro chofer y
+ * volver a armar no mueve la ruta, crea una segunda y deja la original viva con
+ * sus pedidos en `asignado`. `cambiar_transportista_recorrido` mueve el
+ * recorrido y el `transportista_id` de sus pedidos en una sola transacción,
+ * conservando el orden de entrega y la optimización.
+ *
+ * Las guardas (permisos, sucursal, ruta en curso, sin entregas hechas, sin ruta
+ * duplicada del destino) viven en la RPC: acá solo se traduce el error a algo
+ * que se pueda mostrar en pantalla.
+ */
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { supabase } from '../supabase/base'
+import { useSucursal } from '../../contexts/SucursalContext'
+import { pedidosKeys } from './usePedidosQuery'
+
+export interface CambiarTransportistaRutaInput {
+  recorridoId: string
+  transportistaId: string
+}
+
+async function cambiarTransportistaRuta({
+  recorridoId,
+  transportistaId,
+}: CambiarTransportistaRutaInput): Promise<string> {
+  const { data, error } = await supabase.rpc('cambiar_transportista_recorrido', {
+    p_recorrido_id: Number(recorridoId),
+    p_transportista_id: transportistaId,
+  })
+
+  // Los RAISE EXCEPTION de la RPC ya vienen redactados para el usuario ("ya
+  // tiene N entregas hechas", "ya tiene la ruta #X armada para el ..."), así
+  // que se muestran tal cual en vez de taparlos con un mensaje genérico.
+  if (error) throw new Error(error.message || 'No se pudo cambiar el transportista de la ruta')
+
+  return String(data ?? recorridoId)
+}
+
+export function useCambiarTransportistaRutaMutation() {
+  const queryClient = useQueryClient()
+  const { currentSucursalId } = useSucursal()
+
+  return useMutation({
+    mutationFn: cambiarTransportistaRuta,
+    onSuccess: () => {
+      // Los pedidos cambiaron de transportista_id (lo que ve la PWA del chofer).
+      queryClient.invalidateQueries({ queryKey: pedidosKeys.all(currentSucursalId) })
+      // La ruta ya no está bajo el chofer viejo y sí bajo el nuevo: las tres
+      // queries se indexan por transportista, así que se invalidan por prefijo
+      // (no alcanza con la del chofer actual del modal).
+      queryClient.invalidateQueries({ queryKey: ['recorrido-existente'] })
+      queryClient.invalidateQueries({ queryKey: ['rutas-en-curso'] })
+      queryClient.invalidateQueries({ queryKey: ['recorrido-activo'] })
+      // La hoja de ruta lleva el nombre del chofer impreso arriba.
+      queryClient.invalidateQueries({ queryKey: ['recorridos-hoja-ruta'] })
+    },
+  })
+}


### PR DESCRIPTION
## El problema

Para `aplicar_orden_ruta` el transportista es parte de la **identidad** de la ruta: la busca por `(transportista_id, fecha, estado, sucursal_id)`. Elegir otro chofer en el selector y volver a armar no movía la ruta — armaba una **segunda** y dejaba la original viva, con sus pedidos en `asignado` y fuera del pool de disponibles. Una ruta armada a nombre equivocado solo se corregía cancelándola y rehaciéndola.

El caso que lo destapó: en Taco Pozo la ruta del día se arma la tarde anterior. Se armó a nombre del transportista que estaba en el picker y media hora después se le habilitó a Juan —preventista que acompaña al camión— la capacidad `transportista` (mig 155). La ruta quedó a nombre de quien no la iba a repartir.

## La solución

**Mig 172** — `cambiar_transportista_recorrido(recorrido_id, transportista_id)` mueve el recorrido y el `transportista_id` de los pedidos de sus paradas en una sola transacción, conservando el orden de entrega, la optimización y las polylines.

Los pedidos se actualizan además del recorrido porque `pedidos.transportista_id` es lo que leen la PWA del chofer, las policies de `pagos` (mig 155) y la rendición: sin eso la ruta cambia de nombre en el listado y el chofer nuevo no la ve.

### Guardas

| Guarda | Por qué |
|---|---|
| `es_encargado_o_admin()` | Mismo gate que `aplicar_orden_ruta` |
| Ruta y destino de la sucursal activa | Aislamiento multi-tenant |
| Destino habilitado como transportista ahí | Rol base o capacidad extra (mig 155); espeja `fetchTransportistas()` del front, server-side |
| Ruta `en_curso` | Una completada ya se rindió: reabrirla no es un cambio de chofer |
| **Cero entregas hechas** | Si el chofer ya entregó y cobró, la plata del día es suya: mover la ruta partiría la rendición entre dos personas |
| Destino sin otra ruta esa fecha | `uq_recorrido_vigente`, chequeado explícito para dar un mensaje útil en vez de un `23505` crudo |

Idempotente: reasignar al mismo chofer devuelve el id sin tocar nada, así un doble click no es un error en pantalla. Las paradas marcadas "no entregado" **no** bloquean: no mueven plata, y el caso real (se rompió el camión a media mañana) es justamente ese.

### UI

El panel sale en el aviso de *"ya hay una ruta armada para X"* de **Armar ruta del día**, que es donde ya se edita la ruta in-place (agregar/quitar paradas). Al confirmar, el modal queda parado sobre la misma ruta bajo su nuevo dueño.

## Verificación

- **8 escenarios contra la base**, simulando sesión autenticada y revertidos al terminar: happy path, no-op idempotente, transportista de otra sucursal, usuario sin la capacidad, ruta de otra sucursal, ruta con 17 entregas hechas, destino con ruta duplicada esa fecha, y preventista sin permisos. Los 8 se comportan como corresponde.
- **4 tests unitarios** del hook: firma de la RPC (`p_recorrido_id` es bigint — mandarlo como string falla en runtime, no en compilación), que el mensaje del `RAISE EXCEPTION` llegue a la UI tal cual, fallback genérico, e invalidación por prefijo de las queries indexadas por transportista.
- Suite completa: **1048 tests en verde**. `tsc --noEmit`, `eslint` y `npm run build` limpios.

## Notas

- La mig 172 **ya está aplicada en producción** (ledger: `20260808122237`). Solo agrega una función: no modifica ni una fila, todo su SQL corre cuando el usuario dispara la acción desde la UI.
- `MANIFEST.md` actualizado (próxima migración: 173).

---
_Generated by [Claude Code](https://claude.ai/code/session_01T8Up5cea1itwrssEAEzww7)_