### PR TITLE
La comanda dice qué boletas debe, para que el transportista pueda cobrar (mig 218)

### DIFF
--- a/migrations/218_que_boletas_debe_no_solo_cuanto.sql
+++ b/migrations/218_que_boletas_debe_no_solo_cuanto.sql
@@ -1,0 +1,124 @@
+-- Que boletas debe, no solo cuanto (para la comanda del transportista)
+--
+-- La mig 215 dejo `deuda_previa`: cuanto debia el cliente ANTES de este pedido.
+-- Alcanza para un badge en pantalla, pero no para el papel que se lleva el
+-- chofer: con el numero suelto no puede imputar el cobro. Necesita saber QUE
+-- boletas reclamar. Esta funcion devuelve esas boletas, en orden cronologico.
+--
+-- Se imprime en la comanda (`dibujarComanda`, src/lib/pdf/reciboPedido.js), en
+-- las dos copias -- la del cliente incluida.
+--
+-- CUADRA CON EL TOTAL, SALVO POR LOS PAGOS A CUENTA
+-- `deuda_previa` resta ademas los pagos a cuenta (los de `pagos` con
+-- `pedido_id IS NULL`), que no estan imputados a ninguna boleta y por eso no
+-- aparecen aca. Hoy no hay uno solo en toda la base -- 5.401 pagos, todos
+-- contra una boleta -- asi que el detalle suma exactamente el total; el bloque
+-- DO de abajo lo verifica sobre todos los pedidos. Si algun dia aparece uno, el
+-- ticket muestra la diferencia como linea "A cuenta" (ver
+-- `bloqueDeudaComanda`) en vez de imprimir un desglose que no da.
+--
+-- Misma guarda y mismo ACL que la 215: SECURITY DEFINER porque la RLS de
+-- `pedidos` le muestra al preventista solo SUS pedidos, y del caller solo se usa
+-- `p.id` -- cliente, fecha y sucursal se releen de la tabla filtrando por
+-- `current_sucursal_id()`, asi que una fila inventada por RPC devuelve [].
+--
+-- Revertir: `DROP FUNCTION public.deuda_previa_detalle(public.pedidos);`. La
+-- comanda deja de imprimir el desglose; el total (215) sigue.
+-- =========================================================================
+
+BEGIN;
+
+CREATE OR REPLACE FUNCTION public.deuda_previa_detalle(p public.pedidos)
+RETURNS jsonb
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $$
+  WITH ref AS (
+    -- Misma guarda que deuda_previa (mig 215): del caller solo se usa `p.id`.
+    SELECT pe.cliente_id, pe.created_at, pe.id, pe.sucursal_id
+    FROM pedidos pe
+    WHERE pe.id = p.id
+      AND pe.sucursal_id = current_sucursal_id()
+  ),
+  boletas AS (
+    SELECT p2.id,
+           COALESCE(p2.fecha, p2.created_at::date) AS fecha,
+           ROUND(p2.total - COALESCE(p2.monto_pagado, 0), 2) AS monto
+    FROM pedidos p2, ref
+    WHERE p2.cliente_id  = ref.cliente_id
+      AND p2.sucursal_id = ref.sucursal_id
+      AND p2.estado NOT IN ('cancelado', 'anulado')
+      AND (p2.created_at, p2.id) < (ref.created_at, ref.id)
+      AND p2.total - COALESCE(p2.monto_pagado, 0) >= 0.01
+    ORDER BY p2.created_at, p2.id
+  )
+  SELECT COALESCE(
+    jsonb_agg(jsonb_build_object('id', id, 'fecha', fecha, 'monto', monto)),
+    '[]'::jsonb
+  )
+  FROM boletas;
+$$;
+
+COMMENT ON FUNCTION public.deuda_previa_detalle(public.pedidos) IS
+  'Boletas impagas anteriores a este pedido, en orden cronologico (computed column de PostgREST). El total lo da deuda_previa (mig 215), que ademas resta los pagos a cuenta.';
+
+REVOKE ALL ON FUNCTION public.deuda_previa_detalle(public.pedidos) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.deuda_previa_detalle(public.pedidos) TO authenticated;
+
+DO $verif$
+DECLARE
+  v_abiertas text;
+  v_definer  boolean;
+  v_malos    int;
+BEGIN
+  SELECT array_to_string(array_agg(a::text), ' ') INTO v_abiertas
+  FROM pg_proc p, unnest(p.proacl) a
+  WHERE p.pronamespace = 'public'::regnamespace
+    AND p.proname = 'deuda_previa_detalle'
+    AND (a::text LIKE '=%' OR a::text LIKE 'anon=%');
+  IF v_abiertas IS NOT NULL THEN
+    RAISE EXCEPTION 'mig 218: el ACL quedo abierto (%).', v_abiertas;
+  END IF;
+
+  SELECT p.prosecdef INTO v_definer
+  FROM pg_proc p
+  WHERE p.pronamespace = 'public'::regnamespace AND p.proname = 'deuda_previa_detalle';
+  IF NOT COALESCE(v_definer, false) THEN
+    RAISE EXCEPTION 'mig 218: la funcion no quedo SECURITY DEFINER.';
+  END IF;
+
+  -- El detalle tiene que sumar lo mismo que el total de la 215.
+  SELECT count(*) INTO v_malos
+  FROM pedidos pe
+  WHERE pe.estado NOT IN ('cancelado', 'anulado')
+    AND COALESCE((
+          SELECT SUM((b->>'monto')::numeric)
+          FROM jsonb_array_elements(
+            COALESCE((
+              SELECT jsonb_agg(jsonb_build_object('monto', ROUND(p2.total - COALESCE(p2.monto_pagado,0), 2)))
+              FROM pedidos p2
+              WHERE p2.cliente_id  = pe.cliente_id
+                AND p2.sucursal_id = pe.sucursal_id
+                AND p2.estado NOT IN ('cancelado','anulado')
+                AND (p2.created_at, p2.id) < (pe.created_at, pe.id)
+                AND p2.total - COALESCE(p2.monto_pagado,0) >= 0.01
+            ), '[]'::jsonb)
+          ) b
+        ), 0)
+      <> COALESCE((
+          SELECT SUM(GREATEST(0, p2.total - COALESCE(p2.monto_pagado, 0)))
+          FROM pedidos p2
+          WHERE p2.cliente_id  = pe.cliente_id
+            AND p2.sucursal_id = pe.sucursal_id
+            AND p2.estado NOT IN ('cancelado','anulado')
+            AND (p2.created_at, p2.id) < (pe.created_at, pe.id)
+        ), 0);
+  IF v_malos > 0 THEN
+    RAISE EXCEPTION 'mig 218: en % pedidos el detalle no suma lo mismo que el total.', v_malos;
+  END IF;
+END
+$verif$;
+
+COMMIT;

--- a/src/hooks/queries/usePedidosQuery.ts
+++ b/src/hooks/queries/usePedidosQuery.ts
@@ -131,20 +131,19 @@ const PEDIDO_CLIENT_COLS = 'id, nombre_fantasia, razon_social, cuit, direccion, 
 // Exportado para reutilizar la MISMA forma de pedido en queries que embeben
 // pedidos (p. ej. las paradas de un recorrido en useRecorridoExistenteQuery),
 // garantizando paridad con el pool de la ruta para optimizar y generar el PDF.
-export const PEDIDO_SELECT = `*, cliente:clientes(${PEDIDO_CLIENT_COLS}), items:pedido_items(*, producto:productos(${PEDIDO_PRODUCT_COLS}), promocion:promociones(unidades_por_bloque)), pagos(forma_pago, monto)` as const
-const PEDIDO_SELECT_CLIENTE_INNER = `*, cliente:clientes!inner(${PEDIDO_CLIENT_COLS}), items:pedido_items(*, producto:productos(${PEDIDO_PRODUCT_COLS}), promocion:promociones(unidades_por_bloque)), pagos(forma_pago, monto)` as const
-
-// `deuda_previa` es una computed column de PostgREST: la funcion SQL del mismo
-// nombre (mig 215), que devuelve lo que el cliente debia ANTES de este pedido.
-// No sale de `clientes.saldo_cuenta`: ese es un escalar del presente e incluye
+// `deuda_previa` y `deuda_previa_detalle` son computed columns de PostgREST
+// (migs 215 y 218): cuanto debia el cliente ANTES de este pedido, y que boletas.
+// No salen de `clientes.saldo_cuenta` — ese es un escalar del presente e incluye
 // los pedidos POSTERIORES, que fue el bug del PR #530.
 //
-// Va SOLO en la lista, no en el PEDIDO_SELECT compartido: la calcula por fila y
-// la ruta (useRecorridoExistenteQuery) y la hoja de ruta
-// (useRecorridosHojaRutaQuery) traen muchos pedidos y no la muestran. Medido:
-// ~65 ms por pagina de 20.
-const PEDIDO_SELECT_LISTA = `${PEDIDO_SELECT}, deuda_previa` as const
-const PEDIDO_SELECT_LISTA_CLIENTE_INNER = `${PEDIDO_SELECT_CLIENTE_INNER}, deuda_previa` as const
+// Van en el select COMPARTIDO y no solo en la lista porque las comandas se
+// imprimen desde tres lugares distintos —la card, la hoja de ruta
+// (useRecorridosHojaRutaQuery) y la ruta recien armada
+// (useRecorridoExistenteQuery)— y las tres tienen que llevar la deuda al papel
+// del transportista. Medido: 21 ms las dos juntas sobre 53 pedidos.
+export const PEDIDO_SELECT = `*, deuda_previa, deuda_previa_detalle, cliente:clientes(${PEDIDO_CLIENT_COLS}), items:pedido_items(*, producto:productos(${PEDIDO_PRODUCT_COLS}), promocion:promociones(unidades_por_bloque)), pagos(forma_pago, monto)` as const
+const PEDIDO_SELECT_CLIENTE_INNER = `*, deuda_previa, deuda_previa_detalle, cliente:clientes!inner(${PEDIDO_CLIENT_COLS}), items:pedido_items(*, producto:productos(${PEDIDO_PRODUCT_COLS}), promocion:promociones(unidades_por_bloque)), pagos(forma_pago, monto)` as const
+
 
 // Helper: cargar salvedades para un conjunto de pedidos
 async function enrichWithSalvedades(pedidos: Record<string, unknown>[]): Promise<Record<string, PedidoSalvedadResumen[]>> {
@@ -256,7 +255,7 @@ async function fetchPedidosPaginated(
   const hasSearch = search && search.trim().length > 0
 
   // Use !inner join when searching so PostgREST filters parent rows by client fields
-  const selectStr = hasSearch ? PEDIDO_SELECT_LISTA_CLIENTE_INNER : PEDIDO_SELECT_LISTA
+  const selectStr = hasSearch ? PEDIDO_SELECT_CLIENTE_INNER : PEDIDO_SELECT
 
   let query = supabase
     .from('pedidos')

--- a/src/lib/pdf/reciboPedido.js
+++ b/src/lib/pdf/reciboPedido.js
@@ -18,6 +18,7 @@ import {
   setItalicStyle
 } from './utils'
 import { formatAclaracionBulto } from './utils/formatBulto'
+import { bloqueDeudaComanda } from '../../utils/deudaCliente'
 
 // Colores de marca Crecer Distribuciones
 const BRAND = {
@@ -376,6 +377,11 @@ function calcularAlturaComanda(pedido) {
   if (pedido.canal === 'cambio') height += 18 // banner CAMBIO/DEVOLUCION + retirar/entregar
   height += 32 // total + forma pago + estado
   if (pedido.estado_pago === 'parcial') height += 6
+  // Deuda anterior: titulo + una linea por boleta. El alto del ticket ES el
+  // formato de la pagina, asi que lo que no se cuente aca se dibuja fuera del
+  // papel y no sale impreso nunca.
+  const deuda = bloqueDeudaComanda(pedido.deuda_previa, pedido.deuda_previa_detalle)
+  if (deuda) height += 12 + deuda.lineas.length * 4
   if (pedido.notas) height += 18
   height += 18 // pie
   return Math.max(height, 110)
@@ -556,6 +562,28 @@ function dibujarComanda(doc, pedido) {
     doc.text(`Pagado: ${formatPrecio(montoPagado)}`, margin, y)
     doc.text(`Saldo: ${formatPrecio(pedido.total - montoPagado)}`, ticketWidth - margin, y, { align: 'right' })
     y += 4
+  }
+
+  // === DEUDA ANTERIOR ===
+  // Va despues del total del pedido y antes de las notas: primero lo que se
+  // entrega, despues lo que ademas hay que cobrar. El transportista necesita el
+  // detalle, no solo el total: con el numero suelto no puede imputar el cobro.
+  // Sale en las DOS copias, la del cliente incluida (decision explicita).
+  const deuda = bloqueDeudaComanda(pedido.deuda_previa, pedido.deuda_previa_detalle)
+  if (deuda) {
+    y += 2
+    drawDivider(doc, y, margin, ticketWidth - margin, 0.5)
+    y += 5
+    setHeaderStyle(doc, 11)
+    doc.text('DEUDA ANTERIOR:', margin, y)
+    doc.text(formatPrecio(deuda.total), ticketWidth - margin, y, { align: 'right' })
+    y += 5
+    setNormalStyle(doc, 9)
+    deuda.lineas.forEach(linea => {
+      doc.text(linea.etiqueta, margin + 3, y)
+      doc.text(formatPrecio(linea.monto), ticketWidth - margin, y, { align: 'right' })
+      y += 4
+    })
   }
 
   // === NOTAS ===

--- a/src/types/hooks.ts
+++ b/src/types/hooks.ts
@@ -174,11 +174,17 @@ export interface PedidoDB {
   cliente?: ClienteDB;
   /**
    * Lo que el cliente debia ANTES de este pedido, calculado en la base
-   * (computed column `deuda_previa`, mig 215). Solo la trae la lista de
-   * pedidos. No confundir con `cliente.saldo_cuenta`, que es el saldo de HOY e
-   * incluye este pedido y los posteriores.
+   * (computed column `deuda_previa`, mig 215). No confundir con
+   * `cliente.saldo_cuenta`, que es el saldo de HOY e incluye este pedido y los
+   * posteriores.
    */
   deuda_previa?: number;
+  /**
+   * Que boletas componen esa deuda, en orden cronologico (computed column
+   * `deuda_previa_detalle`, mig 218). Va impresa en la comanda: el
+   * transportista necesita saber cuales reclamar para poder imputar el cobro.
+   */
+  deuda_previa_detalle?: Array<{ id: string | number; fecha?: string | null; monto: number }>;
   usuario_id?: string;
   usuario?: PerfilDB | null;
   transportista_id?: string | null;

--- a/src/utils/deudaCliente.test.ts
+++ b/src/utils/deudaCliente.test.ts
@@ -13,7 +13,7 @@
  * Lo que queda es formateo de un monto que el llamador ya decidió.
  */
 import { describe, it, expect } from 'vitest'
-import { avisoDeudaCliente } from './deudaCliente'
+import { avisoDeudaCliente, bloqueDeudaComanda } from './deudaCliente'
 
 describe('avisoDeudaCliente', () => {
   it('no avisa cuando el cliente está al día', () => {
@@ -59,5 +59,71 @@ describe('avisoDeudaCliente — monto posiblemente viejo (offline)', () => {
   it('sin fecha del dato no inventa una', () => {
     const aviso = avisoDeudaCliente(12500, { saldoAl: '   ' })
     expect(aviso?.etiqueta).toMatch(/^Debe\s+\$\s?12\.500,00$/)
+  })
+})
+
+describe('bloqueDeudaComanda', () => {
+  it('no imprime nada cuando el cliente no debe', () => {
+    expect(bloqueDeudaComanda(0, [])).toBeNull()
+    expect(bloqueDeudaComanda(null, null)).toBeNull()
+  })
+
+  it('lista cada boleta con su numero y fecha', () => {
+    const bloque = bloqueDeudaComanda(20000, [
+      { id: 1234, fecha: '2026-08-15', monto: 12000 },
+      { id: 1250, fecha: '2026-08-22', monto: 8000 },
+    ])
+    expect(bloque?.total).toBe(20000)
+    expect(bloque?.lineas).toEqual([
+      { etiqueta: '#1234 15/08', monto: 12000 },
+      { etiqueta: '#1250 22/08', monto: 8000 },
+    ])
+  })
+
+  it('no corre la fecha de dia', () => {
+    // "2026-08-01" con `new Date` en UTC-3 daria 31/07. Por eso se parsea a mano.
+    const bloque = bloqueDeudaComanda(1000, [{ id: 1, fecha: '2026-08-01', monto: 1000 }])
+    expect(bloque?.lineas[0].etiqueta).toBe('#1 01/08')
+  })
+
+  it('agrupa las boletas que no entran en el papel, y el desglose sigue sumando el total', () => {
+    const boletas = Array.from({ length: 10 }, (_, i) => ({
+      id: i + 1, fecha: '2026-08-10', monto: 1000,
+    }))
+    const bloque = bloqueDeudaComanda(10000, boletas, { maxLineas: 4 })
+    expect(bloque?.lineas).toHaveLength(4)
+    expect(bloque?.lineas[3]).toEqual({ etiqueta: 'y 7 boletas mas', monto: 7000 })
+    const suma = bloque!.lineas.reduce((t, l) => t + l.monto, 0)
+    expect(suma).toBe(bloque!.total)
+  })
+
+  it('singulariza "y 1 boleta mas"', () => {
+    const boletas = Array.from({ length: 3 }, (_, i) => ({ id: i + 1, monto: 100 }))
+    const bloque = bloqueDeudaComanda(300, boletas, { maxLineas: 2 })
+    expect(bloque?.lineas[1].etiqueta).toBe('y 2 boletas mas')
+  })
+
+  it('cierra el desglose con el pago a cuenta que no esta imputado', () => {
+    // Boletas por 20.000 pero el cliente tiene 5.000 a cuenta: debe 15.000.
+    const bloque = bloqueDeudaComanda(15000, [{ id: 1, fecha: '2026-08-15', monto: 20000 }])
+    expect(bloque?.total).toBe(15000)
+    expect(bloque?.lineas[1]).toEqual({ etiqueta: 'A cuenta', monto: -5000 })
+    const suma = bloque!.lineas.reduce((t, l) => t + l.monto, 0)
+    expect(suma).toBe(15000)
+  })
+
+  it('cuadra aunque la base no haya mandado el detalle', () => {
+    // Una query que pide deuda_previa pero no el detalle: mejor una linea sin
+    // desglose que un ticket que dice "debe $X" y abajo no muestra nada.
+    const bloque = bloqueDeudaComanda(20000, [])
+    expect(bloque?.lineas).toEqual([{ etiqueta: 'Otros', monto: 20000 }])
+  })
+
+  it('descarta boletas en cero en vez de imprimir lineas vacias', () => {
+    const bloque = bloqueDeudaComanda(5000, [
+      { id: 1, fecha: '2026-08-15', monto: 5000 },
+      { id: 2, fecha: '2026-08-16', monto: 0 },
+    ])
+    expect(bloque?.lineas).toHaveLength(1)
   })
 })

--- a/src/utils/deudaCliente.ts
+++ b/src/utils/deudaCliente.ts
@@ -82,3 +82,91 @@ export function avisoDeudaCliente(
         detalle: `Este cliente tiene una deuda previa de ${importe}.`,
       }
 }
+
+// ---------------------------------------------------------------------------
+// Bloque de deuda para la comanda impresa
+// ---------------------------------------------------------------------------
+
+/** Una boleta anterior sin pagar, tal como la devuelve `deuda_previa_detalle`. */
+export interface BoletaAdeudada {
+  id: string | number
+  /** Fecha del pedido, `YYYY-MM-DD`. */
+  fecha?: string | null
+  monto: number
+}
+
+export interface LineaDeuda {
+  /** Ya formateada para el ticket: "#1234 15/08". */
+  etiqueta: string
+  monto: number
+}
+
+export interface BloqueDeudaComanda {
+  /** El total que encabeza el bloque. Es `deuda_previa`, el numero canonico. */
+  total: number
+  /** Las lineas del desglose. Siempre suman `total`. */
+  lineas: LineaDeuda[]
+}
+
+/** Cuantas boletas entran en un ticket de 75mm sin comerse el papel. */
+const MAX_LINEAS = 6
+
+/** "2026-09-08" -> "08/09". Sin Date: es date-only, y `new Date` la correria de dia. */
+function fechaCorta(fecha: string | null | undefined): string {
+  const m = /^(\d{4})-(\d{2})-(\d{2})/.exec(fecha ?? '')
+  return m ? `${m[3]}/${m[2]}` : ''
+}
+
+/**
+ * Desglose de la deuda para imprimir en la comanda, o null si no hay nada que
+ * cobrar. El transportista necesita saber QUE boletas reclamar, no solo cuanto:
+ * con el numero suelto no puede imputar el cobro.
+ *
+ * Las lineas SIEMPRE suman el total:
+ *  - si hay mas boletas que las que entran en el papel, las que sobran se
+ *    agrupan en una linea ("y N boletas mas") con su suma;
+ *  - si el total es menor que la suma de las boletas, la diferencia es un pago
+ *    a cuenta sin imputar y sale como linea aparte. Hoy no puede pasar (no hay
+ *    un solo pago a cuenta en la base), pero si aparece uno, el ticket cuadra
+ *    igual en vez de mostrar un desglose que no da.
+ */
+export function bloqueDeudaComanda(
+  total: number | null | undefined,
+  boletas: BoletaAdeudada[] | null | undefined,
+  opts: { maxLineas?: number } = {},
+): BloqueDeudaComanda | null {
+  const totalRedondeado = Math.round(aNumero(total) * 100) / 100
+  if (totalRedondeado < EPSILON) return null
+
+  const maxLineas = opts.maxLineas ?? MAX_LINEAS
+  const items = (boletas ?? []).filter(b => aNumero(b.monto) >= EPSILON)
+
+  const lineas: LineaDeuda[] = []
+  const visibles = items.length > maxLineas ? items.slice(0, maxLineas - 1) : items
+  for (const b of visibles) {
+    const fecha = fechaCorta(b.fecha)
+    lineas.push({
+      etiqueta: fecha ? `#${b.id} ${fecha}` : `#${b.id}`,
+      monto: Math.round(aNumero(b.monto) * 100) / 100,
+    })
+  }
+
+  const restantes = items.slice(visibles.length)
+  if (restantes.length > 0) {
+    const suma = restantes.reduce((t, b) => t + aNumero(b.monto), 0)
+    lineas.push({
+      etiqueta: `y ${restantes.length} boleta${restantes.length === 1 ? '' : 's'} mas`,
+      monto: Math.round(suma * 100) / 100,
+    })
+  }
+
+  // Lo que el total no explica: un pago a cuenta que no esta imputado a
+  // ninguna boleta. Va como linea negativa para que el desglose cierre.
+  const sumado = lineas.reduce((t, l) => t + l.monto, 0)
+  const diferencia = Math.round((totalRedondeado - sumado) * 100) / 100
+  if (Math.abs(diferencia) >= EPSILON) {
+    lineas.push({ etiqueta: diferencia < 0 ? 'A cuenta' : 'Otros', monto: diferencia })
+  }
+
+  return { total: totalRedondeado, lineas }
+}


### PR DESCRIPTION
El chofer entrega y cobra, y salía con un papel que no decía nada de la deuda.

> ⚠️ **La migración 218 ya está aplicada en producción**, igual que la 215 y por
> lo mismo: si el front llega antes que la función, el `select` de pedidos falla
> entero y se cae la pantalla. Con la función aplicada, este PR es seguro de
> mergear.

## Qué imprime

```
DEUDA ANTERIOR:      $ 20.000,00
  #1234 15/08        $ 12.000,00
  #1250 22/08         $ 8.000,00
```

Con el total suelto no alcanzaba: para imputar el cobro el chofer necesita saber
**qué** boletas reclamar. Sale en las **dos copias**, la del cliente incluida
(decisión tuya). Si el cliente no debe nada, no se imprime nada.

## Las líneas siempre suman el total

- Las boletas que no entran en el papel se agrupan en **"y N boletas mas"** con
  su suma.
- Un pago a cuenta sin imputar —que `deuda_previa` resta pero no pertenece a
  ninguna boleta— sale como línea **"A cuenta"**. Hoy no puede pasar: 5.401
  pagos en la base, **cero** a cuenta. La migración lo verifica sobre todos los
  pedidos.

## Las columnas pasan al `PEDIDO_SELECT` compartido

En la 215 las puse sólo en la lista, argumentando que la ruta no las mostraba.
Ahora sí las necesita: las comandas se imprimen desde **tres** lugares —la card,
la hoja de ruta (`useRecorridosHojaRutaQuery`) y la ruta recién armada
(`useRecorridoExistenteQuery`)— y las tres tienen que llevar la deuda al papel.
Medido: **21 ms** las dos funciones sobre 53 pedidos, así que el argumento del
costo ya no se sostiene. Al compartido, además, un cuarto camino de impresión
nace con el dato.

Verificado con `curl` que PostgREST acepta computed columns **dentro del embed
anidado** de la hoja de ruta (**200**, contra **42703** del control) — no era
obvio y era el riesgo real del cambio.

## El alto del ticket

El alto **es** el formato de la página, así que el bloque también suma en
`calcularAlturaComanda`: lo que no se cuente ahí se dibuja fuera del papel y no
sale impreso nunca. Eso no lo atrapa ningún test, así que generé las comandas de
verdad y las miré: sin deuda, una boleta, dos, y nueve con el tope agrupando.

## Verificación

`typecheck`, `lint`, **1663 tests** (124 archivos) y `build`, todo verde sobre
`main` actual (rebasado después de que entraran #548, #551 y #554).

El desglose es lógica pura y está en `src/utils/deudaCliente.ts` con 8 tests
propios, incluido que las líneas sumen el total en cada caso y que la fecha no se
corra de día (`"2026-08-01"` con `new Date` en UTC-3 daría 31/07).

## Una incoherencia que te dejo señalada

En la app **le ocultamos la deuda al transportista** (`puedeVerDeudaCliente`), y
ahora se la damos impresa. Si querés, se la habilito también en pantalla — donde
el dato está *más* fresco que en el papel, que se imprime a la mañana. No lo hice
porque pediste la comanda, no la app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
