### PR TITLE
Poner la documentacion al dia con el codigo que quedo

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@ npm ci                 # los worktrees nacen sin node_modules — ver Trampas
 npm run dev            # Vite
 npm run typecheck      # tsc --noEmit
 npm run lint           # eslint
-npm run test:run       # vitest (98 archivos / 1391 tests)
+npm run test:run       # vitest (~100 archivos, ~1400 tests)
 npm run build          # vite build + PWA
 ```
 
@@ -104,7 +104,17 @@ superpuestos** hacen que PostgREST no sepa cuál llamar y tire `PGRST203`, tambi
 runtime y también invisible para `tsc` y para los tests. Al cambiarle la firma a una
 función, **dropeá la vieja** — no dejes las dos conviviendo "por compatibilidad".
 
-**6. Nunca `npm audit fix --force`.** Degrada `exceljs` a 3.4.0 y rompe todos los exports
+**6. Antes de una migración de datos, fijate qué más depende de esa columna.** Dos cosas
+que ya mordieron en la misma migración:
+- `trigger_actualizar_saldo_pedido` es `AFTER UPDATE **OF total, monto_pagado**`. Esa
+  lista de columnas hace que mover `cliente_id` **no** lo dispare: la reatribución se
+  veía hecha y los saldos quedaban sin actualizar. Si tocás una columna, chequeá
+  `pg_get_triggerdef` — un `UPDATE OF` no cubre lo que no nombra.
+- Las FKs del aislamiento por sucursal son **compuestas** (`pedidos_cliente_id_fkey` es
+  `(cliente_id, sucursal_id) → clientes(id, sucursal_id)`). Al recrear una, preservá las
+  dos columnas: dejarla simple rompe el aislamiento y no falla nada visible.
+
+**7. Nunca `npm audit fix --force`.** Degrada `exceljs` a 3.4.0 y rompe todos los exports
 a Excel. El gate de CI es `--audit-level=high --omit=dev`; los `moderate` conviven a
 propósito. Para arreglar un high: `npm audit fix --package-lock-only`.
 

--- a/README.md
+++ b/README.md
@@ -80,11 +80,12 @@ src/
 │   └── vistas/       # Vistas principales
 ├── contexts/         # React Contexts (Theme, Notifications)
 ├── hooks/            # Custom hooks
-│   ├── supabase/     # Hooks de API (useClientes, usePedidos, etc.)
-│   └── handlers/     # Handlers de eventos
+│   ├── queries/      # Capa de datos (TanStack Query) — la que se usa
+│   ├── supabase/     # Hooks de acceso directo y auth
+│   └── state/        # Hooks de estado
 ├── lib/              # Configuraciones y utilidades core
 │   ├── pdf/          # Generadores de PDF
-│   └── schemas.js    # Schemas de validación Zod
+│   └── schemas.ts    # Schemas de validación Zod
 ├── utils/            # Utilidades generales
 └── test/             # Utilidades de testing
 ```

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -3,7 +3,7 @@
 > Describe lo que hay **hoy**. Todo lo que dice acá se puede verificar con `ls`, `grep`
 > o corriendo los comandos. Si algo no se puede verificar, no está escrito.
 >
-> Última verificación contra el código: 2026-08-20.
+> Última verificación contra el código: 2026-08-26.
 
 ## Stack
 
@@ -26,7 +26,7 @@ Conteos reales de archivos, para dar idea de dónde está el peso:
 ```
 src/
 ├── components/
-│   ├── modals/          77   el grueso de la UI
+│   ├── modals/          78   el grueso de la UI
 │   ├── vistas/          23   pantallas
 │   ├── containers/      20   estado + handlers de cada dominio
 │   ├── ui/              15   primitivas
@@ -37,18 +37,17 @@ src/
 │   ├── geolocalizacion/  5
 │   └── dashboard, clientes, misEntregas, a11y, auth, metas, perfil, recorridos
 ├── hooks/
-│   ├── queries/         50   capa de datos real (TanStack Query)
+│   ├── queries/         51   capa de datos real (TanStack Query)
 │   ├── supabase/        19   acceso directo y auth
-│   ├── state/            3
-│   └── handlers/         7   MUERTO — ver abajo
+│   └── state/            3
 ├── utils/               96   lógica pura, es donde viven los cálculos testeables
 ├── lib/                 16   supabase.ts, schemas.ts, offlineDb.ts, permisos.ts, pdf/
-├── contexts/            12
+├── contexts/            11
 ├── services/
-│   ├── api/              4
+│   ├── api/              3   clientes y productos (ver abajo)
 │   └── business/         1
 ├── constants/            5
-└── types/                3
+└── types/                4
 ```
 
 ## Cómo fluyen los datos
@@ -96,27 +95,22 @@ container queda detrás del overlay y falla en silencio.
 `ThemeProvider`, `AuthProvider`, `NotificationProvider` (en `App.tsx`),
 `AuthDataProvider`, `SucursalProvider`, y `QueryClientProvider` (en `main.tsx`).
 
-`src/contexts/` exporta más providers de los que se montan. En particular
-**`HandlersProvider` está exportado y nunca se monta** — es parte del código muerto de
-abajo.
+Todos los que `src/contexts/` exporta se montan. No siempre fue así.
 
-## Código muerto conocido
+## La capa que no existe
 
-`src/hooks/handlers/` (7 archivos) **no tiene ningún consumidor**:
+Si encontrás documentación, comentarios o ramas que hablen de **handlers de UI en hooks
+propios** (`src/hooks/handlers/`, `HandlersContext`, `useHandlerActions`) o de un
+**`pedidoService`**, están hablando de arquitecturas que se intentaron y no se
+terminaron. Se retiraron en agosto de 2026 (#495, #496, #503).
 
-```bash
-grep -rn "from ['\"].*hooks/handlers" src/ e2e/ | grep -v "^src/hooks/handlers/"
-# (sin resultados)
-```
+Los handlers viven en `src/components/containers/`. Los pedidos se leen y escriben por
+`src/hooks/queries/`. `src/services/api/` quedó con `clienteService` y `productoService`,
+que sí se usan.
 
-Es el resto de una arquitectura anterior en la que los handlers de UI vivían en hooks
-propios; hoy viven en los containers. Está anotado en
-[#495](https://github.com/AgustinReiden/distribuidora-app/issues/495) junto con
-`HandlersProvider`.
-
-Se documenta acá porque la versión anterior de este archivo describía esos handlers como
-la capa central de la app, con diagrama incluido — o sea que la arquitectura escrita
-mandaba a leer una capa que no existe.
+Se deja escrito porque la versión anterior de este archivo describía esos handlers como
+la capa central de la app, con diagrama incluido: la arquitectura escrita mandaba a leer
+una capa que ya no ejecutaba nadie.
 
 ## Seguridad
 
@@ -153,7 +147,7 @@ otro.
 
 ## Testing
 
-- **Unit** (Vitest): 98 archivos, 1391 tests. Corren sin `.env` — así se detectan fallos
+- **Unit** (Vitest): del orden de 100 archivos y 1400 tests. Corren sin `.env` — así se detectan fallos
   de import que un `.env` local enmascara.
 - **E2E** (Playwright, chromium): `e2e/`.
 - **Edge** (Deno): `deno task test` desde `supabase/functions/`.

--- a/docs/DEPLOY_GUIDE.md
+++ b/docs/DEPLOY_GUIDE.md
@@ -24,8 +24,8 @@ gh run view --log
 
 | Entorno | Plataforma | Trigger | URL | Vars de build |
 |---------|-----------|---------|-----|---------------|
-| Producción | Coolify (Docker + Nginx) | Push a `main` (webhook `COOLIFY_WEBHOOK_URL`) | Dominio productivo (Hostinger) | `VITE_SUPABASE_URL`, `VITE_SUPABASE_ANON_KEY`, `VITE_SENTRY_DSN`, `VITE_GOOGLE_API_KEY`, `VITE_N8N_WEBHOOK_URL`, `VITE_N8N_FACTURA_WEBHOOK_URL`, `VITE_APP_VERSION`, `N8N_UPSTREAM` (runtime) |
-| Staging | Vercel | `workflow_dispatch` manual con `environment=staging` | Preview URL Vercel | `STAGING_SUPABASE_URL`, `STAGING_SUPABASE_ANON_KEY`, `SENTRY_DSN` (secret GitHub) → `VITE_SENTRY_DSN` (env de build), `VITE_GOOGLE_API_KEY`, `VITE_N8N_WEBHOOK_URL`, `VITE_N8N_FACTURA_WEBHOOK_URL` |
+| Producción | Coolify (Docker + Nginx) | Push a `main` (webhook `COOLIFY_WEBHOOK_URL`) | Dominio productivo (Hostinger) | `VITE_SUPABASE_URL`, `VITE_SUPABASE_ANON_KEY`, `VITE_SENTRY_DSN`, `VITE_GOOGLE_API_KEY`, `VITE_N8N_FACTURA_WEBHOOK_URL`, `VITE_APP_VERSION`, `N8N_UPSTREAM` (runtime) |
+| Staging | Vercel | `workflow_dispatch` manual con `environment=staging` | Preview URL Vercel | `STAGING_SUPABASE_URL`, `STAGING_SUPABASE_ANON_KEY`, `SENTRY_DSN` (secret GitHub) → `VITE_SENTRY_DSN` (env de build), `VITE_GOOGLE_API_KEY`, `VITE_N8N_FACTURA_WEBHOOK_URL` |
 | Local | Vite dev server | `npm run dev` | `http://localhost:5173` | `.env` local (ver `.env.example`) |
 
 ## Flujo de Deploy a Producción
@@ -116,8 +116,7 @@ Fuente: `.env.example` para las `VITE_*` (build-time). `N8N_UPSTREAM` es runtime
 |----------|-----------|-------------|
 | `VITE_SUPABASE_URL` | Sí | URL del proyecto Supabase (`https://<ref>.supabase.co`). |
 | `VITE_SUPABASE_ANON_KEY` | Sí | Clave anon pública de Supabase. RLS protege los datos; no es un secreto. |
-| `VITE_GOOGLE_API_KEY` | No | Google Routes API key para optimización de rutas en cliente. Preferiblemente usar n8n en backend. |
-| `VITE_N8N_WEBHOOK_URL` | Sí | Ruta al webhook de optimización de ruta. En prod: `/api/n8n/webhook/optimizar-ruta` (proxy nginx). |
+| `VITE_GOOGLE_API_KEY` | Sí | Key del SDK de Google Maps (autocompletado de direcciones, geocoding inverso). Viaja en el bundle porque el SDK se carga con `<script src="...?key=">`: es pública por diseño y se protege con restricciones de referrer HTTP en Google Cloud Console. **No** la usa la optimización de rutas — eso va por la Edge Function `optimizar-ruta`, que tiene su propia key como secret del servidor. |
 | `VITE_N8N_FACTURA_WEBHOOK_URL` | Sí | Ruta al webhook de escaneo de factura. En prod: `/api/n8n/webhook/escanear-factura`. |
 | `VITE_SENTRY_DSN` | Recomendado | DSN de Sentry para reportar errores de producción. Vacío desactiva Sentry. |
 | `VITE_APP_VERSION` | Recomendado | Versión de la app para releases de Sentry. En staging (job `deploy-staging`) el workflow pasa `${{ github.sha }}`. En producción (Coolify) se configura como env var en el dashboard de Coolify y se pasa como `ARG` al build del Dockerfile; el `ARG VITE_APP_VERSION` del Dockerfile no define default, así que si no se setea queda vacío. |
@@ -127,7 +126,7 @@ Fuente: `.env.example` para las `VITE_*` (build-time). `N8N_UPSTREAM` es runtime
 
 - **Coolify:** Environment Variables del servicio (se pasan como `ARG` al build del Dockerfile, excepto `N8N_UPSTREAM` que va como `ENV` runtime).
 - **Vercel:** Project Settings → Environment Variables, o como secrets del workflow (`STAGING_*`).
-- **GitHub Actions secrets:** `Settings → Secrets and variables → Actions`. Requeridos: `COOLIFY_WEBHOOK_URL`, `VITE_SUPABASE_URL`, `VITE_SUPABASE_ANON_KEY`, `STAGING_SUPABASE_URL`, `STAGING_SUPABASE_ANON_KEY`, `SENTRY_DSN`, `VERCEL_TOKEN`, `VERCEL_ORG_ID`, `VERCEL_PROJECT_ID`, `VITE_GOOGLE_API_KEY`, `VITE_N8N_WEBHOOK_URL`, `VITE_N8N_FACTURA_WEBHOOK_URL`.
+- **GitHub Actions secrets:** `Settings → Secrets and variables → Actions`. Requeridos: `COOLIFY_WEBHOOK_URL`, `VITE_SUPABASE_URL`, `VITE_SUPABASE_ANON_KEY`, `STAGING_SUPABASE_URL`, `STAGING_SUPABASE_ANON_KEY`, `SENTRY_DSN`, `VERCEL_TOKEN`, `VERCEL_ORG_ID`, `VERCEL_PROJECT_ID`, `VITE_GOOGLE_API_KEY`, `VITE_N8N_FACTURA_WEBHOOK_URL`.
 
 ## Monitoreo Post-Deploy
 


### PR DESCRIPTION
Cerrar los 15 issues borró código que la documentación viva seguía describiendo. Esto la
pone al día.

## Lo que había quedado mintiendo

**`docs/ARCHITECTURE.md`** tenía una sección entera titulada *"Código muerto conocido"*
describiendo `src/hooks/handlers/`… que ya no existe. El documento que se reescribió hace
seis días justamente para ser verificable había pasado a mentir. Se reemplaza por una nota
que le sirve al que venga: si encontrás documentación, comentarios o ramas que hablen de
handlers en hooks propios o de `pedidoService`, están describiendo arquitecturas que se
intentaron y no se terminaron.

**`docs/DEPLOY_GUIDE.md`** era el más riesgoso de los tres, y el menos visible: listaba
`VITE_N8N_WEBHOOK_URL` como requerida en **cuatro** lugares. Es un doc operativo, así que
quien montara un entorno iba a configurar una variable que ya no hace nada. De paso se
corrige la entrada de `VITE_GOOGLE_API_KEY`, que decía *"preferiblemente usar n8n en
backend"* — esa key va en el bundle sí o sí porque el SDK de Maps se carga con
`<script src="…?key=">`; lo que corresponde decir es que se protege con restricciones de
referrer.

**`README.md`** listaba `hooks/handlers/` en el árbol y `schemas.js` en vez de `.ts`.

## Lo que se suma a CLAUDE.md

Una trampa, con las dos cosas que casi rompen producción en la migración de huérfanos y
que van a volver a aparecer en cualquier migración de datos:

- Un trigger `AFTER UPDATE **OF col1, col2**` **no** se dispara al tocar otra columna. Por
  eso mover `cliente_id` no actualizaba los saldos: el trabajo se veía hecho sin estarlo.
- Las FKs del aislamiento por sucursal son **compuestas**. Recrear una simple rompe el
  aislamiento y no falla nada visible.

## Un número que se venció mientras lo escribía

El conteo exacto de tests sale de CLAUDE.md y ARCHITECTURE.md. Lo tenía en 1391, lo
actualicé a 1366 al borrar `pedidoService`, y al verificar ya era 1375 porque entró el
PR #506 de otra sesión. Con varias sesiones escribiendo, un número exacto se vence en el
próximo PR. Queda una magnitud (*~1400*): sirve igual para notar que corrieron tres tests
en vez de mil, y no obliga a nadie a mantenerla.

## Estado al cerrar

- **0 issues abiertos**, 15 cerrados
- **2 ramas locales**, 17 worktrees → 2
- **Gate de integridad en verde** — corrida manual post-merge, 27s y los 5 pasos de
  verificación en OK (una corrida de 15s sería una que no chequeó nada)
- `typecheck`, `lint`, `test:run` (99 archivos / 1375 tests) y `build` en verde

🤖 Generated with [Claude Code](https://claude.com/claude-code)
