### PR TITLE
El factor de fracción tiene una sola fuente viva

### DIFF
--- a/migrations/220_el_factor_de_fraccion_tiene_una_sola_fuente_viva.sql
+++ b/migrations/220_el_factor_de_fraccion_tiene_una_sola_fuente_viva.sql
@@ -1,0 +1,659 @@
+-- =========================================================================
+-- El factor de fraccion tiene UNA SOLA fuente viva
+--
+-- EL BUG (issue #535)
+-- -------------------
+-- Despues de la mig 212 el factor esta en tres lugares y cada consumidor lee
+-- uno distinto. Editarlo desde ModalPromocion mueve `promociones` y no toca
+-- `promo_acumuladores`, sin que falle nada ni avise nadie.
+--
+-- LO QUE LA AUDITORIA ENCONTRO (contra el codigo VIVO, no contra migrations/)
+-- --------------------------------------------------------------------------
+-- 1. El acumulador NO esta en el camino principal del stock. Solo dos
+--    funciones tocan `promo_acumuladores`: esta misma y sustituir_regalo_pedido.
+--    Los cuatro caminos que descuentan stock de verdad -- crear_pedido_completo,
+--    crear_pedido_completo_bot, actualizar_pedido_items y
+--    revertir_bloques_auto_ajuste -- leen `promociones` EN VIVO y no lo miran.
+--    Es la estrategia de "minimo invasivo" que la mig 059 declaro explicitamente.
+--
+-- 2. aplicar_uso_promo_acumulador ya se contradice sola: el GATE lee
+--    v_promo.unidades_por_bloque (vivo) y la ARITMETICA lee
+--    v_acc.unidades_por_bloque (congelado). No hay una postura "el acumulador
+--    congela el factor" que defender: la funcion cree las dos mitades a la vez.
+--
+-- 3. La copia nunca divergio. 11 filas de acumulador en prod:
+--    `unidades_por_bloque` difiere del vivo en 0 y `stock_por_bloque` en 0.
+--    Pero `ajuste_producto_id` difiere en 7 -- ese SI es dato por fila (el
+--    contenedor que eligio el admin para cada sabor sustituido).
+--    De las tres columnas de config copiadas, una es dato y dos son cache.
+--
+-- 4. El "carry forward" ya es el comportamiento vivo: crear_pedido_completo
+--    renormaliza el resto con el N VIVO en cada pedido. Bajar el factor con
+--    resto abierto YA cierra un bloque en el proximo pedido. Nadie lo eligio.
+--
+-- LA DECISION
+-- -----------
+-- Dos fuentes con roles distintos, ninguna tercera copia:
+--   VIVO             promociones.unidades_por_bloque / .stock_por_bloque
+--                    -> gobierna que pasa AHORA
+--   CONGELADO X ITEM pedido_items.unidades_por_bloque_al_crear (mig 212)
+--                    -> gobierna que dice la HISTORIA
+--
+-- Se dropean promo_acumuladores.unidades_por_bloque y .stock_por_bloque: eran
+-- cache, no congelado. Se QUEDAN ajuste_producto_id y usos_pendientes.
+--
+-- OJO CON EL ERROR INVERSO: las tres columnas copiadas se ven iguales y se
+-- resuelven al reves. Dropear tambien `ajuste_producto_id` rompe las barras
+-- paralelas, que son la razon de existir de la tabla.
+--
+-- QUIEN MANDA EN LA BARRA DEFAULT
+-- -------------------------------
+-- `promociones.usos_pendientes`. Los 4 caminos de stock la usan y no conocen
+-- el acumulador; la promo 12 no tiene fila de acumulador para su regalo default
+-- (96), asi que ahi la barra existe SOLO en `promociones`; y VistaPromociones
+-- ya muestra ese valor.
+-- De ahi la regla que evita el doble descuento: el trigger toca
+-- `promociones.usos_pendientes` y las filas de acumulador de SUSTITUTOS
+-- unicamente. La fila del regalo default no la toca nunca -- ni la espeja ni la
+-- cierra. Espejarla haria desaparecer los 4 de la promo 13 sin mover un fardo.
+-- Ese desacuerdo es preexistente y va en el issue #553.
+--
+-- RIESGO: bajo. Solo 5 promos fraccionan (factores 6 y 12) y una sola esta
+-- activa (la 13). El factor nunca cambio en toda la historia: 651 mediciones en
+-- promo_ajustes con min = max = valor vivo (ver mig 212). Este bug es real pero
+-- nunca se disparo.
+--
+-- QUE SE PROBO ANTES DE APLICAR (2026-09-09)
+-- ------------------------------------------
+-- La migracion entera se corrio contra los datos REALES de prod dentro de una
+-- transaccion terminada en ROLLBACK, con siete casos sobre la promo 13 (factor
+-- 6; barras sustitutas 78 -> 0, 79 -> 0, 80 -> 2, 81 -> 4, 83 -> 2):
+--   1. Bajar 6 -> 2 cierra 1+2+1 bloques y descuenta 1, 2 y 1 del contenedor de
+--      cada barra. La fila de acumulador del regalo DEFAULT (82, resto 4) queda
+--      intacta y su contenedor no se mueve: es la regla del doble descuento.
+--   2. Subir 2 -> 12 no mueve un solo fardo, pero deja la constancia igual.
+--   3. N -> NULL deja el resto intacto y no mueve stock.
+--   4. Un UPDATE que no toca esas columnas (renombrar la promo) no dispara nada.
+--   5. Reescribir el MISMO valor tampoco -- es lo que hace updatePromocion en
+--      cada guardado, y sin el WHEN seria una fila de ajuste por edicion.
+--   6. Lo que promete previsualizar_cambio_factor es lo que despues hace el
+--      trigger (misma aritmetica, un solo bloques_a_cerrar).
+--   7. aplicar_uso_promo_acumulador sin la copia usa el factor VIVO: con N = 2 y
+--      resto 0, un delta de +2 cierra bloque -- con la copia vieja (6) no habria
+--      cerrado nada.
+-- Control negativo hecho aparte: un RAISE EXCEPTION dentro del mismo mecanismo
+-- vuelve como error, o sea que "paso" significa algo.
+--
+-- COMO SE REVIERTE: re-agregar las dos columnas, backfillearlas desde
+-- `promociones` (que es de donde salieron y con lo que siempre coincidieron),
+-- dropear el trigger y volver a la version anterior de las dos funciones.
+-- =========================================================================
+
+BEGIN;
+
+-- -------------------------------------------------------------------------
+-- 1 - Parche por ancla sobre el cuerpo VIVO.
+--
+--     migrations/ no es espejo de prod: sustituir_regalo_pedido fue redefinida
+--     varias veces despues de la 059 (hoy tiene v_ajuste_sustituto_efectivo y
+--     el snapshot de costo_unitario_al_crear, que la 059 no tenia). Copiar el
+--     cuerpo del archivo revertiria logica viva en silencio. Mismo mecanismo
+--     que uso la mig 212.
+-- -------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public._mig220_reemplazar_ancla(
+  p_funcion regprocedure,
+  p_ancla   text,
+  p_nuevo   text
+)
+RETURNS void
+LANGUAGE plpgsql
+AS $fn$
+DECLARE
+  v_def   text;
+  v_veces int;
+BEGIN
+  v_def := pg_get_functiondef(p_funcion);
+
+  v_veces := (length(v_def) - length(replace(v_def, p_ancla, ''))) / length(p_ancla);
+  IF v_veces <> 1 THEN
+    RAISE EXCEPTION 'El ancla aparece % veces en % (se esperaba exactamente 1). El cuerpo vivo cambio: revisar a mano.',
+      v_veces, p_funcion;
+  END IF;
+
+  EXECUTE replace(v_def, p_ancla, p_nuevo);
+END;
+$fn$;
+
+-- sustituir_regalo_pedido crea la entry default cuando no existe, copiando las
+-- dos columnas de config. Sin ese INSERT el DROP de mas abajo la rompe en
+-- runtime (y no falla ni en tsc ni en los tests).
+DO $patch$
+DECLARE
+  v_fn regprocedure;
+BEGIN
+  SELECT p.oid::regprocedure INTO v_fn
+  FROM pg_proc p WHERE p.pronamespace = 'public'::regnamespace
+                   AND p.proname = 'sustituir_regalo_pedido';
+
+  PERFORM public._mig220_reemplazar_ancla(
+    v_fn,
+    E'        INSERT INTO promo_acumuladores (promocion_id, producto_regalo_id, ajuste_producto_id,\n'
+    || E'          unidades_por_bloque, stock_por_bloque, usos_pendientes, sucursal_id)\n'
+    || E'        VALUES (v_promo.id, v_promo.producto_regalo_id, v_promo.ajuste_producto_id,\n'
+    || E'          v_promo.unidades_por_bloque, v_promo.stock_por_bloque, COALESCE(v_promo.usos_pendientes, 0), v_sucursal)',
+    E'        INSERT INTO promo_acumuladores (promocion_id, producto_regalo_id, ajuste_producto_id,\n'
+    || E'          usos_pendientes, sucursal_id)\n'
+    || E'        VALUES (v_promo.id, v_promo.producto_regalo_id, v_promo.ajuste_producto_id,\n'
+    || E'          COALESCE(v_promo.usos_pendientes, 0), v_sucursal)'
+  );
+END
+$patch$;
+
+DROP FUNCTION public._mig220_reemplazar_ancla(regprocedure, text, text);
+
+-- -------------------------------------------------------------------------
+-- 2 - aplicar_uso_promo_acumulador deja de leer la copia.
+--
+--     Unico cambio respecto del cuerpo vivo: donde decia v_acc.unidades_por_bloque
+--     y v_acc.stock_por_bloque ahora dice v_promo.*, que es lo que la funcion YA
+--     leia para su propio gate tres lineas mas arriba. El resto del cuerpo
+--     (semantica de resto con clamp de la mig 091, mermas, promo_ajustes,
+--     convencion de signos) queda igual.
+-- -------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.aplicar_uso_promo_acumulador(
+  p_promocion_id bigint,
+  p_producto_regalo_id bigint,
+  p_delta numeric,
+  p_ajuste_producto_id_def bigint,
+  p_sucursal_id bigint,
+  p_usuario_id uuid,
+  p_motivo text
+) RETURNS jsonb
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public'
+AS $function$
+DECLARE
+  v_promo          RECORD;
+  v_acc            RECORD;
+  v_usos_raw       NUMERIC;
+  v_blocks         INT;
+  v_usos_final     NUMERIC;
+  v_stock_delta    INT;
+  v_usos_ajustados INT;
+  v_stock_anterior INT;
+  v_stock_nuevo    INT;
+  v_merma_id       BIGINT;
+BEGIN
+  SELECT id, unidades_por_bloque, stock_por_bloque, ajuste_automatico,
+         ajuste_producto_id, regalo_mueve_stock
+    INTO v_promo
+    FROM promociones
+   WHERE id = p_promocion_id AND sucursal_id = p_sucursal_id
+   FOR UPDATE;
+  IF NOT FOUND THEN
+    RETURN jsonb_build_object('aplicado', false, 'razon', 'promo no encontrada');
+  END IF;
+  IF NOT COALESCE(v_promo.ajuste_automatico, FALSE) THEN
+    RETURN jsonb_build_object('aplicado', false, 'razon', 'promo no es modo B');
+  END IF;
+  IF COALESCE(v_promo.unidades_por_bloque, 0) <= 0
+     OR COALESCE(v_promo.stock_por_bloque, 0) <= 0 THEN
+    RETURN jsonb_build_object('aplicado', false, 'razon', 'config bloque invalida');
+  END IF;
+
+  SELECT id, ajuste_producto_id, usos_pendientes
+    INTO v_acc
+    FROM promo_acumuladores
+   WHERE promocion_id = p_promocion_id
+     AND producto_regalo_id = p_producto_regalo_id
+     AND sucursal_id = p_sucursal_id
+   FOR UPDATE;
+  IF NOT FOUND THEN
+    INSERT INTO promo_acumuladores (
+      promocion_id, producto_regalo_id, ajuste_producto_id,
+      usos_pendientes, sucursal_id
+    ) VALUES (
+      p_promocion_id, p_producto_regalo_id, p_ajuste_producto_id_def,
+      0, p_sucursal_id
+    )
+    ON CONFLICT (promocion_id, producto_regalo_id, sucursal_id) DO NOTHING;
+    SELECT id, ajuste_producto_id, usos_pendientes
+      INTO v_acc
+      FROM promo_acumuladores
+     WHERE promocion_id = p_promocion_id
+       AND producto_regalo_id = p_producto_regalo_id
+       AND sucursal_id = p_sucursal_id
+     FOR UPDATE;
+  END IF;
+
+  -- Semantica de RESTO con clamp: usos_pendientes SIEMPRE queda en [0, N).
+  v_usos_raw := COALESCE(v_acc.usos_pendientes, 0) + p_delta;
+  IF v_usos_raw >= 0 THEN
+    v_blocks      := FLOOR(v_usos_raw / v_promo.unidades_por_bloque)::INT;
+    v_usos_final  := v_usos_raw - (v_blocks * v_promo.unidades_por_bloque);
+    v_stock_delta := -(v_blocks * v_promo.stock_por_bloque);
+    v_usos_ajustados := v_blocks * v_promo.unidades_por_bloque;
+  ELSE
+    v_blocks      := CEIL(ABS(v_usos_raw) / v_promo.unidades_por_bloque)::INT;
+    v_usos_final  := v_usos_raw + (v_blocks * v_promo.unidades_por_bloque);
+    v_stock_delta := (v_blocks * v_promo.stock_por_bloque);
+    v_usos_ajustados := -(v_blocks * v_promo.unidades_por_bloque);
+  END IF;
+
+  UPDATE promo_acumuladores
+     SET usos_pendientes = v_usos_final, updated_at = NOW()
+   WHERE id = v_acc.id;
+
+  IF v_stock_delta <> 0 AND v_acc.ajuste_producto_id IS NOT NULL THEN
+    PERFORM set_config('app.stock_origen', 'auto_ajuste_promo', true);
+    PERFORM set_config('app.stock_ref_tipo', 'promocion', true);
+    PERFORM set_config('app.stock_ref_id', p_promocion_id::TEXT, true);
+    PERFORM set_config('app.stock_user_id', p_usuario_id::TEXT, true);
+
+    SELECT stock INTO v_stock_anterior
+      FROM productos
+     WHERE id = v_acc.ajuste_producto_id AND sucursal_id = p_sucursal_id
+     FOR UPDATE;
+    v_stock_nuevo := COALESCE(v_stock_anterior, 0) + v_stock_delta;
+
+    UPDATE productos SET stock = v_stock_nuevo, updated_at = NOW()
+     WHERE id = v_acc.ajuste_producto_id AND sucursal_id = p_sucursal_id;
+
+    INSERT INTO mermas_stock (
+      producto_id, cantidad, motivo, observaciones,
+      stock_anterior, stock_nuevo, usuario_id, sucursal_id
+    ) VALUES (
+      v_acc.ajuste_producto_id,
+      -v_stock_delta,
+      CASE WHEN v_stock_delta < 0 THEN 'promociones' ELSE 'promociones_reversion' END,
+      p_motivo, COALESCE(v_stock_anterior, 0), v_stock_nuevo, p_usuario_id, p_sucursal_id
+    ) RETURNING id INTO v_merma_id;
+
+    INSERT INTO promo_ajustes (
+      promocion_id, usos_ajustados, unidades_ajustadas,
+      producto_id, merma_id, usuario_id, observaciones, sucursal_id
+    ) VALUES (
+      p_promocion_id, v_usos_ajustados, -v_stock_delta,
+      v_acc.ajuste_producto_id, v_merma_id, p_usuario_id, p_motivo, p_sucursal_id
+    );
+  END IF;
+
+  RETURN jsonb_build_object(
+    'aplicado', true,
+    'acumulador_id', v_acc.id,
+    'usos_pendientes', v_usos_final,
+    'bloques_delta', CASE WHEN v_stock_delta < 0 THEN v_blocks ELSE -v_blocks END
+  );
+END;
+$function$;
+
+ALTER FUNCTION public.aplicar_uso_promo_acumulador(BIGINT, BIGINT, NUMERIC, BIGINT, BIGINT, UUID, TEXT)
+  OWNER TO postgres;
+
+COMMENT ON FUNCTION public.aplicar_uso_promo_acumulador(BIGINT, BIGINT, NUMERIC, BIGINT, BIGINT, UUID, TEXT) IS
+  'Aplica delta al acumulador (promo,producto_regalo,sucursal). El factor y el '
+  'stock por bloque salen SIEMPRE de promociones en vivo: el acumulador solo '
+  'guarda el resto y el contenedor de esa barra.';
+
+-- -------------------------------------------------------------------------
+-- 3 - Se van las dos copias.
+-- -------------------------------------------------------------------------
+ALTER TABLE public.promo_acumuladores
+  DROP COLUMN IF EXISTS unidades_por_bloque,
+  DROP COLUMN IF EXISTS stock_por_bloque;
+
+COMMENT ON COLUMN public.promo_acumuladores.ajuste_producto_id IS
+  'Contenedor (fardo) de ESTA barra. Es dato por fila, no copia: difiere del '
+  'ajuste_producto_id de la promo en 7 de 11 filas. NO dropear "por simetria" '
+  'con unidades_por_bloque / stock_por_bloque, que si eran cache.';
+
+COMMENT ON COLUMN public.promo_acumuladores.usos_pendientes IS
+  'Resto de la barra, en [0, N) con N = promociones.unidades_por_bloque VIVO. '
+  'La barra del regalo default de la promo NO vive aca sino en '
+  'promociones.usos_pendientes (ver issue #553).';
+
+-- -------------------------------------------------------------------------
+-- 4 - La aritmetica de renormalizacion, en un solo lugar.
+--     La usan el trigger (que escribe) y el preview (que solo mira), para que
+--     lo que el modal promete y lo que la base hace no se puedan separar.
+-- -------------------------------------------------------------------------
+-- p_resto es NUMERIC, no INT: promo_acumuladores.usos_pendientes es
+-- NUMERIC(10,2) y pedido_items.cantidad tambien, asi que un resto fraccionario
+-- es posible. Con FLOOR nunca se cierra un bloque que la aritmetica exacta no
+-- cerraria; con un cast a int, un resto de 5.5 con N = 6 redondearia a 6 y
+-- cerraria un bloque de mas.
+CREATE OR REPLACE FUNCTION public.bloques_a_cerrar(
+  p_resto numeric,
+  p_unidades_por_bloque integer
+)
+RETURNS integer
+LANGUAGE sql
+IMMUTABLE
+PARALLEL SAFE
+AS $fn$
+  SELECT CASE
+    WHEN COALESCE(p_unidades_por_bloque, 0) <= 0 THEN 0
+    ELSE FLOOR(GREATEST(COALESCE(p_resto, 0), 0) / p_unidades_por_bloque)::int
+  END;
+$fn$;
+
+COMMENT ON FUNCTION public.bloques_a_cerrar(numeric, integer) IS
+  'Bloques que un resto cierra bajo un factor dado. 0 si el factor no fracciona. '
+  'Con N nuevo > N viejo siempre da 0, porque el resto vive en [0, N viejo).';
+
+REVOKE ALL ON FUNCTION public.bloques_a_cerrar(numeric, integer) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.bloques_a_cerrar(numeric, integer) TO authenticated, service_role;
+
+-- -------------------------------------------------------------------------
+-- 5 - El trigger. Renormaliza las barras abiertas cuando cambia el factor.
+--
+--     Va en la tabla y no en una RPC para que no se pueda saltear: el modal,
+--     una RPC futura, o un UPDATE a mano desde el editor SQL, todos pasan por
+--     aca. Mismo criterio que el trigger de la mig 212.
+-- -------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.renormalizar_bloques_por_cambio_factor()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $fn$
+DECLARE
+  v_usuario     UUID := auth.uid();
+  v_n           INT  := NEW.unidades_por_bloque;
+  v_spb         INT  := NEW.stock_por_bloque;
+  v_obs         TEXT;
+  v_barra       RECORD;
+  v_bloques     INT;
+  v_resto_final NUMERIC;
+  v_unidades    INT;
+  v_stock_ant   INT;
+  v_stock_nue   INT;
+  v_merma_id    BIGINT;
+BEGIN
+  -- El prefijo NO puede ser ninguno de los 5 que la mig 212 lee como medicion
+  -- del factor vivo ('Auto-ajuste%', 'Cancelacion pedido #%', 'Eliminacion
+  -- pedido #%', 'Edicion pedido #%', 'Salvedad%'), para que una arqueologia
+  -- futura distinga una medicion de un cambio.
+  v_obs := format('Cambio de factor: unidades_por_bloque %s -> %s, stock_por_bloque %s -> %s',
+                  COALESCE(OLD.unidades_por_bloque::text, 'NULL'),
+                  COALESCE(NEW.unidades_por_bloque::text, 'NULL'),
+                  COALESCE(OLD.stock_por_bloque::text,   'NULL'),
+                  COALESCE(NEW.stock_por_bloque::text,   'NULL'));
+
+  -- Constancia del cambio, SIEMPRE, haya movido stock o no. Es la unica
+  -- evidencia fechada que va a quedar: audit_log_changes no cubre `promociones`
+  -- y `updated_at` es fecha de ultimo USO, no de edicion (mig 212).
+  INSERT INTO promo_ajustes (promocion_id, usos_ajustados, usuario_id, observaciones, sucursal_id)
+  VALUES (NEW.id, 0, v_usuario, v_obs, NEW.sucursal_id);
+
+  -- Sin N nuevo no hay aritmetica posible: la promo dejo de fraccionar. El
+  -- resto queda INTACTO y se renormaliza si la promo vuelve a fraccionar -- ese
+  -- UPDATE dispara este mismo trigger. Es lo menos destructivo y es reversible.
+  IF COALESCE(v_n, 0) <= 0 OR COALESCE(v_spb, 0) <= 0 THEN
+    RETURN NULL;
+  END IF;
+
+  -- Las barras, en una sola lista. acc_id NULL = la barra default, que vive en
+  -- promociones.usos_pendientes. Las filas de acumulador del regalo default
+  -- quedan EXCLUIDAS a proposito: si no, se cerraria el mismo bloque dos veces.
+  --
+  -- Sin FOR UPDATE sobre promo_acumuladores: el UPDATE de `promociones` que
+  -- disparo este trigger ya tiene la fila de la promo bloqueada, y
+  -- aplicar_uso_promo_acumulador arranca con SELECT ... FROM promociones FOR
+  -- UPDATE. Esa fila serializa los dos caminos.
+  FOR v_barra IN
+    SELECT NULL::bigint AS acc_id,
+           GREATEST(COALESCE(NEW.usos_pendientes, 0), 0)::numeric AS resto,
+           NEW.ajuste_producto_id AS contenedor
+    UNION ALL
+    SELECT a.id, GREATEST(COALESCE(a.usos_pendientes, 0), 0), a.ajuste_producto_id
+      FROM promo_acumuladores a
+     WHERE a.promocion_id = NEW.id
+       AND a.sucursal_id  = NEW.sucursal_id
+       AND a.producto_regalo_id IS DISTINCT FROM NEW.producto_regalo_id
+  LOOP
+    v_bloques := public.bloques_a_cerrar(v_barra.resto, v_n);
+    CONTINUE WHEN v_bloques = 0;
+
+    v_resto_final := v_barra.resto - (v_bloques * v_n);
+    v_unidades    := v_bloques * v_spb;
+
+    IF v_barra.acc_id IS NULL THEN
+      -- No re-dispara este trigger: `usos_pendientes` no esta en la lista de
+      -- columnas del UPDATE OF. Si dispara trg_check_promo_limite, que solo
+      -- desactiva la promo cuando el resto SUBE hasta limite_usos -- y aca solo
+      -- puede bajar.
+      -- La columna es INT y su resto tambien, asi que el cast no pierde nada:
+      -- la barra default nunca paso por la aritmetica NUMERIC del acumulador.
+      UPDATE promociones SET usos_pendientes = v_resto_final::int
+       WHERE id = NEW.id AND sucursal_id = NEW.sucursal_id;
+    ELSE
+      UPDATE promo_acumuladores SET usos_pendientes = v_resto_final, updated_at = NOW()
+       WHERE id = v_barra.acc_id;
+    END IF;
+
+    CONTINUE WHEN v_barra.contenedor IS NULL;
+
+    -- Contexto para el trigger registrar_cambio_stock (mig 038).
+    PERFORM set_config('app.stock_origen', 'auto_ajuste_promo', true);
+    PERFORM set_config('app.stock_ref_tipo', 'promocion', true);
+    PERFORM set_config('app.stock_ref_id', NEW.id::TEXT, true);
+    PERFORM set_config('app.stock_user_id', COALESCE(v_usuario::TEXT, ''), true);
+
+    SELECT stock INTO v_stock_ant
+      FROM productos
+     WHERE id = v_barra.contenedor AND sucursal_id = NEW.sucursal_id
+     FOR UPDATE;
+    v_stock_nue := COALESCE(v_stock_ant, 0) - v_unidades;
+
+    UPDATE productos SET stock = v_stock_nue, updated_at = NOW()
+     WHERE id = v_barra.contenedor AND sucursal_id = NEW.sucursal_id;
+
+    -- Misma convencion de signos que aplicar_uso_promo_acumulador:
+    -- + = descuento, - = devolucion. Aca solo se cierran bloques, nunca se
+    -- revierten, asi que siempre es positivo.
+    INSERT INTO mermas_stock (
+      producto_id, cantidad, motivo, observaciones,
+      stock_anterior, stock_nuevo, usuario_id, sucursal_id
+    ) VALUES (
+      v_barra.contenedor, v_unidades, 'promociones', v_obs,
+      COALESCE(v_stock_ant, 0), v_stock_nue, v_usuario, NEW.sucursal_id
+    ) RETURNING id INTO v_merma_id;
+
+    INSERT INTO promo_ajustes (
+      promocion_id, usos_ajustados, unidades_ajustadas,
+      producto_id, merma_id, usuario_id, observaciones, sucursal_id
+    ) VALUES (
+      NEW.id, v_bloques * v_n, v_unidades,
+      v_barra.contenedor, v_merma_id, v_usuario, v_obs, NEW.sucursal_id
+    );
+  END LOOP;
+
+  RETURN NULL;
+END;
+$fn$;
+
+ALTER FUNCTION public.renormalizar_bloques_por_cambio_factor() OWNER TO postgres;
+
+-- Funcion de trigger: no necesita EXECUTE para nadie, la invoca el executor
+-- como parte del DML. Igual que completar_origen_precio_item (mig 148).
+REVOKE ALL ON FUNCTION public.renormalizar_bloques_por_cambio_factor() FROM PUBLIC, anon, authenticated;
+
+-- El WHEN no es opcional: updatePromocion escribe las 14 columnas en cada
+-- guardado, asi que sin el, renombrar una promo dejaria una fila de "cambio de
+-- factor" que no cambio nada.
+DROP TRIGGER IF EXISTS trg_renormalizar_bloques_por_cambio_factor ON public.promociones;
+CREATE TRIGGER trg_renormalizar_bloques_por_cambio_factor
+  AFTER UPDATE OF unidades_por_bloque, stock_por_bloque ON public.promociones
+  FOR EACH ROW
+  WHEN (OLD.unidades_por_bloque IS DISTINCT FROM NEW.unidades_por_bloque
+     OR OLD.stock_por_bloque    IS DISTINCT FROM NEW.stock_por_bloque)
+  EXECUTE FUNCTION public.renormalizar_bloques_por_cambio_factor();
+
+-- -------------------------------------------------------------------------
+-- 6 - El preview que consume el modal. Read-only, misma aritmetica.
+--     SECURITY INVOKER a proposito: las policies de SELECT de promociones,
+--     promo_acumuladores y productos ya lo scopean por sucursal.
+-- -------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.previsualizar_cambio_factor(
+  p_promocion_id        bigint,
+  p_unidades_por_bloque integer,
+  p_stock_por_bloque    integer
+)
+RETURNS TABLE (
+  barra              text,
+  producto_regalo_id bigint,
+  producto_regalo    text,
+  contenedor_id      bigint,
+  contenedor         text,
+  resto_actual       numeric,
+  bloques_a_cerrar   integer,
+  unidades_de_stock  integer,
+  resto_final        numeric
+)
+LANGUAGE sql
+STABLE
+SET search_path TO 'public'
+AS $fn$
+  WITH promo AS (
+    SELECT p.id, p.sucursal_id, p.producto_regalo_id, p.ajuste_producto_id,
+           GREATEST(COALESCE(p.usos_pendientes, 0), 0)::numeric AS resto
+      FROM promociones p
+     WHERE p.id = p_promocion_id
+  ),
+  barras AS (
+    SELECT 'default'::text AS barra, pr.producto_regalo_id AS regalo_id,
+           pr.ajuste_producto_id AS cont_id, pr.resto, pr.sucursal_id
+      FROM promo pr
+    UNION ALL
+    SELECT 'sustituto', a.producto_regalo_id, a.ajuste_producto_id,
+           GREATEST(COALESCE(a.usos_pendientes, 0), 0), a.sucursal_id
+      FROM promo_acumuladores a
+      JOIN promo pr ON pr.id = a.promocion_id AND pr.sucursal_id = a.sucursal_id
+     WHERE a.producto_regalo_id IS DISTINCT FROM pr.producto_regalo_id
+  ),
+  calc AS (
+    SELECT b.*, public.bloques_a_cerrar(b.resto, p_unidades_por_bloque) AS bloques
+      FROM barras b
+  )
+  SELECT c.barra,
+         c.regalo_id,
+         pg.nombre,
+         c.cont_id,
+         pc.nombre,
+         c.resto,
+         c.bloques,
+         (c.bloques * COALESCE(p_stock_por_bloque, 0))::int,
+         c.resto - (c.bloques * COALESCE(p_unidades_por_bloque, 0))
+    FROM calc c
+    LEFT JOIN productos pg ON pg.id = c.regalo_id AND pg.sucursal_id = c.sucursal_id
+    LEFT JOIN productos pc ON pc.id = c.cont_id   AND pc.sucursal_id = c.sucursal_id
+   ORDER BY c.barra, c.regalo_id;
+$fn$;
+
+COMMENT ON FUNCTION public.previsualizar_cambio_factor(bigint, integer, integer) IS
+  'Que pasaria con las barras abiertas si el factor pasara a los valores dados. '
+  'Sin efectos. Comparte la aritmetica con el trigger via bloques_a_cerrar.';
+
+REVOKE ALL ON FUNCTION public.previsualizar_cambio_factor(bigint, integer, integer) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.previsualizar_cambio_factor(bigint, integer, integer) TO authenticated, service_role;
+
+-- -------------------------------------------------------------------------
+-- 7 - Verificacion.
+-- -------------------------------------------------------------------------
+DO $verif$
+DECLARE
+  v_cols  int;
+  v_acl   text;
+  v_trg   int;
+  v_sobre int;
+  v_def   text;
+BEGIN
+  -- La aritmetica, que es el corazon de todo esto. Sin datos: son propiedades
+  -- de la funcion pura que comparten el trigger y el preview.
+  IF public.bloques_a_cerrar(4, 2) <> 2 THEN
+    RAISE EXCEPTION 'bloques_a_cerrar: resto 4 con N=2 tiene que dar 2 bloques.';
+  END IF;
+  IF public.bloques_a_cerrar(4, 6) <> 0 THEN
+    RAISE EXCEPTION 'bloques_a_cerrar: subir el factor NUNCA puede cerrar un bloque.';
+  END IF;
+  IF public.bloques_a_cerrar(5.5, 6) <> 0 THEN
+    RAISE EXCEPTION 'bloques_a_cerrar: un resto fraccionario no se redondea para arriba.';
+  END IF;
+  IF public.bloques_a_cerrar(4, 1) <> 4 THEN
+    RAISE EXCEPTION 'bloques_a_cerrar: con N=1 cada unidad suelta es un bloque.';
+  END IF;
+  IF public.bloques_a_cerrar(4, NULL) <> 0 OR public.bloques_a_cerrar(4, 0) <> 0 THEN
+    RAISE EXCEPTION 'bloques_a_cerrar: sin factor no hay aritmetica, tiene que dar 0.';
+  END IF;
+  IF public.bloques_a_cerrar(0, 6) <> 0 OR public.bloques_a_cerrar(NULL, 6) <> 0 THEN
+    RAISE EXCEPTION 'bloques_a_cerrar: sin resto no se cierra nada.';
+  END IF;
+
+  -- Las dos copias se fueron y las dos columnas que son dato se quedaron.
+  SELECT count(*) INTO v_cols FROM information_schema.columns
+   WHERE table_schema='public' AND table_name='promo_acumuladores'
+     AND column_name IN ('unidades_por_bloque','stock_por_bloque');
+  IF v_cols <> 0 THEN
+    RAISE EXCEPTION 'Quedaron % columna(s) de config en promo_acumuladores.', v_cols;
+  END IF;
+
+  SELECT count(*) INTO v_cols FROM information_schema.columns
+   WHERE table_schema='public' AND table_name='promo_acumuladores'
+     AND column_name IN ('ajuste_producto_id','usos_pendientes');
+  IF v_cols <> 2 THEN
+    RAISE EXCEPTION 'Faltan columnas de dato en promo_acumuladores (hay %, se esperaban 2).', v_cols;
+  END IF;
+
+  -- No quedo ninguna lectura de la copia en el cuerpo vivo de las dos funciones
+  -- que tocan el acumulador.
+  SELECT string_agg(p.proname, ', ') INTO v_acl
+  FROM pg_proc p
+  WHERE p.pronamespace='public'::regnamespace
+    AND p.proname IN ('aplicar_uso_promo_acumulador','sustituir_regalo_pedido')
+    AND pg_get_functiondef(p.oid) LIKE '%v_acc.unidades_por_bloque%';
+  IF v_acl IS NOT NULL THEN
+    RAISE EXCEPTION 'Quedo una lectura de la copia congelada en: %.', v_acl;
+  END IF;
+
+  -- El trigger existe, con la lista de columnas y el WHEN.
+  SELECT count(*) INTO v_trg FROM pg_trigger t
+   WHERE t.tgrelid='public.promociones'::regclass
+     AND t.tgname='trg_renormalizar_bloques_por_cambio_factor';
+  IF v_trg <> 1 THEN
+    RAISE EXCEPTION 'El trigger de renormalizacion no quedo creado.';
+  END IF;
+
+  SELECT pg_get_triggerdef(t.oid) INTO v_def FROM pg_trigger t
+   WHERE t.tgrelid='public.promociones'::regclass
+     AND t.tgname='trg_renormalizar_bloques_por_cambio_factor';
+  IF v_def NOT LIKE '%UPDATE OF unidades_por_bloque, stock_por_bloque%'
+     OR v_def NOT LIKE '%WHEN%IS DISTINCT FROM%' THEN
+    RAISE EXCEPTION 'El trigger quedo sin lista de columnas o sin WHEN: %', v_def;
+  END IF;
+
+  -- Una sola sobrecarga de cada funcion nueva: dos con rangos superpuestos dan
+  -- PGRST203 en runtime, invisible para tsc y para los tests.
+  SELECT count(*) INTO v_sobre FROM pg_proc p
+   WHERE p.pronamespace='public'::regnamespace AND p.proname='previsualizar_cambio_factor';
+  IF v_sobre <> 1 THEN
+    RAISE EXCEPTION 'Hay % sobrecargas de previsualizar_cambio_factor.', v_sobre;
+  END IF;
+
+  -- El ACL de las dos funciones alcanzables quedo cerrado para anon y PUBLIC.
+  SELECT array_to_string(array_agg(p.proname || ' -> ' || a::text), '; ') INTO v_acl
+  FROM pg_proc p, unnest(p.proacl) a
+  WHERE p.pronamespace='public'::regnamespace
+    AND p.proname IN ('previsualizar_cambio_factor','bloques_a_cerrar',
+                      'renormalizar_bloques_por_cambio_factor')
+    AND (a::text LIKE '=%' OR a::text LIKE 'anon=%');
+  IF v_acl IS NOT NULL THEN
+    RAISE EXCEPTION 'Quedo una funcion ejecutable por anon o PUBLIC: %', v_acl;
+  END IF;
+
+  RAISE NOTICE 'OK: el factor tiene una sola fuente viva.';
+END
+$verif$;
+
+COMMIT;

--- a/src/components/modals/ModalPromocion.factor.test.tsx
+++ b/src/components/modals/ModalPromocion.factor.test.tsx
@@ -1,0 +1,153 @@
+/**
+ * Cambiar el factor de fracción de una promo con barras abiertas cierra bloques
+ * y descuenta stock en la misma transacción del guardado (trigger de
+ * renormalización, issue #535). Lo que se cubre acá es que el modal NO deja
+ * guardar eso sin mostrarlo antes: el guardado silencioso era justamente el bug.
+ *
+ * La aritmética no se testea acá a propósito — vive en SQL (`bloques_a_cerrar`),
+ * compartida entre el trigger que escribe y el preview que muestra. Una copia en
+ * TS sería una tercera fuente, que es lo que esta issue vino a eliminar.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import ModalPromocion from './ModalPromocion'
+import type { ProductoDB } from '../../types'
+import type { PromocionConDetalles } from '../../hooks/queries/usePromocionesQuery'
+
+const preview = vi.hoisted(() => vi.fn())
+
+vi.mock('../../hooks/queries/usePromocionesQuery', () => ({
+  usePreviewCambioFactorQuery: (...args: unknown[]) => preview(...args),
+}))
+
+const PRODUCTOS = [
+  { id: '81', nombre: 'MANAOS NARANJA 3L', precio: 100, stock: 40 },
+  { id: '83', nombre: 'MANAOS GRANADINA 3L', precio: 100, stock: 40 },
+] as unknown as ProductoDB[]
+
+/** Promo 13 de prod: fracción, factor 6, contenedor 81. */
+const PROMO = {
+  id: '13',
+  nombre: 'Promo Manaos 6 + 2 3L',
+  tipo: 'bonificacion',
+  activo: true,
+  fecha_inicio: '2026-01-01',
+  fecha_fin: null,
+  producto_regalo_id: '81',
+  ajuste_producto_id: '81',
+  ajuste_automatico: true,
+  regalo_mueve_stock: false,
+  unidades_por_bloque: 6,
+  stock_por_bloque: 1,
+  descripcion_regalo: '1 botella Manaos 3L',
+  usos_pendientes: 4,
+  productos: [{ producto_id: '81' }],
+  reglas: [
+    { clave: 'cantidad_compra', valor: 6 },
+    { clave: 'cantidad_bonificacion', valor: 2 },
+  ],
+} as unknown as PromocionConDetalles
+
+function sinCambios() {
+  return { data: [], isLoading: false }
+}
+
+function conCierre() {
+  return {
+    data: [
+      {
+        barra: 'sustituto',
+        producto_regalo_id: '83',
+        producto_regalo: 'MANAOS GRANADINA 3L',
+        contenedor_id: '83',
+        contenedor: 'MANAOS GRANADINA 3L',
+        resto_actual: 4,
+        bloques_a_cerrar: 2,
+        unidades_de_stock: 2,
+        resto_final: 0,
+      },
+    ],
+    isLoading: false,
+  }
+}
+
+function renderModal(onSave = vi.fn().mockResolvedValue({ success: true })) {
+  render(
+    <ModalPromocion promocion={PROMO} productos={PRODUCTOS} onSave={onSave} onClose={vi.fn()} />,
+  )
+  return { onSave }
+}
+
+const factorInput = () => screen.getByPlaceholderText('Ej: 6')
+const actualizar = () => screen.getByRole('button', { name: 'Actualizar' })
+
+async function cambiarFactorA(valor: string) {
+  await userEvent.clear(factorInput())
+  await userEvent.type(factorInput(), valor)
+  await userEvent.click(actualizar())
+}
+
+describe('ModalPromocion · cambio del factor de fracción', () => {
+  beforeEach(() => {
+    preview.mockReset()
+    preview.mockReturnValue(sinCambios())
+  })
+
+  it('guarda derecho cuando el factor no cambió', async () => {
+    const { onSave } = renderModal()
+    await userEvent.click(actualizar())
+    expect(onSave).toHaveBeenCalledTimes(1)
+    expect(screen.queryByText(/Cambiás el factor/)).not.toBeInTheDocument()
+  })
+
+  it('no guarda sin confirmar cuando el factor cambió', async () => {
+    const { onSave } = renderModal()
+    preview.mockReturnValue(conCierre())
+    await cambiarFactorA('2')
+    expect(await screen.findByText(/Cambiás el factor de 6 a 2/)).toBeInTheDocument()
+    expect(onSave).not.toHaveBeenCalled()
+  })
+
+  it('dice cuántas unidades de stock se van y de qué contenedor', async () => {
+    renderModal()
+    preview.mockReturnValue(conCierre())
+    await cambiarFactorA('2')
+    expect(await screen.findByText(/Se descuentan 2 unidades de stock/)).toBeInTheDocument()
+    expect(screen.getByText(/MANAOS GRANADINA 3L: 4 pendientes/)).toBeInTheDocument()
+  })
+
+  it('avisa explícitamente cuando no se mueve stock', async () => {
+    renderModal()
+    preview.mockReturnValue({ data: [{ bloques_a_cerrar: 0 }], isLoading: false })
+    await cambiarFactorA('12')
+    expect(await screen.findByText(/No se mueve stock/)).toBeInTheDocument()
+  })
+
+  it('guarda recién al confirmar', async () => {
+    const { onSave } = renderModal()
+    preview.mockReturnValue(conCierre())
+    await cambiarFactorA('2')
+    await userEvent.click(await screen.findByRole('button', { name: 'Guardar igual' }))
+    expect(onSave).toHaveBeenCalledTimes(1)
+    expect(onSave.mock.calls[0][0]).toMatchObject({ unidadesPorBloque: 2, stockPorBloque: 1 })
+  })
+
+  it('volver cancela el guardado y deja el modal editable', async () => {
+    const { onSave } = renderModal()
+    preview.mockReturnValue(conCierre())
+    await cambiarFactorA('2')
+    await userEvent.click(await screen.findByRole('button', { name: 'Volver' }))
+    expect(onSave).not.toHaveBeenCalled()
+    expect(screen.queryByText(/Cambiás el factor/)).not.toBeInTheDocument()
+    expect(factorInput()).toHaveValue(2)
+  })
+
+  it('no confirma nada mientras el preview está cargando', async () => {
+    renderModal()
+    preview.mockReturnValue({ data: undefined, isLoading: true })
+    await cambiarFactorA('2')
+    expect(await screen.findByText(/Calculando/)).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Guardar igual' })).toBeDisabled()
+  })
+})

--- a/src/components/modals/ModalPromocion.tsx
+++ b/src/components/modals/ModalPromocion.tsx
@@ -5,10 +5,11 @@
  * Incluye: nombre, fechas, selector de productos, reglas (cantidad_compra, cantidad_bonificacion).
  */
 import { useState, useMemo } from 'react'
-import { X, Search, Gift, ChevronDown, ChevronRight, Layers, Ban, Package, Droplet } from 'lucide-react'
+import { X, Search, Gift, ChevronDown, ChevronRight, Layers, Ban, Package, Droplet, AlertTriangle } from 'lucide-react'
 import { fechaLocalISO } from '../../utils/formatters'
 import type { ProductoDB } from '../../types'
 import type { PromocionConDetalles, PromocionFormInput } from '../../hooks/queries/usePromocionesQuery'
+import { usePreviewCambioFactorQuery } from '../../hooks/queries/usePromocionesQuery'
 
 export interface ModalPromocionProps {
   promocion: PromocionConDetalles | null
@@ -77,6 +78,7 @@ export default function ModalPromocion({
   const [busqueda, setBusqueda] = useState('')
   const [busquedaRegalo, setBusquedaRegalo] = useState('')
   const [saving, setSaving] = useState(false)
+  const [confirmandoFactor, setConfirmandoFactor] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
   const productosFiltrados = useMemo(() => {
@@ -138,6 +140,25 @@ export default function ModalPromocion({
     })
   }
 
+  // Cambiar el factor de una promo con barras abiertas cierra bloques y mueve
+  // stock en la misma transacción del guardado (trigger de renormalización,
+  // issue #535). El preview es read-only y comparte la aritmética con ese
+  // trigger, así que lo que se muestra acá es lo que va a pasar.
+  const factorNuevo = parseInt(unidadesPorBloque)
+  const factorCambia = isEditing
+    && tipoRegalo === 'fraccion'
+    && Number.isFinite(factorNuevo)
+    && factorNuevo > 0
+    && factorNuevo !== (promocion?.unidades_por_bloque ?? null)
+  const { data: preview, isLoading: cargandoPreview } = usePreviewCambioFactorQuery(
+    promocion?.id ?? null,
+    Number.isFinite(factorNuevo) ? factorNuevo : null,
+    1,
+    factorCambia
+  )
+  const barrasQueCierran = (preview ?? []).filter(b => b.bloques_a_cerrar > 0)
+  const fardosAMover = barrasQueCierran.reduce((acc, b) => acc + b.unidades_de_stock, 0)
+
   const handleSubmit = async () => {
     setError(null)
 
@@ -164,16 +185,7 @@ export default function ModalPromocion({
       return
     }
 
-    // Derivados segun tipo de regalo.
-    // - Fraccion: ajuste_automatico=true (descuenta fardo al cerrar bloque),
-    //   regalo_mueve_stock=false (no descuenta al entregar la botella suelta).
-    // - Unidad entera: ajuste_automatico=false, regalo_mueve_stock=true
-    //   (el stock se descuenta al entregar cada unidad completa).
-    const esFraccion = tipoRegalo === 'fraccion'
-    const finalAjusteAutomatico = esFraccion
-    const finalRegaloMueveStock = !esFraccion
-
-    if (esFraccion) {
+    if (tipoRegalo === 'fraccion') {
       if (!descripcionRegalo.trim()) {
         setError('Escribí una descripción del regalo (ej: "1 botella Manaos Naranja 600cc")')
         return
@@ -189,6 +201,30 @@ export default function ModalPromocion({
       }
     }
 
+    // El factor cambió: no se guarda sin que el admin vea qué le pasa a las
+    // barras abiertas. La confirmación se renderiza DENTRO del modal, no como
+    // hermano en el container, o queda atrás del overlay.
+    if (factorCambia) {
+      setConfirmandoFactor(true)
+      return
+    }
+
+    await guardar()
+  }
+
+  const guardar = async () => {
+    const compra = parseInt(cantidadCompra)
+    const bonif = parseInt(cantidadBonificacion)
+    // Derivados segun tipo de regalo.
+    // - Fraccion: ajuste_automatico=true (descuenta fardo al cerrar bloque),
+    //   regalo_mueve_stock=false (no descuenta al entregar la botella suelta).
+    // - Unidad entera: ajuste_automatico=false, regalo_mueve_stock=true
+    //   (el stock se descuenta al entregar cada unidad completa).
+    const esFraccion = tipoRegalo === 'fraccion'
+    const finalAjusteAutomatico = esFraccion
+    const finalRegaloMueveStock = !esFraccion
+
+    setConfirmandoFactor(false)
     setSaving(true)
     const limite = limiteUsos ? parseInt(limiteUsos) : null
     const prio = parseInt(prioridad)
@@ -232,7 +268,7 @@ export default function ModalPromocion({
 
   return (
     <div className="fixed inset-0 bg-black/50 z-50 flex items-center justify-center p-4">
-      <div className="bg-white dark:bg-gray-800 rounded-xl shadow-xl w-full max-w-lg max-h-[90vh] flex flex-col">
+      <div className="relative bg-white dark:bg-gray-800 rounded-xl shadow-xl w-full max-w-lg max-h-[90vh] flex flex-col">
         {/* Header */}
         <div className="flex items-center justify-between px-5 py-4 border-b dark:border-gray-700">
           <h2 className="text-lg font-semibold dark:text-white">
@@ -752,6 +788,70 @@ export default function ModalPromocion({
             {saving ? 'Guardando...' : isEditing ? 'Actualizar' : 'Crear Promocion'}
           </button>
         </div>
+
+        {/* Confirmación del cambio de factor. Va DENTRO del modal: como hermano
+            en el container quedaría detrás de este overlay y fallaría en silencio. */}
+        {confirmandoFactor && (
+          <div className="absolute inset-0 bg-black/50 rounded-xl flex items-center justify-center p-4">
+            <div className="bg-white dark:bg-gray-800 rounded-lg shadow-xl w-full max-w-md p-5">
+              <div className="flex items-start gap-3 mb-3">
+                <AlertTriangle className="w-5 h-5 text-amber-500 flex-shrink-0 mt-0.5" />
+                <div>
+                  <h3 className="text-base font-semibold dark:text-white">
+                    Cambiás el factor de {promocion?.unidades_por_bloque ?? '?'} a {factorNuevo}
+                  </h3>
+                  <p className="text-sm text-gray-600 dark:text-gray-400 mt-1">
+                    Las unidades ya regaladas que todavía no cerraron un bloque se
+                    saldan con el factor nuevo, ahora.
+                  </p>
+                </div>
+              </div>
+
+              {cargandoPreview ? (
+                <p className="text-sm text-gray-500 dark:text-gray-400 py-3">Calculando…</p>
+              ) : barrasQueCierran.length === 0 ? (
+                <p className="text-sm text-emerald-700 dark:text-emerald-300 bg-emerald-50 dark:bg-emerald-900/20 rounded-lg px-3 py-2">
+                  No se mueve stock: ninguna barra abierta llega a cerrar un bloque
+                  con el factor nuevo.
+                </p>
+              ) : (
+                <div className="text-sm bg-amber-50 dark:bg-amber-900/20 rounded-lg px-3 py-2 space-y-1">
+                  <p className="text-amber-800 dark:text-amber-200 font-medium">
+                    Se descuentan {fardosAMover} {fardosAMover === 1 ? 'unidad' : 'unidades'} de stock:
+                  </p>
+                  <ul className="text-amber-700 dark:text-amber-300 space-y-0.5">
+                    {barrasQueCierran.map((b, i) => (
+                      <li key={`${b.producto_regalo_id ?? 'x'}-${i}`}>
+                        {/* resto_* son `numeric` en la RPC y PostgREST los puede
+                            mandar como string ("4.00"); Number() normaliza. */}
+                        {b.producto_regalo ?? 'Regalo'}: {Number(b.resto_actual)} pendientes →
+                        cierra {b.bloques_a_cerrar} {b.bloques_a_cerrar === 1 ? 'bloque' : 'bloques'},
+                        descuenta {b.unidades_de_stock} de {b.contenedor ?? 'sin contenedor'},
+                        queda en {Number(b.resto_final)}
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              )}
+
+              <div className="flex justify-end gap-2 mt-4">
+                <button
+                  onClick={() => setConfirmandoFactor(false)}
+                  className="px-4 py-2 text-sm text-gray-600 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-lg"
+                >
+                  Volver
+                </button>
+                <button
+                  onClick={guardar}
+                  disabled={saving || cargandoPreview}
+                  className="px-4 py-2 text-sm bg-purple-600 text-white rounded-lg hover:bg-purple-700 disabled:opacity-50 disabled:cursor-not-allowed"
+                >
+                  Guardar igual
+                </button>
+              </div>
+            </div>
+          </div>
+        )}
       </div>
     </div>
   )

--- a/src/components/modals/ModalSustituirRegalo.tsx
+++ b/src/components/modals/ModalSustituirRegalo.tsx
@@ -115,7 +115,8 @@ const ModalSustituirRegalo = memo(function ModalSustituirRegalo({
   const usosOrigDespues = usosOrigAntes - cantidadOriginal
   const usosSustAntes = Number(acumuladorSustituto?.usos_pendientes ?? 0)
   const usosSustDespues = usosSustAntes + cantidadNum
-  const bloque = unidadesPorBloque ?? acumuladorOriginal?.unidades_por_bloque ?? 1
+  // El factor sale de la promo en vivo: el acumulador ya no guarda copia (issue #535).
+  const bloque = unidadesPorBloque ?? 1
   // Defensa display: los acumuladores pueden venir fuera de rango (bug backend de bloques).
   // Clampeamos los valores que se muestran al usuario a [0, bloque].
   const clampBloque = (n: number) => Math.max(0, Math.min(n, bloque))

--- a/src/components/vistas/VistaPromociones.tsx
+++ b/src/components/vistas/VistaPromociones.tsx
@@ -282,8 +282,6 @@ export default function VistaPromociones({
                         producto_regalo_id: defaultProductoId,
                         ajuste_producto_id: accDefault?.ajuste_producto_id
                           ?? (promo.ajuste_producto_id ? String(promo.ajuste_producto_id) : null),
-                        unidades_por_bloque: accDefault?.unidades_por_bloque ?? promo.unidades_por_bloque,
-                        stock_por_bloque: accDefault?.stock_por_bloque ?? promo.stock_por_bloque,
                         usos_pendientes: promo.usos_pendientes ?? 0,
                         sucursal_id: accDefault?.sucursal_id ?? 0,
                         created_at: '',
@@ -303,7 +301,9 @@ export default function VistaPromociones({
                     return (
                       <div className="mb-3 space-y-2">
                         {visibles.map(acc => {
-                          const porBloque = acc.unidades_por_bloque ?? promo.unidades_por_bloque ?? 1
+                          // El factor sale SIEMPRE de la promo en vivo: el acumulador
+                          // ya no guarda copia (issue #535).
+                          const porBloque = promo.unidades_por_bloque ?? 1
                           // Defensa: el acumulador puede venir fuera de rango desde la BD
                           // (bug historico del subsistema de bloques: negativos o > tope).
                           // Clampeamos a [0, porBloque] para no mostrar "24/12" o "-10/12".

--- a/src/hooks/queries/usePromocionesQuery.ts
+++ b/src/hooks/queries/usePromocionesQuery.ts
@@ -12,6 +12,7 @@ import type {
   PromocionReglaDB,
   PromoAcumuladorDB,
   PedidoItemSustitucionDB,
+  PreviewCambioFactorDB,
 } from '../../types'
 import type { PromoMap, PromocionActiva } from '../../utils/promociones'
 import { traerTodo } from '../../utils/paginacion'
@@ -574,6 +575,42 @@ export function usePromoAcumuladoresMapQuery() {
     },
     enabled: !!currentSucursalId,
     staleTime: 30 * 1000,
+  })
+}
+
+/**
+ * Qué le pasaría a las barras abiertas de una promo si el factor pasara a los
+ * valores dados. Read-only: la RPC comparte la aritmética con el trigger que
+ * después escribe, así que lo que el modal promete y lo que la base hace no se
+ * pueden separar (issue #535).
+ *
+ * `enabled` sólo cuando el valor propuesto DIFIERE del guardado: preguntar por
+ * el valor que ya está guardado siempre devuelve "no pasa nada".
+ */
+export function usePreviewCambioFactorQuery(
+  promocionId: string | number | null | undefined,
+  unidadesPorBloque: number | null,
+  stockPorBloque: number | null,
+  habilitado: boolean
+) {
+  const { currentSucursalId } = useSucursal()
+  const pid = promocionId == null ? '' : String(promocionId)
+  return useQuery({
+    queryKey: [
+      ...promocionesKeys.all(currentSucursalId),
+      'preview_factor', pid, unidadesPorBloque, stockPorBloque,
+    ] as const,
+    queryFn: async (): Promise<PreviewCambioFactorDB[]> => {
+      const { data, error } = await supabase.rpc('previsualizar_cambio_factor', {
+        p_promocion_id: Number(pid),
+        p_unidades_por_bloque: unidadesPorBloque,
+        p_stock_por_bloque: stockPorBloque,
+      })
+      if (error) throw error
+      return (data ?? []) as PreviewCambioFactorDB[]
+    },
+    enabled: habilitado && !!promocionId && !!currentSucursalId,
+    staleTime: 0,
   })
 }
 

--- a/src/types/hooks.ts
+++ b/src/types/hooks.ts
@@ -1308,18 +1308,33 @@ export interface SustituirRegaloInput {
 /**
  * Acumulador por (promo, producto regalado, sucursal). Una promo modo B
  * puede tener varios acumuladores cuando admin sustituye regalos. Mig 059.
+ *
+ * NO tiene el factor: `unidades_por_bloque` y `stock_por_bloque` salen siempre
+ * de `promociones` en vivo (issue #535). `ajuste_producto_id` sí es dato por
+ * fila — es el contenedor que eligió el admin para ESE sabor sustituido.
  */
 export interface PromoAcumuladorDB {
   id: string;
   promocion_id: string;
   producto_regalo_id: string;
   ajuste_producto_id: string | null;
-  unidades_por_bloque: number | null;
-  stock_por_bloque: number | null;
   usos_pendientes: number;
   sucursal_id: number;
   created_at: string;
   updated_at: string;
+}
+
+/** Una fila de `previsualizar_cambio_factor`: qué le pasaría a una barra. */
+export interface PreviewCambioFactorDB {
+  barra: 'default' | 'sustituto';
+  producto_regalo_id: string | null;
+  producto_regalo: string | null;
+  contenedor_id: string | null;
+  contenedor: string | null;
+  resto_actual: number;
+  bloques_a_cerrar: number;
+  unidades_de_stock: number;
+  resto_final: number;
 }
 
 export interface SustituirRegaloResult {


### PR DESCRIPTION
Implementa el diseño acordado en #535.

## El problema, y por qué no era el que parecía

El factor de fracción estaba en tres tablas y editarlo desde el modal las desalineaba. Pero leyendo el código **vivo de prod** (no `migrations/`, que no es espejo) apareció que no eran tres fuentes iguales:

- **El acumulador no está en el camino principal del stock.** Solo `aplicar_uso_promo_acumulador` y `sustituir_regalo_pedido` tocan `promo_acumuladores`. Los cuatro caminos que descuentan stock de verdad — `crear_pedido_completo`, el bot, `actualizar_pedido_items`, `revertir_bloques_auto_ajuste` — leen `promociones` en vivo y no lo miran.
- **`aplicar_uso_promo_acumulador` ya se contradecía sola**: el gate leía el valor vivo, la aritmética el congelado.
- **La copia nunca divergió**: en 11 filas, `unidades_por_bloque` y `stock_por_bloque` difieren del vivo en 0. Pero `ajuste_producto_id` difiere en **7** — ese sí es dato por fila.

O sea: de las tres columnas de config copiadas, una es dato y dos eran caché que nadie invalidaba.

## Qué hace

**Dos fuentes con roles distintos.** `promociones` gobierna qué pasa ahora; `pedido_items.unidades_por_bloque_al_crear` (mig 212) gobierna qué dice la historia. Se dropean las dos columnas caché del acumulador y se queda `ajuste_producto_id` + `usos_pendientes`.

**Cambiar el factor renormaliza las barras abiertas en la misma transacción**, vía trigger `AFTER UPDATE OF unidades_por_bloque, stock_por_bloque` sobre `promociones` — en la tabla y no en una RPC para que no se pueda saltear. Deja constancia en `promo_ajustes` **siempre**, haya movido stock o no: hoy no existe ningún historial de ediciones de promo, y esa fila es la única evidencia fechada de que el factor cambió.

**El modal avisa antes.** `previsualizar_cambio_factor` es read-only y comparte la aritmética con el trigger (`bloques_a_cerrar`), así que lo que el modal promete es literalmente lo que la base hace.

## La regla que evita el doble descuento

`promociones.usos_pendientes` manda en la barra default. El trigger toca esa y las filas de acumulador de **sustitutos únicamente**; la fila del regalo default no la toca nunca — ni la espeja ni la cierra. Espejarla haría desaparecer los 4 pendientes de la promo 13 sin mover un fardo.

## Cómo se verificó

La migración entera corrió **contra los datos reales de prod** dentro de una transacción terminada en `ROLLBACK`, con 7 casos sobre la promo 13: bajar el factor cierra los bloques correctos y descuenta de cada contenedor; subirlo no mueve nada; `N → NULL` deja el resto intacto; renombrar la promo no dispara el trigger; reescribir el mismo valor tampoco; el preview coincide con el trigger; y el helper usa el factor vivo. Control negativo aparte para confirmar que un `RAISE EXCEPTION` vuelve como error.

Las cuatro compuertas: `typecheck`, `lint`, `test:run` (1649), `build`. Los 7 tests nuevos del modal verificados por mutación — sacando el gate de confirmación, 6 fallan.

**La migración 220 ya está aplicada a prod** (ledger `220_el_factor_de_fraccion_tiene_una_sola_fuente_viva`). Aplicarla sola no movió ningún número: el trigger recién actúa ante un cambio de factor.

## Dos cosas que no estaban en el plan del issue

- **La aritmética quedó en SQL**, no en `src/utils/`. Una copia en TS habría sido una tercera fuente — justo lo que esta issue vino a eliminar — y no probaría nada sobre el trigger, que es el que escribe. Vive en `bloques_a_cerrar`, compartida, con sus aserciones en la verificación de la migración.
- **`sustituir_regalo_pedido` también había que parchearla**: creaba la entry default copiando las dos columnas, así que el DROP la rompía en runtime sin fallar en `tsc` ni en los tests. Se parchea por ancla sobre el cuerpo vivo, como hizo la 212.

## Fuera de alcance

Salieron del análisis y tienen issue propio: #552 (`unidadesRegalo.ts` lee el factor en vivo para mostrar un pedido histórico) y #553 (el resto de la barra default está doblemente representado y no coincide).

Cierra #535.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
