### PR TITLE
El fin del reparto lo elige el admin, no una constante

### DIFF
--- a/src/components/containers/PedidosContainer.tsx
+++ b/src/components/containers/PedidosContainer.tsx
@@ -219,13 +219,13 @@ export default function PedidosContainer(): React.ReactElement {
   // sucursal en la optimización, así el lado que optimiza y el mapa usan la
   // MISMA ubicación. destino null = la ruta termina en el depósito.
   const optimizarRutaConDeposito = useCallback(
-    (transportistaId: string, pedidosData?: PedidoDB[], fecha?: string, horaInicio?: string) =>
-      optimizarRuta(transportistaId, pedidosData, deposito, destinoRuta, { fecha, horaInicio }),
+    (transportistaId: string, pedidosData?: PedidoDB[], fecha?: string, horaInicio?: string, horaFin?: string) =>
+      optimizarRuta(transportistaId, pedidosData, deposito, destinoRuta, { fecha, horaInicio, horaFin }),
     [optimizarRuta, deposito, destinoRuta],
   )
   const optimizarRutaMultiConDeposito = useCallback(
-    (repartidores: RepartidorParam[], pedidosData?: PedidoDB[], fecha?: string, horaInicio?: string) =>
-      optimizarRutaMulti(repartidores, pedidosData, deposito, destinoRuta, { fecha, horaInicio }),
+    (repartidores: RepartidorParam[], pedidosData?: PedidoDB[], fecha?: string, horaInicio?: string, horaFin?: string) =>
+      optimizarRutaMulti(repartidores, pedidosData, deposito, destinoRuta, { fecha, horaInicio, horaFin }),
     [optimizarRutaMulti, deposito, destinoRuta],
   )
 
@@ -1319,9 +1319,9 @@ export default function PedidosContainer(): React.ReactElement {
   // solo paso (sin botón "optimizar" separado). Las polylines del resultado se
   // pasan explícitamente a aplicar (no se leen del estado, que aún no se
   // actualizó en este tick).
-  const handleArmarRutaDelDia = useCallback(async (transportistaId: string, pedidosSeleccionados: PedidoDB[], fecha: string, horaInicio: string) => {
+  const handleArmarRutaDelDia = useCallback(async (transportistaId: string, pedidosSeleccionados: PedidoDB[], fecha: string, horaInicio: string, horaFin: string) => {
     if (!transportistaId || pedidosSeleccionados.length === 0) return
-    const ruta = await optimizarRutaConDeposito(transportistaId, pedidosSeleccionados, fecha, horaInicio)
+    const ruta = await optimizarRutaConDeposito(transportistaId, pedidosSeleccionados, fecha, horaInicio, horaFin)
     // ruta es null solo si la optimización falló de verdad (error de red/servicio):
     // optimizarRuta ya mostró el mensaje y no armamos nada.
     if (!ruta) return
@@ -1394,9 +1394,9 @@ export default function PedidosContainer(): React.ReactElement {
   // persiste un recorrido por chofer (aplicar_orden_ruta una vez por cada uno).
   // Los pedidos sin coordenadas (que el optimizador no rutea) se reparten por
   // zona preferida o round-robin antes de persistir.
-  const handleArmarRutaMulti = useCallback(async (repartidores: RepartidorParam[], pedidosSeleccionados: PedidoDB[], fecha: string, horaInicio: string) => {
+  const handleArmarRutaMulti = useCallback(async (repartidores: RepartidorParam[], pedidosSeleccionados: PedidoDB[], fecha: string, horaInicio: string, horaFin: string) => {
     if (!repartidores.length || pedidosSeleccionados.length === 0) return
-    const resp = await optimizarRutaMultiConDeposito(repartidores, pedidosSeleccionados, fecha, horaInicio)
+    const resp = await optimizarRutaMultiConDeposito(repartidores, pedidosSeleccionados, fecha, horaInicio, horaFin)
     if (!resp) return // error ya notificado por el hook
 
     const byId = new Map(pedidosSeleccionados.map(p => [String(p.id), p]))

--- a/src/components/modals/ModalGestionRutas.tsx
+++ b/src/components/modals/ModalGestionRutas.tsx
@@ -12,7 +12,7 @@ import { useDepositoCoords, useSetDepositoMutation, useDestinoCoords, useSetDest
 import type { RegistrarCambioInput } from '../../hooks/queries';
 import type { RepartidorParam } from '../../hooks/useOptimizarRuta';
 import { horarioParaRutear } from '../../hooks/useOptimizarRuta';
-import { abreEnDia, clasificarBarrida, encajeEnHorario, ETIQUETA_BARRIDA } from '../../utils/barridas';
+import { abreEnDia, clasificarBarrida, encajeEnHorario, ETIQUETA_BARRIDA, finJornadaSugerida } from '../../utils/barridas';
 import type { EncajeHorario } from '../../utils/barridas';
 import { fechaLocalISO, fechaHaceDias, formatFecha } from '../../utils/formatters';
 import { fechaQueFiltra, pedidoEnRangoDeFechas } from '../../utils/filtroFechaPedidos';
@@ -21,6 +21,12 @@ import type { PedidoDB, PerfilDB, ClienteDB, ProductoDB } from '../../types';
 // Normaliza para búsquedas: saca acentos y pasa a minúsculas.
 const normTexto = (s?: string | null): string =>
   (s || '').normalize('NFD').replace(/\p{Diacritic}/gu, '').toLowerCase();
+
+/** "HH:MM" del input type="time" a minutos. NaN si está vacío o mal formado. */
+const minutosDeHora = (hhmm: string): number => {
+  const m = /^(\d{1,2}):(\d{2})$/.exec(hhmm);
+  return m ? Number(m[1]) * 60 + Number(m[2]) : NaN;
+};
 
 // =============================================================================
 // TIPOS
@@ -102,12 +108,12 @@ export interface ModalGestionRutasProps {
    * Arma la ruta del día: optimiza los pedidos seleccionados y la guarda en
    * un solo paso (el container encadena optimizar + aplicar_orden_ruta).
    */
-  onArmarRuta: (transportistaId: string, pedidos: PedidoDB[], fecha: string, horaInicio: string) => void;
+  onArmarRuta: (transportistaId: string, pedidos: PedidoDB[], fecha: string, horaInicio: string, horaFin: string) => void;
   /**
    * Divide los pedidos seleccionados entre varios repartidores (N recorridos).
    * Cada repartidor puede traer máx paradas y zonas preferidas.
    */
-  onArmarRutaMulti?: (repartidores: RepartidorParam[], pedidos: PedidoDB[], fecha: string, horaInicio: string) => void;
+  onArmarRutaMulti?: (repartidores: RepartidorParam[], pedidos: PedidoDB[], fecha: string, horaInicio: string, horaFin: string) => void;
   onExportarPDF: (transportista: PerfilDB | undefined, pedidos: PedidoOrdenado[]) => void;
   /** Imprime las comandas (duplicado por pedido) de la ruta recién armada. */
   onImprimirComandas?: (pedidos: PedidoOrdenado[]) => void;
@@ -292,6 +298,18 @@ const ModalGestionRutas = memo(function ModalGestionRutas({
   // Hora a la que arranca el recorrido (sale del depósito). Ancla las ventanas
   // horarias en la optimización para priorizar los horarios de entrega.
   const [horaInicio, setHoraInicio] = useState<string>('08:00');
+  // Hora a la que termina el reparto. Acota qué franjas del cliente son entregas
+  // posibles de verdad: la ventana de la noche de un local cortado no lo es, y
+  // sin este corte el optimizador la usaba para dar la parada por resuelta.
+  // Sigue a la hora de salida hasta que el admin la toca a mano.
+  const [horaFin, setHoraFin] = useState<string>(() => finJornadaSugerida('08:00'));
+  const horaFinEditada = useRef<boolean>(false);
+  useEffect(() => {
+    if (!horaFinEditada.current) setHoraFin(finJornadaSugerida(horaInicio));
+  }, [horaInicio]);
+  // Negado a propósito: si alguna hora quedó vacía el input da NaN, y NaN en una
+  // comparación normal daría "válido" y armaría la ruta sin ancla temporal.
+  const jornadaInvalida = !(minutosDeHora(horaFin) > minutosDeHora(horaInicio));
   // Filtro de fecha para acotar el pool de disponibles (suelen acumularse
   // pendientes/en preparación de varios días). Se puede filtrar por fecha de
   // pedido o por fecha de entrega programada (ver filtroTipoFecha).
@@ -582,7 +600,7 @@ const ModalGestionRutas = memo(function ModalGestionRutas({
   const handleArmar = (): void => {
     if (transportistaSeleccionado && pedidosSeleccionados.length > 0) {
       // Optimiza + guarda en un paso, solo con los pedidos seleccionados.
-      onArmarRuta(transportistaSeleccionado, pedidosSeleccionados, fechaEntrega, horaInicio);
+      onArmarRuta(transportistaSeleccionado, pedidosSeleccionados, fechaEntrega, horaInicio, horaFin);
     }
   };
 
@@ -621,7 +639,7 @@ const ModalGestionRutas = memo(function ModalGestionRutas({
 
   const handleDividir = (): void => {
     if (onArmarRutaMulti && repartidoresParam.length > 0 && pedidosSeleccionados.length > 0) {
-      onArmarRutaMulti(repartidoresParam, pedidosSeleccionados, fechaEntrega, horaInicio);
+      onArmarRutaMulti(repartidoresParam, pedidosSeleccionados, fechaEntrega, horaInicio, horaFin);
     }
   };
 
@@ -766,9 +784,25 @@ const ModalGestionRutas = memo(function ModalGestionRutas({
                     onChange={(e: ChangeEvent<HTMLInputElement>) => setHoraInicio(e.target.value)}
                     className="px-3 py-2 border rounded-lg text-sm"
                   />
+                  <label className="text-sm font-medium text-blue-900">y termina</label>
+                  <input
+                    type="time"
+                    value={horaFin}
+                    onChange={(e: ChangeEvent<HTMLInputElement>) => {
+                      horaFinEditada.current = true;
+                      setHoraFin(e.target.value);
+                    }}
+                    className={`px-3 py-2 border rounded-lg text-sm ${jornadaInvalida ? 'border-red-400 bg-red-50' : ''}`}
+                  />
                   <span className="text-xs text-blue-700">
-                    Hora a la que sale del depósito. Prioriza los horarios de entrega de los clientes.
+                    Sale del depósito y vuelve. Prioriza los horarios de entrega de los clientes:
+                    lo que abre después de que termina el reparto no se toma como entregable.
                   </span>
+                  {jornadaInvalida && (
+                    <span className="w-full text-xs text-red-700">
+                      El reparto tiene que terminar después de la hora de salida.
+                    </span>
+                  )}
                 </div>
               </div>
 
@@ -1597,7 +1631,7 @@ const ModalGestionRutas = memo(function ModalGestionRutas({
               modoDividir ? (
                 <button
                   onClick={handleDividir}
-                  disabled={repartidoresSel.size === 0 || loading || guardando || pedidosSeleccionados.length === 0}
+                  disabled={repartidoresSel.size === 0 || loading || guardando || jornadaInvalida || pedidosSeleccionados.length === 0}
                   className="flex items-center space-x-2 px-5 py-2.5 bg-indigo-600 text-white rounded-lg hover:bg-indigo-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
                 >
                   {(loading || guardando) ? <Loader2 className="w-5 h-5 animate-spin" /> : <Route className="w-5 h-5" />}
@@ -1608,7 +1642,7 @@ const ModalGestionRutas = memo(function ModalGestionRutas({
               ) : (
                 <button
                   onClick={handleArmar}
-                  disabled={!transportistaSeleccionado || loading || guardando || pedidosSeleccionados.length === 0}
+                  disabled={!transportistaSeleccionado || loading || guardando || jornadaInvalida || pedidosSeleccionados.length === 0}
                   className="flex items-center space-x-2 px-5 py-2.5 bg-blue-600 text-white rounded-lg hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
                 >
                   {(loading || guardando) ? (

--- a/src/hooks/useOptimizarRuta.ts
+++ b/src/hooks/useOptimizarRuta.ts
@@ -142,6 +142,13 @@ export interface RutaMultiVehiculoResponse {
   mensaje?: string;
 }
 
+/** Ancla temporal de la ruta: cuándo sale el camión y cuándo termina el reparto. */
+export interface OptsTiempo {
+  fecha?: string;
+  horaInicio?: string;
+  horaFin?: string;
+}
+
 export interface OptimizarRutaRequestBody {
   transportista_id: string;
   deposito_lat: number;
@@ -154,6 +161,9 @@ export interface OptimizarRutaRequestBody {
    *  respetar ventanas horarias (solo optimizeTours; el fallback las ignora). */
   fecha?: string;
   hora_inicio?: string;
+  /** "HH:MM" en que termina el reparto: descarta las franjas del cliente que
+   *  arrancan después. Sin esto la edge lo deriva de hora_inicio. */
+  hora_fin?: string;
   /** Ventanas por pedido (del horario del cliente). Solo se respetan con optimizeTours. */
   ventanas?: VentanaPedido[];
   /** Barrida por pedido: hace que el orden entre bloques sea duro. */
@@ -165,9 +175,9 @@ export interface UseOptimizarRutaReturn {
   loading: boolean;
   rutaOptimizada: RutaOptimizadaResponse | null;
   error: string | null;
-  optimizarRuta: (transportistaId: string, pedidos?: PedidoDB[], deposito?: DepositoCoords, destino?: DepositoCoords | null, opts?: { fecha?: string; horaInicio?: string }) => Promise<RutaOptimizadaResponse | null>;
+  optimizarRuta: (transportistaId: string, pedidos?: PedidoDB[], deposito?: DepositoCoords, destino?: DepositoCoords | null, opts?: OptsTiempo) => Promise<RutaOptimizadaResponse | null>;
   /** Split multi-repartidor: divide los pedidos en N recorridos optimizados. */
-  optimizarRutaMulti: (repartidores: RepartidorParam[], pedidos?: PedidoDB[], deposito?: DepositoCoords, destino?: DepositoCoords | null, opts?: { fecha?: string; horaInicio?: string }) => Promise<RutaMultiVehiculoResponse | null>;
+  optimizarRutaMulti: (repartidores: RepartidorParam[], pedidos?: PedidoDB[], deposito?: DepositoCoords, destino?: DepositoCoords | null, opts?: OptsTiempo) => Promise<RutaMultiVehiculoResponse | null>;
   /** Permite al caller reflejar la ruta realmente armada (p.ej. agregando las
    *  paradas sin coordenadas que el optimizador no devuelve) para que el modal
    *  muestre el resultado y los botones de hoja de ruta / comandas. */
@@ -256,7 +266,7 @@ export function useOptimizarRuta(): UseOptimizarRutaReturn {
     pedidos: PedidoDB[] = [],
     deposito?: DepositoCoords,
     destino?: DepositoCoords | null,
-    opts?: { fecha?: string; horaInicio?: string }
+    opts?: OptsTiempo
   ): Promise<RutaOptimizadaResponse | null> => {
     if (!transportistaId) {
       setError('Debes seleccionar un transportista');
@@ -314,6 +324,7 @@ export function useOptimizarRuta(): UseOptimizarRutaReturn {
       pedidos: pedidosConCoordenadas,
       fecha: opts?.fecha,
       hora_inicio: opts?.horaInicio,
+      hora_fin: opts?.horaFin,
       ventanas: ventanas.length > 0 ? ventanas : undefined,
       barridas: barridas.length > 0 ? barridas : undefined
     };
@@ -416,7 +427,7 @@ export function useOptimizarRuta(): UseOptimizarRutaReturn {
     pedidos: PedidoDB[] = [],
     deposito?: DepositoCoords,
     destino?: DepositoCoords | null,
-    opts?: { fecha?: string; horaInicio?: string }
+    opts?: OptsTiempo
   ): Promise<RutaMultiVehiculoResponse | null> => {
     if (!repartidores.length) {
       setError('Elegí al menos un repartidor');
@@ -461,6 +472,7 @@ export function useOptimizarRuta(): UseOptimizarRutaReturn {
       pedidos: pedidosConCoordenadas,
       fecha: opts?.fecha,
       hora_inicio: opts?.horaInicio,
+      hora_fin: opts?.horaFin,
       ventanas: ventanas.length > 0 ? ventanas : undefined,
       barridas: barridas.length > 0 ? barridas : undefined,
       repartidores,

--- a/src/utils/barridas.test.ts
+++ b/src/utils/barridas.test.ts
@@ -3,6 +3,7 @@ import {
   clasificarBarrida,
   abreEnDia,
   encajeEnHorario,
+  finJornadaSugerida,
   intercalarSinCoordenadas,
   UMBRAL_CIERRE_TEMPRANO,
   type Barrida,
@@ -277,5 +278,23 @@ describe('encajeEnHorario', () => {
     expect(encajeEnHorario('10:00', 'de 9 a 14')).toBe('desconocido');
     expect(encajeEnHorario(null, '09:00-14:00')).toBe('desconocido');
     expect(encajeEnHorario('no-es-hora', '09:00-14:00')).toBe('desconocido');
+  });
+});
+
+describe('finJornadaSugerida', () => {
+  it('sugiere la jornada tipica desde la hora de salida', () => {
+    expect(finJornadaSugerida('08:00')).toBe('18:00');
+    expect(finJornadaSugerida('07:30')).toBe('17:30');
+    expect(finJornadaSugerida('06:15')).toBe('16:15');
+  });
+
+  it('no se pasa de las 23:30 aunque salga tarde', () => {
+    expect(finJornadaSugerida('15:00')).toBe('23:30');
+    expect(finJornadaSugerida('22:00')).toBe('23:30');
+  });
+
+  it('hora vacia o mal formada cae en un default usable', () => {
+    expect(finJornadaSugerida('')).toBe('18:00');
+    expect(finJornadaSugerida('no-es-hora')).toBe('18:00');
   });
 });

--- a/src/utils/barridas.ts
+++ b/src/utils/barridas.ts
@@ -205,6 +205,26 @@ export function intercalarSinCoordenadas<R extends ParadaRuteada, S extends Para
   return numerar(salida);
 }
 
+/** Duración típica del reparto. Solo sugiere el default del modal: la hora de
+ *  fin la elige el admin al armar la ruta, igual que la de salida. */
+export const JORNADA_HORAS = 10;
+
+/**
+ * Fin de jornada sugerido a partir de la hora de salida (tope 23:30).
+ *
+ * Es un default, no una regla: un sábado no dura lo mismo que un martes, así
+ * que el modal deja cambiarlo. Lo que el optimizador hace con ese horario es
+ * descartar las franjas del cliente que arrancan después (la ventana de la
+ * noche de un local cortado no es una entrega que se vaya a hacer).
+ */
+export function finJornadaSugerida(horaInicio: string): string {
+  const m = /^(\d{1,2}):(\d{2})$/.exec(horaInicio);
+  if (!m) return '18:00';
+  const tope = 23 * 60 + 30;
+  const fin = Math.min(Number(m[1]) * 60 + Number(m[2]) + JORNADA_HORAS * 60, tope);
+  return `${String(Math.floor(fin / 60)).padStart(2, '0')}:${String(fin % 60).padStart(2, '0')}`;
+}
+
 /** Cómo cae la hora planificada contra el horario del cliente. */
 export type EncajeHorario = 'ok' | 'temprano' | 'tarde' | 'desconocido';
 

--- a/supabase/functions/optimizar-ruta/index.ts
+++ b/supabase/functions/optimizar-ruta/index.ts
@@ -61,6 +61,13 @@ interface RequestBody {
   fecha?: string; // "YYYY-MM-DD"
   hora_inicio?: string; // "HH:MM"
   /**
+   * "HH:MM" en que termina el reparto (lo elige el admin al armar la ruta).
+   * Descarta las franjas del cliente que arrancan después: la ventana de la
+   * noche de un local cortado no es una entrega que se vaya a hacer. Si no
+   * viene, la función la deriva de hora_inicio (compat con clientes viejos).
+   */
+  hora_fin?: string;
+  /**
    * Ventanas de entrega por pedido, derivadas del horario del cliente. Cada
    * pedido puede traer más de una franja (horario cortado).
    */
@@ -335,6 +342,7 @@ serve(async (req: Request) => {
       const optsMulti = {
         fecha: body.fecha,
         horaInicio: body.hora_inicio,
+        horaFinJornada: body.hora_fin,
         ventanas: body.ventanas,
       };
       let result: RutaMultiResultado;
@@ -412,6 +420,7 @@ serve(async (req: Request) => {
           const r = await optimizeToursPorBarridas(saKey, deposito, conBarrida, destino, {
             fecha: body.fecha,
             horaInicio: body.hora_inicio,
+            horaFinJornada: body.hora_fin,
             ventanas: body.ventanas,
           });
           ruta = r;
@@ -421,6 +430,7 @@ serve(async (req: Request) => {
           ruta = await optimizeTours(saKey, deposito, conCoords, destino, {
             fecha: body.fecha,
             horaInicio: body.hora_inicio,
+            horaFinJornada: body.hora_fin,
             ventanas: body.ventanas,
           });
           optimizadoPor = "Google Route Optimization";

--- a/supabase/functions/optimizar-ruta/route-optimization.ts
+++ b/supabase/functions/optimizar-ruta/route-optimization.ts
@@ -121,17 +121,21 @@ function isoFecha(fecha: string, hhmm: string): string {
   return `${fecha}T${t}${TZ}`;
 }
 
-/** Duración del reparto desde que sale el camión. */
+/** Duración del reparto cuando el request no trae la hora de fin. */
 const JORNADA_HORAS = 10;
 
 /**
  * Fin de la jornada de reparto: "HH:MM" de salida + JORNADA_HORAS (tope 23:30).
  *
- * Acota qué franjas del cliente son entregas posibles de verdad. Sin esto, la
- * ventana de la tarde de un local cortado (09:00-13:00 y 18:00-22:00) es una
- * salida de emergencia para el optimizador: si no llega antes de las 13 puede
- * planificar esperar hasta las 18 y dar por resuelta la parada, cuando en la
- * calle esa entrega simplemente no se hace.
+ * Es el FALLBACK: la hora de fin la elige el admin al armar la ruta (viaja como
+ * `hora_fin`), porque un sábado no dura lo mismo que un martes. Esto cubre a los
+ * clientes que no la mandan.
+ *
+ * Sirve para acotar qué franjas del cliente son entregas posibles de verdad. Sin
+ * ese corte, la ventana de la tarde de un local cortado (09:00-13:00 y
+ * 18:00-22:00) es una salida de emergencia para el optimizador: si no llega
+ * antes de las 13 puede planificar esperar hasta las 18 y dar por resuelta la
+ * parada, cuando en la calle esa entrega simplemente no se hace.
  */
 export function finDeJornada(horaInicio: string | undefined): string | null {
   if (!horaInicio) return null;
@@ -183,9 +187,9 @@ export interface OptimizeToursOpts {
     franjas: Array<{ inicio: string; fin: string }>;
   }>;
   /**
-   * "HH:MM" en que termina el reparto. Lo calculan las funciones por barridas a
-   * partir de la salida del camión y se mantiene fijo entre bloques (si se
-   * recalculara por barrida, cada una correría el fin de jornada más tarde).
+   * "HH:MM" en que termina el reparto. Lo elige el admin al armar la ruta; si no
+   * viene se deriva de la salida con `finDeJornada`. Se mantiene fijo entre
+   * barridas: si se recalculara por bloque, cada uno correría el fin más tarde.
    */
   horaFinJornada?: string | null;
 }

--- a/supabase/functions/tests/barridas_ruta.test.ts
+++ b/supabase/functions/tests/barridas_ruta.test.ts
@@ -278,3 +278,34 @@ Deno.test("sin vehicleEndTime la hora de fin es null (se mantiene la previa)", (
   assertEquals(ruta.horaFin, null);
   assertExists(ruta.ultimaParada);
 });
+
+Deno.test("la hora de fin del request manda sobre la derivada de la salida", () => {
+  // El admin la elige en el modal: un sábado corto no tiene por qué tolerar la
+  // franja de las 17, aunque salir 08:00 la habilitaría por default.
+  const m = construirModeloSingle(DEPOSITO, [pedido(1)], DESTINO, {
+    fecha: FECHA,
+    horaInicio: "08:00",
+    horaFinJornada: "13:00",
+    ventanas: [{
+      pedido_id: "1",
+      franjas: [{ inicio: "09:00", fin: "12:00" }, { inicio: "17:00", fin: "22:00" }],
+    }],
+  });
+  const tw = shipments(m)[0].deliveries[0].timeWindows;
+  assertEquals(tw.length, 1);
+  assertEquals(tw[0].softEndTime, `${FECHA}T12:00:00-03:00`);
+});
+
+Deno.test("sin hora de fin en el request se deriva de la salida (compat)", () => {
+  // Saliendo 08:00 la jornada llega hasta las 18:00, así que la franja de las
+  // 17 sigue siendo una entrega posible.
+  const m = construirModeloSingle(DEPOSITO, [pedido(1)], DESTINO, {
+    fecha: FECHA,
+    horaInicio: "08:00",
+    ventanas: [{
+      pedido_id: "1",
+      franjas: [{ inicio: "09:00", fin: "12:00" }, { inicio: "17:00", fin: "22:00" }],
+    }],
+  });
+  assertEquals(shipments(m)[0].deliveries[0].timeWindows.length, 2);
+});


### PR DESCRIPTION
Continuación de #458 (este commit se pushó después del merge y quedó afuera).

## Por qué

`JORNADA_HORAS = 10` decidía qué franjas del cliente contaban como entrega
posible, y eso no es un parámetro del modelo: es un hecho de la operación que
cambia por día (un sábado no dura lo mismo que un martes).

La hora de **salida** ya se elegía en el modal al armar la ruta, así que la de
fin va al lado, en la misma pantalla, y viaja en el request como `hora_fin`.

- El default sigue a la hora de salida (+10 h, tope 23:30) hasta que se lo toca
  a mano.
- No se puede armar la ruta si el fin no es posterior a la salida — incluido el
  caso de un campo vacío, que da `NaN` y en una comparación normal habría pasado
  como válido.
- La constante queda como **fallback** en la edge para los requests que no
  mandan `hora_fin`.

Los **pesos de costo** (km, hora, llegar tarde) no se tocan a propósito: son
pesos relativos del modelo, no plata, y un valor mal puesto ahí no da error —
da rutas peores en silencio.

## Verificación

- 1115 tests (`vitest`) + los del edge (`deno test`) y typecheck en verde sobre
  el main de hoy.
- Casos nuevos: `hora_fin` explícita ganándole a la derivada de la salida,
  compat cuando no viene, y `finJornadaSugerida`.

## OJO con el deploy

La edge `optimizar-ruta` está en **v20**, desplegada a mano, y ya tiene este
cambio. El workflow `Deploy Edge Functions` que entró en #463 está fallando por
falta del secret `SUPABASE_ACCESS_TOKEN`: cuando se lo configure, va a deployar
lo que haya en `main`. Si eso pasa **antes** de mergear este PR, la edge vuelve
a la versión sin `hora_fin` y el modal queda mandando una hora que el servidor
ignora.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
