### PR TITLE
Que la ruta del chofer sobreviva a un corte de señal

### DIFF
--- a/src/components/rutaActiva/RutaActivaTransportista.tsx
+++ b/src/components/rutaActiva/RutaActivaTransportista.tsx
@@ -45,6 +45,16 @@ const ACCURACY_MAX_M = 1000;
 /** Más lejos que esto de la parada activa = el chofer no está en zona */
 const DISTANCIA_ABSURDA_M = 50_000;
 
+/** "hace 5 min" / "hace 2 h" / "ayer". Para rotular datos que no son de ahora. */
+function describirAntiguedad(epochMs: number): string {
+  const min = Math.floor((Date.now() - epochMs) / 60000);
+  if (min < 1) return 'recién actualizada';
+  if (min < 60) return `actualizada hace ${min} min`;
+  const h = Math.floor(min / 60);
+  if (h < 24) return `actualizada hace ${h} h`;
+  return 'actualizada ayer';
+}
+
 export interface RutaActivaTransportistaProps {
   onMarcarEntregado: (pedido: PedidoDB) => void;
   userId: string;
@@ -91,6 +101,8 @@ export default function RutaActivaTransportista({
     isLoading: cargandoRuta,
     isError: rutaFallo,
     refetch: reintentarRuta,
+    desdeCache,
+    datosDe,
   } = useRecorridoActivoQuery(userId);
   const rutaReal = useMemo(
     () => decodePolylines(recorridoActivo?.polylines),
@@ -432,11 +444,23 @@ export default function RutaActivaTransportista({
         )}
       </div>
 
-      {/* Banner offline */}
-      {!isOnline && (
-        <div role="alert" className="absolute inset-x-3 top-20 z-20 flex items-center gap-2 rounded-xl bg-orange-500 px-3 py-2 text-white shadow-lg">
-          <WifiOff className="h-4 w-4 flex-shrink-0" aria-hidden />
-          <p className="text-sm font-medium">Sin conexión — las entregas no se están guardando</p>
+      {/* Banner offline. Dos mensajes distintos a propósito: "no hay red" y "lo
+          que estás viendo salió del teléfono, no del servidor" no son lo mismo,
+          y el segundo es el que evita que el chofer confíe en una ruta vieja. */}
+      {(!isOnline || desdeCache) && (
+        <div role="alert" className="absolute inset-x-3 top-20 z-20 flex items-start gap-2 rounded-xl bg-orange-500 px-3 py-2 text-white shadow-lg">
+          <WifiOff className="mt-0.5 h-4 w-4 flex-shrink-0" aria-hidden />
+          <div className="min-w-0">
+            <p className="text-sm font-medium">
+              {desdeCache ? 'Ruta guardada en el teléfono' : 'Sin conexión'}
+              {datosDe ? ` — ${describirAntiguedad(datosDe)}` : ''}
+            </p>
+            <p className="text-xs text-orange-100">
+              {desdeCache
+                ? 'Puede haber cambiado. Las entregas y cobros no se guardan hasta que vuelva la señal.'
+                : 'Las entregas y cobros no se están guardando.'}
+            </p>
+          </div>
         </div>
       )}
 

--- a/src/hooks/queries/useRecorridoActivoQuery.cache.test.tsx
+++ b/src/hooks/queries/useRecorridoActivoQuery.cache.test.tsx
@@ -1,0 +1,148 @@
+/**
+ * El chofer abre la app sin señal y su ruta sigue ahí.
+ *
+ * Es el escenario que motiva todo el cache: iOS descarta la PWA en segundo
+ * plano y el cache de react-query vive solo en memoria, así que al volver a
+ * abrirla el chofer se quedaba sin paradas, sin direcciones y sin los totales a
+ * cobrar, con el camión cargado.
+ *
+ * Se testea acá y no en el navegador porque supabase-js captura `fetch` al
+ * construir el cliente: pisar `window.fetch` después de que la app arrancó no
+ * corta nada, y una "prueba offline" así da un falso verde.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import React from 'react';
+
+const maybeSingle = vi.fn();
+
+vi.mock('../supabase/base', () => ({
+  supabase: {
+    from: () => ({
+      select: () => ({
+        eq: function () { return this; },
+        in: function () { return this; },
+        order: function () { return this; },
+        limit: function () { return this; },
+        maybeSingle,
+      }),
+    }),
+  },
+}));
+
+vi.mock('../../contexts/SucursalContext', () => ({
+  useSucursal: () => ({ currentSucursalId: 1 }),
+}));
+
+import { useRecorridoActivoQuery } from './useRecorridoActivoQuery';
+import { guardarRuta } from '../../lib/rutaOfflineCache';
+import { fechaLocalISO } from '../../utils/formatters';
+
+const CHOFER = 'a0adb1f2-5bd7-455d-83a7-a51a857798ab';
+
+function almacenEnMemoria() {
+  let store: Record<string, string> = {};
+  return {
+    get length() { return Object.keys(store).length; },
+    getItem: (k: string) => (k in store ? store[k] : null),
+    setItem: (k: string, v: string) => { store[k] = String(v); },
+    removeItem: (k: string) => { delete store[k]; },
+    clear: () => { store = {}; },
+    key: (i: number) => Object.keys(store)[i] ?? null,
+  };
+}
+
+function wrapper({ children }: { children: React.ReactNode }) {
+  // `retry: false` para que el fallo de red sea inmediato, como el primer
+  // intento real; sin esto el test espera los reintentos con backoff.
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return <QueryClientProvider client={qc}>{children}</QueryClientProvider>;
+}
+
+const rutaGuardada = {
+  id: '95',
+  polylines: null,
+  fecha: fechaLocalISO(),
+  obtenidoEn: Date.now() - 60_000,
+  paradas: [
+    { id: '1', estado: 'asignado', total: 61600, cliente: { nombre_fantasia: 'Kiosco villa amalia' } },
+    { id: '2', estado: 'asignado', total: 12000, cliente: { nombre_fantasia: 'Despensa Mi angel' } },
+  ],
+};
+
+describe('useRecorridoActivoQuery — la ruta sobrevive sin señal', () => {
+  beforeEach(() => {
+    Object.defineProperty(globalThis, 'localStorage', {
+      value: almacenEnMemoria(), configurable: true, writable: true,
+    });
+    maybeSingle.mockReset();
+  });
+
+  it('sin red y con cache, muestra la ruta guardada y la marca como tal', async () => {
+    guardarRuta(1, CHOFER, fechaLocalISO(), rutaGuardada);
+    maybeSingle.mockRejectedValue(new TypeError('Failed to fetch'));
+
+    const { result } = renderHook(() => useRecorridoActivoQuery(CHOFER), { wrapper });
+
+    // Lo que importa: hay paradas en pantalla desde el primer render.
+    expect(result.current.data?.paradas).toHaveLength(2);
+    expect(result.current.data?.paradas[0].cliente?.nombre_fantasia).toBe('Kiosco villa amalia');
+    // Y se dice que son viejas, en vez de hacerlas pasar por vivas.
+    await waitFor(() => expect(result.current.desdeCache).toBe(true));
+    expect(result.current.datosDe).toBeTruthy();
+  });
+
+  it('sin red y SIN cache, no inventa una ruta', async () => {
+    maybeSingle.mockRejectedValue(new TypeError('Failed to fetch'));
+
+    const { result } = renderHook(() => useRecorridoActivoQuery(CHOFER), { wrapper });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.data).toBeUndefined();
+    expect(result.current.desdeCache).toBe(false);
+  });
+
+  // Con red, lo fresco gana: el cache no puede dejar la pantalla pegada a una
+  // foto vieja mientras el servidor responde.
+  //
+  // El cache se guarda ENVEJECIDO a proposito. `initialDataUpdatedAt` lleva el
+  // sello del guardado, asi que react-query lo compara contra `staleTime` (60 s):
+  // una ruta guardada recien se considera fresca y NO se refetchea —correcto,
+  // porque se acaba de traer del servidor—, y una guardada hace rato se
+  // considera vieja y dispara el refetch. El caso que importa es el segundo: la
+  // PWA que se reabre horas despues.
+  it('con red, los datos del servidor reemplazan al cache', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(Date.now() - 10 * 60_000));
+    guardarRuta(1, CHOFER, fechaLocalISO(), rutaGuardada);
+    vi.useRealTimers();
+    maybeSingle.mockResolvedValue({
+      data: {
+        id: '95', polylines: null, fecha: fechaLocalISO(),
+        recorrido_pedidos: [
+          { orden_entrega: 1, pedido: { id: '1', estado: 'entregado', cliente: {}, items: [] } },
+          { orden_entrega: 2, pedido: { id: '2', estado: 'asignado', cliente: {}, items: [] } },
+          { orden_entrega: 3, pedido: { id: '3', estado: 'asignado', cliente: {}, items: [] } },
+        ],
+      },
+      error: null,
+    });
+
+    const { result } = renderHook(() => useRecorridoActivoQuery(CHOFER), { wrapper });
+
+    await waitFor(() => expect(result.current.data?.paradas).toHaveLength(3));
+    expect(result.current.desdeCache).toBe(false);
+  });
+
+  // Multi-tenant: la ruta guardada para la sucursal 1 no puede sembrar a otra.
+  it('no siembra con el cache de otra sucursal', async () => {
+    guardarRuta(2, CHOFER, fechaLocalISO(), rutaGuardada);
+    maybeSingle.mockRejectedValue(new TypeError('Failed to fetch'));
+
+    const { result } = renderHook(() => useRecorridoActivoQuery(CHOFER), { wrapper });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.data).toBeUndefined();
+  });
+});

--- a/src/hooks/queries/useRecorridoActivoQuery.fecha.test.ts
+++ b/src/hooks/queries/useRecorridoActivoQuery.fecha.test.ts
@@ -1,0 +1,46 @@
+/**
+ * `fechaDeRuta` — qué día de ruta le toca ver al chofer.
+ *
+ * El bug que cubre: la query filtraba `fecha = hoy` a secas, así que a las
+ * 00:05 la ruta que el chofer está haciendo pasaba a ser "de ayer" y la
+ * pantalla le decía que el administrador todavía no armó la suya. Con el camión
+ * cargado y media ruta sin entregar.
+ */
+import { describe, it, expect } from 'vitest';
+import { fechaDeRuta } from './useRecorridoActivoQuery';
+
+describe('fechaDeRuta', () => {
+  describe('en la madrugada acepta la ruta de ayer', () => {
+    it('devuelve hoy y el día anterior', () => {
+      expect(fechaDeRuta('2026-08-19', 0)).toEqual({ hoy: '2026-08-19', ayer: '2026-08-18' });
+      expect(fechaDeRuta('2026-08-19', 5).ayer).toBe('2026-08-18');
+    });
+
+    it('cruza el principio de mes', () => {
+      expect(fechaDeRuta('2026-08-01', 1).ayer).toBe('2026-07-31');
+    });
+
+    it('cruza el principio de año', () => {
+      expect(fechaDeRuta('2026-01-01', 1).ayer).toBe('2025-12-31');
+    });
+
+    // Argentina es UTC-3: anclar a mediodía evita que el `new Date` se corra un
+    // día al normalizar a la zona local.
+    it('no se corre un día por zona horaria', () => {
+      expect(fechaDeRuta('2026-03-01', 1).ayer).toBe('2026-02-28');
+      expect(fechaDeRuta('2024-03-01', 1).ayer).toBe('2024-02-29');
+    });
+  });
+
+  /**
+   * Pasada la madrugada, "no tenés ruta" es la respuesta correcta. Hay decenas
+   * de recorridos que quedaron `en_curso` de días pasados porque nada los
+   * cierra: sin este corte, un chofer sin ruta hoy veria la de ayer —con
+   * paradas ya entregadas— a las diez de la mañana.
+   */
+  describe('durante el día NO ofrece la de ayer', () => {
+    it.each([6, 10, 15, 23])('a las %i hs devuelve ayer = null', hora => {
+      expect(fechaDeRuta('2026-08-19', hora)).toEqual({ hoy: '2026-08-19', ayer: null });
+    });
+  });
+});

--- a/src/hooks/queries/useRecorridoActivoQuery.ts
+++ b/src/hooks/queries/useRecorridoActivoQuery.ts
@@ -13,8 +13,8 @@ import { useEffect, useMemo } from 'react'
 import { useQuery } from '@tanstack/react-query'
 import { supabase } from '../supabase/base'
 import { useSucursal } from '../../contexts/SucursalContext'
-import { fechaLocalISO } from '../../utils/formatters'
 import { guardarRuta, leerRuta, type RutaCacheada } from '../../lib/rutaOfflineCache'
+import { fechaDeRuta } from '../../utils/fechaRuta'
 import type { PedidoConCliente } from '../../components/rutaActiva/useEntregaParada'
 
 export interface RecorridoActivo {
@@ -53,36 +53,6 @@ interface RecorridoPedidoRaw {
   orden_entrega: number | null
   estado_entrega: string | null
   pedido: (Record<string, unknown> & { orden_entrega?: number | null }) | null
-}
-
-/** Hasta esta hora local, una ruta de ayer todavía puede estar en curso. */
-const HORA_CORTE_RUTA_DE_AYER = 6
-
-/**
- * Fechas de recorrido que le pueden corresponder al chofer.
- *
- * Antes esto era un `.eq('fecha', fechaLocalISO())` a secas y dejaba sin ruta a
- * quien cruza la medianoche terminando el reparto: a las 00:05 la ruta que está
- * haciendo pasa a ser "de ayer" y la pantalla le decía que el administrador
- * todavía no armó la suya, con el camión cargado.
- *
- * Pero aceptar la de ayer SIEMPRE es peor que el bug original. En producción hay
- * decenas de recorridos que quedaron `en_curso` de días pasados porque nada los
- * cierra, así que un chofer sin ruta hoy vería la de ayer —con paradas ya
- * entregadas— a las diez de la mañana. Por eso la ventana: sólo en la madrugada,
- * que es cuando "ayer" de verdad significa "el turno que todavía no terminé".
- * Pasada esa hora, no tener ruta es la respuesta correcta.
- *
- * La causa de fondo (recorridos que nunca se cierran) se ataca aparte.
- */
-export function fechaDeRuta(
-  hoy = fechaLocalISO(),
-  horaLocal = new Date().getHours(),
-): { hoy: string; ayer: string | null } {
-  if (horaLocal >= HORA_CORTE_RUTA_DE_AYER) return { hoy, ayer: null }
-  const d = new Date(`${hoy}T12:00:00`)
-  d.setDate(d.getDate() - 1)
-  return { hoy, ayer: fechaLocalISO(d) }
 }
 
 async function fetchRecorridoActivo(transportistaId: string): Promise<RecorridoActivo | null> {

--- a/src/hooks/queries/useRecorridoActivoQuery.ts
+++ b/src/hooks/queries/useRecorridoActivoQuery.ts
@@ -9,10 +9,12 @@
  * recorrido propio), sus pedidos (transportista_id = auth.uid()), los items de
  * esos pedidos y los clientes/productos de su sucursal. Sin RPC.
  */
+import { useEffect, useMemo } from 'react'
 import { useQuery } from '@tanstack/react-query'
 import { supabase } from '../supabase/base'
 import { useSucursal } from '../../contexts/SucursalContext'
 import { fechaLocalISO } from '../../utils/formatters'
+import { guardarRuta, leerRuta, type RutaCacheada } from '../../lib/rutaOfflineCache'
 import type { PedidoConCliente } from '../../components/rutaActiva/useEntregaParada'
 
 export interface RecorridoActivo {
@@ -20,6 +22,14 @@ export interface RecorridoActivo {
   polylines: string[] | null
   /** Paradas de la ruta del día, ordenadas por orden_entrega, enriquecidas. */
   paradas: PedidoConCliente[]
+  /** Fecha de la ruta (YYYY-MM-DD). Puede ser la de ayer: ver `fechaDeRuta`. */
+  fecha: string
+  /**
+   * Epoch ms de la última vez que estos datos vinieron del servidor. Si salieron
+   * del cache local, es viejo — la pantalla lo rotula en vez de hacer pasar por
+   * vivo algo que no lo es.
+   */
+  obtenidoEn: number
 }
 
 export const recorridoActivoKeys = {
@@ -28,7 +38,7 @@ export const recorridoActivoKeys = {
 }
 
 // Embedding: recorrido → paradas (recorrido_pedidos) → pedido → cliente/items.
-const RECORRIDO_ACTIVO_SELECT = `id, polylines,
+const RECORRIDO_ACTIVO_SELECT = `id, polylines, fecha,
   recorrido_pedidos(
     orden_entrega, estado_entrega, hora_entrega,
     pedido:pedidos(
@@ -45,13 +55,47 @@ interface RecorridoPedidoRaw {
   pedido: (Record<string, unknown> & { orden_entrega?: number | null }) | null
 }
 
+/** Hasta esta hora local, una ruta de ayer todavía puede estar en curso. */
+const HORA_CORTE_RUTA_DE_AYER = 6
+
+/**
+ * Fechas de recorrido que le pueden corresponder al chofer.
+ *
+ * Antes esto era un `.eq('fecha', fechaLocalISO())` a secas y dejaba sin ruta a
+ * quien cruza la medianoche terminando el reparto: a las 00:05 la ruta que está
+ * haciendo pasa a ser "de ayer" y la pantalla le decía que el administrador
+ * todavía no armó la suya, con el camión cargado.
+ *
+ * Pero aceptar la de ayer SIEMPRE es peor que el bug original. En producción hay
+ * decenas de recorridos que quedaron `en_curso` de días pasados porque nada los
+ * cierra, así que un chofer sin ruta hoy vería la de ayer —con paradas ya
+ * entregadas— a las diez de la mañana. Por eso la ventana: sólo en la madrugada,
+ * que es cuando "ayer" de verdad significa "el turno que todavía no terminé".
+ * Pasada esa hora, no tener ruta es la respuesta correcta.
+ *
+ * La causa de fondo (recorridos que nunca se cierran) se ataca aparte.
+ */
+export function fechaDeRuta(
+  hoy = fechaLocalISO(),
+  horaLocal = new Date().getHours(),
+): { hoy: string; ayer: string | null } {
+  if (horaLocal >= HORA_CORTE_RUTA_DE_AYER) return { hoy, ayer: null }
+  const d = new Date(`${hoy}T12:00:00`)
+  d.setDate(d.getDate() - 1)
+  return { hoy, ayer: fechaLocalISO(d) }
+}
+
 async function fetchRecorridoActivo(transportistaId: string): Promise<RecorridoActivo | null> {
+  const { hoy, ayer } = fechaDeRuta()
+  const fechas = ayer ? [hoy, ayer] : [hoy]
   const { data, error } = await supabase
     .from('recorridos')
     .select(RECORRIDO_ACTIVO_SELECT)
     .eq('transportista_id', transportistaId)
-    .eq('fecha', fechaLocalISO())
+    .in('fecha', fechas)
     .eq('estado', 'en_curso')
+    // La de hoy gana; la de ayer es el fallback de la madrugada.
+    .order('fecha', { ascending: false })
     .order('created_at', { ascending: false })
     .limit(1)
     .maybeSingle()
@@ -88,15 +132,62 @@ async function fetchRecorridoActivo(transportistaId: string): Promise<RecorridoA
     id: String(data.id),
     polylines: (data.polylines as string[] | null) ?? null,
     paradas,
+    fecha: String((data as { fecha?: string }).fecha ?? hoy),
+    obtenidoEn: Date.now(),
   }
 }
 
+/**
+ * Ruta del día del chofer, con respaldo local.
+ *
+ * `initialData` siembra desde localStorage: si la app se reabre sin señal (iOS
+ * descarta la PWA en segundo plano y el cache de react-query vive solo en
+ * memoria), el chofer ve sus paradas, direcciones, teléfonos y totales en vez
+ * de una pantalla vacía. `initialDataUpdatedAt` con el sello del guardado hace
+ * que react-query trate esos datos como VIEJOS y dispare un refetch apenas haya
+ * red — no se queda pegado al cache.
+ */
 export function useRecorridoActivoQuery(transportistaId: string | null | undefined) {
   const { currentSucursalId } = useSucursal()
-  return useQuery({
+  const { hoy } = fechaDeRuta()
+
+  // Memoizado por (sucursal, chofer, día) y NO por montaje. La diferencia
+  // importa: leer una sola vez al montar dejaba el valor pegado al primer
+  // render, así que al cambiar de sucursal la query nueva —clave nueva, sin
+  // datos— se sembraba con `initialData` de la sucursal ANTERIOR. Con las deps
+  // correctas, cambiar de sucursal relee el cache de la que corresponde.
+  // Releer localStorage es idempotente y barato; el riesgo no era el costo.
+  const cacheada = useMemo<RutaCacheada<RecorridoActivo> | null>(
+    () => (transportistaId ? leerRuta<RecorridoActivo>(currentSucursalId, transportistaId, hoy) : null),
+    [currentSucursalId, transportistaId, hoy],
+  )
+
+  const query = useQuery({
     queryKey: recorridoActivoKeys.all(currentSucursalId, transportistaId ?? null),
     queryFn: () => fetchRecorridoActivo(transportistaId as string),
     enabled: !!transportistaId,
     staleTime: 60 * 1000,
+    ...(cacheada
+      ? { initialData: cacheada.datos, initialDataUpdatedAt: cacheada.guardadoEn }
+      : {}),
   })
+
+  // Persistir lo que SÍ vino del servidor. `isFetched`/`isSuccess` no alcanzan:
+  // con `initialData` la query arranca en success sin haber ido a la red, y
+  // reescribir el cache con lo que acabamos de leer solo renueva su fecha de
+  // vencimiento y lo hace parecer fresco.
+  const { data, dataUpdatedAt, isFetching } = query
+  useEffect(() => {
+    if (!transportistaId || !data || isFetching) return
+    if (cacheada && dataUpdatedAt === cacheada.guardadoEn) return
+    guardarRuta(currentSucursalId, transportistaId, data.fecha, data)
+  }, [transportistaId, currentSucursalId, data, dataUpdatedAt, isFetching, cacheada])
+
+  return {
+    ...query,
+    /** true cuando lo que se está mostrando salió del cache, no de la red. */
+    desdeCache: !!cacheada && query.dataUpdatedAt === cacheada.guardadoEn,
+    /** Epoch ms de los datos en pantalla (para "actualizado hace X"). */
+    datosDe: query.data?.obtenidoEn ?? cacheada?.guardadoEn ?? null,
+  }
 }

--- a/src/lib/rutaOfflineCache.test.ts
+++ b/src/lib/rutaOfflineCache.test.ts
@@ -1,0 +1,103 @@
+/**
+ * Tests del cache local de la ruta del chofer.
+ *
+ * Lo que protegen es una sola regla: mostrar una ruta vieja como si fuera la de
+ * hoy es PEOR que no mostrar nada. El chofer sale a repartir con ella.
+ */
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+import { guardarRuta, leerRuta, olvidarRuta } from './rutaOfflineCache';
+
+// El setup global (src/test/setup.js) reemplaza localStorage por `vi.fn()` que
+// no guarda nada, asi que un cache no se puede testear contra el. Se instala
+// uno real en memoria, igual que hace useAsync.test.js. No se cambia el global:
+// ErrorBoundary.test.jsx depende de que `removeItem` sea un spy.
+function localStorageEnMemoria() {
+  let store: Record<string, string> = {};
+  return {
+    get length() { return Object.keys(store).length; },
+    getItem: (k: string) => (k in store ? store[k] : null),
+    setItem: (k: string, v: string) => { store[k] = String(v); },
+    removeItem: (k: string) => { delete store[k]; },
+    clear: () => { store = {}; },
+    key: (i: number) => Object.keys(store)[i] ?? null,
+  };
+}
+
+const HOY = '2026-08-19';
+const AYER = '2026-08-18';
+const ruta = { id: '10', paradas: [{ id: '1' }], polylines: null };
+
+describe('rutaOfflineCache', () => {
+  beforeEach(() => {
+    Object.defineProperty(globalThis, 'localStorage', {
+      value: localStorageEnMemoria(),
+      configurable: true,
+      writable: true,
+    });
+    vi.useRealTimers();
+  });
+  afterEach(() => vi.useRealTimers());
+
+  it('guarda y devuelve la ruta del día', () => {
+    guardarRuta(1, 'chofer-a', HOY, ruta);
+    const leido = leerRuta<typeof ruta>(1, 'chofer-a', HOY);
+    expect(leido?.datos).toEqual(ruta);
+    expect(typeof leido?.guardadoEn).toBe('number');
+  });
+
+  it('NO devuelve la ruta de otro día', () => {
+    guardarRuta(1, 'chofer-a', AYER, ruta);
+    expect(leerRuta(1, 'chofer-a', HOY)).toBeNull();
+  });
+
+  // Multi-tenant: un chofer que opera en dos sucursales no puede ver la ruta de
+  // la otra por compartir clave.
+  it('no cruza sucursales ni choferes', () => {
+    guardarRuta(1, 'chofer-a', HOY, ruta);
+    expect(leerRuta(2, 'chofer-a', HOY)).toBeNull();
+    expect(leerRuta(1, 'chofer-b', HOY)).toBeNull();
+  });
+
+  it('descarta lo guardado hace más de 36 h', () => {
+    guardarRuta(1, 'chofer-a', HOY, ruta);
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(Date.now() + 37 * 60 * 60 * 1000));
+    expect(leerRuta(1, 'chofer-a', HOY)).toBeNull();
+  });
+
+  // Un JSON corrupto (quota a mitad de escritura, storage manoseado) no puede
+  // tirar abajo la pantalla del chofer.
+  it('sobrevive a un cache corrupto', () => {
+    localStorage.setItem('ruta-activa:v1:1:chofer-a', '{esto no es json');
+    expect(() => leerRuta(1, 'chofer-a', HOY)).not.toThrow();
+    expect(leerRuta(1, 'chofer-a', HOY)).toBeNull();
+  });
+
+  it('descarta un payload con la forma cambiada', () => {
+    localStorage.setItem('ruta-activa:v1:1:chofer-a', JSON.stringify({ otraCosa: true }));
+    expect(leerRuta(1, 'chofer-a', HOY)).toBeNull();
+  });
+
+  it('olvidarRuta borra solo la del chofer indicado', () => {
+    guardarRuta(1, 'chofer-a', HOY, ruta);
+    guardarRuta(1, 'chofer-b', HOY, ruta);
+    olvidarRuta(1, 'chofer-a');
+    expect(leerRuta(1, 'chofer-a', HOY)).toBeNull();
+    expect(leerRuta(1, 'chofer-b', HOY)).not.toBeNull();
+  });
+
+  // Si localStorage esta lleno, guardar no puede romper a quien YA tiene los
+  // datos frescos en la mano.
+  it('no lanza si localStorage rechaza la escritura', () => {
+    const spy = vi.spyOn(globalThis.localStorage, 'setItem').mockImplementation(() => {
+      throw new DOMException('QuotaExceededError');
+    });
+    expect(() => guardarRuta(1, 'chofer-a', HOY, ruta)).not.toThrow();
+    spy.mockRestore();
+  });
+
+  it('sin transportista no escribe nada', () => {
+    guardarRuta(1, '', HOY, ruta);
+    expect(localStorage.length).toBe(0);
+  });
+});

--- a/src/lib/rutaOfflineCache.ts
+++ b/src/lib/rutaOfflineCache.ts
@@ -1,0 +1,107 @@
+/**
+ * Cache local de la ruta del día del transportista.
+ *
+ * POR QUÉ ESTO Y NO UN PERSISTER GLOBAL DE TANSTACK QUERY
+ * -------------------------------------------------------
+ * La pantalla del chofer dependía 100% de la red: no hay ningún persister
+ * configurado, así que el cache vive solo en memoria con `gcTime` de 30 min.
+ * Cuando iOS descarta la PWA en segundo plano —cosa que hace— el chofer volvía
+ * a abrirla sin señal y se quedaba sin paradas, sin direcciones y sin los
+ * totales a cobrar, con el camión cargado.
+ *
+ * La solución obvia era `persistQueryClient` con una allowlist. Se descartó:
+ *
+ *  1. `useRecorridoActivoQuery` YA es autosuficiente. Embebe cliente (nombre,
+ *     dirección, lat/lng, teléfono, horarios) e items con su producto. Con esa
+ *     sola query el chofer tiene la pantalla completa; no hace falta persistir
+ *     `pedidos`, `clientes` ni `productos`.
+ *  2. Un persister global obliga a mantener una allowlist para no volcar a
+ *     localStorage cosas que no deben estar ahí (caja, rendiciones, reportes).
+ *     Esa allowlist es una lista negra disfrazada: cada query nueva que alguien
+ *     agregue es una fuga potencial hasta que se acuerden de excluirla.
+ *  3. Evita dos dependencias nuevas en un repo cuyo gate de CI es
+ *     `npm audit --audit-level=high`.
+ *
+ * Guardar una sola cosa, a propósito y con nombre, es más chico y más fácil de
+ * razonar que guardar todo y after acordarse de tapar agujeros.
+ *
+ * MULTI-TENANT: la clave incluye sucursal y transportista. Un chofer que opera
+ * en dos sucursales no puede ver la ruta de la otra por reusar la misma clave.
+ */
+import { logger } from '../utils/logger';
+
+/** Sube cuando cambia la forma de lo guardado, para descartar lo viejo. */
+const ESQUEMA = 'v1';
+const PREFIJO = 'ruta-activa';
+
+/** Más viejo que esto no se muestra ni offline: una ruta de anteayer engaña. */
+const MAX_EDAD_MS = 36 * 60 * 60 * 1000;
+
+export interface RutaCacheada<T> {
+  /** Payload de `useRecorridoActivoQuery` tal cual. */
+  datos: T;
+  /** Cuándo se guardó (epoch ms). La pantalla lo muestra. */
+  guardadoEn: number;
+  /** Fecha de la ruta (YYYY-MM-DD), para no revivir la de otro día. */
+  fecha: string;
+}
+
+function clave(sucursalId: number | null, transportistaId: string): string {
+  return `${PREFIJO}:${ESQUEMA}:${sucursalId ?? 'sin-sucursal'}:${transportistaId}`;
+}
+
+/**
+ * Guarda la ruta. Nunca lanza: que falle el cache no puede romper la pantalla
+ * que sí tiene datos frescos en la mano.
+ */
+export function guardarRuta<T>(
+  sucursalId: number | null,
+  transportistaId: string,
+  fecha: string,
+  datos: T,
+): void {
+  if (!transportistaId) return;
+  try {
+    const payload: RutaCacheada<T> = { datos, guardadoEn: Date.now(), fecha };
+    localStorage.setItem(clave(sucursalId, transportistaId), JSON.stringify(payload));
+  } catch (e) {
+    // QuotaExceededError es el caso real (una ruta larga con muchos items).
+    // Se limpia lo propio y se sigue: el chofer online no se entera.
+    logger.warn('[rutaOfflineCache] No se pudo guardar la ruta:', e);
+    try {
+      localStorage.removeItem(clave(sucursalId, transportistaId));
+    } catch { /* nada que hacer */ }
+  }
+}
+
+/**
+ * Lee la ruta guardada. Devuelve `null` si no hay, si está vencida, si es de
+ * otra fecha o si el JSON quedó corrupto — en todos esos casos es preferible
+ * "no tengo ruta" a mostrar una ruta que no es la de hoy.
+ */
+export function leerRuta<T>(
+  sucursalId: number | null,
+  transportistaId: string,
+  fechaEsperada: string,
+): RutaCacheada<T> | null {
+  if (!transportistaId) return null;
+  try {
+    const crudo = localStorage.getItem(clave(sucursalId, transportistaId));
+    if (!crudo) return null;
+    const payload = JSON.parse(crudo) as RutaCacheada<T>;
+    if (!payload?.datos || typeof payload.guardadoEn !== 'number') return null;
+    if (payload.fecha !== fechaEsperada) return null;
+    if (Date.now() - payload.guardadoEn > MAX_EDAD_MS) return null;
+    return payload;
+  } catch (e) {
+    logger.warn('[rutaOfflineCache] Cache de ruta ilegible, se descarta:', e);
+    return null;
+  }
+}
+
+/** Borra la ruta guardada de ese chofer (logout, cambio de sucursal). */
+export function olvidarRuta(sucursalId: number | null, transportistaId: string): void {
+  try {
+    localStorage.removeItem(clave(sucursalId, transportistaId));
+  } catch { /* nada que hacer */ }
+}

--- a/src/utils/fechaRuta.test.ts
+++ b/src/utils/fechaRuta.test.ts
@@ -7,7 +7,7 @@
  * cargado y media ruta sin entregar.
  */
 import { describe, it, expect } from 'vitest';
-import { fechaDeRuta } from './useRecorridoActivoQuery';
+import { fechaDeRuta } from './fechaRuta';
 
 describe('fechaDeRuta', () => {
   describe('en la madrugada acepta la ruta de ayer', () => {

--- a/src/utils/fechaRuta.ts
+++ b/src/utils/fechaRuta.ts
@@ -1,0 +1,41 @@
+/**
+ * Qué día de recorrido le corresponde ver al chofer.
+ *
+ * Vive acá y no dentro de `useRecorridoActivoQuery` a propósito: es una función
+ * pura de fechas, y tenerla en el módulo de la query obligaba a construir el
+ * cliente de Supabase sólo para importarla. En CI —donde no hay `.env`— eso
+ * explota al importar, y el test ni siquiera llega a correr.
+ */
+import { fechaLocalISO } from './formatters';
+
+/** Hasta esta hora local, una ruta de ayer todavía puede estar en curso. */
+export const HORA_CORTE_RUTA_DE_AYER = 6;
+
+/**
+ * Devuelve la fecha de hoy y, sólo en la madrugada, la de ayer.
+ *
+ * La query filtraba `fecha = hoy` a secas y dejaba sin ruta a quien cruza la
+ * medianoche terminando el reparto: a las 00:05 la ruta que está haciendo pasa
+ * a ser "de ayer" y la pantalla le decía que el administrador todavía no armó
+ * la suya, con el camión cargado.
+ *
+ * Pero aceptar la de ayer SIEMPRE es peor que el bug original. En producción hay
+ * decenas de recorridos que quedaron `en_curso` de días pasados porque nada los
+ * cierra, así que un chofer sin ruta hoy vería la de ayer —con paradas ya
+ * entregadas— a las diez de la mañana. De ahí la ventana: sólo en la madrugada,
+ * que es cuando "ayer" de verdad significa "el turno que todavía no terminé".
+ * Pasada esa hora, no tener ruta es la respuesta correcta.
+ *
+ * La causa de fondo (recorridos que nunca se cierran) se ataca aparte.
+ */
+export function fechaDeRuta(
+  hoy = fechaLocalISO(),
+  horaLocal = new Date().getHours(),
+): { hoy: string; ayer: string | null } {
+  if (horaLocal >= HORA_CORTE_RUTA_DE_AYER) return { hoy, ayer: null };
+  // Mediodía como ancla: evita que el `new Date` se corra un día al normalizar
+  // a la zona local (Argentina es UTC-3).
+  const d = new Date(`${hoy}T12:00:00`);
+  d.setDate(d.getDate() - 1);
+  return { hoy, ayer: fechaLocalISO(d) };
+}


### PR DESCRIPTION
Tercera tanda de la auditoría adversarial. Cierra el **#2**: la pantalla del transportista dependía 100% de la red. Continúa [#476](https://github.com/AgustinReiden/distribuidora-app/pull/476) y [#477](https://github.com/AgustinReiden/distribuidora-app/pull/477).

## El problema

No hay ningún persister configurado, así que el cache de react-query vive solo en memoria con `gcTime` de 30 min. Cuando iOS descarta la PWA en segundo plano —cosa que hace— el chofer volvía a abrirla sin señal y se quedaba **sin paradas, sin direcciones y sin los totales a cobrar**, con el camión cargado.

## Me aparté del plan: no hay persister global

El plan aprobado pedía `persistQueryClient` con una allowlist. Lo descarté por tres razones, y creo que la primera es decisiva:

1. **`useRecorridoActivoQuery` ya es autosuficiente.** Embebe cliente (nombre, dirección, lat/lng, teléfono) e items con su producto. Con esa sola query el chofer tiene la pantalla completa — no hace falta persistir `pedidos`, `clientes` ni `productos`.
2. **Una allowlist es una lista negra disfrazada.** Cada query nueva que alguien agregue es una fuga potencial a `localStorage` —caja, rendiciones— hasta que se acuerden de excluirla.
3. Evita dos dependencias nuevas en un repo cuyo gate de CI es `npm audit --audit-level=high`.

Guardar una sola cosa, a propósito y con nombre, es más chico y más fácil de razonar que guardar todo y después tapar agujeros. **Si preferís el persister global, lo cambio.**

`initialData` siembra desde localStorage; `initialDataUpdatedAt` con el sello del guardado hace que react-query trate esos datos como viejos y refetchee apenas haya red — no se queda pegado al cache. La pantalla lo rotula (*"Ruta guardada en el teléfono — actualizada hace 2 h"*) en vez de hacer pasar por vivo algo que no lo es.

## La ruta de la madrugada, y por qué mi primera versión era peor que el bug

`.eq('fecha', fechaLocalISO())` dejaba sin ruta a quien cruza la medianoche terminando el reparto: a las 00:05 la ruta que está haciendo pasa a ser "de ayer".

Mi primer arreglo aceptaba la de ayer **siempre**. Contra datos reales resultó peor que el bug original: hay decenas de recorridos que quedaron `en_curso` de días pasados porque nada los cierra —Juan tiene uno del 18/08 abierto ahora mismo—, así que un chofer sin ruta hoy vería la de ayer, con paradas ya entregadas, a las diez de la mañana.

De ahí la ventana horaria: sólo antes de las 06:00, que es cuando "ayer" de verdad significa *"el turno que todavía no terminé"*. La causa de fondo va en el PR del backlog de recorridos.

## Verificación

- `typecheck`, `lint`, `build` y **1169 tests**.
- **Contra producción con la sesión de Marcos** (26 paradas reales): la ruta se guarda completa —coordenadas, teléfonos, items— en **83 KB**, cómodo para localStorage. El módulo de cache probado en el navegador real: roundtrip, aislamiento por sucursal, rechazo de otra fecha, borrado.
- **El arranque sin señal se testea, no se prueba en el navegador**, y por una razón concreta: supabase-js captura `fetch` al construir el cliente, así que pisar `window.fetch` después de que la app arrancó no corta nada. Mi primer intento de "prueba offline" fue un falso verde y lo descarté. Los 4 tests de integración cubren el escenario con la red bajo control.

### Dos bugs míos que quedaron en el camino

- Leía el cache una vez por montaje, así que **al cambiar de sucursal la query nueva se sembraba con la ruta de la sucursal anterior**. Fuga cross-tenant. Ahora va con `useMemo` sobre (sucursal, chofer, día).
- El `useRef` para eso violaba `react-hooks/refs` (13 errores de lint). El `useMemo` arregló las dos cosas de una.

### Pendiente

El **#4** del [#476](https://github.com/AgustinReiden/distribuidora-app/pull/476) —la boleta impaga sin datos de cliente— sigue sin verificar en vivo. Tuve la sesión de Marcos abierta, pero la única forma de forzar el caso era manipular el cache y tocar "Entregar": si la guarda fallara, marcaría entregado un pedido real de un cliente real. Queda cubierto por 3 tests unitarios.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
