### PR TITLE
Solo le vendés a tu cliente o al huérfano (cierra el agujero de asignación al crear pedidos)

### DIFF
--- a/migrations/216_solo_le_vendes_a_tu_cliente_o_al_huerfano.sql
+++ b/migrations/216_solo_le_vendes_a_tu_cliente_o_al_huerfano.sql
@@ -1,0 +1,190 @@
+-- Migración 216: solo le vendés a tu cliente o al huérfano
+--
+-- Cierra el agujero del issue #544: `crear_pedido_completo` y
+-- `crear_pedido_completo_bot` NO chequean `cliente_preventistas`. La regla de
+-- asignación vivía en todos lados (RLS `mt_clientes_select`, `bot_buscar_cliente`,
+-- `registrar_visita_cliente`, `ficha_cliente.ts`, `previsualizar_pedido.ts`) menos
+-- en el alta del pedido: el front le ocultaba el cliente y el RPC igual le
+-- aceptaba el pedido si conocía el `id` — un bigint correlativo, visible en
+-- cualquier pedido viejo o export.
+--
+-- No es solo visibilidad: la venta se atribuye a `pedidos.usuario_id`, así que
+-- era plata mal atribuida entre preventistas.
+--
+-- LA REGLA. Si quien crea el pedido tiene rol 'preventista', el cliente tiene
+-- que estar SIN ASIGNAR (huérfano) o ASIGNADO A ÉL. Los demás roles pasan sin
+-- chequeo: admin y encargado siguen sin restricción.
+--
+-- POR QUÉ UN TRIGGER Y NO UN CHEQUEO ADENTRO DEL RPC — mismo molde que la 214 §7:
+--   * cubre `crear_pedido_completo` Y `crear_pedido_completo_bot` de una sola vez.
+--     El bot corre con service_role y NO pasa por RLS: adentro de un RPC habría
+--     que repetir el guard en el otro y alguien se lo va a olvidar;
+--   * no toca ningún cuerpo vivo. La 205 le INYECTA código a
+--     `crear_pedido_completo` con `_mig205_insertar_tras_ancla`: un
+--     `CREATE OR REPLACE` desde el repo lo borraría en silencio;
+--   * atrapa además el INSERT directo por PostgREST, que hoy `mt_pedidos_insert`
+--     deja pasar (`es_preventista() AND sucursal_id = current_sucursal_id()`,
+--     sin mirar `usuario_id`).
+--
+-- OJO es_preventista(): devuelve true también para admin y encargado. Acá se lee
+-- `perfiles.rol` CRUDO, nunca el helper.
+--
+-- IMPACTO MEDIDO ANTES DE APLICAR (90 días al 2026-09-09): 200 de 2723 pedidos de
+-- preventistas matchean la consulta cruda, pero 198 son ARTEFACTO — la asignación
+-- del cliente se creó DESPUÉS del pedido, así que en su momento el cliente era
+-- huérfano y esta regla los habría dejado pasar. Casos reales de un preventista
+-- facturándole al cliente ya asignado a otro: 2 (pedidos 5086 y 5192, $26.800).
+
+BEGIN;
+
+-- ---------------------------------------------------------------------------
+-- El guard
+-- ---------------------------------------------------------------------------
+-- SECURITY DEFINER a propósito, igual que la 214: lee `cliente_preventistas` y
+-- `perfiles`, que la RLS le tapa al preventista. Como INVOKER los EXISTS darían
+-- false y el guard quedaría FAIL-OPEN — dejaría pasar todo.
+--
+-- QUIÉN ES EL AUTOR (y por qué NO es `usuario_id`). `crear_pedido_completo`
+-- escribe `usuario_id = v_preventista_final` y `creado_por = p_usuario_id`: son
+-- columnas distintas. Con `p_preventista_id` un ADMIN carga un pedido A NOMBRE
+-- de un preventista, y ahí `usuario_id` es el vendedor ATRIBUIDO, no el autor.
+-- Si el guard mirara `usuario_id`, ese pedido del admin se rechazaría cada vez
+-- que el preventista atribuido no tenga el cliente — y la decisión es que admin
+-- y encargado van sin restricción. Por eso se decide por el AUTOR:
+--
+--   COALESCE(perfil de auth.uid(), creado_por, usuario_id)
+--
+--   * `auth.uid()` primero porque es lo único NO FALSIFICABLE: sale del JWT, no
+--     de la fila. Un preventista que hace INSERT directo no puede escaparse
+--     mandando `creado_por` de un admin. Funciona aunque el trigger corra dentro
+--     de un SECURITY DEFINER (es un GUC, no depende del owner).
+--   * se exige que `auth.uid()` sea un perfil real antes de usarlo: en el camino
+--     del bot el JWT es de service_role y no trae `sub`, así que cae a
+--     `creado_por` (= `p_perfil_id`, el preventista de Telegram). Si algún día un
+--     token de servicio trajera un `sub` ajeno a `perfiles`, el COALESCE lo
+--     ignora en vez de quedar fail-open.
+--   * `usuario_id` al final: `creado_por` es NULL en las filas viejas, anteriores
+--     a la columna (mig 100).
+--
+-- OJO, convive con `trg_pedidos_cliente_reservado` (214 §7), que SÍ mira
+-- `usuario_id`. No se pisan y las dos claves son deliberadas: un cliente
+-- `reservado_admin` NO tiene asignaciones (la 214 las borra y prohíbe), o sea
+-- que para ESTE guard es huérfano y pasa derecho; lo rechaza el otro, con su
+-- propio mensaje. Un cliente asignado a otro nunca está reservado, así que lo
+-- rechaza éste. Cada mensaje dice qué regla se violó — un "no podés crear este
+-- pedido" pelado es un llamado telefónico.
+--
+-- Solo BEFORE INSERT, a propósito: reatribuir un pedido ya creado (mover
+-- `cliente_id` o `usuario_id`) es tarea de administración y de las migraciones
+-- de datos. Poner el guard en UPDATE las rompería.
+CREATE OR REPLACE FUNCTION public.pedidos_cliente_asignado()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $$
+DECLARE
+  v_autor uuid;
+  v_duenos text;
+  v_cliente text;
+BEGIN
+  IF NEW.cliente_id IS NULL THEN
+    RETURN NEW;
+  END IF;
+
+  v_autor := COALESCE(
+    (SELECT p.id FROM perfiles p WHERE p.id = auth.uid()),
+    NEW.creado_por,
+    NEW.usuario_id
+  );
+
+  IF v_autor IS NULL THEN
+    RETURN NEW;
+  END IF;
+
+  -- `perfiles.rol` crudo: es_preventista() incluye a admin y encargado.
+  IF NOT EXISTS (
+    SELECT 1 FROM perfiles p WHERE p.id = v_autor AND p.rol = 'preventista'
+  ) THEN
+    RETURN NEW;
+  END IF;
+
+  -- Huérfano: sin ninguna asignación ⇒ visible para todos los preventistas
+  -- (mig 028). Pasa.
+  IF NOT EXISTS (
+    SELECT 1 FROM cliente_preventistas cp WHERE cp.cliente_id = NEW.cliente_id
+  ) THEN
+    RETURN NEW;
+  END IF;
+
+  -- Asignado a él. Pasa.
+  IF EXISTS (
+    SELECT 1 FROM cliente_preventistas cp
+    WHERE cp.cliente_id = NEW.cliente_id AND cp.preventista_id = v_autor
+  ) THEN
+    RETURN NEW;
+  END IF;
+
+  SELECT string_agg(pf.nombre, ', ' ORDER BY pf.nombre)
+    INTO v_duenos
+    FROM cliente_preventistas cp
+    JOIN perfiles pf ON pf.id = cp.preventista_id
+   WHERE cp.cliente_id = NEW.cliente_id;
+
+  SELECT COALESCE(c.nombre_fantasia, c.razon_social)
+    INTO v_cliente
+    FROM clientes c WHERE c.id = NEW.cliente_id;
+
+  RAISE EXCEPTION 'Cliente asignado a otro preventista: % (#%) lo atiende %. No podés cargarle pedidos.',
+    COALESCE(v_cliente, '?'), NEW.cliente_id, COALESCE(v_duenos, 'otro preventista')
+    USING ERRCODE = '42501';
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_pedidos_cliente_asignado ON public.pedidos;
+CREATE TRIGGER trg_pedidos_cliente_asignado
+  BEFORE INSERT ON public.pedidos
+  FOR EACH ROW
+  EXECUTE FUNCTION public.pedidos_cliente_asignado();
+
+-- ---------------------------------------------------------------------------
+-- ACL
+-- ---------------------------------------------------------------------------
+-- Toda función nueva de `public` nace con EXECUTE para PUBLIC (la entrada
+-- `=X/postgres` sin grantee) y Supabase le concede `authenticated` por separado:
+-- hay que revocar las DOS mitades acá, en la misma migración. Es lo que la 212 se
+-- olvidó y la 213 tuvo que venir a cerrar.
+--
+-- Una función de trigger no necesita EXECUTE para NADIE: la invoca el executor
+-- como parte del DML, no el caller. Queda en postgres, igual que
+-- `pedidos_cliente_reservado` (214) y `completar_origen_precio_item` (148).
+
+REVOKE ALL ON FUNCTION public.pedidos_cliente_asignado()
+  FROM PUBLIC, anon, authenticated;
+
+-- ---------------------------------------------------------------------------
+-- Verificación de ACL (gate de CI: scripts/check-permisos.mjs)
+-- ---------------------------------------------------------------------------
+
+DO $verif$
+DECLARE
+  v_acl text;
+BEGIN
+  SELECT array_to_string(proacl, ',') INTO v_acl
+  FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace
+  WHERE n.nspname = 'public' AND p.proname = 'pedidos_cliente_asignado';
+
+  IF v_acl IS NULL OR v_acl LIKE '=X/%' OR v_acl LIKE '%,=X/%' THEN
+    RAISE EXCEPTION 'trigger pedidos_cliente_asignado quedo ejecutable por PUBLIC: %',
+      coalesce(v_acl, '(default)');
+  END IF;
+  IF v_acl LIKE '%anon=%' THEN
+    RAISE EXCEPTION 'trigger pedidos_cliente_asignado quedo ejecutable por anon: %', v_acl;
+  END IF;
+  IF v_acl LIKE '%authenticated=%' THEN
+    RAISE EXCEPTION 'trigger pedidos_cliente_asignado quedo ejecutable por authenticated: %', v_acl;
+  END IF;
+END
+$verif$;
+
+COMMIT;

--- a/src/components/SyncStatusBanner.tsx
+++ b/src/components/SyncStatusBanner.tsx
@@ -145,16 +145,20 @@ export function SyncStatusBanner({
       {/* Detalles expandibles */}
       {isExpanded && failedOps.length > 0 && (
         <div className="px-4 pb-2 border-t border-red-200 dark:border-red-800">
-          <ul className="mt-2 space-y-1 max-h-32 overflow-y-auto">
+          {/* El motivo va DEBAJO y entero: es lo único que le dice al preventista
+              qué hacer. Truncado a 150px, un rechazo como "Cliente asignado a otro
+              preventista: X (#N) lo atiende Y" se leía "Cliente asignado a…" y
+              terminaba en un llamado a la oficina. */}
+          <ul className="mt-2 space-y-2 max-h-40 overflow-y-auto">
             {failedOps.map((op) => (
               <li
                 key={op.id}
-                className="text-sm text-red-700 dark:text-red-300 flex justify-between"
+                className="text-sm text-red-700 dark:text-red-300"
               >
-                <span>{getOperationLabel(op.type)}</span>
-                <span className="text-red-500 dark:text-red-400 text-xs truncate max-w-[150px]">
+                <span className="font-medium">{getOperationLabel(op.type)}</span>
+                <p className="text-red-500 dark:text-red-400 text-xs break-words">
                   {op.lastError || 'Error desconocido'}
-                </span>
+                </p>
               </li>
             ))}
           </ul>


### PR DESCRIPTION
Cierra #544.

## El agujero

`crear_pedido_completo` y `crear_pedido_completo_bot` no chequeaban `cliente_preventistas`.
La regla de asignación vivía en todos lados (RLS `mt_clientes_select`, `bot_buscar_cliente`,
`registrar_visita_cliente`, `ficha_cliente.ts`, `previsualizar_pedido.ts`) menos en el alta
del pedido: el front le ocultaba el cliente y el RPC igual le aceptaba el pedido si conocía
el `id` — un bigint correlativo, a la vista en cualquier pedido viejo o export.

Como la venta se atribuye a `pedidos.usuario_id`, era **plata mal atribuida entre
preventistas**, no sólo un tema de visibilidad.

## La regla

Si quien crea el pedido tiene rol `preventista` (`perfiles.rol` crudo — nunca
`es_preventista()`, que devuelve true para admin y encargado), el cliente tiene que estar
**sin asignar** (huérfano) o **asignado a él**. Los demás roles pasan sin chequeo.

## 📊 Impacto medido ANTES de aplicar (últimos 90 días)

La consulta cruda da **200 de 2723** pedidos de preventistas (7,3%). Pero 200 no es el
número que importa: `cliente_preventistas` no tiene historial, así que un cliente
reasignado hace que **todos** los pedidos viejos de su preventista anterior parezcan
violaciones retroactivas. Separando por `cliente_preventistas.creado_en` vs
`pedidos.created_at`:

| Caso | Pedidos | Clientes | Preventistas | Monto |
|---|---:|---:|---:|---:|
| Asignación creada **después** del pedido (artefacto de reasignación — el cliente era huérfano en su momento, esta regla lo habría dejado pasar) | **198** | 48 | 2 | $9.269.873 |
| **Ya estaba asignado a otro** (cubrir de verdad) | **2** | 2 | 1 | $26.800 |

Los 2 reales son de Osvaldo sobre clientes de Víctor:

- pedido **5086** · 2026-08-21 · MAS LIMPIO MAS FORRAJERIA · $12.800 (de Víctor desde 07-28)
- pedido **5192** · 2026-08-24 · BENJAMIN PAZ 248-CONTRERAS · $14.000 (de Víctor desde 08-03)

**No es cero, pero es 2 en 90 días, no 200.** En la práctica no se cubren entre
preventistas: lo que hay es reasignación de cartera. Aun así son dos casos reales, así que
la regla va a rechazar en la calle de vez en cuando y conviene avisarles.

## El arreglo

Trigger `BEFORE INSERT` sobre `pedidos` (mig **216**), mismo molde que la 214 §7:

- cubre `crear_pedido_completo` **y** `crear_pedido_completo_bot` de una sola vez — el bot
  corre con `service_role` y no pasa por RLS, así que un guard adentro de un RPC habría que
  repetirlo en el otro;
- no toca ningún cuerpo vivo — la 205 le **inyecta** código a `crear_pedido_completo` con
  `_mig205_insertar_tras_ancla`, y un `CREATE OR REPLACE` desde el repo lo borraría en
  silencio;
- atrapa además el INSERT directo por PostgREST, que hoy `mt_pedidos_insert` deja pasar.

`SECURITY DEFINER` (como invoker, los `EXISTS` sobre `cliente_preventistas` y `perfiles`
pasarían por RLS y el guard quedaría **fail-open**) y sin `EXECUTE` para nadie.

### ⚠️ Decide por el AUTOR, no por `usuario_id`

Esto no estaba en el issue y cambia el diseño. `crear_pedido_completo` escribe
`usuario_id = v_preventista_final` y `creado_por = p_usuario_id`: con `p_preventista_id` un
**admin carga pedidos a nombre de un preventista**, y ahí `usuario_id` es el vendedor
*atribuido*, no el autor. Si el guard mirara `usuario_id` (como hace la 214), esos pedidos
del admin se rechazarían cada vez que el preventista atribuido no tenga el cliente — y la
decisión es que admin y encargado van sin restricción.

El autor sale de `COALESCE(perfil de auth.uid(), creado_por, usuario_id)`:

- `auth.uid()` primero porque es lo único **no falsificable**: sale del JWT, no de la fila.
  Funciona aunque el trigger corra dentro de un `SECURITY DEFINER` (es un GUC).
- se exige que sea un perfil real antes de usarlo: en el bot el JWT es de `service_role` y no
  trae `sub`, así que cae a `creado_por` (= el preventista de Telegram). Si algún día un token
  de servicio trajera un `sub` ajeno a `perfiles`, el COALESCE lo ignora en vez de quedar
  fail-open.
- `usuario_id` al final: `creado_por` es NULL en las filas anteriores a la columna (mig 100).

### Convivencia con `trg_pedidos_cliente_reservado` (214)

No se pisan, y cada mensaje dice qué regla se violó. Un cliente `reservado_admin` no tiene
asignaciones (la 214 las borra y prohíbe), o sea que para este guard es huérfano y pasa
derecho; lo rechaza el otro con su propio mensaje. Un cliente asignado a otro nunca está
reservado, así que lo rechaza éste.

Sólo `BEFORE INSERT`, a propósito: reatribuir un pedido ya creado es tarea de administración
y de las migraciones de datos, y un guard en UPDATE las rompería.

## Cola offline

Un pedido cargado sin señal para un cliente que se reasigna antes de sincronizar va a fallar
al hacer replay. **No se pierde**: queda en IndexedDB como `failed` con el motivo, y el
banner tiene "Reintentar" y "Descartar".

Lo que sí estaba roto era el mensaje: `SyncStatusBanner` lo truncaba a `max-w-[150px]`, o sea
que se leía **"Cliente asignado a…"** y nada más — exactamente el llamado telefónico que se
quería evitar. Ahora el motivo va debajo del label y entero.

## Verificación

Impersonando (`request.jwt.claims`) en transacciones revertidas, contra el trigger ya
aplicado en prod:

| # | Caso | Esperado | |
|---|---|---|---|
| 1 | preventista → cliente propio | PASA | ✅ |
| 2 | preventista → huérfano | PASA | ✅ |
| 3 | preventista → **cliente de otro** | RECHAZA | ✅ |
| 4 | admin → cliente de otro | PASA | ✅ |
| 5 | encargado → cliente de otro | PASA | ✅ |
| 6 | **admin a nombre de Víctor**, cliente de Osvaldo | PASA | ✅ |
| 7 | **bot** (`auth.uid()` NULL) → cliente de otro | RECHAZA | ✅ |
| 8 | bot → huérfano | PASA | ✅ |
| 9 | bot → cliente propio | PASA | ✅ |
| 10 | cliente `reservado_admin` → mensaje de la **214** | RECHAZA | ✅ |

Y de punta a punta contra el RPC real: cliente propio → `{"success": true, "pedido_id": …}`;
cliente ajeno → `[42501] Cliente asignado a otro preventista: Drugstore Lemon (#599) lo
atiende Osvaldo. No podés cargarle pedidos.` — la excepción propaga sin que ningún handler la
trague, así que `supabase.rpc()` la muestra.

Nada quedó en la base (verificado: 0 pedidos de prueba, 0 clientes reservados).

Gates: `typecheck` · `lint` · `test:run` (1616) · `build` · `deno task check/lint/test` (203).

## Nota aparte (no lo arregla este PR)

`mt_pedidos_insert` es `es_preventista() AND sucursal_id = current_sucursal_id()` — no mira
`usuario_id`, así que por PostgREST se puede insertar un pedido atribuido a cualquiera. Este
trigger tapa el caso del cliente ajeno, pero el forjado de `usuario_id` sigue abierto. Va a
issue aparte.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
