### PR TITLE
El detector de duplicados ve lo que la RLS le tapa (#543, mig 217)

### DIFF
--- a/migrations/217_el_detector_de_duplicados_ve_lo_que_la_rls_tapa.sql
+++ b/migrations/217_el_detector_de_duplicados_ve_lo_que_la_rls_tapa.sql
@@ -1,0 +1,209 @@
+-- Migración 217: el detector de duplicados ve lo que la RLS le tapa
+--
+-- Issue #543.
+--
+-- EL BUG. El detector de duplicados por ubicación de `createCliente` corría
+-- COMO EL USUARIO, o sea pasando por la RLS de `clientes`. Un preventista no ve
+-- los clientes asignados a OTRO preventista, así que el detector tampoco los
+-- veía, no avisaba nada, y el preventista creaba un CLON del mismo cliente.
+--
+-- Es la misma forma de fail-open que la 214 documenta en
+-- `cliente_preventistas_no_reservado` y `pedidos_cliente_reservado`: un guard
+-- que consulta bajo la policy que justamente le tapa la fila no falla — APRUEBA.
+-- Por eso esto es SECURITY DEFINER y no invoker.
+--
+-- VERIFICADO EN PROD ANTES DEL ARREGLO, impersonando: el cliente 22
+-- (LOS PORTEÑOS, sucursal 1, asignado a Marcelo y Víctor) existe en esas
+-- coordenadas exactas, y la consulta del detector con el JWT de Osvaldo
+-- —preventista de la MISMA sucursal— devolvía 0 filas.
+--
+-- POR QUÉ IMPORTA MÁS AHORA. Cuando se escribió el detector la base era casi
+-- toda huérfanos (401 vs 26 asignados, mig 028) y casi todo cliente era visible
+-- para casi todo preventista. Hoy está dada vuelta: 598 asignados vs 124
+-- huérfanos. La superficie del bug creció ~20x sin que nadie tocara ese código.
+--
+-- DEVUELVE UN BOOLEANO. Nunca la fila, nunca el nombre, nunca el id. Si
+-- devolviera datos del cliente, el preventista los lee desde la consola del
+-- navegador: sería filtrar por la ventana lo que la policy tapa por la puerta.
+--
+-- LO QUE SÍ SE REVELA, a sabiendas: que HAY alguien en esas coordenadas. No se
+-- puede decir "no crees esto" sin admitir que hay algo ahí — es el piso del
+-- problema, no una elección de implementación. Sondearlo pide el lat/long a 6
+-- decimales (~0,2 m), o sea estar parado en la puerta.
+--
+-- EL DETECTOR POR RAZÓN SOCIAL SE DEJA CIEGO, deliberadamente. Ahí el mismo
+-- booleano sería fácil de sondear —se prueban nombres— y se decidió que el
+-- intercambio no vale. O sea: el clon por nombre contra un cliente de otro
+-- preventista se sigue pudiendo crear, y es una decisión tomada, no un olvido.
+--
+-- EL FRONT NO DUPLICA EL PREDICADO DE LA RLS. La consulta vieja (la que pasa
+-- por RLS) se conserva y va PRIMERO; esta RPC se llama sólo si aquella no
+-- encontró nada. Entonces:
+--   * lo ve     → mensaje de siempre, con nombre, y con el camino de
+--                 reactivación si está inactivo. Sin cambios.
+--   * no lo ve  → mensaje genérico, sin identidad.
+-- Así esta función nunca tiene que contestar "¿este usuario puede verlo?", que
+-- es lo que obligaría a copiar `mt_clientes_select` acá dentro y a mantener las
+-- dos sincronizadas para siempre.
+--
+-- MIRA A LOS INACTIVOS A PROPÓSITO, igual que el detector viejo. El incidente
+-- que originó las migs 199/200 fue exactamente una deduplicación —crear el
+-- nuevo, desactivar el viejo— que partió un historial al medio. Si el de esa
+-- esquina está desactivado, lo que corresponde es reactivarlo. No "arreglar"
+-- esto agregando `activo = true`.
+--
+-- RESERVADO_ADMIN (mig 214): cae solo en la rama de "no lo ve", así que bloquea
+-- el clon sin delatar que el cliente está reservado — que es justo el que más
+-- interesa que no se clone.
+
+BEGIN;
+
+-- ---------------------------------------------------------------------------
+-- 1. El detector, que ve por encima de la RLS
+-- ---------------------------------------------------------------------------
+-- VOLATILE (el default), no STABLE: además de responder, notifica.
+--
+-- Acotada a `current_sucursal_id()` como lo estaba la consulta vieja por vía de
+-- la RLS. Sin eso, un preventista sondearía coordenadas de OTRA sucursal, que
+-- es más de lo que el detector necesita y más de lo que hoy puede.
+
+CREATE OR REPLACE FUNCTION public.existe_cliente_en_ubicacion(
+  p_latitud numeric,
+  p_longitud numeric
+)
+RETURNS boolean
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $$
+DECLARE
+  -- Misma tolerancia que el detector del front: ~0,2 m (6 decimales).
+  c_tolerancia constant numeric := 0.000002;
+  v_uid uuid := auth.uid();
+  v_sucursal bigint := current_sucursal_id();
+  v_cliente record;
+  v_quien text;
+BEGIN
+  IF p_latitud IS NULL OR p_longitud IS NULL THEN
+    RETURN false;
+  END IF;
+
+  -- Fail-closed: sin sesión o sin sucursal activa no se contesta "no hay
+  -- duplicado", que dejaría crear el clon. El front ya corta antes por su
+  -- cuenta si no hay sucursal; esto es el cinturón.
+  IF v_uid IS NULL OR v_sucursal IS NULL THEN
+    RAISE EXCEPTION 'No se pudo verificar duplicados: sin sesión o sin sucursal activa'
+      USING ERRCODE = '42501';
+  END IF;
+
+  SELECT c.id, COALESCE(c.nombre_fantasia, c.razon_social) AS nombre
+    INTO v_cliente
+    FROM clientes c
+   WHERE c.sucursal_id = v_sucursal
+     AND c.latitud  BETWEEN p_latitud  - c_tolerancia AND p_latitud  + c_tolerancia
+     AND c.longitud BETWEEN p_longitud - c_tolerancia AND p_longitud + c_tolerancia
+   LIMIT 1;
+
+  IF NOT FOUND THEN
+    RETURN false;
+  END IF;
+
+  -- ---- Aviso a administración -------------------------------------------
+  -- El preventista recibe un mensaje sin identidad; el admin recibe el nombre
+  -- y el id, porque los ve igual y sin eso el aviso no le sirve para nada.
+  --
+  -- Sólo se avisa si el que pregunta es preventista (`perfiles.rol` CRUDO:
+  -- es_preventista() devuelve true también para admin y encargado). Para los
+  -- demás roles la RLS no tapa nada, así que si llegaron hasta acá no hay
+  -- ningún conflicto de visibilidad que contar.
+  IF EXISTS (SELECT 1 FROM perfiles p WHERE p.id = v_uid AND p.rol = 'preventista') THEN
+    -- Dedupe: el alta se reintenta, y sin esto cada intento deja una fila por
+    -- cada admin y encargado de la sucursal. Una campanita que grita 20 veces
+    -- lo mismo se deja de mirar, que es la forma de que el aviso no exista.
+    IF NOT EXISTS (
+      SELECT 1 FROM notificaciones n
+       WHERE n.tipo = 'cliente_duplicado_oculto'
+         AND n.entidad_id = v_cliente.id
+         AND n.created_at > now() - interval '1 day'
+    ) THEN
+      SELECT p.nombre INTO v_quien FROM perfiles p WHERE p.id = v_uid;
+
+      PERFORM _notificar_sucursal_roles(
+        v_sucursal,
+        v_uid,
+        'cliente_duplicado_oculto',
+        'Alta de cliente bloqueada por duplicado',
+        COALESCE(v_quien, 'Un preventista')
+          || ' intentó cargar un cliente en la dirección de "'
+          || COALESCE(v_cliente.nombre, 'sin nombre')
+          || '" (#' || v_cliente.id || '), que no tiene en su cartera. Se bloqueó el alta. '
+          || 'Puede ser el mismo comercio: si corresponde, asignáselo.',
+        'cliente',
+        v_cliente.id,
+        jsonb_build_object(
+          'preventista_id', v_uid,
+          'latitud', p_latitud,
+          'longitud', p_longitud
+        )
+      );
+    END IF;
+  END IF;
+
+  RETURN true;
+END;
+$$;
+
+COMMENT ON FUNCTION public.existe_cliente_en_ubicacion(numeric, numeric) IS
+  'Issue #543. ¿Hay un cliente en estas coordenadas (~0,2 m) dentro de la '
+  'sucursal activa? SECURITY DEFINER a propósito: como invoker la RLS le tapa '
+  'los clientes de otros preventistas, el EXISTS da false y el guard deja pasar '
+  'el clon (fail-open). Devuelve un booleano y nada más: la identidad del '
+  'cliente no puede volver al que pregunta. Incluye inactivos a propósito '
+  '(migs 199/200). Avisa a admin y encargado cuando el que pregunta es '
+  'preventista.';
+
+-- ---------------------------------------------------------------------------
+-- 2. ACL
+-- ---------------------------------------------------------------------------
+-- Toda función nueva de `public` nace con EXECUTE para PUBLIC (la entrada
+-- `=X/postgres` sin grantee) y Supabase le concede `anon` por separado: hay que
+-- revocar las DOS mitades acá, en la misma migración. Es lo que la 212 se
+-- olvidó y la 213 tuvo que venir a cerrar.
+--
+-- Una función SECURITY DEFINER que ve TODOS los clientes de una sucursal y que
+-- pueda llamar cualquiera es un agujero peor que el bug que vino a arreglar.
+-- Sin sesión `auth.uid()` es NULL y la función tira, pero el REVOKE es el que
+-- vale: el gate de CI (scripts/check-permisos.mjs) falla ante cualquier función
+-- alcanzable con la anon key.
+
+REVOKE ALL ON FUNCTION public.existe_cliente_en_ubicacion(numeric, numeric) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.existe_cliente_en_ubicacion(numeric, numeric) TO authenticated;
+
+-- ---------------------------------------------------------------------------
+-- 3. Verificación de ACL (gate de CI: scripts/check-permisos.mjs)
+-- ---------------------------------------------------------------------------
+
+DO $verif$
+DECLARE
+  v_acl text;
+BEGIN
+  SELECT array_to_string(proacl, ',') INTO v_acl
+    FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace
+   WHERE n.nspname = 'public' AND p.proname = 'existe_cliente_en_ubicacion';
+
+  IF v_acl IS NULL THEN
+    RAISE EXCEPTION 'existe_cliente_en_ubicacion quedo con ACL default (PUBLIC ejecuta)';
+  END IF;
+  IF v_acl LIKE '=X/%' OR v_acl LIKE '%,=X/%' THEN
+    RAISE EXCEPTION 'existe_cliente_en_ubicacion quedo ejecutable por PUBLIC: %', v_acl;
+  END IF;
+  IF v_acl LIKE '%anon=%' THEN
+    RAISE EXCEPTION 'existe_cliente_en_ubicacion quedo ejecutable por anon: %', v_acl;
+  END IF;
+  IF v_acl NOT LIKE '%authenticated=X%' THEN
+    RAISE EXCEPTION 'existe_cliente_en_ubicacion no quedo ejecutable por authenticated: %', v_acl;
+  END IF;
+END
+$verif$;
+
+COMMIT;

--- a/migrations/MANIFEST.md
+++ b/migrations/MANIFEST.md
@@ -137,14 +137,17 @@ funcional** y no se renombran los archivos: renombrarlos los desalinearía del l
 real lo da `version` y está en la sección A: en los dos casos el archivo de `main` quedó
 cronológicamente **fuera** del bloque 139–147 (uno antes, otro entre la 144 y la 145).
 
-**La próxima migración es la 215** — la última numerada en el repo es
-`214_un_cliente_reservado_a_administracion`, y el ledger de prod está alineado con ella.
-Igual, confirmá el número contra las tres fuentes justo antes de aplicar: el
+**La próxima migración es la 218** — la última numerada en el repo es
+`217_el_detector_de_duplicados_ve_lo_que_la_rls_tapa`, y el ledger de prod está alineado
+con ella. Igual, confirmá el número contra las tres fuentes justo antes de aplicar: el
 número se reserva **aplicando**, no escribiendo el archivo.
 
 (Esta línea decía 206 hasta el 2026-09-08, con las 206–209 ya aplicadas: la
-numeración del repo avanzó cuatro veces sin que nadie la corrigiera. Si aplicás
-una migración, actualizá también esta línea. Última actualización: 214, el 2026-09-09.)
+numeración del repo avanzó cuatro veces sin que nadie la corrigiera. Volvió a pasar el
+2026-09-09: decía 215 con la 215 y la 216 ya aplicadas y sus archivos en `main`, así que
+quien fue a escribir la 217 leyó "escribí la 215" y habría pisado dos migraciones vivas.
+Si aplicás una migración, actualizá también esta línea. Última actualización: 217, el
+2026-09-09.)
 
 Las 197–202 no tienen prosa acá (quedaron sin documentar en su momento). Las 203, 204,
 205, 212, 213 y 214 sí:
@@ -233,6 +236,28 @@ Las 206–209 tampoco tienen prosa acá. Las 210 y 211 sí:
   le inyecta código al primero). **No toca ninguna fila**: la columna nace en `false` y todo
   el predicado nuevo es una tautología mientras nadie marque a nadie. Verificado contra prod
   con un usuario de cada rol.
+
+- **217** hace que el detector de duplicados por ubicación de `createCliente` vea por
+  encima de la RLS (issue #543). Corría **como el usuario**, o sea que a un preventista le
+  ocultaba los clientes de OTRO preventista: la consulta volvía vacía, no avisaba nada y
+  se creaba un CLON. Es la misma forma de fail-open que la 214 documenta en
+  `cliente_preventistas_no_reservado` —un guard que consulta bajo la policy que le tapa la
+  fila no falla, **aprueba**—, y por eso `existe_cliente_en_ubicacion` es SECURITY DEFINER.
+  Verificado impersonando: el cliente 22 existe en esas coordenadas y la consulta del
+  detector con el JWT de Osvaldo devolvía 0 filas. Importó más con el tiempo sin que nadie
+  tocara el código: cuando se escribió el detector la base era casi toda huérfanos (401 vs
+  26, mig 028) y hoy es al revés (598 asignados vs 124). **Devuelve un booleano**, nunca la
+  fila: si devolviera el nombre estaríamos filtrando por la ventana lo que la policy tapa
+  por la puerta, y el front por eso muestra un mensaje sin identidad y avisa a admin y
+  encargado por `_notificar_sucursal_roles` (con dedupe de 24 h, porque el alta se
+  reintenta). El front conserva su consulta con RLS y llama a la RPC **solo si aquella no
+  encontró nada**: así el caso visible no cambia en nada y la función nunca tiene que
+  contestar "¿este usuario puede verlo?", que obligaría a copiar `mt_clientes_select` aden-
+  tro y a mantener las dos sincronizadas. Mira a los **inactivos** a propósito (migs
+  199/200). Un `reservado_admin` (214) cae en la rama de "no lo ve": bloquea el clon sin
+  delatar que está reservado. **El detector por RAZÓN SOCIAL se deja ciego a propósito**:
+  ahí el mismo booleano sería fácil de sondear probando nombres, así que el clon por nombre
+  contra un cliente ajeno se sigue pudiendo crear —decisión tomada, no olvido—.
 
 La **195** le da a la cabecera la columna `compras.bonificaciones`, que es donde se resta
 una bonificación general: el `subtotal` es el neto de los RENGLONES y lo clava `COMPRA-A2`

--- a/src/components/layout/DbNotificationBell.tsx
+++ b/src/components/layout/DbNotificationBell.tsx
@@ -19,6 +19,9 @@ import {
 
 function rutaDeNotificacion(n: NotificacionDB): string | null {
   if (n.entidad_tipo === 'movimiento_sucursal') return '/transferencias'
+  // Alta duplicada bloqueada (mig 217): el admin tiene que ir a ver el cliente
+  // que chocó y decidir si se lo asigna al preventista que lo intentó.
+  if (n.entidad_tipo === 'cliente') return '/clientes'
   return null
 }
 

--- a/src/hooks/queries/useClientesQuery.duplicadoOculto.test.tsx
+++ b/src/hooks/queries/useClientesQuery.duplicadoOculto.test.tsx
@@ -1,0 +1,220 @@
+/**
+ * Tests del detector de duplicados por ubicación cuando la RLS le tapa la fila
+ * (issue #543, mig 217).
+ *
+ * EL BUG
+ * ------
+ * El detector consultaba `clientes` COMO EL USUARIO, o sea bajo la RLS. Un
+ * preventista no ve los clientes de OTRO preventista, así que la consulta
+ * volvía vacía, el detector no avisaba nada y se creaba un CLON. Es la forma de
+ * fail-open que la mig 214 ya había documentado: un guard que consulta bajo la
+ * policy que le tapa la fila no falla — aprueba.
+ *
+ * Verificado contra prod impersonando (que es lo único que lo prueba de
+ * verdad): el cliente 22 existe en esas coordenadas y la consulta del detector
+ * con el JWT de Osvaldo devolvía 0 filas.
+ *
+ * QUÉ NO PUEDEN PROBAR ESTOS TESTS
+ * --------------------------------
+ * Que la RPC vea por encima de la RLS: eso vive en la base y no lo ven `tsc`,
+ * ni eslint, ni vitest. Está verificado en el cuerpo de la migración.
+ *
+ * QUÉ SÍ FIJAN — lo que la app puede romper sola y en silencio:
+ *
+ * 1. Que se consulte a la RPC cuando la consulta con RLS no encontró nada. Si
+ *    alguien la saca, vuelve el bug entero y ningún test de tipos se entera.
+ * 2. Que el mensaje NO revele la identidad del cliente que no le corresponde
+ *    ver. Filtrar el nombre por el mensaje de error sería filtrar por la
+ *    ventana lo que la policy tapa por la puerta.
+ * 3. Que ante un error de la RPC NO se cree el cliente (fail-closed). Seguir de
+ *    largo es volver al guard que no puede mirar y aprueba igual.
+ */
+import React from 'react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+
+const insertSpy = vi.fn()
+const rpc = vi.fn()
+const from = vi.fn()
+
+vi.mock('../supabase/base', () => ({
+  supabase: {
+    from: (...args: unknown[]) => from(...args),
+    rpc: (...args: unknown[]) => rpc(...args),
+  },
+}))
+
+vi.mock('../../contexts/SucursalContext', () => ({
+  useSucursal: () => ({ currentSucursalId: 1 }),
+}))
+
+import { useCrearClienteMutation } from './useClientesQuery'
+
+/** El cliente que existe en esas coordenadas y que el preventista NO puede ver. */
+const CLIENTE_AJENO = { id: '22', nombre_fantasia: 'LOS PORTEÑOS', razon_social: 'Los Porteños' }
+
+const CLIENTE_NUEVO = {
+  razon_social: 'Kiosco Nuevo',
+  nombre_fantasia: 'Kiosco Nuevo',
+  direccion: 'San Martín 100',
+  latitud: -26.8355312,
+  longitud: -65.2223494,
+}
+
+/**
+ * `cercanosVisibles` es lo que la consulta CON RLS le muestra al usuario: vacío
+ * cuando el cliente existe pero es de otro preventista, que es el caso de #543.
+ */
+function montarSupabase(cercanosVisibles: unknown[]): void {
+  from.mockImplementation((tabla: string) => {
+    const builder: Record<string, unknown> = {}
+    if (tabla === 'clientes') {
+      builder.insert = (filas: unknown) => { insertSpy(filas); return builder }
+      builder.select = () => builder
+      builder.eq = () => builder
+      builder.gte = () => builder
+      builder.lte = () => builder
+      builder.limit = () => Promise.resolve({ data: cercanosVisibles, error: null })
+      builder.single = () => Promise.resolve({ data: { id: '99' }, error: null })
+      return builder
+    }
+    builder.delete = () => builder
+    builder.eq = () => Promise.resolve({ error: null })
+    builder.insert = () => Promise.resolve({ error: null })
+    return builder
+  })
+}
+
+function wrapper({ children }: { children: React.ReactNode }): React.ReactElement {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false }, mutations: { retry: false } } })
+  return <QueryClientProvider client={qc}>{children}</QueryClientProvider>
+}
+
+const crear = async (datos = CLIENTE_NUEVO) => {
+  const { result } = renderHook(() => useCrearClienteMutation(), { wrapper })
+  return result.current.mutateAsync(datos)
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('duplicado que la RLS le tapa al preventista', () => {
+  describe('lo detecta aunque no lo vea', () => {
+    beforeEach(() => {
+      // La consulta con RLS no devuelve nada (el cliente es de otro), pero la
+      // base sí sabe que está.
+      montarSupabase([])
+      rpc.mockResolvedValue({ data: true, error: null })
+    })
+
+    it('le pregunta a la RPC cuando la consulta con RLS vino vacía', async () => {
+      await expect(crear()).rejects.toThrow()
+      expect(rpc).toHaveBeenCalledWith('existe_cliente_en_ubicacion', {
+        p_latitud: CLIENTE_NUEVO.latitud,
+        p_longitud: CLIENTE_NUEVO.longitud,
+      })
+    })
+
+    it('no crea el cliente', async () => {
+      await expect(crear()).rejects.toThrow()
+      expect(insertSpy).not.toHaveBeenCalled()
+    })
+
+    it('avisa que ya hay uno en esa ubicación', async () => {
+      await expect(crear()).rejects.toThrow(/[Yy]a existe un cliente en esta ubicación/)
+    })
+
+    it('dice que administración ya fue avisada', async () => {
+      await expect(crear()).rejects.toThrow(/administración/)
+    })
+  })
+
+  describe('no revela de quién se trata', () => {
+    beforeEach(() => {
+      montarSupabase([])
+      rpc.mockResolvedValue({ data: true, error: null })
+    })
+
+    // El corazón del asunto: el mensaje es lo único que vuelve al preventista.
+    // Si lleva el nombre, la RLS deja de servir para nada.
+    it('el mensaje no trae el nombre de fantasía del cliente ajeno', async () => {
+      await expect(crear()).rejects.toThrow(
+        expect.not.stringContaining(CLIENTE_AJENO.nombre_fantasia) as unknown as string,
+      )
+    })
+
+    it('el mensaje no trae la razón social ni el id', async () => {
+      let mensaje: string | null = null
+      try { await crear() } catch (e) { mensaje = (e as Error).message }
+      // Sin esto el test pasa solo: si el alta NO falla no hay mensaje, y
+      // "el mensaje vacío no contiene el nombre" es verdad y no prueba nada.
+      expect(mensaje).not.toBeNull()
+      expect(mensaje).not.toContain(CLIENTE_AJENO.razon_social)
+      expect(mensaje).not.toContain(`#${CLIENTE_AJENO.id}`)
+    })
+
+    it('la RPC recibe solo coordenadas: nada del cliente que se está creando', async () => {
+      await expect(crear()).rejects.toThrow()
+      expect(Object.keys(rpc.mock.calls[0][1] as object).sort()).toEqual(['p_latitud', 'p_longitud'])
+    })
+  })
+
+  describe('cuando el cliente SÍ es visible, no cambia nada', () => {
+    beforeEach(() => {
+      montarSupabase([{ ...CLIENTE_AJENO, activo: true }])
+      rpc.mockResolvedValue({ data: true, error: null })
+    })
+
+    it('sigue diciendo cuál es, porque el usuario ya lo puede ver', async () => {
+      await expect(crear()).rejects.toThrow(new RegExp(CLIENTE_AJENO.nombre_fantasia))
+    })
+
+    it('no llama a la RPC: ya sabe la respuesta y no hace falta molestar a administración', async () => {
+      await expect(crear()).rejects.toThrow()
+      expect(rpc).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('fail-closed: si no puede verificar, no crea', () => {
+    beforeEach(() => {
+      montarSupabase([])
+      rpc.mockResolvedValue({ data: null, error: { message: 'boom' } })
+    })
+
+    it('no crea el cliente cuando la RPC falla', async () => {
+      await expect(crear()).rejects.toThrow()
+      expect(insertSpy).not.toHaveBeenCalled()
+    })
+
+    it('lo dice, en vez de crear a ciegas', async () => {
+      await expect(crear()).rejects.toThrow(/No se pudo verificar/)
+    })
+  })
+
+  describe('sin duplicado, el alta sigue de largo', () => {
+    beforeEach(() => {
+      montarSupabase([])
+      rpc.mockResolvedValue({ data: false, error: null })
+    })
+
+    it('crea el cliente', async () => {
+      await crear()
+      expect(insertSpy).toHaveBeenCalled()
+    })
+  })
+
+  describe('sin coordenadas no hay nada que consultar', () => {
+    beforeEach(() => {
+      montarSupabase([])
+      rpc.mockResolvedValue({ data: false, error: null })
+    })
+
+    it('no llama a la RPC si el cliente no trae lat/long', async () => {
+      await crear({ ...CLIENTE_NUEVO, latitud: undefined, longitud: undefined } as never)
+      expect(rpc).not.toHaveBeenCalled()
+      expect(insertSpy).toHaveBeenCalled()
+    })
+  })
+})

--- a/src/hooks/queries/useClientesQuery.ts
+++ b/src/hooks/queries/useClientesQuery.ts
@@ -263,6 +263,40 @@ async function createCliente(cliente: ClienteCreateInput, sucursalId: number | n
         `Si necesitás crear otro, modificá ligeramente la dirección.`
       )
     }
+
+    // Que la consulta de arriba no haya encontrado nada NO significa que no
+    // haya nadie: pasa por la RLS, que a un preventista le tapa los clientes de
+    // OTRO preventista y los reservados a administración (mig 214). Con 598 de
+    // 722 clientes asignados, el detector era ciego para la mayoría de la base
+    // y dejaba crear el clon sin avisar nada (#543).
+    //
+    // `existe_cliente_en_ubicacion` (mig 217) es SECURITY DEFINER y ve por
+    // encima de la policy. Devuelve un booleano pelado a propósito: si
+    // devolviera el nombre estaríamos filtrando por la ventana lo que la RLS
+    // tapa por la puerta. Por eso este mensaje no dice cuál es —no se puede— y
+    // la RPC le avisa a administración, que sí lo ve entero.
+    const { data: hayOculto, error: errorOculto } = await supabase
+      .rpc('existe_cliente_en_ubicacion', {
+        p_latitud: cliente.latitud,
+        p_longitud: cliente.longitud,
+      })
+
+    // Fail-closed, como el chequeo de nombre duplicado: si no se pudo
+    // verificar, no se crea. Seguir de largo ante el error es volver al bug —
+    // un guard que no puede mirar y aprueba igual.
+    if (errorOculto) {
+      throw new Error(
+        'No se pudo verificar si ya hay un cliente en esta ubicación. No se creó nada; probá de nuevo.'
+      )
+    }
+
+    if (hayOculto) {
+      throw new Error(
+        'Ya existe un cliente en esta ubicación, pero no está en tu cartera, así que no podemos mostrarte cuál. ' +
+        'Ya le avisamos a administración para que lo revise. ' +
+        'Si de verdad es otro comercio en la misma puerta, pediles que te lo habiliten.'
+      )
+    }
   }
 
   const { preventista_ids, descuentos_categoria, ...clienteFields } = cliente


### PR DESCRIPTION
Cierra #543.

> **La migración 217 ya está aplicada en prod.** Se aplicó para reservar el número
> (se reserva aplicando, no escribiendo el archivo). Mientras este PR no se mergee,
> la función existe pero no la llama nadie: es inofensiva. Al mergear, el front
> empieza a usarla.

## El bug

El detector de duplicados por ubicación de `createCliente` consultaba `clientes`
**como el usuario**, o sea bajo la RLS. Un preventista no ve los clientes asignados a
**otro** preventista, así que la consulta volvía vacía, no avisaba nada, y se creaba un
**clon** del mismo cliente.

Es la misma forma de fail-open que la mig 214 ya había documentado en
`cliente_preventistas_no_reservado`: un guard que consulta bajo la policy que justamente
le tapa la fila no falla — **aprueba**. Por eso `existe_cliente_en_ubicacion` es
`SECURITY DEFINER` y no invoker.

Importaba más con el tiempo sin que nadie tocara ese código: cuando se escribió el
detector la base era casi toda huérfanos (401 vs 26 asignados, mig 028); hoy está dada
vuelta, **598 asignados vs 124 huérfanos**.

## Verificado contra prod, impersonando

La RLS no la ve `tsc`, ni eslint, ni vitest. Se probó con `SET ROLE authenticated` +
`request.jwt.claims`, dentro de transacciones que después se revierten. Cliente 22
(`LOS PORTEÑOS`, sucursal 1, de Marcelo y Víctor):

| caso | valor |
|---|---|
| osvaldo: `SELECT` directo sobre `clientes` (RLS) | 0 |
| osvaldo: lo ve por coordenadas (RLS) | 0 |
| **osvaldo: la RPC lo detecta igual** | **true** ← el arreglo |
| osvaldo: ubicación libre | false |
| víctor (es suyo): lo ve por RLS | 1 ← el caso visible no cambió |
| juan (sucursal 2): sondea la sucursal 1 | false |
| `anon` puede ejecutarla | permission denied |
| tipo de retorno | `boolean` |
| destinatarios del aviso | admin |

Prod quedó con **0 notificaciones** de prueba.

## Qué se le dice al preventista

No se le puede mostrar el nombre ni la dirección de un cliente de otro —sería filtrar por
la ventana lo que la policy tapa por la puerta— pero tampoco se lo puede dejar crear el
clon:

- **lo ve** → mensaje de siempre, con nombre, y con el camino de reactivación si está
  inactivo. Sin cambios.
- **no lo ve** → mensaje genérico, sin identidad, y la RPC avisa **sola** a admin y
  encargado vía `_notificar_sucursal_roles` (con dedupe de 24 h: el alta se reintenta, y
  una campanita que grita 20 veces lo mismo se deja de mirar). El aviso al admin **sí**
  lleva nombre e id, porque los ve igual y sin eso no le sirve.

## El detalle que evita duplicar la RLS

El front conserva su consulta con RLS, que va **primero**, y llama a la RPC **solo si
aquella no encontró nada**. Así la función nunca tiene que contestar "¿este usuario puede
verlo?", que obligaría a copiar `mt_clientes_select` adentro y a mantener las dos
sincronizadas para siempre. Un `reservado_admin` (214) cae solo en la segunda rama:
bloquea el clon **sin delatar** que el cliente está reservado, que es justo el que más
interesa que no se clone.

## Superficie

- Devuelve **un booleano**, nunca la fila. Acotada a `current_sucursal_id()` para que no
  se pueda sondear otra sucursal.
- Fail-closed de los dos lados: la función tira si no hay sesión o sucursal, y el front
  **no crea el cliente** si la RPC falla.
- ACL en la misma migración: `REVOKE ALL … FROM PUBLIC, anon` + `GRANT EXECUTE …
  TO authenticated`, con bloque de verificación. Una función DEFINER que ve todos los
  clientes de una sucursal y que pueda llamar cualquiera sería un agujero peor que el bug.
- Mira a los **inactivos** a propósito (migs 199/200). No "arreglarlo".

**Lo que sí se revela, a sabiendas:** que *hay* alguien en esas coordenadas. No se puede
decir "no crees esto" sin admitir que hay algo ahí — es el piso del problema. Sondearlo
pide el lat/long a 6 decimales (~0,2 m), o sea estar parado en la puerta.

**El detector por razón social se deja ciego**, decidido explícitamente: ahí el mismo
booleano sería fácil de sondear probando nombres. O sea que el clon **por nombre** contra
un cliente ajeno se sigue pudiendo crear — decisión tomada, no olvido, y escrita como tal
en la migración.

## El número de migración

El MANIFEST decía "la próxima es la 215", pero el ledger ya tenía **215 y 216** aplicadas
y sus archivos estaban en `main`: quien fuera a escribir la 217 leía "escribí la 215" y
pisaba dos migraciones vivas. Es la trampa 3 de `CLAUDE.md` por cuarta vez. Se corrigió la
línea y se le agregó la nota. El número se confirmó contra el ledger **y** contra todas
las ramas remotas justo antes de aplicar.

## Tests

13 nuevos. Fijan que se consulte a la RPC cuando la consulta con RLS vino vacía, que el
mensaje **no** lleve nombre, razón social ni id, y que ante un error de la RPC no se cree
nada. **Verificado que fallan contra el código viejo:** sacando la llamada caen 8 de 13.
(Uno de ellos pasaba vacuosamente al principio —sin excepción no hay mensaje, y "el
mensaje vacío no contiene el nombre" es verdad y no prueba nada—; se corrigió.)

`typecheck`, `lint`, `test:run` (1655 tests, **sin `.env`**) y `build`: verde.

🤖 Generated with [Claude Code](https://claude.com/claude-code)