### PR TITLE
El preventista ve la deuda previa del cliente al cargar un pedido

### DIFF
--- a/src/components/containers/PedidosContainer.tsx
+++ b/src/components/containers/PedidosContainer.tsx
@@ -19,6 +19,7 @@ import PanelPedidosTrabados from '../pedidos/PanelPedidosTrabados'
 import { fechaLocalISO, fechaHaceDias, getFormaPagoDisplay, formatPrecio } from '../../utils/formatters'
 import { explicarErrorDeSesion } from '../../utils/sesionVencida'
 import { preventistaPuedeEditar } from '../../utils/permisosPedido'
+import { puedeVerDeudaCliente } from '../../lib/permisos'
 import { useRequestIdEstable } from '../../hooks/useRequestIdEstable'
 import { nuevoRequestId } from '../../utils/idempotencia'
 import { useQueryClient } from '@tanstack/react-query'
@@ -145,7 +146,7 @@ const campoFechaEntrega = (): NonNullable<ConfirmConfig['campoFecha']> => ({
 
 export default function PedidosContainer(): React.ReactElement {
   const queryClient = useQueryClient()
-  const { user, isAdmin, isPreventista, isTransportista, isEncargado, isOnline, authReady } = useAuthData()
+  const { user, perfil, isAdmin, isPreventista, isTransportista, isEncargado, isOnline, authReady } = useAuthData()
   // Cola offline del alta. La cola real vive en IndexedDB, asi que esta
   // instancia del hook convive sin problema con la de App.tsx (se avisan por
   // el evento OFFLINE_QUEUE_CHANGED).
@@ -195,13 +196,20 @@ export default function PedidosContainer(): React.ReactElement {
   // Queries - use debounced search to avoid firing on every keystroke
   const { registrarPago, registrarPagosBatch, fetchPagosPedido, eliminarPago, actualizarFormaPagoDePago } = usePagos()
 
-  const { data: paginatedResult, isLoading: loadingPedidos } = usePedidosPaginatedQuery(
+  // dataUpdatedAt: cuándo se trajo esta página del servidor. Sólo se usa para
+  // fechar el saldo del cliente en el aviso de deuda cuando no hay señal — el
+  // número que se ve entonces es el del último sync.
+  const {
+    data: paginatedResult,
+    isLoading: loadingPedidos,
+    dataUpdatedAt: pedidosActualizadosAt,
+  } = usePedidosPaginatedQuery(
     paginaActual, ITEMS_PER_PAGE, filtros, debouncedBusqueda, authReady
   )
   const { data: statsSummary = EMPTY_PEDIDO_STATS_SUMMARY } = usePedidoStatsQuery(
     filtros, debouncedBusqueda, authReady
   )
-  const { data: clientes = [] } = useClientesQuery()
+  const { data: clientes = [], dataUpdatedAt: clientesActualizadosAt } = useClientesQuery()
   const { data: productos = [] } = useProductosQuery()
   const { data: transportistas = [] } = useTransportistasQuery()
   // Zonas activas (para elegir zonas preferidas por chofer en el split)
@@ -1903,6 +1911,7 @@ export default function PedidosContainer(): React.ReactElement {
       <Suspense fallback={<LoadingState />}>
         <VistaPedidos
           pedidos={pedidos}
+          saldoActualizadoAt={pedidosActualizadosAt}
           totalCount={totalCount}
           statsSummary={statsSummary}
           paginaActual={paginaActual}
@@ -2073,6 +2082,8 @@ export default function PedidosContainer(): React.ReactElement {
             onPreventistaChange={(preventistaId: string) => setNuevoPedido(prev => ({ ...prev, preventistaId }))}
             currentUserId={user?.id}
             isOffline={!isOnline}
+            puedeVerDeuda={puedeVerDeudaCliente(perfil?.rol)}
+            saldoActualizadoAt={clientesActualizadosAt}
           />
         </Suspense>
       )}

--- a/src/components/modals/ModalPedido.tsx
+++ b/src/components/modals/ModalPedido.tsx
@@ -1,6 +1,6 @@
 import { useState, useMemo, memo, useRef } from 'react';
 import { X, Loader2, Search, MapPin, Tag, Calendar, Trash2, Pencil, Gift, Truck, ChevronLeft, ChevronRight, ShoppingCart, ChevronUp, LocateFixed, AlertCircle, UserCheck, Percent } from 'lucide-react';
-import { formatPrecio, fechaLocalISO } from '../../utils/formatters';
+import { formatPrecio, fechaLocalISO, formatFecha } from '../../utils/formatters';
 import { parsePrecio } from '../../utils/calculations';
 import { AddressAutocomplete } from '../AddressAutocomplete';
 import { usePromocionPedido, type RegaloOverride } from '../../hooks/usePromocionPedido';
@@ -11,6 +11,7 @@ import ModalBase from './ModalBase';
 import ModalConfirmacion, { type ModalConfirmacionConfig } from './ModalConfirmacion';
 import { obtenerMOQ } from '../../utils/precioMayorista';
 import { motivoMontoMinimo } from '../../utils/montoMinimo';
+import { avisoDeudaCliente } from '../../utils/deudaCliente';
 import { usePoliticasComercialesQuery } from '../../hooks/queries/usePoliticasComercialesQuery';
 import GeolocationGate from '../GeolocationGate';
 import NumberInput from '../ui/NumberInput';
@@ -119,6 +120,17 @@ export interface ModalPedidoProps {
   onActualizarPrecio?: (productoId: string, precio: number) => void;
   /** Si está offline */
   isOffline?: boolean;
+  /**
+   * Si el rol puede ver el aviso de deuda previa del cliente. Lo decide el
+   * container con `puedeVerDeudaCliente` (src/lib/permisos.ts) para no evaluar
+   * el criterio de permisos acá adentro.
+   */
+  puedeVerDeuda?: boolean;
+  /**
+   * Timestamp del fetch de clientes (`dataUpdatedAt`). Solo se usa sin conexión,
+   * para fechar el saldo en el aviso de deuda.
+   */
+  saldoActualizadoAt?: number | null;
   /** Callback al cambiar el preventista asignado (solo admin) */
   onPreventistaChange?: (preventistaId: string) => void;
   /** ID del usuario actual (default del selector de preventista) */
@@ -168,6 +180,8 @@ const ModalPedido = memo(function ModalPedido({
   onPreventistaChange,
   currentUserId,
   isOffline,
+  puedeVerDeuda,
+  saldoActualizadoAt,
   regalosOverride,
   onCambiarRegaloCreacion,
   promosEliminadas,
@@ -254,6 +268,17 @@ const ModalPedido = memo(function ModalPedido({
   // con el cliente esperando, nadie lo hacía y el ruteo quedaba sin ventanas.
   const faltaHorarioCliente =
     !!onGuardarHorarioCliente && clienteSinHorario(clienteSeleccionado);
+
+  // Deuda previa del cliente elegido. AVISA, NO BLOQUEA: es una decisión
+  // explícita: quien vende decide si igual le carga el pedido. Por eso no toca
+  // `disabled` del botón Confirmar, a diferencia del mínimo de compra.
+  // Acá el saldo no incluye este pedido —todavía no existe—, así que se usa
+  // crudo; en la tarjeta hay que descontarlo (ver src/utils/deudaCliente.ts).
+  const avisoDeuda = puedeVerDeuda
+    ? avisoDeudaCliente(clienteSeleccionado?.saldo_cuenta, {
+        saldoAl: isOffline && saldoActualizadoAt ? formatFecha(new Date(saldoActualizadoAt)) : null,
+      })
+    : null;
 
   const handleCapturarGps = async (): Promise<void> => {
     setGpsCapturando(true);
@@ -544,6 +569,19 @@ const ModalPedido = memo(function ModalPedido({
               </div>
             )}
 
+            {/* Deuda previa del cliente elegido. Se muestra acá, en el momento
+                en que se lo elige, que es cuando todavía se puede hablar del
+                tema con el cliente adelante. Sólo avisa. */}
+            {avisoDeuda && (
+              <div
+                role="status"
+                className="mt-3 p-3 rounded-lg border bg-rose-50 border-rose-300 text-sm text-rose-900 dark:bg-rose-900/30 dark:border-rose-700 dark:text-rose-200 flex items-start gap-2"
+              >
+                <AlertCircle className="w-4 h-4 mt-0.5 flex-shrink-0" aria-hidden="true" />
+                <span>{avisoDeuda.detalle}</span>
+              </div>
+            )}
+
             {/* Horario faltante del cliente ya seleccionado. Va DENTRO del
                 ModalBase (no como modal hermano): un Radix Dialog deja
                 cualquier overlay hermano detrás y sería inalcanzable.
@@ -748,6 +786,15 @@ const ModalPedido = memo(function ModalPedido({
             aria-hidden={!carritoAbierto}
           >
             <div className="flex-1 overflow-y-auto overscroll-contain p-4 space-y-4 min-h-0">
+              {/* Deuda previa del cliente (avisa, NO bloquea). Va primero: es lo
+                  único de este bloque que no impide confirmar, y repetirlo acá
+                  es para que no se pierda si el carrito se armó largo. */}
+              {avisoDeuda && (
+                <div role="status" className="p-3 bg-rose-50 border border-rose-300 rounded-lg text-sm text-rose-900 dark:bg-rose-900/30 dark:border-rose-700 dark:text-rose-200">
+                  {avisoDeuda.detalle}
+                </div>
+              )}
+
               {/* Compra mínima del pedido (bloquea confirmar) */}
               {motivoMinimo && (
                 <div role="alert" className="p-3 bg-amber-50 border border-amber-300 rounded-lg text-sm text-amber-900 dark:bg-amber-900/30 dark:border-amber-600 dark:text-amber-200">

--- a/src/components/pedidos/PedidoCard.tsx
+++ b/src/components/pedidos/PedidoCard.tsx
@@ -20,6 +20,8 @@ import AccionesDropdown from './PedidoActions';
 import { useCambiarTipoFacturaMutation } from '../../hooks/queries/usePedidosQuery';
 import { useAuthData } from '../../contexts/AuthDataContext';
 import { haversineMeters, formatDistancia, clasificarDistancia, SEMAFORO_COLORS } from '../../utils/geo';
+import { avisoDeudaCliente } from '../../utils/deudaCliente';
+import { puedeVerDeudaCliente } from '../../lib/permisos';
 import { formatCantidadItem, equivalenteEnUnidades } from '../../utils/unidadesRegalo';
 import type { PedidoDB, MotivoSalvedad } from '../../types';
 
@@ -53,6 +55,12 @@ export interface PedidoCardProps {
   onDesmarcarEntregado?: (pedido: PedidoDB) => void;
   onCancelarPedido?: (pedido: PedidoDB) => void;
   onRegistrarPago?: (pedido: PedidoDB) => void;
+  /**
+   * Timestamp del fetch que trajo estos pedidos (`dataUpdatedAt`). Solo se usa
+   * sin conexion, para fechar el saldo del cliente en el aviso de deuda: el
+   * numero es el del ultimo sync y no incluye lo cobrado despues.
+   */
+  saldoActualizadoAt?: number | null;
 }
 
 interface EstadoConfig {
@@ -282,11 +290,26 @@ function PedidoCard({
   onDesmarcarEntregado,
   onCancelarPedido,
   onRegistrarPago,
+  saldoActualizadoAt,
 }: PedidoCardProps): React.ReactElement {
   const [expandido, setExpandido] = useState<boolean>(false);
   const tieneSalvedad = pedido.salvedades && pedido.salvedades.length > 0;
 
-  const { user } = useAuthData();
+  const { user, perfil, isOnline } = useAuthData();
+
+  // Deuda ANTERIOR a este pedido (avisa, no bloquea). El saldo del cliente ya
+  // incluye lo que este pedido dejo impago —lo suma el trigger
+  // `actualizar_saldo_pedido` en el INSERT—, asi que se descuenta acá; el
+  // porque esta en src/utils/deudaCliente.ts.
+  // El gate por rol se evalua contra `perfil.rol` (rol primario) y no contra las
+  // props isAdmin/isPreventista: VirtualizedPedidoList no pasa `isEncargado`, y
+  // el badge tiene que decidirse igual desde las dos listas que montan la card.
+  const avisoDeuda = puedeVerDeudaCliente(perfil?.rol)
+    ? avisoDeudaCliente(pedido.cliente?.saldo_cuenta, {
+        pedido,
+        saldoAl: !isOnline && saldoActualizadoAt ? formatFecha(new Date(saldoActualizadoAt)) : null,
+      })
+    : null;
 
   // Los handlers llegan por props. Hubo un intento de pasarlos por contexto
   // (HandlersContext) que nunca se termino: el provider no se montaba nunca, asi
@@ -357,6 +380,21 @@ function PedidoCard({
               {/* Mobile: deja que la dirección wrappee a 2 líneas (line-clamp-2)
                   para que el operador la vea entera. Desktop: trunca a 1 línea. */}
               <span className="line-clamp-2 sm:line-clamp-none sm:truncate">{pedido.cliente.direccion}</span>
+            </p>
+          )}
+          {/* Deuda previa del cliente. Va aca —bajo el nombre— y no entre los
+              badges de la derecha porque habla del CLIENTE, no del pedido; ahi
+              se leeria como un estado de pago de este pedido. Es informativo:
+              no bloquea nada. */}
+          {avisoDeuda && (
+            <p className="mt-1.5">
+              <span
+                className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-[13px] font-semibold bg-rose-50 text-rose-700 border border-rose-200/70 dark:bg-rose-900/25 dark:text-rose-300 dark:border-rose-800/40"
+                title={avisoDeuda.detalle}
+              >
+                <AlertTriangle className="w-3.5 h-3.5 flex-shrink-0" aria-hidden="true" />
+                <span className="tabular-nums">{avisoDeuda.etiqueta}</span>
+              </span>
             </p>
           )}
         </div>

--- a/src/components/pedidos/__tests__/PedidoCard.deuda.test.tsx
+++ b/src/components/pedidos/__tests__/PedidoCard.deuda.test.tsx
@@ -1,0 +1,137 @@
+/**
+ * Aviso de deuda previa en la tarjeta del pedido.
+ *
+ * POR QUE ESTE TEST EXISTE
+ * ------------------------
+ * El cálculo puro ya está cubierto en src/utils/deudaCliente.test.ts. Lo que se
+ * verifica acá es el cableado, que es donde el error sería invisible: que la
+ * card le pase `pedido` al util (sin eso, `clientes.saldo_cuenta` incluye lo
+ * que ESTE pedido dejó impago y la tarjeta de cualquier pedido sin cobrar
+ * diría "debe"), y que el gate por rol se evalúe contra el rol primario.
+ *
+ * Se monta la card entera a propósito: un test del util no habría atrapado
+ * ninguna de las dos cosas.
+ */
+import '@testing-library/jest-dom/vitest'
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import type { ReactElement, ReactNode } from 'react'
+
+// Mock de supabase antes de importar el componente: la cadena de imports pide
+// supabaseUrl al cargarse (mismo patrón que VincularTelegramButton.test.tsx).
+vi.mock('../../../lib/supabase', () => ({
+  supabase: {
+    rpc: vi.fn(),
+    from: vi.fn(),
+    auth: {
+      getUser: vi.fn(() => Promise.resolve({ data: { user: null } })),
+      getSession: vi.fn(() => Promise.resolve({ data: { session: null } })),
+      onAuthStateChange: vi.fn(() => ({ data: { subscription: { unsubscribe: vi.fn() } } })),
+    },
+  },
+  setSucursalHeader: vi.fn(),
+  getSucursalHeader: vi.fn(),
+}))
+
+vi.mock('../../../contexts/SucursalContext', () => ({
+  useSucursal: () => ({ currentSucursalId: 1, currentSucursalNombre: 'Test' }),
+}))
+
+import PedidoCard from '../PedidoCard'
+import { AuthDataProvider, type AuthDataContextValue } from '../../../contexts/AuthDataContext'
+import type { PedidoDB, RolUsuario } from '../../../types'
+
+/** Pedido de 30.000 sin cobrar, del cliente `saldoCuenta`. */
+function hacerPedido(saldoCuenta: number, montoPagado = 0): PedidoDB {
+  return {
+    id: '1',
+    cliente_id: '10',
+    estado: 'pendiente',
+    estado_pago: montoPagado === 0 ? 'pendiente' : 'parcial',
+    total: 30000,
+    monto_pagado: montoPagado,
+    fecha: '2026-09-08',
+    cliente: {
+      id: '10',
+      nombre_fantasia: 'Kiosco Test',
+      saldo_cuenta: saldoCuenta,
+    },
+  } as PedidoDB
+}
+
+function renderCard(
+  pedido: PedidoDB,
+  rol: RolUsuario,
+  extra: { isOnline?: boolean; saldoActualizadoAt?: number } = {},
+): void {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  const auth = {
+    user: { id: 'u1' },
+    perfil: { id: 'u1', nombre: 'Test', email: 't@t.com', rol },
+    authReady: true,
+    isAdmin: rol === 'admin',
+    isPreventista: rol === 'preventista',
+    isTransportista: rol === 'transportista',
+    isEncargado: rol === 'encargado',
+    isAdminOrEncargado: rol === 'admin' || rol === 'encargado',
+    rolesEfectivos: [rol],
+    isOnline: extra.isOnline ?? true,
+    logout: vi.fn(),
+    currentSucursalId: 1,
+    currentSucursalNombre: 'Test',
+  } as AuthDataContextValue
+
+  function Wrapper({ children }: { children: ReactNode }): ReactElement {
+    return (
+      <QueryClientProvider client={qc}>
+        <AuthDataProvider value={auth}>{children}</AuthDataProvider>
+      </QueryClientProvider>
+    )
+  }
+
+  render(<PedidoCard pedido={pedido} saldoActualizadoAt={extra.saldoActualizadoAt} />, {
+    wrapper: Wrapper,
+  })
+}
+
+describe('PedidoCard — aviso de deuda previa', () => {
+  it('NO avisa cuando toda la deuda es este mismo pedido', () => {
+    // El trigger ya sumó los 30.000 impagos de este pedido al saldo del cliente.
+    // Si la card no los descontara, todo pedido impago mostraría "debe".
+    renderCard(hacerPedido(30000), 'preventista')
+    expect(screen.queryByText(/Debe/)).not.toBeInTheDocument()
+  })
+
+  it('avisa sólo por lo anterior cuando además hay deuda vieja', () => {
+    // Saldo 50.000 = 30.000 de este pedido + 20.000 de antes.
+    renderCard(hacerPedido(50000), 'preventista')
+    expect(screen.getByText(/Debe/)).toHaveTextContent('20.000')
+  })
+
+  it('no avisa cuando el cliente está al día', () => {
+    renderCard(hacerPedido(0), 'preventista')
+    expect(screen.queryByText(/Debe/)).not.toBeInTheDocument()
+  })
+
+  it.each(['admin', 'encargado', 'preventista'] as const)('lo ve el rol %s', rol => {
+    renderCard(hacerPedido(50000), rol)
+    expect(screen.getByText(/Debe/)).toBeInTheDocument()
+  })
+
+  it.each(['transportista', 'deposito'] as const)('lo oculta al rol %s', rol => {
+    renderCard(hacerPedido(50000), rol)
+    expect(screen.queryByText(/Debe/)).not.toBeInTheDocument()
+  })
+
+  it('sin conexión habla en pasado y fecha el dato', () => {
+    const alMediodia = new Date('2026-09-06T15:00:00Z').getTime()
+    renderCard(hacerPedido(50000), 'preventista', {
+      isOnline: false,
+      saldoActualizadoAt: alMediodia,
+    })
+    // "Debía $20.000,00 al 6/9, 12:00" — el número solo sería una afirmación
+    // sobre ahora que el teléfono no puede sostener.
+    expect(screen.getByText(/Debía/)).toHaveTextContent('6/9')
+  })
+})

--- a/src/components/vistas/VistaPedidos.tsx
+++ b/src/components/vistas/VistaPedidos.tsx
@@ -29,6 +29,11 @@ import type { PedidoStatsSummary } from '../../hooks/queries';
 export interface VistaPedidosProps {
   /** Pedidos de la página actual (ya paginados server-side) */
   pedidos: PedidoDB[];
+  /**
+   * `dataUpdatedAt` de la query de pedidos. Sólo lo usa la card sin conexión,
+   * para fechar el saldo del cliente en el aviso de deuda previa.
+   */
+  saldoActualizadoAt?: number | null;
   /** Total de pedidos que coinciden con los filtros (para paginación) */
   totalCount: number;
   /** Totales por estado/pago sobre todos los pedidos filtrados (no sólo la página) */
@@ -114,6 +119,7 @@ export interface VistaPedidosProps {
 
 export default function VistaPedidos({
   pedidos,
+  saldoActualizadoAt,
   totalCount,
   statsSummary,
   paginaActual,
@@ -253,6 +259,7 @@ export default function VistaPedidos({
               >
                 <PedidoCard
                   pedido={pedido}
+                  saldoActualizadoAt={saldoActualizadoAt}
                   isAdmin={isAdmin}
                   isPreventista={isPreventista}
                   isTransportista={isTransportista}

--- a/src/hooks/queries/usePedidosQuery.ts
+++ b/src/hooks/queries/usePedidosQuery.ts
@@ -123,7 +123,13 @@ interface ActualizarPagoInput {
 // inferencia de PostgREST: un string sin literal-type degradaria el resultado
 // a GenericStringError. Mantener sincronizado con el tipo PedidoDB.
 const PEDIDO_PRODUCT_COLS = 'id, nombre, codigo, categoria, unidades_de_venta_por_fardo, etiqueta_bulto' as const
-const PEDIDO_CLIENT_COLS = 'id, nombre_fantasia, razon_social, cuit, direccion, aclaracion_direccion, telefono, contacto, latitud, longitud, horarios_atencion, dias_atencion, horario_entrega, zona, zona_id' as const
+// saldo_cuenta: alimenta el aviso de deuda previa de la tarjeta (src/utils/
+// deudaCliente.ts). Es una columna mas DENTRO del embed que ya existe, no un
+// embed nuevo: agregar un segundo alias a clientes (o embeber pagos) haria
+// ambigua la FK y tiraria PGRST201, volteando la query entera de pedidos.
+// Viaja tambien a useRecorridoExistenteQuery y useRecorridosHojaRutaQuery, que
+// reusan PEDIDO_SELECT; ninguna de las dos la muestra.
+const PEDIDO_CLIENT_COLS = 'id, nombre_fantasia, razon_social, cuit, direccion, aclaracion_direccion, telefono, contacto, latitud, longitud, horarios_atencion, dias_atencion, horario_entrega, zona, zona_id, saldo_cuenta' as const
 // pagos(forma_pago, monto): permite a la card derivar la forma de pago real
 // (incluido "Combinado") sin queries extra. Los pagos combinados se guardan
 // como N filas en `pagos` (una por forma_pago); pedidos.forma_pago es el

--- a/src/lib/permisos.test.ts
+++ b/src/lib/permisos.test.ts
@@ -13,6 +13,7 @@ import {
   puedeAccederTransferencias,
   puedeControlarStock,
   puedeRegistrarPagoCliente,
+  puedeVerDeudaCliente,
   puedeDesactivarCliente,
   puedeEliminarCliente,
   mostrarMontosEnStats,
@@ -115,6 +116,26 @@ describe('permisos por rol', () => {
       expect(puedeRegistrarPagoCliente('deposito')).toBe(false)
       expect(puedeRegistrarPagoCliente(null)).toBe(false)
       expect(puedeRegistrarPagoCliente(undefined)).toBe(false)
+    })
+  })
+
+  // /pedidos esta habilitado para cinco roles (TopNavigation), pero el aviso de
+  // deuda es para quien VENDE: el que decide si le carga un pedido mas a un
+  // cliente que debe. El transportista y el deposito lo ven sin poder hacer
+  // nada con el, y en el reparto el saldo es el del ultimo sync: no incluye lo
+  // que el chofer acaba de cobrar.
+  describe('puedeVerDeudaCliente (aviso de deuda previa)', () => {
+    it('permite a quien vende y a quien controla la cuenta', () => {
+      expect(puedeVerDeudaCliente('admin')).toBe(true)
+      expect(puedeVerDeudaCliente('encargado')).toBe(true)
+      expect(puedeVerDeudaCliente('preventista')).toBe(true)
+    })
+
+    it('lo oculta en el reparto y en deposito', () => {
+      expect(puedeVerDeudaCliente('transportista')).toBe(false)
+      expect(puedeVerDeudaCliente('deposito')).toBe(false)
+      expect(puedeVerDeudaCliente(null)).toBe(false)
+      expect(puedeVerDeudaCliente(undefined)).toBe(false)
     })
   })
 

--- a/src/lib/permisos.ts
+++ b/src/lib/permisos.ts
@@ -130,6 +130,21 @@ export function puedeRegistrarPagoCliente(rol: RolUsuario | null | undefined): b
   return rol === 'admin' || rol === 'encargado'
 }
 
+/**
+ * Si el rol puede ver el aviso de deuda previa del cliente al cargar un pedido y
+ * en la tarjeta del pedido. Admin, encargado y preventista.
+ *
+ * Es quien vende el que necesita saberlo antes de tomar el pedido. Se le oculta
+ * al transportista y al depósito, que también entran a /pedidos
+ * (TopNavigation): el saldo que ve la app es el del último sync y no incluye lo
+ * cobrado en la calle, así que en el reparto sería un número desactualizado
+ * discutiéndose delante del cliente. Al encargado sí, por el mismo criterio con
+ * el que `mostrarMontosEnStats` le deja ver el stat de impagos.
+ */
+export function puedeVerDeudaCliente(rol: RolUsuario | null | undefined): boolean {
+  return rol === 'admin' || rol === 'encargado' || rol === 'preventista'
+}
+
 /** Si el rol puede editar el descuento porcentual precargado del cliente. */
 export function puedeEditarDescuentoCliente(rol: RolUsuario | null | undefined): boolean {
   return rol === 'admin'

--- a/src/utils/deudaCliente.test.ts
+++ b/src/utils/deudaCliente.test.ts
@@ -1,0 +1,106 @@
+/**
+ * Tests del aviso de deuda previa.
+ *
+ * POR QUE ESTOS CASOS
+ * -------------------
+ * El caso que manda es "el saldo incluye este pedido": el trigger
+ * `actualizar_saldo_pedido` suma lo impago del pedido al saldo del cliente en el
+ * mismo INSERT, así que sin descontarlo la tarjeta de CUALQUIER pedido impago
+ * diría "debe" — que es exactamente lo contrario de avisar de un pedido
+ * anterior. Si alguien saca ese descuento, este archivo tiene que ponerse rojo.
+ *
+ * El segundo en importancia es el sobrepago: ahí la contribución del pedido al
+ * saldo es negativa, y restarla sin clamp inventaría deuda. Este aviso se lee
+ * delante del cliente; que subestime es aceptable, que acuse de más no.
+ */
+import { describe, it, expect } from 'vitest'
+import { avisoDeudaCliente } from './deudaCliente'
+
+describe('avisoDeudaCliente — al crear el pedido (sin pedido propio)', () => {
+  it('no avisa cuando el cliente está al día', () => {
+    expect(avisoDeudaCliente(0)).toBeNull()
+  })
+
+  it('no avisa cuando el cliente tiene saldo a favor', () => {
+    // saldo_cuenta negativo = a favor del cliente (COMMENT de la columna).
+    expect(avisoDeudaCliente(-5000)).toBeNull()
+  })
+
+  it('no avisa sin dato de saldo', () => {
+    expect(avisoDeudaCliente(null)).toBeNull()
+    expect(avisoDeudaCliente(undefined)).toBeNull()
+    expect(avisoDeudaCliente(NaN)).toBeNull()
+  })
+
+  it('avisa con el monto cuando el cliente debe', () => {
+    const aviso = avisoDeudaCliente(12500)
+    expect(aviso?.monto).toBe(12500)
+    expect(aviso?.etiqueta).toContain('12.500')
+    expect(aviso?.detalle).toContain('12.500')
+  })
+
+  it('ignora restos por debajo del centavo en vez de avisar $0', () => {
+    expect(avisoDeudaCliente(0.004)).toBeNull()
+    expect(avisoDeudaCliente(0.01)).not.toBeNull()
+  })
+})
+
+describe('avisoDeudaCliente — en la tarjeta (el saldo YA incluye este pedido)', () => {
+  it('no avisa cuando la deuda es sólo este pedido', () => {
+    // Único pedido impago del cliente: saldo == lo que este pedido debe.
+    expect(
+      avisoDeudaCliente(30000, { pedido: { total: 30000, monto_pagado: 0 } }),
+    ).toBeNull()
+  })
+
+  it('avisa sólo por lo anterior cuando hay deuda vieja además de este pedido', () => {
+    // Saldo 50.000 = 30.000 de este pedido + 20.000 de antes.
+    const aviso = avisoDeudaCliente(50000, { pedido: { total: 30000, monto_pagado: 0 } })
+    expect(aviso?.monto).toBe(20000)
+  })
+
+  it('descuenta sólo la parte impaga de un pedido con pago parcial', () => {
+    // Este pedido aporta 30.000 - 18.000 = 12.000 al saldo; lo anterior son 8.000.
+    const aviso = avisoDeudaCliente(20000, { pedido: { total: 30000, monto_pagado: 18000 } })
+    expect(aviso?.monto).toBe(8000)
+  })
+
+  it('un pedido ya cobrado no descuenta nada: el saldo es todo deuda previa', () => {
+    const aviso = avisoDeudaCliente(20000, { pedido: { total: 30000, monto_pagado: 30000 } })
+    expect(aviso?.monto).toBe(20000)
+  })
+
+  it('un pedido sobrepagado no infla la deuda avisada', () => {
+    // Aporte real al saldo = -5.000. Restarlo daría 25.000: deuda inventada.
+    const aviso = avisoDeudaCliente(20000, { pedido: { total: 30000, monto_pagado: 35000 } })
+    expect(aviso?.monto).toBe(20000)
+  })
+
+  it('un pedido cancelado (total 0, mig 175) no descuenta nada', () => {
+    const aviso = avisoDeudaCliente(20000, { pedido: { total: 0, monto_pagado: 0 } })
+    expect(aviso?.monto).toBe(20000)
+  })
+
+  it('trata monto_pagado ausente como 0, igual que el COALESCE del trigger', () => {
+    expect(avisoDeudaCliente(30000, { pedido: { total: 30000 } })).toBeNull()
+  })
+
+  it('no deja resto de float cuando el pedido es toda la deuda', () => {
+    // 0.1 + 0.2 en float no da 0.3: sin redondeo esto avisaría por milésimas.
+    expect(avisoDeudaCliente(0.3, { pedido: { total: 0.1 + 0.2, monto_pagado: 0 } })).toBeNull()
+  })
+})
+
+describe('avisoDeudaCliente — saldo posiblemente viejo (offline)', () => {
+  it('habla en pasado y dice de cuándo es el dato', () => {
+    const aviso = avisoDeudaCliente(12500, { saldoAl: '6/9, 14:32' })
+    expect(aviso?.etiqueta).toContain('6/9, 14:32')
+    expect(aviso?.detalle).toContain('6/9, 14:32')
+    expect(aviso?.detalle).toContain('cobrado después')
+  })
+
+  it('sin fecha del dato no inventa una', () => {
+    const aviso = avisoDeudaCliente(12500, { saldoAl: '   ' })
+    expect(aviso?.etiqueta).toMatch(/^Debe\s+\$\s?12\.500,00$/)
+  })
+})

--- a/src/utils/deudaCliente.ts
+++ b/src/utils/deudaCliente.ts
@@ -1,0 +1,104 @@
+/**
+ * Aviso de deuda previa del cliente. AVISA, NO BLOQUEA.
+ *
+ * El dato es `clientes.saldo_cuenta` (positivo = debe, negativo = a favor), que
+ * ya viaja en el front sin ninguna consulta extra. No se usa "boletas vencidas"
+ * porque esa definición vive en `obtener_deudores_mora` (mig 075), que está
+ * cerrada a admin y encargado: el preventista —que es para quien se hizo este
+ * aviso— no la puede consultar.
+ *
+ * EL SALDO INCLUYE AL PROPIO PEDIDO
+ * ---------------------------------
+ * `trigger_actualizar_saldo_pedido` suma `total - COALESCE(monto_pagado, 0)` al
+ * saldo del cliente en el INSERT del pedido, y lo recalcula en cada UPDATE de
+ * esas dos columnas. O sea: en la tarjeta del pedido X, el saldo del cliente YA
+ * contiene lo que X dejó impago. Mostrarlo crudo diría "debe" en toda tarjeta
+ * impaga, que es lo contrario de avisar de un pedido ANTERIOR. Por eso `pedido`
+ * descuenta la contribución de ese pedido al saldo.
+ *
+ * El clamp a 0 de esa contribución no es cosmético: si el pedido está SOBRE
+ * pagado (monto_pagado > total) su aporte al saldo es negativo, y restarlo
+ * inflaría la deuda mostrada. Ante la duda, este aviso subestima: acusar de una
+ * deuda que no existe, delante del cliente, es peor que no avisar.
+ *
+ * OFFLINE
+ * -------
+ * El saldo que ve un teléfono sin señal es el del último sync y no incluye lo
+ * que se haya cobrado después. Por eso `saldoAl`: cuando el dato puede estar
+ * viejo el texto lo dice y habla en pasado, en vez de afirmar una deuda de
+ * ahora.
+ *
+ * OJO: `saldo_cuenta` es denormalizado y tiene historial de descuadres (migs
+ * 020, 052, 072, 086, 165, 166, 168). Este aviso vuelve visible en la calle
+ * cualquier descuadre viejo que hasta ahora sólo se veía en la ficha.
+ */
+import { formatPrecio } from './formatters'
+
+/** Un peso: por debajo de un centavo no hay deuda que avisar, hay ruido de float. */
+const EPSILON = 0.01
+
+export interface AvisoDeuda {
+  /** Deuda en $. Siempre > 0: si no hay deuda no hay aviso. */
+  monto: number
+  /** Etiqueta corta, para un badge en la tarjeta del pedido. */
+  etiqueta: string
+  /** Texto largo, para el alta del pedido. */
+  detalle: string
+}
+
+export interface AvisoDeudaOpts {
+  /**
+   * Pedido cuya parte impaga YA está sumada en `saldoCuenta` y hay que
+   * descontar para quedarse con la deuda ANTERIOR a él. Sin esto, el aviso
+   * sería el propio pedido.
+   */
+  pedido?: { total?: number | null; monto_pagado?: number | null } | null
+  /**
+   * Fecha del dato, ya formateada, cuando el saldo puede estar viejo (sin
+   * conexión). Si viene, el texto habla en pasado y la incluye.
+   */
+  saldoAl?: string | null
+}
+
+function aNumero(valor: number | null | undefined): number {
+  const n = Number(valor)
+  return Number.isFinite(n) ? n : 0
+}
+
+/**
+ * Deuda a avisar, o null si no hay nada que avisar.
+ *
+ * Sin `pedido` responde "¿cuánto debe este cliente?" (alta de pedido).
+ * Con `pedido` responde "¿cuánto debía ANTES de este pedido?" (tarjeta).
+ */
+export function avisoDeudaCliente(
+  saldoCuenta: number | null | undefined,
+  opts: AvisoDeudaOpts = {},
+): AvisoDeuda | null {
+  const saldo = aNumero(saldoCuenta)
+
+  // Lo que este pedido aporta hoy al saldo, espejo de actualizar_saldo_pedido.
+  const aportePropio = opts.pedido
+    ? Math.max(0, aNumero(opts.pedido.total) - aNumero(opts.pedido.monto_pagado))
+    : 0
+
+  const monto = Math.round((saldo - aportePropio) * 100) / 100
+  if (monto < EPSILON) return null
+
+  const importe = formatPrecio(monto)
+  const saldoAl = opts.saldoAl?.trim()
+
+  return saldoAl
+    ? {
+        monto,
+        etiqueta: `Debía ${importe} al ${saldoAl}`,
+        detalle:
+          `Sin conexión: al ${saldoAl} este cliente debía ${importe}. ` +
+          `No incluye lo que se le haya cobrado después.`,
+      }
+    : {
+        monto,
+        etiqueta: `Debe ${importe}`,
+        detalle: `Este cliente tiene una deuda previa de ${importe}.`,
+      }
+}


### PR DESCRIPTION
Al elegir el cliente en el alta de pedido, y en la tarjeta del pedido, ahora se
ve si ese cliente tiene deuda previa. **Avisa, no bloquea** — decisión explícita:
quien vende decide si igual le carga el pedido. No toca `disabled` de Confirmar,
a diferencia de la compra mínima (mig 205).

Front puro: no toca `crear_pedido_completo`, ni `crear_pedido_completo_bot`, ni
el bot de Telegram, ni SQL.

## El criterio

`clientes.saldo_cuenta > 0`, que ya viajaba al front sin ninguna consulta nueva.
No se usa "boletas vencidas" porque esa definición vive en
`obtener_deudores_mora` (mig 075), cerrada a admin y encargado: el preventista
—para quien se hizo esto— no la puede consultar.

En prod son **121 de 718 clientes activos** (17%), mediana $33.300: aparece
1 de cada 6, no es ruido constante.

## La trampa: el saldo YA incluye el propio pedido

`trigger_actualizar_saldo_pedido` suma `total - COALESCE(monto_pagado, 0)` al
saldo en el INSERT del pedido. Mostrar el saldo crudo en la tarjeta diría "debe"
en **toda** tarjeta impaga, que es exactamente lo contrario de avisar de un
pedido *anterior*. Se descuenta, con clamp a 0 para que un pedido sobrepagado no
invente deuda: ante la duda el aviso subestima, porque se lee delante del
cliente.

La regla pura vive en `src/utils/deudaCliente.ts` con 15 tests. Los 9 tests de
`PedidoCard.deuda.test.tsx` cubren el cableado —que la card le pase el pedido al
util, y el gate por rol—, que es donde el error sería invisible para un test del
util solo.

## Sin conexión

El saldo es el del último sync y no incluye lo que el chofer haya cobrado hoy.
El texto pasa a *"Sin conexión: al 6/9, 12:00 este cliente debía $X. No incluye
lo que se le haya cobrado después"*, con el `dataUpdatedAt` de la query. Decirle
"debe $X" a alguien que ya pagó es peor que no avisar.

## Quién lo ve

Admin, encargado y preventista (`puedeVerDeudaCliente`), evaluado contra el rol
**primario**. Al transportista y a depósito, que también entran a `/pedidos`, se
les oculta. En la card el gate sale de `perfil.rol` y no de las props porque
`VirtualizedPedidoList` no pasa `isEncargado`.

## El embed (PGRST201)

`saldo_cuenta` entra como una columna más **dentro** del embed `cliente:clientes(...)`
que ya existía, no como embed nuevo. Probado con `curl` + anon key contra prod:
**200**; el control negativo con la columna mal escrita da **400 / 42703**, así
que el 200 prueba algo. La columna viaja también a `useRecorridoExistenteQuery`
y `useRecorridosHojaRutaQuery`, que reusan `PEDIDO_SELECT`; ninguna la muestra.

## Verificación

`typecheck`, `lint`, **1593 tests** (118 archivos) y `build`, todo verde.

No verificado: la app corriendo con datos reales (requiere login).

## Dos cosas que quedan afuera

- **El descuadre de `saldo_cuenta` no existe hoy.** Comparé el saldo contra la
  fórmula canónica (la de la mig 199) para los 718 activos: 0 descuadrados,
  desvío total $0,00. El riesgo de que el badge vuelva discutible un descuadre
  viejo no se materializa.
- **La alerta de crédito del bot es letra muerta** (1 de 718 clientes tiene
  `limite_credito > 0`), así que el mismo preventista ve dos reglas distintas
  según el canal. Va en un issue aparte.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
