### PR TITLE
El filtro de fecha de los reportes vuelve a filtrar

### DIFF
--- a/src/components/vistas/VistaReportes.tsx
+++ b/src/components/vistas/VistaReportes.tsx
@@ -105,9 +105,17 @@ export default function VistaReportes({
   // haría cambiar de números en silencio. Los params sólo aparecen cuando el
   // usuario elige un rango o cuando llega por un deep link.
   const rangoUrl = leerRango(searchParams);
-  const fechaDesde = rangoUrl.desde ?? '';
-  const fechaHasta = rangoUrl.hasta ?? '';
+  // El rango es estado del formulario, sembrado UNA vez desde la URL (igual que
+  // `filtrosVentas` acá abajo). No puede leerse de la URL en cada render: mientras
+  // el usuario completa una punta el rango está a medias, y `escribirRango`
+  // descarta los rangos incompletos a propósito. Atado a la URL, la primera fecha
+  // elegida se borraba sola y "Generar" salía sin filtro — el filtro no andaba.
+  const [fechaDesde, setFechaDesdeState] = useState(rangoUrl.desde ?? '');
+  const [fechaHasta, setFechaHastaState] = useState(rangoUrl.hasta ?? '');
+  /** Publica en la URL lo que ella sabe representar; el formulario guarda el resto. */
   const setRango = useCallback((desde: string, hasta: string): void => {
+    setFechaDesdeState(desde);
+    setFechaHastaState(hasta);
     setSearchParams(escribirRango(searchParams, desde || null, hasta || null), { replace: true });
   }, [searchParams, setSearchParams]);
   const setFechaDesde = useCallback((v: string): void => setRango(v, fechaHasta), [setRango, fechaHasta]);
@@ -185,30 +193,36 @@ export default function VistaReportes({
   }, [activeTab]);
 
   // Handlers
-  const handleGenerarReporte = async (): Promise<void> => {
-    if (activeTab === 'preventistas') {
-      await onCalcularReporte(fechaDesde || null, fechaHasta || null);
-    } else {
-      // Recargar el reporte financiero actual
-      switch (activeTab) {
-        case 'cuentas': {
-          const cuentas = await generarReporteCuentasPorCobrar();
-          setReporteCuentas(cuentas);
-          break;
-        }
-        case 'rentabilidad': {
-          const rent = await generarReporteRentabilidad(fechaDesde || null, fechaHasta || null);
-          setReporteRentabilidad(rent);
-          break;
-        }
+  /** Recarga la pestaña activa con el rango dado. El rango viaja por argumento
+   *  porque "Limpiar" lo recarga con el rango nuevo, no con el del render. */
+  const recargarTab = async (desde: string, hasta: string): Promise<void> => {
+    switch (activeTab) {
+      case 'preventistas':
+        await onCalcularReporte(desde || null, hasta || null);
+        break;
+      case 'cuentas': {
+        const cuentas = await generarReporteCuentasPorCobrar();
+        setReporteCuentas(cuentas);
+        break;
+      }
+      case 'rentabilidad': {
+        const rent = await generarReporteRentabilidad(desde || null, hasta || null);
+        setReporteRentabilidad(rent);
+        break;
       }
     }
   };
 
+  const handleGenerarReporte = async (): Promise<void> => {
+    await recargarTab(fechaDesde, fechaHasta);
+  };
+
+  // Limpiar tiene que recargar la pestaña que se está mirando, no sólo
+  // preventistas: si no, el reporte sigue mostrando el período que el usuario
+  // acaba de borrar.
   const handleLimpiarFiltros = async (): Promise<void> => {
-    setFechaDesde('');
-    setFechaHasta('');
-    await onCalcularReporte(null, null);
+    setRango('', '');
+    await recargarTab('', '');
   };
 
   const isLoading = loading || loadingFinanciero;
@@ -292,6 +306,8 @@ export default function VistaReportes({
               <button
                 onClick={handleLimpiarFiltros}
                 disabled={loading}
+                aria-label="Limpiar filtros"
+                title="Limpiar filtros"
                 className="flex items-center justify-center space-x-2 px-4 py-2 bg-gray-500 dark:bg-gray-600 text-white rounded-lg hover:bg-gray-600 dark:hover:bg-gray-500 disabled:opacity-50 transition-colors"
               >
                 <X className="w-5 h-5" />

--- a/src/components/vistas/__tests__/VistaReportes.filtroFecha.test.tsx
+++ b/src/components/vistas/__tests__/VistaReportes.filtroFecha.test.tsx
@@ -1,0 +1,99 @@
+/**
+ * El panel "Filtrar por Fecha" de /reportes.
+ *
+ * El rango vive en la query string, y `escribirRango` descarta el rango entero
+ * si le falta una punta. Como los dos inputs escriben de a uno, la primera
+ * fecha que el usuario elegía se borraba sola y "Generar" salía sin filtro.
+ */
+import '@testing-library/jest-dom/vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { MemoryRouter } from 'react-router-dom';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+vi.mock('../../../lib/supabase', () => ({
+  supabase: { rpc: vi.fn(), from: vi.fn() },
+}));
+
+const mockRentabilidad = vi.fn(async (_d: string | null, _h: string | null) => ({
+  productos: [],
+  totales: {},
+}));
+
+vi.mock('../../../hooks/supabase', () => ({
+  useReportesFinancieros: () => ({
+    loading: false,
+    generarReporteCuentasPorCobrar: vi.fn(async () => []),
+    generarReporteRentabilidad: mockRentabilidad,
+  }),
+}));
+
+import VistaReportes from '../VistaReportes';
+
+function renderVista(entrada = '/reportes?tab=rentabilidad'): void {
+  render(
+    <MemoryRouter initialEntries={[entrada]}>
+      <VistaReportes
+        reportePreventistas={[]}
+        reporteInicializado={true}
+        loading={false}
+        onCalcularReporte={vi.fn(async () => {})}
+      />
+    </MemoryRouter>
+  );
+}
+
+describe('VistaReportes — filtro de fecha', () => {
+  beforeEach(() => {
+    mockRentabilidad.mockClear();
+  });
+
+  it('conserva "Desde" después de elegirlo, aunque "Hasta" siga vacío', async () => {
+    const user = userEvent.setup();
+    renderVista();
+
+    const desde = screen.getByLabelText('Desde') as HTMLInputElement;
+    await user.type(desde, '2026-08-01');
+
+    expect(desde.value).toBe('2026-08-01');
+  });
+
+  it('manda el rango completo al RPC de rentabilidad', async () => {
+    const user = userEvent.setup();
+    renderVista();
+
+    await user.type(screen.getByLabelText('Desde'), '2026-08-01');
+    await user.type(screen.getByLabelText('Hasta'), '2026-08-31');
+    await user.click(screen.getByRole('button', { name: /Generar/ }));
+
+    expect(mockRentabilidad).toHaveBeenLastCalledWith('2026-08-01', '2026-08-31');
+  });
+  it('manda un rango abierto: sólo "Desde" y hasta hoy', async () => {
+    const user = userEvent.setup();
+    renderVista();
+
+    await user.type(screen.getByLabelText('Desde'), '2026-08-01');
+    await user.click(screen.getByRole('button', { name: /Generar/ }));
+
+    expect(mockRentabilidad).toHaveBeenLastCalledWith('2026-08-01', null);
+  });
+
+  it('siembra los inputs desde un deep link del gerencial', () => {
+    renderVista('/reportes?tab=rentabilidad&desde=2026-08-01&hasta=2026-08-31');
+
+    expect((screen.getByLabelText('Desde') as HTMLInputElement).value).toBe('2026-08-01');
+    expect((screen.getByLabelText('Hasta') as HTMLInputElement).value).toBe('2026-08-31');
+    expect(mockRentabilidad).toHaveBeenLastCalledWith('2026-08-01', '2026-08-31');
+  });
+
+  it('"Limpiar" recarga la pestaña que se está mirando, sin filtro', async () => {
+    const user = userEvent.setup();
+    renderVista('/reportes?tab=rentabilidad&desde=2026-08-01&hasta=2026-08-31');
+
+    await user.click(screen.getByRole('button', { name: 'Limpiar filtros' }));
+
+    expect(mockRentabilidad).toHaveBeenLastCalledWith(null, null);
+    expect((screen.getByLabelText('Desde') as HTMLInputElement).value).toBe('');
+    expect((screen.getByLabelText('Hasta') as HTMLInputElement).value).toBe('');
+  });
+});


### PR DESCRIPTION
## Qué pasaba

Reportado como "el filtro de fecha de rentabilidad no funciona". No era de rentabilidad ni del SQL: `reporte_rentabilidad` (mig 208) filtra bien. El roto era el panel **"Filtrar por Fecha"** entero de `/reportes`.

Desde ecf8830 el rango vive en la query string. `escribirRango` descarta el rango **entero** si le falta una punta — a propósito, para que un deep link a medias no muestre un período que nadie pidió. Pero los dos inputs escribían de a uno:

1. Elegís "Desde" → `setRango('2026-08-01', '')` → rango incompleto → se borran los dos params.
2. El input estaba controlado por la URL, así que la fecha recién elegida **se borraba sola**.
3. Elegís "Hasta" → `setRango('', '2026-08-31')` → incompleto de nuevo → se borra igual.
4. "Generar" llamaba a `reporte_rentabilidad(null, null)` → todo el histórico, como si no hubieras filtrado.

Por deep link sí andaba —el "Ver detalle" del gerencial manda las dos fechas juntas—, que es probablemente por qué no saltó antes.

Afectaba a las **tres** pestañas que usan ese panel: Rentabilidad, Por Preventista y Mermas. Las de ventas (`FiltrosVentas`) tienen su propio estado y estaban bien.

## El arreglo

El rango pasa a ser estado del formulario, sembrado una vez desde la URL — el mismo patrón que ya usaba `filtrosVentas` diez líneas más abajo en el mismo archivo. La URL se sigue escribiendo con `escribirRango`, así que el link compartible, el deep link del gerencial y el back de Android no cambian: sólo deja de ser la URL la que dicta lo que muestran los inputs.

Dos cosas más que salían del mismo lugar:

- **"Limpiar" sólo recargaba Preventistas.** Apretado en Rentabilidad, los números seguían siendo los del período borrado.
- **"Limpiar" resucitaba el "Desde"**: las dos llamadas encadenadas se derivaban del mismo render y la segunda pisaba a la primera con el valor viejo.

El botón X además no tenía nombre accesible.

## Verificación

Test nuevo con 5 casos: rango completo, rango abierto (sólo "Desde"), deep link, y "Limpiar". Falla contra el código viejo (`expected ['2026-08-01','2026-08-31'], received [null, null]`) y pasa con el arreglo.

Las cuatro en verde: `typecheck`, `lint`, `test:run` (130 archivos, 1731 tests), `build`.

Sin migración — es puro front.

No verificado en navegador: el worktree no tiene `.env` y el dev server no levanta ahí.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
