### PR TITLE
Un cliente reservado a administración

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,6 +87,14 @@ suelta en `sucursales`.
   —selectores, rutas, recorridos— los oculta; el historial —reportes, cuenta corriente y los
   embeds `cliente:clientes(*)`— **tiene** que seguir viéndolos, que es de lo que se trata la
   baja lógica. Una consulta que no elige está eligiendo mal por omisión.
+- **La asignación de un cliente tiene TRES estados, no dos**: sin asignar / asignado a X /
+  `reservado_admin` (mig 214). Son excluyentes. Cuidado con que "sin asignar" significa
+  **visible para todos los preventistas** (mig 028), o sea lo contrario de reservado. Y
+  `reservado_admin` **no** es "solo lo ve admin": lo ven también encargado, transportista y
+  depósito, y el preventista que ya le vendió —esa excepción es la que evita que sus pedidos
+  viejos pierdan el cliente y desaparezcan por los `!inner` de `usePedidosQuery`—. Todo
+  camino nuevo que ofrezca clientes *para operar* lo excluye; todo camino de *historial* lo
+  sigue mostrando.
 
 ## Trampas
 

--- a/migrations/214_un_cliente_reservado_a_administracion.sql
+++ b/migrations/214_un_cliente_reservado_a_administracion.sql
@@ -1,0 +1,695 @@
+-- Migración 214: un cliente reservado a administración
+--
+-- Agrega el tercer estado de asignación: además de "sin asignar" y "asignado a
+-- X" ahora existe "reservado a administración" (`clientes.reservado_admin`).
+--
+-- QUÉ SIGNIFICA (y qué NO). No es "invisible para todos menos admin":
+--   * admin, encargado, transportista y depósito lo siguen viendo ENTERO, con
+--     nombre y dirección. El transportista tiene que entregarle y cobrarle.
+--   * el preventista que YA le vendió sigue viendo la ficha y sus pedidos
+--     completos. Sin esta excepción el embed `cliente:clientes(*)` devolvería
+--     NULL y los pedidos viejos se quedarían sin cliente — y peor, los
+--     `!inner` de usePedidosQuery / usePedidoStatsQuery los harían DESAPARECER
+--     de la lista y del count, en silencio.
+--   * lo que se cierra es que un preventista lo tome como cliente NUEVO o lo
+--     vea en sus listados operativos.
+--
+-- POR QUÉ UNA COLUMNA Y NO UNA ASIGNACIÓN. "Sin preventista asignado" ya
+-- significa "visible para TODOS los preventistas" (mig 028), o sea justo lo
+-- contrario. Y modelarlo dentro de `cliente_preventistas` no sirve: su policy
+-- de INSERT (mig 002) deja auto-asignarse a cualquiera, así que un preventista
+-- se agregaría solo con un INSERT y burlaría la restricción.
+--
+-- TERCER ESTADO EXCLUYENTE, no un flag que convive con asignaciones: un cliente
+-- "reservado Y asignado a Juan" es una contradicción que alguien va a cargar.
+-- Se enforcea en las dos direcciones (triggers 5 y 6 de abajo).
+--
+-- QUIÉN LO PONE Y LO SACA: solo admin. El encargado lo VE pero no lo administra,
+-- igual que no edita las asignaciones (el bloque del modal es `{isAdmin && …}`)
+-- ni los descuentos por categoría (RLS `es_admin()`). El trigger de la mig 080
+-- no alcanza: sale por RETURN NEW para todo rol que no sea preventista, así que
+-- el encargado necesita guard propio (trigger 4).
+--
+-- OJO es_preventista() / es_transportista(): devuelven true también para admin y
+-- encargado. Acá se lee `perfiles.rol` CRUDO o se usa es_admin(), nunca
+-- es_preventista().
+
+BEGIN;
+
+-- ---------------------------------------------------------------------------
+-- 1. La columna
+-- ---------------------------------------------------------------------------
+
+ALTER TABLE public.clientes
+  ADD COLUMN IF NOT EXISTS reservado_admin boolean NOT NULL DEFAULT false;
+
+COMMENT ON COLUMN public.clientes.reservado_admin IS
+  'Tercer estado de asignación: el cliente lo atiende administración. Lo ven '
+  'admin, encargado, transportista y depósito (con nombre y dirección), y el '
+  'preventista que ya le vendió (historial). Ningún otro preventista lo ve ni '
+  'puede tomarlo. Excluyente con cliente_preventistas: si es true, no hay '
+  'asignaciones. Solo admin lo pone y lo saca.';
+
+-- Índice para la excepción de historial (EXISTS pedidos propios) que aparece en
+-- la RLS de SELECT y de UPDATE. Sin esto el chequeo cae en idx_pedidos_cliente_id
+-- y filtra usuario_id fila por fila.
+CREATE INDEX IF NOT EXISTS idx_pedidos_cliente_usuario
+  ON public.pedidos (cliente_id, usuario_id);
+
+-- ---------------------------------------------------------------------------
+-- 2. RLS de SELECT
+-- ---------------------------------------------------------------------------
+-- La primera rama ("no soy preventista → veo todo") queda intacta: por eso
+-- admin, encargado, transportista y depósito no se enteran de este cambio.
+-- El predicado nuevo cuelga de la rama de preventista y SOLO RESTA: para un
+-- cliente no reservado `NOT reservado_admin` es true y el comportamiento es
+-- idéntico al de hoy, byte por byte.
+--
+-- `preventista_taco` no está: la mig 156 barrió el literal y el CHECK de
+-- perfiles.rol (mig 040) ya no lo admite. Se mantiene el criterio de la policy
+-- viva, que lee perfiles.rol crudo.
+
+DROP POLICY IF EXISTS "mt_clientes_select" ON public.clientes;
+CREATE POLICY "mt_clientes_select"
+  ON public.clientes
+  FOR SELECT TO authenticated
+  USING (
+    sucursal_id = public.current_sucursal_id()
+    AND (
+      -- Roles que no son preventista ven todos los clientes de su sucursal
+      NOT EXISTS (
+        SELECT 1 FROM public.perfiles p
+        WHERE p.id = auth.uid() AND p.rol IN ('preventista')
+      )
+      OR (
+        -- Regla de asignación de siempre: huérfanos + los míos
+        (
+          NOT EXISTS (
+            SELECT 1 FROM public.cliente_preventistas cp
+            WHERE cp.cliente_id = clientes.id
+          )
+          OR EXISTS (
+            SELECT 1 FROM public.cliente_preventistas cp
+            WHERE cp.cliente_id = clientes.id AND cp.preventista_id = auth.uid()
+          )
+        )
+        -- ...menos los reservados, salvo que tenga historial propio con él
+        AND (
+          NOT clientes.reservado_admin
+          OR EXISTS (
+            SELECT 1 FROM public.pedidos pe
+            WHERE pe.cliente_id = clientes.id AND pe.usuario_id = auth.uid()
+          )
+        )
+      )
+    )
+  );
+
+-- ---------------------------------------------------------------------------
+-- 3. RLS de UPDATE e INSERT
+-- ---------------------------------------------------------------------------
+-- mt_clientes_update es INDEPENDIENTE de la de SELECT: usa es_preventista(), así
+-- que hoy un preventista que NO ve la fila igual puede hacerle UPDATE por id vía
+-- PostgREST. El predicado va en USING y en WITH CHECK.
+--
+-- Acá es más estricto que el SELECT a propósito: el preventista con historial
+-- LEE la ficha (para que sus pedidos viejos no se rompan) pero no la EDITA. El
+-- cliente lo administra administración.
+
+DROP POLICY IF EXISTS "mt_clientes_update" ON public.clientes;
+CREATE POLICY "mt_clientes_update"
+  ON public.clientes
+  FOR UPDATE TO authenticated
+  USING (
+    public.es_preventista()
+    AND sucursal_id = public.current_sucursal_id()
+    AND (
+      NOT reservado_admin
+      OR NOT EXISTS (
+        SELECT 1 FROM public.perfiles p
+        WHERE p.id = auth.uid() AND p.rol IN ('preventista')
+      )
+    )
+  )
+  WITH CHECK (
+    public.es_preventista()
+    AND sucursal_id = public.current_sucursal_id()
+    AND (
+      NOT reservado_admin
+      OR NOT EXISTS (
+        SELECT 1 FROM public.perfiles p
+        WHERE p.id = auth.uid() AND p.rol IN ('preventista')
+      )
+    )
+  );
+
+-- INSERT: si no, un preventista crea el cliente ya marcado y después se
+-- auto-asigna. Nace reservado solo si lo crea un admin.
+DROP POLICY IF EXISTS "mt_clientes_insert" ON public.clientes;
+CREATE POLICY "mt_clientes_insert"
+  ON public.clientes
+  FOR INSERT TO authenticated
+  WITH CHECK (
+    public.es_preventista()
+    AND sucursal_id = public.current_sucursal_id()
+    AND (NOT reservado_admin OR public.es_admin())
+  );
+
+-- ---------------------------------------------------------------------------
+-- 4. Solo admin pone y saca la marca
+-- ---------------------------------------------------------------------------
+-- El allow-list de la mig 080 ya deja la columna nueva protegida contra
+-- preventistas (es fail-closed), pero sale por RETURN NEW para admin Y para
+-- encargado. Este trigger cierra la mitad del encargado.
+--
+-- Exenciones, mismas que la 080: las RPC SECURITY DEFINER corren como postgres
+-- y el bot con service_role — ahí `auth.uid()` no sirve para decidir.
+
+CREATE OR REPLACE FUNCTION public.clientes_reservado_solo_admin()
+RETURNS trigger
+LANGUAGE plpgsql
+SET search_path TO 'public'
+AS $$
+BEGIN
+  IF current_user <> 'authenticated' THEN
+    RETURN NEW;
+  END IF;
+  IF pg_trigger_depth() > 1 THEN
+    RETURN NEW;
+  END IF;
+
+  IF TG_OP = 'INSERT' THEN
+    IF NEW.reservado_admin AND NOT es_admin() THEN
+      RAISE EXCEPTION 'Solo un administrador puede crear un cliente reservado a administración'
+        USING ERRCODE = '42501';
+    END IF;
+    RETURN NEW;
+  END IF;
+
+  IF NEW.reservado_admin IS DISTINCT FROM OLD.reservado_admin AND NOT es_admin() THEN
+    RAISE EXCEPTION 'Solo un administrador puede reservar un cliente a administración o liberarlo'
+      USING ERRCODE = '42501';
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_clientes_reservado_solo_admin ON public.clientes;
+CREATE TRIGGER trg_clientes_reservado_solo_admin
+  BEFORE INSERT OR UPDATE ON public.clientes
+  FOR EACH ROW
+  EXECUTE FUNCTION public.clientes_reservado_solo_admin();
+
+-- ---------------------------------------------------------------------------
+-- 5. Reservado ⇒ sin asignaciones (al marcar, se limpian)
+-- ---------------------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION public.clientes_reservado_limpia_asignaciones()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $$
+BEGIN
+  IF NEW.reservado_admin THEN
+    DELETE FROM cliente_preventistas WHERE cliente_id = NEW.id;
+  END IF;
+  RETURN NULL;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_clientes_reservado_limpia_asignaciones ON public.clientes;
+CREATE TRIGGER trg_clientes_reservado_limpia_asignaciones
+  AFTER INSERT OR UPDATE OF reservado_admin ON public.clientes
+  FOR EACH ROW
+  WHEN (NEW.reservado_admin)
+  EXECUTE FUNCTION public.clientes_reservado_limpia_asignaciones();
+
+-- ---------------------------------------------------------------------------
+-- 6. ...y no se le pueden agregar después
+-- ---------------------------------------------------------------------------
+-- Sin esto, cp_insert (mig 002: `es_admin() OR preventista_id = auth.uid()`)
+-- deja que el preventista se auto-asigne y rompa la exclusividad. No le
+-- alcanzaría para VER al cliente (la RLS de arriba pide además que no esté
+-- reservado), pero deja la fila contradictoria en la base.
+
+-- SECURITY DEFINER a proposito: como INVOKER el SELECT sobre `clientes` pasa por
+-- la RLS del que inserta, que justamente NO ve al cliente reservado. El guard
+-- devolveria "no existe" y dejaria pasar el INSERT: fail-open.
+CREATE OR REPLACE FUNCTION public.cliente_preventistas_no_reservado()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM clientes c WHERE c.id = NEW.cliente_id AND c.reservado_admin) THEN
+    RAISE EXCEPTION 'El cliente % está reservado a administración: no admite preventistas asignados', NEW.cliente_id
+      USING ERRCODE = '42501';
+  END IF;
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_cliente_preventistas_no_reservado ON public.cliente_preventistas;
+CREATE TRIGGER trg_cliente_preventistas_no_reservado
+  BEFORE INSERT OR UPDATE ON public.cliente_preventistas
+  FOR EACH ROW
+  EXECUTE FUNCTION public.cliente_preventistas_no_reservado();
+
+-- ---------------------------------------------------------------------------
+-- 7. Ningún preventista le carga un pedido
+-- ---------------------------------------------------------------------------
+-- `crear_pedido_completo` NO valida ninguna regla de asignación (agujero
+-- preexistente: hoy un preventista puede cargarle un pedido a un cliente
+-- asignado a otro si conoce el id — ver issue). Esta feature lo volvería
+-- visible: el front oculta el cliente y el RPC igual aceptaría el pedido.
+--
+-- Va como trigger sobre `pedidos` y no adentro del RPC a propósito:
+--   * cubre `crear_pedido_completo` Y `crear_pedido_completo_bot` de una;
+--   * no toca el cuerpo vivo de ninguno de los dos — la mig 205 le inyecta
+--     código a `crear_pedido_completo` con `_mig205_insertar_tras_ancla`, así
+--     que copiar el cuerpo del repo revertiría lógica viva;
+--   * el bot corre con service_role y BYPASSEA la RLS, así que no se puede
+--     exentar por `current_user` como hacen los guards de la 080.
+-- Un trigger no necesita EXECUTE para nadie: lo invoca el executor como parte
+-- del DML.
+--
+-- Se decide por `pedidos.usuario_id` (el autor de la venta), no por auth.uid():
+-- en el camino del bot auth.uid() es NULL. Es además la columna a la que la
+-- app le atribuye la venta.
+
+-- SECURITY DEFINER por lo mismo: lee `clientes` (que la RLS le tapa al
+-- preventista) y `perfiles` (donde solo ve el suyo). Como INVOKER los dos EXISTS
+-- darian false y el guard dejaria pasar todo.
+CREATE OR REPLACE FUNCTION public.pedidos_cliente_reservado()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $$
+BEGIN
+  IF NEW.cliente_id IS NULL OR NEW.usuario_id IS NULL THEN
+    RETURN NEW;
+  END IF;
+
+  IF EXISTS (SELECT 1 FROM clientes c WHERE c.id = NEW.cliente_id AND c.reservado_admin)
+     AND EXISTS (SELECT 1 FROM perfiles p WHERE p.id = NEW.usuario_id AND p.rol IN ('preventista'))
+  THEN
+    RAISE EXCEPTION 'El cliente % está reservado a administración: no se le pueden cargar pedidos desde un preventista', NEW.cliente_id
+      USING ERRCODE = '42501';
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_pedidos_cliente_reservado ON public.pedidos;
+CREATE TRIGGER trg_pedidos_cliente_reservado
+  BEFORE INSERT ON public.pedidos
+  FOR EACH ROW
+  EXECUTE FUNCTION public.pedidos_cliente_reservado();
+
+-- ---------------------------------------------------------------------------
+-- 8. El bot bypassea la RLS: cada filtro se repite a mano
+-- ---------------------------------------------------------------------------
+-- Misma familia de bug que la 203 (el bot seguía ofreciendo clientes inactivos).
+-- Sin esto el preventista pide el cliente por Telegram y lo obtiene igual.
+--
+-- Un cliente reservado no tiene asignaciones, o sea que es HUÉRFANO: cae justo
+-- en la rama `OR NOT EXISTS(...)` que estas funciones usan para mostrárselo a
+-- cualquier preventista. Por eso hay que tocarlas.
+--
+-- NO hace falta tocar `bot_mis_clientes` ni `bot_sugerir_visitas_rfm`: las dos
+-- hacen INNER JOIN contra cliente_preventistas, así que un cliente sin
+-- asignaciones nunca aparece.
+--
+-- El conjunto nuevo va SUELTO, como AND aparte de la lógica de asignación, para
+-- no alterar en nada el comportamiento actual de los clientes no reservados.
+-- `p_rol` incluye 'encargado' porque en el bot el encargado NO entra por la
+-- rama de admin (`p_rol = 'admin'`) y sin embargo tiene que ver al reservado.
+
+CREATE OR REPLACE FUNCTION public.bot_buscar_cliente(
+  p_q text, p_perfil_id uuid, p_rol text, p_sucursal_id bigint, p_limit integer DEFAULT 10
+)
+RETURNS TABLE(id bigint, codigo integer, nombre_fantasia text, razon_social text,
+              saldo_cuenta numeric, direccion text, zona text, sucursal_id bigint)
+LANGUAGE sql
+STABLE SECURITY DEFINER
+SET search_path TO 'public'
+AS $function$
+  WITH terms AS (
+    SELECT array_remove(
+      string_to_array(
+        trim(lower(f_unaccent(coalesce(p_q, '')))),
+        ' '
+      ),
+      ''
+    ) AS words
+  )
+  SELECT
+    c.id, c.codigo, c.nombre_fantasia, c.razon_social, c.saldo_cuenta,
+    c.direccion, c.zona, c.sucursal_id
+  FROM clientes c, terms t
+  WHERE
+    c.sucursal_id = p_sucursal_id
+    -- Baja logica: un cliente desactivado no se ofrece para operar. Su historial
+    -- sigue intacto y visible en los reportes, que no pasan por aca.
+    AND c.activo = TRUE
+    AND (
+      p_rol = 'admin'
+      OR EXISTS(
+        SELECT 1 FROM cliente_preventistas cp
+        WHERE cp.cliente_id = c.id AND cp.preventista_id = p_perfil_id
+      )
+      -- Huerfanos (sin asignacion a ningun preventista) visibles para cualquier
+      -- preventista de la misma sucursal (mig 028).
+      OR NOT EXISTS(
+        SELECT 1 FROM cliente_preventistas cp WHERE cp.cliente_id = c.id
+      )
+    )
+    -- Reservado a administracion (mig 214): el reservado es huerfano, asi que
+    -- sin esto la rama de arriba se lo muestra a cualquier preventista.
+    AND (
+      p_rol IN ('admin', 'encargado')
+      OR NOT c.reservado_admin
+      OR EXISTS(
+        SELECT 1 FROM pedidos pe
+        WHERE pe.cliente_id = c.id AND pe.usuario_id = p_perfil_id
+      )
+    )
+    AND (
+      array_length(t.words, 1) IS NULL
+      OR (
+        SELECT bool_and(
+          lower(f_unaccent(coalesce(c.nombre_fantasia, ''))) LIKE '%' || w || '%'
+          OR lower(f_unaccent(coalesce(c.razon_social, ''))) LIKE '%' || w || '%'
+          OR lower(coalesce(c.codigo::TEXT, '')) LIKE '%' || w || '%'
+        )
+        FROM unnest(t.words) AS w
+      )
+    )
+  ORDER BY c.nombre_fantasia
+  LIMIT p_limit;
+$function$;
+
+REVOKE ALL ON FUNCTION public.bot_buscar_cliente(text, uuid, text, bigint, integer) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.bot_buscar_cliente(text, uuid, text, bigint, integer) TO service_role;
+
+CREATE OR REPLACE FUNCTION public.bot_historico_pedidos_cliente(
+  p_cliente_id bigint, p_perfil_id uuid, p_rol text, p_sucursal_id bigint,
+  p_dias integer DEFAULT 90, p_limit integer DEFAULT 20
+)
+RETURNS json
+LANGUAGE plpgsql
+STABLE SECURITY DEFINER
+SET search_path TO 'public'
+AS $function$
+DECLARE resultado JSON;
+BEGIN
+  IF p_rol = 'preventista' THEN
+    IF NOT (
+      EXISTS(SELECT 1 FROM cliente_preventistas
+             WHERE cliente_id = p_cliente_id AND preventista_id = p_perfil_id)
+      OR NOT EXISTS(SELECT 1 FROM cliente_preventistas
+                    WHERE cliente_id = p_cliente_id)
+    ) THEN
+      RETURN json_build_object('cliente_id', p_cliente_id, 'pedidos_count', 0,
+        'pedidos', '[]'::JSON, 'error', 'Cliente asignado a otro preventista');
+    END IF;
+
+    -- Reservado a administracion (mig 214). El historial propio SI se ve: es la
+    -- excepcion que evita que sus pedidos viejos queden sin cliente.
+    IF EXISTS(SELECT 1 FROM clientes c WHERE c.id = p_cliente_id AND c.reservado_admin)
+       AND NOT EXISTS(SELECT 1 FROM pedidos pe
+                      WHERE pe.cliente_id = p_cliente_id AND pe.usuario_id = p_perfil_id)
+    THEN
+      RETURN json_build_object('cliente_id', p_cliente_id, 'pedidos_count', 0,
+        'pedidos', '[]'::JSON, 'error', 'Cliente reservado a administración');
+    END IF;
+  END IF;
+
+  WITH ultimos_pedidos AS (
+    SELECT id, fecha, total, estado, estado_pago, created_at
+    FROM pedidos
+    WHERE cliente_id = p_cliente_id AND sucursal_id = p_sucursal_id
+      AND created_at > now() - (p_dias || ' days')::INTERVAL
+      AND COALESCE(estado, '') NOT IN ('cancelado', 'anulado')
+    ORDER BY created_at DESC LIMIT p_limit
+  ),
+  pedidos_con_items AS (
+    SELECT up.id, up.fecha, up.total, up.estado, up.estado_pago, up.created_at,
+      (SELECT json_agg(json_build_object('producto_id', p.id, 'codigo', p.codigo,
+        'nombre', p.nombre, 'cantidad', pi.cantidad, 'subtotal', pi.subtotal)
+        ORDER BY pi.subtotal DESC)
+       FROM pedido_items pi JOIN productos p ON p.id = pi.producto_id
+       WHERE pi.pedido_id = up.id) AS items
+    FROM ultimos_pedidos up
+  )
+  SELECT json_build_object(
+    'cliente_id', p_cliente_id,
+    'pedidos_count', (SELECT COUNT(*) FROM pedidos_con_items),
+    'rango_dias', p_dias,
+    'total_periodo', (SELECT COALESCE(SUM(total), 0) FROM pedidos_con_items),
+    'pedidos', COALESCE(
+      (SELECT json_agg(row_to_json(p.*) ORDER BY p.created_at DESC) FROM pedidos_con_items p),
+      '[]'::JSON
+    )
+  ) INTO resultado;
+  RETURN resultado;
+END;
+$function$;
+
+REVOKE ALL ON FUNCTION public.bot_historico_pedidos_cliente(bigint, uuid, text, bigint, integer, integer) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.bot_historico_pedidos_cliente(bigint, uuid, text, bigint, integer, integer) TO service_role;
+
+CREATE OR REPLACE FUNCTION public.bot_productos_recurrentes_cliente(
+  p_cliente_id bigint, p_perfil_id uuid, p_rol text, p_sucursal_id bigint,
+  p_dias integer DEFAULT 90, p_limit integer DEFAULT 10
+)
+RETURNS json
+LANGUAGE plpgsql
+STABLE SECURITY DEFINER
+SET search_path TO 'public'
+AS $function$
+DECLARE resultado JSON;
+BEGIN
+  IF p_rol = 'preventista' THEN
+    IF NOT (
+      EXISTS(SELECT 1 FROM cliente_preventistas
+             WHERE cliente_id = p_cliente_id AND preventista_id = p_perfil_id)
+      OR NOT EXISTS(SELECT 1 FROM cliente_preventistas
+                    WHERE cliente_id = p_cliente_id)
+    ) THEN
+      RETURN json_build_object('cliente_id', p_cliente_id, 'productos', '[]'::JSON,
+        'error', 'Cliente asignado a otro preventista');
+    END IF;
+
+    -- Reservado a administracion (mig 214), con la misma excepcion de historial.
+    IF EXISTS(SELECT 1 FROM clientes c WHERE c.id = p_cliente_id AND c.reservado_admin)
+       AND NOT EXISTS(SELECT 1 FROM pedidos pe
+                      WHERE pe.cliente_id = p_cliente_id AND pe.usuario_id = p_perfil_id)
+    THEN
+      RETURN json_build_object('cliente_id', p_cliente_id, 'productos', '[]'::JSON,
+        'error', 'Cliente reservado a administración');
+    END IF;
+  END IF;
+
+  WITH items_periodo AS (
+    SELECT pi.producto_id, pi.cantidad, pi.subtotal, pe.id AS pedido_id
+    FROM pedido_items pi JOIN pedidos pe ON pe.id = pi.pedido_id
+    WHERE pe.cliente_id = p_cliente_id AND pe.sucursal_id = p_sucursal_id
+      AND pe.created_at > now() - (p_dias || ' days')::INTERVAL
+      AND COALESCE(pe.estado, '') NOT IN ('cancelado', 'anulado')
+  ),
+  ranked AS (
+    SELECT p.id, p.codigo, p.nombre, p.precio,
+      COUNT(DISTINCT ip.pedido_id) AS pedidos_con_producto,
+      SUM(ip.cantidad) AS unidades_totales,
+      SUM(ip.subtotal) AS facturado_total
+    FROM items_periodo ip JOIN productos p ON p.id = ip.producto_id
+    GROUP BY p.id, p.codigo, p.nombre, p.precio
+    ORDER BY COUNT(DISTINCT ip.pedido_id) DESC, SUM(ip.cantidad) DESC
+    LIMIT p_limit
+  )
+  SELECT json_build_object(
+    'cliente_id', p_cliente_id, 'rango_dias', p_dias,
+    'productos', COALESCE((SELECT json_agg(row_to_json(r.*)) FROM ranked r), '[]'::JSON)
+  ) INTO resultado;
+  RETURN resultado;
+END;
+$function$;
+
+REVOKE ALL ON FUNCTION public.bot_productos_recurrentes_cliente(bigint, uuid, text, bigint, integer, integer) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.bot_productos_recurrentes_cliente(bigint, uuid, text, bigint, integer, integer) TO service_role;
+
+-- ---------------------------------------------------------------------------
+-- 9. Visitas: no se marca visita a un cliente reservado
+-- ---------------------------------------------------------------------------
+-- registrar_visita_cliente es SECURITY DEFINER y corre como postgres, o sea que
+-- la RLS de clientes no la frena: replica la regla a mano, igual que el bot.
+
+CREATE OR REPLACE FUNCTION public.registrar_visita_cliente(
+  p_cliente_id bigint, p_status text, p_lat numeric DEFAULT NULL::numeric,
+  p_lng numeric DEFAULT NULL::numeric, p_accuracy numeric DEFAULT NULL::numeric,
+  p_capturado_at timestamp with time zone DEFAULT NULL::timestamp with time zone,
+  p_motivo_omision text DEFAULT NULL::text
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $function$
+DECLARE
+  v_user_id uuid := auth.uid();
+  v_user_role text;
+  v_sucursal bigint := current_sucursal_id();
+  v_cliente RECORD;
+  v_autorizado boolean;
+  v_visita_id bigint;
+BEGIN
+  IF v_user_id IS NULL THEN
+    RETURN jsonb_build_object('success', false, 'error', 'No autenticado');
+  END IF;
+  IF v_sucursal IS NULL THEN
+    RETURN jsonb_build_object('success', false, 'error', 'No hay sucursal activa');
+  END IF;
+
+  IF p_status NOT IN ('ok','denied','unavailable','timeout','error') THEN
+    RETURN jsonb_build_object('success', false, 'error', 'gps_status invalido');
+  END IF;
+  IF p_status = 'ok' AND (p_lat IS NULL OR p_lng IS NULL) THEN
+    RETURN jsonb_build_object('success', false, 'error', 'lat y lng requeridos cuando status=ok');
+  END IF;
+
+  SELECT rol INTO v_user_role FROM perfiles WHERE id = v_user_id;
+  IF v_user_role NOT IN ('preventista', 'admin') THEN
+    RETURN jsonb_build_object('success', false, 'error', 'Rol no autorizado para marcar visitas');
+  END IF;
+
+  SELECT id, sucursal_id, reservado_admin INTO v_cliente FROM clientes WHERE id = p_cliente_id;
+  IF NOT FOUND THEN
+    RETURN jsonb_build_object('success', false, 'error', 'Cliente no existe');
+  END IF;
+  IF v_cliente.sucursal_id IS DISTINCT FROM v_sucursal THEN
+    RETURN jsonb_build_object('success', false, 'error', 'Cliente fuera de la sucursal activa');
+  END IF;
+
+  IF v_user_role IN ('preventista') THEN
+    SELECT (
+      NOT EXISTS (SELECT 1 FROM cliente_preventistas cp WHERE cp.cliente_id = p_cliente_id)
+      OR EXISTS (SELECT 1 FROM cliente_preventistas cp WHERE cp.cliente_id = p_cliente_id AND cp.preventista_id = v_user_id)
+    ) INTO v_autorizado;
+    IF NOT v_autorizado THEN
+      RETURN jsonb_build_object('success', false, 'error', 'Cliente asignado a otro preventista');
+    END IF;
+
+    -- Reservado a administracion (mig 214). Sin excepcion de historial: marcar
+    -- una visita es operar, no consultar el pasado.
+    IF v_cliente.reservado_admin THEN
+      RETURN jsonb_build_object('success', false, 'error', 'Cliente reservado a administración');
+    END IF;
+  END IF;
+
+  INSERT INTO visitas_cliente (
+    preventista_id, cliente_id, sucursal_id,
+    gps_lat, gps_lng, gps_accuracy, gps_capturado_at, gps_status, gps_motivo_omision
+  ) VALUES (
+    v_user_id, p_cliente_id, v_sucursal,
+    CASE WHEN p_status = 'ok' THEN p_lat ELSE NULL END,
+    CASE WHEN p_status = 'ok' THEN p_lng ELSE NULL END,
+    CASE WHEN p_status = 'ok' THEN p_accuracy ELSE NULL END,
+    COALESCE(p_capturado_at, now()),
+    p_status,
+    CASE WHEN p_status = 'ok' THEN NULL ELSE p_motivo_omision END
+  ) RETURNING id INTO v_visita_id;
+
+  RETURN jsonb_build_object('success', true, 'visita_id', v_visita_id);
+END;
+$function$;
+
+REVOKE ALL ON FUNCTION public.registrar_visita_cliente(bigint, text, numeric, numeric, numeric, timestamptz, text) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.registrar_visita_cliente(bigint, text, numeric, numeric, numeric, timestamptz, text) TO authenticated;
+
+-- ---------------------------------------------------------------------------
+-- 9bis. ACL de las funciones de trigger
+-- ---------------------------------------------------------------------------
+-- Toda funcion nueva de `public` nace con EXECUTE para PUBLIC (esa entrada
+-- `=X/postgres` sin grantee) y Supabase le agrega `authenticated` por separado:
+-- hay que revocar las dos mitades acá, en la misma migración. Es exactamente lo
+-- que la mig 212 se olvidó y la 213 tuvo que venir a cerrar.
+--
+-- Una función de trigger no necesita EXECUTE para NADIE: la invoca el executor
+-- como parte del DML, no el caller. Quedan en postgres + service_role, igual que
+-- `clientes_proteger_columnas_preventista` (080) y `completar_origen_precio_item` (148).
+
+REVOKE ALL ON FUNCTION public.clientes_reservado_solo_admin()
+  FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.clientes_reservado_limpia_asignaciones()
+  FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.cliente_preventistas_no_reservado()
+  FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.pedidos_cliente_reservado()
+  FROM PUBLIC, anon, authenticated;
+
+-- ---------------------------------------------------------------------------
+-- 10. Verificación de ACL (gate de CI: scripts/check-permisos.mjs)
+-- ---------------------------------------------------------------------------
+-- Las funciones de trigger (4, 5, 6, 7) NO necesitan EXECUTE para nadie: las
+-- invoca el executor como parte del DML, no el caller. Quedan en postgres.
+
+DO $verif$
+DECLARE
+  v_nombre text;
+  v_acl text;
+  v_esperado text;
+BEGIN
+  FOR v_nombre, v_esperado IN
+    SELECT * FROM (VALUES
+      ('bot_buscar_cliente', 'service_role'),
+      ('bot_historico_pedidos_cliente', 'service_role'),
+      ('bot_productos_recurrentes_cliente', 'service_role'),
+      ('registrar_visita_cliente', 'authenticated')
+    ) AS t(nombre, esperado)
+  LOOP
+    SELECT array_to_string(proacl, ',') INTO v_acl
+    FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace
+    WHERE n.nspname = 'public' AND p.proname = v_nombre;
+
+    IF v_acl IS NULL THEN
+      RAISE EXCEPTION '% quedo con ACL default (PUBLIC ejecuta)', v_nombre;
+    END IF;
+    IF v_acl LIKE '=X/%' OR v_acl LIKE '%,=X/%' THEN
+      RAISE EXCEPTION '% quedo ejecutable por PUBLIC: %', v_nombre, v_acl;
+    END IF;
+    IF v_acl LIKE '%anon=%' THEN
+      RAISE EXCEPTION '% quedo ejecutable por anon: %', v_nombre, v_acl;
+    END IF;
+    IF v_acl NOT LIKE '%' || v_esperado || '=X%' THEN
+      RAISE EXCEPTION '% no quedo ejecutable por %: %', v_nombre, v_esperado, v_acl;
+    END IF;
+  END LOOP;
+
+  -- Las de trigger no deben tener EXECUTE para authenticated ni anon.
+  FOR v_nombre IN
+    SELECT unnest(ARRAY['clientes_reservado_solo_admin',
+                        'clientes_reservado_limpia_asignaciones',
+                        'cliente_preventistas_no_reservado',
+                        'pedidos_cliente_reservado'])
+  LOOP
+    SELECT array_to_string(proacl, ',') INTO v_acl
+    FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace
+    WHERE n.nspname = 'public' AND p.proname = v_nombre;
+
+    IF v_acl IS NULL OR v_acl LIKE '=X/%' OR v_acl LIKE '%,=X/%' THEN
+      RAISE EXCEPTION 'trigger % quedo ejecutable por PUBLIC: %', v_nombre, coalesce(v_acl, '(default)');
+    END IF;
+    IF v_acl LIKE '%anon=%' THEN
+      RAISE EXCEPTION 'trigger % quedo ejecutable por anon: %', v_nombre, v_acl;
+    END IF;
+  END LOOP;
+END
+$verif$;
+
+COMMIT;

--- a/migrations/MANIFEST.md
+++ b/migrations/MANIFEST.md
@@ -137,17 +137,17 @@ funcional** y no se renombran los archivos: renombrarlos los desalinearía del l
 real lo da `version` y está en la sección A: en los dos casos el archivo de `main` quedó
 cronológicamente **fuera** del bloque 139–147 (uno antes, otro entre la 144 y la 145).
 
-**La próxima migración es la 214** — la última numerada en el repo es
-`213_cerrar_el_acl_del_trigger_de_la_212`, y el ledger de prod está alineado con ella.
+**La próxima migración es la 215** — la última numerada en el repo es
+`214_un_cliente_reservado_a_administracion`, y el ledger de prod está alineado con ella.
 Igual, confirmá el número contra las tres fuentes justo antes de aplicar: el
 número se reserva **aplicando**, no escribiendo el archivo.
 
 (Esta línea decía 206 hasta el 2026-09-08, con las 206–209 ya aplicadas: la
 numeración del repo avanzó cuatro veces sin que nadie la corrigiera. Si aplicás
-una migración, actualizá también esta línea.)
+una migración, actualizá también esta línea. Última actualización: 214, el 2026-09-09.)
 
 Las 197–202 no tienen prosa acá (quedaron sin documentar en su momento). Las 203, 204,
-205, 212 y 213 sí:
+205, 212, 213 y 214 sí:
 
 - **203** `bot_buscar_cliente` pasa a filtrar `activo = TRUE`. Era el único camino
   del bot que no lo hacía, y es la puerta de entrada: un cliente dado de baja
@@ -213,6 +213,26 @@ Las 206–209 tampoco tienen prosa acá. Las 210 y 211 sí:
   como parte del INSERT, no el caller—, así que queda con `postgres` + `service_role`, igual
   que `completar_origen_precio_item` (148) y `validar_precio_item_pedido`. Verificado que el
   trigger sigue disparando después del revoke. **No toca ninguna fila.**
+- **214** agrega el tercer estado de asignación de clientes: `clientes.reservado_admin`
+  ("Solo administradores"). No es "invisible para todos menos admin" — admin, encargado,
+  transportista y depósito lo ven entero, y el preventista que **ya le vendió** también,
+  porque si no el embed `cliente:clientes(*)` devuelve NULL y los `!inner` de
+  `usePedidosQuery` / `usePedidoStatsQuery` le hacen **desaparecer** los pedidos viejos de
+  la lista y del count, en silencio. Lo que cierra es que un preventista lo tome como
+  cliente nuevo. No se pudo modelar como ausencia de asignación porque "sin preventista
+  asignado" ya significa *visible para todos* (mig 028), ni dentro de
+  `cliente_preventistas` porque `cp_insert` (002) deja auto-asignarse a cualquiera. Es
+  **excluyente** con las asignaciones, enforceado en las dos direcciones. Toca las tres
+  policies de `clientes` (select, update e insert — la de update es independiente de la de
+  select y por eso también la lleva), 4 triggers nuevos, y repite el filtro a mano en
+  `bot_buscar_cliente`, `bot_historico_pedidos_cliente`, `bot_productos_recurrentes_cliente`
+  y `registrar_visita_cliente` porque el bot corre con `service_role` y bypassea la RLS
+  (misma familia que la 203). `bot_mis_clientes` y `bot_sugerir_visitas_rfm` no hacen falta:
+  hacen INNER JOIN contra `cliente_preventistas`. El trigger sobre `pedidos` cubre
+  `crear_pedido_completo` y `crear_pedido_completo_bot` sin tocarles el cuerpo vivo (la 205
+  le inyecta código al primero). **No toca ninguna fila**: la columna nace en `false` y todo
+  el predicado nuevo es una tautología mientras nadie marque a nadie. Verificado contra prod
+  con un usuario de cada rol.
 
 La **195** le da a la cabecera la columna `compras.bonificaciones`, que es donde se resta
 una bonificación general: el `subtotal` es el neto de los RENGLONES y lo clava `COMPRA-A2`

--- a/src/components/containers/ClientesContainer.tsx
+++ b/src/components/containers/ClientesContainer.tsx
@@ -380,6 +380,11 @@ export default function ClientesContainer(): React.ReactElement {
     // se espeja con el primer asignado para no romper lecturas en otros modulos
     // hasta que se elimine la columna en una migracion futura.
     const isCreating = !clienteEditando
+    // "Solo administradores" (mig 214) es el tercer estado de asignacion y es
+    // EXCLUYENTE con la N-a-N: un cliente reservado no lleva preventistas. Si
+    // igual mandaramos ids, el trigger trg_cliente_preventistas_no_reservado
+    // rechaza el INSERT. Solo admin puede marcarlo (RLS + trigger de la base).
+    const reservadoAdmin = isAdmin && (data.reservado_admin ?? false)
     // Solo admin puede editar las asignaciones desde la UI. Un preventista
     // editando un cliente NO debe tocar la tabla N-a-N (RLS lo rechazaria y
     // ademas no vio el selector). La unica excepcion: al crear, el preventista
@@ -390,9 +395,12 @@ export default function ClientesContainer(): React.ReactElement {
     let ids: string[] | undefined
     if (willTouchAssignments) {
       const baseIds = data.preventista_ids || []
-      ids = isCreating && isPreventista && !isAdmin && user?.id
-        ? Array.from(new Set([...baseIds, user.id]))
-        : baseIds
+      // Reservado: sin asignaciones, y sin la auto-asignacion del que lo crea.
+      ids = reservadoAdmin
+        ? []
+        : isCreating && isPreventista && !isAdmin && user?.id
+          ? Array.from(new Set([...baseIds, user.id]))
+          : baseIds
     }
 
     // Dual-write zona text + zona_id durante el deprecation window:
@@ -468,6 +476,10 @@ export default function ClientesContainer(): React.ReactElement {
       // cliente_descuentos_categoria exige es_admin()). Para no-admin omitimos
       // la clave para que replaceCategoriaDiscounts ni se ejecute.
       ...(isAdmin ? {
+        // Visibilidad (mig 214): solo admin la administra. El allow-list de la
+        // mig 080 se lo bloquea al preventista y trg_clientes_reservado_solo_admin
+        // al encargado, pero igual no mandamos la clave si no es admin.
+        reservado_admin: reservadoAdmin,
         // FC/ZZ por defecto de pedidos (mig 116): solo admin lo edita (el guard
         // trigger de clientes lo bloquea para preventistas de todas formas).
         tipo_factura_default: data.tipoFacturaDefault ?? 'ZZ',

--- a/src/components/modals/ModalCliente.tsx
+++ b/src/components/modals/ModalCliente.tsx
@@ -1,5 +1,5 @@
 import { useState, memo, useRef, useMemo } from 'react';
-import { Loader2, MapPin, CreditCard, Clock, Tag, FileText, Users, LocateFixed, AlertCircle, Percent, Plus, Trash2 } from 'lucide-react';
+import { Loader2, MapPin, CreditCard, Clock, Tag, FileText, Users, LocateFixed, AlertCircle, Percent, Plus, Trash2, Lock } from 'lucide-react';
 import ModalBase from './ModalBase';
 import NumberInput from '../ui/NumberInput';
 import FranjasHorariasEditor from '../ui/FranjasHorariasEditor';
@@ -66,6 +66,12 @@ export interface ClienteFormData {
   descuentosPorCategoria: Array<{ categoria: string; porcentaje: number }>;
   preventista_id: string;
   preventista_ids: string[];
+  /**
+   * "Solo administradores" (mig 214). Excluyente con `preventista_ids`: si esta
+   * en true el cliente no lleva asignaciones, y la base las borra igual al
+   * marcarlo. Solo admin lo edita.
+   */
+  reservado_admin: boolean;
 }
 
 /** Datos para guardar cliente */
@@ -188,7 +194,8 @@ const ModalCliente = memo(function ModalCliente({ cliente, onSave, onClose, guar
       porcentaje: Number(d.descuento_porcentaje) || 0,
     })),
     preventista_id: cliente.preventista_id || '',
-    preventista_ids: cliente.preventista_ids || []
+    preventista_ids: cliente.preventista_ids || [],
+    reservado_admin: cliente.reservado_admin ?? false
   } : {
     tipo_documento: 'CUIT',
     numero_documento: '',
@@ -215,7 +222,8 @@ const ModalCliente = memo(function ModalCliente({ cliente, onSave, onClose, guar
     tipoFacturaDefault: 'ZZ',
     descuentosPorCategoria: [],
     preventista_id: '',
-    preventista_ids: []
+    preventista_ids: [],
+    reservado_admin: false
   });
 
   // State para captura de GPS del navegador (botón "Usar mi ubicación actual").
@@ -280,6 +288,16 @@ const ModalCliente = memo(function ModalCliente({ cliente, onSave, onClose, guar
           : [...prev.preventista_ids, id]
       };
     });
+  };
+  /**
+   * Los tres estados son excluyentes: al reservar el cliente a administracion
+   * se vacian las asignaciones. Si no, el form manda las dos cosas y el trigger
+   * de la base rechaza el INSERT en cliente_preventistas.
+   */
+  const toggleReservadoAdmin = (): void => {
+    setForm(prev => prev.reservado_admin
+      ? { ...prev, reservado_admin: false }
+      : { ...prev, reservado_admin: true, preventista_ids: [] });
   };
   const preventistasVisibles = preventistas.filter(p =>
     (p.nombre || '').toLowerCase().includes(preventistasFiltro.trim().toLowerCase())
@@ -732,8 +750,36 @@ const ModalCliente = memo(function ModalCliente({ cliente, onSave, onClose, guar
           </div>
         </div>
 
+        {/* Solo administradores (mig 214). Tercer estado, excluyente con la
+            asignacion N-a-N: por eso cuando esta tildado el selector de
+            preventistas de abajo no se muestra. */}
+        {isAdmin && (
+          <div>
+            <label className="flex items-start gap-2 cursor-pointer">
+              <input
+                type="checkbox"
+                checked={form.reservado_admin}
+                onChange={toggleReservadoAdmin}
+                className="rounded mt-1"
+              />
+              <span>
+                <span className="flex items-center gap-1 text-sm font-medium dark:text-gray-200">
+                  <Lock className="w-4 h-4" />
+                  Solo administradores
+                </span>
+                <span className="block text-xs text-gray-500 dark:text-gray-400">
+                  Ningún preventista lo va a ver ni le va a poder cargar pedidos. Lo
+                  siguen viendo administración, el encargado y el transportista que se
+                  lo entrega. El preventista que ya le vendió sigue viendo sus pedidos
+                  anteriores.
+                </span>
+              </span>
+            </label>
+          </div>
+        )}
+
         {/* Preventistas asignados (N-a-N) */}
-        {isAdmin && preventistas.length > 0 && (
+        {isAdmin && !form.reservado_admin && preventistas.length > 0 && (
           <div>
             <label className="block text-sm font-medium mb-1 dark:text-gray-200 flex items-center gap-1">
               <Users className="w-4 h-4" />

--- a/src/hooks/queries/useClientesQuery.reservadoAdmin.test.tsx
+++ b/src/hooks/queries/useClientesQuery.reservadoAdmin.test.tsx
@@ -1,0 +1,150 @@
+/**
+ * Tests de "Solo administradores" (`reservado_admin`, mig 214) en la capa de
+ * escritura.
+ *
+ * QUÉ NO PUEDEN PROBAR ESTOS TESTS
+ * --------------------------------
+ * La restricción de verdad es RLS, y la RLS no la ve `tsc`, ni eslint, ni
+ * vitest: el `select` de PostgREST es un string y la policy vive en la base. La
+ * visibilidad por rol se verificó contra producción, con un usuario de cada rol
+ * (ver el cuerpo de la migración).
+ *
+ * QUÉ SÍ FIJAN
+ * ------------
+ * Lo que la app puede romper sola y en silencio:
+ *
+ * 1. El `insert` de `createCliente` es una **lista explícita** de columnas, no
+ *    un spread. Una columna que no esté nombrada ahí se pierde sin error: el
+ *    cliente se crea igual, pero sin la marca, y queda visible para todos los
+ *    preventistas. Es exactamente lo contrario de lo que pidió el admin.
+ *
+ * 2. Los tres estados son excluyentes (sin asignar / asignado a X / reservado).
+ *    Si el front manda `reservado_admin: true` junto con asignaciones, el
+ *    trigger `trg_cliente_preventistas_no_reservado` rechaza el INSERT y el
+ *    guardado falla entero.
+ */
+import React from 'react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+
+const insertSpy = vi.fn()
+const deleteSpy = vi.fn()
+const updateSpy = vi.fn()
+const from = vi.fn()
+
+vi.mock('../supabase/base', () => ({
+  supabase: {
+    from: (...args: unknown[]) => from(...args),
+    rpc: vi.fn(),
+  },
+}))
+
+vi.mock('../../contexts/SucursalContext', () => ({
+  useSucursal: () => ({ currentSucursalId: 1 }),
+}))
+
+import { useCrearClienteMutation, useActualizarClienteMutation } from './useClientesQuery'
+
+const CLIENTE_CREADO = { id: '77', nombre_fantasia: 'Reservado SA', reservado_admin: true }
+
+/**
+ * `from(tabla)` devuelve un builder encadenable distinto según la tabla: el de
+ * `clientes` termina en `.single()`, el de `cliente_preventistas` resuelve en
+ * `.eq()` (delete) o en `.insert()`.
+ */
+function montarSupabase(): void {
+  from.mockImplementation((tabla: string) => {
+    if (tabla === 'clientes') {
+      const builder: Record<string, unknown> = {}
+      builder.insert = (filas: unknown) => {
+        insertSpy(filas)
+        return builder
+      }
+      builder.update = (payload: unknown) => {
+        updateSpy(payload)
+        return builder
+      }
+      builder.select = () => builder
+      builder.eq = () => builder
+      builder.gte = () => builder
+      builder.lte = () => builder
+      builder.limit = () => Promise.resolve({ data: [], error: null })
+      builder.single = () => Promise.resolve({ data: CLIENTE_CREADO, error: null })
+      return builder
+    }
+    // cliente_preventistas / cliente_descuentos_categoria
+    const builder: Record<string, unknown> = {}
+    builder.delete = () => builder
+    builder.eq = (col: string, val: unknown) => {
+      deleteSpy(col, val)
+      return Promise.resolve({ error: null })
+    }
+    builder.insert = (filas: unknown) => {
+      insertSpy(filas)
+      return Promise.resolve({ error: null })
+    }
+    return builder
+  })
+}
+
+function wrapper({ children }: { children: React.ReactNode }): React.ReactElement {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false }, mutations: { retry: false } } })
+  return <QueryClientProvider client={qc}>{children}</QueryClientProvider>
+}
+
+describe('reservado_admin en la capa de escritura', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    montarSupabase()
+  })
+
+  it('createCliente manda reservado_admin en el insert (la lista de columnas es explícita)', async () => {
+    const { result } = renderHook(() => useCrearClienteMutation(), { wrapper })
+
+    await result.current.mutateAsync({
+      razon_social: 'Reservado SA',
+      nombre_fantasia: 'Reservado SA',
+      direccion: 'San Martín 100',
+      reservado_admin: true,
+      preventista_ids: [],
+    })
+
+    await waitFor(() => expect(insertSpy).toHaveBeenCalled())
+    const fila = (insertSpy.mock.calls[0][0] as Array<Record<string, unknown>>)[0]
+    expect(fila.reservado_admin).toBe(true)
+  })
+
+  it('sin la marca, el insert manda false y no null/undefined (la columna es NOT NULL)', async () => {
+    const { result } = renderHook(() => useCrearClienteMutation(), { wrapper })
+
+    await result.current.mutateAsync({
+      razon_social: 'Comun SA',
+      nombre_fantasia: 'Comun SA',
+      direccion: 'Belgrano 200',
+    })
+
+    await waitFor(() => expect(insertSpy).toHaveBeenCalled())
+    const fila = (insertSpy.mock.calls[0][0] as Array<Record<string, unknown>>)[0]
+    expect(fila.reservado_admin).toBe(false)
+  })
+
+  it('updateCliente propaga la marca en el patch', async () => {
+    const { result } = renderHook(() => useActualizarClienteMutation(), { wrapper })
+
+    await result.current.mutateAsync({ id: '77', data: { reservado_admin: true, preventista_ids: [] } })
+
+    await waitFor(() => expect(updateSpy).toHaveBeenCalled())
+    expect(updateSpy.mock.calls[0][0]).toMatchObject({ reservado_admin: true })
+  })
+
+  it('un cliente reservado se guarda SIN asignaciones: borra las que había y no inserta ninguna', async () => {
+    const { result } = renderHook(() => useActualizarClienteMutation(), { wrapper })
+
+    await result.current.mutateAsync({ id: '77', data: { reservado_admin: true, preventista_ids: [] } })
+
+    await waitFor(() => expect(deleteSpy).toHaveBeenCalledWith('cliente_id', '77'))
+    // El único insert posible sería el de cliente_preventistas: no tiene que existir.
+    expect(insertSpy).not.toHaveBeenCalled()
+  })
+})

--- a/src/hooks/queries/useClientesQuery.ts
+++ b/src/hooks/queries/useClientesQuery.ts
@@ -201,6 +201,11 @@ interface ClienteCreateInput {
   notas?: string
   preventista_id?: string | null
   preventista_ids?: string[]
+  /**
+   * "Solo administradores" (mig 214): tercer estado de asignacion, excluyente
+   * con `preventista_ids`. Solo admin lo escribe.
+   */
+  reservado_admin?: boolean
   descuentos_categoria?: { categoria: string; descuento_porcentaje: number }[]
   /** FC/ZZ por defecto al crear pedidos de este cliente (mig 116) */
   tipo_factura_default?: 'ZZ' | 'FC'
@@ -276,6 +281,10 @@ async function createCliente(cliente: ClienteCreateInput, sucursalId: number | n
       notas: clienteFields.notas || null,
       tipo_factura_default: clienteFields.tipo_factura_default ?? 'ZZ',
       place_id: clienteFields.place_id || null,
+      // "Solo administradores" (mig 214). Esta lista es explicita, asi que sin
+      // esta linea la marca se perderia en silencio al crear. La RLS de INSERT
+      // solo la acepta en true si el que crea es admin.
+      reservado_admin: clienteFields.reservado_admin ?? false,
       sucursal_id: sucursalId,
       ...(clienteFields.preventista_id ? { preventista_id: clienteFields.preventista_id } : {})
     }])

--- a/src/types/hooks.ts
+++ b/src/types/hooks.ts
@@ -66,8 +66,16 @@ export interface ClienteDB {
    * IDs de preventistas asignados (N-a-N via tabla cliente_preventistas).
    * Si el array está vacío o ausente, cualquier preventista lo puede ver.
    * Si contiene uno o más IDs, solo esos preventistas (y admin) lo ven.
+   * Excluyente con `reservado_admin`: si el cliente está reservado, esto va vacío.
    */
   preventista_ids?: string[];
+  /**
+   * Tercer estado de asignación (mig 214): el cliente lo atiende administración.
+   * Lo ven admin, encargado, transportista y depósito, y el preventista que ya
+   * le vendió (su historial no se rompe). Ningún otro preventista lo ve ni lo
+   * puede tomar. Solo admin lo pone y lo saca.
+   */
+  reservado_admin?: boolean;
   activo?: boolean;
   created_at?: string;
   updated_at?: string;

--- a/supabase/functions/_shared/tools/common/ficha_cliente.ts
+++ b/supabase/functions/_shared/tools/common/ficha_cliente.ts
@@ -60,6 +60,8 @@ interface ClienteLookupRow {
   direccion: string | null;
   telefono: string | null;
   zona: string | null;
+  /** Reservado a administración (mig 214): ningún preventista lo toma. */
+  reservado_admin: boolean;
 }
 
 /**
@@ -121,7 +123,7 @@ export const fichaClienteTool: Tool<FichaClienteParams, FichaClienteResult> = {
     // para que la regla "asignado a mí O huérfano" sea expresable sin truco
     // de inner join).
     let clienteQuery = sb.from("clientes")
-      .select("id, codigo, nombre_fantasia, razon_social, direccion, telefono, zona, sucursal_id")
+      .select("id, codigo, nombre_fantasia, razon_social, direccion, telefono, zona, sucursal_id, reservado_admin")
       .eq("id", cliente_id)
       .eq("activo", true);
     if (ctx.sucursal_id != null) {
@@ -157,6 +159,26 @@ export const fichaClienteTool: Tool<FichaClienteParams, FichaClienteResult> = {
         throw new Error("Cliente asignado a otro preventista");
       }
       // Si no tiene asignaciones (huérfano) o me incluye → seguimos.
+
+      // Reservado a administración (mig 214). El cliente reservado NO tiene
+      // asignaciones, así que llega hasta acá por la rama de huérfano — que es
+      // justo la que significa "lo ve cualquier preventista". Hay que repetir
+      // el filtro a mano porque el bot corre con service_role y la RLS no lo
+      // frena. Excepción: si ya le vendió, sigue viendo la ficha, si no sus
+      // pedidos viejos quedarían sin cliente.
+      if (cliente.reservado_admin) {
+        const { count, error: hErr } = await sb
+          .from("pedidos")
+          .select("id", { count: "exact", head: true })
+          .eq("cliente_id", cliente_id)
+          .eq("usuario_id", ctx.perfil_id);
+        if (hErr) {
+          throw new Error(`ficha_cliente: historial lookup: ${hErr.message}`);
+        }
+        if ((count ?? 0) === 0) {
+          throw new Error("Cliente reservado a administración");
+        }
+      }
     }
 
     const { data: resumen, error: rErr } = await sb.rpc(

--- a/supabase/functions/_shared/tools/preventista/previsualizar_pedido.ts
+++ b/supabase/functions/_shared/tools/preventista/previsualizar_pedido.ts
@@ -102,6 +102,8 @@ interface ClienteRow {
   limite_credito: number | string;
   activo: boolean;
   sucursal_id: number;
+  /** Reservado a administración (mig 214): ningún preventista le carga pedidos. */
+  reservado_admin: boolean;
 }
 
 export const previsualizarPedidoTool: Tool<
@@ -180,9 +182,18 @@ export const previsualizarPedidoTool: Tool<
     }
     // Scoping preventista: el cliente debe estar asignado a él O ser huérfano
     if (ctx.rol === "preventista") {
-      const allowed = await isClienteAccesibleParaPreventista(sb, cliente_id, ctx.perfil_id);
+      const allowed = await isClienteAccesibleParaPreventista(
+        sb,
+        cliente_id,
+        ctx.perfil_id,
+        cliente.reservado_admin === true,
+      );
       if (!allowed) {
-        throw new Error("Cliente asignado a otro preventista");
+        throw new Error(
+          cliente.reservado_admin === true
+            ? "Cliente reservado a administración"
+            : "Cliente asignado a otro preventista",
+        );
       }
     }
 
@@ -441,7 +452,7 @@ async function loadCliente(
 ): Promise<ClienteRow | null> {
   const { data, error } = await sb
     .from("clientes")
-    .select("id, codigo, nombre_fantasia, razon_social, saldo_cuenta, limite_credito, activo, sucursal_id")
+    .select("id, codigo, nombre_fantasia, razon_social, saldo_cuenta, limite_credito, activo, sucursal_id, reservado_admin")
     .eq("id", clienteId)
     .eq("sucursal_id", sucursalId)
     .eq("activo", true)
@@ -456,7 +467,15 @@ async function isClienteAccesibleParaPreventista(
   sb: SupabaseClient,
   clienteId: number,
   perfilId: string,
+  reservadoAdmin: boolean,
 ): Promise<boolean> {
+  // Reservado a administración (mig 214): no hay excepción de historial acá.
+  // Ver el pasado es una cosa; cargarle un pedido nuevo es justo lo que la
+  // marca cierra. El trigger trg_pedidos_cliente_reservado lo rechaza igual en
+  // la base, pero el bot corre con service_role y conviene fallar antes, con un
+  // mensaje entendible en vez de un error de Postgres.
+  if (reservadoAdmin) return false;
+
   const { data, error } = await sb
     .from("cliente_preventistas")
     .select("preventista_id")


### PR DESCRIPTION
Agrega la opción **"Solo administradores"** al asignar un cliente: un cliente marcado así no lo ven los preventistas.

## El modelo

Tercer estado de asignación, **excluyente** con los otros dos: `sin asignar` / `asignado a X` / `reservado_admin` (mig 214, ya aplicada — el ledger de prod está en `214_un_cliente_reservado_a_administracion`).

No se pudo modelar como *ausencia* de asignación: **"sin preventista asignado" ya significa "visible para TODOS los preventistas"** (mig 028), o sea exactamente lo contrario. Ni dentro de `cliente_preventistas`: `cp_insert` (mig 002) deja auto-asignarse a cualquiera, así que un preventista se agregaba solo con un INSERT y burlaba la restricción. Por eso es una columna con guard propio.

El predicado nuevo cuelga de la rama de preventista y **solo resta**:

```
(huérfano OR asignado_a_mí) AND (NOT reservado OR tengo_pedidos_propios)
```

Para un cliente no reservado `NOT reservado_admin` es true, así que el comportamiento de hoy queda idéntico.

## Qué NO es

No es "invisible para todos menos admin". Eso rompía dos cosas graves:

- **Admin, encargado, transportista y depósito lo siguen viendo entero**, con nombre y dirección. El transportista tiene que entregarle y cobrarle.
- **El preventista que ya le vendió sigue viendo la ficha y sus pedidos completos.** Sin esa excepción el embed `cliente:clientes(*)` devuelve NULL y —peor— los `!inner` de `usePedidosQuery` y `usePedidoStatsQuery` le hacen **desaparecer** los pedidos viejos de la lista y del count, en silencio.

Lo que se cierra es que un preventista lo tome como cliente nuevo o lo vea en sus listados operativos.

## Superficie tocada

| Dónde | Por qué |
|---|---|
| `mt_clientes_select` | la visibilidad |
| `mt_clientes_update` (USING + WITH CHECK) | es **independiente** de la de select: usa `es_preventista()`, así que sin esto un preventista que no ve la fila igual le hacía UPDATE por id vía PostgREST |
| `mt_clientes_insert` | si no, crea el cliente ya marcado y después se auto-asigna |
| 4 triggers | quién pone la marca, exclusividad en las dos direcciones, y el guard de pedidos |
| `bot_buscar_cliente`, `bot_historico_pedidos_cliente`, `bot_productos_recurrentes_cliente`, `registrar_visita_cliente` | **el bot bypassea la RLS** (`service_role`): cada filtro se repite a mano. Misma familia que la mig 203 |
| `ficha_cliente.ts`, `previsualizar_pedido.ts` | ya replicaban la regla de asignación a mano |

`bot_mis_clientes` y `bot_sugerir_visitas_rfm` **no** hacen falta: hacen INNER JOIN contra `cliente_preventistas`, así que un cliente sin asignaciones nunca aparece.

## Decisiones que conviene revisar

- **Solo admin pone y saca la marca.** El encargado la *ve* pero no la administra, igual que no edita asignaciones ni descuentos por categoría. El allow-list de la mig 080 ya la protege de los preventistas (es fail-closed) pero sale por `RETURN NEW` para el encargado, así que lleva guard propio.
- **UPDATE más estricto que SELECT:** el preventista con historial lee la ficha pero no la edita.
- Las funciones de trigger van **`SECURITY DEFINER`**: como invoker, el `SELECT` sobre `clientes` y `perfiles` pasa por la RLS que justamente les tapa la fila, los `EXISTS` darían false y el guard dejaría pasar todo — fail-open.
- El guard de pedidos va **como trigger sobre `pedidos`**, no adentro del RPC: cubre `crear_pedido_completo` y `crear_pedido_completo_bot` de una y no toca el cuerpo vivo de ninguno (la mig 205 le inyecta código al primero con `_mig205_insertar_tras_ancla`).
- `clientes.preventista_id` (legacy) queda en NULL para un reservado. Verificado que ninguna lectura de `src/` lo usa para decidir visibilidad, así que nadie lo interpreta como "huérfano visible para todos".

## Verificación

La RLS no la ve `tsc`, ni eslint, ni vitest. Se verificó **contra producción**, con un usuario de cada rol, usando `SET ROLE authenticated` + claims del JWT (que es lo que hace PostgREST), todo dentro de transacciones **revertidas**.

| | admin | encargado | transportista | prev. sin historial | prev. con historial |
|---|---|---|---|---|---|
| ve al reservado | ✅ | ✅ | ✅ c/ dirección | ❌ | ✅ 18 pedidos |

El caso "preventista sin historial" se probó sobre un **huérfano** —que hoy ve cualquier preventista— y pasó de `1` a `0`. Es la asimetría que importaba: reservar borra las asignaciones y lo vuelve huérfano.

Guards de escritura, los ocho: UPDATE por id → 0 filas · auto-asignarse → bloqueado · pedido de preventista → bloqueado · pedido de admin → pasa · **encargado sacando la marca → bloqueado** · admin → pasa.

**Rendimiento:** el `EXISTS` de historial sale `never executed` en el plan — Postgres corta el `OR`, así que no cuesta nada hasta que alguien marque un cliente. Lista completa del preventista: 0.69 ms. El índice `idx_pedidos_cliente_usuario` sí se usa (Index Only Scan) en el camino del bot, que no pasa por RLS.

**No toca ninguna fila:** la columna nace en `false` y todo el predicado nuevo es una tautología mientras nadie esté marcado.

## Gates

`typecheck` · `lint` · `test:run` (1629) · `build` · y desde `supabase/functions/`: `deno task check` · `lint` · `test` (203). Ninguna función de `public` quedó alcanzable con la anon key.

## Fuera de alcance (issues)

- #543 — el detector de duplicados corre bajo RLS y **ya está ciego hoy** a los clientes de otro preventista: verificado que Osvaldo obtiene `0` para un cliente que existe en esas coordenadas exactas. Cuando se escribió había 401 huérfanos vs 26 asignados; hoy son 597 asignados vs 122 huérfanos, o sea que la superficie creció sola ~20x. Preexistente, no lo introduce este PR.
- #544 — `crear_pedido_completo` no valida la regla de asignación general. Este PR cierra la mitad de `reservado_admin`; el caso "cliente asignado a otro preventista" cambia la regla para todos y es decisión de negocio aparte.

🤖 Generated with [Claude Code](https://claude.com/claude-code)