### PR TITLE
Terminar de cerrar el truncado silencioso de PostgREST (#523, #524)

### DIFF
--- a/src/components/containers/PedidosContainer.tsx
+++ b/src/components/containers/PedidosContainer.tsx
@@ -63,6 +63,7 @@ import { useResetOnSucursalChange } from '../../hooks/useResetOnSucursalChange'
 import { useRegistrarGeolocalizacionPedido } from '../../hooks/useRegistrarGeolocalizacionPedido'
 import type { GpsResult, GpsStatus } from '../../hooks/useGeolocationCapture'
 import { supabase } from '../../hooks/supabase/base'
+import { traerTodoVerificado } from '../../utils/paginacion'
 import { usePagos } from '../../hooks/supabase/usePagos'
 import { retryWithBackoff, isTransientNetworkError } from '../../utils/retryWithBackoff'
 import { importConRecarga, lazyWithReload } from '../../utils/lazyWithReload'
@@ -701,34 +702,57 @@ export default function PedidosContainer(): React.ReactElement {
     setGuardando(false)
   }, [entregaYPagoMasivos, notify, requestIdMasivo])
 
-  // Fetch todos los pedidos con filtros actuales (sin paginación) para export
+  // Fetch todos los pedidos con filtros actuales para export.
+  //
+  // "Todos" tiene que ser todos. Sin paginar, esto traía 1.000 de los 5.617
+  // pedidos y el Excel/PDF salía igual, con cara de completo: es el mismo
+  // truncado silencioso del backup (#523), en un artefacto que también se
+  // archiva. Por eso además de paginar se VERIFICA contra el `count` exacto y
+  // se tira si no coincide, como `bajarTodoVerificado` en useBackup.ts.
   const fetchAllFilteredPedidos = useCallback(async (): Promise<PedidoDB[]> => {
     const hasSearch = debouncedBusqueda && debouncedBusqueda.trim().length > 0
     const selectStr = hasSearch
       ? '*, cliente:clientes!inner(*), items:pedido_items(*, producto:productos(*)), pagos(forma_pago, monto)'
       : '*, cliente:clientes(*), items:pedido_items(*, producto:productos(*)), pagos(forma_pago, monto)'
 
-    let query = supabase
-      .from('pedidos')
-      .select(selectStr)
-      .order('created_at', { ascending: false })
+    // Los filtros se arman en UN solo lugar: el conteo y las páginas tienen que
+    // mirar exactamente el mismo universo, o la verificación no prueba nada.
+    // El desempate por `id` hace falta porque `created_at` no es único y
+    // paginar sin orden estable repite filas y saltea otras.
+    const armarQuery = (opciones?: { count: 'exact'; head: true }) => {
+      let query = supabase
+        .from('pedidos')
+        .select(selectStr, opciones)
+        .order('created_at', { ascending: false })
+        .order('id')
 
-    if (filtros.estado && filtros.estado !== 'todos') query = query.eq('estado', filtros.estado)
-    if (filtros.estadoPago && filtros.estadoPago !== 'todos') query = query.eq('estado_pago', filtros.estadoPago)
-    if (filtros.transportistaId && filtros.transportistaId !== 'todos') query = query.eq('transportista_id', filtros.transportistaId)
-    if (filtros.fechaDesde) query = query.gte('fecha', filtros.fechaDesde)
-    if (filtros.fechaHasta) query = query.lte('fecha', filtros.fechaHasta)
-    if (!filtros.verCancelados && filtros.estado !== 'cancelado') query = query.neq('estado', 'cancelado')
-    if (hasSearch) {
-      const trimmed = debouncedBusqueda!.trim()
-      query = query.or(
-        `nombre_fantasia.ilike.%${trimmed}%,razon_social.ilike.%${trimmed}%,cuit.ilike.%${trimmed}%,direccion.ilike.%${trimmed}%`,
-        { referencedTable: 'clientes' }
-      )
+      if (filtros.estado && filtros.estado !== 'todos') query = query.eq('estado', filtros.estado)
+      if (filtros.estadoPago && filtros.estadoPago !== 'todos') query = query.eq('estado_pago', filtros.estadoPago)
+      if (filtros.transportistaId && filtros.transportistaId !== 'todos') query = query.eq('transportista_id', filtros.transportistaId)
+      if (filtros.fechaDesde) query = query.gte('fecha', filtros.fechaDesde)
+      if (filtros.fechaHasta) query = query.lte('fecha', filtros.fechaHasta)
+      if (!filtros.verCancelados && filtros.estado !== 'cancelado') query = query.neq('estado', 'cancelado')
+      if (hasSearch) {
+        const trimmed = debouncedBusqueda!.trim()
+        query = query.or(
+          `nombre_fantasia.ilike.%${trimmed}%,razon_social.ilike.%${trimmed}%,cuit.ilike.%${trimmed}%,direccion.ilike.%${trimmed}%`,
+          { referencedTable: 'clientes' }
+        )
+      }
+      return query
     }
 
-    const { data, error } = await query
-    if (error) throw error
+    type FilaExport = Record<string, unknown> & {
+      usuario_id?: string | null
+      transportista_id?: string | null
+    }
+    const data = await traerTodoVerificado<FilaExport>(
+      () => armarQuery(),
+      {
+        etiqueta: 'el export de pedidos',
+        contar: () => armarQuery({ count: 'exact', head: true }),
+      },
+    )
 
     // Enrich with perfiles
     const perfilIds = new Set<string>()
@@ -823,8 +847,11 @@ export default function PedidosContainer(): React.ReactElement {
       ], `pedidos-${suffix}-${fechaLocalISO()}`)
 
       notify.success(`Excel exportado: ${pedidosExport.length} pedidos`)
-    } catch {
-      notify.error('Error al exportar Excel')
+    } catch (e) {
+      // El mensaje va entero: si el export se abortó por venir incompleto, el
+      // motivo es justamente lo que hay que leer. Un "Error al exportar" pelado
+      // deja al usuario reintentando sin saber qué pasó.
+      notify.error('Error al exportar Excel: ' + (e as Error).message)
     }
     setExportando(false)
   }, [pedidos, notify, fetchAllFilteredPedidos])

--- a/src/components/modals/ModalExportarPDF.tsx
+++ b/src/components/modals/ModalExportarPDF.tsx
@@ -49,6 +49,7 @@ const ModalExportarPDF = memo(function ModalExportarPDF({
   const [busquedaPedido, setBusquedaPedido] = useState<string>('');
   const [todosLosPedidos, setTodosLosPedidos] = useState<PedidoDB[] | null>(null);
   const [cargandoTodos, setCargandoTodos] = useState(false);
+  const [errorTodos, setErrorTodos] = useState<string | null>(null);
   // Hoja de ruta Y comandas: se descargan desde la ruta YA armada de un día +
   // transportista (persistida en recorridos), no desde pedidos filtrados a mano.
   const [fechaRuta, setFechaRuta] = useState<string>(fechaLocalISO());
@@ -102,13 +103,17 @@ const ModalExportarPDF = memo(function ModalExportarPDF({
 
     if (nuevoAlcance === 'todos' && !todosLosPedidos && fetchAllFilteredPedidos) {
       setCargandoTodos(true);
+      setErrorTodos(null);
       try {
         const todos = await fetchAllFilteredPedidos();
         setTodosLosPedidos(todos);
-      } catch {
-        // Fallback: usar pedidos de la pagina
+      } catch (e) {
+        // Fallback: usar pedidos de la pagina, PERO diciendolo. Volver a
+        // "pagina actual" en silencio es como se veia antes el truncado:
+        // el usuario pide todos, recibe una parte y nada se lo avisa.
         setTodosLosPedidos(null);
         setAlcance('pagina');
+        setErrorTodos((e as Error).message);
       } finally {
         setCargandoTodos(false);
       }
@@ -299,6 +304,11 @@ const ModalExportarPDF = memo(function ModalExportarPDF({
                 Todos los pedidos (con filtros)
               </button>
             </div>
+            {errorTodos && (
+              <p className="mt-2 text-sm text-red-600 dark:text-red-400">
+                No se pudo traer todos los pedidos, se usa la página actual. {errorTodos}
+              </p>
+            )}
           </div>
         )}
 

--- a/src/hooks/queries/useClientesQuery.ts
+++ b/src/hooks/queries/useClientesQuery.ts
@@ -159,14 +159,25 @@ async function fetchClientesByZona(zona: string): Promise<ClienteDB[]> {
 }
 
 async function fetchZonasUnicas(): Promise<string[]> {
-  const { data, error } = await supabase
-    .from('clientes')
-    .select('zona')
-    .not('zona', 'is', null)
+  // Lee una fila por cliente para quedarse con 13 zonas distintas. Paginado
+  // porque `clientes` es la tabla que más cerca está del tope: hoy 461 filas
+  // con zona de las 722 totales. Pasado el tope no degrada de a poco —se
+  // pierde una zona entera del filtro, sin aviso—, y una zona que desaparece
+  // de la lista es un pedazo del reparto que deja de poder elegirse.
+  //
+  // Lo correcto sería que la base devuelva las zonas distintas en vez de las
+  // filas (como `reporte_ventas_por_cliente`, mig 197). Mientras tanto esto es
+  // correcto para cualquier volumen, que es lo que estaba en juego.
+  const data = await traerTodo<{ zona: string | null }>(
+    () => supabase
+      .from('clientes')
+      .select('zona')
+      .not('zona', 'is', null)
+      .order('id'),
+    { etiqueta: 'zonas de clientes' },
+  )
 
-  if (error) throw error
-
-  const zonas = [...new Set((data || []).map(c => c.zona).filter(Boolean) as string[])]
+  const zonas = [...new Set(data.map(c => c.zona).filter(Boolean) as string[])]
   return zonas.sort()
 }
 

--- a/src/hooks/queries/useMetricasQuery.truncado.test.tsx
+++ b/src/hooks/queries/useMetricasQuery.truncado.test.tsx
@@ -1,0 +1,192 @@
+/**
+ * Tests del truncado silencioso en el dashboard (#524).
+ *
+ * QUÉ PASABA
+ * ----------
+ * PostgREST corta en 1.000 filas y devuelve 200. La query principal del
+ * dashboard se paginó en el PR #525, pero las otras dos del mismo `Promise.all`
+ * quedaron sin paginar, y una de ellas ya truncaba en prod:
+ *
+ *   - "período anterior": tiene la MISMA duración que el período elegido, así
+ *     que con "mes" son 1.064 pedidos y llegaban 1.000. La tarjeta de ventas
+ *     compara el período actual (completo) contra ese anterior (recortado), o
+ *     sea que la flechita de tendencia exageraba el crecimiento: $43,4M en vez
+ *     de $46,3M, un 93,8% del real, y la distorsión crece con el volumen.
+ *   - la serie de 7 días: hoy son ~213 pedidos, no trunca. Lo que la salva es
+ *     el volumen, no el código.
+ *
+ * Y como ninguna de las dos tenía `order`, cuáles 1.000 llegaban no estaba
+ * definido: dos cargas del mismo dashboard podían dar números distintos.
+ *
+ * QUÉ FIJAN ESTOS TESTS
+ * ---------------------
+ * Que las tres consultas de pedidos se paginen (terminan en `.range()`, no en
+ * un await pelado) y que todas lleven un orden estable terminado en `id`
+ * —paginar con `range()` sin ORDER BY único repite filas y saltea otras—.
+ */
+import React from 'react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+
+const from = vi.fn()
+
+vi.mock('../supabase/base', () => ({
+  supabase: {
+    from: (...args: unknown[]) => from(...args),
+    rpc: vi.fn(),
+  },
+}))
+
+vi.mock('../../contexts/SucursalContext', () => ({
+  useSucursal: () => ({ currentSucursalId: 1 }),
+}))
+
+import { useMetricasQuery } from './useMetricasQuery'
+
+/** Una consulta observada: qué columnas pidió, cómo ordenó, qué rangos trajo. */
+interface Consulta {
+  select: string
+  orders: string[]
+  rangos: Array<[number, number]>
+  /** true si se resolvió con un await directo, sin pasar por `.range()`. */
+  awaitDirecto: boolean
+}
+
+/**
+ * Las consultas se agrupan por su `select`, que es lo que las distingue. Hace
+ * falta porque `traerTodo` llama a la factory UNA VEZ POR PAGINA: cada pagina
+ * crea un builder nuevo, y si se contara por builder saldrian seis consultas
+ * de una linea en vez de tres de dos paginas.
+ */
+let consultas = new Map<string, Consulta>()
+
+function registrar(select: string): Consulta {
+  const yaVista = consultas.get(select)
+  if (yaVista) return yaVista
+  const nueva: Consulta = { select, orders: [], rangos: [], awaitDirecto: false }
+  consultas.set(select, nueva)
+  return nueva
+}
+
+/**
+ * Builder encadenable que ademas ANOTA lo que le piden.
+ *
+ * La primera pagina vuelve LLENA (tantas filas como entren en el rango pedido),
+ * que es la unica senal que tiene el paginador para saber que puede haber mas;
+ * la segunda vuelve vacia y ahi corta. O sea: simula una tabla que no entra en
+ * una sola pagina, que es el caso que importa. El `.then` esta para detectar el
+ * caso viejo —una consulta que se await-ea sin paginar—.
+ */
+function armarBuilder() {
+  // Se registra recién en `.select()`: registrar antes dejaría una consulta
+  // fantasma, sin rangos ni orders, que hace fallar a las aserciones "las tres".
+  let consulta: Consulta = { select: '(sin select)', orders: [], rangos: [], awaitDirecto: false }
+
+  const fila = { id: 1, total: 100, estado: 'entregado', fecha: '2026-09-01', items: [] }
+  const builder: Record<string, unknown> = {}
+  const encadenable = () => builder
+
+  builder.select = (cols: string) => { consulta = registrar(cols); return builder }
+  builder.order = (col: string) => {
+    // Los `order` se anotan una sola vez: se repiten en cada pagina.
+    if (consulta.rangos.length === 0 && !consulta.orders.includes(col)) consulta.orders.push(col)
+    return builder
+  }
+  builder.eq = encadenable
+  builder.neq = encadenable
+  builder.gte = encadenable
+  builder.lte = encadenable
+  builder.range = (desde: number, hasta: number) => {
+    consulta.rangos.push([desde, hasta])
+    const filas = desde === 0
+      ? Array.from({ length: hasta - desde + 1 }, () => fila)
+      : []
+    return Promise.resolve({ data: filas, error: null })
+  }
+  // Si alguien await-ea el builder sin `.range()`, cae aca: es exactamente la
+  // forma que tenia el bug.
+  builder.then = (resolver: (v: unknown) => unknown) => {
+    consulta.awaitDirecto = true
+    return Promise.resolve({ data: [fila], error: null }).then(resolver)
+  }
+  return builder
+}
+
+function makeWrapper(qc: QueryClient) {
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return <QueryClientProvider client={qc}>{children}</QueryClientProvider>
+  }
+}
+
+function nuevoQueryClient() {
+  return new QueryClient({ defaultOptions: { queries: { retry: false } } })
+}
+
+/** Corre el hook con período "mes", que es el que dispara el período anterior. */
+async function correrDashboard(): Promise<Consulta[]> {
+  consultas = new Map()
+  from.mockImplementation(() => armarBuilder())
+  const qc = nuevoQueryClient()
+  const { result } = renderHook(() => useMetricasQuery('mes'), {
+    wrapper: makeWrapper(qc),
+  })
+  await waitFor(() => expect(result.current.isSuccess).toBe(true))
+  return [...consultas.values()]
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('useMetricasQuery — truncado silencioso', () => {
+  it('hace las tres consultas de pedidos del dashboard', async () => {
+    const consultas = await correrDashboard()
+    // principal (con items), período anterior (total, estado), serie (total, fecha)
+    expect(consultas).toHaveLength(3)
+  })
+
+  describe('ninguna consulta se resuelve sin paginar', () => {
+    it('las tres pasan por .range()', async () => {
+      const consultas = await correrDashboard()
+      for (const c of consultas) {
+        expect(c.rangos.length).toBeGreaterThan(0)
+      }
+    })
+
+    it('ninguna se await-ea directo, que era la forma del bug', async () => {
+      const consultas = await correrDashboard()
+      expect(consultas.filter(c => c.awaitDirecto)).toEqual([])
+    })
+  })
+
+  describe('el período anterior trae todo, no la primera página', () => {
+    it('sigue pidiendo páginas mientras vengan llenas', async () => {
+      // Una página llena obliga a pedir la siguiente: es lo que no pasaba.
+      const consultas = await correrDashboard()
+      const anterior = consultas.find(c => c.select === 'total, estado')
+      expect(anterior?.rangos).toHaveLength(2)
+    })
+
+    it('la serie de 7 días también', async () => {
+      const consultas = await correrDashboard()
+      const serie = consultas.find(c => c.select === 'total, fecha')
+      expect(serie?.rangos).toHaveLength(2)
+    })
+  })
+
+  describe('el orden es estable, o la paginación miente', () => {
+    it('las tres desempatan por id', async () => {
+      const consultas = await correrDashboard()
+      for (const c of consultas) {
+        expect(c.orders[c.orders.length - 1]).toBe('id')
+      }
+    })
+
+    it('la principal ordena por created_at antes del desempate', async () => {
+      const consultas = await correrDashboard()
+      const principal = consultas.find(c => c.select.includes('items:pedido_items'))
+      expect(principal?.orders).toEqual(['created_at', 'id'])
+    })
+  })
+})

--- a/src/hooks/queries/useMetricasQuery.ts
+++ b/src/hooks/queries/useMetricasQuery.ts
@@ -79,35 +79,47 @@ async function calcularMetricas(params: MetricasParams): Promise<DashboardMetric
   //    convención que el comparativo del RPC reporte_gerencial). Sin `desde`
   //    (historico) no hay comparación posible.
   const prev = ventana.desde ? ventanaAnterior(ventana.desde, ventana.hasta ?? hoyISO) : null
+  //
+  //    Paginado por lo mismo que la query principal: el período anterior tiene
+  //    la misma duración que el elegido, así que un mes son ~1.064 pedidos y ya
+  //    pasaba el tope. La comparación "vs período anterior" salía calculada
+  //    sobre 1.000 pedidos contra el total real del período actual: dos
+  //    universos de distinto tamaño, o sea una variación inventada.
   const anteriorPromise = (async () => {
     if (!prev) return null
-    let query = supabase
-      .from('pedidos')
-      .select('total, estado')
-      .neq('estado', 'cancelado')
-      .gte('fecha', prev.desde)
-      .lte('fecha', prev.hasta)
-    if (usuarioId) query = query.eq('usuario_id', usuarioId)
-    const { data, error } = await query
-    if (error) throw error
-    return (data as Array<{ total: number | null; estado: string }>) || []
+    return traerTodo<{ total: number | null; estado: string }>(
+      () => {
+        let query = supabase
+          .from('pedidos')
+          .select('total, estado')
+          .neq('estado', 'cancelado')
+          .gte('fecha', prev.desde)
+          .lte('fecha', prev.hasta)
+        if (usuarioId) query = query.eq('usuario_id', usuarioId)
+        return query.order('id')
+      },
+      { etiqueta: 'pedidos del período anterior' },
+    )
   })()
 
   // -- Últimos 7 días para el gráfico, SIEMPRE (ventana propia, independiente
   //    del período elegido). Mantiene "no cancelados": con entregado-only los
   //    días recientes se verían vacíos hasta cerrar el reparto.
-  const seriePromise = (async () => {
-    let query = supabase
-      .from('pedidos')
-      .select('total, fecha')
-      .neq('estado', 'cancelado')
-      .gte('fecha', addDiasISO(hoyISO, -6))
-      .lte('fecha', hoyISO)
-    if (usuarioId) query = query.eq('usuario_id', usuarioId)
-    const { data, error } = await query
-    if (error) throw error
-    return (data as Array<{ total: number | null; fecha: string | null }>) || []
-  })()
+  //    Paginado aunque hoy 7 días sean ~213 pedidos: es la misma consulta con
+  //    otra ventana, y lo que la salva es el volumen, no el código.
+  const seriePromise = traerTodo<{ total: number | null; fecha: string | null }>(
+    () => {
+      let query = supabase
+        .from('pedidos')
+        .select('total, fecha')
+        .neq('estado', 'cancelado')
+        .gte('fecha', addDiasISO(hoyISO, -6))
+        .lte('fecha', hoyISO)
+      if (usuarioId) query = query.eq('usuario_id', usuarioId)
+      return query.order('id')
+    },
+    { etiqueta: 'pedidos del gráfico' },
+  )
 
   const [pedidos, pedidosAnterior, filasSerie] = await Promise.all([
     principalPromise,

--- a/src/hooks/supabase/useBackup.test.ts
+++ b/src/hooks/supabase/useBackup.test.ts
@@ -1,0 +1,195 @@
+/**
+ * Tests del backup completo (#523).
+ *
+ * EL INCIDENTE
+ * ------------
+ * `exportarDatos` leía `pedidos` sin `limit` ni `range`. PostgREST corta en
+ * 1.000 filas y devuelve un 200, así que el archivo se bajaba entero, con
+ * nombre `backup_completo_<fecha>.json`, y adentro había 1.000 de los 5.555
+ * pedidos que existían. El 82% no estaba. Ni error, ni conteo, ni aviso.
+ *
+ * Es el peor caso de la familia del truncado: los demás muestran un número mal
+ * en una pantalla y alguien lo cruza contra otra fuente. Éste produce un
+ * artefacto que se guarda PARA EL DÍA QUE ALGO SALGA MAL, y ese día ya es tarde
+ * para descubrir que estaba incompleto desde el principio.
+ *
+ * QUÉ FIJAN ESTOS TESTS
+ * ---------------------
+ * El fake de acá abajo emula el tope de PostgREST de verdad: nunca devuelve más
+ * de 1.000 filas por request, pase lo que pase. Contra ese fake se arma un
+ * backup con los volúmenes de prod (5.624 pedidos, 722 clientes, 287 productos)
+ * y se cuentan las filas de cada "hoja" del JSON.
+ *
+ * Y la otra mitad, que es la que convierte al backup en backup: si lo que se
+ * bajó no coincide con el `count` de la base, NO se genera el archivo.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+
+const from = vi.fn()
+
+vi.mock('./base', () => ({
+  supabase: {
+    from: (...args: unknown[]) => from(...args),
+  },
+}))
+
+vi.mock('../../contexts/SucursalContext', () => ({
+  useSucursal: () => ({ currentSucursalId: 1 }),
+}))
+
+import { useBackup } from './useBackup'
+
+/** Los volúmenes reales de prod al momento de escribir esto. */
+const FILAS_EN_PROD: Record<string, number> = {
+  pedidos: 5624,
+  clientes: 722,
+  productos: 287,
+}
+
+/** El tope de PostgREST. No es configurable desde el cliente: corta y ya. */
+const TOPE_POSTGREST = 1000
+
+interface OpcionesFake { /** Filas que la tabla dice tener, si difiere de las que entrega. */ countMentido?: number }
+
+let opciones: Record<string, OpcionesFake> = {}
+
+/**
+ * Emula PostgREST: `.range(desde, hasta)` devuelve como mucho 1.000 filas
+ * aunque le pidas más, y `head: true` devuelve el `count` sin filas.
+ *
+ * Es la pieza importante del test: si el fake devolviera todo lo pedido, el
+ * bug original no se podría reproducir y el test no probaría nada.
+ */
+function tablaFake(tabla: string) {
+  const total = FILAS_EN_PROD[tabla] ?? 0
+  const filas = Array.from({ length: total }, (_, i) => ({ id: i + 1, tabla }))
+  const entregables = opciones[tabla]?.countMentido != null
+    ? filas.slice(0, opciones[tabla].countMentido!)
+    : filas
+  const count = total
+
+  const builder: Record<string, unknown> = {}
+  builder.order = () => builder
+  builder.range = (desde: number, hasta: number) => {
+    const pedidas = hasta - desde + 1
+    const cuantas = Math.min(pedidas, TOPE_POSTGREST)
+    return Promise.resolve({ data: entregables.slice(desde, desde + cuantas), error: null })
+  }
+  builder.select = (_cols: string, opts?: { head?: boolean; count?: string }) => {
+    if (opts?.head) return Promise.resolve({ count, data: null, error: null })
+    return builder
+  }
+  return builder
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  opciones = {}
+  from.mockImplementation((tabla: string) => tablaFake(tabla))
+})
+
+describe('useBackup — el backup completo tiene que estar completo', () => {
+  describe('cuenta las filas de cada hoja del archivo', () => {
+    it('trae los 5.624 pedidos, no los primeros 1.000', async () => {
+      const { result } = renderHook(() => useBackup())
+      let backup!: Awaited<ReturnType<typeof result.current.exportarDatos>>
+      await act(async () => { backup = await result.current.exportarDatos('completo') })
+      expect(backup.pedidos).toHaveLength(5624)
+    })
+
+    it('trae los 722 clientes', async () => {
+      // Hoy entran bajo el tope, pero están a 278 filas de empezar a truncarse.
+      const { result } = renderHook(() => useBackup())
+      let backup!: Awaited<ReturnType<typeof result.current.exportarDatos>>
+      await act(async () => { backup = await result.current.exportarDatos('completo') })
+      expect(backup.clientes).toHaveLength(722)
+    })
+
+    it('trae los 287 productos', async () => {
+      const { result } = renderHook(() => useBackup())
+      let backup!: Awaited<ReturnType<typeof result.current.exportarDatos>>
+      await act(async () => { backup = await result.current.exportarDatos('completo') })
+      expect(backup.productos).toHaveLength(287)
+    })
+
+    it('un backup parcial trae solo su tabla, completa', async () => {
+      const { result } = renderHook(() => useBackup())
+      let backup!: Awaited<ReturnType<typeof result.current.exportarDatos>>
+      await act(async () => { backup = await result.current.exportarDatos('pedidos') })
+      expect(backup.pedidos).toHaveLength(5624)
+      expect(backup.clientes).toBeUndefined()
+      expect(backup.productos).toBeUndefined()
+    })
+  })
+
+  describe('si no puede probar que está completo, no genera el archivo', () => {
+    it('tira cuando la base entrega menos filas de las que dice tener', async () => {
+      // La foto de #523: la tabla dice 5.624 y solo se pueden bajar 1.000.
+      opciones = { pedidos: { countMentido: TOPE_POSTGREST } }
+      const { result } = renderHook(() => useBackup())
+      await expect(
+        act(async () => { await result.current.exportarDatos('completo') }),
+      ).rejects.toThrow(/incompleto/)
+    })
+
+    it('el error dice cuántas filas se bajaron de cuántas', async () => {
+      opciones = { pedidos: { countMentido: TOPE_POSTGREST } }
+      const { result } = renderHook(() => useBackup())
+      await expect(
+        act(async () => { await result.current.exportarDatos('completo') }),
+      ).rejects.toThrow(/1000 de 5624/)
+    })
+
+    it('el error dice qué tabla quedó incompleta', async () => {
+      opciones = { clientes: { countMentido: 700 } }
+      const { result } = renderHook(() => useBackup())
+      await expect(
+        act(async () => { await result.current.exportarDatos('completo') }),
+      ).rejects.toThrow(/el backup de clientes/)
+    })
+
+    // Lo que hace que esto sea un backup y no un archivo con buena intención:
+    // si falla, no queda un .json a medias en Descargas con cara de completo.
+    it('descargarJSON no baja nada si el backup no cierra', async () => {
+      opciones = { pedidos: { countMentido: TOPE_POSTGREST } }
+      // Se espía el click del <a>, no `createElement`: mockear createElement
+      // entero le rompe el render a React y el test falla por otra cosa.
+      const click = vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(() => {})
+      try {
+        const { result } = renderHook(() => useBackup())
+        await expect(
+          act(async () => { await result.current.descargarJSON('completo') }),
+        ).rejects.toThrow(/incompleto/)
+
+        expect(click).not.toHaveBeenCalled()
+      } finally {
+        click.mockRestore()
+      }
+    })
+
+    it('descargarJSON sí baja el archivo cuando el backup cierra', async () => {
+      // La contracara del test anterior: sin esto, "no bajó nada" podría estar
+      // pasando porque la descarga no funciona nunca.
+      const click = vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(() => {})
+      try {
+        const { result } = renderHook(() => useBackup())
+        await act(async () => { await result.current.descargarJSON('completo') })
+        expect(click).toHaveBeenCalledTimes(1)
+      } finally {
+        click.mockRestore()
+      }
+    })
+  })
+
+  describe('no deja el botón colgado', () => {
+    it('apaga `exportando` aunque el backup falle', async () => {
+      opciones = { pedidos: { countMentido: TOPE_POSTGREST } }
+      const { result } = renderHook(() => useBackup())
+      await expect(
+        act(async () => { await result.current.exportarDatos('completo') }),
+      ).rejects.toThrow()
+      expect(result.current.exportando).toBe(false)
+    })
+  })
+})

--- a/src/hooks/supabase/useBackup.ts
+++ b/src/hooks/supabase/useBackup.ts
@@ -11,7 +11,7 @@ import type {
   ClienteDB,
   ProductoDB
 } from '../../types'
-import { traerTodo } from '../../utils/paginacion'
+import { traerTodoVerificado } from '../../utils/paginacion'
 
 interface PedidoExportacion {
   id: string;
@@ -92,32 +92,22 @@ type BackupTipo = 'completo' | 'clientes' | 'productos' | 'pedidos';
  *
  * Un backup truncado es el peor caso de esta familia de bugs: los demás
  * muestran un número mal en una pantalla y alguien lo nota, éste produce un
- * archivo que parece bien y falla el día que hay que restaurarlo. Antes de este
- * cambio bajaba 1.000 de 5.555 pedidos sin ninguna señal.
+ * archivo que parece bien y falla el día que hay que restaurarlo. Antes de esto
+ * bajaba 1.000 de 5.555 pedidos sin ninguna señal (#523).
  *
- * Por eso no alcanza con paginar: se pide el `count` exacto a la base y se
- * compara. Si no coinciden se tira, porque un backup que no puede demostrar que
- * está completo no sirve como backup.
+ * El cómo está en `traerTodoVerificado`, que es donde vive la comparación
+ * contra el `count` y donde está testeada.
  */
 async function bajarTodoVerificado<T>(
   tabla: string,
   hacerQuery: () => { range(d: number, h: number): PromiseLike<{ data: T[] | null; error: { message: string } | null }> },
 ): Promise<T[]> {
-  const { count, error: errorCount } = await supabase
-    .from(tabla)
-    .select('*', { count: 'exact', head: true })
-  if (errorCount) throw new Error(`No se pudo contar ${tabla}: ${errorCount.message}`)
-
-  const filas = await traerTodo<T>(hacerQuery, { etiqueta: tabla })
-
-  if (count != null && filas.length !== count) {
-    throw new Error(
-      `El backup de ${tabla} quedó incompleto: se bajaron ${filas.length} de ${count} filas. ` +
-      `No se generó el archivo — un backup incompleto es peor que ninguno, porque parece bueno.`,
-    )
-  }
-
-  return filas
+  return traerTodoVerificado<T>(hacerQuery, {
+    etiqueta: `el backup de ${tabla}`,
+    // El backup baja la tabla entera, así que el conteo no lleva filtros. En un
+    // export filtrado el conteo tiene que repetir los mismos filtros.
+    contar: () => supabase.from(tabla).select('*', { count: 'exact', head: true }),
+  })
 }
 
 export function useBackup(): UseBackupReturnExtended {

--- a/src/hooks/supabase/usePagos.test.ts
+++ b/src/hooks/supabase/usePagos.test.ts
@@ -11,6 +11,9 @@ const mockInsert = vi.fn().mockReturnThis()
 const mockDelete = vi.fn().mockReturnThis()
 const mockEq = vi.fn().mockReturnThis()
 const mockOrder = vi.fn().mockReturnThis()
+// `fetchPagosCliente` se pagina, asi que su cadena termina en `.range()`: es
+// esa la que resuelve a `{ data, error }`, no `.order()`.
+const mockRange = vi.fn()
 const mockSingle = vi.fn()
 const mockIn = vi.fn()
 
@@ -22,6 +25,7 @@ vi.mock('./base', () => ({
       delete: mockDelete,
       eq: mockEq,
       order: mockOrder,
+      range: mockRange,
       single: mockSingle,
       in: mockIn
     })),
@@ -45,6 +49,8 @@ describe('usePagos', () => {
     mockDelete.mockReturnThis()
     mockEq.mockReturnThis()
     mockOrder.mockReturnThis()
+    // Por defecto: una pagina vacia, que corta el paginado en la primera vuelta.
+    mockRange.mockResolvedValue({ data: [], error: null })
   })
 
   describe('fetchPagosCliente', () => {
@@ -53,7 +59,7 @@ describe('usePagos', () => {
         { id: '1', cliente_id: 'c1', monto: 1000, usuario: { id: 'u1', nombre: 'Admin' } },
         { id: '2', cliente_id: 'c1', monto: 500, usuario: { id: 'u1', nombre: 'Admin' } }
       ]
-      mockOrder.mockResolvedValueOnce({ data: mockPagos, error: null })
+      mockRange.mockResolvedValueOnce({ data: mockPagos, error: null })
 
       const { result } = renderHook(() => usePagos())
 
@@ -71,7 +77,7 @@ describe('usePagos', () => {
     })
 
     it('debe manejar errores en fetchPagosCliente', async () => {
-      mockOrder.mockResolvedValueOnce({ data: null, error: new Error('DB error') })
+      mockRange.mockResolvedValueOnce({ data: null, error: { message: 'DB error' } })
 
       const { result } = renderHook(() => usePagos())
 
@@ -283,7 +289,7 @@ describe('usePagos', () => {
         { id: '1', monto: 1000 },
         { id: '2', monto: 500 }
       ]
-      mockOrder.mockResolvedValueOnce({ data: mockPagos, error: null })
+      mockRange.mockResolvedValueOnce({ data: mockPagos, error: null })
 
       const { result } = renderHook(() => usePagos())
 

--- a/src/hooks/supabase/usePagos.ts
+++ b/src/hooks/supabase/usePagos.ts
@@ -47,13 +47,20 @@ export function usePagos(): UsePagosReturnExtended {
   const fetchPagosCliente = async (clienteId: string): Promise<PagoDBWithUsuario[]> => {
     setLoading(true)
     try {
-      const { data, error } = await supabase
-        .from('pagos')
-        .select('*, usuario:perfiles(id, nombre)')
-        .eq('cliente_id', clienteId)
-        .order('created_at', { ascending: false })
-      if (error) throw error
-      const pagosData = (data || []) as PagoDBWithUsuario[]
+      // Paginado por lo mismo que las otras dos consultas de la ficha
+      // (`useFichaCliente`): hoy el cliente con más movimiento tiene 118 pagos,
+      // pero la lista de la pestaña "Pagos" es de la misma modal y no tiene
+      // sentido que la mitad aguante el crecimiento y la otra mitad no. El
+      // desempate por `id` va porque `created_at` no es único.
+      const pagosData = await traerTodo<PagoDBWithUsuario>(
+        () => supabase
+          .from('pagos')
+          .select('*, usuario:perfiles(id, nombre)')
+          .eq('cliente_id', clienteId)
+          .order('created_at', { ascending: false })
+          .order('id'),
+        { etiqueta: 'pagos del cliente' },
+      )
       setPagos(pagosData)
       return pagosData
     } catch (error) {

--- a/src/services/analyticsExport.ts
+++ b/src/services/analyticsExport.ts
@@ -342,7 +342,13 @@ export async function fetchComprasFact(
   desde: string,
   hasta: string
 ): Promise<Record<string, unknown>[]> {
-  const { data, error } = await supabase
+  // Paginado como los otros datasets del export. Hoy son 158 compras en toda
+  // la vida del proyecto, muy lejos del tope: se pagina igual porque un export
+  // a BI que trunca no avisa, y las tres consultas de este archivo tienen que
+  // dar la misma garantia. El desempate por `id` va porque `created_at` no es
+  // unico.
+  const data = await traerTodo<Record<string, unknown> & { created_at: string }>(
+    () => supabase
     .from('compras')
     .select(`
       id,
@@ -373,8 +379,9 @@ export async function fetchComprasFact(
     .gte('created_at', `${desde}T00:00:00`)
     .lte('created_at', `${hasta}T23:59:59`)
     .order('created_at', { ascending: false })
-
-  if (error) throw new Error(`Error cargando compras: ${error.message}`)
+    .order('id'),
+    { etiqueta: 'compras' },
+  )
 
   const rows: Record<string, unknown>[] = []
 

--- a/src/utils/paginacion.test.ts
+++ b/src/utils/paginacion.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest'
-import { traerTodo, PAGINA_SUPABASE, TOPE_SEGURIDAD } from './paginacion'
+import { traerTodo, traerTodoVerificado, PAGINA_SUPABASE, TOPE_SEGURIDAD } from './paginacion'
 
 /**
  * Simula el builder de supabase-js: `.range(desde, hasta)` devuelve una porción
@@ -130,6 +130,97 @@ describe('traerTodo', () => {
       }))
       await traerTodo(factory, { pagina: 1000 })
       expect(factory).toHaveBeenCalledTimes(3)
+    })
+  })
+})
+
+describe('traerTodoVerificado', () => {
+  const contarOk = (n: number) => () => Promise.resolve({ count: n, error: null })
+
+  describe('cuando puede demostrar que trajo todo', () => {
+    it('devuelve las filas si coinciden con el count', async () => {
+      const { factory } = fakeTabla(filasDe(2500))
+      const filas = await traerTodoVerificado(factory, {
+        pagina: 1000,
+        contar: contarOk(2500),
+      })
+      expect(filas).toHaveLength(2500)
+    })
+
+    it('sirve para una tabla vacia', async () => {
+      const { factory } = fakeTabla([])
+      expect(await traerTodoVerificado(factory, { contar: contarOk(0) })).toEqual([])
+    })
+  })
+
+  describe('cuando NO puede, no deja generar el archivo', () => {
+    // El caso de #523: la consulta devuelve 1.000 de 5.555 y nadie se entera.
+    // Aca el count no coincide, asi que tiene que tirar en vez de devolver.
+    it('tira si bajo menos filas que el count', async () => {
+      // La foto exacta de #523: la base dice 5.555 y solo llegan 1.000.
+      const { factory } = fakeTabla(filasDe(1000))
+      await expect(
+        traerTodoVerificado(factory, { pagina: 1000, contar: contarOk(5555) }),
+      ).rejects.toThrow(/incompleto/)
+    })
+
+    it('el error dice cuantas filas se bajaron de cuantas', async () => {
+      const { factory } = fakeTabla(filasDe(1000))
+      await expect(
+        traerTodoVerificado(factory, { pagina: 1000, contar: contarOk(5555) }),
+      ).rejects.toThrow(/1000 de 5555/)
+    })
+
+    it('el error dice QUE quedo incompleto', async () => {
+      const { factory } = fakeTabla(filasDe(10))
+      await expect(
+        traerTodoVerificado(factory, {
+          etiqueta: 'el backup de pedidos',
+          contar: contarOk(99),
+        }),
+      ).rejects.toThrow(/el backup de pedidos/)
+    })
+
+    // Una fila insertada entre el conteo y la ultima pagina tambien rompe.
+    // Es a proposito: rehacer un backup es barato, uno incompleto no.
+    it('tira tambien si bajo MAS filas que el count', async () => {
+      const { factory } = fakeTabla(filasDe(11))
+      await expect(
+        traerTodoVerificado(factory, { contar: contarOk(10) }),
+      ).rejects.toThrow(/incompleto/)
+    })
+
+    it('propaga el error del conteo sin llegar a paginar', async () => {
+      const { factory, rangos } = fakeTabla(filasDe(10))
+      await expect(
+        traerTodoVerificado(factory, {
+          etiqueta: 'el backup de pedidos',
+          contar: () => Promise.resolve({ count: null, error: { message: 'boom' } }),
+        }),
+      ).rejects.toThrow('No se pudo contar el backup de pedidos: boom')
+      expect(rangos).toHaveLength(0)
+    })
+
+    // Un error a mitad de la paginacion tampoco puede terminar en archivo.
+    it('propaga el error de una pagina', async () => {
+      const { factory } = fakeTabla(filasDe(10), { error: { message: 'boom' } })
+      await expect(
+        traerTodoVerificado(factory, { contar: contarOk(10) }),
+      ).rejects.toThrow('boom')
+    })
+  })
+
+  describe('cuando la base no da un count', () => {
+    // `count: null` es "no se pudo contar", no "hay cero". Verificar contra eso
+    // convertiria cualquier consulta en un fallo; se deja pasar lo que trajo
+    // `traerTodo`, que ya de por si pagina hasta agotar.
+    it('no inventa una verificacion si el count viene null', async () => {
+      const { factory } = fakeTabla(filasDe(2500))
+      const filas = await traerTodoVerificado(factory, {
+        pagina: 1000,
+        contar: () => Promise.resolve({ count: null, error: null }),
+      })
+      expect(filas).toHaveLength(2500)
     })
   })
 })

--- a/src/utils/paginacion.ts
+++ b/src/utils/paginacion.ts
@@ -102,3 +102,58 @@ export async function traerTodo<T>(
     `Es un freno de seguridad: revisá el filtro de la consulta, o pasá a un RPC que agregue en la base.`,
   )
 }
+
+/** Lo mínimo que se necesita de una consulta de conteo (`head: true`). */
+interface ConCount {
+  count: number | null
+  error: { message: string } | null
+}
+
+export interface OpcionesVerificado extends OpcionesPaginado {
+  /**
+   * Pide el `count` exacto a la base. TIENE que mirar el mismo universo que
+   * `hacerQuery` —los mismos filtros, la misma tabla—: si el conteo y las
+   * páginas no ven lo mismo, la comparación no prueba nada. Por eso conviene
+   * armar los filtros en una sola función y usarla para las dos cosas.
+   */
+  contar: () => PromiseLike<ConCount>
+}
+
+/**
+ * Como `traerTodo`, pero además DEMUESTRA que trajo todo.
+ *
+ * Paginar arregla el truncado mientras nada falle. Para un archivo que se
+ * guarda —un backup, un export— eso no alcanza: si alguna página vuelve corta,
+ * el resultado sigue siendo un archivo con cara de completo, y de eso nadie se
+ * entera hasta el día que hay que usarlo. El backup llegó a guardar 1.000 de
+ * 5.555 pedidos así (#523).
+ *
+ * Entonces se pide el `count` exacto y se compara. Si no coinciden, tira: el
+ * que llama NO tiene que generar el archivo.
+ *
+ * Nota sobre la carrera: entre el conteo y la última página alguien puede
+ * insertar una fila, y entonces esto falla aunque no haya ningún bug. Es a
+ * propósito. Un backup que se rehace es barato; uno incompleto que nadie
+ * cuestionó, no.
+ */
+export async function traerTodoVerificado<T>(
+  hacerQuery: () => ConRange<T>,
+  opciones: OpcionesVerificado,
+): Promise<T[]> {
+  const etiqueta = opciones.etiqueta ?? 'la consulta'
+
+  const { count, error } = await opciones.contar()
+  if (error) throw new Error(`No se pudo contar ${etiqueta}: ${error.message}`)
+
+  const filas = await traerTodo<T>(hacerQuery, opciones)
+
+  if (count != null && filas.length !== count) {
+    throw new Error(
+      `No se generó el archivo: ${etiqueta} quedó incompleto, ` +
+      `se bajaron ${filas.length} de ${count} filas. ` +
+      `Un archivo que dice estar completo y trae una parte es peor que ninguno, porque nadie lo revisa.`,
+    )
+  }
+
+  return filas
+}


### PR DESCRIPTION
Cierra lo que quedaba del truncado silencioso. **Ojo con el punto de partida**,
porque cambia qué hay para revisar acá.

## El backup ya estaba arreglado

`bbe1793` (PR #525) y `924d698` (mig 208) ya traían el helper `traerTodo`, las 19
llamadas y `bajarTodoVerificado` en `useBackup.ts`. Los issues #523 y #524
siguen abiertos sólo porque esos commits dicen *"Cierra #523"* y GitHub sólo
reconoce keywords en inglés (`closes` / `fixes`). El backup **no** está
guardando el 18% de los pedidos: pagina y verifica desde hace dos días.

Este PR es lo que quedaba de verdad después de auditar el resto.

## Lo que estaba roto en prod

**1. Un export que dice "todos" y traía 1.000 de 5.617.**
`fetchAllFilteredPedidos` (`PedidosContainer.tsx`) no tenía `limit` ni
paginación. Alimenta el Excel "completo" y la opción *"Todos los pedidos (con
filtros)"* del modal de PDF. No estaba en el inventario de ninguno de los dos
issues: #524 lista **pantallas**, y esto no muestra un número — produce un
archivo, que es exactamente la naturaleza de #523.

Ahora pagina y verifica contra el `count` exacto. Los filtros se arman en una
sola función que usan el conteo y las páginas: si cada uno mirara un universo
distinto, la verificación no probaría nada.

**2. El dashboard comparaba el período actual completo contra 1.000 pedidos.**
#524 listaba el dashboard por su "query principal", que sí se paginó en el
#525. Las otras dos consultas del mismo `Promise.all` quedaron afuera, y el
"período anterior" —que tiene la misma duración que el período elegido— ya
truncaba:

| | pedidos | ventas |
|---|---|---|
| mes anterior real | 1.064 | $46.302.080 |
| lo que veía la comparación | 1.000 | $43.414.590 (93,8%) |

La flechita de tendencia exageraba el crecimiento. Y como no tenía `order`,
cuáles 1.000 llegaban no estaba definido ni entre dos cargas del mismo
dashboard.

## Lo que no truncaba todavía

Paginadas igual, por la regla general del issue —una consulta sin `limit` no
dice "traeme todo", dice "traeme lo que entre y no me avises"—. Todas medidas
contra prod:

- `fetchComprasFact`, tercer dataset del export a BI (158 filas; los otros dos
  ya se paginaban)
- `fetchPagosCliente`, pestaña "Pagos" de la ficha (118 máx.; las otras dos
  consultas de esa misma modal se paginaron en el #525)
- `fetchZonasUnicas`, zonas del filtro (461 de 1.000 — lo más cerca del tope que
  quedaba, y no degrada de a poco: se pierde una zona entera)

## Una decisión que conviene mirar

**La verificación contra el `count` ahora vive en un solo lugar.** Estaba
escrita a mano en `useBackup.ts` y **sin un solo test**. Copiarla al export
hubiera dejado dos definiciones del mismo invariante, listas para
desincronizarse. Se movió a `traerTodoVerificado` en `src/utils/paginacion.ts`,
al lado de `traerTodo` y de sus tests; `useBackup` quedó como un wrapper de tres
líneas y su comportamiento no cambia.

## Tests: +26, y verificados contra el código viejo

- `paginacion.test.ts` +9 — incluida la foto exacta de #523 (el count dice
  5.555, llegan 1.000, tiene que tirar)
- `useBackup.test.ts` +10 — **el backup no tenía ningún test**, siendo el peor
  caso de la familia. El fake emula el tope real de PostgREST, así que el bug
  original se puede reproducir; se cuentan las filas de cada hoja del JSON con
  los volúmenes de prod. Revirtiendo el fix caen 7 de 10.
- `useMetricasQuery.truncado.test.tsx` +7 — que ninguna consulta se resuelva con
  un await pelado (la forma exacta del bug) y que todas desempaten por `id`.
  Revirtiendo el fix caen 4 de 7.

## Verificación

- `typecheck`, `lint`, `test:run` (1633 tests, **sin `.env`**) y `build`: verde.
- Los dos embeds del export (con y sin `!inner`, éste con el `or` sobre
  `clientes`) probados contra PostgREST con curl + anon key: 200 con
  `count=exact`, sin `PGRST201` ni `PGRST203`.
- Los volúmenes de cada consulta, medidos contra prod.

**Lo que no se pudo verificar:** generar el backup real contra prod necesita una
sesión autenticada (RLS le devuelve cero a la anon key). Por eso el conteo de
filas por hoja se hace contra un fake que impone el tope de 1.000 de verdad, con
los números reales de prod (5.624 pedidos / 722 clientes / 287 productos).

## Aparte

Se filó #550 por tres métodos de `src/services/` que truncan pero **no los llama
nadie** (`getMasVendidos` sobre 19.033 items, entre otros). No son pantallas y no
se ejecutan nunca: probablemente haya que borrarlos, no paginarlos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)