### PR TITLE
Cargar flete, pallets y bonificaciones desde el modal de compras

### DIFF
--- a/src/components/containers/ComprasContainer.tsx
+++ b/src/components/containers/ComprasContainer.tsx
@@ -41,6 +41,27 @@ const ModalEditarCompra = lazyWithReload(() => import('../modals/ModalEditarComp
 const ModalCambiarProveedor = lazyWithReload(() => import('../modals/ModalCambiarProveedor'))
 const ModalConfirmacion = lazyWithReload(() => import('../modals/ModalConfirmacion'))
 
+/**
+ * Muestra los avisos blandos que devuelven las RPCs de compra.
+ *
+ * La RPC no puede saber cuál de los dos números que el usuario tipeó está bien
+ * —el total del papel o la suma de las líneas, el II de cabecera o su apertura
+ * por alícuota— así que no pisa ninguno, deja los dos como llegaron y avisa.
+ * El texto sube tal cual: reescribirlo acá haría que la app y la base cuenten
+ * la misma diferencia con dos números distintos.
+ *
+ * `persist` porque son la clase de aviso que se lee después: el toast dura 4
+ * segundos y un descuadre de factura se revisa contra el papel, no al vuelo.
+ */
+function avisosDeLaBase(
+  notify: { warning: (message: string, options?: { persist?: boolean }) => void },
+  ...mensajes: Array<string | null | undefined>
+): void {
+  for (const mensaje of mensajes) {
+    if (mensaje) notify.warning(mensaje, { persist: true })
+  }
+}
+
 function LoadingState() {
   return (
     <div className="flex items-center justify-center py-20">
@@ -139,8 +160,14 @@ export default function ComprasContainer(): React.ReactElement {
 
   const handleGuardarCompra = useCallback(async (data: CompraFormInputExtended) => {
     try {
-      await registrarCompra.mutateAsync({ ...data, usuarioId: user?.id ?? null })
+      const res = await registrarCompra.mutateAsync({ ...data, usuarioId: user?.id ?? null })
       notify.success('Compra registrada')
+      // Los avisos de la RPC, que hasta acá se descartaban. Son blandos: la
+      // compra YA está registrada, por eso van como warning y no como error, y
+      // persisten en el centro de notificaciones — el toast del éxito los tapa
+      // en la pantalla y el descuadre de una factura es justo lo que hay que
+      // poder releer después.
+      avisosDeLaBase(notify, res.warningDescuadre, res.warningIiDeclarado)
     } catch (err) {
       const msg = err instanceof Error ? err.message : 'Error al registrar compra'
       notify.error(msg)
@@ -194,6 +221,9 @@ export default function ComprasContainer(): React.ReactElement {
     try {
       const res = await actualizarCompra.mutateAsync(input)
       notify.success('Compra actualizada')
+      // Editar los items puede dejar el II declarado sin cuadrar (una línea que
+      // se fue se lleva su alícuota). La RPC avisa; acá se muestra.
+      avisosDeLaBase(notify, null, res.warningIiDeclarado)
       // CPP forward-only (mig 128): editar una compra que NO es la última del
       // producto no re-promedia el costo — avisar para corregirlo en la ficha.
       if (res.warningCostoPromedio.length > 0) {

--- a/src/components/modals/ModalCompra.reducer.test.ts
+++ b/src/components/modals/ModalCompra.reducer.test.ts
@@ -1,0 +1,615 @@
+/**
+ * Vector de pesos de los cargos de compra, a nivel reducer.
+ *
+ * Se testea el reducer y no el DOM porque lo que puede corromper un costo en
+ * silencio vive acá: qué peso se pre-llena, cuál se pisa y cuál no, y qué pasa
+ * con el vector cuando cambian las líneas. Un peso que queda pegado al producto
+ * equivocado no rompe ninguna pantalla; sólo reparte mal el flete.
+ */
+import { describe, it, expect } from 'vitest'
+import {
+  compraReducer, initialState, lineasParaMotor, cargosParaMotor,
+  cuadreImpuestoInterno, DESVIO_II_TOLERADO, cargosPlantillaNuevos,
+  cargosParaRPC, validarCargos, resolucionBasesII,
+} from './ModalCompra.reducer'
+import type { CompraState } from './ModalCompra.reducer'
+import type { CargoPlantillaCompra } from '../../types'
+import { prorratearCargo, calcularCostosCompra } from '../../utils/prorrateoCompra'
+import type { ProductoDB } from '../../types'
+
+type Accion = Parameters<typeof compraReducer>[1]
+
+const producto = (id: string, costo: number): ProductoDB => ({
+  id,
+  nombre: `Producto ${id}`,
+  codigo: id,
+  costo_sin_iva: costo,
+  impuestos_internos: 0,
+  porcentaje_iva: 21,
+  condicion_iva: 'gravado',
+  stock: 10,
+} as unknown as ProductoDB)
+
+const correr = (acciones: Accion[], desde: CompraState = initialState): CompraState =>
+  acciones.reduce(compraReducer, desde)
+
+/** Estado con dos líneas (neto 100 y 300) y un cargo recién agregado. */
+const conDosLineasYUnCargo = () => correr([
+  { type: 'AGREGAR_ITEM', payload: producto('a', 100) },
+  { type: 'AGREGAR_ITEM', payload: producto('b', 300) },
+  { type: 'AGREGAR_CARGO' },
+])
+
+describe('cargos: pre-llenado del vector de pesos', () => {
+  it('numera las lineas y pre-llena por monto al agregar el cargo', () => {
+    const s = conDosLineasYUnCargo()
+    expect(s.items.map(i => i.lineaId)).toEqual([1, 2])
+    expect(s.cargos[0].baseProrrateo).toBe('monto')
+    expect(s.cargos[0].pesos).toEqual({ 1: 100, 2: 300 })
+  })
+
+  it('pre-llena por cantidad y en partes iguales', () => {
+    const base = correr([
+      { type: 'AGREGAR_ITEM', payload: producto('a', 100) },
+      { type: 'AGREGAR_ITEM', payload: producto('b', 300) },
+      { type: 'ACTUALIZAR_ITEM', payload: { index: 1, campo: 'cantidad', valor: 5 } },
+      { type: 'AGREGAR_CARGO' },
+    ])
+    const id = base.cargos[0].id
+
+    const porCantidad = correr([
+      { type: 'ACTUALIZAR_CARGO', payload: { id, cambios: { baseProrrateo: 'cantidad' } } },
+    ], base)
+    expect(porCantidad.cargos[0].pesos).toEqual({ 1: 1, 2: 5 })
+
+    const partesIguales = correr([
+      { type: 'ACTUALIZAR_CARGO', payload: { id, cambios: { baseProrrateo: 'unidades' } } },
+    ], base)
+    expect(partesIguales.cargos[0].pesos).toEqual({ 1: 1, 2: 1 })
+  })
+
+  it('no arrastra la cola binaria del neto al campo de peso', () => {
+    const s = correr([
+      { type: 'AGREGAR_ITEM', payload: producto('a', 158823.76) },
+      { type: 'ACTUALIZAR_ITEM', payload: { index: 0, campo: 'bonificacion', valor: 0.6 } },
+      { type: 'AGREGAR_CARGO' },
+    ])
+    // 158823,76 × 0,994 = 157870,81744 → 4 decimales, la precision de
+    // compra_cargo_repartos.peso. Sin redondear, el campo mostraria la cola entera.
+    expect(String(s.cargos[0].pesos[1])).toBe('157870.8174')
+  })
+})
+
+describe('cargos: el vector sigue a las lineas', () => {
+  it('respeta el peso tipeado a mano al agregar, editar y quitar lineas', () => {
+    const base = conDosLineasYUnCargo()
+    const id = base.cargos[0].id
+
+    // Peso 0 = excluir la linea. Es el caso que NO se puede pisar.
+    let s = correr([
+      { type: 'ACTUALIZAR_CARGO', payload: { id, cambios: { monto: 400 } } },
+      { type: 'SET_PESO_CARGO', payload: { cargoId: id, lineaId: 2, peso: 0 } },
+    ], base)
+    expect(prorratearCargo(s.cargos[0].monto, s.cargos[0].pesos)).toEqual({ 1: 400, 2: 0 })
+
+    s = correr([{ type: 'AGREGAR_ITEM', payload: producto('c', 50) }], s)
+    expect(s.cargos[0].pesos).toEqual({ 1: 100, 2: 0, 3: 50 })
+
+    // Cambiar un costo re-calcula lo automatico y deja quieto lo manual: si no,
+    // el flete se repartiria con los numeros de antes sin avisar.
+    s = correr([{ type: 'ACTUALIZAR_ITEM', payload: { index: 0, campo: 'costoUnitario', valor: 200 } }], s)
+    expect(s.cargos[0].pesos).toEqual({ 1: 200, 2: 0, 3: 50 })
+
+    // Al borrar una linea su peso sale del vector; si quedara, prorratearCargo
+    // le asignaria plata y la grilla dejaria de sumar el monto del cargo.
+    s = correr([{ type: 'ELIMINAR_ITEM', payload: 1 }], s)
+    expect(s.cargos[0].pesos).toEqual({ 1: 200, 3: 50 })
+    expect(Object.values(prorratearCargo(400, s.cargos[0].pesos)).reduce((a, v) => a + v, 0)).toBe(400)
+  })
+
+  it('re-elegir la base es la salida: borra las marcas de manual', () => {
+    const base = conDosLineasYUnCargo()
+    const id = base.cargos[0].id
+    const s = correr([
+      { type: 'SET_PESO_CARGO', payload: { cargoId: id, lineaId: 1, peso: 999 } },
+      { type: 'ACTUALIZAR_CARGO', payload: { id, cambios: { baseProrrateo: 'unidades' } } },
+    ], base)
+    expect(s.cargos[0].pesos).toEqual({ 1: 1, 2: 1 })
+  })
+
+  it('quitar un cargo no toca a los demas', () => {
+    const base = correr([{ type: 'AGREGAR_CARGO' }], conDosLineasYUnCargo())
+    const [primero, segundo] = base.cargos
+    const s = correr([{ type: 'ELIMINAR_CARGO', payload: primero.id }], base)
+    expect(s.cargos.map(c => c.id)).toEqual([segundo.id])
+    expect(s.cargos[0].pesos).toEqual({ 1: 100, 2: 300 })
+  })
+})
+
+describe('cargos: plantilla del proveedor', () => {
+  const plantilla = (over: Partial<CargoPlantillaCompra> = {}): CargoPlantillaCompra => ({
+    concepto: 'Flete y descarga',
+    condicionIva: 'no_gravado',
+    enFactura: true,
+    prorrateaAlCosto: true,
+    afectaBaseII: false,
+    baseProrrateo: 'monto',
+    pesosPorProducto: { a: 40, b: 60 },
+    ...over,
+  })
+
+  it('remapea los pesos por producto y deja el monto en 0', () => {
+    const s = correr([
+      { type: 'AGREGAR_ITEM', payload: producto('a', 100) },
+      { type: 'AGREGAR_ITEM', payload: producto('b', 300) },
+      { type: 'APLICAR_CARGOS_PLANTILLA', payload: [plantilla()] },
+    ])
+    expect(s.cargos).toHaveLength(1)
+    expect(s.cargos[0].concepto).toBe('Flete y descarga')
+    expect(s.cargos[0].monto).toBe(0)
+    expect(s.cargos[0].pesos).toEqual({ 1: 40, 2: 60 })
+  })
+
+  it('la linea que no matchea ningun producto de la plantilla queda en 0', () => {
+    // Y en 0 se QUEDA: si el pre-llenado por monto la pisara, el separador del
+    // bidon terminaria repartido sobre toda la factura.
+    const s = correr([
+      { type: 'AGREGAR_ITEM', payload: producto('a', 100) },
+      { type: 'AGREGAR_ITEM', payload: producto('z', 900) },
+      { type: 'APLICAR_CARGOS_PLANTILLA', payload: [plantilla({ pesosPorProducto: { a: 7 } })] },
+    ])
+    expect(s.cargos[0].pesos).toEqual({ 1: 7, 2: 0 })
+  })
+
+  it('el peso traido sobrevive a editar la linea, y re-elegir la base lo suelta', () => {
+    const base = correr([
+      { type: 'AGREGAR_ITEM', payload: producto('a', 100) },
+      { type: 'APLICAR_CARGOS_PLANTILLA', payload: [plantilla({ pesosPorProducto: { a: 7 } })] },
+    ])
+    const id = base.cargos[0].id
+
+    // Cambiar la cantidad NO recalcula el peso traido: entra al vector con la
+    // misma marca de manual que un peso tipeado a mano.
+    const editada = correr([
+      { type: 'ACTUALIZAR_ITEM', payload: { index: 0, campo: 'cantidad', valor: 9 } },
+    ], base)
+    expect(editada.cargos[0].pesos).toEqual({ 1: 7 })
+
+    // Una linea AGREGADA despues de traer la plantilla si entra por la base, y
+    // es la misma regla que con los pesos manuales: la plantilla no puede opinar
+    // sobre una linea que no existia cuando se la trajo. El orden natural es
+    // cargar los renglones y despues traer los cargos.
+    const conLineaNueva = correr([{ type: 'AGREGAR_ITEM', payload: producto('b', 300) }], editada)
+    expect(conLineaNueva.cargos[0].pesos).toEqual({ 1: 7, 2: 300 })
+
+    const resoltada = correr([
+      { type: 'ACTUALIZAR_CARGO', payload: { id, cambios: { baseProrrateo: 'monto' } } },
+    ], conLineaNueva)
+    expect(resoltada.cargos[0].pesos).toEqual({ 1: 900, 2: 300 })
+  })
+
+  it('no duplica un concepto ya cargado ni cambia el estado si no hay nada nuevo', () => {
+    const base = correr([
+      { type: 'AGREGAR_ITEM', payload: producto('a', 100) },
+      { type: 'APLICAR_CARGOS_PLANTILLA', payload: [plantilla(), plantilla({ concepto: 'Pallets' })] },
+    ])
+    expect(base.cargos.map(c => c.concepto)).toEqual(['Flete y descarga', 'Pallets'])
+    expect(cargosPlantillaNuevos(base.cargos, [plantilla({ concepto: '  flete y  DESCARGA ' })])).toEqual([])
+
+    const otraVez = correr([{ type: 'APLICAR_CARGOS_PLANTILLA', payload: [plantilla()] }], base)
+    expect(otraVez).toBe(base)
+  })
+
+  it('sanea la combinacion imposible: afectaBaseII sin ser gravado', () => {
+    const s = correr([
+      { type: 'AGREGAR_ITEM', payload: producto('a', 100) },
+      { type: 'APLICAR_CARGOS_PLANTILLA', payload: [plantilla({ afectaBaseII: true })] },
+    ])
+    expect(s.cargos[0].afectaBaseII).toBe(false)
+  })
+})
+
+describe('cargos: el payload que sale a la RPC', () => {
+  /** Tres lineas (neto 100, 200, 300) y un cargo con la base en monto. */
+  const conTresLineas = () => correr([
+    { type: 'AGREGAR_ITEM', payload: producto('a', 100) },
+    { type: 'AGREGAR_ITEM', payload: producto('b', 200) },
+    { type: 'AGREGAR_ITEM', payload: producto('c', 300) },
+    { type: 'AGREGAR_CARGO' },
+  ])
+
+  it('los pesos viajan por INDICE del array de items, no por lineaId', () => {
+    const s = conTresLineas()
+    // El vector interno esta contra lineaId, que arranca en 1.
+    expect(s.cargos[0].pesos).toEqual({ 1: 100, 2: 200, 3: 300 })
+
+    const [cargo] = cargosParaRPC(s.items, s.cargos)
+    // Y sale contra el indice del payload, base 0.
+    expect(cargo.pesos).toEqual({ 0: 100, 1: 200, 2: 300 })
+  })
+
+  it('borrar una linea del medio corre los indices, y por eso adentro se usa lineaId', () => {
+    // Este es el caso que justifica los dos sistemas de numeracion: el peso de
+    // la tercera linea tiene que terminar en el indice 1, no en el 2, o la RPC
+    // se lo cobra a otro producto (o lo rechaza por fuera de rango).
+    const s = correr([{ type: 'ELIMINAR_ITEM', payload: 1 }], conTresLineas())
+    expect(s.items.map(i => i.lineaId)).toEqual([1, 3])
+    expect(s.cargos[0].pesos).toEqual({ 1: 100, 3: 300 })
+
+    const [cargo] = cargosParaRPC(s.items, s.cargos)
+    expect(cargo.pesos).toEqual({ 0: 100, 1: 300 })
+  })
+
+  it('traduce el resto del cargo a lo que espera la mig 194', () => {
+    const base = conTresLineas()
+    const id = base.cargos[0].id
+    const s = correr([
+      { type: 'ACTUALIZAR_CARGO', payload: { id, cambios: {
+        concepto: '  Flete y descarga  ', monto: 1900000, condicionIva: 'gravado',
+        enFactura: false, prorrateaAlCosto: true, afectaBaseII: true, baseProrrateo: 'cantidad',
+      } } },
+    ], base)
+
+    expect(cargosParaRPC(s.items, s.cargos)[0]).toEqual({
+      concepto: 'Flete y descarga',
+      monto: 1900000,
+      condicionIva: 'gravado',
+      enFactura: false,
+      prorrateaAlCosto: true,
+      afectaBaseII: true,
+      baseProrrateo: 'cantidad',
+      pesos: { 0: 1, 1: 1, 2: 1 },
+    })
+  })
+
+  it('avisa antes de salir a la red lo que la RPC iba a rechazar', () => {
+    const base = conTresLineas()
+    const id = base.cargos[0].id
+
+    expect(validarCargos(base.cargos)).toMatch(/sin concepto/i)
+
+    const conNombre = correr([
+      { type: 'ACTUALIZAR_CARGO', payload: { id, cambios: { concepto: 'Flete' } } },
+    ], base)
+    expect(validarCargos(conNombre.cargos)).toBeNull()
+
+    // Todos los pesos en 0 y el cargo prorratea: no llegaria a ningun costo.
+    const sinLineas = correr([
+      { type: 'SET_PESO_CARGO', payload: { cargoId: id, lineaId: 1, peso: 0 } },
+      { type: 'SET_PESO_CARGO', payload: { cargoId: id, lineaId: 2, peso: 0 } },
+      { type: 'SET_PESO_CARGO', payload: { cargoId: id, lineaId: 3, peso: 0 } },
+    ], conNombre)
+    expect(validarCargos(sinLineas.cargos)).toMatch(/no tiene ninguna l.nea asignada/i)
+
+    // Mismo cargo sin prorratear al costo: es legal, solo suma al cuadre.
+    const soloFactura = correr([
+      { type: 'ACTUALIZAR_CARGO', payload: { id, cambios: { prorrateaAlCosto: false } } },
+    ], sinLineas)
+    expect(validarCargos(soloFactura.cargos)).toBeNull()
+
+    const pesoPodrido = correr([
+      { type: 'SET_PESO_CARGO', payload: { cargoId: id, lineaId: 1, peso: NaN } },
+    ], conNombre)
+    expect(validarCargos(pesoPodrido.cargos)).toMatch(/peso inv.lido/i)
+  })
+})
+
+describe('cargos: banderas fiscales', () => {
+  it('apaga afectaBaseII al salir de gravado', () => {
+    const base = conDosLineasYUnCargo()
+    const id = base.cargos[0].id
+    const gravado = correr([
+      { type: 'ACTUALIZAR_CARGO', payload: { id, cambios: { condicionIva: 'gravado', afectaBaseII: true } } },
+    ], base)
+    expect(gravado.cargos[0].afectaBaseII).toBe(true)
+
+    // El motor lo lee como `gravado && afectaBaseII`: dejarlo prendido seria
+    // estado invisible que reaparece solo, y ademas se persistiria asi.
+    const noGravado = correr([
+      { type: 'ACTUALIZAR_CARGO', payload: { id, cambios: { condicionIva: 'no_gravado' } } },
+    ], gravado)
+    expect(noGravado.cargos[0].afectaBaseII).toBe(false)
+  })
+
+  it('el impuesto interno declarado en 0 borra la clave en vez de guardarla', () => {
+    // Con declarado 0 y calculado > 0 el factor de ajuste da 0 y el impuesto
+    // interno de esa alicuota se borra entero. Vaciar el campo tiene que
+    // significar "no declarado", no "declaro cero".
+    const cargado = correr([{ type: 'SET_II_DECLARADO', payload: { tasa: 4.1667, monto: 1234 } }])
+    expect(cargado.iiDeclarado).toEqual({ 4.1667: 1234 })
+
+    const vaciado = correr([{ type: 'SET_II_DECLARADO', payload: { tasa: 4.1667, monto: 0 } }], cargado)
+    expect(vaciado.iiDeclarado).toEqual({})
+  })
+})
+
+describe('no gravado de cabecera: sale de los cargos', () => {
+  /** Dos líneas, pallets (170.800 en el papel) y flete (no está en el papel). */
+  const conPalletsYFlete = () => {
+    const base = correr([
+      { type: 'AGREGAR_ITEM', payload: producto('a', 100) },
+      { type: 'AGREGAR_ITEM', payload: producto('b', 300) },
+      { type: 'AGREGAR_CARGO' },
+      { type: 'AGREGAR_CARGO' },
+    ])
+    const [pallets, flete] = base.cargos
+    return correr([
+      { type: 'ACTUALIZAR_CARGO', payload: { id: pallets.id, cambios: { concepto: 'Pallets', monto: 170_800, condicionIva: 'no_gravado', enFactura: true } } },
+      { type: 'ACTUALIZAR_CARGO', payload: { id: flete.id, cambios: { concepto: 'Flete', monto: 1_900_000, condicionIva: 'no_gravado', enFactura: false } } },
+    ], base)
+  }
+
+  it('suma los no gravados que estan en la factura y deja afuera al flete', () => {
+    // El flete tambien es no gravado, pero lo factura el transportista aparte:
+    // no esta en ESTE papel, asi que no puede entrar al no gravado de cabecera.
+    const s = conPalletsYFlete()
+    expect(s.noGravado).toBe(170_800)
+    expect(s.noGravadoManual).toBe(false)
+  })
+
+  it('un cargo gravado no entra al no gravado por mas que este en la factura', () => {
+    const base = conPalletsYFlete()
+    const bonif = correr([{ type: 'AGREGAR_CARGO' }], base)
+    const id = bonif.cargos[2].id
+    const s = correr([
+      { type: 'ACTUALIZAR_CARGO', payload: { id, cambios: { concepto: 'Bonif. promo', monto: -103_465.32, condicionIva: 'gravado', enFactura: true } } },
+    ], bonif)
+    expect(s.noGravado).toBe(170_800)
+  })
+
+  it('sigue al cargo: cambiar el monto o sacarlo del papel mueve la cabecera', () => {
+    const base = conPalletsYFlete()
+    const idPallets = base.cargos[0].id
+
+    const masCaro = correr([
+      { type: 'ACTUALIZAR_CARGO', payload: { id: idPallets, cambios: { monto: 162_000 } } },
+    ], base)
+    expect(masCaro.noGravado).toBe(162_000)
+
+    // Destildar "viene en la factura" lo saca del cuadre contra el papel.
+    const fueraDelPapel = correr([
+      { type: 'ACTUALIZAR_CARGO', payload: { id: idPallets, cambios: { enFactura: false } } },
+    ], masCaro)
+    expect(fueraDelPapel.noGravado).toBe(0)
+
+    // Y borrarlo tambien.
+    const sinCargo = correr([{ type: 'ELIMINAR_CARGO', payload: idPallets }], masCaro)
+    expect(sinCargo.noGravado).toBe(0)
+  })
+
+  it('lo tipeado a mano no se pisa, y el boton lo devuelve al automatico', () => {
+    // Misma regla que los pesos: el pre-llenado no le gana a lo escrito. Una
+    // factura puede traer un no gravado que no se cargo como cargo.
+    const aMano = correr([
+      { type: 'SET_EXTRAS', payload: { noGravado: 999 } },
+    ], conPalletsYFlete())
+    expect(aMano.noGravado).toBe(999)
+    expect(aMano.noGravadoManual).toBe(true)
+
+    const idPallets = aMano.cargos[0].id
+    const tocandoElCargo = correr([
+      { type: 'ACTUALIZAR_CARGO', payload: { id: idPallets, cambios: { monto: 500_000 } } },
+    ], aMano)
+    expect(tocandoElCargo.noGravado).toBe(999)
+
+    const devuelto = correr([{ type: 'USAR_NO_GRAVADO_DE_CARGOS' }], tocandoElCargo)
+    expect(devuelto.noGravado).toBe(500_000)
+    expect(devuelto.noGravadoManual).toBe(false)
+  })
+
+  it('tipear un 0 es un dato, no un campo vacio', () => {
+    // Si el 0 no marcara manual, el pre-llenado lo pisaria en el siguiente tick
+    // y el usuario no podria decir "esta factura no trae no gravado".
+    const s = correr([
+      { type: 'SET_EXTRAS', payload: { noGravado: 0 } },
+    ], conPalletsYFlete())
+    expect(s.noGravadoManual).toBe(true)
+
+    const idPallets = s.cargos[0].id
+    const despues = correr([
+      { type: 'ACTUALIZAR_CARGO', payload: { id: idPallets, cambios: { monto: 162_000 } } },
+    ], s)
+    expect(despues.noGravado).toBe(0)
+  })
+
+  it('tocar otra percepcion no marca el no gravado como manual', () => {
+    const s = correr([
+      { type: 'SET_EXTRAS', payload: { percepcionIva: 1234 } },
+    ], conPalletsYFlete())
+    expect(s.noGravadoManual).toBe(false)
+    expect(s.noGravado).toBe(170_800)
+  })
+
+  it('dice lo mismo que el motor sobre la misma factura', () => {
+    // `totales.noGravado` del motor y la cabecera contestan la misma pregunta:
+    // que parte de esta compra el proveedor facturo fuera del IVA. Si dijeran
+    // distinto, el cuadre contra la factura se pondria rojo sin nada mal.
+    const s = conPalletsYFlete()
+    const r = calcularCostosCompra(
+      lineasParaMotor(s.items, s.tipoFactura),
+      cargosParaMotor(s.cargos),
+      {},
+    )
+    expect(r.totales.noGravado).toBeCloseTo(s.noGravado, 2)
+  })
+})
+
+describe('borde del motor: la regla de ZZ', () => {
+  const conII = () => correr([
+    { type: 'AGREGAR_ITEM', payload: producto('a', 1000) },
+    { type: 'ACTUALIZAR_ITEM', payload: { index: 0, campo: 'cantidad', valor: 4 } },
+    { type: 'ACTUALIZAR_ITEM', payload: { index: 0, campo: 'impuestosInternos', valor: 8.6956 } },
+  ])
+
+  it('en ZZ pone la tasa de II y la alicuota en 0, igual que la mig 194', () => {
+    const s = conII()
+    expect(lineasParaMotor(s.items, 'FC')[0]).toMatchObject({
+      impuestosInternos: 8.6956, porcentajeIva: 21, condicionIva: 'gravado',
+    })
+    expect(lineasParaMotor(s.items, 'ZZ')[0]).toMatchObject({
+      impuestosInternos: 0, porcentajeIva: 0, condicionIva: 'gravado',
+    })
+  })
+
+  it('en ZZ el cargo suma al costo pero el impuesto interno no', () => {
+    // El caso medido en la mig 194: 4 x 1000 con flete de 400 y la linea
+    // declarando 8,6956 de II da costo_real 1100, no 1186,96.
+    const s = conII()
+    const flete = [{
+      id: 1, concepto: 'Flete', monto: 400, condicionIva: 'no_gravado' as const,
+      enFactura: false, prorrateaAlCosto: true, afectaBaseII: false, pesos: { 1: 1 },
+    }]
+    const zz = calcularCostosCompra(lineasParaMotor(s.items, 'ZZ'), flete, {})
+    expect(zz.lineas[0].costoRealUnitario).toBeCloseTo(1100, 6)
+    expect(zz.lineas[0].iiUnitario).toBe(0)
+
+    // La misma compra como FC si paga el II: el cargo no cambia, la tasa si.
+    const fc = calcularCostosCompra(lineasParaMotor(s.items, 'FC'), flete, {})
+    expect(fc.lineas[0].costoRealUnitario).toBeCloseTo(1186.956, 3)
+  })
+})
+
+describe('cuadre del impuesto interno por alicuota', () => {
+  /** Dos lineas de neto 1000 con tasas de II que NO colapsan al mismo bucket. */
+  const dosAlicuotas = () => correr([
+    { type: 'AGREGAR_ITEM', payload: producto('a', 1000) },
+    { type: 'AGREGAR_ITEM', payload: producto('b', 1000) },
+    { type: 'ACTUALIZAR_ITEM', payload: { index: 0, campo: 'impuestosInternos', valor: 4.1667 } },
+    { type: 'ACTUALIZAR_ITEM', payload: { index: 1, campo: 'impuestosInternos', valor: 4.17 } },
+  ])
+
+  it('4,1667 y 4,17 son buckets distintos: declarar uno no ajusta el otro', () => {
+    const s = correr([{ type: 'SET_II_DECLARADO', payload: { tasa: 4.1667, monto: 50 } }], dosAlicuotas())
+    const cuadre = cuadreImpuestoInterno(s.items, s.cargos, s.iiDeclarado, 'FC')!
+    expect(cuadre.map(c => c.tasa)).toEqual([4.1667, 4.17])
+    expect(cuadre[0].calculado).toBeCloseTo(41.667, 6)
+    expect(cuadre[0].declarado).toBe(50)
+    expect(cuadre[0].factor).toBeCloseTo(50 / 41.667, 6)
+    // El otro no se declaro: sin ajuste, y el cuadre lo muestra en vez de
+    // arrastrarlo con el factor del vecino.
+    expect(cuadre[1].declarado).toBeUndefined()
+    expect(cuadre[1].factor).toBe(1)
+    expect(cuadre[1].desvio).toBe(0)
+  })
+
+  it('el calculado NO viene ya ajustado por lo declarado', () => {
+    // Si el "calculado" saliera del motor CON la apertura, seria igual al
+    // declarado por construccion y el desvio daria 0 siempre: el cuadre no
+    // podria avisar nunca.
+    const s = correr([{ type: 'SET_II_DECLARADO', payload: { tasa: 4.1667, monto: 50 } }], dosAlicuotas())
+    const cuadre = cuadreImpuestoInterno(s.items, s.cargos, s.iiDeclarado, 'FC')!
+    expect(cuadre[0].calculado).not.toBeCloseTo(50, 2)
+    expect(Math.abs(cuadre[0].desvio)).toBeGreaterThan(DESVIO_II_TOLERADO)
+  })
+
+  it('un cargo con afectaBaseII mueve el calculado; sin el flag, no', () => {
+    const base = correr([
+      { type: 'AGREGAR_ITEM', payload: producto('a', 1000) },
+      { type: 'ACTUALIZAR_ITEM', payload: { index: 0, campo: 'impuestosInternos', valor: 10 } },
+      { type: 'AGREGAR_CARGO' },
+    ])
+    const id = base.cargos[0].id
+    const bonif = correr([
+      { type: 'ACTUALIZAR_CARGO', payload: { id, cambios: { monto: -200, condicionIva: 'gravado' } } },
+    ], base)
+    expect(cuadreImpuestoInterno(bonif.items, bonif.cargos, {}, 'FC')![0].calculado).toBeCloseTo(100, 6)
+
+    const conFlag = correr([
+      { type: 'ACTUALIZAR_CARGO', payload: { id, cambios: { afectaBaseII: true } } },
+    ], bonif)
+    expect(cuadreImpuestoInterno(conFlag.items, conFlag.cargos, {}, 'FC')![0].calculado).toBeCloseTo(80, 6)
+  })
+
+  it('en ZZ no hay nada que cuadrar', () => {
+    const s = dosAlicuotas()
+    expect(cuadreImpuestoInterno(s.items, s.cargos, s.iiDeclarado, 'ZZ')).toEqual([])
+  })
+})
+
+describe('el declarado deduce que bonificaciones bajan la base', () => {
+  /** Una línea de neto 1000 al 10% de II (= 100) con una bonificación gravada de −200. */
+  const conBonificacion = () => {
+    const base = correr([
+      { type: 'AGREGAR_ITEM', payload: producto('a', 1000) },
+      { type: 'ACTUALIZAR_ITEM', payload: { index: 0, campo: 'impuestosInternos', valor: 10 } },
+      { type: 'AGREGAR_CARGO' },
+    ])
+    return correr([
+      { type: 'ACTUALIZAR_CARGO', payload: { id: base.cargos[0].id, cambios: { monto: -200, condicionIva: 'gravado' } } },
+    ], base)
+  }
+
+  it('declarar 80 escribe el flag; declarar 100 lo deja apagado', () => {
+    // 100 es el II sin bajar la base y 80 el II bajándola: el declarado
+    // distingue las dos hipótesis y el reducer escribe la que cierra.
+    const s = conBonificacion()
+    const baja = correr([{ type: 'SET_II_DECLARADO', payload: { tasa: 10, monto: 80 } }], s)
+    expect(baja.cargos[0].afectaBaseII).toBe(true)
+    expect(baja.cargos[0].afectaBaseIIManual).toBe(false)
+
+    const noBaja = correr([{ type: 'SET_II_DECLARADO', payload: { tasa: 10, monto: 100 } }], s)
+    expect(noBaja.cargos[0].afectaBaseII).toBe(false)
+  })
+
+  it('la deduccion es punto fijo: no oscila al seguir tocando el formulario', () => {
+    // Aplicar la solución cambia el flag, y el reducer vuelve a resolver en la
+    // acción siguiente. Si la búsqueda mirara el valor actual del candidato,
+    // esto alternaría entre dos estados en cada tecla.
+    const s = correr([{ type: 'SET_II_DECLARADO', payload: { tasa: 10, monto: 80 } }], conBonificacion())
+    const otraVez = correr([{ type: 'SET_II_DECLARADO', payload: { tasa: 10, monto: 80 } }], s)
+    expect(otraVez.cargos[0].afectaBaseII).toBe(true)
+    expect(otraVez.cargos).toStrictEqual(s.cargos)
+  })
+
+  it('lo tildado a mano manda sobre lo deducido', () => {
+    const s = conBonificacion()
+    const id = s.cargos[0].id
+    const aMano = correr([{ type: 'ACTUALIZAR_CARGO', payload: { id, cambios: { afectaBaseII: true } } }], s)
+    expect(aMano.cargos[0].afectaBaseIIManual).toBe(true)
+    // El declarado dice que NO baja la base; el usuario dijo que sí. Manda él.
+    const conDeclarado = correr([{ type: 'SET_II_DECLARADO', payload: { tasa: 10, monto: 100 } }], aMano)
+    expect(conDeclarado.cargos[0].afectaBaseII).toBe(true)
+  })
+
+  it('salir de gravado suelta la marca y el solver vuelve a opinar al volver', () => {
+    const s = correr([{ type: 'SET_II_DECLARADO', payload: { tasa: 10, monto: 80 } }], conBonificacion())
+    const id = s.cargos[0].id
+    const destildado = correr([{ type: 'ACTUALIZAR_CARGO', payload: { id, cambios: { afectaBaseII: false } } }], s)
+    expect(destildado.cargos[0].afectaBaseII).toBe(false)
+
+    // La decisión manual era sobre un cargo gravado: al dejar de serlo se va con
+    // el flag, y si vuelve a serlo el declarado manda otra vez.
+    const vuelta = correr([
+      { type: 'ACTUALIZAR_CARGO', payload: { id, cambios: { condicionIva: 'no_gravado' } } },
+      { type: 'ACTUALIZAR_CARGO', payload: { id, cambios: { condicionIva: 'gravado' } } },
+    ], destildado)
+    expect(vuelta.cargos[0].afectaBaseIIManual).toBe(false)
+    expect(vuelta.cargos[0].afectaBaseII).toBe(true)
+  })
+
+  it('si la deduccion no es unica no se escribe nada', () => {
+    // Dos bonificaciones idénticas: "baja la primera" y "baja la segunda" dan el
+    // mismo impuesto interno. Escribir cualquiera de las dos sería inventar.
+    const base = correr([
+      { type: 'AGREGAR_ITEM', payload: producto('a', 1000) },
+      { type: 'ACTUALIZAR_ITEM', payload: { index: 0, campo: 'impuestosInternos', valor: 10 } },
+      { type: 'AGREGAR_CARGO' },
+      { type: 'AGREGAR_CARGO' },
+    ])
+    const dos = correr(base.cargos.map(c => (
+      { type: 'ACTUALIZAR_CARGO', payload: { id: c.id, cambios: { monto: -200, condicionIva: 'gravado' } } } as Accion
+    )), base)
+    const s = correr([{ type: 'SET_II_DECLARADO', payload: { tasa: 10, monto: 80 } }], dos)
+    expect(s.cargos.map(c => c.afectaBaseII)).toEqual([false, false])
+    expect(resolucionBasesII(s.items, s.cargos, s.iiDeclarado, 'FC')!.estado).toBe('ambigua')
+  })
+
+  it('en ZZ no hay apertura declarada, asi que no hay nada que deducir', () => {
+    const s = correr([
+      { type: 'SET_TIPO_FACTURA', payload: 'ZZ' },
+      { type: 'SET_II_DECLARADO', payload: { tasa: 10, monto: 80 } },
+    ], conBonificacion())
+    expect(s.cargos[0].afectaBaseII).toBe(false)
+    expect(resolucionBasesII(s.items, s.cargos, s.iiDeclarado, 'ZZ')!.estado).toBe('sin_datos')
+  })
+})

--- a/src/components/modals/ModalCompra.reducer.ts
+++ b/src/components/modals/ModalCompra.reducer.ts
@@ -1,0 +1,1068 @@
+/**
+ * Estado del modal de compra: tipos, estado inicial y reducer.
+ *
+ * Vive fuera de ModalCompra.tsx por una razón concreta y no por prolijidad:
+ * `react-refresh/only-export-components` prohíbe exportar valores desde un
+ * archivo de componentes, así que mientras el reducer estuvo allá adentro no se
+ * lo podía testear. Y es justo la lógica que se rompe en silencio — un peso que
+ * queda pegado al producto equivocado no tira ninguna pantalla, sólo reparte
+ * mal el flete.
+ *
+ * Además este módulo NO importa supabase, así que sus tests corren sin stubs de
+ * entorno.
+ */
+import { fechaLocalISO } from '../../utils/formatters'
+import { redondearSQL } from '../../utils/calculations'
+import { OPCIONES_CONDICION_IVA } from '../../utils/condicionIva'
+import { calcularCostosCompra, lineaParaMotor, resolverBasesII } from '../../utils/prorrateoCompra'
+import type { PesosCargo, LineaCompra, CargoCompra, ResultadoBasesII } from '../../utils/prorrateoCompra'
+import type { BaseProrrateoCompra, CargoPlantillaCompra, CompraCargoInput, CondicionIva, ProductoDB } from '../../types'
+
+/** Item de compra en el formulario */
+export interface CompraItemForm {
+  productoId: string;
+  productoNombre: string;
+  productoCodigo?: string | null;
+  cantidad: number;
+  bonificacion: number;
+  costoUnitario: number;
+  impuestosInternos: number;
+  porcentajeIva: number;
+  /** Condición de la línea (mig 177). Se siembra del producto y se puede pisar acá. */
+  condicionIva: CondicionIva;
+  stockActual: number;
+  /**
+   * Id local y estable de la línea, asignado por el reducer.
+   *
+   * Los cargos guardan sus pesos contra este id y no contra el índice del
+   * array: borrar una línea corre los índices y el peso tipeado a mano
+   * terminaría pegado a otro producto, en silencio. Es opcional porque los
+   * items también se construyen afuera (ModalImportarCompra) — el reducer
+   * numera todo lo que llegue sin id.
+   */
+  lineaId?: number;
+}
+
+/**
+ * Regla que pre-llena el vector de pesos de un cargo (`base_prorrateo` de la
+ * mig 192). Sólo pre-llena: la verdad siempre es el vector.
+ *
+ * Es un alias del tipo compartido y no una copia: el mismo dominio viaja a la
+ * RPC y vuelve en la plantilla del proveedor, y dos uniones separadas se
+ * desincronizan sin que nada avise.
+ */
+export type BaseProrrateo = BaseProrrateoCompra
+
+/**
+ * Un cargo de la factura tal como se carga en el formulario: flete, pallets,
+ * separadores, bonificación comercial.
+ *
+ * Espeja `CargoCompra` de prorrateoCompra.ts con los mismos nombres —el motor
+ * lo consume tal cual— y le suma lo que sólo vive en la UI: la base que
+ * pre-llena los pesos y qué pesos tocó el usuario a mano.
+ *
+ * No lleva alícuota de IVA propia a propósito: un cargo gravado tributa a la de
+ * las líneas sobre las que cae.
+ */
+export interface CargoCompraForm {
+  /** Id local del cargo (el de la base lo asigna la RPC al persistir). */
+  id: number;
+  concepto: string;
+  /** SIN IVA. Negativo = bonificación. */
+  monto: number;
+  condicionIva: CondicionIva;
+  /** Viene impreso en la factura: suma al cuadre contra el papel. */
+  enFactura: boolean;
+  /** Entra al costo unitario. Independiente de `enFactura`. */
+  prorrateaAlCosto: boolean;
+  /** Mueve la base de impuestos internos. Sólo aplica si es gravado. */
+  afectaBaseII: boolean;
+  /**
+   * `true` si el flag de arriba lo tildó el usuario. Misma regla que los pesos:
+   * lo que se toca a mano no se pisa nunca con lo deducido.
+   *
+   * Existe porque desde el solver (`resolverBasesII`) el valor por defecto de
+   * `afectaBaseII` ya no es una suposición sino el resultado de resolver el
+   * impuesto interno declarado contra las 2^N combinaciones posibles. Eso gana
+   * contra el default y contra la plantilla del proveedor —que son adivinanzas—
+   * pero no contra alguien que sabe qué acordó con el proveedor.
+   */
+  afectaBaseIIManual: boolean;
+  baseProrrateo: BaseProrrateo;
+  /** lineaId → peso. El 0 excluye la línea. */
+  pesos: PesosCargo;
+  /** lineaIds cuyo peso tipeó el usuario: el pre-llenado no los pisa. */
+  pesosManuales: Record<number, true>;
+}
+
+/**
+ * Lo editable de un cargo. El vector de pesos se toca sólo por SET_PESO_CARGO y
+ * las marcas de manual las pone el reducer: si se pudieran mandar desde afuera,
+ * cualquier cambio de campo podría clavar un flag sin que nadie lo haya tocado.
+ */
+export type CambiosCargo =
+  Partial<Omit<CargoCompraForm, 'id' | 'pesos' | 'pesosManuales' | 'afectaBaseIIManual'>>
+
+/** Resultado del escaneo de factura via n8n */
+export interface FacturaEscaneada {
+  proveedorNombre: string | null;
+  proveedorCuit: string | null;
+  numeroFactura: string | null;
+  fechaCompra: string | null;
+  items: Array<{
+    codigo: string | null;
+    descripcion: string;
+    cantidad: number;
+    costoUnitario: number;
+    bonificacion: number;
+    iva: number;
+  }>;
+  subtotal: number | null;
+  iva: number | null;
+  total: number | null;
+  formaPago: string | null;
+  confianza: number;
+}
+
+/** Item escaneado pendiente de revisión humana */
+export type FacturaItemEscaneado = FacturaEscaneada['items'][number]
+
+/**
+ * Normaliza strings para comparar nombres/códigos: minúsculas,
+ * trim, colapsa whitespace.
+ */
+function normalizarTexto(s: string | null | undefined): string {
+  return (s ?? '').trim().toLowerCase().replace(/\s+/g, ' ')
+}
+
+/**
+ * Auto-link estricto: solo retorna match si código exacto o nombre exacto
+ * (case/espacios normalizados). Cualquier otra coincidencia (parcial,
+ * substring) queda fuera para que el usuario decida.
+ */
+export function matchProductoEstricto(
+  scanItem: FacturaItemEscaneado,
+  productos: ProductoDB[]
+): ProductoDB | null {
+  const cod = normalizarTexto(scanItem.codigo)
+  if (cod) {
+    const porCodigo = productos.find(p => normalizarTexto(p.codigo) === cod)
+    if (porCodigo) return porCodigo
+  }
+  const desc = normalizarTexto(scanItem.descripcion)
+  if (desc) {
+    const porNombre = productos.find(p => normalizarTexto(p.nombre) === desc)
+    if (porNombre) return porNombre
+  }
+  return null
+}
+
+/** Construye un CompraItemForm a partir de un producto resuelto + datos de la factura. */
+export function construirCompraItemDesdeScan(
+  producto: ProductoDB,
+  scanItem: FacturaItemEscaneado
+): CompraItemForm {
+  return {
+    productoId: producto.id,
+    productoNombre: producto.nombre,
+    productoCodigo: producto.codigo || scanItem.codigo,
+    cantidad: scanItem.cantidad || 1,
+    bonificacion: scanItem.bonificacion || 0,
+    costoUnitario: scanItem.costoUnitario || 0,
+    impuestosInternos: 0,
+    // `??`, no `||`: un 0 legítimo del escaneo (línea exenta) se convertía en 21.
+    porcentajeIva: scanItem.iva ?? producto.porcentaje_iva ?? 21,
+    condicionIva: producto.condicion_iva ?? 'gravado',
+    stockActual: producto.stock || 0
+  }
+}
+
+/** Totales impresos en la factura física, para el panel "Control contra factura" (0 = no cargado) */
+export interface ControlFactura {
+  gravado: number;
+  iva: number;
+  impuestosInternos: number;
+  percepciones: number;
+  total: number;
+}
+
+/** Estado del reducer de compra */
+export interface CompraState {
+  /** Percepción de IVA de la factura (crédito fiscal, no costo) — solo FC */
+  percepcionIva: number;
+  /** Percepción de IIBB de la factura (crédito fiscal, no costo) — solo FC */
+  percepcionIibb: number;
+  /** Conceptos no gravados (ej: pallets valorizados) — solo FC */
+  noGravado: number;
+  /**
+   * `true` si el usuario tipeó el no gravado. Misma regla que los pesos de un
+   * cargo: lo escrito a mano no se pisa nunca con el pre-llenado.
+   *
+   * Existe porque el campo tiene dos orígenes legítimos. Casi siempre el número
+   * del papel ES la suma de los cargos no gravados que vienen en la factura
+   * —pallets, separadores—, y ésos ya están cargados abajo: pedirle al usuario
+   * que los vuelva a tipear es pedirle un dato que el modal ya tiene, y si no
+   * lo tipea el cuadre contra la factura se pone rojo por un importe que
+   * nadie omitió. Pero una factura puede traer un no gravado que no se cargó
+   * como cargo, y ahí la verdad es lo que el usuario escribe.
+   */
+  noGravadoManual: boolean;
+  controlFactura: ControlFactura;
+  /** Cargos de la factura (flete, pallets, bonificaciones). FC y ZZ: en ZZ el
+   *  cargo suma al costo igual, sólo no se le agrega impuesto interno encima. */
+  cargos: CargoCompraForm[];
+  /**
+   * Impuesto interno DECLARADO en la factura, abierto por alícuota:
+   * tasa → monto. Alimenta el factor de ajuste de `calcularCostosCompra`.
+   * Una tasa ausente no ajusta nada (que NO es lo mismo que declarar 0).
+   */
+  iiDeclarado: Record<number, number>;
+  proveedorId: string;
+  proveedorNombre: string;
+  usarProveedorNuevo: boolean;
+  numeroFactura: string;
+  fechaCompra: string;
+  formaPago: string;
+  tipoFactura: 'ZZ' | 'FC';
+  notas: string;
+  items: CompraItemForm[];
+  busquedaProducto: string;
+  mostrarBuscador: boolean;
+  modoItemRapido: boolean;
+  guardando: boolean;
+  error: string;
+  // Escaneo de factura
+  escaneando: boolean;
+  resultadoEscaneo: FacturaEscaneada | null;
+  errorEscaneo: string;
+  /** Items del último escaneo que no se auto-vincularon y esperan decisión del usuario. */
+  itemsPendientesScan: FacturaItemEscaneado[];
+}
+
+/** Tipos de acciones del reducer */
+export type CompraActionType =
+  | { type: 'SET_PROVEEDOR_ID'; payload: string }
+  | { type: 'SET_PROVEEDOR_NOMBRE'; payload: string }
+  | { type: 'SET_USAR_PROVEEDOR_NUEVO'; payload: boolean }
+  | { type: 'SET_NUMERO_FACTURA'; payload: string }
+  | { type: 'SET_FECHA_COMPRA'; payload: string }
+  | { type: 'SET_FORMA_PAGO'; payload: string }
+  | { type: 'SET_TIPO_FACTURA'; payload: 'ZZ' | 'FC' }
+  | { type: 'SET_NOTAS'; payload: string }
+  | { type: 'SET_BUSQUEDA'; payload: string }
+  | { type: 'SET_MOSTRAR_BUSCADOR'; payload: boolean }
+  | { type: 'SET_GUARDANDO'; payload: boolean }
+  | { type: 'SET_ERROR'; payload: string }
+  | { type: 'AGREGAR_ITEM'; payload: ProductoDB }
+  | { type: 'ACTUALIZAR_ITEM'; payload: { index: number; campo: keyof CompraItemForm; valor: number | string } }
+  // Condición y alícuota se setean juntas: la condición manda sobre la tasa.
+  | { type: 'SET_CONDICION_ITEM'; payload: { index: number; clave: string } }
+  | { type: 'ELIMINAR_ITEM'; payload: number }
+  | { type: 'LIMPIAR_BUSQUEDA' }
+  | { type: 'SET_MODO_ITEM_RAPIDO'; payload: boolean }
+  | { type: 'AGREGAR_ITEM_RAPIDO'; payload: { productoId: string; nombre: string; codigo: string; costoUnitario: number } }
+  | { type: 'IMPORTAR_ITEMS'; payload: CompraItemForm[] }
+  | { type: 'SET_ESCANEANDO'; payload: boolean }
+  | { type: 'SET_RESULTADO_ESCANEO'; payload: FacturaEscaneada | null }
+  | { type: 'SET_ERROR_ESCANEO'; payload: string }
+  | { type: 'APLICAR_ESCANEO'; payload: { proveedorId: string; proveedorNombre: string; numeroFactura: string; fechaCompra: string; formaPago: string; items: CompraItemForm[]; pendientes: FacturaItemEscaneado[] } }
+  | { type: 'RESOLVER_PENDIENTE_VINCULAR'; payload: { index: number; producto: ProductoDB } }
+  | { type: 'RESOLVER_PENDIENTE_CREAR'; payload: { index: number; producto: ProductoDB } }
+  | { type: 'RESOLVER_PENDIENTE_OMITIR'; payload: { index: number } }
+  | { type: 'LIMPIAR_PENDIENTES_SCAN' }
+  | { type: 'SET_EXTRAS'; payload: Partial<Pick<CompraState, 'percepcionIva' | 'percepcionIibb' | 'noGravado'>> }
+  // Suelta el no gravado tipeado y lo devuelve al pre-llenado por cargos.
+  | { type: 'USAR_NO_GRAVADO_DE_CARGOS' }
+  | { type: 'SET_CONTROL'; payload: Partial<ControlFactura> }
+  | { type: 'APLICAR_BONIF_GLOBAL'; payload: number }
+  // Cargos y prorrateo (mig 192). El vector de pesos no se toca desde acá salvo
+  // por SET_PESO_CARGO: lo mantiene alineado el wrapper del reducer.
+  | { type: 'AGREGAR_CARGO' }
+  | { type: 'APLICAR_CARGOS_PLANTILLA'; payload: CargoPlantillaCompra[] }
+  | { type: 'ACTUALIZAR_CARGO'; payload: { id: number; cambios: CambiosCargo } }
+  | { type: 'ELIMINAR_CARGO'; payload: number }
+  | { type: 'SET_PESO_CARGO'; payload: { cargoId: number; lineaId: number; peso: number } }
+  | { type: 'SET_II_DECLARADO'; payload: { tasa: number; monto: number } };
+
+// =============================================================================
+// BORDE DEL MOTOR DE COSTOS
+// =============================================================================
+
+/**
+ * Las líneas del formulario tal como las ve el motor.
+ *
+ * La regla de ZZ y el mapeo de campos viven en `lineaParaMotor`
+ * (prorrateoCompra.ts), que es el mismo CASE que arma `v_items_motor` en la mig
+ * 194 y que también usa el desglose de la cabecera. Acá sólo queda lo que es
+ * propio del formulario: una línea sin `lineaId` no viaja, porque los pesos de
+ * los cargos se guardan contra ese id y una línea sin id no podría recibir su
+ * parte del flete.
+ */
+export function lineasParaMotor(items: CompraItemForm[], tipoFactura: 'ZZ' | 'FC'): LineaCompra[] {
+  return items.flatMap(item =>
+    item.lineaId === undefined ? [] : [lineaParaMotor(item, tipoFactura, item.lineaId)]
+  )
+}
+
+/** El cargo del formulario sin lo que sólo vive en la UI (base y marcas de manual). */
+export function cargosParaMotor(cargos: CargoCompraForm[]): CargoCompra[] {
+  return cargos.map(c => ({
+    id: c.id,
+    concepto: c.concepto,
+    monto: c.monto,
+    condicionIva: c.condicionIva,
+    enFactura: c.enFactura,
+    prorrateaAlCosto: c.prorrateaAlCosto,
+    afectaBaseII: c.afectaBaseII,
+    pesos: c.pesos,
+  }))
+}
+
+/**
+ * Los cargos del formulario tal como los espera la RPC (mig 194): con los pesos
+ * traducidos de `lineaId` a ÍNDICE del array de items que viaja en el MISMO
+ * payload, base 0.
+ *
+ * La traducción es obligatoria, no cosmética. Adentro del modal el peso se
+ * guarda contra `lineaId` porque el índice se corre al borrar una línea y el
+ * peso terminaría pegado a otro producto. La RPC, en cambio, sólo puede hablar
+ * de índices: `compra_items.id` todavía no existe cuando el cliente arma el
+ * payload. Las dos verdades son correctas en su lado y el puente vive acá, en
+ * un solo lugar, contra `items` — que tiene que ser EL MISMO array que se manda
+ * como `p_items`.
+ *
+ * Una línea que ya no está se cae del vector en vez de viajar: la RPC rechaza
+ * un índice fuera de rango, y hace bien, porque ese pedazo del cargo no
+ * matchearía ninguna línea y se evaporaría del costo.
+ */
+export function cargosParaRPC(items: CompraItemForm[], cargos: CargoCompraForm[]): CompraCargoInput[] {
+  const indicePorLinea = new Map<number, number>()
+  items.forEach((item, i) => {
+    if (item.lineaId !== undefined) indicePorLinea.set(item.lineaId, i)
+  })
+  return cargos.map(c => {
+    const pesos: Record<number, number> = {}
+    for (const [lineaId, peso] of Object.entries(c.pesos)) {
+      const indice = indicePorLinea.get(Number(lineaId))
+      if (indice === undefined) continue
+      pesos[indice] = peso
+    }
+    return {
+      concepto: c.concepto.trim(),
+      monto: c.monto,
+      condicionIva: c.condicionIva,
+      enFactura: c.enFactura,
+      prorrateaAlCosto: c.prorrateaAlCosto,
+      afectaBaseII: c.afectaBaseII,
+      baseProrrateo: c.baseProrrateo,
+      pesos,
+    }
+  })
+}
+
+/**
+ * Lo que la RPC va a rechazar de los cargos, dicho antes de salir a la red.
+ *
+ * No es una segunda fuente de verdad: la validación que manda es la de la mig
+ * 194 —corre aunque el cliente esté viejo— y ésta existe para que el usuario
+ * lea el problema al lado del campo que lo causa en vez de un round trip
+ * después. Si la RPC gana una regla nueva, ésta se queda corta y no de más:
+ * el error igual llega y el modal lo muestra.
+ *
+ * El peso positivo sobre una línea de cantidad 0 —la otra causa de rechazo— no
+ * se chequea acá porque los dos modales ya exigen cantidad > 0 antes.
+ */
+export function validarCargos(cargos: CargoCompraForm[]): string | null {
+  for (const c of cargos) {
+    const nombre = c.concepto.trim() || '(sin concepto)'
+    if (!c.concepto.trim()) {
+      return 'Hay un cargo sin concepto. Ponele un nombre (flete, pallets, separadores) o quitalo.'
+    }
+    for (const [lineaId, peso] of Object.entries(c.pesos)) {
+      if (!Number.isFinite(peso) || peso < 0) {
+        return `El cargo "${nombre}" tiene un peso inválido en la línea ${lineaId}. Los pesos son proporciones: el 0 excluye una línea, el negativo no existe.`
+      }
+    }
+    const totalPeso = Object.values(c.pesos).reduce((acc, p) => acc + p, 0)
+    if (c.prorrateaAlCosto && totalPeso === 0) {
+      return `El cargo "${nombre}" no tiene ninguna línea asignada: con todos los pesos en 0 no llegaría a ningún costo. Asignale al menos una línea o destildá "se prorratea al costo".`
+    }
+  }
+  return null
+}
+
+/**
+ * Los cargos que la factura imprime como no gravados: no gravados (ni exentos)
+ * Y en el papel.
+ *
+ * El filtro es el mismo `!gravado && enFactura` que usa `totales.noGravado` del
+ * motor, y tiene que seguir siéndolo: los dos contestan la misma pregunta —qué
+ * parte de esta compra el proveedor facturó fuera del IVA— y responderla
+ * distinto pondría el cuadre contra la factura en rojo sin que nada esté mal.
+ *
+ * El flete queda afuera aunque no sea gravado: lo factura el transportista
+ * aparte, así que no está en ESTE papel. Por eso el filtro mira `enFactura` y
+ * no `prorrateaAlCosto`.
+ */
+export function cargosNoGravadosEnFactura(cargos: CargoCompraForm[]): CargoCompraForm[] {
+  return cargos.filter(c => c.condicionIva !== 'gravado' && c.enFactura)
+}
+
+/**
+ * Lo que suman esos cargos, que es lo que va a la cabecera "No gravado".
+ *
+ * Suma los MONTOS y no el prorrateo del motor a propósito: el motor reparte
+ * sobre las líneas y un cargo sin ninguna línea asignada aportaría 0, pero en
+ * la factura ese importe está impreso igual. La cabecera cuadra contra el
+ * papel, no contra el reparto.
+ */
+export function noGravadoDeCargos(cargos: CargoCompraForm[]): number {
+  return redondearSQL(
+    cargosNoGravadosEnFactura(cargos).reduce((acc, c) => acc + (c.monto || 0), 0),
+    2
+  )
+}
+
+/** El II declarado que llega al motor. En ZZ la RPC lo descarta; acá también. */
+export function iiDeclaradoParaMotor(
+  iiDeclarado: Record<number, number>,
+  tipoFactura: 'ZZ' | 'FC'
+): Record<number, number> {
+  return tipoFactura === 'ZZ' ? {} : iiDeclarado
+}
+
+/** Una alícuota de impuesto interno presente en la compra, calculada vs declarada. */
+export interface CuadreII {
+  tasa: number;
+  /** II de esa alícuota SIN ajustar, tal como sale de las líneas y los cargos. */
+  calculado: number;
+  /** Lo que dice la factura. undefined = no se cargó. */
+  declarado: number | undefined;
+  /** declarado / calculado. 1 = no hay ajuste. */
+  factor: number;
+  /** (declarado − calculado) / calculado. 0 si no hay declarado. */
+  desvio: number;
+}
+
+/**
+ * Cuadre del impuesto interno alícuota por alícuota.
+ *
+ * El "calculado" sale del motor con la apertura VACÍA a propósito: es el número
+ * contra el que se compara lo declarado, así que no puede venir ya ajustado por
+ * lo declarado — daría ✓ siempre y el cuadre no diría nada.
+ *
+ * Las tasas se agrupan con la misma normalización a 4 decimales que usa el
+ * motor: 4,1667 y 4,17 son buckets distintos a propósito (en compra_items
+ * conviven las dos porque alguien tipeó 4,17), y si la factura declara sólo una
+ * la otra no se ajusta y el cuadre lo muestra.
+ *
+ * Devuelve null si el motor no pudo calcular (un peso corrupto). El error
+ * ruidoso es responsabilidad de la vista previa; acá alcanza con no mostrar un
+ * cuadre inventado.
+ */
+export function cuadreImpuestoInterno(
+  items: CompraItemForm[],
+  cargos: CargoCompraForm[],
+  iiDeclarado: Record<number, number>,
+  tipoFactura: 'ZZ' | 'FC',
+): CuadreII[] | null {
+  const lineas = lineasParaMotor(items, tipoFactura)
+  const declarados = iiDeclaradoParaMotor(iiDeclarado, tipoFactura)
+  try {
+    const sinAjuste = calcularCostosCompra(lineas, cargosParaMotor(cargos), {})
+    const porLinea = new Map(sinAjuste.lineas.map(l => [l.id, l]))
+    const porTasa = new Map<number, number>()
+    for (const linea of lineas) {
+      const tasa = redondearSQL(linea.impuestosInternos || 0, 4)
+      if (tasa <= 0) continue
+      const costos = porLinea.get(linea.id)
+      porTasa.set(tasa, (porTasa.get(tasa) ?? 0) + (costos ? costos.iiUnitario * linea.cantidad : 0))
+    }
+    return Array.from(porTasa.entries())
+      .sort((a, b) => a[0] - b[0])
+      .map(([tasa, calculado]) => {
+        const declarado = declarados[tasa]
+        const hayAjuste = declarado !== undefined && calculado !== 0
+        return {
+          tasa,
+          calculado,
+          declarado,
+          factor: hayAjuste ? declarado / calculado : 1,
+          desvio: hayAjuste ? (declarado - calculado) / calculado : 0,
+        }
+      })
+  } catch {
+    return null
+  }
+}
+
+/** Desvío a partir del cual el cuadre del II deja de ser redondeo y hay que mirarlo. */
+export const DESVIO_II_TOLERADO = 0.005
+
+/**
+ * Qué bonificaciones bajan la base del impuesto interno, deducido del declarado.
+ *
+ * El borde del formulario para `resolverBasesII`: traduce las líneas y los
+ * cargos, aplica la regla de ZZ (donde no hay apertura declarada que valga) y
+ * devuelve null si el motor no pudo calcular, con el mismo criterio que
+ * `cuadreImpuestoInterno` — un peso corrupto lo grita la vista previa de costos,
+ * acá alcanza con no deducir nada.
+ */
+export function resolucionBasesII(
+  items: CompraItemForm[],
+  cargos: CargoCompraForm[],
+  iiDeclarado: Record<number, number>,
+  tipoFactura: 'ZZ' | 'FC',
+): ResultadoBasesII | null {
+  try {
+    return resolverBasesII(
+      lineasParaMotor(items, tipoFactura),
+      cargosParaMotor(cargos),
+      iiDeclaradoParaMotor(iiDeclarado, tipoFactura),
+    )
+  } catch {
+    return null
+  }
+}
+
+// Estado inicial
+export const initialState: CompraState = {
+  // Desglose fiscal extra (solo FC)
+  percepcionIva: 0,
+  percepcionIibb: 0,
+  noGravado: 0,
+  noGravadoManual: false,
+  controlFactura:{ gravado: 0, iva: 0, impuestosInternos: 0, percepciones: 0, total: 0 },
+  // Cargos y prorrateo
+  cargos: [],
+  iiDeclarado: {},
+  // Proveedor
+  proveedorId: '',
+  proveedorNombre: '',
+  usarProveedorNuevo: false,
+  // Datos de compra
+  numeroFactura: '',
+  fechaCompra: fechaLocalISO(),
+  formaPago: 'efectivo',
+  tipoFactura: 'FC',
+  notas: '',
+  // Items
+  items: [],
+  // UI
+  busquedaProducto: '',
+  mostrarBuscador: false,
+  modoItemRapido: false,
+  guardando: false,
+  error: '',
+  // Escaneo
+  escaneando: false,
+  resultadoEscaneo: null,
+  errorEscaneo: '',
+  itemsPendientesScan: []
+}
+
+// =============================================================================
+// CARGOS: ids de línea y sincronización del vector de pesos
+// =============================================================================
+
+/**
+ * Los cargos de la plantilla del proveedor que todavía no están cargados,
+ * comparados por concepto normalizado.
+ *
+ * Existe para que el botón y el reducer no puedan discrepar: el botón dice
+ * cuántos va a traer y el reducer trae exactamente esos. Sin el filtro, dos
+ * clics dejan "Flete" dos veces con monto 0 y el usuario carga el importe en
+ * uno de los dos — el otro queda como un cargo fantasma que no suma nada pero
+ * hace fallar la RPC por no tener ninguna línea asignada.
+ */
+export function cargosPlantillaNuevos(
+  cargos: CargoCompraForm[],
+  plantilla: CargoPlantillaCompra[]
+): CargoPlantillaCompra[] {
+  const yaCargados = new Set(cargos.map(c => normalizarTexto(c.concepto)))
+  return plantilla.filter(p => !yaCargados.has(normalizarTexto(p.concepto)))
+}
+
+/** Neto de una línea: cantidad × costo unitario, ya bonificado. */
+function netoLinea(item: CompraItemForm): number {
+  return (item.cantidad || 0) * (item.costoUnitario || 0) * (1 - (item.bonificacion || 0) / 100)
+}
+
+/**
+ * Peso que le toca a una línea según la base del cargo. Sólo pre-llenado.
+ *
+ * A 4 decimales, que es la precisión de `compra_cargo_repartos.peso`: sin eso
+ * el neto de la línea entra al campo con la cola binaria completa
+ * (158823,75999999999) y el usuario ve un número que no puede leer ni corregir.
+ */
+function pesoPorBase(base: BaseProrrateo, item: CompraItemForm): number {
+  switch (base) {
+    case 'monto': return redondearSQL(netoLinea(item), 4)
+    case 'cantidad': return item.cantidad || 0
+    default: return 1
+  }
+}
+
+/** Numera las líneas que llegaron sin id local (importadas, escaneadas). */
+function conLineaIds(items: CompraItemForm[]): CompraItemForm[] {
+  if (items.every(i => i.lineaId !== undefined)) return items
+  let proximo = items.reduce((max, i) => Math.max(max, i.lineaId ?? 0), 0) + 1
+  return items.map(i => (i.lineaId !== undefined ? i : { ...i, lineaId: proximo++ }))
+}
+
+/**
+ * Deja el vector de pesos de cada cargo alineado con las líneas que hay.
+ *
+ * Corre después de CUALQUIER cambio de items, no sólo al agregar o quitar una
+ * línea: con la base en `monto` o en `cantidad`, tocar un costo o una cantidad
+ * cambia el peso, y un vector viejo repartiría el flete con los números de
+ * antes sin que nada lo avise.
+ *
+ * Lo que el usuario tipeó a mano no se pisa nunca acá: sobrevive mientras
+ * exista la línea. La única forma de volver a la regla es re-elegir la base de
+ * reparto (`ACTUALIZAR_CARGO` limpia las marcas), que es un gesto explícito;
+ * sin esa salida un peso manual quedaría clavado para siempre.
+ *
+ * Las líneas borradas desaparecen del vector: si quedaran, `prorratearCargo`
+ * les asignaría plata y la grilla dejaría de sumar el monto del cargo.
+ */
+function sincronizarCargos(cargos: CargoCompraForm[], items: CompraItemForm[]): CargoCompraForm[] {
+  if (cargos.length === 0) return cargos
+  return cargos.map(cargo => {
+    const pesos: PesosCargo = {}
+    const pesosManuales: Record<number, true> = {}
+    for (const item of items) {
+      const id = item.lineaId
+      if (id === undefined) continue
+      if (cargo.pesosManuales[id] && cargo.pesos[id] !== undefined) {
+        pesos[id] = cargo.pesos[id]
+        pesosManuales[id] = true
+      } else {
+        pesos[id] = pesoPorBase(cargo.baseProrrateo, item)
+      }
+    }
+    return { ...cargo, pesos, pesosManuales }
+  })
+}
+
+/**
+ * Escribe en los cargos lo que el impuesto interno declarado permite deducir.
+ *
+ * Sólo si la deducción es ÚNICA. Con más de una combinación que cierre, o con
+ * ninguna, no se toca nada: el modal avisa y el ajuste proporcional del motor
+ * sigue siendo la red de seguridad, pero dicho como lo que es —una aproximación—
+ * y no disfrazado de decisión.
+ *
+ * Los indeterminables no aparecen en la asignación, así que conservan su valor:
+ * sobre ellos el solver no tiene nada que decir y pisarlos sería inventar.
+ *
+ * Devuelve el MISMO array si nada cambió. El punto fijo importa: aplicar la
+ * solución cambia `afectaBaseII` de los candidatos, y volver a correr el solver
+ * sobre el estado nuevo tiene que dar la misma solución —la búsqueda no mira el
+ * valor actual de un candidato, sólo el de los no candidatos— o el reducer
+ * quedaría oscilando entre dos estados en cada tecla.
+ */
+function resolverAfectaBaseII(
+  cargos: CargoCompraForm[],
+  items: CompraItemForm[],
+  iiDeclarado: Record<number, number>,
+  tipoFactura: 'ZZ' | 'FC',
+): CargoCompraForm[] {
+  const resolucion = resolucionBasesII(items, cargos, iiDeclarado, tipoFactura)
+  if (resolucion?.estado !== 'unica') return cargos
+  const deducido = resolucion.soluciones[0].asignacion
+  let cambio = false
+  const salida = cargos.map(c => {
+    const valor = deducido[c.id]
+    if (valor === undefined || c.afectaBaseIIManual || c.afectaBaseII === valor) return c
+    cambio = true
+    return { ...c, afectaBaseII: valor }
+  })
+  return cambio ? salida : cargos
+}
+
+// Reducer
+function aplicarAccion(state: CompraState, action: CompraActionType): CompraState {
+  switch (action.type) {
+    case 'SET_PROVEEDOR_ID':
+      return { ...state, proveedorId: action.payload }
+    case 'SET_PROVEEDOR_NOMBRE':
+      return { ...state, proveedorNombre: action.payload }
+    case 'SET_USAR_PROVEEDOR_NUEVO':
+      return { ...state, usarProveedorNuevo: action.payload }
+    case 'SET_NUMERO_FACTURA':
+      return { ...state, numeroFactura: action.payload }
+    case 'SET_FECHA_COMPRA':
+      return { ...state, fechaCompra: action.payload }
+    case 'SET_FORMA_PAGO':
+      return { ...state, formaPago: action.payload }
+    case 'SET_TIPO_FACTURA':
+      return { ...state, tipoFactura: action.payload }
+    case 'SET_NOTAS':
+      return { ...state, notas: action.payload }
+    case 'SET_BUSQUEDA':
+      return { ...state, busquedaProducto: action.payload, mostrarBuscador: true }
+    case 'SET_MOSTRAR_BUSCADOR':
+      return { ...state, mostrarBuscador: action.payload }
+    case 'SET_GUARDANDO':
+      return { ...state, guardando: action.payload }
+    case 'SET_ERROR':
+      return { ...state, error: action.payload }
+
+    case 'AGREGAR_ITEM': {
+      const producto = action.payload
+      const existente = state.items.find(i => i.productoId === producto.id)
+
+      if (existente) {
+        return {
+          ...state,
+          items: state.items.map(i =>
+            i.productoId === producto.id
+              ? { ...i, cantidad: i.cantidad + 1 }
+              : i
+          ),
+          busquedaProducto: '',
+          mostrarBuscador: false
+        }
+      }
+
+      return {
+        ...state,
+        items: [...state.items, {
+          productoId: producto.id,
+          productoNombre: producto.nombre,
+          productoCodigo: producto.codigo,
+          cantidad: 1,
+          bonificacion: 0,
+          costoUnitario: producto.costo_sin_iva || 0,
+          impuestosInternos: producto.impuestos_internos || 0,
+          porcentajeIva: producto.porcentaje_iva ?? 21,
+          condicionIva: producto.condicion_iva ?? 'gravado',
+          stockActual: producto.stock
+        }],
+        busquedaProducto: '',
+        mostrarBuscador: false
+      }
+    }
+
+    case 'ACTUALIZAR_ITEM':
+      return {
+        ...state,
+        items: state.items.map((item, i) =>
+          i === action.payload.index
+            ? { ...item, [action.payload.campo]: action.payload.valor }
+            : item
+        )
+      }
+
+    case 'SET_CONDICION_ITEM': {
+      const opcion = OPCIONES_CONDICION_IVA.find(o => o.clave === action.payload.clave)
+      if (!opcion) return state
+      return {
+        ...state,
+        items: state.items.map((item, i) =>
+          i === action.payload.index
+            ? { ...item, condicionIva: opcion.condicion, porcentajeIva: opcion.porcentaje }
+            : item
+        )
+      }
+    }
+
+    case 'ELIMINAR_ITEM':
+      return {
+        ...state,
+        items: state.items.filter((_, i) => i !== action.payload)
+      }
+
+    case 'LIMPIAR_BUSQUEDA':
+      return { ...state, busquedaProducto: '', mostrarBuscador: false }
+
+    case 'SET_MODO_ITEM_RAPIDO':
+      return { ...state, modoItemRapido: action.payload }
+
+    case 'AGREGAR_ITEM_RAPIDO': {
+      const { productoId, nombre, codigo, costoUnitario } = action.payload
+      return {
+        ...state,
+        items: [...state.items, {
+          productoId,
+          productoNombre: nombre,
+          productoCodigo: codigo,
+          cantidad: 1,
+          bonificacion: 0,
+          costoUnitario,
+          impuestosInternos: 0,
+          porcentajeIva: 21,
+          condicionIva: 'gravado',
+          stockActual: 0
+        }],
+        modoItemRapido: false,
+        busquedaProducto: '',
+        mostrarBuscador: false
+      }
+    }
+
+    case 'IMPORTAR_ITEMS':
+      return {
+        ...state,
+        items: [...state.items, ...action.payload]
+      }
+
+    case 'SET_ESCANEANDO':
+      return { ...state, escaneando: action.payload, errorEscaneo: '' }
+
+    case 'SET_RESULTADO_ESCANEO':
+      return { ...state, resultadoEscaneo: action.payload, escaneando: false }
+
+    case 'SET_ERROR_ESCANEO':
+      return { ...state, errorEscaneo: action.payload, escaneando: false }
+
+    case 'APLICAR_ESCANEO': {
+      const { proveedorId, proveedorNombre, numeroFactura, fechaCompra, formaPago, items, pendientes } = action.payload
+      return {
+        ...state,
+        proveedorId,
+        proveedorNombre,
+        usarProveedorNuevo: !proveedorId && !!proveedorNombre,
+        numeroFactura,
+        fechaCompra: fechaCompra || state.fechaCompra,
+        formaPago: formaPago || state.formaPago,
+        items,
+        itemsPendientesScan: pendientes,
+        resultadoEscaneo: null,
+        errorEscaneo: ''
+      }
+    }
+
+    case 'RESOLVER_PENDIENTE_VINCULAR':
+    case 'RESOLVER_PENDIENTE_CREAR': {
+      const { index, producto } = action.payload
+      const scanItem = state.itemsPendientesScan[index]
+      if (!scanItem) return state
+      const nuevoItem = construirCompraItemDesdeScan(producto, scanItem)
+      // Si ya existe un item con el mismo productoId, sumar cantidades
+      const existenteIdx = state.items.findIndex(i => i.productoId === producto.id)
+      const itemsActualizados = existenteIdx >= 0
+        ? state.items.map((i, idx) =>
+            idx === existenteIdx
+              ? { ...i, cantidad: i.cantidad + nuevoItem.cantidad }
+              : i
+          )
+        : [...state.items, nuevoItem]
+      return {
+        ...state,
+        items: itemsActualizados,
+        itemsPendientesScan: state.itemsPendientesScan.filter((_, i) => i !== index)
+      }
+    }
+
+    case 'RESOLVER_PENDIENTE_OMITIR': {
+      const { index } = action.payload
+      return {
+        ...state,
+        itemsPendientesScan: state.itemsPendientesScan.filter((_, i) => i !== index)
+      }
+    }
+
+    case 'LIMPIAR_PENDIENTES_SCAN':
+      return { ...state, itemsPendientesScan: [] }
+
+    case 'SET_EXTRAS':
+      return {
+        ...state,
+        ...action.payload,
+        // Tocar el campo lo saca del pre-llenado, igual que tipear un peso.
+        // Se mira la CLAVE y no el valor: escribir un 0 sobre un pre-llenado de
+        // 170.800 es "la factura no trae no gravado", que es un dato, no un
+        // campo vacío.
+        noGravadoManual: action.payload.noGravado !== undefined ? true : state.noGravadoManual,
+      }
+
+    case 'USAR_NO_GRAVADO_DE_CARGOS':
+      // El wrapper recalcula el importe: acá sólo se suelta la marca de manual.
+      return { ...state, noGravadoManual: false }
+
+    case 'SET_CONTROL':
+      return { ...state, controlFactura: { ...state.controlFactura, ...action.payload } }
+
+    case 'APLICAR_BONIF_GLOBAL':
+      return {
+        ...state,
+        items: state.items.map(item => ({ ...item, bonificacion: action.payload }))
+      }
+
+    case 'AGREGAR_CARGO': {
+      const id = state.cargos.reduce((max, c) => Math.max(max, c.id), 0) + 1
+      return {
+        ...state,
+        cargos: [...state.cargos, {
+          id,
+          concepto: '',
+          monto: 0,
+          // Defaults de la mig 192: el caso típico (flete, pallets) no lleva IVA,
+          // viene en el papel y entra al costo.
+          condicionIva: 'no_gravado',
+          enFactura: true,
+          prorrateaAlCosto: true,
+          afectaBaseII: false,
+          afectaBaseIIManual: false,
+          baseProrrateo: 'monto',
+          // El wrapper los pre-llena con la base recién elegida.
+          pesos: {},
+          pesosManuales: {},
+        }],
+      }
+    }
+
+    case 'APLICAR_CARGOS_PLANTILLA': {
+      const nuevos = cargosPlantillaNuevos(state.cargos, action.payload)
+      if (nuevos.length === 0) return state
+      const ultimoId = state.cargos.reduce((max, c) => Math.max(max, c.id), 0)
+      return {
+        ...state,
+        cargos: [...state.cargos, ...nuevos.map((plantilla, i): CargoCompraForm => {
+          const pesos: PesosCargo = {}
+          const pesosManuales: Record<number, true> = {}
+          for (const item of state.items) {
+            if (item.lineaId === undefined) continue
+            // La línea que no matchea ningún producto de la compra vieja queda
+            // en 0, o sea excluida del cargo.
+            pesos[item.lineaId] = plantilla.pesosPorProducto[String(item.productoId)] ?? 0
+            // TODO el vector queda marcado como manual, los ceros incluidos: si
+            // no, `sincronizarCargos` lo pisa entero con el pre-llenado de la
+            // base en el mismo tick y se pierde justo lo que se vino a buscar
+            // —el alcance—, porque el 0 ES la exclusión. La salida sigue siendo
+            // re-elegir la base de reparto, que limpia las marcas.
+            pesosManuales[item.lineaId] = true
+          }
+          return {
+            id: ultimoId + i + 1,
+            concepto: plantilla.concepto,
+            // El monto NO se reusa: es lo único que cambia en cada factura.
+            monto: 0,
+            condicionIva: plantilla.condicionIva,
+            enFactura: plantilla.enFactura,
+            prorrateaAlCosto: plantilla.prorrateaAlCosto,
+            // Misma invariante que ACTUALIZAR_CARGO: el flag sólo existe para un
+            // cargo gravado. Una fila vieja con la combinación imposible entra
+            // saneada en vez de propagar estado invisible.
+            afectaBaseII: plantilla.condicionIva === 'gravado' && plantilla.afectaBaseII,
+            // La plantilla NO es una decisión manual: es lo que el proveedor hizo
+            // la factura pasada, y el solver de esta factura la pisa si puede
+            // deducir otra cosa. Que la promo de agosto haya sido descuento de
+            // precio no dice nada de la de septiembre.
+            afectaBaseIIManual: false,
+            baseProrrateo: plantilla.baseProrrateo,
+            pesos,
+            pesosManuales,
+          }
+        })],
+      }
+    }
+
+    case 'ACTUALIZAR_CARGO': {
+      const { id, cambios } = action.payload
+      return {
+        ...state,
+        cargos: state.cargos.map(c => {
+          if (c.id !== id) return c
+          const actualizado = { ...c, ...cambios }
+          // Tildar el casillero a mano lo saca de lo que deduce el solver, igual
+          // que tipear un peso lo saca del pre-llenado. Se mira la CLAVE y no el
+          // valor: destildar lo que el solver había prendido es una decisión
+          // tanto como prenderlo.
+          if (cambios.afectaBaseII !== undefined) actualizado.afectaBaseIIManual = true
+          // El flag de base de II sólo existe para un cargo gravado: el motor lo
+          // mira como `gravado && afectaBaseII`. Dejarlo prendido bajo una
+          // condición que lo ignora es estado invisible que reaparece solo al
+          // volver a "gravado", y además se persistiría así. Se va con la marca
+          // de manual: la decisión era sobre un cargo gravado, y si vuelve a
+          // serlo el solver tiene que poder opinar de nuevo.
+          if (actualizado.condicionIva !== 'gravado') {
+            actualizado.afectaBaseII = false
+            actualizado.afectaBaseIIManual = false
+          }
+          // Elegir la base ES pedir el pre-llenado, así que borra las marcas de
+          // manual y el wrapper recalcula el vector entero. Es la única salida
+          // del usuario que se arrepintió de un peso tipeado a mano.
+          if (cambios.baseProrrateo !== undefined) actualizado.pesosManuales = {}
+          return actualizado
+        }),
+      }
+    }
+
+    case 'ELIMINAR_CARGO':
+      return { ...state, cargos: state.cargos.filter(c => c.id !== action.payload) }
+
+    case 'SET_PESO_CARGO': {
+      const { cargoId, lineaId, peso } = action.payload
+      // El peso se guarda tal cual llega: normalizarlo acá volvería un dato
+      // corrupto indistinguible de un 0 deliberado, que es justo el mecanismo
+      // de exclusión. Quien parsea es el formulario; quien avisa, la grilla.
+      return {
+        ...state,
+        cargos: state.cargos.map(c =>
+          c.id === cargoId
+            ? {
+                ...c,
+                pesos: { ...c.pesos, [lineaId]: peso },
+                pesosManuales: { ...c.pesosManuales, [lineaId]: true },
+              }
+            : c
+        ),
+      }
+    }
+
+    case 'SET_II_DECLARADO': {
+      const { tasa, monto } = action.payload
+      const iiDeclarado = { ...state.iiDeclarado }
+      // Sin monto se BORRA la clave, no se guarda un 0: con declarado 0 y
+      // calculado > 0 el factor de ajuste da 0 y el impuesto interno de esa
+      // alícuota se borra entero. Vaciar el campo significa "no declarado".
+      if (monto) iiDeclarado[tasa] = monto
+      else delete iiDeclarado[tasa]
+      return { ...state, iiDeclarado }
+    }
+
+    default:
+      return state
+  }
+}
+
+/**
+ * El reducer real: aplica la acción y después deja el estado consistente.
+ *
+ * Numerar las líneas y re-sincronizar los pesos acá —y no adentro de cada
+ * case— es deliberado: los items se reemplazan desde siete acciones distintas
+ * (alta, alta rápida, import de Excel, escaneo, dos resoluciones de pendientes,
+ * bonificación global) y olvidarse en una sola dejaría un cargo repartiendo
+ * sobre líneas que ya no existen.
+ *
+ * El no gravado de cabecera sigue a los cargos por la misma razón: cambiar el
+ * monto de los pallets o destildarles "viene en la factura" cambia lo que el
+ * papel dice fuera del IVA, y un número viejo ahí pone el cuadre en rojo.
+ *
+ * Y `afectaBaseII` sigue al impuesto interno declarado, que es el dato con el
+ * que se deduce. Por eso el guard mira también `iiDeclarado` y `tipoFactura`:
+ * tipear el declarado no toca ni las líneas ni los cargos, y sin eso la
+ * deducción no correría justo cuando aparece la información que la habilita.
+ */
+export function compraReducer(state: CompraState, action: CompraActionType): CompraState {
+  const next = aplicarAccion(state, action)
+  if (
+    next.items === state.items &&
+    next.cargos === state.cargos &&
+    next.noGravadoManual === state.noGravadoManual &&
+    next.iiDeclarado === state.iiDeclarado &&
+    next.tipoFactura === state.tipoFactura
+  ) return next
+  const items = conLineaIds(next.items)
+  const cargos = resolverAfectaBaseII(
+    sincronizarCargos(next.cargos, items), items, next.iiDeclarado, next.tipoFactura)
+  return {
+    ...next,
+    items,
+    cargos,
+    noGravado: next.noGravadoManual ? next.noGravado : noGravadoDeCargos(cargos),
+  }
+}

--- a/src/components/modals/ModalCompra.tsx
+++ b/src/components/modals/ModalCompra.tsx
@@ -6,16 +6,32 @@
  */
 import React, { useReducer, useMemo, useCallback, useState, useEffect, useRef, Suspense } from 'react'
 import type { ChangeEvent, FormEvent } from 'react'
-import { X, ShoppingCart, Plus, Trash2, Package, Building2, FileText, Calculator, Search, Loader2, Camera, CheckCircle, AlertTriangle } from 'lucide-react'
-import { formatPrecio, fechaLocalISO } from '../../utils/formatters'
-import { calcularTotalesCompra } from '../../utils/calculations'
-import type { TotalesCompra } from '../../utils/calculations'
-import { OPCIONES_CONDICION_IVA, claveCondicionIva, labelCondicionIva } from '../../utils/condicionIva'
+import { X, ShoppingCart, Plus, Trash2, Package, Building2, FileText, Calculator, Search, Loader2, Camera, CheckCircle, AlertTriangle, Truck, ChevronDown, ChevronRight, Copy } from 'lucide-react'
+import { formatPrecio } from '../../utils/formatters'
+import { redondearSQL } from '../../utils/calculations'
+import { OPCIONES_CONDICION_IVA, OPCIONES_CONDICION_SIN_ALICUOTA, claveCondicionIva, labelCondicionIva } from '../../utils/condicionIva'
+import { prorratearCargo, calcularCostosCompra, calcularTotalesCompra } from '../../utils/prorrateoCompra'
+import type { CostosCompra, TotalesCompra, ResultadoBasesII } from '../../utils/prorrateoCompra'
 import NumberInput from '../ui/NumberInput'
 import { supabase } from '../../lib/supabase'
+// Del módulo y no del barrel: éste es un modal lazy y el barrel se lleva puesto
+// todo el resto de los hooks de query al chunk.
+import { useCargosPlantillaProveedorQuery } from '../../hooks/queries/useComprasQuery'
 import { CompactErrorBoundary } from '../ErrorBoundary'
-import type { CondicionIva, ProductoDB, ProveedorDBExtended, CompraFormInputExtended, ProveedorFormInputExtended } from '../../types'
+import type { CondicionIva, ProductoDB, ProveedorDBExtended, CompraFormInputExtended, PlantillaCargosProveedor, ProveedorFormInputExtended } from '../../types'
 import { lazyWithReload } from '../../utils/lazyWithReload';
+import {
+  compraReducer, initialState, matchProductoEstricto, construirCompraItemDesdeScan,
+  lineasParaMotor, cargosParaMotor, iiDeclaradoParaMotor,
+  cuadreImpuestoInterno, DESVIO_II_TOLERADO, cargosPlantillaNuevos,
+  cargosParaRPC, validarCargos, cargosNoGravadosEnFactura, noGravadoDeCargos,
+  resolucionBasesII,
+} from './ModalCompra.reducer'
+import type {
+  CompraItemForm, CargoCompraForm, CambiosCargo, BaseProrrateo,
+  FacturaEscaneada, FacturaItemEscaneado, CompraState, CompraActionType,
+} from './ModalCompra.reducer'
+
 
 const ModalProveedor = lazyWithReload(() => import('./ModalProveedor'))
 const ModalImportarCompra = lazyWithReload(() => import('./ModalImportarCompra'))
@@ -24,173 +40,9 @@ const ModalImportarCompra = lazyWithReload(() => import('./ModalImportarCompra')
 // TIPOS
 // =============================================================================
 
-/** Item de compra en el formulario */
-export interface CompraItemForm {
-  productoId: string;
-  productoNombre: string;
-  productoCodigo?: string | null;
-  cantidad: number;
-  bonificacion: number;
-  costoUnitario: number;
-  impuestosInternos: number;
-  porcentajeIva: number;
-  /** Condición de la línea (mig 177). Se siembra del producto y se puede pisar acá. */
-  condicionIva: CondicionIva;
-  stockActual: number;
-}
-
 /** Clave del selector fiscal para el par que tenga la línea. */
 const claveCondicionLinea = (item: CompraItemForm): string =>
   claveCondicionIva(item.condicionIva, item.porcentajeIva)
-
-/** Resultado del escaneo de factura via n8n */
-export interface FacturaEscaneada {
-  proveedorNombre: string | null;
-  proveedorCuit: string | null;
-  numeroFactura: string | null;
-  fechaCompra: string | null;
-  items: Array<{
-    codigo: string | null;
-    descripcion: string;
-    cantidad: number;
-    costoUnitario: number;
-    bonificacion: number;
-    iva: number;
-  }>;
-  subtotal: number | null;
-  iva: number | null;
-  total: number | null;
-  formaPago: string | null;
-  confianza: number;
-}
-
-/** Item escaneado pendiente de revisión humana */
-export type FacturaItemEscaneado = FacturaEscaneada['items'][number]
-
-/**
- * Normaliza strings para comparar nombres/códigos: minúsculas,
- * trim, colapsa whitespace.
- */
-function normalizarTexto(s: string | null | undefined): string {
-  return (s ?? '').trim().toLowerCase().replace(/\s+/g, ' ')
-}
-
-/**
- * Auto-link estricto: solo retorna match si código exacto o nombre exacto
- * (case/espacios normalizados). Cualquier otra coincidencia (parcial,
- * substring) queda fuera para que el usuario decida.
- */
-function matchProductoEstricto(
-  scanItem: FacturaItemEscaneado,
-  productos: ProductoDB[]
-): ProductoDB | null {
-  const cod = normalizarTexto(scanItem.codigo)
-  if (cod) {
-    const porCodigo = productos.find(p => normalizarTexto(p.codigo) === cod)
-    if (porCodigo) return porCodigo
-  }
-  const desc = normalizarTexto(scanItem.descripcion)
-  if (desc) {
-    const porNombre = productos.find(p => normalizarTexto(p.nombre) === desc)
-    if (porNombre) return porNombre
-  }
-  return null
-}
-
-/** Construye un CompraItemForm a partir de un producto resuelto + datos de la factura. */
-function construirCompraItemDesdeScan(
-  producto: ProductoDB,
-  scanItem: FacturaItemEscaneado
-): CompraItemForm {
-  return {
-    productoId: producto.id,
-    productoNombre: producto.nombre,
-    productoCodigo: producto.codigo || scanItem.codigo,
-    cantidad: scanItem.cantidad || 1,
-    bonificacion: scanItem.bonificacion || 0,
-    costoUnitario: scanItem.costoUnitario || 0,
-    impuestosInternos: 0,
-    // `??`, no `||`: un 0 legítimo del escaneo (línea exenta) se convertía en 21.
-    porcentajeIva: scanItem.iva ?? producto.porcentaje_iva ?? 21,
-    condicionIva: producto.condicion_iva ?? 'gravado',
-    stockActual: producto.stock || 0
-  }
-}
-
-/** Totales impresos en la factura física, para el panel "Control contra factura" (0 = no cargado) */
-export interface ControlFactura {
-  gravado: number;
-  iva: number;
-  impuestosInternos: number;
-  percepciones: number;
-  total: number;
-}
-
-/** Estado del reducer de compra */
-export interface CompraState {
-  /** Percepción de IVA de la factura (crédito fiscal, no costo) — solo FC */
-  percepcionIva: number;
-  /** Percepción de IIBB de la factura (crédito fiscal, no costo) — solo FC */
-  percepcionIibb: number;
-  /** Conceptos no gravados (ej: pallets valorizados) — solo FC */
-  noGravado: number;
-  controlFactura: ControlFactura;
-  proveedorId: string;
-  proveedorNombre: string;
-  usarProveedorNuevo: boolean;
-  numeroFactura: string;
-  fechaCompra: string;
-  formaPago: string;
-  tipoFactura: 'ZZ' | 'FC';
-  notas: string;
-  items: CompraItemForm[];
-  busquedaProducto: string;
-  mostrarBuscador: boolean;
-  modoItemRapido: boolean;
-  guardando: boolean;
-  error: string;
-  // Escaneo de factura
-  escaneando: boolean;
-  resultadoEscaneo: FacturaEscaneada | null;
-  errorEscaneo: string;
-  /** Items del último escaneo que no se auto-vincularon y esperan decisión del usuario. */
-  itemsPendientesScan: FacturaItemEscaneado[];
-}
-
-/** Tipos de acciones del reducer */
-type CompraActionType =
-  | { type: 'SET_PROVEEDOR_ID'; payload: string }
-  | { type: 'SET_PROVEEDOR_NOMBRE'; payload: string }
-  | { type: 'SET_USAR_PROVEEDOR_NUEVO'; payload: boolean }
-  | { type: 'SET_NUMERO_FACTURA'; payload: string }
-  | { type: 'SET_FECHA_COMPRA'; payload: string }
-  | { type: 'SET_FORMA_PAGO'; payload: string }
-  | { type: 'SET_TIPO_FACTURA'; payload: 'ZZ' | 'FC' }
-  | { type: 'SET_NOTAS'; payload: string }
-  | { type: 'SET_BUSQUEDA'; payload: string }
-  | { type: 'SET_MOSTRAR_BUSCADOR'; payload: boolean }
-  | { type: 'SET_GUARDANDO'; payload: boolean }
-  | { type: 'SET_ERROR'; payload: string }
-  | { type: 'AGREGAR_ITEM'; payload: ProductoDB }
-  | { type: 'ACTUALIZAR_ITEM'; payload: { index: number; campo: keyof CompraItemForm; valor: number | string } }
-  // Condición y alícuota se setean juntas: la condición manda sobre la tasa.
-  | { type: 'SET_CONDICION_ITEM'; payload: { index: number; clave: string } }
-  | { type: 'ELIMINAR_ITEM'; payload: number }
-  | { type: 'LIMPIAR_BUSQUEDA' }
-  | { type: 'SET_MODO_ITEM_RAPIDO'; payload: boolean }
-  | { type: 'AGREGAR_ITEM_RAPIDO'; payload: { productoId: string; nombre: string; codigo: string; costoUnitario: number } }
-  | { type: 'IMPORTAR_ITEMS'; payload: CompraItemForm[] }
-  | { type: 'SET_ESCANEANDO'; payload: boolean }
-  | { type: 'SET_RESULTADO_ESCANEO'; payload: FacturaEscaneada | null }
-  | { type: 'SET_ERROR_ESCANEO'; payload: string }
-  | { type: 'APLICAR_ESCANEO'; payload: { proveedorId: string; proveedorNombre: string; numeroFactura: string; fechaCompra: string; formaPago: string; items: CompraItemForm[]; pendientes: FacturaItemEscaneado[] } }
-  | { type: 'RESOLVER_PENDIENTE_VINCULAR'; payload: { index: number; producto: ProductoDB } }
-  | { type: 'RESOLVER_PENDIENTE_CREAR'; payload: { index: number; producto: ProductoDB } }
-  | { type: 'RESOLVER_PENDIENTE_OMITIR'; payload: { index: number } }
-  | { type: 'LIMPIAR_PENDIENTES_SCAN' }
-  | { type: 'SET_EXTRAS'; payload: Partial<Pick<CompraState, 'percepcionIva' | 'percepcionIibb' | 'noGravado'>> }
-  | { type: 'SET_CONTROL'; payload: Partial<ControlFactura> }
-  | { type: 'APLICAR_BONIF_GLOBAL'; payload: number };
 
 /** Props del componente principal */
 export interface ModalCompraProps {
@@ -256,11 +108,42 @@ interface ItemRowProps {
   condicionDelProducto?: string;
 }
 
+/** Props de CargosSection */
+interface CargosSectionProps {
+  state: CompraState;
+  dispatch: React.Dispatch<CompraActionType>;
+  /** Cargos de la última compra de este proveedor. null = no hay ninguna con cargos. */
+  plantilla?: PlantillaCargosProveedor | null;
+  /** Lo que el impuesto interno declarado permite deducir. null = el motor no pudo. */
+  resolucion: ResultadoBasesII | null;
+}
+
+/** Props de CargoRow */
+interface CargoRowProps {
+  cargo: CargoCompraForm;
+  items: CompraItemForm[];
+  dispatch: React.Dispatch<CompraActionType>;
+  resolucion: ResultadoBasesII | null;
+}
+
+/** Props de GrillaPesos */
+interface GrillaPesosProps {
+  cargo: CargoCompraForm;
+  items: CompraItemForm[];
+  dispatch: React.Dispatch<CompraActionType>;
+}
+
+/** Props de VistaPreviaCostosSection */
+interface VistaPreviaCostosProps {
+  state: CompraState;
+}
+
 /** Props de ResumenSection */
 interface ResumenSectionProps {
   totales: TotalesCompra;
   state: CompraState;
   dispatch: React.Dispatch<CompraActionType>;
+  resolucion: ResultadoBasesII | null;
 }
 
 // Constantes
@@ -274,254 +157,44 @@ const FORMAS_PAGO = [
   { value: 'tarjeta', label: 'Tarjeta' }
 ]
 
-// Estado inicial
-const initialState: CompraState = {
-  // Desglose fiscal extra (solo FC)
-  percepcionIva: 0,
-  percepcionIibb: 0,
-  noGravado: 0,
-  controlFactura: { gravado: 0, iva: 0, impuestosInternos: 0, percepciones: 0, total: 0 },
-  // Proveedor
-  proveedorId: '',
-  proveedorNombre: '',
-  usarProveedorNuevo: false,
-  // Datos de compra
-  numeroFactura: '',
-  fechaCompra: fechaLocalISO(),
-  formaPago: 'efectivo',
-  tipoFactura: 'FC',
-  notas: '',
-  // Items
-  items: [],
-  // UI
-  busquedaProducto: '',
-  mostrarBuscador: false,
-  modoItemRapido: false,
-  guardando: false,
-  error: '',
-  // Escaneo
-  escaneando: false,
-  resultadoEscaneo: null,
-  errorEscaneo: '',
-  itemsPendientesScan: []
-}
-
-// Reducer
-function compraReducer(state: CompraState, action: CompraActionType): CompraState {
-  switch (action.type) {
-    case 'SET_PROVEEDOR_ID':
-      return { ...state, proveedorId: action.payload }
-    case 'SET_PROVEEDOR_NOMBRE':
-      return { ...state, proveedorNombre: action.payload }
-    case 'SET_USAR_PROVEEDOR_NUEVO':
-      return { ...state, usarProveedorNuevo: action.payload }
-    case 'SET_NUMERO_FACTURA':
-      return { ...state, numeroFactura: action.payload }
-    case 'SET_FECHA_COMPRA':
-      return { ...state, fechaCompra: action.payload }
-    case 'SET_FORMA_PAGO':
-      return { ...state, formaPago: action.payload }
-    case 'SET_TIPO_FACTURA':
-      return { ...state, tipoFactura: action.payload }
-    case 'SET_NOTAS':
-      return { ...state, notas: action.payload }
-    case 'SET_BUSQUEDA':
-      return { ...state, busquedaProducto: action.payload, mostrarBuscador: true }
-    case 'SET_MOSTRAR_BUSCADOR':
-      return { ...state, mostrarBuscador: action.payload }
-    case 'SET_GUARDANDO':
-      return { ...state, guardando: action.payload }
-    case 'SET_ERROR':
-      return { ...state, error: action.payload }
-
-    case 'AGREGAR_ITEM': {
-      const producto = action.payload
-      const existente = state.items.find(i => i.productoId === producto.id)
-
-      if (existente) {
-        return {
-          ...state,
-          items: state.items.map(i =>
-            i.productoId === producto.id
-              ? { ...i, cantidad: i.cantidad + 1 }
-              : i
-          ),
-          busquedaProducto: '',
-          mostrarBuscador: false
-        }
-      }
-
-      return {
-        ...state,
-        items: [...state.items, {
-          productoId: producto.id,
-          productoNombre: producto.nombre,
-          productoCodigo: producto.codigo,
-          cantidad: 1,
-          bonificacion: 0,
-          costoUnitario: producto.costo_sin_iva || 0,
-          impuestosInternos: producto.impuestos_internos || 0,
-          porcentajeIva: producto.porcentaje_iva ?? 21,
-          condicionIva: producto.condicion_iva ?? 'gravado',
-          stockActual: producto.stock
-        }],
-        busquedaProducto: '',
-        mostrarBuscador: false
-      }
-    }
-
-    case 'ACTUALIZAR_ITEM':
-      return {
-        ...state,
-        items: state.items.map((item, i) =>
-          i === action.payload.index
-            ? { ...item, [action.payload.campo]: action.payload.valor }
-            : item
-        )
-      }
-
-    case 'SET_CONDICION_ITEM': {
-      const opcion = OPCIONES_CONDICION_IVA.find(o => o.clave === action.payload.clave)
-      if (!opcion) return state
-      return {
-        ...state,
-        items: state.items.map((item, i) =>
-          i === action.payload.index
-            ? { ...item, condicionIva: opcion.condicion, porcentajeIva: opcion.porcentaje }
-            : item
-        )
-      }
-    }
-
-    case 'ELIMINAR_ITEM':
-      return {
-        ...state,
-        items: state.items.filter((_, i) => i !== action.payload)
-      }
-
-    case 'LIMPIAR_BUSQUEDA':
-      return { ...state, busquedaProducto: '', mostrarBuscador: false }
-
-    case 'SET_MODO_ITEM_RAPIDO':
-      return { ...state, modoItemRapido: action.payload }
-
-    case 'AGREGAR_ITEM_RAPIDO': {
-      const { productoId, nombre, codigo, costoUnitario } = action.payload
-      return {
-        ...state,
-        items: [...state.items, {
-          productoId,
-          productoNombre: nombre,
-          productoCodigo: codigo,
-          cantidad: 1,
-          bonificacion: 0,
-          costoUnitario,
-          impuestosInternos: 0,
-          porcentajeIva: 21,
-          condicionIva: 'gravado',
-          stockActual: 0
-        }],
-        modoItemRapido: false,
-        busquedaProducto: '',
-        mostrarBuscador: false
-      }
-    }
-
-    case 'IMPORTAR_ITEMS':
-      return {
-        ...state,
-        items: [...state.items, ...action.payload]
-      }
-
-    case 'SET_ESCANEANDO':
-      return { ...state, escaneando: action.payload, errorEscaneo: '' }
-
-    case 'SET_RESULTADO_ESCANEO':
-      return { ...state, resultadoEscaneo: action.payload, escaneando: false }
-
-    case 'SET_ERROR_ESCANEO':
-      return { ...state, errorEscaneo: action.payload, escaneando: false }
-
-    case 'APLICAR_ESCANEO': {
-      const { proveedorId, proveedorNombre, numeroFactura, fechaCompra, formaPago, items, pendientes } = action.payload
-      return {
-        ...state,
-        proveedorId,
-        proveedorNombre,
-        usarProveedorNuevo: !proveedorId && !!proveedorNombre,
-        numeroFactura,
-        fechaCompra: fechaCompra || state.fechaCompra,
-        formaPago: formaPago || state.formaPago,
-        items,
-        itemsPendientesScan: pendientes,
-        resultadoEscaneo: null,
-        errorEscaneo: ''
-      }
-    }
-
-    case 'RESOLVER_PENDIENTE_VINCULAR':
-    case 'RESOLVER_PENDIENTE_CREAR': {
-      const { index, producto } = action.payload
-      const scanItem = state.itemsPendientesScan[index]
-      if (!scanItem) return state
-      const nuevoItem = construirCompraItemDesdeScan(producto, scanItem)
-      // Si ya existe un item con el mismo productoId, sumar cantidades
-      const existenteIdx = state.items.findIndex(i => i.productoId === producto.id)
-      const itemsActualizados = existenteIdx >= 0
-        ? state.items.map((i, idx) =>
-            idx === existenteIdx
-              ? { ...i, cantidad: i.cantidad + nuevoItem.cantidad }
-              : i
-          )
-        : [...state.items, nuevoItem]
-      return {
-        ...state,
-        items: itemsActualizados,
-        itemsPendientesScan: state.itemsPendientesScan.filter((_, i) => i !== index)
-      }
-    }
-
-    case 'RESOLVER_PENDIENTE_OMITIR': {
-      const { index } = action.payload
-      return {
-        ...state,
-        itemsPendientesScan: state.itemsPendientesScan.filter((_, i) => i !== index)
-      }
-    }
-
-    case 'LIMPIAR_PENDIENTES_SCAN':
-      return { ...state, itemsPendientesScan: [] }
-
-    case 'SET_EXTRAS':
-      return { ...state, ...action.payload }
-
-    case 'SET_CONTROL':
-      return { ...state, controlFactura: { ...state.controlFactura, ...action.payload } }
-
-    case 'APLICAR_BONIF_GLOBAL':
-      return {
-        ...state,
-        items: state.items.map(item => ({ ...item, bonificacion: action.payload }))
-      }
-
-    default:
-      return state
-  }
-}
-
 // Hook para cálculos de impuestos: delega en calcularTotalesCompra (fuente
 // única, testeada con la factura Manaos). ZZ: lo pagado es todo (sin IVA, II
 // ni percepciones).
+//
+// Los cargos entran acá y no sólo en la vista previa: desde que una bonificación
+// se carga como cargo, el neto gravado, el IVA y el impuesto interno de la
+// cabecera dependen de ellos, y son los que viajan a `compras.iva` y a
+// `compras.impuestos_internos`. Sin esto la posición fiscal quedaba inflada.
+//
+// El motor lanza ante un peso o una cantidad corruptos —mientras el usuario
+// tipea, un campo a medio escribir alcanza— así que la llamada va envuelta: se
+// cae a la aritmética sin cargos para no dejar el resumen en blanco. No tapa
+// nada: la vista previa muestra el error con su texto y `validarCargos` frena
+// el guardado antes de que un número así llegue a la base.
 function useCalculosImpuestos(
   items: CompraItemForm[],
   tipoFactura: 'ZZ' | 'FC',
   percepcionIva: number,
   percepcionIibb: number,
-  noGravado: number
+  noGravado: number,
+  cargos: CargoCompraForm[],
+  iiDeclarado: Record<number, number>
 ): TotalesCompra {
   return useMemo(
-    () => calcularTotalesCompra(items, tipoFactura, { percepcionIva, percepcionIibb, noGravado }),
-    [items, tipoFactura, percepcionIva, percepcionIibb, noGravado]
+    () => {
+      const extras = { percepcionIva, percepcionIibb, noGravado }
+      // El borde va adentro del memo: `cargosParaMotor` arma un array nuevo en
+      // cada render y como dependencia anularía la memoización.
+      try {
+        return calcularTotalesCompra(
+          items, tipoFactura, extras,
+          cargosParaMotor(cargos), iiDeclaradoParaMotor(iiDeclarado, tipoFactura)
+        )
+      } catch {
+        return calcularTotalesCompra(items, tipoFactura, extras)
+      }
+    },
+    [items, tipoFactura, percepcionIva, percepcionIibb, noGravado, cargos, iiDeclarado]
   )
 }
 
@@ -532,8 +205,21 @@ export default function ModalCompra({ productos, proveedores, onSave, onClose, o
   const [state, dispatch] = useReducer(compraReducer, initialState)
   const [modalProveedorOpen, setModalProveedorOpen] = useState(false)
   const [modalImportarOpen, setModalImportarOpen] = useState(false)
-  const totales = useCalculosImpuestos(state.items, state.tipoFactura, state.percepcionIva, state.percepcionIibb, state.noGravado)
+  const totales = useCalculosImpuestos(
+    state.items, state.tipoFactura, state.percepcionIva, state.percepcionIibb, state.noGravado,
+    state.cargos, state.iiDeclarado
+  )
   const { subtotal, iva, impuestosInternos, total } = totales
+
+  // Qué bonificaciones bajan la base del impuesto interno, deducido del
+  // declarado. Se calcula UNA vez acá y baja a las dos secciones que lo
+  // muestran —los casilleros de "Cargos y prorrateo" y el cuadre del resumen—
+  // porque son la misma respuesta dicha en dos lugares y calcularla dos veces
+  // es la forma de que un día digan cosas distintas.
+  const resolucionII = useMemo(
+    () => resolucionBasesII(state.items, state.cargos, state.iiDeclarado, state.tipoFactura),
+    [state.items, state.cargos, state.iiDeclarado, state.tipoFactura]
+  )
 
   // Tasa de II vigente por producto: para autocompletar y detectar líneas que
   // difieren (alícuota cambiada en la factura → se propaga al producto al guardar).
@@ -555,6 +241,14 @@ export default function ModalCompra({ productos, proveedores, onSave, onClose, o
     [productos]
   )
   const fileInputRef = useRef<HTMLInputElement>(null)
+
+  // Cargos de la última compra de este proveedor, para reusarlos. Se pide al
+  // elegir el proveedor y no al apretar el botón: así la sección sabe de
+  // antemano si hay algo para traer, en vez de ofrecer un botón que a veces no
+  // hace nada. Con proveedor nuevo (sin id) la query queda apagada.
+  const plantillaCargos = useCargosPlantillaProveedorQuery(
+    state.usarProveedorNuevo ? null : state.proveedorId
+  )
 
   // Productos filtrados
   const productosFiltrados = useMemo(() => {
@@ -715,6 +409,15 @@ export default function ModalCompra({ productos, proveedores, onSave, onClose, o
         return
       }
     }
+    // Lo que la RPC va a rechazar de los cargos, dicho antes de salir a la red.
+    // La validación que manda sigue siendo la de la mig 194 —corre aunque el
+    // cliente esté viejo— pero un round trip para enterarse de que el flete no
+    // tiene ninguna línea asignada es un round trip de más.
+    const errorCargos = validarCargos(state.cargos)
+    if (errorCargos) {
+      dispatch({ type: 'SET_ERROR', payload: errorCargos })
+      return
+    }
 
     dispatch({ type: 'SET_GUARDANDO', payload: true })
     try {
@@ -729,6 +432,9 @@ export default function ModalCompra({ productos, proveedores, onSave, onClose, o
         percepcionIva: state.tipoFactura === 'FC' ? state.percepcionIva : 0,
         percepcionIibb: state.tipoFactura === 'FC' ? state.percepcionIibb : 0,
         noGravado: state.tipoFactura === 'FC' ? state.noGravado : 0,
+        // mig 195. Ya viene en 0 en ZZ desde el motor; el `total` de arriba la
+        // tiene adentro, así que las dos puntas del cuadre dicen lo mismo.
+        bonificaciones: totales.bonificaciones,
         otrosImpuestos: 0,
         total,
         // Líneas FC cuya tasa de II fue editada a mano: la alícuota nueva se
@@ -745,6 +451,13 @@ export default function ModalCompra({ productos, proveedores, onSave, onClose, o
         formaPago: state.formaPago,
         notas: state.notas,
         tipoFactura: state.tipoFactura,
+        // Los pesos viajan por ÍNDICE del array de items de abajo: los
+        // compra_items.id no existen todavía. `cargosParaRPC` traduce contra
+        // ESE mismo array, así que los dos tienen que salir de `state.items`.
+        cargos: cargosParaRPC(state.items, state.cargos),
+        // En ZZ la RPC lo descarta igual; mandarlo ya filtrado deja a las dos
+        // puntas diciendo lo mismo.
+        iiDeclarado: iiDeclaradoParaMotor(state.iiDeclarado, state.tipoFactura),
         items: state.items.map(item => {
           const costoConBonif = (item.costoUnitario || 0) * (1 - (item.bonificacion || 0) / 100)
           return {
@@ -890,9 +603,22 @@ export default function ModalCompra({ productos, proveedores, onSave, onClose, o
               onImportarExcel={() => setModalImportarOpen(true)}
             />
 
+            {/* Cargos y prorrateo. También en ZZ —el 47,9% de las compras—: el
+                tipo de comprobante decide si se agregan impuestos encima, no si
+                se ignoran costos, y un flete que factura un transportista aparte
+                no está adentro del precio pagado. La regla de ZZ se aplica en el
+                borde del motor (lineasParaMotor), no apagando la sección.
+                El único gate es tener líneas donde repartir. */}
+            {state.items.length > 0 && (
+              <>
+                <CargosSection state={state} dispatch={dispatch} plantilla={plantillaCargos.data} resolucion={resolucionII} />
+                <VistaPreviaCostosSection state={state} />
+              </>
+            )}
+
             {/* Totales */}
             {state.items.length > 0 && (
-              <ResumenSection totales={totales} state={state} dispatch={dispatch} />
+              <ResumenSection totales={totales} state={state} dispatch={dispatch} resolucion={resolucionII} />
             )}
 
             {/* Notas */}
@@ -1916,6 +1642,652 @@ function ItemPendienteRow({
   )
 }
 
+/** Bases de reparto ofrecidas, con la ayuda que explica cada una. */
+const BASES_PRORRATEO: Array<{ value: BaseProrrateo; label: string; ayuda: string }> = [
+  { value: 'monto', label: 'Por monto', ayuda: 'Cada línea pesa lo que vale (neto ya bonificado). Es lo habitual para el flete.' },
+  { value: 'cantidad', label: 'Por cantidad', ayuda: 'Cada línea pesa sus unidades. Sirve para pallets y separadores.' },
+  // La mig 192 la llama 'unidades', pero la regla es peso 1 en TODAS las líneas:
+  // lo que reparte son partes iguales, no unidades del producto.
+  { value: 'unidades', label: 'Partes iguales', ayuda: 'Todas las líneas pesan lo mismo, sin importar monto ni cantidad.' },
+]
+
+/** ¿Este peso puede entrar a `prorratearCargo` sin hacerlo lanzar? */
+function pesoInvalido(peso: number): boolean {
+  return !Number.isFinite(peso) || peso < 0
+}
+
+/**
+ * Reparto de un cargo línea por línea: el peso editable y la plata que le toca.
+ *
+ * `prorratearCargo` LANZA ante un peso no finito o negativo, y está bien que lo
+ * haga: convertir basura en 0 la volvería indistinguible de una exclusión
+ * deliberada, y el 0 ES el mecanismo de exclusión. Consecuencias acá:
+ *  - Quien parsea es el formulario. NumberInput sólo emite números finitos y
+ *    clampea a min=0, así que un campo a medio tipear ("", "1.") nunca llega al
+ *    cálculo: el peso confirmado sigue siendo el anterior.
+ *  - Igual se detectan las filas inválidas ANTES de llamar, y la llamada va
+ *    envuelta. Un peso podrido deja su fila en error; no deja el modal en
+ *    blanco.
+ */
+function GrillaPesos({ cargo, items, dispatch }: GrillaPesosProps) {
+  // Sólo las líneas ya numeradas por el reducer; sin id no hay dónde colgar el peso.
+  const lineas = items.flatMap(item =>
+    item.lineaId === undefined ? [] : [{ item, id: item.lineaId }]
+  )
+
+  const pesoDe = (id: number): number => cargo.pesos[id] ?? 0
+  const hayInvalidos = lineas.some(l => pesoInvalido(pesoDe(l.id)))
+
+  // Sin useMemo: son un puñado de líneas y el React Compiler ya memoiza. Lo que
+  // no puede faltar es el try, que es lo que separa "esa fila está en error" de
+  // "el modal desapareció".
+  const reparto = ((): Record<number, number> | null => {
+    if (hayInvalidos) return null
+    try {
+      return prorratearCargo(cargo.monto, cargo.pesos)
+    } catch {
+      return null
+    }
+  })()
+
+  const totalPeso = lineas.reduce((acc, l) => acc + (pesoInvalido(pesoDe(l.id)) ? 0 : pesoDe(l.id)), 0)
+  const sumaRepartida = reparto ? Object.values(reparto).reduce((acc, v) => acc + v, 0) : 0
+  // El residuo va a la línea de mayor peso justamente para que esto cierre al
+  // centavo. Si alguna vez no cierra, es un bug del motor y hay que verlo.
+  const cuadra = reparto !== null && Math.abs(sumaRepartida - cargo.monto) < 0.005
+
+  const setPeso = (id: number, peso: number) =>
+    dispatch({ type: 'SET_PESO_CARGO', payload: { cargoId: cargo.id, lineaId: id, peso } })
+
+  const inputPeso = (id: number, invalida: boolean) => (
+    <NumberInput
+      min={0}
+      emptyValue={0}
+      value={invalida ? 0 : pesoDe(id)}
+      onChange={(n) => setPeso(id, n)}
+      commitOnChange
+      title="0 excluye la línea de este cargo"
+      className={`w-full px-2 py-1 text-right border rounded text-sm dark:bg-gray-700 dark:text-white ${
+        invalida ? 'border-red-400 bg-red-50 dark:bg-red-900/20' : 'dark:border-gray-600'
+      }`}
+    />
+  )
+
+  const montoAsignado = (id: number) => (reparto === null ? null : reparto[id] ?? 0)
+
+  return (
+    <div className="mt-2 space-y-2">
+      {/* Header solo en desktop */}
+      <div className="hidden md:grid grid-cols-12 gap-2 text-xs font-medium text-gray-500 uppercase px-2">
+        <div className="col-span-6">Producto</div>
+        <div className="col-span-3 text-right">Peso</div>
+        <div className="col-span-3 text-right">Le toca</div>
+      </div>
+
+      {lineas.map(({ item, id }) => {
+        const invalida = pesoInvalido(pesoDe(id))
+        const asignado = montoAsignado(id)
+        return (
+          <div key={id} className="bg-gray-50 dark:bg-gray-900 rounded px-2 py-2">
+            {/* Mobile: apilado */}
+            <div className="md:hidden space-y-2">
+              <p className="text-sm text-gray-800 dark:text-white">{item.productoNombre}</p>
+              <div className="grid grid-cols-2 gap-2 items-center">
+                <div>
+                  <label className="block text-xs text-gray-500 mb-1">Peso</label>
+                  {inputPeso(id, invalida)}
+                </div>
+                <div className="text-right">
+                  <span className="block text-xs text-gray-500 mb-1">Le toca</span>
+                  <span className="text-sm font-medium text-gray-800 dark:text-white">
+                    {asignado === null ? '—' : formatPrecio(asignado)}
+                  </span>
+                </div>
+              </div>
+            </div>
+
+            {/* Desktop: grilla */}
+            <div className="hidden md:grid grid-cols-12 gap-2 items-center">
+              <p className="col-span-6 text-sm text-gray-800 dark:text-white truncate" title={item.productoNombre}>
+                {item.productoNombre}
+              </p>
+              <div className="col-span-3">{inputPeso(id, invalida)}</div>
+              <div className="col-span-3 text-right text-sm font-medium text-gray-800 dark:text-white">
+                {asignado === null ? '—' : formatPrecio(asignado)}
+              </div>
+            </div>
+
+            {invalida && (
+              <p className="text-xs text-red-600 dark:text-red-400 mt-1">
+                Peso inválido ({String(pesoDe(id))}): tiene que ser un número mayor o igual a 0. El 0 excluye la línea.
+              </p>
+            )}
+          </div>
+        )
+      })}
+
+      <div className="flex justify-between items-center text-sm pt-2 border-t dark:border-gray-600">
+        <span className="text-gray-600 dark:text-gray-400">Suma repartida</span>
+        <span className={`font-medium ${cuadra ? 'text-gray-800 dark:text-white' : 'text-red-600'}`}>
+          {reparto === null ? '—' : formatPrecio(sumaRepartida)}
+          <span className="text-gray-500 font-normal"> / {formatPrecio(cargo.monto)}</span>
+        </span>
+      </div>
+
+      {hayInvalidos && (
+        <p className="text-xs text-red-600 dark:text-red-400">
+          Hay pesos inválidos: mientras estén así este cargo no se reparte.
+        </p>
+      )}
+      {!hayInvalidos && totalPeso === 0 && (
+        <p className="text-xs text-amber-700 dark:text-amber-300">
+          ⚠ Todos los pesos están en 0: este cargo no se reparte a ninguna línea y no llega a ningún costo.
+        </p>
+      )}
+      {!hayInvalidos && totalPeso > 0 && !cuadra && (
+        <p className="text-xs text-red-600 dark:text-red-400">
+          El reparto no suma el monto del cargo. Es un error de cálculo, no de carga: no registres la compra así.
+        </p>
+      )}
+    </div>
+  )
+}
+
+/**
+ * Un cargo de la factura: concepto, monto y las tres decisiones fiscales.
+ *
+ * El signo vive en un toggle y no en el campo, porque NumberInput no deja
+ * tipear el "-" (sanitiza a dígitos). Tipear -500 y que quede 500 en silencio
+ * sería peor que pedir el gesto explícito.
+ */
+/**
+ * Lo que el impuesto interno declarado tiene para decir sobre el casillero de
+ * ESTE cargo.
+ *
+ * Desde el solver, `afectaBaseII` deja de ser una pregunta que el usuario no
+ * puede contestar —lo decide el proveedor y la factura testigo demuestra que
+ * trató dos bonificaciones del mismo comprobante de forma distinta— y pasa a ser
+ * una respuesta que sale de la factura. Pero sigue siendo editable, así que la
+ * leyenda tiene que decir de dónde salió el valor que se está viendo: deducido,
+ * puesto a mano, o indeterminable.
+ *
+ * El caso que más importa es el tercero: un cargo que casi no mueve el impuesto
+ * interno de ninguna alícuota no se puede deducir de ningún declarado, y decirlo
+ * es mejor que dejar el casillero mudo al lado de otros que sí se resolvieron.
+ */
+function leyendaBaseII(
+  cargo: CargoCompraForm,
+  resolucion: ResultadoBasesII | null
+): { texto: string; clase: string } | null {
+  if (!resolucion || cargo.condicionIva !== 'gravado') return null
+  if (resolucion.indeterminables.includes(cargo.id)) {
+    return {
+      texto: 'La factura no alcanza para deducirlo: este cargo casi no mueve el impuesto interno de ninguna alícuota.',
+      clase: 'text-gray-500 dark:text-gray-400',
+    }
+  }
+  if (resolucion.estado !== 'unica' || !resolucion.candidatos.includes(cargo.id)) return null
+  const deducido = resolucion.soluciones[0].asignacion[cargo.id]
+  if (!cargo.afectaBaseIIManual) {
+    return {
+      texto: 'Deducido del impuesto interno declarado en la factura. Cambialo si sabés que es otra cosa.',
+      clase: 'text-green-700 dark:text-green-400',
+    }
+  }
+  return deducido === cargo.afectaBaseII
+    ? {
+        texto: 'Lo marcaste vos, y es lo mismo que dice el impuesto interno declarado.',
+        clase: 'text-gray-500 dark:text-gray-400',
+      }
+    : {
+        texto: `Lo marcaste vos. Según el impuesto interno declarado, ${deducido ? 'sí' : 'no'} debería bajar la base — manda lo tuyo.`,
+        clase: 'text-amber-700 dark:text-amber-300',
+      }
+}
+
+function CargoRow({ cargo, items, dispatch, resolucion }: CargoRowProps) {
+  // El signo es estado de la fila y no `cargo.monto < 0`: con monto en 0 el
+  // toggle volvería solo a "Cargo" apenas se elige "Bonificación".
+  const [esBonificacion, setEsBonificacion] = useState(cargo.monto < 0)
+  const [mostrarPesos, setMostrarPesos] = useState(false)
+  const set = (cambios: CambiosCargo) =>
+    dispatch({ type: 'ACTUALIZAR_CARGO', payload: { id: cargo.id, cambios } })
+
+  const cambiarSigno = (bonificacion: boolean) => {
+    setEsBonificacion(bonificacion)
+    const magnitud = Math.abs(cargo.monto)
+    set({ monto: bonificacion ? -magnitud : magnitud })
+  }
+
+  const baseElegida = BASES_PRORRATEO.find(b => b.value === cargo.baseProrrateo)
+  const leyenda = leyendaBaseII(cargo, resolucion)
+
+  return (
+    <div className="bg-white dark:bg-gray-800 p-3 rounded-lg border dark:border-gray-600 space-y-3">
+      <div className="flex items-start gap-2">
+        <div className="flex-1 min-w-0">
+          <label className="block text-xs text-gray-500 mb-1">Concepto</label>
+          <input
+            type="text"
+            value={cargo.concepto}
+            onChange={(e: ChangeEvent<HTMLInputElement>) => set({ concepto: e.target.value })}
+            placeholder="Flete, pallets, separadores, bonificación..."
+            className="w-full px-3 py-1.5 text-sm border dark:border-gray-600 rounded focus:ring-2 focus:ring-green-500 dark:bg-gray-700 dark:text-white"
+          />
+        </div>
+        <button
+          type="button"
+          onClick={() => dispatch({ type: 'ELIMINAR_CARGO', payload: cargo.id })}
+          className="mt-5 p-1 text-red-500 hover:bg-red-50 dark:hover:bg-red-900/20 rounded shrink-0"
+          title="Quitar este cargo"
+        >
+          <Trash2 className="w-4 h-4" />
+        </button>
+      </div>
+
+      <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
+        <div>
+          <label className="block text-xs text-gray-500 mb-1">Monto (sin IVA)</label>
+          <div className="flex gap-1">
+            <div className="flex rounded overflow-hidden border dark:border-gray-600 shrink-0">
+              {([false, true] as const).map(bonif => (
+                <button
+                  key={String(bonif)}
+                  type="button"
+                  onClick={() => cambiarSigno(bonif)}
+                  title={bonif ? 'Resta del costo (bonificación)' : 'Suma al costo'}
+                  className={`px-2 py-1.5 text-sm font-medium transition-colors ${
+                    esBonificacion === bonif
+                      ? 'bg-green-600 text-white'
+                      : 'bg-gray-100 text-gray-600 hover:bg-gray-200 dark:bg-gray-700 dark:text-gray-300 dark:hover:bg-gray-600'
+                  }`}
+                >
+                  {bonif ? '−' : '+'}
+                </button>
+              ))}
+            </div>
+            <NumberInput
+              min={0}
+              emptyValue={0}
+              value={Math.abs(cargo.monto)}
+              onChange={(n) => set({ monto: esBonificacion ? -Math.abs(n) : Math.abs(n) })}
+              commitOnChange
+              placeholder="0.00"
+              className="w-full px-2 py-1.5 text-right text-sm border dark:border-gray-600 rounded focus:ring-2 focus:ring-green-500 dark:bg-gray-700 dark:text-white"
+            />
+          </div>
+        </div>
+
+        <div>
+          <label className="block text-xs text-gray-500 mb-1" title="Un cargo gravado tributa a la alícuota de las líneas donde cae: no lleva alícuota propia.">
+            Tratamiento frente al IVA
+          </label>
+          <select
+            value={cargo.condicionIva}
+            onChange={(e: ChangeEvent<HTMLSelectElement>) => set({ condicionIva: e.target.value as CondicionIva })}
+            className="w-full px-2 py-1.5 text-sm border dark:border-gray-600 rounded focus:ring-2 focus:ring-green-500 dark:bg-gray-700 dark:text-white"
+          >
+            {OPCIONES_CONDICION_SIN_ALICUOTA.map(o => (
+              <option key={o.condicion} value={o.condicion}>{o.label}</option>
+            ))}
+          </select>
+        </div>
+
+        <div>
+          <label className="block text-xs text-gray-500 mb-1">Base de reparto</label>
+          <select
+            value={cargo.baseProrrateo}
+            onChange={(e: ChangeEvent<HTMLSelectElement>) => set({ baseProrrateo: e.target.value as BaseProrrateo })}
+            title={baseElegida?.ayuda}
+            className="w-full px-2 py-1.5 text-sm border dark:border-gray-600 rounded focus:ring-2 focus:ring-green-500 dark:bg-gray-700 dark:text-white"
+          >
+            {BASES_PRORRATEO.map(b => (
+              <option key={b.value} value={b.value}>{b.label}</option>
+            ))}
+          </select>
+        </div>
+      </div>
+
+      {/* Las dos casillas son independientes: el flete de un tercero entra al
+          costo pero no está en el papel; un redondeo de factura, al revés. */}
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+        <label className="flex items-start gap-2 cursor-pointer">
+          <input
+            type="checkbox"
+            checked={cargo.enFactura}
+            onChange={(e: ChangeEvent<HTMLInputElement>) => set({ enFactura: e.target.checked })}
+            className="mt-0.5 w-4 h-4 rounded border-gray-300 text-green-600 focus:ring-green-500"
+          />
+          <span className="text-sm dark:text-gray-200">
+            Viene en la factura
+            <span className="block text-xs text-gray-500 dark:text-gray-400">
+              Está impreso en el comprobante y suma al cuadre contra el papel.
+            </span>
+          </span>
+        </label>
+        <label className="flex items-start gap-2 cursor-pointer">
+          <input
+            type="checkbox"
+            checked={cargo.prorrateaAlCosto}
+            onChange={(e: ChangeEvent<HTMLInputElement>) => set({ prorrateaAlCosto: e.target.checked })}
+            className="mt-0.5 w-4 h-4 rounded border-gray-300 text-green-600 focus:ring-green-500"
+          />
+          <span className="text-sm dark:text-gray-200">
+            Entra al costo
+            <span className="block text-xs text-gray-500 dark:text-gray-400">
+              Se prorratea al costo unitario de los productos.
+            </span>
+          </span>
+        </label>
+      </div>
+
+      {/* Sólo para un cargo gravado: el motor lo lee como `gravado &&
+          afectaBaseII`, así que ofrecerlo en exento o no gravado prometería un
+          efecto que no ocurre. Al salir de "gravado" el reducer lo apaga. */}
+      {cargo.condicionIva === 'gravado' && (
+        <label className="flex items-start gap-2 cursor-pointer">
+          <input
+            type="checkbox"
+            checked={cargo.afectaBaseII}
+            onChange={(e: ChangeEvent<HTMLInputElement>) => set({ afectaBaseII: e.target.checked })}
+            className="mt-0.5 w-4 h-4 rounded border-gray-300 text-green-600 focus:ring-green-500"
+          />
+          <span className="text-sm dark:text-gray-200">
+            Afecta la base de impuestos internos
+            <span className="block text-xs text-gray-500 dark:text-gray-400">
+              Un descuento de precio baja la base; una bonificación comercial no.
+            </span>
+            {leyenda && <span className={`block text-xs ${leyenda.clase}`}>{leyenda.texto}</span>}
+          </span>
+        </label>
+      )}
+
+      <div className="pt-2 border-t dark:border-gray-700">
+        <button
+          type="button"
+          onClick={() => setMostrarPesos(v => !v)}
+          className="text-sm text-blue-600 hover:underline"
+        >
+          {mostrarPesos
+            ? 'Ocultar reparto'
+            : `Ver reparto entre ${items.length} ${items.length === 1 ? 'línea' : 'líneas'} ▸`}
+        </button>
+        {mostrarPesos && <GrillaPesos cargo={cargo} items={items} dispatch={dispatch} />}
+      </div>
+    </div>
+  )
+}
+
+/**
+ * Sección "Cargos y prorrateo": el flete, los pallets y los separadores que hoy
+ * no se cargan en ningún lado y son el 16,2% del costo.
+ *
+ * Plegada por defecto: el promedio es 4,1 ítems por compra y la compra chica no
+ * tiene por qué ver esto. Va también en ZZ —el 47,9% de las compras—: el tipo de
+ * comprobante decide si se agregan impuestos encima, no si se ignoran costos.
+ */
+function CargosSection({ state, dispatch, plantilla, resolucion }: CargosSectionProps) {
+  const [abierta, setAbierta] = useState(false)
+  const { cargos } = state
+  const totalAlCosto = cargos.filter(c => c.prorrateaAlCosto).reduce((acc, c) => acc + c.monto, 0)
+  const totalEnFactura = cargos.filter(c => c.enFactura).reduce((acc, c) => acc + c.monto, 0)
+  // Los de la plantilla que faltan, con el MISMO criterio que usa el reducer al
+  // aplicarla: lo que dice el botón es exactamente lo que va a pasar.
+  const deLaPlantilla = plantilla?.cargos ?? []
+  const paraTraer = cargosPlantillaNuevos(cargos, deLaPlantilla)
+  const facturaPlantilla = plantilla?.numeroFactura ? `factura ${plantilla.numeroFactura}` : 'la última compra'
+
+  return (
+    <div className="bg-gray-50 dark:bg-gray-900 rounded-lg p-3 sm:p-4">
+      <button
+        type="button"
+        onClick={() => setAbierta(v => !v)}
+        className="w-full flex items-center justify-between gap-2 text-left"
+      >
+        <div className="flex items-center gap-2 min-w-0">
+          {abierta
+            ? <ChevronDown className="w-4 h-4 text-gray-500 shrink-0" />
+            : <ChevronRight className="w-4 h-4 text-gray-500 shrink-0" />}
+          <Truck className="w-5 h-5 text-gray-500 shrink-0" />
+          <h3 className="font-medium text-gray-800 dark:text-white truncate">Cargos y prorrateo</h3>
+          {cargos.length > 0 && (
+            <span className="px-1.5 py-0.5 text-xs rounded bg-green-100 text-green-700 dark:bg-green-900/40 dark:text-green-300 shrink-0">
+              {cargos.length}
+            </span>
+          )}
+        </div>
+        {!abierta && (
+          <span className="text-xs text-gray-500 text-right shrink-0">
+            {cargos.length === 0
+              ? 'Flete, pallets, bonificaciones'
+              : `${formatPrecio(totalAlCosto)} al costo`}
+          </span>
+        )}
+      </button>
+
+      {abierta && (
+        <div className="mt-3 space-y-3">
+          {cargos.length === 0 ? (
+            <p className="text-sm text-gray-500">
+              Conceptos de la factura que no son renglones de producto: flete, pallets,
+              separadores, bonificaciones. Se reparten entre las líneas y entran al costo.
+            </p>
+          ) : (
+            cargos.map(cargo => (
+              <CargoRow key={cargo.id} cargo={cargo} items={state.items} dispatch={dispatch}
+                        resolucion={resolucion} />
+            ))
+          )}
+
+          <div className="flex flex-wrap items-center gap-2">
+            <button
+              type="button"
+              onClick={() => dispatch({ type: 'AGREGAR_CARGO' })}
+              className="flex items-center gap-1 px-3 py-1.5 bg-green-600 text-white rounded hover:bg-green-700 text-sm transition-colors"
+            >
+              <Plus className="w-4 h-4" /> Agregar cargo
+            </button>
+
+            {/* Plantilla del proveedor: el flete y los pallets de Manaos son los
+                mismos todos los meses y el reparto a mano no es sostenible. Se
+                traen los conceptos, las banderas y los pesos; el monto queda en
+                0 porque es lo único que cambia factura a factura. */}
+            {paraTraer.length > 0 && (
+              <button
+                type="button"
+                onClick={() => dispatch({ type: 'APLICAR_CARGOS_PLANTILLA', payload: deLaPlantilla })}
+                title={`Trae ${paraTraer.map(c => c.concepto).join(', ')} de ${facturaPlantilla}, con sus pesos y el monto en 0`}
+                className="flex items-center gap-1 px-3 py-1.5 border border-green-600 text-green-700 dark:text-green-400 rounded hover:bg-green-50 dark:hover:bg-green-900/30 text-sm transition-colors"
+              >
+                <Copy className="w-4 h-4" /> Traer cargos de la última compra de este proveedor
+              </button>
+            )}
+          </div>
+
+          {deLaPlantilla.length > 0 && paraTraer.length === 0 && (
+            <p className="text-xs text-gray-500">
+              Los cargos de {facturaPlantilla} ({deLaPlantilla.map(c => c.concepto).join(', ')}) ya están cargados.
+            </p>
+          )}
+
+          {cargos.length > 0 && (
+            <div className="pt-2 border-t dark:border-gray-700 space-y-1 text-sm">
+              <div className="flex justify-between">
+                <span className="text-gray-600 dark:text-gray-400">En la factura:</span>
+                <span className="font-medium text-gray-800 dark:text-white">{formatPrecio(totalEnFactura)}</span>
+              </div>
+              <div className="flex justify-between">
+                <span className="text-gray-600 dark:text-gray-400">Al costo de los productos:</span>
+                <span className="font-medium text-gray-800 dark:text-white">{formatPrecio(totalAlCosto)}</span>
+              </div>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}
+
+/**
+ * Vista previa del costo de cada producto: las cuatro columnas que hoy el
+ * gerente lee del Excel (base IVA, impuesto interno, no gravado, IVA) más el
+ * costo unitario final, y abajo el costo puesto en depósito.
+ *
+ * La alimenta `calcularCostosCompra`, que es el espejo TS de la mig 193: lo que
+ * se ve acá es lo que va a calcular la base al registrar.
+ *
+ * `calcularCostosCompra` lanza ante una cantidad o un peso corrupto —el mismo
+ * criterio que `prorratearCargo`, y por la misma razón— así que la llamada va
+ * envuelta: un dato podrido muestra el error acá adentro y no deja el modal en
+ * blanco.
+ */
+function VistaPreviaCostosSection({ state }: VistaPreviaCostosProps) {
+  const [abierta, setAbierta] = useState(false)
+
+  const esZZ = state.tipoFactura === 'ZZ'
+  const lineas = lineasParaMotor(state.items, state.tipoFactura)
+  const cargos = cargosParaMotor(state.cargos)
+  const iiDeclarado = iiDeclaradoParaMotor(state.iiDeclarado, state.tipoFactura)
+
+  const calculo = ((): { ok: true; costos: CostosCompra } | { ok: false; error: string } => {
+    try {
+      return { ok: true, costos: calcularCostosCompra(lineas, cargos, iiDeclarado) }
+    } catch (err) {
+      return { ok: false, error: err instanceof Error ? err.message : 'No se pudo calcular el costo' }
+    }
+  })()
+
+  const porLinea = calculo.ok
+    ? new Map(calculo.costos.lineas.map(l => [l.id, l]))
+    : new Map<number, CostosCompra['lineas'][number]>()
+  const costoEnDeposito = calculo.ok
+    ? calculo.costos.lineas.reduce((acc, l) => {
+        const item = state.items.find(i => i.lineaId === l.id)
+        return acc + l.costoRealUnitario * (item?.cantidad || 0)
+      }, 0)
+    : 0
+
+  // Factores de ajuste realmente aplicados (los que no son 1). Es lo único que
+  // hace falta decir acá: el que los carga es el panel de control.
+  const ajustesII = calculo.ok
+    ? Object.entries(calculo.costos.factorAjuste)
+        .filter(([, factor]) => redondearSQL(factor, 4) !== 1)
+        .map(([tasa, factor]) => `${tasa}% ×${redondearSQL(factor, 4)}`)
+    : []
+
+  const celda = (valor: number | undefined) => (valor === undefined ? '—' : formatPrecio(valor))
+
+  return (
+    <div className="bg-gray-50 dark:bg-gray-900 rounded-lg p-3 sm:p-4">
+      <button
+        type="button"
+        onClick={() => setAbierta(v => !v)}
+        className="w-full flex items-center justify-between gap-2 text-left"
+      >
+        <div className="flex items-center gap-2 min-w-0">
+          {abierta
+            ? <ChevronDown className="w-4 h-4 text-gray-500 shrink-0" />
+            : <ChevronRight className="w-4 h-4 text-gray-500 shrink-0" />}
+          <Calculator className="w-5 h-5 text-gray-500 shrink-0" />
+          <h3 className="font-medium text-gray-800 dark:text-white truncate">Costo por producto</h3>
+        </div>
+        {!abierta && (
+          <span className="text-xs text-gray-500 text-right shrink-0">
+            {calculo.ok ? `${formatPrecio(costoEnDeposito)} en depósito` : 'no se pudo calcular'}
+          </span>
+        )}
+      </button>
+
+      {abierta && (
+        <div className="mt-3 space-y-3">
+          {!calculo.ok ? (
+            <div className="p-3 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg flex items-start gap-2">
+              <AlertTriangle className="w-4 h-4 text-red-500 mt-0.5 shrink-0" />
+              <p className="text-sm text-red-600 dark:text-red-400">{calculo.error}</p>
+            </div>
+          ) : (
+            <>
+              {/* La apertura del II se carga en "Control contra factura", que es
+                  donde se cuadra contra el papel; acá sólo se avisa que el
+                  ajuste está aplicado, porque mueve la columna de al lado. */}
+              {ajustesII.length > 0 && (
+                <p className="text-xs text-blue-700 dark:text-blue-300">
+                  Impuesto interno ajustado al declarado en la factura ({ajustesII.join(', ')}).
+                  El campo está en "Control contra factura".
+                </p>
+              )}
+
+              {/* Header solo en desktop */}
+              <div className="hidden md:grid grid-cols-12 gap-2 text-xs font-medium text-gray-500 uppercase px-2">
+                <div className="col-span-2">Producto</div>
+                <div className="col-span-2 text-right">Base IVA</div>
+                <div className="col-span-2 text-right">Imp. int.</div>
+                <div className="col-span-2 text-right">No grav.</div>
+                <div className="col-span-2 text-right">IVA</div>
+                <div className="col-span-2 text-right">Costo unit.</div>
+              </div>
+
+              <div className="space-y-2">
+                {state.items.map((item, index) => {
+                  const c = item.lineaId === undefined ? undefined : porLinea.get(item.lineaId)
+                  return (
+                    <div key={item.lineaId ?? index} className="bg-white dark:bg-gray-800 rounded px-2 py-2 border dark:border-gray-600">
+                      {/* Mobile: apilado */}
+                      <div className="md:hidden space-y-1">
+                        <p className="text-sm font-medium text-gray-800 dark:text-white">{item.productoNombre}</p>
+                        <div className="grid grid-cols-2 gap-x-3 gap-y-0.5 text-xs">
+                          <span className="text-gray-500">Base IVA</span>
+                          <span className="text-right dark:text-gray-200">{celda(c?.baseIvaUnitaria)}</span>
+                          <span className="text-gray-500">Imp. interno</span>
+                          <span className="text-right dark:text-gray-200">{celda(c?.iiUnitario)}</span>
+                          <span className="text-gray-500">No gravado</span>
+                          <span className="text-right dark:text-gray-200">{celda(c?.cargosUnitarios)}</span>
+                          <span className="text-gray-500">IVA</span>
+                          <span className="text-right dark:text-gray-200">{celda(c?.ivaUnitario)}</span>
+                        </div>
+                        <div className="flex justify-between items-center pt-1 border-t dark:border-gray-600">
+                          <span className="text-xs text-gray-500">Costo unitario</span>
+                          <span className="text-sm font-semibold text-gray-800 dark:text-white">{celda(c?.costoRealUnitario)}</span>
+                        </div>
+                      </div>
+
+                      {/* Desktop: grilla */}
+                      <div className="hidden md:grid grid-cols-12 gap-2 items-center text-xs">
+                        <p className="col-span-2 text-gray-800 dark:text-white truncate" title={item.productoNombre}>
+                          {item.productoNombre}
+                        </p>
+                        <span className="col-span-2 text-right dark:text-gray-200">{celda(c?.baseIvaUnitaria)}</span>
+                        <span className="col-span-2 text-right dark:text-gray-200">{celda(c?.iiUnitario)}</span>
+                        <span className="col-span-2 text-right dark:text-gray-200">{celda(c?.cargosUnitarios)}</span>
+                        <span className="col-span-2 text-right dark:text-gray-200">{celda(c?.ivaUnitario)}</span>
+                        <span className="col-span-2 text-right font-semibold text-gray-800 dark:text-white">{celda(c?.costoRealUnitario)}</span>
+                      </div>
+                    </div>
+                  )
+                })}
+              </div>
+
+              <p className="text-xs text-gray-500">
+                Todos los importes son por unidad.
+                {esZZ && ' En ZZ lo pagado ya incluye IVA e impuestos internos: por eso las dos columnas van en cero y el cargo suma igual.'}
+              </p>
+
+              <div className="flex justify-between items-center pt-2 border-t dark:border-gray-600">
+                <span className="font-medium text-gray-800 dark:text-white">Costo puesto en depósito</span>
+                <span className="text-lg font-bold text-green-600">{formatPrecio(costoEnDeposito)}</span>
+              </div>
+              <p className="text-xs text-gray-500">
+                Neto + impuestos internos + los cargos que entran al costo. El IVA queda afuera:
+                es crédito fiscal, no costo.
+              </p>
+            </>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}
+
 /** Fila del panel de control: calculado vs impreso en la factura */
 function ControlRow({ label, calculado, impreso, onChange }: {
   label: string;
@@ -1948,14 +2320,39 @@ function ControlRow({ label, calculado, impreso, onChange }: {
   )
 }
 
-function ResumenSection({ totales, state, dispatch }: ResumenSectionProps) {
-  const { subtotalBruto, bonificacionTotal, subtotal, netoGravado, netoExento, netoNoGravado,
-          netoPorAlicuota, iva, impuestosInternos, percepcionIva, percepcionIibb, noGravado, total } = totales
+function ResumenSection({ totales, state, dispatch, resolucion }: ResumenSectionProps) {
+  const { subtotalBruto, bonificacionTotal, subtotal, bonificaciones, netoGravado, netoExento,
+          netoNoGravado, netoPorAlicuota, iva, impuestosInternos, percepcionIva, percepcionIibb,
+          noGravado, total } = totales
   const esFC = state.tipoFactura === 'FC'
   const [bonifGlobal, setBonifGlobal] = useState(0)
   const [mostrarControl, setMostrarControl] = useState(false)
   const ctrl = state.controlFactura
   const percepcionesCalc = percepcionIva + percepcionIibb
+  const cuadreII = cuadreImpuestoInterno(state.items, state.cargos, state.iiDeclarado, state.tipoFactura)
+  // Los cargos que pre-llenan el "No gravado" de cabecera, para poder nombrarlos.
+  const cargosNoGravados = cargosNoGravadosEnFactura(state.cargos)
+  const noGravadoCargos = noGravadoDeCargos(state.cargos)
+
+  // ── Lo que el impuesto interno declarado permite deducir ───────────────────
+  // El ajuste que se está aplicando HOY, alícuota por alícuota. Es lo que hay
+  // que nombrar cuando la deducción no sale: el usuario tiene que saber que
+  // está viendo una aproximación y no un cálculo.
+  const ajusteII = (cuadreII ?? [])
+    .filter(c => c.declarado !== undefined && Math.abs(c.desvio) > 1e-9)
+    .map(c => `${redondearSQL(c.desvio * 100, 2)}% al ${c.tasa}%`)
+    .join(' y ')
+  const nombreCargo = (id: number) =>
+    state.cargos.find(c => c.id === id)?.concepto.trim() || '(sin concepto)'
+  const deduccion = resolucion?.estado === 'unica' ? resolucion.soluciones[0].asignacion : null
+  const porQueNo =
+    resolucion?.estado === 'ambigua'
+      ? 'Hay más de una combinación que llega al mismo número, así que la factura no alcanza para elegir.'
+      : resolucion?.estado === 'sin_solucion'
+        ? 'Ninguna combinación llega a lo declarado: puede faltar un cargo, o estar mal cargada una alícuota.'
+        : resolucion?.estado === 'demasiadas_hipotesis'
+          ? 'Hay demasiadas bonificaciones gravadas para probarlas todas sin arriesgar una coincidencia.'
+          : ''
 
   return (
     <div className="bg-green-50 dark:bg-green-900/20 rounded-lg p-4 space-y-4">
@@ -2023,6 +2420,19 @@ function ResumenSection({ totales, state, dispatch }: ResumenSectionProps) {
           <div>
             <label className="block text-xs text-gray-500 mb-1" title="Conceptos fuera del IVA (ej: pallets/separadores valorizados)">
               No gravado
+              {/* La vuelta al automático, que si no un número tipeado queda
+                  clavado para siempre. Mismo gesto explícito que re-elegir la
+                  base de reparto de un cargo. */}
+              {state.noGravadoManual && noGravadoCargos !== state.noGravado && (
+                <button
+                  type="button"
+                  onClick={() => dispatch({ type: 'USAR_NO_GRAVADO_DE_CARGOS' })}
+                  className="ml-2 text-blue-600 hover:underline"
+                  title="Volver a la suma de los cargos no gravados que vienen en la factura"
+                >
+                  usar los cargos ({formatPrecio(noGravadoCargos)})
+                </button>
+              )}
             </label>
             <NumberInput
               min={0}
@@ -2032,6 +2442,15 @@ function ResumenSection({ totales, state, dispatch }: ResumenSectionProps) {
               commitOnChange
               className="w-full px-2 py-1.5 border dark:border-gray-600 rounded dark:bg-gray-700 dark:text-white text-sm"
             />
+            {/* De dónde sale el número. Sin esto el campo parece pedir un dato
+                que el modal ya tiene cargado tres secciones más arriba. */}
+            <p className="mt-1 text-[11px] leading-tight text-gray-500">
+              {state.noGravadoManual
+                ? `Tipeado a mano.${cargosNoGravados.length > 0 ? ` Los cargos no gravados de la factura suman ${formatPrecio(noGravadoCargos)}.` : ''}`
+                : cargosNoGravados.length > 0
+                  ? `Sale de los cargos no gravados de la factura: ${cargosNoGravados.map(c => c.concepto.trim() || 'sin concepto').join(', ')}.`
+                  : 'Se completa solo con los cargos no gravados que vengan en la factura.'}
+            </p>
           </div>
         </div>
       )}
@@ -2053,6 +2472,17 @@ function ResumenSection({ totales, state, dispatch }: ResumenSectionProps) {
           <span className="text-gray-600 dark:text-gray-400">{esFC ? 'Gravado (neto):' : 'Subtotal Neto:'}</span>
           <span className="font-medium text-gray-800 dark:text-white">{formatPrecio(esFC ? netoGravado : subtotal)}</span>
         </div>
+        {/* Sub-fila y no una fila propia: el gravado de arriba YA tiene la
+            bonificación restada. Se muestra porque es la diferencia entre el
+            neto de los renglones y lo que la factura llama gravado, y hasta la
+            mig 195 no estaba en ningún lado —el total quedaba 306.784,09 arriba
+            del papel en la factura testigo—. */}
+        {esFC && bonificaciones !== 0 && (
+          <div className="flex justify-between text-xs text-orange-600 dark:text-orange-400 pl-3">
+            <span>└ incluye bonificaciones de la factura:</span>
+            <span className="font-medium">{formatPrecio(bonificaciones)}</span>
+          </div>
+        )}
         {/* Con condiciones mezcladas el "gravado" solo ya no explica el total */}
         {esFC && netoExento > 0 && (
           <div className="flex justify-between text-sm">
@@ -2149,6 +2579,77 @@ function ResumenSection({ totales, state, dispatch }: ResumenSectionProps) {
                 onChange={(n) => dispatch({ type: 'SET_CONTROL', payload: { iva: n } })} />
               <ControlRow label="Imp. internos" calculado={impuestosInternos} impreso={ctrl.impuestosInternos}
                 onChange={(n) => dispatch({ type: 'SET_CONTROL', payload: { impuestosInternos: n } })} />
+              {/* Apertura del II POR ALÍCUOTA. La factura lo trae abierto y casi
+                  nunca coincide al peso con el calculado: el gerente hoy corrige
+                  esa diferencia a mano en un Excel, con un factor de 1,0496. Acá
+                  ese número se carga una vez y viaja a la base, que es la única
+                  forma de que el costo guardado lo tenga.
+                  Las alícuotas salen de las líneas, no de una lista fija. */}
+              {cuadreII === null ? (
+                <p className="text-xs text-red-600 dark:text-red-400 pl-3">
+                  No se pudo abrir el impuesto interno por alícuota (ver "Costo por producto").
+                </p>
+              ) : cuadreII.map(c => (
+                <div key={c.tasa} className="grid grid-cols-12 gap-2 items-center text-xs">
+                  <span className="col-span-4 text-gray-500 pl-3">└ declarado al {c.tasa}%</span>
+                  <span className="col-span-3 text-right text-gray-500">{formatPrecio(c.calculado)}</span>
+                  <div className="col-span-3">
+                    <NumberInput
+                      min={0}
+                      emptyValue={0}
+                      value={c.declarado ?? 0}
+                      onChange={(n) => dispatch({ type: 'SET_II_DECLARADO', payload: { tasa: c.tasa, monto: n } })}
+                      commitOnChange
+                      placeholder="factura"
+                      title="Lo que la factura declara de impuesto interno para esta alícuota"
+                      className="w-full px-2 py-1 text-right border dark:border-gray-600 rounded dark:bg-gray-700 dark:text-white text-xs"
+                    />
+                  </div>
+                  <span className={`col-span-2 text-right font-medium ${
+                    c.declarado === undefined ? 'text-gray-400'
+                      : Math.abs(c.desvio) > DESVIO_II_TOLERADO ? 'text-amber-600' : 'text-green-600'
+                  }`}>
+                    {c.declarado === undefined ? '—' : `×${redondearSQL(c.factor, 4)}`}
+                  </span>
+                </div>
+              ))}
+              {/* LA DEDUCCIÓN. El casillero "afecta la base de impuestos
+                  internos" no lo puede contestar el que carga la factura: lo
+                  decide el proveedor, y la testigo demuestra que trató las dos
+                  bonificaciones del MISMO comprobante de forma distinta. Pero la
+                  factura declara el impuesto interno POR ALÍCUOTA, y eso es una
+                  ecuación: con las dos bonificaciones reales hay 4 combinaciones
+                  y una sola cierra —a 6 centavos sobre 338.884—. */}
+              {resolucion && resolucion.candidatos.length > 0 && (
+                deduccion ? (
+                  <p className="text-xs text-green-700 dark:text-green-400 pl-3">
+                    ✓ El impuesto interno declarado determina las bonificaciones:{' '}
+                    {resolucion.candidatos
+                      .map(id => `"${nombreCargo(id)}" ${deduccion[id] ? 'baja' : 'no baja'} la base`)
+                      .join('; ')}
+                    . Quedó marcado así en "Cargos y prorrateo"; si sabés que está mal, cambialo ahí.
+                  </p>
+                ) : ajusteII ? (
+                  <p className="text-xs text-amber-700 dark:text-amber-300 pl-3">
+                    No pude determinar qué bonificaciones bajan la base. Apliqué un ajuste
+                    del {ajusteII}. {porQueNo} Ese ajuste reparte el impuesto interno de la
+                    bonificación entre TODOS los productos de la alícuota, incluso los que no
+                    estuvieron en la promoción: a ésos les carga de más y a los de la promoción,
+                    de menos. Es una aproximación — si sabés cuál bonificación es descuento de
+                    precio, marcala a mano en "Cargos y prorrateo".
+                  </p>
+                ) : null
+              )}
+              {/* Aviso, no bloqueo: hay facturas con redondeos raros. */}
+              {(cuadreII ?? [])
+                .filter(c => Math.abs(c.desvio) > DESVIO_II_TOLERADO)
+                .map(c => (
+                  <p key={c.tasa} className="text-xs text-amber-700 dark:text-amber-300 pl-3">
+                    ⚠ El impuesto interno declarado al {c.tasa}% difiere un {redondearSQL(c.desvio * 100, 2)}%
+                    del calculado. Revisá si alguna bonificación no debería bajar la base, o si alguna
+                    alícuota está mal cargada.
+                  </p>
+                ))}
               <ControlRow label="Percepciones" calculado={percepcionesCalc} impreso={ctrl.percepciones}
                 onChange={(n) => dispatch({ type: 'SET_CONTROL', payload: { percepciones: n } })} />
               <ControlRow label="TOTAL" calculado={total} impreso={ctrl.total}

--- a/src/components/modals/ModalDetalleCompra.tsx
+++ b/src/components/modals/ModalDetalleCompra.tsx
@@ -67,6 +67,8 @@ interface CompraDetalle {
   percepcion_iva?: number;
   percepcion_iibb?: number;
   no_gravado?: number;
+  /** Bonificaciones generales gravadas de la factura, con signo (mig 195). */
+  bonificaciones?: number;
   otros_impuestos?: number;
   total: number;
   notas?: string;
@@ -292,6 +294,15 @@ export default function ModalDetalleCompra({
                 <div className="flex justify-between text-sm">
                   <span className="text-gray-600 dark:text-gray-400">No gravado (cabecera):</span>
                   <span className="font-medium text-gray-800 dark:text-white">{formatPrecio(compra.no_gravado!)}</span>
+                </div>
+              )}
+              {/* Sin esta fila el total no cierra contra las de arriba: el
+                  subtotal es el neto de los RENGLONES y la bonificación general
+                  no es un renglón. */}
+              {(compra.bonificaciones ?? 0) !== 0 && (
+                <div className="flex justify-between text-sm">
+                  <span className="text-gray-600 dark:text-gray-400">Bonificaciones de la factura:</span>
+                  <span className="font-medium text-orange-600 dark:text-orange-400">{formatPrecio(compra.bonificaciones!)}</span>
                 </div>
               )}
               {compra.otros_impuestos && compra.otros_impuestos > 0 && (

--- a/src/components/modals/ModalEditarCompra.cargos.test.jsx
+++ b/src/components/modals/ModalEditarCompra.cargos.test.jsx
@@ -1,0 +1,167 @@
+/**
+ * Los cargos prorrateados al editar una compra (mig 194).
+ *
+ * Esto se testea porque acá el fallo es MUDO. `actualizar_compra_items` borra y
+ * recrea las líneas en cada edición y el CASCADE se lleva puesto el vector de
+ * pesos, así que un modal que no reenvía los cargos deja el flete colgado sin
+ * ninguna línea: la compra se guarda bien, el costo de los productos baja un
+ * 16% y no hay ningún error en ningún lado.
+ *
+ * Y los pesos van por ÍNDICE del payload nuevo, no por id de línea: los
+ * compra_items.id de esta compra dejan de existir en el mismo UPDATE.
+ */
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+vi.mock('../../utils/formatters', () => ({
+  formatPrecio: (value) => `$${Number(value).toFixed(2)}`,
+}))
+
+import ModalEditarCompra from './ModalEditarCompra'
+
+const compraBase = (overrides = {}) => ({
+  id: 500,
+  estado: 'recibida',
+  tipo_factura: 'FC',
+  proveedor: { id: 6, nombre: 'Manaos' },
+  numero_factura: 'A0005-461415',
+  fecha_compra: '2026-08-18',
+  total: 3630,
+  otros_impuestos: 0,
+  percepcion_iva: 0,
+  percepcion_iibb: 0,
+  no_gravado: 0,
+  ii_declarado: { 4.1667: 1234.5 },
+  items: [
+    {
+      id: 91, producto_id: 1, cantidad: 10, costo_unitario: 100, bonificacion: 0,
+      porcentaje_iva: 21, condicion_iva: 'gravado', impuestos_internos: 0,
+      producto: { nombre: 'Lima Limon 600' },
+    },
+    {
+      id: 92, producto_id: 2, cantidad: 5, costo_unitario: 200, bonificacion: 0,
+      porcentaje_iva: 21, condicion_iva: 'gravado', impuestos_internos: 0,
+      producto: { nombre: 'Bidon 20L' },
+    },
+  ],
+  // A propósito fuera de orden: el payload se reordena por `orden`.
+  cargos: [
+    {
+      id: 7, orden: 1, concepto: 'Pallets', monto: 162000, condicion_iva: 'no_gravado',
+      en_factura: true, prorratea_al_costo: true, afecta_base_ii: false, base_prorrateo: 'cantidad',
+      repartos: [{ compra_item_id: 91, peso: 10 }, { compra_item_id: 92, peso: 5 }],
+    },
+    {
+      id: 6, orden: 0, concepto: 'Separadores bidon', monto: 8800, condicion_iva: 'no_gravado',
+      en_factura: true, prorratea_al_costo: true, afecta_base_ii: false, base_prorrateo: 'unidades',
+      repartos: [{ compra_item_id: 92, peso: 1 }],
+    },
+  ],
+  ...overrides,
+})
+
+const props = (compra, onGuardar = vi.fn().mockResolvedValue(undefined)) => ({
+  compra, usuarioId: 'u1', onGuardar, onClose: vi.fn(), guardando: false,
+})
+
+const guardar = (user) => user.click(screen.getByRole('button', { name: /guardar/i }))
+
+/**
+ * El botón de borrar de la línea `i`. Hay dos layouts en el DOM —tarjeta y
+ * tabla— y CSS decide cuál se ve; en jsdom se toma el de la tarjeta.
+ */
+const borrarLinea = (user, i) =>
+  user.click(screen.getAllByRole('button', { name: /eliminar item/i })[i])
+
+describe('ModalEditarCompra · cargos prorrateados', () => {
+  it('reenvía los cargos con los pesos por índice del payload nuevo', async () => {
+    const user = userEvent.setup()
+    const onGuardar = vi.fn().mockResolvedValue(undefined)
+    render(<ModalEditarCompra {...props(compraBase(), onGuardar)} />)
+
+    await guardar(user)
+
+    const enviado = onGuardar.mock.calls[0][0]
+    expect(enviado.cargos).toEqual([
+      // Ordenados por `orden`, no por como vinieron.
+      expect.objectContaining({ concepto: 'Separadores bidon', monto: 8800, pesos: { 1: 1 } }),
+      expect.objectContaining({ concepto: 'Pallets', monto: 162000, pesos: { 0: 10, 1: 5 } }),
+    ])
+    // Las banderas fiscales viajan tal cual: acá no se editan.
+    expect(enviado.cargos[1]).toMatchObject({
+      condicionIva: 'no_gravado', enFactura: true, prorrateaAlCosto: true,
+      afectaBaseII: false, baseProrrateo: 'cantidad',
+    })
+    // Y la apertura del II también, o el factor de ajuste se revierte solo.
+    expect(enviado.iiDeclarado).toEqual({ 4.1667: 1234.5 })
+  })
+
+  it('borrar una línea corre los índices y suelta su peso', async () => {
+    const user = userEvent.setup()
+    const onGuardar = vi.fn().mockResolvedValue(undefined)
+    render(<ModalEditarCompra {...props(compraBase(), onGuardar)} />)
+
+    await borrarLinea(user, 0)
+    await guardar(user)
+
+    const enviado = onGuardar.mock.calls[0][0]
+    expect(enviado.items).toHaveLength(1)
+    // El bidón pasa a ser el índice 0 y el peso de la línea borrada desaparece:
+    // mandarlo apuntaría a un índice que ya no existe y la RPC lo rechaza.
+    expect(enviado.cargos.map(c => c.pesos)).toEqual([{ 0: 1 }, { 0: 5 }])
+  })
+
+  it('bloquea la edición que dejaría un cargo sin ninguna línea', async () => {
+    const user = userEvent.setup()
+    const onGuardar = vi.fn().mockResolvedValue(undefined)
+    render(<ModalEditarCompra {...props(compraBase(), onGuardar)} />)
+
+    // Los separadores sólo pesan sobre el bidón: sin esa línea, esos 8.800
+    // desaparecen del costo sin que nadie los vea irse.
+    await borrarLinea(user, 1)
+    await guardar(user)
+
+    expect(onGuardar).not.toHaveBeenCalled()
+    expect(screen.getByText(/Separadores bidon.*sin ninguna l.nea/i)).toBeInTheDocument()
+  })
+
+  it('sin cargos leídos manda null, no una lista vacía', async () => {
+    // `[]` significa "esta compra no tiene ninguno" y pasa el guard de la RPC
+    // borrándolos; `null` significa "no los conozco" y es lo único que lo
+    // dispara. La distinción es la que separa un rechazo de una pérdida muda.
+    const user = userEvent.setup()
+    const onGuardar = vi.fn().mockResolvedValue(undefined)
+    const compra = compraBase()
+    delete compra.cargos
+    delete compra.ii_declarado
+    render(<ModalEditarCompra {...props(compra, onGuardar)} />)
+
+    await guardar(user)
+
+    expect(onGuardar.mock.calls[0][0].cargos).toBeNull()
+    expect(onGuardar.mock.calls[0][0].iiDeclarado).toBeNull()
+  })
+
+  it('muestra el rechazo de la RPC en vez de tragárselo', async () => {
+    // Las RPCs devuelven {success:false} con HTTP 200; el container lo convierte
+    // en Error. Sin esto el mensaje sólo vivía en un toast que se va solo.
+    const user = userEvent.setup()
+    const onGuardar = vi.fn().mockRejectedValue(
+      new Error('Esta compra tiene cargos prorrateados. Actualizá la aplicación (recargá la página) antes de editarla.'),
+    )
+    render(<ModalEditarCompra {...props(compraBase(), onGuardar)} />)
+
+    await guardar(user)
+
+    expect(await screen.findByText(/Actualizá la aplicación/i)).toBeInTheDocument()
+  })
+
+  it('lista los cargos como informativos: no se editan y no entran al total', () => {
+    render(<ModalEditarCompra {...props(compraBase())} />)
+    expect(screen.getByText(/Separadores bidon \$8800.00 · Pallets \$162000.00/)).toBeInTheDocument()
+    // El total sigue siendo el de las líneas: los cargos van al costo unitario
+    // de los productos, no a la cabecera de la compra.
+    expect(screen.getByText('$2420.00')).toBeInTheDocument()
+  })
+})

--- a/src/components/modals/ModalEditarCompra.tsx
+++ b/src/components/modals/ModalEditarCompra.tsx
@@ -22,12 +22,18 @@ import { Loader2, Trash2, AlertCircle, Building2 } from 'lucide-react'
 import ModalBase from './ModalBase'
 import NumberInput from '../ui/NumberInput'
 import { formatPrecio } from '../../utils/formatters'
-import type { CompraDBExtended, CondicionIva } from '../../types'
+import type { CompraCargoInput, CompraDBExtended, CondicionIva } from '../../types'
 import type { ActualizarCompraItemsInput } from '../../hooks/queries'
 import { OPCIONES_CONDICION_IVA, claveCondicionIva } from '../../utils/condicionIva'
 
 /** Item editable dentro del modal. */
 interface ItemEdit {
+  /**
+   * Id de la línea EN LA BASE. No se manda a la RPC —que borra y recrea las
+   * líneas— pero es el único puente entre los repartos guardados
+   * (`compra_cargo_repartos.compra_item_id`) y el índice del payload nuevo.
+   */
+  compraItemId: string
   productoId: string
   nombre: string
   cantidad: number
@@ -69,9 +75,15 @@ const ModalEditarCompra = memo(function ModalEditarCompra({
   // Percepciones y no gravado (cabecera) no se editan acá: se conservan.
   const percepciones = (compra.percepcion_iva ?? 0) + (compra.percepcion_iibb ?? 0)
   const noGravado = compra.no_gravado ?? 0
+  // Las bonificaciones generales tampoco se editan acá: los cargos se reenvían
+  // verbatim, así que su suma no cambia. Pero TIENE que entrar al total, o cada
+  // edición devolvería la cabecera al número inflado que la mig 195 vino a
+  // arreglar —y pondría COMPRA-A1 en rojo sin que nadie tocara una bonificación.
+  const bonificaciones = compra.bonificaciones ?? 0
 
   const [items, setItems] = useState<ItemEdit[]>(() =>
     (compra.items ?? []).map((it) => ({
+      compraItemId: String(it.id),
       productoId: it.producto_id,
       nombre: it.producto?.nombre ?? `Producto #${it.producto_id}`,
       cantidad: it.cantidad ?? 0,
@@ -130,6 +142,46 @@ const ModalEditarCompra = memo(function ModalEditarCompra({
     canCambiarProveedor && onCambiarProveedor && compra.estado !== 'cancelada',
   )
 
+  /**
+   * Los cargos de la compra, listos para reenviar (mig 194).
+   *
+   * Acá no se editan: se reenvían tal cual, con los pesos traducidos de
+   * `compra_item_id` al ÍNDICE que va a tener la línea en el payload nuevo.
+   * Reenviarlos no es opcional. `actualizar_compra_items` borra y recrea las
+   * líneas en cada edición y el CASCADE se lleva puesto el vector de pesos, así
+   * que un cliente que no los manda deja los cargos vivos con el vector vacío:
+   * el flete deja de repartirse y nadie se entera. La RPC tiene un guard para
+   * eso y devuelve "Actualizá la aplicación".
+   *
+   * El peso de una línea eliminada en esta edición se cae del vector: mandarlo
+   * apuntaría a un índice que no existe y la RPC lo rechaza, con razón.
+   */
+  const cargosGuardados = compra.cargos
+  const cargosPayload = useMemo<CompraCargoInput[]>(() => {
+    const indicePorItem = new Map<string, number>()
+    itemsActivos.forEach((it, i) => indicePorItem.set(it.compraItemId, i))
+    return [...(cargosGuardados ?? [])]
+      .sort((a, b) => (a.orden ?? 0) - (b.orden ?? 0))
+      .map((c) => {
+        const pesos: Record<number, number> = {}
+        for (const r of c.repartos ?? []) {
+          const indice = indicePorItem.get(String(r.compra_item_id))
+          if (indice === undefined) continue
+          pesos[indice] = Number(r.peso ?? 0)
+        }
+        return {
+          concepto: c.concepto,
+          monto: Number(c.monto ?? 0),
+          condicionIva: c.condicion_iva ?? 'no_gravado',
+          enFactura: c.en_factura ?? true,
+          prorrateaAlCosto: c.prorratea_al_costo ?? true,
+          afectaBaseII: c.afecta_base_ii ?? false,
+          baseProrrateo: c.base_prorrateo ?? 'unidades',
+          pesos,
+        }
+      })
+  }, [cargosGuardados, itemsActivos])
+
   // Totales calculados (incluye imp. internos por línea; percepciones y no
   // gravado de la cabecera se conservan tal cual).
   const totales = useMemo(() => {
@@ -147,9 +199,9 @@ const ModalEditarCompra = memo(function ModalEditarCompra({
         impuestosInternos += subtotalItem * ((it.impuestosInternos || 0) / 100)
       }
     }
-    const total = subtotal + iva + impuestosInternos + percepciones + noGravado + otrosImpuestos
+    const total = subtotal + bonificaciones + iva + impuestosInternos + percepciones + noGravado + otrosImpuestos
     return { subtotal, iva, impuestosInternos, total }
-  }, [itemsActivos, esZZ, otrosImpuestos, percepciones, noGravado])
+  }, [itemsActivos, esZZ, otrosImpuestos, percepciones, noGravado, bonificaciones])
 
   function updateItem<K extends keyof ItemEdit>(productoId: string, field: K, value: ItemEdit[K]) {
     setItems((prev) =>
@@ -207,6 +259,12 @@ const ModalEditarCompra = memo(function ModalEditarCompra({
     if (itemsActivos.length === 0) {
       return 'La compra debe tener al menos un item. Si querés vaciarla, anulala desde la lista.'
     }
+    const huerfano = cargosPayload.find(
+      (c) => c.prorrateaAlCosto && Object.values(c.pesos).reduce((a, p) => a + p, 0) === 0,
+    )
+    if (huerfano) {
+      return `El cargo "${huerfano.concepto}" se quedaría sin ninguna línea donde repartirse y ese importe desaparecería del costo. Restaurá la línea que borraste, o anulá la compra y volvé a cargarla.`
+    }
     for (const it of itemsActivos) {
       if (!Number.isFinite(it.cantidad) || it.cantidad <= 0) {
         return `Cantidad invalida en "${it.nombre}". Debe ser mayor a 0.`
@@ -247,15 +305,35 @@ const ModalEditarCompra = memo(function ModalEditarCompra({
       }
     })
 
-    await onGuardar({
-      compraId: compra.id,
-      usuarioId,
-      subtotal: totales.subtotal,
-      iva: totales.iva,
-      total: totales.total,
-      impuestosInternos: totales.impuestosInternos,
-      items: itemsPayload,
-    })
+    try {
+      await onGuardar({
+        compraId: compra.id,
+        usuarioId,
+        subtotal: totales.subtotal,
+        iva: totales.iva,
+        total: totales.total,
+        impuestosInternos: totales.impuestosInternos,
+        items: itemsPayload,
+        // `null` cuando el embed no llegó, y no `[]`: los dos significan cosas
+        // distintas y sólo el null activa el guard de la mig 194. Un `[]` sobre
+        // una compra que sí tiene cargos pasa el guard y los borra, que es
+        // exactamente lo que el guard existe para impedir.
+        cargos: cargosGuardados === undefined ? null : cargosPayload,
+        // Se reenvía el valor guardado, no uno recalculado: acá no se editan
+        // los cargos, así que no hay de dónde sacar otro número.
+        bonificaciones: compra.bonificaciones ?? null,
+        // Misma distinción para la apertura del II: null = "no la conozco",
+        // {} = "esta compra no tiene ajuste". Sin ella el factor se revierte
+        // solo y no deja ningún rastro.
+        iiDeclarado: compra.ii_declarado ?? null,
+      })
+    } catch (err) {
+      // Las RPCs devuelven sus rechazos como {success:false} con HTTP 200 y el
+      // container los convierte en Error. Sin este catch el mensaje sólo vivía
+      // en un toast que se va solo, y encima quedaba una promesa rechazada sin
+      // atender: el usuario veía el modal abierto sin saber qué pasó.
+      setErrorValidacion(err instanceof Error ? err.message : 'No se pudo actualizar la compra.')
+    }
   }
 
   const fechaCompra = compra.fecha_compra ?? '—'
@@ -513,11 +591,27 @@ const ModalEditarCompra = memo(function ModalEditarCompra({
               <span className="tabular-nums">{formatPrecio(noGravado)}</span>
             </div>
           )}
+          {bonificaciones !== 0 && (
+            <div className="flex justify-between dark:text-gray-300">
+              <span>Bonificaciones de la factura (sin cambio)</span>
+              <span className="tabular-nums">{formatPrecio(bonificaciones)}</span>
+            </div>
+          )}
           {otrosImpuestos > 0 && (
             <div className="flex justify-between dark:text-gray-300">
               <span>Otros impuestos (sin cambio)</span>
               <span className="tabular-nums">{formatPrecio(otrosImpuestos)}</span>
             </div>
+          )}
+          {/* Los cargos no se editan acá y tampoco entran en este total: van al
+              costo unitario de los productos, no a la cabecera de la compra.
+              Se listan igual para que quien edite sepa que existen y que se
+              reenvían tal cual. */}
+          {cargosPayload.length > 0 && (
+            <p className="text-xs text-gray-500 dark:text-gray-400 pt-1">
+              Cargos prorrateados al costo (sin cambio):{' '}
+              {cargosPayload.map((c) => `${c.concepto} ${formatPrecio(c.monto)}`).join(' · ')}
+            </p>
           )}
           <div className="flex justify-between font-semibold text-base dark:text-white pt-2 border-t dark:border-gray-700">
             <span>Total</span>

--- a/src/components/modals/ModalImportarCompra.tsx
+++ b/src/components/modals/ModalImportarCompra.tsx
@@ -10,7 +10,7 @@ import { X, Upload, FileSpreadsheet, AlertCircle, CheckCircle, Download } from '
 const loadExcelUtils = () => import('../../utils/excel');
 import { validateExcelFile, validateAndSanitizeExcelData, FILE_LIMITS } from '../../utils/fileValidation';
 import type { ProductoDB } from '../../types';
-import type { CompraItemForm } from './ModalCompra';
+import type { CompraItemForm } from './ModalCompra.reducer';
 
 // =============================================================================
 // TIPOS

--- a/src/hooks/queries/index.ts
+++ b/src/hooks/queries/index.ts
@@ -138,6 +138,7 @@ export {
   useComprasQuery,
   useCompraQuery,
   useComprasByProveedorQuery,
+  useCargosPlantillaProveedorQuery,
   useRegistrarCompraMutation,
   useActualizarCompraMutation,
   useAnularCompraMutation,

--- a/src/hooks/queries/useComprasQuery.ts
+++ b/src/hooks/queries/useComprasQuery.ts
@@ -7,9 +7,13 @@ import { supabase } from '../supabase/base'
 import { useSucursal } from '../../contexts/SucursalContext'
 import { fechaLocalISO } from '../../utils/formatters'
 import type {
+  BaseProrrateoCompra,
+  CargoPlantillaCompra,
+  CompraCargoInput,
   CompraDBExtended,
   CompraFormInputExtended,
   CondicionIva,
+  PlantillaCargosProveedor,
   RegistrarCompraResult
 } from '../../types'
 
@@ -40,6 +44,29 @@ interface RPCResult {
   success: boolean
   compra_id: string
   error?: string
+  /** Avisos blandos: la compra se guardó igual. Ver RegistrarCompraResult. */
+  warning_descuadre?: string | null
+  warning_ii_declarado?: string | null
+}
+
+/**
+ * Los cargos en el shape que espera la mig 194: snake_case y los pesos por
+ * índice del array de items del mismo payload.
+ *
+ * La traducción de `lineaId` a índice ya vino hecha (`cargosParaRPC` del
+ * reducer, o el remapeo de ModalEditarCompra): acá sólo se renombra.
+ */
+function serializarCargos(cargos: CompraCargoInput[]): Array<Record<string, unknown>> {
+  return cargos.map(c => ({
+    concepto: c.concepto,
+    monto: c.monto,
+    condicion_iva: c.condicionIva,
+    en_factura: c.enFactura,
+    prorratea_al_costo: c.prorrateaAlCosto,
+    afecta_base_ii: c.afectaBaseII,
+    base_prorrateo: c.baseProrrateo,
+    pesos: c.pesos,
+  }))
 }
 
 // Fetch functions
@@ -50,7 +77,12 @@ async function fetchCompras(): Promise<CompraDBExtended[]> {
       *,
       proveedor:proveedores(*),
       items:compra_items(*, producto:productos(*)),
-      usuario:perfiles(id, nombre)
+      usuario:perfiles(id, nombre),
+      cargos:compra_cargos(
+        id, orden, concepto, monto, condicion_iva, en_factura,
+        prorratea_al_costo, afecta_base_ii, base_prorrateo,
+        repartos:compra_cargo_repartos(compra_item_id, peso)
+      )
     `)
     .order('created_at', { ascending: false })
 
@@ -68,7 +100,12 @@ async function fetchCompraById(id: string): Promise<CompraDBExtended | null> {
       *,
       proveedor:proveedores(*),
       items:compra_items(*, producto:productos(*)),
-      usuario:perfiles(id, nombre)
+      usuario:perfiles(id, nombre),
+      cargos:compra_cargos(
+        id, orden, concepto, monto, condicion_iva, en_factura,
+        prorratea_al_costo, afecta_base_ii, base_prorrateo,
+        repartos:compra_cargo_repartos(compra_item_id, peso)
+      )
     `)
     .eq('id', id)
     .single()
@@ -90,6 +127,110 @@ async function fetchComprasByProveedor(proveedorId: string): Promise<CompraDBExt
 
   if (error) throw error
   return (data || []) as CompraDBExtended[]
+}
+
+/** Las filas crudas que necesita la plantilla de cargos. */
+interface FilaPlantillaCargos {
+  id: string | number
+  numero_factura: string | null
+  fecha_compra: string | null
+  items: Array<{ id: string | number; producto_id: string | number }> | null
+  cargos: Array<{
+    orden: number | null
+    concepto: string
+    condicion_iva: CondicionIva | null
+    en_factura: boolean | null
+    prorratea_al_costo: boolean | null
+    afecta_base_ii: boolean | null
+    base_prorrateo: BaseProrrateoCompra | null
+    repartos: Array<{ compra_item_id: string | number; peso: number | string | null }> | null
+  }> | null
+}
+
+/**
+ * Los cargos de la última compra no cancelada de un proveedor, para reusarlos
+ * en la que se está cargando.
+ *
+ * El `!inner` del embed no es decoración: sin él "la última compra" es la última
+ * a secas, y el botón se queda mudo apenas el proveedor mete una factura sin
+ * flete. Lo que sirve de plantilla es la última compra que TIENE cargos.
+ *
+ * Los pesos se traducen de `compra_item_id` a `producto_id` acá y no en el
+ * modal: el id de la línea vieja sólo se puede resolver contra los items de
+ * ESTA query, y afuera no significa nada.
+ *
+ * Devuelve null cuando el proveedor no tiene ninguna compra con cargos. La RLS
+ * de `compra_cargos` pide admin o depósito, así que para otro rol el `!inner`
+ * deja la lista vacía y el botón simplemente no aparece.
+ */
+async function fetchCargosPlantillaProveedor(proveedorId: string): Promise<PlantillaCargosProveedor | null> {
+  const { data, error } = await supabase
+    .from('compras')
+    .select(`
+      id,
+      numero_factura,
+      fecha_compra,
+      items:compra_items(id, producto_id),
+      cargos:compra_cargos!inner(
+        orden,
+        concepto,
+        condicion_iva,
+        en_factura,
+        prorratea_al_costo,
+        afecta_base_ii,
+        base_prorrateo,
+        repartos:compra_cargo_repartos(compra_item_id, peso)
+      )
+    `)
+    .eq('proveedor_id', proveedorId)
+    // En prod los estados son 'recibida' y 'cancelada'; no hay 'activa'.
+    .neq('estado', 'cancelada')
+    .order('fecha_compra', { ascending: false })
+    .order('id', { ascending: false })
+    .limit(1)
+
+  if (error) throw error
+
+  const compra = (data as FilaPlantillaCargos[] | null)?.[0]
+  if (!compra) return null
+
+  const productoPorItem = new Map<string, string>(
+    (compra.items ?? []).map(i => [String(i.id), String(i.producto_id)])
+  )
+
+  // El orden de los cargos se ordena acá y no en la query: `orden` es una
+  // columna de la tabla embebida y ordenar por ahí depende de la versión del
+  // cliente. Son 6 cargos en la factura más grande.
+  const cargos: CargoPlantillaCompra[] = [...(compra.cargos ?? [])]
+    .sort((a, b) => (a.orden ?? 0) - (b.orden ?? 0))
+    .map(c => {
+      const pesosPorProducto: Record<string, number> = {}
+      for (const r of c.repartos ?? []) {
+        const productoId = productoPorItem.get(String(r.compra_item_id))
+        if (productoId === undefined) continue
+        // Dos líneas del mismo producto en la compra vieja: los pesos se suman.
+        // En la compra nueva hay una sola línea por producto (AGREGAR_ITEM las
+        // fusiona), así que lo que corresponde traer es el peso del producto
+        // entero y no el de una de sus dos mitades.
+        pesosPorProducto[productoId] = (pesosPorProducto[productoId] ?? 0) + Number(r.peso ?? 0)
+      }
+      return {
+        concepto: c.concepto,
+        condicionIva: c.condicion_iva ?? 'no_gravado',
+        enFactura: c.en_factura ?? true,
+        prorrateaAlCosto: c.prorratea_al_costo ?? true,
+        afectaBaseII: c.afecta_base_ii ?? false,
+        baseProrrateo: c.base_prorrateo ?? 'unidades',
+        pesosPorProducto,
+      }
+    })
+
+  return {
+    compraId: String(compra.id),
+    numeroFactura: compra.numero_factura ?? null,
+    fechaCompra: compra.fecha_compra ?? null,
+    cargos,
+  }
 }
 
 // Mutation functions
@@ -122,7 +263,16 @@ async function registrarCompra(compraData: CompraFormInputExtended): Promise<Reg
     p_impuestos_internos: compraData.impuestosInternos || 0,
     p_percepcion_iva: compraData.percepcionIva || 0,
     p_percepcion_iibb: compraData.percepcionIibb || 0,
-    p_no_gravado: compraData.noGravado || 0
+    p_no_gravado: compraData.noGravado || 0,
+    // mig 195. Sin esto, una factura con bonificación general queda con el total
+    // de cabecera por encima del papel (306.784,09 en la testigo) y COMPRA-A1
+    // —severidad high— se pone rojo, que es lo que vuelve inútil al gate diario.
+    p_bonificaciones: compraData.bonificaciones || 0,
+    // mig 194. Sin estos dos la RPC no ejecuta una sola línea del camino nuevo
+    // del costo: el flete no llega a ningún producto y el factor de ajuste del
+    // impuesto interno se calcula en la vista previa y se tira a la basura.
+    p_cargos: serializarCargos(compraData.cargos ?? []),
+    p_ii_declarado: compraData.iiDeclarado ?? {}
   })
 
   if (error) throw error
@@ -132,7 +282,18 @@ async function registrarCompra(compraData: CompraFormInputExtended): Promise<Reg
     throw new Error(result.error || 'Error al registrar compra')
   }
 
-  return { success: true, compraId: result.compra_id }
+  // Los avisos suben tal como los redactó la RPC, sin reinterpretarlos. Son
+  // blandos por diseño —la compra está registrada— y decían dos cosas que
+  // nadie estaba leyendo: que el total calculado no coincide con el informado,
+  // y que la apertura del impuesto interno por alícuota no cierra contra el
+  // total (o declara una tasa que ninguna línea usa, con lo cual ese importe
+  // no llega a ningún costo).
+  return {
+    success: true,
+    compraId: result.compra_id,
+    warningDescuadre: result.warning_descuadre ?? null,
+    warningIiDeclarado: result.warning_ii_declarado ?? null,
+  }
 }
 
 /**
@@ -196,6 +357,24 @@ export function useComprasByProveedorQuery(proveedorId: string) {
 }
 
 /**
+ * Cargos de la última compra con cargos de un proveedor, como plantilla.
+ *
+ * Se dispara al elegir el proveedor y no al apretar el botón: así el modal sabe
+ * ANTES si hay algo para traer y puede decir cuántos cargos y de qué factura,
+ * en vez de ofrecer un botón que a veces no hace nada.
+ */
+export function useCargosPlantillaProveedorQuery(proveedorId: string | null | undefined) {
+  const { currentSucursalId } = useSucursal()
+  const id = proveedorId ? String(proveedorId) : ''
+  return useQuery({
+    queryKey: [...comprasKeys.byProveedor(currentSucursalId, id), 'cargos-plantilla'] as const,
+    queryFn: () => fetchCargosPlantillaProveedor(id),
+    enabled: !!id,
+    staleTime: 5 * 60 * 1000,
+  })
+}
+
+/**
  * Hook para registrar una compra
  */
 export function useRegistrarCompraMutation() {
@@ -238,6 +417,26 @@ export interface ActualizarCompraItemsInput {
     condicionIva?: CondicionIva
     impuestosInternos?: number
   }>
+  /**
+   * Los cargos de la compra (mig 194). Obligatorio y no opcional a propósito:
+   * `actualizar_compra_items` borra y recrea las líneas en cada edición y el
+   * CASCADE se lleva puesto el vector de pesos, así que un cliente que no los
+   * reenvía deja los cargos vivos con el vector vacío y el flete deja de
+   * repartirse en silencio. Que el tipo lo exija obliga a cada llamador a
+   * decidir, en vez de olvidarse.
+   *
+   * `null` significa "no los conozco" y es lo único que activa el guard de la
+   * RPC; `[]` significa "esta compra no tiene ninguno" y es un dato. Mandar `[]`
+   * cuando no se leyeron los borra, que es justo lo que el guard impide.
+   *
+   * Los pesos van por índice de `items` (base 0), ya remapeados a las líneas
+   * que sobreviven a esta edición.
+   */
+  cargos: CompraCargoInput[] | null
+  /** El II declarado por alícuota, con la misma distinción null/{}: sin él el factor de ajuste se revierte solo. */
+  iiDeclarado: Record<number, number> | null
+  /** Σ de los cargos gravados en factura, con su signo (mig 195). null = no tocar. */
+  bonificaciones?: number | null
 }
 
 /** Producto cuyo CPP puede haber quedado distorsionado al editar una compra vieja (mig 128). */
@@ -249,7 +448,7 @@ export interface WarningCostoPromedio {
 
 async function actualizarCompraItems(
   input: ActualizarCompraItemsInput
-): Promise<{ compraId: string; warningCostoPromedio: WarningCostoPromedio[] }> {
+): Promise<{ compraId: string; warningCostoPromedio: WarningCostoPromedio[]; warningIiDeclarado: string | null }> {
   const itemsParaRPC: CompraItemRPC[] = input.items.map(item => ({
     producto_id: item.productoId,
     cantidad: item.cantidad,
@@ -272,6 +471,14 @@ async function actualizarCompraItems(
     p_percepcion_iva: input.percepcionIva ?? null,
     p_percepcion_iibb: input.percepcionIibb ?? null,
     p_no_gravado: input.noGravado ?? null,
+    // mig 195. `null` = "no lo mandes", y la RPC deja lo que ya tenía: un
+    // cliente viejo no puede borrar la bonificación de cabecera sin querer.
+    p_bonificaciones: input.bonificaciones ?? null,
+    // mig 194. `null` viaja como null a propósito: es lo que hace que la RPC
+    // rechace la edición de una compra con cargos hecha por un cliente que no
+    // los leyó, en vez de borrárselos en silencio.
+    p_cargos: input.cargos === null ? null : serializarCargos(input.cargos),
+    p_ii_declarado: input.iiDeclarado,
   })
 
   if (error) throw error
@@ -280,11 +487,18 @@ async function actualizarCompraItems(
     compra_id: string
     error?: string
     warning_costo_promedio?: WarningCostoPromedio[] | null
+    warning_ii_declarado?: string | null
   }
   if (!result.success) {
     throw new Error(result.error || 'Error al actualizar compra')
   }
-  return { compraId: result.compra_id, warningCostoPromedio: result.warning_costo_promedio ?? [] }
+  // `actualizar_compra_items` NO devuelve `warning_descuadre`: no recalcula el
+  // total contra el informado, lo recibe ya hecho. Sólo el del II declarado.
+  return {
+    compraId: result.compra_id,
+    warningCostoPromedio: result.warning_costo_promedio ?? [],
+    warningIiDeclarado: result.warning_ii_declarado ?? null,
+  }
 }
 
 /**

--- a/src/hooks/queries/useComprasQuery.warnings.test.tsx
+++ b/src/hooks/queries/useComprasQuery.warnings.test.tsx
@@ -1,0 +1,167 @@
+/**
+ * Los avisos blandos que devuelven las RPCs de compra tienen que llegar arriba.
+ *
+ * EL HUECO
+ * --------
+ * `registrar_compra_completa` devuelve `warning_descuadre` (el total calculado
+ * no coincide con el informado) y `warning_ii_declarado` (la apertura del
+ * impuesto interno por alícuota no cierra contra el total, o declara una tasa
+ * que ninguna línea usa). `actualizar_compra_items` devuelve el segundo. La
+ * base los redactaba y el cliente los tiraba a la basura: la compra se
+ * guardaba, el usuario veía "Compra registrada" y el descuadre no existía para
+ * nadie.
+ *
+ * Se testea la capa de query y no el DOM porque lo que se rompe en silencio es
+ * justo esto: leer un campo del jsonb. Un `warning_ii` en vez de
+ * `warning_ii_declarado` no lo ve tsc —el jsonb entra como `any` casteado— y no
+ * tira ninguna pantalla; sólo vuelve a apagar el aviso.
+ */
+import React from 'react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+
+const rpc = vi.fn()
+
+vi.mock('../supabase/base', () => ({
+  supabase: {
+    rpc: (...args: unknown[]) => rpc(...args),
+    from: vi.fn(),
+  },
+}))
+
+vi.mock('../../contexts/SucursalContext', () => ({
+  useSucursal: () => ({ currentSucursalId: 1 }),
+}))
+
+import { useRegistrarCompraMutation, useActualizarCompraMutation } from './useComprasQuery'
+import type { ActualizarCompraItemsInput } from './useComprasQuery'
+
+function makeWrapper(qc: QueryClient) {
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return <QueryClientProvider client={qc}>{children}</QueryClientProvider>
+  }
+}
+
+function setup<T>(hook: () => T) {
+  const qc = new QueryClient({ defaultOptions: { mutations: { retry: false } } })
+  return renderHook(hook, { wrapper: makeWrapper(qc) })
+}
+
+const compra = {
+  proveedorId: '3',
+  proveedorNombre: null,
+  numeroFactura: 'A0005-00461415',
+  fechaCompra: '2026-08-19',
+  subtotal: 10_000,
+  iva: 2100,
+  impuestosInternos: 500,
+  otrosImpuestos: 0,
+  total: 12_600,
+  formaPago: 'efectivo',
+  notas: null,
+  tipoFactura: 'FC' as const,
+  usuarioId: 'user-1',
+  items: [{ productoId: '7', cantidad: 10, costoUnitario: 1000, subtotal: 10_000 }],
+  cargos: [],
+  iiDeclarado: {},
+}
+
+const edicion: ActualizarCompraItemsInput = {
+  compraId: '221',
+  usuarioId: 'user-1',
+  subtotal: 10_000,
+  iva: 2100,
+  total: 12_600,
+  items: [{ productoId: '7', cantidad: 10, costoUnitario: 1000, subtotal: 10_000 }],
+  cargos: [],
+  iiDeclarado: {},
+}
+
+const DESCUADRE = 'Descuadre: total calculado 12700.00 vs total informado 12600.00'
+const II = 'El impuesto interno declarado por alicuota suma 900.00 y el total informado es 500.00.'
+
+describe('avisos de la base al registrar una compra', () => {
+  beforeEach(() => rpc.mockReset())
+
+  it('sube los dos warnings tal como los redacto la RPC', async () => {
+    rpc.mockResolvedValue({
+      data: {
+        success: true,
+        compra_id: '226',
+        warning_descuadre: DESCUADRE,
+        warning_ii_declarado: II,
+      },
+      error: null,
+    })
+    const { result } = setup(useRegistrarCompraMutation)
+
+    const res = await result.current.mutateAsync(compra)
+
+    // Tal cual: reescribir el texto acá haria que la app y la base cuenten la
+    // misma diferencia con dos numeros distintos.
+    expect(res.warningDescuadre).toBe(DESCUADRE)
+    expect(res.warningIiDeclarado).toBe(II)
+    expect(res.compraId).toBe('226')
+  })
+
+  it('sin descuadre no inventa aviso', async () => {
+    rpc.mockResolvedValue({
+      data: { success: true, compra_id: '226', warning_descuadre: null, warning_ii_declarado: null },
+      error: null,
+    })
+    const { result } = setup(useRegistrarCompraMutation)
+
+    const res = await result.current.mutateAsync(compra)
+
+    expect(res.warningDescuadre).toBeNull()
+    expect(res.warningIiDeclarado).toBeNull()
+  })
+
+  it('el aviso NO convierte la compra en un error: viene con success', async () => {
+    // Es la razon de ser del warning blando. Si se tratara como error, el
+    // container haria rollback de la UI de una compra que quedo registrada.
+    rpc.mockResolvedValue({
+      data: { success: true, compra_id: '226', warning_descuadre: DESCUADRE },
+      error: null,
+    })
+    const { result } = setup(useRegistrarCompraMutation)
+
+    await expect(result.current.mutateAsync(compra)).resolves.toMatchObject({ success: true })
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+  })
+})
+
+describe('avisos de la base al editar una compra', () => {
+  beforeEach(() => rpc.mockReset())
+
+  it('sube el del II declarado junto con el del costo promedio', async () => {
+    rpc.mockResolvedValue({
+      data: {
+        success: true,
+        compra_id: '221',
+        warning_costo_promedio: [{ producto_id: 7, costo_real_anterior: 100, costo_real_nuevo: 120 }],
+        warning_ii_declarado: II,
+      },
+      error: null,
+    })
+    const { result } = setup(useActualizarCompraMutation)
+
+    const res = await result.current.mutateAsync(edicion)
+
+    expect(res.warningIiDeclarado).toBe(II)
+    expect(res.warningCostoPromedio).toHaveLength(1)
+  })
+
+  it('sin apertura declarada no hay aviso', async () => {
+    // `actualizar_compra_items` no devuelve `warning_descuadre`: no recalcula el
+    // total contra el informado, lo recibe ya hecho.
+    rpc.mockResolvedValue({ data: { success: true, compra_id: '221' }, error: null })
+    const { result } = setup(useActualizarCompraMutation)
+
+    const res = await result.current.mutateAsync(edicion)
+
+    expect(res.warningIiDeclarado).toBeNull()
+    expect(res.warningCostoPromedio).toEqual([])
+  })
+})

--- a/src/services/analyticsExport.ts
+++ b/src/services/analyticsExport.ts
@@ -296,6 +296,7 @@ export async function fetchComprasFact(
       percepcion_iva,
       percepcion_iibb,
       no_gravado,
+      bonificaciones,
       proveedor:proveedores(nombre, cuit),
       items:compra_items(
         cantidad,
@@ -349,6 +350,9 @@ export async function fetchComprasFact(
         compra_percepcion_iva: compra.percepcion_iva ?? 0,
         compra_percepcion_iibb: compra.percepcion_iibb ?? 0,
         compra_no_gravado: compra.no_gravado ?? 0,
+        // mig 195. Sin esta columna el total exportado no se puede reconstruir
+        // desde el desglose: la bonificación general no es un renglón.
+        compra_bonificaciones: compra.bonificaciones ?? 0,
       })
     }
   }

--- a/src/types/hooks.ts
+++ b/src/types/hooks.ts
@@ -969,6 +969,8 @@ export interface CompraDBExtended {
   percepcion_iva?: number;
   percepcion_iibb?: number;
   no_gravado?: number;
+  /** Bonificaciones generales gravadas de la factura, con su signo (mig 195). */
+  bonificaciones?: number;
   otros_impuestos?: number;
   total: number;
   forma_pago?: string;
@@ -976,7 +978,91 @@ export interface CompraDBExtended {
   notas?: string | null;
   tipo_factura?: 'ZZ' | 'FC';
   items?: CompraItemDBExtended[];
+  /**
+   * Cargos prorrateados (mig 192). `undefined` significa "no los leí", no "no
+   * tiene": quien edite la compra sin ellos le borra el flete en silencio.
+   */
+  cargos?: CompraCargoDBExtended[];
+  /** Impuesto interno declarado por alícuota (mig 194): {tasa: monto}. */
+  ii_declarado?: Record<number, number> | null;
   created_at?: string;
+}
+
+/** Cómo se pre-llena el vector de pesos de un cargo (`compra_cargos.base_prorrateo`). */
+export type BaseProrrateoCompra = 'monto' | 'cantidad' | 'unidades';
+
+/**
+ * Un cargo de una compra anterior, reusado como plantilla en la siguiente.
+ *
+ * Viaja SIN monto a propósito: el concepto y las banderas fiscales se repiten
+ * factura a factura —el flete y los pallets de Manaos son los mismos todos los
+ * meses— y el importe no.
+ */
+export interface CargoPlantillaCompra {
+  concepto: string;
+  condicionIva: CondicionIva;
+  enFactura: boolean;
+  prorrateaAlCosto: boolean;
+  afectaBaseII: boolean;
+  baseProrrateo: BaseProrrateoCompra;
+  /**
+   * producto_id → peso.
+   *
+   * Los repartos se guardan contra `compra_items.id`, que no significa nada en
+   * otra compra: el producto es lo único que sobrevive de una factura a la que
+   * viene. Una línea de la compra nueva que no matchee ningún producto de la
+   * vieja queda en 0, o sea excluida del cargo.
+   */
+  pesosPorProducto: Record<string, number>;
+}
+
+/**
+ * Un cargo tal como viaja a las RPCs de compra (mig 194).
+ *
+ * `pesos` va por ÍNDICE del array de items del MISMO payload, base 0. No por
+ * producto y no por el id local del modal: `compra_items.id` todavía no existe
+ * cuando el cliente arma esto, así que el índice es lo único que las dos puntas
+ * pueden nombrar. La RPC rechaza un índice fuera de rango.
+ */
+export interface CompraCargoInput {
+  concepto: string;
+  /** SIN IVA. Negativo = bonificación. */
+  monto: number;
+  condicionIva: CondicionIva;
+  enFactura: boolean;
+  prorrateaAlCosto: boolean;
+  afectaBaseII: boolean;
+  baseProrrateo: BaseProrrateoCompra;
+  /** índice de la línea (base 0) → peso. El 0 excluye la línea. */
+  pesos: Record<number, number>;
+}
+
+/** Un reparto persistido: contra qué línea pesa un cargo y cuánto. */
+export interface CompraCargoRepartoDB {
+  compra_item_id: string;
+  peso: number;
+}
+
+/** Un cargo tal como vuelve de la base, con su vector de pesos. */
+export interface CompraCargoDBExtended {
+  id: string;
+  orden?: number | null;
+  concepto: string;
+  monto: number;
+  condicion_iva?: CondicionIva | null;
+  en_factura?: boolean | null;
+  prorratea_al_costo?: boolean | null;
+  afecta_base_ii?: boolean | null;
+  base_prorrateo?: BaseProrrateoCompra | null;
+  repartos?: CompraCargoRepartoDB[] | null;
+}
+
+/** Los cargos de la última compra no cancelada de un proveedor. */
+export interface PlantillaCargosProveedor {
+  compraId: string;
+  numeroFactura: string | null;
+  fechaCompra: string | null;
+  cargos: CargoPlantillaCompra[];
 }
 
 export interface CompraFormInputExtended {
@@ -991,6 +1077,12 @@ export interface CompraFormInputExtended {
   percepcionIva?: number;
   percepcionIibb?: number;
   noGravado?: number;
+  /**
+   * Σ de los cargos GRAVADOS que vienen en la factura, con su signo (mig 195).
+   * Negativo = bonificación general. Sin esta columna la cabecera no tiene dónde
+   * restar una bonificación que no es un renglón de producto.
+   */
+  bonificaciones?: number;
   otrosImpuestos?: number;
   total?: number;
   formaPago?: string;
@@ -1009,6 +1101,14 @@ export interface CompraFormInputExtended {
   }>;
   /** Líneas cuya tasa de II fue editada a mano: se propaga al producto tras registrar (mig 123 UI). */
   cambiosImpuestosInternos?: Array<{ productoId: string; nombre: string; impuestosInternos: number }>;
+  /** Cargos de la factura (mig 194). Los pesos van por índice de `items`. */
+  cargos?: CompraCargoInput[];
+  /**
+   * Impuesto interno declarado por alícuota: {tasa: monto}. Alimenta el factor
+   * de ajuste del motor; sin esto el factor se calcula en la vista previa del
+   * navegador y se tira a la basura al guardar.
+   */
+  iiDeclarado?: Record<number, number>;
 }
 
 export interface ProveedorFormInputExtended {
@@ -1037,9 +1137,20 @@ export interface ResumenCompras {
   porProveedor: Record<string, ResumenComprasPorProveedor>;
 }
 
+/**
+ * Lo que devuelve `registrar_compra_completa`, avisos incluidos.
+ *
+ * Los dos warnings son BLANDOS: la compra quedó registrada igual. La RPC no
+ * puede decidir cuál de los dos números que el usuario tipeó está bien, así que
+ * los deja como llegaron y avisa. Si el cliente los tira, el aviso no existe.
+ */
 export interface RegistrarCompraResult {
   success: boolean;
   compraId: string;
+  /** El total calculado no coincide con el informado (umbral: 1 peso). */
+  warningDescuadre?: string | null;
+  /** La apertura del impuesto interno por alícuota no cuadra con el total, o declara una tasa que ninguna línea usa. */
+  warningIiDeclarado?: string | null;
 }
 
 export interface UseComprasReturnExtended {

--- a/src/utils/calculations.ts
+++ b/src/utils/calculations.ts
@@ -432,11 +432,3 @@ export default {
   redondearSQL,
   redondearAMultiplo
 };
-
-// Puente transitorio: `calcularTotalesCompra` y sus tipos se mudaron a
-// `prorrateoCompra.ts` porque el desglose fiscal ahora necesita el motor de
-// cargos, y traer el motor para acá invertía la dependencia. Se re-exporta desde
-// el lugar viejo para no romper a quien todavía importe de acá; el consumidor
-// real (ModalCompra) migra en el PR del modal y ahí se cae este puente.
-export { calcularTotalesCompra } from './prorrateoCompra';
-export type { TotalesCompra, CompraItemCalculo, CompraExtras } from './prorrateoCompra';


### PR DESCRIPTION
**3 de 4.** Va sobre #486. La interfaz del motor: acá la feature se vuelve usable.

## La sección de cargos

Plegable y **cerrada por defecto**: con 4,1 ítems promedio por compra, la compra chica no tiene que verla.

Por cargo: concepto, monto sin IVA, tratamiento fiscal, y **dos casillas separadas** — *viene en la factura* / *entra al costo*. Son independientes a propósito: el flete de un transportista inscripto entra al costo, pero su IVA es crédito fiscal y no toca el IVA de esta factura. Al expandir un cargo, una grilla reparte línea por línea con la vista previa del costo final.

## El casillero que el usuario no puede llenar

`afectaBaseII` decide si una bonificación baja la base del impuesto interno, y **no hay forma de saberlo mirando la factura**: lo decide el proveedor, y la factura testigo demuestra que Manaos trató dos bonificaciones de la misma factura de forma distinta.

Un casillero que el usuario no sabe llenar no sirve. Así que **no se lo pedimos**: `resolverBasesII` lo deduce de lo que la factura declara por alícuota.

```
COLA 3.00  3000cc |    II 8,6956    desvío |    II 4,1667   desvío
  NO baja  NO baja|    347.881,33  8.996,87 |   199.027,22    0,01
  baja     NO baja|    338.884,40     -0,06 |   199.027,22    0,01   ← única que cierra
  NO baja  baja   |    331.861,53 -7.022,93 |   198.231,82  -795,39
  baja     baja   |    322.864,60-16.019,86 |   198.231,82  -795,39
```

Una sola combinación cierra, a **6 centavos sobre 338.884**. El casillero queda editable por si el usuario sabe que está mal, y cuando no hay solución única cae al ajuste proporcional — **pero diciéndolo**, en vez de presentar una aproximación como si fuera el número.

Tener el impuesto interno abierto **por alícuota** es lo que lo vuelve resoluble: con un solo total habría dos candidatas.

## Un defecto que este mismo diseño introdujo

Las bonificaciones pasaron a ser cargos, y `calcularTotalesCompra` no las veía. En la factura testigo eso dejaba la cabecera con el **IVA 64.424,66 arriba** y el **impuesto interno 8.996,90 arriba** — números que alimentan la posición fiscal.

Se arregla acá haciendo que la cabecera salga del motor, sin rama `si hay cargos`: con la lista vacía el motor se reduce a la aritmética de antes, así que el forward-only se sostiene **por construcción** y no por un `if` cuyos dos brazos alguien tiene que mantener de acuerdo — que es exactamente el mecanismo que produjo este bug.

## Otras cosas

- El puente de `calculations.ts` que dejó #485 **se cae acá**: `ModalCompra` pasa a importar del motor.
- Botón para **traer los cargos de la última compra del proveedor** (conceptos y flags se reusan, los montos van en 0). Sin eso el reparto manual no es sostenible: flete y pallets se repiten en cada factura.
- El campo "No gravado" del resumen **se pre-llena** con los cargos no gravados que vienen en la factura, en vez de pedirle al usuario un número que el sistema ya sabe.
- Los avisos que devuelve la base (`warning_descuadre`, `warning_ii_declarado`) ahora llegan al usuario; antes se descartaban.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
