### PR TITLE
Una sola cascada de costo para todas las superficies que reportan margen

### DIFF
--- a/src/hooks/supabase/useReportesFinancieros.test.ts
+++ b/src/hooks/supabase/useReportesFinancieros.test.ts
@@ -1,0 +1,164 @@
+/**
+ * Tests de la pestaña "Rentabilidad" de /reportes.
+ *
+ * Foco: la cascada de costo. Este hook calculaba el CMV con
+ * `costo_unitario_al_crear ?? costo_real ?? fórmula`, salteándose
+ * `costo_promedio` — que es justamente la base de CMV del reporte gerencial
+ * (mig 130). Las dos pantallas daban márgenes distintos para el mismo período.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+
+// Cadena thenable: la query es .from().select().neq() y opcionalmente
+// .gte().lte(); se await sobre el último eslabón, sea cual sea.
+function createChainableMock(finalData: { data: unknown; error: unknown }) {
+  const chain: Record<string, unknown> = {
+    select: vi.fn(),
+    neq: vi.fn(),
+    gte: vi.fn(),
+    lte: vi.fn(),
+    eq: vi.fn(),
+    in: vi.fn(),
+    order: vi.fn(),
+  }
+  Object.keys(chain).forEach(k => {
+    ;(chain[k] as ReturnType<typeof vi.fn>).mockReturnValue(chain)
+  })
+  chain.then = vi.fn((resolve: (v: unknown) => void) => {
+    resolve(finalData)
+    return Promise.resolve(finalData)
+  })
+  return chain
+}
+
+const mockFrom = vi.fn()
+
+vi.mock('./base', () => ({
+  supabase: { from: (...args: unknown[]) => mockFrom(...args) },
+  notifyError: vi.fn(),
+}))
+
+import { useReportesFinancieros } from './useReportesFinancieros'
+import type { ReporteRentabilidad } from '../../types'
+
+/** Un pedido de una línea, para aislar la cascada de costo. */
+function pedidoConItem(item: Record<string, unknown>, producto: Record<string, unknown>) {
+  return [
+    {
+      id: 'p1',
+      cliente_id: 'c1',
+      estado: 'entregado',
+      total: 1000,
+      created_at: '2026-01-15T10:00:00',
+      tipo_factura: 'FC',
+      items: [{ id: 'i1', ...item, producto: { id: 'prod1', nombre: 'Producto A', codigo: 'PA001', ...producto } }],
+    },
+  ]
+}
+
+async function correrReporte(pedidos: unknown[]): Promise<ReporteRentabilidad> {
+  mockFrom.mockReturnValue(createChainableMock({ data: pedidos, error: null }))
+  const { result } = renderHook(() => useReportesFinancieros())
+  let reporte!: ReporteRentabilidad
+  await act(async () => {
+    reporte = await result.current.generarReporteRentabilidad()
+  })
+  return reporte
+}
+
+describe('useReportesFinancieros › generarReporteRentabilidad', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('cascada de costo canónica (mig 130)', () => {
+    it('sin snapshot usa costo_promedio, no costo_real', async () => {
+      // Los tres costos distintos a propósito: el número que sale dice en qué
+      // escalón de la cascada se cayó el cálculo.
+      const reporte = await correrReporte(
+        pedidoConItem(
+          { cantidad: 10, precio_unitario: 100, subtotal: 1000, costo_unitario_al_crear: null },
+          { costo_promedio: 60, costo_real: 80, costo_con_iva: 95, costo_sin_iva: 70, impuestos_internos: 10 }
+        )
+      )
+
+      expect(reporte.productos[0].costos).toBe(600)
+      expect(reporte.productos[0].margen).toBe(400)
+      expect(reporte.totales.costosTotales).toBe(600)
+    })
+
+    it('el snapshot congelado gana sobre costo_promedio', async () => {
+      // Es lo que hace que el margen de un mes cerrado no se mueva cuando
+      // cambia el costo de hoy.
+      const reporte = await correrReporte(
+        pedidoConItem(
+          { cantidad: 10, precio_unitario: 100, subtotal: 1000, costo_unitario_al_crear: 45 },
+          { costo_promedio: 60, costo_real: 80 }
+        )
+      )
+
+      expect(reporte.productos[0].costos).toBe(450)
+      expect(reporte.productos[0].margen).toBe(550)
+    })
+
+    it('sin snapshot ni promedio cae a costo_real', async () => {
+      const reporte = await correrReporte(
+        pedidoConItem(
+          { cantidad: 10, precio_unitario: 100, subtotal: 1000, costo_unitario_al_crear: null },
+          { costo_promedio: null, costo_real: 80, costo_sin_iva: 70, impuestos_internos: 10 }
+        )
+      )
+
+      expect(reporte.productos[0].costos).toBe(800)
+    })
+
+    it('sin snapshot, promedio ni costo_real usa la fórmula con impuestos internos', async () => {
+      const reporte = await correrReporte(
+        pedidoConItem(
+          { cantidad: 10, precio_unitario: 100, subtotal: 1000, costo_unitario_al_crear: null },
+          { costo_promedio: null, costo_real: null, costo_sin_iva: 100, impuestos_internos: 10 }
+        )
+      )
+
+      expect(reporte.productos[0].costos).toBe(1100)
+    })
+
+    it('un producto sin ningún costo cargado no rompe los totales', async () => {
+      const reporte = await correrReporte(
+        pedidoConItem(
+          { cantidad: 10, precio_unitario: 100, subtotal: 1000, costo_unitario_al_crear: null },
+          { costo_promedio: null, costo_real: null, costo_sin_iva: null }
+        )
+      )
+
+      expect(reporte.productos[0].costos).toBe(0)
+      expect(reporte.totales.margenTotal).toBe(1000)
+      expect(Number.isNaN(reporte.totales.costosTotales)).toBe(false)
+    })
+  })
+
+  describe('el ingreso sigue siendo el real (mig 123)', () => {
+    it('en FC el margen se mide contra el neto, no contra el precio final', async () => {
+      const reporte = await correrReporte(
+        pedidoConItem(
+          {
+            cantidad: 10,
+            precio_unitario: 121,
+            subtotal: 1210,
+            costo_unitario_al_crear: 50,
+            ingreso_real_unitario: 100,
+            neto_unitario: 100,
+            iva_unitario: 21,
+          },
+          { costo_promedio: 60 }
+        )
+      )
+
+      expect(reporte.productos[0].ingresos).toBe(1000)
+      expect(reporte.productos[0].costos).toBe(500)
+      expect(reporte.productos[0].margen).toBe(500)
+      expect(reporte.totales.ivaDiscriminado).toBe(210)
+      expect(reporte.totales.ventasBrutas).toBe(1210)
+    })
+  })
+})

--- a/src/hooks/supabase/useReportesFinancieros.ts
+++ b/src/hooks/supabase/useReportesFinancieros.ts
@@ -12,6 +12,7 @@ import type {
   PagoDB,
   ProductoDB
 } from '../../types'
+import { costoCanonicoUnitario } from '../../utils/costoCanonico'
 
 interface PedidoWithItems {
   id: string;
@@ -185,13 +186,15 @@ export function useReportesFinancieros(): UseReportesFinancierosReturn {
             ventasNetas += subtotalItem
           }
 
-          // Costo canónico (mig 120): snapshot congelado al crear el pedido;
-          // fallback a productos.costo_real (mig 111) y por último a la
-          // fórmula vieja. Antes usaba costo_sin_iva vivo SIN imp. internos.
-          const costoUnitario = ((item as Record<string, unknown>).costo_unitario_al_crear as number | null)
-            ?? prod.costo_real
-            ?? ((prod.costo_sin_iva || 0) * (1 + (prod.impuestos_internos || 0) / 100))
-          productoStats[id].costos += (costoUnitario || 0) * item.cantidad
+          // Costo canónico (mig 130): el mismo COALESCE que el reporte
+          // gerencial. Antes se salteaba costo_promedio y cobraba el costo de
+          // reposición como CMV, así que esta pestaña y el gerencial daban
+          // márgenes distintos para el mismo período.
+          const costoUnitario = costoCanonicoUnitario(
+            (item as Record<string, unknown>).costo_unitario_al_crear as number | null,
+            prod
+          )
+          productoStats[id].costos += costoUnitario * item.cantidad
         })
       })
 

--- a/src/services/__tests__/analyticsExport.test.ts
+++ b/src/services/__tests__/analyticsExport.test.ts
@@ -79,30 +79,40 @@ describe('analyticsExport', () => {
             cuit: '20-12345678-9',
           },
           items: [
+            // i1: con snapshot congelado. Gana sobre los tres costos vivos.
             {
               id: 'i1',
               cantidad: 2,
               precio_unitario: 100,
               subtotal: 200,
+              costo_unitario_al_crear: 60,
               producto: {
                 id: 'prod1',
                 nombre: 'Producto A',
                 codigo: 'PA001',
                 categoria: 'Bebidas',
-                costo_con_iva: 80,
+                costo_promedio: 70,
+                costo_real: 80,
+                costo_con_iva: 95,
               },
             },
+            // i2: sin snapshot. Gana costo_promedio (90), NO costo_real (100)
+            // ni costo_con_iva (130). Los tres distintos a propósito: si la
+            // cascada se rompe, el número dice en qué escalón se cayó.
             {
               id: 'i2',
               cantidad: 3,
               precio_unitario: 150,
               subtotal: 450,
+              costo_unitario_al_crear: null,
               producto: {
                 id: 'prod2',
                 nombre: 'Producto B',
                 codigo: 'PB002',
                 categoria: 'Snacks',
-                costo_con_iva: 100,
+                costo_promedio: 90,
+                costo_real: 100,
+                costo_con_iva: 130,
               },
             },
           ],
@@ -139,11 +149,11 @@ describe('analyticsExport', () => {
         cantidad: 2,
         precio_unitario: 100,
         subtotal: 200,
-        costo_unitario: 80,
-        costo_total: 160,
-        margen_unitario: 20,
-        margen_total: 40,
-        margen_porcentaje: 20,
+        costo_unitario: 60,
+        costo_total: 120,
+        margen_unitario: 40,
+        margen_total: 80,
+        margen_porcentaje: 40,
         estado_pedido: 'entregado',
         forma_pago: 'efectivo',
         preventista: 'Juan Perez',
@@ -156,9 +166,10 @@ describe('analyticsExport', () => {
         cantidad: 3,
         precio_unitario: 150,
         subtotal: 450,
-        costo_total: 300,
-        margen_total: 150,
-        margen_porcentaje: 33.33,
+        costo_unitario: 90,
+        costo_total: 270,
+        margen_total: 180,
+        margen_porcentaje: 40,
       })
     })
 
@@ -219,7 +230,7 @@ describe('analyticsExport', () => {
               cantidad: 1,
               precio_unitario: 0,
               subtotal: 0,
-              producto: { id: 'p1', nombre: 'Producto', costo_con_iva: 50 },
+              producto: { id: 'p1', nombre: 'Producto', costo_promedio: 50 },
             },
           ],
         },
@@ -231,6 +242,50 @@ describe('analyticsExport', () => {
       const result = await fetchVentasDetallado('2026-01-01', '2026-01-31')
 
       expect(result[0].margen_porcentaje).toBe(0)
+    })
+
+    // mig 130: costo_con_iva es el costo FINANCIERO (IVA adentro) y su propio
+    // COMMENT dice "NO usar para margen real". Era el último fallback de esta
+    // hoja: metía el IVA dentro del costo y mostraba menos margen del real.
+    it('no usa costo_con_iva como fallback de costo', async () => {
+      const mockPedidos = [
+        {
+          id: 'p1',
+          created_at: '2026-01-15T10:30:00',
+          estado: 'entregado',
+          usuario_id: null,
+          transportista_id: null,
+          cliente: { id: 'c1', nombre_fantasia: 'Cliente' },
+          items: [
+            {
+              id: 'i1',
+              cantidad: 1,
+              precio_unitario: 200,
+              subtotal: 200,
+              costo_unitario_al_crear: null,
+              // Producto sin promedio ni costo_real: cae a la fórmula
+              // (100 + 10% de internos), no a los 145 con IVA adentro.
+              producto: {
+                id: 'prod1',
+                nombre: 'Sin promedio',
+                costo_promedio: null,
+                costo_real: null,
+                costo_sin_iva: 100,
+                impuestos_internos: 10,
+                costo_con_iva: 145,
+              },
+            },
+          ],
+        },
+      ]
+
+      const chain = createChainableMock({ data: mockPedidos, error: null })
+      vi.mocked(supabase.from).mockReturnValue(chain as never)
+
+      const result = await fetchVentasDetallado('2026-01-01', '2026-01-31')
+
+      expect(result[0].costo_unitario).toBe(110)
+      expect(result[0].margen_total).toBe(90)
     })
   })
 
@@ -313,9 +368,9 @@ describe('analyticsExport', () => {
   describe('fetchProductosDimension', () => {
     it('should calculate rotation and velocidad_venta', async () => {
       const mockProductos = [
-        { id: 'p1', nombre: 'Rapido', stock: 100, costo_con_iva: 50, activo: true },
-        { id: 'p2', nombre: 'Medio', stock: 50, costo_con_iva: 30, activo: true },
-        { id: 'p3', nombre: 'Lento', stock: 200, costo_con_iva: 20, activo: true },
+        { id: 'p1', nombre: 'Rapido', stock: 100, costo_promedio: 50, activo: true },
+        { id: 'p2', nombre: 'Medio', stock: 50, costo_promedio: 30, activo: true },
+        { id: 'p3', nombre: 'Lento', stock: 200, costo_promedio: 20, activo: true },
       ]
 
       const mockItems = [
@@ -377,8 +432,8 @@ describe('analyticsExport', () => {
 
     it('should calculate stock_dias and handle zero rotation', async () => {
       const mockProductos = [
-        { id: 'p1', nombre: 'Con ventas', stock: 100, costo_con_iva: 50, activo: true },
-        { id: 'p2', nombre: 'Sin ventas', stock: 50, costo_con_iva: 30, activo: true },
+        { id: 'p1', nombre: 'Con ventas', stock: 100, costo_promedio: 50, activo: true },
+        { id: 'p2', nombre: 'Sin ventas', stock: 50, costo_promedio: 30, activo: true },
       ]
 
       const mockItems = [
@@ -404,6 +459,93 @@ describe('analyticsExport', () => {
 
       expect(result[0].stock_dias).toBe(10) // 100 stock / 10 rotation
       expect(result[1].stock_dias).toBe('N/A') // no sales
+    })
+
+    // mig 130: esta hoja calculaba el margen con costo_real (reposición) y
+    // caía a costo_con_iva (financiero, IVA adentro). Ahora usa la misma
+    // cascada que el gerencial: costo_promedio primero.
+    it('calcula el margen con costo_promedio, no con costo_real', async () => {
+      const mockProductos = [
+        {
+          id: 'p1',
+          nombre: 'Con promedio',
+          stock: 10,
+          costo_promedio: 60,
+          costo_real: 80,
+          costo_con_iva: 95,
+          activo: true,
+        },
+        {
+          id: 'p2',
+          nombre: 'Sin promedio',
+          stock: 10,
+          costo_promedio: null,
+          costo_real: 80,
+          costo_con_iva: 95,
+          activo: true,
+        },
+      ]
+
+      const mockItems = [
+        {
+          producto_id: 'p1',
+          cantidad: 10,
+          precio_unitario: 100,
+          subtotal: 1000,
+          pedido: { created_at: '2026-01-15T10:00:00' },
+        },
+        {
+          producto_id: 'p2',
+          cantidad: 10,
+          precio_unitario: 100,
+          subtotal: 1000,
+          pedido: { created_at: '2026-01-15T10:00:00' },
+        },
+      ]
+
+      const productosChain = createChainableMock({ data: mockProductos, error: null })
+      const itemsChain = createChainableMock({ data: mockItems, error: null })
+
+      let callCount = 0
+      vi.mocked(supabase.from).mockImplementation(() => {
+        callCount++
+        return (callCount === 1 ? productosChain : itemsChain) as never
+      })
+
+      const result = await fetchProductosDimension('2026-01-01', '2026-01-31')
+
+      // p1: 1000 - 10*60 = 400 (con costo_real habría dado 200)
+      expect(result[0]).toMatchObject({
+        costo_unitario_usado: 60,
+        margen_total: 400,
+        margen_porcentaje: 40,
+      })
+      // p2: sin promedio, cae a costo_real. 1000 - 10*80 = 200
+      expect(result[1]).toMatchObject({
+        costo_unitario_usado: 80,
+        margen_total: 200,
+        margen_porcentaje: 20,
+      })
+    })
+
+    // Power BI necesita el promedio para recomputar el CMV por su cuenta.
+    it('exporta costo_promedio y el costo que efectivamente usó', async () => {
+      const mockProductos = [
+        { id: 'p1', nombre: 'Producto', stock: 5, costo_promedio: 42, costo_real: 50, activo: true },
+      ]
+
+      const productosChain = createChainableMock({ data: mockProductos, error: null })
+      const itemsChain = createChainableMock({ data: [], error: null })
+
+      let callCount = 0
+      vi.mocked(supabase.from).mockImplementation(() => {
+        callCount++
+        return (callCount === 1 ? productosChain : itemsChain) as never
+      })
+
+      const result = await fetchProductosDimension('2026-01-01', '2026-01-31')
+
+      expect(result[0]).toMatchObject({ costo_promedio: 42, costo_real: 50, costo_unitario_usado: 42 })
     })
 
     it('should throw error on productos fetch error', async () => {

--- a/src/services/analyticsExport.ts
+++ b/src/services/analyticsExport.ts
@@ -7,6 +7,8 @@
 import { supabase } from '../lib/supabase'
 import type { SheetConfig } from '../utils/excel'
 import { calculateMarketBasket } from '../utils/marketBasket'
+import { costoCanonicoUnitario } from '../utils/costoCanonico'
+import type { ProductoCosto } from '../utils/costoCanonico'
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -53,7 +55,7 @@ export async function fetchVentasDetallado(
         precio_unitario,
         subtotal,
         costo_unitario_al_crear,
-        producto:productos(id, nombre, codigo, categoria, costo_con_iva, costo_real)
+        producto:productos(id, nombre, codigo, categoria, costo_con_iva, costo_real, costo_promedio)
       )
     `)
     .gte('created_at', `${desde}T00:00:00`)
@@ -88,10 +90,12 @@ export async function fetchVentasDetallado(
 
     for (const item of items) {
       const producto = item.producto as Record<string, unknown> | null
-      // Costo canónico (mig 120): snapshot al crear → costo_real vivo → legacy
-      // costo_con_iva (que incluía IVA y sobreestimaba el costo).
-      const costoUnitario = Number(
-        item.costo_unitario_al_crear ?? producto?.costo_real ?? producto?.costo_con_iva ?? 0
+      // Costo canónico (mig 130): el mismo COALESCE que el reporte gerencial.
+      // Antes se salteaba costo_promedio y caía a costo_con_iva, que es el
+      // costo FINANCIERO (IVA adentro): inflaba el costo y hundía el margen.
+      const costoUnitario = costoCanonicoUnitario(
+        item.costo_unitario_al_crear as number | null,
+        producto as ProductoCosto | null
       )
       const precioUnitario = Number(item.precio_unitario || 0)
       const cantidad = Number(item.cantidad || 0)
@@ -241,8 +245,12 @@ export async function fetchProductosDimension(
 
   return (productosRes.data || []).map(p => {
     const ventas = ventasPorProducto.get(p.id) || { cantidad: 0, ingresos: 0, dias: new Set() }
-    // Costo real canónico (mig 111); fallback legacy a costo_con_iva.
-    const costoUnitario = Number(p.costo_real ?? p.costo_con_iva ?? 0)
+    // Costo canónico (mig 130) SIN snapshot: esta hoja agrega por producto
+    // sobre todo el período, así que no hay un `costo_unitario_al_crear` único
+    // que congelar. El margen de acá vale el costo de HOY: para recomputarlo
+    // línea por línea con el costo congelado está la hoja Ventas_Detallado, y
+    // por eso se exporta también costo_promedio.
+    const costoUnitario = costoCanonicoUnitario(null, p as ProductoCosto)
     const costoTotal = costoUnitario * ventas.cantidad
     const margenTotal = ventas.ingresos - costoTotal
 
@@ -261,6 +269,8 @@ export async function fetchProductosDimension(
       costo_sin_iva: p.costo_sin_iva ?? 0,
       costo_con_iva: p.costo_con_iva ?? 0,
       costo_real: p.costo_real ?? 0,
+      costo_promedio: p.costo_promedio ?? 0,
+      costo_unitario_usado: costoUnitario,
       activo: p.activo !== false ? 'Si' : 'No',
       total_vendido: ventas.cantidad,
       total_ingresos: Number(ventas.ingresos.toFixed(2)),

--- a/src/utils/costoCanonico.test.ts
+++ b/src/utils/costoCanonico.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect } from 'vitest'
+import { costoCanonicoUnitario } from './costoCanonico'
+
+// Producto con TODOS los términos cargados y distintos entre sí: cada test
+// tapa un término y verifica cuál gana. Si el orden se rompe, el valor
+// devuelto dice exactamente en qué escalón se cayó.
+const productoCompleto = {
+  costo_promedio: 70,
+  costo_real: 80,
+  costo_sin_iva: 100,
+  impuestos_internos: 10,
+}
+
+describe('costoCanonicoUnitario', () => {
+  describe('orden de la cascada', () => {
+    it('el snapshot congelado gana sobre todo lo demás', () => {
+      expect(costoCanonicoUnitario(55, productoCompleto)).toBe(55)
+    })
+
+    it('sin snapshot gana costo_promedio, no costo_real', () => {
+      // El bug que unifica esta función: las tres superficies viejas se
+      // saltaban el promedio y cobraban el costo de reposición como CMV.
+      expect(costoCanonicoUnitario(null, productoCompleto)).toBe(70)
+    })
+
+    it('sin snapshot ni promedio cae a costo_real', () => {
+      expect(
+        costoCanonicoUnitario(null, { ...productoCompleto, costo_promedio: null })
+      ).toBe(80)
+    })
+
+    it('sin snapshot, promedio ni costo_real usa la fórmula con impuestos internos', () => {
+      expect(
+        costoCanonicoUnitario(null, {
+          ...productoCompleto,
+          costo_promedio: null,
+          costo_real: null,
+        })
+      ).toBe(110)
+    })
+
+    it('la fórmula sin impuestos internos es el neto tal cual', () => {
+      expect(
+        costoCanonicoUnitario(null, { costo_sin_iva: 100, impuestos_internos: null })
+      ).toBe(100)
+    })
+  })
+
+  describe('semántica COALESCE: 0 es un valor, no un hueco', () => {
+    it('un snapshot en 0 corta la cascada (regalo con costo cero)', () => {
+      expect(costoCanonicoUnitario(0, productoCompleto)).toBe(0)
+    })
+
+    it('un costo_promedio en 0 corta la cascada', () => {
+      expect(costoCanonicoUnitario(null, { ...productoCompleto, costo_promedio: 0 })).toBe(0)
+    })
+  })
+
+  describe('ausencia de datos', () => {
+    it('undefined en el snapshot equivale a NULL', () => {
+      expect(costoCanonicoUnitario(undefined, productoCompleto)).toBe(70)
+    })
+
+    it('un producto sin ningún costo cargado da 0, no NaN', () => {
+      expect(costoCanonicoUnitario(null, {})).toBe(0)
+    })
+
+    it('sin producto (embed nulo) y sin snapshot da 0', () => {
+      expect(costoCanonicoUnitario(null, null)).toBe(0)
+      expect(costoCanonicoUnitario(null, undefined)).toBe(0)
+    })
+
+    it('sin producto pero con snapshot devuelve el snapshot', () => {
+      expect(costoCanonicoUnitario(42, null)).toBe(42)
+    })
+
+    it('un valor no numérico se trata como ausente', () => {
+      // PostgREST puede devolver numeric como string; un string vacío o basura
+      // no debe convertirse en 0 silenciosamente y tapar el resto de la cascada.
+      expect(costoCanonicoUnitario('' as unknown as number, productoCompleto)).toBe(70)
+      expect(costoCanonicoUnitario('abc' as unknown as number, productoCompleto)).toBe(70)
+    })
+
+    it('un numeric que llega como string se usa igual', () => {
+      expect(costoCanonicoUnitario('55.5' as unknown as number, productoCompleto)).toBe(55.5)
+    })
+  })
+
+  describe('costo_con_iva no participa', () => {
+    it('un producto que sólo tiene costo_con_iva da 0, no el costo financiero', () => {
+      // costo_con_iva es el costo FINANCIERO (IVA adentro). El COMMENT de la
+      // columna dice literal "NO usar para margen real": entra al CMV inflado.
+      const soloFinanciero = { costo_con_iva: 121 } as unknown as Parameters<
+        typeof costoCanonicoUnitario
+      >[1]
+      expect(costoCanonicoUnitario(null, soloFinanciero)).toBe(0)
+    })
+  })
+
+  describe('ZZ: lo pagado ya incluye IVA e impuestos internos (mig 111)', () => {
+    it('no le suma impuestos internos encima al costo_real de una compra ZZ', () => {
+      // En ZZ costo_real guarda lo pagado tal cual. Como costo_real corta la
+      // cascada antes de la fórmula, los internos nunca se suman dos veces.
+      const zz = { costo_promedio: null, costo_real: 500, costo_sin_iva: 500, impuestos_internos: 8.6956 }
+      expect(costoCanonicoUnitario(null, zz)).toBe(500)
+    })
+  })
+})

--- a/src/utils/costoCanonico.ts
+++ b/src/utils/costoCanonico.ts
@@ -1,0 +1,79 @@
+/**
+ * Costo unitario CANÓNICO — la cascada del reporte gerencial, en JS.
+ *
+ * Espejo exacto del `COALESCE` que usan `reporte_gerencial` (mig 130) y
+ * `reporte_valuacion_inventario` (mig 131):
+ *
+ *   COALESCE(snapshot, costo_promedio, costo_real,
+ *            costo_sin_iva * (1 + impuestos_internos/100))
+ *
+ * Por qué ese orden:
+ * - `snapshot` (`pedido_items.costo_unitario_al_crear`, `mermas_stock.costo_unitario`)
+ *   es el costo congelado en el momento del hecho. Es lo único que hace que el
+ *   margen de un mes cerrado no se mueva cuando cambia el costo de hoy.
+ * - `costo_promedio` es el promedio ponderado (mig 127/128): base de VALUACIÓN
+ *   y de CMV. Es lo que corresponde cuando no hay snapshot.
+ * - `costo_real` es el costo de REPOSICIÓN (mig 111): base de pricing, no de
+ *   CMV. Va después del promedio, no antes.
+ * - La fórmula es el último recurso, con semántica FC (neto + impuestos
+ *   internos). En ZZ lo pagado ya incluye IVA e impuestos internos y quedó
+ *   guardado tal cual en `costo_real` (mig 111), así que un producto ZZ nunca
+ *   llega hasta acá: sumarle los internos encima sería contarlos dos veces.
+ *
+ * `costo_con_iva` NO entra en la cascada: es el costo FINANCIERO (lo
+ * desembolsado, IVA adentro) y el propio COMMENT de la columna dice "NO usar
+ * para margen real". Usarlo de fallback infla el costo y hunde el margen.
+ *
+ * Si cambiás esta cascada, cambiá también las migraciones 130 y 131.
+ */
+import { redondear } from './calculations';
+
+/** Las columnas de `productos` que participan de la cascada. */
+export interface ProductoCosto {
+  costo_promedio?: number | null;
+  costo_real?: number | null;
+  costo_sin_iva?: number | null;
+  impuestos_internos?: number | null;
+}
+
+/**
+ * Como en SQL, sólo NULL/ausente pasa al siguiente término: un costo de 0 es un
+ * valor y corta la cascada, igual que `COALESCE`.
+ */
+function presente(valor: unknown): number | null {
+  if (valor === null || valor === undefined || valor === '') return null;
+  const n = Number(valor);
+  return Number.isFinite(n) ? n : null;
+}
+
+/**
+ * Costo unitario canónico del hecho.
+ *
+ * @param costoSnapshot - Costo congelado al registrar el hecho:
+ *   `pedido_items.costo_unitario_al_crear` en una venta,
+ *   `mermas_stock.costo_unitario` en una merma. `null` en filas viejas.
+ * @param producto - Fila de `productos` (o el embed) con las columnas de costo.
+ * @returns El costo unitario, o 0 si el producto no tiene ningún costo cargado
+ *   (en SQL la cascada daría NULL y la fila no sumaría; acá 0 es lo mismo para
+ *   un `SUM`, y evita propagar NaN a los totales).
+ */
+export function costoCanonicoUnitario(
+  costoSnapshot: number | null | undefined,
+  producto: ProductoCosto | null | undefined
+): number {
+  const snapshot = presente(costoSnapshot);
+  if (snapshot !== null) return snapshot;
+
+  const promedio = presente(producto?.costo_promedio);
+  if (promedio !== null) return promedio;
+
+  const real = presente(producto?.costo_real);
+  if (real !== null) return real;
+
+  const sinIva = presente(producto?.costo_sin_iva);
+  if (sinIva === null) return 0;
+  // 4 decimales como calcularCostoReal y como costo_real_unitario (mig 111):
+  // en SQL la fórmula es aritmética `numeric` exacta, en JS 100*(1+10/100) da
+  // 110.00000000000001 y ese ruido se propaga a los totales.
+  return redondear(sinIva * (1 + (presente(producto?.impuestos_internos) ?? 0) / 100), 4);
+}


### PR DESCRIPTION
Las tres superficies que faltaban usaban cascadas de costo viejas, cada una distinta de la del reporte gerencial (migs 130/131), que es la canónica:

```
COALESCE(pedido_items.costo_unitario_al_crear, productos.costo_promedio,
         productos.costo_real, costo_sin_iva * (1 + impuestos_internos/100))
```

| Superficie | Cascada vieja | Qué estaba mal |
|---|---|---|
| Pestaña "Rentabilidad" de `/reportes` | `snapshot ?? costo_real ?? fórmula` | Se salteaba `costo_promedio` y cobraba el costo de **reposición** como CMV |
| Hoja "Ventas Detallado" del export a BI | `snapshot ?? costo_real ?? costo_con_iva` | Idem, y caía a `costo_con_iva`, que es el costo **financiero** (IVA adentro) |
| Hoja "Productos" del export a BI | `costo_real ?? costo_con_iva` | Ni miraba el snapshot: calculaba el margen de todo el período con el costo de **hoy** |

En el export el dato ni siquiera se pedía — `costo_promedio` no estaba en el `select` de ventas.

## La función

La cascada ahora vive en `src/utils/costoCanonico.ts` (`costoCanonicoUnitario`), función pura con tests propios. Recibe el snapshot como argumento suelto y no como item: mermas tiene la misma cascada con `mermas_stock.costo_unitario` de snapshot, y stock de la red también, así que van a poder usarla tal cual.

Dos detalles que salieron al escribirla y que quedaron con test:

- **Semántica `COALESCE`**: sólo NULL/ausente pasa al siguiente término. Un costo de **0 corta la cascada** — hay que protegerlo, porque un `|| 0` de paso rompería el caso del regalo con costo cero.
- **Redondeo a 4 decimales** en la fórmula de fallback, como `calcularCostoReal` y `costo_real_unitario` (mig 111). En SQL es aritmética `numeric` exacta; en JS `100*(1+10/100)` da `110.00000000000001` y ese ruido se propaga a los totales.

`costo_con_iva` queda fuera de la cascada: es el costo financiero y el `COMMENT` de la columna dice literal "NO usar para margen real".

## Los tests que congelaban el bug

Los fixtures de `analyticsExport.test.ts` daban productos con sólo `costo_con_iva: 80` y asserteaban `costo_unitario: 80`. Arreglar el código sin tocarlos dejaba el test verde protegiendo nada. Reescritos con los tres costos distintos entre sí, así el número que falla dice en qué escalón de la cascada se cayó el cálculo.

`useReportesFinancieros.ts` no tenía archivo de test — ahora tiene, con un producto donde `costo_promedio != costo_real` para fijar el `COALESCE`.

Verifiqué que protegen: rompiendo la cascada a propósito (salteando `costo_promedio`) caen 7 tests entre `analyticsExport` y `costoCanonico`, más 1 en el hook.

## Aviso: esto mueve números de meses cerrados

Los márgenes históricos se van a mover, **sólo en las líneas donde `costo_unitario_al_crear` es NULL**. El backfill de la mig 202 llenó casi todo el histórico con una guarda de ratio 0.20-1.10, así que se mueven las que esa guarda rechazó.

Y los productos que caían al fallback de `costo_con_iva` pasan a mostrar **más** margen, no menos: ese fallback metía el IVA adentro del costo.

## Fuera de alcance

- `aceptar_movimiento_sucursal` (mig 139) tiene un problema real ahí, pero necesita migración y va a su propia sesión.
- El flag "sin costo" del gerencial: issue #511. El diagnóstico terminó siendo distinto al esperado — los predicados de las migs 130 y 109 son idénticos; el problema es que ese predicado mira **sólo** `costo_sin_iva` mientras el costo se calcula con la cascada entera, así que la alerta "margen sobreestimado" se dispara sobre productos que están bien costeados. Aparte, el drill-down de la 109 no filtra por período ni por estados, con lo cual el listado nunca cuadra con el número de la alerta.

## Verificación

`typecheck`, `lint`, `test:run` (103 archivos / 1413 tests, corrido **sin `.env`**) y `build`: los cuatro en verde.

🤖 Generated with [Claude Code](https://claude.com/claude-code)