### PR TITLE
Que perfiles.activo bloquee el acceso de verdad (cierra el drift de la 206)

### DIFF
--- a/migrations/206_activo_bloquea_el_acceso.sql
+++ b/migrations/206_activo_bloquea_el_acceso.sql
@@ -1,0 +1,193 @@
+-- Que `perfiles.activo` bloquee de verdad
+--
+-- EL BUG
+-- ------
+-- El checkbox "Usuario activo" de ModalUsuario.tsx no impedia nada. Verificado
+-- por tres lados en prod:
+--
+--   1. Ninguna policy RLS menciona `activo` (pg_policy filtrado por activo +
+--      perfil: cero filas).
+--   2. `es_preventista()` decide por `rol IN ('admin','preventista','encargado')`
+--      y nunca lo mira. Idem `es_admin()` y `es_transportista()`.
+--   3. El login no lo consulta: en useAuth.tsx `activo` aparece solo como campo
+--      del tipo Perfil.
+--
+-- O sea que un admin podia destildar la casilla creyendo que sacaba a alguien,
+-- verlo en rojo en el panel, y esa persona seguia cargando pedidos con
+-- normalidad. Una UI que promete un candado que no cierra es peor que no tener
+-- el candado: nadie va a buscar el problema donde cree que ya lo resolvio.
+--
+-- POR QUE NO SE ARREGLA METIENDO `AND activo` EN LOS HELPERS
+-- ---------------------------------------------------------
+-- Seria lo obvio y es el peor camino disponible:
+--
+--   - `es_preventista()` NO significa "es preventista": devuelve true tambien
+--     para admin, encargado y para quien tenga el rol extra en `perfil_roles`.
+--     Un CREATE OR REPLACE descuidado de ese helper revierte el multi-rol en
+--     silencio, y lo cubren decenas de policies.
+--   - Seria autorizacion, no autenticacion: el usuario igual entra a la app,
+--     igual tiene sesion valida, y recien rebota contra cada policy. Media app
+--     rota en vez de una puerta cerrada.
+--   - Habria que tocar los tres helpers y acordarse del cuarto que se agregue
+--     manana. Un candado que hay que recordar poner en cada lugar nuevo ya
+--     nacio roto.
+--
+-- LO QUE SI SE HACE
+-- -----------------
+-- `activo` pasa a manejar `auth.users.banned_until`, que es el mecanismo NATIVO
+-- de GoTrue: el endpoint /token lo chequea ANTES de validar el hash de la
+-- contraseña y devuelve 400 user_banned. No depende de que nuestro codigo se
+-- acuerde de nada, no se puede esquivar por otro camino de datos, y cubre por
+-- igual la web, el replay offline y cualquier cliente futuro.
+--
+-- Desactivar ademas purga sesiones, refresh tokens y tokens de recuperacion
+-- pendientes. Sin eso el bloqueo seria a medias: `banned_until` corta el login
+-- nuevo, pero una sesion ya abierta sigue renovandose sola, y un link de
+-- "olvide mi contraseña" sin usar en la casilla del usuario le devuelve la
+-- cuenta cuando quiera.
+--
+-- Es reversible y no destructivo: reactivar limpia el ban. No se borra el
+-- usuario ni su historial, que es justamente por lo que la baja es logica.
+--
+-- LOS DOS GUARDS
+-- --------------
+-- Hacer que el flag muerda de verdad crea un modo de falla que antes no existia
+-- (antes no hacia nada, mal podia dejar a alguien afuera), asi que nacen con el:
+--
+--   1. Un admin no puede desactivarse a si mismo. Un click distraido en su
+--      propia fila lo dejaba afuera de su propia app.
+--   2. No se puede desactivar al ultimo admin activo. Sin admin no queda nadie
+--      que pueda reactivar a nadie, y la unica salida es SQL a mano contra prod.
+--
+-- `prevenir_autoescalada_perfil()` (trigger ya existente) sigue cubriendo lo
+-- suyo: un no-admin no puede cambiar `rol` ni `activo` de nadie, ni de si mismo.
+-- Estos guards son para el admin, que si puede.
+
+-- ---------------------------------------------------------------------------
+-- 1. Guards
+-- ---------------------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION public.perfiles_guard_desactivacion()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public', 'pg_temp'
+AS $$
+DECLARE
+  v_admins_activos INT;
+BEGIN
+  -- Solo interesa la transicion activo -> inactivo.
+  IF COALESCE(NEW.activo, true) OR NOT COALESCE(OLD.activo, true) THEN
+    RETURN NEW;
+  END IF;
+
+  -- auth.uid() es NULL cuando corre una migracion o un job con service_role;
+  -- ahi no hay "si mismo" que proteger y el backfill de abajo tiene que pasar.
+  IF auth.uid() IS NOT NULL AND NEW.id = auth.uid() THEN
+    RAISE EXCEPTION 'No podes desactivar tu propio usuario: quedarias afuera de la app.';
+  END IF;
+
+  IF COALESCE(OLD.rol, '') = 'admin' THEN
+    SELECT count(*) INTO v_admins_activos
+    FROM public.perfiles
+    WHERE rol = 'admin' AND COALESCE(activo, true) AND id <> NEW.id;
+
+    IF v_admins_activos = 0 THEN
+      RAISE EXCEPTION 'No podes desactivar al ultimo administrador activo: nadie podria reactivarlo despues.';
+    END IF;
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+REVOKE EXECUTE ON FUNCTION public.perfiles_guard_desactivacion() FROM PUBLIC, anon;
+
+DROP TRIGGER IF EXISTS trg_perfiles_guard_desactivacion ON public.perfiles;
+CREATE TRIGGER trg_perfiles_guard_desactivacion
+  BEFORE UPDATE OF activo ON public.perfiles
+  FOR EACH ROW
+  WHEN (COALESCE(NEW.activo, true) IS DISTINCT FROM COALESCE(OLD.activo, true))
+  EXECUTE FUNCTION public.perfiles_guard_desactivacion();
+
+-- ---------------------------------------------------------------------------
+-- 2. Sincronizacion con auth
+-- ---------------------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION public.perfiles_sync_acceso_auth()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public', 'pg_temp'
+AS $$
+BEGIN
+  IF COALESCE(NEW.activo, true) THEN
+    -- Reactivar: se levanta el ban. Las sesiones no se restauran (no se puede
+    -- ni corresponde): el usuario vuelve a loguearse con su contraseña.
+    UPDATE auth.users
+       SET banned_until = NULL,
+           updated_at   = now()
+     WHERE id = NEW.id;
+  ELSE
+    -- Desactivar. La fecha lejana en vez de 'infinity' es a proposito: GoTrue
+    -- parsea este campo con el time.Time de Go, que no tiene infinito.
+    UPDATE auth.users
+       SET banned_until = '2099-12-31 00:00:00+00'::timestamptz,
+           updated_at   = now()
+     WHERE id = NEW.id;
+
+    -- Cortar todo acceso vivo. El orden importa: refresh_tokens antes que
+    -- sessions por la FK entre ambas.
+    DELETE FROM auth.refresh_tokens  WHERE user_id = NEW.id::text;
+    DELETE FROM auth.sessions        WHERE user_id = NEW.id;
+    DELETE FROM auth.one_time_tokens WHERE user_id = NEW.id;
+  END IF;
+
+  RETURN NULL;
+END;
+$$;
+
+REVOKE EXECUTE ON FUNCTION public.perfiles_sync_acceso_auth() FROM PUBLIC, anon;
+
+DROP TRIGGER IF EXISTS trg_perfiles_sync_acceso_auth ON public.perfiles;
+CREATE TRIGGER trg_perfiles_sync_acceso_auth
+  AFTER UPDATE OF activo ON public.perfiles
+  FOR EACH ROW
+  WHEN (COALESCE(NEW.activo, true) IS DISTINCT FROM COALESCE(OLD.activo, true))
+  EXECUTE FUNCTION public.perfiles_sync_acceso_auth();
+
+-- ---------------------------------------------------------------------------
+-- 3. Backfill
+-- ---------------------------------------------------------------------------
+-- Los perfiles que hoy estan en false quedaron marcados cuando el flag no hacia
+-- nada, asi que hay que alinearlos a mano: el trigger solo mira transiciones.
+--
+-- La direccion contraria NO se toca. Un `activo = true` con `banned_until`
+-- puesto se deja como esta: ese ban pudo ponerse por otra razon y a mano, y
+-- levantarlo aca seria abrirle la puerta a alguien sin que nadie lo haya pedido.
+
+UPDATE auth.users u
+   SET banned_until = '2099-12-31 00:00:00+00'::timestamptz,
+       updated_at   = now()
+  FROM public.perfiles p
+ WHERE p.id = u.id
+   AND p.activo IS FALSE
+   AND u.banned_until IS NULL;
+
+DELETE FROM auth.refresh_tokens r
+ USING public.perfiles p
+ WHERE p.id::text = r.user_id AND p.activo IS FALSE;
+
+DELETE FROM auth.sessions s
+ USING public.perfiles p
+ WHERE p.id = s.user_id AND p.activo IS FALSE;
+
+DELETE FROM auth.one_time_tokens t
+ USING public.perfiles p
+ WHERE p.id = t.user_id AND p.activo IS FALSE;
+
+COMMENT ON FUNCTION public.perfiles_sync_acceso_auth() IS
+  'Sincroniza perfiles.activo con auth.users.banned_until y purga sesiones al desactivar. Es lo que hace que la baja logica de un usuario bloquee el login de verdad; sin esto el flag es puramente cosmetico. Ver migracion 206.';
+
+COMMENT ON FUNCTION public.perfiles_guard_desactivacion() IS
+  'Impide que un admin se desactive a si mismo o desactive al ultimo admin activo, escenarios que dejan la app sin administrador recuperable. Ver migracion 206.';

--- a/src/components/modals/ModalUsuario.tsx
+++ b/src/components/modals/ModalUsuario.tsx
@@ -268,15 +268,23 @@ const ModalUsuario = memo(function ModalUsuario({ usuario, onSave, onClose, guar
           </div>
         )}
 
-        <div className="flex items-center space-x-2">
-          <input
-            type="checkbox"
-            id="activo"
-            checked={form.activo}
-            onChange={e => handleFieldChange('activo', e.target.checked)}
-            className="w-4 h-4"
-          />
-          <label htmlFor="activo" className="text-sm dark:text-gray-200">Usuario activo</label>
+        <div>
+          <div className="flex items-center space-x-2">
+            <input
+              type="checkbox"
+              id="activo"
+              checked={form.activo}
+              onChange={e => handleFieldChange('activo', e.target.checked)}
+              className="w-4 h-4"
+            />
+            <label htmlFor="activo" className="text-sm dark:text-gray-200">Usuario activo</label>
+          </div>
+          {!form.activo && (
+            <p className="text-xs text-amber-700 dark:text-amber-500 mt-1">
+              Al desactivarlo no va a poder iniciar sesión y se le cierran las sesiones abiertas.
+              No se borra nada: su historial queda intacto y se revierte volviendo a tildarlo.
+            </p>
+          )}
         </div>
       </div>
       <div className="flex justify-end space-x-3 p-4 border-t bg-gray-50 dark:bg-gray-800">


### PR DESCRIPTION
La migración **206** está aplicada en prod desde el `2026-09-04 22:16:35 UTC`
(`20260904221635  206_activo_bloquea_el_acceso` en el ledger), pero su archivo nunca
entró a `main`: quedó en esta rama, sin PR. Desde entonces el drift-check de
`integridad.yml` viene rojo todos los días.

```
❌ Aplicado en prod pero SIN archivo en migrations/:
   20260904221635  206_activo_bloquea_el_acceso
```

Corridas rojas: 33969839810, 34037879282, 34142716800, 34241890338. Última verde:
33886204923 (2026-09-04, antes de que se aplicara la 206).

## Qué trae

- `migrations/206_activo_bloquea_el_acceso.sql` — el archivo de lo que ya está vivo en
  prod. **No re-aplicar**: el ledger ya tiene su fila. Acá entra sólo para que
  `migrations/` vuelva a ser la vista curada de prod que dice ser.
- `src/components/modals/ModalUsuario.tsx` — el aviso bajo el checkbox "Usuario activo".
  Es la contraparte honesta de un comportamiento que **ya está vivo**: hoy destildar la
  casilla banea al usuario y le barre las sesiones, y la UI no lo dice en ningún lado.

## Qué NO se toca, y por qué

`migrations/MANIFEST.md` y el mapa `CONSOLIDACIONES` de `scripts/check-migrations.mjs`
quedan **igual**. Las secciones A–E del MANIFEST son la tabla de excepciones al 1:1, y la
206 es 1 archivo ↔ 1 fila de ledger con el mismo stem — el caso normal. La propia regla
práctica del MANIFEST lo dice: *"todo `NNN_<stem>.sql` que no aparezca en la tabla de
excepciones mapea 1:1"*. Meterla en el § D (que es sólo para N filas → 1 archivo) sería
declarar una consolidación que no existe.

El MANIFEST ya la contempla, además: la línea 171 dice "Las 206–209 tampoco tienen prosa
acá", y "La próxima migración es la 212 [...] el ledger de prod está alineado con ella".
Las dos siguen siendo ciertas con el archivo adentro.

## Verificación

Los cuatro gates locales, sobre el merge con `main` (no sobre la rama vieja):

| gate | resultado |
|---|---|
| `npm run typecheck` | ✅ |
| `npm run lint` | ✅ |
| `npm run test:run` | ✅ 1625 tests, 120 archivos |
| `npm run build` | ✅ |

El apareo del drift-check, contra las mismas regex de `scripts/check-migrations.mjs`:
`fileStem("206_activo_bloquea_el_acceso.sql")` = `ledgerStem("206_activo_bloquea_el_acceso")`
= `activo_bloquea_el_acceso`. Entra por los dos lados del snapshot, así que sale de
`aplicadoSinArchivo` sin caer en `archivoSinAplicar`.

`npm run check:migrations` no corre local (necesita `SUPABASE_SERVICE_ROLE_KEY`). Después
del merge conviene disparar `integridad.yml` a mano (`workflow_dispatch`) para confirmar
el verde sin esperar al cron de las 11:00 UTC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)