### PR TITLE
Vencimientos por lote: el lote mas viejo lleva su propio contador

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,6 +87,13 @@ suelta en `sucursales`.
   —selectores, rutas, recorridos— los oculta; el historial —reportes, cuenta corriente y los
   embeds `cliente:clientes(*)`— **tiene** que seguir viéndolos, que es de lo que se trata la
   baja lógica. Una consulta que no elige está eligiendo mal por omisión.
+- **El stock por lote lo lleva un trigger, no las RPCs.** `trg_lotes_sincronizar` (mig 223)
+  consume FEFO y devuelve al lote en cada `UPDATE productos.stock`, leyendo el mismo
+  `app.stock_origen` que ya usa el ledger. Un camino nuevo que **baje** stock no tiene que
+  tocar `producto_lotes`: el trigger se encarga. Uno que lo **devuelva** —cancelación,
+  salvedad, edición a la baja— sí tiene que etiquetarse con un origen de la lista blanca del
+  trigger, o esas unidades vuelven a la bolsa "sin vencimiento" en vez de a su lote y el
+  contador miente para abajo sin que falle nada.
 - **La asignación de un cliente tiene TRES estados, no dos**: sin asignar / asignado a X /
   `reservado_admin` (mig 214). Son excluyentes. Cuidado con que "sin asignar" significa
   **visible para todos los preventistas** (mig 028), o sea lo contrario de reservado. Y

--- a/migrations/223_el_lote_mas_viejo_lleva_su_propio_contador.sql
+++ b/migrations/223_el_lote_mas_viejo_lleva_su_propio_contador.sql
@@ -1,0 +1,520 @@
+-- =========================================================================
+-- El lote mas viejo lleva su propio contador
+--
+-- EL PROBLEMA
+-- -----------
+-- La distribuidora no lee codigo de barras. Sin lectura no hay forma de saber
+-- que unidad fisica salio, asi que tampoco hay forma de saber cuando se vence
+-- lo que queda en el deposito. Hoy el vencimiento no existe en ningun lado:
+-- `grep -i lote|vencimiento` sobre migrations/ solo devuelve "lote" en el
+-- sentido de batch de registros y `vencimiento` como motivo de merma.
+--
+-- Lo que se necesita es acotado: enterarse a tiempo de lo que esta por vencer
+-- para liquidarlo, bonificarlo o devolverlo antes de perderlo. NO se necesita
+-- trazabilidad lote -> cliente (eso obligaria a guardar el lote en cada
+-- pedido_items y a tocar crear_pedido_completo, que es la funcion mas
+-- parcheada del repo).
+--
+-- EL MODELO: UN LOTE ES UNA FECHA CON UN CONTADOR
+-- -----------------------------------------------
+-- No lleva costo -- la valuacion de la merma ya la congela
+-- trg_mermas_snapshot_costo (mig 119) --, no lleva numero de lote del
+-- proveedor, y no se lo referencia desde el pedido.
+--
+-- La pieza que hace que todo esto funcione sin backfill ni inventario inicial
+-- es que la bolsa "sin vencimiento" NO es una fila: es una resta.
+--
+--   bolsa = productos.stock - SUM(producto_lotes.cantidad_restante)
+--
+-- De ahi sale el resto solo:
+--   * entra mercaderia sin fecha cargada -> sube stock, no hay lote -> engorda
+--     la bolsa;
+--   * entra con fecha -> sube stock y nace el lote -> la bolsa queda igual;
+--   * sale mercaderia -> primero se come la bolsa (automatico, es derivada) y
+--     recien cuando llega a 0 se consume del lote que VENCE ANTES;
+--   * vuelve mercaderia de una venta -> se devuelve al lote del que salio.
+--
+-- El invariante que lo sostiene es SUM(cantidad_restante) <= productos.stock
+-- por (producto, sucursal). Este codigo NUNCA escribe productos.stock: lo lee y
+-- acomoda los lotes contra el. Por eso STK-A y STK-B (los dos critical de
+-- auditoria_integridad) quedan intactos -- el ledger de stock sigue siendo la
+-- unica verdad del saldo, y los lotes son una particion que lo sigue.
+--
+-- FEFO, NO FIFO
+-- -------------
+-- El orden de salida lo manda la fecha de vencimiento, no la de compra. Es la
+-- diferencia que importa: si el proveedor manda mercaderia con vencimiento mas
+-- corto que la que ya estaba, un FIFO puro la deja tapada en el fondo hasta que
+-- se vence. La contrapartida es un compromiso fisico: el deposito tiene que
+-- sacar de la caja que vence antes.
+--
+-- POR QUE UN SOLO TRIGGER Y NO 20 RPCs
+-- ------------------------------------
+-- Todo lo que mueve stock en esta app pasa por UPDATE productos SET stock, y
+-- ya hay un trigger (trg_stock_historico, mig 038) que registra el movimiento
+-- leyendo current_setting('app.stock_origen'). Enganchar el consumo de lotes
+-- ahi cubre de una sola vez pedidos, bot, mermas -- que ni siquiera pasan por
+-- una RPC: son dos statements desde el navegador --, movimientos entre
+-- sucursales, control de stock y el ajuste manual desde la ficha.
+--
+-- Lo que sigue es esta migracion; las RPCs de operacion van en la 224 y los
+-- invariantes LOTE-* en la 225.
+-- =========================================================================
+
+BEGIN;
+
+-- ---------------------------------------------------------------------------
+-- 1 - La tabla
+-- ---------------------------------------------------------------------------
+
+-- La FK compuesta necesita este destino. En produccion ya existe (lo creo el
+-- barrido dinamico de la mig 187), pero no hay ningun archivo del repo que lo
+-- escriba, asi que una base levantada desde migrations/ podria no tenerlo.
+-- El nombre es el de la convencion 187: <padre>_<columna>_<tenant_sin_id>_uk.
+DO $mig$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+     WHERE conname = 'productos_id_sucursal_uk'
+       AND conrelid = 'public.productos'::regclass
+  ) THEN
+    ALTER TABLE public.productos
+      ADD CONSTRAINT productos_id_sucursal_uk UNIQUE (id, sucursal_id);
+  END IF;
+END
+$mig$;
+
+CREATE TABLE IF NOT EXISTS public.producto_lotes (
+  id                bigint GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+  producto_id       bigint  NOT NULL,
+  sucursal_id       bigint  NOT NULL REFERENCES public.sucursales(id),
+  fecha_vencimiento date    NOT NULL,
+  cantidad          integer NOT NULL CHECK (cantidad > 0),
+  cantidad_restante integer NOT NULL CHECK (cantidad_restante >= 0),
+  compra_id         bigint,
+  origen            text    NOT NULL DEFAULT 'compra'
+                      CHECK (origen IN ('compra', 'manual')),
+  usuario_id        uuid REFERENCES public.perfiles(id) ON DELETE SET NULL,
+  created_at        timestamptz NOT NULL DEFAULT now(),
+
+  CONSTRAINT producto_lotes_restante_ck CHECK (cantidad_restante <= cantidad),
+
+  -- FKs COMPUESTAS y no simples. Un admin parado en la sucursal A podria colgar
+  -- un lote con sucursal_id = A sobre un producto de B: la policy chequea la
+  -- fila y pasa, y una FK simple a productos(id) no mira la sucursal. Ademas
+  -- check-sucursal-cruzada.mjs marca al dia siguiente cualquier par hija->padre
+  -- que no la tenga.
+  CONSTRAINT producto_lotes_producto_fk
+    FOREIGN KEY (producto_id, sucursal_id)
+    REFERENCES public.productos(id, sucursal_id) ON DELETE CASCADE,
+  CONSTRAINT producto_lotes_compra_fk
+    FOREIGN KEY (compra_id, sucursal_id)
+    REFERENCES public.compras(id, sucursal_id) ON DELETE CASCADE,
+
+  -- Una compra no puede cargar dos veces la misma fecha para el mismo producto:
+  -- son el mismo lote y van sumados. Con compra_id NULL (lotes manuales) el
+  -- UNIQUE no aplica -- en Postgres los NULL son distintos entre si --, y de eso
+  -- se encarga crear_lote_manual, que fusiona por (producto, fecha).
+  CONSTRAINT producto_lotes_compra_unico UNIQUE (compra_id, producto_id, fecha_vencimiento)
+);
+
+COMMENT ON TABLE public.producto_lotes IS
+  'Vencimientos por lote. Un lote es una fecha con un contador que baja. La '
+  'bolsa "sin vencimiento" NO esta aca: es productos.stock menos la suma de '
+  'cantidad_restante. Invariante: esa suma nunca supera productos.stock '
+  '(LOTE-A). mig 223.';
+
+COMMENT ON COLUMN public.producto_lotes.cantidad IS
+  'Unidades con las que nacio el lote. No cambia salvo re-sync de la compra.';
+COMMENT ON COLUMN public.producto_lotes.cantidad_restante IS
+  'Lo que queda. Lo baja el trigger de productos por FEFO y lo sube de vuelta '
+  'cuando una venta se cancela. 0 = agotado, deja de aparecer en el panel.';
+COMMENT ON COLUMN public.producto_lotes.origen IS
+  'compra = nacio de una factura de compra. manual = alguien etiqueto parte de '
+  'la bolsa desde la ficha del producto (es el camino para el stock que ya '
+  'existia cuando se prendio la feature).';
+
+-- El barrido de consumo: por producto, ordenado por fecha, solo los vivos.
+CREATE INDEX IF NOT EXISTS idx_producto_lotes_fefo
+  ON public.producto_lotes (producto_id, sucursal_id, fecha_vencimiento)
+  WHERE cantidad_restante > 0;
+
+-- El panel de vencimientos: por sucursal, ordenado por fecha, solo los vivos.
+CREATE INDEX IF NOT EXISTS idx_producto_lotes_alerta
+  ON public.producto_lotes (sucursal_id, fecha_vencimiento)
+  WHERE cantidad_restante > 0;
+
+CREATE INDEX IF NOT EXISTS idx_producto_lotes_compra
+  ON public.producto_lotes (compra_id);
+
+-- ---------------------------------------------------------------------------
+-- 2 - RLS
+--
+-- Cuatro policies separadas y nunca una FOR ALL (criterio de la mig 192). Aca
+-- solo va la de SELECT: la escritura entra toda por RPC SECURITY DEFINER, asi
+-- que el default-deny de RLS alcanza -- mismo esquema que comision_reglas o
+-- promo_acumuladores.
+--
+-- Ojo con el default privilege del baseline: toda tabla nueva creada por
+-- postgres en public nace con INSERT/UPDATE/DELETE para cualquier logueado
+-- (mig 186). Lo unico que frena la escritura por PostgREST es que NO exista
+-- policy de escritura. Por eso abajo se otorga SELECT y nada mas.
+-- ---------------------------------------------------------------------------
+
+ALTER TABLE public.producto_lotes ENABLE ROW LEVEL SECURITY;
+
+-- El EXISTS sobre perfiles va inlineado a proposito: NO existe es_deposito() y
+-- no hay que inventarlo (mig 192). es_encargado_o_admin() si existe y cubre a
+-- los dos roles de administracion.
+DROP POLICY IF EXISTS mt_producto_lotes_select ON public.producto_lotes;
+CREATE POLICY mt_producto_lotes_select ON public.producto_lotes
+  FOR SELECT TO authenticated
+  USING (
+    (public.es_encargado_o_admin() OR EXISTS (
+      SELECT 1 FROM public.perfiles
+       WHERE perfiles.id = auth.uid() AND perfiles.rol = 'deposito'))
+    AND sucursal_id = public.current_sucursal_id()
+  );
+
+GRANT SELECT ON public.producto_lotes TO authenticated;
+
+-- ---------------------------------------------------------------------------
+-- 3 - El motor de consumo
+--
+-- Nombre con guion bajo adelante: la convencion de migrations/README.md las
+-- deja sin EXECUTE para nadie. Solo las llama el trigger, que corre como
+-- postgres.
+-- ---------------------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION public._consumir_lotes_fefo(
+  p_producto_id bigint,
+  p_sucursal_id bigint,
+  p_cantidad    integer
+) RETURNS integer
+LANGUAGE plpgsql VOLATILE SECURITY DEFINER
+SET search_path TO 'public'
+AS $fn$
+DECLARE
+  v_pendiente integer := p_cantidad;
+  v_toma      integer;
+  r           record;
+BEGIN
+  IF p_cantidad IS NULL OR p_cantidad <= 0 THEN
+    RETURN 0;
+  END IF;
+
+  -- FEFO: vence antes, sale antes. El desempate por id mantiene el orden
+  -- estable entre transacciones, que es lo que evita deadlocks cuando dos
+  -- pedidos tocan el mismo producto.
+  FOR r IN
+    SELECT id, cantidad_restante
+      FROM public.producto_lotes
+     WHERE producto_id = p_producto_id
+       AND sucursal_id = p_sucursal_id
+       AND cantidad_restante > 0
+     ORDER BY fecha_vencimiento ASC, id ASC
+     FOR UPDATE
+  LOOP
+    EXIT WHEN v_pendiente <= 0;
+    v_toma := LEAST(v_pendiente, r.cantidad_restante);
+    UPDATE public.producto_lotes
+       SET cantidad_restante = cantidad_restante - v_toma
+     WHERE id = r.id;
+    v_pendiente := v_pendiente - v_toma;
+  END LOOP;
+
+  -- Si sobra pendiente es porque no habia lotes suficientes: el resto salio de
+  -- la bolsa, que es derivada y no hay que tocar. No es un error.
+  RETURN p_cantidad - v_pendiente;
+END;
+$fn$;
+
+COMMENT ON FUNCTION public._consumir_lotes_fefo(bigint, bigint, integer) IS
+  'Descuenta N unidades de los lotes del producto, el que vence antes primero. '
+  'Devuelve cuanto pudo descontar. mig 223.';
+
+CREATE OR REPLACE FUNCTION public._restaurar_lotes_fefo(
+  p_producto_id bigint,
+  p_sucursal_id bigint,
+  p_cantidad    integer
+) RETURNS integer
+LANGUAGE plpgsql VOLATILE SECURITY DEFINER
+SET search_path TO 'public'
+AS $fn$
+DECLARE
+  v_pendiente integer := p_cantidad;
+  v_pone      integer;
+  r           record;
+BEGIN
+  IF p_cantidad IS NULL OR p_cantidad <= 0 THEN
+    RETURN 0;
+  END IF;
+
+  -- La inversa exacta del consumo: se devuelve al lote que vence antes, que es
+  -- del que se habia sacado. Nunca por encima de `cantidad`, que es el techo
+  -- de lo que ese lote llego a tener.
+  FOR r IN
+    SELECT id, (cantidad - cantidad_restante) AS hueco
+      FROM public.producto_lotes
+     WHERE producto_id = p_producto_id
+       AND sucursal_id = p_sucursal_id
+       AND cantidad_restante < cantidad
+     ORDER BY fecha_vencimiento ASC, id ASC
+     FOR UPDATE
+  LOOP
+    EXIT WHEN v_pendiente <= 0;
+    v_pone := LEAST(v_pendiente, r.hueco);
+    UPDATE public.producto_lotes
+       SET cantidad_restante = cantidad_restante + v_pone
+     WHERE id = r.id;
+    v_pendiente := v_pendiente - v_pone;
+  END LOOP;
+
+  -- Lo que sobra vuelve a la bolsa: es mercaderia que salio antes de que
+  -- existieran los lotes, o de la propia bolsa.
+  RETURN p_cantidad - v_pendiente;
+END;
+$fn$;
+
+COMMENT ON FUNCTION public._restaurar_lotes_fefo(bigint, bigint, integer) IS
+  'Devuelve N unidades a los lotes del producto, el que vence antes primero. '
+  'Inversa de _consumir_lotes_fefo. mig 223.';
+
+-- ---------------------------------------------------------------------------
+-- 4 - El trigger
+-- ---------------------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION public.sincronizar_lotes_stock() RETURNS trigger
+LANGUAGE plpgsql SECURITY DEFINER
+SET search_path TO 'public'
+AS $fn$
+DECLARE
+  v_delta    integer := NEW.stock - OLD.stock;
+  v_asignado integer;
+  v_bolsa    integer;
+  v_origen   text := COALESCE(NULLIF(current_setting('app.stock_origen', true), ''), 'auto');
+BEGIN
+  IF v_delta = 0 THEN
+    RETURN NEW;
+  END IF;
+
+  SELECT COALESCE(SUM(cantidad_restante), 0) INTO v_asignado
+    FROM public.producto_lotes
+   WHERE producto_id = NEW.id AND sucursal_id = NEW.sucursal_id;
+
+  -- Atajo del caso comun: producto sin lotes vivos. Es el 95% del padron
+  -- mientras la feature se va llenando, y sin esto pagariamos un barrido por
+  -- cada linea de cada pedido.
+  IF v_asignado = 0 THEN
+    RETURN NEW;
+  END IF;
+
+  IF v_delta < 0 THEN
+    -- Sale mercaderia. Primero se come la bolsa, que es derivada y se achica
+    -- sola al bajar el stock; los lotes solo se tocan por el excedente.
+    v_bolsa := OLD.stock - v_asignado;
+    IF (-v_delta) > v_bolsa THEN
+      PERFORM public._consumir_lotes_fefo(NEW.id, NEW.sucursal_id, (-v_delta) - v_bolsa);
+    END IF;
+
+  -- Sube por una DEVOLUCION de venta: la mercaderia vuelve al lote del que
+  -- salio. Sin esta rama el modelo se desangra de a poco -- cada cancelacion
+  -- moveria unidades del lote a la bolsa y los contadores mentirian para abajo.
+  --
+  -- Lo que sube por compra, ingreso entre sucursales, control de stock o ajuste
+  -- manual NO entra aca: es mercaderia nueva o de origen desconocido y va a la
+  -- bolsa. `pedido_creado` esta en la lista porque actualizar_pedido_items lo
+  -- usa para las dos direcciones -- bajar la cantidad de un pedido devuelve
+  -- stock.
+  ELSIF v_origen IN ('pedido_creado', 'pedido_creado_bot', 'pedido_cancelado',
+                     'pedido_eliminado', 'salvedad', 'sustitucion_regalo',
+                     'auto_ajuste_promo', 'movimiento_denegado',
+                     'movimiento_cancelado') THEN
+    PERFORM public._restaurar_lotes_fefo(NEW.id, NEW.sucursal_id, v_delta);
+  END IF;
+
+  RETURN NEW;
+END;
+$fn$;
+
+COMMENT ON FUNCTION public.sincronizar_lotes_stock() IS
+  'Acomoda los lotes contra productos.stock despues de cada movimiento. Nunca '
+  'escribe stock: solo lo lee. mig 223.';
+
+-- AFTER UPDATE sin `OF stock` y filtrando adentro, igual que
+-- registrar_cambio_stock: un UPDATE OF no cubre lo que no nombra, y esa lista
+-- es justamente lo que hizo que trigger_actualizar_saldo_pedido no se disparara
+-- al mover cliente_id.
+--
+-- Va SECURITY DEFINER porque productos se puede editar por PostgREST (admin y
+-- deposito tienen policy de UPDATE) y producto_lotes no tiene policy de
+-- escritura. La advertencia de la mig 181 sobre triggers-guard y SECURITY
+-- DEFINER no aplica: esa es para triggers que filtran por current_user, y este
+-- no lo mira.
+CREATE OR REPLACE TRIGGER trg_lotes_sincronizar
+  AFTER UPDATE ON public.productos
+  FOR EACH ROW EXECUTE FUNCTION public.sincronizar_lotes_stock();
+
+-- ---------------------------------------------------------------------------
+-- 5 - Los umbrales, en la politica comercial de la sucursal
+--
+-- Un parametro de negocio que cambia va en politicas_comerciales, no en una
+-- constante ni en una env var. La tabla es tipada a proposito (mig 204): sumar
+-- una politica es una columna con su propio CHECK.
+--
+-- Dos umbrales y no uno porque son dos decisiones distintas: "ojo con esto,
+-- empujalo" y "esto hay que liquidarlo ya". Los defaults van con valor real y
+-- no en 0: sin lotes cargados no alertan nada, asi que aplicar la migracion
+-- sigue sin cambiarle el comportamiento a nadie -- que es el criterio de la 204.
+-- ---------------------------------------------------------------------------
+
+ALTER TABLE public.politicas_comerciales
+  ADD COLUMN IF NOT EXISTS dias_alerta_vencimiento  integer NOT NULL DEFAULT 60,
+  ADD COLUMN IF NOT EXISTS dias_critico_vencimiento integer NOT NULL DEFAULT 15;
+
+DO $mig$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint
+                  WHERE conname = 'politicas_comerciales_dias_alerta_ck') THEN
+    ALTER TABLE public.politicas_comerciales
+      ADD CONSTRAINT politicas_comerciales_dias_alerta_ck
+      CHECK (dias_alerta_vencimiento >= 0 AND dias_alerta_vencimiento <= 3650);
+  END IF;
+
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint
+                  WHERE conname = 'politicas_comerciales_dias_critico_ck') THEN
+    ALTER TABLE public.politicas_comerciales
+      ADD CONSTRAINT politicas_comerciales_dias_critico_ck
+      CHECK (dias_critico_vencimiento >= 0
+             AND dias_critico_vencimiento <= dias_alerta_vencimiento);
+  END IF;
+END
+$mig$;
+
+COMMENT ON COLUMN public.politicas_comerciales.dias_alerta_vencimiento IS
+  'Dias de anticipacion para el aviso amarillo. 0 = solo avisa lo ya vencido. '
+  'mig 223.';
+COMMENT ON COLUMN public.politicas_comerciales.dias_critico_vencimiento IS
+  'Dias de anticipacion para el aviso rojo. Siempre <= dias_alerta. mig 223.';
+
+CREATE OR REPLACE FUNCTION public.actualizar_alertas_vencimiento(
+  p_dias_alerta  integer,
+  p_dias_critico integer
+) RETURNS jsonb
+LANGUAGE plpgsql VOLATILE SECURITY DEFINER
+SET search_path TO 'public'
+AS $fn$
+DECLARE
+  v_sucursal bigint := public.current_sucursal_id();
+  v_rol      text;
+BEGIN
+  IF v_sucursal IS NULL THEN
+    RAISE EXCEPTION 'No se pudo determinar la sucursal activa';
+  END IF;
+
+  SELECT rol INTO v_rol FROM public.perfiles WHERE id = auth.uid();
+  IF v_rol IS NULL OR v_rol NOT IN ('admin', 'encargado') THEN
+    RAISE EXCEPTION 'Acceso denegado: se requiere rol admin o encargado';
+  END IF;
+
+  IF p_dias_alerta IS NULL OR p_dias_alerta < 0 THEN
+    RAISE EXCEPTION 'Los dias de alerta no pueden ser negativos';
+  END IF;
+  IF p_dias_critico IS NULL OR p_dias_critico < 0 THEN
+    RAISE EXCEPTION 'Los dias criticos no pueden ser negativos';
+  END IF;
+  IF p_dias_critico > p_dias_alerta THEN
+    RAISE EXCEPTION 'El aviso rojo (% dias) no puede ser antes que el amarillo (% dias)',
+      p_dias_critico, p_dias_alerta;
+  END IF;
+
+  -- Va por RPC y no por UPDATE directo para sellar actualizado_por con
+  -- auth.uid() del lado del servidor (mig 204).
+  INSERT INTO public.politicas_comerciales (
+    sucursal_id, dias_alerta_vencimiento, dias_critico_vencimiento,
+    actualizado_por, actualizado_en
+  )
+  VALUES (v_sucursal, p_dias_alerta, p_dias_critico, auth.uid(), now())
+  ON CONFLICT (sucursal_id) DO UPDATE
+    SET dias_alerta_vencimiento  = EXCLUDED.dias_alerta_vencimiento,
+        dias_critico_vencimiento = EXCLUDED.dias_critico_vencimiento,
+        actualizado_por          = EXCLUDED.actualizado_por,
+        actualizado_en           = EXCLUDED.actualizado_en;
+
+  RETURN jsonb_build_object(
+    'dias_alerta_vencimiento',  p_dias_alerta,
+    'dias_critico_vencimiento', p_dias_critico
+  );
+END;
+$fn$;
+
+COMMENT ON FUNCTION public.actualizar_alertas_vencimiento(integer, integer) IS
+  'Fija los dos umbrales de aviso de vencimiento de la sucursal activa. Solo '
+  'admin/encargado. mig 223.';
+
+-- ---------------------------------------------------------------------------
+-- 6 - Permisos
+--
+-- Toda funcion nueva de public nace con EXECUTE para PUBLIC y Supabase se lo
+-- concede a anon por separado: hay que revocar LAS DOS MITADES en la misma
+-- migracion. GRANT TO authenticated no lo revierte.
+--
+-- sincronizar_lotes_stock() es RETURNS trigger: no lleva EXECUTE para nadie.
+-- La invoca el executor como parte del DML, no el caller (mig 213).
+-- Los helpers _consumir/_restaurar tampoco: solo los llama el trigger.
+-- ---------------------------------------------------------------------------
+
+REVOKE ALL ON FUNCTION public._consumir_lotes_fefo(bigint, bigint, integer) FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public._restaurar_lotes_fefo(bigint, bigint, integer) FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.sincronizar_lotes_stock() FROM PUBLIC, anon, authenticated;
+
+REVOKE ALL ON FUNCTION public.actualizar_alertas_vencimiento(integer, integer) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.actualizar_alertas_vencimiento(integer, integer) TO authenticated;
+
+DO $verif$
+DECLARE
+  v_acl text;
+  v_fn  text;
+BEGIN
+  -- Las que NO tienen que ser alcanzables por nadie con la anon key.
+  FOREACH v_fn IN ARRAY ARRAY['_consumir_lotes_fefo', '_restaurar_lotes_fefo',
+                              'sincronizar_lotes_stock'] LOOP
+    SELECT array_to_string(proacl, ',') INTO v_acl
+      FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace
+     WHERE n.nspname = 'public' AND p.proname = v_fn;
+
+    IF v_acl IS NULL THEN
+      RAISE EXCEPTION '% quedo con ACL default (PUBLIC ejecuta)', v_fn;
+    END IF;
+    IF v_acl LIKE '=X/%' OR v_acl LIKE '%,=X/%' THEN
+      RAISE EXCEPTION '% quedo ejecutable por PUBLIC: %', v_fn, v_acl;
+    END IF;
+    IF v_acl LIKE '%anon=%' THEN
+      RAISE EXCEPTION '% quedo ejecutable por anon: %', v_fn, v_acl;
+    END IF;
+    IF v_acl LIKE '%authenticated=%' THEN
+      RAISE EXCEPTION '% no deberia ser ejecutable por authenticated: %', v_fn, v_acl;
+    END IF;
+  END LOOP;
+
+  -- La que si tiene que llamar el front.
+  SELECT array_to_string(proacl, ',') INTO v_acl
+    FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace
+   WHERE n.nspname = 'public' AND p.proname = 'actualizar_alertas_vencimiento';
+
+  IF v_acl IS NULL THEN
+    RAISE EXCEPTION 'actualizar_alertas_vencimiento quedo con ACL default';
+  END IF;
+  IF v_acl LIKE '=X/%' OR v_acl LIKE '%,=X/%' THEN
+    RAISE EXCEPTION 'actualizar_alertas_vencimiento quedo ejecutable por PUBLIC: %', v_acl;
+  END IF;
+  IF v_acl LIKE '%anon=%' THEN
+    RAISE EXCEPTION 'actualizar_alertas_vencimiento quedo ejecutable por anon: %', v_acl;
+  END IF;
+  IF v_acl NOT LIKE '%authenticated=X%' THEN
+    RAISE EXCEPTION 'actualizar_alertas_vencimiento no quedo ejecutable por authenticated: %', v_acl;
+  END IF;
+END
+$verif$;
+
+COMMIT;

--- a/migrations/224_los_lotes_entran_por_la_compra_y_salen_por_la_merma.sql
+++ b/migrations/224_los_lotes_entran_por_la_compra_y_salen_por_la_merma.sql
@@ -1,0 +1,727 @@
+-- =========================================================================
+-- Los lotes entran por la compra y salen por la merma
+--
+-- La mig 223 puso el modelo y el motor de consumo. Esta pone las cinco
+-- operaciones que lo alimentan y lo vacian.
+--
+-- POR QUE LOS LOTES DE UNA COMPRA NO SE ESCRIBEN DENTRO DE
+-- registrar_compra_completa
+-- ---------------------------------------------------------------------------
+-- Esa funcion, actualizar_compra_items y anular_compra_atomica son las tres mas
+-- parcheadas del repo: la 128 las reescribio, la 177 les metio condicion_iva,
+-- la 194 los cargos y la 195 las bonificaciones, todas por el ritual de
+-- pg_get_functiondef + ancla sobre el cuerpo vivo. Cada parche mas es una
+-- oportunidad mas de revertir en silencio lo que hizo el anterior.
+--
+-- Los lotes no necesitan estar ahi. sincronizar_lotes_compra es idempotente y
+-- se llama desde el cliente justo despues de guardar la compra, con el id que
+-- la RPC ya devuelve. Si esa segunda llamada falla, la compra queda bien y los
+-- vencimientos sin cargar -- que es exactamente el mismo estado que "el usuario
+-- los dejo en blanco", un estado soportado y visible en la ficha como bolsa
+-- sin vencimiento.
+--
+-- La anulacion si necesita engancharse sola, porque nadie la va a llamar: va
+-- por un trigger sobre compras.estado.
+-- =========================================================================
+
+BEGIN;
+
+-- ---------------------------------------------------------------------------
+-- 1 - El clamp
+--
+-- Red de seguridad del invariante LOTE-A. Cuando la suma de los lotes queda por
+-- encima del stock -- una compra editada a la baja, una anulacion, un control de
+-- stock que encontro menos --, hay que sacar el excedente de algun lado.
+--
+-- Sale del lote que vence DESPUES, no del que vence antes: si hay que perder
+-- precision, que se pierda sobre la mercaderia que no corre riesgo. Bajar el
+-- contador del lote proximo a vencer seria apagar justamente la alarma que
+-- esta feature existe para prender.
+-- ---------------------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION public._clampear_lotes_a_stock(
+  p_producto_id bigint,
+  p_sucursal_id bigint
+) RETURNS integer
+LANGUAGE plpgsql VOLATILE SECURITY DEFINER
+SET search_path TO 'public'
+AS $fn$
+DECLARE
+  v_stock     integer;
+  v_asignado  integer;
+  v_exceso    integer;
+  v_saca      integer;
+  v_total     integer := 0;
+  r           record;
+BEGIN
+  SELECT stock INTO v_stock
+    FROM public.productos
+   WHERE id = p_producto_id AND sucursal_id = p_sucursal_id;
+
+  IF v_stock IS NULL THEN
+    RETURN 0;
+  END IF;
+
+  SELECT COALESCE(SUM(cantidad_restante), 0) INTO v_asignado
+    FROM public.producto_lotes
+   WHERE producto_id = p_producto_id AND sucursal_id = p_sucursal_id;
+
+  v_exceso := v_asignado - v_stock;
+  IF v_exceso <= 0 THEN
+    RETURN 0;
+  END IF;
+
+  FOR r IN
+    SELECT id, cantidad_restante
+      FROM public.producto_lotes
+     WHERE producto_id = p_producto_id
+       AND sucursal_id = p_sucursal_id
+       AND cantidad_restante > 0
+     ORDER BY fecha_vencimiento DESC, id DESC
+     FOR UPDATE
+  LOOP
+    EXIT WHEN v_exceso <= 0;
+    v_saca := LEAST(v_exceso, r.cantidad_restante);
+    UPDATE public.producto_lotes
+       SET cantidad_restante = cantidad_restante - v_saca
+     WHERE id = r.id;
+    v_exceso := v_exceso - v_saca;
+    v_total  := v_total + v_saca;
+  END LOOP;
+
+  RETURN v_total;
+END;
+$fn$;
+
+COMMENT ON FUNCTION public._clampear_lotes_a_stock(bigint, bigint) IS
+  'Baja los lotes hasta que su suma no supere productos.stock, empezando por el '
+  'que vence despues. Devuelve cuantas unidades tuvo que sacar. mig 224.';
+
+-- ---------------------------------------------------------------------------
+-- 2 - Los lotes de una compra
+--
+-- p_lotes: [{producto_id, fecha_vencimiento, cantidad}, ...] ya agrupado por
+-- (producto, fecha) del lado del cliente. Una linea de factura puede aportar
+-- varias entradas -- vienen 12 cajas que vencen en marzo y 8 en mayo -- y varias
+-- lineas del mismo producto se suman en una sola.
+--
+-- Idempotente: borra los lotes de la compra y los reescribe. Preserva el
+-- consumo cuando la clave (producto, fecha) sobrevive a la edicion, que es el
+-- caso comun -- se corrigio una cantidad, no las fechas.
+-- ---------------------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION public.sincronizar_lotes_compra(
+  p_compra_id bigint,
+  p_lotes     jsonb
+) RETURNS jsonb
+LANGUAGE plpgsql VOLATILE SECURITY DEFINER
+SET search_path TO 'public'
+AS $fn$
+DECLARE
+  v_sucursal  bigint := public.current_sucursal_id();
+  v_rol       text;
+  v_estado    text;
+  v_previos   jsonb;
+  v_tocados   bigint[];
+  v_consumido integer;
+  v_creados   integer := 0;
+  v_clamp     integer;
+  v_avisos    jsonb := '[]'::jsonb;
+  v_prod      bigint;
+  r           record;
+BEGIN
+  IF v_sucursal IS NULL THEN
+    RAISE EXCEPTION 'No se pudo determinar la sucursal activa';
+  END IF;
+
+  SELECT rol INTO v_rol FROM public.perfiles WHERE id = auth.uid();
+  IF v_rol IS NULL OR v_rol NOT IN ('admin', 'encargado') THEN
+    RAISE EXCEPTION 'Acceso denegado: se requiere rol admin o encargado';
+  END IF;
+
+  SELECT estado INTO v_estado
+    FROM public.compras
+   WHERE id = p_compra_id AND sucursal_id = v_sucursal;
+
+  IF v_estado IS NULL THEN
+    RAISE EXCEPTION 'La compra % no existe en esta sucursal', p_compra_id;
+  END IF;
+  IF v_estado = 'cancelada' THEN
+    RAISE EXCEPTION 'La compra % esta cancelada: no se le pueden cargar vencimientos', p_compra_id;
+  END IF;
+
+  IF EXISTS (
+    SELECT 1 FROM jsonb_array_elements(COALESCE(p_lotes, '[]'::jsonb)) e
+     WHERE e->>'producto_id' IS NULL
+        OR e->>'fecha_vencimiento' IS NULL
+        OR e->>'cantidad' IS NULL
+        OR (e->>'cantidad')::integer <= 0
+  ) THEN
+    RAISE EXCEPTION 'Hay lotes sin producto, sin fecha o con cantidad no positiva en el payload';
+  END IF;
+
+  -- Snapshot del consumo actual antes de borrar, indexado por producto|fecha.
+  -- Sin esto, editar una compra resucitaria lotes ya vendidos y el clamp los
+  -- tendria que volver a bajar por el otro extremo, corriendo el consumo de
+  -- lote. Va en un jsonb y no en una tabla temporal: una TEMP TABLE adentro de
+  -- una funcion SECURITY DEFINER sobrevive a la funcion y explota en la segunda
+  -- llamada de la misma transaccion.
+  SELECT COALESCE(jsonb_object_agg(clave, consumido), '{}'::jsonb)
+    INTO v_previos
+    FROM (
+      SELECT producto_id::text || '|' || fecha_vencimiento::text AS clave,
+             SUM(cantidad - cantidad_restante)::integer          AS consumido
+        FROM public.producto_lotes
+       WHERE compra_id = p_compra_id
+       GROUP BY 1
+    ) t;
+
+  SELECT COALESCE(array_agg(DISTINCT producto_id), ARRAY[]::bigint[])
+    INTO v_tocados
+    FROM public.producto_lotes
+   WHERE compra_id = p_compra_id;
+
+  DELETE FROM public.producto_lotes WHERE compra_id = p_compra_id;
+
+  -- Agrupado en SQL: dos entradas del payload con la misma (producto, fecha)
+  -- son el mismo lote y se suman. Asi no hace falta un ON CONFLICT que tendria
+  -- que descontar el consumo dos veces.
+  FOR r IN
+    SELECT (e->>'producto_id')::bigint       AS producto_id,
+           (e->>'fecha_vencimiento')::date   AS fecha,
+           SUM((e->>'cantidad')::integer)::integer AS cantidad
+      FROM jsonb_array_elements(COALESCE(p_lotes, '[]'::jsonb)) e
+     GROUP BY 1, 2
+  LOOP
+    -- La FK compuesta ya lo impediria, pero el mensaje de una FK no le dice
+    -- nada a quien esta cargando una factura.
+    IF NOT EXISTS (SELECT 1 FROM public.productos
+                    WHERE id = r.producto_id AND sucursal_id = v_sucursal) THEN
+      RAISE EXCEPTION 'El producto % no existe en esta sucursal', r.producto_id;
+    END IF;
+
+    v_consumido := COALESCE(
+      (v_previos->>(r.producto_id::text || '|' || r.fecha::text))::integer, 0);
+
+    INSERT INTO public.producto_lotes (
+      producto_id, sucursal_id, fecha_vencimiento, cantidad, cantidad_restante,
+      compra_id, origen, usuario_id
+    ) VALUES (
+      r.producto_id, v_sucursal, r.fecha, r.cantidad,
+      GREATEST(r.cantidad - v_consumido, 0),
+      p_compra_id, 'compra', auth.uid()
+    );
+
+    v_creados := v_creados + 1;
+    v_tocados := v_tocados || r.producto_id;
+  END LOOP;
+
+  -- El clamp por producto tocado, en las dos direcciones: los que quedaron en
+  -- el payload y los que salieron de el.
+  FOREACH v_prod IN ARRAY v_tocados LOOP
+    v_clamp := public._clampear_lotes_a_stock(v_prod, v_sucursal);
+    IF v_clamp > 0 THEN
+      v_avisos := v_avisos || jsonb_build_array(jsonb_build_object(
+        'producto_id', v_prod,
+        'unidades',    v_clamp
+      ));
+    END IF;
+  END LOOP;
+
+  RETURN jsonb_build_object(
+    'ok',            true,
+    'lotes',         v_creados,
+    'warning_clamp', v_avisos
+  );
+END;
+$fn$;
+
+COMMENT ON FUNCTION public.sincronizar_lotes_compra(bigint, jsonb) IS
+  'Reescribe los lotes de una compra desde [{producto_id, fecha_vencimiento, '
+  'cantidad}]. Idempotente. La llama el cliente despues de registrar o editar '
+  'la compra. mig 224.';
+
+-- ---------------------------------------------------------------------------
+-- 3 - Una compra cancelada se lleva sus lotes
+--
+-- Va por trigger y no dentro de anular_compra_atomica para no volver a parchear
+-- esa funcion. Ojo con el orden: anular_compra_atomica revierte el stock ANTES
+-- de poner estado = 'cancelada' (mig 115), asi que cuando este trigger corre el
+-- trigger de productos ya pudo haber consumido lotes por FEFO. El invariante se
+-- mantiene igual -- borrar lotes solo baja la suma --; lo que se pierde es
+-- precision: parte de esas unidades terminan en la bolsa en vez de en un lote.
+-- Solo pasa cuando los lotes cubrian casi todo el stock, y se corrige a mano
+-- desde la ficha.
+--
+-- AFTER UPDATE sin `OF estado` y filtrando adentro, por el mismo criterio que
+-- el resto de los triggers de la casa.
+-- ---------------------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION public.borrar_lotes_compra_cancelada() RETURNS trigger
+LANGUAGE plpgsql SECURITY DEFINER
+SET search_path TO 'public'
+AS $fn$
+BEGIN
+  IF NEW.estado = 'cancelada' AND OLD.estado IS DISTINCT FROM 'cancelada' THEN
+    DELETE FROM public.producto_lotes WHERE compra_id = NEW.id;
+  END IF;
+  RETURN NEW;
+END;
+$fn$;
+
+COMMENT ON FUNCTION public.borrar_lotes_compra_cancelada() IS
+  'Al cancelar una compra, sus lotes dejan de existir. mig 224.';
+
+CREATE OR REPLACE TRIGGER trg_lotes_compra_cancelada
+  AFTER UPDATE ON public.compras
+  FOR EACH ROW EXECUTE FUNCTION public.borrar_lotes_compra_cancelada();
+
+-- ---------------------------------------------------------------------------
+-- 4 - Etiquetar parte de la bolsa
+--
+-- Este es el camino del stock que ya existia cuando se prendio la feature, y
+-- tambien el de la compra a la que no se le cargo la fecha. No hay inventario
+-- inicial: cuando pasas por un producto y miras la caja, cargas la fecha ahi
+-- nomas y esas unidades salen de la bolsa.
+--
+-- NO toca productos.stock. Solo mueve unidades de "no se cuando vence" a "se
+-- cuando vence", que es un cambio de conocimiento, no de saldo.
+-- ---------------------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION public.crear_lote_manual(
+  p_producto_id      bigint,
+  p_fecha_vencimiento date,
+  p_cantidad         integer
+) RETURNS jsonb
+LANGUAGE plpgsql VOLATILE SECURITY DEFINER
+SET search_path TO 'public'
+AS $fn$
+DECLARE
+  v_sucursal bigint := public.current_sucursal_id();
+  v_rol      text;
+  v_stock    integer;
+  v_asignado integer;
+  v_bolsa    integer;
+  v_lote_id  bigint;
+BEGIN
+  IF v_sucursal IS NULL THEN
+    RAISE EXCEPTION 'No se pudo determinar la sucursal activa';
+  END IF;
+
+  -- Deposito incluido: es quien camina el deposito y ve la caja.
+  SELECT rol INTO v_rol FROM public.perfiles WHERE id = auth.uid();
+  IF v_rol IS NULL OR v_rol NOT IN ('admin', 'encargado', 'deposito') THEN
+    RAISE EXCEPTION 'Acceso denegado: se requiere rol admin, encargado o deposito';
+  END IF;
+
+  IF p_fecha_vencimiento IS NULL THEN
+    RAISE EXCEPTION 'Falta la fecha de vencimiento';
+  END IF;
+  IF p_cantidad IS NULL OR p_cantidad <= 0 THEN
+    RAISE EXCEPTION 'La cantidad tiene que ser mayor a 0';
+  END IF;
+
+  SELECT stock INTO v_stock
+    FROM public.productos
+   WHERE id = p_producto_id AND sucursal_id = v_sucursal
+     FOR UPDATE;
+
+  IF v_stock IS NULL THEN
+    RAISE EXCEPTION 'El producto % no existe en esta sucursal', p_producto_id;
+  END IF;
+
+  SELECT COALESCE(SUM(cantidad_restante), 0) INTO v_asignado
+    FROM public.producto_lotes
+   WHERE producto_id = p_producto_id AND sucursal_id = v_sucursal;
+
+  v_bolsa := v_stock - v_asignado;
+
+  IF p_cantidad > v_bolsa THEN
+    RAISE EXCEPTION 'Solo hay % unidades sin vencimiento cargado (stock %, ya asignadas %). No se pueden etiquetar %.',
+      v_bolsa, v_stock, v_asignado, p_cantidad;
+  END IF;
+
+  -- Fusion por (producto, fecha): dos cargas de la misma fecha son el mismo
+  -- lote. El UNIQUE de la tabla no lo cubre porque compra_id es NULL y en
+  -- Postgres los NULL son distintos entre si.
+  SELECT id INTO v_lote_id
+    FROM public.producto_lotes
+   WHERE producto_id = p_producto_id
+     AND sucursal_id = v_sucursal
+     AND fecha_vencimiento = p_fecha_vencimiento
+     AND compra_id IS NULL
+   ORDER BY id
+   LIMIT 1
+     FOR UPDATE;
+
+  IF v_lote_id IS NOT NULL THEN
+    UPDATE public.producto_lotes
+       SET cantidad          = cantidad + p_cantidad,
+           cantidad_restante = cantidad_restante + p_cantidad
+     WHERE id = v_lote_id;
+  ELSE
+    INSERT INTO public.producto_lotes (
+      producto_id, sucursal_id, fecha_vencimiento, cantidad, cantidad_restante,
+      compra_id, origen, usuario_id
+    ) VALUES (
+      p_producto_id, v_sucursal, p_fecha_vencimiento, p_cantidad, p_cantidad,
+      NULL, 'manual', auth.uid()
+    )
+    RETURNING id INTO v_lote_id;
+  END IF;
+
+  RETURN jsonb_build_object(
+    'ok',      true,
+    'lote_id', v_lote_id,
+    'bolsa',   v_bolsa - p_cantidad
+  );
+END;
+$fn$;
+
+COMMENT ON FUNCTION public.crear_lote_manual(bigint, date, integer) IS
+  'Etiqueta con una fecha parte del stock sin vencimiento cargado. No toca '
+  'productos.stock. mig 224.';
+
+-- ---------------------------------------------------------------------------
+-- 5 - Corregir un contador a mano
+--
+-- "El sistema dice 12 y en la caja hay 5." La diferencia no se pierde: vuelve a
+-- la bolsa, que es la respuesta honesta a "esas 7 unidades existen pero no se
+-- de que lote son". Tampoco toca productos.stock: si faltan de verdad, eso es
+-- una merma y va por el otro camino.
+-- ---------------------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION public.ajustar_lote(
+  p_lote_id           bigint,
+  p_cantidad_restante integer
+) RETURNS jsonb
+LANGUAGE plpgsql VOLATILE SECURITY DEFINER
+SET search_path TO 'public'
+AS $fn$
+DECLARE
+  v_sucursal bigint := public.current_sucursal_id();
+  v_rol      text;
+  v_lote     record;
+  v_stock    integer;
+  v_otros    integer;
+BEGIN
+  IF v_sucursal IS NULL THEN
+    RAISE EXCEPTION 'No se pudo determinar la sucursal activa';
+  END IF;
+
+  SELECT rol INTO v_rol FROM public.perfiles WHERE id = auth.uid();
+  IF v_rol IS NULL OR v_rol NOT IN ('admin', 'encargado') THEN
+    RAISE EXCEPTION 'Acceso denegado: se requiere rol admin o encargado';
+  END IF;
+
+  IF p_cantidad_restante IS NULL OR p_cantidad_restante < 0 THEN
+    RAISE EXCEPTION 'La cantidad restante no puede ser negativa';
+  END IF;
+
+  SELECT * INTO v_lote
+    FROM public.producto_lotes
+   WHERE id = p_lote_id AND sucursal_id = v_sucursal
+     FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'El lote % no existe en esta sucursal', p_lote_id;
+  END IF;
+  IF p_cantidad_restante > v_lote.cantidad THEN
+    RAISE EXCEPTION 'El lote nacio con % unidades: no puede quedarle %',
+      v_lote.cantidad, p_cantidad_restante;
+  END IF;
+
+  SELECT stock INTO v_stock
+    FROM public.productos
+   WHERE id = v_lote.producto_id AND sucursal_id = v_sucursal;
+
+  SELECT COALESCE(SUM(cantidad_restante), 0) INTO v_otros
+    FROM public.producto_lotes
+   WHERE producto_id = v_lote.producto_id
+     AND sucursal_id = v_sucursal
+     AND id <> p_lote_id;
+
+  IF v_otros + p_cantidad_restante > v_stock THEN
+    RAISE EXCEPTION 'No entra: el stock del producto es % y los otros lotes ya ocupan %',
+      v_stock, v_otros;
+  END IF;
+
+  UPDATE public.producto_lotes
+     SET cantidad_restante = p_cantidad_restante
+   WHERE id = p_lote_id;
+
+  RETURN jsonb_build_object(
+    'ok',                true,
+    'lote_id',           p_lote_id,
+    'cantidad_restante', p_cantidad_restante,
+    'bolsa',             v_stock - v_otros - p_cantidad_restante
+  );
+END;
+$fn$;
+
+COMMENT ON FUNCTION public.ajustar_lote(bigint, integer) IS
+  'Corrige a mano el contador de un lote. La diferencia vuelve a la bolsa. No '
+  'toca productos.stock. mig 224.';
+
+-- ---------------------------------------------------------------------------
+-- 6 - Dar de baja un lote vencido
+--
+-- EL ORDEN IMPORTA. Se descuenta el lote ANTES que el stock:
+--
+--   bolsa_despues = (stock - N) - (asignado - N) = stock - asignado = bolsa
+--
+-- La bolsa queda igual, asi que cuando el trigger de la mig 223 corra no va a
+-- encontrar excedente y no va a consumir un segundo lote por FEFO. Al reves --
+-- stock primero -- el trigger comeria del lote que vence antes, que podria no
+-- ser este.
+--
+-- El motivo 'vencimiento' ya existe en el CHECK vivo de mermas_stock (mig 011),
+-- asi que no hay que tocar el CHECK ni el invariante MERMA-A. El costo lo
+-- congela solo trg_mermas_snapshot_costo (mig 119).
+-- ---------------------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION public.dar_de_baja_lote(
+  p_lote_id       bigint,
+  p_cantidad      integer,
+  p_observaciones text DEFAULT NULL
+) RETURNS jsonb
+LANGUAGE plpgsql VOLATILE SECURITY DEFINER
+SET search_path TO 'public'
+AS $fn$
+DECLARE
+  v_sucursal bigint := public.current_sucursal_id();
+  v_rol      text;
+  v_lote     record;
+  v_stock    integer;
+  v_merma_id bigint;
+BEGIN
+  IF v_sucursal IS NULL THEN
+    RAISE EXCEPTION 'No se pudo determinar la sucursal activa';
+  END IF;
+
+  SELECT rol INTO v_rol FROM public.perfiles WHERE id = auth.uid();
+  IF v_rol IS NULL OR v_rol NOT IN ('admin', 'encargado') THEN
+    RAISE EXCEPTION 'Acceso denegado: se requiere rol admin o encargado';
+  END IF;
+
+  IF p_cantidad IS NULL OR p_cantidad <= 0 THEN
+    RAISE EXCEPTION 'La cantidad a dar de baja tiene que ser mayor a 0';
+  END IF;
+
+  SELECT * INTO v_lote
+    FROM public.producto_lotes
+   WHERE id = p_lote_id AND sucursal_id = v_sucursal
+     FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'El lote % no existe en esta sucursal', p_lote_id;
+  END IF;
+  IF p_cantidad > v_lote.cantidad_restante THEN
+    RAISE EXCEPTION 'El lote tiene % unidades: no se pueden dar de baja %',
+      v_lote.cantidad_restante, p_cantidad;
+  END IF;
+
+  SELECT stock INTO v_stock
+    FROM public.productos
+   WHERE id = v_lote.producto_id AND sucursal_id = v_sucursal
+     FOR UPDATE;
+
+  IF v_stock < p_cantidad THEN
+    RAISE EXCEPTION 'El stock del producto es % y la baja es de %: dejaria stock negativo',
+      v_stock, p_cantidad;
+  END IF;
+
+  -- 1) el lote
+  UPDATE public.producto_lotes
+     SET cantidad_restante = cantidad_restante - p_cantidad
+   WHERE id = p_lote_id;
+
+  -- 2) la merma. usuario_id nunca NULL: es el invariante MERMA-I.
+  --    stock_nuevo = GREATEST(stock_anterior - cantidad, 0) es MERMA-B.
+  INSERT INTO public.mermas_stock (
+    producto_id, cantidad, motivo, observaciones,
+    stock_anterior, stock_nuevo, usuario_id, sucursal_id
+  ) VALUES (
+    v_lote.producto_id, p_cantidad, 'vencimiento',
+    COALESCE(NULLIF(btrim(COALESCE(p_observaciones, '')), ''),
+             'Lote vencido el ' || to_char(v_lote.fecha_vencimiento, 'DD/MM/YYYY')),
+    v_stock, GREATEST(v_stock - p_cantidad, 0), auth.uid(), v_sucursal
+  )
+  RETURNING id INTO v_merma_id;
+
+  -- 3) el stock, etiquetado para el ledger
+  PERFORM set_config('app.stock_origen',   'lote_vencido',    true);
+  PERFORM set_config('app.stock_ref_tipo', 'producto_lotes',  true);
+  PERFORM set_config('app.stock_ref_id',   p_lote_id::text,   true);
+  PERFORM set_config('app.stock_user_id',  auth.uid()::text,  true);
+
+  UPDATE public.productos
+     SET stock = stock - p_cantidad,
+         updated_at = now()
+   WHERE id = v_lote.producto_id AND sucursal_id = v_sucursal;
+
+  RETURN jsonb_build_object(
+    'ok',                true,
+    'lote_id',           p_lote_id,
+    'merma_id',          v_merma_id,
+    'cantidad',          p_cantidad,
+    'cantidad_restante', v_lote.cantidad_restante - p_cantidad,
+    'stock',             v_stock - p_cantidad
+  );
+END;
+$fn$;
+
+COMMENT ON FUNCTION public.dar_de_baja_lote(bigint, integer, text) IS
+  'Da de baja unidades de un lote como merma por vencimiento. Descuenta el lote '
+  'antes que el stock para que el trigger no consuma un segundo lote. mig 224.';
+
+-- ---------------------------------------------------------------------------
+-- 7 - El panel
+--
+-- Devuelve datos crudos -- la fecha y los dias que faltan -- y NO el semaforo.
+-- La regla de que es amarillo y que es rojo vive una sola vez, en
+-- src/utils/vencimientos.ts con sus tests. Calcularla tambien aca crearia un
+-- espejo que se desincroniza, que es exactamente el problema que obligo a
+-- escribir el gate espejo-motor-compras.mjs.
+--
+-- Una sola firma con DEFAULT y no dos sobrecargas: dos funciones con rangos
+-- [obligatorios, total] superpuestos hacen que PostgREST tire PGRST203 en
+-- runtime, invisible para tsc y para los tests.
+-- ---------------------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION public.reporte_vencimientos(
+  p_dias_horizonte integer DEFAULT 3650
+) RETURNS TABLE (
+  lote_id            bigint,
+  producto_id        bigint,
+  producto_nombre    text,
+  producto_codigo    text,
+  fecha_vencimiento  date,
+  cantidad           integer,
+  cantidad_restante  integer,
+  dias_restantes     integer,
+  origen             text,
+  compra_id          bigint,
+  stock_producto     integer,
+  bolsa_producto     integer
+)
+LANGUAGE plpgsql STABLE SECURITY DEFINER
+SET search_path TO 'public'
+AS $fn$
+DECLARE
+  v_sucursal bigint := public.current_sucursal_id();
+  v_rol      text;
+BEGIN
+  IF v_sucursal IS NULL THEN
+    RAISE EXCEPTION 'No se pudo determinar la sucursal activa';
+  END IF;
+
+  SELECT rol INTO v_rol FROM public.perfiles WHERE id = auth.uid();
+  IF v_rol IS NULL OR v_rol NOT IN ('admin', 'encargado', 'deposito') THEN
+    RAISE EXCEPTION 'Acceso denegado: se requiere rol admin, encargado o deposito';
+  END IF;
+
+  RETURN QUERY
+  WITH asignado AS (
+    SELECT pl.producto_id AS pid, SUM(pl.cantidad_restante)::integer AS total
+      FROM public.producto_lotes pl
+     WHERE pl.sucursal_id = v_sucursal
+     GROUP BY pl.producto_id
+  )
+  SELECT l.id,
+         l.producto_id,
+         p.nombre::text,
+         p.codigo::text,
+         l.fecha_vencimiento,
+         l.cantidad,
+         l.cantidad_restante,
+         (l.fecha_vencimiento - CURRENT_DATE)::integer,
+         l.origen,
+         l.compra_id,
+         p.stock,
+         (p.stock - COALESCE(a.total, 0))::integer
+    FROM public.producto_lotes l
+    JOIN public.productos p
+      ON p.id = l.producto_id AND p.sucursal_id = l.sucursal_id
+    LEFT JOIN asignado a ON a.pid = l.producto_id
+   WHERE l.sucursal_id = v_sucursal
+     AND l.cantidad_restante > 0
+     AND (l.fecha_vencimiento - CURRENT_DATE) <= COALESCE(p_dias_horizonte, 3650)
+   ORDER BY l.fecha_vencimiento ASC, p.nombre ASC;
+END;
+$fn$;
+
+COMMENT ON FUNCTION public.reporte_vencimientos(integer) IS
+  'Lotes vivos de la sucursal activa con los dias que faltan. El semaforo lo '
+  'pinta el front con los umbrales de politicas_comerciales. mig 224.';
+
+-- ---------------------------------------------------------------------------
+-- 8 - Permisos
+-- ---------------------------------------------------------------------------
+
+REVOKE ALL ON FUNCTION public._clampear_lotes_a_stock(bigint, bigint) FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.borrar_lotes_compra_cancelada() FROM PUBLIC, anon, authenticated;
+
+REVOKE ALL ON FUNCTION public.sincronizar_lotes_compra(bigint, jsonb) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.sincronizar_lotes_compra(bigint, jsonb) TO authenticated;
+
+REVOKE ALL ON FUNCTION public.crear_lote_manual(bigint, date, integer) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.crear_lote_manual(bigint, date, integer) TO authenticated;
+
+REVOKE ALL ON FUNCTION public.ajustar_lote(bigint, integer) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.ajustar_lote(bigint, integer) TO authenticated;
+
+REVOKE ALL ON FUNCTION public.dar_de_baja_lote(bigint, integer, text) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.dar_de_baja_lote(bigint, integer, text) TO authenticated;
+
+REVOKE ALL ON FUNCTION public.reporte_vencimientos(integer) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.reporte_vencimientos(integer) TO authenticated;
+
+DO $verif$
+DECLARE
+  v_acl text;
+  v_fn  text;
+BEGIN
+  FOREACH v_fn IN ARRAY ARRAY['_clampear_lotes_a_stock', 'borrar_lotes_compra_cancelada'] LOOP
+    SELECT array_to_string(proacl, ',') INTO v_acl
+      FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace
+     WHERE n.nspname = 'public' AND p.proname = v_fn;
+
+    IF v_acl IS NULL THEN
+      RAISE EXCEPTION '% quedo con ACL default (PUBLIC ejecuta)', v_fn;
+    END IF;
+    IF v_acl LIKE '=X/%' OR v_acl LIKE '%,=X/%' THEN
+      RAISE EXCEPTION '% quedo ejecutable por PUBLIC: %', v_fn, v_acl;
+    END IF;
+    IF v_acl LIKE '%anon=%' THEN
+      RAISE EXCEPTION '% quedo ejecutable por anon: %', v_fn, v_acl;
+    END IF;
+    IF v_acl LIKE '%authenticated=%' THEN
+      RAISE EXCEPTION '% no deberia ser ejecutable por authenticated: %', v_fn, v_acl;
+    END IF;
+  END LOOP;
+
+  FOREACH v_fn IN ARRAY ARRAY['sincronizar_lotes_compra', 'crear_lote_manual',
+                              'ajustar_lote', 'dar_de_baja_lote',
+                              'reporte_vencimientos'] LOOP
+    SELECT array_to_string(proacl, ',') INTO v_acl
+      FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace
+     WHERE n.nspname = 'public' AND p.proname = v_fn;
+
+    IF v_acl IS NULL THEN
+      RAISE EXCEPTION '% quedo con ACL default (PUBLIC ejecuta)', v_fn;
+    END IF;
+    IF v_acl LIKE '=X/%' OR v_acl LIKE '%,=X/%' THEN
+      RAISE EXCEPTION '% quedo ejecutable por PUBLIC: %', v_fn, v_acl;
+    END IF;
+    IF v_acl LIKE '%anon=%' THEN
+      RAISE EXCEPTION '% quedo ejecutable por anon: %', v_fn, v_acl;
+    END IF;
+    IF v_acl NOT LIKE '%authenticated=X%' THEN
+      RAISE EXCEPTION '% no quedo ejecutable por authenticated: %', v_fn, v_acl;
+    END IF;
+  END LOOP;
+END
+$verif$;
+
+COMMIT;

--- a/migrations/225_los_lotes_no_pueden_sumar_mas_que_el_stock.sql
+++ b/migrations/225_los_lotes_no_pueden_sumar_mas_que_el_stock.sql
@@ -1,0 +1,104 @@
+-- =========================================================================
+-- Los lotes no pueden sumar mas que el stock
+--
+-- Tres invariantes para auditoria_integridad(), todos high, que vigilan el
+-- modelo de vencimientos de las migs 223/224.
+--
+-- LOTE-A es el que importa: SUM(cantidad_restante) <= productos.stock por
+-- (producto, sucursal). Es la definicion misma de la bolsa "sin vencimiento" --
+-- si la suma pasa el stock, la bolsa es negativa y eso no significa nada. Se
+-- rompe si alguien escribe producto_lotes por fuera de las RPCs, si el clamp
+-- falla, o si un camino nuevo baja el stock sin que el trigger lo vea.
+--
+-- POR QUE NO SE REESCRIBE LA FUNCION DESDE migrations/105
+-- ------------------------------------------------------
+-- El cuerpo vivo lo parchearon las migs 178, 180, 194 y 195. Un CREATE OR
+-- REPLACE armado desde el archivo original las revertiria todas en silencio.
+-- Se lee la definicion viva del catalogo, se inserta con un ancla que tiene que
+-- aparecer exactamente una vez, y se ejecuta -- el patron de la mig 180.
+-- =========================================================================
+
+BEGIN;
+
+DO $mig$
+DECLARE
+  v_def   text;
+  v_veces integer;
+  -- El cierre del VALUES, justo despues del ultimo check (RUTA-C, mig 180).
+  v_ancla CONSTANT text := $a$WHERE p.estado IN ('cancelado','anulado') AND r.estado='en_curso'))
+  )$a$;
+  v_nuevo CONSTANT text := $a$WHERE p.estado IN ('cancelado','anulado') AND r.estado='en_curso')),
+    -- ===== Vencimientos por lote (mig 225) =====
+    ('LOTE-A','high','productos donde la suma de los lotes supera el stock',
+      (SELECT count(*) FROM (
+         SELECT l.producto_id AS pid, l.sucursal_id AS sid,
+                SUM(l.cantidad_restante) AS asignado
+           FROM producto_lotes l GROUP BY 1,2
+       ) a
+       JOIN productos p ON p.id=a.pid AND p.sucursal_id=a.sid
+      WHERE a.asignado > p.stock)),
+    ('LOTE-B','high','lotes con el contador fuera de rango',
+      (SELECT count(*) FROM producto_lotes
+        WHERE cantidad_restante < 0 OR cantidad_restante > cantidad OR cantidad <= 0)),
+    ('LOTE-C','high','lotes cuya sucursal no coincide con la del producto',
+      (SELECT count(*) FROM producto_lotes l
+         JOIN productos p ON p.id=l.producto_id
+        WHERE p.sucursal_id <> l.sucursal_id))
+  )$a$;
+BEGIN
+  v_def := pg_get_functiondef('public.auditoria_integridad()'::regprocedure);
+
+  IF position('LOTE-A' in v_def) > 0 THEN
+    RAISE NOTICE 'mig 225 - checks LOTE-* ya presentes, se omite';
+    RETURN;
+  END IF;
+
+  v_veces := (length(v_def) - length(replace(v_def, v_ancla, ''))) / length(v_ancla);
+  IF v_veces <> 1 THEN
+    RAISE EXCEPTION 'mig 225 - el ancla de auditoria_integridad aparece % veces (se esperaba 1). El cuerpo derivo; revisa el parche antes de aplicar.', v_veces;
+  END IF;
+
+  EXECUTE replace(v_def, v_ancla, v_nuevo);
+END
+$mig$;
+
+-- ---------------------------------------------------------------------------
+-- Post-condicion, obligatoria.
+--
+-- Los cuerpos plpgsql son strings y Postgres no los valida al crearlos: un
+-- parche que no hubiera entrado NO falla al aplicar, falla en produccion. Hay
+-- que correr la funcion y ver los checks nuevos ahi.
+--
+-- Y tienen que NACER EN VERDE. Un check que nace rojo vuelve inutil al gate
+-- diario -- es lo que le paso a COMPRA-A1 antes de la mig 178, y por eso los
+-- que se agregaban despues nacian invisibles.
+-- ---------------------------------------------------------------------------
+DO $verif$
+DECLARE
+  v_res  jsonb;
+  v_chk  jsonb;
+  v_id   text;
+BEGIN
+  v_res := public.auditoria_integridad();
+
+  FOREACH v_id IN ARRAY ARRAY['LOTE-A', 'LOTE-B', 'LOTE-C'] LOOP
+    SELECT c INTO v_chk
+      FROM jsonb_array_elements(v_res->'checks') c
+     WHERE c->>'id' = v_id;
+
+    IF v_chk IS NULL THEN
+      RAISE EXCEPTION 'mig 225 - % no aparece en la salida de auditoria_integridad(). El parche no entro.', v_id;
+    END IF;
+    IF (v_chk->>'violaciones')::integer <> 0 THEN
+      RAISE EXCEPTION 'mig 225 - % nace en rojo con % violaciones. Un check que nace rojo vuelve inutil al gate diario.',
+        v_id, v_chk->>'violaciones';
+    END IF;
+  END LOOP;
+
+  IF (v_res->>'overall_ok')::boolean IS NOT TRUE THEN
+    RAISE WARNING 'mig 225 - auditoria_integridad() quedo en rojo por checks PREEXISTENTES (los LOTE-* estan en verde). Revisar aparte.';
+  END IF;
+END
+$verif$;
+
+COMMIT;

--- a/migrations/MANIFEST.md
+++ b/migrations/MANIFEST.md
@@ -1,6 +1,6 @@
 # MANIFEST de migraciones — mapeo repo ↔ producción
 
-> **Fechado: 2026-09-09** · Proyecto prod `hmuchlzmuqqxcldbzkgc` (ManaosApp) · región `sa-east-1`.
+> **Fechado: 2026-09-10** · Proyecto prod `hmuchlzmuqqxcldbzkgc` (ManaosApp) · región `sa-east-1`.
 
 ## Regla de oro
 
@@ -137,11 +137,9 @@ funcional** y no se renombran los archivos: renombrarlos los desalinearía del l
 real lo da `version` y está en la sección A: en los dos casos el archivo de `main` quedó
 cronológicamente **fuera** del bloque 139–147 (uno antes, otro entre la 144 y la 145).
 
-**La próxima migración es la 220.** El ledger de prod llega hasta
-`219_la_venta_es_de_quien_la_carga`. **Ojo con el 218**: `218_que_boletas_debe_no_solo_cuanto`
-está aplicada en prod pero su archivo todavía no está en el repo (viene de otra rama sin
-mergear), así que el hueco entre la 217 y la 219 acá es esperable y no es drift.
-Igual, confirmá el número contra las tres fuentes justo antes de aplicar: el número se
+**La próxima migración es la 226.** El ledger de prod llega hasta
+`225_los_lotes_no_pueden_sumar_mas_que_el_stock`.
+Confirmá el número contra las tres fuentes justo antes de aplicar: el número se
 reserva **aplicando**, no escribiendo el archivo.
 
 (Esta línea decía 206 hasta el 2026-09-08, con las 206–209 ya aplicadas: la
@@ -152,7 +150,35 @@ Y otra vez el mismo día: la 218 se aplicó desde otra sesión **mientras** se e
 terminó siendo la 219 — que salió con el número correcto sólo porque se confirmó contra el
 ledger en el último momento, no porque esta línea estuviera al día. Moraleja: esta línea es
 una ayuda, el ledger es la verdad. Si aplicás una migración, actualizá también esta línea.
-Última actualización: 219, el 2026-09-09.)
+Y pasó de nuevo el 2026-09-10: decía 220 con la 220, la 221 y la 222 ya en el ledger — la
+222 desde otra rama, sin archivo en el repo en ese momento. Quien fue a escribir las de
+vencimientos leyó "escribí la 220" y habría pisado tres migraciones vivas.
+Última actualización: 225, el 2026-09-10.)
+
+### 223–225 · Vencimientos por lote
+
+Las tres van juntas y en ese orden: la **223** pone el modelo (`producto_lotes`, el motor de
+consumo y el trigger sobre `productos`), la **224** las cinco operaciones (los lotes de una
+compra, etiquetar la bolsa a mano, corregir un contador, dar de baja y el reporte del panel),
+y la **225** los invariantes `LOTE-A/B/C` de `auditoria_integridad()`.
+
+Dos decisiones que no se ven leyendo el SQL:
+
+- **El consumo se engancha en UN trigger sobre `productos`, no en las ~20 RPCs que mueven
+  stock.** Todas pasan por `UPDATE productos SET stock` y ya hay un trigger hermano
+  (`trg_stock_historico`, mig 038) que lee `current_setting('app.stock_origen')`. El trigger
+  nuevo usa el mismo canal: por eso cubre de una sola vez pedidos, bot, mermas —que ni
+  siquiera pasan por una RPC—, movimientos entre sucursales y control de stock.
+- **Los lotes de una compra NO se escriben dentro de `registrar_compra_completa`.** Esa
+  función, `actualizar_compra_items` y `anular_compra_atomica` son las tres más parcheadas del
+  repo (128, 177, 194, 195, todas por ancla sobre el cuerpo vivo). `sincronizar_lotes_compra`
+  es idempotente y la llama el cliente después de guardar; la anulación se detecta con un
+  trigger sobre `compras.estado`. Si esa segunda llamada falla, la compra queda bien y los
+  vencimientos sin cargar — el mismo estado que si el usuario los hubiera dejado en blanco.
+
+La bolsa "sin vencimiento" (`productos.stock` − Σ `cantidad_restante`) **no es una fila**: es
+lo que hace que la feature no necesite backfill ni inventario inicial. El invariante `LOTE-A`
+es esa resta escrita como check.
 
 Las 197–202 no tienen prosa acá (quedaron sin documentar en su momento). Las 203, 204,
 205, 212, 213 y 214 sí:

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -30,6 +30,7 @@ import BannerActualizacion from './components/BannerActualizacion'
 import SkipLinks from './components/a11y/SkipLinks'
 import ClientesContainer from './components/containers/ClientesContainer'
 import ComprasContainer from './components/containers/ComprasContainer'
+import VencimientosContainer from './components/containers/VencimientosContainer'
 import DashboardContainer from './components/containers/DashboardContainer'
 import PedidosContainer from './components/containers/PedidosContainer'
 import ProductosContainer from './components/containers/ProductosContainer'
@@ -330,6 +331,17 @@ function MainAppInner({ user, perfil, logout, authReady }: {
                 <Route
                   path="/proveedores"
                   element={isAdmin ? <ProveedoresContainer /> : <Navigate to="/pedidos" replace />}
+                />
+
+                {/* Vencimientos por lote (migs 223/224). Deposito entra: es
+                    quien ve la mercaderia y quien tiene que rotarla. Dar de
+                    baja sigue siendo de administracion, y eso lo decide la
+                    RPC, no la ruta. */}
+                <Route
+                  path="/vencimientos"
+                  element={isAdminOrEncargado || effectiveRol === 'deposito'
+                    ? <VencimientosContainer />
+                    : <Navigate to="/pedidos" replace />}
                 />
 
                 {/* Las condiciones mayoristas viven dentro de Productos: son un

--- a/src/components/containers/ComprasContainer.tsx
+++ b/src/components/containers/ComprasContainer.tsx
@@ -24,6 +24,7 @@ import type { ActualizarCompraItemsInput } from '../../hooks/queries'
 import type { CambiarProveedorPayload } from '../modals/ModalCambiarProveedor'
 import { useAuthData } from '../../contexts/AuthDataContext'
 import { useNotification } from '../../contexts/NotificationContext'
+import { useLotesCompraQuery } from '../../hooks/queries/useLotesQuery'
 import { useResetOnSucursalChange } from '../../hooks/useResetOnSucursalChange'
 import { lazyWithReload } from '../../utils/lazyWithReload'
 import type { CompraDBExtended, CompraFormInputExtended, ProveedorFormInputExtended, NotaCreditoFormInput } from '../../types'
@@ -132,6 +133,11 @@ export default function ComprasContainer(): React.ReactElement {
   const compraConNCId = compraParaNC?.id || compraDetalle?.id
   const notasCreditoQuery = useNotasCreditoByCompraQuery(compraConNCId, !!compraConNCId)
 
+  // Los lotes de la compra abierta (migs 223/224). Se piden aca y no adentro de
+  // los modales porque esos se testean renderizandolos pelados, sin providers.
+  const { data: lotesDetalle } = useLotesCompraQuery(compraDetalle?.id ?? null, !!compraDetalle)
+  const { data: lotesEdicion } = useLotesCompraQuery(compraParaEditar?.id ?? null, !!compraParaEditar)
+
   // Handlers
   const handleNuevaCompra = useCallback(() => {
     setModalCompraOpen(true)
@@ -167,7 +173,7 @@ export default function ComprasContainer(): React.ReactElement {
       // persisten en el centro de notificaciones — el toast del éxito los tapa
       // en la pantalla y el descuadre de una factura es justo lo que hay que
       // poder releer después.
-      avisosDeLaBase(notify, res.warningDescuadre, res.warningIiDeclarado)
+      avisosDeLaBase(notify, res.warningDescuadre, res.warningIiDeclarado, res.warningLotes)
     } catch (err) {
       const msg = err instanceof Error ? err.message : 'Error al registrar compra'
       notify.error(msg)
@@ -223,7 +229,7 @@ export default function ComprasContainer(): React.ReactElement {
       notify.success('Compra actualizada')
       // Editar los items puede dejar el II declarado sin cuadrar (una línea que
       // se fue se lleva su alícuota). La RPC avisa; acá se muestra.
-      avisosDeLaBase(notify, null, res.warningIiDeclarado)
+      avisosDeLaBase(notify, null, res.warningIiDeclarado, res.warningLotes)
       // CPP forward-only (mig 128): editar una compra que NO es la última del
       // producto no re-promedia el costo — avisar para corregirlo en la ficha.
       if (res.warningCostoPromedio.length > 0) {
@@ -338,6 +344,7 @@ export default function ComprasContainer(): React.ReactElement {
             onAnular={handleAnularCompra}
             onNotaCredito={(c) => handleNotaCredito(c as CompraDBExtended)}
             notasCredito={notasCreditoQuery.data as any}
+            lotes={lotesDetalle}
           />
         </Suspense>
       )}
@@ -356,6 +363,7 @@ export default function ComprasContainer(): React.ReactElement {
             guardando={actualizarCompra.isPending}
             canCambiarProveedor={isAdmin}
             onCambiarProveedor={handleAbrirCambioProveedor}
+            lotesIniciales={lotesEdicion}
           />
         </Suspense>
       )}

--- a/src/components/containers/ConfiguracionContainer.tsx
+++ b/src/components/containers/ConfiguracionContainer.tsx
@@ -10,6 +10,7 @@ import {
   usePoliticasComercialesQuery,
   useActualizarMontoMinimoMutation,
   useActualizarComisionesDefaultMutation,
+  useActualizarAlertasVencimientoMutation,
   useImpactoMinimoQuery,
 } from '../../hooks/queries/usePoliticasComercialesQuery'
 import { useNotification } from '../../contexts/NotificationContext'
@@ -32,6 +33,7 @@ export default function ConfiguracionContainer() {
   const { politicas, isLoading } = usePoliticasComercialesQuery()
   const actualizar = useActualizarMontoMinimoMutation()
   const actualizarComisiones = useActualizarComisionesDefaultMutation()
+  const actualizarAlertas = useActualizarAlertasVencimientoMutation()
 
   // Lo que el usuario está tipeando, para poder mostrarle el impacto ANTES de
   // guardar. Arranca en el valor vigente.
@@ -60,6 +62,19 @@ export default function ConfiguracionContainer() {
     }
   }, [actualizarComisiones, notify])
 
+  const handleGuardarAlertas = useCallback(async (diasAlerta: number, diasCritico: number) => {
+    try {
+      await actualizarAlertas.mutateAsync({ diasAlerta, diasCritico })
+      notify.success(
+        diasAlerta === 0 && diasCritico === 0
+          ? 'Solo se van a avisar los lotes ya vencidos'
+          : `Aviso de vencimiento: amarillo a ${diasAlerta} dias, rojo a ${diasCritico}`
+      )
+    } catch (err) {
+      notify.error(err instanceof Error ? err.message : 'No se pudieron guardar los avisos')
+    }
+  }, [actualizarAlertas, notify])
+
   return (
     <Suspense fallback={<LoadingState />}>
       <VistaConfiguracion
@@ -75,6 +90,10 @@ export default function ConfiguracionContainer() {
         comisionPctOtros={politicas.comisionPctOtros}
         guardandoComisiones={actualizarComisiones.isPending}
         onGuardarComisiones={handleGuardarComisiones}
+        diasAlertaVencimiento={politicas.diasAlertaVencimiento}
+        diasCriticoVencimiento={politicas.diasCriticoVencimiento}
+        guardandoAlertas={actualizarAlertas.isPending}
+        onGuardarAlertas={handleGuardarAlertas}
       />
     </Suspense>
   )

--- a/src/components/containers/VencimientosContainer.tsx
+++ b/src/components/containers/VencimientosContainer.tsx
@@ -1,0 +1,72 @@
+/**
+ * VencimientosContainer
+ *
+ * Orquesta el panel de vencimientos (migs 223/224/225). Ver y dar de baja son
+ * dos permisos distintos: depósito mira lo que se le vence, administración
+ * decide qué se descarta. El gate real está en las RPCs — esto es la UI que lo
+ * acompaña.
+ */
+import { Suspense, useCallback } from 'react'
+import { Loader2 } from 'lucide-react'
+import { useVencimientosQuery, useDarDeBajaLoteMutation } from '../../hooks/queries/useLotesQuery'
+import { usePoliticasComercialesQuery } from '../../hooks/queries/usePoliticasComercialesQuery'
+import { useAuth } from '../../hooks/supabase/useAuth'
+import { useNotification } from '../../contexts/NotificationContext'
+import { useSucursal } from '../../contexts/SucursalContext'
+import { lazyWithReload } from '../../utils/lazyWithReload'
+
+const VistaVencimientos = lazyWithReload(() => import('../vistas/VistaVencimientos'))
+
+function LoadingState() {
+  return (
+    <div className="flex justify-center py-12">
+      <Loader2 className="w-6 h-6 animate-spin text-stone-400" />
+    </div>
+  )
+}
+
+export default function VencimientosContainer() {
+  const notify = useNotification()
+  const { currentSucursalNombre } = useSucursal()
+  const { isAdminOrEncargado } = useAuth()
+  const { politicas } = usePoliticasComercialesQuery()
+  const darDeBaja = useDarDeBajaLoteMutation()
+
+  // El horizonte es el umbral amarillo, no "todo": traer los lotes cargados a
+  // dos años para mostrar los veinte que importan es tráfico puro. Lo ya
+  // vencido entra igual — su cuenta de días es negativa.
+  //
+  // El `+ 1` deja pasar el lote que cae justo en el umbral: la RPC compara con
+  // `<=` sobre la fecha del servidor, y si el navegador está un día adelantado
+  // el lote del borde no vendría y el semáforo lo perdería.
+  const horizonte = politicas.diasAlertaVencimiento + 1
+  const { data: lotes = [], isLoading, isFetching, refetch } = useVencimientosQuery(horizonte)
+
+  const handleDarDeBaja = useCallback(async (loteId: number, cantidad: number) => {
+    try {
+      const res = await darDeBaja.mutateAsync({ loteId, cantidad })
+      notify.success(
+        `${cantidad} u. dadas de baja por vencimiento. Stock del producto: ${res.stock}.`
+      )
+    } catch (err) {
+      notify.error(err instanceof Error ? err.message : 'No se pudo dar de baja el lote')
+    }
+  }, [darDeBaja, notify])
+
+  return (
+    <Suspense fallback={<LoadingState />}>
+      <VistaVencimientos
+        lotes={lotes}
+        cargando={isLoading}
+        refrescando={isFetching}
+        diasAlerta={politicas.diasAlertaVencimiento}
+        diasCritico={politicas.diasCriticoVencimiento}
+        puedeDarDeBaja={isAdminOrEncargado}
+        darDeBajaPendiente={darDeBaja.isPending}
+        onRefrescar={() => void refetch()}
+        onDarDeBaja={handleDarDeBaja}
+        nombreSucursal={currentSucursalNombre}
+      />
+    </Suspense>
+  )
+}

--- a/src/components/layout/TopNavigation.tsx
+++ b/src/components/layout/TopNavigation.tsx
@@ -5,7 +5,7 @@ import {
   Truck, Menu, X, LogOut, Moon, Sun, ChevronDown,
   BarChart3, ShoppingCart, Users, Package, TrendingUp,
   UserCog,
-  Settings, Route, ShoppingBag, Building2, Banknote, AlertTriangle, Database, Percent, ArrowRightLeft, Gift, Send, MapPin, Clock, Target, ClipboardCheck
+  Settings, Route, ShoppingBag, Building2, Banknote, AlertTriangle, Database, Percent, ArrowRightLeft, Gift, Send, MapPin, Clock, Target, ClipboardCheck, CalendarClock
 } from 'lucide-react';
 import { getRolColor, getRolLabel } from '../../utils/formatters';
 import { useTheme } from '../../contexts/ThemeContext';
@@ -78,6 +78,7 @@ const menuGroups: MenuGroup[] = [
     items: [
       { id: 'productos', icon: Package, label: 'Productos', roles: ['admin', 'encargado', 'preventista', 'deposito'] },
       { id: 'compras', icon: ShoppingBag, label: 'Compras', roles: ['admin', 'encargado'] },
+      { id: 'vencimientos', icon: CalendarClock, label: 'Vencimientos', roles: ['admin', 'encargado', 'deposito'] },
       { id: 'proveedores', icon: Building2, label: 'Proveedores', roles: ['admin'] },
       // Condiciones Mayoristas salio de aca: ahora es una pestaña dentro de Productos.
       { id: 'promociones', icon: Gift, label: 'Promociones', roles: ['admin'] },

--- a/src/components/modals/ModalCompra.reducer.ts
+++ b/src/components/modals/ModalCompra.reducer.ts
@@ -18,6 +18,24 @@ import { calcularCostosCompra, lineaParaMotor, resolverBasesII } from '../../uti
 import type { PesosCargo, LineaCompra, CargoCompra, ResultadoBasesII } from '../../utils/prorrateoCompra'
 import type { BaseProrrateoCompra, CargoPlantillaCompra, CompraCargoInput, CondicionIva, ProductoDB } from '../../types'
 
+/**
+ * Un vencimiento de una línea de factura (migs 223/224).
+ *
+ * Es una lista y no un campo suelto porque una misma línea puede traer dos
+ * lotes: llegan 20 cajas, 12 vencen en marzo y 8 en mayo. Cargar eso como dos
+ * renglones del mismo producto obligaría a partir también el costo y la
+ * bonificación, que son de la línea, no del lote.
+ *
+ * La suma de las cantidades puede ser MENOR que la cantidad de la línea: lo que
+ * no se etiqueta queda en la bolsa "sin vencimiento" del producto, que es un
+ * estado soportado. Nunca mayor.
+ */
+export interface VencimientoLinea {
+  /** 'YYYY-MM-DD'. */
+  fecha: string;
+  cantidad: number;
+}
+
 /** Item de compra en el formulario */
 export interface CompraItemForm {
   productoId: string;
@@ -41,6 +59,15 @@ export interface CompraItemForm {
    * numera todo lo que llegue sin id.
    */
   lineaId?: number;
+  /**
+   * Vencimientos de esta línea (migs 223/224). Opcional: cargarlos es opcional
+   * y una línea sin vencimientos es perfectamente válida.
+   *
+   * No viaja en `p_items` de `registrar_compra_completa`: se manda aparte, con
+   * `sincronizar_lotes_compra`, después de guardar la compra. Ver el encabezado
+   * de la mig 224 para el porqué.
+   */
+  vencimientos?: VencimientoLinea[];
 }
 
 /**
@@ -257,6 +284,8 @@ export type CompraActionType =
   | { type: 'ACTUALIZAR_ITEM'; payload: { index: number; campo: keyof CompraItemForm; valor: number | string } }
   // Condición y alícuota se setean juntas: la condición manda sobre la tasa.
   | { type: 'SET_CONDICION_ITEM'; payload: { index: number; clave: string } }
+  // La sub-fila de vencimientos maneja su propia lista y empuja la foto entera.
+  | { type: 'SET_VENCIMIENTOS_ITEM'; payload: { index: number; vencimientos: VencimientoLinea[] } }
   | { type: 'ELIMINAR_ITEM'; payload: number }
   | { type: 'LIMPIAR_BUSQUEDA' }
   | { type: 'SET_MODO_ITEM_RAPIDO'; payload: boolean }
@@ -767,6 +796,16 @@ function aplicarAccion(state: CompraState, action: CompraActionType): CompraStat
         )
       }
     }
+
+    case 'SET_VENCIMIENTOS_ITEM':
+      return {
+        ...state,
+        items: state.items.map((item, i) =>
+          i === action.payload.index
+            ? { ...item, vencimientos: action.payload.vencimientos }
+            : item
+        )
+      }
 
     case 'ELIMINAR_ITEM':
       return {

--- a/src/components/modals/ModalCompra.tsx
+++ b/src/components/modals/ModalCompra.tsx
@@ -30,7 +30,9 @@ import {
 import type {
   CompraItemForm, CargoCompraForm, CambiosCargo, BaseProrrateo,
   FacturaEscaneada, FacturaItemEscaneado, CompraState, CompraActionType,
+  VencimientoLinea,
 } from './ModalCompra.reducer'
+import VencimientosLineaCompra from '../vencimientos/VencimientosLineaCompra'
 
 
 const ModalProveedor = lazyWithReload(() => import('./ModalProveedor'))
@@ -79,6 +81,8 @@ interface ProductosSectionProps {
   onActualizarItem: (index: number, campo: keyof CompraItemForm, valor: number | string) => void;
   onCondicionItem: (index: number, clave: string) => void;
   onEliminarItem: (index: number) => void;
+  /** Vencimientos de la línea (migs 223/224). Viajan aparte de p_items. */
+  onVencimientosItem: (index: number, vencimientos: VencimientoLinea[]) => void;
   onCrearProductoRapido?: (data: { nombre: string; codigo: string; costoSinIva: number }) => Promise<ProductoDB>;
   onImportarExcel?: () => void;
 }
@@ -89,6 +93,8 @@ interface ItemsListProps {
   onActualizarItem: (index: number, campo: keyof CompraItemForm, valor: number | string) => void;
   onCondicionItem: (index: number, clave: string) => void;
   onEliminarItem: (index: number) => void;
+  /** Vencimientos de la línea (migs 223/224). Viajan aparte de p_items. */
+  onVencimientosItem: (index: number, vencimientos: VencimientoLinea[]) => void;
   /** Tasa de II vigente del producto (para avisar si la línea difiere) */
   iiMaster: Record<string, number>;
   /** Clave de condición vigente en la ficha del producto (mig 177) */
@@ -102,6 +108,8 @@ interface ItemRowProps {
   onActualizarItem: (index: number, campo: keyof CompraItemForm, valor: number | string) => void;
   onCondicionItem: (index: number, clave: string) => void;
   onEliminarItem: (index: number) => void;
+  /** Vencimientos de la línea (migs 223/224). Viajan aparte de p_items. */
+  onVencimientosItem: (index: number, vencimientos: VencimientoLinea[]) => void;
   /** Tasa de II vigente en el maestro del producto (undefined = desconocida) */
   iiDelProducto?: number;
   /** Clave de condición de la ficha (undefined = desconocida) */
@@ -271,6 +279,10 @@ export default function ModalCompra({ productos, proveedores, onSave, onClose, o
 
   const handleCondicionItem = useCallback((index: number, clave: string) => {
     dispatch({ type: 'SET_CONDICION_ITEM', payload: { index, clave } })
+  }, [])
+
+  const handleVencimientosItem = useCallback((index: number, vencimientos: VencimientoLinea[]) => {
+    dispatch({ type: 'SET_VENCIMIENTOS_ITEM', payload: { index, vencimientos } })
   }, [])
 
   const handleEliminarItem = useCallback((index: number) => {
@@ -468,7 +480,10 @@ export default function ModalCompra({ productos, proveedores, onSave, onClose, o
             bonificacion: item.bonificacion || 0,
             porcentajeIva: item.porcentajeIva ?? 21,
             condicionIva: item.condicionIva ?? 'gravado',
-            impuestosInternos: item.impuestosInternos ?? 0
+            impuestosInternos: item.impuestosInternos ?? 0,
+            // Viajan aparte de p_items: los manda `sincronizar_lotes_compra`
+            // una vez que la compra existe (mig 224).
+            vencimientos: item.vencimientos ?? []
           }
         })
       })
@@ -599,6 +614,7 @@ export default function ModalCompra({ productos, proveedores, onSave, onClose, o
               onActualizarItem={handleActualizarItem}
               onCondicionItem={handleCondicionItem}
               onEliminarItem={handleEliminarItem}
+              onVencimientosItem={handleVencimientosItem}
               onCrearProductoRapido={onCrearProductoRapido}
               onImportarExcel={() => setModalImportarOpen(true)}
             />
@@ -835,7 +851,7 @@ function DatosCompraSection({ state, dispatch }: DatosCompraSectionProps) {
   )
 }
 
-function ProductosSection({ state, dispatch, productosFiltrados, iiMaster, condicionMaster, onAgregarItem, onActualizarItem, onCondicionItem, onEliminarItem, onCrearProductoRapido, onImportarExcel }: ProductosSectionProps) {
+function ProductosSection({ state, dispatch, productosFiltrados, iiMaster, condicionMaster, onAgregarItem, onActualizarItem, onCondicionItem, onEliminarItem, onVencimientosItem, onCrearProductoRapido, onImportarExcel }: ProductosSectionProps) {
   const [itemRapido, setItemRapido] = useState({ nombre: '', codigo: '', costo: 0 })
   const [creandoItem, setCreandoItem] = useState(false)
   const buscadorRef = useRef<HTMLDivElement>(null)
@@ -1031,7 +1047,7 @@ function ProductosSection({ state, dispatch, productosFiltrados, iiMaster, condi
 
       {/* Lista de items */}
       {state.items.length > 0 ? (
-        <ItemsList items={state.items} onActualizarItem={onActualizarItem} onCondicionItem={onCondicionItem} onEliminarItem={onEliminarItem} iiMaster={iiMaster} condicionMaster={condicionMaster} />
+        <ItemsList items={state.items} onActualizarItem={onActualizarItem} onCondicionItem={onCondicionItem} onEliminarItem={onEliminarItem} onVencimientosItem={onVencimientosItem} iiMaster={iiMaster} condicionMaster={condicionMaster} />
       ) : (
         <div className="text-center py-8 text-gray-500">
           <Package className="w-12 h-12 mx-auto mb-2 opacity-50" />
@@ -1043,7 +1059,7 @@ function ProductosSection({ state, dispatch, productosFiltrados, iiMaster, condi
   )
 }
 
-function ItemsList({ items, onActualizarItem, onCondicionItem, onEliminarItem, iiMaster, condicionMaster }: ItemsListProps) {
+function ItemsList({ items, onActualizarItem, onCondicionItem, onEliminarItem, onVencimientosItem, iiMaster, condicionMaster }: ItemsListProps) {
   return (
     <div className="space-y-2">
       {/* Header solo en desktop */}
@@ -1065,6 +1081,7 @@ function ItemsList({ items, onActualizarItem, onCondicionItem, onEliminarItem, i
           onActualizarItem={onActualizarItem}
           onCondicionItem={onCondicionItem}
           onEliminarItem={onEliminarItem}
+          onVencimientosItem={onVencimientosItem}
           iiDelProducto={iiMaster[String(item.productoId)]}
           condicionDelProducto={condicionMaster[String(item.productoId)]}
         />
@@ -1088,7 +1105,7 @@ function difiereCondicion(item: CompraItemForm, condicionDelProducto?: string): 
   return claveCondicionLinea(item) !== condicionDelProducto
 }
 
-function ItemRow({ item, index, onActualizarItem, onCondicionItem, onEliminarItem, iiDelProducto, condicionDelProducto }: ItemRowProps) {
+function ItemRow({ item, index, onActualizarItem, onCondicionItem, onEliminarItem, onVencimientosItem, iiDelProducto, condicionDelProducto }: ItemRowProps) {
   const iiDifiere = difiereII(item, iiDelProducto)
   const condDifiere = difiereCondicion(item, condicionDelProducto)
   const selectCondicion = (extraClass = '') => (
@@ -1271,6 +1288,13 @@ function ItemRow({ item, index, onActualizarItem, onCondicionItem, onEliminarIte
           ⚠ La ficha dice {labelCondicionIva(condicionDelProducto!)}: el cambio aplica sólo a esta compra, el producto no se toca.
         </p>
       )}
+      {/* Al pie de la card y fuera de los dos layouts: así aparece UNA sola vez
+          en mobile y en desktop, en vez de duplicarse. */}
+      <VencimientosLineaCompra
+        cantidadLinea={item.cantidad}
+        vencimientos={item.vencimientos ?? []}
+        onChange={(v) => onVencimientosItem(index, v)}
+      />
     </div>
   )
 }

--- a/src/components/modals/ModalDetalleCompra.tsx
+++ b/src/components/modals/ModalDetalleCompra.tsx
@@ -1,4 +1,5 @@
-import React from 'react'
+import React, { useMemo } from 'react'
+import { formatearFechaVencimiento } from '../../utils/vencimientos'
 import { X, ShoppingCart, Package, Building2, Calendar, CreditCard, FileText, TrendingUp, Hash } from 'lucide-react'
 import { formatPrecio } from '../../utils/formatters'
 import type { CondicionIva, Producto, Proveedor, Usuario } from '../../types'
@@ -97,6 +98,8 @@ export interface ModalDetalleCompraProps {
   onAnular?: (compraId: string) => void;
   onNotaCredito?: (compra: any) => void;
   notasCredito?: NotaCreditoResumen[];
+  /** Lotes que cargo esta compra (migs 223/224). Los trae el container. */
+  lotes?: { producto_id: number; fecha_vencimiento: string; cantidad: number }[];
 }
 
 export default function ModalDetalleCompra({
@@ -104,8 +107,23 @@ export default function ModalDetalleCompra({
   onClose,
   onAnular,
   onNotaCredito,
-  notasCredito = []
+  notasCredito = [],
+  lotes = []
 }: ModalDetalleCompraProps): React.ReactElement | null {
+  // Los lotes son del PRODUCTO, no de la linea: dos lineas del mismo producto
+  // con la misma fecha son un solo lote (lo garantiza el UNIQUE de la mig 223).
+  // El useMemo va ANTES del early return: un hook detras de un `return null`
+  // seria una llamada condicional.
+  const vencimientosPorProducto = useMemo(() => {
+    const mapa = new Map<string, string[]>()
+    for (const lote of lotes) {
+      const clave = String(lote.producto_id)
+      const texto = `${formatearFechaVencimiento(lote.fecha_vencimiento)} (${lote.cantidad} u.)`
+      mapa.set(clave, [...(mapa.get(clave) ?? []), texto])
+    }
+    return mapa
+  }, [lotes])
+
   if (!compra) return null
 
   const estado = ESTADOS_COMPRA[compra.estado] || ESTADOS_COMPRA.pendiente
@@ -241,6 +259,12 @@ export default function ModalDetalleCompra({
                               por qué el total no es subtotal × 1,21. */}
                           {esFC && <span className="ml-2">· {etiquetaFiscalLinea(item)}</span>}
                         </p>
+                        {/* Vencimientos que cargo esta compra (migs 223/224). */}
+                        {vencimientosPorProducto.get(String(item.producto_id))?.length ? (
+                          <p className="text-xs text-indigo-700 dark:text-indigo-300 mt-0.5">
+                            Vence: {vencimientosPorProducto.get(String(item.producto_id))!.join(' · ')}
+                          </p>
+                        ) : null}
                       </td>
                       <td className="px-4 py-3 text-center text-gray-800 dark:text-white">
                         {item.cantidad}

--- a/src/components/modals/ModalEditarCompra.tsx
+++ b/src/components/modals/ModalEditarCompra.tsx
@@ -17,10 +17,12 @@
  * reciente del producto.
  */
 
-import { memo, useMemo, useState } from 'react'
+import { Fragment, memo, useEffect, useMemo, useRef, useState } from 'react'
 import { Loader2, Trash2, AlertCircle, Building2 } from 'lucide-react'
 import ModalBase from './ModalBase'
 import NumberInput from '../ui/NumberInput'
+import VencimientosLineaCompra from '../vencimientos/VencimientosLineaCompra'
+import type { VencimientoLinea } from './ModalCompra.reducer'
 import { formatPrecio } from '../../utils/formatters'
 import type { CompraCargoInput, CompraDBExtended, CondicionIva } from '../../types'
 import type { ActualizarCompraItemsInput } from '../../hooks/queries'
@@ -42,6 +44,12 @@ interface ItemEdit {
   porcentajeIva: number
   condicionIva: CondicionIva
   impuestosInternos: number
+  /**
+   * Vencimientos de la línea (migs 223/224). Se precargan de los lotes que esta
+   * compra ya tiene: `sincronizar_lotes_compra` recibe la FOTO completa, así que
+   * si no se precargaran, abrir el modal y guardar los borraría en silencio.
+   */
+  vencimientos: VencimientoLinea[]
   marcadoParaEliminar: boolean
 }
 
@@ -59,6 +67,16 @@ export interface ModalEditarCompraProps {
   canCambiarProveedor?: boolean
   /** Se dispara al pedir el cambio; el container cierra este modal y abre el de cambio. */
   onCambiarProveedor?: () => void
+  /**
+   * Los lotes que esta compra ya tiene cargados (migs 223/224). Los trae el
+   * container: este modal se testea renderizandolo pelado, sin providers, y una
+   * query adentro obligaria a los tests a mockearla.
+   *
+   * Sin esto, editar una compra le borraria los vencimientos en silencio:
+   * `sincronizar_lotes_compra` recibe la FOTO completa de los lotes de la
+   * factura, asi que abrir el modal y guardar mandaria una lista vacia.
+   */
+  lotesIniciales?: { producto_id: number; fecha_vencimiento: string; cantidad: number }[]
 }
 
 const ModalEditarCompra = memo(function ModalEditarCompra({
@@ -69,6 +87,7 @@ const ModalEditarCompra = memo(function ModalEditarCompra({
   guardando,
   canCambiarProveedor = false,
   onCambiarProveedor,
+  lotesIniciales,
 }: ModalEditarCompraProps) {
   const esZZ = compra.tipo_factura === 'ZZ'
   const otrosImpuestos = compra.otros_impuestos ?? 0
@@ -94,11 +113,38 @@ const ModalEditarCompra = memo(function ModalEditarCompra({
       porcentajeIva: esZZ ? 0 : (it.porcentaje_iva ?? it.producto?.porcentaje_iva ?? 21),
       condicionIva: esZZ ? 'gravado' : (it.condicion_iva ?? it.producto?.condicion_iva ?? 'gravado'),
       impuestosInternos: esZZ ? 0 : (it.impuestos_internos ?? it.producto?.impuestos_internos ?? 0),
+      // Arranca vacío y lo llena el efecto de abajo cuando llegan los lotes.
+      vencimientos: [],
       marcadoParaEliminar: false,
     })),
   )
 
   const [errorValidacion, setErrorValidacion] = useState<string | null>(null)
+
+  // --- Vencimientos (migs 223/224) ---
+  // Se precargan una sola vez, con un ref y no con una dependencia: los lotes
+  // llegan del container y cualquier movimiento de lote refresca esa query, así
+  // que sin el ref el efecto volvería a correr y pisaría lo que el usuario esté
+  // tipeando.
+  const vencimientosPrecargados = useRef(false)
+
+  useEffect(() => {
+    if (vencimientosPrecargados.current || !lotesIniciales) return
+    vencimientosPrecargados.current = true
+    if (lotesIniciales.length === 0) return
+
+    setItems((prev) =>
+      prev.map((it) => ({
+        ...it,
+        vencimientos: lotesIniciales
+          .filter((l) => String(l.producto_id) === String(it.productoId))
+          // `cantidad` y no `cantidad_restante`: lo que la compra cargó, no lo
+          // que queda. El contador lo lleva la base y se preserva del lado del
+          // servidor cuando la clave (producto, fecha) sobrevive a la edición.
+          .map((l) => ({ fecha: l.fecha_vencimiento, cantidad: l.cantidad })),
+      })),
+    )
+  }, [lotesIniciales])
 
   // Items que efectivamente se persisten (los no eliminados).
   const itemsActivos = useMemo(() => items.filter((i) => !i.marcadoParaEliminar), [items])
@@ -302,6 +348,7 @@ const ModalEditarCompra = memo(function ModalEditarCompra({
         porcentajeIva: esZZ ? 0 : it.porcentajeIva,
         condicionIva: esZZ ? 'gravado' as const : it.condicionIva,
         impuestosInternos: it.impuestosInternos,
+        vencimientos: it.vencimientos,
       }
     })
 
@@ -478,6 +525,13 @@ const ModalEditarCompra = memo(function ModalEditarCompra({
                     {formatPrecio(subtotalItem)}
                   </span>
                 </div>
+                {!it.marcadoParaEliminar && (
+                  <VencimientosLineaCompra
+                    cantidadLinea={it.cantidad}
+                    vencimientos={it.vencimientos}
+                    onChange={(v) => updateItem(it.productoId, 'vencimientos', v)}
+                  />
+                )}
               </div>
             )
           })}
@@ -505,7 +559,8 @@ const ModalEditarCompra = memo(function ModalEditarCompra({
                   ? 'opacity-40 line-through'
                   : ''
                 return (
-                  <tr key={it.productoId} className={`border-b dark:border-gray-700 ${rowClass}`}>
+                  <Fragment key={it.productoId}>
+                  <tr className={`border-b dark:border-gray-700 ${rowClass}`}>
                     <td className="py-2 pr-2 dark:text-gray-200">{it.nombre}</td>
                     <td className="py-2 px-2">
                       <NumberInput
@@ -557,6 +612,20 @@ const ModalEditarCompra = memo(function ModalEditarCompra({
                       </button>
                     </td>
                   </tr>
+                  {/* Los vencimientos no entran en la grilla de columnas: van
+                      en su propia fila debajo de la línea, a todo el ancho. */}
+                  {!it.marcadoParaEliminar && (
+                    <tr className="border-b dark:border-gray-700">
+                      <td colSpan={esZZ ? 6 : 7} className="pb-2">
+                        <VencimientosLineaCompra
+                          cantidadLinea={it.cantidad}
+                          vencimientos={it.vencimientos}
+                          onChange={(v) => updateItem(it.productoId, 'vencimientos', v)}
+                        />
+                      </td>
+                    </tr>
+                  )}
+                  </Fragment>
                 )
               })}
             </tbody>

--- a/src/components/modals/ModalProducto.stock.test.tsx
+++ b/src/components/modals/ModalProducto.stock.test.tsx
@@ -30,6 +30,12 @@ vi.mock('../productos/ProductoCondicionesMayoristas', () => ({
   default: () => null,
 }))
 
+// Ídem: el bloque de vencimientos (migs 223/224) arrastra la query de lotes,
+// la política comercial y la sesión. Acá se prueba el stock, no los lotes.
+vi.mock('../productos/ProductoLotes', () => ({
+  default: () => null,
+}))
+
 const COCA: ProductoDB = {
   id: '340',
   nombre: 'COCA COLA X 3LTS X 6UND',

--- a/src/components/modals/ModalProducto.tsx
+++ b/src/components/modals/ModalProducto.tsx
@@ -21,6 +21,9 @@ import { lazyWithReload } from '../../utils/lazyWithReload';
 // Lazy: solo hace falta al editar, y arrastra la query de grupos de precio.
 const ProductoCondicionesMayoristas = lazyWithReload(() => import('../productos/ProductoCondicionesMayoristas'));
 
+// Lazy por lo mismo: solo hace falta al editar, y arrastra la query de lotes.
+const ProductoLotes = lazyWithReload(() => import('../productos/ProductoLotes'));
+
 // =============================================================================
 // TYPES
 // =============================================================================
@@ -847,6 +850,19 @@ const ModalProducto = memo(function ModalProducto({ producto, categorias, provee
         {/* porcentajeIva con `?? 21`, no `|| 21`: con la alícuota en 0 (exento /
             no gravado) el margen mayorista se calculaba dividiendo el precio por
             1,21 y salía ~21 puntos peor que el real. */}
+        {/* Vencimientos por lote (migs 223/224). Solo en edición: un producto
+            que todavía no existe no tiene stock ni lotes. El stock sale del
+            form y no del producto, así la "bolsa sin vencimiento" se mueve
+            mientras el admin corrige el stock arriba. */}
+        {producto?.id && (
+          <Suspense fallback={null}>
+            <ProductoLotes
+              productoId={Number(producto.id)}
+              stock={Number(form.stock) || 0}
+            />
+          </Suspense>
+        )}
+
         {producto?.id && (
           <Suspense fallback={null}>
             <ProductoCondicionesMayoristas

--- a/src/components/productos/ProductoLotes.tsx
+++ b/src/components/productos/ProductoLotes.tsx
@@ -1,0 +1,276 @@
+/**
+ * ProductoLotes
+ *
+ * Sección de la ficha que responde "¿qué tengo de este producto y cuándo se me
+ * vence?".
+ *
+ * LA BOLSA "SIN VENCIMIENTO" SE MUESTRA A PROPÓSITO
+ * -------------------------------------------------
+ * No es un detalle técnico que se pueda esconder: es la parte del stock de la
+ * que no se sabe cuándo vence, y crece cada vez que entra mercadería sin fecha
+ * cargada. Mostrarla es lo que hace que se note y se corrija — si la ocultáramos
+ * la pantalla mostraría dos lotes prolijos y daría la impresión de que el
+ * producto está controlado cuando la mitad del stock no lo está.
+ *
+ * De ahí sale también el botón "Cargar vencimiento": es el camino del stock que
+ * ya existía cuando se prendió la feature. No hay inventario inicial que hacer,
+ * se etiqueta producto por producto cuando uno pasa al lado de la caja.
+ *
+ * Vive aparte de ModalProducto a propósito: ese archivo ya tiene 874 líneas.
+ */
+import { useMemo, useState } from 'react'
+import { CalendarClock, Check, Loader2, Package, Pencil, Plus, X } from 'lucide-react'
+import {
+  useLotesProductoQuery,
+  useCrearLoteManualMutation,
+  useAjustarLoteMutation,
+} from '../../hooks/queries/useLotesQuery'
+import { usePoliticasComercialesQuery } from '../../hooks/queries/usePoliticasComercialesQuery'
+import { useAuth } from '../../hooks/supabase/useAuth'
+import { useNotification } from '../../contexts/NotificationContext'
+import { bolsaSinVencimiento, formatearFechaVencimiento } from '../../utils/vencimientos'
+import BadgeVencimiento from '../vencimientos/BadgeVencimiento'
+
+export interface ProductoLotesProps {
+  /** Producto en edición. Sin id (alta nueva) la sección no se muestra. */
+  productoId: number
+  /**
+   * Stock que la ficha tiene en pantalla. Se usa para la bolsa, así el número
+   * se mueve mientras el admin corrige el stock en el form de arriba, sin
+   * esperar a que la base responda.
+   */
+  stock: number
+}
+
+export default function ProductoLotes({ productoId, stock }: ProductoLotesProps) {
+  const notify = useNotification()
+  const { isAdminOrEncargado, perfil } = useAuth()
+  const { politicas } = usePoliticasComercialesQuery()
+  const { data: lotes = [], isLoading } = useLotesProductoQuery(productoId)
+
+  const crearLote = useCrearLoteManualMutation()
+  const ajustarLote = useAjustarLoteMutation()
+
+  // Etiquetar es una tarea de depósito: es quien camina el galpón y ve la caja.
+  // Corregir un contador es administración. La RPC vuelve a chequear las dos
+  // cosas; esto es solo para no ofrecer un botón que va a fallar.
+  const puedeEtiquetar = isAdminOrEncargado || perfil?.rol === 'deposito'
+  const puedeCorregir = isAdminOrEncargado
+
+  const [cargando, setCargando] = useState(false)
+  const [fechaNueva, setFechaNueva] = useState('')
+  const [cantidadNueva, setCantidadNueva] = useState('')
+  /** Id del lote con el contador en edición. */
+  const [editando, setEditando] = useState<number | null>(null)
+  const [restanteEditado, setRestanteEditado] = useState('')
+
+  const asignado = useMemo(
+    () => lotes.reduce((acc, l) => acc + (Number(l.cantidad_restante) || 0), 0),
+    [lotes],
+  )
+  const bolsa = bolsaSinVencimiento(stock, asignado)
+
+  async function guardarLoteNuevo() {
+    const cantidad = Number(cantidadNueva)
+    if (!fechaNueva) {
+      notify.error('Falta la fecha de vencimiento')
+      return
+    }
+    if (!Number.isFinite(cantidad) || cantidad <= 0) {
+      notify.error('La cantidad tiene que ser mayor a 0')
+      return
+    }
+    if (cantidad > bolsa) {
+      notify.error(`Solo hay ${bolsa} u. sin vencimiento cargado`)
+      return
+    }
+    try {
+      await crearLote.mutateAsync({ productoId, fecha: fechaNueva, cantidad })
+      notify.success(`${cantidad} u. etiquetadas con vencimiento ${formatearFechaVencimiento(fechaNueva)}`)
+      setCargando(false)
+      setFechaNueva('')
+      setCantidadNueva('')
+    } catch (e) {
+      notify.error(e instanceof Error ? e.message : 'No se pudo cargar el vencimiento')
+    }
+  }
+
+  async function guardarAjuste(loteId: number) {
+    const restante = Number(restanteEditado)
+    if (!Number.isFinite(restante) || restante < 0) {
+      notify.error('La cantidad no puede ser negativa')
+      return
+    }
+    try {
+      await ajustarLote.mutateAsync({ loteId, cantidadRestante: restante })
+      notify.success('Contador corregido')
+      setEditando(null)
+    } catch (e) {
+      notify.error(e instanceof Error ? e.message : 'No se pudo corregir el lote')
+    }
+  }
+
+  return (
+    <section className="border-t dark:border-gray-700 pt-4">
+      <div className="flex items-center justify-between gap-2 mb-2">
+        <h3 className="text-sm font-medium flex items-center gap-1.5 dark:text-white">
+          <CalendarClock className="w-4 h-4 text-indigo-600" aria-hidden="true" />
+          Vencimientos
+        </h3>
+        {puedeEtiquetar && !cargando && bolsa > 0 && (
+          <button
+            type="button"
+            onClick={() => setCargando(true)}
+            className="inline-flex items-center gap-1 text-sm text-blue-600 hover:text-blue-700"
+          >
+            <Plus className="w-4 h-4" aria-hidden="true" />
+            Cargar vencimiento
+          </button>
+        )}
+      </div>
+
+      {cargando && (
+        <div className="mb-3 flex flex-wrap items-end gap-2 p-2 rounded bg-stone-50 dark:bg-gray-800">
+          <div>
+            {/* Sin `min`: una fecha pasada es un dato legítimo, no un error de
+                tipeo. Etiquetar la caja vencida que apareció en el fondo del
+                depósito es justo para lo que existe este botón, y el badge la
+                pinta en rojo sola. */}
+            <label htmlFor="lote-fecha" className="block text-xs text-stone-500 dark:text-gray-400 mb-0.5">
+              Vence el
+            </label>
+            <input
+              id="lote-fecha"
+              type="date"
+              value={fechaNueva}
+              onChange={e => setFechaNueva(e.target.value)}
+              className="px-2 py-1 border rounded text-sm dark:bg-gray-800 dark:border-gray-600 dark:text-white"
+            />
+          </div>
+          <div>
+            <label htmlFor="lote-cantidad" className="block text-xs text-stone-500 dark:text-gray-400 mb-0.5">
+              Unidades (hay {bolsa})
+            </label>
+            <input
+              id="lote-cantidad"
+              type="number"
+              min={1}
+              max={bolsa}
+              value={cantidadNueva}
+              onChange={e => setCantidadNueva(e.target.value)}
+              className="w-24 px-2 py-1 border rounded text-sm dark:bg-gray-800 dark:border-gray-600 dark:text-white"
+            />
+          </div>
+          <button
+            type="button"
+            onClick={() => void guardarLoteNuevo()}
+            disabled={crearLote.isPending}
+            className="px-3 py-1 bg-blue-600 text-white rounded text-sm hover:bg-blue-700 disabled:opacity-50 inline-flex items-center gap-1"
+          >
+            {crearLote.isPending && <Loader2 className="w-3 h-3 animate-spin" aria-hidden="true" />}
+            Guardar
+          </button>
+          <button
+            type="button"
+            onClick={() => { setCargando(false); setFechaNueva(''); setCantidadNueva('') }}
+            className="text-xs text-stone-500 hover:text-stone-700 dark:text-gray-400"
+          >
+            Cancelar
+          </button>
+        </div>
+      )}
+
+      {isLoading ? (
+        <p className="flex items-center gap-2 text-xs text-stone-500 dark:text-gray-400">
+          <Loader2 className="w-3 h-3 animate-spin" aria-hidden="true" />
+          Cargando lotes…
+        </p>
+      ) : lotes.length === 0 ? (
+        <p className="text-xs text-stone-500 dark:text-gray-400">
+          Sin vencimientos cargados. Se cargan al registrar la factura de compra, o acá a mano.
+        </p>
+      ) : (
+        <ul className="space-y-1">
+          {lotes.map(lote => (
+            <li
+              key={lote.id}
+              className="flex flex-wrap items-center gap-2 text-sm py-1 border-b border-stone-100 dark:border-gray-700 last:border-0"
+            >
+              <span className="font-mono text-xs text-stone-600 dark:text-gray-300 w-20">
+                {formatearFechaVencimiento(lote.fecha_vencimiento)}
+              </span>
+              <BadgeVencimiento
+                fecha={lote.fecha_vencimiento}
+                diasAlerta={politicas.diasAlertaVencimiento}
+                diasCritico={politicas.diasCriticoVencimiento}
+              />
+              {editando === lote.id ? (
+                <span className="flex items-center gap-1">
+                  <input
+                    type="number"
+                    min={0}
+                    max={lote.cantidad}
+                    value={restanteEditado}
+                    onChange={e => setRestanteEditado(e.target.value)}
+                    aria-label="Unidades que quedan"
+                    className="w-20 px-2 py-0.5 border rounded text-sm dark:bg-gray-800 dark:border-gray-600 dark:text-white"
+                  />
+                  <button
+                    type="button"
+                    onClick={() => void guardarAjuste(lote.id)}
+                    disabled={ajustarLote.isPending}
+                    aria-label="Guardar corrección"
+                    className="p-1 text-green-600 hover:text-green-700 disabled:opacity-50"
+                  >
+                    <Check className="w-4 h-4" aria-hidden="true" />
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => setEditando(null)}
+                    aria-label="Cancelar corrección"
+                    className="p-1 text-stone-400 hover:text-stone-600"
+                  >
+                    <X className="w-4 h-4" aria-hidden="true" />
+                  </button>
+                </span>
+              ) : (
+                <span className="ml-auto flex items-center gap-2">
+                  <span className="dark:text-white">
+                    <strong>{lote.cantidad_restante}</strong>
+                    <span className="text-stone-400 dark:text-gray-500"> / {lote.cantidad} u.</span>
+                  </span>
+                  {lote.origen === 'manual' && (
+                    <span className="text-[10px] uppercase tracking-wide text-stone-400 dark:text-gray-500">
+                      a mano
+                    </span>
+                  )}
+                  {puedeCorregir && (
+                    <button
+                      type="button"
+                      onClick={() => { setEditando(lote.id); setRestanteEditado(String(lote.cantidad_restante)) }}
+                      aria-label={`Corregir el contador del lote que vence el ${formatearFechaVencimiento(lote.fecha_vencimiento)}`}
+                      className="p-1 text-stone-400 hover:text-blue-600"
+                    >
+                      <Pencil className="w-3.5 h-3.5" aria-hidden="true" />
+                    </button>
+                  )}
+                </span>
+              )}
+            </li>
+          ))}
+        </ul>
+      )}
+
+      {/* La bolsa. Se muestra siempre, incluso en 0: que diga "0" es la
+          confirmación de que todo el stock tiene fecha, y esa es justamente la
+          información que uno viene a buscar. */}
+      <p className="mt-2 flex items-center gap-1.5 text-xs text-stone-500 dark:text-gray-400">
+        <Package className="w-3.5 h-3.5" aria-hidden="true" />
+        Sin vencimiento cargado: <strong className="text-stone-700 dark:text-gray-200">{bolsa} u.</strong>
+        <span className="text-stone-400 dark:text-gray-500">
+          (de {stock} en stock). Sale antes que cualquier lote con fecha.
+        </span>
+      </p>
+    </section>
+  )
+}

--- a/src/components/vencimientos/BadgeVencimiento.tsx
+++ b/src/components/vencimientos/BadgeVencimiento.tsx
@@ -1,0 +1,55 @@
+/**
+ * El semáforo de un lote, en una etiqueta.
+ *
+ * Vive aparte porque lo usan dos pantallas que no se conocen entre sí: el
+ * bloque de la ficha del producto y el panel de vencimientos. Si el color de
+ * "crítico" cambia, tiene que cambiar en los dos lugares a la vez.
+ *
+ * El estado se calcula con `estadoVencimiento` (src/utils/vencimientos.ts), que
+ * es donde vive la regla. Acá solo se elige cómo se pinta.
+ */
+import { AlertTriangle, Clock, XCircle } from 'lucide-react'
+import { estadoVencimiento, textoVencimiento } from '../../utils/vencimientos'
+import type { EstadoVencimiento } from '../../utils/vencimientos'
+
+const ESTILOS: Record<EstadoVencimiento, { clase: string; Icono: typeof Clock | null }> = {
+  vencido: {
+    clase: 'bg-red-100 text-red-800 dark:bg-red-900/40 dark:text-red-200',
+    Icono: XCircle,
+  },
+  critico: {
+    clase: 'bg-orange-100 text-orange-800 dark:bg-orange-900/40 dark:text-orange-200',
+    Icono: AlertTriangle,
+  },
+  alerta: {
+    clase: 'bg-amber-100 text-amber-800 dark:bg-amber-900/40 dark:text-amber-200',
+    Icono: Clock,
+  },
+  ok: {
+    clase: 'bg-stone-100 text-stone-600 dark:bg-gray-700 dark:text-gray-300',
+    Icono: null,
+  },
+}
+
+export interface BadgeVencimientoProps {
+  /** 'YYYY-MM-DD', tal cual viene de la base. */
+  fecha: string
+  diasAlerta: number
+  diasCritico: number
+  /** Para tests: fija el "hoy" en vez de leer el reloj. */
+  hoy?: string
+}
+
+export default function BadgeVencimiento({ fecha, diasAlerta, diasCritico, hoy }: BadgeVencimientoProps) {
+  const estado = estadoVencimiento(fecha, diasAlerta, diasCritico, hoy)
+  const { clase, Icono } = ESTILOS[estado]
+
+  return (
+    <span
+      className={`inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium whitespace-nowrap ${clase}`}
+    >
+      {Icono && <Icono className="w-3 h-3" aria-hidden="true" />}
+      {textoVencimiento(fecha, hoy)}
+    </span>
+  )
+}

--- a/src/components/vencimientos/VencimientosLineaCompra.tsx
+++ b/src/components/vencimientos/VencimientosLineaCompra.tsx
@@ -1,0 +1,144 @@
+/**
+ * Los vencimientos de UNA línea de factura de compra (migs 223/224).
+ *
+ * POR QUÉ ES UNA LISTA Y NO UN CAMPO DE FECHA
+ * -------------------------------------------
+ * Una misma línea puede traer dos lotes: llegan 20 cajas, 12 vencen en marzo y
+ * 8 en mayo. Resolverlo cargando dos renglones del mismo producto obligaría a
+ * partir también el costo, la bonificación y el II, que son de la línea y no
+ * del lote — y el prorrateo de cargos de la mig 192 reparte por línea, así que
+ * partirla cambiaría los costos.
+ *
+ * CARGAR MENOS QUE LA CANTIDAD DE LA LÍNEA ES LEGAL
+ * -------------------------------------------------
+ * Lo que no se etiqueta queda en la bolsa "sin vencimiento" del producto. Es un
+ * estado soportado y visible en la ficha, no un error. Lo que no se permite es
+ * lo contrario: etiquetar más unidades de las que entraron.
+ *
+ * Lo usan el modal de alta y el de edición de compra, que no se conocen entre
+ * sí pero tienen que cargar esto igual.
+ *
+ * La fecha no tiene mínimo a propósito: un proveedor que manda mercadería con
+ * el vencimiento encima es exactamente lo que hay que poder registrar, y el
+ * panel se encarga de pintarlo en rojo.
+ */
+import { useState } from 'react'
+import { CalendarClock, Plus, X } from 'lucide-react'
+import type { VencimientoLinea } from '../modals/ModalCompra.reducer'
+import { formatearFechaVencimiento } from '../../utils/vencimientos'
+
+export interface VencimientosLineaCompraProps {
+  /** Unidades de la línea: el techo de lo que se puede etiquetar. */
+  cantidadLinea: number
+  vencimientos: VencimientoLinea[]
+  onChange: (vencimientos: VencimientoLinea[]) => void
+}
+
+export default function VencimientosLineaCompra({
+  cantidadLinea,
+  vencimientos,
+  onChange,
+}: VencimientosLineaCompraProps) {
+  const [abierto, setAbierto] = useState(false)
+
+  const asignado = vencimientos.reduce((acc, v) => acc + (Number(v.cantidad) || 0), 0)
+  const libre = Math.max(0, (Number(cantidadLinea) || 0) - asignado)
+  const excede = asignado > (Number(cantidadLinea) || 0)
+
+  function actualizar(i: number, cambios: Partial<VencimientoLinea>) {
+    onChange(vencimientos.map((v, j) => (j === i ? { ...v, ...cambios } : v)))
+  }
+
+  function agregar() {
+    // Arranca con lo que queda libre: en el caso más común —un solo
+    // vencimiento para toda la línea— no hay que tipear la cantidad.
+    onChange([...vencimientos, { fecha: '', cantidad: libre > 0 ? libre : 1 }])
+    setAbierto(true)
+  }
+
+  function quitar(i: number) {
+    onChange(vencimientos.filter((_, j) => j !== i))
+  }
+
+  const resumen =
+    vencimientos.length === 0
+      ? 'Sin vencimiento'
+      : vencimientos.length === 1 && vencimientos[0].fecha
+        ? `Vence ${formatearFechaVencimiento(vencimientos[0].fecha)}`
+        : `${vencimientos.length} vencimientos`
+
+  return (
+    <div className="mt-2 pt-2 border-t border-dashed dark:border-gray-600">
+      <div className="flex flex-wrap items-center gap-2">
+        <button
+          type="button"
+          onClick={() => (vencimientos.length === 0 ? agregar() : setAbierto(!abierto))}
+          className={`inline-flex items-center gap-1 text-xs px-2 py-0.5 rounded-full transition-colors ${
+            excede
+              ? 'bg-red-100 text-red-800 dark:bg-red-900/40 dark:text-red-200'
+              : vencimientos.length > 0
+                ? 'bg-indigo-100 text-indigo-800 dark:bg-indigo-900/40 dark:text-indigo-200'
+                : 'bg-stone-100 text-stone-600 hover:bg-stone-200 dark:bg-gray-700 dark:text-gray-300'
+          }`}
+        >
+          <CalendarClock className="w-3 h-3" aria-hidden="true" />
+          {resumen}
+        </button>
+
+        {vencimientos.length > 0 && !excede && libre > 0 && (
+          <span className="text-xs text-stone-500 dark:text-gray-400">
+            {libre} u. sin vencimiento
+          </span>
+        )}
+        {excede && (
+          <span className="text-xs text-red-700 dark:text-red-300">
+            Etiquetaste {asignado} u. y la línea tiene {cantidadLinea}
+          </span>
+        )}
+      </div>
+
+      {abierto && vencimientos.length > 0 && (
+        <div className="mt-2 space-y-1">
+          {vencimientos.map((v, i) => (
+            <div key={i} className="flex flex-wrap items-center gap-2">
+              <input
+                type="date"
+                value={v.fecha}
+                onChange={e => actualizar(i, { fecha: e.target.value })}
+                aria-label={`Fecha de vencimiento ${i + 1}`}
+                className="px-2 py-1 border rounded text-sm dark:bg-gray-700 dark:border-gray-600 dark:text-white"
+              />
+              <input
+                type="number"
+                min={1}
+                value={v.cantidad}
+                onChange={e => actualizar(i, { cantidad: Number(e.target.value) })}
+                aria-label={`Unidades del vencimiento ${i + 1}`}
+                className="w-20 px-2 py-1 border rounded text-sm dark:bg-gray-700 dark:border-gray-600 dark:text-white"
+              />
+              <span className="text-xs text-stone-500 dark:text-gray-400">u.</span>
+              <button
+                type="button"
+                onClick={() => quitar(i)}
+                aria-label={`Quitar el vencimiento ${i + 1}`}
+                className="p-1 text-stone-400 hover:text-red-600"
+              >
+                <X className="w-3.5 h-3.5" aria-hidden="true" />
+              </button>
+            </div>
+          ))}
+          {libre > 0 && (
+            <button
+              type="button"
+              onClick={agregar}
+              className="inline-flex items-center gap-1 text-xs text-blue-600 hover:text-blue-700"
+            >
+              <Plus className="w-3 h-3" aria-hidden="true" />
+              Otro vencimiento ({libre} u. libres)
+            </button>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/components/vistas/VistaConfiguracion.tsx
+++ b/src/components/vistas/VistaConfiguracion.tsx
@@ -7,7 +7,7 @@
  * un campo acá.
  */
 import { useState, useEffect, type FormEvent } from 'react';
-import { Loader2, Settings, AlertTriangle, Percent } from 'lucide-react';
+import { Loader2, Settings, AlertTriangle, Percent, CalendarClock } from 'lucide-react';
 import { formatCurrency } from '../../utils/formatters';
 
 export interface VistaConfiguracionProps {
@@ -27,7 +27,154 @@ export interface VistaConfiguracionProps {
   comisionPctOtros: number;
   guardandoComisiones: boolean;
   onGuardarComisiones: (pctPreventista: number, pctOtros: number) => void;
+  /** Dias de anticipacion del aviso amarillo de vencimiento (mig 223). */
+  diasAlertaVencimiento: number;
+  /** Dias de anticipacion del aviso rojo. Siempre <= el amarillo. */
+  diasCriticoVencimiento: number;
+  guardandoAlertas: boolean;
+  onGuardarAlertas: (diasAlerta: number, diasCritico: number) => void;
 }
+
+/**
+ * Los dos umbrales del semaforo de vencimientos.
+ *
+ * Van juntos y en un solo formulario porque la base los valida juntos: el rojo
+ * no puede caer despues del amarillo (CHECK de la mig 223). Mandarlos por
+ * separado dejaria un estado intermedio que el servidor rechaza.
+ *
+ * Que los dos den 0 es una configuracion valida, no un formulario vacio:
+ * significa "avisame solo lo que ya se vencio".
+ */
+function FormAlertasVencimiento({
+  diasAlerta,
+  diasCritico,
+  guardando,
+  onGuardar,
+}: {
+  diasAlerta: number;
+  diasCritico: number;
+  guardando: boolean;
+  onGuardar: (diasAlerta: number, diasCritico: number) => void;
+}) {
+  const [amarillo, setAmarillo] = useState(String(diasAlerta));
+  const [rojo, setRojo] = useState(String(diasCritico));
+  const [error, setError] = useState<string | null>(null);
+
+  // El valor del servidor llega despues del primer render y cambia al cambiar
+  // de sucursal.
+  useEffect(() => { setAmarillo(String(diasAlerta)); }, [diasAlerta]);
+  useEffect(() => { setRojo(String(diasCritico)); }, [diasCritico]);
+
+  const nAmarillo = Number(amarillo);
+  const nRojo = Number(rojo);
+  const validoAmarillo = Number.isInteger(nAmarillo) && nAmarillo >= 0 && nAmarillo <= 3650;
+  const validoRojo = Number.isInteger(nRojo) && nRojo >= 0 && nRojo <= 3650;
+  const ordenOk = validoAmarillo && validoRojo && nRojo <= nAmarillo;
+  const valido = validoAmarillo && validoRojo && ordenOk;
+  const cambio = valido && (nAmarillo !== diasAlerta || nRojo !== diasCritico);
+
+  function handleSubmit(e: FormEvent) {
+    e.preventDefault();
+    if (!validoAmarillo || !validoRojo) {
+      setError('Ingresa una cantidad de dias entre 0 y 3650.');
+      return;
+    }
+    if (!ordenOk) {
+      setError('El aviso rojo no puede ser antes que el amarillo.');
+      return;
+    }
+    setError(null);
+    onGuardar(nAmarillo, nRojo);
+  }
+
+  return (
+    <form
+      onSubmit={handleSubmit}
+      className="bg-white dark:bg-gray-800 border border-stone-200/80 dark:border-gray-700 rounded-xl p-5 space-y-4 shadow-warm"
+    >
+      <div>
+        <h2 className="text-sm font-semibold text-stone-900 dark:text-white flex items-center gap-2">
+          <CalendarClock className="w-4 h-4 text-stone-500" aria-hidden="true" />
+          Aviso de vencimientos
+        </h2>
+        <p className="text-xs text-stone-500 dark:text-stone-400 mt-1">
+          Con cuanta anticipacion se marca un lote en <strong>Vencimientos</strong> y en la
+          ficha del producto. El amarillo es &ldquo;ojo con esto, empujalo&rdquo;; el rojo es
+          &ldquo;hay que liquidarlo ya&rdquo;.
+        </p>
+        <p className="text-xs text-stone-500 dark:text-stone-400 mt-2">
+          Los dos en 0 avisan solo lo que ya se vencio. Un lote vencido nunca bloquea la
+          venta: se marca, y vos decidis.
+        </p>
+      </div>
+
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+        <div>
+          <label htmlFor="dias-alerta" className="block text-sm font-medium text-stone-900 dark:text-white">
+            Amarillo
+          </label>
+          <div className="mt-2 flex items-center gap-2">
+            <input
+              id="dias-alerta"
+              type="number"
+              min={0}
+              max={3650}
+              step="1"
+              inputMode="numeric"
+              value={amarillo}
+              onChange={(e) => { setAmarillo(e.target.value); setError(null); }}
+              aria-invalid={!validoAmarillo}
+              className="w-28 px-3 py-2 rounded-lg border border-stone-300 dark:border-gray-600 dark:bg-gray-900 dark:text-white focus:ring-2 focus:ring-amber-500 focus:border-amber-500"
+            />
+            <span className="text-stone-500 dark:text-stone-400">dias antes</span>
+          </div>
+        </div>
+
+        <div>
+          <label htmlFor="dias-critico" className="block text-sm font-medium text-stone-900 dark:text-white">
+            Rojo
+          </label>
+          <div className="mt-2 flex items-center gap-2">
+            <input
+              id="dias-critico"
+              type="number"
+              min={0}
+              max={3650}
+              step="1"
+              inputMode="numeric"
+              value={rojo}
+              onChange={(e) => { setRojo(e.target.value); setError(null); }}
+              aria-invalid={!validoRojo || !ordenOk}
+              className="w-28 px-3 py-2 rounded-lg border border-stone-300 dark:border-gray-600 dark:bg-gray-900 dark:text-white focus:ring-2 focus:ring-amber-500 focus:border-amber-500"
+            />
+            <span className="text-stone-500 dark:text-stone-400">dias antes</span>
+          </div>
+        </div>
+      </div>
+
+      {error && (
+        <p role="alert" className="text-rose-600 text-xs">{error}</p>
+      )}
+
+      <div className="flex items-center gap-3">
+        <button
+          type="submit"
+          disabled={guardando || !cambio}
+          className="px-4 py-2 rounded-lg bg-amber-600 text-white font-semibold text-sm hover:bg-amber-700 disabled:bg-stone-300 dark:disabled:bg-gray-600 disabled:cursor-not-allowed flex items-center gap-2"
+        >
+          {guardando && <Loader2 className="w-4 h-4 animate-spin" aria-hidden="true" />}
+          Guardar avisos
+        </button>
+        {!cambio && valido && (
+          <span className="text-xs text-stone-500 dark:text-stone-400">
+            Vigente: amarillo a {diasAlerta} dias / rojo a {diasCritico}
+          </span>
+        )}
+      </div>
+    </form>
+  );
+}
+
 
 /**
  * Los dos % de comisión por defecto.
@@ -174,6 +321,10 @@ export default function VistaConfiguracion({
   comisionPctOtros,
   guardandoComisiones,
   onGuardarComisiones,
+  diasAlertaVencimiento,
+  diasCriticoVencimiento,
+  guardandoAlertas,
+  onGuardarAlertas,
 }: VistaConfiguracionProps) {
   const [valor, setValor] = useState(String(montoMinimoActual ?? 0));
   const [error, setError] = useState<string | null>(null);
@@ -309,6 +460,13 @@ export default function VistaConfiguracion({
         pctOtros={comisionPctOtros}
         guardando={guardandoComisiones}
         onGuardar={onGuardarComisiones}
+      />
+
+      <FormAlertasVencimiento
+        diasAlerta={diasAlertaVencimiento}
+        diasCritico={diasCriticoVencimiento}
+        guardando={guardandoAlertas}
+        onGuardar={onGuardarAlertas}
       />
     </div>
   );

--- a/src/components/vistas/VistaVencimientos.tsx
+++ b/src/components/vistas/VistaVencimientos.tsx
@@ -1,0 +1,279 @@
+/**
+ * VistaVencimientos
+ *
+ * El panel donde se trabaja lo que está por vencer (migs 223/224/225).
+ *
+ * ES UNA PANTALLA OPERATIVA, NO UN REPORTE
+ * ----------------------------------------
+ * Por eso vive en el menú y no como una pestaña de Reportes: acá no se viene a
+ * mirar un número, se viene a decidir qué se liquida, qué se bonifica y qué se
+ * da de baja. La acción está en la misma fila que el dato.
+ *
+ * LO VENCIDO NO BLOQUEA NADA
+ * --------------------------
+ * Un lote vencido se pinta en rojo y aparece primero, pero el producto se sigue
+ * pudiendo vender. Es una decisión de negocio: una fecha mal tipeada no puede
+ * frenar la operación de una distribuidora, y la corrección tiene su camino
+ * propio en la ficha del producto.
+ *
+ * La baja va por `dar_de_baja_lote`, que escribe la merma con motivo
+ * 'vencimiento' y recién después toca el stock. El costo lo congela solo el
+ * trigger de la mig 119, así que la pérdida queda valorizada sin que esta
+ * pantalla tenga que saber nada de costos.
+ */
+import { useMemo, useState } from 'react'
+import { AlertTriangle, CalendarClock, Check, Loader2, PackageX, RefreshCw, X } from 'lucide-react'
+import type { LoteReporte } from '../../hooks/queries/useLotesQuery'
+import { estadoVencimiento, formatearFechaVencimiento } from '../../utils/vencimientos'
+import type { EstadoVencimiento } from '../../utils/vencimientos'
+import BadgeVencimiento from '../vencimientos/BadgeVencimiento'
+
+type Filtro = 'todos' | 'vencido' | 'critico' | 'alerta'
+
+const FILTROS: { clave: Filtro; label: string }[] = [
+  { clave: 'todos', label: 'Todos' },
+  { clave: 'vencido', label: 'Vencidos' },
+  { clave: 'critico', label: 'Urgentes' },
+  { clave: 'alerta', label: 'Por vencer' },
+]
+
+export interface VistaVencimientosProps {
+  lotes: LoteReporte[]
+  cargando: boolean
+  refrescando: boolean
+  diasAlerta: number
+  diasCritico: number
+  puedeDarDeBaja: boolean
+  darDeBajaPendiente: boolean
+  onRefrescar: () => void
+  onDarDeBaja: (loteId: number, cantidad: number) => Promise<void>
+  nombreSucursal?: string | null
+}
+
+export default function VistaVencimientos({
+  lotes,
+  cargando,
+  refrescando,
+  diasAlerta,
+  diasCritico,
+  puedeDarDeBaja,
+  darDeBajaPendiente,
+  onRefrescar,
+  onDarDeBaja,
+  nombreSucursal,
+}: VistaVencimientosProps) {
+  const [filtro, setFiltro] = useState<Filtro>('todos')
+  /** Lote con el formulario de baja abierto. */
+  const [dandoDeBaja, setDandoDeBaja] = useState<number | null>(null)
+  const [cantidadBaja, setCantidadBaja] = useState('')
+
+  // El estado se calcula acá y no viene de la RPC: la regla vive en
+  // src/utils/vencimientos.ts, en un solo lugar. Ver el encabezado de ese
+  // archivo para por qué tampoco se usa el `dias_restantes` del servidor.
+  const conEstado = useMemo(
+    () =>
+      lotes.map(l => ({
+        lote: l,
+        estado: estadoVencimiento(l.fecha_vencimiento, diasAlerta, diasCritico),
+      })),
+    [lotes, diasAlerta, diasCritico],
+  )
+
+  const conteos = useMemo(() => {
+    const acc: Record<EstadoVencimiento, number> = { vencido: 0, critico: 0, alerta: 0, ok: 0 }
+    for (const { estado } of conEstado) acc[estado] += 1
+    return acc
+  }, [conEstado])
+
+  const visibles = useMemo(
+    () => (filtro === 'todos' ? conEstado : conEstado.filter(c => c.estado === filtro)),
+    [conEstado, filtro],
+  )
+
+  async function confirmarBaja(lote: LoteReporte) {
+    const cantidad = Number(cantidadBaja)
+    if (!Number.isFinite(cantidad) || cantidad <= 0 || cantidad > lote.cantidad_restante) return
+    await onDarDeBaja(lote.lote_id, cantidad)
+    setDandoDeBaja(null)
+    setCantidadBaja('')
+  }
+
+  return (
+    <div className="p-4 sm:p-6 max-w-6xl mx-auto">
+      <div className="flex flex-wrap items-center justify-between gap-3 mb-4">
+        <div>
+          <h1 className="text-xl font-semibold flex items-center gap-2 dark:text-white">
+            <CalendarClock className="w-5 h-5 text-indigo-600" aria-hidden="true" />
+            Vencimientos
+          </h1>
+          <p className="text-sm text-stone-500 dark:text-gray-400">
+            {nombreSucursal ? `${nombreSucursal} · ` : ''}
+            Rojo a {diasCritico} días, amarillo a {diasAlerta}. Se configura en Configuración.
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={onRefrescar}
+          disabled={refrescando}
+          className="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm border rounded-lg dark:border-gray-600 dark:text-gray-200 hover:bg-stone-50 dark:hover:bg-gray-700 disabled:opacity-50"
+        >
+          <RefreshCw className={`w-4 h-4 ${refrescando ? 'animate-spin' : ''}`} aria-hidden="true" />
+          Actualizar
+        </button>
+      </div>
+
+      <div className="flex flex-wrap gap-2 mb-4">
+        {FILTROS.map(f => {
+          const n = f.clave === 'todos' ? conEstado.length : conteos[f.clave]
+          return (
+            <button
+              key={f.clave}
+              type="button"
+              onClick={() => setFiltro(f.clave)}
+              className={`px-3 py-1.5 rounded-lg text-sm border transition-colors ${
+                filtro === f.clave
+                  ? 'bg-indigo-600 text-white border-indigo-600'
+                  : 'border-stone-200 text-stone-600 hover:bg-stone-50 dark:border-gray-600 dark:text-gray-300 dark:hover:bg-gray-700'
+              }`}
+            >
+              {f.label} <span className="opacity-70">({n})</span>
+            </button>
+          )
+        })}
+      </div>
+
+      {cargando ? (
+        <div className="flex justify-center py-12">
+          <Loader2 className="w-6 h-6 animate-spin text-stone-400" aria-hidden="true" />
+        </div>
+      ) : visibles.length === 0 ? (
+        <div className="text-center py-12 text-stone-500 dark:text-gray-400">
+          <PackageX className="w-10 h-10 mx-auto mb-2 opacity-40" aria-hidden="true" />
+          {conEstado.length === 0 ? (
+            <>
+              <p>No hay vencimientos cargados.</p>
+              <p className="text-sm">
+                Se cargan al registrar la factura de compra, o a mano desde la ficha del producto.
+              </p>
+            </>
+          ) : (
+            <p>Nada en esta categoría.</p>
+          )}
+        </div>
+      ) : (
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="text-xs text-stone-500 dark:text-gray-400 border-b dark:border-gray-700">
+                <th className="text-left py-2 pr-2">Producto</th>
+                <th className="text-left py-2 px-2 w-28">Vence</th>
+                <th className="text-left py-2 px-2 w-40">Estado</th>
+                <th className="text-right py-2 px-2 w-24">Quedan</th>
+                <th className="text-right py-2 px-2 w-24">Stock</th>
+                <th className="py-2 pl-2 w-32"></th>
+              </tr>
+            </thead>
+            <tbody>
+              {visibles.map(({ lote, estado }) => (
+                <tr
+                  key={lote.lote_id}
+                  className={`border-b dark:border-gray-700 ${
+                    estado === 'vencido' ? 'bg-red-50/60 dark:bg-red-900/10' : ''
+                  }`}
+                >
+                  <td className="py-2 pr-2 dark:text-gray-200">
+                    <span className="font-medium">{lote.producto_nombre}</span>
+                    {lote.producto_codigo && (
+                      <span className="ml-1 text-xs text-stone-400">{lote.producto_codigo}</span>
+                    )}
+                    {lote.bolsa_producto > 0 && (
+                      <span
+                        className="block text-xs text-stone-400 dark:text-gray-500"
+                        title="Unidades del producto que no están en ningún lote: salen antes que este"
+                      >
+                        + {lote.bolsa_producto} u. sin vencimiento cargado
+                      </span>
+                    )}
+                  </td>
+                  <td className="py-2 px-2 font-mono text-xs dark:text-gray-300">
+                    {formatearFechaVencimiento(lote.fecha_vencimiento)}
+                  </td>
+                  <td className="py-2 px-2">
+                    <BadgeVencimiento
+                      fecha={lote.fecha_vencimiento}
+                      diasAlerta={diasAlerta}
+                      diasCritico={diasCritico}
+                    />
+                  </td>
+                  <td className="py-2 px-2 text-right tabular-nums dark:text-gray-200">
+                    <strong>{lote.cantidad_restante}</strong>
+                    <span className="text-stone-400"> / {lote.cantidad}</span>
+                  </td>
+                  <td className="py-2 px-2 text-right tabular-nums text-stone-500 dark:text-gray-400">
+                    {lote.stock_producto}
+                  </td>
+                  <td className="py-2 pl-2 text-right">
+                    {dandoDeBaja === lote.lote_id ? (
+                      <span className="inline-flex items-center gap-1">
+                        <input
+                          type="number"
+                          min={1}
+                          max={lote.cantidad_restante}
+                          value={cantidadBaja}
+                          onChange={e => setCantidadBaja(e.target.value)}
+                          aria-label="Unidades a dar de baja"
+                          className="w-16 px-2 py-1 border rounded text-sm text-right dark:bg-gray-700 dark:border-gray-600 dark:text-white"
+                        />
+                        <button
+                          type="button"
+                          onClick={() => void confirmarBaja(lote)}
+                          disabled={darDeBajaPendiente}
+                          aria-label="Confirmar la baja"
+                          className="p-1 text-green-600 hover:text-green-700 disabled:opacity-50"
+                        >
+                          {darDeBajaPendiente
+                            ? <Loader2 className="w-4 h-4 animate-spin" aria-hidden="true" />
+                            : <Check className="w-4 h-4" aria-hidden="true" />}
+                        </button>
+                        <button
+                          type="button"
+                          onClick={() => { setDandoDeBaja(null); setCantidadBaja('') }}
+                          aria-label="Cancelar la baja"
+                          className="p-1 text-stone-400 hover:text-stone-600"
+                        >
+                          <X className="w-4 h-4" aria-hidden="true" />
+                        </button>
+                      </span>
+                    ) : (
+                      puedeDarDeBaja && (
+                        <button
+                          type="button"
+                          onClick={() => {
+                            setDandoDeBaja(lote.lote_id)
+                            setCantidadBaja(String(lote.cantidad_restante))
+                          }}
+                          className="inline-flex items-center gap-1 px-2 py-1 text-xs border rounded text-red-700 border-red-200 hover:bg-red-50 dark:text-red-300 dark:border-red-800 dark:hover:bg-red-900/20"
+                        >
+                          <AlertTriangle className="w-3 h-3" aria-hidden="true" />
+                          Dar de baja
+                        </button>
+                      )
+                    )}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      {conteos.vencido > 0 && (
+        <p className="mt-4 text-xs text-stone-500 dark:text-gray-400">
+          Los lotes vencidos <strong>no</strong> bloquean la venta: el producto se sigue pudiendo
+          cargar en un pedido. Dar de baja descuenta el stock y lo registra como merma por
+          vencimiento, con su costo.
+        </p>
+      )}
+    </div>
+  )
+}

--- a/src/hooks/queries/useComprasQuery.ts
+++ b/src/hooks/queries/useComprasQuery.ts
@@ -5,6 +5,7 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { supabase } from '../supabase/base'
 import { useSucursal } from '../../contexts/SucursalContext'
+import { aplanarVencimientos } from '../../utils/vencimientos'
 import { fechaLocalISO } from '../../utils/formatters'
 import type {
   BaseProrrateoCompra,
@@ -234,6 +235,56 @@ async function fetchCargosPlantillaProveedor(proveedorId: string): Promise<Plant
 }
 
 // Mutation functions
+/**
+ * Manda los vencimientos de la compra, después de que la compra existe.
+ *
+ * Va en una segunda llamada y no adentro de `registrar_compra_completa` a
+ * propósito: esa RPC, `actualizar_compra_items` y `anular_compra_atomica` son
+ * las tres más parcheadas del repo, y cada parche nuevo sobre el cuerpo vivo es
+ * una oportunidad más de revertir en silencio lo que hizo el anterior. Ver el
+ * encabezado de la mig 224.
+ *
+ * NO propaga el error: la compra ya está registrada y no se va a deshacer por
+ * esto. Que falle deja los vencimientos sin cargar, que es exactamente el mismo
+ * estado que si el usuario los hubiera dejado en blanco — un estado soportado y
+ * visible en la ficha del producto como "sin vencimiento cargado". Devuelve el
+ * texto del aviso para que la pantalla lo muestre.
+ */
+async function sincronizarLotesDeCompra(
+  compraId: string | number,
+  items: { productoId: string; vencimientos?: { fecha: string; cantidad: number }[] }[],
+  /**
+   * `true` = llamar aunque no haya ningún vencimiento. Lo usa la EDICIÓN: la
+   * RPC recibe la foto completa de los lotes de esta factura, así que una lista
+   * vacía es la forma de borrar los que había. En el ALTA no hay nada que
+   * borrar, así que sin vencimientos ni se llama.
+   */
+  forzar = false,
+): Promise<string | null> {
+  const lotes = aplanarVencimientos(items)
+  if (lotes.length === 0 && !forzar) return null
+
+  try {
+    const { data, error } = await supabase.rpc('sincronizar_lotes_compra', {
+      p_compra_id: compraId,
+      p_lotes: lotes,
+    })
+    if (error) throw error
+
+    const res = data as unknown as { warning_clamp?: { producto_id: number; unidades: number }[] }
+    const clamp = res?.warning_clamp ?? []
+    if (clamp.length > 0) {
+      const total = clamp.reduce((acc, c) => acc + c.unidades, 0)
+      return `Se recortaron ${total} u. de vencimientos en ${clamp.length} producto(s): los lotes no entraban en el stock disponible.`
+    }
+    return null
+  } catch (e) {
+    return `La compra se registró, pero los vencimientos no se pudieron guardar: ${
+      e instanceof Error ? e.message : 'error desconocido'
+    }. Se pueden cargar a mano desde la ficha del producto.`
+  }
+}
+
 async function registrarCompra(compraData: CompraFormInputExtended): Promise<RegistrarCompraResult> {
   const itemsParaRPC: CompraItemRPC[] = compraData.items.map(item => ({
     producto_id: item.productoId,
@@ -288,11 +339,14 @@ async function registrarCompra(compraData: CompraFormInputExtended): Promise<Reg
   // y que la apertura del impuesto interno por alícuota no cierra contra el
   // total (o declara una tasa que ninguna línea usa, con lo cual ese importe
   // no llega a ningún costo).
+  const warningLotes = await sincronizarLotesDeCompra(result.compra_id, compraData.items)
+
   return {
     success: true,
     compraId: result.compra_id,
     warningDescuadre: result.warning_descuadre ?? null,
     warningIiDeclarado: result.warning_ii_declarado ?? null,
+    warningLotes,
   }
 }
 
@@ -416,6 +470,8 @@ export interface ActualizarCompraItemsInput {
     porcentajeIva?: number
     condicionIva?: CondicionIva
     impuestosInternos?: number
+    /** Vencimientos de la línea (migs 223/224). Ver CompraFormInputExtended. */
+    vencimientos?: Array<{ fecha: string; cantidad: number }>
   }>
   /**
    * Los cargos de la compra (mig 194). Obligatorio y no opcional a propósito:
@@ -448,7 +504,7 @@ export interface WarningCostoPromedio {
 
 async function actualizarCompraItems(
   input: ActualizarCompraItemsInput
-): Promise<{ compraId: string; warningCostoPromedio: WarningCostoPromedio[]; warningIiDeclarado: string | null }> {
+): Promise<{ compraId: string; warningCostoPromedio: WarningCostoPromedio[]; warningIiDeclarado: string | null; warningLotes: string | null }> {
   const itemsParaRPC: CompraItemRPC[] = input.items.map(item => ({
     producto_id: item.productoId,
     cantidad: item.cantidad,
@@ -494,10 +550,17 @@ async function actualizarCompraItems(
   }
   // `actualizar_compra_items` NO devuelve `warning_descuadre`: no recalcula el
   // total contra el informado, lo recibe ya hecho. Sólo el del II declarado.
+  // En la edición se llama SIEMPRE, incluso sin vencimientos: la RPC es la foto
+  // completa de los lotes de esta factura, así que una lista vacía es la forma
+  // de borrar los que había. `actualizar_compra_items` borra y recrea las
+  // líneas, y los lotes tienen que seguir a las líneas.
+  const warningLotes = await sincronizarLotesDeCompra(result.compra_id, input.items, true)
+
   return {
     compraId: result.compra_id,
     warningCostoPromedio: result.warning_costo_promedio ?? [],
     warningIiDeclarado: result.warning_ii_declarado ?? null,
+    warningLotes,
   }
 }
 

--- a/src/hooks/queries/useLotesQuery.ts
+++ b/src/hooks/queries/useLotesQuery.ts
@@ -1,0 +1,290 @@
+/**
+ * Lotes y vencimientos (migs 223/224/225).
+ *
+ * Un lote es una fecha de vencimiento con un contador que baja. Lo que NO está
+ * en ningún lote es la "bolsa sin vencimiento", que no es una fila: es
+ * `productos.stock` menos la suma de los contadores. Ver el encabezado de la
+ * mig 223 para el modelo completo.
+ *
+ * TODA LA ESCRITURA VA POR RPC
+ * ----------------------------
+ * `producto_lotes` tiene RLS con policy de SELECT y ninguna de escritura: el
+ * default-deny alcanza y el único camino es una RPC `SECURITY DEFINER`. No es
+ * casual — el contador de un lote decide si algo se pinta en rojo y si se
+ * descuenta stock, y eso no puede quedar en manos de un UPDATE suelto desde el
+ * navegador (que es, justamente, cómo se registran las mermas hoy).
+ *
+ * LA LECTURA DE LA FICHA NO USA EMBEDS
+ * ------------------------------------
+ * `producto_lotes` tiene dos FKs, y aunque hoy apuntan a tablas distintas, un
+ * embed ambiguo de PostgREST rompe la consulta ENTERA con PGRST201 y ni `tsc`
+ * ni eslint ni los tests lo ven (ya rompió "Armar ruta" en producción). Como la
+ * ficha ya conoce el producto, no hace falta ningún embed: un `select` plano
+ * filtrado por `producto_id` alcanza.
+ */
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { supabase } from '../supabase/base'
+import { useSucursal } from '../../contexts/SucursalContext'
+import { productosKeys } from './useProductosQuery'
+import { mermasKeys } from './useMermasQuery'
+
+/** Una fila de `producto_lotes`, como llega de la base. */
+export interface LoteDB {
+  id: number
+  producto_id: number
+  sucursal_id: number
+  fecha_vencimiento: string
+  cantidad: number
+  cantidad_restante: number
+  compra_id: number | null
+  origen: 'compra' | 'manual'
+  created_at: string
+}
+
+/** Una fila de `reporte_vencimientos()`. */
+export interface LoteReporte {
+  lote_id: number
+  producto_id: number
+  producto_nombre: string
+  producto_codigo: string | null
+  fecha_vencimiento: string
+  cantidad: number
+  cantidad_restante: number
+  /**
+   * Días calculados por el servidor. El front NO lo usa para el semáforo — lo
+   * recalcula con `diasHasta` para que la ficha y el panel no puedan diferir.
+   * Queda acá porque es el orden natural de la lista y sirve para diagnosticar.
+   */
+  dias_restantes: number
+  origen: 'compra' | 'manual'
+  compra_id: number | null
+  stock_producto: number
+  bolsa_producto: number
+}
+
+/** Lo que viaja a `sincronizar_lotes_compra`, ya agrupado por producto y fecha. */
+export interface LoteCompraInput {
+  producto_id: number
+  fecha_vencimiento: string
+  cantidad: number
+}
+
+export interface SincronizarLotesResult {
+  ok: boolean
+  lotes: number
+  /** Productos a los que hubo que recortarles lotes para que entraran en el stock. */
+  warning_clamp: { producto_id: number; unidades: number }[]
+}
+
+export const lotesKeys = {
+  all: (sucursalId: number | null) => ['lotes', sucursalId] as const,
+  byProducto: (sucursalId: number | null, productoId: number | null) =>
+    [...lotesKeys.all(sucursalId), 'producto', productoId] as const,
+  reporte: (sucursalId: number | null) => [...lotesKeys.all(sucursalId), 'reporte'] as const,
+}
+
+// ---------------------------------------------------------------------------
+// Lectura
+// ---------------------------------------------------------------------------
+
+/** Los lotes vivos de un producto, para el bloque de la ficha. */
+export function useLotesProductoQuery(productoId: number | null, habilitado = true) {
+  const { currentSucursalId } = useSucursal()
+
+  return useQuery({
+    queryKey: lotesKeys.byProducto(currentSucursalId, productoId),
+    enabled: habilitado && productoId != null,
+    staleTime: 30 * 1000,
+    queryFn: async (): Promise<LoteDB[]> => {
+      const { data, error } = await supabase
+        .from('producto_lotes')
+        .select('id, producto_id, sucursal_id, fecha_vencimiento, cantidad, cantidad_restante, compra_id, origen, created_at')
+        .eq('producto_id', productoId as number)
+        .gt('cantidad_restante', 0)
+        .order('fecha_vencimiento', { ascending: true })
+
+      if (error) throw error
+      return (data ?? []) as LoteDB[]
+    },
+  })
+}
+
+/**
+ * Los lotes cargados por UNA compra, para precargar el modal de edición.
+ *
+ * Sin esto, editar una compra borraría sus vencimientos en silencio:
+ * `sincronizar_lotes_compra` recibe la foto completa de los lotes de la
+ * factura, así que abrir el modal, tocar una cantidad y guardar mandaría una
+ * lista vacía.
+ *
+ * Trae también los agotados (`cantidad_restante = 0`), a diferencia de la
+ * ficha: son lotes que la compra sí cargó, y omitirlos al reenviar la foto los
+ * borraría igual.
+ */
+export function useLotesCompraQuery(compraId: string | number | null, habilitado = true) {
+  const { currentSucursalId } = useSucursal()
+
+  return useQuery({
+    queryKey: [...lotesKeys.all(currentSucursalId), 'compra', String(compraId)],
+    enabled: habilitado && compraId != null,
+    staleTime: 30 * 1000,
+    queryFn: async (): Promise<LoteDB[]> => {
+      const { data, error } = await supabase
+        .from('producto_lotes')
+        .select('id, producto_id, sucursal_id, fecha_vencimiento, cantidad, cantidad_restante, compra_id, origen, created_at')
+        .eq('compra_id', compraId as string | number)
+        .order('fecha_vencimiento', { ascending: true })
+
+      if (error) throw error
+      return (data ?? []) as LoteDB[]
+    },
+  })
+}
+
+/**
+ * Todos los lotes vivos de la sucursal, para el panel.
+ *
+ * `p_dias_horizonte` recorta del lado del servidor: sin él, una distribuidora
+ * con vencimientos cargados a dos años traería miles de filas para mostrar las
+ * veinte que importan. Los ya vencidos entran siempre — su cuenta de días es
+ * negativa, así que quedan por debajo de cualquier horizonte.
+ */
+export function useVencimientosQuery(diasHorizonte: number | null = null) {
+  const { currentSucursalId } = useSucursal()
+
+  return useQuery({
+    queryKey: [...lotesKeys.reporte(currentSucursalId), diasHorizonte],
+    staleTime: 60 * 1000,
+    queryFn: async (): Promise<LoteReporte[]> => {
+      const { data, error } = await supabase.rpc('reporte_vencimientos', {
+        p_dias_horizonte: diasHorizonte,
+      })
+      if (error) throw error
+      return (data ?? []) as LoteReporte[]
+    },
+  })
+}
+
+// ---------------------------------------------------------------------------
+// Escritura
+// ---------------------------------------------------------------------------
+
+/**
+ * Invalida todo lo que un movimiento de lote puede haber cambiado.
+ *
+ * `productos` entra porque dar de baja un lote baja el stock, y `mermas` porque
+ * esa baja deja una fila en el historial.
+ */
+function useInvalidarLotes() {
+  const queryClient = useQueryClient()
+  const { currentSucursalId } = useSucursal()
+
+  return () => {
+    queryClient.invalidateQueries({ queryKey: lotesKeys.all(currentSucursalId) })
+    queryClient.invalidateQueries({ queryKey: productosKeys.all(currentSucursalId) })
+    queryClient.invalidateQueries({ queryKey: mermasKeys.all(currentSucursalId) })
+  }
+}
+
+/**
+ * Reescribe los lotes de una compra.
+ *
+ * La llama `useComprasQuery` justo después de registrar o editar la compra. Es
+ * idempotente: manda la foto completa de los vencimientos de esa factura, no un
+ * delta.
+ */
+export function useSincronizarLotesCompraMutation() {
+  const invalidar = useInvalidarLotes()
+
+  return useMutation({
+    mutationFn: async (input: { compraId: number; lotes: LoteCompraInput[] }) => {
+      const { data, error } = await supabase.rpc('sincronizar_lotes_compra', {
+        p_compra_id: input.compraId,
+        p_lotes: input.lotes,
+      })
+      if (error) throw error
+      return data as unknown as SincronizarLotesResult
+    },
+    onSuccess: invalidar,
+  })
+}
+
+/**
+ * Etiqueta con una fecha parte del stock que no está en ningún lote.
+ *
+ * Es el camino del stock que ya existía cuando se prendió la feature: no hay
+ * inventario inicial, se carga producto por producto cuando se pasa al lado de
+ * la caja. No mueve stock — cambia lo que se sabe, no lo que hay.
+ */
+export function useCrearLoteManualMutation() {
+  const invalidar = useInvalidarLotes()
+
+  return useMutation({
+    mutationFn: async (input: { productoId: number; fecha: string; cantidad: number }) => {
+      const { data, error } = await supabase.rpc('crear_lote_manual', {
+        p_producto_id: input.productoId,
+        p_fecha_vencimiento: input.fecha,
+        p_cantidad: input.cantidad,
+      })
+      if (error) throw error
+      return data as unknown as { ok: boolean; lote_id: number; bolsa: number }
+    },
+    onSuccess: invalidar,
+  })
+}
+
+/**
+ * Corrige a mano el contador de un lote.
+ *
+ * "El sistema dice 12 y en la caja hay 5." Las 7 de diferencia no se pierden:
+ * vuelven a la bolsa, que es la respuesta honesta a "existen pero no sé de qué
+ * lote son". Si de verdad faltan, eso es una merma y va por el otro camino.
+ */
+export function useAjustarLoteMutation() {
+  const invalidar = useInvalidarLotes()
+
+  return useMutation({
+    mutationFn: async (input: { loteId: number; cantidadRestante: number }) => {
+      const { data, error } = await supabase.rpc('ajustar_lote', {
+        p_lote_id: input.loteId,
+        p_cantidad_restante: input.cantidadRestante,
+      })
+      if (error) throw error
+      return data as unknown as { ok: boolean; lote_id: number; cantidad_restante: number; bolsa: number }
+    },
+    onSuccess: invalidar,
+  })
+}
+
+/**
+ * Da de baja unidades de un lote como merma por vencimiento.
+ *
+ * Es lo único de este módulo que mueve `productos.stock`, y lo hace por RPC
+ * porque son tres escrituras que tienen que ir juntas y en orden: primero el
+ * lote, después la merma, y recién ahí el stock. Al revés, el trigger de la
+ * mig 223 consumiría por FEFO y podría comerse un lote distinto del que se está
+ * dando de baja.
+ */
+export function useDarDeBajaLoteMutation() {
+  const invalidar = useInvalidarLotes()
+
+  return useMutation({
+    mutationFn: async (input: { loteId: number; cantidad: number; observaciones?: string }) => {
+      const { data, error } = await supabase.rpc('dar_de_baja_lote', {
+        p_lote_id: input.loteId,
+        p_cantidad: input.cantidad,
+        p_observaciones: input.observaciones ?? null,
+      })
+      if (error) throw error
+      return data as unknown as {
+        ok: boolean
+        lote_id: number
+        merma_id: number
+        cantidad: number
+        cantidad_restante: number
+        stock: number
+      }
+    },
+    onSuccess: invalidar,
+  })
+}

--- a/src/hooks/queries/usePoliticasComercialesQuery.ts
+++ b/src/hooks/queries/usePoliticasComercialesQuery.ts
@@ -30,6 +30,10 @@ export interface PoliticasComerciales {
   comisionPctPreventista: number
   /** % por defecto de quien NO es preventista: admin, encargado (mig 207). */
   comisionPctOtros: number
+  /** Días de anticipación del aviso amarillo de vencimiento (mig 223). */
+  diasAlertaVencimiento: number
+  /** Días de anticipación del aviso rojo. Siempre <= el amarillo (mig 223). */
+  diasCriticoVencimiento: number
 }
 
 const CACHE_KEY = 'politicas_comerciales'
@@ -44,12 +48,14 @@ export const POLITICAS_POR_DEFECTO: PoliticasComerciales = {
   montoMinimoPedido: 0,
   comisionPctPreventista: 2,
   comisionPctOtros: 0,
+  diasAlertaVencimiento: 60,
+  diasCriticoVencimiento: 15,
 }
 
 async function fetchPoliticas(sucursalId: number | null): Promise<PoliticasComerciales> {
   const { data, error } = await supabase
     .from('politicas_comerciales')
-    .select('monto_minimo_pedido, comision_pct_preventista, comision_pct_otros')
+    .select('monto_minimo_pedido, comision_pct_preventista, comision_pct_otros, dias_alerta_vencimiento, dias_critico_vencimiento')
     .maybeSingle()
 
   if (error) throw error
@@ -61,6 +67,10 @@ async function fetchPoliticas(sucursalId: number | null): Promise<PoliticasComer
     // `?? 2` y no `|| 2`: un 0 configurado a mano es un valor, no un hueco.
     comisionPctPreventista: Number(data?.comision_pct_preventista ?? 2),
     comisionPctOtros: Number(data?.comision_pct_otros ?? 0),
+    // Mismo criterio que las comisiones: `??` y no `||`, porque 0 días es una
+    // configuración válida ("avisame solo lo ya vencido"), no un hueco.
+    diasAlertaVencimiento: Number(data?.dias_alerta_vencimiento ?? 60),
+    diasCriticoVencimiento: Number(data?.dias_critico_vencimiento ?? 15),
   }
 
   // Sin expiración a propósito: un valor viejo es infinitamente mejor que
@@ -223,6 +233,48 @@ export function useImpactoMinimoQuery(montoPropuesto: number) {
         total: filas.length,
         bloqueados: filas.filter(p => (Number(p.total) || 0) < montoPropuesto).length,
       }
+    },
+  })
+}
+
+/**
+ * Fija los dos umbrales de aviso de vencimiento de la sucursal activa.
+ *
+ * Viajan juntos por lo mismo que los dos porcentajes de comisión: son una sola
+ * decisión —"cuándo me preocupo y cuándo me alarmo"— y mandarlos por separado
+ * dejaría un estado intermedio donde el rojo queda después del amarillo, que la
+ * base rechaza con un CHECK.
+ */
+export function useActualizarAlertasVencimientoMutation() {
+  const queryClient = useQueryClient()
+  const { currentSucursalId } = useSucursal()
+
+  return useMutation({
+    mutationFn: async (input: { diasAlerta: number; diasCritico: number }) => {
+      const { error } = await supabase.rpc('actualizar_alertas_vencimiento', {
+        p_dias_alerta: input.diasAlerta,
+        p_dias_critico: input.diasCritico,
+      })
+      if (error) throw error
+
+      const previo = await getCachedData<PoliticasComerciales>(CACHE_KEY, currentSucursalId).catch(() => null)
+      await cacheData(
+        CACHE_KEY,
+        {
+          ...(previo ?? POLITICAS_POR_DEFECTO),
+          diasAlertaVencimiento: input.diasAlerta,
+          diasCriticoVencimiento: input.diasCritico,
+        },
+        undefined,
+        currentSucursalId,
+      ).catch(() => {})
+
+      return input
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: politicasComercialesKeys.all(currentSucursalId) })
+      // El semáforo del panel y de la ficha se pinta con estos umbrales.
+      queryClient.invalidateQueries({ queryKey: ['lotes'] })
     },
   })
 }

--- a/src/types/hooks.ts
+++ b/src/types/hooks.ts
@@ -1136,6 +1136,11 @@ export interface CompraFormInputExtended {
     porcentajeIva?: number;
     condicionIva?: CondicionIva;
     impuestosInternos?: number;
+    /**
+     * Vencimientos de la línea (migs 223/224). NO viajan en `p_items`: se
+     * mandan aparte con `sincronizar_lotes_compra` una vez que la compra existe.
+     */
+    vencimientos?: Array<{ fecha: string; cantidad: number }>;
   }>;
   /** Líneas cuya tasa de II fue editada a mano: se propaga al producto tras registrar (mig 123 UI). */
   cambiosImpuestosInternos?: Array<{ productoId: string; nombre: string; impuestosInternos: number }>;
@@ -1189,6 +1194,13 @@ export interface RegistrarCompraResult {
   warningDescuadre?: string | null;
   /** La apertura del impuesto interno por alícuota no cuadra con el total, o declara una tasa que ninguna línea usa. */
   warningIiDeclarado?: string | null;
+  /**
+   * Los vencimientos no se pudieron guardar (migs 223/224). La compra SÍ quedó
+   * registrada: el lote va por una segunda llamada, y que falle deja los
+   * vencimientos sin cargar — el mismo estado que si el usuario los hubiera
+   * dejado en blanco, que es un estado soportado. Se avisa, no se rompe.
+   */
+  warningLotes?: string | null;
 }
 
 export interface UseComprasReturnExtended {

--- a/src/utils/vencimientos.test.ts
+++ b/src/utils/vencimientos.test.ts
@@ -1,0 +1,218 @@
+import { describe, expect, it } from 'vitest'
+import {
+  aplanarVencimientos,
+  bolsaSinVencimiento,
+  diasHasta,
+  estadoVencimiento,
+  formatearFechaVencimiento,
+  textoVencimiento,
+} from './vencimientos'
+
+const HOY = '2026-09-09'
+
+describe('diasHasta', () => {
+  it('cuenta días de calendario hacia adelante', () => {
+    expect(diasHasta('2026-09-10', HOY)).toBe(1)
+    expect(diasHasta('2026-10-09', HOY)).toBe(30)
+  })
+
+  it('devuelve 0 el mismo día', () => {
+    expect(diasHasta(HOY, HOY)).toBe(0)
+  })
+
+  it('devuelve negativo si ya pasó', () => {
+    expect(diasHasta('2026-09-01', HOY)).toBe(-8)
+  })
+
+  it('cruza el cambio de año y los bisiestos sin corrimiento', () => {
+    expect(diasHasta('2027-01-01', '2026-12-31')).toBe(1)
+    // 2028 es bisiesto: febrero tiene 29.
+    expect(diasHasta('2028-03-01', '2028-02-01')).toBe(29)
+  })
+
+  it('NO se corre un día por la zona horaria', () => {
+    // El bug clásico: new Date('2026-10-01') es medianoche UTC, o sea el 30/09
+    // a las 21:00 en Argentina. Si esto diera 0, el lote se marcaría vencido un
+    // día antes de tiempo.
+    expect(diasHasta('2026-10-01', '2026-10-01')).toBe(0)
+    expect(diasHasta('2026-01-01', '2025-12-31')).toBe(1)
+  })
+
+  it('devuelve NaN con una fecha ilegible, no 0', () => {
+    expect(diasHasta('', HOY)).toBeNaN()
+    expect(diasHasta('mañana', HOY)).toBeNaN()
+  })
+
+  it('tolera un timestamp completo, no solo la fecha suelta', () => {
+    expect(diasHasta('2026-09-10T00:00:00Z', HOY)).toBe(1)
+  })
+})
+
+describe('estadoVencimiento', () => {
+  const ALERTA = 60
+  const CRITICO = 15
+
+  it('marca vencido lo que ya pasó', () => {
+    expect(estadoVencimiento('2026-09-08', ALERTA, CRITICO, HOY)).toBe('vencido')
+  })
+
+  it('el día del vencimiento todavía no está vencido', () => {
+    expect(estadoVencimiento(HOY, ALERTA, CRITICO, HOY)).toBe('critico')
+  })
+
+  it('los umbrales son inclusivos', () => {
+    // Justo en el umbral rojo.
+    expect(estadoVencimiento('2026-09-24', ALERTA, CRITICO, HOY)).toBe('critico')
+    // Un día más allá del rojo, todavía dentro del amarillo.
+    expect(estadoVencimiento('2026-09-25', ALERTA, CRITICO, HOY)).toBe('alerta')
+    // Justo en el umbral amarillo.
+    expect(estadoVencimiento('2026-11-08', ALERTA, CRITICO, HOY)).toBe('alerta')
+    // Un día más allá del amarillo.
+    expect(estadoVencimiento('2026-11-09', ALERTA, CRITICO, HOY)).toBe('ok')
+  })
+
+  it('con los dos umbrales en 0 solo marca lo ya vencido', () => {
+    expect(estadoVencimiento('2026-09-08', 0, 0, HOY)).toBe('vencido')
+    expect(estadoVencimiento(HOY, 0, 0, HOY)).toBe('critico')
+    expect(estadoVencimiento('2026-09-10', 0, 0, HOY)).toBe('ok')
+  })
+
+  it('con los dos umbrales iguales no queda ningún amarillo', () => {
+    expect(estadoVencimiento('2026-09-20', 15, 15, HOY)).toBe('critico')
+    expect(estadoVencimiento('2026-09-25', 15, 15, HOY)).toBe('ok')
+  })
+
+  it('una fecha ilegible no inventa una alarma', () => {
+    expect(estadoVencimiento('', ALERTA, CRITICO, HOY)).toBe('ok')
+  })
+})
+
+describe('textoVencimiento', () => {
+  it('singulariza el día', () => {
+    expect(textoVencimiento('2026-09-10', HOY)).toBe('vence en 1 día')
+    expect(textoVencimiento('2026-09-08', HOY)).toBe('vencido hace 1 día')
+  })
+
+  it('pluraliza a partir de dos', () => {
+    expect(textoVencimiento('2026-09-11', HOY)).toBe('vence en 2 días')
+    expect(textoVencimiento('2026-09-07', HOY)).toBe('vencido hace 2 días')
+  })
+
+  it('el mismo día no dice "en 0 días"', () => {
+    expect(textoVencimiento(HOY, HOY)).toBe('vence hoy')
+  })
+})
+
+describe('bolsaSinVencimiento', () => {
+  it('es el stock menos lo asignado a lotes', () => {
+    expect(bolsaSinVencimiento(100, 30)).toBe(70)
+  })
+
+  it('es 0 cuando los lotes cubren todo el stock', () => {
+    expect(bolsaSinVencimiento(50, 50)).toBe(0)
+  })
+
+  it('nunca es negativa aunque el dato llegue inconsistente', () => {
+    // La base lo garantiza con LOTE-A, pero un caché viejo podría mentir.
+    expect(bolsaSinVencimiento(10, 25)).toBe(0)
+  })
+
+  it('trata los valores ausentes como 0', () => {
+    expect(bolsaSinVencimiento(undefined as unknown as number, 5)).toBe(0)
+    expect(bolsaSinVencimiento(10, undefined as unknown as number)).toBe(10)
+  })
+})
+
+describe('aplanarVencimientos', () => {
+  it('convierte las líneas al payload de la RPC', () => {
+    expect(
+      aplanarVencimientos([
+        { productoId: '7', vencimientos: [{ fecha: '2026-10-01', cantidad: 12 }] },
+      ]),
+    ).toEqual([{ producto_id: 7, fecha_vencimiento: '2026-10-01', cantidad: 12 }])
+  })
+
+  it('deja las dos fechas de una misma línea como dos lotes', () => {
+    expect(
+      aplanarVencimientos([
+        {
+          productoId: '7',
+          vencimientos: [
+            { fecha: '2026-10-01', cantidad: 12 },
+            { fecha: '2026-12-01', cantidad: 8 },
+          ],
+        },
+      ]),
+    ).toEqual([
+      { producto_id: 7, fecha_vencimiento: '2026-10-01', cantidad: 12 },
+      { producto_id: 7, fecha_vencimiento: '2026-12-01', cantidad: 8 },
+    ])
+  })
+
+  it('suma dos líneas del mismo producto con la misma fecha', () => {
+    // Dos filas con esa clave violarían el UNIQUE de producto_lotes.
+    expect(
+      aplanarVencimientos([
+        { productoId: '7', vencimientos: [{ fecha: '2026-10-01', cantidad: 12 }] },
+        { productoId: '7', vencimientos: [{ fecha: '2026-10-01', cantidad: 5 }] },
+      ]),
+    ).toEqual([{ producto_id: 7, fecha_vencimiento: '2026-10-01', cantidad: 17 }])
+  })
+
+  it('no mezcla productos distintos con la misma fecha', () => {
+    const r = aplanarVencimientos([
+      { productoId: '7', vencimientos: [{ fecha: '2026-10-01', cantidad: 12 }] },
+      { productoId: '9', vencimientos: [{ fecha: '2026-10-01', cantidad: 3 }] },
+    ])
+    expect(r).toHaveLength(2)
+    expect(r.map(x => x.producto_id).sort()).toEqual([7, 9])
+  })
+
+  it('descarta las filas a medio tipear en vez de hacer fallar la carga entera', () => {
+    expect(
+      aplanarVencimientos([
+        {
+          productoId: '7',
+          vencimientos: [
+            { fecha: '', cantidad: 5 },
+            { fecha: '2026-10-01', cantidad: 0 },
+            { fecha: '2026-11-01', cantidad: -3 },
+            { fecha: '2026-12-01', cantidad: 4 },
+          ],
+        },
+      ]),
+    ).toEqual([{ producto_id: 7, fecha_vencimiento: '2026-12-01', cantidad: 4 }])
+  })
+
+  it('ignora las líneas sin vencimientos, que es el caso normal', () => {
+    expect(
+      aplanarVencimientos([
+        { productoId: '7' },
+        { productoId: '9', vencimientos: [] },
+      ]),
+    ).toEqual([])
+  })
+
+  it('descarta un productoId que no es un número', () => {
+    expect(
+      aplanarVencimientos([
+        { productoId: 'nuevo', vencimientos: [{ fecha: '2026-10-01', cantidad: 5 }] },
+      ]),
+    ).toEqual([])
+  })
+})
+
+describe('formatearFechaVencimiento', () => {
+  it('imprime dd/mm/aaaa sin correrse de zona', () => {
+    expect(formatearFechaVencimiento('2026-10-01')).toBe('01/10/2026')
+    expect(formatearFechaVencimiento('2026-01-31')).toBe('31/01/2026')
+  })
+
+  it('tolera un timestamp completo', () => {
+    expect(formatearFechaVencimiento('2026-10-01T00:00:00Z')).toBe('01/10/2026')
+  })
+
+  it('devuelve una raya con una fecha ilegible', () => {
+    expect(formatearFechaVencimiento('')).toBe('—')
+  })
+})

--- a/src/utils/vencimientos.ts
+++ b/src/utils/vencimientos.ts
@@ -1,0 +1,158 @@
+/**
+ * Semáforo de vencimientos (migs 223/224/225).
+ *
+ * ACÁ VIVE LA REGLA, Y EN UN SOLO LADO
+ * ------------------------------------
+ * `reporte_vencimientos()` devuelve la fecha y los días que faltan, pero **no**
+ * el color. Calcular el semáforo también en SQL crearía un espejo que se
+ * desincroniza — que es exactamente el problema que obligó a escribir el gate
+ * `espejo-motor-compras.mjs` para el motor de costos.
+ *
+ * Por la misma razón el front nunca usa el `dias_restantes` que devuelve la RPC:
+ * lo recalcula desde `fecha_vencimiento` con `diasHasta`. Si no, la ficha (que
+ * lee `producto_lotes` directo y no tiene esa columna) y el panel podrían
+ * mostrar números distintos para el mismo lote cuando el día del servidor y el
+ * del navegador no coinciden.
+ *
+ * LAS FECHAS SE COMPARAN COMO CALENDARIO, NO COMO INSTANTES
+ * ---------------------------------------------------------
+ * `fecha_vencimiento` es un `date` de Postgres: llega como 'YYYY-MM-DD' y no
+ * tiene hora ni zona. `new Date('2026-10-01')` lo interpreta como medianoche
+ * UTC, que en Argentina es el 30/09 a las 21:00 — o sea, un día menos. Por eso
+ * acá no se construyen Date a partir del string: se parsea a mano y se compara
+ * con `Date.UTC`, que es aritmética de calendario pura.
+ */
+
+export type EstadoVencimiento = 'vencido' | 'critico' | 'alerta' | 'ok'
+
+/** La fecha de hoy del navegador, como 'YYYY-MM-DD'. */
+export function hoyISO(): string {
+  const ahora = new Date()
+  const mes = String(ahora.getMonth() + 1).padStart(2, '0')
+  const dia = String(ahora.getDate()).padStart(2, '0')
+  return `${ahora.getFullYear()}-${mes}-${dia}`
+}
+
+/** Milisegundos UTC del comienzo de una fecha 'YYYY-MM-DD'. NaN si no parsea. */
+function aUTC(fecha: string): number {
+  const m = /^(\d{4})-(\d{2})-(\d{2})/.exec(fecha ?? '')
+  if (!m) return NaN
+  return Date.UTC(Number(m[1]), Number(m[2]) - 1, Number(m[3]))
+}
+
+/**
+ * Días de calendario entre hoy y la fecha. Negativo = ya venció.
+ *
+ * Devuelve NaN si alguna fecha no parsea, para que quien la use decida qué
+ * hacer en vez de comerse un 0 que parecería "vence hoy".
+ */
+export function diasHasta(fecha: string, hoy: string = hoyISO()): number {
+  const destino = aUTC(fecha)
+  const origen = aUTC(hoy)
+  if (Number.isNaN(destino) || Number.isNaN(origen)) return NaN
+  return Math.round((destino - origen) / 86_400_000)
+}
+
+/**
+ * El color del lote, según los dos umbrales de la sucursal.
+ *
+ * - `vencido`: la fecha ya pasó. No bloquea la venta, es una decisión de
+ *   negocio: un dato mal tipeado no puede frenar la operación.
+ * - `critico`: entra dentro del umbral rojo. Hay que liquidarlo ya.
+ * - `alerta`: entra dentro del umbral amarillo. Todavía se coloca normal.
+ * - `ok`: falta.
+ *
+ * Los umbrales son inclusivos: con `diasCritico = 15`, un lote que vence en
+ * exactamente 15 días ya es crítico. Es lo que espera quien configuró "avisame
+ * 15 días antes".
+ *
+ * Con umbrales en 0 solo se marca lo ya vencido, que es la forma de tener la
+ * feature prendida sin que avise de nada por adelantado.
+ */
+export function estadoVencimiento(
+  fecha: string,
+  diasAlerta: number,
+  diasCritico: number,
+  hoy: string = hoyISO(),
+): EstadoVencimiento {
+  const dias = diasHasta(fecha, hoy)
+  // Una fecha ilegible no es un vencimiento: no se inventa una alarma.
+  if (Number.isNaN(dias)) return 'ok'
+  if (dias < 0) return 'vencido'
+  if (dias <= diasCritico) return 'critico'
+  if (dias <= diasAlerta) return 'alerta'
+  return 'ok'
+}
+
+/** Texto corto para la UI: "vencido hace 3 días", "vence en 12 días", "vence hoy". */
+export function textoVencimiento(fecha: string, hoy: string = hoyISO()): string {
+  const dias = diasHasta(fecha, hoy)
+  if (Number.isNaN(dias)) return 'sin fecha'
+  if (dias === 0) return 'vence hoy'
+  if (dias < 0) {
+    const d = Math.abs(dias)
+    return `vencido hace ${d} ${d === 1 ? 'día' : 'días'}`
+  }
+  return `vence en ${dias} ${dias === 1 ? 'día' : 'días'}`
+}
+
+/**
+ * Lo que queda sin vencimiento cargado: la bolsa.
+ *
+ * Es una resta y no una fila en ninguna tabla — ver el encabezado de la mig 223.
+ * Nunca negativa: el invariante LOTE-A lo garantiza del lado de la base, y acá
+ * se recorta igual para que un dato viejo en caché no pinte un número absurdo.
+ */
+export function bolsaSinVencimiento(stock: number, asignadoALotes: number): number {
+  return Math.max(0, (Number(stock) || 0) - (Number(asignadoALotes) || 0))
+}
+
+/**
+ * Aplana las líneas de una compra al payload de `sincronizar_lotes_compra`,
+ * agrupando por (producto, fecha).
+ *
+ * Agrupa acá y no solo en la RPC porque el mismo producto puede aparecer en dos
+ * líneas de la misma factura con la misma fecha, y dos filas con esa clave
+ * violarían el UNIQUE de `producto_lotes`. La RPC vuelve a agrupar igual — es
+ * barato y no depende de que el cliente lo haga bien.
+ *
+ * Se descartan las entradas sin fecha o con cantidad no positiva: son filas a
+ * medio tipear, y mandarlas haría fallar la carga de los vencimientos entera
+ * por algo que el usuario simplemente no terminó de completar.
+ */
+export function aplanarVencimientos(
+  items: { productoId: string; vencimientos?: { fecha: string; cantidad: number }[] }[],
+): { producto_id: number; fecha_vencimiento: string; cantidad: number }[] {
+  const acumulado = new Map<string, { producto_id: number; fecha_vencimiento: string; cantidad: number }>()
+
+  for (const item of items) {
+    const productoId = Number(item.productoId)
+    if (!Number.isFinite(productoId)) continue
+
+    for (const v of item.vencimientos ?? []) {
+      const cantidad = Number(v.cantidad) || 0
+      if (!v.fecha || cantidad <= 0) continue
+
+      const clave = `${productoId}|${v.fecha}`
+      const previo = acumulado.get(clave)
+      if (previo) {
+        previo.cantidad += cantidad
+      } else {
+        acumulado.set(clave, { producto_id: productoId, fecha_vencimiento: v.fecha, cantidad })
+      }
+    }
+  }
+
+  return [...acumulado.values()]
+}
+
+/**
+ * La fecha en dd/mm/aaaa.
+ *
+ * Sin construir un Date, por lo mismo que `diasHasta`: `new Date('2026-10-01')`
+ * es medianoche UTC y en Argentina imprime el 30/09.
+ */
+export function formatearFechaVencimiento(fecha: string): string {
+  const m = /^(\d{4})-(\d{2})-(\d{2})/.exec(fecha ?? '')
+  return m ? `${m[3]}/${m[2]}/${m[1]}` : '\u2014'
+}


### PR DESCRIPTION
## El problema

La distribuidora no lee código de barras. Sin lectura no hay forma de saber qué unidad física salió, así que tampoco cuándo se vence lo que queda en el depósito: hasta ahora el vencimiento **no existía en ningún lado** de la app.

Lo que se buscaba es acotado: **enterarse a tiempo de lo que está por vencer** para liquidarlo, bonificarlo o devolverlo antes de perderlo. No trazabilidad lote → cliente (queda en #562).

## El modelo

Un lote es una fecha con un contador que baja. La pieza que hace que esto funcione **sin backfill ni inventario inicial** es que la bolsa "sin vencimiento" no es una fila: es una resta.

```
bolsa = productos.stock − SUM(producto_lotes.cantidad_restante)
```

De ahí sale el resto solo:

- Entra mercadería **sin** fecha cargada → sube `stock`, no hay lote → engorda la bolsa.
- Entra **con** fecha → sube `stock` y nace el lote → la bolsa queda igual.
- **Sale** mercadería → primero se come la bolsa (automático, es derivada); recién cuando llega a 0 se consume del lote que **vence antes**.
- **Vuelve** de una venta cancelada → se devuelve al lote del que salió, no a la bolsa.

**FEFO, no FIFO.** El orden lo manda la fecha de vencimiento, no la de compra: si el proveedor manda mercadería con vencimiento corto, un FIFO puro la deja tapada en el fondo hasta que se vence. La contrapartida es un compromiso físico — el depósito tiene que sacar de la caja que vence antes.

El invariante que lo sostiene es `SUM(cantidad_restante) <= productos.stock`. Este código **nunca escribe `productos.stock`**: lo lee y acomoda los lotes contra él, así que `STK-A` y `STK-B` (los dos `critical`) quedan intactos.

## Dos decisiones que no se ven leyendo el diff

**1. El consumo se engancha en UN trigger sobre `productos`, no en las ~20 RPCs que mueven stock.** Todas pasan por `UPDATE productos SET stock` y ya había un trigger hermano (`trg_stock_historico`, mig 038) que lee `current_setting('app.stock_origen')`. El nuevo usa el mismo canal, y por eso cubre de una sola vez pedidos, bot, mermas —que ni siquiera pasan por una RPC: son dos statements desde el navegador—, movimientos entre sucursales y control de stock.

**2. Los lotes de una compra NO se escriben dentro de `registrar_compra_completa`.** Esa función, `actualizar_compra_items` y `anular_compra_atomica` son las tres más parcheadas del repo (128, 177, 194, 195, todas por ancla sobre el cuerpo vivo). `sincronizar_lotes_compra` es idempotente y la llama el cliente después de guardar; la anulación se detecta con un trigger sobre `compras.estado`. Si esa segunda llamada falla, la compra queda bien y los vencimientos sin cargar — el mismo estado que si el usuario los hubiera dejado en blanco, que es un estado soportado y visible en la ficha.

## Migraciones

Aplicadas a prod y verificadas. **Ojo:** esta rama no trae el archivo de la `222`, que se aplicó desde otra rama y vive en `origin/main`. No es drift; al mergear queda completo.

| | |
|---|---|
| **223** | tabla `producto_lotes` (FKs compuestas + RLS), motor FEFO, trigger sobre `productos`, los dos umbrales en `politicas_comerciales` |
| **224** | las cinco operaciones: lotes de una compra, etiquetar la bolsa a mano, corregir un contador, dar de baja y el reporte del panel |
| **225** | invariantes `LOTE-A/B/C` en `auditoria_integridad()`, por el patrón de ancla sobre el cuerpo vivo |

En `dar_de_baja_lote` **el orden importa**: se descuenta el lote *antes* que el stock, para que la bolsa quede igual y el trigger no consuma un segundo lote por FEFO.

## Front

- Sub-bloque de vencimientos **por línea** en el modal de compra (una línea puede traer dos lotes: 12 vencen en marzo y 8 en mayo) y en el de edición, que **precarga los que ya había** — sin eso, editar una compra se los llevaba en silencio.
- Bloque de lotes en la ficha del producto, con la bolsa **a la vista**: es la parte del stock de la que no se sabe cuándo vence, y mostrarla es lo que hace que se note y se corrija.
- Panel `/vencimientos` con filtros y baja (admin/encargado; depósito lo ve).
- Los dos umbrales en `/configuracion`.

La fecha **no tiene mínimo** a propósito: un vencimiento pasado es un dato legítimo —la caja que apareció en el fondo del depósito, o el proveedor que mandó algo con la fecha encima— y bloquearlo impedía registrarlo. El badge lo pinta en rojo solo.

## Verificación

- `typecheck`, `lint`, `test:run` (1705/1705, **sin `.env`**) y `build`: verde.
- Contra la base, todo revertido con un `RAISE`: la bolsa se come primero; FEFO se lleva el lote **más nuevo** cuando vence antes; una cancelación devuelve al mismo lote; `dar_de_baja_lote` deja los otros lotes intactos y escribe la merma con motivo `vencimiento` y `origen=lote_vencido` en el ledger; re-sincronizar una compra no duplica; anularla se lleva sus lotes y deja los manuales.
- `LOTE-A/B/C` nacen en verde, `LOTE-A` muerde (verificado con un dato ensuciado a mano).
- `auditoria_permisos_execute()`: ninguna función nueva alcanzable con la anon key.
- `auditoria_sucursal_cruzada()`: las dos FKs de `producto_lotes` reconocidas como compuestas.

## Después de mergear

Hay que **poner los umbrales** en `/configuracion`. Arrancan en 60 amarillo / 15 rojo, pero mientras no haya lotes cargados no avisan de nada.

Pendientes: #562 · #563 · #564 · #565 · #566

🤖 Generated with [Claude Code](https://claude.com/claude-code)
