### PR TITLE
La ficha de producto ya no pisa el stock con un valor viejo

### DIFF
--- a/src/components/containers/ProductosContainer.tsx
+++ b/src/components/containers/ProductosContainer.tsx
@@ -321,7 +321,10 @@ export default function ProductosContainer(): React.ReactElement {
       setModalProductoOpen(false)
       setProductoEditando(null)
     } catch (error) {
-      notify.error('Error al guardar producto')
+      // El mensaje real importa: si el compare-and-swap del stock rechazó el
+      // guardado, dice cuánto hay ahora y qué hacer. Un "Error al guardar"
+      // genérico dejaba al admin sin saber que su ajuste no se aplicó.
+      notify.error(error instanceof Error ? error.message : 'Error al guardar producto')
       throw error
     }
   }, [productoEditando, actualizarProducto, crearProducto, notify])

--- a/src/components/modals/ModalProducto.stock.test.tsx
+++ b/src/components/modals/ModalProducto.stock.test.tsx
@@ -1,0 +1,147 @@
+/**
+ * La ficha de producto y el stock: qué manda y qué NO.
+ *
+ * EL INCIDENTE (Taco Pozo, 19/08/2026 — COCA COLA X 3LTS X 6UND)
+ * -------------------------------------------------------------
+ * El admin cargó la compra de 20 unidades (6 → 26). El preventista vendió las
+ * 20 en los cuatro pedidos de los ONE BLOCK y el stock volvió a 6. Correcto.
+ * 29 segundos después el admin guardó la ficha, que seguía abierta con el
+ * snapshot viejo, y el form mandó `stock: 26` como valor absoluto: las 20
+ * unidades vendidas reaparecieron. El admin las siguió viendo en stock sin
+ * entender por qué. (De regalo se revirtió el precio, por el mismo snapshot.)
+ *
+ * El stock no es un campo de la ficha: es un saldo que mueven los pedidos y
+ * las compras mientras el modal está abierto. Lo que se fija acá es que solo
+ * viaje cuando el admin lo edita a mano, y que cuando viaja lleve el valor
+ * esperado para que el update pueda abortar en vez de pisar.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import ModalProducto from './ModalProducto'
+import type { ProductoDB } from '../../types'
+
+vi.mock('../../hooks/queries', () => ({
+  useMarcasQuery: () => ({ data: [] }),
+}))
+
+// Solo se monta en edición y arrastra la query de grupos de precio.
+vi.mock('../productos/ProductoCondicionesMayoristas', () => ({
+  default: () => null,
+}))
+
+const COCA: ProductoDB = {
+  id: '340',
+  nombre: 'COCA COLA X 3LTS X 6UND',
+  precio: 26700,
+  stock: 26,
+  stock_minimo: 10,
+  categoria: 'GASEOSAS',
+  costo_sin_iva: 24300,
+  porcentaje_iva: 21,
+  condicion_iva: 'gravado',
+} as unknown as ProductoDB
+
+function renderFicha(producto: ProductoDB | null = COCA) {
+  const onSave = vi.fn()
+  render(
+    <ModalProducto
+      producto={producto}
+      categorias={['GASEOSAS']}
+      proveedores={[]}
+      onSave={onSave}
+      onClose={vi.fn()}
+      guardando={false}
+      esAdmin
+    />,
+  )
+  return { onSave }
+}
+
+const guardar = () => screen.getByRole('button', { name: /Guardar/ })
+
+/**
+ * Los `<label>` de la ficha no están asociados a su input (sin `htmlFor`), así
+ * que `getByLabelText` no los encuentra: se busca el label por texto exacto y
+ * se baja al input de su mismo bloque.
+ */
+function campo(textoLabel: RegExp): HTMLInputElement {
+  const label = screen.getByText(textoLabel, { selector: 'label' })
+  const input = label.parentElement?.querySelector('input')
+  if (!input) throw new Error(`No hay input para el label ${textoLabel}`)
+  return input as HTMLInputElement
+}
+
+const campoStock = () => campo(/^Stock \*$/)
+const campoPrecio = () => campo(/^Precio Final/)
+const campoNombre = () => campo(/^Nombre \*$/)
+
+describe('ModalProducto — el stock solo viaja si lo tocaste', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('editar el precio no manda el stock (el saldo queda como está en la base)', async () => {
+    const { onSave } = renderFicha()
+
+    const precio = campoPrecio()
+    await userEvent.clear(precio)
+    await userEvent.type(precio, '25500')
+    await userEvent.click(guardar())
+
+    expect(onSave).toHaveBeenCalledTimes(1)
+    const payload = onSave.mock.calls[0][0]
+    expect(payload.stock).toBeUndefined()
+    expect(payload.stock_esperado).toBeUndefined()
+    expect(Number(payload.precio)).toBe(25500)
+  })
+
+  it('cambiar el stock a mano lo manda con el valor esperado (compare-and-swap)', async () => {
+    const { onSave } = renderFicha()
+
+    await userEvent.clear(campoStock())
+    await userEvent.type(campoStock(), '30')
+    await userEvent.click(guardar())
+
+    expect(onSave).toHaveBeenCalledTimes(1)
+    const payload = onSave.mock.calls[0][0]
+    expect(Number(payload.stock)).toBe(30)
+    expect(payload.stock_esperado).toBe(26)
+  })
+
+  it('reescribir el mismo número no cuenta como ajuste', async () => {
+    const { onSave } = renderFicha()
+
+    await userEvent.clear(campoStock())
+    await userEvent.type(campoStock(), '26')
+    await userEvent.click(guardar())
+
+    const payload = onSave.mock.calls[0][0]
+    expect(payload.stock).toBeUndefined()
+    expect(payload.stock_esperado).toBeUndefined()
+  })
+
+  it('en el alta el stock sí es un campo del form: viaja siempre y sin CAS', async () => {
+    const { onSave } = renderFicha(null)
+
+    await userEvent.type(campoNombre(), 'AGUA ECO 2LTS X 6UND')
+    const precio = campoPrecio()
+    await userEvent.clear(precio)
+    await userEvent.type(precio, '9000')
+    await userEvent.clear(campoStock())
+    await userEvent.type(campoStock(), '12')
+    await userEvent.click(guardar())
+
+    expect(onSave).toHaveBeenCalledTimes(1)
+    const payload = onSave.mock.calls[0][0]
+    expect(Number(payload.stock)).toBe(12)
+    expect(payload.stock_esperado).toBeUndefined()
+  })
+
+  it('avisa que la ficha no mueve el saldo, y describe el ajuste cuando lo hay', async () => {
+    renderFicha()
+    expect(screen.getByText(/Lo mueven solos las compras y los pedidos/i)).toBeInTheDocument()
+
+    await userEvent.clear(campoStock())
+    await userEvent.type(campoStock(), '30')
+    expect(screen.getByText(/Ajuste manual: 26 → 30/)).toBeInTheDocument()
+  })
+})

--- a/src/components/modals/ModalProducto.tsx
+++ b/src/components/modals/ModalProducto.tsx
@@ -34,7 +34,13 @@ export interface ProductoFormData {
   /** FK a `marcas` (mig 158). '' = sin marca. Ortogonal a la categoría. */
   marca_id?: string | null;
   proveedor_id: string;
-  stock: number | string;
+  /**
+   * Saldo de stock. Opcional porque en una edición se OMITE si el admin no lo
+   * tocó: `undefined` llega al update como "no tocar este campo".
+   */
+  stock?: number | string;
+  /** Stock que la ficha vio al abrirse; viaja solo si el admin lo cambió (CAS). */
+  stock_esperado?: number;
   stock_minimo: number;
   /**
    * Mínimo de unidades que hay que pedir de este producto (mig 147).
@@ -280,6 +286,13 @@ const ModalProducto = memo(function ModalProducto({ producto, categorias, provee
     }
   };
 
+  // ── Stock: saldo vivo, no campo del form ─────────────────────────────────
+  // Lo mueven los pedidos y las compras mientras la ficha está abierta. Se
+  // manda SOLO si el admin lo cambió a mano, y con el valor que vio al abrir.
+  const esEdicion = Boolean(producto);
+  const stockOriginal = Number(producto?.stock ?? 0);
+  const stockCambiado = esEdicion && Number(form.stock) !== stockOriginal;
+
   const handleSubmit = (): void => {
     // La etiqueta es accesoria al fardo: sin unidades configuradas no tiene
     // sentido persistirla. Normalizar acá hace de defensa en profundidad por
@@ -317,6 +330,16 @@ const ModalProducto = memo(function ModalProducto({ producto, categorias, provee
         id: producto?.id,
         costo_real: costoReal > 0 ? costoReal : null,
         ...(cppCorregido !== undefined ? { costo_promedio: cppCorregido } : {}),
+        // El stock es un saldo vivo, no un campo de la ficha: entre que se
+        // abre el modal y se guarda, el preventista pudo haber vendido. Si el
+        // admin no lo tocó, no viaja (undefined = "no tocar"). Si lo tocó,
+        // viaja con el valor esperado para que el update aborte si el saldo
+        // cambió en el medio, en vez de pisar las ventas.
+        ...(esEdicion
+          ? (stockCambiado
+              ? { stock_esperado: stockOriginal }
+              : { stock: undefined })
+          : {}),
       });
       return;
     }
@@ -359,6 +382,13 @@ const ModalProducto = memo(function ModalProducto({ producto, categorias, provee
               className={inputClass('stock')}
             />
             {errores.stock && <p className="text-red-500 text-xs mt-1">{errores.stock}</p>}
+            {esEdicion && (
+              <p className="text-xs text-gray-500 mt-1">
+                {stockCambiado
+                  ? `Ajuste manual: ${stockOriginal} → ${Number(form.stock) || 0}. Si entra una venta antes de guardar, el ajuste se rechaza y hay que rehacerlo.`
+                  : 'Lo mueven solos las compras y los pedidos. Guardar la ficha no lo toca salvo que lo edites acá.'}
+              </p>
+            )}
           </div>
         </div>
 

--- a/src/hooks/queries/useActualizarProductoMutation.stock.test.tsx
+++ b/src/hooks/queries/useActualizarProductoMutation.stock.test.tsx
@@ -1,0 +1,149 @@
+/**
+ * Tests del contrato de stock al guardar la ficha de producto.
+ *
+ * EL INCIDENTE (Taco Pozo, 19/08/2026 — producto 340, COCA COLA X 3LTS)
+ * ---------------------------------------------------------------------
+ * El admin registró la compra de 20 unidades (stock 6 → 26). En los 90
+ * segundos siguientes el preventista cargó los cuatro pedidos de los ONE
+ * BLOCK: 5 + 5 + 5 + 5 = las 20 unidades, y el stock volvió a 6. Correcto.
+ *
+ * 29 segundos después, el admin guardó la ficha del producto — que seguía
+ * abierta con el snapshot anterior a los pedidos. El form mandó `stock: 26`
+ * como valor ABSOLUTO y el `UPDATE` lo escribió tal cual: 6 → 26. Las 20
+ * unidades vendidas reaparecieron en stock y nadie vio un error. De yapa se
+ * revirtió el precio (26700 → 25500 → 26700), porque el snapshot también era
+ * viejo. En `stock_historico` quedó como `origen='auto'`, sin usuario: un
+ * movimiento fantasma imposible de rastrear desde la app.
+ *
+ * DOS GUARDAS, que es lo que fijan estos tests:
+ *   1. En una edición el stock viaja SOLO si el admin lo cambió a mano
+ *      (`undefined` = "no tocar"). Guardar un precio no toca el saldo.
+ *   2. Cuando sí viaja, va con `stock_esperado` y el update filtra por él
+ *      (compare-and-swap). Si entró una venta en el medio no matchea ninguna
+ *      fila y se aborta con un mensaje, en vez de pisar en silencio.
+ */
+import React from 'react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+
+/** Espía del builder de PostgREST: registra los `.eq()` y el payload. */
+interface UpdateCall {
+  payload: Record<string, unknown>
+  eqs: Array<[string, unknown]>
+}
+
+const updateCalls: UpdateCall[] = []
+/** Fila que devuelve el update; null simula "0 filas" (el CAS no matcheó). */
+let updateResult: { stock: number } | null = { stock: 0 }
+/** Stock que devuelve la relectura posterior al fallo del CAS. */
+let stockActualEnBase: number | null = 26
+
+vi.mock('../supabase/base', () => ({
+  supabase: {
+    rpc: vi.fn(),
+    from: () => ({
+      update: (payload: Record<string, unknown>) => {
+        const call: UpdateCall = { payload, eqs: [] }
+        updateCalls.push(call)
+        const builder = {
+          eq: (col: string, val: unknown) => {
+            call.eqs.push([col, val])
+            return builder
+          },
+          select: () => builder,
+          maybeSingle: async () => ({ data: updateResult, error: null }),
+        }
+        return builder
+      },
+      // Relectura del stock actual cuando el CAS no matchea.
+      select: () => {
+        const builder = {
+          eq: () => builder,
+          maybeSingle: async () => ({
+            data: stockActualEnBase === null ? null : { stock: stockActualEnBase },
+            error: null,
+          }),
+        }
+        return builder
+      },
+    }),
+  },
+}))
+
+vi.mock('../../contexts/SucursalContext', () => ({
+  useSucursal: () => ({ currentSucursalId: 2 }),
+}))
+
+import { useActualizarProductoMutation } from './useProductosQuery'
+
+function makeWrapper(qc: QueryClient) {
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return <QueryClientProvider client={qc}>{children}</QueryClientProvider>
+  }
+}
+
+function setup() {
+  const qc = new QueryClient({ defaultOptions: { mutations: { retry: false } } })
+  return renderHook(() => useActualizarProductoMutation(), { wrapper: makeWrapper(qc) })
+}
+
+describe('guardar la ficha de producto — contrato de stock', () => {
+  beforeEach(() => {
+    updateCalls.length = 0
+    updateResult = { stock: 0 }
+    stockActualEnBase = 26
+  })
+
+  it('sin stock en el payload no escribe la columna (guardar un precio no toca el saldo)', async () => {
+    const { result } = setup()
+
+    await result.current.mutateAsync({
+      id: '340',
+      data: { nombre: 'COCA COLA X 3LTS X 6UND', precio: 26700, stock: undefined },
+    })
+
+    await waitFor(() => expect(updateCalls).toHaveLength(1))
+    expect(updateCalls[0].payload).not.toHaveProperty('stock')
+    expect(updateCalls[0].payload.precio).toBe(26700)
+    // Sin CAS: el único filtro es el id.
+    expect(updateCalls[0].eqs).toEqual([['id', '340']])
+  })
+
+  it('con stock y stock_esperado filtra por el saldo esperado (compare-and-swap)', async () => {
+    const { result } = setup()
+
+    await result.current.mutateAsync({
+      id: '340',
+      data: { stock: 30, stock_esperado: 26 },
+    })
+
+    await waitFor(() => expect(updateCalls).toHaveLength(1))
+    expect(updateCalls[0].payload.stock).toBe(30)
+    // `stock_esperado` es del protocolo, no una columna: no se escribe.
+    expect(updateCalls[0].payload).not.toHaveProperty('stock_esperado')
+    expect(updateCalls[0].eqs).toEqual([
+      ['id', '340'],
+      ['stock', 26],
+    ])
+  })
+
+  it('si el saldo cambió en el medio aborta con el valor real, sin pisar nada', async () => {
+    updateResult = null // el CAS no matcheó ninguna fila
+    stockActualEnBase = 6 // el preventista vendió las 20 mientras la ficha estaba abierta
+    const { result } = setup()
+
+    await expect(
+      result.current.mutateAsync({ id: '340', data: { stock: 26, stock_esperado: 26 } }),
+    ).rejects.toThrow(/ahora hay 6.*ten[ií]a 26/s)
+  })
+
+  it('sin CAS, 0 filas es "no existe o no tenés permiso", no un falso conflicto de stock', async () => {
+    updateResult = null
+    const { result } = setup()
+
+    await expect(
+      result.current.mutateAsync({ id: '999', data: { precio: 100 } }),
+    ).rejects.toThrow(/no existe o no ten[eé]s permiso/)
+  })
+})

--- a/src/hooks/queries/useProductosQuery.ts
+++ b/src/hooks/queries/useProductosQuery.ts
@@ -100,7 +100,8 @@ async function createProducto(producto: ProductoFormInput, sucursalId: number | 
       nombre: producto.nombre,
       codigo: producto.codigo || null,
       precio: producto.precio,
-      stock: producto.stock,
+      // El alta sí fija el saldo inicial (en la edición `stock` es opcional).
+      stock: producto.stock ?? 0,
       stock_minimo: producto.stock_minimo ?? 10,
       // Mínimo de venta (mig 147): distinto de stock_minimo. null = sin mínimo.
       cantidad_minima_venta: producto.cantidad_minima_venta ?? null,
@@ -169,14 +170,43 @@ async function updateProducto({ id, data: producto }: { id: string; data: Partia
     updateData.etiqueta_bulto = producto.etiqueta_bulto || null
   }
 
-  const { data, error } = await supabase
+  let query = supabase
     .from('productos')
     .update(updateData)
     .eq('id', id)
-    .select()
-    .single()
+
+  // Compare-and-swap sobre el stock. El saldo NO es un campo del form: lo
+  // mueven los pedidos del preventista y las compras mientras la ficha está
+  // abierta. Sin esta guarda, guardar la ficha lo reescribía con el valor que
+  // tenía al abrirla y borraba las ventas del medio — pasó en prod (Taco Pozo,
+  // 19/08: 20 unidades vendidas a los ONE BLOCK reaparecieron en stock 29
+  // segundos después). Si el saldo ya no es el esperado, el update no matchea
+  // ninguna fila y abortamos con un mensaje, en vez de pisar en silencio.
+  const conCas = producto.stock !== undefined && producto.stock_esperado !== undefined
+  if (conCas) {
+    query = query.eq('stock', producto.stock_esperado as number)
+  }
+
+  const { data, error } = await query.select().maybeSingle()
 
   if (error) throw error
+  if (!data) {
+    if (conCas) {
+      const { data: actual } = await supabase
+        .from('productos')
+        .select('stock')
+        .eq('id', id)
+        .maybeSingle()
+      if (actual) {
+        throw new Error(
+          `El stock cambió mientras editabas: ahora hay ${actual.stock} y la ficha ` +
+          `tenía ${producto.stock_esperado}. Cerrá la ficha, abrila de nuevo y ` +
+          `volvé a cargar el ajuste. No se guardó nada.`
+        )
+      }
+    }
+    throw new Error('No se pudo actualizar el producto: no existe o no tenés permiso.')
+  }
   return data as ProductoDB
 }
 
@@ -279,10 +309,16 @@ export function useActualizarProductoMutation() {
 
       const previousProductos = queryClient.getQueryData<ProductoDB[]>(productosKeys.lists(currentSucursalId))
 
-      // Aplicar cambios optimistamente
+      // Aplicar cambios optimistamente. Se filtran las claves `undefined`
+      // ("no tocar") para no blanquear el campo en el cache — el caso vivo es
+      // `stock`, que la ficha omite cuando el admin no lo editó. Y
+      // `stock_esperado` es del protocolo del update, no una columna.
+      const cambios = Object.fromEntries(
+        Object.entries(producto).filter(([k, v]) => v !== undefined && k !== 'stock_esperado')
+      )
       queryClient.setQueryData<ProductoDB[]>(productosKeys.lists(currentSucursalId), (old) => {
         if (!old) return old
-        return old.map(p => p.id === id ? { ...p, ...producto } as ProductoDB : p)
+        return old.map(p => p.id === id ? { ...p, ...cambios } as ProductoDB : p)
       })
 
       return { previousProductos }

--- a/src/types/hooks.ts
+++ b/src/types/hooks.ts
@@ -331,7 +331,18 @@ export interface ProductoFormInput {
   codigo?: string;
   nombre: string;
   precio: number;
-  stock: number;
+  /**
+   * Saldo de stock. En una EDICIÓN es opcional a propósito: `undefined` =
+   * "no tocar". La ficha solo lo manda si el admin lo cambió a mano; el resto
+   * del tiempo el saldo lo mueven los pedidos y las compras.
+   */
+  stock?: number;
+  /**
+   * Stock que la ficha vio al abrirse. Viaja junto a `stock` en las ediciones
+   * y hace de compare-and-swap: si el saldo cambió en el medio, el update no
+   * matchea ninguna fila y se aborta en vez de pisar lo que pasó mientras tanto.
+   */
+  stock_esperado?: number;
   stock_minimo?: number;
   categoria?: string;
   /** FK a `marcas` (mig 158). null / '' = sin marca. */


### PR DESCRIPTION
Taco Pozo, 19/08: el admin cargo la compra de 20 COCA COLA 3LTS (stock
6 -> 26), el preventista vendio las 20 en los cuatro pedidos de los ONE
BLOCK (26 -> 6) y 29 segundos despues el admin guardo la ficha del
producto, que seguia abierta con el snapshot anterior a los pedidos. El
form mandaba `stock: 26` como valor ABSOLUTO y el UPDATE lo escribia tal
cual: las 20 unidades vendidas reaparecieron en stock. Nadie vio un
error. El mismo snapshot viejo revirtio el precio (26700 -> 25500 ->
26700). En stock_historico quedo como origen='auto' y usuario NULL.

El stock no es un campo del form: es un saldo que mueven los pedidos y
las compras mientras el modal esta abierto. Dos guardas:

- En una edicion el stock viaja SOLO si el admin lo cambio a mano.
  `undefined` = "no tocar", que es lo que updateProducto ya entendia para
  el resto de los campos. Guardar un precio deja de tocar el saldo.
- Cuando si viaja, va con `stock_esperado` y el update filtra por el
  (compare-and-swap). Si entro una venta en el medio no matchea ninguna
  fila y aborta con el saldo real, en vez de pisar en silencio.

De paso, dos cosas que hacian falta para que la guarda se note: el
container mostraba "Error al guardar producto" y se comia el mensaje que
explica que paso, y el optimistic update metia el `stock: undefined` en
el cache de la lista.

Los tests de ModalProducto fallan sin la primera guarda; los de la
mutation, sin la segunda.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01HDfSZDGCzWExkfqLGTXBz7