### PR TITLE
Armar ruta: mostrar por que fecha entro cada pedido

### DIFF
--- a/src/components/modals/ModalGestionRutas.tsx
+++ b/src/components/modals/ModalGestionRutas.tsx
@@ -15,6 +15,7 @@ import { horarioParaRutear } from '../../hooks/useOptimizarRuta';
 import { abreEnDia, clasificarBarrida, encajeEnHorario, ETIQUETA_BARRIDA } from '../../utils/barridas';
 import type { EncajeHorario } from '../../utils/barridas';
 import { fechaLocalISO, fechaHaceDias, formatFecha } from '../../utils/formatters';
+import { fechaQueFiltra, pedidoEnRangoDeFechas } from '../../utils/filtroFechaPedidos';
 import type { PedidoDB, PerfilDB, ClienteDB, ProductoDB } from '../../types';
 
 // Normaliza para búsquedas: saca acentos y pasa a minúsculas.
@@ -407,15 +408,9 @@ const ModalGestionRutas = memo(function ModalGestionRutas({
   const disponiblesFiltrados = useMemo((): PedidoDB[] => {
     return pedidos.filter(p => {
       if (!filtroActivo) return true;
-      // Columna según el modo: 'entrega' usa fecha_entrega_programada con fallback
-      // a la fecha de pedido; 'pedido' usa fecha.
-      const f = filtroTipoFecha === 'entrega'
-        ? (p.fecha_entrega_programada || p.fecha || null)
-        : (p.fecha || null);
-      if (!f) return true; // sin fecha conocida: incluir antes que ocultar
-      if (filtroDesde && f < filtroDesde) return false;
-      if (filtroHasta && f > filtroHasta) return false;
-      return true;
+      // Misma regla que usa el resaltado de cada fila, para que no puedan
+      // contradecirse (ver utils/filtroFechaPedidos).
+      return pedidoEnRangoDeFechas(p, filtroTipoFecha, filtroDesde, filtroHasta);
     });
   }, [pedidos, filtroActivo, filtroDesde, filtroHasta, filtroTipoFecha]);
 
@@ -1286,9 +1281,22 @@ const ModalGestionRutas = memo(function ModalGestionRutas({
                   {pedidosVisibles.length > 0 ? (
                     <div className="bg-white border rounded-lg">
                       <div className="p-3 border-b bg-gray-50 flex items-center justify-between">
-                        <h3 className="font-medium text-gray-700">
-                          Pedidos del día ({pedidosSeleccionados.length}/{pedidosVisibles.length})
-                        </h3>
+                        <div>
+                          <h3 className="font-medium text-gray-700">
+                            Pedidos del día ({pedidosSeleccionados.length}/{pedidosVisibles.length})
+                          </h3>
+                          {/* El filtro está arriba de todo; al mirar la lista ya
+                              no se ve por cuál de las dos fechas se filtró. */}
+                          {filtroActivo && (
+                            <p className="text-xs text-gray-500 mt-0.5">
+                              Filtrando por{' '}
+                              <span className="font-semibold text-blue-600">
+                                {filtroTipoFecha === 'entrega' ? 'fecha de entrega' : 'fecha de pedido'}
+                              </span>
+                              , resaltada en cada pedido
+                            </p>
+                          )}
+                        </div>
                         <label className="flex items-center gap-2 text-sm text-gray-600 cursor-pointer select-none">
                           <input type="checkbox" checked={todosSeleccionados} onChange={toggleTodos} className="rounded" />
                           Seleccionar todos
@@ -1312,6 +1320,13 @@ const ModalGestionRutas = memo(function ModalGestionRutas({
                         ) : pedidosVisiblesFiltrados.map((pedido) => {
                           const checked = seleccionados.has(pedido.id);
                           const enRuta = idsExistentes.has(pedido.id);
+                          // Con filtro puesto, se marca cuál de las dos fechas
+                          // lo trajo. Sin esto la fila muestra las dos iguales y
+                          // un pedido de ayer entregable hoy parece un error.
+                          const columnaFiltrada = filtroActivo
+                            ? fechaQueFiltra(pedido, filtroTipoFecha).columna
+                            : null;
+                          const resaltar = 'font-semibold text-blue-600';
                           return (
                             <label
                               key={pedido.id}
@@ -1333,7 +1348,21 @@ const ModalGestionRutas = memo(function ModalGestionRutas({
                                   )}
                                 </p>
                                 <p className="text-sm text-gray-500 truncate">{pedido.cliente?.direccion}</p>
-                                <p className="text-xs text-gray-400">Pedido: {pedido.fecha || '—'} · Entrega: {pedido.fecha_entrega_programada || '—'}</p>
+                                <p className="text-xs text-gray-400">
+                                  <span
+                                    className={columnaFiltrada === 'pedido' ? resaltar : undefined}
+                                    title={columnaFiltrada === 'pedido' ? 'Aparece por esta fecha' : undefined}
+                                  >
+                                    Pedido: {pedido.fecha || '—'}
+                                  </span>
+                                  {' · '}
+                                  <span
+                                    className={columnaFiltrada === 'entrega' ? resaltar : undefined}
+                                    title={columnaFiltrada === 'entrega' ? 'Aparece por esta fecha' : undefined}
+                                  >
+                                    Entrega: {pedido.fecha_entrega_programada || '—'}
+                                  </span>
+                                </p>
                               </div>
                               <div className="text-right ml-2">
                                 <p className="font-medium text-gray-900">${pedido.total?.toLocaleString('es-AR')}</p>

--- a/src/utils/filtroFechaPedidos.test.ts
+++ b/src/utils/filtroFechaPedidos.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest';
+import { fechaQueFiltra, pedidoEnRangoDeFechas } from './filtroFechaPedidos';
+
+// El caso real que motivó esto: cargado el sábado, movido a pedido=lunes y
+// entrega=martes. Filtrando "hoy martes" tiene que aparecer, y la fila tiene
+// que decir que apareció por la fecha de ENTREGA, no por la de pedido.
+const PEDIDO_REPROGRAMADO = { fecha: '2026-08-10', fecha_entrega_programada: '2026-08-11' };
+
+describe('fechaQueFiltra', () => {
+  it('en modo entrega manda la fecha de entrega programada', () => {
+    expect(fechaQueFiltra(PEDIDO_REPROGRAMADO, 'entrega'))
+      .toEqual({ columna: 'entrega', valor: '2026-08-11' });
+  });
+
+  it('en modo pedido manda la fecha de pedido', () => {
+    expect(fechaQueFiltra(PEDIDO_REPROGRAMADO, 'pedido'))
+      .toEqual({ columna: 'pedido', valor: '2026-08-10' });
+  });
+
+  it('sin fecha de entrega, el modo entrega cae a la de pedido y lo reporta', () => {
+    // Es el fallback que hacía que resaltar "entrega" fuera mentira.
+    expect(fechaQueFiltra({ fecha: '2026-08-10', fecha_entrega_programada: null }, 'entrega'))
+      .toEqual({ columna: 'pedido', valor: '2026-08-10' });
+  });
+
+  it('sin ninguna fecha no hay columna que resaltar', () => {
+    expect(fechaQueFiltra({ fecha: null, fecha_entrega_programada: null }, 'entrega'))
+      .toEqual({ columna: null, valor: null });
+    expect(fechaQueFiltra({}, 'pedido'))
+      .toEqual({ columna: null, valor: null });
+  });
+});
+
+describe('pedidoEnRangoDeFechas', () => {
+  it('el pedido reprogramado entra al filtrar el martes por entrega', () => {
+    expect(pedidoEnRangoDeFechas(PEDIDO_REPROGRAMADO, 'entrega', '2026-08-11', '2026-08-11')).toBe(true);
+  });
+
+  it('y NO entra al filtrar el martes por fecha de pedido', () => {
+    expect(pedidoEnRangoDeFechas(PEDIDO_REPROGRAMADO, 'pedido', '2026-08-11', '2026-08-11')).toBe(false);
+  });
+
+  it('entra al filtrar el lunes por fecha de pedido', () => {
+    expect(pedidoEnRangoDeFechas(PEDIDO_REPROGRAMADO, 'pedido', '2026-08-10', '2026-08-10')).toBe(true);
+  });
+
+  it('un pedido sin fechas se muestra igual, no se esconde', () => {
+    expect(pedidoEnRangoDeFechas({}, 'entrega', '2026-08-11', '2026-08-11')).toBe(true);
+  });
+
+  it('rango abierto de un lado', () => {
+    expect(pedidoEnRangoDeFechas(PEDIDO_REPROGRAMADO, 'entrega', '2026-08-01', '')).toBe(true);
+    expect(pedidoEnRangoDeFechas(PEDIDO_REPROGRAMADO, 'entrega', '', '2026-08-05')).toBe(false);
+  });
+
+  it('los bordes del rango son inclusivos', () => {
+    expect(pedidoEnRangoDeFechas(PEDIDO_REPROGRAMADO, 'entrega', '2026-08-11', '2026-08-20')).toBe(true);
+    expect(pedidoEnRangoDeFechas(PEDIDO_REPROGRAMADO, 'entrega', '2026-08-01', '2026-08-11')).toBe(true);
+  });
+});

--- a/src/utils/filtroFechaPedidos.ts
+++ b/src/utils/filtroFechaPedidos.ts
@@ -1,0 +1,68 @@
+/**
+ * Qué fecha gobierna el filtro del pool en "Armar ruta".
+ *
+ * El modal filtra los disponibles por fecha de pedido o por fecha de entrega, y
+ * cada fila muestra las dos. Una usuaria filtró por "hoy martes" y le
+ * aparecieron 7 pedidos que en la lista decían "Pedido: lunes": el filtro
+ * estaba en modo entrega -el default- y esos pedidos se entregaban hoy, así que
+ * correspondía que aparecieran. Sin ver cuál de las dos fechas manda, el
+ * resultado se lee como un bug.
+ *
+ * Esta función es la única fuente de esa regla: la usan tanto el filtro como el
+ * resaltado de la fila, así que no pueden decir cosas distintas.
+ */
+
+export type TipoFiltroFecha = 'pedido' | 'entrega';
+
+export interface PedidoConFechas {
+  fecha?: string | null;
+  fecha_entrega_programada?: string | null;
+}
+
+export interface FechaQueFiltra {
+  /** Columna realmente usada, ya resuelto el fallback. null = el pedido no tiene ninguna. */
+  columna: TipoFiltroFecha | null;
+  /** Valor YYYY-MM-DD contra el que se compara. null = sin fecha conocida. */
+  valor: string | null;
+}
+
+/**
+ * En modo 'entrega' la fecha de entrega programada puede faltar, y ahí el
+ * filtro cae a la fecha de pedido. Devolver la columna que se terminó usando
+ * -y no la que se pidió- es lo que permite resaltar la verdadera.
+ */
+export function fechaQueFiltra(
+  pedido: PedidoConFechas,
+  tipo: TipoFiltroFecha,
+): FechaQueFiltra {
+  if (tipo === 'entrega') {
+    if (pedido.fecha_entrega_programada) {
+      return { columna: 'entrega', valor: pedido.fecha_entrega_programada };
+    }
+    return pedido.fecha
+      ? { columna: 'pedido', valor: pedido.fecha }
+      : { columna: null, valor: null };
+  }
+
+  return pedido.fecha
+    ? { columna: 'pedido', valor: pedido.fecha }
+    : { columna: null, valor: null };
+}
+
+/**
+ * ¿Entra el pedido en el rango? Sin fecha conocida entra: es preferible
+ * mostrarlo de más y que lo descarte una persona, a esconderlo.
+ * `desde`/`hasta` vacíos no acotan ese extremo.
+ */
+export function pedidoEnRangoDeFechas(
+  pedido: PedidoConFechas,
+  tipo: TipoFiltroFecha,
+  desde: string,
+  hasta: string,
+): boolean {
+  const { valor } = fechaQueFiltra(pedido, tipo);
+  if (!valor) return true;
+  if (desde && valor < desde) return false;
+  if (hasta && valor > hasta) return false;
+  return true;
+}


### PR DESCRIPTION
## Qué pasó

Una usuaria filtró el pool de "Armar ruta" por **hoy martes** y le aparecieron 7 pedidos que en la lista decían **"Pedido: lunes"**. Lo reportó como un bug.

**No lo era.** El selector estaba en su valor por defecto, **Fecha de entrega**. Los 7 (#4631, #4633, #4637, #4638, #4639, #4648, #4649) se habían cargado el sábado y se reprogramaron a `fecha = lunes 10/08`, `fecha_entrega_programada = martes 11/08`. Aparecían porque se entregaban ese martes — que es exactamente lo que ella quería.

Verificado en prod: los 7 tienen `created_at = 2026-08-08`, `fecha = 2026-08-10`, `fecha_entrega_programada = 2026-08-11`. También descarté que fuera zona horaria: `fechaLocalISO()` usa `America/Argentina/Buenos_Aires` correctamente.

## El problema real

No había forma de darse cuenta. El selector de fecha está arriba de todo y la fila muestra las dos fechas con el mismo peso:

```
Pedido: 2026-08-10 · Entrega: 2026-08-11
```

Al mirar la lista, el resultado se lee como un error. Y la conclusión razonable de un usuario es "el filtro está roto", que es justo lo que pasó.

## Qué cambia

Con filtro puesto:
- **cada fila resalta la fecha que la trajo**;
- el encabezado de la lista aclara por cuál se está filtrando.

Sin filtro no se resalta nada, para no meter ruido.

## Una sola fuente para la regla

La lógica de qué columna manda salió a [`utils/filtroFechaPedidos`](../blob/main/src/utils/filtroFechaPedidos.ts), y la usan **tanto el filtro como el resaltado**. Si vivieran separadas podrían contradecirse, que es exactamente el problema que este PR arregla.

Eso además cubre el fallback que hacía el caso sutil: en modo entrega, un pedido sin `fecha_entrega_programada` se filtra por su **fecha de pedido**. Resaltar "Entrega" ahí habría sido mentira. La función devuelve la columna que se terminó usando, no la que se pidió.

## Verificación

- 10 tests nuevos sobre la función pura, incluido el caso real reproducido (entra filtrando el martes por entrega, no entra filtrando el martes por pedido) y el fallback sin fecha de entrega.
- `tsc`, `eslint`, build y suite completa: **1112/1112**.

**No lo vi renderizado**: el modal está detrás del login y no puedo autenticarme. La regla está cubierta por tests; el riesgo residual es de markup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)