### PR TITLE
Que una caché podrida no pueda tumbar la app con señal

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,14 +12,24 @@ RUN npm ci --ignore-scripts
 # Copy source and build
 COPY . .
 
-# Build args for Vite env vars (baked at compile time)
+# Build args for Vite env vars (baked at compile time).
+# Tienen que estar TODAS las que usa el código: una que falte no rompe el
+# build, se compila con `undefined` y la feature muere en silencio en prod.
 ARG VITE_SUPABASE_URL
 ARG VITE_SUPABASE_ANON_KEY
 ARG VITE_GOOGLE_API_KEY
+# Map ID del vector map (cámara heading-up de navegación). Sin esto el mapa
+# cae al raster y se pierde la rotación.
+ARG VITE_GOOGLE_MAP_ID
 ARG VITE_SENTRY_DSN
 ARG VITE_APP_VERSION
+ARG VITE_TELEGRAM_BOT_USERNAME
 ARG VITE_N8N_WEBHOOK_URL
 ARG VITE_N8N_FACTURA_WEBHOOK_URL
+# Identidad del build para /version.json. Sin esto el build cae al fallback por
+# timestamp (`t<base36>`), que sirve para detectar deploys nuevos pero no dice
+# qué commit corre: pasarle el SHA hace que el dato sirva para soporte.
+ARG VITE_BUILD_ID
 
 RUN npm run build
 

--- a/vite.config.js
+++ b/vite.config.js
@@ -180,6 +180,39 @@ export default defineConfig({
       },
       workbox: {
         runtimeCaching: [
+          // PRIMERA a proposito: el router de workbox se queda con la primera
+          // ruta que matchea. Las navegaciones van a la RED primero y solo
+          // caen al cache si la red falla.
+          //
+          // El porque, que es el motivo de existir de esta entrada: si la
+          // navegacion se sirve del cache y WebKit no puede leer el cuerpo
+          // guardado (purga sus archivos y deja el indice: pasa en iOS), la
+          // pagina muere con "WebKitBlobResource error 1" y no hay JS que lo
+          // pueda atajar, porque el fallo ocurre al streamear la respuesta.
+          // Yendo a la red primero, un telefono con senal nunca toca esa
+          // bomba. Sin senal cae al cache, que es para lo que esta.
+          {
+            urlPattern: ({ request }) => request.mode === 'navigate',
+            handler: 'NetworkFirst',
+            options: {
+              cacheName: 'html-cache',
+              // Con senal mala no la hacemos esperar: a los 3 s sirve el shell.
+              networkTimeoutSeconds: 3,
+              plugins: [{
+                // Todas las navegaciones comparten UNA entrada. La app es una
+                // SPA: el HTML es el mismo para cualquier ruta. Asi una ruta
+                // que nunca abrio online (iOS restaura la ultima URL al
+                // reabrir la app) tambien levanta sin senal.
+                cacheKeyWillBeUsed: async () => '/index.html',
+                // Tercer nivel: sin red y con html-cache todavia vacio (recien
+                // instalado y se quedo sin senal antes de la primera
+                // navegacion), cae al precache. ignoreSearch porque workbox le
+                // cuelga ?__WB_REVISION__ a sus entradas.
+                handlerDidError: async () =>
+                  (await caches.match('/index.html', { ignoreSearch: true })) || undefined,
+              }],
+            },
+          },
           {
             urlPattern: /\.(?:png|jpg|jpeg|svg|gif|webp)$/i,
             handler: 'CacheFirst',
@@ -217,11 +250,15 @@ export default defineConfig({
         globPatterns: ['**/*.{js,css,html,ico,png,svg,woff2}'],
         globIgnores: ['**/*.map'],
         cleanupOutdatedCaches: true,
-        // Cualquier ruta se resuelve con el index.html precacheado: es lo que
-        // hace que la app abra sin señal en vez de quedar en blanco. El proxy
-        // de n8n queda afuera, va siempre a la red.
-        navigateFallback: 'index.html',
-        navigateFallbackDenylist: [/^\/api\//],
+        // Sin navigateFallback a propósito: workbox lo registra ANTES que
+        // runtimeCaching y se comería la ruta network-first de arriba, que es
+        // la que evita el "WebKitBlobResource error 1". El fallback offline
+        // ahora lo da esa misma ruta (html-cache con clave única).
+        navigateFallback: undefined,
+        // Por el mismo motivo. Con el default ('index.html') la ruta de
+        // precache resuelve "/" contra el index.html precacheado y se queda
+        // ella con la navegación, antes de que la vea el network-first.
+        directoryIndex: null,
         // Los dos en false a propósito, y es el corazón del arreglo de marzo:
         // el SW nuevo se queda ESPERANDO en vez de tomar control de la pestaña
         // abierta. Así la sesión en curso sigue sirviéndose del precache viejo


### PR DESCRIPTION
## Qué pasó

Una usuaria abrió `crecer.shycia.com.ar` en Safari y le salió:

> Safari no puede abrir la página. El error es: "No se pudo completar la operación. (Error de WebKitBlobResource 1)"

El server responde 200 — verificado con curl. Ese error lo genera **el propio iPhone** cuando no puede leer el cuerpo de una respuesta guardada en su almacenamiento local: WebKit le purga los archivos que respaldan las entradas y le deja el índice apuntando a la nada. Es un estado por dispositivo, por eso a otros no les pasa.

## Por qué esto era un problema nuestro

Con el service worker sirviendo las navegaciones desde el precache, ese estado se volvía **fatal**: el fallo ocurre mientras se streamea la respuesta, o sea *después* de que el SW ya respondió, y no hay JS que lo pueda atajar. Un teléfono con señal perfecta se quedaba sin poder abrir la app.

## El cambio

Las navegaciones ahora van a la **red primero** y solo caen a la caché si la red falla. Tres niveles:

1. **red** — con corte a los 3 s, para no colgar a alguien con señal mala
2. **`html-cache`** — la copia de la última navegación que funcionó
3. **el precache** — para el caso "recién instalado y todavía sin navegar"

Con señal, la caché no se toca: la bomba queda desarmada. Sin señal sigue abriendo, que era el arreglo original de #467.

## Dos trampas que costaron encontrar

- **`navigateFallback` no se puede usar junto con esto.** Workbox registra su `NavigationRoute` *antes* que `runtimeCaching`, y el router se queda con la primera ruta que matchea: se comía la ruta network-first.
- **`directoryIndex` tiene que ser `null`.** Con el default (`'index.html'`) la ruta de precache resuelve `/` contra el `index.html` precacheado y también se quedaba con la navegación.

El fallback offline lo da la misma ruta: `cacheKeyWillBeUsed` mete todas las navegaciones en **una** entrada, así que una ruta que nunca se abrió online también levanta sin señal. Importa porque iOS restaura la última URL al reabrir la app.

## Dockerfile

Declaraba 6 de los 9 `VITE_` que usa el código. Faltaban `VITE_GOOGLE_MAP_ID` (sin él el mapa pierde la cámara heading-up), `VITE_TELEGRAM_BOT_USERNAME` y `VITE_BUILD_ID`. Una que falte no rompe el build: compila con `undefined` y la feature muere en silencio.

## Verificación

Sobre un build de producción real, con el SW controlando la página:

| escenario | resultado |
|---|---|
| caché envenenada + servidor arriba | sirvió **la red**, no el veneno |
| servidor apagado, ruta **nunca visitada** (`/clientes/nunca-visitada`) | sirvió **html-cache** |
| servidor apagado **y** `html-cache` borrada | sirvió **el precache** |

Suite completa en verde (1131 tests), lint y typecheck limpios. Sin migración.

## Aparte: producción no usa el `nginx.conf` del repo

Mirando prod salió esto, y **no se arregla con este PR** porque es config de Coolify:

| ruta | prod hoy | lo que dice `nginx.conf` |
|---|---|---|
| `/`, `/index.html` | **sin `Cache-Control`** | `no-cache, no-store` |
| `/sw.js` | `public, immutable, max-age=1 año` | `no-store` |
| `/manifest.webmanifest` | `application/octet-stream` | `application/manifest+json` |

`index.html` sin `Cache-Control` deja que Safari le aplique caché heurística y lo sirva viejo sin revalidar; ese HTML pide assets hasheados que el deploy siguiente borró → 404 → pantalla en blanco. Es muy probablemente la causa original del reporte que motivó #467.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
