### PR TITLE
Que el gate de integridad y los chunks viejos dejen de mentir

### DIFF
--- a/migrations/178_compra_a1_cuadre_completo.sql
+++ b/migrations/178_compra_a1_cuadre_completo.sql
@@ -1,0 +1,65 @@
+-- ============================================================================
+-- 178 · auditoria_integridad: COMPRA-A1 vuelve a cuadrar la factura entera
+-- ============================================================================
+-- El check nació en la mig 105 con la estructura de compras de ese momento:
+--
+--     total = subtotal + iva + otros_impuestos
+--
+-- Las migs 113/114 le agregaron a la cabecera `impuestos_internos`,
+-- `percepcion_iva`, `percepcion_iibb` y `no_gravado` (y sacaron el II de
+-- `otros_impuestos`, que volvió a ser catch-all), pero el check nunca se
+-- actualizó. Desde entonces TODA compra FC con percepciones o imp. internos lo
+-- viola: 12 de 120 compras activas al 2026-08-12, severidad `high`.
+--
+-- El costo real de esto no es el número: `scripts/check-integridad.mjs` corre a
+-- diario desde .github/workflows/integridad.yml y sale con exit 1 ante cualquier
+-- critical/high en rojo. Con COMPRA-A1 permanentemente rojo el gate no distingue
+-- una regresión nueva del ruido de fondo, así que los checks que se agreguen
+-- después nacen invisibles.
+--
+-- La fórmula nueva es la misma que ya usa el control blando de cuadre del RPC
+-- registrar_compra_completa (mig 128). Verificado contra prod ANTES de aplicar:
+-- con la fórmula corregida quedan 0 violaciones sobre las 120 compras activas,
+-- o sea las 12 eran 100% fórmula vieja y no hay ningún dato descuadrado.
+--
+-- Se parchea leyendo el catálogo, exigiendo que el ancla aparezca exactamente
+-- una vez: si el cuerpo derivó, la migración falla en vez de aplicar un parche
+-- parcial (mismo criterio que la mig 177). Idempotente: si el check ya está
+-- corregido, no hace nada.
+-- ============================================================================
+
+DO $mig$
+DECLARE
+  v_def   text;
+  v_ancla CONSTANT text := $a$    ('COMPRA-A1','high','compras.total = subtotal+iva+otros_impuestos',
+      (SELECT count(*) FROM compras WHERE estado<>'cancelada' AND abs(COALESCE(total,0)-(COALESCE(subtotal,0)+COALESCE(iva,0)+COALESCE(otros_impuestos,0)))>1.0)),$a$;
+  v_nuevo CONSTANT text := $a$    ('COMPRA-A1','high','compras.total = subtotal+iva+ii+percepciones+no gravado+otros (mig 178)',
+      (SELECT count(*) FROM compras WHERE estado<>'cancelada' AND abs(COALESCE(total,0)-(
+        COALESCE(subtotal,0)+COALESCE(iva,0)+COALESCE(impuestos_internos,0)
+        +COALESCE(percepcion_iva,0)+COALESCE(percepcion_iibb,0)
+        +COALESCE(no_gravado,0)+COALESCE(otros_impuestos,0)))>1.0)),$a$;
+  v_veces integer;
+BEGIN
+  v_def := pg_get_functiondef('public.auditoria_integridad()'::regprocedure);
+
+  IF position('mig 178' in v_def) > 0 THEN
+    RAISE NOTICE 'mig 178 · COMPRA-A1 ya corregido, se omite';
+    RETURN;
+  END IF;
+
+  v_veces := (length(v_def) - length(replace(v_def, v_ancla, ''))) / length(v_ancla);
+  IF v_veces <> 1 THEN
+    RAISE EXCEPTION 'mig 178 · el ancla de COMPRA-A1 aparece % veces (se esperaba 1). El cuerpo derivó; revisá el parche antes de aplicar.', v_veces;
+  END IF;
+
+  EXECUTE replace(v_def, v_ancla, v_nuevo);
+END;
+$mig$;
+
+-- ----------------------------------------------------------------------------
+-- Verificación (esperado: COMPRA-A1 en verde, 0 violaciones)
+--
+--   SELECT c->>'id', c->>'ok', c->>'violaciones'
+--     FROM jsonb_array_elements(auditoria_integridad()->'checks') c
+--    WHERE c->>'id' LIKE 'COMPRA-%';
+-- ----------------------------------------------------------------------------

--- a/src/components/containers/AnalyticsContainer.tsx
+++ b/src/components/containers/AnalyticsContainer.tsx
@@ -4,11 +4,12 @@
  * Container para el Centro de Análisis.
  * Maneja el estado de exportación y delega la UI a VistaAnalytics.
  */
-import React, { lazy, Suspense, useState, useCallback } from 'react'
+import React, { Suspense, useState, useCallback } from 'react'
 import { Loader2 } from 'lucide-react'
 import { exportarBI } from '../../services/analyticsExport'
+import { lazyWithReload } from '../../utils/lazyWithReload'
 
-const VistaAnalytics = lazy(() => import('../vistas/VistaAnalytics'))
+const VistaAnalytics = lazyWithReload(() => import('../vistas/VistaAnalytics'))
 
 function LoadingState() {
   return (

--- a/src/components/containers/ClientesContainer.tsx
+++ b/src/components/containers/ClientesContainer.tsx
@@ -4,7 +4,7 @@
  * Container que carga clientes bajo demanda usando TanStack Query.
  * Maneja estado de modales y operaciones CRUD.
  */
-import React, { lazy, Suspense, useState, useCallback } from 'react'
+import React, { Suspense, useState, useCallback } from 'react'
 import { Loader2 } from 'lucide-react'
 import {
   useClientesQuery,
@@ -25,16 +25,17 @@ import { useQueryClient } from '@tanstack/react-query'
 import { puedeRegistrarPagoCliente } from '../../lib/permisos'
 import type { ClienteDB } from '../../types'
 import type { ClienteSaveData } from '../modals/ModalCliente'
+import { lazyWithReload } from '../../utils/lazyWithReload'
 
 // Lazy load de componentes
-const VistaClientes = lazy(() => import('../vistas/VistaClientes'))
-const ModalCliente = lazy(() => import('../modals/ModalCliente'))
-const ModalFichaCliente = lazy(() => import('../modals/ModalFichaCliente'))
-const ModalConfirmacion = lazy(() => import('../modals/ModalConfirmacion'))
-const ModalZonas = lazy(() => import('../modals/ModalZonas'))
-const ModalRegistrarPago = lazy(() => import('../modals/ModalRegistrarPago'))
-const ModalDeudoresMora = lazy(() => import('../modals/ModalDeudoresMora'))
-const ModalCambioProducto = lazy(() => import('../modals/ModalCambioProducto'))
+const VistaClientes = lazyWithReload(() => import('../vistas/VistaClientes'))
+const ModalCliente = lazyWithReload(() => import('../modals/ModalCliente'))
+const ModalFichaCliente = lazyWithReload(() => import('../modals/ModalFichaCliente'))
+const ModalConfirmacion = lazyWithReload(() => import('../modals/ModalConfirmacion'))
+const ModalZonas = lazyWithReload(() => import('../modals/ModalZonas'))
+const ModalRegistrarPago = lazyWithReload(() => import('../modals/ModalRegistrarPago'))
+const ModalDeudoresMora = lazyWithReload(() => import('../modals/ModalDeudoresMora'))
+const ModalCambioProducto = lazyWithReload(() => import('../modals/ModalCambioProducto'))
 
 function LoadingState() {
   return (

--- a/src/components/containers/ComisionesContainer.tsx
+++ b/src/components/containers/ComisionesContainer.tsx
@@ -1,12 +1,13 @@
-import React, { lazy, Suspense, useCallback, useEffect, useMemo, useState } from 'react'
+import React, { Suspense, useCallback, useEffect, useMemo, useState } from 'react'
 import { Loader2 } from 'lucide-react'
 import { fechaLocalISO } from '../../utils/formatters'
 import { useCalcularComisionesQuery, usePreventistasQuery } from '../../hooks/queries'
 import { useAuthData } from '../../contexts/AuthDataContext'
 import { useNotification } from '../../contexts/NotificationContext'
+import { lazyWithReload } from '../../utils/lazyWithReload'
 
-const VistaComisiones = lazy(() => import('../vistas/VistaComisiones'))
-const ModalComisionReglas = lazy(() => import('../modals/ModalComisionReglas'))
+const VistaComisiones = lazyWithReload(() => import('../vistas/VistaComisiones'))
+const ModalComisionReglas = lazyWithReload(() => import('../modals/ModalComisionReglas'))
 
 function LoadingState(): React.ReactElement {
   return (

--- a/src/components/containers/CondicionesMayoristasPanel.tsx
+++ b/src/components/containers/CondicionesMayoristasPanel.tsx
@@ -8,7 +8,7 @@
  * y tenerlas en una seccion aparte del menu obligaba a saltar de pantalla para
  * algo que se decide mirando el producto.
  */
-import React, { lazy, Suspense, useState, useCallback } from 'react'
+import React, { Suspense, useState, useCallback } from 'react'
 import { Loader2 } from 'lucide-react'
 import {
   useGruposPrecioQuery,
@@ -20,11 +20,12 @@ import {
 } from '../../hooks/queries'
 import { useNotification } from '../../contexts/NotificationContext'
 import type { GrupoPrecioConDetalles, GrupoPrecioFormInput } from '../../types'
+import { lazyWithReload } from '../../utils/lazyWithReload'
 
-const VistaGruposPrecio = lazy(() => import('../vistas/VistaGruposPrecio'))
-const AsistenteConsolidacion = lazy(() => import('../productos/AsistenteConsolidacion'))
-const ModalGrupoPrecio = lazy(() => import('../modals/ModalGrupoPrecio'))
-const ModalConfirmacion = lazy(() => import('../modals/ModalConfirmacion'))
+const VistaGruposPrecio = lazyWithReload(() => import('../vistas/VistaGruposPrecio'))
+const AsistenteConsolidacion = lazyWithReload(() => import('../productos/AsistenteConsolidacion'))
+const ModalGrupoPrecio = lazyWithReload(() => import('../modals/ModalGrupoPrecio'))
+const ModalConfirmacion = lazyWithReload(() => import('../modals/ModalConfirmacion'))
 
 function LoadingState() {
   return (

--- a/src/components/containers/DashboardContainer.tsx
+++ b/src/components/containers/DashboardContainer.tsx
@@ -4,13 +4,14 @@
  * Container que carga datos del dashboard bajo demanda usando TanStack Query.
  * Solo carga métricas cuando el usuario navega a esta vista.
  */
-import React, { lazy, Suspense } from 'react'
+import React, { Suspense } from 'react'
 import { Loader2 } from 'lucide-react'
 import { useMetricasQuery, useClientesQuery, useAvanceMetasQuery, periodoMensual } from '../../hooks/queries'
 import { useAuthData } from '../../contexts/AuthDataContext'
 import { useBackup } from '../../hooks/supabase'
+import { lazyWithReload } from '../../utils/lazyWithReload'
 
-const VistaDashboard = lazy(() => import('../vistas/VistaDashboard'))
+const VistaDashboard = lazyWithReload(() => import('../vistas/VistaDashboard'))
 
 function LoadingState() {
   return (

--- a/src/components/containers/MetasContainer.tsx
+++ b/src/components/containers/MetasContainer.tsx
@@ -1,4 +1,4 @@
-import React, { lazy, Suspense, useEffect, useState } from 'react'
+import React, { Suspense, useEffect, useState } from 'react'
 import { Loader2 } from 'lucide-react'
 import {
   useRendimientoPreventistasQuery,
@@ -9,9 +9,10 @@ import type { AvanceMeta } from '../../hooks/queries'
 import { useAuthData } from '../../contexts/AuthDataContext'
 import { useNotification } from '../../contexts/NotificationContext'
 import { useResetOnSucursalChange } from '../../hooks/useResetOnSucursalChange'
+import { lazyWithReload } from '../../utils/lazyWithReload'
 
-const VistaMetasPreventistas = lazy(() => import('../vistas/VistaMetasPreventistas'))
-const ModalMetasPreventista = lazy(() => import('../modals/ModalMetasPreventista'))
+const VistaMetasPreventistas = lazyWithReload(() => import('../vistas/VistaMetasPreventistas'))
+const ModalMetasPreventista = lazyWithReload(() => import('../modals/ModalMetasPreventista'))
 
 function LoadingState(): React.ReactElement {
   return (

--- a/src/components/containers/MovimientosContainer.tsx
+++ b/src/components/containers/MovimientosContainer.tsx
@@ -2,7 +2,7 @@
  * MovimientosContainer — panel de movimientos entre sucursales (con aprobación).
  * Reemplaza el flujo viejo de transferencias (un solo lado, inmediato).
  */
-import React, { lazy, Suspense, useState, useCallback } from 'react'
+import React, { Suspense, useState, useCallback } from 'react'
 import { Loader2 } from 'lucide-react'
 import {
   useMovimientosQuery,
@@ -20,12 +20,13 @@ import { useAuthData } from '../../contexts/AuthDataContext'
 import { useSucursal } from '../../contexts/SucursalContext'
 import { useNotification } from '../../contexts/NotificationContext'
 import { useResetOnSucursalChange } from '../../hooks/useResetOnSucursalChange'
+import { lazyWithReload } from '../../utils/lazyWithReload'
 
-const VistaMovimientos = lazy(() => import('../vistas/VistaMovimientos'))
-const ModalCrearMovimiento = lazy(() => import('../modals/ModalCrearMovimiento'))
-const ModalAceptarMovimiento = lazy(() => import('../modals/ModalAceptarMovimiento'))
-const ModalDetalleMovimiento = lazy(() => import('../modals/ModalDetalleMovimiento'))
-const ModalCancelarMovimiento = lazy(() => import('../modals/ModalCancelarMovimiento'))
+const VistaMovimientos = lazyWithReload(() => import('../vistas/VistaMovimientos'))
+const ModalCrearMovimiento = lazyWithReload(() => import('../modals/ModalCrearMovimiento'))
+const ModalAceptarMovimiento = lazyWithReload(() => import('../modals/ModalAceptarMovimiento'))
+const ModalDetalleMovimiento = lazyWithReload(() => import('../modals/ModalDetalleMovimiento'))
+const ModalCancelarMovimiento = lazyWithReload(() => import('../modals/ModalCancelarMovimiento'))
 
 type TabEstado = EstadoMovimiento | 'todos'
 

--- a/src/components/containers/PedidosContainer.tsx
+++ b/src/components/containers/PedidosContainer.tsx
@@ -5,7 +5,7 @@
  * Maneja estado de paginación, filtros, búsqueda y modales.
  * Reemplaza el flujo legacy de App.tsx → VistaPedidos con prop drilling.
  */
-import React, { lazy, Suspense, useState, useCallback, useMemo, useRef } from 'react'
+import React, { Suspense, useState, useCallback, useMemo, useRef } from 'react'
 import { useSearchParams } from 'react-router-dom'
 import { calcularNetoVenta } from '../../utils/calculations'
 import {
@@ -61,32 +61,32 @@ import type { GpsResult, GpsStatus } from '../../hooks/useGeolocationCapture'
 import { supabase } from '../../hooks/supabase/base'
 import { usePagos } from '../../hooks/supabase/usePagos'
 import { retryWithBackoff, isTransientNetworkError } from '../../utils/retryWithBackoff'
-import { importConRecarga } from '../../utils/lazyWithReload'
+import { importConRecarga, lazyWithReload } from '../../utils/lazyWithReload'
 import type { PedidoDB, FiltrosPedidosState, PerfilDB, RegistrarSalvedadInput, RegistrarSalvedadResult, PagoDBWithUsuario } from '../../types'
 import type { PedidoEditItem } from '../modals/ModalEditarPedido'
 import type { CambiarClientePayload } from '../modals/ModalCambiarCliente'
 import type { RutaMultiResultadoUI } from '../modals/ModalGestionRutas'
 
 // Lazy load de componentes
-const VistaPedidos = lazy(() => import('../vistas/VistaPedidos'))
-const ModalPedido = lazy(() => import('../modals/ModalPedido'))
-const ModalConfirmacion = lazy(() => import('../modals/ModalConfirmacion'))
-const ModalHistorialPedido = lazy(() => import('../modals/ModalHistorialPedido'))
-const ModalEditarPedido = lazy(() => import('../modals/ModalEditarPedido'))
-const ModalPagoPedido = lazy(() => import('../modals/ModalPagoPedido'))
-const ModalEditarNotas = lazy(() => import('../modals/ModalEditarNotas'))
-const ModalFiltroFecha = lazy(() => import('../modals/ModalFiltroFecha'))
-const ModalExportarPDF = lazy(() => import('../modals/ModalExportarPDF'))
-const ModalGestionRutas = lazy(() => import('../modals/ModalGestionRutas'))
-const ModalCambioProducto = lazy(() => import('../modals/ModalCambioProducto'))
-const ModalEntregaConSalvedad = lazy(() => import('../modals/ModalEntregaConSalvedad'))
-const ModalEntregasMasivas = lazy(() => import('../modals/ModalEntregasMasivas'))
-const ModalCancelarPedido = lazy(() => import('../modals/ModalCancelarPedido'))
-const ModalPagosMasivos = lazy(() => import('../modals/ModalPagosMasivos'))
-const ModalEntregaYPagoMasivos = lazy(() => import('../modals/ModalEntregaYPagoMasivos'))
-const ModalMarcarVisita = lazy(() => import('../modals/ModalMarcarVisita'))
-const ModalVisitasHoy = lazy(() => import('../modals/ModalVisitasHoy'))
-const ModalMotivoSinGps = lazy(() => import('../modals/ModalMotivoSinGps'))
+const VistaPedidos = lazyWithReload(() => import('../vistas/VistaPedidos'))
+const ModalPedido = lazyWithReload(() => import('../modals/ModalPedido'))
+const ModalConfirmacion = lazyWithReload(() => import('../modals/ModalConfirmacion'))
+const ModalHistorialPedido = lazyWithReload(() => import('../modals/ModalHistorialPedido'))
+const ModalEditarPedido = lazyWithReload(() => import('../modals/ModalEditarPedido'))
+const ModalPagoPedido = lazyWithReload(() => import('../modals/ModalPagoPedido'))
+const ModalEditarNotas = lazyWithReload(() => import('../modals/ModalEditarNotas'))
+const ModalFiltroFecha = lazyWithReload(() => import('../modals/ModalFiltroFecha'))
+const ModalExportarPDF = lazyWithReload(() => import('../modals/ModalExportarPDF'))
+const ModalGestionRutas = lazyWithReload(() => import('../modals/ModalGestionRutas'))
+const ModalCambioProducto = lazyWithReload(() => import('../modals/ModalCambioProducto'))
+const ModalEntregaConSalvedad = lazyWithReload(() => import('../modals/ModalEntregaConSalvedad'))
+const ModalEntregasMasivas = lazyWithReload(() => import('../modals/ModalEntregasMasivas'))
+const ModalCancelarPedido = lazyWithReload(() => import('../modals/ModalCancelarPedido'))
+const ModalPagosMasivos = lazyWithReload(() => import('../modals/ModalPagosMasivos'))
+const ModalEntregaYPagoMasivos = lazyWithReload(() => import('../modals/ModalEntregaYPagoMasivos'))
+const ModalMarcarVisita = lazyWithReload(() => import('../modals/ModalMarcarVisita'))
+const ModalVisitasHoy = lazyWithReload(() => import('../modals/ModalVisitasHoy'))
+const ModalMotivoSinGps = lazyWithReload(() => import('../modals/ModalMotivoSinGps'))
 
 const ITEMS_PER_PAGE = 15
 

--- a/src/components/containers/ProductosContainer.tsx
+++ b/src/components/containers/ProductosContainer.tsx
@@ -4,7 +4,7 @@
  * Container que carga productos bajo demanda usando TanStack Query.
  * Maneja estado de modales y operaciones CRUD.
  */
-import React, { lazy, Suspense, useState, useCallback, useMemo } from 'react'
+import React, { Suspense, useState, useCallback, useMemo } from 'react'
 import { useSearchParams } from 'react-router-dom'
 import { Loader2 } from 'lucide-react'
 import {
@@ -32,23 +32,24 @@ import {
 import { useResetOnSucursalChange } from '../../hooks/useResetOnSucursalChange'
 import { formatPrecio } from '../../utils/formatters'
 import type { ProductoDB, ProductoFormInput, MermaFormInputExtended, GrupoPrecioFormInput } from '../../types'
+import { lazyWithReload } from '../../utils/lazyWithReload'
 
 // Lazy load de componentes
-const VistaProductos = lazy(() => import('../vistas/VistaProductos'))
-const ModalProducto = lazy(() => import('../modals/ModalProducto'))
-const ModalMermaStock = lazy(() => import('../modals/ModalMermaStock'))
-const ModalHistorialMermas = lazy(() => import('../modals/ModalHistorialMermas'))
-const ModalActualizacionMasivaPrecios = lazy(() => import('../modals/ModalActualizacionMasivaPrecios'))
-const ModalMinimoVentaMasivo = lazy(() => import('../modals/ModalMinimoVentaMasivo'))
-const ModalGrupoPrecio = lazy(() => import('../modals/ModalGrupoPrecio'))
-const ModalConfirmacion = lazy(() => import('../modals/ModalConfirmacion'))
-const ModalCategorias = lazy(() => import('../modals/ModalCategorias'))
-const ModalMarcas = lazy(() => import('../modals/ModalMarcas'))
-const ModalCambioProducto = lazy(() => import('../modals/ModalCambioProducto'))
-const ModalStockBajo = lazy(() => import('../modals/ModalStockBajo'))
-const ModalControlStock = lazy(() => import('../modals/ModalControlStock'))
-const ModalAjustesStockHistorial = lazy(() => import('../modals/ModalAjustesStockHistorial'))
-const CondicionesMayoristasPanel = lazy(() => import('./CondicionesMayoristasPanel'))
+const VistaProductos = lazyWithReload(() => import('../vistas/VistaProductos'))
+const ModalProducto = lazyWithReload(() => import('../modals/ModalProducto'))
+const ModalMermaStock = lazyWithReload(() => import('../modals/ModalMermaStock'))
+const ModalHistorialMermas = lazyWithReload(() => import('../modals/ModalHistorialMermas'))
+const ModalActualizacionMasivaPrecios = lazyWithReload(() => import('../modals/ModalActualizacionMasivaPrecios'))
+const ModalMinimoVentaMasivo = lazyWithReload(() => import('../modals/ModalMinimoVentaMasivo'))
+const ModalGrupoPrecio = lazyWithReload(() => import('../modals/ModalGrupoPrecio'))
+const ModalConfirmacion = lazyWithReload(() => import('../modals/ModalConfirmacion'))
+const ModalCategorias = lazyWithReload(() => import('../modals/ModalCategorias'))
+const ModalMarcas = lazyWithReload(() => import('../modals/ModalMarcas'))
+const ModalCambioProducto = lazyWithReload(() => import('../modals/ModalCambioProducto'))
+const ModalStockBajo = lazyWithReload(() => import('../modals/ModalStockBajo'))
+const ModalControlStock = lazyWithReload(() => import('../modals/ModalControlStock'))
+const ModalAjustesStockHistorial = lazyWithReload(() => import('../modals/ModalAjustesStockHistorial'))
+const CondicionesMayoristasPanel = lazyWithReload(() => import('./CondicionesMayoristasPanel'))
 
 function LoadingState() {
   return (

--- a/src/components/containers/PromocionesContainer.tsx
+++ b/src/components/containers/PromocionesContainer.tsx
@@ -3,7 +3,7 @@
  *
  * Container que gestiona promociones usando TanStack Query.
  */
-import React, { lazy, Suspense, useMemo, useState, useCallback } from 'react'
+import React, { Suspense, useMemo, useState, useCallback } from 'react'
 import { Loader2 } from 'lucide-react'
 import {
   usePromocionesListQuery,
@@ -17,10 +17,11 @@ import {
 } from '../../hooks/queries'
 import type { PromocionConDetalles, PromocionFormInput } from '../../hooks/queries/usePromocionesQuery'
 import { useNotification } from '../../contexts/NotificationContext'
+import { lazyWithReload } from '../../utils/lazyWithReload'
 
-const VistaPromociones = lazy(() => import('../vistas/VistaPromociones'))
-const ModalPromocion = lazy(() => import('../modals/ModalPromocion'))
-const ModalConfirmacion = lazy(() => import('../modals/ModalConfirmacion'))
+const VistaPromociones = lazyWithReload(() => import('../vistas/VistaPromociones'))
+const ModalPromocion = lazyWithReload(() => import('../modals/ModalPromocion'))
+const ModalConfirmacion = lazyWithReload(() => import('../modals/ModalConfirmacion'))
 
 function LoadingState() {
   return (

--- a/src/components/containers/ProveedoresContainer.tsx
+++ b/src/components/containers/ProveedoresContainer.tsx
@@ -3,7 +3,7 @@
  *
  * Container que carga proveedores bajo demanda usando TanStack Query.
  */
-import React, { lazy, Suspense, useState, useCallback } from 'react'
+import React, { Suspense, useState, useCallback } from 'react'
 import { Loader2 } from 'lucide-react'
 import {
   useProveedoresQuery,
@@ -17,11 +17,12 @@ import { useAuthData } from '../../contexts/AuthDataContext'
 import { useNotification } from '../../contexts/NotificationContext'
 import { useResetOnSucursalChange } from '../../hooks/useResetOnSucursalChange'
 import type { ProveedorDBExtended, ProveedorFormInputExtended } from '../../types'
+import { lazyWithReload } from '../../utils/lazyWithReload'
 
 // Lazy load de componentes
-const VistaProveedores = lazy(() => import('../vistas/VistaProveedores'))
-const ModalProveedor = lazy(() => import('../modals/ModalProveedor'))
-const ModalConfirmacion = lazy(() => import('../modals/ModalConfirmacion'))
+const VistaProveedores = lazyWithReload(() => import('../vistas/VistaProveedores'))
+const ModalProveedor = lazyWithReload(() => import('../modals/ModalProveedor'))
+const ModalConfirmacion = lazyWithReload(() => import('../modals/ModalConfirmacion'))
 
 function LoadingState() {
   return (

--- a/src/components/containers/RecorridoPreventistaContainer.tsx
+++ b/src/components/containers/RecorridoPreventistaContainer.tsx
@@ -4,13 +4,14 @@
  * Container para la optimización de recorridos de preventistas.
  * Usa el mismo webhook n8n que el recorrido de transportistas.
  */
-import React, { lazy, Suspense, useCallback } from 'react'
+import React, { Suspense, useCallback } from 'react'
 import { Loader2 } from 'lucide-react'
 import { useClientesQuery, usePreventistasQuery } from '../../hooks/queries'
 import { useOptimizarRutaPreventista } from '../../hooks/useOptimizarRutaPreventista'
 import type { ClienteDB } from '../../types'
+import { lazyWithReload } from '../../utils/lazyWithReload'
 
-const ModalOptimizarRutaPreventista = lazy(() => import('../modals/ModalOptimizarRutaPreventista'))
+const ModalOptimizarRutaPreventista = lazyWithReload(() => import('../modals/ModalOptimizarRutaPreventista'))
 
 function LoadingState() {
   return (

--- a/src/components/containers/RecorridosContainer.tsx
+++ b/src/components/containers/RecorridosContainer.tsx
@@ -1,10 +1,11 @@
-import React, { lazy, Suspense, useCallback, useEffect, useState } from 'react'
+import React, { Suspense, useCallback, useEffect, useState } from 'react'
 import { Loader2 } from 'lucide-react'
 import { fechaLocalISO } from '../../utils/formatters'
 import { useRecorridos } from '../../hooks/supabase'
 import type { EstadisticasRecorridos } from '../../types'
+import { lazyWithReload } from '../../utils/lazyWithReload'
 
-const VistaRecorridos = lazy(() => import('../vistas/VistaRecorridos'))
+const VistaRecorridos = lazyWithReload(() => import('../vistas/VistaRecorridos'))
 
 function LoadingState(): React.ReactElement {
   return (

--- a/src/components/containers/ReportesContainer.tsx
+++ b/src/components/containers/ReportesContainer.tsx
@@ -1,11 +1,12 @@
-import React, { lazy, Suspense, useCallback, useEffect, useState } from 'react'
+import React, { Suspense, useCallback, useEffect, useState } from 'react'
 import { Loader2 } from 'lucide-react'
 import { useClientesQuery, useReportePreventistasQuery } from '../../hooks/queries'
 import { useNotification } from '../../contexts/NotificationContext'
 import type { ClienteDB } from '../../types'
+import { lazyWithReload } from '../../utils/lazyWithReload'
 
-const VistaReportes = lazy(() => import('../vistas/VistaReportes'))
-const ModalFichaCliente = lazy(() => import('../modals/ModalFichaCliente'))
+const VistaReportes = lazyWithReload(() => import('../vistas/VistaReportes'))
+const ModalFichaCliente = lazyWithReload(() => import('../modals/ModalFichaCliente'))
 
 function LoadingState(): React.ReactElement {
   return (

--- a/src/components/containers/ReportesGerencialesContainer.tsx
+++ b/src/components/containers/ReportesGerencialesContainer.tsx
@@ -1,10 +1,11 @@
-import React, { lazy, Suspense, useEffect, useMemo, useState } from 'react'
+import React, { Suspense, useEffect, useMemo, useState } from 'react'
 import { Loader2 } from 'lucide-react'
 import { useReporteGerencialQuery, useAnalisisMensualQuery, useMetasGerencialQuery, useGuardarMetaMutation, useCalcularComisionesQuery } from '../../hooks/queries'
 import { useSucursal } from '../../contexts/SucursalContext'
 import type { PeriodoOpt, SucursalOpt } from '../vistas/VistaReportesGerenciales'
+import { lazyWithReload } from '../../utils/lazyWithReload'
 
-const VistaReportesGerenciales = lazy(() => import('../vistas/VistaReportesGerenciales'))
+const VistaReportesGerenciales = lazyWithReload(() => import('../vistas/VistaReportesGerenciales'))
 
 const MESES_ES = ['Enero', 'Febrero', 'Marzo', 'Abril', 'Mayo', 'Junio', 'Julio', 'Agosto', 'Septiembre', 'Octubre', 'Noviembre', 'Diciembre']
 

--- a/src/components/containers/RevisionHorariosContainer.tsx
+++ b/src/components/containers/RevisionHorariosContainer.tsx
@@ -1,4 +1,4 @@
-import React, { lazy, Suspense, useCallback } from 'react'
+import React, { Suspense, useCallback } from 'react'
 import { Loader2 } from 'lucide-react'
 import {
   useRevisionHorariosQuery,
@@ -6,8 +6,9 @@ import {
   type HorarioMasivoItem,
 } from '../../hooks/queries/useRevisionHorariosQuery'
 import { useNotification } from '../../contexts/NotificationContext'
+import { lazyWithReload } from '../../utils/lazyWithReload'
 
-const VistaRevisionHorarios = lazy(() => import('../vistas/VistaRevisionHorarios'))
+const VistaRevisionHorarios = lazyWithReload(() => import('../vistas/VistaRevisionHorarios'))
 
 function LoadingState(): React.ReactElement {
   return (

--- a/src/components/containers/UsuariosContainer.tsx
+++ b/src/components/containers/UsuariosContainer.tsx
@@ -1,13 +1,14 @@
-import React, { lazy, Suspense, useCallback, useEffect, useState } from 'react'
+import React, { Suspense, useCallback, useEffect, useState } from 'react'
 import { Loader2 } from 'lucide-react'
 import { useActualizarUsuarioMutation, useUsuariosQuery } from '../../hooks/queries'
 import { useNotification } from '../../contexts/NotificationContext'
 import { useResetOnSucursalChange } from '../../hooks/useResetOnSucursalChange'
 import type { PerfilDB } from '../../types'
 import type { UsuarioFormData } from '../modals/ModalUsuario'
+import { lazyWithReload } from '../../utils/lazyWithReload'
 
-const VistaUsuarios = lazy(() => import('../vistas/VistaUsuarios'))
-const ModalUsuario = lazy(() => import('../modals/ModalUsuario'))
+const VistaUsuarios = lazyWithReload(() => import('../vistas/VistaUsuarios'))
+const ModalUsuario = lazyWithReload(() => import('../modals/ModalUsuario'))
 
 function LoadingState(): React.ReactElement {
   return (

--- a/src/components/containers/VistaBotTelegramContainer.tsx
+++ b/src/components/containers/VistaBotTelegramContainer.tsx
@@ -5,7 +5,7 @@
  * Mantiene el estado de filtros del audit log + páginas locales y orquesta
  * los 4 query hooks + 1 mutation. La vista es presentational.
  */
-import { lazy, Suspense, useCallback, useMemo, useState, type ReactElement } from 'react';
+import { Suspense, useCallback, useMemo, useState, type ReactElement } from 'react';
 import { Loader2 } from 'lucide-react';
 import { useQueryClient } from '@tanstack/react-query';
 import {
@@ -22,8 +22,9 @@ import type {
   BotToggleUsuarioInput,
   BotToggleUsuarioResult,
 } from '../../hooks/queries/useBotAdmin';
+import { lazyWithReload } from '../../utils/lazyWithReload';
 
-const VistaBotTelegram = lazy(() => import('../vistas/VistaBotTelegram'));
+const VistaBotTelegram = lazyWithReload(() => import('../vistas/VistaBotTelegram'));
 
 function LoadingState(): ReactElement {
   return (

--- a/src/components/modals/ModalActualizacionMasivaPrecios.tsx
+++ b/src/components/modals/ModalActualizacionMasivaPrecios.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo, useCallback, lazy, Suspense } from 'react'
+import { useState, useMemo, useCallback, Suspense } from 'react'
 import type { ChangeEvent } from 'react'
 import { Percent, Search, AlertTriangle, TrendingUp, TrendingDown } from 'lucide-react'
 import ModalBase from './ModalBase'
@@ -7,8 +7,9 @@ import { useNotification } from '../../contexts/NotificationContext'
 import { calcularNuevosPrecios } from '../../utils/precios'
 import { formatPrecio } from '../../utils/formatters'
 import type { ProductoDB, ProveedorDBExtended } from '../../types'
+import { lazyWithReload } from '../../utils/lazyWithReload'
 
-const ModalConfirmacion = lazy(() => import('./ModalConfirmacion'))
+const ModalConfirmacion = lazyWithReload(() => import('./ModalConfirmacion'))
 
 export interface ModalActualizacionMasivaPreciosProps {
   productos: ProductoDB[]

--- a/src/components/modals/ModalCambiarProveedor.tsx
+++ b/src/components/modals/ModalCambiarProveedor.tsx
@@ -11,7 +11,7 @@
  * costos vienen de la factura, no de un motor de precios, así que no hay
  * recálculo de promos/mayorista/descuento.
  */
-import { useState, memo, lazy, Suspense } from 'react'
+import { useState, memo, Suspense } from 'react'
 import { Loader2, Building2, Plus, AlertTriangle, ArrowRight } from 'lucide-react'
 import ModalBase from './ModalBase'
 import { formatPrecio } from '../../utils/formatters'
@@ -21,8 +21,9 @@ import type {
   ProveedorFormInputExtended,
   CompraItemDBExtended,
 } from '../../types'
+import { lazyWithReload } from '../../utils/lazyWithReload'
 
-const ModalProveedor = lazy(() => import('./ModalProveedor'))
+const ModalProveedor = lazyWithReload(() => import('./ModalProveedor'))
 
 export type CambiarProveedorPayload = {
   nuevoProveedorId: string | null

--- a/src/components/modals/ModalCompra.tsx
+++ b/src/components/modals/ModalCompra.tsx
@@ -4,7 +4,7 @@
  * Refactorizado con useReducer para mejor gestión de estado
  * Validación con Zod
  */
-import React, { useReducer, useMemo, useCallback, useState, useEffect, useRef, lazy, Suspense } from 'react'
+import React, { useReducer, useMemo, useCallback, useState, useEffect, useRef, Suspense } from 'react'
 import type { ChangeEvent, FormEvent } from 'react'
 import { X, ShoppingCart, Plus, Trash2, Package, Building2, FileText, Calculator, Search, Loader2, Camera, CheckCircle, AlertTriangle } from 'lucide-react'
 import { formatPrecio, fechaLocalISO } from '../../utils/formatters'
@@ -15,9 +15,10 @@ import NumberInput from '../ui/NumberInput'
 import { supabase } from '../../lib/supabase'
 import { CompactErrorBoundary } from '../ErrorBoundary'
 import type { CondicionIva, ProductoDB, ProveedorDBExtended, CompraFormInputExtended, ProveedorFormInputExtended } from '../../types'
+import { lazyWithReload } from '../../utils/lazyWithReload';
 
-const ModalProveedor = lazy(() => import('./ModalProveedor'))
-const ModalImportarCompra = lazy(() => import('./ModalImportarCompra'))
+const ModalProveedor = lazyWithReload(() => import('./ModalProveedor'))
+const ModalImportarCompra = lazyWithReload(() => import('./ModalImportarCompra'))
 
 // =============================================================================
 // TIPOS

--- a/src/components/modals/ModalEditarPedido.tsx
+++ b/src/components/modals/ModalEditarPedido.tsx
@@ -1,4 +1,4 @@
-import { lazy, Suspense, useState, memo, useEffect, useMemo } from 'react';
+import { Suspense, useState, memo, useEffect, useMemo } from 'react';
 import { Loader2, AlertCircle, Package, Plus, Minus, Trash2, Search, X, ShoppingCart, Pencil, Gift, RefreshCw, UserCheck, Check } from 'lucide-react';
 import ModalBase from './ModalBase';
 import ModalConfirmacion, { type ModalConfirmacionConfig } from './ModalConfirmacion';
@@ -14,9 +14,10 @@ import { usePreventistasAsignablesQuery } from '../../hooks/queries/useUsuariosQ
 import { calcularNetoVenta, parsePrecio } from '../../utils/calculations';
 import type { PedidoDB, ProductoDB, PedidoItemDB, ClienteDB } from '../../types';
 import type { CambiarClientePayload } from './ModalCambiarCliente';
+import { lazyWithReload } from '../../utils/lazyWithReload';
 
-const ModalSustituirRegalo = lazy(() => import('./ModalSustituirRegalo'));
-const ModalCambiarCliente = lazy(() => import('./ModalCambiarCliente'));
+const ModalSustituirRegalo = lazyWithReload(() => import('./ModalSustituirRegalo'));
+const ModalCambiarCliente = lazyWithReload(() => import('./ModalCambiarCliente'));
 
 /** Item del pedido para edición. Incluye fiscales opcionales que se pueblan al guardar. */
 export interface PedidoEditItem {

--- a/src/components/modals/ModalProducto.tsx
+++ b/src/components/modals/ModalProducto.tsx
@@ -1,4 +1,4 @@
-import { useState, memo, lazy, Suspense } from 'react';
+import { useState, memo, Suspense } from 'react';
 import type { ChangeEvent } from 'react';
 import { Loader2 } from 'lucide-react';
 import ModalBase from './ModalBase';
@@ -16,9 +16,10 @@ import {
 } from '../../utils/calculations';
 import type { CondicionIva, ProductoDB, ProveedorDBExtended } from '../../types';
 import { OPCIONES_CONDICION_IVA, claveCondicionIva } from '../../utils/condicionIva';
+import { lazyWithReload } from '../../utils/lazyWithReload';
 
 // Lazy: solo hace falta al editar, y arrastra la query de grupos de precio.
-const ProductoCondicionesMayoristas = lazy(() => import('../productos/ProductoCondicionesMayoristas'));
+const ProductoCondicionesMayoristas = lazyWithReload(() => import('../productos/ProductoCondicionesMayoristas'));
 
 // =============================================================================
 // TYPES

--- a/src/components/pedidos/VistaRutaTransportista.tsx
+++ b/src/components/pedidos/VistaRutaTransportista.tsx
@@ -1,7 +1,7 @@
 /**
  * Vista de ruta para transportista
  */
-import React, { useState, useMemo, useRef, memo, lazy, Suspense } from 'react';
+import React, { useState, useMemo, useRef, memo, Suspense } from 'react';
 import { Route, Truck, Check, MapPin, Phone, ChevronDown, ChevronUp, Navigation, AlertTriangle, Gift, WifiOff, X } from 'lucide-react';
 import { formatPrecio, formatFecha, getFormaPagoLabel } from '../../utils/formatters';
 import { googleMapsNavUrl, wazeNavUrl, googleMapsSearchUrl } from '../../utils/navegacion';
@@ -10,9 +10,10 @@ import { useAuthData } from '../../contexts/AuthDataContext';
 import ModalSalvedadItem from '../modals/ModalSalvedadItem';
 import ModalRegistrarPago from '../modals/ModalRegistrarPago';
 import { getDepositoCoords } from '../../hooks/useOptimizarRuta';
+import { lazyWithReload } from '../../utils/lazyWithReload';
 
 // Lazy: leaflet solo se carga al entrar a esta vista
-const MapaRuta = lazy(() => import('../MapaRuta'));
+const MapaRuta = lazyWithReload(() => import('../MapaRuta'));
 
 // =============================================================================
 // INTERFACES DE PROPS Y TIPOS

--- a/src/components/rutaActiva/RutaActivaTransportista.tsx
+++ b/src/components/rutaActiva/RutaActivaTransportista.tsx
@@ -11,7 +11,7 @@
  * transportista en /pedidos. La lógica de entrega/cobro/salvedad es la misma
  * (useEntregaParada). Diseño: docs/plans/2026-06-12-ruta-activa-design.md
  */
-import React, { useState, useMemo, useEffect, useCallback, lazy, Suspense } from 'react';
+import React, { useState, useMemo, useEffect, useCallback, Suspense } from 'react';
 import { Crosshair, WifiOff, Truck, Volume2, VolumeX, LocateFixed, ArrowLeft } from 'lucide-react';
 import { formatPrecio } from '../../utils/formatters';
 import { haversineMeters } from '../../utils/geo';
@@ -33,9 +33,10 @@ import { supabase } from '../../hooks/supabase/base';
 import { useQueryClient } from '@tanstack/react-query';
 import type { MotivoNoEntrega } from '../../constants/motivosNoEntrega';
 import type { PedidoDB, RegistrarSalvedadResult } from '../../types';
+import { lazyWithReload } from '../../utils/lazyWithReload';
 
 // Mapa con Google Maps JS (reemplaza el Leaflet; mejor reactividad y estética).
-const MapaRuta = lazy(() => import('./MapaRutaGoogle'));
+const MapaRuta = lazyWithReload(() => import('./MapaRutaGoogle'));
 
 /** Radio del geofence de llegada, en metros */
 const RADIO_LLEGADA_M = 100;

--- a/src/components/vistas/VistaRecorridos.tsx
+++ b/src/components/vistas/VistaRecorridos.tsx
@@ -1,4 +1,5 @@
-import React, { useState, useMemo, lazy, Suspense, ChangeEvent } from 'react';
+import React, { useState, useMemo, Suspense, ChangeEvent } from 'react';
+import { lazyWithReload } from '../../utils/lazyWithReload';
 import { Route, Truck, Calendar, Check, MapPin, Phone, ChevronDown, ChevronUp, ChevronLeft, ChevronRight, Navigation, RefreshCw, BarChart3, X } from 'lucide-react';
 import { formatPrecio, formatFecha, fechaLocalISO, fechaHaceDias, parseDateSafe } from '../../utils/formatters';
 import LoadingSpinner from '../layout/LoadingSpinner';
@@ -8,7 +9,7 @@ import { decodePolylines } from '../../utils/polyline';
 import PanelNoEntregados from '../recorridos/PanelNoEntregados';
 
 // Lazy: leaflet solo se carga al expandir un recorrido
-const MapaRuta = lazy(() => import('../MapaRuta'));
+const MapaRuta = lazyWithReload(() => import('../MapaRuta'));
 import type {
   RecorridoDBExtended,
   PedidoDB,

--- a/src/components/vistas/VistaRendiciones.tsx
+++ b/src/components/vistas/VistaRendiciones.tsx
@@ -4,7 +4,7 @@
  * pago, total entregado ese dia (comparador secundario), gastos del dia y
  * estado (pendiente/confirmada/disconformidad/resuelta).
  */
-import React, { lazy, Suspense, useState, useEffect, useCallback, useMemo } from 'react'
+import React, { Suspense, useState, useEffect, useCallback, useMemo } from 'react'
 import {
   Banknote,
   Calendar,
@@ -30,11 +30,12 @@ import { useTransportistasQuery, useClientesQuery } from '../../hooks/queries'
 import { useNotification } from '../../contexts/NotificationContext'
 import { FORMAS_PAGO, formaPagoLabel } from '../../constants/formasPago'
 import type { ResumenRendicionDiaria, PerfilDB, EstadoRendicion, RendicionGastoInput, ClienteDB } from '../../types'
+import { lazyWithReload } from '../../utils/lazyWithReload'
 
-const ModalCerrarRendicion = lazy(() => import('../modals/ModalCerrarRendicion'))
-const ModalResolverRendicion = lazy(() => import('../modals/ModalResolverRendicion'))
-const ModalCtaCtePendiente = lazy(() => import('../modals/ModalCtaCtePendiente'))
-const ModalFichaCliente = lazy(() => import('../modals/ModalFichaCliente'))
+const ModalCerrarRendicion = lazyWithReload(() => import('../modals/ModalCerrarRendicion'))
+const ModalResolverRendicion = lazyWithReload(() => import('../modals/ModalResolverRendicion'))
+const ModalCtaCtePendiente = lazyWithReload(() => import('../modals/ModalCtaCtePendiente'))
+const ModalFichaCliente = lazyWithReload(() => import('../modals/ModalFichaCliente'))
 
 function formatMoney(value: number | undefined | null): string {
   return new Intl.NumberFormat('es-AR', { style: 'currency', currency: 'ARS' }).format(value || 0)


### PR DESCRIPTION
Dos deudas que salieron de la sesión del IVA por línea. No tienen relación entre sí más que haber aparecido juntas; van en un PR porque son chicas y ambas son de higiene.

## 1. `COMPRA-A1` llevaba meses en rojo (migración 178, ya aplicada)

El check nació en la mig 105 con la estructura de compras de ese momento:

```
total = subtotal + iva + otros_impuestos
```

Las migs 113/114 le agregaron `impuestos_internos`, `percepcion_iva`, `percepcion_iibb` y `no_gravado` a la cabecera — y sacaron el II de `otros_impuestos`, que volvió a ser catch-all — pero **el check nunca se actualizó**. Desde entonces toda compra FC con percepciones o imp. internos lo viola: **12 de 120 compras activas**, severidad `high`.

El costo real no era el número. `scripts/check-integridad.mjs` corre a diario desde `integridad.yml` y sale con exit 1 ante cualquier `critical`/`high` en rojo. Con `COMPRA-A1` permanentemente rojo el gate no distinguía una regresión nueva del ruido de fondo, así que **los checks que se agregaran después nacían invisibles**.

La fórmula nueva es la misma que ya usa el control blando de cuadre del RPC `registrar_compra_completa` (mig 128).

**Verificado contra prod antes de aplicar**: con la fórmula corregida quedan **0 violaciones** sobre las 120 activas. Las 12 eran 100% fórmula vieja — ningún dato descuadrado. El gate bajó de 3 `high` en rojo a 2 (`VENTA-C` y `CC-PAGOS-CANCEL`, ajenos a compras y preexistentes).

Se parchea leyendo el catálogo con ancla única obligatoria, igual que la 177, y es idempotente.

## 2. 106 `lazy` sin guarda contra chunks viejos

Cada modal/vista lazy es su propio chunk. Sin `lazyWithReload`, una pestaña abierta tras un deploy puede quedarse con un chunk viejo mientras otro ya es nuevo — que es exactamente lo que hizo que el selector de IVA apareciera al crear una compra y no al editarla (PR #461).

Se envolvieron los **27 archivos** que quedaban: 106 lazy cubiertos en 29 archivos, no queda ninguno pelado.

El más expuesto no era el que yo había identificado sino **`PedidosContainer`, con 19**. Una auditoría por grep lo había dado por bueno porque el archivo importa `importConRecarga` **del mismo módulo**, y el filtro `grep -L lazyWithReload` lo excluyó por el nombre del path. Para auditar cobertura hay que buscar el patrón de **uso** (`= lazy(() => import`), no la presencia del import.

Único excluido a propósito: `AppModals.tsx` (20 lazy), que es código muerto — no se renderiza.

## Verificación

1123 tests en verde (83 archivos), typecheck y lint limpios sobre todo `src/`, `npm run build` OK.

El cambio de `lazy` a `lazyWithReload` es de comportamiento nulo salvo cuando el `import()` falla por chunk obsoleto: ahí recarga una vez (con cooldown de 15s por `sessionStorage`) en lugar de dejar el `<Suspense>` colgado.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
