### PR TITLE
Una factura de compra puede mezclar gravados y no gravados

### DIFF
--- a/migrations/177_condicion_iva_por_linea.sql
+++ b/migrations/177_condicion_iva_por_linea.sql
@@ -1,0 +1,302 @@
+-- ============================================================================
+-- 177 · Condición de IVA por producto y por línea de compra
+-- ============================================================================
+-- El gerente necesita cargar UNA factura de proveedor que mezcle productos
+-- gravados y no gravados, con distintas alícuotas. La mitad ya estaba: desde la
+-- mig 113 `compra_items.porcentaje_iva` es un snapshot por línea y los RPCs lo
+-- leen del jsonb. Faltaba poder distinguir "no gravado" de "0% gravado" — hoy
+-- son indistinguibles — y que la condición viva en la ficha del producto para
+-- no re-elegirla en cada factura (la venta ya hereda `productos.porcentaje_iva`,
+-- así que un producto exento sale con IVA 0 sin tocar código de venta).
+--
+-- Decisiones:
+--   · `compras.subtotal` NO cambia de semántica: sigue siendo el neto de TODAS
+--     las líneas (bruto − bonif). Es lo que valida el check COMPRA-A2 de
+--     auditoria_integridad y lo que consume el control blando de cuadre. El
+--     neto gravado real queda derivable exacto desde compra_items (ver el
+--     COMMENT de la columna).
+--   · `compras.no_gravado` (cabecera) no se toca: es para conceptos SIN línea
+--     de producto (pallets, envases). No se mezcla con las líneas no gravadas.
+--   · DEFAULT 'gravado' backfillea correcto: las 506 líneas históricas de prod
+--     (115 FC a 21%, 29 ZZ a 0%, 362 pre-113 en NULL) son todas gravadas.
+--   · Ninguna firma de RPC cambia. `condicion_iva` viaja DENTRO del jsonb
+--     `p_items`, así que una pestaña vieja del PWA sigue funcionando igual y no
+--     se crean sobrecargas ambiguas (ver mig 176 / PGRST203).
+--
+-- Los cuerpos de las 6 funciones se parchean leyendo el catálogo en vez de
+-- hardcodearlos: el cambio es aditivo y así no se revierte en silencio nada que
+-- haya entrado fuera de banda. Cada reemplazo exige que su ancla aparezca
+-- exactamente una vez; si el cuerpo derivó, la migración falla en vez de
+-- aplicar un parche parcial. Cada bloque es idempotente: si la función ya
+-- menciona condicion_iva, se saltea.
+-- ============================================================================
+
+-- ----------------------------------------------------------------------------
+-- 1. Columnas
+-- ----------------------------------------------------------------------------
+
+ALTER TABLE public.productos
+  ADD COLUMN IF NOT EXISTS condicion_iva text NOT NULL DEFAULT 'gravado';
+
+ALTER TABLE public.compra_items
+  ADD COLUMN IF NOT EXISTS condicion_iva text NOT NULL DEFAULT 'gravado';
+
+-- Snapshot para el clonado entre sucursales; espeja origen_porcentaje_iva.
+-- Nullable a propósito: los movimientos anteriores a esta migración no lo tienen.
+ALTER TABLE public.movimiento_sucursal_items
+  ADD COLUMN IF NOT EXISTS origen_condicion_iva text;
+
+COMMENT ON COLUMN public.productos.condicion_iva IS
+  'Condición frente al IVA: gravado (con alícuota en porcentaje_iva) | exento | no_gravado. La venta la hereda vía porcentaje_iva.';
+COMMENT ON COLUMN public.compra_items.condicion_iva IS
+  'Condición de la línea (snapshot al registrar). Distingue no gravado de 0% gravado. Neto gravado de una compra = SUM(subtotal) FILTER (WHERE condicion_iva = ''gravado''); IVA por alícuota = SUM(subtotal * porcentaje_iva / 100) GROUP BY porcentaje_iva.';
+COMMENT ON COLUMN public.movimiento_sucursal_items.origen_condicion_iva IS
+  'Condición de IVA del producto en la sucursal origen (snapshot). NULL = movimiento previo a la mig 177.';
+
+-- OJO (deuda conocida, diferida): posicion_fiscal (mig 121) informa
+-- fc_neto = SUM(compras.subtotal), que con facturas mixtas pasa a ser "neto de
+-- líneas" y no "neto gravado" estricto. Cuando se haga el libro IVA hay que
+-- agregarle un CTE sobre compra_items con las fórmulas del COMMENT de arriba;
+-- no requiere backfill porque la clasificación queda desde esta migración.
+COMMENT ON COLUMN public.compras.subtotal IS
+  'Neto de TODAS las líneas (bruto − bonif), gravadas y no gravadas. Lo valida COMPRA-A2 contra SUM(compra_items.subtotal). El neto gravado se deriva de compra_items.condicion_iva (mig 177).';
+
+-- Coherencia UNIDIRECCIONAL a propósito: no se exige que gravado ⇒ tasa > 0,
+-- porque las 29 líneas ZZ de prod son ('gravado', 0) y son legítimas (una
+-- compra sin factura no discrimina IVA). La otra dirección sí importa: sin ella
+-- un producto ('exento', 21) cobraría IVA en la venta en silencio.
+DO $mig$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'compra_items_condicion_iva_check') THEN
+    ALTER TABLE public.compra_items
+      ADD CONSTRAINT compra_items_condicion_iva_check
+        CHECK (condicion_iva IN ('gravado', 'exento', 'no_gravado')),
+      ADD CONSTRAINT compra_items_condicion_iva_coherente
+        CHECK (condicion_iva = 'gravado' OR COALESCE(porcentaje_iva, 0) = 0);
+  END IF;
+
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'productos_condicion_iva_check') THEN
+    ALTER TABLE public.productos
+      ADD CONSTRAINT productos_condicion_iva_check
+        CHECK (condicion_iva IN ('gravado', 'exento', 'no_gravado')),
+      ADD CONSTRAINT productos_condicion_iva_coherente
+        CHECK (condicion_iva = 'gravado' OR COALESCE(porcentaje_iva, 0) = 0);
+  END IF;
+END;
+$mig$;
+
+-- ----------------------------------------------------------------------------
+-- 2. Helper de parcheo: reemplaza exigiendo que el ancla sea única
+-- ----------------------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION public._mig177_reemplazo_unico(
+  p_texto text, p_ancla text, p_nuevo text, p_donde text
+) RETURNS text LANGUAGE plpgsql IMMUTABLE AS $helper$
+DECLARE
+  v_veces integer;
+BEGIN
+  v_veces := (length(p_texto) - length(replace(p_texto, p_ancla, ''))) / length(p_ancla);
+  IF v_veces <> 1 THEN
+    RAISE EXCEPTION 'mig 177 · % : el ancla "%" aparece % veces (se esperaba 1). El cuerpo derivó del texto conocido; revisá el parche antes de aplicar.',
+      p_donde, left(p_ancla, 70), v_veces;
+  END IF;
+  RETURN replace(p_texto, p_ancla, p_nuevo);
+END;
+$helper$;
+
+-- ----------------------------------------------------------------------------
+-- 3. registrar_compra_completa — lee y persiste condicion_iva
+-- ----------------------------------------------------------------------------
+
+DO $mig$
+DECLARE
+  v_def text;
+BEGIN
+  v_def := pg_get_functiondef(
+    'public.registrar_compra_completa(bigint, character varying, character varying, date, numeric, numeric, numeric, numeric, character varying, text, uuid, jsonb, character varying, numeric, numeric, numeric, numeric)'::regprocedure);
+  IF v_def LIKE '%condicion_iva%' THEN RETURN; END IF;
+
+  v_def := public._mig177_reemplazo_unico(v_def,
+    $a$  v_porcentaje_iva      NUMERIC;$a$,
+    $a$  v_porcentaje_iva      NUMERIC;
+  v_condicion_iva       TEXT;$a$,
+    'registrar_compra_completa/declare');
+
+  v_def := public._mig177_reemplazo_unico(v_def,
+    $a$    v_porcentaje_iva     := CASE WHEN v_es_zz THEN 0 ELSE COALESCE((v_item->>'porcentaje_iva')::NUMERIC, 21) END;$a$,
+    $a$    -- mig 177: la condición manda sobre la alícuota. Normaliza, nunca rechaza:
+    -- un cliente viejo que no manda el campo se comporta exactamente como antes.
+    v_condicion_iva      := CASE
+      WHEN v_es_zz THEN 'gravado'
+      WHEN COALESCE(v_item->>'condicion_iva', 'gravado') IN ('exento', 'no_gravado')
+        THEN v_item->>'condicion_iva'
+      ELSE 'gravado'
+    END;
+    v_porcentaje_iva     := CASE
+      WHEN v_es_zz OR v_condicion_iva <> 'gravado' THEN 0
+      ELSE COALESCE((v_item->>'porcentaje_iva')::NUMERIC, 21)
+    END;$a$,
+    'registrar_compra_completa/asignacion');
+
+  v_def := public._mig177_reemplazo_unico(v_def,
+    $a$      porcentaje_iva, impuestos_internos, costo_neto_unitario, costo_real_unitario$a$,
+    $a$      porcentaje_iva, impuestos_internos, costo_neto_unitario, costo_real_unitario,
+      condicion_iva$a$,
+    'registrar_compra_completa/insert-columnas');
+
+  v_def := public._mig177_reemplazo_unico(v_def,
+    $a$      round(v_costo_neto, 4),
+      v_costo_real
+    );$a$,
+    $a$      round(v_costo_neto, 4),
+      v_costo_real,
+      v_condicion_iva
+    );$a$,
+    'registrar_compra_completa/insert-valores');
+
+  EXECUTE v_def;
+END;
+$mig$;
+
+-- ----------------------------------------------------------------------------
+-- 4. actualizar_compra_items — mismo criterio en la edición
+-- ----------------------------------------------------------------------------
+
+DO $mig$
+DECLARE
+  v_def text;
+BEGIN
+  v_def := pg_get_functiondef(
+    'public.actualizar_compra_items(bigint, jsonb, numeric, numeric, numeric, uuid, numeric, numeric, numeric, numeric, numeric)'::regprocedure);
+  IF v_def LIKE '%condicion_iva%' THEN RETURN; END IF;
+
+  v_def := public._mig177_reemplazo_unico(v_def,
+    $a$  v_porcentaje_iva NUMERIC;$a$,
+    $a$  v_porcentaje_iva NUMERIC;
+  v_condicion_iva TEXT;$a$,
+    'actualizar_compra_items/declare');
+
+  v_def := public._mig177_reemplazo_unico(v_def,
+    $a$    v_porcentaje_iva     := CASE WHEN v_es_zz THEN 0 ELSE COALESCE((v_item->>'porcentaje_iva')::NUMERIC, 21) END;$a$,
+    $a$    -- mig 177: la condición manda sobre la alícuota (ver registrar_compra_completa).
+    v_condicion_iva      := CASE
+      WHEN v_es_zz THEN 'gravado'
+      WHEN COALESCE(v_item->>'condicion_iva', 'gravado') IN ('exento', 'no_gravado')
+        THEN v_item->>'condicion_iva'
+      ELSE 'gravado'
+    END;
+    v_porcentaje_iva     := CASE
+      WHEN v_es_zz OR v_condicion_iva <> 'gravado' THEN 0
+      ELSE COALESCE((v_item->>'porcentaje_iva')::NUMERIC, 21)
+    END;$a$,
+    'actualizar_compra_items/asignacion');
+
+  v_def := public._mig177_reemplazo_unico(v_def,
+    $a$      porcentaje_iva, impuestos_internos, costo_neto_unitario, costo_real_unitario$a$,
+    $a$      porcentaje_iva, impuestos_internos, costo_neto_unitario, costo_real_unitario,
+      condicion_iva$a$,
+    'actualizar_compra_items/insert-columnas');
+
+  v_def := public._mig177_reemplazo_unico(v_def,
+    $a$      v_porcentaje_iva, v_impuestos_internos, round(v_costo_neto, 4), v_costo_real
+    );$a$,
+    $a$      v_porcentaje_iva, v_impuestos_internos, round(v_costo_neto, 4), v_costo_real,
+      v_condicion_iva
+    );$a$,
+    'actualizar_compra_items/insert-valores');
+
+  EXECUTE v_def;
+END;
+$mig$;
+
+-- ----------------------------------------------------------------------------
+-- 5. cambiar_proveedor_compra — el clon tiene que conservar la clasificación
+--    (si no, cambiar de proveedor la perdería en silencio)
+-- ----------------------------------------------------------------------------
+
+DO $mig$
+DECLARE
+  v_def text;
+BEGIN
+  v_def := pg_get_functiondef(
+    'public.cambiar_proveedor_compra(bigint, uuid, bigint, character varying, text)'::regprocedure);
+  IF v_def LIKE '%condicion_iva%' THEN RETURN; END IF;
+
+  v_def := public._mig177_reemplazo_unico(v_def,
+    $a$    porcentaje_iva, impuestos_internos, costo_neto_unitario, costo_real_unitario$a$,
+    $a$    porcentaje_iva, impuestos_internos, costo_neto_unitario, costo_real_unitario,
+    condicion_iva$a$,
+    'cambiar_proveedor_compra/insert-columnas');
+
+  v_def := public._mig177_reemplazo_unico(v_def,
+    $a$    ci.porcentaje_iva, ci.impuestos_internos, ci.costo_neto_unitario, ci.costo_real_unitario$a$,
+    $a$    ci.porcentaje_iva, ci.impuestos_internos, ci.costo_neto_unitario, ci.costo_real_unitario,
+    ci.condicion_iva$a$,
+    'cambiar_proveedor_compra/select-columnas');
+
+  EXECUTE v_def;
+END;
+$mig$;
+
+-- ----------------------------------------------------------------------------
+-- 6. Movimientos entre sucursales — snapshotear y propagar la condición
+--    Sin esto, un producto exento movido a otra sucursal aterriza como gravado:
+--    los números salen bien pero la clasificación se pierde sin aviso.
+-- ----------------------------------------------------------------------------
+
+DO $mig$
+DECLARE
+  v_def text;
+  v_fn  text;
+BEGIN
+  -- crear_ y editar_movimiento_sucursal comparten el INSERT de items
+  FOREACH v_fn IN ARRAY ARRAY[
+    'public.crear_movimiento_sucursal(bigint, text, jsonb)',
+    'public.editar_movimiento_sucursal(bigint, text, jsonb)'
+  ] LOOP
+    v_def := pg_get_functiondef(v_fn::regprocedure);
+    CONTINUE WHEN v_def LIKE '%condicion_iva%';
+
+    v_def := public._mig177_reemplazo_unico(v_def,
+      $a$      origen_impuestos_internos, origen_porcentaje_iva, origen_stock_minimo,$a$,
+      $a$      origen_impuestos_internos, origen_porcentaje_iva, origen_condicion_iva, origen_stock_minimo,$a$,
+      v_fn || '/insert-columnas');
+
+    v_def := public._mig177_reemplazo_unico(v_def,
+      $a$      v_prod.impuestos_internos, v_prod.porcentaje_iva, v_prod.stock_minimo,$a$,
+      $a$      v_prod.impuestos_internos, v_prod.porcentaje_iva, v_prod.condicion_iva, v_prod.stock_minimo,$a$,
+      v_fn || '/insert-valores');
+
+    EXECUTE v_def;
+  END LOOP;
+
+  -- aceptar_movimiento_sucursal: crea el producto en el destino
+  v_def := pg_get_functiondef('public.aceptar_movimiento_sucursal(bigint, jsonb)'::regprocedure);
+  IF v_def LIKE '%condicion_iva%' THEN RETURN; END IF;
+
+  v_def := public._mig177_reemplazo_unico(v_def,
+    $a$        impuestos_internos, porcentaje_iva, stock, stock_minimo, proveedor_id,$a$,
+    $a$        impuestos_internos, porcentaje_iva, condicion_iva, stock, stock_minimo, proveedor_id,$a$,
+    'aceptar_movimiento_sucursal/insert-columnas');
+
+  v_def := public._mig177_reemplazo_unico(v_def,
+    $a$        v_item.origen_impuestos_internos, v_item.origen_porcentaje_iva, 0, v_item.origen_stock_minimo, NULL,$a$,
+    $a$        v_item.origen_impuestos_internos, v_item.origen_porcentaje_iva,
+        COALESCE(v_item.origen_condicion_iva, 'gravado'), 0, v_item.origen_stock_minimo, NULL,$a$,
+    'aceptar_movimiento_sucursal/insert-valores');
+
+  EXECUTE v_def;
+END;
+$mig$;
+
+DROP FUNCTION IF EXISTS public._mig177_reemplazo_unico(text, text, text, text);
+
+-- ----------------------------------------------------------------------------
+-- 7. Verificación (esperado: todo 'gravado', nada se movió)
+--
+--   SELECT condicion_iva, porcentaje_iva, count(*)
+--     FROM compra_items GROUP BY 1,2 ORDER BY 3 DESC;
+--   -- ('gravado',21)=115, ('gravado',0)=29, ('gravado',NULL)=362
+--
+--   SELECT condicion_iva, count(*) FROM productos GROUP BY 1;  -- gravado=247
+-- ----------------------------------------------------------------------------

--- a/src/components/modals/ModalCompra.tsx
+++ b/src/components/modals/ModalCompra.tsx
@@ -10,10 +10,11 @@ import { X, ShoppingCart, Plus, Trash2, Package, Building2, FileText, Calculator
 import { formatPrecio, fechaLocalISO } from '../../utils/formatters'
 import { calcularTotalesCompra } from '../../utils/calculations'
 import type { TotalesCompra } from '../../utils/calculations'
+import { OPCIONES_CONDICION_IVA, claveCondicionIva, labelCondicionIva } from '../../utils/condicionIva'
 import NumberInput from '../ui/NumberInput'
 import { supabase } from '../../lib/supabase'
 import { CompactErrorBoundary } from '../ErrorBoundary'
-import type { ProductoDB, ProveedorDBExtended, CompraFormInputExtended, ProveedorFormInputExtended } from '../../types'
+import type { CondicionIva, ProductoDB, ProveedorDBExtended, CompraFormInputExtended, ProveedorFormInputExtended } from '../../types'
 
 const ModalProveedor = lazy(() => import('./ModalProveedor'))
 const ModalImportarCompra = lazy(() => import('./ModalImportarCompra'))
@@ -32,8 +33,14 @@ export interface CompraItemForm {
   costoUnitario: number;
   impuestosInternos: number;
   porcentajeIva: number;
+  /** Condición de la línea (mig 177). Se siembra del producto y se puede pisar acá. */
+  condicionIva: CondicionIva;
   stockActual: number;
 }
+
+/** Clave del selector fiscal para el par que tenga la línea. */
+const claveCondicionLinea = (item: CompraItemForm): string =>
+  claveCondicionIva(item.condicionIva, item.porcentajeIva)
 
 /** Resultado del escaneo de factura via n8n */
 export interface FacturaEscaneada {
@@ -102,7 +109,9 @@ function construirCompraItemDesdeScan(
     bonificacion: scanItem.bonificacion || 0,
     costoUnitario: scanItem.costoUnitario || 0,
     impuestosInternos: 0,
-    porcentajeIva: scanItem.iva || 21,
+    // `??`, no `||`: un 0 legítimo del escaneo (línea exenta) se convertía en 21.
+    porcentajeIva: scanItem.iva ?? producto.porcentaje_iva ?? 21,
+    condicionIva: producto.condicion_iva ?? 'gravado',
     stockActual: producto.stock || 0
   }
 }
@@ -163,6 +172,8 @@ type CompraActionType =
   | { type: 'SET_ERROR'; payload: string }
   | { type: 'AGREGAR_ITEM'; payload: ProductoDB }
   | { type: 'ACTUALIZAR_ITEM'; payload: { index: number; campo: keyof CompraItemForm; valor: number | string } }
+  // Condición y alícuota se setean juntas: la condición manda sobre la tasa.
+  | { type: 'SET_CONDICION_ITEM'; payload: { index: number; clave: string } }
   | { type: 'ELIMINAR_ITEM'; payload: number }
   | { type: 'LIMPIAR_BUSQUEDA' }
   | { type: 'SET_MODO_ITEM_RAPIDO'; payload: boolean }
@@ -210,8 +221,10 @@ interface ProductosSectionProps {
   dispatch: React.Dispatch<CompraActionType>;
   productosFiltrados: ProductoDB[];
   iiMaster: Record<string, number>;
+  condicionMaster: Record<string, string>;
   onAgregarItem: (producto: ProductoDB) => void;
   onActualizarItem: (index: number, campo: keyof CompraItemForm, valor: number | string) => void;
+  onCondicionItem: (index: number, clave: string) => void;
   onEliminarItem: (index: number) => void;
   onCrearProductoRapido?: (data: { nombre: string; codigo: string; costoSinIva: number }) => Promise<ProductoDB>;
   onImportarExcel?: () => void;
@@ -221,9 +234,12 @@ interface ProductosSectionProps {
 interface ItemsListProps {
   items: CompraItemForm[];
   onActualizarItem: (index: number, campo: keyof CompraItemForm, valor: number | string) => void;
+  onCondicionItem: (index: number, clave: string) => void;
   onEliminarItem: (index: number) => void;
   /** Tasa de II vigente del producto (para avisar si la línea difiere) */
   iiMaster: Record<string, number>;
+  /** Clave de condición vigente en la ficha del producto (mig 177) */
+  condicionMaster: Record<string, string>;
 }
 
 /** Props de ItemRow */
@@ -231,9 +247,12 @@ interface ItemRowProps {
   item: CompraItemForm;
   index: number;
   onActualizarItem: (index: number, campo: keyof CompraItemForm, valor: number | string) => void;
+  onCondicionItem: (index: number, clave: string) => void;
   onEliminarItem: (index: number) => void;
   /** Tasa de II vigente en el maestro del producto (undefined = desconocida) */
   iiDelProducto?: number;
+  /** Clave de condición de la ficha (undefined = desconocida) */
+  condicionDelProducto?: string;
 }
 
 /** Props de ResumenSection */
@@ -342,6 +361,7 @@ function compraReducer(state: CompraState, action: CompraActionType): CompraStat
           costoUnitario: producto.costo_sin_iva || 0,
           impuestosInternos: producto.impuestos_internos || 0,
           porcentajeIva: producto.porcentaje_iva ?? 21,
+          condicionIva: producto.condicion_iva ?? 'gravado',
           stockActual: producto.stock
         }],
         busquedaProducto: '',
@@ -358,6 +378,19 @@ function compraReducer(state: CompraState, action: CompraActionType): CompraStat
             : item
         )
       }
+
+    case 'SET_CONDICION_ITEM': {
+      const opcion = OPCIONES_CONDICION_IVA.find(o => o.clave === action.payload.clave)
+      if (!opcion) return state
+      return {
+        ...state,
+        items: state.items.map((item, i) =>
+          i === action.payload.index
+            ? { ...item, condicionIva: opcion.condicion, porcentajeIva: opcion.porcentaje }
+            : item
+        )
+      }
+    }
 
     case 'ELIMINAR_ITEM':
       return {
@@ -384,6 +417,7 @@ function compraReducer(state: CompraState, action: CompraActionType): CompraStat
           costoUnitario,
           impuestosInternos: 0,
           porcentajeIva: 21,
+          condicionIva: 'gravado',
           stockActual: 0
         }],
         modoItemRapido: false,
@@ -506,6 +540,19 @@ export default function ModalCompra({ productos, proveedores, onSave, onClose, o
     () => Object.fromEntries(productos.map(p => [String(p.id), Number(p.impuestos_internos ?? 0)])),
     [productos]
   )
+
+  // Condición fiscal vigente por producto. A diferencia del II, una condición
+  // distinta en la línea NO se propaga al maestro: la venta hereda del producto
+  // y un typo acá cambiaría el IVA de todas las ventas futuras. Solo se avisa.
+  const condicionMaster = useMemo<Record<string, string>>(
+    () => Object.fromEntries(productos.map(p => [
+      String(p.id),
+      (p.condicion_iva ?? 'gravado') === 'gravado'
+        ? `gravado:${p.porcentaje_iva ?? 21}`
+        : (p.condicion_iva ?? 'gravado'),
+    ])),
+    [productos]
+  )
   const fileInputRef = useRef<HTMLInputElement>(null)
 
   // Productos filtrados
@@ -525,6 +572,10 @@ export default function ModalCompra({ productos, proveedores, onSave, onClose, o
 
   const handleActualizarItem = useCallback((index: number, campo: keyof CompraItemForm, valor: number | string) => {
     dispatch({ type: 'ACTUALIZAR_ITEM', payload: { index, campo, valor } })
+  }, [])
+
+  const handleCondicionItem = useCallback((index: number, clave: string) => {
+    dispatch({ type: 'SET_CONDICION_ITEM', payload: { index, clave } })
   }, [])
 
   const handleEliminarItem = useCallback((index: number) => {
@@ -702,6 +753,7 @@ export default function ModalCompra({ productos, proveedores, onSave, onClose, o
             subtotal: item.cantidad * costoConBonif,
             bonificacion: item.bonificacion || 0,
             porcentajeIva: item.porcentajeIva ?? 21,
+            condicionIva: item.condicionIva ?? 'gravado',
             impuestosInternos: item.impuestosInternos ?? 0
           }
         })
@@ -828,8 +880,10 @@ export default function ModalCompra({ productos, proveedores, onSave, onClose, o
               dispatch={dispatch}
               productosFiltrados={productosFiltrados}
               iiMaster={iiMaster}
+              condicionMaster={condicionMaster}
               onAgregarItem={handleAgregarItem}
               onActualizarItem={handleActualizarItem}
+              onCondicionItem={handleCondicionItem}
               onEliminarItem={handleEliminarItem}
               onCrearProductoRapido={onCrearProductoRapido}
               onImportarExcel={() => setModalImportarOpen(true)}
@@ -1054,7 +1108,7 @@ function DatosCompraSection({ state, dispatch }: DatosCompraSectionProps) {
   )
 }
 
-function ProductosSection({ state, dispatch, productosFiltrados, iiMaster, onAgregarItem, onActualizarItem, onEliminarItem, onCrearProductoRapido, onImportarExcel }: ProductosSectionProps) {
+function ProductosSection({ state, dispatch, productosFiltrados, iiMaster, condicionMaster, onAgregarItem, onActualizarItem, onCondicionItem, onEliminarItem, onCrearProductoRapido, onImportarExcel }: ProductosSectionProps) {
   const [itemRapido, setItemRapido] = useState({ nombre: '', codigo: '', costo: 0 })
   const [creandoItem, setCreandoItem] = useState(false)
   const buscadorRef = useRef<HTMLDivElement>(null)
@@ -1250,7 +1304,7 @@ function ProductosSection({ state, dispatch, productosFiltrados, iiMaster, onAgr
 
       {/* Lista de items */}
       {state.items.length > 0 ? (
-        <ItemsList items={state.items} onActualizarItem={onActualizarItem} onEliminarItem={onEliminarItem} iiMaster={iiMaster} />
+        <ItemsList items={state.items} onActualizarItem={onActualizarItem} onCondicionItem={onCondicionItem} onEliminarItem={onEliminarItem} iiMaster={iiMaster} condicionMaster={condicionMaster} />
       ) : (
         <div className="text-center py-8 text-gray-500">
           <Package className="w-12 h-12 mx-auto mb-2 opacity-50" />
@@ -1262,16 +1316,17 @@ function ProductosSection({ state, dispatch, productosFiltrados, iiMaster, onAgr
   )
 }
 
-function ItemsList({ items, onActualizarItem, onEliminarItem, iiMaster }: ItemsListProps) {
+function ItemsList({ items, onActualizarItem, onCondicionItem, onEliminarItem, iiMaster, condicionMaster }: ItemsListProps) {
   return (
     <div className="space-y-2">
       {/* Header solo en desktop */}
       <div className="hidden md:grid grid-cols-12 gap-2 text-xs font-medium text-gray-500 uppercase px-2">
         <div className="col-span-3">Producto</div>
-        <div className="col-span-2 text-center">Cant.</div>
+        <div className="col-span-1 text-center">Cant.</div>
         <div className="col-span-1 text-center">Bonif.%</div>
         <div className="col-span-2 text-center">Neto</div>
-        <div className="col-span-2 text-center">Imp.Int.%</div>
+        <div className="col-span-2 text-center">IVA</div>
+        <div className="col-span-1 text-center">Imp.Int.%</div>
         <div className="col-span-1 text-right">Subtot.</div>
         <div className="col-span-1"></div>
       </div>
@@ -1281,8 +1336,10 @@ function ItemsList({ items, onActualizarItem, onEliminarItem, iiMaster }: ItemsL
           item={item}
           index={index}
           onActualizarItem={onActualizarItem}
+          onCondicionItem={onCondicionItem}
           onEliminarItem={onEliminarItem}
           iiDelProducto={iiMaster[String(item.productoId)]}
+          condicionDelProducto={condicionMaster[String(item.productoId)]}
         />
       ))}
     </div>
@@ -1295,16 +1352,42 @@ function difiereII(item: CompraItemForm, iiDelProducto?: number): boolean {
   return Math.abs((item.impuestosInternos || 0) - iiDelProducto) > 0.0001
 }
 
-function ItemRow({ item, index, onActualizarItem, onEliminarItem, iiDelProducto }: ItemRowProps) {
+/**
+ * ¿La condición de la línea difiere de la de la ficha? A diferencia del II,
+ * esto NO se propaga al producto: sólo se avisa (la venta hereda de la ficha).
+ */
+function difiereCondicion(item: CompraItemForm, condicionDelProducto?: string): boolean {
+  if (condicionDelProducto === undefined) return false
+  return claveCondicionLinea(item) !== condicionDelProducto
+}
+
+function ItemRow({ item, index, onActualizarItem, onCondicionItem, onEliminarItem, iiDelProducto, condicionDelProducto }: ItemRowProps) {
   const iiDifiere = difiereII(item, iiDelProducto)
+  const condDifiere = difiereCondicion(item, condicionDelProducto)
+  const selectCondicion = (extraClass = '') => (
+    <select
+      value={claveCondicionLinea(item)}
+      onChange={(e) => onCondicionItem(index, e.target.value)}
+      title={condDifiere
+        ? `La ficha dice ${labelCondicionIva(condicionDelProducto!)}: el cambio aplica sólo a esta compra`
+        : 'Condición frente al IVA de esta línea (autocompletada del producto)'}
+      className={`w-full px-2 py-1 text-center border rounded text-sm dark:bg-gray-700 dark:text-white ${
+        condDifiere ? 'border-amber-400 bg-amber-50 dark:bg-amber-900/20' : 'dark:border-gray-600'
+      } ${extraClass}`}
+    >
+      {OPCIONES_CONDICION_IVA.map(o => (
+        <option key={o.clave} value={o.clave}>{o.labelCorto}</option>
+      ))}
+    </select>
+  )
   return (
-    <div className={`bg-white dark:bg-gray-800 p-3 rounded-lg border ${iiDifiere ? 'border-amber-400 dark:border-amber-600' : 'dark:border-gray-600'}`}>
+    <div className={`bg-white dark:bg-gray-800 p-3 rounded-lg border ${iiDifiere || condDifiere ? 'border-amber-400 dark:border-amber-600' : 'dark:border-gray-600'}`}>
       {/* Mobile: Layout en cards */}
       <div className="md:hidden space-y-3">
         <div className="flex justify-between items-start">
           <div className="flex-1">
             <p className="font-medium text-gray-800 dark:text-white">{item.productoNombre}</p>
-            <p className="text-xs text-gray-500">Stock: {item.stockActual} | IVA: {item.porcentajeIva}%</p>
+            <p className="text-xs text-gray-500">Stock: {item.stockActual}</p>
           </div>
           <button
             type="button"
@@ -1351,6 +1434,10 @@ function ItemRow({ item, index, onActualizarItem, onEliminarItem, iiDelProducto 
             />
           </div>
           <div>
+            <label className="block text-xs text-gray-500 mb-1">IVA</label>
+            {selectCondicion()}
+          </div>
+          <div>
             <label className="block text-xs text-gray-500 mb-1">II%</label>
             <NumberInput
               min={0}
@@ -1369,6 +1456,11 @@ function ItemRow({ item, index, onActualizarItem, onEliminarItem, iiDelProducto 
             ⚠ II difiere del producto ({iiDelProducto}% → {item.impuestosInternos}%): al registrar se actualiza la alícuota del producto.
           </p>
         )}
+        {condDifiere && (
+          <p className="text-xs text-amber-700 dark:text-amber-300">
+            ⚠ La ficha dice {labelCondicionIva(condicionDelProducto!)}: el cambio aplica sólo a esta compra, el producto no se toca.
+          </p>
+        )}
         <div className="flex justify-between items-center pt-2 border-t dark:border-gray-600">
           <span className="text-sm text-gray-500">Subtotal:</span>
           <span className="font-semibold text-gray-800 dark:text-white">{formatPrecio(item.cantidad * item.costoUnitario * (1 - (item.bonificacion || 0) / 100))}</span>
@@ -1379,9 +1471,9 @@ function ItemRow({ item, index, onActualizarItem, onEliminarItem, iiDelProducto 
       <div className="hidden md:grid grid-cols-12 gap-2 items-center">
         <div className="col-span-3">
           <p className="font-medium text-gray-800 dark:text-white text-sm">{item.productoNombre}</p>
-          <p className="text-xs text-gray-500">Stock: {item.stockActual} | IVA: {item.porcentajeIva}%</p>
+          <p className="text-xs text-gray-500">Stock: {item.stockActual}</p>
         </div>
-        <div className="col-span-2">
+        <div className="col-span-1">
           <NumberInput
             integer
             min={1}
@@ -1414,6 +1506,9 @@ function ItemRow({ item, index, onActualizarItem, onEliminarItem, iiDelProducto 
           />
         </div>
         <div className="col-span-2">
+          {selectCondicion()}
+        </div>
+        <div className="col-span-1">
           <NumberInput
             min={0}
             emptyValue={0}
@@ -1442,6 +1537,11 @@ function ItemRow({ item, index, onActualizarItem, onEliminarItem, iiDelProducto 
       {iiDifiere && (
         <p className="hidden md:block text-xs text-amber-700 dark:text-amber-300 mt-1">
           ⚠ II difiere del producto ({iiDelProducto}% → {item.impuestosInternos}%): al registrar se actualiza la alícuota del producto.
+        </p>
+      )}
+      {condDifiere && (
+        <p className="hidden md:block text-xs text-amber-700 dark:text-amber-300 mt-1">
+          ⚠ La ficha dice {labelCondicionIva(condicionDelProducto!)}: el cambio aplica sólo a esta compra, el producto no se toca.
         </p>
       )}
     </div>
@@ -1848,7 +1948,8 @@ function ControlRow({ label, calculado, impreso, onChange }: {
 }
 
 function ResumenSection({ totales, state, dispatch }: ResumenSectionProps) {
-  const { subtotalBruto, bonificacionTotal, subtotal, iva, impuestosInternos, percepcionIva, percepcionIibb, noGravado, total } = totales
+  const { subtotalBruto, bonificacionTotal, subtotal, netoGravado, netoExento, netoNoGravado,
+          netoPorAlicuota, iva, impuestosInternos, percepcionIva, percepcionIibb, noGravado, total } = totales
   const esFC = state.tipoFactura === 'FC'
   const [bonifGlobal, setBonifGlobal] = useState(0)
   const [mostrarControl, setMostrarControl] = useState(false)
@@ -1949,11 +2050,28 @@ function ResumenSection({ totales, state, dispatch }: ResumenSectionProps) {
         )}
         <div className="flex justify-between text-sm">
           <span className="text-gray-600 dark:text-gray-400">{esFC ? 'Gravado (neto):' : 'Subtotal Neto:'}</span>
-          <span className="font-medium text-gray-800 dark:text-white">{formatPrecio(subtotal)}</span>
+          <span className="font-medium text-gray-800 dark:text-white">{formatPrecio(esFC ? netoGravado : subtotal)}</span>
         </div>
+        {/* Con condiciones mezcladas el "gravado" solo ya no explica el total */}
+        {esFC && netoExento > 0 && (
+          <div className="flex justify-between text-sm">
+            <span className="text-gray-600 dark:text-gray-400">Exento (neto):</span>
+            <span className="font-medium text-gray-800 dark:text-white">{formatPrecio(netoExento)}</span>
+          </div>
+        )}
+        {esFC && netoNoGravado > 0 && (
+          <div className="flex justify-between text-sm">
+            <span className="text-gray-600 dark:text-gray-400">No gravado (líneas):</span>
+            <span className="font-medium text-gray-800 dark:text-white">{formatPrecio(netoNoGravado)}</span>
+          </div>
+        )}
         {esFC && (
           <div className="flex justify-between text-sm">
-            <span className="text-gray-600 dark:text-gray-400">IVA (sobre neto):</span>
+            <span className="text-gray-600 dark:text-gray-400">
+              IVA (sobre neto{Object.keys(netoPorAlicuota).length > 1
+                ? `, ${Object.keys(netoPorAlicuota).join('% + ')}%`
+                : ''}):
+            </span>
             <span className="font-medium text-gray-800 dark:text-white">{formatPrecio(iva)}</span>
           </div>
         )}
@@ -1971,7 +2089,7 @@ function ResumenSection({ totales, state, dispatch }: ResumenSectionProps) {
         )}
         {noGravado > 0 && (
           <div className="flex justify-between text-sm">
-            <span className="text-gray-600 dark:text-gray-400">No gravado:</span>
+            <span className="text-gray-600 dark:text-gray-400">No gravado (cabecera):</span>
             <span className="font-medium text-gray-800 dark:text-white">{formatPrecio(noGravado)}</span>
           </div>
         )}
@@ -1999,8 +2117,33 @@ function ResumenSection({ totales, state, dispatch }: ResumenSectionProps) {
                 <span className="col-span-3 text-right">Factura dice</span>
                 <span className="col-span-2 text-right">Dif.</span>
               </div>
-              <ControlRow label="Gravado" calculado={subtotal} impreso={ctrl.gravado}
+              <ControlRow label="Gravado" calculado={netoGravado} impreso={ctrl.gravado}
                 onChange={(n) => dispatch({ type: 'SET_CONTROL', payload: { gravado: n } })} />
+              {/* Solo informativos: la factura los imprime abiertos y sin esto
+                  no se puede cuadrar una mixta contra el papel. */}
+              {Object.entries(netoPorAlicuota)
+                .filter(() => Object.keys(netoPorAlicuota).length > 1)
+                .map(([alicuota, neto]) => (
+                  <div key={alicuota} className="grid grid-cols-12 gap-2 text-xs text-gray-500 pl-3">
+                    <span className="col-span-4">└ neto al {alicuota}%</span>
+                    <span className="col-span-3 text-right">{formatPrecio(neto)}</span>
+                    <span className="col-span-5 text-right">IVA {formatPrecio(neto * parseFloat(alicuota) / 100)}</span>
+                  </div>
+                ))}
+              {netoExento > 0 && (
+                <div className="grid grid-cols-12 gap-2 text-xs text-gray-500 pl-3">
+                  <span className="col-span-4">└ exento</span>
+                  <span className="col-span-3 text-right">{formatPrecio(netoExento)}</span>
+                  <span className="col-span-5"></span>
+                </div>
+              )}
+              {netoNoGravado > 0 && (
+                <div className="grid grid-cols-12 gap-2 text-xs text-gray-500 pl-3">
+                  <span className="col-span-4">└ no gravado (líneas)</span>
+                  <span className="col-span-3 text-right">{formatPrecio(netoNoGravado)}</span>
+                  <span className="col-span-5"></span>
+                </div>
+              )}
               <ControlRow label="IVA" calculado={iva} impreso={ctrl.iva}
                 onChange={(n) => dispatch({ type: 'SET_CONTROL', payload: { iva: n } })} />
               <ControlRow label="Imp. internos" calculado={impuestosInternos} impreso={ctrl.impuestosInternos}

--- a/src/components/modals/ModalDetalleCompra.tsx
+++ b/src/components/modals/ModalDetalleCompra.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { X, ShoppingCart, Package, Building2, Calendar, CreditCard, FileText, TrendingUp, Hash } from 'lucide-react'
 import { formatPrecio } from '../../utils/formatters'
-import type { Producto, Proveedor, Usuario } from '../../types'
+import type { CondicionIva, Producto, Proveedor, Usuario } from '../../types'
 
 type EstadoCompra = 'pendiente' | 'recibida' | 'parcial' | 'cancelada';
 type FormaPagoCompra = 'efectivo' | 'transferencia' | 'cheque' | 'cuenta_corriente' | 'tarjeta';
@@ -35,6 +35,20 @@ interface CompraItem {
   subtotal?: number;
   stock_anterior?: number;
   stock_nuevo?: number;
+  /** Snapshots fiscales de la línea (mig 113/177); NULL en líneas viejas. */
+  porcentaje_iva?: number | null;
+  condicion_iva?: CondicionIva | null;
+}
+
+/**
+ * Etiqueta fiscal de la línea. Con una factura mixta el detalle es ilegible sin
+ * esto: no se entiende por qué el total no es subtotal × 1,21.
+ */
+function etiquetaFiscalLinea(item: CompraItem): string {
+  const condicion = item.condicion_iva ?? 'gravado';
+  if (condicion === 'exento') return 'Exento';
+  if (condicion === 'no_gravado') return 'No gravado';
+  return item.porcentaje_iva == null ? 'IVA s/d' : `IVA ${item.porcentaje_iva}%`;
 }
 
 interface CompraDetalle {
@@ -94,6 +108,8 @@ export default function ModalDetalleCompra({
 
   const estado = ESTADOS_COMPRA[compra.estado] || ESTADOS_COMPRA.pendiente
   const totalUnidades = (compra.items || []).reduce((sum, i) => sum + i.cantidad + (i.bonificacion || 0), 0)
+  // En ZZ no hay comprobante que clasificar: la etiqueta fiscal sobra.
+  const esFC = (compra.tipo_factura ?? 'FC') === 'FC'
 
   return (
     <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
@@ -219,6 +235,9 @@ export default function ModalDetalleCompra({
                         <p className="text-xs text-gray-500">
                           Stock: {item.stock_anterior} -&gt; {item.stock_nuevo}
                           <TrendingUp className="inline w-3 h-3 ml-1 text-green-500" />
+                          {/* Con alícuotas mezcladas, sin esto no se entiende
+                              por qué el total no es subtotal × 1,21. */}
+                          {esFC && <span className="ml-2">· {etiquetaFiscalLinea(item)}</span>}
                         </p>
                       </td>
                       <td className="px-4 py-3 text-center text-gray-800 dark:text-white">
@@ -271,7 +290,7 @@ export default function ModalDetalleCompra({
               )}
               {(compra.no_gravado ?? 0) > 0 && (
                 <div className="flex justify-between text-sm">
-                  <span className="text-gray-600 dark:text-gray-400">No gravado:</span>
+                  <span className="text-gray-600 dark:text-gray-400">No gravado (cabecera):</span>
                   <span className="font-medium text-gray-800 dark:text-white">{formatPrecio(compra.no_gravado!)}</span>
                 </div>
               )}

--- a/src/components/modals/ModalEditarCompra.cambiarProveedor.test.jsx
+++ b/src/components/modals/ModalEditarCompra.cambiarProveedor.test.jsx
@@ -29,6 +29,7 @@ describe('ModalEditarCompra · botón "Cambiar proveedor"', () => {
         costo_unitario: 100,
         bonificacion: 0,
         porcentaje_iva: 21,
+        condicion_iva: 'gravado',
         impuestos_internos: 0,
         producto: { nombre: 'Prod 1' },
       },

--- a/src/components/modals/ModalEditarCompra.tsx
+++ b/src/components/modals/ModalEditarCompra.tsx
@@ -1,8 +1,9 @@
 /**
  * ModalEditarCompra
  *
- * Permite al admin editar los items (cantidad, costo, bonificacion y % IVA) de
- * una compra existente, dentro de la ventana de 7 dias desde su creacion.
+ * Permite al admin editar los items (cantidad, costo, bonificacion y condicion
+ * de IVA) de una compra existente, dentro de la ventana de 7 dias desde su
+ * creacion.
  *
  * Limitaciones v1 (intencionales):
  *   - La cabecera (proveedor, fecha, factura, tipo_factura, forma_pago, notas)
@@ -21,8 +22,9 @@ import { Loader2, Trash2, AlertCircle, Building2 } from 'lucide-react'
 import ModalBase from './ModalBase'
 import NumberInput from '../ui/NumberInput'
 import { formatPrecio } from '../../utils/formatters'
-import type { CompraDBExtended } from '../../types'
+import type { CompraDBExtended, CondicionIva } from '../../types'
 import type { ActualizarCompraItemsInput } from '../../hooks/queries'
+import { OPCIONES_CONDICION_IVA, claveCondicionIva } from '../../utils/condicionIva'
 
 /** Item editable dentro del modal. */
 interface ItemEdit {
@@ -32,9 +34,14 @@ interface ItemEdit {
   costoUnitario: number
   bonificacion: number
   porcentajeIva: number
+  condicionIva: CondicionIva
   impuestosInternos: number
   marcadoParaEliminar: boolean
 }
+
+/** Clave del selector para el par (condición, alícuota) de la línea. */
+const claveCondicion = (it: { condicionIva: CondicionIva; porcentajeIva: number }): string =>
+  claveCondicionIva(it.condicionIva, it.porcentajeIva)
 
 export interface ModalEditarCompraProps {
   compra: CompraDBExtended
@@ -73,6 +80,7 @@ const ModalEditarCompra = memo(function ModalEditarCompra({
       // Snapshot de la línea (mig 113); líneas viejas caen a los atributos
       // fiscales actuales del producto y por último a defaults.
       porcentajeIva: esZZ ? 0 : (it.porcentaje_iva ?? it.producto?.porcentaje_iva ?? 21),
+      condicionIva: esZZ ? 'gravado' : (it.condicion_iva ?? it.producto?.condicion_iva ?? 'gravado'),
       impuestosInternos: esZZ ? 0 : (it.impuestos_internos ?? it.producto?.impuestos_internos ?? 0),
       marcadoParaEliminar: false,
     })),
@@ -95,6 +103,7 @@ const ModalEditarCompra = memo(function ModalEditarCompra({
         costoUnitario: it.costo_unitario ?? 0,
         bonificacion: it.bonificacion ?? 0,
         porcentajeIva: esZZ ? 0 : (it.porcentaje_iva ?? it.producto?.porcentaje_iva ?? 21),
+        condicionIva: esZZ ? 'gravado' : (it.condicion_iva ?? it.producto?.condicion_iva ?? 'gravado'),
         impuestosInternos: esZZ ? 0 : (it.impuestos_internos ?? it.producto?.impuestos_internos ?? 0),
       })),
     [compra.items, esZZ],
@@ -111,6 +120,7 @@ const ModalEditarCompra = memo(function ModalEditarCompra({
         orig.costoUnitario !== it.costoUnitario ||
         orig.bonificacion !== it.bonificacion ||
         orig.porcentajeIva !== it.porcentajeIva ||
+        orig.condicionIva !== it.condicionIva ||
         orig.impuestosInternos !== it.impuestosInternos
       )
     })
@@ -131,7 +141,9 @@ const ModalEditarCompra = memo(function ModalEditarCompra({
       const subtotalItem = it.cantidad * netoUnitario
       subtotal += subtotalItem
       if (!esZZ) {
-        iva += subtotalItem * (it.porcentajeIva / 100)
+        // Solo las líneas gravadas generan IVA (mig 177); exento y no gravado
+        // suman al subtotal pero no al crédito fiscal.
+        if (it.condicionIva === 'gravado') iva += subtotalItem * (it.porcentajeIva / 100)
         impuestosInternos += subtotalItem * ((it.impuestosInternos || 0) / 100)
       }
     }
@@ -142,6 +154,19 @@ const ModalEditarCompra = memo(function ModalEditarCompra({
   function updateItem<K extends keyof ItemEdit>(productoId: string, field: K, value: ItemEdit[K]) {
     setItems((prev) =>
       prev.map((it) => (it.productoId === productoId ? { ...it, [field]: value } : it)),
+    )
+  }
+
+  /** Condición y alícuota se setean juntas: la condición manda sobre la tasa. */
+  function updateCondicion(productoId: string, clave: string) {
+    const opcion = OPCIONES_CONDICION_IVA.find((o) => o.clave === clave)
+    if (!opcion) return
+    setItems((prev) =>
+      prev.map((it) =>
+        it.productoId === productoId
+          ? { ...it, condicionIva: opcion.condicion, porcentajeIva: opcion.porcentaje }
+          : it,
+      ),
     )
   }
 
@@ -192,6 +217,7 @@ const ModalEditarCompra = memo(function ModalEditarCompra({
         subtotal: subtotalItem,
         bonificacion: it.bonificacion,
         porcentajeIva: esZZ ? 0 : it.porcentajeIva,
+        condicionIva: esZZ ? 'gravado' as const : it.condicionIva,
         impuestosInternos: it.impuestosInternos,
       }
     })
@@ -276,7 +302,7 @@ const ModalEditarCompra = memo(function ModalEditarCompra({
                 <th className="text-right py-2 px-2 w-24">Cantidad</th>
                 <th className="text-right py-2 px-2 w-32">Costo unit.</th>
                 <th className="text-right py-2 px-2 w-24">Bonif. %</th>
-                {!esZZ && <th className="text-right py-2 px-2 w-20">IVA %</th>}
+                {!esZZ && <th className="text-left py-2 px-2 w-28">IVA</th>}
                 <th className="text-right py-2 px-2 w-32">Subtotal</th>
                 <th className="py-2 pl-2 w-12"></th>
               </tr>
@@ -328,16 +354,21 @@ const ModalEditarCompra = memo(function ModalEditarCompra({
                     </td>
                     {!esZZ && (
                       <td className="py-2 px-2">
-                        <NumberInput
-                          min={0}
-                          max={100}
-                          emptyValue={0}
-                          value={it.porcentajeIva}
-                          onChange={(n) => updateItem(it.productoId, 'porcentajeIva', n)}
-                          commitOnChange
+                        <select
+                          value={claveCondicion(it)}
+                          onChange={(e) => updateCondicion(it.productoId, e.target.value)}
                           disabled={it.marcadoParaEliminar}
-                          className="w-full px-2 py-1 text-right border rounded dark:bg-gray-700 dark:border-gray-600 dark:text-white disabled:opacity-50"
-                        />
+                          className="w-full px-2 py-1 border rounded dark:bg-gray-700 dark:border-gray-600 dark:text-white disabled:opacity-50"
+                        >
+                          {/* Un par legacy fuera de la lista se muestra tal cual
+                              en vez de dejar el select mintiendo. */}
+                          {!OPCIONES_CONDICION_IVA.some(o => o.clave === claveCondicion(it)) && (
+                            <option value={claveCondicion(it)}>{it.porcentajeIva}%</option>
+                          )}
+                          {OPCIONES_CONDICION_IVA.map(o => (
+                            <option key={o.clave} value={o.clave}>{o.label}</option>
+                          ))}
+                        </select>
                       </td>
                     )}
                     <td className="py-2 px-2 text-right tabular-nums dark:text-gray-200">

--- a/src/components/modals/ModalImportarCompra.tsx
+++ b/src/components/modals/ModalImportarCompra.tsx
@@ -192,7 +192,10 @@ export default function ModalImportarCompra({ productos, onImportar, onClose }: 
         bonificacion: item.bonificacion,
         costoUnitario: item.costoUnitario || producto?.costo_sin_iva || 0,
         impuestosInternos: producto?.impuestos_internos || 0,
-        porcentajeIva: 21,
+        // Los atributos fiscales salen de la ficha, no de un 21% fijo: el Excel
+        // no los trae y hardcodearlos gravaba productos exentos.
+        porcentajeIva: producto?.porcentaje_iva ?? 21,
+        condicionIva: producto?.condicion_iva ?? 'gravado',
         stockActual: producto?.stock || 0
       };
     });

--- a/src/components/modals/ModalNotaCredito.tsx
+++ b/src/components/modals/ModalNotaCredito.tsx
@@ -2,7 +2,8 @@ import React, { useState, useMemo } from 'react'
 import { X, FileText, AlertTriangle } from 'lucide-react'
 import NumberInput from '../ui/NumberInput'
 import { formatPrecio } from '../../utils/formatters'
-import type { NotaCreditoDB, NotaCreditoFormInput } from '../../types'
+import type { CondicionIva, NotaCreditoDB, NotaCreditoFormInput } from '../../types'
+import { calcularTotalesNotaCredito } from '../../utils/notaCredito'
 
 interface CompraItem {
   producto_id: string
@@ -10,6 +11,9 @@ interface CompraItem {
   cantidad: number
   costo_unitario: number
   bonificacion?: number
+  /** Snapshots fiscales de la línea original (mig 113/177) */
+  porcentaje_iva?: number | null
+  condicion_iva?: CondicionIva | null
 }
 
 export interface ModalNotaCreditoProps {
@@ -63,37 +67,10 @@ export default function ModalNotaCredito({
   }, [compra.items, yaAcreditado])
 
   // Calculate subtotal from credited items
-  const { subtotal, iva, total, itemsConCantidad } = useMemo(() => {
-    let sub = 0
-    const itemsList: Array<{
-      productoId: string
-      cantidad: number
-      costoUnitario: number
-      subtotal: number
-    }> = []
-
-    for (const item of compra.items) {
-      const cant = cantidades[item.producto_id] || 0
-      if (cant > 0) {
-        const itemSub = cant * item.costo_unitario
-        sub += itemSub
-        itemsList.push({
-          productoId: item.producto_id,
-          cantidad: cant,
-          costoUnitario: item.costo_unitario,
-          subtotal: itemSub,
-        })
-      }
-    }
-
-    const ivaCalc = sub * 0.21
-    return {
-      subtotal: sub,
-      iva: ivaCalc,
-      total: sub + ivaCalc,
-      itemsConCantidad: itemsList,
-    }
-  }, [cantidades, compra.items])
+  const { subtotal, iva, total, itemsConCantidad } = useMemo(
+    () => calcularTotalesNotaCredito(compra.items, cantidades),
+    [cantidades, compra.items],
+  )
 
   const handleCantidadChange = (productoId: string, value: string) => {
     const num = parseInt(value, 10)
@@ -265,7 +242,8 @@ export default function ModalNotaCredito({
                 <span className="font-medium text-gray-800 dark:text-white">{formatPrecio(subtotal)}</span>
               </div>
               <div className="flex justify-between text-sm">
-                <span className="text-gray-600 dark:text-gray-400">IVA (21%):</span>
+                {/* Ya no es un 21% fijo: sale de la alícuota de cada línea. */}
+                <span className="text-gray-600 dark:text-gray-400">IVA:</span>
                 <span className="font-medium text-gray-800 dark:text-white">{formatPrecio(iva)}</span>
               </div>
               <div className="flex justify-between text-lg font-bold pt-2 border-t border-blue-200 dark:border-blue-800">

--- a/src/components/modals/ModalProducto.tsx
+++ b/src/components/modals/ModalProducto.tsx
@@ -14,7 +14,8 @@ import {
   calcularCostoReal,
   parsePrecio,
 } from '../../utils/calculations';
-import type { ProductoDB, ProveedorDBExtended } from '../../types';
+import type { CondicionIva, ProductoDB, ProveedorDBExtended } from '../../types';
+import { OPCIONES_CONDICION_IVA, claveCondicionIva } from '../../utils/condicionIva';
 
 // Lazy: solo hace falta al editar, y arrastra la query de grupos de precio.
 const ProductoCondicionesMayoristas = lazy(() => import('../productos/ProductoCondicionesMayoristas'));
@@ -40,6 +41,8 @@ export interface ProductoFormData {
    */
   cantidad_minima_venta?: number | null;
   porcentaje_iva: number;
+  /** Condición frente al IVA (mig 177). Va siempre en par con porcentaje_iva. */
+  condicion_iva: CondicionIva;
   costo_sin_iva: number | string;
   costo_con_iva: number | string;
   impuestos_internos: number | string;
@@ -53,12 +56,6 @@ export interface ProductoFormData {
   unidades_de_venta_por_fardo?: number;
   /** Etiqueta del bulto: FARDO, CAJA, PACK, BULTO... */
   etiqueta_bulto?: string;
-}
-
-/** Opción de IVA */
-interface OpcionIVA {
-  valor: number;
-  label: string;
 }
 
 /** Validation errors map */
@@ -94,13 +91,6 @@ export interface ModalProductoProps {
   onCrearCondicionMayorista?: () => void;
 }
 
-// Opciones de IVA disponibles
-const OPCIONES_IVA: OpcionIVA[] = [
-  { valor: 21, label: '21%' },
-  { valor: 10.5, label: '10.5%' },
-  { valor: 0, label: '0% (Exento)' }
-];
-
 /** Helper to get category name */
 const getCategoryName = (cat: string | CategoriaOption): string => {
   return typeof cat === 'string' ? cat : cat.nombre;
@@ -135,6 +125,7 @@ const ModalProducto = memo(function ModalProducto({ producto, categorias, provee
     cantidad_minima_venta: producto.cantidad_minima_venta ?? undefined,
     // Atributo fiscal del producto: preservar el real (ej: 10.5) en vez de resetear a 21.
     porcentaje_iva: producto.porcentaje_iva ?? 21,
+    condicion_iva: producto.condicion_iva ?? 'gravado',
     costo_sin_iva: producto.costo_sin_iva ?? '',
     costo_con_iva: producto.costo_con_iva ?? '',
     impuestos_internos: producto.impuestos_internos ?? '',
@@ -153,6 +144,7 @@ const ModalProducto = memo(function ModalProducto({ producto, categorias, provee
     stock_minimo: 10,
     cantidad_minima_venta: undefined,
     porcentaje_iva: 21,
+    condicion_iva: 'gravado',
     costo_sin_iva: '',
     costo_con_iva: '',
     impuestos_internos: '',
@@ -238,7 +230,13 @@ const ModalProducto = memo(function ModalProducto({ producto, categorias, provee
   // recalculan derivados y ambos márgenes.
   const handleCostoSinIvaChange = (valor: string): void => aplicarForm({ ...form, costo_sin_iva: valor });
   const handleImpuestosInternosChange = (valor: string): void => aplicarForm({ ...form, impuestos_internos: valor });
-  const handlePorcentajeIvaChange = (valor: string): void => aplicarForm({ ...form, porcentaje_iva: parseFloat(valor) });
+  // La condición y la alícuota se eligen juntas: cambiar a exento/no gravado
+  // pone la tasa en 0, que es lo que después hereda la venta.
+  const handleCondicionIvaChange = (clave: string): void => {
+    const opcion = OPCIONES_CONDICION_IVA.find(o => o.clave === clave);
+    if (!opcion) return;
+    aplicarForm({ ...form, condicion_iva: opcion.condicion, porcentaje_iva: opcion.porcentaje });
+  };
 
   // Cambio de PRECIO FINAL (lo edita el usuario) → recalcula neto + márgenes.
   const handlePrecioChange = (valor: string): void => {
@@ -330,6 +328,8 @@ const ModalProducto = memo(function ModalProducto({ producto, categorias, provee
   };
 
   const inputClass = (field: string): string => `w-full px-3 py-2 border rounded-lg ${errores[field] ? 'border-red-500 bg-red-50' : ''}`;
+
+  const claveActualIva = claveCondicionIva(form.condicion_iva, form.porcentaje_iva);
 
   return (
     <ModalBase title={producto ? 'Editar Producto' : 'Nuevo Producto'} onClose={onClose} maxWidth="max-w-lg">
@@ -553,17 +553,26 @@ const ModalProducto = memo(function ModalProducto({ producto, categorias, provee
           <h3 className="text-sm font-semibold text-gray-700 mb-3">Configuracion Impositiva</h3>
           <div className="grid grid-cols-2 gap-4">
             <div>
-              <label className="block text-xs font-medium mb-1 text-gray-600">% IVA</label>
+              <label className="block text-xs font-medium mb-1 text-gray-600">Condición IVA</label>
               <select
-                value={form.porcentaje_iva ?? 21}
-                onChange={(e: ChangeEvent<HTMLSelectElement>) => handlePorcentajeIvaChange(e.target.value)}
+                value={claveActualIva}
+                onChange={(e: ChangeEvent<HTMLSelectElement>) => handleCondicionIvaChange(e.target.value)}
                 className="w-full px-3 py-2 border rounded-lg text-sm"
               >
-                {OPCIONES_IVA.map(opt => (
-                  <option key={opt.valor} value={opt.valor}>{opt.label}</option>
+                {/* Un par legacy que no esté en la lista se muestra tal cual en
+                    vez de dejar el select en blanco mintiendo sobre el valor. */}
+                {!OPCIONES_CONDICION_IVA.some(o => o.clave === claveActualIva) && (
+                  <option value={claveActualIva}>{form.porcentaje_iva}% (sin clasificar)</option>
+                )}
+                {OPCIONES_CONDICION_IVA.map(opt => (
+                  <option key={opt.clave} value={opt.clave}>{opt.label}</option>
                 ))}
               </select>
-              <p className="text-xs text-gray-500 mt-1">Se aplica solo sobre el neto</p>
+              <p className="text-xs text-gray-500 mt-1">
+                {form.condicion_iva === 'gravado'
+                  ? 'Se aplica solo sobre el neto'
+                  : 'Sin IVA: la venta de este producto no lo discrimina'}
+              </p>
             </div>
             <div>
               <label className="block text-xs font-medium mb-1 text-gray-600">Imp. Internos (%)</label>
@@ -791,8 +800,12 @@ const ModalProducto = memo(function ModalProducto({ producto, categorias, provee
           })()}
 
           <p className="text-xs text-gray-500 mt-2">
-            * El precio final incluye IVA ({form.porcentaje_iva || 21}%). El neto se calcula hacia atrás.
-            La venta no discrimina imp. internos (no somos agente): el II solo integra el costo.
+            {/* `?? 21`, no `|| 21`: con la alícuota en 0 (exento / no gravado) el
+                precio final NO lleva IVA y decir "21%" acá era mentira. */}
+            * {form.condicion_iva === 'gravado'
+              ? `El precio final incluye IVA (${form.porcentaje_iva ?? 21}%). El neto se calcula hacia atrás.`
+              : 'Producto sin IVA: el precio final es el neto.'}
+            {' '}La venta no discrimina imp. internos (no somos agente): el II solo integra el costo.
             Editá cualquiera de los dos márgenes o el precio final indistintamente.
           </p>
         </div>
@@ -800,6 +813,9 @@ const ModalProducto = memo(function ModalProducto({ producto, categorias, provee
         {/* Condiciones mayoristas de ESTE producto, con su margen. Solo en
             edición: sin id no hay a qué grupo pertenecer todavía. Los costos
             salen del form, así el margen se mueve mientras editás el costo. */}
+        {/* porcentajeIva con `?? 21`, no `|| 21`: con la alícuota en 0 (exento /
+            no gravado) el margen mayorista se calculaba dividiendo el precio por
+            1,21 y salía ~21 puntos peor que el real. */}
         {producto?.id && (
           <Suspense fallback={null}>
             <ProductoCondicionesMayoristas
@@ -807,7 +823,7 @@ const ModalProducto = memo(function ModalProducto({ producto, categorias, provee
               precioLista={parsePrecio(String(form.precio))}
               costoTotal={costosDesdeForm(form).costoTotal}
               costoReal={costosDesdeForm(form).costoReal}
-              porcentajeIva={Number(form.porcentaje_iva) || 21}
+              porcentajeIva={Number(form.porcentaje_iva ?? 21)}
               puedeEditar={esAdmin}
               onCrearCondicion={onCrearCondicionMayorista}
             />

--- a/src/hooks/queries/useComprasQuery.ts
+++ b/src/hooks/queries/useComprasQuery.ts
@@ -9,6 +9,7 @@ import { fechaLocalISO } from '../../utils/formatters'
 import type {
   CompraDBExtended,
   CompraFormInputExtended,
+  CondicionIva,
   RegistrarCompraResult
 } from '../../types'
 
@@ -30,6 +31,8 @@ interface CompraItemRPC {
   subtotal: number
   bonificacion: number
   porcentaje_iva: number
+  /** mig 177: el RPC normaliza lo que no reconozca a 'gravado' */
+  condicion_iva: CondicionIva
   impuestos_internos: number
 }
 
@@ -98,6 +101,7 @@ async function registrarCompra(compraData: CompraFormInputExtended): Promise<Reg
     subtotal: item.subtotal || (item.cantidad * (item.costoUnitario || 0)),
     bonificacion: item.bonificacion || 0,
     porcentaje_iva: item.porcentajeIva ?? 21,
+    condicion_iva: item.condicionIva ?? 'gravado',
     impuestos_internos: item.impuestosInternos ?? 0
   }))
 
@@ -231,6 +235,7 @@ export interface ActualizarCompraItemsInput {
     subtotal: number
     bonificacion?: number
     porcentajeIva?: number
+    condicionIva?: CondicionIva
     impuestosInternos?: number
   }>
 }
@@ -252,6 +257,7 @@ async function actualizarCompraItems(
     subtotal: item.subtotal,
     bonificacion: item.bonificacion ?? 0,
     porcentaje_iva: item.porcentajeIva ?? 21,
+    condicion_iva: item.condicionIva ?? 'gravado',
     impuestos_internos: item.impuestosInternos ?? 0,
   }))
 

--- a/src/hooks/queries/useMovimientosQuery.ts
+++ b/src/hooks/queries/useMovimientosQuery.ts
@@ -12,6 +12,7 @@ import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { supabase } from '../supabase/base'
 import { fechaLocalISO, fechaHaceDias } from '../../utils/formatters'
 import { useSucursal } from '../../contexts/SucursalContext'
+import type { CondicionIva } from '../../types'
 
 export const MOVIMIENTOS_PAGE_SIZE = 50
 
@@ -58,6 +59,8 @@ export interface MovimientoItemDB {
   origen_costo_con_iva: number | null
   origen_impuestos_internos: number | null
   origen_porcentaje_iva: number | null
+  /** Condición de IVA del origen (mig 177). NULL = movimiento anterior. */
+  origen_condicion_iva: CondicionIva | null
   producto_destino_id: number | null
   resolucion: 'match_existente' | 'creado_nuevo' | null
   costo_aplicado_destino: number | null

--- a/src/hooks/queries/useProductosQuery.ts
+++ b/src/hooks/queries/useProductosQuery.ts
@@ -112,7 +112,11 @@ async function createProducto(producto: ProductoFormInput, sucursalId: number | 
       costo_con_iva: producto.costo_con_iva ? parseFloat(String(producto.costo_con_iva)) : null,
       impuestos_internos: producto.impuestos_internos ? parseFloat(String(producto.impuestos_internos)) : null,
       precio_sin_iva: producto.precio_sin_iva ? parseFloat(String(producto.precio_sin_iva)) : null,
-      porcentaje_iva: producto.porcentaje_iva ?? 21,
+      // mig 177: condición y alícuota viajan juntas (CHECK cruzado en la BD).
+      condicion_iva: producto.condicion_iva ?? 'gravado',
+      porcentaje_iva: (producto.condicion_iva ?? 'gravado') === 'gravado'
+        ? (producto.porcentaje_iva ?? 21)
+        : 0,
       costo_real: producto.costo_real ?? null,
       // CPP (mig 127): un producto creado a mano arranca con CPP = costo real;
       // las compras posteriores lo van ponderando.
@@ -144,7 +148,16 @@ async function updateProducto({ id, data: producto }: { id: string; data: Partia
   if (producto.costo_con_iva !== undefined) updateData.costo_con_iva = producto.costo_con_iva ? parseFloat(String(producto.costo_con_iva)) : null
   if (producto.impuestos_internos !== undefined) updateData.impuestos_internos = producto.impuestos_internos ? parseFloat(String(producto.impuestos_internos)) : null
   if (producto.precio_sin_iva !== undefined) updateData.precio_sin_iva = producto.precio_sin_iva ? parseFloat(String(producto.precio_sin_iva)) : null
-  if (producto.porcentaje_iva !== undefined) updateData.porcentaje_iva = producto.porcentaje_iva
+  // mig 177: la condición y la alícuota tienen que llegar coherentes o el CHECK
+  // cruzado rechaza el update. Si la condición viene, ella manda.
+  if (producto.condicion_iva !== undefined) {
+    updateData.condicion_iva = producto.condicion_iva
+    updateData.porcentaje_iva = producto.condicion_iva === 'gravado'
+      ? (producto.porcentaje_iva ?? 21)
+      : 0
+  } else if (producto.porcentaje_iva !== undefined) {
+    updateData.porcentaje_iva = producto.porcentaje_iva
+  }
   if (producto.costo_real !== undefined) updateData.costo_real = producto.costo_real
   // CPP (mig 127): solo llega definido cuando el admin lo corrige a mano en la ficha
   if (producto.costo_promedio !== undefined) updateData.costo_promedio = producto.costo_promedio

--- a/src/hooks/supabase/useCompras.ts
+++ b/src/hooks/supabase/useCompras.ts
@@ -25,6 +25,7 @@ import type {
   ResumenCompras,
   ResumenComprasPorProveedor,
   UseComprasReturnExtended,
+  CondicionIva,
   ProductoDB
 } from '../../types'
 
@@ -35,6 +36,7 @@ interface CompraItemRPC {
   subtotal: number;
   bonificacion: number;
   porcentaje_iva: number;
+  condicion_iva: CondicionIva;
   impuestos_internos: number;
 }
 
@@ -120,6 +122,7 @@ export function useCompras(): UseComprasReturnExtended {
       subtotal: item.subtotal || (item.cantidad * (item.costoUnitario || 0)),
       bonificacion: item.bonificacion || 0,
       porcentaje_iva: item.porcentajeIva ?? 21,
+      condicion_iva: item.condicionIva ?? 'gravado',
       impuestos_internos: item.impuestosInternos ?? 0
     }))
 

--- a/src/lib/schemas.test.js
+++ b/src/lib/schemas.test.js
@@ -179,6 +179,31 @@ describe('Schemas de Validación', () => {
       const result = validateForm(productoSchema, producto)
       expect(result.success).toBe(false)
     })
+
+    // mig 177: condición frente al IVA (distingue no gravado de 0% gravado)
+    it('acepta las tres condiciones de IVA', () => {
+      for (const condicion of ['gravado', 'exento', 'no_gravado']) {
+        const result = validateForm(productoSchema, {
+          nombre: 'Test', precio: 100, unidad: 'unidad', condicion_iva: condicion
+        })
+        expect(result.success).toBe(true)
+      }
+    })
+
+    it('rechaza una condición de IVA inventada', () => {
+      const result = validateForm(productoSchema, {
+        nombre: 'Test', precio: 100, unidad: 'unidad', condicion_iva: 'medio_gravado'
+      })
+      expect(result.success).toBe(false)
+    })
+
+    it('sin condición explícita queda gravado', () => {
+      const result = validateForm(productoSchema, {
+        nombre: 'Test', precio: 100, unidad: 'unidad'
+      })
+      expect(result.success).toBe(true)
+      expect(result.data.condicion_iva).toBe('gravado')
+    })
   })
 
   describe('pagoSchema', () => {

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -52,6 +52,15 @@ export const telefonoSchema = z
   .optional()
 
 /**
+ * Condición frente al IVA (mig 177). Distingue "no gravado" de "0% gravado",
+ * que hasta ahora eran indistinguibles. La BD tiene un CHECK de coherencia: si
+ * no es `gravado`, la alícuota tiene que ser 0.
+ */
+export const condicionIvaSchema = z
+  .enum(['gravado', 'exento', 'no_gravado'], { error: 'Condición de IVA inválida' })
+  .default('gravado')
+
+/**
  * Monto positivo
  */
 export const montoPositivoSchema = z
@@ -180,6 +189,10 @@ export const productoSchema = z.object({
     .max(100, { message: 'El IVA no puede ser mayor a 100%' })
     .default(21),
 
+  // mig 177: distingue "no gravado" de "0% gravado". La BD tiene un CHECK de
+  // coherencia (si no es gravado, la alícuota debe ser 0).
+  condicion_iva: condicionIvaSchema,
+
   impuestos_internos: montoNoNegativoSchema.default(0),
 
   stock: stockSchema.default(0),
@@ -302,7 +315,8 @@ export const itemCompraSchema = z.object({
   cantidad: cantidadSchema,
   costo_unitario: montoNoNegativoSchema,
   impuestos_internos: montoNoNegativoSchema.default(0),
-  porcentaje_iva: z.number().min(0).max(100).default(21)
+  porcentaje_iva: z.number().min(0).max(100).default(21),
+  condicion_iva: condicionIvaSchema
 })
 
 /** Inferred type for ItemCompra schema */
@@ -619,6 +633,7 @@ export const modalProductoSchema = z.object({
     .nullable(),
 
   porcentaje_iva: z.coerce.number().min(0).max(100).default(21),
+  condicion_iva: condicionIvaSchema,
   costo_sin_iva: z.coerce.number().nonnegative().optional(),
   costo_con_iva: z.coerce.number().nonnegative().optional(),
   impuestos_internos: z.coerce.number().nonnegative().optional(),

--- a/src/services/__tests__/analyticsExport.test.ts
+++ b/src/services/__tests__/analyticsExport.test.ts
@@ -430,12 +430,16 @@ describe('analyticsExport', () => {
               cantidad: 10,
               costo_unitario: 200,
               subtotal: 2000,
+              porcentaje_iva: 10.5,
+              condicion_iva: 'gravado',
               producto: { nombre: 'Producto X', codigo: 'PX001', categoria: 'Cat1' },
             },
             {
               cantidad: 5,
               costo_unitario: 300,
               subtotal: 1500,
+              porcentaje_iva: 0,
+              condicion_iva: 'no_gravado',
               producto: { nombre: 'Producto Y', codigo: 'PY002', categoria: 'Cat2' },
             },
           ],
@@ -458,6 +462,35 @@ describe('analyticsExport', () => {
         subtotal: 2000,
         estado: 'recibida',
       })
+    })
+
+    // mig 177: el export es el único lugar fuera del modal donde se ve el
+    // detalle fiscal por línea — hace falta para armar el libro IVA a mano.
+    it('exporta la condición y la alícuota de cada línea', async () => {
+      const mockCompras = [
+        {
+          id: 'comp1',
+          created_at: '2026-01-15T10:00:00',
+          total: 3610,
+          estado: 'recibida',
+          proveedor: { nombre: 'Proveedor A', cuit: '30-12345678-9' },
+          items: [
+            { cantidad: 10, costo_unitario: 200, subtotal: 2000, porcentaje_iva: 10.5, condicion_iva: 'gravado', producto: { nombre: 'X' } },
+            { cantidad: 5, costo_unitario: 300, subtotal: 1500, porcentaje_iva: 0, condicion_iva: 'no_gravado', producto: { nombre: 'Y' } },
+            // Línea anterior a la mig 113: sin snapshot fiscal
+            { cantidad: 1, costo_unitario: 110, subtotal: 110, producto: { nombre: 'Z' } },
+          ],
+        },
+      ]
+      const chain = createChainableMock({ data: mockCompras, error: null })
+      vi.mocked(supabase.from).mockReturnValue(chain as never)
+
+      const result = await fetchComprasFact('2026-01-01', '2026-01-31')
+
+      expect(result[0]).toMatchObject({ condicion_iva: 'gravado', porcentaje_iva: 10.5 })
+      expect(result[1]).toMatchObject({ condicion_iva: 'no_gravado', porcentaje_iva: 0 })
+      // Sin snapshot: la condición cae a gravado y la alícuota queda vacía
+      expect(result[2]).toMatchObject({ condicion_iva: 'gravado', porcentaje_iva: '' })
     })
 
     it('should throw error on Supabase error', async () => {

--- a/src/services/analyticsExport.ts
+++ b/src/services/analyticsExport.ts
@@ -302,6 +302,8 @@ export async function fetchComprasFact(
         costo_unitario,
         bonificacion,
         subtotal,
+        porcentaje_iva,
+        condicion_iva,
         costo_neto_unitario,
         costo_real_unitario,
         producto:productos(nombre, codigo, categoria)
@@ -332,6 +334,10 @@ export async function fetchComprasFact(
         cantidad: item.cantidad,
         costo_unitario: item.costo_unitario,
         bonificacion: item.bonificacion ?? 0,
+        // Único lugar fuera del modal donde se ve el detalle fiscal por línea:
+        // con facturas mixtas hace falta para poder armar el libro IVA a mano.
+        condicion_iva: safe(item.condicion_iva) || 'gravado',
+        porcentaje_iva: item.porcentaje_iva ?? '',
         costo_neto_unitario: item.costo_neto_unitario ?? '',
         costo_real_unitario: item.costo_real_unitario ?? '',
         subtotal: item.subtotal,

--- a/src/types/hooks.ts
+++ b/src/types/hooks.ts
@@ -3,6 +3,9 @@
  */
 
 import type { Dispatch, SetStateAction } from 'react'
+import type { CondicionIva } from '../utils/calculations'
+
+export type { CondicionIva }
 
 // =============================================================================
 // ENTIDADES DE BASE DE DATOS (formato real)
@@ -96,6 +99,11 @@ export interface ProductoDB {
   impuestos_internos?: number | null;
   precio_sin_iva?: number | null;
   porcentaje_iva?: number | null;
+  /**
+   * Condición frente al IVA (mig 177). La venta la hereda vía porcentaje_iva:
+   * un producto exento o no gravado tiene la alícuota en 0 (CHECK en la BD).
+   */
+  condicion_iva?: CondicionIva;
   /** Costo real canónico: FC = neto×(1+II/100); ZZ = pagado (mig 111) */
   costo_real?: number | null;
   /** Costo promedio ponderado: valuación de stock y CMV (mig 127) */
@@ -329,6 +337,11 @@ export interface ProductoFormInput {
   impuestos_internos?: number | string;
   precio_sin_iva?: number | string;
   porcentaje_iva?: number;
+  /**
+   * Condición de IVA (mig 177). Va SIEMPRE junto a `porcentaje_iva`: la BD
+   * tiene un CHECK cruzado y mandar uno solo la haría fallar.
+   */
+  condicion_iva?: CondicionIva;
   /** Costo real canónico calculado en el modal (mig 111) */
   costo_real?: number | null;
   /** Costo promedio ponderado; solo se envía si el admin lo corrige a mano (mig 127) */
@@ -946,6 +959,8 @@ export interface CompraItemDBExtended {
   impuestos_internos?: number | null;
   costo_neto_unitario?: number | null;
   costo_real_unitario?: number | null;
+  /** Condición frente al IVA de la línea (mig 177). Default 'gravado' en la BD. */
+  condicion_iva?: CondicionIva;
 }
 
 export interface CompraDBExtended {
@@ -999,6 +1014,7 @@ export interface CompraFormInputExtended {
     subtotal?: number;
     bonificacion?: number;
     porcentajeIva?: number;
+    condicionIva?: CondicionIva;
     impuestosInternos?: number;
   }>;
   /** Líneas cuya tasa de II fue editada a mano: se propaga al producto tras registrar (mig 123 UI). */

--- a/src/utils/calculations.fiscal.test.ts
+++ b/src/utils/calculations.fiscal.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { calcularCostoReal, calcularCostoFinanciero, calcularNetoVenta, calcularTotalesCompra, calcularMargenPorcentaje } from './calculations'
+import { calcularCostoReal, calcularCostoFinanciero, calcularNetoVenta, calcularTotalesCompra, calcularMargenPorcentaje, calcularNetoDesdeTotal } from './calculations'
 
 // Fixture: factura A 0005-00455160 de Refres Now (Manaos) → T.P. Export,
 // 16/06/2026. Tasas efectivas de imp. internos sobre el neto:
@@ -84,6 +84,30 @@ describe('margen bruto de la ficha según tipo de compra', () => {
   })
 })
 
+// Regresión (mig 177): ModalProducto pasaba `Number(porcentaje_iva) || 21` a
+// ProductoCondicionesMayoristas. En un producto exento (alícuota 0) el `||`
+// caía a 21 y el margen mayorista se calculaba dividiendo el precio por 1,21.
+describe('margen mayorista de un producto sin IVA', () => {
+  const margenNetoEscala = (precio: number, costoReal: number, porcentajeIva: number) =>
+    calcularMargenPorcentaje(calcularNetoDesdeTotal(precio, porcentajeIva, 0), costoReal)
+
+  it('exento: el precio final ES el neto, no se divide por 1,21', () => {
+    expect(calcularNetoDesdeTotal(1000, 0, 0)).toBe(1000)
+    expect(margenNetoEscala(1000, 700, 0)).toBeCloseTo(42.86, 2)
+  })
+
+  it('el bug viejo daba ~21 puntos de menos', () => {
+    const real = margenNetoEscala(1000, 700, 0)
+    const conElBug = margenNetoEscala(1000, 700, 21) // lo que hacía `|| 21`
+    expect(conElBug).toBeCloseTo(18.06, 2)
+    expect(real - conElBug).toBeGreaterThan(20)
+  })
+
+  it('gravado al 21%: sigue igual que siempre', () => {
+    expect(margenNetoEscala(1210, 700, 21)).toBeCloseTo(42.86, 2)
+  })
+})
+
 describe('calcularNetoVenta (mig 123: terna neto / iva / ingreso real)', () => {
   it('FC: neto = precio/(1+IVA%); ingreso real = neto; el II se ignora (no somos agente)', () => {
     // Venta FC de una cola a $10.000 final: aunque el producto tenga II 8,6956%,
@@ -135,5 +159,72 @@ describe('calcularTotalesCompra (estructura de la factura A)', () => {
     expect(t.percepcionIva).toBe(0)
     expect(t.noGravado).toBe(0)
     expect(t.total).toBeCloseTo(t.subtotal, 2)
+  })
+
+  it('sin condicionIva se comporta como antes: todo gravado', () => {
+    const t = calcularTotalesCompra(items, 'FC')
+    expect(t.netoGravado).toBeCloseTo(t.subtotal, 6)
+    expect(t.netoExento).toBe(0)
+    expect(t.netoNoGravado).toBe(0)
+  })
+})
+
+// mig 177: una misma factura puede mezclar condiciones. El IVA sale sólo de las
+// líneas gravadas; exento y no gravado suman al total pero no generan crédito.
+describe('calcularTotalesCompra con condiciones mezcladas', () => {
+  const mixta = [
+    { cantidad: 10, costoUnitario: 1000, porcentajeIva: 21 },
+    { cantidad: 10, costoUnitario: 500, porcentajeIva: 10.5 },
+    { cantidad: 4, costoUnitario: 250, porcentajeIva: 0, condicionIva: 'exento' as const },
+    { cantidad: 2, costoUnitario: 300, porcentajeIva: 0, condicionIva: 'no_gravado' as const },
+  ]
+
+  it('separa el neto por condición y el subtotal sigue siendo la suma de las tres', () => {
+    const t = calcularTotalesCompra(mixta, 'FC')
+    expect(t.netoGravado).toBeCloseTo(15000, 2) // 10000 + 5000
+    expect(t.netoExento).toBeCloseTo(1000, 2)
+    expect(t.netoNoGravado).toBeCloseTo(600, 2)
+    expect(t.subtotal).toBeCloseTo(16600, 2)
+    expect(t.subtotal).toBeCloseTo(t.netoGravado + t.netoExento + t.netoNoGravado, 6)
+  })
+
+  it('el IVA se liquida por alícuota y sólo sobre lo gravado', () => {
+    const t = calcularTotalesCompra(mixta, 'FC')
+    expect(t.netoPorAlicuota).toEqual({ '21': 10000, '10.5': 5000 })
+    expect(t.iva).toBeCloseTo(10000 * 0.21 + 5000 * 0.105, 2) // 2625
+    // Lo exento y lo no gravado no aportan nada de crédito fiscal
+    expect(t.iva).toBeCloseTo(2625, 2)
+  })
+
+  it('el total reconstruye la factura entera', () => {
+    const t = calcularTotalesCompra(mixta, 'FC', { percepcionIva: 300, percepcionIibb: 150, noGravado: 800 })
+    expect(t.total).toBeCloseTo(16600 + 2625 + 300 + 150 + 800, 2)
+    // El "no gravado" de cabecera (pallets) es independiente de las líneas no gravadas
+    expect(t.noGravado).toBe(800)
+    expect(t.netoNoGravado).toBeCloseTo(600, 2)
+  })
+
+  it('una línea no gravada nunca aporta IVA, aunque traiga una alícuota cargada', () => {
+    const t = calcularTotalesCompra(
+      [{ cantidad: 1, costoUnitario: 1000, porcentajeIva: 21, condicionIva: 'no_gravado' as const }], 'FC')
+    expect(t.iva).toBe(0)
+    expect(t.netoPorAlicuota).toEqual({})
+    expect(t.netoNoGravado).toBeCloseTo(1000, 2)
+  })
+
+  it('la bonificación se aplica antes de clasificar el neto', () => {
+    const t = calcularTotalesCompra(
+      [{ cantidad: 10, costoUnitario: 1000, bonificacion: 10, condicionIva: 'exento' as const }], 'FC')
+    expect(t.netoExento).toBeCloseTo(9000, 2)
+    expect(t.bonificacionTotal).toBeCloseTo(1000, 2)
+  })
+
+  it('ZZ ignora la condición: sin factura no hay clasificación (espejo del RPC)', () => {
+    const t = calcularTotalesCompra(mixta, 'ZZ')
+    expect(t.netoGravado).toBeCloseTo(t.subtotal, 6)
+    expect(t.netoExento).toBe(0)
+    expect(t.netoNoGravado).toBe(0)
+    expect(t.netoPorAlicuota).toEqual({})
+    expect(t.iva).toBe(0)
   })
 })

--- a/src/utils/calculations.ts
+++ b/src/utils/calculations.ts
@@ -205,6 +205,13 @@ export function calcularCostoPromedioPonderado(
 // CÁLCULOS DE COMPRAS (desglose fiscal completo)
 // ============================================
 
+/**
+ * Condición frente al IVA de una línea o de un producto (mig 177).
+ * `exento` y `no_gravado` no generan crédito fiscal; la diferencia importa para
+ * el libro IVA (columnas distintas), no para el total.
+ */
+export type CondicionIva = 'gravado' | 'exento' | 'no_gravado';
+
 export interface CompraItemCalculo {
   cantidad: number;
   costoUnitario: number;
@@ -212,6 +219,8 @@ export interface CompraItemCalculo {
   porcentajeIva?: number;
   /** Tasa efectiva de imp. internos (%) */
   impuestosInternos?: number;
+  /** Default: 'gravado' (así se comporta una línea que no lo trae). */
+  condicionIva?: CondicionIva;
 }
 
 export interface CompraExtras {
@@ -224,12 +233,24 @@ export interface CompraExtras {
 export interface TotalesCompra {
   subtotalBruto: number;
   bonificacionTotal: number;
-  /** Neto gravado (bruto − bonif) */
+  /**
+   * Neto de TODAS las líneas (bruto − bonif) = netoGravado + netoExento +
+   * netoNoGravado. Es lo que se manda como p_subtotal y lo que valida el check
+   * COMPRA-A2 contra SUM(compra_items.subtotal): no estrecharlo a "sólo
+   * gravado" o toda factura mixta quedaría en rojo.
+   */
   subtotal: number;
+  netoGravado: number;
+  netoExento: number;
+  /** Líneas de producto no gravadas. NO es `noGravado` (cabecera, sin línea). */
+  netoNoGravado: number;
+  /** Neto gravado abierto por alícuota: { '21': 10000, '10.5': 5000 } */
+  netoPorAlicuota: Record<string, number>;
   iva: number;
   impuestosInternos: number;
   percepcionIva: number;
   percepcionIibb: number;
+  /** Conceptos de cabecera fuera del IVA (pallets, envases): sin línea de producto. */
   noGravado: number;
   otrosImpuestos: number;
   total: number;
@@ -237,21 +258,30 @@ export interface TotalesCompra {
 
 /**
  * Totales de una compra según tipo de comprobante (fuente única del modal de
- * compras; estructura = factura A real: total = gravado + IVA + II +
- * percepciones + no gravado + otros).
+ * compras; estructura = factura A real: total = neto de líneas + IVA + II +
+ * percepciones + no gravado de cabecera + otros).
+ *
+ * Una misma factura puede mezclar condiciones (mig 177): sólo las líneas
+ * gravadas generan IVA, y el crédito se liquida una vez por alícuota, igual que
+ * lo imprime el proveedor.
  *
  * ZZ (sin factura): lo pagado es todo — sin IVA, sin II, sin percepciones ni
- * no gravado. total = subtotal.
+ * no gravado, y sin clasificación (espejo del RPC, que fuerza 'gravado').
+ * total = subtotal.
  */
 export function calcularTotalesCompra(
   items: CompraItemCalculo[],
   tipoFactura: 'ZZ' | 'FC' = 'FC',
   extras: CompraExtras = {}
 ): TotalesCompra {
+  const esFC = tipoFactura === 'FC';
   let subtotalBruto = 0;
   let bonificacionTotal = 0;
-  let iva = 0;
   let impuestosInternos = 0;
+  let netoGravado = 0;
+  let netoExento = 0;
+  let netoNoGravado = 0;
+  const netoPorAlicuota: Record<string, number> = {};
 
   for (const item of items) {
     const bruto = (item.cantidad || 0) * (item.costoUnitario || 0);
@@ -259,14 +289,28 @@ export function calcularTotalesCompra(
     const neto = bruto - bonif;
     subtotalBruto += bruto;
     bonificacionTotal += bonif;
-    if (tipoFactura === 'FC') {
-      iva += neto * ((item.porcentajeIva ?? 21) / 100);
+
+    // En ZZ no hay comprobante que clasificar: todo entra como gravado.
+    const condicion: CondicionIva = esFC ? (item.condicionIva ?? 'gravado') : 'gravado';
+    if (condicion === 'exento') netoExento += neto;
+    else if (condicion === 'no_gravado') netoNoGravado += neto;
+    else netoGravado += neto;
+
+    if (esFC) {
+      // Los imp. internos son un impuesto propio: no dependen de la condición
+      // frente al IVA.
       impuestosInternos += neto * ((item.impuestosInternos || 0) / 100);
+      if (condicion === 'gravado') {
+        const alicuota = String(item.porcentajeIva ?? 21);
+        netoPorAlicuota[alicuota] = (netoPorAlicuota[alicuota] || 0) + neto;
+      }
     }
   }
 
+  const iva = Object.entries(netoPorAlicuota)
+    .reduce((acc, [alicuota, neto]) => acc + neto * (parseFloat(alicuota) / 100), 0);
+
   const subtotal = subtotalBruto - bonificacionTotal;
-  const esFC = tipoFactura === 'FC';
   const percepcionIva = esFC ? (extras.percepcionIva || 0) : 0;
   const percepcionIibb = esFC ? (extras.percepcionIibb || 0) : 0;
   const noGravado = esFC ? (extras.noGravado || 0) : 0;
@@ -274,7 +318,9 @@ export function calcularTotalesCompra(
   const total = subtotal + iva + impuestosInternos + percepcionIva + percepcionIibb + noGravado + otrosImpuestos;
 
   return {
-    subtotalBruto, bonificacionTotal, subtotal, iva, impuestosInternos,
+    subtotalBruto, bonificacionTotal, subtotal,
+    netoGravado, netoExento, netoNoGravado, netoPorAlicuota,
+    iva, impuestosInternos,
     percepcionIva, percepcionIibb, noGravado, otrosImpuestos, total,
   };
 }

--- a/src/utils/condicionIva.ts
+++ b/src/utils/condicionIva.ts
@@ -1,0 +1,48 @@
+/**
+ * Condiciones frente al IVA disponibles en la UI (mig 177).
+ *
+ * Vive aparte de los modales por dos razones: es la única fuente de verdad para
+ * la ficha de producto y las dos pantallas de compra (antes había dos listas
+ * que podían divergir), y es un módulo puro — importarlo desde un modal no
+ * arrastra supabase a los tests.
+ *
+ * El par (condición, alícuota) se elige SIEMPRE junto: la BD tiene un CHECK
+ * cruzado y la condición manda sobre la tasa.
+ */
+import type { CondicionIva } from './calculations';
+
+export interface OpcionCondicionIva {
+  /** Clave del <select>: 'gravado:21' | 'gravado:10.5' | 'exento' | 'no_gravado' */
+  clave: string;
+  label: string;
+  /** Variante corta para la grilla de compra, donde la columna es angosta. */
+  labelCorto: string;
+  condicion: CondicionIva;
+  porcentaje: number;
+}
+
+export const OPCIONES_CONDICION_IVA: OpcionCondicionIva[] = [
+  { clave: 'gravado:21', label: '21%', labelCorto: '21%', condicion: 'gravado', porcentaje: 21 },
+  { clave: 'gravado:10.5', label: '10,5%', labelCorto: '10,5%', condicion: 'gravado', porcentaje: 10.5 },
+  { clave: 'exento', label: 'Exento', labelCorto: 'Exento', condicion: 'exento', porcentaje: 0 },
+  { clave: 'no_gravado', label: 'No gravado', labelCorto: 'No grav.', condicion: 'no_gravado', porcentaje: 0 },
+];
+
+/** Clave del selector para un par (condición, alícuota) cargado. */
+export function claveCondicionIva(
+  condicion: CondicionIva | null | undefined,
+  porcentaje: number | null | undefined,
+): string {
+  const cond = condicion ?? 'gravado';
+  return cond === 'gravado' ? `gravado:${porcentaje ?? 21}` : cond;
+}
+
+/** Opción correspondiente a una clave (undefined si es un par legacy). */
+export function opcionPorClave(clave: string): OpcionCondicionIva | undefined {
+  return OPCIONES_CONDICION_IVA.find(o => o.clave === clave);
+}
+
+/** Etiqueta legible de una clave; devuelve la clave si no la reconoce. */
+export function labelCondicionIva(clave: string): string {
+  return opcionPorClave(clave)?.label ?? clave;
+}

--- a/src/utils/notaCredito.test.ts
+++ b/src/utils/notaCredito.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest'
+import { calcularTotalesNotaCredito } from './notaCredito'
+
+// mig 177: hasta acá la NC liquidaba `subtotal * 0.21` fijo. Contra una factura
+// mixta eso inventa crédito fiscal sobre líneas que el proveedor nunca gravó.
+
+const factura = [
+  { producto_id: '1', cantidad: 10, costo_unitario: 1000, porcentaje_iva: 21 },
+  { producto_id: '2', cantidad: 10, costo_unitario: 500, porcentaje_iva: 10.5 },
+  { producto_id: '3', cantidad: 4, costo_unitario: 250, porcentaje_iva: 0, condicion_iva: 'exento' as const },
+  { producto_id: '4', cantidad: 2, costo_unitario: 300, porcentaje_iva: 0, condicion_iva: 'no_gravado' as const },
+]
+
+describe('calcularTotalesNotaCredito', () => {
+  it('usa la alícuota de cada línea, no un 21% fijo', () => {
+    const t = calcularTotalesNotaCredito(factura, { '1': 2, '2': 4 })
+    expect(t.subtotal).toBeCloseTo(2 * 1000 + 4 * 500, 2) // 4000
+    expect(t.iva).toBeCloseTo(2000 * 0.21 + 2000 * 0.105, 2) // 630, no 840
+    expect(t.total).toBeCloseTo(4630, 2)
+  })
+
+  it('acreditar una línea exenta no genera IVA', () => {
+    const t = calcularTotalesNotaCredito(factura, { '3': 4 })
+    expect(t.subtotal).toBeCloseTo(1000, 2)
+    expect(t.iva).toBe(0)
+    expect(t.total).toBeCloseTo(1000, 2)
+  })
+
+  it('ni una no gravada', () => {
+    const t = calcularTotalesNotaCredito(factura, { '4': 2 })
+    expect(t.iva).toBe(0)
+    expect(t.total).toBeCloseTo(600, 2)
+  })
+
+  it('mezcla gravado con no gravado en la misma nota', () => {
+    const t = calcularTotalesNotaCredito(factura, { '1': 1, '3': 1 })
+    expect(t.subtotal).toBeCloseTo(1250, 2)
+    expect(t.iva).toBeCloseTo(1000 * 0.21, 2) // sólo la línea gravada
+    expect(t.itemsConCantidad).toHaveLength(2)
+  })
+
+  it('sólo entran las líneas con cantidad > 0', () => {
+    const t = calcularTotalesNotaCredito(factura, { '1': 0, '2': 3 })
+    expect(t.itemsConCantidad).toHaveLength(1)
+    expect(t.itemsConCantidad[0].productoId).toBe('2')
+  })
+
+  it('una línea vieja sin snapshot fiscal cae a 21% gravado (compat pre-mig 113)', () => {
+    const t = calcularTotalesNotaCredito(
+      [{ producto_id: '9', cantidad: 1, costo_unitario: 1000 }], { '9': 1 })
+    expect(t.iva).toBeCloseTo(210, 2)
+  })
+})

--- a/src/utils/notaCredito.ts
+++ b/src/utils/notaCredito.ts
@@ -1,0 +1,64 @@
+/**
+ * Totales de una nota de crédito de compra.
+ *
+ * Vive fuera del modal por dos razones: es lógica pura y testeable, y
+ * exportarla desde el componente rompe el fast refresh.
+ */
+import type { CondicionIva } from './calculations';
+
+/** Línea de la factura original, con lo mínimo para liquidar el IVA de la NC. */
+export interface LineaCompraNC {
+  producto_id: string;
+  cantidad: number;
+  costo_unitario: number;
+  /** Snapshots fiscales de la línea original (mig 113/177) */
+  porcentaje_iva?: number | null;
+  condicion_iva?: CondicionIva | null;
+}
+
+export interface TotalesNotaCredito {
+  subtotal: number;
+  iva: number;
+  total: number;
+  itemsConCantidad: Array<{
+    productoId: string;
+    cantidad: number;
+    costoUnitario: number;
+    subtotal: number;
+  }>;
+}
+
+/**
+ * El IVA sale de la alícuota que tenía CADA línea en la factura original, no de
+ * un 21% fijo (como hasta la mig 177): contra una factura mixta, acreditar 21%
+ * sobre una línea exenta inventa crédito fiscal que el proveedor nunca facturó.
+ *
+ * Nota: la base es `costo_unitario` (bruto, pre-bonificación), igual que antes.
+ * Ese criterio es preexistente y queda sin cambios acá.
+ */
+export function calcularTotalesNotaCredito(
+  items: LineaCompraNC[],
+  cantidades: Record<string, number>,
+): TotalesNotaCredito {
+  let subtotal = 0;
+  let iva = 0;
+  const itemsConCantidad: TotalesNotaCredito['itemsConCantidad'] = [];
+
+  for (const item of items) {
+    const cant = cantidades[item.producto_id] || 0;
+    if (cant <= 0) continue;
+    const itemSub = cant * item.costo_unitario;
+    subtotal += itemSub;
+    if ((item.condicion_iva ?? 'gravado') === 'gravado') {
+      iva += itemSub * ((item.porcentaje_iva ?? 21) / 100);
+    }
+    itemsConCantidad.push({
+      productoId: item.producto_id,
+      cantidad: cant,
+      costoUnitario: item.costo_unitario,
+      subtotal: itemSub,
+    });
+  }
+
+  return { subtotal, iva, total: subtotal + iva, itemsConCantidad };
+}


### PR DESCRIPTION
## Qué resuelve

El gerente necesita registrar **una sola factura de proveedor** que mezcle productos gravados y no gravados, con distintas alícuotas.

Hoy no puede: los 247 productos de prod están **todos en 21%** y en el alta de compra la alícuota es texto de sólo lectura — para cambiarla hay que registrar la compra y recién después editarla. Además *no gravado* y *0% gravado* eran indistinguibles.

La mitad ya estaba construida: desde la mig 113 `compra_items.porcentaje_iva` es un snapshot por línea, el RPC ya lo lee del jsonb y `calcularTotalesCompra` ya acumulaba el IVA línea a línea.

## Migración 177 (ya aplicada a prod)

`condicion_iva` (`gravado` | `exento` | `no_gravado`) en `productos` y `compra_items`, más `origen_condicion_iva` en `movimiento_sucursal_items`. `DEFAULT 'gravado'` backfillea correcto: las 506 líneas históricas son todas gravadas.

El CHECK de coherencia es **unidireccional** a propósito (`condicion = 'gravado' OR porcentaje_iva = 0`): las 29 líneas ZZ de prod son `('gravado', 0)` legítimas y un CHECK bidireccional fallaría en el momento de crearse.

Los 6 RPCs (`registrar_compra_completa`, `actualizar_compra_items`, `cambiar_proveedor_compra`, `crear`/`aceptar`/`editar_movimiento_sucursal`) se parchean **leyendo el catálogo** en vez de hardcodear cuerpos, exigiendo que cada ancla aparezca exactamente una vez: si el cuerpo derivó, la migración falla en vez de aplicar un parche parcial. Cada bloque es idempotente.

**Ninguna firma cambia**: `condicion_iva` viaja dentro del jsonb `p_items`. No se crean sobrecargas ambiguas (`PGRST203`, ver mig 176) y una pestaña vieja del PWA sigue funcionando igual — el RPC normaliza lo que no reconoce a `gravado`, nunca rechaza.

## Decisiones que no se ven en el código

- **`compras.subtotal` NO cambia de semántica.** Sigue siendo el neto de *todas* las líneas. Estrecharlo a "sólo gravado" pondría en rojo el check `COMPRA-A2` de `auditoria_integridad` para toda factura mixta. El neto gravado queda derivable exacto desde `compra_items`.
- **`compras.no_gravado` (cabecera) queda como está**: es para conceptos *sin* línea de producto (pallets, envases). No se mezcla con las líneas no gravadas.
- **La condición de la línea NO se propaga al maestro**, a diferencia de los impuestos internos. La venta hereda `productos.porcentaje_iva`, así que un typo en una compra cambiaría el IVA de todas las ventas futuras de ese producto. Sólo muestra un badge ámbar.
- **Lado venta: cero código.** Un producto exento queda con alícuota 0 y toda la cadena de pedidos ya usaba `?? 21`, así que el 0 se propaga solo.

## Front

Un solo selector por línea con las 4 condiciones (21% / 10,5% / Exento / No gravado) en el alta y en la edición, sembrado desde la ficha del producto. El panel "Control contra factura" se abre por alícuota — con una factura mixta la fila "Gravado" sola ya no alcanza para cuadrar contra el papel.

Las opciones viven en `src/utils/condicionIva.ts`, único módulo puro: antes había dos listas (ficha de producto y compra) que podían divergir.

### Bugs vivos que arrastraba el cambio

Ya estaban rotos hoy, porque la ficha ofrecía "0% (Exento)", pero nadie los vio porque ningún producto usaba otra cosa que 21%:

- `ModalCompra.tsx:105` — `scanItem.iva || 21` convertía un 0 legítimo del escaneo n8n en 21.
- `ModalProducto.tsx:794` — decía "El precio final incluye IVA (21%)" en un producto exento.
- `ModalProducto.tsx:810` — `Number(porcentaje_iva) || 21` hacía que `ProductoCondicionesMayoristas` **dividiera el precio mayorista por 1,21**, dejando el margen neto de cada escala ~21 puntos por debajo del real. Éste era el más peligroso: no rompía nada, sólo mentía.

La nota de crédito dejó de liquidar `subtotal * 0.21` fijo y usa la alícuota de cada línea original; el cálculo se extrajo a `src/utils/notaCredito.ts` para poder testearlo.

## Verificación

- **1102 tests** en verde (81 archivos), typecheck y lint limpios, `npm run build` OK.
- **Post-migración en prod, nada se movió**: `compra_items` quedó en (gravado, 21)=115, (gravado, 0)=29, (gravado, NULL)=362 y `productos` en gravado/21=247.
- **`auditoria_integridad` idéntico** al snapshot previo (3 high en rojo, los mismos de antes; ningún check nuevo).
- **Alineación de los INSERT parcheados verificada** columna por valor en las 6 funciones — es lo único que un parche de cuerpo no valida al crearse.
- **Normalización probada con 7 payloads aislados** (sin tocar datos): pestaña vieja sin el campo → idéntico a hoy; basura en el campo → `gravado`; condición incoherente → tasa forzada a 0, pasa el CHECK; ZZ → ignora la condición.

Sobre la reconciliación IVA cabecera vs líneas: hay 51 compras que no cuadran, pero **las 51 son por líneas anteriores a la mig 113** con la alícuota en NULL. Entre las que tienen snapshot completo, cero descuadres.

## Fuera de alcance

- **Apertura por alícuota en `posicion_fiscal`** (mig 121): diferida por decisión del usuario. `fc_neto = SUM(compras.subtotal)` pasa a ser "neto de líneas" y no "neto gravado" estricto — queda anotado en el `COMMENT` junto con la fórmula de derivación, así que no va a requerir backfill cuando se haga el libro IVA.
- **`COMPRA-A1` está en rojo hoy** con 10 violaciones: su fórmula quedó vieja tras las migs 113/114 (le faltan percepciones, imp. internos y no gravado). Es preexistente y ajeno a este cambio; se puede arreglar en 3 líneas si se quiere, en una migración aparte.
- **27% de IVA**: no se incluye porque no aparece en las facturas que carga. Agregarlo después es una línea en `OPCIONES_CONDICION_IVA`, sin migración.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
