### PR TITLE
La etiqueta usa la cascada completa, y promociones se audita

### DIFF
--- a/migrations/222_promociones_se_audita_como_las_otras_once.sql
+++ b/migrations/222_promociones_se_audita_como_las_otras_once.sql
@@ -1,0 +1,138 @@
+-- =========================================================================
+-- promociones se audita como las otras once
+--
+-- EL PROBLEMA (issue #536)
+-- ------------------------
+-- `audit_log_changes` cubre once tablas -- clientes, compras,
+-- grupo_precio_escala_minimos, pagos, pedido_items, pedidos, perfiles,
+-- productos, rendicion_gastos, rendiciones, rendiciones_control -- y
+-- `promociones` no esta. Sus tres triggers no auditan nada: solo pisan
+-- `updated_at`, setean la sucursal y apagan la promo al llegar al limite.
+--
+-- LO QUE COSTO
+-- ------------
+-- Para congelar el factor de fraccion (mig 212) no habia forma directa de
+-- saber si alguna promo se habia editado alguna vez. Hubo que reconstruir el
+-- historico MIDIENDO desde `promo_ajustes`, aprovechando que
+-- `usos_ajustados = bloques * unidades_por_bloque` deja el factor vivo escrito
+-- en cada fila. Funciona, pero es un rodeo, no una fuente.
+--
+-- Y peor: `promociones.updated_at` PARECE fecha de edicion y no lo es. El
+-- trigger que la pisa no tiene `UPDATE OF` ni `WHEN`, y crear_pedido_completo
+-- bumpea la fila en CADA bonificacion, asi que es fecha de ULTIMO USO. Leerla
+-- como "cuando se edito esto" hizo perder una sesion entera creyendo que las 12
+-- promos habian sido editadas cuando ninguna lo fue.
+--
+-- POR QUE EL TRIGGER VA PLANO Y NO CON LISTA DE COLUMNAS
+-- ------------------------------------------------------
+-- La tentacion es `AFTER UPDATE OF <columnas de config>` para no auditar los
+-- bumps del contador. Se descarto por dos razones:
+--
+--   1. `UPDATE OF` no cubre lo que no nombra, y ademas mira la lista SET del
+--      statement, NO lo que escriben los BEFORE triggers. `check_promo_limite_usos`
+--      apaga `activo` desde un BEFORE cuando el statement solo nombraba
+--      `usos_pendientes`: con lista de columnas, esa desactivacion automatica
+--      NO quedaria auditada. Es exactamente la trampa 6 de CLAUDE.md.
+--
+--   2. El volumen no lo justifica. En los ultimos 30 dias hubo 324
+--      bonificaciones y 172 filas de promo_ajustes, o sea ~500 UPDATE a
+--      `promociones`, contra 29.601 filas que audit_logs ya escribe en el mismo
+--      periodo. Es +1,7%.
+--
+-- Va plano, igual que las otras once. La consistencia tambien vale: el proximo
+-- que mire no tiene que aprender un caso especial.
+--
+-- COMO SE FILTRAN LOS BUMPS DEL CONTADOR AL CONSULTAR
+-- ---------------------------------------------------
+--   SELECT * FROM audit_logs
+--    WHERE tabla = 'promociones'
+--      AND NOT (campos_modificados <@ ARRAY['usos_pendientes','updated_at']);
+-- Queda como COMMENT ON TRIGGER, que es donde alguien lo va a buscar.
+--
+-- NO SE TOCA `updated_at`. Cambiarle la semantica es otra discusion y ninguna
+-- de las nueve funciones que hacen UPDATE a `promociones` la lee, ni el front
+-- tampoco. Se documenta la trampa en la columna y listo.
+--
+-- No hay funcion nueva: `audit_log_changes` ya existe con su ACL cerrado
+-- (postgres + service_role, sin PUBLIC ni anon), que es lo que corresponde a
+-- una funcion de trigger. Un trigger nuevo no cambia ningun ACL.
+--
+-- ESTO NO RECONSTRUYE EL PASADO. Previene la proxima vez.
+-- =========================================================================
+
+BEGIN;
+
+-- -------------------------------------------------------------------------
+-- 1 - El trigger, con el mismo nombre y forma que los otros once.
+-- -------------------------------------------------------------------------
+DROP TRIGGER IF EXISTS audit_promociones ON public.promociones;
+CREATE TRIGGER audit_promociones
+  AFTER INSERT OR DELETE OR UPDATE ON public.promociones
+  FOR EACH ROW
+  EXECUTE FUNCTION public.audit_log_changes();
+
+COMMENT ON TRIGGER audit_promociones ON public.promociones IS
+  'Auditoria de promociones (issue #536). Audita TODO, incluidos los bumps de '
+  'usos_pendientes que hace crear_pedido_completo en cada bonificacion. Para ver '
+  'solo las ediciones de verdad: WHERE tabla = ''promociones'' AND NOT '
+  '(campos_modificados <@ ARRAY[''usos_pendientes'',''updated_at'']).';
+
+-- -------------------------------------------------------------------------
+-- 2 - La trampa de updated_at, escrita donde se la busca.
+-- -------------------------------------------------------------------------
+COMMENT ON COLUMN public.promociones.updated_at IS
+  'NO es fecha de edicion: es fecha de ULTIMO USO. El trigger que la pisa no '
+  'tiene UPDATE OF ni WHEN, y crear_pedido_completo bumpea la fila en cada '
+  'bonificacion. Para saber cuando se edito una promo, mirar audit_logs '
+  '(trigger audit_promociones, issue #536).';
+
+-- -------------------------------------------------------------------------
+-- 3 - Verificacion.
+-- -------------------------------------------------------------------------
+DO $verif$
+DECLARE
+  v_trg   int;
+  v_def   text;
+  v_acl   text;
+  v_tablas int;
+BEGIN
+  SELECT count(*) INTO v_trg FROM pg_trigger t
+   WHERE t.tgrelid = 'public.promociones'::regclass AND t.tgname = 'audit_promociones';
+  IF v_trg <> 1 THEN
+    RAISE EXCEPTION 'El trigger de auditoria no quedo creado.';
+  END IF;
+
+  -- Plano: sin lista de columnas y sin WHEN, o se pierde lo que escriben los
+  -- BEFORE triggers (ver el encabezado).
+  SELECT pg_get_triggerdef(t.oid) INTO v_def FROM pg_trigger t
+   WHERE t.tgrelid = 'public.promociones'::regclass AND t.tgname = 'audit_promociones';
+  IF v_def LIKE '%UPDATE OF%' OR v_def LIKE '%WHEN%' THEN
+    RAISE EXCEPTION 'El trigger quedo filtrado y va plano a proposito: %', v_def;
+  END IF;
+  IF v_def NOT LIKE '%INSERT%' OR v_def NOT LIKE '%UPDATE%' OR v_def NOT LIKE '%DELETE%' THEN
+    RAISE EXCEPTION 'El trigger no cubre las tres operaciones: %', v_def;
+  END IF;
+
+  -- Ahora son doce.
+  SELECT count(DISTINCT c.relname) INTO v_tablas
+    FROM pg_trigger t JOIN pg_class c ON c.oid = t.tgrelid
+   WHERE NOT t.tgisinternal AND pg_get_triggerdef(t.oid) LIKE '%audit_log_changes%';
+  IF v_tablas <> 12 THEN
+    RAISE EXCEPTION 'audit_log_changes cubre % tablas, se esperaban 12.', v_tablas;
+  END IF;
+
+  -- El ACL de la funcion de trigger sigue cerrado: no necesita EXECUTE para
+  -- nadie porque la invoca el executor como parte del DML.
+  SELECT array_to_string(array_agg(a::text), ' ') INTO v_acl
+  FROM pg_proc p, unnest(p.proacl) a
+  WHERE p.pronamespace = 'public'::regnamespace AND p.proname = 'audit_log_changes'
+    AND (a::text LIKE '=%' OR a::text LIKE 'anon=%' OR a::text LIKE 'authenticated=%');
+  IF v_acl IS NOT NULL THEN
+    RAISE EXCEPTION 'audit_log_changes quedo ejecutable de mas (%).', v_acl;
+  END IF;
+
+  RAISE NOTICE 'OK: promociones se audita, ahora son 12 tablas.';
+END
+$verif$;
+
+COMMIT;

--- a/src/hooks/queries/usePedidosQuery.ts
+++ b/src/hooks/queries/usePedidosQuery.ts
@@ -141,8 +141,8 @@ const PEDIDO_CLIENT_COLS = 'id, nombre_fantasia, razon_social, cuit, direccion, 
 // (useRecorridosHojaRutaQuery) y la ruta recien armada
 // (useRecorridoExistenteQuery)— y las tres tienen que llevar la deuda al papel
 // del transportista. Medido: 21 ms las dos juntas sobre 53 pedidos.
-export const PEDIDO_SELECT = `*, deuda_previa, deuda_previa_detalle, cliente:clientes(${PEDIDO_CLIENT_COLS}), items:pedido_items(*, producto:productos(${PEDIDO_PRODUCT_COLS}), promocion:promociones(unidades_por_bloque)), pagos(forma_pago, monto)` as const
-const PEDIDO_SELECT_CLIENTE_INNER = `*, deuda_previa, deuda_previa_detalle, cliente:clientes!inner(${PEDIDO_CLIENT_COLS}), items:pedido_items(*, producto:productos(${PEDIDO_PRODUCT_COLS}), promocion:promociones(unidades_por_bloque)), pagos(forma_pago, monto)` as const
+export const PEDIDO_SELECT = `*, deuda_previa, deuda_previa_detalle, cliente:clientes(${PEDIDO_CLIENT_COLS}), items:pedido_items(*, producto:productos(${PEDIDO_PRODUCT_COLS}), promocion:promociones(unidades_por_bloque, regalo_mueve_stock)), pagos(forma_pago, monto)` as const
+const PEDIDO_SELECT_CLIENTE_INNER = `*, deuda_previa, deuda_previa_detalle, cliente:clientes!inner(${PEDIDO_CLIENT_COLS}), items:pedido_items(*, producto:productos(${PEDIDO_PRODUCT_COLS}), promocion:promociones(unidades_por_bloque, regalo_mueve_stock)), pagos(forma_pago, monto)` as const
 
 
 // Helper: cargar salvedades para un conjunto de pedidos
@@ -204,7 +204,7 @@ async function fetchPedidosByTransportista(transportistaId: string): Promise<Ped
 async function fetchPedidosByCliente(clienteId: string): Promise<PedidoDB[]> {
   const { data, error } = await supabase
     .from('pedidos')
-    .select(`*, items:pedido_items(*, producto:productos(${PEDIDO_PRODUCT_COLS}), promocion:promociones(unidades_por_bloque)), pagos(forma_pago, monto)` as const)
+    .select(`*, items:pedido_items(*, producto:productos(${PEDIDO_PRODUCT_COLS}), promocion:promociones(unidades_por_bloque, regalo_mueve_stock)), pagos(forma_pago, monto)` as const)
     .eq('cliente_id', clienteId)
     .order('created_at', { ascending: false })
     .limit(50)

--- a/src/types/hooks.ts
+++ b/src/types/hooks.ts
@@ -136,9 +136,15 @@ export interface PedidoItemDB {
   es_bonificacion?: boolean;
   promocion_id?: string;
   descripcion_regalo?: string | null;
-  /** Datos de la promo asociada (sólo presente cuando promocion_id está set) */
+  /** Factor de fracción congelado al crear la línea (mig 212). Manda sobre el
+   *  vivo de la promo para todo lo que DESCRIBE la línea (issue #534). */
+  unidades_por_bloque_al_crear?: number | null;
+  /** Datos de la promo asociada (sólo presente cuando promocion_id está set).
+   *  Es el fallback vivo de `factor_bonificacion`, y por eso trae también el
+   *  gate `regalo_mueve_stock`, no sólo el divisor. */
   promocion?: {
     unidades_por_bloque?: number | null;
+    regalo_mueve_stock?: boolean | null;
   } | null;
   /** Precio sin IVA por unidad, SIEMPRE (teórico en ZZ; mig 123) */
   neto_unitario?: number;

--- a/src/utils/unidadesRegalo.test.ts
+++ b/src/utils/unidadesRegalo.test.ts
@@ -8,13 +8,13 @@ import {
 describe('esCantidadEnSubunidades', () => {
   it('es true para el regalo de una promo fraccionada', () => {
     expect(esCantidadEnSubunidades({
-      cantidad: 392, es_bonificacion: true, promocion: { unidades_por_bloque: 6 },
+      cantidad: 392, es_bonificacion: true, promocion: { unidades_por_bloque: 6, regalo_mueve_stock: false },
     })).toBe(true);
   });
 
   it('es false para una línea de venta, aunque tenga promo', () => {
     expect(esCantidadEnSubunidades({
-      cantidad: 30, es_bonificacion: false, promocion: { unidades_por_bloque: 6 },
+      cantidad: 30, es_bonificacion: false, promocion: { unidades_por_bloque: 6, regalo_mueve_stock: false },
     })).toBe(false);
   });
 
@@ -32,7 +32,7 @@ describe('esCantidadEnSubunidades', () => {
 describe('formatCantidadItem', () => {
   it('aclara la unidad sólo en el regalo fraccionado', () => {
     expect(formatCantidadItem({
-      cantidad: 392, es_bonificacion: true, promocion: { unidades_por_bloque: 6 },
+      cantidad: 392, es_bonificacion: true, promocion: { unidades_por_bloque: 6, regalo_mueve_stock: false },
     })).toBe('x392 botellas');
     expect(formatCantidadItem({ cantidad: 30 })).toBe('x30');
   });
@@ -42,16 +42,16 @@ describe('equivalenteEnUnidades', () => {
   it('convierte a fardos el regalo fraccionado', () => {
     // El caso que disparó todo: 392 botellas = 65,3 fardos, no 392 fardos.
     expect(equivalenteEnUnidades({
-      cantidad: 392, es_bonificacion: true, promocion: { unidades_por_bloque: 6 },
+      cantidad: 392, es_bonificacion: true, promocion: { unidades_por_bloque: 6, regalo_mueve_stock: false },
     })).toBe('≈ 65,3 fardos');
   });
 
   it('no muestra decimales cuando el bloque cierra justo', () => {
     expect(equivalenteEnUnidades({
-      cantidad: 24, es_bonificacion: true, promocion: { unidades_por_bloque: 6 },
+      cantidad: 24, es_bonificacion: true, promocion: { unidades_por_bloque: 6, regalo_mueve_stock: false },
     })).toBe('≈ 4 fardos');
     expect(equivalenteEnUnidades({
-      cantidad: 6, es_bonificacion: true, promocion: { unidades_por_bloque: 6 },
+      cantidad: 6, es_bonificacion: true, promocion: { unidades_por_bloque: 6, regalo_mueve_stock: false },
     })).toBe('≈ 1 fardo');
   });
 
@@ -73,7 +73,7 @@ describe('precedencia del factor: congelado sobre vivo', () => {
     cantidad: 392,
     es_bonificacion: true,
     unidades_por_bloque_al_crear: 6,
-    promocion: { unidades_por_bloque: 12 },
+    promocion: { unidades_por_bloque: 12, regalo_mueve_stock: false },
   };
 
   it('convierte con el factor de cuando nació, no con el de hoy', () => {
@@ -84,7 +84,7 @@ describe('precedencia del factor: congelado sobre vivo', () => {
     // Los 70 ítems que la mig 212 dejó en NULL a propósito: se comportan como
     // antes de la migración.
     expect(equivalenteEnUnidades({
-      cantidad: 392, es_bonificacion: true, promocion: { unidades_por_bloque: 6 },
+      cantidad: 392, es_bonificacion: true, promocion: { unidades_por_bloque: 6, regalo_mueve_stock: false },
     })).toBe('≈ 65,3 fardos');
   });
 
@@ -95,13 +95,13 @@ describe('precedencia del factor: congelado sobre vivo', () => {
       cantidad: 5,
       es_bonificacion: true,
       unidades_por_bloque_al_crear: 1,
-      promocion: { unidades_por_bloque: 12 },
+      promocion: { unidades_por_bloque: 12, regalo_mueve_stock: false },
     })).toBe(false);
     expect(formatCantidadItem({
       cantidad: 5,
       es_bonificacion: true,
       unidades_por_bloque_al_crear: 1,
-      promocion: { unidades_por_bloque: 12 },
+      promocion: { unidades_por_bloque: 12, regalo_mueve_stock: false },
     })).toBe('x5');
   });
 
@@ -115,5 +115,49 @@ describe('precedencia del factor: congelado sobre vivo', () => {
     expect(equivalenteEnUnidades({
       cantidad: 24, es_bonificacion: true, unidades_por_bloque_al_crear: 6, promocion: null,
     })).toBe('≈ 4 fardos');
+  });
+});
+
+/**
+ * El fallback al vivo replica la cascada COMPLETA de `factor_bonificacion`, no
+ * sólo el divisor: también el gate `regalo_mueve_stock IS FALSE` (issue #534).
+ * Aplica a los 70 ítems que la mig 212 dejó con el congelado en NULL.
+ */
+describe('el fallback vivo respeta el gate regalo_mueve_stock', () => {
+  it('no fracciona si la promo mueve stock, aunque tenga divisor cargado', () => {
+    // El caso peor de la 212: un flip de false → true que no limpió el divisor.
+    // Sin el gate, este regalo se leería 6 veces más chico.
+    expect(esCantidadEnSubunidades({
+      cantidad: 12,
+      es_bonificacion: true,
+      promocion: { unidades_por_bloque: 6, regalo_mueve_stock: true },
+    })).toBe(false);
+  });
+
+  it('tampoco fracciona si no se sabe si mueve stock', () => {
+    // `IS FALSE` en SQL: NULL no es false, así que no hay fallback vivo.
+    expect(esCantidadEnSubunidades({
+      cantidad: 12,
+      es_bonificacion: true,
+      promocion: { unidades_por_bloque: 6, regalo_mueve_stock: null },
+    })).toBe(false);
+  });
+
+  it('el congelado gana incluso cuando el gate vivo está cerrado', () => {
+    // La línea nació fraccionada; que hoy la promo mueva stock no la reescribe.
+    expect(equivalenteEnUnidades({
+      cantidad: 24,
+      es_bonificacion: true,
+      unidades_por_bloque_al_crear: 6,
+      promocion: { unidades_por_bloque: null, regalo_mueve_stock: true },
+    })).toBe('≈ 4 fardos');
+  });
+
+  it('un divisor vivo en 0 cae al neutro, como el NULLIF del SQL', () => {
+    expect(esCantidadEnSubunidades({
+      cantidad: 12,
+      es_bonificacion: true,
+      promocion: { unidades_por_bloque: 0, regalo_mueve_stock: false },
+    })).toBe(false);
   });
 });

--- a/src/utils/unidadesRegalo.ts
+++ b/src/utils/unidadesRegalo.ts
@@ -20,29 +20,37 @@ export interface ItemConUnidad {
   es_bonificacion?: boolean | null;
   /** Factor congelado al crear la línea (mig 212). Manda sobre el vivo. */
   unidades_por_bloque_al_crear?: number | null;
-  promocion?: { unidades_por_bloque?: number | null } | null;
+  promocion?: {
+    unidades_por_bloque?: number | null;
+    regalo_mueve_stock?: boolean | null;
+  } | null;
 }
 
 /**
- * Factor de fracción de esta línea. Misma precedencia que `factor_bonificacion`
- * en SQL (mig 212 §6): congelado → vivo → 1.
+ * Factor de fracción de esta línea. Es el puerto TS de
+ * `public.factor_bonificacion(al_crear, regalo_mueve_stock, unidades_por_bloque)`
+ * (mig 212 §6), con la misma cascada: congelado → vivo → 1.
  *
  * El congelado tiene que ganar. Sin él, editar el factor de una promo cambiaba
  * cómo se lee la cantidad de un regalo en pedidos YA CERRADOS: una promo que
  * pasa de 6 a 12 mostraba un regalo histórico de 392 botellas como ≈32,7 fardos
  * en vez de ≈65,3. Es el mismo bug que la 212 arregló para el reporte, y que
- * seguía abierto para la pantalla y la boleta (issue #552).
+ * seguía abierto para la pantalla y la boleta (issues #534 y #552).
  *
- * El vivo no consulta `regalo_mueve_stock` como sí hace `factor_bonificacion`:
- * `unidades_por_bloque` sólo tiene valor en promos de fracción, donde
- * `regalo_mueve_stock` es false por construcción. El congelado ya no lo
- * necesita: colapsa gate y divisor en un solo número.
+ * El fallback al vivo NO es sólo el divisor: replica también el gate
+ * `regalo_mueve_stock IS FALSE`. Sin ese gate, un flip de false → true en una
+ * promo que todavía tenga `unidades_por_bloque` cargado multiplicaría por 6 o
+ * por 12 la lectura de sus regalos viejos — el caso peor que documenta la 212.
+ * Aplica a los 70 ítems anteriores a la primera medición de su promo, que
+ * quedaron con el congelado en NULL a propósito.
  */
 function factorDeLaLinea(item: ItemConUnidad): number {
-  const factor = item.unidades_por_bloque_al_crear
-    ?? item.promocion?.unidades_por_bloque
-    ?? 1;
-  return Math.max(factor, 1);
+  // `|| null` reproduce el NULLIF(unidades_por_bloque, 0) del SQL: un 0 cae al
+  // neutro en vez de propagarse como divisor.
+  const vivo = item.promocion?.regalo_mueve_stock === false
+    ? (item.promocion?.unidades_por_bloque || null)
+    : null;
+  return Math.max(item.unidades_por_bloque_al_crear ?? vivo ?? 1, 1);
 }
 
 /**


### PR DESCRIPTION
Cierra los dos pendientes que dejó el congelamiento del factor (mig 212).

## #534 — la cascada de la etiqueta, ahora completa

La etiqueta de unidades del regalo ya prefería el congelado desde el PR anterior, pero su fallback al vivo era una versión **recortada** de `factor_bonificacion`: sólo el divisor, sin el gate `regalo_mueve_stock IS FALSE`.

Ahora `unidadesRegalo.ts` es el puerto exacto de la función SQL, incluidos el gate y el `NULLIF(unidades_por_bloque, 0)`.

**Por qué importa**, y no es cosmético: aplica a los 70 ítems que la mig 212 dejó con el congelado en NULL a propósito. Sin el gate, un flip de `regalo_mueve_stock` false → true en una promo que todavía tenga `unidades_por_bloque` cargado multiplicaría por 6 o por 12 la lectura de sus regalos viejos — el caso peor que la 212 documenta y que la propia 212 resolvió colapsando gate y divisor en un solo número congelado.

El embed suma `regalo_mueve_stock`. Es un token dentro de un embed **que ya existía**, no uno nuevo: `pedido_items` tiene **una sola** FK a `promociones` (`pedido_items_promocion_id_fkey`), así que la relación es inequívoca y no hay riesgo de PGRST201.

Es cambio de **pantalla**: `reporte_gerencial` ya leía bien vía `factor_bonificacion`, y el número no se mueve.

4 tests nuevos, verificados por mutación: sacando el gate, 2 fallan.

## #536 — `promociones` se audita (mig 222)

`audit_log_changes` cubría once tablas y no la incluía.

### Va plano, no con lista de columnas

La tentación es `AFTER UPDATE OF <columnas de config>` para no auditar los bumps del contador. Se descartó por dos razones:

1. **`UPDATE OF` mira la lista SET del statement, no lo que escriben los BEFORE triggers.** `check_promo_limite_usos` apaga `activo` desde un BEFORE cuando el statement sólo nombraba `usos_pendientes`: con lista de columnas, esa desactivación automática no quedaría auditada. Es la trampa 6 de CLAUDE.md exacta.
2. **El volumen no lo justifica.** En los últimos 30 días: 324 bonificaciones + 172 filas de `promo_ajustes` ≈ 500 UPDATE a `promociones`, contra **29.601** filas que `audit_logs` ya escribe en el mismo período. Es +1,7%.

Va plano igual que las otras once. La consistencia también vale: el próximo que mire no tiene que aprender un caso especial.

El filtro para separar ediciones reales de bumps queda en un `COMMENT ON TRIGGER`, que es donde alguien lo va a buscar:

```sql
WHERE tabla = 'promociones'
  AND NOT (campos_modificados <@ ARRAY['usos_pendientes','updated_at'])
```

### La trampa de `updated_at`, documentada donde se la busca

`promociones.updated_at` parece fecha de edición y es fecha de **último uso** — eso hizo perder una sesión entera. Queda un `COMMENT ON COLUMN` diciéndolo.

No se le cambia la semántica: verifiqué que ninguna de las nueve funciones que hacen `UPDATE` a `promociones` la lee, y el front tampoco, pero cambiarla es otra discusión y no es lo que pide el issue.

No hay función nueva: `audit_log_changes` ya existe con su ACL cerrado (`postgres` + `service_role`, sin PUBLIC ni anon), que es lo que corresponde a una función de trigger. Un trigger nuevo no cambia ningún ACL — igual la verificación lo asevera.

## Cómo se verificó

La 222 corrió entera contra los datos reales de prod dentro de una transacción terminada en `ROLLBACK`, con 5 casos: una edición de config queda auditada con su antes/después, un UPDATE sin cambios **no** escribe fila, el bump del contador sí se audita y el filtro documentado lo aísla, el camino caliente (`aplicar_uso_promo_acumulador`) sigue funcionando con la auditoría enganchada, y el INSERT también se audita.

Las cuatro compuertas: `typecheck`, `lint`, `test:run` (1679), `build`.

**La migración 222 ya está aplicada a prod.** Ojo que el número salió del ledger, no de `ls migrations/`: la última aplicada era la **221**, no la 214.

Closes #534
Closes #536

🤖 Generated with [Claude Code](https://claude.com/claude-code)
