### PR TITLE
La app avisa cuando hay una version nueva

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -47,7 +47,11 @@ export default defineConfig([
     ],
     languageOptions: {
       ecmaVersion: 2020,
-      globals: globals.browser,
+      globals: {
+        ...globals.browser,
+        // Lo inyecta vite via `define` (ver vite.config.js).
+        __APP_BUILD_ID__: 'readonly',
+      },
       parser: tsparser,
       parserOptions: {
         ecmaVersion: 'latest',

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -26,6 +26,7 @@ import ErrorBoundary from './components/ErrorBoundary'
 import TopNavigation from './components/layout/TopNavigation'
 import OfflineIndicator from './components/layout/OfflineIndicator'
 import SyncStatusBanner from './components/SyncStatusBanner'
+import BannerActualizacion from './components/BannerActualizacion'
 import SkipLinks from './components/a11y/SkipLinks'
 import ClientesContainer from './components/containers/ClientesContainer'
 import ComprasContainer from './components/containers/ComprasContainer'
@@ -386,6 +387,7 @@ function MainAppInner({ user, perfil, logout, authReady }: {
         )}
 
         <SyncStatusBanner onRetrySync={handleRetrySync} />
+        <BannerActualizacion />
       </div>
     </AuthDataProvider>
   )

--- a/src/components/BannerActualizacion.tsx
+++ b/src/components/BannerActualizacion.tsx
@@ -1,0 +1,59 @@
+/**
+ * Cartel de "hay una version nueva". Ver `useActualizacionDisponible` para el
+ * porque: sin service worker la app no se entera sola de los deploys.
+ *
+ * A diferencia del viejo PWAPrompt (que quedo sin montar desde marzo y solo se
+ * renderizaba fuera del modo standalone), este aparece siempre, tambien con la
+ * app instalada, que es justamente donde la pestania vive abierta durante
+ * semanas.
+ */
+import { RefreshCw, X } from 'lucide-react'
+import type { ReactElement } from 'react'
+import { useActualizacionDisponible } from '../hooks/useActualizacionDisponible'
+
+export function BannerActualizacion(): ReactElement | null {
+  const { disponible, actualizar, posponer } = useActualizacionDisponible()
+
+  if (!disponible) return null
+
+  return (
+    <div
+      role="status"
+      className="fixed bottom-4 left-4 right-4 md:left-auto md:right-4 md:w-96 bg-blue-600 text-white p-4 rounded-lg shadow-lg z-50"
+    >
+      <div className="flex items-start gap-3">
+        <RefreshCw className="w-5 h-5 mt-0.5 flex-shrink-0" />
+        <div className="flex-1">
+          <p className="font-medium">Hay una version nueva</p>
+          <p className="text-sm text-blue-100 mt-1">
+            Actualiza para no seguir trabajando con pantallas viejas. Si estas
+            cargando algo, termina primero.
+          </p>
+          <div className="flex gap-2 mt-3">
+            <button
+              onClick={actualizar}
+              className="px-3 py-1.5 bg-white text-blue-600 rounded font-medium text-sm hover:bg-blue-50 transition-colors"
+            >
+              Actualizar
+            </button>
+            <button
+              onClick={posponer}
+              className="px-3 py-1.5 text-blue-100 hover:text-white text-sm"
+            >
+              Mas tarde
+            </button>
+          </div>
+        </div>
+        <button
+          onClick={posponer}
+          className="p-1 hover:bg-blue-500 rounded"
+          aria-label="Cerrar aviso de actualizacion"
+        >
+          <X className="w-4 h-4" />
+        </button>
+      </div>
+    </div>
+  )
+}
+
+export default BannerActualizacion

--- a/src/components/layout/TopNavigation.tsx
+++ b/src/components/layout/TopNavigation.tsx
@@ -12,6 +12,7 @@ import { useAuthData } from '../../contexts/AuthDataContext';
 import DbNotificationBell from './DbNotificationBell';
 import SucursalSelector from './SucursalSelector';
 import VincularTelegramButton from '../perfil/VincularTelegramButton';
+import { BUILD_ACTUAL } from '../../hooks/useActualizacionDisponible';
 import type { PerfilDB, RolUsuario } from '../../types';
 
 // =============================================================================
@@ -352,6 +353,11 @@ export default function TopNavigation({
                     <LogOut className="w-5 h-5" />
                     <span>Cerrar sesion</span>
                   </button>
+                  {/* Sin esto, cuando alguien reporta "me sale distinto" no hay
+                      forma de saber que build esta corriendo. */}
+                  <p className="px-4 pt-2 border-t dark:border-gray-700 text-[11px] text-gray-400 dark:text-gray-500">
+                    Version {BUILD_ACTUAL}
+                  </p>
                 </div>
               )}
             </div>

--- a/src/hooks/useActualizacionDisponible.test.tsx
+++ b/src/hooks/useActualizacionDisponible.test.tsx
@@ -1,0 +1,128 @@
+/**
+ * El bug que motiva este hook: sin service worker, una pestania abierta corre
+ * el bundle del dia que se abrio. Lo que se prueba aca es que avise cuando el
+ * deploy cambio, y sobre todo que NO avise cuando no puede saberlo (sin red,
+ * respuesta rara, deploy a medio subir): un cartel que aparece de gusto es
+ * peor que no tenerlo, porque se aprende a ignorarlo.
+ */
+import { renderHook, act, waitFor } from '@testing-library/react'
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { useActualizacionDisponible } from './useActualizacionDisponible'
+
+// El build id que vite inyecta en el bundle bajo test (define en vite.config.js).
+const BUILD_DE_ESTA_PESTANIA = __APP_BUILD_ID__
+
+/** Deja correr la cadena de promesas del fetch antes de afirmar un negativo. */
+const flush = (): Promise<void> => new Promise(r => setTimeout(r, 0))
+
+function responderVersion(body: unknown, ok = true): void {
+  vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+    ok,
+    json: () => Promise.resolve(body),
+  }))
+}
+
+describe('useActualizacionDisponible', () => {
+  beforeEach(() => {
+    // En DEV el hook queda inerte a proposito; los tests simulan produccion.
+    vi.stubEnv('DEV', false)
+    Object.defineProperty(document, 'visibilityState', {
+      configurable: true,
+      get: () => 'visible',
+    })
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.unstubAllEnvs()
+  })
+
+  it('avisa cuando el build publicado no es el que corre esta pestania', async () => {
+    responderVersion({ buildId: 'otro-build-mas-nuevo' })
+
+    const { result } = renderHook(() => useActualizacionDisponible())
+
+    await waitFor(() => expect(result.current.disponible).toBe(true))
+  })
+
+  it('no avisa si el build publicado es el mismo', async () => {
+    responderVersion({ buildId: BUILD_DE_ESTA_PESTANIA })
+
+    const { result } = renderHook(() => useActualizacionDisponible())
+
+    await waitFor(() => expect(fetch).toHaveBeenCalled())
+    await flush()
+    expect(result.current.disponible).toBe(false)
+  })
+
+  it('no avisa si no hay red', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('Load failed')))
+
+    const { result } = renderHook(() => useActualizacionDisponible())
+
+    await waitFor(() => expect(fetch).toHaveBeenCalled())
+    await flush()
+    expect(result.current.disponible).toBe(false)
+  })
+
+  it('no avisa si el hosting devuelve algo que no es el version.json', async () => {
+    // Caso real: un SPA fallback que responde el index.html con 200.
+    responderVersion({ nada: 'que ver' })
+
+    const { result } = renderHook(() => useActualizacionDisponible())
+
+    await waitFor(() => expect(fetch).toHaveBeenCalled())
+    await flush()
+    expect(result.current.disponible).toBe(false)
+  })
+
+  it('no avisa si el archivo todavia no esta (deploy a medio subir)', async () => {
+    responderVersion({}, false)
+
+    const { result } = renderHook(() => useActualizacionDisponible())
+
+    await waitFor(() => expect(fetch).toHaveBeenCalled())
+    await flush()
+    expect(result.current.disponible).toBe(false)
+  })
+
+  it('pide el archivo sin cache, para no leer una copia vieja del navegador', async () => {
+    responderVersion({ buildId: BUILD_DE_ESTA_PESTANIA })
+
+    renderHook(() => useActualizacionDisponible())
+
+    await waitFor(() => expect(fetch).toHaveBeenCalled())
+    const [url, opciones] = (fetch as unknown as ReturnType<typeof vi.fn>).mock.calls[0]
+    expect(url).toMatch(/^\/version\.json\?t=\d+$/)
+    expect(opciones).toEqual({ cache: 'no-store' })
+  })
+
+  it('posponer apaga el cartel y aguanta los chequeos siguientes', async () => {
+    responderVersion({ buildId: 'otro-build-mas-nuevo' })
+
+    const { result } = renderHook(() => useActualizacionDisponible())
+    await waitFor(() => expect(result.current.disponible).toBe(true))
+
+    act(() => { result.current.posponer() })
+    expect(result.current.disponible).toBe(false)
+
+    const llamadasPrevias = (fetch as unknown as ReturnType<typeof vi.fn>).mock.calls.length
+    // Volver a la pestania dispara un chequeo, que debe respetar el "mas tarde".
+    act(() => { window.dispatchEvent(new Event('focus')) })
+    await new Promise(r => setTimeout(r, 0))
+
+    expect((fetch as unknown as ReturnType<typeof vi.fn>).mock.calls.length).toBe(llamadasPrevias)
+    expect(result.current.disponible).toBe(false)
+  })
+
+  it('en desarrollo no molesta ni pega al servidor', async () => {
+    vi.stubEnv('DEV', true)
+    responderVersion({ buildId: 'otro-build-mas-nuevo' })
+
+    const { result } = renderHook(() => useActualizacionDisponible())
+    await new Promise(r => setTimeout(r, 0))
+
+    expect(fetch).not.toHaveBeenCalled()
+    expect(result.current.disponible).toBe(false)
+  })
+})

--- a/src/hooks/useActualizacionDisponible.ts
+++ b/src/hooks/useActualizacionDisponible.ts
@@ -1,0 +1,104 @@
+/**
+ * Detecta que hay un deploy nuevo mientras la app esta abierta.
+ *
+ * Desde el 20/03 la app no registra service worker (ver `pwaAuthHotfix.ts`,
+ * que los desregistra en cada arranque, y `injectRegister: false` en
+ * vite.config.js). Sin SW no hay chequeo de version de ningun tipo: una
+ * pestania que queda abierta corre el bundle que cargo ese dia para siempre,
+ * y los `import()` lazy se resuelven contra ESE build. Asi es como la usuaria
+ * termino cancelando pedidos en agosto con el modal de texto libre de julio y
+ * sin ver los entregados-impagos en Entrega y Pago Masivos.
+ *
+ * Esto lo resuelve sin resucitar el service worker: se compara el build id
+ * inyectado en el bundle contra el `/version.json` que emite cada build.
+ *
+ * La recarga NUNCA es automatica. El aviso es un cartel que ella acepta cuando
+ * quiere, porque un reload sorpresa mientras carga un pedido le borra lo
+ * tipeado.
+ */
+import { useCallback, useEffect, useRef, useState } from 'react'
+
+/** Cada cuanto se pregunta, con la pestania visible. */
+const INTERVALO_MS = 15 * 60 * 1000
+/** Cuanto se calla el cartel cuando eligen "Mas tarde". */
+const ESPERA_TRAS_POSPONER_MS = 60 * 60 * 1000
+
+/**
+ * Build que corre esta pestania. Se lee como constante (y no llamando al hook)
+ * para poder mostrarlo en la UI sin arrancar un segundo ciclo de chequeo.
+ */
+export const BUILD_ACTUAL: string =
+  typeof __APP_BUILD_ID__ === 'string' ? __APP_BUILD_ID__ : 'dev'
+
+export interface ActualizacionDisponible {
+  /** Hay un build nuevo publicado y esta pestania corre uno viejo. */
+  disponible: boolean
+  /** Build que corre esta pestania. Sirve para soporte. */
+  buildActual: string
+  /** Recarga para tomar el build nuevo. */
+  actualizar: () => void
+  /** Esconde el cartel por un rato. */
+  posponer: () => void
+}
+
+export function useActualizacionDisponible(): ActualizacionDisponible {
+  const [disponible, setDisponible] = useState(false)
+  const pospuestoHasta = useRef(0)
+  // En dev el bundle lo sirve vite con HMR y no hay version.json que pedir.
+  const activo = !import.meta.env.DEV
+
+  const chequear = useCallback(async () => {
+    if (!activo) return
+    if (typeof document !== 'undefined' && document.visibilityState !== 'visible') return
+    if (Date.now() < pospuestoHasta.current) return
+
+    try {
+      // El query param + no-store evitan depender de los headers del hosting.
+      const res = await fetch(`/version.json?t=${Date.now()}`, { cache: 'no-store' })
+      if (!res.ok) return
+
+      const { buildId } = await res.json() as { buildId?: string }
+      // Sin red, con un deploy a medio subir o si el hosting devuelve el
+      // index.html en vez del json, no molestamos: el silencio es preferible
+      // a un cartel que no se puede sacar.
+      if (typeof buildId === 'string' && buildId && buildId !== __APP_BUILD_ID__) {
+        setDisponible(true)
+      }
+    } catch {
+      /* sin conexion: se reintenta en el proximo ciclo */
+    }
+  }, [activo])
+
+  useEffect(() => {
+    if (!activo) return
+
+    void chequear()
+
+    const alVolver = (): void => {
+      if (document.visibilityState === 'visible') void chequear()
+    }
+    document.addEventListener('visibilitychange', alVolver)
+    window.addEventListener('focus', alVolver)
+
+    const id = setInterval(() => { void chequear() }, INTERVALO_MS)
+
+    return () => {
+      document.removeEventListener('visibilitychange', alVolver)
+      window.removeEventListener('focus', alVolver)
+      clearInterval(id)
+    }
+  }, [activo, chequear])
+
+  const actualizar = useCallback(() => {
+    window.location.reload()
+  }, [])
+
+  const posponer = useCallback(() => {
+    pospuestoHasta.current = Date.now() + ESPERA_TRAS_POSPONER_MS
+    setDisponible(false)
+  }, [])
+
+  return { disponible, buildActual: BUILD_ACTUAL, actualizar, posponer }
+}
+
+export default useActualizacionDisponible

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -17,6 +17,12 @@ interface ImportMeta {
   readonly env: ImportMetaEnv
 }
 
+/**
+ * Identidad del build, inyectada por vite (`define`). Se compara contra
+ * `/version.json` para detectar que hay un deploy nuevo. Ver vite.config.js.
+ */
+declare const __APP_BUILD_ID__: string
+
 // =============================================================================
 // GOOGLE MAPS TYPES
 // =============================================================================

--- a/vite.config.js
+++ b/vite.config.js
@@ -4,11 +4,52 @@ import { VitePWA } from 'vite-plugin-pwa'
 import path from 'path'
 import os from 'os'
 import process from 'node:process'
+import { execSync } from 'node:child_process'
 import { fileURLToPath } from 'url'
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
 const cpuCount = os.availableParallelism?.() ?? os.cpus().length
+
+// Identidad del build. Desde el 20/03 la app no registra service worker (ver
+// pwaAuthHotfix.ts), así que una pestaña abierta se queda con el bundle que
+// cargó ese día para siempre: es lo que dejó a la usuaria cancelando pedidos
+// con el modal de julio en agosto. Con esto la app puede darse cuenta sola de
+// que hay un deploy nuevo, sin resucitar el SW.
+function resolverBuildId() {
+  const desdeCI = process.env.VITE_BUILD_ID
+    || process.env.VERCEL_GIT_COMMIT_SHA
+    || process.env.CF_PAGES_COMMIT_SHA
+    || process.env.GITHUB_SHA
+  if (desdeCI) return desdeCI.slice(0, 12)
+
+  try {
+    return execSync('git rev-parse --short=12 HEAD', {
+      stdio: ['ignore', 'pipe', 'ignore'],
+    }).toString().trim()
+  } catch {
+    // Build fuera de un repo (tarball, contenedor sin .git): la marca de
+    // tiempo alcanza, solo tiene que cambiar cuando cambia el bundle.
+    return `t${Date.now().toString(36)}`
+  }
+}
+
+const BUILD_ID = resolverBuildId()
+
+// Se sirve desde la raíz y lo consulta useActualizacionDisponible.
+function versionJsonPlugin() {
+  return {
+    name: 'emit-version-json',
+    apply: 'build',
+    generateBundle() {
+      this.emitFile({
+        type: 'asset',
+        fileName: 'version.json',
+        source: JSON.stringify({ buildId: BUILD_ID }),
+      })
+    },
+  }
+}
 
 function cspConnectSrcPlugin() {
   let resolvedEnv = {}
@@ -46,8 +87,13 @@ function cspConnectSrcPlugin() {
 }
 
 export default defineConfig({
+  define: {
+    __APP_BUILD_ID__: JSON.stringify(BUILD_ID),
+  },
+
   plugins: [
     cspConnectSrcPlugin(),
+    versionJsonPlugin(),
     react(),
     VitePWA({
       injectRegister: false,


### PR DESCRIPTION
## Qué pasó

Una usuaria reportó dos cosas que parecían bugs nuevos y no lo eran:

1. Un pedido entregado con salvedad e impago (#4612) no le aparecía en **Entrega y Pago Masivos**.
2. Al **Cancelar Pedido** a veces le salía la lista de motivos y a veces solo un campo de texto libre.

Las dos son la misma cosa: **su navegador estaba corriendo un bundle de julio**.

La evidencia es concluyente. El pedido #4549 quedó guardado con `motivo_cancelacion_tipo = NULL` y el texto *"estaba cerrado"* tal como lo tipeó (15:11); el #4548, dos minutos después, con `motivo_cancelacion_tipo = 'cerrado'` y el label del desplegable (15:13). El modal actual **no puede** producir el primero: exige elegir de la lista. Ese campo libre es anterior a `2db7f70` (27/07). Lo del modal masivo es igual: el fix es `fdfffe2` (08/07).

## Por qué se quedó semanas atrás

El 20/03, `f4c69c9` ("recover auth for cached browser profiles") sacó `<PWAPrompt />` de `App` y agregó [pwaAuthHotfix.ts](../blob/main/src/utils/pwaAuthHotfix.ts), que desregistra los service workers y borra las caches en cada arranque. Con `injectRegister: false` en `vite.config.js`, **nadie los vuelve a registrar**.

`PWAPrompt` tenía el chequeo horario de actualización y el cartel "Nueva versión disponible". Quedó escrito y testeado, pero sin montar en ningún lado. Desde entonces la app no tiene forma de enterarse de un deploy: una pestaña abierta corre el bundle que cargó ese día, y los `import()` lazy se resuelven contra ESE build.

Esto explica en retrospectiva los "chunk viejo" recurrentes.

## Qué hace este PR

Resuelve el problema **sin resucitar el service worker**, que se apagó a propósito después de un incidente de auth:

- Cada build emite `/version.json` con su id (sha corto, o el de CI).
- El mismo id se inyecta en el bundle vía `define`.
- [useActualizacionDisponible](../blob/main/src/hooks/useActualizacionDisponible.ts) los compara **al volver al foco** y cada 15 minutos. Al foco es la clave: los timers de fondo los estrangula el navegador.
- Si difieren, aparece un cartel con **Actualizar** / **Más tarde** (1 hora de silencio).

Decisiones deliberadas:

- **La recarga nunca es automática.** Un reload sorpresa mientras carga un pedido le borra lo tipeado.
- **El cartel aparece también con la app instalada.** El viejo `PWAPrompt` hacía `if (isStandalone) return null`, que es justo el caso donde la pestaña vive abierta semanas.
- **Ante la duda, se calla.** Sin red, con un deploy a medio subir, o si el hosting devuelve el `index.html` por el fallback SPA, no muestra nada. Un cartel que aparece de gusto se aprende a ignorar.
- **La versión queda visible** en el menú de usuario. No haber tenido esto es lo que más costó en este diagnóstico.

## Verificación

- `npm run build` → `dist/version.json` = `{"buildId":"0b31d68f3d99"}`, coincide con el sha y está embebido en el bundle.
- Servido con `vite preview`: `/version.json` responde `200 application/json`; una ruta SPA cae al `index.html`, que es el caso que cubre el test.
- 8 tests nuevos para el hook; suite completa **1067/1067**.

## Fuera de alcance

El PWA plugin sigue generando `dist/sw.js` aunque nadie lo registre. Es peso muerto inofensivo; sacarlo (o decidir revivir el modo offline) es una conversación aparte.

🤖 Generated with [Claude Code](https://claude.com/claude-code)