### PR TITLE
Motor de costos de compra: repartir cargos y cuadrar el impuesto interno

### DIFF
--- a/docs/plans/2026-08-18-cargos-y-cuadre-de-compras-design.md
+++ b/docs/plans/2026-08-18-cargos-y-cuadre-de-compras-design.md
@@ -1,0 +1,216 @@
+# Cargos prorrateados y cuadre fiscal de compras
+
+Fecha: 2026-08-18 · Estado: diseño aprobado, pendiente de implementación
+
+## El problema
+
+La carga de compras no sabe representar tres cosas que sí existen en una factura real
+(caso testigo: `A0005-00461415` de Manaos, 21 renglones, 13,3 M):
+
+1. **El impuesto interno declarado no coincide con el calculado.** Hoy se cuadra a mano
+   con un factor de ajuste (`1,0496` en el caso testigo, casi 5%).
+2. **El flete, los pallets y los separadores no tienen dónde ir.** Si se cargan como ítem
+   se rompe el stock; si se dejan afuera, el costo unitario queda subvaluado. Y los pallets
+   son **no gravados**: sumarlos al costo del producto haría que se les calcule IVA encima.
+3. **El reparto de esos cargos no es proporcional al monto sino al volumen** (pallets), y
+   algunos aplican sólo a un subconjunto de productos (los separadores, sólo a los bidones).
+
+Magnitud: flete + pallets + separadores son **2.070.800** sobre un costo total sin IVA de
+**12.797.344** — el **16,2% del costo**. Hoy ese 16% no está en ningún lado.
+
+## El impuesto interno no es un misterio: es una regla
+
+Reprodujimos el cálculo bucket por bucket. La diferencia no es ruido ni error de alícuota:
+**no todas las bonificaciones bajan la base del impuesto interno.**
+
+| Alícuota | II calculado | II declarado | Diferencia |
+|---|---:|---:|---:|
+| 4,1667 % | 198.231,81 | 199.027,21 | 795,40 |
+| 8,6956 % | 322.864,60 | 338.884,46 | 16.019,86 |
+
+Calculando el II sobre la base **sin restar la bonificación "PROMO MANAOS 3000cc"**, pero
+**sí restando** la "PROMO COLA 3.00" y el 0,6% general:
+
+| Alícuota | II con base corregida | Declarado | Error |
+|---|---:|---:|---:|
+| 4,1667 % | 199.027,21 | 199.027,21 | 0,00 |
+| 8,6956 % | 338.884,40 | 338.884,46 | 0,06 |
+
+Seis centavos sobre 339 mil. El proveedor trata una promo como **descuento de precio**
+(baja la base imponible) y la otra como **bonificación comercial** (no la baja).
+
+### El modelo además corrige al Excel
+
+El factor de ajuste del Excel reparte la diferencia proporcionalmente al II ya calculado
+de cada línea, o sea **unta el impuesto interno de la promo sobre productos que no
+participaron**. Modelando la causa, cada línea recibe el II de su propia base:
+
+| Línea | II modelo | II Excel | Dif |
+|---|---:|---:|---:|
+| MANAOS COLA 600cc (sin promo) | 47.983,68 | 50.364,52 | −2.380,84 |
+| MANAOS COLA 3000cc (con promo) | 113.961,13 | 112.889,75 | +1.071,38 |
+| MANAOS LIMA LIMON 3000cc (con promo) | 14.890,26 | 14.151,42 | +738,85 |
+
+Los totales por alícuota son idénticos al declarado. Cambia **a quién** se le imputa.
+Es plata chica por pack (~0,35% del costo) pero es exactamente la contaminación que hace
+que un análisis de margen señale al SKU equivocado como rentable.
+
+## Decisiones tomadas
+
+| Tema | Decisión |
+|---|---|
+| Impuesto interno | Modelar la causa (flag por bonificación) + ajuste residual como red de seguridad |
+| Base de prorrateo | Elegible por cargo, con override por línea |
+| Flete y descarga | Cada cargo decide por separado si viene en la factura y si prorratea al costo |
+| Alcance | Sólo el costo. El análisis de margen y el precio de venta quedan para otra etapa |
+| Arquitectura | Cargos persistidos + prorrateo canónico en la RPC; TS sólo para la vista previa |
+
+## Modelo de datos
+
+```sql
+compra_cargos
+  id, compra_id, orden
+  concepto            text          -- "Flete y descarga", "Pallets x 9 tacos"…
+  monto               numeric(12,2) -- SIN IVA. Negativo = bonificación
+  condicion_iva       text          -- gravado | no_gravado | exento  (mig 177)
+  porcentaje_iva      numeric(5,2)
+  en_factura          boolean       -- suma al cuadre contra el papel
+  prorratea_al_costo  boolean       -- entra al costo unitario
+  afecta_base_ii      boolean       -- default: (condicion_iva = 'gravado')
+  base_prorrateo      text          -- monto | cantidad | unidades
+
+compra_cargo_repartos
+  cargo_id, compra_item_id, peso numeric
+```
+
+Dos simplificaciones que salieron del prototipo:
+
+- **El "alcance" no existe como concepto.** Los separadores van 100% al bidón poniendo peso
+  `1` en el bidón y `0` en el resto. Alcance = peso cero. Un solo mecanismo.
+- **Una bonificación es un cargo de monto negativo.** Misma mecánica; cambia sólo
+  `condicion_iva='gravado'` y `afecta_base_ii`. No hacen falta dos entidades.
+
+`base_prorrateo` **sólo pre-llena** el vector de pesos; la verdad siempre es el vector.
+
+Con esto, todo el Excel entra en una sola tabla: flete, pallets, separadores, las dos
+promos y hasta el redondeo de −0,49.
+
+## Motor de cálculo
+
+Por línea:
+
+```
+neto             = cantidad × costo_unitario × (1 − bonif%)
+
+base_iva_factura = neto + Σ cargos gravados CON en_factura         → compras.iva, cuadre
+base_costo       = neto + Σ cargos gravados CON prorratea_al_costo → costo
+base_ii          = neto + Σ cargos gravados CON afecta_base_ii
+ii               = base_ii × ii% × factor_ajuste[alícuota]
+no_grav          = Σ cargos no gravados/exentos CON prorratea_al_costo
+
+costo_real_unitario = (base_costo + ii + no_grav) / cantidad
+```
+
+**Las dos bases están separadas a propósito.** Un flete de transportista inscripto viene con
+IVA 21%: ese IVA es crédito fiscal, no es costo, y no debe tocar el IVA de esta compra. Su
+neto entra al costo; su IVA no entra a ningún lado de esta factura.
+
+`base_iva_factura`, `ii`, `no_grav` e `iva` son exactamente las columnas `Y / Z / AA / AB`
+del Excel. **El IVA se calcula sobre `base_iva_factura`, que nunca incluye cargos no
+gravados** — que es el bug planteado en el punto 2.
+
+### Factor de ajuste residual
+
+Sólo actúa si se carga el II declarado por alícuota. Con `afecta_base_ii` bien puesto da
+`1,000000`. **Si el desvío supera 0,5% el modal avisa** en vez de tapar: deja de ser un
+fudge y pasa a ser un detector de alícuota mal cargada.
+
+### Regla de redondeo
+
+Repartir un monto sobre pesos fraccionarios y redondear a 2 decimales no vuelve a sumar el
+monto original. Regla fija, idéntica en SQL y TS o el test de espejo no puede pasar:
+
+> Redondear cada reparto a 2 decimales; asignar el residuo a la línea de mayor peso,
+> desempatando por menor `compra_item_id`.
+
+## Cambios en funciones existentes
+
+`costo_real_unitario(neto, pct_ii, tipo)` gana un cuarto término aditivo `p_cargo_unitario`.
+**Se reemplaza la firma, no se agrega sobrecarga**: dejar la vieja de 3 argumentos junto a
+una de 4 con `DEFAULT` reproduce la trampa de la mig 176 (rangos de aridad superpuestos →
+ambigüedad invisible para tsc y para los tests). Sus 4 llamadores se actualizan en la misma
+migración: `registrar_compra_completa`, `actualizar_compra_items`, `anular_compra_atomica`,
+`cambiar_proveedor_compra`.
+
+`actualizar_compra_items` hace `DELETE FROM compra_items`. Con una FK a `compra_item_id` con
+`CASCADE`, editar una compra **vaciaría los repartos en silencio**: los cargos quedarían sin
+destino, el costo perdería el 16% y `COMPRA-A2` se pondría rojo sin que nadie tocara un
+cargo. Por eso la RPC de edición pasa a recibir ítems **y** cargos y reescribe ambos; si
+llega sin cargos y la compra tiene, **falla con error explícito**. Un cliente con chunk
+viejo editando una compra con cargos es escenario real en este proyecto, no teórico.
+
+`cambiar_proveedor_compra` clona la compra: debe clonar cargos y repartos.
+
+## Qué NO se toca
+
+`compras.total` y `compras.no_gravado` siguen siendo **de la factura**. El flete
+(`en_factura=false`) no entra ahí: vive sólo en `compra_cargos` y afecta únicamente
+`compra_items.costo_real_unitario` y el costo promedio. Así `COMPRA-A1` sigue en verde y el
+cuadre contra el papel no se ensucia.
+
+## Snapshot por línea
+
+`compra_items` agrega `cargos_unitarios numeric(12,4)`. Con sólo `costo_neto_unitario` y
+`costo_real_unitario` no se puede reconstruir cuánto fue flete y cuánto impuesto interno al
+reabrir la compra.
+
+## Integridad y validaciones
+
+- Check nuevo **`COMPRA-A2`**: Σ repartos de cada cargo = su monto (tolerancia 1 peso).
+- Un cargo con `prorratea_al_costo` y Σ pesos = 0 → error al guardar.
+- `cantidad = 0` en una línea → guarda contra división por cero (hoy 0 casos en prod).
+- RLS en las dos tablas nuevas, espejando la de `compra_items`.
+
+## UX del modal
+
+Sección **"Cargos y prorrateo"**, plegada por defecto. Con 4,1 ítems promedio por compra, la
+compra chica ni la ve.
+
+- `+ Agregar cargo` → concepto, monto **sin IVA**, tratamiento, dos casillas (*viene en la
+  factura* / *entra al costo*), base de reparto.
+- Al elegir base `unidades` se abre una grilla con una celda por línea, pre-llenada.
+- **`Traer cargos de la última compra de este proveedor`** — flete y pallets se repiten en
+  cada factura de Manaos. Sin esto el reparto manual no es sostenible; con esto, una factura
+  nueva es cargar los cargos y ajustar dos números.
+- Vista previa por línea con las 4 columnas del Excel + costo unitario final.
+- "Control contra factura" se extiende con el II declarado **por alícuota** y su desvío.
+
+## Rollout
+
+Forward-only, como el CPP (migs 127-131): las 63 compras FC existentes no tienen cargos →
+`Σ cargos = 0` → costo idéntico al de hoy. **Cero backfill.**
+
+Aviso necesario antes de que aparezca en el dashboard: **el margen reportado de estos
+productos va a bajar ~15 puntos.** No es una regresión — es que hasta hoy el 16% del costo
+no estaba en ningún lado.
+
+## Limitaciones conocidas (fuera de alcance)
+
+- **Una factura repartida entre sucursales.** La hoja `COMO_INGRESAR_LA_FAC.AL SISTEMA` del
+  Excel parte la misma factura entre Taco Pozo y Tucumán. Hoy eso son dos compras distintas,
+  así que el monto del cargo que se carga es **el de esa sucursal** y hay que dividirlo a
+  mano. Resolverlo de verdad ("una factura = N compras") es un cambio de modelo mayor.
+- **Análisis de margen y precio de venta.** Las hojas `AH..AS` y `LISTA PARA PREVENTISTA`
+  del Excel. Dependen de que el costo sea confiable primero.
+- **Notas de crédito posteriores del proveedor.** Es otro flujo.
+
+## Validación del diseño
+
+Se prototipó el motor completo y se contrastó línea por línea contra el Excel:
+
+- Costo total sin IVA: **12.797.344,26** modelo vs **12.797.344,26** Excel — diferencia 0,00.
+- Factor de ajuste residual: **1,000000** en ambas alícuotas (desvío 0,0000%).
+- Los totales de II por alícuota coinciden exactamente con los declarados en la factura.
+
+Las diferencias por línea contra el Excel son las esperadas y documentadas arriba: el
+modelo imputa el impuesto interno a la base real de cada producto en vez de untarlo.

--- a/docs/plans/2026-08-18-cargos-y-cuadre-de-compras.md
+++ b/docs/plans/2026-08-18-cargos-y-cuadre-de-compras.md
@@ -1,0 +1,1310 @@
+# Cargos prorrateados y cuadre fiscal de compras — Plan de implementación
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Que una factura de compra con flete, pallets, separadores y bonificaciones promocionales cargue el costo real correcto en cada producto, y que el impuesto interno cuadre contra el papel sin ajuste manual.
+
+**Architecture:** Una tabla `compra_cargos` con su vector de pesos (`compra_cargo_repartos`) modela todo concepto que no es un renglón de producto. El prorrateo es canónico en la RPC; TypeScript replica el mismo motor sólo para la vista previa del modal, con un test de espejo que ata ambas implementaciones a la factura real `A0005-00461415`.
+
+**Tech Stack:** PostgreSQL/Supabase (RPC plpgsql, RLS), React + TypeScript, Vitest, TanStack Query.
+
+**Diseño de referencia:** `docs/plans/2026-08-18-cargos-y-cuadre-de-compras-design.md` (commit `54dbd94`). Leerlo antes de empezar — explica el *por qué* de cada decisión.
+
+---
+
+## Antes de empezar: cosas que te van a morder
+
+Leé esto entero. Cada punto costó una investigación.
+
+1. **Corré vitest SIEMPRE con `VITEST_MAX_WORKERS=2`, incluido el `git commit`.** Sin eso vitest se autosatura en esta máquina y se cuelga indefinidamente: ya mató a un subagente por watchdog a los 600s y colgó dos commits durante 10 minutos, dejando 26 procesos node huérfanos. Con 2 workers la suite entera corre en **91 segundos**; sin el tope, o tarda 220s o no termina nunca.
+
+   ```bash
+   VITEST_MAX_WORKERS=2 npx vitest run src/utils/prorrateoCompra.test.ts
+   VITEST_MAX_WORKERS=2 git commit -m "..."
+   ```
+
+   El hook de pre-commit corre la suite completa, por eso el commit también necesita la variable. `vite.config.js:374` ya la respeta. Si usás la herramienta Bash, pasale `timeout` de 600000 igual.
+
+2. **`redondear()` de `src/utils/calculations.ts` NO es equivalente a `round(numeric,2)` de Postgres, y arreglar el signo no alcanza.** Hay dos divergencias distintas y es fácil ver sólo la primera:
+   - **Signo:** `redondear` usa `Math.round`, que redondea medio hacia +∞ (`Math.round(-0.5) === -0`); Postgres redondea medio alejándose del cero (`round(-0.5) = -1`). Las bonificaciones son cargos negativos, así que esto pega.
+   - **Representación (la grave):** `Math.abs(1.005) * 100` da `100.49999999999998`, no `100.5`, así que `Math.round` baja y Postgres sube. Verificado contra prod: `1.005 → 1.01` en PG contra `1.00` en JS; igual con `0.145`, `0.565`, `1.025`. En montos de centavo impar repartidos entre 2 líneas, en el rango $1.000–1.400, **divergen el 11,5%**.
+
+   Lo traicionero es que depende de la magnitud de forma impredecible: con los números del flete (73.076,92) no diverge nunca. **Un test de espejo escrito sobre los datos del flete da verde y consagra el bug.** Por eso el test de Task 1 compara contra una tabla calculada en Postgres, no contra valores elegidos en JS.
+
+   Y el fondo: ninguna función sobre `double` puede ser espejo universal de `numeric`, porque `1.005` como double *no es* 1.005. El fix por desplazamiento de exponente cubre el rango del dinero, que es lo que importa acá.
+
+3. **JavaScript acumula error al sumar muchos floats; Postgres `numeric` no.** Sumar los 21 repartos del flete en JS da `1899999.9999999995`, no `1900000`. Cada parte es exacta al centavo, el total no. En los tests de TS, releé el total con `redondearSQL(total, 2)` antes de comparar. En SQL no hace falta: `numeric` es decimal exacto. Esta asimetría es esperada y no significa que el espejo esté roto.
+
+4. **`actualizar_compra_items` hace `DELETE FROM compra_items`.** Una FK de `compra_cargo_repartos` con `ON DELETE CASCADE` vaciaría los repartos en silencio al editar una compra. Por eso la RPC de edición recibe cargos y los reescribe (Task 10).
+
+5. **Nunca dejes dos sobrecargas de una función con rangos de aridad superpuestos.** Una de 3 argumentos y otra de 4 con `DEFAULT` producen `PGRST203` en runtime, invisible para tsc y para los tests. Es la trampa de la mig 176. Se dropea la vieja, no se deja wrapper.
+
+6. **`migrations/` es una vista curada, no es 1:1 con producción.** Verificá siempre contra el catálogo vivo (`pg_get_functiondef`), nunca asumas que el archivo del repo es lo que corre. Ver `migrations/MANIFEST.md` y `npm run check:migrations`.
+
+7. **Los worktrees no tienen `.env`.** Si ves pantalla en blanco o ~22 errores de typecheck, es ambiental. Verificá con `npm run build`.
+
+8. **Nuestras migraciones son la `192`, `193` y `194`.** Y el número hay que reconfirmarlo antes de aplicar, porque **este plan ya perdió el número dos veces**.
+
+   - Primero reservó la `182`, y mientras trabajábamos se mergeó `182_pagos_fecha_en_hora_argentina`. Renumeramos a 183-185.
+   - Después perdió la `183`, cuando otra rama aplicó `183_cerrar_recorridos_terminados`. Y en el mismo rato aparecieron la `186`, `187`, `188` y `189` de otras dos ramas. Renumeramos a 190-192.
+
+   **Mirar tres fuentes, no una.** El repo local es la que menos sirve: desde adentro de un worktree la colisión es **invisible**, porque conserva el estado de su punto de partida y muestra como "última" una migración que dejó de serlo hace rato.
+
+   ```bash
+   git fetch origin                                    # 1. origin/main
+   # 2. el ledger: select max(...) from supabase_migrations.schema_migrations
+   # 3. TODAS las ramas abiertas — es donde la colisión ocurre de verdad:
+   for b in $(git branch -a --format='%(refname:short)' | grep -v HEAD); do
+     git ls-tree --name-only "$b" migrations/ 2>/dev/null | grep -oE '1[0-9]{2}_[a-z_]+' | sort -u | tail -2
+   done | sort -u
+   ```
+
+   El costo no es renombrar el `.sql`: son las referencias cruzadas ya commiteadas —docstrings, `COMMENT ON`, nombres de helpers como `_mig193_reemplazo_unico`, el plan entero— más el rebase. Por eso conviene **reservar tarde**: escribir el contenido primero y numerar al final.
+
+9. **Hay dos implementaciones del hook de compras.** `src/hooks/queries/useComprasQuery.ts` es la viva (la usa `ComprasContainer`). `src/hooks/supabase/useCompras.ts` sólo se exporta desde un barrel y su `registrarCompra` ni siquiera manda `p_tipo_factura` — está muerta. **No la toques**; si algo la usara, se rompería igual hoy.
+
+---
+
+## Fase 1 — Motor de prorrateo en TypeScript
+
+Se hace primero porque es puro, testeable sin base de datos, y fija la semántica que después el SQL tiene que replicar.
+
+### Task 1: Helper de redondeo compatible con Postgres
+
+**Files:**
+- Modify: `src/utils/calculations.ts`
+- Test: `src/utils/calculations.prorrateo.test.ts` (crear)
+
+**Step 1: Escribir el test que falla**
+
+```ts
+import { describe, it, expect } from 'vitest'
+import { redondearSQL } from './calculations'
+
+describe('redondearSQL (espejo de round(numeric, n) de Postgres)', () => {
+  it('redondea medio ALEJANDOSE del cero, no hacia +infinito', () => {
+    // Math.round(-0.5) === -0 → esto es lo que NO queremos
+    expect(redondearSQL(-0.005, 2)).toBe(-0.01)
+    expect(redondearSQL(0.005, 2)).toBe(0.01)
+    expect(redondearSQL(-1.235, 2)).toBe(-1.24)
+    expect(redondearSQL(1.235, 2)).toBe(1.24)
+  })
+
+  it('no devuelve -0 (rompe toBe con Object.is)', () => {
+    expect(Object.is(redondearSQL(-0.001, 2), 0)).toBe(true)
+  })
+
+  it('casos triviales', () => {
+    expect(redondearSQL(1900000 / 26, 2)).toBe(73076.92)
+    expect(redondearSQL(0, 2)).toBe(0)
+  })
+})
+```
+
+**Step 2: Correr y verificar que falla**
+
+Run: `npx vitest run src/utils/calculations.prorrateo.test.ts`
+Expected: FAIL — `redondearSQL is not exported`
+
+**Step 3: Implementar**
+
+En `src/utils/calculations.ts`, junto a `redondear` (~línea 465):
+
+```ts
+export function redondearSQL(valor: number, decimales: number = 2): number {
+  if (!Number.isFinite(valor)) return NaN;
+  const signo = valor < 0 ? -1 : 1;
+  const abs = Math.abs(valor);
+  // Fuera de [1e-6, 1e21) String() usa notacion exponencial y el desplazamiento
+  // por string produciria "1e-7e2". Debajo de 1e-6 el resultado a 2 decimales es
+  // 0 igual; arriba de 1e21 no hay montos de dinero.
+  if (abs !== 0 && (abs < 1e-6 || abs >= 1e21)) {
+    const factor = Math.pow(10, decimales);
+    return (signo * Math.round(abs * factor) / factor) + 0;
+  }
+  const desplazado = Math.round(Number(`${abs}e${decimales}`));
+  return signo * Number(`${desplazado}e-${decimales}`) + 0;  // el + 0 normaliza -0
+}
+```
+
+El desplazamiento por string recupera la intención decimal del double vía su representación round-trip más corta: `String(1.005)` es `"1.005"`, así que `"1.005e2"` da `100.5` limpio y redondea a `1.01` como Postgres. Multiplicar por 100 no lo logra.
+
+Agregarla al `export default` del final del archivo.
+
+**El test tiene que comparar contra una tabla calculada en Postgres**, no contra valores elegidos a mano en JS — si no, es una tautología. Los valores de referencia salen de correr `round(v,2)` en la base sobre valores que caen en el medio centavo:
+
+```ts
+const REFERENCIA_POSTGRES: Array<[number, number]> = [
+  [1.005, 1.01], [1.015, 1.02], [1.025, 1.03], [1.035, 1.04], [1.045, 1.05],
+  [0.145, 0.15], [0.565, 0.57], [0.005, 0.01], [2.675, 2.68], [8.045, 8.05],
+  [-1.005, -1.01], [-1.025, -1.03], [-0.145, -0.15], [-0.565, -0.57],
+  [-0.005, -0.01], [-2.675, -2.68], [1234.565, 1234.57], [73076.925, 73076.93],
+  [36538.455, 36538.46], [292307.685, 292307.69], [1900000.005, 1900000.01],
+  [1.115, 1.12], [1.215, 1.22], [4.985, 4.99],
+]
+
+it.each(REFERENCIA_POSTGRES)('coincide con round(%s, 2) de Postgres', (valor, esperado) => {
+  expect(redondearSQL(valor)).toBe(esperado)
+})
+```
+
+**Step 4: Correr y verificar que pasa**
+
+Run: `npx vitest run src/utils/calculations.prorrateo.test.ts`
+Expected: PASS (3 tests)
+
+**Step 5: Commit**
+
+```bash
+git add src/utils/calculations.ts src/utils/calculations.prorrateo.test.ts && git commit -m "Agregar redondeo compatible con Postgres para el prorrateo"
+```
+
+---
+
+### Task 2: Reparto de un cargo sobre un vector de pesos
+
+**Files:**
+- Create: `src/utils/prorrateoCompra.ts`
+- Test: `src/utils/prorrateoCompra.test.ts`
+
+**Step 1: Escribir el test que falla**
+
+```ts
+import { describe, it, expect } from 'vitest'
+import { prorratearCargo } from './prorrateoCompra'
+import { redondearSQL } from './calculations'
+
+describe('prorratearCargo', () => {
+  it('reparte proporcional al peso', () => {
+    expect(prorratearCargo(1000, { 1: 1, 2: 1 })).toEqual({ 1: 500, 2: 500 })
+  })
+
+  it('la suma de los repartos SIEMPRE da el monto exacto', () => {
+    const r = prorratearCargo(1000, { 1: 1, 2: 1, 3: 1 })
+    expect(Object.values(r).reduce((a, b) => a + b, 0)).toBe(1000)
+  })
+
+  it('el residuo va a la linea de mayor peso', () => {
+    // 100 / 3 partes desiguales: 1+1+4 = 6 → 16.67 + 16.67 + 66.66 = 100.00
+    const r = prorratearCargo(100, { 1: 1, 2: 1, 3: 4 })
+    expect(r[1]).toBe(16.67)
+    expect(r[2]).toBe(16.67)
+    expect(r[3]).toBe(66.66)
+  })
+
+  it('empate de peso maximo: desempata por menor id', () => {
+    const r = prorratearCargo(100, { 7: 1, 3: 1, 5: 1 })
+    expect(Object.values(r).reduce((a, b) => a + b, 0)).toBe(100)
+    expect(r[3]).toBe(33.34) // el residuo cae en el id menor
+  })
+
+  it('peso cero excluye la linea (es el mecanismo de alcance)', () => {
+    const r = prorratearCargo(880, { 1: 0, 2: 0, 3: 1 })
+    expect(r[3]).toBe(880)
+    expect(r[1]).toBe(0)
+  })
+
+  it('monto negativo (bonificacion) reparte igual y suma exacto', () => {
+    const r = prorratearCargo(-100, { 1: 1, 2: 1, 3: 1 })
+    expect(Object.values(r).reduce((a, b) => a + b, 0)).toBe(-100)
+  })
+
+  it('suma de pesos cero devuelve vacio', () => {
+    expect(prorratearCargo(1000, { 1: 0, 2: 0 })).toEqual({})
+  })
+
+  it('el flete real de la factura: 1.900.000 sobre 26 pallets', () => {
+    const pesos = { 1: 0.5, 2: 0.5, 3: 2, 4: 0.5, 5: 0.5, 6: 1, 7: 1, 8: 2, 9: 1, 10: 2,
+                    11: 4, 12: 1, 13: 1, 14: 2, 15: 1, 16: 1, 17: 1, 18: 1, 19: 1, 20: 1, 21: 1 }
+    const r = prorratearCargo(1900000, pesos)
+    expect(r[1]).toBe(36538.46)   // medio pallet
+    expect(r[6]).toBe(73076.92)   // un pallet
+    // Sumar 21 floats acumula error (da 1899999.9999999995). Cada parte es
+    // exacta al centavo; el total hay que releerlo al centavo. En SQL no pasa:
+    // numeric es decimal exacto y sum() da 1900000 clavado.
+    expect(redondearSQL(Object.values(r).reduce((a, b) => a + b, 0), 2)).toBe(1900000)
+  })
+})
+```
+
+**Step 2: Correr y verificar que falla**
+
+Run: `npx vitest run src/utils/prorrateoCompra.test.ts`
+Expected: FAIL — el módulo no existe
+
+**Step 3: Implementar**
+
+```ts
+import { redondearSQL } from './calculations'
+
+/** Vector de pesos de un cargo: id de línea → peso. Peso 0 excluye la línea. */
+export type PesosCargo = Record<number, number>
+
+/**
+ * Reparte un monto entre líneas según un vector de pesos.
+ *
+ * La suma de los repartos es EXACTAMENTE el monto: se redondea cada parte a 2
+ * decimales y el residuo se asigna a la línea de mayor peso (desempate: menor
+ * id). Sin esa regla, repartir sobre pesos fraccionarios no vuelve a sumar el
+ * monto y el check de integridad COMPRA-A2 se pone rojo por centavos.
+ *
+ * Espejo exacto de prorratear_cargo() en SQL (mig 193). Si cambiás uno,
+ * cambiá el otro y corré prorrateoCompra.espejo.test.ts.
+ */
+export function prorratearCargo(monto: number, pesos: PesosCargo): Record<number, number> {
+  const entradas = Object.entries(pesos).map(([k, v]) => [Number(k), Number(v)] as const)
+  const totalPeso = entradas.reduce((acc, [, p]) => acc + p, 0)
+  if (totalPeso === 0) return {}
+
+  const [idResiduo] = entradas.sort((a, b) => b[1] - a[1] || a[0] - b[0])[0]
+
+  const salida: Record<number, number> = {}
+  let acumulado = 0
+  for (const [id, peso] of entradas) {
+    if (id === idResiduo) continue
+    const parte = redondearSQL(monto * peso / totalPeso, 2)
+    salida[id] = parte
+    acumulado += parte
+  }
+  salida[idResiduo] = redondearSQL(monto - acumulado, 2)
+  return salida
+}
+```
+
+**Contrato de entrada — el cero es un estado válido, el negativo y el `NaN` son corrupción.**
+
+Sin esto la función acepta basura en silencio, y en un ERP donde el resultado se convierte en costo eso es peor que fallar. Casos verificados con la versión permisiva: `prorratearCargo(100, {1:1, 2:-1})` devuelve `{}` y **el cargo desaparece entero sin aviso**; `{1:NaN, 2:1}` redistribuye todo a la línea 2 sin que nadie se entere.
+
+- Todos los pesos en cero → `{}`. Estado legítimo mientras el usuario llena la grilla.
+- Un peso negativo o no finito → `throw`, nombrando la línea.
+- `monto` no finito → `throw`. Nada de defensividad asimétrica entre monto y pesos.
+- **No uses `Number(v) || 0`**: convertir `NaN` a `0` hace indistinguible un dato corrupto de una exclusión deliberada, porque `0` *es* el mecanismo de alcance.
+
+Esta decisión define la firma de la RPC, así que tiene que estar tomada antes de la Task 9.
+
+**Sobre el desempate:** el comparador `(a,b) => b[1]-a[1] || a[0]-b[0]` es un orden total sobre ids distintos, así que el resultado **no** depende del orden de iteración de `Object.entries`. En SQL alcanza con `ORDER BY peso DESC, id ASC LIMIT 1` para elegir la fila del residuo; la acumulación no necesita orden, porque `numeric` es exacto y la suma es asociativa.
+
+**Step 4: Correr y verificar que pasa**
+
+Run: `npx vitest run src/utils/prorrateoCompra.test.ts`
+Expected: PASS (8 tests)
+
+**Step 5: Commit**
+
+```bash
+git add src/utils/prorrateoCompra.ts src/utils/prorrateoCompra.test.ts && git commit -m "Repartir un cargo de compra sobre un vector de pesos"
+```
+
+---
+
+### Task 3: Motor de costos de compra
+
+**Files:**
+- Modify: `src/utils/prorrateoCompra.ts`
+- Test: `src/utils/prorrateoCompra.test.ts`
+
+**Step 1: Escribir el test que falla**
+
+Agregá al final del archivo de test:
+
+```ts
+import { calcularCostosCompra, type CargoCompra, type LineaCompra } from './prorrateoCompra'
+
+describe('calcularCostosCompra', () => {
+  const linea = (over: Partial<LineaCompra> = {}): LineaCompra => ({
+    id: 1, cantidad: 10, costoUnitario: 100, bonificacion: 0,
+    impuestosInternos: 0, porcentajeIva: 21, condicionIva: 'gravado', ...over,
+  })
+  const cargo = (over: Partial<CargoCompra> = {}): CargoCompra => ({
+    id: 1, concepto: 'x', monto: 0, condicionIva: 'no_gravado', porcentajeIva: 0,
+    enFactura: true, prorrateaAlCosto: true, afectaBaseII: false, pesos: {}, ...over,
+  })
+
+  it('sin cargos se comporta igual que hoy: neto x (1 + II%)', () => {
+    const r = calcularCostosCompra([linea({ impuestosInternos: 8.6956 })], [], {})
+    expect(r.lineas[0].costoRealUnitario).toBeCloseTo(108.6956, 4)
+  })
+
+  it('un cargo NO GRAVADO entra al costo pero NO a la base de IVA', () => {
+    const r = calcularCostosCompra(
+      [linea()],
+      [cargo({ monto: 500, pesos: { 1: 1 } })],
+      {}
+    )
+    expect(r.lineas[0].baseIvaUnitaria).toBe(100)      // 1000/10, sin el cargo
+    expect(r.lineas[0].ivaUnitario).toBe(21)           // 21% de 100, NO de 150
+    expect(r.lineas[0].cargosUnitarios).toBe(50)       // 500/10
+    expect(r.lineas[0].costoRealUnitario).toBe(150)    // sí entra al costo
+  })
+
+  it('un cargo fuera de factura entra al costo pero no al IVA de la factura', () => {
+    const r = calcularCostosCompra(
+      [linea()],
+      [cargo({ monto: 500, condicionIva: 'gravado', porcentajeIva: 21, enFactura: false, pesos: { 1: 1 } })],
+      {}
+    )
+    expect(r.totales.baseIvaFactura).toBe(1000)   // el cargo no suma al IVA de esta compra
+    expect(r.lineas[0].costoRealUnitario).toBe(150)
+  })
+
+  it('afectaBaseII=false: la bonificacion baja el IVA pero no el impuesto interno', () => {
+    const r = calcularCostosCompra(
+      [linea({ impuestosInternos: 10 })],
+      [cargo({ monto: -200, condicionIva: 'gravado', porcentajeIva: 21, afectaBaseII: false, pesos: { 1: 1 } })],
+      {}
+    )
+    expect(r.lineas[0].baseIvaUnitaria).toBe(80)   // (1000-200)/10
+    expect(r.lineas[0].iiUnitario).toBe(10)        // 10% de 1000/10, NO de 800/10
+  })
+
+  it('afectaBaseII=true: la bonificacion baja las dos bases', () => {
+    const r = calcularCostosCompra(
+      [linea({ impuestosInternos: 10 })],
+      [cargo({ monto: -200, condicionIva: 'gravado', porcentajeIva: 21, afectaBaseII: true, pesos: { 1: 1 } })],
+      {}
+    )
+    expect(r.lineas[0].iiUnitario).toBe(8)         // 10% de 800/10
+  })
+
+  it('el factor de ajuste cuadra el II declarado y se reporta', () => {
+    const r = calcularCostosCompra(
+      [linea({ impuestosInternos: 10 })],
+      [],
+      { 10: 110 }   // declarado 110 vs calculado 100
+    )
+    expect(r.factorAjuste[10]).toBeCloseTo(1.1, 6)
+    expect(r.lineas[0].iiUnitario).toBeCloseTo(11, 4)
+  })
+
+  it('cantidad 0 no explota', () => {
+    const r = calcularCostosCompra([linea({ cantidad: 0 })], [], {})
+    expect(r.lineas[0].costoRealUnitario).toBe(0)
+  })
+})
+```
+
+**Step 2: Correr y verificar que falla**
+
+Run: `npx vitest run src/utils/prorrateoCompra.test.ts -t calcularCostosCompra`
+Expected: FAIL — `calcularCostosCompra is not exported`
+
+**Step 3: Implementar**
+
+Agregá a `src/utils/prorrateoCompra.ts`:
+
+```ts
+import type { CondicionIva } from './condicionIva'
+
+export interface LineaCompra {
+  id: number
+  cantidad: number
+  costoUnitario: number
+  bonificacion: number       // %
+  impuestosInternos: number  // tasa efectiva %
+  porcentajeIva: number      // %
+  condicionIva: CondicionIva
+}
+
+export interface CargoCompra {
+  id: number
+  concepto: string
+  monto: number              // SIN IVA. Negativo = bonificación
+  condicionIva: CondicionIva
+  porcentajeIva: number
+  enFactura: boolean         // suma al cuadre contra el papel
+  prorrateaAlCosto: boolean  // entra al costo unitario
+  afectaBaseII: boolean
+  pesos: PesosCargo
+}
+
+export interface CostosLinea {
+  id: number
+  baseIvaUnitaria: number
+  iiUnitario: number
+  cargosUnitarios: number
+  ivaUnitario: number
+  costoNetoUnitario: number
+  costoRealUnitario: number
+}
+
+export interface CostosCompra {
+  lineas: CostosLinea[]
+  totales: { baseIvaFactura: number; iva: number; impuestosInternos: number; noGravado: number }
+  /** tasa de II → declarado/calculado. 1 = cuadra solo. */
+  factorAjuste: Record<number, number>
+}
+
+/**
+ * Motor canónico de costos de una compra (espejo de la mig 193).
+ *
+ * Dos bases separadas a propósito:
+ *   · baseIvaFactura → sólo cargos EN FACTURA. Alimenta compras.iva y el cuadre.
+ *   · baseCosto      → todos los que prorratean. Alimenta costo_real_unitario.
+ * El IVA de un flete de transportista inscripto es crédito fiscal: entra su
+ * neto al costo, su IVA no entra a ningún lado de esta factura.
+ *
+ * @param iiDeclarado - tasa de II → monto declarado en la factura. Vacío = sin ajuste.
+ */
+export function calcularCostosCompra(
+  lineas: LineaCompra[],
+  cargos: CargoCompra[],
+  iiDeclarado: Record<number, number>
+): CostosCompra {
+  const repartos = new Map<number, Record<number, number>>()
+  for (const c of cargos) repartos.set(c.id, prorratearCargo(c.monto, c.pesos))
+  const asignado = (c: CargoCompra, lineaId: number) => repartos.get(c.id)?.[lineaId] ?? 0
+
+  const neto = (l: LineaCompra) => l.cantidad * l.costoUnitario * (1 - (l.bonificacion || 0) / 100)
+  const suma = (l: LineaCompra, filtro: (c: CargoCompra) => boolean) =>
+    cargos.filter(filtro).reduce((acc, c) => acc + asignado(c, l.id), 0)
+
+  const gravado = (c: CargoCompra) => c.condicionIva === 'gravado'
+
+  // Bases por línea, antes del ajuste de II
+  const bases = lineas.map(l => ({
+    linea: l,
+    baseIvaFactura: neto(l) + suma(l, c => gravado(c) && c.enFactura),
+    baseCosto: neto(l) + suma(l, c => gravado(c) && c.prorrateaAlCosto),
+    baseII: neto(l) + suma(l, c => gravado(c) && c.afectaBaseII),
+    noGravado: suma(l, c => !gravado(c) && c.prorrateaAlCosto),
+  }))
+
+  // Factor de ajuste por alícuota de II
+  const factorAjuste: Record<number, number> = {}
+  for (const [tasaStr, declarado] of Object.entries(iiDeclarado)) {
+    const tasa = Number(tasaStr)
+    const calculado = bases
+      .filter(b => Math.abs(b.linea.impuestosInternos - tasa) < 1e-6)
+      .reduce((acc, b) => acc + b.baseII * tasa / 100, 0)
+    factorAjuste[tasa] = calculado ? declarado / calculado : 1
+  }
+
+  const salida = bases.map(b => {
+    const { linea: l } = b
+    const cant = l.cantidad || 0
+    const factor = factorAjuste[l.impuestosInternos] ?? 1
+    const ii = b.baseII * (l.impuestosInternos || 0) / 100 * factor
+    const porUnidad = (v: number) => (cant > 0 ? v / cant : 0)
+    return {
+      id: l.id,
+      baseIvaUnitaria: porUnidad(b.baseIvaFactura),
+      iiUnitario: porUnidad(ii),
+      cargosUnitarios: porUnidad(b.noGravado),
+      ivaUnitario: porUnidad(b.baseIvaFactura * (l.condicionIva === 'gravado' ? l.porcentajeIva : 0) / 100),
+      costoNetoUnitario: porUnidad(neto(l)),
+      costoRealUnitario: porUnidad(b.baseCosto + ii + b.noGravado),
+    }
+  })
+
+  return {
+    lineas: salida,
+    totales: {
+      baseIvaFactura: bases.reduce((a, b) => a + b.baseIvaFactura, 0),
+      iva: salida.reduce((a, s, i) => a + s.ivaUnitario * (lineas[i].cantidad || 0), 0),
+      impuestosInternos: salida.reduce((a, s, i) => a + s.iiUnitario * (lineas[i].cantidad || 0), 0),
+      noGravado: bases.reduce((a, b) => a + b.noGravado, 0),
+    },
+    factorAjuste,
+  }
+}
+```
+
+**Step 4: Correr y verificar que pasa**
+
+Run: `npx vitest run src/utils/prorrateoCompra.test.ts`
+Expected: PASS (16 tests)
+
+**Step 5: Commit**
+
+```bash
+git add src/utils/prorrateoCompra.ts src/utils/prorrateoCompra.test.ts && git commit -m "Calcular el costo de una compra con cargos prorrateados"
+```
+
+---
+
+### Task 4: Test golden contra la factura real
+
+Este es el test que justifica todo el trabajo. Los números salen del Excel `CALCULO_FACTURA_A0005-00461415.xlsx`.
+
+**Files:**
+- Create: `src/utils/prorrateoCompra.golden.test.ts`
+
+**Step 1: Escribir el test**
+
+```ts
+import { describe, it, expect } from 'vitest'
+import { calcularCostosCompra, type CargoCompra, type LineaCompra } from './prorrateoCompra'
+
+// Fixture: factura A0005-00461415 de Manaos, 21 renglones, 13,3 M.
+// Es el caso que motivó este rediseño. El Excel del gerente cuadra el impuesto
+// interno con un factor manual de 1,0496; acá tiene que dar 1,0000.
+
+const ITEMS: LineaCompra[] = [
+  { id: 1,  cantidad: 60,  costoUnitario: 4793.61, bonificacion: 0.6, impuestosInternos: 4.1667, porcentajeIva: 21, condicionIva: 'gravado' },
+  { id: 2,  cantidad: 60,  costoUnitario: 4793.61, bonificacion: 0.6, impuestosInternos: 4.1667, porcentajeIva: 21, condicionIva: 'gravado' },
+  { id: 3,  cantidad: 120, costoUnitario: 5782.77, bonificacion: 0.6, impuestosInternos: 8.6956, porcentajeIva: 21, condicionIva: 'gravado' },
+  { id: 4,  cantidad: 75,  costoUnitario: 3994.67, bonificacion: 0.6, impuestosInternos: 4.1667, porcentajeIva: 21, condicionIva: 'gravado' },
+  { id: 5,  cantidad: 75,  costoUnitario: 3994.67, bonificacion: 0.6, impuestosInternos: 4.1667, porcentajeIva: 21, condicionIva: 'gravado' },
+  { id: 6,  cantidad: 120, costoUnitario: 2972.04, bonificacion: 0.6, impuestosInternos: 4.1667, porcentajeIva: 21, condicionIva: 'gravado' },
+  { id: 7,  cantidad: 80,  costoUnitario: 2316.91, bonificacion: 0.6, impuestosInternos: 4.1667, porcentajeIva: 21, condicionIva: 'gravado' },
+  { id: 8,  cantidad: 280, costoUnitario: 2197.07, bonificacion: 0.6, impuestosInternos: 4.1667, porcentajeIva: 21, condicionIva: 'gravado' },
+  { id: 9,  cantidad: 120, costoUnitario: 4626.22, bonificacion: 0.6, impuestosInternos: 8.6956, porcentajeIva: 21, condicionIva: 'gravado' },
+  { id: 10, cantidad: 150, costoUnitario: 5123.97, bonificacion: 0.6, impuestosInternos: 0,      porcentajeIva: 21, condicionIva: 'gravado' },
+  { id: 11, cantidad: 240, costoUnitario: 5782.77, bonificacion: 0.6, impuestosInternos: 8.6956, porcentajeIva: 21, condicionIva: 'gravado' },
+  { id: 12, cantidad: 60,  costoUnitario: 5782.77, bonificacion: 0.6, impuestosInternos: 8.6956, porcentajeIva: 21, condicionIva: 'gravado' },
+  { id: 13, cantidad: 60,  costoUnitario: 5992.01, bonificacion: 0.6, impuestosInternos: 4.1667, porcentajeIva: 21, condicionIva: 'gravado' },
+  { id: 14, cantidad: 120, costoUnitario: 5782.77, bonificacion: 0.6, impuestosInternos: 8.6956, porcentajeIva: 21, condicionIva: 'gravado' },
+  { id: 15, cantidad: 60,  costoUnitario: 5782.77, bonificacion: 0.6, impuestosInternos: 8.6956, porcentajeIva: 21, condicionIva: 'gravado' },
+  { id: 16, cantidad: 115, costoUnitario: 8347.11, bonificacion: 0.6, impuestosInternos: 0,      porcentajeIva: 21, condicionIva: 'gravado' },
+  { id: 17, cantidad: 140, costoUnitario: 3822.90, bonificacion: 0.6, impuestosInternos: 4.1667, porcentajeIva: 21, condicionIva: 'gravado' },
+  { id: 18, cantidad: 140, costoUnitario: 3822.90, bonificacion: 0.6, impuestosInternos: 4.1667, porcentajeIva: 21, condicionIva: 'gravado' },
+  { id: 19, cantidad: 140, costoUnitario: 3822.90, bonificacion: 0.6, impuestosInternos: 4.1667, porcentajeIva: 21, condicionIva: 'gravado' },
+  { id: 20, cantidad: 120, costoUnitario: 2796.27, bonificacion: 0.6, impuestosInternos: 4.1667, porcentajeIva: 21, condicionIva: 'gravado' },
+  { id: 21, cantidad: 168, costoUnitario: 1030.63, bonificacion: 0.6, impuestosInternos: 4.1667, porcentajeIva: 21, condicionIva: 'gravado' },
+]
+
+const neto = (id: number) => {
+  const l = ITEMS.find(x => x.id === id)!
+  return l.cantidad * l.costoUnitario * (1 - l.bonificacion / 100)
+}
+const pesosPorMonto = (ids: number[]) => Object.fromEntries(ids.map(id => [id, neto(id)]))
+
+const PALLETS_FLETE: Record<number, number> = { 1: .5, 2: .5, 3: 2, 4: .5, 5: .5, 6: 1, 7: 1, 8: 2, 9: 1, 10: 2, 11: 4, 12: 1, 13: 1, 14: 2, 15: 1, 16: 1, 17: 1, 18: 1, 19: 1, 20: 1, 21: 1 }
+const PALLETS:       Record<number, number> = { ...PALLETS_FLETE, 4: 1, 5: 1 }
+
+const CARGOS: CargoCompra[] = [
+  { id: 1, concepto: 'Flete y descarga', monto: 1_900_000, condicionIva: 'no_gravado', porcentajeIva: 0,
+    enFactura: false, prorrateaAlCosto: true, afectaBaseII: false, pesos: PALLETS_FLETE },
+  { id: 2, concepto: 'Pallets x 9 tacos', monto: 162_000, condicionIva: 'no_gravado', porcentajeIva: 0,
+    enFactura: true, prorrateaAlCosto: true, afectaBaseII: false, pesos: PALLETS },
+  { id: 3, concepto: 'Separadores bidon', monto: 8_800, condicionIva: 'no_gravado', porcentajeIva: 0,
+    enFactura: true, prorrateaAlCosto: true, afectaBaseII: false, pesos: { 21: 1 } },
+  // Descuento de precio: SI baja la base del impuesto interno
+  { id: 4, concepto: 'Bonif. promo COLA 3.00', monto: -103_465.32, condicionIva: 'gravado', porcentajeIva: 21,
+    enFactura: true, prorrateaAlCosto: true, afectaBaseII: true, pesos: pesosPorMonto([3, 11]) },
+  // Bonificacion comercial: NO baja la base del impuesto interno. Este flag es
+  // TODO el descubrimiento: sin el, el II no cuadra por casi 5%.
+  { id: 5, concepto: 'Bonif. promo 3000cc', monto: -203_318.28, condicionIva: 'gravado', porcentajeIva: 21,
+    enFactura: true, prorrateaAlCosto: true, afectaBaseII: false, pesos: pesosPorMonto([3, 11, 12, 13, 14, 15]) },
+  { id: 6, concepto: 'Redondeo', monto: -0.49, condicionIva: 'gravado', porcentajeIva: 21,
+    enFactura: true, prorrateaAlCosto: true, afectaBaseII: true, pesos: pesosPorMonto(ITEMS.map(i => i.id)) },
+]
+
+const II_DECLARADO = { 8.6956: 338_884.46, 4.1667: 199_027.21 }
+
+describe('Factura A0005-00461415 (caso testigo del rediseno)', () => {
+  const r = calcularCostosCompra(ITEMS, CARGOS, II_DECLARADO)
+
+  it('el impuesto interno cuadra SOLO: factor de ajuste = 1', () => {
+    // El Excel del gerente necesita 1,0496 acá. Modelando afectaBaseII, da 1.
+    expect(r.factorAjuste[8.6956]).toBeCloseTo(1, 5)
+    expect(r.factorAjuste[4.1667]).toBeCloseTo(1, 5)
+  })
+
+  it('el impuesto interno total coincide con lo declarado en la factura', () => {
+    expect(r.totales.impuestosInternos).toBeCloseTo(338_884.46 + 199_027.21, 1)
+  })
+
+  it('el costo total sin IVA coincide con el Excel al centavo', () => {
+    const total = r.lineas.reduce(
+      (acc, l, i) => acc + l.costoRealUnitario * ITEMS[i].cantidad, 0)
+    expect(total).toBeCloseTo(12_797_344.26, 1)
+  })
+
+  it('los cargos no gravados no inflan la base de IVA', () => {
+    // Si el flete entrara a la base, el IVA se calcularia sobre 2.070.800 de mas
+    expect(r.totales.baseIvaFactura).toBeCloseTo(12_797_344.26 - 2_070_800 - r.totales.impuestosInternos, 0)
+  })
+
+  it('MANAOS LIMA LIMON 600cc: desglose completo por pack', () => {
+    const l = r.lineas.find(x => x.id === 1)!
+    expect(l.baseIvaUnitaria).toBeCloseTo(4764.85, 2)
+    expect(l.iiUnitario).toBeCloseTo(198.54, 2)
+    expect(l.cargosUnitarios).toBeCloseTo(658.97, 2)   // flete + pallets
+    expect(l.ivaUnitario).toBeCloseTo(1000.62, 2)
+    expect(l.costoRealUnitario).toBeCloseTo(5622.36, 2)
+  })
+
+  it('los separadores caen 100% en el bidon y en ningun otro producto', () => {
+    const bidon = r.lineas.find(x => x.id === 21)!
+    const otra = r.lineas.find(x => x.id === 1)!
+    // bidon: flete 73076.92 + pallets 6000 + separadores 8800 = 87876.92 / 168
+    expect(bidon.cargosUnitarios).toBeCloseTo(523.08, 2)
+    // linea 1: solo flete 36538.46 + pallets 3000, sin separadores
+    expect(otra.cargosUnitarios).toBeCloseTo(658.97, 2)
+  })
+
+  it('el modelo NO copia el reparto de II del Excel: lo corrige', () => {
+    // El factor proporcional del Excel unta el II de la promo sobre productos
+    // que no participaron. MANAOS COLA 600cc (id 9) no tuvo promo: el Excel le
+    // carga 419,70 por pack, el modelo 399,86.
+    const sinPromo = r.lineas.find(x => x.id === 9)!
+    expect(sinPromo.iiUnitario).toBeCloseTo(399.86, 1)
+    expect(sinPromo.iiUnitario).toBeLessThan(419.70)
+  })
+})
+```
+
+**Step 2: Correr**
+
+Run: `npx vitest run src/utils/prorrateoCompra.golden.test.ts`
+Expected: PASS (8 tests). **Si alguno falla, el motor está mal — no toques el test para que pase.** Los números vienen de una factura real verificada.
+
+**Step 3: Commit**
+
+```bash
+git add src/utils/prorrateoCompra.golden.test.ts && git commit -m "Atar el motor de costos a la factura real de Manaos"
+```
+
+---
+
+## Ensayar una migración sin aplicarla
+
+Antes de dar por buena cualquier migración de esta fase, **corrėla entera contra producción dentro de un bloque que termine lanzando una excepción**. La excepción garantiza el rollback, así que el esquema real valida sintaxis y semántica sin que quede nada aplicado:
+
+```sql
+DO $dry$
+DECLARE v_res text;
+BEGIN
+  -- ...toda la DDL / las funciones de la migración...
+
+  SELECT format('tablas=%s policies=%s fks=%s', ...) INTO v_res;
+  RAISE EXCEPTION 'ENSAYO OK >>> %', v_res;   -- fuerza el rollback y devuelve la verificación
+END $dry$;
+```
+
+El resultado vuelve como el mensaje de error. Verificado que el rollback es real: un `CREATE TABLE` de prueba no sobrevive.
+
+Sirve además para probar que un CHECK **muerde**: insertá adentro del ensayo la fila que debería rechazar y confirmá que falla. Sin esto, la primera prueba de sintaxis de una migración es el momento de aplicarla a prod, que es el peor momento posible. Se descubrió al escribir la Task 5, cuando el implementador avisó que su SQL no se había ejecutado en ningún lado.
+
+Las funciones de las tasks 6-8 se pueden ensayar igual: `CREATE OR REPLACE FUNCTION` adentro del bloque, llamarla con los datos de la factura testigo, comparar contra el golden de TS, y `RAISE EXCEPTION` con el resultado.
+
+## Fase 2 — Migraciones 192, 193 y 194
+
+**Van en tres archivos, no en uno.** El plan original metía todo en la 192 y estaba mal: ese archivo termina en `COMMIT;` seguido de un bloque de verificación comentado, así que appendear las funciones al final las dejaba **fuera de la transacción** — justo lo que el `BEGIN`/`COMMIT` estaba evitando. Una falla a mitad de camino habría dejado tablas creadas con RPCs a medias.
+
+- **190** — tablas, índices, RLS, columna `cargos_unitarios` (Task 5)
+- **191** — funciones puras: `prorratear_cargo`, `calcular_costos_compra`, `costo_real_unitario` (Tasks 6-8)
+- **192** — RPCs y el check de integridad (Tasks 9-12)
+
+De paso el ledger queda más legible y cada parte se puede aplicar y verificar sola.
+
+**Antes de escribir SQL:** leé `migrations/MANIFEST.md` y mirá cómo la mig 177 y la 178 parchean funciones leyendo el catálogo en vez de hardcodear el cuerpo. Seguí ese patrón.
+
+**Cómo aplicar y probar:** usá una branch de Supabase (`create_branch`), aplicá ahí, verificá, y recién después a producción. No apliques directo a prod.
+
+### Task 5: Tablas, índices y RLS
+
+**Files:**
+- Create: `migrations/192_compra_cargos_prorrateo.sql`
+
+**Step 1: Escribir la primera parte de la migración**
+
+```sql
+-- ============================================================================
+-- 192 · Compras: cargos prorrateados y cuadre fiscal
+-- ============================================================================
+-- Ver docs/plans/2026-08-18-cargos-y-cuadre-de-compras-design.md
+--
+-- Tres cosas que la carga de compras no sabía representar:
+--   · flete, pallets y separadores (el 16,2% del costo de la factura testigo)
+--   · que el reparto es por volumen, no por monto, y a veces sólo a un subconjunto
+--   · que NO toda bonificación baja la base del impuesto interno
+--
+-- El "alcance" no es un concepto: un peso 0 excluye la línea. Y una bonificación
+-- es un cargo de monto negativo. Por eso alcanza con una sola tabla.
+--
+-- Forward-only: las compras existentes no tienen cargos ⇒ Σ cargos = 0 ⇒ el
+-- costo es idéntico al de hoy. Cero backfill.
+-- ============================================================================
+
+CREATE TABLE IF NOT EXISTS public.compra_cargos (
+  id                 bigserial PRIMARY KEY,
+  compra_id          bigint NOT NULL REFERENCES public.compras(id) ON DELETE CASCADE,
+  sucursal_id        bigint NOT NULL REFERENCES public.sucursales(id),
+  orden              integer NOT NULL DEFAULT 0,
+  concepto           text    NOT NULL,
+  monto              numeric(12,2) NOT NULL,
+  condicion_iva      text    NOT NULL DEFAULT 'no_gravado'
+                       CHECK (condicion_iva IN ('gravado','exento','no_gravado')),
+  en_factura         boolean NOT NULL DEFAULT true,
+  prorratea_al_costo boolean NOT NULL DEFAULT true,
+  afecta_base_ii     boolean NOT NULL DEFAULT false,
+  base_prorrateo     text    NOT NULL DEFAULT 'unidades'
+                       CHECK (base_prorrateo IN ('monto','cantidad','unidades')),
+  created_at         timestamptz NOT NULL DEFAULT now()
+);
+
+COMMENT ON TABLE public.compra_cargos IS
+  'Conceptos de una compra que no son renglones de producto: flete, pallets, separadores, bonificaciones promocionales, redondeo. Monto negativo = bonificación.';
+COMMENT ON COLUMN public.compra_cargos.monto IS
+  'SIN IVA. Negativo = bonificación.';
+COMMENT ON COLUMN public.compra_cargos.en_factura IS
+  'true = el concepto viene impreso en la factura y suma al cuadre. El flete de un tercero va en false: no toca compras.total ni compras.iva, pero sí el costo.';
+COMMENT ON COLUMN public.compra_cargos.prorratea_al_costo IS
+  'true = entra al costo unitario de los productos. Independiente de en_factura.';
+COMMENT ON COLUMN public.compra_cargos.afecta_base_ii IS
+  'true = el cargo modifica la base de cálculo de impuestos internos. Una bonificación comercial NO la modifica; un descuento de precio SI. Es la causa del descuadre histórico del II.';
+COMMENT ON COLUMN public.compra_cargos.base_prorrateo IS
+  'Sólo pre-llena el vector de pesos en la UI. La verdad siempre es compra_cargo_repartos.';
+COMMENT ON COLUMN public.compra_cargos.condicion_iva IS
+  'Un cargo gravado tributa a la alícuota de las líneas sobre las que se prorratea: no lleva alícuota propia. Hoy los 247 productos son 21%, así que la distinción no se plantea. Si alguna vez conviven alícuotas distintas en una misma compra hay que decidir qué significa la base gravada de una línea que recibe un cargo de otra alícuota.';
+
+CREATE TABLE IF NOT EXISTS public.compra_cargo_repartos (
+  cargo_id       bigint NOT NULL REFERENCES public.compra_cargos(id) ON DELETE CASCADE,
+  compra_item_id bigint NOT NULL REFERENCES public.compra_items(id) ON DELETE CASCADE,
+  peso           numeric(12,4) NOT NULL DEFAULT 0,
+  PRIMARY KEY (cargo_id, compra_item_id)
+);
+
+COMMENT ON TABLE public.compra_cargo_repartos IS
+  'Vector de pesos de un cargo. Peso 0 excluye la línea: por eso el "alcance" no existe como concepto aparte.';
+
+CREATE INDEX IF NOT EXISTS idx_compra_cargos_compra ON public.compra_cargos(compra_id);
+
+ALTER TABLE public.compra_cargos          ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.compra_cargo_repartos  ENABLE ROW LEVEL SECURITY;
+
+-- RLS espejo de compra_items: admin escribe, admin y depósito leen, siempre
+-- acotado a la sucursal activa.
+DROP POLICY IF EXISTS mt_compra_cargos_select ON public.compra_cargos;
+CREATE POLICY mt_compra_cargos_select ON public.compra_cargos FOR SELECT TO authenticated
+  USING ((es_admin() OR EXISTS (SELECT 1 FROM perfiles WHERE perfiles.id = auth.uid() AND perfiles.rol = 'deposito'))
+         AND sucursal_id = current_sucursal_id());
+
+DROP POLICY IF EXISTS mt_compra_cargos_insert ON public.compra_cargos;
+CREATE POLICY mt_compra_cargos_insert ON public.compra_cargos FOR INSERT TO authenticated
+  WITH CHECK ((es_admin() OR EXISTS (SELECT 1 FROM perfiles WHERE perfiles.id = auth.uid() AND perfiles.rol = 'deposito'))
+              AND sucursal_id = current_sucursal_id());
+
+DROP POLICY IF EXISTS mt_compra_cargos_update ON public.compra_cargos;
+CREATE POLICY mt_compra_cargos_update ON public.compra_cargos FOR UPDATE TO authenticated
+  USING (es_admin() AND sucursal_id = current_sucursal_id())
+  WITH CHECK (es_admin() AND sucursal_id = current_sucursal_id());
+
+DROP POLICY IF EXISTS mt_compra_cargos_delete ON public.compra_cargos;
+CREATE POLICY mt_compra_cargos_delete ON public.compra_cargos FOR DELETE TO authenticated
+  USING (es_admin() AND sucursal_id = current_sucursal_id());
+
+-- Los repartos heredan el permiso de su cargo.
+DROP POLICY IF EXISTS mt_compra_cargo_repartos_all ON public.compra_cargo_repartos;
+CREATE POLICY mt_compra_cargo_repartos_all ON public.compra_cargo_repartos FOR ALL TO authenticated
+  USING (EXISTS (SELECT 1 FROM compra_cargos c WHERE c.id = cargo_id AND c.sucursal_id = current_sucursal_id()))
+  WITH CHECK (EXISTS (SELECT 1 FROM compra_cargos c WHERE c.id = cargo_id AND c.sucursal_id = current_sucursal_id()));
+
+-- Snapshot por línea: sin esto no se puede reconstruir cuánto fue flete y
+-- cuánto impuesto interno al reabrir la compra.
+ALTER TABLE public.compra_items
+  ADD COLUMN IF NOT EXISTS cargos_unitarios numeric(12,4) NOT NULL DEFAULT 0;
+
+COMMENT ON COLUMN public.compra_items.cargos_unitarios IS
+  'Cargos no gravados prorrateados a esta línea, por unidad (mig 192). Ya está incluido en costo_real_unitario.';
+```
+
+**Step 2: Verificar la sintaxis sin aplicar**
+
+Antes de aplicar, confirmá que `sucursales` y `current_sucursal_id()` existen con esos nombres:
+
+```sql
+SELECT to_regclass('public.sucursales'), pg_get_functiondef('public.current_sucursal_id'::regproc) IS NOT NULL;
+```
+
+**Step 3: Commit** (todavía sin aplicar)
+
+```bash
+git add migrations/192_compra_cargos_prorrateo.sql && git commit -m "Crear las tablas de cargos de compra con su RLS"
+```
+
+---
+
+### Task 6: Función de prorrateo en SQL
+
+**Files:**
+- Create o Modify: `migrations/193_compra_cargos_funciones.sql`
+
+**Step 1: Agregar la función**
+
+```sql
+-- ----------------------------------------------------------------------------
+-- Reparto de un cargo sobre un vector de pesos.
+-- Espejo EXACTO de prorratearCargo() en src/utils/prorrateoCompra.ts.
+-- El residuo va a la línea de mayor peso (desempate: menor id) para que la suma
+-- dé el monto exacto: sin eso, COMPRA-A2 se pone rojo por centavos.
+-- ----------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.prorratear_cargo(p_monto numeric, p_pesos jsonb)
+RETURNS TABLE(item_id bigint, monto numeric)
+LANGUAGE plpgsql IMMUTABLE AS $fn$
+DECLARE
+  v_total_peso numeric;
+  v_id_residuo bigint;
+  v_acumulado  numeric := 0;
+  v_rec        RECORD;
+BEGIN
+  SELECT sum(value::numeric) INTO v_total_peso FROM jsonb_each_text(p_pesos);
+  IF v_total_peso IS NULL OR v_total_peso = 0 THEN RETURN; END IF;
+
+  SELECT key::bigint INTO v_id_residuo
+    FROM jsonb_each_text(p_pesos)
+   ORDER BY value::numeric DESC, key::bigint ASC
+   LIMIT 1;
+
+  FOR v_rec IN
+    SELECT key::bigint AS id, round(p_monto * value::numeric / v_total_peso, 2) AS parte
+      FROM jsonb_each_text(p_pesos)
+     WHERE key::bigint <> v_id_residuo
+     ORDER BY key::bigint
+  LOOP
+    v_acumulado := v_acumulado + v_rec.parte;
+    item_id := v_rec.id;  monto := v_rec.parte;  RETURN NEXT;
+  END LOOP;
+
+  item_id := v_id_residuo;  monto := round(p_monto - v_acumulado, 2);  RETURN NEXT;
+END;
+$fn$;
+```
+
+**Step 2: Verificar el espejo contra el test de TS**
+
+Aplicá en una branch y corré exactamente los casos del test de Task 2:
+
+```sql
+-- debe dar 16.67 / 16.67 / 66.66, suma exacta 100
+SELECT item_id, monto FROM prorratear_cargo(100, '{"1":1,"2":1,"3":4}'::jsonb) ORDER BY item_id;
+-- debe dar suma exacta -100
+SELECT sum(monto) FROM prorratear_cargo(-100, '{"1":1,"2":1,"3":1}'::jsonb);
+-- el flete real: 36538.46 en medio pallet, 73076.92 en uno, suma 1900000
+SELECT sum(monto) FROM prorratear_cargo(1900000, '{"1":0.5,"2":0.5,"3":2,"4":0.5,"5":0.5,"6":1,"7":1,"8":2,"9":1,"10":2,"11":4,"12":1,"13":1,"14":2,"15":1,"16":1,"17":1,"18":1,"19":1,"20":1,"21":1}'::jsonb);
+```
+
+Expected: los tres resultados idénticos a los del test de TypeScript.
+
+**Step 3: Commit**
+
+```bash
+git add migrations/193_compra_cargos_funciones.sql && git commit -m "Repartir un cargo en SQL con la misma regla de residuo que el front"
+```
+
+---
+
+### Task 7: Reemplazar `costo_real_unitario`
+
+**Files:**
+- Create o Modify: `migrations/193_compra_cargos_funciones.sql`
+
+El cuerpo actual (verificado en prod):
+
+```sql
+SELECT CASE
+  WHEN p_tipo_factura = 'ZZ' THEN p_costo_neto
+  ELSE round(p_costo_neto * (1 + COALESCE(p_pct_ii, 0) / 100), 4)
+END;
+```
+
+**Step 1: Agregar el reemplazo**
+
+```sql
+-- ----------------------------------------------------------------------------
+-- costo_real_unitario gana un término ADITIVO para los cargos prorrateados.
+--
+-- Se DROPEA la de 3 argumentos en vez de dejarla junto a una de 4 con DEFAULT:
+-- dos sobrecargas con rangos de aridad superpuestos dan PGRST203 en runtime,
+-- invisible para tsc y para los tests (trampa de la mig 176).
+-- ----------------------------------------------------------------------------
+DROP FUNCTION IF EXISTS public.costo_real_unitario(numeric, numeric, text);
+
+CREATE OR REPLACE FUNCTION public.costo_real_unitario(
+  p_costo_neto     numeric,
+  p_pct_ii         numeric,
+  p_tipo_factura   text,
+  p_cargo_unitario numeric
+) RETURNS numeric LANGUAGE sql IMMUTABLE AS $fn$
+  SELECT CASE
+    WHEN p_tipo_factura = 'ZZ' THEN round(p_costo_neto + COALESCE(p_cargo_unitario, 0), 4)
+    ELSE round(p_costo_neto * (1 + COALESCE(p_pct_ii, 0) / 100)
+               + COALESCE(p_cargo_unitario, 0), 4)
+  END;
+$fn$;
+
+COMMENT ON FUNCTION public.costo_real_unitario(numeric,numeric,text,numeric) IS
+  'Costo real por unidad (mig 192): neto × (1+II%) + cargos prorrateados. El IVA y las percepciones son crédito fiscal, no costo. ZZ = lo pagado.';
+```
+
+**Step 2: Actualizar los llamadores en la misma migración**
+
+Son **tres**, no cuatro: `registrar_compra_completa`, `actualizar_compra_items` y `anular_compra_atomica`. `cambiar_proveedor_compra` menciona `costo_real_unitario` dos veces pero **no la llama** — son referencias a la columna homónima de `compra_items`. Y está bien que así sea: esa RPC clona la compra copiando la columna guardada, que es justo lo que promete. Contá las llamadas con el paréntesis (`costo_real_unitario(`), no con el nombre pelado, o vas a parchear una función que no la usa. En esta task sólo hay que hacer que **compilen** con el nuevo 4º argumento pasando `0`; la lógica de cargos entra en las tasks siguientes.
+
+Usá el patrón de las migs 177/178: leer el cuerpo con `pg_get_functiondef`, reemplazar el ancla exacta exigiendo que aparezca una sola vez, y fallar si el cuerpo derivó. **No copies el cuerpo completo al archivo de migración.**
+
+Verificá primero cuál es el ancla real en cada función:
+
+```sql
+SELECT p.proname, substring(p.prosrc from position('costo_real_unitario' in p.prosrc) - 40 for 140)
+FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace
+WHERE n.nspname = 'public' AND p.prosrc ILIKE '%costo_real_unitario%' AND p.proname <> 'costo_real_unitario';
+```
+
+**En ZZ el cargo TAMBIÉN suma.** La regla, que va en el `COMMENT` de la función:
+
+> `tipo_factura` decide si se agregan **impuestos** encima, no si se ignoran **costos**.
+
+En ZZ lo pagado ya incluye IVA e impuestos internos y por eso no se le suma nada de eso — son impuestos de esa misma operación, ya adentro del precio. Pero un flete que factura un transportista aparte no está adentro de ese precio: es plata que salió igual. Que la mercadería haya venido con factura o sin ella no cambia que el camión se pagó.
+
+No es un caso de borde: **ZZ es el 47,9% de las compras activas** (58 de 121). Si la rama ZZ descartara el cargo, el flete y los pallets de la mitad de las compras se evaporarían sin aviso en cuanto la Task 9 empiece a pasar cargos reales.
+
+La misma decisión aplica al espejo `calcularCostoReal` de `src/utils/calculations.ts:145`, que hoy tiene 3 parámetros y necesita el cuarto (Task 9).
+
+**Step 3: Aplicar en branch y verificar que no quedó ambigüedad**
+
+```sql
+SELECT proname, pronargs FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace
+WHERE n.nspname='public' AND proname = 'costo_real_unitario';
+```
+Expected: **una sola fila**, `pronargs = 4`.
+
+**Step 4: Commit**
+
+```bash
+git add migrations/193_compra_cargos_funciones.sql && git commit -m "Sumar los cargos al costo real canonico sin dejar sobrecarga ambigua"
+```
+
+---
+
+### Task 8: Espejo SQL del motor de costos
+
+**Files:**
+- Create o Modify: `migrations/193_compra_cargos_funciones.sql`
+
+**Step 1: Escribir `calcular_costos_compra`**
+
+Función que recibe `p_items jsonb`, `p_cargos jsonb` (cada cargo con su `pesos`) y `p_ii_declarado jsonb`, y devuelve por línea: `base_iva`, `ii`, `cargos`, `costo_neto`, `costo_real` (todos unitarios) más el `factor_ajuste` por alícuota.
+
+Es la traducción literal de `calcularCostosCompra` de Task 3. Mantené los mismos nombres de concepto (`base_iva_factura`, `base_costo`, `base_ii`) para que el espejo se lea.
+
+Puntos donde es fácil equivocarse (todos salieron de bugs reales encontrados en la versión de TS):
+
+- `base_costo` incluye **sólo los cargos gravados** con `prorratea_al_costo`. Los no gravados van aparte y se suman recién en el costo final. Si los metés también en `base_costo` **los contás dos veces**.
+- `base_costo` filtra por `prorratea_al_costo`, `base_iva_factura` por `en_factura`. Son filtros distintos a propósito.
+- El IVA se calcula sobre `base_iva_factura`, nunca sobre `base_costo`.
+- **`base_iva_factura` incluye sólo las líneas `gravado`.** Sumar el neto de las exentas y no gravadas la vuelve "neto de la factura" y deja de cuadrar contra el papel.
+- **Normalizá la tasa de II con `round(tasa, 4)` en las DOS puntas** — al agrupar el denominador y al buscar el factor. Nada de tolerancia en una y clave exacta en la otra: una línea que entra al denominador por tolerancia pero no matchea exacto se lleva factor 1 y el total deja de cuadrar. En prod ya conviven `4.1667` y `4.1700` (alguien tipeó 4,17), así que el caso es real. Que queden en buckets distintos **es lo correcto**: si la factura declara un solo bucket y hay una línea en 4,17, el cuadre tiene que avisar.
+- Son **dos** totales de no gravado, no uno: los cargos `en_factura` (van a `compras.no_gravado` y al cuadre) y los que `prorratea_al_costo` (reconcilian contra la suma de los unitarios). Un cargo en factura que no prorratea desaparece si los mezclás.
+- `cantidad = 0` ⇒ todo unitario es 0, no división.
+- El factor de ajuste se calcula **antes** de imputar el II a las líneas.
+
+**Step 2: Verificar contra el golden test**
+
+Aplicá en branch, cargá el fixture de la factura A0005-00461415 y comprobá:
+
+```sql
+-- costo total sin IVA = 12797344.26 (±0,05)
+-- factor de ajuste = 1.000000 en ambas alícuotas
+-- linea 1 (MANAOS LIMA LIMON 600): base_iva 4764.85 · ii 198.54 · cargos 658.97 · costo_real 5622.36
+```
+
+Expected: idéntico al test de TypeScript de Task 4. **Si difieren, hay un bug — no ajustes ninguno de los dos "para que coincidan": encontrá cuál está mal.**
+
+**Step 3: Commit**
+
+```bash
+git add migrations/193_compra_cargos_funciones.sql && git commit -m "Calcular los costos de la compra dentro de la base"
+```
+
+---
+
+### Task 9: `registrar_compra_completa` acepta cargos
+
+**Files:**
+- Create o Modify: `migrations/194_compra_cargos_rpcs.sql`
+
+**Step 1: Extender la firma**
+
+Nuevo parámetro `p_cargos jsonb DEFAULT '[]'::jsonb` **al final**. Con `DEFAULT` y siendo el único agregado, un cliente viejo sigue funcionando igual (manda 17 args, la nueva tiene 18 con default). Verificá que no queden dos sobrecargas: si la firma vieja sigue existiendo, dropeala.
+
+Dentro de la función, después de insertar los `compra_items` (que es cuando existen los ids):
+
+1. Insertar los cargos en `compra_cargos` con la `sucursal_id` de la compra.
+2. Resolver los pesos: el payload los trae por **índice del array `p_items`**, no por id (los ids no existen todavía). Mapear índice → `compra_item_id`.
+3. Insertar `compra_cargo_repartos`.
+4. Llamar a `calcular_costos_compra` y usar su resultado para `costo_neto_unitario`, `cargos_unitarios` y `costo_real_unitario` de cada ítem.
+5. Recalcular el costo promedio con el `costo_real` nuevo.
+
+**Validaciones que deben fallar la transacción:**
+- Un cargo con `prorratea_al_costo = true` y suma de pesos 0 → `RAISE EXCEPTION 'El cargo "%" no tiene ninguna línea asignada', concepto`.
+- Un peso que apunta a un índice inexistente → excepción.
+
+**Step 2: Verificar que una compra sin cargos da idéntico a antes**
+
+En la branch, registrá una compra sin `p_cargos` y comprobá que `costo_real_unitario` es el mismo valor que daba antes de la migración. Es la garantía del forward-only.
+
+**Step 3: Commit**
+
+```bash
+git add migrations/194_compra_cargos_rpcs.sql && git commit -m "Registrar una compra con sus cargos prorrateados"
+```
+
+---
+
+### Task 10: `actualizar_compra_items` — el guard contra el borrado silencioso
+
+**Files:**
+- Create o Modify: `migrations/194_compra_cargos_rpcs.sql`
+
+Esta es la task de mayor riesgo del plan. `actualizar_compra_items` hace `DELETE FROM compra_items`, lo que por CASCADE borra los `compra_cargo_repartos`. Si la RPC no recibe cargos, la compra queda con cargos sin destino: el costo pierde el 16% y `COMPRA-A2` se pone rojo sin que nadie haya tocado nada.
+
+**Step 1: Extender la firma con `p_cargos jsonb DEFAULT NULL`**
+
+Ojo con el `NULL` en vez de `'[]'`: hay que poder distinguir "no me mandaron cargos" de "me mandaron una lista vacía".
+
+**Step 2: Implementar el guard**
+
+```sql
+-- Un cliente con chunk viejo del PWA editando una compra con cargos borraría
+-- los repartos en silencio (el DELETE de compra_items cascadea). Falla explícito.
+IF p_cargos IS NULL AND EXISTS (SELECT 1 FROM compra_cargos WHERE compra_id = p_compra_id) THEN
+  RETURN jsonb_build_object('success', false, 'error',
+    'Esta compra tiene cargos prorrateados. Actualizá la aplicación (recargá la página) antes de editarla.');
+END IF;
+```
+
+**Step 3: Reescribir cargos y repartos**
+
+Cuando `p_cargos` no es NULL: borrar los cargos de la compra e insertarlos de nuevo junto con sus repartos, mapeando por índice contra los `compra_items` recién creados. Después, recalcular costos igual que en Task 9.
+
+**Step 4: Test manual del guard**
+
+En la branch: creá una compra con cargos, después llamá a `actualizar_compra_items` **sin** `p_cargos`.
+Expected: `{"success": false, "error": "Esta compra tiene cargos..."}`, y los cargos siguen intactos.
+
+Repetí con una compra **sin** cargos y sin `p_cargos`.
+Expected: `success: true` — el camino viejo sigue funcionando.
+
+**Step 5: Commit**
+
+```bash
+git add migrations/194_compra_cargos_rpcs.sql && git commit -m "Que editar una compra no borre sus cargos en silencio"
+```
+
+---
+
+### Task 11: `cambiar_proveedor_compra` clona los cargos
+
+**Files:**
+- Create o Modify: `migrations/194_compra_cargos_rpcs.sql`
+
+La función anula la compra y la clona con otro proveedor. Si no clona los cargos, la compra nueva pierde el 16% del costo.
+
+**Step 1:** Después del `INSERT INTO compra_items` de la clonación, copiar `compra_cargos` y `compra_cargo_repartos`, mapeando los `compra_item_id` viejos a los nuevos.
+
+**Step 2: Verificar en branch** que el costo real de cada producto es idéntico antes y después de cambiar el proveedor.
+
+**Step 3: Commit**
+
+```bash
+git add migrations/194_compra_cargos_rpcs.sql && git commit -m "Clonar los cargos al cambiar el proveedor de una compra"
+```
+
+---
+
+### Task 12: Check de integridad `COMPRA-A2`
+
+**Files:**
+- Create o Modify: `migrations/194_compra_cargos_rpcs.sql`
+
+**Step 1: Agregar el check a `auditoria_integridad()`**
+
+Seguí el patrón exacto de la mig 178: leer el cuerpo con `pg_get_functiondef`, insertar la fila nueva junto a la de `COMPRA-A1`, exigir que el ancla aparezca una sola vez, ser idempotente.
+
+```sql
+('COMPRA-A2','high','sum(compra_cargo_repartos) = compra_cargos.monto (mig 192)',
+  (SELECT count(*) FROM compra_cargos c
+    WHERE c.prorratea_al_costo
+      AND abs(COALESCE((SELECT sum(peso) FROM compra_cargo_repartos r WHERE r.cargo_id = c.id), 0)) > 0
+      AND abs(c.monto - COALESCE((SELECT sum(peso) FROM compra_cargo_repartos r WHERE r.cargo_id = c.id), 0)) > 1.0)),
+```
+
+**Cuidado:** el check de arriba compara el monto contra la suma de *pesos*, que no es lo mismo. Lo correcto es comparar contra la suma de los *repartos calculados*. Definí bien qué guardás: si guardás sólo pesos, el check tiene que llamar a `prorratear_cargo` y sumar su salida. Resolvelo antes de escribirlo.
+
+**Step 2: Verificar que arranca en verde**
+
+```sql
+SELECT * FROM auditoria_integridad() WHERE check_id IN ('COMPRA-A1','COMPRA-A2');
+```
+Expected: ambos en 0 violaciones. Si `COMPRA-A2` nace rojo, el gate diario de `.github/workflows/integridad.yml` queda inútil.
+
+**Step 3: Correr el gate local**
+
+Run: `node scripts/check-integridad.mjs`
+Expected: exit 0
+
+**Step 4: Commit**
+
+```bash
+git add migrations/194_compra_cargos_rpcs.sql && git commit -m "Vigilar que los cargos siempre cierren contra lo repartido"
+```
+
+---
+
+### Task 13: Aplicar a producción
+
+Son **tres** migraciones, y se aplican en orden: `192` (tablas), `193` (funciones), `194` (RPCs y el check). Si una falla, las siguientes no van.
+
+**Step 1:** Ensayar las tres, cada una con el bloque `DO` que termina en `RAISE EXCEPTION` (ver arriba). La 193 y la 194 se ensayan **encima** de la 192 dentro del mismo bloque, porque dependen de sus tablas.
+
+**Step 2:** Aplicar con `apply_migration`, una por una, verificando entre cada dos.
+
+**Ojo con el `BEGIN;`/`COMMIT;` explícito** de los archivos: es estilo de la casa (42 de 197 archivos, incluida la 155, que se aplicó bien), pero `apply_migration` envuelve en su propia transacción, así que el `COMMIT` del archivo cierra la externa antes de tiempo. Si el ensayo pasa y el `apply_migration` se comporta raro, ése es el primer sospechoso.
+
+**Step 3:** Verificar en prod:
+
+```sql
+SELECT proname, pronargs FROM pg_proc p JOIN pg_namespace n ON n.oid=p.pronamespace
+ WHERE n.nspname='public' AND proname='costo_real_unitario';           -- 1 fila, 4 args
+SELECT * FROM auditoria_integridad() WHERE severidad IN ('critical','high') AND violaciones > 0;  -- vacío
+SELECT count(*) FROM compras WHERE estado<>'cancelada';                -- sigue 121
+```
+
+**Step 4:** Actualizar `migrations/MANIFEST.md` y correr `npm run check:migrations`.
+
+**Step 5: Commit**
+
+```bash
+git add migrations/MANIFEST.md && git commit -m "Registrar las migs 192-194 en el manifiesto"
+```
+
+---
+
+## Fase 3 — Modal de compras
+
+### Task 14: Tipos y estado del reducer
+
+**Files:**
+- Modify: `src/components/modals/ModalCompra.tsx`
+
+Agregar al estado: `cargos: CargoCompraForm[]` y `iiDeclarado: Record<number, number>`. Las acciones: `AGREGAR_CARGO`, `ACTUALIZAR_CARGO`, `ELIMINAR_CARGO`, `SET_PESO_CARGO`, `SET_II_DECLARADO`, `TRAER_CARGOS_PROVEEDOR`.
+
+Regla de pre-llenado al agregar un cargo o al cambiar `base_prorrateo`: `monto` → peso = neto de la línea; `cantidad` → peso = cantidad; `unidades` → peso = 1 en todas. Al agregar o quitar una línea de producto, el peso de la línea nueva se pre-llena con la misma regla; los pesos ya editados a mano no se pisan.
+
+**Commit:** `git commit -m "Sostener los cargos de compra en el estado del modal"`
+
+---
+
+### Task 15: Sección "Cargos y prorrateo"
+
+**Files:**
+- Modify: `src/components/modals/ModalCompra.tsx`
+
+Sección plegable, cerrada por defecto, sólo visible con `tipoFactura === 'FC'`. Con 4,1 ítems promedio por compra, la compra chica no tiene que verla.
+
+Por cargo: concepto, monto (etiquetado **"sin IVA"**), tratamiento fiscal (reusar el selector de condición de la mig 177), dos casillas separadas —*viene en la factura* / *entra al costo*— y la base de reparto. La casilla *afecta la base de impuestos internos* sólo aparece si el tratamiento es `gravado`.
+
+Al lado de esa última casilla, un texto de ayuda corto: *"Un descuento de precio baja la base; una bonificación comercial no."* Es el flag que nadie va a entender sin la explicación.
+
+**Commit:** `git commit -m "Cargar flete, pallets y bonificaciones en el modal de compra"`
+
+---
+
+### Task 16: Grilla de pesos
+
+**Files:**
+- Modify: `src/components/modals/ModalCompra.tsx`
+
+Al expandir un cargo, una grilla con una fila por línea de producto: nombre, peso editable, y el monto que le toca (calculado con `prorratearCargo`). Pie con la suma —que siempre debe dar el monto del cargo— y un aviso si todos los pesos son 0.
+
+En mobile, lista apilada en vez de tabla (mirá cómo `ItemRow` resuelve el doble layout, `ModalCompra.tsx:1365`).
+
+**`prorratearCargo` lanza ante un peso no finito o negativo** (contrato de Task 2, a propósito: convertir basura en 0 la vuelve indistinguible de una exclusión deliberada). Consecuencias para esta grilla:
+
+- El input devuelve strings; **parseá en el borde del formulario**, no dejes que llegue un string al cálculo.
+- Un campo a medio tipear (`""`, `"-"`, `"1."`) tiene que resolverse a un peso válido antes de llamar, o mostrar el error de esa fila.
+- **La vista previa no puede reventar por un throw.** Envolvela: un peso inválido deja esa fila en error, no la pantalla en blanco.
+
+**Commit:** `git commit -m "Repartir un cargo linea por linea desde el modal"`
+
+---
+
+### Task 17: Vista previa por línea
+
+**Files:**
+- Modify: `src/components/modals/ModalCompra.tsx`
+
+Tabla con las cuatro columnas que hoy el gerente lee del Excel: **base IVA · impuesto interno · no gravado · IVA**, más el costo unitario final. Alimentada por `calcularCostosCompra`.
+
+Debajo, el total del costo puesto en depósito. Para la factura testigo tiene que dar **12.797.344,26**.
+
+**Commit:** `git commit -m "Mostrar el costo final de cada producto antes de confirmar"`
+
+---
+
+### Task 18: Cuadre del impuesto interno
+
+**Files:**
+- Modify: `src/components/modals/ModalCompra.tsx` (`ControlRow` ~línea 1920, `ResumenSection` ~1951)
+
+Extender "Control contra factura" con un campo de II declarado **por alícuota** (las alícuotas presentes en las líneas, no una lista fija).
+
+Mostrar el factor de ajuste resultante. **Si el desvío supera 0,5%, aviso visible**: *"El impuesto interno declarado difiere un X% del calculado. Revisá si alguna bonificación no debería bajar la base, o si alguna alícuota está mal cargada."* Es un aviso, no un bloqueo: hay facturas con redondeos raros.
+
+**Commit:** `git commit -m "Avisar cuando el impuesto interno declarado no cierra"`
+
+---
+
+### Task 19: Plantillas por proveedor
+
+**Files:**
+- Modify: `src/components/modals/ModalCompra.tsx`
+- Modify: `src/hooks/queries/useComprasQuery.ts`
+
+Botón **"Traer cargos de la última compra de este proveedor"**: query de los `compra_cargos` de la última compra no cancelada de ese proveedor, y los carga con monto en 0 (los conceptos y los flags se reusan; los montos cambian cada vez). Los pesos se remapean por `producto_id`; las líneas que no matchean quedan en 0.
+
+Sin esto el reparto manual no es sostenible: flete y pallets se repiten en cada factura de Manaos.
+
+**Commit:** `git commit -m "Reusar los cargos de la ultima compra del proveedor"`
+
+---
+
+### Task 20: Enviar los cargos a la RPC
+
+**Files:**
+- Modify: `src/hooks/queries/useComprasQuery.ts` (`registrarCompra` ~línea 95, `actualizarCompraItems` ~línea 250)
+- Modify: `src/components/modals/ModalCompra.tsx` (submit, ~línea 729)
+- Modify: `src/components/modals/ModalEditarCompra.tsx`
+
+Agregar `p_cargos` a las dos mutaciones. **Los pesos viajan por índice del array de items, no por id de producto** — ver Task 9.
+
+`ModalEditarCompra` tiene que cargar los cargos existentes y reenviarlos siempre, o la RPC lo rechaza por el guard de Task 10.
+
+No toques `src/hooks/supabase/useCompras.ts` (código muerto, ver la última nota del preámbulo).
+
+**Commit:** `git commit -m "Mandar los cargos a la base al guardar la compra"`
+
+---
+
+## Fase 4 — Verificación end-to-end
+
+### Task 21: Cargar la factura real en la app
+
+**Step 1:** `npm run build` — confirmá que compila (si falla por variables de entorno, es el worktree, no el código).
+
+**Step 2:** Levantá la app y cargá la factura `A0005-00461415` completa: 21 renglones, 6 cargos, II declarado por alícuota.
+
+**Step 3:** Comprobá contra el Excel:
+- Factor de ajuste **1,0000** en ambas alícuotas.
+- Costo total sin IVA **12.797.344,26**.
+- MANAOS LIMA LIMON 600cc: base IVA 4.764,85 · II 198,54 · no gravado 658,97 · costo 5.622,36.
+- Los separadores sólo tocan el bidón.
+
+**Step 4:** Guardá y verificá en la base que `productos.costo_real` y `costo_promedio` subieron lo esperado, y que `auditoria_integridad()` sigue en verde.
+
+**Step 5:** Probá editar la compra y confirmá que los cargos sobreviven.
+
+### Task 22: Avisar del cambio en el margen
+
+El costo real de estos productos sube ~16%, así que **el margen reportado va a bajar ~15 puntos**. Avisale al gerente antes de que lo vea en el dashboard: no es una regresión, es que hasta hoy ese 16% no estaba en ningún lado.
+
+---
+
+## Fuera de alcance (no lo hagas en este plan)
+
+- **Una factura repartida entre sucursales.** Hoy son dos compras; el monto del cargo que se carga es el de esa sucursal. Resolverlo de verdad es un cambio de modelo mayor.
+- **Análisis de margen y lista de precios** (hojas `AH..AS` y `LISTA PARA PREVENTISTA` del Excel).
+- **Notas de crédito posteriores del proveedor.**

--- a/src/utils/calculations.fiscal.test.ts
+++ b/src/utils/calculations.fiscal.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect } from 'vitest'
-import { calcularCostoReal, calcularCostoFinanciero, calcularNetoVenta, calcularTotalesCompra, calcularMargenPorcentaje, calcularNetoDesdeTotal } from './calculations'
+import { calcularCostoReal, calcularCostoFinanciero, calcularNetoVenta, calcularMargenPorcentaje, calcularNetoDesdeTotal } from './calculations'
+import { calcularTotalesCompra } from './prorrateoCompra'
+import type { CargoCompra } from './prorrateoCompra'
 
 // Fixture: factura A 0005-00455160 de Refres Now (Manaos) → T.P. Export,
 // 16/06/2026. Tasas efectivas de imp. internos sobre el neto:
@@ -166,6 +168,106 @@ describe('calcularTotalesCompra (estructura de la factura A)', () => {
     expect(t.netoGravado).toBeCloseTo(t.subtotal, 6)
     expect(t.netoExento).toBe(0)
     expect(t.netoNoGravado).toBe(0)
+  })
+})
+
+// Los cargos movieron el neto gravado, el IVA y el impuesto interno de la
+// cabecera al motor. Estos tests fijan las dos mitades del contrato: que una
+// compra SIN cargos siga dando exactamente lo de antes (forward-only), y que con
+// cargos diga lo que dice el papel.
+describe('calcularTotalesCompra: los cargos y el forward-only', () => {
+  const items = [
+    { cantidad: 240, costoUnitario: 5397.25, bonificacion: 0.6, porcentajeIva: 21, impuestosInternos: 8.6956, lineaId: 1 },
+    { cantidad: 120, costoUnitario: 2796.27, bonificacion: 0.6, porcentajeIva: 21, impuestosInternos: 4.1667, lineaId: 2 },
+    { cantidad: 150, costoUnitario: 5123.97, bonificacion: 0.6, porcentajeIva: 21, impuestosInternos: 0, lineaId: 3 },
+  ]
+  const neto = (i: typeof items[number]) => i.cantidad * i.costoUnitario * (1 - i.bonificacion / 100)
+
+  it('sin cargos da la aritmetica de siempre: neto x tasa y neto x alicuota', () => {
+    // Escrita a mano y no contra el motor: es LA formula de antes de los cargos.
+    // Si el motor dejara de reducirse a esto, una compra sin cargos cambiaria de
+    // numero en silencio, que es justo lo que no puede pasar.
+    const t = calcularTotalesCompra(items, 'FC', { percepcionIva: 1000, noGravado: 2000 })
+    expect(t.impuestosInternos).toBeCloseTo(
+      items.reduce((a, i) => a + neto(i) * i.impuestosInternos / 100, 0), 6)
+    expect(t.iva).toBeCloseTo(items.reduce((a, i) => a + neto(i) * i.porcentajeIva / 100, 0), 6)
+    expect(t.netoGravado).toBeCloseTo(items.reduce((a, i) => a + neto(i), 0), 6)
+    expect(t.subtotal).toBeCloseTo(items.reduce((a, i) => a + neto(i), 0), 6)
+  })
+
+  it('pasar cargos vacios es lo mismo que no pasarlos', () => {
+    expect(calcularTotalesCompra(items, 'FC', {}, [], {}))
+      .toEqual(calcularTotalesCompra(items, 'FC'))
+  })
+
+  it('una bonificacion cargada como cargo baja el IVA y el impuesto interno', () => {
+    // El defecto que cerro esto: `calcularTotalesCompra` no veia los cargos, asi
+    // que la bonificacion no bajaba ninguna de las dos bases y la cabecera
+    // viajaba inflada a compras.iva y compras.impuestos_internos.
+    const bonif: CargoCompra = {
+      id: 1, concepto: 'Bonif. promo', monto: -100_000, condicionIva: 'gravado',
+      enFactura: true, prorrateaAlCosto: true, afectaBaseII: true,
+      pesos: { 1: 1, 2: 0, 3: 0 },
+    }
+    const sin = calcularTotalesCompra(items, 'FC')
+    const con = calcularTotalesCompra(items, 'FC', {}, [bonif])
+
+    expect(con.netoGravado).toBeCloseTo(sin.netoGravado - 100_000, 2)
+    expect(con.iva).toBeCloseTo(sin.iva - 100_000 * 0.21, 2)
+    // Cae entera sobre la linea 1, que es la del 8,6956%.
+    expect(con.impuestosInternos).toBeCloseTo(sin.impuestosInternos - 100_000 * 0.086956, 2)
+    // El subtotal NO se toca: lo clava COMPRA-A2 contra SUM(compra_items.subtotal).
+    expect(con.subtotal).toBeCloseTo(sin.subtotal, 6)
+  })
+
+  it('una bonificacion comercial baja el IVA pero NO el impuesto interno', () => {
+    // Es el descubrimiento del rediseno: afectaBaseII distingue el descuento de
+    // precio de la bonificacion comercial.
+    const comercial: CargoCompra = {
+      id: 1, concepto: 'Bonif. comercial', monto: -100_000, condicionIva: 'gravado',
+      enFactura: true, prorrateaAlCosto: true, afectaBaseII: false,
+      pesos: { 1: 1, 2: 0, 3: 0 },
+    }
+    const sin = calcularTotalesCompra(items, 'FC')
+    const con = calcularTotalesCompra(items, 'FC', {}, [comercial])
+
+    expect(con.iva).toBeCloseTo(sin.iva - 100_000 * 0.21, 2)
+    expect(con.impuestosInternos).toBeCloseTo(sin.impuestosInternos, 6)
+  })
+
+  it('un cargo no gravado no toca ninguna de las dos bases', () => {
+    // El flete y los pallets entran al COSTO, no a la base del IVA ni a la del
+    // impuesto interno. La cabecera de no gravado va por su propio campo.
+    const flete: CargoCompra = {
+      id: 1, concepto: 'Flete', monto: 500_000, condicionIva: 'no_gravado',
+      enFactura: false, prorrateaAlCosto: true, afectaBaseII: false,
+      pesos: { 1: 1, 2: 1, 3: 1 },
+    }
+    const sin = calcularTotalesCompra(items, 'FC')
+    const con = calcularTotalesCompra(items, 'FC', {}, [flete])
+
+    expect(con.iva).toBeCloseTo(sin.iva, 6)
+    expect(con.impuestosInternos).toBeCloseTo(sin.impuestosInternos, 6)
+    expect(con.netoGravado).toBeCloseTo(sin.netoGravado, 6)
+  })
+
+  it('en ZZ los cargos no agregan impuestos, igual que la RPC', () => {
+    const cargo: CargoCompra = {
+      id: 1, concepto: 'Bonif.', monto: -100_000, condicionIva: 'gravado',
+      enFactura: true, prorrateaAlCosto: true, afectaBaseII: true,
+      pesos: { 1: 1, 2: 0, 3: 0 },
+    }
+    const t = calcularTotalesCompra(items, 'ZZ', { noGravado: 2000 }, [cargo], { 8.6956: 999 })
+    expect(t.iva).toBe(0)
+    expect(t.impuestosInternos).toBe(0)
+    expect(t.total).toBeCloseTo(t.subtotal, 2)
+  })
+
+  it('el impuesto interno de cabecera queda ajustado al declarado', () => {
+    // Es lo que hace que compras.impuestos_internos y el factor de ajuste hablen
+    // del mismo numero, en vez de que el costo use uno y la cabecera otro.
+    const t = calcularTotalesCompra(items, 'FC', {}, [], { 8.6956: 500_000, 4.1667: 10_000 })
+    expect(t.impuestosInternos).toBeCloseTo(510_000, 2)
   })
 })
 

--- a/src/utils/calculations.prorrateo.test.ts
+++ b/src/utils/calculations.prorrateo.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest'
+import { redondearSQL } from './calculations'
+
+describe('redondearSQL (espejo de round(numeric, n) de Postgres)', () => {
+  it('redondea medio ALEJANDOSE del cero, no hacia +infinito', () => {
+    // Math.round(-0.5) === -0 → esto es lo que NO queremos
+    expect(redondearSQL(-0.005, 2)).toBe(-0.01)
+    expect(redondearSQL(0.005, 2)).toBe(0.01)
+    expect(redondearSQL(-1.235, 2)).toBe(-1.24)
+    expect(redondearSQL(1.235, 2)).toBe(1.24)
+  })
+
+  it('no devuelve -0 (rompe toBe con Object.is)', () => {
+    expect(Object.is(redondearSQL(-0.001, 2), 0)).toBe(true)
+  })
+
+  it('casos triviales', () => {
+    expect(redondearSQL(1900000 / 26, 2)).toBe(73076.92)
+    expect(redondearSQL(0, 2)).toBe(0)
+  })
+
+  // Tabla de referencia: la columna esperada se calculo con round(v,2) EN POSTGRES
+  // (proyecto hmuchlzmuqqxcldbzkgc), no en JavaScript. Es lo que hace que este
+  // test sea un espejo y no una tautologia. Todos estos valores caen en el medio
+  // centavo, que es donde double y numeric discrepan.
+  const REFERENCIA_POSTGRES: Array<[number, number]> = [
+    [1.005, 1.01], [1.015, 1.02], [1.025, 1.03], [1.035, 1.04], [1.045, 1.05],
+    [0.145, 0.15], [0.565, 0.57], [0.005, 0.01], [2.675, 2.68], [8.045, 8.05],
+    [-1.005, -1.01], [-1.025, -1.03], [-0.145, -0.15], [-0.565, -0.57],
+    [-0.005, -0.01], [-2.675, -2.68], [1234.565, 1234.57], [73076.925, 73076.93],
+    [36538.455, 36538.46], [292307.685, 292307.69], [1900000.005, 1900000.01],
+    [1.115, 1.12], [1.215, 1.22], [4.985, 4.99],
+  ]
+
+  it.each(REFERENCIA_POSTGRES)('coincide con round(%s, 2) de Postgres', (valor, esperado) => {
+    expect(redondearSQL(valor)).toBe(esperado)
+  })
+
+  it('decimales negativos: redondea a centenas como Postgres', () => {
+    // round(1234, -2) = 1200 y round(1250, -2) = 1300 EN POSTGRES. Aca el
+    // desplazamiento por string no sirve: `${1234}e--2` es NaN. Por eso los
+    // decimales negativos salen por el branch de multiplicacion.
+    expect(redondearSQL(1234, -2)).toBe(1200)
+    expect(redondearSQL(1250, -2)).toBe(1300)
+    expect(redondearSQL(-1250, -2)).toBe(-1300)
+  })
+
+  it('no explota con notacion exponencial', () => {
+    expect(redondearSQL(1e-7)).toBe(0)
+    expect(redondearSQL(-1e-7)).toBe(0)
+    expect(Number.isNaN(redondearSQL(Infinity))).toBe(true)
+    expect(Number.isNaN(redondearSQL(NaN))).toBe(true)
+  })
+})

--- a/src/utils/calculations.ts
+++ b/src/utils/calculations.ts
@@ -202,8 +202,15 @@ export function calcularCostoPromedioPonderado(
 }
 
 // ============================================
-// CÁLCULOS DE COMPRAS (desglose fiscal completo)
+// CONDICIÓN FRENTE AL IVA
 // ============================================
+//
+// El desglose fiscal de una compra (calcularTotalesCompra y sus tipos) vive en
+// prorrateoCompra.ts y no acá: desde que los cargos existen, el neto gravado,
+// el IVA y el impuesto interno de la cabecera salen del motor de costos, y este
+// módulo es una hoja sin imports que el motor importa. Traer el motor para acá
+// invertiría esa dependencia. Lo único que queda es el tipo, que es genérico y
+// lo usa medio código base.
 
 /**
  * Condición frente al IVA de una línea o de un producto (mig 177).
@@ -211,119 +218,6 @@ export function calcularCostoPromedioPonderado(
  * el libro IVA (columnas distintas), no para el total.
  */
 export type CondicionIva = 'gravado' | 'exento' | 'no_gravado';
-
-export interface CompraItemCalculo {
-  cantidad: number;
-  costoUnitario: number;
-  bonificacion?: number;
-  porcentajeIva?: number;
-  /** Tasa efectiva de imp. internos (%) */
-  impuestosInternos?: number;
-  /** Default: 'gravado' (así se comporta una línea que no lo trae). */
-  condicionIva?: CondicionIva;
-}
-
-export interface CompraExtras {
-  percepcionIva?: number;
-  percepcionIibb?: number;
-  noGravado?: number;
-  otrosImpuestos?: number;
-}
-
-export interface TotalesCompra {
-  subtotalBruto: number;
-  bonificacionTotal: number;
-  /**
-   * Neto de TODAS las líneas (bruto − bonif) = netoGravado + netoExento +
-   * netoNoGravado. Es lo que se manda como p_subtotal y lo que valida el check
-   * COMPRA-A2 contra SUM(compra_items.subtotal): no estrecharlo a "sólo
-   * gravado" o toda factura mixta quedaría en rojo.
-   */
-  subtotal: number;
-  netoGravado: number;
-  netoExento: number;
-  /** Líneas de producto no gravadas. NO es `noGravado` (cabecera, sin línea). */
-  netoNoGravado: number;
-  /** Neto gravado abierto por alícuota: { '21': 10000, '10.5': 5000 } */
-  netoPorAlicuota: Record<string, number>;
-  iva: number;
-  impuestosInternos: number;
-  percepcionIva: number;
-  percepcionIibb: number;
-  /** Conceptos de cabecera fuera del IVA (pallets, envases): sin línea de producto. */
-  noGravado: number;
-  otrosImpuestos: number;
-  total: number;
-}
-
-/**
- * Totales de una compra según tipo de comprobante (fuente única del modal de
- * compras; estructura = factura A real: total = neto de líneas + IVA + II +
- * percepciones + no gravado de cabecera + otros).
- *
- * Una misma factura puede mezclar condiciones (mig 177): sólo las líneas
- * gravadas generan IVA, y el crédito se liquida una vez por alícuota, igual que
- * lo imprime el proveedor.
- *
- * ZZ (sin factura): lo pagado es todo — sin IVA, sin II, sin percepciones ni
- * no gravado, y sin clasificación (espejo del RPC, que fuerza 'gravado').
- * total = subtotal.
- */
-export function calcularTotalesCompra(
-  items: CompraItemCalculo[],
-  tipoFactura: 'ZZ' | 'FC' = 'FC',
-  extras: CompraExtras = {}
-): TotalesCompra {
-  const esFC = tipoFactura === 'FC';
-  let subtotalBruto = 0;
-  let bonificacionTotal = 0;
-  let impuestosInternos = 0;
-  let netoGravado = 0;
-  let netoExento = 0;
-  let netoNoGravado = 0;
-  const netoPorAlicuota: Record<string, number> = {};
-
-  for (const item of items) {
-    const bruto = (item.cantidad || 0) * (item.costoUnitario || 0);
-    const bonif = bruto * (item.bonificacion || 0) / 100;
-    const neto = bruto - bonif;
-    subtotalBruto += bruto;
-    bonificacionTotal += bonif;
-
-    // En ZZ no hay comprobante que clasificar: todo entra como gravado.
-    const condicion: CondicionIva = esFC ? (item.condicionIva ?? 'gravado') : 'gravado';
-    if (condicion === 'exento') netoExento += neto;
-    else if (condicion === 'no_gravado') netoNoGravado += neto;
-    else netoGravado += neto;
-
-    if (esFC) {
-      // Los imp. internos son un impuesto propio: no dependen de la condición
-      // frente al IVA.
-      impuestosInternos += neto * ((item.impuestosInternos || 0) / 100);
-      if (condicion === 'gravado') {
-        const alicuota = String(item.porcentajeIva ?? 21);
-        netoPorAlicuota[alicuota] = (netoPorAlicuota[alicuota] || 0) + neto;
-      }
-    }
-  }
-
-  const iva = Object.entries(netoPorAlicuota)
-    .reduce((acc, [alicuota, neto]) => acc + neto * (parseFloat(alicuota) / 100), 0);
-
-  const subtotal = subtotalBruto - bonificacionTotal;
-  const percepcionIva = esFC ? (extras.percepcionIva || 0) : 0;
-  const percepcionIibb = esFC ? (extras.percepcionIibb || 0) : 0;
-  const noGravado = esFC ? (extras.noGravado || 0) : 0;
-  const otrosImpuestos = esFC ? (extras.otrosImpuestos || 0) : 0;
-  const total = subtotal + iva + impuestosInternos + percepcionIva + percepcionIibb + noGravado + otrosImpuestos;
-
-  return {
-    subtotalBruto, bonificacionTotal, subtotal,
-    netoGravado, netoExento, netoNoGravado, netoPorAlicuota,
-    iva, impuestosInternos,
-    percepcionIva, percepcionIibb, noGravado, otrosImpuestos, total,
-  };
-}
 
 // ============================================
 // CÁLCULOS DE PEDIDOS
@@ -468,6 +362,43 @@ export function redondear(valor: number, decimales: number = 2): number {
 }
 
 /**
+ * Redondea medio ALEJANDOSE del cero, como round(numeric, n) de PostgreSQL.
+ * Existe porque el prorrateo de cargos se va a replicar en plpgsql y los dos
+ * lados tienen que dar el mismo número al centavo.
+ *
+ * Corrige dos asimetrías de `redondear` (que es Math.round pelado):
+ *  - Signo: Math.round redondea medio hacia +infinito, así que diverge en
+ *    negativos (Math.round(-0.5) === -0 vs round(-0.5) = -1).
+ *  - Representación: multiplicar por 10^n arrastra el error del double y baja
+ *    donde Postgres sube (Math.abs(1.005) * 100 da 100.49999999999999, no
+ *    100.5). Por eso el desplazamiento va por string: String(1.005) es "1.005"
+ *    —la representación round-trip más corta del double, o sea su intención
+ *    decimal— y "1.005e2" da 100.5 limpio. Multiplicar no lo logra.
+ *
+ * ALCANCE: la equivalencia es para montos de dinero, no universal. `numeric` es
+ * decimal exacto y `double` no, así que ninguna función sobre double puede ser
+ * espejo de round(numeric, n) en general: un valor que el double ni siquiera
+ * representa no tiene por qué caer del mismo lado. Verificada contra la base
+ * para plata a 2 decimales, que es lo único que redondeamos con esta.
+ */
+export function redondearSQL(valor: number, decimales: number = 2): number {
+  if (!Number.isFinite(valor)) return NaN;
+  const signo = valor < 0 ? -1 : 1;
+  const abs = Math.abs(valor);
+  // Tres casos que no pueden ir por el desplazamiento de string: abajo de 1e-6 y
+  // arriba de 1e21 String() usa notación exponencial y armaría "1e-7e2", y con
+  // decimales < 0 el signo del exponente se duplica y armaría "1234e--2". Van
+  // por multiplicación, que ahí alcanza: los dos extremos redondean a 0 o no son
+  // montos de dinero, y el caso de centenas está verificado contra la base.
+  if (abs !== 0 && (abs < 1e-6 || abs >= 1e21 || decimales < 0)) {
+    const factor = Math.pow(10, decimales);
+    return (signo * Math.round(abs * factor) / factor) + 0;
+  }
+  const desplazado = Math.round(Number(`${abs}e${decimales}`));
+  return signo * Number(`${desplazado}e-${decimales}`) + 0;  // el + 0 normaliza -0
+}
+
+/**
  * Redondea al múltiplo más cercano (ej: redondear a 0.50, 1, 5, 10)
  *
  * @param valor - Número a redondear
@@ -491,7 +422,6 @@ export default {
   calcularNetoVenta,
   calcularCostoReal,
   calcularCostoFinanciero,
-  calcularTotalesCompra,
   calcularSubtotalItem,
   calcularTotalPedido,
   calcularMargenPorcentaje,
@@ -499,5 +429,14 @@ export default {
   calcularPrecioDesdeMargen,
   parsePrecio,
   redondear,
+  redondearSQL,
   redondearAMultiplo
 };
+
+// Puente transitorio: `calcularTotalesCompra` y sus tipos se mudaron a
+// `prorrateoCompra.ts` porque el desglose fiscal ahora necesita el motor de
+// cargos, y traer el motor para acá invertía la dependencia. Se re-exporta desde
+// el lugar viejo para no romper a quien todavía importe de acá; el consumidor
+// real (ModalCompra) migra en el PR del modal y ahí se cae este puente.
+export { calcularTotalesCompra } from './prorrateoCompra';
+export type { TotalesCompra, CompraItemCalculo, CompraExtras } from './prorrateoCompra';

--- a/src/utils/condicionIva.ts
+++ b/src/utils/condicionIva.ts
@@ -28,6 +28,29 @@ export const OPCIONES_CONDICION_IVA: OpcionCondicionIva[] = [
   { clave: 'no_gravado', label: 'No gravado', labelCorto: 'No grav.', condicion: 'no_gravado', porcentaje: 0 },
 ];
 
+/** Nombre de la condición sola, sin la alícuota. */
+const LABEL_CONDICION: Record<CondicionIva, string> = {
+  gravado: 'Gravado',
+  exento: 'Exento',
+  no_gravado: 'No gravado',
+};
+
+/**
+ * Tratamientos frente al IVA SIN alícuota, para lo que tributa a la de otro.
+ *
+ * Un cargo de compra (flete, pallets, bonificación) no lleva alícuota propia:
+ * hereda la de las líneas sobre las que se prorratea, y por eso `CargoCompra`
+ * no tiene `porcentajeIva`. Ofrecerle el selector completo pondría "21%" y
+ * "10,5%" como opciones distintas que hacen exactamente lo mismo.
+ *
+ * Se deriva de OPCIONES_CONDICION_IVA a propósito, para que siga habiendo una
+ * sola lista: agregar una condición allá la trae acá, y el Record de arriba
+ * obliga a nombrarla.
+ */
+export const OPCIONES_CONDICION_SIN_ALICUOTA: Array<{ condicion: CondicionIva; label: string }> =
+  Array.from(new Set(OPCIONES_CONDICION_IVA.map(o => o.condicion)))
+    .map(condicion => ({ condicion, label: LABEL_CONDICION[condicion] }));
+
 /** Clave del selector para un par (condición, alícuota) cargado. */
 export function claveCondicionIva(
   condicion: CondicionIva | null | undefined,

--- a/src/utils/prorrateoCompra.escalabilidad.test.ts
+++ b/src/utils/prorrateoCompra.escalabilidad.test.ts
@@ -1,0 +1,39 @@
+// Garantia de que el motor no asume gaseosas: sirve para cualquier rubro, con o
+// sin impuesto interno, con cualquier alicuota de IVA. Sin cargos el costo se
+// reduce a neto x (1 + II%), que es la formula de siempre.
+
+import { describe, it, expect } from 'vitest'
+import { calcularCostosCompra, type LineaCompra } from './prorrateoCompra'
+const L = (o: Partial<LineaCompra> = {}): LineaCompra => ({
+  id: 1, cantidad: 10, costoUnitario: 100, bonificacion: 0,
+  impuestosInternos: 0, porcentajeIva: 21, condicionIva: 'gravado', ...o })
+
+describe('escalabilidad fuera de gaseosas', () => {
+  it('sin impuesto interno y sin cargos: costo = neto', () => {
+    const r = calcularCostosCompra([L()], [], {})
+    expect(r.lineas[0].costoRealUnitario).toBe(100)
+  })
+  it('con impuesto interno y sin cargos: costo = neto x (1 + II%)', () => {
+    const r = calcularCostosCompra([L({ impuestosInternos: 8.6956 })], [], {})
+    expect(r.lineas[0].costoRealUnitario).toBeCloseTo(108.6956, 4)
+  })
+  it('con bonificacion de linea: el neto ya viene bonificado', () => {
+    const r = calcularCostosCompra([L({ bonificacion: 10, impuestosInternos: 4.1667 })], [], {})
+    expect(r.lineas[0].costoNetoUnitario).toBe(90)
+    expect(r.lineas[0].costoRealUnitario).toBeCloseTo(90 * 1.041667, 4)
+  })
+  it('rubro no gravado (exento) y sin II: costo = neto, IVA 0', () => {
+    const r = calcularCostosCompra([L({ condicionIva: 'exento', porcentajeIva: 0 })], [], {})
+    expect(r.lineas[0].costoRealUnitario).toBe(100)
+    expect(r.lineas[0].ivaUnitario).toBe(0)
+  })
+  it('alicuota de II arbitraria (no de gaseosas): 17,3913%', () => {
+    const r = calcularCostosCompra([L({ impuestosInternos: 17.3913 })], [], {})
+    expect(r.lineas[0].costoRealUnitario).toBeCloseTo(117.3913, 4)
+  })
+  it('IVA 10,5% (rubro alimentos): el II no se toca', () => {
+    const r = calcularCostosCompra([L({ porcentajeIva: 10.5, impuestosInternos: 0 })], [], {})
+    expect(r.lineas[0].ivaUnitario).toBe(10.5)
+    expect(r.lineas[0].costoRealUnitario).toBe(100)
+  })
+})

--- a/src/utils/prorrateoCompra.espejo.ts
+++ b/src/utils/prorrateoCompra.espejo.ts
@@ -1,0 +1,547 @@
+import {
+  prorratearCargo,
+  calcularCostosCompra,
+  type CargoCompra,
+  type CostosCompra,
+  type LineaCompra,
+  type PesosCargo,
+} from './prorrateoCompra'
+import { redondearSQL, type CondicionIva } from './calculations'
+
+// =============================================================================
+// EL ESPEJO ENTRE LAS DOS IMPLEMENTACIONES DEL MOTOR DE COMPRAS
+// =============================================================================
+//
+// Hay dos motores que tienen que dar el MISMO número al centavo:
+//
+//   · TypeScript — `src/utils/prorrateoCompra.ts`. Alimenta la vista previa del
+//     modal, que anticipa el costo sin ir a la base.
+//   · SQL — `prorratear_cargo` y `calcular_costos_compra` (mig 193). Es la
+//     implementación CANÓNICA: lo que se persiste sale de ahí.
+//
+// Existen las dos porque el número se calcula y se guarda en la base pero el
+// modal tiene que mostrarlo antes de guardar. Los dos archivos dicen "si cambiás
+// una, cambiá la otra" desde el día uno, y hasta ahora eso era una frase.
+//
+// Este módulo es el material compartido de las dos capas que lo verifican:
+//
+//   1 · `prorrateoCompra.espejo.test.ts` — vitest, sin red. Corre el TS contra
+//       un fixture con la salida del SQL. Rápido, siempre, pero SÓLO ve el lado
+//       TS: el fixture es una foto, no la base.
+//   2 · `scripts/espejo-motor-compras.mjs` — corre LAS DOS sobre los mismos
+//       casos y las compara adentro de Postgres. Es el que ve los dos lados, y
+//       el único que puede detectar que se movió el SQL. Vive en el gate de
+//       integridad, que es el que tiene credenciales.
+//
+// NADA DE ACÁ ENTRA AL BUNDLE: ningún módulo de la app lo importa. Vive en
+// `src/utils` y no en `scripts/` porque el test de vitest sólo levanta
+// `src/**/*.test.ts`, y porque el dato de la factura testigo que exporta es el
+// mismo que consume el golden.
+//
+// EL CONTRATO DE COMPARACIÓN, que es lo que hace que esto signifique algo:
+//
+//   · Las entradas se escriben UNA vez, en forma de cable (el JSON snake_case
+//     que viajaría a la RPC), y el MISMO texto va a los dos motores. Si cada
+//     lado armara su propia entrada, el espejo compararía dos cosas distintas.
+//   · La comparación numérica la hace Postgres con `IS DISTINCT FROM` sobre
+//     `numeric`, no JS: así `500` contra `500.00` no cuenta —numeric ignora la
+//     escala— y un centavo sí.
+//   · Se compara a `DECIMALES_ESPEJO` decimales y no bit a bit, porque el TS
+//     acumula en `double` y el SQL en `numeric` (decimal exacto). Esa diferencia
+//     es de orden 1e-9 sobre los montos de esta factura; el redondeo que este
+//     espejo tiene que cazar es de 1e-2. Ver la constante.
+//
+// =============================================================================
+
+/**
+ * Decimales a los que se comparan las dos implementaciones.
+ *
+ * No es una tolerancia elegida a ojo. El TS suma en `double` y el SQL en
+ * `numeric`, que es decimal exacto: sobre la factura testigo (13,3 M repartidos
+ * en 21 líneas) el error relativo del double, 2^-52, deja una discrepancia del
+ * orden de 1e-9. Comparar bit a bit haría fallar el espejo por eso y no por un
+ * bug. Comparar al centavo dejaría pasar un cambio de redondeo de 3 decimales.
+ *
+ * 6 decimales están tres órdenes de magnitud arriba del ruido del double y
+ * cuatro por debajo del centavo: caza cualquier divergencia real y no inventa
+ * ninguna. Si alguna vez hay que moverlo, que sea con la cuenta hecha.
+ */
+export const DECIMALES_ESPEJO = 6
+
+export type MotorEspejo = 'prorratear_cargo' | 'calcular_costos_compra'
+
+/** Un caso: un nombre, qué motor lo corre y la entrada en forma de cable. */
+export interface CasoEspejo {
+  caso: string
+  motor: MotorEspejo
+  /** El JSON tal cual viaja: claves snake_case, como las de la mig 192. */
+  entrada: Record<string, unknown>
+  /** De dónde salió. Va al reporte, para que ningún caso quede sin dueño. */
+  origen: string
+}
+
+// -----------------------------------------------------------------------------
+// Traducción entre la forma de cable (snake_case, la de la mig 192) y la del TS
+//
+// Es mecánica y va en un solo lugar a propósito: es la única diferencia legítima
+// entre los dos motores —el TS usa camelCase y el jsonb de la RPC snake_case— y
+// dos copias de esta tabla se desincronizan igual que los motores.
+//
+// Las funciones `deWire` NO validan ni completan: el casteo es a ciegas para que
+// un caso de contrato —una condición inventada, una cantidad nula— llegue al
+// motor exactamente como llegaría desde la red. Validar acá taparía justo lo que
+// se quiere medir. `espejoRoundTrip` en el test fija que la traducción de ida y
+// vuelta sea la identidad, así el golden no se compara contra una entrada
+// mutilada sin que nadie se entere.
+// -----------------------------------------------------------------------------
+
+export function lineaAWire(l: LineaCompra): Record<string, unknown> {
+  return {
+    id: l.id,
+    cantidad: l.cantidad,
+    costo_unitario: l.costoUnitario,
+    bonificacion: l.bonificacion,
+    impuestos_internos: l.impuestosInternos,
+    porcentaje_iva: l.porcentajeIva,
+    condicion_iva: l.condicionIva,
+  }
+}
+
+export function lineaDeWire(e: Record<string, unknown>): LineaCompra {
+  return {
+    id: e.id as number,
+    cantidad: e.cantidad as number,
+    costoUnitario: e.costo_unitario as number,
+    bonificacion: e.bonificacion as number,
+    impuestosInternos: e.impuestos_internos as number,
+    porcentajeIva: e.porcentaje_iva as number,
+    condicionIva: e.condicion_iva as CondicionIva,
+  }
+}
+
+export function cargoAWire(c: CargoCompra): Record<string, unknown> {
+  return {
+    id: c.id,
+    concepto: c.concepto,
+    monto: c.monto,
+    condicion_iva: c.condicionIva,
+    en_factura: c.enFactura,
+    prorratea_al_costo: c.prorrateaAlCosto,
+    afecta_base_ii: c.afectaBaseII,
+    pesos: c.pesos,
+  }
+}
+
+export function cargoDeWire(e: Record<string, unknown>): CargoCompra {
+  return {
+    id: e.id as number,
+    concepto: e.concepto as string,
+    monto: e.monto as number,
+    condicionIva: e.condicion_iva as CondicionIva,
+    enFactura: e.en_factura as boolean,
+    prorrateaAlCosto: e.prorratea_al_costo as boolean,
+    afectaBaseII: e.afecta_base_ii as boolean,
+    pesos: e.pesos as PesosCargo,
+  }
+}
+
+/**
+ * La salida del motor de TS, escrita con los nombres del jsonb de la mig 193.
+ *
+ * Las líneas van ORDENADAS POR ID porque el SQL las emite con `ORDER BY f.id` y
+ * el TS en el orden de entrada: sin esto la comparación cotejaría `lineas[0]` de
+ * uno contra `lineas[0]` del otro y en una factura con los ids desordenados
+ * marcaría 126 divergencias que no existen.
+ */
+export function costosAWire(r: CostosCompra): Record<string, unknown> {
+  return {
+    lineas: [...r.lineas]
+      .sort((a, b) => a.id - b.id)
+      .map(l => ({
+        id: l.id,
+        base_iva: l.baseIvaUnitaria,
+        ii: l.iiUnitario,
+        cargos: l.cargosUnitarios,
+        iva: l.ivaUnitario,
+        costo_neto: l.costoNetoUnitario,
+        costo_real: l.costoRealUnitario,
+      })),
+    totales: {
+      neto_gravado: r.totales.netoGravado,
+      neto_exento: r.totales.netoExento,
+      neto_no_gravado: r.totales.netoNoGravado,
+      iva: r.totales.iva,
+      impuestos_internos: r.totales.impuestosInternos,
+      no_gravado: r.totales.noGravado,
+      cargos_al_costo: r.totales.cargosAlCosto,
+    },
+    factor_ajuste: r.factorAjuste,
+  }
+}
+
+/** Lo que devuelve correr el motor de TS sobre un caso: un valor o una excepción. */
+export interface SalidaTS {
+  ts: Record<string, unknown> | null
+  ts_error: string | null
+}
+
+/**
+ * Corre el motor de TypeScript sobre la entrada de cable de un caso.
+ *
+ * Atrapa la excepción y la devuelve como dato en vez de dejarla propagar: que
+ * una implementación LANCE es parte del resultado que hay que comparar, no un
+ * accidente. Un caso de contrato pasa sólo si las dos lanzan.
+ */
+export function correrMotorTS(caso: CasoEspejo): SalidaTS {
+  try {
+    if (caso.motor === 'prorratear_cargo') {
+      const e = caso.entrada as { monto: number; pesos: PesosCargo }
+      return { ts: prorratearCargo(e.monto, e.pesos) as Record<string, unknown>, ts_error: null }
+    }
+    const e = caso.entrada as {
+      items: Record<string, unknown>[]
+      cargos: Record<string, unknown>[]
+      ii_declarado: Record<number, number>
+    }
+    // `ii_declarado` va SIN traducir: las claves de un objeto de JS ya son texto,
+    // así que el objeto del cable ES el que espera el motor. Traducirlo con
+    // Number() colapsaría "10" y "10.0" en una sola clave y taparía el caso de
+    // los buckets que se pisan.
+    const costos = calcularCostosCompra(
+      e.items.map(lineaDeWire),
+      e.cargos.map(cargoDeWire),
+      e.ii_declarado
+    )
+    return { ts: costosAWire(costos), ts_error: null }
+  } catch (err) {
+    return { ts: null, ts_error: err instanceof Error ? err.message : String(err) }
+  }
+}
+
+// -----------------------------------------------------------------------------
+// Comparación (la del lado JS, para la capa 1)
+//
+// La capa 2 compara adentro de Postgres, que es la que vale. Esta reproduce el
+// mismo criterio sobre el fixture: mismo camino de aplanado —así los nombres de
+// campo de los dos reportes son los mismos— y mismo redondeo.
+// -----------------------------------------------------------------------------
+
+/**
+ * La misma estructura con cada número redondeado a `decimales`.
+ *
+ * Es lo que se congela en el fixture. El SQL devuelve `numeric` con veinte
+ * decimales de relleno (`100.00000000000000000000`) o con la cola entera de una
+ * división (`198.5433333333333333`), y ninguna de las dos cosas se puede
+ * preservar: JSON.parse ya las bajó a `double`. Guardar `198.54333333333332`
+ * sería un número que no es ni el del SQL ni el de nadie; guardar `198.543333`
+ * es exactamente lo que el espejo compara, y además se lee en un diff.
+ */
+export function redondearSalida(valor: unknown, decimales: number = DECIMALES_ESPEJO): unknown {
+  if (typeof valor === 'number') return redondearSQL(valor, decimales)
+  if (Array.isArray(valor)) return valor.map(v => redondearSalida(v, decimales))
+  if (valor !== null && typeof valor === 'object') {
+    return Object.fromEntries(
+      Object.entries(valor).map(([k, v]) => [k, redondearSalida(v, decimales)])
+    )
+  }
+  return valor
+}
+
+export interface DivergenciaEspejo {
+  campo: string
+  ts: unknown
+  sql: unknown
+  motivo: string
+}
+
+/** Aplana un JSON a `{ '.lineas[0].base_iva': 4764.85, … }`. Mismo path que el SQL. */
+function hojas(valor: unknown, path = '', acc = new Map<string, unknown>()): Map<string, unknown> {
+  if (Array.isArray(valor)) {
+    valor.forEach((v, i) => hojas(v, `${path}[${i}]`, acc))
+    return acc
+  }
+  if (valor !== null && typeof valor === 'object') {
+    for (const [k, v] of Object.entries(valor)) hojas(v, `${path}.${k}`, acc)
+    return acc
+  }
+  acc.set(path, valor)
+  return acc
+}
+
+/**
+ * Las celdas en las que dos salidas del motor no dicen lo mismo.
+ *
+ * Devuelve también cuántas celdas se compararon: un caso que compara 0 celdas
+ * (las dos salidas vacías) pasa, y el reporte tiene que dejarlo ver en vez de
+ * contarlo como una victoria.
+ */
+export function diferencias(
+  ts: unknown,
+  sql: unknown,
+  decimales: number = DECIMALES_ESPEJO
+): { celdas: number; divergencias: DivergenciaEspejo[] } {
+  const a = hojas(ts)
+  const b = hojas(sql)
+  const campos = [...new Set([...a.keys(), ...b.keys()])].sort()
+  const divergencias: DivergenciaEspejo[] = []
+
+  for (const campo of campos) {
+    const enTS = a.has(campo)
+    const enSQL = b.has(campo)
+    const vTS = a.get(campo)
+    const vSQL = b.get(campo)
+    if (!enTS || !enSQL) {
+      divergencias.push({
+        campo,
+        ts: vTS ?? null,
+        sql: vSQL ?? null,
+        motivo: enTS ? 'falta en el SQL' : 'falta en el TS',
+      })
+      continue
+    }
+    if (typeof vTS === 'number' && typeof vSQL === 'number') {
+      if (redondearSQL(vTS, decimales) !== redondearSQL(vSQL, decimales)) {
+        divergencias.push({ campo, ts: vTS, sql: vSQL, motivo: 'difiere' })
+      }
+      continue
+    }
+    if (vTS !== vSQL) divergencias.push({ campo, ts: vTS, sql: vSQL, motivo: 'difiere' })
+  }
+
+  return { celdas: campos.length, divergencias }
+}
+
+// =============================================================================
+// LA FACTURA TESTIGO
+// =============================================================================
+
+/**
+ * Factura A0005-00461415 de Manaos: 21 renglones, 13,3 M. Es el caso que motivó
+ * el rediseño de cargos y el único con la respuesta conocida de antemano (el
+ * Excel del gerente).
+ *
+ * Vive acá y no adentro del golden porque ahora tiene DOS consumidores —el
+ * golden, que fija los números contra el Excel, y el espejo, que la manda a los
+ * dos motores— y dos copias de 21 líneas se desincronizan sin que nada avise.
+ */
+export const ITEMS_TESTIGO: LineaCompra[] = [
+  { id: 1,  cantidad: 60,  costoUnitario: 4793.61, bonificacion: 0.6, impuestosInternos: 4.1667, porcentajeIva: 21, condicionIva: 'gravado' },
+  { id: 2,  cantidad: 60,  costoUnitario: 4793.61, bonificacion: 0.6, impuestosInternos: 4.1667, porcentajeIva: 21, condicionIva: 'gravado' },
+  { id: 3,  cantidad: 120, costoUnitario: 5782.77, bonificacion: 0.6, impuestosInternos: 8.6956, porcentajeIva: 21, condicionIva: 'gravado' },
+  { id: 4,  cantidad: 75,  costoUnitario: 3994.67, bonificacion: 0.6, impuestosInternos: 4.1667, porcentajeIva: 21, condicionIva: 'gravado' },
+  { id: 5,  cantidad: 75,  costoUnitario: 3994.67, bonificacion: 0.6, impuestosInternos: 4.1667, porcentajeIva: 21, condicionIva: 'gravado' },
+  { id: 6,  cantidad: 120, costoUnitario: 2972.04, bonificacion: 0.6, impuestosInternos: 4.1667, porcentajeIva: 21, condicionIva: 'gravado' },
+  { id: 7,  cantidad: 80,  costoUnitario: 2316.91, bonificacion: 0.6, impuestosInternos: 4.1667, porcentajeIva: 21, condicionIva: 'gravado' },
+  { id: 8,  cantidad: 280, costoUnitario: 2197.07, bonificacion: 0.6, impuestosInternos: 4.1667, porcentajeIva: 21, condicionIva: 'gravado' },
+  { id: 9,  cantidad: 120, costoUnitario: 4626.22, bonificacion: 0.6, impuestosInternos: 8.6956, porcentajeIva: 21, condicionIva: 'gravado' },
+  { id: 10, cantidad: 150, costoUnitario: 5123.97, bonificacion: 0.6, impuestosInternos: 0,      porcentajeIva: 21, condicionIva: 'gravado' },
+  { id: 11, cantidad: 240, costoUnitario: 5782.77, bonificacion: 0.6, impuestosInternos: 8.6956, porcentajeIva: 21, condicionIva: 'gravado' },
+  { id: 12, cantidad: 60,  costoUnitario: 5782.77, bonificacion: 0.6, impuestosInternos: 8.6956, porcentajeIva: 21, condicionIva: 'gravado' },
+  { id: 13, cantidad: 60,  costoUnitario: 5992.01, bonificacion: 0.6, impuestosInternos: 4.1667, porcentajeIva: 21, condicionIva: 'gravado' },
+  { id: 14, cantidad: 120, costoUnitario: 5782.77, bonificacion: 0.6, impuestosInternos: 8.6956, porcentajeIva: 21, condicionIva: 'gravado' },
+  { id: 15, cantidad: 60,  costoUnitario: 5782.77, bonificacion: 0.6, impuestosInternos: 8.6956, porcentajeIva: 21, condicionIva: 'gravado' },
+  { id: 16, cantidad: 115, costoUnitario: 8347.11, bonificacion: 0.6, impuestosInternos: 0,      porcentajeIva: 21, condicionIva: 'gravado' },
+  { id: 17, cantidad: 140, costoUnitario: 3822.90, bonificacion: 0.6, impuestosInternos: 4.1667, porcentajeIva: 21, condicionIva: 'gravado' },
+  { id: 18, cantidad: 140, costoUnitario: 3822.90, bonificacion: 0.6, impuestosInternos: 4.1667, porcentajeIva: 21, condicionIva: 'gravado' },
+  { id: 19, cantidad: 140, costoUnitario: 3822.90, bonificacion: 0.6, impuestosInternos: 4.1667, porcentajeIva: 21, condicionIva: 'gravado' },
+  { id: 20, cantidad: 120, costoUnitario: 2796.27, bonificacion: 0.6, impuestosInternos: 4.1667, porcentajeIva: 21, condicionIva: 'gravado' },
+  { id: 21, cantidad: 168, costoUnitario: 1030.63, bonificacion: 0.6, impuestosInternos: 4.1667, porcentajeIva: 21, condicionIva: 'gravado' },
+]
+
+const neto = (id: number) => {
+  const l = ITEMS_TESTIGO.find(x => x.id === id)!
+  return l.cantidad * l.costoUnitario * (1 - l.bonificacion / 100)
+}
+const pesosPorMonto = (ids: number[]) => Object.fromEntries(ids.map(id => [id, neto(id)]))
+
+// Pallets segun la factura. El flete reparte sobre 26 (los Placer 500cc entran
+// medio pallet); los pallets valorizados se cobran sobre 27 (esos dos van enteros).
+const PALLETS_FLETE: Record<number, number> = { 1: .5, 2: .5, 3: 2, 4: .5, 5: .5, 6: 1, 7: 1, 8: 2, 9: 1, 10: 2, 11: 4, 12: 1, 13: 1, 14: 2, 15: 1, 16: 1, 17: 1, 18: 1, 19: 1, 20: 1, 21: 1 }
+const PALLETS:       Record<number, number> = { ...PALLETS_FLETE, 4: 1, 5: 1 }
+
+export const CARGOS_TESTIGO: CargoCompra[] = [
+  { id: 1, concepto: 'Flete y descarga', monto: 1_900_000, condicionIva: 'no_gravado',
+    enFactura: false, prorrateaAlCosto: true, afectaBaseII: false, pesos: PALLETS_FLETE },
+  { id: 2, concepto: 'Pallets x 9 tacos', monto: 162_000, condicionIva: 'no_gravado',
+    enFactura: true, prorrateaAlCosto: true, afectaBaseII: false, pesos: PALLETS },
+  { id: 3, concepto: 'Separadores bidon', monto: 8_800, condicionIva: 'no_gravado',
+    enFactura: true, prorrateaAlCosto: true, afectaBaseII: false, pesos: { 21: 1 } },
+  // Descuento de precio: SI baja la base del impuesto interno
+  { id: 4, concepto: 'Bonif. promo COLA 3.00', monto: -103_465.32, condicionIva: 'gravado',
+    enFactura: true, prorrateaAlCosto: true, afectaBaseII: true, pesos: pesosPorMonto([3, 11]) },
+  // Bonificacion comercial: NO baja la base del impuesto interno. Este flag es
+  // TODO el descubrimiento: sin el, el II no cuadra por casi 5%.
+  { id: 5, concepto: 'Bonif. promo 3000cc', monto: -203_318.28, condicionIva: 'gravado',
+    enFactura: true, prorrateaAlCosto: true, afectaBaseII: false, pesos: pesosPorMonto([3, 11, 12, 13, 14, 15]) },
+  { id: 6, concepto: 'Redondeo', monto: -0.49, condicionIva: 'gravado',
+    enFactura: true, prorrateaAlCosto: true, afectaBaseII: true, pesos: pesosPorMonto(ITEMS_TESTIGO.map(i => i.id)) },
+]
+
+export const II_DECLARADO_TESTIGO: Record<number, number> = { 8.6956: 338_884.46, 4.1667: 199_027.21 }
+
+// =============================================================================
+// LOS CASOS
+// =============================================================================
+
+const entradaCostos = (
+  items: LineaCompra[],
+  cargos: CargoCompra[] = [],
+  iiDeclarado: Record<number, number> = {}
+): Record<string, unknown> => ({
+  items: items.map(lineaAWire),
+  cargos: cargos.map(cargoAWire),
+  ii_declarado: iiDeclarado,
+})
+
+const linea = (over: Partial<LineaCompra> = {}): LineaCompra => ({
+  id: 1, cantidad: 10, costoUnitario: 100, bonificacion: 0,
+  impuestosInternos: 0, porcentajeIva: 21, condicionIva: 'gravado', ...over,
+})
+const cargo = (over: Partial<CargoCompra> = {}): CargoCompra => ({
+  id: 1, concepto: 'x', monto: 0, condicionIva: 'no_gravado',
+  enFactura: true, prorrateaAlCosto: true, afectaBaseII: false, pesos: {}, ...over,
+})
+
+const UNIT = 'prorrateoCompra.test.ts'
+const GOLDEN = 'prorrateoCompra.golden.test.ts'
+
+/**
+ * Los repartos: los diez casos unitarios de `prorratearCargo`, tal cual están en
+ * la suite. No hay ninguno inventado a propósito: un caso que no está en ningún
+ * test es un caso que nadie revisó.
+ */
+const CASOS_PRORRATEO: CasoEspejo[] = [
+  { caso: 'reparto · proporcional al peso', motor: 'prorratear_cargo', origen: UNIT,
+    entrada: { monto: 1000, pesos: { 1: 1, 2: 1 } } },
+  { caso: 'reparto · la suma da el monto exacto', motor: 'prorratear_cargo', origen: UNIT,
+    entrada: { monto: 1000, pesos: { 1: 1, 2: 1, 3: 1 } } },
+  { caso: 'reparto · el residuo va a la linea de mayor peso', motor: 'prorratear_cargo', origen: UNIT,
+    entrada: { monto: 100, pesos: { 1: 1, 2: 1, 3: 4 } } },
+  { caso: 'reparto · empate de peso maximo: desempata por menor id', motor: 'prorratear_cargo', origen: UNIT,
+    entrada: { monto: 100, pesos: { 7: 1, 3: 1, 5: 1 } } },
+  { caso: 'reparto · peso cero excluye la linea', motor: 'prorratear_cargo', origen: UNIT,
+    entrada: { monto: 880, pesos: { 1: 0, 2: 0, 3: 1 } } },
+  { caso: 'reparto · monto negativo (bonificacion)', motor: 'prorratear_cargo', origen: UNIT,
+    entrada: { monto: -100, pesos: { 1: 1, 2: 1, 3: 1 } } },
+  { caso: 'reparto · redondeo de Postgres: medio centavo negativo', motor: 'prorratear_cargo', origen: UNIT,
+    entrada: { monto: -0.01, pesos: { 1: 1, 2: 1 } } },
+  { caso: 'reparto · suma de pesos cero devuelve vacio', motor: 'prorratear_cargo', origen: UNIT,
+    entrada: { monto: 1000, pesos: { 1: 0, 2: 0 } } },
+  { caso: 'reparto · sin pesos devuelve vacio', motor: 'prorratear_cargo', origen: UNIT,
+    entrada: { monto: 100, pesos: {} } },
+  { caso: 'reparto · el flete real: 1.900.000 sobre 26 pallets', motor: 'prorratear_cargo', origen: UNIT,
+    entrada: { monto: 1_900_000, pesos: PALLETS_FLETE } },
+]
+
+/** Los casos de `calcularCostosCompra` que ya fija la suite unitaria. */
+const CASOS_MOTOR: CasoEspejo[] = [
+  { caso: 'motor · sin cargos: neto x (1 + II%)', motor: 'calcular_costos_compra', origen: UNIT,
+    entrada: entradaCostos([linea({ impuestosInternos: 8.6956 })]) },
+  { caso: 'motor · un cargo NO gravado entra al costo pero no a la base de IVA', motor: 'calcular_costos_compra', origen: UNIT,
+    entrada: entradaCostos([linea()], [cargo({ monto: 500, pesos: { 1: 1 } })]) },
+  { caso: 'motor · un cargo fuera de factura entra al costo y no al IVA', motor: 'calcular_costos_compra', origen: UNIT,
+    entrada: entradaCostos([linea()], [cargo({ monto: 500, condicionIva: 'gravado', enFactura: false, pesos: { 1: 1 } })]) },
+  { caso: 'motor · afectaBaseII=false: baja el IVA pero no el impuesto interno', motor: 'calcular_costos_compra', origen: UNIT,
+    entrada: entradaCostos([linea({ impuestosInternos: 10 })], [cargo({ monto: -200, condicionIva: 'gravado', afectaBaseII: false, pesos: { 1: 1 } })]) },
+  { caso: 'motor · afectaBaseII=true: baja las dos bases', motor: 'calcular_costos_compra', origen: UNIT,
+    entrada: entradaCostos([linea({ impuestosInternos: 10 })], [cargo({ monto: -200, condicionIva: 'gravado', afectaBaseII: true, pesos: { 1: 1 } })]) },
+  { caso: 'motor · el factor de ajuste cuadra el II declarado', motor: 'calcular_costos_compra', origen: UNIT,
+    entrada: entradaCostos([linea({ impuestosInternos: 10 })], [], { 10: 110 }) },
+  { caso: 'motor · cantidad 0 no explota', motor: 'calcular_costos_compra', origen: UNIT,
+    entrada: entradaCostos([linea({ cantidad: 0 })]) },
+  { caso: 'motor · la linea exenta no suma a netoGravado pero tiene costo', motor: 'calcular_costos_compra', origen: UNIT,
+    entrada: entradaCostos([linea({ id: 1 }), linea({ id: 2, condicionIva: 'exento', porcentajeIva: 0 })]) },
+  { caso: 'motor · la linea no gravada abre su propio total', motor: 'calcular_costos_compra', origen: UNIT,
+    entrada: entradaCostos([linea({ id: 1 }), linea({ id: 2, condicionIva: 'no_gravado', porcentajeIva: 0 })]) },
+  { caso: 'motor · un cargo en factura que no prorratea: no gravado y no costo', motor: 'calcular_costos_compra', origen: UNIT,
+    entrada: entradaCostos([linea()], [cargo({ monto: 500, prorrateaAlCosto: false, pesos: { 1: 1 } })]) },
+  { caso: 'motor · 4.17 y 4.1667 son alicuotas distintas', motor: 'calcular_costos_compra', origen: UNIT,
+    entrada: entradaCostos([linea({ id: 1, impuestosInternos: 4.1667 }), linea({ id: 2, impuestosInternos: 4.17 })], [], { 4.1667: 50 }) },
+]
+
+/** La factura testigo entera: 21 líneas, 6 cargos, las dos alícuotas declaradas. */
+const CASOS_TESTIGO: CasoEspejo[] = [
+  { caso: 'testigo · factura A0005-00461415 completa', motor: 'calcular_costos_compra', origen: GOLDEN,
+    entrada: entradaCostos(ITEMS_TESTIGO, CARGOS_TESTIGO, II_DECLARADO_TESTIGO) },
+  { caso: 'testigo · la misma factura sin el cargo de separadores', motor: 'calcular_costos_compra', origen: GOLDEN,
+    entrada: entradaCostos(ITEMS_TESTIGO, CARGOS_TESTIGO.filter(c => c.concepto !== 'Separadores bidon'), II_DECLARADO_TESTIGO) },
+  { caso: 'testigo · sin el II declarado (factor 1, sin ajuste)', motor: 'calcular_costos_compra', origen: GOLDEN,
+    entrada: entradaCostos(ITEMS_TESTIGO, CARGOS_TESTIGO) },
+]
+
+/**
+ * Los casos de CONTRATO: los dos motores tienen que LANZAR.
+ *
+ * Coincidir cuando andan es la mitad del espejo. La otra mitad es que el dato
+ * corrupto se frene en los dos lados: si el SQL lanza y el TS devuelve un
+ * número, la vista previa le muestra al usuario un costo que la base va a
+ * rechazar —o peor, uno que nadie va a poder explicar—.
+ *
+ * SOBRE EL NaN Y EL INFINITO: no existen en JSON. `JSON.stringify(NaN)` es
+ * `null`, así que en el cable —que es lo que este espejo compara— la única forma
+ * de un peso podrido es `null` o una cadena. Los dos casos están, y los dos
+ * motores tienen que rechazar los dos.
+ */
+const CASOS_CONTRATO: CasoEspejo[] = [
+  { caso: 'contrato · peso negativo', motor: 'prorratear_cargo', origen: UNIT,
+    entrada: { monto: 100, pesos: { 1: 1, 2: -1 } } },
+  { caso: 'contrato · peso no finito (null en el cable)', motor: 'prorratear_cargo', origen: UNIT,
+    entrada: { monto: 100, pesos: { 1: null, 2: 1 } } },
+  { caso: 'contrato · peso no finito (la cadena "NaN")', motor: 'prorratear_cargo', origen: UNIT,
+    entrada: { monto: 100, pesos: { 1: 1, 2: 'NaN' } } },
+  { caso: 'contrato · monto no finito (null en el cable)', motor: 'prorratear_cargo', origen: UNIT,
+    entrada: { monto: null, pesos: { 1: 1 } } },
+  { caso: 'contrato · monto no finito (la cadena "Infinity")', motor: 'prorratear_cargo', origen: UNIT,
+    entrada: { monto: 'Infinity', pesos: { 1: 1 } } },
+  { caso: 'contrato · cantidad negativa', motor: 'calcular_costos_compra', origen: UNIT,
+    entrada: entradaCostos([linea({ id: 7, cantidad: -1 })]) },
+  { caso: 'contrato · cantidad no finita (null en el cable)', motor: 'calcular_costos_compra', origen: UNIT,
+    entrada: { items: [{ ...lineaAWire(linea({ id: 4 })), cantidad: null }], cargos: [], ii_declarado: {} } },
+  { caso: 'contrato · condicion_iva invalida en la linea', motor: 'calcular_costos_compra', origen: 'mig 193',
+    entrada: { items: [{ ...lineaAWire(linea()), condicion_iva: 'gravada' }], cargos: [], ii_declarado: {} } },
+  { caso: 'contrato · condicion_iva invalida en el cargo', motor: 'calcular_costos_compra', origen: 'mig 193',
+    entrada: { items: [lineaAWire(linea())], cargos: [{ ...cargoAWire(cargo({ monto: 100, pesos: { 1: 1 } })), condicion_iva: 'grabado' }], ii_declarado: {} } },
+  { caso: 'contrato · dos lineas con el mismo id', motor: 'calcular_costos_compra', origen: 'mig 193',
+    entrada: entradaCostos([linea({ id: 1 }), linea({ id: 1 })]) },
+  { caso: 'contrato · dos tasas declaradas que colapsan al mismo bucket', motor: 'calcular_costos_compra', origen: 'mig 193',
+    entrada: { items: [lineaAWire(linea({ impuestosInternos: 10 }))], cargos: [], ii_declarado: { '10': 100, '10.0': 100 } } },
+]
+
+/** Todo lo que el espejo compara. El orden es el del reporte. */
+export const CASOS_ESPEJO: CasoEspejo[] = [
+  ...CASOS_PRORRATEO,
+  ...CASOS_MOTOR,
+  ...CASOS_TESTIGO,
+  ...CASOS_CONTRATO,
+]
+
+/**
+ * Los casos que esperan que LAS DOS implementaciones lancen.
+ *
+ * Se deriva del nombre y no de un flag por caso para que agregar un caso de
+ * contrato sea imposible de olvidar marcar.
+ */
+export const esCasoDeContrato = (c: CasoEspejo) => c.caso.startsWith('contrato ·')
+
+/**
+ * LO QUE ESTE ESPEJO NO CUBRE. Está acá y no sólo en el README porque un límite
+ * que no se lee es un límite que se olvida:
+ *
+ *  · `resolverBasesII` NO TIENE ESPEJO EN SQL. El solver de bases de impuesto
+ *    interno vive sólo en TypeScript: la mig 193 no lo implementa y no hay nada
+ *    contra qué compararlo. Lo cubren `prorrateoCompra.test.ts` y el golden, y
+ *    nada más. Que use `calcularCostosCompra` por dentro tampoco lo cubre: el
+ *    espejo verifica el motor, no la búsqueda que lo llama 2^N veces.
+ *  · `calcularTotalesCompra` y `lineaParaMotor` tampoco: la regla de ZZ y la
+ *    cabecera fiscal tienen su espejo en la mig 194 (`v_items_motor`), que este
+ *    archivo no toca.
+ *  · Los DEFAULTS del borde jsonb. La mig 193 completa las claves ausentes
+ *    (`condicion_iva`, `en_factura`, `porcentaje_iva`…) y el TS no las tiene
+ *    porque se las exige el compilador. Es una asimetría deliberada y
+ *    documentada en la 193; acá todos los casos mandan el objeto completo.
+ */
+export const NO_CUBIERTO = [
+  'resolverBasesII (el solver de bases de II) no tiene implementacion en SQL: no hay espejo posible',
+  'calcularTotalesCompra / lineaParaMotor (la regla de ZZ y la cabecera fiscal, mig 194)',
+  'los defaults del borde jsonb de la mig 193: todos los casos mandan el objeto completo',
+] as const

--- a/src/utils/prorrateoCompra.golden.test.ts
+++ b/src/utils/prorrateoCompra.golden.test.ts
@@ -1,0 +1,212 @@
+import { describe, it, expect } from 'vitest'
+import { calcularCostosCompra, calcularTotalesCompra, resolverBasesII, toleranciaII } from './prorrateoCompra'
+import { ITEMS_TESTIGO, CARGOS_TESTIGO, II_DECLARADO_TESTIGO } from './prorrateoCompra.espejo'
+
+// La factura testigo —21 renglones, 13,3 M— vive en `prorrateoCompra.espejo.ts`
+// desde que tiene dos consumidores: este golden, que fija sus numeros contra el
+// Excel del gerente, y el espejo, que manda la misma factura a los dos motores.
+// Dos copias de 21 lineas se desincronizan sin que nada avise.
+//
+// Es el caso que motivo este rediseno. El Excel del gerente cuadra el impuesto
+// interno con un factor manual de 1,0496; aca tiene que dar 1,0000.
+const ITEMS = ITEMS_TESTIGO
+const CARGOS = CARGOS_TESTIGO
+const II_DECLARADO = II_DECLARADO_TESTIGO
+
+describe('Factura A0005-00461415 (caso testigo del rediseno)', () => {
+  const r = calcularCostosCompra(ITEMS, CARGOS, II_DECLARADO)
+
+  it('el impuesto interno cuadra SOLO: factor de ajuste = 1', () => {
+    // El Excel del gerente necesita 1,0496 aca. Modelando afectaBaseII, da 1.
+    expect(r.factorAjuste[8.6956]).toBeCloseTo(1, 5)
+    expect(r.factorAjuste[4.1667]).toBeCloseTo(1, 5)
+  })
+
+  it('el factor se aplica a todas las lineas del bucket', () => {
+    // Esta igualdad es POR CONSTRUCCION (factor = declarado/calculado), asi que no
+    // valida el modelo: pasaria igual con afectaBaseII en false en todos lados. El
+    // que valida el modelo es el test de arriba. Lo que si protege es que la tasa
+    // se normalice igual en las dos puntas —4.1667 y 8.6956 tienen que caer en su
+    // bucket— y que el factor llegue a TODAS las lineas, no a algunas.
+    expect(r.totales.impuestosInternos).toBeCloseTo(338_884.46 + 199_027.21, 1)
+  })
+
+  it('el costo total sin IVA coincide con el Excel dentro de 5 centavos', () => {
+    // La tolerancia es `toBeCloseTo(_, 1)`, o sea +-0,05, y NO el centavo: el
+    // modelo da 12.797.344,2543 y el Excel dice 12.797.344,26. Medio centavo de
+    // diferencia, que es lo que hay. Decir "al centavo" afirmaba mas de lo que
+    // este assert puede sostener.
+    // Y ademas: lo que la base PERSISTE no es esta suma. `costo_real_unitario`
+    // es numeric(12,4), asi que redondea el UNITARIO y despues multiplica por la
+    // cantidad: sobre las 2.503 unidades de esta factura eso da 12.797.344,23
+    // (-0,0267, con cota teorica 0,1252). Verificado contra produccion.
+    const total = r.lineas.reduce(
+      (acc, l, i) => acc + l.costoRealUnitario * ITEMS[i].cantidad, 0)
+    expect(total).toBeCloseTo(12_797_344.26, 1)
+  })
+
+  it('MANAOS LIMA LIMON 600cc: desglose completo por pack', () => {
+    const l = r.lineas.find(x => x.id === 1)!
+    expect(l.baseIvaUnitaria).toBeCloseTo(4764.85, 2)
+    expect(l.iiUnitario).toBeCloseTo(198.54, 2)
+    expect(l.cargosUnitarios).toBeCloseTo(658.97, 2)   // flete + pallets
+    expect(l.ivaUnitario).toBeCloseTo(1000.62, 2)
+    expect(l.costoRealUnitario).toBeCloseTo(5622.36, 2)
+  })
+
+  it('los separadores caen 100% en el bidon y en ningun otro producto', () => {
+    // Diferencial contra la misma factura sin el cargo de separadores: lo unico
+    // que puede moverse son los 8.800 del bidon. Un centavo en cualquier otra
+    // linea es un separador que se fue de contrabando.
+    const sinSeparadores = calcularCostosCompra(
+      ITEMS, CARGOS.filter(c => c.concepto !== 'Separadores bidon'), II_DECLARADO)
+    const delta = (id: number) =>
+      r.lineas.find(x => x.id === id)!.cargosUnitarios -
+      sinSeparadores.lineas.find(x => x.id === id)!.cargosUnitarios
+
+    // Primero el que nombra al culpable: si falla, el mensaje trae el id de la
+    // linea que se llevo separadores que no le tocaban.
+    const contrabando = ITEMS.filter(i => i.id !== 21 && delta(i.id) !== 0).map(i => i.id)
+    expect(contrabando).toEqual([])
+    expect(delta(21) * 168).toBeCloseTo(8_800, 2)
+    // Y ademas de los separadores el bidon paga su parte de flete y pallets:
+    // 73.076,92 + 6.000 + 8.800 = 87.876,92 / 168
+    expect(r.lineas.find(x => x.id === 21)!.cargosUnitarios).toBeCloseTo(523.08, 2)
+  })
+
+  it('el modelo NO copia el reparto de II del Excel: lo corrige', () => {
+    // El factor proporcional del Excel unta el II de la promo sobre productos
+    // que no participaron. MANAOS COLA 600cc (id 9) no tuvo promo: el Excel le
+    // carga 419,70 por pack, el modelo 399,86.
+    const sinPromo = r.lineas.find(x => x.id === 9)!
+    expect(sinPromo.iiUnitario).toBeCloseTo(399.86, 2)
+  })
+
+  it('la cabecera fiscal sale del motor y no de un loop sobre las lineas', () => {
+    // El defecto que este test cierra: `calcularTotalesCompra` no veia los
+    // cargos, asi que las tres bonificaciones gravadas no bajaban ninguna base.
+    // Los dos numeros de abajo son los que viajan a compras.impuestos_internos y
+    // compras.iva, o sea a la posicion fiscal.
+    const t = calcularTotalesCompra(
+      ITEMS.map(i => ({ ...i, lineaId: i.id })), 'FC', {}, CARGOS, II_DECLARADO)
+
+    // Ajustado al declarado: 338.884,46 + 199.027,21. Antes daba 546.908,57.
+    expect(t.impuestosInternos).toBeCloseTo(537_911.67, 2)
+    // Sobre la base gravada REAL (10.188.632,58), no sobre los netos de linea.
+    // Antes daba 2.204.037,50, o sea 64.424,66 de credito fiscal inventado.
+    expect(t.netoGravado).toBeCloseTo(10_188_632.58, 2)
+    expect(t.iva).toBeCloseTo(10_188_632.58 * 0.21, 2)
+    // El subtotal sigue siendo el neto de las LINEAS: lo clava COMPRA-A2 contra
+    // SUM(compra_items.subtotal), y por eso el total de cabecera no puede bajar
+    // los cargos gravados. Ver el comentario de TotalesCompra.subtotal.
+    expect(t.subtotal).toBeCloseTo(10_495_416.67, 2)
+  })
+
+  it('los cargos no gravados entran al costo pero no a la base de IVA', () => {
+    // Los 2.070.800 de flete + pallets + separadores no son gravados. Si entraran
+    // a la base gravada, el IVA se inflaria en 434.868 que nadie facturo.
+    // 10.188.632,58 = netos de las 21 lineas (10.495.416,67) menos las tres
+    // bonificaciones gravadas (306.784,09), y nada mas.
+    expect(r.totales.netoGravado).toBeCloseTo(10_188_632.58, 2)
+    expect(r.totales.cargosAlCosto).toBeCloseTo(2_070_800, 2)
+    // De esos 2.070.800 solo 170.800 (pallets + separadores) estan en el papel:
+    // el flete lo factura el transportista aparte, de ahi enFactura: false.
+    expect(r.totales.noGravado).toBeCloseTo(170_800, 2)
+  })
+})
+
+describe('El solver deduce afectaBaseII de la misma factura', () => {
+  // Lo que el golden de arriba tiene CLAVADO —COLA 3.00 baja la base, 3000cc
+  // no—, acá se DEDUCE del impuesto interno declarado. Si el solver deduce otra
+  // cosa, uno de los dos está mal y hay que mirar los dos.
+  const r = resolverBasesII(ITEMS, CARGOS, II_DECLARADO)
+
+  it('encuentra una sola combinacion, y es la del golden', () => {
+    expect(r.estado).toBe('unica')
+    expect(r.soluciones[0].asignacion).toEqual({
+      4: true,   // Bonif. promo COLA 3.00 → descuento de precio
+      5: false,  // Bonif. promo 3000cc    → bonificación comercial
+    })
+  })
+
+  it('el redondeo de -0,49 es indeterminable, no una tercera variable', () => {
+    // Mueve el impuesto interno 1,6 centavos: la factura no puede decidirlo. Si
+    // entrara a la búsqueda, cada solución vendría con su gemela y el resultado
+    // sería "ambigua" para siempre — o sea, el ajuste proporcional de vuelta.
+    expect(r.indeterminables).toEqual([6])
+    expect(r.candidatos).toEqual([4, 5])
+  })
+
+  it('cierra a 6 centavos sobre 338.884, que es el redondeo del proveedor', () => {
+    expect(r.soluciones[0].residuos[8.6956]).toBeCloseTo(0.06, 2)
+    expect(r.soluciones[0].residuos[4.1667]).toBeCloseTo(0, 2)
+  })
+
+  it('LA SEPARACION: la correcta entra holgada y la siguiente queda afuera', () => {
+    // Este test es el que sostiene la tolerancia elegida. Aflojarla hasta que
+    // pasen los 795,40 del 4,1667% convierte al solver en un generador de
+    // respuestas plausibles; apretarla por debajo de los 6 centavos rechaza la
+    // única respuesta correcta que conocemos.
+    expect(r.soluciones[0].holgura).toBeLessThan(0.01)   // 300 veces adentro del borde
+
+    const conAmbas = CARGOS.map(c => c.id === 5 ? { ...c, afectaBaseII: true } : c)
+    const iiAmbas = calcularCostosCompra(ITEMS, conAmbas, {})
+    const ii4 = ITEMS.reduce((acc, l, i) =>
+      acc + (l.impuestosInternos === 4.1667 ? iiAmbas.lineas[i].iiUnitario * l.cantidad : 0), 0)
+    expect(199_027.21 - ii4).toBeCloseTo(795.40, 1)
+    expect(toleranciaII(199_027.21)).toBeCloseTo(99.51, 2)
+    expect(Math.abs(199_027.21 - ii4)).toBeGreaterThan(toleranciaII(199_027.21) * 7)
+  })
+
+  it('sin el impuesto interno declarado no hay nada que deducir', () => {
+    // El casillero vacío no es "no baja la base": es "no sé". El solver lo dice
+    // y la interfaz cae al ajuste proporcional avisando que es una aproximación.
+    expect(resolverBasesII(ITEMS, CARGOS, {}).estado).toBe('sin_datos')
+  })
+})
+
+describe('La cabecera cuadra contra el papel: bonificaciones de factura', () => {
+  const t = calcularTotalesCompra(
+    ITEMS.map(i => ({ ...i, lineaId: i.id })), 'FC',
+    { noGravado: 170_800 }, CARGOS, II_DECLARADO)
+
+  it('la bonificacion general es la suma de los cargos gravados EN la factura', () => {
+    // Las dos promos más el redondeo: -103.465,32 -203.318,28 -0,49.
+    expect(t.bonificaciones).toBeCloseTo(-306_784.09, 2)
+  })
+
+  it('el total baja 306.784,09: es lo que la cabecera no tenia donde restar', () => {
+    // `subtotal` es el neto de los RENGLONES y lo clava COMPRA-A2 contra
+    // SUM(compra_items.subtotal), así que una bonificación general —que no es un
+    // renglón de producto— no tenía columna. El total salía 306.784,09 arriba
+    // del papel y COMPRA-A1 (severidad high) se ponía rojo.
+    const viejo = t.subtotal + t.iva + t.impuestosInternos
+      + t.percepcionIva + t.percepcionIibb + t.noGravado + t.otrosImpuestos
+    expect(viejo - t.total).toBeCloseTo(306_784.09, 2)
+    // ±0,05 y no el centavo: el impuesto interno ajustado arrastra una cola
+    // sub-centavo (537.911,6670) que el total hereda. La base redondea a 2
+    // decimales al persistir; acá no hay dónde hacerlo sin mentir.
+    expect(t.total).toBeCloseTo(13_036_957.10, 1)
+  })
+
+  it('la identidad de COMPRA-A1 (mig 195) cierra al centavo', () => {
+    expect(t.total).toBeCloseTo(
+      t.subtotal + t.bonificaciones + t.iva + t.impuestosInternos
+      + t.percepcionIva + t.percepcionIibb + t.noGravado + t.otrosImpuestos, 6)
+  })
+
+  it('y ahora las filas del resumen suman el total que muestran', () => {
+    // El resumen imprime el GRAVADO (que ya trae la bonificación adentro), no el
+    // subtotal, así que hasta la mig 195 las filas visibles sumaban 306.784,09
+    // menos que el "Total" impreso abajo de ellas.
+    expect(t.netoGravado + t.netoExento + t.netoNoGravado + t.iva
+           + t.impuestosInternos + t.noGravado).toBeCloseTo(t.total, 6)
+  })
+
+  it('en ZZ no hay papel contra el que cuadrar: total = subtotal', () => {
+    const zz = calcularTotalesCompra(
+      ITEMS.map(i => ({ ...i, lineaId: i.id })), 'ZZ', {}, CARGOS, II_DECLARADO)
+    expect(zz.bonificaciones).toBe(0)
+    expect(zz.total).toBeCloseTo(zz.subtotal, 6)
+  })
+})

--- a/src/utils/prorrateoCompra.test.ts
+++ b/src/utils/prorrateoCompra.test.ts
@@ -1,0 +1,350 @@
+import { describe, it, expect } from 'vitest'
+import { prorratearCargo, calcularCostosCompra, resolverBasesII, toleranciaII, TOLERANCIA_II_PISO, MAX_CARGOS_BASE_II, type CargoCompra, type LineaCompra } from './prorrateoCompra'
+import { redondearSQL } from './calculations'
+
+describe('prorratearCargo', () => {
+  it('reparte proporcional al peso', () => {
+    expect(prorratearCargo(1000, { 1: 1, 2: 1 })).toEqual({ 1: 500, 2: 500 })
+  })
+
+  it('la suma de los repartos SIEMPRE da el monto exacto', () => {
+    const r = prorratearCargo(1000, { 1: 1, 2: 1, 3: 1 })
+    expect(Object.values(r).reduce((a, b) => a + b, 0)).toBe(1000)
+  })
+
+  it('el residuo va a la linea de mayor peso', () => {
+    // 100 / 3 partes desiguales: 1+1+4 = 6 → 16.67 + 16.67 + 66.66 = 100.00
+    const r = prorratearCargo(100, { 1: 1, 2: 1, 3: 4 })
+    expect(r[1]).toBe(16.67)
+    expect(r[2]).toBe(16.67)
+    expect(r[3]).toBe(66.66)
+  })
+
+  it('empate de peso maximo: desempata por menor id', () => {
+    const r = prorratearCargo(100, { 7: 1, 3: 1, 5: 1 })
+    expect(Object.values(r).reduce((a, b) => a + b, 0)).toBe(100)
+    expect(r[3]).toBe(33.34) // el residuo cae en el id menor
+  })
+
+  it('peso cero excluye la linea (es el mecanismo de alcance)', () => {
+    const r = prorratearCargo(880, { 1: 0, 2: 0, 3: 1 })
+    expect(r[3]).toBe(880)
+    expect(r[1]).toBe(0)
+  })
+
+  it('monto negativo (bonificacion) reparte igual y suma exacto', () => {
+    const r = prorratearCargo(-100, { 1: 1, 2: 1, 3: 1 })
+    expect(Object.values(r).reduce((a, b) => a + b, 0)).toBe(-100)
+  })
+
+  it('usa el redondeo de Postgres, no el de JS: medio centavo negativo', () => {
+    // Con redondear() (Math.round) esto daria {1: -0.01, 2: -0}: el residuo cae
+    // en la linea equivocada. Es el unico caso de la suite que distingue las dos
+    // funciones de redondeo, asi que una regresion a redondear() lo rompe.
+    const r = prorratearCargo(-0.01, { 1: 1, 2: 1 })
+    expect(r[2]).toBe(-0.01)
+    expect(r[1]).toBe(0)
+  })
+
+  it('suma de pesos cero devuelve vacio', () => {
+    expect(prorratearCargo(1000, { 1: 0, 2: 0 })).toEqual({})
+  })
+
+  it('el flete real de la factura: 1.900.000 sobre 26 pallets', () => {
+    const pesos = { 1: 0.5, 2: 0.5, 3: 2, 4: 0.5, 5: 0.5, 6: 1, 7: 1, 8: 2, 9: 1, 10: 2,
+                    11: 4, 12: 1, 13: 1, 14: 2, 15: 1, 16: 1, 17: 1, 18: 1, 19: 1, 20: 1, 21: 1 }
+    const r = prorratearCargo(1900000, pesos)
+    expect(r[1]).toBe(36538.46)   // medio pallet
+    expect(r[6]).toBe(73076.92)   // un pallet
+    expect(r[11]).toBe(292307.72) // la linea del residuo: absorbe 3 centavos sobre el proporcional
+    // Sumar 21 floats acumula error (da 1899999.9999999995). Cada parte es
+    // exacta al centavo; el total hay que releerlo al centavo. En SQL no pasa:
+    // numeric es decimal exacto y sum() da 1900000 clavado.
+    expect(redondearSQL(Object.values(r).reduce((a, b) => a + b, 0), 2)).toBe(1900000)
+  })
+
+  it('sin pesos devuelve vacio', () => {
+    expect(prorratearCargo(100, {})).toEqual({})
+  })
+
+  describe('contrato de entrada: el cero es valido, el negativo y el NaN son corrupcion', () => {
+    it('peso negativo: falla nombrando la linea, no se come el cargo', () => {
+      // Antes devolvia {} (los pesos se cancelaban a 0) y el cargo desaparecia entero.
+      expect(() => prorratearCargo(100, { 1: 1, 2: -1 })).toThrow(/peso negativo en la linea 2/)
+    })
+
+    it('peso NaN: falla nombrando la linea, no redistribuye en silencio', () => {
+      // Antes Number(v) || 0 lo volvia 0 y la linea 2 se llevaba los 100 enteros.
+      expect(() => prorratearCargo(100, { 1: NaN, 2: 1 })).toThrow(/peso no finito en la linea 1/)
+    })
+
+    it('peso Infinity: falla nombrando la linea', () => {
+      expect(() => prorratearCargo(100, { 1: 1, 2: Infinity })).toThrow(/peso no finito en la linea 2/)
+    })
+
+    it('monto no finito: falla (antes no habia ninguna defensa del lado del monto)', () => {
+      expect(() => prorratearCargo(NaN, { 1: 1 })).toThrow(/monto no finito/)
+      expect(() => prorratearCargo(Infinity, { 1: 1 })).toThrow(/monto no finito/)
+    })
+  })
+})
+
+describe('calcularCostosCompra', () => {
+  const linea = (over: Partial<LineaCompra> = {}): LineaCompra => ({
+    id: 1, cantidad: 10, costoUnitario: 100, bonificacion: 0,
+    impuestosInternos: 0, porcentajeIva: 21, condicionIva: 'gravado', ...over,
+  })
+  const cargo = (over: Partial<CargoCompra> = {}): CargoCompra => ({
+    id: 1, concepto: 'x', monto: 0, condicionIva: 'no_gravado',
+    enFactura: true, prorrateaAlCosto: true, afectaBaseII: false, pesos: {}, ...over,
+  })
+
+  it('sin cargos se comporta igual que hoy: neto x (1 + II%)', () => {
+    const r = calcularCostosCompra([linea({ impuestosInternos: 8.6956 })], [], {})
+    expect(r.lineas[0].costoRealUnitario).toBeCloseTo(108.6956, 4)
+  })
+
+  it('un cargo NO GRAVADO entra al costo pero NO a la base de IVA', () => {
+    const r = calcularCostosCompra(
+      [linea()],
+      [cargo({ monto: 500, pesos: { 1: 1 } })],
+      {}
+    )
+    expect(r.lineas[0].baseIvaUnitaria).toBe(100)      // 1000/10, sin el cargo
+    expect(r.lineas[0].ivaUnitario).toBe(21)           // 21% de 100, NO de 150
+    expect(r.lineas[0].cargosUnitarios).toBe(50)       // 500/10
+    expect(r.lineas[0].costoRealUnitario).toBe(150)    // sí entra al costo
+  })
+
+  it('un cargo fuera de factura entra al costo pero no al IVA de la factura', () => {
+    const r = calcularCostosCompra(
+      [linea()],
+      [cargo({ monto: 500, condicionIva: 'gravado', enFactura: false, pesos: { 1: 1 } })],
+      {}
+    )
+    expect(r.totales.netoGravado).toBe(1000)     // el cargo no suma al IVA de esta compra
+    expect(r.lineas[0].costoRealUnitario).toBe(150)
+  })
+
+  it('afectaBaseII=false: la bonificacion baja el IVA pero no el impuesto interno', () => {
+    const r = calcularCostosCompra(
+      [linea({ impuestosInternos: 10 })],
+      [cargo({ monto: -200, condicionIva: 'gravado', afectaBaseII: false, pesos: { 1: 1 } })],
+      {}
+    )
+    expect(r.lineas[0].baseIvaUnitaria).toBe(80)   // (1000-200)/10
+    expect(r.lineas[0].iiUnitario).toBe(10)        // 10% de 1000/10, NO de 800/10
+  })
+
+  it('afectaBaseII=true: la bonificacion baja las dos bases', () => {
+    const r = calcularCostosCompra(
+      [linea({ impuestosInternos: 10 })],
+      [cargo({ monto: -200, condicionIva: 'gravado', afectaBaseII: true, pesos: { 1: 1 } })],
+      {}
+    )
+    expect(r.lineas[0].iiUnitario).toBe(8)         // 10% de 800/10
+  })
+
+  it('el factor de ajuste cuadra el II declarado y se reporta', () => {
+    const r = calcularCostosCompra(
+      [linea({ impuestosInternos: 10 })],
+      [],
+      { 10: 110 }   // declarado 110 vs calculado 100
+    )
+    expect(r.factorAjuste[10]).toBeCloseTo(1.1, 6)
+    expect(r.lineas[0].iiUnitario).toBeCloseTo(11, 4)
+  })
+
+  it('cantidad 0 no explota', () => {
+    const r = calcularCostosCompra([linea({ cantidad: 0 })], [], {})
+    expect(r.lineas[0].costoRealUnitario).toBe(0)
+  })
+
+  it('la linea exenta no suma a netoGravado, pero si tiene costo', () => {
+    const r = calcularCostosCompra(
+      [linea({ id: 1 }), linea({ id: 2, condicionIva: 'exento', porcentajeIva: 0 })],
+      [],
+      {}
+    )
+    expect(r.totales.netoGravado).toBe(1000)   // solo la linea gravada
+    expect(r.totales.netoExento).toBe(1000)
+    expect(r.totales.iva).toBe(210)            // 21% de 1000, la exenta no aporta
+    expect(r.lineas[1].baseIvaUnitaria).toBe(0)
+    expect(r.lineas[1].ivaUnitario).toBe(0)
+    expect(r.lineas[1].costoRealUnitario).toBe(100)  // exenta de IVA no es exenta de costo
+  })
+
+  it('un cargo en factura que no prorratea al costo: cae en noGravado y no en cargosAlCosto', () => {
+    // El caso pallets: esta en el papel, pero no es costo del producto.
+    const r = calcularCostosCompra(
+      [linea()],
+      [cargo({ monto: 500, prorrateaAlCosto: false, pesos: { 1: 1 } })],
+      {}
+    )
+    expect(r.totales.noGravado).toBe(500)       // cuadra contra el papel
+    expect(r.totales.cargosAlCosto).toBe(0)     // no reconcilia contra ningun costo
+    expect(r.lineas[0].cargosUnitarios).toBe(0)
+    expect(r.lineas[0].costoRealUnitario).toBe(100)
+  })
+
+  it('4.17 y 4.1667 son alicuotas distintas: el bucket tipeado a mano no se ajusta', () => {
+    // Datos reales de compra_items: 18 filas en 4.1667 y 1 en 4.1700.
+    // Si la factura declara un solo bucket, la linea tipeada 4,17 queda afuera
+    // y el II no cuadra. Eso es el detector avisando, no un falso positivo.
+    const r = calcularCostosCompra(
+      [linea({ id: 1, impuestosInternos: 4.1667 }), linea({ id: 2, impuestosInternos: 4.17 })],
+      [],
+      { 4.1667: 50 }   // declarado solo para el bucket bueno; calculado 41.667
+    )
+    expect(r.factorAjuste[4.1667]).toBeCloseTo(50 / 41.667, 9)
+    expect(r.factorAjuste[4.17]).toBeUndefined()
+    expect(r.lineas[0].iiUnitario).toBeCloseTo(5, 9)      // 50 declarados / 10 unidades
+    expect(r.lineas[1].iiUnitario).toBeCloseTo(4.17, 9)   // 41.7 sin ajustar / 10
+    expect(r.totales.impuestosInternos).toBeCloseTo(91.7, 6)
+  })
+
+  describe('contrato de entrada: cantidad 0 es valida, la negativa y el NaN son corrupcion', () => {
+    it('cantidad negativa: falla nombrando la linea', () => {
+      // Antes la linea devolvia 0 en cada unitario y el total sumaba el neto
+      // negativo igual: la asimetria dejaba pasar el dato corrupto.
+      expect(() => calcularCostosCompra([linea({ id: 7, cantidad: -1 })], [], {}))
+        .toThrow(/cantidad invalida en la linea 7/)
+    })
+
+    it('cantidad no finita: falla nombrando la linea', () => {
+      expect(() => calcularCostosCompra([linea({ id: 4, cantidad: NaN })], [], {}))
+        .toThrow(/cantidad invalida en la linea 4/)
+    })
+  })
+})
+
+describe('resolverBasesII', () => {
+  // Una sola línea gravada con impuesto interno del 10%: neto 1000, II 100.
+  // Cada bonificación de −200 baja el II a 80 si afecta la base.
+  const linea = (over: Partial<LineaCompra> = {}): LineaCompra => ({
+    id: 1, cantidad: 10, costoUnitario: 100, bonificacion: 0,
+    impuestosInternos: 10, porcentajeIva: 21, condicionIva: 'gravado', ...over,
+  })
+  const bonif = (over: Partial<CargoCompra> = {}): CargoCompra => ({
+    id: 1, concepto: 'Bonif', monto: -200, condicionIva: 'gravado',
+    enFactura: true, prorrateaAlCosto: true, afectaBaseII: false, pesos: { 1: 1 }, ...over,
+  })
+
+  it('una sola bonificacion: el declarado dice cual de las dos hipotesis es', () => {
+    const baja = resolverBasesII([linea()], [bonif()], { 10: 80 })
+    expect(baja.estado).toBe('unica')
+    expect(baja.soluciones[0].asignacion).toEqual({ 1: true })
+
+    const noBaja = resolverBasesII([linea()], [bonif()], { 10: 100 })
+    expect(noBaja.estado).toBe('unica')
+    expect(noBaja.soluciones[0].asignacion).toEqual({ 1: false })
+  })
+
+  it('el residuo viene con el signo de CuadreII.desvio: declarado - calculado', () => {
+    const r = resolverBasesII([linea()], [bonif()], { 10: 80.5 })
+    // 80,5 declarado contra 80 calculado. Entra por el piso de 1 peso.
+    expect(r.estado).toBe('unica')
+    expect(r.soluciones[0].residuos[10]).toBeCloseTo(0.5, 6)
+  })
+
+  it('dos bonificaciones con el mismo efecto: ambigua, y NO elige una', () => {
+    // Los dos repartos son idénticos, así que "baja la primera" y "baja la
+    // segunda" dan exactamente el mismo impuesto interno. La factura no alcanza.
+    const r = resolverBasesII(
+      [linea()],
+      [bonif({ id: 1 }), bonif({ id: 2, concepto: 'Otra' })],
+      { 10: 80 }
+    )
+    expect(r.estado).toBe('ambigua')
+    expect(r.soluciones).toHaveLength(2)
+    expect(r.soluciones.map(s => s.asignacion)).toEqual(
+      expect.arrayContaining([{ 1: true, 2: false }, { 1: false, 2: true }])
+    )
+  })
+
+  it('ninguna hipotesis cierra: lo dice, no devuelve la menos mala', () => {
+    // 90 no es ni 100 (no baja) ni 80 (baja): las dos se van por 10 pesos.
+    const r = resolverBasesII([linea()], [bonif()], { 10: 90 })
+    expect(r.estado).toBe('sin_solucion')
+    expect(r.soluciones).toEqual([])
+  })
+
+  it('un cargo NO gravado no es candidato: no puede mover la base', () => {
+    // El motor lee `gravado(c) && afectaBaseII`, así que prenderle el flag a un
+    // no gravado no cambia nada y sólo duplicaría las hipótesis.
+    const r = resolverBasesII(
+      [linea()],
+      [bonif({ condicionIva: 'no_gravado' })],
+      { 10: 100 }
+    )
+    expect(r.candidatos).toEqual([])
+    expect(r.estado).toBe('unica')
+    expect(r.soluciones[0].asignacion).toEqual({})
+  })
+
+  it('un cargo gravado que no toca ninguna linea con II es indeterminable', () => {
+    // Su efecto sobre la única alícuota declarada es exactamente 0: con él
+    // adentro toda solución vendría duplicada y el resultado sería "ambigua"
+    // para siempre.
+    const conII = linea({ id: 1 })
+    const sinII = linea({ id: 2, impuestosInternos: 0 })
+    const r = resolverBasesII(
+      [conII, sinII],
+      [bonif({ id: 9, pesos: { 1: 0, 2: 1 } })],
+      { 10: 100 }
+    )
+    expect(r.indeterminables).toEqual([9])
+    expect(r.candidatos).toEqual([])
+    expect(r.estado).toBe('unica')
+  })
+
+  it('el indeterminable conserva el valor que traia, no se lo inventa', () => {
+    const conII = linea({ id: 1 })
+    const sinII = linea({ id: 2, impuestosInternos: 0 })
+    const cargos = [bonif({ id: 9, pesos: { 1: 0, 2: 1 }, afectaBaseII: true })]
+    const r = resolverBasesII([conII, sinII], cargos, { 10: 100 })
+    // No aparece en ninguna asignación: sobre él el solver no dice nada.
+    expect(r.soluciones[0].asignacion).toEqual({})
+    expect(cargos[0].afectaBaseII).toBe(true)
+  })
+
+  it('sin declaracion no hay ecuacion que resolver', () => {
+    expect(resolverBasesII([linea()], [bonif()], {}).estado).toBe('sin_datos')
+  })
+
+  it('una alicuota declarada que ninguna linea tiene NO es una ecuacion', () => {
+    // Si contara, el calculado daría 0 y cualquier hipótesis cerraría o fallaría
+    // por el declarado entero, sin haber demostrado nada sobre esa alícuota.
+    const r = resolverBasesII([linea()], [bonif()], { 21: 5000 })
+    expect(r.alicuotas).toEqual([])
+    expect(r.estado).toBe('sin_datos')
+  })
+
+  it('mas de MAX_CARGOS_BASE_II candidatos: avisa en vez de adivinar', () => {
+    const grande = linea({ cantidad: 1000 })  // neto 100.000, II 10.000
+    const muchos = Array.from({ length: MAX_CARGOS_BASE_II + 1 }, (_, i) =>
+      bonif({ id: i + 1, monto: -1000 }))    // efecto 100 c/u, muy por encima de la tolerancia
+    const r = resolverBasesII([grande], muchos, { 10: 10_000 })
+    expect(r.estado).toBe('demasiadas_hipotesis')
+    expect(r.candidatos).toHaveLength(MAX_CARGOS_BASE_II + 1)
+    expect(r.soluciones).toEqual([])
+  })
+
+  it('todas las alicuotas declaradas tienen que cerrar a la vez, no una sola', () => {
+    // Un flag es UNO para toda la factura: una hipótesis que cuadra el 10% pero
+    // rompe el 5% no es solución. La bonificación cae sobre las dos líneas.
+    const a = linea({ id: 1, impuestosInternos: 10 })
+    const b = linea({ id: 2, impuestosInternos: 5 })
+    const cargo = bonif({ pesos: { 1: 1, 2: 1 } })  // −100 a cada una
+    // Bajando la base: 10% sobre 900 = 90 y 5% sobre 900 = 45.
+    expect(resolverBasesII([a, b], [cargo], { 10: 90, 5: 45 }).estado).toBe('unica')
+    // El 10% cierra con "baja" y el 5% con "no baja": ninguna hipótesis sirve.
+    expect(resolverBasesII([a, b], [cargo], { 10: 90, 5: 50 }).estado).toBe('sin_solucion')
+  })
+
+  it('la tolerancia tiene piso absoluto y parte relativa', () => {
+    expect(toleranciaII(100)).toBe(TOLERANCIA_II_PISO)        // 0,05% = 0,05 → manda el piso
+    expect(toleranciaII(338_884.46)).toBeCloseTo(169.44, 2)   // manda la relativa
+    expect(toleranciaII(-338_884.46)).toBeCloseTo(169.44, 2)  // por magnitud, no por signo
+  })
+})

--- a/src/utils/prorrateoCompra.ts
+++ b/src/utils/prorrateoCompra.ts
@@ -1,0 +1,814 @@
+import { redondearSQL, type CondicionIva } from './calculations'
+
+/** Vector de pesos de un cargo: id de línea → peso. Peso 0 excluye la línea. */
+export type PesosCargo = Record<number, number>
+
+/**
+ * Reparte un monto entre líneas según un vector de pesos.
+ *
+ * La suma de los repartos es EXACTAMENTE el monto: se redondea cada parte a 2
+ * decimales y el residuo se asigna a la línea de mayor peso (desempate: menor
+ * id). Sin esa regla, repartir sobre pesos fraccionarios no vuelve a sumar el
+ * monto y el check de integridad COMPRA-A2 se pone rojo por centavos.
+ *
+ * Contrato de entrada. El cero es un estado válido; el negativo y el NaN son
+ * corrupción:
+ *  - Peso 0: legal, excluye la línea. Es el mecanismo de alcance del cargo.
+ *  - Todos los pesos en 0, o `pesos` vacío: devuelve {}. Legal, es la grilla a
+ *    medio llenar.
+ *  - Peso negativo o no finito: lanza, nombrando la línea. Antes un peso
+ *    negativo hacía desaparecer el cargo entero sin aviso (los pesos se
+ *    cancelaban a 0) y un NaN se redistribuía a las demás líneas. Esto se
+ *    convierte en costo: tragárselo es peor que fallar.
+ *  - Monto no finito: lanza.
+ *
+ * La implementación canónica es la de SQL (`prorratear_cargo`, mig 193), porque
+ * el prorrateo se calcula y se persiste en la base. Ésta es la réplica que
+ * alimenta la vista previa del modal: las dos tienen que dar el mismo número al
+ * centavo —de ahí redondearSQL y no redondear— así que si cambiás una, cambiá
+ * la otra. Eso ya NO es sólo una frase: lo verifica el espejo
+ * (`scripts/espejo-motor-compras.mjs`), que corre las dos sobre los mismos casos
+ * y falla si difieren en un centavo. Tocar esto y no el SQL pone rojo el gate.
+ */
+export function prorratearCargo(monto: number, pesos: PesosCargo): Record<number, number> {
+  if (!Number.isFinite(monto)) {
+    throw new Error(`prorratearCargo: monto no finito (${monto}).`)
+  }
+
+  const entradas = Object.entries(pesos).map(([k, v]) => {
+    const id = Number(k)
+    // Sin Number(v) || 0 a propósito: convertir NaN en 0 vuelve indistinguible
+    // un dato corrupto de una exclusión deliberada, porque 0 ES la exclusión.
+    if (!Number.isFinite(v)) {
+      throw new Error(
+        `prorratearCargo: peso no finito en la linea ${id} (${v}). ` +
+        'Se esperan numeros finitos; el 0 excluye una linea.'
+      )
+    }
+    if (v < 0) {
+      throw new Error(
+        `prorratearCargo: peso negativo en la linea ${id} (${v}). ` +
+        'Los pesos son proporciones; el 0 excluye una linea.'
+      )
+    }
+    return [id, v] as const
+  })
+
+  // Validados los pesos, esto significa exactamente "todos en cero" (o sin
+  // líneas): ya no puede ser una cancelación entre positivos y negativos.
+  const totalPeso = entradas.reduce((acc, [, p]) => acc + p, 0)
+  if (totalPeso === 0) return {}
+
+  // Mayor peso, desempate por menor id. Sin ordenar: `entradas` queda intacto y
+  // el for de abajo conserva su orden. reduce sin semilla es seguro porque el
+  // totalPeso === 0 de arriba ya descartó el vector vacío.
+  const [idResiduo] = entradas.reduce((mejor, e) =>
+    e[1] > mejor[1] || (e[1] === mejor[1] && e[0] < mejor[0]) ? e : mejor
+  )
+
+  const salida: Record<number, number> = {}
+  let acumulado = 0
+  for (const [id, peso] of entradas) {
+    if (id === idResiduo) continue
+    const parte = redondearSQL(monto * peso / totalPeso, 2)
+    salida[id] = parte
+    acumulado += parte
+  }
+  salida[idResiduo] = redondearSQL(monto - acumulado, 2)
+  return salida
+}
+
+export interface LineaCompra {
+  id: number
+  cantidad: number
+  costoUnitario: number
+  bonificacion: number       // %
+  impuestosInternos: number  // tasa efectiva %
+  porcentajeIva: number      // %
+  condicionIva: CondicionIva
+}
+
+/**
+ * Un cargo de la factura: flete, pallets, separadores, bonificación general.
+ *
+ * No lleva alícuota propia a propósito: un cargo gravado tributa a la alícuota
+ * de las líneas sobre las que se prorratea. Hoy los 247 productos son 21%, así
+ * que la distinción no se plantea. Si alguna vez conviven alícuotas distintas
+ * en una misma compra, esto deja de alcanzar: hay que decidir qué significa la
+ * base gravada de una línea que recibe un cargo de otra alícuota.
+ */
+export interface CargoCompra {
+  id: number
+  concepto: string
+  monto: number              // SIN IVA. Negativo = bonificación
+  condicionIva: CondicionIva
+  enFactura: boolean         // suma al cuadre contra el papel
+  prorrateaAlCosto: boolean  // entra al costo unitario
+  afectaBaseII: boolean
+  pesos: PesosCargo
+}
+
+export interface CostosLinea {
+  id: number
+  /** Base sobre la que tributa el IVA de ESTA línea. 0 si la línea no es gravada. */
+  baseIvaUnitaria: number
+  iiUnitario: number
+  cargosUnitarios: number
+  ivaUnitario: number
+  costoNetoUnitario: number
+  costoRealUnitario: number
+}
+
+/** El dominio de `condicion_iva`, el mismo que define la mig 192. */
+const CONDICIONES_IVA: string[] = ['gravado', 'exento', 'no_gravado']
+
+export interface CostosCompra {
+  lineas: CostosLinea[]
+  totales: {
+    /** Neto de las líneas gravadas + cargos gravados en factura. Cuadra contra el papel. */
+    netoGravado: number
+    netoExento: number
+    netoNoGravado: number
+    iva: number
+    impuestosInternos: number
+    /** Cargos NO gravados EN FACTURA. Va a compras.no_gravado y al cuadre. */
+    noGravado: number
+    /** Cargos NO gravados que PRORRATEAN. Reconcilia contra Σ cargosUnitarios × cantidad. */
+    cargosAlCosto: number
+  }
+  /** tasa de II (normalizada a 4 decimales) → declarado/calculado. 1 = cuadra solo. */
+  factorAjuste: Record<number, number>
+}
+
+/**
+ * Motor de costos de una compra (espejo de `calcular_costos_compra`, mig 193).
+ *
+ * Que sea un espejo lo sostiene `scripts/espejo-motor-compras.mjs`, que manda la
+ * MISMA entrada a las dos implementaciones y deja que la comparación la haga
+ * Postgres; y `prorrateoCompra.espejo.test.ts`, que hace lo mismo contra una
+ * foto congelada de la salida del SQL y corre sin base. La canónica es la de
+ * SQL: lo que se persiste sale de ahí.
+ *
+ * Tres bases separadas a propósito, porque responden preguntas distintas:
+ *   · baseIva   → neto de la línea (si es gravada) + cargos gravados EN FACTURA.
+ *     Alimenta compras.iva y el cuadre contra el papel.
+ *   · baseCosto → neto + cargos GRAVADOS que prorratean. Los NO gravados que
+ *     prorratean van aparte, en `cargosAlCosto`, y se suman recién en
+ *     costoRealUnitario: quien replique esto no tiene que sumarlos dos veces.
+ *   · baseII    → neto + los cargos GRAVADOS con afectaBaseII. El filtro por
+ *     condición es deliberado, no un olvido: el flag existe para distinguir un
+ *     descuento de precio (baja la base) de una bonificación comercial (no la
+ *     baja), y las dos son siempre gravadas. Un cargo no gravado —pallets,
+ *     separadores— no tiene por qué mover la base del impuesto interno. Mismo
+ *     filtro en la mig 193; si cambiás uno, cambiá el otro.
+ * El IVA de un flete de transportista inscripto es crédito fiscal: entra su
+ * neto al costo, su IVA no entra a ningún lado de esta factura.
+ *
+ * Los nombres de `totales` son los de calcularTotalesCompra a propósito: los dos
+ * clasifican la misma factura y tienen que decir lo mismo con las mismas palabras.
+ *
+ * Un cargo gravado prorrateado sobre una línea NO gravada suma a `netoGravado`
+ * (está en el papel como gravado) pero no a ninguna `baseIvaUnitaria` (la línea
+ * no tributa). Es el único caso donde Σ baseIvaUnitaria × cantidad ≠ netoGravado,
+ * y es el mismo que el comentario de CargoCompra deja fuera de alcance.
+ *
+ * @param iiDeclarado - tasa de II → monto declarado en la factura. Vacío = sin ajuste.
+ */
+export function calcularCostosCompra(
+  lineas: LineaCompra[],
+  cargos: CargoCompra[],
+  iiDeclarado: Record<number, number>
+): CostosCompra {
+  // Clave de bucket de II. Las tasas reales son 4.1667 y 8.6956, y en compra_items
+  // conviven 4.1667 y 4.1700 (alguien tipeó 4,17): a 4 decimales quedan en buckets
+  // distintos, que es lo correcto. Si la factura declara uno solo, el otro no se
+  // ajusta y el cuadre avisa. En SQL, round(tasa, 4) en las dos puntas.
+  const tasaII = (t: number) => redondearSQL(t || 0, 4)
+
+  // Misma regla que prorratearCargo: el 0 es un estado válido (una línea recién
+  // agregada), el negativo y el NaN son corrupción. Sin esto la línea devolvía 0
+  // en cada unitario mientras el total sumaba el neto igual, y el dato corrupto
+  // pasaba de largo.
+  for (const l of lineas) {
+    if (!Number.isFinite(l.cantidad) || l.cantidad < 0) {
+      throw new Error(
+        `calcularCostosCompra: cantidad invalida en la linea ${l.id} (${l.cantidad}). ` +
+        'Se espera un numero finito no negativo.'
+      )
+    }
+  }
+
+  // LAS CUATRO GUARDAS QUE SIGUEN LAS TENÍA LA MIG 193 Y ESTE ARCHIVO NO. Eran
+  // el único lugar donde las dos implementaciones no fallaban ante lo mismo, y
+  // las encontró el espejo (`scripts/espejo-motor-compras.mjs`) la primera vez
+  // que se lo pudo correr contra la base: en los cuatro casos el SQL rechazaba
+  // la entrada y acá salía un número. Eso es peor que un número distinto — la
+  // vista previa muestra un costo que la base no va a aceptar, o que va a
+  // aceptar contando plata dos veces— y por eso la 193 dejó anotado que el
+  // espejo tenía que copiarlas. Orden y mensajes calcados de esa migración.
+
+  // Dos líneas con el mismo id hacen que el reparto de un cargo se cuente una
+  // vez por cada una: `repartos` es un mapa por id y las dos leen la misma
+  // entrada. Desde compra_items es imposible (id es PK), desde un payload no.
+  const vistos = new Set<number>()
+  for (const l of lineas) {
+    if (vistos.has(l.id)) {
+      throw new Error(`calcularCostosCompra: la linea ${l.id} aparece mas de una vez.`)
+    }
+    vistos.add(l.id)
+  }
+
+  // Un typo en la condición NO es inocuo: `esGravada` y los dos CASE de exento y
+  // no_gravado son excluyentes, así que un valor que no es ninguno de los tres
+  // cae en el hueco y el neto de esa línea desaparece de los CUATRO totales a la
+  // vez, sin un solo error. El tipo lo frena en tiempo de compilación; esto lo
+  // frena cuando el dato viene de la red, que es de donde viene.
+  for (const l of lineas) {
+    if (!CONDICIONES_IVA.includes(l.condicionIva)) {
+      throw new Error(
+        `calcularCostosCompra: condicionIva invalida en la linea ${l.id} (${l.condicionIva}). ` +
+        'Se espera gravado, exento o no_gravado.'
+      )
+    }
+  }
+
+  // Del lado del cargo el hueco es distinto pero igual de mudo: `gravado(c)` sale
+  // de comparar contra 'gravado', así que cualquier typo cae en la rama NO
+  // gravada y el cargo deja de sumar a la base de IVA sin avisar. Se lo nombra
+  // por posición y concepto porque el cargo puede no tener id todavía (viene de
+  // una grilla a medio llenar).
+  cargos.forEach((c, i) => {
+    if (!CONDICIONES_IVA.includes(c.condicionIva)) {
+      throw new Error(
+        `calcularCostosCompra: condicionIva invalida en el cargo ${i + 1} ` +
+        `(${c.concepto || 'sin concepto'}): ${c.condicionIva}. ` +
+        'Se espera gravado, exento o no_gravado.'
+      )
+    }
+  })
+
+  // Dos tasas declaradas que colapsan al MISMO bucket de 4 decimales ('10' y
+  // '10.0', o '4.1667' y '04.1667'): acá la segunda pisaba a la primera en
+  // `factorAjuste` sin avisar, y en SQL el subselect del factor devolvía dos
+  // filas y reventaba. Los dos casos son el mismo dato mal cargado.
+  const bucketsDeclarados = new Map<number, string>()
+  for (const clave of Object.keys(iiDeclarado)) {
+    const bucket = tasaII(Number(clave))
+    const previa = bucketsDeclarados.get(bucket)
+    if (previa !== undefined) {
+      throw new Error(
+        `calcularCostosCompra: las tasas declaradas "${previa}" y "${clave}" ` +
+        'caen en el mismo bucket de 4 decimales y se pisarian.'
+      )
+    }
+    bucketsDeclarados.set(bucket, clave)
+  }
+
+  const repartos = new Map<number, Record<number, number>>()
+  for (const c of cargos) repartos.set(c.id, prorratearCargo(c.monto, c.pesos))
+  const asignado = (c: CargoCompra, lineaId: number) => repartos.get(c.id)?.[lineaId] ?? 0
+
+  const neto = (l: LineaCompra) => l.cantidad * l.costoUnitario * (1 - (l.bonificacion || 0) / 100)
+  const suma = (l: LineaCompra, filtro: (c: CargoCompra) => boolean) =>
+    cargos.filter(filtro).reduce((acc, c) => acc + asignado(c, l.id), 0)
+
+  const gravado = (c: CargoCompra) => c.condicionIva === 'gravado'
+
+  const bases = lineas.map(l => {
+    const esGravada = l.condicionIva === 'gravado'
+    const cargosGravadosFactura = suma(l, c => gravado(c) && c.enFactura)
+    return {
+      linea: l,
+      neto: neto(l),
+      esGravada,
+      cargosGravadosFactura,
+      baseIva: esGravada ? neto(l) + cargosGravadosFactura : 0,
+      baseCosto: neto(l) + suma(l, c => gravado(c) && c.prorrateaAlCosto),
+      baseII: neto(l) + suma(l, c => gravado(c) && c.afectaBaseII),
+      noGravadoFactura: suma(l, c => !gravado(c) && c.enFactura),
+      cargosAlCosto: suma(l, c => !gravado(c) && c.prorrateaAlCosto),
+    }
+  })
+
+  // Factor de ajuste por alícuota de II, con la tasa normalizada en las dos
+  // puntas: se agrupa por clave exacta y se busca por clave exacta.
+  const factorAjuste: Record<number, number> = {}
+  for (const [tasaStr, declarado] of Object.entries(iiDeclarado)) {
+    const tasa = tasaII(Number(tasaStr))
+    const calculado = bases
+      .filter(b => tasaII(b.linea.impuestosInternos) === tasa)
+      .reduce((acc, b) => acc + b.baseII * tasa / 100, 0)
+    factorAjuste[tasa] = calculado ? declarado / calculado : 1
+  }
+
+  const calculadas = bases.map(b => ({
+    ...b,
+    ii: b.baseII * (b.linea.impuestosInternos || 0) / 100
+      * (factorAjuste[tasaII(b.linea.impuestosInternos)] ?? 1),
+    iva: b.baseIva * b.linea.porcentajeIva / 100,
+  }))
+
+  const total = (f: (c: typeof calculadas[number]) => number) =>
+    calculadas.reduce((a, c) => a + f(c), 0)
+
+  return {
+    // Los unitarios se derivan del total de la línea, nunca al revés: el total no
+    // se reconstruye multiplicando de vuelta por la cantidad.
+    lineas: calculadas.map(b => {
+      const cant = b.linea.cantidad
+      const porUnidad = (v: number) => (cant > 0 ? v / cant : 0)
+      return {
+        id: b.linea.id,
+        baseIvaUnitaria: porUnidad(b.baseIva),
+        iiUnitario: porUnidad(b.ii),
+        cargosUnitarios: porUnidad(b.cargosAlCosto),
+        ivaUnitario: porUnidad(b.iva),
+        costoNetoUnitario: porUnidad(b.neto),
+        costoRealUnitario: porUnidad(b.baseCosto + b.ii + b.cargosAlCosto),
+      }
+    }),
+    totales: {
+      netoGravado: total(b => (b.esGravada ? b.neto : 0) + b.cargosGravadosFactura),
+      netoExento: total(b => (b.linea.condicionIva === 'exento' ? b.neto : 0)),
+      netoNoGravado: total(b => (b.linea.condicionIva === 'no_gravado' ? b.neto : 0)),
+      iva: total(b => b.iva),
+      impuestosInternos: total(b => b.ii),
+      noGravado: total(b => b.noGravadoFactura),
+      cargosAlCosto: total(b => b.cargosAlCosto),
+    },
+    factorAjuste,
+  }
+}
+
+// =============================================================================
+// EL SOLVER DE BASES DE IMPUESTO INTERNO
+// =============================================================================
+
+/**
+ * Piso absoluto de la tolerancia del cuadre de impuesto interno, en pesos.
+ *
+ * Es el mismo peso que ya usan `COMPRA-A1`, el control blando de cuadre de la
+ * RPC y el ✓ del panel "Control contra factura": abajo de un peso ninguna parte
+ * de este sistema afirma nada. Existe porque la parte relativa sola quedaría
+ * absurdamente dura en una factura chica —al 0,05%, un II declarado de 500 pesos
+ * toleraría 25 centavos, y el proveedor redondea cada renglón a 2 decimales—.
+ */
+export const TOLERANCIA_II_PISO = 1
+
+/**
+ * Parte relativa de la tolerancia: 0,5 por mil del II declarado de la alícuota.
+ *
+ * Medido contra la factura testigo A0005-00461415, que es el único caso real con
+ * la respuesta conocida:
+ *
+ *   alícuota │ declarado  │ tolerancia │ residuo de la      │ residuo de la más
+ *            │            │            │ hipótesis correcta │ cercana que NO
+ *   ─────────┼────────────┼────────────┼────────────────────┼──────────────────
+ *    8,6956% │ 338.884,46 │     169,44 │               0,06 │       7.022,93
+ *    4,1667% │ 199.027,21 │      99,51 │               0,01 │         795,39
+ *
+ * O sea: la correcta entra con 2.800 veces de margen y la siguiente queda afuera
+ * por 8 veces. Es el ancho que separa "el proveedor redondeó" de "esa
+ * bonificación no es la que baja la base", y deja lugar para que la próxima
+ * factura sea bastante peor que ésta sin que se rompa nada.
+ *
+ * POR QUÉ RELATIVA Y NO UN NÚMERO FIJO. Lo que hay que tolerar es el redondeo del
+ * proveedor, que crece con la factura: centavos por renglón, más lo que se corra
+ * el reparto de la bonificación entre alícuotas respecto del que hizo él. Un
+ * absoluto calibrado con esta factura de 13 millones (169 pesos) aceptaría
+ * cualquier cosa en una de 200.000; uno calibrado con la chica rechazaría la
+ * hipótesis correcta en la grande.
+ *
+ * Si alguna vez hay que aflojarla, que sea con otra factura testigo en la mano y
+ * moviendo también el test que mide la separación: subirla hasta pasar los 795
+ * pesos del 4,1667% convierte al solver en un generador de respuestas plausibles.
+ */
+export const TOLERANCIA_II_RELATIVA = 0.0005
+
+/**
+ * Tope de cargos candidatos. 2^10 = 1024 hipótesis.
+ *
+ * El costo de la fuerza bruta no es el problema —mil corridas del motor sobre 21
+ * líneas es nada—; el problema es que cada variable binaria que se agrega duplica
+ * las chances de que alguna combinación cierre por casualidad contra las dos o
+ * tres ecuaciones que da una factura. Con diez bonificaciones gravadas y dos
+ * alícuotas, la respuesta honesta ya no es "la encontré".
+ */
+export const MAX_CARGOS_BASE_II = 10
+
+/** Lo que se le tolera al cuadre de una alícuota, en pesos. */
+export function toleranciaII(declarado: number): number {
+  return Math.max(TOLERANCIA_II_PISO, Math.abs(declarado) * TOLERANCIA_II_RELATIVA)
+}
+
+/** Una hipótesis que cierra contra el impuesto interno declarado. */
+export interface HipotesisBasesII {
+  /** cargoId → afectaBaseII. Sólo nombra a los candidatos. */
+  asignacion: Record<number, boolean>
+  /** tasa → declarado − calculado (misma orientación que `CuadreII.desvio`). */
+  residuos: Record<number, number>
+  /**
+   * El peor residuo medido en tolerancias: 0 es exacto, 1 es el borde. Ordena
+   * las hipótesis y deja ver si una solución cerró holgada o raspando.
+   */
+  holgura: number
+}
+
+export type EstadoBasesII =
+  /** Exactamente una combinación cierra. Es la respuesta. */
+  | 'unica'
+  /** Más de una cierra: la factura no alcanza para distinguirlas. */
+  | 'ambigua'
+  /** Ninguna cierra: o el declarado está mal, o falta un cargo, o una alícuota. */
+  | 'sin_solucion'
+  /** No hay ninguna ecuación que resolver (no se declaró el II, o es ZZ). */
+  | 'sin_datos'
+  /** Demasiados candidatos: ver `MAX_CARGOS_BASE_II`. */
+  | 'demasiadas_hipotesis'
+
+export interface ResultadoBasesII {
+  estado: EstadoBasesII
+  /** Las hipótesis que cierran, de la más ajustada a la menos. */
+  soluciones: HipotesisBasesII[]
+  /** Ids de los cargos que entraron a la búsqueda. */
+  candidatos: number[]
+  /** Ids de los cargos gravados cuyo efecto no se puede medir. Ver abajo. */
+  indeterminables: number[]
+  /** Las alícuotas que se usaron como ecuación. */
+  alicuotas: number[]
+}
+
+/**
+ * Deduce qué bonificaciones bajan la base del impuesto interno.
+ *
+ * EL PROBLEMA QUE RESUELVE. `afectaBaseII` distingue un descuento de precio (baja
+ * la base imponible) de una bonificación comercial (no la baja), y esa distinción
+ * vale casi el 5% del impuesto interno de la factura testigo. Pero no hay ninguna
+ * regla que el que carga la factura pueda aplicar mirándola: lo decide el
+ * proveedor, y la testigo demuestra que Manaos trató las dos bonificaciones del
+ * MISMO comprobante de forma distinta. Un casillero que el usuario no puede
+ * llenar no sirve de nada.
+ *
+ * LO QUE SÍ HAY es que la factura declara el impuesto interno abierto POR
+ * ALÍCUOTA. Eso es una ecuación por alícuota. Con N bonificaciones gravadas hay
+ * 2^N hipótesis: se prueban todas y se busca cuál cierra. En la testigo, con las
+ * dos bonificaciones reales, cierra una sola —la misma que el golden ya tenía
+ * como correcta—; las otras tres se van por entre 795 y 16.020 pesos.
+ *
+ * QUÉ ES CANDIDATO. Sólo un cargo GRAVADO: el motor lee la base como
+ * `gravado(c) && c.afectaBaseII`, así que prender el flag en un cargo no gravado
+ * no mueve nada y sólo agregaría una variable libre que duplica las hipótesis sin
+ * explicar ninguna diferencia.
+ *
+ * QUÉ ES INDETERMINABLE. Un cargo cuyo efecto sobre TODAS las alícuotas
+ * declaradas es más chico que la tolerancia: la factura no trae con qué
+ * decidirlo. El caso extremo es el cargo que no toca ninguna línea con impuesto
+ * interno —efecto exactamente 0—, pero también cae acá el redondeo de −0,49 de la
+ * testigo, que mueve el II 1,6 centavos. Si entraran a la búsqueda, TODA solución
+ * vendría duplicada por su gemela con el flag al revés y el resultado sería
+ * "ambigua" para siempre. Se los deja afuera con el valor que traen y se los
+ * devuelve por separado, para que la interfaz no los marque como resueltos:
+ * sobre ellos el solver no tiene nada que decir. Se podan de a uno y se verifica
+ * que el CONJUNTO podado también sea despreciable, porque diez efectos
+ * individualmente chicos pueden sumar uno grande.
+ *
+ * LOS TRES RESULTADOS SON DISTINTOS Y SE DEVUELVEN DISTINTOS. Una sola hipótesis
+ * que cierra es una respuesta; varias es una ambigüedad; ninguna es un dato mal
+ * cargado. Devolver "la mejor" en los dos últimos casos sería inventar una
+ * respuesta que la factura no da, que es exactamente el defecto del ajuste
+ * proporcional que este solver viene a reemplazar.
+ *
+ * Función pura: quien la llama decide si aplica el resultado. Y no atrapa lo que
+ * lance el motor —un peso corrupto sigue siendo corrupción—, con el mismo
+ * criterio que `prorratearCargo`.
+ *
+ * @param iiDeclarado - tasa de II → monto declarado en la factura.
+ */
+export function resolverBasesII(
+  lineas: LineaCompra[],
+  cargos: CargoCompra[],
+  iiDeclarado: Record<number, number>
+): ResultadoBasesII {
+  const tasaII = (t: number) => redondearSQL(t || 0, 4)
+
+  // Las ecuaciones son las alícuotas declaradas QUE ADEMÁS EXISTEN en las líneas.
+  // Una declarada que ninguna línea tiene no es una ecuación: daría 0 calculado y
+  // el solver estaría demostrando algo sobre una alícuota que no participa. Que
+  // la factura declare una alícuota ausente de las líneas es un error de carga, y
+  // el panel de cuadre ya lo muestra.
+  const conLinea = new Set(
+    lineas
+      .filter(l => l.cantidad > 0 && tasaII(l.impuestosInternos) > 0)
+      .map(l => tasaII(l.impuestosInternos))
+  )
+  const declarado = new Map<number, number>()
+  for (const [clave, monto] of Object.entries(iiDeclarado)) {
+    const tasa = tasaII(Number(clave))
+    if (conLinea.has(tasa)) declarado.set(tasa, monto)
+  }
+  const alicuotas = [...declarado.keys()].sort((a, b) => a - b)
+
+  const sinSoluciones = (
+    estado: EstadoBasesII,
+    candidatos: number[] = [],
+    indeterminables: number[] = []
+  ): ResultadoBasesII => ({ estado, soluciones: [], candidatos, indeterminables, alicuotas })
+
+  if (alicuotas.length === 0) return sinSoluciones('sin_datos')
+
+  const tolerancia = (tasa: number) => toleranciaII(declarado.get(tasa) ?? 0)
+  const despreciable = (efecto: Record<number, number>) =>
+    alicuotas.every(t => Math.abs(efecto[t]) < tolerancia(t))
+
+  /**
+   * El impuesto interno por alícuota bajo una hipótesis. Los cargos que la
+   * hipótesis no nombra conservan el `afectaBaseII` con el que llegaron.
+   *
+   * La apertura declarada va VACÍA a propósito: el factor de ajuste residual del
+   * motor fuerza el calculado contra el declarado, así que con la apertura puesta
+   * toda hipótesis daría residuo 0 y no habría nada que resolver. Es el mismo
+   * motivo por el que `cuadreImpuestoInterno` la deja vacía.
+   */
+  const iiPorTasa = (asignacion: Record<number, boolean>): Record<number, number> => {
+    const hipotesis = cargos.map(c =>
+      asignacion[c.id] === undefined ? c : { ...c, afectaBaseII: asignacion[c.id] }
+    )
+    const costos = calcularCostosCompra(lineas, hipotesis, {})
+    const total: Record<number, number> = {}
+    for (const t of alicuotas) total[t] = 0
+    // Por ÍNDICE y no por id: es el orden que el motor conserva, y así esto no
+    // depende de que los ids de línea sean únicos. Reconstruir el total como
+    // unitario × cantidad es lo que ya hace `cuadreImpuestoInterno`, así que el
+    // solver y el panel de cuadre no pueden discrepar. (Una línea de cantidad 0
+    // aporta 0 por las dos vías; las RPCs rechazan darle peso a una.)
+    lineas.forEach((linea, i) => {
+      const tasa = tasaII(linea.impuestosInternos)
+      if (total[tasa] === undefined) return
+      total[tasa] += (costos.lineas[i]?.iiUnitario ?? 0) * linea.cantidad
+    })
+    return total
+  }
+
+  const gravados = cargos.filter(c => c.condicionIva === 'gravado')
+  const apagados: Record<number, boolean> = {}
+  for (const c of gravados) apagados[c.id] = false
+
+  // Efecto de cada cargo, medido contra el piso "ninguno baja la base".
+  const base = iiPorTasa(apagados)
+  const efecto = new Map<number, Record<number, number>>()
+  for (const c of gravados) {
+    const conEste = iiPorTasa({ ...apagados, [c.id]: true })
+    efecto.set(c.id, Object.fromEntries(alicuotas.map(t => [t, conEste[t] - base[t]])))
+  }
+
+  const mudos = gravados.filter(c => despreciable(efecto.get(c.id)!))
+  const sumaMudos = Object.fromEntries(
+    alicuotas.map(t => [t, mudos.reduce((acc, c) => acc + efecto.get(c.id)![t], 0)])
+  )
+  const indeterminables = despreciable(sumaMudos) ? mudos.map(c => c.id) : []
+  const candidatos = gravados.map(c => c.id).filter(id => !indeterminables.includes(id))
+
+  if (candidatos.length > MAX_CARGOS_BASE_II) {
+    return sinSoluciones('demasiadas_hipotesis', candidatos, indeterminables)
+  }
+
+  const soluciones: HipotesisBasesII[] = []
+  for (let mascara = 0; mascara < (1 << candidatos.length); mascara++) {
+    const asignacion: Record<number, boolean> = {}
+    candidatos.forEach((id, i) => { asignacion[id] = ((mascara >> i) & 1) === 1 })
+    const ii = iiPorTasa(asignacion)
+    const residuos: Record<number, number> = {}
+    let holgura = 0
+    for (const tasa of alicuotas) {
+      residuos[tasa] = (declarado.get(tasa) ?? 0) - ii[tasa]
+      holgura = Math.max(holgura, Math.abs(residuos[tasa]) / tolerancia(tasa))
+    }
+    if (holgura <= 1) soluciones.push({ asignacion, residuos, holgura })
+  }
+  soluciones.sort((a, b) => a.holgura - b.holgura)
+
+  return {
+    estado:
+      soluciones.length === 1 ? 'unica'
+        : soluciones.length > 1 ? 'ambigua'
+          : 'sin_solucion',
+    soluciones,
+    candidatos,
+    indeterminables,
+    alicuotas,
+  }
+}
+
+// =============================================================================
+// EL DESGLOSE FISCAL DE LA CABECERA
+// =============================================================================
+
+/**
+ * Una línea del formulario tal como la ve el motor, con la regla de ZZ aplicada
+ * — el mismo CASE que arma `v_items_motor` en la mig 194.
+ *
+ * La regla: `tipo_factura` decide si se agregan IMPUESTOS encima, no si se
+ * ignoran COSTOS. En ZZ lo pagado ya incluye IVA e impuestos internos, pero un
+ * flete que factura un transportista aparte no está adentro de ese precio, así
+ * que el cargo tiene que sumar igual. Se implementa poniendo la tasa en 0 acá y
+ * no con un IF adentro del motor: con la tasa en 0, `ii = baseII × tasa ×
+ * factor` da 0 cualquiera sea la base, mientras el cargo viaja por `baseCosto`
+ * (si es gravado) o por `cargosAlCosto` (si no), y ninguno de los dos mira la
+ * tasa.
+ *
+ * Vive acá y no en el modal porque ahora tiene DOS llamadores —la vista previa
+ * de costos y el desglose de la cabecera— y dos copias del CASE se
+ * desincronizan sin que nada avise. Si cambia el de la 194, cambia éste.
+ */
+export function lineaParaMotor(
+  item: CompraItemCalculo,
+  tipoFactura: 'ZZ' | 'FC',
+  id: number
+): LineaCompra {
+  const esZZ = tipoFactura === 'ZZ'
+  const condicionIva: CondicionIva = esZZ ? 'gravado' : (item.condicionIva ?? 'gravado')
+  return {
+    id,
+    cantidad: item.cantidad || 0,
+    costoUnitario: item.costoUnitario || 0,
+    bonificacion: item.bonificacion || 0,
+    impuestosInternos: esZZ ? 0 : (item.impuestosInternos || 0),
+    porcentajeIva: esZZ || condicionIva !== 'gravado' ? 0 : (item.porcentajeIva ?? 21),
+    condicionIva,
+  }
+}
+
+export interface CompraItemCalculo {
+  cantidad: number;
+  costoUnitario: number;
+  bonificacion?: number;
+  porcentajeIva?: number;
+  /** Tasa efectiva de imp. internos (%) */
+  impuestosInternos?: number;
+  /** Default: 'gravado' (así se comporta una línea que no lo trae). */
+  condicionIva?: CondicionIva;
+  /**
+   * Id local de la línea. Sólo importa cuando hay cargos: los `pesos` de un
+   * cargo se guardan contra este id, así que el motor tiene que ver la línea
+   * con el MISMO id o el reparto no matchea nada. Sin cargos da igual y por eso
+   * es opcional (cae al índice).
+   */
+  lineaId?: number;
+}
+
+export interface CompraExtras {
+  percepcionIva?: number;
+  percepcionIibb?: number;
+  noGravado?: number;
+  otrosImpuestos?: number;
+}
+
+export interface TotalesCompra {
+  subtotalBruto: number;
+  bonificacionTotal: number;
+  /**
+   * Neto de TODAS las líneas (bruto − bonif) = netoGravado + netoExento +
+   * netoNoGravado CUANDO NO HAY CARGOS. Es lo que se manda como p_subtotal y lo
+   * que valida el check COMPRA-A2 contra SUM(compra_items.subtotal): no
+   * estrecharlo a "sólo gravado" ni meterle los cargos, o toda factura mixta —o
+   * con flete— quedaría en rojo.
+   */
+  subtotal: number;
+  /** Líneas gravadas + cargos gravados en factura. Cuadra contra el papel. */
+  netoGravado: number;
+  netoExento: number;
+  /** Líneas de producto no gravadas. NO es `noGravado` (cabecera, sin línea). */
+  netoNoGravado: number;
+  /**
+   * Σ de los cargos GRAVADOS que vienen en la factura, CON SU SIGNO: negativo
+   * cuando son bonificaciones, que es el caso normal y el único que se ve hoy.
+   *
+   * Es la pieza que le faltaba a la cabecera para cuadrar contra el papel. El
+   * `subtotal` es el neto de las LÍNEAS y lo clava `COMPRA-A2` contra
+   * SUM(compra_items.subtotal), así que una bonificación general —que no es un
+   * renglón de producto— no tenía dónde restarse: en la factura testigo dejaba
+   * `compras.total` 306.784,09 arriba de lo que dice el papel. Va a la columna
+   * `compras.bonificaciones` (mig 195) y entra a la identidad de `COMPRA-A1`.
+   *
+   * Se suman los MONTOS y no el prorrateo, igual que el "no gravado" de
+   * cabecera y por la misma razón: la cabecera cuadra contra el papel, no contra
+   * el reparto. Un cargo impreso en la factura está impreso aunque no se le haya
+   * asignado ninguna línea.
+   *
+   * En ZZ es 0, como el IVA y las percepciones: sin comprobante no hay cuadre
+   * contra el papel y `total = subtotal`.
+   */
+  bonificaciones: number;
+  /** Neto gravado abierto por alícuota: { '21': 10000, '10.5': 5000 } */
+  netoPorAlicuota: Record<string, number>;
+  iva: number;
+  impuestosInternos: number;
+  percepcionIva: number;
+  percepcionIibb: number;
+  /** Conceptos de cabecera fuera del IVA (pallets, envases): sin línea de producto. */
+  noGravado: number;
+  otrosImpuestos: number;
+  total: number;
+}
+
+/**
+ * Totales de una compra según tipo de comprobante (fuente única del modal de
+ * compras; estructura = factura A real: total = neto de líneas + bonificaciones
+ * generales + IVA + II + percepciones + no gravado de cabecera + otros).
+ *
+ * POR QUÉ EL NETO GRAVADO, EL IVA Y EL IMPUESTO INTERNO SALEN DEL MOTOR Y NO DE
+ * UN LOOP PROPIO. Antes de los cargos, una bonificación se cargaba como línea
+ * negativa o no se cargaba, y `Σ neto × tasa` daba bien. Desde que existen los
+ * cargos, la bonificación es un cargo gravado: baja la base del IVA siempre y
+ * la del impuesto interno cuando es descuento de precio y no bonificación
+ * comercial. Un loop que sólo mira las líneas no las ve, y en la factura
+ * testigo dejaba el impuesto interno 8.996,90 arriba y el IVA 64.424,66 arriba
+ * —números que van a `compras.impuestos_internos` y `compras.iva`, o sea a la
+ * posición fiscal—. El motor ya arma las tres bases bien y es el espejo exacto
+ * de la mig 193, así que el cuadre contra la base cierra por construcción y no
+ * por coincidencia.
+ *
+ * NO HAY RAMA "si hay cargos". Con `cargos: []` el motor da `baseIva = neto` y
+ * `baseII = neto` y factor 1, o sea exactamente la aritmética de antes: una
+ * compra sin cargos sigue dando los mismos totales sin que nadie tenga que
+ * mantener dos brazos de acuerdo. Es la única forma de que no queden dos
+ * fuentes para el mismo número, que es como llegamos acá.
+ *
+ * LO QUE NO SALE DEL MOTOR es lo que el motor no conoce y las líneas sí: el
+ * bruto, la bonificación de línea, el `subtotal` (que COMPRA-A2 clava contra
+ * SUM(compra_items.subtotal)) y la apertura por alícuota. Un cargo gravado no
+ * tiene alícuota propia —tributa a la de las líneas sobre las que cae— así que
+ * no abre un bucket nuevo en `netoPorAlicuota`.
+ *
+ * ZZ (sin factura): lo pagado es todo — sin IVA, sin II, sin percepciones ni no
+ * gravado. `total = subtotal`. La regla la aplica `lineaParaMotor` en el borde.
+ *
+ * @param cargos - los cargos de la factura. Sus `pesos` van por `lineaId`.
+ * @param iiDeclarado - tasa de II → monto declarado. En ZZ se descarta.
+ */
+export function calcularTotalesCompra(
+  items: CompraItemCalculo[],
+  tipoFactura: 'ZZ' | 'FC' = 'FC',
+  extras: CompraExtras = {},
+  cargos: CargoCompra[] = [],
+  iiDeclarado: Record<number, number> = {}
+): TotalesCompra {
+  const esFC = tipoFactura === 'FC';
+  let subtotalBruto = 0;
+  let bonificacionTotal = 0;
+  const netoPorAlicuota: Record<string, number> = {};
+
+  for (const item of items) {
+    const bruto = (item.cantidad || 0) * (item.costoUnitario || 0);
+    const bonif = bruto * (item.bonificacion || 0) / 100;
+    subtotalBruto += bruto;
+    bonificacionTotal += bonif;
+    // En ZZ no hay comprobante que abrir por alícuota.
+    if (esFC && (item.condicionIva ?? 'gravado') === 'gravado') {
+      const alicuota = String(item.porcentajeIva ?? 21);
+      netoPorAlicuota[alicuota] = (netoPorAlicuota[alicuota] || 0) + (bruto - bonif);
+    }
+  }
+
+  // Los ids con los que las líneas entran al motor. El `item.lineaId ?? i` de
+  // antes PODÍA COLISIONAR —un item con lineaId 1 y otro sin lineaId parado en
+  // la posición 1 daban el mismo id— y una colisión hacía que los dos leyeran el
+  // mismo reparto, o sea que un cargo se contara dos veces. Ahora el motor
+  // rechaza los ids repetidos, así que además sería una excepción.
+  // Se numeran los que faltan POR ENCIMA del máximo existente, igual que
+  // `asegurarLineaIds` en el reducer del modal: los que sí tienen id conservan
+  // el suyo y los `pesos` de los cargos siguen matcheando.
+  let proximoId = items.reduce((max, it) => Math.max(max, it.lineaId ?? 0), 0) + 1
+  const idsMotor = items.map(it => it.lineaId ?? proximoId++)
+
+  const costos = calcularCostosCompra(
+    items.map((item, i) => lineaParaMotor(item, tipoFactura, idsMotor[i])),
+    cargos,
+    // Mismo filtro que la RPC: en ZZ la apertura declarada no ajusta nada.
+    esFC ? iiDeclarado : {}
+  );
+  const { netoGravado, netoExento, netoNoGravado, iva, impuestosInternos } = costos.totales;
+
+  const subtotal = subtotalBruto - bonificacionTotal;
+  const bonificaciones = esFC
+    ? redondearSQL(
+        cargos
+          .filter(c => c.condicionIva === 'gravado' && c.enFactura)
+          .reduce((acc, c) => acc + (c.monto || 0), 0),
+        2
+      )
+    : 0;
+  const percepcionIva = esFC ? (extras.percepcionIva || 0) : 0;
+  const percepcionIibb = esFC ? (extras.percepcionIibb || 0) : 0;
+  const noGravado = esFC ? (extras.noGravado || 0) : 0;
+  const otrosImpuestos = esFC ? (extras.otrosImpuestos || 0) : 0;
+  const total = subtotal + bonificaciones + iva + impuestosInternos
+    + percepcionIva + percepcionIibb + noGravado + otrosImpuestos;
+
+  return {
+    subtotalBruto, bonificacionTotal, subtotal, bonificaciones,
+    netoGravado, netoExento, netoNoGravado, netoPorAlicuota,
+    iva, impuestosInternos,
+    percepcionIva, percepcionIibb, noGravado, otrosImpuestos, total,
+  };
+}


### PR DESCRIPTION
**1 de 4.** Este PR es sólo el motor, **sin consumidores**: nada lo importa todavía, así que mergearlo no cambia el comportamiento de la app.

## El problema

Dos cosas que la carga de compras no sabía representar:

- **El flete, los pallets y los separadores son el 16,2% del costo** de la factura testigo y hoy no se cargan en ningún lado. Si se sumaran ingenuamente al costo del producto se les calcularía IVA encima — y los pallets son no gravados.
- **El impuesto interno declarado por el proveedor no cuadra** con el calculado. El gerente lo ajusta a mano con un factor de **1,0496** en un Excel.

## La causa del descuadre, que no se deduce de ningún lado

**No todas las bonificaciones bajan la base del impuesto interno.** En la factura testigo, "PROMO COLA 3.00" es un descuento de precio y sí la baja; "PROMO MANAOS 3000cc" es una bonificación comercial y no. Modelando eso, el factor da **1,0000002**.

Y no es sólo cosmético: el ajuste proporcional **unta** el impuesto de la promo sobre productos que no participaron. MANAOS COLA 600cc no tuvo promo y el Excel le carga 419,70 por pack contra 399,86 del cálculo correcto.

## Qué trae

- `prorratearCargo` — reparte un monto sobre un vector de pesos, con la suma exacta garantizada (el residuo va a la línea de mayor peso). Un peso 0 excluye la línea: por eso el "alcance" no existe como concepto aparte, y una bonificación es simplemente un cargo de monto negativo.
- `calcularCostosCompra` — arma **tres bases distintas** a propósito: la que cuadra contra el papel, la que va al costo, y la del impuesto interno.
- `resolverBasesII` — **deduce** qué bonificación baja la base a partir de lo que la factura declara por alícuota, para que el usuario no tenga que adivinarlo.

## Verificación

Contra la factura real `A0005-00461415` (21 líneas, 13,3 M): costo total **12.797.344,25** y factor **1,000000** en las dos alícuotas.

## Un detalle que vale la pena

`redondearSQL` existe porque `redondear` **no** es espejo de `round(numeric,2)`: diverge el **11,5%** en montos de centavo impar. Lo traicionero es que **nunca diverge con los números del flete**, así que un test de espejo escrito sobre esos datos habría dado verde y consagrado el bug. Por eso compara contra una tabla calculada en Postgres.

## Nota de revisión

`calcularTotalesCompra` se muda a `prorrateoCompra.ts` porque el desglose fiscal ahora necesita el motor, y traerlo al revés invertía la dependencia. Queda un **puente re-exportando desde `calculations.ts`** para no romper a quien importe del lugar viejo; se cae en el PR del modal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)