### PR TITLE
Exportar a Excel el dashboard gerencial, bloque por bloque

### DIFF
--- a/src/components/vistas/VistaReportesGerenciales.tsx
+++ b/src/components/vistas/VistaReportesGerenciales.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useMemo, useEffect } from 'react'
 import {
-  Loader2, TrendingUp, Percent, AlertTriangle, FileText, Building2, CalendarRange, ChevronDown, Target,
+  Loader2, TrendingUp, Percent, AlertTriangle, FileText, Building2, CalendarRange, ChevronDown, Target, Download,
 } from 'lucide-react'
 import ReactMarkdown from 'react-markdown'
 import NumberInput from '../ui/NumberInput'
@@ -14,6 +14,10 @@ import ModalMetas from './reportes-gerenciales/ModalMetas'
 import ModalAlertaDetalle from './reportes-gerenciales/ModalAlertaDetalle'
 import type { ReporteGerencial, AnalisisMensual, MetasGerenciales, Alerta, BonifPromo } from '../../hooks/queries'
 import { usePosicionFiscalQuery } from '../../hooks/queries/useReporteGerencialQuery'
+import {
+  BLOQUES_GERENCIAL, hojasDeBloque, hojasTodo, nombreArchivo,
+  type BloqueGerencial,
+} from '../../utils/exportGerencial'
 
 // Alertas cuyo detalle es una LISTA (modal). El resto hace scroll a su sección.
 const ALERTA_CON_LISTA = new Set(['cobranza_vencida', 'clientes_inactivos', 'productos_sin_costo'])
@@ -113,6 +117,36 @@ function Semaforo({ cur, meta, factor }: { cur: number; meta: number | null | un
   )
 }
 
+/**
+ * El export es FRACCIONADO: un botón por sección, no un único archivo con todo
+ * el dashboard adentro. El armado de las filas vive en `utils/exportGerencial`,
+ * con tests — acá sólo queda disparar la descarga.
+ */
+function BotonExportar({
+  onExportar, exportando, titulo, label,
+}: {
+  onExportar: () => void
+  exportando: boolean
+  titulo: string
+  label?: string
+}): React.ReactElement {
+  return (
+    <button
+      type="button"
+      onClick={onExportar}
+      disabled={exportando}
+      title={titulo}
+      aria-label={titulo}
+      className="inline-flex items-center gap-1.5 px-2.5 py-1.5 rounded-lg border dark:border-gray-600 bg-white dark:bg-gray-800 text-xs font-semibold text-gray-600 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700 disabled:opacity-50 shrink-0"
+    >
+      {exportando
+        ? <Loader2 className="w-3.5 h-3.5 animate-spin" aria-hidden="true" />
+        : <Download className="w-3.5 h-3.5" aria-hidden="true" />}
+      {label ?? 'Excel'}
+    </button>
+  )
+}
+
 function SectionTitle({ icon: Icon, title, hint, right }: { icon: React.ElementType; title: string; hint?: string; right?: React.ReactNode }): React.ReactElement {
   return (
     <div className="flex items-start justify-between gap-3 mb-4">
@@ -203,6 +237,30 @@ export default function VistaReportesGerenciales({
     return { comision, contrib: kp.margen_neto - kp.mermas - comision }
   }, [kp, comPct, comBase, comisionCalculadaPrev])
 
+  // Export fraccionado: qué bloque se está bajando (null = ninguno).
+  const [exportando, setExportando] = useState<string | null>(null)
+
+  const exportar = async (bloqueId: string): Promise<void> => {
+    if (!reporte) return
+    setExportando(bloqueId)
+    try {
+      const bloque = BLOQUES_GERENCIAL.find(b => b.id === bloqueId)
+      const hojas = bloque ? hojasDeBloque(reporte, bloque) : hojasTodo(reporte)
+      const { createMultiSheetExcel } = await import('../../utils/excel')
+      await createMultiSheetExcel(hojas, nombreArchivo(reporte, bloqueId))
+    } finally {
+      setExportando(null)
+    }
+  }
+
+  const botonDe = (b: BloqueGerencial): React.ReactElement => (
+    <BotonExportar
+      onExportar={() => void exportar(b.id)}
+      exportando={exportando === b.id}
+      titulo={`Descargar ${b.label} en Excel`}
+    />
+  )
+
   // Bonificaciones agrupadas por promoción (subtotales + filas por producto).
   const bonifAgrupado = useMemo(() => {
     const grupos = new Map<string, { promocion: string; costo: number; valor_venta: number; items: BonifPromo[] }>()
@@ -240,6 +298,24 @@ export default function VistaReportesGerenciales({
           </p>
         </div>
         <div className="flex flex-wrap items-center gap-2">
+          {/* Export: el resumen (KPIs) y el dashboard entero. Cada sección tiene
+              además su propio botón — el export es fraccionado a propósito. */}
+          {reporte && (
+            <>
+              <BotonExportar
+                onExportar={() => void exportar('resumen')}
+                exportando={exportando === 'resumen'}
+                titulo="Descargar los KPIs del período en Excel"
+                label="Resumen"
+              />
+              <BotonExportar
+                onExportar={() => void exportar('todo')}
+                exportando={exportando === 'todo'}
+                titulo="Descargar todos los bloques del dashboard en un solo Excel"
+                label="Todo"
+              />
+            </>
+          )}
           {/* Toggle: ventas entregadas vs todos los pedidos (pendientes/en camino/entregados) */}
           <div className="flex items-center bg-white dark:bg-gray-800 border dark:border-gray-700 rounded-lg p-0.5 shadow-sm">
             {([['Entregadas', false], ['Todos', true]] as const).map(([lbl, val]) => (
@@ -388,6 +464,16 @@ export default function VistaReportesGerenciales({
           )}
 
           {/* Qué requiere tu atención */}
+          {(reporte.alertas ?? []).length > 0 && (
+            <div className="flex justify-end -mb-3">
+              <BotonExportar
+                onExportar={() => void exportar('alertas')}
+                exportando={exportando === 'alertas'}
+                titulo="Descargar las alertas del período en Excel"
+                label="Alertas a Excel"
+              />
+            </div>
+          )}
           <Alertas items={reporte.alertas ?? []} onSelect={onAlerta} />
 
           {/* Detalle completo: colapsable; los gráficos montan recién al abrir (perf) */}
@@ -444,7 +530,7 @@ export default function VistaReportesGerenciales({
 
           {/* Evolución mensual */}
           <Card id="sec-evolucion" className="p-5">
-            <SectionTitle icon={TrendingUp} title="Evolución mensual" hint="Venta, bonificaciones y margen neto por mes." />
+            <SectionTitle icon={TrendingUp} title="Evolución mensual" hint="Venta, bonificaciones y margen neto por mes." right={botonDe(BLOQUES_GERENCIAL.find(b => b.id === 'evolucion')!)} />
             <div className="grid lg:grid-cols-3 gap-5">
               <div className="lg:col-span-2 h-72"><EvolucionChart data={reporte.mensual} /></div>
               <div className="overflow-x-auto">
@@ -486,6 +572,8 @@ export default function VistaReportesGerenciales({
               icon={Percent} title="Equipo comercial y comisiones"
               hint="La comisión se recalcula en vivo."
               right={
+                <div className="flex items-center gap-2">
+                {botonDe(BLOQUES_GERENCIAL.find(b => b.id === 'vendedores')!)}
                 <div className="flex items-center gap-3 bg-gray-50 dark:bg-gray-700/40 border dark:border-gray-600 rounded-lg px-3 py-2">
                   <div className="flex items-center gap-1.5">
                     <span className="text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase">Comisión</span>
@@ -498,6 +586,7 @@ export default function VistaReportesGerenciales({
                     <option value="nc">No cancelado</option>
                     <option value="ent">Entregado</option>
                   </select>
+                </div>
                 </div>
               }
             />
@@ -545,7 +634,7 @@ export default function VistaReportesGerenciales({
 
           {/* Categorías */}
           <Card id="sec-categorias" className="p-5">
-            <SectionTitle icon={TrendingUp} title="Mezcla por categoría" hint="Venta y margen comercial. △ = margen inflado por productos sin costo." />
+            <SectionTitle icon={TrendingUp} title="Mezcla por categoría" hint="Venta y margen comercial. △ = margen inflado por productos sin costo." right={botonDe(BLOQUES_GERENCIAL.find(b => b.id === 'categorias')!)} />
             <div className="grid lg:grid-cols-3 gap-5">
               <div className="lg:col-span-2 h-80"><CategoriasChart data={reporte.categorias} /></div>
               <div className="overflow-x-auto">
@@ -570,7 +659,7 @@ export default function VistaReportesGerenciales({
           {/* Top productos / clientes */}
           <div className="grid lg:grid-cols-2 gap-5">
             <Card className="p-5">
-              <SectionTitle icon={TrendingUp} title="Top 10 productos" hint="Por facturación de venta real." />
+              <SectionTitle icon={TrendingUp} title="Top 10 productos" hint="Por facturación de venta real." right={botonDe(BLOQUES_GERENCIAL.find(b => b.id === 'top-productos')!)} />
               <table className="w-full">
                 <thead><tr className="border-b dark:border-gray-700">
                   <th className={`${th} text-left`}>Producto</th><th className={`${th} text-right`}>Unid.</th><th className={`${th} text-right`}>Venta</th>
@@ -587,7 +676,7 @@ export default function VistaReportesGerenciales({
               </table>
             </Card>
             <Card id="sec-clientes" className="p-5">
-              <SectionTitle icon={TrendingUp} title="Top 10 clientes" hint="Por facturación entregada." />
+              <SectionTitle icon={TrendingUp} title="Top 10 clientes" hint="Por facturación entregada." right={botonDe(BLOQUES_GERENCIAL.find(b => b.id === 'top-clientes')!)} />
               <table className="w-full">
                 <thead><tr className="border-b dark:border-gray-700">
                   <th className={`${th} text-left`}>Cliente</th><th className={`${th} text-right`}>Ped.</th><th className={`${th} text-right`}>Venta</th>
@@ -608,7 +697,7 @@ export default function VistaReportesGerenciales({
           {/* Cobranza + costos */}
           <div className="grid lg:grid-cols-2 gap-5">
             <Card id="sec-cobranza" className="p-5">
-              <SectionTitle icon={TrendingUp} title="Cobranza y formas de pago" hint={`Pagos registrados de las ventas del período. ${pct(reporte.cobranza.cobrado / (k.venta || 1))} cobrado.`} />
+              <SectionTitle icon={TrendingUp} title="Cobranza y formas de pago" hint={`Pagos registrados de las ventas del período. ${pct(reporte.cobranza.cobrado / (k.venta || 1))} cobrado.`} right={botonDe(BLOQUES_GERENCIAL.find(b => b.id === 'cobranza')!)} />
               <div className="grid grid-cols-2 gap-4 items-center">
                 <div className="h-48"><CobranzaDonut cobranza={reporte.cobranza} /></div>
                 <table className="w-full">
@@ -632,7 +721,7 @@ export default function VistaReportesGerenciales({
               </div>
             </Card>
             <Card id="sec-mermas" className="p-5">
-              <SectionTitle icon={TrendingUp} title="Otros costos del período" hint="Mermas, bonificaciones y reposición." />
+              <SectionTitle icon={TrendingUp} title="Otros costos del período" hint="Mermas, bonificaciones y reposición." right={botonDe(BLOQUES_GERENCIAL.find(b => b.id === 'mermas')!)} />
               <table className="w-full">
                 <thead><tr className="border-b dark:border-gray-700">
                   <th className={`${th} text-left`}>Mes</th><th className={`${th} text-right`}>Mermas</th><th className={`${th} text-right`}>Bonif.</th><th className={`${th} text-right`}>Compras</th>
@@ -657,6 +746,7 @@ export default function VistaReportesGerenciales({
               <SectionTitle
                 icon={TrendingUp} title="Bonificaciones y promociones"
                 hint="Qué se regaló, de qué promoción salió y cuánto vale: costo real vs precio de lista. Unidades en botellas (bot.) cuando la promo es fraccionada."
+                right={botonDe(BLOQUES_GERENCIAL.find(b => b.id === 'bonificaciones')!)}
               />
               <div className="grid lg:grid-cols-3 gap-5">
                 <div className="lg:col-span-2 h-72"><BonifPromosChart data={reporte.bonif_promos ?? []} /></div>

--- a/src/components/vistas/__tests__/VistaReportesGerenciales.export.test.tsx
+++ b/src/components/vistas/__tests__/VistaReportesGerenciales.export.test.tsx
@@ -1,0 +1,237 @@
+/**
+ * El export fraccionado del dashboard gerencial.
+ *
+ * La vista se importa DIRECTO, no por `ReportesGerencialesContainer`: allá se
+ * carga lazy y un test que va por el container paga el `import()` del chunk en
+ * su primera prueba, que es el flake del PR #514.
+ *
+ * El armado de las filas se prueba en `utils/exportGerencial.test.ts`; acá se
+ * prueba el cableado: que cada botón baje SU bloque, con su nombre de archivo,
+ * y que la hoja de metadatos vaya en todos.
+ */
+import '@testing-library/jest-dom/vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+interface HojaExcel {
+  name: string;
+  data: Record<string, unknown>[];
+  columnWidths?: number[];
+}
+
+const mockCrearExcel = vi.fn<(hojas: HojaExcel[], filename: string) => Promise<void>>(() =>
+  Promise.resolve()
+);
+
+// La vista arrastra el barrel de hooks/queries (vía ModalAlertaDetalle), que
+// crea el cliente de Supabase al importarse. Los tests corren SIN .env a
+// propósito, así que se mockea en la raíz de la cadena.
+vi.mock('../../../lib/supabase', () => ({
+  supabase: { rpc: vi.fn(), from: vi.fn() },
+}));
+
+vi.mock('../../../utils/excel', () => ({
+  createMultiSheetExcel: (hojas: HojaExcel[], filename: string) => mockCrearExcel(hojas, filename),
+}));
+
+// Los gráficos son chart.js: montarlos en jsdom no aporta nada al export y
+// obliga a un canvas.
+vi.mock('../reportes-gerenciales/charts', () => ({
+  EvolucionChart: () => <div />, DiarioChart: () => <div />, VendedoresChart: () => <div />,
+  CategoriasChart: () => <div />, WaterfallChart: () => <div />, CobranzaDonut: () => <div />,
+  BonifPromosChart: () => <div />,
+}));
+
+// Mock completo, sin `importOriginal`: el módulo real importa `lib/supabase`,
+// que exige las env vars — y los tests corren SIN .env a propósito.
+vi.mock('../../../hooks/queries/useReporteGerencialQuery', () => ({
+  usePosicionFiscalQuery: () => ({ data: null, isLoading: false }),
+}));
+
+import VistaReportesGerenciales from '../VistaReportesGerenciales';
+import type { ReporteGerencial } from '../../../hooks/queries/useReporteGerencialQuery';
+
+function reporte(over: Partial<ReporteGerencial> = {}): ReporteGerencial {
+  return {
+    meta: {
+      sucursal_id: 1, sucursal_nombre: 'Tucumán', desde: '2026-08-01', hasta: '2026-08-31',
+      generado_at: '2026-09-08T12:00:00Z', incluye_no_entregados: false,
+    },
+    kpis: {
+      venta: 100000, pedidos: 50, clientes: 20, ticket: 2000, clientes_nuevos: 3,
+      cmv: 60000, bonif: 5000, unidades: 500, unidades_bonif: 25,
+      margen_comercial: 40000, margen_neto: 35000, base_comision: 95000,
+      comision_pct_default: 2, mermas: 1000, compras: 70000, ingreso_sin_costo: 0,
+      venta_real: 90000, margen_real: 38000,
+    },
+    mensual: [{ mes: '2026-08', pedidos: 50, venta: 100000, clientes: 20, ticket: 2000, cmv: 60000, bonif: 5000, mermas: 1000, compras: 70000 }],
+    vendedores: [{ nombre: 'Christian', rol: 'preventista', pedidos: 30, venta: 60000, margen_comercial: 24000, bonif: 3000, base_nc: 58000 }],
+    categorias: [{ categoria: 'Bebidas', venta: 70000, margen_comercial: 28000, bonif: 3500, sin_costo: false }],
+    top_productos: [{ nombre: 'Coca 2L', unidades: 200, venta: 40000, margen: 16000 }],
+    top_clientes: [{ cliente: 'Kiosco Luna', pedidos: 12, venta: 25000 }],
+    cobranza: { formas: [{ forma_pago: 'efectivo', monto: 80000 }], cobrado: 80000, pendiente: 20000 },
+    serie_diaria: [['2026-08-01', 3000]],
+    flags: { ingreso_sin_costo: 0, pct_sin_costo: 0 },
+    mermas_motivo: [{ motivo: 'rotura', unidades: 10, costo: 900, clasificacion: 'perdida' }],
+    bonif_promos: [{ promocion: '2x1', producto: 'Coca 2L', unidades: 20, es_fraccion: false, costo: 2000, valor_venta: 4000 }],
+    alertas: [{ severidad: 'warning', codigo: 'x', titulo: 'Deuda vencida', detalle: 'd', valor: 1, seccion: 'sec-cobranza' }],
+    ...over,
+  } as ReporteGerencial;
+}
+
+const periodo = {
+  key: 'ago', label: 'Agosto 2026', desde: '2026-08-01', hasta: '2026-08-31',
+  esMes: true, periodoMes: '2026-08-01', parcial: false,
+};
+
+/**
+ * `null` significa "sin reporte". No se usa `undefined` porque pasarlo dispara
+ * el valor por defecto del parámetro y terminaría renderizando el reporte
+ * completo — que es justo lo contrario de lo que quiere ese caso.
+ */
+function renderVista(r: ReporteGerencial | null = reporte()) {
+  return render(
+    <VistaReportesGerenciales
+      reporte={r ?? undefined}
+      loading={false}
+      error={null}
+      sucursalSel={1}
+      periodoSel={periodo}
+      opcionesSucursal={[{ id: 1, nombre: 'Tucumán' }]}
+      opcionesPeriodo={[periodo]}
+      onSucursal={vi.fn()}
+      onPeriodo={vi.fn()}
+      onRango={vi.fn()}
+      incluirNoEntregados={false}
+      onIncluirNoEntregados={vi.fn()}
+      comparar={false}
+      onComparar={vi.fn()}
+      metas={null}
+      metasEditable={false}
+      onGuardarMeta={vi.fn()}
+      guardandoMeta={false}
+      analisis={null}
+      {...({} as Record<string, unknown>)}
+    />
+  );
+}
+
+/** El detalle (categorías, top, cobranza…) monta recién al abrir el colapsable. */
+async function abrirDetalle(user: ReturnType<typeof userEvent.setup>) {
+  const toggle = screen.getAllByRole('button').find(b => /detalle/i.test(b.textContent ?? ''));
+  if (toggle) await user.click(toggle);
+}
+
+describe('VistaReportesGerenciales › export fraccionado', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('el resumen se baja solo, con su propio archivo', async () => {
+    const user = userEvent.setup();
+    renderVista();
+
+    await user.click(screen.getByRole('button', { name: /Descargar los KPIs/i }));
+
+    const [hojas, filename] = mockCrearExcel.mock.calls[0];
+    expect(hojas.map(h => h.name)).toEqual(['Info', 'Resumen']);
+    expect(filename).toBe('gerencial-resumen-Tucumán-2026-08-01_2026-08-31');
+  });
+
+  it('cada bloque baja SU archivo, no el dashboard entero', async () => {
+    const user = userEvent.setup();
+    renderVista();
+    await abrirDetalle(user);
+
+    await user.click(screen.getByRole('button', { name: /Descargar Top productos/i }));
+
+    const [hojas, filename] = mockCrearExcel.mock.calls[0];
+    expect(hojas.map(h => h.name)).toEqual(['Info', 'Top productos']);
+    expect(filename).toBe('gerencial-top-productos-Tucumán-2026-08-01_2026-08-31');
+    expect(hojas[1].data[0]).toMatchObject({ Producto: 'Coca 2L', Unidades: 200 });
+  });
+
+  // Es el punto del pedido: varios archivos sueltos en una carpeta, y cada uno
+  // tiene que poder interpretarse solo.
+  it('TODOS los archivos llevan la hoja de metadatos', async () => {
+    const user = userEvent.setup();
+    renderVista();
+    await abrirDetalle(user);
+
+    const botones = screen.getAllByRole('button').filter(b =>
+      /^Descargar /.test(b.getAttribute('aria-label') ?? b.getAttribute('title') ?? '')
+    );
+    expect(botones.length).toBeGreaterThan(4);
+
+    for (const b of botones) {
+      mockCrearExcel.mockClear();
+      await user.click(b);
+      const [hojas] = mockCrearExcel.mock.calls[0];
+      expect(hojas[0].name).toBe('Info');
+    }
+  });
+
+  it('la hoja de metadatos dice sucursal, rango y criterio', async () => {
+    const user = userEvent.setup();
+    renderVista();
+
+    await user.click(screen.getByRole('button', { name: /Descargar los KPIs/i }));
+
+    const [hojas] = mockCrearExcel.mock.calls[0];
+    const info = Object.fromEntries(hojas[0].data.map(f => [f.Campo, f.Valor]));
+    expect(info['Sucursal']).toBe('Tucumán');
+    expect(info['Desde']).toBe('2026-08-01');
+    expect(info['Criterio de venta']).toContain('Sólo pedidos entregados');
+  });
+
+  it('"Todo" junta los bloques en un archivo con una sola hoja Info', async () => {
+    const user = userEvent.setup();
+    renderVista();
+
+    await user.click(screen.getByRole('button', { name: /Descargar todos los bloques/i }));
+
+    const [hojas, filename] = mockCrearExcel.mock.calls[0];
+    expect(hojas.filter(h => h.name === 'Info')).toHaveLength(1);
+    expect(hojas.length).toBeGreaterThan(8);
+    expect(filename).toBe('gerencial-todo-Tucumán-2026-08-01_2026-08-31');
+  });
+
+  describe('las dos formas del payload que rompen el export', () => {
+    it('la serie diaria viene en TUPLAS y sale con encabezados de verdad', async () => {
+      const user = userEvent.setup();
+      renderVista();
+      await abrirDetalle(user);
+
+      await user.click(screen.getByRole('button', { name: /Descargar Evolución/i }));
+
+      const [hojas] = mockCrearExcel.mock.calls[0];
+      const serie = hojas.find(h => h.name === 'Serie diaria')!;
+      // Sin mapear, los headers saldrían '0' y '1'.
+      expect(Object.keys(serie.data[0])).toEqual(['Fecha', 'Venta']);
+    });
+
+    it('un KPI opcional ausente no escribe undefined en la celda', async () => {
+      // `margen_real` y `venta_real` no vienen en respuestas cacheadas de
+      // versiones viejas del RPC.
+      const r = reporte();
+      delete (r.kpis as unknown as Record<string, unknown>).margen_real;
+      delete (r.kpis as unknown as Record<string, unknown>).venta_real;
+
+      const user = userEvent.setup();
+      renderVista(r);
+      await user.click(screen.getByRole('button', { name: /Descargar los KPIs/i }));
+
+      const [hojas] = mockCrearExcel.mock.calls[0];
+      const filas = hojas[1].data;
+      expect(filas.every(f => f.Valor !== undefined)).toBe(true);
+      const info = Object.fromEntries(filas.map(f => [f.Indicador, f.Valor]));
+      expect(info['Margen real']).toBe(40000); // el fallback de la pantalla
+    });
+  });
+
+  it('sin reporte no hay nada que bajar', () => {
+    renderVista(null);
+    expect(screen.queryByRole('button', { name: /Descargar los KPIs/i })).not.toBeInTheDocument();
+  });
+});

--- a/src/utils/exportGerencial.test.ts
+++ b/src/utils/exportGerencial.test.ts
@@ -1,0 +1,270 @@
+import { describe, it, expect } from 'vitest'
+import {
+  hojaMetadatos,
+  hojasResumen,
+  hojasEvolucion,
+  hojasVendedores,
+  hojasCategorias,
+  hojasTopProductos,
+  hojasTopClientes,
+  hojasCobranza,
+  hojasMermas,
+  hojasBonificaciones,
+  hojasAlertas,
+  hojasTodo,
+  nombreArchivo,
+  BLOQUES_GERENCIAL,
+} from './exportGerencial'
+import type { ReporteGerencial } from '../hooks/queries/useReporteGerencialQuery'
+
+/** Payload mínimo pero completo: cada bloque tiene al menos una fila. */
+function reporte(over: Partial<ReporteGerencial> = {}): ReporteGerencial {
+  return {
+    meta: {
+      sucursal_id: 1,
+      sucursal_nombre: 'Tucumán',
+      desde: '2026-08-01',
+      hasta: '2026-08-31',
+      generado_at: '2026-09-08T12:00:00Z',
+      incluye_no_entregados: false,
+    },
+    kpis: {
+      venta: 100000, pedidos: 50, clientes: 20, ticket: 2000, clientes_nuevos: 3,
+      cmv: 60000, bonif: 5000, unidades: 500, unidades_bonif: 25,
+      margen_comercial: 40000, margen_neto: 35000, base_comision: 95000,
+      comision_pct_default: 2, mermas: 1000, compras: 70000, ingreso_sin_costo: 0,
+      venta_real: 90000, margen_real: 38000,
+    } as ReporteGerencial['kpis'],
+    mensual: [{ mes: '2026-08', pedidos: 50, venta: 100000, clientes: 20, ticket: 2000, cmv: 60000, bonif: 5000, mermas: 1000, compras: 70000 }],
+    vendedores: [{ nombre: 'Christian', rol: 'preventista', pedidos: 30, venta: 60000, margen_comercial: 24000, bonif: 3000, base_nc: 58000 }],
+    categorias: [{ categoria: 'Bebidas', venta: 70000, margen_comercial: 28000, bonif: 3500, sin_costo: false }],
+    top_productos: [{ nombre: 'Coca 2L', unidades: 200, venta: 40000, margen: 16000 }],
+    top_clientes: [{ cliente: 'Kiosco Luna', pedidos: 12, venta: 25000 }],
+    cobranza: { formas: [{ forma_pago: 'efectivo', monto: 80000 }], cobrado: 80000, pendiente: 20000 },
+    serie_diaria: [['2026-08-01', 3000], ['2026-08-02', 4500]],
+    flags: { ingreso_sin_costo: 0, pct_sin_costo: 0 },
+    mermas_motivo: [{ motivo: 'rotura', unidades: 10, costo: 900, clasificacion: 'perdida' }],
+    bonif_promos: [
+      { promocion: '2x1 Coca', producto: 'Coca 2L', unidades: 20, es_fraccion: false, costo: 2000, valor_venta: 4000 },
+      { promocion: '2x1 Coca', producto: 'Coca 1L', unidades: 10, es_fraccion: true, costo: 500, valor_venta: 1000 },
+    ],
+    alertas: [{ severidad: 'warning', codigo: 'cobranza_vencida', titulo: 'Deuda vencida', detalle: '3 clientes', valor: 15000, seccion: 'sec-cobranza' }],
+    ...over,
+  } as ReporteGerencial
+}
+
+describe('hojaMetadatos', () => {
+  it('dice sucursal, rango y criterio: sin eso el archivo no se puede interpretar', () => {
+    // Con el export fraccionado quedan varios archivos sueltos en una carpeta.
+    const filas = hojaMetadatos(reporte()).data
+    const info = Object.fromEntries(filas.map(f => [f.Campo, f.Valor]))
+
+    expect(info['Sucursal']).toBe('Tucumán')
+    expect(info['Desde']).toBe('2026-08-01')
+    expect(info['Hasta']).toBe('2026-08-31')
+    expect(info['Criterio de venta']).toContain('entregad')
+  })
+
+  it('distingue la red consolidada de una sucursal', () => {
+    const r = reporte()
+    r.meta.sucursal_id = null
+    r.meta.sucursal_nombre = 'Red'
+    const info = Object.fromEntries(hojaMetadatos(r).data.map(f => [f.Campo, f.Valor]))
+    expect(info['Sucursal']).toBe('Red (consolidado)')
+  })
+
+  it('el criterio cambia con el toggle Entregadas/Todos', () => {
+    const r = reporte()
+    r.meta.incluye_no_entregados = true
+    const info = Object.fromEntries(hojaMetadatos(r).data.map(f => [f.Campo, f.Valor]))
+    expect(info['Criterio de venta']).toContain('todos')
+  })
+})
+
+describe('hojasResumen — los KPIs van transpuestos', () => {
+  it('una fila por indicador, no una fila de 30 columnas', () => {
+    const filas = hojasResumen(reporte())[1].data
+    expect(filas.length).toBeGreaterThan(5)
+    expect(Object.keys(filas[0])).toEqual(['Indicador', 'Valor'])
+  })
+
+  it('usa los MISMOS fallbacks que la pantalla para los KPIs opcionales', () => {
+    // `margen_real` y `venta_real` no vienen en respuestas cacheadas viejas.
+    const sinOpcionales = reporte()
+    delete (sinOpcionales.kpis as Record<string, unknown>).margen_real
+    delete (sinOpcionales.kpis as Record<string, unknown>).venta_real
+
+    const info = Object.fromEntries(
+      hojasResumen(sinOpcionales)[1].data.map(f => [f.Indicador, f.Valor]),
+    )
+    expect(info['Margen real']).toBe(40000)  // cae a margen_comercial
+    expect(info['Venta real']).toBe(100000)  // cae a venta
+  })
+
+  it('nunca escribe undefined en una celda', () => {
+    const pelado = reporte()
+    pelado.kpis = { venta: 1, pedidos: 1 } as ReporteGerencial['kpis']
+    const filas = hojasResumen(pelado)[1].data
+    expect(filas.every(f => f.Valor !== undefined && f.Valor !== null)).toBe(true)
+  })
+
+  it('con comparativo agrega la hoja del período anterior', () => {
+    const r = reporte({
+      comparativo: { ...reporte().kpis, desde: '2026-07-01', hasta: '2026-07-31' } as ReporteGerencial['comparativo'],
+    })
+    expect(hojasResumen(r).map(h => h.name)).toContain('Período anterior')
+  })
+
+  it('sin comparativo no inventa una hoja vacía', () => {
+    const r = reporte({ comparativo: null })
+    expect(hojasResumen(r).map(h => h.name)).not.toContain('Período anterior')
+  })
+})
+
+describe('hojasEvolucion — la serie diaria viene en TUPLAS', () => {
+  it('mapea las tuplas a objetos con encabezados de verdad', () => {
+    // Pasarle `[['2026-08-01', 3000]]` a createMultiSheetExcel produce columnas
+    // llamadas '0' y '1', porque los headers salen de Object.keys(data[0]).
+    const serie = hojasEvolucion(reporte()).find(h => h.name === 'Serie diaria')!
+    expect(Object.keys(serie.data[0])).toEqual(['Fecha', 'Venta'])
+    expect(serie.data[0]).toEqual({ Fecha: '2026-08-01', Venta: 3000 })
+  })
+
+  it('la evolución mensual lleva las columnas de la tabla', () => {
+    const mensual = hojasEvolucion(reporte())[0]
+    expect(mensual.data[0]).toMatchObject({
+      Mes: '2026-08', Pedidos: 50, Venta: 100000, CMV: 60000, Mermas: 1000, Compras: 70000,
+    })
+  })
+
+  it('sin serie diaria no rompe', () => {
+    const r = reporte({ serie_diaria: [] })
+    expect(() => hojasEvolucion(r)).not.toThrow()
+  })
+})
+
+describe('las tablas simples', () => {
+  it('vendedores lleva el rol legible, no el crudo', () => {
+    expect(hojasVendedores(reporte())[0].data[0]).toMatchObject({
+      Vendedor: 'Christian', Pedidos: 30, Venta: 60000,
+    })
+  })
+
+  it('categorías marca las que no tienen costo cargado', () => {
+    const fila = hojasCategorias(reporte())[0].data[0]
+    expect(fila).toMatchObject({ Categoría: 'Bebidas', Venta: 70000 })
+    expect(fila['Sin costo']).toBe('No')
+  })
+
+  it('top productos y top clientes', () => {
+    expect(hojasTopProductos(reporte())[0].data[0]).toMatchObject({ Producto: 'Coca 2L', Unidades: 200 })
+    expect(hojasTopClientes(reporte())[0].data[0]).toMatchObject({ Cliente: 'Kiosco Luna', Pedidos: 12 })
+  })
+
+  it('cobranza lleva las formas y cierra con cobrado y pendiente', () => {
+    const filas = hojasCobranza(reporte())[0].data
+    expect(filas[0]).toMatchObject({ 'Forma de pago': 'efectivo', Monto: 80000 })
+    const totales = filas.map(f => f['Forma de pago'])
+    expect(totales).toContain('COBRADO')
+    expect(totales).toContain('PENDIENTE')
+  })
+
+  it('mermas por motivo lleva la clasificación', () => {
+    expect(hojasMermas(reporte())[0].data[0]).toMatchObject({
+      Motivo: 'rotura', Unidades: 10, Costo: 900, Clasificación: 'perdida',
+    })
+  })
+})
+
+describe('hojasBonificaciones — agrupadas por promoción, como en pantalla', () => {
+  it('una hoja de subtotales por promoción y otra con el detalle', () => {
+    const hojas = hojasBonificaciones(reporte())
+    expect(hojas.map(h => h.name)).toEqual(['Bonif por promo', 'Bonif detalle'])
+  })
+
+  it('el subtotal suma los productos de esa promoción', () => {
+    expect(hojasBonificaciones(reporte())[0].data[0]).toMatchObject({
+      Promoción: '2x1 Coca', Costo: 2500, 'Valor de venta': 5000, Productos: 2,
+    })
+  })
+
+  it('el detalle distingue botellas de fardos', () => {
+    const detalle = hojasBonificaciones(reporte())[1].data
+    expect(detalle.find(f => f.Producto === 'Coca 1L')).toMatchObject({ Unidad: 'botellas' })
+    expect(detalle.find(f => f.Producto === 'Coca 2L')).toMatchObject({ Unidad: 'fardos' })
+  })
+
+  it('sin bonificaciones devuelve lista vacía, no una hoja en blanco', () => {
+    expect(hojasBonificaciones(reporte({ bonif_promos: [] }))).toEqual([])
+  })
+
+  it('con bonif_promos ausente tampoco rompe', () => {
+    const r = reporte()
+    delete (r as Record<string, unknown>).bonif_promos
+    expect(hojasBonificaciones(r)).toEqual([])
+  })
+})
+
+describe('hojasAlertas', () => {
+  it('exporta las alertas con severidad y valor', () => {
+    expect(hojasAlertas(reporte())[0].data[0]).toMatchObject({
+      Severidad: 'warning', Título: 'Deuda vencida', Valor: 15000,
+    })
+  })
+
+  it('sin alertas no genera hoja', () => {
+    expect(hojasAlertas(reporte({ alertas: [] }))).toEqual([])
+  })
+})
+
+describe('hojasTodo', () => {
+  it('junta todos los bloques en un solo archivo, con los metadatos primero', () => {
+    const hojas = hojasTodo(reporte())
+    expect(hojas[0].name).toBe('Info')
+    expect(hojas.length).toBeGreaterThan(8)
+  })
+
+  it('no repite la hoja de metadatos por cada bloque', () => {
+    const nombres = hojasTodo(reporte()).map(h => h.name)
+    expect(nombres.filter(n => n === 'Info')).toHaveLength(1)
+  })
+
+  it('los nombres de hoja son únicos: Excel no admite dos iguales', () => {
+    const nombres = hojasTodo(reporte()).map(h => h.name)
+    expect(new Set(nombres).size).toBe(nombres.length)
+  })
+
+  it('ningún nombre de hoja pasa los 31 caracteres que permite Excel', () => {
+    for (const h of hojasTodo(reporte())) {
+      expect(h.name.length).toBeLessThanOrEqual(31)
+    }
+  })
+})
+
+describe('nombreArchivo', () => {
+  it('lleva sucursal y rango, sin espacios', () => {
+    expect(nombreArchivo(reporte(), 'resumen')).toBe('gerencial-resumen-Tucumán-2026-08-01_2026-08-31')
+  })
+
+  it('la red consolidada se llama Red, sin arrastrar el paréntesis al filename', () => {
+    const r = reporte()
+    r.meta.sucursal_id = null
+    r.meta.sucursal_nombre = 'Red (consolidado)'
+    expect(nombreArchivo(r, 'todo')).toBe('gerencial-todo-Red-2026-08-01_2026-08-31')
+  })
+})
+
+describe('BLOQUES_GERENCIAL', () => {
+  it('cada bloque sabe armar sus hojas', () => {
+    for (const b of BLOQUES_GERENCIAL) {
+      expect(typeof b.hojas).toBe('function')
+      expect(b.id.length).toBeGreaterThan(0)
+      expect(b.label.length).toBeGreaterThan(0)
+    }
+  })
+
+  it('los ids son únicos', () => {
+    const ids = BLOQUES_GERENCIAL.map(b => b.id)
+    expect(new Set(ids).size).toBe(ids.length)
+  })
+})

--- a/src/utils/exportGerencial.ts
+++ b/src/utils/exportGerencial.ts
@@ -1,0 +1,360 @@
+/**
+ * Armado de las hojas de Excel del dashboard gerencial.
+ *
+ * FRACCIONADO A PROPÓSITO
+ * -----------------------
+ * Cada bloque se baja por separado —un botón por sección— en vez de un único
+ * archivo monolítico: el dashboard tiene diez bloques y casi nunca se necesitan
+ * todos juntos. `hojasTodo` existe igual para el caso en que sí.
+ *
+ * POR ESO LA HOJA DE METADATOS ES OBLIGATORIA EN CADA ARCHIVO
+ * ----------------------------------------------------------
+ * El mismo reporte puede ser de UNA sucursal o de la red consolidada, con un
+ * rango custom y con el toggle "Entregadas/Todos" en cualquiera de sus dos
+ * posiciones. Un Excel que no dice cuál de todas esas cosas es, es un archivo
+ * que nadie puede interpretar tres semanas después — y con el export
+ * fraccionado quedan varios archivos sueltos en la misma carpeta, así que pesa
+ * el doble. El RPC ya devuelve `meta` con todo eso.
+ *
+ * ESTO SE ROMPE SI CAMBIA EL PAYLOAD DEL RPC
+ * ------------------------------------------
+ * Las claves de cada fila salen directo de los campos de `reporte_gerencial`.
+ * Una tarea que le cambie la forma al RPC —renombrar un campo, sacar uno— deja
+ * columnas vacías acá y NO lo detecta ni `tsc` (varios campos son opcionales
+ * por compat) ni el build. Si tocás el RPC, mirá este archivo.
+ *
+ * SÓLO DATOS, NO IMÁGENES. Los gráficos son chart.js: meterlos en el Excel
+ * obliga a pasar por `canvas.toDataURL`, que es bastante más caro. Se exportan
+ * los datos con los que están hechos.
+ */
+import type { SheetConfig } from './excel'
+import type {
+  ReporteGerencial,
+  ReporteKpis,
+  BonifPromo,
+} from '../hooks/queries/useReporteGerencialQuery'
+
+type Fila = Record<string, unknown>
+
+const n = (v: unknown): number => {
+  const x = Number(v)
+  return Number.isFinite(x) ? x : 0
+}
+
+/** Excel no admite nombres de hoja de más de 31 caracteres. */
+const hoja = (name: string, data: Fila[], columnWidths?: number[]): SheetConfig =>
+  ({ name: name.slice(0, 31), data, columnWidths } as SheetConfig)
+
+// ---------------------------------------------------------------------------
+// Metadatos
+// ---------------------------------------------------------------------------
+
+export function hojaMetadatos(r: ReporteGerencial): SheetConfig {
+  const esRed = r.meta.sucursal_id === null
+  return hoja('Info', [
+    { Campo: 'Sucursal', Valor: esRed ? 'Red (consolidado)' : r.meta.sucursal_nombre },
+    { Campo: 'Desde', Valor: r.meta.desde },
+    { Campo: 'Hasta', Valor: r.meta.hasta },
+    {
+      Campo: 'Criterio de venta',
+      Valor: r.meta.incluye_no_entregados
+        ? 'Incluye todos los pedidos no cancelados (entregados y no entregados)'
+        : 'Sólo pedidos entregados',
+    },
+    { Campo: 'Generado', Valor: r.meta.generado_at },
+    {
+      Campo: 'Nota',
+      Valor: 'Los gráficos del dashboard salen de estas mismas tablas. '
+           + 'Este archivo es un bloque del reporte: puede haber otros del mismo período.',
+    },
+  ], [22, 62])
+}
+
+// ---------------------------------------------------------------------------
+// Resumen (KPIs)
+// ---------------------------------------------------------------------------
+
+/**
+ * Los KPIs son un objeto de ~30 escalares: van TRANSPUESTOS a filas
+ * indicador/valor. Como una sola fila de 30 columnas el archivo es ilegible.
+ *
+ * Los `??` replican exactamente los que usa la pantalla: varios campos son
+ * opcionales por compatibilidad con respuestas cacheadas de versiones viejas
+ * del RPC, y sin fallback se escribiría `undefined` en la celda.
+ */
+function filasKpis(k: ReporteKpis): Fila[] {
+  const ventaReal = k.venta_real ?? k.venta
+  const margenReal = k.margen_real ?? k.margen_comercial
+  return [
+    { Indicador: 'Venta', Valor: n(k.venta) },
+    { Indicador: 'Venta real', Valor: n(ventaReal) },
+    { Indicador: 'Venta neta (sin IVA)', Valor: n(k.venta_neta ?? 0) },
+    { Indicador: 'IVA débito', Valor: n(k.iva_debito ?? 0) },
+    { Indicador: 'Pedidos', Valor: n(k.pedidos) },
+    { Indicador: 'Clientes', Valor: n(k.clientes) },
+    { Indicador: 'Clientes nuevos', Valor: n(k.clientes_nuevos) },
+    { Indicador: 'Ticket promedio', Valor: n(k.ticket) },
+    { Indicador: 'Unidades', Valor: n(k.unidades) },
+    { Indicador: 'Unidades bonificadas', Valor: n(k.unidades_bonif) },
+    { Indicador: 'CMV', Valor: n(k.cmv) },
+    { Indicador: 'Margen real', Valor: n(margenReal) },
+    { Indicador: 'Margen comercial', Valor: n(k.margen_comercial) },
+    { Indicador: 'Margen neto', Valor: n(k.margen_neto) },
+    { Indicador: 'Bonificaciones', Valor: n(k.bonif) },
+    { Indicador: 'Mermas (total)', Valor: n(k.mermas) },
+    { Indicador: 'Mermas — pérdida', Valor: n(k.mermas_perdida ?? 0) },
+    { Indicador: 'Mermas — ajustes', Valor: n(k.mermas_ajuste ?? 0) },
+    { Indicador: 'Mermas — muestras', Valor: n(k.mermas_muestra ?? 0) },
+    { Indicador: 'Compras', Valor: n(k.compras) },
+    { Indicador: 'Base de comisión', Valor: n(k.base_comision) },
+    { Indicador: 'Ingreso sin costo cargado', Valor: n(k.ingreso_sin_costo) },
+    { Indicador: 'Venta FC', Valor: n(k.fc_venta ?? 0) },
+    { Indicador: 'Pedidos FC', Valor: n(k.fc_pedidos ?? 0) },
+    { Indicador: 'Venta ZZ', Valor: n(k.zz_venta ?? 0) },
+    { Indicador: 'Pedidos ZZ', Valor: n(k.zz_pedidos ?? 0) },
+  ]
+}
+
+export function hojasResumen(r: ReporteGerencial): SheetConfig[] {
+  const hojas = [
+    hojaMetadatos(r),
+    hoja('Resumen', filasKpis(r.kpis), [30, 18]),
+  ]
+  if (r.comparativo) {
+    hojas.push(hoja('Período anterior', [
+      { Indicador: 'Desde', Valor: r.comparativo.desde },
+      { Indicador: 'Hasta', Valor: r.comparativo.hasta },
+      ...filasKpis(r.comparativo),
+    ], [30, 18]))
+  }
+  return hojas
+}
+
+// ---------------------------------------------------------------------------
+// Evolución mensual + serie diaria
+// ---------------------------------------------------------------------------
+
+export function hojasEvolucion(r: ReporteGerencial): SheetConfig[] {
+  const mensual = (r.mensual ?? []).map(m => ({
+    Mes: m.mes,
+    Pedidos: n(m.pedidos),
+    Venta: n(m.venta),
+    Clientes: n(m.clientes),
+    'Ticket promedio': n(m.ticket),
+    CMV: n(m.cmv),
+    Bonificaciones: n(m.bonif),
+    Mermas: n(m.mermas),
+    Compras: n(m.compras),
+  }))
+
+  // `serie_diaria` viene como TUPLAS [fecha, venta][], no como objetos. Los
+  // headers del Excel salen de Object.keys(data[0]): pasarle las tuplas crudas
+  // produce dos columnas llamadas '0' y '1'.
+  const serie = (r.serie_diaria ?? []).map(([fecha, venta]) => ({
+    Fecha: fecha,
+    Venta: n(venta),
+  }))
+
+  return [
+    hoja('Evolución mensual', mensual, [10, 10, 16, 10, 16, 16, 16, 14, 16]),
+    hoja('Serie diaria', serie, [13, 16]),
+  ]
+}
+
+// ---------------------------------------------------------------------------
+// Tablas simples
+// ---------------------------------------------------------------------------
+
+const ROLES: Record<string, string> = {
+  preventista: 'Preventista',
+  encargado: 'Encargado',
+  admin: 'Admin',
+}
+
+export function hojasVendedores(r: ReporteGerencial): SheetConfig[] {
+  return [hoja('Vendedores', (r.vendedores ?? []).map(v => ({
+    Vendedor: v.nombre,
+    Rol: ROLES[v.rol] ?? v.rol,
+    Pedidos: n(v.pedidos),
+    Venta: n(v.venta),
+    'Margen comercial': n(v.margen_comercial),
+    Bonificaciones: n(v.bonif),
+    'Base para comisión': n(v.base_nc),
+  })), [26, 14, 10, 16, 18, 16, 18])]
+}
+
+export function hojasCategorias(r: ReporteGerencial): SheetConfig[] {
+  return [hoja('Categorías', (r.categorias ?? []).map(c => ({
+    Categoría: c.categoria,
+    Venta: n(c.venta),
+    'Margen comercial': n(c.margen_comercial),
+    Bonificaciones: n(c.bonif),
+    // Se exporta como texto y no como booleano: en Excel un FALSE en una
+    // columna de datos se lee peor que un "No".
+    'Sin costo': c.sin_costo ? 'Sí' : 'No',
+  })), [28, 16, 18, 16, 11])]
+}
+
+export function hojasTopProductos(r: ReporteGerencial): SheetConfig[] {
+  return [hoja('Top productos', (r.top_productos ?? []).map((p, i) => ({
+    '#': i + 1,
+    Producto: p.nombre,
+    Unidades: n(p.unidades),
+    Venta: n(p.venta),
+    Margen: n(p.margen),
+  })), [5, 40, 12, 16, 16])]
+}
+
+export function hojasTopClientes(r: ReporteGerencial): SheetConfig[] {
+  return [hoja('Top clientes', (r.top_clientes ?? []).map((c, i) => ({
+    '#': i + 1,
+    Cliente: c.cliente,
+    Pedidos: n(c.pedidos),
+    Venta: n(c.venta),
+  })), [5, 38, 10, 16])]
+}
+
+export function hojasCobranza(r: ReporteGerencial): SheetConfig[] {
+  const formas = (r.cobranza?.formas ?? []).map(f => ({
+    'Forma de pago': f.forma_pago,
+    Monto: n(f.monto),
+  }))
+  // Los totales van en el mismo archivo: si no, hay que sumarlos a mano para
+  // confirmar que es el mismo reporte que la pantalla.
+  formas.push(
+    { 'Forma de pago': 'COBRADO', Monto: n(r.cobranza?.cobrado) },
+    { 'Forma de pago': 'PENDIENTE', Monto: n(r.cobranza?.pendiente) },
+  )
+  return [hoja('Cobranza', formas, [24, 18])]
+}
+
+export function hojasMermas(r: ReporteGerencial): SheetConfig[] {
+  const filas = (r.mermas_motivo ?? []).map(m => ({
+    Motivo: m.motivo,
+    Unidades: n(m.unidades),
+    Costo: n(m.costo),
+    Clasificación: m.clasificacion,
+  }))
+  if (filas.length === 0) return []
+  return [hoja('Mermas por motivo', filas, [22, 12, 16, 16])]
+}
+
+// ---------------------------------------------------------------------------
+// Bonificaciones
+// ---------------------------------------------------------------------------
+
+interface GrupoBonif {
+  promocion: string
+  costo: number
+  valor_venta: number
+  items: BonifPromo[]
+}
+
+/** Mismo agrupado que muestra la pantalla: subtotal por promo + detalle. */
+function agruparBonif(promos: readonly BonifPromo[]): GrupoBonif[] {
+  const grupos = new Map<string, GrupoBonif>()
+  for (const b of promos) {
+    const g = grupos.get(b.promocion) ?? { promocion: b.promocion, costo: 0, valor_venta: 0, items: [] }
+    g.costo += n(b.costo)
+    g.valor_venta += n(b.valor_venta)
+    g.items.push(b)
+    grupos.set(b.promocion, g)
+  }
+  return [...grupos.values()]
+    .map(g => ({ ...g, items: [...g.items].sort((a, b) => n(b.valor_venta) - n(a.valor_venta)) }))
+    .sort((a, b) => b.valor_venta - a.valor_venta)
+}
+
+export function hojasBonificaciones(r: ReporteGerencial): SheetConfig[] {
+  const promos = r.bonif_promos ?? []
+  if (promos.length === 0) return []
+
+  const grupos = agruparBonif(promos)
+
+  const porPromo = grupos.map(g => ({
+    Promoción: g.promocion,
+    Productos: g.items.length,
+    Costo: g.costo,
+    'Valor de venta': g.valor_venta,
+  }))
+
+  const detalle = grupos.flatMap(g => g.items.map(i => ({
+    Promoción: g.promocion,
+    Producto: i.producto,
+    Unidades: n(i.unidades),
+    // La promo fraccionada regala BOTELLAS, no fardos: sin esta columna los
+    // números de dos filas parecen comparables y no lo son.
+    Unidad: i.es_fraccion ? 'botellas' : 'fardos',
+    Costo: n(i.costo),
+    'Valor de venta': n(i.valor_venta),
+  })))
+
+  return [
+    hoja('Bonif por promo', porPromo, [34, 11, 16, 18]),
+    hoja('Bonif detalle', detalle, [30, 32, 12, 12, 16, 18]),
+  ]
+}
+
+// ---------------------------------------------------------------------------
+// Alertas
+// ---------------------------------------------------------------------------
+
+export function hojasAlertas(r: ReporteGerencial): SheetConfig[] {
+  const filas = (r.alertas ?? []).map(a => ({
+    Severidad: a.severidad,
+    Código: a.codigo,
+    Título: a.titulo,
+    Detalle: a.detalle,
+    Valor: n(a.valor),
+    Sección: a.seccion,
+  }))
+  if (filas.length === 0) return []
+  return [hoja('Alertas', filas, [12, 24, 30, 50, 16, 18])]
+}
+
+// ---------------------------------------------------------------------------
+// Los bloques que ofrece la pantalla
+// ---------------------------------------------------------------------------
+
+export interface BloqueGerencial {
+  /** Va en el nombre del archivo. */
+  id: string
+  label: string
+  hojas: (r: ReporteGerencial) => SheetConfig[]
+}
+
+/**
+ * Un bloque por sección del dashboard. `hojas` NO incluye los metadatos: los
+ * agrega `hojasDeBloque`, para que ningún bloque se olvide de ponerlos.
+ */
+export const BLOQUES_GERENCIAL: BloqueGerencial[] = [
+  { id: 'resumen', label: 'Resumen y KPIs', hojas: r => hojasResumen(r).slice(1) },
+  { id: 'evolucion', label: 'Evolución', hojas: hojasEvolucion },
+  { id: 'vendedores', label: 'Vendedores', hojas: hojasVendedores },
+  { id: 'categorias', label: 'Categorías', hojas: hojasCategorias },
+  { id: 'top-productos', label: 'Top productos', hojas: hojasTopProductos },
+  { id: 'top-clientes', label: 'Top clientes', hojas: hojasTopClientes },
+  { id: 'cobranza', label: 'Cobranza', hojas: hojasCobranza },
+  { id: 'mermas', label: 'Mermas', hojas: hojasMermas },
+  { id: 'bonificaciones', label: 'Bonificaciones', hojas: hojasBonificaciones },
+  { id: 'alertas', label: 'Alertas', hojas: hojasAlertas },
+]
+
+/** Las hojas de un bloque, siempre con los metadatos adelante. */
+export function hojasDeBloque(r: ReporteGerencial, bloque: BloqueGerencial): SheetConfig[] {
+  return [hojaMetadatos(r), ...bloque.hojas(r)]
+}
+
+/** Todo junto en un archivo, con una sola hoja de metadatos. */
+export function hojasTodo(r: ReporteGerencial): SheetConfig[] {
+  return [hojaMetadatos(r), ...BLOQUES_GERENCIAL.flatMap(b => b.hojas(r))]
+}
+
+/**
+ * `gerencial-<bloque>-<sucursal>-<desde>_<hasta>`, sin espacios y sin
+ * extensión (la agrega el helper de Excel).
+ */
+export function nombreArchivo(r: ReporteGerencial, bloqueId: string): string {
+  const sucursal = r.meta.sucursal_id === null ? 'Red' : r.meta.sucursal_nombre
+  return `gerencial-${bloqueId}-${sucursal}-${r.meta.desde}_${r.meta.hasta}`.replace(/\s+/g, '_')
+}


### PR DESCRIPTION
`/reportes-gerenciales` no exportaba nada. Ahora exporta **fraccionado**: un botón por sección, no un único archivo con las diez secciones adentro.

Casi nunca se necesitan todas juntas, y un archivo por bloque se manda por separado sin tener que explicar cuál de las diez hojas mirar. **"Todo"** queda igual para el caso en que sí.

Diez bloques: Resumen (KPIs) · Evolución · Vendedores · Categorías · Top productos · Top clientes · Cobranza · Mermas · Bonificaciones · Alertas.

## La hoja de metadatos va en todos los archivos

Es lo que hace que el fraccionado funcione. El mismo reporte puede ser de **una sucursal o de la red consolidada**, con rango custom y con el toggle **Entregadas/Todos** en cualquiera de sus dos posiciones. Con el export fraccionado quedan varios archivos sueltos en la misma carpeta: uno que no dice cuál de todas esas cosas es, no se puede interpretar tres semanas después.

Sale de `meta`, que el RPC ya devuelve. El nombre del archivo también lleva sucursal y rango: `gerencial-cobranza-Tucumán-2026-08-01_2026-08-31`.

## Las tres trampas de forma de este payload

Cada una con su test, y verifiqué que muerden — rompiéndolas a propósito caen 8:

| Trampa | Qué pasaba |
|---|---|
| `serie_diaria` viene en **tuplas** `[fecha, venta][]` | Los headers salen de `Object.keys(data[0])`: las tuplas crudas producen dos columnas llamadas `'0'` y `'1'` |
| `kpis` y `comparativo` son objetos de ~30 escalares | Como una fila de 30 columnas el archivo es ilegible. Van **transpuestos** a filas indicador/valor |
| Varios KPIs son **opcionales** por compat con respuestas cacheadas | Sin fallback el Excel escribe `undefined` en celdas. Se usan los **mismos** que la pantalla: `margen_real ?? margen_comercial` |

## Sólo datos, no imágenes

Los gráficos son chart.js: meterlos en el Excel obliga a pasar por `canvas.toDataURL`, que es bastante más caro. Se exportan los datos con los que están hechos — que además es lo que sirve para seguir trabajando el número. Si después se quieren las imágenes, es otra sesión.

## Estructura

El armado de las filas vive en `src/utils/exportGerencial.ts` con **31 tests**; la vista sólo dispara la descarga. Primer test de `VistaReportesGerenciales` (8 casos), importando la vista **directo** y no por el container, que es lazy — el flake del PR #514.

## ⚠️ Deuda declarada

Las claves de cada fila salen **directo** de los campos de `reporte_gerencial`. Una tarea que le cambie la forma al RPC —renombrar un campo, sacar uno— deja columnas vacías acá y **no lo detecta ni `tsc`** (varios campos son opcionales por compat) **ni el build**. Queda dicho en el docblock del módulo: si tocás el RPC, mirá este archivo.

`typecheck`, `lint`, `test:run` (115 archivos / 1559 tests, sin `.env`) y `build`: los cuatro en verde.

🤖 Generated with [Claude Code](https://claude.com/claude-code)