### PR TITLE
Panel "Mis entregas": el preventista se entera de qué pasó con sus pedidos

### DIFF
--- a/migrations/179_jornadas_del_preventista.sql
+++ b/migrations/179_jornadas_del_preventista.sql
@@ -1,0 +1,385 @@
+-- =========================================================================
+-- 179_jornadas_del_preventista.sql
+--
+-- El preventista carga el pedido y después no se entera de nada. Si el
+-- cliente rechazó la mercadería, si el negocio estaba cerrado, si el chofer
+-- entregó de menos con una salvedad — todo eso pasa después de que él cerró
+-- la venta y hoy no tiene ninguna pantalla donde verlo. Se entera cuando el
+-- cliente le reclama en la próxima visita, o no se entera nunca.
+--
+-- Dos funciones de lectura para el panel "Mis entregas": el resumen por día
+-- y el detalle de un día.
+--
+-- Por qué RPC y no PostgREST desde el cliente:
+--
+-- 1) El día del reparto hay que DERIVARLO. `fecha_entrega_programada` no
+--    sirve: coincide con la entrega real sólo el 52% de las veces. Para un
+--    cancelado ni siquiera hay `fecha_entrega` (NULL en 266 de 271), así que
+--    el día del rechazo sólo vive en `pedido_historial`. Cruzar eso desde el
+--    cliente implica bajarse el historial entero.
+--
+-- 2) `pedido_items` y `pedido_historial` tienen RLS pensada para otra cosa
+--    (`pedido_historial` es `sucursal_id = current_sucursal_id()` a secas).
+--    Un SECURITY DEFINER con guard explícito es más chico y más auditable
+--    que abrir policies nuevas.
+--
+-- 3) El embed que haría falta (pedidos → clientes → salvedades_items →
+--    productos) es la forma exacta que dio PGRST201 y rompió "Armar ruta"
+--    en prod. Un RPC no tiene embeds.
+--
+-- Dos decisiones de negocio que quedan escritas acá:
+--
+-- a) NO todo cancelado es un rechazo. De 271 cancelados, 67 son corrección
+--    de oficina (error_de_carga 29, prueba 26, unifica_pedidos 8,
+--    cambio_de_cliente 4). Mostrarle al preventista sus propios errores de
+--    carga junto a los rechazos del cliente arruina el número que importa.
+--
+--    La lista de administrativos es NEGRA, no blanca, y eso es a propósito:
+--    un motivo nuevo cae en 'rechazado' y se ve. Al revés se escondería solo,
+--    que es exactamente la falla que este panel viene a arreglar. Por eso
+--    'otro' (38) y los cancelados sin motivo también cuentan como rechazo:
+--    uno de ellos dice "inconveniente entre fletero y clienta (observar)",
+--    o sea calle pura. Y 'cliente_cancelo' (19) es de las cosas que el
+--    preventista más necesita saber, no una corrección de oficina.
+--    Reparto resultante: 204 rechazados / 67 administrativos.
+--
+-- b) El monto de un cancelado NO es `pedidos.total`: `cancelar_pedido_con_stock`
+--    lo pone en cero (267 de 271 están en 0). El importe original se recupera
+--    de `total_real` o, para los viejos que no lo tienen, de la suma de los
+--    items — que sobrevive a la cancelación. Sin esto cada rechazo se muestra
+--    en $0 y el panel no dice nada.
+--
+-- Nombres nuevos, UNA firma por función: la mig 176 documenta que dos
+-- sobrecargas con aridades superpuestas dan PGRST203 en runtime, invisible
+-- para tsc y para los tests.
+--
+-- Sólo lectura. No toca ninguna fila. Idempotente (CREATE OR REPLACE).
+-- =========================================================================
+
+-- -------------------------------------------------------------------------
+-- 1. Resumen por día
+-- -------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.jornadas_preventista(
+  p_desde          date,
+  p_hasta          date,
+  p_preventista_id uuid DEFAULT NULL
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+STABLE SECURITY DEFINER
+SET search_path TO 'public'
+AS $fn$
+DECLARE
+  v_target    uuid;
+  v_nombre    text;
+  v_sucursal  bigint;
+  v_dias      jsonb;
+  v_pend      jsonb;
+  v_totales   jsonb;
+BEGIN
+  -- Mismo guard que `avance_metas_preventista` (mig 158): sin argumento se
+  -- resuelve al usuario logueado; pedir el de otro requiere admin o encargado.
+  v_target := COALESCE(p_preventista_id, auth.uid());
+
+  IF v_target IS NULL THEN
+    RAISE EXCEPTION 'Sin usuario' USING ERRCODE = '42501';
+  END IF;
+
+  IF auth.uid() IS NOT NULL AND v_target <> auth.uid() AND NOT es_encargado_o_admin() THEN
+    RAISE EXCEPTION 'Acceso denegado' USING ERRCODE = '42501';
+  END IF;
+
+  IF p_desde IS NULL OR p_hasta IS NULL OR p_hasta < p_desde THEN
+    RAISE EXCEPTION 'Rango de fechas inválido' USING ERRCODE = '22007';
+  END IF;
+
+  v_sucursal := current_sucursal_id();
+
+  SELECT nombre INTO v_nombre FROM perfiles WHERE id = v_target;
+
+  WITH resueltos AS (
+    SELECT
+      -- El día del reparto: cuándo se entregó o cuándo se cayó.
+      --
+      -- El `AT TIME ZONE` no es decorativo. La mig 136 tuvo que rehacer 1.380
+      -- pedidos mal clasificados justamente por esto: el cast directo usa el
+      -- TZ de la sesión (UTC en Supabase) y manda una entrega de las 22:00 AR
+      -- al día siguiente.
+      CASE
+        WHEN p.estado = 'entregado' THEN
+          -- 7 entregados no tienen fecha_entrega; el historial los rescata
+          -- antes de caer a la fecha de toma, que sería el día equivocado.
+          COALESCE((p.fecha_entrega AT TIME ZONE 'America/Argentina/Buenos_Aires')::date,
+                   (SELECT (h.created_at AT TIME ZONE 'America/Argentina/Buenos_Aires')::date
+                      FROM pedido_historial h
+                     WHERE h.pedido_id = p.id
+                       AND h.campo_modificado = 'estado'
+                       AND h.valor_nuevo = 'entregado'
+                     ORDER BY h.created_at DESC
+                     LIMIT 1),
+                   p.fecha)
+        ELSE
+          -- `LIKE 'cancelado%'` porque los bundles viejos escribían el motivo
+          -- adentro del valor: 'cancelado - Motivo: CERRADO | Total original: $30600.00'.
+          COALESCE((SELECT (h.created_at AT TIME ZONE 'America/Argentina/Buenos_Aires')::date
+                      FROM pedido_historial h
+                     WHERE h.pedido_id = p.id
+                       AND h.campo_modificado = 'estado'
+                       AND h.valor_nuevo LIKE 'cancelado%'
+                     ORDER BY h.created_at DESC
+                     LIMIT 1),
+                   p.fecha)
+      END AS dia,
+
+      CASE
+        WHEN p.estado = 'entregado'
+             AND EXISTS (SELECT 1 FROM salvedades_items s
+                          WHERE s.pedido_id = p.id
+                            AND s.estado_resolucion <> 'anulada')
+          THEN 'entregado_con_salvedad'
+        WHEN p.estado = 'entregado' THEN 'entregado'
+        -- Lista NEGRA: el pedido no debía existir o fue reemplazado por otro.
+        WHEN p.motivo_cancelacion_tipo IN
+             ('error_de_carga','prueba','duplicado','unifica_pedidos','cambio_de_cliente')
+          THEN 'administrativo'
+        -- Todo el resto —incluido 'otro' y los que no tienen motivo— es el
+        -- cliente que no recibió la mercadería.
+        ELSE 'rechazado'
+      END AS desenlace,
+
+      -- `total` de un cancelado es 0 (lo pone cancelar_pedido_con_stock).
+      CASE WHEN p.estado = 'cancelado'
+        THEN COALESCE(NULLIF(p.total, 0), NULLIF(p.total_real, 0),
+                      (SELECT COALESCE(SUM(pi.subtotal), 0) FROM pedido_items pi
+                        WHERE pi.pedido_id = p.id))
+        ELSE p.total
+      END AS monto
+
+    FROM pedidos p
+    WHERE p.usuario_id  = v_target
+      AND p.sucursal_id = v_sucursal
+      AND p.canal <> 'cambio'          -- devoluciones: logística, no venta
+      AND p.estado IN ('entregado','cancelado')
+      -- El desenlace nunca es anterior a la carga, así que nada con
+      -- fecha > p_hasta puede caer dentro del rango. El margen hacia atrás
+      -- cubre la cola larga (el lag observado llega a 25 días).
+      AND p.fecha >= (p_desde - 90)
+      AND p.fecha <= p_hasta
+  ),
+  del_rango AS (
+    SELECT * FROM resueltos WHERE dia BETWEEN p_desde AND p_hasta
+  ),
+  por_dia AS (
+    SELECT
+      dia,
+      COUNT(*)                                                        AS total,
+      COUNT(*) FILTER (WHERE desenlace LIKE 'entregado%')             AS entregados,
+      COUNT(*) FILTER (WHERE desenlace = 'entregado_con_salvedad')    AS con_salvedad,
+      COUNT(*) FILTER (WHERE desenlace = 'rechazado')                 AS rechazados,
+      COUNT(*) FILTER (WHERE desenlace = 'administrativo')            AS administrativos,
+      COALESCE(SUM(monto) FILTER (WHERE desenlace LIKE 'entregado%'), 0) AS monto_entregado,
+      COALESCE(SUM(monto) FILTER (WHERE desenlace = 'rechazado'), 0)     AS monto_rechazado
+    FROM del_rango
+    GROUP BY dia
+  )
+  SELECT
+    COALESCE(jsonb_agg(jsonb_build_object(
+      'dia',             d.dia,
+      'total',           d.total,
+      'entregados',      d.entregados,
+      'con_salvedad',    d.con_salvedad,
+      'rechazados',      d.rechazados,
+      'administrativos', d.administrativos,
+      'monto_entregado', d.monto_entregado,
+      'monto_rechazado', d.monto_rechazado
+    ) ORDER BY d.dia DESC), '[]'::jsonb),
+    jsonb_build_object(
+      'entregados',  COALESCE(SUM(d.entregados), 0),
+      'rechazados',  COALESCE(SUM(d.rechazados), 0),
+      'pct_rechazo', CASE
+        WHEN COALESCE(SUM(d.entregados), 0) + COALESCE(SUM(d.rechazados), 0) = 0 THEN 0
+        ELSE ROUND(100.0 * SUM(d.rechazados) / (SUM(d.entregados) + SUM(d.rechazados)), 1)
+      END,
+      'monto_rechazado', COALESCE(SUM(d.monto_rechazado), 0)
+    )
+  INTO v_dias, v_totales
+  FROM por_dia d;
+
+  -- Los que no tienen desenlace todavía. Van aparte y SIN filtro de fecha: no
+  -- pertenecen a ninguna jornada cerrada, y el punto es exactamente que hay
+  -- pedidos colgados hace semanas que hoy no mira nadie.
+  SELECT jsonb_build_object(
+    'total',     COUNT(*),
+    'monto',     COALESCE(SUM(p.total), 0),
+    'mas_viejo', MIN(p.fecha)
+  )
+  INTO v_pend
+  FROM pedidos p
+  WHERE p.usuario_id  = v_target
+    AND p.sucursal_id = v_sucursal
+    AND p.canal <> 'cambio'
+    AND p.estado NOT IN ('entregado','cancelado');
+
+  RETURN jsonb_build_object(
+    'preventista_id', v_target,
+    'nombre',         v_nombre,
+    'desde',          p_desde,
+    'hasta',          p_hasta,
+    'dias',           v_dias,
+    'totales',        v_totales,
+    'pendientes',     v_pend
+  );
+END;
+$fn$;
+
+COMMENT ON FUNCTION public.jornadas_preventista(date, date, uuid) IS
+'Panel "Mis entregas": resumen por día de reparto de los pedidos que tomó un preventista (pedidos.usuario_id). Sin p_preventista_id devuelve los del usuario logueado; pedir el de otro requiere admin o encargado. Sólo lectura.';
+
+GRANT EXECUTE ON FUNCTION public.jornadas_preventista(date, date, uuid) TO authenticated;
+
+
+-- -------------------------------------------------------------------------
+-- 2. Detalle de un día
+--
+-- Se llama al expandir una tarjeta, no al cargar la lista: son 8-14 pedidos
+-- por día y traerlos todos de entrada multiplicaría por 30 el payload de una
+-- pantalla que se usa desde el teléfono, en la calle.
+--
+-- p_dia NULL devuelve el bucket de pendientes, así el filtro "pendientes" del
+-- front no necesita una tercera función.
+-- -------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.jornada_preventista_detalle(
+  p_dia            date,
+  p_preventista_id uuid DEFAULT NULL
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+STABLE SECURITY DEFINER
+SET search_path TO 'public'
+AS $fn$
+DECLARE
+  v_target   uuid;
+  v_sucursal bigint;
+  v_out      jsonb;
+BEGIN
+  v_target := COALESCE(p_preventista_id, auth.uid());
+
+  IF v_target IS NULL THEN
+    RAISE EXCEPTION 'Sin usuario' USING ERRCODE = '42501';
+  END IF;
+
+  IF auth.uid() IS NOT NULL AND v_target <> auth.uid() AND NOT es_encargado_o_admin() THEN
+    RAISE EXCEPTION 'Acceso denegado' USING ERRCODE = '42501';
+  END IF;
+
+  v_sucursal := current_sucursal_id();
+
+  WITH candidatos AS (
+    SELECT
+      p.*,
+      CASE
+        WHEN p.estado = 'entregado' THEN
+          COALESCE((p.fecha_entrega AT TIME ZONE 'America/Argentina/Buenos_Aires')::date,
+                   (SELECT (h.created_at AT TIME ZONE 'America/Argentina/Buenos_Aires')::date
+                      FROM pedido_historial h
+                     WHERE h.pedido_id = p.id
+                       AND h.campo_modificado = 'estado'
+                       AND h.valor_nuevo = 'entregado'
+                     ORDER BY h.created_at DESC
+                     LIMIT 1),
+                   p.fecha)
+        WHEN p.estado = 'cancelado' THEN
+          COALESCE((SELECT (h.created_at AT TIME ZONE 'America/Argentina/Buenos_Aires')::date
+                      FROM pedido_historial h
+                     WHERE h.pedido_id = p.id
+                       AND h.campo_modificado = 'estado'
+                       AND h.valor_nuevo LIKE 'cancelado%'
+                     ORDER BY h.created_at DESC
+                     LIMIT 1),
+                   p.fecha)
+        ELSE NULL
+      END AS dia
+    FROM pedidos p
+    WHERE p.usuario_id  = v_target
+      AND p.sucursal_id = v_sucursal
+      AND p.canal <> 'cambio'
+      AND (
+        -- Un día concreto: sólo los que ya tienen desenlace.
+        (p_dia IS NOT NULL
+         AND p.estado IN ('entregado','cancelado')
+         AND p.fecha BETWEEN (p_dia - 90) AND p_dia)
+        -- Sin día: el bucket de colgados, sin filtro de fecha.
+        OR (p_dia IS NULL AND p.estado NOT IN ('entregado','cancelado'))
+      )
+  ),
+  filtrados AS (
+    SELECT * FROM candidatos
+    WHERE (p_dia IS NULL AND dia IS NULL) OR dia = p_dia
+  )
+  SELECT COALESCE(jsonb_agg(jsonb_build_object(
+    'pedido_id', f.id,
+    'cliente',   COALESCE(NULLIF(c.nombre_fantasia, ''), c.razon_social, 'Cliente'),
+    'monto',     CASE WHEN f.estado = 'cancelado'
+                   THEN COALESCE(NULLIF(f.total, 0), NULLIF(f.total_real, 0),
+                                 (SELECT COALESCE(SUM(pi.subtotal), 0) FROM pedido_items pi
+                                   WHERE pi.pedido_id = f.id))
+                   ELSE f.total END,
+    'desenlace', CASE
+      WHEN f.estado = 'entregado'
+           AND EXISTS (SELECT 1 FROM salvedades_items s
+                        WHERE s.pedido_id = f.id AND s.estado_resolucion <> 'anulada')
+        THEN 'entregado_con_salvedad'
+      WHEN f.estado = 'entregado' THEN 'entregado'
+      WHEN f.estado = 'cancelado'
+           AND f.motivo_cancelacion_tipo IN
+               ('error_de_carga','prueba','duplicado','unifica_pedidos','cambio_de_cliente')
+        THEN 'administrativo'
+      WHEN f.estado = 'cancelado' THEN 'rechazado'
+      ELSE 'pendiente'
+    END,
+    'estado',        f.estado,
+    'fecha_pedido',  f.fecha,
+    'motivo_tipo',   f.motivo_cancelacion_tipo,
+    'motivo_nota',   NULLIF(btrim(COALESCE(f.motivo_cancelacion, '')), ''),
+    'transportista', tr.nombre,
+    'salvedades', (
+      SELECT COALESCE(jsonb_agg(jsonb_build_object(
+        'producto',          pr.nombre,
+        'cantidad_afectada', s.cantidad_afectada,
+        'cantidad_original', s.cantidad_original,
+        'motivo',            s.motivo,
+        'descripcion',       NULLIF(btrim(COALESCE(s.descripcion, '')), ''),
+        'monto_afectado',    s.monto_afectado
+      ) ORDER BY pr.nombre), '[]'::jsonb)
+      FROM salvedades_items s
+      JOIN productos pr ON pr.id = s.producto_id
+      WHERE s.pedido_id = f.id AND s.estado_resolucion <> 'anulada'
+    )
+  ) ORDER BY f.id DESC), '[]'::jsonb)
+  INTO v_out
+  FROM filtrados f
+  LEFT JOIN clientes c ON c.id = f.cliente_id
+  LEFT JOIN perfiles tr ON tr.id = f.transportista_id;
+
+  RETURN v_out;
+END;
+$fn$;
+
+COMMENT ON FUNCTION public.jornada_preventista_detalle(date, uuid) IS
+'Panel "Mis entregas": detalle de un día de reparto (pedidos del preventista con su desenlace, motivo y salvedades). p_dia NULL devuelve los pedidos sin desenlace todavía. Sólo lectura.';
+
+GRANT EXECUTE ON FUNCTION public.jornada_preventista_detalle(date, uuid) TO authenticated;
+
+
+-- -------------------------------------------------------------------------
+-- Chequeo anti-PGRST203 (mig 176): ninguna de las dos puede tener más de una
+-- firma, o PostgREST no sabe cuál llamar y falla recién en runtime.
+--
+--   SELECT proname, count(*)
+--     FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace
+--    WHERE n.nspname = 'public'
+--      AND proname IN ('jornadas_preventista','jornada_preventista_detalle')
+--    GROUP BY 1 HAVING count(*) > 1;
+--
+-- Tiene que devolver 0 filas.
+-- -------------------------------------------------------------------------

--- a/migrations/MANIFEST.md
+++ b/migrations/MANIFEST.md
@@ -128,9 +128,20 @@ funcional** y no se renombran los archivos: renombrarlos los desalinearía del l
 real lo da `version` y está en la sección A: en los dos casos el archivo de `main` quedó
 cronológicamente **fuera** del bloque 139–147 (uno antes, otro entre la 144 y la 145).
 
-**La próxima migración es la 177** — la última numerada en el repo es
-`176_sobrecargas_ambiguas` (aplicada). Las **174**
-(`174_salvedad_regalos_y_minimo_de_venta`), **175** y **176** mapean 1:1 con el ledger.
+**La próxima migración es la 180** — la última numerada en el repo es
+`179_jornadas_del_preventista` (aplicada). Las **174**
+(`174_salvedad_regalos_y_minimo_de_venta`), **175**, **176**, **177**, **178** y **179**
+mapean 1:1 con el ledger.
+
+La **179** agrega dos funciones de lectura para el panel "Mis entregas" del preventista
+(`jornadas_preventista` y `jornada_preventista_detalle`). No toca ninguna fila. Deja escrita
+una decisión de negocio que conviene no invertir: **la lista de motivos de cancelación
+administrativos es NEGRA, no blanca**, así que un motivo nuevo cuenta como rechazo y se ve.
+Al revés se escondería solo, que es exactamente la falla que el panel vino a arreglar.
+De paso documenta que `marcar_no_entregado` (mig 144) está prácticamente sin uso —2 filas en
+toda la base—: el pedido que no se entrega se cancela con motivo tipificado o se queda
+colgado en `asignado`, así que **`recorrido_pedidos` no sirve como fuente del "no entregado"**
+(y encima su RLS es admin-o-chofer, invisible para el preventista).
 
 La **176** deja una regla que conviene no volver a romper: **dos sobrecargas cuyas aridades
 se superponen por defaults hacen que PostgREST no pueda elegir** y devuelva HTTP 300

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -40,6 +40,7 @@ import UsuariosContainer from './components/containers/UsuariosContainer'
 // lazyWithReload: si un chunk quedó obsoleto tras un deploy (PWA con SW que
 // tomó control a mitad de sesión), recarga una vez en vez de colgar el Suspense.
 const VistaRendiciones = lazyWithReload(() => import('./components/vistas/VistaRendiciones'))
+const VistaMisEntregas = lazyWithReload(() => import('./components/vistas/VistaMisEntregas'))
 const VistaSalvedades = lazyWithReload(() => import('./components/vistas/VistaSalvedades'))
 const VistaGeolocalizacion = lazyWithReload(() => import('./components/vistas/VistaGeolocalizacion'))
 const AnalyticsContainer = lazyWithReload(() => import('./components/containers/AnalyticsContainer'))
@@ -264,6 +265,13 @@ function MainAppInner({ user, perfil, logout, authReady }: {
                 <Route
                   path="/dashboard"
                   element={(isAdmin || isPreventista) ? <DashboardContainer /> : <Navigate to="/pedidos" replace />}
+                />
+
+                <Route
+                  path="/mis-entregas"
+                  element={(isPreventista || isAdminOrEncargado)
+                    ? <VistaMisEntregas />
+                    : <Navigate to="/pedidos" replace />}
                 />
 
                 <Route path="/pedidos" element={<PedidosContainer />} />

--- a/src/components/layout/TopNavigation.tsx
+++ b/src/components/layout/TopNavigation.tsx
@@ -4,7 +4,7 @@ import type { LucideIcon } from 'lucide-react';
 import {
   Truck, Menu, X, LogOut, Moon, Sun, ChevronDown,
   BarChart3, ShoppingCart, Users, Package, TrendingUp,
-  UserCog, Route, ShoppingBag, Building2, Banknote, AlertTriangle, Database, Percent, ArrowRightLeft, Gift, Send, MapPin, Clock, Target
+  UserCog, Route, ShoppingBag, Building2, Banknote, AlertTriangle, Database, Percent, ArrowRightLeft, Gift, Send, MapPin, Clock, Target, ClipboardCheck
 } from 'lucide-react';
 import { getRolColor, getRolLabel } from '../../utils/formatters';
 import { useTheme } from '../../contexts/ThemeContext';
@@ -51,6 +51,7 @@ const menuGroups: MenuGroup[] = [
     items: [
       { id: 'dashboard', icon: BarChart3, label: 'Dashboard', roles: ['admin', 'preventista'] },
       { id: 'pedidos', icon: ShoppingCart, label: 'Pedidos', roles: ['admin', 'encargado', 'preventista', 'transportista', 'deposito'] },
+      { id: 'mis-entregas', icon: ClipboardCheck, label: 'Mis entregas', roles: ['admin', 'encargado', 'preventista'] },
     ]
   },
   {

--- a/src/components/misEntregas/BadgeDesenlace.tsx
+++ b/src/components/misEntregas/BadgeDesenlace.tsx
@@ -1,0 +1,22 @@
+import { memo } from 'react'
+import { LABEL_DESENLACE, ESTILO_DESENLACE, type Desenlace } from '../../constants/desenlacePedido'
+
+interface Props {
+  desenlace: Desenlace
+}
+
+function BadgeDesenlace({ desenlace }: Props) {
+  const estilo = ESTILO_DESENLACE[desenlace] ?? ESTILO_DESENLACE.pendiente
+  const Icon = estilo.icon
+
+  return (
+    <span
+      className={`inline-flex items-center gap-1 px-1.5 py-0.5 rounded text-xs font-medium ${estilo.badge}`}
+    >
+      <Icon className="w-3 h-3" aria-hidden="true" />
+      {LABEL_DESENLACE[desenlace] ?? desenlace}
+    </span>
+  )
+}
+
+export default memo(BadgeDesenlace)

--- a/src/components/misEntregas/FilaPedidoDia.tsx
+++ b/src/components/misEntregas/FilaPedidoDia.tsx
@@ -1,0 +1,88 @@
+/**
+ * Una fila del día: un cliente y qué pasó con su pedido.
+ *
+ * El motivo se muestra siempre que exista, incluido "Otro" y el caso sin
+ * motivo cargado — esconderlos haría que el panel diga "no entregado" sin
+ * decir por qué, que es justo el vacío que vino a llenar.
+ */
+import { memo } from 'react'
+import { LABEL_MOTIVO, MOTIVO_EXPLICACION } from '../../constants/motivosNoEntrega'
+import { MOTIVOS_SALVEDAD_LABELS } from '../../lib/schemas'
+import { formatPrecio, formatFecha } from '../../utils/formatters'
+import type { PedidoDelDia } from '../../hooks/queries/useJornadasPreventistaQuery'
+import BadgeDesenlace from './BadgeDesenlace'
+
+interface Props {
+  pedido: PedidoDelDia
+  /** En el bucket de pendientes la fecha de carga es el dato que importa
+   *  (cuánto hace que está colgado); en un día cerrado es ruido. */
+  mostrarFechaPedido?: boolean
+}
+
+function textoMotivo(pedido: PedidoDelDia): string | null {
+  if (pedido.desenlace !== 'rechazado' && pedido.desenlace !== 'administrativo') return null
+  if (!pedido.motivo_tipo) return 'Sin motivo cargado'
+  return MOTIVO_EXPLICACION[pedido.motivo_tipo] ?? LABEL_MOTIVO[pedido.motivo_tipo] ?? pedido.motivo_tipo
+}
+
+function FilaPedidoDia({ pedido, mostrarFechaPedido = false }: Props) {
+  const motivo = textoMotivo(pedido)
+
+  return (
+    <li className="py-2.5 border-b border-gray-100 dark:border-gray-700 last:border-0">
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0 flex-1">
+          <p className="text-sm font-medium text-gray-900 dark:text-gray-100 truncate">
+            {pedido.cliente}
+          </p>
+          <div className="mt-1 flex flex-wrap items-center gap-x-2 gap-y-1">
+            <BadgeDesenlace desenlace={pedido.desenlace} />
+            <span className="text-xs text-gray-500 dark:text-gray-400">#{pedido.pedido_id}</span>
+            {mostrarFechaPedido && (
+              <span className="text-xs text-gray-500 dark:text-gray-400">
+                cargado el {formatFecha(pedido.fecha_pedido)}
+              </span>
+            )}
+          </div>
+
+          {motivo && (
+            <p className="mt-1 text-xs text-gray-600 dark:text-gray-300">
+              {motivo}
+              {pedido.motivo_nota && (
+                <span className="italic text-gray-500 dark:text-gray-400"> — «{pedido.motivo_nota}»</span>
+              )}
+            </p>
+          )}
+
+          {pedido.salvedades.length > 0 && (
+            <ul className="mt-1.5 space-y-0.5">
+              {pedido.salvedades.map((s, i) => (
+                <li key={i} className="text-xs text-amber-700 dark:text-amber-300">
+                  {s.cantidad_afectada} de {s.cantidad_original} × {s.producto}
+                  <span className="text-amber-600 dark:text-amber-400">
+                    {' '}· {MOTIVOS_SALVEDAD_LABELS[s.motivo as keyof typeof MOTIVOS_SALVEDAD_LABELS] ?? s.motivo}
+                  </span>
+                  {s.descripcion && (
+                    <span className="italic text-amber-600 dark:text-amber-400"> «{s.descripcion}»</span>
+                  )}
+                </li>
+              ))}
+            </ul>
+          )}
+
+          {pedido.transportista && (
+            <p className="mt-1 text-xs text-gray-400 dark:text-gray-500">
+              Repartió {pedido.transportista}
+            </p>
+          )}
+        </div>
+
+        <span className="shrink-0 text-sm tabular-nums font-medium text-gray-700 dark:text-gray-200">
+          {formatPrecio(pedido.monto)}
+        </span>
+      </div>
+    </li>
+  )
+}
+
+export default memo(FilaPedidoDia)

--- a/src/components/misEntregas/TarjetaDia.tsx
+++ b/src/components/misEntregas/TarjetaDia.tsx
@@ -1,0 +1,140 @@
+/**
+ * Un día de reparto. Colapsada muestra el marcador; el detalle se pide recién
+ * al expandir — mismo patrón que las tarjetas de VistaRendiciones.
+ */
+import { useState } from 'react'
+import { ChevronDown, ChevronUp } from 'lucide-react'
+import { useJornadaDetalleQuery } from '../../hooks/queries/useJornadasPreventistaQuery'
+import type { ResumenDia } from '../../hooks/queries/useJornadasPreventistaQuery'
+import {
+  desenlacesDelFiltro,
+  ESTILO_DESENLACE,
+  type FiltroDesenlace,
+} from '../../constants/desenlacePedido'
+import { formatPrecio, parseDateSafe } from '../../utils/formatters'
+import FilaPedidoDia from './FilaPedidoDia'
+
+interface Props {
+  resumen: ResumenDia
+  preventistaId: string | null
+  filtro: FiltroDesenlace
+  /** El día más reciente arranca abierto: es el que se viene a mirar. */
+  defaultExpandido?: boolean
+}
+
+function fechaLarga(dia: string): string {
+  return parseDateSafe(dia).toLocaleDateString('es-AR', {
+    weekday: 'long',
+    day: 'numeric',
+    month: 'long',
+  })
+}
+
+export default function TarjetaDia({ resumen, preventistaId, filtro, defaultExpandido = false }: Props) {
+  const [expandido, setExpandido] = useState(defaultExpandido)
+  const [verAdministrativos, setVerAdministrativos] = useState(false)
+
+  const { data: pedidos = [], isLoading } = useJornadaDetalleQuery(
+    resumen.dia,
+    preventistaId,
+    expandido,
+  )
+
+  const operativos = resumen.total - resumen.administrativos
+  const permitidos = desenlacesDelFiltro(filtro)
+  const visibles = pedidos.filter(p => {
+    if (p.desenlace === 'administrativo') return false
+    return permitidos === null || permitidos.includes(p.desenlace)
+  })
+  const administrativos = pedidos.filter(p => p.desenlace === 'administrativo')
+
+  return (
+    <div className="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-xl overflow-hidden">
+      <button
+        type="button"
+        onClick={() => setExpandido(!expandido)}
+        aria-expanded={expandido}
+        className="w-full text-left p-4 hover:bg-gray-50 dark:hover:bg-gray-750 transition-colors"
+      >
+        <div className="flex items-start justify-between gap-3">
+          <div className="min-w-0">
+            <p className="text-sm font-semibold text-gray-900 dark:text-gray-100 capitalize">
+              {fechaLarga(resumen.dia)}
+            </p>
+            <div className="mt-1 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs">
+              {/* Sin los administrativos, para que el marcador cierre con lo
+                  que se lista abajo: si el día tuvo un error de carga, ese no
+                  fue un cliente que existió. */}
+              <span className="text-gray-500 dark:text-gray-400">
+                {operativos} {operativos === 1 ? 'pedido' : 'pedidos'}
+              </span>
+              {resumen.entregados > 0 && (
+                <span className={ESTILO_DESENLACE.entregado.punto}>
+                  {resumen.entregados} entregados
+                </span>
+              )}
+              {resumen.con_salvedad > 0 && (
+                <span className={ESTILO_DESENLACE.entregado_con_salvedad.punto}>
+                  {resumen.con_salvedad} con salvedad
+                </span>
+              )}
+              {resumen.rechazados > 0 && (
+                <span className={`font-medium ${ESTILO_DESENLACE.rechazado.punto}`}>
+                  {resumen.rechazados} no {resumen.rechazados === 1 ? 'entregado' : 'entregados'}
+                </span>
+              )}
+            </div>
+            {resumen.monto_rechazado > 0 && (
+              <p className="mt-1 text-xs text-red-600 dark:text-red-400 tabular-nums">
+                {formatPrecio(resumen.monto_rechazado)} sin entregar
+              </p>
+            )}
+          </div>
+          {expandido
+            ? <ChevronUp className="w-4 h-4 shrink-0 mt-1 text-gray-400" aria-hidden="true" />
+            : <ChevronDown className="w-4 h-4 shrink-0 mt-1 text-gray-400" aria-hidden="true" />}
+        </div>
+      </button>
+
+      {expandido && (
+        <div className="px-4 pb-3 border-t border-gray-100 dark:border-gray-700">
+          {isLoading ? (
+            <p className="py-3 text-xs text-gray-500 dark:text-gray-400">Cargando…</p>
+          ) : (
+            <>
+              <ul>
+                {visibles.map(p => <FilaPedidoDia key={p.pedido_id} pedido={p} />)}
+              </ul>
+
+              {visibles.length === 0 && (
+                <p className="py-3 text-xs text-gray-500 dark:text-gray-400">
+                  Nada de este día entra en el filtro.
+                </p>
+              )}
+
+              {/* Los administrativos existen pero no son rechazos: quedan a
+                  mano sin ensuciar el marcador del día. */}
+              {administrativos.length > 0 && (
+                <div className="pt-2">
+                  <button
+                    type="button"
+                    onClick={() => setVerAdministrativos(!verAdministrativos)}
+                    className="text-xs text-gray-500 dark:text-gray-400 hover:underline"
+                  >
+                    {verAdministrativos ? 'Ocultar' : `Ver ${administrativos.length}`} corregidos en
+                    oficina (errores de carga, pruebas, unificados)
+                  </button>
+                  {verAdministrativos && (
+                    <ul className="mt-1">
+                      {administrativos.map(p => <FilaPedidoDia key={p.pedido_id} pedido={p} />)}
+                    </ul>
+                  )}
+                </div>
+              )}
+            </>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/components/pedidos/PanelPedidosNoEntregados.tsx
+++ b/src/components/pedidos/PanelPedidosNoEntregados.tsx
@@ -1,24 +1,29 @@
 /**
  * PanelPedidosNoEntregados
  *
- * Qué pedidos volvieron sin entregar y por qué. Va arriba de /pedidos porque el
- * pedido no entregado vuelve al estado 'pendiente' (mig 144): en la lista se ve
- * idéntico a uno recién cargado, así que sin esto el motivo se pierde apenas la
- * notificación de la campanita queda atrás.
+ * Qué pedidos del preventista quedaron colgados: siguen vivos, sin entregar y
+ * sin cancelar, así que en la lista de /pedidos se ven idénticos a uno recién
+ * cargado y nadie los mira. Va arriba de /pedidos porque es el lugar donde el
+ * preventista ya está parado.
  *
- * Es el lado del preventista de la misma historia que el panel de Recorridos le
- * muestra al admin. La RLS ya acota: cada uno ve los suyos.
+ * Antes esto salía de `recorrido_pedidos` y no devolvía nada para un
+ * preventista: la RLS de esa tabla es admin-o-chofer, así que la query volvía
+ * vacía sin error y el panel no se renderizaba nunca (ver el comentario de
+ * useNoEntregadosQuery). Ahora sale del RPC de la mig 179.
+ *
+ * El detalle completo —con motivo, salvedades y el día de reparto— vive en
+ * /mis-entregas; esto es el empujón para ir hasta ahí.
  */
 import { useState } from 'react'
+import { Link } from 'react-router-dom'
 import { PackageX, ChevronDown, ChevronUp } from 'lucide-react'
-import { usePedidosRebotadosQuery } from '../../hooks/queries'
-import { MOTIVO_EXPLICACION, LABEL_MOTIVO } from '../../constants/motivosNoEntrega'
-import { formatPrecio } from '../../utils/formatters'
+import { usePedidosSinResolverQuery } from '../../hooks/queries'
+import { formatPrecio, formatFecha } from '../../utils/formatters'
 
 const VISIBLES_POR_DEFECTO = 3
 
 export default function PanelPedidosNoEntregados() {
-  const { data: pedidos = [], isLoading } = usePedidosRebotadosQuery()
+  const { data: pedidos = [], isLoading } = usePedidosSinResolverQuery()
   const [expandido, setExpandido] = useState(false)
 
   if (isLoading || pedidos.length === 0) return null
@@ -33,11 +38,11 @@ export default function PanelPedidosNoEntregados() {
         <div className="min-w-0 flex-1">
           <p className="text-sm font-semibold text-amber-800 dark:text-amber-200">
             {pedidos.length === 1
-              ? '1 pedido volvió sin entregar'
-              : `${pedidos.length} pedidos volvieron sin entregar`}
+              ? '1 pedido tuyo sigue sin resolver'
+              : `${pedidos.length} pedidos tuyos siguen sin resolver`}
           </p>
           <p className="text-xs text-amber-700 dark:text-amber-300 mt-0.5">
-            Siguen vivos y volvieron al pool para re-repartir. Revisá el motivo antes de reprogramar.
+            No se entregaron ni se cancelaron. Revisalos antes de que envejezcan más.
           </p>
 
           <ul className="mt-2 space-y-1">
@@ -48,31 +53,39 @@ export default function PanelPedidosNoEntregados() {
               >
                 <span className="font-medium">#{p.pedidoId}</span>
                 <span className="truncate max-w-[14rem]">{p.clienteNombre}</span>
-                <span className="text-amber-700 dark:text-amber-300">
-                  · {p.motivo === 'sin_motivo'
-                      ? 'sin motivo cargado'
-                      : (MOTIVO_EXPLICACION[p.motivo] ?? LABEL_MOTIVO[p.motivo] ?? p.motivo)}
+                {p.fecha && (
+                  <span className="text-amber-600 dark:text-amber-400">
+                    · del {formatFecha(p.fecha)}
+                  </span>
+                )}
+                <span className="tabular-nums text-amber-700 dark:text-amber-300">
+                  {formatPrecio(p.total)}
                 </span>
-                {p.nota && <span className="italic text-amber-700 dark:text-amber-300">«{p.nota}»</span>}
-                {p.fecha && <span className="text-amber-600 dark:text-amber-400">· {p.fecha}</span>}
-                <span className="tabular-nums text-amber-700 dark:text-amber-300">{formatPrecio(p.total)}</span>
               </li>
             ))}
           </ul>
 
-          {(ocultos > 0 || expandido) && (
-            <button
-              type="button"
-              onClick={() => setExpandido(!expandido)}
-              className="mt-1.5 inline-flex items-center gap-1 text-xs font-medium text-amber-800 dark:text-amber-200 hover:underline"
+          <div className="mt-1.5 flex flex-wrap items-center gap-x-3">
+            {(ocultos > 0 || expandido) && (
+              <button
+                type="button"
+                onClick={() => setExpandido(!expandido)}
+                className="inline-flex items-center gap-1 text-xs font-medium text-amber-800 dark:text-amber-200 hover:underline"
+              >
+                {expandido ? (
+                  <>Ver menos <ChevronUp className="w-3 h-3" aria-hidden="true" /></>
+                ) : (
+                  <>Ver {ocultos} más <ChevronDown className="w-3 h-3" aria-hidden="true" /></>
+                )}
+              </button>
+            )}
+            <Link
+              to="/mis-entregas"
+              className="text-xs font-medium text-amber-800 dark:text-amber-200 hover:underline"
             >
-              {expandido ? (
-                <>Ver menos <ChevronUp className="w-3 h-3" aria-hidden="true" /></>
-              ) : (
-                <>Ver {ocultos} más <ChevronDown className="w-3 h-3" aria-hidden="true" /></>
-              )}
-            </button>
-          )}
+              Ver mis entregas
+            </Link>
+          </div>
         </div>
       </div>
     </div>

--- a/src/components/vistas/VistaMisEntregas.tsx
+++ b/src/components/vistas/VistaMisEntregas.tsx
@@ -1,0 +1,231 @@
+/**
+ * "Mis entregas" — qué pasó, día por día, con los pedidos que tomó el
+ * preventista (mig 179).
+ *
+ * El preventista cierra la venta y después no se entera de nada: si el cliente
+ * rechazó, si el local estaba cerrado, si el chofer entregó de menos. Todo eso
+ * pasa cuando él ya no está, y hasta acá no había ninguna pantalla que se lo
+ * contara. Se enteraba en la visita siguiente, por el cliente.
+ *
+ * Los días se agrupan por fecha de REPARTO (cuándo se entregó o se cayó), no
+ * por fecha de carga: la entrega es a D+1 sólo la mitad de las veces y se
+ * estira hasta D+10, así que agrupar por carga mezclaría desenlaces de
+ * semanas distintas en la misma tarjeta.
+ *
+ * Solo lectura. No hay un botón acá que cambie un pedido.
+ */
+import { useMemo, useState } from 'react'
+import { CalendarDays, Clock, PackageX } from 'lucide-react'
+import { useAuthData } from '../../contexts/AuthDataContext'
+import {
+  useJornadasPreventistaQuery,
+  useJornadaDetalleQuery,
+} from '../../hooks/queries/useJornadasPreventistaQuery'
+import { useUsuariosByRolQuery } from '../../hooks/queries'
+import { LABEL_FILTRO, type FiltroDesenlace } from '../../constants/desenlacePedido'
+import { fechaLocalISO, fechaHaceDias, formatPrecio, formatFecha } from '../../utils/formatters'
+import EmptyState from '../ui/EmptyState'
+import TarjetaDia from '../misEntregas/TarjetaDia'
+import FilaPedidoDia from '../misEntregas/FilaPedidoDia'
+
+const PERIODOS = [
+  { dias: 7, label: '7 días' },
+  { dias: 14, label: '14 días' },
+  { dias: 30, label: '30 días' },
+] as const
+
+const FILTROS: FiltroDesenlace[] = ['todos', 'entregados', 'rechazados', 'pendientes']
+
+export default function VistaMisEntregas() {
+  const { isAdmin, isEncargado } = useAuthData()
+  const puedeElegirPreventista = isAdmin || isEncargado
+
+  const [dias, setDias] = useState<number>(14)
+  const [filtro, setFiltro] = useState<FiltroDesenlace>('todos')
+  const [preventistaId, setPreventistaId] = useState<string | null>(null)
+
+  const hasta = fechaLocalISO()
+  const desde = fechaHaceDias(dias - 1)
+
+  const { data, isLoading, error } = useJornadasPreventistaQuery(desde, hasta, preventistaId)
+  const { data: preventistas = [] } = useUsuariosByRolQuery(
+    puedeElegirPreventista ? 'preventista' : '',
+  )
+
+  // El bucket de colgados no pertenece a ningún día: se pide aparte y sólo
+  // cuando el filtro lo pone en primer plano o no filtra nada.
+  const mostrarPendientes = filtro === 'todos' || filtro === 'pendientes'
+  const { data: pendientes = [], isLoading: cargandoPendientes } = useJornadaDetalleQuery(
+    null,
+    preventistaId,
+    mostrarPendientes && Boolean(data?.pendientes.total),
+  )
+
+  const diasVisibles = useMemo(() => {
+    if (!data) return []
+    if (filtro === 'pendientes') return []
+    if (filtro === 'entregados') return data.dias.filter(d => d.entregados > 0)
+    if (filtro === 'rechazados') return data.dias.filter(d => d.rechazados > 0)
+    // Un día que sólo tuvo cancelaciones administrativas no le dice nada al
+    // preventista: no hubo ningún cliente esperando mercadería.
+    return data.dias.filter(d => d.total - d.administrativos > 0)
+  }, [data, filtro])
+
+  if (error) {
+    const msg = (error as { code?: string; message?: string })
+    return (
+      <div className="max-w-3xl mx-auto">
+        <EmptyState
+          icon={PackageX}
+          title={msg.code === '42501' ? 'No tenés permiso para ver este panel' : 'No se pudo cargar'}
+          description={msg.code === '42501' ? undefined : msg.message}
+        />
+      </div>
+    )
+  }
+
+  return (
+    <div className="max-w-3xl mx-auto space-y-4">
+      <div>
+        <h1 className="text-xl font-bold text-gray-900 dark:text-gray-100">
+          {puedeElegirPreventista && data?.nombre ? `Entregas de ${data.nombre}` : 'Mis entregas'}
+        </h1>
+        <p className="text-sm text-gray-500 dark:text-gray-400 mt-0.5">
+          Qué pasó con los pedidos que tomaste, día por día.
+        </p>
+      </div>
+
+      {puedeElegirPreventista && preventistas.length > 0 && (
+        <select
+          value={preventistaId ?? ''}
+          onChange={e => setPreventistaId(e.target.value || null)}
+          className="w-full sm:w-auto h-9 px-3 rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-sm text-gray-900 dark:text-gray-100"
+          aria-label="Elegir preventista"
+        >
+          <option value="">Mis pedidos</option>
+          {preventistas.map(p => (
+            <option key={p.id} value={p.id}>{p.nombre}</option>
+          ))}
+        </select>
+      )}
+
+      <div className="flex flex-wrap gap-2">
+        {PERIODOS.map(p => (
+          <button
+            key={p.dias}
+            type="button"
+            onClick={() => setDias(p.dias)}
+            aria-pressed={dias === p.dias}
+            className={`h-8 px-3 rounded-lg text-sm font-medium transition-colors ${
+              dias === p.dias
+                ? 'bg-blue-600 text-white'
+                : 'bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-200 hover:bg-gray-200 dark:hover:bg-gray-600'
+            }`}
+          >
+            {p.label}
+          </button>
+        ))}
+      </div>
+
+      {data && (
+        <div className="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-xl p-4">
+          <div className="grid grid-cols-3 gap-3 text-center">
+            <div>
+              <p className="text-lg font-bold text-emerald-600 dark:text-emerald-400 tabular-nums">
+                {data.totales.entregados}
+              </p>
+              <p className="text-xs text-gray-500 dark:text-gray-400">entregados</p>
+            </div>
+            <div>
+              <p className="text-lg font-bold text-red-600 dark:text-red-400 tabular-nums">
+                {data.totales.rechazados}
+              </p>
+              <p className="text-xs text-gray-500 dark:text-gray-400">no entregados</p>
+            </div>
+            <div>
+              <p className="text-lg font-bold text-gray-700 dark:text-gray-200 tabular-nums">
+                {data.totales.pct_rechazo}%
+              </p>
+              <p className="text-xs text-gray-500 dark:text-gray-400">de rechazo</p>
+            </div>
+          </div>
+          {data.totales.monto_rechazado > 0 && (
+            <p className="mt-2 text-center text-xs text-gray-500 dark:text-gray-400 tabular-nums">
+              {formatPrecio(data.totales.monto_rechazado)} que no llegaron a destino
+            </p>
+          )}
+        </div>
+      )}
+
+      <div className="flex flex-wrap gap-2">
+        {FILTROS.map(f => (
+          <button
+            key={f}
+            type="button"
+            onClick={() => setFiltro(f)}
+            aria-pressed={filtro === f}
+            className={`h-8 px-3 rounded-lg text-sm font-medium transition-colors ${
+              filtro === f
+                ? 'bg-gray-900 dark:bg-gray-100 text-white dark:text-gray-900'
+                : 'bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-200 hover:bg-gray-200 dark:hover:bg-gray-600'
+            }`}
+          >
+            {LABEL_FILTRO[f]}
+            {f === 'pendientes' && data?.pendientes.total ? ` (${data.pendientes.total})` : ''}
+          </button>
+        ))}
+      </div>
+
+      {/* Los colgados van arriba: son los que nadie está mirando. */}
+      {mostrarPendientes && data && data.pendientes.total > 0 && (
+        <div className="bg-sky-50 dark:bg-sky-900/20 border border-sky-200 dark:border-sky-800/60 rounded-xl p-4">
+          <div className="flex items-start gap-2">
+            <Clock className="w-4 h-4 shrink-0 mt-0.5 text-sky-600 dark:text-sky-400" aria-hidden="true" />
+            <div className="min-w-0 flex-1">
+              <p className="text-sm font-semibold text-sky-900 dark:text-sky-100">
+                {data.pendientes.total} {data.pendientes.total === 1 ? 'pedido sigue' : 'pedidos siguen'} sin resolver
+              </p>
+              <p className="text-xs text-sky-700 dark:text-sky-300 mt-0.5 tabular-nums">
+                {formatPrecio(data.pendientes.monto)}
+                {data.pendientes.mas_viejo && ` · el más viejo es del ${formatFecha(data.pendientes.mas_viejo)}`}
+              </p>
+              {cargandoPendientes ? (
+                <p className="mt-2 text-xs text-sky-700 dark:text-sky-300">Cargando…</p>
+              ) : (
+                <ul className="mt-2">
+                  {pendientes.map(p => (
+                    <FilaPedidoDia key={p.pedido_id} pedido={p} mostrarFechaPedido />
+                  ))}
+                </ul>
+              )}
+            </div>
+          </div>
+        </div>
+      )}
+
+      {isLoading && (
+        <p className="text-sm text-gray-500 dark:text-gray-400">Cargando…</p>
+      )}
+
+      {!isLoading && diasVisibles.length === 0 && filtro !== 'pendientes' && (
+        <EmptyState
+          icon={CalendarDays}
+          title="Sin movimientos"
+          description={`No hay pedidos tuyos con desenlace en los últimos ${dias} días.`}
+        />
+      )}
+
+      <div className="space-y-2">
+        {diasVisibles.map((d, i) => (
+          <TarjetaDia
+            key={d.dia}
+            resumen={d}
+            preventistaId={preventistaId}
+            filtro={filtro}
+            defaultExpandido={i === 0}
+          />
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/src/constants/desenlacePedido.ts
+++ b/src/constants/desenlacePedido.ts
@@ -1,0 +1,119 @@
+/**
+ * Desenlace de un pedido para el panel "Mis entregas" (mig 179).
+ *
+ * Es una dimensión distinta de `pedidos.estado`: responde "¿el cliente
+ * terminó recibiendo la mercadería?", que es lo que le importa al preventista.
+ * Un `cancelado` puede ser un rechazo del cliente o la corrección de un error
+ * de carga, y mezclarlos arruina el número.
+ *
+ * La clasificación la hace el SQL, no el front — acá sólo viven las etiquetas.
+ * Las listas de motivos están para que un test pueda afirmar que cubren el
+ * CHECK de la mig 175 entero: si mañana se agrega un motivo y nadie lo
+ * clasifica, tiene que romper en CI, no aparecer callado en la columna
+ * equivocada.
+ */
+import { AlertTriangle, Check, Clock, PackageX, Wrench, type LucideIcon } from 'lucide-react'
+import {
+  MOTIVOS_NO_ENTREGA,
+  MOTIVOS_CANCELACION_ADMIN,
+  MOTIVOS_CANCELACION_SISTEMA,
+} from './motivosNoEntrega'
+
+export type Desenlace =
+  | 'entregado'
+  | 'entregado_con_salvedad'
+  | 'rechazado'
+  | 'administrativo'
+  | 'pendiente'
+
+export const LABEL_DESENLACE: Record<Desenlace, string> = {
+  entregado: 'Entregado',
+  entregado_con_salvedad: 'Entregado con salvedad',
+  rechazado: 'No entregado',
+  administrativo: 'Corregido en oficina',
+  pendiente: 'Sin resolver',
+}
+
+export interface EstiloDesenlace {
+  /** Clases de la píldora. */
+  badge: string
+  /** Color del punto/contador en el encabezado del día. */
+  punto: string
+  icon: LucideIcon
+}
+
+export const ESTILO_DESENLACE: Record<Desenlace, EstiloDesenlace> = {
+  entregado: {
+    badge: 'bg-emerald-100 text-emerald-800 dark:bg-emerald-900/40 dark:text-emerald-200',
+    punto: 'text-emerald-600 dark:text-emerald-400',
+    icon: Check,
+  },
+  entregado_con_salvedad: {
+    badge: 'bg-amber-100 text-amber-800 dark:bg-amber-900/40 dark:text-amber-200',
+    punto: 'text-amber-600 dark:text-amber-400',
+    icon: AlertTriangle,
+  },
+  rechazado: {
+    badge: 'bg-red-100 text-red-800 dark:bg-red-900/40 dark:text-red-200',
+    punto: 'text-red-600 dark:text-red-400',
+    icon: PackageX,
+  },
+  administrativo: {
+    badge: 'bg-gray-100 text-gray-600 dark:bg-gray-700 dark:text-gray-300',
+    punto: 'text-gray-500 dark:text-gray-400',
+    icon: Wrench,
+  },
+  pendiente: {
+    badge: 'bg-sky-100 text-sky-800 dark:bg-sky-900/40 dark:text-sky-200',
+    punto: 'text-sky-600 dark:text-sky-400',
+    icon: Clock,
+  },
+}
+
+/**
+ * Los motivos que NO son un rechazo: el pedido no debía existir o fue
+ * reemplazado por otro. Espeja la lista negra del `CASE` de la mig 179.
+ *
+ * Ojo: `cliente_cancelo` NO está acá aunque viva en MOTIVOS_CANCELACION_ADMIN.
+ * Que el cliente cancele es justo de lo que el preventista tiene que
+ * enterarse, no una corrección administrativa.
+ */
+export const MOTIVOS_ADMINISTRATIVOS = [
+  'error_de_carga',
+  'prueba',
+  'duplicado',
+  'unifica_pedidos',
+  'cambio_de_cliente',
+] as const
+
+/** Todos los valores del CHECK `pedidos_motivo_cancelacion_tipo_check` (mig 175). */
+export const MOTIVOS_CANCELACION_TODOS: readonly string[] = [
+  ...MOTIVOS_NO_ENTREGA.map(m => m.valor),
+  ...MOTIVOS_CANCELACION_ADMIN.map(m => m.valor),
+  ...MOTIVOS_CANCELACION_SISTEMA.map(m => m.valor),
+]
+
+/** Filtros de la barra superior del panel. */
+export type FiltroDesenlace = 'todos' | 'entregados' | 'rechazados' | 'pendientes'
+
+export const LABEL_FILTRO: Record<FiltroDesenlace, string> = {
+  todos: 'Todos',
+  entregados: 'Entregados',
+  rechazados: 'No entregados',
+  pendientes: 'Sin resolver',
+}
+
+/** Qué desenlaces entran en cada filtro. `administrativo` nunca es un filtro:
+ *  se muestra plegado al pie del día. */
+export function desenlacesDelFiltro(filtro: FiltroDesenlace): Desenlace[] | null {
+  switch (filtro) {
+    case 'entregados':
+      return ['entregado', 'entregado_con_salvedad']
+    case 'rechazados':
+      return ['rechazado']
+    case 'pendientes':
+      return ['pendiente']
+    default:
+      return null
+  }
+}

--- a/src/constants/motivosNoEntrega.ts
+++ b/src/constants/motivosNoEntrega.ts
@@ -6,7 +6,9 @@
  * decenas de variantes más, así que no se podía medir nada ni mostrarle al
  * preventista un motivo confiable.
  *
- * Los valores deben coincidir con los CHECK de la migración 140.
+ * Los valores deben coincidir con los CHECK de las migraciones 143
+ * (`recorrido_pedidos_motivo_no_entrega_check`, que los creó) y 175
+ * (`pedidos_motivo_cancelacion_tipo_check`, que agregó `cambio_de_cliente`).
  */
 
 /** Motivos que puede elegir el chofer cuando no pudo entregar. */

--- a/src/hooks/queries/index.ts
+++ b/src/hooks/queries/index.ts
@@ -205,8 +205,22 @@ export type {
 } from './useGruposPrecioQuery'
 
 // No entregados por motivo y barrida (migs 142-144)
-export { noEntregadosKeys, useNoEntregadosQuery, usePedidosRebotadosQuery } from './useNoEntregadosQuery'
-export type { NoEntregadosResumen, NoEntregadoFila, PedidoRebotado } from './useNoEntregadosQuery'
+export { noEntregadosKeys, useNoEntregadosQuery, usePedidosSinResolverQuery } from './useNoEntregadosQuery'
+export type { NoEntregadosResumen, NoEntregadoFila, PedidoSinResolver } from './useNoEntregadosQuery'
+
+// Panel "Mis entregas": el día a día del preventista (mig 179)
+export {
+  jornadasKeys,
+  useJornadasPreventistaQuery,
+  useJornadaDetalleQuery,
+} from './useJornadasPreventistaQuery'
+export type {
+  JornadasResultado,
+  ResumenDia,
+  PedidoDelDia,
+  SalvedadResumen,
+  PendientesResumen,
+} from './useJornadasPreventistaQuery'
 
 // Comisiones variables (migs 148-150)
 export {

--- a/src/hooks/queries/useJornadasPreventistaQuery.ts
+++ b/src/hooks/queries/useJornadasPreventistaQuery.ts
@@ -1,0 +1,171 @@
+/**
+ * Panel "Mis entregas": qué pasó, día por día, con los pedidos que tomó el
+ * preventista (migs 179).
+ *
+ * Sale de dos RPC y no de PostgREST, por tres razones que no son de estilo:
+ *
+ * - El día del reparto hay que derivarlo. `fecha_entrega_programada` coincide
+ *   con la entrega real sólo el 52% de las veces, y un cancelado ni siquiera
+ *   tiene `fecha_entrega` (NULL en 266 de 271): el día del rechazo vive en
+ *   `pedido_historial`.
+ * - La RLS de `clientes` acota al preventista a los clientes asignados a él
+ *   (`cliente_preventistas`), así que por PostgREST unos cuantos pedidos
+ *   propios volverían con el cliente en null. Un panel que se llama "a qué
+ *   clientes se les entregó" no puede tener filas sin nombre.
+ * - `salvedades_items` tiene DOS FKs a `pedidos` (`pedido_id` y
+ *   `pedido_reprogramado_id`): embeberla da PGRST201 y rompe la consulta
+ *   entera. Es la misma forma que tumbó "Armar ruta" en prod.
+ *
+ * CONTRATO DE PERMISOS (igual que `avance_metas_preventista`):
+ * `p_preventista_id: null` = el usuario logueado. Pasar otro id devuelve
+ * 42501 salvo que quien pregunta sea admin o encargado.
+ */
+import { useQuery } from '@tanstack/react-query'
+import { supabase } from '../supabase/base'
+import { useSucursal } from '../../contexts/SucursalContext'
+import type { Desenlace } from '../../constants/desenlacePedido'
+
+// =============================================================================
+// TYPES
+// =============================================================================
+
+export interface ResumenDia {
+  /** YYYY-MM-DD del día de reparto (entrega o caída), no el de la carga. */
+  dia: string
+  total: number
+  /** Incluye los entregados con salvedad. */
+  entregados: number
+  con_salvedad: number
+  rechazados: number
+  /** Cancelados por error de carga, prueba, duplicado, unificación o cambio
+   *  de cliente. No son rechazos y no cuentan como tales. */
+  administrativos: number
+  monto_entregado: number
+  monto_rechazado: number
+}
+
+export interface SalvedadResumen {
+  producto: string
+  cantidad_afectada: number
+  cantidad_original: number
+  motivo: string
+  descripcion: string | null
+  monto_afectado: number
+}
+
+export interface PedidoDelDia {
+  pedido_id: number
+  cliente: string
+  monto: number
+  desenlace: Desenlace
+  estado: string
+  /** Día en que el preventista cargó el pedido (puede ser muy anterior). */
+  fecha_pedido: string
+  motivo_tipo: string | null
+  motivo_nota: string | null
+  transportista: string | null
+  salvedades: SalvedadResumen[]
+}
+
+export interface PendientesResumen {
+  total: number
+  monto: number
+  /** Fecha del pedido colgado más viejo. Null si no hay ninguno. */
+  mas_viejo: string | null
+}
+
+export interface JornadasResultado {
+  preventista_id: string
+  nombre: string | null
+  desde: string
+  hasta: string
+  dias: ResumenDia[]
+  totales: {
+    entregados: number
+    rechazados: number
+    pct_rechazo: number
+    monto_rechazado: number
+  }
+  pendientes: PendientesResumen
+}
+
+// =============================================================================
+// QUERY KEYS
+// =============================================================================
+
+export const jornadasKeys = {
+  all: (sucursalId: number | null) => ['jornadas-preventista', sucursalId] as const,
+  rango: (sucursalId: number | null, preventistaId: string | null, desde: string, hasta: string) =>
+    [...jornadasKeys.all(sucursalId), preventistaId ?? 'yo', desde, hasta] as const,
+  detalle: (sucursalId: number | null, preventistaId: string | null, dia: string | null) =>
+    [...jornadasKeys.all(sucursalId), preventistaId ?? 'yo', 'detalle', dia ?? 'pendientes'] as const,
+}
+
+// =============================================================================
+// HOOKS
+// =============================================================================
+
+async function fetchJornadas(
+  desde: string,
+  hasta: string,
+  preventistaId: string | null,
+): Promise<JornadasResultado> {
+  const { data, error } = await supabase.rpc('jornadas_preventista', {
+    p_desde: desde,
+    p_hasta: hasta,
+    p_preventista_id: preventistaId,
+  })
+
+  if (error) throw error
+  return data as JornadasResultado
+}
+
+/** Resumen por día. Liviano: una fila por día, sin los pedidos. */
+export function useJornadasPreventistaQuery(
+  desde: string,
+  hasta: string,
+  preventistaId: string | null = null,
+  enabled = true,
+) {
+  const { currentSucursalId } = useSucursal()
+  return useQuery({
+    queryKey: jornadasKeys.rango(currentSucursalId, preventistaId, desde, hasta),
+    queryFn: () => fetchJornadas(desde, hasta, preventistaId),
+    enabled: enabled && Boolean(desde) && Boolean(hasta),
+    staleTime: 2 * 60 * 1000,
+  })
+}
+
+async function fetchDetalle(
+  dia: string | null,
+  preventistaId: string | null,
+): Promise<PedidoDelDia[]> {
+  const { data, error } = await supabase.rpc('jornada_preventista_detalle', {
+    p_dia: dia,
+    p_preventista_id: preventistaId,
+  })
+
+  if (error) throw error
+  return (data as PedidoDelDia[]) ?? []
+}
+
+/**
+ * Detalle de un día, al expandir la tarjeta. `dia = null` devuelve el bucket
+ * de pedidos sin desenlace.
+ *
+ * Se pide on-expand y no todo junto porque son 30 días × ~14 pedidos y esta
+ * pantalla se abre desde el teléfono, en la calle.
+ */
+export function useJornadaDetalleQuery(
+  dia: string | null,
+  preventistaId: string | null = null,
+  enabled = true,
+) {
+  const { currentSucursalId } = useSucursal()
+  return useQuery({
+    queryKey: jornadasKeys.detalle(currentSucursalId, preventistaId, dia),
+    queryFn: () => fetchDetalle(dia, preventistaId),
+    enabled,
+    staleTime: 2 * 60 * 1000,
+  })
+}

--- a/src/hooks/queries/useNoEntregadosQuery.ts
+++ b/src/hooks/queries/useNoEntregadosQuery.ts
@@ -81,93 +81,60 @@ async function fetchNoEntregados(desde: string, hasta: string): Promise<NoEntreg
 }
 
 // ---------------------------------------------------------------------------
-// Vista del preventista: qué pedidos MÍOS volvieron sin entregar y por qué.
+// Vista del preventista: qué pedidos MÍOS quedaron sin resolver.
 //
-// El pedido no entregado vuelve a 'pendiente' sin transportista (mig 144), así
-// que en la lista de /pedidos se ve igual que uno recién cargado. Sin esto, el
-// preventista se entera por la campanita y después el motivo se pierde.
+// Esto consultaba `recorrido_pedidos` y NO FUNCIONABA para un preventista. La
+// policy `mt_recorrido_pedidos_select` es `es_admin() OR (chofer dueño del
+// recorrido)`: el preventista no entra por ninguna rama, la query volvía
+// vacía SIN error (la RLS filtra, no falla) y el panel hacía `return null`.
+// Era invisible justo para el rol al que apuntaba.
 //
-// La RLS de `pedidos` ya acota: un preventista ve los suyos, un admin todos.
+// Y encima la fuente estaba mal elegida: `marcar_no_entregado` (mig 144), que
+// es lo que escribe en `recorrido_pedidos`, casi no se usa — 2 filas en toda
+// la base. En la práctica el pedido que no se entrega se CANCELA con motivo
+// tipificado, o se queda colgado en 'asignado'.
+//
+// Ahora sale del RPC `jornada_preventista_detalle(NULL)` (mig 179), que
+// devuelve los pedidos del preventista todavía sin desenlace y ya resuelve el
+// nombre del cliente (la RLS de `clientes` también lo escondía).
 // ---------------------------------------------------------------------------
 
-export interface PedidoRebotado {
+export interface PedidoSinResolver {
   pedidoId: string
   clienteNombre: string
-  motivo: string
-  nota: string | null
+  /** Día en que el preventista lo cargó: cuánto hace que está trabado. */
   fecha: string | null
   total: number
 }
 
-interface FilaPedidoCruda {
-  pedido_id: string
-  motivo_no_entrega: string | null
-  nota_no_entrega: string | null
-  recorridos: { fecha: string } | { fecha: string }[] | null
-  pedidos: {
-    id: string
-    total: number | null
-    estado: string
-    clientes: { nombre_fantasia: string | null; razon_social: string | null }
-      | { nombre_fantasia: string | null; razon_social: string | null }[] | null
-  } | null
+interface FilaPendiente {
+  pedido_id: number
+  cliente: string
+  monto: number | null
+  fecha_pedido: string | null
 }
 
-/** PostgREST devuelve objeto o array según la cardinalidad que infiere. */
-function primero<T>(v: T | T[] | null | undefined): T | null {
-  if (!v) return null
-  return Array.isArray(v) ? (v[0] ?? null) : v
-}
-
-async function fetchPedidosRebotados(dias: number): Promise<PedidoRebotado[]> {
-  const desde = new Date()
-  desde.setDate(desde.getDate() - dias)
-  const desdeISO = desde.toISOString().slice(0, 10)
-
-  const { data, error } = await supabase
-    .from('recorrido_pedidos')
-    .select(`
-      pedido_id, motivo_no_entrega, nota_no_entrega,
-      recorridos!inner(fecha),
-      pedidos!inner(id, total, estado, clientes(nombre_fantasia, razon_social))
-    `)
-    .eq('estado_entrega', 'no_entregado')
-    .gte('recorridos.fecha', desdeISO)
-    .order('id', { ascending: false })
+async function fetchPedidosSinResolver(): Promise<PedidoSinResolver[]> {
+  const { data, error } = await supabase.rpc('jornada_preventista_detalle', {
+    p_dia: null,
+    p_preventista_id: null,
+  })
 
   if (error) throw error
 
-  const filas = (data as unknown as FilaPedidoCruda[]) || []
-  const vistos = new Set<string>()
-  const out: PedidoRebotado[] = []
-
-  for (const f of filas) {
-    const pedido = primero(f.pedidos)
-    // Ya entregado o cancelado = el problema se resolvió; no ensucia la lista.
-    if (!pedido || pedido.estado === 'entregado' || pedido.estado === 'cancelado') continue
-    // Un pedido puede haber rebotado más de una vez: vale el rebote más reciente.
-    if (vistos.has(String(f.pedido_id))) continue
-    vistos.add(String(f.pedido_id))
-
-    const cliente = primero(pedido.clientes)
-    out.push({
-      pedidoId: String(f.pedido_id),
-      clienteNombre: cliente?.nombre_fantasia || cliente?.razon_social || 'Cliente',
-      motivo: f.motivo_no_entrega || 'sin_motivo',
-      nota: f.nota_no_entrega,
-      fecha: primero(f.recorridos)?.fecha ?? null,
-      total: Number(pedido.total ?? 0),
-    })
-  }
-
-  return out
+  return ((data as FilaPendiente[]) ?? []).map(f => ({
+    pedidoId: String(f.pedido_id),
+    clienteNombre: f.cliente,
+    fecha: f.fecha_pedido,
+    total: Number(f.monto ?? 0),
+  }))
 }
 
-export function usePedidosRebotadosQuery(dias = 30, enabled = true) {
+export function usePedidosSinResolverQuery(enabled = true) {
   const { currentSucursalId } = useSucursal()
   return useQuery({
-    queryKey: [...noEntregadosKeys.all(currentSucursalId), 'pedidos', dias] as const,
-    queryFn: () => fetchPedidosRebotados(dias),
+    queryKey: [...noEntregadosKeys.all(currentSucursalId), 'sin-resolver'] as const,
+    queryFn: fetchPedidosSinResolver,
     enabled,
     staleTime: 2 * 60 * 1000,
   })


### PR DESCRIPTION
## El problema

El preventista carga el pedido y después no sabe nada más. Si el cliente rechazó la mercadería, si el local estaba cerrado, si el chofer entregó de menos con una salvedad — todo eso pasa cuando él ya no está. Se entera en la visita siguiente, por el cliente, o no se entera.

## Qué hay ahora

Sección nueva `/mis-entregas` (menú principal, para preventista / encargado / admin):

- **Tarjetas por jornada de reparto** que se abren y muestran cliente por cliente el desenlace, el motivo tipificado con la nota del chofer, y las salvedades con producto y cantidad.
- **Filtros**: Todos / Entregados / No entregados / Sin resolver.
- **Marcador** con entregados, no entregados, % de rechazo y monto que no llegó a destino.
- **Bucket de colgados** arriba de todo: los pedidos que siguen en `asignado` sin entregarse ni cancelarse. Esa lista hoy no existe en ninguna pantalla.
- Los admin/encargados pueden elegir preventista en un combo.

Solo lectura: no hay un botón acá que cambie un pedido, toque stock ni mueva saldos.

## Tres hallazgos que cambiaron el diseño

**1. El panel que ya existía para esto estaba muerto.** `PanelPedidosNoEntregados` está montado en `PedidosContainer` desde hace meses y su comentario dice "la RLS ya acota: cada uno ve los suyos". Consulta `recorrido_pedidos`, cuya policy real en prod es:

```sql
mt_recorrido_pedidos_select: es_admin() OR (EXISTS (SELECT 1 FROM recorridos r
  WHERE r.id = recorrido_pedidos.recorrido_id AND r.transportista_id = auth.uid()))
```

Un preventista no entra por ninguna rama. La query devolvía `[]` **sin error** (la RLS filtra, no falla), el hook resolvía con array vacío y el componente hacía `return null`. Invisible exactamente para el rol al que apuntaba. Mismo modo de falla que documenta la mig 173.

**2. El "no entregado" no vive en `recorrido_pedidos`.** `marcar_no_entregado` (mig 144), que sería el registro canónico del rebote, tiene **2 filas en toda la base** y emitió **0 notificaciones**. En la práctica el pedido que no se entrega se **cancela con `motivo_cancelacion_tipo`** (271 casos). La fuente real es `pedidos` + `pedido_historial`.

**3. `pedidos.total` es 0 en 267 de 271 cancelados** (lo pone `cancelar_pedido_con_stock`). Sin recuperar el importe de `total_real` o de la suma de ítems, cada rechazo se mostraba en $0 y el panel no decía nada.

## Migración 179 — **ya aplicada a prod**

Dos funciones de lectura, `SECURITY DEFINER`, con el guard self-o-admin de `avance_metas_preventista`. **No tocan ninguna fila.**

Van por RPC y no por PostgREST por tres razones que no son de estilo:

- **El día del reparto hay que derivarlo.** `fecha_entrega_programada` coincide con la entrega real solo el **52%** de las veces, y un cancelado ni siquiera tiene `fecha_entrega` (NULL en 266 de 271): el día del rechazo vive en `pedido_historial`.
- **La RLS de `clientes`** acota al preventista a los clientes asignados a él, así que por PostgREST parte de los pedidos propios volverían con el cliente en `null`.
- **`salvedades_items` tiene dos FKs a `pedidos`** (`pedido_id` y `pedido_reprogramado_id`): embeberla da `PGRST201` y rompe la consulta entera. Es la misma forma que tumbó "Armar ruta" en prod.

### La decisión de negocio que queda escrita

**La lista de motivos administrativos es NEGRA, no blanca.** Un motivo nuevo cuenta como rechazo y se ve; al revés se escondería solo, que es justo la falla que el panel viene a arreglar.

- **Administrativos** (67): `error_de_carga`, `prueba`, `duplicado`, `unifica_pedidos`, `cambio_de_cliente`. Van plegados al pie del día, fuera del marcador.
- **Rechazos** (204): todo el resto, incluidos `otro` (38 — uno dice literalmente *"inconveniente entre fletero y clienta (observar)"*) y `cliente_cancelo` (19), que es de las cosas que el preventista más necesita saber.

## Verificación

- **Los totales cierran**: 803 = 803 para Marcelo (688 entregados / 71 rechazados / 5 administrativos / 39 pendientes). Ningún pedido se cae del `CASE`.
- **Guard probado en ambos sentidos**: un preventista pidiendo el id de otro recibe `42501`; un admin sí puede.
- **Una sola firma por función** — sin riesgo de `PGRST203` (la trampa de la mig 176).
- **16,5 ms para 90 días**, todo desde cache, cero lecturas de disco. Por eso descarté el índice extra que tenía previsto.
- Ledger y archivo 1:1 (`179_jornadas_del_preventista`).
- typecheck, lint, build y **1123 tests** en verde.

Con datos reales, Marcelo tiene **7,8% de rechazo** en 14 días ($360.160) y **39 pedidos colgados por $1.179.250**, el más viejo del 24 de julio.

## Fuera de alcance

- Notificar al preventista (push/campanita) cuando le rechazan: el `INSERT` en `notificaciones` cuelga de `marcar_no_entregado`, la RPC que nadie usa. Hacerlo bien implica emitirla desde `cancelar_pedido_con_stock`.
- Que el preventista pueda recargar o reprogramar el pedido rechazado.
- Cambiar que el equipo cancele en vez de usar `marcar_no_entregado`. El panel funciona con el flujo real tal como es hoy.

## Nota para el deploy

No hay service worker desde marzo: un preventista con la pestaña abierta hace días no va a ver el ítem del menú hasta recargar. No es una regresión (un bundle viejo simplemente no llama al RPC nuevo), pero conviene avisarles que recarguen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
