### PR TITLE
Stock de la red para todo admin, y el costo que viaja con el producto

### DIFF
--- a/migrations/210_stock_de_la_red.sql
+++ b/migrations/210_stock_de_la_red.sql
@@ -1,0 +1,197 @@
+-- Stock, costo y precio de la otra sucursal — solo lectura, para todo admin
+--
+-- EL PEDIDO
+-- ---------
+-- "Que cualquier admin pueda ver el stock, el costo y el precio de la otra
+-- sucursal, en SOLO LECTURA."
+--
+-- POR QUE HACE FALTA CODIGO
+-- -------------------------
+-- De los 7 admins, solo dos (Agustin y Jorge) estan en `usuario_sucursales`
+-- para las dos sucursales. Julio y Pablo son admin solo de Taco Pozo; Emilia,
+-- Nacho y Virginia solo de Tucuman. Todo lo que hay hoy cruza contra
+-- `usuario_sucursales`, asi que esos cinco no ven la otra sucursal por ningun
+-- lado: `reporte_valuacion_inventario` (mig 131) INTERSECTA las sucursales
+-- activas con las asignadas, y la policy `mt_productos_select` filtra por
+-- `current_sucursal_id()`.
+--
+-- POR QUE NO SE LOS AGREGA A usuario_sucursales
+-- ---------------------------------------------
+-- Porque eso no es "ver": es acceso OPERATIVO completo a la otra sucursal
+-- (crear pedidos, mover stock, editar productos, cambiar precios). El pedido
+-- es de lectura.
+--
+-- POR QUE NO SE RELAJA mt_productos_select
+-- ----------------------------------------
+-- `fetchProductos` es `.from('productos').select('*')` SIN filtro de sucursal,
+-- y ninguno de los 24 call sites de `.from('productos')` lleva
+-- `.eq('sucursal_id')`: TODO el aislamiento lo pone la policy. Abrirla haria
+-- que el selector de items del pedido, las categorias, las mermas,
+-- ModalCrearMovimiento y el backup a Excel pasen a mostrar el catalogo de las
+-- dos sucursales, en silencio y sin que falle ningun test. Y la policy es
+-- sobre la FILA ENTERA: expondria costo_sin_iva, costo_con_iva, costo_real,
+-- costo_promedio, precio y proveedor_id de una. Un RPC elige columna por
+-- columna, y este devuelve solo stock, costo (promedio y reposicion) y precio.
+--
+-- POR QUE UN RPC NUEVO Y NO UN PARAMETRO EN LA 131
+-- ------------------------------------------------
+-- Agregarle un `p_todas boolean DEFAULT false` a
+-- `reporte_valuacion_inventario(bigint)` deja dos sobrecargas con rangos
+-- [obligatorios, total] superpuestos: PostgREST no sabria cual llamar y
+-- tiraria PGRST203 en runtime, invisible para tsc, eslint y los tests
+-- (precedente: mig 176). Nombre nuevo, sin sobrecarga.
+--
+-- EL GATE
+-- -------
+-- Rol CRUDO de `perfiles`, como las migs 130 y 131. Nunca `es_preventista()`
+-- ni `es_transportista()`, que devuelven true tambien para admin y encargado.
+-- Alcanza con ser admin en alguna sucursal asignada ademas de por rol global:
+-- el front gatea `/reportes` con el rol EN LA SUCURSAL ACTIVA
+-- (`App.tsx: currentSucursalRol ?? perfil.rol`), asi que si el RPC mirara
+-- solo el rol global, un admin-en-la-sucursal-pero-no-global entraria a la
+-- pantalla y recibiria "Acceso denegado". El gate del RPC es superset del
+-- gate del front: todo el que ve la pestaña puede leer el dato.
+--
+-- Encargado NO entra. La 131 lo deja pasar para SU sucursal; cruzar de
+-- sucursal es otra cosa y el pedido dijo admin.
+--
+-- QUE DEVUELVE
+-- ------------
+-- Una fila por producto de cada sucursal activa (TODAS, tambien las que no
+-- estan asignadas al usuario), con stock, costo promedio, costo de reposicion
+-- y precio de lista, mas agregados por sucursal. No filtra `stock <> 0` como
+-- la 131: acá el "Taco Pozo tiene 0" es justamente el dato que se busca.
+--
+-- EL EMPAREJADO NO SE HACE ACA
+-- ----------------------------
+-- No hay clave que una un producto de Tucuman con "el mismo" de Taco Pozo:
+-- filas independientes, ids distintos, sin tabla de equivalencias, y
+-- `productos.codigo` no tiene UNIQUE. El RPC devuelve las filas planas y el
+-- emparejado (codigo exacto o nombre exacto, el criterio estricto de
+-- `sugerirMatchProducto`) vive en `src/utils/stockRed.ts`, con tests. Medido
+-- hoy: de 176 productos en Tucuman y 111 en Taco Pozo emparejan 10. El resto
+-- no es un error del emparejado: son catalogos distintos, y la vista los
+-- muestra en su propia seccion en vez de esconderlos.
+
+CREATE OR REPLACE FUNCTION public.reporte_stock_red(
+  p_sucursal_id bigint DEFAULT NULL
+)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ STABLE SECURITY DEFINER
+ SET search_path TO 'public'
+AS $function$
+DECLARE
+  v_sucursales bigint[]; v_nombre text; v_result jsonb;
+  v_es_servicio boolean := (auth.uid() IS NULL);
+  v_rol text; v_es_admin boolean;
+BEGIN
+  IF NOT v_es_servicio THEN
+    SELECT rol INTO v_rol FROM perfiles WHERE id = auth.uid() AND COALESCE(activo, true);
+    -- Admin global, o admin en alguna sucursal asignada ('mismo' resuelve al
+    -- rol global, igual que _rol_en_sucursal).
+    v_es_admin := (v_rol = 'admin') OR EXISTS (
+      SELECT 1 FROM usuario_sucursales us
+      WHERE us.usuario_id = auth.uid()
+        AND (CASE WHEN us.rol = 'mismo' THEN v_rol ELSE us.rol END) = 'admin');
+    IF NOT COALESCE(v_es_admin, false) THEN
+      RAISE EXCEPTION 'Acceso denegado: se requiere rol admin'; END IF;
+  END IF;
+
+  -- SIN interseccion contra usuario_sucursales: es el punto del RPC.
+  IF p_sucursal_id IS NULL THEN
+    SELECT array_agg(id ORDER BY id) INTO v_sucursales FROM sucursales WHERE activa;
+    v_nombre := 'Red (consolidado)';
+  ELSE
+    SELECT nombre INTO v_nombre FROM sucursales WHERE id = p_sucursal_id;
+    IF v_nombre IS NULL THEN
+      RAISE EXCEPTION 'La sucursal % no existe', p_sucursal_id; END IF;
+    v_sucursales := ARRAY[p_sucursal_id];
+  END IF;
+  IF v_sucursales IS NULL OR array_length(v_sucursales, 1) IS NULL THEN
+    RAISE EXCEPTION 'No hay sucursales activas'; END IF;
+
+  WITH
+  base AS (
+    SELECT p.id, p.nombre, p.codigo, p.stock, p.precio,
+           p.sucursal_id, s.nombre AS sucursal_nombre,
+           COALESCE(NULLIF(p.categoria,''),'(sin categoría)') AS categoria,
+           -- Misma cascada que la 131 y que costoCanonicoUnitario(): en ZZ lo
+           -- pagado ya incluye IVA e impuestos internos y quedó en costo_real,
+           -- así que la fórmula (semántica FC) es el último recurso.
+           COALESCE(p.costo_promedio, p.costo_real,
+                    round(p.costo_sin_iva*(1+COALESCE(p.impuestos_internos,0)/100), 4)) AS cpp,
+           COALESCE(p.costo_real,
+                    round(p.costo_sin_iva*(1+COALESCE(p.impuestos_internos,0)/100), 4)) AS reposicion,
+           p.ultimo_tipo_compra
+    FROM productos p
+    JOIN sucursales s ON s.id = p.sucursal_id
+    WHERE p.sucursal_id = ANY(v_sucursales)
+  ),
+  productos_j AS (
+    SELECT jsonb_agg(jsonb_build_object(
+        'producto_id', id, 'nombre', nombre, 'codigo', codigo,
+        'categoria', categoria,
+        'sucursal_id', sucursal_id, 'sucursal_nombre', sucursal_nombre,
+        'stock', stock, 'precio', precio,
+        'costo_promedio', cpp, 'costo_reposicion', reposicion,
+        'ultimo_tipo_compra', ultimo_tipo_compra
+      ) ORDER BY nombre, sucursal_id) AS arr
+    FROM base
+  ),
+  sucursales_j AS (
+    SELECT jsonb_agg(to_jsonb(x) ORDER BY x.sucursal_nombre) AS arr FROM (
+      SELECT sucursal_id, sucursal_nombre,
+             COUNT(*) AS productos,
+             COUNT(*) FILTER (WHERE stock > 0) AS productos_con_stock,
+             COALESCE(SUM(GREATEST(stock,0)), 0) AS unidades,
+             COALESCE(round(SUM(GREATEST(stock,0) * COALESCE(cpp,0)), 2), 0) AS valuacion_promedio
+      FROM base GROUP BY sucursal_id, sucursal_nombre
+    ) x
+  )
+  SELECT jsonb_build_object(
+    'meta', jsonb_build_object(
+      'sucursal_id', p_sucursal_id, 'sucursal_nombre', COALESCE(v_nombre,'?'),
+      'generado_at', now(),
+      'criterio', 'costo promedio ponderado (fallback: costo reposición) · solo lectura'),
+    'sucursales', (SELECT COALESCE(arr,'[]'::jsonb) FROM sucursales_j),
+    'productos', (SELECT COALESCE(arr,'[]'::jsonb) FROM productos_j)
+  ) INTO v_result;
+
+  RETURN v_result;
+END;
+$function$;
+
+COMMENT ON FUNCTION public.reporte_stock_red(bigint) IS
+  'Stock, costo y precio de TODAS las sucursales activas, solo lectura. Gate: admin (rol crudo). No cruza contra usuario_sucursales, a proposito. mig 210.';
+
+REVOKE ALL ON FUNCTION public.reporte_stock_red(bigint) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.reporte_stock_red(bigint) TO authenticated, service_role;
+
+-- Toda funcion nueva nace con EXECUTE para PUBLIC y el GRANT a authenticated
+-- no lo revierte (ver README § Permisos y el gate scripts/check-permisos.mjs).
+DO $verif$
+DECLARE
+  v_acl text;
+BEGIN
+  SELECT array_to_string(proacl, ',') INTO v_acl
+  FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace
+  WHERE n.nspname = 'public' AND p.proname = 'reporte_stock_red';
+
+  IF v_acl IS NULL THEN
+    RAISE EXCEPTION 'reporte_stock_red quedo con ACL default (PUBLIC ejecuta)'; END IF;
+  IF v_acl LIKE '=X/%' OR v_acl LIKE '%,=X/%' THEN
+    RAISE EXCEPTION 'reporte_stock_red quedo ejecutable por PUBLIC: %', v_acl; END IF;
+  IF v_acl LIKE '%anon=%' THEN
+    RAISE EXCEPTION 'reporte_stock_red quedo ejecutable por anon: %', v_acl; END IF;
+  IF v_acl NOT LIKE '%authenticated=X%' THEN
+    RAISE EXCEPTION 'reporte_stock_red no quedo ejecutable por authenticated: %', v_acl; END IF;
+END
+$verif$;
+
+-- VERIFICACION (post-aplicacion, con un admin de una sola sucursal):
+--   SELECT jsonb_pretty(reporte_stock_red(NULL) -> 'sucursales');
+--   -- tiene que traer las DOS sucursales activas, no solo la asignada.
+-- Y con la anon key, tiene que dar 42501 (permission denied for function):
+--   curl -s -X POST "$SUPABASE_URL/rest/v1/rpc/reporte_stock_red" \
+--     -H "apikey: $ANON" -H "Content-Type: application/json" -d '{}'

--- a/migrations/211_el_costo_viaja_con_el_producto.sql
+++ b/migrations/211_el_costo_viaja_con_el_producto.sql
@@ -1,0 +1,155 @@
+-- El producto que nace en el destino se lleva su valuacion del origen
+--
+-- EL DEFECTO
+-- ----------
+-- `aceptar_movimiento_sucursal` sube el stock del destino y escribe
+-- `costo_con_iva` / `costo_sin_iva` con GREATEST(origen, destino), pero cuando
+-- el producto NO existe en el destino lo CREA sin `costo_real`, sin
+-- `costo_promedio` y sin `ultimo_tipo_compra`. La funcion viene de la mig 076,
+-- anterior a la 111 (costo_real) y a la 127 (costo_promedio): nadie volvio
+-- sobre ella cuando aparecieron esas columnas.
+--
+-- POR QUE IMPORTA
+-- ---------------
+-- Toda la app valua por la cascada
+--     COALESCE(snapshot, costo_promedio, costo_real,
+--              costo_sin_iva * (1 + impuestos_internos/100))
+-- (migs 130 y 131, y `costoCanonicoUnitario()` en JS). Un producto recien
+-- creado por un movimiento entra a esa cascada por el ULTIMO escalon, que
+-- tiene semantica FC: neto + impuestos internos. Si la ultima compra del
+-- origen fue ZZ, lo pagado YA incluye IVA e impuestos internos (mig 111), asi
+-- que sumarselos encima cuenta el impuesto dos veces — exactamente lo que la
+-- 111 vino a arreglar. En una Manaos con neto ~5.365 e II 8,6956% son ~466
+-- pesos por unidad de costo inventado. Y `ultimo_tipo_compra` en NULL borra
+-- el unico dato que distingue FC de ZZ, asi que el error no se puede ni
+-- detectar mirando la fila.
+--
+-- LA EVIDENCIA
+-- ------------
+-- En Taco Pozo hay 10 productos nacidos de un movimiento
+-- (`movimiento_sucursal_items.resolucion = 'creado_nuevo'`). De esos, 3
+-- siguen hoy con `costo_real` Y `costo_promedio` en NULL (ALFATUC BLANCO
+-- DISPLAY X 18, ALFATUC NEGRO DISPLAY X 18, SAL FINA x 500 g x 10 u) y otros
+-- 2 con `costo_promedio` en NULL (los FIDEO COTELLA). Los cinco tienen
+-- `ultimo_tipo_compra` NULL. Sus origenes en Tucuman tenian los tres campos
+-- cargados en el momento del envio: el dato existia y se tiraba.
+-- Da la casualidad de que esos cinco tienen impuestos internos 0, asi que hoy
+-- la cascada no infla nada; el proximo producto con II que se cree por un
+-- movimiento si.
+--
+-- QUE CAMBIA Y QUE NO
+-- -------------------
+-- CAMBIA: al crear el producto en el destino se copian `costo_real`,
+-- `costo_promedio` y `ultimo_tipo_compra` de la fila del origen.
+--
+-- NO CAMBIA la regla de costo del camino "match con un producto existente":
+-- sigue siendo GREATEST(origen, destino) sobre costo_con_iva/costo_sin_iva.
+-- Es una decision comercial tomada a proposito y documentada en la mig 076,
+-- no un olvido; cambiarla por "promediar como una compra" es otra discusion,
+-- y ademas obligaria a cambiar el texto del modal
+-- (`ModalAceptarMovimiento.tsx`: "Costo destino quedara en X (el mayor)").
+-- Corolario conocido: en ese camino `costo_real` y `costo_promedio` del
+-- destino siguen sin moverse, asi que las unidades que entran quedan valuadas
+-- al promedio viejo del destino. Queda igual que antes a proposito.
+--
+-- NO SE BACKFILLEAN los 5 productos de arriba. El costo del origen HOY no es
+-- el costo de aquellas unidades (los FIDEO ya divergieron: 5.584,04 en el
+-- origen contra 5.895,55 en el destino), y el promedio ponderado es
+-- forward-only por diseño (mig 127). Inventarles un promedio retroactivo
+-- seria peor que dejarlos con el fallback.
+--
+-- POR QUE EL PARCHE ES QUIRURGICO Y NO UN CREATE OR REPLACE
+-- ---------------------------------------------------------
+-- La mig 177 ya parcheo esta funcion IN SITU (le metio `condicion_iva` al
+-- INSERT) leyendo `pg_get_functiondef`. Un CREATE OR REPLACE armado desde el
+-- texto de `migrations/139` revertiria ese cambio EN SILENCIO. Se usa el mismo
+-- patron: se lee la definicion VIVA del catalogo y se reemplaza sobre ella,
+-- con un helper que falla si el ancla no aparece exactamente una vez.
+
+CREATE OR REPLACE FUNCTION public._mig211_reemplazo_unico(
+  p_texto text, p_ancla text, p_nuevo text, p_donde text
+) RETURNS text LANGUAGE plpgsql IMMUTABLE AS $helper$
+DECLARE
+  v_veces integer;
+BEGIN
+  v_veces := (length(p_texto) - length(replace(p_texto, p_ancla, ''))) / length(p_ancla);
+  IF v_veces <> 1 THEN
+    RAISE EXCEPTION 'mig 211 · % : el ancla "%" aparece % veces (se esperaba 1). El cuerpo derivo del texto conocido; revisa el parche antes de aplicar.',
+      p_donde, left(p_ancla, 70), v_veces;
+  END IF;
+  RETURN replace(p_texto, p_ancla, p_nuevo);
+END;
+$helper$;
+
+DO $mig$
+DECLARE
+  v_def text;
+BEGIN
+  v_def := pg_get_functiondef('public.aceptar_movimiento_sucursal(bigint, jsonb)'::regprocedure);
+  IF v_def LIKE '%v_orig_costo_real%' THEN RETURN; END IF;
+
+  v_def := public._mig211_reemplazo_unico(v_def,
+    $a$  v_items_count integer;$a$,
+    $a$  v_items_count integer;
+  v_orig_costo_real numeric; v_orig_costo_promedio numeric; v_orig_tipo_compra varchar;$a$,
+    'aceptar_movimiento_sucursal/declare');
+
+  -- Si el producto del origen ya no existe, el SELECT INTO deja los tres en
+  -- NULL y el INSERT queda como estaba: nunca es peor que hoy.
+  v_def := public._mig211_reemplazo_unico(v_def,
+    $a$    IF v_accion = 'crear_nuevo' THEN
+      INSERT INTO productos ($a$,
+    $a$    IF v_accion = 'crear_nuevo' THEN
+      -- mig 211: el producto nace en el destino con la valuacion del origen.
+      SELECT o.costo_real, o.costo_promedio, o.ultimo_tipo_compra
+        INTO v_orig_costo_real, v_orig_costo_promedio, v_orig_tipo_compra
+        FROM productos o
+        WHERE o.id = v_item.producto_origen_id AND o.sucursal_id = v_mov.sucursal_origen_id;
+      INSERT INTO productos ($a$,
+    'aceptar_movimiento_sucursal/select-origen');
+
+  v_def := public._mig211_reemplazo_unico(v_def,
+    $a$        unidades_de_venta_por_fardo, etiqueta_bulto, tp_import_id, sucursal_id
+      ) VALUES ($a$,
+    $a$        unidades_de_venta_por_fardo, etiqueta_bulto, tp_import_id, sucursal_id,
+        costo_real, costo_promedio, ultimo_tipo_compra
+      ) VALUES ($a$,
+    'aceptar_movimiento_sucursal/insert-columnas');
+
+  v_def := public._mig211_reemplazo_unico(v_def,
+    $a$        v_item.origen_unidades_por_fardo, v_item.origen_etiqueta_bulto, v_item.origen_tp_import_id, v_destino
+      ) RETURNING id, stock INTO v_dest_id, v_stock_d;$a$,
+    $a$        v_item.origen_unidades_por_fardo, v_item.origen_etiqueta_bulto, v_item.origen_tp_import_id, v_destino,
+        v_orig_costo_real, v_orig_costo_promedio, v_orig_tipo_compra
+      ) RETURNING id, stock INTO v_dest_id, v_stock_d;$a$,
+    'aceptar_movimiento_sucursal/insert-valores');
+
+  EXECUTE v_def;
+END;
+$mig$;
+
+DROP FUNCTION IF EXISTS public._mig211_reemplazo_unico(text, text, text, text);
+
+-- La funcion parcheada conserva sus permisos (ALTER/REPLACE no los toca) y no
+-- se crea ninguna funcion nueva que quede abierta a PUBLIC: el helper se
+-- dropea arriba. Verificacion de que el parche entro y de que no se perdio lo
+-- que puso la 177:
+DO $verif$
+DECLARE
+  v_def text;
+BEGIN
+  v_def := pg_get_functiondef('public.aceptar_movimiento_sucursal(bigint, jsonb)'::regprocedure);
+  IF v_def NOT LIKE '%v_orig_costo_real%' THEN
+    RAISE EXCEPTION 'el parche de la mig 211 no quedo aplicado'; END IF;
+  IF v_def NOT LIKE '%condicion_iva%' THEN
+    RAISE EXCEPTION 'se perdio el parche de la mig 177 (condicion_iva)'; END IF;
+END
+$verif$;
+
+-- VERIFICACION MANUAL (no hay tests de aceptar_movimiento_sucursal):
+--   1. Mover a la otra sucursal un producto que NO exista alla, aceptarlo con
+--      "crear nuevo", y mirar la fila creada:
+--        SELECT nombre, costo_sin_iva, costo_real, costo_promedio, ultimo_tipo_compra
+--          FROM productos WHERE id = <nuevo>;
+--      Los tres ultimos tienen que venir del origen, no NULL.
+--   2. SELECT * FROM auditoria_integridad();

--- a/migrations/MANIFEST.md
+++ b/migrations/MANIFEST.md
@@ -1,6 +1,6 @@
 # MANIFEST de migraciones — mapeo repo ↔ producción
 
-> **Fechado: 2026-08-26** · Proyecto prod `hmuchlzmuqqxcldbzkgc` (ManaosApp) · región `sa-east-1`.
+> **Fechado: 2026-09-08** · Proyecto prod `hmuchlzmuqqxcldbzkgc` (ManaosApp) · región `sa-east-1`.
 
 ## Regla de oro
 
@@ -137,10 +137,14 @@ funcional** y no se renombran los archivos: renombrarlos los desalinearía del l
 real lo da `version` y está en la sección A: en los dos casos el archivo de `main` quedó
 cronológicamente **fuera** del bloque 139–147 (uno antes, otro entre la 144 y la 145).
 
-**La próxima migración es la 206** — la última numerada en el repo es
-`205_hacer_valer_la_compra_minima`, y el ledger de prod está alineado con ella.
+**La próxima migración es la 212** — la última numerada en el repo es
+`211_el_costo_viaja_con_el_producto`, y el ledger de prod está alineado con ella.
 Igual, confirmá el número contra las tres fuentes justo antes de aplicar: el
 número se reserva **aplicando**, no escribiendo el archivo.
+
+(Esta línea decía 206 hasta el 2026-09-08, con las 206–209 ya aplicadas: la
+numeración del repo avanzó cuatro veces sin que nadie la corrigiera. Si aplicás
+una migración, actualizá también esta línea.)
 
 Las 197–202 no tienen prosa acá (quedaron sin documentar en su momento). Las 203, 204 y
 205 sí:
@@ -163,6 +167,28 @@ Las 197–202 no tienen prosa acá (quedaron sin documentar en su momento). Las 
   Sólo redefine funciones: **no toca ninguna fila**. El rollback está al pie del
   archivo y es gratis mientras los mínimos sigan en 0; si alguien ya cargó uno,
   revertirla apaga la validación sin avisar.
+
+Las 206–209 tampoco tienen prosa acá. Las 210 y 211 sí:
+
+- **210** crea `reporte_stock_red(bigint)`: stock, costo y precio de **todas** las
+  sucursales activas, solo lectura, gate de admin por rol crudo. Es el único RPC que
+  **no** intersecta contra `usuario_sucursales` — a propósito: 5 de los 7 admins están
+  asignados a una sola sucursal y no veían la otra por ningún lado. No se relajó
+  `mt_productos_select` porque `fetchProductos` no filtra por sucursal en ningún call
+  site y la policy es sobre la fila entera. Nombre nuevo en vez de un parámetro en la
+  131, para no dejar dos sobrecargas ambiguas (PGRST203, ver mig 176).
+  **No toca ninguna fila.**
+- **211** parchea `aceptar_movimiento_sucursal` para que el producto que se CREA en el
+  destino se lleve `costo_real`, `costo_promedio` y `ultimo_tipo_compra` del origen.
+  Sin eso nacía con los tres en NULL y la cascada de costo caía al último escalón, que
+  tiene semántica FC (neto + impuestos internos): con un origen ZZ eso suma dos veces
+  el impuesto interno. El parche es **quirúrgico sobre la definición viva** (mismo
+  patrón que la 177, que ya la había parcheado in situ: un `CREATE OR REPLACE` armado
+  desde `migrations/139` revertiría `condicion_iva` en silencio).
+  **No toca ninguna fila** — no backfillea los 5 productos que ya quedaron sin costo
+  (el costo del origen HOY no es el de aquellas unidades y el CPP es forward-only).
+  La regla `GREATEST(origen, destino)` del camino "match con un producto existente"
+  queda **igual**: es una decisión comercial de la 076, no un olvido.
 
 La **195** le da a la cabecera la columna `compras.bonificaciones`, que es donde se resta
 una bonificación general: el `subtotal` es el neto de los RENGLONES y lo clava `COMPRA-A2`

--- a/src/components/vistas/VistaReportes.tsx
+++ b/src/components/vistas/VistaReportes.tsx
@@ -8,6 +8,7 @@
  * - Ventas por Cliente  (RPC reporte_ventas_por_cliente, mig 197)
  * - Ventas por Zona     (mismo RPC, mismo cache)
  * - Valuación de Stock
+ * - Stock de la red   (RPC reporte_stock_red — cross-sucursal, solo lectura)
  *
  * Los sub-componentes están extraídos en archivos separados para
  * mejor mantenibilidad y separación de concerns.
@@ -19,7 +20,7 @@
  */
 import React, { useState, useEffect, ChangeEvent } from 'react';
 import type { LucideIcon } from 'lucide-react';
-import { TrendingUp, BarChart3, X, Loader2, Users, DollarSign, MapPin, Boxes } from 'lucide-react';
+import { TrendingUp, BarChart3, X, Loader2, Users, DollarSign, MapPin, Boxes, Network } from 'lucide-react';
 import { formatPrecio } from '../../utils/formatters';
 import { useReportesFinancieros } from '../../hooks/supabase';
 import type {
@@ -38,6 +39,7 @@ import {
   ReporteVentasClientes,
   ReporteVentasZonas,
   ReporteValuacionInventario,
+  ReporteStockRed,
   FiltrosVentas,
   filtrosVentasIniciales,
   type FiltrosVentasValue
@@ -62,10 +64,10 @@ interface TabConfig {
   icon: LucideIcon;
 }
 
-type ReportTabId = 'preventistas' | 'cuentas' | 'rentabilidad' | 'clientes' | 'zonas' | 'valuacion';
+type ReportTabId = 'preventistas' | 'cuentas' | 'rentabilidad' | 'clientes' | 'zonas' | 'valuacion' | 'stock-red';
 
 /** Tabs que traen sus propios filtros y no usan el panel de fechas de arriba. */
-const TABS_CON_FILTROS_PROPIOS: ReportTabId[] = ['clientes', 'zonas', 'valuacion'];
+const TABS_CON_FILTROS_PROPIOS: ReportTabId[] = ['clientes', 'zonas', 'valuacion', 'stock-red'];
 
 // =============================================================================
 // COMPONENT
@@ -106,7 +108,8 @@ export default function VistaReportes({
     { id: 'rentabilidad', label: 'Rentabilidad', icon: TrendingUp },
     { id: 'clientes', label: 'Por Cliente', icon: Users },
     { id: 'zonas', label: 'Por Zona', icon: MapPin },
-    { id: 'valuacion', label: 'Valuación de Stock', icon: Boxes }
+    { id: 'valuacion', label: 'Valuación de Stock', icon: Boxes },
+    { id: 'stock-red', label: 'Stock de la Red', icon: Network }
   ];
 
   // Cargar reporte automáticamente solo la primera vez
@@ -308,6 +311,10 @@ export default function VistaReportes({
 
       {activeTab === 'valuacion' && (
         <ReporteValuacionInventario formatPrecio={formatPrecio} />
+      )}
+
+      {activeTab === 'stock-red' && (
+        <ReporteStockRed formatPrecio={formatPrecio} />
       )}
     </div>
   );

--- a/src/components/vistas/reportes/ReporteStockRed.test.tsx
+++ b/src/components/vistas/reportes/ReporteStockRed.test.tsx
@@ -1,0 +1,157 @@
+/**
+ * Stock de la red: lo que NO se puede esconder.
+ *
+ * El emparejado entre sucursales es una heurística (código o nombre exactos) y
+ * empareja poco: medido el 2026-09-08, de 176 productos en Tucumán y 111 en
+ * Taco Pozo emparejaron 10. Si la vista mostrara solo los emparejados, el
+ * 96% del catálogo desaparecería de la pantalla sin decirlo. Estos tests fijan
+ * que lo que no empareja se sigue viendo, con su sucursal y su cantidad.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ReporteStockRed } from './ReporteStockRed';
+import type { StockRed } from '../../../hooks/queries/useStockRedQuery';
+
+const mockQuery = vi.fn();
+vi.mock('../../../hooks/queries/useStockRedQuery', () => ({
+  useStockRedQuery: (...args: unknown[]) => mockQuery(...args),
+}));
+
+const formatPrecio = (n: number): string => `$${n}`;
+
+const DATA: StockRed = {
+  meta: {
+    sucursal_id: null,
+    sucursal_nombre: 'Red (consolidado)',
+    generado_at: '2026-09-08T00:00:00Z',
+    criterio: 'costo promedio ponderado',
+  },
+  sucursales: [
+    {
+      sucursal_id: 2,
+      sucursal_nombre: 'Taco Pozo',
+      productos: 2,
+      productos_con_stock: 2,
+      unidades: 12,
+      valuacion_promedio: 1000,
+    },
+    {
+      sucursal_id: 1,
+      sucursal_nombre: 'Tucuman',
+      productos: 2,
+      productos_con_stock: 1,
+      unidades: 7,
+      valuacion_promedio: 2000,
+    },
+  ],
+  productos: [
+    {
+      producto_id: 10, sucursal_id: 1, sucursal_nombre: 'Tucuman',
+      nombre: 'ALFATUC BLANCO x 18 u', codigo: 'A1', categoria: 'GALLETITAS',
+      stock: 7, costo_promedio: 4300, costo_reposicion: 4300,
+      ultimo_tipo_compra: 'ZZ', precio: 6000,
+    },
+    {
+      producto_id: 11, sucursal_id: 1, sucursal_nombre: 'Tucuman',
+      nombre: 'SOLO TUCUMAN', codigo: null, categoria: 'VARIOS',
+      stock: 0, costo_promedio: null, costo_reposicion: null,
+      ultimo_tipo_compra: null, precio: 100,
+    },
+    {
+      producto_id: 20, sucursal_id: 2, sucursal_nombre: 'Taco Pozo',
+      nombre: 'ALFATUC BLANCO DISPLAY X 18', codigo: 'A1', categoria: 'GALLETITAS',
+      stock: 3, costo_promedio: 4500, costo_reposicion: 4500,
+      ultimo_tipo_compra: 'ZZ', precio: 6500,
+    },
+    {
+      producto_id: 21, sucursal_id: 2, sucursal_nombre: 'Taco Pozo',
+      nombre: 'SOLO TACO POZO', codigo: 'B9', categoria: 'VARIOS',
+      stock: 9, costo_promedio: 50, costo_reposicion: 60,
+      ultimo_tipo_compra: 'FC', precio: 120,
+    },
+  ],
+};
+
+function montar(data: StockRed = DATA): void {
+  mockQuery.mockReturnValue({ data, isLoading: false, error: null });
+  render(<ReporteStockRed formatPrecio={formatPrecio} />);
+}
+
+describe('ReporteStockRed', () => {
+  it('dice que es solo lectura', () => {
+    montar();
+    expect(screen.getByText(/Solo lectura/i)).toBeInTheDocument();
+  });
+
+  it('muestra las dos sucursales, no solo la activa', () => {
+    montar();
+    expect(screen.getAllByText('Tucuman').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('Taco Pozo').length).toBeGreaterThan(0);
+  });
+
+  it('empareja el producto que está en las dos y muestra el stock de cada una', () => {
+    montar();
+    expect(screen.getByText('En más de una sucursal (1)')).toBeInTheDocument();
+    // La celda del nombre lleva además el código y la categoría, así que la
+    // fila se busca por su contenido y no por un texto exacto.
+    const fila = screen
+      .getAllByRole('row')
+      .find((r) => r.textContent?.includes('ALFATUC BLANCO DISPLAY X 18'));
+    expect(fila).toBeDefined();
+    expect(fila).toHaveTextContent('7');
+    expect(fila).toHaveTextContent('3');
+    // El costo y el precio de la OTRA sucursal, que es el punto del reporte.
+    expect(fila).toHaveTextContent('$4500');
+    expect(fila).toHaveTextContent('$6500');
+  });
+
+  it('el par muestra los dos nombres: el emparejado es una heurística y tiene que poder auditarse', () => {
+    montar();
+    const fila = screen
+      .getAllByRole('row')
+      .find((r) => r.textContent?.includes('ALFATUC BLANCO DISPLAY X 18'));
+    expect(fila).toHaveTextContent('Tucuman: ALFATUC BLANCO x 18 u');
+  });
+
+  it('lo que no empareja NO se esconde: va en su propia sección, por sucursal', () => {
+    montar();
+    expect(screen.getByText('Solo en Tucuman (1)')).toBeInTheDocument();
+    expect(screen.getByText('Solo en Taco Pozo (1)')).toBeInTheDocument();
+    expect(screen.getByText('SOLO TUCUMAN')).toBeInTheDocument();
+    expect(screen.getByText('SOLO TACO POZO')).toBeInTheDocument();
+  });
+
+  it('con una sucursal elegida muestra su catálogo completo, emparejados incluidos', async () => {
+    montar();
+    await userEvent.selectOptions(screen.getByLabelText('Sucursal'), '2');
+
+    expect(screen.getByText('Taco Pozo (2)')).toBeInTheDocument();
+    expect(screen.getByText('ALFATUC BLANCO DISPLAY X 18')).toBeInTheDocument();
+    expect(screen.getByText('SOLO TACO POZO')).toBeInTheDocument();
+    // Nada de la otra sucursal.
+    expect(screen.queryByText('SOLO TUCUMAN')).not.toBeInTheDocument();
+  });
+
+  it('el buscador encuentra por el nombre de la otra sucursal', async () => {
+    montar();
+    await userEvent.type(screen.getByLabelText('Buscar producto'), 'display');
+
+    expect(screen.getByText('En más de una sucursal (1)')).toBeInTheDocument();
+    expect(screen.getByText('Solo en Taco Pozo (0)')).toBeInTheDocument();
+  });
+
+  it('"solo con stock" esconde el que está en cero en todas', async () => {
+    montar();
+    await userEvent.click(screen.getByLabelText('Solo con stock'));
+
+    expect(screen.queryByText('SOLO TUCUMAN')).not.toBeInTheDocument();
+    expect(screen.getByText('SOLO TACO POZO')).toBeInTheDocument();
+  });
+
+  it('avisa el error en vez de mostrar una tabla vacía', () => {
+    mockQuery.mockReturnValue({ data: undefined, isLoading: false, error: new Error('boom') });
+    render(<ReporteStockRed formatPrecio={formatPrecio} />);
+    expect(screen.getByText(/No se pudo cargar el stock de la red: boom/)).toBeInTheDocument();
+  });
+});

--- a/src/components/vistas/reportes/ReporteStockRed.tsx
+++ b/src/components/vistas/reportes/ReporteStockRed.tsx
@@ -1,0 +1,410 @@
+/**
+ * Stock de la red — stock, costo y precio de TODAS las sucursales.
+ *
+ * SOLO LECTURA. Cualquier admin ve las dos sucursales, esté asignado o no: el
+ * dato viene del RPC `reporte_stock_red`, que no cruza contra
+ * `usuario_sucursales`. No se relajó la policy `mt_productos_select` porque
+ * eso abriría el catálogo entero (selector de items del pedido, mermas,
+ * backup a Excel) y expondría la fila completa; el RPC elige columna por
+ * columna.
+ *
+ * Sobre el emparejado: no hay clave que una un producto de una sucursal con
+ * "el mismo" de la otra. Se usa el criterio estricto de `emparejarRed`
+ * (código o nombre exactos) y lo que no empareja se muestra aparte, con su
+ * nombre y su cantidad: son catálogos distintos, no un error del reporte.
+ */
+import React, { useMemo, useState } from 'react';
+import { AlertTriangle, Network, Search } from 'lucide-react';
+import LoadingSpinner from '../../layout/LoadingSpinner';
+import { useStockRedQuery } from '../../../hooks/queries/useStockRedQuery';
+import {
+  emparejarRed,
+  coincideBusqueda,
+  tieneStock,
+  type FilaRed,
+  type ProductoRed,
+} from '../../../utils/stockRed';
+
+export interface ReporteStockRedProps {
+  formatPrecio: (precio: number) => string;
+}
+
+function claseStock(stock: number): string {
+  if (stock < 0) return 'text-red-600 dark:text-red-400';
+  if (stock === 0) return 'text-gray-400';
+  return 'text-gray-800 dark:text-gray-100';
+}
+
+/** Las tres celdas (stock/costo/precio) de una sucursal en la tabla comparativa. */
+function CeldasSucursal({
+  producto,
+  formatPrecio,
+}: {
+  producto: ProductoRed | undefined;
+  formatPrecio: (precio: number) => string;
+}): React.ReactElement {
+  if (!producto) {
+    return (
+      <>
+        <td className="py-2 pr-4 text-right text-gray-300 dark:text-gray-600">—</td>
+        <td className="py-2 pr-4 text-right text-gray-300 dark:text-gray-600">—</td>
+        <td className="py-2 pr-4 text-right text-gray-300 dark:text-gray-600">—</td>
+      </>
+    );
+  }
+  return (
+    <>
+      <td className={`py-2 pr-4 text-right font-semibold ${claseStock(producto.stock)}`}>
+        {producto.stock}
+      </td>
+      <td className="py-2 pr-4 text-right">
+        {producto.costo_promedio != null ? formatPrecio(producto.costo_promedio) : '—'}
+      </td>
+      <td className="py-2 pr-4 text-right">{formatPrecio(producto.precio)}</td>
+    </>
+  );
+}
+
+/** Tabla plana de una sola sucursal (catálogo completo o exclusivos). */
+function TablaSucursal({
+  filas,
+  sucursalId,
+  formatPrecio,
+}: {
+  filas: FilaRed[];
+  sucursalId: number;
+  formatPrecio: (precio: number) => string;
+}): React.ReactElement {
+  return (
+    <table className="w-full text-sm">
+      <thead>
+        <tr className="text-left text-gray-500 dark:text-gray-400 border-b dark:border-gray-700">
+          <th className="py-2 pr-4">Producto</th>
+          <th className="py-2 pr-4">Categoría</th>
+          <th className="py-2 pr-4 text-right">Stock</th>
+          <th className="py-2 pr-4 text-right">Costo prom.</th>
+          <th className="py-2 pr-4 text-right">Reposición</th>
+          <th className="py-2 text-right">Precio</th>
+        </tr>
+      </thead>
+      <tbody>
+        {filas.map((f) => {
+          const p = f.porSucursal[sucursalId];
+          if (!p) return null;
+          return (
+            <tr key={f.clave} className="border-b dark:border-gray-700/50 last:border-0">
+              <td className="py-2 pr-4 text-gray-800 dark:text-gray-100">
+                {p.nombre}
+                {p.codigo && <span className="ml-2 text-xs text-gray-400">{p.codigo}</span>}
+                {p.ultimo_tipo_compra && (
+                  <span className="ml-2 text-[10px] font-semibold px-1.5 py-0.5 rounded bg-gray-100 dark:bg-gray-700 text-gray-500 dark:text-gray-300">
+                    {p.ultimo_tipo_compra}
+                  </span>
+                )}
+              </td>
+              <td className="py-2 pr-4 text-gray-500 dark:text-gray-400">{p.categoria}</td>
+              <td className={`py-2 pr-4 text-right font-semibold ${claseStock(p.stock)}`}>
+                {p.stock}
+              </td>
+              <td className="py-2 pr-4 text-right">
+                {p.costo_promedio != null ? formatPrecio(p.costo_promedio) : '—'}
+              </td>
+              <td className="py-2 pr-4 text-right">
+                {p.costo_reposicion != null ? formatPrecio(p.costo_reposicion) : '—'}
+              </td>
+              <td className="py-2 text-right">{formatPrecio(p.precio)}</td>
+            </tr>
+          );
+        })}
+      </tbody>
+    </table>
+  );
+}
+
+export function ReporteStockRed({ formatPrecio }: ReporteStockRedProps): React.ReactElement {
+  const { data, isLoading, error } = useStockRedQuery(null);
+  const [sucursalSel, setSucursalSel] = useState<number | 'red'>('red');
+  const [busqueda, setBusqueda] = useState('');
+  const [categoriaFiltro, setCategoriaFiltro] = useState('todas');
+  const [soloConStock, setSoloConStock] = useState(false);
+
+  const sucursales = useMemo(() => data?.sucursales ?? [], [data]);
+  const orden = useMemo(() => sucursales.map((s) => s.sucursal_id), [sucursales]);
+
+  const { emparejados, sinPar } = useMemo(
+    () => emparejarRed(data?.productos ?? [], orden),
+    [data, orden]
+  );
+
+  const filtrar = useMemo(
+    () =>
+      (filas: FilaRed[]): FilaRed[] =>
+        filas.filter(
+          (f) =>
+            (categoriaFiltro === 'todas' || f.categoria === categoriaFiltro) &&
+            (!soloConStock || tieneStock(f)) &&
+            coincideBusqueda(f, busqueda)
+        ),
+    [busqueda, categoriaFiltro, soloConStock]
+  );
+
+  const categorias = useMemo(
+    () => Array.from(new Set((data?.productos ?? []).map((p) => p.categoria))).sort(),
+    [data]
+  );
+
+  if (isLoading) return <LoadingSpinner />;
+  if (error) {
+    return (
+      <div className="bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg p-4 text-red-700 dark:text-red-300 text-sm">
+        No se pudo cargar el stock de la red: {(error as Error).message}
+      </div>
+    );
+  }
+  if (!data) return <LoadingSpinner />;
+
+  const enVariasSucursales = filtrar(emparejados);
+  const sinParFiltrado = filtrar(sinPar);
+  const ambiguos = sinPar.filter((f) => f.ambiguo);
+  const sucursalesVisibles =
+    sucursalSel === 'red' ? sucursales : sucursales.filter((s) => s.sucursal_id === sucursalSel);
+
+  // Con una sucursal elegida no hay comparación: es su catálogo completo.
+  const filasUnaSucursal =
+    sucursalSel === 'red'
+      ? []
+      : filtrar([...emparejados, ...sinPar]).filter((f) => f.porSucursal[sucursalSel] != null);
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-start gap-2 bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-800 rounded-lg p-3 text-sm text-blue-800 dark:text-blue-200">
+        <Network className="w-4 h-4 mt-0.5 shrink-0" />
+        <p>
+          Stock, costo y precio de todas las sucursales. <strong>Solo lectura</strong>: desde acá
+          no se opera sobre la otra sucursal.
+        </p>
+      </div>
+
+      {/* KPIs por sucursal */}
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+        {sucursalesVisibles.map((s) => (
+          <div
+            key={s.sucursal_id}
+            className="bg-white dark:bg-gray-800 border dark:border-gray-700 p-4 rounded-lg"
+          >
+            <p className="text-sm text-gray-500 dark:text-gray-400">{s.sucursal_nombre}</p>
+            <p className="text-xl font-bold text-gray-800 dark:text-gray-100">
+              {s.unidades} unidades
+            </p>
+            <p className="text-xs text-gray-500 mt-1">
+              {s.productos_con_stock} de {s.productos} productos con stock ·{' '}
+              {formatPrecio(s.valuacion_promedio)} valuado
+            </p>
+          </div>
+        ))}
+      </div>
+
+      {/* Filtros */}
+      <div className="flex flex-wrap gap-3 items-center">
+        <select
+          aria-label="Sucursal"
+          value={sucursalSel}
+          onChange={(e) =>
+            setSucursalSel(e.target.value === 'red' ? 'red' : Number(e.target.value))
+          }
+          className="px-3 py-2 border dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 text-sm text-gray-900 dark:text-white"
+        >
+          <option value="red">Red (consolidado)</option>
+          {sucursales.map((s) => (
+            <option key={s.sucursal_id} value={s.sucursal_id}>
+              {s.sucursal_nombre}
+            </option>
+          ))}
+        </select>
+
+        <div className="relative">
+          <Search className="w-4 h-4 absolute left-3 top-1/2 -translate-y-1/2 text-gray-400" />
+          <input
+            aria-label="Buscar producto"
+            type="search"
+            value={busqueda}
+            onChange={(e) => setBusqueda(e.target.value)}
+            placeholder="Buscar por nombre o código"
+            className="pl-9 pr-3 py-2 border dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 text-sm text-gray-900 dark:text-white"
+          />
+        </div>
+
+        <select
+          aria-label="Categoría"
+          value={categoriaFiltro}
+          onChange={(e) => setCategoriaFiltro(e.target.value)}
+          className="px-3 py-2 border dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 text-sm text-gray-900 dark:text-white"
+        >
+          <option value="todas">Todas las categorías</option>
+          {categorias.map((c) => (
+            <option key={c} value={c}>
+              {c}
+            </option>
+          ))}
+        </select>
+
+        <label className="flex items-center gap-2 text-sm text-gray-700 dark:text-gray-300">
+          <input
+            type="checkbox"
+            checked={soloConStock}
+            onChange={(e) => setSoloConStock(e.target.checked)}
+            className="rounded border-gray-300"
+          />
+          Solo con stock
+        </label>
+      </div>
+
+      {sucursalSel === 'red' ? (
+        <>
+          {/* En más de una sucursal */}
+          <div className="bg-white dark:bg-gray-800 border dark:border-gray-700 rounded-lg shadow-sm overflow-hidden">
+            <div className="px-4 pt-4">
+              <h3 className="font-semibold text-gray-700 dark:text-gray-200">
+                En más de una sucursal ({enVariasSucursales.length})
+              </h3>
+              <p className="text-xs text-gray-500 mt-1">
+                Emparejados por código exacto o nombre exacto. No hay tabla de equivalencias entre
+                sucursales, así que lo que no empareja va más abajo, listado.
+              </p>
+            </div>
+            <div className="overflow-x-auto p-4">
+              {enVariasSucursales.length === 0 ? (
+                <p className="text-sm text-gray-500 py-2">
+                  Ningún producto empareja con el filtro elegido.
+                </p>
+              ) : (
+                <table className="w-full text-sm">
+                  <thead>
+                    <tr className="text-left text-gray-500 dark:text-gray-400">
+                      <th className="py-2 pr-4" rowSpan={2}>
+                        Producto
+                      </th>
+                      {sucursales.map((s) => (
+                        <th
+                          key={s.sucursal_id}
+                          colSpan={3}
+                          className="py-2 pr-4 text-center border-b dark:border-gray-700"
+                        >
+                          {s.sucursal_nombre}
+                        </th>
+                      ))}
+                    </tr>
+                    <tr className="text-left text-gray-500 dark:text-gray-400 border-b dark:border-gray-700">
+                      {sucursales.map((s) => (
+                        <React.Fragment key={s.sucursal_id}>
+                          <th className="py-2 pr-4 text-right font-normal">Stock</th>
+                          <th className="py-2 pr-4 text-right font-normal">Costo</th>
+                          <th className="py-2 pr-4 text-right font-normal">Precio</th>
+                        </React.Fragment>
+                      ))}
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {enVariasSucursales.map((f) => (
+                      <tr key={f.clave} className="border-b dark:border-gray-700/50 last:border-0">
+                        <td className="py-2 pr-4 text-gray-800 dark:text-gray-100">
+                          {f.nombre}
+                          {f.codigo && (
+                            <span className="ml-2 text-xs text-gray-400">{f.codigo}</span>
+                          )}
+                          <span className="block text-xs text-gray-400">{f.categoria}</span>
+                          {/* El emparejado es una heurística: si el producto se
+                              llama distinto en la otra sucursal, se muestra —
+                              es lo que deja auditar el par. */}
+                          {Object.values(f.porSucursal)
+                            .filter((p): p is ProductoRed => p != null && p.nombre !== f.nombre)
+                            .map((p) => (
+                              <span
+                                key={p.sucursal_id}
+                                className="block text-xs text-gray-400 italic"
+                              >
+                                {p.sucursal_nombre}: {p.nombre}
+                              </span>
+                            ))}
+                        </td>
+                        {sucursales.map((s) => (
+                          <CeldasSucursal
+                            key={s.sucursal_id}
+                            producto={f.porSucursal[s.sucursal_id]}
+                            formatPrecio={formatPrecio}
+                          />
+                        ))}
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              )}
+            </div>
+          </div>
+
+          {ambiguos.length > 0 && (
+            <div className="flex items-start gap-2 bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800 rounded-lg p-3 text-sm text-amber-800 dark:text-amber-200">
+              <AlertTriangle className="w-4 h-4 mt-0.5 shrink-0" />
+              <p>
+                {ambiguos.length} producto(s) quedaron sin emparejar porque el código o el nombre
+                coincide con más de uno: {ambiguos.map((f) => f.nombre).join(', ')}.
+              </p>
+            </div>
+          )}
+
+          {/* Lo que existe en una sola sucursal */}
+          {sucursales.map((s) => {
+            const filas = sinParFiltrado.filter((f) => f.sucursales[0] === s.sucursal_id);
+            return (
+              <div
+                key={s.sucursal_id}
+                className="bg-white dark:bg-gray-800 border dark:border-gray-700 rounded-lg shadow-sm overflow-hidden"
+              >
+                <h3 className="font-semibold text-gray-700 dark:text-gray-200 px-4 pt-4">
+                  Solo en {s.sucursal_nombre} ({filas.length})
+                </h3>
+                <div className="overflow-x-auto p-4">
+                  {filas.length === 0 ? (
+                    <p className="text-sm text-gray-500 py-2">
+                      Nada exclusivo de esta sucursal con el filtro elegido.
+                    </p>
+                  ) : (
+                    <TablaSucursal
+                      filas={filas}
+                      sucursalId={s.sucursal_id}
+                      formatPrecio={formatPrecio}
+                    />
+                  )}
+                </div>
+              </div>
+            );
+          })}
+        </>
+      ) : (
+        <div className="bg-white dark:bg-gray-800 border dark:border-gray-700 rounded-lg shadow-sm overflow-hidden">
+          <h3 className="font-semibold text-gray-700 dark:text-gray-200 px-4 pt-4">
+            {sucursales.find((s) => s.sucursal_id === sucursalSel)?.sucursal_nombre ?? 'Sucursal'} (
+            {filasUnaSucursal.length})
+          </h3>
+          <div className="overflow-x-auto p-4">
+            {filasUnaSucursal.length === 0 ? (
+              <p className="text-sm text-gray-500 py-2">Sin productos para el filtro elegido.</p>
+            ) : (
+              <TablaSucursal
+                filas={filasUnaSucursal}
+                sucursalId={sucursalSel}
+                formatPrecio={formatPrecio}
+              />
+            )}
+          </div>
+        </div>
+      )}
+
+      <p className="text-xs text-gray-500">
+        Costo = costo promedio ponderado; "reposición" es el costo de la última compra (FC: neto +
+        impuestos internos · ZZ: total pagado, que ya los incluye). El precio es el de lista de
+        cada sucursal.
+      </p>
+    </div>
+  );
+}

--- a/src/components/vistas/reportes/index.ts
+++ b/src/components/vistas/reportes/index.ts
@@ -20,6 +20,9 @@ export type { ReporteVentasZonasProps } from './ReporteVentasZonas';
 export { ReporteValuacionInventario } from './ReporteValuacionInventario';
 export type { ReporteValuacionInventarioProps } from './ReporteValuacionInventario';
 
+export { ReporteStockRed } from './ReporteStockRed';
+export type { ReporteStockRedProps } from './ReporteStockRed';
+
 export { FiltrosVentas } from './FiltrosVentas';
 export type { FiltrosVentasProps } from './FiltrosVentas';
 export { filtrosVentasIniciales } from './filtrosVentasState';

--- a/src/hooks/queries/index.ts
+++ b/src/hooks/queries/index.ts
@@ -38,6 +38,10 @@ export {
 } from './useCategoriasQuery'
 export type { CategoriaDB } from './useCategoriasQuery'
 
+// Stock de la red (cross-sucursal, solo lectura)
+export { stockRedKeys, useStockRedQuery } from './useStockRedQuery'
+export type { StockRed, StockRedSucursal } from './useStockRedQuery'
+
 // Marcas (mig 158)
 export {
   marcasKeys,

--- a/src/hooks/queries/useStockRedQuery.ts
+++ b/src/hooks/queries/useStockRedQuery.ts
@@ -1,0 +1,56 @@
+/**
+ * TanStack Query hook para "Stock de la red" (RPC `reporte_stock_red`).
+ *
+ * SOLO LECTURA y CROSS-SUCURSAL: devuelve stock, costo y precio de TODAS las
+ * sucursales activas, sin importar a cuáles esté asignado el admin. Es un RPC
+ * y no una consulta a `productos` a propósito: la policy `mt_productos_select`
+ * aísla por sucursal y abrirla filtraría de más (el selector de items del
+ * pedido, las mermas, el backup a Excel) y expondría la fila entera. El RPC
+ * elige columna por columna.
+ *
+ * CACHE: key propia. NO puede colgar de `productosKeys.all(sucursalId)` — el
+ * dato no es de la sucursal activa y `switchSucursal` invalida todo eso.
+ */
+import { useQuery } from '@tanstack/react-query'
+import { supabase } from '../../lib/supabase'
+import type { ProductoRed } from '../../utils/stockRed'
+
+export interface StockRedSucursal {
+  sucursal_id: number
+  sucursal_nombre: string
+  productos: number
+  productos_con_stock: number
+  unidades: number
+  valuacion_promedio: number
+}
+
+export interface StockRed {
+  meta: {
+    sucursal_id: number | null
+    sucursal_nombre: string
+    generado_at: string
+    criterio: string
+  }
+  sucursales: StockRedSucursal[]
+  productos: ProductoRed[]
+}
+
+export const stockRedKeys = {
+  all: ['stock-red'] as const,
+  scope: (sucursalId: number | null) => ['stock-red', sucursalId] as const,
+}
+
+export function useStockRedQuery(sucursalId: number | null = null, enabled = true) {
+  return useQuery({
+    queryKey: stockRedKeys.scope(sucursalId),
+    queryFn: async (): Promise<StockRed> => {
+      const { data, error } = await supabase.rpc('reporte_stock_red', {
+        p_sucursal_id: sucursalId,
+      })
+      if (error) throw new Error(error.message)
+      return data as StockRed
+    },
+    enabled,
+    staleTime: 5 * 60 * 1000,
+  })
+}

--- a/src/utils/stockRed.test.ts
+++ b/src/utils/stockRed.test.ts
@@ -1,0 +1,191 @@
+import { describe, it, expect } from 'vitest'
+import { emparejarRed, coincideBusqueda, tieneStock, type ProductoRed } from './stockRed'
+
+const TUC = 1
+const TP = 2
+
+let seq = 0
+function prod(sucursal_id: number, nombre: string, extra: Partial<ProductoRed> = {}): ProductoRed {
+  seq += 1
+  return {
+    producto_id: seq,
+    sucursal_id,
+    sucursal_nombre: sucursal_id === TUC ? 'Tucuman' : 'Taco Pozo',
+    nombre,
+    codigo: null,
+    categoria: 'GASEOSAS',
+    stock: 10,
+    costo_promedio: 100,
+    costo_reposicion: 120,
+    ultimo_tipo_compra: 'FC',
+    precio: 200,
+    ...extra,
+  }
+}
+
+describe('emparejarRed', () => {
+  it('empareja por código exacto aunque el nombre no coincida', () => {
+    // Caso real: "ALFATUC BLANCO x 18 u" en Tucumán y "ALFATUC BLANCO DISPLAY
+    // X 18" en Taco Pozo comparten código.
+    const { emparejados, sinPar } = emparejarRed([
+      prod(TUC, 'ALFATUC BLANCO x 18 u', { codigo: 'A100' }),
+      prod(TP, 'ALFATUC BLANCO DISPLAY X 18', { codigo: 'A100' }),
+    ], [TUC, TP])
+
+    expect(sinPar).toHaveLength(0)
+    expect(emparejados).toHaveLength(1)
+    expect(emparejados[0].sucursales).toEqual([TUC, TP])
+    expect(emparejados[0].porSucursal[TP]?.nombre).toBe('ALFATUC BLANCO DISPLAY X 18')
+  })
+
+  it('empareja por nombre exacto normalizado cuando no hay código', () => {
+    // "PINDAPOY DURAZNO 200 cc x 18" vs "PINDAPOY DURAZNO 200 CC X 18".
+    const { emparejados } = emparejarRed([
+      prod(TUC, 'PINDAPOY DURAZNO 200 cc x 18'),
+      prod(TP, '  PINDAPOY  DURAZNO   200 CC X 18 '),
+    ], [TUC, TP])
+
+    expect(emparejados).toHaveLength(1)
+    expect(emparejados[0].nombre).toBe('PINDAPOY DURAZNO 200 cc x 18')
+  })
+
+  it('NO empareja por coincidencia parcial', () => {
+    const { emparejados, sinPar } = emparejarRed([
+      prod(TUC, 'MANAOS COLA 2.25 L'),
+      prod(TP, 'MANAOS COLA 2.25 L X 6'),
+    ], [TUC, TP])
+
+    expect(emparejados).toHaveLength(0)
+    expect(sinPar).toHaveLength(2)
+    expect(sinPar.every((f) => f.ambiguo)).toBe(false)
+  })
+
+  it('el código manda sobre el nombre', () => {
+    const { emparejados } = emparejarRed([
+      prod(TUC, 'AGUA 1.5', { codigo: 'C1' }),
+      prod(TP, 'OTRA COSA', { codigo: 'C1' }),
+      prod(TP, 'AGUA 1.5', { codigo: 'C9' }),
+    ], [TUC, TP])
+
+    expect(emparejados).toHaveLength(1)
+    expect(emparejados[0].porSucursal[TP]?.nombre).toBe('OTRA COSA')
+  })
+
+  it('un producto se empareja una sola vez: el segundo del mismo código queda sin par', () => {
+    const { emparejados, sinPar } = emparejarRed([
+      prod(TUC, 'SAL FINA x 500 g x 10 u', { codigo: 'S1' }),
+      prod(TP, 'SAL FINA DISPLAY', { codigo: 'S1' }),
+      prod(TP, 'SAL FINA SUELTA', { codigo: 'S1' }),
+    ], [TUC, TP])
+
+    expect(emparejados).toHaveLength(1)
+    expect(sinPar.map((f) => f.nombre)).toEqual(['SAL FINA SUELTA'])
+  })
+
+  it('marca ambiguo y NO empareja cuando el código coincide con más de un candidato', () => {
+    // productos.codigo no tiene UNIQUE: dos filas de Tucumán pueden compartirlo.
+    const { emparejados, sinPar } = emparejarRed([
+      prod(TUC, 'COLA 2.25 RETORNABLE', { codigo: 'D1' }),
+      prod(TUC, 'COLA 2.25 DESCARTABLE', { codigo: 'D1' }),
+      prod(TP, 'COLA 2.25', { codigo: 'D1' }),
+    ], [TUC, TP])
+
+    expect(emparejados).toHaveLength(0)
+    expect(sinPar).toHaveLength(3)
+    expect(sinPar.find((f) => f.nombre === 'COLA 2.25')?.ambiguo).toBe(true)
+  })
+
+  it('el código vacío no empareja con otro código vacío', () => {
+    const { emparejados, sinPar } = emparejarRed([
+      prod(TUC, 'UNO', { codigo: '' }),
+      prod(TP, 'DOS', { codigo: '   ' }),
+    ], [TUC, TP])
+
+    expect(emparejados).toHaveLength(0)
+    expect(sinPar).toHaveLength(2)
+  })
+
+  it('el producto que está en una sola sucursal queda en sinPar, no se pierde', () => {
+    const { emparejados, sinPar } = emparejarRed([
+      prod(TUC, 'A', { codigo: 'X' }),
+      prod(TP, 'A', { codigo: 'X' }),
+      prod(TP, 'SOLO EN TACO POZO'),
+    ], [TUC, TP])
+
+    expect(emparejados).toHaveLength(1)
+    expect(sinPar.map((f) => f.nombre)).toEqual(['SOLO EN TACO POZO'])
+    expect(sinPar[0].sucursales).toEqual([TP])
+  })
+
+  it('ningún producto se pierde ni se duplica', () => {
+    const productos = [
+      prod(TUC, 'A', { codigo: 'X' }), prod(TUC, 'B'), prod(TUC, 'C'),
+      prod(TP, 'A', { codigo: 'X' }), prod(TP, 'D'),
+    ]
+    const { emparejados, sinPar } = emparejarRed(productos, [TUC, TP])
+    const ids = [...emparejados, ...sinPar]
+      .flatMap((f) => Object.values(f.porSucursal))
+      .map((p) => p?.producto_id)
+
+    expect(ids).toHaveLength(productos.length)
+    expect(new Set(ids).size).toBe(productos.length)
+  })
+
+  it('sin orden de sucursales usa el orden de aparición', () => {
+    const { emparejados } = emparejarRed([
+      prod(TP, 'A', { codigo: 'X' }),
+      prod(TUC, 'A', { codigo: 'X' }),
+    ])
+
+    expect(emparejados).toHaveLength(1)
+    expect(emparejados[0].sucursales).toEqual([TP, TUC])
+  })
+})
+
+describe('coincideBusqueda', () => {
+  const [fila] = emparejarRed([
+    prod(TUC, 'MANAOS COLA 2.25', { codigo: 'MC225', categoria: 'GASEOSAS' }),
+    prod(TP, 'MANAOS COLA GRANDE', { codigo: 'MC225' }),
+  ], [TUC, TP]).emparejados
+
+  it('sin texto pasa todo', () => {
+    expect(coincideBusqueda(fila, '   ')).toBe(true)
+  })
+
+  it('busca por nombre, código y categoría, sin distinguir mayúsculas', () => {
+    expect(coincideBusqueda(fila, 'manaos')).toBe(true)
+    expect(coincideBusqueda(fila, 'mc225')).toBe(true)
+    expect(coincideBusqueda(fila, 'gaseosas')).toBe(true)
+  })
+
+  it('encuentra por el nombre de la OTRA sucursal', () => {
+    expect(coincideBusqueda(fila, 'grande')).toBe(true)
+  })
+
+  it('no inventa coincidencias', () => {
+    expect(coincideBusqueda(fila, 'cerveza')).toBe(false)
+  })
+})
+
+describe('tieneStock', () => {
+  it('alcanza con que una sucursal tenga stock', () => {
+    const { emparejados } = emparejarRed([
+      prod(TUC, 'A', { codigo: 'X', stock: 0 }),
+      prod(TP, 'A', { codigo: 'X', stock: 5 }),
+    ], [TUC, TP])
+    expect(tieneStock(emparejados[0])).toBe(true)
+  })
+
+  it('el stock negativo cuenta como stock (hay que verlo, no esconderlo)', () => {
+    const { sinPar } = emparejarRed([prod(TUC, 'A', { stock: -3 })], [TUC])
+    expect(tieneStock(sinPar[0])).toBe(true)
+  })
+
+  it('todo en cero es sin stock', () => {
+    const { emparejados } = emparejarRed([
+      prod(TUC, 'A', { codigo: 'X', stock: 0 }),
+      prod(TP, 'A', { codigo: 'X', stock: 0 }),
+    ], [TUC, TP])
+    expect(tieneStock(emparejados[0])).toBe(false)
+  })
+})

--- a/src/utils/stockRed.ts
+++ b/src/utils/stockRed.ts
@@ -1,0 +1,148 @@
+/**
+ * "Stock de la red": emparejar el mismo producto entre sucursales.
+ *
+ * No hay clave que una un producto de Tucumán con "el mismo" de Taco Pozo:
+ * son filas independientes, con ids distintos y sin tabla de equivalencias.
+ * `productos.codigo` tampoco es UNIQUE. Así que el emparejado es una
+ * HEURÍSTICA, y se elige la más conservadora que ya usa la app: el criterio
+ * estricto de `sugerirMatchProducto` (código exacto y, si no hay, nombre
+ * exacto normalizado — nada parcial). De ahí sale `normalizarTexto`, para que
+ * las dos pantallas normalicen igual.
+ *
+ * Consecuencia medida (2026-09-08, 176 productos en Tucumán y 111 en Taco
+ * Pozo): sólo emparejan 10. El resto NO es un error del emparejado: son
+ * catálogos distintos. Por eso esta función devuelve los `sinPar` como
+ * ciudadanos de primera y la vista los muestra en su propia sección — un
+ * emparejado laxo (por prefijo, por palabras) inventaría pares que nadie
+ * verificó y sería peor que no emparejar.
+ */
+import { normalizarTexto } from './matchProducto'
+
+/** Una fila de `productos` de cualquier sucursal, como la devuelve el RPC. */
+export interface ProductoRed {
+  producto_id: number
+  sucursal_id: number
+  sucursal_nombre: string
+  nombre: string
+  codigo: string | null
+  categoria: string
+  stock: number
+  costo_promedio: number | null
+  costo_reposicion: number | null
+  ultimo_tipo_compra: 'FC' | 'ZZ' | null
+  precio: number
+}
+
+/** El mismo producto visto en una o más sucursales. */
+export interface FilaRed {
+  /** Key estable para React: sucursal + id del primer producto del grupo. */
+  clave: string
+  nombre: string
+  codigo: string | null
+  categoria: string
+  porSucursal: Record<number, ProductoRed | undefined>
+  /** Ids de sucursal donde aparece, en el orden en que se recorrieron. */
+  sucursales: number[]
+  /**
+   * El código o el nombre coincidían con MÁS DE UN candidato: no se emparejó
+   * a ninguno a propósito. Elegir el primero sería inventar una equivalencia.
+   */
+  ambiguo: boolean
+}
+
+export interface RedEmparejada {
+  /** Aparece en dos o más sucursales. */
+  emparejados: FilaRed[]
+  /** Aparece en una sola sucursal (o quedó sin emparejar por ambiguo). */
+  sinPar: FilaRed[]
+}
+
+function indexar(mapa: Map<string, FilaRed[]>, clave: string, fila: FilaRed): void {
+  const actual = mapa.get(clave)
+  if (actual) {
+    if (!actual.includes(fila)) actual.push(fila)
+  } else {
+    mapa.set(clave, [fila])
+  }
+}
+
+function porNombreEs(a: FilaRed, b: FilaRed): number {
+  return a.nombre.localeCompare(b.nombre, 'es')
+}
+
+/**
+ * Agrupa los productos de varias sucursales en filas comparables.
+ *
+ * @param productos - Filas de todas las sucursales del alcance.
+ * @param sucursalIds - Orden de recorrido. La primera sucursal aporta el
+ *   nombre y la categoría con que se muestra cada fila; el orden no cambia qué
+ *   empareja con qué, sólo la etiqueta. Si va vacío se usa el orden de
+ *   aparición.
+ */
+export function emparejarRed(productos: ProductoRed[], sucursalIds: number[] = []): RedEmparejada {
+  const orden = sucursalIds.length > 0
+    ? sucursalIds
+    : [...new Set(productos.map((p) => p.sucursal_id))]
+
+  const filas: FilaRed[] = []
+  const porCodigo = new Map<string, FilaRed[]>()
+  const porNombre = new Map<string, FilaRed[]>()
+
+  for (const sucursalId of orden) {
+    for (const p of productos.filter((x) => x.sucursal_id === sucursalId)) {
+      const cod = normalizarTexto(p.codigo)
+      const nom = normalizarTexto(p.nombre)
+      // Una fila que ya tiene un producto de esta sucursal no es candidata:
+      // cada producto se empareja una sola vez.
+      const libres = (arr: FilaRed[] | undefined): FilaRed[] =>
+        (arr ?? []).filter((f) => f.porSucursal[sucursalId] === undefined)
+
+      // El código manda; el nombre es el desempate, igual que en
+      // sugerirMatchProducto.
+      let candidatas = cod ? libres(porCodigo.get(cod)) : []
+      if (candidatas.length === 0 && nom) candidatas = libres(porNombre.get(nom))
+
+      let fila: FilaRed
+      if (candidatas.length === 1) {
+        fila = candidatas[0]
+      } else {
+        fila = {
+          clave: `${sucursalId}-${p.producto_id}`,
+          nombre: p.nombre,
+          codigo: p.codigo ?? null,
+          categoria: p.categoria,
+          porSucursal: {},
+          sucursales: [],
+          ambiguo: candidatas.length > 1,
+        }
+        filas.push(fila)
+      }
+
+      fila.porSucursal[sucursalId] = p
+      fila.sucursales.push(sucursalId)
+      if (cod) indexar(porCodigo, cod, fila)
+      if (nom) indexar(porNombre, nom, fila)
+    }
+  }
+
+  return {
+    emparejados: filas.filter((f) => f.sucursales.length > 1).sort(porNombreEs),
+    sinPar: filas.filter((f) => f.sucursales.length === 1).sort(porNombreEs),
+  }
+}
+
+/** Texto sobre el que filtra el buscador: nombre + código + categoría. */
+export function coincideBusqueda(fila: FilaRed, busqueda: string): boolean {
+  const q = normalizarTexto(busqueda)
+  if (!q) return true
+  const partes = [fila.nombre, fila.codigo, fila.categoria]
+  for (const p of Object.values(fila.porSucursal)) {
+    if (p) partes.push(p.nombre, p.codigo)
+  }
+  return partes.some((t) => normalizarTexto(t).includes(q))
+}
+
+/** ¿La fila tiene stock en alguna de las sucursales donde aparece? */
+export function tieneStock(fila: FilaRed): boolean {
+  return Object.values(fila.porSucursal).some((p) => (p?.stock ?? 0) !== 0)
+}


### PR DESCRIPTION
Dos cosas, una migración cada una. **Las dos migraciones ya están aplicadas en prod** (210 y 211, ledger alineado); lo que falta mergear es el front de la parte A.

## A · Cualquier admin ve el stock, el costo y el precio de la otra sucursal — en solo lectura

De los 7 admins, solo Agustín y Jorge están en las dos sucursales. Julio y Pablo son admin solo de Taco Pozo; Emilia, Nacho y Virginia solo de Tucumán. Esos cinco no veían la otra sucursal por ningún lado: `reporte_valuacion_inventario` (mig 131) intersecta las activas con las asignadas, y `mt_productos_select` filtra por `current_sucursal_id()`.

**Lo que NO se hizo, a propósito:**

- **No se los agrega a `usuario_sucursales`**: eso no es ver, es acceso operativo completo (crear pedidos, mover stock, editar productos, cambiar precios).
- **No se relaja `mt_productos_select`**: `fetchProductos` es `.from('productos').select('*')` sin filtro de sucursal y ninguno de los 24 call sites lleva `.eq('sucursal_id')` — todo el aislamiento lo pone la policy. Abrirla mostraría el catálogo de las dos en el selector de items del pedido, las categorías, las mermas, ModalCrearMovimiento y el backup a Excel, en silencio y sin que falle ningún test. Además la policy es sobre la fila entera.
- **No se le agrega un parámetro a la 131**: dos sobrecargas con rangos `[obligatorios, total]` superpuestos ⇒ PGRST203 en runtime, invisible para `tsc` y los tests (precedente: mig 176). Va con nombre nuevo.

`reporte_stock_red(bigint)` devuelve columna por columna: stock, costo promedio, costo de reposición y precio. Gate: rol **crudo** de `perfiles` — admin global **o** admin en alguna sucursal asignada. Es superset del gate del front (`/reportes` usa el rol en la sucursal activa, no el global), así que nadie ve la pestaña y después recibe "Acceso denegado". Encargado no entra.

| quién | resultado |
|---|---|
| Julio (admin, solo Taco Pozo) | ve **las 2** sucursales, 287 filas |
| Julio pidiendo Tucumán explícito | 176 filas (sucursal no asignada) |
| Jony (encargado) / Marcelo (preventista) / Marcos (transportista) | `Acceso denegado: se requiere rol admin` |
| anon key + curl | `42501 permission denied`, igual que la 131 |

**El emparejado es una heurística y se dice.** No hay clave que una un producto de Tucumán con "el mismo" de Taco Pozo y `productos.codigo` no tiene UNIQUE. Se reusa el criterio estricto de `sugerirMatchProducto` (código exacto; si no, nombre exacto normalizado). Medido en prod: de 176 productos en Tucumán y 111 en Taco Pozo **emparejan 10**. Por eso lo que no empareja no se esconde — va en "Solo en \<sucursal\> (N)" —, los ambiguos se listan sin emparejar (elegir el primero sería inventar una equivalencia) y cada par muestra los dos nombres cuando difieren, para poder auditarlo.

Pantalla: pestaña **Stock de la Red** en `/reportes`, con selector Red / Tucumán / Taco Pozo, buscador, categoría y "solo con stock". No se toca la columna Stock de `/productos`: eso obligaría a resolver el emparejado para todas las filas y ensucia una pantalla operativa. El hook usa key de cache propia (`['stock-red', id]`), no `productosKeys.all(sucursalId)` — el dato no es de la sucursal activa y `switchSucursal` invalida todo eso.

## B · El producto que nace en el destino se lleva su costo del origen

`aceptar_movimiento_sucursal` creaba el producto en el destino sin `costo_real`, sin `costo_promedio` y sin `ultimo_tipo_compra`: viene de la mig 076, anterior a la 111 y a la 127. Esa fila entra a la cascada de costo por el último escalón, que tiene semántica FC (neto + impuestos internos); si el origen era ZZ, lo pagado ya los incluía y se cuentan dos veces (~466 pesos por unidad en una Manaos con II 8,6956%). Y `ultimo_tipo_compra` en NULL borra el único dato que distingue FC de ZZ.

Evidencia: de los 10 productos de Taco Pozo nacidos de un movimiento, 3 siguen con `costo_real` **y** `costo_promedio` en NULL y otros 2 con `costo_promedio` en NULL; los 5 con `ultimo_tipo_compra` NULL, y sus orígenes tenían los tres campos cargados.

- **No cambia** `GREATEST(origen, destino)` en el camino "match con un producto existente": es decisión comercial de la 076 y el modal la anuncia.
- **No backfillea** los 5 productos: el costo del origen hoy no es el de aquellas unidades (los FIDEO ya divergieron, 5.584,04 vs 5.895,55) y el CPP es forward-only (mig 127).
- **Parche quirúrgico sobre la definición viva**, con helper que aborta si un ancla no aparece exactamente una vez: la mig 177 ya había parcheado esta función in situ (`condicion_iva`) y un `CREATE OR REPLACE` armado desde `migrations/139` lo habría revertido en silencio. La migración verifica después que estén los dos parches.

## Verificación

- `typecheck`, `lint`, `test:run` (1625 tests / 120 archivos) y `build`, en verde y sin `.env`.
- 17 tests nuevos del emparejado + 9 del componente (fijan que lo que no empareja se sigue viendo).
- Parte B, sin tests posibles de la RPC: probada contra prod dentro de una transacción abortada. Mover MANAOS POMELO BLANCO 3 LT y aceptar con "crear nuevo" deja `costo_real 5538,0408 · costo_promedio 5542,8837 · ultimo_tipo_compra FC · condicion_iva gravado` (antes: los tres primeros NULL). Rollback sin rastro: ni producto, ni movimiento, stock del origen intacto en 108.
- `auditoria_integridad()` después de las dos migraciones: `overall_ok: true`, 0 critical/high en rojo.
- **Sin verificar en navegador**: `/reportes` está detrás del login. La UI está cubierta por tests de componente, pero conviene mirar la pestaña después del deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
