### PR TITLE
Arreglar que el cobro del chofer no marcaba la parada

### DIFF
--- a/migrations/173_entrega_del_chofer_actualiza_la_parada.sql
+++ b/migrations/173_entrega_del_chofer_actualiza_la_parada.sql
@@ -1,0 +1,118 @@
+-- =========================================================================
+-- 173_entrega_del_chofer_actualiza_la_parada.sql
+--
+-- Cuando el chofer marca una entrega, la parada del recorrido no se enteraba.
+--
+-- EL SINTOMA
+-- ----------
+-- Ruta 82 (Taco Pozo, 08/08): 17 pedidos entregados, pero solo 7 paradas con
+-- `estado_entrega = 'entregado'`. Y `recorridos.total_cobrado` informaba
+-- $263.900 contra $364.500 realmente cobrados: la rendicion del dia salia
+-- $100.600 corta. No es de esa ruta ni de ese chofer — hay 1.331 paradas asi
+-- en la historia (Marcos 1.029, Transporte Taco Pozo 292, Juan 10).
+--
+-- CAUSA 1: el trigger corria con los permisos del chofer
+-- ------------------------------------------------------
+-- `actualizar_recorrido_entrega()` no era SECURITY DEFINER, asi que sus UPDATE
+-- pasaban por la RLS del usuario que disparo el trigger. Y
+-- `mt_recorrido_pedidos_update` solo habilita `es_admin()`:
+--
+--   UPDATE recorrido_pedidos ... -> 0 filas, SIN error (RLS filtra, no falla)
+--   UPDATE recorridos        ... -> OK (su policy permite al transportista dueño)
+--
+-- O sea: el contador de la ruta avanzaba y la parada quedaba en 'pendiente'.
+-- Split-brain garantizado para CUALQUIER chofer que no sea admin, desde
+-- siempre. Verificado reproduciendo la sesion de un chofer con RLS activa.
+--
+-- El fix es SECURITY DEFINER y no abrir la policy: la escritura sigue
+-- encerrada en el trigger, que controla exactamente que columnas toca. Darle
+-- UPDATE directo sobre `recorrido_pedidos` al chofer le abriria tambien
+-- orden_entrega, barrida y notas, que no tiene por que tocar.
+--
+-- CAUSA 2: los contadores se sumaban a ciegas, y en el momento equivocado
+-- ----------------------------------------------------------------------
+-- Hacia `pedidos_entregados = pedidos_entregados + 1` y
+-- `total_cobrado = total_cobrado + NEW.monto_pagado`. Dos problemas:
+--
+--   · Sumar 1 es irreversible: entregado -> asignado -> entregado contaba dos
+--     veces, y una entrega revertida no descontaba nunca.
+--   · `NEW.monto_pagado` se lee en el instante en que se marca entregado. El
+--     chofer cobra DESPUES de marcar (o el cobro entra por otra via), asi que
+--     ahi todavia valia 0 y la plata no se contaba jamas. De ahi los $100.600.
+--
+-- Ahora los dos se recalculan desde las paradas, que es la fuente de verdad, y
+-- el trigger tambien escucha `monto_pagado` para que un cobro posterior
+-- actualice el total. Al ser un recalculo y no un delta, es idempotente: correr
+-- de mas no rompe nada y una reversion se refleja sola.
+--
+-- Se mantiene a proposito el filtro `r.fecha = CURRENT_DATE`: solo se toca la
+-- ruta del dia. Marcar una entrega al dia siguiente sigue sin mover contadores
+-- historicos, igual que hasta hoy.
+-- =========================================================================
+
+BEGIN;
+
+CREATE OR REPLACE FUNCTION public.actualizar_recorrido_entrega()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $fn$
+DECLARE
+  v_recorrido_id BIGINT;
+BEGIN
+  SELECT rp.recorrido_id INTO v_recorrido_id
+  FROM recorrido_pedidos rp
+  JOIN recorridos r ON r.id = rp.recorrido_id
+  WHERE rp.pedido_id = NEW.id
+    AND r.fecha      = CURRENT_DATE
+    AND r.estado     = 'en_curso'
+  LIMIT 1;
+
+  IF v_recorrido_id IS NULL THEN
+    RETURN NEW;
+  END IF;
+
+  -- Solo en la transicion a entregado: si no, un cobro posterior pisaria la
+  -- hora_entrega real.
+  IF NEW.estado = 'entregado' AND OLD.estado IS DISTINCT FROM 'entregado' THEN
+    UPDATE recorrido_pedidos
+    SET estado_entrega = 'entregado',
+        hora_entrega   = NOW()
+    WHERE recorrido_id = v_recorrido_id
+      AND pedido_id    = NEW.id;
+  END IF;
+
+  -- Contadores recalculados desde las paradas (idempotente).
+  UPDATE recorridos r
+  SET pedidos_entregados = sub.entregados,
+      total_cobrado      = sub.cobrado
+  FROM (
+    SELECT COUNT(*) FILTER (WHERE p.estado = 'entregado')                  AS entregados,
+           COALESCE(SUM(p.monto_pagado) FILTER (WHERE p.estado = 'entregado'), 0) AS cobrado
+    FROM recorrido_pedidos rp
+    JOIN pedidos p ON p.id = rp.pedido_id
+    WHERE rp.recorrido_id = v_recorrido_id
+  ) sub
+  WHERE r.id = v_recorrido_id;
+
+  RETURN NEW;
+END;
+$fn$;
+
+COMMENT ON FUNCTION public.actualizar_recorrido_entrega() IS
+  'Sincroniza la parada del recorrido con el pedido: marca estado_entrega al '
+  'entregar y recalcula pedidos_entregados/total_cobrado desde las paradas. '
+  'SECURITY DEFINER a proposito (mig 173): sin eso la RLS de recorrido_pedidos '
+  '(admin-only) descartaba el UPDATE en silencio para todo chofer no admin.';
+
+-- Ahora tambien sobre monto_pagado: el cobro casi siempre entra DESPUES de
+-- marcar entregado, y sin esto total_cobrado se quedaba con el valor de ese
+-- instante (0) para siempre.
+DROP TRIGGER IF EXISTS trigger_actualizar_recorrido_entrega ON public.pedidos;
+CREATE TRIGGER trigger_actualizar_recorrido_entrega
+  AFTER UPDATE OF estado, monto_pagado ON public.pedidos
+  FOR EACH ROW
+  EXECUTE FUNCTION public.actualizar_recorrido_entrega();
+
+COMMIT;

--- a/migrations/MANIFEST.md
+++ b/migrations/MANIFEST.md
@@ -128,8 +128,8 @@ funcional** y no se renombran los archivos: renombrarlos los desalinearía del l
 real lo da `version` y está en la sección A: en los dos casos el archivo de `main` quedó
 cronológicamente **fuera** del bloque 139–147 (uno antes, otro entre la 144 y la 145).
 
-**La próxima migración es la 173** — la última numerada en el repo es
-`172_cambiar_transportista_de_una_ruta`. Las **148–166** (origen del precio, reglas de
+**La próxima migración es la 174** — la última numerada en el repo es
+`173_entrega_del_chofer_actualiza_la_parada`. Las **148–166** (origen del precio, reglas de
 comisión, `place_id`, horarios masivos, barridas, roles extra por sucursal, horario obligatorio
 al cargar pedido, marcas y objetivos por preventista, saldo a favor que no queda atrapado)
 mapean **1:1** con el ledger, así que no agregan ninguna excepción a las tablas de arriba.
@@ -156,6 +156,16 @@ Mueve las escalas conservando su `id` y solo repunta `pedido_items.grupo_precio_
 cuando hay dos escalas equivalentes, para no perder el rastro del descuento por volumen.
 Rechaza la fusión si algún precio cambiaría. La dispara el usuario desde la pestaña de
 condiciones, caso por caso; no corre sola.
+
+La **173** es la primera de esta tanda que **sí toca filas**: arregla
+`actualizar_recorrido_entrega()` y repara la ruta 82. El trigger no era `SECURITY DEFINER`,
+así que sus UPDATE pasaban por la RLS del chofer y `mt_recorrido_pedidos_update` es admin-only:
+el UPDATE de `recorrido_pedidos` se descartaba **en silencio** (RLS filtra, no falla) mientras
+el de `recorridos` sí entraba. Resultado: contador de la ruta avanzando y paradas en
+'pendiente', para todo chofer no admin desde siempre (1.331 paradas históricas). Además los
+contadores pasan de sumar deltas a recalcularse desde las paradas, y el trigger ahora escucha
+`monto_pagado`: antes `total_cobrado` se congelaba en el valor del instante en que se marcaba
+entregado, que casi siempre era 0 porque el cobro entra después.
 
 La **167** renombra 4 RPCs de pago a `<nombre>_impl` y las deja detrás de un wrapper
 idempotente del mismo nombre. Es a propósito: `migrations/` no es 1:1 con prod y esas RPCs ya

--- a/src/components/containers/PedidosContainer.tsx
+++ b/src/components/containers/PedidosContainer.tsx
@@ -974,10 +974,15 @@ export default function PedidosContainer(): React.ReactElement {
   // pendiente = deuda del cliente). Repropaga el error para que el modal del
   // transportista quede abierto y permita reintentar (importante sin red).
   const handleEntregarSinCobrar = useCallback(async (pedido: PedidoDB) => {
+    // El botón que dispara esto cierra las dos situaciones (ver ModalPagoPedido):
+    // entregar fiado, o confirmar la entrega de un pedido que ya quedó cobrado.
+    // Solo cambia el aviso: decirle "a cuenta corriente" sobre un pedido saldado
+    // hace dudar al chofer de si cobró bien.
+    const saldado = (pedido.monto_pagado || 0) >= (pedido.total || 0) - 0.01
     try {
       await cambiarEstado.mutateAsync({ pedidoId: pedido.id, nuevoEstado: 'entregado' })
       queryClient.invalidateQueries({ queryKey: ['pedidos'] })
-      notify.success('Entregado a cuenta corriente (sin cobrar)')
+      notify.success(saldado ? 'Pedido entregado' : 'Entregado a cuenta corriente (sin cobrar)')
     } catch (e) {
       notify.error((e as Error).message)
       throw e

--- a/src/components/containers/PedidosContainer.tsx
+++ b/src/components/containers/PedidosContainer.tsx
@@ -1554,6 +1554,10 @@ export default function PedidosContainer(): React.ReactElement {
 
   // Handler de registrar pago desde la vista transportista. Usa usePagos +
   // invalida cache de pedidos para refrescar monto_pagado / estado_pago.
+  // OJO con `['recorrido-activo']`: la pantalla del chofer NO lee de
+  // `['pedidos']`, lee de esa query (useRecorridoActivoQuery). Sin invalidarla,
+  // el cobro entraba en la base pero la ruta seguía mostrando la parada como
+  // impaga y el header con el total por cobrar viejo.
   const handleRegistrarPagoTransportista = useCallback(async (data: {
     clienteId: string;
     pedidoId: string | null;
@@ -1576,6 +1580,9 @@ export default function PedidosContainer(): React.ReactElement {
       clientRequestId: data.clientRequestId,
     })
     queryClient.invalidateQueries({ queryKey: ['pedidos'] })
+    // Se espera el refetch: al cerrarse el modal se marca entregado, y esa rama
+    // depende de que la ruta ya esté al día.
+    await queryClient.invalidateQueries({ queryKey: ['recorrido-activo'] })
     return pago
   }, [registrarPago, queryClient, user?.id])
 

--- a/src/components/modals/ModalPagoPedido.test.tsx
+++ b/src/components/modals/ModalPagoPedido.test.tsx
@@ -1,0 +1,69 @@
+/**
+ * Tests de `ModalPagoPedido` — la acción que se le ofrece al chofer.
+ *
+ * El botón de abajo cierra dos situaciones distintas con el mismo handler:
+ * entregar fiado, o confirmar la entrega de un pedido ya cobrado. El texto es
+ * lo único que las separa, y equivocarlo tiene costo real: en Taco Pozo el
+ * chofer cobraba en la mano, el modal le ofrecía "Entregar a cuenta corriente
+ * (sin cobrar)", y cancelaba — la parada le quedaba sin entregar.
+ *
+ * La regla: si no queda saldo, nunca se nombra la cuenta corriente.
+ */
+import React from 'react'
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+
+vi.mock('../../hooks/queries/useUltimaFechaCajaCerradaQuery', () => ({
+  useFechaMinimaPago: () => undefined,
+}))
+
+import ModalPagoPedido from './ModalPagoPedido'
+import type { PedidoDB, PagoDBWithUsuario } from '../../types'
+
+const pedido = { id: '4625', cliente_id: '1', total: 21600 } as unknown as PedidoDB
+
+const pagoDe = (monto: number): PagoDBWithUsuario =>
+  ({ id: '1', monto, forma_pago: 'efectivo', fecha: '2026-08-08' }) as unknown as PagoDBWithUsuario
+
+function renderModal(pagosPrevios: PagoDBWithUsuario[]) {
+  return render(
+    <ModalPagoPedido
+      pedido={pedido}
+      pagosPrevios={pagosPrevios}
+      onConfirmar={vi.fn()}
+      modoEntregaTransportista
+      onEntregarSinPago={vi.fn()}
+      onClose={vi.fn()}
+      guardando={false}
+    />,
+  )
+}
+
+describe('ModalPagoPedido — botón de entrega del chofer', () => {
+  it('con saldo pendiente ofrece la cuenta corriente', () => {
+    renderModal([])
+
+    expect(screen.getByRole('button', { name: /cuenta corriente \(sin cobrar\)/i })).toBeTruthy()
+    expect(screen.queryByRole('button', { name: /^confirmar entrega$/i })).toBeNull()
+  })
+
+  it('sin saldo dice "Confirmar entrega" y NO nombra la cuenta corriente', () => {
+    renderModal([pagoDe(21600)])
+
+    expect(screen.getByRole('button', { name: /^confirmar entrega$/i })).toBeTruthy()
+    // Lo que hacía cancelar al chofer que ya tenía la plata en la mano.
+    expect(screen.queryByRole('button', { name: /cuenta corriente/i })).toBeNull()
+  })
+
+  it('cobro parcial sigue siendo cuenta corriente: queda saldo en la calle', () => {
+    renderModal([pagoDe(10000)])
+
+    expect(screen.getByRole('button', { name: /cuenta corriente \(sin cobrar\)/i })).toBeTruthy()
+  })
+
+  it('un sobrepago no reabre la cuenta corriente', () => {
+    renderModal([pagoDe(25000)])
+
+    expect(screen.getByRole('button', { name: /^confirmar entrega$/i })).toBeTruthy()
+  })
+})

--- a/src/components/modals/ModalPagoPedido.tsx
+++ b/src/components/modals/ModalPagoPedido.tsx
@@ -423,14 +423,23 @@ const ModalPagoPedido = memo(function ModalPagoPedido({
         >
           Cancelar
         </button>
+        {/* Mismo botón, dos situaciones. Con saldo es entregar fiado, y va en
+            ámbar porque deja plata en la calle. Sin saldo el pedido ya está
+            cobrado y esto sólo confirma la entrega: ofrecerle "cuenta corriente
+            (sin cobrar)" al chofer que acaba de recibir la plata en la mano lo
+            hace cancelar, y la parada le queda sin entregar. */}
         {modoEntregaTransportista && onEntregarSinPago && (
           <button
             onClick={() => { void handleEntregarSinPago() }}
             disabled={guardando}
-            className="px-4 py-2 bg-amber-600 text-white rounded-lg hover:bg-amber-700 flex items-center disabled:opacity-50"
+            className={`px-4 py-2 text-white rounded-lg flex items-center disabled:opacity-50 ${
+              saldoPendiente > 0
+                ? 'bg-amber-600 hover:bg-amber-700'
+                : 'bg-green-600 hover:bg-green-700'
+            }`}
           >
             {guardando && <Loader2 className="w-4 h-4 mr-2 animate-spin" />}
-            Entregar a cuenta corriente (sin cobrar)
+            {saldoPendiente > 0 ? 'Entregar a cuenta corriente (sin cobrar)' : 'Confirmar entrega'}
           </button>
         )}
         {saldoPendiente > 0 && (

--- a/src/components/rutaActiva/useEntregaParada.test.ts
+++ b/src/components/rutaActiva/useEntregaParada.test.ts
@@ -1,0 +1,131 @@
+/**
+ * Tests de `useEntregaParada` — el cierre del modal de cobranza.
+ *
+ * El bug que cubren (Taco Pozo, 08/08/2026): el chofer cobraba, veía "Pago
+ * registrado", y la parada le seguía apareciendo impaga y sin entregar.
+ *
+ * `pedidoParaCobrar` es una foto sacada al ABRIR el modal. Al cerrarlo se
+ * llamaba a `onMarcarEntregado` con esa foto, donde `monto_pagado` seguía en 0.
+ * El contenedor mira `estado_pago` para decidir: si no está pagado, en vez de
+ * confirmar la entrega vuelve a abrir el modal de cobranza. Resultado: cobro
+ * asentado en la base, parada pendiente en pantalla, y un loop.
+ *
+ * La regla que hay que sostener: al cerrar con un cobro exitoso, el pedido que
+ * se manda ya tiene que reflejar lo cobrado.
+ */
+import { describe, it, expect, vi } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { useEntregaParada, type PedidoConCliente, type DatosPago } from './useEntregaParada'
+
+const pedido = (over: Partial<PedidoConCliente> = {}): PedidoConCliente => ({
+  id: '4625',
+  total: 21600,
+  monto_pagado: 0,
+  estado: 'asignado',
+  estado_pago: 'pendiente',
+  cliente: { id: '1', nombre_fantasia: 'SABRI ARIAS' },
+  items: [],
+  ...over,
+} as unknown as PedidoConCliente)
+
+const datosPago = (monto: number): DatosPago => ({
+  clienteId: '1', pedidoId: '4625', monto, formaPago: 'efectivo',
+  referencia: '', notas: '', fecha: '2026-08-08',
+})
+
+function setup() {
+  const onMarcarEntregado = vi.fn()
+  const onRegistrarPago = vi.fn().mockResolvedValue({ id: '1', monto: 0 })
+  const { result } = renderHook(() =>
+    useEntregaParada({ onMarcarEntregado, onRegistrarPago }),
+  )
+  return { onMarcarEntregado, onRegistrarPago, result }
+}
+
+describe('useEntregaParada — cierre del modal de cobranza', () => {
+  it('al cobrar el total, marca entregado con el pedido YA pagado', async () => {
+    const { onMarcarEntregado, result } = setup()
+
+    act(() => result.current.marcarEntregado(pedido()))
+    await act(async () => { await result.current.confirmarPago(datosPago(21600)) })
+    act(() => result.current.cerrarModalPago())
+
+    expect(onMarcarEntregado).toHaveBeenCalledTimes(1)
+    // Sin esto el contenedor reabre el modal de cobranza en vez de entregar.
+    expect(onMarcarEntregado.mock.calls[0][0]).toMatchObject({
+      id: '4625', estado_pago: 'pagado', monto_pagado: 21600,
+    })
+  })
+
+  it('suma las lineas de un pago dividido (una llamada por forma de pago)', async () => {
+    const { onMarcarEntregado, result } = setup()
+
+    act(() => result.current.marcarEntregado(pedido()))
+    await act(async () => { await result.current.confirmarPago(datosPago(10000)) })
+    await act(async () => { await result.current.confirmarPago(datosPago(11600)) })
+    act(() => result.current.cerrarModalPago())
+
+    expect(onMarcarEntregado.mock.calls[0][0]).toMatchObject({
+      estado_pago: 'pagado', monto_pagado: 21600,
+    })
+  })
+
+  it('cobro parcial: entrega marcada como parcial, no como pagada', async () => {
+    const { onMarcarEntregado, result } = setup()
+
+    act(() => result.current.marcarEntregado(pedido()))
+    await act(async () => { await result.current.confirmarPago(datosPago(10000)) })
+    act(() => result.current.cerrarModalPago())
+
+    expect(onMarcarEntregado.mock.calls[0][0]).toMatchObject({
+      estado_pago: 'parcial', monto_pagado: 10000,
+    })
+  })
+
+  it('parte sobre un pedido que ya venia con un pago previo', async () => {
+    const { onMarcarEntregado, result } = setup()
+
+    act(() => result.current.marcarEntregado(pedido({ monto_pagado: 1600, estado_pago: 'parcial' })))
+    await act(async () => { await result.current.confirmarPago(datosPago(20000)) })
+    act(() => result.current.cerrarModalPago())
+
+    expect(onMarcarEntregado.mock.calls[0][0]).toMatchObject({
+      estado_pago: 'pagado', monto_pagado: 21600,
+    })
+  })
+
+  it('si se cierra sin cobrar, no marca entregado', async () => {
+    const { onMarcarEntregado, result } = setup()
+
+    act(() => result.current.marcarEntregado(pedido()))
+    act(() => result.current.cerrarModalPago())
+
+    expect(onMarcarEntregado).not.toHaveBeenCalled()
+  })
+
+  it('no arrastra lo cobrado de una parada a la siguiente', async () => {
+    const { onMarcarEntregado, result } = setup()
+
+    act(() => result.current.marcarEntregado(pedido()))
+    await act(async () => { await result.current.confirmarPago(datosPago(21600)) })
+    act(() => result.current.cerrarModalPago())
+
+    // Segunda parada, mismo monto de pedido, cobro parcial
+    act(() => result.current.marcarEntregado(pedido({ id: '4626' })))
+    await act(async () => { await result.current.confirmarPago(datosPago(5000)) })
+    act(() => result.current.cerrarModalPago())
+
+    expect(onMarcarEntregado.mock.calls[1][0]).toMatchObject({
+      id: '4626', estado_pago: 'parcial', monto_pagado: 5000,
+    })
+  })
+
+  it('un pedido ya pagado va derecho a entregar, sin abrir cobranza', () => {
+    const { onMarcarEntregado, result } = setup()
+
+    act(() => result.current.marcarEntregado(pedido({ estado_pago: 'pagado', monto_pagado: 21600 })))
+
+    expect(result.current.pedidoParaCobrar).toBeNull()
+    expect(onMarcarEntregado).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/components/rutaActiva/useEntregaParada.ts
+++ b/src/components/rutaActiva/useEntregaParada.ts
@@ -97,10 +97,20 @@ export function useEntregaParada({
   const [errorNoEntrega, setErrorNoEntrega] = useState<string | null>(null);
   // Si el pago del modal fue exitoso, al cerrarse se marca entregado.
   const pagoExitosoRef = useRef(false);
+  // Cuánto se cobró en ESTA pasada del modal. `pedidoParaCobrar` es una foto
+  // sacada al abrirlo: su `monto_pagado` sigue siendo el de antes del cobro,
+  // y refrescar la query no la actualiza. Sin este acumulado, al cerrar se
+  // marcaba entregado con el pedido "sin pagar" y el contenedor reabría el
+  // modal de cobranza en vez de confirmar la entrega — el chofer cobraba,
+  // veía "Pago registrado" y la parada le quedaba pendiente igual.
+  // Es un acumulado y no un valor suelto porque el pago dividido llama a
+  // `confirmarPago` una vez por forma de pago.
+  const montoCobradoRef = useRef(0);
 
   const marcarEntregado = (pedido: PedidoConCliente): void => {
     if (onRegistrarPago && pedido.estado_pago !== 'pagado' && pedido.cliente) {
       pagoExitosoRef.current = false;
+      montoCobradoRef.current = 0;
       setPedidoParaCobrar(pedido);
       return;
     }
@@ -111,6 +121,7 @@ export function useEntregaParada({
     if (!onRegistrarPago) throw new Error('Handler de pago no disponible');
     const pago = await onRegistrarPago(data);
     pagoExitosoRef.current = true;
+    montoCobradoRef.current += Number(data.monto) || 0;
     return pago as Pago & { monto: number };
   };
 
@@ -118,9 +129,18 @@ export function useEntregaParada({
     const pedido = pedidoParaCobrar;
     setPedidoParaCobrar(null);
     if (pagoExitosoRef.current && pedido) {
-      onMarcarEntregado(pedido as PedidoDB);
+      // Se le suma lo cobrado recién a la foto, para que el contenedor vea el
+      // pedido como quedó y siga por la rama de confirmar entrega.
+      const pagado = (Number(pedido.monto_pagado) || 0) + montoCobradoRef.current;
+      const total = Number(pedido.total) || 0;
+      // Epsilon de un centavo: los montos son DECIMAL y el redondeo no debería
+      // dejar una parada "parcial" por dos centavos.
+      const estadoPago: PedidoDB['estado_pago'] =
+        pagado >= total - 0.01 ? 'pagado' : pagado > 0 ? 'parcial' : 'pendiente';
+      onMarcarEntregado({ ...pedido, monto_pagado: pagado, estado_pago: estadoPago } as PedidoDB);
     }
     pagoExitosoRef.current = false;
+    montoCobradoRef.current = 0;
   };
 
   // Entregar a cuenta corriente (sin cobrar). Si falla, propaga para que el


### PR DESCRIPTION
## El síntoma

El chofer cobraba, veía **"Pago registrado ✓"**, y la parada le seguía apareciendo impaga y sin entregar. Al volver a entrar, el modal mostraba de nuevo *"Saldo pendiente: $21.600"*.

El cobro **sí entraba en la base** (los pagos están todos, correctos). Lo que fallaba es la pantalla — y, por detrás, el trigger que sincroniza la parada.

## 1. El modal cerraba con una foto vieja del pedido

`pedidoParaCobrar` se captura al **abrir** el modal, con `monto_pagado` en 0. Al cerrarlo se llamaba a `onMarcarEntregado(pedido)` con esa foto, y `handleMarcarEntregado` decide según `estado_pago`: como seguía en `'pendiente'`, en vez de confirmar la entrega **volvía a abrir el modal de cobranza**. Loop, y la parada nunca se entregaba.

Ahora `cerrarModalPago` le suma lo cobrado a la foto antes de mandarla. Es un **acumulado** y no un valor suelto porque el pago dividido llama a `confirmarPago` una vez por forma de pago.

Se agrega además la invalidación de `['recorrido-activo']` al registrar el cobro. La pantalla del chofer **no** lee de `['pedidos']` — lee de `useRecorridoActivoQuery` — así que el header y la lista se quedaban con el total por cobrar viejo. Era la única mutación del repo que tocaba datos de la ruta sin invalidarla.

## 2. El botón ofrecía cuenta corriente sobre un pedido ya cobrado

El botón de abajo del modal de entrega cierra dos situaciones con el mismo handler: entregar fiado, o confirmar la entrega de un pedido ya cobrado. Decía siempre **"Entregar a cuenta corriente (sin cobrar)"**.

Al chofer que acaba de recibir la plata en la mano eso se le lee como regalar el pedido fiado, así que cancela — y la parada queda sin entregar. Es el mismo problema por otro camino: el arreglo de arriba evita llegar ahí por el flujo normal, pero entrando por otro lado el cartel seguía diciendo lo que no era.

Sin saldo pendiente el botón pasa a **"Confirmar entrega"** y a verde; con saldo queda en ámbar, porque ahí sí deja plata en la calle. El aviso posterior acompaña. El handler no cambia: siempre fue marcar entregado y nada más.

## 3. Mig 173: el trigger corría con los permisos del chofer

`actualizar_recorrido_entrega()` no era `SECURITY DEFINER`, así que sus `UPDATE` pasaban por la RLS del usuario que lo dispara. Y `mt_recorrido_pedidos_update` sólo habilita `es_admin()`:

```
UPDATE recorrido_pedidos ... -> 0 filas, SIN error   (la RLS filtra, no falla)
UPDATE recorridos        ... -> OK                    (su policy permite al chofer dueño)
```

Contador de la ruta avanzando y paradas en `'pendiente'`. Afecta a **cualquier chofer que no sea admin, desde siempre**:

| Chofer | Paradas OK | Desincronizadas |
|---|---|---|
| Marcos | 197 | **1.029** |
| Transporte Taco Pozo | 27 | **292** |
| Juan | 7 | **10** |

Se arregla con `SECURITY DEFINER`, **sin** abrir la policy: la escritura sigue encerrada en el trigger, que controla exactamente qué columnas toca. Darle `UPDATE` directo sobre `recorrido_pedidos` al chofer le abriría también `orden_entrega`, `barrida` y `notas`.

### Los contadores, además

Hacía `pedidos_entregados + 1` y `total_cobrado + NEW.monto_pagado`. Dos problemas:

- Sumar 1 es irreversible: `entregado → asignado → entregado` contaba dos veces y una reversión no descontaba nunca.
- `NEW.monto_pagado` se lee **en el instante en que se marca entregado**. El chofer cobra *después*, así que ahí valía 0 y la plata no se contaba jamás.

Ahora se recalculan desde las paradas (idempotente) y el trigger escucha también `monto_pagado`. La ruta 82 informaba `total_cobrado` **$263.900** contra **$364.500** realmente cobrados.

> Aclaración importante: `obtener_resumen_rendiciones` calcula desde `pagos`, **no** desde `recorridos.total_cobrado`. La rendición ya cerrada del día nunca estuvo mal; el desvío era sólo del contador que muestra la ruta.

## Verificación

- **7 tests** de `useEntregaParada` sobre la cadena exacta: cobro total, pago dividido, cobro parcial, pedido con pago previo, cierre sin cobrar, que no se arrastre lo cobrado de una parada a la siguiente, y pedido ya pagado. Revertí el fix y **5 de los 7 fallan**.
- **4 tests** de `ModalPagoPedido` sobre la regla del botón (con saldo, sin saldo, parcial, sobrepago). Revertí el cambio y **2 de los 4 fallan**.
- El trigger se probó **reproduciendo la sesión del chofer con RLS activa** contra la base, revertido al terminar: marca la parada, el cobro posterior suma, y una reversión descuenta sola.
- Suite completa: **1059 tests en verde**. `tsc --noEmit`, `eslint` y `npm run build` limpios.

## Notas

- La mig 173 **ya está aplicada en producción** y la **ruta 82 quedó reparada** (17/17 paradas marcadas, `total_cobrado` $364.500). El histórico viejo (1.331 paradas de otras rutas) se dejó como está, según lo acordado.
- `MANIFEST.md` actualizado (próxima migración: 174).