### PR TITLE
Migraciones de cargos de compra: tablas, motor en SQL y RPCs

### DIFF
--- a/migrations/192_compra_cargos_prorrateo.sql
+++ b/migrations/192_compra_cargos_prorrateo.sql
@@ -1,0 +1,421 @@
+-- ============================================================================
+-- 192 · Compras: cargos prorrateados y cuadre fiscal
+-- ============================================================================
+-- Ver docs/plans/2026-08-18-cargos-y-cuadre-de-compras.md
+--
+-- Tres cosas que la carga de compras no sabía representar:
+--   · flete, pallets y separadores (el 16,2% del costo de la factura testigo)
+--   · que el reparto es por volumen, no por monto, y a veces sólo a un subconjunto
+--   · que NO toda bonificación baja la base del impuesto interno
+--
+-- El "alcance" no es un concepto: un peso 0 excluye la línea. Y una bonificación
+-- es un cargo de monto negativo. Por eso alcanza con una sola tabla.
+--
+-- Forward-only: las compras existentes no tienen cargos ⇒ Σ cargos = 0 ⇒ el
+-- costo es idéntico al de hoy. Cero backfill.
+--
+-- Terminó siendo la 192 después de perder el número TRES veces, y conviene que
+-- quede contado porque a la tercera ya no es mala suerte. Nació como 182: la 182
+-- se la llevó `182_pagos_fecha_en_hora_argentina`, mergeada a main mientras esta
+-- rama estaba abierta, así que pasó a 183. Y mientras se escribía el motor,
+-- otras ramas aplicaron `183_cerrar_recorridos_terminados` y las 186-189 — el
+-- ledger llegó a 189 y las tres de esta tanda pasaron a 190, 191 y 192. Y
+-- todavía no era el final: mientras se cerraba el check de integridad entraron
+-- `190_guards_de_estado_y_cobranza`, `190b_pagos_forzar_usuario_no_definer` y
+-- `191_pagos_forzar_usuario_sin_public`, el ledger llegó a 191, y las tres de
+-- esta tanda terminaron en 192, 193 y 194.
+--
+-- La lección de la segunda vez es más dura que la de la primera. La primera
+-- decía "preguntale al LEDGER, no a `ls migrations/`", y no alcanzó: son TRES
+-- las fuentes que pueden ocupar un número —`origin/main`, el ledger de prod y
+-- las ramas abiertas de los demás— y la tercera no hay forma confiable de
+-- consultarla. Así que lo que cambia no es a quién preguntarle sino CUÁNDO
+-- preguntar: el número se elige AL FINAL, justo antes de aplicar, no al empezar
+-- a escribir. Numerar primero es reservar algo que no se puede reservar.
+-- A la tercera la regla se siguió: se reconfirmó contra el ledger y contra todas
+-- las refs de git en el minuto anterior a aplicar, y recién ahí se aplicó.
+--
+-- El espejo en TypeScript de todo esto es `src/utils/prorrateoCompra.ts`, que ya
+-- reproduce la factura testigo: cada línea al medio centavo, y los dos totales
+-- del golden dentro de los 5 centavos. Las funciones SQL NO van en este archivo:
+-- van en la 193 (motor de cálculo) y la 194 (RPCs y check de integridad).
+-- Appendearlas acá las dejaría fuera del BEGIN/COMMIT de abajo, que es justo lo
+-- que evita quedarse con las tablas creadas y las RPCs a medias.
+-- ============================================================================
+
+BEGIN;
+
+-- ----------------------------------------------------------------------------
+-- 1 · Los destinos de las FK compuestas
+--
+-- Las dos son redundantes por construcción —`id` ya es PK en las dos tablas—, así
+-- que no rechazan ninguna fila existente: verificado con conteos contra prod, 128
+-- compras y 524 líneas, 0 duplicados y 0 nulos en las dos parejas. Existen sólo
+-- para poder exigir por FK, más abajo, que un cargo no cruce de sucursal y que un
+-- reparto no cruce de compra.
+--
+-- `ADD CONSTRAINT` no acepta IF NOT EXISTS: el guard va afuera.
+-- ----------------------------------------------------------------------------
+DO $mig$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+     WHERE conname = 'compras_id_sucursal_uk'
+       AND conrelid = 'public.compras'::regclass
+  ) THEN
+    ALTER TABLE public.compras
+      ADD CONSTRAINT compras_id_sucursal_uk UNIQUE (id, sucursal_id);
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+     WHERE conname = 'compra_items_id_compra_uk'
+       AND conrelid = 'public.compra_items'::regclass
+  ) THEN
+    ALTER TABLE public.compra_items
+      ADD CONSTRAINT compra_items_id_compra_uk UNIQUE (id, compra_id);
+  END IF;
+END;
+$mig$;
+
+-- ----------------------------------------------------------------------------
+-- 2 · Los cargos de la factura
+--
+-- La FK a `compras` es COMPUESTA por (compra_id, sucursal_id), y eso cierra un
+-- agujero real: `es_admin()` es global y `current_sucursal_id()` sale del header,
+-- así que un admin parado en la sucursal A podía colgar un cargo con
+-- `sucursal_id = A` sobre una compra de B — la policy de INSERT chequea la fila y
+-- pasa, y una FK simple a `compras(id)` no mira la sucursal. Lo grave no es que
+-- se pueda: es que el cargo quedaba INVISIBLE para los usuarios de B, porque la
+-- policy de SELECT filtra por `sucursal_id` del cargo. Corrupción silenciosa con
+-- la víctima ciega. Ahora la base lo rechaza.
+-- ----------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS public.compra_cargos (
+  id                 bigint GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+  compra_id          bigint NOT NULL,
+  sucursal_id        bigint NOT NULL REFERENCES public.sucursales(id),
+  usuario_id         uuid REFERENCES public.perfiles(id) ON DELETE SET NULL,
+  orden              integer NOT NULL DEFAULT 0,
+  concepto           text    NOT NULL CHECK (btrim(concepto) <> ''),
+  monto              numeric(12,2) NOT NULL,
+  condicion_iva      text    NOT NULL DEFAULT 'no_gravado'
+                       CHECK (condicion_iva IN ('gravado','exento','no_gravado')),
+  en_factura         boolean NOT NULL DEFAULT true,
+  prorratea_al_costo boolean NOT NULL DEFAULT true,
+  afecta_base_ii     boolean NOT NULL DEFAULT false,
+  base_prorrateo     text    NOT NULL DEFAULT 'unidades'
+                       CHECK (base_prorrateo IN ('monto','cantidad','unidades')),
+  created_at         timestamptz NOT NULL DEFAULT now(),
+
+  CONSTRAINT compra_cargos_compra_fk
+    FOREIGN KEY (compra_id, sucursal_id)
+    REFERENCES public.compras(id, sucursal_id) ON DELETE CASCADE,
+
+  -- Destino de la FK compuesta de compra_cargo_repartos.
+  CONSTRAINT compra_cargos_id_compra_uk UNIQUE (id, compra_id)
+);
+
+COMMENT ON TABLE public.compra_cargos IS
+  'Conceptos de una compra que no son renglones de producto: flete, pallets, separadores, bonificaciones promocionales, redondeo. Monto negativo = bonificación.';
+COMMENT ON COLUMN public.compra_cargos.monto IS
+  'SIN IVA. Negativo = bonificación.';
+COMMENT ON COLUMN public.compra_cargos.usuario_id IS
+  'Quién cargó el concepto. El contenido de esta tabla mueve el costo de los productos y la RLS deja escribirla directo a los admin, así que la autoría importa. Misma convención que compras.usuario_id.';
+COMMENT ON COLUMN public.compra_cargos.en_factura IS
+  'true = el concepto viene impreso en la factura y suma al cuadre. El flete de un tercero va en false: no toca compras.total ni compras.iva, pero sí el costo.';
+COMMENT ON COLUMN public.compra_cargos.prorratea_al_costo IS
+  'true = entra al costo unitario de los productos. Independiente de en_factura.';
+COMMENT ON COLUMN public.compra_cargos.afecta_base_ii IS
+  'true = el cargo modifica la base de cálculo de impuestos internos. Una bonificación comercial NO la modifica; un descuento de precio SI. Es la causa del descuadre histórico del II.';
+COMMENT ON COLUMN public.compra_cargos.base_prorrateo IS
+  'Sólo pre-llena el vector de pesos en la UI. La verdad siempre es compra_cargo_repartos.';
+COMMENT ON COLUMN public.compra_cargos.condicion_iva IS
+  'Un cargo gravado tributa a la alícuota de las líneas sobre las que se prorratea: no lleva alícuota propia. Hoy los 247 productos son 21%, así que la distinción no se plantea. Si alguna vez conviven alícuotas distintas en una misma compra hay que decidir qué significa la base gravada de una línea que recibe un cargo de otra alícuota.';
+
+CREATE INDEX IF NOT EXISTS idx_compra_cargos_compra ON public.compra_cargos(compra_id);
+
+-- ----------------------------------------------------------------------------
+-- 3 · El vector de pesos
+--
+-- `compra_id` está denormalizado a propósito: es lo que permite que las DOS FK
+-- sean compuestas y que la base —no la buena conducta de la RPC— garantice que un
+-- reparto nunca cruce COMPRAS. Sin esto, `compra_item_id` podía apuntar a la
+-- línea de otra compra y nada lo impedía; importa porque la RLS habilita
+-- escritura directa a los admin, no sólo por RPC. Las dos FK compuestas mantienen
+-- las tres compra_id consistentes entre sí.
+--
+-- El alcance exacto, para no prometer de más: la coherencia de SUCURSAL de esta
+-- tabla se apoya en la del cargo (sección 2). Nada ata todavía
+-- `compra_items.sucursal_id` a `compras.sucursal_id` — es un hueco preexistente,
+-- de otro trabajo.
+--
+-- ON UPDATE queda en NO ACTION a propósito: si alguien moviera una línea de
+-- compra, que falle ruidosamente en vez de arrastrar el reparto en silencio.
+-- ----------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS public.compra_cargo_repartos (
+  cargo_id       bigint NOT NULL,
+  compra_item_id bigint NOT NULL,
+  compra_id      bigint NOT NULL,
+  -- Misma invariante que `prorratearCargo` en prorrateoCompra.ts, que lanza tanto
+  -- ante un peso negativo como ante uno no finito: los pesos son proporciones y
+  -- el 0 es la exclusión.
+  --
+  -- El `<> 'NaN'` NO es redundante con el `>= 0`: en numeric, `'NaN' >= 0` es
+  -- TRUE, así que el chequeo de signo por sí solo deja entrar un NaN. Y un solo
+  -- NaN contamina el cargo entero —sum(peso) da NaN y por lo tanto TODOS sus
+  -- repartos salen NaN—, o sea costos corruptos en silencio. Funciona porque
+  -- `'NaN' <> 'NaN'` es false en numeric.
+  --
+  -- (16,4) y no (12,4) pese a que la columna sea una proporción: con
+  -- `base_prorrateo = 'monto'` el pre-llenado deja literalmente un MONTO acá, y
+  -- (12,4) topea en ~100 M contra una línea máxima de 3,0 M hoy. 33x no es
+  -- horizonte en pesos argentinos; ensanchar ahora es gratis y con datos adentro
+  -- es un rewrite de tabla.
+  peso           numeric(16,4) NOT NULL DEFAULT 0
+                   CHECK (peso >= 0 AND peso <> 'NaN'::numeric),
+
+  PRIMARY KEY (cargo_id, compra_item_id),
+
+  CONSTRAINT compra_cargo_repartos_cargo_fk
+    FOREIGN KEY (cargo_id, compra_id)
+    REFERENCES public.compra_cargos(id, compra_id) ON DELETE CASCADE,
+
+  -- El CASCADE es deliberado, y hay que decir lo que se lleva puesto:
+  -- `actualizar_compra_items` hace DELETE + INSERT de las líneas en CADA edición
+  -- de una compra, así que cada edición borra TODOS los repartos de esa compra.
+  -- Los cargos sobreviven —cuelgan de compra_id, no de la línea— y queda el peor
+  -- estado posible: cargo vivo con el vector vacío ⇒ sum(peso) = 0 ⇒ el flete
+  -- deja de repartirse. Y no grita, porque el espejo TS trata el vector vacío
+  -- como legal (`prorratearCargo` devuelve {}): los cargos se caen del costo en
+  -- silencio, que es exactamente el bug que esta feature viene a arreglar.
+  -- El CASCADE evita huérfanos; NO evita esa pérdida. Quien tiene que evitarla es
+  -- la RPC de edición, reescribiendo los cargos junto con las líneas (Task 10).
+  CONSTRAINT compra_cargo_repartos_item_fk
+    FOREIGN KEY (compra_item_id, compra_id)
+    REFERENCES public.compra_items(id, compra_id) ON DELETE CASCADE
+);
+
+COMMENT ON TABLE public.compra_cargo_repartos IS
+  'Vector de pesos de un cargo. Peso 0 excluye la línea: por eso el "alcance" no existe como concepto aparte. OJO: editar la compra borra estas filas por CASCADE (actualizar_compra_items recrea las líneas) y deja los cargos con el vector vacío; la RPC de edición tiene que reescribirlos.';
+COMMENT ON COLUMN public.compra_cargo_repartos.compra_id IS
+  'Denormalizado desde el cargo y la línea. Las dos FK compuestas lo usan para garantizar que un reparto no cruce compras.';
+COMMENT ON COLUMN public.compra_cargo_repartos.peso IS
+  'Proporción, no monto — salvo que base_prorrateo sea monto, donde el pre-llenado deja un monto acá; de ahí el ancho. 0 excluye la línea del reparto. Un peso negativo y un NaN son dato corrupto, no una exclusión: el CHECK rechaza los dos. El NaN necesita su propia mitad porque NaN >= 0 es TRUE en numeric.';
+
+-- El compuesto (compra_id, compra_item_id) y no (compra_item_id) solo, porque
+-- sirve a los tres accesos con un solo índice:
+--   · reabrir una compra = todos sus repartos (compra_id es prefijo);
+--   · reconstruir una línea = (compra_id, compra_item_id) exacto;
+--   · la integridad referencial de compra_cargo_repartos_item_fk, que filtra las
+--     dos columnas por igualdad y por lo tanto no depende del orden.
+-- Ese último es el que importa en caliente: `actualizar_compra_items` hace
+-- DELETE + INSERT de las líneas, así que sin índice cada edición de compra
+-- dispararía un seq scan por fila borrada.
+-- La PK (cargo_id, compra_item_id) ya cubre el acceso por cargo y la FK al cargo.
+CREATE INDEX IF NOT EXISTS idx_compra_cargo_repartos_compra_item
+  ON public.compra_cargo_repartos(compra_id, compra_item_id);
+
+-- ----------------------------------------------------------------------------
+-- 4 · Los dos snapshots
+--
+-- Sin el de la LÍNEA no se puede reconstruir cuánto fue flete y cuánto impuesto
+-- interno al reabrir la compra.
+-- ----------------------------------------------------------------------------
+ALTER TABLE public.compra_items
+  ADD COLUMN IF NOT EXISTS cargos_unitarios numeric(12,4) NOT NULL DEFAULT 0;
+
+COMMENT ON COLUMN public.compra_items.cargos_unitarios IS
+  'Cargos no gravados prorrateados a esta línea, por unidad (mig 192). Ya está incluido en costo_real_unitario.';
+
+-- Y el de la COMPRA es la apertura del impuesto interno por alícuota, que es lo
+-- único que el factor de ajuste de `calcular_costos_compra` sabe leer.
+--
+-- No está acá para que alguien la consulte: está para que el ajuste no se
+-- EVAPORE. Es una entrada que mueve el costo guardado y no dejaba rastro, así
+-- que una edición que no la reenviara recalculaba con factor 1 y revertía el
+-- ajuste en silencio — la misma pérdida que el CASCADE le hace a los repartos,
+-- pero peor, porque sin esta columna la base no tiene con qué darse cuenta. El
+-- guard de `actualizar_compra_items` que la usa vive en la 194.
+--
+-- La factura testigo necesita un factor de 1,0496 para que el II declarado cuadre
+-- con el calculado: un ajuste de ese tamaño desapareciendo solo al editar es peor
+-- que no tenerlo, porque nadie lo va a sospechar.
+--
+-- Nullable y sin DEFAULT a propósito: las 128 compras existentes quedan en NULL,
+-- que es exactamente lo que son —compras cargadas sin apertura—, y ese ALTER no
+-- reescribe la tabla.
+ALTER TABLE public.compras
+  ADD COLUMN IF NOT EXISTS ii_declarado jsonb;
+
+COMMENT ON COLUMN public.compras.ii_declarado IS
+  'Apertura del impuesto interno POR ALICUOTA tal como vino en la factura: {tasa: monto}. Alimenta el factor de ajuste de calcular_costos_compra, que corrige el II calculado hasta el declarado. NULL = esta compra no se cargo con apertura, y NO es lo mismo que {}: el parametro p_ii_declarado de las RPCs distingue "no me mandaron nada" (NULL, y si la compra tiene apertura la edicion se rechaza) de "me mandaron vacio" ({}, el usuario la borro). Una apertura vacia se persiste como NULL, porque no ajusta nada y no hay nada que proteger. Se guarda porque sin ella el ajuste se revertiria solo en la primera edicion que no la reenviara, y la base no tendria con que detectarlo (mig 192/194).';
+
+-- ----------------------------------------------------------------------------
+-- 5 · RLS
+--
+-- Espejo exacto de `mt_compra_items_*`: depósito lee y carga, admin corrige y
+-- borra, todo acotado a la sucursal de la sesión. Un reparto es tan sensible como
+-- la línea de compra —es la plata—, así que NO va una sola policy FOR ALL que
+-- mire sólo la sucursal: eso le daría lectura y escritura a un preventista o a un
+-- transportista de esa sucursal, o sea la capacidad de alterar el costo de los
+-- productos.
+--
+-- No existe un helper `es_deposito()`: las policies de compra_items inlinean el
+-- EXISTS sobre `perfiles`, y acá se replica literal para no introducir una
+-- variante que después divergiera.
+--
+-- En compra_cargo_repartos el rol y la sucursal se resuelven por el join con
+-- compra_cargos. Ese EXISTS pasa además por la RLS de compra_cargos, lo cual es
+-- redundante pero deliberado: si mañana se endurece compra_cargos, los repartos
+-- se endurecen solos. La contracara, que hay que tener presente: como el EXISTS
+-- pasa por la policy de SELECT, endurecer esa LECTURA cambia en silencio quién
+-- puede ESCRIBIR repartos, y el síntoma sería un error de RLS apuntando a la
+-- tabla equivocada.
+-- ----------------------------------------------------------------------------
+ALTER TABLE public.compra_cargos          ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.compra_cargo_repartos  ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS mt_compra_cargos_select ON public.compra_cargos;
+CREATE POLICY mt_compra_cargos_select ON public.compra_cargos
+  FOR SELECT TO authenticated
+  USING (
+    (es_admin() OR EXISTS (
+      SELECT 1 FROM public.perfiles
+       WHERE perfiles.id = auth.uid() AND perfiles.rol = 'deposito'))
+    AND sucursal_id = current_sucursal_id()
+  );
+
+DROP POLICY IF EXISTS mt_compra_cargos_insert ON public.compra_cargos;
+CREATE POLICY mt_compra_cargos_insert ON public.compra_cargos
+  FOR INSERT TO authenticated
+  WITH CHECK (
+    (es_admin() OR EXISTS (
+      SELECT 1 FROM public.perfiles
+       WHERE perfiles.id = auth.uid() AND perfiles.rol = 'deposito'))
+    AND sucursal_id = current_sucursal_id()
+  );
+
+DROP POLICY IF EXISTS mt_compra_cargos_update ON public.compra_cargos;
+CREATE POLICY mt_compra_cargos_update ON public.compra_cargos
+  FOR UPDATE TO authenticated
+  USING      (es_admin() AND sucursal_id = current_sucursal_id())
+  WITH CHECK (es_admin() AND sucursal_id = current_sucursal_id());
+
+DROP POLICY IF EXISTS mt_compra_cargos_delete ON public.compra_cargos;
+CREATE POLICY mt_compra_cargos_delete ON public.compra_cargos
+  FOR DELETE TO authenticated
+  USING (es_admin() AND sucursal_id = current_sucursal_id());
+
+DROP POLICY IF EXISTS mt_compra_cargo_repartos_select ON public.compra_cargo_repartos;
+CREATE POLICY mt_compra_cargo_repartos_select ON public.compra_cargo_repartos
+  FOR SELECT TO authenticated
+  USING (
+    (es_admin() OR EXISTS (
+      SELECT 1 FROM public.perfiles
+       WHERE perfiles.id = auth.uid() AND perfiles.rol = 'deposito'))
+    AND EXISTS (
+      SELECT 1 FROM public.compra_cargos c
+       WHERE c.id = compra_cargo_repartos.cargo_id
+         AND c.sucursal_id = current_sucursal_id())
+  );
+
+DROP POLICY IF EXISTS mt_compra_cargo_repartos_insert ON public.compra_cargo_repartos;
+CREATE POLICY mt_compra_cargo_repartos_insert ON public.compra_cargo_repartos
+  FOR INSERT TO authenticated
+  WITH CHECK (
+    (es_admin() OR EXISTS (
+      SELECT 1 FROM public.perfiles
+       WHERE perfiles.id = auth.uid() AND perfiles.rol = 'deposito'))
+    AND EXISTS (
+      SELECT 1 FROM public.compra_cargos c
+       WHERE c.id = compra_cargo_repartos.cargo_id
+         AND c.sucursal_id = current_sucursal_id())
+  );
+
+DROP POLICY IF EXISTS mt_compra_cargo_repartos_update ON public.compra_cargo_repartos;
+CREATE POLICY mt_compra_cargo_repartos_update ON public.compra_cargo_repartos
+  FOR UPDATE TO authenticated
+  USING (
+    es_admin() AND EXISTS (
+      SELECT 1 FROM public.compra_cargos c
+       WHERE c.id = compra_cargo_repartos.cargo_id
+         AND c.sucursal_id = current_sucursal_id())
+  )
+  WITH CHECK (
+    es_admin() AND EXISTS (
+      SELECT 1 FROM public.compra_cargos c
+       WHERE c.id = compra_cargo_repartos.cargo_id
+         AND c.sucursal_id = current_sucursal_id())
+  );
+
+DROP POLICY IF EXISTS mt_compra_cargo_repartos_delete ON public.compra_cargo_repartos;
+CREATE POLICY mt_compra_cargo_repartos_delete ON public.compra_cargo_repartos
+  FOR DELETE TO authenticated
+  USING (
+    es_admin() AND EXISTS (
+      SELECT 1 FROM public.compra_cargos c
+       WHERE c.id = compra_cargo_repartos.cargo_id
+         AND c.sucursal_id = current_sucursal_id())
+  );
+
+COMMIT;
+
+-- ----------------------------------------------------------------------------
+-- Rollback
+--
+--   DROP TABLE  IF EXISTS public.compra_cargo_repartos;
+--   DROP TABLE  IF EXISTS public.compra_cargos;
+--   ALTER TABLE public.compras      DROP COLUMN     IF EXISTS ii_declarado;
+--   ALTER TABLE public.compra_items DROP COLUMN     IF EXISTS cargos_unitarios;
+--   ALTER TABLE public.compra_items DROP CONSTRAINT IF EXISTS compra_items_id_compra_uk;
+--   ALTER TABLE public.compras      DROP CONSTRAINT IF EXISTS compras_id_sucursal_uk;
+--
+-- Mientras no existan cargos eso es exacto y el costo vuelve solo: Σ cargos = 0.
+--
+-- DEJA de ser exacto en cuanto los cargos empiecen a entrar al
+-- `costo_real_unitario` y, por ahí, al costo promedio ponderado. A partir de ese
+-- momento dropear estas tablas borra CUÁLES fueron los cargos pero NO los saca de
+-- los costos ya calculados: quedan costos que incluyen cargos sin ningún registro
+-- de su origen, y nada que permita reconstruirlos. Deja de ser reversible y pasa
+-- a ser reversible-con-recálculo — hay que recomputar el costo de las compras
+-- afectadas y su CPP, con las tablas todavía en pie.
+-- ----------------------------------------------------------------------------
+
+-- ----------------------------------------------------------------------------
+-- Verificación
+--
+--   -- Las dos tablas, con RLS prendida y 4 policies cada una:
+--   SELECT c.relname, c.relrowsecurity,
+--          (SELECT count(*) FROM pg_policies p
+--            WHERE p.schemaname = 'public' AND p.tablename = c.relname) AS policies
+--     FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+--    WHERE n.nspname = 'public'
+--      AND c.relname IN ('compra_cargos','compra_cargo_repartos');
+--   -- compra_cargos         | t | 4
+--   -- compra_cargo_repartos | t | 4
+--
+--   -- Las tres FK compuestas: la del cargo a su compra+sucursal, y las dos del
+--   -- reparto a su cargo y a su línea.
+--   SELECT conrelid::regclass AS tabla, conname, pg_get_constraintdef(oid)
+--     FROM pg_constraint
+--    WHERE contype = 'f'
+--      AND conrelid IN ('public.compra_cargos'::regclass,
+--                       'public.compra_cargo_repartos'::regclass)
+--      AND cardinality(conkey) = 2;
+--   -- compra_cargos_compra_fk      | (compra_id, sucursal_id)   -> compras(id, sucursal_id)
+--   -- compra_cargo_repartos_cargo_fk | (cargo_id, compra_id)    -> compra_cargos(id, compra_id)
+--   -- compra_cargo_repartos_item_fk  | (compra_item_id, compra_id) -> compra_items(id, compra_id)
+--
+--   -- El snapshot por línea, en 0 para las 524 líneas existentes (forward-only):
+--   SELECT count(*) AS lineas,
+--          count(*) FILTER (WHERE cargos_unitarios = 0) AS en_cero
+--     FROM compra_items;                                  -- 524 | 524
+--
+--   -- Y el de la compra, en NULL para todas las existentes:
+--   SELECT count(*) AS compras,
+--          count(*) FILTER (WHERE ii_declarado IS NULL) AS sin_apertura
+--     FROM compras;                                       -- 128 | 128
+--
+--   -- Y ninguna compra cambió de costo, porque todavía no hay cargos:
+--   SELECT count(*) FROM compra_cargos;                   -- 0
+-- ----------------------------------------------------------------------------

--- a/migrations/193_compra_cargos_funciones.sql
+++ b/migrations/193_compra_cargos_funciones.sql
@@ -1,0 +1,1058 @@
+-- ============================================================================
+-- 193 · Compras: el motor de cálculo de los cargos, en SQL
+-- ============================================================================
+-- Ver docs/plans/2026-08-18-cargos-y-cuadre-de-compras.md
+--
+-- La 192 creó las tablas; acá va la aritmética que las lee. El archivo se llena
+-- en tres tramos, y con la task 8 queda completo:
+--
+--   1 · prorratear_cargo        — reparte UN cargo sobre un vector de pesos
+--   2 · costo_real_unitario     — el costo por unidad gana el término de los cargos,
+--                                 y los tres llamadores pasan a la firma nueva
+--   3 · calcular_costos_compra  — las tres bases, el II ajustado al declarado y
+--                                 los unitarios de cada línea
+--
+-- Los tres van adentro del mismo BEGIN/COMMIT: el motor a medias no sirve para
+-- nada, y dejar la mitad aplicada es peor que no aplicar nada.
+--
+-- Todo lo de acá es espejo EXACTO de `src/utils/prorrateoCompra.ts`, que ya
+-- reproduce la factura testigo A0005-00461415 al medio centavo por línea. Las dos
+-- implementaciones existen porque el número se calcula y se PERSISTE en la base,
+-- pero el modal tiene que anticiparlo sin ir a la base. Si cambiás una, cambiá la
+-- otra: `prorrateoCompra.test.ts` y `prorrateoCompra.golden.test.ts` son la
+-- especificación de las dos.
+--
+-- Y desde la mig 196 eso NO depende de que alguien se acuerde. El espejo
+-- (`scripts/espejo-motor-compras.mjs`, sobre `espejo_motor_compras`) corre las
+-- DOS implementaciones sobre los mismos casos —los 10 repartos unitarios, la
+-- factura testigo entera y los casos de contrato— y falla si difieren en un
+-- centavo o si sólo una lanza. Corre en el gate de integridad, todos los días.
+-- Tocar este archivo y no el TypeScript lo pone rojo, que es exactamente lo que
+-- esta frase pedía y no podía garantizar.
+--
+-- "EXACTO" lo es para todo dato bien formado, y en el BORDE del jsonb es a
+-- propósito MÁS permisivo que el TS: acá las claves opcionales tienen DEFAULT
+-- (`condicion_iva` 'gravado' en la línea y 'no_gravado' en el cargo,
+-- `porcentaje_iva` 0, `en_factura` true…), y son los MISMOS defaults que los de
+-- las tablas de la 192, para que armar el jsonb desde una fila y omitir una
+-- columna den lo mismo. El TS no los tiene: sus campos son obligatorios y se los
+-- exige el compilador. Donde el dato es basura —no donde falta— las dos LANZAN.
+--
+-- ⚠ SEIS MIGRACIONES VIEJAS DEL REPO SON MINAS: `111`, `112`, `114`, `115`,
+-- `126` y `128` tienen call sites de `costo_real_unitario` con TRES argumentos.
+-- Una vez aplicada ésta, re-aplicar cualquiera de ellas deja una RPC de compras
+-- llamando a una firma que ya no existe — y NO rompe al aplicarla, rompe en
+-- producción la próxima vez que alguien registra o anula una compra. Es el mismo
+-- patrón que ya mordió al trabajo de multi-rol: un `CREATE OR REPLACE` viejo que
+-- revierte lógica viva en silencio. Si hay que reaplicar alguna, actualizale el
+-- call site a la firma de 4 argumentos ANTES de correrla.
+-- (El revisor contó cinco; la `112` también la tiene, en el UPDATE de productos.)
+-- ============================================================================
+
+BEGIN;
+
+-- ----------------------------------------------------------------------------
+-- 1 · Reparto de un cargo sobre un vector de pesos
+--
+-- Espejo de `prorratearCargo()` en src/utils/prorrateoCompra.ts.
+--
+-- El residuo va a la línea de mayor peso (desempate: menor id) para que la suma
+-- dé el monto EXACTO: sin eso, repartir sobre pesos fraccionarios no vuelve a
+-- sumar el monto y el check de integridad COMPRA-A3 se pone rojo por centavos.
+-- (Se llama A3 y no A2: cuando se escribió esto A2 parecía libre y no lo estaba.)
+-- `ORDER BY peso DESC, id ASC` es un orden total sobre ids distintos, así que
+-- cuál es la línea del residuo no depende del orden en que llegue el vector.
+--
+-- El orden en que se ACUMULAN las partes tampoco importa acá, y eso es una
+-- propiedad de `numeric`, no una casualidad: la suma es exacta y por lo tanto
+-- asociativa. En el espejo de JS sí importaba. Es también lo que permite marcar
+-- la función IMMUTABLE aun con un `sum()` que el planner puede paralelizar: con
+-- `double precision` el resultado dependería del plan.
+--
+-- Contrato de entrada, el mismo que el del TS. El cero es un estado válido; el
+-- negativo, el NaN y el infinito son corrupción:
+--   · peso 0        → legal, excluye la línea. ES el mecanismo de alcance.
+--   · vector vacío  → 0 filas. Legal: es la grilla a medio llenar. `p_pesos`
+--     NULL cuenta como vacío, porque `jsonb_object_agg` de cero filas devuelve
+--     NULL y ésa es exactamente la forma en que un cargo sin repartos va a
+--     llegar hasta acá.
+--   · peso negativo o no finito → LANZA, nombrando la línea.
+--   · monto NULL o no finito    → LANZA.
+--
+-- Por qué lanza en vez de normalizar a 0: convertir basura en 0 la vuelve
+-- indistinguible de una exclusión deliberada, porque el 0 ES la exclusión. Y el
+-- daño no es "un poco de error". Un solo NaN hace NaN a `sum(peso)` y por lo
+-- tanto a TODOS los repartos del cargo, y de ahí al costo_real_unitario y al
+-- costo promedio ponderado. El peso negativo es peor todavía porque no deja
+-- rastro: da números plausibles, y si los negativos cancelan a los positivos el
+-- cargo entero desaparece sin un solo aviso.
+--
+-- El CHECK de compra_cargo_repartos ya filtra lo que se GUARDA, pero `p_pesos`
+-- es un jsonb: puede llegar armado desde el payload de una RPC sin haber pasado
+-- nunca por la tabla. Y las dos defensas no cubren lo mismo — `'NaN' >= 0` es
+-- TRUE, y `'Infinity'` pasa el CHECK entero: al infinito lo frena recién el
+-- numeric(16,4) de la columna, que acá no existe.
+-- ----------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.prorratear_cargo(p_monto numeric, p_pesos jsonb)
+RETURNS TABLE (item_id bigint, monto numeric)
+LANGUAGE plpgsql
+IMMUTABLE          -- sólo mira sus argumentos: ni tablas, ni now(), ni GUCs
+PARALLEL SAFE
+ROWS 25            -- líneas por compra: media 4, máximo 31. El default de 1000 miente feo
+SET search_path TO 'public'
+AS $fn$
+DECLARE
+  v_total_peso numeric;
+  v_id_residuo bigint;
+  v_key        text;
+  v_motivo     text;
+  v_val        jsonb;
+BEGIN
+  -- NO es STRICT a propósito: STRICT devolvería 0 filas ante un monto NULL, o
+  -- sea justo el silencio que este contrato viene a evitar.
+  IF p_monto IS NULL
+     OR p_monto = 'NaN'::numeric
+     OR p_monto = 'Infinity'::numeric
+     OR p_monto = '-Infinity'::numeric THEN
+    RAISE EXCEPTION 'prorratear_cargo: monto no finito (%).', COALESCE(p_monto::text, 'NULL')
+      USING ERRCODE = '22023';
+  END IF;
+
+  -- Vector ausente ≡ vector vacío. Cualquier otro jsonb que no sea un objeto es
+  -- un error de forma, y conviene decirlo acá: `jsonb_each_text` tira "cannot
+  -- call jsonb_each_text on a non-object", que no nombra ni la función ni el
+  -- cargo.
+  IF p_pesos IS NULL OR jsonb_typeof(p_pesos) = 'null' THEN
+    RETURN;
+  END IF;
+  IF jsonb_typeof(p_pesos) <> 'object' THEN
+    RAISE EXCEPTION 'prorratear_cargo: se esperaba un objeto {id: peso} y llego un %.',
+      jsonb_typeof(p_pesos) USING ERRCODE = '22023';
+  END IF;
+
+  -- Las claves son ids de línea. Se validan ANTES que los pesos porque todo lo
+  -- que sigue castea la clave a bigint, y ese error de cast no dice ni qué clave
+  -- fue ni de qué función salió. Son TRES formas de romperlo y antes las tres
+  -- pasaban por el mismo `!~ '^-?[0-9]+$'`, que sólo atajaba la primera:
+  --   · no numérica ('pallet') → la atajaba el regex, sigue igual.
+  --   · fuera del rango de bigint ('999999999999999999999') → pasaba el regex y
+  --     reventaba después en el cast con un 22003 crudo, que es exactamente el
+  --     error que esta validación existe para no mostrar.
+  --   · no canónica ('01', '-0') → la peor, porque no es un error de forma sino
+  --     PLATA DUPLICADA: '01' y '1' son claves jsonb distintas que castean al
+  --     MISMO bigint, así que `repartos` emite dos filas con item_id = 1 y la
+  --     línea cobra el cargo DOS VECES. Se compara contra la forma canónica en
+  --     vez de buscar ceros a la izquierda porque así cae también el '-0'.
+  -- El CASE fuerza el orden de evaluación en los dos lados: sin él el planner
+  -- puede correr el cast antes del regex y volver al error crudo.
+  SELECT e.key,
+         CASE WHEN e.key !~ '^-?[0-9]+$' THEN 'no es un id de linea'
+              WHEN e.key::numeric NOT BETWEEN -9223372036854775808
+                                          AND  9223372036854775807
+                THEN 'se sale del rango de bigint'
+              ELSE 'no esta en forma canonica (como "01" o "-0"), y dos claves que castean al mismo id le cobran el cargo dos veces a esa linea'
+         END
+    INTO v_key, v_motivo
+    FROM jsonb_each(p_pesos) e
+   WHERE CASE WHEN e.key !~ '^-?[0-9]+$' THEN true
+              WHEN e.key::numeric NOT BETWEEN -9223372036854775808
+                                          AND  9223372036854775807 THEN true
+              ELSE e.key <> (e.key::bigint)::text
+         END
+   ORDER BY e.key
+   LIMIT 1;
+  IF v_key IS NOT NULL THEN
+    RAISE EXCEPTION 'prorratear_cargo: la clave "%" %.', v_key, v_motivo
+      USING ERRCODE = '22023';
+  END IF;
+
+  -- Un solo recorrido, en el mismo orden y con la misma precedencia que el TS
+  -- (primero "no finito", después "negativo"): ante un vector con las dos clases
+  -- de basura, las dos implementaciones nombran la misma línea.
+  --
+  -- `jsonb_typeof = 'number'` es lo que ataja el NaN, no el chequeo de signo:
+  -- Postgres serializa el NaN y el infinito de numeric como STRING
+  -- (`jsonb_object_agg` de un peso NaN da '{"1": "NaN"}'), y el texto 'NaN'
+  -- castea a numeric sin chistar. Al revés, un jsonb de tipo 'number' no puede
+  -- ser NaN ni infinito: JSON no tiene esos literales.
+  FOR v_key, v_val IN
+    SELECT e.key, e.value FROM jsonb_each(p_pesos) e ORDER BY e.key::bigint
+  LOOP
+    IF jsonb_typeof(v_val) <> 'number' THEN
+      RAISE EXCEPTION
+        'prorratear_cargo: peso no finito en la linea % (%). Se esperan numeros finitos; el 0 excluye una linea.',
+        v_key, v_val USING ERRCODE = '22023';
+    END IF;
+    IF (v_val #>> '{}')::numeric < 0 THEN
+      RAISE EXCEPTION
+        'prorratear_cargo: peso negativo en la linea % (%). Los pesos son proporciones; el 0 excluye una linea.',
+        v_key, v_val USING ERRCODE = '22023';
+    END IF;
+  END LOOP;
+
+  SELECT sum(e.value::numeric) INTO v_total_peso FROM jsonb_each_text(p_pesos) e;
+
+  -- Validados los pesos, esto significa exactamente "todos en cero" (o sin
+  -- líneas): ya no puede ser una cancelación entre positivos y negativos.
+  IF v_total_peso IS NULL OR v_total_peso = 0 THEN
+    RETURN;
+  END IF;
+
+  SELECT e.key::bigint INTO v_id_residuo
+    FROM jsonb_each_text(p_pesos) e
+   ORDER BY e.value::numeric DESC, e.key::bigint ASC
+   LIMIT 1;
+
+  -- Una sola consulta en vez de un loop con acumulador: así la definición del
+  -- residuo —el monto menos todo lo demás— se lee de un renglón, que es la
+  -- invariante que justifica la función entera.
+  --
+  -- El `ORDER BY` final no es parte del contrato, pero hace reproducible
+  -- cualquier volcado y sobre 31 filas como máximo no se paga nada por él.
+  RETURN QUERY
+  WITH partes AS (
+    SELECT e.key::bigint AS id,
+           round(p_monto * e.value::numeric / v_total_peso, 2) AS parte
+      FROM jsonb_each_text(p_pesos) e
+     WHERE e.key::bigint <> v_id_residuo
+  )
+  SELECT p.id, p.parte
+    FROM partes p
+   UNION ALL
+  SELECT v_id_residuo,
+         round(p_monto - COALESCE((SELECT sum(x.parte) FROM partes x), 0), 2)
+   ORDER BY 1;
+END;
+$fn$;
+
+COMMENT ON FUNCTION public.prorratear_cargo(numeric, jsonb) IS
+  'Reparte un cargo de compra sobre un vector {id_de_linea: peso}. La suma de '
+  'los repartos da el monto EXACTO: el residuo del redondeo cae en la linea de '
+  'mayor peso (desempate por menor id). Peso 0 excluye la linea y vector vacio '
+  'devuelve 0 filas; un peso negativo, NaN o infinito LANZA, porque el 0 ya es '
+  'el mecanismo de exclusion y normalizar basura a 0 la volveria invisible. '
+  'Espejo exacto de prorratearCargo() en src/utils/prorrateoCompra.ts (mig 193).';
+
+-- Aritmética pura, sin datos adentro, pero no hay motivo para publicarla como
+-- endpoint de PostgREST para `anon`. Las RPCs de la 194 son la superficie.
+--
+-- `anon` va nombrado aparte y NO es redundante con PUBLIC —una concesión
+-- explícita del ALTER DEFAULT PRIVILEGES no se va revocando PUBLIC— pero es
+-- DEFENSIVO, no correctivo: si hoy aplica `postgres`, no saca nada. Depende del
+-- rol que aplique, y eso no lo decide este archivo.
+--
+-- Medido el 2026-08-19: sobre el schema `public` conviven DOS default privileges
+-- para funciones, y no dicen lo mismo. El de `postgres` ya NO le da EXECUTE a
+-- anon (se lo sacó la mig 188); el de `supabase_admin` SÍ se lo sigue dando. O
+-- sea que el REVOKE es redundante mientras aplique `postgres` y necesario apenas
+-- aplique otro rol —o si alguna vez se revierte la 188—, que es justo el momento
+-- en que nadie lo estaría mirando. Se queda.
+REVOKE ALL ON FUNCTION public.prorratear_cargo(numeric, jsonb) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.prorratear_cargo(numeric, jsonb) TO authenticated, service_role;
+
+-- ----------------------------------------------------------------------------
+-- 2 · costo_real_unitario gana un término ADITIVO para los cargos prorrateados
+--
+-- Hoy los tres llamadores pasan 0, así que **ningún costo se mueve**: esta
+-- sección es puro andamiaje. Los cargos de verdad entran en la task 9.
+--
+-- LA REGLA, porque no es obvia y ya se discutió una vez:
+-- **`tipo_factura` decide si se agregan IMPUESTOS encima, no si se ignoran
+-- COSTOS.** En ZZ lo pagado ya incluye IVA e impuestos internos —son impuestos
+-- de esa misma operación, ya adentro del precio— y por eso no se le suma nada de
+-- eso. Pero un flete que factura un transportista aparte, o unos pallets que se
+-- pagaron aparte, NO están adentro de ese precio: es plata que salió igual. Que
+-- la mercadería haya venido con factura o sin ella no cambia que el camión se
+-- pagó. Y mirado desde el dato: si alguien carga un cargo de flete sobre una
+-- compra ZZ está afirmando que es un costo adicional; si ya estuviera adentro
+-- del precio no lo cargaría. Descartarlo sería ignorar lo que el usuario dijo.
+-- Por eso el cargo entra en las DOS ramas, y el II sólo en una.
+--
+-- La rama ZZ ahora también redondea, cosa que antes no hacía porque devolvía el
+-- neto tal cual. Verificado contra las 109 líneas ZZ de prod: 0 se mueven —
+-- ninguna tiene bonificación, así que su neto es el costo_unitario numeric(12,2)
+-- y ya venía con 2 decimales. No es cosmético igual: `v_costo_real` no va sólo a
+-- la columna numeric(12,4), también entra al cálculo del costo promedio
+-- ponderado multiplicado por la cantidad, antes de que ninguna columna lo trunque
+-- (registrar_compra_completa línea 130, actualizar_compra_items línea 243). O sea
+-- que el round alinea ZZ con FC —que ya redondeaba— y hace que el CPP use el
+-- mismo número que queda guardado en la línea, en vez de uno más largo que nadie
+-- puede auditar después.
+--
+-- Se DROPEA la de 3 argumentos en vez de dejarla al lado de una de 4 con
+-- DEFAULT: dos sobrecargas con rangos de aridad superpuestos dan PGRST203 en
+-- runtime, invisible para tsc y para los tests (la trampa de la mig 176).
+-- Verificado antes de escribir esto: la función no tiene NINGUNA dependencia
+-- registrada —ni vistas, ni índices, ni CHECKs, ni defaults, ni triggers— y no
+-- la llama nadie por RPC desde el front, el bot ni las edge functions. Los
+-- únicos llamadores son los tres plpgsql de más abajo.
+--
+-- El DROP no protege de nada por sí solo: los cuerpos plpgsql son strings y
+-- Postgres no los valida al dropear, así que una RPC que quedara sin parchear
+-- no falla hasta que alguien la ejecuta en producción. Por eso el DROP y los
+-- tres parches van en la MISMA transacción, y por eso el ensayo registra una
+-- compra de punta a punta en vez de conformarse con que compile.
+-- ----------------------------------------------------------------------------
+DROP FUNCTION IF EXISTS public.costo_real_unitario(numeric, numeric, text);
+
+CREATE OR REPLACE FUNCTION public.costo_real_unitario(
+  p_costo_neto     numeric,
+  p_pct_ii         numeric,
+  p_tipo_factura   text,
+  p_cargo_unitario numeric
+) RETURNS numeric
+LANGUAGE sql
+IMMUTABLE
+PARALLEL SAFE     -- la vieja era UNSAFE (el default), y es aritmética pura
+AS $fn$
+  SELECT CASE
+    WHEN p_tipo_factura = 'ZZ' THEN round(p_costo_neto + COALESCE(p_cargo_unitario, 0), 4)
+    ELSE round(p_costo_neto * (1 + COALESCE(p_pct_ii, 0) / 100)
+               + COALESCE(p_cargo_unitario, 0), 4)
+  END;
+$fn$;
+
+COMMENT ON FUNCTION public.costo_real_unitario(numeric, numeric, text, numeric) IS
+  'Costo de reposicion por unidad: neto + impuesto interno + cargos prorrateados '
+  '(flete, pallets, separadores, bonificaciones). LA REGLA: tipo_factura decide '
+  'si se agregan IMPUESTOS encima, no si se ignoran COSTOS. En ZZ lo pagado ya '
+  'incluye IVA e II —son impuestos de esa operacion— asi que no se le suma nada '
+  'de eso; pero el flete que factura un tercero no esta adentro de ese precio y '
+  'SI suma. Por eso el cargo entra en las dos ramas y el II en una sola. '
+  'El 4o argumento llego con la mig 193 y hoy todos los llamadores pasan 0. '
+  'DECISION YA TOMADA, no re-litigar: el espejo calcularCostoReal() de '
+  'src/utils/calculations.ts se alinea con esta misma regla en la task 9.';
+
+-- Las dos mitades del REVOKE, por el mismo motivo defensivo que arriba.
+--
+-- La justificación vieja —"la de 3 argumentos está abierta a PUBLIC y a anon a
+-- la vez, recrearla es la oportunidad de cerrarla"— YA NO ES CIERTA, y conviene
+-- que quede dicho en vez de borrado: era verdad cuando se midió y dejó de serlo
+-- cuando las migs 188/189 se aplicaron con esta rama abierta. Hoy su ACL medido
+-- es `postgres=X/postgres authenticated=X/postgres service_role=X/postgres`, sin
+-- PUBLIC y sin anon. El REVOKE ya no cierra nada que esté abierto: evita que el
+-- CREATE de acá lo reabra según qué rol aplique la migración.
+REVOKE ALL ON FUNCTION public.costo_real_unitario(numeric, numeric, text, numeric) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.costo_real_unitario(numeric, numeric, text, numeric) TO authenticated, service_role;
+
+-- ----------------------------------------------------------------------------
+-- 2.1 · Helper de parcheo: reemplaza exigiendo que el ancla sea única
+--
+-- Mismo patrón que las migs 176/177/178. Los cuerpos se leen del CATÁLOGO VIVO
+-- con pg_get_functiondef y se les cambia sólo la llamada: `migrations/` no es
+-- 1:1 con prod, así que copiar el cuerpo del archivo más reciente puede revertir
+-- lógica viva en silencio. Si el ancla no aparece exactamente una vez, la
+-- migración FALLA en vez de aplicar un parche parcial.
+-- ----------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public._mig193_reemplazo_unico(
+  p_texto text, p_ancla text, p_nuevo text, p_donde text
+) RETURNS text LANGUAGE plpgsql IMMUTABLE AS $helper$
+DECLARE
+  v_veces integer;
+BEGIN
+  v_veces := (length(p_texto) - length(replace(p_texto, p_ancla, ''))) / length(p_ancla);
+  IF v_veces <> 1 THEN
+    RAISE EXCEPTION 'mig 193 · % : el ancla "%" aparece % veces (se esperaba 1). El cuerpo derivó del texto conocido; revisá el parche antes de aplicar.',
+      p_donde, left(p_ancla, 70), v_veces;
+  END IF;
+  RETURN replace(p_texto, p_ancla, p_nuevo);
+END;
+$helper$;
+
+-- ----------------------------------------------------------------------------
+-- 2.2 · Los llamadores pasan a la firma de 4 argumentos
+--
+-- Son TRES, no cuatro. `cambiar_proveedor_compra` NO llama a la función:
+-- clona la compra copiando la COLUMNA `ci.costo_real_unitario` de las líneas
+-- originales, que es justo lo que esa RPC promete (anula y clona sin tocar
+-- stock ni costos). Las dos menciones que tiene son a la columna, no a la
+-- función — verificado contando `costo_real_unitario(` con el paréntesis.
+--
+-- El marcador de idempotencia va en un comentario de BLOQUE y no de línea: un
+-- `--` pegado a la llamada se comería el `;` o el `),` que vienen después.
+-- ----------------------------------------------------------------------------
+DO $mig$
+DECLARE
+  v_def text;
+BEGIN
+  -- a) registrar_compra_completa · alta de una compra
+  v_def := pg_get_functiondef('public.registrar_compra_completa(bigint,character varying,character varying,date,numeric,numeric,numeric,numeric,character varying,text,uuid,jsonb,character varying,numeric,numeric,numeric,numeric)'::regprocedure);
+  IF position('mig 193' in v_def) = 0 THEN
+    EXECUTE public._mig193_reemplazo_unico(v_def,
+      $a$costo_real_unitario(v_costo_neto, v_impuestos_internos, v_tipo_factura)$a$,
+      $a$costo_real_unitario(v_costo_neto, v_impuestos_internos, v_tipo_factura, 0 /* mig 193: los cargos entran en la task 9 */)$a$,
+      'registrar_compra_completa');
+  END IF;
+
+  -- b) actualizar_compra_items · edición de una compra
+  v_def := pg_get_functiondef('public.actualizar_compra_items(bigint,jsonb,numeric,numeric,numeric,uuid,numeric,numeric,numeric,numeric,numeric)'::regprocedure);
+  IF position('mig 193' in v_def) = 0 THEN
+    EXECUTE public._mig193_reemplazo_unico(v_def,
+      $a$costo_real_unitario(v_costo_neto, v_impuestos_internos, v_compra.tipo_factura)$a$,
+      $a$costo_real_unitario(v_costo_neto, v_impuestos_internos, v_compra.tipo_factura, 0 /* mig 193: los cargos entran en la task 9 */)$a$,
+      'actualizar_compra_items');
+  END IF;
+
+  -- c) anular_compra_atomica · reconstruye el costo del producto con la compra
+  --    anterior. Acá la llamada es el 2º argumento de un COALESCE, no una
+  --    asignación: el ancla la agarra igual porque es la expresión de la llamada.
+  v_def := pg_get_functiondef('public.anular_compra_atomica(bigint,uuid)'::regprocedure);
+  IF position('mig 193' in v_def) = 0 THEN
+    EXECUTE public._mig193_reemplazo_unico(v_def,
+      $a$costo_real_unitario(v_neto, COALESCE(v_ult.ii_linea, p.impuestos_internos), v_ult.tipo_factura)$a$,
+      $a$costo_real_unitario(v_neto, COALESCE(v_ult.ii_linea, p.impuestos_internos), v_ult.tipo_factura, 0 /* mig 193: los cargos entran en la task 9 */)$a$,
+      'anular_compra_atomica');
+  END IF;
+END;
+$mig$;
+
+-- ----------------------------------------------------------------------------
+-- 2.3 · POST-condición: los tres cuerpos quedaron con la llamada nueva
+--
+-- La PRE-condición (el ancla tiene que aparecer exactamente una vez) es fuerte,
+-- pero el guard de idempotencia de arriba es `position('mig 193' in v_def) = 0`
+-- sobre TODO el functiondef. Si mañana cualquiera de esos tres cuerpos gana una
+-- mención no relacionada a "mig 193" —un comentario, otra migración que la
+-- nombre— el parche se saltea sin decir una palabra. Y como la firma de 3
+-- argumentos ya se dropeó en esta MISMA transacción, el cuerpo queda llamando a
+-- una función que no existe: no falla al aplicar, falla en producción la próxima
+-- vez que alguien registra o anula una compra. El archivo describía ese modo de
+-- falla más arriba y después no se defendía de él.
+--
+-- Se busca la MARCA COMPLETA y no el string 'mig 193': la marca sólo la puede
+-- haber escrito este parche, así que una mención casual no la satisface.
+-- ----------------------------------------------------------------------------
+DO $post$
+DECLARE
+  v_marca constant text := ', 0 /* mig 193: los cargos entran en la task 9 */)';
+  v_fn    text;
+  v_veces integer;
+  v_mal   text := '';
+BEGIN
+  FOREACH v_fn IN ARRAY ARRAY[
+    'public.registrar_compra_completa(bigint,character varying,character varying,date,numeric,numeric,numeric,numeric,character varying,text,uuid,jsonb,character varying,numeric,numeric,numeric,numeric)',
+    'public.actualizar_compra_items(bigint,jsonb,numeric,numeric,numeric,uuid,numeric,numeric,numeric,numeric,numeric)',
+    'public.anular_compra_atomica(bigint,uuid)']
+  LOOP
+    v_veces := (length(pg_get_functiondef(v_fn::regprocedure))
+                - length(replace(pg_get_functiondef(v_fn::regprocedure), v_marca, '')))
+               / length(v_marca);
+    IF v_veces <> 1 THEN
+      v_mal := v_mal || format('%s (%s marcas) ', split_part(v_fn, '(', 1), v_veces);
+    END IF;
+  END LOOP;
+  IF v_mal <> '' THEN
+    RAISE EXCEPTION 'mig 193 · el parche NO quedó aplicado en: %. Se esperaba exactamente 1 llamada marcada por función. La firma de 3 argumentos ya se dropeó en esta transaccion, asi que dejar pasar esto seria publicar RPCs de compras rotas.', v_mal
+      USING ERRCODE = '22023';
+  END IF;
+END;
+$post$;
+
+-- El helper es andamiaje de esta migración, no API: se va con ella. En prod no
+-- sobrevive ningún `_mig*`, así que la convención es dropearlos.
+DROP FUNCTION IF EXISTS public._mig193_reemplazo_unico(text, text, text, text);
+
+-- ----------------------------------------------------------------------------
+-- 3 · El motor de costos de una compra
+--
+-- Espejo de `calcularCostosCompra()` en src/utils/prorrateoCompra.ts. Recibe las
+-- líneas, los cargos y el impuesto interno DECLARADO por alícuota, y devuelve los
+-- unitarios de cada línea más los totales que cuadran contra el papel.
+--
+-- El contrato de entrada usa los nombres de columna de la mig 192
+-- (`condicion_iva`, `en_factura`, `prorratea_al_costo`, `afecta_base_ii`, `pesos`)
+-- porque la RPC de la task 9 va a armar estos jsonb leyendo esas tablas: un
+-- renombre en el medio sería una oportunidad de error sin ninguna ganancia.
+--
+-- TRES BASES SEPARADAS, y son distintas a propósito porque responden preguntas
+-- distintas. Es acá donde se equivoca cualquiera que traduzca esto de memoria:
+--
+--   · base_iva_factura → neto de la línea (SÓLO si es gravada) + cargos gravados
+--     que están EN FACTURA. Alimenta el IVA y el cuadre contra el papel. Filtra
+--     por `en_factura`.
+--   · base_costo       → neto + cargos GRAVADOS que PRORRATEAN AL COSTO. Filtra
+--     por `prorratea_al_costo`, que NO es el mismo filtro. El IVA de un flete de
+--     transportista inscripto es crédito fiscal: su neto entra al costo, su IVA
+--     no entra a ningún lado de esta factura.
+--   · base_ii          → neto + los cargos GRAVADOS con `afecta_base_ii`. El
+--     filtro por condición es deliberado, no un olvido: el flag existe para
+--     distinguir un descuento de precio (baja la base) de una bonificación
+--     comercial (no la baja), y las dos son siempre gravadas. Un cargo no gravado
+--     —pallets, separadores— no tiene por qué mover la base del impuesto interno.
+--     Mismo filtro en prorrateoCompra.ts; si cambiás uno, cambiá el otro.
+--
+-- Y los cargos NO gravados que prorratean NO entran a `base_costo`: van aparte en
+-- `cargos_al_costo` y se suman recién en `costo_real`. Meterlos en las dos los
+-- CONTARÍA DOS VECES. (Este error exacto estuvo escrito en un comentario del TS.)
+--
+-- El IVA sale de `base_iva_factura`, NUNCA de `base_costo`.
+--
+-- Sumar el neto de las líneas exentas o no gravadas a `base_iva_factura` la
+-- convierte en "neto de la factura" y deja de cuadrar contra el papel: por eso el
+-- CASE mira `es_gravada` y devuelve 0, no el neto.
+--
+-- Son DOS totales de no gravado y no uno: `no_gravado` son los cargos EN FACTURA
+-- (van a compras.no_gravado y al cuadre) y `cargos_al_costo` son los que
+-- PRORRATEAN. Un cargo que está en el papel pero no es costo del producto —el
+-- caso pallets— desaparece si se mezclan.
+--
+-- `cargos_al_costo` reconcilia contra Σ (cargos_unitarios × cantidad) SÓLO si
+-- toda línea tiene cantidad > 0 y todo peso apunta a una línea de `p_items`. Las
+-- dos excepciones son reales y ninguna se puede tapar acá. Con cantidad = 0 —que
+-- este mismo archivo declara legal— el unitario se fuerza a 0 y el cargo no
+-- vuelve a salir por ningún lado. Y un peso que apunta a un id que no está en
+-- `p_items` es peor: `prorratear_cargo` lo reparte igual, pero ese pedazo no
+-- matchea ninguna línea en `bases`, así que el cargo se EVAPORA del costo aunque
+-- siga contado en el total. Acá no hay con qué atajarlo, porque `p_items` puede
+-- ser legítimamente un subconjunto de la compra. LA RPC DE LA 192 TIENE QUE
+-- VALIDAR que todos los pesos de un cargo apunten a líneas reales de la compra:
+-- ése es el lugar correcto, no éste.
+--
+-- LA TASA DE II SE NORMALIZA CON round(tasa, 4) EN LAS DOS PUNTAS: al agrupar el
+-- denominador y al buscar el factor. Nada de tolerancia en una y clave exacta en
+-- la otra — una línea que entrara al denominador por tolerancia pero no matcheara
+-- exacto se llevaría factor 1 y el total dejaría de cuadrar. En compra_items ya
+-- conviven 4.1667 y 4.1700 (alguien tipeó 4,17), así que es un caso real. Que
+-- queden en buckets distintos ES LO CORRECTO: si la factura declara un solo
+-- bucket y hay una línea en 4,17, el cuadre tiene que avisar.
+--
+-- Una asimetría del TS que se replica a propósito, no por descuido: el
+-- DENOMINADOR del factor usa la tasa declarada YA REDONDEADA, mientras que el II
+-- de cada línea se calcula con la tasa CRUDA de la línea y sólo BUSCA el factor
+-- por el bucket redondeado. Con tasas de 4 decimales o menos —todas las reales—
+-- las dos coinciden; se replica igual para que el espejo sea espejo.
+--
+-- El factor se calcula ANTES de imputar el II a las líneas: por eso `factores`
+-- es una CTE aparte y `finales` la consulta.
+--
+-- cantidad = 0 ⇒ todos los unitarios en 0, no una división. Y los unitarios se
+-- derivan del total de la línea, nunca al revés.
+--
+-- POR QUÉ NO LLAMA A costo_real_unitario, que es la pregunta obvia: porque no hay
+-- forma honesta de hacerlo. (a) Esta función no tiene `tipo_factura` —el modelo
+-- de cargos vive en el mundo FC, donde la línea tiene condición frente al IVA—
+-- así que no habría qué pasarle al 3º argumento. (b) El término de II es
+-- estructuralmente distinto: acá es `base_ii × tasa × factor_de_ajuste`, y
+-- costo_real_unitario sólo sabe hacer `neto × tasa`; no puede expresar ni la base
+-- separada ni el factor. (c) La única llamada que compilaría sería con
+-- `p_pct_ii = 0`, y con la tasa en 0 las DOS ramas del CASE dan lo mismo: la
+-- regla de ZZ no se aplicaría sola, se saltearía. Una llamada que parece reuso y
+-- no lo es sería peor que no llamarla.
+-- Lo que SÍ se reusa —y es lo que importa— es `prorratear_cargo`: el reparto de
+-- cada cargo sale de una sola implementación, igual que en el TS.
+-- ----------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.calcular_costos_compra(
+  p_items        jsonb,
+  p_cargos       jsonb DEFAULT '[]'::jsonb,
+  p_ii_declarado jsonb DEFAULT '{}'::jsonb
+) RETURNS jsonb
+LANGUAGE plpgsql
+IMMUTABLE
+PARALLEL SAFE
+SET search_path TO 'public'
+AS $motor$
+DECLARE
+  v_id     text;
+  v_motivo text;
+  v_val    jsonb;
+  v_res    jsonb;
+BEGIN
+  IF p_items IS NULL OR jsonb_typeof(p_items) <> 'array' THEN
+    RAISE EXCEPTION 'calcular_costos_compra: p_items tiene que ser un array y llego %.',
+      COALESCE(jsonb_typeof(p_items), 'NULL') USING ERRCODE = '22023';
+  END IF;
+  -- Se NORMALIZA primero y se valida después. Whitelistear 'null' en el
+  -- validador y confiar en un COALESCE más abajo no alcanza: COALESCE sólo tapa
+  -- el NULL de SQL, y `COALESCE('null'::jsonb, '[]'::jsonb)` devuelve el escalar
+  -- JSON null, no el array vacío. El validador dejaba pasar ese caso y después
+  -- jsonb_array_elements moría con "cannot extract elements from a scalar", que
+  -- no nombra ni la función ni el argumento — justo lo que estos IF vienen a
+  -- evitar. Ausente ≡ JSON null ≡ vacío; cualquier otra forma es error.
+  IF p_cargos IS NULL OR jsonb_typeof(p_cargos) = 'null' THEN
+    p_cargos := '[]'::jsonb;
+  END IF;
+  IF jsonb_typeof(p_cargos) <> 'array' THEN
+    RAISE EXCEPTION 'calcular_costos_compra: p_cargos tiene que ser un array y llego %.',
+      jsonb_typeof(p_cargos) USING ERRCODE = '22023';
+  END IF;
+
+  IF p_ii_declarado IS NULL OR jsonb_typeof(p_ii_declarado) = 'null' THEN
+    p_ii_declarado := '{}'::jsonb;
+  END IF;
+  IF jsonb_typeof(p_ii_declarado) <> 'object' THEN
+    RAISE EXCEPTION 'calcular_costos_compra: p_ii_declarado tiene que ser un objeto {tasa: monto} y llego %.',
+      jsonb_typeof(p_ii_declarado) USING ERRCODE = '22023';
+  END IF;
+
+  -- Mismo contrato que el TS: la cantidad 0 es válida (una línea recién agregada),
+  -- la negativa y la no finita son corrupción. Sin esto la línea devolvía 0 en
+  -- cada unitario mientras el total sumaba el neto igual, y el dato corrupto
+  -- pasaba de largo. El CASE fuerza el orden de evaluación: sin él el planner
+  -- puede correr el cast antes del chequeo de tipo y reventar con otro mensaje.
+  -- El COALESCE sobre jsonb_typeof NO es decorativo: con la clave `cantidad`
+  -- AUSENTE, jsonb_typeof devuelve NULL de SQL, y `NULL <> 'number'` es NULL, no
+  -- true. Sin el COALESCE el CASE caía al ELSE, donde `NULL::numeric < 0` también
+  -- da NULL, la fila no entraba al WHERE y el guard NO disparaba — dejando pasar
+  -- exactamente el caso que viene a atajar. Y aguas abajo el daño es el peor de
+  -- todos: cantidad NULL ⇒ neto NULL ⇒ los unitarios caen al ELSE 0, y como sum()
+  -- saltea los NULL, la línea DESAPARECE de los totales sin un solo aviso.
+  -- El golden no lo ve porque siempre manda `cantidad`.
+  SELECT e->>'id', e->'cantidad' INTO v_id, v_val
+    FROM jsonb_array_elements(p_items) e
+   WHERE CASE WHEN COALESCE(jsonb_typeof(e->'cantidad'), 'ausente') <> 'number' THEN true
+              ELSE (e->>'cantidad')::numeric < 0 END
+   LIMIT 1;
+  IF FOUND THEN
+    RAISE EXCEPTION 'calcular_costos_compra: cantidad invalida en la linea % (%). Se espera un numero finito no negativo.',
+      COALESCE(v_id, '?'), COALESCE(v_val::text, 'null') USING ERRCODE = '22023';
+  END IF;
+
+  -- El id de la línea, con el mismo criterio que las claves de p_pesos y por el
+  -- mismo motivo. Sin esto una línea sin `id` salía con "id": null y sin UN SOLO
+  -- cargo —ningún peso matchea contra NULL— en silencio. Y la forma no canónica
+  -- importa todavía más acá: si '01' y '1' conviven, el guard de duplicados de
+  -- más abajo NO los ve, porque agrupa por el TEXTO de la clave, y las dos filas
+  -- terminan cobrando el mismo cargo.
+  SELECT COALESCE(e->>'id', '(ausente)'),
+         CASE WHEN e->>'id' IS NULL
+                THEN 'falta, y sin id la linea no recibe NINGUN cargo porque ningun peso matchea contra NULL'
+              WHEN e->>'id' !~ '^-?[0-9]+$' THEN 'no es un id de linea'
+              WHEN (e->>'id')::numeric NOT BETWEEN -9223372036854775808
+                                               AND  9223372036854775807
+                THEN 'se sale del rango de bigint'
+              ELSE 'no esta en forma canonica (como "01" o "-0"), y dos ids que castean al mismo bigint cuentan la linea dos veces'
+         END
+    INTO v_id, v_motivo
+    FROM jsonb_array_elements(p_items) e
+   WHERE CASE WHEN e->>'id' IS NULL THEN true
+              WHEN e->>'id' !~ '^-?[0-9]+$' THEN true
+              WHEN (e->>'id')::numeric NOT BETWEEN -9223372036854775808
+                                               AND  9223372036854775807 THEN true
+              ELSE e->>'id' <> ((e->>'id')::bigint)::text
+         END
+   LIMIT 1;
+  IF FOUND THEN
+    RAISE EXCEPTION 'calcular_costos_compra: el id de linea "%" %.', v_id, v_motivo
+      USING ERRCODE = '22023';
+  END IF;
+
+  -- Guarda que el TS NO tiene, y va igual: dos líneas con el mismo id hacen que
+  -- el reparto de un cargo se cuente una vez por cada una. Desde compra_items es
+  -- imposible (id es PK), desde un payload de RPC no. Duplicar plata en silencio
+  -- es peor que fallar; anotado para que el espejo TS lo copie en la task 9.
+  SELECT e->>'id' INTO v_id
+    FROM jsonb_array_elements(p_items) e
+   GROUP BY e->>'id' HAVING count(*) > 1
+   LIMIT 1;
+  IF FOUND THEN
+    RAISE EXCEPTION 'calcular_costos_compra: la linea % aparece mas de una vez.', v_id
+      USING ERRCODE = '22023';
+  END IF;
+
+  -- `condicion_iva` contra el dominio que ya define la 192. Un typo NO es
+  -- inocuo y no es teórico: medido, una línea de mil pesos con "gravada" en vez
+  -- de "gravado" devuelve neto_gravado 0, neto_exento 0, neto_no_gravado 0 e
+  -- iva 0 — la plata desaparece de los cuatro totales A LA VEZ y no hay un solo
+  -- error. El CASE de `es_gravada` y los dos de exento/no_gravado son
+  -- excluyentes, así que un valor que no es ninguno de los tres cae en el hueco.
+  -- Misma vara que el id duplicado: fallar antes que evaporar plata.
+  SELECT e->>'id', e->'condicion_iva' INTO v_id, v_val
+    FROM jsonb_array_elements(p_items) e
+   WHERE COALESCE(e->>'condicion_iva', 'gravado')
+         NOT IN ('gravado', 'exento', 'no_gravado')
+   LIMIT 1;
+  IF FOUND THEN
+    RAISE EXCEPTION 'calcular_costos_compra: condicion_iva invalida en la linea % (%). Se espera gravado, exento o no_gravado.',
+      COALESCE(v_id, '?'), COALESCE(v_val::text, 'null') USING ERRCODE = '22023';
+  END IF;
+
+  -- Lo mismo del lado del cargo, donde el hueco es distinto pero igual de mudo:
+  -- `gravado` sale de comparar contra 'gravado', así que cualquier typo cae en
+  -- la rama NO gravada y el cargo deja de sumar a la base de IVA sin avisar. Se
+  -- lo nombra por posición y concepto porque el cargo puede no tener id todavía
+  -- (viene de una grilla a medio llenar).
+  SELECT format('%s (%s)', c.ord, COALESCE(c.val->>'concepto', 'sin concepto')),
+         c.val->'condicion_iva'
+    INTO v_id, v_val
+    FROM jsonb_array_elements(p_cargos) WITH ORDINALITY AS c(val, ord)
+   WHERE COALESCE(c.val->>'condicion_iva', 'no_gravado')
+         NOT IN ('gravado', 'exento', 'no_gravado')
+   LIMIT 1;
+  IF FOUND THEN
+    RAISE EXCEPTION 'calcular_costos_compra: condicion_iva invalida en el cargo % (%). Se espera gravado, exento o no_gravado.',
+      v_id, COALESCE(v_val::text, 'null') USING ERRCODE = '22023';
+  END IF;
+
+  -- Las claves de p_ii_declarado son tasas. Sin esto '{"pallet":10}' tiraba un
+  -- 22P02 crudo desde el cast, asimétrico con todo el cuidado que se le puso a
+  -- `p_pesos` tres funciones más arriba.
+  SELECT d.key INTO v_id
+    FROM jsonb_each(p_ii_declarado) d
+   WHERE d.key !~ '^[0-9]+(\.[0-9]+)?$'
+   ORDER BY d.key
+   LIMIT 1;
+  IF v_id IS NOT NULL THEN
+    RAISE EXCEPTION 'calcular_costos_compra: la clave "%" de p_ii_declarado no es una tasa de impuesto interno.', v_id
+      USING ERRCODE = '22023';
+  END IF;
+
+  -- Y el MONTO declarado tiene que ser un número. Esto no es cosmético: con un
+  -- monto null, `factor_ajuste` REPORTABA null mientras `finales` APLICABA 1 por
+  -- su COALESCE(...,1). O sea que el número que va al cuadre contradecía al
+  -- cálculo que lo produjo, y encima el TS en ese caso da factor 0 y II 0. De
+  -- las tres respuestas posibles la única defendible es no aceptar la entrada:
+  -- un monto declarado que no es un número no es un cero, es un dato que falta.
+  SELECT d.key, d.value INTO v_id, v_val
+    FROM jsonb_each(p_ii_declarado) d
+   WHERE jsonb_typeof(d.value) <> 'number'
+   ORDER BY d.key
+   LIMIT 1;
+  IF FOUND THEN
+    RAISE EXCEPTION 'calcular_costos_compra: el monto declarado para la tasa % no es un numero (%).',
+      v_id, COALESCE(v_val::text, 'null') USING ERRCODE = '22023';
+  END IF;
+
+  -- Dos claves declaradas que colapsan al MISMO bucket de 4 decimales ('10' y
+  -- '10.0', o '4.1667' y '04.1667') hacían que el subselect escalar de `finales`
+  -- devolviera dos filas y Postgres tirara 'more than one row returned by a
+  -- subquery', que no nombra ni la función ni las claves culpables. Simétrico
+  -- con el guard de id duplicado, y con el mismo criterio: nombrar a los dos.
+  SELECT string_agg(d.key, '" y "' ORDER BY d.key) INTO v_id
+    FROM jsonb_each_text(p_ii_declarado) d
+   GROUP BY round((d.key)::numeric, 4)
+  HAVING count(*) > 1
+   LIMIT 1;
+  IF v_id IS NOT NULL THEN
+    RAISE EXCEPTION 'calcular_costos_compra: las tasas declaradas "%" caen en el mismo bucket de 4 decimales y se pisarian.', v_id
+      USING ERRCODE = '22023';
+  END IF;
+
+  WITH items AS (
+    SELECT (e->>'id')::bigint                                  AS id,
+           (e->>'cantidad')::numeric                           AS cantidad,
+           COALESCE((e->>'costo_unitario')::numeric, 0)        AS costo_unitario,
+           COALESCE((e->>'bonificacion')::numeric, 0)          AS bonificacion,
+           COALESCE((e->>'impuestos_internos')::numeric, 0)    AS ii_tasa,
+           COALESCE((e->>'porcentaje_iva')::numeric, 0)        AS pct_iva,
+           COALESCE(e->>'condicion_iva', 'gravado')            AS condicion_iva
+      FROM jsonb_array_elements(p_items) e
+  ),
+  cargos AS (
+    SELECT COALESCE((e->>'monto')::numeric, 0)                 AS monto,
+           COALESCE(e->>'condicion_iva', 'no_gravado') = 'gravado' AS gravado,
+           COALESCE((e->>'en_factura')::boolean, true)         AS en_factura,
+           COALESCE((e->>'prorratea_al_costo')::boolean, true) AS prorratea_al_costo,
+           COALESCE((e->>'afecta_base_ii')::boolean, false)    AS afecta_base_ii,
+           e->'pesos'                                          AS pesos
+      FROM jsonb_array_elements(p_cargos) e   -- ya normalizado arriba
+  ),
+  -- Una sola implementación del reparto, la misma que alimenta la vista previa.
+  repartos AS (
+    SELECT c.gravado, c.en_factura, c.prorratea_al_costo, c.afecta_base_ii,
+           r.item_id, r.monto
+      FROM cargos c
+      CROSS JOIN LATERAL prorratear_cargo(c.monto, c.pesos) r
+  ),
+  bases AS (
+    SELECT i.id, i.cantidad, i.ii_tasa, i.pct_iva, i.condicion_iva,
+           i.cantidad * i.costo_unitario * (1 - i.bonificacion / 100) AS neto,
+           (i.condicion_iva = 'gravado')                              AS es_gravada,
+           COALESCE((SELECT sum(r.monto) FROM repartos r
+                      WHERE r.item_id = i.id AND r.gravado AND r.en_factura), 0)
+             AS cargos_gravados_factura,
+           COALESCE((SELECT sum(r.monto) FROM repartos r
+                      WHERE r.item_id = i.id AND r.gravado AND r.prorratea_al_costo), 0)
+             AS cargos_gravados_costo,
+           COALESCE((SELECT sum(r.monto) FROM repartos r
+                      WHERE r.item_id = i.id AND r.gravado AND r.afecta_base_ii), 0)
+             AS cargos_base_ii,
+           COALESCE((SELECT sum(r.monto) FROM repartos r
+                      WHERE r.item_id = i.id AND NOT r.gravado AND r.en_factura), 0)
+             AS no_gravado_factura,
+           COALESCE((SELECT sum(r.monto) FROM repartos r
+                      WHERE r.item_id = i.id AND NOT r.gravado AND r.prorratea_al_costo), 0)
+             AS cargos_al_costo
+      FROM items i
+  ),
+  con_bases AS (
+    SELECT b.*,
+           CASE WHEN b.es_gravada THEN b.neto + b.cargos_gravados_factura ELSE 0 END
+             AS base_iva_factura,
+           b.neto + b.cargos_gravados_costo AS base_costo,
+           b.neto + b.cargos_base_ii        AS base_ii,
+           round(b.ii_tasa, 4)              AS bucket
+      FROM bases b
+  ),
+  factores AS (
+    SELECT round((d.key)::numeric, 4) AS tasa,
+           CASE WHEN x.calculado IS NULL OR x.calculado = 0 THEN 1
+                ELSE (d.value)::numeric / x.calculado END AS factor
+      FROM jsonb_each_text(p_ii_declarado) d   -- ya normalizado arriba
+      CROSS JOIN LATERAL (
+        SELECT sum(c.base_ii * round((d.key)::numeric, 4) / 100) AS calculado
+          FROM con_bases c
+         WHERE c.bucket = round((d.key)::numeric, 4)
+      ) x
+  ),
+  finales AS (
+    SELECT c.*,
+           c.base_ii * c.ii_tasa / 100
+             * COALESCE((SELECT f.factor FROM factores f WHERE f.tasa = c.bucket), 1) AS ii,
+           c.base_iva_factura * c.pct_iva / 100 AS iva
+      FROM con_bases c
+  )
+  SELECT jsonb_build_object(
+    'lineas', COALESCE((
+      SELECT jsonb_agg(jsonb_build_object(
+               'id',         f.id,
+               'base_iva',   CASE WHEN f.cantidad > 0 THEN f.base_iva_factura / f.cantidad ELSE 0 END,
+               'ii',         CASE WHEN f.cantidad > 0 THEN f.ii              / f.cantidad ELSE 0 END,
+               'cargos',     CASE WHEN f.cantidad > 0 THEN f.cargos_al_costo / f.cantidad ELSE 0 END,
+               'iva',        CASE WHEN f.cantidad > 0 THEN f.iva             / f.cantidad ELSE 0 END,
+               'costo_neto', CASE WHEN f.cantidad > 0 THEN f.neto            / f.cantidad ELSE 0 END,
+               'costo_real', CASE WHEN f.cantidad > 0
+                                  THEN (f.base_costo + f.ii + f.cargos_al_costo) / f.cantidad
+                                  ELSE 0 END
+             ) ORDER BY f.id) FROM finales f), '[]'::jsonb),
+    'totales', (SELECT jsonb_build_object(
+         'neto_gravado',       COALESCE(sum(CASE WHEN f.es_gravada THEN f.neto ELSE 0 END
+                                            + f.cargos_gravados_factura), 0),
+         'neto_exento',        COALESCE(sum(CASE WHEN f.condicion_iva = 'exento'     THEN f.neto ELSE 0 END), 0),
+         'neto_no_gravado',    COALESCE(sum(CASE WHEN f.condicion_iva = 'no_gravado' THEN f.neto ELSE 0 END), 0),
+         'iva',                COALESCE(sum(f.iva), 0),
+         'impuestos_internos', COALESCE(sum(f.ii), 0),
+         'no_gravado',         COALESCE(sum(f.no_gravado_factura), 0),
+         'cargos_al_costo',    COALESCE(sum(f.cargos_al_costo), 0)
+       ) FROM finales f),
+    -- trim_scale para que la clave sea '10' y no '10.0000': el espejo de JS usa
+    -- el número como clave y no arrastra ceros de relleno.
+    'factor_ajuste', COALESCE((
+      SELECT jsonb_object_agg(trim_scale(f.tasa)::text, f.factor) FROM factores f), '{}'::jsonb)
+  ) INTO v_res;
+
+  RETURN v_res;
+END;
+$motor$;
+
+COMMENT ON FUNCTION public.calcular_costos_compra(jsonb, jsonb, jsonb) IS
+  'Motor de costos de una compra: reparte los cargos, arma las tres bases '
+  '(base_iva_factura para el cuadre contra el papel, base_costo para el costo, '
+  'base_ii para el impuesto interno), ajusta el II al declarado por alicuota y '
+  'devuelve los unitarios por linea mas los totales. Espejo exacto de '
+  'calcularCostosCompra() en src/utils/prorrateoCompra.ts, verificado contra la '
+  'factura testigo A0005-00461415 campo por campo (mig 193). Los cargos NO '
+  'gravados que prorratean NO estan en base_costo: van en cargos_al_costo y se '
+  'suman una sola vez en costo_real.';
+
+REVOKE ALL ON FUNCTION public.calcular_costos_compra(jsonb, jsonb, jsonb) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.calcular_costos_compra(jsonb, jsonb, jsonb) TO authenticated, service_role;
+
+COMMIT;
+
+-- ----------------------------------------------------------------------------
+-- Rollback
+--
+--   -- 1 y 3 · no escriben nada: dropearlos es exacto.
+--   DROP FUNCTION IF EXISTS public.prorratear_cargo(numeric, jsonb);
+--   DROP FUNCTION IF EXISTS public.calcular_costos_compra(jsonb, jsonb, jsonb);
+--
+--   -- 2 · costo_real_unitario. NO alcanza con recrear la de 3 argumentos: hay
+--   --     que despatchar los tres llamadores en la MISMA transacción, o quedan
+--   --     llamando a una firma que ya no existe y la compra deja de registrarse.
+--   -- ⚠ EL DROP + CREATE HACE UNA FUNCIÓN NUEVA, que nace con los privilegios
+--   -- por defecto del rol que corra el rollback. Sin las dos últimas líneas de
+--   -- este bloque, seguir el recipe al pie DESHACE EN SILENCIO lo que hicieron
+--   -- las migs 188/189 —se midió que así queda un `=X/postgres`, o sea PUBLIC
+--   -- adentro— y pone en rojo el gate de permisos de CI. Un rollback no puede
+--   -- reabrir una superficie que otra migración cerró.
+--   --
+--   -- `PARALLEL SAFE` va explícito por lo mismo: sin repetirlo se pierde. Ojo
+--   -- que la de 3 argumentos ORIGINAL era PARALLEL UNSAFE (el default), así que
+--   -- esto no restaura el estado previo al 100%: es deliberado. Volver a marcar
+--   -- UNSAFE una función de aritmética pura sería restaurar una pesimización,
+--   -- no una garantía; lo que el rollback tiene que devolver es la FIRMA.
+--   BEGIN;
+--     DROP FUNCTION IF EXISTS public.costo_real_unitario(numeric, numeric, text, numeric);
+--     CREATE OR REPLACE FUNCTION public.costo_real_unitario(
+--       p_costo_neto numeric, p_pct_ii numeric, p_tipo_factura text
+--     ) RETURNS numeric LANGUAGE sql IMMUTABLE PARALLEL SAFE AS $r$
+--       SELECT CASE
+--         WHEN p_tipo_factura = 'ZZ' THEN p_costo_neto
+--         ELSE round(p_costo_neto * (1 + COALESCE(p_pct_ii, 0) / 100), 4)
+--       END;
+--     $r$;
+--     REVOKE ALL ON FUNCTION public.costo_real_unitario(numeric, numeric, text)
+--       FROM PUBLIC, anon;
+--     GRANT EXECUTE ON FUNCTION public.costo_real_unitario(numeric, numeric, text)
+--       TO authenticated, service_role;
+--     DO $r$
+--     DECLARE v_def text; v_fn text;
+--     BEGIN
+--       FOREACH v_fn IN ARRAY ARRAY[
+--         'public.registrar_compra_completa(bigint,character varying,character varying,date,numeric,numeric,numeric,numeric,character varying,text,uuid,jsonb,character varying,numeric,numeric,numeric,numeric)',
+--         'public.actualizar_compra_items(bigint,jsonb,numeric,numeric,numeric,uuid,numeric,numeric,numeric,numeric,numeric)',
+--         'public.anular_compra_atomica(bigint,uuid)']
+--       LOOP
+--         v_def := pg_get_functiondef(v_fn::regprocedure);
+--         EXECUTE replace(v_def,
+--           ', 0 /* mig 193: los cargos entran en la task 9 */)', ')');
+--       END LOOP;
+--     END $r$;
+--   COMMIT;
+--
+-- Exacto mientras el 4º argumento siga en 0 en todos lados: ningún costo se
+-- movió. Deja de serlo en cuanto la task 9 empiece a pasar cargos de verdad —
+-- ahí el rollback pasa a ser el de la 192, con recálculo de costos y CPP.
+-- ----------------------------------------------------------------------------
+
+-- ----------------------------------------------------------------------------
+-- Pendientes deliberados (revisados y postergados, no olvidados)
+--
+--   · Las SEIS subconsultas correlacionadas de `bases` colapsan en un solo
+--     `LEFT JOIN LATERAL` con seis `sum() FILTER (...)`. Es la misma cuenta con
+--     un barrido en vez de seis. No se hace acá porque cambia la forma del plan
+--     y este archivo ya se verificó campo por campo contra el golden; va con su
+--     propia comparación de 126 celdas.
+--   · `costo_real_unitario` no tiene `SET search_path`. Las otras dos de este
+--     archivo sí. Es LANGUAGE sql y no referencia nada por nombre no calificado,
+--     así que hoy no es explotable, pero la asimetría no tiene defensa.
+--   · `src/utils/prorrateoCompra.espejo.test.ts` — el test que corre los mismos
+--     casos contra las dos implementaciones y falla si divergen. El plan lo
+--     menciona y no existe: hoy el espejo lo sostiene un ensayo manual. Va
+--     aparte porque es TypeScript, no SQL.
+-- ----------------------------------------------------------------------------
+
+-- ----------------------------------------------------------------------------
+-- Verificación
+--
+--   -- Reparto proporcional, y el residuo en la linea de mayor peso:
+--   SELECT * FROM prorratear_cargo(100, '{"1":1,"2":1,"3":4}'::jsonb);
+--   -- 1 | 16.67
+--   -- 2 | 16.67
+--   -- 3 | 66.66     <- absorbe el residuo
+--
+--   -- La suma es el monto exacto, sobre el flete real de la factura testigo:
+--   SELECT sum(monto) FROM prorratear_cargo(1900000,
+--     '{"1":0.5,"2":0.5,"3":2,"4":0.5,"5":0.5,"6":1,"7":1,"8":2,"9":1,"10":2,
+--       "11":4,"12":1,"13":1,"14":2,"15":1,"16":1,"17":1,"18":1,"19":1,"20":1,"21":1}');
+--   -- 1900000.00   (y la linea 11 se lleva 292307.72, tres centavos sobre el proporcional)
+--
+--   -- El peso 0 excluye, el vector vacio no explota:
+--   SELECT * FROM prorratear_cargo(880, '{"1":0,"2":0,"3":1}');  -- 1|0  2|0  3|880.00
+--   SELECT count(*) FROM prorratear_cargo(100, '{}');            -- 0
+--
+--   -- Y la basura no pasa (las cuatro tienen que fallar). La segunda va con
+--   -- subselect porque un agregado no puede ir suelto en el FROM:
+--   SELECT * FROM prorratear_cargo(100, '{"1":1,"2":-1}');       -- peso negativo en la linea 2
+--   SELECT * FROM prorratear_cargo(100, (SELECT jsonb_object_agg('1','NaN'::numeric)));
+--                                                                -- peso no finito en la linea 1
+--   SELECT * FROM prorratear_cargo(NULL, '{"1":1}');             -- monto no finito
+--   SELECT * FROM prorratear_cargo(100, '{"pallet":1}');         -- la clave no es un id de linea
+--
+--   -- Y que anon NO quedó con EXECUTE (el ACL no puede nombrarlo):
+--   SELECT array_to_string(proacl, ' ') FROM pg_proc WHERE proname = 'prorratear_cargo';
+--   -- postgres=X/postgres authenticated=X/postgres service_role=X/postgres
+--
+--   -- 2 · UNA sola firma de costo_real_unitario, y con 4 argumentos. Si esto
+--   --     devuelve dos filas, PostgREST tira PGRST203 en runtime y no lo ve ni
+--   --     tsc ni los tests:
+--   SELECT proname, pronargs, array_to_string(proacl,' ')
+--     FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace
+--    WHERE n.nspname = 'public' AND proname = 'costo_real_unitario';
+--   -- costo_real_unitario | 4 | postgres=X/postgres authenticated=X/postgres service_role=X/postgres
+--
+--   -- Los tres llamadores parchados, y el cuarto que no había que tocar:
+--   SELECT proname,
+--          (position('mig 193' in prosrc) > 0)              AS parchado,
+--          (length(prosrc)-length(replace(prosrc,'costo_real_unitario(','')))
+--            / length('costo_real_unitario(')               AS llamadas
+--     FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace
+--    WHERE n.nspname = 'public'
+--      AND proname IN ('registrar_compra_completa','actualizar_compra_items',
+--                      'anular_compra_atomica','cambiar_proveedor_compra');
+--   -- actualizar_compra_items   | t | 1
+--   -- anular_compra_atomica     | t | 1
+--   -- cambiar_proveedor_compra  | f | 0   <- no la llama: copia la columna
+--   -- registrar_compra_completa | t | 1
+--
+--   -- La regla de ZZ, en dos renglones: el II no suma, el cargo sí.
+--   SELECT costo_real_unitario(1000, 8.6956, 'ZZ', 0)   AS zz_sin_cargo,   -- 1000.0000
+--          costo_real_unitario(1000, 8.6956, 'ZZ', 50)  AS zz_con_cargo,   -- 1050.0000
+--          costo_real_unitario(1000, 8.6956, 'FC', 0)   AS fc_sin_cargo,   -- 1086.9560
+--          costo_real_unitario(1000, 8.6956, 'FC', 50)  AS fc_con_cargo;   -- 1136.9560
+--
+--   -- Que el round nuevo de la rama ZZ no mueva ninguna línea existente
+--   -- (0 = ninguna; hoy ninguna ZZ tiene bonificación, así que su neto ya venía
+--   -- con 2 decimales):
+--   SELECT count(*) FILTER (
+--            WHERE ci.costo_unitario * (1 - COALESCE(ci.bonificacion,0)/100)
+--               <> round(ci.costo_unitario * (1 - COALESCE(ci.bonificacion,0)/100), 4))
+--     FROM compra_items ci JOIN compras c ON c.id = ci.compra_id
+--    WHERE c.tipo_factura = 'ZZ';                              -- 0 sobre 109 líneas
+--
+--   -- Y que el andamiaje no quedó vivo:
+--   SELECT count(*) FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace
+--    WHERE n.nspname = 'public' AND proname LIKE '\_mig193%';   -- 0
+--
+--   -- 3 · el motor de costos, sobre un caso mínimo: una línea gravada de 10 x 100
+--   --     con un flete no gravado de 500 que prorratea al costo.
+--   SELECT jsonb_pretty(calcular_costos_compra(
+--     '[{"id":1,"cantidad":10,"costo_unitario":100,"bonificacion":0,
+--        "impuestos_internos":0,"porcentaje_iva":21,"condicion_iva":"gravado"}]',
+--     '[{"id":1,"monto":500,"condicion_iva":"no_gravado","en_factura":true,
+--        "prorratea_al_costo":true,"afecta_base_ii":false,"pesos":{"1":1}}]',
+--     '{}'));
+--   -- lineas[0]: base_iva 100 · iva 21 · cargos 50 · costo_neto 100 · costo_real 150
+--   -- El cargo NO gravado entra al costo pero NO a la base de IVA: el IVA es 21
+--   -- (21% de 100), no 31,50. Y costo_real lo cuenta UNA sola vez.
+--
+--   -- El caso pallets, que separa los dos totales de no gravado: en el papel
+--   -- pero no es costo del producto.
+--   SELECT calcular_costos_compra(
+--     '[{"id":1,"cantidad":10,"costo_unitario":100,"porcentaje_iva":21,"condicion_iva":"gravado"}]',
+--     '[{"id":1,"monto":500,"condicion_iva":"no_gravado","en_factura":true,
+--        "prorratea_al_costo":false,"pesos":{"1":1}}]')->'totales';
+--   -- no_gravado 500 (cuadra contra el papel) · cargos_al_costo 0 (no reconcilia
+--   -- contra ningún costo). Si se mezclaran, este cargo desaparecería.
+--
+--   -- Y que 4,17 y 4,1667 caen en buckets distintos: la línea tipeada a mano NO
+--   -- se ajusta, y eso es el detector avisando, no un falso positivo.
+--   SELECT calcular_costos_compra(
+--     '[{"id":1,"cantidad":10,"costo_unitario":100,"impuestos_internos":4.1667,"porcentaje_iva":21},
+--       {"id":2,"cantidad":10,"costo_unitario":100,"impuestos_internos":4.17,"porcentaje_iva":21}]',
+--     '[]', '{"4.1667": 50}')->'factor_ajuste';
+--   -- {"4.1667": 1.199990400076799385604915}  <- sólo el bucket declarado; el 4.17 no
+--   -- aparece. El valor va COMPLETO a propósito: decía "1.2000..." y no es un
+--   -- 1,2 truncado, es 1,19999… — la elipsis redondeaba para arriba y escondía
+--   -- que el factor NO es 1,2. En un archivo cuyo punto es que el factor da 1,
+--   -- una elipsis que miente en el cuarto decimal no es un detalle.
+--
+--   -- ── Los guards, que tienen que fallar los seis ────────────────────────────
+--   -- Cero a la izquierda: '01' y '1' son la MISMA línea y cobrarían dos veces.
+--   SELECT * FROM prorratear_cargo(100, '{"1":1,"01":1}');
+--   -- la clave "01" no esta en forma canonica...
+--   SELECT * FROM prorratear_cargo(100, '{"999999999999999999999":1}');
+--   -- la clave "999999999999999999999" se sale del rango de bigint
+--
+--   -- condicion_iva con un typo: mil pesos que se evaporaban sin un error.
+--   SELECT calcular_costos_compra(
+--     '[{"id":1,"cantidad":10,"costo_unitario":100,"condicion_iva":"gravada"}]');
+--   -- condicion_iva invalida en la linea 1 ("gravada")
+--
+--   -- Monto declarado nulo: reportaba factor null y aplicaba 1.
+--   SELECT calcular_costos_compra(
+--     '[{"id":1,"cantidad":10,"costo_unitario":100,"impuestos_internos":10}]',
+--     '[]', '{"10": null}');
+--   -- el monto declarado para la tasa 10 no es un numero (null)
+--
+--   -- Dos claves que colapsan al mismo bucket: antes era "more than one row
+--   -- returned by a subquery", que no nombraba a ninguna de las dos.
+--   SELECT calcular_costos_compra(
+--     '[{"id":1,"cantidad":10,"costo_unitario":100,"impuestos_internos":10}]',
+--     '[]', '{"10":50,"10.0":60}');
+--   -- las tasas declaradas "10" y "10.0" caen en el mismo bucket de 4 decimales
+--
+--   -- Y una clave de tasa que no es una tasa: antes, un 22P02 crudo.
+--   SELECT calcular_costos_compra('[]', '[]', '{"pallet":10}');
+--   -- la clave "pallet" de p_ii_declarado no es una tasa de impuesto interno
+-- ----------------------------------------------------------------------------

--- a/migrations/194_compra_cargos_rpcs.sql
+++ b/migrations/194_compra_cargos_rpcs.sql
@@ -1,0 +1,1712 @@
+-- ============================================================================
+-- 194 · Compras: las RPCs aprenden a recibir cargos y el II declarado
+-- ============================================================================
+-- Ver docs/plans/2026-08-18-cargos-y-cuadre-de-compras.md
+--
+-- La 192 creó las tablas, la 193 el motor de cálculo. Acá se enchufa ese motor
+-- a las dos RPCs que la app usa de verdad:
+--
+--   · registrar_compra_completa  — gana `p_cargos jsonb DEFAULT '[]'` (task 9)
+--   · actualizar_compra_items    — gana `p_cargos jsonb DEFAULT NULL` (task 10)
+--   · las dos                    — ganan `p_ii_declarado jsonb DEFAULT '{}'`
+--
+-- EL II DECLARADO POR ALÍCUOTA ES LA MITAD QUE FALTABA. El motor de la 193 sabe
+-- ajustar el impuesto interno calculado al declarado —`factor_ajuste`— pero las
+-- RPCs sólo recibían el II TOTAL del header (`p_impuestos_internos`), no su
+-- apertura `{tasa: monto}`, que es lo único que ese ajuste sabe leer. Sin este
+-- parámetro el factor se calculaba en la vista previa del navegador y se tiraba
+-- a la basura al guardar. La factura testigo hoy se corrige a mano con 1,0496.
+--
+-- Y por eso el motor ya NO corre sólo cuando hay cargos: corre cuando hay cargos
+-- **o** cuando hay II declarado (`v_usar_motor`). El ajuste del II es
+-- independiente de los cargos — una factura sin un solo cargo puede igual
+-- declarar un II que no cuadra con el calculado.
+--
+-- CUANDO EL TOTAL Y LA APERTURA SE CONTRADICEN no se pisa ninguno de los dos: se
+-- avisa en `warning_ii_declarado` y listo. `p_impuestos_internos` es lo que va a
+-- `compras.impuestos_internos`, al cuadre contra `p_total` y a la posición
+-- fiscal; `p_ii_declarado` sólo alimenta el factor. Sobrescribir el header con la
+-- suma de la apertura movería la posición fiscal sin que nadie lo pidiera, y
+-- fallar bloquearía una carga por una diferencia que puede ser legítima. La RPC
+-- no tiene cómo saber cuál de los dos está bien. Mismo umbral de 1 peso que el
+-- cuadre del total. Se avisa también si una tasa declarada no la usa ninguna
+-- línea: su factor es un no-op y ese importe no se refleja en ningún costo.
+--
+-- LOS PESOS VIENEN POR ÍNDICE DE `p_items`, BASE 0. Y no es un capricho: cuando
+-- el cliente arma el payload los `compra_items` todavía no existen, así que no
+-- hay ids que mandar. El índice es lo único que el cliente puede nombrar.
+--
+-- POR QUÉ EL MOTOR CORRE ANTES DEL LOOP Y NO DESPUÉS DE INSERTAR LAS LÍNEAS.
+-- La lectura obvia es "primero insertá las líneas, así tenés los ids, y recién
+-- ahí calculá". Pero el cálculo no necesita ids REALES: necesita identificadores,
+-- y los índices sirven igual —`calcular_costos_compra` es aritmética pura sobre
+-- las claves que le des—. Hacerlo después obligaría a RE-DERIVAR el costo
+-- promedio ponderado, porque el loop ya lo calculó con el costo sin cargos: una
+-- segunda copia de la recurrencia del CPP, con su encadenamiento por producto
+-- repetido, sus `stock_anterior` y su rama de "compra vieja". Duplicar esa lógica
+-- es exactamente la clase de cosa que después diverge en silencio. Corriendo el
+-- motor ANTES, el loop calcula el CPP con el costo real definitivo y no hay
+-- ninguna lógica duplicada. Lo único que sí necesita los ids reales es
+-- PERSISTIR `compra_cargo_repartos`, y eso va después del loop, que es cuando
+-- existen.
+--
+-- FORWARD-ONLY, y es el criterio de éxito: sin `p_cargos` y sin
+-- `p_ii_declarado`, `v_usar_motor` queda en false y **no se ejecuta una sola
+-- línea nueva** en el camino del costo — se sigue llamando a
+-- `costo_real_unitario(...)` igual que antes. Verificado registrando y editando
+-- la misma compra contra la base con y sin la migración: mismo
+-- `costo_real_unitario`, mismo `costo_neto_unitario` y mismo costo promedio
+-- ponderado al último decimal.
+--
+-- LA REGLA DE ZZ, que ya está decidida y no se re-litiga: `tipo_factura` decide
+-- si se agregan IMPUESTOS encima, no si se ignoran COSTOS. ZZ es el 47,9% de las
+-- compras, así que conviene decir POR DÓNDE pasa y no dejarlo inferir del
+-- resultado: **`calcular_costos_compra` no conoce `tipo_factura`**, y su
+-- `costo_real` es `(base_costo + ii + cargos_al_costo) / cantidad`, sin una sola
+-- rama por tipo. Lo que hace que ZZ se comporte distinto es que la RPC le pasa
+-- **la tasa de II de cada línea en 0** —el mismo CASE que ya usaba el loop para
+-- guardar la fila— y entonces `ii = base_ii × tasa × factor` da 0 cualquiera sea
+-- la base y cualquiera sea el factor. El cargo, en cambio, viaja en `base_costo`
+-- (si es gravado) o en `cargos_al_costo` (si no lo es), y ninguno de los dos mira
+-- la tasa: por eso suma igual. O sea que la regla NO está implementada con un IF
+-- adentro del motor sino **poniendo la tasa en 0 en el borde**. Medido: una ZZ de
+-- 4 × 1000 con flete de 400 y la línea declarando 8,6956 de II da `costo_real`
+-- 1100, no 1186,96. Y `p_ii_declarado` se descarta en ZZ por el mismo motivo,
+-- aunque no haría falta: contra una tasa 0 el factor es irrelevante.
+--
+-- SOBRECARGAS: las dos funciones cambian de firma, y `CREATE OR REPLACE` con un
+-- parámetro nuevo NO reemplaza —crea una segunda—. Las viejas se DROPEAN en esta
+-- misma transacción. Dos sobrecargas con rangos de aridad superpuestos dan
+-- PGRST203 en runtime, invisible para tsc y para los tests; ya nos mordió en la
+-- mig 176 y la post-condición de abajo lo verifica.
+--
+-- Los cuerpos se leen del CATÁLOGO VIVO con `pg_get_functiondef` y se parchean
+-- por ancla única, igual que la 193: `migrations/` no es 1:1 con prod y copiar un
+-- cuerpo del repo puede revertir lógica viva sin decir nada.
+--
+-- ⚠ DEPENDE DE LA 191. Los parches anclan en la marca que dejó la 193
+-- (`, 0 /* mig 193: los cargos entran en la task 9 */)`). Si la 193 no está
+-- aplicada, esta migración falla al aplicar en vez de dejar algo a medias.
+--
+-- ----------------------------------------------------------------------------
+-- CINCO COSAS QUE ALGUIEN VA A QUERER "ARREGLAR", Y NO HAY QUE
+-- ----------------------------------------------------------------------------
+--
+-- 1 · EL 4º ARGUMENTO DE `costo_real_unitario` SE QUEDA EN 0. La 193 lo introdujo
+--     diciendo "los cargos entran en la task 9" y la task 9 NO lo usa, a
+--     propósito. **Un cargo GRAVADO que prorratea al costo viaja adentro de
+--     `base_costo`, no adentro de `cargos`**, así que pasarle el `cargos` del
+--     motor como 4º argumento perdería la mitad gravada en silencio. Y el término
+--     de II es estructuralmente distinto: el motor hace `base_ii × tasa × factor`
+--     y esa función sólo sabe hacer `neto × tasa` — no puede expresar ni la base
+--     separada ni el factor de ajuste. Por eso la rama CON cargos usa el
+--     `costo_real` del motor y `costo_real_unitario` sobrevive sólo en la rama
+--     SIN cargos, que es justamente lo que sostiene el forward-only. La promesa
+--     de la 193 queda acotada acá: los tres call sites siguen pasando 0.
+--
+-- 2 · `cargos_al_costo` NO PUEDE RECONCILIAR EXACTO contra Σ (`cargos_unitarios`
+--     × cantidad), ni con los tres guards de abajo puestos. `cargos_unitarios` es
+--     `numeric(12,4)` y el cargo se divide por la cantidad: 500 sobre 3 unidades
+--     da 166,6667 × 3 = 500,0001 al reconstruir. La 193 enumera dos excepciones
+--     (cantidad 0 y peso fuera de rango) y las dos están cerradas acá, pero el
+--     redondeo es estructural y no se cierra. Por eso **el check COMPRA-A3 lleva
+--     tolerancia —un centavo por línea más el redondeo del unitario—, no
+--     igualdad.** Lo mismo ya pasa hoy con `costo_real_unitario`.
+--     (Y se llama A3 y no A2 porque **A2 ya existía**: `compras.subtotal =
+--     SUM(compra_items.subtotal)`, en rojo con 5 legacy. Medido, no supuesto.)
+--
+-- 3 · UN CARGO `en_factura` NO LLEGA SOLO A `compras.no_gravado`. Los pallets
+--     están en el papel y suman al cuadre, pero esta RPC no toca el header: el
+--     cliente tiene que incluirlos en `p_no_gravado`. Si no lo hace salta el
+--     warning blando de descuadre, que es lo correcto. Va en el trabajo de front.
+--
+-- 4 · LOS `RAISE` DE ACÁ NO ABORTAN LA TRANSACCIÓN DEL LLAMADOR. Las dos RPCs
+--     terminan en `EXCEPTION WHEN OTHERS THEN RETURN jsonb_build_object(...)`,
+--     así que una validación que falla vuelve como `{"success": false, "error":
+--     "..."}` con HTTP 200 y el bloque plpgsql revierte todo lo que la RPC había
+--     escrito — nada queda a medias. Pero la transacción EXTERNA no se aborta.
+--     Hoy da igual porque el front no las llama adentro de una transacción más
+--     grande; si algún día lo hiciera, hay que mirar el `success` y no confiar en
+--     que la excepción se propague sola.
+--
+-- 5 · SON DOS LOS GUARDS DE LA EDICIÓN, NO UNO, y el segundo no es opcional.
+--     `p_ii_declarado` mueve el costo guardado igual que los cargos, así que se
+--     PERSISTE en `compras.ii_declarado` (mig 192) y `actualizar_compra_items`
+--     rechaza la edición que no lo reenvía sobre una compra que lo tiene. Sin eso
+--     el ajuste se revertía SOLO en la primera edición de un cliente viejo, y es
+--     peor que la pérdida de los cargos en un aspecto: los cargos se reconstruyen
+--     desde `compra_cargos`, un factor revertido no deja ningún rastro.
+--     Los dos guards son independientes porque las dos entradas lo son: una
+--     compra puede tener apertura sin un solo cargo, y de hecho ése es el caso
+--     normal. Una apertura vacía se persiste como NULL y no como `{}`, para que
+--     el guard no rechace a un cliente viejo por una compra sin ajuste ninguno.
+--
+-- ----------------------------------------------------------------------------
+-- ⚠ LO QUE ESTA MIGRACIÓN NO CIERRA: `cambiar_proveedor_compra`
+-- ----------------------------------------------------------------------------
+-- Medido sobre el catálogo vivo, no inferido: esa RPC anula y CLONA la compra, y
+-- las dos copias van con lista de columnas EXPLÍCITA. Con esta tanda aplicada, el
+-- clon queda así:
+--   · `compras.ii_declarado`        NO se copia  → la apertura desaparece;
+--   · `compra_items.cargos_unitarios` NO se copia → cae al DEFAULT 0;
+--   · `compra_cargos` y `compra_cargo_repartos` NO se clonan (cuelgan de compra_id);
+--   · `costo_real_unitario` SÍ se copia, con los cargos y el factor ya adentro.
+-- O sea que después de un cambio de proveedor queda exactamente el estado que el
+-- rollback de la 192 describe como el peor: costos que incluyen cargos sin
+-- ningún registro de su origen. Y el comentario de esa RPC —"clonar items
+-- verbatim (incluye snapshots fiscales)"— pasa a ser falso.
+-- NO se parchea acá a propósito: es una tercera RPC, clonar los cargos exige
+-- remapear ids (cargo nuevo → línea nueva) y eso pide su propio ensayo. Hoy no
+-- hay una sola compra con cargos, así que la ventana está abierta; hay que
+-- cerrarla antes de que el front empiece a cargarlos.
+-- ============================================================================
+
+BEGIN;
+
+-- ----------------------------------------------------------------------------
+-- 0 · Helper de parcheo: reemplaza exigiendo que el ancla sea única
+--
+-- Mismo patrón que las migs 176/177/178/191. Si el ancla no aparece exactamente
+-- una vez, la migración FALLA en vez de aplicar un parche parcial.
+-- ----------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public._mig192_reemplazo_unico(
+  p_texto text, p_ancla text, p_nuevo text, p_donde text
+) RETURNS text LANGUAGE plpgsql IMMUTABLE AS $helper$
+DECLARE
+  v_veces integer;
+BEGIN
+  v_veces := (length(p_texto) - length(replace(p_texto, p_ancla, ''))) / length(p_ancla);
+  IF v_veces <> 1 THEN
+    RAISE EXCEPTION 'mig 194 · % : el ancla "%" aparece % veces (se esperaba 1). El cuerpo derivó del texto conocido; revisá el parche antes de aplicar.',
+      p_donde, left(p_ancla, 90), v_veces;
+  END IF;
+  RETURN replace(p_texto, p_ancla, p_nuevo);
+END;
+$helper$;
+
+-- ----------------------------------------------------------------------------
+-- 1 · TASK 9 · registrar_compra_completa acepta cargos y el II declarado
+--
+-- Cinco parches sobre el cuerpo vivo:
+--   a) la firma gana `p_cargos jsonb DEFAULT '[]'::jsonb` AL FINAL. Con DEFAULT
+--      y siendo el único agregado, un cliente viejo sigue andando tal cual.
+--   b) las variables nuevas.
+--   c) el bloque de validación + motor, justo antes del loop.
+--   d) el costo real de la línea sale del motor cuando hay cargos.
+--   e) la línea guarda `cargos_unitarios` y devuelve su id, para poder mapear
+--      índice → compra_item_id al persistir los repartos después del loop.
+-- ----------------------------------------------------------------------------
+DO $mig$
+DECLARE
+  v_vieja constant text := 'public.registrar_compra_completa(bigint,character varying,character varying,date,numeric,numeric,numeric,numeric,character varying,text,uuid,jsonb,character varying,numeric,numeric,numeric,numeric)';
+  v_nueva constant text := 'public.registrar_compra_completa(bigint,character varying,character varying,date,numeric,numeric,numeric,numeric,character varying,text,uuid,jsonb,character varying,numeric,numeric,numeric,numeric,jsonb,jsonb)';
+  v_def   text;
+BEGIN
+  -- Idempotencia por FIRMA y no por marca en el cuerpo: es lo único que no puede
+  -- dar un falso positivo si mañana alguien menciona "mig 194" en un comentario.
+  IF to_regprocedure(v_nueva) IS NOT NULL AND to_regprocedure(v_vieja) IS NULL THEN
+    RETURN;
+  END IF;
+  IF to_regprocedure(v_vieja) IS NULL THEN
+    RAISE EXCEPTION 'mig 194 · no existe % en el catálogo. Esta migración parchea el cuerpo vivo: revisá qué le pasó antes de seguir.', v_vieja;
+  END IF;
+
+  v_def := pg_get_functiondef(to_regprocedure(v_vieja));
+
+  IF position(', 0 /* mig 193: los cargos entran en la task 9 */)' in v_def) = 0 THEN
+    RAISE EXCEPTION 'mig 194 · registrar_compra_completa no tiene la marca de la mig 193. Aplicá la 193 antes que ésta.'
+      USING ERRCODE = '22023';
+  END IF;
+
+  -- a) firma -----------------------------------------------------------------
+  v_def := public._mig192_reemplazo_unico(v_def,
+    $a$p_no_gravado numeric DEFAULT 0)$a$,
+    $a$p_no_gravado numeric DEFAULT 0, p_cargos jsonb DEFAULT '[]'::jsonb, p_ii_declarado jsonb DEFAULT '{}'::jsonb)$a$,
+    'registrar_compra_completa · firma');
+
+  -- b) variables -------------------------------------------------------------
+  v_def := public._mig192_reemplazo_unico(v_def,
+    $a$  v_user_role           TEXT;
+BEGIN$a$,
+    $a$  v_user_role           TEXT;
+  -- mig 194 · cargos prorrateados
+  v_cargos              JSONB;       -- p_cargos normalizado: ES la version que se valida, se calcula y se guarda
+  v_hay_cargos          BOOLEAN := false;
+  v_items_motor         JSONB;
+  v_costos              JSONB;
+  v_costos_por_linea    JSONB;       -- {indice: {costo_real, cargos, ...}}
+  v_linea_costos        JSONB;
+  v_idx                 INTEGER := 0;
+  v_n_items             INTEGER;
+  v_item_id             BIGINT;
+  v_item_ids            BIGINT[] := '{}';
+  v_cargo_unit          NUMERIC := 0;
+  v_concepto            TEXT;
+  v_clave               TEXT;
+  v_motivo              TEXT;
+  v_ii_declarado        JSONB;       -- p_ii_declarado normalizado ({} en ZZ)
+  v_ii_suma             NUMERIC;
+  v_usar_motor          BOOLEAN := false;
+  v_warning_ii          TEXT;
+BEGIN$a$,
+    'registrar_compra_completa · declaraciones');
+
+  -- c) validación + motor, antes del loop ------------------------------------
+  v_def := public._mig192_reemplazo_unico(v_def,
+    $a$  FOR v_item IN SELECT * FROM jsonb_array_elements(p_items) LOOP
+    SELECT id, stock, costo_promedio INTO v_producto$a$,
+    $a$  /* ── mig 194 · cargos prorrateados ──────────────────────────────────────
+       Los pesos vienen por INDICE de p_items (base 0): cuando el cliente arma el
+       payload los compra_items todavia no existen. El motor corre ACA, sobre esos
+       indices, para que el loop calcule el costo promedio ponderado con el costo
+       real definitivo y no haya que re-derivar el CPP. Los repartos se persisten
+       despues del loop, ya con los ids reales.                                  */
+  IF p_cargos IS NULL OR jsonb_typeof(p_cargos) = 'null' THEN
+    p_cargos := '[]'::JSONB;
+  END IF;
+  IF jsonb_typeof(p_cargos) <> 'array' THEN
+    RAISE EXCEPTION 'p_cargos tiene que ser un array de cargos y llego %.', jsonb_typeof(p_cargos);
+  END IF;
+  v_hay_cargos := jsonb_array_length(p_cargos) > 0;
+
+  /* El impuesto interno DECLARADO por alicuota: {tasa: monto}. Es lo unico que
+     el ajuste del motor sabe leer, y sin este parametro el factor se calculaba en
+     la vista previa del navegador y se tiraba a la basura al guardar.
+     En ZZ se descarta, con el mismo criterio que el IVA, las dos percepciones y
+     el II total del header: en ZZ no se agregan impuestos encima. Aunque no se
+     descartara daria igual —la tasa de cada linea tambien va en 0 y el II del
+     motor es base_ii x tasa x factor—, pero descartarlo lo deja dicho. */
+  v_ii_declarado := CASE
+    WHEN v_es_zz THEN '{}'::JSONB
+    WHEN p_ii_declarado IS NULL OR jsonb_typeof(p_ii_declarado) = 'null' THEN '{}'::JSONB
+    ELSE p_ii_declarado END;
+  IF jsonb_typeof(v_ii_declarado) <> 'object' THEN
+    RAISE EXCEPTION 'p_ii_declarado tiene que ser un objeto {tasa: monto} y llego %.', jsonb_typeof(v_ii_declarado);
+  END IF;
+
+  -- Un declarado NEGATIVO daria un factor negativo y le daria vuelta el signo al
+  -- II de TODAS las lineas de ese bucket. El 0 si es legal y significa algo: "esa
+  -- alicuota no tributa en esta factura". El resto de la forma —que las claves
+  -- sean tasas, que los montos sean numeros, que dos claves no colapsen al mismo
+  -- bucket de 4 decimales— lo valida el motor con sus propios mensajes.
+  SELECT d.key INTO v_clave
+    FROM jsonb_each(v_ii_declarado) d
+   WHERE jsonb_typeof(d.value) = 'number' AND (d.value #>> '{}')::NUMERIC < 0
+   ORDER BY d.key
+   LIMIT 1;
+  IF FOUND THEN
+    RAISE EXCEPTION 'El impuesto interno declarado para la tasa % es negativo. El 0 es valido (esa alicuota no tributa en esta factura); un negativo le daria vuelta el signo al II de todas las lineas de esa tasa.', v_clave;
+  END IF;
+
+  v_n_items := CASE WHEN jsonb_typeof(p_items) = 'array' THEN jsonb_array_length(p_items) ELSE 0 END;
+
+  -- El motor corre si hay cargos O si hay II declarado. El ajuste del II es
+  -- INDEPENDIENTE de los cargos: una factura sin un solo cargo puede igual
+  -- declarar un II que no cuadra con el calculado — es el caso de la factura
+  -- testigo, que hoy se ajusta a mano con 1,0496. Sin ninguno de los dos no se
+  -- ejecuta una sola linea nueva del camino del costo: ahi esta el forward-only.
+  v_usar_motor := (v_hay_cargos OR v_ii_declarado <> '{}'::JSONB) AND v_n_items > 0;
+
+  IF v_hay_cargos THEN
+    IF v_n_items = 0 THEN
+      RAISE EXCEPTION 'Hay cargos para prorratear pero la compra no tiene lineas.';
+    END IF;
+
+    -- Forma del cargo. El CASE fuerza el orden de evaluacion en los dos lados.
+    SELECT (c.ord - 1)::TEXT,
+           CASE WHEN jsonb_typeof(c.val) <> 'object'                    THEN 'no es un objeto'
+                WHEN COALESCE(btrim(c.val->>'concepto'), '') = ''        THEN 'no tiene concepto'
+                ELSE 'no tiene un monto numerico' END
+      INTO v_clave, v_motivo
+      FROM jsonb_array_elements(p_cargos) WITH ORDINALITY AS c(val, ord)
+     WHERE CASE WHEN jsonb_typeof(c.val) <> 'object'               THEN true
+                WHEN COALESCE(btrim(c.val->>'concepto'), '') = ''  THEN true
+                ELSE jsonb_typeof(c.val->'monto') <> 'number' END
+     ORDER BY c.ord
+     LIMIT 1;
+    IF FOUND THEN
+      RAISE EXCEPTION 'El cargo en la posicion % %.', v_clave, v_motivo;
+    END IF;
+
+    -- Dominios y banderas. Sin esto un typo en condicion_iva cae en la rama NO
+    -- gravada y el cargo deja de sumar a la base de IVA sin avisar, y una bandera
+    -- que no es booleana revienta en el cast sin nombrar el cargo. La clave
+    -- ausente y el null explicito valen lo mismo: el default.
+    SELECT COALESCE(c.val->>'concepto', '?'),
+           CASE WHEN COALESCE(c.val->>'condicion_iva', 'no_gravado') NOT IN ('gravado','exento','no_gravado')
+                  THEN 'tiene una condicion_iva invalida (se espera gravado, exento o no_gravado)'
+                WHEN COALESCE(c.val->>'base_prorrateo', 'unidades') NOT IN ('monto','cantidad','unidades')
+                  THEN 'tiene una base_prorrateo invalida (se espera monto, cantidad o unidades)'
+                ELSE 'tiene en_factura, prorratea_al_costo o afecta_base_ii con un valor que no es booleano'
+           END
+      INTO v_concepto, v_motivo
+      FROM jsonb_array_elements(p_cargos) AS c(val)
+     WHERE COALESCE(c.val->>'condicion_iva', 'no_gravado') NOT IN ('gravado','exento','no_gravado')
+        OR COALESCE(c.val->>'base_prorrateo', 'unidades') NOT IN ('monto','cantidad','unidades')
+        OR jsonb_typeof(COALESCE(NULLIF(c.val->'en_factura',         'null'::JSONB), 'true'::JSONB))  <> 'boolean'
+        OR jsonb_typeof(COALESCE(NULLIF(c.val->'prorratea_al_costo', 'null'::JSONB), 'true'::JSONB))  <> 'boolean'
+        OR jsonb_typeof(COALESCE(NULLIF(c.val->'afecta_base_ii',     'null'::JSONB), 'false'::JSONB)) <> 'boolean'
+     LIMIT 1;
+    IF FOUND THEN
+      RAISE EXCEPTION 'El cargo "%" %.', v_concepto, v_motivo;
+    END IF;
+
+    -- El vector de pesos tiene que ser un objeto {indice: peso}. Ausente ≡ {}.
+    SELECT COALESCE(c.val->>'concepto', '?') INTO v_concepto
+      FROM jsonb_array_elements(p_cargos) AS c(val)
+     WHERE jsonb_typeof(COALESCE(NULLIF(c.val->'pesos', 'null'::JSONB), '{}'::JSONB)) <> 'object'
+     LIMIT 1;
+    IF FOUND THEN
+      RAISE EXCEPTION 'El cargo "%" tiene un vector de pesos que no es un objeto {indice: peso}.', v_concepto;
+    END IF;
+
+    -- Claves y valores del vector. Las claves NO se castean a int hasta estar
+    -- validadas: se comparan como numeric, que no desborda. La forma canonica
+    -- importa tanto como el rango — "01" y "1" son claves jsonb distintas que
+    -- apuntan a la MISMA linea y le cobrarian el cargo dos veces.
+    -- Y el fuera de rango es el agujero que la 193 dejo anotado para esta RPC:
+    -- prorratear_cargo reparte igual, pero ese pedazo no matchea ninguna linea y
+    -- el cargo se EVAPORA del costo aunque siga contado en el total.
+    SELECT COALESCE(c.val->>'concepto', '?'), w.key,
+           CASE WHEN w.key !~ '^[0-9]+$'                THEN 'no es un indice de linea'
+                WHEN w.key <> (w.key::NUMERIC)::TEXT    THEN format('no esta en forma canonica (sobra un cero a la izquierda: es la misma linea que "%s"), y dos claves que apuntan a la misma linea le cobrarian el cargo dos veces', (w.key::NUMERIC)::TEXT)
+                WHEN w.key::NUMERIC > v_n_items - 1     THEN format('apunta a una linea que no existe: la compra tiene %s (indices 0 a %s)', v_n_items, v_n_items - 1)
+                ELSE 'tiene un peso que no es un numero finito no negativo; el 0 excluye la linea' END
+      INTO v_concepto, v_clave, v_motivo
+      FROM jsonb_array_elements(p_cargos) AS c(val)
+      CROSS JOIN LATERAL jsonb_each(COALESCE(NULLIF(c.val->'pesos', 'null'::JSONB), '{}'::JSONB)) AS w
+     WHERE CASE WHEN w.key !~ '^[0-9]+$'              THEN true
+                WHEN w.key <> (w.key::NUMERIC)::TEXT  THEN true
+                WHEN w.key::NUMERIC > v_n_items - 1   THEN true
+                WHEN jsonb_typeof(w.value) <> 'number' THEN true
+                ELSE (w.value #>> '{}')::NUMERIC < 0 END
+     LIMIT 1;
+    IF FOUND THEN
+      RAISE EXCEPTION 'El cargo "%": la clave "%" %.', v_concepto, v_clave, v_motivo;
+    END IF;
+
+    -- Normalizacion canonica. El monto va a numeric(12,2) y el peso a
+    -- numeric(16,4): si el motor calculara con los crudos, el costo persistido no
+    -- se podria reproducir despues leyendo las filas. Una sola version para
+    -- validar, calcular y guardar.
+    SELECT jsonb_agg(jsonb_build_object(
+             'orden',              (c.ord - 1)::INT,
+             'concepto',           btrim(c.val->>'concepto'),
+             'monto',              round((c.val->>'monto')::NUMERIC, 2),
+             'condicion_iva',      COALESCE(c.val->>'condicion_iva', 'no_gravado'),
+             'en_factura',         COALESCE((c.val->>'en_factura')::BOOLEAN, true),
+             'prorratea_al_costo', COALESCE((c.val->>'prorratea_al_costo')::BOOLEAN, true),
+             'afecta_base_ii',     COALESCE((c.val->>'afecta_base_ii')::BOOLEAN, false),
+             'base_prorrateo',     COALESCE(c.val->>'base_prorrateo', 'unidades'),
+             'pesos',              COALESCE((SELECT jsonb_object_agg(w.key, round((w.value #>> '{}')::NUMERIC, 4))
+                                               FROM jsonb_each(COALESCE(NULLIF(c.val->'pesos', 'null'::JSONB), '{}'::JSONB)) w),
+                                            '{}'::JSONB)
+           ) ORDER BY c.ord)
+      INTO v_cargos
+      FROM jsonb_array_elements(p_cargos) WITH ORDINALITY AS c(val, ord);
+
+    -- Un cargo que prorratea y no apunta a ninguna linea se evaporaria del costo
+    -- SIN UN SOLO AVISO: el motor trata el vector vacio como legal (es el estado
+    -- de una grilla a medio llenar) y devuelve 0 filas.
+    SELECT c.val->>'concepto' INTO v_concepto
+      FROM jsonb_array_elements(v_cargos) AS c(val)
+     WHERE (c.val->>'prorratea_al_costo')::BOOLEAN
+       AND COALESCE((SELECT sum((w.value #>> '{}')::NUMERIC) FROM jsonb_each(c.val->'pesos') w), 0) = 0
+     ORDER BY (c.val->>'orden')::INT
+     LIMIT 1;
+    IF FOUND THEN
+      RAISE EXCEPTION 'El cargo "%" no tiene ninguna línea asignada', v_concepto;
+    END IF;
+
+    -- Y un peso positivo sobre una linea de cantidad 0 lo evapora igual, por la
+    -- otra puerta: el unitario se derivaria dividiendo por cero, asi que el motor
+    -- lo fuerza a 0 y ese pedazo del cargo no vuelve a salir por ningun lado. Es
+    -- la segunda excepcion que la 193 declara y no puede atajar.
+    SELECT c.val->>'concepto', w.key INTO v_concepto, v_clave
+      FROM jsonb_array_elements(v_cargos) AS c(val)
+      CROSS JOIN LATERAL jsonb_each(c.val->'pesos') AS w
+     WHERE (c.val->>'prorratea_al_costo')::BOOLEAN
+       AND (w.value #>> '{}')::NUMERIC > 0
+       AND (p_items->(w.key::INT)->>'cantidad')::NUMERIC = 0
+     ORDER BY (c.val->>'orden')::INT, w.key
+     LIMIT 1;
+    IF FOUND THEN
+      RAISE EXCEPTION 'El cargo "%" reparte sobre la linea % que tiene cantidad 0: ese importe no se podria expresar en el costo unitario y se perderia.',
+        v_concepto, v_clave;
+    END IF;
+
+  ELSE
+    v_cargos := '[]'::JSONB;
+  END IF;
+
+  IF v_usar_motor THEN
+    /* EL MOTOR, SOBRE LOS INDICES.
+
+       ACA PASA LA REGLA DE ZZ, y conviene leerla de un renglon porque
+       `calcular_costos_compra` NO conoce `tipo_factura`: su costo_real es
+       (base_costo + ii + cargos_al_costo) / cantidad, sin una sola rama por tipo
+       de factura. Lo que hace que ZZ se comporte distinto es que la tasa de II de
+       cada linea le llega en 0 —el CASE de aca abajo la fuerza, igual que el loop
+       de mas abajo— y entonces `ii = base_ii x tasa x factor` da 0 cualquiera sea
+       la base y cualquiera sea el factor. El cargo, en cambio, viaja en
+       base_costo (si es gravado) o en cargos_al_costo (si no lo es), y ninguno de
+       los dos mira la tasa: por eso suma igual.
+       O sea que la regla —el tipo de factura decide si se agregan IMPUESTOS
+       encima, no si se ignoran COSTOS— no esta implementada con un IF adentro del
+       motor sino poniendo la tasa en 0 EN EL BORDE. Medido: una ZZ de 4 x 1000
+       con flete de 400 y la linea declarando 8,6956 de II da costo_real 1100, no
+       1186,96.
+
+       `porcentaje_iva` y `condicion_iva` se normalizan con el mismo CASE del loop
+       aunque no muevan el costo_real: asi el motor ve exactamente la fila que se
+       va a guardar y no una version paralela.                                    */
+    SELECT jsonb_agg(jsonb_build_object(
+             'id',                 (e.ord - 1)::INT,
+             'cantidad',           (e.val->>'cantidad')::INT,
+             'costo_unitario',     COALESCE((e.val->>'costo_unitario')::NUMERIC, 0),
+             'bonificacion',       COALESCE((e.val->>'bonificacion')::NUMERIC, 0),
+             'impuestos_internos', CASE WHEN v_es_zz THEN 0
+                                        ELSE COALESCE((e.val->>'impuestos_internos')::NUMERIC, 0) END,
+             'porcentaje_iva',     CASE WHEN v_es_zz OR n.cond <> 'gravado' THEN 0
+                                        ELSE COALESCE((e.val->>'porcentaje_iva')::NUMERIC, 21) END,
+             'condicion_iva',      n.cond
+           ) ORDER BY e.ord)
+      INTO v_items_motor
+      FROM jsonb_array_elements(p_items) WITH ORDINALITY AS e(val, ord)
+      CROSS JOIN LATERAL (SELECT CASE
+             WHEN v_es_zz THEN 'gravado'
+             WHEN COALESCE(e.val->>'condicion_iva', 'gravado') IN ('exento','no_gravado')
+               THEN e.val->>'condicion_iva'
+             ELSE 'gravado' END AS cond) n;
+
+    v_costos := calcular_costos_compra(v_items_motor, v_cargos, v_ii_declarado);
+
+    SELECT jsonb_object_agg(l->>'id', l) INTO v_costos_por_linea
+      FROM jsonb_array_elements(v_costos->'lineas') l;
+
+    /* AVISO BLANDO, no bloqueante: el II TOTAL del header y la APERTURA por
+       alicuota son dos numeros que el usuario tipea por separado y pueden
+       contradecirse. NO se pisa ninguno de los dos, y es deliberado.
+       `p_impuestos_internos` es lo que va a compras.impuestos_internos, al cuadre
+       contra p_total y a la posicion fiscal; `p_ii_declarado` solo alimenta el
+       factor de ajuste. Sobrescribir el header con la suma de la apertura
+       cambiaria la posicion fiscal sin que nadie lo haya pedido, y fallar
+       bloquearia una carga por una diferencia que puede ser legitima. La RPC no
+       tiene como saber cual de los dos esta bien: avisa y deja los dos como
+       llegaron. Mismo umbral de 1 peso que el cuadre del total.                  */
+    IF v_ii_declarado <> '{}'::JSONB THEN
+      SELECT COALESCE(sum((d.value #>> '{}')::NUMERIC), 0) INTO v_ii_suma
+        FROM jsonb_each(v_ii_declarado) d;
+      IF abs(v_ii_suma - COALESCE(v_ii_hdr, 0)) > 1 THEN
+        v_warning_ii := format('El impuesto interno declarado por alicuota suma %s y el total informado es %s.',
+                               round(v_ii_suma, 2), round(COALESCE(v_ii_hdr, 0), 2));
+      END IF;
+
+      -- Y una tasa declarada que no usa NINGUNA linea: su factor es un no-op
+      -- (calculado = 0 => factor 1) y ese importe no se refleja en ningun costo.
+      SELECT string_agg(d.key, ', ' ORDER BY d.key) INTO v_clave
+        FROM jsonb_each(v_ii_declarado) d
+       WHERE NOT EXISTS (
+         SELECT 1 FROM jsonb_array_elements(v_items_motor) l
+          WHERE round((l->>'impuestos_internos')::NUMERIC, 4) = round((d.key)::NUMERIC, 4));
+      IF v_clave IS NOT NULL THEN
+        v_warning_ii := COALESCE(v_warning_ii || ' ', '')
+          || format('Las tasas declaradas %s no las usa ninguna linea: ese importe no se refleja en ningun costo.', v_clave);
+      END IF;
+    END IF;
+  END IF;
+
+  FOR v_item IN SELECT * FROM jsonb_array_elements(p_items) LOOP
+    v_idx := v_idx + 1;   /* mig 194 · posicion en p_items, base 1 */
+
+    SELECT id, stock, costo_promedio INTO v_producto$a$,
+    'registrar_compra_completa · bloque de cargos');
+
+  -- d) el costo real de la línea sale del motor cuando hay cargos -------------
+  --
+  -- No se llama a costo_real_unitario() en esa rama, y no es un olvido: esa
+  -- función sabe hacer `neto × tasa`, y el motor calcula el II sobre `base_ii`
+  -- (que puede incluir cargos) por un factor de ajuste. Además el cargo GRAVADO
+  -- que prorratea al costo viaja adentro de `base_costo`, no de `cargos`: pasarle
+  -- sólo `cargos` como 4º argumento perdería esa mitad. La 193 documenta la misma
+  -- asimetría del lado del motor. Sin cargos la expresión es la de siempre, con
+  -- la marca de la 193 intacta: ahí está el forward-only.
+  v_def := public._mig192_reemplazo_unico(v_def,
+    $a$v_costo_real    := costo_real_unitario(v_costo_neto, v_impuestos_internos, v_tipo_factura, 0 /* mig 193: los cargos entran en la task 9 */);$a$,
+    $a$v_cargo_unit    := 0;   /* mig 194 */
+    IF v_usar_motor AND v_cantidad > 0 THEN
+      v_linea_costos := v_costos_por_linea -> (v_idx - 1)::TEXT;
+      IF v_linea_costos IS NULL THEN
+        RAISE EXCEPTION 'mig 194 · el motor no devolvio la linea %.', v_idx - 1;
+      END IF;
+      v_cargo_unit  := round((v_linea_costos->>'cargos')::NUMERIC, 4);
+      v_costo_real  := round((v_linea_costos->>'costo_real')::NUMERIC, 4);
+    ELSE
+      v_costo_real  := costo_real_unitario(v_costo_neto, v_impuestos_internos, v_tipo_factura, 0 /* mig 193: los cargos entran en la task 9 */);
+    END IF;$a$,
+    'registrar_compra_completa · costo real de la linea');
+
+  -- e) la línea guarda cargos_unitarios y devuelve su id ----------------------
+  v_def := public._mig192_reemplazo_unico(v_def,
+    $a$      porcentaje_iva, impuestos_internos, costo_neto_unitario, costo_real_unitario,
+      condicion_iva
+    ) VALUES ($a$,
+    $a$      porcentaje_iva, impuestos_internos, costo_neto_unitario, costo_real_unitario,
+      condicion_iva, cargos_unitarios /* mig 194 */
+    ) VALUES ($a$,
+    'registrar_compra_completa · columnas de compra_items');
+
+  -- `costo_neto_unitario` se deja como estaba: `round(v_costo_neto, 4)` YA ES el
+  -- `costo_neto` que devuelve el motor (neto/cantidad = costo_unitario ×
+  -- (1 − bonif/100)), redondeado al mismo lugar. Pisarlo con el del motor sería
+  -- escribir el mismo número por otro camino y mover una coma del camino sin
+  -- cargos para nada.
+  v_def := public._mig192_reemplazo_unico(v_def,
+    $a$      round(v_costo_neto, 4),
+      v_costo_real,
+      v_condicion_iva
+    );$a$,
+    $a$      round(v_costo_neto, 4),
+      v_costo_real,
+      v_condicion_iva,
+      v_cargo_unit /* mig 194 */
+    )
+    RETURNING id INTO v_item_id;
+
+    /* mig 194 · el indice del payload (base 0) es v_item_ids[indice + 1]. Es el
+       unico puente entre los pesos que mando el cliente y los ids reales. */
+    v_item_ids := v_item_ids || v_item_id;$a$,
+    'registrar_compra_completa · valores de compra_items');
+
+  -- f) el aviso del II declarado, en la respuesta ----------------------------
+  v_def := public._mig192_reemplazo_unico(v_def,
+    $a$    'warning_descuadre', v_warning
+  );$a$,
+    $a$    'warning_descuadre', v_warning,
+    'warning_ii_declarado', v_warning_ii /* mig 194 */
+  );$a$,
+    'registrar_compra_completa · aviso del II declarado');
+
+  -- g) persistir los cargos y sus repartos, ya con los ids reales -------------
+  v_def := public._mig192_reemplazo_unico(v_def,
+    $a$  -- Control blando de cuadre contra el total informado$a$,
+    $a$  /* mig 194 · la apertura del II, para que el ajuste no se evapore. Se guarda
+     el jsonb NORMALIZADO, o sea vacio en ZZ. Una apertura vacia se persiste como
+     NULL y no como {}: no ajusta nada, asi que no hay nada que proteger, y
+     guardar {} haria que el guard de la edicion rechazara a un cliente viejo por
+     una compra que no tiene ajuste ninguno.                                     */
+  IF v_ii_declarado <> '{}'::JSONB THEN
+    UPDATE compras SET ii_declarado = v_ii_declarado
+     WHERE id = v_compra_id AND sucursal_id = v_sucursal;
+  END IF;
+
+  /* mig 194 · los cargos, ya con los ids reales de las lineas.
+     Los montos y los pesos son los NORMALIZADOS (v_cargos): las mismas cifras con
+     las que se calculo el costo de arriba, para que la compra se pueda recalcular
+     desde sus filas y de lo mismo.                                             */
+  IF v_hay_cargos THEN
+    INSERT INTO compra_cargos (
+      compra_id, sucursal_id, usuario_id, orden, concepto, monto,
+      condicion_iva, en_factura, prorratea_al_costo, afecta_base_ii, base_prorrateo
+    )
+    SELECT v_compra_id, v_sucursal, p_usuario_id,
+           (c.val->>'orden')::INT,
+           c.val->>'concepto',
+           (c.val->>'monto')::NUMERIC,
+           c.val->>'condicion_iva',
+           (c.val->>'en_factura')::BOOLEAN,
+           (c.val->>'prorratea_al_costo')::BOOLEAN,
+           (c.val->>'afecta_base_ii')::BOOLEAN,
+           c.val->>'base_prorrateo'
+      FROM jsonb_array_elements(v_cargos) AS c(val);
+
+    INSERT INTO compra_cargo_repartos (cargo_id, compra_item_id, compra_id, peso)
+    SELECT cc.id, v_item_ids[(w.key)::INT + 1], v_compra_id, (w.value #>> '{}')::NUMERIC
+      FROM compra_cargos cc
+      JOIN jsonb_array_elements(v_cargos) AS c(val) ON (c.val->>'orden')::INT = cc.orden
+      CROSS JOIN LATERAL jsonb_each(c.val->'pesos') AS w
+     WHERE cc.compra_id = v_compra_id;
+  END IF;
+
+  -- Control blando de cuadre contra el total informado$a$,
+    'registrar_compra_completa · persistencia de los cargos');
+
+  EXECUTE v_def;
+  EXECUTE format('DROP FUNCTION %s', v_vieja);
+END;
+$mig$;
+
+-- `pg_get_functiondef` no trae los GRANT: la función nueva nace con los
+-- privilegios por defecto del rol que aplique. Sin esto, crear la de 18
+-- argumentos puede reabrir a PUBLIC lo que cerraron las migs 188/189 y poner en
+-- rojo el gate de permisos de CI. `anon` va nombrado aparte porque una concesión
+-- explícita del ALTER DEFAULT PRIVILEGES no se va revocando PUBLIC.
+REVOKE ALL ON FUNCTION public.registrar_compra_completa(bigint,character varying,character varying,date,numeric,numeric,numeric,numeric,character varying,text,uuid,jsonb,character varying,numeric,numeric,numeric,numeric,jsonb,jsonb) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.registrar_compra_completa(bigint,character varying,character varying,date,numeric,numeric,numeric,numeric,character varying,text,uuid,jsonb,character varying,numeric,numeric,numeric,numeric,jsonb,jsonb) TO authenticated, service_role;
+
+COMMENT ON FUNCTION public.registrar_compra_completa(bigint,character varying,character varying,date,numeric,numeric,numeric,numeric,character varying,text,uuid,jsonb,character varying,numeric,numeric,numeric,numeric,jsonb,jsonb) IS
+  'Alta de una compra con stock, costos y costo promedio ponderado. Desde la mig '
+  '194 acepta p_cargos: [{concepto, monto, condicion_iva, en_factura, '
+  'prorratea_al_costo, afecta_base_ii, base_prorrateo, pesos}]. LOS PESOS VAN POR '
+  'INDICE DE p_items, BASE 0 — cuando el cliente arma el payload los compra_items '
+  'todavia no existen. Un peso fuera de rango, un cargo que prorratea sin ninguna '
+  'linea asignada o un peso positivo sobre una linea de cantidad 0 FALLAN: las '
+  'tres formas hacen que el cargo se evapore del costo sin aviso. '
+  'Acepta ademas p_ii_declarado {tasa: monto}, la apertura POR ALICUOTA del '
+  'impuesto interno de la factura: es lo unico que el factor de ajuste del motor '
+  'sabe leer, y sin el ese factor se calculaba en el navegador y se tiraba al '
+  'guardar. Si la apertura no suma lo mismo que p_impuestos_internos NO se pisa '
+  'ninguno de los dos: se avisa en warning_ii_declarado. La apertura se PERSISTE '
+  'en compras.ii_declarado (NULL si viene vacia) para que el ajuste no se pueda '
+  'revertir solo en una edicion posterior. Sin p_cargos y sin p_ii_declarado el '
+  'costo es identico al de antes de la 194 (forward-only).';
+
+-- ----------------------------------------------------------------------------
+-- 2 · TASK 10 · editar una compra ya no le borra los cargos en silencio
+--
+-- `actualizar_compra_items` hace DELETE + INSERT de las líneas en CADA edición, y
+-- por el CASCADE de la 192 eso se lleva puesto TODOS los `compra_cargo_repartos`
+-- de la compra. Los `compra_cargos` sobreviven, porque cuelgan de `compra_id`.
+-- El estado que queda es el peor posible: cargos vivos con el vector de pesos
+-- vacío ⇒ `sum(peso) = 0` ⇒ el flete deja de repartirse. Y el motor trata el
+-- vector vacío como LEGAL —es el estado de una grilla a medio llenar—, así que no
+-- grita: los cargos se caen del costo sin un solo aviso y la compra pierde el 16%
+-- hasta que el check de integridad se ponga rojo.
+--
+-- POR QUÉ EL DEFAULT ES NULL Y NO '[]', que es lo contrario de la task 9: acá hay
+-- que poder distinguir "no me mandaron cargos" (un cliente viejo) de "me mandaron
+-- una lista vacía" (el usuario borró todos los cargos). Con '[]' las dos cosas
+-- serían la misma y la primera borraría los cargos de la segunda manera.
+--
+-- El JSON `null` cuenta como NO provisto, igual que la ausencia. Un cliente que
+-- manda `p_cargos: undefined` omite la clave; uno que manda `null` casi siempre
+-- es un cliente que no conoce la feature, no alguien pidiendo borrar. La lista
+-- vacía explícita es `[]` y no se confunde con ninguna de las dos.
+--
+-- Y el guard no es paranoia: este proyecto estuvo SEIS MESES sin service worker,
+-- así que una pestaña abierta puede estar corriendo un bundle viejo por tiempo
+-- indefinido. Un chunk viejo del PWA editando una compra con cargos es un
+-- escenario real, no teórico.
+-- ----------------------------------------------------------------------------
+DO $mig$
+DECLARE
+  v_vieja constant text := 'public.actualizar_compra_items(bigint,jsonb,numeric,numeric,numeric,uuid,numeric,numeric,numeric,numeric,numeric)';
+  v_nueva constant text := 'public.actualizar_compra_items(bigint,jsonb,numeric,numeric,numeric,uuid,numeric,numeric,numeric,numeric,numeric,jsonb,jsonb)';
+  v_def   text;
+BEGIN
+  IF to_regprocedure(v_nueva) IS NOT NULL AND to_regprocedure(v_vieja) IS NULL THEN
+    RETURN;
+  END IF;
+  IF to_regprocedure(v_vieja) IS NULL THEN
+    RAISE EXCEPTION 'mig 194 · no existe % en el catálogo. Esta migración parchea el cuerpo vivo: revisá qué le pasó antes de seguir.', v_vieja;
+  END IF;
+
+  v_def := pg_get_functiondef(to_regprocedure(v_vieja));
+
+  IF position(', 0 /* mig 193: los cargos entran en la task 9 */)' in v_def) = 0 THEN
+    RAISE EXCEPTION 'mig 194 · actualizar_compra_items no tiene la marca de la mig 193. Aplicá la 193 antes que ésta.'
+      USING ERRCODE = '22023';
+  END IF;
+
+  -- a) firma -----------------------------------------------------------------
+  v_def := public._mig192_reemplazo_unico(v_def,
+    $a$p_otros_impuestos numeric DEFAULT NULL::numeric)$a$,
+    $a$p_otros_impuestos numeric DEFAULT NULL::numeric, p_cargos jsonb DEFAULT NULL::jsonb, p_ii_declarado jsonb DEFAULT NULL::jsonb)$a$,
+    'actualizar_compra_items · firma');
+
+  -- b) variables -------------------------------------------------------------
+  v_def := public._mig192_reemplazo_unico(v_def,
+    $a$  v_warning_cpp JSONB := '[]'::JSONB;
+BEGIN$a$,
+    $a$  v_warning_cpp JSONB := '[]'::JSONB;
+  -- mig 194 · cargos prorrateados
+  v_cargos_provistos BOOLEAN := (p_cargos IS NOT NULL AND jsonb_typeof(p_cargos) <> 'null');
+  v_ii_provisto      BOOLEAN := (p_ii_declarado IS NOT NULL AND jsonb_typeof(p_ii_declarado) <> 'null');
+  v_cargos           JSONB;
+  v_hay_cargos       BOOLEAN := false;
+  v_items_motor      JSONB;
+  v_costos           JSONB;
+  v_costos_por_linea JSONB;
+  v_linea_costos     JSONB;
+  v_idx              INTEGER := 0;
+  v_n_items          INTEGER;
+  v_item_id          BIGINT;
+  v_item_ids         BIGINT[] := '{}';
+  v_cargo_unit       NUMERIC := 0;
+  v_concepto         TEXT;
+  v_clave            TEXT;
+  v_motivo           TEXT;
+  v_ii_declarado     JSONB;
+  v_autoria          JSONB;       -- {definicion_del_cargo: usuario_id} de antes del DELETE
+  v_ii_hdr           NUMERIC;
+  v_ii_suma          NUMERIC;
+  v_usar_motor       BOOLEAN := false;
+  v_warning_ii       TEXT;
+BEGIN$a$,
+    'actualizar_compra_items · declaraciones');
+
+  -- b.1) `v_compra` gana `impuestos_internos` y `ii_declarado` ---------------
+  --
+  -- El total del header hace falta para comparar contra la apertura por alícuota:
+  -- `p_impuestos_internos` tiene DEFAULT NULL y en ese caso la compra CONSERVA el
+  -- suyo, así que el total efectivo no sale del parámetro sino de la fila.
+  -- Y `ii_declarado` es lo que hace posible el segundo guard: sin traerlo, la RPC
+  -- no puede saber si la compra se cargó con un factor de ajuste.
+  v_def := public._mig192_reemplazo_unico(v_def,
+    $a$  SELECT id, estado, tipo_factura, created_at, fecha_compra
+    INTO v_compra$a$,
+    $a$  SELECT id, estado, tipo_factura, created_at, fecha_compra, impuestos_internos, ii_declarado /* mig 194 */
+    INTO v_compra$a$,
+    'actualizar_compra_items · v_compra gana impuestos_internos y ii_declarado');
+
+  -- c) el guard, y después la validación + el motor ---------------------------
+  --
+  -- El guard va acá y no más abajo porque acá todavía no se movió NADA: los
+  -- chequeos de permiso, estado y ventana de 7 días ya pasaron, y el DELETE de
+  -- las líneas, los UPDATE de stock y los set_config vienen después. Devuelve
+  -- success:false en vez de lanzar, que es como esta RPC comunica los rechazos
+  -- de negocio y lo que el front ya sabe mostrar.
+  v_def := public._mig192_reemplazo_unico(v_def,
+    $a$  v_es_zz := (v_compra.tipo_factura = 'ZZ');
+  v_iva_efectivo := CASE WHEN v_es_zz THEN 0 ELSE p_iva END;$a$,
+    $a$  v_es_zz := (v_compra.tipo_factura = 'ZZ');
+  v_iva_efectivo := CASE WHEN v_es_zz THEN 0 ELSE p_iva END;
+
+  /* mig 194 · el II total EFECTIVO del header: el parametro si lo mandaron, y si
+     no el que ya tenia la compra — que es lo que el UPDATE de mas abajo va a
+     dejar por su COALESCE. Es contra este numero que se compara la apertura. */
+  v_ii_hdr := CASE WHEN v_es_zz THEN 0
+                   ELSE COALESCE(p_impuestos_internos, v_compra.impuestos_internos, 0) END;
+
+  /* ── mig 194 · cargos prorrateados ──────────────────────────────────────────
+     Un cliente con un chunk viejo del PWA editando una compra con cargos borraria
+     los repartos en silencio: el DELETE de compra_items cascadea, los cargos
+     sobreviven con el vector vacio y el motor trata el vector vacio como legal.
+     Falla explicito.                                                            */
+  IF NOT v_cargos_provistos AND EXISTS (
+       SELECT 1 FROM compra_cargos WHERE compra_id = p_compra_id) THEN
+    RETURN jsonb_build_object('success', false, 'error',
+      'Esta compra tiene cargos prorrateados. Actualizá la aplicación (recargá la página) antes de editarla.');
+  END IF;
+
+  /* mig 194 · el MISMO guard para la apertura del impuesto interno, y hace falta
+     por separado: los cargos y el II declarado son dos entradas distintas y una
+     compra puede tener la segunda sin la primera —de hecho es el caso normal—.
+     Sin este guard, un cliente que no reenvia la apertura recalcula con factor 1
+     y el ajuste se revierte SOLO. Es la misma perdida que la de los cargos, y en
+     un aspecto es peor: los cargos se pueden reconstruir desde compra_cargos, y
+     un factor revertido no deja absolutamente ningun rastro.
+     El texto nombra la causa real en vez de repetir el de los cargos: la accion
+     que el usuario tiene que hacer es la misma, pero decirle "tiene cargos
+     prorrateados" a una compra que no tiene ninguno lo manda a buscar donde no
+     hay nada.                                                                   */
+  IF NOT v_ii_provisto AND v_compra.ii_declarado IS NOT NULL THEN
+    RETURN jsonb_build_object('success', false, 'error',
+      'Esta compra tiene el impuesto interno declarado por alícuota. Actualizá la aplicación (recargá la página) antes de editarla.');
+  END IF;
+
+  IF v_cargos_provistos AND jsonb_typeof(p_cargos) <> 'array' THEN
+    RAISE EXCEPTION 'p_cargos tiene que ser un array de cargos y llego %.', jsonb_typeof(p_cargos);
+  END IF;
+  v_hay_cargos := v_cargos_provistos AND jsonb_array_length(p_cargos) > 0;
+
+  /* El impuesto interno DECLARADO por alicuota: {tasa: monto}. Es lo unico que
+     el ajuste del motor sabe leer, y sin este parametro el factor se calculaba en
+     la vista previa del navegador y se tiraba a la basura al guardar.
+     En ZZ se descarta, con el mismo criterio que el IVA, las dos percepciones y
+     el II total del header: en ZZ no se agregan impuestos encima. Aunque no se
+     descartara daria igual —la tasa de cada linea tambien va en 0 y el II del
+     motor es base_ii x tasa x factor—, pero descartarlo lo deja dicho. */
+  v_ii_declarado := CASE
+    WHEN v_es_zz THEN '{}'::JSONB
+    WHEN p_ii_declarado IS NULL OR jsonb_typeof(p_ii_declarado) = 'null' THEN '{}'::JSONB
+    ELSE p_ii_declarado END;
+  IF jsonb_typeof(v_ii_declarado) <> 'object' THEN
+    RAISE EXCEPTION 'p_ii_declarado tiene que ser un objeto {tasa: monto} y llego %.', jsonb_typeof(v_ii_declarado);
+  END IF;
+
+  -- Un declarado NEGATIVO daria un factor negativo y le daria vuelta el signo al
+  -- II de TODAS las lineas de ese bucket. El 0 si es legal y significa algo: "esa
+  -- alicuota no tributa en esta factura". El resto de la forma —que las claves
+  -- sean tasas, que los montos sean numeros, que dos claves no colapsen al mismo
+  -- bucket de 4 decimales— lo valida el motor con sus propios mensajes.
+  SELECT d.key INTO v_clave
+    FROM jsonb_each(v_ii_declarado) d
+   WHERE jsonb_typeof(d.value) = 'number' AND (d.value #>> '{}')::NUMERIC < 0
+   ORDER BY d.key
+   LIMIT 1;
+  IF FOUND THEN
+    RAISE EXCEPTION 'El impuesto interno declarado para la tasa % es negativo. El 0 es valido (esa alicuota no tributa en esta factura); un negativo le daria vuelta el signo al II de todas las lineas de esa tasa.', v_clave;
+  END IF;
+
+  v_n_items := CASE WHEN jsonb_typeof(p_items_nuevos) = 'array' THEN jsonb_array_length(p_items_nuevos) ELSE 0 END;
+
+  -- El motor corre si hay cargos O si hay II declarado. El ajuste del II es
+  -- INDEPENDIENTE de los cargos: una factura sin un solo cargo puede igual
+  -- declarar un II que no cuadra con el calculado — es el caso de la factura
+  -- testigo, que hoy se ajusta a mano con 1,0496. Sin ninguno de los dos no se
+  -- ejecuta una sola linea nueva del camino del costo: ahi esta el forward-only.
+  v_usar_motor := (v_hay_cargos OR v_ii_declarado <> '{}'::JSONB) AND v_n_items > 0;
+
+  IF v_hay_cargos THEN
+    IF v_n_items = 0 THEN
+      RAISE EXCEPTION 'Hay cargos para prorratear pero la compra no tiene lineas.';
+    END IF;
+
+    -- Forma del cargo. El CASE fuerza el orden de evaluacion en los dos lados.
+    SELECT (c.ord - 1)::TEXT,
+           CASE WHEN jsonb_typeof(c.val) <> 'object'                    THEN 'no es un objeto'
+                WHEN COALESCE(btrim(c.val->>'concepto'), '') = ''        THEN 'no tiene concepto'
+                ELSE 'no tiene un monto numerico' END
+      INTO v_clave, v_motivo
+      FROM jsonb_array_elements(p_cargos) WITH ORDINALITY AS c(val, ord)
+     WHERE CASE WHEN jsonb_typeof(c.val) <> 'object'               THEN true
+                WHEN COALESCE(btrim(c.val->>'concepto'), '') = ''  THEN true
+                ELSE jsonb_typeof(c.val->'monto') <> 'number' END
+     ORDER BY c.ord
+     LIMIT 1;
+    IF FOUND THEN
+      RAISE EXCEPTION 'El cargo en la posicion % %.', v_clave, v_motivo;
+    END IF;
+
+    -- Dominios y banderas. La clave ausente y el null explicito valen lo mismo:
+    -- el default.
+    SELECT COALESCE(c.val->>'concepto', '?'),
+           CASE WHEN COALESCE(c.val->>'condicion_iva', 'no_gravado') NOT IN ('gravado','exento','no_gravado')
+                  THEN 'tiene una condicion_iva invalida (se espera gravado, exento o no_gravado)'
+                WHEN COALESCE(c.val->>'base_prorrateo', 'unidades') NOT IN ('monto','cantidad','unidades')
+                  THEN 'tiene una base_prorrateo invalida (se espera monto, cantidad o unidades)'
+                ELSE 'tiene en_factura, prorratea_al_costo o afecta_base_ii con un valor que no es booleano'
+           END
+      INTO v_concepto, v_motivo
+      FROM jsonb_array_elements(p_cargos) AS c(val)
+     WHERE COALESCE(c.val->>'condicion_iva', 'no_gravado') NOT IN ('gravado','exento','no_gravado')
+        OR COALESCE(c.val->>'base_prorrateo', 'unidades') NOT IN ('monto','cantidad','unidades')
+        OR jsonb_typeof(COALESCE(NULLIF(c.val->'en_factura',         'null'::JSONB), 'true'::JSONB))  <> 'boolean'
+        OR jsonb_typeof(COALESCE(NULLIF(c.val->'prorratea_al_costo', 'null'::JSONB), 'true'::JSONB))  <> 'boolean'
+        OR jsonb_typeof(COALESCE(NULLIF(c.val->'afecta_base_ii',     'null'::JSONB), 'false'::JSONB)) <> 'boolean'
+     LIMIT 1;
+    IF FOUND THEN
+      RAISE EXCEPTION 'El cargo "%" %.', v_concepto, v_motivo;
+    END IF;
+
+    -- El vector de pesos tiene que ser un objeto {indice: peso}. Ausente ≡ {}.
+    SELECT COALESCE(c.val->>'concepto', '?') INTO v_concepto
+      FROM jsonb_array_elements(p_cargos) AS c(val)
+     WHERE jsonb_typeof(COALESCE(NULLIF(c.val->'pesos', 'null'::JSONB), '{}'::JSONB)) <> 'object'
+     LIMIT 1;
+    IF FOUND THEN
+      RAISE EXCEPTION 'El cargo "%" tiene un vector de pesos que no es un objeto {indice: peso}.', v_concepto;
+    END IF;
+
+    -- Claves y valores del vector: mismo criterio que en registrar_compra_completa.
+    -- Las claves NO se castean a int hasta estar validadas: se comparan como
+    -- numeric, que no desborda.
+    SELECT COALESCE(c.val->>'concepto', '?'), w.key,
+           CASE WHEN w.key !~ '^[0-9]+$'                THEN 'no es un indice de linea'
+                WHEN w.key <> (w.key::NUMERIC)::TEXT    THEN format('no esta en forma canonica (sobra un cero a la izquierda: es la misma linea que "%s"), y dos claves que apuntan a la misma linea le cobrarian el cargo dos veces', (w.key::NUMERIC)::TEXT)
+                WHEN w.key::NUMERIC > v_n_items - 1     THEN format('apunta a una linea que no existe: la compra tiene %s (indices 0 a %s)', v_n_items, v_n_items - 1)
+                ELSE 'tiene un peso que no es un numero finito no negativo; el 0 excluye la linea' END
+      INTO v_concepto, v_clave, v_motivo
+      FROM jsonb_array_elements(p_cargos) AS c(val)
+      CROSS JOIN LATERAL jsonb_each(COALESCE(NULLIF(c.val->'pesos', 'null'::JSONB), '{}'::JSONB)) AS w
+     WHERE CASE WHEN w.key !~ '^[0-9]+$'              THEN true
+                WHEN w.key <> (w.key::NUMERIC)::TEXT  THEN true
+                WHEN w.key::NUMERIC > v_n_items - 1   THEN true
+                WHEN jsonb_typeof(w.value) <> 'number' THEN true
+                ELSE (w.value #>> '{}')::NUMERIC < 0 END
+     LIMIT 1;
+    IF FOUND THEN
+      RAISE EXCEPTION 'El cargo "%": la clave "%" %.', v_concepto, v_clave, v_motivo;
+    END IF;
+
+    -- Normalizacion canonica: montos a 2 decimales y pesos a 4, que es lo que
+    -- guardan las columnas. Una sola version para validar, calcular y guardar.
+    SELECT jsonb_agg(jsonb_build_object(
+             'orden',              (c.ord - 1)::INT,
+             'concepto',           btrim(c.val->>'concepto'),
+             'monto',              round((c.val->>'monto')::NUMERIC, 2),
+             'condicion_iva',      COALESCE(c.val->>'condicion_iva', 'no_gravado'),
+             'en_factura',         COALESCE((c.val->>'en_factura')::BOOLEAN, true),
+             'prorratea_al_costo', COALESCE((c.val->>'prorratea_al_costo')::BOOLEAN, true),
+             'afecta_base_ii',     COALESCE((c.val->>'afecta_base_ii')::BOOLEAN, false),
+             'base_prorrateo',     COALESCE(c.val->>'base_prorrateo', 'unidades'),
+             'pesos',              COALESCE((SELECT jsonb_object_agg(w.key, round((w.value #>> '{}')::NUMERIC, 4))
+                                               FROM jsonb_each(COALESCE(NULLIF(c.val->'pesos', 'null'::JSONB), '{}'::JSONB)) w),
+                                            '{}'::JSONB)
+           ) ORDER BY c.ord)
+      INTO v_cargos
+      FROM jsonb_array_elements(p_cargos) WITH ORDINALITY AS c(val, ord);
+
+    -- Un cargo que prorratea y no apunta a ninguna linea se evaporaria del costo
+    -- SIN UN SOLO AVISO.
+    SELECT c.val->>'concepto' INTO v_concepto
+      FROM jsonb_array_elements(v_cargos) AS c(val)
+     WHERE (c.val->>'prorratea_al_costo')::BOOLEAN
+       AND COALESCE((SELECT sum((w.value #>> '{}')::NUMERIC) FROM jsonb_each(c.val->'pesos') w), 0) = 0
+     ORDER BY (c.val->>'orden')::INT
+     LIMIT 1;
+    IF FOUND THEN
+      RAISE EXCEPTION 'El cargo "%" no tiene ninguna línea asignada', v_concepto;
+    END IF;
+
+    -- Y un peso positivo sobre una linea de cantidad 0 lo evapora por la otra
+    -- puerta. Acá el loop de abajo ya rechaza cantidad <= 0, asi que esto sólo
+    -- adelanta el error con un mensaje que nombra el cargo; se deja para que las
+    -- dos RPCs validen exactamente lo mismo y no diverjan cuando alguien toque
+    -- una sola.
+    SELECT c.val->>'concepto', w.key INTO v_concepto, v_clave
+      FROM jsonb_array_elements(v_cargos) AS c(val)
+      CROSS JOIN LATERAL jsonb_each(c.val->'pesos') AS w
+     WHERE (c.val->>'prorratea_al_costo')::BOOLEAN
+       AND (w.value #>> '{}')::NUMERIC > 0
+       AND (p_items_nuevos->(w.key::INT)->>'cantidad')::NUMERIC = 0
+     ORDER BY (c.val->>'orden')::INT, w.key
+     LIMIT 1;
+    IF FOUND THEN
+      RAISE EXCEPTION 'El cargo "%" reparte sobre la linea % que tiene cantidad 0: ese importe no se podria expresar en el costo unitario y se perderia.',
+        v_concepto, v_clave;
+    END IF;
+
+  ELSE
+    v_cargos := '[]'::JSONB;
+  END IF;
+
+  IF v_usar_motor THEN
+    /* EL MOTOR, SOBRE LOS INDICES.
+
+       ACA PASA LA REGLA DE ZZ, y conviene leerla de un renglon porque
+       `calcular_costos_compra` NO conoce `tipo_factura`: su costo_real es
+       (base_costo + ii + cargos_al_costo) / cantidad, sin una sola rama por tipo
+       de factura. Lo que hace que ZZ se comporte distinto es que la tasa de II de
+       cada linea le llega en 0 —el CASE de aca abajo la fuerza, igual que el loop
+       de mas abajo— y entonces `ii = base_ii x tasa x factor` da 0 cualquiera sea
+       la base y cualquiera sea el factor. El cargo, en cambio, viaja en
+       base_costo (si es gravado) o en cargos_al_costo (si no lo es), y ninguno de
+       los dos mira la tasa: por eso suma igual.
+       O sea que la regla —el tipo de factura decide si se agregan IMPUESTOS
+       encima, no si se ignoran COSTOS— no esta implementada con un IF adentro del
+       motor sino poniendo la tasa en 0 EN EL BORDE. Medido: una ZZ de 4 x 1000
+       con flete de 400 y la linea declarando 8,6956 de II da costo_real 1100, no
+       1186,96.
+
+       `porcentaje_iva` y `condicion_iva` se normalizan con el mismo CASE del loop
+       aunque no muevan el costo_real: asi el motor ve exactamente la fila que se
+       va a guardar y no una version paralela.                                    */
+    SELECT jsonb_agg(jsonb_build_object(
+             'id',                 (e.ord - 1)::INT,
+             'cantidad',           (e.val->>'cantidad')::INT,
+             'costo_unitario',     COALESCE((e.val->>'costo_unitario')::NUMERIC, 0),
+             'bonificacion',       COALESCE((e.val->>'bonificacion')::NUMERIC, 0),
+             'impuestos_internos', CASE WHEN v_es_zz THEN 0
+                                        ELSE COALESCE((e.val->>'impuestos_internos')::NUMERIC, 0) END,
+             'porcentaje_iva',     CASE WHEN v_es_zz OR n.cond <> 'gravado' THEN 0
+                                        ELSE COALESCE((e.val->>'porcentaje_iva')::NUMERIC, 21) END,
+             'condicion_iva',      n.cond
+           ) ORDER BY e.ord)
+      INTO v_items_motor
+      FROM jsonb_array_elements(p_items_nuevos) WITH ORDINALITY AS e(val, ord)
+      CROSS JOIN LATERAL (SELECT CASE
+             WHEN v_es_zz THEN 'gravado'
+             WHEN COALESCE(e.val->>'condicion_iva', 'gravado') IN ('exento','no_gravado')
+               THEN e.val->>'condicion_iva'
+             ELSE 'gravado' END AS cond) n;
+
+    v_costos := calcular_costos_compra(v_items_motor, v_cargos, v_ii_declarado);
+
+    SELECT jsonb_object_agg(l->>'id', l) INTO v_costos_por_linea
+      FROM jsonb_array_elements(v_costos->'lineas') l;
+
+    /* AVISO BLANDO, no bloqueante: el II TOTAL del header y la APERTURA por
+       alicuota son dos numeros que el usuario tipea por separado y pueden
+       contradecirse. NO se pisa ninguno de los dos, y es deliberado.
+       `p_impuestos_internos` es lo que va a compras.impuestos_internos, al cuadre
+       contra p_total y a la posicion fiscal; `p_ii_declarado` solo alimenta el
+       factor de ajuste. Sobrescribir el header con la suma de la apertura
+       cambiaria la posicion fiscal sin que nadie lo haya pedido, y fallar
+       bloquearia una carga por una diferencia que puede ser legitima. La RPC no
+       tiene como saber cual de los dos esta bien: avisa y deja los dos como
+       llegaron. Mismo umbral de 1 peso que el cuadre del total.                  */
+    IF v_ii_declarado <> '{}'::JSONB THEN
+      SELECT COALESCE(sum((d.value #>> '{}')::NUMERIC), 0) INTO v_ii_suma
+        FROM jsonb_each(v_ii_declarado) d;
+      IF abs(v_ii_suma - COALESCE(v_ii_hdr, 0)) > 1 THEN
+        v_warning_ii := format('El impuesto interno declarado por alicuota suma %s y el total informado es %s.',
+                               round(v_ii_suma, 2), round(COALESCE(v_ii_hdr, 0), 2));
+      END IF;
+
+      -- Y una tasa declarada que no usa NINGUNA linea: su factor es un no-op
+      -- (calculado = 0 => factor 1) y ese importe no se refleja en ningun costo.
+      SELECT string_agg(d.key, ', ' ORDER BY d.key) INTO v_clave
+        FROM jsonb_each(v_ii_declarado) d
+       WHERE NOT EXISTS (
+         SELECT 1 FROM jsonb_array_elements(v_items_motor) l
+          WHERE round((l->>'impuestos_internos')::NUMERIC, 4) = round((d.key)::NUMERIC, 4));
+      IF v_clave IS NOT NULL THEN
+        v_warning_ii := COALESCE(v_warning_ii || ' ', '')
+          || format('Las tasas declaradas %s no las usa ninguna linea: ese importe no se refleja en ningun costo.', v_clave);
+      END IF;
+    END IF;
+  END IF;$a$,
+    'actualizar_compra_items · guard y bloque de cargos');
+
+  -- d) contador de posición en el payload ------------------------------------
+  v_def := public._mig192_reemplazo_unico(v_def,
+    $a$  FOR v_item IN SELECT * FROM jsonb_array_elements(p_items_nuevos) LOOP
+    v_producto_id        := (v_item->>'producto_id')::BIGINT;$a$,
+    $a$  FOR v_item IN SELECT * FROM jsonb_array_elements(p_items_nuevos) LOOP
+    v_idx := v_idx + 1;   /* mig 194 · posicion en p_items_nuevos, base 1 */
+    v_producto_id        := (v_item->>'producto_id')::BIGINT;$a$,
+    'actualizar_compra_items · contador del loop');
+
+  -- e) el costo real de la línea sale del motor cuando hay cargos -------------
+  --
+  -- Lo importante de que esto pase ACÁ y no después del loop: el CPP se calcula
+  -- tres renglones más abajo con `v_costo_real`, así que con el costo definitivo
+  -- ya adentro sale bien de una. Y el warning de "compra vieja" compara contra el
+  -- mismo número.
+  v_def := public._mig192_reemplazo_unico(v_def,
+    $a$v_costo_real    := costo_real_unitario(v_costo_neto, v_impuestos_internos, v_compra.tipo_factura, 0 /* mig 193: los cargos entran en la task 9 */);$a$,
+    $a$v_cargo_unit    := 0;   /* mig 194 */
+    IF v_usar_motor AND v_cantidad > 0 THEN
+      v_linea_costos := v_costos_por_linea -> (v_idx - 1)::TEXT;
+      IF v_linea_costos IS NULL THEN
+        RAISE EXCEPTION 'mig 194 · el motor no devolvio la linea %.', v_idx - 1;
+      END IF;
+      v_cargo_unit  := round((v_linea_costos->>'cargos')::NUMERIC, 4);
+      v_costo_real  := round((v_linea_costos->>'costo_real')::NUMERIC, 4);
+    ELSE
+      v_costo_real  := costo_real_unitario(v_costo_neto, v_impuestos_internos, v_compra.tipo_factura, 0 /* mig 193: los cargos entran en la task 9 */);
+    END IF;$a$,
+    'actualizar_compra_items · costo real de la linea');
+
+  -- f) la línea guarda cargos_unitarios y devuelve su id ----------------------
+  v_def := public._mig192_reemplazo_unico(v_def,
+    $a$      porcentaje_iva, impuestos_internos, costo_neto_unitario, costo_real_unitario,
+      condicion_iva
+    ) VALUES (
+      p_compra_id, v_producto_id, v_cantidad, v_costo_unitario,
+      v_subtotal_item, v_stock_anterior, v_stock_nuevo, v_bonificacion, v_sucursal,
+      v_porcentaje_iva, v_impuestos_internos, round(v_costo_neto, 4), v_costo_real,
+      v_condicion_iva
+    );$a$,
+    $a$      porcentaje_iva, impuestos_internos, costo_neto_unitario, costo_real_unitario,
+      condicion_iva, cargos_unitarios /* mig 194 */
+    ) VALUES (
+      p_compra_id, v_producto_id, v_cantidad, v_costo_unitario,
+      v_subtotal_item, v_stock_anterior, v_stock_nuevo, v_bonificacion, v_sucursal,
+      v_porcentaje_iva, v_impuestos_internos, round(v_costo_neto, 4), v_costo_real,
+      v_condicion_iva, v_cargo_unit
+    )
+    RETURNING id INTO v_item_id;
+
+    /* mig 194 · el indice del payload (base 0) es v_item_ids[indice + 1]. Es el
+       unico puente entre los pesos que mando el cliente y los ids reales, y las
+       lineas viejas ya no existen: el DELETE de arriba se las llevo. */
+    v_item_ids := v_item_ids || v_item_id;$a$,
+    'actualizar_compra_items · insert de compra_items');
+
+  -- g) reescribir los cargos junto con las líneas -----------------------------
+  --
+  -- Ésta es la parte que evita la pérdida: los repartos viejos ya se fueron con
+  -- el CASCADE del DELETE, así que los cargos se borran y se vuelven a insertar
+  -- enteros contra las líneas NUEVAS. `p_cargos = '[]'` borra y no repone, que es
+  -- exactamente "el usuario sacó todos los cargos".
+  v_def := public._mig192_reemplazo_unico(v_def,
+    $a$  UPDATE compras
+     SET subtotal = p_subtotal,$a$,
+    $a$  /* mig 194 · los cargos, ya con los ids reales de las lineas nuevas. */
+  IF v_cargos_provistos THEN
+    /* La AUTORIA se preserva cuando el cargo NO cambio. `usuario_id` existe para
+       poder auditar quien movio el costo de los productos, y el DELETE + INSERT
+       de aca abajo la reescribiria entera en cada edicion: si Ana carga el flete
+       de 1,9 M y Beto despues corrige una cantidad, el flete pasaria a figurar
+       como de Beto sin que Beto lo haya tocado.
+       La clave del match es la DEFINICION del cargo —orden, concepto, monto,
+       condicion frente al IVA y las tres banderas—, NO los pesos: los pesos son
+       funcion de las lineas, y las lineas son justamente lo que una edicion
+       cambia. Si algo de la definicion cambio, el cargo es otro y lo firma quien
+       edita. Degrada solo: sin match queda p_usuario_id, que es lo que hacia
+       antes de este bloque.
+       La clave va como texto de un jsonb y no concatenada con un separador
+       porque un concepto es texto libre: el escapeo de JSON la hace inyectable a
+       prueba de conceptos con cualquier contenido.                              */
+    SELECT COALESCE(jsonb_object_agg(
+             jsonb_build_array(cc.orden, cc.concepto, cc.monto, cc.condicion_iva,
+                               cc.en_factura, cc.prorratea_al_costo,
+                               cc.afecta_base_ii, cc.base_prorrateo)::TEXT,
+             cc.usuario_id), '{}'::JSONB)
+      INTO v_autoria
+      FROM compra_cargos cc
+     WHERE cc.compra_id = p_compra_id AND cc.sucursal_id = v_sucursal
+       AND cc.usuario_id IS NOT NULL;
+
+    DELETE FROM compra_cargos WHERE compra_id = p_compra_id AND sucursal_id = v_sucursal;
+
+    IF v_hay_cargos THEN
+      INSERT INTO compra_cargos (
+        compra_id, sucursal_id, usuario_id, orden, concepto, monto,
+        condicion_iva, en_factura, prorratea_al_costo, afecta_base_ii, base_prorrateo
+      )
+      SELECT p_compra_id, v_sucursal,
+             COALESCE((v_autoria ->> jsonb_build_array(
+                         (c.val->>'orden')::INT,
+                         c.val->>'concepto',
+                         (c.val->>'monto')::NUMERIC(12,2),
+                         c.val->>'condicion_iva',
+                         (c.val->>'en_factura')::BOOLEAN,
+                         (c.val->>'prorratea_al_costo')::BOOLEAN,
+                         (c.val->>'afecta_base_ii')::BOOLEAN,
+                         c.val->>'base_prorrateo')::TEXT)::UUID,
+                      p_usuario_id) /* mig 194 */,
+             (c.val->>'orden')::INT,
+             c.val->>'concepto',
+             (c.val->>'monto')::NUMERIC,
+             c.val->>'condicion_iva',
+             (c.val->>'en_factura')::BOOLEAN,
+             (c.val->>'prorratea_al_costo')::BOOLEAN,
+             (c.val->>'afecta_base_ii')::BOOLEAN,
+             c.val->>'base_prorrateo'
+        FROM jsonb_array_elements(v_cargos) AS c(val);
+
+      INSERT INTO compra_cargo_repartos (cargo_id, compra_item_id, compra_id, peso)
+      SELECT cc.id, v_item_ids[(w.key)::INT + 1], p_compra_id, (w.value #>> '{}')::NUMERIC
+        FROM compra_cargos cc
+        JOIN jsonb_array_elements(v_cargos) AS c(val) ON (c.val->>'orden')::INT = cc.orden
+        CROSS JOIN LATERAL jsonb_each(c.val->'pesos') AS w
+       WHERE cc.compra_id = p_compra_id;
+    END IF;
+  END IF;
+
+  UPDATE compras
+     SET ii_declarado = CASE WHEN v_ii_provisto THEN NULLIF(v_ii_declarado, '{}'::JSONB)
+                             ELSE ii_declarado END,   /* mig 194 */
+         subtotal = p_subtotal,$a$,
+    'actualizar_compra_items · persistencia de los cargos y de la apertura');
+
+  -- h) el aviso del II declarado, en la respuesta ----------------------------
+  v_def := public._mig192_reemplazo_unico(v_def,
+    $a$    'warnings', NULL
+  );$a$,
+    $a$    'warnings', NULL,
+    'warning_ii_declarado', v_warning_ii /* mig 194 */
+  );$a$,
+    'actualizar_compra_items · aviso del II declarado');
+
+  EXECUTE v_def;
+  EXECUTE format('DROP FUNCTION %s', v_vieja);
+END;
+$mig$;
+
+REVOKE ALL ON FUNCTION public.actualizar_compra_items(bigint,jsonb,numeric,numeric,numeric,uuid,numeric,numeric,numeric,numeric,numeric,jsonb,jsonb) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.actualizar_compra_items(bigint,jsonb,numeric,numeric,numeric,uuid,numeric,numeric,numeric,numeric,numeric,jsonb,jsonb) TO authenticated, service_role;
+
+COMMENT ON FUNCTION public.actualizar_compra_items(bigint,jsonb,numeric,numeric,numeric,uuid,numeric,numeric,numeric,numeric,numeric,jsonb,jsonb) IS
+  'Edicion de las lineas de una compra (admin, ventana de 7 dias). Desde la mig '
+  '194 acepta p_cargos, con los pesos POR INDICE DE p_items_nuevos, BASE 0. El '
+  'DEFAULT es NULL y no [] a proposito: NULL (o JSON null) es "no me mandaron '
+  'cargos" y [] es "el usuario borro todos". Si no los mandan y la compra TIENE '
+  'cargos, la RPC rechaza con success:false en vez de editar: el DELETE de '
+  'compra_items cascadea sobre compra_cargo_repartos y dejaria los cargos vivos '
+  'con el vector vacio, que el motor considera legal — el flete se caeria del '
+  'costo sin un solo aviso. SON DOS GUARDS Y NO UNO: p_ii_declarado tiene el '
+  'mismo DEFAULT NULL y el mismo rechazo, porque la apertura del impuesto interno '
+  'mueve el costo igual que los cargos y una edicion que no la reenvie recalcula '
+  'con factor 1 y revierte el ajuste. Son independientes porque una compra puede '
+  'tener apertura sin un solo cargo, que es el caso normal. La apertura se '
+  'persiste en compras.ii_declarado; vacia se guarda como NULL, para no rechazar '
+  'a un cliente viejo por una compra que no tiene ningun ajuste que perder.';
+
+-- ----------------------------------------------------------------------------
+-- 3 · TASK 11 · cambiar_proveedor_compra clona TODO, no sólo los ítems
+--
+-- Esa RPC anula la compra y la clona con otro proveedor, y las dos copias van con
+-- lista de columnas EXPLÍCITA. Medido sobre el catálogo vivo antes de escribir
+-- esto: con la 192 y la 194 aplicadas, el clon perdía CUATRO cosas.
+--
+--   · `compras.ii_declarado`          → la apertura del II desaparecía, y encima el
+--     guard de la task 10 no protegía al clon porque su `ii_declarado` era NULL;
+--   · `compra_items.cargos_unitarios` → caía al DEFAULT 0;
+--   · `compra_cargos` y sus repartos  → no se clonaban (cuelgan de `compra_id`);
+--   · y `costo_real_unitario` SÍ se copiaba, con los cargos y el factor adentro.
+--
+-- La última es la que vuelve grave a las otras tres: quedaba exactamente el estado
+-- que el rollback de la 192 describe como irreversible —costos que incluyen cargos
+-- sin ningún registro de cuáles fueron— y el check COMPRA-A3 se habría puesto rojo
+-- sobre una compra que nadie tocó a mano.
+--
+-- POR QUÉ EL CLON DE LOS ÍTEMS PASA A SER UN LOOP y deja de ser un INSERT … SELECT:
+-- hace falta el mapa `id viejo → id nuevo` para reapuntar los repartos, y un
+-- INSERT … SELECT no lo da. `RETURNING` devuelve los ids nuevos pero no dice de qué
+-- fila salió cada uno, y aparearlos por posición depende de que el ejecutor inserte
+-- en el orden del SELECT: cierto en la práctica, no garantizado, y este archivo no
+-- se apoya en eso. Tampoco hay clave natural — una compra puede repetir el mismo
+-- producto, medido en prod. El loop es explícito y no cuesta nada: 4 líneas de
+-- media por compra, 31 como máximo.
+--
+-- La firma no cambia, así que acá no hay DROP ni sobrecarga: es un CREATE OR
+-- REPLACE puro sobre el cuerpo vivo.
+-- ----------------------------------------------------------------------------
+DO $mig$
+DECLARE
+  v_firma constant text := 'public.cambiar_proveedor_compra(bigint,uuid,bigint,character varying,text)';
+  v_def   text;
+BEGIN
+  IF to_regprocedure(v_firma) IS NULL THEN
+    RAISE EXCEPTION 'mig 194 · no existe % en el catálogo.', v_firma;
+  END IF;
+
+  v_def := pg_get_functiondef(to_regprocedure(v_firma));
+
+  -- Idempotencia por una marca que sólo puede haber escrito este parche.
+  IF position('mig 194 · clonar los cargos' in v_def) > 0 THEN
+    RETURN;
+  END IF;
+
+  -- a) variables para el mapa de ítems y el clon de los cargos ----------------
+  v_def := public._mig192_reemplazo_unico(v_def,
+    $a$  v_nueva_id   BIGINT;
+BEGIN$a$,
+    $a$  v_nueva_id   BIGINT;
+  -- mig 194 · clonar los cargos
+  v_item        RECORD;
+  v_cargo       RECORD;
+  v_item_nuevo  BIGINT;
+  v_cargo_nuevo BIGINT;
+  v_map_items   JSONB := '{}'::JSONB;   -- {id_viejo: id_nuevo}
+BEGIN$a$,
+    'cambiar_proveedor_compra · declaraciones');
+
+  -- b) la cabecera se lleva la apertura del II -------------------------------
+  v_def := public._mig192_reemplazo_unico(v_def,
+    $a$    otros_impuestos, total, forma_pago, notas, usuario_id, estado, tipo_factura, sucursal_id
+  )$a$,
+    $a$    otros_impuestos, total, forma_pago, notas, usuario_id, estado, tipo_factura, sucursal_id,
+    ii_declarado /* mig 194 */
+  )$a$,
+    'cambiar_proveedor_compra · columnas de la cabecera');
+
+  v_def := public._mig192_reemplazo_unico(v_def,
+    $a$    c.usuario_id, 'recibida', c.tipo_factura, c.sucursal_id
+  FROM compras c$a$,
+    $a$    c.usuario_id, 'recibida', c.tipo_factura, c.sucursal_id,
+    c.ii_declarado /* mig 194 */
+  FROM compras c$a$,
+    'cambiar_proveedor_compra · valores de la cabecera');
+
+  -- c) los ítems se clonan uno por uno, y detrás van los cargos --------------
+  v_def := public._mig192_reemplazo_unico(v_def,
+    $a$  -- 2) Clonar items verbatim (incluye snapshots fiscales), SIN mover stock
+  INSERT INTO compra_items (
+    compra_id, producto_id, cantidad, costo_unitario, subtotal,
+    stock_anterior, stock_nuevo, bonificacion, sucursal_id,
+    porcentaje_iva, impuestos_internos, costo_neto_unitario, costo_real_unitario,
+    condicion_iva
+  )
+  SELECT
+    v_nueva_id, ci.producto_id, ci.cantidad, ci.costo_unitario, ci.subtotal,
+    ci.stock_anterior, ci.stock_nuevo, ci.bonificacion, ci.sucursal_id,
+    ci.porcentaje_iva, ci.impuestos_internos, ci.costo_neto_unitario, ci.costo_real_unitario,
+    ci.condicion_iva
+  FROM compra_items ci
+  WHERE ci.compra_id = p_compra_id AND ci.sucursal_id = v_sucursal;$a$,
+    $a$  /* 2) Clonar items verbatim, y ahora SI con todos los snapshots fiscales: la
+        mig 194 sumo cargos_unitarios, y sin copiarla la linea diria que no tuvo
+        cargos mientras su costo_real_unitario los incluye. SIN mover stock.
+        Es un loop y no un INSERT ... SELECT porque hace falta el mapa
+        id viejo -> id nuevo para reapuntar los repartos, y RETURNING no dice de
+        que fila salio cada id. Media 4 lineas por compra, maximo 31. */
+  FOR v_item IN
+    SELECT * FROM compra_items
+     WHERE compra_id = p_compra_id AND sucursal_id = v_sucursal
+     ORDER BY id
+  LOOP
+    INSERT INTO compra_items (
+      compra_id, producto_id, cantidad, costo_unitario, subtotal,
+      stock_anterior, stock_nuevo, bonificacion, sucursal_id,
+      porcentaje_iva, impuestos_internos, costo_neto_unitario, costo_real_unitario,
+      condicion_iva, cargos_unitarios
+    ) VALUES (
+      v_nueva_id, v_item.producto_id, v_item.cantidad, v_item.costo_unitario, v_item.subtotal,
+      v_item.stock_anterior, v_item.stock_nuevo, v_item.bonificacion, v_item.sucursal_id,
+      v_item.porcentaje_iva, v_item.impuestos_internos, v_item.costo_neto_unitario,
+      v_item.costo_real_unitario, v_item.condicion_iva, v_item.cargos_unitarios
+    )
+    RETURNING id INTO v_item_nuevo;
+
+    v_map_items := v_map_items || jsonb_build_object(v_item.id::TEXT, v_item_nuevo);
+  END LOOP;
+
+  /* 2.1) Y los cargos con sus repartos, reapuntados a las lineas nuevas. El
+        compra_id del reparto tambien tiene que ser el nuevo: las dos FK
+        compuestas de la mig 192 lo exigen y si no rebota.
+        usuario_id del cargo se copia tal cual — cambiar el proveedor no cambia
+        quien cargo el flete, mismo criterio que la autoria en la edicion. */
+  FOR v_cargo IN
+    SELECT * FROM compra_cargos
+     WHERE compra_id = p_compra_id AND sucursal_id = v_sucursal
+     ORDER BY orden, id
+  LOOP
+    INSERT INTO compra_cargos (
+      compra_id, sucursal_id, usuario_id, orden, concepto, monto,
+      condicion_iva, en_factura, prorratea_al_costo, afecta_base_ii, base_prorrateo
+    ) VALUES (
+      v_nueva_id, v_cargo.sucursal_id, v_cargo.usuario_id, v_cargo.orden, v_cargo.concepto,
+      v_cargo.monto, v_cargo.condicion_iva, v_cargo.en_factura, v_cargo.prorratea_al_costo,
+      v_cargo.afecta_base_ii, v_cargo.base_prorrateo
+    )
+    RETURNING id INTO v_cargo_nuevo;
+
+    INSERT INTO compra_cargo_repartos (cargo_id, compra_item_id, compra_id, peso)
+    SELECT v_cargo_nuevo, (v_map_items ->> r.compra_item_id::TEXT)::BIGINT, v_nueva_id, r.peso
+      FROM compra_cargo_repartos r
+     WHERE r.cargo_id = v_cargo.id;
+  END LOOP;$a$,
+    'cambiar_proveedor_compra · clon de items, cargos y repartos');
+
+  EXECUTE v_def;
+END;
+$mig$;
+
+-- ----------------------------------------------------------------------------
+-- 4 · TASK 12 · el check de integridad de los cargos
+--
+-- ⚠ SE LLAMA `COMPRA-A3` Y NO `COMPRA-A2`: **A2 YA EXISTE** y encima está en rojo
+-- —`compras.subtotal = SUM(compra_items.subtotal)`, 5 violaciones legacy,
+-- severidad medium—. Se midió antes de escribir esto. Reusar el id habría
+-- duplicado una clave que el gate lee por nombre. A3 sigue la familia: A1 es la
+-- aritmética del header, A2 la del subtotal contra las líneas, A3 la de los
+-- cargos contra lo repartido.
+--
+-- QUÉ VIGILA, porque la primera versión del plan comparaba cosas distintas —el
+-- `monto` del cargo contra la suma de sus PESOS, que son proporciones, no plata—:
+--
+--   · que `sum(prorratear_cargo(...))` dé `monto` está GARANTIZADO POR
+--     CONSTRUCCIÓN: la regla del residuo lo fuerza. Verificarlo sería testear la
+--     función, no los datos, y un check que no puede ponerse rojo no vigila nada.
+--   · lo que SÍ se desincroniza en producción es lo que quedó GUARDADO en
+--     `compra_items.cargos_unitarios` contra lo que los cargos dicen HOY. Un cargo
+--     editado a mano sin recalcular las líneas, un reparto que se llevó el CASCADE
+--     de una edición, una fila tocada por SQL directo: en los tres casos el costo
+--     sigue con los cargos adentro y el desglose ya no los explica. Ése es el
+--     drift real, y es exactamente el bug que esta tanda entera viene a evitar.
+--
+-- Compara POR LÍNEA y no por compra: sumar la compra dejaría que dos errores de
+-- signo opuesto se cancelen entre líneas.
+--
+-- TOLERANCIA, NO IGUALDAD, y no es pereza: `cargos_unitarios` es `numeric(12,4)` y
+-- el cargo se divide por la cantidad, así que reconstruirlo multiplicando de vuelta
+-- no puede dar exacto. 500 sobre 3 unidades da 166,6667 × 3 = 500,0001. El margen
+-- es `1 centavo + 0,0001 × cantidad`: el término de la cantidad cubre el redondeo
+-- del unitario con el doble del error máximo teórico (0,00005 × cantidad), y sigue
+-- siendo tres órdenes de magnitud más chico que cualquier cargo perdido de verdad.
+--
+-- NACE EN VERDE, y eso es un requisito y no una expectativa: hoy no hay una sola
+-- compra con cargos, así que las 527 líneas tienen `cargos_unitarios = 0` y el
+-- reparto esperado es 0. Un check que nace rojo vuelve inútil al gate diario —es
+-- lo que le pasó a `COMPRA-A1` antes de la mig 178, y por eso los checks que se
+-- agregaban después nacían invisibles—. Verificado corriendo la función, no
+-- asumido. Y verificado también que MUERDE: con un `cargos_unitarios` ensuciado a
+-- mano, lo cuenta.
+--
+-- Severidad `high` a propósito: el gate de CI falla con critical/high en rojo, y
+-- un desglose que dejó de explicar el costo es plata. Los 7 checks que hoy están
+-- en rojo son todos medium/low/info, así que el gate está verde y este check no lo
+-- cambia mientras no haya drift.
+--
+-- Mismo patrón que la mig 178: se lee el cuerpo vivo, se inserta la fila con ancla
+-- única, y es idempotente por la presencia del id.
+-- ----------------------------------------------------------------------------
+DO $mig$
+DECLARE
+  v_def text;
+BEGIN
+  v_def := pg_get_functiondef('public.auditoria_integridad()'::regprocedure);
+
+  IF position('COMPRA-A3' in v_def) > 0 THEN
+    RETURN;
+  END IF;
+
+  v_def := public._mig192_reemplazo_unico(v_def,
+    $a$    ('COMPRA-A2','medium','compras.subtotal = SUM(compra_items.subtotal) (5 legacy)',$a$,
+    $a$    ('COMPRA-A3','high','cargos_unitarios guardado = lo que hoy reparten los cargos no gravados (mig 194)',
+      (SELECT count(*) FROM compra_items ci
+         JOIN compras c ON c.id=ci.compra_id AND c.estado<>'cancelada'
+         LEFT JOIN (
+           SELECT r.item_id, sum(r.monto) AS monto
+             FROM (SELECT cc.monto AS m,
+                          (SELECT jsonb_object_agg(x.compra_item_id::text, x.peso)
+                             FROM compra_cargo_repartos x WHERE x.cargo_id=cc.id) AS pesos
+                     FROM compra_cargos cc
+                     JOIN compras cx ON cx.id=cc.compra_id AND cx.estado<>'cancelada'
+                    WHERE cc.condicion_iva<>'gravado' AND cc.prorratea_al_costo) g
+             CROSS JOIN LATERAL prorratear_cargo(g.m, g.pesos) r
+            GROUP BY r.item_id) rep ON rep.item_id=ci.id
+        WHERE abs(COALESCE(rep.monto,0) - COALESCE(ci.cargos_unitarios,0)*ci.cantidad)
+              > 0.01 + 0.0001*ci.cantidad)),
+    ('COMPRA-A2','medium','compras.subtotal = SUM(compra_items.subtotal) (5 legacy)',$a$,
+    'auditoria_integridad · fila de COMPRA-A3');
+
+  EXECUTE v_def;
+END;
+$mig$;
+
+-- ----------------------------------------------------------------------------
+-- 5 · POST-condición
+--
+-- El DROP por sí solo no protege de nada: los cuerpos plpgsql son strings y
+-- Postgres no los valida, así que un parche que no hubiera entrado no falla al
+-- aplicar — falla en producción la próxima vez que alguien registra o edita una
+-- compra. Por eso además de contar sobrecargas se verifica que el cuerpo tenga
+-- las piezas.
+-- ----------------------------------------------------------------------------
+DO $post$
+DECLARE
+  v_fn     text;
+  v_nargs  integer;
+  v_oid    oid;
+  v_real   integer;
+  v_marca  text;
+  v_n      integer;
+BEGIN
+  FOREACH v_fn IN ARRAY ARRAY['registrar_compra_completa', 'actualizar_compra_items'] LOOP
+    v_nargs := CASE v_fn WHEN 'registrar_compra_completa' THEN 19 ELSE 13 END;
+
+    SELECT count(*) INTO v_n
+      FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace
+     WHERE n.nspname = 'public' AND p.proname = v_fn;
+    IF v_n <> 1 THEN
+      RAISE EXCEPTION 'mig 194 · quedaron % sobrecargas de %. Dos con rangos de aridad superpuestos dan PGRST203 en runtime, invisible para tsc y para los tests.', v_n, v_fn
+        USING ERRCODE = '22023';
+    END IF;
+
+    SELECT p.oid, p.pronargs INTO v_oid, v_real
+      FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace
+     WHERE n.nspname = 'public' AND p.proname = v_fn;
+
+    IF v_real <> v_nargs THEN
+      RAISE EXCEPTION 'mig 194 · % quedó con % argumentos y se esperaban %.', v_fn, v_real, v_nargs
+        USING ERRCODE = '22023';
+    END IF;
+
+    FOREACH v_marca IN ARRAY ARRAY['cargos_unitarios', 'RETURNING id INTO v_item_id;',
+                                   -- La llamada COMPLETA, no `calcular_costos_compra(` a
+                                   -- secas: lo que hay que verificar no es que el motor se
+                                   -- llame, es que el II DECLARADO le llegue. Con un
+                                   -- '{}'::JSONB hardcodeado en el 3er argumento el factor
+                                   -- se calcularia y se tiraria, que es el bug que la
+                                   -- correccion de esta migracion vino a cerrar.
+                                   'calcular_costos_compra(v_items_motor, v_cargos, v_ii_declarado)']
+    LOOP
+      SELECT (length(p.prosrc) - length(replace(p.prosrc, v_marca, ''))) / length(v_marca) INTO v_n
+        FROM pg_proc p WHERE p.oid = v_oid;
+      IF v_n <> 1 THEN
+        RAISE EXCEPTION 'mig 194 · % tiene % veces "%" y se esperaba 1: el parche no quedó como se creía.', v_fn, v_n, v_marca
+          USING ERRCODE = '22023';
+      END IF;
+    END LOOP;
+
+    IF has_function_privilege('anon', v_oid, 'EXECUTE') THEN
+      RAISE EXCEPTION 'mig 194 · % quedó ejecutable por anon.', v_fn
+        USING ERRCODE = '22023';
+    END IF;
+    IF NOT has_function_privilege('authenticated', v_oid, 'EXECUTE') THEN
+      RAISE EXCEPTION 'mig 194 · % NO quedó ejecutable por authenticated: la app dejaría de poder operar compras.', v_fn
+        USING ERRCODE = '22023';
+    END IF;
+  END LOOP;
+
+  -- El guard de la task 10, nombrado: es la única pieza cuya ausencia no rompe
+  -- nada al aplicar y borra plata en silencio en producción.
+  FOREACH v_marca IN ARRAY ARRAY['Esta compra tiene cargos prorrateados.',
+                                 'Esta compra tiene el impuesto interno declarado'] LOOP
+    SELECT (length(p.prosrc) - length(replace(p.prosrc, v_marca, ''))) / length(v_marca) INTO v_n
+      FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace
+     WHERE n.nspname = 'public' AND p.proname = 'actualizar_compra_items';
+    IF v_n <> 1 THEN
+      RAISE EXCEPTION 'mig 194 · actualizar_compra_items quedó SIN el guard "%" (% ocurrencias). Es la pieza cuya ausencia no rompe nada al aplicar y borra plata en silencio en producción.', v_marca, v_n
+        USING ERRCODE = '22023';
+    END IF;
+  END LOOP;
+
+  -- Y que la apertura se PERSISTA en las dos: sin eso el guard de arriba nunca
+  -- tendría contra qué disparar.
+  SELECT (length(p.prosrc) - length(replace(p.prosrc, 'UPDATE compras SET ii_declarado = v_ii_declarado', '')))
+         / length('UPDATE compras SET ii_declarado = v_ii_declarado') INTO v_n
+    FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace
+   WHERE n.nspname = 'public' AND p.proname = 'registrar_compra_completa';
+  IF v_n <> 1 THEN
+    RAISE EXCEPTION 'mig 194 · registrar_compra_completa no persiste ii_declarado (% ocurrencias).', v_n
+      USING ERRCODE = '22023';
+  END IF;
+
+  SELECT (length(p.prosrc) - length(replace(p.prosrc, 'SET ii_declarado = CASE WHEN v_ii_provisto', '')))
+         / length('SET ii_declarado = CASE WHEN v_ii_provisto') INTO v_n
+    FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace
+   WHERE n.nspname = 'public' AND p.proname = 'actualizar_compra_items';
+  IF v_n <> 1 THEN
+    RAISE EXCEPTION 'mig 194 · actualizar_compra_items no persiste ii_declarado (% ocurrencias).', v_n
+      USING ERRCODE = '22023';
+  END IF;
+
+  -- Task 11: el clon se lleva las cuatro cosas. `cargos_unitarios` aparece dos
+  -- veces (columna y valor), `ii_declarado` dos (columna y valor) y los repartos
+  -- una: si alguna cae a 0, el clon vuelve a perder el origen de sus costos.
+  FOREACH v_marca IN ARRAY ARRAY['cargos_unitarios', 'ii_declarado',
+                                 'INSERT INTO compra_cargo_repartos'] LOOP
+    SELECT (length(p.prosrc) - length(replace(p.prosrc, v_marca, ''))) / length(v_marca) INTO v_n
+      FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace
+     WHERE n.nspname = 'public' AND p.proname = 'cambiar_proveedor_compra';
+    IF v_n = 0 THEN
+      RAISE EXCEPTION 'mig 194 · cambiar_proveedor_compra no clona "%": el clon quedaria con los costos y sin el origen.', v_marca
+        USING ERRCODE = '22023';
+    END IF;
+  END LOOP;
+
+  -- Task 12: el check existe UNA vez, y sigue existiendo el A2 que ya estaba.
+  FOREACH v_marca IN ARRAY ARRAY['''COMPRA-A3''', '''COMPRA-A2'''] LOOP
+    SELECT (length(p.prosrc) - length(replace(p.prosrc, v_marca, ''))) / length(v_marca) INTO v_n
+      FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace
+     WHERE n.nspname = 'public' AND p.proname = 'auditoria_integridad';
+    IF v_n <> 1 THEN
+      RAISE EXCEPTION 'mig 194 · auditoria_integridad tiene % veces el check % (se esperaba 1).', v_n, v_marca
+        USING ERRCODE = '22023';
+    END IF;
+  END LOOP;
+
+  -- Y NACE EN VERDE. Si arranca rojo, el gate diario queda inutil: es lo que le
+  -- paso a COMPRA-A1 antes de la mig 178.
+  -- `auditoria_integridad()` devuelve un jsonb ESCALAR, no una tabla: se expande
+  -- directo. (Lo agarró el ensayo al EJECUTAR; compilar no lo hubiera visto,
+  -- que es exactamente por lo que la 193 exige ejecutar y no compilar.)
+  SELECT (a.c->>'violaciones')::int INTO v_n
+    FROM jsonb_array_elements(auditoria_integridad()->'checks') a(c)
+   WHERE a.c->>'id' = 'COMPRA-A3';
+  IF v_n IS NULL THEN
+    RAISE EXCEPTION 'mig 194 · COMPRA-A3 no aparece en la salida de auditoria_integridad().'
+      USING ERRCODE = '22023';
+  END IF;
+  IF v_n <> 0 THEN
+    RAISE EXCEPTION 'mig 194 · COMPRA-A3 nace con % violaciones. Un check que nace rojo vuelve inutil al gate diario: revisa el drift antes de aplicar.', v_n
+      USING ERRCODE = '22023';
+  END IF;
+END;
+$post$;
+
+-- El helper es andamiaje de esta migración, no API: se va con ella.
+DROP FUNCTION IF EXISTS public._mig192_reemplazo_unico(text, text, text, text);
+
+COMMIT;
+
+-- ----------------------------------------------------------------------------
+-- Rollback
+--
+-- No alcanza con recrear las firmas viejas: hay que volver los DOS CUERPOS al de
+-- antes, porque los nuevos referencian compra_cargos y compra_cargo_repartos.
+-- El recipe es simétrico al de aplicar —leer el cuerpo vivo y desandar los
+-- parches— y sólo es EXACTO mientras ninguna compra tenga cargos todavía. En
+-- cuanto los tenga, dropear las firmas nuevas deja los costos con cargos adentro
+-- y los repartos sin quien los recalcule: ahí el rollback pasa a ser el de la 192
+-- (recálculo de costos y CPP con las tablas todavía en pie).
+--
+-- Y hay un orden que importa: volver `actualizar_compra_items` a 11 argumentos
+-- SIN haber sacado antes los cargos de las compras que los tengan reinstala
+-- exactamente el bug que la task 10 vino a tapar — la RPC vieja no conoce el
+-- guard y la próxima edición se lleva los repartos puestos.
+--
+--   BEGIN;
+--     -- 1. desandar los parches sobre el cuerpo vivo
+--     DO $r$
+--     DECLARE v_def text;
+--     BEGIN
+--       v_def := pg_get_functiondef('public.registrar_compra_completa(bigint,character varying,character varying,date,numeric,numeric,numeric,numeric,character varying,text,uuid,jsonb,character varying,numeric,numeric,numeric,numeric,jsonb,jsonb)'::regprocedure);
+--       -- ... quitar el bloque de cargos, el IF del costo real, cargos_unitarios,
+--       --     el RETURNING y la persistencia; devolver la firma a 17 argumentos ...
+--       EXECUTE v_def;
+--     END $r$;
+--     DROP FUNCTION public.registrar_compra_completa(bigint,character varying,character varying,date,numeric,numeric,numeric,numeric,character varying,text,uuid,jsonb,character varying,numeric,numeric,numeric,numeric,jsonb,jsonb);
+--     -- 2. y devolverle los privilegios, que el CREATE no restaura solo:
+--     REVOKE ALL ON FUNCTION public.registrar_compra_completa(bigint,character varying,character varying,date,numeric,numeric,numeric,numeric,character varying,text,uuid,jsonb,character varying,numeric,numeric,numeric,numeric)
+--       FROM PUBLIC, anon;
+--     GRANT EXECUTE ON FUNCTION public.registrar_compra_completa(bigint,character varying,character varying,date,numeric,numeric,numeric,numeric,character varying,text,uuid,jsonb,character varying,numeric,numeric,numeric,numeric)
+--       TO authenticated, service_role;
+--   COMMIT;
+--
+-- En la práctica es más barato revertir el commit y re-aplicar 190+191 sobre una
+-- base sin cargos que desandar el parche a mano.
+-- ----------------------------------------------------------------------------
+
+-- ----------------------------------------------------------------------------
+-- Verificación
+--
+--   -- UNA sola firma de cada una, con 19 y 13 argumentos. Si esto devuelve más
+--   -- de dos filas, PostgREST tira PGRST203 en runtime y no lo ve ni tsc ni los
+--   -- tests:
+--   SELECT proname, pronargs, array_to_string(proacl, ' ')
+--     FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace
+--    WHERE n.nspname = 'public'
+--      AND proname IN ('registrar_compra_completa','actualizar_compra_items');
+--   -- actualizar_compra_items   | 13 | postgres=X/postgres authenticated=X/postgres service_role=X/postgres
+--   -- registrar_compra_completa | 19 | postgres=X/postgres authenticated=X/postgres service_role=X/postgres
+--
+--   -- FORWARD-ONLY: la misma compra SIN cargos, antes y después de la migración,
+--   -- tiene que dar el mismo costo_real_unitario al último decimal.
+--   SELECT registrar_compra_completa(NULL,'Testigo','FWD',CURRENT_DATE,
+--            1000,210,0,1210,'efectivo',NULL, auth.uid(),
+--            '[{"producto_id":<id>,"cantidad":10,"costo_unitario":100,
+--               "bonificacion":0,"porcentaje_iva":21,"impuestos_internos":8.6956,
+--               "condicion_iva":"gravado"}]'::jsonb);
+--   -- costo_real_unitario 108.6956 · cargos_unitarios 0 — igual que antes de la 194.
+--
+--   -- CON cargos: un flete no gravado de 500 sobre la única línea.
+--   SELECT registrar_compra_completa(..., p_cargos =>
+--     '[{"concepto":"Flete","monto":500,"condicion_iva":"no_gravado",
+--        "en_factura":false,"prorratea_al_costo":true,"afecta_base_ii":false,
+--        "pesos":{"0":1}}]'::jsonb);
+--   -- cargos_unitarios 50 · costo_real_unitario 158.6956 (108.6956 + 50)
+--
+--   -- Los tres guards, que tienen que fallar los tres:
+--   --   pesos:{}            → El cargo "Flete" no tiene ninguna línea asignada
+--   --   pesos:{"7":1}       → El cargo "Flete": la clave "7" apunta a una linea
+--   --                          que no existe: la compra tiene 1 (indices 0 a 0)
+--   --   linea con cantidad 0 → El cargo "Flete" reparte sobre la linea 0 que
+--   --                          tiene cantidad 0 ...
+--   --
+--   -- Ojo con leerlos: registrar_compra_completa termina en
+--   -- `EXCEPTION WHEN OTHERS THEN RETURN jsonb_build_object('success', false, ...)`,
+--   -- así que el RAISE no sale como error de SQL sino como
+--   -- {"success": false, "error": "..."} — y el bloque plpgsql revierte todo lo
+--   -- que la RPC había escrito. La compra NO queda a medias.
+--
+--   -- Y que el reparto cuadra contra los unitarios guardados:
+--   SELECT cc.concepto, cc.monto,
+--          sum(ci.cargos_unitarios * ci.cantidad) AS reconstruido
+--     FROM compra_cargos cc
+--     JOIN compra_cargo_repartos r ON r.cargo_id = cc.id
+--     JOIN compra_items ci ON ci.id = r.compra_item_id
+--    WHERE cc.compra_id = <id> AND NOT cc.condicion_iva = 'gravado'
+--    GROUP BY cc.concepto, cc.monto;
+--   -- El reconstruido puede diferir del monto por menos de un centavo por línea:
+--   -- cargos_unitarios es numeric(12,4) y el cargo se reparte por unidad. El
+--   -- check de integridad tiene que llevar tolerancia, no exigir igualdad.
+--
+--   -- ── TASK 10 · el guard ────────────────────────────────────────────────────
+--   -- 1) Compra CON cargos, editada SIN p_cargos: rechaza y NO toca nada.
+--   SELECT actualizar_compra_items(<id_con_cargos>, '[...]'::jsonb,
+--            0,0,0, auth.uid(), 0,0,0,0,0);
+--   -- {"error": "Esta compra tiene cargos prorrateados. Actualizá la aplicación
+--   --  (recargá la página) antes de editarla.", "success": false}
+--   SELECT count(*) FROM compra_cargos         WHERE compra_id = <id_con_cargos>;
+--   SELECT count(*) FROM compra_cargo_repartos WHERE compra_id = <id_con_cargos>;
+--   -- los dos conteos INTACTOS: el guard devuelve antes del DELETE de las líneas.
+--
+--   -- 2) Compra SIN cargos, editada SIN p_cargos: el camino viejo sigue andando.
+--   SELECT actualizar_compra_items(<id_sin_cargos>, '[...]'::jsonb,
+--            0,0,0, auth.uid(), 0,0,0,0,0);
+--   -- {"success": true, ...} y el mismo costo_real_unitario que antes de la 194.
+--
+--   -- 3) Con p_cargos: se borran los cargos viejos y se reponen contra las
+--   --    líneas NUEVAS (los repartos viejos ya se los llevó el CASCADE).
+--   -- 4) Con p_cargos => '[]': se borran y no se reponen. Es "el usuario sacó
+--   --    todos los cargos", y el costo vuelve a ser el de la compra sin cargos.
+-- ----------------------------------------------------------------------------

--- a/migrations/195_compra_bonificaciones_de_cabecera.sql
+++ b/migrations/195_compra_bonificaciones_de_cabecera.sql
@@ -1,0 +1,371 @@
+-- ============================================================================
+-- 195 · compras.bonificaciones: la cabecera puede restar una bonificación
+-- ============================================================================
+-- El problema, medido sobre la factura testigo A0005-00461415:
+--
+--     compras.total  13.343.741,18
+--     el papel       13.036.957,09
+--     diferencia        306.784,09   ← las tres bonificaciones gravadas
+--
+-- La cabecera no tiene dónde restarlas. `compras.subtotal` es el neto de los
+-- RENGLONES —lo clava `COMPRA-A2` contra SUM(compra_items.subtotal)— y una
+-- bonificación general no es un renglón de producto: es un cargo gravado de la
+-- factura (`compra_cargos` con monto negativo, mig 192). Baja el neto gravado y
+-- por lo tanto el IVA, y los dos ya salen bien del motor desde la 193/194; lo
+-- único que quedaba mal era el TOTAL, y con él `COMPRA-A1`, que exige
+--
+--     total = subtotal + iva + ii + percepciones + no gravado + otros   (mig 178)
+--
+-- y es severidad `high`: `scripts/check-integridad.mjs` corre a diario desde
+-- .github/workflows/integridad.yml y sale con exit 1 ante cualquier high en
+-- rojo. O sea que la primera compra con bonificación general apagaba el gate
+-- entero para todos los demás checks.
+--
+-- De las tres salidas posibles —cambiarle la semántica a `subtotal` (rompe
+-- COMPRA-A2 y 132 compras), cargar la bonificación como renglón negativo (rompe
+-- el stock), o agregar una columna— se eligió la ADITIVA: una columna nueva que
+-- entra a la identidad. No toca `subtotal`, no toca ningún check existente, y
+-- con `bonificaciones = 0` —las 132 compras de hoy— la identidad nueva ES la
+-- vieja, así que el check no puede ponerse rojo por esta migración.
+--
+-- EL SIGNO. La columna guarda la Σ de los cargos gravados en factura TAL CUAL,
+-- con su signo: negativa cuando son bonificaciones, que es el único caso que se
+-- ve hoy. Es el mismo número y el mismo signo que `compra_cargos.monto`, sin
+-- traducción en el medio, y deja la identidad puramente aditiva. Un
+-- `bonificaciones = -306784.09` se lee raro la primera vez; una columna que a
+-- veces se suma y a veces se resta se lee mal siempre.
+--
+-- Se parchea leyendo el catálogo y exigiendo que cada ancla aparezca una sola
+-- vez (patrón de las migs 176/177/178/191/194): si un cuerpo derivó, la
+-- migración falla en vez de aplicar un parche parcial.
+--
+-- LAS DOS RPCs CAMBIAN DE FIRMA, así que la vieja se DROPEA en la misma
+-- transacción. Dejar la de N argumentos junto a la de N+1 con DEFAULT reproduce
+-- la trampa de la mig 176: rangos de aridad superpuestos → PGRST203 en runtime,
+-- invisible para tsc y para los tests. `cambiar_proveedor_compra` no cambia de
+-- firma —sólo copia una columna más al clonar— así que va con CREATE OR REPLACE.
+-- ============================================================================
+
+BEGIN;
+
+-- ----------------------------------------------------------------------------
+-- 0 · Helper de parcheo: reemplaza exigiendo que el ancla sea única
+-- ----------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public._mig195_reemplazo_unico(
+  p_texto text, p_ancla text, p_nuevo text, p_donde text
+) RETURNS text LANGUAGE plpgsql IMMUTABLE AS $helper$
+DECLARE
+  v_veces integer;
+BEGIN
+  v_veces := (length(p_texto) - length(replace(p_texto, p_ancla, ''))) / length(p_ancla);
+  IF v_veces <> 1 THEN
+    RAISE EXCEPTION 'mig 195 · % : el ancla "%" aparece % veces (se esperaba 1). El cuerpo derivó del texto conocido; revisá el parche antes de aplicar.',
+      p_donde, left(p_ancla, 90), v_veces;
+  END IF;
+  RETURN replace(p_texto, p_ancla, p_nuevo);
+END;
+$helper$;
+
+-- ----------------------------------------------------------------------------
+-- 1 · La columna
+--
+-- NOT NULL DEFAULT 0: el 0 es "esta factura no trae bonificación general", que
+-- es lo que pasa en las 132 compras existentes y lo que preserva la identidad
+-- vieja. NULL no significaría nada distinto y obligaría a un COALESCE más en
+-- cada lectura.
+-- ----------------------------------------------------------------------------
+ALTER TABLE public.compras
+  ADD COLUMN IF NOT EXISTS bonificaciones numeric(12,2) NOT NULL DEFAULT 0;
+
+COMMENT ON COLUMN public.compras.bonificaciones IS
+  'Suma de los cargos GRAVADOS que vienen impresos en la factura (compra_cargos '
+  'con condicion_iva=''gravado'' y en_factura), CON SU SIGNO: negativa cuando son '
+  'bonificaciones generales, que es el caso normal. Existe porque compras.subtotal '
+  'es el neto de los RENGLONES —lo clava COMPRA-A2 contra SUM(compra_items.subtotal)— '
+  'y una bonificacion general no es un renglon de producto: sin esta columna el '
+  'total de cabecera quedaba por encima del papel (306.784,09 en la factura testigo '
+  'A0005-00461415) y COMPRA-A1 se ponia rojo. Entra a la identidad del check: '
+  'total = subtotal + bonificaciones + iva + ii + percepciones + no_gravado + otros. '
+  'Se suman los MONTOS y no el prorrateo, igual que no_gravado: la cabecera cuadra '
+  'contra el papel, no contra el reparto. En ZZ es 0 (no hay comprobante). '
+  'mig 195.';
+
+-- ----------------------------------------------------------------------------
+-- 2 · registrar_compra_completa recibe y persiste la bonificación de cabecera
+--
+-- Cinco parches sobre el cuerpo vivo: la firma, la variable, la normalización
+-- (0 en ZZ, como el IVA y las percepciones), el INSERT y el control blando de
+-- cuadre contra p_total.
+-- ----------------------------------------------------------------------------
+DO $mig$
+DECLARE
+  v_vieja constant text := 'public.registrar_compra_completa(bigint,character varying,character varying,date,numeric,numeric,numeric,numeric,character varying,text,uuid,jsonb,character varying,numeric,numeric,numeric,numeric,jsonb,jsonb)';
+  v_nueva constant text := 'public.registrar_compra_completa(bigint,character varying,character varying,date,numeric,numeric,numeric,numeric,character varying,text,uuid,jsonb,character varying,numeric,numeric,numeric,numeric,jsonb,jsonb,numeric)';
+  v_def   text;
+BEGIN
+  -- Idempotencia por FIRMA y no por marca en el cuerpo: es lo único que no puede
+  -- dar un falso positivo si mañana alguien menciona "mig 195" en un comentario.
+  IF to_regprocedure(v_nueva) IS NOT NULL AND to_regprocedure(v_vieja) IS NULL THEN
+    RAISE NOTICE 'mig 195 · registrar_compra_completa ya migrada, se omite';
+    RETURN;
+  END IF;
+  IF to_regprocedure(v_vieja) IS NULL THEN
+    RAISE EXCEPTION 'mig 195 · no existe % en el catálogo. Esta migración parchea el cuerpo vivo: revisá qué le pasó antes de seguir.', v_vieja;
+  END IF;
+
+  v_def := pg_get_functiondef(to_regprocedure(v_vieja));
+
+  -- a) firma
+  v_def := public._mig195_reemplazo_unico(v_def,
+    $a$p_ii_declarado jsonb DEFAULT '{}'::jsonb)$a$,
+    $a$p_ii_declarado jsonb DEFAULT '{}'::jsonb, p_bonificaciones numeric DEFAULT 0)$a$,
+    'registrar_compra_completa · firma');
+
+  -- b) variable
+  v_def := public._mig195_reemplazo_unico(v_def,
+    '  v_no_gravado_hdr      NUMERIC;
+',
+    '  v_no_gravado_hdr      NUMERIC;
+  v_bonif_hdr           NUMERIC;    -- mig 195 · bonificaciones gravadas de la factura
+',
+    'registrar_compra_completa · declaraciones');
+
+  -- c) normalización: 0 en ZZ, con el mismo criterio que el IVA
+  v_def := public._mig195_reemplazo_unico(v_def,
+    '  v_no_gravado_hdr := CASE WHEN v_es_zz THEN 0 ELSE COALESCE(p_no_gravado, 0) END;
+',
+    '  v_no_gravado_hdr := CASE WHEN v_es_zz THEN 0 ELSE COALESCE(p_no_gravado, 0) END;
+  v_bonif_hdr      := CASE WHEN v_es_zz THEN 0 ELSE COALESCE(p_bonificaciones, 0) END;  /* mig 195 */
+',
+    'registrar_compra_completa · normalizacion');
+
+  -- d) INSERT
+  v_def := public._mig195_reemplazo_unico(v_def,
+    '    no_gravado, otros_impuestos, total, forma_pago, notas,
+',
+    '    no_gravado, bonificaciones, otros_impuestos, total, forma_pago, notas,
+',
+    'registrar_compra_completa · columnas del INSERT');
+  v_def := public._mig195_reemplazo_unico(v_def,
+    '    v_no_gravado_hdr, COALESCE(p_otros_impuestos, 0), p_total, p_forma_pago, p_notas,
+',
+    '    v_no_gravado_hdr, v_bonif_hdr, COALESCE(p_otros_impuestos, 0), p_total, p_forma_pago, p_notas,
+',
+    'registrar_compra_completa · valores del INSERT');
+
+  -- e) control blando de cuadre: la misma identidad que COMPRA-A1
+  v_def := public._mig195_reemplazo_unico(v_def,
+    '         + v_perc_iibb_hdr + v_no_gravado_hdr + COALESCE(p_otros_impuestos, 0)
+',
+    '         + v_perc_iibb_hdr + v_no_gravado_hdr + v_bonif_hdr + COALESCE(p_otros_impuestos, 0)
+',
+    'registrar_compra_completa · cuadre');
+
+  EXECUTE v_def;
+  EXECUTE format('DROP FUNCTION %s', v_vieja);
+END;
+$mig$;
+
+-- `pg_get_functiondef` no trae los GRANT: la función nueva nace con los
+-- privilegios por defecto del rol que aplique. Sin esto se puede reabrir a
+-- PUBLIC lo que cerraron las migs 188/189 y poner en rojo el gate de permisos.
+REVOKE ALL ON FUNCTION public.registrar_compra_completa(bigint,character varying,character varying,date,numeric,numeric,numeric,numeric,character varying,text,uuid,jsonb,character varying,numeric,numeric,numeric,numeric,jsonb,jsonb,numeric) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.registrar_compra_completa(bigint,character varying,character varying,date,numeric,numeric,numeric,numeric,character varying,text,uuid,jsonb,character varying,numeric,numeric,numeric,numeric,jsonb,jsonb,numeric) TO authenticated, service_role;
+
+-- ----------------------------------------------------------------------------
+-- 3 · actualizar_compra_items conserva la bonificación al editar
+--
+-- `NULL` = "no me lo mandaste, dejá lo que había", igual que las percepciones y
+-- el no gravado. Es lo que evita que un cliente con el bundle viejo le borre la
+-- bonificación de cabecera a una compra al editarle una cantidad — y con eso le
+-- vuelva a inflar el total 306.784,09 y ponga COMPRA-A1 en rojo.
+-- ----------------------------------------------------------------------------
+DO $mig$
+DECLARE
+  v_vieja constant text := 'public.actualizar_compra_items(bigint,jsonb,numeric,numeric,numeric,uuid,numeric,numeric,numeric,numeric,numeric,jsonb,jsonb)';
+  v_nueva constant text := 'public.actualizar_compra_items(bigint,jsonb,numeric,numeric,numeric,uuid,numeric,numeric,numeric,numeric,numeric,jsonb,jsonb,numeric)';
+  v_def   text;
+BEGIN
+  IF to_regprocedure(v_nueva) IS NOT NULL AND to_regprocedure(v_vieja) IS NULL THEN
+    RAISE NOTICE 'mig 195 · actualizar_compra_items ya migrada, se omite';
+    RETURN;
+  END IF;
+  IF to_regprocedure(v_vieja) IS NULL THEN
+    RAISE EXCEPTION 'mig 195 · no existe % en el catálogo. Esta migración parchea el cuerpo vivo: revisá qué le pasó antes de seguir.', v_vieja;
+  END IF;
+
+  v_def := pg_get_functiondef(to_regprocedure(v_vieja));
+
+  v_def := public._mig195_reemplazo_unico(v_def,
+    $a$p_ii_declarado jsonb DEFAULT NULL::jsonb)$a$,
+    $a$p_ii_declarado jsonb DEFAULT NULL::jsonb, p_bonificaciones numeric DEFAULT NULL::numeric)$a$,
+    'actualizar_compra_items · firma');
+
+  v_def := public._mig195_reemplazo_unico(v_def,
+    '         no_gravado         = CASE WHEN v_es_zz THEN 0 ELSE COALESCE(p_no_gravado, no_gravado) END,
+',
+    '         no_gravado         = CASE WHEN v_es_zz THEN 0 ELSE COALESCE(p_no_gravado, no_gravado) END,
+         bonificaciones     = CASE WHEN v_es_zz THEN 0 ELSE COALESCE(p_bonificaciones, bonificaciones) END,  /* mig 195 */
+',
+    'actualizar_compra_items · UPDATE de la cabecera');
+
+  EXECUTE v_def;
+  EXECUTE format('DROP FUNCTION %s', v_vieja);
+END;
+$mig$;
+
+REVOKE ALL ON FUNCTION public.actualizar_compra_items(bigint,jsonb,numeric,numeric,numeric,uuid,numeric,numeric,numeric,numeric,numeric,jsonb,jsonb,numeric) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.actualizar_compra_items(bigint,jsonb,numeric,numeric,numeric,uuid,numeric,numeric,numeric,numeric,numeric,jsonb,jsonb,numeric) TO authenticated, service_role;
+
+-- ----------------------------------------------------------------------------
+-- 4 · cambiar_proveedor_compra clona también la bonificación
+--
+-- Esta RPC anula la compra y la clona contra otro proveedor con una lista de
+-- columnas EXPLÍCITA. Una columna que no esté en esa lista cae al DEFAULT: el
+-- clon nacería con bonificaciones = 0 y el mismo `total`, o sea violando
+-- COMPRA-A1 desde el minuto cero. La firma no cambia, así que va por CREATE OR
+-- REPLACE y no hace falta dropear nada.
+-- ----------------------------------------------------------------------------
+DO $mig$
+DECLARE
+  v_firma constant text := 'public.cambiar_proveedor_compra(bigint,uuid,bigint,character varying,text)';
+  v_def   text;
+BEGIN
+  IF to_regprocedure(v_firma) IS NULL THEN
+    RAISE EXCEPTION 'mig 195 · no existe % en el catálogo.', v_firma;
+  END IF;
+  v_def := pg_get_functiondef(to_regprocedure(v_firma));
+
+  IF position('c.bonificaciones' in v_def) > 0 THEN
+    RAISE NOTICE 'mig 195 · cambiar_proveedor_compra ya clona la bonificación, se omite';
+    RETURN;
+  END IF;
+
+  v_def := public._mig195_reemplazo_unico(v_def,
+    '    subtotal, iva, impuestos_internos, percepcion_iva, percepcion_iibb, no_gravado,
+',
+    '    subtotal, iva, impuestos_internos, percepcion_iva, percepcion_iibb, no_gravado,
+    bonificaciones, /* mig 195 */
+',
+    'cambiar_proveedor_compra · columnas del clon');
+
+  v_def := public._mig195_reemplazo_unico(v_def,
+    '    c.subtotal, c.iva, c.impuestos_internos, c.percepcion_iva, c.percepcion_iibb, c.no_gravado,
+',
+    '    c.subtotal, c.iva, c.impuestos_internos, c.percepcion_iva, c.percepcion_iibb, c.no_gravado,
+    c.bonificaciones, /* mig 195 */
+',
+    'cambiar_proveedor_compra · valores del clon');
+
+  EXECUTE v_def;
+END;
+$mig$;
+
+-- ----------------------------------------------------------------------------
+-- 5 · COMPRA-A1 incluye la columna nueva en la identidad
+--
+-- Mismo patrón que la mig 178. Con `bonificaciones = 0` la fórmula nueva es
+-- idéntica a la vieja, así que las 132 compras existentes siguen en verde por
+-- construcción y no por suerte.
+-- ----------------------------------------------------------------------------
+DO $mig$
+DECLARE
+  v_def   text;
+  v_ancla CONSTANT text := $a$('COMPRA-A1','high','compras.total = subtotal+iva+ii+percepciones+no gravado+otros (mig 178)',
+      (SELECT count(*) FROM compras WHERE estado<>'cancelada' AND abs(COALESCE(total,0)-(
+        COALESCE(subtotal,0)+COALESCE(iva,0)+COALESCE(impuestos_internos,0)
+        +COALESCE(percepcion_iva,0)+COALESCE(percepcion_iibb,0)
+        +COALESCE(no_gravado,0)+COALESCE(otros_impuestos,0)))>1.0)),$a$;
+  v_nuevo CONSTANT text := $a$('COMPRA-A1','high','compras.total = subtotal+bonificaciones+iva+ii+percepciones+no gravado+otros (mig 195)',
+      (SELECT count(*) FROM compras WHERE estado<>'cancelada' AND abs(COALESCE(total,0)-(
+        COALESCE(subtotal,0)+COALESCE(bonificaciones,0)+COALESCE(iva,0)+COALESCE(impuestos_internos,0)
+        +COALESCE(percepcion_iva,0)+COALESCE(percepcion_iibb,0)
+        +COALESCE(no_gravado,0)+COALESCE(otros_impuestos,0)))>1.0)),$a$;
+BEGIN
+  v_def := pg_get_functiondef('public.auditoria_integridad()'::regprocedure);
+
+  IF position('(mig 195)' in v_def) > 0 THEN
+    RAISE NOTICE 'mig 195 · COMPRA-A1 ya incluye las bonificaciones, se omite';
+    RETURN;
+  END IF;
+
+  EXECUTE public._mig195_reemplazo_unico(v_def, v_ancla, v_nuevo, 'auditoria_integridad · COMPRA-A1');
+END;
+$mig$;
+
+-- ----------------------------------------------------------------------------
+-- 6 · Post-check: nada nace en rojo y no queda ninguna firma ambigua
+--
+-- Se EJECUTA y no se compila: la mig 194 dejó dicho por qué —un `format()` con
+-- un placeholder de más compila perfecto y explota en runtime, y lo agarró el
+-- ensayo al ejecutar, no al crear la función—.
+-- ----------------------------------------------------------------------------
+DO $post$
+DECLARE
+  v_n integer;
+BEGIN
+  SELECT count(*) INTO v_n
+    FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace
+   WHERE n.nspname = 'public'
+     AND p.proname IN ('registrar_compra_completa', 'actualizar_compra_items');
+  IF v_n <> 2 THEN
+    RAISE EXCEPTION 'mig 195 · hay % firmas de las dos RPCs de compra (se esperaban 2). Rangos de aridad superpuestos = PGRST203 en runtime, invisible para tsc y los tests.', v_n
+      USING ERRCODE = '22023';
+  END IF;
+
+  SELECT (a.c->>'violaciones')::int INTO v_n
+    FROM jsonb_array_elements(auditoria_integridad()->'checks') a(c)
+   WHERE a.c->>'id' = 'COMPRA-A1';
+  IF v_n IS NULL THEN
+    RAISE EXCEPTION 'mig 195 · COMPRA-A1 desapareció de auditoria_integridad(): el parche se comió el check.'
+      USING ERRCODE = '22023';
+  END IF;
+  IF v_n <> 0 THEN
+    RAISE EXCEPTION 'mig 195 · COMPRA-A1 queda con % violaciones. Con bonificaciones=0 la identidad nueva ES la vieja, así que esto significa drift previo: revisalo antes de aplicar.', v_n
+      USING ERRCODE = '22023';
+  END IF;
+END;
+$post$;
+
+-- El helper es andamiaje de esta migración, no API: se va con ella.
+DROP FUNCTION IF EXISTS public._mig195_reemplazo_unico(text, text, text, text);
+
+COMMIT;
+
+-- ----------------------------------------------------------------------------
+-- Rollback
+--
+--   BEGIN;
+--     -- 1. desandar el parche de COMPRA-A1 (volver la fórmula al texto de la 178)
+--     -- 2. volver las dos RPCs a su firma anterior leyendo el cuerpo vivo y
+--     --    sacando p_bonificaciones, la variable, el INSERT/UPDATE y el cuadre;
+--     --    después DROP de las firmas de 20 y 14 argumentos.
+--     -- 3. re-otorgar los privilegios, que el CREATE no restaura solo.
+--     -- 4. recién ahí: ALTER TABLE compras DROP COLUMN bonificaciones;
+--   COMMIT;
+--
+-- El orden importa: dropear la columna antes que el check deja
+-- auditoria_integridad() referenciando una columna que no existe y TODOS los
+-- checks se caen juntos, no sólo COMPRA-A1.
+--
+-- Y sólo es limpio mientras ninguna compra tenga bonificación de cabecera. En
+-- cuanto la tenga, dropear la columna devuelve esa compra al total inflado.
+-- ----------------------------------------------------------------------------
+
+-- ----------------------------------------------------------------------------
+-- Verificación
+--
+--   -- UNA sola firma de cada RPC, con 20 y 14 argumentos:
+--   SELECT proname, pronargs, array_to_string(proacl, ' ')
+--     FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace
+--    WHERE n.nspname = 'public'
+--      AND proname IN ('registrar_compra_completa','actualizar_compra_items');
+--
+--   -- Los checks de compras, todos en verde:
+--   SELECT c->>'id', c->>'severidad', c->>'violaciones'
+--     FROM jsonb_array_elements(auditoria_integridad()->'checks') c
+--    WHERE c->>'id' LIKE 'COMPRA-%';
+--
+--   -- La factura testigo end-to-end (21 renglones, 6 cargos): total contra el
+--   -- papel = 13.036.957,09 y factor de ajuste 1,000000 en las dos alícuotas.
+-- ----------------------------------------------------------------------------

--- a/migrations/MANIFEST.md
+++ b/migrations/MANIFEST.md
@@ -1,6 +1,6 @@
 # MANIFEST de migraciones — mapeo repo ↔ producción
 
-> **Fechado: 2026-08-19** · Proyecto prod `hmuchlzmuqqxcldbzkgc` (ManaosApp) · región `sa-east-1`.
+> **Fechado: 2026-08-20** · Proyecto prod `hmuchlzmuqqxcldbzkgc` (ManaosApp) · región `sa-east-1`.
 
 ## Regla de oro
 
@@ -137,108 +137,90 @@ funcional** y no se renombran los archivos: renombrarlos los desalinearía del l
 real lo da `version` y está en la sección A: en los dos casos el archivo de `main` quedó
 cronológicamente **fuera** del bloque 139–147 (uno antes, otro entre la 144 y la 145).
 
-**La próxima migración es la 192.** Estado al 2026-08-19 (todo lo de abajo está
-aplicado, salvo donde se aclara):
+**La próxima migración es la 197** — la última numerada en el repo es
+`196_espejo_del_motor_de_compras`.
 
-| NN | estado |
-|----|--------|
-| 182 | `182_pagos_fecha_en_hora_argentina` |
-| 183 | `183_cerrar_recorridos_terminados` |
-| 184–185 | **libres en `main`, pero reservadas** por la rama de cargos de compra (ver abajo) |
-| 186 | `186_quien_cruza_de_sucursal` |
-| 187 | `187_la_hija_no_cruza_de_sucursal` |
-| 188 | `188_anon_deja_de_ejecutar_rpcs` |
-| 189 | `189_auditoria_de_permisos_execute` |
-| 190 | `190_guards_de_estado_y_cobranza` |
-| 190b | `190b_pagos_forzar_usuario_no_definer` — aplicada sin archivo; el archivo se escribió después, leyendo el catálogo |
-| 191 | `191_pagos_forzar_usuario_sin_public` |
+La **195** le da a la cabecera la columna `compras.bonificaciones`, que es donde se resta
+una bonificación general: el `subtotal` es el neto de los RENGLONES y lo clava `COMPRA-A2`
+contra `SUM(compra_items.subtotal)`, así que un cargo gravado que no es un renglón de
+producto no tenía dónde ir y dejaba `compras.total` por encima del papel.
 
-> ⚠️ **La rama de cargos de compra (`claude/invoice-cost-calculation-370b62`)
-> tiene `183_compra_cargos_prorrateo.sql` y `184_compra_cargos_funciones.sql`, y
-> la 183 ya la ocupó `183_cerrar_recorridos_terminados` en `main`.** Esa rama hay
-> que renumerarla a 192+ antes de mergear. Es la tercera vez que pasa lo mismo
-> (el `167` duplicado, la 183 que nació 182, y ahora ésta): **el número no se
-> reserva escribiendo el archivo, se reserva aplicando la migración.** Mientras
-> la rama esté abierta el número no es de nadie.
+La **196** es el **espejo del motor**: `espejo_motor_compras(jsonb, integer)` recibe un lote
+de casos con la salida que dio el motor de TypeScript, corre el de SQL sobre la MISMA entrada
+y devuelve las celdas donde no coinciden, comparando con `IS DISTINCT FROM` sobre `numeric`
+—así `500` y `500.00` son el mismo número y un centavo no—. Que sólo una de las dos LANCE
+también cuenta como divergencia. La consume `scripts/espejo-motor-compras.mjs` desde el gate
+de integridad, que es el único lugar con credenciales de servicio. Es la única función de
+este bloque que **no** se le da a `authenticated`: no la llama ni el front ni el bot.
 
-Al elegir número hay que mirar las tres cosas: el ledger, `origin/main` y las
-ramas abiertas.
+La **193** es el motor de cálculo de esos cargos, en SQL, y va entero adentro de un solo
+`BEGIN/COMMIT` porque el motor a medias no sirve para nada. Trae tres cosas:
+`prorratear_cargo(numeric, jsonb)` reparte UN cargo sobre un vector `{id_de_línea: peso}` y
+manda el residuo del redondeo a la línea de mayor peso, para que la suma dé el monto EXACTO;
+`costo_real_unitario` gana un 4º argumento aditivo para los cargos —y se **dropea** la de 3
+en vez de dejar las dos, porque dos sobrecargas con aridades superpuestas dan `PGRST203` en
+runtime, invisible para `tsc` y para los tests (la trampa de la mig 176)—; y
+`calcular_costos_compra(jsonb, jsonb, jsonb)` arma las tres bases (IVA de factura, costo,
+impuesto interno), ajusta el II al declarado por alícuota y devuelve los unitarios por línea
+más los totales. Es **espejo exacto** de `src/utils/prorrateoCompra.ts`: si cambiás una,
+cambiá la otra. Los tres llamadores de `costo_real_unitario` se parchean en la MISMA
+transacción leyendo su cuerpo del **catálogo vivo** con `pg_get_functiondef` —nunca copiando
+el del archivo, que puede estar viejo— y exigiendo que el ancla aparezca exactamente una vez.
+Hoy los tres pasan `0`, así que **ningún costo se mueve**: los cargos de verdad entran en la
+194. **Aplicada a producción el 2026-08-19**, igual que la 192 y la 194.
 
-Las **186** y **187** cierran un agujero de RLS preexistente, encontrado de paso
-al revisar la 183. Las policies de las tablas hijas validan `sucursal_id =
-current_sucursal_id()` sobre la propia fila y **nadie valida que el padre
-referenciado sea de esa misma sucursal**; las FK no pasan por RLS, así que una
-línea podía colgarse de la compra de la otra sucursal, quedar invisible para su
-dueña —la policy de SELECT filtra por el `sucursal_id` de la línea— y moverle el
-costo igual. **Medido contra prod el 2026-08-19: 69 pares y 0 filas cruzadas.**
-Era latente, no un incidente.
+Verificada contra la factura testigo `A0005-00461415` (21 renglones, 13,3 M) con un ensayo
+sobre prod que termina en `RAISE EXCEPTION` para garantizar el rollback: **126 celdas
+comparadas** (21 líneas × 6 campos) con `IS DISTINCT FROM` sobre `numeric` contra la salida
+del TS, **0 divergencias**, y el factor de ajuste del impuesto interno da **1,000000 en las
+dos alícuotas** (8,6956 y 4,1667) — que es el corazón del rediseño: el Excel del gerente
+necesita un 1,0496 puesto a mano, y modelando `afecta_base_ii` cuadra solo.
 
-La **186** es sólo lectura: `auditoria_sucursal_cruzada()` y sus helpers
-`_pares_sucursal_cruzada()` y `_tenant_col_por_tabla()`, que descubren los pares
-hija→padre **del catálogo**, no de una lista. La **187** convierte cada FK de una
-columna en compuesta `(columna, tenant) → padre(id, tenant)`, el mismo patrón
-estructural que la 183 estrena para `compra_cargos`. No toca ni una fila y aborta
-con la lista completa si encuentra alguna cruzada.
+La **192** es el esqueleto de datos de los cargos de compra: `compra_cargos` (flete,
+pallets, separadores, bonificaciones; monto negativo = bonificación) y
+`compra_cargo_repartos` (el vector de pesos, donde un peso 0 excluye la línea y por
+eso el "alcance" no existe como concepto aparte), más el snapshot
+`compra_items.cargos_unitarios`. Todavía **sin funciones**: el motor vive por ahora
+sólo en `src/utils/prorrateoCompra.ts` y las RPC llegan en las migraciones
+siguientes: la **193** trae el motor de cálculo y la **194** las RPCs y el check de
+integridad. Van en archivos separados a propósito — appendearlas a la 192 las dejaría
+fuera de su `BEGIN/COMMIT` y un fallo a mitad daría tablas creadas con RPCs a medias.
+**Aplicada a producción el 2026-08-19**, junto con la 193 y la 194: las tres se aplicaron
+seguidas y verificando entre una y otra (firmas, gate de integridad y que ningún costo ya
+guardado se moviera).
 
-Seis cosas que conviene no volver a descubrir:
+**El rollback deja de ser gratis apenas haya cargos.** Mientras no exista ninguno,
+dropear las dos tablas y la columna devuelve el costo exacto (Σ cargos = 0). En cuanto
+los cargos entren al `costo_real_unitario` y al costo promedio, dropearlas borra CUÁLES
+fueron los cargos pero no los saca de los costos ya calculados: quedan costos que los
+incluyen sin registro de su origen. Desde ahí no es reversible sino
+reversible-con-recálculo, y hay que recomputar antes de dropear. El plan de rollback
+está escrito al pie del archivo.
 
-- **Se eligió FK y no un `EXISTS` en las policies** porque casi toda la escritura
-  de esta base entra por RPCs `SECURITY DEFINER`, que saltean RLS por definición:
-  una policy no las ve pasar. La FK sí. Refuerza el argumento que cinco de estas
-  hijas (`recorrido_cambios`, `promo_acumuladores`, `pedido_item_sustituciones`,
-  `comision_reglas`, `metas_preventista`) tengan **sólo policies de SELECT**: el
-  default-deny de RLS ya les cierra PostgREST, así que su único camino de
-  escritura es justo el que ninguna policy vigila.
-- **El tenant no siempre se llama `sucursal_id`.** `transferencias_stock` tiene
-  las dos columnas: `tenant_sucursal_id` es el tenant (es la que usa su policy de
-  escritura) y `sucursal_id` es **la otra punta del traslado**. Comparar contra la
-  segunda daba 4 de 13 filas "cruzadas" que son historia correcta —un traslado
-  tiene las dos puntas distintas por definición—; contra la primera dan 0. Si
-  alguien las "arreglaba", rompía datos buenos. De ahí `_tenant_col_por_tabla()`.
-- **`ON DELETE SET NULL` sobre una FK compuesta anula TODAS las columnas
-  referenciantes**, el tenant incluido, que es NOT NULL en 68 de los 69 pares ⇒ el
-  borrado del padre pasaría a fallar con un 23502. Hay que escribirlo
-  `ON DELETE SET NULL (columna)`, que existe recién en **PostgreSQL 15**. Prod
-  corre 17.6, así que el guard de versión de la 187 no va a saltar; queda igual.
-- **Que el tenant sea NOT NULL no es un detalle**: la FK es MATCH SIMPLE y se da
-  por satisfecha si CUALQUIERA de las columnas referenciantes es NULL. Aflojar ese
-  NOT NULL apaga media protección en silencio. El único caso hoy es
-  `comision_reglas.sucursal_id`, nullable a propósito (una regla sin sucursal es
-  global): el reporte lo marca `parcial` en vez de contarlo como cubierto.
-- **Un tenant NULL es "global", no "cruzada".** La primera versión contaba la
-  divergencia con `IS DISTINCT FROM` y una regla de comisión global —tenant NULL
-  contra un producto de otra sucursal— salía como violación, dejando el preflight
-  de la 187 abortando para siempre por una fila legal. El reporte tiene que contar
-  **exactamente** lo que la FK rechaza, o los dos dejan de decir lo mismo.
-- **El reporte cuenta los pares protegidos, no sólo los rotos.** La primera
-  versión sólo miraba FK de una columna y después de la 187 el tablero quedaba
-  vacío: un gate que se apaga solo justo cuando empieza a tener algo que vigilar.
+Tres decisiones de esa 192 que no son obvias leyendo el DDL. Las policies de
+`compra_cargo_repartos` son **cuatro**, no una `FOR ALL`: un reparto es la plata (mueve
+el costo de los productos), así que replica el permiso de `mt_compra_items_*` —depósito
+lee y carga, admin corrige y borra—; una `FOR ALL` que sólo mirara la sucursal le habría
+dado escritura a preventistas y transportistas. Y `compra_cargo_repartos` lleva
+`compra_id` **denormalizado** para poder atar sus dos FK como compuestas contra
+`compra_cargos(id, compra_id)` y `compra_items(id, compra_id)`: sin eso nada impedía que
+un reparto apuntara a la línea de otra compra o de otra sucursal, y no queremos que esa
+garantía dependa de que la RPC se porte bien. De ahí los `UNIQUE (id, compra_id)` en las
+dos tablas padre, redundantes por construcción pero necesarios como destino de la FK.
 
-**Resultado de aplicarlas (2026-08-19):** 69 pares, **69 protegidos**, 0 sin
-proteger, 0 filas cruzadas, 2 parciales (`comision_reglas`). 69 FK compuestas y
-19 UNIQUE nuevas; ningún `SET NULL` quedó sin su lista de columnas.
-`auditoria_integridad()` siguió en `overall_ok = true` con 0 critical/high, y los
-advisors de Supabase no sumaron ningún ERROR. Verificado además en vivo, dentro de
-un bloque que se revierte: el INSERT cruzado y el item de traslado mal etiquetado
-se rechazan con 23503, y el INSERT coherente sigue entrando.
+Y el mismo truco un nivel más arriba: `compra_cargos` referencia
+`compras(id, sucursal_id)`, no `compras(id)`. Cierra un hueco concreto — `es_admin()` es
+global y `current_sucursal_id()` sale del header, así que un admin parado en la sucursal
+A podía colgar un cargo con `sucursal_id = A` sobre una compra de B; la policy de INSERT
+chequea la fila y pasa, y una FK simple no mira la sucursal. Lo peor era que el cargo
+quedaba **invisible** para los usuarios de B, porque la policy de SELECT filtra por la
+sucursal del cargo. El hueco equivalente en `compra_items` (nada ata su `sucursal_id` al
+de `compras`) es preexistente y queda para un trabajo aparte.
 
-Y la razón de fondo para que todo salga del catálogo: **el repo predecía 60 pares
-y prod tiene 69.** Los 9 que faltaban (`comision_reglas`,
-`grupo_precio_escala_minimos`, `metas_preventista`, `productos.categoria_id`,
-`productos.marca_id`, `pedido_item_sustituciones.ajuste_producto_id_nuevo`) los
-encuentra `pg_constraint` y los habría perdido una lista escrita leyendo
-`migrations/`. Es la regla de oro de este archivo, cobrándose una más.
-
-El gate permanente es `scripts/check-sucursal-cruzada.mjs`, un paso más del
-workflow `integridad.yml`: una tabla nueva con `sucursal_id` y FK simple sale en
-rojo al día siguiente. Ése es el punto — el hallazgo no fue "compra_items está
-mal", fue "hay una clase de tabla que está mal y nadie la miraba".
-
-`movimiento_sucursal_items` **no** está en la lista y no es un olvido: no tiene
-columna de tenant propia, la resuelve por join con el movimiento. Lo que no se
-copia no puede contradecirse. Igual `compra_cargo_repartos` (183), y por eso
-`movimientos_sucursal` —que sólo tiene `sucursal_origen_id` y
-`sucursal_destino_id`— ni siquiera entra al análisis.
+La **182** (`182_pagos_fecha_en_hora_argentina`) no es de esta tanda: entró por `main`
+mientras la rama de compras estaba abierta. Cambia el default de `pagos.fecha` a hora
+argentina porque la base corre en UTC y entre las 21:00 y las 24:00 ART `CURRENT_DATE`
+fechaba el cobro al día siguiente. 0 casos en prod; no reescribe filas.
 
 La **181** cierra la otra mitad de la auditoría adversarial: las invariantes que
 vivían en el front. Trigger `pedidos_proteger_columnas` (el chofer sólo escribe
@@ -381,6 +363,28 @@ día siguiente. Ese es exactamente el escenario para el que existe el gate: el p
 saca a `anon` del default privilege, pero **a PUBLIC no lo puede sacar** (medido, ver la
 migración), así que toda función nueva sigue naciendo con PUBLIC y **cada migración tiene que
 revocarlo**. Ver `README.md § Permisos`.
+
+**Y `ls migrations/` tampoco alcanza solo: hay que preguntarle al ledger.** La tanda de
+cargos de compra nació como 182 y terminó siendo 183. El worktree venía de un commit de 6
+atrás, y desde adentro `ls migrations/` mostraba la 181 como última: la 182 ya existía en
+`origin/main` y estaba aplicada en prod desde hacía un día, pero el árbol local no la veía.
+Un worktree o una rama larga esconden exactamente este choque, y no lo detecta ningún test
+—dos migraciones con el mismo número no rompen nada hasta que hay que aplicarlas—.
+
+**Y le volvió a pasar a la misma tanda, DOS veces más, así que la regla de arriba no era
+suficiente.** Con el motor ya escrito como 184, otras tres ramas aplicaron
+`183_cerrar_recorridos_terminados` y las 186–189; el ledger llegó a 189 y las tres pasaron a
+**190** (tablas), **191** (funciones) y **192** (RPCs). Y ahí se las volvieron a comer:
+antes de aplicarlas entraron `190_guards_de_estado_y_cobranza`,
+`190b_pagos_forzar_usuario_no_definer` y `191_pagos_forzar_usuario_sin_public`, así que
+terminaron en **192** (tablas), **193** (funciones) y **194** (RPCs), que es donde están
+aplicadas. A la tercera la regla se siguió al pie: se reconfirmó contra el ledger en el
+minuto anterior a aplicar. Son **TRES** las fuentes que pueden ocupar un número —
+`origin/main`, el ledger de prod y **las ramas abiertas de los demás**— y a la tercera no se
+la puede consultar de forma confiable. Por eso la regla ya no es a quién preguntarle sino
+**cuándo**: elegí el número **al final, justo antes de aplicar**. Numerar al empezar es
+reservar algo que no se puede reservar, y el costo de renumerar después no es `git mv` — es
+la prosa, que ningún reemplazo mecánico agarra.
 
 ---
 


### PR DESCRIPTION
**2 de 4.** Va sobre #485. Espejo en la base del motor del PR anterior.

> **Ya están APLICADAS a producción** (ledger 2026-08-19). Son **inertes**: el front todavía no manda los parámetros nuevos, así que las 132 compras existentes no se movieron un centavo. Verificado fila por fila con `xmin`: ninguna fue escrita en la ventana de las migraciones.

## 192 — Tablas

`compra_cargos` y `compra_cargo_repartos`, con RLS espejo de `compra_items`, y **FK compuestas** que hacen estructuralmente imposible que un reparto cruce de compra o de sucursal.

Eso último no es paranoia: la RLS de la hija no mira la sucursal del padre, y las RPCs `SECURITY DEFINER` saltean RLS. Un admin parado en una sucursal podía colgar un cargo sobre la compra de otra — y quedaba **invisible para los dueños de esa compra**, porque la policy de lectura filtra por la sucursal del cargo.

## 193 — El motor en SQL

`prorratear_cargo`, `calcular_costos_compra`, y `costo_real_unitario` con un cuarto término.

La versión de 3 argumentos **se dropea** en lugar de dejarla junto a una de 4 con `DEFAULT`: dos sobrecargas con rangos de aridad superpuestos dan `PGRST203` en runtime, invisible para `tsc` y para los tests. Sus tres llamadores se parchean **leyendo el catálogo vivo**, no copiando cuerpos del repo, porque `migrations/` no es 1:1 con producción.

## 194 — Las RPCs

`registrar_compra_completa` y `actualizar_compra_items` aceptan los cargos y la apertura del impuesto interno; `cambiar_proveedor_compra` los clona.

**Tres guards contra el borrado silencioso.** `actualizar_compra_items` hace `DELETE FROM compra_items`, que por CASCADE vacía los repartos: los cargos sobrevivirían con vector vacío y el flete dejaría de repartirse **sin que nada grite**, porque el motor trata "vector vacío" como legal. Un cliente con un bundle viejo rebota con un mensaje en vez de destruir el costo.

## 195 — La columna de bonificaciones

`compras.total` no cerraba contra el papel: no había dónde restar una bonificación gravada sin romper `COMPRA-A1`.

## Una decisión que conviene mirar

**En ZZ el cargo también suma.** El tipo de factura decide si se agregan **impuestos** encima, no si se ignoran **costos**: en ZZ lo pagado ya incluye IVA e impuestos internos porque son de esa misma operación, pero un flete que factura un tercero no está adentro de ese precio. Es el **47,9%** de las compras.

## Verificación

Cada migración se ensayó entera contra producción dentro de un bloque que termina lanzando una excepción (rollback garantizado), con el SQL generado desde el `.sql` real y verificado por `md5`. El check `COMPRA-A3` nace en verde y **muerde** (probado ensuciando un `cargos_unitarios` a mano).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
