### PR TITLE
La venta es de quien la carga: cerrar la atribución forjada en el alta (#549, mig 219)

### DIFF
--- a/migrations/219_la_venta_es_de_quien_la_carga.sql
+++ b/migrations/219_la_venta_es_de_quien_la_carga.sql
@@ -1,0 +1,251 @@
+-- Migración 219: la venta es de quien la carga
+--
+-- Issue #549.
+--
+-- EL AGUJERO. `mt_pedidos_insert` es `(es_preventista() AND sucursal_id =
+-- current_sucursal_id())` y no mira `usuario_id`. Por PostgREST, sin pasar por
+-- ningún RPC, se podía hacer `INSERT INTO pedidos` con el `usuario_id` de otro
+-- y atribuirle la venta a un tercero (o quitársela a uno mismo).
+--
+-- Y la superficie era más ancha de lo que parece: `es_preventista()` devuelve
+-- true también para admin y encargado (trampa 4 de CLAUDE.md), así que el
+-- predicado no acotaba casi nada.
+--
+-- POR QUÉ IMPORTA. `calcular_comisiones` agrupa por `pedidos.usuario_id`, igual
+-- que los reportes de ventas por vendedor. Una atribución forjada mueve plata
+-- de una liquidación a otra.
+--
+-- LA ASIMETRÍA QUE LO DEJÓ PASAR. El UPDATE ya estaba tapado: este mismo
+-- trigger bloquea `usuario_id`, `creado_por`, `cliente_id`, `total` y otras
+-- para todo el que no sea encargado ni admin. O sea que robarse una venta YA
+-- HECHA era imposible; lo que faltaba era la misma protección en el alta. Por
+-- eso el arreglo va acá adentro y no en una función nueva: la asimetría
+-- INSERT/UPDATE fue justamente lo que hizo que el agujero pasara desapercibido,
+-- y partir la regla en dos lugares la reproduce.
+--
+-- LA REGLA. Quien crea el pedido puede atribuírselo a sí mismo siempre. A OTRO,
+-- solo si es admin o encargado. Un preventista no puede crear un pedido a
+-- nombre de un tercero.
+--
+-- POR QUÉ NO ROMPE EL FLUJO DEL ADMIN. Un admin carga pedidos A NOMBRE de un
+-- preventista (`p_preventista_id` en `crear_pedido_completo`, que escribe
+-- `usuario_id = v_preventista_final` y `creado_por = p_usuario_id`): son 55 de
+-- los 5.628 pedidos del último año. Ese caso sale por el `RETURN NEW` de
+-- `es_encargado_o_admin()`, que ya estaba dos líneas más arriba y ahora también
+-- gobierna el INSERT. No hizo falta agregarle nada.
+--
+-- QUIÉN ES EL AUTOR: `auth.uid()`, Y NO EL COALESCE DE LA MIG 216.
+-- La 216 (`pedidos_cliente_asignado`) decide con
+--   COALESCE((SELECT p.id FROM perfiles WHERE p.id = auth.uid()), NEW.creado_por, NEW.usuario_id)
+-- porque ESE trigger corre para todos los caminos, incluidos los RPC (que
+-- corren como `postgres`) y el bot (`service_role`), donde `auth.uid()` es NULL
+-- y hace falta el fallback.
+--
+-- Acá no, y la diferencia importa en la dirección de la seguridad: este bloque
+-- solo se alcanza si `current_user = 'authenticated'` —lo garantiza la primera
+-- línea de la función, que ya estaba—, o sea que `auth.uid()` nunca es NULL y
+-- es el autor, punto. Traer el COALESCE igual sería peor, no mejor:
+--   * el término de `perfiles` depende de que la RLS de `perfiles` siga siendo
+--     permisiva (hoy `perfiles_select_all USING (true)`). El día que alguien la
+--     ajuste —que sería una mejora— ese término devuelve NULL y el guard cae al
+--     término siguiente;
+--   * y ese término siguiente es `NEW.creado_por`, que en un INSERT directo lo
+--     manda el atacante. O sea: fail-OPEN.
+-- Con `auth.uid()` pelado, un `auth.uid()` nulo hace que cualquier `usuario_id`
+-- no nulo sea distinto del autor y el INSERT se rechaza: fail-CLOSED.
+--
+-- LOS RPC Y EL BOT NO PASAN POR ACÁ, a propósito: `crear_pedido_completo` y
+-- `crear_pedido_completo_bot` son SECURITY DEFINER, así que adentro
+-- `current_user` es `postgres` y la función sale por el `RETURN NEW` de la
+-- primera línea. No es un olvido: los dos RPC ya validan lo mismo por su cuenta
+-- (`p_usuario_id IS DISTINCT FROM auth.uid()` → error), y el camino del bot
+-- —donde `auth.uid()` es NULL— tiene que seguir funcionando. Lo que este trigger
+-- cubre es exactamente el INSERT directo por PostgREST, que es donde estaba el
+-- agujero y el único lugar sin dueño.
+--
+-- POR QUÉ SIGUE SIENDO INVOKER (y no SECURITY DEFINER como los guards de las
+-- migs 214 y 216): porque su primera línea es `current_user <> 'authenticated'`.
+-- Adentro de una función SECURITY DEFINER `current_user` es el dueño, así que
+-- pasarla a definer haría que ESA comparación diera siempre true y toda la
+-- protección de columnas del UPDATE se apagaría en silencio. No necesita ser
+-- definer: los roles los resuelve con `es_encargado_o_admin()` y
+-- `es_transportista()`, que ya son SECURITY DEFINER, y la identidad con
+-- `auth.uid()`, que sale del JWT y no se falsifica. Ninguna lee tablas bajo la
+-- RLS del caller.
+--
+-- LO QUE NO CIERRA, dicho a propósito: un INSERT directo con `usuario_id NULL`
+-- pasa. No es "atribuírsela a otro" —es no atribuirla a nadie—, y la columna es
+-- nullable con 2 pedidos así en el último año (ambos de marzo, ambos también
+-- sin `creado_por`). Cerrarlo es otra decisión, con otro riesgo: convierte en
+-- error un dato que la base hoy admite.
+
+BEGIN;
+
+-- ---------------------------------------------------------------------------
+-- 1. El guard, adentro de la función que ya protege las columnas en UPDATE
+-- ---------------------------------------------------------------------------
+-- El bloque nuevo va DESPUÉS del `RETURN NEW` de encargado/admin (así ese caso
+-- queda cubierto sin escribir nada) y ANTES de todo lo que usa OLD, que en un
+-- INSERT no existe. El resto del cuerpo queda byte por byte como estaba.
+
+CREATE OR REPLACE FUNCTION public.pedidos_proteger_columnas()
+RETURNS trigger
+LANGUAGE plpgsql
+SET search_path TO 'public'
+AS $function$
+DECLARE
+  v_bloqueadas text;
+BEGIN
+  IF current_user <> 'authenticated' THEN
+    RETURN NEW;
+  END IF;
+
+  IF pg_trigger_depth() > 1 THEN
+    RETURN NEW;
+  END IF;
+
+  IF es_encargado_o_admin() THEN
+    RETURN NEW;
+  END IF;
+
+  -- ---- Alta: la venta es de quien la carga (mig 219, issue #549) ----------
+  -- Acá abajo el caller ya no es admin ni encargado, así que solo puede
+  -- atribuirse el pedido a sí mismo.
+  IF TG_OP = 'INSERT' THEN
+    IF NEW.usuario_id IS NOT NULL AND NEW.usuario_id IS DISTINCT FROM auth.uid() THEN
+      RAISE EXCEPTION
+        'Un pedido se atribuye a quien lo carga: no podés crear uno a nombre de otro usuario (usuario_id %). Solo un administrador o encargado puede hacerlo.',
+        NEW.usuario_id
+        USING ERRCODE = '42501';
+    END IF;
+
+    RETURN NEW;
+  END IF;
+
+  -- ---- De acá abajo es UPDATE (usa OLD) ----------------------------------
+  IF es_transportista() THEN
+    SELECT string_agg(o.key, ', ' ORDER BY o.key) INTO v_bloqueadas
+    FROM jsonb_each(to_jsonb(OLD)) o
+    JOIN jsonb_each(to_jsonb(NEW)) n ON n.key = o.key
+    WHERE o.value IS DISTINCT FROM n.value
+      AND o.key NOT IN ('estado', 'fecha_entrega', 'updated_at');
+
+    IF v_bloqueadas IS NOT NULL THEN
+      RAISE EXCEPTION 'Un transportista solo puede confirmar la entrega. Columnas rechazadas: %',
+        v_bloqueadas
+        USING ERRCODE = '42501';
+    END IF;
+
+    IF NEW.estado IS DISTINCT FROM OLD.estado AND NEW.estado <> 'entregado' THEN
+      RAISE EXCEPTION 'Un transportista solo puede marcar la entrega, no pasar el pedido a "%"',
+        NEW.estado
+        USING ERRCODE = '42501';
+    END IF;
+
+    RETURN NEW;
+  END IF;
+
+  SELECT string_agg(o.key, ', ' ORDER BY o.key) INTO v_bloqueadas
+  FROM jsonb_each(to_jsonb(OLD)) o
+  JOIN jsonb_each(to_jsonb(NEW)) n ON n.key = o.key
+  WHERE o.value IS DISTINCT FROM n.value
+    AND o.key IN (
+      'total', 'total_neto', 'total_iva', 'total_real', 'monto_pagado',
+      'estado_pago', 'cliente_id', 'sucursal_id', 'usuario_id', 'creado_por',
+      'preventista_id', 'tipo_factura', 'stock_descontado', 'offline_id'
+    );
+
+  IF v_bloqueadas IS NOT NULL THEN
+    RAISE EXCEPTION 'No tenes permiso para modificar estas columnas de pedidos: %',
+      v_bloqueadas
+      USING ERRCODE = '42501';
+  END IF;
+
+  RETURN NEW;
+END;
+$function$;
+
+-- ---------------------------------------------------------------------------
+-- 2. El trigger pasa a correr también en INSERT
+-- ---------------------------------------------------------------------------
+-- Se llama igual que antes. Por orden alfabético queda ANTES que
+-- `trg_pedidos_cliente_asignado` (216) y `trg_pedidos_cliente_reservado` (214),
+-- que son los otros dos BEFORE INSERT de la tabla. No se pisan: cada uno mira
+-- otra cosa —la atribución acá, el cliente ajeno en la 216, el reservado en la
+-- 214— y cada uno tira su propio mensaje. Si un INSERT viola dos reglas a la
+-- vez, gana el mensaje de éste, que es igual de específico.
+
+DROP TRIGGER IF EXISTS pedidos_proteger_columnas ON public.pedidos;
+CREATE TRIGGER pedidos_proteger_columnas
+  BEFORE INSERT OR UPDATE ON public.pedidos
+  FOR EACH ROW
+  EXECUTE FUNCTION public.pedidos_proteger_columnas();
+
+-- ---------------------------------------------------------------------------
+-- 3. ACL
+-- ---------------------------------------------------------------------------
+-- Una función de trigger no necesita EXECUTE para NADIE: la invoca el executor
+-- como parte del DML, no el caller. `CREATE OR REPLACE` conserva el ACL que ya
+-- tenía (postgres + service_role), pero se reafirma acá porque una función que
+-- se reescribe entera merece que su ACL quede escrito al lado, y porque el gate
+-- de CI (scripts/check-permisos.mjs) falla ante cualquier función alcanzable
+-- con la anon key.
+
+REVOKE ALL ON FUNCTION public.pedidos_proteger_columnas()
+  FROM PUBLIC, anon, authenticated;
+
+-- ---------------------------------------------------------------------------
+-- 4. Verificación
+-- ---------------------------------------------------------------------------
+
+DO $verif$
+DECLARE
+  v_acl text;
+  v_eventos int;
+BEGIN
+  SELECT array_to_string(proacl, ',') INTO v_acl
+    FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace
+   WHERE n.nspname = 'public' AND p.proname = 'pedidos_proteger_columnas';
+
+  IF v_acl IS NULL OR v_acl LIKE '=X/%' OR v_acl LIKE '%,=X/%' THEN
+    RAISE EXCEPTION 'pedidos_proteger_columnas quedo ejecutable por PUBLIC: %', coalesce(v_acl, '(default)');
+  END IF;
+  IF v_acl LIKE '%anon=%' THEN
+    RAISE EXCEPTION 'pedidos_proteger_columnas quedo ejecutable por anon: %', v_acl;
+  END IF;
+  IF v_acl LIKE '%authenticated=%' THEN
+    RAISE EXCEPTION 'pedidos_proteger_columnas quedo ejecutable por authenticated: %', v_acl;
+  END IF;
+
+  -- Que el trigger haya quedado en INSERT **y** UPDATE: si se pierde el UPDATE,
+  -- se apaga toda la proteccion de columnas que ya existia y nada lo delata.
+  SELECT t.tgtype::int INTO v_eventos
+    FROM pg_trigger t
+   WHERE t.tgrelid = 'public.pedidos'::regclass AND t.tgname = 'pedidos_proteger_columnas';
+
+  IF v_eventos IS NULL THEN
+    RAISE EXCEPTION 'el trigger pedidos_proteger_columnas no existe';
+  END IF;
+  IF (v_eventos & 4) = 0 THEN
+    RAISE EXCEPTION 'pedidos_proteger_columnas no quedo en INSERT (tgtype=%)', v_eventos;
+  END IF;
+  IF (v_eventos & 16) = 0 THEN
+    RAISE EXCEPTION 'pedidos_proteger_columnas perdio el UPDATE (tgtype=%)', v_eventos;
+  END IF;
+  IF (v_eventos & 2) = 0 THEN
+    RAISE EXCEPTION 'pedidos_proteger_columnas no quedo BEFORE (tgtype=%)', v_eventos;
+  END IF;
+
+  -- La funcion NO puede ser SECURITY DEFINER: adentro de una definer
+  -- `current_user` es el dueño, la primera linea daria siempre true y toda la
+  -- proteccion se apagaria en silencio.
+  IF EXISTS (
+    SELECT 1 FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace
+     WHERE n.nspname = 'public' AND p.proname = 'pedidos_proteger_columnas' AND p.prosecdef
+  ) THEN
+    RAISE EXCEPTION 'pedidos_proteger_columnas quedo SECURITY DEFINER: current_user dejaria de ser authenticated y el guard se apaga';
+  END IF;
+END
+$verif$;
+
+COMMIT;

--- a/migrations/MANIFEST.md
+++ b/migrations/MANIFEST.md
@@ -137,17 +137,22 @@ funcional** y no se renombran los archivos: renombrarlos los desalinearía del l
 real lo da `version` y está en la sección A: en los dos casos el archivo de `main` quedó
 cronológicamente **fuera** del bloque 139–147 (uno antes, otro entre la 144 y la 145).
 
-**La próxima migración es la 218** — la última numerada en el repo es
-`217_el_detector_de_duplicados_ve_lo_que_la_rls_tapa`, y el ledger de prod está alineado
-con ella. Igual, confirmá el número contra las tres fuentes justo antes de aplicar: el
-número se reserva **aplicando**, no escribiendo el archivo.
+**La próxima migración es la 220.** El ledger de prod llega hasta
+`219_la_venta_es_de_quien_la_carga`. **Ojo con el 218**: `218_que_boletas_debe_no_solo_cuanto`
+está aplicada en prod pero su archivo todavía no está en el repo (viene de otra rama sin
+mergear), así que el hueco entre la 217 y la 219 acá es esperable y no es drift.
+Igual, confirmá el número contra las tres fuentes justo antes de aplicar: el número se
+reserva **aplicando**, no escribiendo el archivo.
 
 (Esta línea decía 206 hasta el 2026-09-08, con las 206–209 ya aplicadas: la
 numeración del repo avanzó cuatro veces sin que nadie la corrigiera. Volvió a pasar el
 2026-09-09: decía 215 con la 215 y la 216 ya aplicadas y sus archivos en `main`, así que
 quien fue a escribir la 217 leyó "escribí la 215" y habría pisado dos migraciones vivas.
-Si aplicás una migración, actualizá también esta línea. Última actualización: 217, el
-2026-09-09.)
+Y otra vez el mismo día: la 218 se aplicó desde otra sesión **mientras** se escribía la que
+terminó siendo la 219 — que salió con el número correcto sólo porque se confirmó contra el
+ledger en el último momento, no porque esta línea estuviera al día. Moraleja: esta línea es
+una ayuda, el ledger es la verdad. Si aplicás una migración, actualizá también esta línea.
+Última actualización: 219, el 2026-09-09.)
 
 Las 197–202 no tienen prosa acá (quedaron sin documentar en su momento). Las 203, 204,
 205, 212, 213 y 214 sí:
@@ -258,6 +263,31 @@ Las 206–209 tampoco tienen prosa acá. Las 210 y 211 sí:
   delatar que está reservado. **El detector por RAZÓN SOCIAL se deja ciego a propósito**:
   ahí el mismo booleano sería fácil de sondear probando nombres, así que el clon por nombre
   contra un cliente ajeno se sigue pudiendo crear —decisión tomada, no olvido—.
+
+- **219** cierra el forjado de la atribución en el ALTA de pedidos (issue #549).
+  `mt_pedidos_insert` es `(es_preventista() AND sucursal_id = current_sucursal_id())` y **no
+  mira `usuario_id`**, así que por PostgREST se podía insertar un pedido atribuido a
+  cualquiera —y como `es_preventista()` incluye admin y encargado (trampa 4), el predicado
+  no acotaba casi nada—. Importa porque `calcular_comisiones` agrupa por `pedidos.usuario_id`:
+  una atribución forjada mueve plata de una liquidación a otra. **El UPDATE ya estaba
+  tapado** por `pedidos_proteger_columnas`, que bloquea `usuario_id` y otras para todo el que
+  no sea encargado ni admin; faltaba lo mismo en el alta, y esa asimetría INSERT/UPDATE fue
+  justamente lo que dejó pasar el agujero. Por eso el guard va **adentro de esa misma
+  función** —que ahora corre `BEFORE INSERT OR UPDATE`— y no en una nueva: partir la regla en
+  dos lugares reproduce el problema. El bloque nuevo va DESPUÉS del `RETURN NEW` de
+  `es_encargado_o_admin()`, así el flujo real de "admin carga a nombre de un preventista"
+  (55 de los 5.628 pedidos del último año) queda cubierto sin escribir una línea, y ANTES de
+  todo lo que usa `OLD`. **La identidad sale de `auth.uid()`, no del COALESCE de la 216**: acá
+  el bloque solo se alcanza con `current_user = 'authenticated'`, donde `auth.uid()` nunca es
+  NULL, y el fallback a `NEW.creado_por` sería **fail-open** porque en un INSERT directo lo
+  manda el atacante. La función **sigue siendo INVOKER** a propósito: adentro de una SECURITY
+  DEFINER `current_user` es el dueño, su primera línea daría siempre true y toda la
+  protección de columnas se apagaría en silencio (hay un check en la migración que lo
+  impide). Los RPC y el bot **no pasan por acá** —son DEFINER, salen por esa primera
+  línea— y ya validan lo mismo por su cuenta. Verificado impersonando contra prod los 7
+  casos, incluidos los dos RPC punta a punta y el camino del bot. **No cierra** el INSERT
+  directo con `usuario_id NULL`: no es atribuírsela a otro sino a nadie, y la columna es
+  nullable con 2 pedidos así en el último año.
 
 La **195** le da a la cabecera la columna `compras.bonificaciones`, que es donde se resta
 una bonificación general: el `subtotal` es el neto de los RENGLONES y lo clava `COMPRA-A2`


### PR DESCRIPTION
Cierra #549.

> **La migración 219 ya está aplicada en prod.** Se aplicó para reservar el número (se
> reserva aplicando, no escribiendo el archivo). El guard ya está activo: cubre el INSERT
> directo por PostgREST, que es donde estaba el agujero, y no toca ningún camino de la app.

## El agujero

`mt_pedidos_insert` es `(es_preventista() AND sucursal_id = current_sucursal_id())` y **no
mira `usuario_id`**. Por PostgREST, sin pasar por ningún RPC, se podía hacer
`INSERT INTO pedidos` con el `usuario_id` de otro y atribuirle la venta a un tercero. Y la
superficie era más ancha de lo que parece: `es_preventista()` devuelve `true` también para
admin y encargado (trampa 4 de `CLAUDE.md`), así que el predicado no acotaba casi nada.

Importa porque `calcular_comisiones` agrupa por `pedidos.usuario_id`, igual que los reportes
de ventas por vendedor: **una atribución forjada mueve plata de una liquidación a otra**.

## Por qué va adentro de `pedidos_proteger_columnas`

Esa función ya bloqueaba `usuario_id`, `creado_por`, `cliente_id`, `total` y otras… **pero
sólo en UPDATE**. O sea que robarse una venta ya hecha era imposible y falsificar el alta no.
Esa asimetría INSERT/UPDATE es exactamente lo que dejó pasar el agujero, así que partir la
regla entre una policy y un trigger la reproduce.

El trigger ahora corre `BEFORE INSERT OR UPDATE`. El bloque nuevo va **después** del
`RETURN NEW` de `es_encargado_o_admin()` —con lo cual el flujo real de "admin carga a nombre
de un preventista" (55 de los 5.628 pedidos del último año) queda cubierto sin escribir una
línea— y **antes** de todo lo que usa `OLD`, que en un INSERT no existe. El resto del cuerpo
quedó byte por byte como estaba.

Encontré además una razón que no estaba en el issue: esa función arranca con
`current_user <> 'authenticated' → RETURN NEW`, así que los RPC (que corren como `postgres`)
y el bot (`service_role`) **salen antes de llegar al guard**. El trigger cubre exactamente el
INSERT directo y no puede romper los caminos que sí funcionan.

## Dos desvíos deliberados del enfoque propuesto

**1. La identidad sale de `auth.uid()`, no del COALESCE de la mig 216.**
La 216 usa `COALESCE(perfil de auth.uid(), NEW.creado_por, NEW.usuario_id)` porque *ese*
trigger corre para todos los caminos, incluidos aquellos donde `auth.uid()` es NULL. Acá el
bloque sólo se alcanza con `current_user = 'authenticated'`, donde `auth.uid()` nunca es NULL.
Traer el COALESCE igual sería **peor**: el término de `perfiles` depende de que la RLS de
`perfiles` siga permisiva (hoy `perfiles_select_all USING (true)`), y el término siguiente es
`NEW.creado_por`, que en un INSERT directo **lo manda el atacante** → fail-**open**. Con
`auth.uid()` pelado, un `auth.uid()` nulo hace que cualquier `usuario_id` no nulo sea distinto
y se rechace → fail-**closed**. Verificado forjando `usuario_id` **y** `creado_por` juntos:
igual rechaza.

**2. La función sigue siendo INVOKER, no SECURITY DEFINER como los guards de las migs 214 y
216.** Adentro de una `SECURITY DEFINER`, `current_user` es el dueño: pasarla a definer haría
que su primera línea diera **siempre** true y toda la protección de columnas del UPDATE se
apagaría en silencio. No lo necesita — los roles los resuelve con `es_encargado_o_admin()` y
`es_transportista()`, que ya son definer, y la identidad con `auth.uid()`, que sale del JWT.
La migración incluye un check que falla si alguien la convierte.

## Verificado contra prod, impersonando

En transacciones revertidas, contra la función ya aplicada:

| caso | resultado |
|---|---|
| preventista → a sí mismo | PASA |
| preventista → a otro preventista | RECHAZA |
| …forjando también `creado_por` | RECHAZA |
| RPC `crear_pedido_completo` (a sí mismo) | `true` |
| camino del bot (DEFINER, `auth.uid()` NULL) | PASA |
| UPDATE: robar una venta ya hecha | RECHAZA |
| **RPC admin con `p_preventista_id`** | `true` ← el flujo real, intacto |

Y los tres `BEFORE INSERT` de la tabla no se pisan: con un cliente ajeno el rechazo sale con
el mensaje de la 216 (`Cliente asignado a otro preventista: LOS PORTEÑOS (#22)`), no con el de
esta. Cada uno mira otra cosa y tira lo suyo.

## Por qué no hay cambios de código ni tests nuevos

El front **no hace ningún INSERT directo** a `pedidos` — todo va por `crear_pedido_completo` /
`crear_pedido_idempotente`. Esa era la medición que el issue pedía antes de tocar nada. Lo
único que se movió vive en la base, y la RLS no la ven `tsc`, eslint ni vitest: la evidencia
es la impersonación de arriba. Los gates corrieron igual —`typecheck`, `lint`, `test:run`
(1655, sin `.env`), `build`, y `deno task check/lint/test` (203)— y están verdes.

## Lo que no cierra, a propósito

Un INSERT directo con `usuario_id NULL` pasa. No es atribuírsela a otro sino a nadie, pero
igual escapa a las comisiones. La columna es nullable y hay 2 pedidos así en el último año
(ambos de marzo, ambos también sin `creado_por`). Cerrarlo convierte en error un dato que la
base hoy admite, así que es otra decisión.

## El número de migración

El punto de partida decía "la última aplicada es la 216"; el ledger ya tenía la 217 y, mientras
se escribía ésta, otra sesión aplicó la **218** (`que_boletas_debe_no_solo_cuanto`) sin pushear
su archivo. Salió 219 porque se confirmó contra el ledger en el último momento — sexta vez que
pasa. El MANIFEST quedó con la nota y avisando que **el hueco del 218 en el repo es esperable**
hasta que mergeen esa rama: no es drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)