### PR TITLE
Ventas por cliente con la zona de la ficha, filtrables por vendedor

### DIFF
--- a/migrations/197_ventas_por_cliente_y_zona.sql
+++ b/migrations/197_ventas_por_cliente_y_zona.sql
@@ -1,0 +1,261 @@
+-- =========================================================================
+-- 197_ventas_por_cliente_y_zona.sql
+--
+-- "Necesito todas las ventas de Cristian desde principio de año por cliente.
+--  No el detalle sino el total por cada cliente. Para ver a quiénes le vendió.
+--  NECESITO QUE AL LADO DE CADA CLIENTE SALGA A QUÉ ZONA PERTENECE SEGÚN LA
+--  CLASIFICACIÓN QUE TIENE EN LA FICHA."
+--
+-- La pestaña "Por Cliente" de Reportes ya existía y no servía para eso. Hacía
+-- `from('pedidos').select('*, cliente:clientes(*)')` desde el navegador, sin
+-- filtro de estado y sin paginar:
+--
+--   * sumaba pedidos CANCELADOS (284 en lo que va de 2026);
+--   * se cortaba en las 1.000 filas del default de PostgREST, y este año hay
+--     4.558 pedidos entregados -> el total que mostraba estaba mal, en silencio
+--     y sin ningún cartel;
+--   * filtraba por `created_at` en vez de `pedidos.fecha`, que es la base que
+--     usan `bot_mis_ventas` y `reporte_gerencial`;
+--   * y arriba de todo eso la tabla hacía `slice(0, 30)`.
+--
+-- Los cuatro se arreglan moviendo la agregación acá. De paso el mismo payload
+-- alimenta la pestaña "Por Zona", que tenía los mismos dos primeros bugs.
+--
+-- TRES DEFINICIONES DE NEGOCIO QUE QUEDAN ESCRITAS ACÁ
+-- ----------------------------------------------------
+--
+-- 1) La venta se le atribuye a `pedidos.usuario_id` -- quién CARGÓ el pedido --
+--    y no a `clientes.preventista_id` -- de quién es el cliente.
+--
+--    Es lo que se pidió ("para ver a quiénes le vendió") y es la convención que
+--    ya usa `bot_mis_ventas`. La diferencia no es cosmética; medida sobre 2026:
+--
+--      por usuario_id            Christian 1.164 ped / $40.198.490
+--      por clientes.preventista  Christian 1.180 ped / $37.210.720
+--                                + 891 ped / $48.925.572 SIN preventista, que
+--                                  por ese criterio no se le cuentan a nadie.
+--
+--    El cruce entre las dos lecturas es justamente lo que el informe muestra:
+--    de los 1.164 pedidos de Christian, 78 ($3,5M) son a clientes de zonas de
+--    MARCELO y 53 ($4,8M) a clientes sin zona cargada.
+--
+-- 2) `COALESCE(canal,'app') <> 'cambio'` en vez del `canal = 'app'` que usa el
+--    bot. Los cambios/devoluciones son pedidos con total 0 (mig 089): sumarlos
+--    no mueve el monto pero infla el conteo de pedidos y ensucia el ticket
+--    promedio. La lista negra es a propósito: una lista blanca dejaría caer en
+--    silencio un canal futuro que sí fuera venta real, que es exactamente la
+--    familia de bug que esta migración viene a cerrar.
+--
+-- 3) La zona sale de `clientes.zona_id -> zonas.nombre`, con el texto libre
+--    `clientes.zona` sólo como fallback. `zona_id` es la columna canónica (es
+--    la que escribe el select de la ficha); `clientes.zona` está marcada
+--    @deprecated en el front y hoy está 100% sincronizada (459 de 459), así que
+--    el COALESCE es red de seguridad, no fuente.
+--
+-- EL LEFT JOIN A CLIENTES NO ES DECORATIVO
+-- -----------------------------------------
+-- Hay 7 pedidos entregados en 2026 con `cliente_id IS NULL` ($200.070; 3 de
+-- ellos, $83.750, son de Christian). Con INNER JOIN desaparecían y el informe
+-- cerraba $83.750 por debajo del total de ventas del preventista, sin avisar.
+-- Van agrupados en una fila `(sin cliente asignado)` para que el total del
+-- informe SIEMPRE reconcilie contra el total de ventas. No hay FKs rotas:
+-- `cliente_id` es NULL de verdad, no apunta a un cliente borrado.
+--
+-- Guard: calcado de `reporte_valuacion_inventario` (mig 131) -- rol
+-- admin/encargado, sucursales de `usuario_sucursales`, p_sucursal_id NULL =
+-- consolidado de las asignadas, auth.uid() NULL = service role.
+-- =========================================================================
+
+CREATE OR REPLACE FUNCTION public.reporte_ventas_por_cliente(
+  p_desde          date,
+  p_hasta          date,
+  p_preventista_id uuid   DEFAULT NULL,
+  p_sucursal_id    bigint DEFAULT NULL
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+STABLE SECURITY DEFINER
+SET search_path TO 'public'
+AS $function$
+DECLARE
+  v_sucursales   bigint[];
+  v_asignadas    bigint[];
+  v_nombre       text;
+  v_prev_nombre  text;
+  v_result       jsonb;
+  v_es_servicio  boolean := (auth.uid() IS NULL);
+  v_rol          text;
+BEGIN
+  IF p_desde IS NULL OR p_hasta IS NULL THEN
+    RAISE EXCEPTION 'Se requieren las fechas desde y hasta';
+  END IF;
+  IF p_desde > p_hasta THEN
+    RAISE EXCEPTION 'La fecha desde (%) es posterior a la fecha hasta (%)', p_desde, p_hasta;
+  END IF;
+
+  -- ---- Guard (idéntico a reporte_valuacion_inventario) -------------------
+  IF NOT v_es_servicio THEN
+    SELECT rol INTO v_rol FROM perfiles WHERE id = auth.uid();
+    IF v_rol IS NULL OR v_rol NOT IN ('admin', 'encargado') THEN
+      RAISE EXCEPTION 'Acceso denegado: se requiere rol admin o encargado';
+    END IF;
+    SELECT array_agg(sucursal_id) INTO v_asignadas
+      FROM usuario_sucursales WHERE usuario_id = auth.uid();
+    IF v_asignadas IS NULL THEN
+      RAISE EXCEPTION 'Acceso denegado: el usuario no tiene sucursales asignadas';
+    END IF;
+  END IF;
+
+  IF p_sucursal_id IS NULL THEN
+    SELECT array_agg(id) INTO v_sucursales FROM sucursales WHERE activa;
+    IF NOT v_es_servicio THEN
+      SELECT array_agg(s) INTO v_sucursales
+        FROM unnest(v_sucursales) AS s WHERE s = ANY(v_asignadas);
+    END IF;
+    v_nombre := 'Red (consolidado)';
+  ELSE
+    IF NOT v_es_servicio AND NOT (p_sucursal_id = ANY(v_asignadas)) THEN
+      RAISE EXCEPTION 'Acceso denegado: la sucursal % no está asignada al usuario', p_sucursal_id;
+    END IF;
+    v_sucursales := ARRAY[p_sucursal_id];
+    SELECT nombre INTO v_nombre FROM sucursales WHERE id = p_sucursal_id;
+  END IF;
+
+  IF v_sucursales IS NULL OR array_length(v_sucursales, 1) IS NULL THEN
+    RAISE EXCEPTION 'Acceso denegado: sin sucursales disponibles para el usuario';
+  END IF;
+
+  IF p_preventista_id IS NOT NULL THEN
+    SELECT nombre INTO v_prev_nombre FROM perfiles WHERE id = p_preventista_id;
+  END IF;
+
+  -- ---- Datos --------------------------------------------------------------
+  WITH base AS (
+    SELECT
+      pe.cliente_id,
+      pe.total,
+      to_char(pe.fecha, 'YYYY-MM') AS mes,
+      CASE
+        WHEN pe.cliente_id IS NULL THEN '(sin cliente asignado)'
+        ELSE COALESCE(
+               NULLIF(btrim(c.nombre_fantasia), ''),
+               NULLIF(btrim(c.razon_social), ''),
+               '(sin nombre)')
+      END AS nombre,
+      c.codigo,
+      COALESCE(z.nombre, NULLIF(btrim(c.zona), ''), 'SIN ZONA') AS zona
+    FROM pedidos pe
+    LEFT JOIN clientes c ON c.id = pe.cliente_id
+    LEFT JOIN zonas    z ON z.id = c.zona_id
+    WHERE pe.estado = 'entregado'
+      AND COALESCE(pe.canal, 'app') <> 'cambio'
+      AND pe.fecha BETWEEN p_desde AND p_hasta
+      AND pe.sucursal_id = ANY(v_sucursales)
+      AND (p_preventista_id IS NULL OR pe.usuario_id = p_preventista_id)
+  ),
+  por_cliente AS (
+    SELECT cliente_id, nombre, codigo, zona,
+           COUNT(*)::int AS pedidos,
+           SUM(total)    AS total
+    FROM base
+    GROUP BY cliente_id, nombre, codigo, zona
+  ),
+  mes_por_cliente AS (
+    SELECT cliente_id, jsonb_object_agg(mes, total) AS por_mes
+    FROM (SELECT cliente_id, mes, SUM(total) AS total FROM base GROUP BY cliente_id, mes) t
+    GROUP BY cliente_id
+  ),
+  -- por_zona se arma sobre por_cliente y no sobre base: así la fila
+  -- "(sin cliente asignado)" cuenta como un cliente y los totales de las dos
+  -- vistas dan exactamente lo mismo.
+  por_zona AS (
+    SELECT zona,
+           COUNT(*)::int      AS clientes,
+           SUM(pedidos)::int  AS pedidos,
+           SUM(total)         AS total
+    FROM por_cliente
+    GROUP BY zona
+  )
+  SELECT jsonb_build_object(
+    'meta', jsonb_build_object(
+      'desde',              p_desde,
+      'hasta',              p_hasta,
+      'preventista_id',     p_preventista_id,
+      'preventista_nombre', COALESCE(v_prev_nombre, 'Todos'),
+      'sucursal_id',        p_sucursal_id,
+      'sucursal_nombre',    v_nombre,
+      'generado_at',        now(),
+      'criterio',           'Pedidos entregados, por fecha de pedido, atribuidos a quien los cargó. Excluye cancelados y cambios/devoluciones.'
+    ),
+    'meses', COALESCE((SELECT jsonb_agg(m ORDER BY m) FROM (SELECT DISTINCT mes AS m FROM base) x), '[]'::jsonb),
+    'totales', jsonb_build_object(
+      'clientes', (SELECT COUNT(*)::int             FROM por_cliente),
+      'pedidos',  (SELECT COALESCE(SUM(pedidos),0)::int FROM por_cliente),
+      'total',    (SELECT COALESCE(SUM(total),0)    FROM por_cliente)
+    ),
+    'clientes', COALESCE((
+      SELECT jsonb_agg(jsonb_build_object(
+               'cliente_id', pc.cliente_id,
+               'codigo',     pc.codigo,
+               'nombre',     pc.nombre,
+               'zona',       pc.zona,
+               'pedidos',    pc.pedidos,
+               'total',      pc.total,
+               'por_mes',    COALESCE(mc.por_mes, '{}'::jsonb)
+             ) ORDER BY pc.total DESC, pc.nombre)
+      FROM por_cliente pc
+      LEFT JOIN mes_por_cliente mc ON mc.cliente_id IS NOT DISTINCT FROM pc.cliente_id
+    ), '[]'::jsonb),
+    'zonas', COALESCE((
+      SELECT jsonb_agg(jsonb_build_object(
+               'zona',            pz.zona,
+               'clientes',        pz.clientes,
+               'pedidos',         pz.pedidos,
+               'total',           pz.total,
+               'ticket_promedio', CASE WHEN pz.pedidos > 0 THEN round(pz.total / pz.pedidos, 2) ELSE 0 END
+             ) ORDER BY pz.total DESC)
+      FROM por_zona pz
+    ), '[]'::jsonb)
+  ) INTO v_result;
+
+  RETURN v_result;
+END;
+$function$;
+
+COMMENT ON FUNCTION public.reporte_ventas_por_cliente(date, date, uuid, bigint) IS
+  'Ventas por cliente (con la zona de la ficha) y por zona, filtrables por preventista. Entregados, por pedidos.fecha, atribuidos a pedidos.usuario_id.';
+
+-- Permisos: el default privilege de PUBLIC no se puede sacar (ver mig 188), así
+-- que cada función nueva tiene que revocarlo o `npm run check:permisos` se pone
+-- rojo. El REVOKE necesita PUBLIC *y* anon: sacar sólo uno deja pasar al otro.
+REVOKE ALL ON FUNCTION public.reporte_ventas_por_cliente(date, date, uuid, bigint) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.reporte_ventas_por_cliente(date, date, uuid, bigint) TO authenticated;
+
+-- ---- Verificación fail-closed, en la misma transacción --------------------
+DO $verif$
+DECLARE
+  v_acl text;
+BEGIN
+  SELECT array_to_string(proacl, ',') INTO v_acl
+  FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace
+  WHERE n.nspname = 'public' AND p.proname = 'reporte_ventas_por_cliente';
+
+  -- proacl NULL = privilegios default = PUBLIC puede ejecutar. Es un fallo,
+  -- no un "no hay nada que revisar".
+  IF v_acl IS NULL THEN
+    RAISE EXCEPTION 'reporte_ventas_por_cliente quedó con ACL default (PUBLIC ejecuta)';
+  END IF;
+  -- PUBLIC aparece como un elemento con grantee vacío: `=X/postgres`, al
+  -- principio de la lista o después de una coma. Buscar `%=X/%` a secas daría
+  -- falso positivo con `postgres=X/postgres`.
+  IF v_acl LIKE '=X/%' OR v_acl LIKE '%,=X/%' THEN
+    RAISE EXCEPTION 'reporte_ventas_por_cliente quedó ejecutable por PUBLIC: %', v_acl;
+  END IF;
+  IF v_acl LIKE '%anon=%' THEN
+    RAISE EXCEPTION 'reporte_ventas_por_cliente quedó ejecutable por anon: %', v_acl;
+  END IF;
+  IF v_acl NOT LIKE '%authenticated=X%' THEN
+    RAISE EXCEPTION 'reporte_ventas_por_cliente no quedó ejecutable por authenticated: %', v_acl;
+  END IF;
+END
+$verif$;

--- a/migrations/198_vendedores_del_periodo.sql
+++ b/migrations/198_vendedores_del_periodo.sql
@@ -1,0 +1,241 @@
+-- =========================================================================
+-- 198_vendedores_del_periodo.sql
+--
+-- Corrige un agujero de la 197 detectado al cablear el front.
+--
+-- El selector de preventista del reporte se iba a llenar con
+-- `usePreventistasQuery`, que filtra `perfiles.rol = 'preventista'`. Pero la
+-- venta se atribuye a `pedidos.usuario_id`, y quien carga pedidos NO es sólo
+-- quien tiene ese rol. Medido sobre 2026:
+--
+--     Juan        preventista   912 ped   $45.796.256
+--     Christian   preventista  1164 ped   $40.198.490
+--     Osvaldo     preventista  1035 ped   $30.427.603
+--     Marcelo     preventista   787 ped   $24.452.008
+--     Jony        ENCARGADO     287 ped   $16.630.570   <- no entraba en la lista
+--     Nacho R     admin          48 ped    $6.102.760   <- tampoco
+--     Virginia H  admin         197 ped    $5.925.140   <- tampoco
+--     Agustín     admin          70 ped    $1.963.550
+--     Pablo       admin          31 ped    $1.664.680
+--     Emilia H    admin          24 ped      $487.520
+--     Julio       admin           2 ped       $54.300
+--
+-- O sea: un desplegable por rol escondía $32,8M de venta real y no había forma
+-- de pedirle al reporte las ventas de Jony. Es exactamente la misma familia de
+-- bug que la 197 vino a cerrar (el dato existe y la pantalla no lo puede
+-- alcanzar), así que la lista sale de los DATOS y no de los roles: quien tenga
+-- una entrega en el período aparece, sea cual sea su rol hoy.
+--
+-- `vendedores` se calcula ignorando `p_preventista_id` a propósito: si se
+-- filtrara junto con el resto, al elegir a alguien el desplegable se quedaría
+-- con esa única opción y no habría manera de volver.
+--
+-- Quedan afuera los pedidos con `usuario_id IS NULL` (2 entregados en 2026):
+-- no son de nadie, no se pueden ofrecer como filtro. Siguen contando dentro de
+-- "Todos", así que el total no cambia.
+-- =========================================================================
+
+CREATE OR REPLACE FUNCTION public.reporte_ventas_por_cliente(
+  p_desde          date,
+  p_hasta          date,
+  p_preventista_id uuid   DEFAULT NULL,
+  p_sucursal_id    bigint DEFAULT NULL
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+STABLE SECURITY DEFINER
+SET search_path TO 'public'
+AS $function$
+DECLARE
+  v_sucursales   bigint[];
+  v_asignadas    bigint[];
+  v_nombre       text;
+  v_prev_nombre  text;
+  v_result       jsonb;
+  v_es_servicio  boolean := (auth.uid() IS NULL);
+  v_rol          text;
+BEGIN
+  IF p_desde IS NULL OR p_hasta IS NULL THEN
+    RAISE EXCEPTION 'Se requieren las fechas desde y hasta';
+  END IF;
+  IF p_desde > p_hasta THEN
+    RAISE EXCEPTION 'La fecha desde (%) es posterior a la fecha hasta (%)', p_desde, p_hasta;
+  END IF;
+
+  -- ---- Guard (idéntico a reporte_valuacion_inventario) -------------------
+  IF NOT v_es_servicio THEN
+    SELECT rol INTO v_rol FROM perfiles WHERE id = auth.uid();
+    IF v_rol IS NULL OR v_rol NOT IN ('admin', 'encargado') THEN
+      RAISE EXCEPTION 'Acceso denegado: se requiere rol admin o encargado';
+    END IF;
+    SELECT array_agg(sucursal_id) INTO v_asignadas
+      FROM usuario_sucursales WHERE usuario_id = auth.uid();
+    IF v_asignadas IS NULL THEN
+      RAISE EXCEPTION 'Acceso denegado: el usuario no tiene sucursales asignadas';
+    END IF;
+  END IF;
+
+  IF p_sucursal_id IS NULL THEN
+    SELECT array_agg(id) INTO v_sucursales FROM sucursales WHERE activa;
+    IF NOT v_es_servicio THEN
+      SELECT array_agg(s) INTO v_sucursales
+        FROM unnest(v_sucursales) AS s WHERE s = ANY(v_asignadas);
+    END IF;
+    v_nombre := 'Red (consolidado)';
+  ELSE
+    IF NOT v_es_servicio AND NOT (p_sucursal_id = ANY(v_asignadas)) THEN
+      RAISE EXCEPTION 'Acceso denegado: la sucursal % no está asignada al usuario', p_sucursal_id;
+    END IF;
+    v_sucursales := ARRAY[p_sucursal_id];
+    SELECT nombre INTO v_nombre FROM sucursales WHERE id = p_sucursal_id;
+  END IF;
+
+  IF v_sucursales IS NULL OR array_length(v_sucursales, 1) IS NULL THEN
+    RAISE EXCEPTION 'Acceso denegado: sin sucursales disponibles para el usuario';
+  END IF;
+
+  IF p_preventista_id IS NOT NULL THEN
+    SELECT nombre INTO v_prev_nombre FROM perfiles WHERE id = p_preventista_id;
+  END IF;
+
+  -- ---- Datos --------------------------------------------------------------
+  WITH ventana AS (
+    -- El período/sucursal SIN el filtro de preventista. De acá sale la lista de
+    -- vendedores del desplegable.
+    SELECT pe.id, pe.cliente_id, pe.total, pe.fecha, pe.usuario_id
+    FROM pedidos pe
+    WHERE pe.estado = 'entregado'
+      AND COALESCE(pe.canal, 'app') <> 'cambio'
+      AND pe.fecha BETWEEN p_desde AND p_hasta
+      AND pe.sucursal_id = ANY(v_sucursales)
+  ),
+  vendedores AS (
+    SELECT v.usuario_id AS id,
+           COALESCE(NULLIF(btrim(per.nombre), ''), '(sin nombre)') AS nombre,
+           COUNT(*)::int AS pedidos,
+           SUM(v.total)  AS total
+    FROM ventana v
+    JOIN perfiles per ON per.id = v.usuario_id
+    GROUP BY v.usuario_id, per.nombre
+  ),
+  base AS (
+    SELECT
+      v.cliente_id,
+      v.total,
+      to_char(v.fecha, 'YYYY-MM') AS mes,
+      CASE
+        WHEN v.cliente_id IS NULL THEN '(sin cliente asignado)'
+        ELSE COALESCE(
+               NULLIF(btrim(c.nombre_fantasia), ''),
+               NULLIF(btrim(c.razon_social), ''),
+               '(sin nombre)')
+      END AS nombre,
+      c.codigo,
+      COALESCE(z.nombre, NULLIF(btrim(c.zona), ''), 'SIN ZONA') AS zona
+    FROM ventana v
+    LEFT JOIN clientes c ON c.id = v.cliente_id
+    LEFT JOIN zonas    z ON z.id = c.zona_id
+    WHERE p_preventista_id IS NULL OR v.usuario_id = p_preventista_id
+  ),
+  por_cliente AS (
+    SELECT cliente_id, nombre, codigo, zona,
+           COUNT(*)::int AS pedidos,
+           SUM(total)    AS total
+    FROM base
+    GROUP BY cliente_id, nombre, codigo, zona
+  ),
+  mes_por_cliente AS (
+    SELECT cliente_id, jsonb_object_agg(mes, total) AS por_mes
+    FROM (SELECT cliente_id, mes, SUM(total) AS total FROM base GROUP BY cliente_id, mes) t
+    GROUP BY cliente_id
+  ),
+  -- por_zona se arma sobre por_cliente y no sobre base: así la fila
+  -- "(sin cliente asignado)" cuenta como un cliente y los totales de las dos
+  -- vistas dan exactamente lo mismo.
+  por_zona AS (
+    SELECT zona,
+           COUNT(*)::int      AS clientes,
+           SUM(pedidos)::int  AS pedidos,
+           SUM(total)         AS total
+    FROM por_cliente
+    GROUP BY zona
+  )
+  SELECT jsonb_build_object(
+    'meta', jsonb_build_object(
+      'desde',              p_desde,
+      'hasta',              p_hasta,
+      'preventista_id',     p_preventista_id,
+      'preventista_nombre', COALESCE(v_prev_nombre, 'Todos'),
+      'sucursal_id',        p_sucursal_id,
+      'sucursal_nombre',    v_nombre,
+      'generado_at',        now(),
+      'criterio',           'Pedidos entregados, por fecha de pedido, atribuidos a quien los cargó. Excluye cancelados y cambios/devoluciones.'
+    ),
+    'meses', COALESCE((SELECT jsonb_agg(m ORDER BY m) FROM (SELECT DISTINCT mes AS m FROM base) x), '[]'::jsonb),
+    'vendedores', COALESCE((
+      SELECT jsonb_agg(jsonb_build_object(
+               'id', vd.id, 'nombre', vd.nombre, 'pedidos', vd.pedidos, 'total', vd.total
+             ) ORDER BY vd.total DESC)
+      FROM vendedores vd
+    ), '[]'::jsonb),
+    'totales', jsonb_build_object(
+      'clientes', (SELECT COUNT(*)::int                 FROM por_cliente),
+      'pedidos',  (SELECT COALESCE(SUM(pedidos),0)::int FROM por_cliente),
+      'total',    (SELECT COALESCE(SUM(total),0)        FROM por_cliente)
+    ),
+    'clientes', COALESCE((
+      SELECT jsonb_agg(jsonb_build_object(
+               'cliente_id', pc.cliente_id,
+               'codigo',     pc.codigo,
+               'nombre',     pc.nombre,
+               'zona',       pc.zona,
+               'pedidos',    pc.pedidos,
+               'total',      pc.total,
+               'por_mes',    COALESCE(mc.por_mes, '{}'::jsonb)
+             ) ORDER BY pc.total DESC, pc.nombre)
+      FROM por_cliente pc
+      LEFT JOIN mes_por_cliente mc ON mc.cliente_id IS NOT DISTINCT FROM pc.cliente_id
+    ), '[]'::jsonb),
+    'zonas', COALESCE((
+      SELECT jsonb_agg(jsonb_build_object(
+               'zona',            pz.zona,
+               'clientes',        pz.clientes,
+               'pedidos',         pz.pedidos,
+               'total',           pz.total,
+               'ticket_promedio', CASE WHEN pz.pedidos > 0 THEN round(pz.total / pz.pedidos, 2) ELSE 0 END
+             ) ORDER BY pz.total DESC)
+      FROM por_zona pz
+    ), '[]'::jsonb)
+  ) INTO v_result;
+
+  RETURN v_result;
+END;
+$function$;
+
+-- CREATE OR REPLACE conserva el ACL de la 197, pero el REVOKE/GRANT se repite
+-- igual: es barato y no depende de que nadie haya tocado los permisos en el medio.
+REVOKE ALL ON FUNCTION public.reporte_ventas_por_cliente(date, date, uuid, bigint) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.reporte_ventas_por_cliente(date, date, uuid, bigint) TO authenticated;
+
+DO $verif$
+DECLARE
+  v_acl text;
+BEGIN
+  SELECT array_to_string(proacl, ',') INTO v_acl
+  FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace
+  WHERE n.nspname = 'public' AND p.proname = 'reporte_ventas_por_cliente';
+
+  IF v_acl IS NULL THEN
+    RAISE EXCEPTION 'reporte_ventas_por_cliente quedó con ACL default (PUBLIC ejecuta)';
+  END IF;
+  IF v_acl LIKE '=X/%' OR v_acl LIKE '%,=X/%' THEN
+    RAISE EXCEPTION 'reporte_ventas_por_cliente quedó ejecutable por PUBLIC: %', v_acl;
+  END IF;
+  IF v_acl LIKE '%anon=%' THEN
+    RAISE EXCEPTION 'reporte_ventas_por_cliente quedó ejecutable por anon: %', v_acl;
+  END IF;
+  IF v_acl NOT LIKE '%authenticated=X%' THEN
+    RAISE EXCEPTION 'reporte_ventas_por_cliente no quedó ejecutable por authenticated: %', v_acl;
+  END IF;
+END
+$verif$;

--- a/src/components/containers/ReportesContainer.tsx
+++ b/src/components/containers/ReportesContainer.tsx
@@ -50,10 +50,17 @@ export default function ReportesContainer(): React.ReactElement {
     setReporteInicializado(true)
   }, [])
 
-  const handleVerFichaCliente = useCallback((cliente: ClienteDB) => {
-    setClienteFichaId(cliente.id)
+  // `clientes.id` es bigint: PostgREST lo devuelve como number en runtime aunque
+  // ClienteDB lo tipe string, y el RPC de ventas también. Se guarda y se compara
+  // siempre como string para que las dos fuentes coincidan.
+  const handleVerFichaClienteId = useCallback((clienteId: string) => {
+    setClienteFichaId(String(clienteId))
     setModalFichaOpen(true)
   }, [])
+
+  const handleVerFichaCliente = useCallback((cliente: ClienteDB) => {
+    handleVerFichaClienteId(String(cliente.id))
+  }, [handleVerFichaClienteId])
 
   return (
     <>
@@ -64,13 +71,14 @@ export default function ReportesContainer(): React.ReactElement {
           loading={isLoading}
           onCalcularReporte={handleCalcularReporte}
           onVerFichaCliente={handleVerFichaCliente}
+          onVerFichaClienteId={handleVerFichaClienteId}
         />
       </Suspense>
 
       {modalFichaOpen && clienteFichaId && (
         <Suspense fallback={null}>
           <ModalFichaCliente
-            cliente={clientes.find(cliente => cliente.id === clienteFichaId) || null}
+            cliente={clientes.find(cliente => String(cliente.id) === clienteFichaId) || null}
             onClose={() => {
               setModalFichaOpen(false)
               setClienteFichaId(null)

--- a/src/components/vistas/VistaReportes.tsx
+++ b/src/components/vistas/VistaReportes.tsx
@@ -5,11 +5,17 @@
  * - Por Preventista
  * - Cuentas por Cobrar (con aging)
  * - Rentabilidad por Producto
- * - Ventas por Cliente
- * - Ventas por Zona
+ * - Ventas por Cliente  (RPC reporte_ventas_por_cliente, mig 197)
+ * - Ventas por Zona     (mismo RPC, mismo cache)
+ * - Valuación de Stock
  *
  * Los sub-componentes están extraídos en archivos separados para
  * mejor mantenibilidad y separación de concerns.
+ *
+ * Nota sobre los filtros: "Por Cliente" y "Por Zona" NO usan el panel
+ * "Filtrar por Fecha" de arriba. Tienen el suyo (`FiltrosVentas`) porque además
+ * de fechas filtran por preventista y ofrecen atajos de mes; el estado vive acá
+ * para que las dos pestañas compartan la misma entrada de cache.
  */
 import React, { useState, useEffect, ChangeEvent } from 'react';
 import type { LucideIcon } from 'lucide-react';
@@ -21,8 +27,6 @@ import type {
   ReportePreventista,
   ReporteCuentaPorCobrar,
   ReporteRentabilidad,
-  VentaPorCliente,
-  VentaPorZona,
   TotalesRentabilidad
 } from '../../types';
 
@@ -33,7 +37,10 @@ import {
   ReporteRentabilidadSection,
   ReporteVentasClientes,
   ReporteVentasZonas,
-  ReporteValuacionInventario
+  ReporteValuacionInventario,
+  FiltrosVentas,
+  filtrosVentasIniciales,
+  type FiltrosVentasValue
 } from './reportes';
 
 // =============================================================================
@@ -46,6 +53,7 @@ export interface VistaReportesProps {
   loading: boolean;
   onCalcularReporte: (fechaDesde: string | null, fechaHasta: string | null) => Promise<void>;
   onVerFichaCliente?: (cliente: ClienteDB) => void;
+  onVerFichaClienteId?: (clienteId: string) => void;
 }
 
 interface TabConfig {
@@ -56,6 +64,9 @@ interface TabConfig {
 
 type ReportTabId = 'preventistas' | 'cuentas' | 'rentabilidad' | 'clientes' | 'zonas' | 'valuacion';
 
+/** Tabs que traen sus propios filtros y no usan el panel de fechas de arriba. */
+const TABS_CON_FILTROS_PROPIOS: ReportTabId[] = ['clientes', 'zonas', 'valuacion'];
+
 // =============================================================================
 // COMPONENT
 // =============================================================================
@@ -65,20 +76,20 @@ export default function VistaReportes({
   reporteInicializado,
   loading,
   onCalcularReporte,
-  onVerFichaCliente
+  onVerFichaCliente,
+  onVerFichaClienteId
 }: VistaReportesProps): React.ReactElement {
   // Estado local
   const [fechaDesde, setFechaDesde] = useState<string>('');
   const [fechaHasta, setFechaHasta] = useState<string>('');
   const [activeTab, setActiveTab] = useState<ReportTabId>('preventistas');
+  const [filtrosVentas, setFiltrosVentas] = useState<FiltrosVentasValue>(filtrosVentasIniciales);
 
   // Reportes financieros
   const {
     loading: loadingFinanciero,
     generarReporteCuentasPorCobrar,
-    generarReporteRentabilidad,
-    generarReporteVentasPorCliente,
-    generarReporteVentasPorZona
+    generarReporteRentabilidad
   } = useReportesFinancieros();
 
   // Estados de reportes
@@ -87,8 +98,6 @@ export default function VistaReportes({
     productos: [],
     totales: {} as TotalesRentabilidad
   });
-  const [reporteClientes, setReporteClientes] = useState<VentaPorCliente[]>([]);
-  const [reporteZonas, setReporteZonas] = useState<VentaPorZona[]>([]);
 
   // Configuración de tabs
   const tabs: TabConfig[] = [
@@ -123,21 +132,6 @@ export default function VistaReportes({
             setReporteRentabilidad(rent);
           }
           break;
-        case 'clientes':
-          if (reporteClientes.length === 0) {
-            const clientes = await generarReporteVentasPorCliente(
-              fechaDesde || null,
-              fechaHasta || null
-            );
-            setReporteClientes(clientes);
-          }
-          break;
-        case 'zonas':
-          if (reporteZonas.length === 0) {
-            const zonas = await generarReporteVentasPorZona(fechaDesde || null, fechaHasta || null);
-            setReporteZonas(zonas);
-          }
-          break;
       }
     };
 
@@ -162,19 +156,6 @@ export default function VistaReportes({
           setReporteRentabilidad(rent);
           break;
         }
-        case 'clientes': {
-          const clientes = await generarReporteVentasPorCliente(
-            fechaDesde || null,
-            fechaHasta || null
-          );
-          setReporteClientes(clientes);
-          break;
-        }
-        case 'zonas': {
-          const zonas = await generarReporteVentasPorZona(fechaDesde || null, fechaHasta || null);
-          setReporteZonas(zonas);
-          break;
-        }
       }
     }
   };
@@ -186,6 +167,7 @@ export default function VistaReportes({
   };
 
   const isLoading = loading || loadingFinanciero;
+  const esTabDeVentas = activeTab === 'clientes' || activeTab === 'zonas';
 
   return (
     <div className="space-y-4">
@@ -209,8 +191,12 @@ export default function VistaReportes({
         ))}
       </div>
 
-      {/* Filtros de fecha (la valuación es una foto del stock actual: no aplican) */}
-      {activeTab !== 'valuacion' && (
+      {/* Filtros propios de las pestañas de ventas: preventista + período */}
+      {esTabDeVentas && <FiltrosVentas value={filtrosVentas} onChange={setFiltrosVentas} />}
+
+      {/* Filtros de fecha genéricos (la valuación es una foto del stock actual y
+          las pestañas de ventas traen los suyos: no aplican) */}
+      {!TABS_CON_FILTROS_PROPIOS.includes(activeTab) && (
       <div className="bg-white dark:bg-gray-800 border dark:border-gray-700 rounded-lg shadow-sm p-4">
         <h2 className="font-semibold mb-3 text-gray-700 dark:text-gray-200">Filtrar por Fecha</h2>
         <div className="grid grid-cols-1 md:grid-cols-3 gap-4 items-end">
@@ -299,17 +285,19 @@ export default function VistaReportes({
 
       {activeTab === 'clientes' && (
         <ReporteVentasClientes
-          reporte={reporteClientes}
-          loading={loadingFinanciero}
+          desde={filtrosVentas.desde}
+          hasta={filtrosVentas.hasta}
+          preventistaId={filtrosVentas.preventistaId}
           formatPrecio={formatPrecio}
-          onVerCliente={onVerFichaCliente as ((cliente: ClienteDB | null) => void) | undefined}
+          onVerCliente={onVerFichaClienteId}
         />
       )}
 
       {activeTab === 'zonas' && (
         <ReporteVentasZonas
-          reporte={reporteZonas}
-          loading={loadingFinanciero}
+          desde={filtrosVentas.desde}
+          hasta={filtrosVentas.hasta}
+          preventistaId={filtrosVentas.preventistaId}
           formatPrecio={formatPrecio}
         />
       )}

--- a/src/components/vistas/reportes/FiltrosVentas.tsx
+++ b/src/components/vistas/reportes/FiltrosVentas.tsx
@@ -1,0 +1,143 @@
+/**
+ * Filtros compartidos por las pestañas "Por Cliente" y "Por Zona":
+ * preventista + período. El estado vive en VistaReportes y los dos reportes
+ * consumen el mismo hook con los mismos parámetros, así que React Query
+ * resuelve las dos pestañas con un solo viaje.
+ */
+import React from 'react';
+import { Calendar, User } from 'lucide-react';
+import { useVentasPorClienteQuery } from '../../../hooks/queries/useVentasPorClienteQuery';
+import { formatCurrencyCompact } from '../../../utils/formatters';
+import { presetsVentas, type PeriodoPreset } from '../../../utils/periodosReporte';
+import type { FiltrosVentasValue } from './filtrosVentasState';
+
+export interface FiltrosVentasProps {
+  value: FiltrosVentasValue;
+  onChange: (value: FiltrosVentasValue) => void;
+}
+
+const inputCls =
+  'px-3 py-2 border dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 text-sm text-gray-900 dark:text-white focus:ring-2 focus:ring-blue-500';
+
+export function FiltrosVentas({ value, onChange }: FiltrosVentasProps): React.ReactElement {
+  // Con preventistaId = null a propósito: es la lista completa de quien vendió
+  // en el período, y no se achica al elegir a alguien. Con el filtro en "Todos"
+  // comparte la query key con el reporte, así que no agrega un viaje.
+  const { data } = useVentasPorClienteQuery(value.desde, value.hasta, null);
+  const vendedores = data?.vendedores ?? [];
+  const presets: PeriodoPreset[] = presetsVentas();
+
+  // Si el elegido no vendió nada en el período nuevo, la opción desaparecería y
+  // el <select> se vería en "Todos" mientras el filtro sigue aplicado. Se
+  // mantiene visible y dice por qué la tabla está vacía.
+  const elegidoSinVentas =
+    value.preventistaId != null &&
+    vendedores.length > 0 &&
+    !vendedores.some((v) => v.id === value.preventistaId);
+
+  const elegirPreset = (presetId: string): void => {
+    if (presetId === 'custom') {
+      onChange({ ...value, presetId });
+      return;
+    }
+    const p = presets.find((x) => x.id === presetId);
+    if (p) onChange({ ...value, presetId, desde: p.desde, hasta: p.hasta });
+  };
+
+  return (
+    <div className="bg-white dark:bg-gray-800 border dark:border-gray-700 rounded-lg shadow-sm p-4 space-y-3">
+      <div className="flex flex-wrap gap-3 items-end">
+        <div>
+          <label
+            htmlFor="ventas-preventista"
+            className="block text-xs font-medium mb-1 text-gray-600 dark:text-gray-400"
+          >
+            <User className="w-3 h-3 inline mr-1" />
+            Vendedor
+          </label>
+          <select
+            id="ventas-preventista"
+            value={value.preventistaId ?? ''}
+            onChange={(e) => onChange({ ...value, preventistaId: e.target.value || null })}
+            className={inputCls}
+          >
+            <option value="">Todos</option>
+            {elegidoSinVentas && (
+              <option value={value.preventistaId as string}>Sin ventas en el período</option>
+            )}
+            {vendedores.map((v) => (
+              <option key={v.id} value={v.id}>
+                {v.nombre} — {formatCurrencyCompact(v.total)}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        <div>
+          <label
+            htmlFor="ventas-periodo"
+            className="block text-xs font-medium mb-1 text-gray-600 dark:text-gray-400"
+          >
+            <Calendar className="w-3 h-3 inline mr-1" />
+            Período
+          </label>
+          <select
+            id="ventas-periodo"
+            value={value.presetId}
+            onChange={(e) => elegirPreset(e.target.value)}
+            className={inputCls}
+          >
+            {presets.map((p) => (
+              <option key={p.id} value={p.id}>
+                {p.label}
+              </option>
+            ))}
+            <option value="custom">Personalizado…</option>
+          </select>
+        </div>
+
+        {value.presetId === 'custom' && (
+          <>
+            <div>
+              <label
+                htmlFor="ventas-desde"
+                className="block text-xs font-medium mb-1 text-gray-600 dark:text-gray-400"
+              >
+                Desde
+              </label>
+              <input
+                id="ventas-desde"
+                type="date"
+                value={value.desde}
+                max={value.hasta}
+                onChange={(e) => onChange({ ...value, desde: e.target.value })}
+                className={inputCls}
+              />
+            </div>
+            <div>
+              <label
+                htmlFor="ventas-hasta"
+                className="block text-xs font-medium mb-1 text-gray-600 dark:text-gray-400"
+              >
+                Hasta
+              </label>
+              <input
+                id="ventas-hasta"
+                type="date"
+                value={value.hasta}
+                min={value.desde}
+                onChange={(e) => onChange({ ...value, hasta: e.target.value })}
+                className={inputCls}
+              />
+            </div>
+          </>
+        )}
+      </div>
+
+      <p className="text-xs text-gray-500 dark:text-gray-400">
+        Venta = pedidos <strong>entregados</strong>, por fecha del pedido, atribuidos a quien lo
+        cargó. No cuenta cancelados ni cambios/devoluciones.
+      </p>
+    </div>
+  );
+}

--- a/src/components/vistas/reportes/ReporteVentasClientes.tsx
+++ b/src/components/vistas/reportes/ReporteVentasClientes.tsx
@@ -1,85 +1,241 @@
 /**
- * Componente para mostrar el reporte de ventas por cliente
+ * Ventas totalizadas por cliente, con la zona que el cliente tiene en su ficha.
+ *
+ * Responde a "quiero ver a quiénes le vendió cada preventista y de qué zona son
+ * esos clientes": la columna Zona hace visible la venta fuera de zona, que es
+ * la lectura que el informe viene a dar.
+ *
+ * Los datos salen del RPC `reporte_ventas_por_cliente` (mig 197), no de una
+ * agregación en el navegador: la versión anterior se comía el límite de 1.000
+ * filas de PostgREST y además sumaba pedidos cancelados.
  */
-import React from 'react';
-import { Users } from 'lucide-react';
+import React, { useMemo, useState } from 'react';
+import { Users, Download, Loader2 } from 'lucide-react';
 import LoadingSpinner from '../../layout/LoadingSpinner';
-import type { ClienteDB, VentaPorCliente } from '../../../types';
+import { useVentasPorClienteQuery } from '../../../hooks/queries/useVentasPorClienteQuery';
+import { labelMes } from '../../../utils/periodosReporte';
 
 export interface ReporteVentasClientesProps {
-  reporte: VentaPorCliente[];
-  loading: boolean;
+  desde: string;
+  hasta: string;
+  preventistaId: string | null;
   formatPrecio: (precio: number) => string;
-  onVerCliente?: (cliente: ClienteDB | null) => void;
+  onVerCliente?: (clienteId: string) => void;
 }
 
 export function ReporteVentasClientes({
-  reporte,
-  loading,
+  desde,
+  hasta,
+  preventistaId,
   formatPrecio,
-  onVerCliente
+  onVerCliente,
 }: ReporteVentasClientesProps): React.ReactElement {
-  if (loading) return <LoadingSpinner />;
+  const { data, isLoading, error } = useVentasPorClienteQuery(desde, hasta, preventistaId);
+  const [verMeses, setVerMeses] = useState(false);
+  const [exportando, setExportando] = useState(false);
 
-  if (reporte.length === 0) {
+  const meses = useMemo(() => data?.meses ?? [], [data]);
+  const mostrarMeses = verMeses && meses.length > 1;
+
+  const exportar = async (): Promise<void> => {
+    if (!data) return;
+    setExportando(true);
+    try {
+      const porCliente = data.clientes.map((c, i) => ({
+        '#': i + 1,
+        Cliente: c.nombre,
+        Zona: c.zona,
+        Pedidos: c.pedidos,
+        Total: c.total,
+        '% del total': data.totales.total ? c.total / data.totales.total : 0,
+        ...Object.fromEntries(meses.map((m) => [labelMes(m), c.por_mes?.[m] ?? 0])),
+      }));
+      const porZona = data.zonas.map((z) => ({
+        Zona: z.zona,
+        Clientes: z.clientes,
+        Pedidos: z.pedidos,
+        Total: z.total,
+        '% del total': data.totales.total ? z.total / data.totales.total : 0,
+        'Ticket promedio': z.ticket_promedio,
+      }));
+
+      const { createMultiSheetExcel } = await import('../../../utils/excel');
+      await createMultiSheetExcel(
+        [
+          { name: 'Por cliente', data: porCliente, columnWidths: [5, 42, 22, 10, 15, 12] },
+          { name: 'Por zona', data: porZona, columnWidths: [24, 10, 10, 15, 12, 15] },
+        ],
+        `ventas-por-cliente-${data.meta.preventista_nombre}-${desde}_${hasta}`.replace(/\s+/g, '_')
+      );
+    } finally {
+      setExportando(false);
+    }
+  };
+
+  if (isLoading) return <LoadingSpinner />;
+
+  if (error) {
     return (
-      <div className="text-center py-12 text-gray-500 bg-white dark:bg-gray-800 rounded-lg">
-        <Users className="w-12 h-12 mx-auto mb-3 opacity-50" />
-        <p>No hay datos de ventas por cliente</p>
+      <div className="bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg p-4 text-red-700 dark:text-red-300 text-sm">
+        No se pudo cargar el reporte: {(error as Error).message}
       </div>
     );
   }
 
-  const totalVentas = reporte.reduce((s, r) => s + r.totalVentas, 0);
-  const totalPedidos = reporte.reduce((s, r) => s + r.cantidadPedidos, 0);
+  if (!data || data.clientes.length === 0) {
+    return (
+      <div className="text-center py-12 text-gray-500 bg-white dark:bg-gray-800 rounded-lg">
+        <Users className="w-12 h-12 mx-auto mb-3 opacity-50" />
+        <p>No hay ventas entregadas en el período elegido</p>
+      </div>
+    );
+  }
+
+  const { totales } = data;
 
   return (
-    <div className="bg-white dark:bg-gray-800 border dark:border-gray-700 rounded-lg overflow-x-auto">
-      <table className="w-full">
-        <thead className="bg-gray-50 dark:bg-gray-700/50">
-          <tr>
-            <th className="px-4 py-3 text-left text-sm font-medium">Cliente</th>
-            <th className="px-4 py-3 text-right text-sm font-medium">Pedidos</th>
-            <th className="px-4 py-3 text-right text-sm font-medium">Total</th>
-            <th className="px-4 py-3 text-right text-sm font-medium">% Total</th>
-            <th className="px-4 py-3 text-center text-sm font-medium">Acciones</th>
-          </tr>
-        </thead>
-        <tbody className="divide-y dark:divide-gray-700">
-          {reporte.slice(0, 30).map((r, i) => (
-            <tr key={i} className="hover:bg-gray-50 dark:hover:bg-gray-700/50">
-              <td className="px-4 py-3">
-                <p className="font-medium">{r.cliente?.nombre_fantasia || 'Cliente'}</p>
-                <p className="text-sm text-gray-500">{r.cliente?.zona || 'Sin zona'}</p>
-              </td>
-              <td className="px-4 py-3 text-right">{r.cantidadPedidos}</td>
-              <td className="px-4 py-3 text-right font-bold text-blue-600">
-                {formatPrecio(r.totalVentas)}
-              </td>
-              <td className="px-4 py-3 text-right text-gray-600">
-                {((r.totalVentas / totalVentas) * 100).toFixed(1)}%
-              </td>
-              <td className="px-4 py-3 text-center">
-                <button
-                  onClick={() => onVerCliente?.(r.cliente)}
-                  className="text-blue-600 hover:text-blue-700 text-sm"
-                >
-                  Ver ficha
-                </button>
-              </td>
+    <div className="space-y-3">
+      {/* Resumen + export */}
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div className="flex flex-wrap gap-3 text-sm">
+          <span className="px-3 py-1.5 rounded-lg bg-blue-50 dark:bg-blue-900/20 text-blue-700 dark:text-blue-300">
+            <strong>{totales.clientes}</strong> clientes
+          </span>
+          <span className="px-3 py-1.5 rounded-lg bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-200">
+            <strong>{totales.pedidos}</strong> pedidos
+          </span>
+          <span className="px-3 py-1.5 rounded-lg bg-green-50 dark:bg-green-900/20 text-green-700 dark:text-green-300">
+            <strong>{formatPrecio(totales.total)}</strong>
+          </span>
+        </div>
+        <div className="flex items-center gap-3">
+          {meses.length > 1 && (
+            <label className="flex items-center gap-2 text-sm text-gray-600 dark:text-gray-300 cursor-pointer">
+              <input
+                type="checkbox"
+                checked={verMeses}
+                onChange={(e) => setVerMeses(e.target.checked)}
+                className="rounded border-gray-300 dark:border-gray-600"
+              />
+              Desglose por mes
+            </label>
+          )}
+          <button
+            onClick={exportar}
+            disabled={exportando}
+            className="flex items-center gap-2 px-3 py-2 bg-green-600 text-white rounded-lg hover:bg-green-700 disabled:opacity-50 text-sm transition-colors"
+          >
+            {exportando ? (
+              <Loader2 className="w-4 h-4 animate-spin" />
+            ) : (
+              <Download className="w-4 h-4" />
+            )}
+            Exportar a Excel
+          </button>
+        </div>
+      </div>
+
+      <div className="bg-white dark:bg-gray-800 border dark:border-gray-700 rounded-lg overflow-x-auto">
+        <table className="w-full text-sm">
+          <thead className="bg-gray-50 dark:bg-gray-700/50">
+            <tr>
+              <th className="px-3 py-3 text-left font-medium w-10">#</th>
+              <th className="px-3 py-3 text-left font-medium">Cliente</th>
+              <th className="px-3 py-3 text-left font-medium">Zona (ficha)</th>
+              <th className="px-3 py-3 text-right font-medium">Pedidos</th>
+              <th className="px-3 py-3 text-right font-medium">Total</th>
+              <th className="px-3 py-3 text-right font-medium">% Total</th>
+              {mostrarMeses &&
+                meses.map((m) => (
+                  <th key={m} className="px-3 py-3 text-right font-medium whitespace-nowrap">
+                    {labelMes(m)}
+                  </th>
+                ))}
+              <th className="px-3 py-3 text-center font-medium">Acciones</th>
             </tr>
-          ))}
-        </tbody>
-        <tfoot className="bg-gray-50 dark:bg-gray-700/50 font-bold">
-          <tr>
-            <td className="px-4 py-3">TOTAL ({reporte.length} clientes)</td>
-            <td className="px-4 py-3 text-right">{totalPedidos}</td>
-            <td className="px-4 py-3 text-right text-blue-600">{formatPrecio(totalVentas)}</td>
-            <td className="px-4 py-3 text-right">100%</td>
-            <td></td>
-          </tr>
-        </tfoot>
-      </table>
+          </thead>
+          <tbody className="divide-y dark:divide-gray-700">
+            {data.clientes.map((c, i) => (
+              <tr
+                key={c.cliente_id ?? `sin-cliente-${i}`}
+                className="hover:bg-gray-50 dark:hover:bg-gray-700/50"
+              >
+                <td className="px-3 py-2 text-gray-400">{i + 1}</td>
+                <td className="px-3 py-2 font-medium text-gray-800 dark:text-gray-100">
+                  {c.nombre}
+                </td>
+                <td className="px-3 py-2">
+                  <span
+                    className={
+                      c.zona === 'SIN ZONA'
+                        ? 'text-amber-600 dark:text-amber-400'
+                        : 'text-gray-600 dark:text-gray-300'
+                    }
+                  >
+                    {c.zona}
+                  </span>
+                </td>
+                <td className="px-3 py-2 text-right">{c.pedidos}</td>
+                <td className="px-3 py-2 text-right font-bold text-blue-600 dark:text-blue-400 whitespace-nowrap">
+                  {formatPrecio(c.total)}
+                </td>
+                <td className="px-3 py-2 text-right text-gray-500">
+                  {totales.total ? ((c.total / totales.total) * 100).toFixed(1) : '0.0'}%
+                </td>
+                {mostrarMeses &&
+                  meses.map((m) => (
+                    <td
+                      key={m}
+                      className="px-3 py-2 text-right text-gray-600 dark:text-gray-300 whitespace-nowrap"
+                    >
+                      {c.por_mes?.[m] ? formatPrecio(c.por_mes[m]) : '—'}
+                    </td>
+                  ))}
+                <td className="px-3 py-2 text-center">
+                  {c.cliente_id != null ? (
+                    <button
+                      onClick={() => onVerCliente?.(String(c.cliente_id))}
+                      className="text-blue-600 hover:text-blue-700 dark:text-blue-400"
+                    >
+                      Ver ficha
+                    </button>
+                  ) : (
+                    <span className="text-gray-400 text-xs">sin ficha</span>
+                  )}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+          <tfoot className="bg-gray-50 dark:bg-gray-700/50 font-bold">
+            <tr>
+              <td className="px-3 py-3" />
+              <td className="px-3 py-3">TOTAL ({totales.clientes} clientes)</td>
+              <td />
+              <td className="px-3 py-3 text-right">{totales.pedidos}</td>
+              <td className="px-3 py-3 text-right text-blue-600 dark:text-blue-400 whitespace-nowrap">
+                {formatPrecio(totales.total)}
+              </td>
+              <td className="px-3 py-3 text-right">100%</td>
+              {mostrarMeses &&
+                meses.map((m) => (
+                  <td key={m} className="px-3 py-3 text-right whitespace-nowrap">
+                    {formatPrecio(
+                      data.clientes.reduce((s, c) => s + (c.por_mes?.[m] ?? 0), 0)
+                    )}
+                  </td>
+                ))}
+              <td />
+            </tr>
+          </tfoot>
+        </table>
+      </div>
+
+      {data.clientes.some((c) => c.cliente_id == null) && (
+        <p className="text-xs text-amber-700 dark:text-amber-400">
+          La fila "(sin cliente asignado)" agrupa pedidos entregados que quedaron sin cliente en la
+          base. Se muestran para que el total del informe coincida con el total de ventas.
+        </p>
+      )}
     </div>
   );
 }

--- a/src/components/vistas/reportes/ReporteVentasZonas.tsx
+++ b/src/components/vistas/reportes/ReporteVentasZonas.tsx
@@ -1,43 +1,58 @@
 /**
- * Componente para mostrar el reporte de ventas por zona geográfica
+ * Ventas por zona geográfica (la zona de la ficha del cliente).
+ *
+ * Lee el MISMO hook que "Por Cliente" con los mismos parámetros: React Query
+ * comparte la entrada de cache, así que cambiar de pestaña no dispara otro
+ * viaje. Antes esta pestaña agregaba en el navegador y arrastraba los mismos
+ * dos bugs que la de clientes (contaba cancelados y se cortaba en 1.000 filas).
  */
 import React from 'react';
 import { MapPin } from 'lucide-react';
 import LoadingSpinner from '../../layout/LoadingSpinner';
-import type { VentaPorZona } from '../../../types';
+import { useVentasPorClienteQuery } from '../../../hooks/queries/useVentasPorClienteQuery';
 
 export interface ReporteVentasZonasProps {
-  reporte: VentaPorZona[];
-  loading: boolean;
+  desde: string;
+  hasta: string;
+  preventistaId: string | null;
   formatPrecio: (precio: number) => string;
 }
 
 export function ReporteVentasZonas({
-  reporte,
-  loading,
-  formatPrecio
+  desde,
+  hasta,
+  preventistaId,
+  formatPrecio,
 }: ReporteVentasZonasProps): React.ReactElement {
-  if (loading) return <LoadingSpinner />;
+  const { data, isLoading, error } = useVentasPorClienteQuery(desde, hasta, preventistaId);
 
-  if (reporte.length === 0) {
+  if (isLoading) return <LoadingSpinner />;
+
+  if (error) {
     return (
-      <div className="text-center py-12 text-gray-500 bg-white dark:bg-gray-800 rounded-lg">
-        <MapPin className="w-12 h-12 mx-auto mb-3 opacity-50" />
-        <p>No hay datos de ventas por zona</p>
+      <div className="bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg p-4 text-red-700 dark:text-red-300 text-sm">
+        No se pudo cargar el reporte: {(error as Error).message}
       </div>
     );
   }
 
-  const totalVentas = reporte.reduce((s, r) => s + r.totalVentas, 0);
-  const totalClientes = reporte.reduce((s, r) => s + r.cantidadClientes, 0);
-  const totalPedidos = reporte.reduce((s, r) => s + r.cantidadPedidos, 0);
+  if (!data || data.zonas.length === 0) {
+    return (
+      <div className="text-center py-12 text-gray-500 bg-white dark:bg-gray-800 rounded-lg">
+        <MapPin className="w-12 h-12 mx-auto mb-3 opacity-50" />
+        <p>No hay ventas entregadas en el período elegido</p>
+      </div>
+    );
+  }
+
+  const { totales, zonas } = data;
 
   return (
     <div className="bg-white dark:bg-gray-800 border dark:border-gray-700 rounded-lg overflow-x-auto">
       <table className="w-full">
         <thead className="bg-gray-50 dark:bg-gray-700/50">
           <tr>
-            <th className="px-4 py-3 text-left text-sm font-medium">Zona</th>
+            <th className="px-4 py-3 text-left text-sm font-medium">Zona (ficha)</th>
             <th className="px-4 py-3 text-right text-sm font-medium">Clientes</th>
             <th className="px-4 py-3 text-right text-sm font-medium">Pedidos</th>
             <th className="px-4 py-3 text-right text-sm font-medium">Total</th>
@@ -46,26 +61,36 @@ export function ReporteVentasZonas({
           </tr>
         </thead>
         <tbody className="divide-y dark:divide-gray-700">
-          {reporte.map((r, i) => (
-            <tr key={i} className="hover:bg-gray-50 dark:hover:bg-gray-700/50">
-              <td className="px-4 py-3 font-medium">{r.zona}</td>
-              <td className="px-4 py-3 text-right">{r.cantidadClientes}</td>
-              <td className="px-4 py-3 text-right">{r.cantidadPedidos}</td>
-              <td className="px-4 py-3 text-right font-bold text-blue-600">
-                {formatPrecio(r.totalVentas)}
+          {zonas.map((z) => (
+            <tr key={z.zona} className="hover:bg-gray-50 dark:hover:bg-gray-700/50">
+              <td
+                className={`px-4 py-3 font-medium ${
+                  z.zona === 'SIN ZONA' ? 'text-amber-600 dark:text-amber-400' : ''
+                }`}
+              >
+                {z.zona}
               </td>
-              <td className="px-4 py-3 text-right text-gray-600">
-                {formatPrecio(r.ticketPromedio)}
+              <td className="px-4 py-3 text-right">{z.clientes}</td>
+              <td className="px-4 py-3 text-right">{z.pedidos}</td>
+              <td className="px-4 py-3 text-right font-bold text-blue-600 dark:text-blue-400">
+                {formatPrecio(z.total)}
+              </td>
+              <td className="px-4 py-3 text-right text-gray-600 dark:text-gray-300">
+                {formatPrecio(z.ticket_promedio)}
               </td>
               <td className="px-4 py-3 text-right">
                 <div className="flex items-center justify-end gap-2">
-                  <div className="w-16 bg-gray-200 rounded-full h-2">
+                  <div className="w-16 bg-gray-200 dark:bg-gray-600 rounded-full h-2">
                     <div
                       className="bg-blue-600 h-2 rounded-full"
-                      style={{ width: `${(r.totalVentas / totalVentas) * 100}%` }}
+                      style={{
+                        width: `${totales.total ? (z.total / totales.total) * 100 : 0}%`,
+                      }}
                     />
                   </div>
-                  <span className="text-sm">{((r.totalVentas / totalVentas) * 100).toFixed(1)}%</span>
+                  <span className="text-sm">
+                    {totales.total ? ((z.total / totales.total) * 100).toFixed(1) : '0.0'}%
+                  </span>
                 </div>
               </td>
             </tr>
@@ -74,11 +99,13 @@ export function ReporteVentasZonas({
         <tfoot className="bg-gray-50 dark:bg-gray-700/50 font-bold">
           <tr>
             <td className="px-4 py-3">TOTAL</td>
-            <td className="px-4 py-3 text-right">{totalClientes}</td>
-            <td className="px-4 py-3 text-right">{totalPedidos}</td>
-            <td className="px-4 py-3 text-right text-blue-600">{formatPrecio(totalVentas)}</td>
+            <td className="px-4 py-3 text-right">{totales.clientes}</td>
+            <td className="px-4 py-3 text-right">{totales.pedidos}</td>
+            <td className="px-4 py-3 text-right text-blue-600 dark:text-blue-400">
+              {formatPrecio(totales.total)}
+            </td>
             <td className="px-4 py-3 text-right">
-              {formatPrecio(totalVentas / Math.max(1, totalPedidos))}
+              {formatPrecio(totales.total / Math.max(1, totales.pedidos))}
             </td>
             <td className="px-4 py-3 text-right">100%</td>
           </tr>

--- a/src/components/vistas/reportes/__tests__/FiltrosVentas.test.tsx
+++ b/src/components/vistas/reportes/__tests__/FiltrosVentas.test.tsx
@@ -1,0 +1,141 @@
+/**
+ * Tests de la barra de filtros de las pestañas de ventas.
+ *
+ * Lo que importa acá:
+ *   1) la lista de vendedores sale de los DATOS, no de `perfiles.rol` — si
+ *      saliera del rol, Jony (encargado, $16,6M en 2026) no aparecería;
+ *   2) se pide siempre con preventistaId = null, para que elegir a alguien no
+ *      deje el desplegable con una sola opción;
+ *   3) los atajos de mes escriben desde/hasta y "Personalizado" abre los campos;
+ *   4) si el elegido no vendió en el período nuevo, la opción sigue visible en
+ *      vez de que el <select> se vea en "Todos" con el filtro puesto.
+ */
+import '@testing-library/jest-dom/vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+const mockUseQuery = vi.fn();
+
+vi.mock('../../../../hooks/queries/useVentasPorClienteQuery', () => ({
+  useVentasPorClienteQuery: (desde: string, hasta: string, preventistaId: string | null) =>
+    mockUseQuery(desde, hasta, preventistaId),
+}));
+
+import { FiltrosVentas } from '../FiltrosVentas';
+import type { FiltrosVentasValue } from '../filtrosVentasState';
+
+const VENDEDORES = [
+  { id: 'juan', nombre: 'Juan', pedidos: 912, total: 45796256.96 },
+  { id: 'christian', nombre: 'Christian', pedidos: 1164, total: 40198490.26 },
+  // Encargado: la prueba de que la lista no viene filtrada por rol.
+  { id: 'jony', nombre: 'Jony', pedidos: 287, total: 16630570 },
+];
+
+const BASE: FiltrosVentasValue = {
+  desde: '2026-01-01',
+  hasta: '2026-08-20',
+  preventistaId: null,
+  presetId: 'anio-2026',
+};
+
+function renderFiltros(value: Partial<FiltrosVentasValue> = {}) {
+  const onChange = vi.fn();
+  render(<FiltrosVentas value={{ ...BASE, ...value }} onChange={onChange} />);
+  return onChange;
+}
+
+beforeEach(() => {
+  mockUseQuery.mockReset();
+  mockUseQuery.mockReturnValue({ data: { vendedores: VENDEDORES } });
+});
+
+describe('FiltrosVentas', () => {
+  it('lista a quien vendió, sin importar el rol, con su total', () => {
+    renderFiltros();
+    const select = screen.getByLabelText(/Vendedor/i);
+    expect(select).toHaveTextContent('Juan — $45.8M');
+    expect(select).toHaveTextContent('Christian — $40.2M');
+    // Un desplegable por `rol = 'preventista'` se habría comido a Jony.
+    expect(select).toHaveTextContent('Jony — $16.6M');
+  });
+
+  it('pide la lista con preventistaId null aunque haya uno elegido', () => {
+    renderFiltros({ preventistaId: 'christian' });
+    expect(mockUseQuery).toHaveBeenCalledWith('2026-01-01', '2026-08-20', null);
+    // Y sigue mostrando a los tres, no sólo al elegido.
+    expect(screen.getByLabelText(/Vendedor/i)).toHaveTextContent('Juan');
+  });
+
+  it('elegir un vendedor lo propaga', async () => {
+    const user = userEvent.setup();
+    const onChange = renderFiltros();
+    await user.selectOptions(screen.getByLabelText(/Vendedor/i), 'christian');
+    expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ preventistaId: 'christian' }));
+  });
+
+  it('volver a "Todos" manda null y no la cadena vacía', async () => {
+    const user = userEvent.setup();
+    const onChange = renderFiltros({ preventistaId: 'christian' });
+    await user.selectOptions(screen.getByLabelText(/Vendedor/i), '');
+    expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ preventistaId: null }));
+  });
+
+  it('un atajo de mes escribe desde y hasta', async () => {
+    const user = userEvent.setup();
+    const onChange = renderFiltros();
+    const periodo = screen.getByLabelText(/Período/i);
+    // El segundo preset es el mes en curso; se elige por su value.
+    const opciones = Array.from((periodo as HTMLSelectElement).options).map((o) => o.value);
+    const unMes = opciones.find((v) => v.startsWith('mes-')) as string;
+
+    await user.selectOptions(periodo, unMes);
+    const arg = onChange.mock.calls[0][0] as FiltrosVentasValue;
+    expect(arg.presetId).toBe(unMes);
+    expect(arg.desde).toMatch(/^\d{4}-\d{2}-01$/);
+    expect(arg.hasta).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+    expect(arg.desde <= arg.hasta).toBe(true);
+  });
+
+  it('los campos de fecha aparecen sólo en "Personalizado"', async () => {
+    const user = userEvent.setup();
+    const onChange = renderFiltros();
+    expect(screen.queryByLabelText('Desde')).not.toBeInTheDocument();
+
+    await user.selectOptions(screen.getByLabelText(/Período/i), 'custom');
+    expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ presetId: 'custom' }));
+
+    renderFiltros({ presetId: 'custom' });
+    expect(screen.getByLabelText('Desde')).toBeInTheDocument();
+    expect(screen.getByLabelText('Hasta')).toBeInTheDocument();
+  });
+
+  it('"Personalizado" no pisa las fechas que ya estaban', async () => {
+    const user = userEvent.setup();
+    const onChange = renderFiltros({ desde: '2026-03-05', hasta: '2026-04-09' });
+    await user.selectOptions(screen.getByLabelText(/Período/i), 'custom');
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({ desde: '2026-03-05', hasta: '2026-04-09' })
+    );
+  });
+
+  it('si el elegido no vendió en el período, la opción sigue visible', () => {
+    renderFiltros({ preventistaId: 'osvaldo' });
+    const select = screen.getByLabelText(/Vendedor/i) as HTMLSelectElement;
+    // Sin esta opción el <select> caería a "Todos" mostrando datos filtrados.
+    expect(select.value).toBe('osvaldo');
+    expect(select).toHaveTextContent('Sin ventas en el período');
+  });
+
+  it('no inventa esa opción mientras la lista todavía no cargó', () => {
+    mockUseQuery.mockReturnValue({ data: undefined });
+    renderFiltros({ preventistaId: 'christian' });
+    expect(screen.getByLabelText(/Vendedor/i)).not.toHaveTextContent('Sin ventas en el período');
+  });
+
+  it('deja escrito el criterio de qué cuenta como venta', () => {
+    renderFiltros();
+    expect(screen.getByText(/entregados/i)).toBeInTheDocument();
+    expect(screen.getByText(/No cuenta cancelados/i)).toBeInTheDocument();
+  });
+});

--- a/src/components/vistas/reportes/__tests__/ReporteVentasClientes.test.tsx
+++ b/src/components/vistas/reportes/__tests__/ReporteVentasClientes.test.tsx
@@ -1,0 +1,281 @@
+/**
+ * Tests de la pestaña "Por Cliente" de Reportes.
+ *
+ * Cubren justamente lo que la versión anterior hacía mal:
+ *   1) lista TODOS los clientes (antes cortaba en 30 con un slice);
+ *   2) la zona de la ficha es una columna propia por fila;
+ *   3) los totales del pie salen del RPC, no de sumar las filas visibles;
+ *   4) el desglose por mes aparece sólo si el rango abarca más de un mes;
+ *   5) los pedidos sin cliente se muestran con su aviso, en vez de desaparecer.
+ *
+ * El hook se mockea: el cuadre de los números contra prod ya lo garantiza el
+ * RPC (mig 197), acá se verifica el render.
+ */
+import '@testing-library/jest-dom/vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+interface HojaExcel {
+  name: string;
+  data: Record<string, unknown>[];
+  columnWidths?: number[];
+}
+
+const mockUseQuery = vi.fn();
+const mockCrearExcel = vi.fn<(hojas: HojaExcel[], filename: string) => Promise<void>>(() =>
+  Promise.resolve()
+);
+
+vi.mock('../../../../hooks/queries/useVentasPorClienteQuery', () => ({
+  useVentasPorClienteQuery: (desde: string, hasta: string, preventistaId: string | null) =>
+    mockUseQuery(desde, hasta, preventistaId),
+}));
+
+vi.mock('../../../../utils/excel', () => ({
+  createMultiSheetExcel: (hojas: HojaExcel[], filename: string) => mockCrearExcel(hojas, filename),
+}));
+
+vi.mock('../../../layout/LoadingSpinner', () => ({
+  default: () => <div>cargando…</div>,
+}));
+
+import { ReporteVentasClientes } from '../ReporteVentasClientes';
+import type { VentasPorCliente } from '../../../../hooks/queries/useVentasPorClienteQuery';
+
+const formatPrecio = (n: number): string => `$${n.toLocaleString('es-AR')}`;
+
+function datos(overrides: Partial<VentasPorCliente> = {}): VentasPorCliente {
+  return {
+    meta: {
+      desde: '2026-06-01',
+      hasta: '2026-08-20',
+      preventista_id: 'p-1',
+      preventista_nombre: 'Christian',
+      sucursal_id: 1,
+      sucursal_nombre: 'Tucuman',
+      generado_at: '2026-08-20T17:00:00Z',
+      criterio: 'Pedidos entregados…',
+    },
+    meses: ['2026-06', '2026-07'],
+    vendedores: [{ id: 'p-1', nombre: 'Christian', pedidos: 10, total: 3000 }],
+    totales: { clientes: 2, pedidos: 10, total: 3000 },
+    clientes: [
+      {
+        cliente_id: 11,
+        codigo: 101,
+        nombre: 'BENJAMIN PAZ 298',
+        zona: 'ZONA 4 CHRISTIAN',
+        pedidos: 7,
+        total: 2000,
+        por_mes: { '2026-06': 1200, '2026-07': 800 },
+      },
+      {
+        cliente_id: 22,
+        codigo: 102,
+        nombre: 'Escuela Avellaneda',
+        zona: 'ZONA 1 MARCELO',
+        pedidos: 3,
+        total: 1000,
+        por_mes: { '2026-06': 1000 },
+      },
+    ],
+    zonas: [
+      { zona: 'ZONA 4 CHRISTIAN', clientes: 1, pedidos: 7, total: 2000, ticket_promedio: 285.71 },
+      { zona: 'ZONA 1 MARCELO', clientes: 1, pedidos: 3, total: 1000, ticket_promedio: 333.33 },
+    ],
+    ...overrides,
+  };
+}
+
+function renderReporte(): void {
+  render(
+    <ReporteVentasClientes
+      desde="2026-06-01"
+      hasta="2026-08-20"
+      preventistaId="p-1"
+      formatPrecio={formatPrecio}
+    />
+  );
+}
+
+beforeEach(() => {
+  mockUseQuery.mockReset();
+  mockCrearExcel.mockClear();
+});
+
+describe('ReporteVentasClientes', () => {
+  it('le pasa período y preventista al hook', () => {
+    mockUseQuery.mockReturnValue({ data: datos(), isLoading: false, error: null });
+    renderReporte();
+    expect(mockUseQuery).toHaveBeenCalledWith('2026-06-01', '2026-08-20', 'p-1');
+  });
+
+  it('muestra la zona de la ficha en su propia columna, por fila', () => {
+    mockUseQuery.mockReturnValue({ data: datos(), isLoading: false, error: null });
+    renderReporte();
+
+    const fila = screen.getByText('Escuela Avellaneda').closest('tr');
+    expect(fila).not.toBeNull();
+    // La venta fuera de zona es la lectura del informe: el cliente es de una
+    // zona de MARCELO aunque la venta sea de Christian.
+    expect(within(fila as HTMLElement).getByText('ZONA 1 MARCELO')).toBeInTheDocument();
+    expect(screen.getByRole('columnheader', { name: /Zona/i })).toBeInTheDocument();
+  });
+
+  it('lista TODOS los clientes, sin cortar en 30', () => {
+    const muchos = Array.from({ length: 45 }, (_, i) => ({
+      cliente_id: i + 1,
+      codigo: i + 1,
+      nombre: `Cliente ${i + 1}`,
+      zona: 'ZONA 1 CHRISTIAN',
+      pedidos: 1,
+      total: 100,
+      por_mes: { '2026-06': 100 },
+    }));
+    mockUseQuery.mockReturnValue({
+      data: datos({ clientes: muchos, totales: { clientes: 45, pedidos: 45, total: 4500 } }),
+      isLoading: false,
+      error: null,
+    });
+    renderReporte();
+
+    expect(screen.getByText('Cliente 45')).toBeInTheDocument();
+    expect(screen.getByText('Cliente 31')).toBeInTheDocument();
+  });
+
+  it('los totales del pie salen del RPC y no de sumar lo que se ve', () => {
+    // totales.total (3000) coincide con las filas acá, pero el pie debe leer el
+    // campo del RPC: es la única fuente que no depende de la paginación.
+    mockUseQuery.mockReturnValue({ data: datos(), isLoading: false, error: null });
+    renderReporte();
+
+    expect(screen.getByText('TOTAL (2 clientes)')).toBeInTheDocument();
+    const pie = screen.getByText('TOTAL (2 clientes)').closest('tr') as HTMLElement;
+    expect(within(pie).getByText('$3.000')).toBeInTheDocument();
+    expect(within(pie).getByText('10')).toBeInTheDocument();
+  });
+
+  it('el desglose por mes está oculto por defecto y se puede prender', async () => {
+    const user = userEvent.setup();
+    mockUseQuery.mockReturnValue({ data: datos(), isLoading: false, error: null });
+    renderReporte();
+
+    expect(screen.queryByRole('columnheader', { name: 'Jun 26' })).not.toBeInTheDocument();
+    await user.click(screen.getByLabelText(/Desglose por mes/i));
+    expect(screen.getByRole('columnheader', { name: 'Jun 26' })).toBeInTheDocument();
+    expect(screen.getByRole('columnheader', { name: 'Jul 26' })).toBeInTheDocument();
+  });
+
+  it('no ofrece el desglose si el rango tiene un solo mes', () => {
+    mockUseQuery.mockReturnValue({
+      data: datos({ meses: ['2026-07'] }),
+      isLoading: false,
+      error: null,
+    });
+    renderReporte();
+    expect(screen.queryByLabelText(/Desglose por mes/i)).not.toBeInTheDocument();
+  });
+
+  it('muestra los pedidos sin cliente con su aviso, en vez de esconderlos', () => {
+    mockUseQuery.mockReturnValue({
+      data: datos({
+        clientes: [
+          {
+            cliente_id: null,
+            codigo: null,
+            nombre: '(sin cliente asignado)',
+            zona: 'SIN ZONA',
+            pedidos: 3,
+            total: 83750,
+            por_mes: { '2026-06': 83750 },
+          },
+        ],
+        totales: { clientes: 1, pedidos: 3, total: 83750 },
+      }),
+      isLoading: false,
+      error: null,
+    });
+    renderReporte();
+
+    expect(screen.getByText('(sin cliente asignado)')).toBeInTheDocument();
+    expect(screen.getByText('sin ficha')).toBeInTheDocument();
+    expect(screen.getByText(/coincida con el total de ventas/i)).toBeInTheDocument();
+  });
+
+  it('el botón "Ver ficha" manda el id del cliente como string', async () => {
+    const user = userEvent.setup();
+    const onVerCliente = vi.fn();
+    mockUseQuery.mockReturnValue({ data: datos(), isLoading: false, error: null });
+    render(
+      <ReporteVentasClientes
+        desde="2026-06-01"
+        hasta="2026-08-20"
+        preventistaId="p-1"
+        formatPrecio={formatPrecio}
+        onVerCliente={onVerCliente}
+      />
+    );
+
+    const fila = screen.getByText('BENJAMIN PAZ 298').closest('tr') as HTMLElement;
+    await user.click(within(fila).getByRole('button', { name: /Ver ficha/i }));
+    // String, no number: `clientes.id` es bigint y las dos fuentes lo tipan distinto.
+    expect(onVerCliente).toHaveBeenCalledWith('11');
+  });
+
+  it('exporta dos hojas: una por cliente con la zona y una por zona', async () => {
+    const user = userEvent.setup();
+    mockUseQuery.mockReturnValue({ data: datos(), isLoading: false, error: null });
+    renderReporte();
+
+    await user.click(screen.getByRole('button', { name: /Exportar a Excel/i }));
+
+    expect(mockCrearExcel).toHaveBeenCalledTimes(1);
+    const [hojas, nombreArchivo] = mockCrearExcel.mock.calls[0];
+
+    expect(hojas.map((h) => h.name)).toEqual(['Por cliente', 'Por zona']);
+
+    // El Excel siempre lleva el desglose por mes, aunque en pantalla esté oculto.
+    expect(hojas[0].data[0]).toMatchObject({
+      '#': 1,
+      Cliente: 'BENJAMIN PAZ 298',
+      Zona: 'ZONA 4 CHRISTIAN',
+      Pedidos: 7,
+      Total: 2000,
+      'Jun 26': 1200,
+      'Jul 26': 800,
+    });
+    // Un cliente que no compró en julio va con 0, no con la celda ausente.
+    expect(hojas[0].data[1]).toMatchObject({ Cliente: 'Escuela Avellaneda', 'Jul 26': 0 });
+
+    expect(hojas[1].data[0]).toMatchObject({
+      Zona: 'ZONA 4 CHRISTIAN',
+      Clientes: 1,
+      Pedidos: 7,
+      Total: 2000,
+    });
+
+    // El nombre del archivo dice de quién y de cuándo es, sin espacios.
+    expect(nombreArchivo).toBe('ventas-por-cliente-Christian-2026-06-01_2026-08-20');
+  });
+
+  it('muestra el error del RPC en vez de una tabla vacía', () => {
+    mockUseQuery.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      error: new Error('Acceso denegado: se requiere rol admin o encargado'),
+    });
+    renderReporte();
+    expect(screen.getByText(/Acceso denegado/i)).toBeInTheDocument();
+  });
+
+  it('avisa cuando no hay ventas en el período', () => {
+    mockUseQuery.mockReturnValue({
+      data: datos({ clientes: [], zonas: [], totales: { clientes: 0, pedidos: 0, total: 0 } }),
+      isLoading: false,
+      error: null,
+    });
+    renderReporte();
+    expect(screen.getByText(/No hay ventas entregadas/i)).toBeInTheDocument();
+  });
+});

--- a/src/components/vistas/reportes/filtrosVentasState.ts
+++ b/src/components/vistas/reportes/filtrosVentasState.ts
@@ -1,0 +1,22 @@
+/**
+ * Estado de los filtros de las pestañas de ventas ("Por Cliente" y "Por Zona").
+ *
+ * Vive en su propio módulo y no dentro de `FiltrosVentas.tsx` porque el fast
+ * refresh de React sólo funciona si un archivo de componentes exporta
+ * únicamente componentes.
+ */
+import { presetsVentas } from '../../../utils/periodosReporte';
+
+export interface FiltrosVentasValue {
+  desde: string;
+  hasta: string;
+  preventistaId: string | null;
+  /** id de un preset de `presetsVentas`, o 'custom'. */
+  presetId: string;
+}
+
+/** Estado inicial: el año en curso, todos los preventistas. */
+export function filtrosVentasIniciales(hoy: Date = new Date()): FiltrosVentasValue {
+  const [anio] = presetsVentas(hoy);
+  return { desde: anio.desde, hasta: anio.hasta, preventistaId: null, presetId: anio.id };
+}

--- a/src/components/vistas/reportes/index.ts
+++ b/src/components/vistas/reportes/index.ts
@@ -19,3 +19,8 @@ export type { ReporteVentasZonasProps } from './ReporteVentasZonas';
 
 export { ReporteValuacionInventario } from './ReporteValuacionInventario';
 export type { ReporteValuacionInventarioProps } from './ReporteValuacionInventario';
+
+export { FiltrosVentas } from './FiltrosVentas';
+export type { FiltrosVentasProps } from './FiltrosVentas';
+export { filtrosVentasIniciales } from './filtrosVentasState';
+export type { FiltrosVentasValue } from './filtrosVentasState';

--- a/src/hooks/queries/useVentasPorClienteQuery.ts
+++ b/src/hooks/queries/useVentasPorClienteQuery.ts
@@ -1,0 +1,107 @@
+/**
+ * TanStack Query hook para el reporte de ventas por cliente y por zona (mig 197).
+ *
+ * RPC `reporte_ventas_por_cliente(p_desde, p_hasta, p_preventista_id, p_sucursal_id)`:
+ * total vendido a cada cliente en el período, con la zona que el cliente tiene
+ * en su ficha, más el mismo corte agregado por zona. Un solo viaje alimenta las
+ * dos pestañas ("Por Cliente" y "Por Zona").
+ *
+ * Criterio (vive en el RPC, ver el comentario de la migración): pedidos
+ * ENTREGADOS, por `pedidos.fecha`, atribuidos a quien los cargó
+ * (`pedidos.usuario_id`). Excluye cancelados y cambios/devoluciones.
+ *
+ * La agregación es del lado del servidor a propósito: la versión anterior la
+ * hacía en el navegador y se comía el límite de 1.000 filas de PostgREST sin
+ * avisar.
+ */
+import { useQuery } from '@tanstack/react-query'
+import { supabase } from '../../lib/supabase'
+import { useSucursal } from '../../contexts/SucursalContext'
+
+export interface VentaClienteRow {
+  /** NULL en la fila "(sin cliente asignado)": pedidos con cliente_id NULL. */
+  cliente_id: number | null
+  codigo: number | null
+  nombre: string
+  zona: string
+  pedidos: number
+  total: number
+  /** { 'YYYY-MM': total } — sólo los meses en que ese cliente compró. */
+  por_mes: Record<string, number>
+}
+
+export interface VentaZonaRow {
+  zona: string
+  clientes: number
+  pedidos: number
+  total: number
+  ticket_promedio: number
+}
+
+/**
+ * Quien cargó ventas en el período (mig 198). Sale de los datos, no de
+ * `perfiles.rol`: la venta se atribuye a `pedidos.usuario_id` y también cargan
+ * pedidos encargados y admins (Jony, encargado, lleva $16,6M en 2026). Se
+ * calcula ignorando el filtro de preventista, así que la lista no se achica al
+ * elegir a alguien.
+ */
+export interface VendedorRow {
+  id: string
+  nombre: string
+  pedidos: number
+  total: number
+}
+
+export interface VentasPorCliente {
+  meta: {
+    desde: string
+    hasta: string
+    preventista_id: string | null
+    preventista_nombre: string
+    sucursal_id: number | null
+    sucursal_nombre: string
+    generado_at: string
+    criterio: string
+  }
+  /** Meses con datos dentro del rango, ordenados: ['2026-06', '2026-07', ...] */
+  meses: string[]
+  /** Para el selector: NO se achica al filtrar por preventista. */
+  vendedores: VendedorRow[]
+  totales: { clientes: number; pedidos: number; total: number }
+  clientes: VentaClienteRow[]
+  zonas: VentaZonaRow[]
+}
+
+export const ventasPorClienteKeys = {
+  all: (sucursalId: number | null) => ['ventas-por-cliente', sucursalId] as const,
+  rango: (
+    sucursalId: number | null,
+    desde: string,
+    hasta: string,
+    preventistaId: string | null
+  ) => [...ventasPorClienteKeys.all(sucursalId), desde, hasta, preventistaId] as const,
+}
+
+export function useVentasPorClienteQuery(
+  desde: string,
+  hasta: string,
+  preventistaId: string | null = null
+) {
+  const { currentSucursalId } = useSucursal()
+
+  return useQuery({
+    queryKey: ventasPorClienteKeys.rango(currentSucursalId, desde, hasta, preventistaId),
+    queryFn: async (): Promise<VentasPorCliente> => {
+      const { data, error } = await supabase.rpc('reporte_ventas_por_cliente', {
+        p_desde: desde,
+        p_hasta: hasta,
+        p_preventista_id: preventistaId,
+        p_sucursal_id: currentSucursalId,
+      })
+      if (error) throw new Error(error.message)
+      return data as VentasPorCliente
+    },
+    enabled: !!currentSucursalId && !!desde && !!hasta,
+    staleTime: 5 * 60 * 1000,
+  })
+}

--- a/src/hooks/supabase/useReportesFinancieros.ts
+++ b/src/hooks/supabase/useReportesFinancieros.ts
@@ -5,8 +5,6 @@ import type {
   ReporteRentabilidad,
   ProductoRentabilidad,
   TotalesRentabilidad,
-  VentaPorCliente,
-  VentaPorZona,
   AgingDeuda,
   UseReportesFinancierosReturn,
   ClienteDB,
@@ -30,31 +28,8 @@ interface PedidoWithItems {
   }>;
 }
 
-interface PedidoWithCliente {
-  id: string;
-  cliente_id: string;
-  estado: string;
-  estado_pago?: string;
-  total: number;
-  created_at?: string;
-  cliente?: ClienteDB | null;
-}
-
 interface ProductoStatsMap {
   [key: string]: ProductoRentabilidad;
-}
-
-interface ClienteStatsMap {
-  [key: string]: VentaPorCliente;
-}
-
-interface ZonaStatsMap {
-  [key: string]: {
-    zona: string;
-    cantidadPedidos: number;
-    totalVentas: number;
-    clientes: Set<string>;
-  };
 }
 
 export function useReportesFinancieros(): UseReportesFinancierosReturn {
@@ -263,97 +238,10 @@ export function useReportesFinancieros(): UseReportesFinancierosReturn {
     }
   }
 
-  const generarReporteVentasPorCliente = async (
-    fechaDesde: string | null = null,
-    fechaHasta: string | null = null
-  ): Promise<VentaPorCliente[]> => {
-    setLoading(true)
-    try {
-      let query = supabase.from('pedidos').select(`*, cliente:clientes(*)`)
-      if (fechaDesde) query = query.gte('created_at', `${fechaDesde}T00:00:00`)
-      if (fechaHasta) query = query.lte('created_at', `${fechaHasta}T23:59:59`)
-
-      const { data: pedidos, error } = await query
-      if (error) throw error
-
-      const pedidosTyped = (pedidos || []) as PedidoWithCliente[]
-
-      const clienteStats: ClienteStatsMap = {}
-      pedidosTyped.forEach(p => {
-        const clienteId = p.cliente_id
-        if (!clienteStats[clienteId]) {
-          clienteStats[clienteId] = {
-            cliente: p.cliente || null,
-            cantidadPedidos: 0,
-            totalVentas: 0,
-            pedidosPagados: 0,
-            pedidosPendientes: 0
-          }
-        }
-        clienteStats[clienteId].cantidadPedidos += 1
-        clienteStats[clienteId].totalVentas += p.total || 0
-        if (p.estado_pago === 'pagado') clienteStats[clienteId].pedidosPagados += 1
-        else clienteStats[clienteId].pedidosPendientes += 1
-      })
-
-      return Object.values(clienteStats).sort((a, b) => b.totalVentas - a.totalVentas)
-    } catch {
-      return []
-    } finally {
-      setLoading(false)
-    }
-  }
-
-  const generarReporteVentasPorZona = async (
-    fechaDesde: string | null = null,
-    fechaHasta: string | null = null
-  ): Promise<VentaPorZona[]> => {
-    setLoading(true)
-    try {
-      let query = supabase.from('pedidos').select(`*, cliente:clientes(*)`)
-      if (fechaDesde) query = query.gte('created_at', `${fechaDesde}T00:00:00`)
-      if (fechaHasta) query = query.lte('created_at', `${fechaHasta}T23:59:59`)
-
-      const { data: pedidos, error } = await query
-      if (error) throw error
-
-      const pedidosTyped = (pedidos || []) as PedidoWithCliente[]
-
-      const zonaStats: ZonaStatsMap = {}
-      pedidosTyped.forEach(p => {
-        const zona = p.cliente?.zona || 'Sin zona'
-        if (!zonaStats[zona]) {
-          zonaStats[zona] = {
-            zona,
-            cantidadPedidos: 0,
-            totalVentas: 0,
-            clientes: new Set<string>()
-          }
-        }
-        zonaStats[zona].cantidadPedidos += 1
-        zonaStats[zona].totalVentas += p.total || 0
-        zonaStats[zona].clientes.add(p.cliente_id)
-      })
-
-      return Object.values(zonaStats).map(z => ({
-        zona: z.zona,
-        cantidadPedidos: z.cantidadPedidos,
-        totalVentas: z.totalVentas,
-        cantidadClientes: z.clientes.size,
-        ticketPromedio: z.cantidadPedidos > 0 ? z.totalVentas / z.cantidadPedidos : 0
-      })).sort((a, b) => b.totalVentas - a.totalVentas)
-    } catch {
-      return []
-    } finally {
-      setLoading(false)
-    }
-  }
 
   return {
     loading,
     generarReporteCuentasPorCobrar,
-    generarReporteRentabilidad,
-    generarReporteVentasPorCliente,
-    generarReporteVentasPorZona
+    generarReporteRentabilidad
   }
 }

--- a/src/types/hooks.ts
+++ b/src/types/hooks.ts
@@ -1389,28 +1389,14 @@ export interface ReporteRentabilidad {
   totales: TotalesRentabilidad;
 }
 
-export interface VentaPorCliente {
-  cliente: ClienteDB | null;
-  cantidadPedidos: number;
-  totalVentas: number;
-  pedidosPagados: number;
-  pedidosPendientes: number;
-}
-
-export interface VentaPorZona {
-  zona: string;
-  cantidadPedidos: number;
-  totalVentas: number;
-  cantidadClientes: number;
-  ticketPromedio: number;
-}
+// Las ventas por cliente y por zona ya no se agregan en el navegador: salen del
+// RPC `reporte_ventas_por_cliente` (mig 197). Sus tipos viven en
+// `hooks/queries/useVentasPorClienteQuery.ts`.
 
 export interface UseReportesFinancierosReturn {
   loading: boolean;
   generarReporteCuentasPorCobrar: () => Promise<ReporteCuentaPorCobrar[]>;
   generarReporteRentabilidad: (fechaDesde?: string | null, fechaHasta?: string | null) => Promise<ReporteRentabilidad>;
-  generarReporteVentasPorCliente: (fechaDesde?: string | null, fechaHasta?: string | null) => Promise<VentaPorCliente[]>;
-  generarReporteVentasPorZona: (fechaDesde?: string | null, fechaHasta?: string | null) => Promise<VentaPorZona[]>;
 }
 
 // =============================================================================

--- a/src/utils/periodosReporte.test.ts
+++ b/src/utils/periodosReporte.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect } from 'vitest'
+import {
+  presetAnio,
+  presetMes,
+  presetsVentas,
+  labelMes,
+  ultimoDiaDelMes,
+} from './periodosReporte'
+
+// 20/08/2026, que es el día en que se pidió el informe.
+const HOY = new Date(2026, 7, 20)
+
+describe('presetMes', () => {
+  it('el mes en curso corta HOY, no a fin de mes', () => {
+    expect(presetMes(0, HOY)).toEqual({
+      id: 'mes-2026-08',
+      label: 'Agosto 2026 (en curso)',
+      desde: '2026-08-01',
+      hasta: '2026-08-20',
+    })
+  })
+
+  it('los meses cerrados van del 1 al último día', () => {
+    expect(presetMes(1, HOY)).toEqual({
+      id: 'mes-2026-07',
+      label: 'Julio 2026',
+      desde: '2026-07-01',
+      hasta: '2026-07-31',
+    })
+    expect(presetMes(2, HOY)).toEqual({
+      id: 'mes-2026-06',
+      label: 'Junio 2026',
+      desde: '2026-06-01',
+      hasta: '2026-06-30',
+    })
+  })
+
+  it('cruza el año hacia atrás sin romperse', () => {
+    const enero = new Date(2026, 0, 15)
+    expect(presetMes(1, enero)).toMatchObject({
+      label: 'Diciembre 2025',
+      desde: '2025-12-01',
+      hasta: '2025-12-31',
+    })
+    expect(presetMes(2, enero)).toMatchObject({
+      label: 'Noviembre 2025',
+      desde: '2025-11-01',
+      hasta: '2025-11-30',
+    })
+  })
+
+  it('febrero bisiesto termina el 29', () => {
+    expect(presetMes(1, new Date(2028, 2, 10)).hasta).toBe('2028-02-29')
+    expect(presetMes(1, new Date(2027, 2, 10)).hasta).toBe('2027-02-28')
+  })
+
+  it('a primera hora del día la fecha no se corre para atrás', () => {
+    // El bug clásico de toISOString() en UTC-3: 00:30 local del 20/08 es
+    // 03:30 UTC del 20/08 en Argentina, pero en zonas al este daría el 19.
+    // Con componentes locales siempre es el día que marca el reloj.
+    const madrugada = new Date(2026, 7, 20, 0, 30)
+    expect(presetMes(0, madrugada).hasta).toBe('2026-08-20')
+  })
+})
+
+describe('presetAnio', () => {
+  it('va del 1 de enero a hoy', () => {
+    expect(presetAnio(HOY)).toEqual({
+      id: 'anio-2026',
+      label: 'Año 2026',
+      desde: '2026-01-01',
+      hasta: '2026-08-20',
+    })
+  })
+})
+
+describe('presetsVentas', () => {
+  it('ofrece el año y los tres últimos meses, del más nuevo al más viejo', () => {
+    expect(presetsVentas(HOY).map((p) => p.label)).toEqual([
+      'Año 2026',
+      'Agosto 2026 (en curso)',
+      'Julio 2026',
+      'Junio 2026',
+    ])
+  })
+
+  it('los ids son únicos (se usan como key de React)', () => {
+    const ids = presetsVentas(HOY).map((p) => p.id)
+    expect(new Set(ids).size).toBe(ids.length)
+  })
+})
+
+describe('ultimoDiaDelMes', () => {
+  it('resuelve diciembre sin desbordar el año', () => {
+    expect(ultimoDiaDelMes(2026, 11)).toBe(31)
+  })
+})
+
+describe('labelMes', () => {
+  it('abrevia la clave YYYY-MM que devuelve el RPC', () => {
+    expect(labelMes('2026-06')).toBe('Jun 26')
+    expect(labelMes('2026-12')).toBe('Dic 26')
+  })
+
+  it('devuelve la clave tal cual si no la entiende', () => {
+    expect(labelMes('cualquier-cosa')).toBe('cualquier-cosa')
+  })
+})

--- a/src/utils/periodosReporte.ts
+++ b/src/utils/periodosReporte.ts
@@ -1,0 +1,84 @@
+/**
+ * Atajos de período para el reporte de ventas por cliente/zona.
+ *
+ * Se calculan contra la fecha de hoy en hora local, no hardcodeados: el mes en
+ * curso y los dos anteriores, más el acumulado del año.
+ *
+ * Todo en componentes locales (getFullYear/getMonth/getDate) a propósito. Usar
+ * toISOString() acá correría la fecha un día para atrás en Argentina (UTC-3)
+ * durante las primeras 3 horas del día.
+ */
+
+export interface PeriodoPreset {
+  /** Estable, sirve de key de React y de valor del <select>. */
+  id: string
+  /** "Julio 2026", "Agosto 2026 (en curso)", "Año 2026". */
+  label: string
+  /** 'YYYY-MM-DD' */
+  desde: string
+  /** 'YYYY-MM-DD' */
+  hasta: string
+}
+
+const MESES = [
+  'Enero', 'Febrero', 'Marzo', 'Abril', 'Mayo', 'Junio',
+  'Julio', 'Agosto', 'Septiembre', 'Octubre', 'Noviembre', 'Diciembre',
+]
+
+function iso(anio: number, mes0: number, dia: number): string {
+  return `${anio}-${String(mes0 + 1).padStart(2, '0')}-${String(dia).padStart(2, '0')}`
+}
+
+/** Último día del mes `mes0` (0-11) de `anio`. */
+export function ultimoDiaDelMes(anio: number, mes0: number): number {
+  // El día 0 del mes siguiente es el último del actual, y el constructor
+  // normaliza mes0 = 12 al enero del año siguiente.
+  return new Date(anio, mes0 + 1, 0).getDate()
+}
+
+/**
+ * Preset del mes calendario que está `atras` meses antes del de `hoy`
+ * (0 = mes en curso). El mes en curso corta en el día de hoy, no a fin de mes:
+ * pedir hasta el 31 cuando estamos a 20 no cambia el número pero hace creer que
+ * el período está cerrado.
+ */
+export function presetMes(atras: number, hoy: Date = new Date()): PeriodoPreset {
+  const ref = new Date(hoy.getFullYear(), hoy.getMonth() - atras, 1)
+  const anio = ref.getFullYear()
+  const mes0 = ref.getMonth()
+  const enCurso = atras === 0
+
+  return {
+    id: `mes-${anio}-${String(mes0 + 1).padStart(2, '0')}`,
+    label: `${MESES[mes0]} ${anio}${enCurso ? ' (en curso)' : ''}`,
+    desde: iso(anio, mes0, 1),
+    hasta: enCurso ? iso(anio, mes0, hoy.getDate()) : iso(anio, mes0, ultimoDiaDelMes(anio, mes0)),
+  }
+}
+
+/** Del 1 de enero al día de hoy. */
+export function presetAnio(hoy: Date = new Date()): PeriodoPreset {
+  const anio = hoy.getFullYear()
+  return {
+    id: `anio-${anio}`,
+    label: `Año ${anio}`,
+    desde: iso(anio, 0, 1),
+    hasta: iso(anio, hoy.getMonth(), hoy.getDate()),
+  }
+}
+
+/**
+ * Los atajos que se ofrecen en el reporte: el año en curso y los últimos tres
+ * meses calendario (el actual y los dos cerrados anteriores).
+ */
+export function presetsVentas(hoy: Date = new Date()): PeriodoPreset[] {
+  return [presetAnio(hoy), presetMes(0, hoy), presetMes(1, hoy), presetMes(2, hoy)]
+}
+
+/** Etiqueta legible de una clave 'YYYY-MM' que devuelve el RPC. */
+export function labelMes(clave: string): string {
+  const [a, m] = clave.split('-')
+  const mes0 = Number(m) - 1
+  if (!MESES[mes0]) return clave
+  return `${MESES[mes0].slice(0, 3)} ${a.slice(2)}`
+}


### PR DESCRIPTION
## Qué pidió Jorge

> Necesito saber todas las ventas de Cristian desde principio de año por cliente. No el detalle sino el total por cada cliente. Para ver a quiénes le vendió. **NECESITO QUE AL LADO DE CADA CLIENTE SALGA A QUÉ ZONA PERTENECE SEGÚN LA CLASIFICACIÓN QUE TIENE EN LA FICHA.** Y si es posible el mismo informe, pero por separado del último y del penúltimo mes. Y después agregá ese informe en la App.

El Excel ya se entregó aparte. Este PR es la parte "en la App".

## La pestaña que ya existía no servía, y además mentía

`Reportes → Por Cliente` agregaba en el navegador con `from('pedidos').select('*, cliente:clientes(*)')`, sin filtro de estado y sin paginar:

- sumaba pedidos **cancelados** (284 en lo que va de 2026);
- **se cortaba en las 1.000 filas** del default de PostgREST habiendo **4.558 entregados** este año → el total que mostraba estaba mal, en silencio y sin ningún cartel;
- filtraba por `created_at` en vez de `pedidos.fecha`, que es la base que usan `bot_mis_ventas` y `reporte_gerencial`;
- y la tabla encima hacía `slice(0, 30)`.

Los cuatro se cierran moviendo la agregación a un RPC. `Por Zona` tenía los mismos dos primeros y sale gratis: consume el mismo payload con la misma query key.

## Qué queda

Selector de **vendedor**, atajos de período (Año / los 3 últimos meses / Personalizado), columna **Zona (ficha)**, desglose por mes opcional y **Exportar a Excel** (hoja por cliente + hoja por zona).

## Tres definiciones de negocio, escritas en la migración

- **La venta se atribuye a `pedidos.usuario_id`** (quién la cargó), no a `clientes.preventista_id`. Es lo que se pidió y la convención vigente de `bot_mis_ventas`. Por el otro criterio Christian daría $37,2M en vez de $40,2M **y 891 pedidos ($48,9M) no serían de nadie**, porque esos clientes no tienen preventista asignado.
- **`LEFT JOIN clientes`, con fila `(sin cliente asignado)`.** Hay **7 entregados en 2026 con `cliente_id` NULL** ($200.070; 3 de Christian, $83.750). No son FKs rotas. Con `INNER JOIN` desaparecían y el informe cerraba por debajo del total de ventas sin avisar.
- **La zona sale de `zona_id → zonas.nombre`**, con el texto libre `clientes.zona` (marcado `@deprecated`) sólo como fallback. Hoy están 100% sincronizados (459/459).

## El agujero que apareció al cablear el front (mig 198)

El selector iba a listar `perfiles.rol = 'preventista'`. Pero la venta se atribuye a `usuario_id`, y **quien carga pedidos no es sólo quien tiene ese rol**:

| | rol | pedidos | total 2026 |
|---|---|---|---|
| Juan | preventista | 912 | $45.796.256 |
| Christian | preventista | 1.164 | $40.198.490 |
| Osvaldo | preventista | 1.035 | $30.427.603 |
| Marcelo | preventista | 787 | $24.452.008 |
| **Jony** | **encargado** | 287 | **$16.630.570** ← no entraba |
| Nacho R / Virginia H / Agustín / Pablo / Emilia H / Julio | admin | 372 | $16.197.850 ← tampoco |

Un desplegable por rol escondía **$32,8M de venta real** y no había forma de pedirle al reporte las ventas de Jony — la misma familia de bug que este trabajo vino a cerrar. La lista ahora sale de los **datos**: quien tenga una entrega en el período aparece, sea cual sea su rol hoy. Se calcula **ignorando** el filtro de vendedor, para que elegir a alguien no deje el desplegable con una sola opción.

## Verificación

Cuadre contra prod, exacto contra la consulta cruda en los tres casos:

| caso | clientes | pedidos | total |
|---|---|---|---|
| Christian 2026 | 151 | 1.164 | $40.198.490,26 |
| Sin filtro, sucursal 1 | 512 | 3.323 | $109.527.872,17 |
| Sin filtro, consolidado | 643 | 4.558 | $173.778.279,13 |

Y por mes: junio $10.836.830,10 · julio $7.333.180,06 · agosto $3.929.400,00.

ACL de la función: `postgres`, `authenticated`, `service_role` — **sin PUBLIC ni anon**, con verificación fail-closed dentro de la misma transacción de cada migración.

`typecheck`, `lint`, **1.206 tests** y `build` en verde. 32 tests nuevos. Verifiqué que no pasan en vacío: reintroduje el `slice(0, 30)` a propósito y falla exactamente el test que debe fallar.

**No verificado:** la pantalla en el navegador. La sesión del preview está logueada como transportista y `/reportes` es admin-only; queda cubierto por tests de componente sobre el render real, pero conviene una mirada humana antes de mergear.

## Migraciones

`197` y `198` **ya aplicadas a prod**, con el `name` del ledger igual al nombre del archivo (sin excepción que documentar en el MANIFEST).

> **Ojo, no es de este PR:** el drift-check ya está rojo en `main` por las migs **192–196** (motor de compras), aplicadas en prod desde otra rama cuyos archivos todavía no se mergearon. Se resuelve cuando entre ese PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
