### PR TITLE
Que se le pueda cargar un % de comisión a quien no es preventista

### DIFF
--- a/src/components/containers/ComisionesContainer.test.tsx
+++ b/src/components/containers/ComisionesContainer.test.tsx
@@ -1,0 +1,158 @@
+/**
+ * El desplegable de "Reglas de comisión" salía de un padrón filtrado por
+ * `rol = 'preventista'`, y como la regla se identifica por
+ * `comision_reglas.preventista_id`, a un admin o a un encargado no había forma
+ * de asignarle un %. Pero `calcular_comisiones` agrupa por `pedidos.usuario_id`
+ * sin mirar rol (mig 150): esa gente YA acumula comisión al % por defecto.
+ *
+ * El test monta el modal de verdad y mira el `<select>`, no una lista interna:
+ * es el desplegable lo que estaba roto.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import type { ComisionesResultado } from '../../hooks/queries/useComisionesQuery'
+
+const mockCalcular = vi.fn()
+const mockPadron = vi.fn()
+
+vi.mock('../../hooks/queries', () => ({
+  useCalcularComisionesQuery: () => mockCalcular(),
+  usePreventistasQuery: () => mockPadron(),
+  useComisionReglasQuery: () => ({ data: [], isLoading: false }),
+  useGuardarComisionReglaMutation: () => ({ mutateAsync: vi.fn(), isPending: false }),
+  useDesactivarComisionReglaMutation: () => ({ mutateAsync: vi.fn(), isPending: false }),
+}))
+
+vi.mock('../../contexts/AuthDataContext', () => ({
+  useAuthData: () => ({ isAdmin: true }),
+}))
+
+vi.mock('../../contexts/NotificationContext', () => ({
+  useNotification: () => ({ error: vi.fn(), success: vi.fn() }),
+}))
+
+// La vista no es lo que se prueba acá: sólo hace falta el botón que abre el modal.
+vi.mock('../vistas/VistaComisiones', () => ({
+  default: ({ onAbrirReglas }: { onAbrirReglas?: () => void }) => (
+    <button type="button" onClick={onAbrirReglas}>Reglas de comisión</button>
+  ),
+}))
+
+import ComisionesContainer from './ComisionesContainer'
+
+/** Vendedor tal como lo devuelve el RPC: sin rol, porque el cálculo no lo mira. */
+function vendedor(id: string, nombre: string, base: number) {
+  return {
+    id,
+    nombre,
+    email: `${id}@x.com`,
+    base,
+    comision: base * 0.02,
+    items: 1,
+    items_sin_desglose: 0,
+    base_sin_desglose: 0,
+    por_origen: [],
+  }
+}
+
+function resultadoCon(preventistas: ComisionesResultado['preventistas']): ComisionesResultado {
+  return {
+    desde: '2026-01-01',
+    hasta: '2026-09-07',
+    comision_default: 2,
+    preventistas,
+    totales: { base: 0, comision: 0, items: 0, items_sin_desglose: 0, base_sin_desglose: 0 },
+  }
+}
+
+async function abrirReglas() {
+  const user = userEvent.setup()
+  render(<ComisionesContainer />)
+  await user.click(await screen.findByRole('button', { name: 'Reglas de comisión' }))
+  return screen.findByRole('combobox', { name: 'Vendedor' })
+}
+
+describe('ComisionesContainer › desplegable de reglas', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockPadron.mockReturnValue({ data: [] })
+  })
+
+  it('un admin y un encargado que vendieron aparecen en el desplegable', async () => {
+    // Los dos casos reales: Jony es encargado y es el que más comisión
+    // acumula; ninguno de los dos tiene rol 'preventista'.
+    mockCalcular.mockReturnValue({
+      data: resultadoCon([
+        vendedor('u-encargado', 'Jony', 361000),
+        vendedor('u-admin', 'Agustin', 39000),
+      ]),
+      isLoading: false,
+      error: null,
+    })
+
+    const select = await abrirReglas()
+
+    expect(within(select).getByRole('option', { name: 'Jony' })).toBeInTheDocument()
+    expect(within(select).getByRole('option', { name: 'Agustin' })).toBeInTheDocument()
+  })
+
+  it('incluye al preventista del padrón que todavía no vendió en el período', async () => {
+    mockCalcular.mockReturnValue({
+      data: resultadoCon([vendedor('u-admin', 'Agustin', 39000)]),
+      isLoading: false,
+      error: null,
+    })
+    mockPadron.mockReturnValue({
+      data: [{ id: 'u-prev', nombre: 'Nuevo Preventista', email: 'np@x.com' }],
+    })
+
+    const select = await abrirReglas()
+
+    expect(within(select).getByRole('option', { name: 'Nuevo Preventista' })).toBeInTheDocument()
+    expect(within(select).getByRole('option', { name: 'Agustin' })).toBeInTheDocument()
+  })
+
+  it('no duplica a quien está en las dos fuentes', async () => {
+    mockCalcular.mockReturnValue({
+      data: resultadoCon([vendedor('u-prev', 'Ana', 1000)]),
+      isLoading: false,
+      error: null,
+    })
+    mockPadron.mockReturnValue({ data: [{ id: 'u-prev', nombre: 'Ana', email: 'ana@x.com' }] })
+
+    const select = await abrirReglas()
+
+    expect(within(select).getAllByRole('option', { name: 'Ana' })).toHaveLength(1)
+  })
+
+  it('mantiene la opción «Todos» para la regla general', async () => {
+    mockCalcular.mockReturnValue({
+      data: resultadoCon([vendedor('u1', 'Ana', 1000)]),
+      isLoading: false,
+      error: null,
+    })
+
+    const select = await abrirReglas()
+
+    expect(within(select).getByRole('option', { name: 'Todos' })).toBeInTheDocument()
+  })
+
+  it('ordena por nombre y no por monto vendido', async () => {
+    mockCalcular.mockReturnValue({
+      data: resultadoCon([
+        vendedor('u1', 'Zulema', 500000),
+        vendedor('u2', 'Ana', 1000),
+      ]),
+      isLoading: false,
+      error: null,
+    })
+
+    const select = await abrirReglas()
+    const nombres = within(select)
+      .getAllByRole('option')
+      .map(o => o.textContent)
+
+    expect(nombres).toEqual(['Todos', 'Ana', 'Zulema'])
+  })
+})

--- a/src/components/containers/ComisionesContainer.tsx
+++ b/src/components/containers/ComisionesContainer.tsx
@@ -36,12 +36,32 @@ export default function ComisionesContainer(): React.ReactElement {
   // El cálculo lo resuelve la DB (mig 150): misma base que el reporte gerencial
   // y % por regla vigente, en vez del `ventas × % tipeado` que había acá.
   const { data: resultado, isLoading, error } = useCalcularComisionesQuery(fechaDesde, fechaHasta)
-  const { data: preventistasData = [] } = usePreventistasQuery()
+  const { data: padronPreventistas = [] } = usePreventistasQuery()
 
-  const preventistas = useMemo(
-    () => preventistasData.map(p => ({ id: p.id, nombre: p.nombre || p.email || 'Sin nombre' })),
-    [preventistasData],
-  )
+  // La lista del desplegable sale de los DATOS, no de los roles. Precedente
+  // escrito en la mig 198: un desplegable filtrado por rol escondía $32,8M de
+  // venta real. Acá el filtro por rol dejaba afuera a admins y encargados, que
+  // comisionan igual —`calcular_comisiones` agrupa por `pedidos.usuario_id` sin
+  // mirar rol (mig 150)— y por eso no había forma de asignarles un %.
+  //
+  // Unión de dos fuentes: quien efectivamente vendió en el período, sea cual
+  // sea su rol, y el padrón de preventistas de la sucursal, para el que todavía
+  // no vendió. Un admin o encargado sin ventas en el período no aparece: no
+  // tiene comisión que configurar hasta que venda, y aparece solo con ampliar
+  // el rango de fechas.
+  const preventistas = useMemo(() => {
+    const porId = new Map<string, string>()
+    const nombreDe = (n: string | null, e: string | null): string => n || e || 'Sin nombre'
+    for (const p of resultado?.preventistas ?? []) {
+      porId.set(p.id, nombreDe(p.nombre, p.email))
+    }
+    for (const p of padronPreventistas) {
+      if (!porId.has(p.id)) porId.set(p.id, nombreDe(p.nombre ?? null, p.email ?? null))
+    }
+    return [...porId]
+      .map(([id, nombre]) => ({ id, nombre }))
+      .sort((a, b) => a.nombre.localeCompare(b.nombre, 'es'))
+  }, [resultado, padronPreventistas])
 
   useEffect(() => {
     if (error) {

--- a/src/components/modals/ModalComisionReglas.tsx
+++ b/src/components/modals/ModalComisionReglas.tsx
@@ -63,9 +63,17 @@ export default function ModalComisionReglas({
   const [porcentaje, setPorcentaje] = useState<number>(2)
   const [vigenteDesde, setVigenteDesde] = useState<string>(fechaLocalISO())
 
+  /**
+   * El fallback NO puede ser un rótulo genérico: una regla con `preventista_id`
+   * NULL ya se muestra como «Todos», así que un nombre genérico para un id que
+   * no está en la lista se lee como si la regla fuera para todos —justo lo
+   * contrario de lo que es—. La lista se arma con quien vendió en el período
+   * mostrado, así que un id ausente significa exactamente eso.
+   */
   const nombrePreventista = useMemo(() => {
     const map = new Map(preventistas.map(p => [p.id, p.nombre]))
-    return (id: string | null): string => (id ? map.get(id) ?? 'Preventista' : 'Todos')
+    return (id: string | null): string =>
+      id ? (map.get(id) ?? 'Vendedor sin ventas en el período') : 'Todos'
   }, [preventistas])
 
   /**
@@ -126,7 +134,7 @@ export default function ModalComisionReglas({
   return (
     <ModalBase
       title="Reglas de comisión"
-      description="Porcentaje por preventista y por origen del precio"
+      description="Porcentaje por vendedor y por origen del precio"
       onClose={onClose}
       maxWidth="max-w-3xl"
     >
@@ -136,7 +144,7 @@ export default function ModalComisionReglas({
           <p className="text-xs text-stone-600 dark:text-gray-300">
             Gana la regla más específica que coincida. Sin ninguna regla que aplique se usa el{' '}
             <strong>{comisionDefault}%</strong>. Cargá una regla con origen «Cualquiera» para el %
-            base del preventista y otra con «{etiquetaOrigen('mayorista')}» para el % reducido.
+            base del vendedor y otra con «{etiquetaOrigen('mayorista')}» para el % reducido.
           </p>
         </div>
 
@@ -163,7 +171,7 @@ export default function ModalComisionReglas({
         <div className="rounded-lg border dark:border-gray-700 p-3 space-y-3">
           <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
             <div>
-              <label htmlFor="regla-preventista" className="block text-sm font-medium mb-1">Preventista</label>
+              <label htmlFor="regla-preventista" className="block text-sm font-medium mb-1">Vendedor</label>
               <select
                 id="regla-preventista"
                 value={preventistaId}
@@ -241,7 +249,7 @@ export default function ModalComisionReglas({
             <table className="w-full text-sm">
               <thead className="bg-stone-50 dark:bg-gray-700/50">
                 <tr>
-                  <th className="px-3 py-2 text-left font-medium">Preventista</th>
+                  <th className="px-3 py-2 text-left font-medium">Vendedor</th>
                   <th className="px-3 py-2 text-left font-medium">Origen</th>
                   <th className="px-3 py-2 text-right font-medium">%</th>
                   <th className="px-3 py-2 text-left font-medium">Vigencia</th>

--- a/src/components/vistas/VistaComisiones.tsx
+++ b/src/components/vistas/VistaComisiones.tsx
@@ -209,7 +209,7 @@ export default function VistaComisiones({
           <table className="w-full">
             <thead className="bg-gray-50 dark:bg-gray-700/50">
               <tr>
-                <th className="px-4 py-3 text-left text-sm font-medium text-gray-700 dark:text-gray-300">Preventista</th>
+                <th className="px-4 py-3 text-left text-sm font-medium text-gray-700 dark:text-gray-300">Vendedor</th>
                 <th className="px-4 py-3 text-right text-sm font-medium text-gray-700 dark:text-gray-300">Base</th>
                 <th className="px-4 py-3 text-right text-sm font-medium text-gray-700 dark:text-gray-300">Ítems</th>
                 <th className="px-4 py-3 text-right text-sm font-medium text-gray-700 dark:text-gray-300">


### PR DESCRIPTION
## El bug, en una línea

El desplegable de "Reglas de comisión" salía de `fetchPreventistas`, que filtra `rol = 'preventista'`. Como una regla se identifica por `comision_reglas.preventista_id` y ese id sólo podía salir de ese desplegable, **a un admin o a un encargado no había forma de asignarle un porcentaje**.

Pero `calcular_comisiones` (mig 150) agrupa por `pedidos.usuario_id` y **no mira rol**: esa gente ya venía acumulando comisión al 2% por defecto. Verificado contra la base: son siete personas por **$728.960**, y la que más acumula —Jony, $361.069— es *encargado*, así que tampoco entraba en `usePreventistasAsignablesQuery`, que es admin + preventista.

El backend ya lo soportaba entero: `preventista_id` es FK a `perfiles` sin filtro de rol, y `guardar_comision_regla` sólo valida `es_admin()` y `0 <= pct <= 100`. **No hace falta SQL.**

## La lista sale de los datos, no de los roles

Precedente escrito en la mig 198 (*"un desplegable por rol escondía $32,8M de venta real"*). Unión de dos fuentes:

- `resultado.preventistas` del RPC — quien efectivamente vendió en el período, sea cual sea su rol.
- El padrón de preventistas de la sucursal — para el que todavía no vendió.

Un admin o encargado sin ventas en el período no aparece: no tiene comisión que configurar hasta que venda, y aparece con sólo ampliar el rango de fechas.

**Lo que NO se tocó, a propósito:** `fetchPreventistas` la usan `ModalCliente` y `RecorridoPreventistaContainer`, donde filtrar por rol *sí* es lo correcto. Y `usePreventistasAsignablesQuery` decide quién puede ser el `usuario_id` de un pedido — ensancharla habría cambiado en silencio quién puede figurar como vendedor. Son otras decisiones.

## Un bug de paso, peor que el que veníamos a arreglar

`nombrePreventista` caía a un rótulo genérico para un id fuera de la lista. Como una regla con `preventista_id` NULL ya se muestra como **«Todos»**, la regla de *una persona* se leía como si fuera *para todos* — el error justo al revés, y de los que se descubren cuando ya liquidaste mal. Ahora dice que esa persona no vendió en el período mostrado, que es lo que realmente pasa.

## Copy

"Preventista" → "Vendedor", acotado a las dos pantallas de comisiones, que es donde el rol no es lo que se está mirando. Sólo copy: ningún identificador, ningún tipo, ninguna otra pantalla.

## Este PR no mueve ni un número

Deliberado. El 0% retroactivo es **carga de datos** y va por separado, en el modal ya destrabado — que es el camino auditado: `guardar_comision_regla` sella `usuario_id = auth.uid()`, y hacerlo por SQL dejaría sin autor la regla que apaga $728.960.

Separarlos hace que cada uno se revierta por su lado: el código con un revert, y las reglas desactivándolas (`comision_reglas.activo`), sin borrar filas ni perder autor ni fecha.

Las siete reglas a cargar después del merge — idénticas salvo el nombre:

| Campo | Valor |
|---|---|
| Vendedor | Jony · Nacho R · Virginia H · Pablo · Agustín · Emilia H · Julio |
| Origen del precio | `Cualquiera (% base)` |
| Porcentaje | `0` |
| Vigente desde | `2026-01-01` |

El primer pedido del sistema es del **2026-01-14**, así que el 1/1 cubre todo el histórico. Cuando se carguen, la comisión total pasa de **$4.060.343 a $3.331.383**, y se mueve también el KPI "Comisión (reglas)" y la contribución del waterfall del gerencial en **todos** los meses. Enero y febrero van a **cero**, no bajan: en esos dos meses el 100% de la comisión era de admins, antes de que existieran preventistas.

## Transportistas

Van a poder tener un % cargado y editable, pero les va a liquidar **$0**. Verificado: los tres transportistas no tienen **ni un** pedido, de ningún canal. Además un transportista nunca es `pedidos.usuario_id`, porque `crear_pedido_completo` exige admin/preventista/encargado. Hasta que se defina qué se les comisiona —cobranza, entregas, o las ventas del recorrido— el número va a ser cero.

## Tests

`ComisionesContainer.test.tsx`, nuevo (5 casos). Monta el **modal real** y mira el `<select>` real, no una lista interna: el desplegable es lo que estaba roto. Verificado que muerde: volviendo la fuente al padrón por rol caen 3 de los 5.

`typecheck`, `lint`, `test:run` (102 archivos / 1394 tests, corrido **sin `.env`**) y `build`: los cuatro en verde.

🤖 Generated with [Claude Code](https://claude.com/claude-code)