### PR TITLE
Cerrar los dos huecos que quedaron de la tanda anterior

### DIFF
--- a/src/components/containers/PedidosContainer.tsx
+++ b/src/components/containers/PedidosContainer.tsx
@@ -224,6 +224,18 @@ export default function PedidosContainer(): React.ReactElement {
   const requestIdMasivo = useRequestIdEstable()
   // UUID de idempotencia del cobro que se declara al CREAR el pedido (mig 167).
   const requestIdAlta = useRequestIdEstable()
+  /**
+   * Clave de idempotencia del ALTA en sí (mig 071, `pedidos.offline_id`).
+   *
+   * No se deriva del contenido del pedido a propósito: un cliente puede repetir
+   * el mismo pedido en el día, y una huella por contenido lo haría desaparecer
+   * como si fuera un duplicado. La unidad correcta es la INTENCIÓN de alta: se
+   * acuña al primer intento de guardar y se descarta cuando el formulario se
+   * limpia (`resetNuevoPedido`), así que todo reintento del mismo pedido —el
+   * automático de react-query incluido— reusa el mismo id y el servidor lo
+   * reconoce, mientras que un pedido nuevo arranca con otro.
+   */
+  const altaIdRef = useRef<string | null>(null)
   const crearClienteMut = useCrearClienteMutation()
   const actualizarClienteMut = useActualizarClienteMutation()
   const crearCambioEnRutaMut = useCrearPedidoCambioEnRutaMutation()
@@ -362,6 +374,8 @@ export default function PedidosContainer(): React.ReactElement {
     })
     setRegalosOverride({})
     setPromosEliminadas([])
+    // Formulario limpio = próxima alta es otra intención. Ver `altaIdRef`.
+    altaIdRef.current = null
   }, [])
 
   // Admin elige/cambia el producto del regalo de una promo al crear el pedido.
@@ -1178,7 +1192,12 @@ export default function PedidosContainer(): React.ReactElement {
         },
       )
 
+      // Se acuña en el primer intento y sobrevive a los reintentos: es lo que
+      // impide que un corte de señal después del COMMIT cree el pedido dos veces.
+      altaIdRef.current ??= nuevoRequestId()
+
       const pedidoCreado = await crearPedido.mutateAsync({
+        offlineId: altaIdRef.current,
         clienteId: nuevoPedido.clienteId,
         items: itemsParaCrear,
         origenes,

--- a/src/components/modals/ModalGestionRutas.tsx
+++ b/src/components/modals/ModalGestionRutas.tsx
@@ -7,8 +7,11 @@ import {
   ArrowLeftRight, Search, UserCog
 } from 'lucide-react';
 import ModalBase from './ModalBase';
+// DENTRO del ModalBase: es un Radix Dialog portaleado con z-50 y un hermano
+// `fixed inset-0 z-50` queda detrás del overlay. Ver ModalPedido.
+import ModalConfirmacion, { type ModalConfirmacionConfig } from './ModalConfirmacion';
 import ModalCambioProducto, { type CambioProductoSaveData } from './ModalCambioProducto';
-import { useDepositoCoords, useSetDepositoMutation, useDestinoCoords, useSetDestinoMutation, useRecorridoExistenteQuery, useRutasEnCursoQuery, useCambiarTransportistaRutaMutation } from '../../hooks/queries';
+import { useDepositoCoords, useSetDepositoMutation, useDestinoCoords, useSetDestinoMutation, useRecorridoExistenteQuery, useRutasEnCursoQuery, useRutasEnCursoMultiQuery, useCambiarTransportistaRutaMutation } from '../../hooks/queries';
 import type { RegistrarCambioInput } from '../../hooks/queries';
 import type { RepartidorParam } from '../../hooks/useOptimizarRuta';
 import { horarioParaRutear } from '../../hooks/useOptimizarRuta';
@@ -286,6 +289,7 @@ const ModalGestionRutas = memo(function ModalGestionRutas({
   const [cambioOpen, setCambioOpen] = useState<boolean>(false);
   // Modo de armado: un solo chofer (con edición in-place) o dividir entre varios.
   const [modoDividir, setModoDividir] = useState<boolean>(false);
+  const [confirmConfig, setConfirmConfig] = useState<ModalConfirmacionConfig | null>(null);
   // Modo dividir: repartidores elegidos + sus parámetros (máx paradas, zonas).
   const [repartidoresSel, setRepartidoresSel] = useState<Set<string>>(new Set());
   const [paramsPorChofer, setParamsPorChofer] = useState<Record<string, { maxParadas: string; zonas: string[] }>>({});
@@ -379,9 +383,30 @@ const ModalGestionRutas = memo(function ModalGestionRutas({
   const { data: rutasEnCurso = [] } = useRutasEnCursoQuery(
     modoDividir ? null : transportistaSeleccionado || null,
   );
+  // En modo dividir esta query estaba apagada (`modoDividir ? null : ...`), o
+  // sea que el modal era ciego a las rutas ya armadas. Y `aplicar_orden_ruta`
+  // reemplaza las paradas PENDIENTES del recorrido de ese día: dividir sobre un
+  // chofer que ya está repartiendo le vacía las paradas del celular en plena
+  // calle. Ahora se le avisa antes.
+  const { data: rutasDeLosRepartidores = [] } = useRutasEnCursoMultiQuery(
+    modoDividir ? Array.from(repartidoresSel) : [],
+  );
   const rutasOtraFecha = useMemo(
     () => rutasEnCurso.filter(r => r.fecha !== fechaEntrega && r.paradas > 0),
     [rutasEnCurso, fechaEntrega],
+  );
+  /** Repartidores elegidos que YA tienen ruta armada para esta misma fecha. */
+  const repartidoresConRutaEsteDia = useMemo(
+    () =>
+      rutasDeLosRepartidores
+        .filter(r => r.fecha === fechaEntrega && r.paradas > 0)
+        .map(r => ({
+          paradas: r.paradas,
+          nombre:
+            transportistas.find(t => String(t.id) === String(r.transportistaId))?.nombre ??
+            'Transportista',
+        })),
+    [rutasDeLosRepartidores, fechaEntrega, transportistas],
   );
   const idsExistentes = useMemo(() => new Set(paradasExistentes.map(p => p.id)), [paradasExistentes]);
   // Paradas que el chofer YA entregó. No se pueden seleccionar: mandarlas en el
@@ -652,10 +677,36 @@ const ModalGestionRutas = memo(function ModalGestionRutas({
     });
   }, [repartidoresSel, paramsPorChofer]);
 
-  const handleDividir = (): void => {
+  const ejecutarDividir = (): void => {
     if (onArmarRutaMulti && repartidoresParam.length > 0 && pedidosSeleccionados.length > 0) {
       onArmarRutaMulti(repartidoresParam, pedidosSeleccionados, fechaEntrega, horaInicio, horaFin);
     }
+  };
+
+  const handleDividir = (): void => {
+    // Dividir REEMPLAZA la ruta del día de cada chofer elegido: sus paradas
+    // pendientes se sacan del recorrido. Si alguno ya está repartiendo, eso le
+    // vacía el celular en la calle. Antes pasaba sin ningún aviso.
+    if (repartidoresConRutaEsteDia.length > 0) {
+      const detalle = repartidoresConRutaEsteDia
+        .map(r => `${r.nombre} (${r.paradas} paradas)`)
+        .join(', ');
+      setConfirmConfig({
+        visible: true,
+        tipo: 'warning',
+        titulo: 'Ya hay ruta armada para esta fecha',
+        mensaje:
+          `${detalle} ya tiene ruta del ${fechaEntrega}. Dividir la reemplaza: las paradas ` +
+          'pendientes salen del recorrido y, si ya está repartiendo, le desaparecen del celular. ' +
+          'Lo ya entregado no se toca.',
+        onConfirm: () => {
+          setConfirmConfig(null);
+          ejecutarDividir();
+        },
+      });
+      return;
+    }
+    ejecutarDividir();
   };
 
   // Crea la parada de cambio y la agrega (pre-tildada) a la selección de la
@@ -1198,6 +1249,18 @@ const ModalGestionRutas = memo(function ModalGestionRutas({
                           <p className="text-indigo-100 text-sm">Total a cobrar</p>
                         </div>
                       </div>
+                      {repartidoresConRutaEsteDia.length > 0 && (
+                        <div className="mt-3 rounded-lg bg-white/15 p-3 text-sm">
+                          <p className="font-semibold">Ojo: ya hay ruta armada para el {fechaEntrega}</p>
+                          <p className="text-indigo-100">
+                            {repartidoresConRutaEsteDia
+                              .map(r => `${r.nombre} (${r.paradas} paradas)`)
+                              .join(', ')}
+                            . Dividir la reemplaza: las paradas pendientes salen del recorrido.
+                            Lo ya entregado no se toca.
+                          </p>
+                        </div>
+                      )}
                     </div>
                   ) : (
                     <div className="bg-gradient-to-r from-blue-500 to-blue-600 rounded-xl p-4 text-white">
@@ -1704,6 +1767,7 @@ const ModalGestionRutas = memo(function ModalGestionRutas({
           </div>
         </div>
       </div>
+      <ModalConfirmacion config={confirmConfig} onClose={() => setConfirmConfig(null)} />
     </ModalBase>
 
     {/* Cambio/devolución como parada: se renderiza por encima del modal de ruta. */}

--- a/src/hooks/queries/index.ts
+++ b/src/hooks/queries/index.ts
@@ -279,7 +279,7 @@ export {
 export type { RecorridoExistente } from './useRecorridoExistenteQuery'
 
 // Rutas en curso del transportista (para avisar que ya hay una en otra fecha)
-export { rutasEnCursoKeys, useRutasEnCursoQuery } from './useRutasEnCursoQuery'
+export { rutasEnCursoKeys, useRutasEnCursoQuery, useRutasEnCursoMultiQuery } from './useRutasEnCursoQuery'
 export type { RutaEnCurso } from './useRutasEnCursoQuery'
 
 // Reasignar una ruta ya armada a otro transportista (mig 172)

--- a/src/hooks/queries/useCrearPedidoMutation.test.tsx
+++ b/src/hooks/queries/useCrearPedidoMutation.test.tsx
@@ -1,0 +1,123 @@
+/**
+ * Tests del contrato de alta de pedido con la base.
+ *
+ * EL INCIDENTE
+ * ------------
+ * El camino online llamaba a `crear_pedido_completo`, que NO tiene clave de
+ * idempotencia. Y las mutations de react-query reintentan ante error de red. Si
+ * la RPC commiteaba y la respuesta se perdía —señal débil, no caída: con 3G malo
+ * `navigator.onLine` sigue en true— el pedido se creaba dos o tres veces,
+ * descontando stock cada vez.
+ *
+ * `crear_pedido_idempotente` (mig 071, columna `pedidos.offline_id` con índice
+ * único parcial) existía desde abril y sólo la usaba el replay offline: la
+ * protección estaba escrita y sin usar justo en el camino por el que entra la
+ * mayoría de los pedidos.
+ *
+ * Lo que estos tests fijan es el contrato, que es lo que se rompe en silencio:
+ * el nombre de la RPC y el del parámetro. PostgREST resuelve la firma por
+ * nombre de argumento, así que un typo no lo ve ni `tsc` ni el linter — falla
+ * en runtime, con el preventista adelante del cliente.
+ */
+import React from 'react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+
+const rpc = vi.fn()
+
+vi.mock('../supabase/base', () => ({
+  supabase: {
+    rpc: (...args: unknown[]) => rpc(...args),
+    from: vi.fn(),
+  },
+}))
+
+vi.mock('../../contexts/SucursalContext', () => ({
+  useSucursal: () => ({ currentSucursalId: 1 }),
+}))
+
+import { useCrearPedidoMutation } from './usePedidosQuery'
+
+function makeWrapper(qc: QueryClient) {
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return <QueryClientProvider client={qc}>{children}</QueryClientProvider>
+  }
+}
+
+function setup() {
+  const qc = new QueryClient({ defaultOptions: { mutations: { retry: false } } })
+  return renderHook(() => useCrearPedidoMutation(), { wrapper: makeWrapper(qc) })
+}
+
+const input = {
+  clienteId: '42',
+  items: [{ productoId: '7', cantidad: 3, precioUnitario: 1200 }],
+  total: 3600,
+  usuarioId: 'user-1',
+}
+
+describe('alta de pedido — contrato con la base', () => {
+  beforeEach(() => {
+    rpc.mockReset()
+    // El segundo rpc (registrar_origen_precio_items) también pasa por acá.
+    rpc.mockResolvedValue({ data: { success: true, pedido_id: '5001' }, error: null })
+  })
+
+  it('usa crear_pedido_idempotente, no la RPC cruda', async () => {
+    const { result } = setup()
+    await result.current.mutateAsync({ ...input, offlineId: 'uuid-alta-1' })
+
+    await waitFor(() => expect(rpc).toHaveBeenCalled())
+    expect(rpc.mock.calls[0][0]).toBe('crear_pedido_idempotente')
+  })
+
+  it('manda el offlineId como p_offline_id — el nombre exacto del parámetro', async () => {
+    const { result } = setup()
+    await result.current.mutateAsync({ ...input, offlineId: 'uuid-alta-1' })
+
+    expect(rpc).toHaveBeenCalledWith(
+      'crear_pedido_idempotente',
+      expect.objectContaining({
+        p_offline_id: 'uuid-alta-1',
+        p_cliente_id: '42',
+        p_total: 3600,
+      }),
+    )
+  })
+
+  it('sin offlineId manda null y se comporta como antes', async () => {
+    const { result } = setup()
+    await result.current.mutateAsync(input)
+
+    expect(rpc).toHaveBeenCalledWith(
+      'crear_pedido_idempotente',
+      expect.objectContaining({ p_offline_id: null }),
+    )
+  })
+
+  it('devuelve el id del pedido que la base reconoció como ya creado', async () => {
+    // Lo que responde el short-circuit: el pedido de la PRIMERA vez.
+    rpc.mockResolvedValueOnce({
+      data: { success: true, pedido_id: '5001', idempotente: true },
+      error: null,
+    })
+
+    const { result } = setup()
+    const creado = await result.current.mutateAsync({ ...input, offlineId: 'uuid-alta-1' })
+
+    expect(creado).toEqual({ id: '5001' })
+  })
+
+  it('propaga el error de negocio de la RPC', async () => {
+    rpc.mockResolvedValueOnce({
+      data: { success: false, errores: ['Stock insuficiente para MANAOS COLA 3LT'] },
+      error: null,
+    })
+
+    const { result } = setup()
+    await expect(
+      result.current.mutateAsync({ ...input, offlineId: 'uuid-alta-1' }),
+    ).rejects.toThrow(/stock insuficiente/i)
+  })
+})

--- a/src/hooks/queries/usePedidosQuery.ts
+++ b/src/hooks/queries/usePedidosQuery.ts
@@ -65,6 +65,20 @@ interface CrearPedidoInput {
   // exige que el actor sea admin (mig 060).
   preventistaId?: string | null
   /**
+   * Clave de idempotencia del alta (mig 071, columna `pedidos.offline_id` con
+   * índice único parcial). Sin esto, el alta NO es idempotente: las mutations de
+   * react-query reintentan ante error de red, y si la RPC commiteó pero la
+   * respuesta se perdió —señal débil, no caída: con 3G malo `navigator.onLine`
+   * sigue en true— el pedido se crea dos o tres veces, descontando stock cada
+   * vez. Los pagos tienen `client_request_id` desde la mig 167; el alta se había
+   * quedado atrás, con la protección existiendo y sin usarse en el camino online.
+   *
+   * Tiene que ser estable por INTENCIÓN de alta: el mismo valor en todo reintento
+   * del mismo pedido, y distinto para un pedido nuevo aunque tenga el mismo
+   * contenido (un cliente puede repetir el pedido en el día).
+   */
+  offlineId?: string
+  /**
    * Por qué se cobró cada precio (mig 148/149). Se registra en un segundo paso,
    * después de crear el pedido: es metadato analítico y no justifica tocar
    * `crear_pedido_completo`. Si falta o falla, los ítems quedan en
@@ -371,7 +385,13 @@ async function crearPedido(input: CrearPedidoInput): Promise<{ id: string }> {
     ...(item.porcentaje_iva != null ? { porcentaje_iva: item.porcentaje_iva } : {}),
   }))
 
-  const { data, error } = await supabase.rpc('crear_pedido_completo', {
+  // `crear_pedido_idempotente` (mig 071) envuelve a `crear_pedido_completo`: si
+  // ya vio ese `p_offline_id` devuelve el pedido que creó la primera vez en vez
+  // de crear otro. Existía desde abril y sólo la usaba el replay offline; el
+  // camino online llamaba a la RPC cruda y quedaba expuesto al reintento
+  // automático de react-query. Sin `offlineId` se comporta igual que antes.
+  const { data, error } = await supabase.rpc('crear_pedido_idempotente', {
+    p_offline_id: input.offlineId ?? null,
     p_cliente_id: input.clienteId,
     p_total: input.total,
     p_usuario_id: input.usuarioId,

--- a/src/hooks/queries/useRutasEnCursoQuery.ts
+++ b/src/hooks/queries/useRutasEnCursoQuery.ts
@@ -23,11 +23,15 @@ export interface RutaEnCurso {
   recorridoId: string
   fecha: string
   paradas: number
+  /** Sólo lo puebla la variante multi; en la de un chofer es redundante. */
+  transportistaId?: string
 }
 
 export const rutasEnCursoKeys = {
   all: (sucursalId: number | null, transportistaId: string | null) =>
     ['rutas-en-curso', sucursalId, transportistaId] as const,
+  multi: (sucursalId: number | null, transportistaIds: string[]) =>
+    ['rutas-en-curso', 'multi', sucursalId, [...transportistaIds].sort().join(',')] as const,
 }
 
 interface RutaEnCursoRaw {
@@ -68,6 +72,50 @@ export function useRutasEnCursoQuery(transportistaId: string | null | undefined)
     queryKey: rutasEnCursoKeys.all(currentSucursalId, transportistaId ?? null),
     queryFn: () => fetchRutasEnCurso(currentSucursalId, transportistaId as string),
     enabled: !!transportistaId,
+    staleTime: 30 * 1000,
+  })
+}
+
+async function fetchRutasEnCursoMulti(
+  sucursalId: number | null,
+  transportistaIds: string[],
+): Promise<RutaEnCurso[]> {
+  let query = supabase
+    .from('recorridos')
+    .select('id, fecha, transportista_id, recorrido_pedidos(count)')
+    .in('transportista_id', transportistaIds)
+    .eq('estado', 'en_curso')
+    .gte('fecha', fechaLocalISO())
+    .order('fecha', { ascending: true })
+
+  if (sucursalId != null) query = query.eq('sucursal_id', sucursalId)
+
+  const { data, error } = await query
+  if (error) throw error
+
+  return ((data as unknown as Array<RutaEnCursoRaw & { transportista_id: string }>) || []).map(r => ({
+    recorridoId: String(r.id),
+    fecha: r.fecha,
+    paradas: r.recorrido_pedidos?.[0]?.count ?? 0,
+    transportistaId: String(r.transportista_id),
+  }))
+}
+
+/**
+ * Igual que la anterior pero para VARIOS choferes a la vez.
+ *
+ * La necesita el modo "Dividir" de armar ruta, que hasta ahora pasaba `null` a
+ * la query de un chofer —o sea, la tenía apagada— y por lo tanto era ciego a las
+ * rutas ya armadas. Como `aplicar_orden_ruta` reemplaza las paradas pendientes
+ * del recorrido de ese día, dividir sobre un chofer que está repartiendo le
+ * vacía las paradas del celular en plena calle, sin que nadie lo vea venir.
+ */
+export function useRutasEnCursoMultiQuery(transportistaIds: string[]) {
+  const { currentSucursalId } = useSucursal()
+  return useQuery({
+    queryKey: rutasEnCursoKeys.multi(currentSucursalId, transportistaIds),
+    queryFn: () => fetchRutasEnCursoMulti(currentSucursalId, transportistaIds),
+    enabled: transportistaIds.length > 0,
     staleTime: 30 * 1000,
   })
 }


### PR DESCRIPTION
Cerrar los dos huecos que quedaron de la tanda anterior

Dos items del plan de la auditoría que se me pasaron: el 4.5 del PR #471 y la
mitad del hallazgo del split en el PR #472. Ninguno necesita migración.

1. El alta de pedido no era idempotente
---------------------------------------
El camino online llamaba a `crear_pedido_completo`, que no tiene clave de
idempotencia, y las mutations de react-query reintentan ante error de red. Si la
RPC commiteaba y la respuesta se perdía —señal débil, no caída: con 3G malo
`navigator.onLine` sigue en true— el pedido se creaba dos o tres veces,
descontando stock cada vez.

`crear_pedido_idempotente` (mig 071, `pedidos.offline_id` con índice único
parcial) existe desde abril y sólo la usaba el replay offline. O sea: la
protección estaba escrita, testeada y sin usar justo en el camino por el que
entra la mayoría de los pedidos. Los pagos tienen `client_request_id` desde la
mig 167; el alta se había quedado atrás.

La clave NO se deriva del contenido del pedido, a propósito: un cliente puede
repetir el mismo pedido en el día y una huella por contenido lo haría
desaparecer como duplicado. La unidad correcta es la intención de alta — se
acuña al primer intento de guardar y se descarta cuando el formulario se limpia.

Se agregan tests del contrato con la base (nombre de la RPC y del parámetro):
PostgREST resuelve la firma por nombre de argumento, así que un typo ahí no lo
ve ni tsc ni el linter, falla en runtime con el preventista adelante del cliente.
Firma verificada contra prod: `crear_pedido_idempotente` es única y sus 14
nombres coinciden.

2. Dividir la ruta pisaba al chofer que estaba repartiendo
-----------------------------------------------------------
En modo "Dividir", la query de rutas ya armadas estaba literalmente apagada
(`useRutasEnCursoQuery(modoDividir ? null : ...)`), así que el modal era ciego.
Y `aplicar_orden_ruta` reemplaza las paradas pendientes del recorrido de ese día:
dividir sobre un chofer que ya salió le vacía las paradas del celular en plena
calle, sin que nadie lo vea venir.

El PR #472 arregló la otra mitad de este hallazgo —los pedidos sin coordenadas
que se perdían en silencio— y esta quedó afuera.

Ahora hay una variante multi-chofer de la query, un aviso en el panel de dividir
diciendo quién ya tiene ruta y con cuántas paradas, y una confirmación antes de
reemplazarla. Lo ya entregado no se toca: eso lo garantiza la mig 180.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
