### PR TITLE
Que la hija no pueda colgarse de un padre de otra sucursal

### DIFF
--- a/.github/workflows/integridad.yml
+++ b/.github/workflows/integridad.yml
@@ -34,6 +34,17 @@ jobs:
           fi
           node scripts/check-integridad.mjs
 
+      - name: Aislamiento por sucursal (FK compuestas)
+        env:
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+        run: |
+          if [ -z "$SUPABASE_URL" ] || [ -z "$SUPABASE_SERVICE_ROLE_KEY" ]; then
+            echo "::warning::Faltan secrets — gate de sucursal omitido."
+            exit 0
+          fi
+          node scripts/check-sucursal-cruzada.mjs
+
       - name: Drift-check de migraciones (repo vs prod)
         env:
           SUPABASE_URL: ${{ secrets.SUPABASE_URL }}

--- a/migrations/186_quien_cruza_de_sucursal.sql
+++ b/migrations/186_quien_cruza_de_sucursal.sql
@@ -1,0 +1,253 @@
+-- ============================================================================
+-- 186 · Quién puede cruzar de sucursal: el reporte
+-- ============================================================================
+-- Sólo lectura. No crea ni una constraint y no toca ni una fila. Es el paso
+-- previo a la 187, que es la que cierra el agujero.
+--
+-- EL AGUJERO. Las policies de las tablas hijas validan `sucursal_id =
+-- current_sucursal_id()` sobre LA PROPIA FILA, y nada valida que el padre
+-- referenciado sea de esa misma sucursal. Las FK no pasan por RLS. Entonces un
+-- INSERT con `sucursal_id` = la mía apuntando a un `compra_id` de la otra
+-- sucursal pasa las dos verificaciones y entra. Lo grave no es que se pueda: es
+-- que la línea queda INVISIBLE para la sucursal dueña de la compra —su policy de
+-- SELECT filtra por el `sucursal_id` de la línea, que dice otra cosa— mientras le
+-- mueve el costo y el stock. Corrupción silenciosa con la víctima ciega.
+--
+-- Es el mismo agujero que la 183 cerró para `compra_cargos` con una FK compuesta,
+-- y que su sección 3 dejó anotado como preexistente y de otro trabajo:
+--   "Nada ata todavía compra_items.sucursal_id a compras.sucursal_id".
+-- Éste es ese otro trabajo, generalizado a todo el esquema.
+--
+-- POR QUÉ FK Y NO RLS. Un EXISTS sobre el padre en las policies taparía sólo el
+-- camino de PostgREST. En esta base casi toda la escritura entra por RPCs
+-- SECURITY DEFINER, que saltean RLS por definición: la policy no las ve pasar.
+-- La FK las ve a todas. Y una policy la pisa cualquier CREATE POLICY futuro y
+-- deja de filtrar sin fallar —ya pasó con `es_preventista()` en la 058—; una
+-- constraint no se pisa por accidente.
+--
+-- POR QUÉ CATÁLOGO Y NO UNA LISTA. `migrations/` es una vista curada, no un
+-- espejo de prod (MANIFEST, regla de oro), así que una lista sacada del repo nace
+-- desalineada. Y una lista congelada no ve la tabla que alguien agregue mañana:
+-- este reporte sí, porque los pares los descubre de pg_constraint. Ése es el
+-- punto — el hallazgo no fue "compra_items está mal", fue "hay una CLASE de tabla
+-- que está mal y nadie la estaba mirando".
+--
+-- El reporte recorre entera cada tabla hija, así que es una herramienta de
+-- verificación y de CI, no algo para colgar de una pantalla.
+-- ============================================================================
+
+BEGIN;
+
+-- ----------------------------------------------------------------------------
+-- 1 · Los pares, salidos del catálogo
+--
+-- Un par es una FK entre dos tablas que tienen las dos `sucursal_id`. Ese
+-- `sucursal_id` repetido en la hija es la premisa entera del problema: es un dato
+-- derivable del padre que igual se guarda al lado, así que puede contradecirlo.
+-- Si la hija no lo tuviera no habría nada que contradecir —`movimiento_sucursal_
+-- items` es exactamente ese caso: resuelve la sucursal por join con el
+-- movimiento, no la copia, y por eso no aparece acá ni puede divergir. Lo mismo
+-- `compra_cargo_repartos` (mig 183).
+--
+-- El par se identifica por su COLUMNA DE NEGOCIO —la que no es `sucursal_id`—,
+-- no por la aridad de la FK, y de eso depende que el reporte siga sirviendo
+-- después de la 187:
+--   · 1 columna                      → el par existe y NO está protegido;
+--   · 2, y la segunda ata sucursal_id → el par existe y SÍ está protegido.
+-- La primera versión de esto sólo miraba las FK de una columna, y después de
+-- convertirlas el tablero quedaba vacío en vez de quedar en verde: un gate que
+-- se apaga solo justo cuando empieza a tener algo que vigilar. Contar los pares
+-- protegidos, y no sólo los rotos, es lo que lo mantiene vivo.
+--
+-- Quedan afuera las FK que no son de esta forma: las de dos columnas de negocio
+-- (`compra_cargo_repartos`) y las que apuntan a `sucursales`, que es el ancla del
+-- tenant y no tiene `sucursal_id` propio.
+--
+-- Interna a propósito: devuelve nombres de constraint y códigos de pg_constraint,
+-- que son insumo de la 187, no algo para mostrarle a nadie. La cara pública es
+-- auditoria_sucursal_cruzada().
+-- ----------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public._pares_sucursal_cruzada()
+RETURNS TABLE (
+  conname        text,
+  hija           text,
+  hija_oid       oid,
+  columna        text,
+  padre          text,
+  padre_oid      oid,
+  columna_padre  text,
+  confdeltype    "char",
+  confupdtype    "char",
+  condeferrable  boolean,
+  condeferred    boolean,
+  convalidated   boolean,
+  protegida      boolean
+)
+LANGUAGE sql
+STABLE
+SET search_path TO 'public'
+AS $fn$
+  WITH cand AS (
+    SELECT c.conname::text  AS conname,
+           ch.relname::text AS hija,
+           c.conrelid       AS hija_oid,
+           pa.relname::text AS padre,
+           c.confrelid      AS padre_oid,
+           c.conkey, c.confkey,
+           c.confdeltype, c.confupdtype,
+           c.condeferrable, c.condeferred, c.convalidated
+      FROM pg_constraint c
+      JOIN pg_class     ch ON ch.oid = c.conrelid
+      JOIN pg_class     pa ON pa.oid = c.confrelid
+      JOIN pg_namespace nh ON nh.oid = ch.relnamespace AND nh.nspname = 'public'
+      JOIN pg_namespace np ON np.oid = pa.relnamespace AND np.nspname = 'public'
+     WHERE c.contype = 'f'
+       AND cardinality(c.conkey) <= 2         -- las formas que este modelo cubre
+       AND c.conrelid <> c.confrelid          -- la autorreferencia no cruza nada
+       AND ch.relkind IN ('r', 'p')
+       AND pa.relkind IN ('r', 'p')
+       AND EXISTS (SELECT 1 FROM pg_attribute a
+                    WHERE a.attrelid = c.conrelid  AND a.attname = 'sucursal_id'
+                      AND a.attnum > 0 AND NOT a.attisdropped)
+       AND EXISTS (SELECT 1 FROM pg_attribute a
+                    WHERE a.attrelid = c.confrelid AND a.attname = 'sucursal_id'
+                      AND a.attnum > 0 AND NOT a.attisdropped)
+  ),
+  -- Una fila por columna de la FK, con su contraparte en el padre. El WITH
+  -- ORDINALITY es el que aparea hija y padre por POSICIÓN, que es como
+  -- pg_constraint los relaciona.
+  cols AS (
+    SELECT cand.*,
+           (SELECT a.attname::text FROM pg_attribute a
+             WHERE a.attrelid = cand.hija_oid  AND a.attnum = k.ck)                 AS c_col,
+           (SELECT a.attname::text FROM pg_attribute a
+             WHERE a.attrelid = cand.padre_oid AND a.attnum = cand.confkey[k.ord])  AS p_col
+      FROM cand, LATERAL unnest(cand.conkey) WITH ORDINALITY AS k(ck, ord)
+  ),
+  agg AS (
+    SELECT conname, hija, hija_oid, padre, padre_oid,
+           confdeltype, confupdtype, condeferrable, condeferred, convalidated,
+           count(*)                                                        AS n_cols,
+           count(*) FILTER (WHERE c_col <> 'sucursal_id')                  AS n_negocio,
+           max(c_col) FILTER (WHERE c_col <> 'sucursal_id')                AS columna,
+           max(p_col) FILTER (WHERE c_col <> 'sucursal_id')                AS columna_padre,
+           bool_or(c_col = 'sucursal_id' AND p_col = 'sucursal_id')        AS ata_sucursal
+      FROM cols
+     GROUP BY conname, hija, hija_oid, padre, padre_oid,
+              confdeltype, confupdtype, condeferrable, condeferred, convalidated
+  )
+  SELECT agg.conname, agg.hija, agg.hija_oid, agg.columna,
+         agg.padre, agg.padre_oid, agg.columna_padre,
+         agg.confdeltype, agg.confupdtype,
+         agg.condeferrable, agg.condeferred, agg.convalidated,
+         (agg.n_cols = 2 AND agg.ata_sucursal) AS protegida
+    FROM agg
+   WHERE agg.n_negocio = 1                          -- una sola columna de negocio
+     AND (agg.n_cols = 1 OR agg.ata_sucursal)       -- suelta, o atada por sucursal_id
+$fn$;
+
+COMMENT ON FUNCTION public._pares_sucursal_cruzada() IS
+  'Interna (mig 186). Descubre en pg_constraint los pares hija->padre donde las dos tablas tienen sucursal_id y la FK es de una sola columna: el patrón que permite que la hija contradiga la sucursal del padre. La usan auditoria_sucursal_cruzada() y la migración 187.';
+
+REVOKE ALL ON FUNCTION public._pares_sucursal_cruzada() FROM PUBLIC, anon, authenticated;
+
+-- ----------------------------------------------------------------------------
+-- 2 · El reporte
+--
+-- Por cada par: cuántas filas cuelgan de un padre y en cuántas la sucursal no
+-- coincide. El JOIN interno ya descarta la FK nula, que es legal y no es un cruce.
+--
+-- `IS DISTINCT FROM` y no `<>` por defensa, no por necesidad: hoy `sucursal_id`
+-- es NOT NULL en los dos lados de los 60 pares —verificado sobre el esquema
+-- entero—, y de eso depende que la FK compuesta de la 187 sirva para algo, porque
+-- MATCH SIMPLE se da por satisfecha si CUALQUIERA de las columnas referenciantes
+-- es NULL. Si alguna vez alguien afloja ese NOT NULL, la FK deja de mirar esas
+-- filas y este reporte las cuenta como divergentes en vez de dejarlas pasar en
+-- silencio. Es el único lugar donde el agujero podría volver sin que se note.
+--
+-- Admin-only con el mismo gate que auditoria_integridad(): service_role
+-- (auth.uid() IS NULL) entra libre, que es como lo llama el CI.
+-- ----------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.auditoria_sucursal_cruzada()
+RETURNS TABLE (
+  hija         text,
+  columna      text,
+  padre        text,
+  protegida    boolean,
+  filas        bigint,
+  divergentes  bigint
+)
+LANGUAGE plpgsql
+STABLE SECURITY DEFINER
+SET search_path TO 'public'
+AS $fn$
+DECLARE
+  r        record;
+  v_filas  bigint;
+  v_div    bigint;
+BEGIN
+  IF auth.uid() IS NOT NULL
+     AND NOT EXISTS (SELECT 1 FROM perfiles WHERE id = auth.uid() AND rol = 'admin') THEN
+    RAISE EXCEPTION 'Acceso denegado: se requiere rol admin';
+  END IF;
+
+  FOR r IN SELECT * FROM _pares_sucursal_cruzada() p ORDER BY p.hija, p.columna, p.padre
+  LOOP
+    EXECUTE format(
+      'SELECT count(*)::bigint,'
+      '       count(*) FILTER (WHERE h.sucursal_id IS DISTINCT FROM p.sucursal_id)::bigint'
+      '  FROM public.%I h JOIN public.%I p ON p.%I = h.%I',
+      r.hija, r.padre, r.columna_padre, r.columna)
+    INTO v_filas, v_div;
+
+    hija        := r.hija;
+    columna     := r.columna;
+    padre       := r.padre;
+    protegida   := r.protegida;
+    filas       := v_filas;
+    divergentes := v_div;
+    RETURN NEXT;
+  END LOOP;
+END;
+$fn$;
+
+COMMENT ON FUNCTION public.auditoria_sucursal_cruzada() IS
+  'Tablero de aislamiento por sucursal (mig 186). Una fila por par hija->padre donde las dos tablas tienen sucursal_id: protegida = la base ya impide el cruce con una FK compuesta; divergentes = filas que HOY contradicen la sucursal del padre. El objetivo es 0 divergentes y protegida en todas. Recorre entera cada tabla hija: es para CI y verificación, no para una pantalla. Admin-only.';
+
+REVOKE EXECUTE ON FUNCTION public.auditoria_sucursal_cruzada() FROM PUBLIC, anon;
+GRANT  EXECUTE ON FUNCTION public.auditoria_sucursal_cruzada() TO authenticated, service_role;
+
+COMMIT;
+
+-- ----------------------------------------------------------------------------
+-- Rollback
+--
+--   DROP FUNCTION IF EXISTS public.auditoria_sucursal_cruzada();
+--   DROP FUNCTION IF EXISTS public._pares_sucursal_cruzada();
+--
+-- Exacto: las dos son de sólo lectura y nadie más las llama salvo la 187 y el
+-- gate de CI. Dropearlas con la 187 ya aplicada deja las FK compuestas en pie
+-- (que es lo que protege) y ciego al gate (que es lo que avisa).
+-- ----------------------------------------------------------------------------
+
+-- ----------------------------------------------------------------------------
+-- Verificación
+--
+--   -- El tablero entero. Lo que predice el repo al 2026-08-19: 60 pares, 0
+--   -- protegidos (61 y 1 si la 183 ya entró: `compra_cargos.compra_id` nace
+--   -- con la FK compuesta puesta). Si prod devuelve otro número, gana prod:
+--   -- `migrations/` no es 1:1 con producción (MANIFEST, regla de oro).
+--   SELECT * FROM auditoria_sucursal_cruzada() ORDER BY divergentes DESC, hija;
+--
+--   -- Lo único que hay que mirar antes de aplicar la 187 — tiene que dar 0 filas:
+--   SELECT * FROM auditoria_sucursal_cruzada() WHERE divergentes > 0;
+--
+--   -- Y el resumen:
+--   SELECT count(*)                              AS pares,
+--          count(*) FILTER (WHERE protegida)     AS con_fk_compuesta,
+--          count(*) FILTER (WHERE divergentes>0) AS con_filas_cruzadas,
+--          sum(divergentes)                      AS filas_cruzadas
+--     FROM auditoria_sucursal_cruzada();
+--   -- Antes de la 187:   60 |  0 | 0 | 0     (esperado)
+--   -- Después de la 187: 60 | 60 | 0 | 0
+-- ----------------------------------------------------------------------------

--- a/migrations/186_quien_cruza_de_sucursal.sql
+++ b/migrations/186_quien_cruza_de_sucursal.sql
@@ -18,6 +18,15 @@
 --   "Nada ata todavía compra_items.sucursal_id a compras.sucursal_id".
 -- Éste es ese otro trabajo, generalizado a todo el esquema.
 --
+-- QUIÉN LLEGA. Todos. El baseline deja
+-- `ALTER DEFAULT PRIVILEGES ... IN SCHEMA public GRANT ALL ON TABLES TO
+-- authenticated`, así que toda tabla que cree `postgres` en `public` nace con
+-- INSERT/UPDATE/DELETE para cualquier usuario logueado, la haya pedido alguien o
+-- no. Buscar `GRANT` explícitos en las migraciones subestima el alcance: varias
+-- de estas tablas no tienen ninguno y son escribibles igual. Lo único que las
+-- separa de un `INSERT` directo por PostgREST es la policy, que es justamente lo
+-- que no mira al padre.
+--
 -- POR QUÉ FK Y NO RLS. Un EXISTS sobre el padre en las policies taparía sólo el
 -- camino de PostgREST. En esta base casi toda la escritura entra por RPCs
 -- SECURITY DEFINER, que saltean RLS por definición: la policy no las ve pasar.

--- a/migrations/186_quien_cruza_de_sucursal.sql
+++ b/migrations/186_quien_cruza_de_sucursal.sql
@@ -13,19 +13,25 @@
 -- SELECT filtra por el `sucursal_id` de la línea, que dice otra cosa— mientras le
 -- mueve el costo y el stock. Corrupción silenciosa con la víctima ciega.
 --
--- Es el mismo agujero que la 183 cerró para `compra_cargos` con una FK compuesta,
--- y que su sección 3 dejó anotado como preexistente y de otro trabajo:
+-- Es el mismo agujero que la 183 cierra para `compra_cargos` con una FK
+-- compuesta, y que su sección 3 dejó anotado como preexistente y de otro trabajo:
 --   "Nada ata todavía compra_items.sucursal_id a compras.sucursal_id".
 -- Éste es ese otro trabajo, generalizado a todo el esquema.
 --
--- QUIÉN LLEGA. Todos. El baseline deja
+-- Verificado contra prod el 2026-08-19: **69 pares y 0 filas cruzadas**. Es un
+-- agujero latente, no un incidente.
+--
+-- QUIÉN LLEGA. El baseline deja
 -- `ALTER DEFAULT PRIVILEGES ... IN SCHEMA public GRANT ALL ON TABLES TO
 -- authenticated`, así que toda tabla que cree `postgres` en `public` nace con
 -- INSERT/UPDATE/DELETE para cualquier usuario logueado, la haya pedido alguien o
--- no. Buscar `GRANT` explícitos en las migraciones subestima el alcance: varias
--- de estas tablas no tienen ninguno y son escribibles igual. Lo único que las
--- separa de un `INSERT` directo por PostgREST es la policy, que es justamente lo
--- que no mira al padre.
+-- no: confirmado con `has_table_privilege` sobre las hijas, incluidas las que no
+-- tienen ningún GRANT en las migraciones. Lo único que frena la escritura directa
+-- por PostgREST es que exista o no una policy de escritura. Donde no la hay
+-- —`recorrido_cambios`, `promo_acumuladores`, `pedido_item_sustituciones`,
+-- `comision_reglas`, `metas_preventista`: sólo SELECT— el default-deny de RLS
+-- alcanza, y el único camino de escritura son las RPCs SECURITY DEFINER. Que es
+-- justo el camino que ninguna policy vigila.
 --
 -- POR QUÉ FK Y NO RLS. Un EXISTS sobre el padre en las policies taparía sólo el
 -- camino de PostgREST. En esta base casi toda la escritura entra por RPCs
@@ -35,11 +41,14 @@
 -- constraint no se pisa por accidente.
 --
 -- POR QUÉ CATÁLOGO Y NO UNA LISTA. `migrations/` es una vista curada, no un
--- espejo de prod (MANIFEST, regla de oro), así que una lista sacada del repo nace
--- desalineada. Y una lista congelada no ve la tabla que alguien agregue mañana:
--- este reporte sí, porque los pares los descubre de pg_constraint. Ése es el
--- punto — el hallazgo no fue "compra_items está mal", fue "hay una CLASE de tabla
--- que está mal y nadie la estaba mirando".
+-- espejo de prod (MANIFEST, regla de oro), y acá se nota: el repo predice 60
+-- pares y prod tiene 69. Los 9 que faltaban (`comision_reglas`,
+-- `grupo_precio_escala_minimos`, `metas_preventista`, `productos.categoria_id`,
+-- `productos.marca_id`, `pedido_item_sustituciones.ajuste_producto_id_nuevo`) los
+-- encuentra el catálogo y los habría perdido una lista escrita a mano. Además
+-- una lista congelada no ve la tabla que alguien agregue mañana. Ése es el punto
+-- — el hallazgo no fue "compra_items está mal", fue "hay una CLASE de tabla que
+-- está mal y nadie la estaba mirando".
 --
 -- El reporte recorre entera cada tabla hija, así que es una herramienta de
 -- verificación y de CI, no algo para colgar de una pantalla.
@@ -48,29 +57,83 @@
 BEGIN;
 
 -- ----------------------------------------------------------------------------
--- 1 · Los pares, salidos del catálogo
+-- 1 · Cuál es la columna de tenant de cada tabla
 --
--- Un par es una FK entre dos tablas que tienen las dos `sucursal_id`. Ese
--- `sucursal_id` repetido en la hija es la premisa entera del problema: es un dato
+-- NO siempre es `sucursal_id`, y asumirlo daba un falso positivo caro.
+-- `transferencias_stock` tiene las DOS columnas y significan cosas distintas:
+--
+--   · `tenant_sucursal_id` es el tenant — es la que usa la policy de escritura
+--     (`mt_transferencias_stock_all`: es_admin() AND tenant_sucursal_id = ...);
+--   · `sucursal_id` es LA OTRA PUNTA del traslado, y por eso la policy de SELECT
+--     es `tenant_sucursal_id = current OR sucursal_id = current`: las dos
+--     sucursales tienen que poder ver el movimiento.
+--
+-- Comparar `transferencia_items.sucursal_id` contra `transferencias_stock.
+-- sucursal_id` daba 4 de 13 filas "cruzadas" que en realidad son correctas: son
+-- traslados entre sucursales, que por definición tienen las dos puntas distintas.
+-- Contra `tenant_sucursal_id` dan 0. Si alguien "arreglaba" esas 4 filas rompía
+-- historia buena.
+--
+-- La regla, entonces: el tenant es `tenant_sucursal_id` si la tabla lo tiene, y
+-- si no `sucursal_id`. Hoy hay un solo caso, pero la regla se lee sola —una
+-- columna que se llama "tenant" es el tenant— y evita que el próximo la pise.
+-- `movimientos_sucursal` (mig 076) ni siquiera entra: tiene `sucursal_origen_id`
+-- y `sucursal_destino_id` y ninguna columna de tenant, así que no hay nada que
+-- atar.
+-- ----------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public._tenant_col_por_tabla()
+RETURNS TABLE (reloid oid, tabla text, tcol text, tcol_nullable boolean)
+LANGUAGE sql
+STABLE
+SET search_path TO 'public'
+AS $fn$
+  SELECT c.oid,
+         c.relname::text,
+         t.tcol,
+         NOT a.attnotnull
+    FROM pg_class c
+    JOIN pg_namespace n ON n.oid = c.relnamespace AND n.nspname = 'public'
+    CROSS JOIN LATERAL (
+      SELECT CASE WHEN EXISTS (
+                    SELECT 1 FROM pg_attribute x
+                     WHERE x.attrelid = c.oid AND x.attname = 'tenant_sucursal_id'
+                       AND x.attnum > 0 AND NOT x.attisdropped)
+                  THEN 'tenant_sucursal_id' ELSE 'sucursal_id' END AS tcol
+    ) t
+    JOIN pg_attribute a ON a.attrelid = c.oid AND a.attname = t.tcol
+                       AND a.attnum > 0 AND NOT a.attisdropped
+   WHERE c.relkind IN ('r', 'p')
+$fn$;
+
+COMMENT ON FUNCTION public._tenant_col_por_tabla() IS
+  'Interna (mig 186). Resuelve cuál columna es el tenant de cada tabla: tenant_sucursal_id si existe, si no sucursal_id. Existe porque transferencias_stock tiene las dos y significan cosas distintas — sucursal_id ahi es la otra punta del traslado, no el tenant.';
+
+REVOKE ALL ON FUNCTION public._tenant_col_por_tabla() FROM PUBLIC, anon, authenticated;
+
+-- ----------------------------------------------------------------------------
+-- 2 · Los pares, salidos del catálogo
+--
+-- Un par es una FK entre dos tablas que tienen las dos columna de tenant. Ese
+-- tenant repetido en la hija es la premisa entera del problema: es un dato
 -- derivable del padre que igual se guarda al lado, así que puede contradecirlo.
 -- Si la hija no lo tuviera no habría nada que contradecir —`movimiento_sucursal_
 -- items` es exactamente ese caso: resuelve la sucursal por join con el
 -- movimiento, no la copia, y por eso no aparece acá ni puede divergir. Lo mismo
 -- `compra_cargo_repartos` (mig 183).
 --
--- El par se identifica por su COLUMNA DE NEGOCIO —la que no es `sucursal_id`—,
--- no por la aridad de la FK, y de eso depende que el reporte siga sirviendo
--- después de la 187:
---   · 1 columna                      → el par existe y NO está protegido;
---   · 2, y la segunda ata sucursal_id → el par existe y SÍ está protegido.
+-- El par se identifica por su COLUMNA DE NEGOCIO —la que no es el tenant—, no por
+-- la aridad de la FK, y de eso depende que el reporte siga sirviendo después de
+-- la 187:
+--   · 1 columna                   → el par existe y NO está protegido;
+--   · 2, y la segunda ata el tenant → el par existe y SÍ está protegido.
 -- La primera versión de esto sólo miraba las FK de una columna, y después de
--- convertirlas el tablero quedaba vacío en vez de quedar en verde: un gate que
--- se apaga solo justo cuando empieza a tener algo que vigilar. Contar los pares
+-- convertirlas el tablero quedaba vacío en vez de quedar en verde: un gate que se
+-- apaga solo justo cuando empieza a tener algo que vigilar. Contar los pares
 -- protegidos, y no sólo los rotos, es lo que lo mantiene vivo.
 --
 -- Quedan afuera las FK que no son de esta forma: las de dos columnas de negocio
 -- (`compra_cargo_repartos`) y las que apuntan a `sucursales`, que es el ancla del
--- tenant y no tiene `sucursal_id` propio.
+-- tenant y no tiene columna de tenant propia.
 --
 -- Interna a propósito: devuelve nombres de constraint y códigos de pg_constraint,
 -- que son insumo de la 187, no algo para mostrarle a nadie. La cara pública es
@@ -81,46 +144,42 @@ RETURNS TABLE (
   conname        text,
   hija           text,
   hija_oid       oid,
+  tcol_hija      text,
   columna        text,
   padre          text,
   padre_oid      oid,
+  tcol_padre     text,
   columna_padre  text,
   confdeltype    "char",
   confupdtype    "char",
   condeferrable  boolean,
   condeferred    boolean,
   convalidated   boolean,
-  protegida      boolean
+  protegida      boolean,
+  parcial        boolean
 )
 LANGUAGE sql
 STABLE
 SET search_path TO 'public'
 AS $fn$
   WITH cand AS (
-    SELECT c.conname::text  AS conname,
-           ch.relname::text AS hija,
-           c.conrelid       AS hija_oid,
-           pa.relname::text AS padre,
-           c.confrelid      AS padre_oid,
+    SELECT c.conname::text AS conname,
+           th.tabla        AS hija,
+           c.conrelid      AS hija_oid,
+           th.tcol         AS tcol_hija,
+           tp.tabla        AS padre,
+           c.confrelid     AS padre_oid,
+           tp.tcol         AS tcol_padre,
+           th.tcol_nullable OR tp.tcol_nullable AS parcial,
            c.conkey, c.confkey,
            c.confdeltype, c.confupdtype,
            c.condeferrable, c.condeferred, c.convalidated
       FROM pg_constraint c
-      JOIN pg_class     ch ON ch.oid = c.conrelid
-      JOIN pg_class     pa ON pa.oid = c.confrelid
-      JOIN pg_namespace nh ON nh.oid = ch.relnamespace AND nh.nspname = 'public'
-      JOIN pg_namespace np ON np.oid = pa.relnamespace AND np.nspname = 'public'
+      JOIN public._tenant_col_por_tabla() th ON th.reloid = c.conrelid
+      JOIN public._tenant_col_por_tabla() tp ON tp.reloid = c.confrelid
      WHERE c.contype = 'f'
        AND cardinality(c.conkey) <= 2         -- las formas que este modelo cubre
        AND c.conrelid <> c.confrelid          -- la autorreferencia no cruza nada
-       AND ch.relkind IN ('r', 'p')
-       AND pa.relkind IN ('r', 'p')
-       AND EXISTS (SELECT 1 FROM pg_attribute a
-                    WHERE a.attrelid = c.conrelid  AND a.attname = 'sucursal_id'
-                      AND a.attnum > 0 AND NOT a.attisdropped)
-       AND EXISTS (SELECT 1 FROM pg_attribute a
-                    WHERE a.attrelid = c.confrelid AND a.attname = 'sucursal_id'
-                      AND a.attnum > 0 AND NOT a.attisdropped)
   ),
   -- Una fila por columna de la FK, con su contraparte en el padre. El WITH
   -- ORDINALITY es el que aparea hija y padre por POSICIÓN, que es como
@@ -128,51 +187,63 @@ AS $fn$
   cols AS (
     SELECT cand.*,
            (SELECT a.attname::text FROM pg_attribute a
-             WHERE a.attrelid = cand.hija_oid  AND a.attnum = k.ck)                 AS c_col,
+             WHERE a.attrelid = cand.hija_oid  AND a.attnum = k.ck)                AS c_col,
            (SELECT a.attname::text FROM pg_attribute a
-             WHERE a.attrelid = cand.padre_oid AND a.attnum = cand.confkey[k.ord])  AS p_col
+             WHERE a.attrelid = cand.padre_oid AND a.attnum = cand.confkey[k.ord]) AS p_col
       FROM cand, LATERAL unnest(cand.conkey) WITH ORDINALITY AS k(ck, ord)
   ),
   agg AS (
-    SELECT conname, hija, hija_oid, padre, padre_oid,
+    SELECT conname, hija, hija_oid, tcol_hija, padre, padre_oid, tcol_padre, parcial,
            confdeltype, confupdtype, condeferrable, condeferred, convalidated,
-           count(*)                                                        AS n_cols,
-           count(*) FILTER (WHERE c_col <> 'sucursal_id')                  AS n_negocio,
-           max(c_col) FILTER (WHERE c_col <> 'sucursal_id')                AS columna,
-           max(p_col) FILTER (WHERE c_col <> 'sucursal_id')                AS columna_padre,
-           bool_or(c_col = 'sucursal_id' AND p_col = 'sucursal_id')        AS ata_sucursal
+           count(*)                                                  AS n_cols,
+           count(*) FILTER (WHERE c_col <> tcol_hija)                AS n_negocio,
+           max(c_col) FILTER (WHERE c_col <> tcol_hija)              AS columna,
+           max(p_col) FILTER (WHERE c_col <> tcol_hija)              AS columna_padre,
+           bool_or(c_col = tcol_hija AND p_col = tcol_padre)         AS ata_tenant
       FROM cols
-     GROUP BY conname, hija, hija_oid, padre, padre_oid,
+     GROUP BY conname, hija, hija_oid, tcol_hija, padre, padre_oid, tcol_padre, parcial,
               confdeltype, confupdtype, condeferrable, condeferred, convalidated
   )
-  SELECT agg.conname, agg.hija, agg.hija_oid, agg.columna,
-         agg.padre, agg.padre_oid, agg.columna_padre,
+  SELECT agg.conname, agg.hija, agg.hija_oid, agg.tcol_hija, agg.columna,
+         agg.padre, agg.padre_oid, agg.tcol_padre, agg.columna_padre,
          agg.confdeltype, agg.confupdtype,
          agg.condeferrable, agg.condeferred, agg.convalidated,
-         (agg.n_cols = 2 AND agg.ata_sucursal) AS protegida
+         (agg.n_cols = 2 AND agg.ata_tenant) AS protegida,
+         agg.parcial
     FROM agg
-   WHERE agg.n_negocio = 1                          -- una sola columna de negocio
-     AND (agg.n_cols = 1 OR agg.ata_sucursal)       -- suelta, o atada por sucursal_id
+   WHERE agg.n_negocio = 1                        -- una sola columna de negocio
+     AND (agg.n_cols = 1 OR agg.ata_tenant)       -- suelta, o atada por el tenant
 $fn$;
 
 COMMENT ON FUNCTION public._pares_sucursal_cruzada() IS
-  'Interna (mig 186). Descubre en pg_constraint los pares hija->padre donde las dos tablas tienen sucursal_id y la FK es de una sola columna: el patrón que permite que la hija contradiga la sucursal del padre. La usan auditoria_sucursal_cruzada() y la migración 187.';
+  'Interna (mig 186). Descubre en pg_constraint los pares hija->padre donde las dos tablas tienen columna de tenant y la FK es de una sola columna de negocio: el patrón que permite que la hija contradiga la sucursal del padre. La usan auditoria_sucursal_cruzada() y la migración 187.';
 
 REVOKE ALL ON FUNCTION public._pares_sucursal_cruzada() FROM PUBLIC, anon, authenticated;
 
 -- ----------------------------------------------------------------------------
--- 2 · El reporte
+-- 3 · El reporte
 --
--- Por cada par: cuántas filas cuelgan de un padre y en cuántas la sucursal no
+-- Por cada par: cuántas filas cuelgan de un padre y en cuántas el tenant no
 -- coincide. El JOIN interno ya descarta la FK nula, que es legal y no es un cruce.
 --
--- `IS DISTINCT FROM` y no `<>` por defensa, no por necesidad: hoy `sucursal_id`
--- es NOT NULL en los dos lados de los 60 pares —verificado sobre el esquema
--- entero—, y de eso depende que la FK compuesta de la 187 sirva para algo, porque
--- MATCH SIMPLE se da por satisfecha si CUALQUIERA de las columnas referenciantes
--- es NULL. Si alguna vez alguien afloja ese NOT NULL, la FK deja de mirar esas
--- filas y este reporte las cuenta como divergentes en vez de dejarlas pasar en
--- silencio. Es el único lugar donde el agujero podría volver sin que se note.
+-- `parcial` es la letra chica de `protegida`, y hay que decirla porque si no el
+-- tablero promete de más. La FK compuesta es MATCH SIMPLE: se da por satisfecha
+-- si CUALQUIERA de las columnas referenciantes es NULL. Con el tenant NOT NULL
+-- —que es el caso de 68 de los 69 pares— eso no pasa nunca y la protección es
+-- total. `comision_reglas.sucursal_id` es nullable (una regla de comisión sin
+-- sucursal es global, y está bien que exista), así que ahí la FK cubre las filas
+-- con sucursal y deja pasar las globales. Es mejor que nada y no se puede
+-- endurecer sin romper la regla global; lo que no se puede es contarlo como
+-- cubierto. Si alguien afloja un NOT NULL de tenant, ese par pasa a `parcial` y
+-- se ve, en vez de perder la protección en silencio.
+--
+-- Por eso `divergentes` compara con las dos puntas NO NULAS y no con
+-- `IS DISTINCT FROM`: un tenant NULL es "global", no "cruzada". Con
+-- `IS DISTINCT FROM` una regla de comisión global —tenant NULL contra un producto
+-- de la sucursal 2— contaba como divergencia y dejaba el preflight de la 187
+-- abortando para siempre por una fila perfectamente legal. Contar exactamente lo
+-- que la FK rechaza es también lo que mantiene al reporte y a la constraint
+-- diciendo lo mismo.
 --
 -- Admin-only con el mismo gate que auditoria_integridad(): service_role
 -- (auth.uid() IS NULL) entra libre, que es como lo llama el CI.
@@ -183,6 +254,7 @@ RETURNS TABLE (
   columna      text,
   padre        text,
   protegida    boolean,
+  parcial      boolean,
   filas        bigint,
   divergentes  bigint
 )
@@ -204,8 +276,10 @@ BEGIN
   LOOP
     EXECUTE format(
       'SELECT count(*)::bigint,'
-      '       count(*) FILTER (WHERE h.sucursal_id IS DISTINCT FROM p.sucursal_id)::bigint'
+      '       count(*) FILTER (WHERE h.%I IS NOT NULL AND p.%I IS NOT NULL'
+      '                          AND h.%I <> p.%I)::bigint'
       '  FROM public.%I h JOIN public.%I p ON p.%I = h.%I',
+      r.tcol_hija, r.tcol_padre, r.tcol_hija, r.tcol_padre,
       r.hija, r.padre, r.columna_padre, r.columna)
     INTO v_filas, v_div;
 
@@ -213,6 +287,7 @@ BEGIN
     columna     := r.columna;
     padre       := r.padre;
     protegida   := r.protegida;
+    parcial     := r.parcial;
     filas       := v_filas;
     divergentes := v_div;
     RETURN NEXT;
@@ -221,7 +296,7 @@ END;
 $fn$;
 
 COMMENT ON FUNCTION public.auditoria_sucursal_cruzada() IS
-  'Tablero de aislamiento por sucursal (mig 186). Una fila por par hija->padre donde las dos tablas tienen sucursal_id: protegida = la base ya impide el cruce con una FK compuesta; divergentes = filas que HOY contradicen la sucursal del padre. El objetivo es 0 divergentes y protegida en todas. Recorre entera cada tabla hija: es para CI y verificación, no para una pantalla. Admin-only.';
+  'Tablero de aislamiento por sucursal (mig 186). Una fila por par hija->padre donde las dos tablas tienen columna de tenant: protegida = la base ya impide el cruce con una FK compuesta; parcial = el tenant es nullable, así que la FK (MATCH SIMPLE) no cubre las filas sin sucursal; divergentes = filas que HOY contradicen el tenant del padre. El objetivo es 0 divergentes y protegida en todas. Recorre entera cada tabla hija: es para CI y verificación, no para una pantalla. Admin-only.';
 
 REVOKE EXECUTE ON FUNCTION public.auditoria_sucursal_cruzada() FROM PUBLIC, anon;
 GRANT  EXECUTE ON FUNCTION public.auditoria_sucursal_cruzada() TO authenticated, service_role;
@@ -233,19 +308,18 @@ COMMIT;
 --
 --   DROP FUNCTION IF EXISTS public.auditoria_sucursal_cruzada();
 --   DROP FUNCTION IF EXISTS public._pares_sucursal_cruzada();
+--   DROP FUNCTION IF EXISTS public._tenant_col_por_tabla();
 --
--- Exacto: las dos son de sólo lectura y nadie más las llama salvo la 187 y el
+-- Exacto: las tres son de sólo lectura y nadie más las llama salvo la 187 y el
 -- gate de CI. Dropearlas con la 187 ya aplicada deja las FK compuestas en pie
 -- (que es lo que protege) y ciego al gate (que es lo que avisa).
 -- ----------------------------------------------------------------------------
 
 -- ----------------------------------------------------------------------------
--- Verificación
+-- Verificación — números medidos contra prod el 2026-08-19
 --
---   -- El tablero entero. Lo que predice el repo al 2026-08-19: 60 pares, 0
---   -- protegidos (61 y 1 si la 183 ya entró: `compra_cargos.compra_id` nace
---   -- con la FK compuesta puesta). Si prod devuelve otro número, gana prod:
---   -- `migrations/` no es 1:1 con producción (MANIFEST, regla de oro).
+--   -- El tablero entero: 69 pares, 0 protegidos, 0 cruzados, 2 parciales
+--   -- (comision_reglas, por su sucursal_id nullable).
 --   SELECT * FROM auditoria_sucursal_cruzada() ORDER BY divergentes DESC, hija;
 --
 --   -- Lo único que hay que mirar antes de aplicar la 187 — tiene que dar 0 filas:
@@ -254,9 +328,17 @@ COMMIT;
 --   -- Y el resumen:
 --   SELECT count(*)                              AS pares,
 --          count(*) FILTER (WHERE protegida)     AS con_fk_compuesta,
+--          count(*) FILTER (WHERE parcial)       AS tenant_nullable,
 --          count(*) FILTER (WHERE divergentes>0) AS con_filas_cruzadas,
 --          sum(divergentes)                      AS filas_cruzadas
 --     FROM auditoria_sucursal_cruzada();
---   -- Antes de la 187:   60 |  0 | 0 | 0     (esperado)
---   -- Después de la 187: 60 | 60 | 0 | 0
+--   -- Antes de la 187:   69 |  0 | 2 | 0 | 0     (medido)
+--   -- Después de la 187: 69 | 69 | 2 | 0 | 0
+--
+--   -- El caso que justifica _tenant_col_por_tabla(): contra la columna
+--   -- equivocada dan 4 divergencias que son historia buena, contra la correcta 0.
+--   SELECT count(*) FILTER (WHERE i.sucursal_id <> t.sucursal_id)        AS falso_positivo,
+--          count(*) FILTER (WHERE i.sucursal_id <> t.tenant_sucursal_id) AS real
+--     FROM transferencia_items i JOIN transferencias_stock t ON t.id = i.transferencia_id;
+--   -- 4 | 0
 -- ----------------------------------------------------------------------------

--- a/migrations/187_la_hija_no_cruza_de_sucursal.sql
+++ b/migrations/187_la_hija_no_cruza_de_sucursal.sql
@@ -1,26 +1,31 @@
 -- ============================================================================
 -- 187 · Que la hija no pueda cruzar de sucursal
 -- ============================================================================
--- Requiere la 186 (`_pares_sucursal_cruzada()` y `auditoria_sucursal_cruzada()`).
--- Leer el encabezado de la 186 para el planteo del agujero y por qué se cierra
--- con FK y no con RLS.
+-- Requiere la 186 (`_tenant_col_por_tabla()`, `_pares_sucursal_cruzada()` y
+-- `auditoria_sucursal_cruzada()`). Leer su encabezado para el planteo del
+-- agujero, por qué se cierra con FK y no con RLS, y por qué el tenant no siempre
+-- se llama `sucursal_id`.
 --
--- Acá se convierte cada FK de una columna entre dos tablas que tienen las dos
--- `sucursal_id` en una FK COMPUESTA `(columna, sucursal_id) -> padre(id,
--- sucursal_id)`. Mismo patrón estructural que la 183 usó para atar un cargo a su
--- compra, aplicado a todo lo que ya estaba suelto.
+-- Acá se convierte cada FK de una columna entre dos tablas con columna de tenant
+-- en una FK COMPUESTA `(columna, tenant_hija) -> padre(id, tenant_padre)`. Mismo
+-- patrón estructural que la 183 usa para atar un cargo a su compra, aplicado a
+-- todo lo que ya estaba suelto.
 --
--- NO TOCA NI UNA FILA. Sólo constraints. Si algún dato hoy cruza de sucursal, la
+-- Medido contra prod el 2026-08-19: **69 pares, 0 filas cruzadas**, PostgreSQL
+-- 17.6. Ningún padre tiene todavía un UNIQUE sobre (id, tenant): los crea la
+-- sección 4.
+--
+-- NO TOCA NI UNA FILA. Sólo constraints. Si algún dato cruzara de sucursal, la
 -- migración ABORTA en la sección 2 con la lista completa en vez de aplicar la
 -- mitad: no hay nada acá que "arregle" filas, porque cuál es la sucursal correcta
 -- de una línea cruzada es una decisión de negocio, no de esta migración.
 --
--- LAS UNIQUE DE LA SECCIÓN 3 NO PUEDEN RECHAZAR NADA. Para que una FK apunte a
--- `padre(columna, sucursal_id)` tiene que existir un UNIQUE sobre ese par. Y esa
+-- LAS UNIQUE DE LA SECCIÓN 4 NO PUEDEN RECHAZAR NADA. Para que una FK apunte a
+-- `padre(columna, tenant)` tiene que existir un UNIQUE sobre ese par. Y ese
 -- UNIQUE es redundante por construcción: para ser destino de la FK original,
--- `columna` ya era única sola. Una fila que violara `(columna, sucursal_id)`
--- estaría violando primero la clave de una sola columna. Es el mismo razonamiento
--- de la sección 1 de la 183, que ya lo verificó con conteos contra prod.
+-- `columna` ya era única sola —verificado: los 19 padres tienen `PRIMARY KEY
+-- (id)`—. Una fila que violara `(id, tenant)` estaría violando primero la PK. Es
+-- el mismo razonamiento de la sección 1 de la 183.
 --
 -- LO QUE SÍ CAMBIA DE COMPORTAMIENTO: nada, si el dato está sano. Un INSERT o un
 -- UPDATE que hoy cruza de sucursal pasa a fallar con
@@ -31,7 +36,9 @@ BEGIN;
 
 -- Un DDL que espera detrás de una transacción larga bloquea la app entera, y
 -- todo esto vive en un solo BEGIN/COMMIT. Mejor fallar en 10 segundos y volver
--- en un rato que dejar la app colgada: el rollback no deja nada a medias.
+-- en un rato que dejar la app colgada: el rollback no deja nada a medias. Las
+-- tablas son chicas (la más grande, pedido_historial, tiene 26k filas), así que
+-- la validación de cada FK es cuestión de milisegundos.
 SET LOCAL lock_timeout = '10s';
 SET LOCAL statement_timeout = '5min';
 
@@ -45,7 +52,7 @@ SET LOCAL statement_timeout = '5min';
 --
 -- `NOT protegida` alcanza como filtro: la 186 ya deja afuera todo lo que no es
 -- esta forma —las FK de dos columnas de negocio, las que apuntan a `sucursales`—
--- y garantiza que `columna` sea siempre la de negocio y nunca `sucursal_id`.
+-- y garantiza que `columna` sea siempre la de negocio y nunca el tenant.
 -- ----------------------------------------------------------------------------
 CREATE TEMP TABLE _pares_a_componer ON COMMIT DROP AS
   SELECT p.*
@@ -53,10 +60,10 @@ CREATE TEMP TABLE _pares_a_componer ON COMMIT DROP AS
    WHERE NOT p.protegida;
 
 DO $mig$
-DECLARE v_n int;
+DECLARE v_n int; v_p int;
 BEGIN
-  SELECT count(*) INTO v_n FROM _pares_a_componer;
-  RAISE NOTICE '187 · pares a convertir en FK compuesta: %', v_n;
+  SELECT count(*), count(*) FILTER (WHERE parcial) INTO v_n, v_p FROM _pares_a_componer;
+  RAISE NOTICE '187 · pares a convertir en FK compuesta: % (% con tenant nullable)', v_n, v_p;
 END;
 $mig$;
 
@@ -66,6 +73,12 @@ $mig$;
 -- La FK igual rechazaría la migración si hubiera filas divergentes, pero lo haría
 -- con el error de UNA constraint y sin decir cuántas más vienen atrás. Esto las
 -- lista todas de una, que es lo que hace falta para decidir qué hacer con ellas.
+--
+-- Ojo con el reflejo de "corregir" lo que salga acá: la primera corrida de este
+-- reporte marcó 4 de 13 filas de `transferencia_items` y eran correctas — se
+-- estaba comparando contra `transferencias_stock.sucursal_id`, que es la otra
+-- punta del traslado y no el tenant. Antes de tocar una fila hay que estar seguro
+-- de que las dos columnas significan lo mismo (ver sección 1 de la 186).
 -- ----------------------------------------------------------------------------
 DO $mig$
 DECLARE v_txt text;
@@ -89,10 +102,14 @@ $mig$;
 -- 3 · Guard de versión
 --
 -- `ON DELETE SET NULL` sobre una FK compuesta anula TODAS las columnas
--- referenciantes, `sucursal_id` incluida — que es NOT NULL en las 60 hijas. O sea
--- que el borrado del padre pasaría de anular la referencia a fallar con un
+-- referenciantes, el tenant incluido — que es NOT NULL en 68 de los 69 pares. O
+-- sea que el borrado del padre pasaría de anular la referencia a fallar con un
 -- 23502. Restringir el SET NULL a la columna de la FK (`SET NULL (columna)`)
 -- existe recién en PostgreSQL 15.
+--
+-- Prod corre 17.6, así que este guard no va a saltar nunca. Queda igual: es la
+-- clase de detalle que se descubre en el peor momento si la base cambia de
+-- versión hacia atrás o si alguien reusa este archivo en otro proyecto.
 --
 -- No hay plan B decente: degradar esos SET NULL a NO ACTION cambiaría el
 -- comportamiento del borrado de un producto o de un cliente sin avisar. Así que
@@ -118,15 +135,15 @@ $mig$;
 -- error que ya conoce el equipo no cambian, y nada que busque una constraint por
 -- nombre se rompe. Lo que cambia es de cuántas columnas es.
 --
--- La UNIQUE del padre sigue la convención que estrenó la 183:
--- `<padre>_<columna>_sucursal_uk`. Si la 183 entró antes, `compras_id_sucursal_uk`
--- ya existe y el guard la saltea; si entra después, la encuentra hecha. Las dos
--- migraciones conviven en cualquier orden.
+-- La UNIQUE del padre sigue la convención que estrena la 183:
+-- `<padre>_<columna>_<tenant>_uk`. Si la 183 entra antes,
+-- `compras_id_sucursal_uk` ya existe y el guard la saltea; si entra después, la
+-- encuentra hecha. Las dos migraciones conviven en cualquier orden.
 --
 -- El DROP + ADD va adentro de la misma transacción, así que no hay ventana sin
 -- integridad referencial. Y no hace falta ningún índice nuevo en la hija: el
--- chequeo al borrar un padre filtra `columna = X AND sucursal_id = Y`, y el
--- índice que ya existe sobre `columna` sirve igual.
+-- chequeo al borrar un padre filtra `columna = X AND tenant = Y`, y el índice que
+-- ya existe sobre `columna` sirve igual.
 -- ----------------------------------------------------------------------------
 DO $mig$
 DECLARE
@@ -140,13 +157,14 @@ DECLARE
 BEGIN
   FOR r IN SELECT * FROM _pares_a_componer ORDER BY hija, columna, padre
   LOOP
-    -- 4.a · El destino: UNIQUE (columna_padre, sucursal_id) en el padre.
-    v_uk := format('%s_%s_sucursal_uk', r.padre, r.columna_padre);
+    -- 4.a · El destino: UNIQUE (columna_padre, tenant) en el padre.
+    v_uk := format('%s_%s_%s_uk', r.padre, r.columna_padre,
+                   replace(r.tcol_padre, '_id', ''));
     IF NOT EXISTS (SELECT 1 FROM pg_constraint
                     WHERE conname = v_uk AND conrelid = r.padre_oid) THEN
-      EXECUTE format('ALTER TABLE public.%I ADD CONSTRAINT %I UNIQUE (%I, sucursal_id)',
-                     r.padre, v_uk, r.columna_padre);
-      RAISE NOTICE '  + UNIQUE %(%, sucursal_id)', r.padre, r.columna_padre;
+      EXECUTE format('ALTER TABLE public.%I ADD CONSTRAINT %I UNIQUE (%I, %I)',
+                     r.padre, v_uk, r.columna_padre, r.tcol_padre);
+      RAISE NOTICE '  + UNIQUE %(%, %)', r.padre, r.columna_padre, r.tcol_padre;
     END IF;
 
     -- 4.b · Las acciones referenciales de la vieja, preservadas al pie de la letra.
@@ -179,12 +197,14 @@ BEGIN
 
     EXECUTE format('ALTER TABLE public.%I DROP CONSTRAINT %I', r.hija, r.conname);
     EXECUTE format(
-      'ALTER TABLE public.%I ADD CONSTRAINT %I FOREIGN KEY (%I, sucursal_id) '
-      'REFERENCES public.%I (%I, sucursal_id)%s%s%s%s',
-      r.hija, r.conname, r.columna, r.padre, r.columna_padre, v_upd, v_del, v_dfr, v_val);
+      'ALTER TABLE public.%I ADD CONSTRAINT %I FOREIGN KEY (%I, %I) '
+      'REFERENCES public.%I (%I, %I)%s%s%s%s',
+      r.hija, r.conname, r.columna, r.tcol_hija,
+      r.padre, r.columna_padre, r.tcol_padre, v_upd, v_del, v_dfr, v_val);
 
     v_n := v_n + 1;
-    RAISE NOTICE '  ~ %.% -> %  (%)', r.hija, r.columna, r.padre, r.conname;
+    RAISE NOTICE '  ~ %.% -> %  (%)%', r.hija, r.columna, r.padre, r.conname,
+      CASE WHEN r.parcial THEN '  [tenant nullable: cubre sólo las filas con sucursal]' ELSE '' END;
   END LOOP;
 
   RAISE NOTICE '187 · % FK convertidas en compuestas.', v_n;
@@ -227,17 +247,17 @@ COMMIT;
 --     FOR r IN
 --       SELECT c.conname, ch.relname AS hija, pa.relname AS padre, c.confdeltype,
 --              (SELECT a.attname FROM pg_attribute a
---                WHERE a.attrelid=c.conrelid AND a.attnum=c.conkey[1]
---                  AND a.attname <> 'sucursal_id') AS columna,
+--                WHERE a.attrelid=c.conrelid AND a.attnum=c.conkey[1]) AS columna,
 --              (SELECT a.attname FROM pg_attribute a
---                WHERE a.attrelid=c.confrelid AND a.attnum=c.confkey[1]
---                  AND a.attname <> 'sucursal_id') AS columna_padre
+--                WHERE a.attrelid=c.confrelid AND a.attnum=c.confkey[1]) AS columna_padre
 --         FROM pg_constraint c
 --         JOIN pg_class ch ON ch.oid=c.conrelid
 --         JOIN pg_class pa ON pa.oid=c.confrelid
 --        WHERE c.contype='f' AND cardinality(c.conkey)=2
---          AND 'sucursal_id' = ANY (SELECT a.attname FROM pg_attribute a
---                                    WHERE a.attrelid=c.conrelid AND a.attnum=ANY(c.conkey))
+--          AND c.connamespace='public'::regnamespace
+--          AND EXISTS (SELECT 1 FROM pg_attribute a
+--                       WHERE a.attrelid=c.conrelid AND a.attnum=c.conkey[2]
+--                         AND a.attname IN ('sucursal_id','tenant_sucursal_id'))
 --     LOOP
 --       v_del := CASE r.confdeltype WHEN 'c' THEN ' ON DELETE CASCADE'
 --                                   WHEN 'n' THEN ' ON DELETE SET NULL'
@@ -248,26 +268,28 @@ COMMIT;
 --     END LOOP;
 --   END $rb$;
 --
--- OJO: ese loop toma TODAS las FK de dos columnas con `sucursal_id`, o sea que se
--- llevaría puestas también las que creó la 183 a mano (compra_cargos ->
--- compras). Si la 183 está aplicada, hay que excluirla.
+-- OJO: ese loop asume que el tenant quedó SEGUNDO en la constraint, que es como
+-- las escribe la sección 4, y toma TODAS las FK de dos columnas con tenant — o
+-- sea que se llevaría puestas también las que crea la 183 a mano (compra_cargos
+-- -> compras). Si la 183 está aplicada, hay que excluirla.
 --
--- Las UNIQUE `<padre>_<col>_sucursal_uk` se pueden dejar: son redundantes con la
--- clave de una columna y no rechazan nada. Dropearlas es opcional y hay que
--- hacerlo DESPUÉS de las FK, no antes.
+-- Las UNIQUE `<padre>_<col>_<tenant>_uk` se pueden dejar: son redundantes con la
+-- PK y no rechazan nada. Dropearlas es opcional y hay que hacerlo DESPUÉS de las
+-- FK, no antes.
 -- ----------------------------------------------------------------------------
 
 -- ----------------------------------------------------------------------------
 -- Verificación
 --
---   -- 1. El tablero, que es el resultado que importa: 0 sin proteger, 0 cruzadas.
---   SELECT count(*)                               AS pares,
---          count(*) FILTER (WHERE NOT protegida)  AS sin_proteger,
---          sum(divergentes)                       AS filas_cruzadas
+--   -- 1. El tablero, que es el resultado que importa.
+--   SELECT count(*)                              AS pares,
+--          count(*) FILTER (WHERE NOT protegida) AS sin_proteger,
+--          count(*) FILTER (WHERE parcial)       AS tenant_nullable,
+--          sum(divergentes)                      AS filas_cruzadas
 --     FROM auditoria_sucursal_cruzada();
---   -- esperado: 60 | 0 | 0
+--   -- esperado: 69 | 0 | 2 | 0
 --
---   -- 2. Las FK compuestas, una por par (más las 3 que ya trae la 183):
+--   -- 2. Las FK compuestas, una por par (más las 3 que trae la 183 si ya entró):
 --   SELECT conrelid::regclass AS hija, conname, pg_get_constraintdef(oid) AS def
 --     FROM pg_constraint
 --    WHERE contype='f' AND cardinality(conkey)=2
@@ -276,14 +298,14 @@ COMMIT;
 --
 --   -- 3. Que ningún ON DELETE se haya perdido en el cambio. Tiene que dar 0:
 --   --    toda FK compuesta con SET NULL debe traer su lista de columnas, si no
---   --    el borrado del padre va a fallar contra el NOT NULL de sucursal_id.
+--   --    el borrado del padre va a fallar contra el NOT NULL del tenant.
 --   SELECT count(*) FROM pg_constraint
 --    WHERE contype='f' AND cardinality(conkey)=2 AND confdeltype='n'
 --      AND connamespace='public'::regnamespace
 --      AND pg_get_constraintdef(oid) NOT LIKE '%SET NULL (%';
 --
 --   -- 4. La prueba de fuego, en una transacción que se descarta. Tiene que
---   --    fallar con 23503 (ajustar los ids a dos sucursales distintas):
+--   --    fallar con 23503:
 --   BEGIN;
 --     INSERT INTO compra_items (compra_id, producto_id, sucursal_id, cantidad, costo_unitario, subtotal)
 --     SELECT c.id, p.id, p.sucursal_id, 1, 1, 1

--- a/migrations/187_la_hija_no_cruza_de_sucursal.sql
+++ b/migrations/187_la_hija_no_cruza_de_sucursal.sql
@@ -1,0 +1,294 @@
+-- ============================================================================
+-- 187 · Que la hija no pueda cruzar de sucursal
+-- ============================================================================
+-- Requiere la 186 (`_pares_sucursal_cruzada()` y `auditoria_sucursal_cruzada()`).
+-- Leer el encabezado de la 186 para el planteo del agujero y por qué se cierra
+-- con FK y no con RLS.
+--
+-- Acá se convierte cada FK de una columna entre dos tablas que tienen las dos
+-- `sucursal_id` en una FK COMPUESTA `(columna, sucursal_id) -> padre(id,
+-- sucursal_id)`. Mismo patrón estructural que la 183 usó para atar un cargo a su
+-- compra, aplicado a todo lo que ya estaba suelto.
+--
+-- NO TOCA NI UNA FILA. Sólo constraints. Si algún dato hoy cruza de sucursal, la
+-- migración ABORTA en la sección 2 con la lista completa en vez de aplicar la
+-- mitad: no hay nada acá que "arregle" filas, porque cuál es la sucursal correcta
+-- de una línea cruzada es una decisión de negocio, no de esta migración.
+--
+-- LAS UNIQUE DE LA SECCIÓN 3 NO PUEDEN RECHAZAR NADA. Para que una FK apunte a
+-- `padre(columna, sucursal_id)` tiene que existir un UNIQUE sobre ese par. Y esa
+-- UNIQUE es redundante por construcción: para ser destino de la FK original,
+-- `columna` ya era única sola. Una fila que violara `(columna, sucursal_id)`
+-- estaría violando primero la clave de una sola columna. Es el mismo razonamiento
+-- de la sección 1 de la 183, que ya lo verificó con conteos contra prod.
+--
+-- LO QUE SÍ CAMBIA DE COMPORTAMIENTO: nada, si el dato está sano. Un INSERT o un
+-- UPDATE que hoy cruza de sucursal pasa a fallar con
+-- `23503 violates foreign key constraint`. Que es el punto.
+-- ============================================================================
+
+BEGIN;
+
+-- Un DDL que espera detrás de una transacción larga bloquea la app entera, y
+-- todo esto vive en un solo BEGIN/COMMIT. Mejor fallar en 10 segundos y volver
+-- en un rato que dejar la app colgada: el rollback no deja nada a medias.
+SET LOCAL lock_timeout = '10s';
+SET LOCAL statement_timeout = '5min';
+
+-- ----------------------------------------------------------------------------
+-- 1 · Los pares a tocar, congelados antes de empezar
+--
+-- En una tabla temporal y no en un `FOR ... IN SELECT ... FROM pg_constraint`
+-- porque el cuerpo del loop MODIFICA pg_constraint: iterar el catálogo mientras
+-- se lo reescribe es pedirle al cursor que decida qué ve. Congelarlo primero
+-- también deja la lista exacta de lo que se va a hacer disponible para el NOTICE.
+--
+-- `NOT protegida` alcanza como filtro: la 186 ya deja afuera todo lo que no es
+-- esta forma —las FK de dos columnas de negocio, las que apuntan a `sucursales`—
+-- y garantiza que `columna` sea siempre la de negocio y nunca `sucursal_id`.
+-- ----------------------------------------------------------------------------
+CREATE TEMP TABLE _pares_a_componer ON COMMIT DROP AS
+  SELECT p.*
+    FROM public._pares_sucursal_cruzada() p
+   WHERE NOT p.protegida;
+
+DO $mig$
+DECLARE v_n int;
+BEGIN
+  SELECT count(*) INTO v_n FROM _pares_a_componer;
+  RAISE NOTICE '187 · pares a convertir en FK compuesta: %', v_n;
+END;
+$mig$;
+
+-- ----------------------------------------------------------------------------
+-- 2 · Preflight: que hoy no haya nada cruzado
+--
+-- La FK igual rechazaría la migración si hubiera filas divergentes, pero lo haría
+-- con el error de UNA constraint y sin decir cuántas más vienen atrás. Esto las
+-- lista todas de una, que es lo que hace falta para decidir qué hacer con ellas.
+-- ----------------------------------------------------------------------------
+DO $mig$
+DECLARE v_txt text;
+BEGIN
+  SELECT string_agg(format('  %s.%s -> %s: %s de %s filas', a.hija, a.columna, a.padre,
+                           a.divergentes, a.filas),
+                    E'\n' ORDER BY a.hija, a.columna)
+    INTO v_txt
+    FROM public.auditoria_sucursal_cruzada() a
+   WHERE a.divergentes > 0;
+
+  IF v_txt IS NOT NULL THEN
+    RAISE EXCEPTION E'Hay filas que YA cruzan de sucursal. La FK compuesta las rechazaría, así que no se aplica nada.\n%\n\nCada una hay que resolverla a mano: decidir cuál es la sucursal correcta de la fila hija y corregirla, o darla de baja. No hay un backfill automático posible — cuál de las dos sucursales es la buena es información que no está en la base.', v_txt;
+  END IF;
+
+  RAISE NOTICE '187 · preflight OK: ninguna fila cruza de sucursal.';
+END;
+$mig$;
+
+-- ----------------------------------------------------------------------------
+-- 3 · Guard de versión
+--
+-- `ON DELETE SET NULL` sobre una FK compuesta anula TODAS las columnas
+-- referenciantes, `sucursal_id` incluida — que es NOT NULL en las 60 hijas. O sea
+-- que el borrado del padre pasaría de anular la referencia a fallar con un
+-- 23502. Restringir el SET NULL a la columna de la FK (`SET NULL (columna)`)
+-- existe recién en PostgreSQL 15.
+--
+-- No hay plan B decente: degradar esos SET NULL a NO ACTION cambiaría el
+-- comportamiento del borrado de un producto o de un cliente sin avisar. Así que
+-- si la versión no da, no se aplica nada y se dice por qué.
+-- ----------------------------------------------------------------------------
+DO $mig$
+DECLARE v_n int;
+BEGIN
+  SELECT count(*) INTO v_n FROM _pares_a_componer
+   WHERE confdeltype IN ('n','d') OR confupdtype IN ('n','d');
+
+  IF v_n > 0 AND current_setting('server_version_num')::int < 150000 THEN
+    RAISE EXCEPTION 'Se necesita PostgreSQL 15+ para % de estas FK (usan SET NULL / SET DEFAULT y hay que restringirlo a una columna). Esta base es la %.',
+      v_n, current_setting('server_version');
+  END IF;
+END;
+$mig$;
+
+-- ----------------------------------------------------------------------------
+-- 4 · Las UNIQUE de los padres y las FK compuestas
+--
+-- El nombre de la FK nueva es EL MISMO de la vieja, a propósito: los mensajes de
+-- error que ya conoce el equipo no cambian, y nada que busque una constraint por
+-- nombre se rompe. Lo que cambia es de cuántas columnas es.
+--
+-- La UNIQUE del padre sigue la convención que estrenó la 183:
+-- `<padre>_<columna>_sucursal_uk`. Si la 183 entró antes, `compras_id_sucursal_uk`
+-- ya existe y el guard la saltea; si entra después, la encuentra hecha. Las dos
+-- migraciones conviven en cualquier orden.
+--
+-- El DROP + ADD va adentro de la misma transacción, así que no hay ventana sin
+-- integridad referencial. Y no hace falta ningún índice nuevo en la hija: el
+-- chequeo al borrar un padre filtra `columna = X AND sucursal_id = Y`, y el
+-- índice que ya existe sobre `columna` sirve igual.
+-- ----------------------------------------------------------------------------
+DO $mig$
+DECLARE
+  r      record;
+  v_uk   text;
+  v_del  text;
+  v_upd  text;
+  v_dfr  text;
+  v_val  text;
+  v_n    int := 0;
+BEGIN
+  FOR r IN SELECT * FROM _pares_a_componer ORDER BY hija, columna, padre
+  LOOP
+    -- 4.a · El destino: UNIQUE (columna_padre, sucursal_id) en el padre.
+    v_uk := format('%s_%s_sucursal_uk', r.padre, r.columna_padre);
+    IF NOT EXISTS (SELECT 1 FROM pg_constraint
+                    WHERE conname = v_uk AND conrelid = r.padre_oid) THEN
+      EXECUTE format('ALTER TABLE public.%I ADD CONSTRAINT %I UNIQUE (%I, sucursal_id)',
+                     r.padre, v_uk, r.columna_padre);
+      RAISE NOTICE '  + UNIQUE %(%, sucursal_id)', r.padre, r.columna_padre;
+    END IF;
+
+    -- 4.b · Las acciones referenciales de la vieja, preservadas al pie de la letra.
+    v_del := CASE r.confdeltype
+               WHEN 'a' THEN ''
+               WHEN 'r' THEN ' ON DELETE RESTRICT'
+               WHEN 'c' THEN ' ON DELETE CASCADE'
+               WHEN 'n' THEN format(' ON DELETE SET NULL (%I)', r.columna)
+               WHEN 'd' THEN format(' ON DELETE SET DEFAULT (%I)', r.columna)
+             END;
+    v_upd := CASE r.confupdtype
+               WHEN 'a' THEN ''
+               WHEN 'r' THEN ' ON UPDATE RESTRICT'
+               WHEN 'c' THEN ' ON UPDATE CASCADE'
+               WHEN 'n' THEN format(' ON UPDATE SET NULL (%I)', r.columna)
+               WHEN 'd' THEN format(' ON UPDATE SET DEFAULT (%I)', r.columna)
+             END;
+    IF v_del IS NULL OR v_upd IS NULL THEN
+      RAISE EXCEPTION 'FK % (%.%): acción referencial desconocida (del=%, upd=%). No se adivina.',
+        r.conname, r.hija, r.columna, r.confdeltype, r.confupdtype;
+    END IF;
+
+    v_dfr := CASE WHEN r.condeferrable AND r.condeferred THEN ' DEFERRABLE INITIALLY DEFERRED'
+                  WHEN r.condeferrable                   THEN ' DEFERRABLE'
+                  ELSE '' END;
+    -- Una FK que ya estaba NOT VALID se recrea NOT VALID: validarla de prepo
+    -- convertiría esta migración en una que puede fallar por datos viejos que
+    -- alguien decidió tolerar en su momento.
+    v_val := CASE WHEN r.convalidated THEN '' ELSE ' NOT VALID' END;
+
+    EXECUTE format('ALTER TABLE public.%I DROP CONSTRAINT %I', r.hija, r.conname);
+    EXECUTE format(
+      'ALTER TABLE public.%I ADD CONSTRAINT %I FOREIGN KEY (%I, sucursal_id) '
+      'REFERENCES public.%I (%I, sucursal_id)%s%s%s%s',
+      r.hija, r.conname, r.columna, r.padre, r.columna_padre, v_upd, v_del, v_dfr, v_val);
+
+    v_n := v_n + 1;
+    RAISE NOTICE '  ~ %.% -> %  (%)', r.hija, r.columna, r.padre, r.conname;
+  END LOOP;
+
+  RAISE NOTICE '187 · % FK convertidas en compuestas.', v_n;
+END;
+$mig$;
+
+-- ----------------------------------------------------------------------------
+-- 5 · Post-condición
+--
+-- Que no quede ni un par sin cubrir. Si la sección 4 se saltó algo por una rama
+-- que no previmos, acá se entera la migración y no producción.
+-- ----------------------------------------------------------------------------
+DO $mig$
+DECLARE v_txt text;
+BEGIN
+  SELECT string_agg(format('%s.%s -> %s', p.hija, p.columna, p.padre), ', ' ORDER BY p.hija)
+    INTO v_txt
+    FROM public._pares_sucursal_cruzada() p
+   WHERE NOT p.protegida;
+
+  IF v_txt IS NOT NULL THEN
+    RAISE EXCEPTION 'Quedaron pares sin FK compuesta: %', v_txt;
+  END IF;
+END;
+$mig$;
+
+COMMIT;
+
+-- ----------------------------------------------------------------------------
+-- Rollback
+--
+-- No hay uno de una línea, y conviene decirlo en vez de fingirlo: la migración
+-- no crea constraints nuevas con nombre propio, REEMPLAZA las que ya estaban.
+-- Volver atrás es hacer el camino inverso — dejar cada FK en una sola columna
+-- conservando su nombre y su ON DELETE:
+--
+--   DO $rb$
+--   DECLARE r record; v_del text;
+--   BEGIN
+--     FOR r IN
+--       SELECT c.conname, ch.relname AS hija, pa.relname AS padre, c.confdeltype,
+--              (SELECT a.attname FROM pg_attribute a
+--                WHERE a.attrelid=c.conrelid AND a.attnum=c.conkey[1]
+--                  AND a.attname <> 'sucursal_id') AS columna,
+--              (SELECT a.attname FROM pg_attribute a
+--                WHERE a.attrelid=c.confrelid AND a.attnum=c.confkey[1]
+--                  AND a.attname <> 'sucursal_id') AS columna_padre
+--         FROM pg_constraint c
+--         JOIN pg_class ch ON ch.oid=c.conrelid
+--         JOIN pg_class pa ON pa.oid=c.confrelid
+--        WHERE c.contype='f' AND cardinality(c.conkey)=2
+--          AND 'sucursal_id' = ANY (SELECT a.attname FROM pg_attribute a
+--                                    WHERE a.attrelid=c.conrelid AND a.attnum=ANY(c.conkey))
+--     LOOP
+--       v_del := CASE r.confdeltype WHEN 'c' THEN ' ON DELETE CASCADE'
+--                                   WHEN 'n' THEN ' ON DELETE SET NULL'
+--                                   WHEN 'r' THEN ' ON DELETE RESTRICT' ELSE '' END;
+--       EXECUTE format('ALTER TABLE public.%I DROP CONSTRAINT %I', r.hija, r.conname);
+--       EXECUTE format('ALTER TABLE public.%I ADD CONSTRAINT %I FOREIGN KEY (%I) REFERENCES public.%I (%I)%s',
+--                      r.hija, r.conname, r.columna, r.padre, r.columna_padre, v_del);
+--     END LOOP;
+--   END $rb$;
+--
+-- OJO: ese loop toma TODAS las FK de dos columnas con `sucursal_id`, o sea que se
+-- llevaría puestas también las que creó la 183 a mano (compra_cargos ->
+-- compras). Si la 183 está aplicada, hay que excluirla.
+--
+-- Las UNIQUE `<padre>_<col>_sucursal_uk` se pueden dejar: son redundantes con la
+-- clave de una columna y no rechazan nada. Dropearlas es opcional y hay que
+-- hacerlo DESPUÉS de las FK, no antes.
+-- ----------------------------------------------------------------------------
+
+-- ----------------------------------------------------------------------------
+-- Verificación
+--
+--   -- 1. El tablero, que es el resultado que importa: 0 sin proteger, 0 cruzadas.
+--   SELECT count(*)                               AS pares,
+--          count(*) FILTER (WHERE NOT protegida)  AS sin_proteger,
+--          sum(divergentes)                       AS filas_cruzadas
+--     FROM auditoria_sucursal_cruzada();
+--   -- esperado: 60 | 0 | 0
+--
+--   -- 2. Las FK compuestas, una por par (más las 3 que ya trae la 183):
+--   SELECT conrelid::regclass AS hija, conname, pg_get_constraintdef(oid) AS def
+--     FROM pg_constraint
+--    WHERE contype='f' AND cardinality(conkey)=2
+--      AND connamespace='public'::regnamespace
+--    ORDER BY 1, 2;
+--
+--   -- 3. Que ningún ON DELETE se haya perdido en el cambio. Tiene que dar 0:
+--   --    toda FK compuesta con SET NULL debe traer su lista de columnas, si no
+--   --    el borrado del padre va a fallar contra el NOT NULL de sucursal_id.
+--   SELECT count(*) FROM pg_constraint
+--    WHERE contype='f' AND cardinality(conkey)=2 AND confdeltype='n'
+--      AND connamespace='public'::regnamespace
+--      AND pg_get_constraintdef(oid) NOT LIKE '%SET NULL (%';
+--
+--   -- 4. La prueba de fuego, en una transacción que se descarta. Tiene que
+--   --    fallar con 23503 (ajustar los ids a dos sucursales distintas):
+--   BEGIN;
+--     INSERT INTO compra_items (compra_id, producto_id, sucursal_id, cantidad, costo_unitario, subtotal)
+--     SELECT c.id, p.id, p.sucursal_id, 1, 1, 1
+--       FROM compras c, productos p
+--      WHERE c.sucursal_id <> p.sucursal_id
+--      LIMIT 1;
+--   ROLLBACK;
+-- ----------------------------------------------------------------------------

--- a/migrations/MANIFEST.md
+++ b/migrations/MANIFEST.md
@@ -1,6 +1,6 @@
 # MANIFEST de migraciones — mapeo repo ↔ producción
 
-> **Fechado: 2026-08-08** · Proyecto prod `hmuchlzmuqqxcldbzkgc` (ManaosApp) · región `sa-east-1`.
+> **Fechado: 2026-08-19** · Proyecto prod `hmuchlzmuqqxcldbzkgc` (ManaosApp) · región `sa-east-1`.
 
 ## Regla de oro
 
@@ -128,8 +128,64 @@ funcional** y no se renombran los archivos: renombrarlos los desalinearía del l
 real lo da `version` y está en la sección A: en los dos casos el archivo de `main` quedó
 cronológicamente **fuera** del bloque 139–147 (uno antes, otro entre la 144 y la 145).
 
-**La próxima migración es la 182** — la última numerada en el repo es
-`181_guards_de_estado_y_permisos` (aplicada).
+**La próxima migración es la 188.** Al 2026-08-19 el rango 182–187 está tomado y
+sólo la **182** llegó a `main`:
+
+| NN | dónde vive | estado |
+|----|------------|--------|
+| 182 | `main` | `182_pagos_fecha_en_hora_argentina`, aplicada |
+| 183 | rama de cargos de compra (abierta) | `183_compra_cargos_prorrateo` |
+| 184 | rama de cargos de compra (abierta) | `184_compra_cargos_funciones` |
+| 185 | rama de cargos de compra (abierta) | reservada en el encabezado de la 183 (RPCs + check de integridad); todavía sin archivo |
+| 186 | rama de aislamiento por sucursal (abierta) | `186_quien_cruza_de_sucursal` |
+| 187 | rama de aislamiento por sucursal (abierta) | `187_la_hija_no_cruza_de_sucursal` |
+
+O sea que **`ls migrations/` sobre `main` te dice 183 y se equivoca por cinco**.
+Al elegir número hay que mirar las tres cosas: el ledger, `origin/main` y las
+ramas abiertas. La 183 ya se comió esta trampa una vez (nació 182 y tuvo que
+renumerarse porque la 182 se mergeó mientras su rama estaba abierta).
+
+Las **186** y **187** cierran un agujero de RLS preexistente, encontrado de paso
+al revisar la 183. Las policies de las tablas hijas validan `sucursal_id =
+current_sucursal_id()` sobre la propia fila y **nadie valida que el padre
+referenciado sea de esa misma sucursal**; las FK no pasan por RLS, así que una
+línea podía colgarse de la compra de la otra sucursal, quedar invisible para su
+dueña —la policy de SELECT filtra por el `sucursal_id` de la línea— y moverle el
+costo igual. Al 2026-08-19 había **0 filas cruzadas**: era latente, no un
+incidente.
+
+La **186** es sólo lectura: `auditoria_sucursal_cruzada()` y su helper
+`_pares_sucursal_cruzada()`, que descubren los pares hija→padre **del catálogo**,
+no de una lista. La **187** convierte cada FK de una columna en compuesta
+`(columna, sucursal_id) → padre(id, sucursal_id)`, el mismo patrón estructural
+que la 183 estrenó para `compra_cargos`. No toca ni una fila y aborta con la
+lista completa si encuentra alguna cruzada.
+
+Cuatro cosas que conviene no volver a descubrir:
+
+- **Se eligió FK y no un `EXISTS` en las policies** porque casi toda la escritura
+  de esta base entra por RPCs `SECURITY DEFINER`, que saltean RLS por definición:
+  una policy no las ve pasar. La FK sí.
+- **`ON DELETE SET NULL` sobre una FK compuesta anula TODAS las columnas
+  referenciantes**, `sucursal_id` incluida, que es NOT NULL en los 60 pares ⇒ el
+  borrado del padre pasaría a fallar con un 23502. Hay que escribirlo
+  `ON DELETE SET NULL (columna)`, que existe recién en **PostgreSQL 15**. La 187
+  tiene un guard de versión.
+- **Que `sucursal_id` sea NOT NULL en los dos lados no es un detalle**: la FK es
+  MATCH SIMPLE y se da por satisfecha si CUALQUIERA de las columnas
+  referenciantes es NULL. Aflojar ese NOT NULL apaga la protección en silencio.
+- **El reporte cuenta los pares protegidos, no sólo los rotos.** La primera
+  versión sólo miraba FK de una columna y después de la 187 el tablero quedaba
+  vacío: un gate que se apaga solo justo cuando empieza a tener algo que vigilar.
+
+El gate permanente es `scripts/check-sucursal-cruzada.mjs`, un paso más del
+workflow `integridad.yml`: una tabla nueva con `sucursal_id` y FK simple sale en
+rojo al día siguiente. Ése es el punto — el hallazgo no fue "compra_items está
+mal", fue "hay una clase de tabla que está mal y nadie la miraba".
+
+`movimiento_sucursal_items` **no** está en la lista y no es un olvido: no tiene
+`sucursal_id` propio, la resuelve por join con el movimiento. Lo que no se copia
+no puede contradecirse. Igual `compra_cargo_repartos` (183).
 
 La **181** cierra la otra mitad de la auditoría adversarial: las invariantes que
 vivían en el front. Trigger `pedidos_proteger_columnas` (el chofer sólo escribe
@@ -227,9 +283,28 @@ idempotente del mismo nombre. Es a propósito: `migrations/` no es 1:1 con prod 
 habían driftado (ver la nota de la 100), así que el cuerpo real no se reescribe, se envuelve.
 Al leer el catálogo, la lógica de negocio de esas 4 vive en la función `_impl`.
 
-**Antes de elegir el número de una migración nueva, mirar `ls migrations/` además del
-ledger**: el ledger no siempre lleva el prefijo, así que por sí solo no alcanza. Y si mergeaste
-`main` en el medio, volvé a mirarlo — los números que estaban libres pueden haberse ocupado.
+**Antes de elegir el número de una migración nueva hay que mirar TRES cosas**, y ninguna
+alcanza sola:
+
+1. **el ledger** — es la fuente de verdad de lo aplicado, pero no siempre lleva el prefijo
+   `NNN_`, así que por sí solo no dice qué números están gastados;
+2. **`ls migrations/` sobre `origin/main`** — tapa el agujero anterior, pero sólo ve lo
+   mergeado;
+3. **las ramas abiertas** — que es donde la numeración choca de verdad, porque dos ramas
+   paralelas eligen el mismo número el mismo día y ninguna se entera hasta el merge. Ya pasó
+   con el `167` duplicado (sección A) y volvió a pasar con la 183.
+
+Barrido rápido de lo que se están comiendo las ramas abiertas:
+
+```bash
+for b in $(git branch -a --format='%(refname:short)'); do
+  git ls-tree --name-only "$b" migrations/ | grep -oE '^migrations/[0-9]+' | sort -u |
+    tail -3 | sed "s|^|$b :: |"
+done | sort -u
+```
+
+Y si mergeaste `main` en el medio, volvé a mirar las tres — los números que estaban libres
+pueden haberse ocupado.
 
 ---
 

--- a/migrations/MANIFEST.md
+++ b/migrations/MANIFEST.md
@@ -133,7 +133,7 @@ sólo la **182** llegó a `main`:
 
 | NN | dónde vive | estado |
 |----|------------|--------|
-| 182 | `main` | `182_pagos_fecha_en_hora_argentina`, aplicada |
+| 182 | `main` | `182_pagos_fecha_en_hora_argentina`, aplicada — **es la última del ledger**, verificado el 2026-08-19 |
 | 183 | rama de cargos de compra (abierta) | `183_compra_cargos_prorrateo` |
 | 184 | rama de cargos de compra (abierta) | `184_compra_cargos_funciones` |
 | 185 | rama de cargos de compra (abierta) | reservada en el encabezado de la 183 (RPCs + check de integridad); todavía sin archivo |
@@ -151,32 +151,56 @@ current_sucursal_id()` sobre la propia fila y **nadie valida que el padre
 referenciado sea de esa misma sucursal**; las FK no pasan por RLS, así que una
 línea podía colgarse de la compra de la otra sucursal, quedar invisible para su
 dueña —la policy de SELECT filtra por el `sucursal_id` de la línea— y moverle el
-costo igual. Al 2026-08-19 había **0 filas cruzadas**: era latente, no un
-incidente.
+costo igual. **Medido contra prod el 2026-08-19: 69 pares y 0 filas cruzadas.**
+Era latente, no un incidente.
 
-La **186** es sólo lectura: `auditoria_sucursal_cruzada()` y su helper
-`_pares_sucursal_cruzada()`, que descubren los pares hija→padre **del catálogo**,
-no de una lista. La **187** convierte cada FK de una columna en compuesta
-`(columna, sucursal_id) → padre(id, sucursal_id)`, el mismo patrón estructural
-que la 183 estrenó para `compra_cargos`. No toca ni una fila y aborta con la
-lista completa si encuentra alguna cruzada.
+La **186** es sólo lectura: `auditoria_sucursal_cruzada()` y sus helpers
+`_pares_sucursal_cruzada()` y `_tenant_col_por_tabla()`, que descubren los pares
+hija→padre **del catálogo**, no de una lista. La **187** convierte cada FK de una
+columna en compuesta `(columna, tenant) → padre(id, tenant)`, el mismo patrón
+estructural que la 183 estrena para `compra_cargos`. No toca ni una fila y aborta
+con la lista completa si encuentra alguna cruzada.
 
-Cuatro cosas que conviene no volver a descubrir:
+Seis cosas que conviene no volver a descubrir:
 
 - **Se eligió FK y no un `EXISTS` en las policies** porque casi toda la escritura
   de esta base entra por RPCs `SECURITY DEFINER`, que saltean RLS por definición:
-  una policy no las ve pasar. La FK sí.
+  una policy no las ve pasar. La FK sí. Refuerza el argumento que cinco de estas
+  hijas (`recorrido_cambios`, `promo_acumuladores`, `pedido_item_sustituciones`,
+  `comision_reglas`, `metas_preventista`) tengan **sólo policies de SELECT**: el
+  default-deny de RLS ya les cierra PostgREST, así que su único camino de
+  escritura es justo el que ninguna policy vigila.
+- **El tenant no siempre se llama `sucursal_id`.** `transferencias_stock` tiene
+  las dos columnas: `tenant_sucursal_id` es el tenant (es la que usa su policy de
+  escritura) y `sucursal_id` es **la otra punta del traslado**. Comparar contra la
+  segunda daba 4 de 13 filas "cruzadas" que son historia correcta —un traslado
+  tiene las dos puntas distintas por definición—; contra la primera dan 0. Si
+  alguien las "arreglaba", rompía datos buenos. De ahí `_tenant_col_por_tabla()`.
 - **`ON DELETE SET NULL` sobre una FK compuesta anula TODAS las columnas
-  referenciantes**, `sucursal_id` incluida, que es NOT NULL en los 60 pares ⇒ el
+  referenciantes**, el tenant incluido, que es NOT NULL en 68 de los 69 pares ⇒ el
   borrado del padre pasaría a fallar con un 23502. Hay que escribirlo
-  `ON DELETE SET NULL (columna)`, que existe recién en **PostgreSQL 15**. La 187
-  tiene un guard de versión.
-- **Que `sucursal_id` sea NOT NULL en los dos lados no es un detalle**: la FK es
-  MATCH SIMPLE y se da por satisfecha si CUALQUIERA de las columnas
-  referenciantes es NULL. Aflojar ese NOT NULL apaga la protección en silencio.
+  `ON DELETE SET NULL (columna)`, que existe recién en **PostgreSQL 15**. Prod
+  corre 17.6, así que el guard de versión de la 187 no va a saltar; queda igual.
+- **Que el tenant sea NOT NULL no es un detalle**: la FK es MATCH SIMPLE y se da
+  por satisfecha si CUALQUIERA de las columnas referenciantes es NULL. Aflojar ese
+  NOT NULL apaga media protección en silencio. El único caso hoy es
+  `comision_reglas.sucursal_id`, nullable a propósito (una regla sin sucursal es
+  global): el reporte lo marca `parcial` en vez de contarlo como cubierto.
+- **Un tenant NULL es "global", no "cruzada".** La primera versión contaba la
+  divergencia con `IS DISTINCT FROM` y una regla de comisión global —tenant NULL
+  contra un producto de otra sucursal— salía como violación, dejando el preflight
+  de la 187 abortando para siempre por una fila legal. El reporte tiene que contar
+  **exactamente** lo que la FK rechaza, o los dos dejan de decir lo mismo.
 - **El reporte cuenta los pares protegidos, no sólo los rotos.** La primera
   versión sólo miraba FK de una columna y después de la 187 el tablero quedaba
   vacío: un gate que se apaga solo justo cuando empieza a tener algo que vigilar.
+
+Y la razón de fondo para que todo salga del catálogo: **el repo predecía 60 pares
+y prod tiene 69.** Los 9 que faltaban (`comision_reglas`,
+`grupo_precio_escala_minimos`, `metas_preventista`, `productos.categoria_id`,
+`productos.marca_id`, `pedido_item_sustituciones.ajuste_producto_id_nuevo`) los
+encuentra `pg_constraint` y los habría perdido una lista escrita leyendo
+`migrations/`. Es la regla de oro de este archivo, cobrándose una más.
 
 El gate permanente es `scripts/check-sucursal-cruzada.mjs`, un paso más del
 workflow `integridad.yml`: una tabla nueva con `sucursal_id` y FK simple sale en
@@ -184,8 +208,10 @@ rojo al día siguiente. Ése es el punto — el hallazgo no fue "compra_items es
 mal", fue "hay una clase de tabla que está mal y nadie la miraba".
 
 `movimiento_sucursal_items` **no** está en la lista y no es un olvido: no tiene
-`sucursal_id` propio, la resuelve por join con el movimiento. Lo que no se copia
-no puede contradecirse. Igual `compra_cargo_repartos` (183).
+columna de tenant propia, la resuelve por join con el movimiento. Lo que no se
+copia no puede contradecirse. Igual `compra_cargo_repartos` (183), y por eso
+`movimientos_sucursal` —que sólo tiene `sucursal_origen_id` y
+`sucursal_destino_id`— ni siquiera entra al análisis.
 
 La **181** cierra la otra mitad de la auditoría adversarial: las invariantes que
 vivían en el front. Trigger `pedidos_proteger_columnas` (el chofer sólo escribe

--- a/migrations/MANIFEST.md
+++ b/migrations/MANIFEST.md
@@ -137,8 +137,8 @@ sólo la **182** llegó a `main`:
 | 183 | rama de cargos de compra (abierta) | `183_compra_cargos_prorrateo` |
 | 184 | rama de cargos de compra (abierta) | `184_compra_cargos_funciones` |
 | 185 | rama de cargos de compra (abierta) | reservada en el encabezado de la 183 (RPCs + check de integridad); todavía sin archivo |
-| 186 | rama de aislamiento por sucursal (abierta) | `186_quien_cruza_de_sucursal` |
-| 187 | rama de aislamiento por sucursal (abierta) | `187_la_hija_no_cruza_de_sucursal` |
+| 186 | rama de aislamiento por sucursal | `186_quien_cruza_de_sucursal`, **aplicada 2026-08-19** |
+| 187 | rama de aislamiento por sucursal | `187_la_hija_no_cruza_de_sucursal`, **aplicada 2026-08-19** |
 
 O sea que **`ls migrations/` sobre `main` te dice 183 y se equivoca por cinco**.
 Al elegir número hay que mirar las tres cosas: el ledger, `origin/main` y las
@@ -194,6 +194,14 @@ Seis cosas que conviene no volver a descubrir:
 - **El reporte cuenta los pares protegidos, no sólo los rotos.** La primera
   versión sólo miraba FK de una columna y después de la 187 el tablero quedaba
   vacío: un gate que se apaga solo justo cuando empieza a tener algo que vigilar.
+
+**Resultado de aplicarlas (2026-08-19):** 69 pares, **69 protegidos**, 0 sin
+proteger, 0 filas cruzadas, 2 parciales (`comision_reglas`). 69 FK compuestas y
+19 UNIQUE nuevas; ningún `SET NULL` quedó sin su lista de columnas.
+`auditoria_integridad()` siguió en `overall_ok = true` con 0 critical/high, y los
+advisors de Supabase no sumaron ningún ERROR. Verificado además en vivo, dentro de
+un bloque que se revierte: el INSERT cruzado y el item de traslado mal etiquetado
+se rechazan con 23503, y el INSERT coherente sigue entrando.
 
 Y la razón de fondo para que todo salga del catálogo: **el repo predecía 60 pares
 y prod tiene 69.** Los 9 que faltaban (`comision_reglas`,

--- a/scripts/check-sucursal-cruzada.mjs
+++ b/scripts/check-sucursal-cruzada.mjs
@@ -1,0 +1,83 @@
+#!/usr/bin/env node
+/**
+ * Gate de aislamiento por sucursal.
+ * Llama al RPC auditoria_sucursal_cruzada() (ver migrations/186) vía PostgREST
+ * con la service_role key y falla (exit 1) si aparece cualquiera de las dos
+ * cosas que la migración 187 dejó imposibles:
+ *
+ *   · una fila hija que contradice la sucursal de su padre  → dato ya corrupto;
+ *   · un par hija->padre sin FK compuesta                   → agujero reabierto.
+ *
+ * El segundo es el que importa a futuro y el que justifica que esto viva en CI:
+ * el agujero original no fue una tabla mal hecha, fue que nadie miraba la CLASE.
+ * Una tabla nueva con `sucursal_id` y una FK simple al padre aparece acá al día
+ * siguiente, en vez de dentro de un año cuando alguien note que un costo se fue
+ * a la sucursal equivocada.
+ *
+ * Requiere env: SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY.
+ * Uso local:  SUPABASE_URL=... SUPABASE_SERVICE_ROLE_KEY=... node scripts/check-sucursal-cruzada.mjs
+ */
+const url = process.env.SUPABASE_URL;
+const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+if (!url || !key) {
+  console.error('Faltan SUPABASE_URL / SUPABASE_SERVICE_ROLE_KEY en el entorno.');
+  process.exit(2);
+}
+
+const res = await fetch(`${url.replace(/\/$/, '')}/rest/v1/rpc/auditoria_sucursal_cruzada`, {
+  method: 'POST',
+  headers: {
+    apikey: key,
+    Authorization: `Bearer ${key}`,
+    'Content-Type': 'application/json',
+  },
+  body: '{}',
+});
+
+if (!res.ok) {
+  console.error(`El RPC auditoria_sucursal_cruzada() falló: HTTP ${res.status}\n${await res.text()}`);
+  console.error('¿Aplicaste migrations/186_quien_cruza_de_sucursal.sql?');
+  process.exit(2);
+}
+
+const pares = await res.json();
+
+if (!Array.isArray(pares) || pares.length === 0) {
+  // Cero pares no es "todo bien": es que el reporte dejó de ver el esquema.
+  // Mientras existan compra_items o pedido_items tiene que haber pares.
+  console.error('El reporte devolvió 0 pares. Eso no puede pasar con este esquema:');
+  console.error('revisar _pares_sucursal_cruzada() antes de dar el gate por bueno.');
+  process.exit(2);
+}
+
+const cruzados = pares.filter((p) => Number(p.divergentes) > 0);
+const sinProteger = pares.filter((p) => !p.protegida);
+
+console.log(`Aislamiento por sucursal: ${pares.length} pares hija->padre`);
+console.log(
+  `Protegidos por FK compuesta: ${pares.length - sinProteger.length} | sin proteger: ${sinProteger.length} | con filas cruzadas: ${cruzados.length}`,
+);
+
+if (sinProteger.length) {
+  console.log('\nSin FK compuesta (la hija puede colgarse de un padre de otra sucursal):');
+  for (const p of sinProteger) {
+    console.log(`  ${p.hija}.${p.columna} -> ${p.padre}  (${p.filas} filas)`);
+  }
+}
+
+if (cruzados.length) {
+  console.log('\nCon filas que YA cruzan de sucursal:');
+  for (const p of cruzados) {
+    console.log(`  ${p.hija}.${p.columna} -> ${p.padre}: ${p.divergentes} de ${p.filas} filas`);
+  }
+}
+
+if (cruzados.length || sinProteger.length) {
+  console.error(
+    '\n❌ El aislamiento por sucursal tiene agujeros. Ver migrations/186 y 187: una tabla nueva con sucursal_id necesita FK compuesta (columna, sucursal_id) -> padre(id, sucursal_id), no una FK simple.',
+  );
+  process.exit(1);
+}
+
+console.log('\n✅ Todos los pares atados por FK compuesta y sin filas cruzadas.');

--- a/scripts/check-sucursal-cruzada.mjs
+++ b/scripts/check-sucursal-cruzada.mjs
@@ -53,6 +53,7 @@ if (!Array.isArray(pares) || pares.length === 0) {
 
 const cruzados = pares.filter((p) => Number(p.divergentes) > 0);
 const sinProteger = pares.filter((p) => !p.protegida);
+const parciales = pares.filter((p) => p.protegida && p.parcial);
 
 console.log(`Aislamiento por sucursal: ${pares.length} pares hija->padre`);
 console.log(
@@ -63,6 +64,18 @@ if (sinProteger.length) {
   console.log('\nSin FK compuesta (la hija puede colgarse de un padre de otra sucursal):');
   for (const p of sinProteger) {
     console.log(`  ${p.hija}.${p.columna} -> ${p.padre}  (${p.filas} filas)`);
+  }
+}
+
+// Cobertura parcial: el tenant es nullable, y la FK compuesta es MATCH SIMPLE,
+// así que las filas sin sucursal quedan afuera del chequeo. NO es motivo de
+// rojo —hoy es `comision_reglas`, donde una regla sin sucursal es global a
+// propósito— pero tiene que verse: si mañana aparece un par nuevo acá, es que
+// alguien aflojó un NOT NULL y apagó media protección sin querer.
+if (parciales.length) {
+  console.log('\nCobertura parcial (tenant nullable: las filas sin sucursal no se chequean):');
+  for (const p of parciales) {
+    console.log(`  ${p.hija}.${p.columna} -> ${p.padre}`);
   }
 }
 


### PR DESCRIPTION
Las policies de las tablas hijas validan `sucursal_id = current_sucursal_id()` sobre **la propia fila**, y nadie valida que el padre referenciado sea de esa misma sucursal. Las FK no pasan por RLS, así que una línea podía entrar con mi sucursal apuntando a la compra de la otra.

Lo grave no es que se pueda: es que esa línea queda **invisible para la sucursal dueña de la compra** —su policy de SELECT filtra por el `sucursal_id` de la línea, que dice otra cosa— mientras le mueve el costo y el stock igual. Corrupción silenciosa con la víctima ciega.

Se encontró de paso al revisar la 183, que cierra este mismo agujero para `compra_cargos` y dejó anotado que `compra_items` seguía suelto.

## Estado: ya aplicado a producción

**186 y 187 aplicadas el 2026-08-19.** Resultado medido: **69 pares, 69 protegidos, 0 filas cruzadas**, 2 parciales. 69 FK compuestas y 19 UNIQUE nuevas.

Probado en vivo dentro de un bloque que se revierte: el INSERT cruzado y el item de traslado mal etiquetado se rechazan con `23503`, el INSERT coherente sigue entrando. `auditoria_integridad()` quedó en `overall_ok = true` con 0 critical/high, y los advisors no sumaron ningún ERROR.

## Por qué FK y no un EXISTS en las policies

Casi toda la escritura de esta base entra por RPCs `SECURITY DEFINER`, que **saltean RLS por definición**: una policy no las ve pasar. La FK sí. Lo refuerza que cinco de estas hijas (`recorrido_cambios`, `promo_acumuladores`, `pedido_item_sustituciones`, `comision_reglas`, `metas_preventista`) tengan **sólo policies de SELECT**: el default-deny ya les cierra PostgREST, así que su único camino de escritura es justo el que ninguna policy vigila.

Además una policy la pisa cualquier `CREATE POLICY` futuro y deja de filtrar sin fallar —ya pasó con `es_preventista()` en la 058—; una constraint no se pisa por accidente.

## Qué trae

- **`migrations/186_quien_cruza_de_sucursal.sql`** — sólo lectura. `auditoria_sucursal_cruzada()` y los helpers `_pares_sucursal_cruzada()` y `_tenant_col_por_tabla()`, que descubren los pares hija→padre **del catálogo**, no de una lista.
- **`migrations/187_la_hija_no_cruza_de_sucursal.sql`** — convierte cada FK de una columna en compuesta `(columna, tenant) → padre(id, tenant)`, preservando nombre, `ON DELETE`, deferibilidad y validez. No toca ni una fila; aborta con la lista completa si encuentra alguna cruzada.
- **`scripts/check-sucursal-cruzada.mjs`** + un paso más en `integridad.yml` — el gate permanente: una tabla nueva con `sucursal_id` y FK simple sale en rojo al día siguiente.

## Cinco cosas que conviene no volver a descubrir

1. **El tenant no siempre se llama `sucursal_id`.** `transferencias_stock` tiene las dos columnas: `tenant_sucursal_id` es el tenant y `sucursal_id` es **la otra punta del traslado**. Comparar contra la segunda daba 4 de 13 filas "cruzadas" que son historia correcta —un traslado tiene las dos puntas distintas por definición—; contra la primera dan 0. Si alguien las "arreglaba", rompía datos buenos.
2. **`ON DELETE SET NULL` compuesto anula TODAS las columnas referenciantes**, el tenant incluido, que es NOT NULL en 68 de los 69 pares ⇒ el borrado del padre pasaría a fallar con `23502`. Hay que escribir `SET NULL (columna)`, que existe recién en PostgreSQL 15 (prod: 17.6).
3. **Que el tenant sea NOT NULL no es un detalle**: la FK es MATCH SIMPLE y se satisface si cualquiera de las columnas referenciantes es NULL. El único caso hoy es `comision_reglas.sucursal_id`, nullable a propósito (una regla sin sucursal es global): el reporte lo marca `parcial` en vez de contarlo como cubierto.
4. **Un tenant NULL es "global", no "cruzada".** Contar la divergencia con `IS DISTINCT FROM` marcaba la regla global como violación y dejaba el preflight abortando para siempre por una fila legal.
5. **El reporte cuenta los pares protegidos, no sólo los rotos.** La primera versión sólo miraba FK de una columna y después de la 187 el tablero quedaba vacío: un gate que se apaga solo justo cuando empieza a tener algo que vigilar.

## Por qué el catálogo y no una lista

**El repo predecía 60 pares y prod tiene 69.** Los 9 que faltaban (`comision_reglas`, `grupo_precio_escala_minimos`, `metas_preventista`, `productos.categoria_id`, `productos.marca_id`, `pedido_item_sustituciones.ajuste_producto_id_nuevo`) los encuentra `pg_constraint` y los habría perdido una lista escrita leyendo `migrations/`. Es la regla de oro del MANIFEST cobrándose una más.

`movimiento_sucursal_items` no está y no es un olvido: no copia el tenant, lo resuelve por join. Lo que no se copia no puede contradecirse. Igual `compra_cargo_repartos`.

## Verificación

Además de lo medido en prod, todo se probó contra un PostgreSQL 17 local con un fixture que reproduce las formas reales (CASCADE, SET NULL, DEFERRABLE, NOT VALID, autorreferencia, tabla sin tenant, tabla con dos columnas de sucursal, tenant nullable): el preflight aborta dejando la base intacta, reaplicar es idempotente, y una tabla nueva sin proteger aparece en el reporte. Gate de CI: 6 casos. Suite: 1148 tests en verde.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
