### PR TITLE
Al editar una compra el IVA se ve también en el teléfono

### DIFF
--- a/src/components/containers/ComprasContainer.tsx
+++ b/src/components/containers/ComprasContainer.tsx
@@ -3,7 +3,7 @@
  *
  * Container que carga compras y proveedores bajo demanda usando TanStack Query.
  */
-import React, { lazy, Suspense, useState, useCallback } from 'react'
+import React, { Suspense, useState, useCallback } from 'react'
 import { Loader2 } from 'lucide-react'
 import {
   useComprasQuery,
@@ -25,16 +25,21 @@ import type { CambiarProveedorPayload } from '../modals/ModalCambiarProveedor'
 import { useAuthData } from '../../contexts/AuthDataContext'
 import { useNotification } from '../../contexts/NotificationContext'
 import { useResetOnSucursalChange } from '../../hooks/useResetOnSucursalChange'
+import { lazyWithReload } from '../../utils/lazyWithReload'
 import type { CompraDBExtended, CompraFormInputExtended, ProveedorFormInputExtended, NotaCreditoFormInput } from '../../types'
 
-// Lazy load de componentes
-const VistaCompras = lazy(() => import('../vistas/VistaCompras'))
-const ModalCompra = lazy(() => import('../modals/ModalCompra'))
-const ModalDetalleCompra = lazy(() => import('../modals/ModalDetalleCompra'))
-const ModalNotaCredito = lazy(() => import('../modals/ModalNotaCredito'))
-const ModalEditarCompra = lazy(() => import('../modals/ModalEditarCompra'))
-const ModalCambiarProveedor = lazy(() => import('../modals/ModalCambiarProveedor'))
-const ModalConfirmacion = lazy(() => import('../modals/ModalConfirmacion'))
+// Lazy load de componentes.
+// lazyWithReload y no lazy pelado (igual que App y PedidosContainer): el SW usa
+// skipWaiting + clientsClaim, así que tras un deploy una pestaña abierta sigue
+// pidiendo chunks con el hash viejo. Cada modal es su propio chunk, de modo que
+// se puede quedar con uno viejo (ej. el de editar) mientras otro ya es nuevo.
+const VistaCompras = lazyWithReload(() => import('../vistas/VistaCompras'))
+const ModalCompra = lazyWithReload(() => import('../modals/ModalCompra'))
+const ModalDetalleCompra = lazyWithReload(() => import('../modals/ModalDetalleCompra'))
+const ModalNotaCredito = lazyWithReload(() => import('../modals/ModalNotaCredito'))
+const ModalEditarCompra = lazyWithReload(() => import('../modals/ModalEditarCompra'))
+const ModalCambiarProveedor = lazyWithReload(() => import('../modals/ModalCambiarProveedor'))
+const ModalConfirmacion = lazyWithReload(() => import('../modals/ModalConfirmacion'))
 
 function LoadingState() {
   return (

--- a/src/components/modals/ModalEditarCompra.cambiarProveedor.test.jsx
+++ b/src/components/modals/ModalEditarCompra.cambiarProveedor.test.jsx
@@ -57,7 +57,8 @@ describe('ModalEditarCompra · botón "Cambiar proveedor"', () => {
     render(<ModalEditarCompra {...adminProps} />)
     expect(screen.getByRole('button', { name: /Cambiar proveedor/i })).toBeEnabled()
     // marcar el item para eliminar => hay cambios sin guardar
-    await user.click(screen.getByTitle('Eliminar item'))
+    // Hay uno por layout (tarjeta mobile + tabla desktop); da igual cuál.
+    await user.click(screen.getAllByTitle('Eliminar item')[0])
     expect(screen.getByRole('button', { name: /Cambiar proveedor/i })).toBeDisabled()
   })
 })

--- a/src/components/modals/ModalEditarCompra.condicionIva.test.jsx
+++ b/src/components/modals/ModalEditarCompra.condicionIva.test.jsx
@@ -1,0 +1,110 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+vi.mock('../../utils/formatters', () => ({
+  formatPrecio: (value) => `$${Number(value).toFixed(2)}`,
+}))
+
+import ModalEditarCompra from './ModalEditarCompra'
+
+// mig 177: la condición de IVA también se edita línea por línea al modificar
+// una compra ya registrada, no sólo al cargarla.
+
+const compraBase = (overrides = {}) => ({
+  id: 133,
+  estado: 'recibida',
+  tipo_factura: 'FC',
+  proveedor: { id: 6, nombre: 'Proveedor' },
+  numero_factura: '0001-1',
+  fecha_compra: '2026-07-12',
+  total: 1210,
+  otros_impuestos: 0,
+  percepcion_iva: 0,
+  percepcion_iibb: 0,
+  no_gravado: 0,
+  items: [
+    {
+      producto_id: 1,
+      cantidad: 10,
+      costo_unitario: 100,
+      bonificacion: 0,
+      porcentaje_iva: 21,
+      condicion_iva: 'gravado',
+      impuestos_internos: 0,
+      producto: { nombre: 'Prod 1' },
+    },
+  ],
+  ...overrides,
+})
+
+const props = (compra, onGuardar = vi.fn()) => ({
+  compra, usuarioId: 'u1', onGuardar, onClose: vi.fn(), guardando: false,
+})
+
+/** El <select> de condición de la única línea. */
+const selectorIva = () => screen.getByRole('combobox')
+
+describe('ModalEditarCompra · condición de IVA por línea', () => {
+  it('ofrece las cuatro condiciones y arranca en la de la línea', () => {
+    render(<ModalEditarCompra {...props(compraBase())} />)
+    expect(selectorIva()).toHaveValue('gravado:21')
+    const labels = screen.getAllByRole('option').map(o => o.textContent)
+    expect(labels).toEqual(['21%', '10,5%', 'Exento', 'No gravado'])
+  })
+
+  it('cambiar a 10,5% recalcula el IVA del resumen', async () => {
+    const user = userEvent.setup()
+    render(<ModalEditarCompra {...props(compraBase())} />)
+    expect(screen.getByText('$210.00')).toBeInTheDocument() // 1000 × 21%
+
+    await user.selectOptions(selectorIva(), 'gravado:10.5')
+
+    expect(screen.getByText('$105.00')).toBeInTheDocument() // 1000 × 10,5%
+    expect(screen.queryByText('$210.00')).not.toBeInTheDocument()
+  })
+
+  it('pasar a no gravado deja el IVA en cero sin tocar el neto', async () => {
+    const user = userEvent.setup()
+    render(<ModalEditarCompra {...props(compraBase())} />)
+
+    await user.selectOptions(selectorIva(), 'no_gravado')
+
+    expect(selectorIva()).toHaveValue('no_gravado')
+    expect(screen.getByText('$0.00')).toBeInTheDocument() // IVA
+    // El neto no se mueve: aparece como subtotal de la línea, subtotal y total.
+    expect(screen.getAllByText('$1000.00').length).toBeGreaterThanOrEqual(2)
+    expect(screen.queryByText('$210.00')).not.toBeInTheDocument()
+  })
+
+  it('el payload que se guarda lleva la condición y la alícuota coherentes', async () => {
+    const user = userEvent.setup()
+    const onGuardar = vi.fn().mockResolvedValue(undefined)
+    render(<ModalEditarCompra {...props(compraBase(), onGuardar)} />)
+
+    await user.selectOptions(selectorIva(), 'exento')
+    await user.click(screen.getByRole('button', { name: /guardar/i }))
+
+    expect(onGuardar).toHaveBeenCalledTimes(1)
+    const enviado = onGuardar.mock.calls[0][0]
+    expect(enviado.items[0]).toMatchObject({ condicionIva: 'exento', porcentajeIva: 0 })
+    expect(enviado.iva).toBe(0)
+    expect(enviado.subtotal).toBe(1000)
+  })
+
+  it('una línea vieja sin snapshot cae a la condición de la ficha del producto', () => {
+    const compra = compraBase({
+      items: [{
+        producto_id: 1, cantidad: 10, costo_unitario: 100, bonificacion: 0,
+        producto: { nombre: 'Prod 1', porcentaje_iva: 10.5, condicion_iva: 'gravado' },
+      }],
+    })
+    render(<ModalEditarCompra {...props(compra)} />)
+    expect(selectorIva()).toHaveValue('gravado:10.5')
+  })
+
+  it('en ZZ no hay condición que elegir: sin factura no se discrimina', () => {
+    render(<ModalEditarCompra {...props(compraBase({ tipo_factura: 'ZZ' }))} />)
+    expect(screen.queryByRole('combobox')).not.toBeInTheDocument()
+  })
+})

--- a/src/components/modals/ModalEditarCompra.condicionIva.test.jsx
+++ b/src/components/modals/ModalEditarCompra.condicionIva.test.jsx
@@ -42,15 +42,44 @@ const props = (compra, onGuardar = vi.fn()) => ({
   compra, usuarioId: 'u1', onGuardar, onClose: vi.fn(), guardando: false,
 })
 
-/** El <select> de condición de la única línea. */
-const selectorIva = () => screen.getByRole('combobox')
+/**
+ * El <select> de condición de la única línea.
+ * Hay DOS en el DOM — tarjeta (mobile) y tabla (desktop) — y CSS decide cuál se
+ * ve. En jsdom no hay media queries, así que se toma el primero: alcanza para
+ * verificar comportamiento, y `ambosLayouts` cubre que estén los dos.
+ */
+const selectorIva = () => screen.getAllByRole('combobox')[0]
+const ambosLayouts = () => screen.getAllByRole('combobox')
 
 describe('ModalEditarCompra · condición de IVA por línea', () => {
   it('ofrece las cuatro condiciones y arranca en la de la línea', () => {
     render(<ModalEditarCompra {...props(compraBase())} />)
     expect(selectorIva()).toHaveValue('gravado:21')
-    const labels = screen.getAllByRole('option').map(o => o.textContent)
+    const labels = [...selectorIva().options].map(o => o.textContent)
     expect(labels).toEqual(['21%', '10,5%', 'Exento', 'No gravado'])
+  })
+
+  // La tabla tiene 600px de columnas fijas dentro de un overflow-x-auto: en un
+  // teléfono el IVA quedaba fuera de pantalla y parecía que no existía.
+  it('el selector está en los dos layouts, tarjeta y tabla', () => {
+    render(<ModalEditarCompra {...props(compraBase())} />)
+    const [tarjeta, tabla] = ambosLayouts()
+    expect(ambosLayouts()).toHaveLength(2)
+    // `closest` en vez de querySelector sobre el container: el modal va en un
+    // portal, así que no cuelga del nodo que devuelve render().
+    expect(tarjeta.closest('.md\\:hidden')).not.toBeNull()
+    expect(tabla.closest('.md\\:block')).not.toBeNull()
+  })
+
+  it('editar en un layout se refleja en el otro: es el mismo estado', async () => {
+    const user = userEvent.setup()
+    render(<ModalEditarCompra {...props(compraBase())} />)
+    const [tarjeta, tabla] = ambosLayouts()
+
+    await user.selectOptions(tarjeta, 'exento')
+
+    expect(tarjeta).toHaveValue('exento')
+    expect(tabla).toHaveValue('exento')
   })
 
   it('cambiar a 10,5% recalcula el IVA del resumen', async () => {

--- a/src/components/modals/ModalEditarCompra.tsx
+++ b/src/components/modals/ModalEditarCompra.tsx
@@ -170,6 +170,31 @@ const ModalEditarCompra = memo(function ModalEditarCompra({
     )
   }
 
+  /** Selector de condición de la línea; se usa igual en la tarjeta y en la tabla. */
+  function selectorCondicion(it: ItemEdit) {
+    const clave = claveCondicion(it)
+    return (
+      <select
+        value={clave}
+        onChange={(e) => updateCondicion(it.productoId, e.target.value)}
+        disabled={it.marcadoParaEliminar}
+        aria-label={`Condición de IVA de ${it.nombre}`}
+        className="w-full px-2 py-1 border rounded dark:bg-gray-700 dark:border-gray-600 dark:text-white disabled:opacity-50"
+      >
+        {/* Un par legacy fuera de la lista se muestra tal cual en vez de dejar
+            el select mintiendo sobre el valor guardado. */}
+        {!OPCIONES_CONDICION_IVA.some((o) => o.clave === clave) && (
+          <option value={clave}>{it.porcentajeIva}%</option>
+        )}
+        {OPCIONES_CONDICION_IVA.map((o) => (
+          <option key={o.clave} value={o.clave}>
+            {o.label}
+          </option>
+        ))}
+      </select>
+    )
+  }
+
   function toggleEliminar(productoId: string) {
     setItems((prev) =>
       prev.map((it) =>
@@ -293,8 +318,95 @@ const ModalEditarCompra = memo(function ModalEditarCompra({
           </div>
         )}
 
-        {/* Tabla de items */}
-        <div className="overflow-x-auto">
+        {/* Items · MOBILE: tarjetas.
+            La tabla de abajo tiene 600px de columnas fijas dentro de un
+            overflow-x-auto, así que en un teléfono las últimas (IVA, subtotal,
+            borrar) quedan fuera de pantalla detrás de un scroll horizontal que
+            nadie descubre. Es el mismo patrón de tarjetas que usa ModalCompra. */}
+        <div className="md:hidden space-y-3">
+          {items.map((it) => {
+            const neto = it.costoUnitario * (1 - it.bonificacion / 100)
+            const subtotalItem = it.cantidad * neto
+            return (
+              <div
+                key={it.productoId}
+                className={`rounded-lg border p-3 dark:border-gray-600 ${
+                  it.marcadoParaEliminar ? 'opacity-40 line-through' : ''
+                }`}
+              >
+                <div className="flex items-start justify-between gap-2">
+                  <p className="font-medium dark:text-gray-200">{it.nombre}</p>
+                  {/* min-h-11/min-w-11: mismo target táctil que los botones de
+                      VistaCompras en mobile (con p-1 quedaba en ~24px). */}
+                  <button
+                    type="button"
+                    onClick={() => toggleEliminar(it.productoId)}
+                    title={it.marcadoParaEliminar ? 'Restaurar item' : 'Eliminar item'}
+                    aria-label={it.marcadoParaEliminar ? 'Restaurar item' : 'Eliminar item'}
+                    className="shrink-0 min-h-11 min-w-11 flex items-center justify-center text-red-600 hover:text-red-800 dark:text-red-400 dark:hover:text-red-300"
+                  >
+                    <Trash2 className="w-4 h-4" />
+                  </button>
+                </div>
+                <div className="mt-3 grid grid-cols-2 gap-2">
+                  <div>
+                    <label className="block text-xs text-gray-500 mb-1">Cantidad</label>
+                    <NumberInput
+                      integer
+                      min={1}
+                      emptyValue={1}
+                      value={it.cantidad}
+                      onChange={(n) => updateItem(it.productoId, 'cantidad', n)}
+                      commitOnChange
+                      disabled={it.marcadoParaEliminar}
+                      className="w-full px-2 py-1 text-right border rounded dark:bg-gray-700 dark:border-gray-600 dark:text-white disabled:opacity-50"
+                    />
+                  </div>
+                  <div>
+                    <label className="block text-xs text-gray-500 mb-1">Costo unit.</label>
+                    <NumberInput
+                      min={0}
+                      emptyValue={0}
+                      value={it.costoUnitario}
+                      onChange={(n) => updateItem(it.productoId, 'costoUnitario', n)}
+                      commitOnChange
+                      disabled={it.marcadoParaEliminar}
+                      className="w-full px-2 py-1 text-right border rounded dark:bg-gray-700 dark:border-gray-600 dark:text-white disabled:opacity-50"
+                    />
+                  </div>
+                  <div>
+                    <label className="block text-xs text-gray-500 mb-1">Bonif. %</label>
+                    <NumberInput
+                      min={0}
+                      max={99.99}
+                      emptyValue={0}
+                      value={it.bonificacion}
+                      onChange={(n) => updateItem(it.productoId, 'bonificacion', n)}
+                      commitOnChange
+                      disabled={it.marcadoParaEliminar}
+                      className="w-full px-2 py-1 text-right border rounded dark:bg-gray-700 dark:border-gray-600 dark:text-white disabled:opacity-50"
+                    />
+                  </div>
+                  {!esZZ && (
+                    <div>
+                      <label className="block text-xs text-gray-500 mb-1">IVA</label>
+                      {selectorCondicion(it)}
+                    </div>
+                  )}
+                </div>
+                <div className="mt-3 flex justify-between border-t pt-2 text-sm dark:border-gray-600">
+                  <span className="text-gray-500">Subtotal:</span>
+                  <span className="font-semibold tabular-nums dark:text-gray-200">
+                    {formatPrecio(subtotalItem)}
+                  </span>
+                </div>
+              </div>
+            )
+          })}
+        </div>
+
+        {/* Items · DESKTOP: tabla */}
+        <div className="hidden md:block overflow-x-auto">
           <table className="w-full text-sm">
             <thead>
               <tr className="text-xs text-gray-500 dark:text-gray-400 border-b dark:border-gray-700">
@@ -352,25 +464,7 @@ const ModalEditarCompra = memo(function ModalEditarCompra({
                         className="w-full px-2 py-1 text-right border rounded dark:bg-gray-700 dark:border-gray-600 dark:text-white disabled:opacity-50"
                       />
                     </td>
-                    {!esZZ && (
-                      <td className="py-2 px-2">
-                        <select
-                          value={claveCondicion(it)}
-                          onChange={(e) => updateCondicion(it.productoId, e.target.value)}
-                          disabled={it.marcadoParaEliminar}
-                          className="w-full px-2 py-1 border rounded dark:bg-gray-700 dark:border-gray-600 dark:text-white disabled:opacity-50"
-                        >
-                          {/* Un par legacy fuera de la lista se muestra tal cual
-                              en vez de dejar el select mintiendo. */}
-                          {!OPCIONES_CONDICION_IVA.some(o => o.clave === claveCondicion(it)) && (
-                            <option value={claveCondicion(it)}>{it.porcentajeIva}%</option>
-                          )}
-                          {OPCIONES_CONDICION_IVA.map(o => (
-                            <option key={o.clave} value={o.clave}>{o.label}</option>
-                          ))}
-                        </select>
-                      </td>
-                    )}
+                    {!esZZ && <td className="py-2 px-2">{selectorCondicion(it)}</td>}
                     <td className="py-2 px-2 text-right tabular-nums dark:text-gray-200">
                       {formatPrecio(subtotalItem)}
                     </td>

--- a/src/utils/lazyWithReload.ts
+++ b/src/utils/lazyWithReload.ts
@@ -37,7 +37,11 @@ function recargarUnaVezPorChunk(): boolean {
   return false
 }
 
-export function lazyWithReload<T extends ComponentType<unknown>>(
+// El genérico espeja el de React.lazy (`ComponentType<any>`): con
+// `ComponentType<unknown>` no entran los componentes con props requeridas, que
+// es la mayoría de los modales. Es un ensanchamiento puro, ningún call site
+// existente cambia de tipo.
+export function lazyWithReload<T extends ComponentType<any>>(
   factory: () => Promise<{ default: T }>,
 ): LazyExoticComponent<T> {
   return lazy(async () => {


### PR DESCRIPTION
## El problema reportado

> "Existe cuando creo una compra, pero no lo veo al editar / apretar lapicito"

El selector de condición de IVA por línea ya estaba en `ModalEditarCompra` desde el PR #460. Era inalcanzable en la práctica por **dos motivos independientes**, ninguno relacionado con el IVA:

### 1. Era el único modal de compras sin layout mobile

`ModalEditarCompra` renderiza una `<table>` de 7 columnas con ~600px de anchos fijos (`w-24`, `w-32`, `w-24`, `w-28`, `w-32`, `w-12`) dentro de un `overflow-x-auto`. En un teléfono las últimas columnas — **IVA, Subtotal y el botón de borrar** — quedan fuera de pantalla, detrás de un scroll horizontal que nadie descubre.

`ModalCompra` (el de alta) sí tiene tarjetas `md:hidden`, y por eso **al crear sí se veía**. Se le agrega el mismo patrón: tarjetas en mobile, tabla en desktop. El selector se extrae a un helper (`selectorCondicion`) para que ambos layouts compartan estado y marcado sin duplicar el markup.

### 2. `ComprasContainer` no tenía la guarda contra chunks viejos

Declaraba sus 7 modales con `lazy()` pelado, mientras `App.tsx` y `PedidosContainer` ya usan `lazyWithReload`. Cada modal es su propio chunk, así que una pestaña abierta puede quedarse con el chunk viejo de *editar* mientras el de *crear* ya es nuevo — que es exactamente el síntoma reportado.

Al pasarlo a `lazyWithReload` apareció **por qué nadie lo había usado ahí**: el genérico era `ComponentType<unknown>`, que rechaza cualquier componente con props requeridas (o sea, casi todos los modales). Ahora espeja la firma de React (`ComponentType<any>`). Es un ensanchamiento puro: ningún call site existente cambia de tipo.

## Tests

Regresión nueva sobre el modal de edición, que antes sólo tenía cobertura del botón de cambiar proveedor:

- El selector ofrece las cuatro condiciones y arranca en la de la línea.
- Cambiar de 21% a 10,5% recalcula el IVA del resumen ($210 → $105).
- *No gravado* deja el IVA en cero **sin mover el neto**.
- El payload sale coherente: `condicionIva: 'exento'` con `porcentajeIva: 0` e `iva: 0` — lo que exige el CHECK cruzado de la mig 177.
- Una línea anterior a la mig 113 cae a la condición de la ficha del producto.
- **El selector está en los dos layouts** y editarlo en uno se refleja en el otro (es el mismo estado).
- En ZZ no se renderiza selector.

`ModalEditarCompra.cambiarProveedor.test.jsx` pasa a `getAllByTitle(...)[0]`: ahora hay un botón de borrar por layout.

## Verificación

1110 tests en verde (82 archivos), typecheck y lint limpios, `npm run build` OK.

Sin cambios de schema ni de RPC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
