### PR TITLE
La regla de permisos no es solo para SECURITY DEFINER

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,9 +66,14 @@ suelta en `sucursales`.
 - Los schemas Zod de un modal lazy van **co-locados en el modal**, no importados de un
   chunk compartido: si no, un bundle viejo del PWA valida contra un schema desincronizado
   y tira "Invalid input" sin ningún error de chunk.
-- Toda función `SECURITY DEFINER` nueva nace con `EXECUTE` para `PUBLIC`. Hay que
-  **revocarlo explícitamente en la misma migración** (`REVOKE ... FROM PUBLIC, anon`).
-  `GRANT TO authenticated` no lo revierte. Hay un gate de CI que lo verifica.
+- **Toda función nueva** de `public` nace con `EXECUTE` para `PUBLIC` — sea `SECURITY
+  DEFINER` o no — y Supabase además se lo concede a `anon` por separado. Hay que
+  **revocar las dos mitades en la misma migración** (`REVOKE ... FROM PUBLIC, anon`);
+  `GRANT TO authenticated` no lo revierte. El gate de CI (`scripts/check-permisos.mjs`)
+  falla ante **cualquier** función alcanzable con la anon key, no solo las definer.
+  Una función de **trigger** no necesita `EXECUTE` para nadie: la invoca el executor como
+  parte del DML, no el caller. Dejala en `postgres` + `service_role`, como
+  `completar_origen_precio_item` (148) o `validar_precio_item_pedido`.
 - Los ids son `bigint` y llegan como `number` en runtime: usá `z.coerce.string()`, no
   `z.string()`.
 - **Las 4 RPCs de pago son wrappers**: la lógica vive en `<nombre>_impl` (mig 167, por la


### PR DESCRIPTION
Corrección de una regla de `CLAUDE.md` que **causó un bug esta misma semana**.

## Qué decía y por qué está mal

> Toda función **`SECURITY DEFINER`** nueva nace con `EXECUTE` para `PUBLIC`. Hay que revocarlo explícitamente en la misma migración…

El `SECURITY DEFINER` sobra y desorienta. **Toda** función nueva de `public` nace con el grant implícito a `PUBLIC` —definer o invoker— y Supabase además se lo concede a `anon` por separado. Y `scripts/check-permisos.mjs` no distingue: falla ante *cualquier* función alcanzable con la anon key.

## No es teórico

En la mig **212** (PR #541) leí la regla al pie de la letra: la función del trigger era invoker, así que no le puse el `REVOKE`. El gate la marcó:

```
Ejecutables por anon:
  completar_unidades_por_bloque_item()  (invoker, SIN GUARDA, sólo lee)
  acl: =X/postgres | postgres=X/postgres | authenticated=X/postgres | service_role=X/postgres
```

Hubo que arreglarlo con la mig **213**. La regla, tal como estaba escrita, apuntaba en la dirección equivocada.

## Qué queda

Además de sacar el `SECURITY DEFINER`, se agrega el corolario que faltaba y que tuve que deducir a mano leyendo el ACL de las funciones vecinas: **una función de trigger no necesita `EXECUTE` para nadie**, porque la invoca el executor como parte del DML, no el caller. Va con los dos ejemplos que ya viven en prod (`completar_origen_precio_item` de la 148 y `validar_precio_item_pedido`), para que la próxima no haya que deducirlo.

Solo toca `CLAUDE.md`: **no hay cambio de código ni de base**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)