### PR TITLE
La deuda previa la calcula la base, no el saldo de hoy (mig 215)

### DIFF
--- a/migrations/215_la_deuda_previa_es_la_de_antes_del_pedido.sql
+++ b/migrations/215_la_deuda_previa_es_la_de_antes_del_pedido.sql
@@ -1,0 +1,152 @@
+-- La deuda previa de un pedido es la de ANTES del pedido, no el saldo de hoy
+--
+-- El aviso de deuda en la tarjeta del pedido (PR #530) derivaba el numero de
+-- `clientes.saldo_cuenta` restandole la parte impaga de ESE pedido, para
+-- quedarse con "lo anterior". El calculo estaba bien y la premisa mal:
+-- `saldo_cuenta` es un escalar del PRESENTE, asi que lo que quedaba incluia
+-- tambien los pedidos POSTERIORES. Cada pedido nuevo inflaba el aviso de todas
+-- las tarjetas viejas del mismo cliente. Medido antes de esta migracion: de
+-- 1.083 tarjetas que mostraban el aviso, 1.009 eran falsas -- el 93% -- con
+-- hasta $1.834.150 de sobreestimacion en una sola tarjeta.
+--
+-- La deuda que habia AL MOMENTO de un pedido no se puede derivar de un escalar:
+-- hay que sumar lo impago de los pedidos ANTERIORES de ese cliente y restarle
+-- los pagos a cuenta anteriores. Es la misma formula canonica del saldo (la que
+-- usa la mig 199), pero cortada en el instante del pedido.
+--
+-- POR QUE ES UNA COMPUTED COLUMN Y NO UN RPC
+-- Viaja dentro del `select` de pedidos que el front ya hace: cero queries
+-- nuevas, y no es un embed, asi que no puede volverse ambiguo (PGRST201).
+--
+-- POR QUE ES SECURITY DEFINER
+-- La RLS de `pedidos` (`mt_pedidos_select`) le muestra al preventista solo SUS
+-- pedidos: medido con su propio JWT, 1.330 de 5.612. Una funcion invoker
+-- sumaria unicamente esos, e ignoraria los que le cargo al mismo cliente otro
+-- preventista, o un admin, o un encargado.
+--
+-- Con los datos de hoy la diferencia no se ve: los dos unicos pedidos cuya
+-- deuda previa viene de otro vendedor son de un admin, para quien la RLS no
+-- aplica. Pero hay una contradiccion que si es actual: el aviso del ALTA sale
+-- de `clientes.saldo_cuenta`, que no pasa por RLS y suma todo. Con una funcion
+-- invoker, el mismo cliente mostraria una deuda en el alta y otra --menor-- en
+-- la tarjeta, sin que nada lo explique.
+--
+-- No agrega exposicion: ese total ya lo ve cualquiera de ellos en
+-- `clientes.saldo_cuenta`, que incluye lo mismo y mas.
+--
+-- LA GUARDA QUE NO ES OBVIA
+-- Una computed column tambien es invocable como RPC, y ahi el caller elige el
+-- contenido de la fila. Si la funcion confiara en el `cliente_id`/`sucursal_id`
+-- que le pasan, un authenticated podria pedir la deuda de cualquier cliente de
+-- CUALQUIER sucursal inventandose una fila -- rompiendo el aislamiento por
+-- sucursal, que no depende de la buena fe del caller en ningun otro lado.
+-- Por eso NO se usa nada de `p` salvo `p.id`: el cliente, la fecha y la
+-- sucursal se releen de la tabla, y filtrados por `current_sucursal_id()`. Una
+-- fila inventada no matchea y devuelve 0.
+--
+-- Revertir: `DROP FUNCTION public.deuda_previa(public.pedidos);`. El front deja
+-- de mostrar el aviso en la tarjeta; nada mas depende de ella.
+-- =========================================================================
+
+BEGIN;
+
+CREATE OR REPLACE FUNCTION public.deuda_previa(p public.pedidos)
+RETURNS numeric
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $$
+  WITH ref AS (
+    -- Solo `p.id` viene del caller; el resto se relee. Ver LA GUARDA arriba.
+    SELECT pe.cliente_id, pe.created_at, pe.id, pe.sucursal_id
+    FROM pedidos pe
+    WHERE pe.id = p.id
+      AND pe.sucursal_id = current_sucursal_id()
+  )
+  SELECT GREATEST(0, ROUND(
+      COALESCE((
+        SELECT SUM(GREATEST(0, p2.total - COALESCE(p2.monto_pagado, 0)))
+        FROM pedidos p2, ref
+        WHERE p2.cliente_id  = ref.cliente_id
+          AND p2.sucursal_id = ref.sucursal_id
+          -- Un pedido cancelado tiene total 0 (mig 175) y no deberia sumar
+          -- igual; se excluye explicito para no depender de eso.
+          AND p2.estado NOT IN ('cancelado', 'anulado')
+          -- Desempate por id: dos pedidos pueden compartir `created_at`.
+          AND (p2.created_at, p2.id) < (ref.created_at, ref.id)
+      ), 0)
+    - COALESCE((
+        SELECT SUM(pg.monto)
+        FROM pagos pg, ref
+        WHERE pg.cliente_id  = ref.cliente_id
+          AND pg.sucursal_id = ref.sucursal_id
+          -- pedido_id IS NULL = pago a cuenta. Los pagos contra un pedido ya
+          -- estan en su `monto_pagado`; contarlos aca los restaria dos veces.
+          AND pg.pedido_id IS NULL
+          AND pg.created_at < ref.created_at
+      ), 0)
+  , 2));
+$$;
+
+COMMENT ON FUNCTION public.deuda_previa(public.pedidos) IS
+  'Deuda del cliente inmediatamente ANTES de este pedido (computed column de PostgREST). '
+  'No es el saldo de hoy: excluye este pedido y todos los posteriores.';
+
+-- Supabase le da EXECUTE a PUBLIC (implicito) y a anon (explicito) a toda
+-- funcion nueva; revocar una sola mitad no cierra nada. `authenticated` si lo
+-- necesita: PostgREST evalua la computed column como el usuario logueado.
+REVOKE ALL ON FUNCTION public.deuda_previa(public.pedidos) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.deuda_previa(public.pedidos) TO authenticated;
+
+DO $verif$
+DECLARE
+  v_abiertas text;
+  v_definer  boolean;
+  v_malos    int;
+BEGIN
+  -- 1. Ni PUBLIC (entrada sin grantee, arranca con '=') ni anon.
+  SELECT array_to_string(array_agg(a::text), ' ') INTO v_abiertas
+  FROM pg_proc p, unnest(p.proacl) a
+  WHERE p.pronamespace = 'public'::regnamespace
+    AND p.proname = 'deuda_previa'
+    AND (a::text LIKE '=%' OR a::text LIKE 'anon=%');
+  IF v_abiertas IS NOT NULL THEN
+    RAISE EXCEPTION 'mig 215: el ACL quedo abierto (%).', v_abiertas;
+  END IF;
+
+  -- 2. Sin DEFINER la RLS la vaciaria para el preventista, en silencio.
+  SELECT p.prosecdef INTO v_definer
+  FROM pg_proc p
+  WHERE p.pronamespace = 'public'::regnamespace AND p.proname = 'deuda_previa';
+  IF NOT COALESCE(v_definer, false) THEN
+    RAISE EXCEPTION 'mig 215: la funcion no quedo SECURITY DEFINER.';
+  END IF;
+
+  -- 3. Invariante: el PRIMER pedido de cada cliente no puede tener deuda
+  --    previa por pedidos (no hay ninguno antes). Es la prueba de que corta
+  --    en el instante correcto y no arrastra los posteriores, que es el bug
+  --    que esta migracion existe para cerrar. Se mira contra la suma cruda,
+  --    sin los pagos a cuenta, que si pueden ser anteriores a todo.
+  SELECT count(*) INTO v_malos
+  FROM (
+    SELECT DISTINCT ON (pe.cliente_id) pe.id, pe.cliente_id, pe.created_at, pe.sucursal_id
+    FROM pedidos pe
+    WHERE pe.estado NOT IN ('cancelado', 'anulado')
+    ORDER BY pe.cliente_id, pe.created_at, pe.id
+  ) primeros
+  WHERE COALESCE((
+          SELECT SUM(GREATEST(0, p2.total - COALESCE(p2.monto_pagado, 0)))
+          FROM pedidos p2
+          WHERE p2.cliente_id  = primeros.cliente_id
+            AND p2.sucursal_id = primeros.sucursal_id
+            AND p2.estado NOT IN ('cancelado', 'anulado')
+            AND (p2.created_at, p2.id) < (primeros.created_at, primeros.id)
+        ), 0) <> 0;
+  IF v_malos > 0 THEN
+    RAISE EXCEPTION 'mig 215: % primeros pedidos tendrian deuda previa; el corte temporal esta mal.', v_malos;
+  END IF;
+END
+$verif$;
+
+COMMIT;

--- a/src/components/containers/PedidosContainer.tsx
+++ b/src/components/containers/PedidosContainer.tsx
@@ -196,7 +196,14 @@ export default function PedidosContainer(): React.ReactElement {
   // Queries - use debounced search to avoid firing on every keystroke
   const { registrarPago, registrarPagosBatch, fetchPagosPedido, eliminarPago, actualizarFormaPagoDePago } = usePagos()
 
-  const { data: paginatedResult, isLoading: loadingPedidos } = usePedidosPaginatedQuery(
+  // dataUpdatedAt: cuándo se trajo esta página del servidor. Sólo se usa para
+  // fechar la deuda previa cuando no hay señal — el número que se ve entonces es
+  // el del último sync y no incluye lo cobrado después.
+  const {
+    data: paginatedResult,
+    isLoading: loadingPedidos,
+    dataUpdatedAt: pedidosActualizadosAt,
+  } = usePedidosPaginatedQuery(
     paginaActual, ITEMS_PER_PAGE, filtros, debouncedBusqueda, authReady
   )
   const { data: statsSummary = EMPTY_PEDIDO_STATS_SUMMARY } = usePedidoStatsQuery(
@@ -1904,6 +1911,7 @@ export default function PedidosContainer(): React.ReactElement {
       <Suspense fallback={<LoadingState />}>
         <VistaPedidos
           pedidos={pedidos}
+          saldoActualizadoAt={pedidosActualizadosAt}
           totalCount={totalCount}
           statsSummary={statsSummary}
           paginaActual={paginaActual}

--- a/src/components/pedidos/PedidoCard.tsx
+++ b/src/components/pedidos/PedidoCard.tsx
@@ -20,6 +20,8 @@ import AccionesDropdown from './PedidoActions';
 import { useCambiarTipoFacturaMutation } from '../../hooks/queries/usePedidosQuery';
 import { useAuthData } from '../../contexts/AuthDataContext';
 import { haversineMeters, formatDistancia, clasificarDistancia, SEMAFORO_COLORS } from '../../utils/geo';
+import { avisoDeudaCliente } from '../../utils/deudaCliente';
+import { puedeVerDeudaCliente } from '../../lib/permisos';
 import { formatCantidadItem, equivalenteEnUnidades } from '../../utils/unidadesRegalo';
 import type { PedidoDB, MotivoSalvedad } from '../../types';
 
@@ -53,6 +55,12 @@ export interface PedidoCardProps {
   onDesmarcarEntregado?: (pedido: PedidoDB) => void;
   onCancelarPedido?: (pedido: PedidoDB) => void;
   onRegistrarPago?: (pedido: PedidoDB) => void;
+  /**
+   * Timestamp del fetch que trajo estos pedidos (`dataUpdatedAt`). Solo se usa
+   * sin conexion, para fechar la deuda en el aviso: el numero es el del ultimo
+   * sync y no incluye lo cobrado despues.
+   */
+  saldoActualizadoAt?: number | null;
 }
 
 interface EstadoConfig {
@@ -282,11 +290,27 @@ function PedidoCard({
   onDesmarcarEntregado,
   onCancelarPedido,
   onRegistrarPago,
+  saldoActualizadoAt,
 }: PedidoCardProps): React.ReactElement {
   const [expandido, setExpandido] = useState<boolean>(false);
   const tieneSalvedad = pedido.salvedades && pedido.salvedades.length > 0;
 
-  const { user } = useAuthData();
+  const { user, perfil, isOnline } = useAuthData();
+
+  // Deuda que el cliente ya tenia ANTES de este pedido. Viene calculada de la
+  // base (`deuda_previa`, mig 215) y NO se deriva de `cliente.saldo_cuenta`:
+  // ese es el saldo de HOY, e incluye este pedido y los posteriores. Derivarlo
+  // fue el bug del PR #530 --cada pedido nuevo inflaba el aviso de las tarjetas
+  // viejas del mismo cliente-- y por eso el numero se calcula donde estan los
+  // pedidos anteriores, no aca.
+  // El gate por rol se evalua contra `perfil.rol` (rol primario) y no contra las
+  // props isAdmin/isPreventista: VirtualizedPedidoList no pasa `isEncargado`, y
+  // el badge tiene que decidirse igual desde las dos listas que montan la card.
+  const avisoDeuda = puedeVerDeudaCliente(perfil?.rol)
+    ? avisoDeudaCliente(pedido.deuda_previa, {
+        saldoAl: !isOnline && saldoActualizadoAt ? formatFecha(new Date(saldoActualizadoAt)) : null,
+      })
+    : null;
 
   // Los handlers llegan por props. Hubo un intento de pasarlos por contexto
   // (HandlersContext) que nunca se termino: el provider no se montaba nunca, asi
@@ -357,6 +381,21 @@ function PedidoCard({
               {/* Mobile: deja que la dirección wrappee a 2 líneas (line-clamp-2)
                   para que el operador la vea entera. Desktop: trunca a 1 línea. */}
               <span className="line-clamp-2 sm:line-clamp-none sm:truncate">{pedido.cliente.direccion}</span>
+            </p>
+          )}
+          {/* Deuda que el cliente traia de antes de este pedido. Va aca --bajo
+              el nombre-- y no entre los badges de la derecha porque habla del
+              CLIENTE, no del pedido; ahi se leeria como un estado de pago de
+              este pedido. Es informativo: no bloquea nada. */}
+          {avisoDeuda && (
+            <p className="mt-1.5">
+              <span
+                className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-[13px] font-semibold bg-rose-50 text-rose-700 border border-rose-200/70 dark:bg-rose-900/25 dark:text-rose-300 dark:border-rose-800/40"
+                title={avisoDeuda.detalle}
+              >
+                <AlertTriangle className="w-3.5 h-3.5 flex-shrink-0" aria-hidden="true" />
+                <span className="tabular-nums">{avisoDeuda.etiqueta}</span>
+              </span>
             </p>
           )}
         </div>

--- a/src/components/pedidos/__tests__/PedidoCard.deuda.test.tsx
+++ b/src/components/pedidos/__tests__/PedidoCard.deuda.test.tsx
@@ -1,0 +1,137 @@
+/**
+ * Aviso de deuda previa en la tarjeta del pedido.
+ *
+ * EL TEST QUE IMPORTA ES "no deriva la deuda de saldo_cuenta".
+ * La primera version de este aviso (PR #530) la derivaba: tomaba el saldo del
+ * cliente y le restaba la parte impaga de ESE pedido. `saldo_cuenta` es del
+ * presente, asi que lo que quedaba incluia los pedidos POSTERIORES y cada
+ * pedido nuevo inflaba el aviso de todas las tarjetas viejas del mismo cliente
+ * -- 1.009 de 1.083 avisos eran falsos en produccion. Ahora el numero lo
+ * calcula la base (`deuda_previa`, mig 215) y la card solo lo muestra. Si
+ * alguien vuelve a mirar `saldo_cuenta` aca, ese test se pone rojo.
+ */
+import '@testing-library/jest-dom/vitest'
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import type { ReactElement, ReactNode } from 'react'
+
+// Mock de supabase antes de importar el componente: la cadena de imports pide
+// supabaseUrl al cargarse (mismo patrón que VincularTelegramButton.test.tsx).
+vi.mock('../../../lib/supabase', () => ({
+  supabase: {
+    rpc: vi.fn(),
+    from: vi.fn(),
+    auth: {
+      getUser: vi.fn(() => Promise.resolve({ data: { user: null } })),
+      getSession: vi.fn(() => Promise.resolve({ data: { session: null } })),
+      onAuthStateChange: vi.fn(() => ({ data: { subscription: { unsubscribe: vi.fn() } } })),
+    },
+  },
+  setSucursalHeader: vi.fn(),
+  getSucursalHeader: vi.fn(),
+}))
+
+vi.mock('../../../contexts/SucursalContext', () => ({
+  useSucursal: () => ({ currentSucursalId: 1, currentSucursalNombre: 'Test' }),
+}))
+
+import PedidoCard from '../PedidoCard'
+import { AuthDataProvider, type AuthDataContextValue } from '../../../contexts/AuthDataContext'
+import type { PedidoDB, RolUsuario } from '../../../types'
+
+function hacerPedido(
+  campos: { deuda_previa?: number; saldo_cuenta?: number } = {},
+): PedidoDB {
+  return {
+    id: '1',
+    cliente_id: '10',
+    estado: 'pendiente',
+    estado_pago: 'pendiente',
+    total: 30000,
+    monto_pagado: 0,
+    fecha: '2026-09-09',
+    deuda_previa: campos.deuda_previa,
+    cliente: {
+      id: '10',
+      nombre_fantasia: 'Kiosco Test',
+      saldo_cuenta: campos.saldo_cuenta ?? 0,
+    },
+  } as PedidoDB
+}
+
+function renderCard(
+  pedido: PedidoDB,
+  rol: RolUsuario,
+  extra: { isOnline?: boolean; saldoActualizadoAt?: number } = {},
+): void {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  const auth = {
+    user: { id: 'u1' },
+    perfil: { id: 'u1', nombre: 'Test', email: 't@t.com', rol },
+    authReady: true,
+    isAdmin: rol === 'admin',
+    isPreventista: rol === 'preventista',
+    isTransportista: rol === 'transportista',
+    isEncargado: rol === 'encargado',
+    isAdminOrEncargado: rol === 'admin' || rol === 'encargado',
+    rolesEfectivos: [rol],
+    isOnline: extra.isOnline ?? true,
+    logout: vi.fn(),
+    currentSucursalId: 1,
+    currentSucursalNombre: 'Test',
+  } as AuthDataContextValue
+
+  function Wrapper({ children }: { children: ReactNode }): ReactElement {
+    return (
+      <QueryClientProvider client={qc}>
+        <AuthDataProvider value={auth}>{children}</AuthDataProvider>
+      </QueryClientProvider>
+    )
+  }
+
+  render(<PedidoCard pedido={pedido} saldoActualizadoAt={extra.saldoActualizadoAt} />, {
+    wrapper: Wrapper,
+  })
+}
+
+describe('PedidoCard — aviso de deuda previa', () => {
+  it('NO deriva la deuda de saldo_cuenta', () => {
+    // El cliente debe $80.000 HOY, pero antes de este pedido no debía nada.
+    // Esta es la regresión del PR #530: si la card vuelve a mirar el saldo,
+    // muestra deuda que nació después de este pedido.
+    renderCard(hacerPedido({ deuda_previa: 0, saldo_cuenta: 80000 }), 'preventista')
+    expect(screen.queryByText(/Debe/)).not.toBeInTheDocument()
+  })
+
+  it('muestra la deuda previa que calculó la base', () => {
+    renderCard(hacerPedido({ deuda_previa: 20000, saldo_cuenta: 50000 }), 'preventista')
+    // 20.000 (lo previo), no 50.000 (el saldo de hoy).
+    expect(screen.getByText(/Debe/)).toHaveTextContent('20.000')
+  })
+
+  it('no avisa cuando la base no mandó el dato', () => {
+    // Las queries que no piden la computed column (ruta, hoja de ruta) traen el
+    // pedido sin `deuda_previa`. Ausente no es cero-con-aviso: es sin dato.
+    renderCard(hacerPedido({ saldo_cuenta: 50000 }), 'preventista')
+    expect(screen.queryByText(/Debe/)).not.toBeInTheDocument()
+  })
+
+  it.each(['admin', 'encargado', 'preventista'] as const)('lo ve el rol %s', rol => {
+    renderCard(hacerPedido({ deuda_previa: 20000 }), rol)
+    expect(screen.getByText(/Debe/)).toBeInTheDocument()
+  })
+
+  it.each(['transportista', 'deposito'] as const)('lo oculta al rol %s', rol => {
+    renderCard(hacerPedido({ deuda_previa: 20000 }), rol)
+    expect(screen.queryByText(/Debe/)).not.toBeInTheDocument()
+  })
+
+  it('sin conexión habla en pasado y fecha el dato', () => {
+    renderCard(hacerPedido({ deuda_previa: 20000 }), 'preventista', {
+      isOnline: false,
+      saldoActualizadoAt: new Date('2026-09-06T15:00:00Z').getTime(),
+    })
+    expect(screen.getByText(/Debía/)).toHaveTextContent('6/9')
+  })
+})

--- a/src/components/vistas/VistaPedidos.tsx
+++ b/src/components/vistas/VistaPedidos.tsx
@@ -29,6 +29,11 @@ import type { PedidoStatsSummary } from '../../hooks/queries';
 export interface VistaPedidosProps {
   /** Pedidos de la página actual (ya paginados server-side) */
   pedidos: PedidoDB[];
+  /**
+   * `dataUpdatedAt` de la query de pedidos. Sólo lo usa la card sin conexión,
+   * para fechar la deuda previa del cliente.
+   */
+  saldoActualizadoAt?: number | null;
   /** Total de pedidos que coinciden con los filtros (para paginación) */
   totalCount: number;
   /** Totales por estado/pago sobre todos los pedidos filtrados (no sólo la página) */
@@ -114,6 +119,7 @@ export interface VistaPedidosProps {
 
 export default function VistaPedidos({
   pedidos,
+  saldoActualizadoAt,
   totalCount,
   statsSummary,
   paginaActual,
@@ -253,6 +259,7 @@ export default function VistaPedidos({
               >
                 <PedidoCard
                   pedido={pedido}
+                  saldoActualizadoAt={saldoActualizadoAt}
                   isAdmin={isAdmin}
                   isPreventista={isPreventista}
                   isTransportista={isTransportista}

--- a/src/hooks/queries/usePedidosQuery.ts
+++ b/src/hooks/queries/usePedidosQuery.ts
@@ -134,6 +134,18 @@ const PEDIDO_CLIENT_COLS = 'id, nombre_fantasia, razon_social, cuit, direccion, 
 export const PEDIDO_SELECT = `*, cliente:clientes(${PEDIDO_CLIENT_COLS}), items:pedido_items(*, producto:productos(${PEDIDO_PRODUCT_COLS}), promocion:promociones(unidades_por_bloque)), pagos(forma_pago, monto)` as const
 const PEDIDO_SELECT_CLIENTE_INNER = `*, cliente:clientes!inner(${PEDIDO_CLIENT_COLS}), items:pedido_items(*, producto:productos(${PEDIDO_PRODUCT_COLS}), promocion:promociones(unidades_por_bloque)), pagos(forma_pago, monto)` as const
 
+// `deuda_previa` es una computed column de PostgREST: la funcion SQL del mismo
+// nombre (mig 215), que devuelve lo que el cliente debia ANTES de este pedido.
+// No sale de `clientes.saldo_cuenta`: ese es un escalar del presente e incluye
+// los pedidos POSTERIORES, que fue el bug del PR #530.
+//
+// Va SOLO en la lista, no en el PEDIDO_SELECT compartido: la calcula por fila y
+// la ruta (useRecorridoExistenteQuery) y la hoja de ruta
+// (useRecorridosHojaRutaQuery) traen muchos pedidos y no la muestran. Medido:
+// ~65 ms por pagina de 20.
+const PEDIDO_SELECT_LISTA = `${PEDIDO_SELECT}, deuda_previa` as const
+const PEDIDO_SELECT_LISTA_CLIENTE_INNER = `${PEDIDO_SELECT_CLIENTE_INNER}, deuda_previa` as const
+
 // Helper: cargar salvedades para un conjunto de pedidos
 async function enrichWithSalvedades(pedidos: Record<string, unknown>[]): Promise<Record<string, PedidoSalvedadResumen[]>> {
   const pedidosEntregadosIds = pedidos
@@ -244,7 +256,7 @@ async function fetchPedidosPaginated(
   const hasSearch = search && search.trim().length > 0
 
   // Use !inner join when searching so PostgREST filters parent rows by client fields
-  const selectStr = hasSearch ? PEDIDO_SELECT_CLIENTE_INNER : PEDIDO_SELECT
+  const selectStr = hasSearch ? PEDIDO_SELECT_LISTA_CLIENTE_INNER : PEDIDO_SELECT_LISTA
 
   let query = supabase
     .from('pedidos')

--- a/src/types/hooks.ts
+++ b/src/types/hooks.ts
@@ -172,6 +172,13 @@ export interface PedidoDB {
   id: string;
   cliente_id: string;
   cliente?: ClienteDB;
+  /**
+   * Lo que el cliente debia ANTES de este pedido, calculado en la base
+   * (computed column `deuda_previa`, mig 215). Solo la trae la lista de
+   * pedidos. No confundir con `cliente.saldo_cuenta`, que es el saldo de HOY e
+   * incluye este pedido y los posteriores.
+   */
+  deuda_previa?: number;
   usuario_id?: string;
   usuario?: PerfilDB | null;
   transportista_id?: string | null;


### PR DESCRIPTION
Devuelve el aviso de deuda a la tarjeta del pedido, ahora con el número
correcto. Va sobre #546 (el apagado); **mergear #546 primero**.

> ⚠️ **La migración 215 ya está aplicada en producción.** Tenía que ir primero:
> si el front llega antes que la función, el `select` de pedidos falla entero
> (42883) y se cae la pantalla. Con la función ya aplicada, este PR es seguro de
> mergear cuando quieras.

## Por qué no se puede calcular en el front

La deuda que había **al momento** de un pedido no sale de `clientes.saldo_cuenta`:
es un escalar del presente e incluye los pedidos posteriores. Hay que sumar lo
impago de los pedidos **anteriores** del cliente y restarle los pagos a cuenta
anteriores — la fórmula canónica del saldo, cortada en el instante del pedido.
Eso sólo se puede hacer donde están esos pedidos: la lista está paginada y
filtrada, así que en el front casi nunca están todos.

## `deuda_previa` como computed column

Viaja **dentro** del `select` que la lista ya hace: cero queries nuevas, y al no
ser un embed no puede volverse ambigua (PGRST201). Va sólo en el select de la
**lista**: la ruta (`useRecorridoExistenteQuery`) y la hoja de ruta
(`useRecorridosHojaRutaQuery`) reusan `PEDIDO_SELECT`, traen muchos pedidos y no
la muestran.

## Por qué `SECURITY DEFINER`

La RLS de `pedidos` le muestra al preventista sólo **sus** pedidos — medido con
su propio JWT: **1.330 de 5.612**. Una función invoker le escondería lo que le
cargó al mismo cliente otro vendedor, y el mismo pedido mostraría una deuda
distinta según quién lo mire.

Con los datos de hoy esa diferencia no se ve (los dos únicos pedidos cuya deuda
previa viene de otro vendedor son de un admin, para quien la RLS no aplica).
Pero hay una contradicción **actual**: el aviso del alta ya sale de
`saldo_cuenta`, que no pasa por RLS. Con invoker, el mismo cliente mostraría una
deuda en el alta y otra menor en la tarjeta, sin que nada lo explique.

No agrega exposición: ese total ya lo ven todos en `saldo_cuenta`.

### La guarda que no es obvia

Una computed column también es invocable como RPC, y ahí el caller elige el
contenido de la fila. Si la función confiara en el `cliente_id`/`sucursal_id`
que le pasan, un `authenticated` podría pedir la deuda de cualquier cliente de
**cualquier sucursal** inventándose una fila. Por eso no usa nada de `p` salvo
`p.id`: cliente, fecha y sucursal se releen de la tabla, filtrados por
`current_sucursal_id()`.

Verificado: una fila inventada devuelve `0`, y mentirle el `sucursal_id` no
cambia el resultado porque ese valor se ignora.

## Verificado en producción

| | |
|---|---|
| Pedidos con aviso | **73** (eran 1.083, 93% falsos) |
| Costo | **~65 ms** por página de 20, todo en cache |
| ACL | `postgres`, `authenticated`, `service_role` — sin PUBLIC ni anon |
| `curl` con anon key | **42501** permission denied (vs **42703** del control) |
| Invariante de la migración | el primer pedido de cada cliente no puede tener deuda previa |

## Tests

`typecheck`, `lint`, **1616 tests** (121 archivos) y `build`, todo verde.

El test que importa es *"no deriva la deuda de `saldo_cuenta`"*: un cliente que
debe $80.000 hoy pero no debía nada antes de este pedido no muestra aviso. Si
alguien vuelve a mirar el saldo en la card, se pone rojo.

No verificado: la app corriendo con datos reales (requiere login).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
