### PR TITLE
reporte_gerencial devuelve el id del vendedor

### DIFF
--- a/migrations/209_gerencial_devuelve_el_id_del_vendedor.sql
+++ b/migrations/209_gerencial_devuelve_el_id_del_vendedor.sql
@@ -1,0 +1,118 @@
+-- reporte_gerencial devuelve el id del vendedor
+--
+-- EL PROBLEMA
+-- -----------
+-- `reporte_gerencial.vendedores[]` traia nombre, rol, pedidos, venta,
+-- venta_real, margen_comercial, margen_real, bonif y base_nc -- pero NO el id
+-- del perfil. Cuando el PR #528 tuvo que mostrar la comision real por vendedor
+-- (que sale de `calcular_comisiones`, que si devuelve el id), el unico cruce
+-- posible fue POR NOMBRE.
+--
+-- Hoy no hay nombres repetidos en `perfiles`, pero nada lo impide: el dia que
+-- haya dos homonimos comparten la celda de comision y nadie se entera. Un cruce
+-- por nombre entre dos fuentes es una bomba de tiempo silenciosa, del mismo
+-- tipo que las que se vinieron cerrando en las migs 207 y 208.
+--
+-- EL CAMBIO ES UNA COLUMNA
+-- ------------------------
+-- La CTE `vendedores` pasa de:
+--
+--   vendedores AS (SELECT pf.nombre, pf.rol, ...
+--                          ^^^^^^^^^
+-- a:
+--
+--   vendedores AS (SELECT pf.id, pf.nombre, pf.rol, ...
+--                         ^^^^^^
+--
+-- El JSON se arma con `to_jsonb(v)` sobre esa CTE, asi que la clave `id` sale
+-- sola. Es ADITIVO: ningun consumidor existente se rompe.
+--
+-- POR QUE ESTA MIGRACION ES UN PARCHE Y NO EL CUERPO COMPLETO
+-- ----------------------------------------------------------
+-- `reporte_gerencial` son 19.264 caracteres. El precedente del repo (mig 123)
+-- pega el body entero, y es lo correcto cuando el cambio es grande. Aca cambia
+-- UNA columna: un diff de 19.000 lineas donde cambio una esconde el cambio en
+-- vez de mostrarlo, y transcribir a mano el cuerpo de la funcion que calcula
+-- todo el dashboard es un riesgo peor que el que se viene a evitar.
+--
+-- Por eso el parche se aplica sobre el body VIVO (pg_get_functiondef) y se
+-- AUTOVERIFICA: si el ancla no aparece exactamente una vez, ABORTA. No hay
+-- forma de que "parezca" que funciono sin haber funcionado.
+--
+-- Si esta migracion falla al reaplicarse es porque la CTE `vendedores` cambio
+-- de forma: hay que mirar el body actual y ajustar el ancla, no relajar la
+-- guarda.
+--
+-- MISMA FIRMA. Es CREATE OR REPLACE (adentro del EXECUTE) sobre
+-- reporte_gerencial(bigint, date, date, boolean, boolean), la unica que existe.
+-- No se crea una sobrecarga: dos con rangos [obligatorios, total] superpuestos
+-- darian PGRST203 en runtime (trampa 5 de CLAUDE.md).
+--
+-- Los permisos NO se tocan: CREATE OR REPLACE preserva los ACL. Verificado
+-- despues de aplicar: authenticated=X, anon afuera.
+
+BEGIN;
+
+DO $patch$
+DECLARE
+  v_src   text;
+  v_viejo text := 'vendedores AS (SELECT pf.nombre, pf.rol,';
+  v_nuevo text := 'vendedores AS (SELECT pf.id, pf.nombre, pf.rol,';
+  v_ocurr int;
+BEGIN
+  SELECT pg_get_functiondef(p.oid) INTO v_src
+  FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace
+  WHERE n.nspname = 'public' AND p.proname = 'reporte_gerencial';
+
+  IF v_src IS NULL THEN
+    RAISE EXCEPTION 'No existe public.reporte_gerencial: aplica primero la mig 130';
+  END IF;
+
+  -- Ya parcheada (reaplicacion): no hay nada que hacer.
+  IF position(v_nuevo in v_src) > 0 THEN
+    RAISE NOTICE 'reporte_gerencial ya devuelve el id del vendedor, no se toca';
+    RETURN;
+  END IF;
+
+  v_ocurr := (length(v_src) - length(replace(v_src, v_viejo, ''))) / length(v_viejo);
+  IF v_ocurr <> 1 THEN
+    RAISE EXCEPTION
+      'Se esperaba 1 ocurrencia del ancla de la CTE vendedores y hay %. '
+      'La CTE cambio de forma: revisa el body actual con pg_get_functiondef.', v_ocurr;
+  END IF;
+
+  EXECUTE replace(v_src, v_viejo, v_nuevo);
+END
+$patch$;
+
+-- Verificacion: la clave tiene que estar en el JSON, no alcanza con que el
+-- EXECUTE no haya tirado.
+DO $verif$
+DECLARE
+  v_tiene boolean;
+BEGIN
+  SELECT position('vendedores AS (SELECT pf.id, pf.nombre' in pg_get_functiondef(p.oid)) > 0
+    INTO v_tiene
+  FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace
+  WHERE n.nspname = 'public' AND p.proname = 'reporte_gerencial';
+
+  IF NOT v_tiene THEN
+    RAISE EXCEPTION 'El parche no quedo aplicado en reporte_gerencial';
+  END IF;
+END
+$verif$;
+
+COMMIT;
+
+-- ROLLBACK (si hiciera falta): el mismo parche al reves.
+--   DO $$
+--   DECLARE v_src text;
+--   BEGIN
+--     SELECT pg_get_functiondef(p.oid) INTO v_src FROM pg_proc p
+--     JOIN pg_namespace n ON n.oid=p.pronamespace
+--     WHERE n.nspname='public' AND p.proname='reporte_gerencial';
+--     EXECUTE replace(v_src, 'vendedores AS (SELECT pf.id, pf.nombre',
+--                            'vendedores AS (SELECT pf.nombre');
+--   END $$;
+-- El front vuelve a cruzar por nombre revirtiendo el commit; la clave `id` de
+-- mas no rompe a nadie mientras tanto.

--- a/src/components/vistas/VistaReportesGerenciales.tsx
+++ b/src/components/vistas/VistaReportesGerenciales.tsx
@@ -69,7 +69,7 @@ export interface VistaReportesGerencialesProps {
    * Es lo que se liquida: respeta el rol y las reglas individuales. null =
    * todavía no llegó.
    */
-  comisionPorVendedor?: { nombre: string; comision: number }[] | null
+  comisionPorVendedor?: { id: string; nombre: string; comision: number }[] | null
 }
 
 // ---- helpers de UI -------------------------------------------------------
@@ -244,17 +244,16 @@ export default function VistaReportesGerenciales({
   }, [kp, comPct, comBase, comisionCalculadaPrev])
 
   /**
-   * Comisión real por vendedor, indexada por nombre.
+   * Comisión real por vendedor, indexada por ID del perfil (mig 209).
    *
-   * El cruce es POR NOMBRE porque `reporte_gerencial.vendedores[]` no trae el
-   * id del perfil — sólo `nombre` y `rol`. Hoy no hay nombres repetidos en
-   * `perfiles`, pero nada lo impide: si algún día los hay, los dos homónimos
-   * comparten la misma celda. La salida definitiva es que el RPC devuelva el
-   * id; mientras tanto esto es lo que hay sin tocar SQL.
+   * Antes el cruce era por NOMBRE, porque `reporte_gerencial.vendedores[]` no
+   * traía el id: dos homónimos habrían compartido la celda de comisión sin que
+   * nadie se enterara. Ahora los dos RPCs devuelven el mismo id y el cruce es
+   * exacto.
    */
-  const comisionRealPorNombre = useMemo(() => {
+  const comisionRealPorId = useMemo(() => {
     const m = new Map<string, number>()
-    for (const v of comisionPorVendedor ?? []) m.set(v.nombre, v.comision)
+    for (const v of comisionPorVendedor ?? []) m.set(v.id, v.comision)
     return m
   }, [comisionPorVendedor])
 
@@ -645,7 +644,7 @@ export default function VistaReportesGerenciales({
                           <td className={`${td} text-right tabular-nums font-medium ${mnp < 0.1 ? 'text-amber-600 dark:text-amber-400' : 'text-emerald-600 dark:text-emerald-400'}`}>{pct(mnp)}</td>
                           {hayComisionReal && (
                             <td className={`${td} text-right tabular-nums font-bold text-gray-900 dark:text-white`}>
-                              {money(comisionRealPorNombre.get(v.nombre) ?? 0)}
+                              {money(comisionRealPorId.get(v.id) ?? 0)}
                             </td>
                           )}
                           {/* Simulación. Va apagada cuando al lado está la real,
@@ -666,7 +665,7 @@ export default function VistaReportesGerenciales({
                       <td className={td}></td>
                       {hayComisionReal && (
                         <td className={`${td} text-right tabular-nums`}>
-                          {money(reporte.vendedores.reduce((s, v) => s + (comisionRealPorNombre.get(v.nombre) ?? 0), 0))}
+                          {money(reporte.vendedores.reduce((s, v) => s + (comisionRealPorId.get(v.id) ?? 0), 0))}
                         </td>
                       )}
                       <td className={`${td} text-right tabular-nums ${hayComisionReal ? 'text-gray-400 dark:text-gray-500 font-normal' : ''}`}>

--- a/src/components/vistas/__tests__/VistaReportesGerenciales.comision.test.tsx
+++ b/src/components/vistas/__tests__/VistaReportesGerenciales.comision.test.tsx
@@ -54,8 +54,8 @@ const $$ = (x: number): string => money(x).replace(/\s/g, ' ');
 
 /** Un preventista y un encargado, como en los datos reales de agosto. */
 const VENDEDORES = [
-  { nombre: 'Juan', rol: 'preventista', pedidos: 100, venta: 15121320, margen_comercial: 3000000, bonif: 200000, base_nc: 15121320 },
-  { nombre: 'Jony', rol: 'encargado', pedidos: 20, venta: 2964100, margen_comercial: 600000, bonif: 40000, base_nc: 2964100 },
+  { id: 'u-juan', nombre: 'Juan', rol: 'preventista', pedidos: 100, venta: 15121320, margen_comercial: 3000000, bonif: 200000, base_nc: 15121320 },
+  { id: 'u-jony', nombre: 'Jony', rol: 'encargado', pedidos: 20, venta: 2964100, margen_comercial: 600000, bonif: 40000, base_nc: 2964100 },
 ];
 
 function reporte(): ReporteGerencial {
@@ -84,11 +84,11 @@ const periodo = {
 
 /** Lo que devuelve `calcular_comisiones`: Jony es encargado, cobra 0. */
 const COMISION_REAL = [
-  { nombre: 'Juan', comision: 302426 },
-  { nombre: 'Jony', comision: 0 },
+  { id: 'u-juan', nombre: 'Juan', comision: 302426 },
+  { id: 'u-jony', nombre: 'Jony', comision: 0 },
 ];
 
-function renderVista(comisionPorVendedor: { nombre: string; comision: number }[] | null = COMISION_REAL) {
+function renderVista(comisionPorVendedor: { id: string; nombre: string; comision: number }[] | null = COMISION_REAL) {
   return render(
     <VistaReportesGerenciales
       reporte={reporte()}
@@ -192,6 +192,47 @@ describe('VistaReportesGerenciales › comisión por vendedor', () => {
     // Real: 302.426 + 0. Simulado: (15.121.320 + 2.964.100) × 2% = 361.708.
     expect(within(total).getByText($$(302426))).toBeInTheDocument();
     expect(within(total).getByText($$(361708))).toBeInTheDocument();
+  });
+
+  // El motivo de la mig 209: antes el cruce era por nombre y dos homónimos
+  // compartían la celda de comisión sin que nadie se enterara.
+  it('cruza por ID, no por nombre: dos homónimos no comparten comisión', async () => {
+    const user = userEvent.setup();
+    render(
+      <VistaReportesGerenciales
+        reporte={{
+          ...reporte(),
+          vendedores: [
+            { ...VENDEDORES[0], id: 'u-juan-1', nombre: 'Juan' },
+            { ...VENDEDORES[1], id: 'u-juan-2', nombre: 'Juan' },
+          ],
+        } as unknown as ReporteGerencial}
+        loading={false} error={null} sucursalSel={1} periodoSel={periodo}
+        opcionesSucursal={[{ id: 1, nombre: 'Tucumán' }]} opcionesPeriodo={[periodo]}
+        onSucursal={vi.fn()} onPeriodo={vi.fn()} onRango={vi.fn()}
+        incluirNoEntregados={false} onIncluirNoEntregados={vi.fn()}
+        comparar={false} onComparar={vi.fn()}
+        metas={null} metasEditable={false} onGuardarMeta={vi.fn()} guardandoMeta={false}
+        analisis={null}
+        comisionCalculada={302426}
+        comisionPorVendedor={[
+          { id: 'u-juan-1', nombre: 'Juan', comision: 302426 },
+          { id: 'u-juan-2', nombre: 'Juan', comision: 0 },
+        ]}
+      />
+    );
+    await abrirDetalle(user);
+
+    // Los dos se llaman igual; cada uno tiene que ver SU número. Se mira la
+    // celda de la columna real por posición (Vendedor, Venta, Mg neto, % neto,
+    // Comisión, Simulado) y no por texto: el primero tiene el mismo importe en
+    // las dos columnas y `getByText` encontraría dos.
+    const filas = screen.getAllByText('Juan').map(e => e.closest('tr') as HTMLElement);
+    expect(filas).toHaveLength(2);
+    const comisionReal = (fila: HTMLElement) =>
+      within(fila).getAllByRole('cell')[4].textContent?.replace(/\s/g, ' ');
+    expect(comisionReal(filas[0])).toBe($$(302426));
+    expect(comisionReal(filas[1])).toBe($$(0));
   });
 
   it('mientras la comisión real no llegó, se muestra sólo el simulador', async () => {

--- a/src/hooks/queries/useReporteGerencialQuery.ts
+++ b/src/hooks/queries/useReporteGerencialQuery.ts
@@ -125,6 +125,8 @@ export interface ReporteMes {
 }
 
 export interface ReporteVendedor {
+  /** Id del perfil (mig 209). Es la clave para cruzar con calcular_comisiones. */
+  id: string
   nombre: string
   rol: string
   pedidos: number


### PR DESCRIPTION
Cierra la limitación que quedó declarada en #528: la comisión real por vendedor se cruzaba **por nombre**, porque `reporte_gerencial.vendedores[]` no traía el id del perfil. Hoy no hay homónimos en `perfiles`, pero nada lo impide — y el día que los haya comparten la celda de comisión sin que nadie se entere.

## El cambio es una columna

La CTE `vendedores` pasa de:

```sql
vendedores AS (SELECT pf.nombre, pf.rol, ...
```

a:

```sql
vendedores AS (SELECT pf.id, pf.nombre, pf.rol, ...
```

El JSON se arma con `to_jsonb(v)` sobre esa CTE, así que la clave `id` sale sola. Es **aditivo**: ningún consumidor existente se rompe.

## Por qué la migración es un parche y no el cuerpo completo

Me aparto del precedente del repo (mig 123 pega el body entero) y quiero justificarlo:

`reporte_gerencial` son **19.264 caracteres**. Pegar el cuerpo completo es lo correcto cuando el cambio es grande. Acá cambia **una columna**: un diff de 19.000 líneas donde cambió una esconde el cambio en vez de mostrarlo. Y no hay forma de copiar ese body sin transcribirlo a mano — no tengo credenciales locales para `pg_dump` —, lo que sería un riesgo peor que el que se viene a evitar, sobre la función que calcula todo el dashboard.

A cambio, el parche **no puede fallar en silencio**:

- se aplica sobre el body **vivo** (`pg_get_functiondef`), así que preserva los otros 19k caracteres verbatim;
- **aborta** si el ancla no aparece exactamente una vez, con un mensaje que dice qué mirar;
- es **idempotente**: detecta que ya está parcheada y no hace nada;
- al final **verifica** que el cambio quedó, en un bloque aparte.

Si algún día la CTE cambia de forma, esta migración falla ruidosamente en vez de aplicar mal.

## Seguridad y firma

**Misma firma**: `reporte_gerencial(bigint, date, date, boolean, boolean)`, la única que existe — verificado antes de tocar nada. No se crea una sobrecarga (`PGRST203`, trampa 5).

**Los permisos no se tocan**: `CREATE OR REPLACE` preserva los ACL. Verificado después de aplicar: `authenticated=X`, `anon` afuera.

## Verificado contra prod

Los ids que ahora devuelve el gerencial **coinciden con los de `calcular_comisiones`** para los cuatro preventistas con venta en agosto.

## El front

Pasa a cruzar por id. El test nuevo pone **dos vendedores llamados "Juan"** con comisiones distintas y verifica que cada uno vea la suya — con el cruce por nombre ese test cae, que es exactamente el bug que la migración cierra. Verificado.

`typecheck`, `lint`, `test:run` (116 archivos / 1567 tests, sin `.env`) y `build`: los cuatro en verde.

🤖 Generated with [Claude Code](https://claude.com/claude-code)