### PR TITLE
Que la anon key deje de ejecutar las RPCs

### DIFF
--- a/.github/workflows/integridad.yml
+++ b/.github/workflows/integridad.yml
@@ -44,3 +44,17 @@ jobs:
             exit 0
           fi
           node scripts/check-migrations.mjs
+
+      # Falla si alguna función de public volvió a quedar ejecutable con la anon
+      # key. Ver migrations/188 y migrations/README.md § Permisos.
+      - name: Permisos EXECUTE (nada abierto a anon)
+        if: always()
+        env:
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+        run: |
+          if [ -z "$SUPABASE_URL" ] || [ -z "$SUPABASE_SERVICE_ROLE_KEY" ]; then
+            echo "::warning::Faltan secrets — chequeo de permisos omitido."
+            exit 0
+          fi
+          node scripts/check-permisos.mjs

--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,7 @@ backups/
 !supabase/migrations/*.sql
 !scripts/verify-multi-tenant.sql
 !scripts/fix-pedido-3602-pagos-duplicados.sql
+!scripts/auditoria-permisos.sql
 !migrations/*.sql
 !migrations/**/*.sql
 

--- a/migrations/188_anon_deja_de_ejecutar_rpcs.sql
+++ b/migrations/188_anon_deja_de_ejecutar_rpcs.sql
@@ -1,0 +1,437 @@
+-- ============================================================================
+-- Migración 188: la anon key deja de ejecutar RPCs del schema public
+-- ============================================================================
+-- Proyecto: hmuchlzmuqqxcldbzkgc (ManaosApp). Auditoría de permisos 2026-08-19.
+--
+-- QUÉ PASA HOY
+-- ------------
+-- Supabase trae un ALTER DEFAULT PRIVILEGES que le concede EXECUTE a `anon` de
+-- forma EXPLÍCITA en cada función nueva del schema public, ADEMÁS del grant
+-- implícito a PUBLIC que pone Postgres. El ACL de una función recién creada es:
+--
+--     {=X/postgres, postgres=X/postgres, anon=X/postgres,
+--      authenticated=X/postgres, service_role=X/postgres}
+--      ^^^^^^^^^^^^ este es PUBLIC
+--
+-- Por eso ninguna de las dos mitades del REVOKE alcanza sola:
+--
+--     REVOKE ... FROM PUBLIC        -> sobrevive anon=X/postgres
+--     REVOKE ... FROM anon          -> sobrevive =X/postgres (anon entra por PUBLIC)
+--     REVOKE ... FROM PUBLIC, anon  -> la única que cierra
+--
+-- El repo usó las tres variantes. Las migraciones 103-131 lo hicieron bien; de
+-- la 140 en adelante se estandarizó `REVOKE ALL ... FROM PUBLIC` a secas, que
+-- no cierra nada.
+--
+-- El caso más nítido es la 089, que dice textual:
+--
+--     -- Solo lo llaman los wrappers DEFINER; no se expone a clientes.
+--     REVOKE ALL ON FUNCTION public._aplicar_cambio_producto(...) FROM PUBLIC;
+--
+-- La intención era exactamente la correcta y el mecanismo la dejó pasar.
+-- `_aplicar_cambio_producto` es SECURITY DEFINER, no tiene gate propio (recibe
+-- p_sucursal_id y p_usuario_id por parámetro: quien llama declara quién es) y
+-- mueve stock. Sus tres wrappers -- registrar_cambio_producto,
+-- aplicar_cambio_de_parada, crear_pedido_cambio_en_ruta -- sí son SECURITY
+-- DEFINER y sí chequean es_encargado_o_admin() / current_sucursal_id().
+--
+-- QUÉ HACE ESTA MIGRACIÓN
+-- -----------------------
+--   0. Saca `anon` del ALTER DEFAULT PRIVILEGES, para que las funciones NUEVAS
+--      no nazcan con el grant explícito. OJO: NO se puede sacar a PUBLIC del
+--      default (ver el paso 0, está medido) — la garantía de que esto no
+--      recaiga es el gate de CI de la 189, no el default privilege.
+--   1. Congela como grants EXPLÍCITOS el acceso que authenticated y
+--      service_role tienen HOY. Es la red de seguridad del paso 2: hay
+--      funciones cuyo único permiso vigente es el de PUBLIC (p.ej.
+--      recalcular_recorrido, con ACL `=X/postgres`), y sacar PUBLIC sin este
+--      paso previo también se lo quitaría a la app.
+--   2. Barre PUBLIC + anon de todas las funciones de public.
+--   3. A los internos les saca además authenticated: funciones `_*`, `*_impl` y
+--      las que devuelven `trigger`. Sus llamadores son SECURITY DEFINER y las
+--      ejecutan como owner, así que no necesitan permiso propio. El EXECUTE de
+--      una función trigger se chequea en CREATE TRIGGER, no cuando dispara: la
+--      069 ya hizo esto en prod y los triggers siguen andando. Acá alcanza a
+--      las ~20 funciones trigger creadas después de aquella.
+--   4. Verificación fail-closed en la MISMA transacción: si quedó algo abierto
+--      a anon, o si alguna RPC que usa la app perdió authenticated, RAISE
+--      EXCEPTION y rollback de todo.
+--
+-- QUIÉN DEPENDE DE ESTO (verificado contra el código, no supuesto)
+-- ---------------------------------------------------------------
+--   * Web: entra como `authenticated`; requiere login, no hay RPC pre-sesión.
+--     Llama 96 RPCs (grep `.rpc(` sobre src/, excluidos los tests) -- la lista
+--     está abajo, en el paso 4.
+--   * Bot de Telegram y edge functions (optimizar-ruta, telegram-webhook,
+--     telegram-digest): usan SUPABASE_SERVICE_ROLE_KEY.
+--     Ver supabase/functions/_shared/supabase.ts.
+--   * scripts/check-integridad.mjs y scripts/check-migrations.mjs: service_role.
+--   Ningún consumidor conocido llama a PostgREST sin sesión.
+--
+-- SE EXCLUYEN del barrido las funciones que pertenecen a una extensión
+-- (pg_depend.deptype = 'e'): pgcrypto, pg_trgm, unaccent, etc. Tocarles el ACL
+-- rompe índices y operadores, y no son parte del problema.
+--
+-- CÓMO PROBARLA SIN APLICARLA
+-- ---------------------------
+-- Pegar este archivo entero en el SQL editor y agregarle al final:
+--     DO $dry$ BEGIN RAISE EXCEPTION 'dry-run'; END $dry$;
+-- La excepción garantiza el rollback; los NOTICE de los pasos 1-4 igual salen,
+-- así que se ven los conteos reales sin dejar nada aplicado.
+--
+-- REVERSIÓN (si algo se rompe):
+--     ALTER DEFAULT PRIVILEGES FOR ROLE postgres IN SCHEMA public
+--       GRANT EXECUTE ON FUNCTIONS TO anon;
+--     GRANT EXECUTE ON ALL FUNCTIONS IN SCHEMA public TO anon;
+-- ============================================================================
+
+
+-- ----------------------------------------------------------------------------
+-- 0. Default privileges: sacar el grant explícito a anon
+-- ----------------------------------------------------------------------------
+-- Sin esto, la próxima migración que cree una función le vuelve a dar EXECUTE a
+-- anon de forma explícita. `authenticated` y `service_role` se mantienen en el
+-- default: la app sigue andando sin que cada migración tenga que acordarse.
+--
+-- NO se puede sacar a PUBLIC del default, y conviene tenerlo claro. Medido
+-- sobre Postgres 17:
+--
+--     ALTER DEFAULT PRIVILEGES IN SCHEMA public REVOKE EXECUTE ON FUNCTIONS FROM PUBLIC;
+--
+--   es un no-op: no crea fila en pg_default_acl, y cuando la fila existe (por
+--   el GRANT de Supabase) el acldefault() built-in — que incluye `=X` para
+--   PUBLIC — se concatena igual. Toda función nueva nace con `=X/postgres`.
+--
+-- Consecuencia práctica, y es la parte que importa: después de este paso, una
+-- migración que escriba el patrón habitual del repo
+--
+--     REVOKE ALL ON FUNCTION public.mi_rpc(...) FROM PUBLIC;
+--
+--   SÍ cierra a anon, porque ya no queda un `anon=X/postgres` atrás. O sea que
+--   esto convierte en correcto el patrón que hoy está roto en 40 migraciones.
+--   Igual conviene escribir las dos mitades (`FROM PUBLIC, anon`): es
+--   idempotente y sirve para las funciones viejas, que sí tienen el explícito.
+--
+-- La garantía real de no recaída es el gate de CI (mig 189 +
+-- scripts/check-permisos.mjs), no este ALTER.
+--
+-- `FOR ROLE postgres` no es decorativo: en prod hay DOS entradas de default
+-- privileges para funciones de public, una de `postgres` y otra de
+-- `supabase_admin`. Postgres aplica **sólo la del rol que crea la función**, y
+-- las migraciones corren como postgres (verificado: `current_user` = postgres,
+-- `is_superuser` = off). La de supabase_admin es de la plataforma: no somos
+-- superuser, no la podemos ni la debemos tocar.
+
+ALTER DEFAULT PRIVILEGES FOR ROLE postgres IN SCHEMA public
+  REVOKE EXECUTE ON FUNCTIONS FROM anon;
+
+
+-- ----------------------------------------------------------------------------
+-- 1. Piso: congelar el acceso vigente de authenticated / service_role
+-- ----------------------------------------------------------------------------
+-- has_function_privilege() responde por el permiso EFECTIVO, así que devuelve
+-- true también cuando llega sólo por PUBLIC. Ese es justamente el caso que hay
+-- que materializar antes de sacar PUBLIC.
+--
+-- Efecto colateral buscado: lo que la 069 y la 167 ya cerraron (RPCs del bot,
+-- las 4 `*_impl`) da has_function_privilege = false y NO se vuelve a otorgar.
+-- El barrido no revierte hardening previo.
+
+DO $piso$
+DECLARE
+  r      RECORD;
+  n_auth INT := 0;
+  n_svc  INT := 0;
+BEGIN
+  FOR r IN
+    SELECT p.oid::regprocedure AS sig,
+           has_function_privilege('authenticated', p.oid, 'EXECUTE') AS auth_ok,
+           has_function_privilege('service_role',  p.oid, 'EXECUTE') AS svc_ok
+    FROM pg_proc p
+    JOIN pg_type t ON t.oid = p.prorettype
+    WHERE p.pronamespace = 'public'::regnamespace
+      AND p.prokind IN ('f', 'p')
+      AND t.typname <> 'trigger'
+      AND p.proname NOT LIKE '\_%'
+      AND p.proname NOT LIKE '%\_impl'
+      AND NOT EXISTS (
+        SELECT 1 FROM pg_depend d
+        WHERE d.objid = p.oid
+          AND d.classid = 'pg_proc'::regclass
+          AND d.deptype = 'e'
+      )
+  LOOP
+    IF r.auth_ok THEN
+      EXECUTE format('GRANT EXECUTE ON FUNCTION %s TO authenticated', r.sig);
+      n_auth := n_auth + 1;
+    END IF;
+    IF r.svc_ok THEN
+      EXECUTE format('GRANT EXECUTE ON FUNCTION %s TO service_role', r.sig);
+      n_svc := n_svc + 1;
+    END IF;
+  END LOOP;
+
+  RAISE NOTICE '[188/1] grants explícitos: authenticated=%, service_role=%', n_auth, n_svc;
+END
+$piso$;
+
+
+-- ----------------------------------------------------------------------------
+-- 2. Barrido: sacar PUBLIC y anon de TODAS las funciones de public
+-- ----------------------------------------------------------------------------
+
+DO $barrido$
+DECLARE
+  r RECORD;
+  n INT := 0;
+BEGIN
+  FOR r IN
+    SELECT p.oid::regprocedure AS sig
+    FROM pg_proc p
+    WHERE p.pronamespace = 'public'::regnamespace
+      AND p.prokind IN ('f', 'p')
+      AND NOT EXISTS (
+        SELECT 1 FROM pg_depend d
+        WHERE d.objid = p.oid
+          AND d.classid = 'pg_proc'::regclass
+          AND d.deptype = 'e'
+      )
+  LOOP
+    EXECUTE format('REVOKE EXECUTE ON FUNCTION %s FROM PUBLIC, anon', r.sig);
+    n := n + 1;
+  END LOOP;
+
+  RAISE NOTICE '[188/2] PUBLIC+anon revocados en % funciones', n;
+END
+$barrido$;
+
+
+-- ----------------------------------------------------------------------------
+-- 3. Internos: tampoco authenticated
+-- ----------------------------------------------------------------------------
+-- Convención del repo, ahora con efecto real:
+--   `_nombre`      -> helper interno; sólo lo llaman wrappers SECURITY DEFINER
+--   `nombre_impl`  -> cuerpo real detrás de un wrapper (idempotencia, mig 167)
+--   RETURNS trigger-> lo dispara el motor; nadie lo invoca por nombre
+-- Ninguna de las 96 RPCs que usa la app cae en estos patrones (verificado).
+
+DO $internos$
+DECLARE
+  r RECORD;
+  n INT := 0;
+BEGIN
+  FOR r IN
+    SELECT p.oid::regprocedure AS sig
+    FROM pg_proc p
+    JOIN pg_type t ON t.oid = p.prorettype
+    WHERE p.pronamespace = 'public'::regnamespace
+      AND p.prokind IN ('f', 'p')
+      AND (
+            p.proname LIKE '\_%'
+         OR p.proname LIKE '%\_impl'
+         OR t.typname = 'trigger'
+      )
+      AND NOT EXISTS (
+        SELECT 1 FROM pg_depend d
+        WHERE d.objid = p.oid
+          AND d.classid = 'pg_proc'::regclass
+          AND d.deptype = 'e'
+      )
+  LOOP
+    EXECUTE format('REVOKE EXECUTE ON FUNCTION %s FROM PUBLIC, anon, authenticated', r.sig);
+    n := n + 1;
+  END LOOP;
+
+  RAISE NOTICE '[188/3] internos cerrados también a authenticated: %', n;
+END
+$internos$;
+
+
+-- ----------------------------------------------------------------------------
+-- 4. Verificación fail-closed (misma transacción: si falla, rollback de todo)
+-- ----------------------------------------------------------------------------
+
+DO $verif$
+DECLARE
+  v_abiertas   TEXT;
+  v_n_abiertas INT;
+  v_rotas      TEXT;
+  v_n_rotas    INT;
+  v_faltantes  TEXT;
+  -- Las 96 RPCs que llama src/ (grep `.rpc(`, excluidos archivos de test).
+  v_app_rpcs   TEXT[] := ARRAY[
+    'aceptar_movimiento_sucursal',
+    'actualizar_barridas_recorrido',
+    'actualizar_compra_items',
+    'actualizar_forma_pago_pago',
+    'actualizar_minimo_venta_masivo',
+    'actualizar_pedido_items',
+    'actualizar_precios_masivo',
+    'actualizar_preventista_pedido',
+    'ajustar_stock_promocion_completo',
+    'anular_compra_atomica',
+    'anular_salvedad',
+    'aplicar_cambio_de_parada',
+    'aplicar_control_stock',
+    'aplicar_orden_ruta',
+    'asignar_marca_masiva',
+    'avance_metas_preventista',
+    'bot_admin_audit_log',
+    'bot_admin_audit_summary',
+    'bot_admin_digests_enviados',
+    'bot_admin_listar_vinculados',
+    'bot_admin_toggle_usuario',
+    'calcular_comisiones',
+    'cambiar_cliente_pedido',
+    'cambiar_proveedor_compra',
+    'cambiar_sucursal',
+    'cambiar_tipo_factura_pedido',
+    'cambiar_transportista_recorrido',
+    'cancelar_movimiento_sucursal',
+    'cancelar_pedido_con_stock',
+    'confirmar_rendicion',
+    'consolidar_condiciones',
+    'consultar_control_rendicion',
+    'crear_condicion_para_producto',
+    'crear_movimiento_sucursal',
+    'crear_pedido_cambio_en_ruta',
+    'crear_pedido_completo',
+    'crear_pedido_idempotente',
+    'crear_recorrido',
+    'denegar_movimiento_sucursal',
+    'desactivar_comision_regla',
+    'desactivar_meta_preventista',
+    'descontar_stock_atomico',
+    'desmarcar_rendicion_controlada',
+    'editar_movimiento_sucursal',
+    'eliminar_pedido_completo',
+    'eliminar_proveedor',
+    'generar_codigo_vinculacion_bot',
+    'get_deposito_sucursal',
+    'get_destino_sucursal',
+    'guardar_comision_regla',
+    'guardar_horario_cliente_masivo',
+    'guardar_meta_gerencial',
+    'guardar_meta_preventista',
+    'jornada_preventista_detalle',
+    'jornadas_preventista',
+    'listar_visitas_hoy',
+    'marcar_entrega_y_pago_masivo',
+    'marcar_entregas_masivo',
+    'marcar_no_entregado',
+    'marcar_notificacion_leida',
+    'marcar_pagos_masivo',
+    'marcar_rendicion_controlada',
+    'marcar_todas_notificaciones_leidas',
+    'obtener_detalle_rendicion',
+    'obtener_deudores_mora',
+    'obtener_estadisticas_pedidos',
+    'obtener_geolocalizacion_preventistas',
+    'obtener_pagos_rendicion_cliente',
+    'obtener_pedidos_ctacte_pendientes',
+    'obtener_resumen_cuenta_cliente',
+    'obtener_resumen_rendiciones',
+    'posicion_fiscal',
+    'quitar_pedido_de_recorridos_activos',
+    'registrar_cambio_producto',
+    'registrar_compra_completa',
+    'registrar_geolocalizacion_pedido',
+    'registrar_nota_credito',
+    'registrar_origen_precio_items',
+    'registrar_pago_cliente_fifo',
+    'registrar_pago_combinado_cliente_fifo',
+    'registrar_salvedad',
+    'registrar_visita_cliente',
+    'rendicion_dia_cerrada',
+    'rendimiento_preventistas',
+    'reporte_alerta_detalle',
+    'reporte_gerencial',
+    'reporte_valuacion_inventario',
+    'resolver_rendicion',
+    'resolver_salvedad',
+    'restaurar_stock_atomico',
+    'set_deposito_sucursal',
+    'set_destino_sucursal',
+    'simular_salvedad_promo_impacto',
+    'simular_salvedades_promo_impacto',
+    'sustituir_regalo_pedido',
+    'ultima_fecha_caja_cerrada'
+  ];
+BEGIN
+  -- 4a. Nada de public queda ejecutable por anon.
+  --     Si algo sobrevive suele ser por owner distinto de postgres: el REVOKE
+  --     emite WARNING y sigue. Por eso el reporte incluye el owner.
+  SELECT count(*), string_agg(sig || ' [owner=' || owner || ']', E'\n  ' ORDER BY sig)
+    INTO v_n_abiertas, v_abiertas
+  FROM (
+    SELECT p.oid::regprocedure::text     AS sig,
+           pg_get_userbyid(p.proowner)   AS owner
+    FROM pg_proc p
+    WHERE p.pronamespace = 'public'::regnamespace
+      AND p.prokind IN ('f', 'p')
+      AND has_function_privilege('anon', p.oid, 'EXECUTE')
+      AND NOT EXISTS (
+        SELECT 1 FROM pg_depend d
+        WHERE d.objid = p.oid
+          AND d.classid = 'pg_proc'::regclass
+          AND d.deptype = 'e'
+      )
+  ) s;
+
+  IF v_n_abiertas > 0 THEN
+    RAISE EXCEPTION E'[188] Quedaron % funciones ejecutables por anon:\n  %',
+      v_n_abiertas, v_abiertas;
+  END IF;
+
+  -- 4b. Ninguna RPC que usa la app perdió authenticated.
+  SELECT count(*), string_agg(sig, ', ' ORDER BY sig)
+    INTO v_n_rotas, v_rotas
+  FROM (
+    SELECT p.oid::regprocedure::text AS sig
+    FROM pg_proc p
+    WHERE p.pronamespace = 'public'::regnamespace
+      AND p.prokind IN ('f', 'p')
+      AND p.proname = ANY (v_app_rpcs)
+      AND NOT has_function_privilege('authenticated', p.oid, 'EXECUTE')
+  ) s;
+
+  IF v_n_rotas > 0 THEN
+    RAISE EXCEPTION E'[188] % RPCs de la app quedaron sin EXECUTE para authenticated:\n  %',
+      v_n_rotas, v_rotas;
+  END IF;
+
+  -- 4c. Drift informativo: nombres que la app llama y no existen en el catálogo.
+  --     No aborta (puede ser una RPC de una rama sin mergear), pero conviene verlo.
+  SELECT string_agg(a, ', ' ORDER BY a) INTO v_faltantes
+  FROM unnest(v_app_rpcs) AS a
+  WHERE NOT EXISTS (
+    SELECT 1 FROM pg_proc p
+    WHERE p.pronamespace = 'public'::regnamespace AND p.proname = a
+  );
+
+  IF v_faltantes IS NOT NULL THEN
+    RAISE NOTICE '[188/4c] la app llama RPCs que no existen en public: %', v_faltantes;
+  END IF;
+
+  -- 4d. El paso 0 quedó grabado: el default de `postgres` ya no le da EXECUTE a anon.
+  --     Se filtra por defaclrole: hay DOS entradas de default privileges para
+  --     funciones de public, una de `postgres` y otra de `supabase_admin`, y
+  --     sólo aplica la del rol que CREA la función. Las migraciones corren como
+  --     postgres, así que la de supabase_admin no nos toca (y es de Supabase:
+  --     no somos superuser, no podemos ni deberíamos modificarla).
+  IF EXISTS (
+    SELECT 1
+    FROM pg_default_acl d, aclexplode(d.defaclacl) a
+    WHERE d.defaclobjtype = 'f'
+      AND d.defaclnamespace = 'public'::regnamespace
+      AND d.defaclrole = 'postgres'::regrole
+      AND a.grantee = 'anon'::regrole
+      AND a.privilege_type = 'EXECUTE'
+  ) THEN
+    RAISE EXCEPTION '[188] El default privilege de postgres sigue otorgándole EXECUTE a anon; el paso 0 no quedó.';
+  END IF;
+
+  RAISE NOTICE '[188/4] OK — 0 funciones abiertas a anon, RPCs de la app intactas, default cerrado para anon.';
+  RAISE NOTICE '[188/!] Recordá: las funciones NUEVAS igual nacen con PUBLIC (=X/postgres). Cada migración debe revocarlo. Lo vigila scripts/check-permisos.mjs.';
+END
+$verif$;

--- a/migrations/189_auditoria_de_permisos_execute.sql
+++ b/migrations/189_auditoria_de_permisos_execute.sql
@@ -1,0 +1,139 @@
+-- ============================================================================
+-- Migración 189: auditoria_permisos_execute() — el gate que evita la recaída
+-- ============================================================================
+-- Proyecto: hmuchlzmuqqxcldbzkgc (ManaosApp).
+--
+-- La 188 cierra el agujero de hoy. Esta lo deja medido, para que no vuelva:
+--
+--   * Devuelve la clasificación por riesgo del schema public (qué ejecuta anon,
+--     qué es SECURITY DEFINER, qué tiene gate propio, qué escribe).
+--   * scripts/check-permisos.mjs la consume y falla si `expuestas_a_anon > 0`.
+--     Queda colgada del workflow "Integridad de datos", junto a
+--     auditoria_integridad() (mig 105) y al drift-check de migraciones.
+--
+-- Sobre la clasificación: "menciona auth.uid()" NO es lo mismo que "se protege
+-- con auth.uid()". Una función puede usarlo sólo para estampar una columna. Por
+-- eso `tiene_guarda` es una PISTA (grep sobre el cuerpo), no un veredicto: sirve
+-- para ordenar la cola de revisión, no para dar algo por seguro. Lo que sí es
+-- veredicto es `ejecuta_anon`, que sale del ACL.
+--
+-- Sigue el patrón correcto de permisos, que ahora está en migrations/README.md:
+-- REVOKE de las DOS mitades (PUBLIC y anon) + GRANT explícito a quien la usa.
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION public.auditoria_permisos_execute()
+RETURNS jsonb
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public, pg_catalog
+AS $fn$
+WITH f AS (
+  SELECT
+    p.oid,
+    p.oid::regprocedure::text                                   AS firma,
+    pg_get_userbyid(p.proowner)                                 AS owner,
+    p.prosecdef                                                 AS security_definer,
+    (t.typname = 'trigger')                                     AS es_trigger,
+    COALESCE(array_to_string(p.proacl, ' | '), '(default: owner + PUBLIC)') AS acl,
+    has_function_privilege('anon',          p.oid, 'EXECUTE')    AS ejecuta_anon,
+    has_function_privilege('authenticated', p.oid, 'EXECUTE')    AS ejecuta_authenticated,
+    has_function_privilege('service_role',  p.oid, 'EXECUTE')    AS ejecuta_service_role,
+    (p.provolatile = 'v')                                        AS volatil,
+    pg_get_functiondef(p.oid)                                    AS def
+  FROM pg_proc p
+  JOIN pg_type t ON t.oid = p.prorettype
+  WHERE p.pronamespace = 'public'::regnamespace
+    AND p.prokind IN ('f', 'p')
+    -- Las funciones que trae una extensión (pg_trgm, unaccent, pgcrypto…) no
+    -- son nuestras y no se tocan.
+    AND NOT EXISTS (
+      SELECT 1 FROM pg_depend d
+      WHERE d.objid = p.oid
+        AND d.classid = 'pg_proc'::regclass
+        AND d.deptype = 'e'
+    )
+),
+c AS (
+  SELECT
+    f.*,
+    (f.def ~* 'auth\.uid\(\)|es_admin\(\)|es_encargado_o_admin\(\)|current_sucursal_id\(\)|es_preventista\(\)|es_transportista\(\)|_rol_en_sucursal\(')
+      AS menciona_guarda,
+    -- Heurística de escritura: grep sobre el cuerpo Y volatilidad. Postgres no
+    -- deja que una función STABLE/IMMUTABLE haga INSERT/UPDATE/DELETE, así que
+    -- exigir VOLATILE descarta los falsos positivos por comentarios, strings o
+    -- una regex citada dentro del propio cuerpo (esta función se matcheaba sola).
+    (f.volatil AND f.def ~* '\m(insert|update|delete|truncate)\M')
+      AS escribe
+  FROM f
+)
+SELECT jsonb_build_object(
+  'generado_at', now(),
+
+  'total_funciones',           (SELECT count(*) FROM c),
+  'security_definer',          (SELECT count(*) FROM c WHERE security_definer),
+
+  -- El veredicto duro: después de la 188 esto tiene que ser 0.
+  'expuestas_a_anon',          (SELECT count(*) FROM c WHERE ejecuta_anon),
+  'expuestas_a_anon_definer',  (SELECT count(*) FROM c WHERE ejecuta_anon AND security_definer),
+  'expuestas_a_anon_sin_guarda',
+    (SELECT count(*) FROM c WHERE ejecuta_anon AND security_definer AND NOT menciona_guarda),
+  'expuestas_a_anon_sin_guarda_que_escriben',
+    (SELECT count(*) FROM c WHERE ejecuta_anon AND security_definer AND NOT menciona_guarda AND escribe),
+
+  -- Riesgo residual: lo que un usuario logueado puede invocar directo sin que la
+  -- función chequee nada. No es un agujero abierto a internet, pero es la cola
+  -- de revisión que queda después de la 188.
+  'definer_sin_guarda_para_authenticated',
+    (SELECT count(*) FROM c
+      WHERE ejecuta_authenticated AND security_definer AND NOT menciona_guarda AND NOT es_trigger),
+
+  'detalle_anon', COALESCE(
+    (SELECT jsonb_agg(jsonb_build_object(
+        'firma', firma, 'owner', owner,
+        'security_definer', security_definer, 'trigger', es_trigger,
+        'menciona_guarda', menciona_guarda, 'escribe', escribe,
+        'acl', acl
+      ) ORDER BY security_definer DESC, escribe DESC, firma)
+     FROM c WHERE ejecuta_anon),
+    '[]'::jsonb),
+
+  'detalle_authenticated_sin_guarda', COALESCE(
+    (SELECT jsonb_agg(jsonb_build_object(
+        'firma', firma, 'escribe', escribe
+      ) ORDER BY escribe DESC, firma)
+     FROM c
+     WHERE ejecuta_authenticated AND security_definer AND NOT menciona_guarda AND NOT es_trigger),
+    '[]'::jsonb)
+);
+$fn$;
+
+ALTER FUNCTION public.auditoria_permisos_execute() OWNER TO postgres;
+
+-- Las DOS mitades del REVOKE. Ver migrations/README.md § Permisos.
+REVOKE EXECUTE ON FUNCTION public.auditoria_permisos_execute() FROM PUBLIC, anon;
+GRANT  EXECUTE ON FUNCTION public.auditoria_permisos_execute() TO authenticated, service_role;
+
+COMMENT ON FUNCTION public.auditoria_permisos_execute() IS
+  'Clasifica por riesgo los permisos EXECUTE del schema public. Lo consume '
+  'scripts/check-permisos.mjs, que falla si expuestas_a_anon > 0. Ver mig 188/189.';
+
+
+-- ----------------------------------------------------------------------------
+-- Verificación: la función nueva no nació abierta a anon
+-- ----------------------------------------------------------------------------
+-- Si la 188 se aplicó, el ALTER DEFAULT PRIVILEGES ya lo garantiza y esto es
+-- redundante. Si alguien aplica la 189 sin la 188, esto lo detecta.
+
+DO $verif$
+DECLARE
+  v_anon BOOLEAN;
+BEGIN
+  SELECT has_function_privilege('anon', 'public.auditoria_permisos_execute()'::regprocedure, 'EXECUTE')
+    INTO v_anon;
+
+  IF v_anon THEN
+    RAISE EXCEPTION '[189] auditoria_permisos_execute() quedó ejecutable por anon. ¿Se aplicó la 188?';
+  END IF;
+END
+$verif$;

--- a/migrations/MANIFEST.md
+++ b/migrations/MANIFEST.md
@@ -24,6 +24,9 @@ prefijo `NNN_`, es normal: guarda el `name` que se pasó al `apply_migration`).
 - **CI / humano:** `node scripts/check-migrations.mjs` (env `SUPABASE_URL` +
   `SUPABASE_SERVICE_ROLE_KEY`). Lee el ledger vía el RPC `public.migraciones_aplicadas()`
   (creado en `109`) porque el schema `supabase_migrations` no está expuesto por PostgREST.
+- **Permisos:** `node scripts/check-permisos.mjs` (mismos env). Falla si alguna función de
+  `public` quedó ejecutable con la anon key. No es drift de migraciones, pero corre en el mismo
+  workflow y detecta lo mismo que la `188` cerró. Ver `README.md § Permisos`.
 
 ## Cómo se aplican las migraciones
 
@@ -230,6 +233,29 @@ Al leer el catálogo, la lógica de negocio de esas 4 vive en la función `_impl
 **Antes de elegir el número de una migración nueva, mirar `ls migrations/` además del
 ledger**: el ledger no siempre lleva el prefijo, así que por sí solo no alcanza. Y si mergeaste
 `main` en el medio, volvé a mirarlo — los números que estaban libres pueden haberse ocupado.
+
+### E. La 188/189 quedó intercalada con la 186/187 (2026-08-19)
+
+El ledger tiene, por `version`, este orden:
+
+| hora (UTC) | ledger | rama |
+| --- | --- | --- |
+| 16:56:50 | `186_quien_cruza_de_sucursal` | aislamiento por sucursal |
+| 16:57:07 | `188_anon_deja_de_ejecutar_rpcs` | permisos EXECUTE |
+| 16:58:04 | `189_auditoria_de_permisos_execute` | permisos EXECUTE |
+| 16:58:07 | `187_la_hija_no_cruza_de_sucursal` | aislamiento por sucursal |
+
+O sea que **el número de archivo no refleja el orden de aplicación**: dos ramas aplicaron a
+prod con minutos de diferencia. No rompe nada (el ledger ordena por `version`, y ninguna de
+las cuatro depende de otra), pero si mirás sólo los números vas a suponer un orden que no fue.
+
+Vale la pena por lo que dejó demostrado: la **187 se aplicó después del barrido de la 188** y
+aun así no quedó nada abierto a `anon`, porque no creó funciones. Si hubiera creado una, habría
+nacido con `=X/postgres` (PUBLIC) y el gate `scripts/check-permisos.mjs` la habría marcado al
+día siguiente. Ese es exactamente el escenario para el que existe el gate: el paso 0 de la 188
+saca a `anon` del default privilege, pero **a PUBLIC no lo puede sacar** (medido, ver la
+migración), así que toda función nueva sigue naciendo con PUBLIC y **cada migración tiene que
+revocarlo**. Ver `README.md § Permisos`.
 
 ---
 

--- a/migrations/README.md
+++ b/migrations/README.md
@@ -43,6 +43,100 @@ que el MANIFEST tenga que documentar la excepción.
 
 Proyecto: `hmuchlzmuqqxcldbzkgc` (región `sa-east-1`, Postgres 17.6.1).
 
+## Permisos: el REVOKE necesita las DOS mitades
+
+**`REVOKE ... FROM PUBLIC` a secas no cierra nada. `REVOKE ... FROM anon` a secas tampoco.**
+
+Supabase trae un `ALTER DEFAULT PRIVILEGES` que le concede `EXECUTE` a `anon` de forma
+**explícita** en cada función nueva, **además** del grant implícito a `PUBLIC` que pone
+Postgres. El ACL de una función recién creada tiene las dos cosas:
+
+```
+{=X/postgres, postgres=X/postgres, anon=X/postgres, authenticated=X/postgres, service_role=X/postgres}
+ ^^^^^^^^^^^^ esto es PUBLIC                ^^^^^^^^^^^^^^^^ y esto es el grant explícito
+```
+
+| Lo que escribís | Lo que queda | ¿anon ejecuta? |
+| --- | --- | --- |
+| `REVOKE ... FROM PUBLIC` | `anon=X/postgres` | **sí** |
+| `REVOKE ... FROM anon` | `=X/postgres` | **sí**, por PUBLIC |
+| `REVOKE ... FROM PUBLIC, anon` | — | no ✅ |
+
+Esto rompió en silencio durante meses. La migración **089** dice textual
+*«Solo lo llaman los wrappers DEFINER; no se expone a clientes»* y a continuación hace
+`REVOKE ALL ... FROM PUBLIC`: la intención era correcta y el mecanismo la dejó pasar.
+`_aplicar_cambio_producto` quedó alcanzable con la anon key, siendo `SECURITY DEFINER`,
+sin gate propio y recibiendo `p_sucursal_id` / `p_usuario_id` por parámetro.
+
+La **188** cerró todo lo existente y sacó `anon` del `ALTER DEFAULT PRIVILEGES`.
+
+> **Lo que el default privilege NO puede hacer.** A `PUBLIC` no se lo puede sacar del default:
+> `ALTER DEFAULT PRIVILEGES ... REVOKE EXECUTE ON FUNCTIONS FROM PUBLIC` es un **no-op** (no crea
+> fila en `pg_default_acl`, y cuando la fila existe el `acldefault()` built-in —que incluye
+> `=X` para PUBLIC— se concatena igual). Medido sobre Postgres 17. O sea: **toda función nueva
+> sigue naciendo con `=X/postgres`** y hay que revocárselo a mano.
+>
+> Lo que sí cambió: como ya no queda un `anon=X/postgres` atrás, escribir sólo
+> `REVOKE ... FROM PUBLIC` **ahora sí** cierra a anon. El patrón que estaba roto en 40
+> migraciones pasó a ser correcto. Igual conviene escribir las dos mitades: es idempotente y
+> hace falta para las funciones viejas.
+>
+> La garantía de que esto no recaiga es el **gate de CI**, no el default privilege.
+
+### La receta
+
+```sql
+REVOKE EXECUTE ON FUNCTION public.mi_rpc(bigint, date) FROM PUBLIC, anon;
+GRANT  EXECUTE ON FUNCTION public.mi_rpc(bigint, date) TO authenticated;   -- la app web
+-- GRANT  EXECUTE ON FUNCTION public.mi_rpc(bigint, date) TO service_role; -- bot / edge / scripts
+```
+
+Quién es quién: la web entra como **`authenticated`** (requiere login); el bot de Telegram,
+las edge functions y `scripts/check-*.mjs` usan **`service_role`**. **`anon` no lo usa nadie**
+— es el rol de la clave pública sin sesión.
+
+### Trampas
+
+- **`CREATE OR REPLACE` conserva el ACL; `DROP` + `CREATE` lo resetea.** Si cambiás la firma
+  de una función (lo que obliga a dropear), **el hardening previo se pierde** y hay que
+  reescribir el `REVOKE`/`GRANT`. `ALTER FUNCTION ... RENAME TO` también conserva el ACL
+  (es lo que aprovechó la 167 con las `*_impl`).
+- **Un `CREATE OR REPLACE` de `es_admin()` / `es_preventista()` / `current_sucursal_id()`
+  revierte cambios de rol en silencio.** Ver la nota de la mig 155/156.
+- **No revoques `authenticated` de los helpers de RLS** (`es_admin()`, `current_sucursal_id()`,
+  `es_encargado_o_admin()`, …): las políticas RLS se evalúan como el usuario que consulta, así
+  que necesita `EXECUTE`. Sacárselo rompe **todas** las queries, no una.
+- **Las funciones de extensiones no se tocan** (`pg_trgm`, `unaccent`, `pgcrypto`). Filtralas
+  con `pg_depend.deptype = 'e'` o vas a romper índices y operadores.
+- **Las funciones trigger no necesitan `EXECUTE` para dispararse**: el permiso se chequea en
+  `CREATE TRIGGER`, no cuando el trigger corre. Se les puede revocar todo (lo hicieron la 069
+  y la 188).
+
+### Convención de nombres (ahora con efecto real)
+
+| Patrón | Significa | Permisos |
+| --- | --- | --- |
+| `_nombre` | helper interno; sólo lo llaman wrappers `SECURITY DEFINER` | nadie: ni `anon`, ni `authenticated` |
+| `nombre_impl` | cuerpo real detrás de un wrapper (idempotencia, mig 167) | ídem |
+| `RETURNS trigger` | lo dispara el motor | ídem |
+| `bot_*` | las llama el bot | sólo `service_role` (excepto `bot_admin_*`, que las usa la web) |
+
+La 188 barre por estos patrones, así que **una función nueva que se llame `_algo` queda
+cerrada sola**. Si necesitás que la app la llame, no la nombres con guion bajo.
+
+### Verificarlo
+
+```bash
+SUPABASE_URL=... SUPABASE_SERVICE_ROLE_KEY=... node scripts/check-permisos.mjs
+```
+
+Falla si alguna función de `public` volvió a quedar ejecutable por `anon`. Corre a diario en
+`.github/workflows/integridad.yml`. Se apoya en el RPC `auditoria_permisos_execute()`
+(mig 189), que además lista las `SECURITY DEFINER` sin gate propio alcanzables por
+`authenticated` — el riesgo residual, informativo.
+
+Para mirar el estado sin aplicar nada: `scripts/auditoria-permisos.sql` (sólo lee el catálogo).
+
 ## Regenerar el baseline
 
 Si el schema de prod cambia mucho fuera de banda y conviene re-sincronizar el punto de partida:

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "prepare": "husky",
     "check-secrets": "./scripts/check-secrets.sh",
     "check:migrations": "node scripts/check-migrations.mjs",
+    "check:permisos": "node scripts/check-permisos.mjs",
     "typecheck": "tsc --noEmit",
     "typecheck:watch": "tsc --noEmit --watch",
     "generate:pwa-assets": "node scripts/generate-pwa-assets.js",

--- a/scripts/auditoria-permisos.sql
+++ b/scripts/auditoria-permisos.sql
@@ -1,0 +1,78 @@
+-- ============================================================================
+-- Auditoría de permisos EXECUTE del schema public — consulta de pre-vuelo
+-- ============================================================================
+-- Sólo LEE el catálogo. Pegar en el SQL editor del dashboard (o correr con
+-- execute_sql) ANTES de aplicar la migración 188, para ver contra qué se está
+-- comparando. Después de la 188, lo mismo lo devuelve el RPC
+-- auditoria_permisos_execute() (mig 189) y lo chequea scripts/check-permisos.mjs.
+--
+-- Salvedad importante sobre la columna `menciona_guarda`: es un grep sobre el
+-- cuerpo de la función, no un veredicto. Que una función mencione auth.uid() no
+-- significa que se proteja con auth.uid() — puede usarlo sólo para estampar una
+-- columna. Sirve para ordenar la cola de revisión. Lo que sí es duro es
+-- `ejecuta_anon`, que sale del ACL.
+-- ============================================================================
+
+WITH f AS (
+  SELECT
+    p.oid,
+    p.oid::regprocedure::text                                    AS firma,
+    pg_get_userbyid(p.proowner)                                  AS owner,
+    p.prosecdef                                                  AS security_definer,
+    (t.typname = 'trigger')                                      AS es_trigger,
+    COALESCE(array_to_string(p.proacl, ' | '), '(default: owner + PUBLIC)') AS acl,
+    has_function_privilege('anon',          p.oid, 'EXECUTE')     AS ejecuta_anon,
+    has_function_privilege('authenticated', p.oid, 'EXECUTE')     AS ejecuta_authenticated,
+    (p.provolatile = 'v')                                         AS volatil,
+    pg_get_functiondef(p.oid)                                     AS def
+  FROM pg_proc p
+  JOIN pg_type t ON t.oid = p.prorettype
+  WHERE p.pronamespace = 'public'::regnamespace
+    AND p.prokind IN ('f', 'p')
+    AND NOT EXISTS (                       -- funciones que trae una extensión: no son nuestras
+      SELECT 1 FROM pg_depend d
+      WHERE d.objid = p.oid
+        AND d.classid = 'pg_proc'::regclass
+        AND d.deptype = 'e'
+    )
+),
+c AS (
+  SELECT f.*,
+    (def ~* 'auth\.uid\(\)|es_admin\(\)|es_encargado_o_admin\(\)|current_sucursal_id\(\)|es_preventista\(\)|es_transportista\(\)|_rol_en_sucursal\(')
+      AS menciona_guarda,
+    -- Grep + volatilidad: Postgres no deja escribir a una función STABLE, así
+    -- que exigir VOLATILE descarta falsos positivos por comentarios o strings.
+    (volatil AND def ~* '\m(insert|update|delete|truncate)\M') AS escribe
+  FROM f
+)
+
+-- ---------------------------------------------------------------------------
+-- (1) Resumen
+-- ---------------------------------------------------------------------------
+SELECT
+  count(*)                                                                    AS total,
+  count(*) FILTER (WHERE ejecuta_anon)                                        AS ejecuta_anon,
+  count(*) FILTER (WHERE ejecuta_anon AND security_definer)                   AS anon_definer,
+  count(*) FILTER (WHERE ejecuta_anon AND security_definer
+                     AND NOT menciona_guarda)                                 AS anon_definer_sin_guarda,
+  count(*) FILTER (WHERE ejecuta_anon AND security_definer
+                     AND NOT menciona_guarda AND escribe)                     AS anon_definer_sin_guarda_escribe,
+  -- Cómo llega el permiso: las dos mitades por separado.
+  count(*) FILTER (WHERE ejecuta_anon AND acl LIKE '%anon=%')                 AS via_grant_explicito_a_anon,
+  count(*) FILTER (WHERE ejecuta_anon AND (acl LIKE '=X/%' OR acl LIKE '%| =X/%'
+                                            OR acl = '(default: owner + PUBLIC)')) AS via_public
+FROM c;
+
+-- ---------------------------------------------------------------------------
+-- (2) Detalle ordenado por riesgo — arriba lo que escribe sin gate
+-- ---------------------------------------------------------------------------
+-- Descomentar para verlo (la CTE hay que repetirla; en el SQL editor conviene
+-- correr un bloque por vez).
+--
+-- SELECT firma, owner, security_definer, es_trigger, menciona_guarda, escribe, acl
+-- FROM c
+-- WHERE ejecuta_anon
+-- ORDER BY (security_definer AND NOT menciona_guarda AND escribe) DESC,
+--          (security_definer AND NOT menciona_guarda)             DESC,
+--          security_definer DESC,
+--          firma;

--- a/scripts/check-permisos.mjs
+++ b/scripts/check-permisos.mjs
@@ -1,0 +1,85 @@
+#!/usr/bin/env node
+/**
+ * Gate de permisos EXECUTE.
+ * Llama al RPC auditoria_permisos_execute() (ver migrations/189) vía PostgREST
+ * con la service_role key y falla (exit 1) si alguna función del schema public
+ * quedó ejecutable por el rol `anon`.
+ *
+ * Por qué existe: Supabase le concede EXECUTE a `anon` explícitamente en cada
+ * función nueva, ADEMÁS del grant implícito a PUBLIC. Revocar una sola de las
+ * dos mitades no cierra nada, y el error es invisible en code review.
+ * Ver migrations/README.md § Permisos y la migración 188.
+ *
+ * Requiere env: SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY.
+ * Uso local:  SUPABASE_URL=... SUPABASE_SERVICE_ROLE_KEY=... node scripts/check-permisos.mjs
+ */
+const url = process.env.SUPABASE_URL;
+const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+if (!url || !key) {
+  console.error('Faltan SUPABASE_URL / SUPABASE_SERVICE_ROLE_KEY en el entorno.');
+  process.exit(2);
+}
+
+const res = await fetch(`${url.replace(/\/$/, '')}/rest/v1/rpc/auditoria_permisos_execute`, {
+  method: 'POST',
+  headers: {
+    apikey: key,
+    Authorization: `Bearer ${key}`,
+    'Content-Type': 'application/json',
+  },
+  body: '{}',
+});
+
+if (!res.ok) {
+  console.error(`El RPC auditoria_permisos_execute() falló: HTTP ${res.status}\n${await res.text()}`);
+  process.exit(2);
+}
+
+const r = await res.json();
+const abiertas = r.detalle_anon ?? [];
+const sinGuarda = r.detalle_authenticated_sin_guarda ?? [];
+
+console.log(`Auditoría de permisos EXECUTE @ ${r.generado_at}`);
+console.log(
+  `Funciones en public: ${r.total_funciones} | SECURITY DEFINER: ${r.security_definer} | ` +
+    `ejecutables por anon: ${r.expuestas_a_anon}`,
+);
+
+if (abiertas.length) {
+  console.log('\nEjecutables por anon:');
+  for (const f of abiertas) {
+    const flags = [
+      f.security_definer ? 'DEFINER' : 'invoker',
+      f.menciona_guarda ? 'con guarda' : 'SIN GUARDA',
+      f.escribe ? 'ESCRIBE' : 'sólo lee',
+    ].join(', ');
+    console.log(`  ${f.firma}  (${flags})`);
+    console.log(`      acl: ${f.acl}`);
+  }
+}
+
+// Riesgo residual, informativo: un usuario logueado puede invocarlas directo y
+// la función no chequea nada por sí misma. No rompe el gate — es la cola de
+// revisión que queda después de la 188.
+if (sinGuarda.length) {
+  console.log(
+    `\nℹ️  ${sinGuarda.length} función(es) SECURITY DEFINER sin gate propio alcanzables por ` +
+      'authenticated (no rompe el gate, es backlog de revisión):',
+  );
+  for (const f of sinGuarda.slice(0, 15)) {
+    console.log(`  ${f.firma}${f.escribe ? '  [escribe]' : ''}`);
+  }
+  if (sinGuarda.length > 15) console.log(`  … y ${sinGuarda.length - 15} más.`);
+}
+
+if ((r.expuestas_a_anon ?? 0) > 0) {
+  console.error(
+    `\n❌ ${r.expuestas_a_anon} función(es) del schema public son ejecutables con la anon key.\n` +
+      '   Arreglo: REVOKE EXECUTE ON FUNCTION <firma> FROM PUBLIC, anon;  ← las DOS mitades.\n' +
+      '   Ver migrations/README.md § Permisos.',
+  );
+  process.exit(1);
+}
+
+console.log('\n✅ Ninguna función de public es ejecutable por anon.');


### PR DESCRIPTION
## El hallazgo

Medido contra prod el 2026-08-19: **132 de las 206 funciones propias de `public` eran ejecutables por `anon`**, el rol de la clave pública. **116 son `SECURITY DEFINER`** (corren como owner, saltean RLS) y **8 no tienen ninguna guarda de identidad**.

PostgREST expone toda función del schema que el rol pueda ejecutar, así que eran alcanzables con `POST /rest/v1/rpc/<nombre>` usando la anon key. **No se probó la explotación** — sería irresponsable ejecutar funciones que mutan datos de producción. La evidencia es estructural: `SECURITY DEFINER` + `anon` con EXECUTE + sin guarda interna.

## La causa raíz

Supabase trae un `ALTER DEFAULT PRIVILEGES` que le concede EXECUTE a `anon` de forma **explícita** en cada función nueva, **además** del grant implícito a PUBLIC que pone Postgres. Ninguna mitad del REVOKE alcanza sola:

| Lo que escribís | Lo que queda | ¿anon ejecuta? |
| --- | --- | --- |
| `REVOKE ... FROM PUBLIC` | `anon=X/postgres` | **sí** |
| `REVOKE ... FROM anon` | `=X/postgres` | **sí**, por PUBLIC |
| `REVOKE ... FROM PUBLIC, anon` | — | no |

El repo usó las tres variantes: las migraciones 103-131 lo hicieron bien, y de la 140 en adelante se estandarizó `REVOKE ALL ... FROM PUBLIC` a secas.

El caso más nítido es la **089**, que dice textual:

```sql
-- Solo lo llaman los wrappers DEFINER; no se expone a clientes.
REVOKE ALL ON FUNCTION public._aplicar_cambio_producto(...) FROM PUBLIC;
```

La intención era exactamente la correcta y el mecanismo la dejó pasar.

## Las 8 sin guarda, por riesgo real

**`_aplicar_cambio_producto`** es la única sin identidad en toda la cadena: recibe `p_sucursal_id` y `p_usuario_id` por parámetro — quien llama declara quién es — y mueve stock. Sus tres wrappers (`registrar_cambio_producto`, `aplicar_cambio_de_parada`, `crear_pedido_cambio_en_ruta`) sí chequean `es_encargado_o_admin()` y `current_sucursal_id()`.

**Las 4 RPCs de pago de la mig 167** también estaban expuestas, y esto no estaba en el diagnóstico original: la 167 revocó los `_impl` pero **no los wrappers**, que se crearon con firma nueva (el `client_request_id`) y heredaron el default completo. Son `SECURITY DEFINER`, sin gate propio, y llaman al `_impl` como owner. Lo que las salva es que el gate vive adentro (`auth.uid()` + `current_sucursal_id()` + `RAISE EXCEPTION`) — protección **de hecho, no de diseño**.

Las 2 restantes son funciones trigger (PostgREST no expone lo que devuelve `trigger`) y `ultima_fecha_caja_cerrada`, que sólo filtra una fecha.

## Qué hace la 188

0. Saca `anon` del `ALTER DEFAULT PRIVILEGES`. `FOR ROLE postgres` no es decorativo: hay **dos** entradas para funciones de `public` (una de `postgres`, otra de `supabase_admin`) y Postgres aplica sólo la del rol que crea la función.
1. **Congela como grants explícitos** lo que `authenticated` y `service_role` pueden hoy. Es la red de seguridad del paso 2: `has_function_privilege()` da true también cuando el permiso llega sólo por PUBLIC, y hay que materializarlo antes de sacarlo.
2. Barre `PUBLIC + anon` de todas las funciones de `public`, salvo las de extensiones (`pg_depend.deptype = 'e'`).
3. A los internos (`_*`, `*_impl`, `RETURNS trigger`) les saca además `authenticated`.
4. **Verificación fail-closed en la misma transacción**: si quedó algo abierto a anon, o si alguna de las 96 RPCs que usa la app perdió `authenticated`, `RAISE EXCEPTION` y rollback de todo.

## Por qué además hace falta la 189

**A PUBLIC no se lo puede sacar del default privilege.** Medido sobre Postgres 17 y confirmado sobre Supabase real con una función sonda: `ALTER DEFAULT PRIVILEGES ... REVOKE EXECUTE ON FUNCTIONS FROM PUBLIC` es un no-op, el `acldefault()` built-in se concatena igual. Toda función nueva sigue naciendo con `=X/postgres`.

O sea que el paso 0 **convierte en correcto** el patrón `REVOKE ... FROM PUBLIC` que hoy está roto en 40 migraciones (ya no queda un `anon=X` atrás), pero cada migración nueva **sigue teniendo que revocar**. La garantía de no recaída no es el ALTER: es el gate.

La 189 agrega `auditoria_permisos_execute()` + `scripts/check-permisos.mjs`, colgado del workflow de integridad. Falla si `expuestas_a_anon > 0`. También reporta el riesgo residual (11 `SECURITY DEFINER` sin gate propio alcanzables por `authenticated`) como backlog informativo, sin romper el gate.

## Cómo se verificó

- **Fixture en Docker** (Postgres 17) reproduciendo el entorno de Supabase: el bug se reproduce exacto, y se probó que el trigger **sigue disparando** sin `EXECUTE` (el permiso se chequea en `CREATE TRIGGER`, no cuando dispara), que los wrappers DEFINER siguen llamando al helper, y que `anon` y `authenticated` quedan afuera.
- **Contra prod, antes de aplicar**: las 96 RPCs que llama `src/` existen todas (cero drift), ninguna cae en los patrones de "interno", y **no hay funciones con owner distinto de `postgres`** (o sea que ningún REVOKE iba a fallar en silencio).
- **Dry-run del archivo entero** dentro de `BEGIN … ROLLBACK`. Falló a la primera y con razón: mi chequeo del default privilege no filtraba por `defaclrole` y daba falso positivo por la entrada de `supabase_admin`. Corregido y vuelto a correr: los cuatro bloques pasaron.

**Después de aplicar**: 0 funciones ejecutables por anon (eran 132), 0 con PUBLIC, 0 con grant explícito a anon, 210 con `service_role`, 140 con `authenticated`.

## Dependencias

Nada dependía de ese acceso. La web entra como `authenticated` (requiere login, no hay RPC pre-sesión); el bot de Telegram, las edge functions y `scripts/check-*.mjs` usan `service_role`.

## Ojo con esto

Las **188/189 quedaron intercaladas con las 186/187** de la rama de aislamiento por sucursal, que se aplicaron a prod con minutos de diferencia. El número de archivo no refleja el orden de aplicación; está documentado en `MANIFEST.md § E`. La **187 entró después del barrido** y no quedó nada abierto porque no creó funciones — si hubiera creado una, el gate la habría marcado. Es exactamente el escenario para el que existe.

## Reversión

```sql
ALTER DEFAULT PRIVILEGES FOR ROLE postgres IN SCHEMA public
  GRANT EXECUTE ON FUNCTIONS TO anon;
GRANT EXECUTE ON ALL FUNCTIONS IN SCHEMA public TO anon;
```

---

Migraciones **ya aplicadas a prod** (`188_anon_deja_de_ejecutar_rpcs`, `189_auditoria_de_permisos_execute`), registradas en el ledger con el mismo nombre que el archivo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
