### PR TITLE
Mermas: filtro por fecha, cuánto costó, y export a Excel

### DIFF
--- a/src/components/containers/ProductosContainer.tsx
+++ b/src/components/containers/ProductosContainer.tsx
@@ -13,7 +13,7 @@ import {
   useActualizarProductoMutation,
   useEliminarProductoMutation,
 } from '../../hooks/queries'
-import { useMermasQuery, useRegistrarMermaMutation } from '../../hooks/queries'
+import { useRegistrarMermaMutation, useUsuariosQuery } from '../../hooks/queries'
 import { useProveedoresActivosQuery } from '../../hooks/queries'
 import { useClientesQuery } from '../../hooks/queries'
 import { useRegistrarCambioProductoMutation, type RegistrarCambioInput } from '../../hooks/queries'
@@ -94,7 +94,9 @@ export default function ProductosContainer(): React.ReactElement {
 
   // Queries
   const { data: productos = [], isLoading } = useProductosQuery()
-  const { data: mermas = [] } = useMermasQuery()
+  // Para poder decir QUIÉN registró cada merma: el prop nunca se pasaba y el
+  // historial mostraba "Usuario desconocido" en todas las filas.
+  const { data: usuarios = [] } = useUsuariosQuery()
   const { data: proveedores = [] } = useProveedoresActivosQuery()
   const { data: clientes = [] } = useClientesQuery()
   const { data: categoriasTabla = [] } = useCategoriasQuery()
@@ -453,8 +455,8 @@ export default function ProductosContainer(): React.ReactElement {
       {modalHistorialOpen && (
         <Suspense fallback={null}>
           <ModalHistorialMermas
-            mermas={mermas as Parameters<typeof ModalHistorialMermas>[0]['mermas']}
             productos={productos as unknown as Parameters<typeof ModalHistorialMermas>[0]['productos']}
+            usuarios={usuarios as unknown as Parameters<typeof ModalHistorialMermas>[0]['usuarios']}
             onClose={() => setModalHistorialOpen(false)}
           />
         </Suspense>

--- a/src/components/modals/ModalHistorialMermas.test.tsx
+++ b/src/components/modals/ModalHistorialMermas.test.tsx
@@ -1,0 +1,276 @@
+/**
+ * El modal se importa DIRECTO, no por ProductosContainer: allá se carga con
+ * `lazyWithReload` y la primera prueba del archivo pagaría el `import()` del
+ * chunk, que es el flake que se cazó en el PR #514.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+const mockCrearExcel = vi.fn()
+const mockUseMermas = vi.fn()
+
+vi.mock('../../utils/excel', () => ({
+  createMultiSheetExcel: (hojas: unknown[], filename: string) => mockCrearExcel(hojas, filename),
+}))
+
+vi.mock('../../hooks/queries/useMermasQuery', () => ({
+  useMermasQuery: (filtros: unknown) => mockUseMermas(filtros),
+  LIMITE_MERMAS: 1000,
+}))
+
+// Período fijo: si no, el nombre del archivo depende del día en que corran los
+// tests y la aserción exacta sería imposible.
+vi.mock('../../utils/periodosReporte', () => ({
+  presetsVentas: () => [
+    { id: 'anio-2026', label: 'Año 2026', desde: '2026-01-01', hasta: '2026-09-07' },
+    { id: 'mes-2026-09', label: 'Septiembre 2026 (en curso)', desde: '2026-09-01', hasta: '2026-09-07' },
+  ],
+}))
+
+import ModalHistorialMermas from './ModalHistorialMermas'
+
+const productos = [
+  { id: 'p1', nombre: 'Coca 2L', codigo: 'C2L', precio: 3000, costo_promedio: 1000, costo_real: 1200 },
+  { id: 'p2', nombre: 'Agua 500', codigo: 'A500', precio: 800, costo_promedio: 300 },
+  { id: 'p3', nombre: 'Sin costo', codigo: 'SC', precio: 100 },
+]
+
+const usuarios = [{ id: 'u1', nombre: 'Jony' }]
+
+const mermas = [
+  // Pérdida real con costo congelado.
+  {
+    id: 'm1', producto_id: 'p1', cantidad: 2, motivo: 'rotura', costo_unitario: 900,
+    usuario_id: 'u1', stock_anterior: 10, stock_nuevo: 8,
+    created_at: '2026-08-15T14:00:00Z', observaciones: 'Se cayó el pallet',
+  },
+  // Vieja: sin snapshot, se valúa al costo de hoy.
+  {
+    id: 'm2', producto_id: 'p2', cantidad: 5, motivo: 'vencimiento', costo_unitario: null,
+    usuario_id: null, stock_anterior: 50, stock_nuevo: 45, created_at: '2026-05-10T14:00:00Z',
+  },
+  // Producto sin ningún costo cargado.
+  {
+    id: 'm3', producto_id: 'p3', cantidad: 1, motivo: 'otro', costo_unitario: null,
+    usuario_id: 'u1', stock_anterior: 5, stock_nuevo: 4, created_at: '2026-08-20T14:00:00Z',
+  },
+  // Ajuste de promoción: NO es pérdida.
+  {
+    id: 'm4', producto_id: 'p1', cantidad: 10, motivo: 'promociones', costo_unitario: 900,
+    usuario_id: 'u1', stock_anterior: 100, stock_nuevo: 90, created_at: '2026-08-21T14:00:00Z',
+  },
+  // Reversión: cantidad NEGATIVA.
+  {
+    id: 'm5', producto_id: 'p1', cantidad: -3, motivo: 'promociones_reversion', costo_unitario: 900,
+    usuario_id: 'u1', stock_anterior: 90, stock_nuevo: 93, created_at: '2026-08-22T14:00:00Z',
+  },
+]
+
+function renderModal(data = mermas) {
+  mockUseMermas.mockReturnValue({ data, isLoading: false })
+  return render(
+    <ModalHistorialMermas
+      productos={productos as never}
+      usuarios={usuarios as never}
+      onClose={vi.fn()}
+    />,
+  )
+}
+
+describe('ModalHistorialMermas', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('el filtro de fecha va al servidor', () => {
+    it('le pasa el rango del preset al hook, no filtra en el cliente', () => {
+      renderModal()
+      expect(mockUseMermas).toHaveBeenCalledWith({ desde: '2026-01-01', hasta: '2026-09-07' })
+    })
+
+    it('cambiar de período vuelve a consultar con el rango nuevo', async () => {
+      const user = userEvent.setup()
+      renderModal()
+
+      await user.selectOptions(screen.getByLabelText(/Período/), 'mes-2026-09')
+
+      expect(mockUseMermas).toHaveBeenLastCalledWith({ desde: '2026-09-01', hasta: '2026-09-07' })
+    })
+  })
+
+  describe('los ajustes de promoción quedan fuera del total', () => {
+    it('la pérdida a costo no los suma', () => {
+      // 2*900 (rotura) + 5*300 (vencimiento, al costo de hoy) + 1*0 = 3.300.
+      // Si sumara promociones (10*900) y la reversión (-3*900) daría 9.600.
+      renderModal()
+      expect(screen.getByText('$3.300,00')).toBeInTheDocument()
+    })
+
+    it('lo explica en pantalla en vez de esconderlos', () => {
+      renderModal()
+      expect(screen.getByText(/ajustes de promoción/i)).toBeInTheDocument()
+      expect(screen.getByText(/contrapartida de un regalo/i)).toBeInTheDocument()
+    })
+
+    it('las unidades perdidas tampoco los cuentan', () => {
+      // 2 + 5 + 1 = 8, no 15.
+      renderModal()
+      const resumen = screen.getByText('Unidades perdidas').closest('div') as HTMLElement
+      expect(within(resumen).getByText('8')).toBeInTheDocument()
+    })
+  })
+
+  describe('las tres marcas de calidad del dato', () => {
+    it('marca la fila valuada al costo de hoy por no tener snapshot', () => {
+      renderModal()
+      expect(screen.getByText('Costo estimado al valor actual')).toBeInTheDocument()
+      expect(screen.getByText(/anteriores a que se guardara el costo del momento/i)).toBeInTheDocument()
+    })
+
+    it('marca el producto sin costo cargado: $0 no es "no vale nada"', () => {
+      renderModal()
+      expect(screen.getByText('Sin costo cargado')).toBeInTheDocument()
+      expect(screen.getByText(/no es que valgan \$0, es que no se sabe/i)).toBeInTheDocument()
+    })
+
+    it('aclara que el precio de venta es el de hoy', () => {
+      renderModal()
+      expect(screen.getByText(/la base no guarda a cuánto se vendía el día de la merma/i)).toBeInTheDocument()
+    })
+  })
+
+  describe('los tres defectos de render', () => {
+    it('una cantidad negativa no imprime el doble signo', () => {
+      // Antes salía "--3": el signo ya venía en el número.
+      renderModal()
+      expect(screen.getByText('+3')).toBeInTheDocument()
+      expect(screen.queryByText('--3')).not.toBeInTheDocument()
+    })
+
+    it('promociones_reversion tiene etiqueta, no sale el string crudo', () => {
+      renderModal()
+      expect(screen.getAllByText('Reversión de promoción').length).toBeGreaterThan(0)
+      expect(screen.queryByText('promociones_reversion')).not.toBeInTheDocument()
+    })
+
+    it('muestra quién registró la merma', () => {
+      // El prop `usuarios` nunca se pasaba: todas las filas decían
+      // "Usuario desconocido".
+      renderModal()
+      expect(screen.getAllByText('Jony').length).toBeGreaterThan(0)
+      expect(screen.queryByText('Usuario desconocido')).not.toBeInTheDocument()
+    })
+
+    it('una merma sin usuario dice que no está registrado, no que es desconocido', () => {
+      renderModal()
+      expect(screen.getByText('Sin registrar')).toBeInTheDocument()
+    })
+  })
+
+  describe('export a Excel', () => {
+    it('exporta dos hojas: el detalle y el resumen por motivo', async () => {
+      const user = userEvent.setup()
+      renderModal()
+
+      await user.click(screen.getByRole('button', { name: /Exportar a Excel/i }))
+
+      expect(mockCrearExcel).toHaveBeenCalledTimes(1)
+      const [hojas, nombreArchivo] = mockCrearExcel.mock.calls[0]
+
+      expect(hojas.map((h: { name: string }) => h.name)).toEqual(['Detalle', 'Resumen por motivo'])
+      expect(nombreArchivo).toBe('mermas-2026-01-01_a_2026-09-07')
+    })
+
+    it('el detalle lleva el costo, el precio y de dónde salió cada costo', async () => {
+      const user = userEvent.setup()
+      renderModal()
+
+      await user.click(screen.getByRole('button', { name: /Exportar a Excel/i }))
+      const [hojas] = mockCrearExcel.mock.calls[0]
+
+      expect(hojas[0].data[0]).toMatchObject({
+        Producto: 'Coca 2L',
+        Motivo: 'Rotura',
+        Tipo: 'Pérdida',
+        Cantidad: 2,
+        'Costo unitario': 900,
+        'Costo total': 1800,
+        'Precio total (hoy)': 6000,
+        'Origen del costo': 'Congelado al momento',
+        Usuario: 'Jony',
+      })
+    })
+
+    it('cada fila dice si su costo es estimado o si no hay costo', async () => {
+      const user = userEvent.setup()
+      renderModal()
+
+      await user.click(screen.getByRole('button', { name: /Exportar a Excel/i }))
+      const [hojas] = mockCrearExcel.mock.calls[0]
+      const porId = Object.fromEntries(
+        hojas[0].data.map((f: Record<string, unknown>) => [f.Producto, f]),
+      )
+
+      expect(porId['Agua 500']['Origen del costo']).toBe('Estimado al valor actual')
+      expect(porId['Sin costo']['Origen del costo']).toBe('Sin costo cargado')
+    })
+
+    it('marca los ajustes de promoción como tales en el detalle', async () => {
+      const user = userEvent.setup()
+      renderModal()
+
+      await user.click(screen.getByRole('button', { name: /Exportar a Excel/i }))
+      const [hojas] = mockCrearExcel.mock.calls[0]
+      const ajustes = hojas[0].data.filter((f: Record<string, unknown>) => f.Tipo === 'Ajuste de promoción')
+
+      expect(ajustes).toHaveLength(2)
+    })
+
+    it('el resumen cierra con el total de pérdida y los ajustes aparte', async () => {
+      const user = userEvent.setup()
+      renderModal()
+
+      await user.click(screen.getByRole('button', { name: /Exportar a Excel/i }))
+      const [hojas] = mockCrearExcel.mock.calls[0]
+      const filas = hojas[1].data as Record<string, unknown>[]
+
+      // Sin esto, el archivo sale del sistema y nadie puede saber por qué el
+      // total no es la suma de la columna Costo.
+      expect(filas.find(f => String(f.Motivo).startsWith('TOTAL PÉRDIDA'))).toMatchObject({
+        Unidades: 8,
+        Costo: 3300,
+      })
+      expect(filas.find(f => String(f.Motivo).startsWith('Ajustes de promoción'))).toMatchObject({
+        Registros: 2,
+        Costo: 6300, // 10*900 + (-3)*900
+      })
+    })
+
+    it('no exporta si no hay filas', async () => {
+      const user = userEvent.setup()
+      renderModal([])
+
+      const boton = screen.getByRole('button', { name: /Exportar a Excel/i })
+      expect(boton).toBeDisabled()
+      await user.click(boton)
+      expect(mockCrearExcel).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('truncamiento', () => {
+    it('avisa cuando el período llega al tope de filas', () => {
+      const muchas = Array.from({ length: 1000 }, (_, i) => ({
+        ...mermas[0], id: `x${i}`,
+      }))
+      renderModal(muchas)
+
+      expect(screen.getByText(/se muestran los 1000 más recientes/i)).toBeInTheDocument()
+    })
+
+    it('no avisa cuando entran todas', () => {
+      renderModal()
+      expect(screen.queryByText(/más recientes/i)).not.toBeInTheDocument()
+    })
+  })
+})

--- a/src/components/modals/ModalHistorialMermas.tsx
+++ b/src/components/modals/ModalHistorialMermas.tsx
@@ -1,91 +1,209 @@
-import React, { useState, ChangeEvent } from 'react'
-import { X, Package, Calendar, User, FileText, TrendingDown } from 'lucide-react'
+/**
+ * Historial de mermas, con rango de fechas, valorización y export.
+ *
+ * QUÉ NÚMERO MUESTRA, Y POR QUÉ NO ES LA SUMA DE TODO
+ * --------------------------------------------------
+ * El total en plata EXCLUYE los motivos 'promociones' y 'promociones_reversion',
+ * igual que el KPI de mermas del reporte gerencial (mig 130): no son pérdida,
+ * son la contrapartida de un regalo que ya está contabilizado en el pedido.
+ * Sumarlos mostraría ~$2,5M donde el gerencial muestra ~$597.600, y alguien lo
+ * reportaría como bug con razón. Se muestran igual en el detalle y en el
+ * resumen por motivo, etiquetados como ajuste.
+ *
+ * DE DÓNDE SALE LA PLATA
+ * ----------------------
+ * El costo es el CONGELADO al momento de la merma (`costo_unitario`, mig 119).
+ * Las filas viejas que no lo tienen caen al costo de hoy y se marcan como
+ * estimadas. El precio de venta no tiene histórico en la base, así que es
+ * siempre el precio de HOY, y se aclara. Todo eso vive en
+ * `utils/valorizacionMermas.ts`, con tests.
+ *
+ * EL FILTRO DE FECHA VA AL SERVIDOR
+ * ---------------------------------
+ * Filtrar en el cliente obligaría a traer todo, y PostgREST corta en 1000 filas
+ * en silencio. Ver `useMermasQuery`.
+ */
+import React, { useState, useMemo, useCallback, ChangeEvent } from 'react'
+import { X, Package, Calendar, User, FileText, TrendingDown, Download, AlertTriangle, Info } from 'lucide-react'
 import type { Producto, Usuario } from '../../types'
-
-type MotivoMerma = 'rotura' | 'vencimiento' | 'robo' | 'decomiso' | 'devolucion' | 'error_inventario' | 'muestra' | 'promociones' | 'otro';
-
-interface Merma {
-  id: string;
-  producto_id: string;
-  usuario_id?: string;
-  cantidad: number;
-  motivo: MotivoMerma;
-  observaciones?: string;
-  stock_anterior: number;
-  stock_nuevo: number;
-  created_at: string;
-}
+import { useMermasQuery, LIMITE_MERMAS } from '../../hooks/queries/useMermasQuery'
+import { presetsVentas } from '../../utils/periodosReporte'
+import { formatCurrency } from '../../utils/formatters'
+import {
+  valorizarMerma,
+  totalizarMermas,
+  resumenPorMotivo,
+  type MermaValorizada,
+  type ProductoParaValorizar,
+} from '../../utils/valorizacionMermas'
 
 export interface ModalHistorialMermasProps {
-  mermas?: Merma[];
-  productos?: Producto[];
-  usuarios?: Usuario[];
-  onClose: () => void;
+  productos?: Producto[]
+  usuarios?: Usuario[]
+  onClose: () => void
+}
+
+/**
+ * 'promociones_reversion' faltaba: caía al fallback y se renderizaba el string
+ * crudo de la base, con guion bajo y todo.
+ */
+const LABELS_MOTIVO: Record<string, string> = {
+  rotura: 'Rotura',
+  vencimiento: 'Vencimiento',
+  robo: 'Robo/Hurto',
+  decomiso: 'Decomiso',
+  devolucion: 'Devolución',
+  error_inventario: 'Error inventario',
+  muestra: 'Muestra',
+  promociones: 'Promociones',
+  promociones_reversion: 'Reversión de promoción',
+  otro: 'Otro',
+}
+
+function labelMotivo(motivo: string): string {
+  return LABELS_MOTIVO[motivo] ?? motivo
+}
+
+function fechaCorta(iso?: string): string {
+  if (!iso) return ''
+  return new Date(iso).toLocaleDateString('es-AR')
 }
 
 export default function ModalHistorialMermas({
-  mermas = [],
   productos = [],
   usuarios = [],
-  onClose
+  onClose,
 }: ModalHistorialMermasProps): React.ReactElement {
+  const presets = useMemo(() => presetsVentas(), [])
+  const [presetId, setPresetId] = useState<string>(presets[0].id)
+  const [desde, setDesde] = useState<string>(presets[0].desde)
+  const [hasta, setHasta] = useState<string>(presets[0].hasta)
   const [filtroProducto, setFiltroProducto] = useState<string>('')
   const [filtroMotivo, setFiltroMotivo] = useState<string>('')
+  const [exportando, setExportando] = useState(false)
 
-  const mermasFiltradas = mermas.filter(m => {
-    if (filtroProducto && m.producto_id !== filtroProducto) return false
-    if (filtroMotivo && m.motivo !== filtroMotivo) return false
-    return true
-  })
+  const { data: mermas = [], isLoading } = useMermasQuery({ desde, hasta })
 
-  const getProductoNombre = (productoId: string): string => {
-    const producto = productos.find(p => p.id === productoId)
-    return producto?.nombre || 'Producto desconocido'
-  }
-
-  const getUsuarioNombre = (usuarioId: string | undefined): string => {
-    if (!usuarioId) return 'Usuario desconocido'
-    const usuario = usuarios.find(u => u.id === usuarioId)
-    return usuario?.nombre || 'Usuario desconocido'
-  }
-
-  const getMotivoEmoji = (motivo: MotivoMerma): string => {
-    const emojis: Record<MotivoMerma, string> = {
-      rotura: '!',
-      vencimiento: 'V',
-      robo: '!',
-      decomiso: '!',
-      devolucion: '<-',
-      error_inventario: '#',
-      muestra: '*',
-      promociones: '%',
-      otro: '?'
+  const elegirPreset = useCallback((id: string) => {
+    setPresetId(id)
+    const p = presets.find(x => x.id === id)
+    if (p) {
+      setDesde(p.desde)
+      setHasta(p.hasta)
     }
-    return emojis[motivo] || '?'
-  }
+  }, [presets])
 
-  const getMotivoLabel = (motivo: MotivoMerma): string => {
-    const labels: Record<MotivoMerma, string> = {
-      rotura: 'Rotura',
-      vencimiento: 'Vencimiento',
-      robo: 'Robo/Hurto',
-      decomiso: 'Decomiso',
-      devolucion: 'Devolucion',
-      error_inventario: 'Error inventario',
-      muestra: 'Muestra',
-      promociones: 'Promociones',
-      otro: 'Otro'
+  const productosPorId = useMemo(() => {
+    const m = new Map<string, ProductoParaValorizar>()
+    for (const p of productos) m.set(String(p.id), p as unknown as ProductoParaValorizar)
+    return m
+  }, [productos])
+
+  const getUsuarioNombre = useCallback((usuarioId: string | null | undefined): string => {
+    // "Sin registrar" y no "desconocido": hasta este cambio toda merma manual
+    // entraba con usuario_id NULL, así que no es que no sepamos quién es — es
+    // que no se guardó (invariante MERMA-I, mig 105).
+    if (!usuarioId) return 'Sin registrar'
+    return usuarios.find(u => u.id === usuarioId)?.nombre || 'Usuario desconocido'
+  }, [usuarios])
+
+  // TODO lo demás —totales, resumen y Excel— se calcula sobre ESTE array: si no,
+  // los totales contradicen a la lista.
+  const filas: MermaValorizada[] = useMemo(() => {
+    return mermas
+      .filter(m => {
+        if (filtroProducto && String(m.producto_id) !== filtroProducto) return false
+        if (filtroMotivo && m.motivo !== filtroMotivo) return false
+        return true
+      })
+      .map(m => valorizarMerma(m, productosPorId.get(String(m.producto_id))))
+  }, [mermas, filtroProducto, filtroMotivo, productosPorId])
+
+  const totales = useMemo(() => totalizarMermas(filas), [filas])
+  const resumen = useMemo(() => resumenPorMotivo(filas), [filas])
+  const motivosUnicos = useMemo(
+    () => [...new Set(mermas.map(m => m.motivo))].sort(),
+    [mermas],
+  )
+  const truncado = mermas.length >= LIMITE_MERMAS
+
+  const handleExportar = useCallback(async () => {
+    if (filas.length === 0) return
+    setExportando(true)
+    try {
+      const detalle = filas.map(f => ({
+        Fecha: fechaCorta(f.created_at),
+        Producto: f.productoNombre,
+        Código: f.productoCodigo,
+        Motivo: labelMotivo(f.motivo),
+        Tipo: f.esAjustePromocion ? 'Ajuste de promoción' : 'Pérdida',
+        Cantidad: f.cantidad,
+        'Costo unitario': f.costoUnitario,
+        'Costo total': f.costoTotal,
+        'Precio unitario (hoy)': f.precioUnitario,
+        'Precio total (hoy)': f.precioTotal,
+        'Origen del costo': f.sinCosto
+          ? 'Sin costo cargado'
+          : f.costoEstimado
+            ? 'Estimado al valor actual'
+            : 'Congelado al momento',
+        Usuario: getUsuarioNombre(f.usuario_id),
+        'Stock antes': f.stock_anterior ?? '',
+        'Stock después': f.stock_nuevo ?? '',
+        Observaciones: f.observaciones || '',
+      }))
+
+      const porMotivo = resumen.map(r => ({
+        Motivo: labelMotivo(r.motivo),
+        Tipo: r.esAjustePromocion ? 'Ajuste de promoción' : 'Pérdida',
+        Registros: r.registros,
+        Unidades: r.unidades,
+        Costo: r.costo,
+        'Precio (hoy)': r.precio,
+      }))
+
+      // Las aclaraciones viajan en el Excel: sin ellas, el archivo sale del
+      // sistema y nadie puede saber por qué el total no es la suma de la
+      // columna Costo.
+      porMotivo.push(
+        { Motivo: '', Tipo: '', Registros: '' as never, Unidades: '' as never, Costo: '' as never, 'Precio (hoy)': '' as never },
+        {
+          Motivo: 'TOTAL PÉRDIDA (sin ajustes de promoción)',
+          Tipo: '',
+          Registros: totales.registros - totales.registrosAjustePromocion,
+          Unidades: totales.unidades,
+          Costo: totales.costoTotal,
+          'Precio (hoy)': totales.precioTotal,
+        },
+        {
+          Motivo: 'Ajustes de promoción (no son pérdida)',
+          Tipo: '',
+          Registros: totales.registrosAjustePromocion,
+          Unidades: totales.unidadesAjustePromocion,
+          Costo: totales.costoAjustePromocion,
+          'Precio (hoy)': '' as never,
+        },
+      )
+
+      const { createMultiSheetExcel } = await import('../../utils/excel')
+      await createMultiSheetExcel(
+        [
+          { name: 'Detalle', data: detalle, columnWidths: [11, 32, 12, 20, 20, 10, 14, 14, 18, 18, 24, 20, 12, 13, 40] },
+          { name: 'Resumen por motivo', data: porMotivo, columnWidths: [38, 20, 11, 11, 14, 14] },
+        ],
+        `mermas-${desde}_a_${hasta}`,
+      )
+    } finally {
+      setExportando(false)
     }
-    return labels[motivo] || motivo
-  }
+  }, [filas, resumen, totales, desde, hasta, getUsuarioNombre])
 
-  // Calcular totales
-  const totalUnidades = mermasFiltradas.reduce((sum, m) => sum + m.cantidad, 0)
-  const motivosUnicos = [...new Set(mermas.map(m => m.motivo))]
+  const inputCls =
+    'w-full px-3 py-2 border dark:border-gray-600 rounded-lg text-sm dark:bg-gray-700 dark:text-white'
 
   return (
     <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
-      <div className="bg-white dark:bg-gray-800 rounded-xl shadow-xl w-full max-w-3xl max-h-[90vh] flex flex-col">
+      <div className="bg-white dark:bg-gray-800 rounded-xl shadow-xl w-full max-w-5xl max-h-[90vh] flex flex-col">
         {/* Header */}
         <div className="flex items-center justify-between p-4 border-b dark:border-gray-700">
           <div className="flex items-center gap-2">
@@ -97,103 +215,243 @@ export default function ModalHistorialMermas({
               <p className="text-sm text-gray-500">Registro de bajas de stock</p>
             </div>
           </div>
-          <button onClick={onClose} className="p-2 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-lg">
-            <X className="w-5 h-5" />
-          </button>
-        </div>
-
-        {/* Resumen */}
-        <div className="p-4 bg-gray-50 dark:bg-gray-900 border-b dark:border-gray-700">
-          <div className="grid grid-cols-3 gap-4">
-            <div className="text-center">
-              <p className="text-2xl font-bold text-red-600">{mermasFiltradas.length}</p>
-              <p className="text-xs text-gray-500">Registros</p>
-            </div>
-            <div className="text-center">
-              <p className="text-2xl font-bold text-red-600">{totalUnidades}</p>
-              <p className="text-xs text-gray-500">Unidades perdidas</p>
-            </div>
-            <div className="text-center">
-              <p className="text-2xl font-bold text-gray-600">{motivosUnicos.length}</p>
-              <p className="text-xs text-gray-500">Motivos diferentes</p>
-            </div>
+          <div className="flex items-center gap-2">
+            <button
+              type="button"
+              onClick={() => void handleExportar()}
+              disabled={exportando || filas.length === 0}
+              className="inline-flex items-center gap-1.5 px-3 py-2 rounded-lg border dark:border-gray-600 text-sm font-medium disabled:opacity-50 dark:text-gray-200"
+            >
+              <Download className="w-4 h-4" aria-hidden="true" />
+              {exportando ? 'Exportando…' : 'Exportar a Excel'}
+            </button>
+            <button onClick={onClose} aria-label="Cerrar" className="p-2 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-lg">
+              <X className="w-5 h-5" />
+            </button>
           </div>
         </div>
 
         {/* Filtros */}
-        <div className="p-4 border-b dark:border-gray-700 flex gap-4">
-          <div className="flex-1">
-            <label className="block text-xs font-medium text-gray-500 mb-1">Filtrar por producto</label>
+        <div className="p-4 border-b dark:border-gray-700 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-3">
+          <div>
+            <label htmlFor="mermas-periodo" className="block text-xs font-medium text-gray-500 mb-1">
+              <Calendar className="w-3 h-3 inline mr-1" />
+              Período
+            </label>
             <select
+              id="mermas-periodo"
+              value={presetId}
+              onChange={(e: ChangeEvent<HTMLSelectElement>) => elegirPreset(e.target.value)}
+              className={inputCls}
+            >
+              {presets.map(p => (
+                <option key={p.id} value={p.id}>{p.label}</option>
+              ))}
+              <option value="custom">Personalizado…</option>
+            </select>
+          </div>
+
+          {presetId === 'custom' && (
+            <>
+              <div>
+                <label htmlFor="mermas-desde" className="block text-xs font-medium text-gray-500 mb-1">Desde</label>
+                <input
+                  id="mermas-desde"
+                  type="date"
+                  value={desde}
+                  max={hasta}
+                  onChange={(e) => setDesde(e.target.value)}
+                  className={inputCls}
+                />
+              </div>
+              <div>
+                <label htmlFor="mermas-hasta" className="block text-xs font-medium text-gray-500 mb-1">Hasta</label>
+                <input
+                  id="mermas-hasta"
+                  type="date"
+                  value={hasta}
+                  min={desde}
+                  onChange={(e) => setHasta(e.target.value)}
+                  className={inputCls}
+                />
+              </div>
+            </>
+          )}
+
+          <div>
+            <label htmlFor="mermas-producto" className="block text-xs font-medium text-gray-500 mb-1">Producto</label>
+            <select
+              id="mermas-producto"
               value={filtroProducto}
               onChange={(e: ChangeEvent<HTMLSelectElement>) => setFiltroProducto(e.target.value)}
-              className="w-full px-3 py-2 border dark:border-gray-600 rounded-lg text-sm dark:bg-gray-700"
+              className={inputCls}
             >
               <option value="">Todos los productos</option>
               {productos.map(p => (
-                <option key={p.id} value={p.id}>{p.nombre}</option>
+                <option key={p.id} value={String(p.id)}>{p.nombre}</option>
               ))}
             </select>
           </div>
-          <div className="flex-1">
-            <label className="block text-xs font-medium text-gray-500 mb-1">Filtrar por motivo</label>
+
+          <div>
+            <label htmlFor="mermas-motivo" className="block text-xs font-medium text-gray-500 mb-1">Motivo</label>
             <select
+              id="mermas-motivo"
               value={filtroMotivo}
               onChange={(e: ChangeEvent<HTMLSelectElement>) => setFiltroMotivo(e.target.value)}
-              className="w-full px-3 py-2 border dark:border-gray-600 rounded-lg text-sm dark:bg-gray-700"
+              className={inputCls}
             >
               <option value="">Todos los motivos</option>
               {motivosUnicos.map(m => (
-                <option key={m} value={m}>{getMotivoLabel(m)}</option>
+                <option key={m} value={m}>{labelMotivo(m)}</option>
               ))}
             </select>
           </div>
         </div>
 
-        {/* Lista de mermas */}
+        {/* Resumen en plata */}
+        <div className="p-4 bg-gray-50 dark:bg-gray-900 border-b dark:border-gray-700">
+          <div className="grid grid-cols-2 lg:grid-cols-4 gap-4">
+            <div className="text-center">
+              <p className="text-2xl font-bold text-red-600 tabular-nums">{totales.unidades}</p>
+              <p className="text-xs text-gray-500">Unidades perdidas</p>
+            </div>
+            <div className="text-center">
+              <p className="text-2xl font-bold text-red-600 tabular-nums">{formatCurrency(totales.costoTotal)}</p>
+              <p className="text-xs text-gray-500">Pérdida a costo</p>
+            </div>
+            <div className="text-center">
+              <p className="text-2xl font-bold text-amber-600 tabular-nums">{formatCurrency(totales.precioTotal)}</p>
+              <p className="text-xs text-gray-500">A precio de venta de hoy</p>
+            </div>
+            <div className="text-center">
+              <p className="text-2xl font-bold text-gray-600 tabular-nums">{totales.registros}</p>
+              <p className="text-xs text-gray-500">Registros</p>
+            </div>
+          </div>
+
+          <div className="mt-3 space-y-1.5 text-xs">
+            {totales.registrosAjustePromocion > 0 && (
+              <p className="flex items-start gap-1.5 text-gray-600 dark:text-gray-400">
+                <Info className="w-3.5 h-3.5 mt-0.5 shrink-0" aria-hidden="true" />
+                <span>
+                  {totales.registrosAjustePromocion} registros son{' '}
+                  <strong>ajustes de promoción</strong> por {formatCurrency(totales.costoAjustePromocion)} y
+                  quedan fuera del total: no son pérdida, son la contrapartida de un regalo ya
+                  contabilizado en el pedido. Es el mismo criterio del reporte gerencial.
+                </span>
+              </p>
+            )}
+            <p className="flex items-start gap-1.5 text-gray-500">
+              <Info className="w-3.5 h-3.5 mt-0.5 shrink-0" aria-hidden="true" />
+              <span>
+                El precio de venta es el de <strong>hoy</strong>: la base no guarda a cuánto se
+                vendía el día de la merma.
+              </span>
+            </p>
+            {totales.filasCostoEstimado > 0 && (
+              <p className="flex items-start gap-1.5 text-amber-700 dark:text-amber-400">
+                <AlertTriangle className="w-3.5 h-3.5 mt-0.5 shrink-0" aria-hidden="true" />
+                <span>
+                  {totales.filasCostoEstimado} registros son anteriores a que se guardara el costo
+                  del momento: van valuados al <strong>costo actual</strong>.
+                </span>
+              </p>
+            )}
+            {totales.filasSinCosto > 0 && (
+              <p className="flex items-start gap-1.5 text-amber-700 dark:text-amber-400">
+                <AlertTriangle className="w-3.5 h-3.5 mt-0.5 shrink-0" aria-hidden="true" />
+                <span>
+                  {totales.filasSinCosto} registros son de productos <strong>sin costo cargado</strong>:
+                  no suman al total. No es que valgan $0, es que no se sabe.
+                </span>
+              </p>
+            )}
+            {truncado && (
+              <p className="flex items-start gap-1.5 text-amber-700 dark:text-amber-400">
+                <AlertTriangle className="w-3.5 h-3.5 mt-0.5 shrink-0" aria-hidden="true" />
+                <span>
+                  El período tiene más de {LIMITE_MERMAS} registros y se muestran los{' '}
+                  {LIMITE_MERMAS} más recientes. Achicá el rango de fechas para verlos todos.
+                </span>
+              </p>
+            )}
+          </div>
+        </div>
+
+        {/* Lista */}
         <div className="flex-1 overflow-y-auto p-4">
-          {mermasFiltradas.length === 0 ? (
+          {isLoading ? (
+            <p className="text-center py-8 text-gray-500">Cargando…</p>
+          ) : filas.length === 0 ? (
             <div className="text-center py-8 text-gray-500">
               <Package className="w-12 h-12 mx-auto mb-3 opacity-50" />
-              <p>No hay mermas registradas</p>
+              <p>No hay mermas en el período seleccionado</p>
             </div>
           ) : (
             <div className="space-y-3">
-              {mermasFiltradas.map(merma => (
+              {filas.map(f => (
                 <div
-                  key={merma.id}
+                  key={f.id}
                   className="p-4 bg-gray-50 dark:bg-gray-900 rounded-lg border dark:border-gray-700"
                 >
-                  <div className="flex items-start justify-between">
-                    <div className="flex items-start gap-3">
-                      <div className="text-2xl">{getMotivoEmoji(merma.motivo)}</div>
-                      <div>
-                        <p className="font-medium text-gray-800 dark:text-white">
-                          {getProductoNombre(merma.producto_id)}
+                  <div className="flex items-start justify-between gap-3">
+                    <div className="min-w-0">
+                      <p className="font-medium text-gray-800 dark:text-white truncate">
+                        {f.productoNombre}
+                      </p>
+                      <div className="flex flex-wrap items-center gap-3 mt-1 text-sm text-gray-500">
+                        <span className="flex items-center gap-1">
+                          <Calendar className="w-3 h-3" />
+                          {fechaCorta(f.created_at)}
+                        </span>
+                        <span className="flex items-center gap-1">
+                          <User className="w-3 h-3" />
+                          {getUsuarioNombre(f.usuario_id)}
+                        </span>
+                      </div>
+                      {f.observaciones && (
+                        <p className="mt-2 text-sm text-gray-600 dark:text-gray-400 flex items-start gap-1">
+                          <FileText className="w-3 h-3 mt-0.5 flex-shrink-0" />
+                          {f.observaciones}
                         </p>
-                        <div className="flex items-center gap-3 mt-1 text-sm text-gray-500">
-                          <span className="flex items-center gap-1">
-                            <Calendar className="w-3 h-3" />
-                            {new Date(merma.created_at).toLocaleDateString('es-AR')}
+                      )}
+                      <div className="mt-2 flex flex-wrap gap-1.5">
+                        {f.esAjustePromocion && (
+                          <span className="text-[11px] px-1.5 py-0.5 rounded bg-sky-100 text-sky-800 dark:bg-sky-900/40 dark:text-sky-200">
+                            Ajuste de promoción · fuera del total
                           </span>
-                          <span className="flex items-center gap-1">
-                            <User className="w-3 h-3" />
-                            {getUsuarioNombre(merma.usuario_id)}
+                        )}
+                        {f.costoEstimado && (
+                          <span className="text-[11px] px-1.5 py-0.5 rounded bg-amber-100 text-amber-800 dark:bg-amber-900/40 dark:text-amber-200">
+                            Costo estimado al valor actual
                           </span>
-                        </div>
-                        {merma.observaciones && (
-                          <p className="mt-2 text-sm text-gray-600 dark:text-gray-400 flex items-start gap-1">
-                            <FileText className="w-3 h-3 mt-0.5 flex-shrink-0" />
-                            {merma.observaciones}
-                          </p>
+                        )}
+                        {f.sinCosto && (
+                          <span className="text-[11px] px-1.5 py-0.5 rounded bg-amber-100 text-amber-800 dark:bg-amber-900/40 dark:text-amber-200">
+                            Sin costo cargado
+                          </span>
                         )}
                       </div>
                     </div>
-                    <div className="text-right">
-                      <p className="text-lg font-bold text-red-600">-{merma.cantidad}</p>
-                      <p className="text-xs text-gray-500">{getMotivoLabel(merma.motivo)}</p>
+
+                    <div className="text-right shrink-0">
+                      {/* Las reversiones vienen con cantidad NEGATIVA: el signo
+                          ya está en el número, ponerle otro imprimía "--3". */}
+                      <p className={`text-lg font-bold tabular-nums ${f.cantidad < 0 ? 'text-emerald-600' : 'text-red-600'}`}>
+                        {f.cantidad > 0 ? `-${f.cantidad}` : `+${Math.abs(f.cantidad)}`}
+                      </p>
+                      <p className="text-xs text-gray-500">{labelMotivo(f.motivo)}</p>
+                      <p className="text-sm font-medium text-gray-700 dark:text-gray-300 tabular-nums mt-1">
+                        {f.sinCosto ? 's/costo' : formatCurrency(f.costoTotal)}
+                      </p>
+                      {!f.sinPrecio && (
+                        <p className="text-xs text-gray-400 tabular-nums">
+                          {formatCurrency(f.precioTotal)} a precio
+                        </p>
+                      )}
                       <p className="text-xs text-gray-400 mt-1">
-                        {merma.stock_anterior} -&gt; {merma.stock_nuevo}
+                        {f.stock_anterior} -&gt; {f.stock_nuevo}
                       </p>
                     </div>
                   </div>
@@ -207,7 +465,7 @@ export default function ModalHistorialMermas({
         <div className="p-4 border-t dark:border-gray-700">
           <button
             onClick={onClose}
-            className="w-full px-4 py-2 bg-gray-100 dark:bg-gray-700 hover:bg-gray-200 dark:hover:bg-gray-600 rounded-lg transition-colors"
+            className="w-full px-4 py-2 bg-gray-100 dark:bg-gray-700 hover:bg-gray-200 dark:hover:bg-gray-600 rounded-lg transition-colors dark:text-gray-200"
           >
             Cerrar
           </button>

--- a/src/components/modals/ModalMermaStock.tsx
+++ b/src/components/modals/ModalMermaStock.tsx
@@ -21,7 +21,12 @@ const MOTIVOS_MERMA: MotivoMermaOption[] = [
   { value: 'devolucion', label: 'Devolucion defectuosa', icon: '<-' },
   { value: 'error_inventario', label: 'Error de inventario', icon: '#' },
   { value: 'muestra', label: 'Muestra/Degustacion', icon: '*' },
-  { value: 'promociones', label: 'Promociones', icon: '%' },
+  // 'promociones' NO se ofrece a mano. Ese motivo lo escribe el motor de
+  // promociones como contrapartida de un regalo que ya esta contabilizado en el
+  // pedido, y por eso el reporte gerencial lo EXCLUYE de las mermas (mig 130) y
+  // el historial lo deja fuera del total. Una merma real cargada a mano con ese
+  // motivo desaparecia de todos los KPIs sin dejar rastro: la plata se
+  // evaporaba. Para una perdida real esta 'otro'.
   { value: 'otro', label: 'Otro motivo', icon: '?' }
 ]
 

--- a/src/hooks/queries/useMermasQuery.ts
+++ b/src/hooks/queries/useMermasQuery.ts
@@ -23,12 +23,54 @@ export const mermasKeys = {
   byMotivo: (sucursalId: number | null, motivo: string) => [...mermasKeys.all(sucursalId), 'motivo', motivo] as const,
 }
 
+/**
+ * Tope de filas por consulta. PostgREST corta solo y en SILENCIO: sin un límite
+ * explícito la pantalla diría "todas" y estaría mostrando las N más recientes.
+ * Explícito, la UI puede comparar `length` contra esto y avisar.
+ */
+export const LIMITE_MERMAS = 1000
+
+export interface FiltrosMermas {
+  /** 'YYYY-MM-DD' en hora de Argentina. */
+  desde?: string | null
+  /** 'YYYY-MM-DD' en hora de Argentina, inclusive. */
+  hasta?: string | null
+}
+
+/**
+ * El corte por fecha va al SERVIDOR, no al cliente: sin filtro la consulta trae
+ * todo y se come el tope de PostgREST. El índice `idx_mermas_fecha` sobre
+ * created_at DESC ya existe, así que es gratis.
+ *
+ * `created_at` es timestamptz y el día que le importa al usuario es el día
+ * ARGENTINO, que es el corte que usa el reporte gerencial
+ * (`created_at AT TIME ZONE 'America/Argentina/Buenos_Aires'`). Comparar contra
+ * un ISO sin offset cortaría en UTC y mandaría todo lo cargado después de las
+ * 21hs al día siguiente. El offset va fijo en -03:00 porque Argentina no tiene
+ * horario de verano desde 2009; la zona por nombre se usa en `fechaLocalISO`.
+ */
+function rangoArgentino(filtros?: FiltrosMermas) {
+  return {
+    desde: filtros?.desde ? `${filtros.desde}T00:00:00-03:00` : null,
+    // Inclusive hasta el último microsegundo del día: es la precisión de
+    // timestamptz, así que no se pierde ninguna fila del borde.
+    hasta: filtros?.hasta ? `${filtros.hasta}T23:59:59.999999-03:00` : null,
+  }
+}
+
 // Fetch functions
-async function fetchMermas(): Promise<MermaDBExtended[]> {
-  const { data, error } = await supabase
+async function fetchMermas(filtros?: FiltrosMermas): Promise<MermaDBExtended[]> {
+  const rango = rangoArgentino(filtros)
+  let query = supabase
     .from('mermas_stock')
     .select('*')
     .order('created_at', { ascending: false })
+    .limit(LIMITE_MERMAS)
+
+  if (rango.desde) query = query.gte('created_at', rango.desde)
+  if (rango.hasta) query = query.lte('created_at', rango.hasta)
+
+  const { data, error } = await query
 
   if (error) {
     if (error.message.includes('does not exist')) return []
@@ -84,7 +126,12 @@ async function registrarMerma(
       observaciones: mermaData.observaciones || null,
       stock_anterior: mermaData.stockAnterior,
       stock_nuevo: mermaData.stockNuevo,
-      usuario_id: mermaData.usuarioId || null,
+      // El modal de carga nunca manda usuarioId, así que TODA merma manual
+      // entraba con usuario_id NULL y el historial no podía decir quién la
+      // registró. Es el invariante MERMA-I (mig 105). Se resuelve acá y no en
+      // el formulario: quien registra es siempre el que tiene la sesión, no
+      // algo que el usuario elija.
+      usuario_id: mermaData.usuarioId || (await supabase.auth.getUser()).data.user?.id || null,
       sucursal_id: sucursalId
     }])
     .select()
@@ -125,11 +172,15 @@ async function registrarMerma(
 /**
  * Hook para obtener todas las mermas
  */
-export function useMermasQuery() {
+export function useMermasQuery(filtros?: FiltrosMermas) {
   const { currentSucursalId } = useSucursal()
+  const desde = filtros?.desde ?? null
+  const hasta = filtros?.hasta ?? null
   return useQuery({
-    queryKey: mermasKeys.lists(currentSucursalId),
-    queryFn: fetchMermas,
+    // `list` con los filtros adentro: dos rangos distintos son dos cachés
+    // distintas, si no el segundo mostraría el resultado del primero.
+    queryKey: mermasKeys.list(currentSucursalId, { desde, hasta }),
+    queryFn: () => fetchMermas({ desde, hasta }),
     staleTime: 5 * 60 * 1000, // 5 minutos
   })
 }

--- a/src/types/hooks.ts
+++ b/src/types/hooks.ts
@@ -889,6 +889,12 @@ export interface MermaDBExtended {
   stock_nuevo: number;
   usuario_id?: string | null;
   created_at?: string;
+  /**
+   * Costo promedio ponderado CONGELADO al momento de la merma (mig 119), lo
+   * sella un trigger BEFORE INSERT así que cubre todos los caminos de alta.
+   * NULL en las 479 filas anteriores a que existiera.
+   */
+  costo_unitario?: number | null;
 }
 
 export interface MermaFormInputExtended {

--- a/src/utils/valorizacionMermas.test.ts
+++ b/src/utils/valorizacionMermas.test.ts
@@ -1,0 +1,232 @@
+import { describe, it, expect } from 'vitest'
+import {
+  esAjustePromocion,
+  valorizarMerma,
+  totalizarMermas,
+  resumenPorMotivo,
+  MOTIVOS_AJUSTE_PROMOCION,
+} from './valorizacionMermas'
+import { costoCanonicoUnitario } from './costoCanonico'
+
+function merma(over: Partial<Parameters<typeof valorizarMerma>[0]> = {}) {
+  return {
+    id: 'm1',
+    producto_id: 'p1',
+    cantidad: 3,
+    motivo: 'rotura',
+    costo_unitario: 100,
+    created_at: '2026-08-15T14:00:00Z',
+    ...over,
+  }
+}
+
+const producto = {
+  id: 'p1',
+  nombre: 'Producto A',
+  codigo: 'PA1',
+  precio: 500,
+  costo_promedio: 120,
+  costo_real: 140,
+  costo_sin_iva: 150,
+  impuestos_internos: 0,
+}
+
+describe('esAjustePromocion', () => {
+  it('promociones y su reversión no son pérdida', () => {
+    // Son la contrapartida de un regalo YA contabilizado en el pedido. El
+    // reporte gerencial los excluye del KPI de mermas (mig 130); si el modal
+    // los sumara mostraría ~$2,5M donde el gerencial muestra ~$597.600.
+    expect(esAjustePromocion('promociones')).toBe(true)
+    expect(esAjustePromocion('promociones_reversion')).toBe(true)
+  })
+
+  it('los motivos de pérdida real sí cuentan', () => {
+    for (const m of ['rotura', 'vencimiento', 'robo', 'decomiso', 'devolucion', 'error_inventario', 'muestra', 'otro']) {
+      expect(esAjustePromocion(m)).toBe(false)
+    }
+  })
+
+  it('la lista es exactamente la que excluye el gerencial', () => {
+    expect([...MOTIVOS_AJUSTE_PROMOCION]).toEqual(['promociones', 'promociones_reversion'])
+  })
+})
+
+describe('valorizarMerma', () => {
+  describe('costo', () => {
+    it('usa el costo CONGELADO al momento de la merma, no el de hoy', () => {
+      // Si usara el costo vivo, el total de un mes ya cerrado cambiaría solo
+      // cada vez que llega una compra.
+      const v = valorizarMerma(merma({ costo_unitario: 100 }), producto)
+      expect(v.costoUnitario).toBe(100)
+      expect(v.costoTotal).toBe(300)
+      expect(v.costoEstimado).toBe(false)
+    })
+
+    it('sin snapshot cae a la cascada canónica y queda MARCADA como estimada', () => {
+      // Son 479 filas viejas (abril a julio 2026). No pueden mezclarse en
+      // silencio con las que sí tienen el costo del momento.
+      const v = valorizarMerma(merma({ costo_unitario: null }), producto)
+      expect(v.costoUnitario).toBe(120) // costo_promedio, no costo_real
+      expect(v.costoEstimado).toBe(true)
+    })
+
+    it('un snapshot de 0 es un valor, no un hueco', () => {
+      const v = valorizarMerma(merma({ costo_unitario: 0 }), producto)
+      expect(v.costoUnitario).toBe(0)
+      expect(v.costoEstimado).toBe(false)
+      expect(v.sinCosto).toBe(false)
+    })
+  })
+
+  describe('sinCosto: 0 no es lo mismo que "no sabemos"', () => {
+    it('marca la fila cuando el producto no tiene NINGÚN costo cargado', () => {
+      // costoCanonicoUnitario devuelve 0 en ese caso. Para un SUM da igual,
+      // pero en el historial una fila en $0 se lee como "no vale nada" cuando
+      // en realidad es "no sabemos".
+      const sinNada = { id: 'p9', precio: 500 }
+      const v = valorizarMerma(merma({ costo_unitario: null }), sinNada)
+      expect(v.costoUnitario).toBe(0)
+      expect(v.sinCosto).toBe(true)
+    })
+
+    it('un costo cargado en 0 NO se marca: es una decisión, no un vacío', () => {
+      const gratis = { id: 'p9', precio: 500, costo_promedio: 0 }
+      const v = valorizarMerma(merma({ costo_unitario: null }), gratis)
+      expect(v.costoUnitario).toBe(0)
+      expect(v.sinCosto).toBe(false)
+    })
+
+    it('sin producto tampoco sabemos el costo', () => {
+      const v = valorizarMerma(merma({ costo_unitario: null }), undefined)
+      expect(v.sinCosto).toBe(true)
+      expect(v.costoTotal).toBe(0)
+    })
+
+    // Este test es el que atrapa que las dos funciones se desalineen: la marca
+    // vive acá y la cascada en costoCanonico.ts.
+    it('sinCosto implica que la cascada devolvió 0', () => {
+      const casos = [{ id: 'x' }, { id: 'x', precio: 10 }, { id: 'x', costo_sin_iva: null }]
+      for (const p of casos) {
+        const v = valorizarMerma(merma({ costo_unitario: null }), p)
+        expect(v.sinCosto).toBe(true)
+        expect(costoCanonicoUnitario(null, p)).toBe(0)
+      }
+    })
+  })
+
+  describe('precio de venta', () => {
+    it('valúa contra el precio de HOY, porque no hay precio histórico', () => {
+      // mermas_stock no tiene ninguna columna de precio: no se puede saber a
+      // cuánto se vendía el día de la merma.
+      const v = valorizarMerma(merma(), producto)
+      expect(v.precioUnitario).toBe(500)
+      expect(v.precioTotal).toBe(1500)
+      expect(v.sinPrecio).toBe(false)
+    })
+
+    it('marca la fila cuando el producto no tiene precio', () => {
+      const v = valorizarMerma(merma(), { id: 'p1' })
+      expect(v.precioTotal).toBe(0)
+      expect(v.sinPrecio).toBe(true)
+    })
+  })
+
+  describe('cantidades negativas', () => {
+    it('una reversión conserva el signo y no lo duplica', () => {
+      // El CHECK pasó a `cantidad <> 0` (mig 011), así que las reversiones
+      // entran negativas. La tarjeta imprimía "-{cantidad}" y mostraba "--3".
+      const v = valorizarMerma(
+        merma({ cantidad: -3, motivo: 'promociones_reversion', costo_unitario: 100 }),
+        producto,
+      )
+      expect(v.cantidad).toBe(-3)
+      expect(v.costoTotal).toBe(-300)
+      expect(v.esAjustePromocion).toBe(true)
+    })
+  })
+})
+
+describe('totalizarMermas', () => {
+  const filas = [
+    valorizarMerma(merma({ id: 'a', cantidad: 2, motivo: 'rotura', costo_unitario: 100 }), producto),
+    valorizarMerma(merma({ id: 'b', cantidad: 1, motivo: 'vencimiento', costo_unitario: 200 }), producto),
+    valorizarMerma(merma({ id: 'c', cantidad: 10, motivo: 'promociones', costo_unitario: 50 }), producto),
+    valorizarMerma(merma({ id: 'd', cantidad: -4, motivo: 'promociones_reversion', costo_unitario: 50 }), producto),
+  ]
+
+  it('el total en plata EXCLUYE los ajustes de promoción', () => {
+    // Es lo que hace que el modal cuadre con el reporte gerencial.
+    const t = totalizarMermas(filas)
+    expect(t.costoTotal).toBe(400) // 2*100 + 1*200
+    expect(t.precioTotal).toBe(1500) // 3 unidades * 500
+  })
+
+  it('las unidades perdidas también excluyen los ajustes', () => {
+    expect(totalizarMermas(filas).unidades).toBe(3)
+  })
+
+  it('los ajustes se cuentan aparte, no se esconden', () => {
+    const t = totalizarMermas(filas)
+    expect(t.registrosAjustePromocion).toBe(2)
+    expect(t.costoAjustePromocion).toBe(300) // 10*50 + (-4)*50
+  })
+
+  it('cuenta TODOS los registros, sean pérdida o ajuste', () => {
+    expect(totalizarMermas(filas).registros).toBe(4)
+  })
+
+  // Las dos marcas son DISJUNTAS: una fila sin ningún costo no es una
+  // estimación, es un dato ausente. Contarla como estimada diría que hay un
+  // número aproximado cuando no hay ninguno.
+  it('cuenta por separado las estimadas y las que no tienen costo', () => {
+    const mezcla = [
+      valorizarMerma(merma({ id: 'e', costo_unitario: null }), producto),
+      valorizarMerma(merma({ id: 'f', costo_unitario: null }), { id: 'p2' }),
+      valorizarMerma(merma({ id: 'g', costo_unitario: 100 }), producto),
+    ]
+    const t = totalizarMermas(mezcla)
+    expect(t.filasCostoEstimado).toBe(1)
+    expect(t.filasSinCosto).toBe(1)
+  })
+
+  it('ninguna fila es estimada y sin costo a la vez', () => {
+    const filas = [
+      valorizarMerma(merma({ costo_unitario: null }), producto),
+      valorizarMerma(merma({ costo_unitario: null }), { id: 'p2' }),
+      valorizarMerma(merma({ costo_unitario: 5 }), producto),
+    ]
+    expect(filas.every(f => !(f.costoEstimado && f.sinCosto))).toBe(true)
+  })
+
+  it('sin filas devuelve ceros, no NaN', () => {
+    const t = totalizarMermas([])
+    expect(t).toMatchObject({ registros: 0, unidades: 0, costoTotal: 0, precioTotal: 0 })
+    expect(Number.isNaN(t.costoTotal)).toBe(false)
+  })
+})
+
+describe('resumenPorMotivo', () => {
+  it('agrupa unidades y plata por motivo, ordenado por costo', () => {
+    const filas = [
+      valorizarMerma(merma({ id: 'a', cantidad: 2, motivo: 'rotura', costo_unitario: 100 }), producto),
+      valorizarMerma(merma({ id: 'b', cantidad: 1, motivo: 'rotura', costo_unitario: 100 }), producto),
+      valorizarMerma(merma({ id: 'c', cantidad: 1, motivo: 'vencimiento', costo_unitario: 1000 }), producto),
+    ]
+
+    expect(resumenPorMotivo(filas)).toEqual([
+      { motivo: 'vencimiento', esAjustePromocion: false, registros: 1, unidades: 1, costo: 1000, precio: 500 },
+      { motivo: 'rotura', esAjustePromocion: false, registros: 2, unidades: 3, costo: 300, precio: 1500 },
+    ])
+  })
+
+  it('los ajustes de promoción aparecen en el resumen, marcados', () => {
+    const filas = [
+      valorizarMerma(merma({ id: 'c', cantidad: 10, motivo: 'promociones', costo_unitario: 50 }), producto),
+    ]
+    expect(resumenPorMotivo(filas)[0]).toMatchObject({
+      motivo: 'promociones',
+      esAjustePromocion: true,
+      costo: 500,
+    })
+  })
+})

--- a/src/utils/valorizacionMermas.ts
+++ b/src/utils/valorizacionMermas.ts
@@ -1,0 +1,206 @@
+/**
+ * Valorización del historial de mermas: cuánto costó y cuánto se dejó de vender.
+ *
+ * EL COSTO ES EL CONGELADO, NO EL DE HOY
+ * --------------------------------------
+ * `mermas_stock.costo_unitario` (mig 119) lo sella un trigger BEFORE INSERT con
+ * el costo promedio ponderado del momento, así que cubre todos los caminos de
+ * inserción. Es el mismo criterio del reporte gerencial. Con el costo vivo, el
+ * total de un mes ya cerrado cambiaría solo cada vez que llega una compra.
+ *
+ * Las mermas anteriores a que existiera el snapshot —479 filas, de abril a
+ * julio de 2026— caen a la cascada canónica, o sea al costo de HOY. Se marcan
+ * con `costoEstimado`: mezclarlas en silencio con las que sí tienen el costo
+ * del momento sería presentar una estimación como un dato.
+ *
+ * EL PRECIO DE VENTA NO TIENE HISTÓRICO
+ * -------------------------------------
+ * `mermas_stock` no tiene ninguna columna de precio: sólo se puede valuar
+ * contra `productos.precio` de hoy. Es una referencia de "cuánto se dejó de
+ * facturar a precio actual", no el precio que regía el día de la merma, y la
+ * pantalla y el Excel lo dicen.
+ *
+ * LOS AJUSTES DE PROMOCIÓN NO SON PÉRDIDA
+ * ---------------------------------------
+ * `reporte_gerencial` excluye 'promociones' y 'promociones_reversion' del KPI
+ * de mermas (mig 130), porque son la contrapartida de un regalo que YA está
+ * contabilizado en el pedido: contarlos sería contar la misma plata dos veces.
+ * En los datos de prod pesan $2.637.977 y -$755.516 contra ~$597.600 de merma
+ * real, así que un total que los incluya no cuadra con el gerencial por un
+ * factor de cuatro. Se muestran igual, en el detalle y en el resumen por
+ * motivo, pero etiquetados y fuera del total en plata.
+ */
+import { costoCanonicoUnitario, type ProductoCosto } from './costoCanonico'
+
+/** Motivos que NO son pérdida. Es exactamente lo que excluye la mig 130. */
+export const MOTIVOS_AJUSTE_PROMOCION = ['promociones', 'promociones_reversion'] as const
+
+export function esAjustePromocion(motivo: string): boolean {
+  return (MOTIVOS_AJUSTE_PROMOCION as readonly string[]).includes(motivo)
+}
+
+/** Lo que se necesita de una fila de `mermas_stock`. */
+export interface MermaParaValorizar {
+  id: string
+  producto_id: string
+  /** Negativa en las reversiones: el CHECK es `cantidad <> 0` (mig 011). */
+  cantidad: number
+  motivo: string
+  /** Costo congelado por el trigger (mig 119). NULL en las filas viejas. */
+  costo_unitario?: number | null
+  observaciones?: string | null
+  usuario_id?: string | null
+  stock_anterior?: number
+  stock_nuevo?: number
+  created_at?: string
+}
+
+/** Lo que se necesita de `productos`: las columnas de costo, más el precio. */
+export interface ProductoParaValorizar extends ProductoCosto {
+  id: string
+  nombre?: string | null
+  codigo?: string | null
+  precio?: number | null
+}
+
+export interface MermaValorizada extends MermaParaValorizar {
+  productoNombre: string
+  productoCodigo: string
+  costoUnitario: number
+  costoTotal: number
+  precioUnitario: number
+  precioTotal: number
+  /** No es pérdida: contrapartida de un regalo ya contabilizado en el pedido. */
+  esAjustePromocion: boolean
+  /** No había snapshot: el costo sale del valor de hoy. */
+  costoEstimado: boolean
+  /** No hay NINGÚN costo cargado: el 0 significa "no sabemos", no "no vale nada". */
+  sinCosto: boolean
+  /** El producto no tiene precio cargado. */
+  sinPrecio: boolean
+}
+
+/**
+ * Espejo del `presente()` de costoCanonico.ts, que no se exporta a propósito.
+ * Sirve para distinguir un costo de 0 cargado a mano —que es una decisión— de
+ * la ausencia total de costo, que es lo que hay que marcar. El último test de
+ * `sinCosto` fija que las dos funciones sigan de acuerdo.
+ */
+function hayValor(v: unknown): boolean {
+  if (v === null || v === undefined || v === '') return false
+  return Number.isFinite(Number(v))
+}
+
+export function valorizarMerma(
+  merma: MermaParaValorizar,
+  producto: ProductoParaValorizar | null | undefined,
+): MermaValorizada {
+  const costoUnitario = costoCanonicoUnitario(merma.costo_unitario, producto)
+  const conSnapshot = hayValor(merma.costo_unitario)
+  const sinCosto =
+    !conSnapshot &&
+    !hayValor(producto?.costo_promedio) &&
+    !hayValor(producto?.costo_real) &&
+    !hayValor(producto?.costo_sin_iva)
+
+  const sinPrecio = !hayValor(producto?.precio)
+  const precioUnitario = sinPrecio ? 0 : Number(producto?.precio)
+
+  return {
+    ...merma,
+    productoNombre: producto?.nombre || 'Producto desconocido',
+    productoCodigo: producto?.codigo || '',
+    costoUnitario,
+    costoTotal: costoUnitario * merma.cantidad,
+    precioUnitario,
+    precioTotal: precioUnitario * merma.cantidad,
+    esAjustePromocion: esAjustePromocion(merma.motivo),
+    // Una fila sin ningún costo no es una estimación: es un dato ausente, y se
+    // marca con `sinCosto`. Marcarla además como estimada diría que hay un
+    // número aproximado cuando no hay ninguno.
+    costoEstimado: !conSnapshot && !sinCosto,
+    sinCosto,
+    sinPrecio,
+  }
+}
+
+export interface TotalesMermas {
+  /** Todos los registros del período, sean pérdida o ajuste. */
+  registros: number
+  /** Unidades perdidas: NO incluye los ajustes de promoción. */
+  unidades: number
+  /** Costo de la pérdida real. Es el número que cuadra con el gerencial. */
+  costoTotal: number
+  /** Lo mismo valuado a precio de venta de HOY. */
+  precioTotal: number
+  registrosAjustePromocion: number
+  unidadesAjustePromocion: number
+  costoAjustePromocion: number
+  /** Cuántas filas se valuaron con el costo de hoy por no tener snapshot. */
+  filasCostoEstimado: number
+  /** Cuántas filas no tienen ningún costo con el cual valuarse. */
+  filasSinCosto: number
+}
+
+export function totalizarMermas(filas: readonly MermaValorizada[]): TotalesMermas {
+  const t: TotalesMermas = {
+    registros: filas.length,
+    unidades: 0,
+    costoTotal: 0,
+    precioTotal: 0,
+    registrosAjustePromocion: 0,
+    unidadesAjustePromocion: 0,
+    costoAjustePromocion: 0,
+    filasCostoEstimado: 0,
+    filasSinCosto: 0,
+  }
+
+  for (const f of filas) {
+    if (f.costoEstimado) t.filasCostoEstimado++
+    if (f.sinCosto) t.filasSinCosto++
+
+    if (f.esAjustePromocion) {
+      t.registrosAjustePromocion++
+      t.unidadesAjustePromocion += f.cantidad
+      t.costoAjustePromocion += f.costoTotal
+    } else {
+      t.unidades += f.cantidad
+      t.costoTotal += f.costoTotal
+      t.precioTotal += f.precioTotal
+    }
+  }
+
+  return t
+}
+
+export interface ResumenMotivo {
+  motivo: string
+  esAjustePromocion: boolean
+  registros: number
+  unidades: number
+  costo: number
+  precio: number
+}
+
+/** El mismo corte que arma el gerencial en su bloque `mermas_motivo`. */
+export function resumenPorMotivo(filas: readonly MermaValorizada[]): ResumenMotivo[] {
+  const porMotivo = new Map<string, ResumenMotivo>()
+
+  for (const f of filas) {
+    const acc = porMotivo.get(f.motivo) ?? {
+      motivo: f.motivo,
+      esAjustePromocion: f.esAjustePromocion,
+      registros: 0,
+      unidades: 0,
+      costo: 0,
+      precio: 0,
+    }
+    acc.registros++
+    acc.unidades += f.cantidad
+    acc.costo += f.costoTotal
+    acc.precio += f.precioTotal
+    porMotivo.set(f.motivo, acc)
+  }
+
+  return [...porMotivo.values()].sort((a, b) => b.costo - a.costo)
+}


### PR DESCRIPTION
El historial de mermas mostraba tarjetas con la cantidad y nada más: sin rango de fechas, sin plata y sin export. **Sin migración.**

## El total no es la suma de todo, a propósito

Excluye `promociones` y `promociones_reversion`, igual que el KPI de mermas del reporte gerencial (mig 130): no son pérdida, son la contrapartida de un regalo que **ya está contabilizado en el pedido**.

En los datos de prod pesan $2.637.977 y −$755.516 contra ~$597.600 de merma real. Un total que los incluyera mostraría ~$2,5M y no cuadraría con el gerencial por un factor de cuatro — y alguien lo reportaría como bug, con razón. Se muestran igual, en el detalle y en el resumen por motivo, etiquetados como ajuste y contados aparte.

**Corolario que había que cerrar:** `ModalMermaStock` le *ofrecía* "Promociones" en la carga manual. Una merma real cargada con ese motivo desaparecía de todos los KPIs sin dejar rastro — la plata se evaporaba. Ese motivo sale del selector; para una pérdida real está "Otro".

## De dónde sale la plata

El costo es el **congelado al momento de la merma** (`mermas_stock.costo_unitario`, mig 119, sellado por un trigger `BEFORE INSERT` así que cubre todos los caminos de alta). Es el criterio del gerencial: con el costo vivo, el total de un mes ya cerrado cambiaría solo cada vez que llega una compra. Reusa `costoCanonicoUnitario`.

El precio de venta **no tiene histórico**: `mermas_stock` no tiene ninguna columna de precio, así que sólo se puede valuar contra el precio de hoy. La pantalla y el Excel lo dicen. No se agregó columna ni trigger para congelarlo: eso es forward-only, no arregla el pasado, y el pasado es justo lo que se quería ver.

## Tres marcas de calidad del dato

Un número sin contexto miente, así que ninguna de estas se mezcla en silencio:

| Marca | Qué significa |
|---|---|
| **Costo estimado al valor actual** | Las 479 filas de abril a julio, anteriores al snapshot: van al costo de hoy |
| **Sin costo cargado** | El producto no tiene ningún costo. Da $0, y $0 se lee como "no vale nada" cuando en realidad es "no sabemos" |
| **Tope de filas** | Si el período llega al límite de PostgREST lo dice, en vez de mentir "todas" |

Las dos primeras son **disjuntas**: un dato ausente no es una estimación, y contarlo como tal diría que hay un número aproximado cuando no hay ninguno.

## El filtro de fecha va al servidor

`fetchMermas` no tenía ni filtros ni `limit`. PostgREST corta en 1000 filas **en silencio** y hoy hay ~871: estaba al borde de empezar a mentir.

El corte usa el día **argentino** (offset `-03:00`), que es el mismo de la mig 130. Comparar contra un ISO pelado cortaría en UTC y mandaría todo lo cargado después de las 21hs al día siguiente. El índice `idx_mermas_fecha` ya existía, así que es gratis.

De paso, la query se mudó del container al modal: `/productos` traía **todas** las mermas en cada carga, aunque nadie abriera el historial.

## Los tres defectos de render

- El prop `usuarios` nunca se pasaba: todas las filas decían "Usuario desconocido". Y además **toda merma manual entraba con `usuario_id` NULL** (invariante MERMA-I) — ahora sale de la sesión autenticada, que es de donde tiene que salir: quién registra no es algo que el usuario elija.
- Las reversiones tienen cantidad negativa y la tarjeta imprimía `-{cantidad}`, o sea `--3`.
- `promociones_reversion` no estaba en las etiquetas y salía el string crudo de la base.

## Tests

No existía ni un test de mermas en el repo. Ahora hay 42:

- `utils/valorizacionMermas.ts` (22): la cascada de costo, las dos marcas, el signo de las reversiones, la exclusión de promociones y el resumen por motivo. Escritos antes de la implementación — uno falló y **el test estaba mal**, no el código: fue lo que decidió que las dos marcas fueran disjuntas.
- `ModalHistorialMermas.test.tsx` (20): filtro al servidor, exclusión de promociones, las tres marcas, los tres defectos de render y el Excel — nombres de hoja, primera fila y filename exacto, con `utils/excel` mockeado.

Verificado que muerden: sumando los ajustes al total caen 5.

El modal se importa **directo**, no por el container, para no pagar el `import()` del chunk lazy — es el flake del PR #514.

`typecheck`, `lint`, `test:run` (107 archivos / 1476 tests, sin `.env`) y `build`: los cuatro en verde.

## Lo que quedó afuera

- **#518** — `registrarMerma` pisa el stock con un valor absoluto calculado en el cliente: lost update, rompe STK-A. Necesita RPC + migración. El camino de fallback es peor: descuenta stock sin dejar fila de merma.
- **#519** — La merma offline no llega nunca: el handler inserta en `mermas` (la tabla es `mermas_stock`) y además `guardarMermaOffline` no tiene ningún caller. Los dos defectos se tapan entre sí.

🤖 Generated with [Claude Code](https://claude.com/claude-code)