### PR TITLE
Que el drift-check distinga una consolidación de un agujero

### DIFF
--- a/migrations/190b_pagos_forzar_usuario_no_definer.sql
+++ b/migrations/190b_pagos_forzar_usuario_no_definer.sql
@@ -1,0 +1,57 @@
+-- ============================================================================
+-- 190b · pagos_forzar_usuario deja de ser SECURITY DEFINER
+-- ============================================================================
+-- ARCHIVO ESCRITO DESPUÉS DE APLICAR. La migración se aplicó a prod el
+-- 2026-08-19 (ledger `20260819200704 190b_pagos_forzar_usuario_no_definer`) sin
+-- dejar archivo en el repo. El drift-check lo detectó al día siguiente de que el
+-- gate empezara a correr de verdad — que es exactamente para lo que está.
+--
+-- El cuerpo de abajo NO está reconstruido de memoria: sale de
+-- `pg_get_functiondef()` contra prod, que es la regla de este repo para tocar
+-- algo que ya está vivo (ver MANIFEST y la nota de la 167).
+--
+-- QUÉ ARREGLA. El trigger de la 190 nació `SECURITY DEFINER`, y eso rompe en
+-- silencio el guard que la propia función usa: adentro de una SECURITY DEFINER
+-- `current_user` es SIEMPRE el dueño, nunca 'authenticated', así que la primera
+-- rama tomaba de largo para todo el mundo y `usuario_id` dejaba de forzarse.
+-- Es la misma trampa que documenta la 181 para `pedidos_proteger_columnas` y
+-- `clientes_proteger_columnas_preventista` (mig 080): **un trigger dispara
+-- igual aunque quien escriba sea SECURITY DEFINER —eso saltea RLS, no
+-- triggers—, así que la exención se hace con `current_user`, y para que
+-- `current_user` sirva la función NO puede ser DEFINER.**
+--
+-- Idempotente: es un CREATE OR REPLACE del estado que ya está vivo.
+-- ============================================================================
+
+BEGIN;
+
+CREATE OR REPLACE FUNCTION public.pagos_forzar_usuario()
+ RETURNS trigger
+ LANGUAGE plpgsql
+ SET search_path TO 'public'
+AS $function$
+BEGIN
+  IF current_user <> 'authenticated' THEN
+    RETURN NEW;
+  END IF;
+
+  IF es_admin() AND NEW.usuario_id IS NOT NULL THEN
+    RETURN NEW;
+  END IF;
+
+  NEW.usuario_id := auth.uid();
+  RETURN NEW;
+END;
+$function$;
+
+COMMIT;
+
+-- ----------------------------------------------------------------------------
+-- Verificación
+--
+--   -- Tiene que decir false. Si vuelve a decir true, el guard de current_user
+--   -- dejó de filtrar y no lo va a avisar nadie.
+--   SELECT proname, prosecdef FROM pg_proc p
+--     JOIN pg_namespace n ON n.oid = p.pronamespace AND n.nspname = 'public'
+--    WHERE proname = 'pagos_forzar_usuario';   -- pagos_forzar_usuario | f
+-- ----------------------------------------------------------------------------

--- a/migrations/191_pagos_forzar_usuario_sin_public.sql
+++ b/migrations/191_pagos_forzar_usuario_sin_public.sql
@@ -1,0 +1,55 @@
+-- ============================================================================
+-- 191 · Sacarle a PUBLIC el EXECUTE de pagos_forzar_usuario()
+-- ============================================================================
+-- Lo encontró `scripts/check-permisos.mjs` en la primera corrida real del gate
+-- (2026-08-19): 212 funciones en `public`, 1 ejecutable por `anon`.
+--
+-- No es un descuido de quien escribió la 190: es el comportamiento por defecto
+-- que la **188** vino a cerrar y que vuelve solo con cada función nueva.
+-- Supabase le da EXECUTE a `anon` explícitamente Y deja el grant implícito a
+-- PUBLIC, y a PUBLIC no se lo puede sacar del default privilege. Por eso la 188
+-- dejó el gate de CI: la única defensa posible es detectarlo cada vez, no
+-- prevenirlo de una.
+--
+-- El ACL vivo lo muestra: `=X/postgres` (PUBLIC) es lo que la deja abierta.
+--
+-- SOBRE LA GRAVEDAD, sin inflarla: `pagos_forzar_usuario()` es una función de
+-- TRIGGER (`RETURNS trigger`), y PostgreSQL **no deja invocar directamente** una
+-- función de trigger — muere con "trigger functions can only be called as
+-- triggers". Así que el EXECUTE abierto no era explotable. Se cierra igual, por
+-- dos razones: la regla del gate es "cero funciones alcanzables por anon" y una
+-- regla con excepciones caso por caso deja de ser verificable; y el día que
+-- alguien la convierta en una función normal, la puerta ya estaría abierta.
+--
+-- `REVOKE ... FROM PUBLIC, anon` con las DOS mitades, que es la lección de la
+-- 188: sacarle a una sola no alcanza porque `anon` entra por las dos vías.
+-- ============================================================================
+
+BEGIN;
+
+REVOKE EXECUTE ON FUNCTION public.pagos_forzar_usuario() FROM PUBLIC, anon;
+
+COMMIT;
+
+-- ----------------------------------------------------------------------------
+-- Rollback
+--
+--   GRANT EXECUTE ON FUNCTION public.pagos_forzar_usuario() TO PUBLIC;
+--
+-- No hay motivo para hacerlo: el trigger sigue disparando igual, porque un
+-- trigger no pasa por el EXECUTE de quien escribe en la tabla.
+-- ----------------------------------------------------------------------------
+
+-- ----------------------------------------------------------------------------
+-- Verificación
+--
+--   SELECT has_function_privilege('anon','public.pagos_forzar_usuario()','EXECUTE');
+--   -- false
+--
+--   -- Y el gate entero, que es lo que importa — expuestas_a_anon = 0:
+--   SELECT auditoria_permisos_execute();
+--
+--   -- El trigger sigue vivo y forzando el usuario:
+--   SELECT tgname, tgenabled FROM pg_trigger
+--    WHERE tgrelid = 'public.pagos'::regclass AND NOT tgisinternal;
+-- ----------------------------------------------------------------------------

--- a/migrations/MANIFEST.md
+++ b/migrations/MANIFEST.md
@@ -98,6 +98,12 @@ desfasan y **se realinean en `101`**:
 | `165_saldo_a_favor_no_queda_atrapado.sql` | `165_…` (guard + helpers + trigger) + `165_…_rpcs_fifo` (las 2 RPCs FIFO) — aplicado en 2 tandas por tamaño |
 | (bot 014–020) | hotfix `020_bot_fix_pgcrypto_schema` plegado en la tanda, sin archivo propio |
 
+> Las tres consolidaciones que están **por encima del snapshot** (`123`, `139`, `165`) viven
+> además declaradas en `CONSOLIDACIONES`, adentro de `scripts/check-migrations.mjs`. Si tocás
+> una, tocá las dos. El script exime esas filas del ledger; sin la declaración el drift-check
+> queda **rojo para siempre** por migraciones perfectamente sanas — que fue exactamente lo que
+> pasó en su primera corrida real (9 de 10 hallazgos eran esto).
+
 **Cadena `reporte_gerencial`** (reescrita ~9 veces por `CREATE OR REPLACE`): el repo versiona
 los hitos (`095`, `097` grants, `098`, `103`, `106`, `107`, `110`). Los intermedios del ledger
 `reporte_gerencial_restringir_por_sucursal_asignada` y `reporte_gerencial_desglose_bonif_mermas`
@@ -131,22 +137,32 @@ funcional** y no se renombran los archivos: renombrarlos los desalinearía del l
 real lo da `version` y está en la sección A: en los dos casos el archivo de `main` quedó
 cronológicamente **fuera** del bloque 139–147 (uno antes, otro entre la 144 y la 145).
 
-**La próxima migración es la 188.** Al 2026-08-19 el rango 182–187 está tomado y
-sólo la **182** llegó a `main`:
+**La próxima migración es la 192.** Estado al 2026-08-19 (todo lo de abajo está
+aplicado, salvo donde se aclara):
 
-| NN | dónde vive | estado |
-|----|------------|--------|
-| 182 | `main` | `182_pagos_fecha_en_hora_argentina`, aplicada — **es la última del ledger**, verificado el 2026-08-19 |
-| 183 | rama de cargos de compra (abierta) | `183_compra_cargos_prorrateo` |
-| 184 | rama de cargos de compra (abierta) | `184_compra_cargos_funciones` |
-| 185 | rama de cargos de compra (abierta) | reservada en el encabezado de la 183 (RPCs + check de integridad); todavía sin archivo |
-| 186 | rama de aislamiento por sucursal | `186_quien_cruza_de_sucursal`, **aplicada 2026-08-19** |
-| 187 | rama de aislamiento por sucursal | `187_la_hija_no_cruza_de_sucursal`, **aplicada 2026-08-19** |
+| NN | estado |
+|----|--------|
+| 182 | `182_pagos_fecha_en_hora_argentina` |
+| 183 | `183_cerrar_recorridos_terminados` |
+| 184–185 | **libres en `main`, pero reservadas** por la rama de cargos de compra (ver abajo) |
+| 186 | `186_quien_cruza_de_sucursal` |
+| 187 | `187_la_hija_no_cruza_de_sucursal` |
+| 188 | `188_anon_deja_de_ejecutar_rpcs` |
+| 189 | `189_auditoria_de_permisos_execute` |
+| 190 | `190_guards_de_estado_y_cobranza` |
+| 190b | `190b_pagos_forzar_usuario_no_definer` — aplicada sin archivo; el archivo se escribió después, leyendo el catálogo |
+| 191 | `191_pagos_forzar_usuario_sin_public` |
 
-O sea que **`ls migrations/` sobre `main` te dice 183 y se equivoca por cinco**.
+> ⚠️ **La rama de cargos de compra (`claude/invoice-cost-calculation-370b62`)
+> tiene `183_compra_cargos_prorrateo.sql` y `184_compra_cargos_funciones.sql`, y
+> la 183 ya la ocupó `183_cerrar_recorridos_terminados` en `main`.** Esa rama hay
+> que renumerarla a 192+ antes de mergear. Es la tercera vez que pasa lo mismo
+> (el `167` duplicado, la 183 que nació 182, y ahora ésta): **el número no se
+> reserva escribiendo el archivo, se reserva aplicando la migración.** Mientras
+> la rama esté abierta el número no es de nadie.
+
 Al elegir número hay que mirar las tres cosas: el ledger, `origin/main` y las
-ramas abiertas. La 183 ya se comió esta trampa una vez (nació 182 y tuvo que
-renumerarse porque la 182 se mergeó mientras su rama estaba abierta).
+ramas abiertas.
 
 Las **186** y **187** cierran un agujero de RLS preexistente, encontrado de paso
 al revisar la 183. Las policies de las tablas hijas validan `sucursal_id =

--- a/scripts/check-migrations.mjs
+++ b/scripts/check-migrations.mjs
@@ -23,6 +23,35 @@ import { readdirSync } from 'node:fs';
 const SNAPSHOT_VERSION = '20260630160533'; // 109_migraciones_aplicadas_rpc
 const SNAPSHOT_MAX_FILE = 109;
 
+// Consolidaciones POR ENCIMA del snapshot: N filas del ledger → 1 archivo.
+// Espejo de `migrations/MANIFEST.md § D`. Si agregás una fila acá, agregala allá.
+//
+// Por qué hace falta: el modelo del script era "arriba del snapshot todo es
+// 1:1", y el MANIFEST documenta tres consolidaciones que son 1:N y están arriba
+// del snapshot (123, 139, 165). O sea que el script estaba condenado a marcar
+// drift para siempre por migraciones perfectamente sanas, hiciera lo que hiciera
+// cualquiera. En la primera corrida real del gate fueron 9 de 10 hallazgos.
+//
+// Un gate permanentemente rojo se ignora igual que uno permanentemente verde:
+// las dos formas terminan en nadie mirándolo. Por eso las excepciones legítimas
+// van declaradas, no toleradas.
+//
+// Clave = stem del ledger (sin prefijo NNN_), valor = stem del archivo que la
+// consolida. Se verifica que el archivo exista, así que un typo no pasa.
+const CONSOLIDACIONES = {
+  // 123_terna_ingresos_pedidos.sql — aplicado en 3 tandas por tamaño
+  terna_ingresos_pedidos_rpcs: 'terna_ingresos_pedidos',
+  terna_ingresos_pedidos_rpcs2: 'terna_ingresos_pedidos',
+  // 139_movimientos_stock_preventivo.sql — 5 filas, sin prefijo en el ledger
+  movimientos_stock_preventivo_ddl: 'movimientos_stock_preventivo',
+  movimientos_stock_preventivo_crear: 'movimientos_stock_preventivo',
+  movimientos_stock_preventivo_aceptar: 'movimientos_stock_preventivo',
+  movimientos_stock_preventivo_denegar_cancelar: 'movimientos_stock_preventivo',
+  movimientos_stock_preventivo_editar: 'movimientos_stock_preventivo',
+  // 165_saldo_a_favor_no_queda_atrapado.sql — aplicado en 2 tandas por tamaño
+  saldo_a_favor_no_queda_atrapado_rpcs_fifo: 'saldo_a_favor_no_queda_atrapado',
+};
+
 const url = process.env.SUPABASE_URL;
 const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
 
@@ -60,14 +89,38 @@ const ledger = await res.json(); // [{ version, name }]
 const ledgerStem = (name) => name.replace(/\s*\(backfill.*$/i, '').replace(/^\d+[a-z]?_/, '').trim();
 
 // --- 3. Diff por encima del snapshot ---
-const nuevosArchivos = files.filter((f) => fileNum(f) > SNAPSHOT_MAX_FILE);
-const nuevasFilas = ledger.filter((m) => m.version > SNAPSHOT_VERSION);
+// `>=` en los dos lados, no `>`. Con `>` el número 109 caía en la grieta: el
+// snapshot ES `109_migraciones_aplicadas_rpc`, así que `109_reporte_alerta_
+// detalle` —mismo número de archivo, aplicado más tarde ese día— quedaba fuera
+// por el lado de los archivos y adentro por el lado del ledger, y se reportaba
+// como "aplicado sin archivo" teniendo el archivo ahí. Con `>=` entran los dos
+// lados del 109 y se aparean solos.
+const nuevosArchivos = files.filter((f) => fileNum(f) >= SNAPSHOT_MAX_FILE);
+const nuevasFilas = ledger.filter((m) => m.version >= SNAPSHOT_VERSION);
 
 const stemsArchivo = new Set(nuevosArchivos.map(fileStem));
 const stemsLedger = new Set(nuevasFilas.map((m) => ledgerStem(m.name)));
 
-const aplicadoSinArchivo = nuevasFilas.filter((m) => !stemsArchivo.has(ledgerStem(m.name)));
-const archivoSinAplicar = nuevosArchivos.filter((f) => !stemsLedger.has(fileStem(f)));
+// Una fila consolidada cuenta como presente si existe el archivo que la consolida.
+const stemsConsolidados = new Set();
+const consolidacionesRotas = [];
+for (const [filaLedger, archivo] of Object.entries(CONSOLIDACIONES)) {
+  if (stemsArchivo.has(archivo)) stemsConsolidados.add(filaLedger);
+  else if (stemsLedger.has(filaLedger)) consolidacionesRotas.push(`${filaLedger} -> ${archivo}.sql`);
+}
+// Y el archivo consolidador cuenta como aplicado si al menos una de sus filas está.
+const archivosConsolidadores = new Set(
+  Object.entries(CONSOLIDACIONES)
+    .filter(([filaLedger]) => stemsLedger.has(filaLedger))
+    .map(([, archivo]) => archivo),
+);
+
+const aplicadoSinArchivo = nuevasFilas.filter(
+  (m) => !stemsArchivo.has(ledgerStem(m.name)) && !stemsConsolidados.has(ledgerStem(m.name)),
+);
+const archivoSinAplicar = nuevosArchivos.filter(
+  (f) => !stemsLedger.has(fileStem(f)) && !archivosConsolidadores.has(fileStem(f)),
+);
 
 // --- 4. Reporte ---
 console.log(`Drift-check de migraciones @ snapshot ${SNAPSHOT_VERSION} (archivos <= ${SNAPSHOT_MAX_FILE} reconciliados en MANIFEST.md)`);
@@ -83,7 +136,19 @@ if (archivoSinAplicar.length) {
   for (const f of archivoSinAplicar) console.log(`   ${f}`);
 }
 
-if (aplicadoSinArchivo.length || archivoSinAplicar.length) {
+// Una consolidación declarada cuyo archivo ya no existe es una excepción podrida:
+// estaría tapando drift real en silencio, que es lo contrario de para qué está.
+if (consolidacionesRotas.length) {
+  console.log('\n❌ Consolidaciones declaradas cuyo archivo no existe (arreglá CONSOLIDACIONES y MANIFEST § D):');
+  for (const c of consolidacionesRotas) console.log(`   ${c}`);
+}
+
+if (Object.keys(CONSOLIDACIONES).some((k) => stemsConsolidados.has(k))) {
+  const n = Object.keys(CONSOLIDACIONES).filter((k) => stemsConsolidados.has(k)).length;
+  console.log(`\nℹ️  ${n} fila(s) del ledger exentas por consolidación declarada (MANIFEST § D).`);
+}
+
+if (aplicadoSinArchivo.length || archivoSinAplicar.length || consolidacionesRotas.length) {
   console.error(
     '\n❌ Drift detectado. Reconciliá (agregá el archivo / aplicá la migración / alineá el name) ' +
     'o, si es legítimo, actualizá migrations/MANIFEST.md y subí el snapshot en este script.',


### PR DESCRIPTION
Primera corrida real del gate (después de la #482), **10 hallazgos de drift + 1 de permisos**. Nueve de los diez eran falsos positivos. Uno era de verdad.

## Los ocho grandes: el script contradecía al MANIFEST

`check-migrations.mjs` asumía *"por encima del snapshot todo es 1:1"*. Pero el MANIFEST documenta en su **§ D** tres consolidaciones que son **1:N y están por encima del snapshot**:

| archivo | filas del ledger |
|---|---|
| `123_terna_ingresos_pedidos.sql` | `_rpcs`, `_rpcs2` |
| `139_movimientos_stock_preventivo.sql` | `_ddl`, `_crear`, `_aceptar`, `_denegar_cancelar`, `_editar` |
| `165_saldo_a_favor_no_queda_atrapado.sql` | `_rpcs_fifo` |

O sea que el drift-check estaba **condenado a salir rojo para siempre** por migraciones perfectamente sanas, hiciera lo que hiciera cualquiera.

Eso importa más de lo que parece: un gate permanentemente rojo se ignora igual que uno permanentemente verde. Las dos formas terminan en nadie mirándolo — y de eso justo veníamos.

Ahora las consolidaciones se **declaran** en un mapa `CONSOLIDACIONES`, espejo de la § D. Y si el archivo que consolida no existe, el script **también falla**: una excepción podrida taparía drift real en silencio, que es lo contrario de para qué está.

## El noveno: un off-by-one en el borde del snapshot

`109_reporte_alerta_detalle` salía como "aplicado sin archivo" **teniendo el archivo ahí**.

El snapshot *es* `109_migraciones_aplicadas_rpc`, y el corte estaba en `> 109` por el lado de los archivos y `> version` por el lado del ledger. El otro 109 —mismo número de archivo, aplicado más tarde ese día— caía justo en la grieta: afuera por un lado, adentro por el otro. Los dos lados pasan a `>=`.

## El que era de verdad

`190b_pagos_forzar_usuario_no_definer` se aplicó a prod **sin dejar archivo**. Se escribe ahora leyendo `pg_get_functiondef()`, que es la regla del repo para tocar algo ya vivo.

Deja anotado por qué esa función **no puede** ser `SECURITY DEFINER`: adentro de una definer `current_user` es siempre el dueño, y el guard de la propia función se apoya justo en `current_user` — misma trampa que documentan la 181 y la 080.

## Y el gate de permisos

Encontró `pagos_forzar_usuario()` ejecutable por `anon`. Va la **191** con el `REVOKE` de las dos mitades (`PUBLIC` **y** `anon`), ya aplicada.

Sin inflarlo: es una función de **trigger**, y PostgreSQL no deja invocarlas directamente, así que no era explotable. Se cierra igual porque la regla del gate es "cero funciones alcanzables por anon", y una regla con excepciones caso por caso deja de ser verificable.

No es un descuido de quien escribió la 190: es el default de Supabase que la **188** vino a cerrar y que vuelve solo con cada función nueva. Por eso la 188 dejó el gate.

## Verificación

Contra el **ledger real de prod** servido por un stub (no tengo la service key):

- antes: 10 hallazgos → después: **0, exit 0**
- con una fila inventada sin archivo: **vuelve a exit 1** — no quedó permisivo
- `auditoria_permisos_execute()`: 212 funciones, **0 expuestas a anon**
- el trigger `trg_pagos_forzar_usuario` sigue vivo

## Aparte: hay una colisión de números esperando

`main` ya tiene `183_cerrar_recorridos_terminados`, y la rama de cargos de compra (`claude/invoice-cost-calculation-370b62`) tiene `183_compra_cargos_prorrateo.sql` + `184_compra_cargos_funciones.sql`. **Esa rama hay que renumerarla a 192+ antes de mergear.**

Es la tercera vez que pasa lo mismo (el `167` duplicado, la 183 que nació 182, y ahora ésta), así que queda escrito en el MANIFEST: **el número no se reserva escribiendo el archivo, se reserva aplicando la migración.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
