### PR TITLE
Que el gate de integridad deje de mentir en verde

### DIFF
--- a/.github/workflows/integridad.yml
+++ b/.github/workflows/integridad.yml
@@ -23,38 +23,64 @@ jobs:
         with:
           node-version: '20'
 
-      - name: Correr batería de invariantes
+      # Un solo lugar donde se verifica que los secrets estén, y FALLA si no.
+      #
+      # Antes cada paso traía su propio `if [ -z ... ]; then warning; exit 0; fi`.
+      # Los secrets nunca existieron —el repo tiene SUPABASE_DB_URL y
+      # SUPABASE_ACCESS_TOKEN, no estos dos— así que las 52 corridas entre el
+      # 2026-06-30 y el 2026-08-19 salieron VERDES sin chequear una sola cosa, en
+      # 15 segundos: checkout, setup y cuatro warnings que nadie mira. Un gate que
+      # da luz verde cuando no puede mirar es peor que no tener gate, porque el
+      # tilde verde se lee como "verificado".
+      #
+      # Este paso convierte "no puedo chequear" en rojo, que es lo que es. Y al
+      # estar una sola vez, el paso que agregue el próximo no puede nacer con el
+      # bug de vuelta.
+      #
+      # No hay caso legítimo de correr esto sin secrets: el workflow sólo dispara
+      # por `schedule` y `workflow_dispatch` sobre el repo de origen. No corre en
+      # forks ni en PRs.
+      - name: Verificar que los secrets estén configurados
         env:
           SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
           SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
         run: |
-          if [ -z "$SUPABASE_URL" ] || [ -z "$SUPABASE_SERVICE_ROLE_KEY" ]; then
-            echo "::warning::Faltan secrets SUPABASE_URL / SUPABASE_SERVICE_ROLE_KEY — gate omitido."
-            exit 0
+          faltan=""
+          [ -z "$SUPABASE_URL" ] && faltan="$faltan SUPABASE_URL"
+          [ -z "$SUPABASE_SERVICE_ROLE_KEY" ] && faltan="$faltan SUPABASE_SERVICE_ROLE_KEY"
+          if [ -n "$faltan" ]; then
+            echo "::error::Faltan los secrets:$faltan — el gate NO puede correr y por eso falla."
+            echo "Cargalos en Settings > Secrets and variables > Actions."
+            echo "SUPABASE_SERVICE_ROLE_KEY es la service_role key (Settings > API en Supabase), NO la anon."
+            exit 1
           fi
-          node scripts/check-integridad.mjs
+          echo "Secrets presentes. Corriendo los cuatro chequeos contra prod."
+
+      # Los cuatro van con `if: always()` para que una corrida diga TODO lo que
+      # está mal de una vez, en vez de esconder los tres siguientes detrás del
+      # primero que falle. Si el paso de arriba falló, igual corren y mueren solos
+      # con "Faltan SUPABASE_URL / SUPABASE_SERVICE_ROLE_KEY" (exit 2): ruidoso a
+      # propósito, que es lo contrario de lo que hacían antes.
+      - name: Correr batería de invariantes
+        if: always()
+        env:
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+        run: node scripts/check-integridad.mjs
 
       - name: Aislamiento por sucursal (FK compuestas)
+        if: always()
         env:
           SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
           SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
-        run: |
-          if [ -z "$SUPABASE_URL" ] || [ -z "$SUPABASE_SERVICE_ROLE_KEY" ]; then
-            echo "::warning::Faltan secrets — gate de sucursal omitido."
-            exit 0
-          fi
-          node scripts/check-sucursal-cruzada.mjs
+        run: node scripts/check-sucursal-cruzada.mjs
 
       - name: Drift-check de migraciones (repo vs prod)
+        if: always()
         env:
           SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
           SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
-        run: |
-          if [ -z "$SUPABASE_URL" ] || [ -z "$SUPABASE_SERVICE_ROLE_KEY" ]; then
-            echo "::warning::Faltan secrets — drift-check omitido."
-            exit 0
-          fi
-          node scripts/check-migrations.mjs
+        run: node scripts/check-migrations.mjs
 
       # Falla si alguna función de public volvió a quedar ejecutable con la anon
       # key. Ver migrations/188 y migrations/README.md § Permisos.
@@ -63,9 +89,4 @@ jobs:
         env:
           SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
           SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
-        run: |
-          if [ -z "$SUPABASE_URL" ] || [ -z "$SUPABASE_SERVICE_ROLE_KEY" ]; then
-            echo "::warning::Faltan secrets — chequeo de permisos omitido."
-            exit 0
-          fi
-          node scripts/check-permisos.mjs
+        run: node scripts/check-permisos.mjs


### PR DESCRIPTION
## El problema

Las **52 corridas** del workflow `Integridad de datos` entre el 2026-06-30 y el 2026-08-19 salieron **todas `success`, sin chequear absolutamente nada**, en ~15 segundos cada una (checkout + setup node + cuatro warnings).

Los secrets `SUPABASE_URL` y `SUPABASE_SERVICE_ROLE_KEY` **nunca existieron en el repo**. `gh secret list` devuelve `SUPABASE_DB_URL` y `SUPABASE_ACCESS_TOKEN`, que son otros. Y cada paso traía su propio guard:

```bash
if [ -z "$SUPABASE_URL" ] || [ -z "$SUPABASE_SERVICE_ROLE_KEY" ]; then
  echo "::warning::Faltan secrets — gate omitido."
  exit 0
fi
```

`exit 0` convierte "no puedo chequear" en "chequeé y está todo bien".

## Qué llevaba 51 días sin correr

Los cuatro chequeos, no uno:

- la batería de invariantes (`auditoria_integridad()`)
- el drift-check de migraciones repo vs prod
- el chequeo de permisos EXECUTE / anon (mig 188)
- el aislamiento por sucursal (migs 186/187)

El tilde verde se lee como "verificado", así que esto era **peor que no tener gate**: daba confianza falsa sobre cuatro cosas distintas a la vez. Se descubrió al lanzar el workflow a mano para confirmar el chequeo nuevo de la #479.

## El arreglo

Un **único** paso que verifica los secrets y **falla** si no están, en lugar de cuatro copias del mismo `exit 0`. Al estar una sola vez, el paso que agregue el próximo no puede nacer con el bug de vuelta.

Los cuatro chequeos pasan a `if: always()` para que una corrida diga **todo** lo que está mal de una vez, en vez de esconder los tres siguientes detrás del primero que falle. Los cuatro scripts ya salen con `exit 2` si les falta el env (verificado), así que ninguna rama queda en silencio.

No hay caso legítimo de correr esto sin secrets: el workflow sólo dispara por `schedule` y `workflow_dispatch` sobre el repo de origen, nunca en forks ni en PRs.

## Lo que hay que hacer además de mergear

Cargar los dos secrets en **Settings → Secrets and variables → Actions**:

- `SUPABASE_URL` — la URL del proyecto
- `SUPABASE_SERVICE_ROLE_KEY` — la **service_role** key (Supabase → Settings → API), **no** la anon

**Hasta que estén cargados, el workflow va a salir rojo todos los días.** Es correcto: está roto desde junio y recién ahora se ve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
