### PR TITLE
Sacarle el flake al test del desplegable de comisiones

### DIFF
--- a/src/components/containers/ComisionesContainer.test.tsx
+++ b/src/components/containers/ComisionesContainer.test.tsx
@@ -66,11 +66,19 @@ function resultadoCon(preventistas: ComisionesResultado['preventistas']): Comisi
   }
 }
 
+/**
+ * El modal se carga con `lazyWithReload`, así que la PRIMERA prueba del archivo
+ * paga el `import()` dinámico y las demás lo toman del caché del módulo. Con el
+ * millisegundo por defecto de `findBy` eso da un test que pasa solo o en
+ * caliente y cae en frío o con la máquina cargada: verde cinco corridas
+ * seguidas y rojo en el pre-commit. El timeout largo es por la carga del
+ * chunk, no por la aserción.
+ */
 async function abrirReglas() {
   const user = userEvent.setup()
   render(<ComisionesContainer />)
   await user.click(await screen.findByRole('button', { name: 'Reglas de comisión' }))
-  return screen.findByRole('combobox', { name: 'Vendedor' })
+  return screen.findByRole('combobox', { name: 'Vendedor' }, { timeout: 15000 })
 }
 
 describe('ComisionesContainer › desplegable de reglas', () => {


### PR DESCRIPTION
Sale de [#513](https://github.com/AgustinReiden/distribuidora-app/pull/513): el test que agregué ahí falla una de cada tantas. Se mergeó antes de que terminara de cazarlo, así que va aparte.

## Qué pasaba

El primer test del archivo caía intermitentemente: verde cinco corridas seguidas y rojo en el pre-commit. El síntoma que lo delata es que fallaba **siempre el primero y nunca los otros cuatro**, que abren exactamente el mismo modal.

`ModalComisionReglas` se carga con `lazyWithReload`, así que la primera prueba paga el `import()` dinámico del chunk y las demás lo toman del caché del módulo. Con el segundo por defecto de `findBy`, en frío o con la máquina cargada no llega a resolver, y el modal todavía no está en el DOM cuando se busca el `<select>`.

Es un defecto del test, no del código: la aserción es sobre contenido, y el timeout largo cubre la carga del chunk, no la aserción.

## Cómo se verificó

Reproducido **2/2** forzando una corrida en frío, y verde **3/3** con el arreglo en esa misma condición, más las dos suites completas.

Vale aclararlo porque la primera hipótesis fue otra: el repo documenta en `periodosReporte.ts:7-9` que armar fechas con `toISOString()` corre el día para atrás en Argentina, y el flake apareció al perseguir eso. No era. `fechaLocalISO` fija la zona a Argentina explícitamente y es a prueba de TZ; la correlación con la zona horaria era coincidencia de qué corridas cayeron en frío. La suite pasa igual con `TZ=UTC` y con `TZ=Asia/Karachi`.

`test:run`: 104 archivos / 1418 tests, en verde.

🤖 Generated with [Claude Code](https://claude.com/claude-code)