### PR TITLE
El alta rápida de producto desde la factura avisa cuando falla

### DIFF
--- a/src/components/containers/ComprasContainer.productoRapido.test.tsx
+++ b/src/components/containers/ComprasContainer.productoRapido.test.tsx
@@ -1,0 +1,132 @@
+/**
+ * "Crear producto rápido" desde una factura tiene que avisar cuando falla.
+ *
+ * EL HUECO
+ * --------
+ * El handler llamaba a `mutateAsync` sin `catch`, y el modal atrapaba el
+ * rechazo con un `catch {}` cuyo comentario decía "Error handled by container".
+ * No lo manejaba nadie: el mensaje —que existía, y era bueno— se computaba y se
+ * tiraba. Para la usuaria el botón "Crear y Agregar" no hacía absolutamente
+ * nada.
+ *
+ * Pasó en prod (Tucumán, 10/09/2026): cargó cuatro productos nuevos en una
+ * factura y en el quinto chocó contra el código duplicado del que acababa de
+ * crear. Diez clicks, cero mensajes, y la conclusión razonable de que la app se
+ * había roto. Los logs del gateway muestran el intento repetido y ninguna
+ * respuesta de error: nunca llegó a haber INSERT.
+ *
+ * Se monta el container con el modal stubbeado porque lo que se rompió es el
+ * cableado —quién avisa—, no el formulario.
+ */
+import React from 'react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+const mockCrearProducto = vi.fn()
+const notifyError = vi.fn()
+const notifySuccess = vi.fn()
+
+vi.mock('../../hooks/queries', () => ({
+  useComprasQuery: () => ({ data: [], isLoading: false }),
+  useProveedoresQuery: () => ({ data: [] }),
+  useProductosQuery: () => ({ data: [] }),
+  useNotasCreditoByCompraQuery: () => ({ data: [] }),
+  useNotasCreditoResumenQuery: () => ({ data: {} }),
+  useRegistrarCompraMutation: () => ({ mutateAsync: vi.fn(), isPending: false }),
+  useActualizarCompraMutation: () => ({ mutateAsync: vi.fn(), isPending: false }),
+  useAnularCompraMutation: () => ({ mutateAsync: vi.fn(), isPending: false }),
+  useCambiarProveedorCompraMutation: () => ({ mutateAsync: vi.fn(), isPending: false }),
+  useCrearProductoMutation: () => ({ mutateAsync: mockCrearProducto, isPending: false }),
+  useCrearProveedorMutation: () => ({ mutateAsync: vi.fn(), isPending: false }),
+  useRegistrarNotaCreditoMutation: () => ({ mutateAsync: vi.fn(), isPending: false }),
+  useActualizarProductoMutation: () => ({ mutateAsync: vi.fn(), isPending: false }),
+}))
+
+vi.mock('../../hooks/queries/useLotesQuery', () => ({
+  useLotesCompraQuery: () => ({ data: [] }),
+}))
+
+vi.mock('../../contexts/AuthDataContext', () => ({
+  useAuthData: () => ({ isAdmin: true, user: { id: 'u1' } }),
+}))
+
+vi.mock('../../contexts/NotificationContext', () => ({
+  useNotification: () => ({ error: notifyError, success: notifySuccess, warning: vi.fn() }),
+}))
+
+vi.mock('../../hooks/useResetOnSucursalChange', () => ({
+  useResetOnSucursalChange: () => undefined,
+}))
+
+vi.mock('../vistas/VistaCompras', () => ({
+  default: ({ onNuevaCompra }: { onNuevaCompra?: () => void }) => (
+    <button type="button" onClick={onNuevaCompra}>Nueva compra</button>
+  ),
+}))
+
+// El modal real no es lo que se prueba: sólo hace falta disparar el alta rápida
+// tal como la dispara él —await, y si rechaza, seguir sin romper la pantalla—.
+vi.mock('../modals/ModalCompra', () => ({
+  default: ({ onCrearProductoRapido }: {
+    onCrearProductoRapido?: (d: { nombre: string; codigo: string; costoSinIva: number }) => Promise<unknown>
+  }) => (
+    <button
+      type="button"
+      onClick={async () => {
+        try {
+          await onCrearProductoRapido?.({ nombre: 'MANI JAMON x 1kg', codigo: '0802', costoSinIva: 7533 })
+        } catch {
+          // Igual que el modal de verdad: deja el formulario como estaba.
+        }
+      }}
+    >
+      Crear y Agregar
+    </button>
+  ),
+}))
+
+import ComprasContainer from './ComprasContainer'
+
+async function abrirCompraYCrearProducto() {
+  const user = userEvent.setup()
+  render(<ComprasContainer />)
+  // Los modales y la vista son chunks lazy: hay que esperar a que resuelvan.
+  await user.click(await screen.findByText('Nueva compra'))
+  await user.click(await screen.findByText('Crear y Agregar'))
+}
+
+describe('alta rápida de producto desde la factura', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('muestra el error de la base cuando el alta falla', async () => {
+    mockCrearProducto.mockRejectedValue(
+      new Error('Ya existe un producto con código "0802": «MANI JAMON x 1kg». Buscalo por nombre o código y agregalo, o cargá este con otro código.')
+    )
+
+    await abrirCompraYCrearProducto()
+
+    await waitFor(() => expect(notifyError).toHaveBeenCalledTimes(1))
+    expect(notifyError.mock.calls[0][0]).toContain('Ya existe un producto con código "0802"')
+    expect(notifySuccess).not.toHaveBeenCalled()
+  })
+
+  it('no se queda callado ni cuando el error no es un Error', async () => {
+    mockCrearProducto.mockRejectedValue('boom')
+
+    await abrirCompraYCrearProducto()
+
+    await waitFor(() => expect(notifyError).toHaveBeenCalledWith('No se pudo crear el producto'))
+  })
+
+  it('avisa del éxito y no ensucia con un error cuando el alta anda', async () => {
+    mockCrearProducto.mockResolvedValue({ id: 398, nombre: 'MANI JAMON x 1kg', codigo: '0802' })
+
+    await abrirCompraYCrearProducto()
+
+    await waitFor(() => expect(notifySuccess).toHaveBeenCalledTimes(1))
+    expect(notifyError).not.toHaveBeenCalled()
+  })
+})

--- a/src/components/containers/ComprasContainer.tsx
+++ b/src/components/containers/ComprasContainer.tsx
@@ -201,16 +201,28 @@ export default function ComprasContainer(): React.ReactElement {
     }
   }, [registrarCompra, actualizarProducto, notify, user])
 
+  // Crear un producto sin salir de la factura. El catch no es decorativo: el
+  // modal deja el formulario como estaba y sigue, así que si el error no se
+  // muestra acá no se muestra en ningún lado. Pasó en prod (Tucumán, 10/09):
+  // el alta chocaba contra el código duplicado del producto que la usuaria
+  // acababa de crear, el botón no hacía nada visible y lo apretó diez veces.
   const handleCrearProductoRapido = useCallback(async (data: { nombre: string; codigo: string; costoSinIva: number }) => {
-    const producto = await crearProducto.mutateAsync({
-      nombre: data.nombre,
-      codigo: data.codigo || undefined,
-      precio: data.costoSinIva * 1.21,
-      stock: 0,
-      costo_sin_iva: data.costoSinIva
-    })
-    notify.success(`Producto "${data.nombre}" creado`)
-    return producto
+    try {
+      const producto = await crearProducto.mutateAsync({
+        nombre: data.nombre,
+        codigo: data.codigo || undefined,
+        precio: data.costoSinIva * 1.21,
+        stock: 0,
+        costo_sin_iva: data.costoSinIva
+      })
+      notify.success(`Producto "${data.nombre}" creado`)
+      return producto
+    } catch (err) {
+      notify.error(err instanceof Error ? err.message : 'No se pudo crear el producto')
+      // Sigue viajando: el que llama distingue "creado" de "no creado" por el
+      // rechazo, y sobre eso decide si agrega la línea o deja el pendiente.
+      throw err
+    }
   }, [crearProducto, notify])
 
   const handleNotaCredito = useCallback((compra: CompraDBExtended) => {

--- a/src/components/modals/ModalCompra.tsx
+++ b/src/components/modals/ModalCompra.tsx
@@ -885,7 +885,8 @@ function ProductosSection({ state, dispatch, productosFiltrados, iiMaster, condi
       }})
       setItemRapido({ nombre: '', codigo: '', costo: 0 })
     } catch {
-      // Error handled by container
+      // El toast lo tira el container. Acá se deja el formulario intacto —con
+      // lo que la usuaria tipeó— para que pueda corregir el dato que falló.
     } finally {
       setCreandoItem(false)
     }
@@ -1498,7 +1499,8 @@ function ItemPendienteRow({
       })
       // El reducer remueve la fila; este componente se desmonta.
     } catch {
-      // Error manejado arriba (toast del container)
+      // El toast lo tira el container. La fila queda pendiente a propósito: si
+      // el alta falló, el ítem de la factura sigue sin producto al que apuntar.
     } finally {
       setCreando(false)
     }

--- a/src/hooks/queries/useProductosQuery.codigoDuplicado.test.tsx
+++ b/src/hooks/queries/useProductosQuery.codigoDuplicado.test.tsx
@@ -1,0 +1,97 @@
+/**
+ * El alta con código repetido tiene que fallar rápido y decir qué hacer.
+ *
+ * `productos.codigo` no tiene UNIQUE (mig 210), así que esta comprobación en el
+ * cliente es la única guarda que hay. Dos cosas se rompieron alrededor de ella:
+ *
+ * 1. El mensaje nombraba el producto existente pero no decía qué hacer con él.
+ *    Quien lo lee está cargando una factura y lo que necesita es saber que el
+ *    producto ya está y que lo busque, no que "ya existe".
+ * 2. El `retry` global de mutations (main.tsx) sólo perdona los 4xx, y mira
+ *    `error.status`. Un `new Error(...)` pelado no lo tiene: el rechazo se
+ *    reintentaba tres veces con backoff de 1s y 2s antes de fallar igual. En los
+ *    logs de prod cada click aparecía como tres consultas espaciadas así.
+ *
+ * El status va acá, en la capa que redacta el error, y no en el predicado de
+ * main.tsx: el predicado no puede distinguir una regla de negocio de una caída
+ * de red mirando un Error sin datos.
+ */
+import React from 'react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+
+const maybeSingle = vi.fn()
+const insert = vi.fn()
+
+vi.mock('../supabase/base', () => ({
+  supabase: {
+    from: () => ({
+      select: () => ({ eq: () => ({ limit: () => ({ maybeSingle }) }) }),
+      insert: (...args: unknown[]) => {
+        insert(...args)
+        return { select: () => ({ single: () => Promise.resolve({ data: { id: 1 }, error: null }) }) }
+      },
+    }),
+  },
+}))
+
+vi.mock('../../contexts/SucursalContext', () => ({
+  useSucursal: () => ({ currentSucursalId: 1 }),
+}))
+
+import { useCrearProductoMutation } from './useProductosQuery'
+
+/** El mismo predicado de retry que corre en producción (main.tsx). */
+function retryDeProduccion(failureCount: number, error: unknown): boolean {
+  const status = (error as { status?: number })?.status
+  if (status && status >= 400 && status < 500) return false
+  return failureCount < 2
+}
+
+function setup() {
+  const qc = new QueryClient({ defaultOptions: { mutations: { retry: retryDeProduccion, retryDelay: 0 } } })
+  return renderHook(() => useCrearProductoMutation(), {
+    wrapper: ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={qc}>{children}</QueryClientProvider>
+    ),
+  })
+}
+
+const productoNuevo = { nombre: 'MANI JAMON x 1kg', codigo: '0802', precio: 9115, stock: 0 }
+
+describe('crear producto con código duplicado', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('nombra al producto que ya tiene ese código y dice qué hacer', async () => {
+    maybeSingle.mockResolvedValue({ data: { id: 398, nombre: 'MANI JAMON x 1kg' }, error: null })
+    const { result } = setup()
+
+    await expect(result.current.mutateAsync(productoNuevo)).rejects.toThrow(
+      /Ya existe un producto con código "0802".*MANI JAMON x 1kg.*Buscalo por nombre o código/s
+    )
+    expect(insert).not.toHaveBeenCalled()
+  })
+
+  it('no se reintenta: el código duplicado no se va a destrabar solo', async () => {
+    maybeSingle.mockResolvedValue({ data: { id: 398, nombre: 'MANI JAMON x 1kg' }, error: null })
+    const { result } = setup()
+
+    await expect(result.current.mutateAsync(productoNuevo)).rejects.toThrow()
+
+    // Una sola consulta = un solo intento. Tres serían los reintentos de 1s y 2s
+    // que dejaban el botón mudo durante tres segundos.
+    await waitFor(() => expect(maybeSingle).toHaveBeenCalledTimes(1))
+  })
+
+  it('inserta cuando el código está libre', async () => {
+    maybeSingle.mockResolvedValue({ data: null, error: null })
+    const { result } = setup()
+
+    await result.current.mutateAsync(productoNuevo)
+
+    expect(insert).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/hooks/queries/useProductosQuery.ts
+++ b/src/hooks/queries/useProductosQuery.ts
@@ -73,6 +73,20 @@ async function fetchProductosStockBajo(umbral: number): Promise<ProductoDB[]> {
   return (data as ProductoDB[]) || []
 }
 
+/**
+ * Error de regla de negocio, marcado como conflicto (409).
+ *
+ * El `retry` global de mutations (main.tsx) reintenta 3 veces con backoff todo
+ * lo que no sea un 4xx, y un `new Error(...)` pelado no lo es: un código
+ * duplicado —que nunca va a dejar de estar duplicado— se reintentaba durante 3
+ * segundos antes de fallar igual. Con el status puesto falla en el acto.
+ */
+function errorDeConflicto(mensaje: string): Error {
+  const error = new Error(mensaje)
+  ;(error as Error & { status?: number }).status = 409
+  return error
+}
+
 // Mutation functions
 async function createProducto(producto: ProductoFormInput, sucursalId: number | null): Promise<ProductoDB> {
   // La RLS multi-tenant requiere sucursal_id = current_sucursal_id() y la
@@ -81,7 +95,8 @@ async function createProducto(producto: ProductoFormInput, sucursalId: number | 
     throw new Error('No hay sucursal activa. Recargá la página e intentá de nuevo.')
   }
 
-  // Validar código duplicado
+  // Validar código duplicado. `productos.codigo` no tiene UNIQUE (ver mig 210),
+  // así que esta es la única guarda: si no corta acá, no corta en ningún lado.
   if (producto.codigo) {
     const { data: existente } = await supabase
       .from('productos')
@@ -90,7 +105,13 @@ async function createProducto(producto: ProductoFormInput, sucursalId: number | 
       .limit(1)
       .maybeSingle()
     if (existente) {
-      throw new Error(`Ya existe un producto con código "${producto.codigo}": ${existente.nombre}`)
+      // El mensaje tiene que decir qué hacer, no sólo que no se pudo: el que
+      // llega acá casi siempre está cargando una factura y no sabe que el
+      // producto ya lo creó él mismo un minuto antes, en la línea anterior.
+      throw errorDeConflicto(
+        `Ya existe un producto con código "${producto.codigo}": «${existente.nombre}». ` +
+        'Buscalo por nombre o código y agregalo, o cargá este con otro código.'
+      )
     }
   }
 


### PR DESCRIPTION
## El reporte

Una usuaria de Tucumán cargó una factura, creó cuatro productos nuevos desde el modal y en el quinto el botón "Crear y Agregar" dejó de hacer nada. Lo apretó diez veces, en esa factura y en la siguiente. Lo reportó como un límite de cuatro productos.

## Qué pasaba de verdad

No hay ningún límite. Los cuatro productos se crearon bien (ids 395–398) y entraron en la compra 258, factura `00014-00059511`. Del quinto intento en adelante, los logs del gateway muestran **30 consultas `productos?codigo=eq.0802` y cero INSERT**, en tres tandas: 18:59, 19:00 y 19:04 (esta última ya en la factura siguiente).

`0802` es el código de `MANI JAMON x 1kg`, el producto que ella misma acababa de crear a las 18:58:40. Cada intento moría en la validación de código duplicado de `createProducto`, que lanza un error correcto y que nombra al producto existente.

Ese mensaje no llegaba a ninguna parte:

- `ComprasContainer.handleCrearProductoRapido` llamaba a `mutateAsync` sin `catch`.
- Los dos formularios de `ModalCompra` (el alta rápida y el panel de pendientes de escaneo) atrapaban el rechazo con `catch {}` y un comentario que decía que el container lo manejaba. No lo manejaba nadie.

Para la usuaria: ni toast, ni campo en rojo, ni nada. El botón no hacía absolutamente nada. Encima el `retry` global de mutations reintentaba tres veces con backoff de 1s y 2s, así que cada click dejaba el botón mudo tres segundos — por eso las consultas de los logs vienen agrupadas de a tres.

La falla era entera del lado del cliente. Por eso no dejó rastro: ni un 4xx en el gateway, ni una fila fallida, ni un hueco en la secuencia de `productos`.

## Qué cambia

- **`ComprasContainer`**: el handler atrapa, avisa con `notify.error` y re-lanza. El re-lanzado importa: el que llama distingue "creado" de "no creado" por el rechazo, y sobre eso decide si agrega la línea o deja el pendiente.
- **`useProductosQuery`**: el mensaje de código duplicado dice qué hacer, no sólo que no se pudo — *"Buscalo por nombre o código y agregalo, o cargá este con otro código."* Quien lo lee está cargando una factura y lo que necesita saber es que el producto ya está.
- **`useProductosQuery`**: ese error sale marcado como `409`. El `retry` global sólo perdona los 4xx mirando `error.status`, y un `Error` pelado no lo tiene. El status se pone en la capa que redacta el error, no en el predicado de `main.tsx`: el predicado no puede distinguir una regla de negocio de una caída de red mirando un Error sin datos.
- **`ModalCompra`**: los dos comentarios que afirmaban que el container manejaba el error ahora dicen lo que cada `catch` hace de verdad.

Sin migraciones: no se toca la base. El repo y el ledger de prod están los dos en la 227.

## Cómo se verificó

Dos tests de regresión nuevos, uno por capa, y los dos se comprobaron revirtiendo el arreglo a propósito:

- `ComprasContainer.productoRapido.test.tsx` — monta el container con el modal stubbeado y verifica que el error llega al usuario (también cuando el rechazo no es un `Error`). Sin el `catch`: 2 tests en rojo.
- `useProductosQuery.codigoDuplicado.test.tsx` — verifica el mensaje, que no se llegue a insertar, y que con el predicado de retry real de producción haya **una sola** consulta en vez de tres. Sin el `409`: 1 test en rojo.

Las cuatro compuertas en verde: `typecheck`, `lint`, `test:run` (1726 tests), `build`.

## Queda afuera, en un issue

Arreglando esto salió a la luz algo más serio que no toqué acá porque es refactor de paso: el `retry` global de mutations mira `error.status`, y un `PostgrestError` de supabase no lo tiene — tiene `code`. La guarda de "no reintentar 4xx" nunca se activa para un error de la base, así que toda escritura fallida se reintenta dos veces, y un INSERT o una RPC no son idempotentes. Está en #576.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019cY8CCeoRPEd1XnZzMbpf2

---
_Generated by [Claude Code](https://claude.ai/code/session_019cY8CCeoRPEd1XnZzMbpf2)_