### PR TITLE
Comisión por defecto según el rol, configurable por sucursal

### DIFF
--- a/migrations/207_comision_default_por_rol.sql
+++ b/migrations/207_comision_default_por_rol.sql
@@ -1,0 +1,397 @@
+-- Comision por defecto segun el rol del vendedor, configurable por sucursal
+--
+-- EL PROBLEMA
+-- -----------
+-- El porcentaje por defecto era `c_default numeric := 2`, una constante en el
+-- cuerpo de `calcular_comisiones` (mig 150), y se aplicaba a TODO el que tuviera
+-- un pedido atribuido. Como `calcular_comisiones` agrupa por `pedidos.usuario_id`
+-- y no mira rol, el sistema le venia liquidando $728.960 a siete personas sin rol
+-- de preventista: un encargado y seis admins que cargan pedidos como parte de su
+-- trabajo, no como venta comisionable.
+--
+-- POR QUE NO SE RESUELVE CON SIETE REGLAS INDIVIDUALES
+-- ---------------------------------------------------
+-- Se puede: `comision_reglas` ya permite cargarle un % a cualquiera. Pero obliga
+-- a acordarse de cargar una regla cada vez que entra alguien nuevo, y el dia que
+-- nadie se acuerde el admin nuevo cobra 2% sin que nadie lo haya decidido.
+-- Invertirlo hace que el caso comun salga solo: el default depende del rol, y la
+-- regla individual queda para la EXCEPCION, que es para lo que sirve.
+--
+-- POR QUE EN `politicas_comerciales` Y NO EN UNA CONSTANTE
+-- -------------------------------------------------------
+-- Es lo que manda CLAUDE.md: un parametro de negocio que cambia va en
+-- `politicas_comerciales`, no en el codigo. El 2 ademas ya estaba duplicado en
+-- `130_reporte_gerencial_cpp.sql:228`, que es exactamente el problema que la
+-- regla previene. (Ese otro 2 NO se toca aca: es la semilla de un simulador
+-- editable en la pantalla del gerencial, no el numero de la liquidacion.)
+--
+-- EL ROL SE LEE VIVO, NO SE CONGELA EN EL PEDIDO
+-- ----------------------------------------------
+-- Decision tomada: si alguien pasa de encargado a preventista, sus ventas viejas
+-- pasan a liquidar 2%. Es el precio de leer `perfiles.rol` en vez de guardarlo en
+-- el pedido, y se acepta a cambio de no sumar una columna que habria que llenar
+-- en todos los caminos de alta.
+--
+-- OJO: el predicado es `perfiles.rol = 'preventista'` crudo. NO `es_preventista()`,
+-- que devuelve true tambien para admin y encargado (trampa 4 de CLAUDE.md) y aca
+-- seria exactamente la logica equivocada aunque parezca la obvia.
+--
+-- EFECTO MEDIDO (los mismos $728.960, en todos los meses):
+--   mes        antes       despues
+--   2026-01      6.132           0
+--   2026-02     59.755           0
+--   2026-03    200.245     154.600
+--   2026-04    507.895     425.901
+--   2026-05    585.556     488.627
+--   2026-06    732.243     641.024
+--   2026-07    856.321     659.092
+--   2026-08    926.042     804.668
+--   2026-09    186.155     157.472
+--   TOTAL    4.060.343   3.331.383
+-- Enero y febrero van a CERO, no bajan: en esos dos meses vendian solo admins,
+-- antes de que hubiera preventistas. La linea de comision desaparece entera ahi.
+--
+-- NO HACE FALTA BACKFILL: `calcular_comisiones` recalcula contra `pedidos.fecha`
+-- en cada consulta y no hay tabla de comisiones liquidadas.
+
+BEGIN;
+
+-- ---------------------------------------------------------------------------
+-- 1. Las dos columnas
+-- ---------------------------------------------------------------------------
+
+ALTER TABLE public.politicas_comerciales
+  ADD COLUMN IF NOT EXISTS comision_pct_preventista numeric(5,2) NOT NULL DEFAULT 2,
+  ADD COLUMN IF NOT EXISTS comision_pct_otros       numeric(5,2) NOT NULL DEFAULT 0;
+
+-- Los CHECK van en un DO que mira pg_constraint para que la migracion se pueda
+-- reaplicar sin explotar (patron de la mig 148).
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'politicas_comerciales_comision_preventista_check') THEN
+    ALTER TABLE public.politicas_comerciales
+      ADD CONSTRAINT politicas_comerciales_comision_preventista_check
+      CHECK (comision_pct_preventista >= 0 AND comision_pct_preventista <= 100);
+  END IF;
+
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'politicas_comerciales_comision_otros_check') THEN
+    ALTER TABLE public.politicas_comerciales
+      ADD CONSTRAINT politicas_comerciales_comision_otros_check
+      CHECK (comision_pct_otros >= 0 AND comision_pct_otros <= 100);
+  END IF;
+END $$;
+
+COMMENT ON COLUMN public.politicas_comerciales.comision_pct_preventista IS
+  'Comision por defecto de quien tiene perfiles.rol = preventista, en %. Se usa '
+  'cuando NINGUNA regla de comision_reglas matchea; una regla individual '
+  '(preventista_id, peso 8 en la precedencia) siempre le gana. Arranca en 2, que '
+  'es el valor que estaba hardcodeado en calcular_comisiones. mig 207.';
+
+COMMENT ON COLUMN public.politicas_comerciales.comision_pct_otros IS
+  'Comision por defecto de quien NO es preventista (admin, encargado), en %. Se '
+  'usa cuando ninguna regla matchea; la regla individual le gana. Arranca en 0: '
+  'cargar un pedido siendo admin es parte del trabajo, no una venta comisionable. '
+  'Para que un admin comisione se le carga su regla propia. mig 207.';
+
+-- ---------------------------------------------------------------------------
+-- 2. El default deja de ser una constante
+--
+-- MISMA FIRMA y CREATE OR REPLACE sin DROP: cambiarla dejaria dos sobrecargas
+-- con rangos [obligatorios, total] superpuestos y PostgREST no sabria cual
+-- llamar -> PGRST203 en runtime, invisible para tsc, eslint y los tests
+-- (trampa 5 de CLAUDE.md).
+--
+-- Cuerpo tomado del vivo (pg_get_functiondef) y comparado contra la mig 150.
+-- Cambios, y nada mas que estos:
+--   . se va `c_default numeric := 2`
+--   . el CTE `it` suma LEFT JOIN perfiles y arrastra el rol del vendedor
+--   . `con_pct` suma LEFT JOIN politicas_comerciales y el CASE por rol
+--   . la salida informa los dos porcentajes ademas de `comision_default`
+-- La subconsulta de reglas NO se toca: es la que hace que la excepcion funcione.
+-- ---------------------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION public.calcular_comisiones(
+  p_desde        date,
+  p_hasta        date,
+  p_sucursal_ids bigint[] DEFAULT NULL
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $fn$
+DECLARE
+  v_sucursales bigint[];
+  v_pct_prev   numeric;
+  v_pct_otros  numeric;
+  v_out        jsonb;
+BEGIN
+  IF NOT es_admin() THEN
+    RAISE EXCEPTION 'Solo un admin puede ver el calculo de comisiones' USING ERRCODE = '42501';
+  END IF;
+
+  IF p_desde IS NULL OR p_hasta IS NULL OR p_hasta < p_desde THEN
+    RAISE EXCEPTION 'Rango de fechas invalido';
+  END IF;
+
+  -- Sin sucursales explicitas: las que el admin tiene asignadas.
+  v_sucursales := COALESCE(
+    p_sucursal_ids,
+    ARRAY(SELECT sucursal_id FROM usuario_sucursales WHERE usuario_id = auth.uid())
+  );
+  IF v_sucursales IS NULL OR array_length(v_sucursales, 1) IS NULL THEN
+    v_sucursales := ARRAY(SELECT id FROM sucursales);
+  END IF;
+
+  -- Solo para informar en la salida: la liquidacion usa la politica de CADA
+  -- pedido via el JOIN de abajo, no estos dos numeros. Con varias sucursales de
+  -- politicas distintas la pantalla muestra la mas alta, que es un cartel
+  -- informativo; los importes siguen siendo exactos por sucursal.
+  SELECT COALESCE(MAX(pc.comision_pct_preventista), 2),
+         COALESCE(MAX(pc.comision_pct_otros), 0)
+    INTO v_pct_prev, v_pct_otros
+    FROM politicas_comerciales pc
+   WHERE pc.sucursal_id = ANY(v_sucursales);
+  v_pct_prev  := COALESCE(v_pct_prev, 2);
+  v_pct_otros := COALESCE(v_pct_otros, 0);
+
+  WITH ped AS (
+    SELECT p.id, p.usuario_id, p.fecha, p.sucursal_id
+    FROM pedidos p
+    WHERE p.estado <> 'cancelado'
+      AND p.canal = 'app'
+      AND p.fecha BETWEEN p_desde AND p_hasta
+      AND p.sucursal_id = ANY(v_sucursales)
+      AND p.usuario_id IN (SELECT id FROM perfiles)
+  ),
+  it AS (
+    SELECT ped.usuario_id, ped.fecha, ped.sucursal_id,
+           pi.subtotal,
+           pi.producto_id,
+           pi.origen_precio,
+           prod.categoria_id,
+           -- Rol vivo del vendedor. `perfiles.rol` crudo y no es_preventista(),
+           -- que devuelve true para admin y encargado.
+           perf.rol AS rol_vendedor
+    FROM ped
+    JOIN pedido_items pi ON pi.pedido_id = ped.id
+    LEFT JOIN productos prod ON prod.id = pi.producto_id
+    LEFT JOIN perfiles perf ON perf.id = ped.usuario_id
+    WHERE COALESCE(pi.es_bonificacion, false) = false
+  ),
+  con_pct AS (
+    SELECT it.*,
+      COALESCE((
+        SELECT r.porcentaje FROM comision_reglas r
+        WHERE r.activo
+          AND (r.sucursal_id    IS NULL OR r.sucursal_id    = it.sucursal_id)
+          AND (r.preventista_id IS NULL OR r.preventista_id = it.usuario_id)
+          AND (r.origen_precio  IS NULL OR r.origen_precio  = it.origen_precio)
+          AND (r.producto_id    IS NULL OR r.producto_id    = it.producto_id)
+          AND (r.categoria_id   IS NULL OR r.categoria_id   = it.categoria_id)
+          AND r.vigente_desde <= it.fecha
+          AND (r.vigente_hasta IS NULL OR r.vigente_hasta >= it.fecha)
+        ORDER BY
+          (CASE WHEN r.preventista_id IS NOT NULL THEN 8 ELSE 0 END
+         + CASE WHEN r.producto_id    IS NOT NULL THEN 4 ELSE 0 END
+         + CASE WHEN r.categoria_id   IS NOT NULL THEN 2 ELSE 0 END
+         + CASE WHEN r.origen_precio  IS NOT NULL THEN 1 ELSE 0 END) DESC,
+          (r.sucursal_id IS NOT NULL) DESC,
+          r.vigente_desde DESC,
+          r.id DESC
+        LIMIT 1
+      ),
+      -- El default, ahora por rol y por sucursal. El COALESCE interno cubre que
+      -- a una sucursal le falte la fila de politica: cae a los valores de hoy
+      -- en vez de hacer desaparecer la comision.
+      CASE WHEN it.rol_vendedor = 'preventista'
+           THEN COALESCE(pc.comision_pct_preventista, 2)
+           ELSE COALESCE(pc.comision_pct_otros, 0)
+      END) AS pct
+    FROM it
+    LEFT JOIN politicas_comerciales pc ON pc.sucursal_id = it.sucursal_id
+  ),
+  por_origen AS (
+    SELECT usuario_id,
+           COALESCE(origen_precio, 'sin_dato') AS origen,
+           SUM(subtotal)                 AS base,
+           SUM(subtotal * pct / 100.0)   AS comision,
+           COUNT(*)                      AS items
+    FROM con_pct
+    GROUP BY usuario_id, COALESCE(origen_precio, 'sin_dato')
+  ),
+  por_preventista AS (
+    SELECT c.usuario_id,
+           COALESCE(pf.nombre, 'Sin nombre')                                  AS nombre,
+           pf.email,
+           SUM(c.subtotal)                                                    AS base,
+           SUM(c.subtotal * c.pct / 100.0)                                    AS comision,
+           COUNT(*)                                                           AS items,
+           COUNT(*) FILTER (WHERE c.origen_precio IS NULL)                    AS items_sin_desglose,
+           COALESCE(SUM(c.subtotal) FILTER (WHERE c.origen_precio IS NULL),0) AS base_sin_desglose
+    FROM con_pct c
+    LEFT JOIN perfiles pf ON pf.id = c.usuario_id
+    GROUP BY c.usuario_id, pf.nombre, pf.email
+  )
+  SELECT jsonb_build_object(
+    'desde', p_desde,
+    'hasta', p_hasta,
+    -- Se mantiene la clave vieja para no romper a quien la lea; ahora es el %
+    -- de los preventistas, que es el caso mayoritario.
+    'comision_default', v_pct_prev,
+    'comision_pct_preventista', v_pct_prev,
+    'comision_pct_otros', v_pct_otros,
+    'preventistas', COALESCE((
+      SELECT jsonb_agg(x ORDER BY (x->>'base')::numeric DESC)
+      FROM (
+        SELECT jsonb_build_object(
+          'id', pp.usuario_id,
+          'nombre', pp.nombre,
+          'email', pp.email,
+          'base', ROUND(pp.base, 2),
+          'comision', ROUND(pp.comision, 2),
+          'items', pp.items,
+          'items_sin_desglose', pp.items_sin_desglose,
+          'base_sin_desglose', ROUND(pp.base_sin_desglose, 2),
+          'por_origen', COALESCE((
+            SELECT jsonb_agg(jsonb_build_object(
+              'origen', po.origen,
+              'base', ROUND(po.base, 2),
+              'comision', ROUND(po.comision, 2),
+              'items', po.items
+            ) ORDER BY po.base DESC)
+            FROM por_origen po WHERE po.usuario_id = pp.usuario_id
+          ), '[]'::jsonb)
+        ) AS x
+        FROM por_preventista pp
+      ) s
+    ), '[]'::jsonb),
+    'totales', (
+      SELECT jsonb_build_object(
+        'base', COALESCE(ROUND(SUM(base), 2), 0),
+        'comision', COALESCE(ROUND(SUM(comision), 2), 0),
+        'items', COALESCE(SUM(items), 0),
+        'items_sin_desglose', COALESCE(SUM(items_sin_desglose), 0),
+        'base_sin_desglose', COALESCE(ROUND(SUM(base_sin_desglose), 2), 0)
+      ) FROM por_preventista
+    )
+  ) INTO v_out;
+
+  RETURN v_out;
+END;
+$fn$;
+
+ALTER FUNCTION public.calcular_comisiones(date, date, bigint[]) OWNER TO postgres;
+REVOKE ALL ON FUNCTION public.calcular_comisiones(date, date, bigint[]) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.calcular_comisiones(date, date, bigint[]) TO authenticated;
+
+COMMENT ON FUNCTION public.calcular_comisiones(date, date, bigint[]) IS
+  'Comision por vendedor con desglose por origen del precio. El % sale de la '
+  'regla vigente mas especifica (comision_reglas) y, si no hay ninguna, del '
+  'default por ROL de politicas_comerciales: preventista o resto. Misma base '
+  'que reporte_gerencial.base_comision. Migs 150 y 207.';
+
+-- ---------------------------------------------------------------------------
+-- 3. Escritura desde la pantalla de configuracion
+--
+-- Va por RPC y no por UPDATE directo por el mismo motivo que el monto minimo
+-- (mig 204): que `actualizado_por` lo selle el servidor con auth.uid(). Si lo
+-- mandara el cliente seria un dato que el cliente elige.
+--
+-- admin/encargado, igual que `actualizar_monto_minimo_pedido` y que la policy
+-- de UPDATE de la tabla. Pedir admin-only aca daria una falsa sensacion de
+-- cierre: un encargado podria hacer el UPDATE directo por PostgREST igual,
+-- porque la policy de la mig 204 se lo permite. Si se quiere que solo un admin
+-- toque los porcentajes, hay que apretar la RLS, no este IF.
+-- ---------------------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION public.actualizar_comisiones_default(
+  p_pct_preventista numeric,
+  p_pct_otros       numeric
+)
+RETURNS jsonb
+LANGUAGE plpgsql VOLATILE SECURITY DEFINER
+SET search_path TO 'public'
+AS $$
+DECLARE
+  v_sucursal bigint := public.current_sucursal_id();
+  v_rol      text;
+BEGIN
+  IF v_sucursal IS NULL THEN
+    RAISE EXCEPTION 'No se pudo determinar la sucursal activa';
+  END IF;
+
+  SELECT rol INTO v_rol FROM public.perfiles WHERE id = auth.uid();
+  IF v_rol IS NULL OR v_rol NOT IN ('admin', 'encargado') THEN
+    RAISE EXCEPTION 'Acceso denegado: se requiere rol admin o encargado';
+  END IF;
+
+  IF p_pct_preventista IS NULL OR p_pct_preventista < 0 OR p_pct_preventista > 100 THEN
+    RAISE EXCEPTION 'El porcentaje de preventista debe estar entre 0 y 100';
+  END IF;
+  IF p_pct_otros IS NULL OR p_pct_otros < 0 OR p_pct_otros > 100 THEN
+    RAISE EXCEPTION 'El porcentaje del resto debe estar entre 0 y 100';
+  END IF;
+
+  INSERT INTO public.politicas_comerciales (
+    sucursal_id, comision_pct_preventista, comision_pct_otros, actualizado_por, actualizado_en
+  )
+  VALUES (v_sucursal, p_pct_preventista, p_pct_otros, auth.uid(), now())
+  ON CONFLICT (sucursal_id) DO UPDATE
+    SET comision_pct_preventista = EXCLUDED.comision_pct_preventista,
+        comision_pct_otros       = EXCLUDED.comision_pct_otros,
+        actualizado_por          = EXCLUDED.actualizado_por,
+        actualizado_en           = EXCLUDED.actualizado_en;
+
+  RETURN jsonb_build_object(
+    'comision_pct_preventista', p_pct_preventista,
+    'comision_pct_otros', p_pct_otros
+  );
+END;
+$$;
+
+COMMENT ON FUNCTION public.actualizar_comisiones_default(numeric, numeric) IS
+  'Fija los dos % de comision por defecto de la sucursal activa. Solo '
+  'admin/encargado. mig 207.';
+
+REVOKE ALL ON FUNCTION public.actualizar_comisiones_default(numeric, numeric) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.actualizar_comisiones_default(numeric, numeric) TO authenticated;
+
+-- Misma verificacion de ACL que la mig 204: una funcion SECURITY DEFINER nace
+-- con EXECUTE para PUBLIC y el GRANT a authenticated no lo revierte.
+DO $verif$
+DECLARE
+  v_acl text;
+  v_fn  text;
+BEGIN
+  FOREACH v_fn IN ARRAY ARRAY['actualizar_comisiones_default', 'calcular_comisiones'] LOOP
+    SELECT array_to_string(proacl, ',') INTO v_acl
+    FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace
+    WHERE n.nspname = 'public' AND p.proname = v_fn;
+
+    IF v_acl IS NULL THEN
+      RAISE EXCEPTION '% quedo con ACL default (PUBLIC ejecuta)', v_fn;
+    END IF;
+    IF v_acl LIKE '=X/%' OR v_acl LIKE '%,=X/%' THEN
+      RAISE EXCEPTION '% quedo ejecutable por PUBLIC: %', v_fn, v_acl;
+    END IF;
+    IF v_acl LIKE '%anon=%' THEN
+      RAISE EXCEPTION '% quedo ejecutable por anon: %', v_fn, v_acl;
+    END IF;
+    IF v_acl NOT LIKE '%authenticated=X%' THEN
+      RAISE EXCEPTION '% no quedo ejecutable por authenticated: %', v_fn, v_acl;
+    END IF;
+  END LOOP;
+END
+$verif$;
+
+COMMIT;
+
+-- ROLLBACK (si hiciera falta):
+--   Volver a aplicar el cuerpo de calcular_comisiones de la mig 150 (con
+--   c_default := 2) y despues:
+--     ALTER TABLE public.politicas_comerciales
+--       DROP COLUMN IF EXISTS comision_pct_preventista,
+--       DROP COLUMN IF EXISTS comision_pct_otros;
+--     DROP FUNCTION IF EXISTS public.actualizar_comisiones_default(numeric, numeric);
+--   El orden importa: la funcion lee las columnas.

--- a/src/components/containers/ComisionesContainer.test.tsx
+++ b/src/components/containers/ComisionesContainer.test.tsx
@@ -1,12 +1,15 @@
 /**
- * El desplegable de "Reglas de comisión" salía de un padrón filtrado por
- * `rol = 'preventista'`, y como la regla se identifica por
- * `comision_reglas.preventista_id`, a un admin o a un encargado no había forma
- * de asignarle un %. Pero `calcular_comisiones` agrupa por `pedidos.usuario_id`
- * sin mirar rol (mig 150): esa gente YA acumula comisión al % por defecto.
+ * El desplegable de "Reglas de comisión" tuvo dos bugs encadenados. El primero:
+ * salía de un padrón filtrado por `rol = 'preventista'`, así que a un admin o a
+ * un encargado no había forma de asignarle un %. El segundo, al arreglar mal el
+ * primero: pasó a salir de quien vendió EN EL PERÍODO CONSULTADO, así que la
+ * lista cambiaba al cambiar el rango de fechas y un admin sin ventas seguía sin
+ * aparecer.
  *
- * El test monta el modal de verdad y mira el `<select>`, no una lista interna:
- * es el desplegable lo que estaba roto.
+ * Ahora el piso es el padrón de quienes PUEDEN vender. La regla de armado vive
+ * en `vendedoresElegibles` y tiene sus propios tests; acá se prueba el cableado
+ * del container montando el modal de verdad y mirando el `<select>`, que es lo
+ * que estaba roto.
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, within } from '@testing-library/react'
@@ -18,7 +21,7 @@ const mockPadron = vi.fn()
 
 vi.mock('../../hooks/queries', () => ({
   useCalcularComisionesQuery: () => mockCalcular(),
-  usePreventistasQuery: () => mockPadron(),
+  useVendedoresComisionablesQuery: () => mockPadron(),
   useComisionReglasQuery: () => ({ data: [], isLoading: false }),
   useGuardarComisionReglaMutation: () => ({ mutateAsync: vi.fn(), isPending: false }),
   useDesactivarComisionReglaMutation: () => ({ mutateAsync: vi.fn(), isPending: false }),
@@ -132,6 +135,42 @@ describe('ComisionesContainer › desplegable de reglas', () => {
     const select = await abrirReglas()
 
     expect(within(select).getAllByRole('option', { name: 'Ana' })).toHaveLength(1)
+  })
+
+  it('un admin que NO vendió en el período aparece igual en el desplegable', async () => {
+    // Es el bug que arregla este cambio: antes la fuente era quien vendió en el
+    // período, así que Julio —2 pedidos en todo el año— aparecía o desaparecía
+    // según el mes que estuvieras mirando.
+    mockCalcular.mockReturnValue({
+      data: resultadoCon([vendedor('u-vendio', 'Marcelo', 33000)]),
+      isLoading: false,
+      error: null,
+    })
+    mockPadron.mockReturnValue({
+      data: [
+        { id: 'u-julio', nombre: 'Julio', email: 'julio@x.com' },
+        { id: 'u-vendio', nombre: 'Marcelo', email: 'm@x.com' },
+      ],
+    })
+
+    const select = await abrirReglas()
+
+    expect(within(select).getByRole('option', { name: 'Julio' })).toBeInTheDocument()
+  })
+
+  it('rescata a quien vendió pero ya no está en el padrón', async () => {
+    // Christian: preventista inactivo con $804.249 acumulados. Sale del padrón
+    // por `activo = false` y hay que poder editarle la regla igual.
+    mockCalcular.mockReturnValue({
+      data: resultadoCon([vendedor('u-christian', 'Christian', 40212490)]),
+      isLoading: false,
+      error: null,
+    })
+    mockPadron.mockReturnValue({ data: [{ id: 'u-otro', nombre: 'Ana', email: 'a@x.com' }] })
+
+    const select = await abrirReglas()
+
+    expect(within(select).getByRole('option', { name: 'Christian' })).toBeInTheDocument()
   })
 
   it('mantiene la opción «Todos» para la regla general', async () => {

--- a/src/components/containers/ComisionesContainer.tsx
+++ b/src/components/containers/ComisionesContainer.tsx
@@ -1,7 +1,8 @@
 import React, { Suspense, useCallback, useEffect, useMemo, useState } from 'react'
 import { Loader2 } from 'lucide-react'
 import { fechaLocalISO } from '../../utils/formatters'
-import { useCalcularComisionesQuery, usePreventistasQuery } from '../../hooks/queries'
+import { useCalcularComisionesQuery, useVendedoresComisionablesQuery } from '../../hooks/queries'
+import { vendedoresElegibles } from '../../utils/vendedoresComision'
 import { useAuthData } from '../../contexts/AuthDataContext'
 import { useNotification } from '../../contexts/NotificationContext'
 import { lazyWithReload } from '../../utils/lazyWithReload'
@@ -36,32 +37,16 @@ export default function ComisionesContainer(): React.ReactElement {
   // El cálculo lo resuelve la DB (mig 150): misma base que el reporte gerencial
   // y % por regla vigente, en vez del `ventas × % tipeado` que había acá.
   const { data: resultado, isLoading, error } = useCalcularComisionesQuery(fechaDesde, fechaHasta)
-  const { data: padronPreventistas = [] } = usePreventistasQuery()
+  const { data: padron = [] } = useVendedoresComisionablesQuery()
 
-  // La lista del desplegable sale de los DATOS, no de los roles. Precedente
-  // escrito en la mig 198: un desplegable filtrado por rol escondía $32,8M de
-  // venta real. Acá el filtro por rol dejaba afuera a admins y encargados, que
-  // comisionan igual —`calcular_comisiones` agrupa por `pedidos.usuario_id` sin
-  // mirar rol (mig 150)— y por eso no había forma de asignarles un %.
-  //
-  // Unión de dos fuentes: quien efectivamente vendió en el período, sea cual
-  // sea su rol, y el padrón de preventistas de la sucursal, para el que todavía
-  // no vendió. Un admin o encargado sin ventas en el período no aparece: no
-  // tiene comisión que configurar hasta que venda, y aparece solo con ampliar
-  // el rango de fechas.
-  const preventistas = useMemo(() => {
-    const porId = new Map<string, string>()
-    const nombreDe = (n: string | null, e: string | null): string => n || e || 'Sin nombre'
-    for (const p of resultado?.preventistas ?? []) {
-      porId.set(p.id, nombreDe(p.nombre, p.email))
-    }
-    for (const p of padronPreventistas) {
-      if (!porId.has(p.id)) porId.set(p.id, nombreDe(p.nombre ?? null, p.email ?? null))
-    }
-    return [...porId]
-      .map(([id, nombre]) => ({ id, nombre }))
-      .sort((a, b) => a.nombre.localeCompare(b.nombre, 'es'))
-  }, [resultado, padronPreventistas])
+  // El padrón —quienes PUEDEN vender— es el piso, así la lista no cambia al
+  // cambiar el rango de fechas; `resultado.preventistas` sólo suma al que ya
+  // no está en el padrón pero tiene comisión acumulada. La regla vive en
+  // `vendedoresElegibles`, con tests.
+  const preventistas = useMemo(
+    () => vendedoresElegibles(padron, resultado?.preventistas),
+    [padron, resultado],
+  )
 
   useEffect(() => {
     if (error) {
@@ -91,7 +76,8 @@ export default function ComisionesContainer(): React.ReactElement {
         <Suspense fallback={null}>
           <ModalComisionReglas
             preventistas={preventistas}
-            comisionDefault={resultado?.comision_default ?? 2}
+            comisionPreventista={resultado?.comision_pct_preventista ?? resultado?.comision_default ?? 2}
+            comisionOtros={resultado?.comision_pct_otros ?? 0}
             onClose={() => setModalReglasOpen(false)}
           />
         </Suspense>

--- a/src/components/containers/ConfiguracionContainer.tsx
+++ b/src/components/containers/ConfiguracionContainer.tsx
@@ -9,6 +9,7 @@ import { Loader2 } from 'lucide-react'
 import {
   usePoliticasComercialesQuery,
   useActualizarMontoMinimoMutation,
+  useActualizarComisionesDefaultMutation,
   useImpactoMinimoQuery,
 } from '../../hooks/queries/usePoliticasComercialesQuery'
 import { useNotification } from '../../contexts/NotificationContext'
@@ -30,6 +31,7 @@ export default function ConfiguracionContainer() {
   const { currentSucursalNombre } = useSucursal()
   const { politicas, isLoading } = usePoliticasComercialesQuery()
   const actualizar = useActualizarMontoMinimoMutation()
+  const actualizarComisiones = useActualizarComisionesDefaultMutation()
 
   // Lo que el usuario está tipeando, para poder mostrarle el impacto ANTES de
   // guardar. Arranca en el valor vigente.
@@ -49,6 +51,15 @@ export default function ConfiguracionContainer() {
     }
   }, [actualizar, notify])
 
+  const handleGuardarComisiones = useCallback(async (pctPreventista: number, pctOtros: number) => {
+    try {
+      await actualizarComisiones.mutateAsync({ pctPreventista, pctOtros })
+      notify.success(`Comisión por defecto: ${pctPreventista}% preventistas, ${pctOtros}% el resto`)
+    } catch (err) {
+      notify.error(err instanceof Error ? err.message : 'No se pudieron guardar las comisiones')
+    }
+  }, [actualizarComisiones, notify])
+
   return (
     <Suspense fallback={<LoadingState />}>
       <VistaConfiguracion
@@ -60,6 +71,10 @@ export default function ConfiguracionContainer() {
         onMontoTipeado={setMontoTipeado}
         onGuardar={handleGuardar}
         nombreSucursal={currentSucursalNombre}
+        comisionPctPreventista={politicas.comisionPctPreventista}
+        comisionPctOtros={politicas.comisionPctOtros}
+        guardandoComisiones={actualizarComisiones.isPending}
+        onGuardarComisiones={handleGuardarComisiones}
       />
     </Suspense>
   )

--- a/src/components/modals/ModalComisionReglas.tsx
+++ b/src/components/modals/ModalComisionReglas.tsx
@@ -34,7 +34,10 @@ export interface PreventistaOption {
 
 export interface ModalComisionReglasProps {
   preventistas: PreventistaOption[]
-  comisionDefault: number
+  /** % por defecto de los preventistas (mig 207). */
+  comisionPreventista: number
+  /** % por defecto del resto: admin, encargado (mig 207). */
+  comisionOtros: number
   onClose: () => void
 }
 
@@ -50,7 +53,8 @@ const ORIGENES_REGLA: Array<{ value: '' | OrigenPrecio; label: string }> = [
 
 export default function ModalComisionReglas({
   preventistas,
-  comisionDefault,
+  comisionPreventista,
+  comisionOtros,
   onClose,
 }: ModalComisionReglasProps) {
   const notify = useNotification()
@@ -142,9 +146,11 @@ export default function ModalComisionReglas({
         <div className="flex items-start gap-3 p-3 rounded-lg bg-stone-50 dark:bg-gray-900/40 border border-stone-200 dark:border-gray-700">
           <Percent className="w-5 h-5 shrink-0 mt-0.5 text-indigo-600" aria-hidden="true" />
           <p className="text-xs text-stone-600 dark:text-gray-300">
-            Gana la regla más específica que coincida. Sin ninguna regla que aplique se usa el{' '}
-            <strong>{comisionDefault}%</strong>. Cargá una regla con origen «Cualquiera» para el %
-            base del vendedor y otra con «{etiquetaOrigen('mayorista')}» para el % reducido.
+            Gana la regla más específica que coincida. Sin ninguna regla que aplique se usa el
+            porcentaje por defecto según el rol: <strong>{comisionPreventista}%</strong> para
+            preventistas y <strong>{comisionOtros}%</strong> para el resto (admin, encargado), que
+            se configuran en Configuración. Cargá una regla con origen «Cualquiera» para el % base
+            de una persona y otra con «{etiquetaOrigen('mayorista')}» para el % reducido.
           </p>
         </div>
 
@@ -242,7 +248,8 @@ export default function ModalComisionReglas({
           <p className="text-sm text-stone-500">Cargando reglas…</p>
         ) : reglas.length === 0 ? (
           <p className="text-sm text-stone-500 dark:text-gray-400">
-            No hay reglas cargadas: todo se comisiona al {comisionDefault}%.
+            No hay reglas cargadas: se comisiona con el default por rol
+            ({comisionPreventista}% preventistas, {comisionOtros}% el resto).
           </p>
         ) : (
           <div className="overflow-x-auto">

--- a/src/components/vistas/VistaConfiguracion.tsx
+++ b/src/components/vistas/VistaConfiguracion.tsx
@@ -1,12 +1,13 @@
 /**
  * Configuración comercial de la sucursal activa.
  *
- * Primera pantalla de configuración del sistema. Hoy tiene una sola política —
- * la compra mínima por pedido — pero es el lugar donde van las que vengan:
- * sumar una es una columna en `politicas_comerciales` (mig 204) y un campo acá.
+ * Pantalla de configuración del sistema: la compra mínima por pedido (mig 204)
+ * y los dos % de comisión por defecto (mig 207). Es el lugar donde van las
+ * políticas que vengan: sumar una es una columna en `politicas_comerciales` y
+ * un campo acá.
  */
 import { useState, useEffect, type FormEvent } from 'react';
-import { Loader2, Settings, AlertTriangle } from 'lucide-react';
+import { Loader2, Settings, AlertTriangle, Percent } from 'lucide-react';
 import { formatCurrency } from '../../utils/formatters';
 
 export interface VistaConfiguracionProps {
@@ -20,6 +21,144 @@ export interface VistaConfiguracionProps {
   onMontoTipeado: (monto: number) => void;
   onGuardar: (monto: number) => void;
   nombreSucursal?: string | null;
+  /** % por defecto de quien tiene rol preventista (mig 207). */
+  comisionPctPreventista: number;
+  /** % por defecto de quien NO es preventista: admin, encargado. */
+  comisionPctOtros: number;
+  guardandoComisiones: boolean;
+  onGuardarComisiones: (pctPreventista: number, pctOtros: number) => void;
+}
+
+/**
+ * Los dos % de comisión por defecto.
+ *
+ * Van en su propio formulario y no junto al monto mínimo porque son otra
+ * decisión y otro RPC: guardar uno no tiene por qué guardar el otro.
+ */
+function FormComisiones({
+  pctPreventista,
+  pctOtros,
+  guardando,
+  onGuardar,
+}: {
+  pctPreventista: number;
+  pctOtros: number;
+  guardando: boolean;
+  onGuardar: (pctPreventista: number, pctOtros: number) => void;
+}) {
+  const [prev, setPrev] = useState(String(pctPreventista));
+  const [otros, setOtros] = useState(String(pctOtros));
+  const [error, setError] = useState<string | null>(null);
+
+  // El valor del servidor llega después del primer render y cambia al cambiar
+  // de sucursal.
+  useEffect(() => { setPrev(String(pctPreventista)); }, [pctPreventista]);
+  useEffect(() => { setOtros(String(pctOtros)); }, [pctOtros]);
+
+  const nPrev = Number(prev.replace(',', '.'));
+  const nOtros = Number(otros.replace(',', '.'));
+  const validoPrev = Number.isFinite(nPrev) && nPrev >= 0 && nPrev <= 100;
+  const validoOtros = Number.isFinite(nOtros) && nOtros >= 0 && nOtros <= 100;
+  const valido = validoPrev && validoOtros;
+  const cambio = valido && (nPrev !== pctPreventista || nOtros !== pctOtros);
+
+  function handleSubmit(e: FormEvent) {
+    e.preventDefault();
+    if (!valido) {
+      setError('Ingresá porcentajes entre 0 y 100.');
+      return;
+    }
+    setError(null);
+    onGuardar(nPrev, nOtros);
+  }
+
+  return (
+    <form
+      onSubmit={handleSubmit}
+      className="bg-white dark:bg-gray-800 border border-stone-200/80 dark:border-gray-700 rounded-xl p-5 space-y-4 shadow-warm"
+    >
+      <div>
+        <h2 className="text-sm font-semibold text-stone-900 dark:text-white flex items-center gap-2">
+          <Percent className="w-4 h-4 text-stone-500" aria-hidden="true" />
+          Comisión por defecto
+        </h2>
+        <p className="text-xs text-stone-500 dark:text-stone-400 mt-1">
+          Es el porcentaje que se usa cuando esa persona no tiene una regla propia cargada
+          en <strong>Comisiones → Reglas de comisión</strong>. Si tiene una regla, la regla
+          manda y estos valores no la tocan.
+        </p>
+        <p className="text-xs text-stone-500 dark:text-stone-400 mt-2">
+          Cargar un pedido siendo admin o encargado es parte del trabajo, no una venta:
+          por eso el resto arranca en 0. Para que alguien del resto comisione, cargale su
+          regla propia.
+        </p>
+      </div>
+
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+        <div>
+          <label htmlFor="pct-preventista" className="block text-sm font-medium text-stone-900 dark:text-white">
+            Preventistas
+          </label>
+          <div className="mt-2 flex items-center gap-2">
+            <input
+              id="pct-preventista"
+              type="number"
+              min={0}
+              max={100}
+              step="0.01"
+              inputMode="decimal"
+              value={prev}
+              onChange={(e) => { setPrev(e.target.value); setError(null); }}
+              aria-invalid={!validoPrev}
+              className="w-28 px-3 py-2 rounded-lg border border-stone-300 dark:border-gray-600 dark:bg-gray-900 dark:text-white focus:ring-2 focus:ring-amber-500 focus:border-amber-500"
+            />
+            <span className="text-stone-500 dark:text-stone-400">%</span>
+          </div>
+        </div>
+
+        <div>
+          <label htmlFor="pct-otros" className="block text-sm font-medium text-stone-900 dark:text-white">
+            Resto (admin, encargado)
+          </label>
+          <div className="mt-2 flex items-center gap-2">
+            <input
+              id="pct-otros"
+              type="number"
+              min={0}
+              max={100}
+              step="0.01"
+              inputMode="decimal"
+              value={otros}
+              onChange={(e) => { setOtros(e.target.value); setError(null); }}
+              aria-invalid={!validoOtros}
+              className="w-28 px-3 py-2 rounded-lg border border-stone-300 dark:border-gray-600 dark:bg-gray-900 dark:text-white focus:ring-2 focus:ring-amber-500 focus:border-amber-500"
+            />
+            <span className="text-stone-500 dark:text-stone-400">%</span>
+          </div>
+        </div>
+      </div>
+
+      {error && (
+        <p role="alert" className="text-rose-600 text-xs">{error}</p>
+      )}
+
+      <div className="flex items-center gap-3">
+        <button
+          type="submit"
+          disabled={guardando || !cambio}
+          className="px-4 py-2 rounded-lg bg-amber-600 text-white font-semibold text-sm hover:bg-amber-700 disabled:bg-stone-300 dark:disabled:bg-gray-600 disabled:cursor-not-allowed flex items-center gap-2"
+        >
+          {guardando && <Loader2 className="w-4 h-4 animate-spin" aria-hidden="true" />}
+          Guardar comisiones
+        </button>
+        {!cambio && valido && (
+          <span className="text-xs text-stone-500 dark:text-stone-400">
+            Vigente: {pctPreventista}% preventistas · {pctOtros}% el resto
+          </span>
+        )}
+      </div>
+    </form>
+  );
 }
 
 export default function VistaConfiguracion({
@@ -31,6 +170,10 @@ export default function VistaConfiguracion({
   onMontoTipeado,
   onGuardar,
   nombreSucursal,
+  comisionPctPreventista,
+  comisionPctOtros,
+  guardandoComisiones,
+  onGuardarComisiones,
 }: VistaConfiguracionProps) {
   const [valor, setValor] = useState(String(montoMinimoActual ?? 0));
   const [error, setError] = useState<string | null>(null);
@@ -160,6 +303,13 @@ export default function VistaConfiguracion({
           )}
         </div>
       </form>
+
+      <FormComisiones
+        pctPreventista={comisionPctPreventista}
+        pctOtros={comisionPctOtros}
+        guardando={guardandoComisiones}
+        onGuardar={onGuardarComisiones}
+      />
     </div>
   );
 }

--- a/src/hooks/queries/index.ts
+++ b/src/hooks/queries/index.ts
@@ -138,6 +138,7 @@ export {
   useTransportistasQuery,
   usePreventistasQuery,
   usePreventistasAsignablesQuery,
+  useVendedoresComisionablesQuery,
   usePerfilRolesQuery,
   useAsignarPerfilRolesMutation,
   useActualizarUsuarioMutation,

--- a/src/hooks/queries/useComisionesQuery.ts
+++ b/src/hooks/queries/useComisionesQuery.ts
@@ -42,7 +42,14 @@ export interface ComisionPreventista {
 export interface ComisionesResultado {
   desde: string
   hasta: string
+  /** @deprecated Desde la mig 207 el default depende del rol: es el de preventista. */
   comision_default: number
+  /**
+   * Los dos defaults por rol de `politicas_comerciales` (mig 207). Opcionales
+   * porque una respuesta cacheada de antes de la migración no los trae.
+   */
+  comision_pct_preventista?: number
+  comision_pct_otros?: number
   preventistas: ComisionPreventista[]
   totales: {
     base: number

--- a/src/hooks/queries/usePoliticasComercialesQuery.ts
+++ b/src/hooks/queries/usePoliticasComercialesQuery.ts
@@ -26,6 +26,10 @@ import { cacheData, getCachedData } from '../../lib/offlineDb'
 export interface PoliticasComerciales {
   /** Monto mínimo en $ que debe alcanzar un pedido. 0 = sin política. */
   montoMinimoPedido: number
+  /** % por defecto de quien tiene rol preventista (mig 207). */
+  comisionPctPreventista: number
+  /** % por defecto de quien NO es preventista: admin, encargado (mig 207). */
+  comisionPctOtros: number
 }
 
 const CACHE_KEY = 'politicas_comerciales'
@@ -34,12 +38,18 @@ export const politicasComercialesKeys = {
   all: (sucursalId: number | null) => ['politicas-comerciales', sucursalId] as const,
 }
 
-export const POLITICAS_POR_DEFECTO: PoliticasComerciales = { montoMinimoPedido: 0 }
+// Los valores de arranque de la mig 207, que son los que rigen si todavía no
+// llegó la fila del servidor. No inventan nada: son el default de las columnas.
+export const POLITICAS_POR_DEFECTO: PoliticasComerciales = {
+  montoMinimoPedido: 0,
+  comisionPctPreventista: 2,
+  comisionPctOtros: 0,
+}
 
 async function fetchPoliticas(sucursalId: number | null): Promise<PoliticasComerciales> {
   const { data, error } = await supabase
     .from('politicas_comerciales')
-    .select('monto_minimo_pedido')
+    .select('monto_minimo_pedido, comision_pct_preventista, comision_pct_otros')
     .maybeSingle()
 
   if (error) throw error
@@ -48,6 +58,9 @@ async function fetchPoliticas(sucursalId: number | null): Promise<PoliticasComer
   // sucursal creada después todavía no la tendría, y eso no es un error.
   const politicas: PoliticasComerciales = {
     montoMinimoPedido: Number(data?.monto_minimo_pedido ?? 0) || 0,
+    // `?? 2` y no `|| 2`: un 0 configurado a mano es un valor, no un hueco.
+    comisionPctPreventista: Number(data?.comision_pct_preventista ?? 2),
+    comisionPctOtros: Number(data?.comision_pct_otros ?? 0),
   }
 
   // Sin expiración a propósito: un valor viejo es infinitamente mejor que
@@ -113,11 +126,61 @@ export function useActualizarMontoMinimoMutation() {
       if (error) throw error
       // Se refresca el caché de Dexie en el acto: si no, un teléfono que queda
       // sin señal justo después seguiría validando contra el mínimo viejo.
-      await cacheData(CACHE_KEY, { montoMinimoPedido: monto }, undefined, currentSucursalId).catch(() => {})
+      // Se preserva el resto de la política: pisar el caché con un objeto de un
+      // solo campo dejaría los porcentajes en undefined hasta la próxima lectura.
+      const previo = await getCachedData<PoliticasComerciales>(CACHE_KEY, currentSucursalId).catch(() => null)
+      await cacheData(
+        CACHE_KEY,
+        { ...(previo ?? POLITICAS_POR_DEFECTO), montoMinimoPedido: monto },
+        undefined,
+        currentSucursalId,
+      ).catch(() => {})
       return Number(data ?? monto)
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: politicasComercialesKeys.all(currentSucursalId) })
+    },
+  })
+}
+
+/**
+ * Fija los dos % de comisión por defecto de la sucursal activa.
+ *
+ * Va por RPC por lo mismo que el monto mínimo: `actualizado_por` lo sella el
+ * servidor con auth.uid(). Los dos porcentajes viajan juntos porque son una
+ * sola decisión —"cuánto cobra cada tipo de vendedor"— y mandarlos por separado
+ * dejaría un estado intermedio raro entre las dos escrituras.
+ */
+export function useActualizarComisionesDefaultMutation() {
+  const queryClient = useQueryClient()
+  const { currentSucursalId } = useSucursal()
+
+  return useMutation({
+    mutationFn: async (input: { pctPreventista: number; pctOtros: number }) => {
+      const { error } = await supabase.rpc('actualizar_comisiones_default', {
+        p_pct_preventista: input.pctPreventista,
+        p_pct_otros: input.pctOtros,
+      })
+      if (error) throw error
+
+      const previo = await getCachedData<PoliticasComerciales>(CACHE_KEY, currentSucursalId).catch(() => null)
+      await cacheData(
+        CACHE_KEY,
+        {
+          ...(previo ?? POLITICAS_POR_DEFECTO),
+          comisionPctPreventista: input.pctPreventista,
+          comisionPctOtros: input.pctOtros,
+        },
+        undefined,
+        currentSucursalId,
+      ).catch(() => {})
+
+      return input
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: politicasComercialesKeys.all(currentSucursalId) })
+      // El cálculo de comisiones cambia de resultado: su caché queda viejo.
+      queryClient.invalidateQueries({ queryKey: ['comisiones'] })
     },
   })
 }

--- a/src/hooks/queries/useUsuariosQuery.ts
+++ b/src/hooks/queries/useUsuariosQuery.ts
@@ -25,6 +25,7 @@ export const usuariosKeys = {
   transportistas: (sucursalId: number | null) => [...usuariosKeys.all(sucursalId), 'transportistas'] as const,
   preventistas: (sucursalId: number | null) => [...usuariosKeys.all(sucursalId), 'preventistas'] as const,
   preventistasAsignables: (sucursalId: number | null) => [...usuariosKeys.all(sucursalId), 'preventistasAsignables'] as const,
+  vendedoresComisionables: (sucursalId: number | null) => [...usuariosKeys.all(sucursalId), 'vendedoresComisionables'] as const,
   rolesExtra: (sucursalId: number | null, id: string) =>
     [...usuariosKeys.all(sucursalId), 'rolesExtra', id] as const,
 }
@@ -175,6 +176,31 @@ async function fetchPreventistasAsignables(sucursalId: number | null): Promise<P
   return (data as PerfilDB[]) || []
 }
 
+// Padron de quienes PUEDEN vender, para las reglas de comision.
+//
+// Es una tercera lista a proposito, y no un ensanche de las dos de arriba:
+// `fetchPreventistas` la usan ModalCliente y RecorridoPreventistaContainer,
+// donde filtrar por rol si es lo correcto, y `fetchPreventistasAsignables`
+// decide quien puede ser el `usuario_id` de un pedido. Tocar cualquiera de las
+// dos cambiaria pantallas que no tienen nada que ver con comisiones.
+//
+// Los tres roles salen de quien puede ser el vendedor de un pedido segun
+// `crear_pedido_completo` (mig 205). Los transportistas quedan afuera: no
+// pueden serlo, y en los datos no tienen ni un pedido.
+async function fetchVendedoresComisionables(sucursalId: number | null): Promise<PerfilDB[]> {
+  if (!sucursalId) return []
+  const { data, error } = await supabase
+    .from('perfiles')
+    .select('*, usuario_sucursales!inner(sucursal_id)')
+    .in('rol', ['admin', 'encargado', 'preventista'])
+    .eq('activo', true)
+    .eq('usuario_sucursales.sucursal_id', sucursalId)
+    .order('nombre')
+
+  if (error) throw error
+  return (data as PerfilDB[]) || []
+}
+
 // Mutation functions
 async function updateUsuario({ id, data: usuario }: { id: string; data: UsuarioUpdateInput }): Promise<PerfilDB> {
   const { data, error } = await supabase
@@ -317,6 +343,21 @@ export function usePreventistasAsignablesQuery() {
   return useQuery({
     queryKey: usuariosKeys.preventistasAsignables(currentSucursalId),
     queryFn: () => fetchPreventistasAsignables(currentSucursalId),
+    enabled: !!currentSucursalId,
+    staleTime: 10 * 60 * 1000,
+  })
+}
+
+/**
+ * Padron de quienes pueden vender (admin + encargado + preventista activos).
+ * Es el piso estable del desplegable de reglas de comision: no depende del
+ * periodo que se este mirando.
+ */
+export function useVendedoresComisionablesQuery() {
+  const { currentSucursalId } = useSucursal()
+  return useQuery({
+    queryKey: usuariosKeys.vendedoresComisionables(currentSucursalId),
+    queryFn: () => fetchVendedoresComisionables(currentSucursalId),
     enabled: !!currentSucursalId,
     staleTime: 10 * 60 * 1000,
   })

--- a/src/utils/vendedoresComision.test.ts
+++ b/src/utils/vendedoresComision.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect } from 'vitest'
+import { vendedoresElegibles } from './vendedoresComision'
+
+describe('vendedoresElegibles', () => {
+  describe('quién entra en la lista', () => {
+    it('incluye a todo el padrón aunque no haya vendido nunca', () => {
+      // El bug que arregla: la fuente era quien vendió EN EL PERÍODO
+      // CONSULTADO, así que un admin sin ventas no aparecía nunca y no había
+      // forma de cargarle una regla.
+      const lista = vendedoresElegibles(
+        [
+          { id: 'a', nombre: 'Admin Sin Ventas' },
+          { id: 'e', nombre: 'Encargado Sin Ventas' },
+          { id: 'p', nombre: 'Preventista Sin Ventas' },
+        ],
+        [],
+      )
+
+      expect(lista.map(v => v.id)).toEqual(['a', 'e', 'p'])
+    })
+
+    it('incluye a quien vendió aunque no esté en el padrón', () => {
+      // Christian: preventista inactivo, $804.249 acumulados. Sale del padrón
+      // por `activo = false`, pero tiene que poder editársele la regla.
+      const lista = vendedoresElegibles(
+        [{ id: 'p', nombre: 'Activo' }],
+        [{ id: 'x', nombre: 'Christian' }],
+      )
+
+      expect(lista.map(v => v.nombre)).toEqual(['Activo', 'Christian'])
+    })
+
+    it('la lista NO cambia al cambiar el período: el padrón es el piso', () => {
+      // Julio tiene 2 pedidos en todo el año. Mirando un mes sin ventas suyas
+      // el RPC no lo devuelve, y antes desaparecía del desplegable.
+      const padron = [{ id: 'julio', nombre: 'Julio' }, { id: 'ana', nombre: 'Ana' }]
+
+      const conVentas = vendedoresElegibles(padron, [{ id: 'julio', nombre: 'Julio' }])
+      const sinVentas = vendedoresElegibles(padron, [])
+
+      expect(sinVentas.map(v => v.id)).toEqual(conVentas.map(v => v.id))
+    })
+  })
+
+  describe('dedupe', () => {
+    it('no duplica a quien está en las dos fuentes', () => {
+      const lista = vendedoresElegibles(
+        [{ id: 'a', nombre: 'Ana' }],
+        [{ id: 'a', nombre: 'Ana' }],
+      )
+
+      expect(lista).toHaveLength(1)
+    })
+
+    it('ante el mismo id, el nombre del padrón le gana al del RPC', () => {
+      // El padrón es la fuente viva de `perfiles`; el resultado del RPC es una
+      // foto del período consultado.
+      const lista = vendedoresElegibles(
+        [{ id: 'a', nombre: 'Ana Actualizada' }],
+        [{ id: 'a', nombre: 'Ana Vieja' }],
+      )
+
+      expect(lista[0].nombre).toBe('Ana Actualizada')
+    })
+  })
+
+  describe('orden', () => {
+    it('ordena por nombre y no por monto ni por fuente', () => {
+      const lista = vendedoresElegibles(
+        [{ id: '1', nombre: 'Zulema' }, { id: '2', nombre: 'Ana' }],
+        [{ id: '3', nombre: 'Marcelo' }],
+      )
+
+      expect(lista.map(v => v.nombre)).toEqual(['Ana', 'Marcelo', 'Zulema'])
+    })
+
+    it('ordena en español: los acentos no van al final', () => {
+      // Con un sort de strings crudo, 'Ágata' cae después de 'Zulema'.
+      const lista = vendedoresElegibles(
+        [{ id: '1', nombre: 'Zulema' }, { id: '2', nombre: 'Ágata' }, { id: '3', nombre: 'Ñuke' }],
+        [],
+      )
+
+      expect(lista.map(v => v.nombre)).toEqual(['Ágata', 'Ñuke', 'Zulema'])
+    })
+
+    it('ignora mayúsculas y minúsculas', () => {
+      const lista = vendedoresElegibles(
+        [{ id: '1', nombre: 'zulema' }, { id: '2', nombre: 'Ana' }],
+        [],
+      )
+
+      expect(lista.map(v => v.nombre)).toEqual(['Ana', 'zulema'])
+    })
+  })
+
+  describe('nombre legible siempre', () => {
+    it('sin nombre cae al email', () => {
+      const lista = vendedoresElegibles([{ id: 'a', nombre: null, email: 'ana@x.com' }], [])
+      expect(lista[0].nombre).toBe('ana@x.com')
+    })
+
+    it('un nombre en blanco no se toma por bueno', () => {
+      const lista = vendedoresElegibles([{ id: 'a', nombre: '   ', email: 'ana@x.com' }], [])
+      expect(lista[0].nombre).toBe('ana@x.com')
+    })
+
+    it('sin nombre ni email cae a un rótulo legible, nunca a undefined', () => {
+      const lista = vendedoresElegibles([{ id: 'a' }], [])
+      expect(lista[0].nombre).toBe('Sin nombre')
+    })
+
+    it('nunca devuelve undefined en el nombre', () => {
+      const lista = vendedoresElegibles(
+        [{ id: 'a', nombre: null, email: null }, { id: 'b', nombre: undefined }],
+        [{ id: 'c', nombre: '' }],
+      )
+      expect(lista.every(v => typeof v.nombre === 'string' && v.nombre.length > 0)).toBe(true)
+    })
+  })
+
+  describe('bordes', () => {
+    it('sin ninguna fuente devuelve lista vacía', () => {
+      expect(vendedoresElegibles([], [])).toEqual([])
+    })
+
+    it('tolera fuentes nulas', () => {
+      expect(vendedoresElegibles(null, undefined)).toEqual([])
+    })
+  })
+})

--- a/src/utils/vendedoresComision.ts
+++ b/src/utils/vendedoresComision.ts
@@ -1,0 +1,74 @@
+/**
+ * Quién puede tener una regla de comisión cargada.
+ *
+ * EL BUG QUE ARREGLA
+ * ------------------
+ * El desplegable se armaba con `resultado.preventistas` del RPC, que es quien
+ * vendió EN EL PERÍODO CONSULTADO. Eso hacía dos cosas malas a la vez: un admin
+ * que no vendió no aparecía nunca, y la lista cambiaba al cambiar el rango de
+ * fechas —Julio, con 2 pedidos en todo el año, aparecía o desaparecía según el
+ * mes que estuvieras mirando—. Una lista de "a quién puedo configurarle el %"
+ * no puede depender de qué mes estás mirando.
+ *
+ * LAS DOS FUENTES, Y POR QUÉ HACEN FALTA LAS DOS
+ * ---------------------------------------------
+ * · El PADRÓN —`perfiles` con rol admin/encargado/preventista, activos, de la
+ *   sucursal— es el piso: son los que PUEDEN vender, hayan vendido o no. Es lo
+ *   que hace que la lista sea estable.
+ * · QUIEN VENDIÓ rescata al que ya no está en el padrón pero tiene plata
+ *   acumulada: Christian es preventista inactivo con $804.249, sale del padrón
+ *   por `activo = false` y igual hay que poder editarle la regla.
+ *
+ * Los transportistas quedan afuera de las dos: no pueden ser el `usuario_id` de
+ * un pedido (`crear_pedido_completo` exige admin/preventista/encargado) y en los
+ * datos no tienen ni un pedido, así que nunca aparecen por la segunda fuente.
+ *
+ * El % por defecto NO se decide acá: lo resuelve `calcular_comisiones` por rol
+ * contra `politicas_comerciales`. Esta lista es sólo quién es elegible para la
+ * EXCEPCIÓN, que es la regla individual.
+ */
+
+/** Lo mínimo que se necesita de cualquiera de las dos fuentes. */
+export interface FuenteVendedor {
+  id: string
+  nombre?: string | null
+  email?: string | null
+}
+
+export interface VendedorComision {
+  id: string
+  /** Siempre un string no vacío: es lo que se muestra en el desplegable. */
+  nombre: string
+}
+
+/** Nombre → email → rótulo. Nunca undefined ni una cadena en blanco. */
+function nombreLegible(v: FuenteVendedor): string {
+  const nombre = v.nombre?.trim()
+  if (nombre) return nombre
+  const email = v.email?.trim()
+  if (email) return email
+  return 'Sin nombre'
+}
+
+/**
+ * @param padron - Quienes PUEDEN vender: el piso estable de la lista.
+ * @param vendieron - Quienes vendieron en el período consultado, del RPC.
+ *   Aporta sólo a los que el padrón ya no tiene.
+ */
+export function vendedoresElegibles(
+  padron: readonly FuenteVendedor[] | null | undefined,
+  vendieron: readonly FuenteVendedor[] | null | undefined,
+): VendedorComision[] {
+  const porId = new Map<string, string>()
+
+  // El padrón va primero a propósito: ante el mismo id, su nombre le gana al
+  // del RPC, que es una foto del período consultado.
+  for (const v of padron ?? []) porId.set(v.id, nombreLegible(v))
+  for (const v of vendieron ?? []) {
+    if (!porId.has(v.id)) porId.set(v.id, nombreLegible(v))
+  }
+
+  return [...porId]
+    .map(([id, nombre]) => ({ id, nombre }))
+    .sort((a, b) => a.nombre.localeCompare(b.nombre, 'es'))
+}


### PR DESCRIPTION
Implementa el issue #515. **La migración 207 ya está aplicada en producción** (el número se reserva aplicándola), así que este PR sincroniza el repo con lo que prod ya hace, más el front que lo acompaña.

## El problema

El % por defecto era `c_default numeric := 2` adentro de `calcular_comisiones` y se aplicaba a todo el que tuviera un pedido atribuido. Como la función agrupa por `pedidos.usuario_id` y **no mira rol**, el sistema le venía liquidando **$728.960** a siete personas sin rol de preventista: un encargado y seis admins que cargan pedidos como parte de su trabajo, no como venta comisionable.

Se podía resolver cargándoles una regla individual al 0% a cada uno. No escala: obliga a acordarse cada vez que entra alguien nuevo, y el día que nadie se acuerde el admin nuevo cobra 2% sin que nadie lo haya decidido. Queda invertido — el default depende del rol y la regla individual queda para la **excepción**, que es para lo que sirve.

## El número que decide

Verificado contra prod mes a mes, con el RPC de verdad (impersonando a un admin, porque `calcular_comisiones` exige `es_admin()`):

| Mes | Antes | Después | Objetivo | |
|---|---|---|---|---|
| 2026-01 | 6.132 | **0** | 0 | OK |
| 2026-02 | 59.755 | **0** | 0 | OK |
| 2026-03 | 200.245 | 154.600 | 154.600 | OK |
| 2026-04 | 507.895 | 425.901 | 425.901 | OK |
| 2026-05 | 585.556 | 488.627 | 488.627 | OK |
| 2026-06 | 732.243 | 641.024 | 641.024 | OK |
| 2026-07 | 856.321 | 659.092 | 659.092 | OK |
| 2026-08 | 926.042 | 804.668 | 804.668 | OK |

**Enero y febrero van a cero, no bajan.** En esos dos meses vendían sólo admins, antes de que hubiera preventistas: la línea de comisión del gerencial desaparece entera ahí.

Septiembre no está en la tabla porque es mes abierto y se movió entre mediciones (entraron ventas). Sobre la **misma foto de datos**, el RPC y el cálculo directo dan idéntico —159.344 los dos—, así que cuadra igual.

## Verificación end to end

Dentro de una transacción **revertida**, para no dejar rastro en prod:

| Paso | Comisión de Jony (encargado) en agosto |
|---|---|
| Estado actual, resto al 0% | **$0** |
| `comision_pct_otros = 1` en configuración | **$29.641** |
| Regla individual del 3% para Jony | **$88.923** |

88.923 es exactamente el triple de 29.641: el porcentaje se aplica bien y la regla individual (peso 8) le gana al default. Después del rollback, prod quedó con 0 reglas y las tres sucursales en `2.00/0.00`.

## La migración

- Dos columnas en `politicas_comerciales`: `comision_pct_preventista` (default 2) y `comision_pct_otros` (default 0), con sus `CHECK (0..100)` dentro de un `DO` que mira `pg_constraint`, para que sea reaplicable.
- `calcular_comisiones`: **misma firma**, `CREATE OR REPLACE` sin `DROP` — cambiarla dejaría dos sobrecargas superpuestas y `PGRST203` en runtime. El cuerpo salió del vivo (`pg_get_functiondef`) y se comparó contra `migrations/150`. La subconsulta de reglas no se toca.
- El predicado es **`perfiles.rol = 'preventista'` crudo**, no `es_preventista()`, que devuelve `true` para admin y encargado y acá sería exactamente la lógica equivocada aunque parezca la obvia.
- RPC `actualizar_comisiones_default` con `REVOKE ... FROM PUBLIC, anon` y el mismo bloque de verificación de ACL que la mig 204.

**El 206 estaba tomado.** El ledger tiene `206_activo_bloquea_el_acceso` aplicada el 04-09, y su archivo no está en el repo — la trampa 3 de `CLAUDE.md`, tercera aparición. Va por separado en #516, porque además deja el gate de integridad en rojo por una causa ajena a este cambio.

## El bug del desplegable

La fuente era `resultado.preventistas`, o sea quien vendió **en el período consultado**: la lista cambiaba al cambiar el rango de fechas y un admin que no vendió no aparecía nunca. Julio, con 2 pedidos en todo el año, aparecía o desaparecía según el mes.

Ahora el piso es el padrón de quienes **pueden** vender (hook nuevo; sin tocar `fetchPreventistas` ni `usePreventistasAsignablesQuery`, que resuelven otras cosas), y el resultado del RPC sólo suma al que ya no está en el padrón pero tiene plata acumulada — Christian, inactivo, $804.249. El armado quedó en `src/utils/vendedoresComision.ts` con 14 tests escritos antes de la implementación.

## Verificación

`typecheck`, `lint`, `test:run` (105 archivos / 1434 tests, sin `.env`) y `build`: los cuatro en verde.

🤖 Generated with [Claude Code](https://claude.com/claude-code)