### PR TITLE
La tabla del gerencial muestra la comisión que se liquida, no un 2% plano

### DIFF
--- a/src/components/containers/ReportesGerencialesContainer.tsx
+++ b/src/components/containers/ReportesGerencialesContainer.tsx
@@ -141,6 +141,7 @@ export default function ReportesGerencialesContainer(): React.ReactElement {
         analisis={analisis ?? null}
         comisionCalculada={comisionCalc?.totales.comision ?? null}
         comisionCalculadaPrev={comisionCalcPrev?.totales.comision ?? null}
+        comisionPorVendedor={comisionCalc?.preventistas ?? null}
       />
     </Suspense>
   )

--- a/src/components/vistas/VistaReportesGerenciales.tsx
+++ b/src/components/vistas/VistaReportesGerenciales.tsx
@@ -64,6 +64,12 @@ export interface VistaReportesGerencialesProps {
    */
   comisionCalculada?: number | null
   comisionCalculadaPrev?: number | null
+  /**
+   * Comisión REAL por vendedor, del RPC `calcular_comisiones` (mig 150+207).
+   * Es lo que se liquida: respeta el rol y las reglas individuales. null =
+   * todavía no llegó.
+   */
+  comisionPorVendedor?: { nombre: string; comision: number }[] | null
 }
 
 // ---- helpers de UI -------------------------------------------------------
@@ -170,7 +176,7 @@ export default function VistaReportesGerenciales({
   reporte, loading, error, sucursalSel, periodoSel, opcionesSucursal, opcionesPeriodo,
   onSucursal, onPeriodo, onRango, incluirNoEntregados, onIncluirNoEntregados,
   comparar, onComparar, metas, metasEditable, onGuardarMeta, guardandoMeta, analisis,
-  comisionCalculada, comisionCalculadaPrev,
+  comisionCalculada, comisionCalculadaPrev, comisionPorVendedor,
 }: VistaReportesGerencialesProps): React.ReactElement {
   const [comPct, setComPct] = useState(2)
   const [comBase, setComBase] = useState<'nc' | 'ent'>('nc')
@@ -236,6 +242,23 @@ export default function VistaReportesGerenciales({
       : base * comPct / 100
     return { comision, contrib: kp.margen_neto - kp.mermas - comision }
   }, [kp, comPct, comBase, comisionCalculadaPrev])
+
+  /**
+   * Comisión real por vendedor, indexada por nombre.
+   *
+   * El cruce es POR NOMBRE porque `reporte_gerencial.vendedores[]` no trae el
+   * id del perfil — sólo `nombre` y `rol`. Hoy no hay nombres repetidos en
+   * `perfiles`, pero nada lo impide: si algún día los hay, los dos homónimos
+   * comparten la misma celda. La salida definitiva es que el RPC devuelva el
+   * id; mientras tanto esto es lo que hay sin tocar SQL.
+   */
+  const comisionRealPorNombre = useMemo(() => {
+    const m = new Map<string, number>()
+    for (const v of comisionPorVendedor ?? []) m.set(v.nombre, v.comision)
+    return m
+  }, [comisionPorVendedor])
+
+  const hayComisionReal = (comisionPorVendedor?.length ?? 0) > 0
 
   // Export fraccionado: qué bloque se está bajando (null = ninguno).
   const [exportando, setExportando] = useState<string | null>(null)
@@ -577,7 +600,7 @@ export default function VistaReportesGerenciales({
                 <div className="flex items-center gap-3 bg-gray-50 dark:bg-gray-700/40 border dark:border-gray-600 rounded-lg px-3 py-2">
                   <div className="flex items-center gap-1.5">
                     <span className="text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase">Comisión</span>
-                    <NumberInput min={0} max={100} value={comPct} onChange={setComPct} commitOnChange emptyValue={0}
+                    <NumberInput aria-label="Porcentaje de comisión a simular" min={0} max={100} value={comPct} onChange={setComPct} commitOnChange emptyValue={0}
                       className="w-14 px-2 py-1 border rounded text-center text-sm font-semibold dark:bg-gray-700 dark:border-gray-600 dark:text-white" />
                     <span className="text-sm font-medium text-gray-600 dark:text-gray-300">%</span>
                   </div>
@@ -596,7 +619,15 @@ export default function VistaReportesGerenciales({
                   <thead><tr className="border-b dark:border-gray-700">
                     <th className={`${th} text-left`}>Vendedor</th><th className={`${th} text-right`}>Venta</th>
                     <th className={`${th} text-right`}>Mg neto</th><th className={`${th} text-right`}>% neto</th>
-                    <th className={`${th} text-right`}>Comisión</th>
+                    {hayComisionReal && (
+                      <th className={`${th} text-right`} title="Lo que se liquida: según las reglas vigentes y el rol de cada uno. Es el mismo número que /comisiones.">
+                        Comisión
+                      </th>
+                    )}
+                    <th className={`${th} text-right ${hayComisionReal ? 'text-gray-400 dark:text-gray-500' : ''}`}
+                        title={hayComisionReal ? 'Simulación: el mismo % para todos, sin mirar rol ni reglas. No es lo que se paga.' : undefined}>
+                      {hayComisionReal ? `Simulado ${String(comPct).replace('.', ',')}%` : 'Comisión'}
+                    </th>
                   </tr></thead>
                   <tbody className="divide-y dark:divide-gray-700/60">
                     {[...reporte.vendedores].sort((a, b) => b.venta - a.venta).map((v, i) => {
@@ -612,7 +643,17 @@ export default function VistaReportesGerenciales({
                           <td className={`${td} text-right tabular-nums`}>{moneyC(v.venta)}</td>
                           <td className={`${td} text-right tabular-nums ${mn < 0 ? 'text-red-600 dark:text-red-400' : ''}`}>{moneyC(mn)}</td>
                           <td className={`${td} text-right tabular-nums font-medium ${mnp < 0.1 ? 'text-amber-600 dark:text-amber-400' : 'text-emerald-600 dark:text-emerald-400'}`}>{pct(mnp)}</td>
-                          <td className={`${td} text-right tabular-nums font-bold text-gray-900 dark:text-white`}>{money(base * comPct / 100)}</td>
+                          {hayComisionReal && (
+                            <td className={`${td} text-right tabular-nums font-bold text-gray-900 dark:text-white`}>
+                              {money(comisionRealPorNombre.get(v.nombre) ?? 0)}
+                            </td>
+                          )}
+                          {/* Simulación. Va apagada cuando al lado está la real,
+                              para que nadie lea el número del simulador como si
+                              fuera el que se paga. */}
+                          <td className={`${td} text-right tabular-nums ${hayComisionReal ? 'text-gray-400 dark:text-gray-500' : 'font-bold text-gray-900 dark:text-white'}`}>
+                            {money(base * comPct / 100)}
+                          </td>
                         </tr>
                       )
                     })}
@@ -623,7 +664,14 @@ export default function VistaReportesGerenciales({
                       <td className={`${td} text-right tabular-nums`}>{moneyC(reporte.vendedores.reduce((s, v) => s + v.venta, 0))}</td>
                       <td className={`${td} text-right tabular-nums`}>{moneyC(reporte.vendedores.reduce((s, v) => s + v.margen_comercial - v.bonif, 0))}</td>
                       <td className={td}></td>
-                      <td className={`${td} text-right tabular-nums`}>{money(reporte.vendedores.reduce((s, v) => s + (comBase === 'nc' ? v.base_nc : v.venta) * comPct / 100, 0))}</td>
+                      {hayComisionReal && (
+                        <td className={`${td} text-right tabular-nums`}>
+                          {money(reporte.vendedores.reduce((s, v) => s + (comisionRealPorNombre.get(v.nombre) ?? 0), 0))}
+                        </td>
+                      )}
+                      <td className={`${td} text-right tabular-nums ${hayComisionReal ? 'text-gray-400 dark:text-gray-500 font-normal' : ''}`}>
+                        {money(reporte.vendedores.reduce((s, v) => s + (comBase === 'nc' ? v.base_nc : v.venta) * comPct / 100, 0))}
+                      </td>
                     </tr>
                   </tfoot>
                 </table>

--- a/src/components/vistas/__tests__/VistaReportesGerenciales.comision.test.tsx
+++ b/src/components/vistas/__tests__/VistaReportesGerenciales.comision.test.tsx
@@ -1,0 +1,206 @@
+/**
+ * Las dos comisiones de la tabla de vendedores.
+ *
+ * EL BUG QUE FIJA
+ * ---------------
+ * La mig 207 hizo que el % por defecto dependa del rol: un admin o un encargado
+ * comisionan 0%. Pero en el gerencial había DOS cálculos de comisión y sólo uno
+ * miraba las reglas:
+ *
+ *   · el KPI de arriba usaba `calcular_comisiones` — correcto
+ *   · la tabla de vendedores hacía `base × comPct / 100` — el mismo % para todos
+ *
+ * En agosto la misma pantalla mostraba $804.668 en el KPI y $926.042 en el pie
+ * de la tabla. La diferencia, $121.374, eran seis no-preventistas cobrando un
+ * 2% que la liquidación real dice que es 0.
+ *
+ * El bug estaba latente desde antes: mientras TODOS cobraban 2%, multiplicar
+ * por un % plano daba el mismo número. La mig 207 lo destapó.
+ *
+ * La vista se importa DIRECTO, no por el container (lazy, flake del PR #514).
+ */
+import '@testing-library/jest-dom/vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+vi.mock('../../../lib/supabase', () => ({
+  supabase: { rpc: vi.fn(), from: vi.fn() },
+}));
+
+vi.mock('../../../utils/excel', () => ({ createMultiSheetExcel: vi.fn() }));
+
+vi.mock('../reportes-gerenciales/charts', () => ({
+  EvolucionChart: () => <div />, DiarioChart: () => <div />, VendedoresChart: () => <div />,
+  CategoriasChart: () => <div />, WaterfallChart: () => <div />, CobranzaDonut: () => <div />,
+  BonifPromosChart: () => <div />,
+}));
+
+vi.mock('../../../hooks/queries/useReporteGerencialQuery', () => ({
+  usePosicionFiscalQuery: () => ({ data: null, isLoading: false }),
+}));
+
+import VistaReportesGerenciales from '../VistaReportesGerenciales';
+// Se usa el MISMO formateador que la vista para armar las expectativas.
+import { money } from '../reportes-gerenciales/formato';
+import type { ReporteGerencial } from '../../../hooks/queries/useReporteGerencialQuery';
+
+/**
+ * `money` es Intl y separa con espacio DURO (U+00A0). testing-library normaliza
+ * el texto del DOM —colapsa \s, que incluye el duro— pero NO el string que uno
+ * le pasa, así que compararlo crudo nunca matchea. Se normaliza igual.
+ */
+const $$ = (x: number): string => money(x).replace(/\s/g, ' ');
+
+/** Un preventista y un encargado, como en los datos reales de agosto. */
+const VENDEDORES = [
+  { nombre: 'Juan', rol: 'preventista', pedidos: 100, venta: 15121320, margen_comercial: 3000000, bonif: 200000, base_nc: 15121320 },
+  { nombre: 'Jony', rol: 'encargado', pedidos: 20, venta: 2964100, margen_comercial: 600000, bonif: 40000, base_nc: 2964100 },
+];
+
+function reporte(): ReporteGerencial {
+  return {
+    meta: {
+      sucursal_id: 1, sucursal_nombre: 'Tucumán', desde: '2026-08-01', hasta: '2026-08-31',
+      generado_at: '2026-09-08T12:00:00Z', incluye_no_entregados: false,
+    },
+    kpis: {
+      venta: 18085420, pedidos: 120, clientes: 60, ticket: 150000, clientes_nuevos: 2,
+      cmv: 12000000, bonif: 240000, unidades: 5000, unidades_bonif: 100,
+      margen_comercial: 3600000, margen_neto: 3360000, base_comision: 18085420,
+      comision_pct_default: 2, mermas: 50000, compras: 9000000, ingreso_sin_costo: 0,
+    },
+    mensual: [], vendedores: VENDEDORES, categorias: [], top_productos: [], top_clientes: [],
+    cobranza: { formas: [], cobrado: 0, pendiente: 0 },
+    serie_diaria: [], flags: { ingreso_sin_costo: 0, pct_sin_costo: 0 },
+    alertas: [],
+  } as unknown as ReporteGerencial;
+}
+
+const periodo = {
+  key: 'ago', label: 'Agosto 2026', desde: '2026-08-01', hasta: '2026-08-31',
+  esMes: true, periodoMes: '2026-08-01', parcial: false,
+};
+
+/** Lo que devuelve `calcular_comisiones`: Jony es encargado, cobra 0. */
+const COMISION_REAL = [
+  { nombre: 'Juan', comision: 302426 },
+  { nombre: 'Jony', comision: 0 },
+];
+
+function renderVista(comisionPorVendedor: { nombre: string; comision: number }[] | null = COMISION_REAL) {
+  return render(
+    <VistaReportesGerenciales
+      reporte={reporte()}
+      loading={false}
+      error={null}
+      sucursalSel={1}
+      periodoSel={periodo}
+      opcionesSucursal={[{ id: 1, nombre: 'Tucumán' }]}
+      opcionesPeriodo={[periodo]}
+      onSucursal={vi.fn()}
+      onPeriodo={vi.fn()}
+      onRango={vi.fn()}
+      incluirNoEntregados={false}
+      onIncluirNoEntregados={vi.fn()}
+      comparar={false}
+      onComparar={vi.fn()}
+      metas={null}
+      metasEditable={false}
+      onGuardarMeta={vi.fn()}
+      guardandoMeta={false}
+      analisis={null}
+      comisionCalculada={302426}
+      comisionPorVendedor={comisionPorVendedor}
+    />
+  );
+}
+
+async function abrirDetalle(user: ReturnType<typeof userEvent.setup>) {
+  const toggle = screen.getAllByRole('button').find(b => /detalle/i.test(b.textContent ?? ''));
+  if (toggle) await user.click(toggle);
+}
+
+function filaDe(nombre: string): HTMLElement {
+  return screen.getByText(nombre).closest('tr') as HTMLElement;
+}
+
+describe('VistaReportesGerenciales › comisión por vendedor', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('un encargado cobra 0 en la columna de lo que se liquida', async () => {
+    const user = userEvent.setup();
+    renderVista();
+    await abrirDetalle(user);
+
+    // Antes esta celda mostraba $59.282: base_nc × 2%, sin mirar el rol.
+    const jony = filaDe('Jony');
+    expect(within(jony).getByText($$(0))).toBeInTheDocument();
+  });
+
+  it('el simulador sigue mostrando su número, en su propia columna', async () => {
+    const user = userEvent.setup();
+    renderVista();
+    await abrirDetalle(user);
+
+    // 2.964.100 × 2% = 59.282. Sigue estando, pero como simulación.
+    const jony = filaDe('Jony');
+    expect(within(jony).getByText($$(59282))).toBeInTheDocument();
+  });
+
+  it('un preventista tiene el mismo número en las dos columnas', async () => {
+    const user = userEvent.setup();
+    renderVista();
+    await abrirDetalle(user);
+
+    // 15.121.320 × 2% = 302.426, que es lo que devuelve el RPC para Juan.
+    const juan = filaDe('Juan');
+    expect(within(juan).getAllByText($$(302426))).toHaveLength(2);
+  });
+
+  it('la columna del simulador dice que es una simulación', async () => {
+    const user = userEvent.setup();
+    renderVista();
+    await abrirDetalle(user);
+
+    expect(screen.getByText(/Simulado 2%/)).toBeInTheDocument();
+  });
+
+  it('cambiar el % del simulador NO toca lo que se liquida', async () => {
+    const user = userEvent.setup();
+    renderVista();
+    await abrirDetalle(user);
+
+    const input = screen.getByLabelText('Porcentaje de comisión a simular');
+    await user.clear(input);
+    await user.type(input, '5');
+
+    // La real no se mueve: sale de las reglas, no del input.
+    expect(within(filaDe('Juan')).getByText($$(302426))).toBeInTheDocument();
+    expect(within(filaDe('Jony')).getByText($$(0))).toBeInTheDocument();
+  });
+
+  // Es lo que hacía que la pantalla se contradijera consigo misma.
+  it('el pie de la columna real cuadra con el KPI, no con el simulado', async () => {
+    const user = userEvent.setup();
+    renderVista();
+    await abrirDetalle(user);
+
+    const total = screen.getByText('Total').closest('tr') as HTMLElement;
+    // Real: 302.426 + 0. Simulado: (15.121.320 + 2.964.100) × 2% = 361.708.
+    expect(within(total).getByText($$(302426))).toBeInTheDocument();
+    expect(within(total).getByText($$(361708))).toBeInTheDocument();
+  });
+
+  it('mientras la comisión real no llegó, se muestra sólo el simulador', async () => {
+    const user = userEvent.setup();
+    renderVista(null);
+    await abrirDetalle(user);
+
+    expect(screen.queryByText(/Simulado/)).not.toBeInTheDocument();
+    // Y la única columna es la de siempre, sin fingir que es la liquidación.
+    expect(within(filaDe('Jony')).getByText($$(59282))).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Reportado por vos: después de la mig 207 el gerencial seguía mostrando comisiones para no-preventistas. **Confirmado**, y era peor: la misma pantalla se contradecía a sí misma.

## Lo que medí en prod, agosto

| | |
|---|---|
| KPI "Comisión (reglas)" | **$804.668** ← correcto |
| Pie de la tabla de vendedores | **$926.042** ← el número viejo |
| Diferencia | **$121.374** |

Y esa diferencia son exactamente los seis no-preventistas:

| Vendedor | Rol | Mostraba | Real |
|---|---|---|---|
| Jony | encargado | 59.282 | **0** |
| Pablo | admin | 43.914 | **0** |
| Virginia H | admin | 10.179 | **0** |
| Nacho R | admin | 5.029 | **0** |
| Emilia H | admin | 2.520 | **0** |
| Julio | admin | 450 | **0** |

Los cuatro preventistas ya coincidían al peso, lo que confirma que la liquidación está bien y el problema era sólo de esta tabla.

## Por qué pasó

Había **dos cálculos de comisión** en la misma vista y la mig 207 sólo alcanzó a uno:

- El **KPI** usa `comisionCalculada`, del RPC `calcular_comisiones` → respeta el rol.
- La **tabla** hacía `base × comPct / 100` con el % del simulador → el mismo porcentaje para todos.

El bug estaba **latente desde antes**: mientras todos cobraban 2%, multiplicar por un % plano daba el mismo número que las reglas. La mig 207 no lo causó, lo destapó.

## El arreglo

El simulador se queda, **en su propia columna**:

| Columna | Qué es |
|---|---|
| **Comisión** | Lo que se liquida, por vendedor, del RPC. Mismo número que `/comisiones` |
| **Simulado X%** | La cuenta del simulador, en gris, para que nadie la lea como si fuera lo que se paga |

El pie suma las dos por separado, así que el total real **cuadra con el KPI**.

Sin migración: `calcular_comisiones` ya devolvía `preventistas[]` con la comisión por persona — el container sólo pasaba el total. Ahora pasa también el desglose.

## ⚠️ Limitación declarada

El cruce es **por nombre**, porque `reporte_gerencial.vendedores[]` no trae el id del perfil (verificado: sus claves son `nombre`, `rol`, `pedidos`, `venta`, `margen_comercial`, `margen_real`, `venta_real`, `bonif`, `base_nc`).

Hoy no hay nombres repetidos en `perfiles`, pero nada lo impide: si algún día los hay, los homónimos comparten celda. La salida definitiva es que el RPC devuelva el id — queda dicho al lado del código.

Mientras el RPC de comisiones no respondió, la tabla muestra **sólo** el simulador con su etiqueta de siempre, en vez de fingir que es la liquidación.

## Tests

7 casos nuevos, con la vista importada directo (lazy → flake del #514). Verificado que muerden: volviendo la columna real al `base × comPct` caen 4.

De paso, el input del simulador no tenía nombre accesible.

`typecheck`, `lint`, `test:run` (116 archivos / 1566 tests, sin `.env`) y `build`: los cuatro en verde.

🤖 Generated with [Claude Code](https://claude.com/claude-code)