### PR TITLE
El motivo de cancelacion no se pierde mas, y las sobrecargas que PostgREST no podia resolver

### DIFF
--- a/migrations/175_motivo_de_cancelacion_siempre_tipificado.sql
+++ b/migrations/175_motivo_de_cancelacion_siempre_tipificado.sql
@@ -1,0 +1,330 @@
+-- =========================================================================
+-- 175_motivo_de_cancelacion_siempre_tipificado.sql
+--
+-- La mig 143 puso una lista cerrada de motivos de cancelación para poder
+-- medir por qué no se entrega. Desde su backfill (27/07) se filtraron 9
+-- cancelaciones sin tipificar, por tres caminos distintos:
+--
+--   1. `cambiar_cliente_pedido` cancela el pedido viejo llamando a
+--      `cancelar_pedido_con_stock`, que no sabe de tipos. Nunca estampa uno.
+--      Es un agujero permanente: 4 de las 9 (#4478, #4516, #4660, #4690) y
+--      sigue sumando una por cada cambio de cliente.
+--
+--   2. El front guardaba el tipo con un UPDATE aparte, después del RPC. Va
+--      por PostgREST con la sesión del usuario y sobre un pedido que ya
+--      quedó cancelado, así que cualquier RLS o guarda lo rechaza; el catch
+--      solo hacía console.error. El pedido queda cancelado y sin motivo, sin
+--      que nadie se entere.
+--
+--   3. Pestañas con un bundle anterior al 27/07, que todavía mandaban texto
+--      libre (#4549, #4552, #4555, #4572 el 10/08). Eso lo ataca el aviso de
+--      versión nueva, no esta migración.
+--
+-- Acá se cierran 1 y 2, y se backfillean las 9.
+--
+-- Idempotente (CREATE OR REPLACE + DROP/ADD del CHECK).
+-- =========================================================================
+
+-- -------------------------------------------------------------------------
+-- 1. El cambio de cliente es un motivo real y le faltaba lugar en la lista.
+--    No es elegible en el desplegable: lo estampa solo el sistema.
+-- -------------------------------------------------------------------------
+ALTER TABLE public.pedidos
+  DROP CONSTRAINT IF EXISTS pedidos_motivo_cancelacion_tipo_check;
+
+ALTER TABLE public.pedidos
+  ADD CONSTRAINT pedidos_motivo_cancelacion_tipo_check
+  CHECK (motivo_cancelacion_tipo IS NULL OR motivo_cancelacion_tipo IN (
+    'cerrado', 'sin_dinero', 'cliente_rechaza', 'ausente',
+    'direccion_incorrecta', 'clima',
+    'cliente_cancelo', 'error_de_carga', 'duplicado', 'unifica_pedidos',
+    'prueba', 'cambio_de_cliente', 'otro'
+  ));
+
+COMMENT ON COLUMN public.pedidos.motivo_cancelacion_tipo IS
+  'Motivo de cancelación tipificado. `motivo_cancelacion` (text) queda como nota complementaria. Migs 143 y 175.';
+
+-- -------------------------------------------------------------------------
+-- 2. cancelar_pedido_con_stock escribe el tipo en la misma transacción.
+--    Antes el front lo hacía aparte y podía perderse en silencio.
+-- -------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.cancelar_pedido_con_stock(
+  p_pedido_id  bigint,
+  p_motivo     text,
+  p_usuario_id uuid DEFAULT NULL::uuid,
+  p_tipo       text DEFAULT NULL::text
+) RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $fn$
+DECLARE
+  v_sucursal BIGINT := current_sucursal_id();
+  v_pedido RECORD;
+  v_item RECORD;
+  v_total_original DECIMAL;
+  v_user_role TEXT;
+  v_acting_user uuid;
+BEGIN
+  IF v_sucursal IS NULL THEN
+    RETURN jsonb_build_object('success', false, 'error', 'No se pudo determinar la sucursal activa');
+  END IF;
+
+  v_acting_user := auth.uid();
+  IF p_usuario_id IS NOT NULL AND p_usuario_id IS DISTINCT FROM v_acting_user THEN
+    RETURN jsonb_build_object('success', false, 'error', 'ID de usuario no coincide con la sesion autenticada');
+  END IF;
+
+  SELECT rol INTO v_user_role FROM perfiles WHERE id = v_acting_user;
+  IF v_user_role IS NULL OR v_user_role <> 'admin' THEN
+    RETURN jsonb_build_object('success', false, 'error', 'No autorizado: solo admin puede cancelar pedidos');
+  END IF;
+
+  SELECT * INTO v_pedido FROM pedidos WHERE id = p_pedido_id AND sucursal_id = v_sucursal FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RETURN jsonb_build_object('success', false, 'error', 'Pedido no encontrado');
+  END IF;
+
+  IF v_pedido.estado = 'cancelado' THEN
+    RETURN jsonb_build_object('success', false, 'error', 'El pedido ya esta cancelado');
+  END IF;
+
+  IF v_pedido.estado = 'entregado' THEN
+    RETURN jsonb_build_object('success', false, 'error', 'No se puede cancelar un pedido entregado');
+  END IF;
+
+  v_total_original := v_pedido.total;
+
+  FOR v_item IN
+    SELECT pi.producto_id, pi.cantidad, COALESCE(pi.es_bonificacion, false) AS es_bonificacion,
+           pi.promocion_id, COALESCE(pr.regalo_mueve_stock, FALSE) AS regalo_mueve_stock
+    FROM pedido_items pi
+    LEFT JOIN promociones pr ON pr.id = pi.promocion_id AND pr.sucursal_id = pi.sucursal_id
+    WHERE pi.pedido_id = p_pedido_id AND pi.sucursal_id = v_sucursal
+  LOOP
+    IF v_item.es_bonificacion THEN
+      IF v_item.promocion_id IS NOT NULL THEN
+        UPDATE promociones
+        SET usos_pendientes = GREATEST(usos_pendientes - v_item.cantidad, 0)
+        WHERE id = v_item.promocion_id AND sucursal_id = v_sucursal;
+      END IF;
+      IF v_item.regalo_mueve_stock THEN
+        UPDATE productos SET stock = stock + v_item.cantidad
+        WHERE id = v_item.producto_id AND sucursal_id = v_sucursal;
+      END IF;
+    ELSE
+      UPDATE productos SET stock = stock + v_item.cantidad
+      WHERE id = v_item.producto_id AND sucursal_id = v_sucursal;
+    END IF;
+  END LOOP;
+
+  UPDATE pedidos
+  SET estado = 'cancelado',
+      motivo_cancelacion = p_motivo,
+      -- NULL deja el tipo como estaba: quien no manda tipo no lo pisa.
+      motivo_cancelacion_tipo = COALESCE(p_tipo, motivo_cancelacion_tipo),
+      total = 0,
+      monto_pagado = 0,
+      total_neto = 0,
+      total_iva = 0,
+      updated_at = NOW()
+  WHERE id = p_pedido_id AND sucursal_id = v_sucursal;
+
+  INSERT INTO pedido_historial (pedido_id, usuario_id, campo_modificado, valor_anterior, valor_nuevo, sucursal_id)
+  VALUES (
+    p_pedido_id,
+    v_acting_user,
+    'estado',
+    v_pedido.estado,
+    'cancelado - Motivo: ' || COALESCE(p_motivo, 'Sin motivo') || ' | Total original: $' || v_total_original,
+    v_sucursal
+  );
+
+  RETURN jsonb_build_object(
+    'success', true,
+    'mensaje', 'Pedido cancelado, stock restaurado, saldo ajustado',
+    'total_original', v_total_original
+  );
+END;
+$fn$;
+
+ALTER FUNCTION public.cancelar_pedido_con_stock(bigint, text, uuid, text) OWNER TO postgres;
+REVOKE ALL ON FUNCTION public.cancelar_pedido_con_stock(bigint, text, uuid, text) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.cancelar_pedido_con_stock(bigint, text, uuid, text) TO authenticated;
+
+COMMENT ON FUNCTION public.cancelar_pedido_con_stock(bigint, text, uuid, text) IS
+  'Cancela un pedido, restaura stock y estampa el motivo tipificado en la misma transaccion. Mig 175.';
+
+-- -------------------------------------------------------------------------
+-- 3. Se elimina la firma vieja de 3 args.
+--
+--    NO puede quedar como wrapper: con f(a,b,c) y f(a,b,c,d DEFAULT) vivas a
+--    la vez, una llamada de 3 argumentos es ambigua y Postgres tira
+--    "function cancelar_pedido_con_stock is not unique". Justo lo que hace
+--    `cambiar_cliente_pedido` y lo que mandan los bundles viejos.
+--
+--    Sacarla no rompe a nadie: PostgREST resuelve por nombre de parámetro, y
+--    un cliente que mande {p_pedido_id, p_motivo, p_usuario_id} matchea la de
+--    4 args tomando p_tipo del default.
+-- -------------------------------------------------------------------------
+DROP FUNCTION IF EXISTS public.cancelar_pedido_con_stock(bigint, text, uuid);
+
+-- -------------------------------------------------------------------------
+-- 4. El cambio de cliente deja de ser un hueco en el reporte.
+--    Unico cambio respecto de la mig 094: pasa el tipo al cancelar.
+-- -------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.cambiar_cliente_pedido(
+  p_pedido_id        bigint,
+  p_nuevo_cliente_id bigint,
+  p_usuario_id       uuid,
+  p_items            jsonb,
+  p_total            numeric,
+  p_total_neto       numeric DEFAULT NULL::numeric,
+  p_total_iva        numeric DEFAULT 0,
+  p_motivo           text    DEFAULT 'Cambio de cliente'::text
+) RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $fn$
+DECLARE
+  v_sucursal     BIGINT := current_sucursal_id();
+  v_acting       UUID := auth.uid();
+  v_role         TEXT;
+  v_pedido       RECORD;
+  v_prev_role    TEXT;
+  v_preventista  UUID := NULL;
+  v_preventista_fallback BOOLEAN := false;
+  v_cancel       JSONB;
+  v_crear        JSONB;
+  v_nuevo_id     BIGINT;
+BEGIN
+  IF v_sucursal IS NULL THEN
+    RETURN jsonb_build_object('success', false, 'error', 'No hay sucursal activa');
+  END IF;
+
+  IF p_usuario_id IS DISTINCT FROM v_acting THEN
+    RETURN jsonb_build_object('success', false, 'error', 'ID de usuario no coincide con la sesion autenticada');
+  END IF;
+
+  SELECT rol INTO v_role FROM perfiles WHERE id = v_acting;
+  IF v_role IS NULL OR v_role <> 'admin' THEN
+    RETURN jsonb_build_object('success', false, 'error', 'No autorizado: solo admin puede cambiar el cliente de un pedido');
+  END IF;
+
+  IF p_items IS NULL OR jsonb_typeof(p_items) <> 'array' OR jsonb_array_length(p_items) = 0 THEN
+    RETURN jsonb_build_object('success', false, 'error', 'El pedido nuevo no tiene items');
+  END IF;
+
+  SELECT * INTO v_pedido FROM pedidos WHERE id = p_pedido_id AND sucursal_id = v_sucursal FOR UPDATE;
+  IF NOT FOUND THEN
+    RETURN jsonb_build_object('success', false, 'error', 'Pedido no encontrado');
+  END IF;
+
+  IF v_pedido.estado IN ('entregado', 'cancelado') THEN
+    RETURN jsonb_build_object('success', false, 'error', 'No se puede cambiar el cliente de un pedido ' || v_pedido.estado);
+  END IF;
+
+  IF p_nuevo_cliente_id = v_pedido.cliente_id THEN
+    RETURN jsonb_build_object('success', false, 'error', 'El cliente nuevo es el mismo que el actual');
+  END IF;
+
+  PERFORM 1 FROM clientes WHERE id = p_nuevo_cliente_id AND sucursal_id = v_sucursal;
+  IF NOT FOUND THEN
+    RETURN jsonb_build_object('success', false, 'error', 'El cliente nuevo no existe en esta sucursal');
+  END IF;
+
+  IF v_pedido.usuario_id IS DISTINCT FROM p_usuario_id THEN
+    SELECT p.rol INTO v_prev_role
+    FROM perfiles p
+    WHERE p.id = v_pedido.usuario_id
+      AND p.activo = true
+      AND EXISTS (SELECT 1 FROM usuario_sucursales us WHERE us.usuario_id = p.id AND us.sucursal_id = v_sucursal);
+    IF v_prev_role IN ('admin', 'preventista') THEN
+      v_preventista := v_pedido.usuario_id;
+    ELSE
+      v_preventista_fallback := true;
+    END IF;
+  END IF;
+
+  v_cancel := cancelar_pedido_con_stock(p_pedido_id, p_motivo, p_usuario_id, 'cambio_de_cliente');
+  IF NOT COALESCE((v_cancel->>'success')::boolean, false) THEN
+    RETURN v_cancel;
+  END IF;
+
+  PERFORM quitar_pedido_de_recorridos_activos(p_pedido_id);
+
+  v_crear := crear_pedido_completo(
+    p_nuevo_cliente_id,
+    p_total,
+    p_usuario_id,
+    p_items,
+    v_pedido.notas,
+    v_pedido.forma_pago,
+    'pendiente',
+    v_pedido.fecha,
+    v_pedido.tipo_factura,
+    p_total_neto,
+    COALESCE(p_total_iva, 0),
+    v_pedido.fecha_entrega_programada,
+    v_preventista
+  );
+  IF NOT COALESCE((v_crear->>'success')::boolean, false) THEN
+    RAISE EXCEPTION 'No se pudo crear el pedido nuevo: %',
+      COALESCE(v_crear->>'errores', v_crear->>'error', 'error desconocido');
+  END IF;
+  v_nuevo_id := (v_crear->>'pedido_id')::bigint;
+
+  UPDATE pagos
+     SET pedido_id = v_nuevo_id,
+         cliente_id = p_nuevo_cliente_id
+   WHERE pedido_id = p_pedido_id
+     AND sucursal_id = v_sucursal;
+
+  UPDATE pedidos
+     SET motivo_cancelacion = COALESCE(motivo_cancelacion, p_motivo) || ' -> pedido #' || v_nuevo_id
+   WHERE id = p_pedido_id AND sucursal_id = v_sucursal;
+
+  INSERT INTO pedido_historial (pedido_id, usuario_id, campo_modificado, valor_anterior, valor_nuevo, sucursal_id)
+  VALUES (
+    v_nuevo_id,
+    v_acting,
+    'cliente_id',
+    v_pedido.cliente_id::text,
+    p_nuevo_cliente_id::text || ' (cambio de cliente desde pedido #' || p_pedido_id || ')',
+    v_sucursal
+  );
+
+  RETURN jsonb_build_object(
+    'success', true,
+    'nuevo_pedido_id', v_nuevo_id,
+    'pedido_cancelado_id', p_pedido_id,
+    'preventista_fallback', v_preventista_fallback
+  );
+END;
+$fn$;
+
+ALTER FUNCTION public.cambiar_cliente_pedido(bigint, bigint, uuid, jsonb, numeric, numeric, numeric, text) OWNER TO postgres;
+
+-- -------------------------------------------------------------------------
+-- 5. Backfill de lo que se filtró. Mismos criterios que la mig 143, aplicados
+--    solo a las que quedaron en NULL, así no se pisa nada ya clasificado.
+-- -------------------------------------------------------------------------
+UPDATE pedidos SET motivo_cancelacion_tipo = CASE
+  WHEN motivo_cancelacion ~* 'cambio de cliente'                        THEN 'cambio_de_cliente'
+  WHEN motivo_cancelacion ~* 'cerrad'                                   THEN 'cerrado'
+  WHEN motivo_cancelacion ~* 'sin plata|no ten(i|í)a plata|sin dinero'  THEN 'sin_dinero'
+  WHEN motivo_cancelacion ~* 'prueba'                                   THEN 'prueba'
+  WHEN motivo_cancelacion ~* 'rechaz'                                   THEN 'cliente_rechaza'
+  WHEN motivo_cancelacion ~* 'unifica'                                  THEN 'unifica_pedidos'
+  WHEN motivo_cancelacion ~* 'duplicad'                                 THEN 'duplicado'
+  WHEN motivo_cancelacion ~* 'clima|lluvia'                             THEN 'clima'
+  WHEN motivo_cancelacion ~* 'no hab(i|í)a nadie|ausente'               THEN 'ausente'
+  WHEN motivo_cancelacion ~* 'direcci(o|ó)n'                            THEN 'direccion_incorrecta'
+  WHEN motivo_cancelacion ~* 'error de carga|mal cargad'                THEN 'error_de_carga'
+  ELSE motivo_cancelacion_tipo
+END
+WHERE estado = 'cancelado'
+  AND motivo_cancelacion_tipo IS NULL
+  AND motivo_cancelacion IS NOT NULL;

--- a/migrations/176_sobrecargas_ambiguas.sql
+++ b/migrations/176_sobrecargas_ambiguas.sql
@@ -1,0 +1,72 @@
+-- =========================================================================
+-- 176_sobrecargas_ambiguas.sql
+--
+-- Al revisar la 175 salió que dos sobrecargas cuyas aridades se superponen
+-- por defaults dejan la llamada ambigua. PostgREST no puede elegir y contesta
+-- HTTP 300 `PGRST203`. Un barrido sobre todo el esquema encontró que quedaban
+-- dos casos vivos, los dos verificados con curl contra prod:
+--
+--   1. `registrar_salvedad`: 7 args (wrapper de la mig 174) y 8 args
+--      (idempotente, mig 167). Las dos tienen 4 obligatorios, así que
+--      cualquier llamada de 4 a 7 argumentos es ambigua.
+--      `useSalvedades.registrarSalvedad` manda exactamente 7 → PGRST203.
+--      Hoy no lo rompe a nadie porque ningún componente usa ese hook (el
+--      chofer va por handleRegistrarSalvedadSingle, que manda 8), pero es
+--      una mina para el primero que lo use.
+--
+--   2. `actualizar_orden_entrega_batch(jsonb)` y `(orden_entrega_item[])`.
+--      Este SÍ estaba fallando: las dos formas en que lo llama el front dan
+--      PGRST203. No se notaba porque `usePedidos.actualizarOrdenEntrega`
+--      cae a un fallback que actualiza pedido por pedido, y
+--      `pedidoService` hace lo mismo en su catch. O sea: el orden de entrega
+--      se guardaba igual, pero con N updates sueltos en vez de uno solo y
+--      sin la atomicidad del RPC.
+--
+-- En los dos casos sobra una de las dos. Se dropea la sobrante en vez de
+-- renombrarla: PostgREST resuelve por nombre de parámetro, así que los
+-- clientes que mandan menos parámetros caen en la que queda y toman el resto
+-- de los defaults. Verificado con curl + anon key antes y después.
+-- =========================================================================
+
+-- -------------------------------------------------------------------------
+-- 1. registrar_salvedad: queda solo la de 8 args.
+--    Un cliente que mande los 7 de siempre matchea igual y `p_client_request_id`
+--    sale del default, que es exactamente lo que hacía el wrapper.
+-- -------------------------------------------------------------------------
+DROP FUNCTION IF EXISTS public.registrar_salvedad(
+  bigint, bigint, integer, character varying, text, text, boolean
+);
+
+-- -------------------------------------------------------------------------
+-- 2. actualizar_orden_entrega_batch: queda la de jsonb.
+--    Los dos cuerpos son idénticos salvo cómo desarman el parámetro, y las
+--    dos formas en que llama el front (array de objetos y string JSON) son
+--    JSON, no `orden_entrega_item[]`.
+--
+--    El tipo `orden_entrega_item` queda: no molesta y dropearlo es riesgo
+--    innecesario para esta migración.
+-- -------------------------------------------------------------------------
+DROP FUNCTION IF EXISTS public.actualizar_orden_entrega_batch(public.orden_entrega_item[]);
+
+COMMENT ON FUNCTION public.actualizar_orden_entrega_batch(jsonb) IS
+  'Guarda el orden de entrega optimizado en un solo viaje. Unica sobrecarga desde la mig 176: convivia con una de orden_entrega_item[] y PostgREST no podia elegir (PGRST203).';
+
+-- -------------------------------------------------------------------------
+-- Para auditar esto en el futuro. Si devuelve filas, esas llamadas dan
+-- PGRST203 y no lo va a ver ni tsc ni los tests: el nombre del RPC es un
+-- string y el error aparece recien en runtime contra la base.
+--
+--   with f as (
+--     select p.oid, p.proname, p.pronargs as total,
+--            p.pronargs - p.pronargdefaults as oblig
+--     from pg_proc p join pg_namespace n on n.oid = p.pronamespace
+--     where n.nspname = 'public' and p.prokind = 'f'
+--       and p.prolang <> (select oid from pg_language where lanname = 'c')
+--   )
+--   select a.proname,
+--          a.oid::regprocedure::text as firma_a,
+--          b.oid::regprocedure::text as firma_b,
+--          greatest(a.oblig, b.oblig) || '..' || least(a.total, b.total) as n_args_ambiguos
+--   from f a join f b on a.proname = b.proname and a.oid < b.oid
+--   where greatest(a.oblig, b.oblig) <= least(a.total, b.total);
+-- -------------------------------------------------------------------------

--- a/migrations/MANIFEST.md
+++ b/migrations/MANIFEST.md
@@ -128,9 +128,17 @@ funcional** y no se renombran los archivos: renombrarlos los desalinearía del l
 real lo da `version` y está en la sección A: en los dos casos el archivo de `main` quedó
 cronológicamente **fuera** del bloque 139–147 (uno antes, otro entre la 144 y la 145).
 
-**La próxima migración es la 176** — la última numerada en el repo es
-`175_motivo_de_cancelacion_siempre_tipificado` (aplicada). La **174**
-(`174_salvedad_regalos_y_minimo_de_venta`) y la **175** mapean 1:1 con el ledger.
+**La próxima migración es la 177** — la última numerada en el repo es
+`176_sobrecargas_ambiguas` (aplicada). Las **174**
+(`174_salvedad_regalos_y_minimo_de_venta`), **175** y **176** mapean 1:1 con el ledger.
+
+La **176** deja una regla que conviene no volver a romper: **dos sobrecargas cuyas aridades
+se superponen por defaults hacen que PostgREST no pueda elegir** y devuelva HTTP 300
+`PGRST203`, sin que lo vea ni `tsc` ni los tests. Antes de dejar una firma vieja como
+wrapper, contar los obligatorios de cada una; si los rangos `[obligatorios, total]` se
+tocan, hay que dropear la vieja en vez de conservarla. Consulta para auditarlo en
+`migrations/176_sobrecargas_ambiguas.sql`.
+
 Las **148–166** (origen del precio, reglas de
 comisión, `place_id`, horarios masivos, barridas, roles extra por sucursal, horario obligatorio
 al cargar pedido, marcas y objetivos por preventista, saldo a favor que no queda atrapado)

--- a/migrations/MANIFEST.md
+++ b/migrations/MANIFEST.md
@@ -128,8 +128,10 @@ funcional** y no se renombran los archivos: renombrarlos los desalinearía del l
 real lo da `version` y está en la sección A: en los dos casos el archivo de `main` quedó
 cronológicamente **fuera** del bloque 139–147 (uno antes, otro entre la 144 y la 145).
 
-**La próxima migración es la 174** — la última numerada en el repo es
-`173_entrega_del_chofer_actualiza_la_parada`. Las **148–166** (origen del precio, reglas de
+**La próxima migración es la 176** — la última numerada en el repo es
+`175_motivo_de_cancelacion_siempre_tipificado` (aplicada). La **174**
+(`174_salvedad_regalos_y_minimo_de_venta`) y la **175** mapean 1:1 con el ledger.
+Las **148–166** (origen del precio, reglas de
 comisión, `place_id`, horarios masivos, barridas, roles extra por sucursal, horario obligatorio
 al cargar pedido, marcas y objetivos por preventista, saldo a favor que no queda atrapado)
 mapean **1:1** con el ledger, así que no agregan ninguna excepción a las tablas de arriba.

--- a/src/constants/motivosNoEntrega.ts
+++ b/src/constants/motivosNoEntrega.ts
@@ -31,10 +31,21 @@ export const MOTIVOS_CANCELACION_ADMIN = [
   { valor: 'prueba', label: 'Pedido de prueba' },
 ] as const;
 
+/**
+ * Motivos que estampa el sistema y nadie elige a mano. No van en el
+ * desplegable, pero necesitan etiqueta para los listados y el reporte: sin
+ * esto, cada cambio de cliente quedaba como cancelación sin clasificar y le
+ * hacía un agujero a la medición (mig 175).
+ */
+export const MOTIVOS_CANCELACION_SISTEMA = [
+  { valor: 'cambio_de_cliente', label: 'Cambio de cliente' },
+] as const;
+
 /** Etiqueta legible de cualquier motivo, para mostrar en listados y reportes. */
 export const LABEL_MOTIVO: Record<string, string> = {
   ...Object.fromEntries(MOTIVOS_NO_ENTREGA.map(m => [m.valor, m.label])),
   ...Object.fromEntries(MOTIVOS_CANCELACION_ADMIN.map(m => [m.valor, m.label])),
+  ...Object.fromEntries(MOTIVOS_CANCELACION_SISTEMA.map(m => [m.valor, m.label])),
 };
 
 /** Texto para el preventista, en tercera persona. */

--- a/src/hooks/queries/usePedidosQuery.ts
+++ b/src/hooks/queries/usePedidosQuery.ts
@@ -954,10 +954,16 @@ async function cancelarPedido(
   usuarioId?: string,
   tipo?: string,
 ): Promise<void> {
+  // El motivo tipificado (mig 143) viaja dentro del RPC desde la mig 175.
+  // Antes se guardaba con un UPDATE aparte, despues de cancelar: iba por
+  // PostgREST sobre un pedido que ya estaba cancelado y su unico manejo de
+  // error era un console.error, asi que cuando fallaba el pedido quedaba sin
+  // motivo y nadie se enteraba.
   const { data, error } = await supabase.rpc('cancelar_pedido_con_stock', {
     p_pedido_id: pedidoId,
     p_motivo: motivo,
     p_usuario_id: usuarioId || null,
+    p_tipo: tipo || null,
   })
 
   if (error) throw error
@@ -965,17 +971,6 @@ async function cancelarPedido(
   const result = data as { success: boolean; error?: string }
   if (!result.success) {
     throw new Error(result.error || 'Error al cancelar pedido')
-  }
-
-  // El motivo tipificado (mig 143) se guarda aparte para no reescribir
-  // `cancelar_pedido_con_stock`, que además restaura stock. Si este update
-  // fallara, el pedido igual queda cancelado con su motivo en texto.
-  if (tipo) {
-    const { error: errTipo } = await supabase
-      .from('pedidos')
-      .update({ motivo_cancelacion_tipo: tipo })
-      .eq('id', pedidoId)
-    if (errTipo) console.error('[pedidos] no se pudo guardar el motivo tipificado:', errTipo)
   }
 }
 


### PR DESCRIPTION
Dos migraciones. La 175 era el objetivo; la 176 salió de verificar la 175 antes de mergear y encontró un bug **activo** en producción.

---

## Migración 175 — el motivo de cancelación no se pierde más

**9 cancelaciones sin motivo tipificado desde el backfill de la mig 143** (27/07). Esa migración existe para poder medir por qué no se entrega y mostrárselo al preventista; cada hueco le hace un agujero a la medición. Venían de tres caminos, **dos abiertos**:

1. **`cambiar_cliente_pedido` nunca estampaba un tipo.** Cancela el pedido viejo vía `cancelar_pedido_con_stock`, que no sabía de tipos. Agujero permanente: 4 de los 9 (#4478, #4516, #4660, #4690) y suma uno por cada cambio de cliente. El #4690 apareció durante la propia investigación.
2. **El front lo guardaba con un `UPDATE` aparte, después del RPC.** Por PostgREST, sobre un pedido ya cancelado, con `console.error` como único manejo de error. Cuando fallaba, el pedido quedaba cancelado y sin motivo, en silencio.
3. Pestañas con bundle anterior al 27/07 mandando texto libre. Eso lo ataca #457.

**Qué hace:** el tipo viaja dentro del RPC y se escribe en la misma transacción; `cambiar_cliente_pedido` estampa `cambio_de_cliente` (valor nuevo del CHECK, no elegible a mano); backfill de los 9.

**Verificado:** 0 sin clasificar sobre 269 cancelados.

---

## Migración 176 — sobrecargas que PostgREST no puede resolver

Al escribir la 175 apareció que **dos sobrecargas cuyas aridades se superponen por defaults dejan la llamada ambigua**: PostgREST contesta HTTP 300 `PGRST203`. Un barrido sobre todo el esquema encontró los dos casos que quedaban:

**1. `registrar_salvedad`** — el wrapper de 7 args (mig 174) y la de 8 (mig 167) tienen 4 obligatorios cada una, así que toda llamada de 4 a 7 argumentos es ambigua. `useSalvedades.registrarSalvedad` manda exactamente 7. **Latente**: ningún componente usa ese hook hoy (el chofer va por `handleRegistrarSalvedadSingle`, que manda 8), pero estaba armado para el primero que lo usara.

**2. `actualizar_orden_entrega_batch`** — `(jsonb)` y `(orden_entrega_item[])`. **Este estaba fallando de verdad**: las dos formas en que lo llama el front dan `PGRST203`. No se notaba porque `usePedidos.actualizarOrdenEntrega` cae a un fallback que actualiza pedido por pedido, y `pedidoService` hace lo mismo en su `catch`. El orden se guardaba igual, pero con N updates sueltos en vez de uno y sin la atomicidad del RPC.

Se dropea la sobrante de cada par en vez de renombrarla: PostgREST resuelve por nombre de parámetro, así que quien manda menos parámetros cae en la que queda y toma los defaults.

---

## Verificación en prod (curl + anon key, después de aplicar)

| llamada | antes | ahora |
|---|---|---|
| `registrar_salvedad` 7 params | **300 PGRST203** | 200 |
| `registrar_salvedad` 8 params | 200 | 200 |
| `actualizar_orden_entrega_batch` array | **300 PGRST203** | 401 |
| `actualizar_orden_entrega_batch` string JSON | **300 PGRST203** | 401 |
| `cancelar_pedido_con_stock` 3 params | 200 | 200 |
| `cancelar_pedido_con_stock` 4 params | n/a | 200 |
| `simular_salvedades_promo_impacto` | 200 | 200 |

El 401 de orden de entrega **es lo correcto**: la de `jsonb` tiene EXECUTE para `authenticated` y no para `anon` (confirmado con `has_function_privilege`). Antes el `PGRST203` cortaba antes de llegar a chequear permisos, así que lo enmascaraba.

Suite completa **1082/1082**. `npm run check:migrations` no corre acá: el worktree no tiene las credenciales de servicio.

## Por qué esto no lo agarra el CI

El nombre del RPC es un string: no lo ve `tsc`, no lo ven los tests. El error aparece recién en runtime contra la base. Queda en el MANIFEST y en la propia migración la consulta para auditarlo.

## Observación, fuera de alcance

`registrar_salvedad` y `cancelar_pedido_con_stock` tienen `GRANT EXECUTE` a **anon**. No hay exposición real —las dos cortan en `auth.uid()` / `current_sucursal_id()`, verificado— pero es superficie innecesaria. `REVOKE ALL FROM PUBLIC` no lo saca, porque `anon` es un rol propio. Lo dejo señalado en vez de cambiarlo acá.

🤖 Generated with [Claude Code](https://claude.com/claude-code)