### PR TITLE
Que la red mala deje de costar plata

### DIFF
--- a/src/components/containers/PedidosContainer.tsx
+++ b/src/components/containers/PedidosContainer.tsx
@@ -19,6 +19,7 @@ import { fechaLocalISO, fechaHaceDias, getFormaPagoDisplay, formatPrecio } from 
 import { explicarErrorDeSesion } from '../../utils/sesionVencida'
 import { preventistaPuedeEditar } from '../../utils/permisosPedido'
 import { useRequestIdEstable } from '../../hooks/useRequestIdEstable'
+import { nuevoRequestId } from '../../utils/idempotencia'
 import { useQueryClient } from '@tanstack/react-query'
 import { Loader2 } from 'lucide-react'
 import {
@@ -1611,16 +1612,20 @@ export default function PedidosContainer(): React.ReactElement {
   }, [notify])
 
   // ModalEntregaConSalvedad handlers
-  // Idempotente via client_request_id (mig 049): un UUID por salvedad persiste
-  // entre reintentos. El RPC short-circuit si ya creo la salvedad con ese UUID.
-  // Retry automatico con backoff cubre "TypeError: Load failed" (iOS Safari /
-  // PWA) y otros errores transient de red sin riesgo de duplicar.
+  // Idempotente via client_request_id (mig 049): el RPC hace short-circuit si ya
+  // creo la salvedad con ese UUID.
+  //
+  // El UUID lo trae el caller (`salvedad.clientRequestId`), y eso es lo que hace
+  // que sirva: antes se acuñaba uno nuevo ACA, dentro del loop, en cada
+  // invocacion. Asi solo cubria el retry interno de retryWithBackoff —que
+  // ademas nunca disparaba, ver retryWithBackoff.ts— y no el reintento del
+  // usuario: si el lote fallaba a la mitad y volvia a tocar "Confirmar", las
+  // salvedades que si habian entrado se aplicaban de nuevo, el total bajaba dos
+  // veces y el stock volvia dos veces.
   const handleSaveSalvedades = useCallback(async (salvedades: RegistrarSalvedadInput[]): Promise<RegistrarSalvedadResult[]> => {
     const results: RegistrarSalvedadResult[] = []
     for (const salvedad of salvedades) {
-      const clientRequestId = (typeof crypto !== 'undefined' && 'randomUUID' in crypto)
-        ? crypto.randomUUID()
-        : `${Date.now()}-${Math.random().toString(36).slice(2)}`
+      const clientRequestId = salvedad.clientRequestId || nuevoRequestId()
       try {
         const { data, error } = await retryWithBackoff(
           async () => {

--- a/src/components/modals/ModalEntregaConSalvedad.tsx
+++ b/src/components/modals/ModalEntregaConSalvedad.tsx
@@ -7,6 +7,7 @@ import React, { useState, useCallback, useMemo } from 'react'
 import { X, AlertTriangle, Package, Check, ChevronDown, ChevronUp, Truck, Gift } from 'lucide-react'
 import { MOTIVOS_SALVEDAD_LABELS } from '../../lib/schemas'
 import { useSimularSalvedadesPromoImpactoQuery } from '../../hooks/queries'
+import { useRequestIdEstable } from '../../hooks/useRequestIdEstable'
 import NumberInput from '../ui/NumberInput'
 import type { PedidoDB, PedidoItemDB, MotivoSalvedad, RegistrarSalvedadInput, RegistrarSalvedadResult } from '../../types'
 
@@ -68,6 +69,10 @@ export default function ModalEntregaConSalvedad({
   const [guardando, setGuardando] = useState(false)
   const [error, setError] = useState('')
   const [paso, setPaso] = useState<'seleccion' | 'confirmacion'>('seleccion')
+  // Idempotencia del lote (mig 049). La cache del hook vive lo que vive el
+  // modal, que es exactamente un intento de entrega: reintentar reusa los
+  // mismos UUIDs, y una entrega distinta más tarde arranca con otros.
+  const requestId = useRequestIdEstable()
 
   const itemsConSalvedad = itemsSalvedad.filter(i => i.seleccionado)
   const itemsSinProblemas = itemsSalvedad.filter(i => !i.seleccionado)
@@ -157,7 +162,15 @@ export default function ModalEntregaConSalvedad({
             cantidadAfectada: itemSalv.cantidadAfectada,
             motivo: itemSalv.motivo as MotivoSalvedad,
             descripcion: itemSalv.descripcion.trim() || undefined,
-            devolverStock: motivoConfig?.devuelveStock ?? true
+            devolverStock: motivoConfig?.devuelveStock ?? true,
+            // El UUID se deriva del contenido de la salvedad, así que volver a
+            // tocar "Confirmar" tras un fallo parcial reenvía EL MISMO id y el
+            // servidor lo reconoce. Antes se acuñaba uno nuevo en cada intento:
+            // las salvedades que sí habían entrado se aplicaban de nuevo, el
+            // total bajaba dos veces y el stock volvía dos veces.
+            clientRequestId: requestId(
+              `salvedad|${pedido.id}|${itemSalv.item.id}|${itemSalv.cantidadAfectada}|${itemSalv.motivo}`,
+            ),
           }
         })
 

--- a/src/components/rutaActiva/RutaActivaTransportista.tsx
+++ b/src/components/rutaActiva/RutaActivaTransportista.tsx
@@ -83,7 +83,15 @@ export default function RutaActivaTransportista({
   // Ruta del día: el transportista lee del recorrido en_curso (las paradas que
   // armó el admin), NO de "todos sus pedidos asignados". Trae también la ruta
   // real (polylines) para dibujarla.
-  const { data: recorridoActivo, isLoading: cargandoRuta } = useRecorridoActivoQuery(userId);
+  // `isError`/`refetch` no son opcionales de estilo: sin ellos, un fallo de red
+  // deja `data` en undefined y la pantalla lo lee como "el admin no armó la
+  // ruta". Ver el early return de abajo.
+  const {
+    data: recorridoActivo,
+    isLoading: cargandoRuta,
+    isError: rutaFallo,
+    refetch: reintentarRuta,
+  } = useRecorridoActivoQuery(userId);
   const rutaReal = useMemo(
     () => decodePolylines(recorridoActivo?.polylines),
     [recorridoActivo?.polylines],
@@ -267,6 +275,31 @@ export default function RutaActivaTransportista({
   }, [guiando, paradaActiva, pararGuia]);
 
   if (pedidosOrdenados.length === 0) {
+    // Tres estados distintos, no dos. El que faltaba era el error: la query
+    // falla (timeout, JWT vencido, un PGRST201 por embed ambiguo — ya pasó en
+    // prod), `data` queda undefined, y el chofer leía "el administrador todavía
+    // no armó tu ruta del día" con el camión cargado. Llamaba a la oficina o
+    // directamente no salía, y nadie podía saber que el problema era de red.
+    if (rutaFallo) {
+      return (
+        <div className="text-center py-12 px-4">
+          <WifiOff className="w-16 h-16 mx-auto text-orange-300 dark:text-orange-700 mb-4" />
+          <h3 className="text-xl font-semibold text-gray-700 dark:text-gray-300 mb-2">
+            No pudimos cargar tu ruta
+          </h3>
+          <p className="text-gray-500 dark:text-gray-500 mb-6">
+            Puede ser la conexión. Tu ruta no se perdió: probá de nuevo.
+          </p>
+          <button
+            type="button"
+            onClick={() => void reintentarRuta()}
+            className="min-h-[52px] px-8 rounded-xl bg-blue-600 text-white font-semibold active:bg-blue-700"
+          >
+            Reintentar
+          </button>
+        </div>
+      );
+    }
     // Distinguir "todavía no hay ruta armada" de "ruta cargando".
     const sinRuta = !cargandoRuta && recorridoActivo == null;
     return (

--- a/src/types/hooks.ts
+++ b/src/types/hooks.ts
@@ -1603,6 +1603,14 @@ export interface RegistrarSalvedadInput {
   descripcion?: string | null;
   fotoUrl?: string | null;
   devolverStock?: boolean;
+  /**
+   * UUID de idempotencia (mig 049). Lo genera QUIEN arma el lote, no el handler:
+   * tiene que sobrevivir a que el usuario vuelva a tocar "Confirmar" tras un
+   * fallo parcial. Generarlo con `useRequestIdEstable`, cuya cache vive lo que
+   * vive el modal — o sea, exactamente un intento de entrega.
+   * Si se omite, el handler acuña uno nuevo (camino de salvedad suelta).
+   */
+  clientRequestId?: string;
 }
 
 export interface RegistrarSalvedadResult {

--- a/src/utils/lazyWithReload.test.ts
+++ b/src/utils/lazyWithReload.test.ts
@@ -59,4 +59,59 @@ describe('importConRecarga', () => {
     await expect(importConRecarga(() => Promise.reject(err))).rejects.toThrow('boom de negocio')
     expect(reloadMock).not.toHaveBeenCalled()
   })
+
+  /**
+   * El chofer en la calle. La app NO registra service worker, así que no hay app
+   * shell precacheado: recargar sin red deja la pantalla en blanco y lo deja sin
+   * app en medio del reparto. Antes se recargaba igual.
+   */
+  describe('sin conexión', () => {
+    const setOnline = (v: boolean) =>
+      Object.defineProperty(navigator, 'onLine', { configurable: true, value: v })
+
+    afterEach(() => setOnline(true))
+
+    it('NO recarga y avisa que no recargue', async () => {
+      setOnline(false)
+      const factory = () => Promise.reject(new Error('Failed to fetch dynamically imported module: /assets/x.js'))
+
+      await expect(importConRecarga(factory)).rejects.toThrow(/no hay conexión/i)
+      await expect(importConRecarga(factory)).rejects.toThrow(/no recargues/i)
+      expect(reloadMock).not.toHaveBeenCalled()
+    })
+
+    it('con la red de vuelta sí recarga', async () => {
+      setOnline(false)
+      const factory = () => Promise.reject(new Error('Failed to fetch dynamically imported module: /assets/x.js'))
+      await expect(importConRecarga(factory)).rejects.toThrow(/no hay conexión/i)
+      expect(reloadMock).not.toHaveBeenCalled()
+
+      setOnline(true)
+      await expect(importConRecarga(factory)).rejects.toThrow(/versión nueva/i)
+      expect(reloadMock).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  /**
+   * El cooldown viejo era temporal, no un tope: pasados 15 s volvía a recargar,
+   * y si el chunk seguía sin estar la pestaña entraba en loop de recargas.
+   */
+  it('deja de insistir tras 2 recargas, aunque pase el cooldown', async () => {
+    const factory = () => Promise.reject(new Error('Failed to fetch dynamically imported module: /assets/x.js'))
+
+    await expect(importConRecarga(factory)).rejects.toThrow(/versión nueva/i)
+    expect(reloadMock).toHaveBeenCalledTimes(1)
+
+    // Se simula que pasó el cooldown conservando el contador de intentos.
+    const [intentos] = (sessionStorage.getItem('chunk-reload-at') || '0|0').split('|')
+    sessionStorage.setItem('chunk-reload-at', `${intentos}|0`)
+    await expect(importConRecarga(factory)).rejects.toThrow(/versión nueva/i)
+    expect(reloadMock).toHaveBeenCalledTimes(2)
+
+    // Tercera: el tope corta, no importa el cooldown.
+    const [intentos2] = (sessionStorage.getItem('chunk-reload-at') || '0|0').split('|')
+    sessionStorage.setItem('chunk-reload-at', `${intentos2}|0`)
+    await expect(importConRecarga(factory)).rejects.toThrow(/Recargá la página/i)
+    expect(reloadMock).toHaveBeenCalledTimes(2)
+  })
 })

--- a/src/utils/lazyWithReload.ts
+++ b/src/utils/lazyWithReload.ts
@@ -22,19 +22,37 @@ export function esErrorDeChunk(err: unknown): boolean {
   return /Failed to fetch dynamically imported module|error loading dynamically imported module|Importing a module script failed|ChunkLoadError/i.test(msg)
 }
 
+/** Cuántas recargas se permiten por sesión antes de dejar de insistir. */
+const RELOAD_MAX_INTENTOS = 2
+
 /**
- * Recarga la página UNA vez (con cooldown por sessionStorage) para traer
- * index.html + chunks frescos. Devuelve true si disparó la recarga; false si
- * está en cooldown (ya recargó hace poco y sigue fallando → no insistir).
+ * Recarga la página para traer index.html + chunks frescos. Devuelve true si
+ * disparó la recarga; false si no corresponde recargar.
+ *
+ * NO recarga en dos casos, y los dos son el mismo usuario: el chofer en la calle.
+ *
+ * 1. Sin conexión. La app NO registra service worker (`injectRegister: false` en
+ *    vite.config, y PWAPrompt quedó sin montar), así que no hay app shell
+ *    precacheado: recargar sin red deja la pantalla en blanco y el chofer sin
+ *    app en medio del reparto. Con red, recargar es lo correcto — el chunk viejo
+ *    no existe más en el server.
+ * 2. Ya se recargó `RELOAD_MAX_INTENTOS` veces. El cooldown viejo era temporal,
+ *    no un tope: pasados 15 s volvía a recargar, y si el chunk seguía sin estar
+ *    la pestaña entraba en loop de recargas.
  */
 function recargarUnaVezPorChunk(): boolean {
-  const last = Number(sessionStorage.getItem(RELOAD_KEY) || 0)
-  if (Date.now() - last > RELOAD_COOLDOWN_MS) {
-    sessionStorage.setItem(RELOAD_KEY, String(Date.now()))
-    window.location.reload()
-    return true
-  }
-  return false
+  if (typeof navigator !== 'undefined' && navigator.onLine === false) return false
+
+  const [intentosRaw, lastRaw] = (sessionStorage.getItem(RELOAD_KEY) || '0|0').split('|')
+  const intentos = Number(intentosRaw) || 0
+  const last = Number(lastRaw) || 0
+
+  if (intentos >= RELOAD_MAX_INTENTOS) return false
+  if (Date.now() - last <= RELOAD_COOLDOWN_MS) return false
+
+  sessionStorage.setItem(RELOAD_KEY, `${intentos + 1}|${Date.now()}`)
+  window.location.reload()
+  return true
 }
 
 // El genérico espeja el de React.lazy (`ComponentType<any>`): con
@@ -72,9 +90,13 @@ export async function importConRecarga<T>(factory: () => Promise<T>): Promise<T>
   } catch (err) {
     if (esErrorDeChunk(err)) {
       const recargo = recargarUnaVezPorChunk()
+      if (recargo) throw new Error('Hay una versión nueva de la app. Recargando…')
+      // Sin conexión NO hay que decirle "recargá": no hay service worker, así
+      // que recargar deja la pantalla en blanco. Es el chofer en la calle.
+      const sinRed = typeof navigator !== 'undefined' && navigator.onLine === false
       throw new Error(
-        recargo
-          ? 'Hay una versión nueva de la app. Recargando…'
+        sinRed
+          ? 'No hay conexión. Volvé a intentar cuando tengas señal — no recargues la app.'
           : 'No se pudo cargar el módulo. Recargá la página e intentá de nuevo.',
       )
     }

--- a/src/utils/retryWithBackoff.test.ts
+++ b/src/utils/retryWithBackoff.test.ts
@@ -1,0 +1,124 @@
+/**
+ * Tests de `retryWithBackoff` / `isTransientNetworkError`.
+ *
+ * EL INCIDENTE
+ * ------------
+ * Toda esta capa era código muerto en runtime. `isTransientNetworkError`
+ * arrancaba con `if (!(err instanceof Error)) return false`, y supabase-js **no
+ * lanza Error**: `PostgrestError` sólo se instancia con `.throwOnError()`, que
+ * no se usa en ningún lado del repo. Sin él, un fallo de red vuelve como objeto
+ * plano `{ message: "TypeError: Failed to fetch", details, hint, code: '' }`.
+ *
+ * Resultado: `shouldRetry` devolvía false justo para el caso que motivó el
+ * helper. Los 5 call sites (4 de cobro en `usePagos`, 1 de salvedad) hacían un
+ * único intento; los 3 intentos con backoff nunca ocurrieron. El chofer perdía
+ * el cobro al primer blip de red, que en la calle es la condición normal.
+ *
+ * El fix no fue sacar el guard sino cambiar el discriminante: lo que no se debe
+ * reintentar es un error SEMÁNTICO del servidor (23505, 42501, PGRST203) —
+ * reintentarlo no cambia nada— y esos se reconocen por el `code`, no por el
+ * tipo. Los de red traen `code: ''`.
+ *
+ * El caso central de este archivo es el objeto plano: es exactamente lo que
+ * ningún test cubría.
+ */
+import { describe, it, expect, vi } from 'vitest'
+import { retryWithBackoff, isTransientNetworkError } from './retryWithBackoff'
+
+/** Lo que supabase-js devuelve realmente ante un fallo de red. */
+const errorDeRedDeSupabase = {
+  message: 'TypeError: Failed to fetch',
+  details: 'TypeError: Failed to fetch',
+  hint: '',
+  code: '',
+}
+
+/** Lo que devuelve ante un error semántico de Postgres. */
+const errorSemantico = {
+  message: 'duplicate key value violates unique constraint "idx_pagos_client_request_id"',
+  details: null,
+  hint: null,
+  code: '23505',
+}
+
+describe('isTransientNetworkError', () => {
+  it('reconoce el objeto plano de supabase-js — el caso que estaba roto', () => {
+    expect(isTransientNetworkError(errorDeRedDeSupabase)).toBe(true)
+  })
+
+  it('reconoce "Load failed" de Safari/WebKit como objeto plano', () => {
+    expect(isTransientNetworkError({ message: 'TypeError: Load failed', code: '' })).toBe(true)
+  })
+
+  it('sigue reconociendo un Error nativo', () => {
+    expect(isTransientNetworkError(new TypeError('Failed to fetch'))).toBe(true)
+    expect(isTransientNetworkError(new Error('Network request failed'))).toBe(true)
+    expect(isTransientNetworkError(new Error('timeout of 30000ms exceeded'))).toBe(true)
+  })
+
+  it('NO reintenta errores semánticos de Postgres: reintentar no cambia nada', () => {
+    expect(isTransientNetworkError(errorSemantico)).toBe(false)
+    expect(isTransientNetworkError({ message: 'permiso denegado', code: '42501' })).toBe(false)
+    // El que rompió "Armar ruta" en prod por un embed ambiguo.
+    expect(isTransientNetworkError({ message: 'ambiguous embed', code: 'PGRST203' })).toBe(false)
+  })
+
+  it('no confunde un mensaje cualquiera con un problema de red', () => {
+    expect(isTransientNetworkError({ message: 'stock insuficiente', code: '' })).toBe(false)
+    expect(isTransientNetworkError(new Error('El pedido ya esta cancelado'))).toBe(false)
+    expect(isTransientNetworkError(null)).toBe(false)
+    expect(isTransientNetworkError(undefined)).toBe(false)
+  })
+})
+
+describe('retryWithBackoff', () => {
+  it('reintenta hasta que sale bien y devuelve el resultado', async () => {
+    const fn = vi
+      .fn()
+      .mockRejectedValueOnce(errorDeRedDeSupabase)
+      .mockResolvedValueOnce('cobrado')
+
+    const res = await retryWithBackoff(fn, {
+      shouldRetry: isTransientNetworkError,
+      initialDelayMs: 1,
+    })
+
+    expect(res).toBe('cobrado')
+    expect(fn).toHaveBeenCalledTimes(2)
+  })
+
+  it('hace los 3 intentos ante red mala persistente y recién ahí propaga', async () => {
+    const fn = vi.fn().mockRejectedValue(errorDeRedDeSupabase)
+
+    await expect(
+      retryWithBackoff(fn, { shouldRetry: isTransientNetworkError, initialDelayMs: 1 }),
+    ).rejects.toBe(errorDeRedDeSupabase)
+
+    // Antes del fix esto valía 1: el bug entero en un número.
+    expect(fn).toHaveBeenCalledTimes(3)
+  })
+
+  it('con un error semántico corta al primer intento', async () => {
+    const fn = vi.fn().mockRejectedValue(errorSemantico)
+
+    await expect(
+      retryWithBackoff(fn, { shouldRetry: isTransientNetworkError, initialDelayMs: 1 }),
+    ).rejects.toBe(errorSemantico)
+
+    expect(fn).toHaveBeenCalledTimes(1)
+  })
+
+  it('respeta maxAttempts', async () => {
+    const fn = vi.fn().mockRejectedValue(errorDeRedDeSupabase)
+
+    await expect(
+      retryWithBackoff(fn, {
+        shouldRetry: isTransientNetworkError,
+        initialDelayMs: 1,
+        maxAttempts: 5,
+      }),
+    ).rejects.toBe(errorDeRedDeSupabase)
+
+    expect(fn).toHaveBeenCalledTimes(5)
+  })
+})

--- a/src/utils/retryWithBackoff.ts
+++ b/src/utils/retryWithBackoff.ts
@@ -7,6 +7,7 @@
  * idempotentes: el retry duplicaria efectos si la primera request llego al
  * servidor pero la respuesta se perdio.
  */
+import { getErrorMessage } from './errorHandling'
 
 export interface RetryOptions {
   maxAttempts?: number
@@ -37,12 +38,29 @@ export async function retryWithBackoff<T>(
 /**
  * Heuristica de errores de red transitorios. Cubre Safari/WebKit ("Load
  * failed"), Chrome/Android ("Failed to fetch"), variantes de timeout y
- * NetworkError. NO matchea PostgrestError con codigo semantico (esos vienen
- * con `error.code` y NO se lanzan como Error desde supabase-js).
+ * NetworkError.
+ *
+ * OJO CON EL DISCRIMINANTE. Hasta 2026-08 esto arrancaba con
+ * `if (!(err instanceof Error)) return false`, y eso volvia inerte a toda la
+ * capa de reintento: supabase-js **no lanza Error**. `PostgrestError` solo se
+ * instancia con `.throwOnError()`, que no se usa en ningun lado del repo; sin
+ * el, un fallo de red vuelve como objeto plano
+ * `{ message: "TypeError: Failed to fetch", details, hint, code: '' }`.
+ * O sea que `shouldRetry` daba false justo para el caso que motivo el helper, y
+ * los 5 call sites hacian 1 solo intento — el chofer perdia el cobro al primer
+ * blip de red, que en la calle es lo normal.
+ *
+ * Lo que el guard viejo SI queria evitar era reintentar un error semantico del
+ * servidor (23505 duplicado, 42501 permisos, PGRST203 sobrecarga ambigua):
+ * reintentarlos no cambia nada. Eso se discrimina por el `code`, no por el tipo:
+ * los semanticos traen un codigo no vacio y los de red traen `code: ''`.
  */
 export function isTransientNetworkError(err: unknown): boolean {
-  if (!(err instanceof Error)) return false
-  const m = err.message?.toLowerCase() ?? ''
+  const code = (err as { code?: unknown } | null | undefined)?.code
+  if (typeof code === 'string' && code !== '') return false
+  if (typeof code === 'number') return false
+
+  const m = getErrorMessage(err).toLowerCase()
   return (
     m.includes('load failed') ||
     m.includes('failed to fetch') ||


### PR DESCRIPTION
Que la red mala deje de costar plata

Cuatro cosas de resiliencia. Todas apuntan al mismo usuario: el chofer en la
calle, que es donde la señal es mala por definición.

1. Toda la capa de reintento era código muerto
----------------------------------------------
`isTransientNetworkError` arrancaba con `if (!(err instanceof Error)) return
false`. Y supabase-js NO lanza Error: `PostgrestError` sólo se instancia con
`.throwOnError()`, que no se usa en ningún lado del repo. Sin él, un fallo de red
vuelve como objeto plano `{ message: "TypeError: Failed to fetch", code: '' }`.

O sea que `shouldRetry` devolvía false justo para el caso que motivó el helper.
Los 5 call sites —4 de cobro en `usePagos`, 1 de salvedad— hacían un único
intento; los 3 intentos con backoff de 500ms/1000ms nunca ocurrieron. El chofer
perdía el cobro al primer blip de red.

El fix no fue sacar el guard: lo que el guard quería evitar era reintentar un
error SEMÁNTICO del servidor (23505, 42501, PGRST203), y reintentarlos no cambia
nada. Eso se discrimina por el `code`, no por el tipo — los semánticos traen
código no vacío y los de red traen `code: ''`.

`retryWithBackoff.test.ts` no existía. Ahora existe, y el caso central es
exactamente el objeto plano.

Nota: el re-throw de `PedidosContainer` que envuelve `response.error` en un
Error NO era redundante, al revés. supabase-js devuelve el error de red en
`response.error` en vez de lanzarlo, así que sin ese re-throw `retryWithBackoff`
nunca vería un throw. Recién ahora funciona.

2. Reintentar una salvedad la aplicaba dos veces
------------------------------------------------
El `client_request_id` se acuñaba dentro del handler, en el loop, en cada
invocación. Así sólo cubría el retry interno (que además nunca disparaba) y no el
reintento del usuario: si el lote fallaba a la mitad y volvía a tocar
"Confirmar", las salvedades que sí habían entrado se aplicaban de nuevo — el
total bajaba dos veces y el stock volvía dos veces.

Ahora el UUID lo genera quien arma el lote, derivado del contenido de cada
salvedad, con `useRequestIdEstable`. La cache del hook vive lo que vive el modal,
que es exactamente un intento de entrega: reintentar reusa los mismos ids y el
servidor los reconoce; una entrega distinta más tarde arranca con otros.

Con esto el modal no necesita llevar la cuenta de cuáles entraron.

3. Un error de red le decía al chofer "no tenés ruta"
-----------------------------------------------------
`RutaActivaTransportista` sólo tomaba `data` e `isLoading`. Si la query falla
—timeout, JWT vencido, un PGRST201 por embed ambiguo, que ya pasó en prod—
`data` queda undefined y el early return lo leía como "El administrador todavía
no armó tu ruta del día". Con el camión cargado. El chofer llamaba a la oficina o
directamente no salía, y nadie podía saber que el problema era de red.

Ahora son tres estados y no dos, con botón de reintento a escala táctil.

4. El chunk que no carga dejaba al chofer sin app
--------------------------------------------------
`lazyWithReload` recargaba la página ante un chunk fallido. Como la app no
registra service worker, sin red eso deja la pantalla en blanco: el chofer se
queda sin app en medio del reparto. Y el "cooldown" era temporal, no un tope:
pasados 15 s volvía a recargar, en loop.

Ahora no recarga sin conexión (y el mensaje dice explícitamente que no recargue),
y hay un tope de 2 recargas por sesión.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
