### PR TITLE
Exportar a Excel las cinco pestañas de reportes que faltaban

### DIFF
--- a/src/components/vistas/VistaReportes.tsx
+++ b/src/components/vistas/VistaReportes.tsx
@@ -263,6 +263,8 @@ export default function VistaReportes({
           reportePreventistas={reportePreventistas}
           loading={loading}
           formatPrecio={formatPrecio}
+          desde={fechaDesde}
+          hasta={fechaHasta}
         />
       )}
 
@@ -280,6 +282,8 @@ export default function VistaReportes({
           reporte={reporteRentabilidad}
           loading={loadingFinanciero}
           formatPrecio={formatPrecio}
+          desde={fechaDesde}
+          hasta={fechaHasta}
         />
       )}
 

--- a/src/components/vistas/reportes/ReporteCuentasPorCobrar.tsx
+++ b/src/components/vistas/reportes/ReporteCuentasPorCobrar.tsx
@@ -1,8 +1,8 @@
 /**
  * Componente para mostrar el reporte de cuentas por cobrar con aging
  */
-import React from 'react';
-import { DollarSign } from 'lucide-react';
+import React, { useState } from 'react';
+import { DollarSign, Download, Loader2 } from 'lucide-react';
 import LoadingSpinner from '../../layout/LoadingSpinner';
 import type { ClienteDB, ReporteCuentaPorCobrar } from '../../../types';
 
@@ -19,7 +19,7 @@ export function ReporteCuentasPorCobrar({
   formatPrecio,
   onVerCliente
 }: ReporteCuentasPorCobrarProps): React.ReactElement {
-  if (loading) return <LoadingSpinner />;
+  const [exportando, setExportando] = useState(false);
 
   // Totales por aging
   const totalCorriente = reporte.reduce((s, r) => s + r.aging.corriente, 0);
@@ -28,8 +28,73 @@ export function ReporteCuentasPorCobrar({
   const total90 = reporte.reduce((s, r) => s + r.aging.vencido90, 0);
   const totalGeneral = reporte.reduce((s, r) => s + r.saldoPendiente, 0);
 
+  const exportar = async (): Promise<void> => {
+    if (reporte.length === 0) return;
+    setExportando(true);
+    try {
+      // `cliente` y `aging` vienen anidados: el Excel es plano, así que se
+      // aplanan a columnas. El aging va en columnas y no en filas porque la
+      // lectura del informe es "quién me debe y de cuándo", por cliente.
+      const detalle = reporte.map((r) => ({
+        Cliente: r.cliente.nombre_fantasia ?? '',
+        'Razón social': r.cliente.razon_social ?? '',
+        Zona: r.cliente.zona || 'Sin zona',
+        CUIT: r.cliente.cuit ?? '',
+        Teléfono: r.cliente.telefono ?? '',
+        Activo: r.cliente.activo === false ? 'No' : 'Sí',
+        'Total facturado': r.totalDeuda,
+        Pagado: r.totalPagado,
+        Saldo: r.saldoPendiente,
+        Corriente: r.aging.corriente,
+        '1-30 días': r.aging.vencido30,
+        '31-60 días': r.aging.vencido60,
+        '+60 días': r.aging.vencido90,
+        'Límite de crédito': r.limiteCredito,
+        'Crédito disponible': r.creditoDisponible,
+        'Pedidos pendientes': r.pedidosPendientes,
+      }));
+
+      const resumen = [
+        { Tramo: 'Corriente', Monto: totalCorriente, Clientes: reporte.filter((r) => r.aging.corriente > 0).length },
+        { Tramo: '1-30 días', Monto: total30, Clientes: reporte.filter((r) => r.aging.vencido30 > 0).length },
+        { Tramo: '31-60 días', Monto: total60, Clientes: reporte.filter((r) => r.aging.vencido60 > 0).length },
+        { Tramo: '+60 días', Monto: total90, Clientes: reporte.filter((r) => r.aging.vencido90 > 0).length },
+        { Tramo: 'TOTAL', Monto: totalGeneral, Clientes: reporte.length },
+      ];
+
+      const { createMultiSheetExcel } = await import('../../../utils/excel');
+      await createMultiSheetExcel(
+        [
+          { name: 'Resumen aging', data: resumen, columnWidths: [16, 18, 11] },
+          { name: 'Por cliente', data: detalle, columnWidths: [34, 34, 20, 15, 16, 8, 17, 15, 15, 14, 13, 13, 13, 18, 19, 12] },
+        ],
+        // Sin período: la cuenta corriente es una foto de HOY, no de un rango.
+        `cuentas-por-cobrar-${new Date().toLocaleDateString('sv-SE')}`
+      );
+    } finally {
+      setExportando(false);
+    }
+  };
+
+  if (loading) return <LoadingSpinner />;
+
   return (
     <div className="space-y-4">
+      <div className="flex justify-end">
+        <button
+          onClick={exportar}
+          disabled={exportando || reporte.length === 0}
+          className="flex items-center gap-2 px-3 py-2 bg-green-600 text-white rounded-lg hover:bg-green-700 disabled:opacity-50 text-sm transition-colors"
+        >
+          {exportando ? (
+            <Loader2 className="w-4 h-4 animate-spin" />
+          ) : (
+            <Download className="w-4 h-4" />
+          )}
+          Exportar a Excel
+        </button>
+      </div>
+
       {/* Resumen Aging */}
       <div className="grid grid-cols-2 md:grid-cols-5 gap-4">
         <div className="bg-green-50 dark:bg-green-900/20 p-4 rounded-lg">

--- a/src/components/vistas/reportes/ReportePreventistas.tsx
+++ b/src/components/vistas/reportes/ReportePreventistas.tsx
@@ -1,8 +1,8 @@
 /**
  * Componente para mostrar el reporte de ventas por preventista
  */
-import React from 'react';
-import { TrendingUp } from 'lucide-react';
+import React, { useState } from 'react';
+import { TrendingUp, Download, Loader2 } from 'lucide-react';
 import LoadingSpinner from '../../layout/LoadingSpinner';
 import type { ReportePreventista } from '../../../types';
 
@@ -10,13 +10,65 @@ export interface ReportePreventistasProps {
   reportePreventistas: ReportePreventista[];
   loading: boolean;
   formatPrecio: (precio: number) => string;
+  /** Sólo para el nombre del archivo: '' = sin filtro de fecha. */
+  desde?: string;
+  hasta?: string;
 }
 
 export function ReportePreventistas({
   reportePreventistas,
   loading,
-  formatPrecio
+  formatPrecio,
+  desde = '',
+  hasta = ''
 }: ReportePreventistasProps): React.ReactElement {
+  const [exportando, setExportando] = useState(false);
+
+  const totales = {
+    ventas: reportePreventistas.reduce((s, p) => s + p.totalVentas, 0),
+    pedidos: reportePreventistas.reduce((s, p) => s + p.cantidadPedidos, 0),
+    pagado: reportePreventistas.reduce((s, p) => s + p.totalPagado, 0),
+    pendiente: reportePreventistas.reduce((s, p) => s + p.totalPendiente, 0)
+  };
+
+  // Sin filtro de fecha el reporte es de todo el histórico, y el archivo tiene
+  // que decirlo: 'todo' y no un rango inventado.
+  const periodo = desde || hasta ? `${desde || 'inicio'}_${hasta || 'hoy'}` : 'todo';
+
+  const exportar = async (): Promise<void> => {
+    if (reportePreventistas.length === 0) return;
+    setExportando(true);
+    try {
+      const filas = reportePreventistas.map((p) => ({
+        Preventista: p.nombre,
+        Email: p.email ?? '',
+        'Total ventas': p.totalVentas,
+        Pedidos: p.cantidadPedidos,
+        Pagado: p.totalPagado,
+        Pendiente: p.totalPendiente
+      }));
+      // La fila TOTAL viaja en el Excel porque está en la pantalla: un archivo
+      // que no la trae obliga a rehacer la suma para confirmar que es el mismo
+      // reporte.
+      filas.push({
+        Preventista: 'TOTAL',
+        Email: '',
+        'Total ventas': totales.ventas,
+        Pedidos: totales.pedidos,
+        Pagado: totales.pagado,
+        Pendiente: totales.pendiente
+      });
+
+      const { createMultiSheetExcel } = await import('../../../utils/excel');
+      await createMultiSheetExcel(
+        [{ name: 'Por preventista', data: filas, columnWidths: [28, 30, 16, 10, 16, 16] }],
+        `ventas-por-preventista-${periodo}`
+      );
+    } finally {
+      setExportando(false);
+    }
+  };
+
   if (loading) return <LoadingSpinner />;
 
   if (reportePreventistas.length === 0) {
@@ -28,15 +80,24 @@ export function ReportePreventistas({
     );
   }
 
-  const totales = {
-    ventas: reportePreventistas.reduce((s, p) => s + p.totalVentas, 0),
-    pedidos: reportePreventistas.reduce((s, p) => s + p.cantidadPedidos, 0),
-    pagado: reportePreventistas.reduce((s, p) => s + p.totalPagado, 0),
-    pendiente: reportePreventistas.reduce((s, p) => s + p.totalPendiente, 0)
-  };
-
   return (
-    <div className="bg-white dark:bg-gray-800 border dark:border-gray-700 rounded-lg shadow-sm overflow-x-auto">
+    <div className="space-y-3">
+      <div className="flex justify-end">
+        <button
+          onClick={exportar}
+          disabled={exportando}
+          className="flex items-center gap-2 px-3 py-2 bg-green-600 text-white rounded-lg hover:bg-green-700 disabled:opacity-50 text-sm transition-colors"
+        >
+          {exportando ? (
+            <Loader2 className="w-4 h-4 animate-spin" />
+          ) : (
+            <Download className="w-4 h-4" />
+          )}
+          Exportar a Excel
+        </button>
+      </div>
+
+      <div className="bg-white dark:bg-gray-800 border dark:border-gray-700 rounded-lg shadow-sm overflow-x-auto">
       <table className="w-full">
         <thead className="bg-gray-50 dark:bg-gray-700/50">
           <tr>
@@ -83,6 +144,7 @@ export function ReportePreventistas({
           </tr>
         </tfoot>
       </table>
+      </div>
     </div>
   );
 }

--- a/src/components/vistas/reportes/ReporteRentabilidad.tsx
+++ b/src/components/vistas/reportes/ReporteRentabilidad.tsx
@@ -1,8 +1,8 @@
 /**
  * Componente para mostrar el reporte de rentabilidad por producto
  */
-import React from 'react';
-import { Package } from 'lucide-react';
+import React, { useState } from 'react';
+import { Package, Download, Loader2 } from 'lucide-react';
 import LoadingSpinner from '../../layout/LoadingSpinner';
 import type { ReporteRentabilidad } from '../../../types';
 
@@ -10,19 +10,90 @@ export interface ReporteRentabilidadProps {
   reporte: ReporteRentabilidad;
   loading: boolean;
   formatPrecio: (precio: number) => string;
+  /** Sólo para el nombre del archivo: '' = sin filtro de fecha. */
+  desde?: string;
+  hasta?: string;
 }
+
+/** Lo que la tabla muestra en pantalla. El Excel se lleva TODOS. */
+const PRODUCTOS_EN_PANTALLA = 20;
 
 export function ReporteRentabilidadSection({
   reporte,
   loading,
-  formatPrecio
+  formatPrecio,
+  desde = '',
+  hasta = ''
 }: ReporteRentabilidadProps): React.ReactElement {
-  if (loading) return <LoadingSpinner />;
-
+  const [exportando, setExportando] = useState(false);
   const { productos, totales } = reporte;
+  const periodo = desde || hasta ? `${desde || 'inicio'}_${hasta || 'hoy'}` : 'todo';
+
+  const exportar = async (): Promise<void> => {
+    if (productos.length === 0) return;
+    setExportando(true);
+    try {
+      // TODOS los productos, no los 20 de la pantalla. El nombre de la hoja lo
+      // dice para que nadie crea que el archivo no coincide con lo que ve.
+      const filas = productos.map((p, i) => ({
+        '#': i + 1,
+        Producto: p.nombre,
+        Código: p.codigo ?? '',
+        Vendido: p.cantidadVendida ?? 0,
+        Ingresos: p.ingresos ?? 0,
+        Costos: p.costos ?? 0,
+        Margen: p.margen ?? 0,
+        '% margen': (p.margenPorcentaje ?? 0) / 100
+      }));
+
+      // El desglose fiscal está en la pantalla y no en la tabla: sin esta hoja
+      // el Excel perdería el IVA y los impuestos internos, que es lo que separa
+      // la venta bruta del ingreso real.
+      const resumen = [
+        { Concepto: 'Ventas brutas', Monto: totales.ventasBrutas ?? 0 },
+        { Concepto: 'IVA discriminado', Monto: totales.ivaDiscriminado ?? 0 },
+        { Concepto: 'Impuestos internos', Monto: totales.impuestosInternos ?? 0 },
+        { Concepto: 'Ventas netas', Monto: totales.ventasNetas ?? 0 },
+        { Concepto: 'Ingresos netos', Monto: totales.ingresosTotales ?? 0 },
+        { Concepto: 'Costos', Monto: totales.costosTotales ?? 0 },
+        { Concepto: 'Margen', Monto: totales.margenTotal ?? 0 },
+        { Concepto: '% margen', Monto: (totales.margenPorcentaje ?? 0) / 100 },
+        { Concepto: 'Pedidos', Monto: totales.cantidadPedidos ?? 0 },
+        { Concepto: 'Productos en el reporte', Monto: productos.length }
+      ];
+
+      const { createMultiSheetExcel } = await import('../../../utils/excel');
+      await createMultiSheetExcel(
+        [
+          { name: 'Resumen', data: resumen, columnWidths: [26, 18] },
+          { name: `Productos (todos, ${productos.length})`, data: filas, columnWidths: [5, 40, 14, 10, 16, 16, 16, 11] }
+        ],
+        `rentabilidad-${periodo}`
+      );
+    } finally {
+      setExportando(false);
+    }
+  };
+
+  if (loading) return <LoadingSpinner />;
 
   return (
     <div className="space-y-4">
+      <div className="flex justify-end">
+        <button
+          onClick={exportar}
+          disabled={exportando || productos.length === 0}
+          className="flex items-center gap-2 px-3 py-2 bg-green-600 text-white rounded-lg hover:bg-green-700 disabled:opacity-50 text-sm transition-colors"
+        >
+          {exportando ? (
+            <Loader2 className="w-4 h-4 animate-spin" />
+          ) : (
+            <Download className="w-4 h-4" />
+          )}
+          Exportar a Excel
+        </button>
+      </div>
+
       {/* Desglose Ventas */}
       <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
         <div className="bg-indigo-50 dark:bg-indigo-900/20 p-4 rounded-lg">
@@ -99,7 +170,7 @@ export function ReporteRentabilidadSection({
               </tr>
             </thead>
             <tbody className="divide-y dark:divide-gray-700">
-              {productos.slice(0, 20).map((p, i) => (
+              {productos.slice(0, PRODUCTOS_EN_PANTALLA).map((p, i) => (
                 <tr key={i} className="hover:bg-gray-50 dark:hover:bg-gray-700/50">
                   <td className="px-4 py-3">
                     <p className="font-medium">{p.nombre}</p>
@@ -128,6 +199,12 @@ export function ReporteRentabilidadSection({
               ))}
             </tbody>
           </table>
+          {productos.length > PRODUCTOS_EN_PANTALLA && (
+            <p className="px-4 py-3 text-sm text-gray-500 border-t dark:border-gray-700">
+              Se muestran los {PRODUCTOS_EN_PANTALLA} de mayor margen. El Excel lleva los{' '}
+              {productos.length}.
+            </p>
+          )}
         </div>
       )}
     </div>

--- a/src/components/vistas/reportes/ReporteValuacionInventario.tsx
+++ b/src/components/vistas/reportes/ReporteValuacionInventario.tsx
@@ -7,7 +7,7 @@
  * usuario) y filtra por sucursal/categoría del lado del cliente.
  */
 import React, { useMemo, useState } from 'react';
-import { Package, AlertTriangle } from 'lucide-react';
+import { Package, AlertTriangle, Download, Loader2 } from 'lucide-react';
 import LoadingSpinner from '../../layout/LoadingSpinner';
 import {
   useValuacionInventarioQuery,
@@ -44,6 +44,88 @@ export function ReporteValuacionInventario({
     );
   }, [productosFiltrados]);
 
+  const [exportando, setExportando] = useState(false);
+
+  const exportar = async (): Promise<void> => {
+    if (!data) return;
+    setExportando(true);
+    try {
+      const nombreSucursal =
+        sucursalFiltro === 'todas'
+          ? 'Todas'
+          : (data.sucursales.find((x) => x.sucursal_id === sucursalFiltro)?.sucursal_nombre ??
+             String(sucursalFiltro));
+
+      // El filtro es EN CLIENTE: exportar data.productos crudo ignoraría los
+      // filtros que el usuario tiene puestos en pantalla y el archivo no
+      // coincidiría con lo que está mirando. Por eso van los FILTRADOS, y el
+      // filtro aplicado queda escrito en la hoja de metadatos: fuera de la app,
+      // nadie puede saber si este archivo es de una sucursal o de todas.
+      const meta = [
+        { Campo: 'Generado', Valor: data.meta.generado_at },
+        { Campo: 'Criterio', Valor: data.meta.criterio },
+        { Campo: 'Sucursal (filtro aplicado)', Valor: nombreSucursal },
+        { Campo: 'Categoría (filtro aplicado)', Valor: categoriaFiltro === 'todas' ? 'Todas' : categoriaFiltro },
+        { Campo: 'Productos en este archivo', Valor: productosFiltrados.length },
+        { Campo: 'Productos en el reporte completo', Valor: data.productos.length },
+        { Campo: 'Unidades', Valor: totalesFiltro.unidades },
+        { Campo: 'Valuación a costo promedio', Valor: totalesFiltro.promedio },
+        { Campo: 'Valuación a costo de reposición', Valor: totalesFiltro.reposicion },
+        { Campo: 'Diferencia', Valor: totalesFiltro.reposicion - totalesFiltro.promedio },
+        { Campo: 'Productos con stock negativo', Valor: data.calidad_datos.stock_negativo },
+        { Campo: 'Productos sin costo', Valor: data.calidad_datos.sin_costo },
+      ];
+
+      const filas = productosFiltrados.map((p) => ({
+        Producto: p.nombre,
+        Categoría: p.categoria,
+        Sucursal: p.sucursal_nombre,
+        Stock: p.stock,
+        'Costo promedio': p.costo_promedio ?? '',
+        'Costo reposición': p.costo_reposicion ?? '',
+        'Última compra': p.ultimo_tipo_compra ?? '',
+        'Valuación promedio': p.valuacion_promedio,
+        'Valuación reposición': p.valuacion_reposicion,
+        Diferencia: p.diferencia,
+      }));
+
+      // Las categorías del RPC son GLOBALES: con un filtro puesto no cuadrarían
+      // con el detalle. Se recalculan sobre lo filtrado, que es lo que el
+      // usuario está viendo.
+      const porCategoria = new Map<string, { productos: number; unidades: number; promedio: number; reposicion: number }>();
+      for (const p of productosFiltrados) {
+        const acc = porCategoria.get(p.categoria) ?? { productos: 0, unidades: 0, promedio: 0, reposicion: 0 };
+        acc.productos += 1;
+        acc.unidades += Math.max(p.stock, 0);
+        acc.promedio += p.valuacion_promedio || 0;
+        acc.reposicion += p.valuacion_reposicion || 0;
+        porCategoria.set(p.categoria, acc);
+      }
+      const categoriasFilas = [...porCategoria.entries()]
+        .map(([categoria, v]) => ({
+          Categoría: categoria,
+          Productos: v.productos,
+          Unidades: v.unidades,
+          'Valuación promedio': v.promedio,
+          'Valuación reposición': v.reposicion,
+          Diferencia: v.reposicion - v.promedio,
+        }))
+        .sort((a, b) => b['Valuación promedio'] - a['Valuación promedio']);
+
+      const { createMultiSheetExcel } = await import('../../../utils/excel');
+      await createMultiSheetExcel(
+        [
+          { name: 'Info', data: meta, columnWidths: [34, 26] },
+          { name: 'Por categoría', data: categoriasFilas, columnWidths: [28, 11, 11, 20, 20, 16] },
+          { name: 'Detalle', data: filas, columnWidths: [40, 24, 18, 9, 16, 17, 14, 20, 20, 16] },
+        ],
+        `valuacion-inventario-${nombreSucursal}-${data.meta.generado_at.slice(0, 10)}`.replace(/\s+/g, '_')
+      );
+    } finally {
+      setExportando(false);
+    }
+  };
+
   if (isLoading) return <LoadingSpinner />;
   if (error) {
     return (
@@ -59,6 +141,21 @@ export function ReporteValuacionInventario({
 
   return (
     <div className="space-y-4">
+      <div className="flex justify-end">
+        <button
+          onClick={exportar}
+          disabled={exportando || productosFiltrados.length === 0}
+          className="flex items-center gap-2 px-3 py-2 bg-green-600 text-white rounded-lg hover:bg-green-700 disabled:opacity-50 text-sm transition-colors"
+        >
+          {exportando ? (
+            <Loader2 className="w-4 h-4 animate-spin" />
+          ) : (
+            <Download className="w-4 h-4" />
+          )}
+          Exportar a Excel
+        </button>
+      </div>
+
       {/* KPIs */}
       <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
         <div className="bg-blue-50 dark:bg-blue-900/20 p-4 rounded-lg">
@@ -121,6 +218,7 @@ export function ReporteValuacionInventario({
       <div className="flex flex-wrap gap-3">
         {data.sucursales.length > 1 && (
           <select
+            aria-label="Sucursal"
             value={sucursalFiltro}
             onChange={(e) => setSucursalFiltro(e.target.value === 'todas' ? 'todas' : Number(e.target.value))}
             className="px-3 py-2 border dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 text-sm text-gray-900 dark:text-white"
@@ -132,6 +230,7 @@ export function ReporteValuacionInventario({
           </select>
         )}
         <select
+          aria-label="Categoría"
           value={categoriaFiltro}
           onChange={(e) => setCategoriaFiltro(e.target.value)}
           className="px-3 py-2 border dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 text-sm text-gray-900 dark:text-white"

--- a/src/components/vistas/reportes/ReporteVentasZonas.tsx
+++ b/src/components/vistas/reportes/ReporteVentasZonas.tsx
@@ -6,8 +6,8 @@
  * viaje. Antes esta pestaña agregaba en el navegador y arrastraba los mismos
  * dos bugs que la de clientes (contaba cancelados y se cortaba en 1.000 filas).
  */
-import React from 'react';
-import { MapPin } from 'lucide-react';
+import React, { useState } from 'react';
+import { MapPin, Download, Loader2 } from 'lucide-react';
 import LoadingSpinner from '../../layout/LoadingSpinner';
 import { useVentasPorClienteQuery } from '../../../hooks/queries/useVentasPorClienteQuery';
 
@@ -25,6 +25,33 @@ export function ReporteVentasZonas({
   formatPrecio,
 }: ReporteVentasZonasProps): React.ReactElement {
   const { data, isLoading, error } = useVentasPorClienteQuery(desde, hasta, preventistaId);
+  const [exportando, setExportando] = useState(false);
+
+  // Mismo contenido que la hoja "Por zona" del export de "Por Cliente": es el
+  // mismo hook y la misma cache. Se repite acá porque quien está mirando esta
+  // pestaña no tiene por qué saber que el otro reporte se lo lleva de regalo.
+  const exportar = async (): Promise<void> => {
+    if (!data) return;
+    setExportando(true);
+    try {
+      const porZona = data.zonas.map((z) => ({
+        Zona: z.zona,
+        Clientes: z.clientes,
+        Pedidos: z.pedidos,
+        Total: z.total,
+        '% del total': data.totales.total ? z.total / data.totales.total : 0,
+        'Ticket promedio': z.ticket_promedio,
+      }));
+
+      const { createMultiSheetExcel } = await import('../../../utils/excel');
+      await createMultiSheetExcel(
+        [{ name: 'Por zona', data: porZona, columnWidths: [24, 10, 10, 15, 12, 15] }],
+        `ventas-por-zona-${data.meta.preventista_nombre}-${desde}_${hasta}`.replace(/\s+/g, '_')
+      );
+    } finally {
+      setExportando(false);
+    }
+  };
 
   if (isLoading) return <LoadingSpinner />;
 
@@ -48,7 +75,23 @@ export function ReporteVentasZonas({
   const { totales, zonas } = data;
 
   return (
-    <div className="bg-white dark:bg-gray-800 border dark:border-gray-700 rounded-lg overflow-x-auto">
+    <div className="space-y-3">
+      <div className="flex justify-end">
+        <button
+          onClick={exportar}
+          disabled={exportando}
+          className="flex items-center gap-2 px-3 py-2 bg-green-600 text-white rounded-lg hover:bg-green-700 disabled:opacity-50 text-sm transition-colors"
+        >
+          {exportando ? (
+            <Loader2 className="w-4 h-4 animate-spin" />
+          ) : (
+            <Download className="w-4 h-4" />
+          )}
+          Exportar a Excel
+        </button>
+      </div>
+
+      <div className="bg-white dark:bg-gray-800 border dark:border-gray-700 rounded-lg overflow-x-auto">
       <table className="w-full">
         <thead className="bg-gray-50 dark:bg-gray-700/50">
           <tr>
@@ -111,6 +154,7 @@ export function ReporteVentasZonas({
           </tr>
         </tfoot>
       </table>
+      </div>
     </div>
   );
 }

--- a/src/components/vistas/reportes/__tests__/ReporteCuentasPorCobrar.test.tsx
+++ b/src/components/vistas/reportes/__tests__/ReporteCuentasPorCobrar.test.tsx
@@ -1,0 +1,166 @@
+/**
+ * El export de "Cuentas por Cobrar".
+ *
+ * Las filas tienen dos niveles anidados —`cliente` y `aging`— y el Excel es
+ * plano, así que lo que se verifica es el aplanado.
+ *
+ * Componente importado directo (ver #514).
+ */
+import '@testing-library/jest-dom/vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+interface HojaExcel {
+  name: string;
+  data: Record<string, unknown>[];
+  columnWidths?: number[];
+}
+
+const mockCrearExcel = vi.fn<(hojas: HojaExcel[], filename: string) => Promise<void>>(() =>
+  Promise.resolve()
+);
+
+vi.mock('../../../../utils/excel', () => ({
+  createMultiSheetExcel: (hojas: HojaExcel[], filename: string) => mockCrearExcel(hojas, filename),
+}));
+
+vi.mock('../../../layout/LoadingSpinner', () => ({
+  default: () => <div>cargando…</div>,
+}));
+
+import { ReporteCuentasPorCobrar } from '../ReporteCuentasPorCobrar';
+
+const formatPrecio = (n: number): string => `$${n.toLocaleString('es-AR')}`;
+
+const reporte = [
+  {
+    cliente: {
+      id: '1', nombre_fantasia: 'Kiosco Luna', razon_social: 'Luna SRL',
+      zona: 'ZONA 4', cuit: '30-1234-5', telefono: '381-555', activo: true,
+    },
+    totalDeuda: 10000, totalPagado: 4000, saldoPendiente: 6000,
+    limiteCredito: 8000, creditoDisponible: 2000, pedidosPendientes: 3,
+    aging: { corriente: 1000, vencido30: 2000, vencido60: 1500, vencido90: 1500 },
+  },
+  {
+    // Cliente dado de baja: para un informe histórico TIENE que seguir
+    // apareciendo, es de lo que se trata la baja lógica.
+    cliente: {
+      id: '2', nombre_fantasia: 'Almacén Sur', razon_social: null,
+      zona: null, cuit: null, telefono: null, activo: false,
+    },
+    totalDeuda: 5000, totalPagado: 0, saldoPendiente: 5000,
+    limiteCredito: 0, creditoDisponible: -5000, pedidosPendientes: 1,
+    aging: { corriente: 0, vencido30: 0, vencido60: 0, vencido90: 5000 },
+  },
+];
+
+function renderReporte(filas = reporte) {
+  return render(
+    <ReporteCuentasPorCobrar
+      reporte={filas as never}
+      loading={false}
+      formatPrecio={formatPrecio}
+    />
+  );
+}
+
+describe('ReporteCuentasPorCobrar › export', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('exporta el resumen de aging y el detalle por cliente', async () => {
+    const user = userEvent.setup();
+    renderReporte();
+
+    await user.click(screen.getByRole('button', { name: /Exportar a Excel/i }));
+
+    const [hojas] = mockCrearExcel.mock.calls[0];
+    expect(hojas.map((h) => h.name)).toEqual(['Resumen aging', 'Por cliente']);
+  });
+
+  it('aplana cliente y aging a columnas', async () => {
+    const user = userEvent.setup();
+    renderReporte();
+
+    await user.click(screen.getByRole('button', { name: /Exportar a Excel/i }));
+
+    const [hojas] = mockCrearExcel.mock.calls[0];
+    expect(hojas[1].data[0]).toEqual({
+      Cliente: 'Kiosco Luna',
+      'Razón social': 'Luna SRL',
+      Zona: 'ZONA 4',
+      CUIT: '30-1234-5',
+      Teléfono: '381-555',
+      Activo: 'Sí',
+      'Total facturado': 10000,
+      Pagado: 4000,
+      Saldo: 6000,
+      Corriente: 1000,
+      '1-30 días': 2000,
+      '31-60 días': 1500,
+      '+60 días': 1500,
+      'Límite de crédito': 8000,
+      'Crédito disponible': 2000,
+      'Pedidos pendientes': 3,
+    });
+  });
+
+  it('los clientes dados de baja siguen en el informe', async () => {
+    // Un reporte de deuda que esconde al que debe y ya no opera no sirve para
+    // cobrarle. La baja lógica existe justamente para que el historial lo siga
+    // viendo.
+    const user = userEvent.setup();
+    renderReporte();
+
+    await user.click(screen.getByRole('button', { name: /Exportar a Excel/i }));
+
+    const [hojas] = mockCrearExcel.mock.calls[0];
+    expect(hojas[1].data).toHaveLength(2);
+    expect(hojas[1].data[1]).toMatchObject({ Cliente: 'Almacén Sur', Activo: 'No', Saldo: 5000 });
+  });
+
+  it('los campos vacíos van en blanco, no como "null"', async () => {
+    const user = userEvent.setup();
+    renderReporte();
+
+    await user.click(screen.getByRole('button', { name: /Exportar a Excel/i }));
+
+    const [hojas] = mockCrearExcel.mock.calls[0];
+    expect(hojas[1].data[1]).toMatchObject({ 'Razón social': '', CUIT: '', Teléfono: '' });
+    expect(hojas[1].data[1].Zona).toBe('Sin zona');
+  });
+
+  it('el resumen suma cada tramo de aging y cierra con el total', async () => {
+    const user = userEvent.setup();
+    renderReporte();
+
+    await user.click(screen.getByRole('button', { name: /Exportar a Excel/i }));
+
+    const [hojas] = mockCrearExcel.mock.calls[0];
+    expect(hojas[0].data).toEqual([
+      { Tramo: 'Corriente', Monto: 1000, Clientes: 1 },
+      { Tramo: '1-30 días', Monto: 2000, Clientes: 1 },
+      { Tramo: '31-60 días', Monto: 1500, Clientes: 1 },
+      { Tramo: '+60 días', Monto: 6500, Clientes: 2 },
+      { Tramo: 'TOTAL', Monto: 11000, Clientes: 2 },
+    ]);
+  });
+
+  it('el archivo se fecha con el día de hoy: la deuda es una foto, no un rango', async () => {
+    const user = userEvent.setup();
+    renderReporte();
+
+    await user.click(screen.getByRole('button', { name: /Exportar a Excel/i }));
+
+    const [, nombreArchivo] = mockCrearExcel.mock.calls[0];
+    expect(nombreArchivo).toMatch(/^cuentas-por-cobrar-\d{4}-\d{2}-\d{2}$/);
+  });
+
+  it('sin deuda el botón está deshabilitado', () => {
+    renderReporte([]);
+    expect(screen.getByRole('button', { name: /Exportar a Excel/i })).toBeDisabled();
+  });
+});

--- a/src/components/vistas/reportes/__tests__/ReportePreventistas.test.tsx
+++ b/src/components/vistas/reportes/__tests__/ReportePreventistas.test.tsx
@@ -1,0 +1,112 @@
+/** El export de "Por Preventista". Componente importado directo (ver #514). */
+import '@testing-library/jest-dom/vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import type { ComponentProps } from 'react';
+import userEvent from '@testing-library/user-event';
+
+interface HojaExcel {
+  name: string;
+  data: Record<string, unknown>[];
+  columnWidths?: number[];
+}
+
+const mockCrearExcel = vi.fn<(hojas: HojaExcel[], filename: string) => Promise<void>>(() =>
+  Promise.resolve()
+);
+
+vi.mock('../../../../utils/excel', () => ({
+  createMultiSheetExcel: (hojas: HojaExcel[], filename: string) => mockCrearExcel(hojas, filename),
+}));
+
+vi.mock('../../../layout/LoadingSpinner', () => ({
+  default: () => <div>cargando…</div>,
+}));
+
+import { ReportePreventistas } from '../ReportePreventistas';
+
+const formatPrecio = (n: number): string => `$${n.toLocaleString('es-AR')}`;
+
+const filas = [
+  { id: 'u1', nombre: 'Christian', email: 'chris@x.com', totalVentas: 4000, cantidadPedidos: 9, totalPagado: 3000, totalPendiente: 1000 },
+  { id: 'u2', nombre: 'Marcelo', email: 'marce@x.com', totalVentas: 1000, cantidadPedidos: 3, totalPagado: 1000, totalPendiente: 0 },
+];
+
+function renderReporte(props: Partial<ComponentProps<typeof ReportePreventistas>> = {}) {
+  return render(
+    <ReportePreventistas
+      reportePreventistas={filas as never}
+      loading={false}
+      formatPrecio={formatPrecio}
+      desde="2026-06-01"
+      hasta="2026-08-20"
+      {...props}
+    />
+  );
+}
+
+describe('ReportePreventistas › export', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('exporta una hoja con las ventas, lo pagado y lo pendiente', async () => {
+    const user = userEvent.setup();
+    renderReporte();
+
+    await user.click(screen.getByRole('button', { name: /Exportar a Excel/i }));
+
+    const [hojas, nombreArchivo] = mockCrearExcel.mock.calls[0];
+    expect(hojas.map((h) => h.name)).toEqual(['Por preventista']);
+    expect(hojas[0].data[0]).toMatchObject({
+      Preventista: 'Christian',
+      Email: 'chris@x.com',
+      'Total ventas': 4000,
+      Pedidos: 9,
+      Pagado: 3000,
+      Pendiente: 1000,
+    });
+    expect(nombreArchivo).toBe('ventas-por-preventista-2026-06-01_2026-08-20');
+  });
+
+  it('la última fila es el TOTAL, igual que el pie de la tabla', async () => {
+    const user = userEvent.setup();
+    renderReporte();
+
+    await user.click(screen.getByRole('button', { name: /Exportar a Excel/i }));
+
+    const [hojas] = mockCrearExcel.mock.calls[0];
+    expect(hojas[0].data[hojas[0].data.length - 1]).toMatchObject({
+      Preventista: 'TOTAL',
+      'Total ventas': 5000,
+      Pedidos: 12,
+      Pagado: 4000,
+      Pendiente: 1000,
+    });
+  });
+
+  it('sin filtro de fecha el archivo dice "todo", no un rango inventado', async () => {
+    const user = userEvent.setup();
+    renderReporte({ desde: '', hasta: '' });
+
+    await user.click(screen.getByRole('button', { name: /Exportar a Excel/i }));
+
+    const [, nombreArchivo] = mockCrearExcel.mock.calls[0];
+    expect(nombreArchivo).toBe('ventas-por-preventista-todo');
+  });
+
+  it('con media fecha el archivo dice cuál falta, no la inventa', async () => {
+    const user = userEvent.setup();
+    renderReporte({ desde: '2026-06-01', hasta: '' });
+
+    await user.click(screen.getByRole('button', { name: /Exportar a Excel/i }));
+
+    const [, nombreArchivo] = mockCrearExcel.mock.calls[0];
+    expect(nombreArchivo).toBe('ventas-por-preventista-2026-06-01_hoy');
+  });
+
+  it('sin datos no hay botón que apretar', () => {
+    renderReporte({ reportePreventistas: [] });
+    expect(screen.queryByRole('button', { name: /Exportar a Excel/i })).not.toBeInTheDocument();
+  });
+});

--- a/src/components/vistas/reportes/__tests__/ReporteRentabilidad.test.tsx
+++ b/src/components/vistas/reportes/__tests__/ReporteRentabilidad.test.tsx
@@ -1,0 +1,144 @@
+/** El export de "Rentabilidad". Componente importado directo (ver #514). */
+import '@testing-library/jest-dom/vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import type { ComponentProps } from 'react';
+import userEvent from '@testing-library/user-event';
+
+interface HojaExcel {
+  name: string;
+  data: Record<string, unknown>[];
+  columnWidths?: number[];
+}
+
+const mockCrearExcel = vi.fn<(hojas: HojaExcel[], filename: string) => Promise<void>>(() =>
+  Promise.resolve()
+);
+
+vi.mock('../../../../utils/excel', () => ({
+  createMultiSheetExcel: (hojas: HojaExcel[], filename: string) => mockCrearExcel(hojas, filename),
+}));
+
+vi.mock('../../../layout/LoadingSpinner', () => ({
+  default: () => <div>cargando…</div>,
+}));
+
+import { ReporteRentabilidadSection } from '../ReporteRentabilidad';
+
+const formatPrecio = (n: number): string => `$${n.toLocaleString('es-AR')}`;
+
+function producto(i: number) {
+  return {
+    id: `p${i}`,
+    nombre: `Producto ${i}`,
+    codigo: `C${i}`,
+    cantidadVendida: 10,
+    ingresos: 1000 - i,
+    costos: 600,
+    margen: 400 - i,
+    margenPorcentaje: 40,
+  };
+}
+
+function reporte(cantidadProductos = 3) {
+  return {
+    productos: Array.from({ length: cantidadProductos }, (_, i) => producto(i)),
+    totales: {
+      ingresosTotales: 3000,
+      costosTotales: 1800,
+      margenTotal: 1200,
+      cantidadPedidos: 25,
+      margenPorcentaje: 40,
+      ventasBrutas: 3630,
+      ivaDiscriminado: 630,
+      impuestosInternos: 0,
+      ventasNetas: 3000,
+    },
+  };
+}
+
+function renderReporte(props: Partial<ComponentProps<typeof ReporteRentabilidadSection>> = {}) {
+  return render(
+    <ReporteRentabilidadSection
+      reporte={reporte() as never}
+      loading={false}
+      formatPrecio={formatPrecio}
+      desde="2026-06-01"
+      hasta="2026-08-20"
+      {...props}
+    />
+  );
+}
+
+describe('ReporteRentabilidad › export', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('exporta el resumen fiscal y el detalle por producto', async () => {
+    const user = userEvent.setup();
+    renderReporte();
+
+    await user.click(screen.getByRole('button', { name: /Exportar a Excel/i }));
+
+    const [hojas, nombreArchivo] = mockCrearExcel.mock.calls[0];
+    expect(hojas[0].name).toBe('Resumen');
+    expect(hojas[1].name).toBe('Productos (todos, 3)');
+    expect(nombreArchivo).toBe('rentabilidad-2026-06-01_2026-08-20');
+
+    expect(hojas[1].data[0]).toMatchObject({
+      '#': 1,
+      Producto: 'Producto 0',
+      Código: 'C0',
+      Vendido: 10,
+      Ingresos: 1000,
+      Costos: 600,
+      Margen: 400,
+    });
+  });
+
+  it('el resumen lleva el desglose fiscal, que en la tabla no está', async () => {
+    const user = userEvent.setup();
+    renderReporte();
+
+    await user.click(screen.getByRole('button', { name: /Exportar a Excel/i }));
+
+    const [hojas] = mockCrearExcel.mock.calls[0];
+    const porConcepto = Object.fromEntries(
+      hojas[0].data.map((f) => [f.Concepto, f.Monto])
+    );
+    expect(porConcepto['Ventas brutas']).toBe(3630);
+    expect(porConcepto['IVA discriminado']).toBe(630);
+    expect(porConcepto['Ventas netas']).toBe(3000);
+    expect(porConcepto['Margen']).toBe(1200);
+  });
+
+  // El bug que este export podría haber tenido: la tabla muestra 20 y el
+  // archivo tiene que llevar todos, con el nombre de la hoja diciéndolo.
+  it('el Excel lleva TODOS los productos, no los 20 de la pantalla', async () => {
+    const user = userEvent.setup();
+    renderReporte({ reporte: reporte(45) as never });
+
+    await user.click(screen.getByRole('button', { name: /Exportar a Excel/i }));
+
+    const [hojas] = mockCrearExcel.mock.calls[0];
+    expect(hojas[1].data).toHaveLength(45);
+    expect(hojas[1].name).toBe('Productos (todos, 45)');
+  });
+
+  it('la pantalla avisa que muestra menos filas que el archivo', () => {
+    renderReporte({ reporte: reporte(45) as never });
+    expect(screen.getByText(/Se muestran los 20 de mayor margen/i)).toBeInTheDocument();
+    expect(screen.getByText(/El Excel lleva los 45/i)).toBeInTheDocument();
+  });
+
+  it('con 20 productos o menos no avisa nada', () => {
+    renderReporte({ reporte: reporte(20) as never });
+    expect(screen.queryByText(/El Excel lleva los/i)).not.toBeInTheDocument();
+  });
+
+  it('sin productos el botón está deshabilitado', () => {
+    renderReporte({ reporte: reporte(0) as never });
+    expect(screen.getByRole('button', { name: /Exportar a Excel/i })).toBeDisabled();
+  });
+});

--- a/src/components/vistas/reportes/__tests__/ReporteValuacionInventario.test.tsx
+++ b/src/components/vistas/reportes/__tests__/ReporteValuacionInventario.test.tsx
@@ -1,0 +1,176 @@
+/**
+ * El export de "Valuación de Stock".
+ *
+ * Lo que más importa acá: el filtrado de esta pestaña es EN CLIENTE, así que un
+ * export que mandara `data.productos` crudo ignoraría los filtros que el usuario
+ * tiene puestos y el archivo no coincidiría con lo que está mirando.
+ *
+ * Componente importado directo (ver #514).
+ */
+import '@testing-library/jest-dom/vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+interface HojaExcel {
+  name: string;
+  data: Record<string, unknown>[];
+  columnWidths?: number[];
+}
+
+const mockUseQuery = vi.fn();
+const mockCrearExcel = vi.fn<(hojas: HojaExcel[], filename: string) => Promise<void>>(() =>
+  Promise.resolve()
+);
+
+vi.mock('../../../../hooks/queries/useValuacionInventarioQuery', () => ({
+  useValuacionInventarioQuery: () => mockUseQuery(),
+}));
+
+vi.mock('../../../../utils/excel', () => ({
+  createMultiSheetExcel: (hojas: HojaExcel[], filename: string) => mockCrearExcel(hojas, filename),
+}));
+
+vi.mock('../../../layout/LoadingSpinner', () => ({
+  default: () => <div>cargando…</div>,
+}));
+
+import { ReporteValuacionInventario } from '../ReporteValuacionInventario';
+
+const formatPrecio = (n: number): string => `$${n.toLocaleString('es-AR')}`;
+
+function datos() {
+  return {
+    meta: {
+      sucursal_id: null,
+      sucursal_nombre: 'Red',
+      generado_at: '2026-09-07T15:00:00Z',
+      criterio: 'Stock a costo promedio ponderado',
+    },
+    totales: { productos: 3, unidades: 60, valuacion_promedio: 6000, valuacion_reposicion: 6600, diferencia: 600 },
+    sucursales: [
+      { sucursal_id: 1, sucursal_nombre: 'Tucuman', productos: 2, unidades: 40, valuacion_promedio: 4000, valuacion_reposicion: 4400 },
+      { sucursal_id: 2, sucursal_nombre: 'Taco Pozo', productos: 1, unidades: 20, valuacion_promedio: 2000, valuacion_reposicion: 2200 },
+    ],
+    categorias: [
+      { categoria: 'Bebidas', productos: 2, unidades: 40, valuacion_promedio: 4000, valuacion_reposicion: 4400, diferencia: 400 },
+      { categoria: 'Snacks', productos: 1, unidades: 20, valuacion_promedio: 2000, valuacion_reposicion: 2200, diferencia: 200 },
+    ],
+    productos: [
+      { producto_id: 1, nombre: 'Coca 2L', categoria: 'Bebidas', sucursal_id: 1, sucursal_nombre: 'Tucuman', stock: 20, costo_promedio: 100, costo_reposicion: 110, ultimo_tipo_compra: 'FC', valuacion_promedio: 2000, valuacion_reposicion: 2200, diferencia: 200 },
+      { producto_id: 2, nombre: 'Agua 500', categoria: 'Bebidas', sucursal_id: 1, sucursal_nombre: 'Tucuman', stock: 20, costo_promedio: 100, costo_reposicion: 110, ultimo_tipo_compra: 'FC', valuacion_promedio: 2000, valuacion_reposicion: 2200, diferencia: 200 },
+      { producto_id: 3, nombre: 'Papas', categoria: 'Snacks', sucursal_id: 2, sucursal_nombre: 'Taco Pozo', stock: 20, costo_promedio: 100, costo_reposicion: 110, ultimo_tipo_compra: 'ZZ', valuacion_promedio: 2000, valuacion_reposicion: 2200, diferencia: 200 },
+    ],
+    calidad_datos: { stock_negativo: 1, sin_costo: 2, detalle_stock_negativo: [] },
+  };
+}
+
+function renderReporte() {
+  mockUseQuery.mockReturnValue({ data: datos(), isLoading: false, error: null });
+  return render(<ReporteValuacionInventario formatPrecio={formatPrecio} />);
+}
+
+async function exportar(user: ReturnType<typeof userEvent.setup>) {
+  await user.click(screen.getByRole('button', { name: /Exportar a Excel/i }));
+  return mockCrearExcel.mock.calls[0];
+}
+
+describe('ReporteValuacionInventario › export', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('exporta tres hojas: metadatos, categorías y detalle', async () => {
+    const user = userEvent.setup();
+    renderReporte();
+
+    const [hojas, nombreArchivo] = await exportar(user);
+
+    expect(hojas.map((h) => h.name)).toEqual(['Info', 'Por categoría', 'Detalle']);
+    expect(nombreArchivo).toBe('valuacion-inventario-Todas-2026-09-07');
+    expect(hojas[2].data[0]).toMatchObject({
+      Producto: 'Coca 2L',
+      Categoría: 'Bebidas',
+      Sucursal: 'Tucuman',
+      Stock: 20,
+      'Costo promedio': 100,
+      'Costo reposición': 110,
+      'Última compra': 'FC',
+      'Valuación promedio': 2000,
+    });
+  });
+
+  it('respeta el filtro de sucursal que el usuario tiene puesto', async () => {
+    const user = userEvent.setup();
+    renderReporte();
+
+    await user.selectOptions(screen.getByRole('combobox', { name: 'Sucursal' }), '2');
+    const [hojas, nombreArchivo] = await exportar(user);
+
+    // Sólo el producto de Taco Pozo, no los tres.
+    expect(hojas[2].data).toHaveLength(1);
+    expect(hojas[2].data[0]).toMatchObject({ Producto: 'Papas', Sucursal: 'Taco Pozo' });
+    expect(nombreArchivo).toBe('valuacion-inventario-Taco_Pozo-2026-09-07');
+  });
+
+  it('respeta el filtro de categoría', async () => {
+    const user = userEvent.setup();
+    renderReporte();
+
+    await user.selectOptions(screen.getByRole('combobox', { name: 'Categoría' }), 'Snacks');
+    const [hojas] = await exportar(user);
+
+    expect(hojas[2].data).toHaveLength(1);
+    expect(hojas[2].data[0]).toMatchObject({ Producto: 'Papas' });
+  });
+
+  it('la hoja de metadatos deja escrito qué filtro estaba aplicado', async () => {
+    const user = userEvent.setup();
+    renderReporte();
+
+    await user.selectOptions(screen.getByRole('combobox', { name: 'Categoría' }), 'Snacks');
+    const [hojas] = await exportar(user);
+    const info = Object.fromEntries(hojas[0].data.map((f) => [f.Campo, f.Valor]));
+
+    // Fuera de la app nadie puede saber si el archivo es de todo o de una parte.
+    expect(info['Categoría (filtro aplicado)']).toBe('Snacks');
+    expect(info['Sucursal (filtro aplicado)']).toBe('Todas');
+    expect(info['Productos en este archivo']).toBe(1);
+    expect(info['Productos en el reporte completo']).toBe(3);
+    expect(info['Productos con stock negativo']).toBe(1);
+    expect(info['Productos sin costo']).toBe(2);
+  });
+
+  it('los totales de la hoja Info son los del filtro, no los globales', async () => {
+    const user = userEvent.setup();
+    renderReporte();
+
+    await user.selectOptions(screen.getByRole('combobox', { name: 'Categoría' }), 'Snacks');
+    const [hojas] = await exportar(user);
+    const info = Object.fromEntries(hojas[0].data.map((f) => [f.Campo, f.Valor]));
+
+    expect(info['Valuación a costo promedio']).toBe(2000);
+    expect(info['Unidades']).toBe(20);
+  });
+
+  // Las categorías que devuelve el RPC son globales: con un filtro puesto no
+  // cuadrarían con el detalle del mismo archivo.
+  it('el resumen por categoría se recalcula sobre lo filtrado', async () => {
+    const user = userEvent.setup();
+    renderReporte();
+
+    await user.selectOptions(screen.getByRole('combobox', { name: 'Sucursal' }), '1');
+    const [hojas] = await exportar(user);
+
+    expect(hojas[1].data).toEqual([
+      {
+        Categoría: 'Bebidas',
+        Productos: 2,
+        Unidades: 40,
+        'Valuación promedio': 4000,
+        'Valuación reposición': 4400,
+        Diferencia: 400,
+      },
+    ]);
+  });
+});

--- a/src/components/vistas/reportes/__tests__/ReporteVentasZonas.test.tsx
+++ b/src/components/vistas/reportes/__tests__/ReporteVentasZonas.test.tsx
@@ -1,0 +1,125 @@
+/**
+ * El export de "Por Zona".
+ *
+ * El componente se importa DIRECTO, no por ReportesContainer: los reportes son
+ * lazy y un test que va por el container paga el `import()` del chunk en su
+ * primera prueba, que es el flake del PR #514.
+ */
+import '@testing-library/jest-dom/vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+interface HojaExcel {
+  name: string;
+  data: Record<string, unknown>[];
+  columnWidths?: number[];
+}
+
+const mockUseQuery = vi.fn();
+const mockCrearExcel = vi.fn<(hojas: HojaExcel[], filename: string) => Promise<void>>(() =>
+  Promise.resolve()
+);
+
+vi.mock('../../../../hooks/queries/useVentasPorClienteQuery', () => ({
+  useVentasPorClienteQuery: (desde: string, hasta: string, preventistaId: string | null) =>
+    mockUseQuery(desde, hasta, preventistaId),
+}));
+
+vi.mock('../../../../utils/excel', () => ({
+  createMultiSheetExcel: (hojas: HojaExcel[], filename: string) => mockCrearExcel(hojas, filename),
+}));
+
+vi.mock('../../../layout/LoadingSpinner', () => ({
+  default: () => <div>cargando…</div>,
+}));
+
+import { ReporteVentasZonas } from '../ReporteVentasZonas';
+
+const formatPrecio = (n: number): string => `$${n.toLocaleString('es-AR')}`;
+
+function datos() {
+  return {
+    meta: {
+      desde: '2026-06-01',
+      hasta: '2026-08-20',
+      preventista_id: null,
+      preventista_nombre: 'Todos',
+      sucursal_id: 1,
+      sucursal_nombre: 'Tucuman',
+      generado_at: '2026-08-20T17:00:00Z',
+      criterio: 'Pedidos entregados…',
+    },
+    meses: ['2026-06'],
+    vendedores: [],
+    totales: { clientes: 3, pedidos: 12, total: 5000 },
+    clientes: [],
+    zonas: [
+      { zona: 'ZONA 4 CHRISTIAN', clientes: 2, pedidos: 9, total: 4000, ticket_promedio: 444.44 },
+      { zona: 'SIN ZONA', clientes: 1, pedidos: 3, total: 1000, ticket_promedio: 333.33 },
+    ],
+  };
+}
+
+function renderReporte() {
+  return render(
+    <ReporteVentasZonas
+      desde="2026-06-01"
+      hasta="2026-08-20"
+      preventistaId={null}
+      formatPrecio={formatPrecio}
+    />
+  );
+}
+
+describe('ReporteVentasZonas › export', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('exporta una hoja con la zona, el volumen y el ticket promedio', async () => {
+    const user = userEvent.setup();
+    mockUseQuery.mockReturnValue({ data: datos(), isLoading: false, error: null });
+    renderReporte();
+
+    await user.click(screen.getByRole('button', { name: /Exportar a Excel/i }));
+
+    expect(mockCrearExcel).toHaveBeenCalledTimes(1);
+    const [hojas, nombreArchivo] = mockCrearExcel.mock.calls[0];
+
+    expect(hojas.map((h) => h.name)).toEqual(['Por zona']);
+    expect(hojas[0].data[0]).toMatchObject({
+      Zona: 'ZONA 4 CHRISTIAN',
+      Clientes: 2,
+      Pedidos: 9,
+      Total: 4000,
+      'Ticket promedio': 444.44,
+    });
+    // Fracción, no porcentaje: el 0-1 lo formatea Excel como %.
+    expect(hojas[0].data[0]['% del total']).toBeCloseTo(0.8);
+
+    expect(nombreArchivo).toBe('ventas-por-zona-Todos-2026-06-01_2026-08-20');
+  });
+
+  it('el nombre del archivo dice de qué preventista es, sin espacios', async () => {
+    const user = userEvent.setup();
+    const d = datos();
+    d.meta.preventista_nombre = 'Christian Perez';
+    mockUseQuery.mockReturnValue({ data: d, isLoading: false, error: null });
+    renderReporte();
+
+    await user.click(screen.getByRole('button', { name: /Exportar a Excel/i }));
+
+    const [, nombreArchivo] = mockCrearExcel.mock.calls[0];
+    expect(nombreArchivo).toBe('ventas-por-zona-Christian_Perez-2026-06-01_2026-08-20');
+  });
+
+  it('sin ventas no hay botón que apretar', () => {
+    const d = datos();
+    d.zonas = [];
+    mockUseQuery.mockReturnValue({ data: d, isLoading: false, error: null });
+    renderReporte();
+
+    expect(screen.queryByRole('button', { name: /Exportar a Excel/i })).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
`/reportes` tenía seis pestañas y exportaba una. Ahora exportan las seis.

Un botón por reporte, dentro de la vista que ya tiene los datos en memoria, siguiendo el patrón vivo de los otros seis sitios que exportan: import **dinámico** de `utils/excel` justo antes de usar, estado local `exportando` con `try/finally`, filas inline como `Record` donde la clave castellana es el header, filename sin extensión. Sin componente compartido de botón: no existe en el repo y crearlo sería refactor de paso.

Verificado en el build que **exceljs sigue aislado en `lib-excel` (916K)** y no se coló en ningún chunk de reportes.

## Lo que exporta cada una

**Por Zona** — 1 hoja. Es el mismo contenido que la hoja "Por zona" del export de Por Cliente (mismo hook, misma caché), pero quien está parado en esta pestaña no tiene por qué saber que el otro reporte se lo lleva de regalo.

**Por Preventista** — 1 hoja, con la fila TOTAL adentro. Está en la pantalla, y un archivo que no la trae obliga a rehacer la suma para confirmar que es el mismo reporte.

**Rentabilidad** — 2 hojas. La tabla muestra 20 productos y **el Excel lleva todos**; el nombre de la hoja dice cuántos son, y la pantalla ahora avisa que el archivo trae más filas que la tabla. La segunda hoja es el desglose fiscal (bruto, IVA, impuestos internos, neto), que vive en las tarjetas de arriba y no en la tabla: sin esa hoja el Excel perdía justo lo que separa la venta bruta del ingreso real.

**Valuación de Stock** — 3 hojas. El filtrado de esta pestaña es **en cliente**, así que exportar `data.productos` crudo habría ignorado los filtros que el usuario tiene puestos y el archivo no coincidiría con lo que está mirando. Van los filtrados, y el filtro aplicado queda escrito en una hoja de metadatos: fuera de la app nadie puede saber si el archivo es de una sucursal o de todas. El resumen por categoría se **recalcula** sobre lo filtrado, porque el del RPC es global y con un filtro puesto no cuadraría con el detalle del mismo archivo.

**Cuentas por Cobrar** — 2 hojas. `cliente` y `aging` vienen anidados y el Excel es plano, así que se aplanan a columnas. Los **clientes dados de baja siguen en el informe** a propósito: un reporte de deuda que esconde al que debe y ya no opera no sirve para cobrarle, que es de lo que se trata la baja lógica. El archivo se fecha con hoy y no con un rango: la cuenta corriente es una foto, no un período.

## De paso

Los dos `<select>` de filtro de Valuación no tenían nombre accesible — un lector de pantalla los anunciaba como "combobox" a secas. Con `aria-label`, además, el test asserta sobre significado en vez de sobre el índice del elemento.

## Tests

Uno por reporte, **28 casos**, importando el componente **directo** y no por el container: los reportes son lazy y por el container la primera prueba paga el `import()` del chunk, que es el flake del PR #514. Nunca se ejercita exceljs de verdad.

Verificado que muerden: exportando los productos crudos en Valuación y sólo los 20 de pantalla en Rentabilidad caen 3.

`typecheck`, `lint`, `test:run` (112 archivos / 1503 tests, sin `.env`) y `build`: los cuatro en verde.

## ⚠️ Aviso: tres de estos reportes ya muestran números truncados

> **Corregido después del merge.** La versión original de este aviso decía que Cuentas por Cobrar *sobreestima* la deuda. **Es al revés: la subestima y omite deudores**, y el problema de fondo no es el truncado sino el cálculo. Se corrigió acá y en #521, porque "sobreestima" invita a perdonar deuda que existe.

Preexistente, no se toca acá — pero ahora esos números **salen del sistema como archivo**. Medido en prod:

| Consulta | Filas | ¿Trunca en 1.000? |
|---|---|---|
| `pagos` (Cuentas por Cobrar, sin filtro) | 5.317 | Sí |
| `pedidos` no cancelados (Rentabilidad) | 5.254 | Sí |
| `pedidos` con items (**Por Preventista**) | 5.258 | Sí — y **1.064 con un solo mes puesto**, así que trunca igual con filtro |

**Por Preventista también está afectado**, cosa que la versión original de este aviso no decía.

**Cuentas por Cobrar** tiene además un bug de cálculo más grave que el truncado: `totalDeuda` suma sólo los pedidos impagos pero `totalPagado` suma **todos** los pagos históricos del cliente — $10,4M contra $193,5M. El saldo sale masivamente negativo, y como hay un `.filter(saldo > 0)` al final, esos clientes **desaparecen de la lista** en vez de mostrarse en negativo. El reporte real son $8.756.340 y 109 clientes; hoy se ve un subconjunto arbitrario según qué pagos entraron en las 1.000 filas.

Corolario: **arreglar sólo la paginación empeoraría el reporte**, de 109 clientes a ~4. Primero va el cálculo. El detalle y el orden correcto, en #521.

El aging **no** está afectado: usa `total − monto_pagado` por pedido, no la suma de pagos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
