### PR TITLE
Que el backlog de pedidos trabados se vea (+ mig 183: cerrar recorridos terminados)

### DIFF
--- a/migrations/183_cerrar_recorridos_terminados.sql
+++ b/migrations/183_cerrar_recorridos_terminados.sql
@@ -1,0 +1,104 @@
+-- =========================================================================
+-- 183_cerrar_recorridos_terminados.sql
+--
+-- Nada cierra un recorrido. `completarRecorrido` existe en el front desde hace
+-- meses (useRecorridos.ts) y NADIE la llama: el estado terminal se diseño y
+-- nunca se cableo. Resultado al 2026-08-19: de 86 recorridos, 85 estan en
+-- `en_curso` y son de dias pasados. El mas viejo es del 2026-06-15, y
+-- `completado` tiene CERO filas en toda la tabla.
+--
+-- No es cosmetico: cualquier lectura del estado de la flota ("cuantas rutas hay
+-- en curso") da 85 en vez de 1, y obliga a que la pantalla del chofer filtre por
+-- fecha para no mostrar una ruta de junio.
+--
+-- QUE SE CIERRA Y QUE NO
+-- -----------------------
+-- Los numeros dicen que la enorme mayoria de esas rutas SI se hicieron: de 1917
+-- paradas en recorridos vencidos, 1896 estan entregadas (98,9%) y ninguna
+-- cancelada. O sea, el chofer repartio y nadie marco la ruta como cerrada.
+--
+-- Pero 21 paradas siguen en `asignado`, y estan concentradas en apenas 2
+-- recorridos. Esas NO se tocan: cerrar una ruta con entregas pendientes seria
+-- declarar terminado un reparto que no se hizo, y esconderia justamente los
+-- pedidos que hay que rescatar. Son los mismos 21 pedidos trabados que el panel
+-- de "pedidos frenados" pone a la vista para que alguien decida.
+--
+-- Por eso `cerrar_recorridos_vencidos` cierra SOLO lo que esta probadamente
+-- terminado: recorridos de fecha pasada sin ninguna parada pendiente.
+-- =========================================================================
+
+-- -------------------------------------------------------------------------
+-- 1 · La funcion
+-- -------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.cerrar_recorridos_vencidos(
+  p_sucursal_id BIGINT DEFAULT NULL
+)
+RETURNS TABLE (cerrados INT, con_pendientes INT)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $$
+DECLARE
+  v_cerrados INT := 0;
+  v_pendientes INT := 0;
+BEGIN
+  -- SECURITY DEFINER + GRANT a `authenticated` = cualquier usuario logueado
+  -- puede invocarla. Cerrar rutas de toda la sucursal es de admin/encargado.
+  -- `current_user <> 'authenticated'` exime a las corridas por consola y a
+  -- otras RPCs, igual que hace `pedidos_proteger_columnas` (mig 181).
+  IF current_user = 'authenticated' AND NOT es_encargado_o_admin() THEN
+    RAISE EXCEPTION 'Solo un admin o encargado puede cerrar recorridos vencidos'
+      USING ERRCODE = '42501';
+  END IF;
+
+  -- Un recorrido esta terminado cuando ninguna de sus paradas sigue esperando.
+  -- `asignado` es el unico estado que significa "todavia hay que ir"; entregado,
+  -- cancelado y anulado son desenlaces.
+  WITH vencidos AS (
+    SELECT r.id,
+           EXISTS (
+             SELECT 1
+             FROM recorrido_pedidos rp
+             JOIN pedidos p ON p.id = rp.pedido_id
+             WHERE rp.recorrido_id = r.id
+               AND p.estado = 'asignado'
+           ) AS tiene_pendientes
+    FROM recorridos r
+    WHERE r.estado = 'en_curso'
+      AND r.fecha < CURRENT_DATE
+      AND (p_sucursal_id IS NULL OR r.sucursal_id = p_sucursal_id)
+  ),
+  cerrados_ahora AS (
+    UPDATE recorridos r
+       SET estado = 'completado',
+           completed_at = COALESCE(r.completed_at, (r.fecha + TIME '23:59')::timestamptz)
+      FROM vencidos v
+     WHERE v.id = r.id
+       AND NOT v.tiene_pendientes
+    RETURNING r.id
+  )
+  SELECT
+    (SELECT count(*) FROM cerrados_ahora),
+    (SELECT count(*) FROM vencidos WHERE tiene_pendientes)
+  INTO v_cerrados, v_pendientes;
+
+  RETURN QUERY SELECT v_cerrados, v_pendientes;
+END;
+$$;
+
+COMMENT ON FUNCTION public.cerrar_recorridos_vencidos(BIGINT) IS
+  'Cierra los recorridos de fecha pasada que ya no tienen paradas pendientes. '
+  'Los que SI tienen entregas sin resolver quedan abiertos a proposito: cerrarlos '
+  'declararia terminado un reparto que no se hizo y esconderia los pedidos a '
+  'rescatar. Devuelve (cerrados, con_pendientes). Ver mig 183.';
+
+-- Solo admin/encargado: cierra rutas de toda la sucursal.
+REVOKE ALL ON FUNCTION public.cerrar_recorridos_vencidos(BIGINT) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.cerrar_recorridos_vencidos(BIGINT) TO authenticated;
+
+-- -------------------------------------------------------------------------
+-- 2 · Limpieza de lo acumulado
+-- -------------------------------------------------------------------------
+-- Se corre una vez para las ~83 rutas que quedaron abiertas desde junio. Las 2
+-- que tienen paradas pendientes sobreviven y quedan visibles.
+SELECT * FROM public.cerrar_recorridos_vencidos();

--- a/src/components/containers/PedidosContainer.tsx
+++ b/src/components/containers/PedidosContainer.tsx
@@ -15,6 +15,7 @@ import {
 } from '../../utils/descuentoCliente'
 import { construirOrigenPrecioItems, type OrigenPrecioItem } from '../../utils/origenPrecio'
 import PanelPedidosNoEntregados from '../pedidos/PanelPedidosNoEntregados'
+import PanelPedidosTrabados from '../pedidos/PanelPedidosTrabados'
 import { fechaLocalISO, fechaHaceDias, getFormaPagoDisplay, formatPrecio } from '../../utils/formatters'
 import { explicarErrorDeSesion } from '../../utils/sesionVencida'
 import { preventistaPuedeEditar } from '../../utils/permisosPedido'
@@ -1866,6 +1867,17 @@ export default function PedidosContainer(): React.ReactElement {
           porque vuelven a 'pendiente' y ahi se confunden con los nuevos. */}
       <div className="mb-3">
         <PanelPedidosNoEntregados />
+      </div>
+
+      {/* Los que quedaron trabados en 'asignado': no los ve el pool de "Armar
+          ruta", asi que sin este panel no aparecen en ninguna pantalla. Dispara
+          el MISMO handler que la fila del pedido — el boton ya existia, lo que
+          faltaba era enterarse de que habia que usarlo. */}
+      <div className="mb-3">
+        <PanelPedidosTrabados
+          enabled={isAdmin || isEncargado}
+          onVolverAPendiente={p => handleVolverAPendiente(p as unknown as PedidoDB)}
+        />
       </div>
 
       <Suspense fallback={<LoadingState />}>

--- a/src/components/pedidos/PanelPedidosTrabados.test.tsx
+++ b/src/components/pedidos/PanelPedidosTrabados.test.tsx
@@ -1,0 +1,71 @@
+/**
+ * PanelPedidosTrabados — el listado que le faltaba al backlog.
+ *
+ * El pool de "Armar ruta" filtra `pendiente`/`en_preparacion`, así que un pedido
+ * que llegó a `asignado` y no se resolvió no aparece en ninguna pantalla. La
+ * salida (volver a pendiente) ya existía; lo que faltaba era enterarse.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+
+const usePedidosTrabadosQuery = vi.fn();
+vi.mock('../../hooks/queries/usePedidosTrabadosQuery', () => ({
+  usePedidosTrabadosQuery: (...args: unknown[]) => usePedidosTrabadosQuery(...args),
+}));
+
+import PanelPedidosTrabados from './PanelPedidosTrabados';
+
+const trabados = [
+  { id: '3001', fecha: '2026-06-24', total: 61600, clienteNombre: 'Kiosco villa amalia', transportistaId: 'chofer-1', diasTrabado: 56 },
+  { id: '3002', fecha: '2026-07-02', total: 12000, clienteNombre: 'Despensa Mi angel', transportistaId: null, diasTrabado: 48 },
+  { id: '3003', fecha: '2026-07-10', total: 9000, clienteNombre: 'Almacen Don Jose', transportistaId: 'chofer-2', diasTrabado: 40 },
+  { id: '3004', fecha: '2026-07-11', total: 5000, clienteNombre: 'Maxikiosco', transportistaId: null, diasTrabado: 39 },
+];
+
+beforeEach(() => usePedidosTrabadosQuery.mockReset());
+
+describe('PanelPedidosTrabados', () => {
+  it('no se muestra para quien no puede resolverlo', () => {
+    usePedidosTrabadosQuery.mockReturnValue({ data: trabados, isLoading: false });
+    const { container } = render(<PanelPedidosTrabados enabled={false} onVolverAPendiente={vi.fn()} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('no se muestra si no hay nada trabado', () => {
+    usePedidosTrabadosQuery.mockReturnValue({ data: [], isLoading: false });
+    const { container } = render(<PanelPedidosTrabados enabled onVolverAPendiente={vi.fn()} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  // La plata colgada y la antigüedad son el motivo para actuar: sin eso el panel
+  // es un aviso más que se ignora.
+  it('dice cuántos son, cuánta plata y qué tan viejo es el peor', () => {
+    usePedidosTrabadosQuery.mockReturnValue({ data: trabados, isLoading: false });
+    render(<PanelPedidosTrabados enabled onVolverAPendiente={vi.fn()} />);
+
+    expect(screen.getByText(/4 pedidos quedaron trabados/)).toBeInTheDocument();
+    expect(screen.getByText(/56 días/)).toBeInTheDocument();
+    expect(screen.getByText(/no aparecen al armar la ruta/i)).toBeInTheDocument();
+  });
+
+  it('rescata el pedido con su transportista, para que se lo desasigne', async () => {
+    const onVolverAPendiente = vi.fn();
+    usePedidosTrabadosQuery.mockReturnValue({ data: trabados, isLoading: false });
+    render(<PanelPedidosTrabados enabled onVolverAPendiente={onVolverAPendiente} />);
+
+    await userEvent.click(screen.getAllByRole('button', { name: /volver a pendiente/i })[0]);
+
+    expect(onVolverAPendiente).toHaveBeenCalledWith({ id: '3001', transportista_id: 'chofer-1' });
+  });
+
+  it('muestra 3 y despliega el resto', async () => {
+    usePedidosTrabadosQuery.mockReturnValue({ data: trabados, isLoading: false });
+    render(<PanelPedidosTrabados enabled onVolverAPendiente={vi.fn()} />);
+
+    expect(screen.queryByText('#3004')).not.toBeInTheDocument();
+    await userEvent.click(screen.getByRole('button', { name: /ver 1 más/i }));
+    expect(screen.getByText('#3004')).toBeInTheDocument();
+  });
+});

--- a/src/components/pedidos/PanelPedidosTrabados.tsx
+++ b/src/components/pedidos/PanelPedidosTrabados.tsx
@@ -1,0 +1,100 @@
+/**
+ * PanelPedidosTrabados
+ *
+ * Pedidos que quedaron en `asignado` y envejecieron ahí: mercadería vendida que
+ * no se entregó, no se canceló, y que el pool de "Armar ruta del día" no ve
+ * porque filtra `pendiente`/`en_preparacion`. Sin este panel no aparecen en
+ * ninguna pantalla — sólo salían con una consulta a mano.
+ *
+ * El botón para rescatarlos ("Volver a pendiente") existía y estaba cableado
+ * desde hace rato. Lo que faltaba era enterarse de que había que usarlo, así que
+ * esto va arriba de /pedidos, donde el admin ya está parado, y dispara la misma
+ * acción que la fila del pedido.
+ *
+ * Hermano de PanelPedidosNoEntregados, que muestra lo del preventista; este es
+ * la vista de admin/encargado.
+ */
+import { useState } from 'react'
+import { AlertTriangle, ChevronDown, ChevronUp, Undo2 } from 'lucide-react'
+import { usePedidosTrabadosQuery, type PedidoTrabado } from '../../hooks/queries/usePedidosTrabadosQuery'
+import { formatPrecio, formatFecha } from '../../utils/formatters'
+
+const VISIBLES_POR_DEFECTO = 3
+
+export interface PanelPedidosTrabadosProps {
+  /** Sólo admin/encargado: la acción de rescate es suya. */
+  enabled: boolean
+  /** Mismo handler que la fila del pedido; abre la confirmación. */
+  onVolverAPendiente: (pedido: { id: string; transportista_id: string | null }) => void
+}
+
+export default function PanelPedidosTrabados({ enabled, onVolverAPendiente }: PanelPedidosTrabadosProps) {
+  const { data: pedidos = [], isLoading } = usePedidosTrabadosQuery(enabled)
+  const [expandido, setExpandido] = useState(false)
+
+  if (!enabled || isLoading || pedidos.length === 0) return null
+
+  const mostrados = expandido ? pedidos : pedidos.slice(0, VISIBLES_POR_DEFECTO)
+  const ocultos = pedidos.length - mostrados.length
+  const plata = pedidos.reduce((s, p) => s + p.total, 0)
+  const masViejo = pedidos.reduce((max, p) => Math.max(max, p.diasTrabado), 0)
+
+  return (
+    <div className="rounded-xl border border-rose-300 dark:border-rose-800/60 bg-rose-50 dark:bg-rose-900/20 p-3">
+      <div className="flex items-start gap-3">
+        <AlertTriangle className="w-5 h-5 shrink-0 mt-0.5 text-rose-600 dark:text-rose-400" aria-hidden="true" />
+        <div className="min-w-0 flex-1">
+          <p className="text-sm font-semibold text-rose-800 dark:text-rose-200">
+            {pedidos.length === 1
+              ? '1 pedido quedó trabado en "asignado"'
+              : `${pedidos.length} pedidos quedaron trabados en "asignado"`}
+            {' · '}
+            <span className="tabular-nums">{formatPrecio(plata)}</span>
+          </p>
+          <p className="text-xs text-rose-700 dark:text-rose-300 mt-0.5">
+            No se entregaron ni se cancelaron, y <strong>no aparecen al armar la ruta</strong>.
+            {masViejo > 0 && ` El más viejo lleva ${masViejo} días.`} Volvelos a pendiente para
+            poder rutearlos de nuevo.
+          </p>
+
+          <ul className="mt-2 space-y-1">
+            {mostrados.map((p: PedidoTrabado) => (
+              <li key={p.id} className="text-xs text-rose-900 dark:text-rose-100 flex flex-wrap items-baseline gap-x-2">
+                <span className="font-medium">#{p.id}</span>
+                <span className="truncate max-w-[14rem]">{p.clienteNombre}</span>
+                {p.fecha && (
+                  <span className="text-rose-600 dark:text-rose-400">
+                    · del {formatFecha(p.fecha)} ({p.diasTrabado} d)
+                  </span>
+                )}
+                <span className="tabular-nums text-rose-700 dark:text-rose-300">{formatPrecio(p.total)}</span>
+                <button
+                  type="button"
+                  onClick={() => onVolverAPendiente({ id: p.id, transportista_id: p.transportistaId })}
+                  className="inline-flex items-center gap-1 font-medium text-rose-800 dark:text-rose-200 hover:underline"
+                >
+                  <Undo2 className="w-3 h-3" aria-hidden="true" />
+                  Volver a pendiente
+                </button>
+              </li>
+            ))}
+          </ul>
+
+          {(ocultos > 0 || expandido) && (
+            <button
+              type="button"
+              onClick={() => setExpandido(!expandido)}
+              className="mt-1.5 inline-flex items-center gap-1 text-xs font-medium text-rose-800 dark:text-rose-200 hover:underline"
+            >
+              {expandido ? (
+                <>Ver menos <ChevronUp className="w-3 h-3" aria-hidden="true" /></>
+              ) : (
+                <>Ver {ocultos} más <ChevronDown className="w-3 h-3" aria-hidden="true" /></>
+              )}
+            </button>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/hooks/queries/usePedidosTrabadosQuery.ts
+++ b/src/hooks/queries/usePedidosTrabadosQuery.ts
@@ -1,0 +1,94 @@
+/**
+ * Pedidos trabados: quedaron en `asignado` y envejecieron ahí.
+ *
+ * El agujero que tapan: el pool de "Armar ruta del día" (`fetchPedidosAsignados`)
+ * filtra `estado IN ('pendiente','en_preparacion')`. Un pedido que llegó a
+ * `asignado` y no se entregó ni se canceló queda fuera de ese pool PARA SIEMPRE
+ * y no aparece en ninguna pantalla.
+ *
+ * Lo importante es que la salida SÍ existe y está cableada desde hace rato:
+ * "Volver a pendiente" (`handleVolverAPendiente` en PedidosContainer) desasigna,
+ * vuelve el pedido a `pendiente` y lo saca de la ruta en curso. El problema
+ * nunca fue que no se pudiera — es que nadie sabía que había que hacerlo.
+ * Falta el listado, no el botón.
+ *
+ * Al 2026-08-19 eran 21 pedidos por $632.600, el más viejo del 24/06.
+ */
+import { useQuery } from '@tanstack/react-query'
+import { supabase } from '../supabase/base'
+import { useSucursal } from '../../contexts/SucursalContext'
+import { pedidosKeys } from './usePedidosQuery'
+
+/**
+ * Días que un pedido puede estar `asignado` antes de considerarse trabado.
+ *
+ * Con 2 días no se cuela ninguno en vuelo: el reparto normal se arma para el día
+ * siguiente y se cierra ese mismo día. En producción el corte es nítido — no hay
+ * ningún pedido `asignado` de entre 2 y 7 días: o son de hoy/ayer, o llevan
+ * semanas.
+ */
+export const DIAS_PARA_CONSIDERAR_TRABADO = 2
+
+export interface PedidoTrabado {
+  id: string
+  fecha: string | null
+  total: number
+  clienteNombre: string
+  transportistaId: string | null
+  /** Días enteros que lleva en `asignado`. */
+  diasTrabado: number
+}
+
+function diasDesde(fecha: string | null): number {
+  if (!fecha) return 0
+  const d = new Date(`${fecha}T12:00:00`)
+  return Math.max(0, Math.floor((Date.now() - d.getTime()) / 86_400_000))
+}
+
+async function fetchPedidosTrabados(sucursalId: number | null): Promise<PedidoTrabado[]> {
+  const corte = new Date()
+  corte.setDate(corte.getDate() - DIAS_PARA_CONSIDERAR_TRABADO)
+  const corteISO = corte.toISOString().slice(0, 10)
+
+  let query = supabase
+    .from('pedidos')
+    .select('id, fecha, total, transportista_id, cliente:clientes(nombre_fantasia, razon_social)')
+    .eq('estado', 'asignado')
+    .lt('fecha', corteISO)
+
+  if (sucursalId != null) query = query.eq('sucursal_id', sucursalId)
+
+  const { data, error } = await query.order('fecha', { ascending: true })
+  if (error) throw error
+
+  return (data || []).map(p => {
+    // PostgREST devuelve el embed como objeto o array segun la relacion.
+    const c = p.cliente as unknown
+    const cliente = (Array.isArray(c) ? c[0] : c) as
+      | { nombre_fantasia?: string; razon_social?: string }
+      | null
+    return {
+      id: String(p.id),
+      fecha: p.fecha as string | null,
+      total: Number(p.total) || 0,
+      clienteNombre: cliente?.nombre_fantasia || cliente?.razon_social || 'Cliente',
+      transportistaId: (p.transportista_id as string | null) ?? null,
+      diasTrabado: diasDesde(p.fecha as string | null),
+    }
+  })
+}
+
+/**
+ * Solo para admin/encargado: la acción de rescate (volver a pendiente) es suya.
+ * Un preventista vería únicamente los propios por RLS, pero no puede resolverlos,
+ * así que mostrárselos sería ruido.
+ */
+export function usePedidosTrabadosQuery(enabled = false) {
+  const { currentSucursalId } = useSucursal()
+  return useQuery({
+    queryKey: [...pedidosKeys.all(currentSucursalId), 'trabados'] as const,
+    queryFn: () => fetchPedidosTrabados(currentSucursalId),
+    enabled,
+    staleTime: 5 * 60 * 1000,
+  })
+}


### PR DESCRIPTION
Cuarta tanda de la auditoría adversarial. Cierra el **#3**. Continúa [#476](https://github.com/AgustinReiden/distribuidora-app/pull/476), [#477](https://github.com/AgustinReiden/distribuidora-app/pull/477) y [#478](https://github.com/AgustinReiden/distribuidora-app/pull/478).

## El agujero

Un pedido que llegó a `asignado` y no se entregó ni se canceló **queda fuera del pool de "Armar ruta del día" para siempre**: `fetchPedidosAsignados` filtra `estado IN ('pendiente','en_preparacion')`. No aparecía en ninguna pantalla — sólo salía con una consulta a mano.

Al 2026-08-19: **21 pedidos, $632.600, el más viejo del 24/06.**

La salida ya existía y estaba cableada — "Volver a pendiente" desasigna, vuelve a `pendiente` y saca el pedido de la ruta en curso. **El problema nunca fue que no se pudiera, era que nadie sabía que había que hacerlo.** Faltaba el listado, no el botón, así que el panel dispara el mismo handler que la fila del pedido.

Va arriba de `/pedidos` y dice las dos cosas que mueven a actuar: cuánta plata hay colgada y cuántos días lleva el peor.

## mig 183 — nadie cierra un recorrido

`completarRecorrido` existe en `useRecorridos.ts` desde hace meses y **no la llama nadie**: el estado terminal se diseñó y nunca se cableó. De 86 recorridos, 85 estaban `en_curso` con fecha pasada, el más viejo del 15/06, y `completado` tenía **cero filas**.

Es la causa de fondo del recorte que tuve que hacer en el fallback de madrugada del [#478](https://github.com/AgustinReiden/distribuidora-app/pull/478).

**Cierra sólo lo probadamente terminado**, y los números lo justifican: de 1917 paradas en recorridos vencidos, **1896 están entregadas (98,9%)** y ninguna cancelada — el chofer repartió y nadie marcó la ruta como cerrada. Pero 21 paradas siguen en `asignado` y están concentradas en **2 recorridos**: ésos no se tocan, porque cerrarlos declararía terminado un reparto que no se hizo y escondería justo los pedidos a rescatar.

Son los mismos 21 que muestra el panel. Las dos mitades del PR atacan el mismo problema desde los dos lados.

**Ya aplicada a producción**: 83 cerradas, quedan 3 `en_curso` (la de hoy + las 2 con pendientes). La función lleva guard de rol propio — es `SECURITY DEFINER` y está grantada a `authenticated`, así que sin el chequeo cualquier usuario logueado podría cerrar rutas de toda la sucursal. Verifiqué los permisos post-aplicación: sin `PUBLIC` ni `anon`.

## Verificación

- **Sin `.env`, como hace CI**: 1174 tests, typecheck, lint y build. (Lo aprendí a la mala en el #478: el `.env` del worktree enmascara fallos de import.)
- 5 tests nuevos del panel: gating por rol, listado vacío, el resumen de plata/antigüedad, el payload del rescate y el desplegable.

## Un aparte que no es mío

Las migraciones **186, 187, 188 y 189 se aplicaron a producción hoy** (aislamiento por sucursal y permisos EXECUTE) y **no tienen archivo en `migrations/`** en esta rama — supongo que están en otra sin mergear. No las toqué. Vale confirmarlo antes de que el número quede huérfano en el ledger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
