### PR TITLE
Que desactivar un cliente lo desactive, y compra mínima configurable por sucursal

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,6 +54,11 @@ Si no entra claro en una caja, probablemente no hace falta escribirlo.
 - `migrations/` — SQL numerado. Ver Trampas.
 - `supabase/functions/` — edge functions Deno (bot de Telegram, optimizar-ruta)
 
+La política comercial configurable no vive en el código: está en la tabla
+`politicas_comerciales` (una fila por sucursal) y se edita en `/configuracion`. Un
+parámetro de negocio que cambia va ahí, no en una constante, una env var ni una columna
+suelta en `sucursales`.
+
 ## Convenciones
 
 - **Nada de refactors de paso.** Un bug que no es el que viniste a arreglar → issue.
@@ -70,6 +75,13 @@ Si no entra claro en una caja, probablemente no hace falta escribirlo.
   idempotencia). Si editás la RPC y no el `_impl`, no cambia nada y no falla nada.
 - Una confirmación disparada desde un modal Radix tiene que renderizarse **dentro** del
   modal. Como hermano en el container queda detrás del overlay y falla en silencio.
+- **Toda lectura nueva de `clientes` decide qué hace con los inactivos.** Un cliente con
+  pedidos no se puede borrar (la FK es RESTRICT desde la mig 200), así que desactivarlo es la
+  única salida y siempre va a haber inactivos. `fetchClientes` filtra `activo = true` por
+  defecto (`includeInactivos` para el panel, que es desde donde se reactiva). Lo operativo
+  —selectores, rutas, recorridos— los oculta; el historial —reportes, cuenta corriente y los
+  embeds `cliente:clientes(*)`— **tiene** que seguir viéndolos, que es de lo que se trata la
+  baja lógica. Una consulta que no elige está eligiendo mal por omisión.
 
 ## Trampas
 
@@ -117,6 +129,15 @@ que ya mordieron en la misma migración:
 **7. Nunca `npm audit fix --force`.** Degrada `exceljs` a 3.4.0 y rompe todos los exports
 a Excel. El gate de CI es `--audit-level=high --omit=dev`; los `moderate` conviven a
 propósito. Para arreglar un high: `npm audit fix --package-lock-only`.
+
+**8. Un mínimo de pedido no puede ser un CHECK sobre `pedidos.total`.** Parece el lugar
+obvio para la compra mínima (mig 204/205), y rompe la cancelación: `cancelar_pedido` pone
+`total = 0` (mig 175) y el invariante `VENTA-I` de `auditoria_integridad()` **exige** que un
+pedido cancelado tenga total 0 (mig 105). Las dos reglas se contradicen y ningún código lo
+dice. Por eso se valida **al crear** —dentro de `crear_pedido_completo` y de
+`crear_pedido_completo_bot`— y nunca como constraint ni como trigger sobre el `UPDATE` del
+total. Corolario: la política rige el alta, no retroactivamente. Cuando el mínimo sube, los
+pedidos viejos por debajo eran legales cuando se crearon y tienen que seguir siéndolo.
 
 ## Los pendientes van a issues
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -27,8 +27,8 @@ Conteos reales de archivos, para dar idea de dónde está el peso:
 src/
 ├── components/
 │   ├── modals/          78   el grueso de la UI
-│   ├── vistas/          23   pantallas
-│   ├── containers/      20   estado + handlers de cada dominio
+│   ├── vistas/          24   pantallas
+│   ├── containers/      21   estado + handlers de cada dominio
 │   ├── ui/              15   primitivas
 │   ├── pedidos/         12
 │   ├── productos/       12
@@ -37,10 +37,10 @@ src/
 │   ├── geolocalizacion/  5
 │   └── dashboard, clientes, misEntregas, a11y, auth, metas, perfil, recorridos
 ├── hooks/
-│   ├── queries/         51   capa de datos real (TanStack Query)
+│   ├── queries/         53   capa de datos real (TanStack Query)
 │   ├── supabase/        19   acceso directo y auth
 │   └── state/            3
-├── utils/               96   lógica pura, es donde viven los cálculos testeables
+├── utils/               99   lógica pura, es donde viven los cálculos testeables
 ├── lib/                 16   supabase.ts, schemas.ts, offlineDb.ts, permisos.ts, pdf/
 ├── contexts/            11
 ├── services/
@@ -62,7 +62,7 @@ supabase-js  →  RPC SECURITY DEFINER  o  PostgREST con RLS
 Postgres
 ```
 
-Las escrituras van por dos caminos, y la división es deliberada:
+Las escrituras van por tres caminos, y la división es deliberada:
 
 - **Operaciones transaccionales** —pedidos, pagos, stock, recorridos— pasan por una
   **RPC `SECURITY DEFINER`**, para que la regla de negocio y la transacción vivan en un
@@ -70,8 +70,12 @@ Las escrituras van por dos caminos, y la división es deliberada:
   directas.
 - **ABM de catálogo** —clientes, productos, proveedores, zonas, marcas, categorías,
   promociones, usuarios— escribe directo contra PostgREST, apoyado en RLS.
+- **Configuración comercial** —`politicas_comerciales`, una fila por sucursal, editable en
+  `/configuracion` por admin y encargado— escribe por RPC, pero no por transaccionalidad: es
+  para que el servidor selle `actualizado_por` con `auth.uid()`. Si ese campo lo mandara el
+  cliente sería un dato que el cliente elige, y la auditoría no auditaría nada.
 
-En total: 72 llamadas `.rpc()` y 73 escrituras directas en `src/hooks/queries/`.
+En total: 73 llamadas `.rpc()` y 74 escrituras directas en `src/hooks/queries/`.
 
 Consecuencia importante: **una RPC `SECURITY DEFINER` saltea RLS**, así que el aislamiento
 por sucursal no puede depender sólo de las policies. Se ata además con FKs compuestas
@@ -79,6 +83,12 @@ por sucursal no puede depender sólo de las policies. Se ata además con FKs com
 
 Sin conexión, el alta de pedido se encola en IndexedDB (`src/lib/offlineDb.ts`) y se
 replaya después contra `crear_pedido_idempotente`, que es idempotente por diseño.
+
+Las reglas que la base hace cumplir al crear un pedido —stock, mínimo por producto, compra
+mínima de la sucursal— se validan **también antes de encolar**, con la última configuración
+conocida cacheada en Dexie. No es redundancia: un pedido que se acepta en el teléfono y lo
+rechaza el servidor recién al sincronizar falla horas después, lejos del cliente, y queda
+como una operación fallida en IndexedDB que sólo se ve en el panel de fallidas.
 
 ## Los containers
 

--- a/migrations/203_el_bot_no_ve_clientes_inactivos.sql
+++ b/migrations/203_el_bot_no_ve_clientes_inactivos.sql
@@ -1,0 +1,109 @@
+-- Que el bot deje de ofrecer clientes dados de baja (#491)
+--
+-- `clientes.activo` existe desde el baseline y es la baja logica: desde la mig
+-- 200 un cliente con pedidos NO se puede borrar (FK RESTRICT), asi que
+-- desactivarlo es la unica salida. El front ya filtra, y en el bot casi todo
+-- filtraba tambien:
+--   bot_mis_clientes            -> AND c.activo = TRUE   (mig 015)
+--   bot_sugerir_visitas_rfm     -> AND c.activo = TRUE   (mig 017)
+--   ficha_cliente (edge fn)     -> .eq("activo", true)
+--   previsualizar_pedido (edge) -> .eq("activo", true)
+--
+-- El unico que no era `bot_buscar_cliente`, que es justo la PUERTA DE ENTRADA:
+-- es la busqueda por nombre o codigo desde la que el preventista llega a todo
+-- lo demas. O sea que un cliente desactivado seguia siendo encontrable y
+-- seleccionable desde Telegram, aunque en la app web ya no apareciera.
+--
+-- Se agrega el mismo `AND c.activo = TRUE` que ya usan sus hermanas. No cambia
+-- la firma: es un CREATE OR REPLACE del cuerpo, verificado contra el catalogo
+-- vivo (identico a la mig 028, sin drift).
+--
+-- Efecto medido en prod al momento de escribir esto: 2 clientes inactivos sobre
+-- 712 dejan de aparecer en la busqueda del bot.
+
+CREATE OR REPLACE FUNCTION public.bot_buscar_cliente(
+  p_q          text,
+  p_perfil_id  uuid,
+  p_rol        text,
+  p_sucursal_id bigint,
+  p_limit      integer DEFAULT 10
+)
+RETURNS TABLE(
+  id bigint, codigo integer, nombre_fantasia text, razon_social text,
+  saldo_cuenta numeric, direccion text, zona text, sucursal_id bigint
+)
+LANGUAGE sql STABLE SECURITY DEFINER
+SET search_path = public
+AS $$
+  WITH terms AS (
+    SELECT array_remove(
+      string_to_array(
+        trim(lower(f_unaccent(coalesce(p_q, '')))),
+        ' '
+      ),
+      ''
+    ) AS words
+  )
+  SELECT
+    c.id, c.codigo, c.nombre_fantasia, c.razon_social, c.saldo_cuenta,
+    c.direccion, c.zona, c.sucursal_id
+  FROM clientes c, terms t
+  WHERE
+    c.sucursal_id = p_sucursal_id
+    -- Baja logica: un cliente desactivado no se ofrece para operar. Su historial
+    -- sigue intacto y visible en los reportes, que no pasan por aca.
+    AND c.activo = TRUE
+    AND (
+      p_rol = 'admin'
+      OR EXISTS(
+        SELECT 1 FROM cliente_preventistas cp
+        WHERE cp.cliente_id = c.id AND cp.preventista_id = p_perfil_id
+      )
+      -- Huerfanos (sin asignacion a ningun preventista) visibles para cualquier
+      -- preventista de la misma sucursal (mig 028).
+      OR NOT EXISTS(
+        SELECT 1 FROM cliente_preventistas cp WHERE cp.cliente_id = c.id
+      )
+    )
+    AND (
+      array_length(t.words, 1) IS NULL
+      OR (
+        SELECT bool_and(
+          lower(f_unaccent(coalesce(c.nombre_fantasia, ''))) LIKE '%' || w || '%'
+          OR lower(f_unaccent(coalesce(c.razon_social, ''))) LIKE '%' || w || '%'
+          OR lower(coalesce(c.codigo::TEXT, '')) LIKE '%' || w || '%'
+        )
+        FROM unnest(t.words) AS w
+      )
+    )
+  ORDER BY c.nombre_fantasia
+  LIMIT p_limit;
+$$;
+
+-- CREATE OR REPLACE conserva el ACL, pero el hardening se repite igual: es
+-- barato y no depende de que nadie lo haya tocado en el medio. `bot_*` la llama
+-- el bot con service_role; anon y PUBLIC no tienen nada que hacer aca.
+REVOKE ALL ON FUNCTION public.bot_buscar_cliente(text, uuid, text, bigint, integer) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.bot_buscar_cliente(text, uuid, text, bigint, integer) TO service_role;
+
+DO $verif$
+DECLARE v_acl text;
+BEGIN
+  SELECT array_to_string(proacl, ',') INTO v_acl
+  FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace
+  WHERE n.nspname = 'public' AND p.proname = 'bot_buscar_cliente';
+
+  IF v_acl IS NULL THEN
+    RAISE EXCEPTION 'bot_buscar_cliente quedo con ACL default (PUBLIC ejecuta)';
+  END IF;
+  IF v_acl LIKE '=X/%' OR v_acl LIKE '%,=X/%' THEN
+    RAISE EXCEPTION 'bot_buscar_cliente quedo ejecutable por PUBLIC: %', v_acl;
+  END IF;
+  IF v_acl LIKE '%anon=%' THEN
+    RAISE EXCEPTION 'bot_buscar_cliente quedo ejecutable por anon: %', v_acl;
+  END IF;
+  IF v_acl NOT LIKE '%service_role=X%' THEN
+    RAISE EXCEPTION 'bot_buscar_cliente no quedo ejecutable por service_role: %', v_acl;
+  END IF;
+END
+$verif$;

--- a/migrations/204_politicas_comerciales_por_sucursal.sql
+++ b/migrations/204_politicas_comerciales_por_sucursal.sql
@@ -1,0 +1,206 @@
+-- Compra minima en $ por pedido, configurable por sucursal
+--
+-- EL PEDIDO
+-- ---------
+-- "Poder configurar una compra minima en $ para todos los pedidos, que no quede
+-- hardcodeado porque es una politica cambiante."
+--
+-- POR QUE POR SUCURSAL Y NO UN NUMERO GLOBAL
+-- ------------------------------------------
+-- Medido sobre los ultimos 90 dias, pedidos no cancelados:
+--   Sucursal 1 (Tucuman)   2051 pedidos, mediana $22.200, p05 $9.220
+--   Sucursal 2 (Taco Pozo)  852 pedidos, mediana $35.750, p05 $11.100
+-- Un minimo unico de $10.000 habria frenado 147 pedidos en Tucuman (7%) y 26 en
+-- Taco Pozo (3%). La misma cifra pega muy distinto en cada una, asi que un solo
+-- numero global obliga a elegir entre quedarse corto en una o apretar de mas en
+-- la otra.
+--
+-- POR QUE UNA TABLA Y NO UNA COLUMNA EN `sucursales`
+-- --------------------------------------------------
+-- `sucursales` es la tabla de identidad (nombre, direccion, tipo). La politica
+-- comercial cambia seguido y la escribe otra gente: para que un encargado mueva
+-- el minimo habria que darle UPDATE sobre la fila de identidad de la sucursal,
+-- que es bastante mas de lo que se quiere. Aparte, cada politica nueva seria una
+-- columna mas en una tabla que no es sobre eso.
+--
+-- POR QUE TIPADA Y NO CLAVE-VALOR EN JSONB
+-- ----------------------------------------
+-- Una tabla `configuracion(clave, valor jsonb)` es tentadora por lo extensible,
+-- pero pierde el CHECK y el tipo: nada impide guardar un minimo negativo o un
+-- string. Y este repo NO tiene tipos generados de la base (se escriben a mano),
+-- asi que una clave mal escrita no la atrapa ni tsc, ni eslint, ni los tests --
+-- se descubre en produccion cuando el minimo resulta ser NULL y no frena nada.
+-- Una tabla angosta y tipada da CHECK, tipo y auditoria; sumar una politica
+-- manana es una columna con su propio CHECK.
+--
+-- ARRANCA EN 0 = SIN POLITICA
+-- ---------------------------
+-- El seed pone 0 en todas las sucursales, que es exactamente la regla de hoy.
+-- Aplicar esta migracion no le cambia el comportamiento a nadie: recien cuando
+-- alguien carga un numero desde la pantalla de configuracion empieza a regir.
+-- Es a proposito -- 736 pedidos de Tucuman en 90 dias estan por debajo de
+-- $20.000, asi que un minimo mal elegido frena la operacion de una.
+--
+-- La validacion en si NO va aca: va en la mig 205, en el alta del pedido.
+
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS public.politicas_comerciales (
+  sucursal_id          bigint PRIMARY KEY REFERENCES public.sucursales(id) ON DELETE CASCADE,
+  monto_minimo_pedido  numeric(12,2) NOT NULL DEFAULT 0
+                       CHECK (monto_minimo_pedido >= 0),
+  actualizado_por      uuid REFERENCES public.perfiles(id) ON DELETE SET NULL,
+  actualizado_en       timestamptz NOT NULL DEFAULT now()
+);
+
+COMMENT ON TABLE public.politicas_comerciales IS
+  'Politica comercial por sucursal. Una fila por sucursal. Tipada a proposito '
+  '(no clave-valor): el repo no tiene tipos generados de la base, asi que una '
+  'clave mal escrita en un jsonb no la atraparia nada. mig 204.';
+
+COMMENT ON COLUMN public.politicas_comerciales.monto_minimo_pedido IS
+  'Monto minimo en $ que debe alcanzar un pedido para poder crearse. 0 = sin '
+  'minimo (el valor con el que arranca todo). Se valida al CREAR el pedido, '
+  'nunca como CHECK sobre pedidos.total: cancelar un pedido lo pone en 0 y el '
+  'invariante VENTA-I exige que asi sea. mig 204/205.';
+
+-- Una fila por sucursal, incluida la inactiva: si manana se reactiva, tiene su
+-- politica y no hay que acordarse de crearla.
+INSERT INTO public.politicas_comerciales (sucursal_id, monto_minimo_pedido)
+SELECT s.id, 0 FROM public.sucursales s
+ON CONFLICT (sucursal_id) DO NOTHING;
+
+ALTER TABLE public.politicas_comerciales ENABLE ROW LEVEL SECURITY;
+
+-- SELECT abierto a authenticated de la sucursal activa: lo necesita CUALQUIERA
+-- que cargue un pedido, para poder avisar antes de confirmar en vez de comerse
+-- el rechazo del servidor. Escritura solo admin/encargado.
+-- Cuatro policies separadas y no una FOR ALL, por el criterio de la mig 192: una
+-- FOR ALL que solo mirara la sucursal le daria escritura a preventistas.
+DROP POLICY IF EXISTS mt_politicas_comerciales_select ON public.politicas_comerciales;
+CREATE POLICY mt_politicas_comerciales_select ON public.politicas_comerciales
+  FOR SELECT TO authenticated
+  USING (sucursal_id = public.current_sucursal_id());
+
+DROP POLICY IF EXISTS mt_politicas_comerciales_update ON public.politicas_comerciales;
+CREATE POLICY mt_politicas_comerciales_update ON public.politicas_comerciales
+  FOR UPDATE TO authenticated
+  USING      (public.es_encargado_o_admin() AND sucursal_id = public.current_sucursal_id())
+  WITH CHECK (public.es_encargado_o_admin() AND sucursal_id = public.current_sucursal_id());
+
+DROP POLICY IF EXISTS mt_politicas_comerciales_insert ON public.politicas_comerciales;
+CREATE POLICY mt_politicas_comerciales_insert ON public.politicas_comerciales
+  FOR INSERT TO authenticated
+  WITH CHECK (public.es_encargado_o_admin() AND sucursal_id = public.current_sucursal_id());
+
+-- Sin policy de DELETE: una sucursal siempre tiene politica. Borrar la fila
+-- dejaria el minimo indefinido, que no es un estado que queramos representar.
+
+GRANT SELECT, INSERT, UPDATE ON public.politicas_comerciales TO authenticated;
+
+-- ---------------------------------------------------------------------------
+-- Lectura para el motor SQL y para el bot.
+--
+-- STABLE y no VOLATILE: se llama una vez por alta de pedido y el planner puede
+-- cachearla dentro de la sentencia. Devuelve 0 (no NULL) cuando no hay fila:
+-- "sin politica" y "sin fila" son lo mismo, y un NULL se propagaria a la
+-- comparacion y la volveria NULL -- o sea, no frenaria nada.
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.monto_minimo_pedido(p_sucursal_id bigint)
+RETURNS numeric
+LANGUAGE sql STABLE SECURITY DEFINER
+SET search_path TO 'public'
+AS $$
+  SELECT COALESCE(
+    (SELECT pc.monto_minimo_pedido
+       FROM public.politicas_comerciales pc
+      WHERE pc.sucursal_id = p_sucursal_id),
+    0
+  );
+$$;
+
+COMMENT ON FUNCTION public.monto_minimo_pedido(bigint) IS
+  'Minimo vigente de la sucursal, o 0 si no hay fila. mig 204.';
+
+REVOKE ALL ON FUNCTION public.monto_minimo_pedido(bigint) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.monto_minimo_pedido(bigint) TO authenticated, service_role;
+
+-- ---------------------------------------------------------------------------
+-- Escritura desde la pantalla de configuracion.
+--
+-- Va por RPC y no por UPDATE directo para poder sellar `actualizado_por` con
+-- auth.uid() del lado del servidor: si lo mandara el cliente, seria un dato que
+-- el cliente elige, y entonces la auditoria no auditaria nada.
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.actualizar_monto_minimo_pedido(p_monto numeric)
+RETURNS numeric
+LANGUAGE plpgsql VOLATILE SECURITY DEFINER
+SET search_path TO 'public'
+AS $$
+DECLARE
+  v_sucursal bigint := public.current_sucursal_id();
+  v_rol      text;
+BEGIN
+  IF v_sucursal IS NULL THEN
+    RAISE EXCEPTION 'No se pudo determinar la sucursal activa';
+  END IF;
+
+  SELECT rol INTO v_rol FROM public.perfiles WHERE id = auth.uid();
+  IF v_rol IS NULL OR v_rol NOT IN ('admin', 'encargado') THEN
+    RAISE EXCEPTION 'Acceso denegado: se requiere rol admin o encargado';
+  END IF;
+
+  IF p_monto IS NULL OR p_monto < 0 THEN
+    RAISE EXCEPTION 'El monto minimo no puede ser negativo';
+  END IF;
+
+  INSERT INTO public.politicas_comerciales (sucursal_id, monto_minimo_pedido, actualizado_por, actualizado_en)
+  VALUES (v_sucursal, p_monto, auth.uid(), now())
+  ON CONFLICT (sucursal_id) DO UPDATE
+    SET monto_minimo_pedido = EXCLUDED.monto_minimo_pedido,
+        actualizado_por     = EXCLUDED.actualizado_por,
+        actualizado_en      = EXCLUDED.actualizado_en;
+
+  RETURN p_monto;
+END;
+$$;
+
+COMMENT ON FUNCTION public.actualizar_monto_minimo_pedido(numeric) IS
+  'Fija el minimo de la sucursal activa. Solo admin/encargado. mig 204.';
+
+REVOKE ALL ON FUNCTION public.actualizar_monto_minimo_pedido(numeric) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.actualizar_monto_minimo_pedido(numeric) TO authenticated;
+
+DO $verif$
+DECLARE
+  v_acl text;
+  v_fn  text;
+BEGIN
+  FOREACH v_fn IN ARRAY ARRAY['monto_minimo_pedido', 'actualizar_monto_minimo_pedido'] LOOP
+    SELECT array_to_string(proacl, ',') INTO v_acl
+    FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace
+    WHERE n.nspname = 'public' AND p.proname = v_fn;
+
+    IF v_acl IS NULL THEN
+      RAISE EXCEPTION '% quedo con ACL default (PUBLIC ejecuta)', v_fn;
+    END IF;
+    IF v_acl LIKE '=X/%' OR v_acl LIKE '%,=X/%' THEN
+      RAISE EXCEPTION '% quedo ejecutable por PUBLIC: %', v_fn, v_acl;
+    END IF;
+    IF v_acl LIKE '%anon=%' THEN
+      RAISE EXCEPTION '% quedo ejecutable por anon: %', v_fn, v_acl;
+    END IF;
+    IF v_acl NOT LIKE '%authenticated=X%' THEN
+      RAISE EXCEPTION '% no quedo ejecutable por authenticated: %', v_fn, v_acl;
+    END IF;
+  END LOOP;
+END
+$verif$;
+
+COMMIT;
+
+-- ROLLBACK (si hiciera falta):
+--   DROP FUNCTION IF EXISTS public.actualizar_monto_minimo_pedido(numeric);
+--   DROP FUNCTION IF EXISTS public.monto_minimo_pedido(bigint);
+--   DROP TABLE IF EXISTS public.politicas_comerciales;
+-- Nada mas depende de esto mientras la mig 205 no este aplicada.

--- a/migrations/205_hacer_valer_la_compra_minima.sql
+++ b/migrations/205_hacer_valer_la_compra_minima.sql
@@ -1,0 +1,271 @@
+-- Hacer valer la compra minima en los dos caminos que crean pedidos
+--
+-- La mig 204 dejo el numero configurable por sucursal. Esta lo hace cumplir.
+--
+-- DONDE SE VALIDA Y POR QUE AHI
+-- -----------------------------
+-- En el ALTA del pedido, nunca como CHECK sobre `pedidos.total` ni como trigger
+-- sobre el UPDATE del total. Dos razones, las dos medidas:
+--
+--   1. Cancelar un pedido le pone `total = 0` (mig 175, linea 127), y el
+--      invariante VENTA-I de `auditoria_integridad()` EXIGE que un pedido
+--      cancelado tenga total 0 (mig 105). Un CHECK `total >= minimo` haria
+--      imposible cancelar. Verificado en prod: los 175 pedidos en $0 de los
+--      ultimos 90 dias son todos `estado = 'cancelado'`.
+--
+--   2. Cuando el minimo suba, los pedidos viejos que quedaron por debajo eran
+--      legales cuando se crearon. La politica rige el alta, no retroactivamente.
+--
+-- LOS CAMINOS
+-- -----------
+-- Hay dos cuerpos que insertan en `pedidos` con total de venta, y los dos se
+-- parchean aca:
+--   crear_pedido_completo      <- web online, replay offline y cambiar_cliente_pedido
+--   crear_pedido_completo_bot  <- Telegram
+--
+-- `crear_pedido_cambio_en_ruta` (mig 090) queda EXENTO y no hace falta tocarlo:
+-- inserta directo, con `canal='cambio'` y `total=0` por diseño -- un cambio de
+-- producto no es una venta y no tiene por que alcanzar ningun minimo. La
+-- exencion es automatica justamente porque no pasa por ninguno de los dos.
+--
+-- EL ESCAPE HATCH
+-- ---------------
+-- `app.omitir_minimo_pedido = '1'`, hermano del `app.omitir_minimo_venta` que la
+-- mig 174 uso para el minimo por producto, con el mismo criterio: el minimo rige
+-- EL PEDIDO, NO LA ENTREGA. Un RPC de salvedad que rearma un pedido no tiene por
+-- que quedar trabado por una politica que se cumplio cuando se vendio.
+--
+-- EL PARCHE
+-- ---------
+-- Los dos cuerpos son grandes (14k y 12k) y pudieron driftar, asi que NO se
+-- copian del archivo: se leen del catalogo vivo con pg_get_functiondef y se les
+-- inserta el bloque justo despues del guard de permisos, exigiendo que el ancla
+-- aparezca EXACTAMENTE UNA VEZ (patron de las migs 176/191/193/195).
+--
+-- Cada uno respeta su propia forma de contestar el error, que es contrato con
+-- sus clientes: `errores` (array) en crear_pedido_completo, `error` (string) en
+-- la del bot.
+
+BEGIN;
+
+-- ---------------------------------------------------------------------------
+-- La regla, en un solo lugar.
+--
+-- Se cumple con `>=`: un pedido que da exactamente el minimo pasa. Y minimo 0
+-- no frena nada, que es el estado con el que arranca todo (mig 204).
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.pedido_incumple_minimo(
+  p_total       numeric,
+  p_sucursal_id bigint
+)
+RETURNS text
+LANGUAGE plpgsql STABLE SECURITY DEFINER
+SET search_path TO 'public'
+AS $fn$
+DECLARE
+  v_minimo numeric;
+BEGIN
+  -- Escape hatch: mismo criterio que app.omitir_minimo_venta (mig 174).
+  IF COALESCE(current_setting('app.omitir_minimo_pedido', true), '') = '1' THEN
+    RETURN NULL;
+  END IF;
+
+  v_minimo := public.monto_minimo_pedido(p_sucursal_id);
+
+  IF v_minimo IS NULL OR v_minimo <= 0 THEN
+    RETURN NULL;
+  END IF;
+
+  IF COALESCE(p_total, 0) >= v_minimo THEN
+    RETURN NULL;
+  END IF;
+
+  -- El mensaje lleva los dos numeros a proposito: sale por caminos donde nadie
+  -- va a ir a buscar cual era el minimo (el replay offline, el bot).
+  RETURN format(
+    'El pedido no alcanza la compra minima de %s. Total del pedido: %s.',
+    to_char(v_minimo, 'FM$999G999G999D00'),
+    to_char(COALESCE(p_total, 0), 'FM$999G999G999D00')
+  );
+END;
+$fn$;
+
+COMMENT ON FUNCTION public.pedido_incumple_minimo(numeric, bigint) IS
+  'Devuelve el motivo si el pedido no llega al minimo de la sucursal, o NULL si '
+  'esta bien. Se evalua SOLO al crear: cancelar pone total=0 y VENTA-I lo exige. '
+  'mig 205.';
+
+REVOKE ALL ON FUNCTION public.pedido_incumple_minimo(numeric, bigint) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.pedido_incumple_minimo(numeric, bigint) TO authenticated, service_role;
+
+-- ---------------------------------------------------------------------------
+-- Helper de parcheo: inserta despues de un ancla que debe aparecer 1 sola vez.
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public._mig205_insertar_tras_ancla(
+  p_funcion regprocedure,
+  p_ancla   text,
+  p_bloque  text
+)
+RETURNS void
+LANGUAGE plpgsql
+AS $fn$
+DECLARE
+  v_def   text;
+  v_veces int;
+BEGIN
+  v_def := pg_get_functiondef(p_funcion);
+
+  v_veces := (length(v_def) - length(replace(v_def, p_ancla, ''))) / length(p_ancla);
+  IF v_veces <> 1 THEN
+    RAISE EXCEPTION 'El ancla aparece % veces en % (se esperaba exactamente 1). El cuerpo vivo cambio: revisar a mano.',
+      v_veces, p_funcion;
+  END IF;
+
+  v_def := replace(v_def, p_ancla, p_ancla || p_bloque);
+  EXECUTE v_def;
+END;
+$fn$;
+
+-- ---------------------------------------------------------------------------
+-- 1 · crear_pedido_completo  (web online, replay offline, cambiar_cliente_pedido)
+--     Contesta con `errores` (array de textos).
+-- ---------------------------------------------------------------------------
+DO $patch$
+DECLARE
+  v_ancla  text;
+  v_bloque text;
+BEGIN
+  v_ancla := 'IF v_user_role IS NULL OR v_user_role NOT IN (''admin'', ''preventista'', ''encargado'') THEN RETURN jsonb_build_object(''success'', false, ''errores'', jsonb_build_array(''No tiene permisos para crear pedidos'')); END IF;';
+
+  v_bloque := E'\n\n  -- Compra minima de la sucursal (mig 204/205). Va aca, antes de tocar stock\n'
+           || E'  -- o promociones, para que un pedido que no llega no deje nada a medias.\n'
+           || E'  DECLARE v_motivo_minimo TEXT;\n'
+           || E'  BEGIN\n'
+           || E'    v_motivo_minimo := public.pedido_incumple_minimo(p_total, v_sucursal);\n'
+           || E'    IF v_motivo_minimo IS NOT NULL THEN\n'
+           || E'      RETURN jsonb_build_object(''success'', false, ''errores'', jsonb_build_array(v_motivo_minimo));\n'
+           || E'    END IF;\n'
+           || E'  END;\n';
+
+  PERFORM public._mig205_insertar_tras_ancla(
+    'public.crear_pedido_completo(bigint, numeric, uuid, jsonb, text, text, text, date, text, numeric, numeric, date, uuid)'::regprocedure,
+    v_ancla,
+    v_bloque
+  );
+END
+$patch$;
+
+-- ---------------------------------------------------------------------------
+-- 2 · crear_pedido_completo_bot  (Telegram)
+--     Contesta con `error` (string). El total y la sucursal vienen de la
+--     confirmacion pendiente ya bloqueada con FOR UPDATE.
+-- ---------------------------------------------------------------------------
+DO $patch$
+DECLARE
+  v_ancla  text;
+  v_bloque text;
+BEGIN
+  v_ancla := E'  SELECT rol INTO v_user_role FROM perfiles WHERE id = p_perfil_id;\n  IF v_user_role IS NULL OR v_user_role NOT IN (''admin'', ''encargado'', ''preventista'') THEN\n    RETURN jsonb_build_object(''success'', false, ''error'', ''No tiene permisos para crear pedidos'');\n  END IF;';
+
+  v_bloque := E'\n\n  -- Compra minima de la sucursal (mig 204/205). previsualizar_pedido ya avisa\n'
+           || E'  -- antes de que el preventista confirme; esto es la red de abajo, para que\n'
+           || E'  -- la regla valga aunque se llegue por otro lado.\n'
+           || E'  DECLARE v_motivo_minimo TEXT;\n'
+           || E'  BEGIN\n'
+           || E'    v_motivo_minimo := public.pedido_incumple_minimo(v_pendiente.total, v_pendiente.sucursal_id);\n'
+           || E'    IF v_motivo_minimo IS NOT NULL THEN\n'
+           || E'      RETURN jsonb_build_object(''success'', false, ''error'', v_motivo_minimo);\n'
+           || E'    END IF;\n'
+           || E'  END;\n';
+
+  PERFORM public._mig205_insertar_tras_ancla(
+    'public.crear_pedido_completo_bot(uuid, uuid)'::regprocedure,
+    v_ancla,
+    v_bloque
+  );
+END
+$patch$;
+
+-- ---------------------------------------------------------------------------
+-- 3 · cambiar_cliente_pedido  <- prende el escape hatch
+--
+-- Reatribuir un pedido a otro cliente cancela el original y lo vuelve a crear
+-- por crear_pedido_completo, asi que sin esto quedaria sujeto al minimo. Y seria
+-- el minimo de HOY contra un pedido que se vendio con el de ANTES: si la
+-- politica subio en el medio, corregir un cliente mal cargado se volveria
+-- imposible. Es exactamente el caso que la mig 199 tuvo que arreglar a mano.
+--
+-- Es una correccion administrativa de admin sobre una venta que ya ocurrio, no
+-- una venta nueva: mismo criterio que los RPCs de salvedad en la mig 174.
+-- set_config con is_local = true muere con la transaccion, asi que no se filtra.
+-- ---------------------------------------------------------------------------
+DO $patch$
+DECLARE
+  v_ancla  text;
+  v_bloque text;
+BEGIN
+  v_ancla := E'  SELECT rol INTO v_role FROM perfiles WHERE id = v_acting;\n  IF v_role IS NULL OR v_role <> ''admin'' THEN\n    RETURN jsonb_build_object(''success'', false, ''error'', ''No autorizado: solo admin puede cambiar el cliente de un pedido'');\n  END IF;';
+
+  v_bloque := E'\n\n  -- La reatribucion no es una venta nueva: el pedido ya cumplio (o no) el\n'
+           || E'  -- minimo cuando se creo. Ver mig 205.\n'
+           || E'  PERFORM set_config(''app.omitir_minimo_pedido'', ''1'', true);\n';
+
+  PERFORM public._mig205_insertar_tras_ancla(
+    (SELECT p.oid::regprocedure FROM pg_proc p
+      WHERE p.pronamespace = 'public'::regnamespace
+        AND p.proname = 'cambiar_cliente_pedido'),
+    v_ancla,
+    v_bloque
+  );
+END
+$patch$;
+
+DROP FUNCTION public._mig205_insertar_tras_ancla(regprocedure, text, text);
+
+-- ---------------------------------------------------------------------------
+-- Verificacion: el parche entro en los dos, y el ACL de los dos sigue cerrado.
+-- CREATE OR REPLACE conserva el ACL, pero si alguna vez alguien las dropea y
+-- recrea, esto avisa.
+-- ---------------------------------------------------------------------------
+DO $verif$
+DECLARE
+  v_def text;
+  v_fn  text;
+  v_acl text;
+BEGIN
+  FOREACH v_fn IN ARRAY ARRAY['crear_pedido_completo', 'crear_pedido_completo_bot'] LOOP
+    SELECT pg_get_functiondef(p.oid) INTO v_def
+    FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace
+    WHERE n.nspname = 'public' AND p.proname = v_fn;
+
+    IF v_def NOT LIKE '%pedido_incumple_minimo%' THEN
+      RAISE EXCEPTION '% no quedo con la validacion de compra minima', v_fn;
+    END IF;
+
+    SELECT array_to_string(proacl, ',') INTO v_acl
+    FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace
+    WHERE n.nspname = 'public' AND p.proname = v_fn;
+
+    IF v_acl IS NOT NULL AND (v_acl LIKE '=X/%' OR v_acl LIKE '%,=X/%' OR v_acl LIKE '%anon=%') THEN
+      RAISE EXCEPTION '% quedo ejecutable por PUBLIC o anon: %', v_fn, v_acl;
+    END IF;
+  END LOOP;
+
+  SELECT pg_get_functiondef(p.oid) INTO v_def
+  FROM pg_proc p WHERE p.pronamespace = 'public'::regnamespace
+    AND p.proname = 'cambiar_cliente_pedido';
+  IF v_def NOT LIKE '%omitir_minimo_pedido%' THEN
+    RAISE EXCEPTION 'cambiar_cliente_pedido no quedo con el escape hatch: una reatribucion podria trabarse por el minimo de hoy';
+  END IF;
+
+  -- La regla no debe frenar nada mientras el minimo sea 0 (estado inicial).
+  IF public.pedido_incumple_minimo(1, 1) IS NOT NULL THEN
+    RAISE EXCEPTION 'Con minimo 0 la validacion no deberia frenar ningun pedido';
+  END IF;
+END
+$verif$;
+
+COMMIT;
+
+-- ROLLBACK: volver a aplicar la mig 132 (que define los dos cuerpos sin este
+-- bloque) y despues DROP FUNCTION public.pedido_incumple_minimo(numeric, bigint).

--- a/migrations/MANIFEST.md
+++ b/migrations/MANIFEST.md
@@ -142,22 +142,27 @@ cronológicamente **fuera** del bloque 139–147 (uno antes, otro entre la 144 y
 Igual, confirmá el número contra las tres fuentes justo antes de aplicar: el
 número se reserva **aplicando**, no escribiendo el archivo.
 
-Las 197–202 no tienen prosa acá (quedaron sin documentar en su momento). Las tres
-últimas sí:
+Las 197–202 no tienen prosa acá (quedaron sin documentar en su momento). Las 203, 204 y
+205 sí:
 
 - **203** `bot_buscar_cliente` pasa a filtrar `activo = TRUE`. Era el único camino
   del bot que no lo hacía, y es la puerta de entrada: un cliente dado de baja
   seguía siendo encontrable desde Telegram aunque en la web ya no apareciera.
+  `CREATE OR REPLACE` puro: **no toca ninguna fila**.
 - **204** crea `politicas_comerciales` (una fila por sucursal) con
   `monto_minimo_pedido`, más `monto_minimo_pedido()` y
-  `actualizar_monto_minimo_pedido()`. Arranca en 0 en todas las sucursales, o sea
-  que aplicarla no cambia ningún comportamiento hasta que alguien cargue un número.
+  `actualizar_monto_minimo_pedido()`. **Sí toca filas**: inserta una por sucursal
+  (3 al aplicarla), todas con el mínimo en 0 — o sea que aplicarla no cambia
+  ningún comportamiento hasta que alguien cargue un número.
 - **205** hace cumplir ese mínimo. Parchea `crear_pedido_completo` y
   `crear_pedido_completo_bot` leyendo del catálogo vivo, y le prende el escape
   hatch `app.omitir_minimo_pedido` a `cambiar_cliente_pedido`.
   **El mínimo se valida SOLO al crear**, nunca como CHECK sobre `pedidos.total`:
   cancelar un pedido lo pone en 0 (mig 175) y el invariante `VENTA-I` exige que
   así sea (mig 105), así que un CHECK haría imposible cancelar.
+  Sólo redefine funciones: **no toca ninguna fila**. El rollback está al pie del
+  archivo y es gratis mientras los mínimos sigan en 0; si alguien ya cargó uno,
+  revertirla apaga la validación sin avisar.
 
 La **195** le da a la cabecera la columna `compras.bonificaciones`, que es donde se resta
 una bonificación general: el `subtotal` es el neto de los RENGLONES y lo clava `COMPRA-A2`

--- a/migrations/MANIFEST.md
+++ b/migrations/MANIFEST.md
@@ -1,6 +1,6 @@
 # MANIFEST de migraciones — mapeo repo ↔ producción
 
-> **Fechado: 2026-08-20** · Proyecto prod `hmuchlzmuqqxcldbzkgc` (ManaosApp) · región `sa-east-1`.
+> **Fechado: 2026-08-26** · Proyecto prod `hmuchlzmuqqxcldbzkgc` (ManaosApp) · región `sa-east-1`.
 
 ## Regla de oro
 
@@ -137,8 +137,27 @@ funcional** y no se renombran los archivos: renombrarlos los desalinearía del l
 real lo da `version` y está en la sección A: en los dos casos el archivo de `main` quedó
 cronológicamente **fuera** del bloque 139–147 (uno antes, otro entre la 144 y la 145).
 
-**La próxima migración es la 197** — la última numerada en el repo es
-`196_espejo_del_motor_de_compras`.
+**La próxima migración es la 206** — la última numerada en el repo es
+`205_hacer_valer_la_compra_minima`, y el ledger de prod está alineado con ella.
+Igual, confirmá el número contra las tres fuentes justo antes de aplicar: el
+número se reserva **aplicando**, no escribiendo el archivo.
+
+Las 197–202 no tienen prosa acá (quedaron sin documentar en su momento). Las tres
+últimas sí:
+
+- **203** `bot_buscar_cliente` pasa a filtrar `activo = TRUE`. Era el único camino
+  del bot que no lo hacía, y es la puerta de entrada: un cliente dado de baja
+  seguía siendo encontrable desde Telegram aunque en la web ya no apareciera.
+- **204** crea `politicas_comerciales` (una fila por sucursal) con
+  `monto_minimo_pedido`, más `monto_minimo_pedido()` y
+  `actualizar_monto_minimo_pedido()`. Arranca en 0 en todas las sucursales, o sea
+  que aplicarla no cambia ningún comportamiento hasta que alguien cargue un número.
+- **205** hace cumplir ese mínimo. Parchea `crear_pedido_completo` y
+  `crear_pedido_completo_bot` leyendo del catálogo vivo, y le prende el escape
+  hatch `app.omitir_minimo_pedido` a `cambiar_cliente_pedido`.
+  **El mínimo se valida SOLO al crear**, nunca como CHECK sobre `pedidos.total`:
+  cancelar un pedido lo pone en 0 (mig 175) y el invariante `VENTA-I` exige que
+  así sea (mig 105), así que un CHECK haría imposible cancelar.
 
 La **195** le da a la cabecera la columna `compras.bonificaciones`, que es donde se resta
 una bonificación general: el `subtotal` es el neto de los RENGLONES y lo clava `COMPRA-A2`

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -36,6 +36,7 @@ import ProductosContainer from './components/containers/ProductosContainer'
 import ProveedoresContainer from './components/containers/ProveedoresContainer'
 import RevisionHorariosContainer from './components/containers/RevisionHorariosContainer'
 import UsuariosContainer from './components/containers/UsuariosContainer'
+import ConfiguracionContainer from './components/containers/ConfiguracionContainer'
 
 // lazyWithReload: si un chunk quedó obsoleto tras un deploy (PWA con SW que
 // tomó control a mitad de sesión), recarga una vez en vez de colgar el Suspense.
@@ -304,6 +305,11 @@ function MainAppInner({ user, perfil, logout, authReady }: {
                 <Route
                   path="/usuarios"
                   element={isAdmin ? <UsuariosContainer /> : <Navigate to="/pedidos" replace />}
+                />
+
+                <Route
+                  path="/configuracion"
+                  element={isAdminOrEncargado ? <ConfiguracionContainer /> : <Navigate to="/pedidos" replace />}
                 />
 
                 <Route

--- a/src/components/containers/ClientesContainer.tsx
+++ b/src/components/containers/ClientesContainer.tsx
@@ -8,10 +8,12 @@ import React, { Suspense, useState, useCallback } from 'react'
 import { Loader2 } from 'lucide-react'
 import {
   useClientesQuery,
+  useClienteQuery,
   useCrearClienteMutation,
   useActualizarClienteMutation,
   useEliminarClienteMutation,
-  contarPedidosDeCliente,
+  contarReferenciasDeCliente,
+  buscarClientePorRazonSocial,
   useZonasEstandarizadasQuery,
   useProductosQuery,
   useCrearPedidoCambioEnRutaMutation,
@@ -23,7 +25,7 @@ import { useFichaCliente } from '../../hooks/supabase/useFichaCliente'
 import { usePagos } from '../../hooks/supabase'
 import { useResetOnSucursalChange } from '../../hooks/useResetOnSucursalChange'
 import { useQueryClient } from '@tanstack/react-query'
-import { puedeRegistrarPagoCliente } from '../../lib/permisos'
+import { puedeRegistrarPagoCliente, puedeDesactivarCliente, puedeEliminarCliente } from '../../lib/permisos'
 import type { ClienteDB } from '../../types'
 import type { ClienteSaveData } from '../modals/ModalCliente'
 import { lazyWithReload } from '../../utils/lazyWithReload'
@@ -67,8 +69,12 @@ export default function ClientesContainer(): React.ReactElement {
   // horarios, notas). El resto lo gestiona admin/encargado.
   const edicionRestringida = isPreventista && !isAdmin && !isEncargado
 
+  // "Ver inactivos": el panel es el unico lugar desde donde se reactiva un
+  // cliente dado de baja, asi que tiene que poder mostrarlos a pedido.
+  const [verInactivos, setVerInactivos] = useState(false)
+
   // Queries
-  const { data: clientes = [], isLoading } = useClientesQuery()
+  const { data: clientes = [], isLoading } = useClientesQuery({ includeInactivos: verInactivos })
   // includeInactive: true para no perder el texto cuando una zona se desactiva
   // entre ediciones del cliente — el espejo legacy debe seguir resolviendo
   // aunque la zona ya no esté disponible en el selector activo.
@@ -95,6 +101,12 @@ export default function ClientesContainer(): React.ReactElement {
 
   // Ficha cliente hook - ModalFichaCliente lo usa internamente
   useFichaCliente(clienteFichaId)
+
+  // Se resuelve por ID contra la base y no buscando en `clientes`: con
+  // "Ver inactivos" apagado esa lista no trae los desactivados, y la ficha se
+  // abre igual desde el panel de deudores, donde un inactivo con saldo sigue
+  // figurando.
+  const { data: clienteFicha } = useClienteQuery(clienteFichaId ?? '')
 
   // Estado de edición
   const [clienteEditando, setClienteEditando] = useState<ClienteDB | null>(null)
@@ -138,41 +150,65 @@ export default function ClientesContainer(): React.ReactElement {
     if (!cliente) return
     const nombre = cliente.nombre_fantasia || cliente.razon_social
 
-    let pedidos: { cantidad: number; total: number }
+    let referencias: Awaited<ReturnType<typeof contarReferenciasDeCliente>>
     try {
-      pedidos = await contarPedidosDeCliente(clienteId)
+      referencias = await contarReferenciasDeCliente(clienteId)
     } catch {
       // Sin poder contar no se pregunta: preguntar sin saber es lo que causo el problema.
-      notify.error('No se pudo verificar si el cliente tiene pedidos. No se eliminó nada.')
+      notify.error('No se pudo verificar si el cliente tiene movimientos. No se eliminó nada.')
       return
     }
 
-    if (pedidos.cantidad === 0) {
+    if (!referencias.bloqueanBorrado) {
+      if (!puedeEliminarCliente(rol)) {
+        notify.error('Solo un administrador puede eliminar clientes.')
+        return
+      }
       setConfirmConfig({
         visible: true, tipo: 'danger', titulo: 'Eliminar cliente',
-        mensaje: `¿Eliminar "${nombre}"? No tiene pedidos asociados.`,
+        mensaje: `¿Eliminar "${nombre}"? No tiene pedidos ni movimientos asociados.`,
         onConfirm: async () => {
           setConfirmConfig({ visible: false })
           try {
             await eliminarCliente.mutateAsync(clienteId)
             notify.success('Cliente eliminado')
-          } catch {
-            notify.error('Error al eliminar cliente')
+          } catch (err) {
+            // deleteCliente ya traduce el 23503 a un mensaje que dice que lo traba.
+            notify.error(err instanceof Error ? err.message : 'Error al eliminar cliente')
           }
         },
       })
       return
     }
 
-    // Con pedidos la base rechaza el DELETE (FK RESTRICT, mig 200). Se explica
-    // por que y se ofrece la accion que si corresponde: desactivarlo.
+    if (!puedeDesactivarCliente(rol)) {
+      notify.error('No tenés permiso para desactivar clientes.')
+      return
+    }
+
+    // Con movimientos la base rechaza el DELETE (FKs RESTRICT, migs 200/024/089).
+    // Se explica por que y se ofrece la accion que si corresponde: desactivarlo.
+    const detalle: string[] = []
+    if (referencias.pedidos.cantidad > 0) {
+      detalle.push(
+        `${referencias.pedidos.cantidad} ${referencias.pedidos.cantidad === 1 ? 'pedido' : 'pedidos'} ` +
+        `por ${formatCurrency(referencias.pedidos.total)}`
+      )
+    }
+    if (referencias.cambiosProductos > 0) {
+      detalle.push(`${referencias.cambiosProductos} ${referencias.cambiosProductos === 1 ? 'cambio' : 'cambios'} de producto`)
+    }
+    if (referencias.recorridoCambios > 0) {
+      detalle.push(`${referencias.recorridoCambios} ${referencias.recorridoCambios === 1 ? 'parada' : 'paradas'} de cambio`)
+    }
+
     setConfirmConfig({
-      visible: true, tipo: 'warning', titulo: 'El cliente tiene pedidos',
+      visible: true, tipo: 'warning', titulo: 'El cliente tiene historial',
       mensaje:
-        `"${nombre}" tiene ${pedidos.cantidad} ` +
-        `${pedidos.cantidad === 1 ? 'pedido' : 'pedidos'} por ${formatCurrency(pedidos.total)}. ` +
-        'No se puede eliminar sin perder esa venta del historial y de la cuenta corriente. ' +
-        'Al confirmar se DESACTIVA: deja de aparecer en las listas y sus pedidos quedan intactos.',
+        `"${nombre}" tiene ${detalle.join(' y ')}. ` +
+        'No se puede eliminar sin perder eso del historial y de la cuenta corriente. ' +
+        'Al confirmar se DESACTIVA: deja de aparecer en el panel y en los pedidos, ' +
+        'pero sus datos siguen intactos y visibles en los reportes.',
       onConfirm: async () => {
         setConfirmConfig({ visible: false })
         try {
@@ -183,7 +219,26 @@ export default function ClientesContainer(): React.ReactElement {
         }
       },
     })
-  }, [clientes, eliminarCliente, actualizarCliente, notify])
+  }, [clientes, eliminarCliente, actualizarCliente, notify, rol])
+
+  // Reactivar: la contracara de desactivar. Sin esto la baja logica seria un
+  // viaje de ida y el unico camino de vuelta seria crear un cliente nuevo, que
+  // es exactamente lo que parte el historial en dos.
+  const handleReactivarCliente = useCallback(async (clienteId: string) => {
+    const cliente = clientes.find(c => c.id === clienteId)
+    if (!cliente) return
+    const nombre = cliente.nombre_fantasia || cliente.razon_social
+    if (!puedeDesactivarCliente(rol)) {
+      notify.error('No tenés permiso para reactivar clientes.')
+      return
+    }
+    try {
+      await actualizarCliente.mutateAsync({ id: clienteId, data: { activo: true } })
+      notify.success(`"${nombre}" volvió a estar activo`)
+    } catch {
+      notify.error('Error al reactivar el cliente')
+    }
+  }, [clientes, actualizarCliente, notify, rol])
 
   const handleGuardarCambioEnRuta = useCallback(async (data: RegistrarCambioInput) => {
     try {
@@ -297,13 +352,25 @@ export default function ClientesContainer(): React.ReactElement {
     const nombreNuevoNorm = nombreNuevo.toLowerCase()
     const nombreOriginalNorm = (clienteEditando?.razon_social || '').trim().toLowerCase()
     if (nombreNuevoNorm && nombreNuevoNorm !== nombreOriginalNorm) {
-      const yaExiste = clientes.some(
-        c => c.id !== clienteEditando?.id &&
-          c.activo !== false &&
-          (c.razon_social || '').trim().toLowerCase() === nombreNuevoNorm
-      )
-      if (yaExiste) {
-        notify.error(`Ya existe un cliente con el nombre "${nombreNuevo}" en esta sucursal.`)
+      // Se consulta la BASE, no el array `clientes`: por defecto ese array no
+      // trae inactivos, asi que mirarlo dejaba crear un clon exacto del cliente
+      // recien desactivado -- la forma mas facil de partirle el historial al
+      // medio, y justo el movimiento que origino los 9 pedidos huerfanos.
+      // Cuando el que choca esta inactivo, el mensaje ofrece reactivarlo.
+      let choque: Awaited<ReturnType<typeof buscarClientePorRazonSocial>> = null
+      try {
+        choque = await buscarClientePorRazonSocial(nombreNuevo, clienteEditando?.id)
+      } catch {
+        notify.error('No se pudo verificar si el nombre ya existe. No se guardó nada.')
+        return
+      }
+      if (choque) {
+        notify.error(
+          choque.activo === false
+            ? `Ya existe "${nombreNuevo}" en esta sucursal, pero está inactivo. ` +
+              `Activá "Ver inactivos" y reactivalo, así conserva su historial.`
+            : `Ya existe un cliente con el nombre "${nombreNuevo}" en esta sucursal.`
+        )
         return
       }
     }
@@ -424,7 +491,7 @@ export default function ClientesContainer(): React.ReactElement {
       notify.error((error as Error).message || 'Error al guardar cliente')
       throw error
     }
-  }, [clienteEditando, clientes, actualizarCliente, crearCliente, notify, isAdmin, isPreventista, edicionRestringida, user, zonas])
+  }, [clienteEditando, actualizarCliente, crearCliente, notify, isAdmin, isPreventista, edicionRestringida, user, zonas])
 
   return (
     <>
@@ -438,6 +505,10 @@ export default function ClientesContainer(): React.ReactElement {
           onNuevoCliente={handleNuevoCliente}
           onEditarCliente={handleEditarCliente}
           onEliminarCliente={handleEliminarCliente}
+          onReactivarCliente={handleReactivarCliente}
+          verInactivos={verInactivos}
+          onVerInactivosChange={setVerInactivos}
+          puedeDesactivar={puedeDesactivarCliente(rol)}
           onVerFichaCliente={handleVerFichaCliente}
           onGestionarZonas={isAdmin ? handleGestionarZonas : undefined}
           onVerDeudores={(isAdmin || isEncargado) ? () => setModalDeudoresOpen(true) : undefined}
@@ -475,7 +546,7 @@ export default function ClientesContainer(): React.ReactElement {
       {modalFichaOpen && clienteFichaId && (
         <Suspense fallback={null}>
           <ModalFichaCliente
-            cliente={clientes.find(c => c.id === clienteFichaId) || null}
+            cliente={clienteFicha ?? clientes.find(c => c.id === clienteFichaId) ?? null}
             onClose={() => {
               setModalFichaOpen(false)
               setClienteFichaId(null)

--- a/src/components/containers/ConfiguracionContainer.tsx
+++ b/src/components/containers/ConfiguracionContainer.tsx
@@ -1,0 +1,66 @@
+/**
+ * ConfiguracionContainer
+ *
+ * Pantalla de políticas comerciales por sucursal (mig 204). Solo admin/encargado
+ * — el gate real está en el RPC y en la RLS; esto es la UI que lo acompaña.
+ */
+import { Suspense, useState, useCallback } from 'react'
+import { Loader2 } from 'lucide-react'
+import {
+  usePoliticasComercialesQuery,
+  useActualizarMontoMinimoMutation,
+  useImpactoMinimoQuery,
+} from '../../hooks/queries/usePoliticasComercialesQuery'
+import { useNotification } from '../../contexts/NotificationContext'
+import { useSucursal } from '../../contexts/SucursalContext'
+import { lazyWithReload } from '../../utils/lazyWithReload'
+
+const VistaConfiguracion = lazyWithReload(() => import('../vistas/VistaConfiguracion'))
+
+function LoadingState() {
+  return (
+    <div className="flex justify-center py-12">
+      <Loader2 className="w-6 h-6 animate-spin text-stone-400" />
+    </div>
+  )
+}
+
+export default function ConfiguracionContainer() {
+  const notify = useNotification()
+  const { currentSucursalNombre } = useSucursal()
+  const { politicas, isLoading } = usePoliticasComercialesQuery()
+  const actualizar = useActualizarMontoMinimoMutation()
+
+  // Lo que el usuario está tipeando, para poder mostrarle el impacto ANTES de
+  // guardar. Arranca en el valor vigente.
+  const [montoTipeado, setMontoTipeado] = useState<number>(politicas.montoMinimoPedido)
+  const { data: impacto, isFetching: impactoCargando } = useImpactoMinimoQuery(montoTipeado)
+
+  const handleGuardar = useCallback(async (monto: number) => {
+    try {
+      await actualizar.mutateAsync(monto)
+      notify.success(
+        monto > 0
+          ? `Compra mínima fijada en $${monto.toLocaleString('es-AR')}`
+          : 'Compra mínima desactivada'
+      )
+    } catch (err) {
+      notify.error(err instanceof Error ? err.message : 'No se pudo guardar la compra mínima')
+    }
+  }, [actualizar, notify])
+
+  return (
+    <Suspense fallback={<LoadingState />}>
+      <VistaConfiguracion
+        montoMinimoActual={politicas.montoMinimoPedido}
+        cargando={isLoading}
+        guardando={actualizar.isPending}
+        impacto={impacto}
+        impactoCargando={impactoCargando}
+        onMontoTipeado={setMontoTipeado}
+        onGuardar={handleGuardar}
+        nombreSucursal={currentSucursalNombre}
+      />
+    </Suspense>
+  )
+}

--- a/src/components/containers/ReportesContainer.tsx
+++ b/src/components/containers/ReportesContainer.tsx
@@ -1,6 +1,6 @@
 import React, { Suspense, useCallback, useEffect, useState } from 'react'
 import { Loader2 } from 'lucide-react'
-import { useClientesQuery, useReportePreventistasQuery } from '../../hooks/queries'
+import { useClienteQuery, useClientesQuery, useReportePreventistasQuery } from '../../hooks/queries'
 import { useNotification } from '../../contexts/NotificationContext'
 import type { ClienteDB } from '../../types'
 import { lazyWithReload } from '../../utils/lazyWithReload'
@@ -38,6 +38,12 @@ export default function ReportesContainer(): React.ReactElement {
   } = useReportePreventistasQuery(filtros.fechaDesde, filtros.fechaHasta, reporteInicializado)
 
   const { data: clientes = [] } = useClientesQuery()
+
+  // La ficha se resuelve por ID contra la base, NO buscando en `clientes`: esa
+  // lista ya no trae inactivos, y un cliente desactivado con deuda sigue
+  // apareciendo en el panel de deudores. Buscarlo en la lista devolvia null y
+  // la ficha se abria vacia justo para el caso que mas importa mirar.
+  const { data: clienteFicha } = useClienteQuery(clienteFichaId ?? '')
 
   useEffect(() => {
     if (error) {
@@ -78,7 +84,7 @@ export default function ReportesContainer(): React.ReactElement {
       {modalFichaOpen && clienteFichaId && (
         <Suspense fallback={null}>
           <ModalFichaCliente
-            cliente={clientes.find(cliente => String(cliente.id) === clienteFichaId) || null}
+            cliente={clienteFicha ?? clientes.find(cliente => String(cliente.id) === clienteFichaId) ?? null}
             onClose={() => {
               setModalFichaOpen(false)
               setClienteFichaId(null)

--- a/src/components/layout/TopNavigation.tsx
+++ b/src/components/layout/TopNavigation.tsx
@@ -4,7 +4,8 @@ import type { LucideIcon } from 'lucide-react';
 import {
   Truck, Menu, X, LogOut, Moon, Sun, ChevronDown,
   BarChart3, ShoppingCart, Users, Package, TrendingUp,
-  UserCog, Route, ShoppingBag, Building2, Banknote, AlertTriangle, Database, Percent, ArrowRightLeft, Gift, Send, MapPin, Clock, Target, ClipboardCheck
+  UserCog,
+  Settings, Route, ShoppingBag, Building2, Banknote, AlertTriangle, Database, Percent, ArrowRightLeft, Gift, Send, MapPin, Clock, Target, ClipboardCheck
 } from 'lucide-react';
 import { getRolColor, getRolLabel } from '../../utils/formatters';
 import { useTheme } from '../../contexts/ThemeContext';
@@ -96,6 +97,7 @@ const menuGroups: MenuGroup[] = [
       { id: 'horarios-clientes', icon: Clock, label: 'Horarios a revisar', roles: ['admin'] },
       { id: 'usuarios', icon: UserCog, label: 'Usuarios', roles: ['admin'] },
       { id: 'bot-telegram', icon: Send, label: 'Bot Telegram', roles: ['admin'] },
+      { id: 'configuracion', icon: Settings, label: 'Configuración', roles: ['admin', 'encargado'] },
     ]
   }
 ];

--- a/src/components/modals/ModalPedido.tsx
+++ b/src/components/modals/ModalPedido.tsx
@@ -10,6 +10,8 @@ import { usePreventistasAsignablesQuery } from '../../hooks/queries/useUsuariosQ
 import ModalBase from './ModalBase';
 import ModalConfirmacion, { type ModalConfirmacionConfig } from './ModalConfirmacion';
 import { obtenerMOQ } from '../../utils/precioMayorista';
+import { motivoMontoMinimo } from '../../utils/montoMinimo';
+import { usePoliticasComercialesQuery } from '../../hooks/queries/usePoliticasComercialesQuery';
 import GeolocationGate from '../GeolocationGate';
 import NumberInput from '../ui/NumberInput';
 import FranjasHorariasEditor from '../ui/FranjasHorariasEditor';
@@ -374,6 +376,16 @@ const ModalPedido = memo(function ModalPedido({
   const totalParaMostrar = hayDescuentoTotal ? totalConDescuentoCliente : calcularTotal();
   const hayItems = nuevoPedido.items.length > 0;
 
+  // Compra mínima de la sucursal (migs 204/205). La base la rechaza igual, pero
+  // el rechazo del servidor llega con el cliente adelante y el carrito entero
+  // cargado — y si el pedido se cargó sin señal, llega horas después. Se bloquea
+  // acá por lo mismo que se bloquea el MOQ, y sobre el total que realmente se
+  // persiste (el que ya tiene descuentos y promos aplicados).
+  const { politicas } = usePoliticasComercialesQuery();
+  const motivoMinimo = hayItems
+    ? motivoMontoMinimo(totalParaMostrar, politicas.montoMinimoPedido)
+    : null;
+
   const tipoFacturaToggle = (
     <label className="flex items-center gap-1.5">
       <span className="text-xs font-medium text-gray-600 dark:text-gray-400">Factura</span>
@@ -736,6 +748,13 @@ const ModalPedido = memo(function ModalPedido({
             aria-hidden={!carritoAbierto}
           >
             <div className="flex-1 overflow-y-auto overscroll-contain p-4 space-y-4 min-h-0">
+              {/* Compra mínima del pedido (bloquea confirmar) */}
+              {motivoMinimo && (
+                <div role="alert" className="p-3 bg-amber-50 border border-amber-300 rounded-lg text-sm text-amber-900 dark:bg-amber-900/30 dark:border-amber-600 dark:text-amber-200">
+                  <strong>No se puede confirmar:</strong> {motivoMinimo}
+                </div>
+              )}
+
               {/* Violaciones MOQ (bloquean confirmar) */}
               {violacionesMOQ.length > 0 && (
                 <div role="alert" className="p-3 bg-amber-50 border border-amber-300 rounded-lg text-sm text-amber-900 dark:bg-amber-900/30 dark:border-amber-600 dark:text-amber-200">
@@ -1176,6 +1195,13 @@ const ModalPedido = memo(function ModalPedido({
           </div>
         )}
 
+        {/* Aviso compacto de compra mínima (siempre visible cuando aplica) */}
+        {motivoMinimo && (
+          <div role="alert" className="flex-shrink-0 px-4 py-1.5 bg-amber-100 dark:bg-amber-900/40 border-t border-amber-300 dark:border-amber-700 text-xs text-amber-900 dark:text-amber-200">
+            {motivoMinimo}
+          </div>
+        )}
+
         {/* Aviso compacto de violaciones (siempre visible cuando aplican) */}
         {violacionesMOQ.length > 0 && (
           <div role="alert" className="flex-shrink-0 px-4 py-1.5 bg-amber-100 dark:bg-amber-900/40 border-t border-amber-300 dark:border-amber-700 text-xs text-amber-900 dark:text-amber-200">
@@ -1213,7 +1239,7 @@ const ModalPedido = memo(function ModalPedido({
           <button
             type="button"
             onClick={onGuardar}
-            disabled={guardando || violacionesMOQ.length > 0 || violacionesStock.length > 0 || !hayItems || debeElegirPreventista || faltaHorarioCliente}
+            disabled={guardando || violacionesMOQ.length > 0 || violacionesStock.length > 0 || !hayItems || debeElegirPreventista || faltaHorarioCliente || motivoMinimo !== null}
             className="px-5 bg-green-600 text-white font-semibold hover:bg-green-700 disabled:bg-gray-400 disabled:cursor-not-allowed flex items-center justify-center gap-1.5 text-sm"
           >
             {guardando && <Loader2 className="w-4 h-4 animate-spin" />}

--- a/src/components/vistas/VistaClientes.tsx
+++ b/src/components/vistas/VistaClientes.tsx
@@ -1,6 +1,6 @@
 import { useState, useMemo } from 'react';
 import type { ChangeEvent } from 'react';
-import { Users, Plus, Edit2, Trash2, Search, MapPin, Phone, FileText, Tag, Building2, AlertTriangle } from 'lucide-react';
+import { Users, Plus, Edit2, Trash2, Search, MapPin, Phone, FileText, Tag, Building2, AlertTriangle, RotateCcw } from 'lucide-react';
 import LoadingSpinner from '../layout/LoadingSpinner';
 import Paginacion from '../layout/Paginacion';
 import ClientesViewHeader from '../clientes/ClientesViewHeader';
@@ -35,6 +35,13 @@ export interface VistaClientesProps {
   onNuevoCliente: () => void;
   onEditarCliente: (cliente: ClienteDB) => void;
   onEliminarCliente: (id: string) => void;
+  /** Vuelve a poner activo un cliente dado de baja. */
+  onReactivarCliente: (id: string) => void;
+  /** Estado del check "Ver inactivos" (lo gobierna el container: cambia la query). */
+  verInactivos: boolean;
+  onVerInactivosChange: (valor: boolean) => void;
+  /** Si el usuario puede desactivar/reactivar (admin o encargado). */
+  puedeDesactivar: boolean;
   onVerFichaCliente?: (cliente: ClienteDB) => void;
   /** Solo se pasa cuando el usuario es admin (gating en el container). */
   onGestionarZonas?: () => void;
@@ -55,6 +62,10 @@ export default function VistaClientes({
   onNuevoCliente,
   onEditarCliente,
   onEliminarCliente,
+  onReactivarCliente,
+  verInactivos,
+  onVerInactivosChange,
+  puedeDesactivar,
   onVerFichaCliente,
   onGestionarZonas,
   onVerDeudores
@@ -280,6 +291,20 @@ export default function VistaClientes({
       {/* Stats */}
       <ClienteStats clientes={clientes} />
 
+      {/* Ver inactivos: el unico camino de vuelta para un cliente dado de baja.
+          Cambia la query (no filtra en memoria), por eso lo gobierna el container. */}
+      {puedeDesactivar && (
+        <label className="flex items-center gap-2 text-xs font-medium text-stone-600 dark:text-stone-300 cursor-pointer select-none w-fit">
+          <input
+            type="checkbox"
+            checked={verInactivos}
+            onChange={(e) => onVerInactivosChange(e.target.checked)}
+            className="rounded border-stone-300 dark:border-gray-600 text-amber-600 focus:ring-amber-500"
+          />
+          Ver clientes inactivos
+        </label>
+      )}
+
       {/* Contador de resultados (solo si hay filtros activos) */}
       {filtrosActivos && (
         <div className="text-xs font-medium uppercase tracking-[0.1em] text-stone-500 dark:text-stone-400">
@@ -302,8 +327,10 @@ export default function VistaClientes({
               idx={idx}
               isAdmin={isAdmin}
               canEditar={isAdmin || isEncargado || isPreventista}
+              puedeDesactivar={puedeDesactivar}
               onEditar={() => onEditarCliente(cliente)}
               onEliminar={() => onEliminarCliente(cliente.id)}
+              onReactivar={() => onReactivarCliente(cliente.id)}
               onVerFicha={onVerFichaCliente ? () => onVerFichaCliente(cliente) : undefined}
             />
           ))}
@@ -330,12 +357,15 @@ interface ClienteCardProps {
   idx: number;
   isAdmin: boolean;
   canEditar: boolean;
+  puedeDesactivar: boolean;
   onEditar: () => void;
   onEliminar: () => void;
+  onReactivar: () => void;
   onVerFicha?: () => void;
 }
 
-function ClienteCard({ cliente, idx, isAdmin, canEditar, onEditar, onEliminar, onVerFicha }: ClienteCardProps) {
+function ClienteCard({ cliente, idx, isAdmin, canEditar, puedeDesactivar, onEditar, onEliminar, onReactivar, onVerFicha }: ClienteCardProps) {
+  const inactivo = cliente.activo === false;
   const saldo = cliente.saldo_cuenta ?? 0;
   const saldoColor =
     saldo > 0 ? 'text-rose-700 dark:text-rose-300'
@@ -344,7 +374,11 @@ function ClienteCard({ cliente, idx, isAdmin, canEditar, onEditar, onEliminar, o
 
   return (
     <div
-      className="group bg-white dark:bg-gray-800 border border-stone-200/80 dark:border-gray-700 rounded-xl shadow-warm hover:shadow-warm-md hover:-translate-y-px hover:border-stone-300 dark:hover:border-gray-600 transition-[transform,box-shadow,border-color] duration-200 overflow-hidden flex flex-col"
+      className={`group bg-white dark:bg-gray-800 border rounded-xl shadow-warm hover:shadow-warm-md hover:-translate-y-px dark:hover:border-gray-600 transition-[transform,box-shadow,border-color] duration-200 overflow-hidden flex flex-col ${
+        inactivo
+          ? 'border-stone-300 dark:border-gray-600 opacity-60 grayscale'
+          : 'border-stone-200/80 dark:border-gray-700 hover:border-stone-300'
+      }`}
       style={{
         animation: 'card-in 0.32s cubic-bezier(0.22, 1, 0.36, 1) both',
         animationDelay: `${Math.min(idx, 12) * 40}ms`,
@@ -353,6 +387,11 @@ function ClienteCard({ cliente, idx, isAdmin, canEditar, onEditar, onEliminar, o
       {/* Crumb + acciones admin */}
       <div className="px-4 pt-3 flex items-center justify-between gap-2">
         <div className="text-[10.5px] font-semibold uppercase tracking-[0.18em] text-stone-500 dark:text-stone-400 flex items-center gap-0 min-w-0 flex-wrap">
+          {inactivo && (
+            <span className="mr-2 px-1.5 py-0.5 rounded bg-stone-200 dark:bg-gray-700 text-stone-700 dark:text-stone-300 tracking-normal">
+              Inactivo
+            </span>
+          )}
           {cliente.codigo != null && (
             <span className="tabular-nums">#{cliente.codigo}</span>
           )}
@@ -380,14 +419,27 @@ function ClienteCard({ cliente, idx, isAdmin, canEditar, onEditar, onEliminar, o
                 <Edit2 className="w-3.5 h-3.5" aria-hidden="true" />
               </button>
             )}
-            {isAdmin && (
-              <button
-                onClick={onEliminar}
-                className="p-1.5 text-stone-500 hover:text-rose-600 hover:bg-rose-50 dark:hover:bg-rose-900/30 rounded-md transition-colors"
-                aria-label={`Eliminar cliente ${cliente.nombre_fantasia}`}
-              >
-                <Trash2 className="w-3.5 h-3.5" aria-hidden="true" />
-              </button>
+            {inactivo ? (
+              puedeDesactivar && (
+                <button
+                  onClick={onReactivar}
+                  className="p-1.5 text-stone-500 hover:text-emerald-600 hover:bg-emerald-50 dark:hover:bg-emerald-900/30 rounded-md transition-colors"
+                  aria-label={`Reactivar cliente ${cliente.nombre_fantasia}`}
+                >
+                  <RotateCcw className="w-3.5 h-3.5" aria-hidden="true" />
+                </button>
+              )
+            ) : (
+              (isAdmin || puedeDesactivar) && (
+                <button
+                  onClick={onEliminar}
+                  className="p-1.5 text-stone-500 hover:text-rose-600 hover:bg-rose-50 dark:hover:bg-rose-900/30 rounded-md transition-colors"
+                  aria-label={`Eliminar o desactivar cliente ${cliente.nombre_fantasia}`}
+                  title="Eliminar. Si el cliente tiene historial, se ofrece desactivarlo."
+                >
+                  <Trash2 className="w-3.5 h-3.5" aria-hidden="true" />
+                </button>
+              )
             )}
           </div>
         )}

--- a/src/components/vistas/VistaConfiguracion.tsx
+++ b/src/components/vistas/VistaConfiguracion.tsx
@@ -1,0 +1,165 @@
+/**
+ * Configuración comercial de la sucursal activa.
+ *
+ * Primera pantalla de configuración del sistema. Hoy tiene una sola política —
+ * la compra mínima por pedido — pero es el lugar donde van las que vengan:
+ * sumar una es una columna en `politicas_comerciales` (mig 204) y un campo acá.
+ */
+import { useState, useEffect, type FormEvent } from 'react';
+import { Loader2, Settings, AlertTriangle } from 'lucide-react';
+import { formatCurrency } from '../../utils/formatters';
+
+export interface VistaConfiguracionProps {
+  montoMinimoActual: number;
+  cargando: boolean;
+  guardando: boolean;
+  /** Impacto del valor tipeado sobre los últimos 90 días. */
+  impacto?: { total: number; bloqueados: number };
+  impactoCargando: boolean;
+  /** Lo dispara el container al tipear, para recalcular el impacto. */
+  onMontoTipeado: (monto: number) => void;
+  onGuardar: (monto: number) => void;
+  nombreSucursal?: string | null;
+}
+
+export default function VistaConfiguracion({
+  montoMinimoActual,
+  cargando,
+  guardando,
+  impacto,
+  impactoCargando,
+  onMontoTipeado,
+  onGuardar,
+  nombreSucursal,
+}: VistaConfiguracionProps) {
+  const [valor, setValor] = useState(String(montoMinimoActual ?? 0));
+  const [error, setError] = useState<string | null>(null);
+
+  // El valor del servidor llega después del primer render (y cambia al cambiar
+  // de sucursal): sin esto el campo se quedaría mostrando 0.
+  useEffect(() => {
+    setValor(String(montoMinimoActual ?? 0));
+  }, [montoMinimoActual]);
+
+  const parseado = Number(valor.replace(',', '.'));
+  const valido = Number.isFinite(parseado) && parseado >= 0;
+  const cambio = valido && parseado !== montoMinimoActual;
+
+  function handleChange(v: string) {
+    setValor(v);
+    setError(null);
+    const n = Number(v.replace(',', '.'));
+    if (Number.isFinite(n) && n >= 0) onMontoTipeado(n);
+  }
+
+  function handleSubmit(e: FormEvent) {
+    e.preventDefault();
+    if (!valido) {
+      setError('Ingresá un monto válido (0 o mayor).');
+      return;
+    }
+    onGuardar(parseado);
+  }
+
+  if (cargando) {
+    return (
+      <div className="flex justify-center py-12">
+        <Loader2 className="w-6 h-6 animate-spin text-stone-400" aria-label="Cargando" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6 max-w-2xl">
+      <header className="flex items-center gap-3">
+        <Settings className="w-6 h-6 text-stone-500" aria-hidden="true" />
+        <div>
+          <h1 className="text-2xl font-semibold text-stone-900 dark:text-white">Configuración</h1>
+          <p className="text-sm text-stone-500 dark:text-stone-400">
+            Políticas comerciales de {nombreSucursal || 'la sucursal activa'}
+          </p>
+        </div>
+      </header>
+
+      <form
+        onSubmit={handleSubmit}
+        className="bg-white dark:bg-gray-800 border border-stone-200/80 dark:border-gray-700 rounded-xl p-5 space-y-4 shadow-warm"
+      >
+        <div>
+          <label
+            htmlFor="monto-minimo"
+            className="block text-sm font-semibold text-stone-900 dark:text-white"
+          >
+            Compra mínima por pedido
+          </label>
+          <p className="text-xs text-stone-500 dark:text-stone-400 mt-1">
+            Ningún pedido de esta sucursal va a poder cargarse por debajo de este monto —
+            ni desde la app, ni sin señal, ni desde el bot. Dejalo en 0 para no exigir mínimo.
+          </p>
+
+          <div className="mt-3 flex items-center gap-2">
+            <span className="text-stone-500 dark:text-stone-400">$</span>
+            <input
+              id="monto-minimo"
+              type="number"
+              min={0}
+              step="0.01"
+              inputMode="decimal"
+              value={valor}
+              onChange={(e) => handleChange(e.target.value)}
+              aria-invalid={!valido}
+              aria-describedby={error ? 'monto-minimo-error' : undefined}
+              className="w-48 px-3 py-2 rounded-lg border border-stone-300 dark:border-gray-600 dark:bg-gray-900 dark:text-white focus:ring-2 focus:ring-amber-500 focus:border-amber-500"
+            />
+          </div>
+
+          {error && (
+            <p id="monto-minimo-error" role="alert" className="text-rose-600 text-xs mt-2">
+              {error}
+            </p>
+          )}
+        </div>
+
+        {/* Impacto: que nadie elija el número a ciegas. Un mínimo mal puesto no
+            falla — simplemente frena la operación, y se nota recién en la calle. */}
+        {parseado > 0 && (
+          <div className="rounded-lg border border-amber-300 bg-amber-50 dark:bg-amber-900/20 dark:border-amber-700 p-3 text-sm">
+            <div className="flex items-start gap-2">
+              <AlertTriangle className="w-4 h-4 text-amber-600 dark:text-amber-400 mt-0.5 shrink-0" aria-hidden="true" />
+              <div className="text-amber-900 dark:text-amber-200">
+                {impactoCargando ? (
+                  'Calculando el impacto…'
+                ) : impacto && impacto.total > 0 ? (
+                  <>
+                    Con un mínimo de <strong>{formatCurrency(parseado)}</strong>,{' '}
+                    <strong>{impacto.bloqueados}</strong> de los {impacto.total} pedidos
+                    de los últimos 90 días no se habrían podido cargar
+                    {' '}({Math.round((impacto.bloqueados / impacto.total) * 100)}%).
+                  </>
+                ) : (
+                  'No hay pedidos recientes para estimar el impacto.'
+                )}
+              </div>
+            </div>
+          </div>
+        )}
+
+        <div className="flex items-center gap-3">
+          <button
+            type="submit"
+            disabled={guardando || !cambio}
+            className="px-4 py-2 rounded-lg bg-amber-600 text-white font-semibold text-sm hover:bg-amber-700 disabled:bg-stone-300 dark:disabled:bg-gray-600 disabled:cursor-not-allowed flex items-center gap-2"
+          >
+            {guardando && <Loader2 className="w-4 h-4 animate-spin" aria-hidden="true" />}
+            Guardar
+          </button>
+          {!cambio && valido && (
+            <span className="text-xs text-stone-500 dark:text-stone-400">
+              Mínimo vigente: {formatCurrency(montoMinimoActual)}
+            </span>
+          )}
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/src/hooks/queries/index.ts
+++ b/src/hooks/queries/index.ts
@@ -87,7 +87,8 @@ export {
   useCrearClienteMutation,
   useActualizarClienteMutation,
   useEliminarClienteMutation,
-  contarPedidosDeCliente,
+  contarReferenciasDeCliente,
+  buscarClientePorRazonSocial,
 } from './useClientesQuery'
 
 // Pedidos

--- a/src/hooks/queries/index.ts
+++ b/src/hooks/queries/index.ts
@@ -91,6 +91,17 @@ export {
   buscarClientePorRazonSocial,
 } from './useClientesQuery'
 
+// Politica comercial por sucursal (mig 204)
+export {
+  usePoliticasComercialesQuery,
+  useActualizarMontoMinimoMutation,
+  useImpactoMinimoQuery,
+  leerMontoMinimoCacheado,
+  POLITICAS_POR_DEFECTO,
+  politicasComercialesKeys,
+} from './usePoliticasComercialesQuery'
+export type { PoliticasComerciales, ImpactoMinimo } from './usePoliticasComercialesQuery'
+
 // Pedidos
 export {
   pedidosKeys,

--- a/src/hooks/queries/useCambiosProductosQuery.ts
+++ b/src/hooks/queries/useCambiosProductosQuery.ts
@@ -57,7 +57,7 @@ export function useRegistrarCambioProductoMutation() {
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: productosKeys.lists(currentSucursalId) })
       queryClient.invalidateQueries({ queryKey: productosKeys.stockBajo(currentSucursalId, 10) })
-      queryClient.invalidateQueries({ queryKey: clientesKeys.lists(currentSucursalId) })
+      queryClient.invalidateQueries({ queryKey: clientesKeys.listsPrefix(currentSucursalId) })
       queryClient.invalidateQueries({ queryKey: cambiosProductosKeys.lists(currentSucursalId) })
     },
   })
@@ -130,7 +130,7 @@ export function useAplicarCambioParadaMutation() {
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: productosKeys.lists(currentSucursalId) })
       queryClient.invalidateQueries({ queryKey: productosKeys.stockBajo(currentSucursalId, 10) })
-      queryClient.invalidateQueries({ queryKey: clientesKeys.lists(currentSucursalId) })
+      queryClient.invalidateQueries({ queryKey: clientesKeys.listsPrefix(currentSucursalId) })
       queryClient.invalidateQueries({ queryKey: cambiosProductosKeys.lists(currentSucursalId) })
       queryClient.invalidateQueries({ queryKey: ['recorrido-activo'] })
       queryClient.invalidateQueries({ queryKey: ['pedidos'] })

--- a/src/hooks/queries/useClientesQuery.bajaLogica.test.tsx
+++ b/src/hooks/queries/useClientesQuery.bajaLogica.test.tsx
@@ -1,0 +1,107 @@
+/**
+ * Tests de la baja lógica de clientes.
+ *
+ * EL INCIDENTE
+ * ------------
+ * Borrar un cliente con pedidos ya no se puede: desde la mig 200 la FK es
+ * `ON DELETE RESTRICT` (antes era SET NULL, y así 9 pedidos por $200.070
+ * quedaron sin dueño — mig 199). La app pasó a ofrecer "desactivar" en su lugar
+ * y le decía al usuario, textualmente, que el cliente "deja de aparecer en las
+ * listas".
+ *
+ * Era falso: `fetchClientes` no filtraba por `activo` y ningún consumidor lo
+ * hacía tampoco. En prod había dos clientes con `activo = false` visibles en el
+ * panel, en el selector de pedidos y en los recorridos. La única acción que la
+ * app ofrecía no tenía ningún efecto observable, y por eso se percibía como
+ * "no se pueden eliminar clientes".
+ *
+ * Lo que fijan estos tests es el filtro y su contracara: que por defecto no
+ * vengan inactivos, que `includeInactivos` sí los traiga (es el único camino
+ * para reactivar uno), y que las dos variantes no compartan entrada de caché
+ * —si la compartieran, prender el check devolvería la lista filtrada—.
+ */
+import React from 'react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+
+const eq = vi.fn()
+const order = vi.fn()
+const select = vi.fn()
+const from = vi.fn()
+
+vi.mock('../supabase/base', () => ({
+  supabase: {
+    from: (...args: unknown[]) => from(...args),
+    rpc: vi.fn(),
+  },
+}))
+
+vi.mock('../../contexts/SucursalContext', () => ({
+  useSucursal: () => ({ currentSucursalId: 1 }),
+}))
+
+import { useClientesQuery, clientesKeys } from './useClientesQuery'
+
+const FILAS = [{ id: '1', nombre_fantasia: 'Activo', activo: true }]
+
+/**
+ * El builder de PostgREST es encadenable y "thenable": `fetchClientes` puede
+ * terminar en `.order(...)` o en `.eq(...)` según el flag, así que las dos
+ * puntas tienen que resolver a `{ data, error }`.
+ */
+function armarBuilder() {
+  const resultado = Promise.resolve({ data: FILAS, error: null })
+  const builder: Record<string, unknown> = {}
+  builder.select = select.mockReturnValue(builder)
+  builder.order = order.mockReturnValue(builder)
+  builder.eq = eq.mockReturnValue(resultado)
+  builder.then = resultado.then.bind(resultado)
+  return builder
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  from.mockImplementation(() => armarBuilder())
+})
+
+function makeWrapper(qc: QueryClient) {
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return <QueryClientProvider client={qc}>{children}</QueryClientProvider>
+  }
+}
+
+function nuevoQueryClient() {
+  return new QueryClient({ defaultOptions: { queries: { retry: false } } })
+}
+
+describe('useClientesQuery — baja lógica', () => {
+  it('por defecto pide solo los clientes activos', async () => {
+    const qc = nuevoQueryClient()
+    const { result } = renderHook(() => useClientesQuery(), { wrapper: makeWrapper(qc) })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(from).toHaveBeenCalledWith('clientes')
+    expect(eq).toHaveBeenCalledWith('activo', true)
+  })
+
+  it('con includeInactivos NO filtra, que es como se llega a reactivar uno', async () => {
+    const qc = nuevoQueryClient()
+    const { result } = renderHook(
+      () => useClientesQuery({ includeInactivos: true }),
+      { wrapper: makeWrapper(qc) }
+    )
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(from).toHaveBeenCalledWith('clientes')
+    expect(eq).not.toHaveBeenCalledWith('activo', true)
+  })
+
+  it('las dos variantes no comparten entrada de caché', () => {
+    // Si compartieran clave, prender "Ver inactivos" serviría la lista ya
+    // filtrada desde la caché y el check parecería no hacer nada.
+    expect(clientesKeys.lists(1, false)).not.toEqual(clientesKeys.lists(1, true))
+  })
+})

--- a/src/hooks/queries/useClientesQuery.ts
+++ b/src/hooks/queries/useClientesQuery.ts
@@ -10,7 +10,8 @@ import type { ClienteDB } from '../../types'
 // Query keys
 export const clientesKeys = {
   all: (sucursalId: number | null) => ['clientes', sucursalId] as const,
-  lists: (sucursalId: number | null) => [...clientesKeys.all(sucursalId), 'list'] as const,
+  lists: (sucursalId: number | null, includeInactivos = false) =>
+    [...clientesKeys.all(sucursalId), 'list', includeInactivos] as const,
   list: (sucursalId: number | null, filters: Record<string, unknown>) => [...clientesKeys.lists(sucursalId), filters] as const,
   details: (sucursalId: number | null) => [...clientesKeys.all(sucursalId), 'detail'] as const,
   detail: (sucursalId: number | null, id: string) => [...clientesKeys.details(sucursalId), id] as const,
@@ -38,11 +39,24 @@ function flattenClienteRow(row: ClienteRow): ClienteDB {
 const CLIENTE_SELECT = '*, cliente_preventistas(preventista_id), cliente_descuentos_categoria(categoria, descuento_porcentaje)'
 
 // Fetch functions
-async function fetchClientes(): Promise<ClienteDB[]> {
-  const { data, error } = await supabase
+
+// Baja logica: `activo = false` es un cliente dado de baja. Se filtra ACA y no en
+// cada consumidor porque este fetch alimenta el panel, los tres autocompletes de
+// pedidos, el dashboard y los recorridos: un filtro por pantalla se olvida en la
+// proxima. Hasta la mig 200 la app ofrecia desactivar y no filtraba en ningun
+// lado, asi que el cliente "desactivado" seguia apareciendo entero y la accion
+// parecia no hacer nada.
+// El historial NO pasa por aca: los pedidos viejos resuelven el nombre por el
+// embed `cliente:clientes(*)` de PedidosContainer, y los reportes por sus RPCs.
+async function fetchClientes(includeInactivos = false): Promise<ClienteDB[]> {
+  let query = supabase
     .from('clientes')
     .select(CLIENTE_SELECT)
     .order('nombre_fantasia')
+
+  if (!includeInactivos) query = query.eq('activo', true)
+
+  const { data, error } = await query
 
   if (error) throw error
   return ((data as ClienteRow[]) || []).map(flattenClienteRow)
@@ -185,12 +199,17 @@ async function createCliente(cliente: ClienteCreateInput, sucursalId: number | n
     throw new Error('No hay sucursal activa. Recargá la página e intentá de nuevo.')
   }
 
-  // Detección de duplicados por ubicación (~0.2 metros de tolerancia)
+  // Detección de duplicados por ubicación (~0.2 metros de tolerancia).
+  // Mira TAMBIEN a los inactivos, y a proposito: el caso que origino todo el
+  // incidente de los huerfanos (mig 199) fue una deduplicacion -- alguien creaba
+  // el cliente nuevo y despues borraba el viejo. Si el de esa esquina esta
+  // desactivado, lo que corresponde es reactivarlo, no crear un segundo cliente
+  // con la misma direccion y partirle el historial al medio.
   if (cliente.latitud != null && cliente.longitud != null) {
     const TOLERANCE = 0.000002 // ~0.2 metros (6 decimales de precisión)
     const { data: cercanos } = await supabase
       .from('clientes')
-      .select('id, nombre_fantasia, razon_social')
+      .select('id, nombre_fantasia, razon_social, activo')
       .gte('latitud', cliente.latitud - TOLERANCE)
       .lte('latitud', cliente.latitud + TOLERANCE)
       .gte('longitud', cliente.longitud - TOLERANCE)
@@ -198,7 +217,14 @@ async function createCliente(cliente: ClienteCreateInput, sucursalId: number | n
       .limit(1)
 
     if (cercanos && cercanos.length > 0) {
-      const nombre = cercanos[0].nombre_fantasia || cercanos[0].razon_social
+      const encontrado = cercanos[0] as { nombre_fantasia?: string; razon_social?: string; activo?: boolean }
+      const nombre = encontrado.nombre_fantasia || encontrado.razon_social
+      if (encontrado.activo === false) {
+        throw new Error(
+          `Ya existe un cliente en esta ubicación, "${nombre}", pero está inactivo. ` +
+          `Activá "Ver inactivos" en el panel de clientes y reactivalo, así conserva su historial.`
+        )
+      }
       throw new Error(
         `Ya existe un cliente en esta ubicación: ${nombre}. ` +
         `Si necesitás crear otro, modificá ligeramente la dirección.`
@@ -295,44 +321,135 @@ async function deleteCliente(id: string): Promise<void> {
     .delete()
     .eq('id', id)
 
-  if (error) throw error
+  if (!error) return
+
+  // 23503 = foreign_key_violation. La base es la fuente de verdad: aunque el
+  // container cuenta las referencias antes de preguntar, entre el conteo y el
+  // DELETE puede entrar un pedido. Sin esta traduccion el usuario ve
+  // "Error al eliminar cliente" y no tiene forma de saber que lo trabo.
+  if (error.code === '23503') {
+    const referencias = await contarReferenciasDeCliente(id).catch(() => null)
+    const partes: string[] = []
+    if (referencias) {
+      const { cantidad } = referencias.pedidos
+      if (cantidad > 0) partes.push(`${cantidad} pedido${cantidad === 1 ? '' : 's'}`)
+      if (referencias.cambiosProductos > 0) {
+        partes.push(`${referencias.cambiosProductos} cambio${referencias.cambiosProductos === 1 ? '' : 's'} de producto`)
+      }
+      if (referencias.recorridoCambios > 0) {
+        partes.push(`${referencias.recorridoCambios} parada${referencias.recorridoCambios === 1 ? '' : 's'} de cambio`)
+      }
+    }
+    const ref = partes.length > 0 ? partes.join(', ') : 'movimientos asociados'
+    throw new Error(
+      `No se puede eliminar: el cliente tiene ${ref}. Desactivalo para sacarlo de las listas sin perder el historial.`
+    )
+  }
+
+  throw error
 }
 
 /**
- * Cuenta los pedidos de un cliente y cuanto suman, para poder avisar ANTES de
- * borrarlo.
+ * Busca un cliente por razon social exacta (case-insensitive), INCLUIDOS los
+ * inactivos, dentro de la sucursal activa (la RLS la acota sola).
  *
- * Existe porque la FK era ON DELETE SET NULL y borrar un cliente desprendia sus
- * pedidos en silencio: 9 pedidos por $200.070 quedaron sin dueno asi (mig 199).
- * Desde la mig 200 la FK es RESTRICT y la base rechaza el borrado, pero el
- * usuario merece saber por que antes de intentarlo, no despues.
+ * No alcanza con mirar el array que ya tiene el container: por defecto ese array
+ * NO trae inactivos, asi que el chequeo de duplicados no los veia y dejaba crear
+ * un clon exacto del cliente recien desactivado.
+ *
+ * `ilike` sin comodines es igualdad case-insensitive. Se escapan `%` y `_`
+ * porque en un nombre son literales, no comodines.
  */
-export async function contarPedidosDeCliente(
-  clienteId: string
-): Promise<{ cantidad: number; total: number }> {
-  const { data, error } = await supabase
-    .from('pedidos')
-    .select('total')
-    .eq('cliente_id', clienteId)
+export async function buscarClientePorRazonSocial(
+  razonSocial: string,
+  excluirId?: string
+): Promise<{ id: string; nombre_fantasia?: string; razon_social?: string; activo?: boolean } | null> {
+  const patron = razonSocial.trim().replace(/[\\%_]/g, m => `\\${m}`)
+  if (!patron) return null
 
+  let query = supabase
+    .from('clientes')
+    .select('id, nombre_fantasia, razon_social, activo')
+    .ilike('razon_social', patron)
+    .limit(2)
+
+  if (excluirId) query = query.neq('id', excluirId)
+
+  const { data, error } = await query
   if (error) throw error
-  const filas = data || []
+  return (data && data.length > 0) ? (data[0] as { id: string; nombre_fantasia?: string; razon_social?: string; activo?: boolean }) : null
+}
+
+export interface ReferenciasCliente {
+  /** Pedidos del cliente y cuanto suman. Es la referencia que se le explica al usuario. */
+  pedidos: { cantidad: number; total: number }
+  /** Cambios de producto (mig 024). FK sin ON DELETE => RESTRICT. */
+  cambiosProductos: number
+  /** Paradas de cambio en recorridos (mig 089). FK sin ON DELETE => RESTRICT. */
+  recorridoCambios: number
+  /** true si alguna FK RESTRICT va a rechazar el DELETE. */
+  bloqueanBorrado: boolean
+}
+
+/**
+ * Cuenta todo lo que cuelga de un cliente, para poder avisar ANTES de borrarlo.
+ *
+ * Existe porque la FK de pedidos era ON DELETE SET NULL y borrar un cliente
+ * desprendia sus pedidos en silencio: 9 pedidos por $200.070 quedaron sin dueno
+ * asi (mig 199). Desde la mig 200 la FK es RESTRICT y la base rechaza el
+ * borrado, pero el usuario merece saber por que antes de intentarlo, no despues.
+ *
+ * OJO: `pedidos` no es la unica FK que traba el DELETE. `cambios_productos`
+ * (024) y `recorrido_cambios` (089) tampoco declaran ON DELETE, y en Postgres
+ * eso es NO ACTION -- o sea RESTRICT. Contando solo pedidos, un cliente con un
+ * cambio de producto y ningun pedido caia igual en el 23503, pero la app le
+ * mostraba el confirm de "no tiene pedidos asociados" y despues un
+ * "Error al eliminar cliente" sin explicacion.
+ */
+export async function contarReferenciasDeCliente(
+  clienteId: string
+): Promise<ReferenciasCliente> {
+  const [pedidosRes, cambiosRes, recorridoRes] = await Promise.all([
+    supabase.from('pedidos').select('total').eq('cliente_id', clienteId),
+    supabase.from('cambios_productos').select('id').eq('cliente_id', clienteId),
+    supabase.from('recorrido_cambios').select('id').eq('cliente_id', clienteId),
+  ])
+
+  if (pedidosRes.error) throw pedidosRes.error
+  if (cambiosRes.error) throw cambiosRes.error
+  if (recorridoRes.error) throw recorridoRes.error
+
+  const filas = pedidosRes.data || []
+  const cambiosProductos = (cambiosRes.data || []).length
+  const recorridoCambios = (recorridoRes.data || []).length
+
   return {
-    cantidad: filas.length,
-    total: filas.reduce((acc, p) => acc + Number(p.total || 0), 0),
+    pedidos: {
+      cantidad: filas.length,
+      total: filas.reduce((acc, p) => acc + Number(p.total || 0), 0),
+    },
+    cambiosProductos,
+    recorridoCambios,
+    bloqueanBorrado: filas.length > 0 || cambiosProductos > 0 || recorridoCambios > 0,
   }
 }
 
 // Hooks
 
 /**
- * Hook para obtener todos los clientes activos
+ * Hook para obtener los clientes de la sucursal activa.
+ *
+ * Por defecto devuelve SOLO los activos: un cliente dado de baja no tiene que
+ * aparecer en el panel ni en ningun selector. `includeInactivos` es para el
+ * check "Ver inactivos" del panel de clientes, que es desde donde se los
+ * reactiva -- sin eso, desactivar seria un viaje de ida.
  */
-export function useClientesQuery() {
+export function useClientesQuery(opts?: { includeInactivos?: boolean }) {
   const { currentSucursalId } = useSucursal()
+  const includeInactivos = opts?.includeInactivos ?? false
   return useQuery({
-    queryKey: clientesKeys.lists(currentSucursalId),
-    queryFn: fetchClientes,
+    queryKey: clientesKeys.lists(currentSucursalId, includeInactivos),
+    queryFn: () => fetchClientes(includeInactivos),
     staleTime: 5 * 60 * 1000, // 5 minutos
   })
 }
@@ -391,8 +508,8 @@ export function useCrearClienteMutation() {
           (a.nombre_fantasia || '').localeCompare(b.nombre_fantasia || '')
         )
       })
-      // Invalidar zonas por si es una nueva zona
-      queryClient.invalidateQueries({ queryKey: clientesKeys.zonas(currentSucursalId) })
+      // Invalidar el prefijo: alcanza a las dos variantes de lista y a las zonas
+      queryClient.invalidateQueries({ queryKey: clientesKeys.all(currentSucursalId) })
       // Invalidar clientes por zona si aplica
       if (newCliente.zona) {
         queryClient.invalidateQueries({ queryKey: clientesKeys.byZona(currentSucursalId, newCliente.zona) })
@@ -435,9 +552,11 @@ export function useActualizarClienteMutation() {
       queryClient.setQueryData(clientesKeys.detail(currentSucursalId, updatedCliente.id), updatedCliente)
     },
     onSettled: () => {
-      // Revalidar para asegurar consistencia
-      queryClient.invalidateQueries({ queryKey: clientesKeys.lists(currentSucursalId) })
-      queryClient.invalidateQueries({ queryKey: clientesKeys.zonas(currentSucursalId) })
+      // Se invalida el PREFIJO `all`, no `lists()`: desde que la lista tiene dos
+      // variantes en cache (con y sin inactivos), invalidar solo la de activos
+      // dejaba la otra vieja. Se notaba justo en el caso que importa: desactivar
+      // un cliente y que siguiera figurando en "Ver inactivos" como activo.
+      queryClient.invalidateQueries({ queryKey: clientesKeys.all(currentSucursalId) })
     },
   })
 }
@@ -454,11 +573,13 @@ export function useEliminarClienteMutation() {
     onSuccess: (_, deletedId) => {
       // Remover de cache de detalle
       queryClient.removeQueries({ queryKey: clientesKeys.detail(currentSucursalId, deletedId) })
-      // Actualizar cache de lista
-      queryClient.setQueryData<ClienteDB[]>(clientesKeys.lists(currentSucursalId), (old) => {
-        if (!old) return []
-        return old.filter(c => c.id !== deletedId)
-      })
+      // Sacarlo de las dos variantes de la lista (con y sin inactivos)
+      for (const incluirInactivos of [false, true]) {
+        queryClient.setQueryData<ClienteDB[]>(
+          clientesKeys.lists(currentSucursalId, incluirInactivos),
+          (old) => (old ? old.filter(c => c.id !== deletedId) : old)
+        )
+      }
     },
   })
 }

--- a/src/hooks/queries/useClientesQuery.ts
+++ b/src/hooks/queries/useClientesQuery.ts
@@ -10,9 +10,18 @@ import type { ClienteDB } from '../../types'
 // Query keys
 export const clientesKeys = {
   all: (sucursalId: number | null) => ['clientes', sucursalId] as const,
+  /**
+   * OJO: la lista tiene DOS variantes en cache (con y sin inactivos), y el
+   * segundo argumento tiene default. `lists(sucursalId)` compila y apunta a la
+   * de activos, asi que usarla como filtro de invalidacion deja la otra vieja
+   * -- y `tsc` no lo ve. Para invalidar o escribir sobre "la lista", usá
+   * `listsPrefix` con las APIs plurales (`setQueriesData`/`getQueriesData`),
+   * que alcanzan a las dos.
+   */
   lists: (sucursalId: number | null, includeInactivos = false) =>
     [...clientesKeys.all(sucursalId), 'list', includeInactivos] as const,
-  list: (sucursalId: number | null, filters: Record<string, unknown>) => [...clientesKeys.lists(sucursalId), filters] as const,
+  listsPrefix: (sucursalId: number | null) => [...clientesKeys.all(sucursalId), 'list'] as const,
+  list: (sucursalId: number | null, filters: Record<string, unknown>) => [...clientesKeys.listsPrefix(sucursalId), filters] as const,
   details: (sucursalId: number | null) => [...clientesKeys.all(sucursalId), 'detail'] as const,
   detail: (sucursalId: number | null, id: string) => [...clientesKeys.details(sucursalId), id] as const,
   byZona: (sucursalId: number | null, zona: string) => [...clientesKeys.all(sucursalId), 'zona', zona] as const,
@@ -502,8 +511,8 @@ export function useCrearClienteMutation() {
     mutationFn: (cliente: ClienteCreateInput) => createCliente(cliente, currentSucursalId),
     onSuccess: (newCliente) => {
       // Actualizar cache de lista
-      queryClient.setQueryData<ClienteDB[]>(clientesKeys.lists(currentSucursalId), (old) => {
-        if (!old) return [newCliente]
+      queryClient.setQueriesData<ClienteDB[]>({ queryKey: clientesKeys.listsPrefix(currentSucursalId) }, (old) => {
+        if (!old) return old
         return [...old, newCliente].sort((a, b) =>
           (a.nombre_fantasia || '').localeCompare(b.nombre_fantasia || '')
         )
@@ -529,12 +538,15 @@ export function useActualizarClienteMutation() {
     mutationFn: updateCliente,
     // Optimistic update
     onMutate: async ({ id, data: cliente }) => {
-      await queryClient.cancelQueries({ queryKey: clientesKeys.lists(currentSucursalId) })
+      // Plural y por prefijo: la mutacion mas comun de esta pantalla es
+      // desactivar/reactivar, que es justo la que cambia de que variante de la
+      // lista tiene que salir el cliente. Tocando una sola, la otra queda vieja.
+      const prefijo = clientesKeys.listsPrefix(currentSucursalId)
+      await queryClient.cancelQueries({ queryKey: prefijo })
 
-      const previousClientes = queryClient.getQueryData<ClienteDB[]>(clientesKeys.lists(currentSucursalId))
+      const previousClientes = queryClient.getQueriesData<ClienteDB[]>({ queryKey: prefijo })
 
-      // Aplicar cambios optimistamente
-      queryClient.setQueryData<ClienteDB[]>(clientesKeys.lists(currentSucursalId), (old) => {
+      queryClient.setQueriesData<ClienteDB[]>({ queryKey: prefijo }, (old) => {
         if (!old) return old
         return old.map(c => c.id === id ? { ...c, ...cliente } as ClienteDB : c)
       })
@@ -542,9 +554,9 @@ export function useActualizarClienteMutation() {
       return { previousClientes }
     },
     onError: (_, __, context) => {
-      // Rollback on error
-      if (context?.previousClientes) {
-        queryClient.setQueryData(clientesKeys.lists(currentSucursalId), context.previousClientes)
+      // Rollback: se restaura cada variante con lo que tenia antes.
+      for (const [queryKey, data] of context?.previousClientes ?? []) {
+        queryClient.setQueryData(queryKey, data)
       }
     },
     onSuccess: (updatedCliente) => {
@@ -562,7 +574,17 @@ export function useActualizarClienteMutation() {
 }
 
 /**
- * Hook para eliminar (desactivar) un cliente
+ * Hook para ELIMINAR de verdad un cliente (DELETE).
+ *
+ * Solo admin (policy `mt_clientes_delete`) y solo si el cliente no tiene ninguna
+ * referencia: desde la mig 200 la FK de pedidos es RESTRICT, y `cambios_productos`
+ * y `recorrido_cambios` tampoco declaran ON DELETE. En la practica casi nunca
+ * aplica -- 678 de los 712 clientes tienen pedidos.
+ *
+ * **La baja logica NO pasa por aca**: desactivar es
+ * `useActualizarClienteMutation` con `{ activo: false }`, y reactivar con
+ * `{ activo: true }`. El "(desactivar)" que decia antes este docstring era de
+ * cuando eliminar y desactivar eran la misma cosa.
  */
 export function useEliminarClienteMutation() {
   const queryClient = useQueryClient()
@@ -574,12 +596,10 @@ export function useEliminarClienteMutation() {
       // Remover de cache de detalle
       queryClient.removeQueries({ queryKey: clientesKeys.detail(currentSucursalId, deletedId) })
       // Sacarlo de las dos variantes de la lista (con y sin inactivos)
-      for (const incluirInactivos of [false, true]) {
-        queryClient.setQueryData<ClienteDB[]>(
-          clientesKeys.lists(currentSucursalId, incluirInactivos),
-          (old) => (old ? old.filter(c => c.id !== deletedId) : old)
-        )
-      }
+      queryClient.setQueriesData<ClienteDB[]>(
+        { queryKey: clientesKeys.listsPrefix(currentSucursalId) },
+        (old) => (old ? old.filter(c => c.id !== deletedId) : old)
+      )
     },
   })
 }

--- a/src/hooks/queries/usePoliticasComercialesQuery.ts
+++ b/src/hooks/queries/usePoliticasComercialesQuery.ts
@@ -1,0 +1,165 @@
+/**
+ * Política comercial de la sucursal activa (mig 204).
+ *
+ * Hoy tiene un solo campo, el monto mínimo de pedido, pero la tabla existe para
+ * ser el lugar donde vive la política comercial: sumar una es una columna más
+ * acá y un campo más en la pantalla de configuración.
+ *
+ * EL PUNTO IMPORTANTE ES EL CACHÉ OFFLINE
+ * ---------------------------------------
+ * El mínimo se valida en la base (mig 205), pero un pedido cargado sin señal no
+ * llega a la base hasta que se sincroniza. Si el teléfono no conoce la regla, el
+ * pedido se acepta ahí mismo, el preventista se va del comercio, y el rechazo
+ * aparece horas después como una operación fallida en IndexedDB.
+ *
+ * Por eso el último valor conocido se persiste en Dexie y se usa como
+ * `initialData`: un teléfono sin señal arranca sabiendo cuál era el mínimo la
+ * última vez que hubo conexión. Es lo mejor que se puede saber offline, y es
+ * muchísimo mejor que no saber nada.
+ */
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { useEffect, useState } from 'react'
+import { supabase } from '../supabase/base'
+import { useSucursal } from '../../contexts/SucursalContext'
+import { cacheData, getCachedData } from '../../lib/offlineDb'
+
+export interface PoliticasComerciales {
+  /** Monto mínimo en $ que debe alcanzar un pedido. 0 = sin política. */
+  montoMinimoPedido: number
+}
+
+const CACHE_KEY = 'politicas_comerciales'
+
+export const politicasComercialesKeys = {
+  all: (sucursalId: number | null) => ['politicas-comerciales', sucursalId] as const,
+}
+
+export const POLITICAS_POR_DEFECTO: PoliticasComerciales = { montoMinimoPedido: 0 }
+
+async function fetchPoliticas(sucursalId: number | null): Promise<PoliticasComerciales> {
+  const { data, error } = await supabase
+    .from('politicas_comerciales')
+    .select('monto_minimo_pedido')
+    .maybeSingle()
+
+  if (error) throw error
+
+  // Sin fila = sin política. La mig 204 siembra una por sucursal, pero una
+  // sucursal creada después todavía no la tendría, y eso no es un error.
+  const politicas: PoliticasComerciales = {
+    montoMinimoPedido: Number(data?.monto_minimo_pedido ?? 0) || 0,
+  }
+
+  // Sin expiración a propósito: un valor viejo es infinitamente mejor que
+  // ninguno cuando no hay señal, y en cuanto haya conexión se pisa.
+  await cacheData(CACHE_KEY, politicas, undefined, sucursalId).catch(() => {
+    // Que falle el caché no puede romper la carga de un pedido.
+  })
+
+  return politicas
+}
+
+export function usePoliticasComercialesQuery() {
+  const { currentSucursalId } = useSucursal()
+  const [cacheado, setCacheado] = useState<PoliticasComerciales | null>(null)
+
+  useEffect(() => {
+    let vigente = true
+    getCachedData<PoliticasComerciales>(CACHE_KEY, currentSucursalId)
+      .then(valor => { if (vigente && valor) setCacheado(valor) })
+      .catch(() => { /* sin caché se usa el default */ })
+    return () => { vigente = false }
+  }, [currentSucursalId])
+
+  const query = useQuery({
+    queryKey: politicasComercialesKeys.all(currentSucursalId),
+    queryFn: () => fetchPoliticas(currentSucursalId),
+    staleTime: 5 * 60 * 1000,
+  })
+
+  return {
+    ...query,
+    /**
+     * Siempre devuelve algo usable: lo del servidor, si no lo cacheado, si no
+     * "sin política". Nunca undefined — quien valida un pedido no puede quedar
+     * esperando.
+     */
+    politicas: query.data ?? cacheado ?? POLITICAS_POR_DEFECTO,
+  }
+}
+
+/** Lectura puntual desde Dexie, para los caminos que no son React (encolar offline). */
+export async function leerMontoMinimoCacheado(sucursalId: number | null): Promise<number> {
+  const valor = await getCachedData<PoliticasComerciales>(CACHE_KEY, sucursalId).catch(() => null)
+  return Number(valor?.montoMinimoPedido ?? 0) || 0
+}
+
+/**
+ * Fija el monto mínimo de la sucursal activa.
+ *
+ * Va por RPC y no por UPDATE directo para que `actualizado_por` lo selle el
+ * servidor con auth.uid(): si lo mandara el cliente sería un dato que el cliente
+ * elige, y la auditoría no auditaría nada (mig 204).
+ */
+export function useActualizarMontoMinimoMutation() {
+  const queryClient = useQueryClient()
+  const { currentSucursalId } = useSucursal()
+
+  return useMutation({
+    mutationFn: async (monto: number) => {
+      const { data, error } = await supabase.rpc('actualizar_monto_minimo_pedido', {
+        p_monto: monto,
+      })
+      if (error) throw error
+      // Se refresca el caché de Dexie en el acto: si no, un teléfono que queda
+      // sin señal justo después seguiría validando contra el mínimo viejo.
+      await cacheData(CACHE_KEY, { montoMinimoPedido: monto }, undefined, currentSucursalId).catch(() => {})
+      return Number(data ?? monto)
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: politicasComercialesKeys.all(currentSucursalId) })
+    },
+  })
+}
+
+export interface ImpactoMinimo {
+  /** Pedidos considerados (no cancelados) en la ventana mirada. */
+  total: number
+  /** Cuántos de esos no habrían podido cargarse con el mínimo propuesto. */
+  bloqueados: number
+}
+
+/**
+ * Cuántos de los últimos pedidos no habrían entrado con un mínimo dado.
+ *
+ * Existe para que nadie elija el número a ciegas: en los datos de prod, un
+ * mínimo de $20.000 habría frenado 736 de 2051 pedidos de una sucursal en 90
+ * días. Ver ese número antes de guardar es la diferencia entre fijar una
+ * política y cortar la operación sin querer.
+ *
+ * Se excluyen los cancelados porque cancelar pone `total = 0` (mig 175) y
+ * contarlos inflaría el impacto con pedidos que ni siquiera existen ya.
+ */
+export function useImpactoMinimoQuery(montoPropuesto: number) {
+  const { currentSucursalId } = useSucursal()
+  return useQuery({
+    queryKey: ['politicas-comerciales', currentSucursalId, 'impacto', montoPropuesto],
+    enabled: montoPropuesto > 0,
+    staleTime: 5 * 60 * 1000,
+    queryFn: async (): Promise<ImpactoMinimo> => {
+      const desde = new Date()
+      desde.setDate(desde.getDate() - 90)
+      const { data, error } = await supabase
+        .from('pedidos')
+        .select('total')
+        .neq('estado', 'cancelado')
+        .gte('fecha', desde.toISOString().slice(0, 10))
+      if (error) throw error
+      const filas = data ?? []
+      return {
+        total: filas.length,
+        bloqueados: filas.filter(p => (Number(p.total) || 0) < montoPropuesto).length,
+      }
+    },
+  })
+}

--- a/src/hooks/supabase/useClientes.ts
+++ b/src/hooks/supabase/useClientes.ts
@@ -9,7 +9,14 @@
  * - useEliminarClienteMutation() para eliminar
  *
  * Migración: Reemplazar `const { clientes } = useClientes()`
- * con `const { data: clientes } = useClientesQuery()`
+ * con `const { data: clientes } = useClientesQuery()`.
+ *
+ * OJO, el reemplazo NO es equivalente: este hook va por `clienteService.getAll()`,
+ * que no filtra `activo` y trae también los clientes dados de baja.
+ * `useClientesQuery()` devuelve **solo los activos**. Casi siempre eso es lo que
+ * se quiere, pero si el consumidor necesita ver las bajas —un reporte histórico,
+ * un backup— tiene que pedir `useClientesQuery({ includeInactivos: true })` y no
+ * asumir que el swap conserva el conjunto de datos.
  */
 
 import { useState, useEffect, useCallback } from 'react'

--- a/src/hooks/useOfflineSync.ts
+++ b/src/hooks/useOfflineSync.ts
@@ -345,9 +345,15 @@ export function useOfflineSync(): UseOfflineSyncReturn {
   }, [loadPendingOperations])
 
   /**
-   * Guarda un pedido en modo offline con validación de stock
-   * Ahora usa IndexedDB via queueOperation
-   * Usa pedidosPendientesRef para evitar re-renders innecesarios
+   * Guarda un pedido en modo offline.
+   *
+   * Valida **compra mínima** (migs 204/205, contra el último valor cacheado en
+   * Dexie) y stock ANTES de encolar: si alguna falla no encola nada y devuelve
+   * `{ success: false, error }`. Ojo que la compra mínima corre siempre, incluso
+   * con `validarStock: false`.
+   *
+   * Usa IndexedDB via queueOperation, y `pedidosPendientesRef` para evitar
+   * re-renders innecesarios.
    */
   const guardarPedidoOffline = useCallback(async (
     pedidoData: Omit<PedidoOffline, 'offlineId' | 'creadoOffline' | 'sincronizado'>,

--- a/src/hooks/useOfflineSync.ts
+++ b/src/hooks/useOfflineSync.ts
@@ -12,6 +12,8 @@ import { logger } from '../utils/logger'
 import type { MermaFormInput, ProductoDB } from '../types'
 import type { OrigenPrecioItem } from '../utils/origenPrecio'
 import { useSucursal } from '../contexts/SucursalContext'
+import { motivoMontoMinimo } from '../utils/montoMinimo'
+import { leerMontoMinimoCacheado } from './queries/usePoliticasComercialesQuery'
 import { setSucursalHeader, getSucursalHeader } from '../lib/supabase'
 
 /**
@@ -352,6 +354,18 @@ export function useOfflineSync(): UseOfflineSyncReturn {
     options: GuardarPedidoOptions = {}
   ): Promise<GuardarPedidoResult> => {
     const { productos = [], validarStock = true } = options
+
+    // Compra mínima (migs 204/205). ESTE es el chequeo que evita el peor final:
+    // sin él, un pedido por debajo del mínimo se acepta en el teléfono sin
+    // señal, el preventista se va del comercio, y el rechazo del servidor llega
+    // horas después — como una operación fallida en IndexedDB que sólo se ve en
+    // el panel de fallidas. El mínimo se lee del caché de Dexie, que es lo mejor
+    // que se puede saber sin conexión (ver usePoliticasComercialesQuery).
+    const minimo = await leerMontoMinimoCacheado(currentSucursalIdRef.current).catch(() => 0)
+    const motivoMinimo = motivoMontoMinimo(Number(pedidoData.total) || 0, minimo)
+    if (motivoMinimo) {
+      return { success: false, error: motivoMinimo }
+    }
 
     // Validar stock si se proporciona lista de productos
     if (validarStock && productos.length > 0 && pedidoData.items?.length > 0) {

--- a/src/lib/permisos.test.ts
+++ b/src/lib/permisos.test.ts
@@ -13,6 +13,8 @@ import {
   puedeAccederTransferencias,
   puedeControlarStock,
   puedeRegistrarPagoCliente,
+  puedeDesactivarCliente,
+  puedeEliminarCliente,
   mostrarMontosEnStats,
 } from './permisos'
 import type { RolUsuario } from '@/types'
@@ -113,6 +115,42 @@ describe('permisos por rol', () => {
       expect(puedeRegistrarPagoCliente('deposito')).toBe(false)
       expect(puedeRegistrarPagoCliente(null)).toBe(false)
       expect(puedeRegistrarPagoCliente(undefined)).toBe(false)
+    })
+  })
+
+  // Espejo del trigger `clientes_guard_update_preventista` (mig 080), que tiene
+  // `activo` en su blacklist SOLO para el rol preventista. La UI decia `isAdmin`
+  // a mano y le negaba al encargado algo que la base si le permite; si alguien
+  // vuelve a cerrar esto a admin puro, el encargado pierde la unica forma de
+  // sacar un cliente de las listas sin borrarle el historial.
+  describe('puedeDesactivarCliente (baja logica)', () => {
+    it('permite admin y encargado, como el trigger de la mig 080', () => {
+      expect(puedeDesactivarCliente('admin')).toBe(true)
+      expect(puedeDesactivarCliente('encargado')).toBe(true)
+    })
+
+    it('bloquea al preventista, que el trigger rechaza con 42501', () => {
+      expect(puedeDesactivarCliente('preventista')).toBe(false)
+      expect(puedeDesactivarCliente('transportista')).toBe(false)
+      expect(puedeDesactivarCliente('deposito')).toBe(false)
+      expect(puedeDesactivarCliente(null)).toBe(false)
+      expect(puedeDesactivarCliente(undefined)).toBe(false)
+    })
+  })
+
+  // Espejo de la policy `mt_clientes_delete`, que exige es_admin(). Ojo: desde
+  // la mig 200 la FK de pedidos es RESTRICT, asi que esto solo aplica a clientes
+  // sin ningun movimiento.
+  describe('puedeEliminarCliente (DELETE real)', () => {
+    it('permite solo admin', () => {
+      expect(puedeEliminarCliente('admin')).toBe(true)
+    })
+
+    it('bloquea al encargado, que si puede desactivar pero no borrar', () => {
+      expect(puedeEliminarCliente('encargado')).toBe(false)
+      expect(puedeEliminarCliente('preventista')).toBe(false)
+      expect(puedeEliminarCliente(null)).toBe(false)
+      expect(puedeEliminarCliente(undefined)).toBe(false)
     })
   })
 })

--- a/src/lib/permisos.ts
+++ b/src/lib/permisos.ts
@@ -92,6 +92,29 @@ export function puedeCrearPedido(rol: RolUsuario | null | undefined): boolean {
   return rol === 'admin' || rol === 'preventista' || rol === 'encargado'
 }
 
+/**
+ * Si el rol puede dar de baja logica (o reactivar) un cliente.
+ *
+ * Espeja lo que ya permite el servidor: el trigger
+ * `clientes_guard_update_preventista` (mig 080) tiene `activo` en su blacklist
+ * SOLO para el rol preventista, asi que encargado si puede. La UI decia `isAdmin`
+ * a mano y le negaba al encargado algo que la base le permite.
+ */
+export function puedeDesactivarCliente(rol: RolUsuario | null | undefined): boolean {
+  return rol === 'admin' || rol === 'encargado'
+}
+
+/**
+ * Si el rol puede eliminar un cliente de verdad (DELETE).
+ *
+ * Solo admin, para coincidir con la policy `mt_clientes_delete`. Ademas casi
+ * nunca aplica: desde la mig 200 la FK de pedidos es RESTRICT, asi que solo se
+ * puede borrar un cliente sin ningun movimiento.
+ */
+export function puedeEliminarCliente(rol: RolUsuario | null | undefined): boolean {
+  return rol === 'admin'
+}
+
 /** Si el rol puede ver la facturacion total en el dashboard. Solo admin. */
 export function puedeVerFacturacionTotal(rol: RolUsuario | null | undefined): boolean {
   return rol === 'admin'

--- a/src/utils/montoMinimo.test.ts
+++ b/src/utils/montoMinimo.test.ts
@@ -1,0 +1,56 @@
+/**
+ * Tests de la compra mínima por pedido.
+ *
+ * POR QUE ESTOS CASOS
+ * -------------------
+ * La regla vive en la base (`pedido_incumple_minimo`, mig 205) y acá se espeja
+ * para poder bloquear ANTES de confirmar. Si las dos se desalinean, el síntoma
+ * es el peor posible: el pedido se acepta en el teléfono sin señal y falla al
+ * sincronizar, horas después, lejos del cliente.
+ *
+ * El caso del 0 es el que más importa: es el estado con el que la política
+ * arranca en todas las sucursales (mig 204). Si 0 frenara pedidos, aplicar la
+ * migración cortaría la operación entera de una.
+ */
+import { describe, it, expect } from 'vitest'
+import { cumpleMontoMinimo, motivoMontoMinimo } from './montoMinimo'
+
+describe('cumpleMontoMinimo', () => {
+  it('mínimo 0 = sin política: no frena nada', () => {
+    // Es el estado inicial de todas las sucursales tras la mig 204.
+    expect(cumpleMontoMinimo(0, 0)).toBe(true)
+    expect(cumpleMontoMinimo(1, 0)).toBe(true)
+    expect(cumpleMontoMinimo(999999, 0)).toBe(true)
+  })
+
+  it('deja pasar el pedido que da exactamente el mínimo', () => {
+    expect(cumpleMontoMinimo(10000, 10000)).toBe(true)
+  })
+
+  it('frena por debajo y deja pasar por encima', () => {
+    expect(cumpleMontoMinimo(9999.99, 10000)).toBe(false)
+    expect(cumpleMontoMinimo(10000.01, 10000)).toBe(true)
+  })
+
+  it('trata un total no numérico como 0, no como "pasa"', () => {
+    expect(cumpleMontoMinimo(NaN, 10000)).toBe(false)
+  })
+
+  it('un mínimo inválido no frena: ante la duda, no cortar la operación', () => {
+    expect(cumpleMontoMinimo(500, NaN)).toBe(true)
+    expect(cumpleMontoMinimo(500, -1)).toBe(true)
+  })
+})
+
+describe('motivoMontoMinimo', () => {
+  it('devuelve null cuando el pedido cumple', () => {
+    expect(motivoMontoMinimo(10000, 10000)).toBeNull()
+    expect(motivoMontoMinimo(500, 0)).toBeNull()
+  })
+
+  it('dice el mínimo y cuánto falta', () => {
+    const motivo = motivoMontoMinimo(7500, 10000)
+    expect(motivo).toContain('10.000')
+    expect(motivo).toContain('2.500')
+  })
+})

--- a/src/utils/montoMinimo.ts
+++ b/src/utils/montoMinimo.ts
@@ -1,0 +1,35 @@
+/**
+ * Compra mínima en $ por pedido.
+ *
+ * Espejo EXACTO de `pedido_incumple_minimo` (mig 205). La regla vive en la base
+ * para que valga en todos los caminos de alta, pero tiene que estar también acá:
+ * si sólo viviera en SQL, un pedido cargado sin señal se aceptaría en el
+ * teléfono, el preventista se iría del comercio, y el rechazo llegaría horas
+ * después al sincronizar — quedando como una operación fallida en IndexedDB que
+ * nadie mira. Es el mismo criterio que ya se usa para el mínimo por producto
+ * (mig 147): validar en la base Y avisar antes de confirmar.
+ *
+ * Si cambiás esta regla, cambiá también `pedido_incumple_minimo`.
+ */
+import { formatCurrency } from './formatters'
+
+/** Un pedido que da exactamente el mínimo pasa. */
+export function cumpleMontoMinimo(total: number, minimo: number): boolean {
+  if (!Number.isFinite(minimo) || minimo <= 0) return true // 0 = sin política
+  return (Number.isFinite(total) ? total : 0) >= minimo
+}
+
+/**
+ * Motivo del rechazo, o null si el pedido está bien.
+ *
+ * Devuelve el texto ya armado (con los dos montos) porque sale por caminos
+ * donde nadie va a ir a buscar cuál era el mínimo.
+ */
+export function motivoMontoMinimo(total: number, minimo: number): string | null {
+  if (cumpleMontoMinimo(total, minimo)) return null
+  const faltante = minimo - (Number.isFinite(total) ? total : 0)
+  return (
+    `El pedido no alcanza la compra mínima de ${formatCurrency(minimo)}. ` +
+    `Faltan ${formatCurrency(faltante)}.`
+  )
+}

--- a/supabase/functions/_shared/tools/preventista/previsualizar_pedido.ts
+++ b/supabase/functions/_shared/tools/preventista/previsualizar_pedido.ts
@@ -313,6 +313,24 @@ export const previsualizarPedidoTool: Tool<
       }
     }
 
+    // ---- Compra mínima del pedido ----
+    // El mínimo en $ es de la SUCURSAL (migs 204/205), a diferencia del MOQ de
+    // más arriba que es por producto. Se corta acá, antes de persistir la
+    // confirmación pendiente: `crear_pedido_completo_bot` lo rechaza igual, pero
+    // entonces el preventista ya apretó "confirmar" y recibe un error opaco.
+    const { data: politica } = await sb
+      .from("politicas_comerciales")
+      .select("monto_minimo_pedido")
+      .eq("sucursal_id", sucursalId)
+      .maybeSingle();
+    const montoMinimo = Number(politica?.monto_minimo_pedido ?? 0) || 0;
+    if (montoMinimo > 0 && total < montoMinimo) {
+      throw new Error(
+        `El pedido no alcanza la compra mínima de $${montoMinimo.toLocaleString("es-AR")}. ` +
+          `Total del pedido: $${total.toLocaleString("es-AR")}.`,
+      );
+    }
+
     // ---- Alerta de crédito ----
     const limiteCredito = Number(cliente.limite_credito ?? 0);
     const saldoActual = Number(cliente.saldo_cuenta ?? 0);


### PR DESCRIPTION
Dos pedidos que venían juntos: que se puedan "eliminar" clientes sin perder trazabilidad, y poder configurar una compra mínima en $ que no quede hardcodeada.

> **Las migraciones 203, 204 y 205 ya están aplicadas en prod** (26-08 16:51–16:53). El repo y el ledger están alineados, así que el gate de integridad queda verde. Ver *Estado de las migraciones* al final.

---

## 1. Baja lógica de clientes

**El diagnóstico no era el esperado.** La app *ya* ofrecía desactivar (mig 200 hizo que un cliente con pedidos no se pueda borrar). El problema es que esa acción **no hacía nada visible**: `fetchClientes` nunca filtró por `activo`, y ningún consumidor lo hacía tampoco. En prod había 2 clientes desactivados apareciendo enteros en el panel, en el selector de pedidos y en los recorridos. El cartel le decía al usuario *"deja de aparecer en las listas"* y era falso — por eso se percibía como "no se pueden eliminar clientes".

- El filtro va en `fetchClientes`, no pantalla por pantalla: alimenta el panel, los tres autocompletes de pedidos, el dashboard y los recorridos.
- **El historial no se toca.** Los pedidos viejos resuelven el nombre por el embed `cliente:clientes(*)` y los reportes por sus RPCs; ninguno pasa por ahí. Los datos siguen siendo trazables, que era el requisito.
- Check **"Ver inactivos"** y botón de reactivar. Sin eso la baja era un viaje de ida.
- El conteo previo al borrado sólo miraba `pedidos`. `cambios_productos` (024) y `recorrido_cambios` (089) tampoco declaran `ON DELETE` —o sea `RESTRICT`—, así que un cliente con un cambio y ningún pedido recibía *"no tiene pedidos asociados"* y después un `23503` opaco. Ahora se cuentan las tres y el error se traduce.
- Los dos chequeos de duplicados (ubicación y nombre) ahora ven a los inactivos y ofrecen reactivar. El de nombre consulta la base y no el array en memoria, que por defecto ya no los trae — mirarlo dejaba crear un clon exacto del cliente recién desactivado, **que es justo el movimiento que dejó 9 pedidos huérfanos** (#490).
- La ficha se resuelve por ID: un inactivo con deuda sigue saliendo en el panel de deudores y su ficha se abría vacía.
- `puedeDesactivarCliente` / `puedeEliminarCliente` en `permisos.ts`, espejando el trigger de la mig 080 y la policy `mt_clientes_delete`. La UI decía `isAdmin` a mano y le negaba al encargado algo que la base sí le permite.

Cierra el hueco que quedaba de #491.

## 2. Compra mínima configurable

No existía ninguna infraestructura de configuración. Se crea `politicas_comerciales`, una fila por sucursal, con pantalla propia en **Operaciones → Configuración** (admin y encargado).

**Arranca en $0 en las tres sucursales: hoy no frena ningún pedido hasta que alguien cargue un número.**

Tres decisiones que conviene revisar:

- **Por sucursal, no global.** En 90 días Tucumán tiene mediana $22.200 y Taco Pozo $35.750. Un mínimo único de $10.000 habría frenado el 7% de los pedidos de una y el 3% de la otra.
- **Tabla tipada, no clave-valor en `jsonb`.** El repo no tiene tipos generados de la base, así que una clave mal escrita no la atraparía ni `tsc` ni los tests. Y tabla propia en vez de columna en `sucursales`, que es la tabla de identidad: mover una política no debería requerir `UPDATE` sobre ella.
- **Se valida al crear, nunca como CHECK.** `cancelar_pedido` pone `total = 0` (mig 175) y el invariante `VENTA-I` exige que así sea (mig 105) — un CHECK haría imposible cancelar. Verificado: los 175 pedidos en $0 de los últimos 90 días son todos cancelados. Corolario: cuando el mínimo suba, los pedidos viejos por debajo siguen siendo legales.

Cobertura de los caminos de alta: `crear_pedido_completo` (web online, replay offline) y `crear_pedido_completo_bot` (Telegram) se parchean leyendo del catálogo vivo. `crear_pedido_cambio_en_ruta` queda exento solo (no pasa por ninguno). `cambiar_cliente_pedido` prende el escape hatch `app.omitir_minimo_pedido`: reatribuir un pedido lo re-crea, y sin eso una corrección administrativa quedaría trabada por el mínimo de hoy contra una venta de ayer.

**El riesgo que más importaba era el offline.** Si el mínimo viviera sólo en SQL, el pedido se aceptaría en el teléfono, el preventista se iría del comercio, y el rechazo llegaría horas después como una operación fallida que sólo se ve en el panel de fallidas. Por eso el mínimo se cachea en Dexie y se bloquea antes de encolar, además de validarse en la base. El bot corta en `previsualizar_pedido`, antes de confirmar.

La pantalla muestra, mientras se tipea, cuántos de los últimos 90 días de pedidos no habrían entrado con ese número: un mínimo mal elegido no falla, sólo frena la operación, y eso se nota recién en la calle.

## 3. Un bug de caché que salió de la propia revisión

Al agregar el filtro, `clientesKeys.lists()` quedó con dos variantes en caché y un default en el segundo argumento — así que `lists(sucursalId)` compila y apunta a la de activos, dejando la otra vieja sin que `tsc` lo vea. Había quedado mal en cuatro lugares, incluido el *optimistic update* de actualizar cliente, que es justo la mutación que decide de qué lista sale el cliente. Se agregó `listsPrefix()` y se pasó a las APIs plurales, que alcanzan a las dos.

También se corrigieron cuatro docstrings que mentían; el peor: `useEliminarClienteMutation` decía "eliminar (desactivar)" y hace un `DELETE` real.

---

## Estado de las migraciones

| Migración | Aplicada | Toca filas |
|---|---|---|
| `203_el_bot_no_ve_clientes_inactivos` | 26-08 16:51 | No (`CREATE OR REPLACE`) |
| `204_politicas_comerciales_por_sucursal` | 26-08 16:52 | Sí: 3 filas, todas con mínimo en 0 |
| `205_hacer_valer_la_compra_minima` | 26-08 16:53 | No (sólo redefine funciones) |

Cada una es 1:1 con su fila del ledger y con el mismo stem, así que **no hay que tocar `CONSOLIDACIONES` de `check-migrations.mjs`** (verificado: la 205 se aplicó en una sola llamada). Ninguna requiere entrada en §A–§E del MANIFEST.

## Verificación

- `typecheck`, `lint`, **1389 tests** y `build` en verde.
- Los tres anclajes de la 205 verificados contra el catálogo vivo antes de aplicar (exactamente una coincidencia cada uno).
- Prueba funcional de la validación en prod, dentro de una transacción revertida: por debajo frena, justo el mínimo pasa, por encima pasa, total 0 frena al crear, y el escape hatch funciona. Los mínimos quedaron en 0.

**Pendiente antes de mergear:** no pude correr los tests de las edge functions (`deno` no está instalado en el entorno). El cambio en `previsualizar_pedido.ts` es chico pero conviene correr `deno task check && deno task test` y redesplegar las functions.

## Fuera de alcance

- [#509](https://github.com/AgustinReiden/distribuidora-app/issues/509) — `useOfflineQueue` llama a la RPC con el payload crudo; parece fallar siempre. Encontrado al mapear los caminos de alta, no se tocó para no mezclar.
- La tabla de roles del `README.md` no lista `encargado` ni `deposito`, y su árbol no lista `containers/`. Desactualización preexistente.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U9ijACCufFf8FMRoG5Mrcz

---
_Generated by [Claude Code](https://claude.ai/code/session_01U9ijACCufFf8FMRoG5Mrcz)_