### PR TITLE
Entrega con salvedad: el minimo de venta no la traba y los regalos se ven

### DIFF
--- a/migrations/174_salvedad_regalos_y_minimo_de_venta.sql
+++ b/migrations/174_salvedad_regalos_y_minimo_de_venta.sql
@@ -1,0 +1,646 @@
+-- =========================================================================
+-- 174_salvedad_regalos_y_minimo_de_venta.sql
+--
+-- Dos cosas que trababan la entrega con salvedad en la calle:
+--
+-- 1) El mínimo de venta (mig 147) bloqueaba la salvedad.
+--    `trg_validar_minimo_venta_item` dispara en UPDATE OF cantidad, así que
+--    bajar una línea de 3 a 1 porque faltó stock reventaba con
+--    "La compra mínima de X es 3 unidades". El mínimo es una regla de CARGA
+--    del pedido, no de lo que efectivamente bajó del camión: pedido #4503
+--    quedó entregado por $21.190 con 2 unidades de ALIC COMINO que nunca se
+--    entregaron. 36 productos (condimentos + fideos) tienen mínimo hoy.
+--    Fix: escape hatch por GUC de transacción que sólo prenden los RPCs de
+--    salvedad. La guarda sigue intacta para alta y edición de pedidos.
+--
+-- 2) Los regalos de promoción no se podían tocar y encima nadie avisaba.
+--    - `registrar_salvedad` ya resincroniza las bonificaciones (mig 010),
+--      pero el modal de entrega mostraba los regalos como "entregados
+--      correctamente" en el resumen. Pedido #4609: se cayeron los 12
+--      PERONACHO, el sistema borró solo el regalo de 4 y la usuaria nunca
+--      se enteró.
+--    - Si el regalo NO se entregó pero los disparadores sí (no se cargó en
+--      el camión), no había forma de registrarlo: el modal no dejaba
+--      seleccionarlo. En la vista del chofer sí se podía, pero devolvía
+--      stock de un regalo que nunca lo había descontado
+--      (`regalo_mueve_stock = false`) y no descontaba `usos_pendientes`.
+--    Fix: la salvedad sobre una línea de bonificación es legal y contabiliza
+--    bien; + RPC de simulación multi-item para que el modal muestre en qué
+--    queda cada regalo ANTES de confirmar.
+--
+-- De paso se convergen las dos sobrecargas de `registrar_salvedad`, que
+-- estaban divergidas en prod: la de 7 args tenía `revertir_bloques_auto_ajuste`
+-- pero no la trazabilidad de stock, la de 8 args al revés. La de 7 args pasa a
+-- ser un wrapper; la lógica vive en la de 8.
+--
+-- Idempotente (CREATE OR REPLACE).
+-- =========================================================================
+
+-- -------------------------------------------------------------------------
+-- 1. El mínimo de venta no aplica a lo que se entrega
+-- -------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.validar_minimo_venta_item()
+RETURNS trigger
+LANGUAGE plpgsql
+SET search_path TO 'public'
+AS $fn$
+DECLARE
+  v_nombre text;
+  v_minimo integer;
+BEGIN
+  -- Los RPCs de salvedad prenden este flag (local a la transacción): lo que
+  -- se entrega de menos no puede quedar trabado por el mínimo de compra.
+  IF COALESCE(current_setting('app.omitir_minimo_venta', true), '') = '1' THEN
+    RETURN NEW;
+  END IF;
+
+  IF COALESCE(NEW.es_bonificacion, false) THEN
+    RETURN NEW;
+  END IF;
+
+  SELECT nombre, cantidad_minima_venta INTO v_nombre, v_minimo
+  FROM productos WHERE id = NEW.producto_id;
+
+  IF v_minimo IS NOT NULL AND NEW.cantidad < v_minimo THEN
+    RAISE EXCEPTION 'La compra mínima de "%" es % unidades (se cargaron %)',
+      COALESCE(v_nombre, NEW.producto_id::text), v_minimo, NEW.cantidad
+      USING ERRCODE = 'check_violation';
+  END IF;
+
+  RETURN NEW;
+END;
+$fn$;
+
+ALTER FUNCTION public.validar_minimo_venta_item() OWNER TO postgres;
+
+COMMENT ON FUNCTION public.validar_minimo_venta_item() IS
+  'Mínimo de compra por producto (mig 147). Se saltea con app.omitir_minimo_venta=1, que prenden los RPCs de salvedad: el mínimo rige el pedido, no la entrega. Mig 174.';
+
+-- -------------------------------------------------------------------------
+-- 2. registrar_salvedad: implementación única (8 args)
+-- -------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.registrar_salvedad(
+  p_pedido_id         bigint,
+  p_pedido_item_id    bigint,
+  p_cantidad_afectada integer,
+  p_motivo            character varying,
+  p_descripcion       text    DEFAULT NULL::text,
+  p_foto_url          text    DEFAULT NULL::text,
+  p_devolver_stock    boolean DEFAULT true,
+  p_client_request_id uuid    DEFAULT NULL::uuid
+) RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $fn$
+DECLARE
+  v_sucursal              BIGINT := current_sucursal_id();
+  v_salvedad_id           BIGINT;
+  v_item                  RECORD;
+  v_existing              RECORD;
+  v_cantidad_entregada    INTEGER;
+  v_monto_afectado        DECIMAL;
+  v_usuario_id            UUID;
+  v_es_admin_o_encargado  BOOLEAN;
+  v_subtotal_nuevo        DECIMAL;
+  v_stock_devuelto        BOOLEAN := FALSE;
+  v_merma_registrada      BOOLEAN := FALSE;
+  v_stock_actual          INTEGER;
+  v_es_bonif              BOOLEAN;
+  v_mueve_stock           BOOLEAN;
+  v_bonif                 RECORD;
+  v_cant_compra           INT;
+  v_cant_bonif            INT;
+  v_total_qty             INT;
+  v_bloques               INT;
+  v_expected_bonif        INT;
+  v_diff                  INT;
+  v_regalo_mueve_stock    BOOLEAN;
+  v_tipo_factura          TEXT;
+BEGIN
+  IF p_client_request_id IS NOT NULL THEN
+    SELECT id, motivo, monto_afectado, cantidad_entregada, stock_devuelto, pedido_id
+      INTO v_existing
+      FROM salvedades_items
+     WHERE client_request_id = p_client_request_id;
+
+    IF FOUND THEN
+      RETURN jsonb_build_object(
+        'success', true,
+        'salvedad_id', v_existing.id,
+        'monto_afectado', v_existing.monto_afectado,
+        'cantidad_entregada', v_existing.cantidad_entregada,
+        'stock_devuelto', v_existing.stock_devuelto,
+        'merma_registrada', v_existing.motivo IN ('producto_danado', 'producto_vencido'),
+        'nuevo_total_pedido', (
+          SELECT total FROM pedidos
+           WHERE id = v_existing.pedido_id AND sucursal_id = v_sucursal
+        ),
+        'idempotent_replay', true
+      );
+    END IF;
+  END IF;
+
+  IF v_sucursal IS NULL THEN
+    RETURN jsonb_build_object('success', false, 'error', 'No se pudo determinar la sucursal activa');
+  END IF;
+
+  v_usuario_id := auth.uid();
+  IF v_usuario_id IS NULL THEN
+    RETURN jsonb_build_object('success', false, 'error', 'Usuario no autenticado');
+  END IF;
+
+  SELECT EXISTS (
+    SELECT 1 FROM perfiles
+     WHERE id = v_usuario_id AND rol IN ('admin', 'encargado')
+  ) INTO v_es_admin_o_encargado;
+  IF NOT v_es_admin_o_encargado THEN
+    IF NOT EXISTS (
+      SELECT 1 FROM pedidos
+       WHERE id = p_pedido_id AND transportista_id = v_usuario_id AND sucursal_id = v_sucursal
+    ) THEN
+      RETURN jsonb_build_object('success', false, 'error', 'No autorizado para este pedido');
+    END IF;
+  END IF;
+
+  SELECT pi.id, pi.producto_id, pi.cantidad, pi.precio_unitario, pi.subtotal,
+         COALESCE(pi.es_bonificacion, FALSE) AS es_bonificacion, pi.promocion_id
+    INTO v_item
+    FROM pedido_items pi
+   WHERE pi.id = p_pedido_item_id
+     AND pi.pedido_id = p_pedido_id
+     AND pi.sucursal_id = v_sucursal;
+
+  IF NOT FOUND THEN
+    -- Puede pasar legítimamente con un regalo que la resincronización de
+    -- promos ya sacó del pedido; el `codigo` deja que el llamador lo
+    -- distinga de un error real.
+    RETURN jsonb_build_object(
+      'success', false,
+      'error', 'Item de pedido no encontrado',
+      'codigo', 'item_no_encontrado'
+    );
+  END IF;
+
+  IF p_cantidad_afectada > v_item.cantidad THEN
+    RETURN jsonb_build_object('success', false, 'error', 'Cantidad afectada mayor a cantidad del item');
+  END IF;
+  IF p_cantidad_afectada <= 0 THEN
+    RETURN jsonb_build_object('success', false, 'error', 'Cantidad debe ser mayor a 0');
+  END IF;
+
+  v_es_bonif := v_item.es_bonificacion;
+
+  -- ¿Esta línea descontó stock cuando se cargó el pedido? Un regalo de una
+  -- promo con `regalo_mueve_stock = false` nunca lo tocó, así que tampoco lo
+  -- devuelve ni genera merma.
+  IF v_es_bonif THEN
+    SELECT COALESCE(pr.regalo_mueve_stock, FALSE) INTO v_mueve_stock
+      FROM promociones pr
+     WHERE pr.id = v_item.promocion_id AND pr.sucursal_id = v_sucursal;
+    v_mueve_stock := COALESCE(v_mueve_stock, FALSE);
+  ELSE
+    v_mueve_stock := TRUE;
+  END IF;
+
+  v_cantidad_entregada := v_item.cantidad - p_cantidad_afectada;
+  v_monto_afectado     := p_cantidad_afectada * v_item.precio_unitario;
+  v_subtotal_nuevo     := v_cantidad_entregada * v_item.precio_unitario;
+
+  IF p_motivo IN ('cliente_rechaza', 'error_pedido', 'diferencia_precio') THEN
+    v_stock_devuelto := TRUE;
+  END IF;
+  v_stock_devuelto := v_stock_devuelto AND v_mueve_stock;
+
+  PERFORM set_config('app.stock_origen', 'salvedad', true);
+  PERFORM set_config('app.stock_ref_tipo', 'pedido', true);
+  PERFORM set_config('app.stock_ref_id', p_pedido_id::TEXT, true);
+  PERFORM set_config('app.stock_user_id', v_usuario_id::TEXT, true);
+  -- Lo que se entregó de menos no lo trapa el mínimo de compra (mig 147).
+  PERFORM set_config('app.omitir_minimo_venta', '1', true);
+
+  INSERT INTO salvedades_items (
+    pedido_id, pedido_item_id, producto_id, cantidad_original, cantidad_afectada,
+    cantidad_entregada, motivo, descripcion, foto_url, monto_afectado, precio_unitario,
+    reportado_por, stock_devuelto, stock_devuelto_at, estado_resolucion, sucursal_id,
+    client_request_id
+  ) VALUES (
+    p_pedido_id, p_pedido_item_id, v_item.producto_id, v_item.cantidad, p_cantidad_afectada,
+    v_cantidad_entregada, p_motivo, p_descripcion, p_foto_url, v_monto_afectado, v_item.precio_unitario,
+    v_usuario_id, v_stock_devuelto, CASE WHEN v_stock_devuelto THEN NOW() ELSE NULL END, 'pendiente', v_sucursal,
+    p_client_request_id
+  ) RETURNING id INTO v_salvedad_id;
+
+  IF v_salvedad_id IS NULL THEN
+    RAISE EXCEPTION 'No se pudo crear la salvedad';
+  END IF;
+
+  IF v_cantidad_entregada > 0 THEN
+    UPDATE pedido_items
+       SET cantidad = v_cantidad_entregada,
+           subtotal = v_subtotal_nuevo
+     WHERE id = p_pedido_item_id AND sucursal_id = v_sucursal;
+  ELSE
+    DELETE FROM pedido_items
+     WHERE id = p_pedido_item_id AND sucursal_id = v_sucursal;
+  END IF;
+
+  -- Salvedad sobre el regalo mismo: las unidades que no se entregaron dejan
+  -- de estar comprometidas por la promo.
+  IF v_es_bonif AND v_item.promocion_id IS NOT NULL THEN
+    PERFORM public.revertir_bloques_auto_ajuste(
+      v_item.promocion_id, p_cantidad_afectada, v_sucursal,
+      v_usuario_id, 'Salvedad sobre regalo, pedido #' || p_pedido_id
+    );
+  END IF;
+
+  -- Resincronizar bonificaciones: si cayó el disparador, cae el regalo.
+  -- Sólo reduce, nunca aumenta, así que no pisa una salvedad manual sobre el
+  -- propio regalo hecha en el mismo lote.
+  FOR v_bonif IN
+    SELECT pi.id, pi.producto_id, pi.cantidad, pi.promocion_id
+      FROM pedido_items pi
+     WHERE pi.pedido_id = p_pedido_id
+       AND pi.sucursal_id = v_sucursal
+       AND COALESCE(pi.es_bonificacion, FALSE) = TRUE
+       AND pi.promocion_id IS NOT NULL
+  LOOP
+    SELECT
+      MAX(CASE WHEN pr.clave = 'cantidad_compra'       THEN pr.valor END)::INT,
+      MAX(CASE WHEN pr.clave = 'cantidad_bonificacion' THEN pr.valor END)::INT,
+      MAX(p.regalo_mueve_stock::INT)::BOOLEAN
+    INTO v_cant_compra, v_cant_bonif, v_regalo_mueve_stock
+    FROM promociones p
+    LEFT JOIN promocion_reglas pr
+      ON pr.promocion_id = p.id
+    WHERE p.id = v_bonif.promocion_id
+      AND p.sucursal_id = v_sucursal
+    GROUP BY p.id;
+
+    IF v_cant_compra IS NULL OR v_cant_compra <= 0
+       OR v_cant_bonif IS NULL OR v_cant_bonif <= 0 THEN
+      CONTINUE;
+    END IF;
+
+    SELECT COALESCE(SUM(pi.cantidad), 0)::INT
+      INTO v_total_qty
+      FROM pedido_items pi
+      JOIN promocion_productos pp
+        ON pp.producto_id = pi.producto_id
+       AND pp.promocion_id = v_bonif.promocion_id
+     WHERE pi.pedido_id = p_pedido_id
+       AND pi.sucursal_id = v_sucursal
+       AND COALESCE(pi.es_bonificacion, FALSE) = FALSE;
+
+    v_bloques        := v_total_qty / v_cant_compra;
+    v_expected_bonif := v_bloques * v_cant_bonif;
+
+    IF v_expected_bonif < v_bonif.cantidad THEN
+      v_diff := v_bonif.cantidad - v_expected_bonif;
+
+      IF COALESCE(v_regalo_mueve_stock, FALSE) THEN
+        UPDATE productos
+           SET stock = stock + v_diff
+         WHERE id = v_bonif.producto_id
+           AND sucursal_id = v_sucursal;
+      END IF;
+
+      PERFORM public.revertir_bloques_auto_ajuste(
+        v_bonif.promocion_id, v_diff, v_sucursal,
+        v_usuario_id, 'Salvedad pedido #' || p_pedido_id
+      );
+
+      IF v_expected_bonif = 0 THEN
+        DELETE FROM pedido_items WHERE id = v_bonif.id;
+      ELSE
+        UPDATE pedido_items
+           SET cantidad = v_expected_bonif,
+               subtotal = v_expected_bonif * COALESCE(precio_unitario, 0)
+         WHERE id = v_bonif.id;
+      END IF;
+    END IF;
+  END LOOP;
+
+  SELECT COALESCE(tipo_factura, 'ZZ') INTO v_tipo_factura
+    FROM pedidos WHERE id = p_pedido_id AND sucursal_id = v_sucursal;
+
+  UPDATE pedidos
+     SET total = sub.total_recalc,
+         total_neto = sub.neto_recalc,
+         total_iva = sub.iva_recalc,
+         total_real = sub.real_recalc,
+         updated_at = NOW()
+    FROM (
+      SELECT
+        COALESCE(SUM(subtotal), 0) AS total_recalc,
+        COALESCE(SUM(CASE WHEN COALESCE(es_bonificacion, FALSE) = FALSE
+                          THEN cantidad * COALESCE(neto_unitario, precio_unitario)
+                          ELSE 0 END), 0) AS neto_recalc,
+        COALESCE(SUM(CASE WHEN COALESCE(es_bonificacion, FALSE) = FALSE
+                          THEN cantidad * COALESCE(iva_unitario, 0)
+                          ELSE 0 END), 0) AS iva_recalc,
+        COALESCE(SUM(CASE WHEN COALESCE(es_bonificacion, FALSE) = FALSE
+                          THEN cantidad * COALESCE(ingreso_real_unitario,
+                               CASE WHEN v_tipo_factura = 'FC'
+                                    THEN COALESCE(neto_unitario, precio_unitario)
+                                    ELSE precio_unitario END)
+                          ELSE 0 END), 0) AS real_recalc
+        FROM pedido_items
+       WHERE pedido_id = p_pedido_id AND sucursal_id = v_sucursal
+    ) sub
+   WHERE id = p_pedido_id AND sucursal_id = v_sucursal;
+
+  IF v_stock_devuelto THEN
+    UPDATE productos
+       SET stock = stock + p_cantidad_afectada
+     WHERE id = v_item.producto_id AND sucursal_id = v_sucursal;
+  END IF;
+
+  IF p_motivo IN ('producto_danado', 'producto_vencido') AND v_mueve_stock THEN
+    SELECT stock INTO v_stock_actual
+      FROM productos
+     WHERE id = v_item.producto_id AND sucursal_id = v_sucursal
+     FOR UPDATE;
+
+    INSERT INTO mermas_stock (
+      producto_id, cantidad, motivo, observaciones,
+      stock_anterior, stock_nuevo, usuario_id, sucursal_id
+    ) VALUES (
+      v_item.producto_id, p_cantidad_afectada,
+      CASE p_motivo WHEN 'producto_danado' THEN 'rotura' WHEN 'producto_vencido' THEN 'vencimiento' END,
+      COALESCE(p_descripcion, 'Salvedad pedido #' || p_pedido_id || ': ' || p_motivo),
+      v_stock_actual, GREATEST(v_stock_actual - p_cantidad_afectada, 0), v_usuario_id, v_sucursal
+    );
+
+    UPDATE productos
+       SET stock = GREATEST(stock - p_cantidad_afectada, 0)
+     WHERE id = v_item.producto_id AND sucursal_id = v_sucursal;
+
+    v_merma_registrada := TRUE;
+  END IF;
+
+  INSERT INTO salvedad_historial (salvedad_id, accion, estado_nuevo, notas, usuario_id, sucursal_id)
+  VALUES (v_salvedad_id, 'creacion', 'pendiente', p_descripcion, v_usuario_id, v_sucursal);
+
+  RETURN jsonb_build_object(
+    'success', true,
+    'salvedad_id', v_salvedad_id,
+    'monto_afectado', v_monto_afectado,
+    'cantidad_entregada', v_cantidad_entregada,
+    'stock_devuelto', v_stock_devuelto,
+    'merma_registrada', v_merma_registrada,
+    'es_bonificacion', v_es_bonif,
+    'nuevo_total_pedido', (
+      SELECT total FROM pedidos WHERE id = p_pedido_id AND sucursal_id = v_sucursal
+    )
+  );
+EXCEPTION WHEN OTHERS THEN
+  RETURN jsonb_build_object('success', false, 'error', SQLERRM);
+END;
+$fn$;
+
+ALTER FUNCTION public.registrar_salvedad(bigint, bigint, integer, character varying, text, text, boolean, uuid) OWNER TO postgres;
+REVOKE ALL ON FUNCTION public.registrar_salvedad(bigint, bigint, integer, character varying, text, text, boolean, uuid) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.registrar_salvedad(bigint, bigint, integer, character varying, text, text, boolean, uuid) TO authenticated;
+
+COMMENT ON FUNCTION public.registrar_salvedad(bigint, bigint, integer, character varying, text, text, boolean, uuid) IS
+  'Registra una salvedad de entrega. Acepta líneas de bonificación (regalo no entregado): devuelve stock sólo si la promo mueve stock y libera usos_pendientes. Mig 174.';
+
+-- -------------------------------------------------------------------------
+-- 3. La sobrecarga de 7 args pasa a ser un wrapper (la usa useSalvedades)
+-- -------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.registrar_salvedad(
+  p_pedido_id         bigint,
+  p_pedido_item_id    bigint,
+  p_cantidad_afectada integer,
+  p_motivo            character varying,
+  p_descripcion       text    DEFAULT NULL::text,
+  p_foto_url          text    DEFAULT NULL::text,
+  p_devolver_stock    boolean DEFAULT true
+) RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $fn$
+BEGIN
+  RETURN public.registrar_salvedad(
+    p_pedido_id, p_pedido_item_id, p_cantidad_afectada, p_motivo,
+    p_descripcion, p_foto_url, p_devolver_stock, NULL::uuid
+  );
+END;
+$fn$;
+
+ALTER FUNCTION public.registrar_salvedad(bigint, bigint, integer, character varying, text, text, boolean) OWNER TO postgres;
+REVOKE ALL ON FUNCTION public.registrar_salvedad(bigint, bigint, integer, character varying, text, text, boolean) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.registrar_salvedad(bigint, bigint, integer, character varying, text, text, boolean) TO authenticated;
+
+COMMENT ON FUNCTION public.registrar_salvedad(bigint, bigint, integer, character varying, text, text, boolean) IS
+  'Wrapper sin client_request_id. La lógica vive en la sobrecarga de 8 args. Mig 174.';
+
+-- -------------------------------------------------------------------------
+-- 4. anular_salvedad tampoco se traba con el mínimo
+--    (restaurar una línea histórica cargada por debajo del mínimo actual)
+-- -------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.anular_salvedad(
+  p_salvedad_id bigint,
+  p_notas       text DEFAULT NULL::text
+) RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $fn$
+DECLARE
+  v_sucursal BIGINT := current_sucursal_id();
+  v_salvedad RECORD;
+  v_usuario_id UUID := auth.uid();
+  v_tipo_factura TEXT;
+  v_pct_iva NUMERIC; v_pct_ii NUMERIC; v_costo_real NUMERIC; v_costo_sin NUMERIC;
+  v_costo_prom NUMERIC;
+  v_neto NUMERIC; v_iva NUMERIC; v_real NUMERIC;
+BEGIN
+  IF v_sucursal IS NULL THEN
+    RETURN jsonb_build_object('success', false, 'error', 'No se pudo determinar la sucursal activa');
+  END IF;
+  IF NOT es_admin_salvedades() THEN
+    RETURN jsonb_build_object('success', false, 'error', 'Solo admin');
+  END IF;
+  SELECT * INTO v_salvedad FROM salvedades_items WHERE id = p_salvedad_id AND sucursal_id = v_sucursal;
+  IF NOT FOUND THEN RETURN jsonb_build_object('success', false, 'error', 'No encontrada'); END IF;
+  IF v_salvedad.estado_resolucion = 'anulada' THEN
+    RETURN jsonb_build_object('success', false, 'error', 'Ya anulada');
+  END IF;
+
+  -- Devolver la línea a su cantidad original no es cargar un pedido nuevo:
+  -- el mínimo de venta no debe trabarlo (mig 174).
+  PERFORM set_config('app.omitir_minimo_venta', '1', true);
+
+  SELECT COALESCE(tipo_factura, 'ZZ') INTO v_tipo_factura
+    FROM pedidos WHERE id = v_salvedad.pedido_id AND sucursal_id = v_sucursal;
+  IF EXISTS (SELECT 1 FROM pedido_items WHERE id = v_salvedad.pedido_item_id AND sucursal_id = v_sucursal) THEN
+    UPDATE pedido_items SET
+      cantidad = v_salvedad.cantidad_original,
+      subtotal = v_salvedad.cantidad_original * v_salvedad.precio_unitario
+    WHERE id = v_salvedad.pedido_item_id AND sucursal_id = v_sucursal;
+  ELSE
+    -- Reinsertar con la terna de ingresos y costo snapshot (CPP primero, mig 129)
+    SELECT COALESCE(porcentaje_iva, 21), COALESCE(impuestos_internos, 0), costo_promedio, costo_real, costo_sin_iva
+      INTO v_pct_iva, v_pct_ii, v_costo_prom, v_costo_real, v_costo_sin
+      FROM productos WHERE id = v_salvedad.producto_id AND sucursal_id = v_sucursal;
+    SELECT d.neto, d.iva, d.ingreso_real INTO v_neto, v_iva, v_real
+      FROM calcular_desglose_venta(v_salvedad.precio_unitario, v_pct_iva, v_pct_ii, v_tipo_factura) d;
+
+    INSERT INTO pedido_items (
+      pedido_id, producto_id, cantidad, precio_unitario, subtotal, sucursal_id,
+      neto_unitario, iva_unitario, impuestos_internos_unitario, porcentaje_iva,
+      ingreso_real_unitario, costo_unitario_al_crear
+    )
+    VALUES (
+      v_salvedad.pedido_id, v_salvedad.producto_id, v_salvedad.cantidad_original,
+      v_salvedad.precio_unitario, v_salvedad.cantidad_original * v_salvedad.precio_unitario, v_sucursal,
+      v_neto, v_iva, 0, v_pct_iva,
+      v_real,
+      COALESCE(v_costo_prom, v_costo_real,
+        CASE WHEN v_costo_sin IS NULL THEN NULL ELSE round(v_costo_sin * (1 + v_pct_ii / 100), 4) END)
+    );
+  END IF;
+  UPDATE pedidos SET
+    total = (SELECT COALESCE(SUM(subtotal), 0) FROM pedido_items WHERE pedido_id = v_salvedad.pedido_id AND sucursal_id = v_sucursal),
+    total_neto = (SELECT COALESCE(SUM(CASE WHEN NOT COALESCE(es_bonificacion, false) THEN cantidad * COALESCE(neto_unitario, precio_unitario) ELSE 0 END), 0)
+                    FROM pedido_items WHERE pedido_id = v_salvedad.pedido_id AND sucursal_id = v_sucursal),
+    total_iva = (SELECT COALESCE(SUM(CASE WHEN NOT COALESCE(es_bonificacion, false) THEN cantidad * COALESCE(iva_unitario, 0) ELSE 0 END), 0)
+                   FROM pedido_items WHERE pedido_id = v_salvedad.pedido_id AND sucursal_id = v_sucursal),
+    total_real = (SELECT COALESCE(SUM(CASE WHEN NOT COALESCE(es_bonificacion, false)
+                          THEN cantidad * COALESCE(ingreso_real_unitario,
+                               CASE WHEN v_tipo_factura = 'FC' THEN COALESCE(neto_unitario, precio_unitario) ELSE precio_unitario END)
+                          ELSE 0 END), 0)
+                    FROM pedido_items WHERE pedido_id = v_salvedad.pedido_id AND sucursal_id = v_sucursal),
+    updated_at = NOW()
+  WHERE id = v_salvedad.pedido_id AND sucursal_id = v_sucursal;
+  IF v_salvedad.stock_devuelto THEN
+    UPDATE productos SET stock = stock - v_salvedad.cantidad_afectada
+     WHERE id = v_salvedad.producto_id AND sucursal_id = v_sucursal;
+  END IF;
+  UPDATE salvedades_items SET
+    estado_resolucion = 'anulada',
+    resolucion_notas = p_notas,
+    resolucion_fecha = NOW(),
+    resuelto_por = v_usuario_id,
+    updated_at = NOW()
+  WHERE id = p_salvedad_id AND sucursal_id = v_sucursal;
+  INSERT INTO salvedad_historial (salvedad_id, accion, estado_anterior, estado_nuevo, notas, usuario_id, sucursal_id)
+  VALUES (p_salvedad_id, 'anulacion', v_salvedad.estado_resolucion, 'anulada', p_notas, v_usuario_id, v_sucursal);
+  RETURN jsonb_build_object('success', true);
+END;
+$fn$;
+
+ALTER FUNCTION public.anular_salvedad(bigint, text) OWNER TO postgres;
+REVOKE ALL ON FUNCTION public.anular_salvedad(bigint, text) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.anular_salvedad(bigint, text) TO authenticated;
+
+-- -------------------------------------------------------------------------
+-- 5. Simulación multi-item: en qué queda CADA regalo del pedido si se
+--    confirma este lote de salvedades. Espeja exactamente la resincronización
+--    de arriba (sólo reduce; promo sin reglas => no se toca) para que el
+--    resumen del modal no mienta.
+--
+--    p_salvedades: [{"pedido_item_id": 123, "cantidad_afectada": 12}, ...]
+-- -------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.simular_salvedades_promo_impacto(
+  p_pedido_id  bigint,
+  p_salvedades jsonb
+)
+RETURNS TABLE(
+  pedido_item_id     bigint,
+  promocion_id       bigint,
+  promo_nombre       text,
+  producto_id        bigint,
+  producto_nombre    text,
+  descripcion_regalo text,
+  cantidad_actual    integer,
+  cantidad_final     integer,
+  delta              integer,
+  sera_eliminada     boolean
+)
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $fn$
+  WITH afectadas AS (
+    SELECT (e->>'pedido_item_id')::BIGINT AS item_id,
+           GREATEST(COALESCE((e->>'cantidad_afectada')::INT, 0), 0) AS cant
+      FROM jsonb_array_elements(COALESCE(p_salvedades, '[]'::jsonb)) e
+     WHERE (e->>'pedido_item_id') IS NOT NULL
+  ),
+  items AS (
+    SELECT pi.id, pi.producto_id, pi.cantidad, pi.promocion_id,
+           pi.descripcion_regalo,
+           COALESCE(pi.es_bonificacion, FALSE) AS es_bonif,
+           GREATEST(pi.cantidad - COALESCE(a.cant, 0), 0)::INT AS cantidad_post
+      FROM pedido_items pi
+      LEFT JOIN afectadas a ON a.item_id = pi.id
+     WHERE pi.pedido_id = p_pedido_id
+       AND pi.sucursal_id = current_sucursal_id()
+  ),
+  reglas AS (
+    SELECT p.id AS promocion_id, p.nombre, p.descripcion_regalo,
+           MAX(CASE WHEN pr.clave = 'cantidad_compra'       THEN pr.valor END)::INT AS cant_compra,
+           MAX(CASE WHEN pr.clave = 'cantidad_bonificacion' THEN pr.valor END)::INT AS cant_bonif
+      FROM promociones p
+      LEFT JOIN promocion_reglas pr ON pr.promocion_id = p.id
+     WHERE p.sucursal_id = current_sucursal_id()
+     GROUP BY p.id, p.nombre, p.descripcion_regalo
+  ),
+  totales AS (
+    SELECT pp.promocion_id, SUM(i.cantidad_post)::INT AS qty_post
+      FROM items i
+      JOIN promocion_productos pp ON pp.producto_id = i.producto_id
+     WHERE NOT i.es_bonif
+     GROUP BY pp.promocion_id
+  ),
+  calculo AS (
+    SELECT
+      b.id,
+      b.promocion_id,
+      r.nombre,
+      b.producto_id,
+      prod.nombre AS producto_nombre,
+      COALESCE(b.descripcion_regalo, r.descripcion_regalo) AS desc_regalo,
+      b.cantidad,
+      LEAST(
+        b.cantidad_post,
+        CASE
+          WHEN r.promocion_id IS NULL
+            OR COALESCE(r.cant_compra, 0) <= 0
+            OR COALESCE(r.cant_bonif, 0)  <= 0
+          THEN b.cantidad_post            -- promo sin reglas: la resync la saltea
+          ELSE (COALESCE(t.qty_post, 0) / r.cant_compra) * r.cant_bonif
+        END
+      )::INT AS cantidad_final
+      FROM items b
+      LEFT JOIN reglas   r    ON r.promocion_id = b.promocion_id
+      LEFT JOIN totales  t    ON t.promocion_id = b.promocion_id
+      LEFT JOIN productos prod ON prod.id = b.producto_id
+     WHERE b.es_bonif
+  )
+  SELECT
+    c.id                             AS pedido_item_id,
+    c.promocion_id,
+    c.nombre::TEXT                   AS promo_nombre,
+    c.producto_id,
+    c.producto_nombre::TEXT,
+    c.desc_regalo::TEXT              AS descripcion_regalo,
+    c.cantidad                       AS cantidad_actual,
+    c.cantidad_final,
+    (c.cantidad - c.cantidad_final)  AS delta,
+    (c.cantidad_final = 0)           AS sera_eliminada
+  FROM calculo c
+  ORDER BY c.id;
+$fn$;
+
+ALTER FUNCTION public.simular_salvedades_promo_impacto(bigint, jsonb) OWNER TO postgres;
+REVOKE ALL ON FUNCTION public.simular_salvedades_promo_impacto(bigint, jsonb) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.simular_salvedades_promo_impacto(bigint, jsonb) TO authenticated;
+
+COMMENT ON FUNCTION public.simular_salvedades_promo_impacto(bigint, jsonb) IS
+  'Dry-run multi-item: devuelve una fila por línea de regalo del pedido con la cantidad en la que queda si se confirma el lote de salvedades. Mig 174.';

--- a/src/components/containers/PedidosContainer.tsx
+++ b/src/components/containers/PedidosContainer.tsx
@@ -1526,6 +1526,7 @@ export default function PedidosContainer(): React.ReactElement {
           results.push({
             success: !!result?.success,
             error: result?.success ? undefined : String(result?.error || 'Error desconocido'),
+            codigo: result?.codigo ? String(result.codigo) : undefined,
           })
         }
       } catch (err) {

--- a/src/components/modals/ModalEntregaConSalvedad.tsx
+++ b/src/components/modals/ModalEntregaConSalvedad.tsx
@@ -3,9 +3,10 @@
  * Permite seleccionar items con problemas antes de marcar el pedido como entregado
  * Validación con Zod
  */
-import React, { useState, useCallback } from 'react'
+import React, { useState, useCallback, useMemo } from 'react'
 import { X, AlertTriangle, Package, Check, ChevronDown, ChevronUp, Truck, Gift } from 'lucide-react'
 import { MOTIVOS_SALVEDAD_LABELS } from '../../lib/schemas'
+import { useSimularSalvedadesPromoImpactoQuery } from '../../hooks/queries'
 import NumberInput from '../ui/NumberInput'
 import type { PedidoDB, PedidoItemDB, MotivoSalvedad, RegistrarSalvedadInput, RegistrarSalvedadResult } from '../../types'
 
@@ -24,6 +25,14 @@ const MOTIVOS_SALVEDAD: MotivoOption[] = [
   { value: 'diferencia_precio', label: MOTIVOS_SALVEDAD_LABELS.diferencia_precio, devuelveStock: true },
   { value: 'otro', label: MOTIVOS_SALVEDAD_LABELS.otro, devuelveStock: false }
 ]
+
+// Un regalo va a $0: "diferencia de precio" no aplica.
+const MOTIVOS_REGALO: MotivoOption[] = MOTIVOS_SALVEDAD.filter(m => m.value !== 'diferencia_precio')
+
+const esRegaloItem = (item: PedidoItemDB): boolean => item.es_bonificacion === true
+
+const nombreItem = (item: PedidoItemDB): string =>
+  (esRegaloItem(item) && item.descripcion_regalo) || item.producto?.nombre || 'Producto'
 
 interface ItemSalvedad {
   item: PedidoItemDB;
@@ -62,15 +71,27 @@ export default function ModalEntregaConSalvedad({
 
   const itemsConSalvedad = itemsSalvedad.filter(i => i.seleccionado)
   const itemsSinProblemas = itemsSalvedad.filter(i => !i.seleccionado)
+  // Los regalos tienen su propia seccion en el resumen: lo que pasa con ellos
+  // no lo decide solo el checkbox, tambien la promo que los origina.
+  const entregadosCobrables = itemsSinProblemas.filter(i => !esRegaloItem(i.item))
+
+  // Dry-run del lote completo: en que queda cada regalo si se confirma esto.
+  const salvedadesParaSimular = useMemo(
+    () => itemsConSalvedad.map(i => ({
+      pedidoItemId: i.item.id,
+      cantidadAfectada: i.cantidadAfectada,
+    })),
+    [itemsConSalvedad],
+  )
+  const { data: regalosSimulados = [], isLoading: simulando } =
+    useSimularSalvedadesPromoImpactoQuery(pedido.id, salvedadesParaSimular, {
+      enabled: paso === 'confirmacion',
+    })
 
   const toggleItem = useCallback((itemId: string) => {
-    setItemsSalvedad(prev => {
-      const target = prev.find(i => i.item.id === itemId)
-      if (target?.item.es_bonificacion) return prev
-      return prev.map(i =>
-        i.item.id === itemId ? { ...i, seleccionado: !i.seleccionado } : i
-      )
-    })
+    setItemsSalvedad(prev => prev.map(i =>
+      i.item.id === itemId ? { ...i, seleccionado: !i.seleccionado } : i
+    ))
     setExpandido(prev => prev === itemId ? null : itemId)
   }, [])
 
@@ -82,7 +103,7 @@ export default function ModalEntregaConSalvedad({
 
   const validarDatos = (): boolean => {
     for (const itemSalv of itemsConSalvedad) {
-      const productoNombre = itemSalv.item.producto?.nombre || 'Producto'
+      const productoNombre = nombreItem(itemSalv.item)
 
       // Validaciones explícitas antes de Zod (Zod 4 da mensajes genéricos para enum/undefined)
       if (!itemSalv.motivo) {
@@ -119,10 +140,17 @@ export default function ModalEntregaConSalvedad({
     setGuardando(true)
 
     try {
-      // Registrar todas las salvedades
+      // Registrar todas las salvedades. Los regalos van primero: si despues se
+      // registra la salvedad del producto que dispara la promo, la resync del
+      // servidor termina de bajar el regalo. Al reves la linea del regalo ya no
+      // existiria cuando le toca el turno.
       if (itemsConSalvedad.length > 0) {
-        const salvedades: RegistrarSalvedadInput[] = itemsConSalvedad.map(itemSalv => {
-          const motivoConfig = MOTIVOS_SALVEDAD.find(m => m.value === itemSalv.motivo)
+        const ordenadas = [...itemsConSalvedad].sort(
+          (a, b) => Number(esRegaloItem(b.item)) - Number(esRegaloItem(a.item))
+        )
+        const salvedades: RegistrarSalvedadInput[] = ordenadas.map(itemSalv => {
+          const motivos = esRegaloItem(itemSalv.item) ? MOTIVOS_REGALO : MOTIVOS_SALVEDAD
+          const motivoConfig = motivos.find(m => m.value === itemSalv.motivo)
           return {
             pedidoId: pedido.id,
             pedidoItemId: itemSalv.item.id,
@@ -134,7 +162,11 @@ export default function ModalEntregaConSalvedad({
         })
 
         const results = await onSave(salvedades)
-        const errores = results.filter(r => !r.success)
+        // Un regalo que la promo ya saco del pedido no es un error: el
+        // resultado buscado (no se entrega) ya esta.
+        const errores = results.filter((r, idx) => !r.success && !(
+          r.codigo === 'item_no_encontrado' && esRegaloItem(ordenadas[idx].item)
+        ))
         if (errores.length > 0) {
           setError(`Error al registrar ${errores.length} salvedad(es): ${errores[0].error}`)
           return
@@ -192,33 +224,8 @@ export default function ModalEntregaConSalvedad({
               <div className="space-y-2">
                 {itemsSalvedad.map(itemSalv => {
                   const isExpanded = expandido === itemSalv.item.id
-                  const esRegalo = itemSalv.item.es_bonificacion === true
-
-                  if (esRegalo) {
-                    return (
-                      <div
-                        key={itemSalv.item.id}
-                        className="border rounded-lg overflow-hidden border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800/40 opacity-75"
-                      >
-                        <div className="flex items-center gap-3 p-3">
-                          <Gift className="w-5 h-5 text-emerald-500 shrink-0" />
-                          <div className="flex-1 min-w-0">
-                            <p className="font-medium text-gray-700 dark:text-gray-200 truncate">
-                              {itemSalv.item.producto?.nombre || 'Producto'}
-                            </p>
-                            <p className="text-xs text-gray-500 dark:text-gray-400">
-                              Regalo por promocion - se ajusta automaticamente
-                            </p>
-                          </div>
-                          <div className="text-right shrink-0">
-                            <p className="text-sm text-gray-500">
-                              {itemSalv.item.cantidad} ud.
-                            </p>
-                          </div>
-                        </div>
-                      </div>
-                    )
-                  }
+                  const esRegalo = esRegaloItem(itemSalv.item)
+                  const motivosDisponibles = esRegalo ? MOTIVOS_REGALO : MOTIVOS_SALVEDAD
 
                   return (
                     <div
@@ -226,7 +233,9 @@ export default function ModalEntregaConSalvedad({
                       className={`border rounded-lg overflow-hidden transition-colors ${
                         itemSalv.seleccionado
                           ? 'border-amber-500 bg-amber-50 dark:bg-amber-900/20'
-                          : 'border-gray-200 dark:border-gray-700'
+                          : esRegalo
+                            ? 'border-emerald-200 dark:border-emerald-800/60 bg-emerald-50/50 dark:bg-emerald-900/10'
+                            : 'border-gray-200 dark:border-gray-700'
                       }`}
                     >
                       {/* Item header */}
@@ -241,19 +250,29 @@ export default function ModalEntregaConSalvedad({
                         }`}>
                           {itemSalv.seleccionado && <Check className="w-3 h-3 text-white" />}
                         </div>
-                        <Package className="w-5 h-5 text-gray-400" />
-                        <div className="flex-1">
+                        {esRegalo
+                          ? <Gift className="w-5 h-5 text-emerald-500 shrink-0" />
+                          : <Package className="w-5 h-5 text-gray-400" />}
+                        <div className="flex-1 min-w-0">
                           <p className="font-medium text-gray-800 dark:text-white">
-                            {itemSalv.item.producto?.nombre || 'Producto'}
+                            {nombreItem(itemSalv.item)}
                           </p>
                           <p className="text-sm text-gray-500">
-                            {itemSalv.item.cantidad} x {formatMoney(itemSalv.item.precio_unitario)}
+                            {esRegalo
+                              ? `${itemSalv.item.cantidad} ud. de regalo - si cae la promo se ajusta solo`
+                              : `${itemSalv.item.cantidad} x ${formatMoney(itemSalv.item.precio_unitario)}`}
                           </p>
                         </div>
-                        <div className="text-right">
-                          <p className="font-bold text-gray-800 dark:text-white">
-                            {formatMoney(itemSalv.item.cantidad * itemSalv.item.precio_unitario)}
-                          </p>
+                        <div className="text-right shrink-0">
+                          {esRegalo ? (
+                            <span className="text-xs bg-emerald-100 dark:bg-emerald-800 text-emerald-700 dark:text-emerald-300 px-1.5 py-0.5 rounded font-medium">
+                              REGALO
+                            </span>
+                          ) : (
+                            <p className="font-bold text-gray-800 dark:text-white">
+                              {formatMoney(itemSalv.item.cantidad * itemSalv.item.precio_unitario)}
+                            </p>
+                          )}
                         </div>
                         {itemSalv.seleccionado && (
                           isExpanded ? <ChevronUp className="w-5 h-5 text-gray-400" /> : <ChevronDown className="w-5 h-5 text-gray-400" />
@@ -296,7 +315,7 @@ export default function ModalEntregaConSalvedad({
                               className="w-full px-3 py-2 border dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-amber-500 dark:bg-gray-700 dark:text-white"
                             >
                               <option value="">Seleccionar motivo...</option>
-                              {MOTIVOS_SALVEDAD.map(m => (
+                              {motivosDisponibles.map(m => (
                                 <option key={m.value} value={m.value}>{m.label}</option>
                               ))}
                             </select>
@@ -329,14 +348,14 @@ export default function ModalEntregaConSalvedad({
               <div className="p-4 bg-blue-50 dark:bg-blue-900/20 rounded-lg border border-blue-200 dark:border-blue-800">
                 <h3 className="font-semibold text-blue-800 dark:text-blue-400 mb-2">Resumen de la entrega</h3>
 
-                {/* Items entregados correctamente */}
-                {itemsSinProblemas.length > 0 && (
+                {/* Items entregados correctamente (los regalos van aparte) */}
+                {entregadosCobrables.length > 0 && (
                   <div className="mb-3">
                     <p className="text-sm font-medium text-green-700 dark:text-green-400 flex items-center gap-1 mb-1">
                       <Check className="w-4 h-4" /> Productos entregados correctamente:
                     </p>
                     <ul className="text-sm text-gray-600 dark:text-gray-300 ml-5 space-y-1">
-                      {itemsSinProblemas.map(i => (
+                      {entregadosCobrables.map(i => (
                         <li key={i.item.id}>
                           {i.item.cantidad}x {i.item.producto?.nombre} - {formatMoney(i.item.cantidad * i.item.precio_unitario)}
                         </li>
@@ -353,12 +372,53 @@ export default function ModalEntregaConSalvedad({
                     </p>
                     <ul className="text-sm text-gray-600 dark:text-gray-300 ml-5 space-y-1">
                       {itemsConSalvedad.map(i => {
-                        const motivoLabel = MOTIVOS_SALVEDAD.find(m => m.value === i.motivo)?.label || i.motivo
+                        const motivos = esRegaloItem(i.item) ? MOTIVOS_REGALO : MOTIVOS_SALVEDAD
+                        const motivoLabel = motivos.find(m => m.value === i.motivo)?.label || i.motivo
                         const entregados = i.item.cantidad - i.cantidadAfectada
                         return (
                           <li key={i.item.id}>
-                            {i.item.producto?.nombre}: {i.cantidadAfectada} ud. con problema ({motivoLabel})
+                            {nombreItem(i.item)}: {i.cantidadAfectada} ud. con problema ({motivoLabel})
                             {entregados > 0 && ` - Se entregan ${entregados} ud.`}
+                          </li>
+                        )
+                      })}
+                    </ul>
+                  </div>
+                )}
+
+                {/* Regalos: lo que realmente queda despues de recalcular las promos */}
+                {simulando && (
+                  <p className="mb-3 text-sm text-gray-500 dark:text-gray-400">
+                    Recalculando los regalos por promocion...
+                  </p>
+                )}
+                {!simulando && regalosSimulados.length > 0 && (
+                  <div className="mb-3">
+                    <p className="text-sm font-medium text-emerald-700 dark:text-emerald-400 flex items-center gap-1 mb-1">
+                      <Gift className="w-4 h-4" /> Regalos por promocion:
+                    </p>
+                    <ul className="text-sm text-gray-600 dark:text-gray-300 ml-5 space-y-1">
+                      {regalosSimulados.map(r => {
+                        const nombre = r.descripcion_regalo || r.producto_nombre || 'Regalo'
+                        if (r.sera_eliminada) {
+                          return (
+                            <li key={r.pedido_item_id} className="text-red-600 dark:text-red-400">
+                              {nombre}: no se entrega
+                              {r.promo_nombre && ` - se cae la promo "${r.promo_nombre}"`}
+                            </li>
+                          )
+                        }
+                        if (r.delta > 0) {
+                          return (
+                            <li key={r.pedido_item_id} className="text-amber-700 dark:text-amber-400">
+                              {nombre}: baja de {r.cantidad_actual} a {r.cantidad_final} ud.
+                              {r.promo_nombre && ` (${r.promo_nombre})`}
+                            </li>
+                          )
+                        }
+                        return (
+                          <li key={r.pedido_item_id}>
+                            {r.cantidad_final}x {nombre} - se entrega
                           </li>
                         )
                       })}

--- a/src/hooks/queries/index.ts
+++ b/src/hooks/queries/index.ts
@@ -390,6 +390,8 @@ export {
 } from './usePromocionesQuery'
 export { useSimularSalvedadPromoImpactoQuery } from './useSimularSalvedadQuery'
 export type { PromoImpactoSalvedad } from './useSimularSalvedadQuery'
+export { useSimularSalvedadesPromoImpactoQuery } from './useSimularSalvedadesQuery'
+export type { RegaloSimulado, SalvedadSimulada } from './useSimularSalvedadesQuery'
 export type { PromocionConDetalles, PromocionFormInput } from './usePromocionesQuery'
 
 // Notas de Crédito

--- a/src/hooks/queries/useSimularSalvedadesQuery.ts
+++ b/src/hooks/queries/useSimularSalvedadesQuery.ts
@@ -1,0 +1,76 @@
+/**
+ * Dry-run multi-item: en que queda cada regalo del pedido si se confirma un
+ * lote entero de salvedades. Llama al RPC `simular_salvedades_promo_impacto`
+ * (migracion 174).
+ *
+ * El de a un item vive en `useSimularSalvedadQuery` y sirve para el modal del
+ * chofer; este es el que necesita la "Entrega con salvedad", donde se marcan
+ * varios productos de una y el resumen tiene que decir la verdad sobre los
+ * regalos antes de confirmar.
+ */
+import { useQuery } from '@tanstack/react-query'
+import { supabase } from '../supabase/base'
+import { useSucursal } from '../../contexts/SucursalContext'
+
+export interface SalvedadSimulada {
+  pedidoItemId: string | number
+  cantidadAfectada: number
+}
+
+export interface RegaloSimulado {
+  pedido_item_id: number
+  promocion_id: number | null
+  promo_nombre: string | null
+  producto_id: number
+  producto_nombre: string | null
+  descripcion_regalo: string | null
+  cantidad_actual: number
+  cantidad_final: number
+  delta: number
+  sera_eliminada: boolean
+}
+
+async function fetchSimularSalvedades(
+  pedidoId: string | number,
+  salvedades: SalvedadSimulada[],
+): Promise<RegaloSimulado[]> {
+  const { data, error } = await supabase.rpc('simular_salvedades_promo_impacto', {
+    p_pedido_id: Number(pedidoId),
+    p_salvedades: salvedades.map(s => ({
+      pedido_item_id: Number(s.pedidoItemId),
+      cantidad_afectada: s.cantidadAfectada,
+    })),
+  })
+  if (error) {
+    // El RPC recien existe desde la mig 174; si el deploy de base todavia no
+    // paso, el modal sigue funcionando sin la seccion de regalos.
+    if (error.message.includes('does not exist')) return []
+    throw error
+  }
+  return (data as RegaloSimulado[]) ?? []
+}
+
+/**
+ * Una fila por linea de regalo del pedido, con la cantidad en la que queda si
+ * se confirman estas salvedades. Array vacio = el pedido no tiene regalos.
+ */
+export function useSimularSalvedadesPromoImpactoQuery(
+  pedidoId: string | number | null | undefined,
+  salvedades: SalvedadSimulada[],
+  opciones?: { enabled?: boolean },
+) {
+  const { currentSucursalId } = useSucursal()
+  // Clave estable: el orden de seleccion no deberia disparar un refetch.
+  const firma = salvedades
+    .map(s => `${s.pedidoItemId}:${s.cantidadAfectada}`)
+    .sort()
+    .join('|')
+  const enabled = !!pedidoId && !!currentSucursalId && (opciones?.enabled ?? true)
+
+  return useQuery({
+    queryKey: ['simular_salvedades_promo_impacto', currentSucursalId, pedidoId, firma] as const,
+    queryFn: () => fetchSimularSalvedades(pedidoId!, salvedades),
+    enabled,
+    staleTime: 10 * 1000,
+  })
+}

--- a/src/hooks/supabase/useSalvedades.ts
+++ b/src/hooks/supabase/useSalvedades.ts
@@ -175,7 +175,7 @@ export function useSalvedades(): UseSalvedadesReturn {
 
       if (!result?.success) {
         notifyError(result?.error || 'Error al registrar salvedad')
-        return { success: false, error: result?.error }
+        return { success: false, error: result?.error, codigo: result?.codigo }
       }
 
       return {

--- a/src/types/hooks.ts
+++ b/src/types/hooks.ts
@@ -1592,6 +1592,8 @@ export interface RegistrarSalvedadInput {
 export interface RegistrarSalvedadResult {
   success: boolean;
   error?: string;
+  /** Codigo estable del fallo. `item_no_encontrado` = la linea ya no esta en el pedido. */
+  codigo?: string;
   salvedad_id?: string;
   monto_afectado?: number;
   cantidad_entregada?: number;


### PR DESCRIPTION
Los dos reportes de la usuaria, y son dos bugs distintos.

## 1. "No me deja registrar que la venta solo fue x1 COMINO"

El mínimo de venta (mig 147) bloqueaba la salvedad. El trigger `trg_validar_minimo_venta_item` dispara en `UPDATE OF cantidad`, así que bajar una línea de 3 a 1 porque faltó stock reventaba con *"La compra mínima de ALIC COMINO X 25 G es 3 unidades (se cargaron 1)"*.

El mínimo es una regla de **carga** del pedido, no de lo que efectivamente bajó del camión. El pedido **#4503 quedó entregado y cobrado por $21.190 con 2 unidades de ALIC COMINO ($1.820) que nunca se entregaron**. Hoy hay 36 productos con mínimo (condimentos + fideos), o sea que cualquier entrega parcial de esos venía fallando.

Fix: los RPCs de salvedad prenden `app.omitir_minimo_venta` (GUC local a la transacción) y el trigger lo respeta. La guarda sigue intacta para alta y edición de pedidos. `anular_salvedad` también lo prende, para poder restaurar una línea histórica cargada por debajo del mínimo actual.

## 2. "Los 4 que arriba me figuran entregados tampoco se entregaron y no me deja eliminarlo"

Dos problemas encadenados:

**El resumen mentía.** `registrar_salvedad` ya resincroniza las bonificaciones desde la mig 010, pero el modal listaba los regalos bajo "Productos entregados correctamente". En el pedido #4609 se cayeron los 12 PERONACHO, el sistema borró solo el regalo de 4 (correcto) y la usuaria nunca se enteró. El otro regalo de la captura (POMELO BLANCO) sí correspondía entregarlo: viene de otra promo, atada a los 4 fardos PLACER que sí bajaron.

**Y no había forma de sacar un regalo a mano.** Si el regalo no se cargó en el camión pero los disparadores sí, el modal no dejaba seleccionarlo. En la vista del chofer sí se podía, pero devolvía stock de un regalo que nunca lo había descontado (`regalo_mueve_stock = false`) y no descontaba `usos_pendientes`.

Fix:
- `registrar_salvedad` acepta líneas de bonificación: monto 0, devuelve stock **solo** si la promo mueve stock, y libera `usos_pendientes` por las unidades no entregadas.
- Nuevo RPC `simular_salvedades_promo_impacto(pedido, salvedades[])`: dry-run del lote completo, una fila por regalo con la cantidad en la que queda. Espeja exactamente la resincronización (solo reduce; promo sin reglas no se toca) para que el resumen no vuelva a mentir.
- El modal muestra una sección **"Regalos por promoción"** que dice, de cada uno, si se entrega, si baja de N a M o si se cancela y por qué promo.
- Los regalos son seleccionables y se mandan primero, para que la resync del disparador termine de bajarlos.

## De yapa

Las dos sobrecargas de `registrar_salvedad` estaban divergidas en prod: la de 7 args tenía `revertir_bloques_auto_ajuste` pero no la trazabilidad de stock, la de 8 al revés — y las dos están vivas (`useSalvedades` llama la de 7, `PedidosContainer` la de 8). La de 7 pasa a ser un wrapper; la lógica queda en una sola.

## Verificación

Migración **174 aplicada a prod** (solo `CREATE OR REPLACE`, sin cambios de datos) y probada contra los pedidos reales de las capturas, dentro de una transacción revertida:

| | resultado |
|---|---|
| Salvedad de 2 ALIC COMINO (mínimo 3) en #4503 | pasa; item queda en 1, total $21.190 → **$19.370** |
| Salvedad sobre el regalo POMELO de #4609 | monto $0, **stock 31→31 sin tocar**, `usos_pendientes` 5→1, total del pedido intacto |
| Repetir sobre un item ya borrado | `codigo=item_no_encontrado`, el modal lo tolera para regalos |
| Simulación sin salvedades / sacando 2 de 4 / sacando 4 de 4 fardos | regalo queda en 6 / 3 / 0 (`sera_eliminada`) |

Todo revertido después: pedido #4503 volvió a $21.190, el regalo a 4, `usos_pendientes` a 5.

Además, el modal abierto sobre el pedido real #4618 (sin confirmar, pedido intacto): el regalo aparece como línea seleccionable y el resumen dice *"1 Botella Placer Pomelo Blanco 500cc: baja de 6 a 3 ud."* al marcar 3 PLACER MANZANA.

typecheck, eslint, `npm run build` y los 1059 tests en verde.

## Pendiente para vos

El pedido **#4503** sigue cobrado de más por $1.820. Con la 174 ya aplicada, se arregla desde la app: revertir el pedido a "asignado", registrar la salvedad de las 2 unidades, y el total y el pago bajan solos (migs 165-168).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
