### PR TITLE
En la tarjeta, la deuda es «por otros pedidos», no «previa»

### DIFF
--- a/src/components/pedidos/__tests__/PedidoCard.deuda.test.tsx
+++ b/src/components/pedidos/__tests__/PedidoCard.deuda.test.tsx
@@ -109,6 +109,14 @@ describe('PedidoCard — aviso de deuda previa', () => {
     expect(screen.getByText(/Debe/)).toHaveTextContent('20.000')
   })
 
+  // El badge NO dice "deuda previa": el monto es la deuda menos ESTE pedido, y
+  // eso puede venir de uno posterior. Un cliente con dos impagos ve, en la
+  // tarjeta del viejo, el saldo del nuevo.
+  it('el badge dice que la deuda es por OTROS pedidos', () => {
+    renderCard(hacerPedido(50000), 'preventista')
+    expect(screen.getByText(/Debe/)).toHaveTextContent('por otros pedidos')
+  })
+
   it('no avisa cuando el cliente está al día', () => {
     renderCard(hacerPedido(0), 'preventista')
     expect(screen.queryByText(/Debe/)).not.toBeInTheDocument()

--- a/src/utils/deudaCliente.test.ts
+++ b/src/utils/deudaCliente.test.ts
@@ -15,6 +15,9 @@
  */
 import { describe, it, expect } from 'vitest'
 import { avisoDeudaCliente } from './deudaCliente'
+// El importe sale de `formatPrecio`, que es Intl y separa con espacio DURO:
+// hardcodearlo con un espacio normal nunca matchea.
+import { formatPrecio } from './formatters'
 
 describe('avisoDeudaCliente — al crear el pedido (sin pedido propio)', () => {
   it('no avisa cuando el cliente está al día', () => {
@@ -91,11 +94,58 @@ describe('avisoDeudaCliente — en la tarjeta (el saldo YA incluye este pedido)'
   })
 })
 
+describe('avisoDeudaCliente — qué dice el texto según lo que el dato garantiza', () => {
+  it('en la tarjeta habla de OTROS pedidos, no de deuda previa', () => {
+    // Con `pedido`, el monto es la deuda menos ESE pedido — y eso puede venir
+    // de un pedido POSTERIOR. Decir "previa" ahí es cronológicamente falso.
+    const aviso = avisoDeudaCliente(50000, { pedido: { total: 20000, monto_pagado: 0 } })
+
+    expect(aviso?.etiqueta).toBe(`Debe ${formatPrecio(30000)} por otros pedidos`)
+    expect(aviso?.detalle).toContain('Además de este pedido')
+    expect(aviso?.detalle).not.toContain('previa')
+  })
+
+  it('el detalle avisa que puede haber pedidos posteriores', () => {
+    const aviso = avisoDeudaCliente(50000, { pedido: { total: 20000 } })
+    expect(aviso?.detalle).toContain('posteriores')
+  })
+
+  it('en el alta sí es toda la deuda del cliente, y el texto lo dice', () => {
+    // Sin `pedido` no hay nada que descontar: el pedido todavía no existe.
+    const aviso = avisoDeudaCliente(50000)
+
+    expect(aviso?.etiqueta).toBe(`Debe ${formatPrecio(50000)}`)
+    expect(aviso?.detalle).toContain('deuda previa')
+    expect(aviso?.etiqueta).not.toContain('otros pedidos')
+  })
+
+  // El caso que motivó el cambio, con los dos pedidos de un mismo cliente.
+  it('la tarjeta del pedido VIEJO no llama "previa" a la deuda del nuevo', () => {
+    // Cliente con A (viejo, $20.000) y B (nuevo, $30.000), los dos impagos.
+    // El saldo del cliente es 50.000 y la tarjeta de A muestra los 30.000 de B.
+    const enLaTarjetaDeA = avisoDeudaCliente(50000, { pedido: { total: 20000, monto_pagado: 0 } })
+
+    expect(enLaTarjetaDeA?.monto).toBe(30000)
+    expect(enLaTarjetaDeA?.detalle).not.toContain('previa')
+  })
+})
+
 describe('avisoDeudaCliente — saldo posiblemente viejo (offline)', () => {
   it('habla en pasado y dice de cuándo es el dato', () => {
     const aviso = avisoDeudaCliente(12500, { saldoAl: '6/9, 14:32' })
     expect(aviso?.etiqueta).toContain('6/9, 14:32')
     expect(aviso?.detalle).toContain('6/9, 14:32')
+    expect(aviso?.detalle).toContain('cobrado después')
+  })
+
+  it('sin conexión, en la tarjeta, el detalle sigue diciendo el alcance', () => {
+    const aviso = avisoDeudaCliente(50000, {
+      pedido: { total: 20000 },
+      saldoAl: '6/9, 14:32',
+    })
+    // La antigüedad pesa más que el alcance: el badge la lleva a ella.
+    expect(aviso?.etiqueta).toBe(`Debía ${formatPrecio(30000)} al 6/9, 14:32`)
+    expect(aviso?.detalle).toContain('por otros pedidos')
     expect(aviso?.detalle).toContain('cobrado después')
   })
 

--- a/src/utils/deudaCliente.ts
+++ b/src/utils/deudaCliente.ts
@@ -21,6 +21,16 @@
  * inflaría la deuda mostrada. Ante la duda, este aviso subestima: acusar de una
  * deuda que no existe, delante del cliente, es peor que no avisar.
  *
+ * "OTROS PEDIDOS", NO "DEUDA PREVIA"
+ * ---------------------------------
+ * Con `pedido`, el monto es la deuda del cliente MENOS este pedido — y eso
+ * incluye pedidos POSTERIORES a él. Para un cliente con un solo impago da lo
+ * mismo, pero hay 10 clientes con dos o más (hasta 5): en la tarjeta del más
+ * viejo, el número es el de los más nuevos. Llamarlo "deuda previa" ahí es
+ * cronológicamente falso, y es la clase de imprecisión que termina en una
+ * discusión con el cliente en el mostrador. El texto dice lo que el dato
+ * garantiza: que hay deuda por FUERA de este pedido.
+ *
  * OFFLINE
  * -------
  * El saldo que ve un teléfono sin señal es el del último sync y no incluye lo
@@ -87,14 +97,33 @@ export function avisoDeudaCliente(
 
   const importe = formatPrecio(monto)
   const saldoAl = opts.saldoAl?.trim()
+  // Con `pedido` el monto excluye a ESE pedido, así que la deuda es "por otros
+  // pedidos" y no "previa": puede venir de uno posterior. Sin `pedido` —el alta,
+  // donde todavía no existe— sí es toda la deuda del cliente.
+  const esPorOtrosPedidos = !!opts.pedido
 
-  return saldoAl
+  if (saldoAl) {
+    // Sin conexión el dato es del último sync: se habla en pasado y se fecha.
+    // La antigüedad pesa más que el alcance, así que el badge la lleva a ella y
+    // el alcance queda en el detalle.
+    return {
+      monto,
+      etiqueta: `Debía ${importe} al ${saldoAl}`,
+      detalle: esPorOtrosPedidos
+        ? `Sin conexión: al ${saldoAl} este cliente debía ${importe} por otros pedidos. ` +
+          `No incluye lo que se le haya cobrado después.`
+        : `Sin conexión: al ${saldoAl} este cliente debía ${importe}. ` +
+          `No incluye lo que se le haya cobrado después.`,
+    }
+  }
+
+  return esPorOtrosPedidos
     ? {
         monto,
-        etiqueta: `Debía ${importe} al ${saldoAl}`,
+        etiqueta: `Debe ${importe} por otros pedidos`,
         detalle:
-          `Sin conexión: al ${saldoAl} este cliente debía ${importe}. ` +
-          `No incluye lo que se le haya cobrado después.`,
+          `Además de este pedido, este cliente debe ${importe}. ` +
+          `Puede incluir pedidos posteriores a éste.`,
       }
     : {
         monto,


### PR DESCRIPTION
Sale de revisar #530. El cálculo estaba bien; la palabra no.

## El problema

En la tarjeta, el monto es la deuda del cliente **menos ese pedido** — y eso incluye pedidos **posteriores** a él. Un cliente con dos impagos ve, en la tarjeta del más viejo, el saldo del más nuevo, etiquetado como *"deuda previa"*.

Es cronológicamente falso, y es la clase de imprecisión que termina en una discusión con el cliente en el mostrador.

Medido en prod: **10 clientes tienen más de un pedido impago** (hasta 5), con **$2.670.750** entre ellos. Acotado, pero existe.

## Qué cambia

**El número no.** "Cuánto debe además de este pedido" sigue siendo el dato útil. Cambia lo que el texto **afirma**, que ahora es lo que el dato garantiza:

| Contexto | Badge | Detalle |
|---|---|---|
| **Tarjeta** | `Debe $X por otros pedidos` | Además de este pedido, este cliente debe $X. Puede incluir pedidos posteriores a éste. |
| **Alta** | `Debe $X` *(sin cambios)* | tiene una deuda previa de $X *(sin cambios)* |

El alta no se toca: ahí no hay pedido que descontar, así que sí es toda la deuda del cliente y "previa" es literalmente correcto.

Sin conexión el badge sigue priorizando la **antigüedad** del dato sobre el alcance (`Debía $X al 6/9, 14:32`): que el número pueda estar viejo pesa más que de dónde viene. El alcance queda en el detalle.

## Los tests que había no protegían esto

Verificaban el monto con `toContain('20.000')`, no el texto — así que pasaban igual con el copy viejo. Se agregan **5 que sí lo fijan**, uno de ellos con los dos pedidos del mismo cliente para dejar el caso escrito.

Verificado que muerden: volviendo al copy anterior caen 4.

## Contexto de la revisión

También verifiqué contra prod el resto de #530, y está todo bien:

- `trigger_actualizar_saldo_pedido` es `AFTER INSERT OR DELETE OR UPDATE OF total, monto_pagado` — exactamente lo que el docblock asume, así que descontar el aporte propio es necesario y correcto.
- `saldo_cuenta` == Σ `max(0, total − monto_pagado)` sobre impagos no cancelados, **cliente por cliente, cero desvíos**: la resta usa la misma fórmula y los bordes (cancelado, pagado, sobrepagado) cierran solos.
- El embed no introduce ambigüedad de FK; `saldo_cuenta` está tipado en `ClienteDB`.

`typecheck`, `lint`, `test:run` (118 archivos / 1599 tests, sin `.env`) y `build`: los cuatro en verde.

🤖 Generated with [Claude Code](https://claude.com/claude-code)