### PR TITLE
Que un cuelgue de CI falle rápido en vez de simular que trabaja

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,7 @@ jobs:
   lint:
     name: Lint
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -32,6 +33,7 @@ jobs:
   test:
     name: Unit Tests
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -61,6 +63,7 @@ jobs:
   deno-changes:
     name: Detect Deno changes
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     outputs:
       deno: ${{ steps.filter.outputs.deno }}
     steps:
@@ -79,6 +82,7 @@ jobs:
   deno:
     name: Deno (supabase/functions)
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     needs: [deno-changes]
     # The job itself always runs (returns success) so the downstream `build`
     # job (which has `needs: [..., deno]`) is not skipped when supabase/functions
@@ -115,6 +119,7 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     needs: [lint, test, typecheck, security, deno]
     steps:
       - name: Checkout code
@@ -158,6 +163,12 @@ jobs:
     name: E2E Tests
     runs-on: ubuntu-latest
     needs: [build]
+    # Los tests tardan ~75 s de forma consistente. El techo NO es para ellos: es
+    # para que un cuelgue de infraestructura falle rapido en vez de simular que
+    # trabaja. El 18/08 este job estuvo 48 minutos trabado en `apt-get update`
+    # contra archive.ubuntu.com y sin timeout habria seguido hasta el limite de 6
+    # horas de GitHub, quemando minutos y bloqueando el merge de un PR sano.
+    timeout-minutes: 15
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -171,7 +182,28 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      # La version sale del lockfile instalado, no de package.json: el rango
+      # ("^1.58.1") resolveria a binarios distintos con la misma clave de cache.
+      - name: Resolver version de Playwright
+        id: pw
+        run: echo "version=$(node -p "require('@playwright/test/package.json').version")" >> "$GITHUB_OUTPUT"
+
+      - name: Cache de navegadores de Playwright
+        id: pw-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ steps.pw.outputs.version }}
+
       - name: Install Playwright browsers
+        if: steps.pw-cache.outputs.cache-hit != 'true'
+        # Techo propio: es el paso que se cuelga, y el que se cuelga es el
+        # `apt-get` de `--with-deps`, no la descarga de los binarios. Se mantiene
+        # `--with-deps` a proposito: sacarlo evitaria el apt del todo, pero
+        # apostaria a que la imagen del runner ya trae las librerias que chromium
+        # necesita, y eso no esta verificado. Si el cuelgue se repite, ese es el
+        # proximo paso.
+        timeout-minutes: 8
         run: npx playwright install --with-deps chromium
 
       - name: Download build artifacts
@@ -198,6 +230,7 @@ jobs:
   typecheck:
     name: TypeScript Check
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -217,6 +250,7 @@ jobs:
   security:
     name: Security Audit
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
Que un cuelgue de CI falle rapido en vez de simular que trabaja

Hoy el job de E2E del PR #474 estuvo 48 minutos sin avanzar. No era el PR: los
tests ni siquiera arrancaron.

QUE PASO
--------
El paso trabado era `Install Playwright browsers`, y dentro de el, el `apt-get`
que dispara `--with-deps`. El log lo muestra sin ambiguedad:

  16:12:59  Get:5 https://archive.ubuntu.com/ubuntu noble-security InRelease [126 kB]
  17:03:28  ##[error]The operation was canceled.

Cincuenta minutos entre una linea y la siguiente, contra los mirrors de Ubuntu.
No fue la descarga de los binarios de Playwright.

La degradacion venia avisando, y nadie la vio porque el job igual terminaba en
verde:

  PR #471   install 26s      tests 79s
  PR #472   install 24s      tests 74s
  PR #473   install 10m31s   tests 78s     <- ya era esto
  PR #474   install colgado  tests nunca

Los tests en si tardan ~75 segundos siempre. La unica variable es el install.

Lo importante no es que se colgo —eso es infraestructura de terceros y va a
volver a pasar— sino que **se colgo en silencio**. Sin `timeout-minutes`, GitHub
deja el job hasta su limite de 6 horas: quema minutos, bloquea el merge de un PR
sano, y desde afuera no se distingue de "esta trabajando".

QUE CAMBIA
----------
1. `timeout-minutes` en TODOS los jobs, no solo en E2E. El techo esta puesto a
   ~5x la duracion real observada (lint 53s -> 10, tests 2m19s -> 15, build 48s
   -> 15, typecheck 43s -> 10, security 20s -> 10, deno 7s -> 10, detect 8s -> 5,
   e2e 2m16s -> 15). Cualquiera de estos jobs se puede colgar igual; E2E fue el
   que toco hoy.

2. Techo propio de 8 minutos en el paso del install, que es el que se cuelga.

3. Cache de `~/.cache/ms-playwright` con clave por version de Playwright. La
   version se resuelve del paquete instalado y no de package.json, porque el
   rango "^1.58.1" puede resolver a binarios distintos bajo la misma clave.

LO QUE NO SE HIZO, Y POR QUE
-----------------------------
Sacar `--with-deps` evitaria el apt del todo y seria el fix definitivo del
cuelgue. No lo hice porque apostaria a que la imagen del runner ya trae las
librerias que chromium necesita, y eso no esta verificado: si falta una, chromium
no levanta y el sintoma es peor de diagnosticar que este. Con el cache, el paso
se saltea entero mientras no cambie la version de Playwright, asi que la
exposicion baja bastante igual. Si el cuelgue se repite, ese es el proximo paso y
queda anotado en el propio workflow.

VERIFICACION
------------
El YAML parsea y los 8 jobs quedan con techo. La corrida relanzada del #474 paso
en 2m16s con el install en 35s, o sea que la infraestructura ya se normalizo:
este PR no arregla el cuelgue de hoy, arregla que el proximo se note.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
