### PR TITLE
Atar las dos implementaciones del motor con un espejo automatico

### DIFF
--- a/.github/workflows/integridad.yml
+++ b/.github/workflows/integridad.yml
@@ -90,3 +90,25 @@ jobs:
           SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
           SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
         run: node scripts/check-permisos.mjs
+
+      # El motor de costos de una compra está escrito dos veces —TypeScript para
+      # la vista previa del modal, SQL para lo que se persiste— y las dos tienen
+      # que dar el mismo número al centavo. Esto corre LAS DOS sobre los mismos
+      # casos y deja que la comparación la haga Postgres.
+      #
+      # Va acá y no en la suite de vitest porque necesita la base. La contraparte
+      # local y sin red es `src/utils/prorrateoCompra.espejo.test.ts`, que compara
+      # el TS contra un fixture congelado y por eso NO ve si el que se movió fue
+      # el SQL. Éste sí.
+      #
+      # Único paso que necesita node_modules: carga el motor de TypeScript con
+      # Vite en vez de copiar la aritmética al script. Sin `if [ -z ... ] exit 0`
+      # a propósito — el paso de secrets de arriba ya falla por todos.
+      - name: Espejo del motor de compras (TS vs SQL)
+        if: always()
+        env:
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+        run: |
+          npm ci --no-audit --no-fund
+          node scripts/espejo-motor-compras.mjs

--- a/migrations/196_espejo_del_motor_de_compras.sql
+++ b/migrations/196_espejo_del_motor_de_compras.sql
@@ -1,0 +1,285 @@
+-- ============================================================================
+-- 196 · El espejo entre las dos implementaciones del motor de compras
+-- ============================================================================
+-- Ver docs/plans/2026-08-18-cargos-y-cuadre-de-compras.md y la mig 193.
+--
+-- EL PROBLEMA. El motor de costos de una compra está escrito DOS veces:
+--
+--   · `src/utils/prorrateoCompra.ts` — alimenta la vista previa del modal, que
+--     tiene que anticipar el costo sin ir a la base.
+--   · `prorratear_cargo` / `calcular_costos_compra` (mig 193) — la canónica: lo
+--     que se PERSISTE sale de acá.
+--
+-- Las dos se verificaron a mano contra la factura testigo A0005-00461415 —126
+-- celdas y 22 repartos, cero divergencias— y los dos archivos dicen "si cambiás
+-- una, cambiá la otra". Eso es una frase, no una garantía: si mañana alguien
+-- toca un lado, nadie se entera hasta que un costo sale mal en producción.
+--
+-- LO QUE HACE ESTA FUNCIÓN. Recibe un lote de casos con la entrada en jsonb y la
+-- salida que dio el motor de TypeScript, corre el motor de SQL sobre la MISMA
+-- entrada y devuelve las celdas en las que los dos no dicen lo mismo. Es el
+-- corazón de `scripts/espejo-motor-compras.mjs`, que corre en el gate de
+-- integridad —el único lugar del proyecto con credenciales de servicio— y sale
+-- con 1 ante cualquier divergencia.
+--
+-- POR QUÉ LA COMPARACIÓN LA HACE POSTGRES Y NO EL SCRIPT. Porque de este lado
+-- los números son `numeric` —decimal exacto— y del otro son `double`. Comparar
+-- en JavaScript obligaría a bajar el numeric a double primero, que es
+-- exactamente la conversión que puede tapar la diferencia que se busca. Acá
+-- `IS DISTINCT FROM` sobre numeric ignora la escala (500 y 500.00 son el mismo
+-- número, que es lo correcto: nadie escribió mal nada) y no ignora un centavo.
+--
+-- POR QUÉ SE REDONDEA A `p_decimales` ANTES DE COMPARAR. El TS acumula en double
+-- y sobre esta factura eso deja una discrepancia del orden de 1e-9 contra la
+-- suma exacta de numeric. Comparar bit a bit haría fallar el espejo por el
+-- formato de punto flotante y no por un bug, y un espejo que grita siempre no lo
+-- mira nadie. El default de 6 decimales está tres órdenes arriba de ese ruido y
+-- cuatro por debajo del centavo, que es la unidad que este espejo tiene que
+-- cazar. La constante gemela está en `prorrateoCompra.espejo.ts`.
+--
+-- QUÉ ES UNA DIVERGENCIA. Tres cosas, y las tres cuentan igual:
+--   · una celda con distinto valor;
+--   · una celda que existe de un lado y no del otro (una línea de más, un total
+--     que se dejó de emitir);
+--   · que UNA SOLA de las dos implementaciones lance. Que las dos rechacen la
+--     misma basura es la mitad del contrato: si el SQL lanza y el TS devuelve un
+--     número, el modal le muestra al usuario un costo que la base va a rechazar.
+--     El texto del mensaje NO se compara —el de SQL nombra la función en
+--     snake_case y el de TS en camelCase— pero los dos viajan al reporte para
+--     que un humano los lea.
+--
+-- ESTA FUNCIÓN NO TOCA NINGUNA TABLA. Es aritmética sobre sus argumentos, igual
+-- que las dos que compara; se la marca STABLE y no IMMUTABLE sólo por el now()
+-- del encabezado del reporte.
+-- ============================================================================
+
+BEGIN;
+
+CREATE OR REPLACE FUNCTION public.espejo_motor_compras(
+  p_casos     jsonb,
+  p_decimales integer DEFAULT 6
+) RETURNS jsonb
+LANGUAGE plpgsql
+STABLE
+SET search_path TO 'public'
+AS $espejo$
+DECLARE
+  v_caso        jsonb;
+  v_nombre      text;
+  v_motor       text;
+  v_entrada     jsonb;
+  v_ts_json     jsonb;
+  v_ts_error    text;
+  v_sql_json    jsonb;
+  v_sql_error   text;
+  v_divs        jsonb;
+  v_celdas      integer;
+  v_detalle     jsonb := '[]'::jsonb;
+  v_tot_celdas  integer := 0;
+  v_tot_divs    integer := 0;
+  v_casos_rojos integer := 0;
+BEGIN
+  IF p_casos IS NULL OR jsonb_typeof(p_casos) <> 'array' THEN
+    RAISE EXCEPTION 'espejo_motor_compras: p_casos tiene que ser un array y llego %.',
+      COALESCE(jsonb_typeof(p_casos), 'NULL') USING ERRCODE = '22023';
+  END IF;
+  -- Un p_decimales absurdo no es un detalle: es la diferencia entre un espejo
+  -- que mide y uno que dice que sí a cualquier cosa. 12 es el techo porque abajo
+  -- de eso ya no hay señal, sólo el ruido del double.
+  IF p_decimales IS NULL OR p_decimales < 0 OR p_decimales > 12 THEN
+    RAISE EXCEPTION 'espejo_motor_compras: p_decimales fuera de rango (%). Se espera 0..12.',
+      COALESCE(p_decimales::text, 'NULL') USING ERRCODE = '22023';
+  END IF;
+
+  FOR v_caso IN SELECT e FROM jsonb_array_elements(p_casos) e LOOP
+    v_nombre    := COALESCE(v_caso->>'caso', '(sin nombre)');
+    v_motor     := v_caso->>'motor';
+    v_entrada   := COALESCE(v_caso->'entrada', '{}'::jsonb);
+    v_ts_error  := v_caso->>'ts_error';
+    v_ts_json   := CASE WHEN COALESCE(jsonb_typeof(v_caso->'ts'), 'null') = 'null'
+                        THEN NULL ELSE v_caso->'ts' END;
+    v_sql_json  := NULL;
+    v_sql_error := NULL;
+
+    -- Fuera del bloque con EXCEPTION a propósito: un motor mal escrito en el
+    -- payload es un error del espejo, no una divergencia entre los motores, y
+    -- tragárselo lo haría pasar por un caso que "coincidió".
+    IF v_motor IS NULL OR v_motor NOT IN ('prorratear_cargo', 'calcular_costos_compra') THEN
+      RAISE EXCEPTION 'espejo_motor_compras: motor desconocido "%" en el caso "%".',
+        COALESCE(v_motor, 'null'), v_nombre USING ERRCODE = '22023';
+    END IF;
+
+    BEGIN
+      IF v_motor = 'prorratear_cargo' THEN
+        -- Se re-arma el objeto {id: monto} para que las dos salidas tengan la
+        -- misma forma: el TS devuelve un Record y el SQL un conjunto de filas.
+        -- Sin cargo repartido son 0 filas y `{}`, que es lo que devuelve el TS.
+        SELECT COALESCE(jsonb_object_agg(r.item_id::text, r.monto), '{}'::jsonb)
+          INTO v_sql_json
+          FROM prorratear_cargo((v_entrada->>'monto')::numeric, v_entrada->'pesos') r;
+      ELSE
+        v_sql_json := calcular_costos_compra(
+          v_entrada->'items', v_entrada->'cargos', v_entrada->'ii_declarado');
+      END IF;
+    EXCEPTION WHEN OTHERS THEN
+      -- El cast de `monto` a numeric también cae acá, y está bien: desde el
+      -- punto de vista del contrato, "el SQL no acepta esta entrada" es el mismo
+      -- hecho lo tire la función o lo tire el borde.
+      v_sql_json  := NULL;
+      v_sql_error := SQLERRM;
+    END;
+
+    IF v_ts_error IS NOT NULL OR v_sql_error IS NOT NULL THEN
+      v_celdas := 0;
+      v_divs := CASE
+        WHEN v_ts_error IS NOT NULL AND v_sql_error IS NOT NULL THEN '[]'::jsonb
+        WHEN v_ts_error IS NULL THEN jsonb_build_array(jsonb_build_object(
+               'campo', '(contrato)',
+               'motivo', 'el SQL rechazo la entrada y el TS la acepto',
+               'ts', COALESCE(v_ts_json, 'null'::jsonb),
+               'sql', to_jsonb(v_sql_error)))
+        ELSE jsonb_build_array(jsonb_build_object(
+               'campo', '(contrato)',
+               'motivo', 'el TS rechazo la entrada y el SQL la acepto',
+               'ts', to_jsonb(v_ts_error),
+               'sql', COALESCE(v_sql_json, 'null'::jsonb)))
+      END;
+    ELSE
+      -- Aplanado de los dos jsonb a `(ruta, valor)` y comparación celda por
+      -- celda. La ruta se arma igual que en el espejo de JS —`.lineas[0].ii`—
+      -- para que los dos reportes nombren el mismo campo con el mismo texto.
+      --
+      -- El FULL OUTER JOIN es el que atrapa la asimetría estructural: una clave
+      -- que un lado dejó de emitir no es "igual a nada", es una divergencia.
+      -- Un objeto o un array VACÍO no deja hoja, así que dos vacíos comparan 0
+      -- celdas; por eso el reporte publica `celdas` y no sólo el veredicto.
+      WITH RECURSIVE hojas(lado, ruta, valor) AS (
+        SELECT o.lado, ''::text, o.j
+          FROM (VALUES ('ts', v_ts_json), ('sql', v_sql_json)) AS o(lado, j)
+        UNION ALL
+        SELECT h.lado, h.ruta || e.paso, e.hijo
+          FROM hojas h
+          CROSS JOIN LATERAL (
+            SELECT CASE WHEN jsonb_typeof(h.valor) = 'array'
+                        THEN '[' || t.key || ']' ELSE '.' || t.key END AS paso,
+                   t.value AS hijo
+              FROM jsonb_each(
+                     -- El array se vuelve objeto con el índice de clave: así una
+                     -- sola rama recursiva cubre los dos contenedores (un CTE
+                     -- recursivo no admite dos referencias a sí mismo). El ELSE
+                     -- '{}' es el que corta en los escalares, y va acá adentro y
+                     -- no en un WHERE porque el planner puede evaluar el LATERAL
+                     -- antes que el filtro y reventar con "cannot call
+                     -- jsonb_each on a scalar".
+                     CASE jsonb_typeof(h.valor)
+                       WHEN 'array' THEN (
+                         SELECT COALESCE(jsonb_object_agg((a.i - 1)::text, a.v), '{}'::jsonb)
+                           FROM jsonb_array_elements(h.valor) WITH ORDINALITY AS a(v, i))
+                       WHEN 'object' THEN h.valor
+                       ELSE '{}'::jsonb
+                     END) AS t
+          ) AS e
+      ),
+      planas AS (
+        SELECT h.lado, h.ruta, h.valor
+          FROM hojas h
+         WHERE jsonb_typeof(h.valor) NOT IN ('object', 'array')
+      ),
+      pares AS (
+        SELECT COALESCE(t.ruta, s.ruta) AS ruta,
+               t.valor AS valor_ts, s.valor AS valor_sql,
+               (t.ruta IS NOT NULL) AS en_ts, (s.ruta IS NOT NULL) AS en_sql
+          FROM (SELECT ruta, valor FROM planas WHERE lado = 'ts')  t
+          FULL OUTER JOIN
+               (SELECT ruta, valor FROM planas WHERE lado = 'sql') s ON s.ruta = t.ruta
+      )
+      SELECT count(*)::integer,
+             COALESCE(jsonb_agg(jsonb_build_object(
+                        'campo', p.ruta,
+                        'motivo', CASE WHEN NOT p.en_sql THEN 'falta en el SQL'
+                                       WHEN NOT p.en_ts  THEN 'falta en el TS'
+                                       ELSE 'difiere' END,
+                        'ts',  COALESCE(p.valor_ts,  'null'::jsonb),
+                        'sql', COALESCE(p.valor_sql, 'null'::jsonb))
+                      ORDER BY p.ruta)
+                      FILTER (WHERE
+                        NOT p.en_ts OR NOT p.en_sql
+                        OR CASE WHEN jsonb_typeof(p.valor_ts)  = 'number'
+                                 AND jsonb_typeof(p.valor_sql) = 'number'
+                                THEN round((p.valor_ts  #>> '{}')::numeric, p_decimales)
+                                     IS DISTINCT FROM
+                                     round((p.valor_sql #>> '{}')::numeric, p_decimales)
+                                ELSE p.valor_ts IS DISTINCT FROM p.valor_sql
+                           END),
+                      '[]'::jsonb)
+        INTO v_celdas, v_divs
+        FROM pares p;
+    END IF;
+
+    v_tot_celdas := v_tot_celdas + COALESCE(v_celdas, 0);
+    v_tot_divs   := v_tot_divs + jsonb_array_length(v_divs);
+    IF jsonb_array_length(v_divs) > 0 THEN
+      v_casos_rojos := v_casos_rojos + 1;
+    END IF;
+
+    v_detalle := v_detalle || jsonb_build_array(jsonb_build_object(
+      'caso',         v_nombre,
+      'motor',        v_motor,
+      'origen',       v_caso->>'origen',
+      'celdas',       COALESCE(v_celdas, 0),
+      -- La salida del SQL viaja entera aunque el caso esté en verde: es la que
+      -- `--fijar` congela como fixture de la capa 1.
+      'sql',          v_sql_json,
+      'sql_error',    v_sql_error,
+      'ts_error',     v_ts_error,
+      'divergencias', v_divs
+    ));
+  END LOOP;
+
+  RETURN jsonb_build_object(
+    'generado_at',  now(),
+    'decimales',    p_decimales,
+    'casos',        jsonb_array_length(p_casos),
+    'casos_rojos',  v_casos_rojos,
+    'celdas',       v_tot_celdas,
+    'divergencias', v_tot_divs,
+    'detalle',      v_detalle
+  );
+END;
+$espejo$;
+
+COMMENT ON FUNCTION public.espejo_motor_compras(jsonb, integer) IS
+  'Espejo entre las dos implementaciones del motor de costos de compra. Recibe '
+  'casos con la entrada en jsonb y la salida del motor de TypeScript, corre el '
+  'de SQL (prorratear_cargo / calcular_costos_compra, mig 193) sobre la MISMA '
+  'entrada y devuelve las celdas donde no coinciden. Compara con IS DISTINCT '
+  'FROM sobre numeric redondeado a p_decimales, asi 500 y 500.00 son el mismo '
+  'numero y un centavo no. Que solo una de las dos lance tambien es divergencia. '
+  'Lo consume scripts/espejo-motor-compras.mjs desde el gate de integridad '
+  '(mig 196).';
+
+-- Sólo el gate. No la llama ni el front ni el bot, así que `authenticated` va
+-- en el REVOKE junto con PUBLIC y anon —y NO es simétrico con la 193, que sí se
+-- la da a authenticated porque el modal la usa—.
+--
+-- `authenticated` va nombrado y medido: el default privilege del schema public
+-- le da EXECUTE a los tres roles de Supabase apenas se crea la función, así que
+-- revocar sólo PUBLIC y anon deja la puerta abierta sin que se note. Se midió
+-- al aplicar esta misma migración: quedó `EXECUTE:authenticated` puesto por el
+-- default, contra lo que decía este mismo comentario. Ver el comentario largo
+-- de la 193 sobre los dos default privileges que conviven en el schema.
+REVOKE ALL ON FUNCTION public.espejo_motor_compras(jsonb, integer)
+  FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.espejo_motor_compras(jsonb, integer) TO service_role;
+
+COMMIT;
+
+-- ----------------------------------------------------------------------------
+-- Rollback
+--
+-- No escribe nada y no la llama ninguna otra función: dropearla es exacto. Deja
+-- al gate de espejo sin backend, así que el paso de CI hay que sacarlo en el
+-- mismo movimiento o queda fallando con un 404 de PostgREST.
+--
+--   DROP FUNCTION IF EXISTS public.espejo_motor_compras(jsonb, integer);
+-- ----------------------------------------------------------------------------

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "prepare": "husky",
     "check-secrets": "./scripts/check-secrets.sh",
     "check:migrations": "node scripts/check-migrations.mjs",
-    "check:permisos": "node scripts/check-permisos.mjs",
+    "check:espejo": "node scripts/espejo-motor-compras.mjs",
     "typecheck": "tsc --noEmit",
     "typecheck:watch": "tsc --noEmit --watch",
     "generate:pwa-assets": "node scripts/generate-pwa-assets.js",

--- a/scripts/espejo-motor-compras.mjs
+++ b/scripts/espejo-motor-compras.mjs
@@ -1,0 +1,208 @@
+#!/usr/bin/env node
+/**
+ * EL ESPEJO ENTRE LAS DOS IMPLEMENTACIONES DEL MOTOR DE COSTOS DE COMPRA.
+ *
+ * El motor está escrito dos veces y las dos tienen que dar el mismo número:
+ *
+ *   · TypeScript — `src/utils/prorrateoCompra.ts`, la vista previa del modal.
+ *   · SQL — `prorratear_cargo` / `calcular_costos_compra` (mig 193), la
+ *     canónica: lo que se PERSISTE sale de ahí.
+ *
+ * Este script corre LAS DOS sobre los mismos casos y sale con 1 ante cualquier
+ * divergencia. Es la única de las dos capas que ve los dos lados: el test de
+ * vitest (`src/utils/prorrateoCompra.espejo.test.ts`) compara el TS contra un
+ * fixture congelado y por eso NO puede detectar que se movió el SQL. Este sí, y
+ * además es el que regenera ese fixture.
+ *
+ * CÓMO COMPARA. Las entradas se serializan a JSON —lo que viajaría por la red— y
+ * el MISMO texto va a los dos motores. El de TypeScript se importa de verdad
+ * (vía Vite, para que el `.ts` se resuelva igual que en la app): nada de copiar
+ * la aritmética acá, que sería un tercer motor para mantener. La comparación la
+ * hace Postgres, en `espejo_motor_compras` (mig 196), con `IS DISTINCT FROM`
+ * sobre `numeric`: así `500` contra `500.00` no cuenta y un centavo sí.
+ *
+ * Requiere env: SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY (service_role, NO anon:
+ * la RPC del espejo no está expuesta a anon ni a authenticated).
+ *
+ *   node scripts/espejo-motor-compras.mjs             # compara y falla si difiere
+ *   node scripts/espejo-motor-compras.mjs --fijar     # además regenera el fixture
+ *   node scripts/espejo-motor-compras.mjs --payload p.json   # sólo escribe el payload
+ *   node scripts/espejo-motor-compras.mjs --respuesta r.json # lee la respuesta de un archivo
+ *
+ * Los dos últimos existen para poder correr el espejo sin credenciales de
+ * servicio a mano —se manda el payload a la base por otro camino y se le da la
+ * respuesta al script—, que es como se verifica desde una máquina de desarrollo.
+ * No los usa el gate.
+ */
+import { writeFileSync, readFileSync } from 'node:fs';
+import path from 'node:path';
+import process from 'node:process';
+import { fileURLToPath } from 'node:url';
+
+const RAIZ = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const FIXTURE = path.join(RAIZ, 'src', 'utils', 'prorrateoCompra.espejo.fixture.json');
+
+const args = process.argv.slice(2);
+const flag = (nombre) => args.includes(nombre);
+const valor = (nombre) => {
+  const i = args.indexOf(nombre);
+  return i >= 0 ? args[i + 1] : undefined;
+};
+
+const fijar = flag('--fijar');
+const salidaPayload = valor('--payload');
+const desdeArchivo = valor('--respuesta');
+
+// --- 1. El motor de TypeScript, importado de verdad ---------------------------
+// `ssrLoadModule` de Vite en vez de un import de Node: `prorrateoCompra.ts`
+// importa `./calculations` sin extensión y el resolver de Node no la completa.
+// Usar Vite además garantiza que se está cargando EL MISMO módulo que la app,
+// que es la única forma de que este script signifique algo.
+const { createServer } = await import('vite');
+const vite = await createServer({
+  configFile: false,          // sin el config de la app: el motor es TS puro
+  root: RAIZ,
+  logLevel: 'error',
+  appType: 'custom',
+  server: { middlewareMode: true, hmr: false, watch: null },
+  optimizeDeps: { noDiscovery: true, include: [] },
+});
+
+let espejo;
+try {
+  espejo = await vite.ssrLoadModule('/src/utils/prorrateoCompra.espejo.ts');
+} finally {
+  // Se cierra apenas se cargó el módulo: el resto del script no necesita Vite y
+  // un servidor abierto deja el proceso colgado en CI.
+  await vite.close();
+}
+
+const { CASOS_ESPEJO, DECIMALES_ESPEJO, correrMotorTS, redondearSalida, NO_CUBIERTO } = espejo;
+
+// --- 2. El payload: la misma entrada para los dos motores ---------------------
+const casos = CASOS_ESPEJO.map((c) => {
+  const { ts, ts_error } = correrMotorTS(c);
+  return { caso: c.caso, motor: c.motor, origen: c.origen, entrada: c.entrada, ts, ts_error };
+});
+const payload = { p_casos: casos, p_decimales: DECIMALES_ESPEJO };
+
+if (salidaPayload) {
+  writeFileSync(salidaPayload, JSON.stringify(payload), 'utf8');
+  console.log(`Payload de ${casos.length} caso(s) escrito en ${salidaPayload}.`);
+  console.log('Pasalo por public.espejo_motor_compras(p_casos, p_decimales) y volvé con --respuesta.');
+  process.exit(0);
+}
+
+// --- 3. El motor de SQL y la comparación, adentro de Postgres -----------------
+let r;
+if (desdeArchivo) {
+  r = JSON.parse(readFileSync(desdeArchivo, 'utf8'));
+  console.log(`Respuesta leída de ${desdeArchivo} (sin ir a la red).`);
+} else {
+  const url = process.env.SUPABASE_URL;
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!url || !key) {
+    console.error('Faltan SUPABASE_URL / SUPABASE_SERVICE_ROLE_KEY en el entorno.');
+    process.exit(2);
+  }
+  const res = await fetch(`${url.replace(/\/$/, '')}/rest/v1/rpc/espejo_motor_compras`, {
+    method: 'POST',
+    headers: {
+      apikey: key,
+      Authorization: `Bearer ${key}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(payload),
+  });
+  if (!res.ok) {
+    console.error(`El RPC espejo_motor_compras() falló: HTTP ${res.status}\n${await res.text()}`);
+    console.error('¿Aplicaste migrations/196_espejo_del_motor_de_compras.sql?');
+    process.exit(2);
+  }
+  r = await res.json();
+}
+
+// --- 4. Reporte ---------------------------------------------------------------
+const detalle = Array.isArray(r.detalle) ? r.detalle : [];
+const rojos = detalle.filter((c) => (c.divergencias ?? []).length > 0);
+
+console.log(`Espejo TS ↔ SQL del motor de compras @ ${r.generado_at ?? '(sin fecha)'}`);
+console.log(
+  `Casos: ${r.casos} | celdas comparadas: ${r.celdas} | ` +
+  `divergencias: ${r.divergencias} en ${r.casos_rojos} caso(s) | ` +
+  `comparado a ${r.decimales} decimales`,
+);
+
+// Un caso que no compara ninguna celda y tampoco es de contrato pasa por no
+// mirar nada. Se nombra: es la forma más silenciosa de que este gate se vacíe.
+const mudos = detalle.filter((c) => c.celdas === 0 && !c.sql_error && !c.ts_error);
+if (mudos.length) {
+  console.log('\n⚠ Casos que no compararon ninguna celda (las dos salidas vacías):');
+  for (const c of mudos) console.log(`   ${c.caso}`);
+}
+
+const contrato = detalle.filter((c) => c.sql_error || c.ts_error);
+console.log(
+  `\nContrato: ${contrato.length} caso(s) donde alguna implementación rechaza la entrada; ` +
+  `${contrato.filter((c) => c.sql_error && c.ts_error).length} donde la rechazan las dos.`,
+);
+
+if (rojos.length) {
+  console.log('\n❌ Divergencias:');
+  for (const c of rojos) {
+    console.log(`\n  ${c.caso}  [${c.motor}, de ${c.origen ?? '?'}]`);
+    for (const d of c.divergencias.slice(0, 12)) {
+      console.log(`    ${d.campo}  ${d.motivo}`);
+      console.log(`      TS  = ${JSON.stringify(d.ts)}`);
+      console.log(`      SQL = ${JSON.stringify(d.sql)}`);
+    }
+    if (c.divergencias.length > 12) {
+      console.log(`    … y ${c.divergencias.length - 12} más.`);
+    }
+  }
+}
+
+// --- 5. El fixture de la capa 1 ----------------------------------------------
+// Se escribe SIEMPRE que se pida, aun con divergencias, pero después del reporte
+// y sólo si el espejo está en verde: congelar una salida de SQL que no coincide
+// con el TS convertiría el test rápido en un test que exige la divergencia.
+if (fijar) {
+  if (rojos.length) {
+    console.error('\n❌ No se regenera el fixture con divergencias abiertas: congelaría el desacuerdo.');
+    process.exit(1);
+  }
+  const fixture = {
+    _: [
+      'GENERADO por scripts/espejo-motor-compras.mjs --fijar. No editar a mano.',
+      'Es la salida del motor de SQL (mig 193) para cada caso, redondeada a los',
+      'mismos decimales a los que el espejo compara: la referencia contra la que',
+      'prorrateoCompra.espejo.test.ts corre el motor de TypeScript sin base.',
+      'Sin fecha a proposito: regenerarlo sin cambios tiene que dar un archivo',
+      'identico, para que un diff vacio signifique "el SQL no se movio".',
+    ].join(' '),
+    decimales: r.decimales,
+    casos: detalle.map((c) => ({
+      caso: c.caso,
+      motor: c.motor,
+      origen: c.origen,
+      entrada: casos.find((x) => x.caso === c.caso)?.entrada,
+      celdas: c.celdas,
+      sql: c.sql == null ? null : redondearSalida(c.sql, r.decimales),
+      sql_error: c.sql_error ?? null,
+    })),
+  };
+  writeFileSync(FIXTURE, `${JSON.stringify(fixture, null, 2)}\n`, 'utf8');
+  console.log(`\nFixture regenerado: ${path.relative(RAIZ, FIXTURE)}`);
+}
+
+if (rojos.length) {
+  console.error(
+    `\n❌ ${r.divergencias} divergencia(s) entre el motor de TypeScript y el de SQL. ` +
+    'Una de las dos implementaciones se movió sin la otra.',
+  );
+  process.exit(1);
+}
+
+console.log('\n✅ Las dos implementaciones dan lo mismo en todos los casos.');
+console.log('   Lo que este espejo NO cubre:');
+for (const l of NO_CUBIERTO) console.log(`   · ${l}`);

--- a/src/utils/prorrateoCompra.espejo.fixture.json
+++ b/src/utils/prorrateoCompra.espejo.fixture.json
@@ -1,0 +1,2715 @@
+{
+  "_": "GENERADO por scripts/espejo-motor-compras.mjs --fijar. No editar a mano. Es la salida del motor de SQL (mig 193) para cada caso, redondeada a los mismos decimales a los que el espejo compara: la referencia contra la que prorrateoCompra.espejo.test.ts corre el motor de TypeScript sin base. Sin fecha a proposito: regenerarlo sin cambios tiene que dar un archivo identico, para que un diff vacio signifique \"el SQL no se movio\".",
+  "decimales": 6,
+  "casos": [
+    {
+      "caso": "reparto · proporcional al peso",
+      "motor": "prorratear_cargo",
+      "origen": "prorrateoCompra.test.ts",
+      "entrada": {
+        "monto": 1000,
+        "pesos": {
+          "1": 1,
+          "2": 1
+        }
+      },
+      "celdas": 2,
+      "sql": {
+        "1": 500,
+        "2": 500
+      },
+      "sql_error": null
+    },
+    {
+      "caso": "reparto · la suma da el monto exacto",
+      "motor": "prorratear_cargo",
+      "origen": "prorrateoCompra.test.ts",
+      "entrada": {
+        "monto": 1000,
+        "pesos": {
+          "1": 1,
+          "2": 1,
+          "3": 1
+        }
+      },
+      "celdas": 3,
+      "sql": {
+        "1": 333.34,
+        "2": 333.33,
+        "3": 333.33
+      },
+      "sql_error": null
+    },
+    {
+      "caso": "reparto · el residuo va a la linea de mayor peso",
+      "motor": "prorratear_cargo",
+      "origen": "prorrateoCompra.test.ts",
+      "entrada": {
+        "monto": 100,
+        "pesos": {
+          "1": 1,
+          "2": 1,
+          "3": 4
+        }
+      },
+      "celdas": 3,
+      "sql": {
+        "1": 16.67,
+        "2": 16.67,
+        "3": 66.66
+      },
+      "sql_error": null
+    },
+    {
+      "caso": "reparto · empate de peso maximo: desempata por menor id",
+      "motor": "prorratear_cargo",
+      "origen": "prorrateoCompra.test.ts",
+      "entrada": {
+        "monto": 100,
+        "pesos": {
+          "3": 1,
+          "5": 1,
+          "7": 1
+        }
+      },
+      "celdas": 3,
+      "sql": {
+        "3": 33.34,
+        "5": 33.33,
+        "7": 33.33
+      },
+      "sql_error": null
+    },
+    {
+      "caso": "reparto · peso cero excluye la linea",
+      "motor": "prorratear_cargo",
+      "origen": "prorrateoCompra.test.ts",
+      "entrada": {
+        "monto": 880,
+        "pesos": {
+          "1": 0,
+          "2": 0,
+          "3": 1
+        }
+      },
+      "celdas": 3,
+      "sql": {
+        "1": 0,
+        "2": 0,
+        "3": 880
+      },
+      "sql_error": null
+    },
+    {
+      "caso": "reparto · monto negativo (bonificacion)",
+      "motor": "prorratear_cargo",
+      "origen": "prorrateoCompra.test.ts",
+      "entrada": {
+        "monto": -100,
+        "pesos": {
+          "1": 1,
+          "2": 1,
+          "3": 1
+        }
+      },
+      "celdas": 3,
+      "sql": {
+        "1": -33.34,
+        "2": -33.33,
+        "3": -33.33
+      },
+      "sql_error": null
+    },
+    {
+      "caso": "reparto · redondeo de Postgres: medio centavo negativo",
+      "motor": "prorratear_cargo",
+      "origen": "prorrateoCompra.test.ts",
+      "entrada": {
+        "monto": -0.01,
+        "pesos": {
+          "1": 1,
+          "2": 1
+        }
+      },
+      "celdas": 2,
+      "sql": {
+        "1": 0,
+        "2": -0.01
+      },
+      "sql_error": null
+    },
+    {
+      "caso": "reparto · suma de pesos cero devuelve vacio",
+      "motor": "prorratear_cargo",
+      "origen": "prorrateoCompra.test.ts",
+      "entrada": {
+        "monto": 1000,
+        "pesos": {
+          "1": 0,
+          "2": 0
+        }
+      },
+      "celdas": 0,
+      "sql": {},
+      "sql_error": null
+    },
+    {
+      "caso": "reparto · sin pesos devuelve vacio",
+      "motor": "prorratear_cargo",
+      "origen": "prorrateoCompra.test.ts",
+      "entrada": {
+        "monto": 100,
+        "pesos": {}
+      },
+      "celdas": 0,
+      "sql": {},
+      "sql_error": null
+    },
+    {
+      "caso": "reparto · el flete real: 1.900.000 sobre 26 pallets",
+      "motor": "prorratear_cargo",
+      "origen": "prorrateoCompra.test.ts",
+      "entrada": {
+        "monto": 1900000,
+        "pesos": {
+          "1": 0.5,
+          "2": 0.5,
+          "3": 2,
+          "4": 0.5,
+          "5": 0.5,
+          "6": 1,
+          "7": 1,
+          "8": 2,
+          "9": 1,
+          "10": 2,
+          "11": 4,
+          "12": 1,
+          "13": 1,
+          "14": 2,
+          "15": 1,
+          "16": 1,
+          "17": 1,
+          "18": 1,
+          "19": 1,
+          "20": 1,
+          "21": 1
+        }
+      },
+      "celdas": 21,
+      "sql": {
+        "1": 36538.46,
+        "2": 36538.46,
+        "3": 146153.85,
+        "4": 36538.46,
+        "5": 36538.46,
+        "6": 73076.92,
+        "7": 73076.92,
+        "8": 146153.85,
+        "9": 73076.92,
+        "10": 146153.85,
+        "11": 292307.72,
+        "12": 73076.92,
+        "13": 73076.92,
+        "14": 146153.85,
+        "15": 73076.92,
+        "16": 73076.92,
+        "17": 73076.92,
+        "18": 73076.92,
+        "19": 73076.92,
+        "20": 73076.92,
+        "21": 73076.92
+      },
+      "sql_error": null
+    },
+    {
+      "caso": "motor · sin cargos: neto x (1 + II%)",
+      "motor": "calcular_costos_compra",
+      "origen": "prorrateoCompra.test.ts",
+      "entrada": {
+        "items": [
+          {
+            "id": 1,
+            "cantidad": 10,
+            "costo_unitario": 100,
+            "bonificacion": 0,
+            "impuestos_internos": 8.6956,
+            "porcentaje_iva": 21,
+            "condicion_iva": "gravado"
+          }
+        ],
+        "cargos": [],
+        "ii_declarado": {}
+      },
+      "celdas": 14,
+      "sql": {
+        "lineas": [
+          {
+            "id": 1,
+            "ii": 8.6956,
+            "iva": 21,
+            "cargos": 0,
+            "base_iva": 100,
+            "costo_neto": 100,
+            "costo_real": 108.6956
+          }
+        ],
+        "totales": {
+          "iva": 210,
+          "no_gravado": 0,
+          "neto_exento": 0,
+          "neto_gravado": 1000,
+          "cargos_al_costo": 0,
+          "neto_no_gravado": 0,
+          "impuestos_internos": 86.956
+        },
+        "factor_ajuste": {}
+      },
+      "sql_error": null
+    },
+    {
+      "caso": "motor · un cargo NO gravado entra al costo pero no a la base de IVA",
+      "motor": "calcular_costos_compra",
+      "origen": "prorrateoCompra.test.ts",
+      "entrada": {
+        "items": [
+          {
+            "id": 1,
+            "cantidad": 10,
+            "costo_unitario": 100,
+            "bonificacion": 0,
+            "impuestos_internos": 0,
+            "porcentaje_iva": 21,
+            "condicion_iva": "gravado"
+          }
+        ],
+        "cargos": [
+          {
+            "id": 1,
+            "concepto": "x",
+            "monto": 500,
+            "condicion_iva": "no_gravado",
+            "en_factura": true,
+            "prorratea_al_costo": true,
+            "afecta_base_ii": false,
+            "pesos": {
+              "1": 1
+            }
+          }
+        ],
+        "ii_declarado": {}
+      },
+      "celdas": 14,
+      "sql": {
+        "lineas": [
+          {
+            "id": 1,
+            "ii": 0,
+            "iva": 21,
+            "cargos": 50,
+            "base_iva": 100,
+            "costo_neto": 100,
+            "costo_real": 150
+          }
+        ],
+        "totales": {
+          "iva": 210,
+          "no_gravado": 500,
+          "neto_exento": 0,
+          "neto_gravado": 1000,
+          "cargos_al_costo": 500,
+          "neto_no_gravado": 0,
+          "impuestos_internos": 0
+        },
+        "factor_ajuste": {}
+      },
+      "sql_error": null
+    },
+    {
+      "caso": "motor · un cargo fuera de factura entra al costo y no al IVA",
+      "motor": "calcular_costos_compra",
+      "origen": "prorrateoCompra.test.ts",
+      "entrada": {
+        "items": [
+          {
+            "id": 1,
+            "cantidad": 10,
+            "costo_unitario": 100,
+            "bonificacion": 0,
+            "impuestos_internos": 0,
+            "porcentaje_iva": 21,
+            "condicion_iva": "gravado"
+          }
+        ],
+        "cargos": [
+          {
+            "id": 1,
+            "concepto": "x",
+            "monto": 500,
+            "condicion_iva": "gravado",
+            "en_factura": false,
+            "prorratea_al_costo": true,
+            "afecta_base_ii": false,
+            "pesos": {
+              "1": 1
+            }
+          }
+        ],
+        "ii_declarado": {}
+      },
+      "celdas": 14,
+      "sql": {
+        "lineas": [
+          {
+            "id": 1,
+            "ii": 0,
+            "iva": 21,
+            "cargos": 0,
+            "base_iva": 100,
+            "costo_neto": 100,
+            "costo_real": 150
+          }
+        ],
+        "totales": {
+          "iva": 210,
+          "no_gravado": 0,
+          "neto_exento": 0,
+          "neto_gravado": 1000,
+          "cargos_al_costo": 0,
+          "neto_no_gravado": 0,
+          "impuestos_internos": 0
+        },
+        "factor_ajuste": {}
+      },
+      "sql_error": null
+    },
+    {
+      "caso": "motor · afectaBaseII=false: baja el IVA pero no el impuesto interno",
+      "motor": "calcular_costos_compra",
+      "origen": "prorrateoCompra.test.ts",
+      "entrada": {
+        "items": [
+          {
+            "id": 1,
+            "cantidad": 10,
+            "costo_unitario": 100,
+            "bonificacion": 0,
+            "impuestos_internos": 10,
+            "porcentaje_iva": 21,
+            "condicion_iva": "gravado"
+          }
+        ],
+        "cargos": [
+          {
+            "id": 1,
+            "concepto": "x",
+            "monto": -200,
+            "condicion_iva": "gravado",
+            "en_factura": true,
+            "prorratea_al_costo": true,
+            "afecta_base_ii": false,
+            "pesos": {
+              "1": 1
+            }
+          }
+        ],
+        "ii_declarado": {}
+      },
+      "celdas": 14,
+      "sql": {
+        "lineas": [
+          {
+            "id": 1,
+            "ii": 10,
+            "iva": 16.8,
+            "cargos": 0,
+            "base_iva": 80,
+            "costo_neto": 100,
+            "costo_real": 90
+          }
+        ],
+        "totales": {
+          "iva": 168,
+          "no_gravado": 0,
+          "neto_exento": 0,
+          "neto_gravado": 800,
+          "cargos_al_costo": 0,
+          "neto_no_gravado": 0,
+          "impuestos_internos": 100
+        },
+        "factor_ajuste": {}
+      },
+      "sql_error": null
+    },
+    {
+      "caso": "motor · afectaBaseII=true: baja las dos bases",
+      "motor": "calcular_costos_compra",
+      "origen": "prorrateoCompra.test.ts",
+      "entrada": {
+        "items": [
+          {
+            "id": 1,
+            "cantidad": 10,
+            "costo_unitario": 100,
+            "bonificacion": 0,
+            "impuestos_internos": 10,
+            "porcentaje_iva": 21,
+            "condicion_iva": "gravado"
+          }
+        ],
+        "cargos": [
+          {
+            "id": 1,
+            "concepto": "x",
+            "monto": -200,
+            "condicion_iva": "gravado",
+            "en_factura": true,
+            "prorratea_al_costo": true,
+            "afecta_base_ii": true,
+            "pesos": {
+              "1": 1
+            }
+          }
+        ],
+        "ii_declarado": {}
+      },
+      "celdas": 14,
+      "sql": {
+        "lineas": [
+          {
+            "id": 1,
+            "ii": 8,
+            "iva": 16.8,
+            "cargos": 0,
+            "base_iva": 80,
+            "costo_neto": 100,
+            "costo_real": 88
+          }
+        ],
+        "totales": {
+          "iva": 168,
+          "no_gravado": 0,
+          "neto_exento": 0,
+          "neto_gravado": 800,
+          "cargos_al_costo": 0,
+          "neto_no_gravado": 0,
+          "impuestos_internos": 80
+        },
+        "factor_ajuste": {}
+      },
+      "sql_error": null
+    },
+    {
+      "caso": "motor · el factor de ajuste cuadra el II declarado",
+      "motor": "calcular_costos_compra",
+      "origen": "prorrateoCompra.test.ts",
+      "entrada": {
+        "items": [
+          {
+            "id": 1,
+            "cantidad": 10,
+            "costo_unitario": 100,
+            "bonificacion": 0,
+            "impuestos_internos": 10,
+            "porcentaje_iva": 21,
+            "condicion_iva": "gravado"
+          }
+        ],
+        "cargos": [],
+        "ii_declarado": {
+          "10": 110
+        }
+      },
+      "celdas": 15,
+      "sql": {
+        "lineas": [
+          {
+            "id": 1,
+            "ii": 11,
+            "iva": 21,
+            "cargos": 0,
+            "base_iva": 100,
+            "costo_neto": 100,
+            "costo_real": 111
+          }
+        ],
+        "totales": {
+          "iva": 210,
+          "no_gravado": 0,
+          "neto_exento": 0,
+          "neto_gravado": 1000,
+          "cargos_al_costo": 0,
+          "neto_no_gravado": 0,
+          "impuestos_internos": 110
+        },
+        "factor_ajuste": {
+          "10": 1.1
+        }
+      },
+      "sql_error": null
+    },
+    {
+      "caso": "motor · cantidad 0 no explota",
+      "motor": "calcular_costos_compra",
+      "origen": "prorrateoCompra.test.ts",
+      "entrada": {
+        "items": [
+          {
+            "id": 1,
+            "cantidad": 0,
+            "costo_unitario": 100,
+            "bonificacion": 0,
+            "impuestos_internos": 0,
+            "porcentaje_iva": 21,
+            "condicion_iva": "gravado"
+          }
+        ],
+        "cargos": [],
+        "ii_declarado": {}
+      },
+      "celdas": 14,
+      "sql": {
+        "lineas": [
+          {
+            "id": 1,
+            "ii": 0,
+            "iva": 0,
+            "cargos": 0,
+            "base_iva": 0,
+            "costo_neto": 0,
+            "costo_real": 0
+          }
+        ],
+        "totales": {
+          "iva": 0,
+          "no_gravado": 0,
+          "neto_exento": 0,
+          "neto_gravado": 0,
+          "cargos_al_costo": 0,
+          "neto_no_gravado": 0,
+          "impuestos_internos": 0
+        },
+        "factor_ajuste": {}
+      },
+      "sql_error": null
+    },
+    {
+      "caso": "motor · la linea exenta no suma a netoGravado pero tiene costo",
+      "motor": "calcular_costos_compra",
+      "origen": "prorrateoCompra.test.ts",
+      "entrada": {
+        "items": [
+          {
+            "id": 1,
+            "cantidad": 10,
+            "costo_unitario": 100,
+            "bonificacion": 0,
+            "impuestos_internos": 0,
+            "porcentaje_iva": 21,
+            "condicion_iva": "gravado"
+          },
+          {
+            "id": 2,
+            "cantidad": 10,
+            "costo_unitario": 100,
+            "bonificacion": 0,
+            "impuestos_internos": 0,
+            "porcentaje_iva": 0,
+            "condicion_iva": "exento"
+          }
+        ],
+        "cargos": [],
+        "ii_declarado": {}
+      },
+      "celdas": 21,
+      "sql": {
+        "lineas": [
+          {
+            "id": 1,
+            "ii": 0,
+            "iva": 21,
+            "cargos": 0,
+            "base_iva": 100,
+            "costo_neto": 100,
+            "costo_real": 100
+          },
+          {
+            "id": 2,
+            "ii": 0,
+            "iva": 0,
+            "cargos": 0,
+            "base_iva": 0,
+            "costo_neto": 100,
+            "costo_real": 100
+          }
+        ],
+        "totales": {
+          "iva": 210,
+          "no_gravado": 0,
+          "neto_exento": 1000,
+          "neto_gravado": 1000,
+          "cargos_al_costo": 0,
+          "neto_no_gravado": 0,
+          "impuestos_internos": 0
+        },
+        "factor_ajuste": {}
+      },
+      "sql_error": null
+    },
+    {
+      "caso": "motor · la linea no gravada abre su propio total",
+      "motor": "calcular_costos_compra",
+      "origen": "prorrateoCompra.test.ts",
+      "entrada": {
+        "items": [
+          {
+            "id": 1,
+            "cantidad": 10,
+            "costo_unitario": 100,
+            "bonificacion": 0,
+            "impuestos_internos": 0,
+            "porcentaje_iva": 21,
+            "condicion_iva": "gravado"
+          },
+          {
+            "id": 2,
+            "cantidad": 10,
+            "costo_unitario": 100,
+            "bonificacion": 0,
+            "impuestos_internos": 0,
+            "porcentaje_iva": 0,
+            "condicion_iva": "no_gravado"
+          }
+        ],
+        "cargos": [],
+        "ii_declarado": {}
+      },
+      "celdas": 21,
+      "sql": {
+        "lineas": [
+          {
+            "id": 1,
+            "ii": 0,
+            "iva": 21,
+            "cargos": 0,
+            "base_iva": 100,
+            "costo_neto": 100,
+            "costo_real": 100
+          },
+          {
+            "id": 2,
+            "ii": 0,
+            "iva": 0,
+            "cargos": 0,
+            "base_iva": 0,
+            "costo_neto": 100,
+            "costo_real": 100
+          }
+        ],
+        "totales": {
+          "iva": 210,
+          "no_gravado": 0,
+          "neto_exento": 0,
+          "neto_gravado": 1000,
+          "cargos_al_costo": 0,
+          "neto_no_gravado": 1000,
+          "impuestos_internos": 0
+        },
+        "factor_ajuste": {}
+      },
+      "sql_error": null
+    },
+    {
+      "caso": "motor · un cargo en factura que no prorratea: no gravado y no costo",
+      "motor": "calcular_costos_compra",
+      "origen": "prorrateoCompra.test.ts",
+      "entrada": {
+        "items": [
+          {
+            "id": 1,
+            "cantidad": 10,
+            "costo_unitario": 100,
+            "bonificacion": 0,
+            "impuestos_internos": 0,
+            "porcentaje_iva": 21,
+            "condicion_iva": "gravado"
+          }
+        ],
+        "cargos": [
+          {
+            "id": 1,
+            "concepto": "x",
+            "monto": 500,
+            "condicion_iva": "no_gravado",
+            "en_factura": true,
+            "prorratea_al_costo": false,
+            "afecta_base_ii": false,
+            "pesos": {
+              "1": 1
+            }
+          }
+        ],
+        "ii_declarado": {}
+      },
+      "celdas": 14,
+      "sql": {
+        "lineas": [
+          {
+            "id": 1,
+            "ii": 0,
+            "iva": 21,
+            "cargos": 0,
+            "base_iva": 100,
+            "costo_neto": 100,
+            "costo_real": 100
+          }
+        ],
+        "totales": {
+          "iva": 210,
+          "no_gravado": 500,
+          "neto_exento": 0,
+          "neto_gravado": 1000,
+          "cargos_al_costo": 0,
+          "neto_no_gravado": 0,
+          "impuestos_internos": 0
+        },
+        "factor_ajuste": {}
+      },
+      "sql_error": null
+    },
+    {
+      "caso": "motor · 4.17 y 4.1667 son alicuotas distintas",
+      "motor": "calcular_costos_compra",
+      "origen": "prorrateoCompra.test.ts",
+      "entrada": {
+        "items": [
+          {
+            "id": 1,
+            "cantidad": 10,
+            "costo_unitario": 100,
+            "bonificacion": 0,
+            "impuestos_internos": 4.1667,
+            "porcentaje_iva": 21,
+            "condicion_iva": "gravado"
+          },
+          {
+            "id": 2,
+            "cantidad": 10,
+            "costo_unitario": 100,
+            "bonificacion": 0,
+            "impuestos_internos": 4.17,
+            "porcentaje_iva": 21,
+            "condicion_iva": "gravado"
+          }
+        ],
+        "cargos": [],
+        "ii_declarado": {
+          "4.1667": 50
+        }
+      },
+      "celdas": 22,
+      "sql": {
+        "lineas": [
+          {
+            "id": 1,
+            "ii": 5,
+            "iva": 21,
+            "cargos": 0,
+            "base_iva": 100,
+            "costo_neto": 100,
+            "costo_real": 105
+          },
+          {
+            "id": 2,
+            "ii": 4.17,
+            "iva": 21,
+            "cargos": 0,
+            "base_iva": 100,
+            "costo_neto": 100,
+            "costo_real": 104.17
+          }
+        ],
+        "totales": {
+          "iva": 420,
+          "no_gravado": 0,
+          "neto_exento": 0,
+          "neto_gravado": 2000,
+          "cargos_al_costo": 0,
+          "neto_no_gravado": 0,
+          "impuestos_internos": 91.7
+        },
+        "factor_ajuste": {
+          "4.1667": 1.19999
+        }
+      },
+      "sql_error": null
+    },
+    {
+      "caso": "testigo · factura A0005-00461415 completa",
+      "motor": "calcular_costos_compra",
+      "origen": "prorrateoCompra.golden.test.ts",
+      "entrada": {
+        "items": [
+          {
+            "id": 1,
+            "cantidad": 60,
+            "costo_unitario": 4793.61,
+            "bonificacion": 0.6,
+            "impuestos_internos": 4.1667,
+            "porcentaje_iva": 21,
+            "condicion_iva": "gravado"
+          },
+          {
+            "id": 2,
+            "cantidad": 60,
+            "costo_unitario": 4793.61,
+            "bonificacion": 0.6,
+            "impuestos_internos": 4.1667,
+            "porcentaje_iva": 21,
+            "condicion_iva": "gravado"
+          },
+          {
+            "id": 3,
+            "cantidad": 120,
+            "costo_unitario": 5782.77,
+            "bonificacion": 0.6,
+            "impuestos_internos": 8.6956,
+            "porcentaje_iva": 21,
+            "condicion_iva": "gravado"
+          },
+          {
+            "id": 4,
+            "cantidad": 75,
+            "costo_unitario": 3994.67,
+            "bonificacion": 0.6,
+            "impuestos_internos": 4.1667,
+            "porcentaje_iva": 21,
+            "condicion_iva": "gravado"
+          },
+          {
+            "id": 5,
+            "cantidad": 75,
+            "costo_unitario": 3994.67,
+            "bonificacion": 0.6,
+            "impuestos_internos": 4.1667,
+            "porcentaje_iva": 21,
+            "condicion_iva": "gravado"
+          },
+          {
+            "id": 6,
+            "cantidad": 120,
+            "costo_unitario": 2972.04,
+            "bonificacion": 0.6,
+            "impuestos_internos": 4.1667,
+            "porcentaje_iva": 21,
+            "condicion_iva": "gravado"
+          },
+          {
+            "id": 7,
+            "cantidad": 80,
+            "costo_unitario": 2316.91,
+            "bonificacion": 0.6,
+            "impuestos_internos": 4.1667,
+            "porcentaje_iva": 21,
+            "condicion_iva": "gravado"
+          },
+          {
+            "id": 8,
+            "cantidad": 280,
+            "costo_unitario": 2197.07,
+            "bonificacion": 0.6,
+            "impuestos_internos": 4.1667,
+            "porcentaje_iva": 21,
+            "condicion_iva": "gravado"
+          },
+          {
+            "id": 9,
+            "cantidad": 120,
+            "costo_unitario": 4626.22,
+            "bonificacion": 0.6,
+            "impuestos_internos": 8.6956,
+            "porcentaje_iva": 21,
+            "condicion_iva": "gravado"
+          },
+          {
+            "id": 10,
+            "cantidad": 150,
+            "costo_unitario": 5123.97,
+            "bonificacion": 0.6,
+            "impuestos_internos": 0,
+            "porcentaje_iva": 21,
+            "condicion_iva": "gravado"
+          },
+          {
+            "id": 11,
+            "cantidad": 240,
+            "costo_unitario": 5782.77,
+            "bonificacion": 0.6,
+            "impuestos_internos": 8.6956,
+            "porcentaje_iva": 21,
+            "condicion_iva": "gravado"
+          },
+          {
+            "id": 12,
+            "cantidad": 60,
+            "costo_unitario": 5782.77,
+            "bonificacion": 0.6,
+            "impuestos_internos": 8.6956,
+            "porcentaje_iva": 21,
+            "condicion_iva": "gravado"
+          },
+          {
+            "id": 13,
+            "cantidad": 60,
+            "costo_unitario": 5992.01,
+            "bonificacion": 0.6,
+            "impuestos_internos": 4.1667,
+            "porcentaje_iva": 21,
+            "condicion_iva": "gravado"
+          },
+          {
+            "id": 14,
+            "cantidad": 120,
+            "costo_unitario": 5782.77,
+            "bonificacion": 0.6,
+            "impuestos_internos": 8.6956,
+            "porcentaje_iva": 21,
+            "condicion_iva": "gravado"
+          },
+          {
+            "id": 15,
+            "cantidad": 60,
+            "costo_unitario": 5782.77,
+            "bonificacion": 0.6,
+            "impuestos_internos": 8.6956,
+            "porcentaje_iva": 21,
+            "condicion_iva": "gravado"
+          },
+          {
+            "id": 16,
+            "cantidad": 115,
+            "costo_unitario": 8347.11,
+            "bonificacion": 0.6,
+            "impuestos_internos": 0,
+            "porcentaje_iva": 21,
+            "condicion_iva": "gravado"
+          },
+          {
+            "id": 17,
+            "cantidad": 140,
+            "costo_unitario": 3822.9,
+            "bonificacion": 0.6,
+            "impuestos_internos": 4.1667,
+            "porcentaje_iva": 21,
+            "condicion_iva": "gravado"
+          },
+          {
+            "id": 18,
+            "cantidad": 140,
+            "costo_unitario": 3822.9,
+            "bonificacion": 0.6,
+            "impuestos_internos": 4.1667,
+            "porcentaje_iva": 21,
+            "condicion_iva": "gravado"
+          },
+          {
+            "id": 19,
+            "cantidad": 140,
+            "costo_unitario": 3822.9,
+            "bonificacion": 0.6,
+            "impuestos_internos": 4.1667,
+            "porcentaje_iva": 21,
+            "condicion_iva": "gravado"
+          },
+          {
+            "id": 20,
+            "cantidad": 120,
+            "costo_unitario": 2796.27,
+            "bonificacion": 0.6,
+            "impuestos_internos": 4.1667,
+            "porcentaje_iva": 21,
+            "condicion_iva": "gravado"
+          },
+          {
+            "id": 21,
+            "cantidad": 168,
+            "costo_unitario": 1030.63,
+            "bonificacion": 0.6,
+            "impuestos_internos": 4.1667,
+            "porcentaje_iva": 21,
+            "condicion_iva": "gravado"
+          }
+        ],
+        "cargos": [
+          {
+            "id": 1,
+            "concepto": "Flete y descarga",
+            "monto": 1900000,
+            "condicion_iva": "no_gravado",
+            "en_factura": false,
+            "prorratea_al_costo": true,
+            "afecta_base_ii": false,
+            "pesos": {
+              "1": 0.5,
+              "2": 0.5,
+              "3": 2,
+              "4": 0.5,
+              "5": 0.5,
+              "6": 1,
+              "7": 1,
+              "8": 2,
+              "9": 1,
+              "10": 2,
+              "11": 4,
+              "12": 1,
+              "13": 1,
+              "14": 2,
+              "15": 1,
+              "16": 1,
+              "17": 1,
+              "18": 1,
+              "19": 1,
+              "20": 1,
+              "21": 1
+            }
+          },
+          {
+            "id": 2,
+            "concepto": "Pallets x 9 tacos",
+            "monto": 162000,
+            "condicion_iva": "no_gravado",
+            "en_factura": true,
+            "prorratea_al_costo": true,
+            "afecta_base_ii": false,
+            "pesos": {
+              "1": 0.5,
+              "2": 0.5,
+              "3": 2,
+              "4": 1,
+              "5": 1,
+              "6": 1,
+              "7": 1,
+              "8": 2,
+              "9": 1,
+              "10": 2,
+              "11": 4,
+              "12": 1,
+              "13": 1,
+              "14": 2,
+              "15": 1,
+              "16": 1,
+              "17": 1,
+              "18": 1,
+              "19": 1,
+              "20": 1,
+              "21": 1
+            }
+          },
+          {
+            "id": 3,
+            "concepto": "Separadores bidon",
+            "monto": 8800,
+            "condicion_iva": "no_gravado",
+            "en_factura": true,
+            "prorratea_al_costo": true,
+            "afecta_base_ii": false,
+            "pesos": {
+              "21": 1
+            }
+          },
+          {
+            "id": 4,
+            "concepto": "Bonif. promo COLA 3.00",
+            "monto": -103465.32,
+            "condicion_iva": "gravado",
+            "en_factura": true,
+            "prorratea_al_costo": true,
+            "afecta_base_ii": true,
+            "pesos": {
+              "3": 689768.8056,
+              "11": 1379537.6112
+            }
+          },
+          {
+            "id": 5,
+            "concepto": "Bonif. promo 3000cc",
+            "monto": -203318.28,
+            "condicion_iva": "gravado",
+            "en_factura": true,
+            "prorratea_al_costo": true,
+            "afecta_base_ii": false,
+            "pesos": {
+              "3": 689768.8056,
+              "11": 1379537.6112,
+              "12": 344884.4028,
+              "13": 357363.47640000004,
+              "14": 689768.8056,
+              "15": 344884.4028
+            }
+          },
+          {
+            "id": 6,
+            "concepto": "Redondeo",
+            "monto": -0.49,
+            "condicion_iva": "gravado",
+            "en_factura": true,
+            "prorratea_al_costo": true,
+            "afecta_base_ii": true,
+            "pesos": {
+              "1": 285890.9004,
+              "2": 285890.9004,
+              "3": 689768.8056,
+              "4": 297802.6485,
+              "5": 297802.6485,
+              "6": 354504.9312,
+              "7": 184240.6832,
+              "8": 611488.5224000001,
+              "9": 551815.5216,
+              "10": 763983.927,
+              "11": 1379537.6112,
+              "12": 344884.4028,
+              "13": 357363.47640000004,
+              "14": 689768.8056,
+              "15": 344884.4028,
+              "16": 954158.1441,
+              "17": 531994.764,
+              "18": 531994.764,
+              "19": 531994.764,
+              "20": 333539.08560000005,
+              "21": 172106.96496
+            }
+          }
+        ],
+        "ii_declarado": {
+          "8.6956": 338884.46,
+          "4.1667": 199027.21
+        }
+      },
+      "celdas": 156,
+      "sql": {
+        "lineas": [
+          {
+            "id": 1,
+            "ii": 198.536928,
+            "iva": 1000.618116,
+            "cargos": 658.974333,
+            "base_iva": 4764.848173,
+            "costo_neto": 4764.84834,
+            "costo_real": 5622.359435
+          },
+          {
+            "id": 2,
+            "ii": 198.536928,
+            "iva": 1000.618116,
+            "cargos": 658.974333,
+            "base_iva": 4764.848173,
+            "costo_neto": 4764.84834,
+            "costo_real": 5622.359435
+          },
+          {
+            "id": 3,
+            "ii": 474.838052,
+            "iva": 1082.260507,
+            "cargos": 1317.94875,
+            "base_iva": 5153.621463,
+            "costo_neto": 5748.07338,
+            "costo_real": 6946.408266
+          },
+          {
+            "id": 4,
+            "ii": 165.447233,
+            "iva": 833.847388,
+            "cargos": 567.179467,
+            "base_iva": 3970.701847,
+            "costo_neto": 3970.70198,
+            "costo_real": 4703.328547
+          },
+          {
+            "id": 5,
+            "ii": 165.447233,
+            "iva": 833.847388,
+            "cargos": 567.179467,
+            "base_iva": 3970.701847,
+            "costo_neto": 3970.70198,
+            "costo_real": 4703.328547
+          },
+          {
+            "id": 6,
+            "ii": 123.092967,
+            "iva": 620.383595,
+            "cargos": 658.974333,
+            "base_iva": 2954.207593,
+            "costo_neto": 2954.20776,
+            "costo_real": 3736.274894
+          },
+          {
+            "id": 7,
+            "ii": 95.959451,
+            "iva": 483.631767,
+            "cargos": 988.4615,
+            "base_iva": 2303.008415,
+            "costo_neto": 2303.00854,
+            "costo_real": 3387.429366
+          },
+          {
+            "id": 8,
+            "ii": 90.996039,
+            "iva": 458.616369,
+            "cargos": 564.835179,
+            "base_iva": 2183.887473,
+            "costo_neto": 2183.88758,
+            "costo_real": 2839.71869
+          },
+          {
+            "id": 9,
+            "ii": 399.863965,
+            "iva": 965.67711,
+            "cargos": 658.974333,
+            "base_iva": 4598.46243,
+            "costo_neto": 4598.46268,
+            "costo_real": 5657.300728
+          },
+          {
+            "id": 10,
+            "ii": 0,
+            "iva": 1069.577442,
+            "cargos": 1054.359,
+            "base_iva": 5093.225913,
+            "costo_neto": 5093.22618,
+            "costo_real": 6147.584913
+          },
+          {
+            "id": 11,
+            "ii": 474.838049,
+            "iva": 1082.260499,
+            "cargos": 1317.948833,
+            "base_iva": 5153.621422,
+            "costo_neto": 5748.07338,
+            "costo_real": 6946.408304
+          },
+          {
+            "id": 12,
+            "ii": 499.829522,
+            "iva": 1142.61526,
+            "cargos": 1317.948667,
+            "base_iva": 5441.025047,
+            "costo_neto": 5748.07338,
+            "costo_real": 7258.803236
+          },
+          {
+            "id": 13,
+            "ii": 248.171051,
+            "iva": 1183.958917,
+            "cargos": 1317.948667,
+            "base_iva": 5637.899607,
+            "costo_neto": 5956.05794,
+            "costo_real": 7204.019325
+          },
+          {
+            "id": 14,
+            "ii": 499.82953,
+            "iva": 1142.615277,
+            "cargos": 1317.94875,
+            "base_iva": 5441.02513,
+            "costo_neto": 5748.07338,
+            "costo_real": 7258.80341
+          },
+          {
+            "id": 15,
+            "ii": 499.829522,
+            "iva": 1142.61526,
+            "cargos": 1317.948667,
+            "base_iva": 5441.025047,
+            "costo_neto": 5748.07338,
+            "costo_real": 7258.803236
+          },
+          {
+            "id": 16,
+            "ii": 0,
+            "iva": 1742.375668,
+            "cargos": 687.625391,
+            "base_iva": 8297.026992,
+            "costo_neto": 8297.02734,
+            "costo_real": 8984.652383
+          },
+          {
+            "id": 17,
+            "ii": 158.333035,
+            "iva": 797.992116,
+            "cargos": 564.835143,
+            "base_iva": 3799.962457,
+            "costo_neto": 3799.9626,
+            "costo_real": 4523.130635
+          },
+          {
+            "id": 18,
+            "ii": 158.333035,
+            "iva": 797.992116,
+            "cargos": 564.835143,
+            "base_iva": 3799.962457,
+            "costo_neto": 3799.9626,
+            "costo_real": 4523.130635
+          },
+          {
+            "id": 19,
+            "ii": 158.333035,
+            "iva": 797.992116,
+            "cargos": 564.835143,
+            "base_iva": 3799.962457,
+            "costo_neto": 3799.9626,
+            "costo_real": 4523.130635
+          },
+          {
+            "id": 20,
+            "ii": 115.813102,
+            "iva": 583.693365,
+            "cargos": 658.974333,
+            "base_iva": 2779.492213,
+            "costo_neto": 2779.49238,
+            "costo_real": 3554.279648
+          },
+          {
+            "id": 21,
+            "ii": 42.685598,
+            "iva": 215.133694,
+            "cargos": 523.076905,
+            "base_iva": 1024.44616,
+            "costo_neto": 1024.44622,
+            "costo_real": 1590.208663
+          }
+        ],
+        "totales": {
+          "iva": 2139612.842695,
+          "no_gravado": 170800,
+          "neto_exento": 0,
+          "neto_gravado": 10188632.58426,
+          "cargos_al_costo": 2070800,
+          "neto_no_gravado": 0,
+          "impuestos_internos": 537911.67
+        },
+        "factor_ajuste": {
+          "4.1667": 1,
+          "8.6956": 1
+        }
+      },
+      "sql_error": null
+    },
+    {
+      "caso": "testigo · la misma factura sin el cargo de separadores",
+      "motor": "calcular_costos_compra",
+      "origen": "prorrateoCompra.golden.test.ts",
+      "entrada": {
+        "items": [
+          {
+            "id": 1,
+            "cantidad": 60,
+            "costo_unitario": 4793.61,
+            "bonificacion": 0.6,
+            "impuestos_internos": 4.1667,
+            "porcentaje_iva": 21,
+            "condicion_iva": "gravado"
+          },
+          {
+            "id": 2,
+            "cantidad": 60,
+            "costo_unitario": 4793.61,
+            "bonificacion": 0.6,
+            "impuestos_internos": 4.1667,
+            "porcentaje_iva": 21,
+            "condicion_iva": "gravado"
+          },
+          {
+            "id": 3,
+            "cantidad": 120,
+            "costo_unitario": 5782.77,
+            "bonificacion": 0.6,
+            "impuestos_internos": 8.6956,
+            "porcentaje_iva": 21,
+            "condicion_iva": "gravado"
+          },
+          {
+            "id": 4,
+            "cantidad": 75,
+            "costo_unitario": 3994.67,
+            "bonificacion": 0.6,
+            "impuestos_internos": 4.1667,
+            "porcentaje_iva": 21,
+            "condicion_iva": "gravado"
+          },
+          {
+            "id": 5,
+            "cantidad": 75,
+            "costo_unitario": 3994.67,
+            "bonificacion": 0.6,
+            "impuestos_internos": 4.1667,
+            "porcentaje_iva": 21,
+            "condicion_iva": "gravado"
+          },
+          {
+            "id": 6,
+            "cantidad": 120,
+            "costo_unitario": 2972.04,
+            "bonificacion": 0.6,
+            "impuestos_internos": 4.1667,
+            "porcentaje_iva": 21,
+            "condicion_iva": "gravado"
+          },
+          {
+            "id": 7,
+            "cantidad": 80,
+            "costo_unitario": 2316.91,
+            "bonificacion": 0.6,
+            "impuestos_internos": 4.1667,
+            "porcentaje_iva": 21,
+            "condicion_iva": "gravado"
+          },
+          {
+            "id": 8,
+            "cantidad": 280,
+            "costo_unitario": 2197.07,
+            "bonificacion": 0.6,
+            "impuestos_internos": 4.1667,
+            "porcentaje_iva": 21,
+            "condicion_iva": "gravado"
+          },
+          {
+            "id": 9,
+            "cantidad": 120,
+            "costo_unitario": 4626.22,
+            "bonificacion": 0.6,
+            "impuestos_internos": 8.6956,
+            "porcentaje_iva": 21,
+            "condicion_iva": "gravado"
+          },
+          {
+            "id": 10,
+            "cantidad": 150,
+            "costo_unitario": 5123.97,
+            "bonificacion": 0.6,
+            "impuestos_internos": 0,
+            "porcentaje_iva": 21,
+            "condicion_iva": "gravado"
+          },
+          {
+            "id": 11,
+            "cantidad": 240,
+            "costo_unitario": 5782.77,
+            "bonificacion": 0.6,
+            "impuestos_internos": 8.6956,
+            "porcentaje_iva": 21,
+            "condicion_iva": "gravado"
+          },
+          {
+            "id": 12,
+            "cantidad": 60,
+            "costo_unitario": 5782.77,
+            "bonificacion": 0.6,
+            "impuestos_internos": 8.6956,
+            "porcentaje_iva": 21,
+            "condicion_iva": "gravado"
+          },
+          {
+            "id": 13,
+            "cantidad": 60,
+            "costo_unitario": 5992.01,
+            "bonificacion": 0.6,
+            "impuestos_internos": 4.1667,
+            "porcentaje_iva": 21,
+            "condicion_iva": "gravado"
+          },
+          {
+            "id": 14,
+            "cantidad": 120,
+            "costo_unitario": 5782.77,
+            "bonificacion": 0.6,
+            "impuestos_internos": 8.6956,
+            "porcentaje_iva": 21,
+            "condicion_iva": "gravado"
+          },
+          {
+            "id": 15,
+            "cantidad": 60,
+            "costo_unitario": 5782.77,
+            "bonificacion": 0.6,
+            "impuestos_internos": 8.6956,
+            "porcentaje_iva": 21,
+            "condicion_iva": "gravado"
+          },
+          {
+            "id": 16,
+            "cantidad": 115,
+            "costo_unitario": 8347.11,
+            "bonificacion": 0.6,
+            "impuestos_internos": 0,
+            "porcentaje_iva": 21,
+            "condicion_iva": "gravado"
+          },
+          {
+            "id": 17,
+            "cantidad": 140,
+            "costo_unitario": 3822.9,
+            "bonificacion": 0.6,
+            "impuestos_internos": 4.1667,
+            "porcentaje_iva": 21,
+            "condicion_iva": "gravado"
+          },
+          {
+            "id": 18,
+            "cantidad": 140,
+            "costo_unitario": 3822.9,
+            "bonificacion": 0.6,
+            "impuestos_internos": 4.1667,
+            "porcentaje_iva": 21,
+            "condicion_iva": "gravado"
+          },
+          {
+            "id": 19,
+            "cantidad": 140,
+            "costo_unitario": 3822.9,
+            "bonificacion": 0.6,
+            "impuestos_internos": 4.1667,
+            "porcentaje_iva": 21,
+            "condicion_iva": "gravado"
+          },
+          {
+            "id": 20,
+            "cantidad": 120,
+            "costo_unitario": 2796.27,
+            "bonificacion": 0.6,
+            "impuestos_internos": 4.1667,
+            "porcentaje_iva": 21,
+            "condicion_iva": "gravado"
+          },
+          {
+            "id": 21,
+            "cantidad": 168,
+            "costo_unitario": 1030.63,
+            "bonificacion": 0.6,
+            "impuestos_internos": 4.1667,
+            "porcentaje_iva": 21,
+            "condicion_iva": "gravado"
+          }
+        ],
+        "cargos": [
+          {
+            "id": 1,
+            "concepto": "Flete y descarga",
+            "monto": 1900000,
+            "condicion_iva": "no_gravado",
+            "en_factura": false,
+            "prorratea_al_costo": true,
+            "afecta_base_ii": false,
+            "pesos": {
+              "1": 0.5,
+              "2": 0.5,
+              "3": 2,
+              "4": 0.5,
+              "5": 0.5,
+              "6": 1,
+              "7": 1,
+              "8": 2,
+              "9": 1,
+              "10": 2,
+              "11": 4,
+              "12": 1,
+              "13": 1,
+              "14": 2,
+              "15": 1,
+              "16": 1,
+              "17": 1,
+              "18": 1,
+              "19": 1,
+              "20": 1,
+              "21": 1
+            }
+          },
+          {
+            "id": 2,
+            "concepto": "Pallets x 9 tacos",
+            "monto": 162000,
+            "condicion_iva": "no_gravado",
+            "en_factura": true,
+            "prorratea_al_costo": true,
+            "afecta_base_ii": false,
+            "pesos": {
+              "1": 0.5,
+              "2": 0.5,
+              "3": 2,
+              "4": 1,
+              "5": 1,
+              "6": 1,
+              "7": 1,
+              "8": 2,
+              "9": 1,
+              "10": 2,
+              "11": 4,
+              "12": 1,
+              "13": 1,
+              "14": 2,
+              "15": 1,
+              "16": 1,
+              "17": 1,
+              "18": 1,
+              "19": 1,
+              "20": 1,
+              "21": 1
+            }
+          },
+          {
+            "id": 4,
+            "concepto": "Bonif. promo COLA 3.00",
+            "monto": -103465.32,
+            "condicion_iva": "gravado",
+            "en_factura": true,
+            "prorratea_al_costo": true,
+            "afecta_base_ii": true,
+            "pesos": {
+              "3": 689768.8056,
+              "11": 1379537.6112
+            }
+          },
+          {
+            "id": 5,
+            "concepto": "Bonif. promo 3000cc",
+            "monto": -203318.28,
+            "condicion_iva": "gravado",
+            "en_factura": true,
+            "prorratea_al_costo": true,
+            "afecta_base_ii": false,
+            "pesos": {
+              "3": 689768.8056,
+              "11": 1379537.6112,
+              "12": 344884.4028,
+              "13": 357363.47640000004,
+              "14": 689768.8056,
+              "15": 344884.4028
+            }
+          },
+          {
+            "id": 6,
+            "concepto": "Redondeo",
+            "monto": -0.49,
+            "condicion_iva": "gravado",
+            "en_factura": true,
+            "prorratea_al_costo": true,
+            "afecta_base_ii": true,
+            "pesos": {
+              "1": 285890.9004,
+              "2": 285890.9004,
+              "3": 689768.8056,
+              "4": 297802.6485,
+              "5": 297802.6485,
+              "6": 354504.9312,
+              "7": 184240.6832,
+              "8": 611488.5224000001,
+              "9": 551815.5216,
+              "10": 763983.927,
+              "11": 1379537.6112,
+              "12": 344884.4028,
+              "13": 357363.47640000004,
+              "14": 689768.8056,
+              "15": 344884.4028,
+              "16": 954158.1441,
+              "17": 531994.764,
+              "18": 531994.764,
+              "19": 531994.764,
+              "20": 333539.08560000005,
+              "21": 172106.96496
+            }
+          }
+        ],
+        "ii_declarado": {
+          "8.6956": 338884.46,
+          "4.1667": 199027.21
+        }
+      },
+      "celdas": 156,
+      "sql": {
+        "lineas": [
+          {
+            "id": 1,
+            "ii": 198.536928,
+            "iva": 1000.618116,
+            "cargos": 658.974333,
+            "base_iva": 4764.848173,
+            "costo_neto": 4764.84834,
+            "costo_real": 5622.359435
+          },
+          {
+            "id": 2,
+            "ii": 198.536928,
+            "iva": 1000.618116,
+            "cargos": 658.974333,
+            "base_iva": 4764.848173,
+            "costo_neto": 4764.84834,
+            "costo_real": 5622.359435
+          },
+          {
+            "id": 3,
+            "ii": 474.838052,
+            "iva": 1082.260507,
+            "cargos": 1317.94875,
+            "base_iva": 5153.621463,
+            "costo_neto": 5748.07338,
+            "costo_real": 6946.408266
+          },
+          {
+            "id": 4,
+            "ii": 165.447233,
+            "iva": 833.847388,
+            "cargos": 567.179467,
+            "base_iva": 3970.701847,
+            "costo_neto": 3970.70198,
+            "costo_real": 4703.328547
+          },
+          {
+            "id": 5,
+            "ii": 165.447233,
+            "iva": 833.847388,
+            "cargos": 567.179467,
+            "base_iva": 3970.701847,
+            "costo_neto": 3970.70198,
+            "costo_real": 4703.328547
+          },
+          {
+            "id": 6,
+            "ii": 123.092967,
+            "iva": 620.383595,
+            "cargos": 658.974333,
+            "base_iva": 2954.207593,
+            "costo_neto": 2954.20776,
+            "costo_real": 3736.274894
+          },
+          {
+            "id": 7,
+            "ii": 95.959451,
+            "iva": 483.631767,
+            "cargos": 988.4615,
+            "base_iva": 2303.008415,
+            "costo_neto": 2303.00854,
+            "costo_real": 3387.429366
+          },
+          {
+            "id": 8,
+            "ii": 90.996039,
+            "iva": 458.616369,
+            "cargos": 564.835179,
+            "base_iva": 2183.887473,
+            "costo_neto": 2183.88758,
+            "costo_real": 2839.71869
+          },
+          {
+            "id": 9,
+            "ii": 399.863965,
+            "iva": 965.67711,
+            "cargos": 658.974333,
+            "base_iva": 4598.46243,
+            "costo_neto": 4598.46268,
+            "costo_real": 5657.300728
+          },
+          {
+            "id": 10,
+            "ii": 0,
+            "iva": 1069.577442,
+            "cargos": 1054.359,
+            "base_iva": 5093.225913,
+            "costo_neto": 5093.22618,
+            "costo_real": 6147.584913
+          },
+          {
+            "id": 11,
+            "ii": 474.838049,
+            "iva": 1082.260499,
+            "cargos": 1317.948833,
+            "base_iva": 5153.621422,
+            "costo_neto": 5748.07338,
+            "costo_real": 6946.408304
+          },
+          {
+            "id": 12,
+            "ii": 499.829522,
+            "iva": 1142.61526,
+            "cargos": 1317.948667,
+            "base_iva": 5441.025047,
+            "costo_neto": 5748.07338,
+            "costo_real": 7258.803236
+          },
+          {
+            "id": 13,
+            "ii": 248.171051,
+            "iva": 1183.958917,
+            "cargos": 1317.948667,
+            "base_iva": 5637.899607,
+            "costo_neto": 5956.05794,
+            "costo_real": 7204.019325
+          },
+          {
+            "id": 14,
+            "ii": 499.82953,
+            "iva": 1142.615277,
+            "cargos": 1317.94875,
+            "base_iva": 5441.02513,
+            "costo_neto": 5748.07338,
+            "costo_real": 7258.80341
+          },
+          {
+            "id": 15,
+            "ii": 499.829522,
+            "iva": 1142.61526,
+            "cargos": 1317.948667,
+            "base_iva": 5441.025047,
+            "costo_neto": 5748.07338,
+            "costo_real": 7258.803236
+          },
+          {
+            "id": 16,
+            "ii": 0,
+            "iva": 1742.375668,
+            "cargos": 687.625391,
+            "base_iva": 8297.026992,
+            "costo_neto": 8297.02734,
+            "costo_real": 8984.652383
+          },
+          {
+            "id": 17,
+            "ii": 158.333035,
+            "iva": 797.992116,
+            "cargos": 564.835143,
+            "base_iva": 3799.962457,
+            "costo_neto": 3799.9626,
+            "costo_real": 4523.130635
+          },
+          {
+            "id": 18,
+            "ii": 158.333035,
+            "iva": 797.992116,
+            "cargos": 564.835143,
+            "base_iva": 3799.962457,
+            "costo_neto": 3799.9626,
+            "costo_real": 4523.130635
+          },
+          {
+            "id": 19,
+            "ii": 158.333035,
+            "iva": 797.992116,
+            "cargos": 564.835143,
+            "base_iva": 3799.962457,
+            "costo_neto": 3799.9626,
+            "costo_real": 4523.130635
+          },
+          {
+            "id": 20,
+            "ii": 115.813102,
+            "iva": 583.693365,
+            "cargos": 658.974333,
+            "base_iva": 2779.492213,
+            "costo_neto": 2779.49238,
+            "costo_real": 3554.279648
+          },
+          {
+            "id": 21,
+            "ii": 42.685598,
+            "iva": 215.133694,
+            "cargos": 470.695952,
+            "base_iva": 1024.44616,
+            "costo_neto": 1024.44622,
+            "costo_real": 1537.827711
+          }
+        ],
+        "totales": {
+          "iva": 2139612.842695,
+          "no_gravado": 162000,
+          "neto_exento": 0,
+          "neto_gravado": 10188632.58426,
+          "cargos_al_costo": 2062000,
+          "neto_no_gravado": 0,
+          "impuestos_internos": 537911.67
+        },
+        "factor_ajuste": {
+          "4.1667": 1,
+          "8.6956": 1
+        }
+      },
+      "sql_error": null
+    },
+    {
+      "caso": "testigo · sin el II declarado (factor 1, sin ajuste)",
+      "motor": "calcular_costos_compra",
+      "origen": "prorrateoCompra.golden.test.ts",
+      "entrada": {
+        "items": [
+          {
+            "id": 1,
+            "cantidad": 60,
+            "costo_unitario": 4793.61,
+            "bonificacion": 0.6,
+            "impuestos_internos": 4.1667,
+            "porcentaje_iva": 21,
+            "condicion_iva": "gravado"
+          },
+          {
+            "id": 2,
+            "cantidad": 60,
+            "costo_unitario": 4793.61,
+            "bonificacion": 0.6,
+            "impuestos_internos": 4.1667,
+            "porcentaje_iva": 21,
+            "condicion_iva": "gravado"
+          },
+          {
+            "id": 3,
+            "cantidad": 120,
+            "costo_unitario": 5782.77,
+            "bonificacion": 0.6,
+            "impuestos_internos": 8.6956,
+            "porcentaje_iva": 21,
+            "condicion_iva": "gravado"
+          },
+          {
+            "id": 4,
+            "cantidad": 75,
+            "costo_unitario": 3994.67,
+            "bonificacion": 0.6,
+            "impuestos_internos": 4.1667,
+            "porcentaje_iva": 21,
+            "condicion_iva": "gravado"
+          },
+          {
+            "id": 5,
+            "cantidad": 75,
+            "costo_unitario": 3994.67,
+            "bonificacion": 0.6,
+            "impuestos_internos": 4.1667,
+            "porcentaje_iva": 21,
+            "condicion_iva": "gravado"
+          },
+          {
+            "id": 6,
+            "cantidad": 120,
+            "costo_unitario": 2972.04,
+            "bonificacion": 0.6,
+            "impuestos_internos": 4.1667,
+            "porcentaje_iva": 21,
+            "condicion_iva": "gravado"
+          },
+          {
+            "id": 7,
+            "cantidad": 80,
+            "costo_unitario": 2316.91,
+            "bonificacion": 0.6,
+            "impuestos_internos": 4.1667,
+            "porcentaje_iva": 21,
+            "condicion_iva": "gravado"
+          },
+          {
+            "id": 8,
+            "cantidad": 280,
+            "costo_unitario": 2197.07,
+            "bonificacion": 0.6,
+            "impuestos_internos": 4.1667,
+            "porcentaje_iva": 21,
+            "condicion_iva": "gravado"
+          },
+          {
+            "id": 9,
+            "cantidad": 120,
+            "costo_unitario": 4626.22,
+            "bonificacion": 0.6,
+            "impuestos_internos": 8.6956,
+            "porcentaje_iva": 21,
+            "condicion_iva": "gravado"
+          },
+          {
+            "id": 10,
+            "cantidad": 150,
+            "costo_unitario": 5123.97,
+            "bonificacion": 0.6,
+            "impuestos_internos": 0,
+            "porcentaje_iva": 21,
+            "condicion_iva": "gravado"
+          },
+          {
+            "id": 11,
+            "cantidad": 240,
+            "costo_unitario": 5782.77,
+            "bonificacion": 0.6,
+            "impuestos_internos": 8.6956,
+            "porcentaje_iva": 21,
+            "condicion_iva": "gravado"
+          },
+          {
+            "id": 12,
+            "cantidad": 60,
+            "costo_unitario": 5782.77,
+            "bonificacion": 0.6,
+            "impuestos_internos": 8.6956,
+            "porcentaje_iva": 21,
+            "condicion_iva": "gravado"
+          },
+          {
+            "id": 13,
+            "cantidad": 60,
+            "costo_unitario": 5992.01,
+            "bonificacion": 0.6,
+            "impuestos_internos": 4.1667,
+            "porcentaje_iva": 21,
+            "condicion_iva": "gravado"
+          },
+          {
+            "id": 14,
+            "cantidad": 120,
+            "costo_unitario": 5782.77,
+            "bonificacion": 0.6,
+            "impuestos_internos": 8.6956,
+            "porcentaje_iva": 21,
+            "condicion_iva": "gravado"
+          },
+          {
+            "id": 15,
+            "cantidad": 60,
+            "costo_unitario": 5782.77,
+            "bonificacion": 0.6,
+            "impuestos_internos": 8.6956,
+            "porcentaje_iva": 21,
+            "condicion_iva": "gravado"
+          },
+          {
+            "id": 16,
+            "cantidad": 115,
+            "costo_unitario": 8347.11,
+            "bonificacion": 0.6,
+            "impuestos_internos": 0,
+            "porcentaje_iva": 21,
+            "condicion_iva": "gravado"
+          },
+          {
+            "id": 17,
+            "cantidad": 140,
+            "costo_unitario": 3822.9,
+            "bonificacion": 0.6,
+            "impuestos_internos": 4.1667,
+            "porcentaje_iva": 21,
+            "condicion_iva": "gravado"
+          },
+          {
+            "id": 18,
+            "cantidad": 140,
+            "costo_unitario": 3822.9,
+            "bonificacion": 0.6,
+            "impuestos_internos": 4.1667,
+            "porcentaje_iva": 21,
+            "condicion_iva": "gravado"
+          },
+          {
+            "id": 19,
+            "cantidad": 140,
+            "costo_unitario": 3822.9,
+            "bonificacion": 0.6,
+            "impuestos_internos": 4.1667,
+            "porcentaje_iva": 21,
+            "condicion_iva": "gravado"
+          },
+          {
+            "id": 20,
+            "cantidad": 120,
+            "costo_unitario": 2796.27,
+            "bonificacion": 0.6,
+            "impuestos_internos": 4.1667,
+            "porcentaje_iva": 21,
+            "condicion_iva": "gravado"
+          },
+          {
+            "id": 21,
+            "cantidad": 168,
+            "costo_unitario": 1030.63,
+            "bonificacion": 0.6,
+            "impuestos_internos": 4.1667,
+            "porcentaje_iva": 21,
+            "condicion_iva": "gravado"
+          }
+        ],
+        "cargos": [
+          {
+            "id": 1,
+            "concepto": "Flete y descarga",
+            "monto": 1900000,
+            "condicion_iva": "no_gravado",
+            "en_factura": false,
+            "prorratea_al_costo": true,
+            "afecta_base_ii": false,
+            "pesos": {
+              "1": 0.5,
+              "2": 0.5,
+              "3": 2,
+              "4": 0.5,
+              "5": 0.5,
+              "6": 1,
+              "7": 1,
+              "8": 2,
+              "9": 1,
+              "10": 2,
+              "11": 4,
+              "12": 1,
+              "13": 1,
+              "14": 2,
+              "15": 1,
+              "16": 1,
+              "17": 1,
+              "18": 1,
+              "19": 1,
+              "20": 1,
+              "21": 1
+            }
+          },
+          {
+            "id": 2,
+            "concepto": "Pallets x 9 tacos",
+            "monto": 162000,
+            "condicion_iva": "no_gravado",
+            "en_factura": true,
+            "prorratea_al_costo": true,
+            "afecta_base_ii": false,
+            "pesos": {
+              "1": 0.5,
+              "2": 0.5,
+              "3": 2,
+              "4": 1,
+              "5": 1,
+              "6": 1,
+              "7": 1,
+              "8": 2,
+              "9": 1,
+              "10": 2,
+              "11": 4,
+              "12": 1,
+              "13": 1,
+              "14": 2,
+              "15": 1,
+              "16": 1,
+              "17": 1,
+              "18": 1,
+              "19": 1,
+              "20": 1,
+              "21": 1
+            }
+          },
+          {
+            "id": 3,
+            "concepto": "Separadores bidon",
+            "monto": 8800,
+            "condicion_iva": "no_gravado",
+            "en_factura": true,
+            "prorratea_al_costo": true,
+            "afecta_base_ii": false,
+            "pesos": {
+              "21": 1
+            }
+          },
+          {
+            "id": 4,
+            "concepto": "Bonif. promo COLA 3.00",
+            "monto": -103465.32,
+            "condicion_iva": "gravado",
+            "en_factura": true,
+            "prorratea_al_costo": true,
+            "afecta_base_ii": true,
+            "pesos": {
+              "3": 689768.8056,
+              "11": 1379537.6112
+            }
+          },
+          {
+            "id": 5,
+            "concepto": "Bonif. promo 3000cc",
+            "monto": -203318.28,
+            "condicion_iva": "gravado",
+            "en_factura": true,
+            "prorratea_al_costo": true,
+            "afecta_base_ii": false,
+            "pesos": {
+              "3": 689768.8056,
+              "11": 1379537.6112,
+              "12": 344884.4028,
+              "13": 357363.47640000004,
+              "14": 689768.8056,
+              "15": 344884.4028
+            }
+          },
+          {
+            "id": 6,
+            "concepto": "Redondeo",
+            "monto": -0.49,
+            "condicion_iva": "gravado",
+            "en_factura": true,
+            "prorratea_al_costo": true,
+            "afecta_base_ii": true,
+            "pesos": {
+              "1": 285890.9004,
+              "2": 285890.9004,
+              "3": 689768.8056,
+              "4": 297802.6485,
+              "5": 297802.6485,
+              "6": 354504.9312,
+              "7": 184240.6832,
+              "8": 611488.5224000001,
+              "9": 551815.5216,
+              "10": 763983.927,
+              "11": 1379537.6112,
+              "12": 344884.4028,
+              "13": 357363.47640000004,
+              "14": 689768.8056,
+              "15": 344884.4028,
+              "16": 954158.1441,
+              "17": 531994.764,
+              "18": 531994.764,
+              "19": 531994.764,
+              "20": 333539.08560000005,
+              "21": 172106.96496
+            }
+          }
+        ],
+        "ii_declarado": {}
+      },
+      "celdas": 154,
+      "sql": {
+        "lineas": [
+          {
+            "id": 1,
+            "ii": 198.536929,
+            "iva": 1000.618116,
+            "cargos": 658.974333,
+            "base_iva": 4764.848173,
+            "costo_neto": 4764.84834,
+            "costo_real": 5622.359436
+          },
+          {
+            "id": 2,
+            "ii": 198.536929,
+            "iva": 1000.618116,
+            "cargos": 658.974333,
+            "base_iva": 4764.848173,
+            "costo_neto": 4764.84834,
+            "costo_real": 5622.359436
+          },
+          {
+            "id": 3,
+            "ii": 474.837974,
+            "iva": 1082.260507,
+            "cargos": 1317.94875,
+            "base_iva": 5153.621463,
+            "costo_neto": 5748.07338,
+            "costo_real": 6946.408187
+          },
+          {
+            "id": 4,
+            "ii": 165.447234,
+            "iva": 833.847388,
+            "cargos": 567.179467,
+            "base_iva": 3970.701847,
+            "costo_neto": 3970.70198,
+            "costo_real": 4703.328547
+          },
+          {
+            "id": 5,
+            "ii": 165.447234,
+            "iva": 833.847388,
+            "cargos": 567.179467,
+            "base_iva": 3970.701847,
+            "costo_neto": 3970.70198,
+            "costo_real": 4703.328547
+          },
+          {
+            "id": 6,
+            "ii": 123.092968,
+            "iva": 620.383595,
+            "cargos": 658.974333,
+            "base_iva": 2954.207593,
+            "costo_neto": 2954.20776,
+            "costo_real": 3736.274894
+          },
+          {
+            "id": 7,
+            "ii": 95.959452,
+            "iva": 483.631767,
+            "cargos": 988.4615,
+            "base_iva": 2303.008415,
+            "costo_neto": 2303.00854,
+            "costo_real": 3387.429367
+          },
+          {
+            "id": 8,
+            "ii": 90.996039,
+            "iva": 458.616369,
+            "cargos": 564.835179,
+            "base_iva": 2183.887473,
+            "costo_neto": 2183.88758,
+            "costo_real": 2839.718691
+          },
+          {
+            "id": 9,
+            "ii": 399.863899,
+            "iva": 965.67711,
+            "cargos": 658.974333,
+            "base_iva": 4598.46243,
+            "costo_neto": 4598.46268,
+            "costo_real": 5657.300662
+          },
+          {
+            "id": 10,
+            "ii": 0,
+            "iva": 1069.577442,
+            "cargos": 1054.359,
+            "base_iva": 5093.225913,
+            "costo_neto": 5093.22618,
+            "costo_real": 6147.584913
+          },
+          {
+            "id": 11,
+            "ii": 474.83797,
+            "iva": 1082.260499,
+            "cargos": 1317.948833,
+            "base_iva": 5153.621422,
+            "costo_neto": 5748.07338,
+            "costo_real": 6946.408225
+          },
+          {
+            "id": 12,
+            "ii": 499.82944,
+            "iva": 1142.61526,
+            "cargos": 1317.948667,
+            "base_iva": 5441.025047,
+            "costo_neto": 5748.07338,
+            "costo_real": 7258.803153
+          },
+          {
+            "id": 13,
+            "ii": 248.171052,
+            "iva": 1183.958917,
+            "cargos": 1317.948667,
+            "base_iva": 5637.899607,
+            "costo_neto": 5956.05794,
+            "costo_real": 7204.019326
+          },
+          {
+            "id": 14,
+            "ii": 499.829447,
+            "iva": 1142.615277,
+            "cargos": 1317.94875,
+            "base_iva": 5441.02513,
+            "costo_neto": 5748.07338,
+            "costo_real": 7258.803327
+          },
+          {
+            "id": 15,
+            "ii": 499.82944,
+            "iva": 1142.61526,
+            "cargos": 1317.948667,
+            "base_iva": 5441.025047,
+            "costo_neto": 5748.07338,
+            "costo_real": 7258.803153
+          },
+          {
+            "id": 16,
+            "ii": 0,
+            "iva": 1742.375668,
+            "cargos": 687.625391,
+            "base_iva": 8297.026992,
+            "costo_neto": 8297.02734,
+            "costo_real": 8984.652383
+          },
+          {
+            "id": 17,
+            "ii": 158.333036,
+            "iva": 797.992116,
+            "cargos": 564.835143,
+            "base_iva": 3799.962457,
+            "costo_neto": 3799.9626,
+            "costo_real": 4523.130636
+          },
+          {
+            "id": 18,
+            "ii": 158.333036,
+            "iva": 797.992116,
+            "cargos": 564.835143,
+            "base_iva": 3799.962457,
+            "costo_neto": 3799.9626,
+            "costo_real": 4523.130636
+          },
+          {
+            "id": 19,
+            "ii": 158.333036,
+            "iva": 797.992116,
+            "cargos": 564.835143,
+            "base_iva": 3799.962457,
+            "costo_neto": 3799.9626,
+            "costo_real": 4523.130636
+          },
+          {
+            "id": 20,
+            "ii": 115.813102,
+            "iva": 583.693365,
+            "cargos": 658.974333,
+            "base_iva": 2779.492213,
+            "costo_neto": 2779.49238,
+            "costo_real": 3554.279649
+          },
+          {
+            "id": 21,
+            "ii": 42.685598,
+            "iva": 215.133694,
+            "cargos": 523.076905,
+            "base_iva": 1024.44616,
+            "costo_neto": 1024.44622,
+            "costo_real": 1590.208663
+          }
+        ],
+        "totales": {
+          "iva": 2139612.842695,
+          "no_gravado": 170800,
+          "neto_exento": 0,
+          "neto_gravado": 10188632.58426,
+          "cargos_al_costo": 2070800,
+          "neto_no_gravado": 0,
+          "impuestos_internos": 537911.614725
+        },
+        "factor_ajuste": {}
+      },
+      "sql_error": null
+    },
+    {
+      "caso": "contrato · peso negativo",
+      "motor": "prorratear_cargo",
+      "origen": "prorrateoCompra.test.ts",
+      "entrada": {
+        "monto": 100,
+        "pesos": {
+          "1": 1,
+          "2": -1
+        }
+      },
+      "celdas": 0,
+      "sql": null,
+      "sql_error": "prorratear_cargo: peso negativo en la linea 2 (-1). Los pesos son proporciones; el 0 excluye una linea."
+    },
+    {
+      "caso": "contrato · peso no finito (null en el cable)",
+      "motor": "prorratear_cargo",
+      "origen": "prorrateoCompra.test.ts",
+      "entrada": {
+        "monto": 100,
+        "pesos": {
+          "1": null,
+          "2": 1
+        }
+      },
+      "celdas": 0,
+      "sql": null,
+      "sql_error": "prorratear_cargo: peso no finito en la linea 1 (null). Se esperan numeros finitos; el 0 excluye una linea."
+    },
+    {
+      "caso": "contrato · peso no finito (la cadena \"NaN\")",
+      "motor": "prorratear_cargo",
+      "origen": "prorrateoCompra.test.ts",
+      "entrada": {
+        "monto": 100,
+        "pesos": {
+          "1": 1,
+          "2": "NaN"
+        }
+      },
+      "celdas": 0,
+      "sql": null,
+      "sql_error": "prorratear_cargo: peso no finito en la linea 2 (\"NaN\"). Se esperan numeros finitos; el 0 excluye una linea."
+    },
+    {
+      "caso": "contrato · monto no finito (null en el cable)",
+      "motor": "prorratear_cargo",
+      "origen": "prorrateoCompra.test.ts",
+      "entrada": {
+        "monto": null,
+        "pesos": {
+          "1": 1
+        }
+      },
+      "celdas": 0,
+      "sql": null,
+      "sql_error": "prorratear_cargo: monto no finito (NULL)."
+    },
+    {
+      "caso": "contrato · monto no finito (la cadena \"Infinity\")",
+      "motor": "prorratear_cargo",
+      "origen": "prorrateoCompra.test.ts",
+      "entrada": {
+        "monto": "Infinity",
+        "pesos": {
+          "1": 1
+        }
+      },
+      "celdas": 0,
+      "sql": null,
+      "sql_error": "prorratear_cargo: monto no finito (Infinity)."
+    },
+    {
+      "caso": "contrato · cantidad negativa",
+      "motor": "calcular_costos_compra",
+      "origen": "prorrateoCompra.test.ts",
+      "entrada": {
+        "items": [
+          {
+            "id": 7,
+            "cantidad": -1,
+            "costo_unitario": 100,
+            "bonificacion": 0,
+            "impuestos_internos": 0,
+            "porcentaje_iva": 21,
+            "condicion_iva": "gravado"
+          }
+        ],
+        "cargos": [],
+        "ii_declarado": {}
+      },
+      "celdas": 0,
+      "sql": null,
+      "sql_error": "calcular_costos_compra: cantidad invalida en la linea 7 (-1). Se espera un numero finito no negativo."
+    },
+    {
+      "caso": "contrato · cantidad no finita (null en el cable)",
+      "motor": "calcular_costos_compra",
+      "origen": "prorrateoCompra.test.ts",
+      "entrada": {
+        "items": [
+          {
+            "id": 4,
+            "cantidad": null,
+            "costo_unitario": 100,
+            "bonificacion": 0,
+            "impuestos_internos": 0,
+            "porcentaje_iva": 21,
+            "condicion_iva": "gravado"
+          }
+        ],
+        "cargos": [],
+        "ii_declarado": {}
+      },
+      "celdas": 0,
+      "sql": null,
+      "sql_error": "calcular_costos_compra: cantidad invalida en la linea 4 (null). Se espera un numero finito no negativo."
+    },
+    {
+      "caso": "contrato · condicion_iva invalida en la linea",
+      "motor": "calcular_costos_compra",
+      "origen": "mig 193",
+      "entrada": {
+        "items": [
+          {
+            "id": 1,
+            "cantidad": 10,
+            "costo_unitario": 100,
+            "bonificacion": 0,
+            "impuestos_internos": 0,
+            "porcentaje_iva": 21,
+            "condicion_iva": "gravada"
+          }
+        ],
+        "cargos": [],
+        "ii_declarado": {}
+      },
+      "celdas": 0,
+      "sql": null,
+      "sql_error": "calcular_costos_compra: condicion_iva invalida en la linea 1 (\"gravada\"). Se espera gravado, exento o no_gravado."
+    },
+    {
+      "caso": "contrato · condicion_iva invalida en el cargo",
+      "motor": "calcular_costos_compra",
+      "origen": "mig 193",
+      "entrada": {
+        "items": [
+          {
+            "id": 1,
+            "cantidad": 10,
+            "costo_unitario": 100,
+            "bonificacion": 0,
+            "impuestos_internos": 0,
+            "porcentaje_iva": 21,
+            "condicion_iva": "gravado"
+          }
+        ],
+        "cargos": [
+          {
+            "id": 1,
+            "concepto": "x",
+            "monto": 100,
+            "condicion_iva": "grabado",
+            "en_factura": true,
+            "prorratea_al_costo": true,
+            "afecta_base_ii": false,
+            "pesos": {
+              "1": 1
+            }
+          }
+        ],
+        "ii_declarado": {}
+      },
+      "celdas": 0,
+      "sql": null,
+      "sql_error": "calcular_costos_compra: condicion_iva invalida en el cargo 1 (x) (\"grabado\"). Se espera gravado, exento o no_gravado."
+    },
+    {
+      "caso": "contrato · dos lineas con el mismo id",
+      "motor": "calcular_costos_compra",
+      "origen": "mig 193",
+      "entrada": {
+        "items": [
+          {
+            "id": 1,
+            "cantidad": 10,
+            "costo_unitario": 100,
+            "bonificacion": 0,
+            "impuestos_internos": 0,
+            "porcentaje_iva": 21,
+            "condicion_iva": "gravado"
+          },
+          {
+            "id": 1,
+            "cantidad": 10,
+            "costo_unitario": 100,
+            "bonificacion": 0,
+            "impuestos_internos": 0,
+            "porcentaje_iva": 21,
+            "condicion_iva": "gravado"
+          }
+        ],
+        "cargos": [],
+        "ii_declarado": {}
+      },
+      "celdas": 0,
+      "sql": null,
+      "sql_error": "calcular_costos_compra: la linea 1 aparece mas de una vez."
+    },
+    {
+      "caso": "contrato · dos tasas declaradas que colapsan al mismo bucket",
+      "motor": "calcular_costos_compra",
+      "origen": "mig 193",
+      "entrada": {
+        "items": [
+          {
+            "id": 1,
+            "cantidad": 10,
+            "costo_unitario": 100,
+            "bonificacion": 0,
+            "impuestos_internos": 10,
+            "porcentaje_iva": 21,
+            "condicion_iva": "gravado"
+          }
+        ],
+        "cargos": [],
+        "ii_declarado": {
+          "10": 100,
+          "10.0": 100
+        }
+      },
+      "celdas": 0,
+      "sql": null,
+      "sql_error": "calcular_costos_compra: las tasas declaradas \"10\" y \"10.0\" caen en el mismo bucket de 4 decimales y se pisarian."
+    }
+  ]
+}

--- a/src/utils/prorrateoCompra.espejo.test.ts
+++ b/src/utils/prorrateoCompra.espejo.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect } from 'vitest'
+import fixture from './prorrateoCompra.espejo.fixture.json'
+import {
+  CASOS_ESPEJO,
+  CARGOS_TESTIGO,
+  ITEMS_TESTIGO,
+  cargoAWire,
+  cargoDeWire,
+  correrMotorTS,
+  diferencias,
+  esCasoDeContrato,
+  lineaAWire,
+  lineaDeWire,
+  type CasoEspejo,
+} from './prorrateoCompra.espejo'
+
+/**
+ * CAPA 1 DEL ESPEJO: el motor de TypeScript contra una FOTO del de SQL.
+ *
+ * LO QUE ESTE ARCHIVO NO PUEDE DETECTAR, y por eso lo dice el nombre del
+ * describe y no sólo este comentario: que se haya movido el SQL. El fixture es
+ * una foto congelada de la salida de `calcular_costos_compra` / `prorratear_cargo`
+ * (mig 193); si alguien edita esas funciones en la base, la foto sigue diciendo
+ * lo de antes y este test sigue verde mientras la producción calcula otra cosa.
+ *
+ * El que ve los dos lados es `scripts/espejo-motor-compras.mjs`, que corre las
+ * DOS implementaciones sobre los mismos casos, deja que la comparación la haga
+ * Postgres y vive en el gate de integridad —donde hay credenciales—. Ese es
+ * también el único que puede regenerar este fixture, y sólo lo hace cuando la
+ * comparación con la base salió en verde.
+ *
+ * Lo que SÍ detecta, al instante y sin red: que alguien tocó el motor de
+ * TypeScript. Que es el caso frecuente, porque es el archivo que se edita
+ * mientras se programa.
+ */
+
+interface CasoFixture {
+  caso: string
+  motor: string
+  origen: string
+  entrada: Record<string, unknown>
+  celdas: number
+  sql: Record<string, unknown> | null
+  sql_error: string | null
+}
+
+const casosFixture = fixture.casos as unknown as CasoFixture[]
+const decimales: number = fixture.decimales
+
+/** El caso tal como lo va a correr el motor: la entrada sale DEL FIXTURE. */
+const desdeFixture = (f: CasoFixture): CasoEspejo => ({
+  caso: f.caso,
+  motor: f.motor as CasoEspejo['motor'],
+  entrada: f.entrada,
+  origen: f.origen,
+})
+
+describe('Espejo TS ↔ SQL contra el fixture (no detecta que se haya movido el SQL)', () => {
+  it('el fixture cubre exactamente los casos del espejo, con las mismas entradas', () => {
+    // Si esto falla, alguien agregó o cambió un caso y no regeneró el fixture:
+    // `node scripts/espejo-motor-compras.mjs --fijar`. Que el test siguiera
+    // pasando con el fixture viejo sería peor que fallar — estaría verificando
+    // un conjunto de casos que ya no es el que se declara.
+    expect(casosFixture.map(c => c.caso)).toEqual(CASOS_ESPEJO.map(c => c.caso))
+    for (const [i, caso] of CASOS_ESPEJO.entries()) {
+      expect(casosFixture[i].motor).toBe(caso.motor)
+      // Por el cable: es la forma en la que la entrada llegó a las dos
+      // implementaciones, y la única que el fixture puede haber guardado.
+      expect(casosFixture[i].entrada).toEqual(JSON.parse(JSON.stringify(caso.entrada)))
+    }
+  })
+
+  it('el fixture se generó con los decimales que usa el espejo', () => {
+    expect(decimales).toBe(6)
+  })
+
+  it('la traduccion a la forma de cable y de vuelta es la identidad', () => {
+    // Sin esto, un error en el traductor haría que el espejo compare las dos
+    // implementaciones sobre una entrada MUTILADA —las dos igual de mutilada—
+    // y todo daría verde mientras nadie está mirando la factura que cree mirar.
+    expect(ITEMS_TESTIGO.map(l => lineaDeWire(lineaAWire(l)))).toEqual(ITEMS_TESTIGO)
+    expect(CARGOS_TESTIGO.map(c => cargoDeWire(cargoAWire(c)))).toEqual(CARGOS_TESTIGO)
+  })
+
+  const conValor = casosFixture.filter(f => !f.sql_error)
+  const deContrato = casosFixture.filter(f => f.sql_error)
+
+  describe('el motor de TS da lo que dio el de SQL', () => {
+    it.each(conValor.map(f => [f.caso, f] as const))('%s', (_nombre, f) => {
+      const { ts, ts_error } = correrMotorTS(desdeFixture(f))
+      expect(ts_error).toBeNull()
+
+      const { celdas, divergencias } = diferencias(ts, f.sql, decimales)
+      // El mensaje de una divergencia trae el campo y los dos valores: sin eso
+      // el fallo dice "objetos distintos" sobre 126 celdas y no sirve de nada.
+      expect(
+        divergencias.map(d => `${d.campo}: TS=${JSON.stringify(d.ts)} SQL=${JSON.stringify(d.sql)} (${d.motivo})`)
+      ).toEqual([])
+      // Y que además se hayan comparado TODAS: un motor que dejara de emitir un
+      // campo bajaría este número, y el array vacío de arriba no lo diría.
+      expect(celdas).toBe(f.celdas)
+    })
+  })
+
+  describe('las dos rechazan la misma basura', () => {
+    it.each(deContrato.map(f => [f.caso, f] as const))('%s', (_nombre, f) => {
+      // El fixture guarda que el SQL rechazó esta entrada. Si el TS la acepta,
+      // la vista previa le muestra al usuario un costo que la base no va a
+      // guardar. El TEXTO no se compara: el de SQL nombra la funcion en
+      // snake_case y el de TS en camelCase, y atarlos volveria fragil el gate
+      // sin agregar nada. Lo que se compara es que los dos frenen.
+      const { ts, ts_error } = correrMotorTS(desdeFixture(f))
+      expect(ts).toBeNull()
+      expect(ts_error).toBeTruthy()
+      expect(f.sql_error).toBeTruthy()
+    })
+
+    it('todos los casos marcados de contrato son de contrato, y viceversa', () => {
+      // Que el nombre y el comportamiento no se despeguen: un caso bautizado
+      // "contrato ·" que en realidad devuelve un número dejaría de probar nada
+      // y nadie lo notaría leyendo la lista.
+      expect(deContrato.map(f => f.caso).sort())
+        .toEqual(CASOS_ESPEJO.filter(esCasoDeContrato).map(c => c.caso).sort())
+    })
+  })
+
+  it('la factura testigo compara las 156 celdas enteras, no una muestra', () => {
+    // 21 lineas x 7 claves (el id y los seis unitarios) + 7 totales + los 2
+    // factores de ajuste. El numero esta clavado para que un caso que se vacie
+    // —una entrada que deje de tener lineas, un adaptador que devuelva {}— se
+    // note: el resto de la suite pasaria igual comparando cero contra cero.
+    const testigo = casosFixture.find(f => f.caso === 'testigo · factura A0005-00461415 completa')!
+    expect(testigo.celdas).toBe(21 * 7 + 7 + 2)
+  })
+})


### PR DESCRIPTION
**4 de 4.** Va sobre #487. La protección que faltaba.

## El problema

El motor de costos está escrito **dos veces** — TypeScript para la vista previa del modal, SQL para lo que se persiste — y las dos tienen que dar el mismo número al centavo.

Se verificaron a mano: 126 celdas de la factura testigo, 22 casos de reparto, todos con 0 divergencias. **Pero nada lo sostenía.** Los archivos decían *"si cambiás una, cambiá la otra"* y no había nada que lo verificara. Si alguien tocaba un lado, nadie se enteraba hasta que un costo saliera mal en producción.

## Dos capas, porque una sola no alcanza

**La rápida** (`prorrateoCompra.espejo.test.ts`) corre siempre, sin red: compara el TypeScript contra un fixture congelado. Detecta al instante que se movió el TS. Su nombre dice explícitamente que **no** ve si el que se movió fue el SQL — el límite está en el nombre, no escondido en un comentario.

**La de verdad** (`scripts/espejo-motor-compras.mjs`) corre **las dos** implementaciones sobre los mismos casos y deja que la comparación la haga Postgres con `IS DISTINCT FROM` sobre `numeric`. Vive en el gate diario, que es donde están las credenciales — un test de vitest no tiene con qué conectarse.

El fixture de la capa 1 lo regenera **sólo** la capa 2, y **sólo si la comparación contra la base salió en verde**. Así un diff vacío al regenerarlo significa "el SQL no se movió".

## Los casos

**35 casos, 683 celdas**, ninguno inventado: los repartos unitarios, la factura testigo entera, y los de contrato — porque las dos implementaciones tienen que **fallar en los mismos casos**, no sólo coincidir cuando andan.

## Lo que encontró apenas se pudo correr

**Cuatro divergencias reales** donde el SQL rechazaba la entrada y el TypeScript devolvía un número:

- Dos líneas con el mismo id: el cargo se contaba **dos veces**.
- `condicionIva` con un typo (`"gravada"`): la plata desaparecía de los cuatro totales **sin un solo error**.
- Dos tasas declaradas que colapsan al mismo bucket de 4 decimales.

Van con las guardas calcadas del lado del SQL.

## Que muerde, probado

| sabotaje | capa 2 | capa 1 |
|---|---|---|
| desempate del residuo por mayor id | **8 divergencias**, exit 1 | roja |
| `Math.round` en vez del redondeo de Postgres | **2 divergencias** | roja |
| romper el **SQL** (no el TS) | **56 divergencias** | verde — su límite documentado |

## Nota

El paso nuevo del workflow va **sin** `if [ -z secrets ]; then warning; exit 0; fi`. Ese patrón es por el que este mismo gate corrió 52 veces en verde sin chequear nada; el paso único que ya falla si faltan los secrets cubre a todos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
